### PR TITLE
fix(agent-gui): keep rail visible during pin refresh

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1322,6 +1322,15 @@ filtering pinned rows after section pagination corrupts page size and totals.
 If a refresh of an already-resolved section scope fails, keep its membership,
 cursor, and totals; only an unresolved or newly selected scope may resolve to an
 empty failure state.
+Section-query `pending` has two presentation meanings. An unresolved first page
+is blocking and may reveal the delayed rail skeleton. A same-scope membership
+refresh, including pin or unpin invalidation, is non-blocking: keep the resolved
+membership visible and interactive until the authoritative daemon page replaces
+it. A scope change may also keep the previous page visible to avoid destructive
+layout churn, but actions whose section or target scope could be stale remain
+locked until the new scope resolves. Derive these meanings inside the dedicated
+rail query controller from its current and resolved scope keys; do not add engine
+state, manually move rows, or make the view reinterpret raw request state.
 The active conversation is a
 display overlay, not a pageable row: it may render beside the first five rows,
 but it must not consume the local visible-item limit or advance the cursor.

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -465,35 +465,52 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
 - Symptom:
   Pinning or unpinning a conversation backed by a live runtime succeeds in the
   daemon, but the rail does not move the row or update its action until a later
-  list refresh. Old conversations without a live runtime update immediately.
+  list refresh. Old conversations without a live runtime update immediately. In
+  another variant, the pin command completes quickly but the whole rail becomes
+  disabled or changes to a skeleton while section membership refreshes.
 - Quick checks:
   Correlate `pin_result` with `agent.activity.store.session_version_regression`.
   Compare the command response's `updatedAtUnixMs` with the engine's current
   session version, then inspect the exported session for a newer
   `pinnedAtUnixMs`. A fast command carrying the new pin value but an older
   `updatedAtUnixMs` identifies a stale runtime projection, not a slow database
-  write.
+  write. If the pin value applies promptly, correlate
+  `agent_gui.conversation_rail.first_pages_slow` with
+  `workspace.agent_session.sections.list_slow`. The renderer event should report
+  `refreshReason=membership_change`; the daemon event separates
+  `projects_ms`, `store_ms`, and `hydrate_ms` and reports current/non-empty
+  project counts, target-scoped visible sessions, and returned first-page rows.
 - Root cause:
   Durable metadata updates advance the persisted session timestamp. When a live
   runtime session is also present, the service merges persisted metadata such
   as `pinnedAtUnixMs` into the runtime projection. If that merge keeps the older
   runtime timestamp, the frontend's monotonic session reducer correctly rejects
   the whole stale response, including the new pin value.
+  When the entity update is accepted, pin membership still requires an
+  authoritative section refresh. Treating every pending section request as an
+  unresolved list load turns that same-scope background refresh into a blocking
+  skeleton even though valid membership is already available.
 - Fix:
   Merge session freshness monotonically across runtime and persistence using
   the newer timestamp. Pin responses that advance the session version must also
   include protocol-v2 active/latest turn state so accepting the metadata update
   cannot clear a running turn. Do not weaken frontend version checks or hide the
-  mismatch behind delayed refetches.
+  mismatch behind delayed refetches. For an accepted membership update, keep the
+  resolved section page visible during the same-scope refresh and reveal the rail
+  skeleton only when no first page has resolved. Lock scope-sensitive actions
+  only while the displayed membership belongs to a different or unresolved
+  scope; do not patch daemon-owned membership locally.
 - Validation:
   Cover a live runtime session whose persisted pin update is newer, a newer
   runtime snapshot that must not regress, and a running turn that remains
   attached to the pin response. Run `go test ./services/tuttid/service/agent`
-  plus daemon lint, tests, and build.
+  plus daemon lint, tests, and build. Add controller coverage for initial load,
+  same-scope membership refresh, scope change, and stale request cancellation.
 - References:
   [service.go](../../../services/tuttid/service/agent/service.go)
   [service_session.go](../../../services/tuttid/service/agent/service_session.go)
   [sessionEntities.reducer.ts](../../../packages/agent/activity-core/src/engine/sessionEntities.reducer.ts)
