### PR TITLE
feat(workspace-apps): add local database directory

### DIFF
--- a/docs/architecture/workspace-app-factory.md
+++ b/docs/architecture/workspace-app-factory.md
@@ -140,6 +140,7 @@ apps/
   packages/<appId>/<version>/
   workspaces/<workspaceId>/<appId>/
     data/
+    database/
     runtime/
     logs/
 ```
@@ -151,7 +152,8 @@ directory.
 ## Preparation And Validation
 
 When present, `prepare.sh` must be an executable file. It runs with Factory
-runtime/data/log/toolchain environment directories and a bounded timeout.
+runtime/data/log/toolchain environment directories and a bounded timeout. It
+must not create or migrate an active app database during package preparation.
 
 Validation then verifies:
 
@@ -162,9 +164,10 @@ Validation then verifies:
 - a non-empty, runtime-cleaned `AGENTS.md`;
 - successful dry-run startup and healthcheck within the validation timeout.
 
-Validation uses the normal App Runner with a Factory-scoped workspace id and
-always stops the dry-run process afterward. Failure records a structured
-validation result and moves the job to `failed`.
+Validation uses the normal App Runner with a Factory-scoped workspace id,
+including an isolated `TUTTI_APP_DATABASE_DIR`, and always stops the dry-run
+process afterward. Failure records a structured validation result and moves the
+job to `failed`.
 
 This is local package/runtime validation, not static security analysis or
 cross-machine portability certification.
@@ -191,7 +194,10 @@ environment boundaries include:
 
 - `TUTTI_APP_PACKAGE_DIR`: read-only package content;
 - `TUTTI_APP_RUNTIME_DIR`: scratch/runtime data;
-- `TUTTI_APP_DATA_DIR`: durable app data;
+- `TUTTI_APP_DATA_DIR`: durable app artifacts and non-database state;
+- `TUTTI_APP_DATABASE_DIR`: host-local durable active databases and their
+  sidecar files, separate from data that may be referenced, exported, backed
+  up, or synchronized;
 - `TUTTI_APP_LOG_DIR`: backend logs;
 - `TUTTI_APP_TOOLCHAIN_ROOT`: reusable app-managed tools;
 - `TUTTI_APP_SERVER_TOKEN`: server-only scoped daemon access.
@@ -202,7 +208,8 @@ capabilities; App Factory does not currently provide sandbox, VM, container, or
 firewall isolation.
 
 App schemas and data migrations remain owned by each generated app. Package
-rollback changes code, not `TUTTI_APP_DATA_DIR`.
+rollback changes code, not `TUTTI_APP_DATA_DIR` or
+`TUTTI_APP_DATABASE_DIR`.
 
 ## Events And UI
 

--- a/docs/conventions/local-state-storage.md
+++ b/docs/conventions/local-state-storage.md
@@ -164,6 +164,7 @@ Migrated agent runtime state should derive from the same root:
         <installation-scope>/
           runtime/
           data/
+          database/
           logs/
     factory/
       jobs/
@@ -228,8 +229,12 @@ Tutti provider startup.
 - the bundled CLI discovers the managed daemon by reading `<state-dir>/run/tuttid.listener.json`
 - packaged desktop shim install or repair uses `<state-dir>/bin/tutti` as the user-level command path and points it at the packaged CLI binary
 - local development scripts install or repair `<state-dir>/bin/tutti-dev` as the development CLI command and default it to `TUTTI_ENV=development`
-- workspace app package cache, per-installation runtime/data/log state, and
+- workspace app package cache, per-installation runtime/data/database/log state, and
   app factory job working directories live under `<state-dir>/apps`
+- each workspace app installation receives a host-local durable `database/`
+  directory for active SQLite databases and other files that require local
+  filesystem locking; uninstalling the installation removes it with the rest
+  of that installation's state
 - workspace apps receive `<state-dir>/app-toolchains` as the shared cache root
   for reusable app-managed binaries
 

--- a/docs/conventions/workspace-app-runtime.md
+++ b/docs/conventions/workspace-app-runtime.md
@@ -4,6 +4,27 @@ Workspace App Center apps and daemon-managed ACP npm adapters run against a
 daemon-managed runtime baseline. App packages must not bundle or declare
 Python/Node versions; Tutti injects the managed runtime paths at launch.
 
+## App State Directories
+
+Each installed app receives installation-scoped directories below the Tutti
+state root. The runner creates them before `bootstrap.sh` starts and injects:
+
+- `TUTTI_APP_DATA_DIR` for durable artifacts and non-database state;
+- `TUTTI_APP_DATABASE_DIR` for host-local durable active databases, including
+  SQLite WAL/SHM files and indexes;
+- `TUTTI_APP_RUNTIME_DIR` for restartable scratch/runtime state;
+- `TUTTI_APP_LOG_DIR` for backend logs.
+
+An app may create multiple database files under `TUTTI_APP_DATABASE_DIR`.
+Keeping live databases separate prevents synchronized, referenced, or exported
+data paths from weakening filesystem locking and atomic-write guarantees. App
+restarts and package upgrades preserve the database directory; uninstalling the
+workspace app removes it together with the installation state root.
+
+`TUTTI_CLI` is the app-facing CLI contract. Apps and skills must not depend on a
+host-internal CLI configuration variable: the injected command is responsible
+for locating and authenticating its own daemon connection.
+
 ## Runtime Baseline
 
 The baseline runtime is componentized. The default baseline profile contains the

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/app-architecture.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/app-architecture.md
@@ -70,7 +70,8 @@ Tutti package startup:
 - Bind to `$TUTTI_APP_HOST:$TUTTI_APP_PORT`.
 - Use `$TUTTI_APP_NODE` for the app server and `$TUTTI_APP_NPM` for prepare/build steps; do not rely on system runtime names. Use `$TUTTI_APP_PYTHON` only when adapting an existing Python helper, not as the primary agent-enabled app server.
 - Treat `$TUTTI_APP_PACKAGE_DIR` as read-only after startup.
-- Store durable data under `$TUTTI_APP_DATA_DIR`.
+- Store durable artifacts and non-database state under `$TUTTI_APP_DATA_DIR`.
+- Store active SQLite databases, WAL/SHM files, indexes, and other database-managed files under the host-local durable `$TUTTI_APP_DATABASE_DIR`; multiple database files are allowed.
 - Store scratch files under `$TUTTI_APP_RUNTIME_DIR`.
 - Write file logs under `$TUTTI_APP_LOG_DIR` only when needed.
 - Read `$TUTTI_WORKSPACE_ROOT` only for explicit workspace features.

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/package-builder.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/package-builder.md
@@ -28,7 +28,7 @@ Generated `bootstrap.sh` should:
 - Resolve `TUTTI_APP_PACKAGE_DIR`, defaulting to its own directory for local direct startup.
 - Export app-specific env vars from Tutti runtime env vars.
 - Use `TUTTI_APP_NODE` instead of bare `node`.
-- Use `TUTTI_APP_DATA_DIR`, `TUTTI_APP_RUNTIME_DIR`, and `TUTTI_APP_LOG_DIR` for mutable files.
+- Use `TUTTI_APP_DATA_DIR` for durable artifacts, `TUTTI_APP_DATABASE_DIR` for active databases, `TUTTI_APP_RUNTIME_DIR` for scratch files, and `TUTTI_APP_LOG_DIR` for logs.
 - Set a package-local path for bundled MCP tools when local agents need them.
 - Start all required child processes and clean them up on `INT`/`TERM`.
 - Leave managed-agent credential, managed run cwd, and Codex home policy to `@tutti-os/agent-acp-kit` server calls. Do not export credentials or synthesize `CODEX_HOME` in `bootstrap.sh`.
@@ -46,12 +46,13 @@ export HOST="${TUTTI_APP_HOST:-127.0.0.1}"
 : "${TUTTI_APP_PORT:?TUTTI_APP_PORT is required}"
 export APP_PORT="$TUTTI_APP_PORT"
 export APP_DATA_ROOT="${TUTTI_APP_DATA_DIR:-$package_dir/.data}"
+export APP_DATABASE_ROOT="${TUTTI_APP_DATABASE_DIR:-$APP_DATA_ROOT/.database}"
 export APP_RUNTIME_ROOT="${TUTTI_APP_RUNTIME_DIR:-$APP_DATA_ROOT/.runtime}"
 export APP_WEB_DIST="$package_dir/dist"
 export APP_TOOLS_MCP_PATH="$package_dir/server/tools-mcp.js"
 
 node_bin="${TUTTI_APP_NODE:?TUTTI_APP_NODE is required}"
-mkdir -p "$APP_DATA_ROOT" "$APP_RUNTIME_ROOT"
+mkdir -p "$APP_DATA_ROOT" "$APP_DATABASE_ROOT" "$APP_RUNTIME_ROOT"
 
 cd "$APP_RUNTIME_ROOT"
 "$node_bin" "$package_dir/server/server.js"

--- a/services/tuttid/service/workspace/app_factory.go
+++ b/services/tuttid/service/workspace/app_factory.go
@@ -567,6 +567,7 @@ func (s *AppFactoryService) validatePackage(ctx context.Context, workspaceID str
 		RuntimeProfile:  strings.TrimSpace(manifest.Runtime.Profile),
 		RuntimeDir:      job.RuntimeDir,
 		DataDir:         job.DataDir,
+		DatabaseDir:     filepath.Join(filepath.Dir(job.DataDir), "database"),
 		LogDir:          job.LogDir,
 	})
 	if err != nil {

--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -116,7 +116,8 @@ The runtime must:
 - Fail startup with a clear error when `$TUTTI_APP_PORT` is absent. Do not guess, reserve, or hard-code a fallback port; the daemon owns port allocation.
 - Serve the manifest healthcheck path with a 2xx response.
 - Treat `$TUTTI_APP_PACKAGE_DIR` as read-only after startup.
-- Write durable app data only under `$TUTTI_APP_DATA_DIR`.
+- Write durable app artifacts and non-database state only under `$TUTTI_APP_DATA_DIR`.
+- Write active SQLite databases, WAL/SHM files, indexes, and other database-managed files only under `$TUTTI_APP_DATABASE_DIR`. The directory is host-local and durable for the installation; apps may create multiple databases beneath it.
 - Write scratch/runtime files only under `$TUTTI_APP_RUNTIME_DIR`.
 - Write logs only under `$TUTTI_APP_LOG_DIR` when backend/server-side file logs are needed.
 - Store reusable app-managed binaries only under `$TUTTI_APP_TOOLCHAIN_ROOT`.

--- a/services/tuttid/service/workspace/app_factory_reference/references/runtime-env.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/runtime-env.md
@@ -11,7 +11,8 @@ Use these environment variables:
 - `TUTTI_APP_INSTALLATION_ID`: current `<workspace-id>:<app-id>` installation id.
 - `TUTTI_APP_PACKAGE_DIR`: package files, read-only at runtime.
 - `TUTTI_APP_RUNTIME_DIR`: scratch/runtime files.
-- `TUTTI_APP_DATA_DIR`: durable app data.
+- `TUTTI_APP_DATA_DIR`: durable app artifacts and non-database state.
+- `TUTTI_APP_DATABASE_DIR`: host-local durable database files for this installation. Put active SQLite databases and their WAL/SHM files here; multiple database files are allowed.
 - `TUTTI_APP_LOG_DIR`: app logs.
 - `TUTTI_APP_TOOLCHAIN_ROOT`: shared daemon-owned toolchain cache for app-managed binaries that are safe to reuse across workspace app installations.
 - `TUTTI_APP_NODE`: managed Node.js executable path for generated apps.
@@ -29,6 +30,18 @@ Use these environment variables:
 Read `TUTTI_APP_SERVER_TOKEN` only in the app server process. Never send it to browser code, persist it, or write it to logs. It remains available for non-Agent app-scoped daemon resources. Agent catalog and composer discovery must not use this token, daemon URL, workspace ID, or app ID; call the `@tutti-os/agent-acp-kit/tutti` facade, which owns `TUTTI_CLI` execution.
 
 For local Tutti capabilities, use `TUTTI_CLI`.
+
+`TUTTI_APP_DATABASE_DIR` is intentionally separate from `TUTTI_APP_DATA_DIR`.
+The data directory may be exposed through app references, uploads, backup, or a
+synchronized workspace implementation, while a live SQLite database requires
+local filesystem locking and atomic-write semantics. Do not put a live SQLite
+database in `TUTTI_APP_DATA_DIR`, and do not expose host paths from either
+directory to browser code. An app can keep exportable snapshots or documents in
+the data directory while keeping its active database in the database directory.
+
+`TUTTI_CLI` is the complete app-facing CLI contract. App code and generated
+skills must not require, parse, or document host-internal CLI configuration
+variables; the host-provided command owns its own connection configuration.
 
 Tutti keeps the managed runtime baseline outside app packages under daemon-owned state. Operators can override the cache with `TUTTI_APP_RUNTIME_CACHE_ROOT`, point at an exact prepared runtime with `TUTTI_APP_RUNTIME_ROOT`, or override first-use runtime downloads with `TUTTI_APP_RUNTIME_CATALOG`. App packages must not set these variables themselves.
 

--- a/services/tuttid/service/workspace/app_factory_reference/references/validation-checklist.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/validation-checklist.md
@@ -18,7 +18,8 @@ Before finishing:
 - If `tutti.app.json` declares `references.listEndpoint`, that endpoint accepts JSON `POST` requests with optional `parentGroupId`, `filterText`, `cursor`, `timeRange`, and returns direct group/reference items using `location`, not host absolute `path`.
 - If `tutti.app.json` declares `references.searchEndpoint`, that endpoint accepts JSON `POST` requests with a required `query` plus optional `cursor`, `limit`, `kinds`, `timeRange`, and returns a flat, relevance-ordered list of reference items (no group items) using `location`, not host absolute `path`.
 - The `searchEndpoint` matches `query` against each file's **own name** only (the `displayName`), never against `location.path`, the containing folder/project, or `parentGroupLabel` — searching `2` must not return a file named `cover.svg` just because it lives in a project named `2222`.
-- Durable app data is written only under `TUTTI_APP_DATA_DIR`.
+- Durable app artifacts and non-database state are written only under `TUTTI_APP_DATA_DIR`.
+- Active databases, SQLite WAL/SHM files, indexes, and other database-managed files are written only under `TUTTI_APP_DATABASE_DIR`.
 - Runtime scratch data is written only under `TUTTI_APP_RUNTIME_DIR`.
 - Logs are written only under `TUTTI_APP_LOG_DIR`.
 - Reusable app-managed binaries are written only under `TUTTI_APP_TOOLCHAIN_ROOT`.

--- a/services/tuttid/service/workspace/apps_runner.go
+++ b/services/tuttid/service/workspace/apps_runner.go
@@ -52,6 +52,7 @@ type AppStartInput struct {
 	RuntimeProfile  string
 	RuntimeDir      string
 	DataDir         string
+	DatabaseDir     string
 	LogDir          string
 	Restart         bool
 }
@@ -174,6 +175,11 @@ func (r *AppRunner) startProcess(ctx context.Context, key string, input AppStart
 		r.setFailed(key, "startup", fmt.Errorf("create app data dir: %w", err))
 		return
 	}
+	if err := os.MkdirAll(input.DatabaseDir, 0o755); err != nil {
+		logAppRuntimeControl("workspace_app_runtime_start_failed", input, port, "startup", fmt.Errorf("create app database dir: %w", err))
+		r.setFailed(key, "startup", fmt.Errorf("create app database dir: %w", err))
+		return
+	}
 	if err := os.MkdirAll(input.LogDir, 0o755); err != nil {
 		logAppRuntimeControl("workspace_app_runtime_start_failed", input, port, "startup", fmt.Errorf("create app log dir: %w", err))
 		r.setFailed(key, "startup", fmt.Errorf("create app log dir: %w", err))
@@ -215,6 +221,7 @@ func (r *AppRunner) startProcess(ctx context.Context, key string, input AppStart
 		"TUTTI_APP_PACKAGE_DIR=" + input.PackageDir,
 		"TUTTI_APP_RUNTIME_DIR=" + input.RuntimeDir,
 		"TUTTI_APP_DATA_DIR=" + input.DataDir,
+		"TUTTI_APP_DATABASE_DIR=" + input.DatabaseDir,
 		"TUTTI_APP_LOG_DIR=" + input.LogDir,
 		"TUTTI_APP_TOOLCHAIN_ROOT=" + appToolchainRoot,
 		"TUTTI_APP_PORT=" + strconv.Itoa(port),
@@ -541,6 +548,7 @@ func writeAppStartupDiagnostic(logFile *os.File, input AppStartInput, bootstrapP
 	_, _ = fmt.Fprintf(logFile, "  cwd=%s\n", input.RuntimeDir)
 	_, _ = fmt.Fprintf(logFile, "  packageDir=%s\n", input.PackageDir)
 	_, _ = fmt.Fprintf(logFile, "  dataDir=%s\n", input.DataDir)
+	_, _ = fmt.Fprintf(logFile, "  databaseDir=%s\n", input.DatabaseDir)
 	_, _ = fmt.Fprintf(logFile, "  logDir=%s\n", input.LogDir)
 	_, _ = fmt.Fprintf(logFile, "  toolchainRoot=%s\n", appRuntimeEnvValue(env, "TUTTI_APP_TOOLCHAIN_ROOT"))
 	_, _ = fmt.Fprintf(logFile, "  host=127.0.0.1\n")

--- a/services/tuttid/service/workspace/apps_runner_test.go
+++ b/services/tuttid/service/workspace/apps_runner_test.go
@@ -30,6 +30,7 @@ func TestAppRunnerStartsHealthyAppWithWorkspaceScopedCwdAndInjectedDirs(t *testi
 	packageDir := filepath.Join(root, "package")
 	runtimeDir := filepath.Join(root, "runtime")
 	dataDir := filepath.Join(root, "data")
+	databaseDir := filepath.Join(root, "database")
 	logDir := filepath.Join(root, "logs")
 	if err := os.MkdirAll(packageDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(packageDir) error = %v", err)
@@ -59,6 +60,7 @@ exec "$TUTTI_APP_PYTHON" "$TUTTI_APP_PACKAGE_DIR/server.py"
 		HealthcheckPath: "/ready",
 		RuntimeDir:      runtimeDir,
 		DataDir:         dataDir,
+		DatabaseDir:     databaseDir,
 		LogDir:          logDir,
 	})
 	if err != nil {
@@ -77,6 +79,9 @@ exec "$TUTTI_APP_PYTHON" "$TUTTI_APP_PACKAGE_DIR/server.py"
 	if state.Port == nil || *state.Port <= 0 {
 		t.Fatalf("Port = %v", state.Port)
 	}
+	if info, err := os.Stat(databaseDir); err != nil || !info.IsDir() {
+		t.Fatalf("database directory stat = (%v, %v), want directory", info, err)
+	}
 
 	probePath := filepath.Join(dataDir, "probe.json")
 	probe, err := os.ReadFile(probePath)
@@ -94,6 +99,7 @@ exec "$TUTTI_APP_PYTHON" "$TUTTI_APP_PACKAGE_DIR/server.py"
 		"packageDir":    packageDir,
 		"runtimeDir":    runtimeDir,
 		"dataDir":       dataDir,
+		"databaseDir":   databaseDir,
 		"logDir":        logDir,
 		"toolchainRoot": filepath.Join(stateRoot, "app-toolchains"),
 		"workspaceRoot": root,
@@ -187,6 +193,7 @@ exec python3 "$TUTTI_APP_PACKAGE_DIR/server.py"
 		RuntimeProfile:  workspaceAppStandaloneRuntimeProfile,
 		RuntimeDir:      runtimeDir,
 		DataDir:         dataDir,
+		DatabaseDir:     filepath.Join(root, "database"),
 		LogDir:          logDir,
 	})
 	if err != nil {
@@ -249,6 +256,7 @@ exec "$TUTTI_APP_PYTHON" "$TUTTI_APP_PACKAGE_DIR/server.py"
 		HealthcheckPath: "/ready",
 		RuntimeDir:      runtimeDir,
 		DataDir:         dataDir,
+		DatabaseDir:     filepath.Join(root, "database"),
 		LogDir:          logDir,
 	}
 	if _, err := runner.Start(context.Background(), input); err != nil {
@@ -486,6 +494,7 @@ func TestAppRunnerStartWithoutRestartReusesQueuedStart(t *testing.T) {
 		HealthcheckPath: "/ready",
 		RuntimeDir:      filepath.Join(root, "runtime"),
 		DataDir:         filepath.Join(root, "data"),
+		DatabaseDir:     filepath.Join(root, "database"),
 		LogDir:          filepath.Join(root, "logs"),
 	}
 	state, err := runner.Start(context.Background(), input)
@@ -564,6 +573,7 @@ func TestAppRunnerStartWithoutRestartReusesStartingProcess(t *testing.T) {
 		HealthcheckPath: "/ready",
 		RuntimeDir:      filepath.Join(root, "runtime"),
 		DataDir:         filepath.Join(root, "data"),
+		DatabaseDir:     filepath.Join(root, "database"),
 		LogDir:          filepath.Join(root, "logs"),
 	}
 	if _, err := runner.Start(context.Background(), input); err != nil {
@@ -626,6 +636,7 @@ exec "$TUTTI_APP_NODE" "$TUTTI_APP_PACKAGE_DIR/server.js"
 		HealthcheckPath: "/healthz",
 		RuntimeDir:      runtimeDir,
 		DataDir:         dataDir,
+		DatabaseDir:     filepath.Join(root, "database"),
 		LogDir:          logDir,
 	})
 	if err != nil {
@@ -674,6 +685,7 @@ sleep 30
 		HealthcheckPath: "/ready",
 		RuntimeDir:      filepath.Join(root, "runtime"),
 		DataDir:         filepath.Join(root, "data"),
+		DatabaseDir:     filepath.Join(root, "database"),
 		LogDir:          filepath.Join(root, "logs"),
 	})
 	if err != nil {
@@ -737,6 +749,7 @@ sleep 30
 		HealthcheckPath: "/ready",
 		RuntimeDir:      filepath.Join(root, "runtime"),
 		DataDir:         filepath.Join(root, "data"),
+		DatabaseDir:     filepath.Join(root, "database"),
 		LogDir:          filepath.Join(root, "logs"),
 	})
 	if err != nil {
@@ -891,6 +904,7 @@ func pythonAppReadyServerScript(healthcheckPath string, writeProbe bool) string 
                 "packageDir": os.environ["TUTTI_APP_PACKAGE_DIR"],
                 "runtimeDir": os.environ["TUTTI_APP_RUNTIME_DIR"],
                 "dataDir": os.environ["TUTTI_APP_DATA_DIR"],
+                "databaseDir": os.environ["TUTTI_APP_DATABASE_DIR"],
                 "logDir": os.environ["TUTTI_APP_LOG_DIR"],
                 "toolchainRoot": os.environ["TUTTI_APP_TOOLCHAIN_ROOT"],
                 "tuttiCli": os.environ["TUTTI_CLI"],

--- a/services/tuttid/service/workspace/apps_runtime.go
+++ b/services/tuttid/service/workspace/apps_runtime.go
@@ -283,6 +283,7 @@ func (s *AppCenterService) startPackage(ctx context.Context, workspaceID string,
 		RuntimeProfile:  appRuntimeProfileForPackage(appPackage),
 		RuntimeDir:      filepath.Join(root, "runtime"),
 		DataDir:         filepath.Join(root, "data"),
+		DatabaseDir:     filepath.Join(root, "database"),
 		LogDir:          filepath.Join(root, "logs"),
 		Restart:         restart,
 	})

--- a/services/tuttid/service/workspace/apps_test.go
+++ b/services/tuttid/service/workspace/apps_test.go
@@ -3173,11 +3173,11 @@ func TestAppCenterServiceRemoveDeletesWorkspaceAppState(t *testing.T) {
 		StateDir:       t.TempDir(),
 	}
 	stateRoot := service.workspaceAppStateRoot("ws-1", "sample-app")
-	if err := os.MkdirAll(filepath.Join(stateRoot, "data"), 0o755); err != nil {
-		t.Fatalf("create app data dir: %v", err)
+	if err := os.MkdirAll(filepath.Join(stateRoot, "database"), 0o755); err != nil {
+		t.Fatalf("create app database dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(stateRoot, "data", "app.sqlite"), []byte("sqlite data"), 0o644); err != nil {
-		t.Fatalf("write app data: %v", err)
+	if err := os.WriteFile(filepath.Join(stateRoot, "database", "app.sqlite"), []byte("sqlite data"), 0o644); err != nil {
+		t.Fatalf("write app database: %v", err)
 	}
 
 	if _, err := service.Remove(context.Background(), "ws-1", "sample-app"); err != nil {


### PR DESCRIPTION
## Summary

- add an installation-scoped, host-local `database/` directory to the Workspace App state layout
- create the directory before app startup and inject it as `TUTTI_APP_DATABASE_DIR`
- pass the same contract through App Factory dry-run validation
- update the embedded Workspace App Factory and Agent Workspace App skills to keep active SQLite/WAL/SHM files separate from artifact data
- document persistence, uninstall cleanup, multiple-database support, and the `TUTTI_CLI` ownership boundary

## Runtime chain

```text
AppCenterService.startPackage
  -> <state-dir>/apps/installations/<app-id>/<scope>/database
  -> AppRunner creates the directory
  -> TUTTI_APP_DATABASE_DIR is injected into bootstrap.sh
  -> app keeps active databases and sidecar files under that directory
