### PR TITLE
feat(agent-gui): expose provenance filter catalog

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2935,7 +2935,13 @@ running, or read-only tool calls must be ignored even when their payloads carry
 The desktop product may enable Agent provenance filtering through the
 default-off `agent.referenceProvenanceFilter` developer feature flag. The flag
 is projected into AgentGUI as a host capability; AgentGUI does not read desktop
-preferences directly. Preview mode keeps the capability disabled.
+preferences directly. Preview mode keeps the capability disabled. Public
+AgentGUI hosts may instead opt in with
+`hostCapabilities.referenceProvenanceFilterCatalog`, which carries the full
+host-owned `enabledDimensions`, `agentOptions`, and `memberOptions` catalog. An
+explicit catalog takes precedence over the legacy boolean switch. With neither
+property, filtering remains disabled; the legacy switch continues to derive an
+Agent-only catalog and never enables members.
 
 AgentGUI creates one controlled provenance controller for both the composer
 `@` palette and the `+` reference picker. The desktop host injects the current
@@ -2950,9 +2956,12 @@ generated-file provider for an active Agent constraint, then apply file type
 filters and the result limit. This provenance constraint does not imply a file
 path constraint, so picker location ids must not be mapped to session working
 directories. Ordinary opened-file and issue-summary records do not currently
-carry durable Agent provenance and therefore fail closed when an Agent
-constraint is active. Existing result groups remain unchanged; the filter
-narrows their contents and does not introduce a second grouping layer.
+carry durable provenance and therefore fail closed when either an Agent or
+Member constraint is active. A typed File query must route to the
+provenance-aware generated-file provider for either active dimension, even when
+the ordinary generated-files group is otherwise disabled. Existing result
+groups remain unchanged; the filter narrows their contents and does not
+introduce a second grouping layer.
 
 Only catalog entries with a durable `agentTargetId` participate in filtering;
 host target ids are not substitutes. Catalogs and filters are normalized at the
@@ -2969,7 +2978,9 @@ window's click-capture guard otherwise treats the option click as a draggable
 window interaction and stops it before the filter row receives the event.
 
 The shared contracts reserve a separate member dimension for collaboration
-hosts. Tutti personal edition must not enable member or group-chat filtering.
+hosts. Collaboration hosts own Member option identity and the providers that
+enforce `memberIds` before pagination. Tutti personal edition must not inject
+that dimension and must not enable member or group-chat filtering.
 
 ### Approval Or Ask-User Prompt
 

--- a/docs/architecture/agent-reference-sources.md
+++ b/docs/architecture/agent-reference-sources.md
@@ -95,6 +95,13 @@ actual filtering. An active filter is part of the query and cache identity and
 must be applied before pagination. Picker result grouping remains source-owned;
 the filter option list itself is flat.
 
+AgentGUI exposes that host boundary as the optional complete
+`referenceProvenanceFilterCatalog` capability. Omitting it keeps the public
+surface disabled by default. Tutti's legacy boolean capability remains an
+Agent-only adapter over the current Agent directory and does not synthesize
+Member options; collaboration hosts explicitly inject both their enabled
+dimensions and catalogs.
+
 Catalog option identity is host-owned and normalized at the shared-package
 boundary. Agent options require a durable `agentTargetId`; product-local target
 ids are not provenance fallbacks. Filter cache keys use a collision-free

--- a/packages/agent/gui/AgentGUI.tsx
+++ b/packages/agent/gui/AgentGUI.tsx
@@ -21,6 +21,7 @@ import { AgentActivityHostProvider } from "./agentActivityHost";
 import { AgentGuiI18nProvider, type AgentGuiI18nLocale } from "./i18n/index";
 
 export type { AgentGUIHomeSuggestionId } from "./types";