+  [AgentGUIConversationRailQueryController.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts)
 
 ### AgentGUI model switch changes defaults but not the active session
 
@@ -633,7 +650,11 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   projects, store, and hydration time. Corresponding `*_failed` events record
   real failures. Successful requests below 250 ms, aborted requests, and stale
   responses are intentionally silent; these diagnostics must not log project
-  paths, section keys, session titles, or prompts.
+  paths, section keys, session titles, or prompts. Use `refreshReason` to
+  distinguish attach, scope change, and membership invalidation. Interpret
+  `rail_visible_session_count` as the target-scoped total across requested
+  sections and `returned_session_count` as only the bounded first-page rows;
+  neither requires another full-workspace count query.
 - Root cause:
   A second React summary cache mixed entity data, section membership, active
   selection, and visible-item limits. Effects manually patched section rows

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
@@ -1,3 +1,4 @@
+import { normalizeAgentActivitySession } from "@tutti-os/agent-activity-core";
 import { describe, expect, it, vi } from "vitest";
 import { createTestAgentSessionEngine } from "../../../shared/testing/createTestAgentSessionEngine";
 import {
@@ -62,17 +63,44 @@ describe("AgentGUIConversationRailQueryController", () => {
     }
   });
 
-  it("owns the latest rail interaction lock instead of mirroring it in view refs", async () => {
+  it("locks unresolved scopes but keeps same-scope pin refreshes interactive", async () => {
     const engine = createTestAgentSessionEngine();
-    let resolveSections!: () => void;
+    const session = normalizeAgentActivitySession({
+      activeTurnId: null,
+      agentSessionId: "session-1",
+      agentTargetId: "local:codex",
+      cwd: "/workspace",
+      latestTurnInteractions: [],
+      pendingInteractions: [],
+      provider: "codex",
+      title: "Session",
+      updatedAtUnixMs: 1,
+      workspaceId: "test-workspace"
+    });
+    const sectionResolvers: Array<() => void> = [];
+    const diagnosticLogger = vi.fn();
     const controller = new AgentGUIConversationRailQueryController({
+      diagnosticLogger,
+      diagnosticSlowThresholdMs: 0,
       engine,
       getActiveConversationId: () => null,
       runtime: {
         listSessionSections: (input) =>
           new Promise((resolve) => {
-            resolveSections = () =>
-              resolve({ sections: [], workspaceId: input.workspaceId });
+            sectionResolvers.push(() =>
+              resolve({
+                sections: [
+                  {
+                    hasMore: false,
+                    kind: "conversations",
+                    sectionKey: "conversations",
+                    sessions: [session],
+                    totalCount: 1
+                  }
+                ],
+                workspaceId: input.workspaceId
+              })
+            );
           }),
         listSessionSectionPage: async (input) => ({
           hasMore: false,
@@ -99,13 +127,46 @@ describe("AgentGUIConversationRailQueryController", () => {
     const detach = controller.attach();
     expect(controller.isInteractionLocked()).toBe(true);
 
-    controller.setSearchQuery("active search");
-    expect(controller.isInteractionLocked()).toBe(false);
-
-    resolveSections();
+    sectionResolvers.shift()?.();
     await vi.waitFor(() =>
       expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
     );
+    expect(controller.isInteractionLocked()).toBe(false);
+
+    engine.dispatch({
+      type: "session/upserted",
+      session: {
+        ...session,
+        pinnedAtUnixMs: 100,
+        updatedAtUnixMs: 2
+      }
+    });
+    expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(true);
+    expect(controller.getSnapshot().runtimeRailMemberships).toHaveLength(1);
+    expect(controller.isInteractionLocked()).toBe(false);
+
+    sectionResolvers.shift()?.();
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
+    expect(diagnosticLogger).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        refreshReason: "membership_change",
+        returnedSessionCount: 1
+      })
+    );
+
+    controller.configure({
+      conversationFilter: {
+        agentTargetId: "local:claude-code",
+        kind: "agentTarget"
+      },
+      previewMode: false,
+      sectionAgentTargetFallbackId: null,
+      userProjects: []
+    });
+    expect(controller.isInteractionLocked()).toBe(true);
+
     detach();
     engine.dispose();
   });
@@ -295,8 +356,9 @@ describe("AgentGUIConversationRailQueryController", () => {
         event: "agent_gui.conversation_rail.first_pages_slow",
         requestId: 2,
         requestMs: 300,
+        refreshReason: "attach",
+        returnedSessionCount: 0,
         sectionCount: 2,
-        sessionCount: 0,
         status: "ready",
         workspaceId: "test-workspace"
       },
@@ -362,8 +424,9 @@ describe("AgentGUIConversationRailQueryController", () => {
       event: "agent_gui.conversation_rail.first_pages_failed",
       requestId: 4,
       requestMs: 20,
+      refreshReason: "attach",
+      returnedSessionCount: 0,
       sectionCount: 0,
-      sessionCount: 0,
       status: "error",
       workspaceId: "test-workspace"
     });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -17,7 +17,8 @@ import {
   CONVERSATION_RAIL_SLOW_DIAGNOSTIC_THRESHOLD_MS,
   createConversationRailDiagnosticLogger,
   emitConversationRailFirstPagesDiagnostic,
-  type ConversationRailDiagnosticLogger
+  type ConversationRailDiagnosticLogger,
+  type ConversationRailRefreshReason
 } from "./agentGuiConversationRailDiagnostics";
 import {
   mergeConversationRailSessionIds,
@@ -112,7 +113,8 @@ export class AgentGUIConversationRailQueryController {
   readonly getSnapshot = (): AgentGUIConversationRailQuerySnapshot =>
     this.snapshot;
   readonly isInteractionLocked = (): boolean =>
-    this.snapshot.runtimeRailSectionsPending &&
+    this.queryState.pending &&
+    this.queryState.resolvedScopeKey !== this.railSectionQueryKey &&
     !(this.searchQuery && this.snapshot.railSearch.enabled);
   readonly subscribe = (listener: Listener): (() => void) => {
     this.listeners.add(listener);
@@ -171,7 +173,7 @@ export class AgentGUIConversationRailQueryController {
     this.unsubscribeEngine = this.engine.subscribe((state) => {
       this.handleEngineState(state);
     });
-    if (this.scope) this.refreshFirstPages();
+    if (this.scope) this.refreshFirstPages("attach");
     if (this.searchQuery) this.requestSearch();
     return () => this.detach();
   }
@@ -208,7 +210,7 @@ export class AgentGUIConversationRailQueryController {
       reconcilingSessionIds: []
     };
     this.emit();
-    if (this.attached) this.refreshFirstPages();
+    if (this.attached) this.refreshFirstPages("scope_change");
     if (this.searchQuery) this.requestSearch();
   }
 
@@ -432,10 +434,12 @@ export class AgentGUIConversationRailQueryController {
       )
     };
     this.emit();
-    this.refreshFirstPages();
+    this.refreshFirstPages("membership_change");
   }
 
-  private refreshFirstPages(): void {
+  private refreshFirstPages(
+    refreshReason: ConversationRailRefreshReason
+  ): void {
     const listSections = this.runtime.listSessionSections;
     const scopeKey = this.railSectionQueryKey;
     if (!this.runtimeSectionsEnabled() || !listSections || !scopeKey) {
@@ -507,13 +511,14 @@ export class AgentGUIConversationRailQueryController {
           durationMs: Math.max(0, completedAt - requestStartedAt),
           requestId: requestSequence,
           requestMs: Math.max(0, requestResolvedAt - requestStartedAt),
-          sectionCount: page.sections.length + (page.pinned ? 1 : 0),
-          sessionCount:
+          refreshReason,
+          returnedSessionCount:
             (page.pinned?.sessions.length ?? 0) +
             page.sections.reduce(
               (count, section) => count + section.sessions.length,
               0
             ),
+          sectionCount: page.sections.length + (page.pinned ? 1 : 0),
           status: "ready",
           workspaceId: this.workspaceId
         });
@@ -536,8 +541,9 @@ export class AgentGUIConversationRailQueryController {
           error,
           requestId: requestSequence,
           requestMs: Math.max(0, failedAt - requestStartedAt),
+          refreshReason,
+          returnedSessionCount: 0,
           sectionCount: 0,
-          sessionCount: 0,
           status: "error",
           workspaceId: this.workspaceId
         });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailDiagnostics.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailDiagnostics.ts
@@ -2,6 +2,11 @@ import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 
 export const CONVERSATION_RAIL_SLOW_DIAGNOSTIC_THRESHOLD_MS = 250;
 
+export type ConversationRailRefreshReason =
+  | "attach"
+  | "membership_change"
+  | "scope_change";
+
 export interface ConversationRailFirstPagesDiagnostic {
   agentTargetId: string | null;
   controllerApplyMs: number;
@@ -12,8 +17,9 @@ export interface ConversationRailFirstPagesDiagnostic {
     | "agent_gui.conversation_rail.first_pages_failed";
   requestId: number;
   requestMs: number;
+  refreshReason: ConversationRailRefreshReason;
+  returnedSessionCount: number;
   sectionCount: number;
-  sessionCount: number;
   status: "ready" | "error";
   workspaceId: string;
 }
@@ -31,8 +37,9 @@ export function emitConversationRailFirstPagesDiagnostic(input: {
   error?: unknown;
   requestId: number;
   requestMs: number;
+  refreshReason: ConversationRailRefreshReason;
+  returnedSessionCount: number;
   sectionCount: number;
-  sessionCount: number;
   status: "ready" | "error";
   workspaceId: string;
 }): void {
@@ -55,8 +62,9 @@ export function emitConversationRailFirstPagesDiagnostic(input: {
         : "agent_gui.conversation_rail.first_pages_slow",
     requestId: input.requestId,
     requestMs: input.requestMs,
+    refreshReason: input.refreshReason,
+    returnedSessionCount: input.returnedSessionCount,
     sectionCount: input.sectionCount,
-    sessionCount: input.sessionCount,
     status: input.status,
     workspaceId: input.workspaceId
   };

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.spec.ts
@@ -4,6 +4,7 @@ import type { ConversationSection } from "../agentGuiNodeViewConversation";
 import {
   insertConversationRailSectionOverlay,
   conversationSummariesRenderEqual,
+  isConversationRailInitialLoadPending,
   projectConversationRailSectionsWithActiveConversation,
   planRuntimeRailMembershipRefresh,
   projectRuntimeSectionsToConversationRailMemberships,
@@ -45,6 +46,32 @@ function section(
     }
   ];
 }
+
+describe("isConversationRailInitialLoadPending", () => {
+  it("blocks only while the first runtime membership page is unresolved", () => {
+    expect(
+      isConversationRailInitialLoadPending({
+        pending: true,
+        runtimeSectionsEnabled: true,
+        sections: null
+      })
+    ).toBe(true);
+    expect(
+      isConversationRailInitialLoadPending({
+        pending: true,
+        runtimeSectionsEnabled: true,
+        sections: []
+      })
+    ).toBe(false);
+    expect(
+      isConversationRailInitialLoadPending({
+        pending: false,
+        runtimeSectionsEnabled: true,
+        sections: null
+      })
+    ).toBe(false);
+  });
+});
 
 function membership(
   items: readonly AgentGUIConversationSummary[]

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts
@@ -43,6 +43,16 @@ export interface ConversationRailQueryState {
   sections: ConversationRailSectionMembership[] | null;
 }
 
+export function isConversationRailInitialLoadPending(input: {
+  pending: boolean;
+  runtimeSectionsEnabled: boolean;
+  sections: ConversationRailSectionMembership[] | null;
+}): boolean {
+  return (
+    input.runtimeSectionsEnabled && input.pending && input.sections === null
+  );
+}
+
 export interface ConversationRailActiveOverlay {
   conversation: NonNullable<
     AgentGUINodeViewModel["rail"]["activeConversation"]

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
@@ -31,6 +31,7 @@ import {
   type ConversationSection
 } from "../agentGuiNodeViewConversation";
 import {
+  isConversationRailInitialLoadPending,
   projectConversationRailMemberships,
   projectConversationRailSectionsWithActiveConversation,
   projectConversationRailSectionsWithTransientConversations,
@@ -233,8 +234,7 @@ export const AgentGUIConversationRailPane = memo(
     const railConversationEntities = [...railConversationEntitiesById.values()];
     const hasConversationQuery = conversationQuery.trim().length > 0;
     const backendSearchActive = hasConversationQuery && railSearch.enabled;
-    const railInteractionsLocked =
-      runtimeRailSectionsPending && !backendSearchActive;
+    const railInteractionsLocked = isInteractionLocked();
     const backendSearchConversations = backendSearchActive
       ? railSearch.sessionIds.flatMap((id) => {
           const conversation = railConversationEntitiesById.get(id);
@@ -463,9 +463,11 @@ export const AgentGUIConversationRailPane = memo(
         sectionAgentTargetId
       ]
     );
-    const isRuntimeRailLoading =
-      runtimeSectionsEnabled &&
-      (runtimeRailSections === null || runtimeRailSectionsPending);
+    const isRuntimeRailLoading = isConversationRailInitialLoadPending({
+      pending: runtimeRailSectionsPending,
+      runtimeSectionsEnabled,
+      sections: runtimeRailMemberships
+    });
     const isConversationRailListLoading = backendSearchActive
       ? railSearch.pending
       : isRuntimeRailLoading ||
@@ -571,10 +573,7 @@ export const AgentGUIConversationRailPane = memo(
               </span>
             </div>
           ) : (
-            <fieldset
-              className="contents"
-              disabled={runtimeRailSectionsPending && !backendSearchActive}
-            >
+            <fieldset className="contents" disabled={railInteractionsLocked}>
               {groupedConversations.map((section, sectionIndex) => {
                 const projectPath =
                   section.kind === "project"

--- a/services/tuttid/service/agent/service_session_sections.go
+++ b/services/tuttid/service/agent/service_session_sections.go
@@ -20,12 +20,15 @@ const (
 )
 
 type sessionSectionsDiagnostics struct {
-	failureStage    string
-	hydrateDuration time.Duration
-	projectDuration time.Duration
-	sectionCount    int
-	sessionCount    int
-	storeDuration   time.Duration
+	currentProjectCount     int
+	failureStage            string
+	hydrateDuration         time.Duration
+	nonEmptyProjectCount    int
+	projectDuration         time.Duration
+	railVisibleSessionCount int
+	returnedSessionCount    int
+	sectionCount            int
+	storeDuration           time.Duration
 }
 
 func (s *Service) ListSessionSections(
@@ -95,6 +98,7 @@ func (s *Service) listSessionSectionsBatched(
 		sectionKeys = append(sectionKeys, project.SectionKey)
 	}
 	sectionKeys = append(sectionKeys, sessionSectionKeyConversations)
+	diagnostics.currentProjectCount = len(normalizedProjects)
 	diagnostics.failureStage = "store"
 	storeStartedAt := time.Now()
 	page, ok, err := reader.ListSessionSections(ctx, agentactivitybiz.ListSessionSectionsInput{
@@ -119,9 +123,15 @@ func (s *Service) listSessionSectionsBatched(
 		}
 		rawPagesByKey[sectionKey] = section
 		rawSessions = append(rawSessions, section.Sessions...)
+		diagnostics.railVisibleSessionCount += section.TotalCount
 	}
 	diagnostics.sectionCount = len(page.Sections)
-	diagnostics.sessionCount = len(rawSessions)
+	diagnostics.returnedSessionCount = len(rawSessions)
+	for _, project := range normalizedProjects {
+		if rawPage, ok := rawPagesByKey[project.SectionKey]; ok && rawPage.TotalCount > 0 {
+			diagnostics.nonEmptyProjectCount++
+		}
+	}
 	diagnostics.failureStage = "hydrate"
 	hydrateStartedAt := time.Now()
 	sessions, err := s.sessionsFromActivity(ctx, workspaceID, rawSessions)
@@ -228,8 +238,11 @@ func logSessionSectionsDiagnostics(
 		"projects_ms", diagnostics.projectDuration.Milliseconds(),
 		"store_ms", diagnostics.storeDuration.Milliseconds(),
 		"hydrate_ms", diagnostics.hydrateDuration.Milliseconds(),
+		"current_project_count", diagnostics.currentProjectCount,
+		"non_empty_project_count", diagnostics.nonEmptyProjectCount,
+		"rail_visible_session_count", diagnostics.railVisibleSessionCount,
+		"returned_session_count", diagnostics.returnedSessionCount,
 		"section_count", diagnostics.sectionCount,
-		"session_count", diagnostics.sessionCount,
 	}
 	if err != nil {
 		args = append(args, "error", err)

--- a/services/tuttid/service/agent/service_session_sections_diagnostics_test.go
+++ b/services/tuttid/service/agent/service_session_sections_diagnostics_test.go
@@ -47,11 +47,14 @@ func TestSessionSectionsDiagnosticsRecordSlowAndFailedRequests(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewTextHandler(&output, nil)))
 	t.Cleanup(func() { slog.SetDefault(previousLogger) })
 	diagnostics := &sessionSectionsDiagnostics{
-		hydrateDuration: 30 * time.Millisecond,
-		projectDuration: 10 * time.Millisecond,
-		sectionCount:    4,
-		sessionCount:    12,
-		storeDuration:   220 * time.Millisecond,
+		currentProjectCount:     2,
+		hydrateDuration:         30 * time.Millisecond,
+		nonEmptyProjectCount:    1,
+		projectDuration:         10 * time.Millisecond,
+		railVisibleSessionCount: 42,
+		returnedSessionCount:    12,
+		sectionCount:            4,
+		storeDuration:           220 * time.Millisecond,
 	}
 
 	logSessionSectionsDiagnostics(
@@ -83,8 +86,11 @@ func TestSessionSectionsDiagnosticsRecordSlowAndFailedRequests(t *testing.T) {
 		"projects_ms=10",
 		"store_ms=220",
 		"hydrate_ms=30",
+		"current_project_count=2",
+		"non_empty_project_count=1",
+		"rail_visible_session_count=42",
+		"returned_session_count=12",
 		"section_count=4",
-		"session_count=12",
 		"failure_stage=store",
 	} {
 		if !strings.Contains(logs, expected) {


### PR DESCRIPTION
## Summary

- distinguish unresolved rail loads from same-scope membership refreshes so pin and unpin keep the resolved list visible
- keep scope-sensitive actions locked only when displayed membership belongs to an unresolved or different scope
- add low-noise rail diagnostics for refresh reason, current project count, non-empty projects, target-scoped visible sessions, and returned first-page rows
- document the loading, ownership, and troubleshooting rules without adding engine state or a second membership cache

Root cause: the rail treated every pending section request as a blocking load. Pin membership invalidation therefore replaced valid resolved content with a delayed skeleton and disabled the whole list.

## Verification

- `pnpm --filter @tutti-os/agent-gui test` — 179 files, 1626 tests
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm lint:ts`
- `pnpm typecheck`
- `pnpm lint:go`
- `pnpm test:go`
- `pnpm build:go`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:changed --tail-lines 80`
- pre-push `pnpm check:full` — 18 tasks

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the conversation rail visible and interactive during pin/unpin by treating same‑scope membership refreshes as non‑blocking. Only lock interactions on initial unresolved loads or when the displayed scope changes.

- **Bug Fixes**
  - Keep the last resolved membership visible during pin/unpin; only show the skeleton when no first page has resolved.
  - Lock scope-sensitive actions only when the visible membership is unresolved or belongs to a different scope; search remains usable.

- **New Features**
  - Add low-noise rail and service diagnostics: `refreshReason` (attach | membership_change | scope_change), `returnedSessionCount`, split timings, and project/session visibility counts; update docs and tests.

<sup>Written for commit 92d8bcf7cd6289a748e13c9d9cc7bdf94eaaba81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

