### PR TITLE
fix(agent): harden ACP lifecycle and Cursor model discovery

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -330,6 +330,17 @@ When an empty composer has an `agentTargetId`, model, permission, reasoning,
 and speed options are target-scoped. Do not fall back to provider-level options
 for that target; a missing target-scoped option snapshot should remain a
 loading/missing state until the target options arrive.
+Providers whose model catalog exists only after runtime session bootstrap must
+declare hidden live-model probing and its cache scope in their provider
+descriptor. The daemon may
+start an invisible, no-prompt discovery session, cache the advertised catalog,
+and clean up that session after discovery so a first-time empty composer can
+choose a non-default model before creating a visible conversation. When visible
+conversation creation settles, AgentGUI must force one target-scoped options
+refresh: an earlier selected-model-only bootstrap response must not stay
+valid merely because its request signature matches. This refresh goes through
+`AgentActivityRuntime`; AgentGUI must not recover the catalog by reading private
+session runtime context.
 When a model catalog advertises model-specific reasoning profiles, the composer
 must derive the reasoning options from the currently presented model and
 re-resolve an unsupported prior effort to that model's advertised default.

--- a/docs/architecture/agent-runtime-preparation.md
+++ b/docs/architecture/agent-runtime-preparation.md
@@ -19,6 +19,16 @@ Dynamic host skills use `SkillSource`; per-session skills use `ExtraSkills`.
 The canonical template and shared skill bodies remain in runtimeprep so hosts
 do not fork the actual prompt content.
 
