### PR TITLE
fix(workbench): enforce snapshot writer isolation

### DIFF
--- a/apps/desktop/src/main/host/durableWorkspaceWindowCoordinator.test.ts
+++ b/apps/desktop/src/main/host/durableWorkspaceWindowCoordinator.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createDurableWorkspaceWindowCoordinator } from "./durableWorkspaceWindowCoordinator.ts";
+
+interface TestWindow {
+  id: string;
+}
+
+test("durable workspace window coordinator reuses and activates an existing owner", async () => {
+  const events: string[] = [];
+  const existingWindow = { id: "existing" };
+  const coordinator = createDurableWorkspaceWindowCoordinator<TestWindow>({
+    activate(window) {
+      events.push(`activate:${window.id}`);
+    },
+    find(workspaceID) {
+      events.push(`find:${workspaceID}`);
+      return existingWindow;
+    },
+    async open(workspaceID) {
+      events.push(`open:${workspaceID}`);
+      return { id: "opened" };
+    }
+  });
+
+  assert.equal(await coordinator.show("workspace-1"), existingWindow);
+  assert.deepEqual(events, ["find:workspace-1", "activate:existing"]);
+});
+
+test("durable workspace window coordinator shares one pending open per workspace", async () => {
+  let resolveOpen!: (window: { id: string }) => void;
+  let openCount = 0;
+  const openWindow = new Promise<{ id: string }>((resolve) => {
+    resolveOpen = resolve;
+  });
+  const coordinator = createDurableWorkspaceWindowCoordinator<TestWindow>({
+    activate() {},
+    find() {
+      return null;
+    },
+    open() {
+      openCount += 1;
+      return openWindow;
+    }
+  });
+
+  const firstShow = coordinator.show("workspace-1");
+  const secondShow = coordinator.show("workspace-1");
+  assert.equal(openCount, 1);
+
+  const window = { id: "opened" };
+  resolveOpen(window);
+  assert.equal(await firstShow, window);
+  assert.equal(await secondShow, window);
+});
+
+test("durable workspace window coordinator retries after a failed open", async () => {
+  let openCount = 0;
+  const coordinator = createDurableWorkspaceWindowCoordinator<TestWindow>({
+    activate() {},
+    find() {
+      return null;
+    },
+    async open() {
+      openCount += 1;
+      if (openCount === 1) {
+        throw new Error("open failed");
+      }
+      return { id: "recovered" };
+    }
+  });
+
+  await assert.rejects(coordinator.show("workspace-1"), /open failed/);
+  assert.deepEqual(await coordinator.show("workspace-1"), { id: "recovered" });
+  assert.equal(openCount, 2);
+});

--- a/apps/desktop/src/main/host/durableWorkspaceWindowCoordinator.ts
+++ b/apps/desktop/src/main/host/durableWorkspaceWindowCoordinator.ts
@@ -1,0 +1,34 @@
+export interface DurableWorkspaceWindowCoordinator<TWindow> {
+  show(workspaceID: string): Promise<TWindow>;
+}
+
+export function createDurableWorkspaceWindowCoordinator<TWindow>(input: {
+  activate(window: TWindow): void;
+  find(workspaceID: string): TWindow | null;
+  open(workspaceID: string): Promise<TWindow>;
+}): DurableWorkspaceWindowCoordinator<TWindow> {
+  const pendingWindows = new Map<string, Promise<TWindow>>();
+
+  return {
+    async show(workspaceID) {
+      const pendingWindow = pendingWindows.get(workspaceID);
+      if (pendingWindow) {
+        return await pendingWindow;
+      }
+      const existingWindow = input.find(workspaceID);
+      if (existingWindow) {
+        input.activate(existingWindow);
+        return existingWindow;
+      }
+      const openWindow = input.open(workspaceID);
+      pendingWindows.set(workspaceID, openWindow);
+      try {
+        return await openWindow;
+      } finally {
+        if (pendingWindows.get(workspaceID) === openWindow) {
+          pendingWindows.delete(workspaceID);
+        }
+      }
+    }
+  };
+}

--- a/apps/desktop/src/main/host/workspaceLaunch.test.ts
+++ b/apps/desktop/src/main/host/workspaceLaunch.test.ts
@@ -769,6 +769,31 @@ test("workspace launch prefers destroying owner windows after workspace handoff"
   assert.deepEqual(events, ["workspace:ws-destroy", "owner:destroyed"]);
 });
 
+test("workspace launch keeps a reused durable workspace owner open", async () => {
+  const events: string[] = [];
+  const ownerWindow: WorkspaceLaunchOwnerWindow = {
+    close() {
+      events.push("owner:closed");
+    },
+    destroy() {
+      events.push("owner:destroyed");
+    }
+  };
+  const launch = createWorkspaceLaunch({
+    adapters: createAdapters({
+      async showWorkspaceWindow(workspaceID) {
+        events.push(`workspace:${workspaceID}:reused`);
+        return ownerWindow;
+      }
+    }),
+    tuttidClient: createTransportClient()
+  });
+
+  await launch.showWorkspace(ownerWindow, "ws-existing-owner");
+
+  assert.deepEqual(events, ["workspace:ws-existing-owner:reused"]);
+});
+
 test("workspace launch keeps owner open when replacement workspace window fails", async () => {
   let ownerWindowClosed = false;
 

--- a/apps/desktop/src/main/host/workspaceLaunch.ts
+++ b/apps/desktop/src/main/host/workspaceLaunch.ts
@@ -12,7 +12,7 @@ export interface WorkspaceLaunchAdapters {
   showWorkspaceWindow(
     workspaceID: string,
     options?: WorkspaceLaunchWorkspaceWindowOptions
-  ): Promise<void>;
+  ): Promise<WorkspaceLaunchOwnerWindow | null | void>;
   warnStartupWindowResolutionFailure(error: unknown): void;
 }
 
@@ -87,7 +87,11 @@ export function createWorkspaceLaunch(
     ownerWindow: WorkspaceLaunchOwnerWindow | null,
     workspaceID: string
   ): Promise<void> {
-    await deps.adapters.showWorkspaceWindow(workspaceID);
+    const workspaceWindow =
+      await deps.adapters.showWorkspaceWindow(workspaceID);
+    if (workspaceWindow === ownerWindow) {
+      return;
+    }
     forceCloseWindow(ownerWindow);
   }
 
@@ -96,7 +100,15 @@ export function createWorkspaceLaunch(
     workspaceID: string,
     windowKind: "agent" | "workspace"
   ): Promise<void> {
-    await deps.adapters.showWorkspaceWindow(workspaceID, { windowKind });
+    const workspaceWindow = await deps.adapters.showWorkspaceWindow(
+      workspaceID,
+      {
+        windowKind
+      }
+    );
+    if (workspaceWindow === ownerWindow) {
+      return;
+    }
     forceCloseWindow(ownerWindow);
   }
 }

--- a/apps/desktop/src/main/host/workspaceLaunchDesktopAdapters.ts
+++ b/apps/desktop/src/main/host/workspaceLaunchDesktopAdapters.ts
@@ -12,11 +12,13 @@ import type {
 } from "./workspaceLaunch";
 import {
   createWorkspaceWindow,
+  findWorkspaceWindow,
   loadAgentWindowContent,
   loadWorkspaceWindowContent
 } from "../windows/workspaceWindow";
 import { awaitWorkspaceWindowReady } from "./workspaceWindowReady.ts";
 import type { WorkspaceLaunchWindowKind } from "./workspaceLaunchMode.ts";
