### PR TITLE
fix(tooling): isolate temporary git fixtures

### DIFF
--- a/.codex/skills/tutti-architecture-review/scripts/plan-review.test.mjs
+++ b/.codex/skills/tutti-architecture-review/scripts/plan-review.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -416,6 +416,7 @@ async function createFixtureRepo() {
   );
 
   runGit(workspaceRoot, ["init"]);
+  await assertFixtureGitRoot(workspaceRoot);
   runGit(workspaceRoot, ["add", "."]);
   runGit(workspaceRoot, [
     "-c",
@@ -462,16 +463,59 @@ function sampleTask(id) {
 function runPlanner(workspaceRoot, args) {
   return spawnSync(process.execPath, [scriptPath, ...args], {
     cwd: workspaceRoot,
-    encoding: "utf8"
+    encoding: "utf8",
+    env: isolatedFixtureGitEnvironment(workspaceRoot)
   });
 }
 
 function runGit(workspaceRoot, args) {
   const result = spawnSync("git", args, {
     cwd: workspaceRoot,
-    encoding: "utf8"
+    encoding: "utf8",
+    env: isolatedFixtureGitEnvironment(workspaceRoot)
   });
 
   assert.equal(result.status, 0, result.stderr || result.stdout);
   return result;
+}
+
+const gitRepositoryEnvironmentVariables = [
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_COMMON_DIR",
+  "GIT_CONFIG",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_DIR",
+  "GIT_GRAFT_FILE",
+  "GIT_IMPLICIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_INTERNAL_SUPER_PREFIX",
+  "GIT_NO_REPLACE_OBJECTS",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_PREFIX",
+  "GIT_REPLACE_REF_BASE",
+  "GIT_SHALLOW_FILE",
+  "GIT_WORK_TREE"
+];
+
+function isolatedFixtureGitEnvironment(workspaceRoot) {
+  const env = { ...process.env };
+  for (const name of gitRepositoryEnvironmentVariables) {
+    delete env[name];
+  }
+  for (const name of Object.keys(env)) {
+    if (/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/u.test(name)) {
+      delete env[name];
+    }
+  }
+  env.GIT_CEILING_DIRECTORIES = workspaceRoot;
+  return env;
+}
+
+async function assertFixtureGitRoot(workspaceRoot) {
+  const result = runGit(workspaceRoot, ["rev-parse", "--absolute-git-dir"]);
+  assert.equal(
+    await realpath(result.stdout.trim()),
+    await realpath(join(workspaceRoot, ".git"))
+  );
 }

--- a/.codex/skills/tutti-architecture-review/scripts/plan-review.test.mjs
+++ b/.codex/skills/tutti-architecture-review/scripts/plan-review.test.mjs
@@ -6,6 +6,8 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
+import { createIsolatedGitEnvironment } from "../../../../tools/scripts/git-environment.mjs";
+
 const scriptPath = resolve(
   dirname(fileURLToPath(import.meta.url)),
   "plan-review.mjs"
@@ -464,7 +466,7 @@ function runPlanner(workspaceRoot, args) {
   return spawnSync(process.execPath, [scriptPath, ...args], {
     cwd: workspaceRoot,
     encoding: "utf8",
-    env: isolatedFixtureGitEnvironment(workspaceRoot)
+    env: createIsolatedGitEnvironment(workspaceRoot)
   });
 }
 
@@ -472,44 +474,11 @@ function runGit(workspaceRoot, args) {
   const result = spawnSync("git", args, {
     cwd: workspaceRoot,
     encoding: "utf8",
-    env: isolatedFixtureGitEnvironment(workspaceRoot)
+    env: createIsolatedGitEnvironment(workspaceRoot)
   });
 
   assert.equal(result.status, 0, result.stderr || result.stdout);
   return result;
-}
-
-const gitRepositoryEnvironmentVariables = [
-  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-  "GIT_COMMON_DIR",
-  "GIT_CONFIG",
-  "GIT_CONFIG_COUNT",
-  "GIT_CONFIG_PARAMETERS",
-  "GIT_DIR",
-  "GIT_GRAFT_FILE",
-  "GIT_IMPLICIT_WORK_TREE",
-  "GIT_INDEX_FILE",
-  "GIT_INTERNAL_SUPER_PREFIX",
-  "GIT_NO_REPLACE_OBJECTS",
-  "GIT_OBJECT_DIRECTORY",
-  "GIT_PREFIX",
-  "GIT_REPLACE_REF_BASE",
-  "GIT_SHALLOW_FILE",
-  "GIT_WORK_TREE"
-];
-
-function isolatedFixtureGitEnvironment(workspaceRoot) {
-  const env = { ...process.env };
-  for (const name of gitRepositoryEnvironmentVariables) {
-    delete env[name];
-  }
-  for (const name of Object.keys(env)) {
-    if (/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/u.test(name)) {
-      delete env[name];
-    }
-  }
-  env.GIT_CEILING_DIRECTORIES = workspaceRoot;
-  return env;
 }
 
 async function assertFixtureGitRoot(workspaceRoot) {

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -37,6 +37,16 @@ Validation runners that spawn nested pnpm commands should read the root
 let runner-spawned lanes resolve a bare `pnpm` from `PATH`, because local
 package-manager shims can differ from the repository pin.
 
+Tests and checks that create temporary Git repositories must also isolate
+repository-local Git environment variables before invoking Git. In particular,
+remove inherited `GIT_DIR`, `GIT_WORK_TREE`, `GIT_COMMON_DIR`, index/object
+overrides, and command-scoped `GIT_CONFIG_*` entries; set
+`GIT_CEILING_DIRECTORIES` to the fixture root; fail immediately when fixture Git
+commands fail; and verify the initialized Git directory before staging,
+committing, fetching, or checking out. A temporary cwd alone is not isolation
+because `GIT_DIR` takes precedence and can redirect `git init` and later
+commands into a caller's linked-worktree metadata.
+
 ## TypeScript Baseline
 
 TypeScript linting uses Oxlint.

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -40,7 +40,8 @@ package-manager shims can differ from the repository pin.
 Tests and checks that create temporary Git repositories must also isolate
 repository-local Git environment variables before invoking Git. In particular,
 remove inherited `GIT_DIR`, `GIT_WORK_TREE`, `GIT_COMMON_DIR`, index/object
-overrides, and command-scoped `GIT_CONFIG_*` entries; set
+overrides, and command-scoped `GIT_CONFIG_*` entries using case-insensitive
+name matching for Windows compatibility; set
 `GIT_CEILING_DIRECTORIES` to the fixture root; fail immediately when fixture Git
 commands fail; and verify the initialized Git directory before staging,
 committing, fetching, or checking out. A temporary cwd alone is not isolation

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -81,3 +81,4 @@ CLI behavior, CI, package assets, skills, Browser Node, and terminal input.
 - [Published package runtime asset 404 because the consumer bundler never saw the file](./toolchain-browser-terminal.md#published-package-runtime-asset-404-because-the-consumer-bundler-never-saw-the-file)
 - [New release CDN namespace returns an S3 403](./toolchain-browser-terminal.md#new-release-cdn-namespace-returns-an-s3-403)
 - [Browser Node focus pings miss iframe-hosted editors](./toolchain-browser-terminal.md#browser-node-focus-pings-miss-iframe-hosted-editors)
+- [Temporary Git fixture turns a linked worktree bare](./toolchain-browser-terminal.md#temporary-git-fixture-turns-a-linked-worktree-bare)

--- a/docs/conventions/troubleshooting/toolchain-browser-terminal.md
+++ b/docs/conventions/troubleshooting/toolchain-browser-terminal.md
@@ -21,15 +21,17 @@
   against the real branch.
 - Fix:
   Remove repository-local Git environment variables for every fixture Git
-  command, set `GIT_CEILING_DIRECTORIES` to the fixture root, stop on any command
-  failure, verify `--absolute-git-dir` after initialization, and pass fixture
-  author identity through commit-local `-c` arguments instead of `git config`.
+  command using case-insensitive name matching, set `GIT_CEILING_DIRECTORIES` to
+  the fixture root, stop on any command failure, verify `--absolute-git-dir`
+  after initialization, and pass fixture author identity through commit-local
+  `-c` arguments instead of `git config`.
 - Validation:
   Run the fixture tests with poisoned `GIT_DIR`, `GIT_WORK_TREE`, and
   `GIT_CONFIG_*` inputs that point only at disposable paths. Confirm the fixture
   initializes its own `.git`, then verify the caller's config, index, branch,
   and worktree remain unchanged.
 - References:
+  [git-environment.mjs](../../../tools/scripts/git-environment.mjs)
   [check-agent-gui-degradation.test.mjs](../../../tools/scripts/check-agent-gui-degradation.test.mjs)
   [static-analysis.md](../static-analysis.md)
 

--- a/docs/conventions/troubleshooting/toolchain-browser-terminal.md
+++ b/docs/conventions/troubleshooting/toolchain-browser-terminal.md
@@ -2,6 +2,37 @@
 
 [Back to troubleshooting index](./README.md)
 
+### Temporary Git fixture turns a linked worktree bare
+
+- Symptom:
+  A test run leaves the shared repository config with `core.bare=true`, writes
+  fixture author identity into `.git/config`, or creates an `init` commit that
+  deletes most tracked files from a linked-worktree branch.
+- Quick checks:
+  Run `git config --show-origin --get core.bare`, inspect local `user.name` and
+  `user.email`, then inspect the affected branch reflog for a fixture-authored
+  commit. Search the responsible test for temporary-repository Git commands
+  whose child environment inherits `GIT_DIR` or `GIT_WORK_TREE`.
+- Root cause:
+  `mkdtemp` isolates files, not Git repository selection. An inherited
+  linked-worktree `GIT_DIR` overrides the fixture cwd, so `git init` reinitializes
+  the caller's private worktree metadata and updates its shared common config.
+  Later fixture `add` and `commit` commands can then stage the fixture tree
+  against the real branch.
+- Fix:
+  Remove repository-local Git environment variables for every fixture Git
+  command, set `GIT_CEILING_DIRECTORIES` to the fixture root, stop on any command
+  failure, verify `--absolute-git-dir` after initialization, and pass fixture
+  author identity through commit-local `-c` arguments instead of `git config`.
+- Validation:
+  Run the fixture tests with poisoned `GIT_DIR`, `GIT_WORK_TREE`, and
+  `GIT_CONFIG_*` inputs that point only at disposable paths. Confirm the fixture
+  initializes its own `.git`, then verify the caller's config, index, branch,
+  and worktree remain unchanged.
+- References:
+  [check-agent-gui-degradation.test.mjs](../../../tools/scripts/check-agent-gui-degradation.test.mjs)
+  [static-analysis.md](../static-analysis.md)
+
 ### Dynamic CLI input rejects plausible flags
 
 - Symptom:

--- a/tools/scripts/check-agent-gui-degradation.test.mjs
+++ b/tools/scripts/check-agent-gui-degradation.test.mjs
@@ -28,6 +28,7 @@ import {
   measureFileMetrics,
   parseStagedAddedLines
 } from "./check-agent-gui-degradation.mjs";
+import { createIsolatedGitEnvironment } from "./git-environment.mjs";
 
 const scriptPath = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -353,30 +354,6 @@ test("staged check flags new module-level mutable globals", () => {
   assert.equal(violations[0].rule, "no-module-mutable-global");
 });
 
-test("temporary Git fixtures discard inherited repository selectors", () => {
-  const workspaceRoot = "/tmp/tutti-git-fixture";
-  const inheritedEnvironment = Object.fromEntries(
-    gitRepositoryEnvironmentVariables.map((name) => [name, `/poison/${name}`])
-  );
-  inheritedEnvironment.GIT_CEILING_DIRECTORIES = "/poison/ceiling";
-  inheritedEnvironment.GIT_CONFIG_KEY_0 = "core.bare";
-  inheritedEnvironment.GIT_CONFIG_VALUE_0 = "true";
-  inheritedEnvironment.PRESERVED_FIXTURE_VALUE = "preserved";
-
-  const env = isolatedFixtureGitEnvironment(
-    workspaceRoot,
-    inheritedEnvironment
-  );
-
-  for (const name of gitRepositoryEnvironmentVariables) {
-    assert.equal(env[name], undefined, `${name} must not reach fixture Git`);
-  }
-  assert.equal(env.GIT_CONFIG_KEY_0, undefined);
-  assert.equal(env.GIT_CONFIG_VALUE_0, undefined);
-  assert.equal(env.GIT_CEILING_DIRECTORIES, workspaceRoot);
-  assert.equal(env.PRESERVED_FIXTURE_VALUE, "preserved");
-});
-
 test("full mode generates a baseline and then detects regressions", async () => {
   const workspaceRoot = await mkdtemp(join(tmpdir(), "agent-gui-degradation-"));
   const sourcePath = join(
@@ -486,54 +463,18 @@ function runScript(workspaceRoot, baselinePath, args) {
   return spawnSync(process.execPath, [scriptPath, ...args], {
     encoding: "utf8",
     env: {
-      ...isolatedFixtureGitEnvironment(workspaceRoot),
+      ...createIsolatedGitEnvironment(workspaceRoot),
       TUTTI_AGENT_GUI_DEGRADATION_BASELINE: baselinePath,
       TUTTI_WORKSPACE_ROOT: workspaceRoot
     }
   });
 }
 
-const gitRepositoryEnvironmentVariables = [
-  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-  "GIT_COMMON_DIR",
-  "GIT_CONFIG",
-  "GIT_CONFIG_COUNT",
-  "GIT_CONFIG_PARAMETERS",
-  "GIT_DIR",
-  "GIT_GRAFT_FILE",
-  "GIT_IMPLICIT_WORK_TREE",
-  "GIT_INDEX_FILE",
-  "GIT_INTERNAL_SUPER_PREFIX",
-  "GIT_NO_REPLACE_OBJECTS",
-  "GIT_OBJECT_DIRECTORY",
-  "GIT_PREFIX",
-  "GIT_REPLACE_REF_BASE",
-  "GIT_SHALLOW_FILE",
-  "GIT_WORK_TREE"
-];
-
-function isolatedFixtureGitEnvironment(
-  workspaceRoot,
-  inheritedEnvironment = process.env
-) {
-  const env = { ...inheritedEnvironment };
-  for (const name of gitRepositoryEnvironmentVariables) {
-    delete env[name];
-  }
-  for (const name of Object.keys(env)) {
-    if (/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/u.test(name)) {
-      delete env[name];
-    }
-  }
-  env.GIT_CEILING_DIRECTORIES = workspaceRoot;
-  return env;
-}
-
 function runFixtureGit(workspaceRoot, args) {
   const result = spawnSync("git", args, {
     cwd: workspaceRoot,
     encoding: "utf8",
-    env: isolatedFixtureGitEnvironment(workspaceRoot)
+    env: createIsolatedGitEnvironment(workspaceRoot)
   });
   assert.equal(result.status, 0, result.stderr || result.stdout);
   return result;

--- a/tools/scripts/check-agent-gui-degradation.test.mjs
+++ b/tools/scripts/check-agent-gui-degradation.test.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  realpath,
+  writeFile
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -347,6 +353,30 @@ test("staged check flags new module-level mutable globals", () => {
   assert.equal(violations[0].rule, "no-module-mutable-global");
 });
 
+test("temporary Git fixtures discard inherited repository selectors", () => {
+  const workspaceRoot = "/tmp/tutti-git-fixture";
+  const inheritedEnvironment = Object.fromEntries(
+    gitRepositoryEnvironmentVariables.map((name) => [name, `/poison/${name}`])
+  );
+  inheritedEnvironment.GIT_CEILING_DIRECTORIES = "/poison/ceiling";
+  inheritedEnvironment.GIT_CONFIG_KEY_0 = "core.bare";
+  inheritedEnvironment.GIT_CONFIG_VALUE_0 = "true";
+  inheritedEnvironment.PRESERVED_FIXTURE_VALUE = "preserved";
+
+  const env = isolatedFixtureGitEnvironment(
+    workspaceRoot,
+    inheritedEnvironment
+  );
+
+  for (const name of gitRepositoryEnvironmentVariables) {
+    assert.equal(env[name], undefined, `${name} must not reach fixture Git`);
+  }
+  assert.equal(env.GIT_CONFIG_KEY_0, undefined);
+  assert.equal(env.GIT_CONFIG_VALUE_0, undefined);
+  assert.equal(env.GIT_CEILING_DIRECTORIES, workspaceRoot);
+  assert.equal(env.PRESERVED_FIXTURE_VALUE, "preserved");
+});
+
 test("full mode generates a baseline and then detects regressions", async () => {
   const workspaceRoot = await mkdtemp(join(tmpdir(), "agent-gui-degradation-"));
   const sourcePath = join(
@@ -383,11 +413,8 @@ test("full mode generates a baseline and then detects regressions", async () => 
 
 test("staged mode flags violations on staged added lines end to end", async () => {
   const workspaceRoot = await mkdtemp(join(tmpdir(), "agent-gui-degradation-"));
-  const run = (command, args) =>
-    spawnSync(command, args, { cwd: workspaceRoot, encoding: "utf8" });
-  run("git", ["init", "--quiet"]);
-  run("git", ["config", "user.email", "test@example.com"]);
-  run("git", ["config", "user.name", "Test"]);
+  runFixtureGit(workspaceRoot, ["init", "--quiet"]);
+  await assertFixtureGitRoot(workspaceRoot);
 
   const sourcePath = join(
     workspaceRoot,
@@ -395,14 +422,23 @@ test("staged mode flags violations on staged added lines end to end", async () =
   );
   await mkdir(dirname(sourcePath), { recursive: true });
   await writeFile(sourcePath, "export const before = 1;\n");
-  run("git", ["add", "."]);
-  run("git", ["commit", "--quiet", "-m", "init"]);
+  runFixtureGit(workspaceRoot, ["add", "."]);
+  runFixtureGit(workspaceRoot, [
+    "-c",
+    "user.email=test@example.com",
+    "-c",
+    "user.name=Test",
+    "commit",
+    "--quiet",
+    "-m",
+    "init"
+  ]);
 
   await writeFile(
     sourcePath,
     "export const before = 1;\nsetTimeout(retry, 100);\n"
   );
-  run("git", ["add", "."]);
+  runFixtureGit(workspaceRoot, ["add", "."]);
 
   const baselinePath = join(workspaceRoot, "baseline/agent-gui.json");
   const result = runScript(workspaceRoot, baselinePath, ["--staged"]);
@@ -413,7 +449,7 @@ test("staged mode flags violations on staged added lines end to end", async () =
     sourcePath,
     "export const before = 1;\n// timing: retry with visible reason\nsetTimeout(retry, 100);\n"
   );
-  run("git", ["add", "."]);
+  runFixtureGit(workspaceRoot, ["add", "."]);
   const pass = runScript(workspaceRoot, baselinePath, ["--staged"]);
   assert.equal(pass.status, 0, pass.stderr || pass.stdout);
 });
@@ -450,9 +486,66 @@ function runScript(workspaceRoot, baselinePath, args) {
   return spawnSync(process.execPath, [scriptPath, ...args], {
     encoding: "utf8",
     env: {
-      ...process.env,
+      ...isolatedFixtureGitEnvironment(workspaceRoot),
       TUTTI_AGENT_GUI_DEGRADATION_BASELINE: baselinePath,
       TUTTI_WORKSPACE_ROOT: workspaceRoot
     }
   });
+}
+
+const gitRepositoryEnvironmentVariables = [
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_COMMON_DIR",
+  "GIT_CONFIG",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_DIR",
+  "GIT_GRAFT_FILE",
+  "GIT_IMPLICIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_INTERNAL_SUPER_PREFIX",
+  "GIT_NO_REPLACE_OBJECTS",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_PREFIX",
+  "GIT_REPLACE_REF_BASE",
+  "GIT_SHALLOW_FILE",
+  "GIT_WORK_TREE"
+];
+
+function isolatedFixtureGitEnvironment(
+  workspaceRoot,
+  inheritedEnvironment = process.env
+) {
+  const env = { ...inheritedEnvironment };
+  for (const name of gitRepositoryEnvironmentVariables) {
+    delete env[name];
+  }
+  for (const name of Object.keys(env)) {
+    if (/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/u.test(name)) {
+      delete env[name];
+    }
+  }
+  env.GIT_CEILING_DIRECTORIES = workspaceRoot;
+  return env;
+}
+
+function runFixtureGit(workspaceRoot, args) {
+  const result = spawnSync("git", args, {
+    cwd: workspaceRoot,
+    encoding: "utf8",
+    env: isolatedFixtureGitEnvironment(workspaceRoot)
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result;
+}
+
+async function assertFixtureGitRoot(workspaceRoot) {
+  const result = runFixtureGit(workspaceRoot, [
+    "rev-parse",
+    "--absolute-git-dir"
+  ]);
+  assert.equal(
+    await realpath(result.stdout.trim()),
+    await realpath(join(workspaceRoot, ".git"))
+  );
 }

--- a/tools/scripts/check-codexproto-generated.mjs
+++ b/tools/scripts/check-codexproto-generated.mjs
@@ -3,6 +3,7 @@ import {
   mkdtempSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
   statSync
 } from "node:fs";
@@ -20,6 +21,7 @@ const workspaceRoot = join(scriptDirectory, "..", "..");
 const daemonRoot = join(workspaceRoot, "packages", "agent", "daemon");
 const codexprotoRoot = join(daemonRoot, "runtime", "codexproto");
 const vendoredSchemaRoot = join(codexprotoRoot, "schema", "json");
+const workspaceEnv = isolatedGitEnvironment(workspaceRoot);
 
 // The upstream re-fetch against the pinned Codex commit is CI's job
 // (ADR 0002): local check:full runs must not block on cloning
@@ -33,11 +35,17 @@ if (process.env.CI || process.argv.includes("--upstream")) {
   );
 }
 
-run("go", ["run", "./runtime/codexproto/internal/codegen"], daemonRoot);
+run(
+  "go",
+  ["run", "./runtime/codexproto/internal/codegen"],
+  daemonRoot,
+  workspaceEnv
+);
 run(
   "git",
   ["diff", "--exit-code", "--", "packages/agent/daemon/runtime/codexproto"],
-  workspaceRoot
+  workspaceRoot,
+  workspaceEnv
 );
 assertNoUntrackedGeneratedFiles();
 
@@ -47,21 +55,34 @@ function compareVendoredSchemaAgainstUpstream() {
   const tempRoot = mkdtempSync(join(tmpdir(), "tutti-codexproto-"));
   try {
     const upstreamRoot = join(tempRoot, "codex");
-    run("git", ["init", upstreamRoot], workspaceRoot);
+    const gitEnv = isolatedGitEnvironment(upstreamRoot);
+    run("git", ["init", upstreamRoot], workspaceRoot, gitEnv);
+    const gitDir = output(
+      "git",
+      ["-C", upstreamRoot, "rev-parse", "--absolute-git-dir"],
+      workspaceRoot,
+      gitEnv
+    );
+    if (realpathSync(gitDir) !== realpathSync(join(upstreamRoot, ".git"))) {
+      throw new Error(`upstream Git fixture escaped ${upstreamRoot}`);
+    }
     run(
       "git",
       ["-C", upstreamRoot, "remote", "add", "origin", codexRepoUrl],
-      workspaceRoot
+      workspaceRoot,
+      gitEnv
     );
     run(
       "git",
       ["-C", upstreamRoot, "fetch", "--depth=1", "origin", codexSourceCommit],
-      workspaceRoot
+      workspaceRoot,
+      gitEnv
     );
     run(
       "git",
       ["-C", upstreamRoot, "checkout", "FETCH_HEAD", "--", schemaSubdir],
-      workspaceRoot
+      workspaceRoot,
+      gitEnv
     );
 
     compareDirectories(join(upstreamRoot, schemaSubdir), vendoredSchemaRoot);
@@ -107,7 +128,7 @@ function assertNoUntrackedGeneratedFiles() {
   const result = spawnSync(
     "git",
     ["status", "--porcelain", "--", "packages/agent/daemon/runtime/codexproto"],
-    { cwd: workspaceRoot, encoding: "utf8" }
+    { cwd: workspaceRoot, encoding: "utf8", env: workspaceEnv }
   );
   if (result.status !== 0) {
     throw new Error("git status for codexproto failed");
@@ -170,12 +191,55 @@ function walkFiles(root) {
   return out;
 }
 
-function run(command, args, cwd) {
+function run(command, args, cwd, env = process.env) {
   const result = spawnSync(command, args, {
     cwd,
+    env,
     stdio: "inherit"
   });
   if (result.status !== 0) {
     throw new Error(`${command} ${args.join(" ")} failed`);
   }
+}
+
+function output(command, args, cwd, env = process.env) {
+  const result = spawnSync(command, args, { cwd, encoding: "utf8", env });
+  if (result.status !== 0) {
+    throw new Error(
+      result.stderr.trim() || `${command} ${args.join(" ")} failed`
+    );
+  }
+  return result.stdout.trim();
+}
+
+function isolatedGitEnvironment(fixtureRoot) {
+  const env = { ...process.env };
+  const repositoryVariables = new Set([
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_CONFIG",
+    "GIT_CONFIG_COUNT",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_DIR",
+    "GIT_GRAFT_FILE",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_INTERNAL_SUPER_PREFIX",
+    "GIT_NO_REPLACE_OBJECTS",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_PREFIX",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_SHALLOW_FILE",
+    "GIT_WORK_TREE"
+  ]);
+  for (const name of Object.keys(env)) {
+    if (
+      repositoryVariables.has(name) ||
+      /^GIT_CONFIG_(?:KEY|VALUE)_\d+$/u.test(name)
+    ) {
+      delete env[name];
+    }
+  }
+  env.GIT_CEILING_DIRECTORIES = fixtureRoot;
+  return env;
 }

--- a/tools/scripts/check-codexproto-generated.mjs
+++ b/tools/scripts/check-codexproto-generated.mjs
@@ -12,6 +12,8 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createHash } from "node:crypto";
 
+import { createIsolatedGitEnvironment } from "./git-environment.mjs";
+
 const codexRepoUrl = "https://github.com/openai/codex.git";
 const codexSourceCommit = "6d2168f06ae275d5e1f73cabf935d2bcc8549998";
 const schemaSubdir = "codex-rs/app-server-protocol/schema/json";
@@ -21,7 +23,7 @@ const workspaceRoot = join(scriptDirectory, "..", "..");
 const daemonRoot = join(workspaceRoot, "packages", "agent", "daemon");
 const codexprotoRoot = join(daemonRoot, "runtime", "codexproto");
 const vendoredSchemaRoot = join(codexprotoRoot, "schema", "json");
-const workspaceEnv = isolatedGitEnvironment(workspaceRoot);
+const workspaceEnv = createIsolatedGitEnvironment(workspaceRoot);
 
 // The upstream re-fetch against the pinned Codex commit is CI's job
 // (ADR 0002): local check:full runs must not block on cloning
@@ -55,7 +57,7 @@ function compareVendoredSchemaAgainstUpstream() {
   const tempRoot = mkdtempSync(join(tmpdir(), "tutti-codexproto-"));
   try {
     const upstreamRoot = join(tempRoot, "codex");
-    const gitEnv = isolatedGitEnvironment(upstreamRoot);
+    const gitEnv = createIsolatedGitEnvironment(upstreamRoot);
     run("git", ["init", upstreamRoot], workspaceRoot, gitEnv);
     const gitDir = output(
       "git",
@@ -210,36 +212,4 @@ function output(command, args, cwd, env = process.env) {
     );
   }
   return result.stdout.trim();
-}
-
-function isolatedGitEnvironment(fixtureRoot) {
-  const env = { ...process.env };
-  const repositoryVariables = new Set([
-    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-    "GIT_COMMON_DIR",
-    "GIT_CONFIG",
-    "GIT_CONFIG_COUNT",
-    "GIT_CONFIG_PARAMETERS",
-    "GIT_DIR",
-    "GIT_GRAFT_FILE",
-    "GIT_IMPLICIT_WORK_TREE",
-    "GIT_INDEX_FILE",
-    "GIT_INTERNAL_SUPER_PREFIX",
-    "GIT_NO_REPLACE_OBJECTS",
-    "GIT_OBJECT_DIRECTORY",
-    "GIT_PREFIX",
-    "GIT_REPLACE_REF_BASE",
-    "GIT_SHALLOW_FILE",
-    "GIT_WORK_TREE"
-  ]);
-  for (const name of Object.keys(env)) {
-    if (
-      repositoryVariables.has(name) ||
-      /^GIT_CONFIG_(?:KEY|VALUE)_\d+$/u.test(name)
-    ) {
-      delete env[name];
-    }
-  }
-  env.GIT_CEILING_DIRECTORIES = fixtureRoot;
-  return env;
 }

--- a/tools/scripts/git-environment.mjs
+++ b/tools/scripts/git-environment.mjs
@@ -1,0 +1,37 @@
+const gitRepositoryEnvironmentVariables = new Set([
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_CEILING_DIRECTORIES",
+  "GIT_COMMON_DIR",
+  "GIT_CONFIG",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_DIR",
+  "GIT_GRAFT_FILE",
+  "GIT_IMPLICIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_INTERNAL_SUPER_PREFIX",
+  "GIT_NO_REPLACE_OBJECTS",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_PREFIX",
+  "GIT_REPLACE_REF_BASE",
+  "GIT_SHALLOW_FILE",
+  "GIT_WORK_TREE"
+]);
+
+export function createIsolatedGitEnvironment(
+  fixtureRoot,
+  inheritedEnvironment = process.env
+) {
+  const env = { ...inheritedEnvironment };
+  for (const name of Object.keys(env)) {
+    const normalizedName = name.toUpperCase();
+    if (
+      gitRepositoryEnvironmentVariables.has(normalizedName) ||
+      /^GIT_CONFIG_(?:KEY|VALUE)_\d+$/u.test(normalizedName)
+    ) {
+      delete env[name];
+    }
+  }
+  env.GIT_CEILING_DIRECTORIES = fixtureRoot;
+  return env;
+}

--- a/tools/scripts/git-environment.test.mjs
+++ b/tools/scripts/git-environment.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createIsolatedGitEnvironment } from "./git-environment.mjs";
+
+test("isolates Git repository selectors case-insensitively", () => {
+  const fixtureRoot = "/tmp/tutti-git-fixture";
+  const env = createIsolatedGitEnvironment(fixtureRoot, {
+    Git_Alternate_Object_Directories: "/poison/objects",
+    git_ceiling_directories: "/poison/ceiling",
+    Git_Common_Dir: "/poison/common",
+    git_config_count: "1",
+    Git_Config_Key_0: "core.bare",
+    git_config_value_0: "true",
+    git_dir: "/poison/git-dir",
+    Git_Index_File: "/poison/index",
+    git_work_tree: "/poison/worktree",
+    PRESERVED_FIXTURE_VALUE: "preserved"
+  });
+
+  assert.deepEqual(env, {
+    GIT_CEILING_DIRECTORIES: fixtureRoot,
+    PRESERVED_FIXTURE_VALUE: "preserved"
+  });
+});


### PR DESCRIPTION
## Summary

- isolate temporary Git fixtures from inherited repository-local environment variables
- verify fixture Git roots before staging, committing, fetching, or checking out
- harden Agent GUI degradation tests, architecture review tests, and the Codex protocol upstream check
- document the linked-worktree failure mode and repository convention

## Verification

- `pnpm test:tools`
- `pnpm review:architecture:test`
- `pnpm check:full`
- poisoned linked-worktree validation with a disposable `GIT_DIR`; shared config, branch HEAD, and index hashes remained unchanged
- `node tools/scripts/check-codexproto-generated.mjs --upstream` under the poisoned disposable environment

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated temporary Git fixtures from inherited Git environment to prevent linked-worktree corruption. Added a shared helper to normalize the Git env (case-insensitive), verified fixture Git roots, and made related tests and the Codex schema check deterministic and fail fast.

- **Bug Fixes**
  - Strip repository-scoped `GIT_*` and `GIT_CONFIG_*` variables case-insensitively; set `GIT_CEILING_DIRECTORIES`; stop on any Git error.
  - Add `createIsolatedGitEnvironment` and a unit test; use it across tests and `tools/scripts/check-codexproto-generated.mjs` (including `go run` and all Git calls).
  - Verify `rev-parse --absolute-git-dir` (via `realpath`) equals the fixture `.git`; detect and fail on fixture escape.
  - Document the linked-worktree failure mode and isolation steps; add a troubleshooting entry.

<sup>Written for commit 14b9a265e7c78366f25de6f7f44279769ffb997c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Fix Scope Justification

- Root cause: temporary Git fixture subprocesses inherited repository-local selectors such as `GIT_DIR`, so fixture setup targeted linked-worktree shared metadata instead of the temporary repository.
- Why not at a lower layer: Git resolves these environment selectors before repository discovery. The shared environment sanitizer is the lowest common layer used by every affected temporary-repository caller; each caller still verifies its expected Git root before mutation.

