### PR TITLE
fix(agent-gui): persist historical session settings

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -3110,7 +3110,8 @@ provider capability/options
   -> composer support model
   -> node default settings
   -> per-session settings
-  -> runtime settings update or draft settings tracking
+  -> AgentSessionEngine settings-update intent
+  -> live runtime update or historical durable projection update
   -> menu rendering
 ```
 
@@ -3118,10 +3119,24 @@ Avoid fixing a menu label or disabled state without checking whether the same
 setting is also used by prompt creation, session continuation, and runtime
 tracking.
 Active-session settings are first-class session state, not composer defaults.
-The controller should submit the runtime settings patch and let the provider
-adapter decide whether the change can be applied live or requires a new
-session. Provider capability differences belong in the daemon runtime adapter:
-for example, OpenCode model and reasoning-effort changes are live ACP
+The controller should submit exactly one engine intent for one menu selection;
+it must not also promote the active value into target defaults. The engine owns
+the operation state. A timed-out update remains `unknown`, and the next explicit
+user selection carries retry intent instead of being silently dropped.
+
+The daemon selects the mutation path from session liveness. A live session
+updates through its provider adapter. A historical session updates the durable
+activity projection directly and publishes reconciliation without resuming the
+provider runtime or starting a sidecar. This keeps historical settings available
+for the next explicit continuation while avoiding hidden startup latency and
+provider side effects. Runtime resume and durable settings read-modify-write
+share a per-session daemon serialization boundary, so a concurrent continuation
+cannot restore stale settings and partial patches cannot overwrite one another.
+Workflows that must continue the same provider
+conversation, such as plan implementation, explicitly resume first and then use
+the live settings path; they must not depend on a generic settings call to wake
+the runtime. Provider capability differences belong in the daemon runtime
+adapter: for example, OpenCode model and reasoning-effort changes are live ACP
 `session/set_config_option` updates, while spawn-time-only provider settings may
 return the `agent.settings_require_new_session` reason. The UI should surface
 that reason as guidance, not as an unhandled runtime error.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -3122,7 +3122,10 @@ Active-session settings are first-class session state, not composer defaults.
 The controller should submit exactly one engine intent for one menu selection;
 it must not also promote the active value into target defaults. The engine owns
 the operation state. A timed-out update remains `unknown`, and the next explicit
-user selection carries retry intent instead of being silently dropped.
+user selection carries retry intent instead of being silently dropped. That
+retry merges the unresolved in-flight patch, any queued patch, and the latest
+selection in that order, so the newest value wins without losing settings that
+the daemon may not have applied before the timeout.
 
 The daemon selects the mutation path from session liveness. A live session
 updates through its provider adapter. A historical session updates the durable
@@ -3130,8 +3133,9 @@ activity projection directly and publishes reconciliation without resuming the
 provider runtime or starting a sidecar. This keeps historical settings available
 for the next explicit continuation while avoiding hidden startup latency and
 provider side effects. Runtime resume and durable settings read-modify-write
-share a per-session daemon serialization boundary, so a concurrent continuation
-cannot restore stale settings and partial patches cannot overwrite one another.
+share a context-aware per-session daemon serialization boundary, so a canceled
+caller does not remain blocked behind a slow resume, a concurrent continuation
+cannot restore stale settings, and partial patches cannot overwrite one another.
 Workflows that must continue the same provider
 conversation, such as plan implementation, explicitly resume first and then use
 the live settings path; they must not depend on a generic settings call to wake

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -47,6 +47,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [AgentGUI loading disappears before active turn settles](./agent-session-lifecycle.md#agentgui-loading-disappears-before-active-turn-settles)
 - [Agent session stays loading after a completed turn](./agent-session-lifecycle.md#agent-session-stays-loading-after-a-completed-turn)
 - [AgentGUI model switch changes defaults but not the active session](./agent-session-lifecycle.md#agentgui-model-switch-changes-defaults-but-not-the-active-session)
+- [Historical AgentGUI permission changes time out or stop responding](./agent-session-lifecycle.md#historical-agentgui-permission-changes-time-out-or-stop-responding)
 - [AgentGUI pin or unpin appears stuck for a live session](./agent-session-lifecycle.md#agentgui-pin-or-unpin-appears-stuck-for-a-live-session)
 - [Agent GUI provider tab shows fused or stale conversations](./agent-session-lifecycle.md#agent-gui-provider-tab-shows-fused-or-stale-conversations)
 - [Agent GUI no-project sessions appear under a user project](./agent-session-lifecycle.md#agent-gui-no-project-sessions-appear-under-a-user-project)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -529,6 +529,44 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [controller.go](../../../packages/agent/daemon/runtime/controller.go)
   [codex_appserver_adapter.go](../../../packages/agent/daemon/runtime/codex_appserver_adapter.go)
 
+### Historical AgentGUI permission changes time out or stop responding
+
+- Symptom:
+  Changing permission mode in a historical conversation appears to do nothing,
+  or the first selection times out and later selections are ignored. Logs may
+  show a 30-second settings request with no provider settings application.
+- Quick checks:
+  Confirm the selected session is absent from the live runtime but present in
+  `workspace_agent_sessions`. Check whether one menu choice emitted two settings
+  requests. After a timeout, inspect the engine settings operation: `unknown`
+  plus a later request without `retry` explains a silent drop.
+- Root cause:
+  Historical settings were routed through runtime preparation, so a metadata
+  change could block on provider resume and sidecar startup. The permission
+  menu also handled both item pointer-down and Select value-change, duplicating
+  one user action. When the first command timed out, the engine correctly kept
+  uncertainty but the controller did not mark a later explicit choice as a
+  retry.
+- Fix:
+  Send one settings intent from Select value-change. Read the current engine
+  operation at action time and mark an explicit choice as retry when its status
+  is `unknown`. In the daemon, update inactive-session settings through the
+  durable activity projection and publish reconciliation; reserve provider
+  runtime updates for sessions that are already live. Serialize runtime resume
+  with durable settings read-modify-write per session, preventing stale resume
+  inputs and lost concurrent partial patches. Do not copy an active session
+  setting into target defaults.
+- Validation:
+  Cover one pointer selection producing one callback, timeout followed by an
+  explicit retry, and a historical Claude Code settings update that persists
+  while runtime resume and live adapter update counts remain zero. Run the
+  AgentGUI, activity-core, store-sqlite, and agent-service focused tests.
+- References:
+  [AgentComposerSettingsMenus.tsx](../../../packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.tsx)
+  [useAgentGUIComposerSettingsActions.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.ts)
+  [service_settings.go](../../../services/tuttid/service/agent/service_settings.go)
+  [agent-gui-node.md](../../architecture/agent-gui-node.md)
+
 ### Agent GUI provider tab shows fused or stale conversations
 
 - Symptom:

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
@@ -62,6 +62,30 @@ test("snapshot restores a settled latest turn without an active turn", () => {
   );
 });
 
+test("settings timeout requires an explicit retry before sending again", () => {
+  let state = reduce(createInitialSessionLifecycleState(), {
+    type: "session/snapshotReceived",
+    sessions: [session(null, 1)]
+  }).state;
+  const requested = reduce(state, settingsUpdateRequested("settings-1"));
+  assert.equal(requested.commands[0]?.type, "session/updateSettings");
+  state = reduce(requested.state, {
+    commandId: "settings-1",
+    commandType: "session/updateSettings",
+    correlationId: "session-1",
+    outcome: "timedOut",
+    type: "engine/commandResult"
+  }).state;
+
+  const dropped = reduce(state, settingsUpdateRequested("settings-2"));
+  assert.deepEqual(dropped.commands, []);
+  const retried = reduce(state, {
+    ...settingsUpdateRequested("settings-2"),
+    retry: true
+  });
+  assert.equal(retried.commands[0]?.type, "session/updateSettings");
+});
+
 test("bounded snapshots preserve page-loaded session entities omitted from the response", () => {
   const pageLoaded = {
     ...session(null, 2),
@@ -1021,6 +1045,16 @@ function interactionResponseRequested(commandId: string) {
     requestId: "request-1",
     turnId: "turn-1",
     timeoutMs: 30_000,
+    workspaceId: "workspace-1"
+  };
+}
+
+function settingsUpdateRequested(commandId: string) {
+  return {
+    type: "session/settingsUpdateRequested" as const,
+    agentSessionId: "session-1",
+    commandId,
+    settings: { permissionModeId: "acceptEdits" },
     workspaceId: "workspace-1"
   };
 }

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
@@ -69,7 +69,12 @@ test("settings timeout requires an explicit retry before sending again", () => {
   }).state;
   const requested = reduce(state, settingsUpdateRequested("settings-1"));
   assert.equal(requested.commands[0]?.type, "session/updateSettings");
-  state = reduce(requested.state, {
+  const queued = reduce(
+    requested.state,
+    settingsUpdateRequested("settings-queued", { planMode: true })
+  );
+  assert.deepEqual(queued.commands, []);
+  state = reduce(queued.state, {
     commandId: "settings-1",
     commandType: "session/updateSettings",
     correlationId: "session-1",
@@ -77,13 +82,27 @@ test("settings timeout requires an explicit retry before sending again", () => {
     type: "engine/commandResult"
   }).state;
 
-  const dropped = reduce(state, settingsUpdateRequested("settings-2"));
+  const dropped = reduce(
+    state,
+    settingsUpdateRequested("settings-2", { speed: "fast" })
+  );
   assert.deepEqual(dropped.commands, []);
   const retried = reduce(state, {
-    ...settingsUpdateRequested("settings-2"),
+    ...settingsUpdateRequested("settings-2", { speed: "fast" }),
     retry: true
   });
-  assert.equal(retried.commands[0]?.type, "session/updateSettings");
+  assert.deepEqual(retried.commands[0], {
+    agentSessionId: "session-1",
+    commandId: "settings-2",
+    correlationId: "session-1",
+    settings: {
+      permissionModeId: "acceptEdits",
+      planMode: true,
+      speed: "fast"
+    },
+    type: "session/updateSettings",
+    workspaceId: "workspace-1"
+  });
 });
 
 test("bounded snapshots preserve page-loaded session entities omitted from the response", () => {
@@ -1049,12 +1068,17 @@ function interactionResponseRequested(commandId: string) {
   };
 }
 
-function settingsUpdateRequested(commandId: string) {
+function settingsUpdateRequested(
+  commandId: string,
+  settings: Readonly<Record<string, unknown>> = {
+    permissionModeId: "acceptEdits"
+  }
+) {
   return {
     type: "session/settingsUpdateRequested" as const,
     agentSessionId: "session-1",
     commandId,
-    settings: { permissionModeId: "acceptEdits" },
+    settings,
     workspaceId: "workspace-1"
   };
 }

--- a/packages/agent/activity-core/src/engine/sessionSettings.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionSettings.reducer.ts
@@ -58,7 +58,14 @@ export function requestSettingsUpdate(
   }
   if (operation.settingsUpdate.status === "unknown" && intent.retry !== true)
     return unchanged(state);
-  const settings = { ...intent.settings };
+  const settings =
+    operation.settingsUpdate.status === "unknown"
+      ? {
+          ...(operation.settingsUpdate.settings ?? {}),
+          ...(operation.settingsUpdate.queuedSettings ?? {}),
+          ...intent.settings
+        }
+      : { ...intent.settings };
   return {
     commands: [
       settingsCommand(id, workspaceId, commandId, settings, intent.timeoutMs)

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -1,0 +1,77 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { AgentPermissionModeDropdown } from "./AgentComposerSettingsMenus";
+import type { AgentGUIComposerSettingsVM } from "./model/agentGuiNodeTypes";
+
+beforeAll(() => {
+  Object.defineProperties(HTMLElement.prototype, {
+    hasPointerCapture: { configurable: true, value: () => false },
+    releasePointerCapture: { configurable: true, value: () => undefined },
+    setPointerCapture: { configurable: true, value: () => undefined }
+  });
+});
+
+describe("AgentPermissionModeDropdown", () => {
+  it("dispatches one settings change for one permission selection", async () => {
+    const onSettingsChange = vi.fn();
+    render(
+      <AgentPermissionModeDropdown
+        composerSettings={composerSettings()}
+        labels={{
+          loadingOptions: "Loading permission modes",
+          permissionLabel: "Permission mode"
+        }}
+        onSettingsChange={onSettingsChange}
+      />
+    );
+
+    fireEvent.pointerDown(
+      screen.getByRole("combobox", { name: "Permission mode" }),
+      { button: 0, ctrlKey: false, pointerType: "mouse" }
+    );
+    const option = await screen.findByRole("option", { name: "Accept edits" });
+    fireEvent.pointerDown(option, { button: 0, ctrlKey: false });
+    fireEvent.click(option);
+
+    expect(onSettingsChange).toHaveBeenCalledTimes(1);
+    expect(onSettingsChange).toHaveBeenCalledWith({
+      permissionModeId: "acceptEdits",
+      planMode: false
+    });
+  });
+});
+
+function composerSettings(): AgentGUIComposerSettingsVM {
+  return {
+    availableModels: [],
+    availablePermissionModes: [
+      { label: "Default", value: "default" },
+      { label: "Accept edits", value: "acceptEdits" }
+    ],
+    availableReasoningEfforts: [],
+    availableSpeeds: [],
+    draftSettings: {
+      browserUse: true,
+      computerUse: true,
+      model: null,
+      permissionModeId: "default",
+      planMode: false,
+      reasoningEffort: null,
+      speed: null
+    },
+    isSettingsLoading: false,
+    modelUnavailable: true,
+    permissionModeUnavailable: false,
+    planExclusiveWithPermissionMode: true,
+    reasoningUnavailable: true,
+    selectedPermissionModeValue: "default",
+    sessionSettings: null,
+    speedUnavailable: true,
+    supportsModel: false,
+    supportsPermissionMode: true,
+    supportsPlanMode: true,
+    supportsReasoningEffort: false,
+    supportsSpeed: false
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.tsx
@@ -113,16 +113,6 @@ export function AgentPermissionModeDropdown({
       })
     );
   };
-  const handleSelectedItemPointerDown = (
-    event: React.PointerEvent,
-    permissionModeId: string
-  ): void => {
-    if (selectDisabled || event.button !== 0 || event.ctrlKey) {
-      return;
-    }
-    applyPermissionModeId(permissionModeId);
-  };
-
   const trigger = (
     <button
       type="button"
@@ -205,9 +195,6 @@ export function AgentPermissionModeDropdown({
               value={option.value}
               disabled={selectDisabled}
               className={cn(styles.composerMenuItem, "group/composer-option")}
-              onPointerDown={(event) =>
-                handleSelectedItemPointerDown(event, option.value)
-              }
             >
               <span className="flex min-w-0 items-center gap-1.5">
                 <span className="min-w-0 truncate">{option.label}</span>

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.spec.tsx
@@ -1,0 +1,130 @@
+import { act, renderHook } from "@testing-library/react";
+import {
+  createAgentSessionEngine,
+  normalizeAgentActivitySession,
+  selectEngineSessionSettingsUpdate
+} from "@tutti-os/agent-activity-core";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
+import type { AgentSessionComposerSettings } from "../../../shared/agentSessionTypes";
+import type { AgentGUINodeData } from "../../../types";
+import type { useAgentGUIActivation } from "./useAgentGUIActivation";
+import { useAgentGUIComposerSettingsActions } from "./useAgentGUIComposerSettingsActions";
+
+describe("useAgentGUIComposerSettingsActions", () => {
+  it("retries an unknown active-session update without changing target defaults", () => {
+    const execute = vi.fn(() => new Promise<unknown>(() => undefined));
+    const sessionEngine = createAgentSessionEngine({
+      clock: { nowUnixMs: () => 1 },
+      commandPort: { execute },
+      identity: { origin: "test", workspaceId: "workspace-1" },
+      scheduler: { schedule: () => ({ cancel() {} }) }
+    });
+    sessionEngine.dispatch({
+      type: "session/snapshotReceived",
+      sessions: [
+        normalizeAgentActivitySession({
+          activeTurnId: null,
+          agentSessionId: "session-1",
+          cwd: "/workspace",
+          latestTurnInteractions: [],
+          pendingInteractions: [],
+          provider: "claude-code",
+          settings: { permissionModeId: "dontAsk", planMode: false },
+          title: "Historical session",
+          workspaceId: "workspace-1"
+        })
+      ]
+    });
+    sessionEngine.dispatch({
+      agentSessionId: "session-1",
+      commandId: "settings-1",
+      settings: { permissionModeId: "acceptEdits" },
+      type: "session/settingsUpdateRequested",
+      workspaceId: "workspace-1"
+    });
+    sessionEngine.dispatch({
+      commandId: "settings-1",
+      commandType: "session/updateSettings",
+      correlationId: "session-1",
+      outcome: "timedOut",
+      type: "engine/commandResult"
+    });
+    expect(
+      selectEngineSessionSettingsUpdate(
+        sessionEngine.getSnapshot(),
+        "session-1"
+      )?.status
+    ).toBe("unknown");
+
+    const data: AgentGUINodeData = {
+      agentTargetId: "local:claude-code",
+      lastActiveAgentSessionId: null,
+      provider: "claude-code"
+    };
+    const onDataChange = vi.fn();
+    const onRememberComposerDefaults = vi.fn();
+    const setDraftSettingsBySessionId = vi.fn();
+    const dispatch = vi.spyOn(sessionEngine, "dispatch");
+    const activeSettings: AgentSessionComposerSettings = {
+      browserUse: true,
+      computerUse: true,
+      permissionModeId: "dontAsk",
+      planMode: false
+    };
+    const activation = {
+      stateFor: vi.fn(() => "inactive" as const)
+    } as unknown as ReturnType<typeof useAgentGUIActivation>;
+    const rendered = renderHook(() =>
+      useAgentGUIComposerSettingsActions({
+        activation,
+        activeCanonicalComposerSettings: activeSettings,
+        activeConversationIdRef: { current: "session-1" },
+        activeEngineActiveTurn: null,
+        agentActivityRuntime: {
+          getSnapshot: () => ({})
+        } as unknown as AgentActivityRuntime,
+        composerSupportPermissionModeChangeDeferred: false,
+        defaultReasoningEffort: null,
+        draftSettingsBySessionIdRef: { current: {} },
+        loadDraftComposerOptions: vi.fn(),
+        onDataChangeRef: { current: onDataChange },
+        onRememberComposerDefaultsRef: {
+          current: onRememberComposerDefaults
+        },
+        onShowMessageRef: { current: vi.fn() },
+        selectedComposerTargetDataRef: {
+          current: {
+            agentTargetId: "local:claude-code",
+            data,
+            provider: "claude-code",
+            targetId: "local:claude-code"
+          }
+        },
+        sessionEngine,
+        setDraftSettingsBySessionId,
+        updateComposerSettingsRef: { current: vi.fn() },
+        workspaceId: "workspace-1"
+      })
+    );
+
+    act(() => {
+      rendered.result.current.updateComposerSettings({
+        permissionModeId: "acceptEdits"
+      });
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentSessionId: "session-1",
+        retry: true,
+        settings: { permissionModeId: "acceptEdits" },
+        type: "session/settingsUpdateRequested"
+      })
+    );
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(onRememberComposerDefaults).not.toHaveBeenCalled();
+    expect(onDataChange).not.toHaveBeenCalled();
+    expect(setDraftSettingsBySessionId).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.ts
@@ -1,5 +1,6 @@
 import {
   selectEngineSession,
+  selectEngineSessionSettingsUpdate,
   type AgentActivityTurn,
   type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
@@ -20,6 +21,7 @@ import {
   readNodeDefaultDraftSettings,
   resolveEffectiveComposerSettings
 } from "./agentGuiController.composerHelpers";
+import { shouldRetrySessionSettingsUpdate } from "../model/composerModeSelection";
 import {
   sanitizeComposerSettingsForTarget,
   type AgentGUIComposerTargetData
@@ -31,7 +33,6 @@ import {
 import {
   composerDefaultsPatchFromSettings,
   composerOptionsForTarget,
-  rememberComposerDefaultsFields,
   type AgentGUIRememberComposerDefaultsInput
 } from "./agentGuiController.providerHelpers";
 import type { useAgentGUIActivation } from "./useAgentGUIActivation";
@@ -43,7 +44,6 @@ interface UseAgentGUIComposerSettingsActionsInput {
   activeEngineActiveTurn: AgentActivityTurn | null;
   agentActivityRuntime: AgentActivityRuntime;
   composerSupportPermissionModeChangeDeferred: boolean;
-  dataRef: RefObject<AgentGUINodeData>;
   defaultReasoningEffort: AgentSessionReasoningEffort | null;
   draftSettingsBySessionIdRef: RefObject<
     Record<string, AgentSessionComposerSettings>
@@ -79,7 +79,6 @@ export function useAgentGUIComposerSettingsActions(
     activeConversationIdRef,
     activeEngineActiveTurn,
     agentActivityRuntime,
-    dataRef,
     defaultReasoningEffort,
     draftSettingsBySessionIdRef,
     loadDraftComposerOptions,
@@ -273,56 +272,6 @@ export function useAgentGUIComposerSettingsActions(
         Object.keys(sessionSettingsPatch).length > 0 &&
         (canonicalSession !== null || isPreActivationSession)
       ) {
-        // A switch inside an active session also becomes the remembered
-        // default for this agent target. Only the fields the user changed
-        // are passed; the consumer merges them field-wise so untouched
-        // remembered fields stay intact, and explicit clears propagate as
-        // null tombstones.
-        void onRememberComposerDefaultsRef.current?.({
-          agentTargetId: normalizeOptionalText(dataRef.current.agentTargetId),
-          provider: dataRef.current.provider,
-          defaults: composerDefaultsPatchFromSettings(
-            sessionSettingsPatch,
-            sessionSettingsPatch
-          )
-        });
-        // The node-level default drafts take precedence over the remembered
-        // preferences on the read path, so sync the durable fields into them
-        // as well or this node's next composer would keep showing its stale
-        // draft.
-        const durableNodeDefaultsPatch: Partial<AgentSessionComposerSettings> =
-          {};
-        for (const field of rememberComposerDefaultsFields) {
-          if (sessionSettingsPatch[field] !== undefined) {
-            durableNodeDefaultsPatch[field] = sessionSettingsPatch[field];
-          }
-        }
-        if (Object.keys(durableNodeDefaultsPatch).length > 0) {
-          const defaultDraftKey = nodeDefaultDraftKey(
-            dataRef.current.provider,
-            dataRef.current.agentTargetId
-          );
-          const storedNodeDefaults = readNodeDefaultDraftSettings({
-            data: dataRef.current,
-            defaultReasoningEffort,
-            drafts: draftSettingsBySessionIdRef.current
-          });
-          const nextNodeDefaults = {
-            ...storedNodeDefaults,
-            ...durableNodeDefaultsPatch
-          };
-          draftSettingsBySessionIdRef.current = {
-            ...draftSettingsBySessionIdRef.current,
-            [defaultDraftKey]: nextNodeDefaults
-          };
-          setDraftSettingsBySessionId((current) => ({
-            ...current,
-            [defaultDraftKey]: nextNodeDefaults
-          }));
-          onDataChangeRef.current((current) =>
-            nodeDataFromComposerSettings(current, nextNodeDefaults)
-          );
-        }
         if (isPreActivationSession) {
           sessionEngine.dispatch({
             type: "activation/settingsPatched",
@@ -330,9 +279,14 @@ export function useAgentGUIComposerSettingsActions(
             settings: { ...sessionSettingsPatch }
           });
         } else {
+          const settingsUpdate = selectEngineSessionSettingsUpdate(
+            sessionEngine.getSnapshot(),
+            agentSessionId
+          );
           sessionEngine.dispatch({
             agentSessionId,
             commandId: `settings:${createAgentGUIConversationId()}`,
+            retry: shouldRetrySessionSettingsUpdate(settingsUpdate?.status),
             settings: { ...sessionSettingsPatch },
             timeoutMs: 30_000,
             type: "session/settingsUpdateRequested",

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.spec.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   permissionModeSelectionPatch,
-  resolvePermissionModeControlsDisabled
+  resolvePermissionModeControlsDisabled,
+  shouldRetrySessionSettingsUpdate
 } from "./composerModeSelection";
 
 describe("permissionModeSelectionPatch", () => {
@@ -67,4 +68,17 @@ describe("resolvePermissionModeControlsDisabled", () => {
       })
     ).toBe(false);
   });
+});
+
+describe("shouldRetrySessionSettingsUpdate", () => {
+  it("treats a new user selection as an explicit retry after an unknown result", () => {
+    expect(shouldRetrySessionSettingsUpdate("unknown")).toBe(true);
+  });
+
+  it.each([null, "idle", "inFlight", "failed"])(
+    "does not mark %s as an uncertain retry",
+    (status) => {
+      expect(shouldRetrySessionSettingsUpdate(status)).toBe(false);
+    }
+  );
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.ts
@@ -36,3 +36,15 @@ export function resolvePermissionModeControlsDisabled(options: {
     options.showStopButton
   );
 }
+
+/**
+ * A settings timeout means delivery is uncertain, so the engine blocks a new
+ * command until the caller explicitly identifies a user retry. A fresh menu
+ * selection is that explicit retry; ordinary idle/in-flight/failed updates are
+ * not.
+ */
+export function shouldRetrySessionSettingsUpdate(
+  status: string | null | undefined
+): boolean {
+  return status === "unknown";
+}

--- a/packages/agent/store-sqlite/activity_update.go
+++ b/packages/agent/store-sqlite/activity_update.go
@@ -90,3 +90,48 @@ WHERE workspace_id = ? AND agent_session_id = ? AND deleted_at_unix_ms = 0
 	}
 	return session, ok, nil
 }
+
+func (s *Store) UpdateSessionSettings(
+	ctx context.Context,
+	workspaceID string,
+	agentSessionID string,
+	model string,
+	settings map[string]any,
+) (Session, bool, error) {
+	if s == nil || s.db == nil {
+		return Session{}, false, errors.New("workspace database is not initialized")
+	}
+	workspaceID = strings.TrimSpace(workspaceID)
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	if workspaceID == "" || agentSessionID == "" {
+		return Session{}, false, nil
+	}
+	settingsJSON, err := marshalJSONMap(settings)
+	if err != nil {
+		return Session{}, false, err
+	}
+
+	now := unixMs(time.Now().UTC())
+	result, err := s.db.ExecContext(ctx, `
+UPDATE workspace_agent_sessions
+SET model = ?,
+    settings_json = ?,
+    updated_at_unix_ms = ?
+WHERE workspace_id = ? AND agent_session_id = ? AND deleted_at_unix_ms = 0
+`, strings.TrimSpace(model), settingsJSON, now, workspaceID, agentSessionID)
+	if err != nil {
+		return Session{}, false, fmt.Errorf("update workspace agent session settings: %w", err)
+	}
+	updated, err := rowsWereAffected(result, "update workspace agent session settings")
+	if err != nil {
+		return Session{}, false, err
+	}
+	if !updated {
+		return Session{}, false, nil
+	}
+	session, ok, err := s.GetSession(ctx, workspaceID, agentSessionID)
+	if err != nil {
+		return Session{}, false, err
+	}
+	return session, ok, nil
+}

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -45,6 +45,7 @@ type Repository interface {
 	MarkRuntimeOperationEventPublished(context.Context, string, int64, int64) (bool, error)
 	SettleStaleTurns(context.Context) ([]StaleTurnSettlement, error)
 	UpdateSessionPinned(context.Context, string, string, bool) (Session, bool, error)
+	UpdateSessionSettings(context.Context, string, string, string, map[string]any) (Session, bool, error)
 	UpdateSessionTitle(context.Context, string, string, string) (Session, bool, error)
 }
 

--- a/packages/agent/store-sqlite/store_test.go
+++ b/packages/agent/store-sqlite/store_test.go
@@ -308,6 +308,16 @@ func TestStoreReportAndListSessionLifecycle(t *testing.T) {
 		t.Fatalf("UpdateSessionTitle() = %#v ok=%v error=%v", renamed, ok, err)
 	}
 
+	updatedSettings, ok, err := store.UpdateSessionSettings(ctx, "ws-1", "session-1", "gpt-5.4", map[string]any{
+		"model":            "gpt-5.4",
+		"permissionModeId": "full-access",
+	})
+	if err != nil || !ok || updatedSettings.Model != "gpt-5.4" ||
+		updatedSettings.Settings["permissionModeId"] != "full-access" ||
+		updatedSettings.UpdatedAtUnixMS < renamed.UpdatedAtUnixMS {
+		t.Fatalf("UpdateSessionSettings() = %#v ok=%v error=%v", updatedSettings, ok, err)
+	}
+
 	blankRenamed, ok, err := store.UpdateSessionTitle(ctx, "ws-1", "session-1", "   ")
 	if err != nil || ok {
 		t.Fatalf("UpdateSessionTitle(blank) = %#v ok=%v error=%v, want no update", blankRenamed, ok, err)

--- a/services/tuttid/data/workspace/agent_store.go
+++ b/services/tuttid/data/workspace/agent_store.go
@@ -147,6 +147,10 @@ func (s *SQLiteStore) UpdateSessionPinned(ctx context.Context, workspaceID strin
 	return s.agentStore().UpdateSessionPinned(ctx, workspaceID, agentSessionID, pinned)
 }
 
+func (s *SQLiteStore) UpdateSessionSettings(ctx context.Context, workspaceID string, agentSessionID string, model string, settings map[string]any) (agentactivitybiz.Session, bool, error) {
+	return s.agentStore().UpdateSessionSettings(ctx, workspaceID, agentSessionID, model, settings)
+}
+
 func (s *SQLiteStore) UpdateSessionTitle(ctx context.Context, workspaceID string, agentSessionID string, title string) (agentactivitybiz.Session, bool, error) {
 	return s.agentStore().UpdateSessionTitle(ctx, workspaceID, agentSessionID, title)
 }

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -538,6 +538,30 @@ func (p *ActivityProjection) UpdateSessionPinned(ctx context.Context, workspaceI
 	return persisted, true, nil
 }
 
+func (p *ActivityProjection) UpdateSessionSettings(ctx context.Context, workspaceID string, agentSessionID string, settings ComposerSettings) (PersistedSession, bool, error) {
+	if p == nil || p.repo == nil {
+		return PersistedSession{}, false, nil
+	}
+	workspaceID = strings.TrimSpace(workspaceID)
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	session, ok, err := p.repo.UpdateSessionSettings(
+		ctx,
+		workspaceID,
+		agentSessionID,
+		settings.Model,
+		ComposerSettingsToMap(settings),
+	)
+	if err != nil {
+		return PersistedSession{}, false, err
+	}
+	if !ok {
+		return PersistedSession{}, false, nil
+	}
+	persisted := persistedSessionFromActivity(session)
+	p.publishActivityUpdated(ctx, workspaceID, agentSessionID, "session_reconcile_required", activitySessionUpdateEventPayload(workspaceID, agentSessionID, persisted.UpdatedAtUnixMS))
+	return persisted, true, nil
+}
+
 func (p *ActivityProjection) UpdateSessionTitle(ctx context.Context, workspaceID string, agentSessionID string, title string) (PersistedSession, bool, error) {
 	if p == nil || p.repo == nil {
 		return PersistedSession{}, false, nil

--- a/services/tuttid/service/agent/runtime_operation_plan_decision.go
+++ b/services/tuttid/service/agent/runtime_operation_plan_decision.go
@@ -172,6 +172,12 @@ func (s *Service) executePlanImplementationRuntimeOperation(
 ) (agentactivitybiz.RuntimeOperation, error) {
 	step := payloadText(operation.Payload, "step")
 	if step == "prepared" {
+		// Plan implementation continues the same provider conversation. Restore
+		// that runtime explicitly before applying the live plan-mode transition;
+		// generic historical settings updates intentionally remain persistence-only.
+		if _, err := s.ensureRuntimeSessionResult(ctx, operation.WorkspaceID, operation.AgentSessionID); err != nil {
+			return s.releaseRuntimeOperation(ctx, operation, owner, normalizeRuntimeError(err), !isRetryableRuntimeOperationError(err))
+		}
 		planMode := false
 		if _, err := s.UpdateSettings(ctx, operation.WorkspaceID, operation.AgentSessionID, ComposerSettingsPatch{PlanMode: &planMode}); err != nil {
 			return s.releaseRuntimeOperation(ctx, operation, owner, normalizeRuntimeError(err), !isRetryableRuntimeOperationError(err))

--- a/services/tuttid/service/agent/service_resume_helpers.go
+++ b/services/tuttid/service/agent/service_resume_helpers.go
@@ -24,6 +24,18 @@ func (s *Service) ensureRuntimeSessionResult(
 	workspaceID string,
 	agentSessionID string,
 ) (ensuredRuntimeSession, error) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	release := s.acquireSessionSettingsLock(workspaceID, agentSessionID)
+	defer release()
+	return s.ensureRuntimeSessionResultLocked(ctx, workspaceID, agentSessionID)
+}
+
+func (s *Service) ensureRuntimeSessionResultLocked(
+	ctx context.Context,
+	workspaceID string,
+	agentSessionID string,
+) (ensuredRuntimeSession, error) {
 	if session, ok := s.controller().Session(workspaceID, agentSessionID); ok {
 		if !externalImportResumeSupported(session.RuntimeContext) {
 			return ensuredRuntimeSession{}, ErrSessionNotFound

--- a/services/tuttid/service/agent/service_resume_helpers.go
+++ b/services/tuttid/service/agent/service_resume_helpers.go
@@ -26,7 +26,10 @@ func (s *Service) ensureRuntimeSessionResult(
 ) (ensuredRuntimeSession, error) {
 	workspaceID = strings.TrimSpace(workspaceID)
 	agentSessionID = strings.TrimSpace(agentSessionID)
-	release := s.acquireSessionSettingsLock(workspaceID, agentSessionID)
+	release, err := s.acquireSessionSettingsLock(ctx, workspaceID, agentSessionID)
+	if err != nil {
+		return ensuredRuntimeSession{}, err
+	}
 	defer release()
 	return s.ensureRuntimeSessionResultLocked(ctx, workspaceID, agentSessionID)
 }

--- a/services/tuttid/service/agent/service_session_settings_lock.go
+++ b/services/tuttid/service/agent/service_session_settings_lock.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"strings"
+	"sync"
+)
+
+type serviceSessionSettingsLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+// acquireSessionSettingsLock serializes runtime resume with durable settings
+// read-modify-write for one session. It intentionally does not span provider
+// turn execution or unrelated metadata mutations.
+func (s *Service) acquireSessionSettingsLock(workspaceID string, agentSessionID string) func() {
+	key := strings.TrimSpace(workspaceID) + "\x00" + strings.TrimSpace(agentSessionID)
+	s.sessionSettingsMu.Lock()
+	if s.sessionSettingsLocks == nil {
+		s.sessionSettingsLocks = make(map[string]*serviceSessionSettingsLock)
+	}
+	lock := s.sessionSettingsLocks[key]
+	if lock == nil {
+		lock = &serviceSessionSettingsLock{}
+		s.sessionSettingsLocks[key] = lock
+	}
+	lock.refs++
+	s.sessionSettingsMu.Unlock()
+
+	lock.mu.Lock()
+	return func() {
+		lock.mu.Unlock()
+		s.sessionSettingsMu.Lock()
+		lock.refs--
+		if lock.refs <= 0 && s.sessionSettingsLocks[key] == lock {
+			delete(s.sessionSettingsLocks, key)
+		}
+		s.sessionSettingsMu.Unlock()
+	}
+}

--- a/services/tuttid/service/agent/service_session_settings_lock.go
+++ b/services/tuttid/service/agent/service_session_settings_lock.go
@@ -1,19 +1,23 @@
 package agent
 
 import (
+	"context"
 	"strings"
-	"sync"
 )
 
 type serviceSessionSettingsLock struct {
-	mu   sync.Mutex
-	refs int
+	available chan struct{}
+	refs      int
 }
 
 // acquireSessionSettingsLock serializes runtime resume with durable settings
 // read-modify-write for one session. It intentionally does not span provider
 // turn execution or unrelated metadata mutations.
-func (s *Service) acquireSessionSettingsLock(workspaceID string, agentSessionID string) func() {
+func (s *Service) acquireSessionSettingsLock(
+	ctx context.Context,
+	workspaceID string,
+	agentSessionID string,
+) (func(), error) {
 	key := strings.TrimSpace(workspaceID) + "\x00" + strings.TrimSpace(agentSessionID)
 	s.sessionSettingsMu.Lock()
 	if s.sessionSettingsLocks == nil {
@@ -21,20 +25,35 @@ func (s *Service) acquireSessionSettingsLock(workspaceID string, agentSessionID 
 	}
 	lock := s.sessionSettingsLocks[key]
 	if lock == nil {
-		lock = &serviceSessionSettingsLock{}
+		lock = &serviceSessionSettingsLock{available: make(chan struct{}, 1)}
+		lock.available <- struct{}{}
 		s.sessionSettingsLocks[key] = lock
 	}
 	lock.refs++
 	s.sessionSettingsMu.Unlock()
 
-	lock.mu.Lock()
-	return func() {
-		lock.mu.Unlock()
-		s.sessionSettingsMu.Lock()
-		lock.refs--
-		if lock.refs <= 0 && s.sessionSettingsLocks[key] == lock {
-			delete(s.sessionSettingsLocks, key)
-		}
-		s.sessionSettingsMu.Unlock()
+	select {
+	case <-ctx.Done():
+		s.releaseSessionSettingsLockRef(key, lock)
+		return nil, ctx.Err()
+	case <-lock.available:
 	}
+	if err := ctx.Err(); err != nil {
+		lock.available <- struct{}{}
+		s.releaseSessionSettingsLockRef(key, lock)
+		return nil, err
+	}
+	return func() {
+		lock.available <- struct{}{}
+		s.releaseSessionSettingsLockRef(key, lock)
+	}, nil
+}
+
+func (s *Service) releaseSessionSettingsLockRef(key string, lock *serviceSessionSettingsLock) {
+	s.sessionSettingsMu.Lock()
+	lock.refs--
+	if lock.refs <= 0 && s.sessionSettingsLocks[key] == lock {
+		delete(s.sessionSettingsLocks, key)
+	}
+	s.sessionSettingsMu.Unlock()
 }

--- a/services/tuttid/service/agent/service_settings.go
+++ b/services/tuttid/service/agent/service_settings.go
@@ -68,7 +68,10 @@ func (s *Service) UpdateSettings(ctx context.Context, workspaceID string, agentS
 	if workspaceID == "" || agentSessionID == "" {
 		return Session{}, ErrInvalidArgument
 	}
-	release := s.acquireSessionSettingsLock(workspaceID, agentSessionID)
+	release, err := s.acquireSessionSettingsLock(ctx, workspaceID, agentSessionID)
+	if err != nil {
+		return Session{}, err
+	}
 	defer release()
 	if _, live := s.controller().Session(workspaceID, agentSessionID); !live {
 		return s.updatePersistedSessionSettings(ctx, workspaceID, agentSessionID, settings)

--- a/services/tuttid/service/agent/service_settings.go
+++ b/services/tuttid/service/agent/service_settings.go
@@ -63,7 +63,17 @@ func (s *Service) clampPersistedSessionReasoningEffortForResume(
 }
 
 func (s *Service) UpdateSettings(ctx context.Context, workspaceID string, agentSessionID string, settings ComposerSettingsPatch) (Session, error) {
-	ensured, err := s.ensureRuntimeSessionResult(ctx, workspaceID, agentSessionID)
+	workspaceID = strings.TrimSpace(workspaceID)
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	if workspaceID == "" || agentSessionID == "" {
+		return Session{}, ErrInvalidArgument
+	}
+	release := s.acquireSessionSettingsLock(workspaceID, agentSessionID)
+	defer release()
+	if _, live := s.controller().Session(workspaceID, agentSessionID); !live {
+		return s.updatePersistedSessionSettings(ctx, workspaceID, agentSessionID, settings)
+	}
+	ensured, err := s.ensureRuntimeSessionResultLocked(ctx, workspaceID, agentSessionID)
 	if err != nil {
 		return Session{}, err
 	}
@@ -111,4 +121,76 @@ func (s *Service) UpdateSettings(ctx context.Context, workspaceID string, agentS
 		return Session{}, err
 	}
 	return session, nil
+}
+
+func (s *Service) updatePersistedSessionSettings(
+	ctx context.Context,
+	workspaceID string,
+	agentSessionID string,
+	patch ComposerSettingsPatch,
+) (Session, error) {
+	if s.SessionReader == nil {
+		return Session{}, ErrSessionNotFound
+	}
+	persisted, ok := s.SessionReader.GetSession(workspaceID, agentSessionID)
+	if !ok {
+		return Session{}, ErrSessionNotFound
+	}
+	updater, ok := s.SessionReader.(SessionSettingsUpdater)
+	if !ok {
+		return Session{}, ErrSessionNotFound
+	}
+	settings := applyComposerSettingsPatch(persisted.Settings, patch)
+	settings = normalizeObservedComposerSettingsForProvider(persisted.Provider, settings)
+	if patch.Model != nil || patch.ReasoningEffort != nil {
+		settings.ReasoningEffort = s.clampReasoningEffortForModel(
+			ctx,
+			persisted.Provider,
+			settings.Model,
+			settings.ReasoningEffort,
+		)
+	}
+	updated, ok, err := updater.UpdateSessionSettings(
+		ctx,
+		workspaceID,
+		agentSessionID,
+		settings,
+	)
+	if err != nil {
+		return Session{}, err
+	}
+	if !ok {
+		return Session{}, ErrSessionNotFound
+	}
+	return s.withProtocolV2TurnState(ctx, workspaceID, sessionFromPersisted(
+		updated,
+		persistedSessionCanResume(s.controller(), updated),
+	))
+}
+
+func applyComposerSettingsPatch(settings ComposerSettings, patch ComposerSettingsPatch) ComposerSettings {
+	if patch.Model != nil {
+		settings.Model = strings.TrimSpace(*patch.Model)
+	}
+	if patch.PermissionModeID != nil {
+		settings.PermissionModeID = strings.TrimSpace(*patch.PermissionModeID)
+	}
+	if patch.PlanMode != nil {
+		settings.PlanMode = *patch.PlanMode
+	}
+	if patch.BrowserUse != nil {
+		value := *patch.BrowserUse
+		settings.BrowserUse = &value
+	}
+	if patch.ComputerUse != nil {
+		value := *patch.ComputerUse
+		settings.ComputerUse = &value
+	}
+	if patch.ReasoningEffort != nil {
+		settings.ReasoningEffort = strings.TrimSpace(*patch.ReasoningEffort)
+	}
+	if patch.Speed != nil {
+		settings.Speed = strings.TrimSpace(*patch.Speed)
+	}
+	return settings
 }

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -6143,6 +6143,10 @@ func (*activityProjectionRepoStub) UpdateSessionPinned(context.Context, string, 
 	return agentactivitybiz.Session{}, false, nil
 }
 
+func (*activityProjectionRepoStub) UpdateSessionSettings(context.Context, string, string, string, map[string]any) (agentactivitybiz.Session, bool, error) {
+	return agentactivitybiz.Session{}, false, nil
+}
+
 func (*activityProjectionRepoStub) UpdateSessionTitle(context.Context, string, string, string) (agentactivitybiz.Session, bool, error) {
 	return agentactivitybiz.Session{}, false, nil
 }

--- a/services/tuttid/service/agent/service_update_settings_test.go
+++ b/services/tuttid/service/agent/service_update_settings_test.go
@@ -1,0 +1,273 @@
+package agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestServiceUpdateSettingsPersistsHistoricalSessionWithoutRuntimeResume(t *testing.T) {
+	runtime := newFakeRuntime()
+	reader := &settingsUpdateSessionReader{
+		fakeSessionReader: &fakeSessionReader{sessions: map[string]PersistedSession{
+			"ws-1:session-1": {
+				ID:                "session-1",
+				WorkspaceID:       "ws-1",
+				AgentTargetID:     "local:claude-code",
+				Provider:          "claude-code",
+				ProviderSessionID: "provider-session-1",
+				Cwd:               "/workspace",
+				Settings:          ComposerSettings{Model: "default", PermissionModeID: "dontAsk"},
+				CreatedAtUnixMS:   100,
+				UpdatedAtUnixMS:   200,
+				LastEventUnixMS:   200,
+			},
+		}},
+		updatedAtUnixMS: 300,
+	}
+	service := newTestService(runtime)
+	service.SessionReader = reader
+	permissionModeID := "acceptEdits"
+
+	session, err := service.UpdateSettings(context.Background(), "ws-1", "session-1", ComposerSettingsPatch{
+		PermissionModeID: &permissionModeID,
+	})
+	if err != nil {
+		t.Fatalf("UpdateSettings returned error: %v", err)
+	}
+	if len(runtime.resumeCalls) != 0 {
+		t.Fatalf("UpdateSettings runtime resume calls = %d, want 0", len(runtime.resumeCalls))
+	}
+	if len(runtime.updateSettingsCalls) != 0 {
+		t.Fatalf("UpdateSettings live runtime calls = %d, want 0", len(runtime.updateSettingsCalls))
+	}
+	if reader.updateCalls != 1 {
+		t.Fatalf("UpdateSessionSettings calls = %d, want 1", reader.updateCalls)
+	}
+	if session.Settings == nil || session.Settings.PermissionModeID != "acceptEdits" {
+		t.Fatalf("UpdateSettings session settings = %#v, want acceptEdits", session.Settings)
+	}
+	if session.Settings.Model != "default" {
+		t.Fatalf("UpdateSettings model = %q, want preserved default", session.Settings.Model)
+	}
+	if session.UpdatedAt == nil || session.UpdatedAt.UnixMilli() != 300 {
+		t.Fatalf("UpdateSettings updatedAt = %v, want 300", session.UpdatedAt)
+	}
+}
+
+func TestServiceUpdateSettingsSerializesWithHistoricalResume(t *testing.T) {
+	baseRuntime := newFakeRuntime()
+	runtime := &blockingResumeRuntime{
+		fakeRuntime:       baseRuntime,
+		resumeEntered:     make(chan RuntimeResumeInput, 1),
+		resumeRelease:     make(chan struct{}),
+		liveUpdateEntered: make(chan RuntimeUpdateSettingsInput, 1),
+	}
+	reader := &settingsUpdateSessionReader{
+		fakeSessionReader: &fakeSessionReader{sessions: map[string]PersistedSession{
+			"ws-1:session-1": {
+				ID:                "session-1",
+				WorkspaceID:       "ws-1",
+				AgentTargetID:     "local:claude-code",
+				Provider:          "claude-code",
+				ProviderSessionID: "provider-session-1",
+				Cwd:               "/workspace",
+				Settings:          ComposerSettings{PermissionModeID: "dontAsk"},
+			},
+		}},
+		updatedAtUnixMS: 300,
+	}
+	service := newTestService(runtime)
+	service.SessionReader = reader
+	resumeDone := make(chan error, 1)
+	go func() {
+		_, err := service.ensureRuntimeSessionResult(context.Background(), "ws-1", "session-1")
+		resumeDone <- err
+	}()
+	resumeInput := <-runtime.resumeEntered
+	if resumeInput.Settings.PermissionModeID != "dontAsk" {
+		t.Fatalf("resume permission = %q, want dontAsk", resumeInput.Settings.PermissionModeID)
+	}
+
+	permissionModeID := "acceptEdits"
+	settingsStarted := make(chan struct{})
+	settingsDone := make(chan error, 1)
+	go func() {
+		close(settingsStarted)
+		_, err := service.UpdateSettings(context.Background(), "ws-1", "session-1", ComposerSettingsPatch{
+			PermissionModeID: &permissionModeID,
+		})
+		settingsDone <- err
+	}()
+	<-settingsStarted
+	select {
+	case input := <-runtime.liveUpdateEntered:
+		t.Fatalf("live settings update entered before resume completed: %#v", input)
+	case <-settingsDone:
+		t.Fatal("settings update completed before resume completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(runtime.resumeRelease)
+	if err := <-resumeDone; err != nil {
+		t.Fatalf("resume returned error: %v", err)
+	}
+	if err := <-settingsDone; err != nil {
+		t.Fatalf("UpdateSettings returned error: %v", err)
+	}
+	if reader.updateCalls != 0 {
+		t.Fatalf("durable historical updates = %d, want 0 after runtime became live", reader.updateCalls)
+	}
+	if len(baseRuntime.updateSettingsCalls) != 1 {
+		t.Fatalf("live runtime updates = %d, want 1", len(baseRuntime.updateSettingsCalls))
+	}
+	session, ok := baseRuntime.Session("ws-1", "session-1")
+	if !ok || session.Settings == nil || session.Settings.PermissionModeID != "acceptEdits" {
+		t.Fatalf("runtime session settings = %#v ok=%v, want acceptEdits", session.Settings, ok)
+	}
+}
+
+func TestServiceUpdateSettingsSerializesHistoricalPartialPatches(t *testing.T) {
+	reader := &serializedSettingsReader{
+		fakeSessionReader: &fakeSessionReader{sessions: map[string]PersistedSession{
+			"ws-1:session-1": {
+				ID:          "session-1",
+				WorkspaceID: "ws-1",
+				Provider:    "claude-code",
+				Settings:    ComposerSettings{PermissionModeID: "dontAsk", PlanMode: false},
+			},
+		}},
+		firstRead:   make(chan struct{}),
+		releaseRead: make(chan struct{}),
+		secondRead:  make(chan struct{}),
+	}
+	service := newIsolatedAgentService(newFakeRuntime())
+	service.SessionReader = reader
+	permissionModeID := "acceptEdits"
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := service.UpdateSettings(context.Background(), "ws-1", "session-1", ComposerSettingsPatch{
+			PermissionModeID: &permissionModeID,
+		})
+		firstDone <- err
+	}()
+	<-reader.firstRead
+
+	planMode := true
+	secondStarted := make(chan struct{})
+	secondDone := make(chan error, 1)
+	go func() {
+		close(secondStarted)
+		_, err := service.UpdateSettings(context.Background(), "ws-1", "session-1", ComposerSettingsPatch{
+			PlanMode: &planMode,
+		})
+		secondDone <- err
+	}()
+	<-secondStarted
+	select {
+	case <-reader.secondRead:
+		t.Fatal("second historical settings read overlapped the first mutation")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(reader.releaseRead)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first UpdateSettings returned error: %v", err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("second UpdateSettings returned error: %v", err)
+	}
+	final, ok := reader.GetSession("ws-1", "session-1")
+	if !ok || final.Settings.PermissionModeID != "acceptEdits" || !final.Settings.PlanMode {
+		t.Fatalf("final settings = %#v ok=%v, want both patches", final.Settings, ok)
+	}
+}
+
+type settingsUpdateSessionReader struct {
+	*fakeSessionReader
+	updateCalls     int
+	updatedAtUnixMS int64
+}
+
+type blockingResumeRuntime struct {
+	*fakeRuntime
+	resumeEntered     chan RuntimeResumeInput
+	resumeRelease     chan struct{}
+	liveUpdateEntered chan RuntimeUpdateSettingsInput
+}
+
+func (r *blockingResumeRuntime) Resume(ctx context.Context, input RuntimeResumeInput) (ProviderRuntimeSession, error) {
+	r.resumeEntered <- input
+	select {
+	case <-ctx.Done():
+		return ProviderRuntimeSession{}, ctx.Err()
+	case <-r.resumeRelease:
+		return r.fakeRuntime.Resume(ctx, input)
+	}
+}
+
+func (r *blockingResumeRuntime) UpdateSettings(ctx context.Context, input RuntimeUpdateSettingsInput) error {
+	r.liveUpdateEntered <- input
+	return r.fakeRuntime.UpdateSettings(ctx, input)
+}
+
+type serializedSettingsReader struct {
+	*fakeSessionReader
+	mu          sync.Mutex
+	readCalls   int
+	firstRead   chan struct{}
+	releaseRead chan struct{}
+	secondRead  chan struct{}
+}
+
+func (r *serializedSettingsReader) GetSession(workspaceID string, agentSessionID string) (PersistedSession, bool) {
+	r.mu.Lock()
+	r.readCalls++
+	call := r.readCalls
+	session, ok := r.sessions[workspaceID+":"+agentSessionID]
+	r.mu.Unlock()
+	switch call {
+	case 1:
+		close(r.firstRead)
+		<-r.releaseRead
+	case 2:
+		close(r.secondRead)
+	}
+	return session, ok
+}
+
+func (r *serializedSettingsReader) UpdateSessionSettings(
+	_ context.Context,
+	workspaceID string,
+	agentSessionID string,
+	settings ComposerSettings,
+) (PersistedSession, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := workspaceID + ":" + agentSessionID
+	session, ok := r.sessions[key]
+	if !ok {
+		return PersistedSession{}, false, nil
+	}
+	session.Settings = settings
+	r.sessions[key] = session
+	return session, true, nil
+}
+
+func (r *settingsUpdateSessionReader) UpdateSessionSettings(
+	_ context.Context,
+	workspaceID string,
+	agentSessionID string,
+	settings ComposerSettings,
+) (PersistedSession, bool, error) {
+	key := workspaceID + ":" + agentSessionID
+	session, ok := r.sessions[key]
+	if !ok {
+		return PersistedSession{}, false, nil
+	}
+	r.updateCalls++
+	session.Settings = settings
+	session.UpdatedAtUnixMS = r.updatedAtUnixMS
+	r.sessions[key] = session
+	return session, true, nil
+}

--- a/services/tuttid/service/agent/service_update_settings_test.go
+++ b/services/tuttid/service/agent/service_update_settings_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -125,6 +126,84 @@ func TestServiceUpdateSettingsSerializesWithHistoricalResume(t *testing.T) {
 	session, ok := baseRuntime.Session("ws-1", "session-1")
 	if !ok || session.Settings == nil || session.Settings.PermissionModeID != "acceptEdits" {
 		t.Fatalf("runtime session settings = %#v ok=%v, want acceptEdits", session.Settings, ok)
+	}
+}
+
+func TestServiceUpdateSettingsStopsWaitingWhenContextIsCanceled(t *testing.T) {
+	baseRuntime := newFakeRuntime()
+	runtime := &blockingResumeRuntime{
+		fakeRuntime:       baseRuntime,
+		resumeEntered:     make(chan RuntimeResumeInput, 1),
+		resumeRelease:     make(chan struct{}),
+		liveUpdateEntered: make(chan RuntimeUpdateSettingsInput, 1),
+	}
+	reader := &settingsUpdateSessionReader{
+		fakeSessionReader: &fakeSessionReader{sessions: map[string]PersistedSession{
+			"ws-1:session-1": {
+				ID:                "session-1",
+				WorkspaceID:       "ws-1",
+				AgentTargetID:     "local:claude-code",
+				Provider:          "claude-code",
+				ProviderSessionID: "provider-session-1",
+				Cwd:               "/workspace",
+				Settings:          ComposerSettings{PermissionModeID: "dontAsk"},
+			},
+		}},
+	}
+	service := newTestService(runtime)
+	service.SessionReader = reader
+	resumeDone := make(chan error, 1)
+	go func() {
+		_, err := service.ensureRuntimeSessionResult(context.Background(), "ws-1", "session-1")
+		resumeDone <- err
+	}()
+	select {
+	case <-runtime.resumeEntered:
+	case <-time.After(time.Second):
+		t.Fatal("resume did not acquire the session settings lock")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	settingsDone := make(chan error, 1)
+	permissionModeID := "acceptEdits"
+	go func() {
+		_, err := service.UpdateSettings(ctx, "ws-1", "session-1", ComposerSettingsPatch{
+			PermissionModeID: &permissionModeID,
+		})
+		settingsDone <- err
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		service.sessionSettingsMu.Lock()
+		refs := service.sessionSettingsLocks["ws-1\x00session-1"].refs
+		service.sessionSettingsMu.Unlock()
+		if refs == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("settings update did not begin waiting for the session settings lock")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	cancel()
+	select {
+	case err := <-settingsDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("UpdateSettings error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled settings update remained blocked on the session settings lock")
+	}
+
+	close(runtime.resumeRelease)
+	if err := <-resumeDone; err != nil {
+		t.Fatalf("resume returned error: %v", err)
+	}
+	service.sessionSettingsMu.Lock()
+	remainingLocks := len(service.sessionSettingsLocks)
+	service.sessionSettingsMu.Unlock()
+	if remainingLocks != 0 {
+		t.Fatalf("session settings locks = %d, want 0", remainingLocks)
 	}
 }
 

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -52,6 +52,8 @@ type Service struct {
 	liveModelInvalidatedAtUnixMS   map[string]int64
 	liveModelDiscoverySessions     map[string]liveModelDiscoverySessionRef
 	liveModelDiscoveryGroup        singleflight.Group
+	sessionSettingsMu              sync.Mutex
+	sessionSettingsLocks           map[string]*serviceSessionSettingsLock
 	// liveModelPersistedScanMissAtUnixMS memoizes, per live-model cache key,
 	// when the persisted-session fallback scan last found nothing, so the
 	// full session scan is not repeated on every composer-options fetch.
@@ -316,6 +318,10 @@ type SessionDeleter interface {
 
 type SessionPinUpdater interface {
 	UpdateSessionPinned(context.Context, string, string, bool) (PersistedSession, bool, error)
+}
+
+type SessionSettingsUpdater interface {
+	UpdateSessionSettings(context.Context, string, string, ComposerSettings) (PersistedSession, bool, error)
 }
 
 type SessionTitleUpdater interface {


### PR DESCRIPTION
## Summary

- Persist settings changes for inactive historical AgentGUI sessions without resuming the provider runtime or starting a sidecar
- Emit one settings intent per permission selection, and treat a new user selection as an explicit retry after an unknown timeout result
- Keep active-session settings separate from target defaults
- Serialize historical settings read-modify-write with runtime resume per session, preventing stale resumes and lost concurrent partial patches
- Preserve plan-implementation behavior by making its required runtime resume explicit
- Document the settings ownership/data flow and the recurring troubleshooting pattern

## Verification

- `pnpm check:full` — 18 tasks passed
- `pnpm check:changed --tail-lines 50` — 14 lanes passed after rebase
- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 --reporter=dot` — 165 files / 1568 tests passed
- `pnpm --filter @tutti-os/agent-activity-core test` — 175 tests passed
- `cd services/tuttid && go test ./... -count=1 && go build ./...`
- `go test -race ./service/agent -run 'TestServiceUpdateSettingsSerializes|TestServiceUpdateSettingsPersistsHistorical|TestPlanDecisionRecoveryResumes' -count=1`
- `pnpm lint:ts`, `pnpm typecheck`, `pnpm lint:go`
- Agent activity runtime boundary, provider strategy boundary, and AgentGUI degradation checks
- Three independent architecture/performance review rounds; final round reported no current-diff findings and no performance findings

