### PR TITLE
fix(tuttid): prevent concurrent state ownership

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ pnpm generate:defaults
 pnpm check:defaults-generated
 ```
 
-Run the main validation entrypoint before pushing:
+Full validation entrypoint:
 
 ```sh
 pnpm check:full
@@ -122,10 +122,9 @@ This appends a `Signed-off-by: Your Name <your@email>` line to the commit messag
 
 1. Fork the repository and create a branch from `main`. Suggested branch naming: `feat/...`, `fix/...`, `docs/...`
 2. Make your changes; keep each PR focused on a single concern
-3. Run `pnpm check:full` locally — `pre-push` hooks run it as well
-4. Open a PR with a clear description of the motivation and changes
-5. CI runs TypeScript linting, Go linting, typechecking, tests, and tooling consistency checks; all checks must pass
-6. A maintainer reviews your PR; please respond to feedback and keep the conversation in the PR
+3. Open a PR with a clear description of the motivation and changes
+4. CI runs TypeScript linting, Go linting, typechecking, tests, and tooling consistency checks; all checks must pass
+5. A maintainer reviews your PR; please respond to feedback and keep the conversation in the PR
 
 Local hooks use `husky`:
 

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -68,7 +68,7 @@ pnpm generate:defaults
 pnpm check:defaults-generated
 ```
 
-推送前运行主验证入口：
+完整验证入口：
 
 ```sh
 pnpm check:full
@@ -122,10 +122,9 @@ git commit -s -m "feat(scope): add something"
 
 1. Fork 仓库并从 `main` 创建分支。建议的分支命名：`feat/...`、`fix/...`、`docs/...`
 2. 完成你的改动；每个 PR 只关注一件事
-3. 本地运行 `pnpm check:full`——`pre-push` 钩子也会执行它
-4. 提交 PR，清晰描述动机与改动内容
-5. CI 会运行 TypeScript lint、Go lint、类型检查、测试和工具一致性检查；所有检查必须通过
-6. 维护者会 review 你的 PR；请回应反馈，并把讨论保留在 PR 中
+3. 提交 PR，清晰描述动机与改动内容
+4. CI 会运行 TypeScript lint、Go lint、类型检查、测试和工具一致性检查；所有检查必须通过
+5. 维护者会 review 你的 PR；请回应反馈，并把讨论保留在 PR 中
 
 本地钩子使用 `husky`：
 

--- a/CONTRIBUTING.zh-TW.md
+++ b/CONTRIBUTING.zh-TW.md
@@ -68,7 +68,7 @@ pnpm generate:defaults
 pnpm check:defaults-generated
 ```
 
-推送前執行主驗證入口：
+完整驗證入口：
 
 ```sh
 pnpm check:full
@@ -122,10 +122,9 @@ git commit -s -m "feat(scope): add something"
 
 1. Fork 儲存庫並從 `main` 建立分支。建議的分支命名：`feat/...`、`fix/...`、`docs/...`
 2. 完成你的變更；每個 PR 只聚焦一件事
-3. 本機執行 `pnpm check:full`——`pre-push` 鉤子也會執行它
-4. 送出 PR，清楚描述動機與變更內容
-5. CI 會執行 TypeScript lint、Go lint、型別檢查、測試和工具一致性檢查；所有檢查必須通過
-6. 維護者會 review 你的 PR；請回應回饋，並把討論保留在 PR 中
+3. 送出 PR，清楚描述動機與變更內容
+4. CI 會執行 TypeScript lint、Go lint、型別檢查、測試和工具一致性檢查；所有檢查必須通過
+5. 維護者會 review 你的 PR；請回應回饋，並把討論保留在 PR 中
 
 本機鉤子使用 `husky`：
 

--- a/docs/conventions/local-state-storage.md
+++ b/docs/conventions/local-state-storage.md
@@ -62,6 +62,7 @@ Production:
   run/
     tuttid.listener.json
     tuttid.pid
+    tuttid.pid.lock
 ```
 
 Local development:
@@ -78,11 +79,33 @@ Local development:
   run/
     tuttid.listener.json
     tuttid.pid
+    tuttid.pid.lock
 ```
 
 `tuttid.listener.json` is runtime endpoint metadata. It contains the loopback
 address and per-run bearer auth needed by local clients such as the bundled
 CLI, and should be written with restrictive file permissions.
+
+## Daemon State Ownership
+
+One state root has exactly one live `tuttid` owner. The daemon must acquire and
+hold an exclusive operating-system lock on `<state-dir>/run/tuttid.pid.lock` before
+initializing logging, recovering runtime locks, opening SQLite, running
+migrations, seeding system records, or publishing listener metadata. A second
+daemon targeting the same root must fail before touching durable state. The PID
+text remains available for desktop supervision and also protects upgrades from
+an older live daemon that did not yet hold the operating-system lock.
+
+Arguments that only inspect the daemon executable, such as `--help`, must exit
+before state-path creation or ownership acquisition. Unknown arguments must
+also fail without starting a daemon. Building or probing `tuttid` from an agent
+or terminal therefore cannot silently become another production daemon.
+
+Bare daemon execution defaults to production state. Development commands must
+set `TUTTI_ENV=development`, set an explicit `TUTTI_STATE_DIR`, or use the
+repository's managed development entry points. Environment separation and
+single-owner locking are complementary: separation prevents unintended access;
+locking prevents concurrent mutation after a root has been selected.
 
 Migrated agent runtime state should derive from the same root:
 
@@ -189,6 +212,7 @@ Tutti provider startup.
 - desktop-managed local development starts `tuttid` with `TUTTI_ENV=development`
 - packaged desktop builds start `tuttid` with `TUTTI_ENV=production`
 - path helpers reserve `<state-dir>/logs` and `<state-dir>/run` for daemon log, listener-info, and pid files
