### PR TITLE
fix(agent): recover settled submits and enforce Cursor read-only

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -234,6 +234,12 @@ consumer status therefore bridges a new activation to `working` only when that
 activation submitted initial content, then derives status from its first
 canonical turn. Empty new sessions become `idle` after confirmation. GUI
 projections must not patch this confirmation gap locally.
+Accepted submit intents are optimistic correlation records, not an independent
+busy source after canonical turn ownership moves on. Composer send/loading
+projections may treat an accepted submit as unconfirmed only while its accepted
+turn is still the session's active turn; a settled, cleared, or superseded
+active turn must let canonical session and turn lifecycle unlock the composer
+even if the pending intent record is waiting for later cleanup.
 
 AgentGuiNode may expose agent selection in multiple UI-local entry points,
 including the conversation rail agent grid and the agent select next to the
@@ -312,6 +318,12 @@ immediately, including host-provided name/artwork, model options,
 and permission modes. Generic home composer overrides are single-target draft
 state and must be cleared when the selected agent changes; provider-
 or target-scoped defaults may still provide the next settings.
+Provider permission tiers and provider workflow modes are separate contracts.
+A provider's read-only tier must map to its actual non-writing execution mode,
+not to a planning workflow that can advance into implementation. For Cursor,
+the durable `read-only` tier maps to ACP `ask`, while the independent
+`planMode` flag maps to ACP `plan`; leaving plan mode restores the runtime mode
+derived from the durable permission tier.
 Host feature switches that disable an agent for new conversations should keep
 the entry present with a non-ready `availability.status` when another surface
 still needs to show it. Filter the entry out only for surfaces that should

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -409,6 +409,42 @@ file or directory`. If the CLI path exists but `codex app-server` cannot
   [acp_provider_cursor.go](../../../packages/agent/daemon/runtime/acp_provider_cursor.go)
   [skill_options.go](../../../services/tuttid/service/agent/skill_options.go)
 
+### Cursor read-only mode still creates files without approval
+
+- Symptom:
+  AgentGUI shows Cursor as Read-only, but the transcript reports a successful
+  `Switch Mode` followed by `Edit`, the file appears on disk, and no approval
+  interaction is shown.
+- Quick checks:
+  Inspect the exported session settings and ACP startup logs together. If the
+  durable `permissionModeId` is `read-only` while
+  `agent_session.acp.permission_mode.start` reports `mode_id=plan`, then the
+  permission tier was mapped to Cursor's planning workflow rather than its
+  read-only execution mode. Confirm the turn contains no
+  `session/request_permission` before investigating AgentGUI approval cards.
+- Root cause:
+  Cursor `plan` and `ask` are different workflow modes. Plan can transition
+  into implementation, including a provider-owned `Switch Mode`, whereas Ask
+  retains read/search tools without making changes. Mapping Tutti's durable
+  read-only permission tier to Plan therefore delegated a security boundary to
+  a workflow that could advance into editing. A provider-owned tool call is
+  historical activity, not a canonical approval Interaction, so AgentGUI
+  correctly had no approval request to render.
+- Fix:
+  Map Cursor `read-only` to ACP `ask`. Keep the independent AgentGUI plan-mode
+  control mapped to ACP `plan`, and when plan mode is turned off, restore the
+  runtime mode derived from the durable permission tier instead of assuming
+  `agent`.
+- Validation:
+  Cover startup tier mapping (`read-only -> ask`) and a read-only plan-mode
+  round trip (`ask -> plan -> ask`). With a real Cursor ACP binary, verify Ask
+  can search and read project files, a request to create a file does not write
+  one, and no provider-owned mode switch silently enables Edit.
+- References:
+  [providers.go](../../../packages/agent/daemon/providerregistry/providers.go)
+  [acp_provider_cursor.go](../../../packages/agent/daemon/runtime/acp_provider_cursor.go)
+  [standard_acp_adapter_test.go](../../../packages/agent/daemon/runtime/standard_acp_adapter_test.go)
+
 ### Codex provider shows login required when global service tier is legacy
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -18,6 +18,7 @@ Provider discovery, installation, authentication, models, configuration, and run
 - [Codex provider install fails with missing npm](./agent-provider-setup.md#codex-provider-install-fails-with-missing-npm)
 - [Codex ACP warns about user-level config as project-local config](./agent-provider-setup.md#codex-acp-warns-about-user-level-config-as-project-local-config)
 - [Cursor sessions create project `.cursor/skills` or `AGENTS.md` changes](./agent-provider-setup.md#cursor-sessions-create-project-cursorskills-or-agentsmd-changes)
+- [Cursor read-only mode still creates files without approval](./agent-provider-setup.md#cursor-read-only-mode-still-creates-files-without-approval)
 - [Codex provider shows login required when global service tier is legacy](./agent-provider-setup.md#codex-provider-shows-login-required-when-global-service-tier-is-legacy)
 - [Codex provider shows login required when only an API key is configured](./agent-provider-setup.md#codex-provider-shows-login-required-when-only-an-api-key-is-configured)
 - [Codex session fails with not connected when model_catalog_json is relative](./agent-provider-setup.md#codex-session-fails-with-not-connected-when-modelcatalogjson-is-relative)

--- a/packages/agent/activity-core/src/engine/engineRuntime.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/engineRuntime.reducer.test.ts
@@ -8,6 +8,7 @@ import {
   createInitialAgentSessionEngineState,
   rootEngineReducer
 } from "./rootReducer.ts";
+import { selectSessionHasUnconfirmedSubmit } from "./pendingIntents.selectors.ts";
 import type { EngineIntent, EngineRuntimeState } from "./types.ts";
 import type { AgentActivitySessionCapabilities } from "../types.ts";
 
@@ -444,6 +445,76 @@ test("submit acceptance rejects unknown and cross-workspace canonical sessions a
     undefined
   );
   assert.deepEqual(crossWorkspace.commands, []);
+});
+
+test("accepted submit stops blocking once its turn is no longer active", () => {
+  let state = createInitialAgentSessionEngineState();
+  const runningTurn = {
+    agentSessionId: "session-1",
+    phase: "running" as const,
+    startedAtUnixMs: 1,
+    turnId: "turn-1",
+    updatedAtUnixMs: 1
+  };
+  const session = {
+    activeTurn: runningTurn,
+    activeTurnId: "turn-1",
+    agentSessionId: "session-1",
+    cwd: "/workspace",
+    latestTurnInteractions: [],
+    pendingInteractions: [],
+    provider: "codex",
+    title: "Session",
+    updatedAtUnixMs: 1,
+    workspaceId: "workspace-1"
+  };
+  state = rootEngineReducer(state, {
+    sessions: [session],
+    type: "session/snapshotReceived"
+  }).state;
+  state = rootEngineReducer(state, {
+    agentSessionId: "session-1",
+    clientSubmitId: "submit-1",
+    content: [{ type: "text", text: "retry" }],
+    expiresAtUnixMs: 120_000,
+    requestedAtUnixMs: 2,
+    type: "submit/requested",
+    workspaceId: "workspace-1"
+  }).state;
+  state = rootEngineReducer(state, {
+    commandId: "submit:send:submit-1",
+    commandType: "queue/sendPrompt",
+    correlationId: "submit-1",
+    outcome: "succeeded",
+    type: "engine/commandResult",
+    value: {
+      session,
+      turn: runningTurn,
+      turnId: "turn-1"
+    }
+  }).state;
+  assert.equal(selectSessionHasUnconfirmedSubmit(state, "session-1"), true);
+
+  const laterTurn = {
+    agentSessionId: "session-1",
+    outcome: "completed" as const,
+    phase: "settled" as const,
+    settledAtUnixMs: 4,
+    startedAtUnixMs: 3,
+    turnId: "turn-2",
+    updatedAtUnixMs: 4
+  };
+  state = rootEngineReducer(state, {
+    session: {
+      ...session,
+      activeTurn: null,
+      activeTurnId: null,
+      latestTurn: laterTurn,
+      updatedAtUnixMs: 4
+    },
+    type: "session/upserted"
+  }).state;
+  assert.equal(selectSessionHasUnconfirmedSubmit(state, "session-1"), false);
 });
 
 test("an uncertain queued submit cannot be half-canceled", () => {

--- a/packages/agent/activity-core/src/engine/pendingIntents.selectors.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.selectors.ts
@@ -3,6 +3,7 @@ import type {
   PendingActivationIntentRecord,
   PendingSubmitIntentRecord
 } from "./pendingIntents.types.ts";
+import { canonicalTurnKey } from "./sessionEntityKeys.ts";
 
 export function selectPendingActivations(
   state: AgentSessionEngineState
@@ -77,8 +78,20 @@ export function selectSessionHasUnconfirmedSubmit(
   state: AgentSessionEngineState,
   agentSessionId: string | null | undefined
 ): boolean {
+  const id = agentSessionId?.trim() ?? "";
+  const session = id ? state.sessionLifecycle.sessionsById[id] : undefined;
   return selectPendingSubmitsForSession(state, agentSessionId).some(
-    (pending) => pending.status === "accepted"
+    (pending) => {
+      if (pending.status !== "accepted") return false;
+      const turnId = pending.turnId?.trim() ?? "";
+      if (!turnId) return true;
+      const turn =
+        state.sessionLifecycle.turnsById[
+          canonicalTurnKey(pending.agentSessionId, turnId)
+        ];
+      if (turn?.phase === "settled") return false;
+      return session?.activeTurnId === turnId;
+    }
   );
 }
 

--- a/packages/agent/daemon/providerregistry/providers.go
+++ b/packages/agent/daemon/providerregistry/providers.go
@@ -25,7 +25,7 @@ func cursorDescriptor() ProviderDescriptor {
 			AuthRequiredMessage: "Cursor ACP requires authentication; run `cursor-agent login` (or set CURSOR_API_KEY) on the host, then retry this session.",
 			StandardACP: StandardACPRuntimeDescriptor{
 				AdapterStrategy:    StandardACPAdapterStrategyCursor,
-				PermissionModes:    []RuntimePermissionModeDescriptor{{InputID: "read-only", RuntimeID: "plan"}, {InputID: "agent", RuntimeID: "agent"}, {InputID: "full-access", RuntimeID: "agent"}, {InputID: "plan", RuntimeID: "plan"}, {InputID: "ask", RuntimeID: "ask"}},
+				PermissionModes:    []RuntimePermissionModeDescriptor{{InputID: "read-only", RuntimeID: "ask"}, {InputID: "agent", RuntimeID: "agent"}, {InputID: "full-access", RuntimeID: "agent"}, {InputID: "plan", RuntimeID: "plan"}, {InputID: "ask", RuntimeID: "ask"}},
 				PlanModeRuntimeID:  "plan",
 				ProjectCurrentMode: true,
 			},

--- a/packages/agent/daemon/runtime/acp_provider_cursor.go
+++ b/packages/agent/daemon/runtime/acp_provider_cursor.go
@@ -14,7 +14,7 @@ package agentruntime
 // Permissions are exposed as approval tiers (matching the Codex/Claude Code
 // experience) rather than Cursor's raw agent/plan/ask execution modes:
 //
-//	read-only   -> ACP session mode "plan" (reads and proposes, no changes)
+//	read-only   -> ACP session mode "ask" (read/search tools only, no changes)
 //	agent       -> ACP session mode "agent"; Cursor sends
 //	               session/request_permission per risky action (default)
 //	full-access -> ACP session mode "agent"; the client auto-approves every
@@ -58,7 +58,7 @@ const cursorPluginDirEnv = "TUTTI_CURSOR_PLUGIN_DIR"
 func cursorACPModeID(mode string) string {
 	switch strings.TrimSpace(mode) {
 	case cursorPermissionReadOnly:
-		return "plan"
+		return "ask"
 	case cursorPermissionAgent, cursorPermissionFullAccess:
 		return "agent"
 	default:

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -365,7 +365,7 @@ func TestCursorAdapterStartMapsPermissionTiersToACPModes(t *testing.T) {
 	t.Parallel()
 
 	for tier, wantMode := range map[string]string{
-		"read-only":   "plan",
+		"read-only":   "ask",
 		"agent":       "agent",
 		"full-access": "agent",
 	} {
@@ -867,7 +867,7 @@ func TestCursorACPModeID(t *testing.T) {
 	t.Parallel()
 
 	for mode, want := range map[string]string{
-		"read-only":   "plan",
+		"read-only":   "ask",
 		"agent":       "agent",
 		"full-access": "agent",
 		" agent ":     "agent",
@@ -943,6 +943,48 @@ func TestCursorAdapterApplySessionSettingsTogglesPlanMode(t *testing.T) {
 	}
 	if transport.conn.lastModeID() != "agent" {
 		t.Fatalf("mode id = %q, want agent", transport.conn.lastModeID())
+	}
+}
+
+func TestCursorAdapterReadOnlyReturnsFromPlanModeToAsk(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Cursor Agent", "cursor-session-read-only-plan-toggle")
+	adapter := newCursorAdapterWithHostMetadata(transport, LegacyHostMetadata(), nil)
+	session := standardTestSession(ProviderCursor)
+	session.PermissionModeID = cursorPermissionReadOnly
+	session.Settings = &SessionSettings{
+		PermissionModeID: cursorPermissionReadOnly,
+		PlanMode:         false,
+	}
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if transport.conn.lastModeID() != "ask" {
+		t.Fatalf("initial mode id = %q, want ask", transport.conn.lastModeID())
+	}
+
+	session.ProviderSessionID = "cursor-session-read-only-plan-toggle"
+	planMode := true
+	session.Settings.PlanMode = planMode
+	if err := adapter.ApplySessionSettings(context.Background(), session, SessionSettingsPatch{
+		PlanMode: &planMode,
+	}); err != nil {
+		t.Fatalf("ApplySessionSettings plan on: %v", err)
+	}
+	if transport.conn.lastModeID() != "plan" {
+		t.Fatalf("plan mode id = %q, want plan", transport.conn.lastModeID())
+	}
+
+	planMode = false
+	session.Settings.PlanMode = planMode
+	if err := adapter.ApplySessionSettings(context.Background(), session, SessionSettingsPatch{
+		PlanMode: &planMode,
+	}); err != nil {
+		t.Fatalf("ApplySessionSettings plan off: %v", err)
+	}
+	if transport.conn.lastModeID() != "ask" {
+		t.Fatalf("restored mode id = %q, want ask", transport.conn.lastModeID())
 	}
 }
 

--- a/services/tuttid/service/agent/locales/en.json
+++ b/services/tuttid/service/agent/locales/en.json
@@ -35,7 +35,7 @@
     "cursor": {
       "read-only": {
         "label": "Read-only",
-        "description": "Cursor plans and reads only. Proposes changes without making them."
+        "description": "Cursor explores and reads with search tools, without making changes."
       },
       "agent": {
         "label": "Ask for approval",

--- a/services/tuttid/service/agent/locales/zh-CN.json
+++ b/services/tuttid/service/agent/locales/zh-CN.json
@@ -35,7 +35,7 @@
     "cursor": {
       "read-only": {
         "label": "只读",
-        "description": "Cursor 只读取和规划，提出修改建议但不做任何更改。"
+        "description": "Cursor 可使用搜索和读取工具探索项目，但不会进行任何更改"
       },
       "agent": {
         "label": "请求批准",


### PR DESCRIPTION
## Summary

- stop accepted submit intents from keeping the composer busy after their canonical turn settles, clears, or is superseded
- map Cursor's durable read-only permission tier to ACP `ask` while keeping plan mode mapped to ACP `plan`
- add regression coverage, update localized permission descriptions, and document the durable runtime and troubleshooting rules

## Verification

- `pnpm --filter @tutti-os/agent-activity-core test`
- `pnpm typecheck`
- `pnpm lint:ts`
- `pnpm test:go:agent-daemon`
- `pnpm lint:go`
- `pnpm test:go`
- `pnpm build:go`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:i18n`
- `pnpm check:changed`

A pre-push `pnpm check:full` rerun passed preparation and all 12 preflight tasks, then hit a one-off timeout in the unchanged `TestCodexAppServerAdapterCommandApprovalApprove` test. The focused test subsequently passed three consecutive runs with `go test ./runtime -run '^TestCodexAppServerAdapterCommandApprovalApprove$' -count=3`.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two regressions: accepted submit intents no longer keep the composer stuck after the active turn moves on, and Cursor read-only no longer writes files without approval by mapping it to ACP `ask`.

- **Bug Fixes**
  - Composer no longer blocks on an accepted submit once its turn is settled, cleared, or superseded; it only blocks while that turn remains active.
  - Cursor permission mapping: durable `read-only` now maps to ACP `ask`; plan mode remains ACP `plan`, and turning plan off restores the mode from the durable tier. Prevents silent edits and missing approval prompts.
  - Added regression tests in `@tutti-os/agent-activity-core` and daemon; updated troubleshooting/architecture docs and localized permission descriptions.

<sup>Written for commit 27f4af13fefb8246a6c5c49f90f77b8bb8f97cfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