## Fix Scope Justification

- Root cause: one permission selection fired both an item pointer handler and Radix Select value change; a timed-out settings command left engine state `unknown` but later explicit selections omitted retry intent; inactive-session updates also resumed Claude just to mutate durable settings, causing the observed timeout and silent later drops
- Why can this not be fixed at a lower layer? Each correction is placed at its actual owner: the menu owns event deduplication, the workspace engine owns uncertain operation state, and `tuttid` owns durable session settings and runtime liveness. A single lower-layer workaround would leave at least one incorrect owner or retain hidden provider startup

## Fallback Three Questions

- Source: the retry flag represents an engine-owned `unknown` result after the settings command exceeds its response deadline
- Why can it not be fixed at that source? A timeout cannot prove whether the daemon accepted the mutation; automatically resending could duplicate an already-applied command. A new user selection is the explicit retry decision
- Removal condition: remove this retry path when settings updates have an authoritative idempotent acknowledgment/reconciliation contract that eliminates unknown outcomes

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist settings changes for historical AgentGUI sessions without waking the provider runtime or sidecar, fixing timeouts and dropped updates. Also send one settings event per selection and treat the next selection after a timeout as an explicit retry that merges unresolved and queued patches.

- **Bug Fixes**
  - Historical sessions: write settings to the durable activity projection and publish reconcile; no provider resume/sidecar.
  - Permission menu: emit one settings change per selection (remove pointer-down path); do not copy active-session settings into target defaults.
  - Timeouts: when the last update is `unknown`, mark the next selection as an explicit retry; engine merges the unresolved patch, any queued patch, and the latest selection so the newest wins; resends are blocked until retry.
  - Serialization: per-session lock serializes runtime resume with durable settings writes, avoiding stale resumes, lost partial patches, and blocked cancelations; plan implementation explicitly resumes before live updates.
  - Tests and docs: add unit tests across GUI, `@tutti-os/agent-activity-core`, store, and service; update troubleshooting and architecture docs.

<sup>Written for commit de3939a59625720028c6fa0144ee2595725115e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