+- `tuttid` holds an exclusive lock on `<state-dir>/run/tuttid.pid.lock` for its full state-owning lifetime
 - desktop main-process operational logging defaults to `<state-dir>/logs/tutti-desktop.log`
 - desktop-to-daemon listener publication defaults to `<state-dir>/run/tuttid.listener.json`
 - the bundled CLI discovers the managed daemon by reading `<state-dir>/run/tuttid.listener.json`

--- a/docs/conventions/local-state-storage.md
+++ b/docs/conventions/local-state-storage.md
@@ -26,6 +26,10 @@ They are not the primary source of product defaults.
 
 Per-file overrides such as `TUTTID_DB_PATH` are still allowed for narrow operational needs, but new local storage code should derive paths from the shared generated defaults and shared state root first.
 
+`TUTTID_RUN_DIR` and `TUTTID_PID_PATH` redirect runtime metadata only. They do
+not redirect the state ownership lock, which is always derived from
+`TUTTI_STATE_DIR` as `<state-dir>/run/tuttid.pid.lock`.
+
 ## Allowed Override Surface
 
 Current supported override surface for local state and closely-related runtime paths:
@@ -92,9 +96,15 @@ One state root has exactly one live `tuttid` owner. The daemon must acquire and
 hold an exclusive operating-system lock on `<state-dir>/run/tuttid.pid.lock` before
 initializing logging, recovering runtime locks, opening SQLite, running
 migrations, seeding system records, or publishing listener metadata. A second
-daemon targeting the same root must fail before touching durable state. The PID
+daemon targeting the same root must fail before touching durable state, even if
+its pid or runtime metadata path is overridden. The PID
 text remains available for desktop supervision and also protects upgrades from
-an older live daemon that did not yet hold the operating-system lock.
+an older live daemon that did not yet hold the operating-system lock. Before a
+legacy PID blocks startup, the daemon verifies that the positive PID still
+identifies a `tuttid` executable; a reused PID owned by an unrelated process is
+stale metadata. Shutdown leaves the PID marker in place instead of racing a
+legacy writer with a non-atomic read-then-remove. The next owner validates and
+replaces that stale marker while holding the state-root lock.
 
 Arguments that only inspect the daemon executable, such as `--help`, must exit
 before state-path creation or ownership acquisition. Unknown arguments must

--- a/docs/conventions/runtime-overrides.md
+++ b/docs/conventions/runtime-overrides.md
@@ -13,17 +13,17 @@ Use the owner documents linked below for detailed behavior. This file exists to 
 
 ## Local State And Runtime Paths
 
