### PR TITLE
fix(agent-gui): preserve optimistic image presentation

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1488,6 +1488,16 @@ content in the pending record. Activation and existing-session submit share this
 contract. Their optimistic user messages use the authoritative payload shape:
 `content`, optional `displayPrompt`, and `text` resolved from `displayPrompt`
 before content-derived text.
+Timeline admission must treat renderable structured prompt content as a user
+message even when that derived text is empty. In particular, an image-only
+pending prompt projects through the same canonical user-message path and
+renders its image grid before the durable twin arrives; the GUI must not invent
+an `[Image]` text placeholder. Empty-text structured prompts use stable submit
+or event identity for duplicate suppression instead of sharing an empty-text
+key. Image presentation identity derives from the stable message identity and
+content position, never from a transport locator such as a prompt-asset path or
+durable attachment ID; locator promotion must not remount an already rendered
+image.
 After activation succeeds, the controller attaches the durable conversation and
 reconciles the optimistic user message before loading runtime projection. For
 Claude Code,

--- a/docs/architecture/agent-gui-refactor-plan.md
+++ b/docs/architecture/agent-gui-refactor-plan.md
@@ -710,6 +710,12 @@ engine pending record、typed command 和 selector 持有；旧 session-view/lis
 激活与普通提交共用同一 prompt envelope：pending record 保留用于投影的
 `content`/`displayPrompt`，物化后的 `runtimeContent` 只进入 typed transport
 command，不能覆盖乐观消息的展示语义。
+乐观消息准入同时认文本与可渲染的结构化 `content`；纯图片 prompt 即使派生文本
+为空，也必须沿 canonical 用户消息投影立即显示，并按 `clientSubmitId`/事件身份
+去重，禁止用 `[Image]` 占位或另建图片覆盖层。后续 `PendingBootstrapIntent` 必须
+复用这条投影契约，不能随 bootstrap submit 再造一套首消息展示逻辑。图片展示身份
+必须由稳定消息身份与内容位置派生；`path` 提升为 durable `attachmentId` 只更新读取
+定位，不能触发图片节点重挂载。
 Codex 合成的“实施计划”决策已收敛为 tuttid 语义 API 与 durable
 `plan_decision` saga：严格绑定 workspace/session/plan-turn/request/idempotency，
 设置目标值与发送步骤持久 checkpoint，发送未知结果只按稳定

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.promptHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.promptHelpers.spec.ts
@@ -39,6 +39,32 @@ describe("createOptimisticPromptMessage", () => {
     });
   });
 
