### PR TITLE
docs(agent-gui): clarify approval transcript policy

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -995,23 +995,29 @@ output into `fileChanges.files` and emit a `turn.updated` patch carrying those
 source for the response-tail changed-file list; tool-only payloads are not a
 substitute for that state.
 
-Approval tool calls may wrap the pending Edit/Write input so the transcript can
-preview what the user approved. Treat that nested input as preview-only data:
-Approval rows must not contribute edit diff counts, changed-file summaries, or
-undo/reapply patch batches. The executed file-change tool output remains the
-source of truth for edit statistics and reversible patches.
+Approval transport calls may wrap pending Edit/Write input, but they are
+interaction plumbing rather than transcript content. Preserve that nested input
+in durable activity for correlation and diagnostics only. Conversation
+projection removes top-level and delegated-task calls identified by
+`callType=approval` or `toolName=Approval` before they reach React. Those calls
+must not contribute edit diff counts, changed-file summaries, or undo/reapply
+patch batches. The executed file-change tool output remains the source of truth
+for edit statistics and reversible patches. Actionable approval surfaces read
+canonical Interaction state, so filtering working, completed, and failed
+Approval tool rows must not remove a pending approval.
 
 Claude SDK interactive tools must preserve `callType: "interactive"` on the
-top-level durable tool payload, not only inside `metadata`. Agent GUI and
-Message Center both project approvals and prompts from the normalized top-level
-call type. For `AskUserQuestion`, renderer payloads may keep
+top-level durable tool payload, not only inside `metadata`, so historical
+display-only prompt rows can be classified consistently. Actionable Agent GUI
+and Message Center approvals and prompts come from canonical Interaction state,
+not transcript tool rows. For `AskUserQuestion`, renderer payloads may keep
 `answersByQuestionId` keyed by stable UI question ids, but the Claude SDK
 permission callback must return `updatedInput.answers` keyed by the full
 question text because current Claude SDK result rendering looks up answers by
 question text. Legacy Claude ACP `AskUserQuestion` failures may be hidden only
 when the recorded failure says the tool is unavailable; waiting or completed
-Claude SDK `AskUserQuestion` calls must remain in the Agent GUI detail
-projection so the composer prompt can render.
+Claude SDK `AskUserQuestion` calls may remain in the Agent GUI detail projection
+as display-only history without becoming an actionable prompt source.
 
 Runtime interactive prompts also travel through session state. Provider
 adapters expose them as `SessionStateSnapshot.pendingInteractive`; runtime
@@ -2884,23 +2890,18 @@ hosts. Tutti personal edition must not enable member or group-chat filtering.
 ### Approval Or Ask-User Prompt
 
 ```text
-runtime messages
-  -> timeline projection
+provider interaction request
+  -> durable Interaction(pending)
+  -> interaction_update
+  -> AgentSessionEngine pendingInteractions selector
   -> prompt view model
   -> AgentInteractivePromptSurface or approval card
   -> runtime submitInteractive
-  -> snapshot/message update
+  -> durable Interaction(answered or superseded)
 ```
 
 Check stale prompt IDs, answered prompt filtering, bottom dock state, and
 selected conversation synchronization together.
-
-Approval transport calls are interaction plumbing, not transcript content.
-Conversation projection must remove top-level and delegated-task tool calls
-identified by `callType=approval` or `toolName=Approval` before they reach
-React. Pending approvals remain sourced from canonical Interaction state, so
-hiding running, completed, and failed Approval tool cards must not remove the
-actionable approval surfaces.
 
 ### Composer Settings
 


### PR DESCRIPTION
## Summary

- merge the Approval transport visibility rule into the existing tool-call and file-change guidance
- distinguish durable transport/history data from canonical Interaction-owned approval actionability
- update the Approval and AskUser prompt flow to start from durable Interaction state
- clarify that historical AskUser rows are display-only and remove the duplicate Approval rule

This follows up on #1173. The merged documentation said both that Approval rows could preview approved Edit/Write input and that Approval transport calls must never reach React. This PR resolves that contradiction without changing runtime behavior.

## Verification

- `pnpm exec prettier --check --config packages/configs/prettier/base.mjs docs/architecture/agent-gui-node.md`
- `pnpm check:changed --tail-lines 80`
- `pnpm check:full` (18 tasks passed)

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the Approval transcript policy in `agent-gui` docs: approvals come from durable Interaction state; Approval transport/tool calls are removed from the conversation projection before React and kept only for diagnostics; historical `AskUser` rows are display‑only.
Merges the Approval rule into the tool/file-change guidance, updates the prompt flow to start from durable Interaction state, and clarifies that Approval calls don’t affect diff counts or file summaries; documentation only, no runtime changes.

<sup>Written for commit 7c11d525a8c46cbb921b58d80df0aafa62a47e67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no code or runtime behavior changes.
> 
> **Overview**
> Resolves a **documentation contradiction** in `docs/architecture/agent-gui-node.md`: Approval transport is **interaction plumbing**, not transcript content—nested Edit/Write input stays in durable activity for **correlation/diagnostics only**, while conversation projection **strips** `callType=approval` / `toolName=Approval` rows before React. Those rows must not affect diff counts, file summaries, or undo/reapply; **actionable approvals** come from **canonical Interaction state**, so filtering completed Approval tool rows must not hide a pending approval.
> 
> The **Approval Or Ask-User Prompt** flow is rewritten to start from a provider interaction → durable `Interaction(pending)` → `interaction_update` → `pendingInteractions`, not from runtime messages through timeline projection. **AskUserQuestion** is clarified as **display-only** in the detail transcript; actionable prompts still come from Interaction state. A **duplicate** Approval visibility subsection under user-facing flows is **removed** because the merged tool-call guidance already covers it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c11d525a8c46cbb921b58d80df0aafa62a47e67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->