### PR TITLE
fix(agent-gui): stabilize queued prompt truncation

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2179,6 +2179,12 @@ Preview-mode AgentGUI surfaces are read-only for this runtime: they may render a
 existing queue if injected into the same context, but they must not enqueue,
 send now, edit, or delete queued prompts.
 
+Collapsed queued-prompt summaries own truncation disclosure for the whole row.
+Mention chips inside a queued summary keep their presentation and link behavior
+but do not use independent hover highlighting or open mention tooltips. When the
+rendered row actually overflows, one row-level tooltip shows the complete prompt
+as plain text; rows that fit do not show that tooltip.
+
 Queued prompt previews must treat prompt image blocks as the same send contract
 used by the composer and runtime: an image may be inline `data`, a staged
 `path`, or an HTTPS `url`. Do not cast queued images to data-only blocks or build

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
@@ -141,6 +141,47 @@ describe("AgentQueuedPromptPanel", () => {
     clientWidth.mockRestore();
   });
 
+  it("shows one plain-text tooltip for a truncated queue row instead of mention tooltips", async () => {
+    const scrollWidth = vi
+      .spyOn(HTMLElement.prototype, "scrollWidth", "get")
+      .mockImplementation(function (this: HTMLElement) {
+        return this.classList.contains("tsh-agent-object-token__main")
+          ? 240
+          : 120;
+      });
+    const clientWidth = vi
+      .spyOn(HTMLElement.prototype, "clientWidth", "get")
+      .mockReturnValue(120);
+    const { container } = render(
+      <AgentQueuedPromptPanel
+        queuedPrompts={[
+          textQueuedPrompt(
+            "queued-1",
+            "Before [@long session](mention://agent-session/session-1?workspaceId=room-1) after **details**"
+          )
+        ]}
+        drainingQueuedPromptId={null}
+        labels={labels}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+      />
+    );
+
+    const mention = container.querySelector('[data-agent-file-mention="true"]');
+    expect(mention).not.toBeNull();
+    expect(screen.queryByRole("tooltip")).toBeNull();
+
+    fireEvent.pointerMove(mention as Element, { pointerType: "mouse" });
+
+    const tooltips = await screen.findAllByRole("tooltip");
+    expect(tooltips).toHaveLength(1);
+    expect(tooltips[0]).toHaveTextContent("Before @long session after details");
+
+    scrollWidth.mockRestore();
+    clientWidth.mockRestore();
+  });
+
   it("renders queued mention prompts as entity tokens instead of raw markdown links", () => {
     const { container } = render(
       <AgentQueuedPromptPanel

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.tsx
@@ -12,8 +12,14 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuTrigger
+  DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+  useTextOverflow
 } from "@tutti-os/ui-system";
+import { extractPlainTextFromContent } from "@tutti-os/ui-rich-text";
 import {
   AgentMessageMarkdown,
   type AgentMessageMarkdownWorkspaceAppIcon
@@ -47,6 +53,8 @@ import {
 
 const EMPTY_WORKSPACE_APP_ICONS: readonly AgentMessageMarkdownWorkspaceAppIcon[] =
   [];
+const QUEUED_PROMPT_OVERFLOW_DESCENDANTS =
+  '[data-workspace-agent-markdown="true"], .tsh-agent-object-token__main';
 
 type QueuedPromptImageBlock = AgentPromptContentBlock & {
   type: "image";
@@ -247,12 +255,69 @@ function queuedPromptDisplayText(queuedPrompt: AgentGUIQueuedPromptVM): string {
 function queuedPromptTitle(queuedPrompt: AgentGUIQueuedPromptVM): string {
   const prompt = queuedPromptDisplayText(queuedPrompt);
   if (prompt) {
-    return prompt;
+    return extractPlainTextFromContent(prompt);
   }
   return queuedPromptImages(queuedPrompt)
     .map((image) => image.name?.trim() ?? "")
     .filter(Boolean)
     .join(", ");
+}
+
+interface AgentQueuedPromptTextProps {
+  displayText: string;
+  measurementRef?: React.RefObject<HTMLDivElement | null>;
+  onLinkClick?: (href: string) => void;
+  title: string;
+  workspaceAppIcons: readonly AgentMessageMarkdownWorkspaceAppIcon[];
+}
+
+function AgentQueuedPromptText({
+  displayText,
+  measurementRef,
+  onLinkClick,
+  title,
+  workspaceAppIcons
+}: AgentQueuedPromptTextProps): React.JSX.Element {
+  const { ref: overflowRef, overflowing } = useTextOverflow<HTMLDivElement>(
+    displayText,
+    QUEUED_PROMPT_OVERFLOW_DESCENDANTS
+  );
+  const content = (
+    <div
+      ref={(element) => {
+        overflowRef.current = element;
+        if (measurementRef) measurementRef.current = element;
+      }}
+      className={styles.composerQueuedPromptText}
+      data-overflowing={overflowing ? "true" : "false"}
+      onClick={(event) => {
+        if (event.target instanceof Element && event.target.closest("a")) {
+          event.stopPropagation();
+        }
+      }}
+    >
+      <AgentMessageMarkdown
+        content={displayText}
+        className="agent-gui-node__composer-queued-prompt-markdown"
+        inline
+        onLinkClick={onLinkClick}
+        previewMode
+        workspaceAppIcons={workspaceAppIcons}
+      />
+    </div>
+  );
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>{content}</TooltipTrigger>
+        {overflowing && title ? (
+          <TooltipContent className="max-w-[min(520px,calc(100vw-32px))] whitespace-pre-wrap text-left [overflow-wrap:anywhere]">
+            {title}
+          </TooltipContent>
+        ) : null}
+      </Tooltip>
+    </TooltipProvider>
+  );
 }
 
 export function AgentQueuedPromptPanel({
@@ -435,32 +500,19 @@ export function AgentQueuedPromptPanel({
               data-draining={isDraining ? "true" : "false"}
             >
               <div className={styles.composerQueuedPromptMain}>
-                <div className={styles.composerQueuedPromptBody} title={title}>
+                <div className={styles.composerQueuedPromptBody}>
                   {displayText ? (
-                    <div
-                      ref={
+                    <AgentQueuedPromptText
+                      displayText={displayText}
+                      measurementRef={
                         queuedPrompts.length === 1
                           ? singlePromptTextRef
                           : undefined
                       }
-                      className={styles.composerQueuedPromptText}
-                      onClick={(event) => {
-                        if (
-                          event.target instanceof Element &&
-                          event.target.closest("a")
-                        ) {
-                          event.stopPropagation();
-                        }
-                      }}
-                    >
-                      <AgentMessageMarkdown
-                        content={displayText}
-                        className="agent-gui-node__composer-queued-prompt-markdown"
-                        inline
-                        onLinkClick={onLinkClick}
-                        workspaceAppIcons={workspaceAppIcons}
-                      />
-                    </div>
+                      onLinkClick={onLinkClick}
+                      title={title}
+                      workspaceAppIcons={workspaceAppIcons}
+                    />
                   ) : null}
                   {images.length > 0 ? (
                     <div className={styles.composerQueuedPromptImages}>

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -7948,6 +7948,8 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 
 .agent-gui-node__composer-queued-prompt-list {
   display: grid;
+  width: 100%;
+  min-width: 0;
   gap: 0;
   max-height: 36px;
   overflow: hidden;
@@ -7958,6 +7960,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 
 .agent-gui-node__composer-queued-prompt-panel {
   display: grid;
+  min-width: 0;
   gap: 4px;
   position: relative;
   z-index: 1;
@@ -8021,6 +8024,9 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 
 .agent-gui-node__composer-queued-prompt-row {
   display: grid;
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 8px;
   align-items: center;
@@ -8033,13 +8039,16 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 
 .agent-gui-node__composer-queued-prompt-main {
   display: block;
+  width: 100%;
   min-width: 0;
 }
 
 .agent-gui-node__composer-queued-prompt-body {
   display: flex;
+  width: 100%;
   align-items: center;
   min-width: 0;
+  overflow: hidden;
   gap: 6px;
 }
 
@@ -8086,32 +8095,52 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 }
 
 .agent-gui-node__composer-queued-prompt-text {
+  position: relative;
+  width: 0;
+  max-width: 100%;
+  flex: 1 1 0;
   min-width: 0;
   margin: 0;
   color: var(--agent-gui-text-secondary, var(--text-secondary));
   font-size: 13px;
   line-height: 28px;
   overflow: hidden;
-  text-overflow: ellipsis;
+  text-overflow: clip;
   word-break: break-word;
   white-space: nowrap;
 }
 
+.agent-gui-node__composer-queued-prompt-text[data-overflowing="true"]::after {
+  content: "…";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 28px;
+  height: 28px;
+  background: linear-gradient(90deg, transparent, var(--background-panel) 52%);
+  color: var(--agent-gui-text-secondary, var(--text-secondary));
+  line-height: 28px;
+  text-align: right;
+  pointer-events: none;
+}
+
 .agent-gui-node__composer-queued-prompt-markdown {
   display: block;
+  width: 100%;
   min-width: 0;
   max-width: 100%;
   color: inherit;
   font-size: inherit;
   line-height: inherit;
   overflow: hidden;
-  text-overflow: ellipsis;
+  text-overflow: clip;
   white-space: nowrap;
 }
 
 .agent-gui-node__composer-queued-prompt-markdown
   [data-workspace-agent-markdown-shell="true"] {
   display: block;
+  width: 100%;
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
@@ -8122,7 +8151,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   [data-workspace-agent-markdown="true"] {
   display: block;
   overflow: hidden;
-  text-overflow: ellipsis;
+  text-overflow: clip;
   white-space: nowrap;
 }
 
@@ -8133,7 +8162,8 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 
 .agent-gui-node__composer-queued-prompt-markdown
   [data-agent-file-mention="true"] {
-  max-width: 100%;
+  width: max-content;
+  max-width: min(100%, var(--agent-mention-max-width, 16rem));
   color: inherit;
   vertical-align: baseline;
 }
@@ -8142,20 +8172,20 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   [data-agent-file-mention="true"].tsh-agent-object-token--entity {
   color: inherit;
   top: 3px;
+  max-width: min(100%, var(--agent-mention-max-width, 16rem));
   min-height: 24px;
   padding: 2px 4px;
   border: 1px solid transparent;
   border-radius: 4px;
   line-height: 20px;
-  transition:
-    background-color 140ms ease-in-out,
-    border-color 140ms ease-in-out;
+  transition: none;
 }
 
 .agent-gui-node__composer-queued-prompt-markdown
-  [data-agent-file-mention="true"].tsh-agent-object-token--entity:hover {
+  [data-agent-file-mention="true"].tsh-agent-object-token:hover {
   border-color: transparent;
-  background: color-mix(in srgb, var(--text-primary) 10%, transparent);
+  background: transparent;
+  text-decoration: none;
 }
 
 .agent-gui-node__composer-queued-prompt-markdown
@@ -8193,7 +8223,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 .agent-gui-node__composer-queued-prompt-panel[data-expanded="true"]
   .agent-gui-node__composer-queued-prompt-text {
   overflow: hidden;
-  text-overflow: ellipsis;
+  text-overflow: clip;
   white-space: nowrap;
 }
 
@@ -8206,12 +8236,14 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   .agent-gui-node__composer-queued-prompt-markdown
   [data-workspace-agent-markdown="true"] {
   overflow: hidden;
-  text-overflow: ellipsis;
+  text-overflow: clip;
   white-space: nowrap;
 }
 
 .agent-gui-node__composer-queued-prompt-actions {
   display: inline-flex;
+  justify-self: end;
+  flex: 0 0 auto;
   align-items: center;
   gap: 4px;
 }

--- a/packages/ui/system/src/components/mention-pill/truncating-pill-label.tsx
+++ b/packages/ui/system/src/components/mention-pill/truncating-pill-label.tsx
@@ -9,28 +9,42 @@ import {
 } from "../tooltip/tooltip";
 
 /**
- * 监测元素是否因 overflow 被省略号截断(scrollWidth > clientWidth)。
+ * 监测元素或指定后代是否因 overflow 被截断(scrollWidth > clientWidth)。
  * 返回要挂到「截断元素」上的 ref,以及是否正在溢出。随容器尺寸变化实时更新。
  */
 export function useTextOverflow<T extends HTMLElement = HTMLElement>(
-  watch: unknown
+  watch: unknown,
+  descendantSelector?: string
 ): { ref: React.RefObject<T | null>; overflowing: boolean } {
   const ref = React.useRef<T>(null);
   const [overflowing, setOverflowing] = React.useState(false);
 
   React.useEffect(() => {
     const element = ref.current;
-    if (!element || typeof ResizeObserver === "undefined") {
+    if (!element) {
       return;
     }
+    const overflowCandidates = (): HTMLElement[] => [
+      element,
+      ...(descendantSelector
+        ? element.querySelectorAll<HTMLElement>(descendantSelector)
+        : [])
+    ];
     const measure = (): void => {
-      setOverflowing(element.scrollWidth - element.clientWidth > 1);
+      setOverflowing(
+        overflowCandidates().some(
+          (candidate) => candidate.scrollWidth - candidate.clientWidth > 1
+        )
+      );
     };
     measure();
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
     const observer = new ResizeObserver(measure);
-    observer.observe(element);
+    for (const candidate of overflowCandidates()) observer.observe(candidate);
     return () => observer.disconnect();
-  }, [watch]);
+  }, [descendantSelector, watch]);
 
   return { ref, overflowing };
 }


### PR DESCRIPTION
## Summary

- constrain queued prompt rows so long plain text and mention tokens truncate at the row boundary
- replace per-mention hover tooltips with one row-level plain-text tooltip shown only on actual overflow
- reuse the UI System overflow hook and extend it to inspect nested overflow candidates without adding AgentGUI effects
- document the collapsed queue summary interaction contract

## Verification

- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/ui-system typecheck`
- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx` (16/16)
- `pnpm check:agent-gui-degradation`
- `pnpm check:ui-boundaries`
- `pnpm check:full` (18/18)

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes queued prompt truncation in Agent GUI and replaces per-mention hover tooltips with a single row-level plain-text tooltip shown only when the row actually overflows. This prevents layout jitter and makes long text and mention chips truncate cleanly.

- **Bug Fixes**
  - Truncate long text and mention chips at the row boundary; add a fade+ellipsis indicator.
  - Show one tooltip with plain text only on real overflow; mention chips no longer show their own tooltips or hover highlights.
  - Reuse and extend `useTextOverflow` in `@tutti-os/ui-system` to watch nested overflow candidates without new effects.
  - Convert queued prompt titles to plain text for tooltips; add tests for tooltip behavior and document the collapsed summary contract.

<sup>Written for commit 11ca014f08cb5a2b36ebc1add08e29c3e1ebfbfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