+export type { ReferenceProvenanceCatalog as AgentGUIReferenceProvenanceFilterCatalog } from "@tutti-os/workspace-file-reference/contracts";
 
 type AgentGUIPublicHostCapabilities = Omit<
   AgentGUINodeProps["hostCapabilities"],

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -98,6 +98,37 @@ pnpm check:agent-activity-runtime-boundaries
 `hostCapabilities`, `hostActions`, and `renderSlots`. Extend the owning object;
 do not restore flat compatibility props.
 
+## Reference Provenance Filtering
+
+Reference provenance filtering is disabled by default. Collaboration hosts can
+opt in by injecting the complete catalog through
+`hostCapabilities.referenceProvenanceFilterCatalog`:
+
+```tsx
+<AgentGUI
+  {...props}
+  hostCapabilities={{
+    referenceProvenanceFilterCatalog: {
+      enabledDimensions: ["agent", "member"],
+      agentOptions: [{ id: "agent-1", label: "Agent 1" }],
+      memberOptions: [{ id: "member-1", label: "Member 1" }]
+    }
+  }}
+/>
+```
+
+The catalog is host-owned: option IDs must be durable identities understood by
+the host's injected reference/search providers. Active dimensions are passed
+to those providers as query metadata and must be enforced before pagination.
+Sources that cannot enforce an active dimension must fail closed instead of
+returning unfiltered results.
+
+`referenceProvenanceFilterEnabled` remains as the legacy Tutti personal-edition
+switch. When enabled without an explicit catalog, AgentGUI derives only the
+Agent options from the Agent directory and keeps `memberOptions` empty. Omitting
+both properties keeps the filter off. An explicitly supplied catalog (including
+`null`) takes precedence over the legacy switch.
+
 ## Home Suggestions
 
 The five starter entries below the empty new-session composer are enabled by

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -2,7 +2,10 @@ import { memo, useCallback, useEffect, useMemo } from "react";
 import { createWorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-project/i18n";
 import { createWorkspaceFileManagerI18nRuntime } from "@tutti-os/workspace-file-manager";
 import { useReferenceProvenanceFilterCatalog } from "@tutti-os/workspace-file-reference/react";
-import type { WorkspaceFileReference } from "@tutti-os/workspace-file-reference/contracts";
+import type {
+  ReferenceProvenanceCatalog,
+  WorkspaceFileReference
+} from "@tutti-os/workspace-file-reference/contracts";
 import { useTranslation } from "../../i18n/index";
 import type { AgentProvider } from "../../contexts/settings/domain/agentSettings";
 import type { WorkspaceLinkAction } from "../../actions/workspaceLinkActions";
@@ -33,6 +36,7 @@ import {
   resolveAgentGUIConversationRailMaxWidthPx,
   shouldAutoCollapseAgentGUIConversationRail
 } from "./model/agentGuiRailLayout";
+import { resolveAgentGUIReferenceProvenanceFilterCatalog } from "./model/agentReferenceProvenanceCatalog";
 import type { AgentGUINodeProps } from "./AgentGUINode.types";
 import { areAgentGUINodePropsEqual } from "./AgentGUINode.types";
 import {
@@ -47,6 +51,11 @@ import {
 export type { AgentGUINodeProps } from "./AgentGUINode.types";
 
 const EMPTY_SLASH_STATUS_QUOTAS = [] as const;
+const DISABLED_REFERENCE_PROVENANCE_CATALOG: ReferenceProvenanceCatalog = {
+  enabledDimensions: [],
+  agentOptions: [],
+  memberOptions: []
+};
 
 export const AgentGUINode = memo(function AgentGUINode({
   identity,
@@ -112,30 +121,23 @@ export const AgentGUINode = memo(function AgentGUINode({
     contextMentionProviders,
     workspaceAppIcons,
     disabledHomeSuggestions,
+    referenceProvenanceFilterCatalog: injectedReferenceProvenanceFilterCatalog,
     referenceProvenanceFilterEnabled = false
   } = hostCapabilities;
-  const referenceProvenanceFilterBinding = useReferenceProvenanceFilterCatalog({
-    enabledDimensions: referenceProvenanceFilterEnabled ? ["agent"] : [],
-    agentOptions: referenceProvenanceFilterEnabled
-      ? (agentTargets ?? []).flatMap((target) => {
-          const agentTargetId = target.agentTargetId?.trim();
-          return agentTargetId
-            ? [
-                {
-                  disabled: target.disabled,
-                  iconUrl: target.iconUrl,
-                  id: agentTargetId,
-                  label: target.label
-                }
-              ]
-            : [];
-        })
-      : [],
-    memberOptions: []
-  });
-  const referenceProvenanceFilter = referenceProvenanceFilterEnabled
-    ? referenceProvenanceFilterBinding
-    : null;
+  const referenceProvenanceFilterCatalog =
+    resolveAgentGUIReferenceProvenanceFilterCatalog({
+      agentTargets,
+      injectedCatalog: injectedReferenceProvenanceFilterCatalog,
+      legacyAgentFilterEnabled: referenceProvenanceFilterEnabled
+    });
+  const referenceProvenanceFilterBinding = useReferenceProvenanceFilterCatalog(
+    referenceProvenanceFilterCatalog ?? DISABLED_REFERENCE_PROVENANCE_CATALOG
+  );
+  const referenceProvenanceFilter =
+    referenceProvenanceFilterBinding.snapshot.catalog.enabledDimensions.length >
+    0
+      ? referenceProvenanceFilterBinding
+      : null;
   const {
     onLinkAction,
     onHandoffConversation,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
@@ -2,7 +2,8 @@ import type { ReactNode } from "react";
 import type { WorkspaceFileEntry } from "@tutti-os/workspace-file-manager/services";
 import type {
   WorkspaceFileReferenceAdapter,
-  WorkspaceFileReference
+  WorkspaceFileReference,
+  ReferenceProvenanceCatalog
 } from "@tutti-os/workspace-file-reference/contracts";
 import type { ReferenceSourceAggregator } from "@tutti-os/workspace-file-reference/core";
 import type { AgentSettings } from "../../contexts/settings/domain/agentSettings";
@@ -105,6 +106,14 @@ export interface AgentGUINodeRuntimeRequests {
 }
 
 export interface AgentGUINodeHostCapabilities {
+  /**
+   * Complete host-owned catalog for reference provenance filtering. Supplying
+   * it explicitly opts the host into the dimensions declared by the catalog.
+   * Omit it to keep filtering disabled unless the legacy Agent-only flag is
+   * enabled.
+   */
+  referenceProvenanceFilterCatalog?: ReferenceProvenanceCatalog | null;
+  /** Legacy Tutti Agent-only opt-in. Prefer an explicit catalog in new hosts. */
   referenceProvenanceFilterEnabled?: boolean;
   capabilityMenuState?: AgentComposerCapabilityMenuState;
   accountMenuState?: AgentGUIAccountMenuState | null;
@@ -289,6 +298,8 @@ export function areAgentGUINodePropsEqual(
     pw.onFileReferencesAdded === nw.onFileReferencesAdded &&
     pw.agentSettings.avoidGroupingEdits ===
       nw.agentSettings.avoidGroupingEdits &&
+    pc.referenceProvenanceFilterCatalog ===
+      nc.referenceProvenanceFilterCatalog &&
     pc.referenceProvenanceFilterEnabled ===
       nc.referenceProvenanceFilterEnabled &&
     agentGuiStateEquals(previous.state, next.state) &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchIndex.test.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchIndex.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { AGENT_CONTEXT_MENTION_PROVIDER_IDS } from "./agentContextMentionProvider";
+import {
+  fetchAgentMentionFilterResult,
+  type AgentMentionProviderQueryInput
+} from "./AgentMentionSearchIndex";
+
+describe("fetchAgentMentionFilterResult provenance filtering", () => {
+  it("queries only the provenance-aware file provider for a member-only constraint", async () => {
+    const queryProviderMentionItemsById = vi.fn(
+      async (input: AgentMentionProviderQueryInput) =>
+        input.providerId ===
+        AGENT_CONTEXT_MENTION_PROVIDER_IDS.agentGeneratedFile
+          ? [
+              {
+                directoryPath: "/workspace",
+                entryKind: "file" as const,
+                href: "/workspace/report.md",
+                kind: "file" as const,
+                name: "report.md",
+                path: "/workspace/report.md"
+              }
+            ]
+          : [
+              {
+                directoryPath: "/workspace",
+                entryKind: "file" as const,
+                href: "/workspace/unfiltered.md",
+                kind: "file" as const,
+                name: "unfiltered.md",
+                path: "/workspace/unfiltered.md"
+              }
+            ]
+    );
+
+    const result = await fetchAgentMentionFilterResult({
+      workspaceId: "workspace-1",
+      currentUserId: "user-1",
+      query: "report",
+      filter: "file",
+      sessionCwd: "/workspace",
+      includeAgentGeneratedFiles: false,
+      fileLimit: 30,
+      currentFileSearchLimit: 30,
+      currentIssueSearchLimit: 30,
+      provenanceFilter: {
+        agentTargetIds: null,
+        memberIds: ["member-1"]
+      },
+      queryProviderMentionItemsById
+    });
+
+    expect(queryProviderMentionItemsById).toHaveBeenCalledTimes(1);
+    expect(queryProviderMentionItemsById).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: AGENT_CONTEXT_MENTION_PROVIDER_IDS.agentGeneratedFile,
+        provenanceFilter: {
+          agentTargetIds: null,
+          memberIds: ["member-1"]
+        }
+      })
+    );
+    expect(result.rawGroups.opened_files).toEqual([]);
+    expect(result.rawGroups.agent_generated_files).toEqual([
+      expect.objectContaining({ path: "/workspace/report.md" })
+    ]);
+  });
+
+  it("fails closed for issue summaries under a member-only constraint", async () => {
+    const queryProviderMentionItemsById = vi.fn();
+
+    const result = await fetchAgentMentionFilterResult({
+      workspaceId: "workspace-1",
+      currentUserId: "user-1",
+      query: "task",
+      filter: "issue",
+      sessionCwd: "/workspace",
+      includeAgentGeneratedFiles: false,
+      fileLimit: 30,
+      currentFileSearchLimit: 30,
+      currentIssueSearchLimit: 30,
+      provenanceFilter: {
+        agentTargetIds: null,
+        memberIds: ["member-1"]
+      },
+      queryProviderMentionItemsById
+    });
+
+    expect(queryProviderMentionItemsById).not.toHaveBeenCalled();
+    expect(result.rawGroups.issues).toEqual([]);
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchIndex.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchIndex.ts
@@ -20,6 +20,7 @@ import {
 } from "./AgentMentionSearchContracts";
 import type { AgentMentionBrowseFetchResult } from "./AgentMentionSearchCache";
 import type { ReferenceProvenanceFilter } from "@tutti-os/workspace-file-reference/contracts";
+import { referenceProvenanceFilterIsActive } from "@tutti-os/workspace-file-reference/core";
 
 export interface AgentMentionProviderQueryInput {
   diagnostics: AgentMentionProviderQueryDiagnostic[];
@@ -48,14 +49,14 @@ export async function fetchAgentMentionFilterResult(input: {
   ) => Promise<AgentContextMentionItem[]>;
 }): Promise<AgentMentionBrowseFetchResult> {
   const providerDiagnostics: AgentMentionProviderQueryDiagnostic[] = [];
-  const agentFilterActive =
-    input.provenanceFilter !== null &&
-    input.provenanceFilter.agentTargetIds !== null;
+  const provenanceFilterActive = referenceProvenanceFilterIsActive(
+    input.provenanceFilter
+  );
   switch (input.filter) {
     case "file": {
-      // Opened/local files have no Agent provenance. Never silently return
-      // them while the UI says an Agent filter is active.
-      const fileQuery = agentFilterActive
+      // Opened/local files have no durable provenance. Never silently return
+      // them while the UI says any provenance filter is active.
+      const fileQuery = provenanceFilterActive
         ? Promise.resolve([] as AgentContextMentionItem[])
         : input.queryProviderMentionItemsById({
             providerId: FILE_PROVIDER_ID,
@@ -68,7 +69,7 @@ export async function fetchAgentMentionFilterResult(input: {
             provenanceFilter: input.provenanceFilter
           });
       const agentGeneratedFileQuery =
-        input.includeAgentGeneratedFiles || agentFilterActive
+        input.includeAgentGeneratedFiles || provenanceFilterActive
           ? input.queryProviderMentionItemsById({
               providerId: AGENT_GENERATED_FILE_PROVIDER_ID,
               workspaceId: input.workspaceId,
@@ -118,9 +119,9 @@ export async function fetchAgentMentionFilterResult(input: {
       };
     }
     case "issue": {
-      // Issue summaries do not yet carry durable Agent provenance. Fail closed
+      // Issue summaries do not yet carry durable provenance. Fail closed
       // rather than displaying unfiltered issues under an active filter.
-      const issueItems = agentFilterActive
+      const issueItems = provenanceFilterActive
         ? []
         : await input.queryProviderMentionItemsById({
             providerId: WORKSPACE_ISSUE_PROVIDER_ID,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentReferenceProvenanceCatalog.test.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentReferenceProvenanceCatalog.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { ReferenceProvenanceCatalog } from "@tutti-os/workspace-file-reference/contracts";
+import { resolveAgentGUIReferenceProvenanceFilterCatalog } from "./agentReferenceProvenanceCatalog";
+
+const AGENT_TARGET = {
+  agentTargetId: " local:codex ",
+  label: "Codex",
+  provider: "codex" as const
+} as const;
+
+describe("resolveAgentGUIReferenceProvenanceFilterCatalog", () => {
+  it("keeps provenance filtering disabled by default", () => {
+    expect(
+      resolveAgentGUIReferenceProvenanceFilterCatalog({
+        agentTargets: [AGENT_TARGET],
+        injectedCatalog: undefined,
+        legacyAgentFilterEnabled: false
+      })
+    ).toBeNull();
+  });
+
+  it("preserves the legacy Agent-only catalog without enabling members", () => {
+    expect(
+      resolveAgentGUIReferenceProvenanceFilterCatalog({
+        agentTargets: [AGENT_TARGET],
+        injectedCatalog: undefined,
+        legacyAgentFilterEnabled: true
+      })
+    ).toEqual({
+      enabledDimensions: ["agent"],
+      agentOptions: [
+        {
+          disabled: undefined,
+          iconUrl: undefined,
+          id: "local:codex",
+          label: "Codex"
+        }
+      ],
+      memberOptions: []
+    });
+  });
+
+  it("uses the complete host catalog when one is explicitly injected", () => {
+    const catalog: ReferenceProvenanceCatalog = {
+      enabledDimensions: ["agent", "member"],
+      agentOptions: [{ id: "shared:codex", label: "Shared Codex" }],
+      memberOptions: [{ id: "member-1", label: "Ada" }]
+    };
+
+    expect(
+      resolveAgentGUIReferenceProvenanceFilterCatalog({
+        agentTargets: [AGENT_TARGET],
+        injectedCatalog: catalog,
+        legacyAgentFilterEnabled: false
+      })
+    ).toBe(catalog);
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentReferenceProvenanceCatalog.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentReferenceProvenanceCatalog.ts
@@ -1,0 +1,38 @@
+import type { ReferenceProvenanceCatalog } from "@tutti-os/workspace-file-reference/contracts";
+import type { AgentGUIAgentTarget } from "../../../types";
+
+export function resolveAgentGUIReferenceProvenanceFilterCatalog(input: {
+  agentTargets:
+    | readonly Pick<
+        AgentGUIAgentTarget,
+        "agentTargetId" | "disabled" | "iconUrl" | "label"
+      >[]
+    | null
+    | undefined;
+  injectedCatalog: ReferenceProvenanceCatalog | null | undefined;
+  legacyAgentFilterEnabled: boolean;
+}): ReferenceProvenanceCatalog | null {
+  if (input.injectedCatalog !== undefined) {
+    return input.injectedCatalog;
+  }
+  if (!input.legacyAgentFilterEnabled) {
+    return null;
+  }
+  return {
+    enabledDimensions: ["agent"],
+    agentOptions: (input.agentTargets ?? []).flatMap((target) => {
+      const agentTargetId = target.agentTargetId?.trim();
+      return agentTargetId
+        ? [
+            {
+              disabled: target.disabled,
+              iconUrl: target.iconUrl,
+              id: agentTargetId,
+              label: target.label
+            }
+          ]
+        : [];
+    }),
+    memberOptions: []
+  };
+}

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -12,7 +12,10 @@ export {
   AGENT_PASTED_TEXT_MENTION_KIND
 } from "./shared/pastedTextKinds";
 export { AgentGUI } from "./AgentGUI";
-export type { AgentGUIProps } from "./AgentGUI";
+export type {
+  AgentGUIProps,
+  AgentGUIReferenceProvenanceFilterCatalog
+} from "./AgentGUI";
 export type { AgentGUIComposerAppendRequest } from "./agent-gui/agentGuiNode/controller/useAgentGUIComposerAppendRequest";
 export type { AgentComposerDraftFile } from "./agent-gui/agentGuiNode/model/agentGuiNodeTypes";
 export type { AgentGUIAccountMenuState } from "./agent-gui/agentGuiNode/accountMenuState";


### PR DESCRIPTION
## Summary

- expose an optional host-owned `referenceProvenanceFilterCatalog` through the public AgentGUI contract
- preserve the existing default-off behavior and the legacy Agent-only boolean path with empty member options
- make member-only provenance constraints use provenance-aware file queries and fail closed for unfilterable issue summaries
- document the public host contract and durable AgentGUI/reference-source architecture

## Verification

- `pnpm --filter @tutti-os/agent-gui test` (168 files, 1581 tests)
- `pnpm lint:ts`
- `pnpm typecheck`
- `pnpm check:ui-boundaries`
- `pnpm check:changed --tail-lines 80`
- `pnpm release:pack:check`
- `pnpm check:full`

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] README/CONTRIBUTING language variants are not applicable; only the package-local README changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose an optional host-owned provenance filter catalog in AgentGUI to enable Agent and Member filtering while staying default-off and preserving the legacy Agent-only flag. Provenance-constrained queries now use provenance-aware providers and fail closed for sources without durable provenance.

- **New Features**
  - Added `hostCapabilities.referenceProvenanceFilterCatalog` with full catalog (`enabledDimensions`, `agentOptions`, `memberOptions`); explicit catalogs take precedence over `referenceProvenanceFilterEnabled` (including `null` to disable).
  - Kept legacy path: when only `referenceProvenanceFilterEnabled` is true, derive an Agent-only catalog from agent targets; `memberOptions` remain empty.
  - Query behavior: with any active filter, file mentions skip opened files and query only the generated-file provider; issue summaries return empty. Uses `referenceProvenanceFilterIsActive` from `@tutti-os/workspace-file-reference/core`.
  - API/docs: exported `AgentGUIReferenceProvenanceFilterCatalog`, added `resolveAgentGUIReferenceProvenanceFilterCatalog`, updated README and architecture docs, and added tests for catalog resolution and provenance-aware search routing (including member-only constraints).

<sup>Written for commit 774566ae7f0caa4f74c9ba1ba3413fb88af534af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

