### PR TITLE
fix(agent-gui): align slash mention fields

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -4241,7 +4241,7 @@ aside.workspace-agents-status-panel
   .tsh-agent-object-token__main {
   padding: 0 6px;
   border-radius: 6px;
-  background: var(--tutti-purple-bg);
+  background: transparent;
 }
 
 [data-agent-mention-kind="skill"].tsh-agent-object-token--entity.ProseMirror-selectednode
@@ -4340,7 +4340,7 @@ aside.workspace-agents-status-panel
   border-radius: 4px;
   font-size: 13px;
   line-height: 24px;
-  transform: translateY(1px);
+  transform: translateY(-2px);
 }
 
 .agent-gui-node__composer-textarea

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -1894,6 +1894,20 @@ describe("agent GUI workbench contribution copy", () => {
     );
   });
 
+  it("keeps slash mention fields aligned and transparent by default", () => {
+    const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
+
+    expect(css).toMatch(
+      /\[data-agent-mention-kind="skill"\]\.tsh-agent-object-token--entity\s+\.tsh-agent-object-token__main,\s*\[data-agent-mention-kind="capability"\]\.tsh-agent-object-token--entity\s+\.tsh-agent-object-token__main\s*{[^}]*background:\s*transparent;/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer-textarea\s+\[data-agent-mention-kind="skill"\]\.tsh-agent-object-token--entity\s+\.tsh-agent-object-token__main,\s*\.agent-gui-node__composer-textarea\s+\[data-agent-mention-kind="capability"\]\.tsh-agent-object-token--entity\s+\.tsh-agent-object-token__main\s*{[^}]*transform:\s*translateY\(-2px\);/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer-textarea\s+\[data-agent-file-mention="true"\]\.tsh-agent-object-token:hover\s*{[^}]*background:\s*color-mix\(in srgb, currentColor 16%, transparent\);/s
+    );
+  });
+
   it("keeps interactive feedback scrolling above the send button", () => {
     const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
 


### PR DESCRIPTION
## Summary

- keep slash skill and capability mention fields transparent by default
- preserve hover and selected-state feedback
- move slash mention content upward to align with `@` mention fields
- add a focused CSS regression check for default, hover, and vertical alignment states

## Root cause

Slash mention tokens had a provider-specific purple background in their default state and an extra positive vertical translation, which made them appear lower than neighboring text and `@` mentions.

## Impact

Slash mention fields now align consistently with other composer mentions while retaining immediate hover feedback.

## Validation

- `pnpm --dir packages/agent/gui exec vitest run --environment jsdom --maxWorkers=3 workbench/contribution.test.ts` — 51 tests passed
- pre-push `pnpm check:full` — 18 tasks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns slash skill and capability mentions with @ mentions by removing the default purple background and fixing their vertical offset. Keeps hover/selected feedback and adds a regression test to prevent CSS regressions.

- **Bug Fixes**
  - Set default background of slash tokens to transparent in `agentactivity.css`.
  - Adjusted composer offset to `translateY(-2px)` for proper alignment.
  - Added a regression test in `workbench/contribution.test.ts` to assert transparency, alignment, and hover styles.

<sup>Written for commit 7d2a7c9d665e2e2c901a0de97582161bdebd911b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

