### PR TITLE
fix(agent-gui): align queued prompt header

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -7969,13 +7969,14 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 
 .agent-gui-node__composer-queued-prompt-header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: flex-start;
   gap: 4px;
   min-height: 20px;
 }
 
 .agent-gui-node__composer-queued-prompt-expand-cue {
+  display: block;
   flex: 0 0 auto;
   color: var(--agent-gui-accent-strong);
   opacity: 0;


### PR DESCRIPTION
## Summary
- vertically center queued prompt header text, count, and expand cue
- render the expand cue as a block flex item to keep its visual baseline aligned

## Validation
- make dev-web visual check with 3 queued prompts
- pnpm --filter @tutti-os/agent-gui test -- AgentQueuedPromptPanel.spec.tsx
- pnpm check:full

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vertically center the queued prompt header text, count, and expand cue in the Agent GUI for consistent alignment. Render the expand cue as a block flex item so its baseline aligns with the text.

<sup>Written for commit 2b09bc6fd05d7e193d1d6ee7b3c8c250bdf9ec29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

