### PR TITLE
refactor(workbench): complete host package cutover

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkbenchDiagnosticsPort.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkbenchDiagnosticsPort.ts
@@ -1,5 +1,5 @@
 import type { DesktopRuntimeApi } from "@preload/types";
-import type { WorkbenchDiagnosticsPort } from "../workbenchHostPorts.ts";
+import type { WorkbenchDiagnosticsPort } from "@tutti-os/workbench-host";
 
 export function createDesktopWorkbenchDiagnosticsPort(input: {
   readonly runtimeApi: Pick<DesktopRuntimeApi, "logRendererDiagnostic">;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchCapabilityRegistry.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchCapabilityRegistry.ts
@@ -1,4 +1,0 @@
-export {
-  resolveWorkbenchCapabilityRegistry,
-  type WorkbenchCapabilityRegistryResult
-} from "@tutti-os/workbench-host";

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.test.ts
@@ -9,12 +9,10 @@ import {
 import { IWorkbenchHostCoordinator } from "../workbenchHostCoordinator.interface.ts";
 import {
   createWorkbenchHostSessionConfiguration,
-  WorkbenchHostCoordinator
-} from "./workbenchHostCoordinator.ts";
-import {
+  WorkbenchHostCoordinator,
   WorkbenchHostSession,
   type WorkbenchSnapshotPartition
-} from "./workbenchHostSession.ts";
+} from "@tutti-os/workbench-host";
 
 const configuration = createWorkbenchHostSessionConfiguration({
   createSession

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.ts
@@ -1,8 +1,0 @@
-export {
-  createWorkbenchHostSessionConfiguration,
-  WorkbenchHostCoordinator,
-  type WorkbenchHostCoordinatorOptions,
-  type WorkbenchHostSessionConfiguration,
-  type WorkbenchHostSessionLease,
-  type WorkbenchHostSessionOpenInput
-} from "@tutti-os/workbench-host";

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostKernelBoundaries.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostKernelBoundaries.test.ts
@@ -1,32 +1,30 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import test from "node:test";
 
-const neutralKernelFiles = [
-  "workbenchCapabilityRegistry.ts",
-  "workbenchHostCoordinator.ts",
+const productHostContractFiles = [
   "workbenchHostPorts.ts",
-  "workbenchHostSession.ts",
   "workbenchProductProfile.ts"
 ] as const;
 
-const extractedKernelShimFiles = [
+const removedPrivateKernelFiles = [
   "workbenchCapabilityRegistry.ts",
   "workbenchHostCoordinator.ts",
   "workbenchHostSession.ts"
 ] as const;
 
-test("desktop private kernel paths delegate to the shared host package", () => {
-  for (const file of extractedKernelShimFiles) {
-    const source = readFileSync(new URL(`./${file}`, import.meta.url), "utf8");
-
-    assert.match(source, /from "@tutti-os\/workbench-host";/, file);
-    assert.doesNotMatch(source, /\b(?:class|function)\s+WorkbenchHost/, file);
+test("desktop has no private host-kernel compatibility paths", () => {
+  for (const file of removedPrivateKernelFiles) {
+    assert.equal(
+      existsSync(new URL(`./${file}`, import.meta.url)),
+      false,
+      file
+    );
   }
 });
 
-test("private workbench host kernel has no product, DI, or React runtime imports", () => {
-  for (const file of neutralKernelFiles) {
+test("desktop product host contracts have no DI or React runtime imports", () => {
+  for (const file of productHostContractFiles) {
     const source = readFileSync(new URL(`./${file}`, import.meta.url), "utf8");
 
     assert.doesNotMatch(
@@ -42,8 +40,8 @@ test("private workbench host kernel has no product, DI, or React runtime imports
   }
 });
 
-test("private workbench host kernel depends on surface contracts type-only", () => {
-  for (const file of neutralKernelFiles) {
+test("desktop product host contracts depend on surface contracts type-only", () => {
+  for (const file of productHostContractFiles) {
     const source = readFileSync(new URL(`./${file}`, import.meta.url), "utf8");
     const surfaceImports = source.match(
       /^import(?: type)?[^;]+from "@tutti-os\/workbench-surface";/gm

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostPorts.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostPorts.ts
@@ -1,10 +1,5 @@
 import type { WorkbenchSnapshot } from "@tutti-os/workbench-snapshot";
 
-export type {
-  WorkbenchDiagnosticsPort,
-  WorkbenchHostDiagnosticEvent
-} from "@tutti-os/workbench-host";
-
 export interface WorkbenchSnapshotRepositoryPort {
   hasLoaded?(scopeId: string): boolean;
   load(scopeId: string): Promise<WorkbenchSnapshot | null>;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.test.ts
@@ -4,7 +4,7 @@ import type { WorkbenchHostHandle } from "@tutti-os/workbench-surface";
 import {
   WorkbenchHostSession,
   type WorkbenchSnapshotPartition
-} from "./workbenchHostSession.ts";
+} from "@tutti-os/workbench-host";
 
 test("workbench host session captures an immutable partition snapshot", () => {
   const partition = {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.ts
@@ -1,9 +1,0 @@
-export {
-  areWorkbenchSnapshotPartitionsEqual,
-  WorkbenchHostSession,
-  type WorkbenchAuthenticatedPrincipalSnapshot,
-  type WorkbenchHostSessionOptions,
-  type WorkbenchHostSessionResolution,
-  type WorkbenchScope,
-  type WorkbenchSnapshotPartition
-} from "@tutti-os/workbench-host";

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchProductProfile.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchProductProfile.ts
@@ -1,7 +1,7 @@
-import type { WorkbenchCapabilityFactoryDescriptor } from "@tutti-os/workbench-host";
-import type { WorkbenchScope } from "./workbenchHostSession.ts";
-
-export type { WorkbenchCapabilityFactoryDescriptor } from "@tutti-os/workbench-host";
+import type {
+  WorkbenchCapabilityFactoryDescriptor,
+  WorkbenchScope
+} from "@tutti-os/workbench-host";
 
 export interface WorkbenchProductProfile {
   readonly productId: string;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAppExternalUserProjectApi.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAppExternalUserProjectApi.ts
@@ -1,0 +1,43 @@
+import type { WorkspaceUserProjectApi } from "@tutti-os/workspace-user-project/contracts";
+import type { IWorkspaceUserProjectService } from "../../../workspace-user-project/services/workspaceUserProjectService.interface.ts";
+
+export function createWorkspaceAppExternalUserProjectApi(
+  service: IWorkspaceUserProjectService
+): WorkspaceUserProjectApi {
+  return {
+    checkPath: (input) => service.checkProjectPath(input.path),
+    create: (input) => service.createProject(input.name),
+    getDefaultSelection: () => service.getDefaultSelection(),
+    getSnapshot: () =>
+      Promise.resolve(cloneWorkspaceUserProjectServiceSnapshot(service)),
+    list: async () => {
+      await service.ensureLoaded();
+      return {
+        projects: service.store.projects.map((project) => ({ ...project }))
+      };
+    },
+    prepareSelection: (input) => service.prepareSelection(input),
+    refresh: async () => {
+      await service.refresh();
+      return cloneWorkspaceUserProjectServiceSnapshot(service);
+    },
+    rememberDefaultSelection: (input) =>
+      service.rememberDefaultSelection(input),
+    selectDirectory: () => service.selectDirectory(),
+    subscribe: (listener) =>
+      service.subscribe(() => {
+        listener(cloneWorkspaceUserProjectServiceSnapshot(service));
+      }),
+    use: (input) => service.registerProjectPath(input.path)
+  };
+}
+
+function cloneWorkspaceUserProjectServiceSnapshot(
+  service: IWorkspaceUserProjectService
+): ReturnType<IWorkspaceUserProjectService["getSnapshot"]> {
+  const snapshot = service.getSnapshot();
+  return {
+    ...snapshot,
+    projects: snapshot.projects.map((project) => ({ ...project }))
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchContributionFactory.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchContributionFactory.ts
@@ -41,7 +41,7 @@ import type {
   WorkspaceWorkbenchCapabilitySettingsTarget
 } from "../workspaceWorkbenchHostService.interface";
 import type { WorkspaceBrowserService } from "./workspaceBrowserService.ts";
-import type { WorkbenchCapabilityFactoryDescriptor } from "./workbenchProductProfile.ts";
+import type { WorkbenchCapabilityFactoryDescriptor } from "@tutti-os/workbench-host";
 
 export interface DesktopWorkbenchContributionContext {
   appI18n: I18nRuntime<string>;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchContributionRegistry.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchContributionRegistry.test.ts
@@ -1,11 +1,9 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
-import { resolveWorkbenchCapabilityRegistry } from "./workbenchCapabilityRegistry.ts";
-import type {
-  WorkbenchCapabilityFactoryDescriptor,
-  WorkbenchProductProfile
-} from "./workbenchProductProfile.ts";
+import { resolveWorkbenchCapabilityRegistry } from "@tutti-os/workbench-host";
+import type { WorkbenchCapabilityFactoryDescriptor } from "@tutti-os/workbench-host";
+import type { WorkbenchProductProfile } from "./workbenchProductProfile.ts";
 
 test("workbench contribution registry sorts factories and skips unavailable entries", () => {
   const registry = resolveWorkbenchCapabilityRegistry(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostInputResolver.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostInputResolver.ts
@@ -1,0 +1,610 @@
+import type { ReactNode } from "react";
+import type { AgentGUIProvider } from "@tutti-os/agent-gui";
+import type {
+  TuttidClient,
+  TuttidEventStreamClient
+} from "@tutti-os/client-tuttid-ts";
+import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
+import { createWorkbenchLaunchpadDockEntry } from "@tutti-os/workbench-launchpad";
+import {
+  resolveWorkbenchCapabilityRegistry,
+  type WorkbenchHostSessionResolution
+} from "@tutti-os/workbench-host";
+import {
+  resolveWorkbenchHostPrepareClose,
+  type WorkbenchDebugDiagnostics,
+  type WorkbenchHostCloseDialogRequest
+} from "@tutti-os/workbench-surface";
+import type {
+  DesktopBrowserApi,
+  DesktopComputerUseApi,
+  DesktopDockPreviewCacheApi,
+  DesktopHostFilesApi,
+  DesktopHostWindowApi,
+  DesktopPlatformApi,
+  DesktopRuntimeApi
+} from "@preload/types";
+import {
+  workspaceWorkbenchDesktopI18nKeys,
+  type DesktopLocale,
+  type WorkspaceWorkbenchDesktopI18nRuntime
+} from "@shared/i18n";
+import type { DesktopDockIconStyle } from "@shared/preferences";
+import type { DesktopThemeAppearance } from "@shared/theme";
+import {
+  createWorkspaceAppCenterDockEntries,
+  reportWorkspaceAppOpenedFromDockEntry
+} from "@renderer/features/workspace-app-center/services/workspaceAppCenterContribution.ts";
+import type { IWorkspaceAppCenterService } from "@renderer/features/workspace-app-center/services/workspaceAppCenterService.interface.ts";
+import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
+import type { IDesktopRichTextAtService } from "../../../rich-text-at/services/richTextAtService.interface.ts";
+import type { IWorkspaceFileManagerService } from "../../../workspace-file-manager/services/workspaceFileManagerService.interface.ts";
+import type { IWorkspaceUserProjectService } from "../../../workspace-user-project/services/workspaceUserProjectService.interface.ts";
+import type { IAgentProviderStatusService as AgentProviderStatusService } from "../../../workspace-agent/services/agentProviderStatusService.interface.ts";
+import type { IAgentsService as AgentsService } from "../../../workspace-agent/services/agentsService.interface.ts";
+import type { IWorkspaceAgentActivityService as WorkspaceAgentActivityService } from "../../../workspace-agent/services/workspaceAgentActivityService.interface.ts";
+import type { IWorkspaceAgentPromptSessionService as WorkspaceAgentPromptSessionService } from "../../../workspace-agent/services/workspaceAgentPromptSessionService.interface.ts";
+import type {
+  WorkspaceWorkbenchBodyRendererContext,
+  WorkspaceWorkbenchCapabilitySettingsTarget,
+  WorkspaceWorkbenchHostInput,
+  WorkspaceWorkbenchHostSessionUpdate
+} from "../workspaceWorkbenchHostService.interface.ts";
+import {
+  createWorkspaceDockImageIcon,
+  resolveWorkspaceDockIconSet,
+  type WorkspaceDockIconSet
+} from "../workspaceDockIconStyle.ts";
+import { assignWorkspaceTaskDockSection } from "./workspaceDockSections.ts";
+import { createWorkspaceDynamicDockSignature } from "./workspaceDynamicDockSignature.ts";
+import { createDesktopWorkspaceDockPreviewCache } from "./desktopWorkspaceDockPreviewCache.ts";
+import { createTuttiWorkbenchProductProfile } from "./tuttiWorkbenchProductProfile.ts";
+import { createWorkspaceWorkbenchHostInputWithDockEntries } from "./workspaceWorkbenchHostInput.ts";
+import { createWindowCloseDialogRequest } from "./workspaceCloseDialogRequests.ts";
+import type { DesktopWorkspaceWorkbenchRepository } from "./adapters/desktopWorkspaceWorkbenchRepository.ts";
+import type { WorkspaceBrowserService } from "./workspaceBrowserService.ts";
+
+const workspaceDockNativePreviewMaxWidthPx = 260;
+const workspaceDockNativePreviewMaxHeightPx = 170;
+const workspaceDockNativePreviewTimeoutMs = 2_500;
+
+export interface WorkspaceWorkbenchHostInputResolverDependencies {
+  agentProviderStatusService: AgentProviderStatusService;
+  agentsService: AgentsService;
+  appCenterService: IWorkspaceAppCenterService;
+  browserApi?: DesktopBrowserApi;
+  browserService: WorkspaceBrowserService;
+  computerUseApi: DesktopComputerUseApi;
+  dockPreviewCacheApi: DesktopDockPreviewCacheApi;
+  eventStreamClient?: TuttidEventStreamClient;
+  hostFilesApi: DesktopHostFilesApi;
+  hostWindowApi: DesktopHostWindowApi;
+  workspaceFileManagerService: IWorkspaceFileManagerService;
+  workspaceUserProjectService: IWorkspaceUserProjectService;
+  workspaceAgentActivityService: WorkspaceAgentActivityService;
+  workspaceAgentPromptSessionService: WorkspaceAgentPromptSessionService;
+  tuttidClient: TuttidClient;
+  platformApi: Pick<
+    DesktopPlatformApi,
+    "homeDirectory" | "os" | "resolveDroppedEntries" | "resolveDroppedPaths"
+  >;
+  repository: DesktopWorkspaceWorkbenchRepository;
+  reporterService?: Pick<IReporterService, "trackEvents">;
+  richTextAtService: IDesktopRichTextAtService;
+  runtimeApi: DesktopRuntimeApi;
+}
+
+export class WorkspaceWorkbenchHostInputResolver {
+  constructor(
+    private readonly dependencies: WorkspaceWorkbenchHostInputResolverDependencies
+  ) {}
+
+  resolve(
+    input: WorkspaceWorkbenchHostSessionUpdate,
+    current: WorkbenchHostSessionResolution<
+      WorkspaceWorkbenchHostInput,
+      CachedWorkspaceWorkbenchHostInput
+    > | null
+  ): WorkbenchHostSessionResolution<
+    WorkspaceWorkbenchHostInput,
+    CachedWorkspaceWorkbenchHostInput
+  > {
+    const cached = current?.state;
+    if (
+      cached &&
+      cached.appI18n === input.appI18n &&
+      cached.appLocale === input.appLocale &&
+      cached.defaultAgentProvider === input.defaultAgentProvider &&
+      cached.dockIconStyle === input.dockIconStyle &&
+      cached.i18n === input.i18n &&
+      cached.comingSoonAgentProviders === input.comingSoonAgentProviders &&
+      cached.themeAppearance === input.themeAppearance
+    ) {
+      cached.capabilitySettingsRequestRef.current =
+        input.onCapabilitySettingsRequest;
+      cached.confirmCloseGuardRef.current = input.confirmCloseGuard;
+      cached.renderFilesNodeBodyRef.current = input.renderFilesNodeBody;
+      return {
+        hostInput: this.createHostInputWithDynamicDockEntries(
+          cached,
+          cached.baseHostInput,
+          {
+            appI18n: input.appI18n,
+            desktopI18n: cached.i18n
+          }
+        ),
+        state: cached
+      };
+    }
+
+    const renderFilesNodeBodyRef = { current: input.renderFilesNodeBody };
+    const capabilitySettingsRequestRef = {
+      current: input.onCapabilitySettingsRequest
+    };
+    const confirmCloseGuardRef = { current: input.confirmCloseGuard };
+    const dockPreviewCache = createDesktopWorkspaceDockPreviewCache(
+      this.dependencies.dockPreviewCacheApi
+    );
+    const dockIcons = resolveWorkspaceDockIconSet({
+      appearance: input.themeAppearance,
+      style: input.dockIconStyle
+    });
+    const contributionRegistry = resolveWorkbenchCapabilityRegistry(
+      createTuttiWorkbenchProductProfile({
+        appI18n: input.appI18n,
+        appLocale: input.appLocale,
+        appCenterService: this.dependencies.appCenterService,
+        browserApi: this.dependencies.browserApi,
+        browserService: this.dependencies.browserService,
+        computerUseApi: this.dependencies.computerUseApi,
+        confirmCloseGuard: (request) => confirmCloseGuardRef.current(request),
+        dockPreviewCache,
+        defaultAgentProvider: input.defaultAgentProvider,
+        dockIcons: {
+          agentUnified: dockIcons.agentUnified,
+          agents: dockIcons.agents,
+          applications: dockIcons.applications,
+          browser: dockIcons.browser,
+          files: createWorkspaceDockImageIcon(dockIcons.files),
+          issue: dockIcons.issue,
+          terminal: createWorkspaceDockImageIcon(dockIcons.terminal)
+        },
+        hostFilesApi: this.dependencies.hostFilesApi,
+        hostWindowApi: this.dependencies.hostWindowApi,
+        i18n: input.i18n,
+        onCapabilitySettingsRequest: (target) => {
+          capabilitySettingsRequestRef.current?.(target);
+        },
+        agentsService: this.dependencies.agentsService,
+        comingSoonAgentProviders: input.comingSoonAgentProviders,
+        agentProviderStatusService:
+          this.dependencies.agentProviderStatusService,
+        eventStreamClient: this.dependencies.eventStreamClient,
+        workspaceFileManagerService:
+          this.dependencies.workspaceFileManagerService,
+        workspaceUserProjectService:
+          this.dependencies.workspaceUserProjectService,
+        workspaceAgentActivityService:
+          this.dependencies.workspaceAgentActivityService,
+        workspaceAgentPromptSessionService:
+          this.dependencies.workspaceAgentPromptSessionService,
+        tuttidClient: this.dependencies.tuttidClient,
+        platformApi: this.dependencies.platformApi,
+        reporterService: this.dependencies.reporterService,
+        renderFilesNodeBody: (context) =>
+          renderFilesNodeBodyRef.current(context),
+        richTextAtService: this.dependencies.richTextAtService,
+        runtimeApi: this.dependencies.runtimeApi,
+        workspaceId: input.workspaceId
+      })
+    );
+
+    const baseHostInput: WorkspaceWorkbenchHostInput = {
+      captureNodePreviewImage: createDesktopWorkspaceNodePreviewCapture(
+        this.dependencies.hostWindowApi,
+        this.dependencies.runtimeApi,
+        input.workspaceId
+      ),
+      contributions: contributionRegistry.contributions,
+      debugDiagnostics: createWorkspaceWorkbenchDebugDiagnostics(
+        this.dependencies.runtimeApi,
+        input.workspaceId
+      ),
+      dockPreviewCache,
+      prepareHostClose: resolveWorkbenchHostPrepareClose(
+        contributionRegistry.contributions
+      ),
+      createWindowCloseDialogRequest: (effects) =>
+        createWindowCloseDialogRequest({ effects, i18n: input.i18n }),
+      onDockEntryClick: ({ entryId }) =>
+        reportWorkspaceAppOpenedFromDockEntry({
+          appCenterService: this.dependencies.appCenterService,
+          entryId,
+          reporterService: this.dependencies.reporterService
+        }),
+      snapshotRepository: this.dependencies.repository,
+      workspaceId: input.workspaceId
+    };
+    const cachedHostInput: CachedWorkspaceWorkbenchHostInput = {
+      appI18n: input.appI18n,
+      appLocale: input.appLocale,
+      baseHostInput,
+      capabilitySettingsRequestRef,
+      confirmCloseGuardRef,
+      defaultAgentProvider: input.defaultAgentProvider,
+      dockIconStyle: input.dockIconStyle,
+      dockIcons,
+      i18n: input.i18n,
+      comingSoonAgentProviders: input.comingSoonAgentProviders,
+      renderFilesNodeBodyRef,
+      themeAppearance: input.themeAppearance
+    };
+    return {
+      hostInput: this.createHostInputWithDynamicDockEntries(
+        cachedHostInput,
+        baseHostInput,
+        {
+          appI18n: input.appI18n,
+          desktopI18n: input.i18n
+        }
+      ),
+      state: cachedHostInput
+    };
+  }
+
+  private createHostInputWithDynamicDockEntries(
+    cached: CachedWorkspaceWorkbenchHostInput,
+    baseHostInput: WorkspaceWorkbenchHostInput,
+    input: {
+      appI18n: I18nRuntime<string>;
+      desktopI18n: WorkspaceWorkbenchDesktopI18nRuntime;
+    }
+  ): WorkspaceWorkbenchHostInput {
+    const dockSignature = createWorkspaceDynamicDockSignature({
+      agentProviderRevision:
+        this.dependencies.agentProviderStatusService.getRevision(),
+      apps: this.dependencies.appCenterService.store.apps
+    });
+    if (
+      cached.dynamicHostInput &&
+      cached.dynamicAppI18n === input.appI18n &&
+      cached.dynamicDockSignature === dockSignature
+    ) {
+      return cached.dynamicHostInput;
+    }
+
+    const captureBrowserPreview = this.dependencies.browserApi?.capturePreview;
+    const dynamicHostInput = createWorkspaceWorkbenchHostInputWithDockEntries(
+      baseHostInput,
+      [
+        ...assignWorkspaceTaskDockSection(
+          createWorkspaceAppCenterDockEntries({
+            appCenterIconUrl: cached.dockIcons.applications,
+            appCenterService: this.dependencies.appCenterService,
+            captureWebviewPreview: captureBrowserPreview
+              ? (nodeId) => captureBrowserPreview({ nodeId })
+              : undefined,
+            i18n: input.appI18n
+          })
+        ),
+        createWorkbenchLaunchpadDockEntry({
+          label: input.desktopI18n.t(
+            workspaceWorkbenchDesktopI18nKeys.launchpad.dockLabel
+          ),
+          tileIconUrls: cached.dockIcons.launchpadTiles
+        })
+      ]
+    );
+    cached.dynamicAppI18n = input.appI18n;
+    cached.dynamicDockSignature = dockSignature;
+    cached.dynamicHostInput = dynamicHostInput;
+    return dynamicHostInput;
+  }
+}
+
+export interface CachedWorkspaceWorkbenchHostInput {
+  appI18n: I18nRuntime<string>;
+  appLocale: DesktopLocale;
+  baseHostInput: WorkspaceWorkbenchHostInput;
+  capabilitySettingsRequestRef: {
+    current:
+      | ((target: WorkspaceWorkbenchCapabilitySettingsTarget) => void)
+      | undefined;
+  };
+  confirmCloseGuardRef: {
+    current: (
+      request: WorkbenchHostCloseDialogRequest
+    ) => Promise<boolean> | boolean;
+  };
+  defaultAgentProvider?: string | null;
+  dockIconStyle: DesktopDockIconStyle;
+  dockIcons: WorkspaceDockIconSet;
+  dynamicAppI18n?: I18nRuntime<string>;
+  dynamicDockSignature?: string;
+  dynamicHostInput?: WorkspaceWorkbenchHostInput;
+  i18n: WorkspaceWorkbenchDesktopI18nRuntime;
+  comingSoonAgentProviders?: readonly AgentGUIProvider[];
+  renderFilesNodeBodyRef: {
+    current: (context: WorkspaceWorkbenchBodyRendererContext) => ReactNode;
+  };
+  themeAppearance: DesktopThemeAppearance;
+}
+
+function createDesktopWorkspaceNodePreviewCapture(
+  hostWindowApi: DesktopHostWindowApi,
+  runtimeApi: Pick<DesktopRuntimeApi, "logRendererDiagnostic">,
+  workspaceId: string
+): NonNullable<WorkspaceWorkbenchHostInput["captureNodePreviewImage"]> {
+  return async (node) => {
+    if (node.isMinimized || document.visibilityState !== "visible") {
+      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
+        details: {
+          documentVisibilityState: document.visibilityState,
+          isMinimized: node.isMinimized,
+          nodeId: node.id,
+          typeId: node.data.typeId
+        },
+        event: "dock_preview_capture.skipped",
+        level: "debug"
+      });
+      return null;
+    }
+
+    const captureContext = resolveWorkspaceNodeCaptureTarget(node.id);
+    if (!captureContext) {
+      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
+        details: { nodeId: node.id, typeId: node.data.typeId },
+        event: "dock_preview_capture.target_missing",
+        level: "warn"
+      });
+      return null;
+    }
+
+    const { captureTarget, windowElement } = captureContext;
+    if (!isForegroundWorkspaceNodeCaptureTarget(windowElement)) {
+      return null;
+    }
+
+    const rect = captureTarget.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
+        details: {
+          height: rect.height,
+          nodeId: node.id,
+          typeId: node.data.typeId,
+          width: rect.width,
+          x: rect.left,
+          y: rect.top
+        },
+        event: "dock_preview_capture.invalid_rect",
+        level: "warn"
+      });
+      return null;
+    }
+
+    const nativeCaptureBlockReason = resolveNativeCaptureBlockReason(
+      captureTarget,
+      rect
+    );
+    if (nativeCaptureBlockReason) {
+      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
+        details: {
+          height: rect.height,
+          nodeId: node.id,
+          reason: nativeCaptureBlockReason,
+          typeId: node.data.typeId,
+          width: rect.width,
+          x: rect.left,
+          y: rect.top
+        },
+        event: "dock_preview_capture.native_skipped",
+        level: "debug"
+      });
+      return null;
+    }
+
+    const captureStartedAt = performance.now();
+    logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
+      details: {
+        height: rect.height,
+        nodeId: node.id,
+        timeoutMs: workspaceDockNativePreviewTimeoutMs,
+        typeId: node.data.typeId,
+        width: rect.width,
+        x: rect.left,
+        y: rect.top
+      },
+      event: "dock_preview_capture.started",
+      level: "info"
+    });
+
+    let captureResult: DockPreviewCaptureResult;
+    try {
+      const capturePromise = hostWindowApi.capturePreview({
+        maxHeight: workspaceDockNativePreviewMaxHeightPx,
+        maxWidth: workspaceDockNativePreviewMaxWidthPx,
+        rect: {
+          height: rect.height,
+          width: rect.width,
+          x: rect.left,
+          y: rect.top
+        }
+      });
+      capturePromise.catch(() => undefined);
+      captureResult = await resolveDockPreviewCaptureWithTimeout(
+        capturePromise,
+        workspaceDockNativePreviewTimeoutMs
+      );
+    } catch (error) {
+      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
+        details: {
+          durationMs: Math.round(performance.now() - captureStartedAt),
+          error: error instanceof Error ? error.message : String(error),
+          nodeId: node.id,
+          typeId: node.data.typeId
+        },
+        event: "dock_preview_capture.ipc_failed",
+        level: "warn"
+      });
+      return null;
+    }
+
+    if (captureResult.status === "timeout") {
+      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
+        details: {
+          durationMs: Math.round(performance.now() - captureStartedAt),
+          nodeId: node.id,
+          timeoutMs: workspaceDockNativePreviewTimeoutMs,
+          typeId: node.data.typeId
+        },
+        event: "dock_preview_capture.timed_out",
+        level: "warn"
+      });
+      return null;
+    }
+
+    const previewImageUrl = captureResult.previewImageUrl;
+
+    if (!previewImageUrl) {
+      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
+        details: {
+          durationMs: Math.round(performance.now() - captureStartedAt),
+          height: rect.height,
+          nodeId: node.id,
+          typeId: node.data.typeId,
+          width: rect.width,
+          x: rect.left,
+          y: rect.top
+        },
+        event: "dock_preview_capture.empty_result",
+        level: "warn"
+      });
+    } else {
+      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
+        details: {
+          durationMs: Math.round(performance.now() - captureStartedAt),
+          nodeId: node.id,
+          previewLength: previewImageUrl.length,
+          typeId: node.data.typeId
+        },
+        event: "dock_preview_capture.succeeded",
+        level: "info"
+      });
+    }
+
+    return previewImageUrl;
+  };
+}
+
+function resolveNativeCaptureBlockReason(
+  _target: HTMLElement,
+  rect: DOMRect
+): "outside_viewport" | null {
+  if (
+    rect.left < 0 ||
+    rect.top < 0 ||
+    rect.right > window.innerWidth ||
+    rect.bottom > window.innerHeight
+  ) {
+    return "outside_viewport";
+  }
+  return null;
+}
+
+function isForegroundWorkspaceNodeCaptureTarget(
+  windowElement: HTMLElement
+): boolean {
+  return windowElement.dataset.focused === "true";
+}
+
+type DockPreviewCaptureResult =
+  | { previewImageUrl: string | null; status: "resolved" }
+  | { status: "timeout" };
+
+function resolveDockPreviewCaptureWithTimeout(
+  capturePromise: Promise<string | null>,
+  timeoutMs: number
+): Promise<DockPreviewCaptureResult> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<DockPreviewCaptureResult>((resolve) => {
+    timeout = setTimeout(() => resolve({ status: "timeout" }), timeoutMs);
+  });
+  return Promise.race([
+    capturePromise.then((previewImageUrl) => ({
+      previewImageUrl,
+      status: "resolved" as const
+    })),
+    timeoutPromise
+  ]).finally(() => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  });
+}
+
+function logDockPreviewCaptureDiagnostic(
+  runtimeApi: Pick<DesktopRuntimeApi, "logRendererDiagnostic">,
+  workspaceId: string,
+  input: {
+    details: Record<string, unknown>;
+    event: string;
+    level: "debug" | "info" | "warn";
+  }
+): void {
+  void runtimeApi
+    .logRendererDiagnostic({
+      details: input.details,
+      event: input.event,
+      level: input.level,
+      source: "workspace-workbench",
+      workspaceId
+    })
+    .catch(() => undefined);
+}
+
+function resolveWorkspaceNodeCaptureTarget(nodeId: string): {
+  captureTarget: HTMLElement;
+  windowElement: HTMLElement;
+} | null {
+  const windowElement =
+    Array.from(
+      document.querySelectorAll<HTMLElement>("[data-workbench-window-id]")
+    ).find((candidate) => candidate.dataset.workbenchWindowId === nodeId) ??
+    null;
+  if (!windowElement) {
+    return null;
+  }
+  const captureTarget =
+    windowElement.querySelector<HTMLElement>(
+      '[data-workbench-window-capture="true"]'
+    ) ??
+    windowElement.querySelector<HTMLElement>(".workbench-window") ??
+    windowElement;
+  return { captureTarget, windowElement };
+}
+
+function createWorkspaceWorkbenchDebugDiagnostics(
+  runtimeApi: DesktopRuntimeApi,
+  workspaceId: string
+): WorkbenchDebugDiagnostics {
+  return {
+    isEnabled() {
+      try {
+        return (
+          globalThis.localStorage?.getItem("tuttiWorkbenchDebugFrames") === "1"
+        );
+      } catch {
+        return false;
+      }
+    },
+    log(input) {
+      return runtimeApi.logRendererDiagnostic({
+        details: input.details,
+        event: input.event,
+        level: input.level,
+        source: input.source,
+        workspaceId
+      });
+    }
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
@@ -18,6 +18,14 @@ const workspaceWorkbenchHostServiceSource = readFileSync(
   new URL("./workspaceWorkbenchHostService.ts", import.meta.url),
   "utf8"
 );
+const workspaceWorkbenchHostInputResolverSource = readFileSync(
+  new URL("./workspaceWorkbenchHostInputResolver.ts", import.meta.url),
+  "utf8"
+);
+const workspaceAppExternalUserProjectApiSource = readFileSync(
+  new URL("./workspaceAppExternalUserProjectApi.ts", import.meta.url),
+  "utf8"
+);
 const workspaceWorkbenchRegistrationSource = readFileSync(
   new URL("../registerWorkspaceWorkbenchServices.ts", import.meta.url),
   "utf8"
@@ -33,19 +41,19 @@ const workspaceWorkbenchSource = readFileSync(
 
 test("workspace workbench host keeps deterministic composition and close preparation wiring", () => {
   assert.match(
-    workspaceWorkbenchHostServiceSource,
+    workspaceWorkbenchHostInputResolverSource,
     /resolveWorkbenchCapabilityRegistry\(\s+createTuttiWorkbenchProductProfile\(\{[\s\S]*?workspaceId: input\.workspaceId\s+\}\)\s+\)/
   );
   assert.match(
-    workspaceWorkbenchHostServiceSource,
+    workspaceWorkbenchHostInputResolverSource,
     /contributions: contributionRegistry\.contributions/
   );
   assert.match(
-    workspaceWorkbenchHostServiceSource,
+    workspaceWorkbenchHostInputResolverSource,
     /prepareHostClose: resolveWorkbenchHostPrepareClose\(\s+contributionRegistry\.contributions\s+\)/
   );
   assert.match(
-    workspaceWorkbenchHostServiceSource,
+    workspaceWorkbenchHostInputResolverSource,
     /snapshotRepository: this\.dependencies\.repository/
   );
 });
@@ -220,34 +228,34 @@ test("createWindowCloseDialogRequest summarizes close effects for window close",
 
 test("desktop dock preview capture avoids visible window isolation", () => {
   assert.match(
-    workspaceWorkbenchHostServiceSource,
+    workspaceWorkbenchHostInputResolverSource,
     /isForegroundWorkspaceNodeCaptureTarget\(windowElement\)/
   );
   assert.match(
-    workspaceWorkbenchHostServiceSource,
+    workspaceWorkbenchHostInputResolverSource,
     /const capturePromise = hostWindowApi\.capturePreview\(\{/
   );
   assert.doesNotMatch(
-    workspaceWorkbenchHostServiceSource,
+    workspaceWorkbenchHostInputResolverSource,
     new RegExp("data-workbench-" + "preview-capture-" + "active")
   );
   assert.doesNotMatch(
-    workspaceWorkbenchHostServiceSource,
+    workspaceWorkbenchHostInputResolverSource,
     new RegExp("captureIsolated" + "WorkspaceWindowPreview")
   );
 });
 
 test("workspace app external user project API exposes live project state", () => {
   assert.match(
-    workspaceWorkbenchHostServiceSource,
+    workspaceAppExternalUserProjectApiSource,
     /getSnapshot: \(\) =>\s+Promise\.resolve\(cloneWorkspaceUserProjectServiceSnapshot\(service\)\)/
   );
   assert.match(
-    workspaceWorkbenchHostServiceSource,
+    workspaceAppExternalUserProjectApiSource,
     /refresh: async \(\) => \{\s+await service\.refresh\(\);\s+return cloneWorkspaceUserProjectServiceSnapshot\(service\);/
   );
   assert.match(
-    workspaceWorkbenchHostServiceSource,
+    workspaceAppExternalUserProjectApiSource,
     /subscribe: \(listener\) =>\s+service\.subscribe\(\(\) => \{\s+listener\(cloneWorkspaceUserProjectServiceSnapshot\(service\)\);/
   );
 });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -1,26 +1,12 @@
-import type { ReactNode } from "react";
-import type { AgentGUIProvider } from "@tutti-os/agent-gui";
-import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
-import {
-  workspaceWorkbenchDesktopI18nKeys,
-  type DesktopLocale,
-  type WorkspaceWorkbenchDesktopI18nRuntime
-} from "@shared/i18n";
-import type { DesktopDockIconStyle } from "@shared/preferences";
-import type { DesktopThemeAppearance } from "@shared/theme";
 import type {
   WorkbenchHostCloseDialogRequest,
-  WorkbenchDebugDiagnostics,
   WorkbenchHostHandle
 } from "@tutti-os/workbench-surface";
-import { resolveWorkbenchHostPrepareClose } from "@tutti-os/workbench-surface";
 import type {
   IWorkspaceWorkbenchHostService,
   WorkspaceOnboardingAutoOpenDiagnostic,
   WorkspaceCustomWallpaperSnapshot,
   WorkspaceCustomWallpaperStatus,
-  WorkspaceWorkbenchBodyRendererContext,
-  WorkspaceWorkbenchCapabilitySettingsTarget,
   WorkspaceWorkbenchHostInput,
   WorkspaceWorkbenchHostSessionBinding,
   WorkspaceWorkbenchHostSessionUpdate
@@ -57,18 +43,11 @@ import {
   IWorkspaceAgentPromptSessionService,
   type IWorkspaceAgentPromptSessionService as WorkspaceAgentPromptSessionService
 } from "../../../workspace-agent/services/workspaceAgentPromptSessionService.interface.ts";
-import {
-  createWorkspaceAppCenterDockEntries,
-  reportWorkspaceAppOpenedFromDockEntry
-} from "@renderer/features/workspace-app-center/services/workspaceAppCenterContribution.ts";
 import { IWorkspaceAppCenterService } from "@renderer/features/workspace-app-center/services/workspaceAppCenterService.interface.ts";
 import { createDesktopAgentGeneratedFileMentionProvider } from "@renderer/features/workspace-agent/services/createDesktopAgentGeneratedFileMentionProvider.ts";
 import { IWorkspaceFileManagerService } from "../../../workspace-file-manager/services/workspaceFileManagerService.interface.ts";
 import { createDesktopWorkspaceFileReferenceAdapter } from "../../../workspace-file-manager/services/createDesktopWorkspaceFileReferenceAdapter.ts";
 import { IWorkspaceUserProjectService } from "../../../workspace-user-project/services/workspaceUserProjectService.interface.ts";
-import { resolveWorkbenchCapabilityRegistry } from "./workbenchCapabilityRegistry.ts";
-import { createTuttiWorkbenchProductProfile } from "./tuttiWorkbenchProductProfile.ts";
-import { createWorkspaceWorkbenchHostInputWithDockEntries } from "./workspaceWorkbenchHostInput.ts";
 import { confirmWorkspaceWindowClose } from "./workspaceWindowCloseCoordinator.ts";
 import {
   readWorkspaceWallpaperDisplayModeFromSnapshot,
@@ -83,11 +62,6 @@ import {
   writeWorkspaceOnboardingAutoOpenedToSnapshot
 } from "../workspaceOnboarding.ts";
 import { createWindowCloseRequestTracker } from "../windowCloseRequestTracker";
-import { createWindowCloseDialogRequest } from "./workspaceCloseDialogRequests.ts";
-import { assignWorkspaceTaskDockSection } from "./workspaceDockSections.ts";
-import { createWorkspaceDynamicDockSignature } from "./workspaceDynamicDockSignature.ts";
-import { createWorkbenchLaunchpadDockEntry } from "@tutti-os/workbench-launchpad";
-import { createDesktopWorkspaceDockPreviewCache } from "./desktopWorkspaceDockPreviewCache.ts";
 import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
 import type {
   DesktopHostNotificationNavigationPayload,
@@ -96,15 +70,7 @@ import type {
 } from "@shared/contracts/ipc";
 import { SettingsCustomWallpaperClearedReporter } from "../../../analytics/reporters/settings-custom-wallpaper-cleared/settingsCustomWallpaperClearedReporter.ts";
 import { SettingsCustomWallpaperUploadedReporter } from "../../../analytics/reporters/settings-custom-wallpaper-uploaded/settingsCustomWallpaperUploadedReporter.ts";
-import {
-  createWorkspaceBrowserService,
-  type WorkspaceBrowserService
-} from "./workspaceBrowserService.ts";
-import {
-  createWorkspaceDockImageIcon,
-  resolveWorkspaceDockIconSet,
-  type WorkspaceDockIconSet
-} from "../workspaceDockIconStyle.ts";
+import { createWorkspaceBrowserService } from "./workspaceBrowserService.ts";
 import { createRichTextTriggerRegistry } from "@tutti-os/ui-rich-text/plugins";
 import type { RichTextTriggerProvider } from "@tutti-os/ui-rich-text/types";
 import { tuttiExternalAtProviderIds } from "@tutti-os/workspace-external-core/core";
@@ -123,51 +89,28 @@ import {
 import {
   createWorkbenchHostSessionConfiguration,
   WorkbenchHostCoordinator,
-  type WorkbenchHostSessionConfiguration
-} from "./workbenchHostCoordinator.ts";
-import {
   WorkbenchHostSession,
-  type WorkbenchHostSessionResolution,
+  type WorkbenchHostSessionConfiguration,
   type WorkbenchSnapshotPartition
-} from "./workbenchHostSession.ts";
+} from "@tutti-os/workbench-host";
 import { IWorkbenchHostCoordinator } from "../workbenchHostCoordinator.interface.ts";
 import { createWorkspaceWorkbenchHostSessionBinding } from "./workspaceWorkbenchHostSessionBinding.ts";
 import { createDesktopWorkbenchDiagnosticsPort } from "./adapters/desktopWorkbenchDiagnosticsPort.ts";
-const workspaceDockNativePreviewMaxWidthPx = 260;
-const workspaceDockNativePreviewMaxHeightPx = 170;
-const workspaceDockNativePreviewTimeoutMs = 2_500;
+import { createWorkspaceAppExternalUserProjectApi } from "./workspaceAppExternalUserProjectApi.ts";
+import {
+  WorkspaceWorkbenchHostInputResolver,
+  type CachedWorkspaceWorkbenchHostInput,
+  type WorkspaceWorkbenchHostInputResolverDependencies
+} from "./workspaceWorkbenchHostInputResolver.ts";
 
-export interface WorkspaceWorkbenchHostServiceDependencies {
-  agentProviderStatusService: AgentProviderStatusService;
-  agentsService: AgentsService;
+export interface WorkspaceWorkbenchHostServiceDependencies extends WorkspaceWorkbenchHostInputResolverDependencies {
   isAgentProviderHidden?: (provider: string) => boolean;
   subscribeAgentProviderVisibility?: (listener: () => void) => () => void;
-  appCenterService: IWorkspaceAppCenterService;
-  browserApi?: DesktopBrowserApi;
-  browserService: WorkspaceBrowserService;
-  computerUseApi: DesktopComputerUseApi;
-  dockPreviewCacheApi: DesktopDockPreviewCacheApi;
-  hostFilesApi: DesktopHostFilesApi;
   hostNotificationsApi: Pick<DesktopHostNotificationsApi, "onNavigate">;
-  hostWindowApi: DesktopHostWindowApi;
   hostWorkspaceApi: Pick<
     DesktopHostWorkspaceApi,
     "broadcastAgentStatus" | "onOpenFeatureRequest" | "onOpenFileRequest"
   >;
-  workspaceFileManagerService: IWorkspaceFileManagerService;
-  workspaceUserProjectService: IWorkspaceUserProjectService;
-  workspaceAgentActivityService: WorkspaceAgentActivityService;
-  workspaceAgentPromptSessionService: WorkspaceAgentPromptSessionService;
-  eventStreamClient?: TuttidEventStreamClient;
-  tuttidClient: TuttidClient;
-  platformApi: Pick<
-    DesktopPlatformApi,
-    "homeDirectory" | "os" | "resolveDroppedEntries" | "resolveDroppedPaths"
-  >;
-  repository: DesktopWorkspaceWorkbenchRepository;
-  reporterService?: Pick<IReporterService, "trackEvents">;
-  richTextAtService: IDesktopRichTextAtService;
-  runtimeApi: DesktopRuntimeApi;
   wallpaperApi: DesktopWallpaperApi;
 }
 
@@ -205,6 +148,7 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
     WorkspaceWorkbenchHostInput,
     CachedWorkspaceWorkbenchHostInput
   >;
+  private readonly hostInputResolver: WorkspaceWorkbenchHostInputResolver;
   private readonly pendingWallpaperDisplayModes = new Map<
     string,
     WorkspaceWallpaperDisplayMode
@@ -271,6 +215,9 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
       runtimeApi: externalDependencies.runtimeApi,
       wallpaperApi: externalDependencies.wallpaperApi
     };
+    this.hostInputResolver = new WorkspaceWorkbenchHostInputResolver(
+      this.dependencies
+    );
     this.hostSessionConfiguration = createWorkbenchHostSessionConfiguration({
       createSession: (partition) =>
         new WorkbenchHostSession<
@@ -283,7 +230,8 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
             workspaceId: partition.scope.id
           }),
           partition,
-          resolve: (update, current) => this.resolveHostInput(update, current)
+          resolve: (update, current) =>
+            this.hostInputResolver.resolve(update, current)
         })
     });
     this.dependencies.repository.subscribe(() => {
@@ -773,480 +721,10 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
       workspaceId
     });
   }
-
-  private resolveHostInput(
-    input: WorkspaceWorkbenchHostSessionUpdate,
-    current: WorkbenchHostSessionResolution<
-      WorkspaceWorkbenchHostInput,
-      CachedWorkspaceWorkbenchHostInput
-    > | null
-  ): WorkbenchHostSessionResolution<
-    WorkspaceWorkbenchHostInput,
-    CachedWorkspaceWorkbenchHostInput
-  > {
-    const cached = current?.state;
-    if (
-      cached &&
-      cached.appI18n === input.appI18n &&
-      cached.appLocale === input.appLocale &&
-      cached.defaultAgentProvider === input.defaultAgentProvider &&
-      cached.dockIconStyle === input.dockIconStyle &&
-      cached.i18n === input.i18n &&
-      cached.comingSoonAgentProviders === input.comingSoonAgentProviders &&
-      cached.themeAppearance === input.themeAppearance
-    ) {
-      cached.capabilitySettingsRequestRef.current =
-        input.onCapabilitySettingsRequest;
-      cached.confirmCloseGuardRef.current = input.confirmCloseGuard;
-      cached.renderFilesNodeBodyRef.current = input.renderFilesNodeBody;
-      return {
-        hostInput: this.createHostInputWithDynamicDockEntries(
-          cached,
-          cached.baseHostInput,
-          {
-            appI18n: input.appI18n,
-            desktopI18n: cached.i18n
-          }
-        ),
-        state: cached
-      };
-    }
-
-    const renderFilesNodeBodyRef = {
-      current: input.renderFilesNodeBody
-    };
-    const capabilitySettingsRequestRef = {
-      current: input.onCapabilitySettingsRequest
-    };
-    const confirmCloseGuardRef = {
-      current: input.confirmCloseGuard
-    };
-    const dockPreviewCache = createDesktopWorkspaceDockPreviewCache(
-      this.dependencies.dockPreviewCacheApi
-    );
-    const dockIcons = resolveWorkspaceDockIconSet({
-      appearance: input.themeAppearance,
-      style: input.dockIconStyle
-    });
-    const contributionRegistry = resolveWorkbenchCapabilityRegistry(
-      createTuttiWorkbenchProductProfile({
-        appI18n: input.appI18n,
-        appLocale: input.appLocale,
-        appCenterService: this.dependencies.appCenterService,
-        browserApi: this.dependencies.browserApi,
-        browserService: this.dependencies.browserService,
-        computerUseApi: this.dependencies.computerUseApi,
-        confirmCloseGuard: (request) => confirmCloseGuardRef.current(request),
-        dockPreviewCache,
-        defaultAgentProvider: input.defaultAgentProvider,
-        dockIcons: {
-          agentUnified: dockIcons.agentUnified,
-          agents: dockIcons.agents,
-          applications: dockIcons.applications,
-          browser: dockIcons.browser,
-          files: createWorkspaceDockImageIcon(dockIcons.files),
-          issue: dockIcons.issue,
-          terminal: createWorkspaceDockImageIcon(dockIcons.terminal)
-        },
-        hostFilesApi: this.dependencies.hostFilesApi,
-        hostWindowApi: this.dependencies.hostWindowApi,
-        i18n: input.i18n,
-        onCapabilitySettingsRequest: (target) => {
-          capabilitySettingsRequestRef.current?.(target);
-        },
-        agentsService: this.dependencies.agentsService,
-        comingSoonAgentProviders: input.comingSoonAgentProviders,
-        agentProviderStatusService:
-          this.dependencies.agentProviderStatusService,
-        eventStreamClient: this.dependencies.eventStreamClient,
-        workspaceFileManagerService:
-          this.dependencies.workspaceFileManagerService,
-        workspaceUserProjectService:
-          this.dependencies.workspaceUserProjectService,
-        workspaceAgentActivityService:
-          this.dependencies.workspaceAgentActivityService,
-        workspaceAgentPromptSessionService:
-          this.dependencies.workspaceAgentPromptSessionService,
-        tuttidClient: this.dependencies.tuttidClient,
-        platformApi: this.dependencies.platformApi,
-        reporterService: this.dependencies.reporterService,
-        renderFilesNodeBody: (context) =>
-          renderFilesNodeBodyRef.current(context),
-        richTextAtService: this.dependencies.richTextAtService,
-        runtimeApi: this.dependencies.runtimeApi,
-        workspaceId: input.workspaceId
-      })
-    );
-
-    const baseHostInput: WorkspaceWorkbenchHostInput = {
-      captureNodePreviewImage: createDesktopWorkspaceNodePreviewCapture(
-        this.dependencies.hostWindowApi,
-        this.dependencies.runtimeApi,
-        input.workspaceId
-      ),
-      contributions: contributionRegistry.contributions,
-      debugDiagnostics: createWorkspaceWorkbenchDebugDiagnostics(
-        this.dependencies.runtimeApi,
-        input.workspaceId
-      ),
-      dockPreviewCache,
-      prepareHostClose: resolveWorkbenchHostPrepareClose(
-        contributionRegistry.contributions
-      ),
-      createWindowCloseDialogRequest: (effects) =>
-        createWindowCloseDialogRequest({
-          effects,
-          i18n: input.i18n
-        }),
-      onDockEntryClick: ({ entryId }) =>
-        reportWorkspaceAppOpenedFromDockEntry({
-          appCenterService: this.dependencies.appCenterService,
-          entryId,
-          reporterService: this.dependencies.reporterService
-        }),
-      snapshotRepository: this.dependencies.repository,
-      workspaceId: input.workspaceId
-    };
-    const cachedHostInput: CachedWorkspaceWorkbenchHostInput = {
-      appI18n: input.appI18n,
-      appLocale: input.appLocale,
-      baseHostInput,
-      capabilitySettingsRequestRef,
-      confirmCloseGuardRef,
-      defaultAgentProvider: input.defaultAgentProvider,
-      dockIconStyle: input.dockIconStyle,
-      dockIcons,
-      i18n: input.i18n,
-      comingSoonAgentProviders: input.comingSoonAgentProviders,
-      renderFilesNodeBodyRef,
-      themeAppearance: input.themeAppearance
-    };
-    return {
-      hostInput: this.createHostInputWithDynamicDockEntries(
-        cachedHostInput,
-        baseHostInput,
-        {
-          appI18n: input.appI18n,
-          desktopI18n: input.i18n
-        }
-      ),
-      state: cachedHostInput
-    };
-  }
-
-  private createHostInputWithDynamicDockEntries(
-    cached: CachedWorkspaceWorkbenchHostInput,
-    baseHostInput: WorkspaceWorkbenchHostInput,
-    input: {
-      appI18n: I18nRuntime<string>;
-      desktopI18n: WorkspaceWorkbenchDesktopI18nRuntime;
-    }
-  ): WorkspaceWorkbenchHostInput {
-    const dockSignature = createWorkspaceDynamicDockSignature({
-      agentProviderRevision:
-        this.dependencies.agentProviderStatusService.getRevision(),
-      apps: this.dependencies.appCenterService.store.apps
-    });
-    if (
-      cached?.dynamicHostInput &&
-      cached.dynamicAppI18n === input.appI18n &&
-      cached.dynamicDockSignature === dockSignature
-    ) {
-      return cached.dynamicHostInput;
-    }
-
-    const captureBrowserPreview = this.dependencies.browserApi?.capturePreview;
-    const dynamicHostInput = createWorkspaceWorkbenchHostInputWithDockEntries(
-      baseHostInput,
-      [
-        ...assignWorkspaceTaskDockSection(
-          createWorkspaceAppCenterDockEntries({
-            appCenterIconUrl: cached?.dockIcons.applications,
-            appCenterService: this.dependencies.appCenterService,
-            captureWebviewPreview: captureBrowserPreview
-              ? (nodeId) => captureBrowserPreview({ nodeId })
-              : undefined,
-            i18n: input.appI18n
-          })
-        ),
-        createWorkbenchLaunchpadDockEntry({
-          label: input.desktopI18n.t(
-            workspaceWorkbenchDesktopI18nKeys.launchpad.dockLabel
-          ),
-          tileIconUrls: cached.dockIcons.launchpadTiles
-        })
-      ]
-    );
-    cached.dynamicAppI18n = input.appI18n;
-    cached.dynamicDockSignature = dockSignature;
-    cached.dynamicHostInput = dynamicHostInput;
-    return dynamicHostInput;
-  }
 }
 
 function formatDiagnosticError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function createDesktopWorkspaceNodePreviewCapture(
-  hostWindowApi: DesktopHostWindowApi,
-  runtimeApi: Pick<DesktopRuntimeApi, "logRendererDiagnostic">,
-  workspaceId: string
-): NonNullable<WorkspaceWorkbenchHostInput["captureNodePreviewImage"]> {
-  return async (node) => {
-    if (node.isMinimized || document.visibilityState !== "visible") {
-      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-        details: {
-          documentVisibilityState: document.visibilityState,
-          isMinimized: node.isMinimized,
-          nodeId: node.id,
-          typeId: node.data.typeId
-        },
-        event: "dock_preview_capture.skipped",
-        level: "debug"
-      });
-      return null;
-    }
-
-    const captureContext = resolveWorkspaceNodeCaptureTarget(node.id);
-    if (!captureContext) {
-      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-        details: {
-          nodeId: node.id,
-          typeId: node.data.typeId
-        },
-        event: "dock_preview_capture.target_missing",
-        level: "warn"
-      });
-      return null;
-    }
-
-    const { captureTarget, windowElement } = captureContext;
-    if (!isForegroundWorkspaceNodeCaptureTarget(windowElement)) {
-      return null;
-    }
-
-    const rect = captureTarget.getBoundingClientRect();
-    if (rect.width <= 0 || rect.height <= 0) {
-      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-        details: {
-          height: rect.height,
-          nodeId: node.id,
-          typeId: node.data.typeId,
-          width: rect.width,
-          x: rect.left,
-          y: rect.top
-        },
-        event: "dock_preview_capture.invalid_rect",
-        level: "warn"
-      });
-      return null;
-    }
-
-    const nativeCaptureBlockReason = resolveNativeCaptureBlockReason(
-      captureTarget,
-      rect
-    );
-    if (nativeCaptureBlockReason) {
-      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-        details: {
-          height: rect.height,
-          nodeId: node.id,
-          reason: nativeCaptureBlockReason,
-          typeId: node.data.typeId,
-          width: rect.width,
-          x: rect.left,
-          y: rect.top
-        },
-        event: "dock_preview_capture.native_skipped",
-        level: "debug"
-      });
-      return null;
-    }
-
-    const captureStartedAt = performance.now();
-    logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-      details: {
-        height: rect.height,
-        nodeId: node.id,
-        timeoutMs: workspaceDockNativePreviewTimeoutMs,
-        typeId: node.data.typeId,
-        width: rect.width,
-        x: rect.left,
-        y: rect.top
-      },
-      event: "dock_preview_capture.started",
-      level: "info"
-    });
-
-    let captureResult: DockPreviewCaptureResult;
-    try {
-      const capturePromise = hostWindowApi.capturePreview({
-        maxHeight: workspaceDockNativePreviewMaxHeightPx,
-        maxWidth: workspaceDockNativePreviewMaxWidthPx,
-        rect: {
-          height: rect.height,
-          width: rect.width,
-          x: rect.left,
-          y: rect.top
-        }
-      });
-      capturePromise.catch(() => undefined);
-      captureResult = await resolveDockPreviewCaptureWithTimeout(
-        capturePromise,
-        workspaceDockNativePreviewTimeoutMs
-      );
-    } catch (error) {
-      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-        details: {
-          durationMs: Math.round(performance.now() - captureStartedAt),
-          error: error instanceof Error ? error.message : String(error),
-          nodeId: node.id,
-          typeId: node.data.typeId
-        },
-        event: "dock_preview_capture.ipc_failed",
-        level: "warn"
-      });
-      return null;
-    }
-
-    if (captureResult.status === "timeout") {
-      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-        details: {
-          durationMs: Math.round(performance.now() - captureStartedAt),
-          nodeId: node.id,
-          timeoutMs: workspaceDockNativePreviewTimeoutMs,
-          typeId: node.data.typeId
-        },
-        event: "dock_preview_capture.timed_out",
-        level: "warn"
-      });
-      return null;
-    }
-
-    const previewImageUrl = captureResult.previewImageUrl;
-
-    if (!previewImageUrl) {
-      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-        details: {
-          durationMs: Math.round(performance.now() - captureStartedAt),
-          height: rect.height,
-          nodeId: node.id,
-          typeId: node.data.typeId,
-          width: rect.width,
-          x: rect.left,
-          y: rect.top
-        },
-        event: "dock_preview_capture.empty_result",
-        level: "warn"
-      });
-    } else {
-      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-        details: {
-          durationMs: Math.round(performance.now() - captureStartedAt),
-          nodeId: node.id,
-          previewLength: previewImageUrl.length,
-          typeId: node.data.typeId
-        },
-        event: "dock_preview_capture.succeeded",
-        level: "info"
-      });
-    }
-
-    return previewImageUrl;
-  };
-}
-
-function resolveNativeCaptureBlockReason(
-  _target: HTMLElement,
-  rect: DOMRect
-): "outside_viewport" | null {
-  if (
-    rect.left < 0 ||
-    rect.top < 0 ||
-    rect.right > window.innerWidth ||
-    rect.bottom > window.innerHeight
-  ) {
-    return "outside_viewport";
-  }
-  return null;
-}
-
-function isForegroundWorkspaceNodeCaptureTarget(
-  windowElement: HTMLElement
-): boolean {
-  return windowElement.dataset.focused === "true";
-}
-
-type DockPreviewCaptureResult =
-  | {
-      previewImageUrl: string | null;
-      status: "resolved";
-    }
-  | {
-      status: "timeout";
-    };
-
-function resolveDockPreviewCaptureWithTimeout(
-  capturePromise: Promise<string | null>,
-  timeoutMs: number
-): Promise<DockPreviewCaptureResult> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<DockPreviewCaptureResult>((resolve) => {
-    timeout = setTimeout(() => resolve({ status: "timeout" }), timeoutMs);
-  });
-  return Promise.race([
-    capturePromise.then((previewImageUrl) => ({
-      previewImageUrl,
-      status: "resolved" as const
-    })),
-    timeoutPromise
-  ]).finally(() => {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-  });
-}
-
-function logDockPreviewCaptureDiagnostic(
-  runtimeApi: Pick<DesktopRuntimeApi, "logRendererDiagnostic">,
-  workspaceId: string,
-  input: {
-    details: Record<string, unknown>;
-    event: string;
-    level: "debug" | "info" | "warn";
-  }
-): void {
-  void runtimeApi
-    .logRendererDiagnostic({
-      details: input.details,
-      event: input.event,
-      level: input.level,
-      source: "workspace-workbench",
-      workspaceId
-    })
-    .catch(() => undefined);
-}
-
-function resolveWorkspaceNodeCaptureTarget(nodeId: string): {
-  captureTarget: HTMLElement;
-  windowElement: HTMLElement;
-} | null {
-  const windowElement =
-    Array.from(
-      document.querySelectorAll<HTMLElement>("[data-workbench-window-id]")
-    ).find((candidate) => candidate.dataset.workbenchWindowId === nodeId) ??
-    null;
-  if (!windowElement) {
-    return null;
-  }
-  const captureTarget =
-    windowElement.querySelector<HTMLElement>(
-      '[data-workbench-window-capture="true"]'
-    ) ??
-    windowElement.querySelector<HTMLElement>(".workbench-window") ??
-    windowElement;
-  return { captureTarget, windowElement };
 }
 
 // Avoid decorator syntax so the renderer Babel pass can parse this file.
