### PR TITLE
fix(agent): reduce provider rail latency

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1281,6 +1281,21 @@ to engine entities. Do not keep a second summary cache or manually patch
 section rows from conversation summaries. Removing a project removes that rail
 section from the section list; re-adding the same path reveals historical
 sessions with the same section key.
+The daemon first-page reader is a required production repository seam, not an
+optional fast path with a per-section fallback. Its SQLite query must be driven
+by the requested section keys: ordinary branches use the rail-section page
+index, and pinned rows use a separate pinned-page index branch. Do not scan the
+workspace session history and test section membership row by row; workspaces
+retain historical sessions for removed projects that are not part of the
+current rail. Count, sort, and first-page trimming operate on narrow session-id
+rows; load full session entities only after that trimming. The query shape must
+not add one compound-select arm per requested section or inherit SQLite's
+compound-select term limit as a Rail project-count limit.
+When `agentTargetId` narrows the provider rail, use an exact target predicate
+and target-scoped ordinary/pinned composite indexes. An optional
+`(? = '' OR agent_target_id = ?)` predicate on an unscoped index only filters
+after scanning every provider row in the section and is not an acceptable
+provider-switch query plan.
 Rail search is a separate UI-local query over
 `GET /v1/workspaces/{workspaceID}/agent-sessions`. Its `searchQuery` and active
 `agentTargetId` are applied by the daemon before cursor pagination, so results

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -625,7 +625,15 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   by the session primary key after narrow id trimming. A target-filtered rail
   must instead use `idx_workspace_agent_sessions_rail_section_target_page` and
   `idx_workspace_agent_sessions_pinned_target_page` with an exact target
-  predicate; an optional `OR` predicate cannot narrow the index range.
+  predicate; an optional `OR` predicate cannot narrow the index range. For a
+  reported slow switch, correlate
+  `agent_gui.conversation_rail.first_pages_slow` with
+  `workspace.agent_session.sections.list_slow`: the renderer event separates
+  request and controller-apply time, while the daemon event separates current
+  projects, store, and hydration time. Corresponding `*_failed` events record
+  real failures. Successful requests below 250 ms, aborted requests, and stale
+  responses are intentionally silent; these diagnostics must not log project
+  paths, section keys, session titles, or prompts.
 - Root cause:
   A second React summary cache mixed entity data, section membership, active
   selection, and visible-item limits. Effects manually patched section rows

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -602,7 +602,11 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
 - Symptom:
   Switching the Agent GUI aggregation rail between All, Cursor, Codex, or Claude
   makes the selected row disappear, collapses a loaded page, or briefly flashes
-  missing Show more controls. Five page rows plus one selected overlay may show
+  missing Show more controls. The same switch may remain visibly blocked even
+  when each individual session query takes only tens of milliseconds, because
+  the first-page bootstrap repeats count, sort, entity projection, and turn /
+  interaction hydration once per current project section. Five page rows plus
+  one selected overlay may show
   Show more/Show less even when only six sessions exist, or a nine-session
   section may ignore the first Show more click. Restart can reproduce the same
   selected-row loss.
@@ -612,21 +616,39 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   and responses preserve `totalCount`, `hasMore`, and `nextCursor`. In the
   renderer, distinguish daemon-owned section membership ids from engine-owned
   session entities; activating or hydrating one session must not rewrite the
-  loaded membership page.
+  loaded membership page. For latency, count repository section reads per
+  bootstrap: production must issue one `ListSessionSections` batch read, not one
+  `ListSessionSection` call per project plus pinned and Chats. Run
+  `EXPLAIN QUERY PLAN` and confirm ordinary branches use
+  `idx_workspace_agent_sessions_rail_section_page`, pinned branches use
+  `idx_workspace_agent_sessions_pinned_page`, and selected page entities load
+  by the session primary key after narrow id trimming. A target-filtered rail
+  must instead use `idx_workspace_agent_sessions_rail_section_target_page` and
+  `idx_workspace_agent_sessions_pinned_target_page` with an exact target
+  predicate; an optional `OR` predicate cannot narrow the index range.
 - Root cause:
   A second React summary cache mixed entity data, section membership, active
   selection, and visible-item limits. Effects manually patched section rows
   from changing conversation summaries, so provider/detail reconciliation could
   collapse pages or synthesize membership. Counting the active overlay as a
   pageable row also corrupted Show more decisions. Bounded engine snapshots can
-  recreate the loss if omission is treated as deletion.
+  recreate the loss if omission is treated as deletion. The latency variant is
+  an N-section daemon read: current projects are a small requested set, while
+  the workspace DB retains history for removed projects. Scanning that full
+  history or repeating canonical turn / interaction hydration per section makes
+  the rail wait scale with project count even when every leaf query looks fast.
 - Fix:
   Keep page sessions in the workspace engine. Cache only ordered membership ids,
   cursor, `hasMore`, and `totalCount` in the controller query, then join ids to
   engine entities with a pure model projection. Keep active and pending sessions
   as display overlays outside pagination. Preserve old scope chrome and metadata
   atomically while a provider refetch is pending. Engine snapshots merge
-  monotonically; only explicit `session/removed` owns deletion.
+  monotonically; only explicit `session/removed` owns deletion. Keep first-page
+  bootstrap as a required narrow repository seam: one requested-section-driven
+  batch query, independent pinned and ordinary index branches, count/sort/limit
+  on narrow session ids, then one cross-section canonical entity hydration.
+  Do not add one `UNION ALL` arm per section; that restores section-count scaling
+  and inherits SQLite's compound-select term limit.
 - Validation:
   Run `pnpm --filter @tutti-os/agent-gui test`,
   `pnpm --filter @tutti-os/agent-activity-core test`, and
@@ -634,7 +656,10 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   `cd packages/agent/store-sqlite && go test ./... -run 'SessionSection|TurnsBackfill'`
   and
   `cd services/tuttid && go test ./service/agent ./api -run 'ListPage|SessionList|SessionSection'`
-  so cursor metadata and daemon ordering are covered. Cover Codex -> All -> Codex,
+  so cursor metadata and daemon ordering are covered. Run
+  `cd packages/agent/store-sqlite && go test -run '^$' -bench 'BenchmarkStoreListSessionSectionsLargeRemovedProjectHistory' -benchmem`
+  to compare the batch reader with the serial reference across sparse and dense
+  requested-section histories. Cover Codex -> All -> Codex,
   client restart restore, active row outside first page, five-plus-active totals,
   nine-session Show more, slow provider refetch, and bounded snapshot omission.
 - References:

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
@@ -236,4 +236,139 @@ describe("AgentGUIConversationRailQueryController", () => {
     detachSecond();
     engine.dispose();
   });
