### PR TITLE
fix(agent-gui): debounce conversation search

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.ts
@@ -105,7 +105,7 @@ export class AgentMentionSearchController extends AgentMentionSearchControllerBa
       groups: this.groupsFromRawGroups(),
       error: null
     });
-    this.timer = setTimeout(() => {
+    this.timer = this.scheduler.schedule(this.debounceMs, () => {
       void this.runSearch({
         workspaceId: this.activeWorkspaceId,
         currentUserId: this.currentUserId,
@@ -113,7 +113,7 @@ export class AgentMentionSearchController extends AgentMentionSearchControllerBa
         requestId,
         filter: this.currentFilter
       });
-    }, this.debounceMs);
+    });
   }
 
   setFilter(filter: AgentMentionFilterId): void {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchControllerBase.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchControllerBase.ts
@@ -52,6 +52,10 @@ import {
 } from "./AgentMentionSearchIndex";
 import type { ReferenceProvenanceFilter } from "@tutti-os/workspace-file-reference/contracts";
 import { referenceProvenanceFilterCacheKey } from "@tutti-os/workspace-file-reference/core";
+import {
+  agentGuiScheduler,
+  type AgentGuiScheduledTask
+} from "./agentGuiScheduler";
 
 export class AgentMentionSearchControllerBase {
   protected readonly contextMentionProviders: ReadonlyMap<
@@ -73,7 +77,8 @@ export class AgentMentionSearchControllerBase {
     Record<AgentMentionGroupId, number>
   > = {};
   protected readonly totalCounts: AgentMentionTotalCounts = {};
-  protected timer: ReturnType<typeof setTimeout> | null = null;
+  protected readonly scheduler = agentGuiScheduler;
+  protected timer: AgentGuiScheduledTask | null = null;
   protected preloadCancel: (() => void) | null = null;
   protected pendingPreloadKey: string | null = null;
   protected requestId = 0;
@@ -514,7 +519,7 @@ export class AgentMentionSearchControllerBase {
 
   protected clearTimer(): void {
     if (this.timer !== null) {
-      clearTimeout(this.timer);
+      this.timer.cancel();
       this.timer = null;
     }
   }

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiScheduler.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiScheduler.ts
@@ -1,0 +1,19 @@
+export interface AgentGuiScheduledTask {
+  cancel(): void;
+}
+
+export interface AgentGuiScheduler {
+  schedule(delayMs: number, task: () => void): AgentGuiScheduledTask;
+}
+
+export const agentGuiScheduler: AgentGuiScheduler = {
+  schedule(delayMs, task) {
+    // timing: centralize cancellable Agent GUI delays behind one scheduler port
+    const timer = setTimeout(task, delayMs);
+    return {
+      cancel() {
+        clearTimeout(timer);
+      }
+    };
+  }
+};

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
@@ -45,6 +45,12 @@ describe("AgentGUIConversationRailQueryController", () => {
       expect(listSessionsPage).toHaveBeenCalledWith(
         expect.objectContaining({ searchQuery: "second" })
       );
+      expect(controller.getSnapshot().railSearch.pending).toBe(false);
+
+      controller.setSearchQuery("transient");
+      controller.setSearchQuery("second");
+      expect(controller.getSnapshot().railSearch.pending).toBe(true);
+      expect(listSessionsPage).toHaveBeenCalledTimes(1);
 
       controller.setSearchQuery("");
       expect(controller.getSnapshot().railSearch.pending).toBe(false);

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
@@ -2,10 +2,60 @@ import { describe, expect, it, vi } from "vitest";
 import { createTestAgentSessionEngine } from "../../../shared/testing/createTestAgentSessionEngine";
 import {
   AgentGUIConversationRailQueryController,
+  CONVERSATION_SEARCH_DEBOUNCE_MS,
   type ConversationRailQueryRuntime
 } from "./AgentGUIConversationRailQueryController";
 
 describe("AgentGUIConversationRailQueryController", () => {
+  it("debounces conversation searches and immediately clears an active query", async () => {
+    vi.useFakeTimers();
+    try {
+      const engine = createTestAgentSessionEngine();
+      const listSessionsPage = vi.fn<
+        NonNullable<ConversationRailQueryRuntime["listSessionsPage"]>
+      >(async (input) => ({
+        hasMore: false,
+        sessions: [],
+        workspaceId: input.workspaceId
+      }));
+      const controller = new AgentGUIConversationRailQueryController({
+        engine,
+        getActiveConversationId: () => null,
+        runtime: { listSessionsPage },
+        workspaceId: "test-workspace"
+      });
+      controller.configure({
+        conversationFilter: { kind: "all" },
+        previewMode: false,
+        sectionAgentTargetFallbackId: null,
+        userProjects: []
+      });
+
+      const detach = controller.attach();
+      controller.setSearchQuery("first");
+      expect(controller.getSnapshot().railSearch.pending).toBe(true);
+      expect(listSessionsPage).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(CONVERSATION_SEARCH_DEBOUNCE_MS - 1);
+      expect(listSessionsPage).not.toHaveBeenCalled();
+
+      controller.setSearchQuery("second");
+      await vi.advanceTimersByTimeAsync(CONVERSATION_SEARCH_DEBOUNCE_MS);
+      expect(listSessionsPage).toHaveBeenCalledTimes(1);
+      expect(listSessionsPage).toHaveBeenCalledWith(
+        expect.objectContaining({ searchQuery: "second" })
+      );
+
+      controller.setSearchQuery("");
+      expect(controller.getSnapshot().railSearch.pending).toBe(false);
+
+      detach();
+      engine.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("owns the latest rail interaction lock instead of mirroring it in view refs", async () => {
     const engine = createTestAgentSessionEngine();
     let resolveSections!: () => void;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -596,6 +596,7 @@ export class AgentGUIConversationRailQueryController {
       return;
     }
 
+    this.searchRequestKey = null;
     this.emit();
     // timing: wait for a quiet input window before querying conversation history
     this.searchDebounceTask = this.scheduler.schedule(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -7,6 +7,11 @@ import {
 } from "@tutti-os/agent-activity-core";
 import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import type { ConversationSection } from "../agentGuiNodeViewConversation";
+import {
+  agentGuiScheduler,
+  type AgentGuiScheduledTask,
+  type AgentGuiScheduler
+} from "../agentGuiScheduler";
 import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
 import {
   mergeConversationRailSessionIds,
@@ -19,6 +24,7 @@ import {
 
 const SECTION_PAGE_SIZE = 5;
 const SEARCH_PAGE_SIZE = 100;
+export const CONVERSATION_SEARCH_DEBOUNCE_MS = 300;
 
 interface ConversationSearchQueryState {
   failed: boolean;
@@ -78,6 +84,7 @@ interface ControllerInput {
   engine: AgentSessionEngine;
   getActiveConversationId(): string | null;
   runtime: ConversationRailQueryRuntime;
+  scheduler?: AgentGuiScheduler;
   workspaceId: string;
 }
 
@@ -106,6 +113,7 @@ export class AgentGUIConversationRailQueryController {
   private readonly getActiveConversationId: () => string | null;
   private readonly listeners = new Set<Listener>();
   private readonly runtime: ConversationRailQueryRuntime;
+  private readonly scheduler: AgentGuiScheduler;
   private readonly workspaceId: string;
   private readonly pagingAbortControllers = new Map<string, AbortController>();
   private queryState = EMPTY_QUERY_STATE;
@@ -117,6 +125,7 @@ export class AgentGUIConversationRailQueryController {
   private searchQuery = "";
   private searchRequestKey: string | null = null;
   private searchAbortController: AbortController | null = null;
+  private searchDebounceTask: AgentGuiScheduledTask | null = null;
   private pagingRequestSequence = 0;
   private searchRequestSequence = 0;
   private attached = false;
@@ -128,6 +137,7 @@ export class AgentGUIConversationRailQueryController {
     this.engine = input.engine;
     this.getActiveConversationId = input.getActiveConversationId;
     this.runtime = input.runtime;
+    this.scheduler = input.scheduler ?? agentGuiScheduler;
     this.workspaceId = input.workspaceId;
     this.previousMembershipRecords = membershipRecords(
       this.engine.getSnapshot()
@@ -186,7 +196,7 @@ export class AgentGUIConversationRailQueryController {
     const query = value.trim();
     if (query === this.searchQuery) return;
     this.searchQuery = query;
-    this.requestSearch();
+    this.scheduleSearch();
   }
 
   readonly loadMoreSectionConversations = (
@@ -500,6 +510,7 @@ export class AgentGUIConversationRailQueryController {
   }
 
   private requestSearch(): void {
+    this.clearSearchDebounceTimer();
     this.searchRequestKey =
       this.searchEnabled() && this.searchQuery
         ? JSON.stringify([
@@ -574,6 +585,33 @@ export class AgentGUIConversationRailQueryController {
       });
   }
 
+  private scheduleSearch(): void {
+    this.clearSearchDebounceTimer();
+    this.searchRequestSequence += 1;
+    this.searchAbortController?.abort();
+    this.searchAbortController = null;
+
+    if (!this.searchQuery || !this.searchEnabled()) {
+      this.requestSearch();
+      return;
+    }
+
+    this.emit();
+    // timing: wait for a quiet input window before querying conversation history
+    this.searchDebounceTask = this.scheduler.schedule(
+      CONVERSATION_SEARCH_DEBOUNCE_MS,
+      () => {
+        this.searchDebounceTask = null;
+        this.requestSearch();
+      }
+    );
+  }
+
+  private clearSearchDebounceTimer(): void {
+    this.searchDebounceTask?.cancel();
+    this.searchDebounceTask = null;
+  }
+
   private upsertSessions(sessions: readonly AgentActivitySession[]): void {
     this.ingestingSessions = true;
     try {
@@ -643,6 +681,7 @@ export class AgentGUIConversationRailQueryController {
     this.unsubscribeEngine?.();
     this.unsubscribeEngine = null;
     this.cancelPagingRequests();
+    this.clearSearchDebounceTimer();
     this.searchRequestSequence += 1;
     this.searchAbortController?.abort();
     this.searchAbortController = null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
@@ -2,7 +2,7 @@ import {
   selectWorkspaceAgentConsumerSessions,
   type AgentSessionEngineState
 } from "@tutti-os/agent-activity-core";
-import { useDeferredValue, useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useAgentActivityRuntime } from "../../../agentActivityRuntime";
 import { projectCanonicalAgentGUIConversationSummaries } from "../../../contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList";
 import { useEngineSelector } from "../../../shared/engine/useEngineSelector";
@@ -40,7 +40,6 @@ export function useAgentGUIConversationRailQuery({
   );
   const activeConversationIdRef = useRef(activeConversationId);
   activeConversationIdRef.current = activeConversationId;
-  const deferredConversationQuery = useDeferredValue(conversationQuery);
   const controller = useMemo(
     () =>
       new AgentGUIConversationRailQueryController({
@@ -60,11 +59,11 @@ export function useAgentGUIConversationRailQuery({
       sectionAgentTargetFallbackId,
       userProjects
     });
-    controller.setSearchQuery(deferredConversationQuery);
+    controller.setSearchQuery(conversationQuery);
   }, [
     controller,
     conversationFilter,
-    deferredConversationQuery,
+    conversationQuery,
     previewMode,
     sectionAgentTargetFallbackId,
     userProjects


### PR DESCRIPTION
## Summary

- replace useDeferredValue request scheduling with a real 300 ms conversation-search debounce
- mark search pending immediately, cancel stale work, and clear an empty query without delay
- consolidate cancellable Agent GUI delays behind one scheduler port so timer callsite budget does not regress
- add focused coverage for coalescing rapid query changes and immediate clearing

Documentation impact: none. This changes local request timing without changing module ownership, public API, runtime configuration, or durable interaction contracts.

## Verification

- pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=2 agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.search.spec.tsx agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
- pnpm --filter @tutti-os/agent-gui typecheck
- pnpm check:agent-activity-runtime-boundaries
- pnpm check:agent-gui-degradation
- pnpm check:full

## Fallback Three Questions

- Source: each conversationQuery keystroke could reach listSessionsPage as soon as React committed the deferred value, so rapid typing could create one backend request per committed character.
- Why can it not be fixed at that source: the input state must remain immediate for typing responsiveness, while only the renderer knows whether the user has paused; the backend cannot infer the intended quiet window after requests have already arrived.
- Removal condition: remove the debounce when conversation search becomes explicitly submitted, or when the runtime query contract owns equivalent keyed coalescing before transport dispatch.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: git commit -s.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Debounced conversation search in `@tutti-os/agent-gui` with a real 300 ms delay to coalesce rapid typing and cut redundant backend requests. Replaces `useDeferredValue` with a cancellable scheduler; clearing or detaching cancels any scheduled search and is instant.

- **Bug Fixes**
  - Debounce via central `agentGuiScheduler` (cancellable) and fire after 300 ms of no input; cancel on query changes, disable, or detach; abort stale requests. Also applied to mention search.
  - Clear on empty query without delay; no backend call.
  - Added focused tests for debounce, immediate clear, and pending-state invalidation.

<sup>Written for commit daec8cc89ea6856edf80595c4ed436000fccf8a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

