### PR TITLE
fix(agent-gui): hide approval transport tool cards

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2881,6 +2881,13 @@ runtime messages
 Check stale prompt IDs, answered prompt filtering, bottom dock state, and
 selected conversation synchronization together.
 
+Approval transport calls are interaction plumbing, not transcript content.
+Conversation projection must remove top-level and delegated-task tool calls
+identified by `callType=approval` or `toolName=Approval` before they reach
+React. Pending approvals remain sourced from canonical Interaction state, so
+hiding running, completed, and failed Approval tool cards must not remove the
+actionable approval surfaces.
+
 ### Composer Settings
 
 ```text

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
@@ -703,9 +703,18 @@ describe("projectAgentConversationVM", () => {
 
     expect("pendingApproval" in conversation).toBe(false);
     expect("pendingInteractivePrompt" in conversation).toBe(false);
+    expect(
+      conversation.rows.flatMap((row) =>
+        row.kind === "tool-group" ? row.calls : []
+      )
+    ).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ toolName: "Approval" })
+      ])
+    );
   });
 
-  it("surfaces a pending approval nested inside a delegated subagent's steps", () => {
+  it("hides a pending approval nested inside a delegated subagent's steps", () => {
     const detail = detailViewModel({
       turns: [
         {
@@ -764,7 +773,71 @@ describe("projectAgentConversationVM", () => {
     const conversation = projectAgentConversationVM(detail);
 
     expect("pendingApproval" in conversation).toBe(false);
+    const taskCall = conversation.rows
+      .flatMap((row) => (row.kind === "tool-group" ? row.calls : []))
+      .find((call) => call.toolName === "Task");
+    expect(taskCall?.task?.steps).toEqual([]);
   });
+
+  it.each([
+    ["working", "working"],
+    ["completed", "completed"],
+    ["failed", "failed"]
+  ] as const)(
+    "hides %s approval tool calls without hiding neighboring tools",
+    (status, statusKind) => {
+      const conversation = projectAgentConversationVM(
+        detailViewModel({
+          turns: [
+            {
+              id: "turn-1",
+              userMessage: { id: "user-1", body: "Write it" },
+              userMessages: [{ id: "user-1", body: "Write it" }],
+              agentMessages: [],
+              toolCalls: [],
+              toolCallCount: 2,
+              hasFailedToolCall: statusKind === "failed",
+              agentItems: [
+                {
+                  kind: "tool-calls",
+                  id: "tools-1",
+                  toolCalls: [
+                    {
+                      id: "call:write-1",
+                      name: "Write file",
+                      toolName: "Write",
+                      callType: "tool",
+                      status: "completed",
+                      statusKind: "completed",
+                      summary: "hello.md",
+                      payload: null
+                    },
+                    {
+                      id: `call:approval-${status}`,
+                      name: "Approval",
+                      toolName: "Approval",
+                      callType: "approval",
+                      status,
+                      statusKind,
+                      summary: "/workspace/hello.md",
+                      payload: null
+                    }
+                  ],
+                  toolCallCount: 2,
+                  hasFailedToolCall: statusKind === "failed"
+                }
+              ]
+            }
+          ]
+        })
+      );
+
+      const visibleCalls = conversation.rows.flatMap((row) =>
+        row.kind === "tool-group" ? row.calls : []
+      );
+      expect(visibleCalls.map((call) => call.toolName)).toEqual(["Write"]);
+    }
+  );
 
   it("surfaces a pending ask-user prompt nested inside a delegated subagent's steps", () => {
     const detail = detailViewModel({

--- a/packages/agent/gui/shared/agentConversation/projection/agentTaskProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentTaskProjection.ts
@@ -11,6 +11,7 @@ import {
 } from "./agentInteractiveProjection";
 import {
   inferToolCallType,
+  isApprovalToolCall,
   normalizeToolName,
   resolveAgentToolRendererKind
 } from "./agentToolRendererKind";
@@ -87,6 +88,9 @@ function normalizeTaskSteps(
       stringValue(step.tool_name) ??
       stringValue(step.name);
     const callType = stringValue(step.callType) ?? stringValue(step.call_type);
+    if (isApprovalToolCall({ toolName, callType })) {
+      return [];
+    }
     const inputPayload =
       objectValue(step.toolInput) ?? objectValue(step.tool_input);
     const outputPayload =

--- a/packages/agent/gui/shared/agentConversation/projection/agentToolRendererKind.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentToolRendererKind.ts
@@ -132,6 +132,16 @@ export function inferToolCallType(toolName: string | null | undefined): string {
   return "tool";
 }
 
+export function isApprovalToolCall(call: {
+  toolName: string | null | undefined;
+  callType: string | null | undefined;
+}): boolean {
+  return (
+    normalizeCallType(call.callType) === "approval" ||
+    normalizeToolName(call.toolName) === "approval"
+  );
+}
+
 export function normalizeToolName(value: string | null | undefined): string {
   return (value ?? "")
     .replace(/[_\s-]+/g, "")

--- a/packages/agent/gui/shared/agentConversation/projection/agentTurnSequenceProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentTurnSequenceProjection.ts
@@ -10,6 +10,7 @@ import type {
   AgentThinkingContentVM
 } from "../contracts/agentMessageRowVM";
 import type { AgentToolCallVM } from "../contracts/agentToolCallVM";
+import { isApprovalToolCall } from "./agentToolRendererKind";
 import { projectAgentToolCall } from "./agentToolProjection";
 import { projectConversationUserRow } from "./agentConversationUserProjection";
 
@@ -66,6 +67,9 @@ export function buildAgentTurnSequenceItems(
           kind: "thinking",
           thinking: projectThinking(entry.thinking, turn.id)
         });
+        return;
+      }
+      if (isApprovalToolCall(entry.call)) {
         return;
       }
       sequence.push({

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentTimelineProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentTimelineProjection.spec.ts
@@ -25,7 +25,6 @@ describe("projectWorkspaceAgentTimelineToConversationVM", () => {
       "message",
       "tool-group",
       "tool-group",
-      "tool-group",
       "turn-summary"
     ]);
 
@@ -170,7 +169,6 @@ describe("projectWorkspaceAgentTimelineToConversationVM", () => {
     expect(conversation.rows.map((row) => row.kind)).toEqual([
       "message",
       "message",
-      "tool-group",
       "tool-group",
       "tool-group",
       "turn-summary"


### PR DESCRIPTION
## Summary

- filter Approval transport tool calls out of top-level conversation projections
- filter nested Approval calls out of delegated task steps
- preserve actionable approval prompts through canonical Interaction state
- document the AgentGUI projection boundary and add regression coverage for working, completed, and failed states

The extra Approval card was caused by transport plumbing being projected as transcript content alongside the user-visible tool call it authorized.

## Verification

- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 shared/agentConversation/projection/agentConversationProjection.spec.ts shared/agentConversation/projection/workspaceAgentTimelineProjection.spec.ts shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:full` (18 tasks passed)

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide internal Approval transport tool calls in the Agent GUI conversation so only user-visible tools appear. Approval prompts stay actionable via the canonical Interaction state.

