### PR TITLE
fix(agent): keep wait responses low context

### DIFF
--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -155,11 +155,11 @@ recovery.
 `agent wait --json` is the blocking progress helper for launched or continued
 agent sessions. It should wait for the next meaningful stop point such as turn
 completion, failure, cancellation, waiting for approval, waiting for user
-input, or timeout. Its JSON result should stay narrow: `activeTurnId`, latest
-Turn phase/outcome,
-wait reason, latest version, timeout flag, and only the most recent agent
-execution messages from the wait window. It must not return a full transcript;
-callers that need broader context should follow with `agent session-summary`.
+input, or timeout. Its JSON result should stay narrow: compact session status,
+wait reason, latest version, effective wait cursor, and timeout flag. It must
+not return execution messages, pagination state, or a full transcript; callers
+that need broader context should follow with `agent session-summary`. Keep
+message window controls such as `limit` out of the public wait command shape.
 When a caller continues an existing session with `agent send`, the send action
 should return a `waitAfterVersion` cursor, and the next wait call should pass
 that cursor as `agent wait --after-version <waitAfterVersion> ...` so the wait

--- a/services/tuttid/service/agent/service_wait.go
+++ b/services/tuttid/service/agent/service_wait.go
@@ -17,10 +17,12 @@ func (s *Service) Wait(ctx context.Context, input WaitInput) (WaitResult, error)
 		return WaitResult{}, ErrInvalidArgument
 	}
 	messageLimit := input.MessageLimit
