### PR TITLE
fix(agent): omit prompt from Codex client metadata

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1522,6 +1522,10 @@ content in the pending record. Activation and existing-session submit share this
 contract. Their optimistic user messages use the authoritative payload shape:
 `content`, optional `displayPrompt`, and `text` resolved from `displayPrompt`
 before content-derived text.
+Provider adapters must carry the materialized prompt in the provider's input
+field only. Auxiliary request metadata must not duplicate unbounded prompt
+content; provider-specific wire metadata remains adapter-owned and limited to
+the provider contract.
 Timeline admission must treat renderable structured prompt content as a user
 message even when that derived text is empty. In particular, an image-only
 pending prompt projects through the same canonical user-message path and

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -60,6 +60,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [AgentGUI freezes when session history is large](./agent-session-lifecycle.md#agentgui-freezes-when-session-history-is-large)
 - [AgentGUI @ Sessions tab is empty](./agent-session-lifecycle.md#agentgui--sessions-tab-is-empty)
 - [Agent diagnostics flood while a turn is streaming](./agent-session-lifecycle.md#agent-diagnostics-flood-while-a-turn-is-streaming)
+- [Codex WebSocket reconnect rejects a long prompt metadata header](./agent-session-lifecycle.md#codex-websocket-reconnect-rejects-a-long-prompt-metadata-header)
 - [Imported sessions trigger fresh-completion indicators](./agent-session-lifecycle.md#imported-sessions-trigger-fresh-completion-indicators)
 - [Realtime agent completion does not show unread attention](./agent-session-lifecycle.md#realtime-agent-completion-does-not-show-unread-attention)
 - [Completed agent session stays activating and disables the composer](./agent-session-lifecycle.md#completed-agent-session-stays-activating-and-disables-the-composer)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -4,6 +4,36 @@
 
 Turn state, loading, cancel, restore, file-change undo, rail projection, event updates, imports, and performance.
 
+### Codex WebSocket reconnect rejects a long prompt metadata header
+
+- Symptom:
+  A long-running Codex turn disconnects, then its WebSocket reconnect fails with
+  `did not receive a valid HTTP request; Separator is found, but chunk is longer than limit`.
+  The same prompt may succeed when the original connection stays open.
+- Quick checks:
+  Inspect the Codex app-server `turn/start` params without logging prompt text.
+  Compare prompt byte count with any client metadata byte count. An unbounded
+  prompt copy in `responsesapiClientMetadata` can cross a WebSocket HTTP
+  parser's roughly 32 KiB line limit during reconnect.
+- Root cause:
+  Codex may forward Responses API client metadata through the WebSocket HTTP
+  handshake. Duplicating the full prompt into that metadata turns prompt size
+  into header size. Reconnect then fails before the provider can process the
+  normal `input` payload.
+- Fix:
+  Keep the full materialized prompt in `turn/start.input`. Do not duplicate it
+  into auxiliary metadata, truncate it in AgentGUI, or compensate with reconnect
+  retries. Provider-specific metadata stays inside the provider adapter and must
+  follow a demonstrated provider contract.
+- Validation:
+  Cover a prompt larger than 32 KiB. Assert `turn/start.input` preserves it
+  exactly and `responsesapiClientMetadata` contains no prompt copy. Run
+  `go test ./packages/agent/daemon/runtime`.
+- References:
+  [codex_appserver_event_params.go](../../../packages/agent/daemon/runtime/codex_appserver_event_params.go)
+  [codex_appserver_adapter_test.go](../../../packages/agent/daemon/runtime/codex_appserver_adapter_test.go)
+  [agent-gui-node.md](../../architecture/agent-gui-node.md)
+
 ### AgentGUI turn actions return plain-text route 404s
 
 - Symptom:

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -1507,9 +1507,8 @@ func TestCodexAppServerAdapterExecStreamsTurn(t *testing.T) {
 	if len(input) != 1 || asString(payloadObject(input[0])["text"]) != "inspect the repo" {
 		t.Fatalf("turn/start input = %#v", turnStart["input"])
 	}
-	metadata := payloadObject(turnStart["responsesapiClientMetadata"])
-	if asString(metadata["user_prompt_preview"]) != "inspect the repo" {
-		t.Fatalf("turn/start responsesapiClientMetadata = %#v", turnStart["responsesapiClientMetadata"])
+	if _, ok := turnStart["responsesapiClientMetadata"]; ok {
+		t.Fatalf("turn/start responsesapiClientMetadata = %#v, want omitted", turnStart["responsesapiClientMetadata"])
 	}
 
 	messages := eventsOfType(events, activityshared.EventMessageAppended)
@@ -1587,20 +1586,24 @@ func TestCodexAppServerAdapterExecStreamsTurn(t *testing.T) {
 	}
 }
 
-func TestCodexAppServerUserPromptPreviewUsesFullVisibleText(t *testing.T) {
+func TestCodexAppServerTurnStartKeepsLargePromptInInputOnly(t *testing.T) {
 	t.Parallel()
 
-	longVisibleText := strings.Repeat("a", 500)
-	got := appServerUserPromptPreview([]PromptContentBlock{
-		{Type: "text", Text: "provider text"},
-		{Type: "text", Text: "injected routing text"},
-	}, longVisibleText)
-	if got != longVisibleText {
-		t.Fatalf("preview = %q, want full visible text", got)
+	longPrompt := strings.Repeat("a", 33*1024)
+	params := appServerTurnStartParams(
+		Session{},
+		"codex-thread-1",
+		[]PromptContentBlock{{Type: "text", Text: longPrompt}},
+		nil,
+		nil,
+		"",
+	)
+	if _, ok := params["responsesapiClientMetadata"]; ok {
+		t.Fatalf("responsesapiClientMetadata = %#v, want omitted", params["responsesapiClientMetadata"])
 	}
-
-	if got := appServerUserPromptPreview([]PromptContentBlock{{Type: "image"}}, ""); got != "[Image]" {
-		t.Fatalf("image-only preview = %q, want [Image]", got)
+	input, ok := params["input"].([]map[string]any)
+	if !ok || len(input) != 1 || asString(input[0]["text"]) != longPrompt {
+		t.Fatalf("turn/start input did not preserve the full prompt")
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_event_params.go
+++ b/packages/agent/daemon/runtime/codex_appserver_event_params.go
@@ -52,7 +52,6 @@ func appServerTurnStartParams(
 	session Session,
 	threadID string,
 	content []PromptContentBlock,
-	visibleText string,
 	planModeMask map[string]any,
 	defaultModeMask map[string]any,
 	defaultModel string,
@@ -61,11 +60,6 @@ func appServerTurnStartParams(
 	params := map[string]any{
 		"threadId": threadID,
 		"input":    appServerUserInput(content),
-	}
-	if preview := appServerUserPromptPreview(content, visibleText); preview != "" {
-		params["responsesapiClientMetadata"] = map[string]string{
-			"user_prompt_preview": preview,
-		}
 	}
 	if collaborationMode := appServerCollaborationMode(settings, planModeMask, defaultModeMask, defaultModel); collaborationMode != nil {
 		params["collaborationMode"] = collaborationMode
@@ -89,14 +83,6 @@ func appServerTurnStartParams(
 		params["approvalsReviewer"] = approvalsReviewer
 	}
 	return params
-}
-
-func appServerUserPromptPreview(content []PromptContentBlock, visibleText string) string {
-	text := strings.TrimSpace(visibleText)
-	if text == "" {
-		text = strings.TrimSpace(promptDisplayText(content))
-	}
-	return text
 }
 
 // appServerCollaborationMode assembles the turn/start collaborationMode

--- a/packages/agent/daemon/runtime/codex_appserver_turn.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn.go
@@ -351,7 +351,7 @@ func (a *CodexAppServerAdapter) execBlocking(
 	a.markTurnSettleEmits(appTurn)
 
 	trace := newCodexAppServerTurnTrace(session, turnID, execMetadataFromContext(ctx))
-	turnParams := appServerTurnStartParams(session, appSession.threadID, providerContent, visibleText, appSession.planModeMask, appSession.defaultModeMask, execState.defaultModel)
+	turnParams := appServerTurnStartParams(session, appSession.threadID, providerContent, appSession.planModeMask, appSession.defaultModeMask, execState.defaultModel)
 	trace.Log("turn.start.params", codexAppServerTraceTurnStartParams(session, turnParams, providerContent))
 	turnStartedAt := time.Now()
 	result, err := appSession.client.TurnStart(ctx, turnParams,


### PR DESCRIPTION
## Summary

- stop copying full prompt text into Codex `responsesapiClientMetadata.user_prompt_preview`
- keep full prompt content exclusively in `turn/start.input`
- add regression coverage for prompts larger than 32 KiB
- document provider metadata ownership and WebSocket reconnect troubleshooting

## Motivation

Codex can forward Responses API client metadata through its WebSocket HTTP handshake. Tutti copied unbounded prompt text into that metadata, so a reconnect could exceed an HTTP parser line limit and fail before normal input processing.

## Validation

- `go test ./packages/agent/daemon/runtime`
- `pnpm check:changed --tail-lines 60`
- `pnpm check:full`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop copying full prompt text into Codex client metadata to prevent WebSocket reconnect failures from oversized headers. Keep the full prompt only in `turn/start.input`; add a >32 KiB regression test and update troubleshooting/docs on provider metadata ownership.

- **Bug Fixes**
  - Removed `responsesapiClientMetadata.user_prompt_preview` from Codex `turn/start`; no prompt duplication in metadata.
  - Large prompts no longer trigger reconnect HTTP header limits; input is preserved exactly.

<sup>Written for commit f3ef723f753d6c5c4c43a1956224f68343da3638. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

