### PR TITLE
fix(agent): define message versions as snapshot cursors

### DIFF
--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -51,6 +51,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [Agent GUI no-project sessions appear under a user project](./agent-session-lifecycle.md#agent-gui-no-project-sessions-appear-under-a-user-project)
 - [Agent session restore breaks when durable snapshot ownership is split](./agent-session-lifecycle.md#agent-session-restore-breaks-when-durable-snapshot-ownership-is-split)
 - [Agent activity live updates fail after event schema changes](./agent-session-lifecycle.md#agent-activity-live-updates-fail-after-event-schema-changes)
+- [AgentActivity replication repeatedly rejects message batches as invalid](./agent-session-lifecycle.md#agentactivity-replication-repeatedly-rejects-message-batches-as-invalid)
 - [Remote agent cancel does not stop the local turn](./agent-session-lifecycle.md#remote-agent-cancel-does-not-stop-the-local-turn)
 - [Claude Code cancel leaves Write/tool cards stuck in progress](./agent-session-lifecycle.md#claude-code-cancel-leaves-writetool-cards-stuck-in-progress)
 - [AgentGUI freezes when session history is large](./agent-session-lifecycle.md#agentgui-freezes-when-session-history-is-large)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1099,3 +1099,37 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
   [main.ts](../../packages/agent/claude-sdk-sidecar/src/main.ts)
   [main.test.ts](../../packages/agent/claude-sdk-sidecar/src/main.test.ts)
   [claude_sdk_adapter.go](../../packages/agent/daemon/runtime/claude_sdk_adapter.go)
+
+### AgentActivity replication repeatedly rejects message batches as invalid
+
+- Symptom:
+  A downstream AgentActivity replica repeatedly returns `INVALID_ARGUMENT` for
+  the same message batch. The source session has a higher `messageVersion`, but
+  the destination has no messages or stops at an earlier version.
+- Quick checks:
+  Compare the session watermark with the current message rows. Values such as
+  `1,3` or `1,5` are valid when an intermediate snapshot of the same
+  `messageId` was overwritten. Check whether the destination requires
+  `incomingVersion == maxStoredVersion + 1` or treats a message version as
+  immutable identity.
+- Root cause:
+  `Message.Version` is a per-session change cursor on a mutable snapshot. Each
+  accepted update advances the cursor, and updating the same `messageId`
+  replaces its prior row. Current rows therefore need not contain every cursor
+  value, and the same message identity legitimately moves to a higher version.
+- Fix:
+  Replicas must accept any positive version for a new message, accept a higher
+  version for an existing `messageId`, and ignore or reject only stale lower
+  versions. Use a version-guarded atomic upsert so concurrent stale snapshots
+  cannot overwrite newer state. Do not add an event-history table merely to
+  make the current snapshot appear contiguous.
+- Validation:
+  Record message A at v1, message B at v2, then update B to v3. Verify the
+  current snapshot is `A@1,B@3`, `afterVersion=1` returns B at v3, and a
+  rejected projection does not consume another cursor. Downstream replication
+  coverage should also accept an initial v3, update it to v5, and preserve v5
+  when v4 arrives later.
+- References:
+  [activity_messages.go](../../../packages/agent/store-sqlite/activity_messages.go)
+  [activity_message_read.go](../../../packages/agent/store-sqlite/activity_message_read.go)
+  [repository.go](../../../packages/agent/store-sqlite/repository.go)

--- a/packages/agent/store-sqlite/activity.go
+++ b/packages/agent/store-sqlite/activity.go
@@ -197,11 +197,7 @@ func (s *Store) ReportSessionMessages(
 		if message.MessageID == "" {
 			continue
 		}
-		version, err := incrementAgentSessionMessageVersion(ctx, tx, workspaceID, agentSessionID)
-		if err != nil {
-			return MessageReportResult{}, err
-		}
-		acceptedMessage, accepted, err := s.upsertAgentMessageTx(ctx, tx, workspaceID, agentSessionID, version, message, now)
+		acceptedMessage, accepted, err := s.upsertAgentMessageTx(ctx, tx, workspaceID, agentSessionID, message, now)
 		if err != nil {
 			return MessageReportResult{}, err
 		}
@@ -209,7 +205,7 @@ func (s *Store) ReportSessionMessages(
 			continue
 		}
 		result.AcceptedCount++
-		result.LatestVersion = version
+		result.LatestVersion = acceptedMessage.Version
 		result.Messages = append(result.Messages, acceptedMessage)
 	}
 

--- a/packages/agent/store-sqlite/activity_messages.go
+++ b/packages/agent/store-sqlite/activity_messages.go
@@ -38,7 +38,6 @@ func (s *Store) upsertAgentMessageTx(
 	tx *sql.Tx,
 	workspaceID string,
 	agentSessionID string,
-	version uint64,
 	input MessageUpdate,
 	now int64,
 ) (Message, bool, error) {
@@ -61,7 +60,7 @@ func (s *Store) upsertAgentMessageTx(
 			StartedAtUnixMS:   input.StartedAtUnixMS,
 			CompletedAtUnixMS: input.CompletedAtUnixMS,
 		},
-		version,
+		0,
 		now,
 	)
 	if !accepted {
@@ -81,6 +80,11 @@ func (s *Store) upsertAgentMessageTx(
 			}
 		}
 	}
+	version, err := incrementAgentSessionMessageVersion(ctx, tx, workspaceID, agentSessionID)
+	if err != nil {
+		return Message{}, false, err
+	}
+	message.Version = version
 	payloadJSON, err := json.Marshal(message.Payload)
 	if err != nil {
 		return Message{}, false, fmt.Errorf("encode workspace agent message payload: %w", err)

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -64,10 +64,12 @@ type ListSessionMessagesInput struct {
 	WorkspaceID    string
 	AgentSessionID string
 	TurnID         string
-	AfterVersion   uint64
-	BeforeVersion  uint64
-	Limit          int
-	Order          MessageOrder
+	// AfterVersion and BeforeVersion are per-session change cursors. Current
+	// message snapshots may skip cursor values when the same message is updated.
+	AfterVersion  uint64
+	BeforeVersion uint64
+	Limit         int
+	Order         MessageOrder
 }
 
 type ListWorkspaceGeneratedFilesInput struct {
@@ -149,7 +151,9 @@ type Session struct {
 	Title                  string
 	// ActiveTurnID is the protocol v2 turn reference: the id of the turn
 	// currently in flight, empty when the session is idle.
-	ActiveTurnID    string
+	ActiveTurnID string
+	// MessageVersion is the latest accepted per-session message change cursor.
+	// It is a high-water mark, not a count of current message rows.
 	MessageVersion  uint64
 	LastEventUnixMS int64
 	StartedAtUnixMS int64
@@ -361,9 +365,11 @@ type MessageReportResult struct {
 }
 
 type Message struct {
-	ID                uint64
-	AgentSessionID    string
-	MessageID         string
+	ID             uint64
+	AgentSessionID string
+	MessageID      string
+	// Version is a per-session change cursor for this mutable snapshot. Updating
+	// the same MessageID assigns a newer version, so current rows may have gaps.
 	Version           uint64
 	TurnID            string
 	Role              string
@@ -380,6 +386,8 @@ type Message struct {
 type MessagePage struct {
 	AgentSessionID string
 	Messages       []Message
-	LatestVersion  uint64
-	HasMore        bool
+	// LatestVersion is the largest cursor delivered by this page, or the input
+	// AfterVersion when an ascending page contains no newer snapshots.
+	LatestVersion uint64
+	HasMore       bool
 }

--- a/packages/agent/store-sqlite/store_test.go
+++ b/packages/agent/store-sqlite/store_test.go
@@ -334,6 +334,57 @@ func TestStoreReportAndListSessionLifecycle(t *testing.T) {
 	}
 }
 
+func TestStoreMessageVersionsAreSnapshotCursorsAndMayHaveGaps(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1", Origin: "runtime",
+		Provider: "codex", ProviderSessionID: "provider-1", Status: "running", OccurredAtUnixMS: 100,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, report := range []SessionMessageReport{
+		{WorkspaceID: "ws-1", AgentSessionID: "session-1", Messages: []MessageUpdate{{
+			MessageID: "message-a", TurnID: "turn-1", Role: "user", Kind: "text", Status: "completed", Payload: map[string]any{"text": "a"},
+		}}},
+		{WorkspaceID: "ws-1", AgentSessionID: "session-1", Messages: []MessageUpdate{{
+			MessageID: "message-b", Role: "assistant", Kind: "text", Status: "running", Payload: map[string]any{"text": "b"},
+		}}},
+		{WorkspaceID: "ws-1", AgentSessionID: "session-1", Messages: []MessageUpdate{{
+			MessageID: "message-b", Status: "completed", ContentDelta: " done",
+		}}},
+	} {
+		if result, err := store.ReportSessionMessages(ctx, report); err != nil || result.AcceptedCount != 1 {
+			t.Fatalf("ReportSessionMessages() result=%#v error=%v", result, err)
+		}
+	}
+
+	page, ok, err := store.ListSessionMessages(ctx, ListSessionMessagesInput{WorkspaceID: "ws-1", AgentSessionID: "session-1", Limit: 10})
+	if err != nil || !ok || page.LatestVersion != 3 || len(page.Messages) != 2 {
+		t.Fatalf("ListSessionMessages() page=%#v ok=%v error=%v", page, ok, err)
+	}
+	if page.Messages[0].MessageID != "message-a" || page.Messages[0].Version != 1 || page.Messages[1].MessageID != "message-b" || page.Messages[1].Version != 3 {
+		t.Fatalf("current message snapshot versions=%#v, want message-a@1 and message-b@3", page.Messages)
+	}
+	incremental, ok, err := store.ListSessionMessages(ctx, ListSessionMessagesInput{WorkspaceID: "ws-1", AgentSessionID: "session-1", AfterVersion: 1, Limit: 10})
+	if err != nil || !ok || len(incremental.Messages) != 1 || incremental.Messages[0].MessageID != "message-b" || incremental.LatestVersion != 3 {
+		t.Fatalf("incremental page=%#v ok=%v error=%v", incremental, ok, err)
+	}
+
+	rejected, err := store.ReportSessionMessages(ctx, SessionMessageReport{WorkspaceID: "ws-1", AgentSessionID: "session-1", Messages: []MessageUpdate{{
+		MessageID: "message-a", TurnID: "turn-2", Status: "completed",
+	}}})
+	if err != nil || rejected.AcceptedCount != 0 {
+		t.Fatalf("rejected update result=%#v error=%v", rejected, err)
+	}
+	session, ok, err := store.GetSession(ctx, "ws-1", "session-1")
+	if err != nil || !ok || session.MessageVersion != 3 {
+		t.Fatalf("session after rejected update=%#v ok=%v error=%v", session, ok, err)
+	}
+}
+
 func TestStoreClearSessionsTxJoinsCallerTransaction(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What
- allocate a message version only after a projection is accepted inside the write transaction
- document message versions as per-session mutable snapshot cursors rather than row identities or counts
- verify that updates create valid cursor gaps and rejected projections do not consume a version
- add troubleshooting guidance for repeated AgentActivity `400 INVALID_ARGUMENT` responses

## Why
Message projection previously consumed the session sequence before validating whether an update could be applied. That could create gaps from rejected updates. The same logical message also receives a newer version when its mutable snapshot changes. Downstream components treated versions as contiguous immutable row identities, causing remote synchronization to reject valid batches and Share Agent GUI to miss remote sessions.

## Risk
Version assignment moves later within the existing transaction, so accepted writes remain atomic. Consumers must treat the value as a monotonic high-water cursor; paired server and desktop fixes do so explicitly.

## Verification
- `go test ./...` from `packages/agent/store-sqlite`
- `pnpm exec prettier --check docs/conventions/troubleshooting/agent-runtime.md docs/conventions/troubleshooting/agent-session-lifecycle.md`
- `git diff --check`
- commit hooks: lint-staged formatting and staged Electron/UI/renderer/Agent GUI boundary checks
- `pnpm check:full` reached validation but local `lint:go` could not run because pinned `golangci-lint v2.12.0` was unavailable; both the project installer and Go toolchain download were blocked by local network/TLS. PR CI is the final full-check authority.

## Related
- Server acceptance fix: https://github.com/tutti-lab/tsh-server/pull/381
- Desktop replica fix: https://github.com/tutti-lab/tsh/pull/1572

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make AgentActivity message versions per-session snapshot cursors and assign them only after an update is accepted. This prevents advancing the cursor on rejected projections and fixes replication that assumed contiguous immutable row ids.

- **Bug Fixes**
  - Assign version after acceptance inside the write transaction; rejected updates no longer consume a version.
  - Clarify cursor semantics in code and docs: `Message.Version`, session `MessageVersion`, and `AfterVersion/BeforeVersion` are high-water cursors that may have gaps.
  - Add tests for snapshot gaps (e.g., A@1, B@3), incremental paging (`afterVersion=1` returns B@3), and no cursor change on rejected updates.
  - Add troubleshooting for repeated `400 INVALID_ARGUMENT` during AgentActivity replication.
  - Related fixes: server https://github.com/tutti-lab/tsh-server/pull/381 and desktop replica https://github.com/tutti-lab/tsh/pull/1572

- **Migration**
  - Replicas must treat versions as monotonic cursors, not contiguous identities.
  - Allow any positive version for new messages and a higher version for an existing `messageId`; ignore/reject only lower (stale) versions.
  - Use version-guarded atomic upserts to prevent stale snapshots from overwriting newer state.

<sup>Written for commit a04c1c7a969615e3d63990c6e42c8fa5a3fb59db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