- **Bug Fixes**
  - Filter Approval calls (by `callType=approval` or `toolName=Approval`) from top-level and delegated task projections.
  - Add `isApprovalToolCall` and apply it in turn and task projections to drop Approval rows.
  - Keep approvals actionable; hide working/completed/failed Approval cards without hiding neighboring tools.
  - Add regression tests for top-level, nested, and status cases; document the projection boundary.

<sup>Written for commit abe8ab5fc189d49a7f9e43d3005fdb3e37297321. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer filtering in shared projection with regression tests; pending approvals remain on canonical Interaction state, not transcript rows.
> 
> **Overview**
> Stops **Approval** transport tool calls from appearing as transcript tool cards when the same action is already surfaced through canonical Interaction state.
> 
> A shared **`isApprovalToolCall`** helper (by `callType=approval` or normalized `toolName=Approval`) is applied in **turn-sequence** and **delegated-task** projection so working, completed, and failed Approval rows never reach React. Neighboring tools (e.g. Write) stay visible. Timeline specs expect one fewer tool-group row where Approval was previously projected.
> 
> Architecture docs now state that approval transport is interaction plumbing, not transcript content, and that hiding Approval cards must not remove actionable approval UI from pending Interaction projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe8ab5fc189d49a7f9e43d3005fdb3e37297321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->