### PR TITLE
fix(agent): preserve pin update session version

### DIFF
--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -47,6 +47,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [AgentGUI loading disappears before active turn settles](./agent-session-lifecycle.md#agentgui-loading-disappears-before-active-turn-settles)
 - [Agent session stays loading after a completed turn](./agent-session-lifecycle.md#agent-session-stays-loading-after-a-completed-turn)
 - [AgentGUI model switch changes defaults but not the active session](./agent-session-lifecycle.md#agentgui-model-switch-changes-defaults-but-not-the-active-session)
+- [AgentGUI pin or unpin appears stuck for a live session](./agent-session-lifecycle.md#agentgui-pin-or-unpin-appears-stuck-for-a-live-session)
 - [Agent GUI provider tab shows fused or stale conversations](./agent-session-lifecycle.md#agent-gui-provider-tab-shows-fused-or-stale-conversations)
 - [Agent GUI no-project sessions appear under a user project](./agent-session-lifecycle.md#agent-gui-no-project-sessions-appear-under-a-user-project)
 - [Agent session restore breaks when durable snapshot ownership is split](./agent-session-lifecycle.md#agent-session-restore-breaks-when-durable-snapshot-ownership-is-split)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -321,6 +321,41 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [service.go](../../../services/tuttid/service/agent/service.go)
   [service_session_list.go](../../../services/tuttid/service/agent/service_session_list.go)
 
+### AgentGUI pin or unpin appears stuck for a live session
+
+- Symptom:
+  Pinning or unpinning a conversation backed by a live runtime succeeds in the
+  daemon, but the rail does not move the row or update its action until a later
+  list refresh. Old conversations without a live runtime update immediately.
+- Quick checks:
+  Correlate `pin_result` with `agent.activity.store.session_version_regression`.
+  Compare the command response's `updatedAtUnixMs` with the engine's current
+  session version, then inspect the exported session for a newer
+  `pinnedAtUnixMs`. A fast command carrying the new pin value but an older
+  `updatedAtUnixMs` identifies a stale runtime projection, not a slow database
+  write.
+- Root cause:
+  Durable metadata updates advance the persisted session timestamp. When a live
+  runtime session is also present, the service merges persisted metadata such
+  as `pinnedAtUnixMs` into the runtime projection. If that merge keeps the older
+  runtime timestamp, the frontend's monotonic session reducer correctly rejects
+  the whole stale response, including the new pin value.
+- Fix:
+  Merge session freshness monotonically across runtime and persistence using
+  the newer timestamp. Pin responses that advance the session version must also
+  include protocol-v2 active/latest turn state so accepting the metadata update
+  cannot clear a running turn. Do not weaken frontend version checks or hide the
+  mismatch behind delayed refetches.
+- Validation:
+  Cover a live runtime session whose persisted pin update is newer, a newer
+  runtime snapshot that must not regress, and a running turn that remains
+  attached to the pin response. Run `go test ./services/tuttid/service/agent`
+  plus daemon lint, tests, and build.
+- References:
+  [service.go](../../../services/tuttid/service/agent/service.go)
+  [service_session.go](../../../services/tuttid/service/agent/service_session.go)
+  [sessionEntities.reducer.ts](../../../packages/agent/activity-core/src/engine/sessionEntities.reducer.ts)
+
 ### AgentGUI model switch changes defaults but not the active session
 
 - Symptom:

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -579,7 +579,11 @@ func (s *Service) UpdatePin(ctx context.Context, workspaceID string, agentSessio
 			runtime,
 			s.controller().CanResume(runtimeResumeInputFromRuntimeSession(runtime)),
 		)
-		return mergePersistedSessionState(service, persisted), nil
+		return s.withProtocolV2TurnState(
+			ctx,
+			workspaceID,
+			mergePersistedSessionState(service, persisted),
+		)
 	}
 	return sessionFromPersisted(
 		persisted,

--- a/services/tuttid/service/agent/service_session.go
+++ b/services/tuttid/service/agent/service_session.go
@@ -177,6 +177,10 @@ func mergePersistedSessionState(session Session, persisted PersistedSession) Ses
 	}
 	session.PermissionConfig = composerPermissionConfig(session.Provider, permissionModeIDFromSettings(session.Settings), preferencesbiz.DefaultDesktopLocale)
 	session.PinnedAtUnixMS = persisted.PinnedAtUnixMS
+	if persisted.UpdatedAtUnixMS > 0 &&
+		(session.UpdatedAt == nil || persisted.UpdatedAtUnixMS > session.UpdatedAt.UnixMilli()) {
+		session.UpdatedAt = timeFromUnixMSPointer(persisted.UpdatedAtUnixMS)
+	}
 	session.Metadata = persisted.Metadata
 	return session
 }

--- a/services/tuttid/service/agent/service_update_pin_test.go
+++ b/services/tuttid/service/agent/service_update_pin_test.go
@@ -1,0 +1,126 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
+)
+
+func TestServiceUpdatePinReturnsFreshPersistedVersionAndLiveTurn(t *testing.T) {
+	runtime := newFakeRuntime()
+	runtime.sessions["ws-1:session-1"] = ProviderRuntimeSession{
+		ID:              "session-1",
+		WorkspaceID:     "ws-1",
+		Provider:        "codex",
+		Cwd:             "/workspace",
+		Status:          "working",
+		CreatedAtUnixMS: 1,
+		UpdatedAtUnixMS: 100,
+	}
+	reader := &pinUpdateSessionReader{
+		fakeSessionReader: &fakeSessionReader{
+			sessions: map[string]PersistedSession{
+				"ws-1:session-1": {
+					ID:              "session-1",
+					WorkspaceID:     "ws-1",
+					Provider:        "codex",
+					Cwd:             "/workspace",
+					CreatedAtUnixMS: 1,
+					UpdatedAtUnixMS: 100,
+					LastEventUnixMS: 100,
+					PinnedAtUnixMS:  0,
+					ActiveTurnID:    "turn-1",
+				},
+			},
+		},
+		updatedAtUnixMS: 200,
+	}
+	turn := agentactivitybiz.Turn{
+		WorkspaceID:     "ws-1",
+		AgentSessionID:  "session-1",
+		TurnID:          "turn-1",
+		Phase:           agentactivitybiz.TurnPhaseRunning,
+		UpdatedAtUnixMS: 150,
+	}
+	service := newIsolatedAgentService(runtime)
+	service.SessionReader = reader
+	service.TurnStore = failingTurnStore{
+		latestTurn: turn,
+		session: agentactivitybiz.Session{
+			ID:           "session-1",
+			WorkspaceID:  "ws-1",
+			ActiveTurnID: "turn-1",
+		},
+		turn: turn,
+	}
+
+	session, err := service.UpdatePin(context.Background(), "ws-1", "session-1", true)
+	if err != nil {
+		t.Fatalf("UpdatePin returned error: %v", err)
+	}
+	if session.PinnedAtUnixMS != 200 {
+		t.Fatalf("UpdatePin pinnedAtUnixMS = %d, want 200", session.PinnedAtUnixMS)
+	}
+	if session.UpdatedAt == nil || session.UpdatedAt.UnixMilli() != 200 {
+		t.Fatalf("UpdatePin updatedAt = %v, want persisted update timestamp 200", session.UpdatedAt)
+	}
+	if session.ActiveTurnID != "turn-1" || session.ActiveTurn == nil || session.ActiveTurn.TurnID != "turn-1" {
+		t.Fatalf("UpdatePin active turn = %#v id=%q, want turn-1", session.ActiveTurn, session.ActiveTurnID)
+	}
+
+	reader.updatedAtUnixMS = 250
+	session, err = service.UpdatePin(context.Background(), "ws-1", "session-1", false)
+	if err != nil {
+		t.Fatalf("UpdatePin(unpin) returned error: %v", err)
+	}
+	if session.PinnedAtUnixMS != 0 || session.UpdatedAt == nil || session.UpdatedAt.UnixMilli() != 250 {
+		t.Fatalf("UpdatePin(unpin) session = %#v, want unpinned at persisted version 250", session)
+	}
+
+	reconciled, err := service.Get(context.Background(), "ws-1", "session-1")
+	if err != nil {
+		t.Fatalf("Get after UpdatePin returned error: %v", err)
+	}
+	if reconciled.PinnedAtUnixMS != 0 || reconciled.UpdatedAt == nil || reconciled.UpdatedAt.UnixMilli() != 250 {
+		t.Fatalf("Get after UpdatePin session = %#v, want unpinned at persisted version 250", reconciled)
+	}
+}
+
+func TestMergePersistedSessionStateDoesNotRegressNewerRuntimeVersion(t *testing.T) {
+	runtimeUpdatedAt := time.UnixMilli(300)
+	session := mergePersistedSessionState(
+		Session{UpdatedAt: &runtimeUpdatedAt},
+		PersistedSession{UpdatedAtUnixMS: 200},
+	)
+
+	if session.UpdatedAt == nil || session.UpdatedAt.UnixMilli() != 300 {
+		t.Fatalf("merged updatedAt = %v, want newer runtime timestamp 300", session.UpdatedAt)
+	}
+}
+
+type pinUpdateSessionReader struct {
+	*fakeSessionReader
+	updatedAtUnixMS int64
+}
+
+func (r *pinUpdateSessionReader) UpdateSessionPinned(
+	_ context.Context,
+	workspaceID string,
+	agentSessionID string,
+	pinned bool,
+) (PersistedSession, bool, error) {
+	key := workspaceID + ":" + agentSessionID
+	session, ok := r.sessions[key]
+	if !ok {
+		return PersistedSession{}, false, nil
+	}
+	session.PinnedAtUnixMS = 0
+	if pinned {
+		session.PinnedAtUnixMS = r.updatedAtUnixMS
+	}
+	session.UpdatedAtUnixMS = r.updatedAtUnixMS
+	r.sessions[key] = session
+	return session, true, nil
+}


### PR DESCRIPTION
## Summary

- merge persisted pin freshness into live runtime sessions using the newer `updatedAt`
- preserve protocol-v2 active/latest turn state in pin responses
- add pin/unpin regression coverage and a durable AgentGUI troubleshooting entry

## Verification

- `go test ./service/agent -run TestServiceUpdatePinReturnsFreshPersistedVersionAndLiveTurn\|TestMergePersistedSessionStateDoesNotRegressNewerRuntimeVersion -count=1`
- `cd services/tuttid && go test ./...`
- `cd services/tuttid && go build ./...`
- `pnpm lint:go`
- `pnpm exec prettier --check docs/conventions/troubleshooting/agent-runtime.md docs/conventions/troubleshooting/agent-session-lifecycle.md`
- `pnpm check:full`

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale pin/unpin updates for live agent sessions by keeping the newer persisted session timestamp and returning turn state, so the UI reflects pin changes immediately. Prevents version regressions that previously made pins look stuck.

- **Bug Fixes**
  - Merge persisted `pinnedAtUnixMS` and use the newer `updatedAt` when combining persisted and runtime sessions in `mergePersistedSessionState`.
  - `UpdatePin` now wraps the merged session with protocol-v2 turn state, preserving active/latest turn info in the response.
  - Added regression tests for pin/unpin version monotonicity and live turn preservation, plus a troubleshooting entry clarifying the behavior.

<sup>Written for commit 44a9de9d04d2d4c77f1eeba0f92291281b44ba71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

