### PR TITLE
fix(agent-gui): polish composer palettes and dock controls

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
@@ -1350,10 +1350,19 @@ describe("AgentFileMentionPalette", () => {
               iconUrl: "data:image/png;base64,automation",
               description:
                 "Schedule and review recurring automation runs for this workspace."
+            },
+            {
+              kind: "workspace-app",
+              href: "mention://workspace-app/tasks?workspaceId=room-1",
+              workspaceId: "room-1",
+              targetId: "tasks",
+              appId: "tasks",
+              name: "任务管理",
+              description: "管理工作区任务和运行记录。"
             }
           ],
-          totalCount: 1,
-          visibleCount: 1,
+          totalCount: 2,
+          visibleCount: 2,
           hasMore: false
         }
       ],
@@ -1388,7 +1397,7 @@ describe("AgentFileMentionPalette", () => {
     ).toHaveClass("rich-text-at-mention-app-icon");
     expect(
       screen.getByText(
-        "Schedule and review recurring automation runs for this workspace."
+        "Schedule and review recurring automation runs for this workspace"
       )
     ).toBeVisible();
     expect(screen.getByText("Automation").parentElement).toHaveClass(
@@ -1401,14 +1410,21 @@ describe("AgentFileMentionPalette", () => {
     );
     expect(
       screen.getByText(
-        "Schedule and review recurring automation runs for this workspace."
+        "Schedule and review recurring automation runs for this workspace"
       )
     ).toHaveClass("rich-text-at-mention-row__app-description");
     expect(
       screen.getByText(
-        "Schedule and review recurring automation runs for this workspace."
+        "Schedule and review recurring automation runs for this workspace"
       )
     ).toHaveClass("rich-text-at-mention-row__entity-description");
+    expect(
+      screen.queryByText(
+        "Schedule and review recurring automation runs for this workspace."
+      )
+    ).toBeNull();
+    expect(screen.getByText("管理工作区任务和运行记录")).toBeVisible();
+    expect(screen.queryByText("管理工作区任务和运行记录。")).toBeNull();
     expect(screen.queryByText("automation")).toBeNull();
     expect(
       document.querySelector("section")?.textContent?.match(/\bApps\b/g) ?? []

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
@@ -477,7 +477,7 @@ function agentMentionItemToRowItem(
     return {
       kind: "app",
       name: item.name,
-      description: item.description ?? null,
+      description: mentionDescriptionWithoutTerminalPeriod(item.description),
       iconUrl: item.iconUrl ?? null
     };
   }
@@ -486,7 +486,7 @@ function agentMentionItemToRowItem(
     return {
       kind: "app",
       name: item.name,
-      description: item.description ?? null,
+      description: mentionDescriptionWithoutTerminalPeriod(item.description),
       iconUrl: item.iconUrl ?? managedAgentRoundedIconUrl(item.agentProviderId),
       statusTag: agentTargetAvailableStatusTag()
     };
@@ -525,6 +525,15 @@ function agentMentionItemToRowItem(
     creatorName: item.creatorName ?? null,
     statusTag: agentIssueStatusTag(item.status)
   };
+}
+
+function mentionDescriptionWithoutTerminalPeriod(
+  description: string | null | undefined
+): string | null {
+  const normalizedDescription = description?.trimEnd();
+  return normalizedDescription
+    ? normalizedDescription.replace(/[。.]+$/u, "")
+    : null;
 }
 
 /**

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashCommandPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashCommandPalette.spec.tsx
@@ -71,11 +71,56 @@ describe("AgentSlashCommandPalette", () => {
 
     const option = screen.getByRole("option", { name: /tutti-cli/i });
     expect(option).toHaveAttribute("data-highlighted", "");
-    expect(screen.getByText("tutti-cli")).toBeInTheDocument();
+    expect(screen.getByText("tutti-cli")).toHaveClass("text-[13px]");
+    expect(screen.getByText("Inspect tasks and agent context")).toHaveClass(
+      "text-[13px]"
+    );
     expect(
-      screen.getByText("Inspect tasks and agent context.")
-    ).toBeInTheDocument();
+      screen.getByText("tutti-cli").parentElement?.parentElement
+    ).toHaveClass("gap-[8px]");
     expect(screen.queryByText("[issue description]")).toBeNull();
+  });
+
+  it("removes terminal periods from every description", () => {
+    render(
+      <AgentSlashCommandPalette
+        label="Slash commands"
+        commandsGroupLabel="Commands"
+        capabilitiesGroupLabel="Capabilities"
+        skillsGroupLabel="Skills"
+        pluginsGroupLabel="Plugins"
+        connectorsGroupLabel="Connectors"
+        mcpGroupLabel="MCP"
+        highlightedIndex={0}
+        entries={[
+          {
+            type: "command",
+            key: "command:english",
+            label: "english",
+            description: "Keep internal e.g. punctuation.",
+            command: { name: "english" }
+          },
+          {
+            type: "command",
+            key: "command:chinese",
+            label: "chinese",
+            description: "保留内部标点，移除末尾句号。",
+            command: { name: "chinese" }
+          }
+        ]}
+        onHighlightChange={vi.fn()}
+        onSelect={vi.fn()}
+        onSelectCapability={vi.fn()}
+        onSelectSkill={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Keep internal e.g. punctuation")).toHaveClass(
+      "text-[13px]"
+    );
+    expect(screen.getByText("保留内部标点，移除末尾句号")).toBeInTheDocument();
+    expect(screen.queryByText("Keep internal e.g. punctuation.")).toBeNull();
+    expect(screen.queryByText("保留内部标点，移除末尾句号。")).toBeNull();
   });
 
   it("renders a capability section and dispatches capability selection", () => {
@@ -170,10 +215,10 @@ describe("AgentSlashCommandPalette", () => {
     expect(icon).toBeTruthy();
     // The svg carries its own size class so the option's
     // `[&_svg:not([class*='size-'])]:size-4` fallback does not override it.
-    expect(icon).toHaveClass("size-3");
+    expect(icon).toHaveClass("size-4");
     expect(icon?.parentElement).toHaveClass(
       "flex",
-      "w-3",
+      "w-4",
       "shrink-0",
       "items-center",
       "justify-center",
@@ -214,7 +259,12 @@ describe("AgentSlashCommandPalette", () => {
     );
 
     expect(screen.getByText("状态")).toBeInTheDocument();
-    expect(screen.getByText("status")).toBeInTheDocument();
+    expect(screen.getByText("status")).toHaveClass(
+      "text-[13px]",
+      "font-normal",
+      "text-[var(--text-secondary)]"
+    );
+    expect(screen.getByText("status").parentElement).toHaveClass("gap-[8px]");
   });
 
   it("uses distinct icons for plan and review commands", () => {
@@ -349,7 +399,13 @@ describe("AgentSlashCommandPalette", () => {
     );
 
     expect(screen.getByText("Plugins")).toBeInTheDocument();
-    expect(screen.getByText("Connectors")).toBeInTheDocument();
+    expect(screen.getByText("Connectors")).toHaveClass(
+      "mt-3",
+      "pt-3",
+      "before:inset-x-3",
+      "before:border-t",
+      "before:border-[var(--border-1)]"
+    );
     expect(screen.queryByText("Skills")).toBeNull();
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashCommandPalette.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashCommandPalette.tsx
@@ -69,19 +69,20 @@ const paletteStyles = {
     "nodrag agent-gui-node__mention-palette flex h-full min-h-0 flex-col gap-0.5 overflow-y-auto px-1 pb-1 pt-2 [-webkit-app-region:no-drag]",
   option:
     "nodrag relative flex h-7 min-h-7 w-full min-w-0 cursor-pointer select-none items-center gap-2 overflow-hidden rounded-[6px] border-0 bg-transparent px-2.5 py-0 text-left text-[13px] text-[var(--text-primary)] outline-hidden transition-colors duration-200 [-webkit-app-region:no-drag] hover:bg-[var(--transparency-block)] focus-visible:bg-[var(--transparency-block)] focus-visible:outline-none active:bg-[var(--transparency-active)] data-[highlighted]:bg-[var(--transparency-block)] data-[highlighted]:text-[var(--text-primary)] [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-  icon: "flex w-3 shrink-0 items-center justify-center self-center text-[var(--text-secondary)]",
-  copy: "flex min-w-0 flex-1 items-center gap-1 overflow-hidden leading-[16px]",
-  name: "flex min-w-0 max-w-[48%] shrink-0 items-center gap-1 overflow-hidden",
+  icon: "flex w-4 shrink-0 items-center justify-center self-center text-[var(--text-secondary)]",
+  copy: "flex min-w-0 flex-1 items-center gap-[8px] overflow-hidden leading-[16px]",
+  name: "flex min-w-0 max-w-[48%] shrink-0 items-center gap-[8px] overflow-hidden",
   primaryName:
-    "min-w-0 truncate text-[11px] font-semibold text-[var(--text-primary)]",
+    "min-w-0 truncate text-[13px] font-semibold text-[var(--text-primary)]",
   secondaryName:
-    "shrink-0 text-[10px] font-normal text-[var(--text-secondary)]",
+    "shrink-0 text-[13px] font-normal text-[var(--text-secondary)]",
   descriptionText:
-    "min-w-0 flex-1 truncate text-[11px] font-normal text-[var(--text-secondary)]",
+    "min-w-0 flex-1 truncate text-[13px] font-normal text-[var(--text-secondary)]",
   groupHeader:
     "select-none px-2.5 pb-0.5 text-[11px] font-normal text-[var(--text-secondary)]",
   groupHeaderFirst: "pt-1.5",
-  groupHeaderSeparated: "mt-1 border-t border-[var(--border-1)] pt-2",
+  groupHeaderSeparated:
+    "relative mt-3 pt-3 before:absolute before:inset-x-3 before:top-0 before:border-t before:border-[var(--border-1)] before:content-['']",
   settingsButton:
     "nodrag ml-1 flex h-5 min-h-5 shrink-0 items-center rounded-[4px] border-0 bg-[var(--transparency-hover)] px-2 py-0 text-[11px] font-semibold leading-[14px] text-[var(--text-secondary)] outline-none transition-colors duration-150 hover:bg-[var(--transparency-active)] hover:text-[var(--text-primary)] focus-visible:ring-2 focus-visible:ring-[var(--agent-gui-focus-ring,var(--border-focus))]",
   loading:
@@ -241,7 +242,7 @@ export function AgentSlashCommandPalette({
                 </span>
                 {entry.description ? (
                   <span className={paletteStyles.descriptionText}>
-                    {entry.description}
+                    {descriptionWithoutTerminalPeriod(entry.description)}
                   </span>
                 ) : null}
               </span>
@@ -274,6 +275,10 @@ export function AgentSlashCommandPalette({
         : null}
     </div>
   );
+}
+
+function descriptionWithoutTerminalPeriod(description: string): string {
+  return description.trimEnd().replace(/[。.]+$/u, "");
 }
 
 type AgentSlashPaletteEntryGroup =
@@ -348,7 +353,7 @@ function labelForEntryGroupType(
 
 // Keep the explicit `size-*` class on each icon so the palette option's
 // `[&_svg:not([class*='size-'])]:size-4` fallback does not override it.
-const SLASH_PALETTE_ICON_CLASS = "size-3";
+const SLASH_PALETTE_ICON_CLASS = "size-4";
 
 function slashPaletteEntryIcon(entry: AgentSlashPaletteEntry): ReactNode {
   if (entry.type === "capability") {

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
@@ -478,7 +478,10 @@ export function AgentComposerView(input: Props): React.JSX.Element {
               : null}
             <ComposerFloatingMenuSurface
               anchorRef={input.inputShellRef}
-              className="max-h-[320px] border-0 p-0"
+              className={cn(
+                composerStyles.dropdownSurface,
+                "max-h-[320px] overflow-hidden border-[var(--line-1)] p-0"
+              )}
               contentClassName="h-full min-h-0"
               dismissBoundaryRef={input.promptInputAreaRef}
               maxHeight={SLASH_PALETTE_HEIGHT_PX}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx
@@ -158,7 +158,67 @@ describe("useAgentGUIDetailScroll", () => {
 
     expect(harness.timeline.scrollTop).toBe(4_000);
   });
+
+  it("moves floating dock controls above a growing composer without reserving timeline space", () => {
+    const harness = createHarness({ scrollHeight: 5_000 });
+    const composerInputShell = document.createElement("div");
+    const promptInputArea = document.createElement("div");
+    const clippedEditorContent = document.createElement("div");
+    composerInputShell.className = "agent-gui-node__composer-input-shell";
+    promptInputArea.className = "agent-gui-node__composer-prompt-input-area";
+    promptInputArea.appendChild(clippedEditorContent);
+    composerInputShell.appendChild(promptInputArea);
+    harness.bottomDock.appendChild(composerInputShell);
+    harness.bottomDock.getBoundingClientRect = vi.fn(() =>
+      mockRect({ top: 400, bottom: 500, width: 600, height: 100 })
+    );
+    composerInputShell.getBoundingClientRect = vi.fn(() =>
+      mockRect({ top: 320, bottom: 500, width: 600, height: 180 })
+    );
+    promptInputArea.getBoundingClientRect = vi.fn(() =>
+      mockRect({ top: 320, bottom: 450, width: 600, height: 130 })
+    );
+    clippedEditorContent.getBoundingClientRect = vi.fn(() =>
+      mockRect({ top: 240, bottom: 440, width: 560, height: 200 })
+    );
+
+    renderHook(() =>
+      useAgentGUIDetailScroll(
+        harness.input({
+          activeConversationId: "conversation-growing-composer",
+          showTimelineSkeleton: false
+        })
+      )
+    );
+
+    expect(
+      harness.timeline.style.getPropertyValue(
+        "--agent-gui-bottom-dock-safe-area"
+      )
+    ).toBe("0px");
+    expect(
+      harness.bottomDock.style.getPropertyValue(
+        "--agent-gui-bottom-dock-floating-safe-area"
+      )
+    ).toBe("80px");
+  });
 });
+
+function mockRect(input: {
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+}): DOMRect {
+  return {
+    ...input,
+    left: 0,
+    right: input.width,
+    x: 0,
+    y: input.top,
+    toJSON: () => ({})
+  } as DOMRect;
+}
 
 function createHarness(input: { scrollHeight: number }) {
   const timeline = document.createElement("div");
@@ -189,6 +249,7 @@ function createHarness(input: { scrollHeight: number }) {
   const submittedPromptScrollConversationRef = mutableRef<string | null>(null);
 
   return {
+    bottomDock,
     timeline,
     setScrollHeight(value: number) {
       scrollHeight = value;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.ts
@@ -165,34 +165,47 @@ export function useAgentGUIDetailScroll(input: Input) {
 
     const syncBottomDockSafeArea = (): void => {
       const bottomDockRect = bottomDock.getBoundingClientRect();
-      let visualTop = bottomDockRect.top;
+      let timelineVisualTop = bottomDockRect.top;
+      let floatingVisualTop = bottomDockRect.top;
       bottomDock.querySelectorAll("*").forEach((element) => {
         if (element.closest(`.${styles.bottomDockScrollToBottom}`)) {
+          return;
+        }
+        const rect = element.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) {
           return;
         }
         // The prompt input box expands upward past the dock top while the
         // user drafts a long prompt. That transient overhang must not grow
         // the timeline's reserved bottom space: reserving for it re-pins the
-        // scroll position and visibly pushes the message stream up.
+        // scroll position and visibly pushes the message stream up. Only the
+        // input area's own box contributes to the floating controls' offset;
+        // clipped editor descendants can have layout positions above that box
+        // and would otherwise create an oversized gap.
         if (element.closest(`.${styles.composerInputShell}`)) {
+          if (element.matches(".agent-gui-node__composer-prompt-input-area")) {
+            floatingVisualTop = Math.min(floatingVisualTop, rect.top);
+          }
           return;
         }
-        const rect = element.getBoundingClientRect();
-        if (rect.width > 0 && rect.height > 0) {
-          visualTop = Math.min(visualTop, rect.top);
-        }
+        floatingVisualTop = Math.min(floatingVisualTop, rect.top);
+        timelineVisualTop = Math.min(timelineVisualTop, rect.top);
       });
-      const overflowHeight = Math.max(
+      const timelineOverflowHeight = Math.max(
         0,
-        Math.ceil(bottomDockRect.top - visualTop)
+        Math.ceil(bottomDockRect.top - timelineVisualTop)
+      );
+      const floatingOverflowHeight = Math.max(
+        0,
+        Math.ceil(bottomDockRect.top - floatingVisualTop)
       );
       timeline.style.setProperty(
         "--agent-gui-bottom-dock-safe-area",
-        `${overflowHeight}px`
+        `${timelineOverflowHeight}px`
       );
       bottomDock.style.setProperty(
         "--agent-gui-bottom-dock-floating-safe-area",
-        `${overflowHeight}px`
+        `${floatingOverflowHeight}px`
       );
     };
 

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -7515,6 +7515,9 @@ button.agent-gui-node__conversation-section-toggle:hover
 .agent-gui-node__composer[data-layout="dock"]
   .agent-gui-node__composer-prompt-input-area {
   display: grid;
+  /* Keep the input shadow above the following footer row. Both rows otherwise
+     share z-index: 1, so the later-painted footer visually clips the shadow. */
+  z-index: 2;
   grid-template-rows: minmax(0, 1fr);
   box-sizing: border-box;
   height: var(--agent-gui-composer-input-height, 56px);
@@ -8768,6 +8771,14 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 .agent-gui-node__composer-menu-item > span:last-child > span {
   width: 100%;
   min-width: 0;
+}
+
+.agent-gui-node__composer-menu-trigger[data-agent-plan-mode-badge="true"] {
+  color: var(--state-warning);
+}
+
+.agent-gui-node__composer-menu-trigger[data-agent-goal-badge="true"] {
+  color: var(--tutti-purple);
 }
 
 .agent-gui-node__composer-menu-trigger:hover:not(:disabled) {

--- a/packages/ui/rich-text/src/at-panel/mentionPalette.css
+++ b/packages/ui/rich-text/src/at-panel/mentionPalette.css
@@ -641,7 +641,7 @@
 .rich-text-at-mention-row__app-text,
 .rich-text-at-mention-row__entity-text {
   align-items: baseline;
-  gap: 4px;
+  gap: 8px;
 }
 
 .rich-text-at-mention-row__file-text {


### PR DESCRIPTION
## Summary

- align slash-command palette typography, icon sizing, group spacing, dividers, border, and shadow with the @ mention palette
- use semantic orange and purple colors for the persistent plan and goal controls
- normalize option descriptions by removing terminal periods and use an 8px title-to-description gap across slash and @ palettes
- keep the composer input shadow visible above the footer
- move the scroll-to-bottom control with a growing composer while ignoring clipped editor descendants that previously created an oversized gap

## Why

The slash palette and composer controls had drifted from the shared UI-system and the existing @ palette. The floating dock offset also measured every composer descendant, including clipped editor content whose layout position could sit above the visible input box. That caused the scroll-to-bottom button to move too far upward.

## Impact

The command and mention surfaces now share consistent typography and spacing. Composer controls retain their intended persistent colors, the input shadow is no longer clipped, and the scroll-to-bottom button stays close to the visible input edge as the draft grows without pushing the conversation timeline.

## Validation

- `pnpm check:changed --tail-lines 80` (8 lanes)
- `pnpm --filter @tutti-os/agent-gui test` (166 files, 1579 tests)
- `pnpm typecheck` (26 packages)
- pre-push `pnpm check:full` (18 tasks)
- staged Electron runtime, UI boundary, renderer boundary, and Agent GUI degradation checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the composer palettes and bottom dock so slash and @-mention UIs are consistent, and the scroll-to-bottom control stays aligned with the visible input as the composer grows. Also restored semantic colors for plan/goal controls and kept the input shadow visible.

- **UI Polish**
  - Normalize palette descriptions by removing trailing periods (supports "." and "。").
  - Unify typography to 13px, set 8px gaps, use 16px icons, and add clearer group dividers.
  - Apply semantic colors to persistent plan (warning) and goal (purple) controls.
  - Keep the composer input shadow above the footer and add border/overflow to the dropdown surface.

- **Bug Fixes**
  - Reworked bottom dock offset to compute separate safe areas for the timeline and floating controls, ignoring clipped editor descendants. This prevents oversized gaps, avoids pushing the timeline, and keeps the scroll-to-bottom button near the visible input edge.

<sup>Written for commit bc921735a6ae687df39df660dcea50e3231ad846. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