+  it("keeps image-only content without synthesizing presentation text", () => {
+    const echo = createOptimisticPromptMessage({
+      ...echoInput,
+      content: [
+        {
+          type: "image",
+          mimeType: "image/png",
+          path: "/prompt-assets/screen.png",
+          name: "screen.png"
+        }
+      ]
+    });
+
+    expect(echo.payload).toMatchObject({
+      content: [
+        {
+          type: "image",
+          mimeType: "image/png",
+          path: "/prompt-assets/screen.png",
+          name: "screen.png"
+        }
+      ],
+      text: ""
+    });
+  });
+
   it("lets the durable twin replace the echo in an id-keyed merge", () => {
     const echo = createOptimisticPromptMessage(echoInput);
     const durableTwin: AgentActivityMessage = {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -348,6 +348,96 @@ describe("AgentTranscriptItemView render stability", () => {
     delete (window as { agentActivityRuntime?: unknown }).agentActivityRuntime;
   });
 
+  it("keeps a loaded optimistic image mounted when its durable attachment arrives", async () => {
+    const readPromptAsset = vi.fn(async () => ({
+      attachmentId: "prompt-asset-1",
+      data: "b3B0aW1pc3RpYw==",
+      mimeType: "image/png" as const,
+      name: "screen.png",
+      path: "/prompt-assets/screen.png"
+    }));
+    const readSessionAttachment = vi.fn(async () => ({
+      attachmentId: "attachment-1",
+      data: "ZHVyYWJsZQ==",
+      mimeType: "image/png" as const,
+      name: "screen.png"
+    }));
+    Object.defineProperty(window, "agentActivityRuntime", {
+      configurable: true,
+      value: {
+        readPromptAsset,
+        readSessionAttachment
+      } as Partial<AgentActivityRuntime>
+    });
+    const stableImageId = "client-submit:user:submit-1:image:0";
+    const optimisticMessage: AgentMessageContentVM = {
+      kind: "message-content",
+      id: "client-submit:user:submit-1:images:0",
+      turnId: "turn-1",
+      body: "",
+      contentKind: "image-grid",
+      images: [
+        {
+          id: stableImageId,
+          workspaceId: "room-1",
+          agentSessionId: "session-1",
+          mimeType: "image/png",
+          name: "screen.png",
+          path: "/prompt-assets/screen.png"
+        }
+      ],
+      occurredAtUnixMs: 1
+    };
+    const durableMessage: AgentMessageContentVM = {
+      ...optimisticMessage,
+      images: [
+        {
+          id: stableImageId,
+          workspaceId: "room-1",
+          agentSessionId: "session-1",
+          attachmentId: "attachment-1",
+          mimeType: "image/png",
+          name: "screen.png"
+        }
+      ],
+      occurredAtUnixMs: 2
+    };
+    const { rerender } = render(
+      <AgentMessageBlock
+        workspaceRoot="/workspace/demo"
+        basePath="/workspace/demo"
+        row={userMessageRow(optimisticMessage)}
+        thinkingLabel="Thought process"
+      />
+    );
+
+    const optimisticImage = await screen.findByRole("img", {
+      name: "screen.png"
+    });
+    expect(optimisticImage).toHaveAttribute(
+      "src",
+      "data:image/png;base64,b3B0aW1pc3RpYw=="
+    );
+
+    rerender(
+      <AgentMessageBlock
+        workspaceRoot="/workspace/demo"
+        basePath="/workspace/demo"
+        row={userMessageRow(durableMessage)}
+        thinkingLabel="Thought process"
+      />
+    );
+
+    expect(screen.getByRole("img", { name: "screen.png" })).toBe(
+      optimisticImage
+    );
+    expect(screen.queryByTestId("agent-gui-message-image-loading")).toBeNull();
+    expect(readPromptAsset).toHaveBeenCalledTimes(1);
+    expect(readSessionAttachment).not.toHaveBeenCalled();
+
+    delete (window as { agentActivityRuntime?: unknown }).agentActivityRuntime;
+  });
+
   it("renders a user prompt image directly from its remote HTTPS URL", () => {
     const readPromptAsset = vi.fn();
     Object.defineProperty(window, "agentActivityRuntime", {

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationUserProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationUserProjection.ts
@@ -43,8 +43,7 @@ function projectUserMessageContentParts(
       body: "",
       contentKind: "image-grid",
       images: imageBlocks.map((image, index) => ({
-        id:
-          image.path || image.attachmentId || `${message.id}:image:0:${index}`,
+        id: `${message.id}:image:${index}`,
         workspaceId: image.workspaceId,
         agentSessionId: image.agentSessionId,
         attachmentId: image.attachmentId,

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
@@ -551,6 +551,93 @@ describe("projectWorkspaceAgentMessagesToConversationVM", () => {
     );
   });
 
+  it("renders an image-only optimistic prompt without synthetic text", () => {
+    const conversation = projectWorkspaceAgentMessagesToConversationVM({
+      activity: activity(),
+      session: session(),
+      workspaceRoot: "/workspace/demo",
+      messages: [
+        message({
+          messageId: "client-submit:user:submit-image-1",
+          id: 0,
+          role: "user",
+          kind: "text",
+          payload: {
+            __agentGuiOptimisticPrompt: true,
+            clientSubmitId: "submit-image-1",
+            text: "",
+            content: [
+              {
+                type: "image",
+                mimeType: "image/png",
+                path: "/prompt-assets/screen.png",
+                name: "screen.png"
+              }
+            ]
+          }
+        })
+      ]
+    });
+
+    const userRow = conversation.rows.find(
+      (row) => row.kind === "message" && row.speaker === "user"
+    );
+
+    expect(userRow?.kind === "message" ? userRow.messages : null).toEqual([
+      expect.objectContaining({
+        body: "",
+        contentKind: "image-grid",
+        images: [
+          expect.objectContaining({
+            id: "client-submit:user:submit-image-1:image:0",
+            mimeType: "image/png",
+            name: "screen.png",
+            path: "/prompt-assets/screen.png"
+          })
+        ]
+      })
+    ]);
+
+    const durableConversation = projectWorkspaceAgentMessagesToConversationVM({
+      activity: activity(),
+      session: session(),
+      workspaceRoot: "/workspace/demo",
+      messages: [
+        message({
+          messageId: "client-submit:user:submit-image-1",
+          id: 1,
+          version: 1,
+          role: "user",
+          kind: "text",
+          payload: {
+            clientSubmitId: "submit-image-1",
+            text: "[Image]",
+            content: [
+              {
+                type: "image",
+                mimeType: "image/png",
+                attachmentId: "attachment-1",
+                name: "screen.png"
+              }
+            ]
+          }
+        })
+      ]
+    });
+    const durableUserRow = durableConversation.rows.find(
+      (row) => row.kind === "message" && row.speaker === "user"
+    );
+
+    expect(
+      durableUserRow?.kind === "message"
+        ? durableUserRow.messages[0]?.images?.[0]
+        : null
+    ).toMatchObject({
+      id: "client-submit:user:submit-image-1:image:0",
+      attachmentId: "attachment-1"
+    });
+  });
+
   it("renders displayPrompt instead of rich content text while preserving prompt images", () => {
     const conversation = projectWorkspaceAgentMessagesToConversationVM({
       activity: activity(),

--- a/packages/agent/gui/shared/workspaceAgentTimelineCanonical.ts
+++ b/packages/agent/gui/shared/workspaceAgentTimelineCanonical.ts
@@ -19,7 +19,8 @@ import {
   messageStatusKind,
   normalizedMessageBody,
   stripReviewProcessSummaryTitle,
-  thinkingStatusKind
+  thinkingStatusKind,
+  userMessageProjectionKey
 } from "./workspaceAgentTimelineMessageHelpers";
 import { timelineItemOwnerThreadId } from "./agentConversation/projection/subAgentTimelinePartition";
 import {
@@ -72,12 +73,13 @@ export function buildCanonicalWorkspaceAgentDetailView({
 
     if (role === "user") {
       const turnId = explicitTurnId || `seq:${item.seq || item.id}`;
-      if (!body) {
+      const projectionKey = userMessageProjectionKey(item, body);
+      if (!projectionKey) {
         continue;
       }
       if (
         isRecentDuplicateUserMessage(
-          recentUserMessages.get(normalizedMessageBody(body)),
+          recentUserMessages.get(projectionKey),
           item
         )
       ) {
@@ -97,7 +99,7 @@ export function buildCanonicalWorkspaceAgentDetailView({
       );
       turn.userMessages.push(message);
       turn.userMessage ??= message;
-      recentUserMessages.set(normalizedMessageBody(body), item);
+      recentUserMessages.set(projectionKey, item);
       continue;
     }
 

--- a/packages/agent/gui/shared/workspaceAgentTimelineMessageHelpers.ts
+++ b/packages/agent/gui/shared/workspaceAgentTimelineMessageHelpers.ts
@@ -113,6 +113,23 @@ export function normalizedMessageBody(body: string): string {
   return body.trim().replace(/\s+/g, " ");
 }
 
+export function userMessageProjectionKey(
+  item: WorkspaceAgentActivityTimelineItem,
+  body: string
+): string | null {
+  const normalizedBody = normalizedMessageBody(body);
+  if (normalizedBody) {
+    return `text:${normalizedBody}`;
+  }
+  if (!hasRenderableUserPromptContent(item.payload?.content)) {
+    return null;
+  }
+  const clientSubmitId = stringRecordValue(item.payload, "clientSubmitId");
+  return clientSubmitId
+    ? `client-submit:${clientSubmitId}`
+    : `event:${item.eventId}`;
+}
+
 export function isRecentDuplicateUserMessage(
   previous: WorkspaceAgentActivityTimelineItem | undefined,
   current: WorkspaceAgentActivityTimelineItem
@@ -143,6 +160,30 @@ export function isRecentDuplicateUserMessage(
   }
 
   return false;
+}
+
+function hasRenderableUserPromptContent(content: unknown): boolean {
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some((candidate) => {
+    if (
+      !candidate ||
+      typeof candidate !== "object" ||
+      Array.isArray(candidate)
+    ) {
+      return false;
+    }
+    const block = candidate as Record<string, unknown>;
+    if (block.type === "text") {
+      return typeof block.text === "string" && block.text.trim().length > 0;
+    }
+    return (
+      block.type === "image" &&
+      typeof block.mimeType === "string" &&
+      block.mimeType.trim().length > 0
+    );
+  });
 }
 
 function stringRecordValue(record: unknown, key: string): string | null {


### PR DESCRIPTION
## Summary

- admit image-only optimistic prompts through the canonical user-message projection even when derived text is empty
- keep image presentation identity stable while prompt-asset `path` is reconciled to a durable `attachmentId`, avoiding image remounts and loading flashes
- document the projection and reconciliation contract in the Agent GUI architecture and refactor plan

## Testing

- `pnpm --filter @tutti-os/agent-gui test` (1555 tests)
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm lint:ts`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:agent-gui-degradation`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:full` (pre-push, 18 tasks)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes image-only optimistic prompts in the Agent GUI. Images stay mounted when reconciling from `path` to `attachmentId`, removing flicker and fake “[Image]” text.

- **Bug Fixes**
  - Admit image-only optimistic prompts via the canonical user-message path even when derived text is empty.
  - Use stable image IDs from message identity and content index, not from `path` or `attachmentId`.
  - Promote `path` to durable `attachmentId` without remounting or re-reading, preserving the loaded image.
  - Deduplicate empty-text prompts by `clientSubmitId` or `eventId` using `userMessageProjectionKey`.
  - Documented the projection and reconciliation contract in the Agent GUI architecture and refactor plan.

<sup>Written for commit 0a4b76e5656a19787df0a8235ab2066f27845b68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