+
+  it("logs only slow successful first-page rail queries", async () => {
+    const engine = createTestAgentSessionEngine();
+    const reportDiagnostic = vi.fn();
+    const diagnosticTimes = [0, 300, 325];
+    const controller = new AgentGUIConversationRailQueryController({
+      diagnosticNow: () => diagnosticTimes.shift() ?? 325,
+      diagnosticSlowThresholdMs: 250,
+      engine,
+      getActiveConversationId: () => null,
+      runtime: {
+        listSessionSections: async (input) => ({
+          pinned: {
+            hasMore: false,
+            sessions: [],
+            totalCount: 0
+          },
+          sections: [
+            {
+              hasMore: false,
+              kind: "conversations",
+              sectionKey: "conversations",
+              sessions: [],
+              totalCount: 0
+            }
+          ],
+          workspaceId: input.workspaceId
+        }),
+        listSessionSectionPage: async (input) => ({
+          hasMore: false,
+          kind: "conversations",
+          sectionKey: input.sectionKey,
+          sessions: [],
+          totalCount: 0
+        }),
+        reportDiagnostic
+      },
+      workspaceId: "test-workspace"
+    });
+    controller.configure({
+      conversationFilter: {
+        kind: "agentTarget",
+        agentTargetId: "local:codex"
+      },
+      previewMode: false,
+      sectionAgentTargetFallbackId: null,
+      userProjects: []
+    });
+
+    const detach = controller.attach();
+    await vi.waitFor(() => expect(reportDiagnostic).toHaveBeenCalledTimes(1));
+    expect(reportDiagnostic).toHaveBeenCalledWith({
+      details: {
+        agentTargetId: "local:codex",
+        controllerApplyMs: 25,
+        durationMs: 325,
+        event: "agent_gui.conversation_rail.first_pages_slow",
+        requestId: 2,
+        requestMs: 300,
+        sectionCount: 2,
+        sessionCount: 0,
+        status: "ready",
+        workspaceId: "test-workspace"
+      },
+      event: "agent_gui.conversation_rail.first_pages_slow",
+      level: "info",
+      source: "agent-gui",
+      workspaceId: "test-workspace"
+    });
+
+    detach();
+    engine.dispose();
+  });
+
+  it("suppresses fast success diagnostics but records real failures", async () => {
+    const engine = createTestAgentSessionEngine();
+    const diagnosticLogger = vi.fn();
+    let requestCount = 0;
+    const diagnosticTimes = [0, 100, 110, 110, 130];
+    const controller = new AgentGUIConversationRailQueryController({
+      diagnosticLogger,
+      diagnosticNow: () => diagnosticTimes.shift() ?? 130,
+      diagnosticSlowThresholdMs: 250,
+      engine,
+      getActiveConversationId: () => null,
+      runtime: {
+        listSessionSections: async (input) => {
+          requestCount += 1;
+          if (requestCount > 1) throw new TypeError("backend unavailable");
+          return { sections: [], workspaceId: input.workspaceId };
+        },
+        listSessionSectionPage: async (input) => ({
+          hasMore: false,
+          kind: "conversations",
+          sectionKey: input.sectionKey,
+          sessions: [],
+          totalCount: 0
+        })
+      },
+      workspaceId: "test-workspace"
+    });
+    const scope = {
+      conversationFilter: { kind: "all" } as const,
+      previewMode: false,
+      sectionAgentTargetFallbackId: null,
+      userProjects: []
+    };
+    controller.configure(scope);
+
+    const detachFirst = controller.attach();
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
+    expect(diagnosticLogger).not.toHaveBeenCalled();
+    detachFirst();
+
+    const detachSecond = controller.attach();
+    await vi.waitFor(() => expect(diagnosticLogger).toHaveBeenCalledTimes(1));
+    expect(diagnosticLogger).toHaveBeenCalledWith({
+      agentTargetId: null,
+      controllerApplyMs: 0,
+      durationMs: 20,
+      errorKind: "TypeError",
+      event: "agent_gui.conversation_rail.first_pages_failed",
+      requestId: 4,
+      requestMs: 20,
+      sectionCount: 0,
+      sessionCount: 0,
+      status: "error",
+      workspaceId: "test-workspace"
+    });
+
+    detachSecond();
+    engine.dispose();
+  });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -14,6 +14,12 @@ import {
 } from "../agentGuiScheduler";
 import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
 import {
+  CONVERSATION_RAIL_SLOW_DIAGNOSTIC_THRESHOLD_MS,
+  createConversationRailDiagnosticLogger,
+  emitConversationRailFirstPagesDiagnostic,
+  type ConversationRailDiagnosticLogger
+} from "./agentGuiConversationRailDiagnostics";
+import {
   mergeConversationRailSessionIds,
   planRuntimeRailMembershipRefresh,
   projectRuntimeSectionsToConversationRailMemberships,
@@ -81,6 +87,9 @@ export interface AgentGUIConversationRailQuerySnapshot {
 }
 
 interface ControllerInput {
+  diagnosticLogger?: ConversationRailDiagnosticLogger;
+  diagnosticNow?: () => number;
+  diagnosticSlowThresholdMs?: number;
   engine: AgentSessionEngine;
   getActiveConversationId(): string | null;
   runtime: ConversationRailQueryRuntime;
@@ -94,6 +103,7 @@ export type ConversationRailQueryRuntime = Pick<
   | "listSessionSectionPage"
   | "listSessionSections"
   | "listSessionsPage"
+  | "reportDiagnostic"
 >;
 
 type Listener = (snapshot: AgentGUIConversationRailQuerySnapshot) => void;
@@ -110,6 +120,9 @@ export class AgentGUIConversationRailQueryController {
   };
 
   private readonly engine: AgentSessionEngine;
+  private readonly diagnosticLogger: ConversationRailDiagnosticLogger;
+  private readonly diagnosticNow: () => number;
+  private readonly diagnosticSlowThresholdMs: number;
   private readonly getActiveConversationId: () => string | null;
   private readonly listeners = new Set<Listener>();
   private readonly runtime: ConversationRailQueryRuntime;
@@ -134,6 +147,13 @@ export class AgentGUIConversationRailQueryController {
   private unsubscribeEngine: (() => void) | null = null;
 
   constructor(input: ControllerInput) {
+    this.diagnosticLogger =
+      input.diagnosticLogger ??
+      createConversationRailDiagnosticLogger(input.runtime);
+    this.diagnosticNow = input.diagnosticNow ?? Date.now;
+    this.diagnosticSlowThresholdMs =
+      input.diagnosticSlowThresholdMs ??
+      CONVERSATION_RAIL_SLOW_DIAGNOSTIC_THRESHOLD_MS;
     this.engine = input.engine;
     this.getActiveConversationId = input.getActiveConversationId;
     this.runtime = input.runtime;
@@ -425,6 +445,7 @@ export class AgentGUIConversationRailQueryController {
     }
     this.pagingRequestSequence += 1;
     const requestSequence = this.pagingRequestSequence;
+    const requestStartedAt = this.diagnosticNow();
     const wasResolvedForScope =
       this.queryState.resolvedScopeKey === scopeKey &&
       this.queryState.sections !== null;
@@ -450,6 +471,7 @@ export class AgentGUIConversationRailQueryController {
         ) {
           return;
         }
+        const requestResolvedAt = this.diagnosticNow();
         const sections = projectRuntimeSectionsToConversationRailMemberships({
           pinned: page.pinned,
           sections: page.sections
@@ -476,8 +498,27 @@ export class AgentGUIConversationRailQueryController {
           sections
         };
         this.emit();
+        const completedAt = this.diagnosticNow();
+        emitConversationRailFirstPagesDiagnostic({
+          agentTargetId: this.sectionAgentTargetId || null,
+          controllerApplyMs: Math.max(0, completedAt - requestResolvedAt),
+          diagnosticLogger: this.diagnosticLogger,
+          diagnosticSlowThresholdMs: this.diagnosticSlowThresholdMs,
+          durationMs: Math.max(0, completedAt - requestStartedAt),
+          requestId: requestSequence,
+          requestMs: Math.max(0, requestResolvedAt - requestStartedAt),
+          sectionCount: page.sections.length + (page.pinned ? 1 : 0),
+          sessionCount:
+            (page.pinned?.sessions.length ?? 0) +
+            page.sections.reduce(
+              (count, section) => count + section.sessions.length,
+              0
+            ),
+          status: "ready",
+          workspaceId: this.workspaceId
+        });
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         if (
           abortController.signal.aborted ||
           requestSequence !== this.pagingRequestSequence ||
@@ -485,6 +526,21 @@ export class AgentGUIConversationRailQueryController {
         ) {
           return;
         }
+        const failedAt = this.diagnosticNow();
+        emitConversationRailFirstPagesDiagnostic({
+          agentTargetId: this.sectionAgentTargetId || null,
+          controllerApplyMs: 0,
+          diagnosticLogger: this.diagnosticLogger,
+          diagnosticSlowThresholdMs: this.diagnosticSlowThresholdMs,
+          durationMs: Math.max(0, failedAt - requestStartedAt),
+          error,
+          requestId: requestSequence,
+          requestMs: Math.max(0, failedAt - requestStartedAt),
+          sectionCount: 0,
+          sessionCount: 0,
+          status: "error",
+          workspaceId: this.workspaceId
+        });
         this.queryState = wasResolvedForScope
           ? {
               ...this.queryState,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailDiagnostics.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailDiagnostics.ts
@@ -1,0 +1,106 @@
+import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
+
+export const CONVERSATION_RAIL_SLOW_DIAGNOSTIC_THRESHOLD_MS = 250;
+
+export interface ConversationRailFirstPagesDiagnostic {
+  agentTargetId: string | null;
+  controllerApplyMs: number;
+  durationMs: number;
+  errorKind?: string;
+  event:
+    | "agent_gui.conversation_rail.first_pages_slow"
+    | "agent_gui.conversation_rail.first_pages_failed";
+  requestId: number;
+  requestMs: number;
+  sectionCount: number;
+  sessionCount: number;
+  status: "ready" | "error";
+  workspaceId: string;
+}
+
+export type ConversationRailDiagnosticLogger = (
+  payload: ConversationRailFirstPagesDiagnostic
+) => void;
+
+export function emitConversationRailFirstPagesDiagnostic(input: {
+  agentTargetId: string | null;
+  controllerApplyMs: number;
+  diagnosticLogger: ConversationRailDiagnosticLogger;
+  diagnosticSlowThresholdMs: number;
+  durationMs: number;
+  error?: unknown;
+  requestId: number;
+  requestMs: number;
+  sectionCount: number;
+  sessionCount: number;
+  status: "ready" | "error";
+  workspaceId: string;
+}): void {
+  if (
+    input.status === "ready" &&
+    input.durationMs < input.diagnosticSlowThresholdMs
+  ) {
+    return;
+  }
+  const payload: ConversationRailFirstPagesDiagnostic = {
+    agentTargetId: input.agentTargetId,
+    controllerApplyMs: input.controllerApplyMs,
+    durationMs: input.durationMs,
+    ...(input.status === "error"
+      ? { errorKind: conversationRailErrorKind(input.error) }
+      : {}),
+    event:
+      input.status === "error"
+        ? "agent_gui.conversation_rail.first_pages_failed"
+        : "agent_gui.conversation_rail.first_pages_slow",
+    requestId: input.requestId,
+    requestMs: input.requestMs,
+    sectionCount: input.sectionCount,
+    sessionCount: input.sessionCount,
+    status: input.status,
+    workspaceId: input.workspaceId
+  };
+  try {
+    input.diagnosticLogger(payload);
+  } catch (error) {
+    // Diagnostics must never affect rail state or interaction locking.
+    ignoreConversationRailDiagnosticFailure(error);
+  }
+}
+
+export function createConversationRailDiagnosticLogger(
+  runtime: Pick<AgentActivityRuntime, "reportDiagnostic">
+): ConversationRailDiagnosticLogger {
+  return (payload) => {
+    const reportDiagnostic = runtime.reportDiagnostic;
+    if (!reportDiagnostic) return;
+    try {
+      void Promise.resolve(
+        reportDiagnostic.call(runtime, {
+          details: { ...payload },
+          event: payload.event,
+          level: payload.status === "error" ? "warn" : "info",
+          source: "agent-gui",
+          workspaceId: payload.workspaceId
+        })
+      ).catch(ignoreConversationRailDiagnosticFailure);
+    } catch (error) {
+      // Best-effort diagnostics only; avoid console fallback noise.
+      ignoreConversationRailDiagnosticFailure(error);
+    }
+  };
+}
+
+function ignoreConversationRailDiagnosticFailure(error: unknown): void {
+  void error;
+}
+
+function conversationRailErrorKind(error: unknown): string {
+  if (error instanceof Error) {
+    return error.name || "Error";
+  }
+  if (typeof error === "string") {
+    return "string";
+  }
+  return error === null ? "null" : typeof error;
+}

--- a/packages/agent/store-sqlite/activity_sections.go
+++ b/packages/agent/store-sqlite/activity_sections.go
@@ -2,6 +2,7 @@ package storesqlite
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -47,6 +48,14 @@ func (s *Store) ListSessionSection(
 			totalCount,
 		)
 	}
+	indexName := "idx_workspace_agent_sessions_rail_section_page"
+	targetPredicate := ""
+	args := []any{workspaceID, sectionKey}
+	if agentTargetID != "" {
+		indexName = "idx_workspace_agent_sessions_rail_section_target_page"
+		targetPredicate = "AND agent_target_id = ?"
+		args = append(args, agentTargetID)
+	}
 	query := `
 WITH section_sessions AS (
   SELECT workspace_agent_sessions.*,
@@ -62,12 +71,12 @@ WITH section_sessions AS (
            ), 0),
            workspace_agent_sessions.created_at_unix_ms
          ) AS conversation_sort_time_unix_ms
-  FROM workspace_agent_sessions
+  FROM workspace_agent_sessions INDEXED BY ` + indexName + `
   WHERE workspace_id = ?
     AND session_kind = 'root'
     AND rail_section_key = ?
     AND pinned_at_unix_ms = 0
-    AND (? = '' OR agent_target_id = ?)
+    ` + targetPredicate + `
     AND deleted_at_unix_ms = 0
     AND json_extract(session_metadata_json, '$.visible') IS NOT 0
 )
@@ -82,16 +91,12 @@ SELECT workspace_id, agent_session_id, session_kind, root_agent_session_id, root
 FROM section_sessions
 WHERE (? = '' OR conversation_sort_time_unix_ms < ? OR (conversation_sort_time_unix_ms = ? AND agent_session_id > ?))
 ORDER BY conversation_sort_time_unix_ms DESC, agent_session_id ASC`
-	args := []any{
-		workspaceID,
-		sectionKey,
-		agentTargetID,
-		agentTargetID,
+	args = append(args,
 		strings.TrimSpace(input.CursorSessionID),
 		input.CursorSortTimeUnixMS,
 		input.CursorSortTimeUnixMS,
 		strings.TrimSpace(input.CursorSessionID),
-	}
+	)
 	if queryLimit > 0 {
 		query += "\nLIMIT ?"
 		args = append(args, queryLimit)
@@ -137,6 +142,254 @@ ORDER BY conversation_sort_time_unix_ms DESC, agent_session_id ASC`
 	}, true, nil
 }
 
+// ListSessionSections loads the first page and total for every requested rail
+// section with one SQLite query. Pinned sessions are assigned exclusively to
+// the synthetic pinned page; ordinary project and Chats pages exclude them.
+func (s *Store) ListSessionSections(
+	ctx context.Context,
+	input ListSessionSectionsInput,
+) (SessionSectionsPage, bool, error) {
+	if s == nil || s.db == nil {
+		return SessionSectionsPage{}, false, errors.New("workspace database is not initialized")
+	}
+	workspaceID := strings.TrimSpace(input.WorkspaceID)
+	sectionKeys := normalizeSessionSectionKeys(input.SectionKeys)
+	if workspaceID == "" || len(sectionKeys) == 0 || input.LimitPerSection <= 0 {
+		return SessionSectionsPage{}, false, nil
+	}
+	query, args, err := buildListSessionSectionsQuery(ListSessionSectionsInput{
+		WorkspaceID:     workspaceID,
+		SectionKeys:     sectionKeys,
+		AgentTargetID:   strings.TrimSpace(input.AgentTargetID),
+		LimitPerSection: input.LimitPerSection,
+	})
+	if err != nil {
+		return SessionSectionsPage{}, false, err
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return SessionSectionsPage{}, false, fmt.Errorf("list workspace agent session sections: %w", err)
+	}
+	defer rows.Close()
+
+	type sectionAccumulator struct {
+		page      SessionSectionPage
+		sortTimes []int64
+	}
+	accumulators := make(map[string]*sectionAccumulator, len(sectionKeys))
+	for _, sectionKey := range sectionKeys {
+		accumulators[sectionKey] = &sectionAccumulator{page: SessionSectionPage{
+			WorkspaceID: workspaceID,
+			SectionKey:  sectionKey,
+			Sessions:    []Session{},
+		}}
+	}
+	for rows.Next() {
+		var sectionKey string
+		var sortTimeUnixMS int64
+		var totalCount int
+		session, err := scanAgentSessionWithTrailingValues(
+			rows,
+			&sectionKey,
+			&sortTimeUnixMS,
+			&totalCount,
+		)
+		if err != nil {
+			return SessionSectionsPage{}, false, err
+		}
+		sectionKey = strings.TrimSpace(sectionKey)
+		accumulator := accumulators[sectionKey]
+		if accumulator == nil {
+			return SessionSectionsPage{}, false, fmt.Errorf("list workspace agent session sections: unexpected section %q", sectionKey)
+		}
+		accumulator.page.Sessions = append(accumulator.page.Sessions, session)
+		accumulator.page.TotalCount = totalCount
+		accumulator.sortTimes = append(accumulator.sortTimes, sortTimeUnixMS)
+	}
+	if err := rows.Err(); err != nil {
+		return SessionSectionsPage{}, false, fmt.Errorf("iterate workspace agent session sections: %w", err)
+	}
+
+	sections := make([]SessionSectionPage, 0, len(sectionKeys))
+	for _, sectionKey := range sectionKeys {
+		accumulator := accumulators[sectionKey]
+		accumulator.page.HasMore = accumulator.page.TotalCount > len(accumulator.page.Sessions)
+		if accumulator.page.HasMore && len(accumulator.page.Sessions) > 0 {
+			lastIndex := len(accumulator.page.Sessions) - 1
+			accumulator.page.NextCursor = strconv.FormatInt(accumulator.sortTimes[lastIndex], 10) + "|" + strings.TrimSpace(accumulator.page.Sessions[lastIndex].ID)
+		}
+		sections = append(sections, accumulator.page)
+	}
+	return SessionSectionsPage{
+		WorkspaceID: workspaceID,
+		Sections:    sections,
+	}, true, nil
+}
+
+func buildListSessionSectionsQuery(input ListSessionSectionsInput) (string, []any, error) {
+	sectionKeysJSON, err := json.Marshal(input.SectionKeys)
+	if err != nil {
+		return "", nil, fmt.Errorf("encode workspace agent session section keys: %w", err)
+	}
+	pinnedIndex := "idx_workspace_agent_sessions_pinned_page"
+	ordinaryIndex := "idx_workspace_agent_sessions_rail_section_page"
+	targetPredicate := ""
+	if input.AgentTargetID != "" {
+		pinnedIndex = "idx_workspace_agent_sessions_pinned_target_page"
+		ordinaryIndex = "idx_workspace_agent_sessions_rail_section_target_page"
+		targetPredicate = "AND sessions.agent_target_id = ?"
+	}
+	query := `
+WITH requested_sections(section_key) AS MATERIALIZED (
+  SELECT TRIM(CAST(value AS TEXT))
+  FROM json_each(?)
+), section_pages AS MATERIALIZED (
+  SELECT requested_sections.section_key AS requested_section_key,
+         CASE requested_sections.section_key
+           WHEN 'pinned' THEN (
+             SELECT COUNT(1)
+             FROM workspace_agent_sessions AS sessions INDEXED BY {{PINNED_INDEX}}
+             WHERE sessions.workspace_id = ?
+               AND sessions.session_kind = 'root'
+               AND sessions.pinned_at_unix_ms > 0
+               {{TARGET_PREDICATE}}
+               AND sessions.deleted_at_unix_ms = 0
+               AND json_extract(sessions.session_metadata_json, '$.visible') IS NOT 0
+           )
+           ELSE (
+             SELECT COUNT(1)
+             FROM workspace_agent_sessions AS sessions INDEXED BY {{ORDINARY_INDEX}}
+             WHERE sessions.workspace_id = ?
+               AND sessions.session_kind = 'root'
+               AND sessions.rail_section_key = requested_sections.section_key
+               AND sessions.pinned_at_unix_ms = 0
+               {{TARGET_PREDICATE}}
+               AND sessions.deleted_at_unix_ms = 0
+               AND json_extract(sessions.session_metadata_json, '$.visible') IS NOT 0
+           )
+         END AS total_count,
+         CASE requested_sections.section_key
+           WHEN 'pinned' THEN (
+             SELECT json_group_array(json_array(
+               pinned_page.agent_session_id,
+               pinned_page.conversation_sort_time_unix_ms
+             ))
+             FROM (
+               SELECT sessions.agent_session_id,
+                      sessions.pinned_at_unix_ms AS conversation_sort_time_unix_ms
+               FROM workspace_agent_sessions AS sessions INDEXED BY {{PINNED_INDEX}}
+               WHERE sessions.workspace_id = ?
+                 AND sessions.session_kind = 'root'
+                 AND sessions.pinned_at_unix_ms > 0
+                 {{TARGET_PREDICATE}}
+                 AND sessions.deleted_at_unix_ms = 0
+                 AND json_extract(sessions.session_metadata_json, '$.visible') IS NOT 0
+               ORDER BY sessions.pinned_at_unix_ms DESC, sessions.agent_session_id ASC
+               LIMIT ?
+             ) AS pinned_page
+           )
+           ELSE (
+             SELECT json_group_array(json_array(
+               ordinary_page.agent_session_id,
+               ordinary_page.conversation_sort_time_unix_ms
+             ))
+             FROM (
+               SELECT sessions.agent_session_id,
+                      COALESCE(
+                        NULLIF((
+                          SELECT latest.started_at_unix_ms
+                          FROM workspace_agent_turns AS latest INDEXED BY idx_workspace_agent_turns_session_latest
+                          WHERE latest.workspace_id = sessions.workspace_id
+                            AND latest.agent_session_id = sessions.agent_session_id
+                          ORDER BY latest.updated_at_unix_ms DESC, latest.created_at_unix_ms DESC,
+                                   latest.started_at_unix_ms DESC, latest.turn_id DESC
+                          LIMIT 1
+                        ), 0),
+                        sessions.created_at_unix_ms
+                      ) AS conversation_sort_time_unix_ms
+               FROM workspace_agent_sessions AS sessions INDEXED BY {{ORDINARY_INDEX}}
+               WHERE sessions.workspace_id = ?
+                 AND sessions.session_kind = 'root'
+                 AND sessions.rail_section_key = requested_sections.section_key
+                 AND sessions.pinned_at_unix_ms = 0
+                 {{TARGET_PREDICATE}}
+                 AND sessions.deleted_at_unix_ms = 0
+                 AND json_extract(sessions.session_metadata_json, '$.visible') IS NOT 0
+               ORDER BY conversation_sort_time_unix_ms DESC, sessions.agent_session_id ASC
+               LIMIT ?
+             ) AS ordinary_page
+           )
+         END AS page_ids_json
+  FROM requested_sections
+), page_session_ids AS MATERIALIZED (
+  SELECT section_pages.requested_section_key,
+         CAST(json_extract(page_ids.value, '$[0]') AS TEXT) AS agent_session_id,
+         CAST(json_extract(page_ids.value, '$[1]') AS INTEGER) AS conversation_sort_time_unix_ms,
+         section_pages.total_count
+  FROM section_pages
+  CROSS JOIN json_each(section_pages.page_ids_json) AS page_ids
+)
+SELECT sessions.workspace_id, sessions.agent_session_id, sessions.session_kind,
+       sessions.root_agent_session_id, sessions.root_turn_id,
+       sessions.parent_agent_session_id, sessions.parent_turn_id, sessions.parent_tool_call_id,
+       sessions.origin,
+       sessions.agent_target_id, sessions.provider, sessions.provider_session_id, sessions.model,
+       sessions.user_id, sessions.settings_json, sessions.session_metadata_json,
+       sessions.internal_runtime_context_json, sessions.cwd,
+       sessions.title, sessions.message_version, sessions.last_event_at_unix_ms,
+       sessions.started_at_unix_ms, sessions.ended_at_unix_ms, sessions.pinned_at_unix_ms,
+       sessions.created_at_unix_ms, sessions.updated_at_unix_ms, sessions.active_turn_id,
+       page_session_ids.requested_section_key,
+       page_session_ids.conversation_sort_time_unix_ms,
+       page_session_ids.total_count
+FROM page_session_ids
+CROSS JOIN workspace_agent_sessions AS sessions
+WHERE sessions.workspace_id = ?
+  AND sessions.agent_session_id = page_session_ids.agent_session_id
+ORDER BY page_session_ids.requested_section_key ASC,
+         page_session_ids.conversation_sort_time_unix_ms DESC,
+         page_session_ids.agent_session_id ASC
+`
+	query = strings.ReplaceAll(query, "{{PINNED_INDEX}}", pinnedIndex)
+	query = strings.ReplaceAll(query, "{{ORDINARY_INDEX}}", ordinaryIndex)
+	query = strings.ReplaceAll(query, "{{TARGET_PREDICATE}}", targetPredicate)
+	args := []any{string(sectionKeysJSON), input.WorkspaceID}
+	if input.AgentTargetID != "" {
+		args = append(args, input.AgentTargetID)
+	}
+	args = append(args, input.WorkspaceID)
+	if input.AgentTargetID != "" {
+		args = append(args, input.AgentTargetID)
+	}
+	args = append(args, input.WorkspaceID)
+	if input.AgentTargetID != "" {
+		args = append(args, input.AgentTargetID)
+	}
+	args = append(args, input.LimitPerSection, input.WorkspaceID)
+	if input.AgentTargetID != "" {
+		args = append(args, input.AgentTargetID)
+	}
+	args = append(args, input.LimitPerSection, input.WorkspaceID)
+	return query, args, nil
+}
+
+func normalizeSessionSectionKeys(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		sectionKey := strings.TrimSpace(value)
+		if sectionKey == "" {
+			continue
+		}
+		if _, exists := seen[sectionKey]; exists {
+			continue
+		}
+		seen[sectionKey] = struct{}{}
+		result = append(result, sectionKey)
+	}
+	return result
+}
+
 func (s *Store) ListSessionSectionDeletionCandidates(
 	ctx context.Context,
 	input ListSessionSectionDeletionCandidatesInput,
@@ -152,7 +405,7 @@ func (s *Store) ListSessionSectionDeletionCandidates(
 	}
 	rows, err := s.db.QueryContext(ctx, `
 SELECT agent_session_id
-FROM workspace_agent_sessions
+FROM workspace_agent_sessions INDEXED BY idx_workspace_agent_sessions_rail_section_page
 WHERE workspace_id = ?
   AND session_kind = 'root'
   AND rail_section_key = ?
@@ -198,6 +451,14 @@ func (s *Store) listPinnedSessionPage(
 	queryLimit int,
 	totalCount int,
 ) (SessionSectionPage, bool, error) {
+	indexName := "idx_workspace_agent_sessions_pinned_page"
+	targetPredicate := ""
+	args := []any{workspaceID}
+	if agentTargetID != "" {
+		indexName = "idx_workspace_agent_sessions_pinned_target_page"
+		targetPredicate = "AND agent_target_id = ?"
+		args = append(args, agentTargetID)
+	}
 	query := `
 SELECT workspace_id, agent_session_id, session_kind, root_agent_session_id, root_turn_id,
        parent_agent_session_id, parent_turn_id, parent_tool_call_id,
@@ -206,24 +467,21 @@ SELECT workspace_id, agent_session_id, session_kind, root_agent_session_id, root
 	       title, message_version, last_event_at_unix_ms,
        started_at_unix_ms, ended_at_unix_ms, pinned_at_unix_ms,
        created_at_unix_ms, updated_at_unix_ms, active_turn_id
-FROM workspace_agent_sessions
+FROM workspace_agent_sessions INDEXED BY ` + indexName + `
 WHERE workspace_id = ?
   AND session_kind = 'root'
   AND pinned_at_unix_ms > 0
-  AND (? = '' OR agent_target_id = ?)
+  ` + targetPredicate + `
   AND deleted_at_unix_ms = 0
   AND json_extract(session_metadata_json, '$.visible') IS NOT 0
   AND (? = '' OR pinned_at_unix_ms < ? OR (pinned_at_unix_ms = ? AND agent_session_id > ?))
 ORDER BY pinned_at_unix_ms DESC, agent_session_id ASC`
-	args := []any{
-		workspaceID,
-		agentTargetID,
-		agentTargetID,
+	args = append(args,
 		strings.TrimSpace(input.CursorSessionID),
 		input.CursorSortTimeUnixMS,
 		input.CursorSortTimeUnixMS,
 		strings.TrimSpace(input.CursorSessionID),
-	}
+	)
 	if queryLimit > 0 {
 		query += "\nLIMIT ?"
 		args = append(args, queryLimit)
@@ -274,25 +532,38 @@ func (s *Store) countVisibleSessionSectionRows(
 	excludePinned bool,
 ) (int, error) {
 	sectionPredicate := "rail_section_key = ?"
+	indexName := "idx_workspace_agent_sessions_rail_section_page"
 	if sectionKey == PinnedSessionPageKey {
 		sectionPredicate = "pinned_at_unix_ms > 0"
+		indexName = "idx_workspace_agent_sessions_pinned_page"
 	} else if excludePinned {
 		sectionPredicate += " AND pinned_at_unix_ms = 0"
 	}
+	targetPredicate := ""
+	if agentTargetID != "" {
+		targetPredicate = "AND agent_target_id = ?"
+		if sectionKey == PinnedSessionPageKey {
+			indexName = "idx_workspace_agent_sessions_pinned_target_page"
+		} else {
+			indexName = "idx_workspace_agent_sessions_rail_section_target_page"
+		}
+	}
 	query := `
 SELECT COUNT(1)
-FROM workspace_agent_sessions
+FROM workspace_agent_sessions INDEXED BY ` + indexName + `
 WHERE workspace_id = ?
   AND session_kind = 'root'
   AND ` + sectionPredicate + `
-  AND (? = '' OR agent_target_id = ?)
+  ` + targetPredicate + `
   AND deleted_at_unix_ms = 0
   AND json_extract(session_metadata_json, '$.visible') IS NOT 0`
 	args := []any{workspaceID}
 	if sectionKey != PinnedSessionPageKey {
 		args = append(args, sectionKey)
 	}
-	args = append(args, agentTargetID, agentTargetID)
+	if agentTargetID != "" {
+		args = append(args, agentTargetID)
+	}
 	var count int
 	if err := s.db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
 		return 0, fmt.Errorf("count workspace agent session section rows: %w", err)

--- a/packages/agent/store-sqlite/activity_sections_batch_test.go
+++ b/packages/agent/store-sqlite/activity_sections_batch_test.go
@@ -1,0 +1,297 @@
+package storesqlite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestStoreListSessionSectionsBatchesFilteredFirstPages(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t, testOptions(&staticProjectPaths{paths: []string{
+		"/workspace/app",
+		"/workspace/empty",
+	}}))
+	ctx := context.Background()
+	for _, report := range []ActivityStateReport{
+		sectionBatchActivityReport("ws-sections-batch", "project-newer", testTargetIDCodex, "/workspace/app", 3_000),
+		sectionBatchActivityReport("ws-sections-batch", "project-older", testTargetIDCodex, "/workspace/app", 2_000),
+		sectionBatchActivityReport("ws-sections-batch", "project-other-target", testTargetIDClaude, "/workspace/app", 4_000),
+		sectionBatchActivityReport("ws-sections-batch", "pinned-project", testTargetIDCodex, "/workspace/app", 5_000),
+		sectionBatchActivityReport("ws-sections-batch", "chat", testTargetIDCodex, "/workspace/scratch", 1_000),
+	} {
+		if _, err := store.ReportActivityState(ctx, report); err != nil {
+			t.Fatalf("ReportActivityState(%s) error = %v", report.Session.AgentSessionID, err)
+		}
+	}
+	if _, ok, err := store.UpdateSessionPinned(ctx, "ws-sections-batch", "pinned-project", true); err != nil || !ok {
+		t.Fatalf("UpdateSessionPinned() ok=%v error=%v", ok, err)
+	}
+
+	projectKey := RailSectionKeyForProject("/workspace/app")
+	emptyProjectKey := RailSectionKeyForProject("/workspace/empty")
+	result, ok, err := store.ListSessionSections(ctx, ListSessionSectionsInput{
+		WorkspaceID: "ws-sections-batch",
+		SectionKeys: []string{
+			PinnedSessionPageKey,
+			projectKey,
+			emptyProjectKey,
+			RailSectionKeyConversations,
+		},
+		AgentTargetID:   testTargetIDCodex,
+		LimitPerSection: 1,
+	})
+	if err != nil || !ok {
+		t.Fatalf("ListSessionSections() ok=%v error=%v", ok, err)
+	}
+	if len(result.Sections) != 4 {
+		t.Fatalf("sections = %d, want 4", len(result.Sections))
+	}
+	pages := make(map[string]SessionSectionPage, len(result.Sections))
+	for _, page := range result.Sections {
+		pages[page.SectionKey] = page
+	}
+	assertSectionBatchPage(t, pages[PinnedSessionPageKey], []string{"pinned-project"}, 1, false)
+	assertSectionBatchPage(t, pages[projectKey], []string{"project-newer"}, 2, true)
+	if pages[projectKey].NextCursor != "3000|project-newer" {
+		t.Fatalf("project cursor = %q, want latest-turn cursor", pages[projectKey].NextCursor)
+	}
+	assertSectionBatchPage(t, pages[emptyProjectKey], nil, 0, false)
+	assertSectionBatchPage(t, pages[RailSectionKeyConversations], []string{"chat"}, 1, false)
+}
+
+func TestStoreListSessionSectionsUsesRequestedSectionIndexes(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	sectionKeys := []string{
+		PinnedSessionPageKey,
+		RailSectionKeyForProject("/workspace/app"),
+		RailSectionKeyForProject("/workspace/other"),
+		RailSectionKeyConversations,
+	}
+	query, args, err := buildListSessionSectionsQuery(ListSessionSectionsInput{
+		WorkspaceID:     "ws-section-plan",
+		SectionKeys:     sectionKeys,
+		AgentTargetID:   testTargetIDCodex,
+		LimitPerSection: 5,
+	})
+	if err != nil {
+		t.Fatalf("buildListSessionSectionsQuery() error = %v", err)
+	}
+	if strings.Contains(query, "SELECT sessions.*") {
+		t.Fatal("batch query must rank narrow session ids before loading full session rows")
+	}
+	if strings.Contains(query, "UNION ALL") {
+		t.Fatal("batch query must not grow compound SELECT arms with section count")
+	}
+	if got := strings.Count(query, "SELECT latest.started_at_unix_ms"); got != 1 {
+		t.Fatalf("latest-turn expressions = %d, want one ordinary-section expression", got)
+	}
+
+	rows, err := store.db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+query, args...)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	defer rows.Close()
+	planDetails := make([]string, 0)
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatalf("scan query plan error = %v", err)
+		}
+		planDetails = append(planDetails, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate query plan error = %v", err)
+	}
+	plan := strings.Join(planDetails, "\n")
+	if !strings.Contains(plan, "idx_workspace_agent_sessions_pinned_target_page") {
+		t.Fatalf("query plan does not use target-scoped pinned index:\n%s", plan)
+	}
+	if got := strings.Count(plan, "idx_workspace_agent_sessions_rail_section_target_page"); got != 2 {
+		t.Fatalf("target-scoped rail-section index uses = %d, want indexed count and page reads:\n%s", got, plan)
+	}
+	if got := strings.Count(plan, "idx_workspace_agent_sessions_pinned_target_page"); got != 2 {
+		t.Fatalf("target-scoped pinned index uses = %d, want indexed count and page reads:\n%s", got, plan)
+	}
+	if got := strings.Count(plan, "idx_workspace_agent_turns_session_latest"); got < 1 || got > 2 {
+		t.Fatalf("latest-turn index uses = %d, want one page sort expression:\n%s", got, plan)
+	}
+	if strings.Contains(plan, "SCAN sessions") {
+		t.Fatalf("query plan scans workspace sessions instead of requested indexes:\n%s", plan)
+	}
+	if !strings.Contains(plan, "sqlite_autoindex_workspace_agent_sessions_1") {
+		t.Fatalf("query plan does not load page rows by session primary key:\n%s", plan)
+	}
+}
+
+func TestStoreListSessionSectionsDoesNotDependOnCompoundSelectLimit(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	sectionKeys := []string{PinnedSessionPageKey}
+	for index := range 600 {
+		sectionKeys = append(sectionKeys, RailSectionKeyForProject(fmt.Sprintf("/workspace/project-%03d", index)))
+	}
+	sectionKeys = append(sectionKeys, RailSectionKeyConversations)
+	page, ok, err := store.ListSessionSections(context.Background(), ListSessionSectionsInput{
+		WorkspaceID:     "ws-many-sections",
+		SectionKeys:     sectionKeys,
+		LimitPerSection: 5,
+	})
+	if err != nil || !ok {
+		t.Fatalf("ListSessionSections(%d sections) ok=%v error=%v", len(sectionKeys), ok, err)
+	}
+	if len(page.Sections) != len(sectionKeys) {
+		t.Fatalf("sections = %d, want %d", len(page.Sections), len(sectionKeys))
+	}
+	for _, section := range page.Sections {
+		if len(section.Sessions) != 0 || section.TotalCount != 0 || section.HasMore || section.NextCursor != "" {
+			t.Fatalf("empty section %q = %#v", section.SectionKey, section)
+		}
+	}
+}
+
+func TestStoreListSessionSectionsPropagatesCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, ok, err := store.ListSessionSections(ctx, ListSessionSectionsInput{
+		WorkspaceID:     "ws-sections-canceled",
+		SectionKeys:     []string{PinnedSessionPageKey, RailSectionKeyConversations},
+		LimitPerSection: 5,
+	})
+	if ok || !errors.Is(err, context.Canceled) {
+		t.Fatalf("ListSessionSections() ok=%v error=%v, want context.Canceled", ok, err)
+	}
+}
+
+func TestStoreMigrationRestoresPinnedPageIndexAfterSessionTableRebuild(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	if _, err := store.db.ExecContext(ctx, `
+DROP INDEX idx_workspace_agent_sessions_pinned_page;
+DELETE FROM agent_store_schema_migrations WHERE id = ?;
+`, schemaMigrationWorkspaceAgentActivityV9); err != nil {
+		t.Fatalf("prepare missing pinned index error = %v", err)
+	}
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+	var count int
+	if err := store.db.QueryRowContext(ctx, `
+SELECT COUNT(1)
+FROM sqlite_master
+WHERE type = 'index' AND name = 'idx_workspace_agent_sessions_pinned_page'
+`).Scan(&count); err != nil {
+		t.Fatalf("inspect pinned index error = %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("pinned page index count = %d, want 1", count)
+	}
+}
+
+func TestStoreMigrationAddsTargetScopedRailIndexes(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	if _, err := store.db.ExecContext(ctx, `
+DROP INDEX idx_workspace_agent_sessions_rail_section_target_page;
+DROP INDEX idx_workspace_agent_sessions_pinned_target_page;
+DELETE FROM agent_store_schema_migrations WHERE id = ?;
+`, schemaMigrationWorkspaceAgentActivityV10); err != nil {
+		t.Fatalf("prepare missing target-scoped indexes error = %v", err)
+	}
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+	var count int
+	if err := store.db.QueryRowContext(ctx, `
+SELECT COUNT(1)
+FROM sqlite_master
+WHERE type = 'index' AND name IN (
+  'idx_workspace_agent_sessions_rail_section_target_page',
+  'idx_workspace_agent_sessions_pinned_target_page'
+)
+`).Scan(&count); err != nil {
+		t.Fatalf("inspect target-scoped indexes error = %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("target-scoped rail index count = %d, want 2", count)
+	}
+}
+
+func sectionBatchActivityReport(
+	workspaceID string,
+	sessionID string,
+	agentTargetID string,
+	cwd string,
+	turnStartedAtUnixMS int64,
+) ActivityStateReport {
+	provider := "codex"
+	if agentTargetID == testTargetIDClaude {
+		provider = "claude-code"
+	}
+	return ActivityStateReport{
+		Session: SessionStateReport{
+			WorkspaceID:      workspaceID,
+			AgentSessionID:   sessionID,
+			Origin:           "runtime",
+			AgentTargetID:    agentTargetID,
+			Provider:         provider,
+			Cwd:              cwd,
+			Status:           "working",
+			OccurredAtUnixMS: turnStartedAtUnixMS,
+		},
+		Turn: &TurnTransition{
+			WorkspaceID:      workspaceID,
+			AgentSessionID:   sessionID,
+			TurnID:           "turn-" + sessionID,
+			Phase:            TurnPhaseRunning,
+			StartedAtUnixMS:  turnStartedAtUnixMS,
+			OccurredAtUnixMS: turnStartedAtUnixMS,
+		},
+	}
+}
+
+func assertSectionBatchPage(
+	t *testing.T,
+	page SessionSectionPage,
+	wantSessionIDs []string,
+	wantTotal int,
+	wantHasMore bool,
+) {
+	t.Helper()
+	gotSessionIDs := make([]string, 0, len(page.Sessions))
+	for _, session := range page.Sessions {
+		gotSessionIDs = append(gotSessionIDs, session.ID)
+	}
+	if len(gotSessionIDs) != len(wantSessionIDs) {
+		t.Fatalf("section %q session ids = %#v, want %#v", page.SectionKey, gotSessionIDs, wantSessionIDs)
+	}
+	for i := range wantSessionIDs {
+		if gotSessionIDs[i] != wantSessionIDs[i] {
+			t.Fatalf("section %q session ids = %#v, want %#v", page.SectionKey, gotSessionIDs, wantSessionIDs)
+		}
+	}
+	if page.TotalCount != wantTotal || page.HasMore != wantHasMore {
+		t.Fatalf(
+			"section %q total=%d hasMore=%v, want total=%d hasMore=%v",
+			page.SectionKey,
+			page.TotalCount,
+			page.HasMore,
+			wantTotal,
+			wantHasMore,
+		)
+	}
+}

--- a/packages/agent/store-sqlite/activity_sections_benchmark_test.go
+++ b/packages/agent/store-sqlite/activity_sections_benchmark_test.go
@@ -1,0 +1,279 @@
+package storesqlite
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// BenchmarkStoreListSessionSectionsLargeRemovedProjectHistory measures the
+// same 100k-session/200k-turn workspace at several requested-section hit
+// densities. It guards both sparse rails dominated by removed projects and
+// dense current sections with substantial retained history.
+func BenchmarkStoreListSessionSectionsLargeRemovedProjectHistory(b *testing.B) {
+	store := openTestStore(b, testOptions(&staticProjectPaths{}))
+	requestedSections := []string{PinnedSessionPageKey}
+	for index := range 5 {
+		requestedSections = append(requestedSections, RailSectionKeyForProject(fmt.Sprintf("/workspace/current/%d", index)))
+	}
+	requestedSections = append(requestedSections, RailSectionKeyConversations)
+	seedLargeRemovedProjectHistory(b, store)
+
+	for _, fixture := range []struct {
+		name         string
+		matchedCount int
+	}{
+		{name: "density_0_1_percent", matchedCount: 100},
+		{name: "density_10_percent", matchedCount: 10_000},
+		{name: "density_50_percent", matchedCount: 50_000},
+		{name: "density_100_percent", matchedCount: 100_000},
+	} {
+		configureRequestedSectionDensity(b, store, requestedSections, fixture.matchedCount)
+		input := ListSessionSectionsInput{
+			WorkspaceID:     "ws-large-history",
+			SectionKeys:     requestedSections,
+			AgentTargetID:   testTargetIDCodex,
+			LimitPerSection: 5,
+		}
+		assertBatchMatchesSerialPages(b, store, input)
+
+		b.Run(fixture.name, func(b *testing.B) {
+			b.Run("batched_requested_sections", func(b *testing.B) {
+				b.ReportAllocs()
+				for range b.N {
+					if _, ok, err := store.ListSessionSections(context.Background(), input); err != nil || !ok {
+						b.Fatalf("ListSessionSections() ok=%v error=%v", ok, err)
+					}
+				}
+			})
+			b.Run("serial_reference", func(b *testing.B) {
+				b.ReportAllocs()
+				for range b.N {
+					for _, sectionKey := range requestedSections {
+						if _, ok, err := store.ListSessionSection(context.Background(), ListSessionSectionInput{
+							WorkspaceID:   input.WorkspaceID,
+							SectionKey:    sectionKey,
+							AgentTargetID: input.AgentTargetID,
+							Limit:         input.LimitPerSection,
+						}); err != nil || !ok {
+							b.Fatalf("ListSessionSection(%q) ok=%v error=%v", sectionKey, ok, err)
+						}
+					}
+				}
+			})
+		})
+	}
+
+	configureRequestedSectionDensity(b, store, requestedSections, 100_000)
+	configureTargetDensity(b, store, 10)
+	targetInput := ListSessionSectionsInput{
+		WorkspaceID:     "ws-large-history",
+		SectionKeys:     requestedSections,
+		AgentTargetID:   testTargetIDCodex,
+		LimitPerSection: 5,
+	}
+	assertBatchMatchesSerialPages(b, store, targetInput)
+	b.Run("target_density_10_percent", func(b *testing.B) {
+		b.Run("batched_requested_sections", func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				if _, ok, err := store.ListSessionSections(context.Background(), targetInput); err != nil || !ok {
+					b.Fatalf("ListSessionSections() ok=%v error=%v", ok, err)
+				}
+			}
+		})
+		b.Run("serial_reference", func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				for _, sectionKey := range requestedSections {
+					if _, ok, err := store.ListSessionSection(context.Background(), ListSessionSectionInput{
+						WorkspaceID:   targetInput.WorkspaceID,
+						SectionKey:    sectionKey,
+						AgentTargetID: targetInput.AgentTargetID,
+						Limit:         targetInput.LimitPerSection,
+					}); err != nil || !ok {
+						b.Fatalf("ListSessionSection(%q) ok=%v error=%v", sectionKey, ok, err)
+					}
+				}
+			}
+		})
+	})
+}
+
+func assertBatchMatchesSerialPages(b *testing.B, store *Store, input ListSessionSectionsInput) {
+	b.Helper()
+	batchPage, ok, err := store.ListSessionSections(context.Background(), input)
+	if err != nil || !ok {
+		b.Fatalf("ListSessionSections() ok=%v error=%v", ok, err)
+	}
+	batchPages := make(map[string]SessionSectionPage, len(batchPage.Sections))
+	for _, page := range batchPage.Sections {
+		batchPages[page.SectionKey] = page
+	}
+	for _, sectionKey := range input.SectionKeys {
+		serialPage, ok, err := store.ListSessionSection(context.Background(), ListSessionSectionInput{
+			WorkspaceID:   input.WorkspaceID,
+			SectionKey:    sectionKey,
+			AgentTargetID: input.AgentTargetID,
+			Limit:         input.LimitPerSection,
+		})
+		if err != nil || !ok {
+			b.Fatalf("ListSessionSection(%q) ok=%v error=%v", sectionKey, ok, err)
+		}
+		batchPage := batchPages[sectionKey]
+		if len(batchPage.Sessions) != len(serialPage.Sessions) ||
+			batchPage.TotalCount != serialPage.TotalCount ||
+			batchPage.HasMore != serialPage.HasMore ||
+			batchPage.NextCursor != serialPage.NextCursor {
+			b.Fatalf("batch page %q = %#v, serial = %#v", sectionKey, batchPage, serialPage)
+		}
+		for index := range batchPage.Sessions {
+			if batchPage.Sessions[index].ID != serialPage.Sessions[index].ID {
+				b.Fatalf("batch page %q session %d = %q, serial = %q", sectionKey, index, batchPage.Sessions[index].ID, serialPage.Sessions[index].ID)
+			}
+		}
+	}
+}
+
+func seedLargeRemovedProjectHistory(b *testing.B, store *Store) {
+	b.Helper()
+	const sessionCount = 100_000
+	tx, err := store.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		b.Fatalf("BeginTx() error = %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	sessionStatement, err := tx.Prepare(`
+INSERT INTO workspace_agent_sessions (
+  workspace_id, agent_session_id, agent_target_id, provider,
+  session_metadata_json, internal_runtime_context_json, cwd,
+  rail_section_kind, rail_project_path, rail_section_key,
+  pinned_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
+) VALUES (?, ?, ?, 'codex', '{"visible":true,"imported":false,"capabilities":[]}', '{}', ?, ?, ?, ?, ?, ?, ?)
+`)
+	if err != nil {
+		b.Fatalf("prepare session insert error = %v", err)
+	}
+	defer sessionStatement.Close()
+	turnStatement, err := tx.Prepare(`
+INSERT INTO workspace_agent_turns (
+  workspace_id, agent_session_id, turn_id, phase, outcome,
+  started_at_unix_ms, settled_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
+) VALUES (?, ?, ?, 'settled', 'completed', ?, ?, ?, ?)
+`)
+	if err != nil {
+		b.Fatalf("prepare turn insert error = %v", err)
+	}
+	defer turnStatement.Close()
+
+	for index := range sessionCount {
+		sessionID := fmt.Sprintf("session-%06d", index)
+		sectionKey := fmt.Sprintf("project:/workspace/removed/%05d", index%10_000)
+		projectPath := fmt.Sprintf("/workspace/removed/%05d", index%10_000)
+		createdAt := int64(index + 1)
+		if _, err := sessionStatement.Exec(
+			"ws-large-history",
+			sessionID,
+			testTargetIDCodex,
+			projectPath,
+			"project",
+			projectPath,
+			sectionKey,
+			0,
+			createdAt,
+			createdAt,
+		); err != nil {
+			b.Fatalf("insert session %d error = %v", index, err)
+		}
+		for turnIndex := range 2 {
+			turnTime := createdAt*10 + int64(turnIndex)
+			if _, err := turnStatement.Exec(
+				"ws-large-history",
+				sessionID,
+				fmt.Sprintf("turn-%d", turnIndex),
+				turnTime,
+				turnTime,
+				turnTime,
+				turnTime,
+			); err != nil {
+				b.Fatalf("insert turn %d/%d error = %v", index, turnIndex, err)
+			}
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		b.Fatalf("Commit() error = %v", err)
+	}
+}
+
+func configureRequestedSectionDensity(
+	b *testing.B,
+	store *Store,
+	requestedSections []string,
+	matchedCount int,
+) {
+	b.Helper()
+	if len(requestedSections) != 7 {
+		b.Fatalf("requested sections = %d, want pinned + five projects + Chats", len(requestedSections))
+	}
+	tx, err := store.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		b.Fatalf("BeginTx() error = %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.Exec(`
+UPDATE workspace_agent_sessions
+SET rail_section_key = printf('project:/workspace/removed/%05d', (rowid - 1) % 10000),
+    pinned_at_unix_ms = 0
+WHERE workspace_id = 'ws-large-history'
+`); err != nil {
+		b.Fatalf("reset removed-project history error = %v", err)
+	}
+	if _, err := tx.Exec(`
+UPDATE workspace_agent_sessions
+SET rail_section_key = CASE ((rowid - 1) % 7)
+      WHEN 1 THEN ?
+      WHEN 2 THEN ?
+      WHEN 3 THEN ?
+      WHEN 4 THEN ?
+      WHEN 5 THEN ?
+      WHEN 6 THEN ?
+      ELSE rail_section_key
+    END,
+    pinned_at_unix_ms = CASE
+      WHEN ((rowid - 1) % 7) = 0 THEN 200000 + rowid
+      ELSE 0
+    END
+WHERE workspace_id = 'ws-large-history'
+  AND rowid <= ?
+`,
+		requestedSections[1],
+		requestedSections[2],
+		requestedSections[3],
+		requestedSections[4],
+		requestedSections[5],
+		requestedSections[6],
+		matchedCount,
+	); err != nil {
+		b.Fatalf("configure requested-section density error = %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		b.Fatalf("Commit() error = %v", err)
+	}
+}
+
+func configureTargetDensity(b *testing.B, store *Store, codexPercent int) {
+	b.Helper()
+	if codexPercent <= 0 || codexPercent >= 100 || 100%codexPercent != 0 {
+		b.Fatalf("codex target percent = %d, want a positive divisor of 100", codexPercent)
+	}
+	if _, err := store.db.Exec(`
+UPDATE workspace_agent_sessions
+SET agent_target_id = CASE
+  WHEN ((rowid - 1) % ?) = 0 THEN ?
+  ELSE ?
+END
+WHERE workspace_id = 'ws-large-history'
+`, 100/codexPercent, testTargetIDCodex, testTargetIDClaude); err != nil {
+		b.Fatalf("configure target density error = %v", err)
+	}
+}

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -28,6 +28,8 @@ const schemaMigrationWorkspaceAgentActivityV5 = "workspace_agent_activity_v5"
 const schemaMigrationWorkspaceAgentActivityV6 = "workspace_agent_activity_v6"
 const schemaMigrationWorkspaceAgentActivityV7 = "workspace_agent_activity_v7"
 const schemaMigrationWorkspaceAgentActivityV8 = "workspace_agent_activity_v8"
+const schemaMigrationWorkspaceAgentActivityV9 = "workspace_agent_activity_v9"
+const schemaMigrationWorkspaceAgentActivityV10 = "workspace_agent_activity_v10"
 const schemaMigrationWorkspaceAgentActivityRailV1 = "workspace_agent_activity_rail_v1"
 const schemaMigrationWorkspaceAgentActivityTurnsV1 = "workspace_agent_activity_turns_v1"
 const schemaMigrationWorkspaceAgentActivityInteractionsV2 = "workspace_agent_activity_interactions_v2"
@@ -138,6 +140,12 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 		return err
 	}
 	if err := s.applyWorkspaceAgentSessionEntitiesV3(ctx); err != nil {
+		return err
+	}
+	if err := s.applyWorkspaceAgentActivityV9(ctx); err != nil {
+		return err
+	}
+	if err := s.applyWorkspaceAgentActivityV10(ctx); err != nil {
 		return err
 	}
 	if err := s.applyWorkspaceAgentEntityInvariantsV1(ctx); err != nil {

--- a/packages/agent/store-sqlite/migrations_activity.go
+++ b/packages/agent/store-sqlite/migrations_activity.go
@@ -249,6 +249,52 @@ CREATE INDEX IF NOT EXISTS idx_workspace_agent_sessions_pinned_page
 	return s.recordMigration(ctx, schemaMigrationWorkspaceAgentActivityV8)
 }
 
+// applyWorkspaceAgentActivityV9 restores the pinned-page index after the v3
+// session-entity table rebuild. It runs after that rebuild for both fresh and
+// upgraded databases, including databases that already recorded activity v8.
+func (s *Store) applyWorkspaceAgentActivityV9(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV9)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return nil
+	}
+
+	if _, err := s.db.ExecContext(ctx, `
+CREATE INDEX IF NOT EXISTS idx_workspace_agent_sessions_pinned_page
+  ON workspace_agent_sessions(workspace_id, deleted_at_unix_ms, pinned_at_unix_ms DESC, agent_session_id ASC);
+`); err != nil {
+		return fmt.Errorf("migrate workspace agent activity to v9 pinned pagination index: %w", err)
+	}
+
+	return s.recordMigration(ctx, schemaMigrationWorkspaceAgentActivityV9)
+}
+
+// applyWorkspaceAgentActivityV10 adds target-scoped rail indexes. Provider
+// rail switches must narrow by target inside the index instead of scanning all
+// providers in each requested section and filtering rows afterwards.
+func (s *Store) applyWorkspaceAgentActivityV10(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV10)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return nil
+	}
+
+	if _, err := s.db.ExecContext(ctx, `
+CREATE INDEX IF NOT EXISTS idx_workspace_agent_sessions_rail_section_target_page
+  ON workspace_agent_sessions(workspace_id, rail_section_key, agent_target_id, deleted_at_unix_ms, pinned_at_unix_ms, agent_session_id);
+CREATE INDEX IF NOT EXISTS idx_workspace_agent_sessions_pinned_target_page
+  ON workspace_agent_sessions(workspace_id, agent_target_id, deleted_at_unix_ms, pinned_at_unix_ms DESC, agent_session_id ASC);
+`); err != nil {
+		return fmt.Errorf("migrate workspace agent activity to v10 target-scoped rail indexes: %w", err)
+	}
+
+	return s.recordMigration(ctx, schemaMigrationWorkspaceAgentActivityV10)
+}
+
 func (s *Store) backfillSystemAgentTargetIDs(ctx context.Context) error {
 	providers := make([]string, 0, len(s.opts.TargetIDBackfillByProvider))
 	for provider := range s.opts.TargetIDBackfillByProvider {

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -25,6 +25,7 @@ type Repository interface {
 	ListTurnsBySession(context.Context, string, map[string]string) (map[string]Turn, error)
 	ListPendingInteractionsBySession(context.Context, string, []string) (map[string][]Interaction, error)
 	ListSessionSection(context.Context, ListSessionSectionInput) (SessionSectionPage, bool, error)
+	ListSessionSections(context.Context, ListSessionSectionsInput) (SessionSectionsPage, bool, error)
 	ListSessionSectionDeletionCandidates(context.Context, ListSessionSectionDeletionCandidatesInput) (SessionSectionDeletionCandidates, bool, error)
 	ListSessionTurns(context.Context, string, string) ([]Turn, error)
 	ListSessions(context.Context, string) ([]Session, bool, error)
@@ -101,6 +102,16 @@ type ListSessionSectionInput struct {
 	Limit                int
 }
 
+// ListSessionSectionsInput describes the first-page bootstrap for every rail
+// section in one workspace query. SectionKeys includes the synthetic pinned
+// page key when the caller needs pinned conversations.
+type ListSessionSectionsInput struct {
+	WorkspaceID     string
+	SectionKeys     []string
+	AgentTargetID   string
+	LimitPerSection int
+}
+
 type ListSessionSectionDeletionCandidatesInput struct {
 	WorkspaceID   string
 	SectionKey    string
@@ -136,6 +147,11 @@ type SessionSectionPage struct {
 	HasMore     bool
 	TotalCount  int
 	NextCursor  string
+}
+
+type SessionSectionsPage struct {
+	WorkspaceID string
+	Sections    []SessionSectionPage
 }
 
 type Session struct {

--- a/services/tuttid/biz/agentactivity/activity.go
+++ b/services/tuttid/biz/agentactivity/activity.go
@@ -33,7 +33,11 @@ type GeneratedFileList = agentstore.GeneratedFileList
 
 type ListSessionSectionInput = agentstore.ListSessionSectionInput
 
+type ListSessionSectionsInput = agentstore.ListSessionSectionsInput
+
 type SessionSectionPage = agentstore.SessionSectionPage
+
+type SessionSectionsPage = agentstore.SessionSectionsPage
 
 type Session = agentstore.Session
 type SessionMetadata = agentstore.SessionMetadata

--- a/services/tuttid/data/workspace/agent_store.go
+++ b/services/tuttid/data/workspace/agent_store.go
@@ -12,6 +12,8 @@ import (
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 )
 
+var _ agentactivitybiz.Repository = (*SQLiteStore)(nil)
+
 // Agent activity and agent target persistence is delegated to the
 // embeddable packages/agent/store-sqlite module, sharing this store's
 // database handle. The delegation below keeps SQLiteStore satisfying the
@@ -117,6 +119,10 @@ func (s *SQLiteStore) ListSessions(ctx context.Context, workspaceID string) ([]a
 
 func (s *SQLiteStore) ListSessionSection(ctx context.Context, input agentactivitybiz.ListSessionSectionInput) (agentactivitybiz.SessionSectionPage, bool, error) {
 	return s.agentStore().ListSessionSection(ctx, input)
+}
+
+func (s *SQLiteStore) ListSessionSections(ctx context.Context, input agentactivitybiz.ListSessionSectionsInput) (agentactivitybiz.SessionSectionsPage, bool, error) {
+	return s.agentStore().ListSessionSections(ctx, input)
 }
 
 func (s *SQLiteStore) ListSessionSectionDeletionCandidates(ctx context.Context, input agentactivitybiz.ListSessionSectionDeletionCandidatesInput) (agentactivitybiz.SessionSectionDeletionCandidates, bool, error) {

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -22,6 +22,11 @@ type ActivityProjection struct {
 	rootTurnObserver       RootTurnObserver
 }
 
+var (
+	_ SessionReader         = (*ActivityProjection)(nil)
+	_ SessionSectionsReader = (*ActivityProjection)(nil)
+)
+
 func NewActivityProjection(repo agentactivitybiz.Repository) *ActivityProjection {
 	return &ActivityProjection{repo: repo}
 }
@@ -415,24 +420,21 @@ func (p *ActivityProjection) ListChildSessions(
 func (p *ActivityProjection) ListSessionSection(
 	ctx context.Context,
 	input agentactivitybiz.ListSessionSectionInput,
-) (agentactivitybiz.SessionSectionPage, bool) {
+) (agentactivitybiz.SessionSectionPage, bool, error) {
 	if p == nil || p.repo == nil {
-		return agentactivitybiz.SessionSectionPage{}, false
+		return agentactivitybiz.SessionSectionPage{}, false, nil
 	}
-	page, ok, err := p.repo.ListSessionSection(ctx, input)
-	if err != nil {
-		slog.Warn("list workspace agent session section failed",
-			"event", "workspace.agent_session.section.list_failed",
-			"workspace_id", input.WorkspaceID,
-			"section_key", input.SectionKey,
-			"error", err,
-		)
-		return agentactivitybiz.SessionSectionPage{}, false
+	return p.repo.ListSessionSection(ctx, input)
+}
+
+func (p *ActivityProjection) ListSessionSections(
+	ctx context.Context,
+	input agentactivitybiz.ListSessionSectionsInput,
+) (agentactivitybiz.SessionSectionsPage, bool, error) {
+	if p == nil || p.repo == nil {
+		return agentactivitybiz.SessionSectionsPage{}, false, nil
 	}
-	if !ok {
-		return agentactivitybiz.SessionSectionPage{}, false
-	}
-	return page, true
+	return p.repo.ListSessionSections(ctx, input)
 }
 
 func (p *ActivityProjection) DeleteSession(ctx context.Context, workspaceID string, agentSessionID string) (bool, error) {

--- a/services/tuttid/service/agent/service_session_sections.go
+++ b/services/tuttid/service/agent/service_session_sections.go
@@ -2,8 +2,11 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
+	"time"
 
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	userprojectbiz "github.com/tutti-os/tutti/services/tuttid/biz/userproject"
@@ -13,34 +16,62 @@ const (
 	sessionSectionKindConversations = "conversations"
 	sessionSectionKindProject       = "project"
 	sessionSectionKeyConversations  = "conversations"
+	sessionSectionsSlowLogThreshold = 250 * time.Millisecond
 )
+
+type sessionSectionsDiagnostics struct {
+	failureStage    string
+	hydrateDuration time.Duration
+	projectDuration time.Duration
+	sectionCount    int
+	sessionCount    int
+	storeDuration   time.Duration
+}
 
 func (s *Service) ListSessionSections(
 	ctx context.Context,
 	workspaceID string,
 	input ListSessionSectionsInput,
-) (SessionSectionsPage, error) {
+) (result SessionSectionsPage, resultErr error) {
 	workspaceID = strings.TrimSpace(workspaceID)
 	if workspaceID == "" || input.LimitPerSection <= 0 {
 		return SessionSectionsPage{}, ErrInvalidArgument
 	}
 	agentTargetID := strings.TrimSpace(input.AgentTargetID)
+	startedAt := time.Now()
+	diagnostics := &sessionSectionsDiagnostics{failureStage: "projects"}
+	defer func() {
+		logSessionSectionsDiagnostics(
+			ctx,
+			workspaceID,
+			agentTargetID,
+			input.LimitPerSection,
+			time.Since(startedAt),
+			diagnostics,
+			resultErr,
+		)
+	}()
+	projectsStartedAt := time.Now()
 	projects, err := s.currentUserProjects(ctx)
+	diagnostics.projectDuration = time.Since(projectsStartedAt)
 	if err != nil {
 		return SessionSectionsPage{}, err
 	}
+	diagnostics.failureStage = "reader"
 	reader, ok := s.SessionReader.(SessionSectionsReader)
 	if !ok {
 		return SessionSectionsPage{}, ErrInvalidArgument
 	}
-	return s.listSessionSectionsBatched(
+	result, resultErr = s.listSessionSectionsBatched(
 		ctx,
 		reader,
 		workspaceID,
 		projects,
 		input.LimitPerSection,
 		agentTargetID,
+		diagnostics,
 	)
+	return result, resultErr
 }
 
 func (s *Service) listSessionSectionsBatched(
@@ -50,6 +81,7 @@ func (s *Service) listSessionSectionsBatched(
 	projects []userprojectbiz.Project,
 	limitPerSection int,
 	agentTargetID string,
+	diagnostics *sessionSectionsDiagnostics,
 ) (SessionSectionsPage, error) {
 	normalizedProjects := make([]userprojectbiz.Project, 0, len(projects))
 	sectionKeys := make([]string, 0, len(projects)+2)
@@ -63,12 +95,15 @@ func (s *Service) listSessionSectionsBatched(
 		sectionKeys = append(sectionKeys, project.SectionKey)
 	}
 	sectionKeys = append(sectionKeys, sessionSectionKeyConversations)
+	diagnostics.failureStage = "store"
+	storeStartedAt := time.Now()
 	page, ok, err := reader.ListSessionSections(ctx, agentactivitybiz.ListSessionSectionsInput{
 		WorkspaceID:     workspaceID,
 		SectionKeys:     sectionKeys,
 		AgentTargetID:   strings.TrimSpace(agentTargetID),
 		LimitPerSection: limitPerSection,
 	})
+	diagnostics.storeDuration = time.Since(storeStartedAt)
 	if err != nil {
 		return SessionSectionsPage{}, err
 	}
@@ -85,10 +120,16 @@ func (s *Service) listSessionSectionsBatched(
 		rawPagesByKey[sectionKey] = section
 		rawSessions = append(rawSessions, section.Sessions...)
 	}
+	diagnostics.sectionCount = len(page.Sections)
+	diagnostics.sessionCount = len(rawSessions)
+	diagnostics.failureStage = "hydrate"
+	hydrateStartedAt := time.Now()
 	sessions, err := s.sessionsFromActivity(ctx, workspaceID, rawSessions)
+	diagnostics.hydrateDuration = time.Since(hydrateStartedAt)
 	if err != nil {
 		return SessionSectionsPage{}, err
 	}
+	diagnostics.failureStage = "projection"
 	sessionsByID := make(map[string]Session, len(sessions))
 	for _, session := range sessions {
 		sessionsByID[session.ID] = session
@@ -139,7 +180,7 @@ func (s *Service) listSessionSectionsBatched(
 		TotalCount: conversationsPage.TotalCount,
 		NextCursor: conversationsPage.NextCursor,
 	})
-	return SessionSectionsPage{
+	result := SessionSectionsPage{
 		WorkspaceID: workspaceID,
 		Pinned: SessionPage{
 			Sessions:   pinnedSessions,
@@ -148,7 +189,52 @@ func (s *Service) listSessionSectionsBatched(
 			NextCursor: pinnedPage.NextCursor,
 		},
 		Sections: sections,
-	}, nil
+	}
+	diagnostics.failureStage = ""
+	return result, nil
+}
+
+func logSessionSectionsDiagnostics(
+	ctx context.Context,
+	workspaceID string,
+	agentTargetID string,
+	limitPerSection int,
+	duration time.Duration,
+	diagnostics *sessionSectionsDiagnostics,
+	err error,
+) {
+	if errors.Is(err, context.Canceled) || (err == nil && duration < sessionSectionsSlowLogThreshold) {
+		return
+	}
+	status := "slow"
+	event := "workspace.agent_session.sections.list_slow"
+	message := "workspace agent session sections list slow"
+	level := slog.LevelInfo
+	if err != nil {
+		status = "failed"
+		event = "workspace.agent_session.sections.list_failed"
+		message = "workspace agent session sections list failed"
+		level = slog.LevelWarn
+	}
+	args := []any{
+		"event", event,
+		"workspace_id", workspaceID,
+		"agent_target_id", agentTargetID,
+		"target_filtered", agentTargetID != "",
+		"limit_per_section", limitPerSection,
+		"status", status,
+		"failure_stage", diagnostics.failureStage,
+		"duration_ms", duration.Milliseconds(),
+		"projects_ms", diagnostics.projectDuration.Milliseconds(),
+		"store_ms", diagnostics.storeDuration.Milliseconds(),
+		"hydrate_ms", diagnostics.hydrateDuration.Milliseconds(),
+		"section_count", diagnostics.sectionCount,
+		"session_count", diagnostics.sessionCount,
+	}
+	if err != nil {
+		args = append(args, "error", err)
+	}
+	slog.Log(ctx, level, message, args...)
 }
 
 func sessionsForSectionPage(

--- a/services/tuttid/service/agent/service_session_sections.go
+++ b/services/tuttid/service/agent/service_session_sections.go
@@ -29,29 +29,141 @@ func (s *Service) ListSessionSections(
 	if err != nil {
 		return SessionSectionsPage{}, err
 	}
-	pinned, err := s.sessionPinnedPage(ctx, workspaceID, "", input.LimitPerSection, agentTargetID)
-	if err != nil {
-		return SessionSectionsPage{}, err
+	reader, ok := s.SessionReader.(SessionSectionsReader)
+	if !ok {
+		return SessionSectionsPage{}, ErrInvalidArgument
 	}
-	sections := make([]SessionSection, 0, len(projects)+1)
+	return s.listSessionSectionsBatched(
+		ctx,
+		reader,
+		workspaceID,
+		projects,
+		input.LimitPerSection,
+		agentTargetID,
+	)
+}
+
+func (s *Service) listSessionSectionsBatched(
+	ctx context.Context,
+	reader SessionSectionsReader,
+	workspaceID string,
+	projects []userprojectbiz.Project,
+	limitPerSection int,
+	agentTargetID string,
+) (SessionSectionsPage, error) {
+	normalizedProjects := make([]userprojectbiz.Project, 0, len(projects))
+	sectionKeys := make([]string, 0, len(projects)+2)
+	sectionKeys = append(sectionKeys, agentactivitybiz.PinnedSessionPageKey)
 	for _, project := range projects {
 		project = userProjectWithSectionKey(project)
-		section, err := s.sessionSectionPage(ctx, workspaceID, sessionSectionKindProject, project.SectionKey, &project, "", input.LimitPerSection, agentTargetID)
-		if err != nil {
-			return SessionSectionsPage{}, err
+		if strings.TrimSpace(project.SectionKey) == "" {
+			continue
 		}
-		sections = append(sections, section)
+		normalizedProjects = append(normalizedProjects, project)
+		sectionKeys = append(sectionKeys, project.SectionKey)
 	}
-	conversations, err := s.sessionSectionPage(ctx, workspaceID, sessionSectionKindConversations, sessionSectionKeyConversations, nil, "", input.LimitPerSection, agentTargetID)
+	sectionKeys = append(sectionKeys, sessionSectionKeyConversations)
+	page, ok, err := reader.ListSessionSections(ctx, agentactivitybiz.ListSessionSectionsInput{
+		WorkspaceID:     workspaceID,
+		SectionKeys:     sectionKeys,
+		AgentTargetID:   strings.TrimSpace(agentTargetID),
+		LimitPerSection: limitPerSection,
+	})
 	if err != nil {
 		return SessionSectionsPage{}, err
 	}
-	sections = append(sections, conversations)
+	if !ok {
+		return SessionSectionsPage{}, ErrInvalidArgument
+	}
+	rawPagesByKey := make(map[string]agentactivitybiz.SessionSectionPage, len(page.Sections))
+	rawSessions := make([]agentactivitybiz.Session, 0, len(page.Sections)*limitPerSection)
+	for _, section := range page.Sections {
+		sectionKey := strings.TrimSpace(section.SectionKey)
+		if sectionKey == "" {
+			return SessionSectionsPage{}, ErrInvalidArgument
+		}
+		rawPagesByKey[sectionKey] = section
+		rawSessions = append(rawSessions, section.Sessions...)
+	}
+	sessions, err := s.sessionsFromActivity(ctx, workspaceID, rawSessions)
+	if err != nil {
+		return SessionSectionsPage{}, err
+	}
+	sessionsByID := make(map[string]Session, len(sessions))
+	for _, session := range sessions {
+		sessionsByID[session.ID] = session
+	}
+
+	pinnedPage, ok := rawPagesByKey[agentactivitybiz.PinnedSessionPageKey]
+	if !ok {
+		return SessionSectionsPage{}, ErrInvalidArgument
+	}
+	pinnedSessions, ok := sessionsForSectionPage(pinnedPage, sessionsByID)
+	if !ok {
+		return SessionSectionsPage{}, ErrInvalidArgument
+	}
+	sections := make([]SessionSection, 0, len(normalizedProjects)+1)
+	for i := range normalizedProjects {
+		project := normalizedProjects[i]
+		rawPage, ok := rawPagesByKey[project.SectionKey]
+		if !ok {
+			return SessionSectionsPage{}, ErrInvalidArgument
+		}
+		projectSessions, ok := sessionsForSectionPage(rawPage, sessionsByID)
+		if !ok {
+			return SessionSectionsPage{}, ErrInvalidArgument
+		}
+		sections = append(sections, SessionSection{
+			Kind:        sessionSectionKindProject,
+			SectionKey:  project.SectionKey,
+			UserProject: &project,
+			Sessions:    projectSessions,
+			HasMore:     rawPage.HasMore,
+			TotalCount:  rawPage.TotalCount,
+			NextCursor:  rawPage.NextCursor,
+		})
+	}
+	conversationsPage, ok := rawPagesByKey[sessionSectionKeyConversations]
+	if !ok {
+		return SessionSectionsPage{}, ErrInvalidArgument
+	}
+	conversationSessions, ok := sessionsForSectionPage(conversationsPage, sessionsByID)
+	if !ok {
+		return SessionSectionsPage{}, ErrInvalidArgument
+	}
+	sections = append(sections, SessionSection{
+		Kind:       sessionSectionKindConversations,
+		SectionKey: sessionSectionKeyConversations,
+		Sessions:   conversationSessions,
+		HasMore:    conversationsPage.HasMore,
+		TotalCount: conversationsPage.TotalCount,
+		NextCursor: conversationsPage.NextCursor,
+	})
 	return SessionSectionsPage{
 		WorkspaceID: workspaceID,
-		Pinned:      pinned,
-		Sections:    sections,
+		Pinned: SessionPage{
+			Sessions:   pinnedSessions,
+			HasMore:    pinnedPage.HasMore,
+			TotalCount: pinnedPage.TotalCount,
+			NextCursor: pinnedPage.NextCursor,
+		},
+		Sections: sections,
 	}, nil
+}
+
+func sessionsForSectionPage(
+	page agentactivitybiz.SessionSectionPage,
+	sessionsByID map[string]Session,
+) ([]Session, bool) {
+	sessions := make([]Session, 0, len(page.Sessions))
+	for _, rawSession := range page.Sessions {
+		session, ok := sessionsByID[strings.TrimSpace(rawSession.ID)]
+		if !ok {
+			return nil, false
+		}
+		sessions = append(sessions, session)
+	}
+	return sessions, true
 }
 
 func (s *Service) ListSessionSectionPage(
@@ -247,7 +359,7 @@ func (s *Service) sessionSectionPage(
 			return SessionSection{}, err
 		}
 	}
-	page, ok := reader.ListSessionSection(ctx, agentactivitybiz.ListSessionSectionInput{
+	page, ok, err := reader.ListSessionSection(ctx, agentactivitybiz.ListSessionSectionInput{
 		WorkspaceID:          workspaceID,
 		SectionKey:           sectionKey,
 		AgentTargetID:        strings.TrimSpace(agentTargetID),
@@ -255,6 +367,9 @@ func (s *Service) sessionSectionPage(
 		CursorSessionID:      parsedCursor.ID,
 		Limit:                limit,
 	})
+	if err != nil {
+		return SessionSection{}, err
+	}
 	if !ok {
 		return SessionSection{}, ErrInvalidArgument
 	}
@@ -316,7 +431,7 @@ func (s *Service) sessionPinnedPage(
 			return SessionPage{}, err
 		}
 	}
-	page, ok := reader.ListSessionSection(ctx, agentactivitybiz.ListSessionSectionInput{
+	page, ok, err := reader.ListSessionSection(ctx, agentactivitybiz.ListSessionSectionInput{
 		WorkspaceID:          workspaceID,
 		SectionKey:           agentactivitybiz.PinnedSessionPageKey,
 		AgentTargetID:        strings.TrimSpace(agentTargetID),
@@ -324,6 +439,9 @@ func (s *Service) sessionPinnedPage(
 		CursorSessionID:      parsedCursor.ID,
 		Limit:                limit,
 	})
+	if err != nil {
+		return SessionPage{}, err
+	}
 	if !ok {
 		return SessionPage{}, ErrInvalidArgument
 	}

--- a/services/tuttid/service/agent/service_session_sections_diagnostics_test.go
+++ b/services/tuttid/service/agent/service_session_sections_diagnostics_test.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSessionSectionsDiagnosticsSuppressFastAndCanceledRequests(t *testing.T) {
+	var output bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&output, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+	diagnostics := &sessionSectionsDiagnostics{}
+
+	logSessionSectionsDiagnostics(
+		context.Background(),
+		"ws-1",
+		"local:codex",
+		5,
+		sessionSectionsSlowLogThreshold-time.Millisecond,
+		diagnostics,
+		nil,
+	)
+	logSessionSectionsDiagnostics(
+		context.Background(),
+		"ws-1",
+		"local:codex",
+		5,
+		time.Second,
+		diagnostics,
+		context.Canceled,
+	)
+
+	if output.Len() != 0 {
+		t.Fatalf("suppressed diagnostics wrote %q", output.String())
+	}
+}
+
+func TestSessionSectionsDiagnosticsRecordSlowAndFailedRequests(t *testing.T) {
+	var output bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&output, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+	diagnostics := &sessionSectionsDiagnostics{
+		hydrateDuration: 30 * time.Millisecond,
+		projectDuration: 10 * time.Millisecond,
+		sectionCount:    4,
+		sessionCount:    12,
+		storeDuration:   220 * time.Millisecond,
+	}
+
+	logSessionSectionsDiagnostics(
+		context.Background(),
+		"ws-1",
+		"local:codex",
+		5,
+		300*time.Millisecond,
+		diagnostics,
+		nil,
+	)
+	diagnostics.failureStage = "store"
+	logSessionSectionsDiagnostics(
+		context.Background(),
+		"ws-1",
+		"local:codex",
+		5,
+		40*time.Millisecond,
+		diagnostics,
+		errors.New("store unavailable"),
+	)
+
+	logs := output.String()
+	for _, expected := range []string{
+		"workspace.agent_session.sections.list_slow",
+		"workspace.agent_session.sections.list_failed",
+		"agent_target_id=local:codex",
+		"duration_ms=300",
+		"projects_ms=10",
+		"store_ms=220",
+		"hydrate_ms=30",
+		"section_count=4",
+		"session_count=12",
+		"failure_stage=store",
+	} {
+		if !strings.Contains(logs, expected) {
+			t.Fatalf("diagnostics missing %q in:\n%s", expected, logs)
+		}
+	}
+}

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -4579,6 +4579,16 @@ func TestServiceListSessionSectionsUsesCurrentProjectsAndConversations(t *testin
 	}
 	service := newIsolatedAgentService(newFakeRuntime())
 	service.SessionReader = reader
+	latestTurnCalls := 0
+	activeTurnCalls := 0
+	pendingInteractionCalls := 0
+	latestInteractionCalls := 0
+	service.TurnStore = failingTurnStore{
+		latestListCalls:            &latestTurnCalls,
+		activeListCalls:            &activeTurnCalls,
+		interactionListCalls:       &pendingInteractionCalls,
+		latestInteractionListCalls: &latestInteractionCalls,
+	}
 	service.UserProjectReader = fakeUserProjectReader{projects: []userprojectbiz.Project{{
 		ID:    "project-1",
 		Path:  "/workspace/project",
@@ -4619,9 +4629,150 @@ func TestServiceListSessionSectionsUsesCurrentProjectsAndConversations(t *testin
 	if page.Sections[1].Kind != "conversations" || page.Sections[1].SectionKey != "conversations" {
 		t.Fatalf("conversations section = %#v", page.Sections[1])
 	}
-	if reader.lastInput.AgentTargetID != "claude-target" {
-		t.Fatalf("reader agentTargetID = %q, want claude-target", reader.lastInput.AgentTargetID)
+	if reader.sectionBatchCalls != 1 || reader.singleSectionCalls != 0 {
+		t.Fatalf("section reader calls = batch %d single %d, want one batch and no per-section reads", reader.sectionBatchCalls, reader.singleSectionCalls)
 	}
+	if reader.lastSectionsInput.AgentTargetID != "claude-target" || reader.lastSectionsInput.LimitPerSection != 5 {
+		t.Fatalf("reader input = %#v, want filtered five-row first pages", reader.lastSectionsInput)
+	}
+	if latestTurnCalls != 1 || activeTurnCalls != 1 || pendingInteractionCalls != 1 || latestInteractionCalls != 1 {
+		t.Fatalf(
+			"turn projection reads = latest %d active %d pending-interactions %d latest-interactions %d, want one cross-section batch each",
+			latestTurnCalls,
+			activeTurnCalls,
+			pendingInteractionCalls,
+			latestInteractionCalls,
+		)
+	}
+}
+
+func TestServiceListSessionSectionsPropagatesReaderError(t *testing.T) {
+	want := errors.New("section store unavailable")
+	service := newIsolatedAgentService(newFakeRuntime())
+	service.SessionReader = &fakeSectionReader{sectionBatchErr: want}
+	service.UserProjectReader = fakeUserProjectReader{}
+
+	_, err := service.ListSessionSections(context.Background(), "ws-1", ListSessionSectionsInput{
+		LimitPerSection: 5,
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("ListSessionSections() error = %v, want original store error", err)
+	}
+}
+
+func TestServiceListSessionSectionsRequiresBatchReader(t *testing.T) {
+	service := newIsolatedAgentService(newFakeRuntime())
+	service.SessionReader = fakeSessionReader{}
+	service.UserProjectReader = fakeUserProjectReader{}
+
+	_, err := service.ListSessionSections(context.Background(), "ws-1", ListSessionSectionsInput{
+		LimitPerSection: 5,
+	})
+	if !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("ListSessionSections() error = %v, want required batch reader", err)
+	}
+}
+
+func TestServiceListSessionSectionsProductionReaderCanRetryAfterCancellation(t *testing.T) {
+	store := openAgentServiceSQLiteStore(t)
+	service := newIsolatedAgentService(newFakeRuntime())
+	service.SessionReader = NewActivityProjection(store)
+	service.UserProjectReader = fakeUserProjectReader{}
+
+	canceledContext, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := service.ListSessionSections(canceledContext, "ws-1", ListSessionSectionsInput{
+		LimitPerSection: 5,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled ListSessionSections() error = %v, want context.Canceled", err)
+	}
+	if errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("canceled ListSessionSections() error = %v, must not be classified as invalid input", err)
+	}
+
+	page, err := service.ListSessionSections(context.Background(), "ws-1", ListSessionSectionsInput{
+		LimitPerSection: 5,
+	})
+	if err != nil {
+		t.Fatalf("retry ListSessionSections() error = %v", err)
+	}
+	if page.WorkspaceID != "ws-1" || len(page.Sections) != 1 || page.Sections[0].SectionKey != sessionSectionKeyConversations {
+		t.Fatalf("retry page = %#v, want empty Chats section", page)
+	}
+}
+
+func TestServiceListSessionPageReadersPropagateStorageErrors(t *testing.T) {
+	want := errors.New("section page store unavailable")
+	service := newIsolatedAgentService(newFakeRuntime())
+	service.SessionReader = &fakeSectionReader{singleSectionErr: want}
+
+	t.Run("ordinary section", func(t *testing.T) {
+		_, err := service.ListSessionSectionPage(context.Background(), "ws-1", ListSessionSectionPageInput{
+			SectionKey: sessionSectionKeyConversations,
+			Limit:      5,
+		})
+		if !errors.Is(err, want) {
+			t.Fatalf("ListSessionSectionPage() error = %v, want original store error", err)
+		}
+	})
+
+	t.Run("pinned", func(t *testing.T) {
+		_, err := service.ListPinnedSessionPage(context.Background(), "ws-1", ListPinnedSessionPageInput{
+			Limit: 5,
+		})
+		if !errors.Is(err, want) {
+			t.Fatalf("ListPinnedSessionPage() error = %v, want original store error", err)
+		}
+	})
+}
+
+func TestServiceListSessionPageProductionReaderCanRetryAfterCancellation(t *testing.T) {
+	store := openAgentServiceSQLiteStore(t)
+	service := newIsolatedAgentService(newFakeRuntime())
+	service.SessionReader = NewActivityProjection(store)
+
+	t.Run("ordinary section", func(t *testing.T) {
+		canceledContext, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := service.ListSessionSectionPage(canceledContext, "ws-1", ListSessionSectionPageInput{
+			SectionKey: sessionSectionKeyConversations,
+			Limit:      5,
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled ListSessionSectionPage() error = %v, want context.Canceled", err)
+		}
+		if errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("canceled ListSessionSectionPage() error = %v, must not be classified as invalid input", err)
+		}
+		page, err := service.ListSessionSectionPage(context.Background(), "ws-1", ListSessionSectionPageInput{
+			SectionKey: sessionSectionKeyConversations,
+			Limit:      5,
+		})
+		if err != nil || page.SectionKey != sessionSectionKeyConversations || len(page.Sessions) != 0 {
+			t.Fatalf("retry ListSessionSectionPage() page=%#v error=%v", page, err)
+		}
+	})
+
+	t.Run("pinned", func(t *testing.T) {
+		canceledContext, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := service.ListPinnedSessionPage(canceledContext, "ws-1", ListPinnedSessionPageInput{
+			Limit: 5,
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled ListPinnedSessionPage() error = %v, want context.Canceled", err)
+		}
+		if errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("canceled ListPinnedSessionPage() error = %v, must not be classified as invalid input", err)
+		}
+		page, err := service.ListPinnedSessionPage(context.Background(), "ws-1", ListPinnedSessionPageInput{
+			Limit: 5,
+		})
+		if err != nil || len(page.Sessions) != 0 {
+			t.Fatalf("retry ListPinnedSessionPage() page=%#v error=%v", page, err)
+		}
+	})
 }
 
 func TestServiceListSessionSectionPageForwardsStableCursor(t *testing.T) {
@@ -5656,33 +5807,64 @@ type fakeSessionReader struct {
 type fakeSectionReader struct {
 	fakeSessionReader
 	lastInput                   agentactivitybiz.ListSessionSectionInput
+	lastSectionsInput           agentactivitybiz.ListSessionSectionsInput
 	lastDeletionCandidatesInput agentactivitybiz.ListSessionSectionDeletionCandidatesInput
 	deletionCandidates          agentactivitybiz.SessionSectionDeletionCandidates
 	lastBatchDeleteInput        agentactivitybiz.DeleteSessionsBatchInput
 	batchDeleteResult           agentactivitybiz.DeleteSessionsBatchResult
 	batchDeleteErr              error
 	batchDeleteCalls            int
+	sectionBatchCalls           int
+	singleSectionCalls          int
+	sectionBatchErr             error
+	singleSectionErr            error
 	pages                       map[string]agentactivitybiz.SessionSectionPage
 }
 
-func (f *fakeSectionReader) ListSessionSection(_ context.Context, input agentactivitybiz.ListSessionSectionInput) (agentactivitybiz.SessionSectionPage, bool) {
+func (f *fakeSectionReader) ListSessionSection(_ context.Context, input agentactivitybiz.ListSessionSectionInput) (agentactivitybiz.SessionSectionPage, bool, error) {
+	f.singleSectionCalls++
 	f.lastInput = input
+	if f.singleSectionErr != nil {
+		return agentactivitybiz.SessionSectionPage{}, false, f.singleSectionErr
+	}
 	if f.pages == nil {
 		return agentactivitybiz.SessionSectionPage{
 			WorkspaceID: input.WorkspaceID,
 			SectionKey:  input.SectionKey,
-		}, true
+		}, true, nil
 	}
 	page, ok := f.pages[input.SectionKey]
 	if !ok {
 		return agentactivitybiz.SessionSectionPage{
 			WorkspaceID: input.WorkspaceID,
 			SectionKey:  input.SectionKey,
-		}, true
+		}, true, nil
 	}
 	page.WorkspaceID = input.WorkspaceID
 	page.SectionKey = input.SectionKey
-	return page, true
+	return page, true, nil
+}
+
+func (f *fakeSectionReader) ListSessionSections(_ context.Context, input agentactivitybiz.ListSessionSectionsInput) (agentactivitybiz.SessionSectionsPage, bool, error) {
+	f.sectionBatchCalls++
+	f.lastSectionsInput = input
+	if f.sectionBatchErr != nil {
+		return agentactivitybiz.SessionSectionsPage{}, false, f.sectionBatchErr
+	}
+	sections := make([]agentactivitybiz.SessionSectionPage, 0, len(input.SectionKeys))
+	for _, sectionKey := range input.SectionKeys {
+		page, ok := f.pages[sectionKey]
+		if !ok {
+			page = agentactivitybiz.SessionSectionPage{}
+		}
+		page.WorkspaceID = input.WorkspaceID
+		page.SectionKey = sectionKey
+		sections = append(sections, page)
+	}
+	return agentactivitybiz.SessionSectionsPage{
+		WorkspaceID: input.WorkspaceID,
+		Sections:    sections,
+	}, true, nil
 }
 
 func (f *fakeSectionReader) ListSessionSectionDeletionCandidates(_ context.Context, input agentactivitybiz.ListSessionSectionDeletionCandidatesInput) (agentactivitybiz.SessionSectionDeletionCandidates, bool) {
@@ -6056,6 +6238,9 @@ type activityProjectionRepoStub struct {
 	turnResults    map[string]agentactivitybiz.Turn
 	turnFound      bool
 	turnErr        error
+	sectionsPage   agentactivitybiz.SessionSectionsPage
+	sectionsOK     bool
+	sectionsErr    error
 }
 
 func (r *activityProjectionRepoStub) ClearSessions(context.Context, string) (agentactivitybiz.ClearSessionsResult, error) {
@@ -6084,6 +6269,10 @@ func (*activityProjectionRepoStub) ListSessions(context.Context, string) ([]agen
 
 func (*activityProjectionRepoStub) ListSessionSection(context.Context, agentactivitybiz.ListSessionSectionInput) (agentactivitybiz.SessionSectionPage, bool, error) {
 	return agentactivitybiz.SessionSectionPage{}, false, nil
+}
+
+func (r *activityProjectionRepoStub) ListSessionSections(context.Context, agentactivitybiz.ListSessionSectionsInput) (agentactivitybiz.SessionSectionsPage, bool, error) {
+	return r.sectionsPage, r.sectionsOK, r.sectionsErr
 }
 
 func (*activityProjectionRepoStub) ListSessionSectionDeletionCandidates(context.Context, agentactivitybiz.ListSessionSectionDeletionCandidatesInput) (agentactivitybiz.SessionSectionDeletionCandidates, bool, error) {

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -286,8 +286,12 @@ type SessionDetail struct {
 	ChildSessions []Session
 }
 
+type SessionSectionsReader interface {
+	ListSessionSections(context.Context, agentactivitybiz.ListSessionSectionsInput) (agentactivitybiz.SessionSectionsPage, bool, error)
+}
+
 type SessionSectionReader interface {
-	ListSessionSection(context.Context, agentactivitybiz.ListSessionSectionInput) (agentactivitybiz.SessionSectionPage, bool)
+	ListSessionSection(context.Context, agentactivitybiz.ListSessionSectionInput) (agentactivitybiz.SessionSectionPage, bool, error)
 }
 
 type SessionSectionDeletionCandidateReader interface {


### PR DESCRIPTION
## Summary

- batch provider-rail first-page reads into one requested-section SQLite query
- add exact target predicates and target-scoped ordinary/pinned indexes
- trim to narrow session IDs before loading full entities
- hydrate canonical session, turn, and interaction state once across all requested sections
- add low-noise rail diagnostics: slow success at 250 ms and real failures only
- split renderer timing into request/controller apply; split daemon timing into projects/store/hydration
- preserve existing package/store, tuttid data, biz, service, and AgentActivityRuntime ownership

## Fix Scope Justification

- Root cause: switching the provider rail issued serial per-section SQLite reads, then repeatedly hydrated the same canonical session data; the optional target predicate also prevented target-scoped index narrowing
- Lower layer: the repeated work originates across the store batch-read and tuttid service hydration boundary, so a renderer-only fix would preserve the expensive DB work. The implementation changes those two owning layers; renderer/daemon diagnostics only measure that same request path

## Verification

- `pnpm check:changed --tail-lines 120` — 12/12 lanes passed
- `pnpm check:full` — 18/18 tasks passed
- `pnpm --filter @tutti-os/agent-gui test` — 179 files / 1625 tests passed
- `pnpm typecheck`, `pnpm lint:ts`, `pnpm lint:go` passed
- `go test ./... && go build ./...` passed under `services/tuttid`
- 100k-session benchmark: batched reader is faster and allocates less than serial reads at every tested density

## Diagnostic noise policy

- successful requests below 250 ms: silent
- aborted or stale renderer requests: silent
- slow success: at most one renderer event and one daemon event
- real failure: one event per observed boundary
- no project paths, section keys, session titles, or prompts in these events

## Scope

- 18 changed files, all in provider-rail persistence/service/controller flow, tests, benchmark, or matching durable docs
- no Claude SDK, goal-control, generic runtime lifecycle, or event-protocol changes

## Checklist

- [x] Rebased onto latest `origin/main`
- [x] DCO sign-off
- [x] Architecture review: diagnostics use `AgentActivityRuntime.reportDiagnostic`; no ownership/layering findings
- [x] Documentation impact recorded
