### PR TITLE
refactor(workspace-workbench): isolate issue manager shell presentation

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceScopedPresenterRegistry.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceScopedPresenterRegistry.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { WorkspaceScopedPresenterRegistry } from "./workspaceScopedPresenterRegistry.ts";
+
+test("workspace-scoped presenter registry isolates normalized workspace registrations", () => {
+  const registry = new WorkspaceScopedPresenterRegistry<{ id: string }>();
+  const first = { id: "first" };
+  const second = { id: "second" };
+
+  registry.register(" workspace-1 ", first);
+  registry.register("workspace-2", second);
+
+  assert.equal(registry.get("workspace-1"), first);
+  assert.equal(registry.get(" workspace-2 "), second);
+  assert.equal(registry.get("workspace-3"), undefined);
+});
+
+test("workspace-scoped presenter registry ignores empty workspace registrations", () => {
+  const registry = new WorkspaceScopedPresenterRegistry<{ id: string }>();
+  const dispose = registry.register(" ", { id: "ignored" });
+
+  dispose();
+
+  assert.equal(registry.get(" "), undefined);
+});
+
+test("workspace-scoped presenter registry keeps a replacement after stale disposal", () => {
+  const registry = new WorkspaceScopedPresenterRegistry<{ id: string }>();
+  const disposeFirst = registry.register("workspace-1", { id: "first" });
+  const replacement = { id: "replacement" };
+  registry.register("workspace-1", replacement);
+
+  disposeFirst();
+
+  assert.equal(registry.get("workspace-1"), replacement);
+});
+
+test("workspace-scoped presenter registry distinguishes repeated registrations", () => {
+  const registry = new WorkspaceScopedPresenterRegistry<{ id: string }>();
+  const presenter = { id: "shared" };
+  const disposeFirst = registry.register("workspace-1", presenter);
+  registry.register("workspace-1", presenter);
+
+  disposeFirst();
+
+  assert.equal(registry.get("workspace-1"), presenter);
+});
+
+test("workspace-scoped presenter registry removes the active registration", () => {
+  const registry = new WorkspaceScopedPresenterRegistry<{ id: string }>();
+  const dispose = registry.register("workspace-1", { id: "presenter" });
+
+  dispose();
+
+  assert.equal(registry.get("workspace-1"), undefined);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceScopedPresenterRegistry.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceScopedPresenterRegistry.ts
@@ -1,0 +1,39 @@
+interface WorkspaceScopedPresenterRegistration<TPresenter> {
+  presenter: TPresenter;
+}
+
+export class WorkspaceScopedPresenterRegistry<TPresenter> {
+  private readonly registrations = new Map<
+    string,
+    WorkspaceScopedPresenterRegistration<TPresenter>
+  >();
+
+  get(workspaceId: string): TPresenter | undefined {
+    const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+    if (!normalizedWorkspaceId) {
+      return undefined;
+    }
+    return this.registrations.get(normalizedWorkspaceId)?.presenter;
+  }
+
+  register(workspaceId: string, presenter: TPresenter): () => void {
+    const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+    if (!normalizedWorkspaceId) {
+      return noop;
+    }
+
+    const registration = { presenter };
+    this.registrations.set(normalizedWorkspaceId, registration);
+    return () => {
+      if (this.registrations.get(normalizedWorkspaceId) === registration) {
+        this.registrations.delete(normalizedWorkspaceId);
+      }
+    };
+  }
+}
+
+function normalizeWorkspaceId(workspaceId: string): string {
+  return workspaceId.trim();
+}
+
+function noop(): void {}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentWorkspaceIssueManagerPresenter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentWorkspaceIssueManagerPresenter.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { StandaloneAgentIssueManagerOpenRequest } from "./standaloneAgentIssueManagerLaunch.ts";
+import { createStandaloneAgentWorkspaceIssueManagerPresenter } from "./standaloneAgentWorkspaceIssueManagerPresenter.ts";
+
+test("standalone Agent issue-manager presenter opens Tasks inline with activation", () => {
+  const requests: StandaloneAgentIssueManagerOpenRequest[] = [];
+  const presenter = createStandaloneAgentWorkspaceIssueManagerPresenter({
+    open: (request) => requests.push(request)
+  });
+
+  assert.equal(
+    presenter.present({
+      issueId: "issue-1",
+      taskId: "task-1",
+      workspaceId: "workspace-1"
+    }),
+    true
+  );
+  assert.deepEqual(requests, [
+    {
+      activation: {
+        payload: { issueId: "issue-1", taskId: "task-1" },
+        sequence: 1,
+        type: "open-workspace-issue"
+      },
+      requestID: "standalone-agent-issue-1"
+    }
+  ]);
+});
+
+test("standalone Agent issue-manager presenter sequences repeated inline opens", () => {
+  const requestIDs: string[] = [];
+  const presenter = createStandaloneAgentWorkspaceIssueManagerPresenter({
+    open: (request) => requestIDs.push(request.requestID)
+  });
+
+  presenter.present({ workspaceId: "workspace-1" });
+  presenter.present({ workspaceId: "workspace-1" });
+
+  assert.deepEqual(requestIDs, [
+    "standalone-agent-issue-1",
+    "standalone-agent-issue-2"
+  ]);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentWorkspaceIssueManagerPresenter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentWorkspaceIssueManagerPresenter.ts
@@ -1,0 +1,19 @@
+import {
+  createStandaloneAgentIssueManagerOpenRequest,
+  type StandaloneAgentIssueManagerOpenRequest
+} from "./standaloneAgentIssueManagerLaunch.ts";
+import type { WorkspaceIssueManagerLaunchPresenter } from "./workspaceIssueManagerLaunchCoordinator.ts";
+
+export function createStandaloneAgentWorkspaceIssueManagerPresenter(input: {
+  open(request: StandaloneAgentIssueManagerOpenRequest): void;
+}): WorkspaceIssueManagerLaunchPresenter {
+  let sequence = 0;
+  return {
+    present(request) {
+      input.open(
+        createStandaloneAgentIssueManagerOpenRequest(request, ++sequence)
+      );
+      return true;
+    }
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchWorkspaceIssueManagerPresenter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchWorkspaceIssueManagerPresenter.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { defaultIssueManagerWorkbenchTypeId } from "@tutti-os/workspace-issue-manager/workbench/constants";
+import type { WorkbenchHostHandle } from "@tutti-os/workbench-surface";
+import { createWorkbenchWorkspaceIssueManagerPresenter } from "./workbenchWorkspaceIssueManagerPresenter.ts";
+
+test("workbench issue-manager presenter launches and activates a workbench node", async () => {
+  const launches: unknown[] = [];
+  const activations: unknown[] = [];
+  const presenter = createWorkbenchWorkspaceIssueManagerPresenter({
+    host: {
+      activateNode: (...args: unknown[]) => {
+        activations.push(args);
+      },
+      launchNode: async (request: unknown) => {
+        launches.push(request);
+        return "issue-manager-node";
+      }
+    } as unknown as WorkbenchHostHandle
+  });
+
+  assert.equal(
+    await presenter.present({
+      issueId: "issue-1",
+      mode: "execute",
+      outputDir: "issues/issue-1/runs/run-1",
+      runId: "run-1",
+      taskId: "task-1",
+      topicId: "topic-1",
+      workspaceId: "workspace-1"
+    }),
+    true
+  );
+  assert.deepEqual(launches, [
+    {
+      launchSource: "agent_command",
+      reason: "host",
+      typeId: defaultIssueManagerWorkbenchTypeId
+    }
+  ]);
+  assert.deepEqual(activations, [
+    [
+      { nodeId: "issue-manager-node" },
+      {
+        payload: {
+          issueId: "issue-1",
+          mode: "execute",
+          outputDir: "issues/issue-1/runs/run-1",
+          runId: "run-1",
+          taskId: "task-1",
+          topicId: "topic-1"
+        },
+        type: "open-workspace-issue"
+      }
+    ]
+  ]);
+});
+
+test("workbench issue-manager presenter opens the surface without activation", async () => {
+  let activationCount = 0;
+  const presenter = createWorkbenchWorkspaceIssueManagerPresenter({
+    host: {
+      activateNode: () => {
+        activationCount += 1;
+      },
+      launchNode: async () => "issue-manager-node"
+    } as unknown as WorkbenchHostHandle
+  });
+
+  assert.equal(await presenter.present({ workspaceId: "workspace-1" }), true);
+  assert.equal(activationCount, 0);
+});
+
+test("workbench issue-manager presenter reports a rejected launch", async () => {
+  const presenter = createWorkbenchWorkspaceIssueManagerPresenter({
+    host: {
+      activateNode: () => undefined,
+      launchNode: async () => null
+    } as unknown as WorkbenchHostHandle
+  });
+
+  assert.equal(await presenter.present({ workspaceId: "workspace-1" }), false);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchWorkspaceIssueManagerPresenter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchWorkspaceIssueManagerPresenter.ts
@@ -1,0 +1,55 @@
+import type { IssueManagerOpenActivationPayload } from "@tutti-os/workspace-issue-manager/workbench";
+import { defaultIssueManagerWorkbenchTypeId } from "@tutti-os/workspace-issue-manager/workbench/constants";
+import type { WorkbenchHostHandle } from "@tutti-os/workbench-surface";
+import type {
+  WorkspaceIssueManagerLaunchPresenter,
+  WorkspaceIssueManagerLaunchRequest
+} from "./workspaceIssueManagerLaunchCoordinator.ts";
+
+// Value mirror of the stable Issue Manager activation protocol. Keeping it
+// local lets the pure presenter tests avoid loading the React workbench barrel.
+const workbenchIssueManagerOpenActivationType = "open-workspace-issue";
+
+export function createWorkbenchWorkspaceIssueManagerPresenter(input: {
+  host: WorkbenchHostHandle;
+}): WorkspaceIssueManagerLaunchPresenter {
+  return {
+    async present(request) {
+      return openWorkspaceIssueManagerNode(input.host, request);
+    }
+  };
+}
+
+async function openWorkspaceIssueManagerNode(
+  host: WorkbenchHostHandle,
+  request: WorkspaceIssueManagerLaunchRequest
+): Promise<boolean> {
+  const nodeId = await host.launchNode({
+    launchSource: "agent_command",
+    reason: "host",
+    typeId: defaultIssueManagerWorkbenchTypeId
+  });
+  if (!nodeId) {
+    return false;
+  }
+  if (!request.issueId) {
+    return true;
+  }
+
+  const payload: IssueManagerOpenActivationPayload = {
+    issueId: request.issueId,
+    ...(request.mode ? { mode: request.mode } : {}),
+    ...(request.outputDir ? { outputDir: request.outputDir } : {}),
+    ...(request.runId ? { runId: request.runId } : {}),
+    ...(request.taskId ? { taskId: request.taskId } : {}),
+    ...(request.topicId ? { topicId: request.topicId } : {})
+  };
+  host.activateNode(
+    { nodeId },
+    {
+      payload,
+      type: workbenchIssueManagerOpenActivationType
+    }
+  );
+  return true;
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceIssueManagerLaunchCoordinator.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceIssueManagerLaunchCoordinator.test.ts
@@ -1,18 +1,20 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  registerWorkspaceIssueManagerLaunchHandler,
+  registerWorkspaceIssueManagerLaunchPresenter,
   requestWorkspaceIssueManagerLaunch,
   type WorkspaceIssueManagerLaunchRequest
 } from "./workspaceIssueManagerLaunchCoordinator.ts";
 
 test("workspace issue-manager launch coordinator dispatches normalized requests", async () => {
   const requests: WorkspaceIssueManagerLaunchRequest[] = [];
-  const dispose = registerWorkspaceIssueManagerLaunchHandler(
+  const dispose = registerWorkspaceIssueManagerLaunchPresenter(
     " workspace-1 ",
-    (request) => {
-      requests.push(request);
-      return true;
+    {
+      present(request) {
+        requests.push(request);
+        return true;
+      }
     }
   );
 
@@ -51,13 +53,12 @@ test("workspace issue-manager launch coordinator dispatches normalized requests"
 
 test("workspace issue-manager launch coordinator dispatches workspace-only requests", async () => {
   const requests: WorkspaceIssueManagerLaunchRequest[] = [];
-  const dispose = registerWorkspaceIssueManagerLaunchHandler(
-    "workspace-1",
-    (request) => {
+  const dispose = registerWorkspaceIssueManagerLaunchPresenter("workspace-1", {
+    present(request) {
       requests.push(request);
       return true;
     }
-  );
+  });
 
   assert.equal(
     await requestWorkspaceIssueManagerLaunch({
@@ -75,10 +76,12 @@ test("workspace issue-manager launch coordinator dispatches workspace-only reque
 });
 
 test("workspace issue-manager launch coordinator rejects incomplete requests", async () => {
-  const dispose = registerWorkspaceIssueManagerLaunchHandler(
+  const dispose = registerWorkspaceIssueManagerLaunchPresenter(
     "workspace-issue-manager",
-    () => {
-      throw new Error("incomplete requests should not launch");
+    {
+      present() {
+        throw new Error("incomplete requests should not launch");
+      }
     }
   );
 
@@ -90,4 +93,78 @@ test("workspace issue-manager launch coordinator rejects incomplete requests", a
     false
   );
   dispose();
+});
+
+test("workspace issue-manager launch coordinator isolates workspace presenters", async () => {
+  const calls: string[] = [];
+  const disposeFirst = registerWorkspaceIssueManagerLaunchPresenter(
+    "workspace-1",
+    {
+      present() {
+        calls.push("workspace-1");
+        return true;
+      }
+    }
+  );
+  const disposeSecond = registerWorkspaceIssueManagerLaunchPresenter(
+    "workspace-2",
+    {
+      present() {
+        calls.push("workspace-2");
+        return true;
+      }
+    }
+  );
+
+  assert.equal(
+    await requestWorkspaceIssueManagerLaunch({ workspaceId: "workspace-2" }),
+    true
+  );
+  assert.deepEqual(calls, ["workspace-2"]);
+
+  disposeFirst();
+  disposeSecond();
+});
+
+test("workspace issue-manager launch coordinator keeps replacement after stale disposal", async () => {
+  const disposeFirst = registerWorkspaceIssueManagerLaunchPresenter(
+    "workspace-replaced",
+    { present: () => false }
+  );
+  const disposeReplacement = registerWorkspaceIssueManagerLaunchPresenter(
+    "workspace-replaced",
+    { present: () => true }
+  );
+
+  disposeFirst();
+
+  assert.equal(
+    await requestWorkspaceIssueManagerLaunch({
+      workspaceId: "workspace-replaced"
+    }),
+    true
+  );
+  disposeReplacement();
+});
+
+test("workspace issue-manager launch coordinator distinguishes repeated presenter registrations", async () => {
+  const presenter = { present: () => true };
+  const disposeFirst = registerWorkspaceIssueManagerLaunchPresenter(
+    "workspace-repeated",
+    presenter
+  );
+  const disposeReplacement = registerWorkspaceIssueManagerLaunchPresenter(
+    "workspace-repeated",
+    presenter
+  );
+
+  disposeFirst();
+
+  assert.equal(
+    await requestWorkspaceIssueManagerLaunch({
+      workspaceId: "workspace-repeated"
+    }),
+    true
+  );
+  disposeReplacement();
 });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceIssueManagerLaunchCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceIssueManagerLaunchCoordinator.ts
@@ -1,3 +1,5 @@
+import { WorkspaceScopedPresenterRegistry } from "./internal/workspaceScopedPresenterRegistry.ts";
+
 export interface WorkspaceIssueManagerLaunchRequest {
   issueId?: string | null;
   mode?: "breakdown" | "execute";
@@ -8,30 +10,20 @@ export interface WorkspaceIssueManagerLaunchRequest {
   workspaceId: string;
 }
 
-export type WorkspaceIssueManagerLaunchHandler = (
-  request: WorkspaceIssueManagerLaunchRequest
-) => Promise<boolean> | boolean;
+export interface WorkspaceIssueManagerLaunchPresenter {
+  present(
+    request: WorkspaceIssueManagerLaunchRequest
+  ): Promise<boolean> | boolean;
+}
 
-const launchHandlersByWorkspaceId = new Map<
-  string,
-  WorkspaceIssueManagerLaunchHandler
->();
+const presenters =
+  new WorkspaceScopedPresenterRegistry<WorkspaceIssueManagerLaunchPresenter>();
 
-export function registerWorkspaceIssueManagerLaunchHandler(
+export function registerWorkspaceIssueManagerLaunchPresenter(
   workspaceId: string,
-  handler: WorkspaceIssueManagerLaunchHandler
+  presenter: WorkspaceIssueManagerLaunchPresenter
 ): () => void {
-  const normalizedWorkspaceId = workspaceId.trim();
-  if (!normalizedWorkspaceId) {
-    return noop;
-  }
-
-  launchHandlersByWorkspaceId.set(normalizedWorkspaceId, handler);
-  return () => {
-    if (launchHandlersByWorkspaceId.get(normalizedWorkspaceId) === handler) {
-      launchHandlersByWorkspaceId.delete(normalizedWorkspaceId);
-    }
-  };
+  return presenters.register(workspaceId, presenter);
 }
 
 export async function requestWorkspaceIssueManagerLaunch(
@@ -42,12 +34,12 @@ export async function requestWorkspaceIssueManagerLaunch(
     return false;
   }
 
-  const handler = launchHandlersByWorkspaceId.get(normalized.workspaceId);
-  if (!handler) {
+  const presenter = presenters.get(normalized.workspaceId);
+  if (!presenter) {
     return false;
   }
 
-  return handler(normalized);
+  return presenter.present(normalized);
 }
 
 function normalizeWorkspaceIssueManagerLaunchRequest(
@@ -88,5 +80,3 @@ function normalizeOptionalString(
   const normalized = value?.trim() || "";
   return normalized || undefined;
 }
-
-function noop(): void {}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
@@ -128,7 +128,11 @@ test("standalone Agent handles task and app Agent launch requests", () => {
   );
   assert.match(
     standaloneLaunchRoutingSource,
-    /registerWorkspaceIssueManagerLaunchHandler\(workspaceId, \(request\) => \{[\s\S]*?createStandaloneAgentIssueManagerOpenRequest/
+    /const issueManagerPresenter = useMemo\([\s\S]*?createStandaloneAgentWorkspaceIssueManagerPresenter\(\{[\s\S]*?open: setIssueManagerOpenRequest/
+  );
+  assert.match(
+    standaloneLaunchRoutingSource,
+    /registerWorkspaceIssueManagerLaunchPresenter\([\s\S]*?workspaceId,[\s\S]*?issueManagerPresenter/
   );
   assert.match(
     standaloneWindowSource,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -11,11 +11,7 @@ import type {
   WorkspaceAgentProvider,
   WorkspaceSummary
 } from "@tutti-os/client-tuttid-ts";
-import {
-  defaultIssueManagerWorkbenchTypeId,
-  issueManagerOpenActivationType,
-  type IssueManagerOpenActivationPayload
-} from "@tutti-os/workspace-issue-manager/workbench";
+import { defaultIssueManagerWorkbenchTypeId } from "@tutti-os/workspace-issue-manager/workbench";
 import {
   isEditableShortcutTarget,
   type WorkbenchContribution,
@@ -68,10 +64,8 @@ import {
   type WorkspaceFilesLaunchRequest
 } from "../services/workspaceFilesLaunchCoordinator.ts";
 import { showWorkspaceFileMissingToast } from "../services/workspaceFilesLaunchFeedback.ts";
-import {
-  registerWorkspaceIssueManagerLaunchHandler,
-  type WorkspaceIssueManagerLaunchRequest
-} from "../services/workspaceIssueManagerLaunchCoordinator.ts";
+import { registerWorkspaceIssueManagerLaunchPresenter } from "../services/workspaceIssueManagerLaunchCoordinator.ts";
+import { createWorkbenchWorkspaceIssueManagerPresenter } from "../services/workbenchWorkspaceIssueManagerPresenter.ts";
 import { registerWorkspaceWorkbenchNodeLaunchHandler } from "../services/workspaceWorkbenchNodeLaunchCoordinator.ts";
 import {
   buildGroupChatDeepLinkUrl,
@@ -411,11 +405,9 @@ function ReadyWorkspaceWorkbenchWithSession({
         }
       );
       unregisterIssueManagerLaunchRef.current =
-        registerWorkspaceIssueManagerLaunchHandler(
+        registerWorkspaceIssueManagerLaunchPresenter(
           state.workspace.id,
-          async (request) => {
-            return openWorkspaceIssueManagerNode(host, request);
-          }
+          createWorkbenchWorkspaceIssueManagerPresenter({ host })
         );
       unregisterGroupChatLaunchRef.current = registerGroupChatLaunchHandler(
         state.workspace.id,
@@ -1091,40 +1083,6 @@ async function openGroupChatNode(
         url: deepLinkUrl
       },
       type: "open-url"
-    }
-  );
-  return true;
-}
-
-async function openWorkspaceIssueManagerNode(
-  host: WorkbenchHostHandle,
-  request: WorkspaceIssueManagerLaunchRequest
-): Promise<boolean> {
-  const nodeId = await host.launchNode({
-    launchSource: "agent_command",
-    reason: "host",
-    typeId: defaultIssueManagerWorkbenchTypeId
-  });
-  if (!nodeId) {
-    return false;
-  }
-  if (!request.issueId) {
-    return true;
-  }
-
-  const payload: IssueManagerOpenActivationPayload = {
-    issueId: request.issueId,
-    ...(request.mode ? { mode: request.mode } : {}),
-    ...(request.outputDir ? { outputDir: request.outputDir } : {}),
-    ...(request.runId ? { runId: request.runId } : {}),
-    ...(request.taskId ? { taskId: request.taskId } : {}),
-    ...(request.topicId ? { topicId: request.topicId } : {})
-  };
-  host.activateNode(
-    { nodeId },
-    {
-      payload,
-      type: issueManagerOpenActivationType
     }
   );
   return true;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useStandaloneAgentLaunchRouting.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useStandaloneAgentLaunchRouting.ts
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type Dispatch,
@@ -25,12 +26,10 @@ import {
   type DesktopAgentGUIWorkbenchState
 } from "@renderer/features/workspace-agent/desktopAgentGUINodeState.ts";
 import { handleStandaloneAgentGuiLaunch } from "../services/standaloneAgentGuiLaunchHandler.ts";
+import type { StandaloneAgentIssueManagerOpenRequest } from "../services/standaloneAgentIssueManagerLaunch.ts";
+import { createStandaloneAgentWorkspaceIssueManagerPresenter } from "../services/standaloneAgentWorkspaceIssueManagerPresenter.ts";
 import {
-  createStandaloneAgentIssueManagerOpenRequest,
-  type StandaloneAgentIssueManagerOpenRequest
-} from "../services/standaloneAgentIssueManagerLaunch.ts";
-import {
-  registerWorkspaceIssueManagerLaunchHandler,
+  registerWorkspaceIssueManagerLaunchPresenter,
   requestWorkspaceIssueManagerLaunch
 } from "../services/workspaceIssueManagerLaunchCoordinator.ts";
 
@@ -76,9 +75,15 @@ export function useStandaloneAgentLaunchRouting({
   issueManagerOpenRequest: StandaloneAgentIssueManagerOpenRequest | null;
 } {
   const activationSequenceRef = useRef(1);
-  const issueManagerOpenRequestSequenceRef = useRef(0);
   const [issueManagerOpenRequest, setIssueManagerOpenRequest] =
     useState<StandaloneAgentIssueManagerOpenRequest | null>(null);
+  const issueManagerPresenter = useMemo(
+    () =>
+      createStandaloneAgentWorkspaceIssueManagerPresenter({
+        open: setIssueManagerOpenRequest
+      }),
+    []
+  );
   const handleActivateAgentSession = useCallback(
     (input: {
       agentSessionId: string;
@@ -129,16 +134,11 @@ export function useStandaloneAgentLaunchRouting({
   );
   useEffect(
     () =>
-      registerWorkspaceIssueManagerLaunchHandler(workspaceId, (request) => {
-        setIssueManagerOpenRequest(
-          createStandaloneAgentIssueManagerOpenRequest(
-            request,
-            ++issueManagerOpenRequestSequenceRef.current
-          )
-        );
-        return true;
-      }),
-    [workspaceId]
+      registerWorkspaceIssueManagerLaunchPresenter(
+        workspaceId,
+        issueManagerPresenter
+      ),
+    [issueManagerPresenter, workspaceId]
   );
 
   const handleLinkAction = useCallback<

--- a/docs/architecture/desktop-windows.md
+++ b/docs/architecture/desktop-windows.md
@@ -240,6 +240,13 @@ window with the draft bootstrap intent, while existing-session navigation
 reuses the current Agent-only window unless the caller explicitly requests a
 new one. Issue Manager launches open the Tasks sidebar and forward the standard
 issue activation so the embedded surface selects the requested issue and task.
+Issue Manager placement is selected through a workspace-scoped presenter
+coordinator rather than by mode checks in the request source. The OS shell
+registers a presenter that launches and activates the Workbench Node, while the
+standalone Agent shell registers a presenter that opens the Tasks sidebar
+inline. Presenter registrations use registration identity for cleanup, so an
+old shell disposer cannot remove a newer presenter, including when both
+registrations reuse the same presenter object.
 The OS Files floating window opens wide by default so its location, list, and
 detail columns begin at approximately 26%, 55%, and 19% of the content width;
 each splitter remains user-resizable within its minimum-content constraints.


### PR DESCRIPTION
## Summary

- route Issue Manager launches through workspace-scoped Shell presenters
- keep OS Workbench Node presentation and standalone Agent inline Tasks presentation in separate adapters
- add an identity-safe presenter registry so stale cleanup cannot remove a replacement registration
- document the Issue Manager Shell ownership and lifecycle contract

## Validation

- focused Issue Manager and standalone Agent tests (34 passed)
- pnpm --filter @tutti-os/desktop typecheck
- pnpm check:renderer-boundaries
- pnpm --filter @tutti-os/desktop test (1465 passed, 2 skipped)
- pnpm --filter @tutti-os/desktop build
- pnpm check:changed
- pre-push pnpm check:full

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated Issue Manager launch routing behind workspace-scoped presenters, splitting OS Workbench node launches from standalone Agent inline Tasks. This stabilizes routing per workspace and prevents stale disposers from removing active presenters.

- **Refactors**
  - Introduced a workspace-scoped presenter registry with identity-safe disposal and ID normalization.
  - Replaced handler API with presenters in the launch coordinator; requests call `present()` on the active workspace presenter.
  - Added `createWorkbenchWorkspaceIssueManagerPresenter` for launching and activating `defaultIssueManagerWorkbenchTypeId`.
  - Added `createStandaloneAgentWorkspaceIssueManagerPresenter` for inline Tasks opens with sequenced request IDs.
  - Moved Issue Manager launch logic out of `WorkspaceWorkbench.tsx` and into presenters; updated `useStandaloneAgentLaunchRouting`.
  - Added focused unit tests and expanded existing tests; updated desktop windows architecture docs.

- **Migration**
  - Replace `registerWorkspaceIssueManagerLaunchHandler(...)` with `registerWorkspaceIssueManagerLaunchPresenter(...)`.
  - Use `createWorkbenchWorkspaceIssueManagerPresenter({ host })` in the OS shell and `createStandaloneAgentWorkspaceIssueManagerPresenter({ open })` in the standalone Agent shell.
  - No change to request shape or return semantics.

<sup>Written for commit d4ecbf080133c5765b428d08c0d97735f950db9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