@@ -1264,75 +742,6 @@ IWorkspaceAppCenterService(WorkspaceWorkbenchHostService, undefined, 7);
 IWorkspaceFileManagerService(WorkspaceWorkbenchHostService, undefined, 8);
 IWorkspaceUserProjectService(WorkspaceWorkbenchHostService, undefined, 9);
 
-export function createWorkspaceAppExternalUserProjectApi(
-  service: IWorkspaceUserProjectService
-): WorkspaceUserProjectApi {
-  return {
-    checkPath: (input) => service.checkProjectPath(input.path),
-    create: (input) => service.createProject(input.name),
-    getDefaultSelection: () => service.getDefaultSelection(),
-    getSnapshot: () =>
-      Promise.resolve(cloneWorkspaceUserProjectServiceSnapshot(service)),
-    list: async () => {
-      await service.ensureLoaded();
-      return {
-        projects: service.store.projects.map((project) => ({ ...project }))
-      };
-    },
-    prepareSelection: (input) => service.prepareSelection(input),
-    refresh: async () => {
-      await service.refresh();
-      return cloneWorkspaceUserProjectServiceSnapshot(service);
-    },
-    rememberDefaultSelection: (input) =>
-      service.rememberDefaultSelection(input),
-    selectDirectory: () => service.selectDirectory(),
-    subscribe: (listener) =>
-      service.subscribe(() => {
-        listener(cloneWorkspaceUserProjectServiceSnapshot(service));
-      }),
-    use: (input) => service.registerProjectPath(input.path)
-  };
-}
-
-function cloneWorkspaceUserProjectServiceSnapshot(
-  service: IWorkspaceUserProjectService
-): ReturnType<IWorkspaceUserProjectService["getSnapshot"]> {
-  const snapshot = service.getSnapshot();
-  return {
-    ...snapshot,
-    projects: snapshot.projects.map((project) => ({ ...project }))
-  };
-}
-
-interface CachedWorkspaceWorkbenchHostInput {
-  appI18n: I18nRuntime<string>;
-  appLocale: DesktopLocale;
-  baseHostInput: WorkspaceWorkbenchHostInput;
-  capabilitySettingsRequestRef: {
-    current:
-      | ((target: WorkspaceWorkbenchCapabilitySettingsTarget) => void)
-      | undefined;
-  };
-  confirmCloseGuardRef: {
-    current: (
-      request: WorkbenchHostCloseDialogRequest
-    ) => Promise<boolean> | boolean;
-  };
-  defaultAgentProvider?: string | null;
-  dockIconStyle: DesktopDockIconStyle;
-  dockIcons: WorkspaceDockIconSet;
-  dynamicAppI18n?: I18nRuntime<string>;
-  dynamicDockSignature?: string;
-  dynamicHostInput?: WorkspaceWorkbenchHostInput;
-  i18n: WorkspaceWorkbenchDesktopI18nRuntime;
-  comingSoonAgentProviders?: readonly AgentGUIProvider[];
-  renderFilesNodeBodyRef: {
-    current: (context: WorkspaceWorkbenchBodyRendererContext) => ReactNode;
-  };
-  themeAppearance: DesktopThemeAppearance;
-}
-
 function createWorkspaceWorkbenchPartition(
   workspaceId: string
 ): WorkbenchSnapshotPartition {
@@ -1349,30 +758,4 @@ function noop(): void {}
 function createObjectUrlFromBytes(bytes: Uint8Array, mimeType: string): string {
   const copy = new Uint8Array(bytes);
   return URL.createObjectURL(new Blob([copy], { type: mimeType }));
-}
-
-function createWorkspaceWorkbenchDebugDiagnostics(
-  runtimeApi: DesktopRuntimeApi,
-  workspaceId: string
-): WorkbenchDebugDiagnostics {
-  return {
-    isEnabled() {
-      try {
-        return (
-          globalThis.localStorage?.getItem("tuttiWorkbenchDebugFrames") === "1"
-        );
-      } catch {
-        return false;
-      }
-    },
-    log(input) {
-      return runtimeApi.logRendererDiagnostic({
-        details: input.details,
-        event: input.event,
-        level: input.level,
-        source: input.source,
-        workspaceId
-      });
-    }
-  };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostSessionBinding.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostSessionBinding.test.ts
@@ -8,9 +8,9 @@ import type {
 import {
   createWorkbenchHostSessionConfiguration,
   WorkbenchHostCoordinator,
+  WorkbenchHostSession,
   type WorkbenchHostSessionConfiguration
-} from "./workbenchHostCoordinator.ts";
-import { WorkbenchHostSession } from "./workbenchHostSession.ts";
+} from "@tutti-os/workbench-host";
 import { createWorkspaceWorkbenchHostSessionBinding } from "./workspaceWorkbenchHostSessionBinding.ts";
 
 test("workspace session bindings release only their own lease", () => {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostSessionBinding.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostSessionBinding.ts
@@ -1,9 +1,9 @@
+import type { WorkbenchHostSessionLease } from "@tutti-os/workbench-host";
 import type {
   WorkspaceWorkbenchHostInput,
   WorkspaceWorkbenchHostSessionBinding,
   WorkspaceWorkbenchHostSessionUpdate
 } from "../workspaceWorkbenchHostService.interface.ts";
-import type { WorkbenchHostSessionLease } from "./workbenchHostCoordinator.ts";
 
 export function createWorkspaceWorkbenchHostSessionBinding<TState>(input: {
   bindingId: number;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/registerWorkspaceWorkbenchServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/registerWorkspaceWorkbenchServices.ts
@@ -1,4 +1,5 @@
 import { SyncDescriptor, type ServiceRegistry } from "@tutti-os/infra/di";
+import { WorkbenchHostCoordinator } from "@tutti-os/workbench-host";
 import type {
   TuttidClient,
   TuttidEventStreamClient
@@ -20,7 +21,6 @@ import type { IReporterService } from "../../analytics/services/reporterService.
 import { createDesktopWorkspaceSettingsClient } from "./internal/adapters/desktopWorkspaceSettingsClient";
 import { AccountService } from "./internal/accountService";
 import { WorkspaceWorkbenchHostService } from "./internal/workspaceWorkbenchHostService";
-import { WorkbenchHostCoordinator } from "./internal/workbenchHostCoordinator.ts";
 import { WorkspaceSettingsService } from "./internal/workspaceSettingsService";
 import { IAccountService } from "./accountService.interface";
 import { IWorkbenchHostCoordinator } from "./workbenchHostCoordinator.interface.ts";

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchHostCoordinator.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchHostCoordinator.interface.ts
@@ -1,5 +1,5 @@
 import { createDecorator } from "@tutti-os/infra/di";
-import type { WorkbenchHostCoordinator } from "./internal/workbenchHostCoordinator.ts";
+import type { WorkbenchHostCoordinator } from "@tutti-os/workbench-host";
 
 export const IWorkbenchHostCoordinator =
   createDecorator<WorkbenchHostCoordinator>("workbench-host-coordinator");

--- a/docs/architecture/workbench-contributions.md
+++ b/docs/architecture/workbench-contributions.md
@@ -374,8 +374,9 @@ The desktop workspace workbench currently uses these modules:
   factory, contribution, node type, and dock entry ownership before host input
   is published. `services/internal/workbenchProductProfile.ts` keeps Tutti's
   product ID and scope kind private because the shared kernel does not yet
-  consume or enforce those fields; the old desktop registry path is only a
-  compatibility re-export during package cutover.
+  consume or enforce those fields. Desktop production code and lifecycle tests
+  import the shared package directly; there is no private registry,
+  coordinator, or session compatibility path.
 - `services/internal/tuttiWorkbenchProductProfile.ts` owns the Tutti capability
   selection. It binds each desktop contribution factory to a newly projected,
   capability-specific context so factories do not receive the full product
@@ -394,10 +395,13 @@ The desktop workspace workbench currently uses these modules:
 - `services/internal/contributions/*` owns concrete desktop-local adapters for
   browser, terminal, issue-manager, files, and other workspace capabilities
   that have not yet moved into a shared package factory.
-- `workspaceWorkbenchHostService.ts` owns host input assembly. It may compose
-  contribution factories, snapshot repositories, close policy, wallpaper
-  persistence, and desktop IPC adapters, but it should not become a feature
-  business core.
+- `workspaceWorkbenchHostInputResolver.ts` owns product host-input assembly,
+  including contribution factories, dynamic dock entries, snapshot repository
+  wiring, close policy, and node-preview capture.
+- `workspaceWorkbenchHostService.ts` remains the desktop facade for session
+  leases, wallpaper/onboarding persistence, external bridges, and desktop IPC
+  adapters. It delegates host-input assembly to the resolver instead of
+  becoming a second feature business core.
 - `services/workspaceWorkbenchShellRuntimeController.ts` owns shell-level
   runtime state that is independent of DOM rendering: mission control, close
   guard dialog state, host close requests, wallpaper selection, and the

--- a/docs/specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md
+++ b/docs/specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md
@@ -1,8 +1,8 @@
 # Workbench Host Kernel: Phase 0 To Stable
 
 - Date: 2026-07-11
-- Status: Active; ADR accepted, PRs 1–3 and pre-extraction hardening merged,
-  PRs 4–6 approved, and PR 4 ready to start
+- Status: Active; ADR accepted, PRs 1–4 and pre-extraction hardening merged,
+  PR 5 in progress, and PR 6 approved after PR 5 validation
 - Architecture decision:
   [ADR 0009](../adr/0009-cross-product-workbench-host-kernel.md)
 - Scope: Tutti-first implementation, npm beta, read-only/downstream TSH
@@ -35,17 +35,18 @@ gate after external TSH validation.
 
 Approval recorded on 2026-07-11 remains deliberately incremental:
 
-| Scope                                       | Approval                                 |
-| ------------------------------------------- | ---------------------------------------- |
-| ADR 0009 architecture boundary              | Accepted                                 |
-| PR 1 characterization fixtures/tests        | Merged in #1043                          |
-| PR 2 private coordinator/session            | Merged in #1044                          |
-| PR 3 Product Profile/Ports/adapters split   | Merged in #1050                          |
-| Pre-extraction writer/save hardening        | Merged in #1184                          |
-| Public package extraction and Tutti cutover | Approved after PR 3                      |
-| npm beta publication                        | Approved after PRs 3–5 and validation    |
-| TSH renderer DI/host migration              | Deferred; no TSH changes in current work |
-| Stable publication                          | Not approved                             |
+| Scope                                     | Approval                                 |
+| ----------------------------------------- | ---------------------------------------- |
+| ADR 0009 architecture boundary            | Accepted                                 |
+| PR 1 characterization fixtures/tests      | Merged in #1043                          |
+| PR 2 private coordinator/session          | Merged in #1044                          |
+| PR 3 Product Profile/Ports/adapters split | Merged in #1050                          |
+| Pre-extraction writer/save hardening      | Merged in #1184                          |
+| Public package extraction                 | Merged in #1194                          |
+| Tutti direct package cutover              | Approved; PR 5 in progress               |
+| npm beta publication                      | Approved after PRs 3–5 and validation    |
+| TSH renderer DI/host migration            | Deferred; no TSH changes in current work |
+| Stable publication                        | Not approved                             |
 
 The approvals remain sequenced as independently mergeable and revertible PRs.
 They do not authorize combining PRs 3–5, modifying TSH, or publishing stable.


### PR DESCRIPTION
## Summary

- switch Tutti renderer DI, lifecycle, diagnostics, capability registry, bindings, and tests to import `@tutti-os/workbench-host` directly
- remove the three desktop compatibility re-export paths so there is exactly one host coordination implementation
- extract product host-input assembly and external user-project bridging from the desktop facade, keeping each business file below 800 lines
- update Workbench architecture and rollout status after #1194

## Validation

- `pnpm --filter @tutti-os/desktop test` (1456 tests; 1454 passed, 2 skipped)
- `pnpm --filter @tutti-os/workbench-host test` (12 passed)
- `pnpm --filter @tutti-os/workbench-surface test` (214 passed)
- `pnpm --filter @tutti-os/desktop build`
- `pnpm typecheck` (27 packages)
- `pnpm lint:ts`
- `pnpm check:renderer-boundaries`
- `pnpm check:changed --tail-lines 80` (7 lanes)
- pre-push `pnpm check:full` (18 tasks)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Complete cutover to the shared host kernel by importing `@tutti-os/workbench-host` directly in the desktop workbench. Removes private compatibility shims and moves host-input assembly into a focused resolver for simpler, smaller code.

- **Refactors**
  - Switched renderer DI, lifecycle, diagnostics, capability registry, bindings, and tests to import `@tutti-os/workbench-host` directly.
  - Removed desktop compatibility re-export files (`workbenchCapabilityRegistry.ts`, `workbenchHostCoordinator.ts`, `workbenchHostSession.ts`) and added tests to ensure they’re gone.
  - Extracted host-input composition to `workspaceWorkbenchHostInputResolver.ts`; `workspaceWorkbenchHostService.ts` now delegates and is significantly smaller.
  - Added `workspaceAppExternalUserProjectApi.ts` to bridge the live user-project service to external apps.
  - Updated product host contracts and type imports to use `@tutti-os/workbench-host` (e.g., `WorkbenchScope`, capability factory descriptors).
  - Updated architecture docs and rollout status to reflect the direct package cutover after #1194.

<sup>Written for commit da7c174ff9b9fd987bd243a7f7c3a4c213e58735. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

