### PR TITLE
fix(agent): stabilize Cursor approvals, auto-continue, and Claude cancel settlement

### DIFF
--- a/docs/conventions/troubleshooting/agent-approvals-subagents.md
+++ b/docs/conventions/troubleshooting/agent-approvals-subagents.md
@@ -54,25 +54,29 @@ Approval gates, plan exits, parent/child event attribution, background agents, a
   the preceding `tool_call` notification for the same `toolCallId`, which does
   carry `rawInput.command`.
 - Root cause:
-  `normalizedApprovalDisplayInput` only read the permission request's own
-  inline `toolCall`. Codex and Claude Code repeat enough of the original input
-  on their approval-equivalent requests for that to work, but Cursor's ACP
-  implementation does not, so the approval projection had no command/path/
-  query fields to show and the card fell back to title-only.
+  Cursor omits `rawInput` on `session/request_permission`, so approval detail
+  must be backfilled from an earlier same-id `tool_call`. A later
+  `tool_call_update` that repeats only `title`/`kind`/`status`/`content` used
+  to replace the pending snapshot wholesale and wipe `input.command`;
+  `KnownToolCallInput` then returned empty, the durable Interaction stored no
+  structured detail, and AgentGUI (which only renders command/path/query, not
+  `toolCall.title`) showed a blank approval card.
 - Fix:
