### PR TITLE
fix(agent): protect model catalog metadata

### DIFF
--- a/packages/agent/runtimeprep/policy_templates/tutti-runtime.md
+++ b/packages/agent/runtimeprep/policy_templates/tutti-runtime.md
@@ -7,6 +7,12 @@
 - session: `{{AGENT_SESSION_ID}}`
 - provider: `{{PROVIDER}}`
 
+## Model Identity
+
+- Use the declared product identity; never infer an underlying model family, version, or provider from behavior, tools, config, caches, or files.
+- When asked which models are available, do not list, infer, or retrieve a catalog. Say availability depends on the product, account, plan, and access policy; direct the user to Tutti's model selector.
+- Trusted runtime metadata may identify only the selected model. Do not extrapolate other models or inspect tools/local state solely to answer identity or catalog questions.
+
 {{ENVIRONMENT_POLICY_SECTIONS}}
 
 ## Mention Routing

--- a/packages/agent/runtimeprep/provider_skill_test.go
+++ b/packages/agent/runtimeprep/provider_skill_test.go
@@ -133,6 +133,11 @@ func TestTuttiCLIPolicyUsesPreparedCLICommandForAgentCatalogHandoff(t *testing.T
 		"## CLI Reference",
 		"`tutti-dev <scope> --help`",
 		"App id mapping: read `command-guide.md` from visible `$tutti-cli` skill files.",
+		"## Model Identity",
+		"never infer an underlying model family, version, or provider",
+		"do not list, infer, or retrieve a catalog",
+		"direct the user to Tutti's model selector",
+		"inspect tools/local state solely to answer identity or catalog questions",
 	} {
 		if !strings.Contains(policy, want) {
 			t.Fatalf("tutti CLI policy missing %q: %q", want, policy)


### PR DESCRIPTION
## Summary

- add a model identity and availability policy to the run-scoped Tutti Agent `AGENTS.md`
- prevent assistants from inferring model identity from behavior, tools, config, caches, or files
- refuse model-catalog enumeration and direct users to the Tutti model selector
- add rendered-policy regression assertions

## Root cause

The Tutti runtime instructions did not define behavior for model identity or availability questions. Picker-visible model IDs embedded in tool descriptions could therefore be repeated as though they were the complete model catalog.

## Impact

Newly prepared AgentGUI runtimes receive the policy through the managed `AGENTS.md`. The policy does not change model routing, selection, or launcher behavior.

## Validation

- `go test ./...` in `packages/agent/runtimeprep`
- `go test ./...` in `packages/agent/store-sqlite`
- `go test ./...` in `packages/agent/daemon`
- `pnpm check:full` via the pre-push hook
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Protect model identity and availability metadata in the Tutti Agent by adding a Model Identity policy. Assistants now refuse model-catalog enumeration and point users to the Tutti model selector.

- **Bug Fixes**
  - Added a Model Identity section to `tutti-runtime.md` that forbids inferring model family/version/provider and listing or retrieving a catalog.
  - Instructed assistants to say availability depends on product, account, plan, and access policy; direct users to Tutti’s model selector.
  - Clarified that only the selected model may be identified via trusted runtime metadata; do not inspect tools/local state to answer identity or catalog questions.
  - Added regression tests to assert the rendered policy text in `packages/agent/runtimeprep`; no changes to model routing, selection, or launcher behavior.

<sup>Written for commit 6d6aed6534865b71c024f10ebb52c5cfe908088d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

