### PR TITLE
chore(static-analysis): guard workspace launch coordinators

### DIFF
--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -135,6 +135,17 @@ Renderer feature implementation boundaries are checked by `pnpm check:renderer-b
 That check also enforces the Workbench-specific rule that
 `workspace-workbench/ui/**` imports public service or controller seams instead
 of `workspace-workbench/services/internal/**`.
+Workspace Workbench launch coordinators must also route workspace-keyed Shell
+registrations through the private `WorkspaceScopedRegistrationRegistry` rather
+than declaring their own `Map`. The rule covers top-level
+`*LaunchCoordinator.ts` services and the Message Center coordinator, while
+leaving non-launch coordinator state such as Agent GUI open-session reference
+counts outside this registration-specific policy. Because the rule is part of
+`check:renderer-boundaries`, it runs for staged renderer changes, the
+renderer-boundary lane selected by `check:changed`, and `check:full`. Changes
+to the renderer-boundary checker or its fixture suite also select that
+`check:changed` lane, so policy edits validate both their fixtures and the live
+renderer tree.
 
 `pnpm check:ui-boundaries` has a package-scoped temporary migration exception
 for `packages/agent/gui` while the carried agent activity renderer is

--- a/tools/scripts/check-renderer-feature-boundaries.mjs
+++ b/tools/scripts/check-renderer-feature-boundaries.mjs
@@ -99,7 +99,43 @@ function inspectCodeFile(relativePath, content) {
     }
 
     inspectWindowTuttiAccess(relativePath, lines[index], index + 1);
+    inspectWorkspaceLaunchCoordinatorMap(relativePath, lines[index], index + 1);
   }
+}
+
+function inspectWorkspaceLaunchCoordinatorMap(relativePath, lineContent, line) {
+  if (!isWorkspaceLaunchCoordinator(relativePath)) {
+    return;
+  }
+
+  if (!/\bnew\s+Map\s*(?:<|\()/u.test(lineContent)) {
+    return;
+  }
+
+  violations.push({
+    file: relativePath,
+    line,
+    message:
+      "workspace launch coordinators must use WorkspaceScopedRegistrationRegistry instead of owning a Map",
+    rule: "workspace-launch-coordinator-private-map"
+  });
+}
+
+function isWorkspaceLaunchCoordinator(relativePath) {
+  const servicesRoot = `${rendererRoot}/features/workspace-workbench/services/`;
+  if (!relativePath.startsWith(servicesRoot)) {
+    return false;
+  }
+
+  const servicePath = relativePath.slice(servicesRoot.length);
+  if (servicePath.includes("/")) {
+    return false;
+  }
+
+  return (
+    servicePath.endsWith("LaunchCoordinator.ts") ||
+    servicePath === "workspaceMessageCenterCoordinator.ts"
+  );
 }
 
 function inspectImport(importerPath, specifier, line) {

--- a/tools/scripts/check-renderer-feature-boundaries.test.mjs
+++ b/tools/scripts/check-renderer-feature-boundaries.test.mjs
@@ -120,6 +120,56 @@ test("rejects feature service direct access to the preload API", async () => {
   assert.match(result.stderr, /renderer-window-tutti-access/);
 });
 
+test("rejects private Maps in workspace launch coordinators", async () => {
+  const workspaceRoot = await createFixtureWorkspace({
+    "features/workspace-workbench/services/workspaceExampleLaunchCoordinator.ts":
+      "const handlersByWorkspaceId = new Map<string, () => void>();\n"
+  });
+
+  const result = runBoundaryCheck(workspaceRoot);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /workspace-launch-coordinator-private-map/);
+  assert.match(result.stderr, /WorkspaceScopedRegistrationRegistry/);
+});
+
+test("rejects private Maps in the workspace message center coordinator", async () => {
+  const workspaceRoot = await createFixtureWorkspace({
+    "features/workspace-workbench/services/workspaceMessageCenterCoordinator.ts":
+      "const handlersByWorkspaceId = new Map<string, () => void>();\n"
+  });
+
+  const result = runBoundaryCheck(workspaceRoot);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /workspace-launch-coordinator-private-map/);
+});
+
+test("allows workspace launch coordinators to use the shared registration registry", async () => {
+  const workspaceRoot = await createFixtureWorkspace({
+    "features/workspace-workbench/services/internal/workspaceScopedRegistrationRegistry.ts":
+      "export class WorkspaceScopedRegistrationRegistry<T> {}\n",
+    "features/workspace-workbench/services/workspaceExampleLaunchCoordinator.ts":
+      'import { WorkspaceScopedRegistrationRegistry } from "./internal/workspaceScopedRegistrationRegistry";\nconst handlers = new WorkspaceScopedRegistrationRegistry<() => void>();\n'
+  });
+
+  const result = runBoundaryCheck(workspaceRoot);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /renderer feature boundary check passed/);
+});
+
+test("allows non-launch coordinator Maps outside the Shell registration rule", async () => {
+  const workspaceRoot = await createFixtureWorkspace({
+    "features/workspace-workbench/services/workspaceAgentGuiOpenSessionCoordinator.ts":
+      "const refCountsByWorkspaceId = new Map<string, number>();\n"
+  });
+
+  const result = runBoundaryCheck(workspaceRoot);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});
+
 async function createFixtureWorkspace(files) {
   const workspaceRoot = await mkdtemp(
     join(tmpdir(), "tutti-renderer-boundaries-")

--- a/tools/scripts/run-check-changed.mjs
+++ b/tools/scripts/run-check-changed.mjs
@@ -142,11 +142,7 @@ function buildChangedLanes() {
     });
   }
 
-  if (
-    changedFiles.some((file) =>
-      file.startsWith("apps/desktop/src/renderer/src/")
-    )
-  ) {
+  if (changedFiles.some(isRendererBoundaryRelevant)) {
     addLane({
       key: "boundary:renderer",
       label: "boundary:renderer",
@@ -578,6 +574,14 @@ export function isAgentActivityRuntimeBoundaryRelevant(file) {
     file === "tools/scripts/check-agent-activity-runtime-boundaries.mjs" ||
     file === "tools/scripts/check-agent-activity-runtime-boundaries.test.mjs" ||
     file.startsWith("tools/fixtures/agent-activity-runtime-boundaries/")
+  );
+}
+
+export function isRendererBoundaryRelevant(file) {
+  return (
+    file.startsWith("apps/desktop/src/renderer/src/") ||
+    file === "tools/scripts/check-renderer-feature-boundaries.mjs" ||
+    file === "tools/scripts/check-renderer-feature-boundaries.test.mjs"
   );
 }
 

--- a/tools/scripts/run-check-changed.test.mjs
+++ b/tools/scripts/run-check-changed.test.mjs
@@ -5,10 +5,25 @@ import { join } from "node:path";
 import test from "node:test";
 import {
   isAgentActivityRuntimeBoundaryRelevant,
+  isRendererBoundaryRelevant,
   printSummary,
   runLanes,
   selectExistingLintFiles
 } from "./run-check-changed.mjs";
+
+test("renderer boundary lane covers renderer and checker changes", () => {
+  for (const file of [
+    "apps/desktop/src/renderer/src/features/workspace-workbench/services/coordinator.ts",
+    "tools/scripts/check-renderer-feature-boundaries.mjs",
+    "tools/scripts/check-renderer-feature-boundaries.test.mjs"
+  ]) {
+    assert.equal(isRendererBoundaryRelevant(file), true, file);
+  }
+  assert.equal(
+    isRendererBoundaryRelevant("apps/desktop/src/main/index.ts"),
+    false
+  );
+});
 
 test("activity runtime boundary lane covers package, desktop adapter, and checker changes", () => {
   for (const file of [


### PR DESCRIPTION
## Summary

- reject private Map allocations in workspace-workbench launch coordinators and the Message Center coordinator
- direct new workspace-keyed Shell registrations to WorkspaceScopedRegistrationRegistry
- keep non-launch coordinator state such as Agent GUI open-session reference counts outside the rule
- make renderer-boundary checker and fixture changes select the live renderer boundary lane in check:changed
- document staged, changed-aware, and full-check coverage

## Validation

- renderer boundary and changed-runner tests (18 passed)
- pnpm check:renderer-boundaries
- pnpm check:changed
- staged renderer boundary hook
- pre-push pnpm check:full

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a static-analysis rule that blocks private Map allocations in workspace launch coordinators and the message center coordinator, enforcing `WorkspaceScopedRegistrationRegistry`. Also makes the renderer-boundary lane run when the checker or its fixtures change, and documents coverage.

- **New Features**
  - Enforce shared `WorkspaceScopedRegistrationRegistry` in `check:renderer-boundaries`; reject `new Map(...)` in `*LaunchCoordinator.ts` and `workspaceMessageCenterCoordinator.ts`.
  - Exclude non-launch coordinator state (e.g., Agent GUI open-session ref counts) from this rule.
  - Extend `check:changed` to select the renderer-boundary lane for renderer, checker, and test changes.
  - Update docs and tests to cover staged, changed-aware, and full runs.

<sup>Written for commit a7d389e4d4bd28ea3365110273444bf09b523925. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

