### PR TITLE
fix references preserve app order

### DIFF
--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/appReferenceListBackend.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/appReferenceListBackend.ts
@@ -110,7 +110,9 @@ export function createAppReferenceListBackend(
         items: response.items.map((item) =>
           appItemToProtocol(appId, item, appMetadata.label, appMetadata.iconUrl)
         ),
-        nextCursor: response.nextCursor ?? null
+        nextCursor: response.nextCursor ?? null,
+        // 应用负责定义项目/产物的业务顺序（如更新时间倒序），前端不得按名称重排。
+        ordered: true
       };
     },
 

--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/referenceHandle.test.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/referenceHandle.test.ts
@@ -71,6 +71,7 @@ test("app backend describeHandle resolves the app handle", async () => {
   const apps = await backend.list(scope, { parentGroupId: null });
   const appGroupId = firstGroupId(apps.items);
 
+  assert.equal(apps.ordered, undefined);
   assert.deepEqual(backend.describeHandle?.(appGroupId), {
     source: "app",
     id: "app-7"
@@ -118,6 +119,55 @@ test("app backend labels child groups with app and project names", async () => {
       ? childGroup.parentLabel
       : undefined,
     "Prototype Design / 23232"
+  );
+});
+
+test("app backend preserves the application reference order", async () => {
+  const tuttidClient = {
+    listWorkspaceApps: async () => ({
+      apps: [
+        {
+          appId: "ai-media-canvas",
+          displayName: "AI Canvas",
+          installed: true,
+          enabled: true,
+          status: "running",
+          references: { listSupported: true, searchSupported: false }
+        }
+      ]
+    }),
+    listWorkspaceAppReferences: async () => ({
+      items: [
+        {
+          type: "group",
+          id: "project-new",
+          displayName: "Untitled",
+          referenceCount: 0
+        },
+        {
+          type: "group",
+          id: "project-old",
+          displayName: "Alpha",
+          referenceCount: 0
+        }
+      ],
+      nextCursor: null
+    })
+  } as unknown as TuttidClient;
+  const backend = createAppReferenceListBackend(tuttidClient);
+
+  const result = await backend.list(scope, {
+    parentGroupId: "app:ai-media-canvas",
+    cursor: null,
+    filter: null
+  });
+
+  assert.equal(result.ordered, true);
+  assert.deepEqual(
+    result.items.map((item) =>
+      item.type === "group" ? item.displayName : item.reference.displayName
+    ),
+    ["Untitled", "Alpha"]
   );
 });
 

--- a/packages/workspace/file-reference/src/core/referenceListSource.test.ts
+++ b/packages/workspace/file-reference/src/core/referenceListSource.test.ts
@@ -84,6 +84,27 @@ test("根层级:协议 group/reference 映射成 folder/file 节点", async () =
   assert.ok(file.ref.nodeId.startsWith("f:"));
 });
 
+test("backend 声明 ordered 时透传给 picker", async () => {
+  const { source } = makeSource({
+    __root__: {
+      items: [
+        { type: "group", id: "project-new", displayName: "Untitled" },
+        { type: "group", id: "project-old", displayName: "Alpha" }
+      ],
+      nextCursor: null,
+      ordered: true
+    }
+  });
+
+  const result = await source.listChildren(scope, { node: null });
+
+  assert.equal(result.ordered, true);
+  assert.deepEqual(
+    result.entries.map((entry) => entry.displayName),
+    ["Untitled", "Alpha"]
+  );
+});
+
 test("reference.parentLabel 透传为节点 contextLabel,缺省时不带", async () => {
   const { source } = makeSource({
     __root__: {

--- a/packages/workspace/file-reference/src/core/referenceListSource.ts
+++ b/packages/workspace/file-reference/src/core/referenceListSource.ts
@@ -68,6 +68,8 @@ export interface ReferenceListRequest {
 export interface ReferenceListResult {
   items: ReferenceListItem[];
   nextCursor?: string | null;
+  /** backend 已按业务语义排序时置 true，picker 将保留返回顺序。 */
+  ordered?: boolean;
 }
 
 /** 递归搜索请求(跨整源,非当前层 filter)。 */
@@ -169,7 +171,8 @@ export function createReferenceListSource(
       });
       return {
         entries: result.items.map((item) => itemToNode(sourceId, item)),
-        nextCursor: result.nextCursor ?? null
+        nextCursor: result.nextCursor ?? null,
+        ...(result.ordered ? { ordered: true } : {})
       };
     },
 

--- a/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.test.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.test.ts
@@ -132,6 +132,39 @@ test("open 加载 tabs、默认选中首个并加载其根", async () => {
   );
 });
 
+test("首次加载保留 source 声明的业务顺序", async () => {
+  const controller = createReferenceSourcePickerController({
+    aggregator: fakeAggregator({
+      tabs: [tabsTwo[1]!],
+      children: {
+        [`app-artifact:${SOURCE_ROOT_NODE_ID}`]: {
+          entries: [
+            folder("app-artifact", "project-new", "Untitled"),
+            folder("app-artifact", "project-beta", "Beta"),
+            folder("app-artifact", "project-alpha", "Alpha")
+          ],
+          nextCursor: null,
+          ordered: true
+        }
+      }
+    }),
+    scope,
+    searchDebounceMs: 0
+  });
+
+  controller.open();
+  await flush();
+
+  const root =
+    controller.getSnapshot().bySource["app-artifact"]?.childrenByKey[
+      ROOT_CHILDREN_KEY
+    ];
+  assert.deepEqual(
+    root?.entries.map((node) => node.displayName),
+    ["Untitled", "Beta", "Alpha"]
+  );
+});
+
 test("toggleNode 展开 folder 并懒加载子节点", async () => {
   const controller = createReferenceSourcePickerController({
     aggregator: fakeAggregator({


### PR DESCRIPTION
## What changed

- allow reference-list backends to declare their item order authoritative
- preserve application reference API order through the shared source adapter and picker
- keep the app root and other reference sources on their existing fallback ordering
- add regression coverage for backend order, adapter propagation, and first render

## Why

Application reference APIs own business ordering such as project `updated_at DESC`. The desktop adapter preserved the response array, but did not forward the existing `ordered` signal. The picker therefore alphabetically re-sorted a newly created project until its name changed.

## Impact

Projects and artifacts inside an application now render in exactly the order returned by that application. Sources that do not declare an order continue to use folder-first, name-based sorting.

## Validation

- `pnpm --filter @tutti-os/workspace-file-reference test` — 63 passed
- `pnpm --filter @tutti-os/desktop test` — 1409 passed, 2 skipped
- `pnpm --filter @tutti-os/workspace-file-reference typecheck`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm lint:ts`

The repository pre-push `check:full` was blocked by an unrelated stale Agent GUI degradation baseline (`memoCount: 435 -> 434`); this PR does not touch Agent GUI files or its baseline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves app-defined ordering for reference lists so projects and artifacts render exactly in the order the app returns. Sources without an explicit order keep folder-first, name-based sorting.

- **Bug Fixes**
  - Set `ordered: true` in the app reference backend to treat app order as authoritative.
  - Add `ordered` to `ReferenceListResult` and pass it through to the picker so first load keeps backend order.
  - Add tests for backend flag, source pass-through, and picker initial ordering.

<sup>Written for commit 3ee7fc0c5732c1736073c70e7c41c5a4caa52b60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