-  Track per-turn tool-call state in `acpTurnNormalizer` (already recorded from
-  `tool_call`/`tool_call_update`) and expose it by raw `toolCallId` via
-  `KnownToolCallInput`. `standardACPPermissionRequested` now passes the
-  normalizer through, and `normalizedApprovalDisplayInput` fills any field
-  (`command`, `file_path`, `query`, ...) missing from the permission request's
-  own `toolCall` from that known prior input before giving up. Other ACP-style
-  interactive paths (Codex app-server, Claude SDK) keep passing `nil` for this
-  fallback since they do not need it.
+  Keep per-turn tool-call snapshots in `acpTurnNormalizer`, merge later empty
+  or partial updates into the prior `input` instead of replacing it, expose the
+  preserved input via `KnownToolCallInput`, and let
+  `normalizedApprovalDisplayInput` fill missing `command`/`file_path`/`query`
+  fields from that known input. Other ACP-style interactive paths (Codex
+  app-server, Claude SDK) keep passing `nil` for this fallback.
 - Validation:
   `cd packages/agent/daemon && go test ./runtime/... -run
-TestCursorPermissionRequestFallsBackToKnownToolCallInput`. For a live check,
-  run the same direct ACP probe from Quick checks with a tier-"agent" session
-  and confirm the emitted approval payload's `input` carries the command.
+'TestCursorPermissionRequestFallsBackToKnownToolCallInput|TestCursorPermissionRequestKeepsKnownInputAfterEmptyToolCallUpdate'`.
+  For a live check, restart tuttidi, trigger a Cursor ask-for-approval shell
+  command, and confirm `~/.tutti-dev/logs/tuttid.log` shows
+  `agent_session.acp.permission_approval.projected` with
+  `has_display_detail=true` and `known_input_has_command=true`. An empty update
+  that would previously wipe detail now logs
+  `agent_session.acp.pending_tool_call.preserved_detail`.
 - References:
   [acp_turn_normalizer.go](../../../packages/agent/daemon/runtime/acp_turn_normalizer.go)
   [interactive_projection.go](../../../packages/agent/daemon/runtime/interactive_projection.go)

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -59,6 +59,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [Imported sessions trigger fresh-completion indicators](./agent-session-lifecycle.md#imported-sessions-trigger-fresh-completion-indicators)
 - [Realtime agent completion does not show unread attention](./agent-session-lifecycle.md#realtime-agent-completion-does-not-show-unread-attention)
 - [Completed agent session stays activating and disables the composer](./agent-session-lifecycle.md#completed-agent-session-stays-activating-and-disables-the-composer)
+- [Cursor auto-continue invents interrupted work after a network drop](./agent-session-lifecycle.md#cursor-auto-continue-invents-interrupted-work-after-a-network-drop)
 
 ## [Agent Approvals And Sub-Agents](./agent-approvals-subagents.md)
 

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -597,44 +597,58 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
   [controller.go](../../../packages/agent/daemon/runtime/controller.go)
   [controller_test.go](../../../packages/agent/daemon/runtime/controller_test.go)
 
-### Claude Code cancel leaves Write/tool cards stuck in progress
+### Claude Code cancel leaves Write/tool cards or thinking stuck in progress
 
 - Symptom:
-  User stops a Claude Code turn while a tool such as Write is running. The turn
-  settles as canceled/interrupted, but the transcript still shows the tool as
-  in progress.
+  User stops a Claude Code turn while a tool such as Write is running, or while
+  the assistant is still in a thinking disclosure. The turn settles as
+  canceled/interrupted, but the transcript still shows the tool as in progress
+  or thinking as forever-"thinking".
 - Quick checks:
-  Compare durable tool-call message status with turn outcome. If the turn is
-  interrupted/canceled and the open `tool_call` is still `running`, the Claude
-  SDK turn lifecycle did not finish dangling calls. Confirm Codex/ACP cancel of
-  the same shape closes open tools via `acpTurnNormalizer.FinishInterrupted`.
+  Compare durable tool-call / `assistant_thinking` message status with turn
+  outcome. If the turn is interrupted/canceled and an open `tool_call` is still
+  `running`, or thinking is still `streaming`/`working`, the Claude SDK turn
+  lifecycle did not finish dangling normalizer-owned rows. Confirm Codex/ACP
+  cancel of the same shape closes open tools and thinking via
+  `acpTurnNormalizer.FinishInterrupted`.
 - Root cause:
-  Claude Code SDK projected tool events without owning the shared turn event
-  lifecycle (`acpTurnNormalizer`). Cancel and sidecar `turn_canceled` settled
-  the turn without `Finish*`, so open tools never received a terminal
-  `call.failed`.
+  Claude Code SDK first projected tool events without owning the shared turn
+  event lifecycle (`acpTurnNormalizer`), so cancel settled the turn without
+  `Finish*` and open tools never received terminal `call.failed`. A follow-on
+  gap kept thinking/assistant snapshots off that same normalizer: only tools
+  were tracked, so Stop could fail open Write cards while leaving an in-flight
+  thinking row at `streamState=streaming`.
 - Fix:
   Attach per-turn `acpTurnNormalizer` on the Claude SDK session. Track
-  `call.started/completed/failed` against that normalizer, and call
+  `call.started/completed/failed` against that normalizer, route thinking and
+  assistant snapshots through the same normalizer, and call
   `FinishInterrupted` / `FinishFailed` / `FinishCompleted` as part of turn
   terminalization (`Cancel`, sidecar `turn_*`, reader failure). Drop late tool
   events after the turn is already settled.
   Also: controller Cancel cancels the Exec context before `adapter.Cancel`.
   Claude Exec unregisters its waiter on that context cancel, so Cancel must
-  finish open tools from the turn-normalizer map (not only live waiters), and
-  the Exec context-canceled path must retain CallFailed events instead of
-  replacing the whole event slice with a bare turn.canceled.
+  finish open tools/streams from the turn-normalizer map (not only live
+  waiters). The controller Exec context-canceled path must retain those
+  adapter-produced close events via `retainTurnCallLifecycleEvents` — not only
+  `call.failed`, but also failed/completed assistant/thinking message
+  snapshots — instead of replacing the whole event slice with a bare
+  turn.canceled. Otherwise FinishInterrupted runs in Exec, then the controller
+  drops the thinking settlement and the durable row stays `streaming`.
 - Validation:
-  `go test ./packages/agent/daemon/runtime -run 'TestClaudeCodeSDKAdapter(CancelFailsOpenToolCalls|CancelFailsOpenToolsAfterWaiterUnregistered|TurnCanceledFailsOpenToolCalls)'`.
-  Manually: start a long Write on Claude Code, press Stop, confirm the tool
-  card leaves "in progress". Rebuild/restart desktop so the running `tuttid`
-  binary includes the fix.
+  `go test ./packages/agent/daemon/runtime -run 'TestClaudeCodeSDKAdapter(CancelFailsOpenToolCalls|CancelFailsOpenToolsAfterWaiterUnregistered|TurnCanceledFailsOpenToolCalls|CancelFailsOpenThinking|MapsThinkingEvents)|TestRetainTurnCallLifecycleEvents'`.
+  Manually: rebuild/restart desktop so `tuttid` includes the fix, then start
+  Claude Code, stop during thinking and during a long Write; confirm thinking
+  leaves the active state and the tool card leaves "in progress". In
+  `~/.tutti-dev/tuttid.db`, the reasoning message status should leave
+  `streaming` after cancel.
 - References:
   [claude_sdk_turn.go](../../../packages/agent/daemon/runtime/claude_sdk_turn.go)
   [claude_sdk_events.go](../../../packages/agent/daemon/runtime/claude_sdk_events.go)
   [claude_sdk_execution.go](../../../packages/agent/daemon/runtime/claude_sdk_execution.go)
   [controller_turn_exec.go](../../../packages/agent/daemon/runtime/controller_turn_exec.go)
+  [controller_turn_state.go](../../../packages/agent/daemon/runtime/controller_turn_state.go)
   [acp_turn_normalizer.go](../../../packages/agent/daemon/runtime/acp_turn_normalizer.go)
+  [acp_turn_normalizer_snapshots.go](../../../packages/agent/daemon/runtime/acp_turn_normalizer_snapshots.go)
 
 ### AgentGUI freezes when session history is large
 
@@ -933,6 +947,42 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
   [command_catalog.go](../../services/tuttid/service/agentsidecar/command_catalog.go)
   [controller_session_lifecycle.go](../../packages/agent/daemon/runtime/controller_session_lifecycle.go)
   [agent_runtime_adapter.go](../../services/tuttid/agent_runtime_adapter.go)
+
+### Cursor auto-continue invents interrupted work after a network drop
+
+- Symptom:
+  After a Cursor `RetriableError` / TLS drop and Tutti's automatic
+  `transport_retry`, the agent does not answer the user's last message
+  (for example a simple greeting). Instead it talks about recovering prior
+  context, reading transcripts, or continuing an interrupted task that never
+  started.
+- Quick checks:
+  In the session transcript, confirm the failed attempt produced only the
+  `Error: RetriableError:` / `Error: ConnectError:` tail (no useful assistant
+  text and no tool calls) before the retry notice. Check
+  `agent_session.acp.exec.auto_continue` in `tuttid` logs for
+  `has_useful_progress=false`.
+- Root cause:
+  Cursor keeps conversation history on its backend; Tutti can mainly control the
+  synthetic auto-continue `session/prompt`. Mid-task wording
+  ("Continue exactly where you left off") misleads the model when the attempt
+  died before any useful output.
+- Fix:
+  Branch the auto-continue prompt by useful progress: zero-progress retries ask
+  the model to answer the user's most recent message normally and not invent
+  interrupted work; mid-task retries keep the continue wording. Progress is
+  assistant text after stripping the retriable error tail, or any observed tool
+  call.
+- Validation:
+  `cd packages/agent/daemon && go test ./runtime/ -run
+'TestACPAutoContinueHasUsefulProgress|TestACPAutoContinuePromptContentBranches|TestCursorAdapterAutoContinuesAfterRetriableTurnError|TestCursorAdapterAutoContinueMidTaskUsesContinuePrompt'`.
+  Live: send a short Cursor message that fails before any reply, confirm the
+  retry answers the user instead of recovering a phantom task, and that
+  mid-task drops still resume in place.
+- References:
+  [acp_auto_continue.go](../../../packages/agent/daemon/runtime/acp_auto_continue.go)
+  [standard_acp_turn.go](../../../packages/agent/daemon/runtime/standard_acp_turn.go)
+  [acp_auto_continue_test.go](../../../packages/agent/daemon/runtime/acp_auto_continue_test.go)
 
 ### Canceling an old AgentGUI turn stops a newer turn
 

--- a/packages/agent/daemon/runtime/acp_auto_continue.go
+++ b/packages/agent/daemon/runtime/acp_auto_continue.go
@@ -54,14 +54,45 @@ func acpStopReasonEndsTurnNormally(stopReason string) bool {
 	}
 }
 
+// acpAutoContinueHasUsefulProgress reports whether the failed attempt produced
+// anything worth "continuing": assistant text besides the retriable error
+// tail, or at least one tool call. Zero-progress failures (e.g. TLS drop right
+// after the user said hello) must not use mid-task continue wording — that
+// prompts the model to invent interrupted prior work.
+func acpAutoContinueHasUsefulProgress(assistantText string, toolCallCount int) bool {
+	if toolCallCount > 0 {
+		return true
+	}
+	trimmed := strings.TrimSpace(assistantText)
+	if trimmed == "" {
+		return false
+	}
+	if errLine, ok := acpRetriableTurnTailError(trimmed); ok {
+		withoutTail := strings.TrimSpace(strings.TrimSuffix(trimmed, errLine))
+		return withoutTail != ""
+	}
+	return true
+}
+
+const (
+	acpAutoContinueMidTaskPrompt      = "The previous response was interrupted by a transient network error. Continue exactly where you left off; do not repeat work that already completed."
+	acpAutoContinueZeroProgressPrompt = "A transient network error aborted your reply before any useful output. Answer the user's most recent message normally. Do not invent interrupted prior work, recover transcripts, or continue a task that never started."
+)
+
 // acpAutoContinuePromptContent is the synthetic prompt that resumes a turn cut
 // short by a transient network error. It is deliberately not emitted as a
-// user message: the provider session retains the full prior context, so the
-// transcript shows the agent simply picking the work back up.
-func acpAutoContinuePromptContent() []map[string]any {
+// user message: the provider session retains the full prior context.
+//
+// hasUsefulProgress selects wording: mid-task continue vs "answer the last
+// user message" for attempts that died before producing useful output.
+func acpAutoContinuePromptContent(hasUsefulProgress bool) []map[string]any {
+	text := acpAutoContinueZeroProgressPrompt
+	if hasUsefulProgress {
+		text = acpAutoContinueMidTaskPrompt
+	}
 	return []map[string]any{{
 		"type": "text",
-		"text": "The previous response was interrupted by a transient network error. Continue exactly where you left off; do not repeat work that already completed.",
+		"text": text,
 	}}
 }
 

--- a/packages/agent/daemon/runtime/acp_auto_continue_test.go
+++ b/packages/agent/daemon/runtime/acp_auto_continue_test.go
@@ -55,6 +55,63 @@ func TestACPRetriableTurnTailError(t *testing.T) {
 	}
 }
 
+func TestACPAutoContinueHasUsefulProgress(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		assistantText string
+		toolCallCount int
+		want          bool
+	}{
+		{
+			name:          "error-only text is zero progress",
+			assistantText: "\n\nError: RetriableError: [aborted] Client network socket disconnected before secure TLS connection was established",
+			want:          false,
+		},
+		{
+			name:          "empty text is zero progress",
+			assistantText: "",
+			want:          false,
+		},
+		{
+			name:          "prior assistant text is useful progress",
+			assistantText: "Checking the repo.\nError: RetriableError: [canceled] http/2 stream closed",
+			want:          true,
+		},
+		{
+			name:          "tool call alone is useful progress",
+			assistantText: "\n\nError: RetriableError: [canceled] http/2 stream closed",
+			toolCallCount: 1,
+			want:          true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := acpAutoContinueHasUsefulProgress(tc.assistantText, tc.toolCallCount); got != tc.want {
+				t.Fatalf("acpAutoContinueHasUsefulProgress(...) = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestACPAutoContinuePromptContentBranches(t *testing.T) {
+	t.Parallel()
+
+	zero := asString(acpAutoContinuePromptContent(false)[0]["text"])
+	if !strings.Contains(zero, "Answer the user's most recent message normally") {
+		t.Fatalf("zero-progress prompt = %q", zero)
+	}
+	if strings.Contains(zero, "Continue exactly where you left off") {
+		t.Fatalf("zero-progress prompt must not use mid-task continue wording: %q", zero)
+	}
+
+	mid := asString(acpAutoContinuePromptContent(true)[0]["text"])
+	if !strings.Contains(mid, "Continue exactly where you left off") {
+		t.Fatalf("mid-task prompt = %q", mid)
+	}
+}
+
 func acpTestPromptText(params map[string]any) string {
 	blocks, _ := params["prompt"].([]any)
 	var b strings.Builder
@@ -68,8 +125,8 @@ func acpTestPromptText(params map[string]any) string {
 }
 
 // A cursor turn that ends "successfully" right after streaming a transient
-// network error must be resumed automatically with a synthetic continue
-// prompt, and the recovered turn must complete normally.
+// network error with no useful prior output must auto-continue with the
+// zero-progress prompt (answer the last user message), not mid-task continue.
 func TestCursorAdapterAutoContinuesAfterRetriableTurnError(t *testing.T) {
 	t.Parallel()
 
@@ -82,7 +139,7 @@ func TestCursorAdapterAutoContinuesAfterRetriableTurnError(t *testing.T) {
 	}
 	session.ProviderSessionID = "cursor-session-1"
 
-	events, err := adapter.Exec(context.Background(), session, textPrompt("build the report"), "", "turn-1", nil, nil)
+	events, err := adapter.Exec(context.Background(), session, textPrompt("你好"), "", "turn-1", nil, nil)
 	if err != nil {
 		t.Fatalf("Exec: %v", err)
 	}
@@ -94,8 +151,12 @@ func TestCursorAdapterAutoContinuesAfterRetriableTurnError(t *testing.T) {
 	if promptCalls != 2 {
 		t.Fatalf("prompt calls = %d, want the auto-continue to send a second prompt", promptCalls)
 	}
-	if text := acpTestPromptText(snapshots[1]); !strings.Contains(text, "transient network error") {
-		t.Fatalf("continue prompt = %q, want the synthetic continue text", text)
+	text := acpTestPromptText(snapshots[1])
+	if !strings.Contains(text, "Answer the user's most recent message normally") {
+		t.Fatalf("continue prompt = %q, want zero-progress wording", text)
+	}
+	if strings.Contains(text, "Continue exactly where you left off") {
+		t.Fatalf("zero-progress continue must not use mid-task wording: %q", text)
 	}
 
 	var sawRetryNotice, sawCompleted, sawFailed bool
@@ -116,6 +177,38 @@ func TestCursorAdapterAutoContinuesAfterRetriableTurnError(t *testing.T) {
 	}
 	if !sawCompleted || sawFailed {
 		t.Fatalf("turn terminal events completed=%v failed=%v, want completed only", sawCompleted, sawFailed)
+	}
+}
+
+// When the failed attempt already streamed useful assistant text, auto-continue
+// keeps mid-task wording so the model resumes rather than restarting.
+func TestCursorAdapterAutoContinueMidTaskUsesContinuePrompt(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Cursor Agent", "cursor-session-mid")
+	transport.conn.retriableErrorPrompts = 1
+	transport.conn.retriableErrorPriorText = "Checking the repo next."
+	adapter := newCursorAdapterWithHostMetadata(transport, LegacyHostMetadata(), nil)
+	session := standardTestSession(ProviderCursor)
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session.ProviderSessionID = "cursor-session-mid"
+
+	_, err := adapter.Exec(context.Background(), session, textPrompt("build the report"), "", "turn-1", nil, nil)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	transport.conn.mu.Lock()
+	snapshots := append([]map[string]any(nil), transport.conn.promptParamsSnapshots...)
+	transport.conn.mu.Unlock()
+	if len(snapshots) < 2 {
+		t.Fatalf("prompt snapshots = %d, want at least 2", len(snapshots))
+	}
+	text := acpTestPromptText(snapshots[1])
+	if !strings.Contains(text, "Continue exactly where you left off") {
+		t.Fatalf("continue prompt = %q, want mid-task wording", text)
 	}
 }
 

--- a/packages/agent/daemon/runtime/acp_turn_normalizer.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer.go
@@ -1,6 +1,7 @@
 package agentruntime
 
 import (
+	"log/slog"
 	"sort"
 	"strings"
 
@@ -133,6 +134,16 @@ func (n *acpTurnNormalizer) CurrentAssistantText() string {
 		return ""
 	}
 	return n.assistantContent.String()
+}
+
+// SeenToolCallCount returns how many distinct tool calls this turn has
+// observed. Auto-continue uses it (with CurrentAssistantText) to decide
+// whether the failed attempt made useful progress.
+func (n *acpTurnNormalizer) SeenToolCallCount() int {
+	if n == nil {
+		return 0
+	}
+	return len(n.toolCallsSeen)
 }
 
 func (n *acpTurnNormalizer) ApplyAssistantFinalText(finalText string) {
@@ -437,8 +448,10 @@ func (n *acpTurnNormalizer) toolItemID(update map[string]any) string {
 // for it in this turn. Some ACP providers (Cursor) omit `rawInput` on the
 // `toolCall` embedded in `session/request_permission`, repeating only
 // `toolCallId`/`title`/`kind`; the earlier tool_call notification for the same
-// id is the only place the command/path/query detail exists. This lookup does
-// not create a new id mapping, so it must not be used before the tool_call it
+// id is the only place the command/path/query detail exists. Later empty
+// `tool_call_update` snapshots merge into that prior input instead of replacing
+// it, so this lookup still sees the original detail. This lookup does not
+// create a new id mapping, so it must not be used before the tool_call it
 // targets has actually streamed.
 func (n *acpTurnNormalizer) KnownToolCallInput(rawToolCallID string) map[string]any {
 	if n == nil {
@@ -459,6 +472,13 @@ func (n *acpTurnNormalizer) KnownToolCallInput(rawToolCallID string) map[string]
 	return payloadMap(pending.payload, "input")
 }
 
+func (n *acpTurnNormalizer) pendingToolCallCount() int {
+	if n == nil {
+		return 0
+	}
+	return len(n.pendingToolCalls)
+}
+
 func (n *acpTurnNormalizer) trackToolCallEvent(event activityshared.Event) {
 	if n == nil || strings.TrimSpace(event.EventID) == "" {
 		return
@@ -468,13 +488,70 @@ func (n *acpTurnNormalizer) trackToolCallEvent(event activityshared.Event) {
 		if n.pendingToolCalls == nil {
 			n.pendingToolCalls = make(map[string]pendingToolCallSnapshot)
 		}
+		incoming := clonePayload(event.Payload.Metadata)
+		if previous, ok := n.pendingToolCalls[event.EventID]; ok {
+			// Cursor often streams tool_call with rawInput, then a later
+			// tool_call_update that repeats only title/kind/status (no input).
+			// Replacing the snapshot wholesale dropped command/path/query and
+			// left session/request_permission with nothing to backfill.
+			logACPPendingToolCallDetailPreservation(event, previous.payload, incoming)
+			incoming = mergePendingToolCallPayload(previous.payload, incoming)
+		}
 		n.pendingToolCalls[event.EventID] = pendingToolCallSnapshot{
 			eventID: event.EventID,
-			payload: clonePayload(event.Payload.Metadata),
+			payload: incoming,
 		}
 	case activityshared.EventCallCompleted, activityshared.EventCallFailed:
 		delete(n.pendingToolCalls, event.EventID)
 	}
+}
+
+func logACPPendingToolCallDetailPreservation(
+	event activityshared.Event,
+	previousPayload map[string]any,
+	incomingPayload map[string]any,
+) {
+	previousInput := payloadMap(previousPayload, "input")
+	incomingInput := payloadMap(incomingPayload, "input")
+	if !acpApprovalDetailPresent(previousInput) || acpApprovalDetailPresent(incomingInput) {
+		return
+	}
+	slog.Info("agent session ACP pending tool call preserved detail across empty update",
+		"event", "agent_session.acp.pending_tool_call.preserved_detail",
+		"provider", event.Provider,
+		"agent_session_id", strings.TrimSpace(event.AgentSessionID),
+		"turn_id", strings.TrimSpace(event.Payload.TurnID),
+		"event_id", strings.TrimSpace(event.EventID),
+		"call_id", firstNonEmpty(
+			asString(incomingPayload["callId"]),
+			asString(previousPayload["callId"]),
+			strings.TrimSpace(event.Payload.CallID),
+		),
+		"previous_input_keys", sortedACPDiagnosticKeys(previousInput),
+		"incoming_input_keys", sortedACPDiagnosticKeys(incomingInput),
+		"previous_command", truncateACPDiagnosticText(
+			firstNonEmpty(asString(previousInput["command"]), asString(previousInput["cmd"])),
+			160,
+		),
+	)
+}
+
+func acpApprovalDetailPresent(input map[string]any) bool {
+	if len(input) == 0 {
+		return false
+	}
+	return firstNonEmpty(
+		asString(input["command"]),
+		asString(input["cmd"]),
+		asString(input["file_path"]),
+		asString(input["filePath"]),
+		asString(input["path"]),
+		asString(input["notebook_path"]),
+		asString(input["query"]),
+		asString(input["search_query"]),
+		asString(input["searchQuery"]),
+		asString(input["pattern"]),
+	) != ""
 }
 
 func (n *acpTurnNormalizer) mergePendingToolCallSnapshot(event *activityshared.Event) {
@@ -505,12 +582,37 @@ func mergePendingToolCallPayload(started map[string]any, completed map[string]an
 	}
 	for key, value := range completed {
 		if key == "input" {
-			if len(payloadMap(merged, "input")) == 0 {
-				merged[key] = clonePayloadValue(value)
+			if mergedInput := mergePendingToolCallInput(
+				payloadMap(merged, "input"),
+				payloadObject(value),
+			); len(mergedInput) > 0 {
+				merged[key] = mergedInput
 			}
 			continue
 		}
+		if payloadValueIsEmpty(value) {
+			continue
+		}
 		merged[key] = clonePayloadValue(value)
+	}
+	return merged
+}
+
+// mergePendingToolCallInput keeps earlier structured fields (command/path/query)
+// when a later ACP tool_call_update omits or only partially repeats input.
+func mergePendingToolCallInput(base map[string]any, incoming map[string]any) map[string]any {
+	merged := clonePayload(base)
+	if merged == nil {
+		merged = map[string]any{}
+	}
+	for key, value := range incoming {
+		if payloadValueIsEmpty(value) {
+			continue
+		}
+		merged[key] = clonePayloadValue(value)
+	}
+	if len(merged) == 0 {
+		return nil
 	}
 	return merged
 }

--- a/packages/agent/daemon/runtime/acp_turn_normalizer_snapshots.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer_snapshots.go
@@ -1,0 +1,100 @@
+package agentruntime
+
+import (
+	"strings"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+// ApplyStreamingThinkingSnapshot replaces the open thinking segment with a full
+// snapshot (Claude SDK style) while keeping a stable message id so cancel and
+// completed updates rewrite the same row instead of opening a duplicate.
+func (n *acpTurnNormalizer) ApplyStreamingThinkingSnapshot(
+	session Session,
+	turnID string,
+	text string,
+	messageID string,
+) []activityshared.Event {
+	if n == nil || text == "" {
+		return nil
+	}
+	if n.thinkingMessageID == "" || n.thinkingSegmentCompleted {
+		n.thinkingMessageID = firstNonEmpty(strings.TrimSpace(messageID), newID())
+		n.thinkingSegmentCompleted = false
+	}
+	n.thinkingContent.Reset()
+	_, _ = n.thinkingContent.WriteString(text)
+	return []activityshared.Event{n.thinkingSnapshotEvent(session, turnID, messageStreamStateStreaming)}
+}
+
+// CompleteThinkingSnapshot finalizes thinking from an authoritative full-text
+// snapshot, preserving messageID when opening a brand-new segment.
+func (n *acpTurnNormalizer) CompleteThinkingSnapshot(
+	session Session,
+	turnID string,
+	text string,
+	messageID string,
+) []activityshared.Event {
+	if n == nil {
+		return nil
+	}
+	if text != "" {
+		if n.thinkingMessageID == "" || n.thinkingSegmentCompleted {
+			n.thinkingMessageID = firstNonEmpty(strings.TrimSpace(messageID), newID())
+			n.thinkingSegmentCompleted = false
+		}
+		n.thinkingContent.Reset()
+		_, _ = n.thinkingContent.WriteString(text)
+	} else if !n.hasStreamingThinkingSegment() {
+		return nil
+	}
+	return n.Finish(session, turnID, messageStreamStateCompleted)
+}
+
+// ApplyStreamingAssistantSnapshot replaces the open assistant segment with a
+// full snapshot while keeping a stable message id for later completed/cancel
+// settlement.
+func (n *acpTurnNormalizer) ApplyStreamingAssistantSnapshot(
+	session Session,
+	turnID string,
+	text string,
+	messageID string,
+) []activityshared.Event {
+	if n == nil || text == "" {
+		return nil
+	}
+	if n.suppressAssistantOutput {
+		return nil
+	}
+	if n.assistantMessageID == "" || n.assistantSegmentCompleted {
+		n.assistantMessageID = firstNonEmpty(strings.TrimSpace(messageID), newID())
+		n.assistantSegmentCompleted = false
+	}
+	n.assistantContent.Reset()
+	_, _ = n.assistantContent.WriteString(text)
+	return []activityshared.Event{n.assistantSnapshotEvent(session, turnID, messageStreamStateStreaming)}
+}
+
+// CompleteAssistantSnapshot finalizes assistant text from an authoritative
+// snapshot. Empty content finalizes an already-open streaming segment; non-empty
+// content reuses AppendAssistantSnapshot.
+func (n *acpTurnNormalizer) CompleteAssistantSnapshot(
+	session Session,
+	turnID string,
+	text string,
+	messageID string,
+) []activityshared.Event {
+	if n == nil {
+		return nil
+	}
+	if n.suppressAssistantOutput {
+		return nil
+	}
+	if text == "" {
+		if n.assistantMessageID == "" || n.assistantSegmentCompleted || n.assistantContent.Len() == 0 {
+			return nil
+		}
+		return n.Finish(session, turnID, messageStreamStateCompleted)
+	}
+	return n.AppendAssistantSnapshot(session, turnID, text, messageID)
+}

--- a/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
@@ -670,6 +670,55 @@ func TestClaudeCodeSDKAdapterCancelFailsOpenToolCalls(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeSDKAdapterCancelFailsOpenThinking(t *testing.T) {
+	// Mirrors the open-Write cancel path: thinking must leave the shared turn
+	// normalizer so Stop does not leave a forever-"thinking" disclosure.
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{
+		conn:      &recordingClaudeSDKConnection{},
+		liveState: newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+	adapter.registerClaudeSDKTurn(adapterSession, "turn-think", nil)
+
+	streaming, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-think", claudeSDKSidecarEvent{
+		Type: "thinking_delta",
+		Payload: map[string]any{
+			"turnId":   "turn-think",
+			"snapshot": "Still reasoning about the change.",
+		},
+	})
+	if err != nil || terminal {
+		t.Fatalf("thinking_delta err=%v terminal=%v", err, terminal)
+	}
+	if len(streaming) != 1 ||
+		streaming[0].Payload.Role != activityshared.MessageRoleAssistantThinking ||
+		streaming[0].EventID != "claude-sdk:thinking:turn-think" ||
+		streaming[0].Payload.Metadata["streamState"] != messageStreamStateStreaming {
+		t.Fatalf("streaming thinking = %#v, want stable streaming thinking row", streaming)
+	}
+
+	events, err := adapter.Cancel(context.Background(), session, "user")
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("cancel events = %#v, want failed open thinking then interrupted turn", events)
+	}
+	if events[0].Type != activityshared.EventMessageAppended ||
+		events[0].EventID != "claude-sdk:thinking:turn-think" ||
+		events[0].Payload.Role != activityshared.MessageRoleAssistantThinking ||
+		events[0].Payload.Metadata["streamState"] != messageStreamStateFailed ||
+		events[0].Payload.Content != "Still reasoning about the change." {
+		t.Fatalf("open thinking cancel event = %#v, want failed thinking snapshot", events[0])
+	}
+	if events[1].Type != activityshared.EventTurnCompleted ||
+		events[1].Payload.TurnOutcome != string(activityshared.TurnOutcomeInterrupted) {
+		t.Fatalf("cancel turn event = %#v, want interrupted turn", events[1])
+	}
+}
+
 func TestClaudeCodeSDKAdapterCancelFailsOpenToolsAfterWaiterUnregistered(t *testing.T) {
 	// Mirrors controller Cancel ordering: active.cancel() makes Exec unregister
 	// its waiter before adapter.Cancel runs. Open tools must still close.

--- a/packages/agent/daemon/runtime/claude_sdk_events.go
+++ b/packages/agent/daemon/runtime/claude_sdk_events.go
@@ -74,33 +74,31 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 	case "assistant_delta":
 		messageID := firstNonEmptyString(payloadString(event.Payload, "messageId"), adapterSession.assistantMessageID(turnID))
 		content := firstNonEmpty(payloadString(event.Payload, "snapshot"), payloadString(event.Payload, "content"))
-		return []activityshared.Event{newTurnActivityEventWithID(session, messageID, EventMessage, turnID, messageStreamStateStreaming, RoleAssistant, content, map[string]any{
-			"adapter":     claudeSDKSidecarAdapterName,
-			"messageId":   messageID,
-			"contentMode": messageContentModeSnapshot,
-		})}, false, nil
+		return a.claudeSDKAssistantEvents(adapterSession, session, turnID, messageID, content, false), false, nil
 	case "assistant_completed":
 		messageID := firstNonEmptyString(payloadString(event.Payload, "messageId"), adapterSession.assistantMessageID(turnID))
-		return []activityshared.Event{newTurnActivityEventWithID(session, messageID, EventMessage, turnID, messageStreamStateCompleted, RoleAssistant, payloadString(event.Payload, "content"), map[string]any{
-			"adapter":     claudeSDKSidecarAdapterName,
-			"messageId":   messageID,
-			"contentMode": messageContentModeSnapshot,
-		})}, false, nil
+		return a.claudeSDKAssistantEvents(
+			adapterSession,
+			session,
+			turnID,
+			messageID,
+			payloadString(event.Payload, "content"),
+			true,
+		), false, nil
 	case "thinking_delta":
 		messageID := firstNonEmptyString(payloadString(event.Payload, "messageId"), adapterSession.thinkingMessageID(turnID))
 		content := firstNonEmpty(payloadString(event.Payload, "snapshot"), payloadString(event.Payload, "content"))
-		return []activityshared.Event{newTurnActivityEventWithID(session, messageID, EventMessage, turnID, messageStreamStateStreaming, RoleAssistantThinking, content, map[string]any{
-			"adapter":     claudeSDKSidecarAdapterName,
-			"messageId":   messageID,
-			"contentMode": messageContentModeSnapshot,
-		})}, false, nil
+		return a.claudeSDKThinkingEvents(adapterSession, session, turnID, messageID, content, false), false, nil
 	case "thinking_completed":
 		messageID := firstNonEmptyString(payloadString(event.Payload, "messageId"), adapterSession.thinkingMessageID(turnID))
-		return []activityshared.Event{newTurnActivityEventWithID(session, messageID, EventMessage, turnID, messageStreamStateCompleted, RoleAssistantThinking, payloadString(event.Payload, "content"), map[string]any{
-			"adapter":     claudeSDKSidecarAdapterName,
-			"messageId":   messageID,
-			"contentMode": messageContentModeSnapshot,
-		})}, false, nil
+		return a.claudeSDKThinkingEvents(
+			adapterSession,
+			session,
+			turnID,
+			messageID,
+			payloadString(event.Payload, "content"),
+			true,
+		), false, nil
 	case "tool_started", "tool_updated":
 		if a.turnAlreadySettled(adapterSession, turnID) {
 			return nil, false, nil

--- a/packages/agent/daemon/runtime/claude_sdk_turn.go
+++ b/packages/agent/daemon/runtime/claude_sdk_turn.go
@@ -55,6 +55,84 @@ func (a *ClaudeCodeSDKAdapter) trackClaudeSDKTurnCallEvents(
 	}
 }
 
+// claudeSDKThinkingEvents routes Claude thinking snapshots through the shared
+// turn normalizer so cancel/fail/complete can settle an in-flight "thinking"
+// row the same way Codex/ACP do.
+func (a *ClaudeCodeSDKAdapter) claudeSDKThinkingEvents(
+	adapterSession *claudeSDKAdapterSession,
+	session Session,
+	turnID string,
+	messageID string,
+	content string,
+	completed bool,
+) []activityshared.Event {
+	if a == nil || adapterSession == nil {
+		return nil
+	}
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	normalizer := adapterSession.ensureClaudeSDKTurnNormalizerLocked(turnID)
+	if normalizer == nil {
+		return nil
+	}
+	var events []activityshared.Event
+	if completed {
+		events = normalizer.CompleteThinkingSnapshot(session, turnID, content, messageID)
+	} else {
+		events = normalizer.ApplyStreamingThinkingSnapshot(session, turnID, content, messageID)
+	}
+	return stampClaudeSDKAdapterMetadata(events)
+}
+
+// claudeSDKAssistantEvents routes Claude assistant snapshots through the shared
+// turn normalizer so interrupt can close a half-streamed assistant bubble.
+func (a *ClaudeCodeSDKAdapter) claudeSDKAssistantEvents(
+	adapterSession *claudeSDKAdapterSession,
+	session Session,
+	turnID string,
+	messageID string,
+	content string,
+	completed bool,
+) []activityshared.Event {
+	if a == nil || adapterSession == nil {
+		return nil
+	}
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	normalizer := adapterSession.ensureClaudeSDKTurnNormalizerLocked(turnID)
+	if normalizer == nil {
+		return nil
+	}
+	var events []activityshared.Event
+	if completed {
+		events = normalizer.CompleteAssistantSnapshot(session, turnID, content, messageID)
+	} else {
+		events = normalizer.ApplyStreamingAssistantSnapshot(session, turnID, content, messageID)
+	}
+	return stampClaudeSDKAdapterMetadata(events)
+}
+
+func stampClaudeSDKAdapterMetadata(events []activityshared.Event) []activityshared.Event {
+	if len(events) == 0 {
+		return events
+	}
+	for index := range events {
+		if events[index].Payload.Metadata == nil {
+			events[index].Payload.Metadata = map[string]any{}
+		}
+		events[index].Payload.Metadata["adapter"] = claudeSDKSidecarAdapterName
+	}
+	return events
+}
+
 // takeClaudeSDKTurnNormalizerLocked removes and returns the turn lifecycle
 // owner for turnID. Caller must hold the adapter mutex.
 func (s *claudeSDKAdapterSession) takeClaudeSDKTurnNormalizerLocked(turnID string) *acpTurnNormalizer {
@@ -76,8 +154,9 @@ const (
 )
 
 // finishClaudeSDKTurnLifecycle closes the Claude turn's event lifecycle:
-// dangling tool calls (and any normalizer-owned streams) are settled before the
-// caller emits the turn terminal event. Idempotent once the normalizer is taken.
+// dangling tool calls plus any normalizer-owned thinking/assistant streams are
+// settled before the caller emits the turn terminal event. Idempotent once the
+// normalizer is taken.
 func (a *ClaudeCodeSDKAdapter) finishClaudeSDKTurnLifecycle(
 	adapterSession *claudeSDKAdapterSession,
 	session Session,

--- a/packages/agent/daemon/runtime/controller_turn_exec.go
+++ b/packages/agent/daemon/runtime/controller_turn_exec.go
@@ -65,10 +65,11 @@ func (c *Controller) runExecTurn(ctx context.Context, session Session, adapter A
 	shouldEmitTerminalEvents := false
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			// Keep call-lifecycle close events Exec already produced (for
-			// example Claude finishing open tools on ctx cancel). Replacing the
-			// whole slice would drop those CallFailed updates and leave tool
-			// cards stuck in progress after Stop.
+			// Keep lifecycle close events Exec already produced (Claude
+			// finishing open tools and in-flight thinking/assistant snapshots
+			// on ctx cancel). Replacing the whole slice would drop those
+			// CallFailed / failed-stream updates and leave tool cards or
+			// thinking disclosures stuck in progress after Stop.
 			events = append(retainTurnCallLifecycleEvents(events, turnID), newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
 				"error": err.Error(),
 			}))

--- a/packages/agent/daemon/runtime/controller_turn_state.go
+++ b/packages/agent/daemon/runtime/controller_turn_state.go
@@ -463,9 +463,11 @@ func unemittedActivityEvents(events []activityshared.Event, emitted []activitysh
 	return out
 }
 
-// retainTurnCallLifecycleEvents keeps call.started/completed/failed events for
-// turnID when synthesizing a context-canceled terminal. Controllers must not
-// discard adapter-produced CallFailed closes for open tools.
+// retainTurnCallLifecycleEvents keeps adapter-produced close events for turnID
+// when synthesizing a context-canceled terminal. Controllers must not discard:
+//   - CallFailed closes for open tools
+//   - failed/completed assistant or thinking snapshots that settle in-flight
+//     stream rows (Claude FinishInterrupted on ctx cancel)
 func retainTurnCallLifecycleEvents(events []activityshared.Event, turnID string) []activityshared.Event {
 	turnID = strings.TrimSpace(turnID)
 	if len(events) == 0 || turnID == "" {
@@ -473,16 +475,34 @@ func retainTurnCallLifecycleEvents(events []activityshared.Event, turnID string)
 	}
 	out := make([]activityshared.Event, 0, len(events))
 	for _, event := range events {
+		if strings.TrimSpace(event.Payload.TurnID) != turnID {
+			continue
+		}
 		switch event.Type {
 		case activityshared.EventCallStarted,
 			activityshared.EventCallCompleted,
 			activityshared.EventCallFailed:
-			if strings.TrimSpace(event.Payload.TurnID) == turnID {
+			out = append(out, event)
+		case activityshared.EventMessageAppended, activityshared.EventMessageCreated:
+			if isRetainedCancelMessageSettlement(event) {
 				out = append(out, event)
 			}
 		}
 	}
 	return out
+}
+
+func isRetainedCancelMessageSettlement(event activityshared.Event) bool {
+	role := string(event.Payload.Role)
+	if role != string(activityshared.MessageRoleAssistant) &&
+		role != string(activityshared.MessageRoleAssistantThinking) {
+		return false
+	}
+	streamState := asString(event.Payload.Metadata["streamState"])
+	if streamState == "" {
+		streamState = strings.TrimSpace(event.Payload.Status)
+	}
+	return streamState == messageStreamStateCompleted || streamState == messageStreamStateFailed
 }
 
 func activityEventIdentity(event activityshared.Event) string {

--- a/packages/agent/daemon/runtime/controller_turn_state_test.go
+++ b/packages/agent/daemon/runtime/controller_turn_state_test.go
@@ -1,0 +1,62 @@
+package agentruntime
+
+import (
+	"testing"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+func TestRetainTurnCallLifecycleEventsKeepsFailedThinkingSnapshots(t *testing.T) {
+	t.Parallel()
+
+	session := Session{Provider: ProviderClaudeCode, AgentSessionID: "agent-1", RoomID: "room-1"}
+	normalizer := newACPTurnNormalizer()
+	events := append([]activityshared.Event{}, normalizer.ApplyStreamingThinkingSnapshot(
+		session,
+		"turn-1",
+		"Still thinking.",
+		"claude-sdk:thinking:msg:live:0",
+	)...)
+	events = append(events, normalizer.FinishInterrupted(session, "turn-1", "user_interrupt")...)
+	events = append(events, newTurnActivityEvent(session, EventTurnStarted, "turn-other", SessionStatusWorking, "", "", nil))
+
+	retained := retainTurnCallLifecycleEvents(events, "turn-1")
+	if len(retained) != 1 {
+		t.Fatalf("retained = %#v, want one failed thinking snapshot", retained)
+	}
+	if retained[0].EventID != "claude-sdk:thinking:msg:live:0" ||
+		retained[0].Payload.Role != activityshared.MessageRoleAssistantThinking ||
+		retained[0].Payload.Metadata["streamState"] != messageStreamStateFailed {
+		t.Fatalf("retained thinking = %#v, want failed stream settlement", retained[0])
+	}
+}
+
+func TestRetainTurnCallLifecycleEventsKeepsCallFailedAndDropsStreaming(t *testing.T) {
+	t.Parallel()
+
+	session := Session{Provider: ProviderClaudeCode, AgentSessionID: "agent-1", RoomID: "room-1"}
+	streaming := newTurnActivityEventWithID(
+		session,
+		"claude-sdk:thinking:msg:live:0",
+		EventMessage,
+		"turn-1",
+		messageStreamStateStreaming,
+		RoleAssistantThinking,
+		"partial",
+		map[string]any{"streamState": messageStreamStateStreaming},
+	)
+	failedCall := newTurnActivityEventWithID(
+		session,
+		"claude-sdk:tool:toolu-1",
+		EventCallFailed,
+		"turn-1",
+		SessionStatusCanceled,
+		"",
+		"Write",
+		map[string]any{"status": SessionStatusCanceled, "callId": "toolu-1"},
+	)
+	retained := retainTurnCallLifecycleEvents([]activityshared.Event{streaming, failedCall}, "turn-1")
+	if len(retained) != 1 || retained[0].EventID != "claude-sdk:tool:toolu-1" {
+		t.Fatalf("retained = %#v, want only call.failed", retained)
+	}
+}

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -433,6 +433,90 @@ func TestCursorPermissionRequestFallsBackToKnownToolCallInput(t *testing.T) {
 	}
 }
 
+// TestCursorPermissionRequestKeepsKnownInputAfterEmptyToolCallUpdate reproduces
+// the live Cursor sequence behind blank approval cards: tool_call carries
+// rawInput.command, a later tool_call_update for the same id repeats only
+// title/kind/status/content (no rawInput), then session/request_permission
+// also omits rawInput. The empty update must not wipe the pending snapshot, or
+// KnownToolCallInput has nothing left to backfill onto the approval card.
+func TestCursorPermissionRequestKeepsKnownInputAfterEmptyToolCallUpdate(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Cursor Agent", "cursor-session-empty-update")
+	adapter := newCursorAdapterWithHostMetadata(transport, LegacyHostMetadata(), nil)
+	session := standardTestSession(ProviderCursor)
+	normalizer := newACPTurnNormalizer()
+	config := standardACPConfig{provider: ProviderCursor}
+	toolCallID := "call-4341cda2-656d-41c2-8ec3-80f0b3b6d09a-0\nfc_918c4886-f213-9396-8439-d721f380bc12_0"
+	command := `echo "hello from bash" && pwd && date`
+
+	started := standardACPUpdateEvents(config, session, "turn-1", json.RawMessage(`{
+		"update": {
+			"sessionUpdate": "tool_call",
+			"toolCallId": `+jsonString(toolCallID)+`,
+			"title": `+jsonString("`"+command+"`")+`,
+			"kind": "execute",
+			"status": "pending",
+			"rawInput": {"command": `+jsonString(command)+`}
+		}
+	}`), normalizer)
+	if len(started) != 1 || started[0].Type != activityshared.EventCallStarted {
+		t.Fatalf("started events = %#v, want one call.started", started)
+	}
+	if got := asString(payloadMap(started[0].Payload.Metadata, "input")["command"]); got != command {
+		t.Fatalf("started input.command = %q, want %q", got, command)
+	}
+
+	updated := standardACPUpdateEvents(config, session, "turn-1", json.RawMessage(`{
+		"update": {
+			"sessionUpdate": "tool_call_update",
+			"toolCallId": `+jsonString(toolCallID)+`,
+			"title": `+jsonString("`"+command+"`")+`,
+			"kind": "execute",
+			"status": "pending",
+			"content": [{"type": "content", "content": {"type": "text", "text": "Not in allowlist: echo"}}]
+		}
+	}`), normalizer)
+	if len(updated) == 0 {
+		t.Fatal("updated events = empty, want the tool_call_update projection")
+	}
+	if got := normalizer.KnownToolCallInput(toolCallID); asString(got["command"]) != command {
+		t.Fatalf("KnownToolCallInput after empty update = %#v, want command %q preserved", got, command)
+	}
+
+	_, pending, err := standardACPPermissionRequested(adapter, session, "turn-1", json.RawMessage(`0`), json.RawMessage(`{
+		"toolCall": {
+			"toolCallId": `+jsonString(toolCallID)+`,
+			"title": `+jsonString("`"+command+"`")+`,
+			"kind": "execute",
+			"status": "pending",
+			"content": [{"type": "content", "content": {"type": "text", "text": "Not in allowlist: echo"}}]
+		},
+		"options": [
+			{"optionId": "allow-once", "name": "Allow once", "kind": "allow_once"},
+			{"optionId": "allow-always", "name": "Allow always", "kind": "allow_always"},
+			{"optionId": "reject-once", "name": "Reject", "kind": "reject_once"}
+		]
+	}`), normalizer)
+	if err != nil {
+		t.Fatalf("standardACPPermissionRequested: %v", err)
+	}
+	if pending == nil {
+		t.Fatal("pending = nil, want a stored pending approval")
+	}
+	if got := asString(pending.input["command"]); got != command {
+		t.Fatalf("pending.input[command] = %q, want command preserved across empty tool_call_update", got)
+	}
+}
+
+func jsonString(value string) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return string(encoded)
+}
+
 func TestCursorAutoApprovePermissionDecision(t *testing.T) {
 	t.Parallel()
 
@@ -2343,6 +2427,10 @@ type standardACPConnection struct {
 	// cursor-agent's transient-failure shape: an "Error: RetriableError: ..."
 	// text chunk followed by a normal end_turn result.
 	retriableErrorPrompts int
+	// retriableErrorPriorText, when set, is streamed as an agent_message_chunk
+	// before the RetriableError tail so tests can exercise mid-task
+	// auto-continue wording (useful progress before the drop).
+	retriableErrorPriorText string
 	// planLimitPromptError makes session/prompt fail with Cursor's plan-gate
 	// copy so the adapter can soft-settle instead of emitting a red failure.
 	planLimitPromptError bool
@@ -2572,6 +2660,25 @@ func (c *standardACPConnection) Send(data []byte) error {
 				return nil
 			}
 			if promptCall <= c.retriableErrorPrompts {
+				c.mu.Lock()
+				priorText := c.retriableErrorPriorText
+				c.mu.Unlock()
+				if priorText != "" {
+					c.sendJSON(map[string]any{
+						"jsonrpc": "2.0",
+						"method":  acpMethodUpdate,
+						"params": map[string]any{
+							"sessionId": c.sessionID,
+							"update": map[string]any{
+								"sessionUpdate": "agent_message_chunk",
+								"content": map[string]any{
+									"type": "text",
+									"text": priorText,
+								},
+							},
+						},
+					})
+				}
 				c.sendJSON(map[string]any{
 					"jsonrpc": "2.0",
 					"method":  acpMethodUpdate,

--- a/packages/agent/daemon/runtime/standard_acp_events.go
+++ b/packages/agent/daemon/runtime/standard_acp_events.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
@@ -322,8 +323,10 @@ func standardACPPermissionRequested(
 	callID := firstNonEmpty(asString(params.ToolCall["toolCallId"]), asString(params.ToolCall["id"]), newID())
 	callType := "approval"
 	status := string(activityshared.TurnPhaseWaitingApproval)
-	knownInput := normalizer.KnownToolCallInput(asString(params.ToolCall["toolCallId"]))
+	rawToolCallID := asString(params.ToolCall["toolCallId"])
+	knownInput := normalizer.KnownToolCallInput(rawToolCallID)
 	input := normalizedApprovalInput(params.ToolCall, params.Options, requestID, knownInput)
+	logACPPermissionApprovalDiagnostic(session, turnID, requestID, params.ToolCall, knownInput, input, normalizer)
 	payload := map[string]any{
 		"callId":   callID,
 		"callType": "approval",
@@ -389,4 +392,78 @@ func standardACPPermissionRequested(
 		),
 		normalizedInteractionRequestedEvent(session, turnID, pending),
 	}, pending, nil
+}
+
+// logACPPermissionApprovalDiagnostic records whether Cursor-style permission
+// requests recovered structured approval detail (command/path/query). The GUI
+// only renders those fields; title/content alone leave the approval card blank.
+func logACPPermissionApprovalDiagnostic(
+	session Session,
+	turnID string,
+	requestID string,
+	toolCall map[string]any,
+	knownInput map[string]any,
+	approvalInput map[string]any,
+	normalizer *acpTurnNormalizer,
+) {
+	displayCommand := firstNonEmpty(
+		asString(approvalInput["command"]),
+		asString(approvalInput["cmd"]),
+	)
+	displayPath := firstNonEmpty(
+		asString(approvalInput["file_path"]),
+		asString(approvalInput["filePath"]),
+		asString(approvalInput["path"]),
+		asString(approvalInput["notebook_path"]),
+	)
+	displayQuery := firstNonEmpty(
+		asString(approvalInput["query"]),
+		asString(approvalInput["search_query"]),
+		asString(approvalInput["searchQuery"]),
+		asString(approvalInput["pattern"]),
+	)
+	hasDisplayDetail := displayCommand != "" || displayPath != "" || displayQuery != ""
+	slog.Info("agent session ACP permission approval projected",
+		"event", "agent_session.acp.permission_approval.projected",
+		"provider", session.Provider,
+		"room_id", strings.TrimSpace(session.RoomID),
+		"agent_session_id", strings.TrimSpace(session.AgentSessionID),
+		"provider_session_id", strings.TrimSpace(session.ProviderSessionID),
+		"turn_id", strings.TrimSpace(turnID),
+		"request_id", strings.TrimSpace(requestID),
+		"tool_call_id", asString(toolCall["toolCallId"]),
+		"tool_call_kind", asString(toolCall["kind"]),
+		"tool_call_title", truncateACPDiagnosticText(asString(toolCall["title"]), 160),
+		"tool_call_has_raw_input", payloadObject(toolCall["rawInput"]) != nil || payloadObject(toolCall["input"]) != nil,
+		"tool_call_content_text", truncateACPDiagnosticText(acpContentText(toolCall["content"]), 160),
+		"known_input_hit", len(knownInput) > 0,
+		"known_input_keys", sortedACPDiagnosticKeys(knownInput),
+		"known_input_has_command", strings.TrimSpace(asString(knownInput["command"])) != "" || strings.TrimSpace(asString(knownInput["cmd"])) != "",
+		"pending_tool_call_count", normalizer.pendingToolCallCount(),
+		"approval_input_keys", sortedACPDiagnosticKeys(approvalInput),
+		"display_command", truncateACPDiagnosticText(displayCommand, 160),
+		"display_path", truncateACPDiagnosticText(displayPath, 160),
+		"display_query", truncateACPDiagnosticText(displayQuery, 160),
+		"has_display_detail", hasDisplayDetail,
+	)
+}
+
+func sortedACPDiagnosticKeys(payload map[string]any) []string {
+	if len(payload) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(payload))
+	for key := range payload {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func truncateACPDiagnosticText(value string, limit int) string {
+	value = strings.TrimSpace(value)
+	if limit <= 0 || len(value) <= limit {
+		return value
+	}
+	return value[:limit] + "…"
 }

--- a/packages/agent/daemon/runtime/standard_acp_turn.go
+++ b/packages/agent/daemon/runtime/standard_acp_turn.go
@@ -188,9 +188,11 @@ execLoop:
 			"emitted_event_type_counts", activityEventTypeCounts(events),
 		)
 		if a.config.autoContinueRetriableTurnError && acpStopReasonEndsTurnNormally(stopReason) {
-			if errLine, ok := acpRetriableTurnTailError(normalizer.CurrentAssistantText()); ok {
+			assistantText := normalizer.CurrentAssistantText()
+			if errLine, ok := acpRetriableTurnTailError(assistantText); ok {
 				if autoContinueAttempts < acpAutoContinueMaxAttempts {
 					autoContinueAttempts++
+					hasUsefulProgress := acpAutoContinueHasUsefulProgress(assistantText, normalizer.SeenToolCallCount())
 					// Close out the error-text segment so the continuation
 					// streams into a fresh message instead of appending to it.
 					emitEvents(normalizer.Finish(session, turnID, messageStreamStateCompleted))
@@ -208,8 +210,9 @@ execLoop:
 						"attempt", autoContinueAttempts,
 						"max_attempts", acpAutoContinueMaxAttempts,
 						"error_line", errLine,
+						"has_useful_progress", hasUsefulProgress,
 					)
-					promptParams = acpAutoContinuePromptContent()
+					promptParams = acpAutoContinuePromptContent(hasUsefulProgress)
 					continue execLoop
 				}
 				// The retries were cut short too: surface the turn as failed


### PR DESCRIPTION
## Summary
- Preserve Cursor tool-call `input` across empty/partial `tool_call_update`s so approval cards keep command/path/query detail instead of going blank.
- Branch Cursor ACP auto-continue prompts by useful progress so zero-progress retriable drops re-answer the user instead of inventing interrupted work.
- Route Claude SDK thinking/assistant snapshots through `acpTurnNormalizer` and retain cancel settlement events so Stop closes open tools and thinking rows.

## Test plan
- [ ] `cd packages/agent/daemon && go test ./runtime/ -run 'TestCursorPermissionRequestFallsBackToKnownToolCallInput|TestCursorPermissionRequestKeepsKnownInputAfterEmptyToolCallUpdate|TestACPAutoContinueHasUsefulProgress|TestACPAutoContinuePromptContentBranches|TestCursorAdapterAutoContinuesAfterRetriableTurnError|TestCursorAdapterAutoContinueMidTaskUsesContinuePrompt|TestClaudeCodeSDKAdapter(CancelFailsOpenToolCalls|CancelFailsOpenToolsAfterWaiterUnregistered|TurnCanceledFailsOpenToolCalls|CancelFailsOpenThinking|MapsThinkingEvents)|TestRetainTurnCallLifecycleEvents'`
- [ ] Live Cursor: trigger ask-for-approval shell command; confirm approval card shows command and logs `has_display_detail=true`
- [ ] Live Cursor: force a zero-progress retriable drop on a short greeting; confirm retry answers the user instead of recovering a phantom task
- [ ] Live Claude Code: Stop during thinking and during a long Write; confirm thinking and tool cards leave in-progress / streaming


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank Cursor approval cards, prevents auto-continue from inventing work after transient drops, and ensures Claude cancel cleanly closes open tools and thinking so the UI doesn’t get stuck.

- **Bug Fixes**
  - Cursor approvals: preserve `rawInput` across partial `tool_call_update` by merging per-turn snapshots in `acpTurnNormalizer`; `KnownToolCallInput` backfills `command`/`path`/`query` so approval cards show detail.
  - Cursor auto-continue: branch prompt via `acpAutoContinueHasUsefulProgress`; zero-progress retries “answer the last message,” mid-task keeps “continue where you left off.”
  - Claude cancel settlement: route thinking/assistant snapshots through `acpTurnNormalizer` and close them on cancel; controller keeps these close events with `retainTurnCallLifecycleEvents` to avoid stuck thinking/tool rows.

<sup>Written for commit 46ba7418c268cef90b8ae14cf045c6ee50725e51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