+import { createDurableWorkspaceWindowCoordinator } from "./durableWorkspaceWindowCoordinator.ts";
 
 export interface WorkspaceLaunchDesktopAdapterOptions {
   browserNodeGuestPreloadPath?: string;
@@ -33,6 +35,13 @@ export interface WorkspaceLaunchDesktopAdapterOptions {
 export function createWorkspaceLaunchDesktopAdapters(
   options: WorkspaceLaunchDesktopAdapterOptions
 ): WorkspaceLaunchAdapters {
+  const durableWorkspaceWindows = createDurableWorkspaceWindowCoordinator({
+    activate: activateWorkspaceWindow,
+    find: (workspaceID: string) =>
+      findWorkspaceWindow(workspaceID, "workspace"),
+    open: (workspaceID: string) =>
+      createAndShowWorkspaceWindow(options, workspaceID)
+  });
   return {
     async showAgentWindow(input) {
       await showStandaloneAgentWindow(options, input);
@@ -42,29 +51,9 @@ export function createWorkspaceLaunchDesktopAdapters(
       const windowKind =
         input?.windowKind ?? options.getPrimaryWorkspaceWindowKind();
       if (windowKind === "agent") {
-        await showStandaloneAgentWindow(options, { workspaceID });
-        return;
+        return await showStandaloneAgentWindow(options, { workspaceID });
       }
-      const workspaceWindow = createWorkspaceWindow({
-        browserNodeGuestPreloadPath: options.browserNodeGuestPreloadPath,
-        enableDevelopmentReloadShortcut:
-          options.enableDevelopmentReloadShortcut === true,
-        locale: options.getLocale(),
-        preloadPath: options.preloadPath,
-        rendererUrl: options.rendererUrl,
-        theme: options.getTheme(),
-        workspaceAppPreloadPath: options.workspaceAppPreloadPath,
-        workspaceID
-      });
-      await awaitWorkspaceWindowReady(workspaceWindow, () => {
-        loadWorkspaceWindowContent(workspaceWindow, {
-          dockPlacement: options.getDockPlacement(),
-          locale: options.getLocale(),
-          rendererUrl: options.rendererUrl,
-          theme: options.getTheme(),
-          workspaceID
-        });
-      });
+      return await durableWorkspaceWindows.show(workspaceID);
     },
 
     warnStartupWindowResolutionFailure(error) {
@@ -76,10 +65,49 @@ export function createWorkspaceLaunchDesktopAdapters(
   };
 }
 
+async function createAndShowWorkspaceWindow(
+  options: WorkspaceLaunchDesktopAdapterOptions,
+  workspaceID: string
+): Promise<Electron.BrowserWindow> {
+  const workspaceWindow = createWorkspaceWindow({
+    browserNodeGuestPreloadPath: options.browserNodeGuestPreloadPath,
+    enableDevelopmentReloadShortcut:
+      options.enableDevelopmentReloadShortcut === true,
+    locale: options.getLocale(),
+    preloadPath: options.preloadPath,
+    rendererUrl: options.rendererUrl,
+    theme: options.getTheme(),
+    workspaceAppPreloadPath: options.workspaceAppPreloadPath,
+    workspaceID
+  });
+  await awaitWorkspaceWindowReady(workspaceWindow, () => {
+    loadWorkspaceWindowContent(workspaceWindow, {
+      dockPlacement: options.getDockPlacement(),
+      locale: options.getLocale(),
+      rendererUrl: options.rendererUrl,
+      theme: options.getTheme(),
+      workspaceID
+    });
+  });
+  return workspaceWindow;
+}
+
+function activateWorkspaceWindow(
+  workspaceWindow: Electron.BrowserWindow
+): void {
+  if (workspaceWindow.isMinimized()) {
+    workspaceWindow.restore();
+  }
+  if (!workspaceWindow.isVisible()) {
+    workspaceWindow.show();
+  }
+  workspaceWindow.focus();
+}
+
 async function showStandaloneAgentWindow(
   options: WorkspaceLaunchDesktopAdapterOptions,
   input: WorkspaceLaunchAgentWindowInput
-): Promise<void> {
+): Promise<Electron.BrowserWindow> {
   const agentWindow = createWorkspaceWindow({
     browserNodeGuestPreloadPath: options.browserNodeGuestPreloadPath,
     enableDevelopmentReloadShortcut:
@@ -116,4 +144,5 @@ async function showStandaloneAgentWindow(
     },
     { maximizeOnShow: false }
   );
+  return agentWindow;
 }

--- a/apps/desktop/src/main/windows/workspaceWindow.ts
+++ b/apps/desktop/src/main/windows/workspaceWindow.ts
@@ -31,6 +31,7 @@ import {
   resolveStandaloneAgentWindowOffsetBounds,
   resolveStandaloneAgentWindowWorkArea
 } from "./standaloneAgentWindowBounds.ts";
+import { WorkspaceWindowRegistry } from "./workspaceWindowRegistry.ts";
 
 export const workspaceAppBrowserPartitionPrefix = "persist:tutti-app:";
 
@@ -49,10 +50,10 @@ export interface CreateWorkspaceWindowOptions {
   workspaceID: string;
 }
 
-const workspaceWindows = new Set<BrowserWindow>();
+const workspaceWindows = new WorkspaceWindowRegistry<BrowserWindow>();
 // DAU/PV belongs to the first workspace renderer for the lifetime of this main
-// process. Do not derive this from workspaceWindows.size: closing the owner
-// must not let a later window report another process-level open/pageview.
+// process. Do not derive this from current registry membership: closing the
+// owner must not let a later window report another process-level open/pageview.
 const primaryWindowAnalyticsClaim = createPrimaryWindowAnalyticsClaim();
 const reportPredefinePageviewByWindow = new WeakMap<BrowserWindow, boolean>();
 const workspaceWindowHeaderHeightPx = 52;
@@ -65,16 +66,14 @@ const agentWindowMinWidthPx = 420;
 const agentWindowMinHeightPx = 520;
 const agentWindowWorkAreaScale = 0.9;
 const agentWindowDuplicateOffsetPx = 25;
-const workspaceWindowKinds = new WeakMap<
-  BrowserWindow,
-  "agent" | "workspace"
->();
-
 export function createWorkspaceWindow(
   options: CreateWorkspaceWindowOptions
 ): BrowserWindow {
   const logger = getDesktopLogger();
   const windowKind = options.windowKind ?? "workspace";
+  if (windowKind === "workspace") {
+    workspaceWindows.assertDurableWorkspaceAvailable(options.workspaceID);
+  }
   const agentDisplay = options.openerBounds
     ? screen.getDisplayMatching(options.openerBounds)
     : screen.getPrimaryDisplay();
@@ -142,7 +141,6 @@ export function createWorkspaceWindow(
       webviewTag: true
     }
   });
-  workspaceWindowKinds.set(workspaceWindow, windowKind);
   reportPredefinePageviewByWindow.set(
     workspaceWindow,
     primaryWindowAnalyticsClaim.claim()
@@ -206,9 +204,12 @@ export function createWorkspaceWindow(
   installWorkspaceWindowDevelopmentReloadShortcut(workspaceWindow, {
     enabled: options.enableDevelopmentReloadShortcut === true
   });
-  workspaceWindows.add(workspaceWindow);
+  workspaceWindows.register(workspaceWindow, {
+    kind: windowKind,
+    workspaceID: options.workspaceID
+  });
   workspaceWindow.once("closed", () => {
-    workspaceWindows.delete(workspaceWindow);
+    workspaceWindows.unregister(workspaceWindow);
   });
 
   if (process.platform === "darwin") {
@@ -281,7 +282,14 @@ export function createWorkspaceWindow(
 export function getWorkspaceWindowKind(
   workspaceWindow: BrowserWindow
 ): "agent" | "workspace" | null {
-  return workspaceWindowKinds.get(workspaceWindow) ?? null;
+  return workspaceWindows.getKind(workspaceWindow);
+}
+
+export function findWorkspaceWindow(
+  workspaceID: string,
+  kind: "agent" | "workspace"
+): BrowserWindow | null {
+  return workspaceWindows.findWorkspaceWindow(workspaceID, kind);
 }
 
 export function loadAgentWindowContent(

--- a/apps/desktop/src/main/windows/workspaceWindowRegistry.test.ts
+++ b/apps/desktop/src/main/windows/workspaceWindowRegistry.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { WorkspaceWindowRegistry } from "./workspaceWindowRegistry.ts";
+
+interface TestWindow {
+  destroyed: boolean;
+  id: string;
+  isDestroyed(): boolean;
+}
+
+test("workspace window registry allows only one durable window per workspace", () => {
+  const registry = new WorkspaceWindowRegistry<TestWindow>();
+  const firstWindow = createWindow("first");
+  const secondWindow = createWindow("second");
+
+  registry.register(firstWindow, {
+    kind: "workspace",
+    workspaceID: "workspace-1"
+  });
+
+  assert.equal(
+    registry.findWorkspaceWindow("workspace-1", "workspace"),
+    firstWindow
+  );
+  assert.throws(
+    () =>
+      registry.register(secondWindow, {
+        kind: "workspace",
+        workspaceID: "workspace-1"
+      }),
+    /already has a durable workspace window/
+  );
+});
+
+test("workspace window registry permits auxiliary agent windows", () => {
+  const registry = new WorkspaceWindowRegistry<TestWindow>();
+  const firstAgentWindow = createWindow("agent-1");
+  const secondAgentWindow = createWindow("agent-2");
+
+  registry.register(firstAgentWindow, {
+    kind: "agent",
+    workspaceID: "workspace-1"
+  });
+  registry.register(secondAgentWindow, {
+    kind: "agent",
+    workspaceID: "workspace-1"
+  });
+
+  assert.equal(
+    registry.findWorkspaceWindow("workspace-1", "agent"),
+    firstAgentWindow
+  );
+});
+
+test("workspace window registry releases destroyed durable owners", () => {
+  const registry = new WorkspaceWindowRegistry<TestWindow>();
+  const firstWindow = createWindow("first");
+  const secondWindow = createWindow("second");
+  registry.register(firstWindow, {
+    kind: "workspace",
+    workspaceID: "workspace-1"
+  });
+
+  firstWindow.destroyed = true;
+  registry.register(secondWindow, {
+    kind: "workspace",
+    workspaceID: "workspace-1"
+  });
+
+  assert.equal(
+    registry.findWorkspaceWindow("workspace-1", "workspace"),
+    secondWindow
+  );
+});
+
+function createWindow(id: string): TestWindow {
+  return {
+    destroyed: false,
+    id,
+    isDestroyed() {
+      return this.destroyed;
+    }
+  };
+}

--- a/apps/desktop/src/main/windows/workspaceWindowRegistry.ts
+++ b/apps/desktop/src/main/windows/workspaceWindowRegistry.ts
@@ -1,0 +1,61 @@
+export type RegisteredWorkspaceWindowKind = "agent" | "workspace";
+
+export interface RegisteredWorkspaceWindow {
+  isDestroyed(): boolean;
+}
+
+interface WorkspaceWindowRegistration {
+  kind: RegisteredWorkspaceWindowKind;
+  workspaceID: string;
+}
+
+export class WorkspaceWindowRegistry<
+  TWindow extends RegisteredWorkspaceWindow
+> {
+  private readonly registrations = new Map<
+    TWindow,
+    WorkspaceWindowRegistration
+  >();
+
+  assertDurableWorkspaceAvailable(workspaceID: string): void {
+    if (this.findWorkspaceWindow(workspaceID, "workspace")) {
+      throw new Error(
+        `Workspace ${workspaceID} already has a durable workspace window.`
+      );
+    }
+  }
+
+  findWorkspaceWindow(
+    workspaceID: string,
+    kind: RegisteredWorkspaceWindowKind
+  ): TWindow | null {
+    for (const [window, registration] of this.registrations) {
+      if (window.isDestroyed()) {
+        this.registrations.delete(window);
+        continue;
+      }
+      if (
+        registration.kind === kind &&
+        registration.workspaceID === workspaceID
+      ) {
+        return window;
+      }
+    }
+    return null;
+  }
+
+  getKind(window: TWindow): RegisteredWorkspaceWindowKind | null {
+    return this.registrations.get(window)?.kind ?? null;
+  }
+
+  register(window: TWindow, registration: WorkspaceWindowRegistration): void {
+    if (registration.kind === "workspace") {
+      this.assertDurableWorkspaceAvailable(registration.workspaceID);
+    }
+    this.registrations.set(window, registration);
+  }
+
+  unregister(window: TWindow): void {
+    this.registrations.delete(window);
+  }
+}

--- a/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
@@ -23,6 +23,7 @@ import { registerWorkspaceUserProjectServices } from "@renderer/features/workspa
 import { createAgentProviderTerminalCommandRunner } from "@renderer/features/workspace-workbench/services/createAgentProviderTerminalCommandRunner";
 import { createWorkspaceAgentOutcomeNotificationController } from "@renderer/features/workspace-workbench/services/workspaceAgentOutcomeNotification";
 import { registerWorkspaceWorkbenchServices } from "@renderer/features/workspace-workbench/services/registerWorkspaceWorkbenchServices";
+import { createWorkspaceWorkbenchSnapshotRepository } from "@renderer/features/workspace-workbench/services/createWorkspaceWorkbenchSnapshotRepository.ts";
 import { createWorkspaceAgentOutcomeForegroundNotificationPresenter } from "@renderer/features/workspace-workbench/ui/WorkspaceAgentOutcomeNotificationToast";
 import {
   managedAgentRoundedIconUrl,
@@ -76,9 +77,8 @@ export interface WorkspaceWindowContainerResult {
 export function createWorkspaceWindowContainer(): WorkspaceWindowContainerResult {
   const environment = resolveDesktopEnvironment(window.tutti);
   const desktopApi = environment.desktopApi;
-  const routeWorkspaceID = new URLSearchParams(window.location.search).get(
-    "workspaceId"
-  );
+  const routeParameters = new URLSearchParams(window.location.search);
+  const routeWorkspaceID = routeParameters.get("workspaceId");
   const activeWorkspaceID =
     routeWorkspaceID || environment.startupWorkspaceID || "__default__";
   const tuttidClient = createDesktopTuttidClient(desktopApi.runtime);
@@ -289,6 +289,10 @@ export function createWorkspaceWindowContainer(): WorkspaceWindowContainerResult
     platformApi: desktopApi.platform,
     reporterService,
     runtimeApi: desktopApi.runtime,
+    snapshotRepository: createWorkspaceWorkbenchSnapshotRepository({
+      tuttidClient,
+      windowSearch: window.location.search
+    }),
     wallpaperApi: desktopApi.wallpaper,
     onAgentTargetsChanged: async () => {
       await workspaceAgentServices.agentsService.refresh();

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/createWorkspaceWorkbenchSnapshotRepository.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/createWorkspaceWorkbenchSnapshotRepository.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  TuttidClient,
+  WorkbenchSnapshot
+} from "@tutti-os/client-tuttid-ts";
+import { workbenchSnapshotSchemaVersion } from "@tutti-os/workbench-snapshot";
+import {
+  createAgentWindowIntent,
+  createWorkspaceWindowIntent,
+  encodeDesktopWindowIntent
+} from "../../../../../shared/contracts/windowIntent.ts";
+import { writeWorkspaceOnboardingAutoOpenedToSnapshot } from "./workspaceOnboarding.ts";
+import { writeWorkspaceWallpaperIdToSnapshot } from "./workspaceWallpaper.ts";
+import { createWorkspaceWorkbenchSnapshotRepository } from "./createWorkspaceWorkbenchSnapshotRepository.ts";
+
+test("agent window composition keeps all workbench snapshot writes window-local", async () => {
+  const calls: string[] = [];
+  const repository = createWorkspaceWorkbenchSnapshotRepository({
+    tuttidClient: createClient(calls),
+    windowSearch: encodeDesktopWindowIntent(
+      createAgentWindowIntent({ workspaceID: "workspace-1" })
+    )
+  });
+
+  const loadedSnapshot = await repository.load("workspace-1");
+  await repository.save("workspace-1", createSnapshot("host"));
+  await repository.saveProductMetadata(
+    "workspace-1",
+    writeWorkspaceWallpaperIdToSnapshot(loadedSnapshot, "sky"),
+    "wallpaper"
+  );
+  await repository.saveProductMetadata(
+    "workspace-1",
+    writeWorkspaceOnboardingAutoOpenedToSnapshot(loadedSnapshot),
+    "onboarding"
+  );
+
+  assert.deepEqual(calls, ["get:workspace-1"]);
+});
+
+test("agent view fails closed when workspace id comes from startup fallback", async () => {
+  const calls: string[] = [];
+  const repository = createWorkspaceWorkbenchSnapshotRepository({
+    tuttidClient: createClient(calls),
+    windowSearch: "?view=agent"
+  });
+
+  await repository.load("workspace-fallback");
+  await repository.save("workspace-fallback", createSnapshot("local"));
+
+  assert.deepEqual(calls, ["get:workspace-fallback"]);
+});
+
+test("workspace window composition retains durable snapshot writes", async () => {
+  const calls: string[] = [];
+  const repository = createWorkspaceWorkbenchSnapshotRepository({
+    tuttidClient: createClient(calls),
+    windowSearch: encodeDesktopWindowIntent(
+      createWorkspaceWindowIntent("workspace-1")
+    )
+  });
+
+  await repository.load("workspace-1");
+  await repository.save("workspace-1", createSnapshot("durable"));
+
+  assert.deepEqual(calls, ["get:workspace-1", "put:workspace-1"]);
+});
+
+function createClient(calls: string[]): TuttidClient {
+  return {
+    async getWorkspaceWorkbench(workspaceID) {
+      calls.push(`get:${workspaceID}`);
+      return createSnapshot("loaded");
+    },
+    async putWorkspaceWorkbench(workspaceID, snapshot) {
+      calls.push(`put:${workspaceID}`);
+      return snapshot;
+    }
+  } as Partial<TuttidClient> as TuttidClient;
+}
+
+function createSnapshot(testRevision: string): WorkbenchSnapshot {
+  return {
+    activeNodeId: null,
+    metadata: { testRevision },
+    nodes: [],
+    nodeStack: [],
+    schemaVersion: workbenchSnapshotSchemaVersion
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/createWorkspaceWorkbenchSnapshotRepository.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/createWorkspaceWorkbenchSnapshotRepository.ts
@@ -1,0 +1,17 @@
+import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
+import {
+  createDesktopWorkspaceWorkbenchRepository,
+  type DesktopWorkspaceWorkbenchRepository
+} from "./internal/adapters/desktopWorkspaceWorkbenchRepository.ts";
+import { resolveWorkspaceWorkbenchSnapshotPersistence } from "./workspaceWorkbenchSnapshotPersistence.ts";
+
+export function createWorkspaceWorkbenchSnapshotRepository(input: {
+  tuttidClient: TuttidClient;
+  windowSearch: string;
+}): DesktopWorkspaceWorkbenchRepository {
+  return createDesktopWorkspaceWorkbenchRepository(input.tuttidClient, {
+    persistence: resolveWorkspaceWorkbenchSnapshotPersistence(
+      input.windowSearch
+    )
+  });
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceWorkbenchRepository.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceWorkbenchRepository.test.ts
@@ -352,7 +352,7 @@ test("queued host saves cannot restore stale wallpaper metadata over a newer pro
   await repository.load("workspace-1");
   const blockingHostSave = repository.save(
     "workspace-1",
-    createSnapshot("blocking-host")
+    createSnapshot("blocking-host", "current-wallpaper-node")
   );
   await Promise.resolve();
   const wallpaperSave = repository.saveProductMetadata(
@@ -372,6 +372,11 @@ test("queued host saves cannot restore stale wallpaper metadata over a newer pro
   assert.equal(
     readWorkspaceWallpaperIdFromSnapshot(persistedSnapshots[1]),
     "ocean"
+  );
+  assert.equal(persistedSnapshots[1]?.metadata?.testRevision, "blocking-host");
+  assert.deepEqual(
+    persistedSnapshots[1]?.nodes.map((node) => node.id),
+    ["current-wallpaper-node"]
   );
   assert.equal(
     readWorkspaceWallpaperIdFromSnapshot(persistedSnapshots[2]),
@@ -406,7 +411,7 @@ test("queued host saves cannot restore stale onboarding metadata over a newer pr
   await repository.load("workspace-1");
   const blockingHostSave = repository.save(
     "workspace-1",
-    createSnapshot("blocking-host")
+    createSnapshot("blocking-host", "current-onboarding-node")
   );
   await Promise.resolve();
   const onboardingSave = repository.saveProductMetadata(
@@ -423,6 +428,11 @@ test("queued host saves cannot restore stale onboarding metadata over a newer pr
   assert.deepEqual(
     persistedSnapshots[1]?.metadata?.workspaceOnboarding,
     updatedSnapshot.metadata?.workspaceOnboarding
+  );
+  assert.equal(persistedSnapshots[1]?.metadata?.testRevision, "blocking-host");
+  assert.deepEqual(
+    persistedSnapshots[1]?.nodes.map((node) => node.id),
+    ["current-onboarding-node"]
   );
   assert.deepEqual(
     persistedSnapshots[2]?.metadata?.workspaceOnboarding,
@@ -484,12 +494,24 @@ function createDeferred<T>(): {
   return { promise, resolve };
 }
 
-function createSnapshot(testRevision?: string): WorkbenchSnapshot {
+function createSnapshot(
+  testRevision?: string,
+  nodeID?: string
+): WorkbenchSnapshot {
   return {
     ...(testRevision ? { metadata: { testRevision } } : {}),
     schemaVersion: workbenchSnapshotSchemaVersion,
-    nodes: [],
-    nodeStack: [],
-    activeNodeId: null
+    nodes: nodeID
+      ? [
+          {
+            frame: { height: 400, width: 600, x: 20, y: 20 },
+            id: nodeID,
+            kind: "test",
+            title: nodeID
+          }
+        ]
+      : [],
+    nodeStack: nodeID ? [nodeID] : [],
+    activeNodeId: nodeID ?? null
   };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceWorkbenchRepository.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceWorkbenchRepository.test.ts
@@ -116,6 +116,346 @@ test("desktop workspace workbench repository keeps daemon calls workspace-scoped
   assert.equal(repository.readCached("workspace-characterization"), saved);
 });
 
+test("desktop workspace workbench repository serializes saves before reloading the same workspace", async () => {
+  const calls: string[] = [];
+  let persistedSnapshot = createSnapshot("initial");
+  const pendingSaves: Array<{
+    deferred: ReturnType<typeof createDeferred<WorkbenchSnapshot>>;
+    snapshot: WorkbenchSnapshot;
+  }> = [];
+  const repository = createDesktopWorkspaceWorkbenchRepository({
+    async getWorkspaceWorkbench(workspaceID) {
+      calls.push(`get:${workspaceID}`);
+      return persistedSnapshot;
+    },
+    async putWorkspaceWorkbench(workspaceID, snapshot) {
+      calls.push(`put:${String(snapshot.metadata?.testRevision)}`);
+      const deferred = createDeferred<WorkbenchSnapshot>();
+      pendingSaves.push({ deferred, snapshot });
+      persistedSnapshot = await deferred.promise;
+      return persistedSnapshot;
+    }
+  } as Partial<TuttidClient> as TuttidClient);
+
+  await repository.load("workspace-1");
+  calls.length = 0;
+
+  const firstSave = repository.save("workspace-1", createSnapshot("first"));
+  const secondSave = repository.save("workspace-1", createSnapshot("second"));
+  const reload = repository.load("workspace-1");
+  await Promise.resolve();
+
+  assert.deepEqual(calls, ["put:first"]);
+  assert.equal(pendingSaves.length, 1);
+
+  pendingSaves[0]?.deferred.resolve(pendingSaves[0].snapshot);
+  await firstSave;
+  await Promise.resolve();
+
+  assert.deepEqual(calls, ["put:first", "put:second"]);
+  assert.equal(pendingSaves.length, 2);
+
+  pendingSaves[1]?.deferred.resolve(pendingSaves[1].snapshot);
+  await secondSave;
+  const loadedSnapshot = await reload;
+
+  assert.deepEqual(calls, ["put:first", "put:second", "get:workspace-1"]);
+  assert.equal(loadedSnapshot.metadata?.testRevision, "second");
+  assert.equal(repository.readCached("workspace-1"), loadedSnapshot);
+});
+
+test("desktop workspace workbench repository orders final flush, immediate reopen, and the next save", async () => {
+  const calls: string[] = [];
+  let loadCount = 0;
+  const reload = createDeferred<WorkbenchSnapshot>();
+  const firstSave = createDeferred<WorkbenchSnapshot>();
+  const secondSave = createDeferred<WorkbenchSnapshot>();
+  const repository = createDesktopWorkspaceWorkbenchRepository({
+    async getWorkspaceWorkbench(workspaceID) {
+      loadCount += 1;
+      calls.push(`get:${workspaceID}:${loadCount}`);
+      return loadCount === 1 ? createSnapshot("initial") : reload.promise;
+    },
+    async putWorkspaceWorkbench(_workspaceID, snapshot) {
+      const revision = String(snapshot.metadata?.testRevision);
+      calls.push(`put:${revision}`);
+      return revision === "first" ? firstSave.promise : secondSave.promise;
+    }
+  } as Partial<TuttidClient> as TuttidClient);
+
+  await repository.load("workspace-1");
+  calls.length = 0;
+  const finalFlush = repository.save("workspace-1", createSnapshot("first"));
+  const reopenedLoad = repository.load("workspace-1");
+  const reopenedSave = repository.save("workspace-1", createSnapshot("second"));
+  await Promise.resolve();
+
+  assert.deepEqual(calls, ["put:first"]);
+  firstSave.resolve(createSnapshot("first"));
+  await finalFlush;
+  await Promise.resolve();
+  assert.deepEqual(calls, ["put:first", "get:workspace-1:2"]);
+
+  reload.resolve(createSnapshot("first"));
+  await reopenedLoad;
+  await Promise.resolve();
+  assert.deepEqual(calls, ["put:first", "get:workspace-1:2", "put:second"]);
+
+  secondSave.resolve(createSnapshot("second"));
+  const reopenedSavedSnapshot = await reopenedSave;
+  assert.equal(reopenedSavedSnapshot.metadata?.testRevision, "second");
+  assert.equal(
+    repository.readCached("workspace-1")?.metadata?.testRevision,
+    "second"
+  );
+});
+
+test("desktop workspace workbench repository recovers its queue after a failed save", async () => {
+  const calls: string[] = [];
+  const repository = createDesktopWorkspaceWorkbenchRepository({
+    async getWorkspaceWorkbench(workspaceID) {
+      calls.push(`get:${workspaceID}`);
+      return createSnapshot("loaded");
+    },
+    async putWorkspaceWorkbench(_workspaceID, snapshot) {
+      const revision = String(snapshot.metadata?.testRevision);
+      calls.push(`put:${revision}`);
+      if (revision === "first") {
+        throw new Error("save failed");
+      }
+      return snapshot;
+    }
+  } as Partial<TuttidClient> as TuttidClient);
+
+  const failedSave = repository.save("workspace-1", createSnapshot("first"));
+  const secondSave = repository.save("workspace-1", createSnapshot("second"));
+  const load = repository.load("workspace-1");
+
+  await assert.rejects(failedSave, /save failed/);
+  assert.equal((await secondSave).metadata?.testRevision, "second");
+  assert.equal((await load).metadata?.testRevision, "loaded");
+  assert.deepEqual(calls, ["put:first", "put:second", "get:workspace-1"]);
+});
+
+test("desktop workspace workbench repository recovers its queue after a failed load", async () => {
+  const calls: string[] = [];
+  let loadCount = 0;
+  let persistedSnapshot = createSnapshot("initial");
+  const repository = createDesktopWorkspaceWorkbenchRepository({
+    async getWorkspaceWorkbench(workspaceID) {
+      loadCount += 1;
+      calls.push(`get:${workspaceID}:${loadCount}`);
+      if (loadCount === 1) {
+        throw new Error("load failed");
+      }
+      return persistedSnapshot;
+    },
+    async putWorkspaceWorkbench(_workspaceID, snapshot) {
+      calls.push(`put:${String(snapshot.metadata?.testRevision)}`);
+      persistedSnapshot = snapshot;
+      return snapshot;
+    }
+  } as Partial<TuttidClient> as TuttidClient);
+
+  const failedLoad = repository.load("workspace-1");
+  const save = repository.save("workspace-1", createSnapshot("recovered"));
+  const recoveredLoad = repository.load("workspace-1");
+
+  await assert.rejects(failedLoad, /load failed/);
+  assert.equal((await save).metadata?.testRevision, "recovered");
+  assert.equal((await recoveredLoad).metadata?.testRevision, "recovered");
+  assert.deepEqual(calls, [
+    "get:workspace-1:1",
+    "put:recovered",
+    "get:workspace-1:2"
+  ]);
+});
+
+test("desktop workspace workbench repository does not block another workspace", async () => {
+  const blockedSave = createDeferred<WorkbenchSnapshot>();
+  const calls: string[] = [];
+  const repository = createDesktopWorkspaceWorkbenchRepository({
+    async getWorkspaceWorkbench(workspaceID) {
+      calls.push(`get:${workspaceID}`);
+      return createSnapshot(workspaceID);
+    },
+    async putWorkspaceWorkbench(workspaceID, snapshot) {
+      calls.push(`put:${workspaceID}`);
+      return workspaceID === "workspace-a" ? blockedSave.promise : snapshot;
+    }
+  } as Partial<TuttidClient> as TuttidClient);
+
+  const saveA = repository.save("workspace-a", createSnapshot("a"));
+  const saveB = repository.save("workspace-b", createSnapshot("b"));
+
+  assert.equal((await saveB).metadata?.testRevision, "b");
+  assert.deepEqual(calls, ["put:workspace-a", "put:workspace-b"]);
+  blockedSave.resolve(createSnapshot("a"));
+  await saveA;
+});
+
+test("window-local workbench repository never writes the durable workspace snapshot", async () => {
+  let putCount = 0;
+  let getCount = 0;
+  const repository = createDesktopWorkspaceWorkbenchRepository(
+    createTuttidClient({
+      initialSnapshot: createSnapshot("durable"),
+      onLoad() {
+        getCount += 1;
+      },
+      onSave() {
+        putCount += 1;
+      }
+    }),
+    { persistence: "window-local" }
+  );
+
+  assert.equal(
+    (await repository.load("workspace-1")).metadata?.testRevision,
+    "durable"
+  );
+  const localSnapshot = await repository.save(
+    "workspace-1",
+    createSnapshot("standalone-local")
+  );
+
+  assert.equal(putCount, 0);
+  assert.equal(
+    (await repository.load("workspace-1")).metadata?.testRevision,
+    "standalone-local"
+  );
+  assert.equal(getCount, 1);
+  assert.equal(localSnapshot.metadata?.testRevision, "standalone-local");
+  assert.equal(repository.readCached("workspace-1"), localSnapshot);
+});
+
+test("queued host saves cannot restore stale wallpaper metadata over a newer product write", async () => {
+  const persistedSnapshots: WorkbenchSnapshot[] = [];
+  const firstPut = createDeferred<WorkbenchSnapshot>();
+  const initialSnapshot = writeWorkspaceWallpaperIdToSnapshot(
+    createSnapshot("initial"),
+    "sky"
+  );
+  const repository = createDesktopWorkspaceWorkbenchRepository({
+    async getWorkspaceWorkbench() {
+      return initialSnapshot;
+    },
+    async putWorkspaceWorkbench(_workspaceID, snapshot) {
+      persistedSnapshots.push(snapshot);
+      if (persistedSnapshots.length === 1) {
+        return firstPut.promise;
+      }
+      return snapshot;
+    }
+  } as Partial<TuttidClient> as TuttidClient);
+
+  await repository.load("workspace-1");
+  const blockingHostSave = repository.save(
+    "workspace-1",
+    createSnapshot("blocking-host")
+  );
+  await Promise.resolve();
+  const wallpaperSave = repository.saveProductMetadata(
+    "workspace-1",
+    writeWorkspaceWallpaperIdToSnapshot(initialSnapshot, "ocean"),
+    "wallpaper"
+  );
+  const staleHostSave = repository.save(
+    "workspace-1",
+    writeWorkspaceWallpaperIdToSnapshot(createSnapshot("host"), "sky")
+  );
+  const firstPersistedSnapshot = persistedSnapshots[0];
+  assert.ok(firstPersistedSnapshot);
+  firstPut.resolve(firstPersistedSnapshot);
+  await Promise.all([blockingHostSave, wallpaperSave, staleHostSave]);
+
+  assert.equal(
+    readWorkspaceWallpaperIdFromSnapshot(persistedSnapshots[1]),
+    "ocean"
+  );
+  assert.equal(
+    readWorkspaceWallpaperIdFromSnapshot(persistedSnapshots[2]),
+    "ocean"
+  );
+});
+
+test("queued host saves cannot restore stale onboarding metadata over a newer product write", async () => {
+  const persistedSnapshots: WorkbenchSnapshot[] = [];
+  const firstPut = createDeferred<WorkbenchSnapshot>();
+  const initialSnapshot = writeWorkspaceOnboardingAutoOpenedToSnapshot(
+    createSnapshot("initial"),
+    "2026-01-01T00:00:00.000Z"
+  );
+  const updatedSnapshot = writeWorkspaceOnboardingAutoOpenedToSnapshot(
+    initialSnapshot,
+    "2026-07-15T00:00:00.000Z"
+  );
+  const repository = createDesktopWorkspaceWorkbenchRepository({
+    async getWorkspaceWorkbench() {
+      return initialSnapshot;
+    },
+    async putWorkspaceWorkbench(_workspaceID, snapshot) {
+      persistedSnapshots.push(snapshot);
+      if (persistedSnapshots.length === 1) {
+        return firstPut.promise;
+      }
+      return snapshot;
+    }
+  } as Partial<TuttidClient> as TuttidClient);
+
+  await repository.load("workspace-1");
+  const blockingHostSave = repository.save(
+    "workspace-1",
+    createSnapshot("blocking-host")
+  );
+  await Promise.resolve();
+  const onboardingSave = repository.saveProductMetadata(
+    "workspace-1",
+    updatedSnapshot,
+    "onboarding"
+  );
+  const staleHostSave = repository.save("workspace-1", initialSnapshot);
+  const firstPersistedSnapshot = persistedSnapshots[0];
+  assert.ok(firstPersistedSnapshot);
+  firstPut.resolve(firstPersistedSnapshot);
+  await Promise.all([blockingHostSave, onboardingSave, staleHostSave]);
+
+  assert.deepEqual(
+    persistedSnapshots[1]?.metadata?.workspaceOnboarding,
+    updatedSnapshot.metadata?.workspaceOnboarding
+  );
+  assert.deepEqual(
+    persistedSnapshots[2]?.metadata?.workspaceOnboarding,
+    updatedSnapshot.metadata?.workspaceOnboarding
+  );
+});
+
+test("host saves remove stale product metadata when the current cache has none", async () => {
+  const persistedSnapshots: WorkbenchSnapshot[] = [];
+  const repository = createDesktopWorkspaceWorkbenchRepository(
+    createTuttidClient({
+      initialSnapshot: createSnapshot("initial"),
+      onSave(_workspaceID, snapshot) {
+        persistedSnapshots.push(snapshot);
+      }
+    })
+  );
+
+  await repository.load("workspace-1");
+  await repository.save(
+    "workspace-1",
+    writeWorkspaceWallpaperIdToSnapshot(createSnapshot("stale"), "sky")
+  );
+
+  const persistedSnapshot = persistedSnapshots[0];
+  assert.ok(persistedSnapshot);
+  assert.equal(
+    readWorkspaceWallpaperIdFromSnapshot(persistedSnapshot),
+    "tutti"
+  );
+  assert.equal(persistedSnapshot.metadata?.workspaceWallpaper, undefined);
+});
+
 function createTuttidClient(input: {
   initialSnapshot: WorkbenchSnapshot;
   onLoad?: (workspaceID: string) => void;
@@ -133,8 +473,20 @@ function createTuttidClient(input: {
   } as Partial<TuttidClient> as TuttidClient;
 }
 
-function createSnapshot(): WorkbenchSnapshot {
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function createSnapshot(testRevision?: string): WorkbenchSnapshot {
   return {
+    ...(testRevision ? { metadata: { testRevision } } : {}),
     schemaVersion: workbenchSnapshotSchemaVersion,
     nodes: [],
     nodeStack: [],

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceWorkbenchRepository.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceWorkbenchRepository.ts
@@ -3,14 +3,8 @@ import {
   type WorkbenchSnapshot
 } from "@tutti-os/workbench-snapshot";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
-import {
-  preserveWorkspaceWallpaperSnapshotMetadata,
-  replaceWorkspaceWallpaperSnapshotMetadata
-} from "../../workspaceWallpaper.ts";
-import {
-  preserveWorkspaceOnboardingSnapshotMetadata,
-  replaceWorkspaceOnboardingSnapshotMetadata
-} from "../../workspaceOnboarding.ts";
+import { replaceWorkspaceWallpaperSnapshotMetadata } from "../../workspaceWallpaper.ts";
+import { replaceWorkspaceOnboardingSnapshotMetadata } from "../../workspaceOnboarding.ts";
 import type { WorkbenchSnapshotRepositoryPort } from "../workbenchHostPorts.ts";
 
 export type DesktopWorkspaceWorkbenchProductMetadataOwner =
@@ -144,25 +138,27 @@ function mergeProductMetadata(input: {
   owner: DesktopWorkspaceWorkbenchProductMetadataOwner | null;
   snapshot: WorkbenchSnapshot;
 }): WorkbenchSnapshot {
-  const snapshotWithOnboarding =
-    input.owner === "onboarding"
-      ? preserveWorkspaceOnboardingSnapshotMetadata(
-          input.cachedSnapshot,
-          input.snapshot
-        )
-      : replaceWorkspaceOnboardingSnapshotMetadata(
-          input.cachedSnapshot,
-          input.snapshot
-        );
-  return input.owner === "wallpaper"
-    ? preserveWorkspaceWallpaperSnapshotMetadata(
-        input.cachedSnapshot,
-        snapshotWithOnboarding
-      )
-    : replaceWorkspaceWallpaperSnapshotMetadata(
-        input.cachedSnapshot,
-        snapshotWithOnboarding
-      );
+  if (input.owner === "onboarding") {
+    return replaceWorkspaceOnboardingSnapshotMetadata(
+      input.snapshot,
+      input.cachedSnapshot ?? input.snapshot
+    );
+  }
+  if (input.owner === "wallpaper") {
+    return replaceWorkspaceWallpaperSnapshotMetadata(
+      input.snapshot,
+      input.cachedSnapshot ?? input.snapshot
+    );
+  }
+
+  const snapshotWithOnboarding = replaceWorkspaceOnboardingSnapshotMetadata(
+    input.cachedSnapshot,
+    input.snapshot
+  );
+  return replaceWorkspaceWallpaperSnapshotMetadata(
+    input.cachedSnapshot,
+    snapshotWithOnboarding
+  );
 }
 
 function noop(): void {}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceWorkbenchRepository.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceWorkbenchRepository.ts
@@ -3,9 +3,23 @@ import {
   type WorkbenchSnapshot
 } from "@tutti-os/workbench-snapshot";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
-import { preserveWorkspaceWallpaperSnapshotMetadata } from "../../workspaceWallpaper.ts";
-import { preserveWorkspaceOnboardingSnapshotMetadata } from "../../workspaceOnboarding.ts";
+import {
+  preserveWorkspaceWallpaperSnapshotMetadata,
+  replaceWorkspaceWallpaperSnapshotMetadata
+} from "../../workspaceWallpaper.ts";
+import {
+  preserveWorkspaceOnboardingSnapshotMetadata,
+  replaceWorkspaceOnboardingSnapshotMetadata
+} from "../../workspaceOnboarding.ts";
 import type { WorkbenchSnapshotRepositoryPort } from "../workbenchHostPorts.ts";
+
+export type DesktopWorkspaceWorkbenchProductMetadataOwner =
+  | "onboarding"
+  | "wallpaper";
+
+export interface DesktopWorkspaceWorkbenchRepositoryOptions {
+  persistence: "durable" | "window-local";
+}
 
 export interface DesktopWorkspaceWorkbenchRepository extends WorkbenchSnapshotRepositoryPort {
   hasLoaded(workspaceID: string): boolean;
@@ -15,15 +29,24 @@ export interface DesktopWorkspaceWorkbenchRepository extends WorkbenchSnapshotRe
     workspaceID: string,
     snapshot: WorkbenchSnapshot
   ): Promise<WorkbenchSnapshot>;
+  saveProductMetadata(
+    workspaceID: string,
+    snapshot: WorkbenchSnapshot,
+    owner: DesktopWorkspaceWorkbenchProductMetadataOwner
+  ): Promise<WorkbenchSnapshot>;
   subscribe(listener: () => void): () => void;
 }
 
 export function createDesktopWorkspaceWorkbenchRepository(
-  tuttidClient: TuttidClient
+  tuttidClient: TuttidClient,
+  options: DesktopWorkspaceWorkbenchRepositoryOptions = {
+    persistence: "durable"
+  }
 ): DesktopWorkspaceWorkbenchRepository {
   const cachedSnapshots = new Map<string, WorkbenchSnapshot>();
   const loadedWorkspaceIDs = new Set<string>();
   const listeners = new Set<() => void>();
+  const pendingWorkspaceOperations = new Map<string, Promise<void>>();
 
   const notify = () => {
     for (const listener of listeners) {
@@ -36,28 +59,41 @@ export function createDesktopWorkspaceWorkbenchRepository(
     notify();
   };
 
-  return {
-    hasLoaded(workspaceID) {
-      return loadedWorkspaceIDs.has(workspaceID);
-    },
-    async load(workspaceID: string) {
-      const snapshot = migrateWorkbenchSnapshot(
-        await tuttidClient.getWorkspaceWorkbench(workspaceID)
-      );
-      writeCache(workspaceID, snapshot);
-      return snapshot;
-    },
-    readCached(workspaceID) {
-      return cachedSnapshots.get(workspaceID) ?? null;
-    },
-    async save(workspaceID: string, snapshot: WorkbenchSnapshot) {
-      const snapshotWithMetadata = preserveWorkspaceWallpaperSnapshotMetadata(
-        cachedSnapshots.get(workspaceID),
-        preserveWorkspaceOnboardingSnapshotMetadata(
-          cachedSnapshots.get(workspaceID),
-          snapshot
-        )
-      );
+  const enqueueWorkspaceOperation = <T>(
+    workspaceID: string,
+    operation: () => Promise<T>
+  ): Promise<T> => {
+    const previousOperation = pendingWorkspaceOperations.get(workspaceID);
+    const nextOperation = (previousOperation ?? Promise.resolve()).then(
+      operation
+    );
+    const settledOperation = nextOperation.then(noop, noop);
+    pendingWorkspaceOperations.set(workspaceID, settledOperation);
+    void settledOperation.finally(() => {
+      if (pendingWorkspaceOperations.get(workspaceID) === settledOperation) {
+        pendingWorkspaceOperations.delete(workspaceID);
+      }
+    });
+    return nextOperation;
+  };
+
+  const save = (
+    workspaceID: string,
+    snapshot: WorkbenchSnapshot,
+    productMetadataOwner: DesktopWorkspaceWorkbenchProductMetadataOwner | null
+  ): Promise<WorkbenchSnapshot> =>
+    enqueueWorkspaceOperation(workspaceID, async () => {
+      const cachedSnapshot = cachedSnapshots.get(workspaceID);
+      const snapshotWithMetadata = mergeProductMetadata({
+        cachedSnapshot,
+        owner: productMetadataOwner,
+        snapshot
+      });
+      if (options.persistence === "window-local") {
+        const localSnapshot = migrateWorkbenchSnapshot(snapshotWithMetadata);
+        writeCache(workspaceID, localSnapshot);
+        return localSnapshot;
+      }
       const savedSnapshot = migrateWorkbenchSnapshot(
         await tuttidClient.putWorkspaceWorkbench(
           workspaceID,
@@ -66,6 +102,33 @@ export function createDesktopWorkspaceWorkbenchRepository(
       );
       writeCache(workspaceID, savedSnapshot);
       return savedSnapshot;
+    });
+
+  return {
+    hasLoaded(workspaceID) {
+      return loadedWorkspaceIDs.has(workspaceID);
+    },
+    load(workspaceID: string) {
+      return enqueueWorkspaceOperation(workspaceID, async () => {
+        const cachedSnapshot = cachedSnapshots.get(workspaceID);
+        if (options.persistence === "window-local" && cachedSnapshot) {
+          return cachedSnapshot;
+        }
+        const snapshot = migrateWorkbenchSnapshot(
+          await tuttidClient.getWorkspaceWorkbench(workspaceID)
+        );
+        writeCache(workspaceID, snapshot);
+        return snapshot;
+      });
+    },
+    readCached(workspaceID) {
+      return cachedSnapshots.get(workspaceID) ?? null;
+    },
+    save(workspaceID: string, snapshot: WorkbenchSnapshot) {
+      return save(workspaceID, snapshot, null);
+    },
+    saveProductMetadata(workspaceID, snapshot, owner) {
+      return save(workspaceID, snapshot, owner);
     },
     subscribe(listener) {
       listeners.add(listener);
@@ -75,3 +138,31 @@ export function createDesktopWorkspaceWorkbenchRepository(
     }
   };
 }
+
+function mergeProductMetadata(input: {
+  cachedSnapshot: WorkbenchSnapshot | undefined;
+  owner: DesktopWorkspaceWorkbenchProductMetadataOwner | null;
+  snapshot: WorkbenchSnapshot;
+}): WorkbenchSnapshot {
+  const snapshotWithOnboarding =
+    input.owner === "onboarding"
+      ? preserveWorkspaceOnboardingSnapshotMetadata(
+          input.cachedSnapshot,
+          input.snapshot
+        )
+      : replaceWorkspaceOnboardingSnapshotMetadata(
+          input.cachedSnapshot,
+          input.snapshot
+        );
+  return input.owner === "wallpaper"
+    ? preserveWorkspaceWallpaperSnapshotMetadata(
+        input.cachedSnapshot,
+        snapshotWithOnboarding
+      )
+    : replaceWorkspaceWallpaperSnapshotMetadata(
+        input.cachedSnapshot,
+        snapshotWithOnboarding
+      );
+}
+
+function noop(): void {}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.test.ts
@@ -114,6 +114,22 @@ test("workbench host coordinator keeps different scopes independent", () => {
   );
 });
 
+test("renderer coordinators keep the same partition isolated across windows", () => {
+  const firstCoordinator = new WorkbenchHostCoordinator();
+  const secondCoordinator = new WorkbenchHostCoordinator();
+  const partition = workspacePartition("workspace-1");
+
+  const first = firstCoordinator.open({ configuration, partition });
+  const second = secondCoordinator.open({ configuration, partition });
+
+  assert.notEqual(first.session, second.session);
+  first.release();
+  assert.equal(first.session.isDisposed, true);
+  assert.equal(second.session.isDisposed, false);
+  second.release();
+  assert.equal(second.session.isDisposed, true);
+});
+
 test("workbench host coordinator rejects a session for another partition", () => {
   const coordinator = new WorkbenchHostCoordinator();
   const mismatchedSession = createSession(workspacePartition("workspace-2"));

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.ts
@@ -64,7 +64,6 @@ export function createWorkbenchHostSessionConfiguration<
 }
 
 export class WorkbenchHostCoordinator {
-  readonly _serviceBrand = undefined;
   private disposed = false;
   private readonly options: WorkbenchHostCoordinatorOptions;
   private readonly sessionsByScope = new Map<

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -44,7 +44,6 @@ import type {
   TuttidEventStreamClient
 } from "@tutti-os/client-tuttid-ts";
 import type { DesktopWorkspaceWorkbenchRepository } from "./adapters/desktopWorkspaceWorkbenchRepository";
-import { createDesktopWorkspaceWorkbenchRepository } from "./adapters/desktopWorkspaceWorkbenchRepository";
 import { IDesktopRichTextAtService } from "../../../rich-text-at/services/richTextAtService.interface.ts";
 import {
   IAgentProviderStatusService,
@@ -193,6 +192,7 @@ export interface WorkspaceWorkbenchHostExternalDependencies {
   >;
   reporterService?: Pick<IReporterService, "trackEvents">;
   runtimeApi: DesktopRuntimeApi;
+  snapshotRepository: DesktopWorkspaceWorkbenchRepository;
   wallpaperApi: DesktopWallpaperApi;
 }
 
@@ -240,9 +240,7 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
     workspaceFileManagerService: IWorkspaceFileManagerService,
     workspaceUserProjectService: IWorkspaceUserProjectService
   ) {
-    const repository = createDesktopWorkspaceWorkbenchRepository(
-      externalDependencies.tuttidClient
-    );
+    const repository = externalDependencies.snapshotRepository;
     this.dependencies = {
       agentProviderStatusService,
       agentsService,
@@ -423,9 +421,10 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
     const snapshot = cachedSnapshot
       ? cachedSnapshot
       : await this.dependencies.repository.load(workspaceId);
-    await this.dependencies.repository.save(
+    await this.dependencies.repository.saveProductMetadata(
       workspaceId,
-      writeWorkspaceOnboardingAutoOpenedToSnapshot(snapshot)
+      writeWorkspaceOnboardingAutoOpenedToSnapshot(snapshot),
+      "onboarding"
     );
   }
 
@@ -723,10 +722,12 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
       );
     }
 
-    const savedSnapshot = await this.dependencies.repository.save(
-      workspaceId,
-      snapshot
-    );
+    const savedSnapshot =
+      await this.dependencies.repository.saveProductMetadata(
+        workspaceId,
+        snapshot,
+        "wallpaper"
+      );
 
     if (
       wallpaperId !== undefined &&

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/registerWorkspaceWorkbenchServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/registerWorkspaceWorkbenchServices.ts
@@ -25,6 +25,7 @@ import { WorkspaceSettingsService } from "./internal/workspaceSettingsService";
 import { IAccountService } from "./accountService.interface";
 import { IWorkbenchHostCoordinator } from "./workbenchHostCoordinator.interface.ts";
 import { IWorkspaceWorkbenchHostService } from "./workspaceWorkbenchHostService.interface";
+import type { DesktopWorkspaceWorkbenchRepository } from "./internal/adapters/desktopWorkspaceWorkbenchRepository.ts";
 import { IWorkspaceSettingsService } from "./workspaceSettingsService.interface";
 
 export interface WorkspaceWorkbenchServiceRegistrationInput {
@@ -52,6 +53,7 @@ export interface WorkspaceWorkbenchServiceRegistrationInput {
   >;
   reporterService?: Pick<IReporterService, "trackEvents">;
   runtimeApi: DesktopRuntimeApi;
+  snapshotRepository: DesktopWorkspaceWorkbenchRepository;
   wallpaperApi: DesktopWallpaperApi;
   onAgentTargetsChanged?: () => void | Promise<void>;
 }
@@ -92,6 +94,7 @@ export function registerWorkspaceWorkbenchServices(
         platformApi: input.platformApi,
         reporterService: input.reporterService,
         runtimeApi: input.runtimeApi,
+        snapshotRepository: input.snapshotRepository,
         wallpaperApi: input.wallpaperApi
       }
     ])

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceOnboarding.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceOnboarding.ts
@@ -58,6 +58,29 @@ export function preserveWorkspaceOnboardingSnapshotMetadata(
   };
 }
 
+export function replaceWorkspaceOnboardingSnapshotMetadata(
+  authoritativeSnapshot: WorkbenchSnapshot | null | undefined,
+  nextSnapshot: WorkbenchSnapshot
+): WorkbenchSnapshot {
+  const authoritativeMetadata =
+    authoritativeSnapshot?.metadata?.[workspaceOnboardingMetadataKey];
+  const {
+    [workspaceOnboardingMetadataKey]: _discardedOnboardingMetadata,
+    ...nextMetadata
+  } = nextSnapshot.metadata ?? {};
+
+  return {
+    ...nextSnapshot,
+    metadata:
+      authoritativeMetadata === undefined
+        ? nextMetadata
+        : {
+            ...nextMetadata,
+            [workspaceOnboardingMetadataKey]: authoritativeMetadata
+          }
+  };
+}
+
 function readWorkspaceOnboardingMetadata(
   snapshot: WorkbenchSnapshot | null | undefined
 ): WorkspaceOnboardingSnapshotMetadata | null {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWallpaper.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWallpaper.ts
@@ -272,6 +272,29 @@ export function preserveWorkspaceWallpaperSnapshotMetadata(
   };
 }
 
+export function replaceWorkspaceWallpaperSnapshotMetadata(
+  authoritativeSnapshot: WorkbenchSnapshot | null | undefined,
+  nextSnapshot: WorkbenchSnapshot
+): WorkbenchSnapshot {
+  const authoritativeMetadata =
+    authoritativeSnapshot?.metadata?.[workspaceWallpaperMetadataKey];
+  const {
+    [workspaceWallpaperMetadataKey]: _discardedWallpaperMetadata,
+    ...nextMetadata
+  } = nextSnapshot.metadata ?? {};
+
+  return {
+    ...nextSnapshot,
+    metadata:
+      authoritativeMetadata === undefined
+        ? nextMetadata
+        : {
+            ...nextMetadata,
+            [workspaceWallpaperMetadataKey]: authoritativeMetadata
+          }
+  };
+}
+
 interface WorkspaceWallpaperSnapshotMetadata {
   displayMode: WorkspaceWallpaperDisplayMode;
   schemaVersion: typeof workspaceWallpaperMetadataSchemaVersion;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
@@ -48,6 +48,8 @@ import type { DesktopWorkspaceAppOpenFileResolvedPayload } from "@shared/contrac
 
 export type WorkspaceCustomWallpaperStatus = "idle" | "saving" | "removing";
 
+export type WorkspaceWorkbenchSnapshotPersistence = "durable" | "window-local";
+
 export interface WorkspaceCustomWallpaperSnapshot {
   exists: boolean;
   fullUrl: string | null;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchSnapshotPersistence.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchSnapshotPersistence.ts
@@ -1,0 +1,9 @@
+import type { WorkspaceWorkbenchSnapshotPersistence } from "./workspaceWorkbenchHostService.interface.ts";
+
+export function resolveWorkspaceWorkbenchSnapshotPersistence(
+  windowSearch: string
+): WorkspaceWorkbenchSnapshotPersistence {
+  return new URLSearchParams(windowSearch).get("view") === "agent"
+    ? "window-local"
+    : "durable";
+}

--- a/docs/adr/0009-cross-product-workbench-host-kernel.md
+++ b/docs/adr/0009-cross-product-workbench-host-kernel.md
@@ -207,6 +207,16 @@ zero or more sessions, but it is not a process-global static and it does not own
 business entities. It owns only the index and lifecycle of sessions created in
 that renderer.
 
+Coordinator isolation is also the window boundary. Two renderer/window roots
+that open the same immutable partition own independent coordinators and
+independent sessions; sessions are never shared across roots. Inside one root,
+opening the same immutable partition more than once returns leases to the same
+session, but that session has exactly one effective surface attachment. A
+renderer handoff may replace the attachment during React remount or shell
+transition, and a stale detach from the previous owner must not clear the
+current handle. The first public contract does not support two simultaneously
+effective Workbench surfaces for one session.
+
 Opening the same immutable partition twice is idempotent or returns an explicit
 lease to the same session. Opening the same scope with a different immutable
 partition must dispose and replace the old session before the new session can
@@ -223,8 +233,33 @@ Each Tutti workspace or TSH room gets a disposable session. The session owns:
 - the attachment to the surface runtime handle; and
 - cleanup for all resources acquired during session construction.
 
-Disposal is idempotent. After disposal, async completions may not mutate cache,
-publish host input, save a snapshot, or call a detached surface handle.
+Disposal is idempotent. The surface shell session may preserve its existing
+behavior of initiating one final, partition-bound snapshot flush during
+teardown. After teardown begins, the host session may not accept new updates,
+publish host input, notify subscribers, or call a detached surface handle. Late
+load/save completions must remain bound to the immutable snapshot partition;
+they may not publish into the disposed session, mutate another partition's
+cache, or overwrite a newer write for the same partition. Repository adapters
+must serialize or otherwise reject stale same-partition completions.
+
+Renderer isolation does not authorize multiple durable writers for the same
+snapshot partition. A product that can open auxiliary renderer roots for the
+same logical scope must choose one durable owner or give auxiliary roots a
+different durable partition. Tutti's OS workspace renderer is the single
+durable writer for a workspace; standalone Agent renderer roots use a
+read-seeded, window-local repository and never issue workspace Workbench PUTs.
+Within the durable repository, loads and saves for one workspace are one
+invocation-ordered operation stream, while different workspaces remain
+independent. Product-owned snapshot metadata is merged from the latest cache at
+write execution time so a stale surface snapshot cannot undo a newer product
+metadata write.
+
+Tutti enforces its single durable owner in the Electron main process. The
+workspace window registry is keyed by `workspaceId` for OS windows, concurrent
+open requests share one pending creation, and later requests restore/focus the
+registered window. Registration rejects a second OS owner as a backstop.
+Agent-only windows are intentionally excluded from that uniqueness rule because
+their repositories never issue durable Workbench writes.
 
 ### Scope and snapshot partitions
 
@@ -254,18 +289,18 @@ adapter. The shared kernel must not infer that policy.
 
 ## State ownership
 
-| State                                                                    | Authoritative owner                                                       | Kernel/session role                                          | Forbidden owner             |
-| ------------------------------------------------------------------------ | ------------------------------------------------------------------------- | ------------------------------------------------------------ | --------------------------- |
-| Snapshot schema, migrations, normalization                               | `@tutti-os/workbench-snapshot`                                            | Consume unchanged                                            | Product adapter             |
-| Frame, display mode, restore frame, minimized state, stack, active shell | Workbench surface session plus daemon snapshot repository                 | Coordinate attachment and persistence port                   | Capability business service |
-| Snapshot durability                                                      | `tuttid` for Tutti; desktopd SQLite keyed by `(room_id, user_id)` for TSH | Call repository port; maintain only recoverable client cache | Renderer session            |
-| Node type/instance identity and dock affinity                            | Existing Workbench surface contracts and identity helpers                 | Preserve and validate ownership                              | Product profile remapping   |
-| Contribution ordering and duplicate capability ownership                 | Host kernel using declared factory `order` then `id`                      | Resolve deterministically                                    | React render order          |
-| Projected node presence                                                  | Owning product runtime/business service                                   | Forward live projection into the attached surface session    | Snapshot restore            |
-| Terminal, agent, chat, app, file, transfer, and collaboration state      | Product daemon/control plane/domain service                               | Read/project through capability adapter                      | Host kernel or snapshot     |
-| Dynamic dock badges, availability, and attention                         | Owning capability service/store                                           | Forward through stable state source                          | Static host-input rebuild   |
-| Authenticated principal used for partitioning                            | Product authentication authority                                          | Hold immutable identity snapshot for one session             | Capability contribution     |
-| React-only overlay/dialog/DOM state                                      | Product presentation adapter                                              | None, except commands/events across a narrow seam            | Shared kernel               |
+| State                                                                    | Authoritative owner                                                       | Kernel/session role                                                                                                                                           | Forbidden owner             |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| Snapshot schema, migrations, normalization                               | `@tutti-os/workbench-snapshot`                                            | Consume unchanged                                                                                                                                             | Product adapter             |
+| Frame, display mode, restore frame, minimized state, stack, active shell | Workbench surface session plus daemon snapshot repository                 | Coordinate attachment and persistence port                                                                                                                    | Capability business service |
+| Snapshot durability                                                      | `tuttid` for Tutti; desktopd SQLite keyed by `(room_id, user_id)` for TSH | Bind repository/cache access to the immutable partition; allow the surface's final teardown flush without cross-partition or stale same-partition publication | Renderer session            |
+| Node type/instance identity and dock affinity                            | Existing Workbench surface contracts and identity helpers                 | Preserve and validate ownership                                                                                                                               | Product profile remapping   |
+| Contribution ordering and duplicate capability ownership                 | Host kernel using declared factory `order` then `id`                      | Resolve deterministically                                                                                                                                     | React render order          |
+| Projected node presence                                                  | Owning product runtime/business service                                   | Forward live projection into the attached surface session                                                                                                     | Snapshot restore            |
+| Terminal, agent, chat, app, file, transfer, and collaboration state      | Product daemon/control plane/domain service                               | Read/project through capability adapter                                                                                                                       | Host kernel or snapshot     |
+| Dynamic dock badges, availability, and attention                         | Owning capability service/store                                           | Forward through stable state source                                                                                                                           | Static host-input rebuild   |
+| Authenticated principal used for partitioning                            | Product authentication authority                                          | Hold immutable identity snapshot for one session                                                                                                              | Capability contribution     |
+| React-only overlay/dialog/DOM state                                      | Product presentation adapter                                              | None, except commands/events across a narrow seam                                                                                                             | Shared kernel               |
 
 ## Invariants
 
@@ -274,7 +309,7 @@ adapter. The shared kernel must not infer that policy.
    collaboration business entity.
 2. At most one live host session exists per immutable snapshot partition in one
    renderer coordinator, and every session is disposed before its partition is
-   replaced.
+   replaced. Separate renderer/window coordinators never share sessions.
 3. TSH cache and persistence access for a room is partitioned by an immutable
    authenticated-user snapshot; credentials and user IDs are never supplied by
    capability contributions or persisted inside the Workbench snapshot.
@@ -283,16 +318,24 @@ adapter. The shared kernel must not infer that policy.
    order.
 5. Dynamic business or dock state may update a stable session but may not
    recreate the coordinator, session, node definitions, or shell identities.
-6. Session disposal cancels or invalidates all later async writes and callbacks;
-   a disposed session cannot publish or persist state.
-7. Shared code depends on product-neutral ports. Tutti and TSH adapters may
+6. A session has one effective surface attachment. A replacement attachment may
+   take ownership during renderer handoff, while a stale detach cannot clear the
+   replacement handle; simultaneous multi-surface ownership is not supported.
+7. Session disposal invalidates later host callbacks and publications. The
+   surface may initiate its existing final partition-bound flush, but late
+   completions cannot publish into a disposed session, cross partitions, or
+   overwrite a newer same-partition write.
+8. Independent renderer coordinators do not imply independent durable writers:
+   each product designates one writer per durable snapshot partition or assigns
+   auxiliary roots a different or non-durable repository.
+9. Shared code depends on product-neutral ports. Tutti and TSH adapters may
    depend on the kernel, but the kernel never imports either product.
-8. Current `WorkbenchContribution`, snapshot schema, stable node identity,
-   dock ordering/affinity, daemon API shapes, and business authority remain
-   behaviorally compatible throughout Phase 0.
-9. Host may depend on surface public contracts at type/declaration level;
-   surface never depends on host, and neither a React runtime dependency nor a
-   host/surface cycle is allowed.
+10. Current `WorkbenchContribution`, snapshot schema, stable node identity,
+    dock ordering/affinity, daemon API shapes, and business authority remain
+    behaviorally compatible throughout Phase 0.
+11. Host may depend on surface public contracts at type/declaration level;
+    surface never depends on host, and neither a React runtime dependency nor a
+    host/surface cycle is allowed.
 
 ## Compatibility constraints
 
@@ -427,17 +470,17 @@ Costs and constraints:
 - a coordinator/session abstraction adds value only if its public surface stays
   smaller than either product host.
 
+## Resolved Phase 0 constraints
+
+- Keep concurrent distinct partitions available internally, but do not promise
+  multi-view UX or multiple effective surfaces for one session in the first
+  public API.
+- Preserve the current public surface props and returned handle attachment for
+  Phase 0. An externally created shell-session API requires a separate decision.
+
 ## Open questions
 
-1. Should the coordinator allow concurrent sessions in one renderer, or enforce
-   one active session with a map-shaped API for future growth? Default: support
-   a map internally and test multiple partitions without promising multi-view
-   UI behavior.
-2. Should the surface accept an externally created shell session, or should the
-   host session initially expose stable `WorkbenchHost` input and attach the
-   returned handle? Default: attach through the current public surface props and
-   handle until an external-session API is justified independently.
-3. Which Tutti snapshot metadata (currently product-owned wallpaper and
+1. Which Tutti snapshot metadata (currently product-owned wallpaper and
    onboarding fields) should remain in the snapshot repository adapter versus a
    dedicated product metadata port? Default: keep compatibility in the Tutti
    adapter during Phase 0 and extract only after conformance tests prove the

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -715,6 +715,15 @@ so back, forward, reload, address entry, external-open, and overflow actions use
 the same controller and runtime state as the webview. The Terminal tray's close
 control only collapses the tray; it
 must not terminate or unmount the active terminal session.
+
+The standalone Agent renderer is not a durable Workbench snapshot writer. Its
+`view=agent` composition root may read the workspace snapshot once to seed
+product chrome such as wallpaper, but its repository is window-local after
+that read: layout, stack, wallpaper, and onboarding saves update only that
+window's memory and never call the workspace Workbench PUT endpoint. The OS
+workspace renderer remains the single durable snapshot writer for a workspace.
+This keeps the synthetic close-coordination host from accidentally becoming a
+second layout owner while standalone windows coexist with the main workspace.
 Electron main may create one of two native workspace shells. `OS` mode keeps
 the existing workspace window and its `ReadyWorkspaceWorkbench`
 desktop/window/dock surface, while `Agent` mode creates the frameless Agent

--- a/docs/architecture/desktop-windows.md
+++ b/docs/architecture/desktop-windows.md
@@ -46,6 +46,14 @@ Current responsibilities:
 - load the selected workspace shell
 - receive the active `workspaceId`
 - provide the long-lived window that later feature work will build into
+- remain the only durable Workbench snapshot writer for that workspace
+
+The main process permits at most one OS workspace window per `workspaceId`.
+Repeated or concurrent open requests reuse the registered window and restore,
+show, and focus it instead of creating another renderer/repository. The window
+registry also rejects a second durable owner if a future caller bypasses the
+normal launch coordinator. Agent-only windows may still coexist because their
+Workbench snapshot repositories are read-seeded and window-local.
 
 The current renderer content is intentionally minimal. The shell exists so the startup and window model can stabilize before in-workspace features are added.
 
@@ -92,8 +100,8 @@ On macOS activation with no open windows, the app follows the same startup resol
 When a user opens a workspace from the dashboard:
 
 1. desktop asks `tuttid` to mark that workspace as opened
-2. desktop creates the preferred Agent-only or OS workspace window for that
-   workspace
+2. desktop creates the preferred Agent-only window, or reuses/creates the one
+   OS workspace window registered for that workspace
 3. desktop closes the dashboard window
 
 When a user creates a workspace from the dashboard:
@@ -129,6 +137,8 @@ window kind explicitly, so it does not depend on asynchronous preference-event
 delivery in the main process. Desktop waits until the replacement is ready
 before closing the source window. An absent preference resolves to OS mode;
 manual selections persist `true` for Agent mode and `false` for OS mode.
+If the requested OS window already exists, desktop reuses it and does not close
+that same window as the handoff owner.
 
 ## Current Renderer Shell Mapping
 
@@ -262,4 +272,5 @@ The following are still intentionally deferred:
 - a dedicated settings window
 - dashboard search
 - keeping dashboard open after launching a workspace
-- multi-window coordination beyond dashboard -> workspace
+- advanced multi-window coordination beyond the enforced per-workspace durable
+  Workbench owner

--- a/docs/specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md
+++ b/docs/specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md
@@ -1,7 +1,7 @@
 # Workbench Host Kernel: Phase 0 To Stable
 
 - Date: 2026-07-11
-- Status: Active; ADR accepted, PRs 1–2 merged, and PRs 3–6 approved
+- Status: Active; ADR accepted, PRs 1–3 merged, and PRs 4–6 approved
 - Architecture decision:
   [ADR 0009](../adr/0009-cross-product-workbench-host-kernel.md)
 - Scope: Tutti-first implementation, npm beta, read-only/downstream TSH
@@ -39,7 +39,7 @@ Approval recorded on 2026-07-11 remains deliberately incremental:
 | ADR 0009 architecture boundary              | Accepted                                 |
 | PR 1 characterization fixtures/tests        | Merged in #1043                          |
 | PR 2 private coordinator/session            | Merged in #1044                          |
-| PR 3 Product Profile/Ports/adapters split   | Approved for implementation              |
+| PR 3 Product Profile/Ports/adapters split   | Merged in #1050                          |
 | Public package extraction and Tutti cutover | Approved after PR 3                      |
 | npm beta publication                        | Approved after PRs 3–5 and validation    |
 | TSH renderer DI/host migration              | Deferred; no TSH changes in current work |
@@ -78,7 +78,7 @@ This proof does not introduce Product Profile or Ports, move product adapters,
 create a package, change public Workbench contracts, or authorize any release or
 TSH change.
 
-### PR 3 implementation evidence
+### PR 3 merged implementation evidence
 
 The approved product-boundary split keeps all new seams Tutti-private until the
 package API review:
@@ -206,7 +206,43 @@ interface WorkbenchHostSession {
 
 The real API should prefer opaque canonical partition keys over exposing string
 concatenation. It must not expose product clients, React hooks, or a generic
-service locator.
+service locator. A field or port is not public merely because the private proof
+declares it: `productId`, `scopeKind`, repository ports, and similar seams must
+either be consumed and enforced by the extracted kernel or remain internal
+until downstream adoption proves the contract.
+
+## Renderer and surface isolation
+
+Isolation is rooted at the renderer/window DI container:
+
+- each renderer/window root owns its own coordinator, so two windows that open
+  the same partition receive independent sessions;
+- inside one coordinator, repeated opens of the same immutable partition return
+  leases to the same session;
+- one session has exactly one effective surface attachment;
+- React remount or shell transition may replace that attachment, but a stale
+  detach from the previous owner cannot clear the current handle; and
+- the first public API does not support two simultaneously effective Workbench
+  surfaces for one session.
+
+Session isolation is separate from durable-write ownership. Tutti's main OS
+workspace renderer is the only writer for the workspace Workbench snapshot.
+Standalone Agent renderers use a read-seeded, window-local repository: they may
+reuse host contributions and close coordination, but their shell or settings
+changes never PUT the primary workspace snapshot. Product conformance must test
+the actual composition-root repository mode, not only two manually constructed
+coordinators.
+
+Tutti's product-level enforcement lives in Electron main: OS workspace windows
+are registered by `workspaceId`, concurrent opens share one pending creation,
+and an existing window is restored/focused rather than duplicated. The
+registry rejects a second durable owner as a backstop. Executable composition
+tests encode real Agent and OS window intents, construct the production
+repository factory, and verify Agent host/wallpaper/onboarding saves issue no
+PUT while the OS path remains durable.
+
+Multiple leases are a lifecycle and handoff mechanism, not a multi-view product
+feature.
 
 ## DI and package dependency target
 
@@ -221,7 +257,12 @@ renderer products still converge on the same integration framework:
   adapters, and window/renderer lifetime wiring.
 
 This is intentional convergence at the official renderer layer, not DI coupling
-inside `@tutti-os/workbench-host`.
+inside `@tutti-os/workbench-host`. Shared coordinator/session classes and their
+emitted declarations must not contain the renderer DI convention
+`_serviceBrand`; each product's service interface or facade owns that marker.
+For Tutti, the marker stays on `IWorkspaceWorkbenchHostService`; the
+product-owned coordinator decorator may be structurally typed to the shared
+class and must not force a brand back into the kernel class.
 
 The package dependency direction is also fixed:
 
@@ -242,25 +283,26 @@ host/surface cycle.
 
 ## State owner and restart matrix
 
-| State                                   | Runtime writer                                            | Durable/restart owner                   | Session behavior                                                  |
-| --------------------------------------- | --------------------------------------------------------- | --------------------------------------- | ----------------------------------------------------------------- |
-| Workbench shell layout and stack        | Workbench surface controller                              | Tutti `tuttid`; TSH desktopd SQLite     | Load/save through repository port                                 |
-| Snapshot normalization/schema           | Shared snapshot package and Go service                    | Canonical schema sources                | Never reinterpret                                                 |
-| Contribution set and order              | Profile plus capability factories                         | Source code/package version             | Resolve once per stable configuration; update explicitly          |
-| Dynamic dock presentation               | Capability store/service                                  | Usually recomputed                      | Subscribe without session rebuild                                 |
-| Projected shell presence                | Product runtime/business service                          | Owning daemon/control plane             | Reconcile live; never recreate business entity from snapshot      |
-| Surface handle and activation sequence  | Surface session                                           | None                                    | Attach/detach; discard on session disposal                        |
-| Repository optimistic cache/save queue  | Product repository adapter or session port implementation | Daemon remains authority                | Partitioned; rollback/ignore stale completion on failure/disposal |
-| Authenticated identity partition        | Product auth authority                                    | Product auth/profile state              | Immutable snapshot for one session; replace session on change     |
-| Wallpaper/onboarding snapshot metadata  | Tutti adapter during Phase 0                              | Existing Tutti snapshot repository path | Preserve byte/semantic compatibility                              |
-| Room collaboration, shared agents, chat | TSH control plane/domain adapters                         | TSH authorities                         | Capability projection only                                        |
+| State                                   | Runtime writer                                            | Durable/restart owner                   | Session behavior                                                                                                                                                                                                 |
+| --------------------------------------- | --------------------------------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Workbench shell layout and stack        | Workbench surface controller                              | Tutti `tuttid`; TSH desktopd SQLite     | Load/save through a repository binding scoped to the immutable partition; preserve final teardown flush without stale publication; auxiliary renderer roots must be non-writing or use another durable partition |
+| Snapshot normalization/schema           | Shared snapshot package and Go service                    | Canonical schema sources                | Never reinterpret                                                                                                                                                                                                |
+| Contribution set and order              | Profile plus capability factories                         | Source code/package version             | Resolve once per stable configuration; update explicitly                                                                                                                                                         |
+| Dynamic dock presentation               | Capability store/service                                  | Usually recomputed                      | Subscribe without session rebuild                                                                                                                                                                                |
+| Projected shell presence                | Product runtime/business service                          | Owning daemon/control plane             | Reconcile live; never recreate business entity from snapshot                                                                                                                                                     |
+| Surface handle and activation sequence  | Surface session                                           | None                                    | Attach/detach; discard on session disposal                                                                                                                                                                       |
+| Repository optimistic cache/save queue  | Product repository adapter or session port implementation | Daemon remains authority                | Partitioned; rollback/ignore stale completion on failure/disposal                                                                                                                                                |
+| Authenticated identity partition        | Product auth authority                                    | Product auth/profile state              | Immutable snapshot for one session; replace session on change                                                                                                                                                    |
+| Wallpaper/onboarding snapshot metadata  | Tutti adapter during Phase 0                              | Existing Tutti snapshot repository path | Merge from the latest serialized repository cache; stale host snapshots cannot overwrite a newer product metadata write                                                                                          |
+| Room collaboration, shared agents, chat | TSH control plane/domain adapters                         | TSH authorities                         | Capability projection only                                                                                                                                                                                       |
 
 ## Required invariants and conformance assertions
 
 At minimum, implementation tests must prove:
 
-1. the coordinator returns no more than one live session for the same canonical
-   partition and disposes every owned session exactly once;
+1. one coordinator returns no more than one live session for the same canonical
+   partition and disposes every owned session exactly once, while separate
+   renderer/window coordinators never share sessions;
 2. changing a TSH authenticated-user snapshot changes the canonical partition,
    never reuses room cache, and invalidates stale async completion from the old
    session;
@@ -269,15 +311,22 @@ At minimum, implementation tests must prove:
 4. dynamic projection/dock changes preserve session, contribution identity,
    node identity, and surface handle;
 5. snapshot load/restore cannot invoke capability launch/create commands;
-6. disposed sessions cannot notify, persist, attach a handle, or accept updates;
-7. product adapters are the only imports of product transport/auth APIs; and
-8. the host kernel produces the same node definitions, dock order, close
+6. one session has one effective surface attachment; replacement handoff is
+   safe and a stale detach cannot clear the replacement handle;
+7. disposed sessions cannot notify, publish, attach a handle, or accept updates;
+   the existing final surface flush remains partition-bound, and late load/save
+   completion cannot cross partitions or overwrite newer same-partition state;
+8. product adapters are the only imports of product transport/auth APIs; and
+9. the host kernel produces the same node definitions, dock order, close
    preparation, and launch routing as the pre-migration Tutti host fixtures.
-9. both official renderers resolve their product-owned Workbench class service
-   through `@tutti-os/infra/di`, while the shared host package has no DI runtime
-   dependency.
-10. the built host package has no React runtime import, surface has no host
+10. both official renderers resolve their product-owned Workbench class service
+    through `@tutti-os/infra/di`, while the shared host package has no DI runtime
+    dependency.
+11. the built host package has no React runtime import, surface has no host
     dependency, and the package graph is acyclic.
+12. each Tutti workspace has at most one durable OS window owner, Agent window
+    composition issues no Workbench PUT for host or product metadata saves, and
+    concurrent OS open requests reuse one pending/registered window.
 
 ## Shared conformance suite
 
@@ -298,13 +347,14 @@ The harness accepts:
 Shared cases cover:
 
 - open/get/lease/release/dispose lifecycle;
+- independent renderer/window coordinators opening the same partition;
 - concurrent distinct partitions;
 - same scope/different principal isolation;
 - deterministic factory order and duplicate rejection;
 - stable host input across dynamic updates;
 - projection updates without launch side effects;
-- load/save failure and stale completion behavior;
-- attach/detach of a surface handle;
+- load/save failure, final teardown flush, and stale completion behavior;
+- single effective surface attachment, replacement handoff, and stale detach;
 - no callbacks after disposal;
 - snapshot purity using canonical snapshot fixtures; and
 - compatibility of explicit host props and contributions where the kernel
@@ -358,19 +408,19 @@ Every PR below is independently mergeable and revertible. A PR may introduce a
 dormant seam or dual-run assertion, but it may not leave two active writers or
 two launch/close authorities.
 
-| PR  | Repository              | Change                                                                                                                                              | Acceptance                                                                                                                                                                                                                             | Minimum verification                                                                                                                                                                                                        | Rollback boundary                                                                                          |
-| --- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| 0   | Tutti                   | Land ADR, this spec, and indexes only                                                                                                               | Docs describe owners, invariants, release gates, risks, and open questions; no runtime files change                                                                                                                                    | Markdown format/link check and diff scope audit                                                                                                                                                                             | Revert docs only                                                                                           |
-| 1   | Tutti                   | Add characterization fixtures/tests around current host composition and lifecycle                                                                   | Current contribution IDs, node IDs, dock order, host-input stability, snapshot metadata, close behavior, and daemon calls are pinned without production behavior change                                                                | Workbench host/registry/repository focused tests; `pnpm --filter @tutti-os/workbench-surface test`; `pnpm check:renderer-boundaries`                                                                                        | Remove tests/fixtures                                                                                      |
-| 2   | Tutti                   | Introduce Tutti-private coordinator/session interfaces and product-neutral classes behind the current DI service                                    | One renderer coordinator creates/disposes per-workspace sessions; existing public service and UI behavior stay unchanged; no product-union context; file migration follows the mapping above                                           | New class unit tests, focused desktop host tests, `pnpm --filter @tutti-os/desktop typecheck`, `pnpm check:renderer-boundaries`                                                                                             | Switch DI registration back to existing service                                                            |
-| 3   | Tutti                   | Move Tutti-only policy into Product Profile, capability adapters, and narrow ports                                                                  | Kernel classes contain no Tutti client, preload, Electron, wallpaper, onboarding, agent, terminal, or app-center imports; existing adapter tests pass                                                                                  | Import-boundary test, characterization suite, desktop typecheck/tests, `pnpm check:electron-runtime-boundaries` where imports move                                                                                          | Restore adapter calls behind unchanged service facade                                                      |
-| 4   | Tutti                   | Extract `packages/workbench/host` as `@tutti-os/workbench-host`; add conformance harness and package docs                                           | Public exports are limited; surface use is type-only/public-contract; emitted JS has no React runtime import; surface does not import host; package graph is acyclic; pack and fixed release roster/config/scripts include the package | Package test/typecheck/build, emitted-import and dependency-cycle checks, conformance tests, `pnpm release:pack:check`, `pnpm lint:ts`, `pnpm typecheck`, `pnpm check:ui-boundaries` if package graph touches UI boundaries | Stop extraction on React runtime/cycle; otherwise revert package extraction and keep private proven kernel |
-| 5   | Tutti                   | Cut Tutti adapter fully to the package and remove private duplicate kernel                                                                          | Exactly one host coordination path; one DI coordinator per renderer/window; sessions dispose on scope/container teardown; all frozen compatibility fixtures match                                                                      | Focused host + workspace shell tests, `pnpm check:changed`, desktop build, Workbench surface tests                                                                                                                          | Revert adapter cutover to private kernel package-equivalent commit                                         |
-| 6   | Tutti release operation | Publish fixed-group npm beta after explicit approval                                                                                                | `@tutti-os/workbench-host@beta` and its exact fixed-group peers are installable; no `latest`, git tags, lockfile edits, or commits are produced                                                                                        | `pnpm release:pack:check`; dry inspection of versions/tarballs; `pnpm release:beta`; verify npm dist-tags and clean worktree                                                                                                | Deprecate bad beta; publish a new beta version, never overwrite                                            |
-| 7   | TSH                     | In a separate TSH PR, upgrade released beta dependencies, add renderer `@tutti-os/infra/di` registration, and adapt the host to coordinator/session | No filesystem links; room/user partition preserved; DI-resolved class service owns lifecycle; hook no longer owns host lifecycle; existing daemon API and business authority unchanged                                                 | Shared conformance suite, renderer DI/container disposal tests, focused TSH Workbench Vitest tests, `pnpm --dir apps/tsh-desktop check`, desktopd focused Go tests if adapters touch repository wiring                      | Revert dependency/DI/adapter PR to last released stable packages                                           |
-| 8   | Tutti                   | Resolve beta findings generically; publish further beta(s) only when approved                                                                       | Fixes are expressed as kernel contract/conformance changes, not `if (productId === ...)`; Tutti and TSH conformance both pass                                                                                                          | Package/Tutti full focused suite; TSH reports exact beta and passing suite                                                                                                                                                  | Revert individual generic fix or use next beta                                                             |
-| 9   | Tutti                   | Promote docs and prepare stable release                                                                                                             | Current Workbench architecture/conventions describe implemented kernel; active spec is removed when rollout is complete; release roster and package entrypoints are durable                                                            | Docs checks, `pnpm check:full`, package pack check, downstream evidence recorded                                                                                                                                            | Revert docs/release-prep PR; stable not yet published                                                      |
-| 10  | Tutti release operation | Publish stable fixed release group after explicit approval                                                                                          | `latest` contains the validated package set; `packages-v<version>` and all existing `packages/**/go.mod` tags are present; TSH can replace beta with exact stable versions                                                             | Stable workflow logs, npm dist-tags, package tarball smoke test, git tag audit, clean main checkout                                                                                                                         | Follow forward with a new fixed-group release; never retag or overwrite                                    |
+| PR  | Repository              | Change                                                                                                                                              | Acceptance                                                                                                                                                                                                                                                                                                                                                                                           | Minimum verification                                                                                                                                                                                                        | Rollback boundary                                                                                                                                                           |
+| --- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0   | Tutti                   | Land ADR, this spec, and indexes only                                                                                                               | Docs describe owners, invariants, release gates, risks, and open questions; no runtime files change                                                                                                                                                                                                                                                                                                  | Markdown format/link check and diff scope audit                                                                                                                                                                             | Revert docs only                                                                                                                                                            |
+| 1   | Tutti                   | Add characterization fixtures/tests around current host composition and lifecycle                                                                   | Current contribution IDs, node IDs, dock order, host-input stability, snapshot metadata, close behavior, and daemon calls are pinned without production behavior change                                                                                                                                                                                                                              | Workbench host/registry/repository focused tests; `pnpm --filter @tutti-os/workbench-surface test`; `pnpm check:renderer-boundaries`                                                                                        | Remove tests/fixtures                                                                                                                                                       |
+| 2   | Tutti                   | Introduce Tutti-private coordinator/session interfaces and product-neutral classes behind the current DI service                                    | One renderer coordinator creates/disposes per-workspace sessions; existing public service and UI behavior stay unchanged; no product-union context; file migration follows the mapping above                                                                                                                                                                                                         | New class unit tests, focused desktop host tests, `pnpm --filter @tutti-os/desktop typecheck`, `pnpm check:renderer-boundaries`                                                                                             | Switch DI registration back to existing service                                                                                                                             |
+| 3   | Tutti                   | Move Tutti-only policy into Product Profile, capability adapters, and narrow ports                                                                  | Kernel classes contain no Tutti client, preload, Electron, wallpaper, onboarding, agent, terminal, or app-center imports; existing adapter tests pass                                                                                                                                                                                                                                                | Import-boundary test, characterization suite, desktop typecheck/tests, `pnpm check:electron-runtime-boundaries` where imports move                                                                                          | Restore adapter calls behind unchanged service facade                                                                                                                       |
+| 4   | Tutti                   | Extract `packages/workbench/host` as `@tutti-os/workbench-host`; add conformance harness and package docs                                           | Public exports are limited to enforced contracts; renderer/window isolation, one effective surface attachment, replacement handoff, and partition-bound final-flush behavior are covered; surface use is type-only/public-contract; emitted JS has no React runtime import; surface does not import host; package graph is acyclic; pack and fixed release roster/config/scripts include the package | Package test/typecheck/build, emitted-import and dependency-cycle checks, conformance tests, `pnpm release:pack:check`, `pnpm lint:ts`, `pnpm typecheck`, `pnpm check:ui-boundaries` if package graph touches UI boundaries | Stop extraction on unenforced public contracts, React runtime/cycle, or unresolved stale-save ownership; otherwise revert package extraction and keep private proven kernel |
+| 5   | Tutti                   | Cut Tutti adapter fully to the package and remove private duplicate kernel                                                                          | Exactly one host coordination path; one DI coordinator per renderer/window; sessions dispose on scope/container teardown; all frozen compatibility fixtures match                                                                                                                                                                                                                                    | Focused host + workspace shell tests, `pnpm check:changed`, desktop build, Workbench surface tests                                                                                                                          | Revert adapter cutover to private kernel package-equivalent commit                                                                                                          |
+| 6   | Tutti release operation | Publish fixed-group npm beta after explicit approval                                                                                                | `@tutti-os/workbench-host@beta` and its exact fixed-group peers are installable; no `latest`, git tags, lockfile edits, or commits are produced                                                                                                                                                                                                                                                      | `pnpm release:pack:check`; dry inspection of versions/tarballs; `pnpm release:beta`; verify npm dist-tags and clean worktree                                                                                                | Deprecate bad beta; publish a new beta version, never overwrite                                                                                                             |
+| 7   | TSH                     | In a separate TSH PR, upgrade released beta dependencies, add renderer `@tutti-os/infra/di` registration, and adapt the host to coordinator/session | No filesystem links; room/user partition preserved; DI-resolved class service owns lifecycle; hook no longer owns host lifecycle; existing daemon API and business authority unchanged                                                                                                                                                                                                               | Shared conformance suite, renderer DI/container disposal tests, focused TSH Workbench Vitest tests, `pnpm --dir apps/tsh-desktop check`, desktopd focused Go tests if adapters touch repository wiring                      | Revert dependency/DI/adapter PR to last released stable packages                                                                                                            |
+| 8   | Tutti                   | Resolve beta findings generically; publish further beta(s) only when approved                                                                       | Fixes are expressed as kernel contract/conformance changes, not `if (productId === ...)`; Tutti and TSH conformance both pass                                                                                                                                                                                                                                                                        | Package/Tutti full focused suite; TSH reports exact beta and passing suite                                                                                                                                                  | Revert individual generic fix or use next beta                                                                                                                              |
+| 9   | Tutti                   | Promote docs and prepare stable release                                                                                                             | Current Workbench architecture/conventions describe implemented kernel; active spec is removed when rollout is complete; release roster and package entrypoints are durable                                                                                                                                                                                                                          | Docs checks, `pnpm check:full`, package pack check, downstream evidence recorded                                                                                                                                            | Revert docs/release-prep PR; stable not yet published                                                                                                                       |
+| 10  | Tutti release operation | Publish stable fixed release group after explicit approval                                                                                          | `latest` contains the validated package set; `packages-v<version>` and all existing `packages/**/go.mod` tags are present; TSH can replace beta with exact stable versions                                                                                                                                                                                                                           | Stable workflow logs, npm dist-tags, package tarball smoke test, git tag audit, clean main checkout                                                                                                                         | Follow forward with a new fixed-group release; never retag or overwrite                                                                                                     |
 
 PR numbers describe dependency order, not a requirement that every concern be a
 large diff. If a PR cannot be reverted without reverting a later PR, the later
@@ -395,6 +445,8 @@ Includes PRs 0–3. Exit criteria:
 Includes PRs 4–6. Exit criteria:
 
 - public API review approves every root/subpath export;
+- renderer/window isolation, single effective surface attachment, safe handoff,
+  and partition-bound final-flush behavior pass conformance;
 - emitted host JavaScript has no React runtime import and dependency-cycle
   checks prove surface does not depend on host;
 - pack output and fixed release group are correct;
@@ -408,6 +460,9 @@ implementation requires separate approval and repository workflow.
 
 Exit criteria:
 
+- before implementation, refresh the dated TSH baseline against its current
+  main branch and record any host, repository, auth, or renderer-DI drift that
+  affects the beta contract;
 - TSH consumes npm beta from the registry, not a local path;
 - TSH resolves the Workbench class service/coordinator through a product-owned
   `@tutti-os/infra/di` renderer registration;
@@ -464,11 +519,9 @@ git diff --name-only
 git diff --stat
 ```
 
-Also confirm no TSH file changed:
-
-```sh
-git -C /Users/ryan/dev/tutti-lab/tsh status --short
-```
+Also confirm that the Tutti change contains no TSH repository files or
+filesystem links. Downstream TSH status is recorded later by its own approved
+integration change rather than through a developer-specific local path.
 
 ### Implementation PRs
 
@@ -500,21 +553,21 @@ The TSH PR must report:
 
 ## Risks and mitigations
 
-| Risk                                                             | Effect                                                            | Mitigation / stop condition                                                                       |
-| ---------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| Public kernel becomes a renamed Tutti host                       | TSH cannot consume it without fake adapters                       | Import-boundary tests; reject Tutti product types in package exports                              |
-| Product-union context grows                                      | Every capability sees unrelated optional services                 | Narrow capability ports; API review rejects optional product bags                                 |
-| Session replacement during dynamic status update                 | Open nodes disappear or async actions target stale handle         | Stable update channel and identity assertions; dynamic dock conformance case                      |
-| Auth change reuses a TSH room cache                              | Cross-user layout disclosure or overwrite                         | Immutable principal partition; replacement/disposal tests; desktopd remains enforcement authority |
-| Disposed async save wins later                                   | Old scope overwrites current cache or snapshot                    | Generation/abort guard and queued-write conformance tests                                         |
-| Contribution ordering changes                                    | Dock or launch behavior regresses                                 | Characterization fixtures before extraction; exact expected order per product                     |
-| Snapshot restore creates business entities                       | Duplicate terminals/agents or authority inversion                 | Restore-with-zero-launch assertion and existing projection rules                                  |
-| Surface and host sessions duplicate responsibilities             | Conflicting state owners and teardown                             | Keep surface mechanics in surface; kernel coordinates only product-host lifecycle                 |
-| Host extraction imports React runtime or creates a package cycle | Headless ownership is false and package layering becomes unstable | Stop extraction; retain the private proof and re-review the boundary before beta                  |
-| TSH keeps hook lifecycle beside the DI class service             | Two host owners and incomplete product convergence                | PR 7 removes hook ownership; renderer DI/container disposal is a conformance requirement          |
-| Fixed release roster is already inconsistent                     | Wrong package set published                                       | Mandatory roster audit in extraction PR; fail closed on mismatch                                  |
-| Beta works only through local workspace resolution               | TSH fails after install                                           | Tarball consumer smoke test and registry-based TSH validation                                     |
-| Cross-repo rollout leaves a long-lived dual path                 | Behavior drift continues                                          | One active writer/launcher invariant; each cutover removes its replaced path                      |
+| Risk                                                                | Effect                                                               | Mitigation / stop condition                                                                                                                   |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Public kernel becomes a renamed Tutti host                          | TSH cannot consume it without fake adapters                          | Import-boundary tests; reject Tutti product types in package exports                                                                          |
+| Product-union context grows                                         | Every capability sees unrelated optional services                    | Narrow capability ports; API review rejects optional product bags                                                                             |
+| Session replacement during dynamic status update                    | Open nodes disappear or async actions target stale handle            | Stable update channel and identity assertions; dynamic dock conformance case                                                                  |
+| Auth change reuses a TSH room cache                                 | Cross-user layout disclosure or overwrite                            | Immutable principal partition; replacement/disposal tests; desktopd remains enforcement authority                                             |
+| Final teardown save or another disposed async completion wins later | Old partition overwrites current cache or newer same-partition state | Bind repository access to the immutable partition; serialize or reject stale same-partition completion; test final flush and immediate reopen |
+| Contribution ordering changes                                       | Dock or launch behavior regresses                                    | Characterization fixtures before extraction; exact expected order per product                                                                 |
+| Snapshot restore creates business entities                          | Duplicate terminals/agents or authority inversion                    | Restore-with-zero-launch assertion and existing projection rules                                                                              |
+| Surface and host sessions duplicate responsibilities                | Conflicting state owners and teardown                                | Keep surface mechanics in surface; kernel coordinates only product-host lifecycle                                                             |
+| Host extraction imports React runtime or creates a package cycle    | Headless ownership is false and package layering becomes unstable    | Stop extraction; retain the private proof and re-review the boundary before beta                                                              |
+| TSH keeps hook lifecycle beside the DI class service                | Two host owners and incomplete product convergence                   | PR 7 removes hook ownership; renderer DI/container disposal is a conformance requirement                                                      |
+| Fixed release roster is already inconsistent                        | Wrong package set published                                          | Mandatory roster audit in extraction PR; fail closed on mismatch                                                                              |
+| Beta works only through local workspace resolution                  | TSH fails after install                                              | Tarball consumer smoke test and registry-based TSH validation                                                                                 |
+| Cross-repo rollout leaves a long-lived dual path                    | Behavior drift continues                                             | One active writer/launcher invariant; each cutover removes its replaced path                                                                  |
 
 ## Non-goals
 
@@ -534,29 +587,31 @@ The TSH PR must report:
 - publishing beta/stable as part of implementation PRs; or
 - modifying TSH from this Tutti task.
 
+## Resolved Phase 0 constraints
+
+- Preserve the current `WorkbenchHost` props plus `onHandleReady` attachment for
+  Phase 0. One session has one effective surface; replacement handoff is safe,
+  stale detach is ignored, and multi-surface ownership is not supported.
+- Keep concurrent distinct partitions available internally, but do not promise
+  multi-view UX in the first public API.
+
 ## Open questions requiring an approval or measured evidence
 
-1. **Surface attachment:** keep current `WorkbenchHost` props plus
-   `onHandleReady`, or add an external surface-session input later?
-   Recommendation: preserve current props for Phase 0; measure whether the
-   attachment seam causes duplicate lifecycle.
-2. **Coordinator multiplicity:** officially support concurrent Workbench
-   sessions in one renderer, or keep it an internal capability?
-   Recommendation: test it, but do not promise multi-view UX in the first API.
-3. **Tutti user partition:** is `workspaceId` sufficient under the current local
+1. **Tutti user partition:** is `workspaceId` sufficient under the current local
    desktop authority for stable, or must account switching be part of the first
    package contract? Recommendation: keep existing Tutti mapping; require a
    follow-up ADR before multi-user local durability.
-4. **Product metadata:** should wallpaper/onboarding metadata remain in Tutti's
+2. **Product metadata:** should wallpaper/onboarding metadata remain in Tutti's
    repository adapter or move to a dedicated metadata contribution?
    Recommendation: preserve current adapter behavior through beta.
-5. **Conformance subpath:** public `./conformance` versus repository-only shared
+3. **Conformance subpath:** public `./conformance` versus repository-only shared
    test package? Recommendation: public dev/test subpath so the external TSH
    repository runs the exact suite shipped with the beta.
 
 ## Approval gates
 
-ADR 0009 is accepted; PR 1 merged as #1043 and PR 2 merged as #1044. PRs 3–5
-and the fixed-group beta in PR 6 are approved in sequence. TSH integration is
-deferred until later business adoption and remains outside the current Tutti
-implementation scope. Stable publication remains separately unapproved.
+ADR 0009 is accepted; PR 1 merged as #1043, PR 2 merged as #1044, and PR 3
+merged as #1050. PRs 4–5 and the fixed-group beta in PR 6 are approved in
+sequence. TSH integration is deferred until later business adoption and remains
+outside the current Tutti implementation scope. Stable publication remains
+separately unapproved.

--- a/packages/workbench/surface/src/host/session.test.ts
+++ b/packages/workbench/surface/src/host/session.test.ts
@@ -648,6 +648,70 @@ test("a newer synchronous save failure does not invalidate an older pending save
   session.dispose();
 });
 
+test("a newer asynchronous save failure does not invalidate an older successful save", async () => {
+  type Snapshot = ReturnType<typeof createWorkbenchSnapshotFromState>;
+  let saveCount = 0;
+  let resolveFirstSave!: (snapshot: Snapshot) => void;
+  let rejectSecondSave!: (error: Error) => void;
+  const savedSnapshots: Snapshot[] = [];
+  const firstSave = new Promise<Snapshot>((resolve) => {
+    resolveFirstSave = resolve;
+  });
+  const secondSave = new Promise<Snapshot>((_resolve, reject) => {
+    rejectSecondSave = reject;
+  });
+  const session = createWorkbenchHostSession({
+    nodes: [browserNodeDefinition],
+    snapshotRepository: {
+      async load() {
+        return createWorkbenchSnapshotFromState(
+          { nodeStack: [], nodes: [] },
+          {
+            activeSpaceId: "space-initial",
+            metadata: { workbenchHostInitialized: true },
+            spaces: [{ id: "space-initial", name: "Initial", nodeIds: [] }]
+          }
+        );
+      },
+      save(_workspaceId, snapshot) {
+        saveCount += 1;
+        savedSnapshots.push(snapshot);
+        if (saveCount === 1) {
+          return firstSave;
+        }
+        if (saveCount === 2) {
+          return secondSave;
+        }
+        return snapshot;
+      }
+    },
+    workspaceId: "workspace-1"
+  });
+
+  await session.load();
+  await session.launchNode({ reason: "dock", typeId: "browser" });
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 450));
+  session.setNodeTitle("browser", "Second save");
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 450));
+
+  const firstSnapshot = savedSnapshots[0];
+  assert.ok(firstSnapshot);
+  resolveFirstSave({
+    ...firstSnapshot,
+    activeSpaceId: "space-first",
+    spaces: [{ id: "space-first", name: "First", nodeIds: [] }]
+  });
+  await Promise.resolve();
+  rejectSecondSave(new Error("newer save failed asynchronously"));
+  await Promise.resolve();
+
+  session.setNodeTitle("browser", "Third save");
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 450));
+
+  assert.equal(savedSnapshots[2]?.activeSpaceId, "space-first");
+  session.dispose();
+});
+
 test("queued launch from a disposed lifecycle does not run in a restarted load", async () => {
   let resolveFirstLoad!: (
     snapshot: ReturnType<typeof createWorkbenchSnapshotFromState>

--- a/packages/workbench/surface/src/host/session.test.ts
+++ b/packages/workbench/surface/src/host/session.test.ts
@@ -430,6 +430,224 @@ test("load can restart after dispose without reusing the disposed lifecycle", as
   session.dispose();
 });
 
+test("late final save completion cannot replace a restarted lifecycle snapshot", async () => {
+  const lifecycleSnapshot = (lifecycle: string) =>
+    createWorkbenchSnapshotFromState(
+      {
+        nodeStack: [],
+        nodes: []
+      },
+      {
+        activeSpaceId: `space-${lifecycle}`,
+        metadata: {
+          workbenchHostInitialized: true
+        },
+        spaces: [
+          {
+            id: `space-${lifecycle}`,
+            name: lifecycle,
+            nodeIds: []
+          }
+        ]
+      }
+    );
+  let loadCount = 0;
+  let saveCount = 0;
+  let resolveFirstSave!: (
+    snapshot: ReturnType<typeof lifecycleSnapshot>
+  ) => void;
+  const firstSave = new Promise<ReturnType<typeof lifecycleSnapshot>>(
+    (resolve) => {
+      resolveFirstSave = resolve;
+    }
+  );
+  const savedSnapshots: Array<ReturnType<typeof lifecycleSnapshot>> = [];
+  const session = createWorkbenchHostSession({
+    nodes: [browserNodeDefinition],
+    snapshotRepository: {
+      async load() {
+        loadCount += 1;
+        return lifecycleSnapshot(loadCount === 1 ? "first" : "second");
+      },
+      save(_workspaceId, snapshot) {
+        saveCount += 1;
+        savedSnapshots.push(snapshot);
+        if (saveCount === 1) {
+          return firstSave;
+        }
+        return snapshot;
+      }
+    },
+    workspaceId: "workspace-1"
+  });
+
+  await session.load();
+  await session.launchNode({ reason: "dock", typeId: "browser" });
+  session.dispose();
+  assert.equal(saveCount, 1);
+
+  await session.load();
+  const firstSavedSnapshot = savedSnapshots[0];
+  assert.ok(firstSavedSnapshot);
+  resolveFirstSave(firstSavedSnapshot);
+  await Promise.resolve();
+
+  await session.launchNode({ reason: "dock", typeId: "browser" });
+  session.dispose();
+
+  const secondSavedSnapshot = savedSnapshots[1];
+  assert.ok(secondSavedSnapshot);
+  assert.equal(secondSavedSnapshot.activeSpaceId, "space-second");
+});
+
+test("late save completion cannot replace a newer save in the same lifecycle", async () => {
+  type Snapshot = ReturnType<typeof createWorkbenchSnapshotFromState>;
+  const deferredSaves: Array<{
+    resolve(snapshot: Snapshot): void;
+    snapshot: Snapshot;
+  }> = [];
+  const savedSnapshots: Snapshot[] = [];
+  const session = createWorkbenchHostSession({
+    nodes: [browserNodeDefinition],
+    snapshotRepository: {
+      async load() {
+        return createWorkbenchSnapshotFromState(
+          { nodeStack: [], nodes: [] },
+          {
+            activeSpaceId: "space-initial",
+            metadata: { workbenchHostInitialized: true },
+            spaces: [{ id: "space-initial", name: "Initial", nodeIds: [] }]
+          }
+        );
+      },
+      save(_workspaceId, snapshot) {
+        savedSnapshots.push(snapshot);
+        if (savedSnapshots.length > 2) {
+          return snapshot;
+        }
+        let resolve!: (savedSnapshot: Snapshot) => void;
+        const promise = new Promise<Snapshot>((promiseResolve) => {
+          resolve = promiseResolve;
+        });
+        deferredSaves.push({ resolve, snapshot });
+        return promise;
+      }
+    },
+    workspaceId: "workspace-1"
+  });
+
+  await session.load();
+  await session.launchNode({ reason: "dock", typeId: "browser" });
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 450));
+  session.setNodeTitle("browser", "Second save");
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 450));
+
+  const firstSave = deferredSaves[0];
+  const secondSave = deferredSaves[1];
+  assert.ok(firstSave);
+  assert.ok(secondSave);
+  secondSave.resolve({
+    ...secondSave.snapshot,
+    activeSpaceId: "space-second",
+    spaces: [{ id: "space-second", name: "Second", nodeIds: [] }]
+  });
+  await Promise.resolve();
+  firstSave.resolve({
+    ...firstSave.snapshot,
+    activeSpaceId: "space-first",
+    spaces: [{ id: "space-first", name: "First", nodeIds: [] }]
+  });
+  await Promise.resolve();
+
+  session.setNodeTitle("browser", "Third save");
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 450));
+
+  assert.equal(savedSnapshots[2]?.activeSpaceId, "space-second");
+  session.dispose();
+});
+
+test("a synchronous repository save failure does not escape session disposal", async () => {
+  const session = createWorkbenchHostSession({
+    nodes: [browserNodeDefinition],
+    snapshotRepository: {
+      async load() {
+        return createWorkbenchSnapshotFromState(
+          { nodeStack: [], nodes: [] },
+          { metadata: { workbenchHostInitialized: true } }
+        );
+      },
+      save() {
+        throw new Error("synchronous save failure");
+      }
+    },
+    workspaceId: "workspace-1"
+  });
+
+  await session.load();
+  await session.launchNode({ reason: "dock", typeId: "browser" });
+
+  assert.doesNotThrow(() => session.dispose());
+  await Promise.resolve();
+});
+
+test("a newer synchronous save failure does not invalidate an older pending save", async () => {
+  type Snapshot = ReturnType<typeof createWorkbenchSnapshotFromState>;
+  let saveCount = 0;
+  let resolveFirstSave!: (snapshot: Snapshot) => void;
+  const savedSnapshots: Snapshot[] = [];
+  const firstSave = new Promise<Snapshot>((resolve) => {
+    resolveFirstSave = resolve;
+  });
+  const session = createWorkbenchHostSession({
+    nodes: [browserNodeDefinition],
+    snapshotRepository: {
+      async load() {
+        return createWorkbenchSnapshotFromState(
+          { nodeStack: [], nodes: [] },
+          {
+            activeSpaceId: "space-initial",
+            metadata: { workbenchHostInitialized: true },
+            spaces: [{ id: "space-initial", name: "Initial", nodeIds: [] }]
+          }
+        );
+      },
+      save(_workspaceId, snapshot) {
+        saveCount += 1;
+        savedSnapshots.push(snapshot);
+        if (saveCount === 1) {
+          return firstSave;
+        }
+        if (saveCount === 2) {
+          throw new Error("newer save failed synchronously");
+        }
+        return snapshot;
+      }
+    },
+    workspaceId: "workspace-1"
+  });
+
+  await session.load();
+  await session.launchNode({ reason: "dock", typeId: "browser" });
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 450));
+  session.setNodeTitle("browser", "Second save");
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 450));
+
+  const firstSnapshot = savedSnapshots[0];
+  assert.ok(firstSnapshot);
+  resolveFirstSave({
+    ...firstSnapshot,
+    activeSpaceId: "space-first",
+    spaces: [{ id: "space-first", name: "First", nodeIds: [] }]
+  });
+  await Promise.resolve();
+
+  session.setNodeTitle("browser", "Third save");
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 450));
+
+  assert.equal(savedSnapshots[2]?.activeSpaceId, "space-first");
+  session.dispose();
+});
+
 test("queued launch from a disposed lifecycle does not run in a restarted load", async () => {
   let resolveFirstLoad!: (
     snapshot: ReturnType<typeof createWorkbenchSnapshotFromState>

--- a/packages/workbench/surface/src/host/session.ts
+++ b/packages/workbench/surface/src/host/session.ts
@@ -124,6 +124,7 @@ class WorkbenchHostSessionController implements WorkbenchHostRuntimeHandle {
   private readyPromise: Promise<void>;
   private resolveReady: () => void = noop;
   private saveTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  private appliedSaveSequence = 0;
   private saveSequence = 0;
   private externalStateUnsubscribe: (() => void) | null = null;
   private leaseUnsubscribe: (() => void) | null = null;
@@ -986,8 +987,9 @@ class WorkbenchHostSessionController implements WorkbenchHostRuntimeHandle {
       if (
         !this.isDisposed &&
         generation === this.loadGeneration &&
-        saveSequence === this.saveSequence
+        saveSequence > this.appliedSaveSequence
       ) {
+        this.appliedSaveSequence = saveSequence;
         this.loadedSnapshot = savedSnapshot;
       }
     }, noop);

--- a/packages/workbench/surface/src/host/session.ts
+++ b/packages/workbench/surface/src/host/session.ts
@@ -124,6 +124,7 @@ class WorkbenchHostSessionController implements WorkbenchHostRuntimeHandle {
   private readyPromise: Promise<void>;
   private resolveReady: () => void = noop;
   private saveTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  private saveSequence = 0;
   private externalStateUnsubscribe: (() => void) | null = null;
   private leaseUnsubscribe: (() => void) | null = null;
   private unsubscribe: (() => void) | null = null;
@@ -945,6 +946,8 @@ class WorkbenchHostSessionController implements WorkbenchHostRuntimeHandle {
       return;
     }
 
+    const generation = this.loadGeneration;
+
     const snapshot = sanitizeWorkbenchHostSnapshot(
       createWorkbenchSnapshotFromState(
         this.applyExternalSnapshotNodeState(
@@ -969,10 +972,24 @@ class WorkbenchHostSessionController implements WorkbenchHostRuntimeHandle {
     if (workbenchSnapshotSaveKey(snapshot) === this.loadedSnapshotSaveKey()) {
       return;
     }
-    void Promise.resolve(
-      this.input.snapshotRepository.save(this.input.workspaceId, snapshot)
-    ).then((savedSnapshot) => {
-      this.loadedSnapshot = savedSnapshot;
+    let saveResult: Promise<WorkbenchSnapshot> | WorkbenchSnapshot;
+    try {
+      saveResult = this.input.snapshotRepository.save(
+        this.input.workspaceId,
+        snapshot
+      );
+    } catch {
+      return;
+    }
+    const saveSequence = ++this.saveSequence;
+    void Promise.resolve(saveResult).then((savedSnapshot) => {
+      if (
+        !this.isDisposed &&
+        generation === this.loadGeneration &&
+        saveSequence === this.saveSequence
+      ) {
+        this.loadedSnapshot = savedSnapshot;
+      }
     }, noop);
   }
 


### PR DESCRIPTION
## Summary

- enforce a single durable OS workspace window per workspace while allowing multiple non-writing Agent windows
- serialize workspace snapshot operations and prevent stale lifecycle or metadata completions from replacing newer state
- preserve the latest host nodes and layout when wallpaper or onboarding metadata is written
- preserve the latest successful save baseline when a newer asynchronous save fails
- document the writer-isolation invariant in the ADR, implementation spec, Agent GUI architecture, and desktop window lifecycle docs

## Fix Scope Justification

- root cause: OS workspace windows, Agent windows, workbench lifecycle saves, and product metadata writes shared one workspace snapshot without a single durable writer and without an ordered successful-completion baseline. A stale full snapshot or a later failed save could therefore replace or invalidate newer state.
- lower layer: this cannot be fixed at a single lower layer because ownership spans Electron window lifecycle, desktop repository composition, and reusable workbench-surface completion ordering. A daemon-only guard would not stop non-owner windows from attempting writes or prevent stale in-memory baselines, while a surface-only fix cannot enforce one durable OS window or merge product-owned metadata safely.

## Testing

- pnpm --filter @tutti-os/desktop test
- pnpm --filter @tutti-os/workbench-surface test
- pnpm check:electron-runtime-boundaries
- pnpm check:renderer-boundaries
- pnpm check:changed --tail-lines 100
- pnpm --filter @tutti-os/desktop build
- pnpm check:full

## Notes

The review findings about stale product metadata writes and asynchronous save failure ordering are fixed in f27aadca2 with regression coverage. The final local pre-push check passed all 18 tasks.