+Cursor preparation materializes one session-scoped skill plugin outside the
+workspace and supplies it to `cursor-agent acp` through `--plugin-dir`. Cursor
+Agent `2026.07.01-41b2de7` does not merge plugin-provided hooks into its ACP hook
+executor: only user, project, and team hook sources are loaded. Runtimeprep
+therefore must not advertise or materialize plugin hooks for ACP. A focused
+background-Task guard implementation remains dormant with unit coverage so it
+can be enabled if Cursor adds that capability; it is not a current runtime
+guarantee. Never write an equivalent hook into user or project Cursor config to
+work around the provider limitation.
+
 Product-owned responsibilities remain outside the module:
 
 - process or VM transport;

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -387,12 +387,15 @@ file or directory`. If the CLI path exists but `codex app-server` cannot
   `cwd/AGENTS.md`, which dirtied tracked repositories.
 - Fix:
   Materialize Tutti Cursor skills as a session-scoped Cursor plugin with
-  `.cursor-plugin/plugin.json` and `skills/*/SKILL.md`, expose it through
+  `.cursor-plugin/plugin.json` and `skills/*/SKILL.md`; expose it through
   `TUTTI_CURSOR_PLUGIN_DIR`, and start Cursor ACP as
   `cursor-agent --plugin-dir <plugin-dir> acp`. Keep user/project
   `.cursor/skills` discoverable for composer options, but never write Tutti
   injected skills or Tutti runtime instructions into the workspace cwd for
-  Cursor sessions.
+  Cursor sessions. Cursor Agent `2026.07.01-41b2de7` does not load plugin hooks
+  in ACP mode, so do not advertise the dormant background-Task guard in the
+  plugin manifest and do not claim that background Task is blocked. Do not
+  install the hook into user or project Cursor configuration as a workaround.
 - Validation:
   Add `runtimeprep` coverage that Cursor prepare creates the runtime plugin
   while leaving project `.cursor/skills` and `AGENTS.md` untouched, runtime

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -78,3 +78,4 @@ Approval gates, plan exits, root/parent/child event attribution, child sessions,
 - [Claude SDK subagent approval stuck in Message Center](./agent-approvals-subagents.md#claude-sdk-subagent-approval-stuck-in-message-center)
 - [Root remains active after all child turns settle](./agent-approvals-subagents.md#root-remains-active-after-all-child-turns-settle)
 - [Provider terminal report replays a settled root as running](./agent-approvals-subagents.md#provider-terminal-report-replays-a-settled-root-as-running)
+- [Cursor or OpenCode turn settles before late ACP activity arrives](./agent-session-lifecycle.md#cursor-or-opencode-turn-settles-before-late-acp-activity-arrives)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -227,6 +227,63 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [sessionLifecycle.reducer.ts](../../../packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts)
   [controller_exec.go](../../../packages/agent/daemon/runtime/controller_exec.go)
 
+### Cursor or OpenCode turn settles before late ACP activity arrives
+
+- Symptom:
+  A Cursor or OpenCode turn appears complete, then a delayed tool or permission
+  event is projected onto the old turn; the composer may relock, persistence
+  may reject a settled-to-running transition, or a synthetic turn may appear.
+  A Cursor background Task may also appear launched successfully while its
+  detached child later requests permissions that never reach the UI.
+- Quick checks:
+  Correlate `session/prompt` response timing with later `session/update` or
+  `session/request_permission` messages. If the prompt response arrived first,
+  the late event no longer has an active canonical turn owner. Also verify the
+  terminal report is `root_provider_turn.completed`, not a direct canonical
+  `turn.completed` from the ACP adapter. For Cursor Task/subagent probes,
+  correlate `agent_session.cursor.task_tool_update` with
+  `agent_session.cursor.task_extension`; the latter records only redacted
+  identity, ordering, field-presence, and duration facts. A background Task
+  tool result with `isBackground=true` and a very short duration is a launch
+  acknowledgement, not child terminal evidence. Permission requests arriving
+  after the root prompt result confirm the child is still running out of scope.
+- Root cause:
+  Standard ACP has one active prompt handler and a session-level fallback
+  handler. Reusing a recent turn ID in the fallback path treats temporal
+  proximity as ownership. That can reopen a settled root or fabricate a turn,
+  and ordinary tool display fields do not supply the stable child identity and
+  terminal lifecycle required for a provider-native child session. Cursor's
+  background Task implementation records eventual completion in an internal
+  work registry, but Cursor ACP `2026.07.01-41b2de7` does not expose that
+  terminal to Tutti.
+- Fix:
+  Route every Standard ACP prompt terminal through the daemon-owned root
+  provider lifecycle. Drop turn-scoped tool/message updates outside the active
+  prompt call and reject out-of-band permission callbacks; never synthesize a
+  canonical turn. Keep Cursor/OpenCode root-only until their ACP transports
+  expose stable child, parent, and child-terminal facts. Cursor Agent
+  `2026.07.01-41b2de7` does not merge `--plugin-dir` hooks into ACP, so the
+  dormant `preToolUse` Task guard is deliberately not advertised or
+  materialized. Do not treat background Task as supported or blocked, do not
+  write hooks into user/project configuration, and do not settle a detached
+  child from a guessed timeout.
+- Validation:
+  Cover Cursor and OpenCode normal completion with
+  `root_provider_turn.started/completed` and no canonical terminal from the
+  adapter. Deliver a late tool update and late permission after prompt return
+  and verify neither creates a turn, interaction, or child session. Make a
+  `session/cancel` write fail and verify the error reaches the caller. Also
+  fail an automatic permission-response write and verify the adapter does not
+  report a false approval while the provider is still waiting. Verify the
+  dormant Cursor hook allows foreground Task inputs, rejects snake-case and
+  camel-case background flags, does not match flag-like text inside the Task
+  prompt, and fails closed for malformed input; separately verify the current
+  ACP plugin manifest does not advertise or materialize that hook.
+- References:
+  [standard_acp_turn.go](../../../packages/agent/daemon/runtime/standard_acp_turn.go)
+  [standard_acp_stream.go](../../../packages/agent/daemon/runtime/standard_acp_stream.go)
+  [provider-native subagents](../../specs/2026-07-15-provider-native-subagents.md)
+
 ### Codex goal stops after a turn while the goal remains active
 
 - Symptom:

--- a/docs/specs/2026-07-15-provider-native-subagents.md
+++ b/docs/specs/2026-07-15-provider-native-subagents.md
@@ -626,7 +626,31 @@ Treat ACP as capability-driven:
 
 - The current standard ACP adapter does not opt in. It does not infer child
   sessions from ordinary tool/progress updates and exposes no parallel
-  background-agent runtime projection.
+  background-agent runtime projection. Cursor and OpenCode therefore remain
+  root-only until their ACP transports expose the required identity and
+  lifecycle facts; a tool named `Task`, `Agent`, or similar is not enough.
+- Cursor Agent `2026.07.01-41b2de7` also emits a private, non-blocking
+  `cursor/task` extension containing `toolCallId`, `agentId`, task metadata,
+  and optional duration after Task activity. This is stronger identity
+  evidence than the ordinary Task card, but it does not supply one uniform
+  child lifecycle. For a foreground Task, the extension follows the completed
+  Task execution. For `run_in_background=true`, the Task result and extension
+  acknowledge launch within the root prompt while the detached child continues
+  running. Cursor records the later completion in its internal background-work
+  registry, but this ACP version does not bridge that terminal back through a
+  child event or a synthetic provider turn. Log only identifiers, field
+  presence, enum/model values, durations, and text lengths; never log task
+  prompt or description content.
+- Until Cursor ACP exposes the detached child terminal, Tutti supports Cursor
+  Task execution only in the foreground at the canonical-model level. Cursor
+  Agent `2026.07.01-41b2de7` does not merge hooks from `--plugin-dir` into its
+  ACP hook executor, so Tutti cannot currently enforce that restriction before
+  launch without modifying user/project Cursor configuration. Runtimeprep keeps
+  a tested `preToolUse` background-Task guard dormant, but deliberately omits it
+  from the generated plugin manifest and runtime artifact. Do not claim that
+  background Task is blocked, do not write the guard into user/project config,
+  and do not invent a child terminal, keep the canonical root waiting, or
+  settle from a guessed timeout when a detached Task is observed.
 - An ACP provider may create child sessions only when it supplies a stable child
   id, the direct parent session/turn or parent tool-call id, and child turn
   terminal events.
@@ -636,6 +660,12 @@ Treat ACP as capability-driven:
   reconcile the explicit ids before emitting `root_provider_turn_completed`.
 - Root provider terminal events map to `root_provider_turn_completed` and use
   the same `services/tuttid` root/child completion rule as Codex and Claude.
+  Standard ACP adapters must not emit a canonical root `turn.completed`,
+  `turn.failed`, or `turn.canceled` directly from the `session/prompt` result.
+- Turn-scoped ACP message, thought, tool, and permission events are accepted
+  only while their owning `session/prompt` call is active. A late notification
+  after the prompt result must not be attached to a recently settled root turn,
+  and the adapter must not fabricate a synthetic turn to make it persistable.
 - If the provider only emits ordinary tool calls, display text, or progress
   without stable parent/child ids, treat them as ordinary tool calls, not child
   sessions.
@@ -644,6 +674,12 @@ Treat ACP as capability-driven:
   child cancel API does not justify a second completion model.
 - Root-turn guidance support is declared by the provider. Direct user guidance
   to one child remains unsupported.
+- Standard ACP cancellation is root-only. A failed `session/cancel` transport
+  write is an operation failure, not provider confirmation; it must propagate
+  to the durable cancel workflow instead of being reported as success.
+- The same rule applies to automatic permission decisions: a failed ACP
+  response write must be surfaced as an operation failure, never treated as a
+  resolved approval while the provider is still waiting.
 
 ACP adapters should not invent subagent identity from display text, tool title,
 or message order alone.

--- a/packages/agent/daemon/providerregistry/claude_code.go
+++ b/packages/agent/daemon/providerregistry/claude_code.go
@@ -68,8 +68,9 @@ func claudeCodeDescriptor() ProviderDescriptor {
 		ComposerProfile: ComposerProfileDescriptor{
 			ModelSelection: true,
 			LiveModelDiscovery: LiveModelDiscoveryDescriptor{
-				Kind:        LiveModelDiscoveryKindClaudeSDK,
-				HiddenProbe: true,
+				Kind:          LiveModelDiscoveryKindClaudeSDK,
+				HiddenProbe:   true,
+				AccountScoped: true,
 			},
 			ReasoningEffort:        true,
 			ReasoningEffortValues:  []string{"low", "medium", "high", "xhigh"},

--- a/packages/agent/daemon/providerregistry/providers.go
+++ b/packages/agent/daemon/providerregistry/providers.go
@@ -35,7 +35,10 @@ func cursorDescriptor() ProviderDescriptor {
 			Install: InstallerDescriptor{Kind: InstallerKindOfficialScript, DisplayCommand: "curl https://cursor.com/install -fsS | bash", ScriptURL: "https://cursor.com/install", ScriptShell: "bash"},
 		},
 		ComposerProfile: ComposerProfileDescriptor{
-			ModelSelection: true, LiveModelDiscovery: LiveModelDiscoveryDescriptor{Kind: LiveModelDiscoveryKindRuntimeSession}, Capabilities: []string{CapabilityImageInput, CapabilityModelImageInputRequired, CapabilityInterrupt, CapabilityPlanMode}, PermissionConfigurable: true, DefaultPermissionModeID: "agent",
+			// Cursor exposes its account-scoped model catalog from ACP session/new,
+			// so an empty composer needs a no-prompt hidden session before the first
+			// visible conversation can choose a non-default model.
+			ModelSelection: true, LiveModelDiscovery: LiveModelDiscoveryDescriptor{Kind: LiveModelDiscoveryKindRuntimeSession, HiddenProbe: true, AccountScoped: true}, Capabilities: []string{CapabilityImageInput, CapabilityModelImageInputRequired, CapabilityInterrupt, CapabilityPlanMode}, PermissionConfigurable: true, DefaultPermissionModeID: "agent",
 			PermissionModes: []PermissionModeDescriptor{{ID: "read-only", Semantic: "ask-before-write"}, {ID: "agent", Semantic: "auto"}, {ID: "full-access", Semantic: "full-access"}}, ConfigOptionIDs: ComposerConfigOptionIDs{Model: "model"},
 			SlashCommandPolicy: SlashCommandPolicyDescriptor{
 				FallbackCommands:            []string{"plan"},

--- a/packages/agent/daemon/providerregistry/registry.go
+++ b/packages/agent/daemon/providerregistry/registry.go
@@ -448,6 +448,10 @@ func Validate(descriptor ProviderDescriptor) error {
 	default:
 		return fmt.Errorf("provider %q live model discovery kind %q is unsupported", providerID, descriptor.ComposerProfile.LiveModelDiscovery.Kind)
 	}
+	if descriptor.ComposerProfile.LiveModelDiscovery.Kind == "" &&
+		(descriptor.ComposerProfile.LiveModelDiscovery.HiddenProbe || descriptor.ComposerProfile.LiveModelDiscovery.AccountScoped) {
+		return fmt.Errorf("provider %q live model discovery behavior requires a discovery kind", providerID)
+	}
 	if descriptor.ComposerProfile.LiveModelDiscovery.Kind != "" && descriptor.ComposerProfile.ModelCatalog != "" {
 		return fmt.Errorf("provider %q cannot declare both live model discovery and a model catalog", providerID)
 	}

--- a/packages/agent/daemon/providerregistry/registry_test.go
+++ b/packages/agent/daemon/providerregistry/registry_test.go
@@ -195,7 +195,9 @@ func TestMigratedClaudeCodeDescriptorIsComplete(t *testing.T) {
 	}
 	if descriptor.Runtime.Kind != RuntimeKindClaudeSDK ||
 		descriptor.Status.Kind != StatusKindClaudeCLI ||
-		descriptor.ComposerProfile.LiveModelDiscovery.Kind != LiveModelDiscoveryKindClaudeSDK {
+		descriptor.ComposerProfile.LiveModelDiscovery.Kind != LiveModelDiscoveryKindClaudeSDK ||
+		!descriptor.ComposerProfile.LiveModelDiscovery.HiddenProbe ||
+		!descriptor.ComposerProfile.LiveModelDiscovery.AccountScoped {
 		t.Fatalf("implementation kinds = %#v", descriptor)
 	}
 	if descriptor.Target.ID != ClaudeCodeTargetID ||

--- a/packages/agent/daemon/providerregistry/types.go
+++ b/packages/agent/daemon/providerregistry/types.go
@@ -331,8 +331,9 @@ const (
 )
 
 type LiveModelDiscoveryDescriptor struct {
-	Kind        LiveModelDiscoveryKind
-	HiddenProbe bool
+	Kind          LiveModelDiscoveryKind
+	HiddenProbe   bool
+	AccountScoped bool
 }
 
 type ComposerBehaviorDescriptor struct {

--- a/packages/agent/daemon/runtime/acp_auto_continue_test.go
+++ b/packages/agent/daemon/runtime/acp_auto_continue_test.go
@@ -165,11 +165,9 @@ func TestCursorAdapterAutoContinuesAfterRetriableTurnError(t *testing.T) {
 			asString(event.Payload.Metadata["noticeKind"]) == "transport_retry" {
 			sawRetryNotice = true
 		}
-		if event.Type == activityshared.EventTurnCompleted {
-			sawCompleted = true
-		}
-		if event.Type == activityshared.EventTurnFailed {
-			sawFailed = true
+		if event.Type == activityshared.EventRootProviderTurnCompleted {
+			sawCompleted = event.Payload.TurnOutcome == string(activityshared.TurnOutcomeCompleted)
+			sawFailed = event.Payload.TurnOutcome == string(activityshared.TurnOutcomeFailed)
 		}
 	}
 	if !sawRetryNotice {
@@ -243,11 +241,9 @@ func TestCursorAdapterAutoContinueToolOnlyContinuationCompletes(t *testing.T) {
 
 	var sawCompleted, sawFailed bool
 	for _, event := range events {
-		if event.Type == activityshared.EventTurnCompleted {
-			sawCompleted = true
-		}
-		if event.Type == activityshared.EventTurnFailed {
-			sawFailed = true
+		if event.Type == activityshared.EventRootProviderTurnCompleted {
+			sawCompleted = event.Payload.TurnOutcome == string(activityshared.TurnOutcomeCompleted)
+			sawFailed = event.Payload.TurnOutcome == string(activityshared.TurnOutcomeFailed)
 		}
 	}
 	if !sawCompleted || sawFailed {
@@ -284,11 +280,13 @@ func TestCursorAdapterAutoContinueExhaustedMarksTurnFailed(t *testing.T) {
 	var failedError string
 	var sawCompleted bool
 	for _, event := range events {
-		if event.Type == activityshared.EventTurnFailed {
-			failedError = asString(event.Payload.Metadata["error"])
-		}
-		if event.Type == activityshared.EventTurnCompleted {
-			sawCompleted = true
+		if event.Type == activityshared.EventRootProviderTurnCompleted {
+			switch event.Payload.TurnOutcome {
+			case string(activityshared.TurnOutcomeFailed):
+				failedError = asString(event.Payload.Metadata["error"])
+			case string(activityshared.TurnOutcomeCompleted):
+				sawCompleted = true
+			}
 		}
 	}
 	if !strings.Contains(failedError, "RetriableError") {
@@ -325,7 +323,8 @@ func TestStandardACPAdapterWithoutOptInDoesNotAutoContinue(t *testing.T) {
 		t.Fatalf("prompt calls = %d, want no auto-continue without the opt-in", promptCalls)
 	}
 	for _, event := range events {
-		if event.Type == activityshared.EventTurnFailed {
+		if event.Type == activityshared.EventRootProviderTurnCompleted &&
+			event.Payload.TurnOutcome == string(activityshared.TurnOutcomeFailed) {
 			t.Fatalf("event = %#v, want the legacy completed turn", event)
 		}
 	}
@@ -356,13 +355,12 @@ func TestCursorAdapterSoftSettlesPlanLimitPromptError(t *testing.T) {
 	var noticeTitle string
 	for _, event := range events {
 		switch event.Type {
-		case activityshared.EventTurnCompleted:
-			sawCompleted = true
+		case activityshared.EventRootProviderTurnCompleted:
+			sawCompleted = event.Payload.TurnOutcome == string(activityshared.TurnOutcomeCompleted)
+			sawFailed = event.Payload.TurnOutcome == string(activityshared.TurnOutcomeFailed)
 			if event.Payload.Metadata["planLimit"] != true {
 				t.Fatalf("completed metadata = %#v, want planLimit true", event.Payload.Metadata)
 			}
-		case activityshared.EventTurnFailed:
-			sawFailed = true
 		case activityshared.EventMessageAppended:
 			if asString(event.Payload.Metadata["kind"]) == "agent_system_notice" {
 				noticeTitle = asString(event.Payload.Metadata["title"])

--- a/packages/agent/daemon/runtime/acp_provider_cursor.go
+++ b/packages/agent/daemon/runtime/acp_provider_cursor.go
@@ -126,6 +126,11 @@ func newCursorAdapterFromProviderDescriptor(
 	adapter.config.commandWithSettings = cursorACPCommandWithPluginDir
 	adapter.config.autoApprovePermissionDecision = cursorAutoApprovePermissionDecision
 	adapter.config.autoContinueRetriableTurnError = true
+	adapter.config.messageDiagnostics = &standardACPMessageDiagnostics{
+		method:         cursorACPMethodTask,
+		observeMessage: logCursorACPTaskExtension,
+		observeUpdate:  logCursorACPTaskToolUpdate,
+	}
 	return adapter
 }
 

--- a/packages/agent/daemon/runtime/cursor_acp_task_diagnostics.go
+++ b/packages/agent/daemon/runtime/cursor_acp_task_diagnostics.go
@@ -1,0 +1,150 @@
+package agentruntime
+
+import (
+	"encoding/json"
+	"log/slog"
+	"strings"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+const cursorACPMethodTask = "cursor/task"
+
+type cursorACPTaskExtensionDiagnostic struct {
+	ToolCallID        string
+	AgentID           string
+	Model             string
+	SubagentType      string
+	PromptLength      int
+	DescriptionLength int
+	DurationMS        any
+	HasPrompt         bool
+	HasDescription    bool
+	HasAgentID        bool
+	HasDuration       bool
+}
+
+func parseCursorACPTaskExtensionDiagnostic(raw json.RawMessage) (cursorACPTaskExtensionDiagnostic, bool) {
+	var params map[string]any
+	if err := json.Unmarshal(raw, &params); err != nil || params == nil {
+		return cursorACPTaskExtensionDiagnostic{}, false
+	}
+	prompt, promptPresent := params["prompt"].(string)
+	description, descriptionPresent := params["description"].(string)
+	agentID := strings.TrimSpace(asString(params["agentId"]))
+	durationMS, durationPresent := int64Value(params["durationMs"])
+	diagnostic := cursorACPTaskExtensionDiagnostic{
+		ToolCallID:        strings.TrimSpace(asString(params["toolCallId"])),
+		AgentID:           agentID,
+		Model:             strings.TrimSpace(asString(params["model"])),
+		SubagentType:      cursorACPTaskSubagentTypeLogValue(params["subagentType"]),
+		PromptLength:      len(prompt),
+		DescriptionLength: len(description),
+		DurationMS:        nil,
+		HasPrompt:         promptPresent,
+		HasDescription:    descriptionPresent,
+		HasAgentID:        agentID != "",
+		HasDuration:       durationPresent,
+	}
+	if durationPresent {
+		diagnostic.DurationMS = durationMS
+	}
+	return diagnostic, true
+}
+
+func cursorACPTaskSubagentTypeLogValue(value any) string {
+	if value := strings.TrimSpace(asString(value)); value != "" {
+		return value
+	}
+	if custom, ok := value.(map[string]any); ok && len(custom) > 0 {
+		return "custom"
+	}
+	return ""
+}
+
+func logCursorACPTaskExtension(
+	config standardACPConfig,
+	session Session,
+	turnID string,
+	message acpMessage,
+	normalizer *acpTurnNormalizer,
+) {
+	diagnostic, parsed := parseCursorACPTaskExtensionDiagnostic(message.Params)
+	slog.Info("agent session Cursor ACP task extension observed",
+		"event", "agent_session.cursor.task_extension",
+		"provider", config.provider,
+		"adapter", config.adapterName,
+		"room_id", session.RoomID,
+		"agent_session_id", session.AgentSessionID,
+		"provider_session_id", session.ProviderSessionID,
+		"turn_id", strings.TrimSpace(turnID),
+		"message_id", rawMessageLogValue(message.ID),
+		"inside_active_prompt", normalizer != nil && strings.TrimSpace(turnID) != "",
+		"params_parsed", parsed,
+		"tool_call_id", diagnostic.ToolCallID,
+		"has_agent_id", diagnostic.HasAgentID,
+		"agent_id", diagnostic.AgentID,
+		"subagent_type", diagnostic.SubagentType,
+		"model", diagnostic.Model,
+		"has_prompt", diagnostic.HasPrompt,
+		"prompt_length", diagnostic.PromptLength,
+		"has_description", diagnostic.HasDescription,
+		"description_length", diagnostic.DescriptionLength,
+		"has_duration_ms", diagnostic.HasDuration,
+		"duration_ms", diagnostic.DurationMS,
+	)
+}
+
+func logCursorACPTaskToolUpdate(
+	config standardACPConfig,
+	session Session,
+	turnID string,
+	updateType string,
+	update map[string]any,
+) {
+	if !isCursorACPTaskToolUpdate(update) {
+		return
+	}
+	input, _ := acpToolCallRawInput(update).(map[string]any)
+	output, _ := acpToolCallRawOutput(update).(map[string]any)
+	slog.Info("agent session Cursor ACP task tool update observed",
+		"event", "agent_session.cursor.task_tool_update",
+		"provider", config.provider,
+		"adapter", config.adapterName,
+		"room_id", session.RoomID,
+		"agent_session_id", session.AgentSessionID,
+		"provider_session_id", session.ProviderSessionID,
+		"turn_id", strings.TrimSpace(turnID),
+		"update_type", updateType,
+		"tool_call_id", firstNonEmpty(asString(update["toolCallId"]), asString(update["callId"]), asString(update["id"])),
+		"raw_status", strings.TrimSpace(asString(update["status"])),
+		"resolved_status", acpResolvedToolCallStatus(update, string(activityshared.ActivityStatusRunning)),
+		"has_raw_input", len(input) > 0,
+		"input_has_agent_id", strings.TrimSpace(asString(input["agentId"])) != "",
+		"input_agent_id", strings.TrimSpace(asString(input["agentId"])),
+		"input_subagent_type", cursorACPTaskSubagentTypeLogValue(input["subagentType"]),
+		"input_model", strings.TrimSpace(asString(input["model"])),
+		"input_run_in_background", firstCursorACPBoolLogValue(input, "run_in_background", "runInBackground"),
+		"has_raw_output", len(output) > 0,
+		"output_is_background", firstCursorACPBoolLogValue(output, "isBackground", "is_background"),
+		"output_duration_ms", firstInt64ValueLogValue(output, "durationMs", "duration_ms"),
+	)
+}
+
+func isCursorACPTaskToolUpdate(update map[string]any) bool {
+	input, _ := acpToolCallRawInput(update).(map[string]any)
+	if strings.EqualFold(strings.TrimSpace(asString(input["_toolName"])), "task") {
+		return true
+	}
+	title := strings.ToLower(strings.TrimSpace(firstNonEmpty(asString(update["title"]), asString(update["name"]))))
+	return title == "task" || strings.HasPrefix(title, "task:")
+}
+
+func firstCursorACPBoolLogValue(source map[string]any, keys ...string) any {
+	for _, key := range keys {
+		if value, ok := source[key].(bool); ok {
+			return value
+		}
+	}
+	return nil
+}

--- a/packages/agent/daemon/runtime/cursor_acp_task_diagnostics_test.go
+++ b/packages/agent/daemon/runtime/cursor_acp_task_diagnostics_test.go
@@ -1,0 +1,56 @@
+package agentruntime
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseCursorACPTaskExtensionDiagnosticRedactsTaskText(t *testing.T) {
+	t.Parallel()
+
+	diagnostic, ok := parseCursorACPTaskExtensionDiagnostic(json.RawMessage(`{
+		"toolCallId":"task-call-1",
+		"description":"inspect the repository",
+		"prompt":"private task instructions",
+		"subagentType":"explore",
+		"model":"cursor-model",
+		"agentId":"child-agent-1",
+		"durationMs":1250
+	}`))
+	if !ok {
+		t.Fatal("task extension params were not parsed")
+	}
+	if diagnostic.ToolCallID != "task-call-1" || diagnostic.AgentID != "child-agent-1" {
+		t.Fatalf("diagnostic identity = %#v", diagnostic)
+	}
+	if diagnostic.SubagentType != "explore" || diagnostic.Model != "cursor-model" {
+		t.Fatalf("diagnostic provider fields = %#v", diagnostic)
+	}
+	if !diagnostic.HasPrompt || diagnostic.PromptLength != len("private task instructions") ||
+		!diagnostic.HasDescription || diagnostic.DescriptionLength != len("inspect the repository") {
+		t.Fatalf("diagnostic redacted text facts = %#v", diagnostic)
+	}
+	if !diagnostic.HasAgentID || !diagnostic.HasDuration || diagnostic.DurationMS != int64(1250) {
+		t.Fatalf("diagnostic terminal facts = %#v", diagnostic)
+	}
+}
+
+func TestCursorACPTaskToolUpdateDiagnosticDetection(t *testing.T) {
+	t.Parallel()
+
+	if !isCursorACPTaskToolUpdate(map[string]any{
+		"rawInput": map[string]any{"_toolName": "task", "run_in_background": true},
+	}) {
+		t.Fatal("Cursor Task raw input was not detected")
+	}
+	if !isCursorACPTaskToolUpdate(map[string]any{"title": "Task: Explore repository"}) {
+		t.Fatal("Cursor Task title was not detected")
+	}
+	if isCursorACPTaskToolUpdate(map[string]any{"title": "Shell"}) {
+		t.Fatal("ordinary tool was detected as Cursor Task")
+	}
+
+	if got := firstCursorACPBoolLogValue(map[string]any{"isBackground": true}, "isBackground"); got != true {
+		t.Fatalf("background diagnostic = %#v, want true", got)
+	}
+}

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -58,6 +58,13 @@ type standardACPConfig struct {
 	projectCurrentMode             bool
 	startupDiagnostics             bool
 	toolAliases                    map[string]string
+	messageDiagnostics             *standardACPMessageDiagnostics
+}
+
+type standardACPMessageDiagnostics struct {
+	method         string
+	observeMessage func(standardACPConfig, Session, string, acpMessage, *acpTurnNormalizer)
+	observeUpdate  func(standardACPConfig, Session, string, string, map[string]any)
 }
 
 type standardACPAdapter struct {
@@ -212,6 +219,15 @@ func (a *standardACPAdapter) Provider() string {
 		return ""
 	}
 	return a.config.provider
+}
+
+// UsesRootProviderTurnLifecycle keeps provider completion separate from the
+// canonical root turn. Standard ACP does not currently expose durable child
+// sessions, but it must still use the same daemon-owned settlement path as
+// every other provider so adding an ACP child-session strategy cannot create a
+// second completion model.
+func (*standardACPAdapter) UsesRootProviderTurnLifecycle() bool {
+	return true
 }
 
 func (a *standardACPAdapter) SetCommandSnapshotSink(sink CommandSnapshotSink) {

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -43,6 +43,164 @@ func TestStandardACPAdapterStampsAuthoritativeTurnLifecycle(t *testing.T) {
 	}
 }
 
+func TestStandardACPAdaptersReportProviderLifecycleWithoutSettlingCanonicalRoot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		agentTitle        string
+		providerSessionID string
+		provider          string
+		build             func(ProcessTransport) *standardACPAdapter
+	}{
+		{name: "cursor", agentTitle: "Cursor Agent", providerSessionID: "cursor-session-root-lifecycle", provider: ProviderCursor, build: func(transport ProcessTransport) *standardACPAdapter {
+			return newCursorAdapterWithHostMetadata(transport, LegacyHostMetadata(), nil)
+		}},
+		{name: "opencode", agentTitle: "OpenCode", providerSessionID: "opencode-session-root-lifecycle", provider: ProviderOpenCode, build: newOpenCodeTestAdapter},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			transport := newStandardACPTransport(tt.agentTitle, tt.providerSessionID)
+			adapter := tt.build(transport)
+			session := standardTestSession(tt.provider)
+			if _, err := adapter.Start(context.Background(), session); err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+			session.ProviderSessionID = tt.providerSessionID
+
+			events, err := adapter.Exec(context.Background(), session, textPrompt("inspect the workspace"), "", "root-turn-1", nil, nil)
+			if err != nil {
+				t.Fatalf("Exec: %v", err)
+			}
+			if !adapter.UsesRootProviderTurnLifecycle() {
+				t.Fatal("standard ACP adapter did not opt into daemon-owned root settlement")
+			}
+
+			var started, completed bool
+			for _, event := range events {
+				switch event.Type {
+				case activityshared.EventRootProviderTurnStarted:
+					started = event.Payload.TurnID == "root-turn-1" && event.Payload.ProviderTurnID == "root-turn-1"
+				case activityshared.EventRootProviderTurnCompleted:
+					completed = event.Payload.TurnID == "root-turn-1" &&
+						event.Payload.ProviderTurnID == "root-turn-1" &&
+						event.Payload.TurnOutcome == string(activityshared.TurnOutcomeCompleted)
+				case activityshared.EventTurnCompleted, activityshared.EventTurnFailed, activityshared.EventTurnCanceled:
+					t.Fatalf("standard ACP emitted canonical terminal event before daemon settlement: %#v", event)
+				}
+			}
+			if !started || !completed {
+				t.Fatalf("provider lifecycle started=%v completed=%v, events=%#v", started, completed, activityEventTypeCounts(events))
+			}
+		})
+	}
+}
+
+func TestStandardACPDropsLateTurnScopedUpdatesOutsidePromptCall(t *testing.T) {
+	t.Parallel()
+
+	session := standardTestSession(ProviderOpenCode)
+	events := standardACPUpdateEvents(
+		newOpenCodeTestAdapter(nil).config,
+		session,
+		"settled-root-turn",
+		json.RawMessage(`{"update":{"sessionUpdate":"tool_call","toolCallId":"late-task","title":"Task","status":"pending"}}`),
+		nil,
+	)
+	if len(events) != 0 {
+		t.Fatalf("late tool events = %#v, want no events attached to the settled root", events)
+	}
+}
+
+func TestStandardACPRejectsLatePermissionOutsidePromptCall(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Cursor Agent", "cursor-session-late-permission")
+	adapter := newCursorAdapterWithHostMetadata(transport, LegacyHostMetadata(), nil)
+	session := standardTestSession(ProviderCursor)
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session.ProviderSessionID = "cursor-session-late-permission"
+	client := adapter.getSession(session.AgentSessionID).client
+
+	events, err := adapter.handleACPMessage(context.Background(), client, session, "settled-root-turn", acpMessage{
+		ID:     json.RawMessage(`"late-permission"`),
+		Method: acpMethodPermission,
+		Params: json.RawMessage(`{"toolCall":{"toolCallId":"late-task","title":"Allow Task"},"options":[{"optionId":"allow","kind":"allow_once"}]}`),
+	}, nil, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "outside an active prompt turn") {
+		t.Fatalf("late permission error = %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("late permission events = %#v, want no synthetic turn or interaction", events)
+	}
+	if pending := adapter.getPendingApproval(session.AgentSessionID, "settled-root-turn", "late-permission"); pending != nil {
+		t.Fatalf("late permission created pending interaction: %#v", pending)
+	}
+}
+
+func TestStandardACPCancelPropagatesNotifyFailure(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("cancel transport unavailable")
+	adapter := newCursorAdapterWithHostMetadata(nil, LegacyHostMetadata(), nil)
+	session := standardTestSession(ProviderCursor)
+	adapter.storeSession(session.AgentSessionID, &standardACPSession{
+		client:            &acpClient{conn: standardACPFailingSendConnection{err: wantErr}},
+		providerSessionID: "cursor-session-cancel",
+	})
+
+	if _, err := adapter.Cancel(context.Background(), session, "user canceled"); !errors.Is(err, wantErr) {
+		t.Fatalf("Cancel error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestStandardACPAutoApprovePropagatesResponseFailure(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("permission response transport unavailable")
+	adapter := newCursorAdapterWithHostMetadata(nil, LegacyHostMetadata(), nil)
+	session := standardTestSession(ProviderCursor)
+	session.PermissionModeID = "full-access"
+	adapter.storeSession(session.AgentSessionID, &standardACPSession{
+		client:            &acpClient{conn: standardACPFailingSendConnection{err: wantErr}},
+		providerSessionID: "cursor-session-auto-approve",
+		permissionModeID:  "full-access",
+	})
+	client := adapter.getSession(session.AgentSessionID).client
+
+	events, err := adapter.handleACPMessage(context.Background(), client, session, "root-turn-1", acpMessage{
+		ID:     json.RawMessage(`"permission-1"`),
+		Method: acpMethodPermission,
+		Params: json.RawMessage(`{"toolCall":{"toolCallId":"task-1","title":"Allow Task"},"options":[{"optionId":"allow","kind":"allow_once"}]}`),
+	}, newACPTurnNormalizer(), nil, nil)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("auto-approve response error = %v, want %v", err, wantErr)
+	}
+	if len(events) != 0 {
+		t.Fatalf("auto-approve response events = %#v, want no false resolution", events)
+	}
+}
+
+type standardACPFailingSendConnection struct {
+	err error
+}
+
+func (c standardACPFailingSendConnection) Send([]byte) error {
+	return c.err
+}
+
+func (standardACPFailingSendConnection) Recv() (ProcessFrame, error) {
+	return ProcessFrame{}, io.EOF
+}
+
+func (standardACPFailingSendConnection) Close() error {
+	return nil
+}
+
 func TestStandardACPAdapterProviderLaunchPrepareMutatesSpecAndCleansUpOnClose(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/standard_acp_events.go
+++ b/packages/agent/daemon/runtime/standard_acp_events.go
@@ -75,6 +75,27 @@ func standardACPUpdateEvents(config standardACPConfig, session Session, turnID s
 		}
 		return nil
 	case "tool_call", "tool_call_update":
+		if diagnostics := config.messageDiagnostics; diagnostics != nil && diagnostics.observeUpdate != nil {
+			diagnostics.observeUpdate(config, session, turnID, updateType, params.Update)
+		}
+		// Tool activity is turn-scoped. A nil normalizer means the notification
+		// arrived outside the active session/prompt call (for example after the
+		// provider already returned its prompt result). Do not attach that late
+		// activity to a recently settled canonical turn or invent a new identity.
+		if normalizer == nil || strings.TrimSpace(turnID) == "" {
+			slog.Warn("agent session ACP dropped turn-scoped update outside active prompt",
+				"event", "agent_session.acp.update.turn_scope_missing",
+				"provider", config.provider,
+				"adapter", config.adapterName,
+				"room_id", session.RoomID,
+				"agent_session_id", session.AgentSessionID,
+				"provider_session_id", session.ProviderSessionID,
+				"recent_turn_id", strings.TrimSpace(turnID),
+				"update_type", updateType,
+				"tool_call_id", firstNonEmpty(asString(params.Update["toolCallId"]), asString(params.Update["callId"]), asString(params.Update["id"])),
+			)
+			return nil
+		}
 		applyStandardACPToolAlias(config, params.Update)
 		if events, ok := normalizer.StandardToolCallEvents(session, turnID, updateType, params.Update); ok {
 			return events

--- a/packages/agent/daemon/runtime/standard_acp_stream.go
+++ b/packages/agent/daemon/runtime/standard_acp_stream.go
@@ -33,6 +33,18 @@ func (a *standardACPAdapter) handleACPMessage(
 		"message_method", message.Method,
 		"message_id", rawMessageLogValue(message.ID),
 	)
+	if diagnostics := a.config.messageDiagnostics; diagnostics != nil &&
+		message.Method == diagnostics.method {
+		if diagnostics.observeMessage != nil {
+			diagnostics.observeMessage(a.config, session, turnID, message, normalizer)
+		}
+		// Provider diagnostic extensions are observational until their ordering
+		// and lifecycle semantics are deliberately mapped to durable entities.
+		if len(message.ID) > 0 {
+			_ = client.Respond(ctx, message.ID, nil, &acpError{Code: -32601, Message: "method not supported"})
+		}
+		return nil, nil
+	}
 	switch message.Method {
 	case acpMethodUpdate:
 		if !a.standardACPUpdateMatchesProviderSession(session, message.Params) {
@@ -65,18 +77,23 @@ func (a *standardACPAdapter) handleACPMessage(
 		}
 		return events, nil
 	case acpMethodPermission:
-		sessionLevelEmit := false
-		if strings.TrimSpace(turnID) == "" {
-			turnID = a.ensureSessionRecentTurnID(session.AgentSessionID)
-		}
-		if emit == nil {
-			sessionLevelEmit = true
-			emit = func(events []activityshared.Event) {
-				a.emitSessionEvents(session.AgentSessionID, events)
-			}
-		}
-		if strings.TrimSpace(turnID) == "" {
-			err := errors.New("permission request outside active prompt turn is missing a turn id")
+		// A permission callback is actionable only while the session/prompt call
+		// that owns its canonical turn is active. The global client handler has no
+		// normalizer; binding such a late callback to recentTurnID would reopen a
+		// settled turn, while fabricating a synthetic turn would violate durable
+		// turn ownership.
+		if normalizer == nil || strings.TrimSpace(turnID) == "" {
+			err := errors.New("permission request arrived outside an active prompt turn")
+			slog.Warn("agent session ACP rejected permission outside active prompt",
+				"event", "agent_session.acp.permission.turn_scope_missing",
+				"provider", a.config.provider,
+				"adapter", a.config.adapterName,
+				"room_id", session.RoomID,
+				"agent_session_id", session.AgentSessionID,
+				"provider_session_id", session.ProviderSessionID,
+				"recent_turn_id", strings.TrimSpace(turnID),
+				"request_id", rawMessageLogValue(message.ID),
+			)
 			_ = client.Respond(ctx, message.ID, nil, &acpError{Code: -32000, Message: err.Error()})
 			return nil, err
 		}
@@ -85,20 +102,25 @@ func (a *standardACPAdapter) handleACPMessage(
 		// streams its own activity via session/update.
 		if decision := a.autoApprovePermissionDecision(session.AgentSessionID); decision != "" {
 			if optionID, ok := acpPermissionRequestDecisionOptionID(message.Params, decision); ok {
-				_ = client.Respond(ctx, message.ID, acpPermissionResponseResult(optionID), nil)
+				if err := client.Respond(ctx, message.ID, acpPermissionResponseResult(optionID), nil); err != nil {
+					slog.Warn("agent session ACP auto-approve response failed",
+						"event", "agent_session.acp.permission.auto_approve_response_failed",
+						"provider", a.config.provider,
+						"adapter", a.config.adapterName,
+						"room_id", session.RoomID,
+						"agent_session_id", session.AgentSessionID,
+						"provider_session_id", session.ProviderSessionID,
+						"turn_id", turnID,
+						"request_id", rawMessageLogValue(message.ID),
+						"error", err.Error(),
+					)
+					return nil, err
+				}
 				return nil, nil
 			}
 		}
-		if sessionLevelEmit {
-			emit([]activityshared.Event{newTurnActivityEvent(session, EventTurnStarted, turnID, SessionStatusWorking, "", "", map[string]any{
-				"synthetic": true,
-			})})
-		}
 		events, pending, err := standardACPPermissionRequested(a, session, turnID, message.ID, message.Params, normalizer)
 		if err != nil {
-			if sessionLevelEmit {
-				emit(events)
-			}
 			_ = client.Respond(ctx, message.ID, nil, &acpError{Code: -32602, Message: err.Error()})
 			return events, err
 		}
@@ -109,9 +131,6 @@ func (a *standardACPAdapter) handleACPMessage(
 		if err != nil {
 			pending.finish(pendingInteractiveRequestStateInterrupted)
 			events := normalizedPermissionResolvedEvents(session, turnID, pending, pendingInteractiveResponse{}, err)
-			if sessionLevelEmit {
-				emit(events)
-			}
 			_ = client.Respond(ctx, message.ID, nil, &acpError{Code: -32000, Message: err.Error()})
 			return events, err
 		}
@@ -124,16 +143,10 @@ func (a *standardACPAdapter) handleACPMessage(
 			if pending.finish(pendingInteractiveRequestStateSuperseded) {
 				events = normalizedPermissionResolvedEvents(session, turnID, pending, selection, err)
 			}
-			if sessionLevelEmit {
-				emit(events)
-			}
 			return events, err
 		}
 		if pending.finish(pendingInteractiveRequestStateAnswered) {
 			events = normalizedPermissionResolvedEvents(session, turnID, pending, selection, nil)
-		}
-		if sessionLevelEmit {
-			emit(events)
 		}
 		return events, nil
 	default:
@@ -329,15 +342,6 @@ func (a *standardACPAdapter) rememberSessionTurn(agentSessionID string, turnID s
 	}
 	acpSession.recentTurnID = turnID
 	acpSession.recentTurnExpiry = time.Now().Add(standardACPRecentTurnTTL)
-}
-
-func (a *standardACPAdapter) ensureSessionRecentTurnID(agentSessionID string) string {
-	if turnID := a.sessionRecentTurnID(agentSessionID); turnID != "" {
-		return turnID
-	}
-	turnID := "synthetic-" + newID()
-	a.rememberSessionTurn(agentSessionID, turnID)
-	return turnID
 }
 
 func (a *standardACPAdapter) sessionRecentTurnID(agentSessionID string) string {

--- a/packages/agent/daemon/runtime/standard_acp_turn.go
+++ b/packages/agent/daemon/runtime/standard_acp_turn.go
@@ -21,7 +21,12 @@ func (a *standardACPAdapter) Exec(
 ) ([]activityshared.Event, error) {
 	acpSession := a.getSession(session.AgentSessionID)
 	if acpSession == nil || acpSession.client == nil {
-		return nil, ErrSessionDisconnected
+		return []activityshared.Event{standardACPRootProviderTurnCompletedEvent(
+			session,
+			turnID,
+			activityshared.TurnOutcomeFailed,
+			map[string]any{"error": ErrSessionDisconnected.Error()},
+		)}, ErrSessionDisconnected
 	}
 	session.ProviderSessionID = acpSession.providerSessionID
 	a.rememberSessionTurn(session.AgentSessionID, turnID)
@@ -47,6 +52,7 @@ func (a *standardACPAdapter) Exec(
 	startEvents := []activityshared.Event{
 		newTurnActivityEvent(session, EventMessage, turnID, "", RoleUser, visibleText, userPromptActivityPayload(content, explicitDisplayPrompt, userPromptActivityPayloadExtraFromExecMetadata(ctx, nil))),
 		newTurnActivityEvent(session, EventTurnStarted, turnID, SessionStatusWorking, "", "", nil),
+		standardACPRootProviderTurnStartedEvent(session, turnID),
 	}
 	emitEvents(startEvents)
 	slog.Info("agent session ACP exec started",
@@ -130,7 +136,7 @@ execLoop:
 			)
 			if errors.Is(err, context.Canceled) || errors.Is(err, errPermissionRequestCanceled) {
 				terminalEvents := normalizer.FinishInterrupted(session, turnID, "interrupted")
-				terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
+				terminalEvents = append(terminalEvents, standardACPRootProviderTurnCompletedEvent(session, turnID, activityshared.TurnOutcomeCanceled, map[string]any{
 					"error": err.Error(),
 				}))
 				emitEvents(terminalEvents)
@@ -142,7 +148,7 @@ execLoop:
 					emitEvents([]activityshared.Event{notice})
 				}
 				terminalEvents := normalizer.FinishCompleted(session, turnID)
-				terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnCompleted, turnID, SessionStatusReady, "", "", map[string]any{
+				terminalEvents = append(terminalEvents, standardACPRootProviderTurnCompletedEvent(session, turnID, activityshared.TurnOutcomeCompleted, map[string]any{
 					"stopReason": "end_turn",
 					"planLimit":  true,
 				}))
@@ -159,7 +165,7 @@ execLoop:
 				)
 			} else {
 				terminalEvents := normalizer.FinishFailed(session, turnID)
-				terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", map[string]any{
+				terminalEvents = append(terminalEvents, standardACPRootProviderTurnCompletedEvent(session, turnID, activityshared.TurnOutcomeFailed, map[string]any{
 					"error": err.Error(),
 				}))
 				emitEvents(terminalEvents)
@@ -213,7 +219,7 @@ execLoop:
 				// The retries were cut short too: surface the turn as failed
 				// instead of a silent "completed" that strands the conversation.
 				terminalEvents := normalizer.FinishFailed(session, turnID)
-				terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", map[string]any{
+				terminalEvents = append(terminalEvents, standardACPRootProviderTurnCompletedEvent(session, turnID, activityshared.TurnOutcomeFailed, map[string]any{
 					"error":      errLine,
 					"stopReason": firstNonEmpty(stopReason, "end_turn"),
 				}))
@@ -235,19 +241,19 @@ execLoop:
 		switch stopReason {
 		case "canceled":
 			terminalEvents := normalizer.FinishInterrupted(session, turnID, stopReason)
-			terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
+			terminalEvents = append(terminalEvents, standardACPRootProviderTurnCompletedEvent(session, turnID, activityshared.TurnOutcomeCanceled, map[string]any{
 				"stopReason": stopReason,
 			}))
 			emitEvents(terminalEvents)
 		case "refusal", "max_tokens", "max_turn_requests":
 			terminalEvents := normalizer.FinishFailed(session, turnID)
-			terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", map[string]any{
+			terminalEvents = append(terminalEvents, standardACPRootProviderTurnCompletedEvent(session, turnID, activityshared.TurnOutcomeFailed, map[string]any{
 				"stopReason": stopReason,
 			}))
 			emitEvents(terminalEvents)
 		default:
 			terminalEvents := normalizer.FinishCompleted(session, turnID)
-			terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnCompleted, turnID, SessionStatusReady, "", "", map[string]any{
+			terminalEvents = append(terminalEvents, standardACPRootProviderTurnCompletedEvent(session, turnID, activityshared.TurnOutcomeCompleted, map[string]any{
 				"stopReason": firstNonEmpty(stopReason, "end_turn"),
 			}))
 			emitEvents(terminalEvents)
@@ -270,13 +276,41 @@ execLoop:
 
 func (a *standardACPAdapter) Cancel(ctx context.Context, session Session, _ string) ([]activityshared.Event, error) {
 	acpSession := a.getSession(session.AgentSessionID)
-	if acpSession != nil && acpSession.client != nil {
-		_ = acpSession.client.Notify(ctx, acpMethodCancel, map[string]any{
-			"sessionId": acpSession.providerSessionID,
-		})
+	if acpSession == nil || acpSession.client == nil {
+		return nil, ErrSessionNoActiveTurn
+	}
+	if err := acpSession.client.Notify(ctx, acpMethodCancel, map[string]any{
+		"sessionId": acpSession.providerSessionID,
+	}); err != nil {
+		return nil, err
 	}
 	a.rejectPendingApprovals(session.AgentSessionID, errPermissionRequestCanceled)
 	return nil, nil
+}
+
+func standardACPRootProviderTurnStartedEvent(session Session, rootTurnID string) activityshared.Event {
+	rootTurnID = strings.TrimSpace(rootTurnID)
+	ctx, ok := activityEventContext(session, "standard-acp:provider-turn-started:"+rootTurnID, rootTurnID)
+	if !ok {
+		return activityshared.Event{}
+	}
+	return activityshared.NewRootProviderTurnStarted(ctx, rootTurnID, rootTurnID)
+}
+
+func standardACPRootProviderTurnCompletedEvent(
+	session Session,
+	rootTurnID string,
+	outcome activityshared.TurnOutcome,
+	metadata map[string]any,
+) activityshared.Event {
+	rootTurnID = strings.TrimSpace(rootTurnID)
+	ctx, ok := activityEventContext(session, "standard-acp:provider-turn-completed:"+rootTurnID, rootTurnID)
+	if !ok {
+		return activityshared.Event{}
+	}
+	event := activityshared.NewRootProviderTurnCompleted(ctx, rootTurnID, rootTurnID, outcome)
+	event.Payload.Metadata = clonePayload(metadata)
+	return event
 }
 
 func (a *standardACPAdapter) submitPermissionOption(ctx context.Context, session Session, input PermissionOptionInput) (string, error) {

--- a/packages/agent/daemon/runtime/turn_lifecycle_authority_test.go
+++ b/packages/agent/daemon/runtime/turn_lifecycle_authority_test.go
@@ -150,6 +150,75 @@ func TestControllerCodexStreamNeverIdlesMidTurn(t *testing.T) {
 	}
 }
 
+func TestControllerStandardACPWaitsForDaemonRootSettlement(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		agentTitle string
+		provider   string
+		build      func(ProcessTransport) *standardACPAdapter
+	}{
+		{name: "cursor", agentTitle: "Cursor Agent", provider: ProviderCursor, build: func(transport ProcessTransport) *standardACPAdapter {
+			return newCursorAdapterWithHostMetadata(transport, LegacyHostMetadata(), nil)
+		}},
+		{name: "opencode", agentTitle: "OpenCode", provider: ProviderOpenCode, build: newOpenCodeTestAdapter},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			transport := newStandardACPTransport(tt.agentTitle, tt.name+"-root-settlement")
+			adapter := tt.build(transport)
+			controller := NewController([]Adapter{adapter}, nil)
+			started, err := controller.Start(context.Background(), StartInput{
+				RoomID: "room-1", Provider: tt.provider, CWD: "/workspace", Title: tt.agentTitle,
+			})
+			if err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+			agentSessionID := started.Session.AgentSessionID
+			stream, unsubscribe, ok := controller.Subscribe("room-1", agentSessionID)
+			if !ok {
+				t.Fatal("Subscribe returned ok=false")
+			}
+			defer unsubscribe()
+
+			execResult, err := controller.Exec(context.Background(), ExecInput{
+				RoomID: "room-1", AgentSessionID: agentSessionID, Content: textPrompt("inspect the workspace"),
+			})
+			if err != nil {
+				t.Fatalf("Exec: %v", err)
+			}
+
+			deadline := time.NewTimer(5 * time.Second)
+			defer deadline.Stop()
+			providerCompleted := false
+			for !providerCompleted {
+				select {
+				case event := <-stream:
+					patch, ok := event.Data.(agentsessionstore.WorkspaceAgentStatePatch)
+					providerCompleted = event.EventType == StreamEventStatePatch && ok &&
+						patch.RootProviderTurn != nil &&
+						patch.RootProviderTurn.Phase == agentsessionstore.RootProviderTurnPhaseCompleted
+				case <-deadline.C:
+					t.Fatal("stream never published root provider completion")
+				}
+			}
+			if !controller.HasActiveTurn("room-1", agentSessionID) {
+				t.Fatal("controller cleared canonical root before daemon settlement")
+			}
+
+			controller.ReconcileRootTurnSettlement(RootTurnSettlement{
+				RoomID: "room-1", AgentSessionID: agentSessionID, TurnID: execResult.TurnID, Outcome: "completed",
+			})
+			if controller.HasActiveTurn("room-1", agentSessionID) {
+				t.Fatal("controller retained canonical root after daemon settlement")
+			}
+		})
+	}
+}
+
 // applyLifecycleSnapshotToPatch must be provider-agnostic: any provider whose
 // adapter stamps snapshots gets the copied patch, no codex special case.
 func TestApplyLifecycleSnapshotToPatchProviderAgnostic(t *testing.T) {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.ts
@@ -135,21 +135,6 @@ export function reasoningSelectionForModelFromComposerOptions(
   };
 }
 
-// liveModelOptionValuesFromRuntimeContext extracts the model option values a
-// live ACP session advertises through its runtime-context config options
-// (configOptions[id="model"].options[].value). Providers such as Cursor only
-// expose their model list this way — there is no static catalog.
-export function composerOptionsMissingLiveModelValues(
-  options: AgentActivityComposerOptions | null,
-  liveValues: readonly string[]
-): boolean {
-  if (!options || liveValues.length === 0) {
-    return false;
-  }
-  const known = new Set(options.models.map((option) => option.value));
-  return liveValues.some((value) => !known.has(value));
-}
-
 export function modelSelectionFromComposerOptions(
   options: AgentActivityComposerOptions | null,
   currentValue: string | null

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.spec.tsx
@@ -71,6 +71,7 @@ describe("useAgentGUIComposerOptionsSync", () => {
         expect.objectContaining({
           agentTargetId: "local:codex",
           cwd: "/workspace/project",
+          force: true,
           provider: "codex",
           workspaceId: "workspace-1"
         })

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.ts
@@ -3,7 +3,7 @@ import {
   type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
 import type { RefObject } from "react";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import { subscribeCoalesced } from "../../../host/agentHostEventBus";
 import type {
@@ -54,6 +54,10 @@ export function useAgentGUIComposerOptionsSync(input: {
   workspaceId: string;
   workspacePath: string;
 }) {
+  const previousActiveConversationIdRef = useRef(input.activeConversationId);
+  const previousIsCreatingConversationRef = useRef(
+    input.isCreatingConversation
+  );
   const loadComposerOptionsForTarget = useCallback(
     (targetData: AgentGUIComposerTargetData, options?: { force?: boolean }) => {
       if (input.isCreatingConversation || !targetData.agentTargetId) return;
@@ -158,9 +162,24 @@ export function useAgentGUIComposerOptionsSync(input: {
 
   useEffect(() => {
     if (input.previewMode) return;
+    // Session creation can finish after an earlier request cached the
+    // provider's selected-model-only fallback. Once activation or creation
+    // settles, bypass request-signature deduplication so runtime-discovered
+    // model options replace that bootstrap snapshot.
+    const conversationActivated =
+      input.activeConversationId !== null &&
+      previousActiveConversationIdRef.current !== input.activeConversationId;
+    const conversationCreationSettled =
+      previousIsCreatingConversationRef.current &&
+      !input.isCreatingConversation;
+    previousActiveConversationIdRef.current = input.activeConversationId;
+    previousIsCreatingConversationRef.current = input.isCreatingConversation;
     loadDraftComposerOptions(
-      input.providerComposerOptions?.behavior?.prewarmDraftSession === true &&
-        input.isComposerHome
+      conversationActivated ||
+        conversationCreationSettled ||
+        (input.providerComposerOptions?.behavior?.prewarmDraftSession ===
+          true &&
+          input.isComposerHome)
         ? { force: true }
         : undefined
     );

--- a/packages/agent/runtimeprep/cursor.go
+++ b/packages/agent/runtimeprep/cursor.go
@@ -10,6 +10,102 @@ import (
 
 const cursorPluginDirEnv = "TUTTI_CURSOR_PLUGIN_DIR"
 
+const (
+	cursorBackgroundTaskGuardCommand       = `"${CURSOR_PLUGIN_ROOT}/hooks/guard-background-task.sh"`
+	cursorBackgroundTaskGuardDeniedMessage = "Tutti's Cursor ACP integration does not support background Task execution. Retry this Task in the foreground without run_in_background=true."
+)
+
+// The background Task guard is intentionally dormant. Cursor Agent
+// 2026.07.01 loads user, project, and team hooks in ACP mode, but does not
+// merge hooks from --plugin-dir. Keep the implementation and its focused tests
+// so it can be enabled if Cursor ACP gains plugin-hook support, but do not
+// advertise it in plugin.json or materialize it during session preparation.
+// Until then this guard must not be treated as protection against detached
+// background Tasks.
+const cursorBackgroundTaskGuardScript = `#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+resolve_cursor_node() {
+  local invoked="${CURSOR_INVOKED_AS:-}"
+  local candidate=""
+  local resolved=""
+
+  for name in "$invoked" cursor-agent agent; do
+    if [[ -z "$name" ]]; then
+      continue
+    fi
+    candidate="$(command -v "$name" 2>/dev/null || true)"
+    if [[ -n "$candidate" ]]; then
+      break
+    fi
+  done
+
+  if [[ -z "$candidate" ]]; then
+    return 1
+  fi
+  if command -v realpath >/dev/null 2>&1; then
+    resolved="$(realpath "$candidate")"
+  else
+    resolved="$candidate"
+    if [[ -L "$candidate" ]]; then
+      local target
+      target="$(readlink "$candidate")"
+      if [[ "$target" = /* ]]; then
+        resolved="$target"
+      else
+        resolved="$(cd "$(dirname "$candidate")" && pwd)/$target"
+      fi
+    fi
+  fi
+
+  local node_bin
+  node_bin="$(dirname "$resolved")/node"
+  if [[ ! -x "$node_bin" ]]; then
+    return 1
+  fi
+  printf '%s\n' "$node_bin"
+}
+
+if node_bin="$(resolve_cursor_node)"; then
+  payload="$(cat)"
+  if output="$(printf '%s' "$payload" | "$node_bin" "$script_dir/guard-background-task.mjs")"; then
+    printf '%s\n' "$output"
+    exit 0
+  fi
+fi
+
+# Fail closed when Cursor's bundled Node runtime cannot be located. If this
+# dormant hook is enabled in a future compatible ACP runtime, it must never
+# silently allow a matched Task to bypass the guard.
+printf '%s\n' "{\"permission\":\"deny\",\"user_message\":\"` + cursorBackgroundTaskGuardDeniedMessage + `\"}"
+`
+
+const cursorBackgroundTaskGuardJavaScript = `const chunks = [];
+for await (const chunk of process.stdin) {
+  chunks.push(chunk);
+}
+
+const deny = () => ({
+  permission: "deny",
+  user_message: "` + cursorBackgroundTaskGuardDeniedMessage + `",
+});
+
+try {
+  const payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  const input = payload?.tool_input ?? payload?.toolInput;
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    process.stdout.write(JSON.stringify(deny()));
+  } else {
+    const background = input.run_in_background ?? input.runInBackground;
+    process.stdout.write(JSON.stringify(background === true || background === "true" ? deny() : {}));
+  }
+} catch {
+  process.stdout.write(JSON.stringify(deny()));
+}
+`
+
 type CursorPreparer struct{}
 
 func (CursorPreparer) Provider() string {
@@ -63,6 +159,41 @@ func installCursorTuttiPlugin(pluginDir string, input PrepareInput) error {
 	}
 	if _, err := installProviderNativeSkills(filepath.Join(pluginDir, "skills"), input); err != nil {
 		return fmt.Errorf("install cursor tutti skill plugin: %w", err)
+	}
+	return nil
+}
+
+func installCursorBackgroundTaskGuard(hooksDir string) error {
+	if err := os.MkdirAll(hooksDir, 0o700); err != nil {
+		return fmt.Errorf("create cursor plugin hooks directory: %w", err)
+	}
+	hooks := struct {
+		Version int `json:"version"`
+		Hooks   struct {
+			PreToolUse []struct {
+				Matcher string `json:"matcher"`
+				Command string `json:"command"`
+			} `json:"preToolUse"`
+		} `json:"hooks"`
+	}{Version: 1}
+	hooks.Hooks.PreToolUse = []struct {
+		Matcher string `json:"matcher"`
+		Command string `json:"command"`
+	}{
+		{Matcher: "^Task$", Command: cursorBackgroundTaskGuardCommand},
+	}
+	content, err := json.MarshalIndent(hooks, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode cursor plugin hooks: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(hooksDir, "hooks.json"), append(content, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write cursor plugin hooks: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(hooksDir, "guard-background-task.sh"), []byte(cursorBackgroundTaskGuardScript), 0o700); err != nil {
+		return fmt.Errorf("write cursor background Task guard launcher: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(hooksDir, "guard-background-task.mjs"), []byte(cursorBackgroundTaskGuardJavaScript), 0o600); err != nil {
+		return fmt.Errorf("write cursor background Task guard: %w", err)
 	}
 	return nil
 }

--- a/packages/agent/runtimeprep/cursor_test.go
+++ b/packages/agent/runtimeprep/cursor_test.go
@@ -1,0 +1,168 @@
+package runtimeprep
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCursorBackgroundTaskGuardAllowsForegroundAndDeniesBackground(t *testing.T) {
+	nodePath, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required to execute the generated Cursor hook")
+	}
+
+	pluginDir := t.TempDir()
+	if err := installCursorBackgroundTaskGuard(filepath.Join(pluginDir, "hooks")); err != nil {
+		t.Fatalf("installCursorBackgroundTaskGuard() error = %v", err)
+	}
+	hookPath := filepath.Join(pluginDir, "hooks", "guard-background-task.mjs")
+
+	tests := []struct {
+		name       string
+		input      string
+		wantDenied bool
+	}{
+		{
+			name:       "foreground omitted",
+			input:      `{"tool_name":"Task","tool_input":{"prompt":"run_in_background=true is mentioned only as text"}}`,
+			wantDenied: false,
+		},
+		{
+			name:       "foreground false",
+			input:      `{"tool_name":"Task","tool_input":{"run_in_background":false}}`,
+			wantDenied: false,
+		},
+		{
+			name:       "background snake case",
+			input:      `{"tool_name":"Task","tool_input":{"run_in_background":true}}`,
+			wantDenied: true,
+		},
+		{
+			name:       "background camel case",
+			input:      `{"toolName":"Task","toolInput":{"runInBackground":true}}`,
+			wantDenied: true,
+		},
+		{
+			name:       "invalid payload fails closed",
+			input:      `{`,
+			wantDenied: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			command := exec.Command(nodePath, hookPath)
+			command.Stdin = strings.NewReader(tt.input)
+			output, err := command.Output()
+			if err != nil {
+				t.Fatalf("generated hook error = %v", err)
+			}
+			var response struct {
+				Permission  string `json:"permission"`
+				UserMessage string `json:"user_message"`
+			}
+			if err := json.Unmarshal(output, &response); err != nil {
+				t.Fatalf("generated hook output = %q: %v", output, err)
+			}
+			if tt.wantDenied {
+				if response.Permission != "deny" || response.UserMessage != cursorBackgroundTaskGuardDeniedMessage {
+					t.Fatalf("generated hook response = %#v, want background denial", response)
+				}
+			} else if response.Permission != "" || response.UserMessage != "" {
+				t.Fatalf("generated hook response = %#v, want empty allow response", response)
+			}
+		})
+	}
+}
+
+func TestCursorBackgroundTaskGuardLauncherUsesCursorBundledNode(t *testing.T) {
+	nodePath, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required to execute the generated Cursor hook")
+	}
+
+	pluginDir := t.TempDir()
+	if err := installCursorBackgroundTaskGuard(filepath.Join(pluginDir, "hooks")); err != nil {
+		t.Fatalf("installCursorBackgroundTaskGuard() error = %v", err)
+	}
+	installDir := filepath.Join(t.TempDir(), "cursor-version")
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(installDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(nodePath, filepath.Join(installDir, "node")); err != nil {
+		t.Fatal(err)
+	}
+	cursorPath := filepath.Join(installDir, "cursor-agent")
+	if err := os.WriteFile(cursorPath, []byte("#!/usr/bin/env bash\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(cursorPath, filepath.Join(binDir, "cursor-agent")); err != nil {
+		t.Fatal(err)
+	}
+
+	launcherPath := filepath.Join(pluginDir, "hooks", "guard-background-task.sh")
+	for _, tt := range []struct {
+		name       string
+		input      string
+		wantDenied bool
+	}{
+		{name: "foreground", input: `{"tool_name":"Task","tool_input":{"run_in_background":false}}`},
+		{name: "background", input: `{"tool_name":"Task","tool_input":{"run_in_background":true}}`, wantDenied: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			command := exec.Command(launcherPath)
+			command.Stdin = strings.NewReader(tt.input)
+			command.Env = append(os.Environ(),
+				"CURSOR_INVOKED_AS=cursor-agent",
+				"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+			)
+			output, err := command.Output()
+			if err != nil {
+				t.Fatalf("generated launcher error = %v", err)
+			}
+			denied := strings.Contains(string(output), `"permission":"deny"`)
+			if denied != tt.wantDenied {
+				t.Fatalf("generated launcher output = %q, denied = %v want %v", output, denied, tt.wantDenied)
+			}
+		})
+	}
+}
+
+func TestCursorBackgroundTaskGuardLauncherFailsClosedWithoutCursorNode(t *testing.T) {
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash is required to execute the generated Cursor hook launcher")
+	}
+
+	pluginDir := t.TempDir()
+	if err := installCursorBackgroundTaskGuard(filepath.Join(pluginDir, "hooks")); err != nil {
+		t.Fatalf("installCursorBackgroundTaskGuard() error = %v", err)
+	}
+	binDir := t.TempDir()
+	if err := os.Symlink(bashPath, filepath.Join(binDir, "bash")); err != nil {
+		t.Fatal(err)
+	}
+
+	launcherPath := filepath.Join(pluginDir, "hooks", "guard-background-task.sh")
+	command := exec.Command(launcherPath)
+	command.Stdin = strings.NewReader(`{"tool_name":"Task","tool_input":{"run_in_background":false}}`)
+	command.Env = append(os.Environ(),
+		"CURSOR_INVOKED_AS=missing-cursor-agent",
+		"PATH="+strings.Join([]string{binDir, "/usr/bin", "/bin"}, string(os.PathListSeparator)),
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("generated launcher error = %v output = %q", err, output)
+	}
+	if !strings.Contains(string(output), `"permission":"deny"`) ||
+		!strings.Contains(string(output), cursorBackgroundTaskGuardDeniedMessage) {
+		t.Fatalf("generated launcher output = %q, want fail-closed denial", output)
+	}
+}

--- a/packages/agent/runtimeprep/preparer_test.go
+++ b/packages/agent/runtimeprep/preparer_test.go
@@ -1156,6 +1156,12 @@ func TestDefaultPreparerCursorUsesRuntimePluginDir(t *testing.T) {
 		!strings.Contains(string(pluginManifest), `"displayName": "Tutti CLI"`) {
 		t.Fatalf("cursor plugin manifest = %q", string(pluginManifest))
 	}
+	if strings.Contains(string(pluginManifest), `"hooks"`) {
+		t.Fatalf("cursor ACP plugin must not advertise unsupported plugin hooks: %q", string(pluginManifest))
+	}
+	if _, err := os.Stat(filepath.Join(pluginDir, "hooks")); !os.IsNotExist(err) {
+		t.Fatalf("cursor ACP plugin hooks should remain dormant, stat error = %v", err)
+	}
 	pluginSkill, err := os.ReadFile(filepath.Join(pluginDir, "skills", "tutti-cli", "SKILL.md"))
 	if err != nil {
 		t.Fatalf("cursor plugin skill missing: %v", err)

--- a/services/tuttid/service/agent/composer_live_model_cache.go
+++ b/services/tuttid/service/agent/composer_live_model_cache.go
@@ -121,8 +121,8 @@ func (s *Service) liveModelCacheTTL(provider string) time.Duration {
 	if s.LiveModelCacheTTL != 0 {
 		return s.LiveModelCacheTTL
 	}
-	// Cursor cannot start a hidden probe, so expiry would only discard its
-	// last-known-good list. Claude can safely re-discover after the TTL.
+	// Providers with a preserved cache keep their last-known-good catalog until
+	// an explicit invalidation or a running session advertises a fresher list.
 	if composerProfileFor(provider).Behavior.PreserveLiveModelCache {
 		return 0
 	}
@@ -163,10 +163,11 @@ func (s *Service) setLiveComposerModelOptionsForScope(scope composerLiveModelSco
 }
 
 // composerLiveModelCacheKey buckets the cache by provider, workspace, cwd scope,
-// and (for auth-sensitive providers) an auth-context fingerprint. Claude uses
-// one account-level cwd scope so UI project selection cannot duplicate hidden
-// discovery. Other providers retain their caller cwd. The same key also scopes
-// the once-per-key hidden discovery guard.
+// and (for auth-sensitive providers) an auth-context fingerprint. Providers
+// with credential-scoped catalogs use one account-level workspace/cwd scope so
+// UI project selection cannot duplicate hidden discovery. Other providers
+// retain their caller scope. The same key also scopes the once-per-key hidden
+// discovery guard.
 func composerLiveModelCacheKey(provider, workspaceID, cwd, authScope string) string {
 	scope := newComposerLiveModelScope(provider, workspaceID, cwd, "")
 	scope.authScope = strings.TrimSpace(authScope)

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -560,8 +560,9 @@ func (s *Service) mergeLiveComposerModelsForComposerOptions(
 				modelSource = runtimeLiveModelCatalogSource
 			}
 		default:
-			// No running session: prefer the cache, else one hidden discovery,
-			// else fall through to the static fallback below.
+			// No running session: prefer the cache, then the last catalog a
+			// persisted session advertised. Only bootstrap a hidden discovery
+			// session when neither source can populate the first composer.
 			if cached, ok := s.getLiveComposerModelOptionsForScope(scope, now); ok {
 				liveModels = cached
 				modelSource = runtimeLiveModelCatalogSource
@@ -573,6 +574,9 @@ func (s *Service) mergeLiveComposerModelsForComposerOptions(
 					"modelOptionValues": composerConfigOptionValuesDebugValues(cached),
 					"checkedAtUnixMs":   now.UnixMilli(),
 				})
+			} else if persisted, ok := s.persistedLiveModelFallback(input.WorkspaceID, input.Cwd, provider, now, input.AgentTargetID); ok {
+				liveModels = persisted
+				modelSource = runtimeLiveModelCatalogSource
 			} else {
 				discovered, err := s.discoverLiveComposerModels(ctx, input, effectiveSettings)
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -580,13 +584,6 @@ func (s *Service) mergeLiveComposerModelsForComposerOptions(
 				}
 				if err == nil && len(discovered) > 0 {
 					liveModels = discovered
-					modelSource = runtimeLiveModelCatalogSource
-				} else if persisted, ok := s.persistedLiveModelFallback(input.WorkspaceID, input.Cwd, provider, now, input.AgentTargetID); ok {
-					// No live session, no cache, and discovery could not run
-					// (Cursor never probes; Claude probes once per key). Restore
-					// the last list a past session persisted so the picker does
-					// not collapse to the single selected model.
-					liveModels = persisted
 					modelSource = runtimeLiveModelCatalogSource
 				}
 			}

--- a/services/tuttid/service/agent/composer_live_model_discovery_test.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery_test.go
@@ -2,9 +2,10 @@ package agent
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
+
+	"github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 )
 
 func TestClaudeModelCatalogDebugPayloadDropsSensitiveDiagnostics(t *testing.T) {
@@ -73,19 +74,40 @@ func TestLiveModelOptionsFromRunningSessionFiltersProvider(t *testing.T) {
 	}
 }
 
-func TestDiscoverLiveComposerModelsUncachedSkipsProbeForCursor(t *testing.T) {
-	t.Parallel()
+func TestGetComposerOptionsStartsHiddenProbeBeforeFirstCursorSession(t *testing.T) {
+	t.Setenv("TUTTI_STATE_DIR", t.TempDir())
 	runtime := newFakeRuntime()
-	service := newIsolatedAgentService(runtime)
-
-	_, err := service.discoverLiveComposerModelsUncached(
-		context.Background(), "cursor", "ws-1", "", ComposerSettings{},
-	)
-	if !errors.Is(err, errLiveModelDiscoveryAlreadyAttempted) {
-		t.Fatalf("err = %v, want probe skipped for cursor", err)
+	runtime.startHook = func(input RuntimeStartInput, session ProviderRuntimeSession) ProviderRuntimeSession {
+		if input.Provider != "cursor" {
+			t.Fatalf("start provider = %q, want cursor", input.Provider)
+		}
+		if input.Visible == nil || *input.Visible {
+			t.Fatalf("visible = %#v, want hidden discovery session", input.Visible)
+		}
+		if input.RuntimeContext["hiddenLiveModelDiscovery"] != true {
+			t.Fatalf("runtime context = %#v, want hidden discovery marker", input.RuntimeContext)
+		}
+		session.RuntimeContext = cursorModelRuntimeContext()
+		return session
 	}
-	if len(runtime.startCalls) != 0 {
-		t.Fatalf("start calls = %#v, cursor discovery must never spawn a hidden session", runtime.startCalls)
+	service := newIsolatedAgentService(runtime)
+	service.AgentTargetStore = fakeAgentTargetStore{targets: defaultTestAgentTargets()}
+	service.LiveModelDiscoveryDeleteDelay = time.Hour
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		AgentTargetID: agenttarget.IDLocalCursor,
+		Provider:      "cursor",
+		WorkspaceID:   "ws-1",
+		Cwd:           "/repo",
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions: %v", err)
+	}
+	if len(runtime.startCalls) != 1 {
+		t.Fatalf("start calls = %#v, want one hidden cursor discovery session", runtime.startCalls)
+	}
+	if len(options.ModelConfig.Options) != 3 || options.ModelConfig.Options[0].Value != "default[]" {
+		t.Fatalf("model config = %#v, want live cursor model catalog", options.ModelConfig)
 	}
 }
 
@@ -125,8 +147,7 @@ func TestGetComposerOptionsMergesLiveCursorModels(t *testing.T) {
 
 // After a daemon restart the runtime session and the in-memory cache are both
 // gone; the model list a past cursor conversation persisted in its runtime
-// context must restore the picker instead of collapsing it to the single
-// selected model (Cursor has no probe session to re-discover with).
+// context must restore the picker without starting an unnecessary probe.
 func TestGetComposerOptionsRestoresCursorModelsFromPersistedSessions(t *testing.T) {
 	t.Parallel()
 	service := newIsolatedAgentService(newFakeRuntime())

--- a/services/tuttid/service/agent/composer_live_model_persisted.go
+++ b/services/tuttid/service/agent/composer_live_model_persisted.go
@@ -9,9 +9,9 @@ import (
 // liveModelOptionsFromPersistedSessions returns the most recent model list a
 // past provider session persisted in its runtime context. It restores the
 // composer's model picker when both the live runtime session and the
-// in-memory cache are gone (typically after a daemon restart): providers such
-// as Cursor have no probe session, so without this the picker stays pinned to
-// the single selected model until the user starts a new conversation.
+// in-memory cache are gone (typically after a daemon restart). Reusing this
+// durable last-known-good catalog avoids an unnecessary hidden probe and keeps
+// the picker from collapsing to the single selected model.
 func (s *Service) liveModelOptionsFromPersistedSessions(workspaceID string, provider string, agentTargetIDs ...string) []ComposerConfigOptionValue {
 	if s.SessionReader == nil {
 		return nil

--- a/services/tuttid/service/agent/composer_live_model_scope.go
+++ b/services/tuttid/service/agent/composer_live_model_scope.go
@@ -12,8 +12,7 @@ import (
 	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
 )
 
-const claudeLiveModelCacheCwdScope = "account"
-const claudeLiveModelCacheWorkspaceScope = "account"
+const accountLiveModelCacheScope = "account"
 
 type composerLiveModelScope struct {
 	provider      string
@@ -35,8 +34,8 @@ func newComposerLiveModelScope(provider, workspaceID, cwd, agentTargetID string)
 
 func (s composerLiveModelScope) key() string {
 	workspaceScope := s.workspaceID
-	if isClaudeSDKLiveModelProvider(s.provider) {
-		workspaceScope = claudeLiveModelCacheWorkspaceScope
+	if liveModelCatalogUsesAccountScope(s.provider) {
+		workspaceScope = accountLiveModelCacheScope
 	}
 	targetScope := s.agentTargetID
 	if targetScope == "" {
@@ -51,10 +50,14 @@ func (s composerLiveModelScope) key() string {
 }
 
 func liveModelCacheCwdScope(provider string, cwd string) string {
-	if isClaudeSDKLiveModelProvider(provider) {
-		return claudeLiveModelCacheCwdScope
+	if liveModelCatalogUsesAccountScope(provider) {
+		return accountLiveModelCacheScope
 	}
 	return strings.TrimSpace(cwd)
+}
+
+func liveModelCatalogUsesAccountScope(provider string) bool {
+	return composerProfileFor(provider).LiveModelAccountScoped
 }
 
 func (s *Service) resolveLiveModelDiscoveryCwd(
@@ -62,7 +65,7 @@ func (s *Service) resolveLiveModelDiscoveryCwd(
 	provider string,
 	requestedCwd string,
 ) (string, error) {
-	if !isClaudeSDKLiveModelProvider(provider) {
+	if !liveModelCatalogUsesAccountScope(provider) {
 		resolvedCwd := strings.TrimSpace(requestedCwd)
 		if resolvedCwd == "" {
 			return "", nil
@@ -76,7 +79,7 @@ func (s *Service) resolveLiveModelDiscoveryCwd(
 	}
 	discoveryCwd := filepath.Join(stateDir, "agent", "discovery", agentprovider.NormalizeOpen(provider))
 	if err := os.MkdirAll(discoveryCwd, 0o700); err != nil {
-		return "", fmt.Errorf("create Claude live-model discovery directory: %w", err)
+		return "", fmt.Errorf("create live-model discovery directory: %w", err)
 	}
 	return discoveryCwd, nil
 }

--- a/services/tuttid/service/agent/composer_live_model_scope_test.go
+++ b/services/tuttid/service/agent/composer_live_model_scope_test.go
@@ -38,68 +38,68 @@ func (r *startupWaitRuntime) Sessions(string) []ProviderRuntimeSession {
 	return append([]ProviderRuntimeSession(nil), r.afterWaitSessions...)
 }
 
-func TestClaudeLiveModelCacheKeyIgnoresCallerCwd(t *testing.T) {
+func TestAccountScopedLiveModelCacheKeyIgnoresCallerWorkspaceAndCwd(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 
-	rootKey := composerLiveModelCacheKey(
-		agentprovider.ClaudeCode,
-		"workspace-1",
-		"/",
-		liveModelAuthScope(agentprovider.ClaudeCode),
-	)
-	projectKey := composerLiveModelCacheKey(
-		agentprovider.ClaudeCode,
-		"workspace-1",
-		"/Users/example/project",
-		liveModelAuthScope(agentprovider.ClaudeCode),
-	)
-	if rootKey != projectKey {
-		t.Fatalf("Claude cache keys differ by cwd: root=%q project=%q", rootKey, projectKey)
-	}
-
-	cursorRootKey := composerLiveModelCacheKey(agentprovider.Cursor, "workspace-1", "/", "")
-	cursorProjectKey := composerLiveModelCacheKey(agentprovider.Cursor, "workspace-1", "/project", "")
-	if cursorRootKey == cursorProjectKey {
-		t.Fatal("non-Claude cache keys must retain their cwd scope")
+	for _, provider := range []string{agentprovider.ClaudeCode, agentprovider.Cursor} {
+		rootKey := composerLiveModelCacheKey(
+			provider,
+			"workspace-1",
+			"/",
+			liveModelAuthScope(provider),
+		)
+		projectKey := composerLiveModelCacheKey(
+			provider,
+			"workspace-2",
+			"/Users/example/project",
+			liveModelAuthScope(provider),
+		)
+		if rootKey != projectKey {
+			t.Fatalf("%s cache keys differ by workspace/cwd: root=%q project=%q", provider, rootKey, projectKey)
+		}
 	}
 }
 
-func TestClaudeLiveModelScopeIsSharedAcrossWorkspacesAndSeparatedByTarget(t *testing.T) {
+func TestAccountScopedLiveModelScopeIsSharedAcrossWorkspacesAndSeparatedByTarget(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
-	first := newComposerLiveModelScope(agentprovider.ClaudeCode, "workspace-1", "/one", "local-claude")
-	second := newComposerLiveModelScope(agentprovider.ClaudeCode, "workspace-2", "/two", "local-claude")
-	otherTarget := newComposerLiveModelScope(agentprovider.ClaudeCode, "workspace-2", "/two", "remote-claude")
-	if first.key() != second.key() {
-		t.Fatalf("Claude discovery scope differs across workspaces: %q != %q", first.key(), second.key())
-	}
-	if first.key() == otherTarget.key() {
-		t.Fatal("Claude discovery scope must distinguish agent targets")
+	for _, provider := range []string{agentprovider.ClaudeCode, agentprovider.Cursor} {
+		first := newComposerLiveModelScope(provider, "workspace-1", "/one", "local-agent")
+		second := newComposerLiveModelScope(provider, "workspace-2", "/two", "local-agent")
+		otherTarget := newComposerLiveModelScope(provider, "workspace-2", "/two", "remote-agent")
+		if first.key() != second.key() {
+			t.Fatalf("%s discovery scope differs across workspaces: %q != %q", provider, first.key(), second.key())
+		}
+		if first.key() == otherTarget.key() {
+			t.Fatalf("%s discovery scope must distinguish agent targets", provider)
+		}
 	}
 }
 
-func TestClaudeLiveModelDiscoveryUsesDaemonOwnedCwd(t *testing.T) {
+func TestAccountScopedLiveModelDiscoveryUsesDaemonOwnedCwd(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv("TUTTI_STATE_DIR", stateDir)
 	service := newIsolatedAgentService(newFakeRuntime())
 
-	fromRoot, err := service.resolveLiveModelDiscoveryCwd(context.Background(), agentprovider.ClaudeCode, "/")
-	if err != nil {
-		t.Fatalf("resolve root discovery cwd: %v", err)
-	}
-	fromProject, err := service.resolveLiveModelDiscoveryCwd(context.Background(), agentprovider.ClaudeCode, "/Users/example/project")
-	if err != nil {
-		t.Fatalf("resolve project discovery cwd: %v", err)
-	}
-	want := filepath.Join(stateDir, "agent", "discovery", agentprovider.ClaudeCode)
-	if fromRoot != want || fromProject != want {
-		t.Fatalf("Claude discovery cwd = %q and %q, want %q", fromRoot, fromProject, want)
-	}
-	info, err := os.Stat(want)
-	if err != nil {
-		t.Fatalf("stat discovery cwd: %v", err)
-	}
-	if !info.IsDir() {
-		t.Fatalf("discovery cwd %q is not a directory", want)
+	for _, provider := range []string{agentprovider.ClaudeCode, agentprovider.Cursor} {
+		fromRoot, err := service.resolveLiveModelDiscoveryCwd(context.Background(), provider, "/")
+		if err != nil {
+			t.Fatalf("resolve %s root discovery cwd: %v", provider, err)
+		}
+		fromProject, err := service.resolveLiveModelDiscoveryCwd(context.Background(), provider, "/Users/example/project")
+		if err != nil {
+			t.Fatalf("resolve %s project discovery cwd: %v", provider, err)
+		}
+		want := filepath.Join(stateDir, "agent", "discovery", provider)
+		if fromRoot != want || fromProject != want {
+			t.Fatalf("%s discovery cwd = %q and %q, want %q", provider, fromRoot, fromProject, want)
+		}
+		info, err := os.Stat(want)
+		if err != nil {
+			t.Fatalf("stat %s discovery cwd: %v", provider, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("discovery cwd %q is not a directory", want)
+		}
 	}
 }
 

--- a/services/tuttid/service/agent/composer_profiles.go
+++ b/services/tuttid/service/agent/composer_profiles.go
@@ -28,8 +28,12 @@ type composerProfile struct {
 	LiveModelDiscoveryKind providerregistry.LiveModelDiscoveryKind
 	// LiveModelProbeSession: with no running session to reuse, model
 	// discovery may spawn a short-lived hidden provider session. Opt-in
-	// because the probe is a real session (Claude Code only today).
+	// because the probe is a real provider session.
 	LiveModelProbeSession bool
+	// LiveModelAccountScoped: the advertised catalog is credential-scoped,
+	// not workspace/cwd-scoped. Hidden discovery and caching share one scope
+	// per agent target when enabled.
+	LiveModelAccountScoped bool
 	// UsesModelCatalog: model options come from the daemon-side
 	// AgentModelCatalog (CLI/schema-backed lists).
 	UsesModelCatalog bool
@@ -103,6 +107,7 @@ func composerProfileFromDescriptor(provider providerregistry.ProviderDescriptor)
 		LiveModelDiscovery:       descriptor.LiveModelDiscovery.Kind != "",
 		LiveModelDiscoveryKind:   descriptor.LiveModelDiscovery.Kind,
 		LiveModelProbeSession:    descriptor.LiveModelDiscovery.HiddenProbe,
+		LiveModelAccountScoped:   descriptor.LiveModelDiscovery.AccountScoped,
 		UsesModelCatalog:         strings.TrimSpace(string(descriptor.ModelCatalog)) != "",
 		ModelCatalog:             descriptor.ModelCatalog,
 		CapabilityCatalogKind:    descriptor.CapabilityCatalog.Kind,

--- a/services/tuttid/service/agent/provider_descriptor_test.go
+++ b/services/tuttid/service/agent/provider_descriptor_test.go
@@ -36,7 +36,7 @@ func TestCodexComposerProfileComesFromProviderDescriptor(t *testing.T) {
 func TestClaudeCodeComposerProfileComesFromProviderDescriptor(t *testing.T) {
 	profile := composerProfileFor(agentprovider.ClaudeCode)
 	if profile.LiveModelDiscoveryKind != providerregistry.LiveModelDiscoveryKindClaudeSDK ||
-		!profile.LiveModelProbeSession || profile.SkillKind != "claude-code" ||
+		!profile.LiveModelProbeSession || !profile.LiveModelAccountScoped || profile.SkillKind != "claude-code" ||
 		profile.ReasoningEffortOptions != providerregistry.ReasoningEffortOptionsStatic {
 		t.Fatalf("claude composer profile = %#v", profile)
 	}
@@ -47,8 +47,12 @@ func TestClaudeCodeComposerProfileComesFromProviderDescriptor(t *testing.T) {
 	}
 }
 
-func TestCursorSkillDiscoveryComesFromProviderDescriptor(t *testing.T) {
+func TestCursorComposerProfileComesFromProviderDescriptor(t *testing.T) {
 	profile := composerProfileFor(agentprovider.Cursor)
+	if profile.LiveModelDiscoveryKind != providerregistry.LiveModelDiscoveryKindRuntimeSession ||
+		!profile.LiveModelProbeSession || !profile.LiveModelAccountScoped {
+		t.Fatalf("cursor live model discovery profile = %#v", profile)
+	}
 	if profile.SkillKind != string(providerregistry.SkillKindCursor) || profile.SkillInvocation != string(providerregistry.SkillInvocationTextTrigger) {
 		t.Fatalf("cursor skill profile = %#v", profile)
 	}


### PR DESCRIPTION
## Summary

- route Standard ACP completion through the daemon-owned root provider lifecycle, reject late turn-scoped updates, and propagate cancel/permission transport failures
- discover Cursor's account-scoped model catalog with a hidden no-prompt session and force AgentGUI to refresh target-scoped options after conversation creation settles
- add redacted Cursor Task diagnostics while keeping the unsupported background-Task guard dormant, with focused runtime/runtimeprep coverage and durable architecture/troubleshooting updates

## Verification

- `pnpm check:changed --tail-lines 120`
- `pnpm --filter @tutti-os/agent-gui test` (171 files, 1569 tests)
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:agent-gui-provider-catalog-generated`
- `pnpm lint:go`
- `pnpm test:go`
- `pnpm build:go`
- `pnpm check:full` (18 tasks, via pre-push)

## Fix Scope Justification

- Root cause: Standard ACP prompt completion bypassed the daemon-owned root settlement path, while session-level callbacks could attach late tool/permission activity to a recently settled turn. Cursor also exposes its model catalog only after ACP session bootstrap, leaving the first empty composer with a selected-model-only snapshot.
- Why can this not be fixed at a lower layer? The correction spans the provider transport boundary, daemon lifecycle authority, composer-option discovery/cache ownership, and the AgentGUI refresh that replaces the bootstrap snapshot. Fixing only one presentation or persistence layer would leave a competing lifecycle or stale catalog source in place.

## Fallback Three Questions

- Source: the model fallback compensates for ACP providers that advertise catalogs only from `session/new`; the defensive event branch handles provider notifications that arrive after their owning `session/prompt` call has returned.
- Why can it not be fixed at that source? Current Cursor ACP does not expose a pre-session catalog or stable detached-child lifecycle/ownership facts, and Tutti cannot safely infer those identities from tool text or timing.
- Removal condition: hidden probing/persisted catalog fallback can be removed when the provider offers an account-scoped catalog outside session bootstrap. The late-event rejection can be replaced when ACP exposes stable parent/child identity and terminal events that can be reconciled after the root prompt returns.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Standard ACP turn lifecycle and made Cursor model discovery reliable and consistent. This prevents late ACP events from corrupting settled turns and ensures the composer shows the right model options before the first visible conversation.

- **Bug Fixes**
  - Routed Standard ACP completion through daemon-owned root provider lifecycle (`EventRootProviderTurnStarted/Completed`) and stopped emitting canonical `turn.*` terminals directly in `packages/agent/daemon/runtime`.
  - Dropped late turn-scoped tool updates and rejected out-of-band permission callbacks that arrive after the prompt returns; no synthetic turns are created.
  - Propagated transport failures for `session/cancel` and auto-approve permission responses instead of reporting false success.
  - Updated `@tutti-os/agent-gui` to force a one-time composer options refresh after conversation creation settles to replace a selected-model-only bootstrap snapshot.

- **New Features**
  - Enabled account-scoped hidden live-model discovery sessions for Cursor and Claude Code via provider descriptors and `services/tuttid` caching; prefer persisted catalogs when available, probe only when needed.
  - Added redacted Cursor Task diagnostics for `cursor/task` extension and Task tool updates; observational only, no behavior changes.
  - Kept the Cursor background Task guard implemented but dormant in `packages/agent/runtimeprep`; not advertised in the plugin manifest and covered by focused tests.
  - Updated docs to reflect ACP lifecycle rules, Cursor/OpenCode behavior, and provider-native subagent constraints.

<sup>Written for commit 9f6287562f4ea2714ac63336b204f533033e726f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

