### PR TITLE
fix(agent): keep queued submits pending past expiry

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2292,6 +2292,13 @@ turn remains blocked; cancel-then-send records the selected prompt as
 after the cancel result validates or the canonical turn settles. Metadata-only
 session patches and locally inferred idle states cannot unlock the queue.
 
+A pending submit confirmation deadline is not a queue-wait deadline. While the
+same `clientSubmitId` still has a queue-owned delivery that has not failed or
+entered uncertain delivery, expiry rolls the confirmation window forward
+instead of marking the submit failed. An explicit `queue/sendPrompt` failure
+still fails the submit immediately, while a timed-out delivery keeps its
+uncertain reconciliation and terminal expiry behavior.
+
 A user stop is an intent, not just a turn cancel: `interruptCurrentTurn`
 suspends the session's prompt queue (`suspendReason: "user_stop"`) before
 issuing the cancel, so the drainer must not fire the next queued prompt the

--- a/packages/agent/activity-core/src/engine/engineRuntime.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/engineRuntime.reducer.test.ts
@@ -269,6 +269,130 @@ test("canceling a queued submit atomically removes queue and pending intent", ()
   ]);
 });
 
+test("later queued submit stays requested when its expiry follows the prior delivery", () => {
+  let state = createInitialAgentSessionEngineState();
+  const runningSession = {
+    activeTurn: {
+      agentSessionId: "session-1",
+      phase: "running" as const,
+      startedAtUnixMs: 1,
+      turnId: "turn-1",
+      updatedAtUnixMs: 1
+    },
+    activeTurnId: "turn-1",
+    agentSessionId: "session-1",
+    cwd: "/workspace",
+    latestTurnInteractions: [],
+    pendingInteractions: [],
+    provider: "codex",
+    title: "Session",
+    updatedAtUnixMs: 1,
+    workspaceId: "workspace-1"
+  };
+  state = rootEngineReducer(state, {
+    sessions: [runningSession],
+    type: "session/snapshotReceived"
+  }).state;
+  state = rootEngineReducer(state, {
+    agentSessionId: "session-1",
+    clientSubmitId: "submit-1",
+    content: [{ type: "text", text: "queued" }],
+    expiresAtUnixMs: 120_000,
+    requestedAtUnixMs: 0,
+    type: "submit/requested",
+    workspaceId: "workspace-1"
+  }).state;
+  state = rootEngineReducer(state, {
+    agentSessionId: "session-1",
+    clientSubmitId: "submit-2",
+    content: [{ type: "text", text: "queued second" }],
+    expiresAtUnixMs: 120_001,
+    requestedAtUnixMs: 1,
+    type: "submit/requested",
+    workspaceId: "workspace-1"
+  }).state;
+
+  const settled = rootEngineReducer(state, {
+    sessions: [
+      {
+        ...runningSession,
+        activeTurn: {
+          ...runningSession.activeTurn,
+          phase: "settled",
+          settledAtUnixMs: 3,
+          updatedAtUnixMs: 3
+        },
+        activeTurnId: null,
+        updatedAtUnixMs: 3
+      }
+    ],
+    type: "session/snapshotReceived"
+  });
+  const send = settled.commands.find(
+    (command) => command.type === "queue/sendPrompt"
+  );
+  assert.equal(send?.type, "queue/sendPrompt");
+  const nextTurn = {
+    agentSessionId: "session-1",
+    phase: "running" as const,
+    startedAtUnixMs: 4,
+    turnId: "turn-2",
+    updatedAtUnixMs: 4
+  };
+  const firstDelivered = rootEngineReducer(settled.state, {
+    commandId: send?.type === "queue/sendPrompt" ? send.commandId : "",
+    commandType: "queue/sendPrompt",
+    correlationId: "submit-1",
+    outcome: "succeeded",
+    type: "engine/commandResult",
+    value: {
+      session: {
+        ...runningSession,
+        activeTurn: nextTurn,
+        activeTurnId: "turn-2",
+        updatedAtUnixMs: 4
+      },
+      turn: nextTurn,
+      turnId: "turn-2"
+    }
+  });
+  assert.equal(
+    firstDelivered.state.pendingIntents.submitsByClientSubmitId["submit-1"]
+      ?.status,
+    "accepted"
+  );
+  assert.deepEqual(
+    firstDelivered.state.promptQueue.recordsBySessionId[
+      "session-1"
+    ]?.prompts.map((prompt) => prompt.clientSubmitId),
+    ["submit-2"]
+  );
+
+  const secondExpired = rootEngineReducer(firstDelivered.state, {
+    dueAtUnixMs: 120_001,
+    expiryId: "submit:submit-2",
+    type: "engine/intentExpired"
+  });
+  assert.equal(
+    secondExpired.state.pendingIntents.submitsByClientSubmitId["submit-2"]
+      ?.status,
+    "requested"
+  );
+  assert.deepEqual(
+    secondExpired.state.promptQueue.recordsBySessionId[
+      "session-1"
+    ]?.prompts.map((prompt) => prompt.clientSubmitId),
+    ["submit-2"]
+  );
+  assert.deepEqual(secondExpired.commands, [
+    {
+      dueAtUnixMs: 240_001,
+      expiryId: "submit:submit-2",
+      type: "engine/scheduleExpiry"
+    }
+  ]);
+});
+
 test("submit acceptance rejects unknown and cross-workspace canonical sessions atomically", () => {
   const submit = {
     agentSessionId: "session-1",
@@ -400,6 +524,21 @@ test("an uncertain queued submit cannot be half-canceled", () => {
     "submit-1"
   );
   assert.deepEqual(canceled.commands, []);
+
+  const expired = rootEngineReducer(canceled.state, {
+    dueAtUnixMs: 120_000,
+    expiryId: "submit:submit-1",
+    type: "engine/intentExpired"
+  });
+  assert.equal(
+    expired.state.pendingIntents.submitsByClientSubmitId["submit-1"]?.status,
+    "failed"
+  );
+  assert.equal(
+    expired.state.promptQueue.recordsBySessionId["session-1"]
+      ?.uncertainDelivery,
+    null
+  );
 });
 
 test("session tombstone blocks late queue and snapshot resurrection across domains", () => {

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.ts
@@ -47,6 +47,7 @@ export function pendingIntentsReducer(
     settingsResultValidation?: ScopedSessionResultValidation | null;
     planFeedbackAccepted?: boolean;
     submitRequestAccepted?: boolean;
+    submitDeliveryIsQueuePending?: boolean;
   } = {
     deletedSessionIds: {},
     turnsById: {}
@@ -121,7 +122,11 @@ export function pendingIntentsReducer(
     case "engine/intentExpired":
       return intent.expiryId.startsWith("activation:")
         ? expireActivation(state, intent.expiryId)
-        : expireSubmit(state, intent.expiryId);
+        : expireSubmit(state, intent.expiryId, {
+            deliveryIsQueuePending:
+              context.submitDeliveryIsQueuePending === true,
+            dueAtUnixMs: intent.dueAtUnixMs
+          });
     case "session/removed":
       return removeSessionIntents(state, intent.agentSessionId);
     default:

--- a/packages/agent/activity-core/src/engine/pendingSubmit.reducer.ts
+++ b/packages/agent/activity-core/src/engine/pendingSubmit.reducer.ts
@@ -156,7 +156,11 @@ export function confirmFromSessions(
 
 export function expireSubmit(
   state: PendingIntentsState,
-  expiryId: string
+  expiryId: string,
+  options: {
+    deliveryIsQueuePending?: boolean;
+    dueAtUnixMs?: number;
+  } = {}
 ): EngineReducerResult<PendingIntentsState> {
   if (!expiryId.startsWith("submit:")) {
     return unchanged(state);
@@ -165,6 +169,26 @@ export function expireSubmit(
   const record = state.submitsByClientSubmitId[clientSubmitId];
   if (!record) {
     return unchanged(state);
+  }
+  if (options.deliveryIsQueuePending) {
+    const confirmationWindowMs = Math.max(
+      1,
+      record.expiresAtUnixMs - record.requestedAtUnixMs
+    );
+    return {
+      commands: [
+        {
+          dueAtUnixMs:
+            Math.max(
+              record.expiresAtUnixMs,
+              options.dueAtUnixMs ?? record.expiresAtUnixMs
+            ) + confirmationWindowMs,
+          expiryId,
+          type: "engine/scheduleExpiry"
+        }
+      ],
+      state
+    };
   }
   if (record.status === "accepted" || record.status === "confirmed") {
     return {

--- a/packages/agent/activity-core/src/engine/promptQueue.lookup.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.lookup.ts
@@ -30,3 +30,22 @@ export function canCancelQueuedSubmit(
     record.uncertainDelivery?.promptId !== promptId
   );
 }
+
+export function isQueuedSubmitDeliveryPending(
+  state: PromptQueueState,
+  agentSessionId: string,
+  clientSubmitId: string
+): boolean {
+  const record = state.recordsBySessionId[agentSessionId.trim()];
+  const promptId = promptQueuePromptIdForClientSubmit(
+    state,
+    agentSessionId,
+    clientSubmitId
+  );
+  return Boolean(
+    record &&
+    promptId &&
+    record.failedPromptId !== promptId &&
+    record.uncertainDelivery?.promptId !== promptId
+  );
+}

--- a/packages/agent/activity-core/src/engine/rootReducer.ts
+++ b/packages/agent/activity-core/src/engine/rootReducer.ts
@@ -10,7 +10,10 @@ import {
   resolvePromptSendNowStrategy,
   resolveQueuedPromptSendNowStrategy
 } from "./promptQueue.sendNow.ts";
-import { canCancelQueuedSubmit } from "./promptQueue.lookup.ts";
+import {
+  canCancelQueuedSubmit,
+  isQueuedSubmitDeliveryPending
+} from "./promptQueue.lookup.ts";
 import {
   createInitialPendingIntentsState,
   pendingIntentsReducer
@@ -254,6 +257,13 @@ export function rootEngineReducer(
     submitRequestAccepted,
     sendNowStrategy
   });
+  const expiringSubmitId =
+    intent.type === "engine/intentExpired" &&
+    intent.expiryId.startsWith("submit:")
+      ? intent.expiryId.slice("submit:".length)
+      : "";
+  const expiringSubmit =
+    state.pendingIntents.submitsByClientSubmitId[expiringSubmitId];
   const planDecisions = planDecisionReducer(state.planDecisions, intent, {
     feedbackAccepted,
     planTurnValid
@@ -297,6 +307,14 @@ export function rootEngineReducer(
       ),
     planFeedbackAccepted: feedbackAccepted,
     submitRequestAccepted,
+    submitDeliveryIsQueuePending: Boolean(
+      expiringSubmit &&
+      isQueuedSubmitDeliveryPending(
+        state.promptQueue,
+        expiringSubmit.agentSessionId,
+        expiringSubmitId
+      )
+    ),
     sendResultValidation,
     settingsResultValidation
   });


### PR DESCRIPTION
## Summary

- keep pending submits requested while their queue-owned delivery is still waiting or in flight
- roll the confirmation deadline forward without changing explicit failure or uncertain-delivery behavior
- cover the multi-prompt interleaving where the first queued prompt sends while a later prompt reaches its original expiry
- document that submit confirmation deadlines are not queue-wait deadlines

Root cause: every composer submit received the same 120-second confirmation expiry, but a busy-session queued submit could legitimately remain requested longer than that. Expiry then marked it failed even though the workspace engine still owned the queued delivery, allowing draft settlement to restore its content into the composer.

Architecture remains inside the workspace AgentSessionEngine: the queue domain exposes a narrow delivery-pending lookup, the root reducer composes that fact into the pending-intent reducer, and React owns no fallback state.

## Verification

- `pnpm check:full`
- `pnpm --filter @tutti-os/agent-activity-core test`
- `pnpm --filter @tutti-os/agent-gui test`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:agent-gui-degradation`
- `pnpm check:changed --tail-lines 80`

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps queued submits pending past their original confirmation expiry while the queue still owns their delivery, preventing false failures in busy sessions. The confirmation window now rolls forward without changing explicit failure or uncertain-delivery behavior.

- **Bug Fixes**
  - Reschedule submit expiry if its queue delivery is still pending; explicit `queue/sendPrompt` failures still fail immediately; uncertain deliveries keep timeout and terminal expiry.
  - Handle multi-prompt interleaving so a later submit doesn’t fail while an earlier queued prompt is sending.
  - Implemented in `@tutti-os/agent-activity-core` via `pendingIntents`/`pendingSubmit` reducers, `promptQueue.lookup` (`isQueuedSubmitDeliveryPending`), and `rootReducer`; docs clarify confirmation vs queue-wait deadlines.

<sup>Written for commit 0cac57c37ed35b3bcfe7c9de4587bc5ab5a26406. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

