### PR TITLE
perf(agent): parallelize provider status detection

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusDiagnostics.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusDiagnostics.ts
@@ -1,0 +1,263 @@
+import type {
+  AgentProviderStatus,
+  WorkspaceAgentProvider
+} from "@tutti-os/client-tuttid-ts";
+import type { DesktopRuntimeApi } from "@preload/types";
+import {
+  getAgentDiagnosticsConsent,
+  setAgentDiagnosticsConsent
+} from "../../../../lib/agentDiagnosticsConsent.ts";
+import { AgentEnvDetectedReporter } from "../../../analytics/reporters/agent-env-detected/agentEnvDetectedReporter.ts";
+import { AgentEnvIssueReportedReporter } from "../../../analytics/reporters/agent-env-issue-reported/agentEnvIssueReportedReporter.ts";
+import { AgentAnalyticsErrorCode } from "../../../analytics/reporters/agent-error-fields.ts";
+import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
+import {
+  buildEnvDetectedParams,
+  buildEnvIssueParams,
+  envDetectedSignature
+} from "./agentEnvTelemetry.ts";
+import {
+  createAgentNodeResultTracker,
+  safeTrackAgentNodeResult,
+  type AgentAnalyticsFlow,
+  type AgentAnalyticsNode
+} from "./agentNodeResultAnalytics.ts";
+import { latestProviderStatusLogLine } from "./desktopAgentProviderStatusLog.ts";
+
+export interface DiagnosticsConsentStore {
+  get(): boolean;
+  set(value: boolean): void;
+}
+
+export interface AgentProviderStatusRequestInput {
+  providers?: readonly WorkspaceAgentProvider[];
+  includeNetwork?: boolean;
+}
+
+interface DesktopAgentProviderStatusDiagnosticsDependencies {
+  consentStore?: DiagnosticsConsentStore;
+  now?: () => number;
+  reporterNow?: () => number;
+  reporterService?: Pick<IReporterService, "trackEvents">;
+  runtimeApi?: Pick<DesktopRuntimeApi, "logRendererDiagnostic">;
+}
+
+export class DesktopAgentProviderStatusDiagnostics {
+  private readonly consentStore: DiagnosticsConsentStore;
+  private readonly dependencies: DesktopAgentProviderStatusDiagnosticsDependencies;
+  private readonly lastEnvSignatures = new Map<
+    WorkspaceAgentProvider,
+    string
+  >();
+
+  constructor(dependencies: DesktopAgentProviderStatusDiagnosticsDependencies) {
+    this.dependencies = dependencies;
+    this.consentStore = dependencies.consentStore ?? createSharedConsentStore();
+  }
+
+  logStatusRequestCacheHit(
+    input: AgentProviderStatusRequestInput,
+    cachedProviderCount: number
+  ): void {
+    this.logRendererDiagnostic("agent_provider_status.request.cache_hit", {
+      ...statusRequestDetails(input),
+      cachedProviderCount
+    });
+  }
+
+  logStatusRequestReused(input: AgentProviderStatusRequestInput): void {
+    this.logRendererDiagnostic("agent_provider_status.request.reused", {
+      ...statusRequestDetails(input)
+    });
+  }
+
+  logStatusRequestStarted(input: {
+    request: AgentProviderStatusRequestInput;
+    requestId: number;
+  }): number {
+    const startedAt = this.now();
+    this.logRendererDiagnostic("agent_provider_status.request.started", {
+      ...statusRequestDetails(input.request),
+      requestId: input.requestId
+    });
+    return startedAt;
+  }
+
+  logStatusRequestResolved(input: {
+    appliedProviderCount: number;
+    request: AgentProviderStatusRequestInput;
+    requestId: number;
+    responseProviderCount: number;
+    staleProviderCount: number;
+    startedAt: number;
+  }): number {
+    const durationMs = elapsedMilliseconds(this.now(), input.startedAt);
+    this.logRendererDiagnostic("agent_provider_status.request.resolved", {
+      ...statusRequestDetails(input.request),
+      appliedProviderCount: input.appliedProviderCount,
+      durationMs,
+      requestId: input.requestId,
+      responseProviderCount: input.responseProviderCount,
+      staleProviderCount: input.staleProviderCount
+    });
+    return durationMs;
+  }
+
+  logStatusRequestFailed(input: {
+    error: unknown;
+    request: AgentProviderStatusRequestInput;
+    requestId: number;
+    startedAt: number;
+  }): number {
+    const durationMs = elapsedMilliseconds(this.now(), input.startedAt);
+    this.logRendererDiagnostic("agent_provider_status.request.failed", {
+      ...statusRequestDetails(input.request),
+      durationMs,
+      errorType:
+        input.error instanceof Error ? input.error.name : typeof input.error,
+      requestId: input.requestId
+    });
+    return durationMs;
+  }
+
+  reportEnvDetectedChanges(statuses: readonly AgentProviderStatus[]): void {
+    for (const status of statuses) {
+      const signature = envDetectedSignature(status);
+      if (this.lastEnvSignatures.get(status.provider) === signature) {
+        continue;
+      }
+      this.lastEnvSignatures.set(status.provider, signature);
+      void this.reportEnvDetected(status);
+    }
+  }
+
+  getDiagnosticsConsent(): boolean {
+    return this.consentStore.get();
+  }
+
+  setDiagnosticsConsent(value: boolean): void {
+    this.consentStore.set(value);
+  }
+
+  async reportEnvIssue(status: AgentProviderStatus | null): Promise<void> {
+    if (!this.consentStore.get() || !status) {
+      return;
+    }
+    try {
+      await new AgentEnvIssueReportedReporter(buildEnvIssueParams(status), {
+        now: this.dependencies.reporterNow,
+        reporterService: createOptionalReporterService(
+          this.dependencies.reporterService
+        )
+      }).report();
+    } catch {
+      // Analytics must not block agent provider actions.
+    }
+  }
+
+  async reportNodeResult(input: {
+    agentSessionId?: string | null;
+    durationMs?: number | null;
+    error?: unknown;
+    fallbackErrorCode?: AgentAnalyticsErrorCode;
+    flow: AgentAnalyticsFlow;
+    node: AgentAnalyticsNode;
+    provider?: string | null;
+    success: boolean;
+  }): Promise<void> {
+    await safeTrackAgentNodeResult(
+      createAgentNodeResultTracker({
+        reporterNow: this.dependencies.reporterNow,
+        reporterService: this.dependencies.reporterService
+      }),
+      input
+    );
+  }
+
+  logActiveActionSnapshotDiagnostics(
+    statuses: readonly AgentProviderStatus[],
+    isInstallPending: (provider: WorkspaceAgentProvider) => boolean
+  ): void {
+    for (const status of statuses) {
+      const activeAction = status.activeAction ?? null;
+      const installPending = isInstallPending(status.provider);
+      if (!activeAction && !installPending) {
+        continue;
+      }
+      const log = activeAction?.log ?? [];
+      this.logRendererDiagnostic(
+        "agent_provider_status.active_action_snapshot",
+        {
+          activeActionPresent: activeAction !== null,
+          availability: status.availability.status,
+          installPending,
+          latestLogPresent: latestProviderStatusLogLine(log) !== null,
+          logLines: log.length,
+          phase: activeAction?.phase ?? null,
+          provider: status.provider,
+          reasonCode: status.availability.reasonCode ?? null,
+          registryPresent: Boolean(activeAction?.registry)
+        }
+      );
+    }
+  }
+
+  logRendererDiagnostic(event: string, details: Record<string, unknown>): void {
+    void this.dependencies.runtimeApi
+      ?.logRendererDiagnostic({
+        details,
+        event,
+        level: "info",
+        source: "agent-provider-status"
+      })
+      .catch(() => {});
+  }
+
+  private async reportEnvDetected(status: AgentProviderStatus): Promise<void> {
+    try {
+      await new AgentEnvDetectedReporter(buildEnvDetectedParams(status), {
+        now: this.dependencies.reporterNow,
+        reporterService: createOptionalReporterService(
+          this.dependencies.reporterService
+        )
+      }).report();
+    } catch {
+      // Analytics must not block agent provider actions.
+    }
+  }
+
+  private now(): number {
+    return this.dependencies.now?.() ?? Date.now();
+  }
+}
+
+function statusRequestDetails(input: AgentProviderStatusRequestInput) {
+  const providers = [...new Set(input.providers ?? [])].sort();
+  return {
+    includeNetwork: input.includeNetwork === true,
+    providerCount: providers.length,
+    providers,
+    requestScope: providers.length > 0 ? "providers" : "all"
+  };
+}
+
+function elapsedMilliseconds(now: number, startedAt: number): number {
+  return Math.max(0, Math.round(now - startedAt));
+}
+
+function createOptionalReporterService(
+  reporterService: Pick<IReporterService, "trackEvents"> | undefined
+): Pick<IReporterService, "trackEvents"> {
+  return (
+    reporterService ?? {
+      async trackEvents() {}
+    }
+  );
+}
+
+function createSharedConsentStore(): DiagnosticsConsentStore {
+  return {
+    get: getAgentDiagnosticsConsent,
+    set: setAgentDiagnosticsConsent
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.test.ts
@@ -10,6 +10,7 @@ import type {
   WorkspaceAgentProvider
 } from "@tutti-os/client-tuttid-ts";
 import type { NotificationService } from "@tutti-os/ui-notifications";
+import type { DesktopRendererDiagnosticPayload } from "@shared/contracts/ipc";
 import type { ReporterEventInput } from "../../../analytics/services/reporterService.interface.ts";
 import { DesktopAgentProviderStatusService } from "./desktopAgentProviderStatusService.ts";
 
@@ -1181,6 +1182,118 @@ test("ensureLoaded reuses loaded provider statuses and only loads missing provid
   await service.ensureLoaded({ providers: ["claude-code"] });
 
   assert.deepEqual(statusCalls, [["codex"], ["claude-code"]]);
+});
+
+test("provider status requests log duration, scope, and cache hits", async () => {
+  const diagnostics: DesktopRendererDiagnosticPayload[] = [];
+  let now = 100;
+  const service = new DesktopAgentProviderStatusService({
+    diagnosticNow: () => now,
+    runtimeApi: {
+      async logRendererDiagnostic(payload) {
+        diagnostics.push(payload);
+      }
+    },
+    tuttidClient: {
+      async getAgentProviderStatuses() {
+        now = 145;
+        return createStatusResponse([
+          createProviderStatus({
+            actions: [],
+            availability: "ready",
+            provider: "codex"
+          })
+        ]);
+      }
+    } as Partial<TuttidClient> as TuttidClient,
+    terminalCommandRunner: {
+      async runTerminalCommand() {}
+    }
+  });
+
+  await service.ensureLoaded({ providers: ["codex"] });
+  await service.ensureLoaded({ providers: ["codex"] });
+
+  assert.deepEqual(
+    diagnostics.map(({ details, event }) => ({ details, event })),
+    [
+      {
+        details: {
+          includeNetwork: false,
+          providerCount: 1,
+          providers: ["codex"],
+          requestId: 1,
+          requestScope: "providers"
+        },
+        event: "agent_provider_status.request.started"
+      },
+      {
+        details: {
+          appliedProviderCount: 1,
+          durationMs: 45,
+          includeNetwork: false,
+          providerCount: 1,
+          providers: ["codex"],
+          requestId: 1,
+          requestScope: "providers",
+          responseProviderCount: 1,
+          staleProviderCount: 0
+        },
+        event: "agent_provider_status.request.resolved"
+      },
+      {
+        details: {
+          cachedProviderCount: 1,
+          includeNetwork: false,
+          providerCount: 1,
+          providers: ["codex"],
+          requestScope: "providers"
+        },
+        event: "agent_provider_status.request.cache_hit"
+      }
+    ]
+  );
+});
+
+test("failed provider status requests log duration without the error message", async () => {
+  const diagnostics: DesktopRendererDiagnosticPayload[] = [];
+  let now = 200;
+  const service = new DesktopAgentProviderStatusService({
+    diagnosticNow: () => now,
+    runtimeApi: {
+      async logRendererDiagnostic(payload) {
+        diagnostics.push(payload);
+      }
+    },
+    tuttidClient: {
+      async getAgentProviderStatuses() {
+        now = 260;
+        throw new TypeError("sensitive local detail");
+      }
+    } as Partial<TuttidClient> as TuttidClient,
+    terminalCommandRunner: {
+      async runTerminalCommand() {}
+    }
+  });
+
+  await service.refresh(["codex"]);
+
+  const failure = diagnostics.find(
+    ({ event }) => event === "agent_provider_status.request.failed"
+  );
+  assert.deepEqual(failure?.details, {
+    durationMs: 60,
+    errorType: "TypeError",
+    includeNetwork: false,
+    providerCount: 1,
+    providers: ["codex"],
+    requestId: 1,
+    requestScope: "providers"
+  });
+  assert.equal(
+    JSON.stringify(failure).includes("sensitive local detail"),
+    false
+  );
 });
 
 test("hydrate seeds the snapshot for an instance that has not captured its own data yet", () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts
@@ -5,14 +5,7 @@ import type {
   WorkspaceAgentProvider
 } from "@tutti-os/client-tuttid-ts";
 import type { DesktopRuntimeApi } from "@preload/types";
-import { AgentEnvDetectedReporter } from "../../../analytics/reporters/agent-env-detected/agentEnvDetectedReporter.ts";
-import { AgentEnvIssueReportedReporter } from "../../../analytics/reporters/agent-env-issue-reported/agentEnvIssueReportedReporter.ts";
 import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
-import {
-  buildEnvDetectedParams,
-  buildEnvIssueParams,
-  envDetectedSignature
-} from "./agentEnvTelemetry.ts";
 import type {
   AgentProviderStatusActionContext,
   AgentProviderStatusSnapshot,
@@ -26,17 +19,7 @@ import {
 import { translate } from "../../../../i18n/appRuntime.ts";
 import { getActiveLocale } from "../../../../i18n/runtime.ts";
 import { resolveDesktopErrorMessage } from "../../../../lib/desktopErrors.ts";
-import {
-  getAgentDiagnosticsConsent,
-  setAgentDiagnosticsConsent
-} from "../../../../lib/agentDiagnosticsConsent.ts";
 import { AgentAnalyticsErrorCode } from "../../../analytics/reporters/agent-error-fields.ts";
-import {
-  createAgentNodeResultTracker,
-  safeTrackAgentNodeResult,
-  type AgentAnalyticsFlow,
-  type AgentAnalyticsNode
-} from "./agentNodeResultAnalytics.ts";
 import { applyDesktopAgentProviderRuntimeProbeFallbacks } from "./desktopAgentProviderRuntimeProbeFallback.ts";
 import {
   DesktopAgentProviderAccountLifecycle,
@@ -48,7 +31,12 @@ import {
   shouldTrackPendingAction
 } from "./desktopAgentProviderInstall.ts";
 import { reconcileProviderStatuses } from "./desktopAgentProviderStatusCatalog.ts";
-import { latestProviderStatusLogLine } from "./desktopAgentProviderStatusLog.ts";
+import {
+  DesktopAgentProviderStatusDiagnostics,
+  type DiagnosticsConsentStore
+} from "./desktopAgentProviderStatusDiagnostics.ts";
+
+export type { DiagnosticsConsentStore } from "./desktopAgentProviderStatusDiagnostics.ts";
 
 export interface DesktopAgentProviderStatusServiceDependencies {
   loginStatusPollDurationMs?: number;
@@ -58,15 +46,10 @@ export interface DesktopAgentProviderStatusServiceDependencies {
   reporterNow?: () => number;
   reporterService?: Pick<IReporterService, "trackEvents">;
   diagnosticsConsentStore?: DiagnosticsConsentStore;
+  diagnosticNow?: () => number;
   requestTimeoutMs?: number;
   runtimeApi?: Pick<DesktopRuntimeApi, "logRendererDiagnostic">;
   terminalCommandRunner: AgentProviderTerminalCommandRunner;
-}
-
-/** Persists whether the user agreed to send fuller diagnostics via "上报异常". */
-export interface DiagnosticsConsentStore {
-  get(): boolean;
-  set(value: boolean): void;
 }
 
 type AgentProviderStatusPollTimer = number | { unref?: () => void };
@@ -93,6 +76,7 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
   readonly _serviceBrand = undefined;
 
   private readonly dependencies: DesktopAgentProviderStatusServiceDependencies;
+  private readonly diagnostics: DesktopAgentProviderStatusDiagnostics;
   private readonly notifications: NotificationService;
   private readonly inflightRequests = new Map<
     string,
@@ -113,13 +97,6 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
   private revision = 0;
   private snapshot: AgentProviderStatusSnapshot = emptySnapshot;
   private readonly transientDowngradeCounts = new Map<string, number>();
-  // Last env-detection fingerprint per provider, so `agent.env_detected` fires
-  // only when the outcome changes instead of on every status poll.
-  private readonly lastEnvSignatures = new Map<
-    WorkspaceAgentProvider,
-    string
-  >();
-  private readonly consentStore: DiagnosticsConsentStore;
 
   constructor(
     dependencies: DesktopAgentProviderStatusServiceDependencies,
@@ -127,14 +104,19 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
   ) {
     this.dependencies = dependencies;
     this.notifications = notifications;
-    this.consentStore =
-      dependencies.diagnosticsConsentStore ?? createSharedConsentStore();
+    this.diagnostics = new DesktopAgentProviderStatusDiagnostics({
+      consentStore: dependencies.diagnosticsConsentStore,
+      now: dependencies.diagnosticNow,
+      reporterNow: dependencies.reporterNow,
+      reporterService: dependencies.reporterService,
+      runtimeApi: dependencies.runtimeApi
+    });
     this.accountLifecycle = new DesktopAgentProviderAccountLifecycle({
       loginStatusPollDurationMs: dependencies.loginStatusPollDurationMs,
       loginStatusPollIntervalMs: dependencies.loginStatusPollIntervalMs,
       loginStatusPollScheduler: dependencies.loginStatusPollScheduler,
       refresh: async (provider) => this.refresh([provider]),
-      reportNodeResult: (input) => this.reportNodeResult(input),
+      reportNodeResult: (input) => this.diagnostics.reportNodeResult(input),
       reporterNow: dependencies.reporterNow,
       reporterService: dependencies.reporterService
     });
@@ -178,12 +160,17 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
     } = {}
   ): Promise<AgentProviderStatusListResponse | null> {
     if (this.hasLoadedProviderSnapshot(input.providers)) {
+      this.diagnostics.logStatusRequestCacheHit(
+        input,
+        this.snapshot.statuses.length
+      );
       return this.snapshotResponse();
     }
 
     const requestKey = providerStatusRequestKey(input);
     const inflightRequest = this.inflightRequests.get(requestKey);
     if (inflightRequest) {
+      this.diagnostics.logStatusRequestReused(input);
       await inflightRequest;
       if (this.hasLoadedProviderSnapshot(input.providers)) {
         return this.snapshotResponse();
@@ -202,6 +189,7 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
     const requestKey = providerStatusRequestKey(input);
     const inflightRequest = this.inflightRequests.get(requestKey);
     if (inflightRequest) {
+      this.diagnostics.logStatusRequestReused(input);
       return inflightRequest;
     }
 
@@ -214,6 +202,10 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
     const requestId = this.requestSequence + 1;
     this.requestSequence = requestId;
     this.markLatestStatusRequest(input.providers, requestId);
+    const requestStartedAt = this.diagnostics.logStatusRequestStarted({
+      request: input,
+      requestId
+    });
     const request = withTimeout(
       this.dependencies.tuttidClient.getAgentProviderStatuses(input),
       this.dependencies.requestTimeoutMs ?? defaultRequestTimeoutMs
@@ -253,7 +245,10 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
             pendingActions: this.snapshot.pendingActions,
             statuses: reconciledStatuses
           });
-          this.logActiveActionSnapshotDiagnostics(reconciledStatuses);
+          this.diagnostics.logActiveActionSnapshotDiagnostics(
+            reconciledStatuses,
+            (provider) => this.isActionPending(provider, "install")
+          );
           // Report provider_ready before reportCompletedLoginResults so the
           // pendingLoginResults set is still populated when we classify how a
           // provider became ready (login vs. already-ready vs. external).
@@ -261,12 +256,22 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
             previousStatuses,
             reconciledStatuses
           );
-          this.reportEnvDetectedChanges(reconciledStatuses);
+          this.diagnostics.reportEnvDetectedChanges(reconciledStatuses);
           void this.accountLifecycle.reportCompletedLoginResults(
             response.providers
           );
         }
-        await this.reportNodeResult({
+        const durationMs = this.diagnostics.logStatusRequestResolved({
+          appliedProviderCount: currentResponseStatuses.length,
+          request: input,
+          requestId,
+          responseProviderCount: response.providers.length,
+          staleProviderCount:
+            response.providers.length - currentResponseStatuses.length,
+          startedAt: requestStartedAt
+        });
+        await this.diagnostics.reportNodeResult({
+          durationMs,
           flow: "provider_setup",
           node: "provider_status_request",
           provider: input.providers?.[0] ?? response.defaultProvider ?? null,
@@ -285,7 +290,14 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
             isLoading: this.inflightRequests.size > 1
           });
         }
-        await this.reportNodeResult({
+        const durationMs = this.diagnostics.logStatusRequestFailed({
+          error,
+          request: input,
+          requestId,
+          startedAt: requestStartedAt
+        });
+        await this.diagnostics.reportNodeResult({
+          durationMs,
           error,
           fallbackErrorCode: AgentAnalyticsErrorCode.ProviderStatusFailed,
           flow: "provider_setup",
@@ -361,7 +373,7 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
           provider
         );
         await this.refresh([provider]);
-        await this.reportNodeResult({
+        await this.diagnostics.reportNodeResult({
           flow: "provider_setup",
           node: "install_action_requested",
           provider,
@@ -390,7 +402,7 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
           context
         );
       if (isLoginAction) {
-        await this.reportNodeResult({
+        await this.diagnostics.reportNodeResult({
           durationMs: this.accountLifecycle.now() - terminalLaunchStartedAt,
           flow: "provider_setup",
           node: "login_terminal_launch",
@@ -408,7 +420,7 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
             "workspace.workbenchDesktop.agentProviders.installFailed"
           )
         });
-        await this.reportNodeResult({
+        await this.diagnostics.reportNodeResult({
           error,
           fallbackErrorCode: AgentAnalyticsErrorCode.InstallFailed,
           flow: "provider_setup",
@@ -432,7 +444,7 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
           error,
           AgentAnalyticsErrorCode.LoginLaunchFailed
         );
-        await this.reportNodeResult({
+        await this.diagnostics.reportNodeResult({
           error,
           fallbackErrorCode: AgentAnalyticsErrorCode.LoginLaunchFailed,
           flow: "provider_setup",
@@ -568,10 +580,13 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
     if (this.isActionPending(provider, actionId)) {
       return;
     }
-    this.logRendererDiagnostic("agent_provider_status.pending_action_added", {
-      actionId,
-      provider
-    });
+    this.diagnostics.logRendererDiagnostic(
+      "agent_provider_status.pending_action_added",
+      {
+        actionId,
+        provider
+      }
+    );
     this.setSnapshot({
       ...this.snapshot,
       pendingActions: [...this.snapshot.pendingActions, { actionId, provider }]
@@ -589,10 +604,13 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
     if (pendingActions.length === this.snapshot.pendingActions.length) {
       return;
     }
-    this.logRendererDiagnostic("agent_provider_status.pending_action_removed", {
-      actionId,
-      provider
-    });
+    this.diagnostics.logRendererDiagnostic(
+      "agent_provider_status.pending_action_removed",
+      {
+        actionId,
+        provider
+      }
+    );
     this.stopPendingActionStatusPolling(provider, actionId);
     this.setSnapshot({
       ...this.snapshot,
@@ -660,123 +678,18 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
     this.pendingActionStatusPolls.delete(key);
   }
 
-  // Always-on, privacy-safe: fire `agent.env_detected` once per provider per
-  // distinct detection outcome, so we can see how users' environments resolve
-  // without spamming on routine polls.
-  private reportEnvDetectedChanges(
-    statuses: readonly AgentProviderStatus[]
-  ): void {
-    for (const status of statuses) {
-      const signature = envDetectedSignature(status);
-      if (this.lastEnvSignatures.get(status.provider) === signature) {
-        continue;
-      }
-      this.lastEnvSignatures.set(status.provider, signature);
-      void this.reportEnvDetected(status);
-    }
-  }
-
-  private async reportEnvDetected(status: AgentProviderStatus): Promise<void> {
-    try {
-      await new AgentEnvDetectedReporter(buildEnvDetectedParams(status), {
-        now: this.dependencies.reporterNow,
-        reporterService: createOptionalReporterService(
-          this.dependencies.reporterService
-        )
-      }).report();
-    } catch {
-      // Analytics must not block agent provider actions.
-    }
-  }
-
   getDiagnosticsConsent(): boolean {
-    return this.consentStore.get();
+    return this.diagnostics.getDiagnosticsConsent();
   }
 
   setDiagnosticsConsent(value: boolean): void {
-    this.consentStore.set(value);
+    this.diagnostics.setDiagnosticsConsent(value);
   }
 
   // The consent-gated "report problem" action: sends the fuller diagnostic
   // payload, but only when the user has agreed.
   async reportEnvIssue(provider: WorkspaceAgentProvider): Promise<void> {
-    if (!this.consentStore.get()) {
-      return;
-    }
-    const status = this.getStatus(provider);
-    if (!status) {
-      return;
-    }
-    try {
-      await new AgentEnvIssueReportedReporter(buildEnvIssueParams(status), {
-        now: this.dependencies.reporterNow,
-        reporterService: createOptionalReporterService(
-          this.dependencies.reporterService
-        )
-      }).report();
-    } catch {
-      // Analytics must not block agent provider actions.
-    }
-  }
-
-  private async reportNodeResult(input: {
-    agentSessionId?: string | null;
-    durationMs?: number | null;
-    error?: unknown;
-    fallbackErrorCode?: AgentAnalyticsErrorCode;
-    flow: AgentAnalyticsFlow;
-    node: AgentAnalyticsNode;
-    provider?: string | null;
-    success: boolean;
-  }): Promise<void> {
-    await safeTrackAgentNodeResult(
-      createAgentNodeResultTracker({
-        reporterNow: this.dependencies.reporterNow,
-        reporterService: this.dependencies.reporterService
-      }),
-      input
-    );
-  }
-
-  private logActiveActionSnapshotDiagnostics(
-    statuses: readonly AgentProviderStatus[]
-  ): void {
-    for (const status of statuses) {
-      const activeAction = status.activeAction ?? null;
-      const installPending = this.isActionPending(status.provider, "install");
-      if (!activeAction && !installPending) {
-        continue;
-      }
-      const log = activeAction?.log ?? [];
-      this.logRendererDiagnostic(
-        "agent_provider_status.active_action_snapshot",
-        {
-          activeActionPresent: activeAction !== null,
-          availability: status.availability.status,
-          installPending,
-          latestLogPresent: latestProviderStatusLogLine(log) !== null,
-          logLines: log.length,
-          phase: activeAction?.phase ?? null,
-          provider: status.provider,
-          reasonCode: status.availability.reasonCode ?? null,
-          registryPresent: Boolean(activeAction?.registry)
-        }
-      );
-    }
-  }
-
-  private logRendererDiagnostic(
-    event: string,
-    details: Record<string, unknown>
-  ): void {
-    void this.dependencies.runtimeApi
-      ?.logRendererDiagnostic({
-        details,
-        event,
-        level: "info",
-        source: "agent-provider-status"
-      })
-      .catch(() => {});
+    await this.diagnostics.reportEnvIssue(this.getStatus(provider));
   }
 }
 
@@ -796,23 +709,6 @@ function providerStatusRequestKey(input: {
     includeNetwork: input.includeNetwork === true,
     providers: providers.length > 0 ? providers : null
   });
-}
-
-function createOptionalReporterService(
-  reporterService: Pick<IReporterService, "trackEvents"> | undefined
-): Pick<IReporterService, "trackEvents"> {
-  return (
-    reporterService ?? {
-      async trackEvents() {}
-    }
-  );
-}
-
-function createSharedConsentStore(): DiagnosticsConsentStore {
-  return {
-    get: getAgentDiagnosticsConsent,
-    set: setAgentDiagnosticsConsent
-  };
 }
 
 function unrefPollTimer(timer: AgentProviderStatusPollTimer): void {

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -85,6 +85,16 @@
   transformation/evaluation rather than SQLite or workspace hydration. Also
   time provider statuses per provider; one slow CLI probe can dominate a serial
   all-provider scan.
+  For provider-status startup, correlate the same `session_id` across
+  `tutti-desktop.log` and `tuttid.log`. Renderer events
+  `agent_provider_status.request.started`, `.resolved`, `.failed`,
+  `.cache_hit`, and `.reused` show request scope, provider IDs, request ID, and
+  total elapsed time. Daemon event
+  `tutti.agent_provider.status_list.completed` shows the batch total; per-provider
+  `tutti.agent_provider.status_detection.completed` events split runtime
+  resolution, adapter probe, auth, CLI version, and post-check time. Concurrent
+  step times overlap, so compare the largest step with the provider total rather
+  than summing every step.
 - Root cause:
   For the permanent-black variant, an optional startup provider can be passed
   directly to the strict workbench provider normalizer. The generic primary
@@ -146,11 +156,21 @@
   manual renderer verification requires explicit user approval. If the dynamic
   import still dominates, compare cold and warm module-graph timings before
   investigating daemon hydration or provider discovery.
+  When a provider-status request is slow, compare Renderer `durationMs` with the
+  daemon batch `durationMs`. A large daemon total points to provider detection;
+  a large Renderer-only gap points to transport, timeout handling, or Renderer
+  runtime-probe fallback. Within the daemon, compare each provider total and its
+  largest phase. Logs intentionally record provider IDs, counts, outcomes, and
+  durations, but not executable paths, command output, environment values, or
+  error messages.
 - References:
   [agent-gui-node.md](../../architecture/agent-gui-node.md)
   [WorkspaceWindow.tsx](../../../apps/desktop/src/renderer/src/app/windows/workspace/WorkspaceWindow.tsx)
   [StandaloneAgentToolSidebar.tsx](../../../apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx)
   [desktopAgentProviderStatusService.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts)
+  [desktopAgentProviderStatusDiagnostics.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusDiagnostics.ts)
+  [service.go](../../../services/tuttid/service/agentstatus/service.go)
+  [service_status.go](../../../services/tuttid/service/agentstatus/service_status.go)
 
 ### Renderer body requests fail with `ERR_H2_OR_QUIC_REQUIRED`
 

--- a/services/tuttid/service/agentstatus/network_probe_skip_test.go
+++ b/services/tuttid/service/agentstatus/network_probe_skip_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"sync/atomic"
 	"testing"
 )
 
@@ -22,13 +23,15 @@ func TestListNetworkProbeIsOptIn(t *testing.T) {
 	claimActiveAction(resetCtx, provider, ActiveAction{})
 	clearActiveAction(resetCtx, provider)
 
-	var networkCalls int
+	// Atomic because the registry ranking probe hits the transport from one
+	// goroutine per registry concurrently.
+	var networkCalls atomic.Int64
 	newService := func() Service {
 		s := testService(func(_ string) (string, error) {
 			return "", errors.New("not found")
 		}, map[string]bool{})
 		s.HTTPClient = &http.Client{Transport: networkRoundTripFunc(func(*http.Request) (*http.Response, error) {
-			networkCalls++
+			networkCalls.Add(1)
 			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
 		})}
 		s.ResolveProxy = func(*http.Request) (*url.URL, error) { return nil, nil }
@@ -37,7 +40,7 @@ func TestListNetworkProbeIsOptIn(t *testing.T) {
 
 	// Default (IncludeNetwork=false): local-only. No network call, no Network,
 	// but full local availability is still resolved.
-	networkCalls = 0
+	networkCalls.Store(0)
 	local, err := newService().List(context.Background(), ListInput{Providers: []string{provider}})
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
@@ -45,8 +48,8 @@ func TestListNetworkProbeIsOptIn(t *testing.T) {
 	if len(local.Providers) != 1 {
 		t.Fatalf("local: providers = %#v, want 1", local.Providers)
 	}
-	if networkCalls != 0 {
-		t.Fatalf("local: network probed %d times, want 0", networkCalls)
+	if calls := networkCalls.Load(); calls != 0 {
+		t.Fatalf("local: network probed %d times, want 0", calls)
 	}
 	if local.Providers[0].Network != nil {
 		t.Fatalf("local: Network = %#v, want nil (probe not requested)", local.Providers[0].Network)
@@ -56,7 +59,7 @@ func TestListNetworkProbeIsOptIn(t *testing.T) {
 	}
 
 	// IncludeNetwork=true, not installing: List probes the network.
-	networkCalls = 0
+	networkCalls.Store(0)
 	probed, err := newService().List(context.Background(), ListInput{
 		Providers:      []string{provider},
 		IncludeNetwork: true,
@@ -67,7 +70,7 @@ func TestListNetworkProbeIsOptIn(t *testing.T) {
 	if probed.Providers[0].Network == nil {
 		t.Fatalf("opted-in: Network = nil, want probed")
 	}
-	if networkCalls == 0 {
+	if networkCalls.Load() == 0 {
 		t.Fatal("opted-in: expected the network to be probed")
 	}
 
@@ -80,7 +83,7 @@ func TestListNetworkProbeIsOptIn(t *testing.T) {
 	})
 	t.Cleanup(func() { clearActiveAction(installCtx, provider) })
 
-	networkCalls = 0
+	networkCalls.Store(0)
 	installing, err := newService().List(context.Background(), ListInput{
 		Providers:      []string{provider},
 		IncludeNetwork: true,
@@ -91,8 +94,8 @@ func TestListNetworkProbeIsOptIn(t *testing.T) {
 	if installing.Providers[0].Network != nil {
 		t.Fatalf("installing: Network = %#v, want nil (probe skipped)", installing.Providers[0].Network)
 	}
-	if networkCalls != 0 {
-		t.Fatalf("installing: network probed %d times, want 0", networkCalls)
+	if calls := networkCalls.Load(); calls != 0 {
+		t.Fatalf("installing: network probed %d times, want 0", calls)
 	}
 	if installing.Providers[0].ActiveAction == nil {
 		t.Fatal("installing: ActiveAction = nil, want the running install action surfaced")

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -3,11 +3,12 @@ package agentstatus
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	externalagentregistry "github.com/tutti-os/tutti/services/tuttid/service/externalagentregistry"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
@@ -246,6 +247,13 @@ const defaultProbeTimeout = 3 * time.Second
 const defaultProbeWaitDelay = 500 * time.Millisecond
 const externalRegistryNPMProbeTimeoutPadding = 100 * time.Millisecond
 
+// statusDetectionConcurrency bounds how many providers are detected at once.
+// Per-provider detection is dominated by short-lived subprocesses (auth status
+// command, `--version`, adapter probe), so running providers concurrently drops
+// snapshot latency from the serial sum to roughly the slowest provider. The
+// bound keeps the subprocess fan-out small on constrained machines.
+const statusDetectionConcurrency = 4
+
 func (s Service) List(ctx context.Context, input ListInput) (Snapshot, error) {
 	now := s.now()
 	specs, err := s.selectProviderSpecs(ctx, input.Providers, false)
@@ -253,10 +261,18 @@ func (s Service) List(ctx context.Context, input ListInput) (Snapshot, error) {
 		return Snapshot{}, err
 	}
 
-	statuses := make([]ProviderStatus, 0, len(specs))
-	for _, spec := range specs {
-		statuses = append(statuses, s.statusForSpec(ctx, spec, now))
+	// Detect providers concurrently; each writes only its own slot so the
+	// response order stays the registry selection order.
+	statuses := make([]ProviderStatus, len(specs))
+	var group errgroup.Group
+	group.SetLimit(statusDetectionConcurrency)
+	for i, spec := range specs {
+		group.Go(func() error {
+			statuses[i] = s.statusForSpec(ctx, spec, now)
+			return nil
+		})
 	}
+	_ = group.Wait() // statusForSpec never returns an error
 
 	// The network connectivity probe is OPT-IN (input.IncludeNetwork). The dock /
 	// startup / polling / provider-availability path leaves it off so detection is
@@ -577,218 +593,4 @@ func installerFailureReasonCode(installer InstallerSpec, message string, fallbac
 		}
 	}
 	return fallback
-}
-
-func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.Time) ProviderStatus {
-	if status, ok := unsupportedProviderStatus(spec, now); ok {
-		return status
-	}
-	runtimeResolution := s.resolveProviderRuntime(ctx, spec)
-	installed := strings.TrimSpace(runtimeResolution.CLIPath) != ""
-	adapterInstalled := strings.TrimSpace(runtimeResolution.AdapterPath) != ""
-	adapterReady := adapterInstalled && adapterPackageRequirementSatisfied(spec.AdapterPackage, runtimeResolution.AdapterVersion)
-	adapterLaunchFailed := false
-	if installed && adapterReady && s.shouldProbeAdapterCommandForStatus(spec, runtimeResolution) {
-		probe := s.probeAdapterRuntimeCommand(ctx, spec, runtimeResolution, now)
-		if probe.Status == ProbeFailed {
-			adapterReady = false
-			adapterLaunchFailed = true
-		}
-	}
-	auth := s.resolveAuth(ctx, spec, installed, runtimeResolution.CLIPath)
-	cliVersion := ""
-	if installed {
-		cliVersion = s.cliVersion(ctx, runtimeResolution.CLIPath, runtimeResolution.Env)
-	}
-	codexPlatformOK := true
-	if isCodexStatusSpec(spec) && installed {
-		codexPlatformOK = s.codexPlatformBinaryOK(runtimeResolution.CLIPath)
-	}
-	availability := Availability{
-		CheckedAt: &now,
-		Status:    AvailabilityReady,
-	}
-	actions := []Action{}
-
-	if !installed {
-		availability.Status = AvailabilityNotInstalled
-		availability.ReasonCode = "cli_not_found"
-		actions = append(actions, daemonAction(ActionInstall))
-	} else if !adapterInstalled {
-		availability.Status = AvailabilityNotInstalled
-		availability.ReasonCode = firstNonBlank(runtimeResolution.ReasonCode, spec.AdapterUnavailableReasonCode, "acp_adapter_not_found")
-		actions = append(actions, daemonAction(ActionInstall))
-	} else if adapterLaunchFailed {
-		availability.Status = AvailabilityNotInstalled
-		availability.ReasonCode = "acp_adapter_launch_failed"
-		actions = append(actions, daemonAction(ActionInstall))
-	} else if !adapterReady {
-		availability.Status = AvailabilityNotInstalled
-		availability.ReasonCode = "acp_adapter_version_mismatch"
-		actions = append(actions, daemonAction(ActionInstall))
-	} else if isCodexStatusSpec(spec) && !codexPlatformOK {
-		availability.Status = AvailabilityNotInstalled
-		availability.ReasonCode = codexReasonCodeFromErrorCode(string(CodexErrPlatformPkgIncomplete))
-		actions = append(actions, daemonAction(ActionInstall))
-	} else if isCodexStatusSpec(spec) && !cliVersionMeetsMinimum(cliVersion, spec.MinVersion) {
-		availability.Status = AvailabilityNotInstalled
-		availability.ReasonCode = codexReasonCodeFromErrorCode(string(CodexErrVersionTooOld))
-		actions = append(actions, daemonAction(ActionInstall))
-	} else {
-		if spec.LoginActionKind == ActionKindDaemonAction {
-			actions = append(actions, daemonAction(ActionLogin))
-		} else {
-			actions = append(actions, terminalAction(ActionLogin, loginCommandForRuntime(spec, runtimeResolution)))
-		}
-
-		// Claude Code can run in API Usage Billing mode — an API key, an auth
-		// token, or an apiKeyHelper — which bills usage to an API account and
-		// overrides any stored OAuth/subscription session. `claude auth status`
-		// only reflects the stored session, so it is blind to these env/settings
-		// credentials; detect them directly and prefer that signal over whatever
-		// the CLI reports, so the wizard shows "已配置 API 计费" instead of a
-		// stale OAuth label or "未登录". A bare custom endpoint without a
-		// credential is NOT API billing (the user may still be on an OAuth
-		// session), so it does not trigger this override.
-		if isClaudeStatusSpec(spec) && s.providerHasAPICredential(spec.Provider) {
-			auth.Status = AuthAuthenticated
-			auth.AccountLabel = "API Usage Billing"
-			auth.AuthMethod = "apiKey"
-		} else {
-			switch auth.Status {
-			case AuthAuthenticated:
-				// already ready
-			case AuthRequired:
-				availability.Status = AvailabilityAuthRequired
-				availability.ReasonCode = "auth_required"
-				actions = append(actions, Action{ID: ActionRefresh, Kind: ActionKindRefresh})
-			case AuthUnknown:
-				availability.Status = AvailabilityAuthRequired
-				availability.ReasonCode = "auth_unknown"
-				actions = append(actions, Action{ID: ActionRefresh, Kind: ActionKindRefresh})
-			}
-		}
-	}
-
-	status := ProviderStatus{
-		Provider:     spec.Provider,
-		Availability: availability,
-		CLI: CLIStatus{
-			Installed:  installed,
-			BinaryPath: runtimeResolution.CLIPath,
-			Version:    cliVersion,
-		},
-		Adapter: AdapterStatus{
-			Installed:       adapterReady,
-			BinaryPath:      runtimeResolution.AdapterPath,
-			Command:         cloneStrings(runtimeResolution.AdapterCommand),
-			Version:         runtimeResolution.AdapterVersion,
-			RequiredVersion: spec.AdapterPackage.Version,
-		},
-		Auth:    auth,
-		Actions: actions,
-	}
-	status.ActiveAction = activeActionForProvider(spec.Provider)
-	if status.ActiveAction != nil {
-		bytes, lines := activeActionOutputStats(status.ActiveAction.Stdout)
-		slog.Info(
-			"agent provider status attached active action",
-			"event", "tutti.agent_provider.status.active_action_attached",
-			"provider", spec.Provider,
-			"availability", status.Availability.Status,
-			"reasonCode", status.Availability.ReasonCode,
-			"step", status.ActiveAction.Step,
-			"registryPresent", strings.TrimSpace(status.ActiveAction.Registry) != "",
-			"stdoutBytes", bytes,
-			"stdoutLines", lines,
-		)
-	}
-	if isClaudeStatusSpec(spec) {
-		slog.Info(
-			"claude-code agent provider status checked",
-			"event", "tutti.agent_provider.status.checked",
-			"provider", spec.Provider,
-			"availability", status.Availability.Status,
-			"reasonCode", status.Availability.ReasonCode,
-			"authStatus", status.Auth.Status,
-			"authMethod", status.Auth.AuthMethod,
-			"cliInstalled", status.CLI.Installed,
-			"cliVersion", status.CLI.Version,
-			"sdkSidecarInstalled", status.Adapter.Installed,
-		)
-	}
-	if isCodexStatusSpec(spec) {
-		status.CLI.MinVersion = spec.MinVersion
-		status.Checks = codexProviderChecks(status, codexPlatformOK, s.codexNodeRuntimeCheck(spec))
-		status.LastError = codexProviderLastError(status)
-		slog.Info(
-			"codex agent provider status checked",
-			"availability", status.Availability.Status,
-			"reasonCode", status.Availability.ReasonCode,
-			"version", status.CLI.Version,
-			"lastErrorCode", providerLastErrorCode(status.LastError),
-			"missingPlatformPath", s.codexPlatformPackageMissingPath(runtimeResolution.CLIPath),
-		)
-	}
-	return status
-}
-
-func (s Service) shouldProbeAdapterCommandForStatus(spec ProviderSpec, runtimeResolution providerRuntimeResolution) bool {
-	if strings.TrimSpace(spec.ExternalRegistryID) != "" {
-		return true
-	}
-	return isCodexStatusSpec(spec) && s.executableFile(runtimeResolution.AdapterPath)
-}
-
-func (s Service) probeReadyAfterForSpec(spec ProviderSpec) time.Duration {
-	if strings.TrimSpace(spec.ExternalRegistryID) != "" && spec.AdapterInstall.RegistryNPM != nil {
-		return externalRegistryNPMProbeReadyAfter(s.probeTimeout())
-	}
-	return s.probeReadyAfter()
-}
-
-func agentNPMRegistryProbePackage(spec ProviderSpec) string {
-	if strings.TrimSpace(spec.NPMRegistryPackage) != "" {
-		return strings.TrimSpace(spec.NPMRegistryPackage)
-	}
-	if spec.AdapterInstall.RegistryNPM != nil {
-		packageName, _ := splitNPMPackageSpec(spec.AdapterInstall.RegistryNPM.Package)
-		if strings.TrimSpace(packageName) != "" {
-			return packageName
-		}
-	}
-	if spec.Install.RegistryNPM != nil {
-		packageName, _ := splitNPMPackageSpec(spec.Install.RegistryNPM.Package)
-		if strings.TrimSpace(packageName) != "" {
-			return packageName
-		}
-	}
-	return "@openai/codex"
-}
-
-func externalRegistryNPMProbeReadyAfter(timeout time.Duration) time.Duration {
-	if timeout <= 0 {
-		timeout = defaultProbeTimeout
-	}
-	if timeout <= 200*time.Millisecond {
-		return timeout / 2
-	}
-	return timeout - externalRegistryNPMProbeTimeoutPadding
-}
-
-func agentProviderProbeAdapterUnavailableMessage(reasonCode string) string {
-	switch strings.TrimSpace(reasonCode) {
-	case "acp_adapter_version_mismatch":
-		return "ACP adapter version does not match the required package version"
-	case "acp_adapter_launch_failed":
-		return "ACP adapter command failed to start"
-	case ReasonExternalAgentRegistryUnavailable:
-		return "ACP external agent registry is unavailable"
-	case ReasonManagedRuntimeUnavailable:
-		return "Managed Node runtime is unavailable"
-	case ReasonClaudeSDKSidecarUnavailable:
-		return "Claude SDK sidecar not found"
-	default:
-		return "ACP adapter not found"
-	}
 }

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -3,6 +3,7 @@ package agentstatus
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -254,7 +255,21 @@ const externalRegistryNPMProbeTimeoutPadding = 100 * time.Millisecond
 // bound keeps the subprocess fan-out small on constrained machines.
 const statusDetectionConcurrency = 4
 
-func (s Service) List(ctx context.Context, input ListInput) (Snapshot, error) {
+func (s Service) List(ctx context.Context, input ListInput) (snapshot Snapshot, err error) {
+	startedAt := time.Now()
+	defer func() {
+		slog.Info(
+			"agent provider status list completed",
+			"event", "tutti.agent_provider.status_list.completed",
+			"durationMs", time.Since(startedAt).Milliseconds(),
+			"includeNetwork", input.IncludeNetwork,
+			"providerCount", len(snapshot.Providers),
+			"requestedProviderCount", len(input.Providers),
+			"requestedProviders", input.Providers,
+			"success", err == nil,
+		)
+	}()
+
 	now := s.now()
 	specs, err := s.selectProviderSpecs(ctx, input.Providers, false)
 	if err != nil {
@@ -323,10 +338,11 @@ func (s Service) List(ctx context.Context, input ListInput) (Snapshot, error) {
 		statuses[i].ActiveAction = activeActionForProvider(statuses[i].Provider)
 	}
 
-	return Snapshot{
+	snapshot = Snapshot{
 		CapturedAt: now,
 		Providers:  statuses,
-	}, nil
+	}
+	return snapshot, nil
 }
 
 func (s Service) Probe(ctx context.Context, input ProbeInput) (ProbeResult, error) {

--- a/services/tuttid/service/agentstatus/service_status.go
+++ b/services/tuttid/service/agentstatus/service_status.go
@@ -1,0 +1,245 @@
+package agentstatus
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// statusForSpec computes one provider's detection snapshot. It is safe to call
+// concurrently for different specs: it only reads Service configuration, and
+// the shared stores it touches (RunOutcomes, the active-action table) are
+// internally synchronized.
+func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.Time) ProviderStatus {
+	if status, ok := unsupportedProviderStatus(spec, now); ok {
+		return status
+	}
+	runtimeResolution := s.resolveProviderRuntime(ctx, spec)
+	installed := strings.TrimSpace(runtimeResolution.CLIPath) != ""
+	adapterInstalled := strings.TrimSpace(runtimeResolution.AdapterPath) != ""
+	adapterReady := adapterInstalled && adapterPackageRequirementSatisfied(spec.AdapterPackage, runtimeResolution.AdapterVersion)
+	adapterLaunchFailed := false
+
+	// The adapter launch probe, the auth status command, and `--version` are
+	// independent and each can spawn a short-lived subprocess, so run them
+	// concurrently: the per-provider cost becomes the slowest step instead of
+	// the sum. Each goroutine writes distinct variables read only after Wait.
+	var auth AuthInfo
+	cliVersion := ""
+	var checks errgroup.Group
+	if installed && adapterReady && s.shouldProbeAdapterCommandForStatus(spec, runtimeResolution) {
+		checks.Go(func() error {
+			if probe := s.probeAdapterRuntimeCommand(ctx, spec, runtimeResolution, now); probe.Status == ProbeFailed {
+				adapterReady = false
+				adapterLaunchFailed = true
+			}
+			return nil
+		})
+	}
+	checks.Go(func() error {
+		auth = s.resolveAuth(ctx, spec, installed, runtimeResolution.CLIPath)
+		return nil
+	})
+	if installed {
+		checks.Go(func() error {
+			cliVersion = s.cliVersion(ctx, runtimeResolution.CLIPath, runtimeResolution.Env)
+			return nil
+		})
+	}
+	_ = checks.Wait()
+
+	codexPlatformOK := true
+	if isCodexStatusSpec(spec) && installed {
+		codexPlatformOK = s.codexPlatformBinaryOK(runtimeResolution.CLIPath)
+	}
+	availability := Availability{
+		CheckedAt: &now,
+		Status:    AvailabilityReady,
+	}
+	actions := []Action{}
+
+	if !installed {
+		availability.Status = AvailabilityNotInstalled
+		availability.ReasonCode = "cli_not_found"
+		actions = append(actions, daemonAction(ActionInstall))
+	} else if !adapterInstalled {
+		availability.Status = AvailabilityNotInstalled
+		availability.ReasonCode = firstNonBlank(runtimeResolution.ReasonCode, spec.AdapterUnavailableReasonCode, "acp_adapter_not_found")
+		actions = append(actions, daemonAction(ActionInstall))
+	} else if adapterLaunchFailed {
+		availability.Status = AvailabilityNotInstalled
+		availability.ReasonCode = "acp_adapter_launch_failed"
+		actions = append(actions, daemonAction(ActionInstall))
+	} else if !adapterReady {
+		availability.Status = AvailabilityNotInstalled
+		availability.ReasonCode = "acp_adapter_version_mismatch"
+		actions = append(actions, daemonAction(ActionInstall))
+	} else if isCodexStatusSpec(spec) && !codexPlatformOK {
+		availability.Status = AvailabilityNotInstalled
+		availability.ReasonCode = codexReasonCodeFromErrorCode(string(CodexErrPlatformPkgIncomplete))
+		actions = append(actions, daemonAction(ActionInstall))
+	} else if isCodexStatusSpec(spec) && !cliVersionMeetsMinimum(cliVersion, spec.MinVersion) {
+		availability.Status = AvailabilityNotInstalled
+		availability.ReasonCode = codexReasonCodeFromErrorCode(string(CodexErrVersionTooOld))
+		actions = append(actions, daemonAction(ActionInstall))
+	} else {
+		if spec.LoginActionKind == ActionKindDaemonAction {
+			actions = append(actions, daemonAction(ActionLogin))
+		} else {
+			actions = append(actions, terminalAction(ActionLogin, loginCommandForRuntime(spec, runtimeResolution)))
+		}
+
+		// Claude Code can run in API Usage Billing mode — an API key, an auth
+		// token, or an apiKeyHelper — which bills usage to an API account and
+		// overrides any stored OAuth/subscription session. `claude auth status`
+		// only reflects the stored session, so it is blind to these env/settings
+		// credentials; detect them directly and prefer that signal over whatever
+		// the CLI reports, so the wizard shows "已配置 API 计费" instead of a
+		// stale OAuth label or "未登录". A bare custom endpoint without a
+		// credential is NOT API billing (the user may still be on an OAuth
+		// session), so it does not trigger this override.
+		if isClaudeStatusSpec(spec) && s.providerHasAPICredential(spec.Provider) {
+			auth.Status = AuthAuthenticated
+			auth.AccountLabel = "API Usage Billing"
+			auth.AuthMethod = "apiKey"
+		} else {
+			switch auth.Status {
+			case AuthAuthenticated:
+				// already ready
+			case AuthRequired:
+				availability.Status = AvailabilityAuthRequired
+				availability.ReasonCode = "auth_required"
+				actions = append(actions, Action{ID: ActionRefresh, Kind: ActionKindRefresh})
+			case AuthUnknown:
+				availability.Status = AvailabilityAuthRequired
+				availability.ReasonCode = "auth_unknown"
+				actions = append(actions, Action{ID: ActionRefresh, Kind: ActionKindRefresh})
+			}
+		}
+	}
+
+	status := ProviderStatus{
+		Provider:     spec.Provider,
+		Availability: availability,
+		CLI: CLIStatus{
+			Installed:  installed,
+			BinaryPath: runtimeResolution.CLIPath,
+			Version:    cliVersion,
+		},
+		Adapter: AdapterStatus{
+			Installed:       adapterReady,
+			BinaryPath:      runtimeResolution.AdapterPath,
+			Command:         cloneStrings(runtimeResolution.AdapterCommand),
+			Version:         runtimeResolution.AdapterVersion,
+			RequiredVersion: spec.AdapterPackage.Version,
+		},
+		Auth:    auth,
+		Actions: actions,
+	}
+	status.ActiveAction = activeActionForProvider(spec.Provider)
+	if status.ActiveAction != nil {
+		bytes, lines := activeActionOutputStats(status.ActiveAction.Stdout)
+		slog.Info(
+			"agent provider status attached active action",
+			"event", "tutti.agent_provider.status.active_action_attached",
+			"provider", spec.Provider,
+			"availability", status.Availability.Status,
+			"reasonCode", status.Availability.ReasonCode,
+			"step", status.ActiveAction.Step,
+			"registryPresent", strings.TrimSpace(status.ActiveAction.Registry) != "",
+			"stdoutBytes", bytes,
+			"stdoutLines", lines,
+		)
+	}
+	if isClaudeStatusSpec(spec) {
+		slog.Info(
+			"claude-code agent provider status checked",
+			"event", "tutti.agent_provider.status.checked",
+			"provider", spec.Provider,
+			"availability", status.Availability.Status,
+			"reasonCode", status.Availability.ReasonCode,
+			"authStatus", status.Auth.Status,
+			"authMethod", status.Auth.AuthMethod,
+			"cliInstalled", status.CLI.Installed,
+			"cliVersion", status.CLI.Version,
+			"sdkSidecarInstalled", status.Adapter.Installed,
+		)
+	}
+	if isCodexStatusSpec(spec) {
+		status.CLI.MinVersion = spec.MinVersion
+		status.Checks = codexProviderChecks(status, codexPlatformOK, s.codexNodeRuntimeCheck(spec))
+		status.LastError = codexProviderLastError(status)
+		slog.Info(
+			"codex agent provider status checked",
+			"availability", status.Availability.Status,
+			"reasonCode", status.Availability.ReasonCode,
+			"version", status.CLI.Version,
+			"lastErrorCode", providerLastErrorCode(status.LastError),
+			"missingPlatformPath", s.codexPlatformPackageMissingPath(runtimeResolution.CLIPath),
+		)
+	}
+	return status
+}
+
+func (s Service) shouldProbeAdapterCommandForStatus(spec ProviderSpec, runtimeResolution providerRuntimeResolution) bool {
+	if strings.TrimSpace(spec.ExternalRegistryID) != "" {
+		return true
+	}
+	return isCodexStatusSpec(spec) && s.executableFile(runtimeResolution.AdapterPath)
+}
+
+func (s Service) probeReadyAfterForSpec(spec ProviderSpec) time.Duration {
+	if strings.TrimSpace(spec.ExternalRegistryID) != "" && spec.AdapterInstall.RegistryNPM != nil {
+		return externalRegistryNPMProbeReadyAfter(s.probeTimeout())
+	}
+	return s.probeReadyAfter()
+}
+
+func agentNPMRegistryProbePackage(spec ProviderSpec) string {
+	if strings.TrimSpace(spec.NPMRegistryPackage) != "" {
+		return strings.TrimSpace(spec.NPMRegistryPackage)
+	}
+	if spec.AdapterInstall.RegistryNPM != nil {
+		packageName, _ := splitNPMPackageSpec(spec.AdapterInstall.RegistryNPM.Package)
+		if strings.TrimSpace(packageName) != "" {
+			return packageName
+		}
+	}
+	if spec.Install.RegistryNPM != nil {
+		packageName, _ := splitNPMPackageSpec(spec.Install.RegistryNPM.Package)
+		if strings.TrimSpace(packageName) != "" {
+			return packageName
+		}
+	}
+	return "@openai/codex"
+}
+
+func externalRegistryNPMProbeReadyAfter(timeout time.Duration) time.Duration {
+	if timeout <= 0 {
+		timeout = defaultProbeTimeout
+	}
+	if timeout <= 200*time.Millisecond {
+		return timeout / 2
+	}
+	return timeout - externalRegistryNPMProbeTimeoutPadding
+}
+
+func agentProviderProbeAdapterUnavailableMessage(reasonCode string) string {
+	switch strings.TrimSpace(reasonCode) {
+	case "acp_adapter_version_mismatch":
+		return "ACP adapter version does not match the required package version"
+	case "acp_adapter_launch_failed":
+		return "ACP adapter command failed to start"
+	case ReasonExternalAgentRegistryUnavailable:
+		return "ACP external agent registry is unavailable"
+	case ReasonManagedRuntimeUnavailable:
+		return "Managed Node runtime is unavailable"
+	case ReasonClaudeSDKSidecarUnavailable:
+		return "Claude SDK sidecar not found"
+	default:
+		return "ACP adapter not found"
+	}
+}

--- a/services/tuttid/service/agentstatus/service_status.go
+++ b/services/tuttid/service/agentstatus/service_status.go
@@ -13,11 +13,42 @@ import (
 // concurrently for different specs: it only reads Service configuration, and
 // the shared stores it touches (RunOutcomes, the active-action table) are
 // internally synchronized.
-func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.Time) ProviderStatus {
-	if status, ok := unsupportedProviderStatus(spec, now); ok {
-		return status
+func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.Time) (status ProviderStatus) {
+	startedAt := time.Now()
+	var runtimeResolutionDuration time.Duration
+	var adapterProbeDuration time.Duration
+	var authDuration time.Duration
+	var cliVersionDuration time.Duration
+	var postChecksDuration time.Duration
+	adapterProbeRan := false
+	cliVersionRan := false
+	unsupported := false
+	defer func() {
+		slog.Info(
+			"agent provider status detection completed",
+			"event", "tutti.agent_provider.status_detection.completed",
+			"provider", spec.Provider,
+			"availability", status.Availability.Status,
+			"reasonCode", status.Availability.ReasonCode,
+			"durationMs", time.Since(startedAt).Milliseconds(),
+			"runtimeResolutionMs", runtimeResolutionDuration.Milliseconds(),
+			"adapterProbeRan", adapterProbeRan,
+			"adapterProbeMs", adapterProbeDuration.Milliseconds(),
+			"authMs", authDuration.Milliseconds(),
+			"cliVersionRan", cliVersionRan,
+			"cliVersionMs", cliVersionDuration.Milliseconds(),
+			"postChecksMs", postChecksDuration.Milliseconds(),
+			"unsupported", unsupported,
+		)
+	}()
+
+	if unsupportedStatus, ok := unsupportedProviderStatus(spec, now); ok {
+		unsupported = true
+		return unsupportedStatus
 	}
+	runtimeResolutionStartedAt := time.Now()
 	runtimeResolution := s.resolveProviderRuntime(ctx, spec)
+	runtimeResolutionDuration = time.Since(runtimeResolutionStartedAt)
 	installed := strings.TrimSpace(runtimeResolution.CLIPath) != ""
 	adapterInstalled := strings.TrimSpace(runtimeResolution.AdapterPath) != ""
 	adapterReady := adapterInstalled && adapterPackageRequirementSatisfied(spec.AdapterPackage, runtimeResolution.AdapterVersion)
@@ -31,25 +62,34 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 	cliVersion := ""
 	var checks errgroup.Group
 	if installed && adapterReady && s.shouldProbeAdapterCommandForStatus(spec, runtimeResolution) {
+		adapterProbeRan = true
 		checks.Go(func() error {
+			probeStartedAt := time.Now()
 			if probe := s.probeAdapterRuntimeCommand(ctx, spec, runtimeResolution, now); probe.Status == ProbeFailed {
 				adapterReady = false
 				adapterLaunchFailed = true
 			}
+			adapterProbeDuration = time.Since(probeStartedAt)
 			return nil
 		})
 	}
 	checks.Go(func() error {
+		authStartedAt := time.Now()
 		auth = s.resolveAuth(ctx, spec, installed, runtimeResolution.CLIPath)
+		authDuration = time.Since(authStartedAt)
 		return nil
 	})
 	if installed {
+		cliVersionRan = true
 		checks.Go(func() error {
+			cliVersionStartedAt := time.Now()
 			cliVersion = s.cliVersion(ctx, runtimeResolution.CLIPath, runtimeResolution.Env)
+			cliVersionDuration = time.Since(cliVersionStartedAt)
 			return nil
 		})
 	}
 	_ = checks.Wait()
+	postChecksStartedAt := time.Now()
 
 	codexPlatformOK := true
 	if isCodexStatusSpec(spec) && installed {
@@ -121,7 +161,7 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 		}
 	}
 
-	status := ProviderStatus{
+	status = ProviderStatus{
 		Provider:     spec.Provider,
 		Availability: availability,
 		CLI: CLIStatus{
@@ -181,6 +221,7 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 			"missingPlatformPath", s.codexPlatformPackageMissingPath(runtimeResolution.CLIPath),
 		)
 	}
+	postChecksDuration = time.Since(postChecksStartedAt)
 	return status
 }
 

--- a/services/tuttid/service/agentstatus/service_status_test.go
+++ b/services/tuttid/service/agentstatus/service_status_test.go
@@ -1,0 +1,77 @@
+package agentstatus
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestServiceListDetectsProvidersConcurrently proves provider detection fans
+// out instead of running serially: each provider's auth status command blocks
+// until every requested provider has entered its own command. Serial detection
+// would never let the second provider start, so the rendezvous would time out.
+func TestServiceListDetectsProvidersConcurrently(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	service := testService(func(name string) (string, error) {
+		return "/usr/local/bin/" + name, nil
+	}, map[string]bool{})
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	service.RunAuthStatusCommand = func(ctx context.Context, spec ProviderSpec, _ string) (AuthInfo, bool) {
+		started <- spec.Provider
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		return AuthInfo{Status: AuthAuthenticated}, true
+	}
+
+	type listResult struct {
+		snapshot Snapshot
+		err      error
+	}
+	done := make(chan listResult, 1)
+	go func() {
+		snapshot, err := service.List(ctx, ListInput{Providers: []string{"codex", "cursor"}})
+		done <- listResult{snapshot: snapshot, err: err}
+	}()
+
+	seen := map[string]bool{}
+	for len(seen) < 2 {
+		select {
+		case provider := <-started:
+			seen[provider] = true
+		case <-ctx.Done():
+			t.Fatalf("detection did not run concurrently; providers seen before rendezvous: %v", seen)
+		}
+	}
+	close(release)
+
+	var result listResult
+	select {
+	case result = <-done:
+	case <-ctx.Done():
+		t.Fatal("provider detection did not finish after rendezvous release")
+	}
+	if result.err != nil {
+		t.Fatalf("List() error = %v", result.err)
+	}
+	if len(result.snapshot.Providers) != 2 {
+		t.Fatalf("Providers length = %d, want 2", len(result.snapshot.Providers))
+	}
+	// Concurrent detection must not reorder the response: slots follow the
+	// requested provider order.
+	if result.snapshot.Providers[0].Provider != "codex" {
+		t.Fatalf("Providers[0] = %q, want codex", result.snapshot.Providers[0].Provider)
+	}
+	if result.snapshot.Providers[1].Provider != "cursor" {
+		t.Fatalf("Providers[1] = %q, want cursor", result.snapshot.Providers[1].Provider)
+	}
+	for _, status := range result.snapshot.Providers {
+		if status.Auth.Status != AuthAuthenticated {
+			t.Fatalf("Auth.Status for %q = %q, want %q", status.Provider, status.Auth.Status, AuthAuthenticated)
+		}
+	}
+}

--- a/services/tuttid/service/agentstatus/service_status_test.go
+++ b/services/tuttid/service/agentstatus/service_status_test.go
@@ -1,7 +1,11 @@
 package agentstatus
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 )
@@ -72,6 +76,42 @@ func TestServiceListDetectsProvidersConcurrently(t *testing.T) {
 	for _, status := range result.snapshot.Providers {
 		if status.Auth.Status != AuthAuthenticated {
 			t.Fatalf("Auth.Status for %q = %q, want %q", status.Provider, status.Auth.Status, AuthAuthenticated)
+		}
+	}
+}
+
+func TestServiceListLogsProviderDetectionTimings(t *testing.T) {
+	var output bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&output, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	service := testService(func(string) (string, error) {
+		return "", errors.New("not found")
+	}, map[string]bool{})
+	if _, err := service.List(t.Context(), ListInput{Providers: []string{"codex"}}); err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	logOutput := output.String()
+	for _, field := range []string{
+		"event=tutti.agent_provider.status_detection.completed",
+		"provider=codex",
+		"durationMs=",
+		"runtimeResolutionMs=",
+		"adapterProbeMs=",
+		"authMs=",
+		"cliVersionMs=",
+		"postChecksMs=",
+		"event=tutti.agent_provider.status_list.completed",
+		"requestedProviderCount=1",
+		"providerCount=1",
+		"success=true",
+	} {
+		if !strings.Contains(logOutput, field) {
+			t.Fatalf("status timing log missing %q:\n%s", field, logOutput)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- detect up to four providers concurrently while preserving registry order
- run adapter launch, authentication, and CLI version checks concurrently per provider
- log Renderer provider-status request start, completion, failure, cache hit, and in-flight reuse
- log daemon batch totals plus per-provider runtime, adapter, auth, version, and post-check durations
- keep diagnostics privacy-safe and document how to isolate slow startup phases

## Motivation

AgentGUI startup waits for the required provider status before the composer becomes ready. Serial subprocess checks add their latency together, and a background catalog scan compounds that cost across providers. This change reduces each provider to roughly its slowest independent check and leaves enough timing evidence to distinguish Renderer/transport delay from daemon/provider detection when users report slow startup.

## Validation

- `go test -race ./service/agentstatus`
- focused Desktop provider-status service test: 39/39 passed
- `pnpm check:changed --tail-lines 120`
- `pnpm check:full` after rebasing onto current `origin/main`: 18/18 tasks passed
- pre-commit DCO, formatting, lint, Renderer/UI boundary checks passed

## Documentation impact

Improved `docs/conventions/troubleshooting/workbench-renderer.md` with exact event names, correlation guidance, timing interpretation, and privacy boundaries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelizes provider status detection and adds precise timing diagnostics to speed up and debug AgentGUI startup. Detects up to four providers concurrently while preserving registry order, and logs per-provider and batch timings in the daemon and renderer.

- **Performance**
  - Detect up to 4 providers concurrently using a bounded `errgroup`; preserve registry selection order. Within each provider, run adapter probe, auth status, and CLI `--version` checks in parallel.
  - Daemon logs: `tutti.agent_provider.status_detection.completed` per provider with step breakdowns (runtime, adapter probe, auth, CLI version, post-check) and `tutti.agent_provider.status_list.completed` for batch totals.
  - Renderer logs: `agent_provider_status.request.started|resolved|failed|cache_hit|reused` with durations, scope, provider counts, and request IDs; error messages are not recorded. Also logs `agent_provider_status.active_action_snapshot` and pending action add/remove events.
  - Bound subprocess fan-out for more consistent startup on slower machines.

- **Refactors**
  - Moved provider status logic to `service_status.go`; simplified `service.go`.
  - Introduced `DesktopAgentProviderStatusDiagnostics` for request/env telemetry and renderer diagnostics; integrated into `desktopAgentProviderStatusService`.
  - Added tests for concurrent detection, ordering, timing logs, and renderer log privacy; made the network probe test counter race-safe using atomics. Updated troubleshooting docs to explain the new timing events.

<sup>Written for commit 698b2f1a6416a6bfcc9074f52b6cb7270daef864. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