```

The directory survives app restarts and package upgrades because it belongs to the installation state root. Uninstalling the app removes the whole state root, including the database directory.

## CLI configuration decision

This change intentionally does not add `TUTTI_CLI_CONFIG` to the public Workspace App contract. `TUTTI_CLI` remains the complete app-facing entrypoint, and the injected command owns daemon discovery and authentication. Apps and generated skills must not parse host-internal CLI configuration.

## Validation

- `go test ./service/workspace`
- `go test ./service/workspace -run '^(TestAppRunner|TestAppCenterServiceRemoveDeletesWorkspaceAppState|TestAppCenterServiceDeletePackageRemovesWorkspaceAppState)'`
- `pnpm check:changed --tail-lines 80`
- pre-push `pnpm check:full` passed preparation, all preflight checks, and the changed `services/tuttid/service/workspace` package; it hit three unrelated concurrent timeout failures
- isolated reruns passed:
  - `go test ./runtime -run '^TestLocalProcessTransportFindsKnownNodeGlobalBin$' -count=1`
  - `go test ./service/agentstatus -run '^(TestServiceListReportsCodexChecksVersionAndLastError|TestServiceListRunsCodexLauncherWithManagedNodePath)$' -count=1`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a host‑local `database/` directory for each Workspace App installation and inject `TUTTI_APP_DATABASE_DIR` at startup. This keeps active SQLite/WAL/SHM files separate from artifacts, survives restarts and upgrades, and is removed on uninstall.

- **New Features**
  - Runner creates `<state>/apps/installations/<app-id>/<scope>/database` and exports `TUTTI_APP_DATABASE_DIR` to `bootstrap.sh`.
  - App Factory dry‑run validation uses an isolated database dir.
  - Updated Factory and Agent references, templates, and tests to use `TUTTI_APP_DATABASE_DIR`; documented persistence, uninstall cleanup, multiple DB support, and that `TUTTI_CLI` remains the single app‑facing entrypoint.

- **Migration**
  - Store active databases and sidecar files under `TUTTI_APP_DATABASE_DIR`; keep exported/synced artifacts under `TUTTI_APP_DATA_DIR`.
  - Update any `bootstrap.sh` or app code that wrote databases to `DATA_DIR` to create and use `DATABASE_DIR` instead.

<sup>Written for commit ce84958f9b4b6fbd18c9f169b5e07ffc04582f9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->