### PR TITLE
fix(workspace-files): isolate preview shell presentation

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/index.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/index.ts
@@ -1,5 +1,6 @@
 export { registerWorkspaceFileManagerServices } from "./services/registerWorkspaceFileManagerServices";
 export { IWorkspaceFileManagerService } from "./services/workspaceFileManagerService.interface";
+export { IWorkspaceFilePreviewSurfaceHost } from "./services/workspaceFilePreviewSurfaceHost.interface";
 export {
   createDesktopWorkspaceFileReferenceAdapter,
   mapDesktopWorkspaceFileReferenceEntry

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/desktopWorkspaceFileManagerAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/desktopWorkspaceFileManagerAdapter.ts
@@ -14,6 +14,7 @@ import { resolveDesktopErrorMessage } from "../../../../lib/desktopErrors.ts";
 import type { DesktopLocale } from "../../../../../../shared/i18n/index.ts";
 import { extractDesktopDroppedPaths } from "../desktopDroppedPaths.ts";
 import type { WorkspaceFileManagerServiceDependencies } from "./workspaceFileManagerService.ts";
+import type { WorkspaceFilePreviewPresentationResult } from "../workspaceFilePreviewSurfaceHost.interface.ts";
 
 interface DesktopWorkspaceFileManagerAdapterDependencies extends WorkspaceFileManagerServiceDependencies {
   notifyPreviewUnsupportedFallback(): void;
@@ -26,10 +27,13 @@ export function createDesktopWorkspaceFileManagerAdapter(
   dependencies: DesktopWorkspaceFileManagerAdapterDependencies,
   getLocale: () => DesktopLocale,
   canvasPreview?: {
+    getUnsupportedFallbackNotification(
+      workspaceID: string
+    ): WorkspaceFilePreviewPresentationResult["unsupportedFallbackNotification"];
     openCanvasPreview(
       target: WorkspaceFileActivationTarget,
       workspaceID: string
-    ): Promise<boolean>;
+    ): Promise<WorkspaceFilePreviewPresentationResult>;
   }
 ): WorkspaceFileManagerHost {
   const hostFilesApi = dependencies.hostFilesApi;
@@ -135,15 +139,21 @@ export function createDesktopWorkspaceFileManagerAdapter(
       request: WorkspaceFileManagerFileActivationRequest,
       workspaceID: string
     ): Promise<WorkspaceFileManagerHostFileActivationResult> {
-      if (
-        request.target &&
-        (await canvasPreview?.openCanvasPreview(request.target, workspaceID))
-      ) {
+      const previewResult = request.target
+        ? await canvasPreview?.openCanvasPreview(request.target, workspaceID)
+        : undefined;
+      if (previewResult?.presented) {
         dependencies.reportFileOpened?.();
         return { disposition: "handled" };
       }
 
-      dependencies.notifyPreviewUnsupportedFallback();
+      const fallbackNotification =
+        previewResult?.unsupportedFallbackNotification ??
+        canvasPreview?.getUnsupportedFallbackNotification(workspaceID) ??
+        "show";
+      if (fallbackNotification === "show") {
+        dependencies.notifyPreviewUnsupportedFallback();
+      }
       await hostFilesApi.openFile(workspaceID, request.entry.path);
       dependencies.reportFileOpened?.();
       return { disposition: "handled" };

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts
@@ -27,6 +27,7 @@ import {
   buildDesktopWorkspaceFileLocationSections
 } from "../desktopWorkspaceFileLocations.ts";
 import { createDesktopWorkspaceFileManagerAdapter } from "./desktopWorkspaceFileManagerAdapter.ts";
+import { WorkspaceFilePreviewSurfaceHost } from "./workspaceFilePreviewSurfaceHost.ts";
 
 test("workspace file manager service reuses one long-lived session per workspace", () => {
   const service = new WorkspaceFileManagerService(createDependenciesStub());
@@ -475,18 +476,20 @@ test("workspace file manager service can suppress the local app preview fallback
   const dependencies = createDependenciesStub();
   dependencies.hostFilesApi.openFile = async () => {};
   const notifications = createNotificationRecorder();
+  const filePreviewSurfaceHost = new WorkspaceFilePreviewSurfaceHost();
+  filePreviewSurfaceHost.registerPresenter("workspace-1", {
+    present: () => false,
+    unsupportedFallbackNotification: "suppress"
+  });
   const service = new WorkspaceFileManagerService(
     dependencies,
-    notifications.service
+    notifications.service,
+    filePreviewSurfaceHost
   );
   const copy = createWorkspaceFileManagerI18nRuntime(
     createI18nRuntime({
       dictionaries: [workspaceFileManagerI18nResources.en]
     })
-  );
-  service.setPreviewUnsupportedFallbackNotificationEnabled(
-    "workspace-1",
-    false
   );
   const session = service.getSession("workspace-1", copy);
 
@@ -503,6 +506,68 @@ test("workspace file manager service can suppress the local app preview fallback
   });
 
   assert.deepEqual(notifications.items, []);
+});
+
+test("workspace file manager service keeps the starting presenter fallback policy across replacement", async () => {
+  applyLocale("en");
+  const openedFiles: Array<{ path: string; workspaceId: string }> = [];
+  const dependencies = createDependenciesStub();
+  dependencies.hostFilesApi.openFile = async (workspaceId, path) => {
+    openedFiles.push({ path, workspaceId });
+  };
+  const notifications = createNotificationRecorder();
+  const filePreviewSurfaceHost = new WorkspaceFilePreviewSurfaceHost();
+  let finishPresentation: ((presented: boolean) => void) | undefined;
+  filePreviewSurfaceHost.registerPresenter("workspace-1", {
+    present: () =>
+      new Promise<boolean>((resolve) => {
+        finishPresentation = resolve;
+      }),
+    unsupportedFallbackNotification: "suppress"
+  });
+  const service = new WorkspaceFileManagerService(
+    dependencies,
+    notifications.service,
+    filePreviewSurfaceHost
+  );
+  const copy = createWorkspaceFileManagerI18nRuntime(
+    createI18nRuntime({
+      dictionaries: [workspaceFileManagerI18nResources.en]
+    })
+  );
+  const session = service.getSession("workspace-1", copy);
+
+  const activation = session.activateFile({
+    entry: {
+      hasChildren: false,
+      kind: "file",
+      mtimeMs: null,
+      name: "notes.txt",
+      path: "/Users/demo/project/notes.txt",
+      sizeBytes: 5
+    },
+    target: {
+      fileKind: "text",
+      mtimeMs: null,
+      name: "notes.txt",
+      path: "/Users/demo/project/notes.txt",
+      sizeBytes: 5
+    }
+  });
+  filePreviewSurfaceHost.registerPresenter("workspace-1", {
+    present: () => true,
+    unsupportedFallbackNotification: "show"
+  });
+  finishPresentation?.(false);
+  await activation;
+
+  assert.deepEqual(notifications.items, []);
+  assert.deepEqual(openedFiles, [
+    {
+      path: "/Users/demo/project/notes.txt",
+      workspaceId: "workspace-1"
+    }
+  ]);
 });
 
 test("workspace file manager service does not report opened after failed file activation", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.ts
@@ -23,9 +23,13 @@ import { getActiveLocale } from "../../../../i18n/runtime.ts";
 import { createDesktopWorkspaceFileManagerAdapter } from "./desktopWorkspaceFileManagerAdapter.ts";
 import type {
   IWorkspaceFileManagerService,
-  WorkspaceFileManagerCanvasPreviewLauncher,
   WorkspaceFileManagerSession
 } from "../workspaceFileManagerService.interface";
+import {
+  IWorkspaceFilePreviewSurfaceHost,
+  type IWorkspaceFilePreviewSurfaceHost as WorkspaceFilePreviewSurfaceHost
+} from "../workspaceFilePreviewSurfaceHost.interface.ts";
+import { WorkspaceFilePreviewSurfaceHost as DefaultWorkspaceFilePreviewSurfaceHost } from "./workspaceFilePreviewSurfaceHost.ts";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
 import type { DesktopLocale } from "@shared/i18n";
 import {
@@ -67,11 +71,8 @@ export interface WorkspaceFileManagerServiceDependencies {
 
 export class WorkspaceFileManagerService implements IWorkspaceFileManagerService {
   readonly _serviceBrand = undefined;
-  private readonly canvasFilePreviewLaunchers = new Map<
-    string,
-    WorkspaceFileManagerCanvasPreviewLauncher
-  >();
   private readonly dependencies: WorkspaceFileManagerServiceDependencies;
+  private readonly filePreviewSurfaceHost: WorkspaceFilePreviewSurfaceHost;
   private readonly listeners = new Map<string, Set<() => void>>();
   private readonly i18nRuntimeByWorkspace = new Map<
     string,
@@ -82,8 +83,6 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
     string
   >();
   private readonly notifications: NotificationService;
-  private readonly previewUnsupportedFallbackNotificationEnabledByWorkspace =
-    new Map<string, boolean>();
   private readonly referenceSourceAggregators = new Map<
     string,
     ReferenceSourceAggregator
@@ -93,9 +92,11 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
 
   constructor(
     dependencies: WorkspaceFileManagerServiceDependencies,
-    notifications: NotificationService = noopNotifications
+    notifications: NotificationService = noopNotifications,
+    filePreviewSurfaceHost: WorkspaceFilePreviewSurfaceHost = new DefaultWorkspaceFilePreviewSurfaceHost()
   ) {
     this.dependencies = dependencies;
+    this.filePreviewSurfaceHost = filePreviewSurfaceHost;
     this.notifications = notifications;
     dependencies.workspaceUserProjectService?.subscribe(() => {
       void this.refreshAllSessionLocations();
@@ -216,13 +217,6 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
         {
           ...this.dependencies,
           notifyPreviewUnsupportedFallback: () => {
-            if (
-              this.previewUnsupportedFallbackNotificationEnabledByWorkspace.get(
-                workspaceID
-              ) === false
-            ) {
-              return;
-            }
             this.notifications.info({
               title: translate(
                 "workspace.workbenchDesktop.filePreview.unsupportedFallback"
@@ -242,6 +236,10 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
         },
         getActiveLocale,
         {
+          getUnsupportedFallbackNotification: (workspaceID) =>
+            this.filePreviewSurfaceHost.getUnsupportedFallbackNotification(
+              workspaceID
+            ),
           openCanvasPreview: (target, workspaceID) =>
             this.openCanvasPreview(workspaceID, target)
         }
@@ -288,33 +286,10 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
 
   async openCanvasFilePreview(
     workspaceID: string,
-    target: Parameters<WorkspaceFileManagerCanvasPreviewLauncher>[0]
+    target: Parameters<WorkspaceFilePreviewSurfaceHost["present"]>[1]
   ): Promise<boolean> {
-    return (
-      (await this.canvasFilePreviewLaunchers.get(workspaceID)?.(target)) ===
-      true
-    );
-  }
-
-  setCanvasFilePreviewLauncher(
-    workspaceID: string,
-    launcher: WorkspaceFileManagerCanvasPreviewLauncher | null
-  ): void {
-    if (!launcher) {
-      this.canvasFilePreviewLaunchers.delete(workspaceID);
-      return;
-    }
-    this.canvasFilePreviewLaunchers.set(workspaceID, launcher);
-  }
-
-  setPreviewUnsupportedFallbackNotificationEnabled(
-    workspaceID: string,
-    enabled: boolean
-  ): void {
-    this.previewUnsupportedFallbackNotificationEnabledByWorkspace.set(
-      workspaceID,
-      enabled
-    );
+    return (await this.filePreviewSurfaceHost.present(workspaceID, target))
+      .presented;
   }
 
   subscribe(workspaceID: string, listener: () => void): () => void {
@@ -379,9 +354,9 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
 
   private async openCanvasPreview(
     workspaceID: string,
-    target: Parameters<WorkspaceFileManagerCanvasPreviewLauncher>[0]
-  ): Promise<boolean> {
-    return this.openCanvasFilePreview(workspaceID, target);
+    target: Parameters<WorkspaceFilePreviewSurfaceHost["present"]>[1]
+  ): ReturnType<WorkspaceFilePreviewSurfaceHost["present"]> {
+    return this.filePreviewSurfaceHost.present(workspaceID, target);
   }
 
   private async loadReferenceLocationSections(
@@ -566,6 +541,7 @@ function referenceNodeToLocation(
 
 // Avoid decorator syntax so the renderer Babel pass can parse this file.
 INotificationService(WorkspaceFileManagerService, undefined, 1);
+IWorkspaceFilePreviewSurfaceHost(WorkspaceFileManagerService, undefined, 2);
 
 const noopNotifications: NotificationService = {
   _serviceBrand: undefined,

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFilePreviewSurfaceHost.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFilePreviewSurfaceHost.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { WorkspaceFileActivationTarget } from "@tutti-os/workspace-file-manager/services";
+import { WorkspaceFilePreviewSurfaceHost } from "./workspaceFilePreviewSurfaceHost.ts";
+
+const target: WorkspaceFileActivationTarget = {
+  fileKind: "text",
+  mtimeMs: null,
+  name: "notes.txt",
+  path: "/workspace/notes.txt",
+  sizeBytes: 5
+};
+
+test("workspace file preview surface host routes presentation by workspace", async () => {
+  const calls: string[] = [];
+  const host = new WorkspaceFilePreviewSurfaceHost();
+  host.registerPresenter("workspace-1", {
+    present: (request) => {
+      calls.push(request.path);
+      return true;
+    },
+    unsupportedFallbackNotification: "show"
+  });
+
+  assert.deepEqual(await host.present("workspace-1", target), {
+    presented: true,
+    unsupportedFallbackNotification: "show"
+  });
+  assert.deepEqual(await host.present("workspace-2", target), {
+    presented: false,
+    unsupportedFallbackNotification: "show"
+  });
+  assert.deepEqual(calls, [target.path]);
+});
+
+test("workspace file preview surface host keeps a replacement after stale disposal", async () => {
+  const host = new WorkspaceFilePreviewSurfaceHost();
+  const disposeFirst = host.registerPresenter("workspace-1", {
+    present: () => false,
+    unsupportedFallbackNotification: "show"
+  });
+  host.registerPresenter("workspace-1", {
+    present: () => true,
+    unsupportedFallbackNotification: "suppress"
+  });
+
+  disposeFirst();
+
+  assert.equal((await host.present("workspace-1", target)).presented, true);
+  assert.equal(
+    host.getUnsupportedFallbackNotification("workspace-1"),
+    "suppress"
+  );
+});
+
+test("workspace file preview surface host distinguishes repeated registrations", async () => {
+  const host = new WorkspaceFilePreviewSurfaceHost();
+  const presenter = {
+    present: () => true,
+    unsupportedFallbackNotification: "show" as const
+  };
+  const disposeFirst = host.registerPresenter("workspace-1", presenter);
+  host.registerPresenter("workspace-1", presenter);
+
+  disposeFirst();
+
+  assert.equal((await host.present("workspace-1", target)).presented, true);
+});
+
+test("workspace file preview surface host restores default fallback notification policy after disposal", () => {
+  const host = new WorkspaceFilePreviewSurfaceHost();
+  const dispose = host.registerPresenter("workspace-1", {
+    present: () => true,
+    unsupportedFallbackNotification: "suppress"
+  });
+
+  assert.equal(
+    host.getUnsupportedFallbackNotification("workspace-1"),
+    "suppress"
+  );
+  dispose();
+  assert.equal(host.getUnsupportedFallbackNotification("workspace-1"), "show");
+});
+
+test("workspace file preview surface host preserves a completed presentation after replacement", async () => {
+  const host = new WorkspaceFilePreviewSurfaceHost();
+  let finishPresentation: ((value: boolean) => void) | undefined;
+  host.registerPresenter("workspace-1", {
+    present: () =>
+      new Promise<boolean>((resolve) => {
+        finishPresentation = resolve;
+      }),
+    unsupportedFallbackNotification: "show"
+  });
+
+  const presented = host.present("workspace-1", target);
+  host.registerPresenter("workspace-1", {
+    present: () => true,
+    unsupportedFallbackNotification: "show"
+  });
+  finishPresentation?.(true);
+
+  assert.deepEqual(await presented, {
+    presented: true,
+    unsupportedFallbackNotification: "show"
+  });
+});
+
+test("workspace file preview surface host keeps the starting registration policy when a failed presentation completes after replacement", async () => {
+  const host = new WorkspaceFilePreviewSurfaceHost();
+  let finishPresentation: ((value: boolean) => void) | undefined;
+  host.registerPresenter("workspace-1", {
+    present: () =>
+      new Promise<boolean>((resolve) => {
+        finishPresentation = resolve;
+      }),
+    unsupportedFallbackNotification: "suppress"
+  });
+
+  const presented = host.present("workspace-1", target);
+  host.registerPresenter("workspace-1", {
+    present: () => true,
+    unsupportedFallbackNotification: "show"
+  });
+  finishPresentation?.(false);
+
+  assert.deepEqual(await presented, {
+    presented: false,
+    unsupportedFallbackNotification: "suppress"
+  });
+});

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFilePreviewSurfaceHost.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFilePreviewSurfaceHost.ts
@@ -1,0 +1,58 @@
+import type {
+  IWorkspaceFilePreviewSurfaceHost,
+  WorkspaceFilePreviewPresentationResult,
+  WorkspaceFilePreviewSurfacePresenter
+} from "../workspaceFilePreviewSurfaceHost.interface.ts";
+
+interface WorkspaceFilePreviewSurfaceRegistration {
+  presenter: WorkspaceFilePreviewSurfacePresenter;
+}
+
+export class WorkspaceFilePreviewSurfaceHost implements IWorkspaceFilePreviewSurfaceHost {
+  readonly _serviceBrand = undefined;
+
+  private readonly registrations = new Map<
+    string,
+    WorkspaceFilePreviewSurfaceRegistration
+  >();
+
+  getUnsupportedFallbackNotification(
+    workspaceID: string
+  ): WorkspaceFilePreviewPresentationResult["unsupportedFallbackNotification"] {
+    return (
+      this.registrations.get(workspaceID)?.presenter
+        .unsupportedFallbackNotification ?? "show"
+    );
+  }
+
+  async present(
+    workspaceID: string,
+    target: Parameters<WorkspaceFilePreviewSurfacePresenter["present"]>[0]
+  ): Promise<WorkspaceFilePreviewPresentationResult> {
+    const registration = this.registrations.get(workspaceID);
+    if (!registration) {
+      return {
+        presented: false,
+        unsupportedFallbackNotification: "show"
+      };
+    }
+    return {
+      presented: (await registration.presenter.present(target)) === true,
+      unsupportedFallbackNotification:
+        registration.presenter.unsupportedFallbackNotification
+    };
+  }
+
+  registerPresenter(
+    workspaceID: string,
+    presenter: WorkspaceFilePreviewSurfacePresenter
+  ): () => void {
+    const registration = { presenter };
+    this.registrations.set(workspaceID, registration);
+    return () => {
+      if (this.registrations.get(workspaceID) === registration) {
+        this.registrations.delete(workspaceID);
+      }
+    };
+  }
+}

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/registerWorkspaceFileManagerServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/registerWorkspaceFileManagerServices.ts
@@ -5,7 +5,9 @@ import type { IReporterService } from "../../analytics/services/reporterService.
 import type { IDesktopPreferencesService } from "../../desktop-preferences/services/desktopPreferencesService.interface.ts";
 import type { IWorkspaceUserProjectService } from "../../workspace-user-project/index.ts";
 import { WorkspaceFileManagerService } from "./internal/workspaceFileManagerService";
+import { WorkspaceFilePreviewSurfaceHost } from "./internal/workspaceFilePreviewSurfaceHost.ts";
 import { IWorkspaceFileManagerService } from "./workspaceFileManagerService.interface";
+import { IWorkspaceFilePreviewSurfaceHost } from "./workspaceFilePreviewSurfaceHost.interface.ts";
 
 export interface WorkspaceFileManagerServiceRegistrationInput {
   hostFilesApi: DesktopHostFilesApi;
@@ -23,6 +25,10 @@ export function registerWorkspaceFileManagerServices(
   registry: ServiceRegistry,
   input: WorkspaceFileManagerServiceRegistrationInput
 ): void {
+  registry.registerInstance(
+    IWorkspaceFilePreviewSurfaceHost,
+    new WorkspaceFilePreviewSurfaceHost()
+  );
   registry.register(
     IWorkspaceFileManagerService,
     new SyncDescriptor(WorkspaceFileManagerService, [input])

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/workspaceFileManagerService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/workspaceFileManagerService.interface.ts
@@ -10,10 +10,6 @@ import type {
 } from "@tutti-os/workspace-file-manager/services";
 export type WorkspaceFileManagerSession = SharedWorkspaceFileManagerSession;
 
-export type WorkspaceFileManagerCanvasPreviewLauncher = (
-  target: WorkspaceFileActivationTarget
-) => Promise<boolean> | boolean;
-
 export interface IWorkspaceFileManagerService {
   readonly _serviceBrand: undefined;
   readonly hostOs: NodeJS.Platform;
@@ -39,14 +35,6 @@ export interface IWorkspaceFileManagerService {
     workspaceID: string,
     entry: WorkspaceFileEntry
   ): Promise<string | null>;
-  setCanvasFilePreviewLauncher(
-    workspaceID: string,
-    launcher: WorkspaceFileManagerCanvasPreviewLauncher | null
-  ): void;
-  setPreviewUnsupportedFallbackNotificationEnabled(
-    workspaceID: string,
-    enabled: boolean
-  ): void;
   subscribe(workspaceID: string, listener: () => void): () => void;
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/workspaceFilePreviewSurfaceHost.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/workspaceFilePreviewSurfaceHost.interface.ts
@@ -1,0 +1,32 @@
+import { createDecorator } from "@tutti-os/infra/di";
+import type { WorkspaceFileActivationTarget } from "@tutti-os/workspace-file-manager/services";
+
+export interface WorkspaceFilePreviewSurfacePresenter {
+  readonly unsupportedFallbackNotification: "show" | "suppress";
+  present(target: WorkspaceFileActivationTarget): Promise<boolean> | boolean;
+}
+
+export interface WorkspaceFilePreviewPresentationResult {
+  readonly presented: boolean;
+  readonly unsupportedFallbackNotification: "show" | "suppress";
+}
+
+export interface IWorkspaceFilePreviewSurfaceHost {
+  readonly _serviceBrand: undefined;
+  getUnsupportedFallbackNotification(
+    workspaceID: string
+  ): WorkspaceFilePreviewPresentationResult["unsupportedFallbackNotification"];
+  present(
+    workspaceID: string,
+    target: WorkspaceFileActivationTarget
+  ): Promise<WorkspaceFilePreviewPresentationResult>;
+  registerPresenter(
+    workspaceID: string,
+    presenter: WorkspaceFilePreviewSurfacePresenter
+  ): () => void;
+}
+
+export const IWorkspaceFilePreviewSurfaceHost =
+  createDecorator<IWorkspaceFilePreviewSurfaceHost>(
+    "workspace-file-preview-surface-host"
+  );

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.test.ts
@@ -249,8 +249,6 @@ function createFileManagerServiceStub(
     async resolveEntryIconUrl() {
       return null;
     },
-    setCanvasFilePreviewLauncher() {},
-    setPreviewUnsupportedFallbackNotificationEnabled() {},
     subscribe(_workspaceID, listener) {
       listeners.add(listener);
       return () => listeners.delete(listener);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentWorkspaceFilePreviewPresenter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentWorkspaceFilePreviewPresenter.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { WorkspaceFileActivationTarget } from "@tutti-os/workspace-file-manager/services";
+import { createStandaloneAgentWorkspaceFilePreviewPresenter } from "./standaloneAgentWorkspaceFilePreviewPresenter.ts";
+
+test("standalone Agent file preview presenter opens the file with the system host", async () => {
+  const calls: Array<{ path: string; workspaceId: string }> = [];
+  const presenter = createStandaloneAgentWorkspaceFilePreviewPresenter({
+    hostFilesApi: {
+      async openFile(workspaceId, path) {
+        calls.push({ path, workspaceId });
+      }
+    },
+    workspaceId: "workspace-1"
+  });
+  const target: WorkspaceFileActivationTarget = {
+    fileKind: "text",
+    mtimeMs: null,
+    name: "notes.txt",
+    path: "/workspace/notes.txt",
+    sizeBytes: 5
+  };
+
+  assert.equal(await presenter.present(target), true);
+  assert.deepEqual(calls, [
+    { path: "/workspace/notes.txt", workspaceId: "workspace-1" }
+  ]);
+  assert.equal(presenter.unsupportedFallbackNotification, "suppress");
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentWorkspaceFilePreviewPresenter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentWorkspaceFilePreviewPresenter.ts
@@ -1,0 +1,15 @@
+import type { DesktopHostFilesApi } from "@preload/types";
+import type { WorkspaceFilePreviewSurfacePresenter } from "../../workspace-file-manager/services/workspaceFilePreviewSurfaceHost.interface.ts";
+
+export function createStandaloneAgentWorkspaceFilePreviewPresenter(input: {
+  hostFilesApi: Pick<DesktopHostFilesApi, "openFile">;
+  workspaceId: string;
+}): WorkspaceFilePreviewSurfacePresenter {
+  return {
+    async present(target) {
+      await input.hostFilesApi.openFile(input.workspaceId, target.path);
+      return true;
+    },
+    unsupportedFallbackNotification: "suppress"
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchWorkspaceFilePreviewPresenter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchWorkspaceFilePreviewPresenter.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { WorkbenchHostHandle } from "@tutti-os/workbench-surface";
+import type { WorkspaceFileActivationTarget } from "@tutti-os/workspace-file-manager/services";
+import { createWorkspaceFilePreviewLaunchRequest } from "./workspaceFilePreviewLaunch.ts";
+import { createWorkbenchWorkspaceFilePreviewPresenter } from "./workbenchWorkspaceFilePreviewPresenter.ts";
+
+const target: WorkspaceFileActivationTarget = {
+  fileKind: "image",
+  mtimeMs: 1,
+  name: "cover.png",
+  path: "/workspace/cover.png",
+  sizeBytes: 10
+};
+
+test("workbench file preview presenter launches a workbench node", async () => {
+  const launches: unknown[] = [];
+  const presenter = createWorkbenchWorkspaceFilePreviewPresenter({
+    host: {
+      launchNode: async (request) => {
+        launches.push(request);
+        return "preview-node";
+      }
+    } as WorkbenchHostHandle
+  });
+
+  assert.equal(await presenter.present(target), true);
+  assert.deepEqual(launches, [createWorkspaceFilePreviewLaunchRequest(target)]);
+  assert.equal(presenter.unsupportedFallbackNotification, "show");
+});
+
+test("workbench file preview presenter reports a rejected launch", async () => {
+  const presenter = createWorkbenchWorkspaceFilePreviewPresenter({
+    host: { launchNode: async () => null } as unknown as WorkbenchHostHandle
+  });
+
+  assert.equal(await presenter.present(target), false);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchWorkspaceFilePreviewPresenter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchWorkspaceFilePreviewPresenter.ts
@@ -1,0 +1,18 @@
+import type { WorkbenchHostHandle } from "@tutti-os/workbench-surface";
+import type { WorkspaceFilePreviewSurfacePresenter } from "../../workspace-file-manager/services/workspaceFilePreviewSurfaceHost.interface.ts";
+import { createWorkspaceFilePreviewLaunchRequest } from "./workspaceFilePreviewLaunch.ts";
+
+export function createWorkbenchWorkspaceFilePreviewPresenter(input: {
+  host: WorkbenchHostHandle;
+}): WorkspaceFilePreviewSurfacePresenter {
+  return {
+    async present(target) {
+      return (
+        (await input.host.launchNode(
+          createWorkspaceFilePreviewLaunchRequest(target)
+        )) !== null
+      );
+    },
+    unsupportedFallbackNotification: "show"
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
@@ -96,7 +96,7 @@ test("standalone Agent starts the app runtime lifecycle only when apps open", ()
 test("standalone Agent opens files like Finder and routes links into the right sidebar", () => {
   assert.match(
     standaloneWindowSource,
-    /setCanvasFilePreviewLauncher\([\s\S]*?desktopApi\.host\.files\.openFile\(workspaceId, target\.path\)[\s\S]*?return true/
+    /workspaceFilePreviewSurfaceHost\.registerPresenter\([\s\S]*?createStandaloneAgentWorkspaceFilePreviewPresenter\([\s\S]*?hostFilesApi: desktopApi\.host\.files/
   );
   assert.match(standaloneWindowSource, /workspaceFilePreviewMode: "canvas"/);
   assert.match(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -50,7 +50,10 @@ import {
   type IWorkspaceAppCenterService
 } from "@renderer/features/workspace-app-center";
 import { useService } from "@tutti-os/infra/di";
-import { IWorkspaceFileManagerService } from "@renderer/features/workspace-file-manager";
+import {
+  IWorkspaceFileManagerService,
+  IWorkspaceFilePreviewSurfaceHost
+} from "@renderer/features/workspace-file-manager";
 import type {
   DesktopApi,
   DesktopHostWindowApi,
@@ -85,6 +88,7 @@ import { StandaloneAgentWindowContentReady } from "./StandaloneAgentWindowConten
 import { showWorkspaceFileMissingToast } from "../services/workspaceFilesLaunchFeedback.ts";
 import { Toast } from "@renderer/lib/toast";
 import { createStandaloneAgentWorkspaceAppSurfacePresenter } from "../services/standaloneAgentWorkspaceAppSurfacePresenter.ts";
+import { createStandaloneAgentWorkspaceFilePreviewPresenter } from "../services/standaloneAgentWorkspaceFilePreviewPresenter.ts";
 
 const LazyWorkspaceAccountMenu = lazy(() =>
   import("./WorkspaceAccountMenu").then(({ WorkspaceAccountMenu }) => ({
@@ -154,6 +158,9 @@ export function StandaloneAgentWindow({
   const { i18n } = useTranslation();
   const agentsService = useService(IAgentsService);
   const workspaceAppSurfaceHost = useService(IWorkspaceAppSurfaceHost);
+  const workspaceFilePreviewSurfaceHost = useService(
+    IWorkspaceFilePreviewSurfaceHost
+  );
   const workspaceFileManagerService = useService(IWorkspaceFileManagerService);
   const { service: workspaceSettingsService } = useWorkspaceSettingsService();
   const workspaceId = workspace.id;
@@ -350,24 +357,14 @@ export function StandaloneAgentWindow({
     [openFileInSidebar]
   );
   useEffect(() => {
-    workspaceFileManagerService.setCanvasFilePreviewLauncher(
+    return workspaceFilePreviewSurfaceHost.registerPresenter(
       workspaceId,
-      async (target) => {
-        await desktopApi.host.files.openFile(workspaceId, target.path);
-        return true;
-      }
+      createStandaloneAgentWorkspaceFilePreviewPresenter({
+        hostFilesApi: desktopApi.host.files,
+        workspaceId
+      })
     );
-    workspaceFileManagerService.setPreviewUnsupportedFallbackNotificationEnabled(
-      workspaceId,
-      false
-    );
-    return () => {
-      workspaceFileManagerService.setCanvasFilePreviewLauncher(
-        workspaceId,
-        null
-      );
-    };
-  }, [desktopApi.host.files, workspaceFileManagerService, workspaceId]);
+  }, [desktopApi.host.files, workspaceFilePreviewSurfaceHost, workspaceId]);
   useEffect(() => {
     return workspaceAppSurfaceHost.registerPresenter(
       createStandaloneAgentWorkspaceAppSurfacePresenter({

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.test.ts
@@ -25,3 +25,11 @@ test("workbench app presenter registration is independent from App Center snapsh
     /useEffect\(\(\) => \{\s*if \(!workbenchHost\)[\s\S]*?workspaceAppSurfaceHost\.registerPresenter\([\s\S]*?\[workbenchHost, state\.workspace\.id, workspaceAppSurfaceHost\]/
   );
 });
+
+test("workbench file preview presentation is registered through the surface host", () => {
+  assert.match(
+    source,
+    /workspaceFilePreviewSurfaceHost\.registerPresenter\([\s\S]*?createWorkbenchWorkspaceFilePreviewPresenter\(\{ host: workbenchHost \}\)[\s\S]*?\[state\.workspace\.id, workbenchHost, workspaceFilePreviewSurfaceHost\]/
+  );
+  assert.doesNotMatch(source, /setCanvasFilePreviewLauncher/);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
@@ -33,6 +33,7 @@ import { IReporterService } from "@renderer/features/analytics";
 import { IAgentsService } from "@renderer/features/workspace-agent/services/agentsService.interface.ts";
 import { useDesktopPreferencesService } from "@renderer/features/desktop-preferences/ui/useDesktopPreferencesService";
 import { useWorkspaceFileManagerService } from "@renderer/features/workspace-file-manager/ui/useWorkspaceFileManagerService";
+import { IWorkspaceFilePreviewSurfaceHost } from "@renderer/features/workspace-file-manager";
 import { useTranslation } from "@renderer/i18n";
 import { createWorkspaceWorkbenchDesktopI18nRuntime } from "@shared/i18n";
 import type {
@@ -67,6 +68,7 @@ import { renderWorkspaceFilesNodeBody } from "./WorkspaceFilesNodeBody";
 import { useWorkspaceSettingsService } from "./useWorkspaceSettingsService";
 import { useWorkspaceWorkbenchHostService } from "./useWorkspaceWorkbenchHostService";
 import { createWorkbenchWorkspaceAppSurfacePresenter } from "../services/workbenchWorkspaceAppSurfacePresenter.ts";
+import { createWorkbenchWorkspaceFilePreviewPresenter } from "../services/workbenchWorkspaceFilePreviewPresenter.ts";
 
 export interface WorkspaceWorkbenchShellRuntime {
   appI18n: I18nRuntime<string>;
@@ -142,6 +144,9 @@ export function useWorkspaceWorkbenchShellRuntime({
   const { service: workspaceSettingsService } = useWorkspaceSettingsService();
   const agentsService = useService(IAgentsService);
   const workspaceAppSurfaceHost = useService(IWorkspaceAppSurfaceHost);
+  const workspaceFilePreviewSurfaceHost = useService(
+    IWorkspaceFilePreviewSurfaceHost
+  );
   const workspaceFileManagerService = useWorkspaceFileManagerService();
   const workbenchHostService = useWorkspaceWorkbenchHostService();
   const comingSoonAgentProviders = useMemo<readonly AgentGUIProvider[]>(
@@ -365,22 +370,14 @@ export function useWorkspaceWorkbenchShellRuntime({
   }, [shellRuntimeController.dispose]);
 
   useEffect(() => {
-    workspaceFileManagerService.setCanvasFilePreviewLauncher(
+    if (!workbenchHost) {
+      return;
+    }
+    return workspaceFilePreviewSurfaceHost.registerPresenter(
       state.workspace.id,
-      workbenchHost
-        ? async (target) =>
-            (await workbenchHost.launchNode(
-              createWorkspaceFilePreviewLaunchRequest(target)
-            )) !== null
-        : null
+      createWorkbenchWorkspaceFilePreviewPresenter({ host: workbenchHost })
     );
-    return () => {
-      workspaceFileManagerService.setCanvasFilePreviewLauncher(
-        state.workspace.id,
-        null
-      );
-    };
-  }, [state.workspace.id, workbenchHost, workspaceFileManagerService]);
+  }, [state.workspace.id, workbenchHost, workspaceFilePreviewSurfaceHost]);
 
   useEffect(() => {
     if (!workbenchHost) {

--- a/docs/architecture/desktop-windows.md
+++ b/docs/architecture/desktop-windows.md
@@ -191,6 +191,23 @@ Agent-only shell, only the latest attempt whose App is still selected may report
 successful presentation; stale completions cannot claim success for a newer or
 cleared inline selection.
 
+Workspace file previews use the same ownership direction without sharing the
+App Center's attempt protocol. File Manager owns file activation, preview-kind
+resolution, system fallback, and opened-file reporting. A feature-owned file
+preview surface host routes the placement decision by workspace. The OS shell
+registers a presenter that launches the matching Workbench preview Node; the
+standalone Agent shell registers a presenter that opens the file through the
+desktop system host. Unsupported-preview notification policy belongs to that
+presenter registration, so disposing the Agent shell restores the default OS
+policy automatically. Registrations use identity-checked cleanup, preventing an
+old Shell effect cleanup from removing a newer presenter. A presentation started
+under one registration may still report success after that registration is
+replaced or disposed if its presenter eventually completes successfully. Unlike
+App Center preparation, it has no reversible pending attempt, and reporting
+failure would trigger a duplicate system fallback. When presentation fails, its
+fallback notification policy also comes from the registration that started the
+attempt, rather than a replacement registered while the attempt was in flight.
+
 The Agent-only contribution keeps the catalog and one app-specific Browser Node
 for every opened app mounted for the renderer lifetime. The back action clears
 only the selection, marks every retained Browser Node hidden, and reveals the

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -63,6 +63,7 @@ App Center, workspace-app lifecycle, App Factory, file references, and File Mana
 - [Workspace app uninstall fails on cached manifest validation](./workspace-apps-files.md#workspace-app-uninstall-fails-on-cached-manifest-validation)
 - [Workspace app update reopens the old dock window](./workspace-apps-files.md#workspace-app-update-reopens-the-old-dock-window)
 - [Agent inline app opening leaks into the OS App Center](./workspace-apps-files.md#agent-inline-app-opening-leaks-into-the-os-app-center)
+- [Agent file preview behavior leaks into the OS shell](./workspace-apps-files.md#agent-file-preview-behavior-leaks-into-the-os-shell)
 - [Load unpacked project roots with source manifests](./workspace-apps-files.md#load-unpacked-project-roots-with-source-manifests)
 - [Agent GUI app mentions show unavailable workspace apps](./workspace-apps-files.md#agent-gui-app-mentions-show-unavailable-workspace-apps)
 - [Agent generated files under system temp do not open](./workspace-apps-files.md#agent-generated-files-under-system-temp-do-not-open)

--- a/docs/conventions/troubleshooting/workspace-apps-files.md
+++ b/docs/conventions/troubleshooting/workspace-apps-files.md
@@ -155,6 +155,38 @@
   [workbenchWorkspaceAppSurfacePresenter.ts](../../../apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchWorkspaceAppSurfacePresenter.ts)
   [standaloneAgentWorkspaceAppSurfacePresenter.ts](../../../apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentWorkspaceAppSurfacePresenter.ts)
 
+### Agent file preview behavior leaks into the OS shell
+
+- Symptom:
+  Opening a previewable file in the OS shell uses the system default app instead
+  of creating or focusing a Workbench preview Node, or unsupported-preview
+  notifications remain suppressed after leaving the standalone Agent shell.
+- Quick checks:
+  Confirm the renderer window registered one file preview presenter for the
+  workspace: Workbench in the OS shell or standalone Agent in the Agent shell.
+  Search shared File Manager code for callback setters or direct Workbench and
+  system-host presentation calls.
+- Root cause:
+  File activation is feature behavior, but preview placement and unsupported
+  fallback notification policy are Shell behavior. Storing either as mutable
+  File Manager mode state lets one Shell overwrite behavior used by another;
+  asymmetric effect cleanup can leave the policy behind after unmount.
+- Fix:
+  Keep activation and fallback orchestration in File Manager, route preview
+  placement through the feature-owned workspace file preview surface host, and
+  register separate Workbench and standalone Agent presenters. Store fallback
+  notification policy on the presenter registration and use identity-checked
+  disposal so removing an old registration cannot affect a replacement.
+- Validation:
+  Run the file preview surface host and both presenter tests. Verify the OS
+  presenter calls `host.launchNode`, the Agent presenter calls the desktop file
+  host, absent presenters preserve system fallback, workspace registrations stay
+  isolated, and disposing the Agent presenter restores fallback notifications.
+- References:
+  [workspaceFilePreviewSurfaceHost.interface.ts](../../../apps/desktop/src/renderer/src/features/workspace-file-manager/services/workspaceFilePreviewSurfaceHost.interface.ts)
+  [workbenchWorkspaceFilePreviewPresenter.ts](../../../apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchWorkspaceFilePreviewPresenter.ts)
+  [standaloneAgentWorkspaceFilePreviewPresenter.ts](../../../apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentWorkspaceFilePreviewPresenter.ts)
+
 ### Load unpacked project roots with source manifests
 
 - Symptom:


### PR DESCRIPTION
## Summary

- route File Preview placement through a feature-owned, workspace-scoped surface host
- register separate Workbench and standalone Agent presenters so OS previews open nodes while Agent previews use the system host
- bind unsupported-fallback notification policy to the presentation registration that started each activation
- remove mutable File Manager shell-mode callback setters and document the ownership rule

## Verification

- focused File Preview and shell wiring tests: 46 passed
- pnpm lint:ts
- pnpm --filter @tutti-os/desktop typecheck
- pnpm check:renderer-boundaries
- pnpm --filter @tutti-os/desktop build
- pnpm check:changed --tail-lines 100
- pre-push pnpm check:full: 18 tasks passed
- architecture review and post-fix reviewer verification: no remaining P0-P3 findings

## Fix Scope Justification

- Root cause: File Manager stored mutable shell callbacks and notification mode state. That let Agent presentation policy affect OS behavior, and an asynchronous failure could read fallback policy from a replacement presenter instead of the registration that started the activation.
- Why can this not be fixed at a lower layer? Preview placement is renderer-shell policy: Workbench owns node launch while standalone Agent owns system-file presentation. The shared File Manager layer can orchestrate activation and fallback, but it cannot choose a shell surface without reintroducing mode coupling.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: git commit -s.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates file preview placement behind a workspace-scoped surface host with shell-specific presenters. Fixes Agent policy leaking into the OS shell and keeps fallback notifications consistent.

- **Bug Fixes**
  - OS shell previews open Workbench nodes; standalone Agent uses the system host.
  - Fallback notification policy sticks to the activation’s presenter; replacements can’t change in-flight behavior.
  - Disposing the Agent shell restores the default OS notification policy.
  - Identity-checked cleanup prevents old effects from removing newer presenters.

- **Refactors**
  - Introduced `IWorkspaceFilePreviewSurfaceHost` as a DI service with per-workspace routing and a `present(...)` result that includes `unsupportedFallbackNotification`.
  - Registered the host in the service registry; Workbench and standalone Agent UIs now register presenters through it.
  - File Manager adapter consults the surface host for fallback policy and presentation result; removed `setCanvasFilePreviewLauncher` and `setPreviewUnsupportedFallbackNotificationEnabled` from `IWorkspaceFileManagerService`.

<sup>Written for commit 3627eafce9d80586b79450418990ad058acd6ef8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

