### PR TITLE
docs(workbench): mark host extraction ready

### DIFF
--- a/docs/conventions/npm-package-release.md
+++ b/docs/conventions/npm-package-release.md
@@ -16,19 +16,24 @@ automation are updated together.
 The current fixed release group is:
 
 ```text
-@tutti-os/agent-activity-core
-@tutti-os/agent-gui
-@tutti-os/browser-node
-@tutti-os/workspace-file-reference
-@tutti-os/workspace-file-preview
+@tutti-os/event-stream-core
 @tutti-os/workspace-file-manager
+@tutti-os/workspace-file-reference
 @tutti-os/workspace-issue-manager
 @tutti-os/workspace-user-project
 @tutti-os/workspace-app-center
+@tutti-os/workspace-external-core
 @tutti-os/workspace-terminal
+@tutti-os/agent-activity-core
+@tutti-os/agent-gui
+@tutti-os/claude-sdk-sidecar
+@tutti-os/browser-node
+@tutti-os/workspace-file-preview
 @tutti-os/workbench-snapshot
+@tutti-os/workbench-launchpad
 @tutti-os/workbench-surface
 @tutti-os/app-release-tools
+@tutti-os/auth-bridge
 @tutti-os/ui-i18n-runtime
 @tutti-os/ui-notifications
 @tutti-os/ui-rich-text

--- a/docs/specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md
+++ b/docs/specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md
@@ -1,7 +1,8 @@
 # Workbench Host Kernel: Phase 0 To Stable
 
 - Date: 2026-07-11
-- Status: Active; ADR accepted, PRs 1–3 merged, and PRs 4–6 approved
+- Status: Active; ADR accepted, PRs 1–3 and pre-extraction hardening merged,
+  PRs 4–6 approved, and PR 4 ready to start
 - Architecture decision:
   [ADR 0009](../adr/0009-cross-product-workbench-host-kernel.md)
 - Scope: Tutti-first implementation, npm beta, read-only/downstream TSH
@@ -40,6 +41,7 @@ Approval recorded on 2026-07-11 remains deliberately incremental:
 | PR 1 characterization fixtures/tests        | Merged in #1043                          |
 | PR 2 private coordinator/session            | Merged in #1044                          |
 | PR 3 Product Profile/Ports/adapters split   | Merged in #1050                          |
+| Pre-extraction writer/save hardening        | Merged in #1184                          |
 | Public package extraction and Tutti cutover | Approved after PR 3                      |
 | npm beta publication                        | Approved after PRs 3–5 and validation    |
 | TSH renderer DI/host migration              | Deferred; no TSH changes in current work |
@@ -104,6 +106,28 @@ package API review:
 PR 3 does not create a package, change public Workbench or daemon contracts,
 modify TSH, or publish the approved beta. Those remain the independent PR 4–6
 steps.
+
+### Pre-extraction hardening evidence
+
+The durable-writer and stale-save ownership stop condition was resolved before
+package extraction in #1184:
+
+- Electron main enforces one durable OS workspace window per `workspaceId`,
+  coalesces concurrent creation, and restores or focuses the registered owner;
+- standalone Agent renderer composition uses a read-seeded, window-local
+  repository and issues no Workbench PUT for host, wallpaper, or onboarding
+  writes;
+- one workspace repository serializes load and save invocations while keeping
+  different workspaces independent;
+- product metadata merges from the latest serialized cache at write execution
+  time; and
+- the surface ignores stale save completions from an older lifecycle or an
+  older successful save sequence.
+
+Focused coordinator, repository, composition-root, Electron main, and surface
+tests cover these guarantees. PR 4 may therefore proceed without another
+durable-writer hardening phase; the same cases remain required product
+conformance evidence for package beta.
 
 ## Baseline evidence
 
@@ -595,6 +619,13 @@ The TSH PR must report:
 - Keep concurrent distinct partitions available internally, but do not promise
   multi-view UX in the first public API.
 
+## Resolved beta API choice
+
+`@tutti-os/workbench-host/conformance` is a public development/test subpath for
+beta. It lets the external TSH repository run the exact conformance cases from
+the published package without a filesystem link or copied source. The subpath
+is not an application runtime entrypoint.
+
 ## Open questions requiring an approval or measured evidence
 
 1. **Tutti user partition:** is `workspaceId` sufficient under the current local
@@ -604,14 +635,12 @@ The TSH PR must report:
 2. **Product metadata:** should wallpaper/onboarding metadata remain in Tutti's
    repository adapter or move to a dedicated metadata contribution?
    Recommendation: preserve current adapter behavior through beta.
-3. **Conformance subpath:** public `./conformance` versus repository-only shared
-   test package? Recommendation: public dev/test subpath so the external TSH
-   repository runs the exact suite shipped with the beta.
 
 ## Approval gates
 
 ADR 0009 is accepted; PR 1 merged as #1043, PR 2 merged as #1044, and PR 3
-merged as #1050. PRs 4–5 and the fixed-group beta in PR 6 are approved in
-sequence. TSH integration is deferred until later business adoption and remains
-outside the current Tutti implementation scope. Stable publication remains
-separately unapproved.
+merged as #1050. Pre-extraction durable-writer and stale-save hardening merged
+as #1184. PRs 4–5 and the fixed-group beta in PR 6 are approved in sequence,
+and PR 4 is ready to start. TSH integration is deferred until later business
+adoption and remains outside the current Tutti implementation scope. Stable
+publication remains separately unapproved.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -13,4 +13,4 @@ There are currently three active specs:
 
 - [Agent Provider Status Read/Detect Split](./2026-06-28-agent-status-read-detect-split-design.md): pending review.
 - [Agent Extension Package Design](./2026-07-14-agent-extension-package-design.md): pending architecture and implementation approval.
-- [Workbench Host Kernel: Phase 0 To Stable](./2026-07-11-workbench-host-kernel-phase-0-to-stable.md): pending architecture and implementation approval.
+- [Workbench Host Kernel: Phase 0 To Stable](./2026-07-11-workbench-host-kernel-phase-0-to-stable.md): ADR accepted, private proof and pre-extraction hardening merged, and public package extraction ready to start.


### PR DESCRIPTION
## Summary

- record the merged durable-writer and stale-save hardening from #1184
- mark Workbench host package extraction as ready to start
- resolve the beta conformance contract as a public development/test subpath
- reconcile the documented fixed npm release roster with Changesets configuration

## Validation

- pnpm exec prettier --check --config packages/configs/prettier/base.mjs docs/specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md docs/specs/README.md docs/conventions/npm-package-release.md
- pnpm check:changed -- --tail-lines 80
- pnpm check:full (pre-push)
- release roster comparison against .changeset/config.json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Workbench Host Kernel docs to record the merged durable-writer/stale-save hardening, mark PR 4 (public package extraction) ready to start, and define the beta conformance subpath `@tutti-os/workbench-host/conformance`. Also aligns the fixed npm release roster with `.changeset/config.json` and updates the specs README status.

<sup>Written for commit da3774e96bc83e754e429aff3f24b1458e464d04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