-| Variable                    | Owner document                                                                                             | Purpose                                                                               |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `TUTTI_ENV`                 | [Local State Storage](./local-state-storage.md)                                                            | Selects production or development default state roots.                                |
-| `TUTTI_STATE_DIR`           | [Local State Storage](./local-state-storage.md)                                                            | Overrides the shared local state root.                                                |
-| `TUTTI_LOG_DIR`             | [Local State Storage](./local-state-storage.md), [Logging](./logging.md)                                   | Overrides the shared log directory under the state model.                             |
-| `TUTTID_DB_PATH`            | [Local State Storage](./local-state-storage.md)                                                            | Overrides the daemon SQLite database path for narrow operational needs.               |
-| `TUTTID_RUN_DIR`            | [Local State Storage](./local-state-storage.md)                                                            | Overrides the daemon runtime directory for files such as listener info and pid files. |
-| `TUTTID_PID_PATH`           | [Local State Storage](./local-state-storage.md)                                                            | Overrides the daemon pid file path.                                                   |
-| `TUTTID_LISTENER_INFO_PATH` | [Local State Storage](./local-state-storage.md), [Desktop Transport](../architecture/desktop-transport.md) | Overrides the listener-info file path used by managed desktop-to-daemon transport.    |
-| `CODEX_HOME`                | [Local State Storage](./local-state-storage.md)                                                            | Injected per Codex agent run by tuttid; points at the run-scoped `codex-home`.        |
-| `TUTTI_AGENT_HOME`          | [Local State Storage](./local-state-storage.md)                                                            | Injected per Tutti Agent run by tuttid; points at the run-scoped `tutti-agent-home`.  |
+| Variable                    | Owner document                                                                                             | Purpose                                                                              |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `TUTTI_ENV`                 | [Local State Storage](./local-state-storage.md)                                                            | Selects production or development default state roots.                               |
+| `TUTTI_STATE_DIR`           | [Local State Storage](./local-state-storage.md)                                                            | Overrides the shared local state root.                                               |
+| `TUTTI_LOG_DIR`             | [Local State Storage](./local-state-storage.md), [Logging](./logging.md)                                   | Overrides the shared log directory under the state model.                            |
+| `TUTTID_DB_PATH`            | [Local State Storage](./local-state-storage.md)                                                            | Overrides the daemon SQLite database path for narrow operational needs.              |
+| `TUTTID_RUN_DIR`            | [Local State Storage](./local-state-storage.md)                                                            | Overrides listener-info and pid paths, but not the state-root ownership lock.        |
+| `TUTTID_PID_PATH`           | [Local State Storage](./local-state-storage.md)                                                            | Overrides the daemon pid file, but not the state-root ownership lock.                |
+| `TUTTID_LISTENER_INFO_PATH` | [Local State Storage](./local-state-storage.md), [Desktop Transport](../architecture/desktop-transport.md) | Overrides the listener-info file path used by managed desktop-to-daemon transport.   |
+| `CODEX_HOME`                | [Local State Storage](./local-state-storage.md)                                                            | Injected per Codex agent run by tuttid; points at the run-scoped `codex-home`.       |
+| `TUTTI_AGENT_HOME`          | [Local State Storage](./local-state-storage.md)                                                            | Injected per Tutti Agent run by tuttid; points at the run-scoped `tutti-agent-home`. |
 
 ## Workspace App Catalog
 

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -25,6 +25,7 @@ Electron startup, daemon supervision, macOS packaging, updates, and performance 
 
 - [Desktop stable release alias disappears or is not first on Releases](./desktop-release.md#desktop-stable-release-alias-disappears-or-is-not-first-on-releases)
 - [Desktop dev GUI exits before opening](./desktop-release.md#desktop-dev-gui-exits-before-opening)
+- [Running a development tuttid breaks the production Agent session](./desktop-release.md#running-a-development-tuttid-breaks-the-production-agent-session)
 - [macOS updates fail from a mounted DMG](./desktop-release.md#macos-updates-fail-from-a-mounted-dmg)
 - [macOS Gatekeeper dialogs appear during Codex provider probing](./desktop-release.md#macos-gatekeeper-dialogs-appear-during-codex-provider-probing)
 - [Electron main/preload crashes on a workspace package `.ts` export](./desktop-release.md#electron-mainpreload-crashes-on-a-workspace-package-ts-export)

--- a/docs/conventions/troubleshooting/desktop-release.md
+++ b/docs/conventions/troubleshooting/desktop-release.md
@@ -120,7 +120,9 @@
   PID sidecar as an exclusive operating-system lease before logging, lock
   recovery, database wiring, migrations, or listener publication. Keep the PID
   text check so a new daemon also refuses a state root owned by a live older
-  daemon.
+  daemon, but validate process identity so PID reuse by an unrelated process
+  does not block recovery. Leave the marker for stale-owner recovery instead of
+  deleting it through a read/remove race with an older lockless daemon.
 - Validation:
   Run focused daemon tests. Verify `tuttid --help` exits successfully without
   creating the selected state root, invalid arguments exit nonzero without

--- a/docs/conventions/troubleshooting/desktop-release.md
+++ b/docs/conventions/troubleshooting/desktop-release.md
@@ -86,6 +86,51 @@
   [bootstrap.ts](../../../apps/desktop/src/main/bootstrap.ts)
   [defaults.ts](../../../apps/desktop/src/main/defaults.ts)
 
+### Running a development tuttid breaks the production Agent session
+
+- Symptom:
+  Production Tutti is used to develop Tutti itself. After an Agent runs a newly
+  built `tuttid` command, sending in a new conversation fails and the workspace
+  returns to the previously selected conversation. Daemon logs may report an
+  unsupported Agent Target launch-ref type immediately after a second daemon
+  starts.
+- Quick checks:
+  List live `tuttid` processes and compare their command paths. Inspect
+  `~/.tutti/logs/tuttid.log` for overlapping startup records, then check the
+  command run by the Agent for a bare daemon binary without
+  `TUTTI_ENV=development` or `TUTTI_STATE_DIR`. A historical `tuttid --help`
+  invocation is significant because older binaries treated it as normal
+  startup.
+- Root cause:
+  Bare daemon execution selects the production root. Older `tuttid` binaries
+  did not parse `--help` and overwrote the shared PID file instead of claiming
+  exclusive state ownership. The second process could open the production
+  SQLite database and reseed system Agent Targets with a newer launch-ref
+  discriminator while the packaged daemon still expected the older value.
+  Session creation then failed, and renderer recovery restored the previous
+  conversation.
+- Immediate recovery:
+  Quit Tutti completely, terminate any remaining `tuttid` processes after
+  verifying their command paths, then reopen production Tutti. Do not delete
+  `tuttid.db`; normal daemon startup reseeds its own system records. For further
+  local daemon work, use the managed development command or explicitly set
+  `TUTTI_ENV=development`/`TUTTI_STATE_DIR`.
+- Fix:
+  Parse help and reject unknown arguments before creating state. Acquire the
+  PID sidecar as an exclusive operating-system lease before logging, lock
+  recovery, database wiring, migrations, or listener publication. Keep the PID
+  text check so a new daemon also refuses a state root owned by a live older
+  daemon.
+- Validation:
+  Run focused daemon tests. Verify `tuttid --help` exits successfully without
+  creating the selected state root, invalid arguments exit nonzero without
+  state, a live legacy PID is rejected, a stale PID is recovered, and a second
+  lease cannot be acquired while the first is held.
+- References:
+  [main.go](../../../services/tuttid/main.go)
+  [pid_file.go](../../../services/tuttid/pid_file.go)
+  [local-state-storage.md](../local-state-storage.md)
+
 ### macOS updates fail from a mounted DMG
 
 - Symptom:

--- a/services/tuttid/main.go
+++ b/services/tuttid/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -18,27 +18,36 @@ import (
 )
 
 func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout io.Writer, stderr io.Writer) int {
+	if exitCode, shouldExit := handleArguments(args, stdout, stderr); shouldExit {
+		return exitCode
+	}
+
 	signal.Ignore(syscall.SIGPIPE)
+
+	pidLease, err := acquirePIDFile()
+	if err != nil {
+		fmt.Fprintf(stderr, "acquire tuttid pid file: %v\n", err)
+		return 1
+	}
+	defer pidLease.Release()
 
 	loggerSetup, err := tuttiapp.SetupLoggerFromEnv()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "configure tuttid logger: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "configure tuttid logger: %v\n", err)
+		return 1
 	}
 	defer func() {
 		if closeErr := loggerSetup.Close(); closeErr != nil {
-			fmt.Fprintf(os.Stderr, "close tuttid logger: %v\n", closeErr)
+			fmt.Fprintf(stderr, "close tuttid logger: %v\n", closeErr)
 		}
 	}()
 
 	slog.SetDefault(loggerSetup.Logger)
 	recoverInstallCommandLock(slog.Default())
-
-	if err := writePIDFile(); err != nil {
-		fmt.Fprintf(os.Stderr, "write tuttid pid file: %v\n", err)
-		os.Exit(1)
-	}
-	defer removePIDFile()
 
 	parentCtx, cancelParentMonitor := contextWithDesktopParentMonitor(context.Background(), slog.Default())
 	defer cancelParentMonitor()
@@ -48,32 +57,39 @@ func main() {
 
 	srv, listener, wiring, err := buildTuttiServer()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "build tuttid server: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "build tuttid server: %v\n", err)
+		return 1
 	}
 	defer func() {
 		_ = wiring.Close()
 	}()
 
 	if err := tuttiapp.New(srv, listener, loggerSetup.LogFilePath).Run(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "tuttid exited: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "tuttid exited: %v\n", err)
+		return 1
 	}
+	return 0
 }
 
-func writePIDFile() error {
-	pidPath := tuttitypes.TuttidPIDPath()
-	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
-		return fmt.Errorf("create pid file directory: %w", err)
-	}
-	if err := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0o644); err != nil {
-		return fmt.Errorf("write pid file: %w", err)
-	}
-	return nil
-}
+const tuttidUsage = `Usage: tuttid [options]
 
-func removePIDFile() {
-	_ = os.Remove(tuttitypes.TuttidPIDPath())
+Runs the Tutti local daemon. Tutti Desktop normally manages this process.
+
+Options:
+  -h, --help  Show this help.
+`
+
+func handleArguments(args []string, stdout io.Writer, stderr io.Writer) (int, bool) {
+	if len(args) == 0 {
+		return 0, false
+	}
+	if len(args) == 1 && (args[0] == "-h" || args[0] == "--help") {
+		fmt.Fprint(stdout, tuttidUsage)
+		return 0, true
+	}
+
+	fmt.Fprintf(stderr, "tuttid: unexpected arguments: %s\n\n%s", strings.Join(args, " "), tuttidUsage)
+	return 2, true
 }
 
 func recoverInstallCommandLock(logger *slog.Logger) {

--- a/services/tuttid/main_test.go
+++ b/services/tuttid/main_test.go
@@ -1,16 +1,59 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
 )
+
+func TestRunHelpExitsBeforeCreatingState(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state")
+	t.Setenv("TUTTI_STATE_DIR", stateDir)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if exitCode := run([]string{"--help"}, &stdout, &stderr); exitCode != 0 {
+		t.Fatalf("run(--help) exit code = %d, want 0", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "Usage: tuttid") {
+		t.Fatalf("run(--help) stdout = %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("run(--help) stderr = %q, want empty", stderr.String())
+	}
+	if _, err := os.Stat(stateDir); !os.IsNotExist(err) {
+		t.Fatalf("state directory exists after --help: %v", err)
+	}
+}
+
+func TestRunRejectsUnexpectedArgumentsBeforeCreatingState(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state")
+	t.Setenv("TUTTI_STATE_DIR", stateDir)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if exitCode := run([]string{"--version"}, &stdout, &stderr); exitCode != 2 {
+		t.Fatalf("run(--version) exit code = %d, want 2", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("run(--version) stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "unexpected arguments: --version") {
+		t.Fatalf("run(--version) stderr = %q", stderr.String())
+	}
+	if _, err := os.Stat(stateDir); !os.IsNotExist(err) {
+		t.Fatalf("state directory exists after invalid argument: %v", err)
+	}
+}
 
 func TestContextWithDesktopParentMonitorCancelsWhenParentPIDIsGone(t *testing.T) {
 	t.Setenv("TUTTI_DESKTOP_PARENT_PID", "999999999")

--- a/services/tuttid/pid_file.go
+++ b/services/tuttid/pid_file.go
@@ -15,17 +15,19 @@ var errPIDFileLocked = errors.New("pid file is locked")
 
 type pidFileLease struct {
 	lockFile *os.File
-	pidPath  string
-	body     []byte
 }
 
 func acquirePIDFile() (*pidFileLease, error) {
+	return acquirePIDFileWithProcessLookup(processExecutablePath)
+}
+
+func acquirePIDFileWithProcessLookup(lookup processExecutablePathLookup) (*pidFileLease, error) {
 	pidPath := tuttitypes.TuttidPIDPath()
-	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
-		return nil, fmt.Errorf("create pid file directory: %w", err)
+	lockPath := tuttitypes.TuttidStateOwnershipLockPath()
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		return nil, fmt.Errorf("create state ownership lock directory: %w", err)
 	}
 
-	lockPath := pidPath + ".lock"
 	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open state ownership lock: %w", err)
@@ -33,9 +35,13 @@ func acquirePIDFile() (*pidFileLease, error) {
 	if err := lockPIDFile(file); err != nil {
 		_ = file.Close()
 		if errors.Is(err, errPIDFileLocked) {
-			return nil, existingDaemonError(pidPath)
+			return nil, existingDaemonError(pidPath, lookup)
 		}
 		return nil, fmt.Errorf("lock state ownership file: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
+		unlockAndClosePIDFile(file)
+		return nil, fmt.Errorf("create pid file directory: %w", err)
 	}
 
 	existingBody, err := os.ReadFile(pidPath)
@@ -43,7 +49,7 @@ func acquirePIDFile() (*pidFileLease, error) {
 		unlockAndClosePIDFile(file)
 		return nil, fmt.Errorf("read pid file: %w", err)
 	}
-	if existingPID, ok := parsePID(existingBody); ok && tuttitypes.ProcessExists(existingPID) {
+	if existingPID, ok := parsePID(existingBody); ok && isLiveTuttidProcess(existingPID, lookup) {
 		unlockAndClosePIDFile(file)
 		return nil, fmt.Errorf("state directory is already owned by live tuttid process %d", existingPID)
 	}
@@ -54,13 +60,13 @@ func acquirePIDFile() (*pidFileLease, error) {
 		return nil, fmt.Errorf("write pid file: %w", err)
 	}
 
-	return &pidFileLease{lockFile: file, pidPath: pidPath, body: body}, nil
+	return &pidFileLease{lockFile: file}, nil
 }
 
-func existingDaemonError(pidPath string) error {
+func existingDaemonError(pidPath string, lookup processExecutablePathLookup) error {
 	body, err := os.ReadFile(pidPath)
 	if err == nil {
-		if pid, ok := parsePID(body); ok && tuttitypes.ProcessExists(pid) {
+		if pid, ok := parsePID(body); ok && isLiveTuttidProcess(pid, lookup) {
 			return fmt.Errorf("state directory is already owned by live tuttid process %d", pid)
 		}
 	}
@@ -69,7 +75,7 @@ func existingDaemonError(pidPath string) error {
 
 func parsePID(body []byte) (int, bool) {
 	pid, err := strconv.Atoi(strings.TrimSpace(string(body)))
-	return pid, err == nil && pid > 1
+	return pid, err == nil && pid > 0
 }
 
 func unlockAndClosePIDFile(file *os.File) {
@@ -80,10 +86,6 @@ func unlockAndClosePIDFile(file *os.File) {
 func (l *pidFileLease) Release() {
 	if l == nil || l.lockFile == nil {
 		return
-	}
-	currentBody, err := os.ReadFile(l.pidPath)
-	if err == nil && string(currentBody) == string(l.body) {
-		_ = os.Remove(l.pidPath)
 	}
 	unlockAndClosePIDFile(l.lockFile)
 	l.lockFile = nil

--- a/services/tuttid/pid_file.go
+++ b/services/tuttid/pid_file.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
+)
+
+var errPIDFileLocked = errors.New("pid file is locked")
+
+type pidFileLease struct {
+	lockFile *os.File
+	pidPath  string
+	body     []byte
+}
+
+func acquirePIDFile() (*pidFileLease, error) {
+	pidPath := tuttitypes.TuttidPIDPath()
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
+		return nil, fmt.Errorf("create pid file directory: %w", err)
+	}
+
+	lockPath := pidPath + ".lock"
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open state ownership lock: %w", err)
+	}
+	if err := lockPIDFile(file); err != nil {
+		_ = file.Close()
+		if errors.Is(err, errPIDFileLocked) {
+			return nil, existingDaemonError(pidPath)
+		}
+		return nil, fmt.Errorf("lock state ownership file: %w", err)
+	}
+
+	existingBody, err := os.ReadFile(pidPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		unlockAndClosePIDFile(file)
+		return nil, fmt.Errorf("read pid file: %w", err)
+	}
+	if existingPID, ok := parsePID(existingBody); ok && tuttitypes.ProcessExists(existingPID) {
+		unlockAndClosePIDFile(file)
+		return nil, fmt.Errorf("state directory is already owned by live tuttid process %d", existingPID)
+	}
+
+	body := []byte(fmt.Sprintf("%d\n", os.Getpid()))
+	if err := os.WriteFile(pidPath, body, 0o644); err != nil {
+		unlockAndClosePIDFile(file)
+		return nil, fmt.Errorf("write pid file: %w", err)
+	}
+
+	return &pidFileLease{lockFile: file, pidPath: pidPath, body: body}, nil
+}
+
+func existingDaemonError(pidPath string) error {
+	body, err := os.ReadFile(pidPath)
+	if err == nil {
+		if pid, ok := parsePID(body); ok && tuttitypes.ProcessExists(pid) {
+			return fmt.Errorf("state directory is already owned by live tuttid process %d", pid)
+		}
+	}
+	return errors.New("state directory is already owned by another tuttid process")
+}
+
+func parsePID(body []byte) (int, bool) {
+	pid, err := strconv.Atoi(strings.TrimSpace(string(body)))
+	return pid, err == nil && pid > 1
+}
+
+func unlockAndClosePIDFile(file *os.File) {
+	_ = unlockPIDFile(file)
+	_ = file.Close()
+}
+
+func (l *pidFileLease) Release() {
+	if l == nil || l.lockFile == nil {
+		return
+	}
+	currentBody, err := os.ReadFile(l.pidPath)
+	if err == nil && string(currentBody) == string(l.body) {
+		_ = os.Remove(l.pidPath)
+	}
+	unlockAndClosePIDFile(l.lockFile)
+	l.lockFile = nil
+}

--- a/services/tuttid/pid_file_process.go
+++ b/services/tuttid/pid_file_process.go
@@ -1,0 +1,23 @@
+package main
+
+import "strings"
+
+type processExecutablePathLookup func(int) (string, error)
+
+func isLiveTuttidProcess(pid int, lookup processExecutablePathLookup) bool {
+	if pid <= 0 {
+		return false
+	}
+	executablePath, err := lookup(pid)
+	return err == nil && isTuttidExecutablePath(executablePath)
+}
+
+func isTuttidExecutablePath(executablePath string) bool {
+	normalized := strings.TrimSpace(executablePath)
+	normalized = strings.TrimSuffix(normalized, " (deleted)")
+	if separator := strings.LastIndexAny(normalized, `/\\`); separator >= 0 {
+		normalized = normalized[separator+1:]
+	}
+	normalized = strings.TrimSuffix(strings.ToLower(normalized), ".exe")
+	return normalized == "tuttid"
+}

--- a/services/tuttid/pid_file_process_darwin.go
+++ b/services/tuttid/pid_file_process_darwin.go
@@ -1,0 +1,25 @@
+//go:build darwin
+
+package main
+
+import (
+	"bytes"
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+func processExecutablePath(pid int) (string, error) {
+	info, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		return "", err
+	}
+	name := info.Proc.P_comm[:]
+	if end := bytes.IndexByte(name, 0); end >= 0 {
+		name = name[:end]
+	}
+	if len(name) == 0 {
+		return "", errors.New("process executable name is empty")
+	}
+	return string(name), nil
+}

--- a/services/tuttid/pid_file_process_linux.go
+++ b/services/tuttid/pid_file_process_linux.go
@@ -1,0 +1,12 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func processExecutablePath(pid int) (string, error) {
+	return os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
+}

--- a/services/tuttid/pid_file_process_other.go
+++ b/services/tuttid/pid_file_process_other.go
@@ -1,0 +1,17 @@
+//go:build !darwin && !linux && !windows
+
+package main
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func processExecutablePath(pid int) (string, error) {
+	output, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}

--- a/services/tuttid/pid_file_process_windows.go
+++ b/services/tuttid/pid_file_process_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package main
+
+import "golang.org/x/sys/windows"
+
+const maxWindowsProcessImagePath = 32768
+
+func processExecutablePath(pid int) (string, error) {
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return "", err
+	}
+	defer windows.CloseHandle(handle)
+
+	buffer := make([]uint16, maxWindowsProcessImagePath)
+	size := uint32(len(buffer))
+	if err := windows.QueryFullProcessImageName(handle, 0, &buffer[0], &size); err != nil {
+		return "", err
+	}
+	return windows.UTF16ToString(buffer[:size]), nil
+}

--- a/services/tuttid/pid_file_test.go
+++ b/services/tuttid/pid_file_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -18,6 +19,9 @@ import (
 func TestAcquirePIDFileRejectsLiveOwner(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv("TUTTI_STATE_DIR", stateDir)
+	lookup := func(_ int) (string, error) {
+		return "/test/tuttid", nil
+	}
 	pidPath := tuttitypes.TuttidPIDPath()
 	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
 		t.Fatal(err)
@@ -26,7 +30,7 @@ func TestAcquirePIDFileRejectsLiveOwner(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lease, err := acquirePIDFile()
+	lease, err := acquirePIDFileWithProcessLookup(lookup)
 	if err == nil {
 		lease.Release()
 		t.Fatal("acquirePIDFile() succeeded with a live owner")
@@ -34,6 +38,27 @@ func TestAcquirePIDFileRejectsLiveOwner(t *testing.T) {
 	if !strings.Contains(err.Error(), strconv.Itoa(os.Getpid())) {
 		t.Fatalf("acquirePIDFile() error = %q, want owner pid", err)
 	}
+}
+
+func TestAcquirePIDFileIgnoresReusedPIDForUnrelatedProcess(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("TUTTI_STATE_DIR", stateDir)
+	lookup := func(_ int) (string, error) {
+		return "/test/unrelated", nil
+	}
+	pidPath := tuttitypes.TuttidPIDPath()
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lease, err := acquirePIDFileWithProcessLookup(lookup)
+	if err != nil {
+		t.Fatalf("acquirePIDFile() error = %v", err)
+	}
+	lease.Release()
 }
 
 func TestAcquirePIDFileRecoversStaleOwnerAndSerializesAccess(t *testing.T) {
@@ -109,6 +134,56 @@ func TestPIDFileLeaseSerializesProcesses(t *testing.T) {
 	}
 }
 
+func TestPIDFileLeaseSerializesStateRootAcrossPathOverrides(t *testing.T) {
+	tests := []struct {
+		name          string
+		firstRunDir   string
+		firstPIDPath  string
+		secondRunDir  string
+		secondPIDPath string
+	}{
+		{
+			name:          "pid path",
+			firstPIDPath:  filepath.Join(t.TempDir(), "first.pid"),
+			secondPIDPath: filepath.Join(t.TempDir(), "second.pid"),
+		},
+		{
+			name:         "run directory",
+			firstRunDir:  filepath.Join(t.TempDir(), "first-run"),
+			secondRunDir: filepath.Join(t.TempDir(), "second-run"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TUTTI_STATE_DIR", t.TempDir())
+			t.Setenv("TUTTID_RUN_DIR", tt.firstRunDir)
+			t.Setenv("TUTTID_PID_PATH", tt.firstPIDPath)
+
+			lease, err := acquirePIDFile()
+			if err != nil {
+				t.Fatalf("first acquirePIDFile() error = %v", err)
+			}
+			defer lease.Release()
+
+			t.Setenv("TUTTID_RUN_DIR", tt.secondRunDir)
+			t.Setenv("TUTTID_PID_PATH", tt.secondPIDPath)
+			secondPIDPath := tuttitypes.TuttidPIDPath()
+			secondLease, err := acquirePIDFile()
+			if err == nil {
+				secondLease.Release()
+				t.Fatal("second acquirePIDFile() succeeded for the same state root")
+			}
+			if !strings.Contains(err.Error(), "already owned") {
+				t.Fatalf("second acquirePIDFile() error = %q", err)
+			}
+			if _, err := os.Stat(secondPIDPath); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("second pid file exists or stat failed: %v", err)
+			}
+		})
+	}
+}
+
 func TestPIDFileLeaseHelper(t *testing.T) {
 	if os.Getenv("TUTTI_PID_LEASE_HELPER") != "1" {
 		return
@@ -122,24 +197,60 @@ func TestPIDFileLeaseHelper(t *testing.T) {
 	_, _ = io.Copy(io.Discard, os.Stdin)
 }
 
-func TestPIDFileLeaseDoesNotRemoveReplacementOwner(t *testing.T) {
+func TestPIDFileLeaseReleaseLeavesPIDMarkerForStaleRecovery(t *testing.T) {
 	t.Setenv("TUTTI_STATE_DIR", t.TempDir())
 	lease, err := acquirePIDFile()
 	if err != nil {
 		t.Fatalf("acquirePIDFile() error = %v", err)
 	}
-
-	replacement := []byte("424242\n")
-	if err := os.WriteFile(lease.pidPath, replacement, 0o644); err != nil {
-		t.Fatal(err)
-	}
+	pidPath := tuttitypes.TuttidPIDPath()
 	lease.Release()
 
-	body, err := os.ReadFile(lease.pidPath)
+	body, err := os.ReadFile(pidPath)
 	if err != nil {
-		t.Fatalf("read replacement pid file: %v", err)
+		t.Fatalf("read retained pid file: %v", err)
 	}
-	if string(body) != string(replacement) {
-		t.Fatalf("replacement pid file = %q", body)
+	if got := strings.TrimSpace(string(body)); got != strconv.Itoa(os.Getpid()) {
+		t.Fatalf("retained pid file = %q, want %d", got, os.Getpid())
+	}
+}
+
+func TestParsePIDAcceptsEveryPositivePID(t *testing.T) {
+	for _, body := range []string{"1", "2", "4242\n"} {
+		if _, ok := parsePID([]byte(body)); !ok {
+			t.Errorf("parsePID(%q) rejected a positive pid", body)
+		}
+	}
+	for _, body := range []string{"", "0", "-1", "nope"} {
+		if _, ok := parsePID([]byte(body)); ok {
+			t.Errorf("parsePID(%q) accepted an invalid pid", body)
+		}
+	}
+}
+
+func TestIsTuttidExecutablePath(t *testing.T) {
+	tests := map[string]bool{
+		"/Applications/Tutti.app/Contents/Resources/bin/tuttid": true,
+		"/tmp/tuttid (deleted)":                                 true,
+		`C:\Program Files\Tutti\tuttid.exe`:                     true,
+		"tuttid":                                                true,
+		"/tmp/tuttid-helper":                                    false,
+		"/tmp/unrelated":                                        false,
+		"":                                                      false,
+	}
+	for executablePath, want := range tests {
+		if got := isTuttidExecutablePath(executablePath); got != want {
+			t.Errorf("isTuttidExecutablePath(%q) = %t, want %t", executablePath, got, want)
+		}
+	}
+}
+
+func TestProcessExecutablePathFindsCurrentProcess(t *testing.T) {
+	executablePath, err := processExecutablePath(os.Getpid())
+	if err != nil {
+		t.Fatalf("processExecutablePath(os.Getpid()) error = %v", err)
+	}
+	if strings.TrimSpace(executablePath) == "" {
+		t.Fatal("processExecutablePath(os.Getpid()) returned an empty path")
 	}
 }

--- a/services/tuttid/pid_file_test.go
+++ b/services/tuttid/pid_file_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
+)
+
+func TestAcquirePIDFileRejectsLiveOwner(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("TUTTI_STATE_DIR", stateDir)
+	pidPath := tuttitypes.TuttidPIDPath()
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lease, err := acquirePIDFile()
+	if err == nil {
+		lease.Release()
+		t.Fatal("acquirePIDFile() succeeded with a live owner")
+	}
+	if !strings.Contains(err.Error(), strconv.Itoa(os.Getpid())) {
+		t.Fatalf("acquirePIDFile() error = %q, want owner pid", err)
+	}
+}
+
+func TestAcquirePIDFileRecoversStaleOwnerAndSerializesAccess(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("TUTTI_STATE_DIR", stateDir)
+	pidPath := tuttitypes.TuttidPIDPath()
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pidPath, []byte("999999999\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lease, err := acquirePIDFile()
+	if err != nil {
+		t.Fatalf("acquirePIDFile() error = %v", err)
+	}
+	defer lease.Release()
+
+	body, err := os.ReadFile(pidPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(body)); got != strconv.Itoa(os.Getpid()) {
+		t.Fatalf("pid file = %q, want %d", got, os.Getpid())
+	}
+
+	secondLease, err := acquirePIDFile()
+	if err == nil {
+		secondLease.Release()
+		t.Fatal("second acquirePIDFile() succeeded while lease is held")
+	}
+	if !strings.Contains(err.Error(), "already owned") {
+		t.Fatalf("second acquirePIDFile() error = %q", err)
+	}
+}
+
+func TestPIDFileLeaseSerializesProcesses(t *testing.T) {
+	t.Setenv("TUTTI_STATE_DIR", t.TempDir())
+	cmd := exec.Command(os.Args[0], "-test.run=^TestPIDFileLeaseHelper$")
+	cmd.Env = append(os.Environ(), "TUTTI_PID_LEASE_HELPER=1")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = stdin.Close()
+		if err := cmd.Wait(); err != nil {
+			t.Errorf("lease helper failed: %v; stderr=%s", err, stderr.String())
+		}
+	}()
+
+	scanner := bufio.NewScanner(stdout)
+	if !scanner.Scan() || scanner.Text() != "ready" {
+		t.Fatalf("lease helper did not become ready; stderr=%s", stderr.String())
+	}
+	lease, err := acquirePIDFile()
+	if err == nil {
+		lease.Release()
+		t.Fatal("acquirePIDFile() succeeded while another process held the lease")
+	}
+	if !strings.Contains(err.Error(), "already owned") {
+		t.Fatalf("acquirePIDFile() error = %q", err)
+	}
+}
+
+func TestPIDFileLeaseHelper(t *testing.T) {
+	if os.Getenv("TUTTI_PID_LEASE_HELPER") != "1" {
+		return
+	}
+	lease, err := acquirePIDFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lease.Release()
+	fmt.Fprintln(os.Stdout, "ready")
+	_, _ = io.Copy(io.Discard, os.Stdin)
+}
+
+func TestPIDFileLeaseDoesNotRemoveReplacementOwner(t *testing.T) {
+	t.Setenv("TUTTI_STATE_DIR", t.TempDir())
+	lease, err := acquirePIDFile()
+	if err != nil {
+		t.Fatalf("acquirePIDFile() error = %v", err)
+	}
+
+	replacement := []byte("424242\n")
+	if err := os.WriteFile(lease.pidPath, replacement, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lease.Release()
+
+	body, err := os.ReadFile(lease.pidPath)
+	if err != nil {
+		t.Fatalf("read replacement pid file: %v", err)
+	}
+	if string(body) != string(replacement) {
+		t.Fatalf("replacement pid file = %q", body)
+	}
+}

--- a/services/tuttid/pid_file_unix.go
+++ b/services/tuttid/pid_file_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package main
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockPIDFile(file *os.File) error {
+	err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+		return errPIDFileLocked
+	}
+	return err
+}
+
+func unlockPIDFile(file *os.File) error {
+	return unix.Flock(int(file.Fd()), unix.LOCK_UN)
+}

--- a/services/tuttid/pid_file_windows.go
+++ b/services/tuttid/pid_file_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockPIDFile(file *os.File) error {
+	overlapped := new(windows.Overlapped)
+	err := windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		overlapped,
+	)
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return errPIDFileLocked
+	}
+	return err
+}
+
+func unlockPIDFile(file *os.File) error {
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, new(windows.Overlapped))
+}

--- a/services/tuttid/types/statepaths.go
+++ b/services/tuttid/types/statepaths.go
@@ -1,5 +1,7 @@
 package types
 
+import "path/filepath"
+
 func TuttidDBPath() string {
 	return ResolveDefaultsFromEnv().State.TuttidDBPath
 }
@@ -22,6 +24,14 @@ func TuttidListenerInfoPath() string {
 
 func TuttidPIDPath() string {
 	return ResolveDefaultsFromEnv().State.TuttidPIDPath
+}
+
+func TuttidStateOwnershipLockPath() string {
+	return filepath.Join(
+		DefaultStateDir(),
+		generatedDefaults.State.RunDirName,
+		generatedDefaults.State.PIDFileName+".lock",
+	)
 }
 
 func DefaultStateDir() string {

--- a/services/tuttid/types/statepaths_test.go
+++ b/services/tuttid/types/statepaths_test.go
@@ -72,6 +72,7 @@ func TestTuttidDerivedPathsUseDevelopmentRoot(t *testing.T) {
 }
 
 func TestTuttidDerivedPathsUseOverrides(t *testing.T) {
+	t.Setenv("TUTTI_STATE_DIR", "/tmp/tutti-custom")
 	t.Setenv("TUTTID_DB_PATH", "/tmp/tuttid-custom.db")
 	t.Setenv("TUTTID_LOG_PATH", "/tmp/tuttid.log")
 	t.Setenv("TUTTID_RUN_DIR", "/tmp/tuttid-run")
@@ -92,5 +93,8 @@ func TestTuttidDerivedPathsUseOverrides(t *testing.T) {
 	}
 	if got := TuttidPIDPath(); got != "/tmp/tuttid.pid" {
 		t.Fatalf("TuttidPIDPath() = %q", got)
+	}
+	if got, want := TuttidStateOwnershipLockPath(), filepath.Join("/tmp/tutti-custom", "run", "tuttid.pid.lock"); got != want {
+		t.Fatalf("TuttidStateOwnershipLockPath() = %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

- parse `--help` and reject unknown daemon arguments before creating or opening state
- acquire a cross-platform OS lock for each state root before logging, lock recovery, SQLite migrations, target seeding, or listener publication
- retain the PID text guard so a new daemon refuses state owned by an already-running pre-lock release
- add process-level regression coverage and document state ownership plus the production/dev self-hosting recovery path

## Verification

- `pnpm check:full` (passed before commit and again in the pre-push hook)
- `pnpm check:changed --tail-lines 80`
- `pnpm lint:go`
- `cd services/tuttid && go test ./... && go build ./...`
- `cd services/tuttid && GOOS=windows GOARCH=amd64 go test -c . -o /tmp/tuttid-main-windows.test.exe`

## Fix Scope Justification

- Root cause: a second `tuttid` could target the production state root because daemon arguments were ignored and the PID file was overwritten. That process could migrate and reseed the shared database while the packaged daemon was still running.
- Why can this not be fixed at a lower layer? Ownership must be established before any stateful subsystem starts. SQLite locking occurs after bootstrap and cannot prevent compatible concurrent writes or version-skewed system-record seeding. Most added lines are cross-platform ownership code, process-level regression tests, and durable documentation.

## Fallback Three Questions

- Source: already-installed daemon releases write a PID but do not hold the new OS lock, so the PID remains the only inter-version ownership signal during upgrade.
- Why can it not be fixed at that source? Released binaries already running on user machines cannot be retroactively changed.
- Removal condition: the live-PID compatibility guard can be reconsidered after the supported upgrade horizon no longer includes daemon versions from before the state ownership lock.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source (not applicable; no README/CONTRIBUTING changes).
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents multiple `tuttid` instances from owning the same state root, avoiding accidental production DB reseeds and session failures. Hardens ownership with an OS lock, PID verification, and stricter CLI arg handling.

- **Bug Fixes**
  - Parse `--help` and reject unknown args before any state is created or opened.
  - Acquire a cross-platform exclusive lock on `<state-dir>/run/tuttid.pid.lock` before logging, recovery, SQLite migrations, seeding, or listener publication.
  - Validate PID markers belong to `tuttid`, recover stale markers, retain the PID text for legacy upgrade safety, and keep the lock independent of `TUTTID_RUN_DIR`/`TUTTID_PID_PATH`.
  - Add process-level tests and docs covering ownership, serialization across processes and path overrides, and recovery, plus troubleshooting guidance.

<sup>Written for commit 8fe1dfbf50532012e038fa9921a1bf12edd91dda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