-	if messageLimit < 0 {
+	if messageLimit < 0 && !input.SkipMessages {
 		return WaitResult{}, ErrInvalidArgument
 	}
-	if messageLimit == 0 {
+	if input.SkipMessages {
+		messageLimit = -1
+	} else if messageLimit == 0 {
 		messageLimit = defaultWaitMessageLimit
 	}
 	timeout := input.Timeout
@@ -183,6 +185,19 @@ func (s *Service) waitResult(
 	effectiveAfter uint64,
 	messageLimit int,
 ) (WaitResult, error) {
+	if messageLimit < 0 {
+		latestVersion, err := s.latestSessionVersion(ctx, workspaceID, agentSessionID)
+		if err != nil {
+			return WaitResult{}, err
+		}
+		return WaitResult{
+			Session:        cloneSession(session),
+			LatestVersion:  latestVersion,
+			Reason:         reason,
+			TimedOut:       timedOut,
+			EffectiveAfter: effectiveAfter,
+		}, nil
+	}
 	messages, latestVersion, hasMore, err := s.recentAgentExecutionMessages(ctx, workspaceID, agentSessionID, effectiveAfter, messageLimit)
 	if err != nil {
 		return WaitResult{}, err

--- a/services/tuttid/service/agent/service_wait_test.go
+++ b/services/tuttid/service/agent/service_wait_test.go
@@ -147,6 +147,60 @@ func uint64Ptr(value uint64) *uint64 {
 	return &value
 }
 
+func TestWaitSkipMessagesReturnsOnlyStopPointMetadata(t *testing.T) {
+	runtime := newWaitRuntime()
+	turnID := "turn-1"
+	runtime.sessions["ws-1:session-1"] = ProviderRuntimeSession{
+		ID:          "session-1",
+		WorkspaceID: "ws-1",
+		Provider:    "codex",
+		Status:      "waiting",
+		TurnLifecycle: &TurnLifecycle{
+			ActiveTurnID: &turnID,
+			Phase:        "waiting_input",
+		},
+		Visible:         true,
+		CreatedAtUnixMS: time.Now().Add(-time.Minute).UnixMilli(),
+		UpdatedAtUnixMS: time.Now().UnixMilli(),
+	}
+	reader := &waitMessageReader{
+		list: func(input agentactivitybiz.ListSessionMessagesInput) (SessionMessagesPage, bool) {
+			if input.Order != agentactivitybiz.MessageOrderDesc || input.Limit != 1 {
+				t.Fatalf("skip-messages wait queried execution messages: %#v", input)
+			}
+			return SessionMessagesPage{
+				AgentSessionID: input.AgentSessionID,
+				LatestVersion:  7,
+			}, true
+		},
+	}
+	service := newIsolatedAgentService(runtime)
+	service.TurnStore = runtime
+	service.MessageReader = reader
+
+	result, err := service.Wait(context.Background(), WaitInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		AfterVersion:   uint64Ptr(0),
+		SkipMessages:   true,
+	})
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Reason != WaitReasonWaitingInput || result.TimedOut {
+		t.Fatalf("result = %#v", result)
+	}
+	if result.EffectiveAfter != 0 || result.LatestVersion != 7 {
+		t.Fatalf("versions = after %d latest %d, want 0/7", result.EffectiveAfter, result.LatestVersion)
+	}
+	if len(result.Messages) != 0 || result.HasMore {
+		t.Fatalf("skip-messages result should omit message pagination: %#v", result)
+	}
+	if len(reader.calls) != 2 {
+		t.Fatalf("message reads = %d, want two latest-version reads", len(reader.calls))
+	}
+}
+
 func TestWaitIgnoresStaleStopUntilNewProgressArrives(t *testing.T) {
 	runtime := newWaitRuntime()
 	turnID := "turn-1"

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -590,6 +590,7 @@ type WaitInput struct {
 	AgentSessionID string
 	AfterVersion   *uint64
 	MessageLimit   int
+	SkipMessages   bool
 	Timeout        time.Duration
 }
 

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -627,7 +627,7 @@ func TestSessionSummaryCommandRejectsInvalidOrder(t *testing.T) {
 	}
 }
 
-func TestWaitCommandReturnsRecentAgentMessages(t *testing.T) {
+func TestWaitCommandReturnsStopPointWithoutMessages(t *testing.T) {
 	sessions := &fakeAgentSessions{
 		waitResult: agentservice.WaitResult{
 			Session: agentservice.Session{
@@ -658,6 +658,7 @@ func TestWaitCommandReturnsRecentAgentMessages(t *testing.T) {
 				},
 			},
 			LatestVersion:  9,
+			HasMore:        true,
 			Reason:         agentservice.WaitReasonWaitingInput,
 			EffectiveAfter: 7,
 		},
@@ -665,7 +666,7 @@ func TestWaitCommandReturnsRecentAgentMessages(t *testing.T) {
 	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newWaitCommand()
 
 	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
-		Input:      map[string]any{"session-id": "SESSION-1", "after-version": "7", "limit": "5", "timeout-ms": "2500"},
+		Input:      map[string]any{"session-id": "SESSION-1", "after-version": "7", "timeout-ms": "2500"},
 		OutputMode: cliservice.OutputModeJSON,
 	})
 	if err != nil {
@@ -676,7 +677,8 @@ func TestWaitCommandReturnsRecentAgentMessages(t *testing.T) {
 		sessions.waitInput.AgentSessionID != "SESSION-1" ||
 		!ok ||
 		waitAfterVersion != 7 ||
-		sessions.waitInput.MessageLimit != 5 ||
+		sessions.waitInput.MessageLimit != 0 ||
+		!sessions.waitInput.SkipMessages ||
 		sessions.waitInput.Timeout != 2500*time.Millisecond {
 		t.Fatalf("wait input = %#v", sessions.waitInput)
 	}
@@ -691,17 +693,10 @@ func TestWaitCommandReturnsRecentAgentMessages(t *testing.T) {
 	if _, ok := session["settings"]; ok {
 		t.Fatalf("wait session should stay compact: %#v", session)
 	}
-	messages := output.Value["messages"].([]any)
-	if len(messages) != 2 {
-		t.Fatalf("messages = %#v", messages)
-	}
-	first := messages[0].(map[string]any)
-	if first["messageId"] != "assistant-1" || first["text"] != "First reply" {
-		t.Fatalf("first message = %#v", first)
-	}
-	second := messages[1].(map[string]any)
-	if second["messageId"] != "tool-1" || second["text"] != "call: Read files" {
-		t.Fatalf("second message = %#v", second)
+	for _, key := range []string{"messages", "hasMore"} {
+		if _, ok := output.Value[key]; ok {
+			t.Fatalf("wait output should omit %q: %#v", key, output.Value)
+		}
 	}
 }
 
@@ -721,57 +716,17 @@ func TestWaitCommandPreservesExplicitZeroAfterVersion(t *testing.T) {
 	}
 }
 
-func TestWaitCommandIncludesImageCompactMetadata(t *testing.T) {
-	sessions := &fakeAgentSessions{
-		localPaths: map[string]string{"attachment-1": "/tmp/agent/attachments/SESSION-1/attachment-1.png"},
-		waitResult: agentservice.WaitResult{
-			Session: agentservice.Session{
-				ID:           "SESSION-1",
-				Provider:     "codex",
-				ActiveTurnID: "turn-1",
-				Visible:      true,
-			},
-			Messages: []agentservice.SessionMessage{{
-				AgentSessionID: "SESSION-1",
-				MessageID:      "message-1",
-				Role:           "user",
-				Kind:           "text",
-				Status:         "completed",
-				Payload: map[string]any{
-					"content": []any{
-						map[string]any{"type": "text", "text": "look"},
-						map[string]any{
-							"type":         "image",
-							"attachmentId": "attachment-1",
-							"mimeType":     "image/png",
-							"name":         "shot.png",
-						},
-					},
-				},
-				Version: 8,
-			}},
-			LatestVersion:  8,
-			Reason:         agentservice.WaitReasonWaitingInput,
-			EffectiveAfter: 7,
-		},
-	}
-	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newWaitCommand()
+func TestWaitCommandExposesOnlyWaitParameters(t *testing.T) {
+	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, &fakeAgentSessions{}).newWaitCommand()
 
-	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
-		Input:      map[string]any{"session-id": "SESSION-1"},
-		OutputMode: cliservice.OutputModeJSON,
-	})
-	if err != nil {
-		t.Fatalf("Handler: %v", err)
+	properties := command.Capability.InputSchema["properties"].(map[string]any)
+	for _, key := range []string{"session-id", "after-version", "timeout-ms"} {
+		if _, ok := properties[key]; !ok {
+			t.Fatalf("wait schema should include %q: %#v", key, properties)
+		}
 	}
-	messages := output.Value["messages"].([]any)
-	images := messages[0].(map[string]any)["images"].([]any)
-	image := images[0].(map[string]any)
-	if image["attachmentId"] != "attachment-1" ||
-		image["mimeType"] != "image/png" ||
-		image["name"] != "shot.png" ||
-		image["localPath"] != "/tmp/agent/attachments/SESSION-1/attachment-1.png" {
-		t.Fatalf("image = %#v", image)
+	if _, ok := properties["limit"]; ok {
+		t.Fatalf("wait schema should omit limit: %#v", properties)
 	}
 }
 
@@ -787,6 +742,9 @@ func TestWaitCommandUsesDefaultTimeout(t *testing.T) {
 	}
 	if sessions.waitInput.AfterVersion != nil {
 		t.Fatalf("after version = %#v, want nil when omitted", sessions.waitInput.AfterVersion)
+	}
+	if !sessions.waitInput.SkipMessages {
+		t.Fatalf("skip messages = false, want true")
 	}
 	if sessions.waitInput.Timeout != 5*time.Minute {
 		t.Fatalf("timeout = %v, want 5m", sessions.waitInput.Timeout)

--- a/services/tuttid/service/cli/providers/agentcontext/sessions.go
+++ b/services/tuttid/service/cli/providers/agentcontext/sessions.go
@@ -32,7 +32,6 @@ type sessionSummaryInput struct {
 type waitInput struct {
 	SessionID    string `cli:"session-id" validate:"required" description:"Agent session id to await."`
 	AfterVersion *int64 `cli:"after-version" validate:"min=0" description:"Wait for a stop point after this message version."`
-	Limit        int    `cli:"limit" validate:"min=0" description:"Maximum number of recent messages to return."`
 	TimeoutMS    int    `cli:"timeout-ms" validate:"min=0" description:"Maximum time to wait in milliseconds before returning a timeout result."`
 }
 
@@ -49,8 +48,7 @@ type sessionSummaryResult struct {
 }
 
 type waitCommandResult struct {
-	ImageLocalPath imageLocalPathResolver
-	Result         agentservice.WaitResult
+	Result agentservice.WaitResult
 }
 
 type turnResourcesResult struct {
@@ -202,16 +200,13 @@ func (p Provider) runWait(ctx context.Context, invoke framework.InvokeContext, i
 		WorkspaceID:    invoke.WorkspaceID,
 		AgentSessionID: input.SessionID,
 		AfterVersion:   afterVersion,
-		MessageLimit:   input.Limit,
+		SkipMessages:   true,
 		Timeout:        timeout,
 	})
 	if err != nil {
 		return nil, err
 	}
-	return waitCommandResult{
-		ImageLocalPath: p.imageLocalPathResolver(ctx, invoke.WorkspaceID),
-		Result:         result,
-	}, nil
+	return waitCommandResult{Result: result}, nil
 }
 
 func (p Provider) runTurnResources(ctx context.Context, invoke framework.InvokeContext, input turnResourcesInput) (any, error) {
@@ -271,9 +266,7 @@ func waitJSONValue(result any) map[string]any {
 	return map[string]any{
 		"agentSessionId": waited.Result.Session.ID,
 		"session":        sessionSummaryValue(waited.Result.Session),
-		"messages":       messageCompactValues(waited.Result.Messages, waited.ImageLocalPath),
 		"latestVersion":  waited.Result.LatestVersion,
-		"hasMore":        waited.Result.HasMore,
 		"effectiveAfter": waited.Result.EffectiveAfter,
 		"timedOut":       waited.Result.TimedOut,
 		"reason":         string(waited.Result.Reason),


### PR DESCRIPTION
## Summary

- remove `--limit` from `agent wait` and stop returning `messages` or `hasMore`
- preserve `--after-version`, `effectiveAfter`, and narrow stop-point metadata for reliable synchronization
- skip transcript-window collection in the CLI wait path and document the low-context contract
- add daemon and CLI regression coverage for the reduced command schema and response

## Verification

- `go test ./service/agent ./service/cli/providers/agentcontext`
- `pnpm check:changed`
- `pnpm check:full`
- `make dev-web`
- live hidden Codex E2E: observed the turn in `running`, then `agent wait` blocked for 8.65s and returned `completed`/`settled` with `timedOut=false`, no message pagination fields, and the final `E2E_WAIT_OK` output confirmed via `session-summary`

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `agent wait` return low-context results only. Removes message pagination from the wait path for faster, more reliable synchronization.

- **Refactors**
  - Dropped `--limit` from `agent wait` and removed `messages`/`hasMore` from the JSON result.
  - Added `SkipMessages` to `WaitInput`; service fast-path now returns only compact session status, wait reason, `latestVersion`, `effectiveAfter`, and `timedOut`. Negative `messageLimit` is valid only with `SkipMessages`.
  - CLI always calls wait with `SkipMessages=true`; schema now exposes only `session-id`, `after-version`, and `timeout-ms`.
  - Preserved `--after-version` and `effectiveAfter` to keep wait cursors stable.
  - Updated docs to describe the low-context contract; added daemon/CLI tests to cover the new shape.

- **Migration**
  - Stop passing `--limit` to `agent wait`.
  - Stop reading `messages` or `hasMore` from wait responses.
  - Use `agent session-summary` to fetch transcript context after a wait.
  - Continue chaining with `--after-version <waitAfterVersion>` from `agent send` as before.

<sup>Written for commit c99ada189e5ab4562aba3edd6083c9da0fd74692. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

