### PR TITLE
fix(agent-gui): clarify approval rejection follow-up

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentInteractivePromptSurface.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentInteractivePromptSurface.spec.tsx
@@ -181,6 +181,7 @@ describe("AgentInteractivePromptSurface", () => {
 
   it("submits abort approval options with optional feedback", () => {
     const onSubmit = vi.fn();
+    setAgentGuiI18nTestLocale("zh-CN");
     render(
       <AgentInteractivePromptSurface
         prompt={{
@@ -201,8 +202,8 @@ describe("AgentInteractivePromptSurface", () => {
             },
             {
               id: "abort",
-              label: "No, and tell Codex what to do differently",
-              kind: "reject_once"
+              label: "Deny and stop the turn",
+              kind: "reject_always"
             }
           ],
           output: null,
@@ -219,13 +220,13 @@ describe("AgentInteractivePromptSurface", () => {
     ).toBeNull();
     fireEvent.click(
       screen.getByRole("button", {
-        name: "No, then send new instructions"
+        name: "拒绝，然后发送新的指令"
       })
     );
     expect(onSubmit).not.toHaveBeenCalled();
     expect(
       screen.queryByRole("button", {
-        name: "No, then send new instructions"
+        name: "拒绝，然后发送新的指令"
       })
     ).toBeNull();
     expect(screen.getByPlaceholderText(labels.feedbackPlaceholder)).toBe(
@@ -250,10 +251,11 @@ describe("AgentInteractivePromptSurface", () => {
       screen.getByRole("button", { name: labels.sendFeedback })
     ).toBeDisabled();
 
-    fireEvent.change(screen.getByPlaceholderText(labels.feedbackPlaceholder), {
+    const feedback = screen.getByPlaceholderText(labels.feedbackPlaceholder);
+    fireEvent.change(feedback, {
       target: { value: "Please split the work into smaller steps." }
     });
-    fireEvent.click(screen.getByRole("button", { name: labels.sendFeedback }));
+    fireEvent.keyDown(feedback, { key: "Enter", code: "Enter" });
 
     expect(onSubmit).toHaveBeenCalledWith({
       requestId: "request-approval",
@@ -463,7 +465,7 @@ describe("AgentInteractivePromptSurface", () => {
     ).toBeNull();
   });
 
-  it("does not submit approval shortcuts while editing feedback", () => {
+  it("does not submit empty feedback with Enter", () => {
     const onSubmit = vi.fn();
     render(
       <AgentInteractivePromptSurface

--- a/packages/agent/gui/shared/agentConversation/approvalOptionPresentation.ts
+++ b/packages/agent/gui/shared/agentConversation/approvalOptionPresentation.ts
@@ -50,7 +50,9 @@ export function approvalOptionDisplayLabel(
     return translate("agentHost.agentGui.approvalOptions.allowAlways");
   }
   if (idToken === "rejectalways" || kindToken === "rejectalways") {
-    return translate("agentHost.agentGui.approvalOptions.rejectAlways");
+    return intent.feedback
+      ? translate("agentHost.agentGui.approvalOptions.rejectWithFollowUp")
+      : translate("agentHost.agentGui.approvalOptions.rejectAlways");
   }
   if (
     idToken === "rejectonce" ||

--- a/packages/agent/gui/shared/agentConversation/components/AgentInteractiveDecisionPromptSurfaces.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentInteractiveDecisionPromptSurfaces.tsx
@@ -213,9 +213,8 @@ export function ApprovalPromptSurface({
                     onChange={(event) => setFeedback(event.currentTarget.value)}
                     onKeyDown={(event) => {
                       if (
-                        !keyboardShortcuts ||
                         event.key !== "Enter" ||
-                        (!event.metaKey && !event.ctrlKey) ||
+                        event.shiftKey ||
                         event.nativeEvent.isComposing
                       ) {
                         return;


### PR DESCRIPTION
## Summary

- label the Codex abort feedback action as rejecting and sending new instructions
- submit non-empty rejection feedback with Enter while preserving Shift+Enter for newlines and IME composition
- reuse the existing interaction test for the localized label and keyboard behavior

## Verification

- `pnpm check:full`
- hot-reloaded the active Tutti development window once

## Checklist

- [x] I kept the change focused on one concern.
- [x] I checked documentation impact; no durable documentation update was needed.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the reject-and-follow-up action in the agent approval UI and updates keyboard behavior so Enter submits non‑empty feedback while preserving Shift+Enter for newlines and IME safety.

- **Bug Fixes**
  - Show “reject with follow‑up” label when feedback is present; otherwise show “reject always”.
  - Enter submits feedback only when non‑empty; Shift+Enter inserts a newline; IME composition is respected.
  - Tests updated to cover localized labels (zh-CN) and Enter submission, reusing the existing interaction test.

<sup>Written for commit 459ae6fa468f713bb26f3eb87dc0852951f0f7ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

