### PR TITLE
fix(agent): avoid transient unavailable states

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderReadinessGate.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderReadinessGate.test.ts
@@ -50,6 +50,22 @@ test("projectDesktopAgentProviderReadinessGates gates missing provider statuses 
   assert.equal(gates["claude-code"]?.status, "checking");
 });
 
+test("projectDesktopAgentProviderReadinessGates keeps missing providers checking in partial snapshots", () => {
+  const gates = projectDesktopAgentProviderReadinessGates({
+    snapshot: {
+      capturedAt: "2026-07-15T00:00:00.000Z",
+      defaultProvider: "codex",
+      error: null,
+      isLoading: false,
+      pendingActions: [],
+      statuses: [providerStatus("codex", "ready")]
+    }
+  });
+
+  assert.equal(gates.codex, null);
+  assert.equal(gates["claude-code"]?.status, "checking");
+});
+
 test("projectDesktopAgentProviderReadinessGates lets users retry missing statuses after a failed first check", () => {
   const gates = projectDesktopAgentProviderReadinessGates({
     snapshot: {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderReadinessGate.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderReadinessGate.ts
@@ -31,7 +31,6 @@ export function projectDesktopAgentProviderReadinessGates(input: {
   for (const provider of desktopManagedAgentProviders) {
     const agentGuiProvider = provider as AgentGUIProvider;
     const gate = projectDesktopAgentProviderReadinessGate({
-      captured: Boolean(input.snapshot.capturedAt),
       hasError: Boolean(input.snapshot.error),
       isLoading: input.snapshot.isLoading,
       pendingActions: input.snapshot.pendingActions,
@@ -55,7 +54,6 @@ export function projectDesktopAgentProviderReadinessGates(input: {
 }
 
 function projectDesktopAgentProviderReadinessGate(input: {
-  captured: boolean;
   hasError: boolean;
   isLoading: boolean;
   pendingActions: AgentProviderStatusSnapshot["pendingActions"];
@@ -64,10 +62,7 @@ function projectDesktopAgentProviderReadinessGate(input: {
 }): AgentGUIProviderReadinessGate | null {
   if (!input.status) {
     return {
-      status:
-        input.isLoading || (!input.captured && !input.hasError)
-          ? "checking"
-          : "unavailable",
+      status: input.hasError && !input.isLoading ? "unavailable" : "checking",
       pendingAction: pendingActionForProvider(
         input.pendingActions,
         input.provider

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2211,6 +2211,10 @@ User-visible rules:
   retry path that silently creates another session.
 - Deleted or filtered sessions should clear selection only through the
   selection fallback path; do not let a hidden row leave a stale detail pane.
+  User-confirmed deletion of the active session must commit that fallback
+  selection before dispatching the runtime deletion that tombstones the old
+  session. Do not suppress authoritative `not_found` presentation to hide a
+  selection/tombstone ordering bug.
 - Event-stream disconnect should not erase current transcript state. It should
   make live freshness uncertain until reconciliation succeeds.
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationBatchDeletion.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationBatchDeletion.spec.tsx
@@ -1,12 +1,13 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
 import type { AgentSessionEngine } from "@tutti-os/agent-activity-core";
 import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import { useAgentGUIConversationBatchDeletion } from "./useAgentGUIConversationBatchDeletion";
 
 function createInput(agentActivityRuntime: AgentActivityRuntime) {
   return {
-    activeConversationIdRef: { current: null },
+    activeConversationIdRef: { current: null as string | null },
     agentActivityRuntime,
     agentHostApi: { toast: { error: vi.fn() } } as never,
     conversationsRef: {
@@ -37,7 +38,6 @@ function createInput(agentActivityRuntime: AgentActivityRuntime) {
       workspaceId: "workspace-1"
     }),
     setActiveConversationId: vi.fn(),
-    setAgentSessionViewMessagesLoading: vi.fn(),
     setDetailError: vi.fn(),
     setDraftByScopeKey: vi.fn(),
     setIntent: vi.fn(),
@@ -133,5 +133,62 @@ describe("useAgentGUIConversationBatchDeletion", () => {
     expect(sessionIds).toEqual([]);
     await waitFor(() => expect(load).toHaveBeenCalledWith("workspace-1"));
     expect(runtime.deleteSessionsBatch).not.toHaveBeenCalled();
+  });
+
+  it("commits a surviving conversation before deleting a batch containing the active session", async () => {
+    let committedActiveConversationId: string | null = "loaded-session";
+    let activeConversationIdObservedByDelete: string | null = null;
+    const deleteSessionsBatch = vi.fn(async () => {
+      activeConversationIdObservedByDelete = committedActiveConversationId;
+      return {
+        removedMessages: 0,
+        removedSessionIds: ["loaded-session"],
+        removedSessions: 1
+      };
+    });
+    const runtime = {
+      deleteSession: vi.fn(),
+      deleteSessionsBatch
+    } as unknown as AgentActivityRuntime;
+    const input = createInput(runtime);
+    input.activeConversationIdRef.current = "loaded-session";
+    input.conversationsRef.current = [
+      ...input.conversationsRef.current,
+      {
+        cwd: "/workspace",
+        id: "surviving-session",
+        provider: "codex" as const,
+        sortTimeUnixMs: 2,
+        status: "completed" as const,
+        title: "Surviving",
+        titleFallback: null,
+        updatedAtUnixMs: 2,
+        userId: "user-1"
+      }
+    ];
+    const { result } = renderHook(() => {
+      const [activeConversationId, setActiveConversationId] = useState<
+        string | null
+      >("loaded-session");
+      committedActiveConversationId = activeConversationId;
+      return {
+        activeConversationId,
+        ...useAgentGUIConversationBatchDeletion({
+          ...input,
+          setActiveConversationId
+        })
+      };
+    });
+
+    act(() => result.current.confirmDeleteConversations(["loaded-session"]));
+
+    expect(result.current.activeConversationId).toBe("surviving-session");
+    expect(activeConversationIdObservedByDelete).toBe("surviving-session");
+    expect(input.persistActiveConversation).toHaveBeenCalledWith(
+      "surviving-session"
+    );
+    await waitFor(() =>
+      expect(input.removeConversations).toHaveBeenCalledWith(["loaded-session"])
+    );
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationBatchDeletion.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationBatchDeletion.ts
@@ -4,6 +4,7 @@ import {
   type RefObject,
   type SetStateAction
 } from "react";
+import { flushSync } from "react-dom";
 import type { AgentSessionEngine } from "@tutti-os/agent-activity-core";
 import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import type { useAgentHostApi } from "../../../agentActivityHost";
@@ -51,10 +52,6 @@ export interface UseAgentGUIConversationBatchDeletionInput {
   removeConversations: (conversationIds: readonly string[]) => void;
   workspaceId: string;
   setIsDeletingProjectConversations: Dispatch<SetStateAction<boolean>>;
-  setAgentSessionViewMessagesLoading: (
-    ref: AgentSessionViewRef,
-    value: boolean
-  ) => void;
   agentActivityRuntime: AgentActivityRuntime;
   dataRef: RefObject<AgentGUINodeData>;
   agentHostApi: ReturnType<typeof useAgentHostApi>;
@@ -82,7 +79,6 @@ export function useAgentGUIConversationBatchDeletion(
     removeConversations,
     workspaceId,
     setIsDeletingProjectConversations,
-    setAgentSessionViewMessagesLoading,
     agentActivityRuntime,
     dataRef,
     agentHostApi
@@ -112,31 +108,15 @@ export function useAgentGUIConversationBatchDeletion(
           type: "queue/sessionCleaned"
         });
       }
-      const nextConversations = conversationsRef.current.filter(
-        (conversation) => !targetIds.has(conversation.id)
-      );
-      const currentActiveId = activeConversationIdRef.current;
-      if (currentActiveId && targetIds.has(currentActiveId)) {
-        const nextActive = nextConversations[0]?.id ?? null;
-        if (nextActive) {
-          markSelectedConversationDetailPending(nextActive);
-          setIntent({ tag: "active", id: nextActive });
-        } else {
-          setIsLoadingMessages(false);
-          setIntent({ tag: "home" });
-        }
-        activeConversationIdRef.current = nextActive;
-        setActiveConversationId(nextActive);
-        persistActiveConversation(nextActive);
-      }
       removeConversations([...targetIds]);
     },
     [
-      markSelectedConversationDetailPending,
-      persistActiveConversation,
+      deleteAgentSessionView,
+      removeConversations,
       sessionEngine,
       sessionViewRef,
-      removeConversations
+      setDraftByScopeKey,
+      submittedDraftSnapshotsRef
     ]
   );
 
@@ -214,11 +194,24 @@ export function useAgentGUIConversationBatchDeletion(
         activeDeletedConversationId &&
         targetIds.has(activeDeletedConversationId)
       ) {
-        setIsLoadingMessages(true);
-        setAgentSessionViewMessagesLoading(
-          sessionViewRef(activeDeletedConversationId),
-          true
-        );
+        const nextActive =
+          conversationsRef.current.find(
+            (conversation) => !targetIds.has(conversation.id)
+          )?.id ?? null;
+        if (nextActive) {
+          markSelectedConversationDetailPending(nextActive);
+        }
+        activeConversationIdRef.current = nextActive;
+        flushSync(() => {
+          if (nextActive) {
+            setIntent({ tag: "active", id: nextActive });
+          } else {
+            setIsLoadingMessages(false);
+            setIntent({ tag: "home" });
+          }
+          setActiveConversationId(nextActive);
+        });
+        persistActiveConversation(nextActive);
       }
       void deleteSessionsBatch({
         sessionIds: [...targetIds],
@@ -243,27 +236,27 @@ export function useAgentGUIConversationBatchDeletion(
           });
           setListError(message);
           showAgentGUIControllerErrorToast(agentHostApi.toast, message);
-          if (
-            activeDeletedConversationId &&
-            activeConversationIdRef.current === activeDeletedConversationId
-          ) {
-            setIsLoadingMessages(false);
-            setAgentSessionViewMessagesLoading(
-              sessionViewRef(activeDeletedConversationId),
-              false
-            );
-          }
         })
         .finally(() => {
           setIsDeletingProjectConversations(false);
         });
     },
     [
+      activeConversationIdRef,
       agentActivityRuntime,
+      agentHostApi.toast,
+      conversationsRef,
+      dataRef,
       finalizeConversationBatchDeletion,
       isDeletingProjectConversations,
-      sessionViewRef,
-      agentHostApi.toast,
+      markSelectedConversationDetailPending,
+      persistActiveConversation,
+      setActiveConversationId,
+      setDetailError,
+      setIntent,
+      setIsDeletingProjectConversations,
+      setIsLoadingMessages,
+      setListError,
       workspaceId
     ]
   );

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDeletion.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDeletion.spec.tsx
@@ -1,0 +1,143 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import type { AgentSessionEngine } from "@tutti-os/agent-activity-core";
+import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
+import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
+import { useAgentGUIConversationDeletion } from "./useAgentGUIConversationDeletion";
+
+const targetConversation: AgentGUIConversationSummary = {
+  cwd: "/workspace",
+  id: "session-1",
+  provider: "codex",
+  sortTimeUnixMs: 2,
+  status: "completed",
+  title: "Session 1",
+  titleFallback: null,
+  updatedAtUnixMs: 2,
+  userId: "user-1"
+};
+
+const nextConversation: AgentGUIConversationSummary = {
+  ...targetConversation,
+  id: "session-2",
+  sortTimeUnixMs: 1,
+  title: "Session 2",
+  updatedAtUnixMs: 1
+};
+
+function createInput(agentActivityRuntime: AgentActivityRuntime) {
+  const activeConversationIdRef = { current: targetConversation.id };
+  const unactivate = vi.fn(async () => {});
+  const toastError = vi.fn();
+  const input = {
+    activeConversationIdRef,
+    activation: { unactivate } as never,
+    agentActivityRuntime,
+    agentHostApi: { toast: { error: toastError } } as never,
+    conversations: [targetConversation, nextConversation],
+    conversationsRef: {
+      current: [targetConversation, nextConversation]
+    },
+    deleteAgentSessionView: vi.fn(),
+    isDeletingConversation: false,
+    markSelectedConversationDetailPending: vi.fn(() => null),
+    pendingDeleteConversation: targetConversation,
+    persistActiveConversation: vi.fn(),
+    removeConversations: vi.fn(),
+    sessionEngine: { dispatch: vi.fn() } as unknown as AgentSessionEngine,
+    sessionViewRef: (agentSessionId: string | null | undefined) => ({
+      agentSessionId,
+      origin: "local",
+      workspaceId: "workspace-1"
+    }),
+    setActiveConversationId: vi.fn(),
+    setDetailError: vi.fn(),
+    setDraftByScopeKey: vi.fn(),
+    setIntent: vi.fn(),
+    setIsDeletingConversation: vi.fn(),
+    setIsLoadingMessages: vi.fn(),
+    setPendingDeleteConversation: vi.fn(),
+    submittedDraftSnapshotsRef: { current: {} },
+    workspaceId: "workspace-1"
+  };
+  return { input, toastError, unactivate };
+}
+
+describe("useAgentGUIConversationDeletion", () => {
+  it("commits the next conversation selection before deleting the active session", async () => {
+    let committedActiveConversationId: string | null = targetConversation.id;
+    let activeConversationIdObservedByDelete: string | null = null;
+    const deleteSession = vi.fn(async () => {
+      activeConversationIdObservedByDelete = committedActiveConversationId;
+      return {
+        removed: true,
+        removedMessages: 0
+      };
+    });
+    const { input, unactivate } = createInput({
+      deleteSession
+    } as unknown as AgentActivityRuntime);
+    const { result } = renderHook(() => {
+      const [activeConversationId, setActiveConversationId] = useState<
+        string | null
+      >(targetConversation.id);
+      committedActiveConversationId = activeConversationId;
+      return {
+        activeConversationId,
+        ...useAgentGUIConversationDeletion({
+          ...input,
+          setActiveConversationId
+        })
+      };
+    });
+
+    act(() => result.current.confirmDeleteConversation());
+
+    expect(result.current.activeConversationId).toBe(nextConversation.id);
+    expect(input.persistActiveConversation).toHaveBeenCalledWith(
+      nextConversation.id
+    );
+    expect(unactivate).toHaveBeenCalledWith(targetConversation.id);
+    await waitFor(() => expect(deleteSession).toHaveBeenCalledTimes(1));
+    expect(activeConversationIdObservedByDelete).toBe(nextConversation.id);
+    expect(deleteSession).toHaveBeenCalledWith({
+      agentSessionId: targetConversation.id,
+      workspaceId: "workspace-1"
+    });
+    await waitFor(() =>
+      expect(input.removeConversations).toHaveBeenCalledWith([
+        targetConversation.id
+      ])
+    );
+  });
+
+  it("keeps the committed fallback selection when deletion fails", async () => {
+    const deleteSession = vi.fn(async () => {
+      throw new Error("delete failed");
+    });
+    const { input, toastError } = createInput({
+      deleteSession
+    } as unknown as AgentActivityRuntime);
+    const { result } = renderHook(() => {
+      const [activeConversationId, setActiveConversationId] = useState<
+        string | null
+      >(targetConversation.id);
+      return {
+        activeConversationId,
+        ...useAgentGUIConversationDeletion({
+          ...input,
+          setActiveConversationId
+        })
+      };
+    });
+
+    act(() => result.current.confirmDeleteConversation());
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(1));
+    expect(result.current.activeConversationId).toBe(nextConversation.id);
+    expect(input.activeConversationIdRef.current).toBe(nextConversation.id);
+    expect(input.removeConversations).not.toHaveBeenCalled();
+    expect(input.setIsDeletingConversation).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDeletion.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDeletion.ts
@@ -4,12 +4,12 @@ import {
   type RefObject,
   type SetStateAction
 } from "react";
+import { flushSync } from "react-dom";
 import type { AgentSessionEngine } from "@tutti-os/agent-activity-core";
 import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import type { useAgentHostApi } from "../../../agentActivityHost";
 import type { AgentSessionViewRef } from "../../../contexts/workspace/presentation/renderer/agentSessions/useAgentSessionTransport";
 import type { useAgentGUIActivation } from "./useAgentGUIActivation";
-import { type AgentGUIConversationListQuery } from "../../../contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList";
 import { type AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
 import type {
   AgentComposerDraft,
@@ -35,10 +35,6 @@ export interface UseAgentGUIConversationDeletionInput {
   setIsDeletingConversation: Dispatch<SetStateAction<boolean>>;
   activeConversationIdRef: RefObject<string | null>;
   setIsLoadingMessages: Dispatch<SetStateAction<boolean>>;
-  setAgentSessionViewMessagesLoading: (
-    ref: AgentSessionViewRef,
-    value: boolean
-  ) => void;
   sessionViewRef: (agentSessionId: string | null | undefined) => {
     workspaceId: string;
     agentSessionId: string | null | undefined;
@@ -61,7 +57,6 @@ export interface UseAgentGUIConversationDeletionInput {
   persistActiveConversation: (agentSessionId: string | null) => void;
   removeConversations: (conversationIds: readonly string[]) => void;
   agentHostApi: ReturnType<typeof useAgentHostApi>;
-  conversationListQuery: AgentGUIConversationListQuery | null;
   workspaceId: string;
 }
 
@@ -77,7 +72,6 @@ export function useAgentGUIConversationDeletion(
     setIsDeletingConversation,
     activeConversationIdRef,
     setIsLoadingMessages,
-    setAgentSessionViewMessagesLoading,
     sessionViewRef,
     activation,
     agentActivityRuntime,
@@ -92,10 +86,8 @@ export function useAgentGUIConversationDeletion(
     persistActiveConversation,
     removeConversations,
     agentHostApi,
-    conversationListQuery,
     workspaceId
   } = input;
-
   const requestDeleteConversation = useCallback(
     (agentSessionId: string) => {
       const normalized = agentSessionId.trim();
@@ -129,8 +121,31 @@ export function useAgentGUIConversationDeletion(
     setIsDeletingConversation(true);
     setDetailError(null);
     if (activeConversationIdRef.current === target.id) {
-      setIsLoadingMessages(true);
-      setAgentSessionViewMessagesLoading(sessionViewRef(target.id), true);
+      const currentConversations = conversationsRef.current;
+      const targetIndex = currentConversations.findIndex(
+        (conversation) => conversation.id === target.id
+      );
+      const nextConversations = currentConversations.filter(
+        (conversation) => conversation.id !== target.id
+      );
+      const nextActive =
+        nextConversations[Math.max(0, targetIndex)]?.id ??
+        nextConversations[Math.max(0, targetIndex - 1)]?.id ??
+        null;
+      if (nextActive) {
+        markSelectedConversationDetailPending(nextActive);
+      }
+      activeConversationIdRef.current = nextActive;
+      flushSync(() => {
+        if (nextActive) {
+          setIntent({ tag: "active", id: nextActive });
+        } else {
+          setIsLoadingMessages(false);
+          setIntent({ tag: "home" });
+        }
+        setActiveConversationId(nextActive);
+      });
+      persistActiveConversation(nextActive);
     }
     void activation
       .unactivate(target.id)
@@ -159,29 +174,6 @@ export function useAgentGUIConversationDeletion(
           type: "queue/sessionCleaned"
         });
         deleteAgentSessionView(sessionViewRef(target.id));
-        const currentConversations = conversationsRef.current;
-        const targetIndex = currentConversations.findIndex(
-          (conversation) => conversation.id === target.id
-        );
-        const nextConversations = currentConversations.filter(
-          (conversation) => conversation.id !== target.id
-        );
-        if (activeConversationIdRef.current === target.id) {
-          const nextActive =
-            nextConversations[Math.max(0, targetIndex)]?.id ??
-            nextConversations[Math.max(0, targetIndex - 1)]?.id ??
-            null;
-          if (nextActive) {
-            markSelectedConversationDetailPending(nextActive);
-            setIntent({ tag: "active", id: nextActive });
-          } else {
-            setIsLoadingMessages(false);
-            setIntent({ tag: "home" });
-          }
-          activeConversationIdRef.current = nextActive;
-          setActiveConversationId(nextActive);
-          persistActiveConversation(nextActive);
-        }
         removeConversations([target.id]);
         setPendingDeleteConversation(null);
       })
@@ -196,27 +188,33 @@ export function useAgentGUIConversationDeletion(
           workspaceId
         });
         showAgentGUIControllerErrorToast(agentHostApi.toast, message);
-        if (activeConversationIdRef.current === target.id) {
-          setIsLoadingMessages(false);
-          setAgentSessionViewMessagesLoading(sessionViewRef(target.id), false);
-        }
       })
       .finally(() => {
         setIsDeletingConversation(false);
       });
   }, [
     activation,
-    conversationListQuery,
-    isDeletingConversation,
-    pendingDeleteConversation,
-    markSelectedConversationDetailPending,
-    persistActiveConversation,
-    workspaceId,
-    sessionViewRef,
+    activeConversationIdRef,
     agentActivityRuntime,
     agentHostApi.toast,
+    conversationsRef,
+    deleteAgentSessionView,
+    isDeletingConversation,
+    markSelectedConversationDetailPending,
+    pendingDeleteConversation,
+    persistActiveConversation,
+    removeConversations,
     sessionEngine,
-    removeConversations
+    sessionViewRef,
+    setActiveConversationId,
+    setDetailError,
+    setDraftByScopeKey,
+    setIntent,
+    setIsDeletingConversation,
+    setIsLoadingMessages,
+    setPendingDeleteConversation,
+    submittedDraftSnapshotsRef,
+    workspaceId
   ]);
 
   return {


### PR DESCRIPTION
## Summary

- Keep providers absent from progressive readiness snapshots in the checking state, preventing a false unavailable message during startup.
- Commit the fallback conversation selection before deleting the active runtime session, preventing the old detail pane from flashing unavailable.
- Apply the deletion ordering to both single and batch deletion, with focused regression tests and an AgentGUI architecture note.

## Verification

- `pnpm check:changed --tail-lines 80`
- `pnpm --filter @tutti-os/desktop build`
- Focused AgentGUI deletion tests: 5 passed
- Focused desktop readiness tests: 4 passed
- Pre-push `pnpm check:full`: 18 tasks passed

## Fix Scope Justification

- Root cause: progressive provider status snapshots were treated as complete once captured, and active conversations were tombstoned before React committed their fallback selection.
- Why can this not be fixed at a lower layer? Partial provider snapshots and authoritative session `not_found` tombstones are correct runtime contracts. Suppressing either below the presentation/controller layer would hide legitimate state. The fix therefore corrects readiness projection and deletion ordering at their owning layers; most added lines are regression tests.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes transient "unavailable" UI states on startup and during conversation deletion. Missing provider statuses now stay "checking," and deletion commits the next selection before runtime tombstones to remove flicker.

- **Bug Fixes**
  - Provider readiness: Missing statuses in partial snapshots remain "checking"; show "unavailable" only when there’s an error and not loading. Added desktop tests for partial snapshots.
  - Conversation deletion (single and batch): Compute fallback selection, mark pending, flushSync to commit and persist it, then call runtime deletion. The delete sees the new active ID; on failure, keep the committed selection. Added targeted tests and updated the AgentGUI architecture note.

<sup>Written for commit b60a7f73b0a5a32b9d38dba119ded2d02f30500d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

