### PR TITLE
fix(workbench): polish dock alignment and tooltips

### DIFF
--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -32,10 +32,10 @@ import {
   type ResolvedWorkbenchHostDockEntry
 } from "./dockEntries.ts";
 import {
-  DOCK_ICON_BASE_SIZE,
   DOCK_ICON_PEAK_SIZE,
   useDockMagnification
 } from "./dockMagnification.ts";
+import { resolveDockLabelTooltipAnchorRect } from "./dockLabelTooltipAnchor.ts";
 import {
   resolveWorkbenchHostDockScrollState,
   type WorkbenchHostDockScrollState
@@ -620,10 +620,7 @@ export function WorkbenchHostDock({
       }
 
       const dockRect = dockElement.getBoundingClientRect();
-      const anchorRect = resolveDockLabelTooltipAnchorRect({
-        dockPlacement,
-        slotElement: anchorElement
-      });
+      const anchorRect = resolveDockLabelTooltipAnchorRect(anchorElement);
       clearLabelTooltipOpenTimer();
       const nextTooltip = {
         anchorKey,
@@ -639,7 +636,7 @@ export function WorkbenchHostDock({
       activeLabelTooltipRef.current = nextTooltip;
       setActiveLabelTooltip(nextTooltip);
     },
-    [clearLabelTooltipOpenTimer, dockPlacement]
+    [clearLabelTooltipOpenTimer]
   );
 
   const scheduleLabelTooltipAfterRest = useCallback(
@@ -2838,36 +2835,6 @@ function dockLabelTooltipTarget(
   label: string
 ): WorkbenchHostDockLabelTooltipTarget {
   return { key, label: label.trim() };
-}
-
-function resolveDockLabelTooltipAnchorRect({
-  dockPlacement,
-  slotElement
-}: {
-  dockPlacement: WorkbenchHostProps["dockPlacement"];
-  slotElement: HTMLElement;
-}): {
-  height: number;
-  left: number;
-  top: number;
-  width: number;
-} {
-  const slotRect = slotElement.getBoundingClientRect();
-  if (dockPlacement === "left") {
-    return {
-      height: DOCK_ICON_BASE_SIZE,
-      left: slotRect.left,
-      top: slotRect.top + (slotRect.height - DOCK_ICON_BASE_SIZE) / 2,
-      width: DOCK_ICON_BASE_SIZE
-    };
-  }
-
-  return {
-    height: DOCK_ICON_BASE_SIZE,
-    left: slotRect.left + (slotRect.width - DOCK_ICON_BASE_SIZE) / 2,
-    top: slotRect.bottom - DOCK_ICON_BASE_SIZE,
-    width: DOCK_ICON_BASE_SIZE
-  };
 }
 
 function renderDockBadge(

--- a/packages/workbench/surface/src/host/dockChromeStyle.test.ts
+++ b/packages/workbench/surface/src/host/dockChromeStyle.test.ts
@@ -5,11 +5,15 @@ import test from "node:test";
 
 const styles = readFileSync(resolve("src/styles/workbench.css"), "utf8");
 
-test("left dock centers its icon column without an indicator gutter", () => {
+test("left dock aligns its icon column and scroll buttons on the offset axis", () => {
   assert.doesNotMatch(styles, /--desktop-dock-left-indicator-gutter/u);
   assert.match(
     styles,
-    /\.desktop-dock\[data-dock-placement="left"\] \.desktop-dock__items \{[\s\S]*?align-items: center;[\s\S]*?padding: var\(--desktop-dock-left-items-padding-block\) 0;/u
+    /--desktop-dock-left-items-padding-inline-end: calc\([\s\S]*?var\(--desktop-dock-left-axis-offset\) \* 2[\s\S]*?\);/u
+  );
+  assert.match(
+    styles,
+    /\.desktop-dock\[data-dock-placement="left"\] \.desktop-dock__items \{[\s\S]*?align-items: center;[\s\S]*?padding: var\(--desktop-dock-left-items-padding-block\)[\s\S]*?var\(--desktop-dock-left-items-padding-inline-end\)[\s\S]*?var\(--desktop-dock-left-items-padding-block\) 0;/u
   );
   assert.match(
     styles,
@@ -17,7 +21,7 @@ test("left dock centers its icon column without an indicator gutter", () => {
   );
   assert.match(
     styles,
-    /\.desktop-dock\[data-dock-placement="left"\] \.desktop-dock__scroll-button \{[\s\S]*?left: 50%;/u
+    /\.desktop-dock\[data-dock-placement="left"\] \.desktop-dock__scroll-button \{[\s\S]*?left: calc\(50% - var\(--desktop-dock-left-axis-offset\)\);/u
   );
 });
 
@@ -26,5 +30,12 @@ test("left dock renders state indicators beside open and minimized entries", () 
   assert.match(
     styles,
     /\.desktop-dock\[data-dock-placement="left"\][\s\S]*?\.desktop-dock__slot\[data-node-state="open"\]::before,[\s\S]*?\.desktop-dock__slot\[data-node-state="minimized"\]::before \{[\s\S]*?top: 50%;[\s\S]*?bottom: auto;[\s\S]*?left: calc\(var\(--desktop-dock-indicator-offset\) - 2px\);[\s\S]*?transform: translateY\(-50%\);/u
+  );
+});
+
+test("dock label tooltips keep a compact gap from the icon", () => {
+  assert.match(
+    styles,
+    /\.desktop-dock \{[\s\S]*?--desktop-dock-tooltip-gap: 12px;/u
   );
 });

--- a/packages/workbench/surface/src/host/dockLabelTooltipAnchor.test.ts
+++ b/packages/workbench/surface/src/host/dockLabelTooltipAnchor.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveDockLabelTooltipAnchorRect } from "./dockLabelTooltipAnchor.ts";
+
+function rect({
+  height,
+  left,
+  top,
+  width
+}: {
+  height: number;
+  left: number;
+  top: number;
+  width: number;
+}): DOMRect {
+  return {
+    bottom: top + height,
+    height,
+    left,
+    right: left + width,
+    top,
+    width,
+    x: left,
+    y: top,
+    toJSON: () => ({})
+  };
+}
+
+test("dock label tooltip anchors to the transformed icon bounds", () => {
+  const slotRect = rect({ height: 74, left: 20, top: 40, width: 74 });
+  const visualRect = rect({ height: 74, left: 20, top: 40, width: 74 });
+  const slotElement = {
+    getBoundingClientRect: () => slotRect,
+    querySelector: () => ({ getBoundingClientRect: () => visualRect })
+  } as unknown as HTMLElement;
+
+  assert.deepEqual(resolveDockLabelTooltipAnchorRect(slotElement), {
+    height: 74,
+    left: 20,
+    top: 40,
+    width: 74
+  });
+});
+
+test("dock label tooltip falls back to the slot bounds", () => {
+  const slotRect = rect({ height: 43.2, left: 20, top: 40, width: 43.2 });
+  const slotElement = {
+    getBoundingClientRect: () => slotRect,
+    querySelector: () => null
+  } as unknown as HTMLElement;
+
+  assert.deepEqual(resolveDockLabelTooltipAnchorRect(slotElement), {
+    height: 43.2,
+    left: 20,
+    top: 40,
+    width: 43.2
+  });
+});

--- a/packages/workbench/surface/src/host/dockLabelTooltipAnchor.ts
+++ b/packages/workbench/surface/src/host/dockLabelTooltipAnchor.ts
@@ -1,0 +1,21 @@
+const dockLabelTooltipVisualSelector = [
+  "[data-desktop-dock-icon-shell]",
+  ".desktop-dock__minimized-preview",
+  ".desktop-dock__minimized-stack-icon"
+].join(", ");
+
+export function resolveDockLabelTooltipAnchorRect(
+  slotElement: HTMLElement
+): Pick<DOMRect, "height" | "left" | "top" | "width"> {
+  const visualElement = slotElement.querySelector<HTMLElement>(
+    dockLabelTooltipVisualSelector
+  );
+  const anchorRect = (visualElement ?? slotElement).getBoundingClientRect();
+
+  return {
+    height: anchorRect.height,
+    left: anchorRect.left,
+    top: anchorRect.top,
+    width: anchorRect.width
+  };
+}

--- a/packages/workbench/surface/src/styles/workbench.css
+++ b/packages/workbench/surface/src/styles/workbench.css
@@ -729,6 +729,10 @@
   --desktop-dock-gap: 16px;
   --desktop-dock-items-padding: 6.3px;
   --desktop-dock-left-items-padding-block: 8px;
+  --desktop-dock-left-axis-offset: 24px;
+  --desktop-dock-left-items-padding-inline-end: calc(
+    var(--desktop-dock-left-axis-offset) * 2
+  );
   --desktop-dock-items-padding-block-end: 8px;
   --desktop-dock-icon-center-block-end: calc(
     var(--desktop-dock-items-padding-block-end) +
@@ -789,7 +793,7 @@
   --desktop-dock-scroll-button-gap: 32px;
   --desktop-dock-scroll-button-z-index: 120;
   --desktop-dock-scroll-fade-size: 48px;
-  --desktop-dock-tooltip-gap: 32px;
+  --desktop-dock-tooltip-gap: 12px;
   --desktop-dock-hover-panel-gap: 12px;
   position: relative;
   z-index: 1;
@@ -936,7 +940,9 @@
   height: 100%;
   align-items: center;
   flex-direction: column;
-  padding: var(--desktop-dock-left-items-padding-block) 0;
+  padding: var(--desktop-dock-left-items-padding-block)
+    var(--desktop-dock-left-items-padding-inline-end)
+    var(--desktop-dock-left-items-padding-block) 0;
 }
 
 .desktop-dock[data-dock-placement="left"][data-scroll-overflow="true"]
@@ -1067,7 +1073,7 @@
 }
 
 .desktop-dock[data-dock-placement="left"] .desktop-dock__scroll-button {
-  left: 50%;
+  left: calc(50% - var(--desktop-dock-left-axis-offset));
   transform: translateX(-50%) scale(0.94);
 }
 


### PR DESCRIPTION
## Summary

- shift the left Dock icon axis inward without changing the Dock container width
- keep vertical scroll controls aligned with the shifted icon axis
- preserve open and minimized state indicators beside left Dock icons
- anchor labels to the transformed icon bounds and use a compact 12px tooltip gap for both Dock placements

## Root cause

The left Dock used a centered 124px viewport while its controls, state indicators, and tooltips each used independent positioning rules. After tightening the icon axis, those rules drifted apart. Tooltips also used the fixed base icon size instead of the transformed visual bounds.

## Impact

Left Dock spacing is tighter, scroll controls stay centered on the icons, running-state dots remain visible, and tooltips no longer overlap icons or sit excessively far away.

## Validation

- `pnpm --filter @tutti-os/workbench-surface test` (209 tests)
- `pnpm --filter @tutti-os/workbench-surface typecheck`
- `pnpm check:changed --tail-lines 40`
- `pnpm check:full` (18 tasks)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the left Dock alignment and label tooltips for `@tutti-os/workbench-surface`. Icons, scroll controls, and tooltips now align on the same axis with a compact 12px gap.

- **Bug Fixes**
  - Align left Dock icon column and scroll buttons on an offset axis without changing dock width.
  - Keep open/minimized state indicators visible beside icons.
  - Anchor label tooltips to the transformed icon bounds with a 12px `--desktop-dock-tooltip-gap`.

- **Refactors**
  - Extracted `resolveDockLabelTooltipAnchorRect` to `dockLabelTooltipAnchor.ts` and removed the old in-component logic and `dockPlacement` dependency.
  - Added tests for tooltip anchoring and updated CSS assertions for the new variables.

<sup>Written for commit ddf3dbfb5805f0d0eecf5d7507e840ad2de83d10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

