### PR TITLE
refactor: preserve app reference source order

### DIFF
--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/appArtifactReferenceSource.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/appArtifactReferenceSource.ts
@@ -27,6 +27,8 @@ export function createAppArtifactReferenceSource(input: {
     sourceId: APP_ARTIFACT_SOURCE_ID,
     label: input.label,
     order: input.order ?? 1,
+    // App Reference 协议中 items 的数组顺序由应用定义，Tutti 只映射字段、不重排。
+    preserveBackendOrder: true,
     // 应用产物:全版布局——分组导航栏(app→项目)+ 文件类型筛选。
     // searchable:跨「声明 searchEndpoint」的 app 并行搜索(见 appReferenceListBackend.search)。
     // filterable:已选分类作为 search() 的 filters 下钻到各 app 的 searchEndpoint 过滤。

--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/appReferenceListBackend.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/appReferenceListBackend.ts
@@ -110,9 +110,7 @@ export function createAppReferenceListBackend(
         items: response.items.map((item) =>
           appItemToProtocol(appId, item, appMetadata.label, appMetadata.iconUrl)
         ),
-        nextCursor: response.nextCursor ?? null,
-        // 应用负责定义项目/产物的业务顺序（如更新时间倒序），前端不得按名称重排。
-        ordered: true
+        nextCursor: response.nextCursor ?? null
       };
     },
 

--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/referenceHandle.test.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/referenceHandle.test.ts
@@ -8,6 +8,7 @@ import {
   createAppReferenceListBackend,
   listReferenceSupportingApps
 } from "./appReferenceListBackend.ts";
+import { createAppArtifactReferenceSource } from "./appArtifactReferenceSource.ts";
 
 const scope: ReferenceScope = { workspaceId: "workspace-1" };
 
@@ -71,7 +72,6 @@ test("app backend describeHandle resolves the app handle", async () => {
   const apps = await backend.list(scope, { parentGroupId: null });
   const appGroupId = firstGroupId(apps.items);
 
-  assert.equal(apps.ordered, undefined);
   assert.deepEqual(backend.describeHandle?.(appGroupId), {
     source: "app",
     id: "app-7"
@@ -122,7 +122,7 @@ test("app backend labels child groups with app and project names", async () => {
   );
 });
 
-test("app backend preserves the application reference order", async () => {
+test("app source renders application references in the returned order", async () => {
   const tuttidClient = {
     listWorkspaceApps: async () => ({
       apps: [
@@ -154,19 +154,21 @@ test("app backend preserves the application reference order", async () => {
       nextCursor: null
     })
   } as unknown as TuttidClient;
-  const backend = createAppReferenceListBackend(tuttidClient);
-
-  const result = await backend.list(scope, {
-    parentGroupId: "app:ai-media-canvas",
-    cursor: null,
-    filter: null
+  const source = createAppArtifactReferenceSource({
+    tuttidClient,
+    adapter: {},
+    label: "应用文件"
   });
 
+  const root = await source.listChildren(scope, { node: null });
+  const appGroup = root.entries[0];
+  assert.ok(appGroup);
+  const result = await source.listChildren(scope, { node: appGroup.ref });
+
+  assert.equal(root.ordered, true);
   assert.equal(result.ordered, true);
   assert.deepEqual(
-    result.items.map((item) =>
-      item.type === "group" ? item.displayName : item.reference.displayName
-    ),
+    result.entries.map((item) => item.displayName),
     ["Untitled", "Alpha"]
   );
 });

--- a/packages/workspace/file-reference/src/core/referenceListSource.test.ts
+++ b/packages/workspace/file-reference/src/core/referenceListSource.test.ts
@@ -38,7 +38,10 @@ const fakeAdapter = {
   readReferencePreview: async () => null
 };
 
-function makeSource(byParent: Record<string, ReferenceListResult>) {
+function makeSource(
+  byParent: Record<string, ReferenceListResult>,
+  options: { preserveBackendOrder?: boolean } = {}
+) {
   const { backend, calls } = backendOf(byParent);
   const source = createReferenceListSource({
     sourceId: "issue-file",
@@ -52,6 +55,7 @@ function makeSource(byParent: Record<string, ReferenceListResult>) {
     },
     isAvailable: () => true,
     backend,
+    ...(options.preserveBackendOrder ? { preserveBackendOrder: true } : {}),
     adapter: fakeAdapter
   });
   return { source, calls };
@@ -84,17 +88,19 @@ test("根层级:协议 group/reference 映射成 folder/file 节点", async () =
   assert.ok(file.ref.nodeId.startsWith("f:"));
 });
 
-test("backend 声明 ordered 时透传给 picker", async () => {
-  const { source } = makeSource({
-    __root__: {
-      items: [
-        { type: "group", id: "project-new", displayName: "Untitled" },
-        { type: "group", id: "project-old", displayName: "Alpha" }
-      ],
-      nextCursor: null,
-      ordered: true
-    }
-  });
+test("source 配置保留 backend 返回顺序时阻止 picker 重排", async () => {
+  const { source } = makeSource(
+    {
+      __root__: {
+        items: [
+          { type: "group", id: "project-new", displayName: "Untitled" },
+          { type: "group", id: "project-old", displayName: "Alpha" }
+        ],
+        nextCursor: null
+      }
+    },
+    { preserveBackendOrder: true }
+  );
 
   const result = await source.listChildren(scope, { node: null });
 

--- a/packages/workspace/file-reference/src/core/referenceListSource.ts
+++ b/packages/workspace/file-reference/src/core/referenceListSource.ts
@@ -68,8 +68,6 @@ export interface ReferenceListRequest {
 export interface ReferenceListResult {
   items: ReferenceListItem[];
   nextCursor?: string | null;
-  /** backend 已按业务语义排序时置 true，picker 将保留返回顺序。 */
-  ordered?: boolean;
 }
 
 /** 递归搜索请求(跨整源,非当前层 filter)。 */
@@ -126,6 +124,8 @@ export interface CreateReferenceListSourceInput {
   capabilities: ReferenceSourceCapabilities;
   isAvailable: (scope: ReferenceScope) => boolean | Promise<boolean>;
   backend: ReferenceListBackend;
+  /** 保留 backend.list 返回的数组顺序，禁止 picker 按名称重新排序。 */
+  preserveBackendOrder?: boolean;
   /** open/preview 复用 host 链路(协议返回的 path 可被解析打开)。 */
   adapter: WorkspaceFileReferenceAdapter;
 }
@@ -172,7 +172,7 @@ export function createReferenceListSource(
       return {
         entries: result.items.map((item) => itemToNode(sourceId, item)),
         nextCursor: result.nextCursor ?? null,
-        ...(result.ordered ? { ordered: true } : {})
+        ...(input.preserveBackendOrder ? { ordered: true } : {})
       };
     },
 


### PR DESCRIPTION
## Summary

- preserve App Artifact reference item order as a static source policy
- remove the per-response `ordered` field from the app backend adapter contract
- cover root and nested App Reference rendering order end to end

## Root cause

The shared picker sorts entries by display name unless a source marks its list results as already ordered. The earlier implementation made this a backend response field, which incorrectly exposed a Tutti rendering concern to every app adapter response. App Reference ordering is a source-level invariant: applications define the order of the returned `items` array, and Tutti must preserve it.

## Validation

- `pnpm --filter @tutti-os/workspace-file-reference test`
- focused App Reference tests (11 passed)
- `pnpm --filter @tutti-os/workspace-file-reference typecheck`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop test` (1414 passed, 3 skipped)
- `pnpm lint:ts`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves application-defined ordering for App Reference lists by making it a source-level policy. Removes the per-response `ordered` field and ensures root and nested lists render in backend order.

- **Refactors**
  - Add `preserveBackendOrder` to `createReferenceListSource` and use it to mark results as ordered.
  - Set `preserveBackendOrder: true` for the App Artifact reference source.
  - Remove `ordered` from `ReferenceListResult` and from `appReferenceListBackend` responses.
  - Update tests to validate root and nested ordering via the source config.

- **Migration**
  - Do not return `ordered` from backend list responses.
  - For sources that must keep backend order, pass `preserveBackendOrder: true` when creating the source.

<sup>Written for commit 1531f9af2de7e8e65ff18a0784123fac4412c13d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

