### PR TITLE
AT 任务按主题分组并支持独立搜索分页

### DIFF
--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
@@ -502,9 +502,16 @@ test("desktop rich text @ service resolves workspace issue query by issue id", a
       ) {
         assert.equal(request?.searchQuery, "issue-restore-1");
         return {
-          issues: [],
+          issues: Array.from({ length: 10 }, (_, index) => ({
+            issueId: `issue-existing-${index + 1}`,
+            status: "open",
+            title: `Existing issue ${index + 1}`,
+            topicId: "topic-1",
+            workspaceId
+          })),
+          nextPageToken: "cursor-2",
           statusCounts: {},
-          totalCount: 0,
+          totalCount: 25,
           workspaceId
         };
       },
@@ -552,7 +559,7 @@ test("desktop rich text @ service resolves workspace issue query by issue id", a
     { issueId: "issue-restore-1", workspaceId: "workspace-1" },
     { issueId: "issue-restore-1", workspaceId: "workspace-1" }
   ]);
-  assert.equal(items.length, 1);
+  assert.equal(items.length, 10);
   assert.equal(provider.getItemKey(items[0]), "issue-restore-1");
   assert.equal(
     provider.getItemIconUrl?.(items[0]),
@@ -562,13 +569,28 @@ test("desktop rich text @ service resolves workspace issue query by issue id", a
     grouped.groups.map((group) => ({
       id: group.id,
       label: group.label,
+      totalCount: group.totalCount,
+      nextCursor: group.nextCursor,
       issueIds: group.items.map((item) => (item as { issueId: string }).issueId)
     })),
     [
       {
         id: "topic-1",
         label: "Default",
-        issueIds: ["issue-restore-1"]
+        totalCount: 25,
+        nextCursor: "cursor-2",
+        issueIds: [
+          "issue-restore-1",
+          "issue-existing-1",
+          "issue-existing-2",
+          "issue-existing-3",
+          "issue-existing-4",
+          "issue-existing-5",
+          "issue-existing-6",
+          "issue-existing-7",
+          "issue-existing-8",
+          "issue-existing-9"
+        ]
       }
     ]
   );

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
@@ -230,7 +230,7 @@ test("desktop rich text @ service assembles workspace issue providers by capabil
   assert.deepEqual(listCalls, [
     {
       workspaceId: "workspace-1",
-      pageSize: 5,
+      pageSize: 10,
       searchQuery: "login",
       topicId: "topic-1"
     }
@@ -274,6 +274,209 @@ test("desktop rich text @ service assembles workspace issue providers by capabil
       }
     }
   );
+});
+
+test("workspace issue provider queries every topic in order and pages one group", async () => {
+  const calls: Array<{
+    topicId: string;
+    pageToken?: string;
+    signal?: AbortSignal;
+  }> = [];
+  const service = new DesktopRichTextAtService({
+    tuttidClient: {
+      async listWorkspaceIssueTopics(
+        workspaceId: string,
+        options?: { signal?: AbortSignal }
+      ) {
+        assert.equal(workspaceId, "workspace-1");
+        assert.ok(options?.signal);
+        return {
+          topics: ["pinned/topic", "recent:topic", "empty-topic"].map(
+            (topicId, index) => ({
+              isDefault: index === 0,
+              summary: "",
+              title: index === 0 ? "Pinned" : index === 1 ? "Recent" : "Empty",
+              topicId,
+              workspaceId
+            })
+          )
+        };
+      },
+      async listWorkspaceIssues(
+        workspaceId: string,
+        request: {
+          pageSize?: number;
+          pageToken?: string;
+          searchQuery?: string;
+          topicId: string;
+        },
+        options?: { signal?: AbortSignal }
+      ) {
+        calls.push({
+          topicId: request.topicId,
+          pageToken: request.pageToken,
+          signal: options?.signal
+        });
+        if (request.topicId === "empty-topic") {
+          return {
+            issues: [],
+            statusCounts: {},
+            totalCount: 0
+          };
+        }
+        const suffix = request.pageToken ? "next" : "first";
+        return {
+          issues: [
+            {
+              content: request.searchQuery,
+              issueId: `issue-${request.topicId}-${suffix}`,
+              status: "open",
+              title: `${request.topicId} ${suffix}`,
+              topicId: request.topicId,
+              workspaceId
+            }
+          ],
+          nextPageToken: request.pageToken
+            ? undefined
+            : `cursor-${request.topicId}`,
+          statusCounts: {},
+          totalCount: 11
+        };
+      }
+    } as unknown as TuttidClient
+  });
+  const provider = service.getProviders({
+    capabilities: ["workspace-issue"],
+    surface: "agent-composer",
+    target: "agent-gui",
+    workspaceId: "workspace-1"
+  })[0];
+  assert.ok(provider?.queryGroups);
+  assert.ok(provider.queryGroupPage);
+  const abortController = new AbortController();
+  const result = await provider.queryGroups({
+    context: {},
+    keyword: "  login   bug ",
+    abortSignal: abortController.signal,
+    trigger: "@"
+  });
+  assert.deepEqual(
+    result.groups.map((group) => ({
+      id: group.id,
+      label: group.label,
+      totalCount: group.totalCount,
+      nextCursor: group.nextCursor
+    })),
+    [
+      {
+        id: "pinned/topic",
+        label: "Pinned",
+        totalCount: 11,
+        nextCursor: "cursor-pinned/topic"
+      },
+      {
+        id: "recent:topic",
+        label: "Recent",
+        totalCount: 11,
+        nextCursor: "cursor-recent:topic"
+      }
+    ]
+  );
+  const page = await provider.queryGroupPage({
+    context: {},
+    keyword: "login bug",
+    groupId: "recent:topic",
+    cursor: "cursor-recent:topic",
+    pageSize: 10,
+    abortSignal: abortController.signal,
+    trigger: "@"
+  });
+  assert.equal(
+    (page.items[0] as { issueId?: string } | undefined)?.issueId,
+    "issue-recent:topic-next"
+  );
+  assert.deepEqual(
+    calls.map((call) => ({
+      topicId: call.topicId,
+      pageToken: call.pageToken,
+      hasSignal: call.signal === abortController.signal
+    })),
+    [
+      { topicId: "pinned/topic", pageToken: undefined, hasSignal: true },
+      { topicId: "recent:topic", pageToken: undefined, hasSignal: true },
+      { topicId: "empty-topic", pageToken: undefined, hasSignal: true },
+      {
+        topicId: "recent:topic",
+        pageToken: "cursor-recent:topic",
+        hasSignal: true
+      }
+    ]
+  );
+});
+
+test("workspace issue provider limits first-page topic concurrency to four", async () => {
+  let active = 0;
+  let maxActive = 0;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const service = new DesktopRichTextAtService({
+    tuttidClient: {
+      async listWorkspaceIssueTopics(workspaceId: string) {
+        return {
+          topics: Array.from({ length: 8 }, (_, index) => ({
+            isDefault: index === 0,
+            summary: "",
+            title: `Topic ${index}`,
+            topicId: `topic-${index}`,
+            workspaceId
+          }))
+        };
+      },
+      async listWorkspaceIssues(
+        workspaceId: string,
+        request: { topicId: string }
+      ) {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await gate;
+        active -= 1;
+        return {
+          issues: [
+            {
+              issueId: `issue-${request.topicId}`,
+              status: "open",
+              title: request.topicId,
+              topicId: request.topicId,
+              workspaceId
+            }
+          ],
+          statusCounts: {},
+          totalCount: 1
+        };
+      }
+    } as unknown as TuttidClient
+  });
+  const provider = service.getProviders({
+    capabilities: ["workspace-issue"],
+    surface: "agent-composer",
+    target: "agent-gui",
+    workspaceId: "workspace-1"
+  })[0];
+  assert.ok(provider?.queryGroups);
+  const pending = provider.queryGroups({
+    context: {},
+    keyword: "",
+    trigger: "@"
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(active, 4);
+  assert.equal(maxActive, 4);
+  release();
+  const result = await pending;
+  assert.equal(result.groups.length, 8);
+  assert.equal(maxActive, 4);
 });
 
 test("desktop rich text @ service resolves workspace issue query by issue id", async () => {
@@ -337,8 +540,16 @@ test("desktop rich text @ service resolves workspace issue query by issue id", a
     maxResults: 5,
     trigger: "@"
   });
+  assert.ok(provider.queryGroups);
+  const grouped = await provider.queryGroups({
+    context: {},
+    keyword: "issue-restore-1",
+    maxResults: 5,
+    trigger: "@"
+  });
 
   assert.deepEqual(detailCalls, [
+    { issueId: "issue-restore-1", workspaceId: "workspace-1" },
     { issueId: "issue-restore-1", workspaceId: "workspace-1" }
   ]);
   assert.equal(items.length, 1);
@@ -346,6 +557,20 @@ test("desktop rich text @ service resolves workspace issue query by issue id", a
   assert.equal(
     provider.getItemIconUrl?.(items[0]),
     "tutti-asset://issue/default.png"
+  );
+  assert.deepEqual(
+    grouped.groups.map((group) => ({
+      id: group.id,
+      label: group.label,
+      issueIds: group.items.map((item) => (item as { issueId: string }).issueId)
+    })),
+    [
+      {
+        id: "topic-1",
+        label: "Default",
+        issueIds: ["issue-restore-1"]
+      }
+    ]
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
@@ -559,7 +559,7 @@ test("desktop rich text @ service resolves workspace issue query by issue id", a
     { issueId: "issue-restore-1", workspaceId: "workspace-1" },
     { issueId: "issue-restore-1", workspaceId: "workspace-1" }
   ]);
-  assert.equal(items.length, 10);
+  assert.equal(items.length, 11);
   assert.equal(provider.getItemKey(items[0]), "issue-restore-1");
   assert.equal(
     provider.getItemIconUrl?.(items[0]),
@@ -589,11 +589,86 @@ test("desktop rich text @ service resolves workspace issue query by issue id", a
           "issue-existing-6",
           "issue-existing-7",
           "issue-existing-8",
-          "issue-existing-9"
+          "issue-existing-9",
+          "issue-existing-10"
         ]
       }
     ]
   );
+});
+
+test("workspace issue compatibility query interleaves topics before global truncation", async () => {
+  const service = new DesktopRichTextAtService({
+    tuttidClient: {
+      async listWorkspaceIssueTopics(workspaceId: string) {
+        return {
+          topics: ["topic-a", "topic-b"].map((topicId) => ({
+            isDefault: topicId === "topic-a",
+            summary: "",
+            title: topicId,
+            topicId,
+            workspaceId
+          }))
+        };
+      },
+      async listWorkspaceIssues(
+        workspaceId: string,
+        request: { topicId: string }
+      ) {
+        const itemCount = request.topicId === "topic-a" ? 10 : 2;
+        return {
+          issues: Array.from({ length: itemCount }, (_, index) => ({
+            issueId: `${request.topicId}-${index + 1}`,
+            status: "open",
+            title: `${request.topicId} issue ${index + 1}`,
+            topicId: request.topicId,
+            workspaceId
+          })),
+          statusCounts: {},
+          totalCount: itemCount
+        };
+      },
+      async getWorkspaceIssueDetail(workspaceId: string, issueId: string) {
+        return {
+          issue: {
+            issueId,
+            status: "open",
+            title: "Exact issue",
+            topicId: "topic-b",
+            workspaceId
+          },
+          tasks: []
+        };
+      }
+    } as unknown as TuttidClient
+  });
+  const provider = service.getProviders({
+    capabilities: ["workspace-issue"],
+    surface: "agent-composer",
+    target: "agent-gui",
+    workspaceId: "workspace-1"
+  })[0];
+  assert.ok(provider);
+
+  const items = await provider.query({
+    context: {},
+    keyword: "",
+    maxResults: 5,
+    trigger: "@"
+  });
+
+  assert.deepEqual(
+    items.slice(0, 5).map((item) => provider.getItemKey(item)),
+    ["topic-a-1", "topic-b-1", "topic-a-2", "topic-b-2", "topic-a-3"]
+  );
+
+  const exactItems = await provider.query({
+    context: {},
+    keyword: "issue-exact",
+    maxResults: 5,
+    trigger: "@"
+  });
+  assert.equal(provider.getItemKey(exactItems[0]), "issue-exact");
 });
 
 test("desktop rich text @ service assembles agent session providers by capability", async () => {

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.ts
@@ -15,8 +15,7 @@ import {
 import type { RichTextTriggerProvider } from "@tutti-os/ui-rich-text/types";
 import {
   tuttiFileAssetUrls,
-  tuttiFolderAssetUrls,
-  tuttiIssueAssetUrls
+  tuttiFolderAssetUrls
 } from "../../../../../../shared/tuttiAssetProtocol.ts";
 import type { IAgentsService } from "../../../workspace-agent/services/agentsService.interface";
 import { resolveDesktopWorkspaceAppDefaultIconUrl } from "../../../../../../shared/workspaceAppIconDefaults.ts";
@@ -42,6 +41,7 @@ import {
   scopeString,
   type DesktopRichTextAtContributor
 } from "./desktopRichTextAtMentionSupport.ts";
+import { createWorkspaceIssueAtContributor } from "./desktopWorkspaceIssueAtContributor.ts";
 
 export interface DesktopRichTextAtServiceDependencies {
   agentsService?: Pick<IAgentsService, "load">;
@@ -67,16 +67,6 @@ interface WorkspaceFileAtItem {
   kind?: "directory" | "file" | (string & {});
   name?: string | null;
   path: string;
-}
-
-interface WorkspaceIssueAtItem {
-  content?: string | null;
-  creatorDisplayName?: string | null;
-  issueId: string;
-  status?: string | null;
-  title: string;
-  topicId: string;
-  workspaceId: string;
 }
 
 interface WorkspaceAppAtItem {
@@ -111,8 +101,7 @@ interface BuiltInWorkspaceAppResource {
 const {
   agentSession: AGENT_SESSION_PROVIDER_ID,
   file: FILE_PROVIDER_ID,
-  workspaceApp: WORKSPACE_APP_PROVIDER_ID,
-  workspaceIssue: WORKSPACE_ISSUE_PROVIDER_ID
+  workspaceApp: WORKSPACE_APP_PROVIDER_ID
 } = AGENT_CONTEXT_MENTION_PROVIDER_IDS;
 
 export class DesktopRichTextAtService implements IDesktopRichTextAtService {
@@ -614,146 +603,4 @@ function workspaceFileIconUrl(item: WorkspaceFileAtItem): string {
   return item.kind === "directory"
     ? tuttiFolderAssetUrls.default
     : tuttiFileAssetUrls.default;
-}
-
-function createWorkspaceIssueAtContributor(
-  tuttidClient: TuttidClient
-): DesktopRichTextAtContributor {
-  return {
-    capability: "workspace-issue",
-    getProviders(input) {
-      return [
-        createRichTextTriggerProvider<WorkspaceIssueAtItem>({
-          id: WORKSPACE_ISSUE_PROVIDER_ID,
-          trigger: "@",
-          async query(searchInput) {
-            if (searchInput.abortSignal?.aborted) {
-              return [];
-            }
-            const topicResponse = await tuttidClient.listWorkspaceIssueTopics(
-              input.workspaceId
-            );
-            if (searchInput.abortSignal?.aborted) {
-              return [];
-            }
-            const topicId = topicResponse.topics[0]?.topicId;
-            if (!topicId) {
-              return [];
-            }
-            const response = await tuttidClient.listWorkspaceIssues(
-              input.workspaceId,
-              {
-                pageSize: searchInput.maxResults,
-                searchQuery: searchInput.keyword,
-                topicId
-              }
-            );
-            if (searchInput.abortSignal?.aborted) {
-              return [];
-            }
-            const items = response.issues.map(workspaceIssueAtItemFromIssue);
-            const issueId = workspaceIssueIdSearchKeyword(searchInput.keyword);
-            if (!issueId || items.some((item) => item.issueId === issueId)) {
-              return items;
-            }
-            const detail = await getWorkspaceIssueDetailSafely(
-              tuttidClient,
-              input.workspaceId,
-              issueId
-            );
-            if (!detail) {
-              return items;
-            }
-            if (searchInput.abortSignal?.aborted) {
-              return [];
-            }
-            return [workspaceIssueAtItemFromIssue(detail.issue), ...items];
-          },
-          getItemKey: (item) => item.issueId,
-          getItemLabel: (item) => item.title,
-          getItemSubtitle: (item) =>
-            [item.status, item.creatorDisplayName, item.content]
-              .map((value) => value?.trim() ?? "")
-              .filter(Boolean)
-              .join(" · "),
-          getItemIconUrl: () => tuttiIssueAssetUrls.default,
-          toInsertResult(item) {
-            return createDesktopRichTextMentionInsertResult({
-              entityId: item.issueId,
-              label: item.title,
-              scope: compactStringRecord({
-                topicId: item.topicId,
-                workspaceId: item.workspaceId
-              }),
-              presentation: compactMentionPresentation({
-                description: item.content?.trim() ?? "",
-                iconUrl: tuttiIssueAssetUrls.default,
-                status: item.status?.trim() ?? ""
-              })
-            });
-          },
-          async resolveMention(identity) {
-            const workspaceId = scopeString(identity.scope, "workspaceId");
-            if (!workspaceId) {
-              return null;
-            }
-            return resolveMentionSafely(async () => {
-              const response = await tuttidClient.getWorkspaceIssueDetail(
-                workspaceId,
-                identity.entityId
-              );
-              const issue = response.issue;
-              return {
-                label: issue.title,
-                presentation: compactMentionPresentation({
-                  description: issue.content,
-                  iconUrl: tuttiIssueAssetUrls.default,
-                  status: issue.status
-                })
-              };
-            });
-          }
-        })
-      ];
-    }
-  };
-}
-
-async function getWorkspaceIssueDetailSafely(
-  tuttidClient: TuttidClient,
-  workspaceId: string,
-  issueId: string
-): Promise<Awaited<
-  ReturnType<TuttidClient["getWorkspaceIssueDetail"]>
-> | null> {
-  try {
-    return await tuttidClient.getWorkspaceIssueDetail(workspaceId, issueId);
-  } catch {
-    return null;
-  }
-}
-
-function workspaceIssueAtItemFromIssue(issue: {
-  content?: string | null;
-  creatorDisplayName?: string | null;
-  issueId: string;
-  status?: string | null;
-  title: string;
-  topicId: string;
-  workspaceId: string;
-}): WorkspaceIssueAtItem {
-  return {
-    content: issue.content,
-    creatorDisplayName: issue.creatorDisplayName,
-    issueId: issue.issueId,
-    status: issue.status,
-    title: issue.title,
-    topicId: issue.topicId,
-    workspaceId: issue.workspaceId
-  };
-}
-
-function workspaceIssueIdSearchKeyword(keyword: string): string | null {
-  const issueId = keyword.trim();
-  return /^issue-[A-Za-z0-9_-]+$/.test(issueId) ? issueId : null;
 }

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopWorkspaceIssueAtContributor.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopWorkspaceIssueAtContributor.ts
@@ -1,0 +1,296 @@
+import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
+import { AGENT_CONTEXT_MENTION_PROVIDER_IDS } from "@tutti-os/agent-gui/context-mention-provider";
+import { createRichTextTriggerProvider } from "@tutti-os/ui-rich-text/plugins";
+import type {
+  RichTextTriggerQueryGroup,
+  RichTextTriggerQueryInput
+} from "@tutti-os/ui-rich-text/types";
+import { tuttiIssueAssetUrls } from "../../../../../../shared/tuttiAssetProtocol.ts";
+import {
+  compactMentionPresentation,
+  compactStringRecord,
+  createDesktopRichTextMentionInsertResult,
+  resolveMentionSafely,
+  scopeString,
+  type DesktopRichTextAtContributor
+} from "./desktopRichTextAtMentionSupport.ts";
+
+interface WorkspaceIssueAtItem {
+  content?: string | null;
+  creatorDisplayName?: string | null;
+  issueId: string;
+  status?: string | null;
+  title: string;
+  topicId: string;
+  workspaceId: string;
+}
+
+const WORKSPACE_ISSUE_PROVIDER_ID =
+  AGENT_CONTEXT_MENTION_PROVIDER_IDS.workspaceIssue;
+const WORKSPACE_ISSUE_MENTION_PAGE_SIZE = 10;
+const WORKSPACE_ISSUE_TOPIC_QUERY_CONCURRENCY = 4;
+
+export function createWorkspaceIssueAtContributor(
+  tuttidClient: TuttidClient
+): DesktopRichTextAtContributor {
+  return {
+    capability: "workspace-issue",
+    getProviders(input) {
+      return [
+        createRichTextTriggerProvider<WorkspaceIssueAtItem>({
+          id: WORKSPACE_ISSUE_PROVIDER_ID,
+          trigger: "@",
+          async query(searchInput) {
+            const result = await queryWorkspaceIssueMentionGroups({
+              tuttidClient,
+              workspaceId: input.workspaceId,
+              searchInput
+            });
+            return result.flatMap((group) => group.items);
+          },
+          async queryGroups(searchInput) {
+            return {
+              groups: await queryWorkspaceIssueMentionGroups({
+                tuttidClient,
+                workspaceId: input.workspaceId,
+                searchInput
+              })
+            };
+          },
+          async queryGroupPage(searchInput) {
+            if (searchInput.abortSignal?.aborted) {
+              return emptyWorkspaceIssueMentionGroup(searchInput.groupId);
+            }
+            const response = await tuttidClient.listWorkspaceIssues(
+              input.workspaceId,
+              {
+                pageSize: searchInput.pageSize,
+                pageToken: searchInput.cursor,
+                searchQuery: normalizeWorkspaceIssueSearchQuery(
+                  searchInput.keyword
+                ),
+                topicId: searchInput.groupId
+              },
+              { signal: searchInput.abortSignal }
+            );
+            if (searchInput.abortSignal?.aborted) {
+              return emptyWorkspaceIssueMentionGroup(searchInput.groupId);
+            }
+            return {
+              id: searchInput.groupId,
+              label: searchInput.groupId,
+              items: response.issues.map(workspaceIssueAtItemFromIssue),
+              totalCount: response.totalCount,
+              ...(response.nextPageToken
+                ? { nextCursor: response.nextPageToken }
+                : {})
+            };
+          },
+          getItemKey: (item) => item.issueId,
+          getItemLabel: (item) => item.title,
+          getItemSubtitle: (item) =>
+            [item.status, item.creatorDisplayName, item.content]
+              .map((value) => value?.trim() ?? "")
+              .filter(Boolean)
+              .join(" · "),
+          getItemIconUrl: () => tuttiIssueAssetUrls.default,
+          toInsertResult(item) {
+            return createDesktopRichTextMentionInsertResult({
+              entityId: item.issueId,
+              label: item.title,
+              scope: compactStringRecord({
+                topicId: item.topicId,
+                workspaceId: item.workspaceId
+              }),
+              presentation: compactMentionPresentation({
+                description: item.content?.trim() ?? "",
+                iconUrl: tuttiIssueAssetUrls.default,
+                status: item.status?.trim() ?? ""
+              })
+            });
+          },
+          async resolveMention(identity) {
+            const workspaceId = scopeString(identity.scope, "workspaceId");
+            if (!workspaceId) {
+              return null;
+            }
+            return resolveMentionSafely(async () => {
+              const response = await tuttidClient.getWorkspaceIssueDetail(
+                workspaceId,
+                identity.entityId
+              );
+              const issue = response.issue;
+              return {
+                label: issue.title,
+                presentation: compactMentionPresentation({
+                  description: issue.content,
+                  iconUrl: tuttiIssueAssetUrls.default,
+                  status: issue.status
+                })
+              };
+            });
+          }
+        })
+      ];
+    }
+  };
+}
+
+async function queryWorkspaceIssueMentionGroups(input: {
+  tuttidClient: TuttidClient;
+  workspaceId: string;
+  searchInput: RichTextTriggerQueryInput;
+}): Promise<RichTextTriggerQueryGroup<WorkspaceIssueAtItem>[]> {
+  const { searchInput, tuttidClient, workspaceId } = input;
+  if (searchInput.abortSignal?.aborted) {
+    return [];
+  }
+  const topicResponse = await tuttidClient.listWorkspaceIssueTopics(
+    workspaceId,
+    { signal: searchInput.abortSignal }
+  );
+  if (searchInput.abortSignal?.aborted) {
+    return [];
+  }
+  const searchQuery = normalizeWorkspaceIssueSearchQuery(searchInput.keyword);
+  const groups = await mapWithConcurrency(
+    topicResponse.topics,
+    WORKSPACE_ISSUE_TOPIC_QUERY_CONCURRENCY,
+    async (topic): Promise<RichTextTriggerQueryGroup<WorkspaceIssueAtItem>> => {
+      const response = await tuttidClient.listWorkspaceIssues(
+        workspaceId,
+        {
+          pageSize: WORKSPACE_ISSUE_MENTION_PAGE_SIZE,
+          searchQuery,
+          topicId: topic.topicId
+        },
+        { signal: searchInput.abortSignal }
+      );
+      return {
+        id: topic.topicId,
+        label: topic.title,
+        items: response.issues.map(workspaceIssueAtItemFromIssue),
+        totalCount: response.totalCount,
+        ...(response.nextPageToken
+          ? { nextCursor: response.nextPageToken }
+          : {})
+      };
+    }
+  );
+  if (searchInput.abortSignal?.aborted) {
+    return [];
+  }
+
+  const issueId = workspaceIssueIdSearchKeyword(searchQuery);
+  if (
+    issueId &&
+    !groups.some((group) =>
+      group.items.some((item) => item.issueId === issueId)
+    )
+  ) {
+    const detail = await getWorkspaceIssueDetailSafely(
+      tuttidClient,
+      workspaceId,
+      issueId
+    );
+    if (detail && !searchInput.abortSignal?.aborted) {
+      const item = workspaceIssueAtItemFromIssue(detail.issue);
+      const groupIndex = groups.findIndex((group) => group.id === item.topicId);
+      if (groupIndex >= 0) {
+        const group = groups[groupIndex];
+        if (!group) {
+          return groups.filter((candidate) => candidate.items.length > 0);
+        }
+        groups[groupIndex] = {
+          ...group,
+          items: [
+            item,
+            ...group.items.filter(
+              (candidate) => candidate.issueId !== item.issueId
+            )
+          ].slice(0, WORKSPACE_ISSUE_MENTION_PAGE_SIZE)
+        };
+      } else {
+        groups.push({
+          id: item.topicId,
+          label: item.topicId,
+          items: [item],
+          totalCount: 1
+        });
+      }
+    }
+  }
+
+  return groups.filter((group) => group.items.length > 0);
+}
+
+function emptyWorkspaceIssueMentionGroup(
+  topicId: string
+): RichTextTriggerQueryGroup<WorkspaceIssueAtItem> {
+  return { id: topicId, label: topicId, items: [], totalCount: 0 };
+}
+
+function normalizeWorkspaceIssueSearchQuery(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+async function mapWithConcurrency<TInput, TOutput>(
+  inputs: readonly TInput[],
+  concurrency: number,
+  mapper: (input: TInput) => Promise<TOutput>
+): Promise<TOutput[]> {
+  const results = new Map<number, TOutput>();
+  let nextIndex = 0;
+  const worker = async (): Promise<void> => {
+    while (nextIndex < inputs.length) {
+      const index = nextIndex++;
+      results.set(index, await mapper(inputs[index] as TInput));
+    }
+  };
+  await Promise.all(
+    Array.from(
+      { length: Math.min(Math.max(1, concurrency), inputs.length) },
+      worker
+    )
+  );
+  return inputs.map((_, index) => results.get(index) as TOutput);
+}
+
+async function getWorkspaceIssueDetailSafely(
+  tuttidClient: TuttidClient,
+  workspaceId: string,
+  issueId: string
+): Promise<Awaited<
+  ReturnType<TuttidClient["getWorkspaceIssueDetail"]>
+> | null> {
+  try {
+    return await tuttidClient.getWorkspaceIssueDetail(workspaceId, issueId);
+  } catch {
+    return null;
+  }
+}
+
+function workspaceIssueAtItemFromIssue(issue: {
+  content?: string | null;
+  creatorDisplayName?: string | null;
+  issueId: string;
+  status?: string | null;
+  title: string;
+  topicId: string;
+  workspaceId: string;
+}): WorkspaceIssueAtItem {
+  return {
+    content: issue.content,
+    creatorDisplayName: issue.creatorDisplayName,
+    issueId: issue.issueId,
+    status: issue.status,
+    title: issue.title,
+    topicId: issue.topicId,
+    workspaceId: issue.workspaceId
+  };
+}
+
+function workspaceIssueIdSearchKeyword(keyword: string): string | null {
+  const issueId = keyword.trim();
+  return /^issue-[A-Za-z0-9_-]+$/.test(issueId) ? issueId : null;
+}

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopWorkspaceIssueAtContributor.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopWorkspaceIssueAtContributor.ts
@@ -41,12 +41,17 @@ export function createWorkspaceIssueAtContributor(
           id: WORKSPACE_ISSUE_PROVIDER_ID,
           trigger: "@",
           async query(searchInput) {
-            const result = await queryWorkspaceIssueMentionGroups({
+            const groups = await queryWorkspaceIssueMentionGroups({
               tuttidClient,
               workspaceId: input.workspaceId,
               searchInput
             });
-            return result.flatMap((group) => group.items);
+            return mergeWorkspaceIssueMentionGroups(
+              groups,
+              workspaceIssueIdSearchKeyword(
+                normalizeWorkspaceIssueSearchQuery(searchInput.keyword)
+              )
+            );
           },
           async queryGroups(searchInput) {
             return {
@@ -201,14 +206,16 @@ async function queryWorkspaceIssueMentionGroups(input: {
         if (!group) {
           return groups.filter((candidate) => candidate.items.length > 0);
         }
+        const items = [
+          item,
+          ...group.items.filter(
+            (candidate) => candidate.issueId !== item.issueId
+          )
+        ];
         groups[groupIndex] = {
           ...group,
-          items: [
-            item,
-            ...group.items.filter(
-              (candidate) => candidate.issueId !== item.issueId
-            )
-          ].slice(0, WORKSPACE_ISSUE_MENTION_PAGE_SIZE)
+          items,
+          totalCount: Math.max(group.totalCount, items.length)
         };
       } else {
         groups.push({
@@ -222,6 +229,39 @@ async function queryWorkspaceIssueMentionGroups(input: {
   }
 
   return groups.filter((group) => group.items.length > 0);
+}
+
+function mergeWorkspaceIssueMentionGroups(
+  groups: readonly RichTextTriggerQueryGroup<WorkspaceIssueAtItem>[],
+  exactIssueId: string | null
+): WorkspaceIssueAtItem[] {
+  const items: WorkspaceIssueAtItem[] = [];
+  const seenIssueIds = new Set<string>();
+  if (exactIssueId) {
+    const exactItem = groups
+      .flatMap((group) => group.items)
+      .find((item) => item.issueId === exactIssueId);
+    if (exactItem) {
+      items.push(exactItem);
+      seenIssueIds.add(exactItem.issueId);
+    }
+  }
+
+  const maxGroupLength = Math.max(
+    0,
+    ...groups.map((group) => group.items.length)
+  );
+  for (let itemIndex = 0; itemIndex < maxGroupLength; itemIndex += 1) {
+    for (const group of groups) {
+      const item = group.items[itemIndex];
+      if (!item || seenIssueIds.has(item.issueId)) {
+        continue;
+      }
+      items.push(item);
+      seenIssueIds.add(item.issueId);
+    }
+  }
+  return items;
 }
 
 function emptyWorkspaceIssueMentionGroup(

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -3091,6 +3091,34 @@ App ids, descriptions, scopes, and CLI command metadata may enrich presentation
 or routing, but they must not produce search results that the visible app name
 cannot explain.
 
+Workspace-issue candidates use the rich-text provider's optional grouped query
+contract. The desktop provider first lists every daemon-ordered issue topic,
+loads each topic's first page with bounded concurrency, and returns one
+provider-owned group per non-empty topic. AgentGUI encodes the opaque topic id
+into a dynamic `issue-topic:*` presentation key, then atomically replaces the
+ordered group list for each debounced search. Each group owns its items,
+query-scoped total, cursor, and load-more status; loading or retrying one topic
+must not replace sibling groups or put the whole palette into loading state.
+
+```text
+Agent mention query identity
+  -> desktop workspace-issue grouped provider
+  -> daemon-ordered topic list
+  -> bounded first-page issue queries
+  -> atomic AgentGUI topic-group projection
+  -> one-topic cursor requests from expand actions
+```
+
+Browse topic groups participate in the existing 30-second
+stale-while-revalidate cache and shared in-flight dedupe. Successful browse
+pages merge into the cached topic group so reopening the palette preserves
+appended rows. Search groups remain request-scoped. Query, filter, workspace,
+close, and dispose transitions invalidate old first-page and page requests;
+`AbortSignal` is propagated through the desktop provider to the tuttid topic
+and issue-list requests, while request identity and cursor checks remain the
+final stale-response defense. Group metadata never changes the persisted
+`workspace-issue` mention URI or scope.
+
 Quick check:
 
 ```sh

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
@@ -26,6 +26,8 @@ vi.mock("../../i18n/index", async () => {
       "暂无已打开或 Agent 生成的文件，继续输入文件名可搜索本机文件",
     "agentHost.agentGui.contextPickerBrowseSessionHint":
       "输入内容以搜索我发起的 Agent 会话",
+    "agentHost.agentGui.contextPickerLoadMoreLoading": "正在加载",
+    "agentHost.agentGui.contextPickerLoadMoreRetry": "加载失败，重试",
     "agentHost.agentGui.mentionGroupOpenedFiles": "我打开的文件",
     "agentHost.agentGui.mentionGroupAgentGeneratedFiles": "Agent 生成的文件",
     "agentHost.agentGui.mentionAgentGeneratedFolderBack": "返回",
@@ -1555,5 +1557,71 @@ describe("AgentFileMentionPalette", () => {
       2,
       "opened_files:file:/workspace/assets/demo.png"
     );
+  });
+
+  it("renders dynamic task topic labels and isolated load-more states", () => {
+    const onExpandGroup = vi.fn();
+    const baseGroup = {
+      id: "issue-topic:topic%2Fone",
+      label: "Pinned topic",
+      items: [
+        {
+          kind: "workspace-issue" as const,
+          href: "mention://workspace-issue/issue-1?workspaceId=room-1&topicId=topic%2Fone",
+          workspaceId: "room-1",
+          targetId: "issue-1",
+          name: "Fix pagination",
+          title: "Fix pagination",
+          status: "running"
+        }
+      ],
+      totalCount: 11,
+      visibleCount: 1,
+      hasMore: true
+    };
+    const state: AgentMentionSearchState = {
+      status: "ready",
+      query: "",
+      mode: "browse",
+      filter: "issue",
+      categories: [],
+      groups: [{ ...baseGroup, expandStatus: "loading" }],
+      error: null
+    };
+    const props = {
+      highlightedKey: "expand:issue-topic:topic%2Fone",
+      label: "mention palette",
+      loadingLabel: "loading",
+      emptyLabel: "empty",
+      errorLabel: "error",
+      tabHintLabel: "hint",
+      maxHeightPx: 320,
+      onHighlightChange: vi.fn(),
+      onSelectItem: vi.fn(),
+      onSelectCategory: vi.fn(),
+      onSelectFilter: vi.fn(),
+      onExpandGroup
+    };
+    const { rerender } = render(
+      <AgentFileMentionPalette {...props} state={state} />
+    );
+
+    expect(screen.getByText("Pinned topic")).toBeVisible();
+    expect(screen.getByRole("button", { name: "正在加载" })).toBeDisabled();
+    expect(screen.getByText("Fix pagination")).toBeVisible();
+
+    rerender(
+      <AgentFileMentionPalette
+        {...props}
+        state={{
+          ...state,
+          groups: [{ ...baseGroup, expandStatus: "error" }]
+        }}
+      />
+    );
+    const retry = screen.getByRole("button", { name: "加载失败，重试" });
+    expect(retry).toBeEnabled();
+    fireEvent.click(retry);
+    expect(onExpandGroup).toHaveBeenCalledWith("issue-topic:topic%2Fone");
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
@@ -349,7 +349,11 @@ function decorateMentionGroup(
   });
   return {
     ...group,
-    label: showLabel ? agentMentionGroupLabel(groupId) : undefined,
+    label: showLabel
+      ? groupId.startsWith("issue-topic:")
+        ? group.label
+        : agentMentionGroupLabel(groupId)
+      : undefined,
     emptyLabel: suppressChrome
       ? undefined
       : agentMentionEmptyGroupLabel(groupId, query),
@@ -358,6 +362,12 @@ function decorateMentionGroup(
           count: mentionGroupExpandCount(group, filter)
         })
       : undefined,
+    expandLoadingLabel: translate(
+      "agentHost.agentGui.contextPickerLoadMoreLoading"
+    ),
+    expandErrorLabel: translate(
+      "agentHost.agentGui.contextPickerLoadMoreRetry"
+    ),
     sectionClassName: followsMySessions ? "mt-2" : undefined,
     hideTopDivider: suppressChrome
   };

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionIssueTopicGroups.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionIssueTopicGroups.spec.ts
@@ -294,6 +294,77 @@ describe("AgentMentionSearchController issue topic groups", () => {
     expect(queryGroups).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves a page that completes while stale browse data revalidates", async () => {
+    let now = 1_000;
+    const refresh = deferred<RichTextTriggerGroupedQueryResult<TestIssue>>();
+    const queryGroups = vi
+      .fn()
+      .mockResolvedValueOnce(
+        groupedResult([
+          {
+            id: "topic/one",
+            label: "Pinned",
+            items: [issue("issue-1", "topic/one")],
+            totalCount: 2,
+            nextCursor: "cursor-1"
+          }
+        ])
+      )
+      .mockReturnValueOnce(refresh.promise);
+    const provider = groupedIssueProvider({
+      queryGroups,
+      queryGroupPage: vi.fn(async () => ({
+        id: "topic/one",
+        label: "Pinned",
+        items: [issue("issue-2", "topic/one")],
+        totalCount: 2
+      }))
+    });
+    const controller = new AgentMentionSearchController({
+      browseCacheTtlMs: 0,
+      contextMentionProviders: [provider],
+      diagnosticNow: () => now
+    });
+    const states: AgentMentionSearchState[] = [];
+    controller.subscribe((state) => states.push(state));
+    controller.setFilter("issue");
+    controller.updateQuery({ workspaceId: "workspace-1", query: "" });
+    await vi.waitFor(() => expect(states.at(-1)?.status).toBe("ready"));
+
+    controller.close();
+    now += 1;
+    controller.updateQuery({ workspaceId: "workspace-1", query: "" });
+    controller.setFilter("issue");
+    await vi.waitFor(() => expect(queryGroups).toHaveBeenCalledTimes(2));
+    controller.expandGroup("issue-topic:topic%2Fone");
+    await vi.waitFor(() =>
+      expect(states.at(-1)?.groups[0]?.items).toHaveLength(2)
+    );
+
+    refresh.resolve(
+      groupedResult([
+        {
+          id: "topic/one",
+          label: "Pinned refreshed",
+          items: [issue("issue-1", "topic/one")],
+          totalCount: 2,
+          nextCursor: "cursor-1"
+        }
+      ])
+    );
+
+    await vi.waitFor(() =>
+      expect(states.at(-1)?.groups[0]).toMatchObject({
+        label: "Pinned refreshed",
+        hasMore: false,
+        items: [
+          expect.objectContaining({ targetId: "issue-1" }),
+          expect.objectContaining({ targetId: "issue-2" })
+        ]
+      })
+    );
+  });
+
   it("loads search pages with the active query and cursor while preserving stable entry keys", async () => {
     vi.useFakeTimers();
     const initialItems = Array.from({ length: 10 }, (_, index) =>

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionIssueTopicGroups.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionIssueTopicGroups.spec.ts
@@ -1,0 +1,570 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  RichTextTriggerGroupPageQueryInput,
+  RichTextTriggerGroupedQueryResult,
+  RichTextTriggerQueryInput
+} from "@tutti-os/ui-rich-text/types";
+import type { AgentContextMentionProvider } from "./agentContextMentionProvider";
+import { AGENT_CONTEXT_MENTION_PROVIDER_IDS } from "./agentContextMentionProvider";
+import {
+  AgentMentionSearchController,
+  resetAgentMentionSearchBrowseCacheForTests,
+  type AgentMentionSearchState
+} from "./AgentMentionSearchController";
+import { flattenAgentMentionPaletteEntries } from "./AgentFileMentionPalette";
+import { mentionGroupExpandCount } from "./agentMentionSearchHelpers";
+
+interface TestIssue {
+  issueId: string;
+  status: string;
+  title: string;
+  topicId: string;
+  workspaceId: string;
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+function issue(issueId: string, topicId: string): TestIssue {
+  return {
+    issueId,
+    status: "open",
+    title: issueId,
+    topicId,
+    workspaceId: "workspace-1"
+  };
+}
+
+function groupedIssueProvider(input: {
+  queryGroups: NonNullable<
+    AgentContextMentionProvider<TestIssue>["queryGroups"]
+  >;
+  queryGroupPage?: NonNullable<
+    AgentContextMentionProvider<TestIssue>["queryGroupPage"]
+  >;
+}): AgentContextMentionProvider<TestIssue> {
+  return {
+    id: AGENT_CONTEXT_MENTION_PROVIDER_IDS.workspaceIssue,
+    trigger: "@",
+    query: async () => [],
+    queryGroups: input.queryGroups,
+    ...(input.queryGroupPage ? { queryGroupPage: input.queryGroupPage } : {}),
+    getItemKey: (item) => item.issueId,
+    getItemLabel: (item) => item.title,
+    toInsertResult: (item) => ({
+      kind: "mention",
+      mention: {
+        entityId: item.issueId,
+        label: item.title,
+        scope: {
+          topicId: item.topicId,
+          workspaceId: item.workspaceId
+        },
+        presentation: { status: item.status }
+      }
+    })
+  };
+}
+
+function groupedResult(
+  groups: RichTextTriggerGroupedQueryResult<TestIssue>["groups"]
+): RichTextTriggerGroupedQueryResult<TestIssue> {
+  return { groups };
+}
+
+function abortError(): Error {
+  const error = new Error("aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+describe("AgentMentionSearchController issue topic groups", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    resetAgentMentionSearchBrowseCacheForTests();
+  });
+
+  it("atomically replaces search groups, encodes dynamic ids, and rejects an aborted stale search", async () => {
+    vi.useFakeTimers();
+    const first = deferred<RichTextTriggerGroupedQueryResult<TestIssue>>();
+    const second = deferred<RichTextTriggerGroupedQueryResult<TestIssue>>();
+    const signals: AbortSignal[] = [];
+    const queryGroups = vi.fn(
+      ({ abortSignal, keyword }: RichTextTriggerQueryInput) => {
+        signals.push(abortSignal!);
+        return keyword === "first" ? first.promise : second.promise;
+      }
+    );
+    const controller = new AgentMentionSearchController({
+      contextMentionProviders: [groupedIssueProvider({ queryGroups })]
+    });
+    const states: AgentMentionSearchState[] = [];
+    controller.subscribe((state) => states.push(state));
+    controller.setFilter("issue");
+
+    controller.updateQuery({ workspaceId: "workspace-1", query: "first" });
+    await vi.advanceTimersByTimeAsync(120);
+    expect(queryGroups).toHaveBeenCalledTimes(1);
+
+    controller.updateQuery({ workspaceId: "workspace-1", query: "second" });
+    expect(signals[0]?.aborted).toBe(true);
+    await vi.advanceTimersByTimeAsync(120);
+    expect(queryGroups).toHaveBeenCalledTimes(2);
+    expect(states.at(-1)?.status).toBe("loading");
+    expect(
+      states.at(-1)?.groups.some((group) => group.id.startsWith("issue-topic:"))
+    ).toBe(false);
+
+    first.resolve(
+      groupedResult([
+        {
+          id: "stale/topic",
+          label: "Stale",
+          items: [issue("stale-1", "stale/topic")],
+          totalCount: 1
+        }
+      ])
+    );
+    second.resolve(
+      groupedResult([
+        {
+          id: "topic/one",
+          label: "Pinned",
+          items: [issue("issue-1", "topic/one")],
+          totalCount: 11,
+          nextCursor: "cursor-1"
+        },
+        {
+          id: "topic:two",
+          label: "Recent",
+          items: [issue("issue-2", "topic:two")],
+          totalCount: 1
+        }
+      ])
+    );
+
+    await vi.waitFor(() =>
+      expect(states.at(-1)).toMatchObject({
+        status: "ready",
+        query: "second",
+        groups: [
+          {
+            id: "issue-topic:topic%2Fone",
+            label: "Pinned",
+            totalCount: 11,
+            hasMore: true,
+            items: [expect.objectContaining({ targetId: "issue-1" })]
+          },
+          {
+            id: "issue-topic:topic%3Atwo",
+            label: "Recent",
+            totalCount: 1,
+            hasMore: false,
+            items: [expect.objectContaining({ targetId: "issue-2" })]
+          }
+        ]
+      })
+    );
+    expect(states.at(-1)?.groups.some((group) => group.label === "Stale")).toBe(
+      false
+    );
+  });
+
+  it("keeps rows ready during load more, dedupes clicks and items, retries failures, and restores the browse cache", async () => {
+    const failedPage = deferred<{
+      id: string;
+      label: string;
+      items: TestIssue[];
+      totalCount: number;
+      nextCursor?: string;
+    }>();
+    const retryPage = deferred<{
+      id: string;
+      label: string;
+      items: TestIssue[];
+      totalCount: number;
+      nextCursor?: string;
+    }>();
+    const queryGroups = vi.fn(async () =>
+      groupedResult([
+        {
+          id: "topic/one",
+          label: "Pinned",
+          items: [issue("issue-1", "topic/one")],
+          totalCount: 2,
+          nextCursor: "cursor-1"
+        },
+        {
+          id: "topic:two",
+          label: "Recent",
+          items: [issue("issue-3", "topic:two")],
+          totalCount: 1
+        }
+      ])
+    );
+    const pageSignals: AbortSignal[] = [];
+    let pageCallCount = 0;
+    const queryGroupPage = vi.fn(
+      (input: RichTextTriggerGroupPageQueryInput) => {
+        pageSignals.push(input.abortSignal!);
+        pageCallCount += 1;
+        return pageCallCount === 1 ? failedPage.promise : retryPage.promise;
+      }
+    );
+    const provider = groupedIssueProvider({ queryGroups, queryGroupPage });
+    const controller = new AgentMentionSearchController({
+      contextMentionProviders: [provider]
+    });
+    const states: AgentMentionSearchState[] = [];
+    controller.subscribe((state) => states.push(state));
+    controller.setFilter("issue");
+    controller.updateQuery({ workspaceId: "workspace-1", query: "" });
+
+    await vi.waitFor(() => expect(states.at(-1)?.status).toBe("ready"));
+    const groupId = "issue-topic:topic%2Fone";
+    controller.expandGroup(groupId);
+    controller.expandGroup(groupId);
+    await vi.waitFor(() => expect(queryGroupPage).toHaveBeenCalledTimes(1));
+    expect(states.at(-1)).toMatchObject({
+      status: "ready",
+      groups: [
+        {
+          id: groupId,
+          expandStatus: "loading",
+          items: [expect.objectContaining({ targetId: "issue-1" })]
+        },
+        expect.objectContaining({ id: "issue-topic:topic%3Atwo" })
+      ]
+    });
+
+    failedPage.reject(new Error("page unavailable"));
+    await vi.waitFor(() =>
+      expect(states.at(-1)?.groups[0]).toMatchObject({
+        id: groupId,
+        expandStatus: "error",
+        hasMore: true
+      })
+    );
+
+    controller.expandGroup(groupId);
+    await vi.waitFor(() => expect(queryGroupPage).toHaveBeenCalledTimes(2));
+    retryPage.resolve({
+      id: "topic/one",
+      label: "topic/one",
+      items: [issue("issue-1", "topic/one"), issue("issue-2", "topic/one")],
+      totalCount: 2
+    });
+    await vi.waitFor(() =>
+      expect(states.at(-1)?.groups[0]).toMatchObject({
+        id: groupId,
+        expandStatus: "idle",
+        hasMore: false,
+        items: [
+          expect.objectContaining({ targetId: "issue-1" }),
+          expect.objectContaining({ targetId: "issue-2" })
+        ]
+      })
+    );
+    expect(pageSignals.every((signal) => !signal.aborted)).toBe(true);
+
+    controller.close();
+    const restored = new AgentMentionSearchController({
+      contextMentionProviders: [provider]
+    });
+    const restoredStates: AgentMentionSearchState[] = [];
+    restored.subscribe((state) => restoredStates.push(state));
+    restored.setFilter("issue");
+    restored.updateQuery({ workspaceId: "workspace-1", query: "" });
+    await vi.waitFor(() =>
+      expect(restoredStates.at(-1)?.groups[0]?.items).toHaveLength(2)
+    );
+    expect(queryGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads search pages with the active query and cursor while preserving stable entry keys", async () => {
+    vi.useFakeTimers();
+    const initialItems = Array.from({ length: 10 }, (_, index) =>
+      issue(`issue-${index + 1}`, "topic/one")
+    );
+    const queryGroups = vi.fn(async () =>
+      groupedResult([
+        {
+          id: "topic/one",
+          label: "Pinned",
+          items: initialItems,
+          totalCount: 25,
+          nextCursor: "cursor-1"
+        }
+      ])
+    );
+    const queryGroupPage = vi.fn(
+      async ({ cursor }: RichTextTriggerGroupPageQueryInput) => ({
+        id: "topic/one",
+        label: "Pinned",
+        items: Array.from(
+          { length: cursor === "cursor-1" ? 10 : 5 },
+          (_, index) =>
+            issue(
+              `issue-${index + (cursor === "cursor-1" ? 11 : 21)}`,
+              "topic/one"
+            )
+        ),
+        totalCount: 25,
+        ...(cursor === "cursor-1" ? { nextCursor: "cursor-2" } : {})
+      })
+    );
+    const controller = new AgentMentionSearchController({
+      contextMentionProviders: [
+        groupedIssueProvider({ queryGroups, queryGroupPage })
+      ]
+    });
+    const states: AgentMentionSearchState[] = [];
+    controller.subscribe((state) => states.push(state));
+    controller.setFilter("issue");
+    controller.updateQuery({ workspaceId: "workspace-1", query: " needle " });
+    await vi.advanceTimersByTimeAsync(120);
+    await vi.waitFor(() => expect(states.at(-1)?.status).toBe("ready"));
+
+    const initialState = states.at(-1)!;
+    const initialGroup = initialState.groups[0]!;
+    const initialEntryKeys = flattenAgentMentionPaletteEntries(
+      initialState
+    ).map((entry) => entry.key);
+    expect(mentionGroupExpandCount(initialGroup, "issue")).toBe(10);
+
+    controller.expandGroup("issue-topic:topic%2Fone");
+    await vi.waitFor(() => expect(queryGroupPage).toHaveBeenCalledTimes(1));
+    expect(queryGroupPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        keyword: "needle",
+        groupId: "topic/one",
+        cursor: "cursor-1",
+        pageSize: 10
+      })
+    );
+    await vi.waitFor(() =>
+      expect(states.at(-1)?.groups[0]?.visibleCount).toBe(20)
+    );
+
+    const pagedState = states.at(-1)!;
+    const pagedGroup = pagedState.groups[0]!;
+    const pagedEntryKeys = flattenAgentMentionPaletteEntries(pagedState).map(
+      (entry) => entry.key
+    );
+    expect(pagedGroup).toMatchObject({
+      totalCount: 25,
+      visibleCount: 20,
+      hasMore: true,
+      expandStatus: "idle"
+    });
+    expect(mentionGroupExpandCount(pagedGroup, "issue")).toBe(5);
+    expect(pagedEntryKeys.slice(0, initialItems.length)).toEqual(
+      initialEntryKeys.slice(0, initialItems.length)
+    );
+    expect(pagedEntryKeys.at(-1)).toBe("expand:issue-topic:topic%2Fone");
+
+    controller.expandGroup("issue-topic:topic%2Fone");
+    await vi.waitFor(() => expect(queryGroupPage).toHaveBeenCalledTimes(2));
+    expect(queryGroupPage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        keyword: "needle",
+        groupId: "topic/one",
+        cursor: "cursor-2",
+        pageSize: 10
+      })
+    );
+    await vi.waitFor(() =>
+      expect(states.at(-1)?.groups[0]).toMatchObject({
+        totalCount: 25,
+        visibleCount: 25,
+        hasMore: false
+      })
+    );
+  });
+
+  it("cancels orphaned initial browse requests on every controller identity change", async () => {
+    const runCase = async (
+      suffix: string,
+      change: (controller: AgentMentionSearchController) => void
+    ): Promise<void> => {
+      const signals: AbortSignal[] = [];
+      const provider = groupedIssueProvider({
+        queryGroups: vi.fn(
+          ({ abortSignal }: RichTextTriggerQueryInput) =>
+            new Promise<RichTextTriggerGroupedQueryResult<TestIssue>>(
+              (_resolve, reject) => {
+                signals.push(abortSignal!);
+                abortSignal?.addEventListener(
+                  "abort",
+                  () => reject(abortError()),
+                  { once: true }
+                );
+              }
+            )
+        )
+      });
+      const controller = new AgentMentionSearchController({
+        contextMentionProviders: [provider]
+      });
+      controller.setFilter("issue");
+      controller.updateQuery({
+        workspaceId: `workspace-${suffix}`,
+        query: ""
+      });
+      await vi.waitFor(() => expect(signals).toHaveLength(1));
+
+      change(controller);
+      expect(signals[0]?.aborted).toBe(true);
+      controller.dispose();
+      resetAgentMentionSearchBrowseCacheForTests();
+    };
+
+    await runCase("workspace", (controller) =>
+      controller.updateQuery({ workspaceId: "workspace-next", query: "" })
+    );
+    await runCase("category", (controller) => controller.setFilter("app"));
+    await runCase("query", (controller) =>
+      controller.updateQuery({
+        workspaceId: "workspace-query",
+        query: "needle"
+      })
+    );
+    await runCase("close", (controller) => controller.close());
+    await runCase("dispose", (controller) => controller.dispose());
+  });
+
+  it("keeps a shared browse request alive until its final consumer closes", async () => {
+    let providerSignal: AbortSignal | undefined;
+    const queryGroups = vi.fn(
+      ({ abortSignal }: RichTextTriggerQueryInput) =>
+        new Promise<RichTextTriggerGroupedQueryResult<TestIssue>>(
+          (_resolve, reject) => {
+            providerSignal = abortSignal;
+            abortSignal?.addEventListener("abort", () => reject(abortError()), {
+              once: true
+            });
+          }
+        )
+    );
+    const provider = groupedIssueProvider({ queryGroups });
+    const first = new AgentMentionSearchController({
+      contextMentionProviders: [provider]
+    });
+    const second = new AgentMentionSearchController({
+      contextMentionProviders: [provider]
+    });
+    for (const controller of [first, second]) {
+      controller.setFilter("issue");
+      controller.updateQuery({ workspaceId: "workspace-shared", query: "" });
+    }
+    await vi.waitFor(() => expect(queryGroups).toHaveBeenCalledTimes(1));
+
+    first.close();
+    expect(providerSignal?.aborted).toBe(false);
+    second.close();
+    expect(providerSignal?.aborted).toBe(true);
+  });
+
+  it("aborts a pending topic page when the search query changes and ignores its late result", async () => {
+    vi.useFakeTimers();
+    const page = deferred<{
+      id: string;
+      label: string;
+      items: TestIssue[];
+      totalCount: number;
+    }>();
+    let pageSignal: AbortSignal | undefined;
+    const provider = groupedIssueProvider({
+      queryGroups: vi.fn(async ({ keyword }: RichTextTriggerQueryInput) =>
+        groupedResult([
+          {
+            id: "topic/one",
+            label: "Pinned",
+            items: [issue(`${keyword || "browse"}-1`, "topic/one")],
+            totalCount: 2,
+            nextCursor: "cursor-1"
+          }
+        ])
+      ),
+      queryGroupPage: vi.fn((input) => {
+        pageSignal = input.abortSignal;
+        return page.promise;
+      })
+    });
+    const controller = new AgentMentionSearchController({
+      contextMentionProviders: [provider]
+    });
+    const states: AgentMentionSearchState[] = [];
+    controller.subscribe((state) => states.push(state));
+    controller.setFilter("issue");
+    controller.updateQuery({ workspaceId: "workspace-1", query: "" });
+    await vi.waitFor(() => expect(states.at(-1)?.status).toBe("ready"));
+
+    controller.expandGroup("issue-topic:topic%2Fone");
+    await vi.waitFor(() => expect(pageSignal?.aborted).toBe(false));
+    controller.updateQuery({ workspaceId: "workspace-1", query: "new" });
+    expect(pageSignal?.aborted).toBe(true);
+    await vi.advanceTimersByTimeAsync(120);
+    page.resolve({
+      id: "topic/one",
+      label: "Pinned",
+      items: [issue("late-2", "topic/one")],
+      totalCount: 2
+    });
+
+    await vi.waitFor(() =>
+      expect(states.at(-1)).toMatchObject({
+        status: "ready",
+        query: "new",
+        groups: [
+          {
+            items: [expect.objectContaining({ targetId: "new-1" })]
+          }
+        ]
+      })
+    );
+    expect(
+      states
+        .at(-1)
+        ?.groups[0]?.items.some(
+          (item) =>
+            item.kind === "workspace-issue" && item.targetId === "late-2"
+        )
+    ).toBe(false);
+  });
+
+  it("surfaces an initial grouped provider failure as the existing global error state", async () => {
+    const controller = new AgentMentionSearchController({
+      contextMentionProviders: [
+        groupedIssueProvider({
+          queryGroups: vi.fn().mockRejectedValue(new Error("topics failed"))
+        })
+      ]
+    });
+    const states: AgentMentionSearchState[] = [];
+    controller.subscribe((state) => states.push(state));
+    controller.setFilter("issue");
+    controller.updateQuery({ workspaceId: "workspace-1", query: "" });
+
+    await vi.waitFor(() =>
+      expect(states.at(-1)).toMatchObject({
+        status: "error",
+        groups: [],
+        error: "topics failed"
+      })
+    );
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionLabels.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionLabels.ts
@@ -5,6 +5,9 @@ import type {
 } from "./AgentMentionSearchController";
 
 export function agentMentionGroupLabel(groupId: AgentMentionGroupId): string {
+  if (groupId.startsWith("issue-topic:")) {
+    return "";
+  }
   switch (groupId) {
     case "apps":
       return translate("agentHost.agentGui.mentionGroupApps");
@@ -22,6 +25,8 @@ export function agentMentionGroupLabel(groupId: AgentMentionGroupId): string {
       return translate("agentHost.agentGui.mentionGroupCollabSessions");
     case "issues":
       return translate("agentHost.agentGui.mentionGroupIssues");
+    default:
+      return "";
   }
 }
 
@@ -44,6 +49,9 @@ export function agentMentionEmptyGroupLabel(
   groupId: AgentMentionGroupId,
   query: string
 ): string {
+  if (groupId.startsWith("issue-topic:")) {
+    return "";
+  }
   if (groupId === "files" || groupId === "opened_files") {
     return query.trim()
       ? translate("agentHost.agentGui.mentionNoMatchingFiles")

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchCache.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchCache.ts
@@ -29,9 +29,16 @@ const sharedAgentMentionBrowseCache = new Map<
   string,
   AgentMentionBrowseCacheEntry
 >();
+interface SharedAgentMentionBrowseFetch {
+  abortController: AbortController;
+  consumers: Set<symbol>;
+  promise: Promise<AgentMentionBrowseFetchResult> | null;
+  settled: boolean;
+}
+
 const sharedAgentMentionBrowseFetches = new Map<
   string,
-  Promise<AgentMentionBrowseFetchResult>
+  SharedAgentMentionBrowseFetch
 >();
 
 // Bound the shared browse cache so long-lived renderer sessions cannot grow it
@@ -133,6 +140,9 @@ export function scheduleAgentMentionIdleTask(task: () => void): () => void {
 
 export function resetAgentMentionSearchBrowseCacheForTests(): void {
   sharedAgentMentionBrowseCache.clear();
+  for (const fetch of sharedAgentMentionBrowseFetches.values()) {
+    fetch.abortController.abort();
+  }
   sharedAgentMentionBrowseFetches.clear();
 }
 
@@ -157,7 +167,10 @@ export async function loadAgentMentionBrowseFetchResult(input: {
   reason: AgentMentionBrowseLoadReason;
   diagnosticNow: () => number;
   providerIds: string;
-  fetchBrowseResult: () => Promise<AgentMentionBrowseFetchResult>;
+  abortSignal?: AbortSignal;
+  fetchBrowseResult: (
+    abortSignal: AbortSignal
+  ) => Promise<AgentMentionBrowseFetchResult>;
   logLifecycle: (
     event: AgentMentionLifecycleDiagnosticLog["event"],
     details: AgentMentionLifecycleDiagnosticLog["details"]
@@ -165,46 +178,122 @@ export async function loadAgentMentionBrowseFetchResult(input: {
 }): Promise<AgentMentionBrowseFetchResult> {
   const { cacheKey, reason } = input;
   const browseInput = input.input;
-  const existingFetch = sharedAgentMentionBrowseFetches.get(cacheKey);
-  if (existingFetch) {
+  let sharedFetch = sharedAgentMentionBrowseFetches.get(cacheKey);
+  if (sharedFetch) {
     input.logLifecycle("browse.fetch.dedupe", {
       filter: browseInput.filter,
       reason,
       workspaceId: browseInput.workspaceId
     });
-    return existingFetch;
-  }
-  const startedAt = input.diagnosticNow();
-  input.logLifecycle("browse.fetch.start", {
-    filter: browseInput.filter,
-    providerIds: input.providerIds,
-    reason,
-    workspaceId: browseInput.workspaceId
-  });
-  const fetchPromise = input
-    .fetchBrowseResult()
-    .then((result) => {
-      writeBrowseCacheEntry(cacheKey, {
-        ...result,
-        cachedAt: input.diagnosticNow()
-      });
-      input.logLifecycle("browse.fetch.success", {
-        durationMs: elapsedDiagnosticMs(input.diagnosticNow(), startedAt),
-        filter: browseInput.filter,
-        itemCount: rawGroupItemCount(result.rawGroups),
-        providerResults: providerDiagnosticsSummary(result.providerDiagnostics),
-        reason,
-        workspaceId: browseInput.workspaceId
-      });
-      return result;
-    })
-    .finally(() => {
-      if (sharedAgentMentionBrowseFetches.get(cacheKey) === fetchPromise) {
-        sharedAgentMentionBrowseFetches.delete(cacheKey);
-      }
+  } else {
+    const startedAt = input.diagnosticNow();
+    input.logLifecycle("browse.fetch.start", {
+      filter: browseInput.filter,
+      providerIds: input.providerIds,
+      reason,
+      workspaceId: browseInput.workspaceId
     });
-  sharedAgentMentionBrowseFetches.set(cacheKey, fetchPromise);
-  return fetchPromise;
+    const abortController = new AbortController();
+    sharedFetch = {
+      abortController,
+      consumers: new Set(),
+      promise: null,
+      settled: false
+    };
+    const entry = sharedFetch;
+    entry.promise = input
+      .fetchBrowseResult(abortController.signal)
+      .then((result) => {
+        if (abortController.signal.aborted) {
+          const error = new Error("Mention browse request aborted");
+          error.name = "AbortError";
+          throw error;
+        }
+        writeBrowseCacheEntry(cacheKey, {
+          ...result,
+          cachedAt: input.diagnosticNow()
+        });
+        input.logLifecycle("browse.fetch.success", {
+          durationMs: elapsedDiagnosticMs(input.diagnosticNow(), startedAt),
+          filter: browseInput.filter,
+          itemCount: rawGroupItemCount(result.rawGroups),
+          providerResults: providerDiagnosticsSummary(
+            result.providerDiagnostics
+          ),
+          reason,
+          workspaceId: browseInput.workspaceId
+        });
+        return result;
+      })
+      .finally(() => {
+        entry.settled = true;
+        if (sharedAgentMentionBrowseFetches.get(cacheKey) === entry) {
+          sharedAgentMentionBrowseFetches.delete(cacheKey);
+        }
+      });
+    sharedAgentMentionBrowseFetches.set(cacheKey, entry);
+  }
+
+  return consumeSharedBrowseFetch({
+    abortSignal: input.abortSignal,
+    cacheKey,
+    sharedFetch
+  });
+}
+
+function consumeSharedBrowseFetch(input: {
+  abortSignal?: AbortSignal;
+  cacheKey: string;
+  sharedFetch: SharedAgentMentionBrowseFetch;
+}): Promise<AgentMentionBrowseFetchResult> {
+  const consumer = Symbol(input.cacheKey);
+  input.sharedFetch.consumers.add(consumer);
+  const sharedPromise = input.sharedFetch.promise;
+  if (!sharedPromise) {
+    input.sharedFetch.consumers.delete(consumer);
+    return Promise.reject(new Error("Mention browse request was not started"));
+  }
+
+  return new Promise((resolve, reject) => {
+    let finished = false;
+    const finish = (settle: () => void, abortWhenUnused: boolean): void => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      input.abortSignal?.removeEventListener("abort", onAbort);
+      input.sharedFetch.consumers.delete(consumer);
+      if (
+        abortWhenUnused &&
+        !input.sharedFetch.settled &&
+        input.sharedFetch.consumers.size === 0
+      ) {
+        if (
+          sharedAgentMentionBrowseFetches.get(input.cacheKey) ===
+          input.sharedFetch
+        ) {
+          sharedAgentMentionBrowseFetches.delete(input.cacheKey);
+        }
+        input.sharedFetch.abortController.abort();
+      }
+      settle();
+    };
+    const onAbort = (): void => {
+      const error = new Error("Mention browse request aborted");
+      error.name = "AbortError";
+      finish(() => reject(error), true);
+    };
+
+    if (input.abortSignal?.aborted) {
+      onAbort();
+      return;
+    }
+    input.abortSignal?.addEventListener("abort", onAbort, { once: true });
+    sharedPromise.then(
+      (result) => finish(() => resolve(result), false),
+      (error: unknown) => finish(() => reject(error), false)
+    );
+  });
 }
 
 export function readAgentMentionBrowseCache(input: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchCache.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchCache.ts
@@ -1,6 +1,7 @@
 import type { AgentMentionProviderQueryDiagnostic } from "./agentMentionSearchDiagnostics";
 import type {
   AgentMentionFilterId,
+  AgentMentionIssueTopicGroup,
   AgentMentionLifecycleDiagnosticLog,
   AgentMentionRawGroups,
   AgentMentionTotalCounts
@@ -15,6 +16,7 @@ export interface AgentMentionBrowseFetchResult {
   providerDiagnostics: AgentMentionProviderQueryDiagnostic[];
   rawGroups: AgentMentionRawGroups;
   totalCounts: AgentMentionTotalCounts;
+  issueTopicGroups: AgentMentionIssueTopicGroup[] | null;
 }
 
 export interface AgentMentionBrowseCacheEntry extends AgentMentionBrowseFetchResult {
@@ -52,6 +54,60 @@ function writeBrowseCacheEntry(
     }
     sharedAgentMentionBrowseCache.delete(oldestKey);
   }
+}
+
+export function mergeAgentMentionBrowseIssueGroupPage(input: {
+  cacheKey: string;
+  group: AgentMentionIssueTopicGroup;
+  cachedAt: number;
+}): void {
+  const entry = sharedAgentMentionBrowseCache.get(input.cacheKey);
+  if (!entry?.issueTopicGroups) {
+    return;
+  }
+  const groupIndex = entry.issueTopicGroups.findIndex(
+    (group) => group.id === input.group.id
+  );
+  if (groupIndex < 0) {
+    return;
+  }
+  const previous = entry.issueTopicGroups[groupIndex];
+  if (!previous) {
+    return;
+  }
+  const seen = new Set(
+    previous.items
+      .filter((item) => item.kind === "workspace-issue")
+      .map((item) => item.targetId)
+  );
+  const appended = input.group.items.filter((item) => {
+    if (item.kind !== "workspace-issue") {
+      return true;
+    }
+    if (seen.has(item.targetId)) {
+      return false;
+    }
+    seen.add(item.targetId);
+    return true;
+  });
+  const mergedItems = [...previous.items, ...appended];
+  const groups = entry.issueTopicGroups.map((group, index) =>
+    index === groupIndex
+      ? {
+          ...previous,
+          items: mergedItems,
+          totalCount: Math.max(input.group.totalCount, mergedItems.length),
+          nextPageToken: input.group.nextPageToken,
+          loadMoreStatus: "idle" as const,
+          loadMoreError: null
+        }
+      : group
+  );
+  writeBrowseCacheEntry(input.cacheKey, {
+    ...entry,
+    issueTopicGroups: groups,
+    cachedAt: input.cachedAt
+  });
 }
 
 // Defer speculative warm-up to a browser idle slot so it never blocks the

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchContracts.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchContracts.ts
@@ -16,7 +16,7 @@ export type AgentMentionFilterId =
   | "issue"
   | "agent"
   | "app";
-export type AgentMentionGroupId =
+export type AgentMentionStaticGroupId =
   | "apps"
   | "agents"
   | "files"
@@ -25,8 +25,14 @@ export type AgentMentionGroupId =
   | "my_sessions"
   | "collab_sessions"
   | "issues";
+export type AgentMentionGroupId =
+  | AgentMentionStaticGroupId
+  | `issue-topic:${string}`;
 
-export type AgentMentionRawGroupId = Exclude<AgentMentionGroupId, "files">;
+export type AgentMentionRawGroupId = Exclude<
+  AgentMentionStaticGroupId,
+  "files"
+>;
 export type AgentMentionRawGroups = Record<
   AgentMentionRawGroupId,
   AgentContextMentionItem[]
@@ -34,6 +40,17 @@ export type AgentMentionRawGroups = Record<
 export type AgentMentionTotalCounts = Partial<
   Record<AgentMentionGroupId, number>
 >;
+
+export interface AgentMentionIssueTopicGroup {
+  id: `issue-topic:${string}`;
+  providerGroupId: string;
+  label: string;
+  items: AgentContextMentionItem[];
+  totalCount: number;
+  nextPageToken: string | null;
+  loadMoreStatus: "idle" | "loading" | "error";
+  loadMoreError: string | null;
+}
 
 export interface AgentMentionBrowseCategory {
   id: AgentMentionFilterId;

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
@@ -1204,16 +1204,18 @@ describe("AgentMentionSearchController", () => {
     expect(queryWorkspaceApps).toHaveBeenCalledTimes(1);
   });
 
-  it("dedupes in-flight browse loads across close and reopen", async () => {
-    let resolveFiles: (value: {
-      workspaceId: string;
-      root: string;
-      entries: { path: string; name: string; kind: string }[];
-    }) => void = () => undefined;
+  it("cancels an orphaned browse load and refetches after reopen", async () => {
+    const resolveFiles: Array<
+      (value: {
+        workspaceId: string;
+        root: string;
+        entries: { path: string; name: string; kind: string }[];
+      }) => void
+    > = [];
     const queryFiles = vi.fn(
       () =>
         new Promise((resolve) => {
-          resolveFiles = resolve;
+          resolveFiles.push(resolve);
         })
     );
     const controller = new AgentMentionSearchController({
@@ -1237,11 +1239,11 @@ describe("AgentMentionSearchController", () => {
     controller.updateQuery({ workspaceId: "room-1", query: "" });
     await vi.waitFor(() => expect(queryFiles).toHaveBeenCalledTimes(1));
     controller.close();
-    controller.setFilter("file");
     controller.updateQuery({ workspaceId: "room-1", query: "" });
-    expect(queryFiles).toHaveBeenCalledTimes(1);
+    controller.setFilter("file");
+    await vi.waitFor(() => expect(queryFiles).toHaveBeenCalledTimes(2));
 
-    resolveFiles({
+    resolveFiles[1]?.({
       workspaceId: "room-1",
       root: "/workspace",
       entries: [
@@ -1270,19 +1272,21 @@ describe("AgentMentionSearchController", () => {
         ])
       })
     );
-    expect(queryFiles).toHaveBeenCalledTimes(1);
+    expect(queryFiles).toHaveBeenCalledTimes(2);
   });
 
-  it("dedupes in-flight browse loads across agent GUI controller recreation", async () => {
-    let resolveFiles: (value: {
-      workspaceId: string;
-      root: string;
-      entries: { path: string; name: string; kind: string }[];
-    }) => void = () => undefined;
+  it("cancels an orphaned browse load and refetches after controller recreation", async () => {
+    const resolveFiles: Array<
+      (value: {
+        workspaceId: string;
+        root: string;
+        entries: { path: string; name: string; kind: string }[];
+      }) => void
+    > = [];
     const queryFiles = vi.fn(
       () =>
         new Promise((resolve) => {
-          resolveFiles = resolve;
+          resolveFiles.push(resolve);
         })
     );
     const providerOptions: TestContextMentionProviderOptions = {
@@ -1315,9 +1319,9 @@ describe("AgentMentionSearchController", () => {
     secondController.subscribe((state) => secondStates.push(state));
     secondController.setFilter("file");
     secondController.updateQuery({ workspaceId: "room-1", query: "" });
-    expect(queryFiles).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(queryFiles).toHaveBeenCalledTimes(2));
 
-    resolveFiles({
+    resolveFiles[1]?.({
       workspaceId: "room-1",
       root: "/workspace",
       entries: [
@@ -1346,7 +1350,7 @@ describe("AgentMentionSearchController", () => {
         ])
       })
     );
-    expect(queryFiles).toHaveBeenCalledTimes(1);
+    expect(queryFiles).toHaveBeenCalledTimes(2);
   });
 
   it("debounces grouped searches and returns file results", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.ts
@@ -8,16 +8,23 @@ import type { AgentContextMentionItem } from "./agentRichText/agentFileMentionEx
 import type { AgentContextMentionProvider } from "./agentContextMentionProvider";
 import {
   buildBrowseCategories,
+  WORKSPACE_ISSUE_PROVIDER_ID,
   type AgentMentionFilterId,
   type AgentMentionGroupId,
   type AgentMentionSearchListener
 } from "./AgentMentionSearchContracts";
 import {
   scheduleAgentMentionIdleTask,
+  mergeAgentMentionBrowseIssueGroupPage,
   MAX_BROWSE_CACHE_ENTRIES,
   resetAgentMentionSearchBrowseCacheForTests
 } from "./AgentMentionSearchCache";
 import { diagnosticErrorKind } from "./AgentMentionSearchModel";
+import {
+  queryAgentMentionProviderWithDiagnostics,
+  type AgentMentionProviderQueryDiagnostic
+} from "./agentMentionSearchDiagnostics";
+import { queryAgentMentionProviderGroupPage } from "./AgentMentionSearchIndex";
 import { AgentMentionSearchControllerBase } from "./AgentMentionSearchControllerBase";
 import type { ReferenceProvenanceFilter } from "@tutti-os/workspace-file-reference/contracts";
 import { referenceProvenanceFilterCacheKey } from "@tutti-os/workspace-file-reference/core";
@@ -32,6 +39,11 @@ export type {
 export { MAX_BROWSE_CACHE_ENTRIES, resetAgentMentionSearchBrowseCacheForTests };
 
 export class AgentMentionSearchController extends AgentMentionSearchControllerBase {
+  private readonly issueLoadMoreRequests = new Map<
+    string,
+    { abortController: AbortController; token: symbol }
+  >();
+
   setProvenanceFilter(filter: ReferenceProvenanceFilter | null): void {
     const previousKey = this.currentProvenanceFilter
       ? referenceProvenanceFilterCacheKey(this.currentProvenanceFilter)
@@ -72,6 +84,8 @@ export class AgentMentionSearchController extends AgentMentionSearchControllerBa
     this.currentSessionCwd = input.sessionCwd?.trim() ?? "";
     this.currentQuery = normalizeQuery(input.query);
     this.clearTimer();
+    this.abortActiveRequest();
+    this.cancelIssueLoadMoreRequests();
     const requestId = ++this.requestId;
     this.resetAgentGeneratedBrowsePath();
     this.resetExpandedCounts();
@@ -105,13 +119,17 @@ export class AgentMentionSearchController extends AgentMentionSearchControllerBa
       groups: this.groupsFromRawGroups(),
       error: null
     });
+    const abortSignal = this.beginActiveRequest();
     this.timer = this.scheduler.schedule(this.debounceMs, () => {
       void this.runSearch({
         workspaceId: this.activeWorkspaceId,
         currentUserId: this.currentUserId,
         query: this.currentQuery,
         requestId,
-        filter: this.currentFilter
+        filter: this.currentFilter,
+        provenanceFilter: this.currentProvenanceFilter,
+        sessionCwd: this.currentSessionCwd,
+        abortSignal
       });
     });
   }
@@ -122,6 +140,8 @@ export class AgentMentionSearchController extends AgentMentionSearchControllerBa
     }
     this.currentFilter = filter;
     this.clearTimer();
+    this.abortActiveRequest();
+    this.cancelIssueLoadMoreRequests();
     const requestId = ++this.requestId;
     this.resetAgentGeneratedBrowsePath();
     this.resetExpandedCounts();
@@ -152,12 +172,16 @@ export class AgentMentionSearchController extends AgentMentionSearchControllerBa
       groups: this.groupsFromRawGroups(),
       error: null
     });
+    const abortSignal = this.beginActiveRequest();
     void this.runSearch({
       workspaceId: this.activeWorkspaceId,
       currentUserId: this.currentUserId,
       query: this.currentQuery,
       requestId,
-      filter
+      filter,
+      provenanceFilter: this.currentProvenanceFilter,
+      sessionCwd: this.currentSessionCwd,
+      abortSignal
     });
   }
 
@@ -327,6 +351,10 @@ export class AgentMentionSearchController extends AgentMentionSearchControllerBa
   }
 
   expandGroup(groupId: AgentMentionGroupId): void {
+    if (groupId.startsWith("issue-topic:")) {
+      this.loadMoreIssueTopic(groupId as `issue-topic:${string}`);
+      return;
+    }
     const pageSize = mentionGroupPageSize(this.currentFilter, groupId);
     const current = this.expandedCounts[groupId] ?? pageSize;
     this.expandedCounts[groupId] = current + pageSize;
@@ -362,6 +390,7 @@ export class AgentMentionSearchController extends AgentMentionSearchControllerBa
     }
     if (needsMoreFiles || needsMoreIssues) {
       this.clearTimer();
+      this.abortActiveRequest();
       const requestId = ++this.requestId;
       this.setState({
         status: "loading",
@@ -372,12 +401,16 @@ export class AgentMentionSearchController extends AgentMentionSearchControllerBa
         groups: this.groupsFromRawGroups(),
         error: null
       });
+      const abortSignal = this.beginActiveRequest();
       void this.runSearch({
         workspaceId: this.activeWorkspaceId,
         currentUserId: this.currentUserId,
         query: this.currentQuery,
         requestId,
-        filter: this.currentFilter
+        filter: this.currentFilter,
+        provenanceFilter: this.currentProvenanceFilter,
+        sessionCwd: this.currentSessionCwd,
+        abortSignal
       });
       return;
     }
@@ -394,6 +427,8 @@ export class AgentMentionSearchController extends AgentMentionSearchControllerBa
 
   close(): void {
     this.clearTimer();
+    this.abortActiveRequest();
+    this.cancelIssueLoadMoreRequests();
     this.requestId += 1;
     this.currentFilter = DEFAULT_AGENT_MENTION_FILTER;
     this.resetAgentGeneratedBrowsePath();
@@ -415,9 +450,167 @@ export class AgentMentionSearchController extends AgentMentionSearchControllerBa
   dispose(): void {
     this.disposed = true;
     this.clearTimer();
+    this.abortActiveRequest();
+    this.cancelIssueLoadMoreRequests();
     this.cancelPendingPreload();
     this.listeners.clear();
     this.requestId += 1;
+  }
+
+  private loadMoreIssueTopic(groupId: `issue-topic:${string}`): void {
+    const group = this.issueTopicGroups?.find(
+      (candidate) => candidate.id === groupId
+    );
+    const cursor = group?.nextPageToken;
+    const provider = this.contextMentionProviders.get(
+      WORKSPACE_ISSUE_PROVIDER_ID
+    );
+    if (!group || !cursor || !provider?.queryGroupPage) {
+      return;
+    }
+    const requestKey = JSON.stringify({
+      workspaceId: this.activeWorkspaceId,
+      query: this.currentQuery,
+      providerGroupId: group.providerGroupId,
+      cursor
+    });
+    if (this.issueLoadMoreRequests.has(requestKey)) {
+      return;
+    }
+    const requestId = this.requestId;
+    const workspaceId = this.activeWorkspaceId;
+    const currentUserId = this.currentUserId;
+    const sessionCwd = this.currentSessionCwd;
+    const provenanceFilter = this.currentProvenanceFilter;
+    const query = this.currentQuery;
+    const filter = this.currentFilter;
+    const abortController = new AbortController();
+    const requestToken = Symbol(requestKey);
+    group.loadMoreStatus = "loading";
+    group.loadMoreError = null;
+    this.emitIssueTopicGroupsState();
+
+    void (async () => {
+      try {
+        const diagnostics: AgentMentionProviderQueryDiagnostic[] = [];
+        const page = await queryAgentMentionProviderWithDiagnostics({
+          abortSignal: abortController.signal,
+          diagnosticNow: this.diagnosticNow,
+          diagnostics,
+          fallback: null,
+          providerId: WORKSPACE_ISSUE_PROVIDER_ID,
+          providerTimeoutMs: this.providerTimeoutMs,
+          throwOnTimeout: true,
+          query: (abortSignal) =>
+            queryAgentMentionProviderGroupPage({
+              provider,
+              providerGroupId: group.providerGroupId,
+              workspaceId,
+              currentUserId,
+              query,
+              cursor,
+              pageSize: DEFAULT_MENTION_GROUP_PAGE_SIZE,
+              sessionCwd,
+              abortSignal,
+              provenanceFilter
+            }),
+          resultCount: (result) => result?.items.length ?? 0
+        });
+        if (
+          !page ||
+          !this.canApply(requestId, workspaceId, query, filter) ||
+          abortController.signal.aborted
+        ) {
+          return;
+        }
+        const current = this.issueTopicGroups?.find(
+          (candidate) => candidate.id === groupId
+        );
+        if (!current || current.nextPageToken !== cursor) {
+          return;
+        }
+        const seen = new Set(
+          current.items
+            .filter((item) => item.kind === "workspace-issue")
+            .map((item) => item.targetId)
+        );
+        const appended = page.items.filter((item) => {
+          if (item.kind !== "workspace-issue") {
+            return true;
+          }
+          if (seen.has(item.targetId)) {
+            return false;
+          }
+          seen.add(item.targetId);
+          return true;
+        });
+        current.items = [...current.items, ...appended];
+        current.totalCount = Math.max(page.totalCount, current.items.length);
+        current.nextPageToken = page.nextPageToken;
+        current.loadMoreStatus = "idle";
+        current.loadMoreError = null;
+        if (!query) {
+          mergeAgentMentionBrowseIssueGroupPage({
+            cacheKey: this.browseCacheKey(
+              {
+                workspaceId,
+                currentUserId,
+                filter,
+                sessionCwd
+              },
+              provenanceFilter
+            ),
+            group: page,
+            cachedAt: this.diagnosticNow()
+          });
+        }
+        this.emitIssueTopicGroupsState();
+      } catch (error) {
+        if (
+          !this.canApply(requestId, workspaceId, query, filter) ||
+          abortController.signal.aborted
+        ) {
+          return;
+        }
+        const current = this.issueTopicGroups?.find(
+          (candidate) => candidate.id === groupId
+        );
+        if (current?.nextPageToken === cursor) {
+          current.loadMoreStatus = "error";
+          current.loadMoreError =
+            error instanceof Error ? error.message : String(error);
+          this.emitIssueTopicGroupsState();
+        }
+      } finally {
+        const active = this.issueLoadMoreRequests.get(requestKey);
+        if (active?.token === requestToken) {
+          this.issueLoadMoreRequests.delete(requestKey);
+        }
+      }
+    })();
+    this.issueLoadMoreRequests.set(requestKey, {
+      abortController,
+      token: requestToken
+    });
+  }
+
+  private emitIssueTopicGroupsState(): void {
+    this.setState({
+      status: "ready",
+      query: this.currentQuery,
+      mode: this.currentQuery ? "results" : "browse",
+      filter: this.currentFilter,
+      categories: buildBrowseCategories(),
+      groups: this.groupsFromRawGroups(),
+      error: null
+    });
+  }
+
+  private cancelIssueLoadMoreRequests(): void {
+    for (const request of this.issueLoadMoreRequests.values()) {
+      request.abortController.abort();
+    }
+    this.issueLoadMoreRequests.clear();
   }
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchControllerBase.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchControllerBase.ts
@@ -179,12 +179,14 @@ export class AgentMentionSearchControllerBase {
       this.resetTotalCounts();
       this.emitBrowseState("loading");
     }
+    const abortSignal = this.beginActiveRequest();
     void this.runBrowseSearch({
       workspaceId: this.activeWorkspaceId,
       currentUserId: this.currentUserId,
       requestId,
       filter,
-      sessionCwd: this.currentSessionCwd
+      sessionCwd: this.currentSessionCwd,
+      abortSignal
     });
   }
 
@@ -290,6 +292,7 @@ export class AgentMentionSearchControllerBase {
     requestId: number;
     filter: AgentMentionFilterId;
     sessionCwd: string;
+    abortSignal: AbortSignal;
   }): Promise<void> {
     const startedAt = this.diagnosticNow();
     let providerDiagnostics: AgentMentionProviderQueryDiagnostic[] = [];
@@ -300,7 +303,8 @@ export class AgentMentionSearchControllerBase {
         input,
         cacheKey,
         "open",
-        provenanceFilter
+        provenanceFilter,
+        input.abortSignal
       );
       providerDiagnostics = result.providerDiagnostics;
       if (
@@ -375,7 +379,8 @@ export class AgentMentionSearchControllerBase {
       sessionCwd: string;
     },
     provenanceFilter: ReferenceProvenanceFilter | null = this
-      .currentProvenanceFilter
+      .currentProvenanceFilter,
+    abortSignal?: AbortSignal
   ): Promise<AgentMentionBrowseFetchResult> {
     return this.fetchFilterResult(
       {
@@ -383,7 +388,8 @@ export class AgentMentionSearchControllerBase {
         query: "",
         includeAgentGeneratedFiles: input.filter === "file"
       },
-      provenanceFilter
+      provenanceFilter,
+      abortSignal
     );
   }
 
@@ -687,15 +693,18 @@ export class AgentMentionSearchControllerBase {
     cacheKey: string,
     reason: AgentMentionBrowseLoadReason,
     provenanceFilter: ReferenceProvenanceFilter | null = this
-      .currentProvenanceFilter
+      .currentProvenanceFilter,
+    abortSignal?: AbortSignal
   ): Promise<AgentMentionBrowseFetchResult> {
     return loadAgentMentionBrowseFetchResult({
       input,
       cacheKey,
       reason,
+      abortSignal,
       diagnosticNow: this.diagnosticNow,
       providerIds: this.providerIdsForDiagnostics(),
-      fetchBrowseResult: () => this.fetchBrowseResult(input, provenanceFilter),
+      fetchBrowseResult: (sharedAbortSignal) =>
+        this.fetchBrowseResult(input, provenanceFilter, sharedAbortSignal),
       logLifecycle: (event, details) => this.logLifecycle(event, details)
     });
   }

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchControllerBase.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchControllerBase.ts
@@ -23,6 +23,7 @@ import {
   type AgentMentionFilterId,
   type AgentMentionGroup,
   type AgentMentionGroupId,
+  type AgentMentionIssueTopicGroup,
   type AgentMentionLifecycleDiagnosticLog,
   type AgentMentionRawGroups,
   type AgentMentionSearchControllerOptions,
@@ -40,6 +41,7 @@ import {
 } from "./AgentMentionSearchCache";
 import {
   buildAgentMentionGroups,
+  cloneAgentMentionIssueTopicGroups,
   cloneAgentMentionRawGroups,
   elapsedDiagnosticMs,
   emptyAgentMentionRawGroups,
@@ -48,6 +50,7 @@ import {
 } from "./AgentMentionSearchModel";
 import {
   fetchAgentMentionFilterResult,
+  queryAgentMentionProviderGroups,
   queryAgentMentionProviderItems
 } from "./AgentMentionSearchIndex";
 import type { ReferenceProvenanceFilter } from "@tutti-os/workspace-file-reference/contracts";
@@ -82,6 +85,7 @@ export class AgentMentionSearchControllerBase {
   protected preloadCancel: (() => void) | null = null;
   protected pendingPreloadKey: string | null = null;
   protected requestId = 0;
+  protected activeRequestAbortController: AbortController | null = null;
   protected disposed = false;
   protected activeWorkspaceId = "";
   protected currentUserId = "";
@@ -93,6 +97,7 @@ export class AgentMentionSearchControllerBase {
   protected currentIssueSearchLimit: number;
   protected agentGeneratedBrowsePath: string | null = null;
   protected rawGroups: AgentMentionRawGroups = emptyAgentMentionRawGroups();
+  protected issueTopicGroups: AgentMentionIssueTopicGroup[] | null = null;
   protected state: AgentMentionSearchState = {
     status: "idle",
     query: "",
@@ -189,18 +194,25 @@ export class AgentMentionSearchControllerBase {
     query: string;
     requestId: number;
     filter: AgentMentionFilterId;
+    provenanceFilter: ReferenceProvenanceFilter | null;
+    sessionCwd: string;
+    abortSignal?: AbortSignal;
   }): Promise<void> {
     const startedAt = this.diagnosticNow();
     let providerDiagnostics: AgentMentionProviderQueryDiagnostic[] = [];
     try {
-      const result = await this.fetchFilterResult({
-        workspaceId: input.workspaceId,
-        currentUserId: input.currentUserId,
-        query: input.query,
-        filter: input.filter,
-        sessionCwd: this.currentSessionCwd,
-        includeAgentGeneratedFiles: false
-      });
+      const result = await this.fetchFilterResult(
+        {
+          workspaceId: input.workspaceId,
+          currentUserId: input.currentUserId,
+          query: input.query,
+          filter: input.filter,
+          sessionCwd: input.sessionCwd,
+          includeAgentGeneratedFiles: false
+        },
+        input.provenanceFilter,
+        input.abortSignal
+      );
       providerDiagnostics = result.providerDiagnostics;
 
       if (
@@ -379,6 +391,9 @@ export class AgentMentionSearchControllerBase {
     result: AgentMentionBrowseFetchResult
   ): void {
     this.rawGroups = cloneAgentMentionRawGroups(result.rawGroups);
+    this.issueTopicGroups = cloneAgentMentionIssueTopicGroups(
+      result.issueTopicGroups
+    );
     this.resetTotalCounts();
     for (const [groupId, count] of Object.entries(result.totalCounts) as [
       AgentMentionGroupId,
@@ -434,10 +449,12 @@ export class AgentMentionSearchControllerBase {
     limit?: number;
     sessionCwd?: string;
     provenanceFilter: ReferenceProvenanceFilter | null;
+    abortSignal?: AbortSignal;
   }): Promise<AgentContextMentionItem[]> {
     const provider = this.contextMentionProviders.get(input.providerId);
     return queryAgentMentionProviderWithDiagnostics({
       diagnosticNow: this.diagnosticNow,
+      abortSignal: input.abortSignal,
       diagnostics: input.diagnostics,
       fallback: [] as AgentContextMentionItem[],
       providerId: input.providerId,
@@ -456,6 +473,45 @@ export class AgentMentionSearchControllerBase {
             })
         : null,
       resultCount: (result) => result.length
+    });
+  }
+
+  protected async queryProviderMentionGroupsById(input: {
+    diagnostics: AgentMentionProviderQueryDiagnostic[];
+    providerId: string;
+    workspaceId: string;
+    currentUserId: string;
+    query: string;
+    limit?: number;
+    sessionCwd?: string;
+    provenanceFilter: ReferenceProvenanceFilter | null;
+    abortSignal?: AbortSignal;
+  }): Promise<AgentMentionIssueTopicGroup[] | null> {
+    const provider = this.contextMentionProviders.get(input.providerId);
+    if (!provider?.queryGroups) {
+      return null;
+    }
+    return queryAgentMentionProviderWithDiagnostics({
+      abortSignal: input.abortSignal,
+      diagnosticNow: this.diagnosticNow,
+      diagnostics: input.diagnostics,
+      fallback: [] as AgentMentionIssueTopicGroup[],
+      providerId: input.providerId,
+      providerTimeoutMs: this.providerTimeoutMs,
+      throwOnTimeout: true,
+      query: (abortSignal) =>
+        queryAgentMentionProviderGroups({
+          provider,
+          workspaceId: input.workspaceId,
+          currentUserId: input.currentUserId,
+          query: input.query,
+          limit: input.limit,
+          sessionCwd: input.sessionCwd ?? this.currentSessionCwd,
+          abortSignal,
+          provenanceFilter: input.provenanceFilter
+        }).then((groups) => groups ?? []),
+      resultCount: (groups) =>
+        groups.reduce((count, group) => count + group.items.length, 0)
     });
   }
 
@@ -549,6 +605,7 @@ export class AgentMentionSearchControllerBase {
 
   protected resetRawGroups(): void {
     this.rawGroups = emptyAgentMentionRawGroups();
+    this.issueTopicGroups = null;
     this.resetTotalCounts();
   }
 
@@ -586,7 +643,8 @@ export class AgentMentionSearchControllerBase {
       currentQuery: this.currentQuery,
       expandedCounts: this.expandedCounts,
       rawGroups: this.rawGroups,
-      totalCounts: this.totalCounts
+      totalCounts: this.totalCounts,
+      issueTopicGroups: this.issueTopicGroups
     });
   }
 
@@ -652,7 +710,8 @@ export class AgentMentionSearchControllerBase {
       includeAgentGeneratedFiles: boolean;
     },
     provenanceFilter: ReferenceProvenanceFilter | null = this
-      .currentProvenanceFilter
+      .currentProvenanceFilter,
+    abortSignal?: AbortSignal
   ): Promise<AgentMentionBrowseFetchResult> {
     return fetchAgentMentionFilterResult({
       ...input,
@@ -660,8 +719,22 @@ export class AgentMentionSearchControllerBase {
       currentFileSearchLimit: this.currentFileSearchLimit,
       currentIssueSearchLimit: this.currentIssueSearchLimit,
       provenanceFilter,
+      queryProviderMentionGroupsById: (queryInput) =>
+        this.queryProviderMentionGroupsById({ ...queryInput, abortSignal }),
       queryProviderMentionItemsById: (queryInput) =>
-        this.queryProviderMentionItemsById(queryInput)
+        this.queryProviderMentionItemsById({ ...queryInput, abortSignal })
     });
+  }
+
+  protected beginActiveRequest(): AbortSignal {
+    this.abortActiveRequest();
+    const controller = new AbortController();
+    this.activeRequestAbortController = controller;
+    return controller.signal;
+  }
+
+  protected abortActiveRequest(): void {
+    this.activeRequestAbortController?.abort();
+    this.activeRequestAbortController = null;
   }
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchControllerBase.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchControllerBase.ts
@@ -34,6 +34,7 @@ import {
 import {
   buildAgentMentionBrowseCacheKey,
   loadAgentMentionBrowseFetchResult,
+  mergeAgentMentionBrowseIssueGroupPage,
   readAgentMentionBrowseCache,
   type AgentMentionBrowseCacheEntry,
   type AgentMentionBrowseFetchResult,
@@ -45,6 +46,7 @@ import {
   cloneAgentMentionRawGroups,
   elapsedDiagnosticMs,
   emptyAgentMentionRawGroups,
+  issueTopicPaginationChanges,
   logAgentMentionLifecycleDiagnostic,
   rawGroupItemCount
 } from "./AgentMentionSearchModel";
@@ -298,6 +300,9 @@ export class AgentMentionSearchControllerBase {
     let providerDiagnostics: AgentMentionProviderQueryDiagnostic[] = [];
     const provenanceFilter = this.currentProvenanceFilter;
     const cacheKey = this.browseCacheKey(input, provenanceFilter);
+    const issueTopicGroupsAtStart = cloneAgentMentionIssueTopicGroups(
+      this.issueTopicGroups
+    );
     try {
       const result = await this.loadBrowseFetchResult(
         input,
@@ -318,7 +323,22 @@ export class AgentMentionSearchControllerBase {
         });
         return;
       }
-      this.applyBrowseFetchResult(result);
+      const paginationChanges = issueTopicPaginationChanges(
+        issueTopicGroupsAtStart,
+        this.issueTopicGroups
+      );
+      for (const group of paginationChanges) {
+        mergeAgentMentionBrowseIssueGroupPage({
+          cacheKey,
+          group,
+          cachedAt: this.diagnosticNow()
+        });
+      }
+      const resultToApply =
+        paginationChanges.length > 0
+          ? (this.readBrowseCache(cacheKey).entry ?? result)
+          : result;
+      this.applyBrowseFetchResult(resultToApply);
       const groups = this.groupsFromRawGroups();
 
       this.setState({

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchIndex.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchIndex.ts
@@ -9,6 +9,7 @@ import {
   totalCountsFromRawGroups
 } from "./AgentMentionSearchModel";
 import type { AgentMentionFilterId } from "./AgentMentionSearchContracts";
+import type { AgentMentionIssueTopicGroup } from "./AgentMentionSearchContracts";
 import {
   AGENT_GENERATED_FILE_PROVIDER_ID,
   AGENT_SESSION_PROVIDER_ID,
@@ -23,6 +24,7 @@ import type { ReferenceProvenanceFilter } from "@tutti-os/workspace-file-referen
 import { referenceProvenanceFilterIsActive } from "@tutti-os/workspace-file-reference/core";
 
 export interface AgentMentionProviderQueryInput {
+  abortSignal?: AbortSignal;
   diagnostics: AgentMentionProviderQueryDiagnostic[];
   providerId: string;
   workspaceId: string;
@@ -32,6 +34,8 @@ export interface AgentMentionProviderQueryInput {
   sessionCwd?: string;
   provenanceFilter: ReferenceProvenanceFilter | null;
 }
+
+export interface AgentMentionProviderGroupedQueryInput extends AgentMentionProviderQueryInput {}
 
 export async function fetchAgentMentionFilterResult(input: {
   workspaceId: string;
@@ -47,6 +51,9 @@ export async function fetchAgentMentionFilterResult(input: {
   queryProviderMentionItemsById: (
     input: AgentMentionProviderQueryInput
   ) => Promise<AgentContextMentionItem[]>;
+  queryProviderMentionGroupsById?: (
+    input: AgentMentionProviderGroupedQueryInput
+  ) => Promise<AgentMentionIssueTopicGroup[] | null>;
 }): Promise<AgentMentionBrowseFetchResult> {
   const providerDiagnostics: AgentMentionProviderQueryDiagnostic[] = [];
   const provenanceFilterActive = referenceProvenanceFilterIsActive(
@@ -93,7 +100,8 @@ export async function fetchAgentMentionFilterResult(input: {
       return {
         providerDiagnostics,
         rawGroups,
-        totalCounts: totalCountsFromRawGroups(rawGroups)
+        totalCounts: totalCountsFromRawGroups(rawGroups),
+        issueTopicGroups: null
       };
     }
     case "session": {
@@ -115,24 +123,33 @@ export async function fetchAgentMentionFilterResult(input: {
       return {
         providerDiagnostics,
         rawGroups,
-        totalCounts: totalCountsFromRawGroups(rawGroups)
+        totalCounts: totalCountsFromRawGroups(rawGroups),
+        issueTopicGroups: null
       };
     }
     case "issue": {
       // Issue summaries do not yet carry durable provenance. Fail closed
       // rather than displaying unfiltered issues under an active filter.
+      const queryInput = {
+        providerId: WORKSPACE_ISSUE_PROVIDER_ID,
+        workspaceId: input.workspaceId,
+        currentUserId: input.currentUserId,
+        query: input.query,
+        limit: input.currentIssueSearchLimit,
+        sessionCwd: input.sessionCwd,
+        diagnostics: providerDiagnostics,
+        provenanceFilter: input.provenanceFilter
+      };
+      const issueTopicGroups = provenanceFilterActive
+        ? []
+        : input.queryProviderMentionGroupsById
+          ? await input.queryProviderMentionGroupsById(queryInput)
+          : null;
       const issueItems = provenanceFilterActive
         ? []
-        : await input.queryProviderMentionItemsById({
-            providerId: WORKSPACE_ISSUE_PROVIDER_ID,
-            workspaceId: input.workspaceId,
-            currentUserId: input.currentUserId,
-            query: input.query,
-            limit: input.currentIssueSearchLimit,
-            sessionCwd: input.sessionCwd,
-            diagnostics: providerDiagnostics,
-            provenanceFilter: input.provenanceFilter
-          });
+        : issueTopicGroups === null
+          ? await input.queryProviderMentionItemsById(queryInput)
+          : [];
       const rawGroups = emptyAgentMentionRawGroups();
       rawGroups.issues = issueItems.filter(
         (item) => item.kind === "workspace-issue"
@@ -140,7 +157,8 @@ export async function fetchAgentMentionFilterResult(input: {
       return {
         providerDiagnostics,
         rawGroups,
-        totalCounts: totalCountsFromRawGroups(rawGroups)
+        totalCounts: totalCountsFromRawGroups(rawGroups),
+        issueTopicGroups
       };
     }
     case "agent": {
@@ -160,7 +178,8 @@ export async function fetchAgentMentionFilterResult(input: {
       return {
         providerDiagnostics,
         rawGroups,
-        totalCounts: totalCountsFromRawGroups(rawGroups)
+        totalCounts: totalCountsFromRawGroups(rawGroups),
+        issueTopicGroups: null
       };
     }
     case "app": {
@@ -178,7 +197,8 @@ export async function fetchAgentMentionFilterResult(input: {
       return {
         providerDiagnostics,
         rawGroups,
-        totalCounts: totalCountsFromRawGroups(rawGroups)
+        totalCounts: totalCountsFromRawGroups(rawGroups),
+        issueTopicGroups: null
       };
     }
   }
@@ -212,8 +232,145 @@ export async function queryAgentMentionProviderItems(input: {
   if (input.abortSignal.aborted) {
     return [];
   }
+  return mapProviderItemsToAgentMentionItems({
+    ...input,
+    items
+  });
+}
+
+export async function queryAgentMentionProviderGroups(input: {
+  provider: AgentContextMentionProvider;
+  workspaceId: string;
+  currentUserId: string;
+  query: string;
+  limit?: number;
+  sessionCwd: string;
+  abortSignal: AbortSignal;
+  provenanceFilter: ReferenceProvenanceFilter | null;
+}): Promise<AgentMentionIssueTopicGroup[] | null> {
+  if (!input.provider.queryGroups) {
+    return null;
+  }
+  const result = await input.provider.queryGroups({
+    keyword: input.query,
+    maxResults: input.limit,
+    abortSignal: input.abortSignal,
+    trigger: "@",
+    context: {
+      metadata: {
+        currentUserId: input.currentUserId,
+        sessionCwd: input.sessionCwd || undefined,
+        target: "agent-gui",
+        workspaceId: input.workspaceId,
+        referenceProvenanceFilter: input.provenanceFilter ?? undefined
+      }
+    }
+  });
+  if (input.abortSignal.aborted) {
+    return [];
+  }
+  return Promise.all(
+    result.groups.map(async (group): Promise<AgentMentionIssueTopicGroup> => {
+      const items = await mapProviderItemsToAgentMentionItems({
+        ...input,
+        items: group.items
+      });
+      const uniqueItems = dedupeWorkspaceIssueMentionItems(items);
+      return {
+        id: agentMentionIssueTopicGroupId(group.id),
+        providerGroupId: group.id,
+        label: group.label,
+        items: uniqueItems,
+        totalCount: Math.max(group.totalCount, uniqueItems.length),
+        nextPageToken: group.nextCursor ?? null,
+        loadMoreStatus: "idle",
+        loadMoreError: null
+      };
+    })
+  );
+}
+
+export async function queryAgentMentionProviderGroupPage(input: {
+  provider: AgentContextMentionProvider;
+  providerGroupId: string;
+  workspaceId: string;
+  currentUserId: string;
+  query: string;
+  cursor: string;
+  pageSize: number;
+  sessionCwd: string;
+  abortSignal: AbortSignal;
+  provenanceFilter: ReferenceProvenanceFilter | null;
+}): Promise<AgentMentionIssueTopicGroup> {
+  if (!input.provider.queryGroupPage) {
+    throw new Error("Mention provider does not support grouped pagination.");
+  }
+  const group = await input.provider.queryGroupPage({
+    groupId: input.providerGroupId,
+    cursor: input.cursor,
+    pageSize: input.pageSize,
+    keyword: input.query,
+    maxResults: input.pageSize,
+    abortSignal: input.abortSignal,
+    trigger: "@",
+    context: {
+      metadata: {
+        currentUserId: input.currentUserId,
+        sessionCwd: input.sessionCwd || undefined,
+        target: "agent-gui",
+        workspaceId: input.workspaceId,
+        referenceProvenanceFilter: input.provenanceFilter ?? undefined
+      }
+    }
+  });
+  const items = await mapProviderItemsToAgentMentionItems({
+    ...input,
+    provider: input.provider,
+    items: group.items
+  });
+  const uniqueItems = dedupeWorkspaceIssueMentionItems(items);
+  return {
+    id: agentMentionIssueTopicGroupId(input.providerGroupId),
+    providerGroupId: input.providerGroupId,
+    label: group.label,
+    items: uniqueItems,
+    totalCount: Math.max(group.totalCount, uniqueItems.length),
+    nextPageToken: group.nextCursor ?? null,
+    loadMoreStatus: "idle",
+    loadMoreError: null
+  };
+}
+
+export function agentMentionIssueTopicGroupId(
+  topicId: string
+): `issue-topic:${string}` {
+  return `issue-topic:${encodeURIComponent(topicId)}`;
+}
+
+function dedupeWorkspaceIssueMentionItems(
+  items: readonly AgentContextMentionItem[]
+): AgentContextMentionItem[] {
+  const issueIds = new Set<string>();
+  return items.filter((item) => {
+    if (item.kind !== "workspace-issue") {
+      return true;
+    }
+    if (issueIds.has(item.targetId)) {
+      return false;
+    }
+    issueIds.add(item.targetId);
+    return true;
+  });
+}
+
+async function mapProviderItemsToAgentMentionItems(input: {
+  provider: AgentContextMentionProvider;
+  workspaceId: string;
+  currentUserId: string;
+  items: readonly any[];
+}): Promise<AgentContextMentionItem[]> {
   const mentionItems = await Promise.all(
-    items.map(async (item) => {
+    input.items.map(async (item) => {
       const mentionItem = providerItemToAgentMentionItem({
         currentUserId: input.currentUserId,
         insertResult: input.provider.toInsertResult(item),

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
@@ -114,6 +114,40 @@ export function cloneAgentMentionIssueTopicGroups(
   );
 }
 
+export function issueTopicPaginationChanges(
+  groupsAtStart: readonly AgentMentionIssueTopicGroup[] | null,
+  currentGroups: readonly AgentMentionIssueTopicGroup[] | null
+): AgentMentionIssueTopicGroup[] {
+  if (!groupsAtStart || !currentGroups) {
+    return [];
+  }
+  const startingGroups = new Map(
+    groupsAtStart.map((group) => [group.id, group] as const)
+  );
+  return currentGroups.flatMap((group) => {
+    const startingGroup = startingGroups.get(group.id);
+    if (!startingGroup) {
+      return [];
+    }
+    const startingIssueIds = new Set(
+      startingGroup.items
+        .filter((item) => item.kind === "workspace-issue")
+        .map((item) => item.targetId)
+    );
+    const appendedItems = group.items.filter(
+      (item) =>
+        item.kind !== "workspace-issue" || !startingIssueIds.has(item.targetId)
+    );
+    if (
+      appendedItems.length === 0 &&
+      group.nextPageToken === startingGroup.nextPageToken
+    ) {
+      return [];
+    }
+    return [{ ...group, items: appendedItems }];
+  });
+}
+
 export function emptyAgentMentionRawGroups(): AgentMentionRawGroups {
   return {
     apps: [],

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
@@ -8,6 +8,7 @@ import type {
   AgentMentionFilterId,
   AgentMentionGroup,
   AgentMentionGroupId,
+  AgentMentionIssueTopicGroup,
   AgentMentionRawGroups,
   AgentMentionTotalCounts
 } from "./AgentMentionSearchContracts";
@@ -38,9 +39,21 @@ export function buildAgentMentionGroups(input: {
   currentFilter: AgentMentionFilterId;
   currentQuery: string;
   expandedCounts: Partial<Record<AgentMentionGroupId, number>>;
+  issueTopicGroups: readonly AgentMentionIssueTopicGroup[] | null;
   rawGroups: AgentMentionRawGroups;
   totalCounts: AgentMentionTotalCounts;
 }): AgentMentionGroup[] {
+  if (input.currentFilter === "issue" && input.issueTopicGroups !== null) {
+    return input.issueTopicGroups.map((group) => ({
+      id: group.id,
+      label: group.label,
+      items: group.items,
+      totalCount: group.totalCount,
+      visibleCount: group.items.length,
+      hasMore: group.nextPageToken !== null,
+      expandStatus: group.loadMoreStatus
+    }));
+  }
   const orderedGroupIds = groupIdsForFilter(input.currentFilter);
   return orderedGroupIds
     .map((groupId) => {
@@ -91,6 +104,14 @@ export function buildAgentMentionGroups(input: {
       } satisfies AgentMentionGroup;
     })
     .filter((group): group is AgentMentionGroup => group !== null);
+}
+
+export function cloneAgentMentionIssueTopicGroups(
+  groups: readonly AgentMentionIssueTopicGroup[] | null
+): AgentMentionIssueTopicGroup[] | null {
+  return (
+    groups?.map((group) => ({ ...group, items: [...group.items] })) ?? null
+  );
 }
 
 export function emptyAgentMentionRawGroups(): AgentMentionRawGroups {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentMentionSearchDiagnostics.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentMentionSearchDiagnostics.ts
@@ -111,6 +111,7 @@ export function emitAgentMentionSearchDiagnostic(input: {
 }
 
 export async function queryAgentMentionProviderWithDiagnostics<T>(input: {
+  abortSignal?: AbortSignal;
   diagnosticNow: () => number;
   diagnostics: AgentMentionProviderQueryDiagnostic[];
   fallback: T;
@@ -118,6 +119,7 @@ export async function queryAgentMentionProviderWithDiagnostics<T>(input: {
   providerTimeoutMs: number;
   query: ((abortSignal: AbortSignal) => Promise<T>) | null;
   resultCount: (result: T) => number;
+  throwOnTimeout?: boolean;
 }): Promise<T> {
   if (!input.query) {
     input.diagnostics.push({
@@ -131,6 +133,7 @@ export async function queryAgentMentionProviderWithDiagnostics<T>(input: {
   const startedAt = input.diagnosticNow();
   try {
     const { result, timedOut } = await runAgentMentionProviderQuery({
+      abortSignal: input.abortSignal,
       fallback: input.fallback,
       providerTimeoutMs: input.providerTimeoutMs,
       query: input.query
@@ -144,8 +147,21 @@ export async function queryAgentMentionProviderWithDiagnostics<T>(input: {
       resultCount: input.resultCount(result),
       status: timedOut ? "timeout" : "success"
     });
+    if (timedOut && input.throwOnTimeout) {
+      const error = new Error("Mention provider query timed out.");
+      error.name = "TimeoutError";
+      throw error;
+    }
     return result;
   } catch (error) {
+    if (
+      error instanceof Error &&
+      error.name === "TimeoutError" &&
+      input.diagnostics.at(-1)?.providerId === input.providerId &&
+      input.diagnostics.at(-1)?.status === "timeout"
+    ) {
+      throw error;
+    }
     input.diagnostics.push({
       durationMs: elapsedAgentMentionSearchDiagnosticMs(
         input.diagnosticNow(),
@@ -205,11 +221,20 @@ function providerDiagnosticOrder(providerId: string): number {
 }
 
 async function runAgentMentionProviderQuery<T>(input: {
+  abortSignal?: AbortSignal;
   fallback: T;
   providerTimeoutMs: number;
   query: (abortSignal: AbortSignal) => Promise<T>;
 }): Promise<{ result: T; timedOut: boolean }> {
   const abortController = new AbortController();
+  const abortFromParent = () => abortController.abort();
+  if (input.abortSignal?.aborted) {
+    abortController.abort();
+  } else {
+    input.abortSignal?.addEventListener("abort", abortFromParent, {
+      once: true
+    });
+  }
   let timedOut = false;
   const queryPromise = Promise.resolve().then(() =>
     input.query(abortController.signal)
@@ -228,7 +253,11 @@ async function runAgentMentionProviderQuery<T>(input: {
     input.providerTimeoutMs <= 0 ||
     !Number.isFinite(input.providerTimeoutMs)
   ) {
-    return queryResultPromise;
+    try {
+      return await queryResultPromise;
+    } finally {
+      input.abortSignal?.removeEventListener("abort", abortFromParent);
+    }
   }
 
   let timeout: ReturnType<typeof setTimeout> | null = null;
@@ -245,6 +274,7 @@ async function runAgentMentionProviderQuery<T>(input: {
   try {
     return await Promise.race([queryResultPromise, timeoutPromise]);
   } finally {
+    input.abortSignal?.removeEventListener("abort", abortFromParent);
     if (timeout !== null) {
       clearTimeout(timeout);
     }

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentMentionSearchHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentMentionSearchHelpers.ts
@@ -263,6 +263,9 @@ export function shouldShowEmptyGroup(
   filter: AgentMentionFilterId,
   query: string
 ): boolean {
+  if (groupId.startsWith("issue-topic:")) {
+    return false;
+  }
   const hasQuery = query.trim().length > 0;
   if (groupId === "files") {
     return false;
@@ -303,16 +306,22 @@ function emptyGroupLabel(groupId: AgentMentionGroupId, query: string): string {
   return agentMentionEmptyGroupLabel(groupId, query);
 }
 
-type AgentMentionRawGroupId = Exclude<AgentMentionGroupId, "files">;
+type AgentMentionRawGroupId = Exclude<
+  AgentMentionGroupId,
+  "files" | `issue-topic:${string}`
+>;
 
 export function resolveMentionGroupItems(
   groupId: AgentMentionGroupId,
   rawGroups: Record<AgentMentionRawGroupId, AgentContextMentionItem[]>
 ): AgentContextMentionItem[] {
+  if (groupId.startsWith("issue-topic:")) {
+    return [];
+  }
   if (groupId === "files") {
     return [...rawGroups.opened_files, ...rawGroups.agent_generated_files];
   }
-  return rawGroups[groupId] ?? [];
+  return rawGroups[groupId as AgentMentionRawGroupId] ?? [];
 }
 
 export function resolveMentionGroupTotalCount(
@@ -320,6 +329,9 @@ export function resolveMentionGroupTotalCount(
   totalCounts: Partial<Record<AgentMentionGroupId, number>>,
   itemCount: number
 ): number {
+  if (groupId.startsWith("issue-topic:")) {
+    return itemCount;
+  }
   if (groupId === "files") {
     return (
       (totalCounts.opened_files ?? 0) + (totalCounts.agent_generated_files ?? 0)

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -368,6 +368,8 @@ export const enAgentGui = {
   contextPickerBrowseIssueHint: "Type to search tasks in the current room",
   workspaceAppFactoryMentionFallback: "Create app",
   contextPickerExpandMore: "Show {{count}} more",
+  contextPickerLoadMoreLoading: "Loading…",
+  contextPickerLoadMoreRetry: "Load failed. Retry",
   contextPickerCategoryFileDescription: "Search Files and folders",
   contextPickerCategorySessionDescription: "Find agent sessions that I started",
   contextPickerCategoryCollabDescription:

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -342,6 +342,8 @@ export const zhCNAgentGui = {
   contextPickerBrowseIssueHint: "输入内容以搜索当前房间内的任务",
   workspaceAppFactoryMentionFallback: "创建应用",
   contextPickerExpandMore: "展开更多 {{count}} 条",
+  contextPickerLoadMoreLoading: "正在加载",
+  contextPickerLoadMoreRetry: "加载失败，重试",
   contextPickerCategoryFileDescription: "搜索工作区文件和目录",
   contextPickerCategorySessionDescription: "查找我发起的 Agent 会话",
   contextPickerCategoryCollabDescription: "查看其他人和 Agent 的会话",

--- a/packages/clients/tuttid-ts/src/index.test.ts
+++ b/packages/clients/tuttid-ts/src/index.test.ts
@@ -516,6 +516,46 @@ test("shared tuttid client lists workspace agent sessions with query params", as
   });
 });
 
+test("shared tuttid client forwards AbortSignal for issue topic and issue list requests", async () => {
+  const requests: Request[] = [];
+  const client = createTuttidClient({
+    fetch: async (input, init) => {
+      const request =
+        input instanceof Request ? input : new Request(input, init);
+      requests.push(request);
+      const path = new URL(request.url).pathname;
+      return new Response(
+        JSON.stringify(
+          path.endsWith("/issue-topics")
+            ? { topics: [] }
+            : { issues: [], statusCounts: {}, totalCount: 0 }
+        ),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+  });
+  const abortController = new AbortController();
+
+  await client.listWorkspaceIssueTopics("ws-1", {
+    signal: abortController.signal
+  });
+  await client.listWorkspaceIssues(
+    "ws-1",
+    { pageSize: 10, searchQuery: "task", topicId: "topic-1" },
+    { signal: abortController.signal }
+  );
+
+  assert.deepEqual(
+    requests.map((request) => new URL(request.url).pathname),
+    ["/v1/workspaces/ws-1/issue-topics", "/v1/workspaces/ws-1/issues"]
+  );
+  abortController.abort();
+  assert.equal(
+    requests.every((request) => request.signal.aborted),
+    true
+  );
+});
+
 test("shared tuttid client lists section deletion candidates with pinned exclusion", async () => {
   let requestPath = "";
   let requestQueryEntries: Record<string, string> = {};

--- a/packages/clients/tuttid-ts/src/tuttidClient.ts
+++ b/packages/clients/tuttid-ts/src/tuttidClient.ts
@@ -505,18 +505,20 @@ export function createTuttidClient(
       return unwrapData(response, "Workspace workbench request failed.")
         .snapshot;
     },
-    async listWorkspaceIssues(workspaceID, request) {
+    async listWorkspaceIssues(workspaceID, request, requestOptions) {
       const response = await listWorkspaceIssues({
         client,
         path: { workspaceID },
-        query: request
+        query: request,
+        ...requestOptions
       });
       return unwrapData(response, "Workspace issues request failed.");
     },
-    async listWorkspaceIssueTopics(workspaceID) {
+    async listWorkspaceIssueTopics(workspaceID, requestOptions) {
       const response = await listWorkspaceIssueTopics({
         client,
-        path: { workspaceID }
+        path: { workspaceID },
+        ...requestOptions
       });
       return unwrapData(response, "Workspace issue topics request failed.");
     },

--- a/packages/clients/tuttid-ts/src/tuttidClientTypes.ts
+++ b/packages/clients/tuttid-ts/src/tuttidClientTypes.ts
@@ -473,10 +473,12 @@ export interface TuttidClient {
       searchQuery?: string;
       statusFilter?: IssueManagerStatus | "all";
       topicId: string;
-    }
+    },
+    requestOptions?: TuttidRequestOptions
   ): Promise<IssueManagerIssueListResponse>;
   listWorkspaceIssueTopics(
-    workspaceID: string
+    workspaceID: string,
+    requestOptions?: TuttidRequestOptions
   ): Promise<IssueManagerTopicListResponse>;
   listWorkspaceIssueTaskRuns(
     workspaceID: string,

--- a/packages/ui/rich-text/README.md
+++ b/packages/ui/rich-text/README.md
@@ -92,18 +92,28 @@ interface RichTextTriggerProvider<TItem = unknown> {
   trigger: RichTextTrigger;
   boundary?: RichTextTriggerBoundary;
   query: (
-    input: RichTextTriggerQueryInput
+    input: RichTextTriggerQueryInput,
   ) => Promise<readonly TItem[]> | readonly TItem[];
+  queryGroups?: (
+    input: RichTextTriggerQueryInput,
+  ) =>
+    | Promise<RichTextTriggerGroupedQueryResult<TItem>>
+    | RichTextTriggerGroupedQueryResult<TItem>;
+  queryGroupPage?: (
+    input: RichTextTriggerGroupPageQueryInput,
+  ) =>
+    | Promise<RichTextTriggerQueryGroup<TItem>>
+    | RichTextTriggerQueryGroup<TItem>;
   getItemKey: (item: TItem) => string;
   getItemLabel: (item: TItem) => string;
   getItemSubtitle?: (item: TItem) => string | null | undefined;
   getItemIconUrl?: (
-    item: TItem
+    item: TItem,
   ) => string | null | undefined | Promise<string | null | undefined>;
   getItemKeywords?: (item: TItem) => readonly string[] | undefined;
   toInsertResult: (item: TItem) => RichTextTriggerInsertResult;
   resolveMention?: (
-    identity: RichTextMentionIdentity
+    identity: RichTextMentionIdentity,
   ) => Promise<RichTextMentionResolved | null> | RichTextMentionResolved | null;
 }
 ```
@@ -111,11 +121,16 @@ interface RichTextTriggerProvider<TItem = unknown> {
 Interpretation:
 
 - `query` decides what a trigger can mention
+- `queryGroups` optionally returns provider-owned groups with stable ids,
+  labels, query-scoped totals, and independent cursors; `queryGroupPage`
+  appends one cursor page without re-querying sibling groups
 - `getItemLabel` and `getItemSubtitle` decide the suggestion copy
 - `toInsertResult` maps a chosen item into a mention, markdown-link, or text
   insertion
 - `resolveMention` restores editor-only label or presentation data from the
   stored mention identity
+- group ids, labels, totals, and cursors are candidate-panel metadata only;
+  they must not be copied into mention identity, href, or persisted scope
 
 Mention data:
 
@@ -184,7 +199,7 @@ import { createTuttiExternalAtRichTextTriggerProviders } from "@tutti-os/workspa
 
 const providers = createTuttiExternalAtRichTextTriggerProviders({
   bridge: window.tuttiExternal,
-  providerIds: ["workspace-app", "agent-session"]
+  providerIds: ["workspace-app", "agent-session"],
 });
 ```
 
@@ -223,10 +238,10 @@ Minimum integration checklist:
          mention: {
            entityId: record.id,
            label: record.title,
-           scope: { ownerId: record.ownerId }
-         }
-       })
-     }
+           scope: { ownerId: record.ownerId },
+         },
+       }),
+     },
    ];
    ```
 
@@ -253,20 +268,20 @@ Minimum integration checklist:
          {
            id: "recent",
            label: t("mentions.recent"),
-           matches: (match) => match.item.bucket === "recent"
+           matches: (match) => match.item.bucket === "recent",
          },
          {
            id: "all",
            label: t("mentions.all"),
-           matches: (match) => match.item.bucket !== "recent"
-         }
-       ]
+           matches: (match) => match.item.bucket !== "recent",
+         },
+       ],
      },
      {
        id: "secondary",
        label: t("mentions.secondary"),
-       providerIds: ["secondary-record"]
-     }
+       providerIds: ["secondary-record"],
+     },
    ];
    ```
 
@@ -277,7 +292,7 @@ Minimum integration checklist:
      MentionPaletteFromState,
      buildMentionPaletteModelFromTriggerMatches,
      renderMentionRow,
-     richTextTriggerQueryMatchToMentionRowItem
+     richTextTriggerQueryMatchToMentionRowItem,
    } from "@tutti-os/ui-rich-text/at-panel";
 
    const state = buildMentionPaletteModelFromTriggerMatches({
@@ -285,7 +300,7 @@ Minimum integration checklist:
      categories,
      matches,
      loading,
-     query
+     query,
    });
 
    <MentionPaletteFromState
@@ -295,23 +310,23 @@ Minimum integration checklist:
      callbacks={{
        onActiveCategoryIdChange: setActiveCategoryId,
        onHighlightChange: setHighlightedKey,
-       onSelectItem: commitMatch
+       onSelectItem: commitMatch,
      }}
      labels={{
        empty: t("mentions.empty"),
-       loading: t("mentions.loading")
+       loading: t("mentions.loading"),
      }}
      hintLabels={{
        cycleFilter: t("mentions.switchCategory"),
-       moveSelection: t("mentions.switchSelection")
+       moveSelection: t("mentions.switchSelection"),
      }}
      maxHeightPx={360}
      renderItem={(match) =>
        renderMentionRow(
          richTextTriggerQueryMatchToMentionRowItem(match, {
            getDescription: (candidate) => candidate.subtitle,
-           renderLeading: (ctx) => renderAppSpecificLeading(ctx)
-         })
+           renderLeading: (ctx) => renderAppSpecificLeading(ctx),
+         }),
        )
      }
    />;

--- a/packages/ui/rich-text/src/at-panel/MentionPalette.tsx
+++ b/packages/ui/rich-text/src/at-panel/MentionPalette.tsx
@@ -14,6 +14,7 @@ import {
 import { UnderlineTabs } from "@tutti-os/ui-system/components";
 import { cn } from "@tutti-os/ui-system/utils";
 import { flattenMentionPaletteEntries } from "./mentionPaletteEntries.ts";
+import { mentionPaletteExpandLabel } from "./mentionPaletteModel.ts";
 import { MentionPaletteScrollbar } from "./mentionPaletteScrollbar.tsx";
 import type {
   MentionPaletteGroup,
@@ -481,12 +482,7 @@ function MentionPaletteGroups<TItem>({
                     }
                   }}
                 >
-                  {group.expandStatus === "loading"
-                    ? (group.expandLoadingLabel ?? group.expandLabel)
-                    : group.expandStatus === "error"
-                      ? (group.expandErrorLabel ?? group.expandLabel)
-                      : (group.expandLabel ??
-                        `+${Math.max(0, group.totalCount - group.visibleCount)}`)}
+                  {mentionPaletteExpandLabel(group)}
                 </button>
               ) : null}
             </div>

--- a/packages/ui/rich-text/src/at-panel/MentionPalette.tsx
+++ b/packages/ui/rich-text/src/at-panel/MentionPalette.tsx
@@ -464,6 +464,8 @@ function MentionPaletteGroups<TItem>({
                   }
                   type="button"
                   className={paletteStyles.expandButton}
+                  disabled={group.expandStatus === "loading"}
+                  aria-busy={group.expandStatus === "loading" || undefined}
                   data-highlighted={
                     `expand:${group.id}` === highlightedKey ? "" : undefined
                   }
@@ -473,10 +475,18 @@ function MentionPaletteGroups<TItem>({
                     }
                   }}
                   onMouseDown={(event) => event.preventDefault()}
-                  onClick={() => onExpandGroup(group.id)}
+                  onClick={() => {
+                    if (group.expandStatus !== "loading") {
+                      onExpandGroup(group.id);
+                    }
+                  }}
                 >
-                  {group.expandLabel ??
-                    `+${Math.max(0, group.totalCount - group.visibleCount)}`}
+                  {group.expandStatus === "loading"
+                    ? (group.expandLoadingLabel ?? group.expandLabel)
+                    : group.expandStatus === "error"
+                      ? (group.expandErrorLabel ?? group.expandLabel)
+                      : (group.expandLabel ??
+                        `+${Math.max(0, group.totalCount - group.visibleCount)}`)}
                 </button>
               ) : null}
             </div>

--- a/packages/ui/rich-text/src/at-panel/mentionPalette.css
+++ b/packages/ui/rich-text/src/at-panel/mentionPalette.css
@@ -227,6 +227,11 @@
   outline: none;
 }
 
+.rich-text-at-mention-palette__expand-button:disabled {
+  cursor: default;
+  opacity: 0.65;
+}
+
 .rich-text-at-mention-palette__row-button {
   position: relative;
   display: flex;

--- a/packages/ui/rich-text/src/at-panel/mentionPaletteModel.test.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionPaletteModel.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   buildMentionPaletteModel,
   buildMentionPaletteModelFromTriggerMatches,
+  mentionPaletteExpandLabel,
   mentionPaletteGroup,
   moveMentionPaletteHighlight,
   nextMentionPaletteCategory,
@@ -22,6 +23,22 @@ const categories = [
 ] as const;
 
 const getItemKey = (item: Item) => item.key;
+
+test("mentionPaletteExpandLabel keeps the count fallback for transient states", () => {
+  const group = { totalCount: 12, visibleCount: 10 };
+  assert.equal(
+    mentionPaletteExpandLabel({ ...group, expandStatus: "loading" }),
+    "+2"
+  );
+  assert.equal(
+    mentionPaletteExpandLabel({ ...group, expandStatus: "error" }),
+    "+2"
+  );
+  assert.equal(
+    mentionPaletteExpandLabel({ ...group, expandStatus: "idle" }),
+    "+2"
+  );
+});
 
 function makeMatch(
   providerId: string,

--- a/packages/ui/rich-text/src/at-panel/mentionPaletteModel.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionPaletteModel.ts
@@ -54,6 +54,29 @@ export function mentionPaletteGroup<TItem>(input: {
   };
 }
 
+export function mentionPaletteExpandLabel<TItem>(
+  group: Pick<
+    MentionPaletteGroup<TItem>,
+    | "expandErrorLabel"
+    | "expandLabel"
+    | "expandLoadingLabel"
+    | "expandStatus"
+    | "totalCount"
+    | "visibleCount"
+  >
+): string {
+  const fallbackLabel =
+    group.expandLabel ??
+    `+${Math.max(0, group.totalCount - group.visibleCount)}`;
+  if (group.expandStatus === "loading") {
+    return group.expandLoadingLabel ?? fallbackLabel;
+  }
+  if (group.expandStatus === "error") {
+    return group.expandErrorLabel ?? fallbackLabel;
+  }
+  return fallbackLabel;
+}
+
 export function buildMentionPaletteModel<TItem>(
   input: MentionPaletteModelInput<TItem>
 ): MentionPaletteState<TItem> {

--- a/packages/ui/rich-text/src/at-panel/mentionPaletteTypes.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionPaletteTypes.ts
@@ -15,6 +15,9 @@ export interface MentionPaletteGroup<TItem> {
   totalCount: number;
   visibleCount: number;
   hasMore: boolean;
+  expandStatus?: "idle" | "loading" | "error";
+  expandLoadingLabel?: string;
+  expandErrorLabel?: string;
   emptyLabel?: string;
   /**
    * Optional precomputed label for the "show more" expand control. When omitted

--- a/packages/ui/rich-text/src/types/index.ts
+++ b/packages/ui/rich-text/src/types/index.ts
@@ -5,12 +5,15 @@ export type {
   RichTextTrigger,
   RichTextTriggerBoundary,
   RichTextTriggerConfig,
+  RichTextTriggerGroupedQueryResult,
+  RichTextTriggerGroupPageQueryInput,
   RichTextTriggerInsertResult,
   RichTextTriggerProvider,
   RichTextTriggerProviderContext,
   RichTextTriggerQueryMatch,
   RichTextTriggerRegistry,
-  RichTextTriggerQueryInput
+  RichTextTriggerQueryInput,
+  RichTextTriggerQueryGroup
 } from "./trigger.ts";
 export type {
   RichTextMentionAttrs,

--- a/packages/ui/rich-text/src/types/trigger.ts
+++ b/packages/ui/rich-text/src/types/trigger.ts
@@ -28,6 +28,25 @@ export interface RichTextTriggerQueryInput {
   trigger: RichTextTrigger;
 }
 
+export interface RichTextTriggerQueryGroup<TItem = unknown> {
+  /** Stable provider-owned identity used only by candidate-panel state. */
+  id: string;
+  label: string;
+  items: readonly TItem[];
+  totalCount: number;
+  nextCursor?: string;
+}
+
+export interface RichTextTriggerGroupedQueryResult<TItem = unknown> {
+  groups: readonly RichTextTriggerQueryGroup<TItem>[];
+}
+
+export interface RichTextTriggerGroupPageQueryInput extends RichTextTriggerQueryInput {
+  groupId: string;
+  cursor: string;
+  pageSize: number;
+}
+
 export interface RichTextMentionTriggerInsertResult {
   kind: "mention";
   mention: RichTextMentionInsert;
@@ -56,6 +75,18 @@ export interface RichTextTriggerProvider<TItem = unknown> {
   query(
     input: RichTextTriggerQueryInput
   ): Promise<readonly TItem[]> | readonly TItem[];
+  /** Optional grouped/cursor query used by candidate panels that support it. */
+  queryGroups?(
+    input: RichTextTriggerQueryInput
+  ):
+    | Promise<RichTextTriggerGroupedQueryResult<TItem>>
+    | RichTextTriggerGroupedQueryResult<TItem>;
+  /** Load one page for one group without re-querying sibling groups. */
+  queryGroupPage?(
+    input: RichTextTriggerGroupPageQueryInput
+  ):
+    | Promise<RichTextTriggerQueryGroup<TItem>>
+    | RichTextTriggerQueryGroup<TItem>;
   getItemKey(item: TItem): string;
   getItemLabel(item: TItem): string;
   getItemSubtitle?(item: TItem): string | null | undefined;


### PR DESCRIPTION
## 方案
# AT 任务按主题分组并支持独立搜索分页

## 目标/背景

Agent GUI 的 `@` 面板在“任务”分类中目前只读取 `listWorkspaceIssueTopics` 返回的第一个主题，再调用 `listWorkspaceIssues`，因此当工作区存在多个主题时，只能看到置顶或最近活动主题下的任务，其他主题中的任务无法被选择。需要把任务候选改为按主题分组展示，并让用户能够通过每个主题独立的 Load more 访问该主题下的全部任务。搜索必须覆盖所有主题且仍按主题分组，不能退化为只过滤已经加载到前端的少量任务。

## 改动点

### 1. 扩展通用富文本 mention provider 的可选分组查询能力

- 在 `packages/ui/rich-text` 的公开 provider 类型中增加向后兼容的可选分组查询协议，供支持分组和 cursor 分页的 provider 使用。协议应能表达稳定分组 id、展示 label、条目数组、查询范围内的 `totalCount`、下一页 cursor，以及按单个分组加载下一页所需的输入。
- 保留现有 `query()`、`toInsertResult()` 和 mention resolve 能力，已有 file/session/app/agent provider 不需要迁移。分组元数据仅服务候选面板，不得写入最终 mention identity、href 或持久化 scope。
- `@tutti-os/ui-rich-text/at-panel` 继续作为通用渲染层。复用它已有的动态 group id、label、totalCount、visibleCount、hasMore 和 expand control，按最小范围补充分组级 Load more 状态，使按钮能够表达 idle/loading/error、加载时禁用、防止重复触发，并允许失败后重试。不要加入任务领域判断或文案。

### 2. workspace-issue provider 返回所有主题的分组第一页

- 修改桌面 `DesktopRichTextAtService` 中的 workspace-issue contributor，不再读取 `topics[0]`。
- 空查询和有关键词查询都先获得完整主题列表，并保留 daemon 返回的主题顺序，即置顶优先、随后按最近活动排序。
- 对主题执行有上限的并发查询，建议最大并发数 4。每个主题调用现有 `listWorkspaceIssues`，携带 `topicId`、规范化后的 `searchQuery`、`pageSize=10`；首批结果使用响应中的 `totalCount` 和 `nextPageToken` 建立独立分组。
- 默认不输出没有任务的主题；搜索时不输出零匹配主题。主题分组标题使用主题 title，必要时可显示该查询范围下的任务总数。
- 提供按分组加载下一页的方法：输入必须包含稳定 topic 分组身份、当前规范化搜索词、该组 `nextPageToken` 和 `pageSize=10`，只请求目标主题，不重新请求其他主题。
- 现有普通 `query()` 仍须对其他富文本表面保持兼容，并能够返回跨主题的任务候选；不得重新引入“只查询第一个主题”的行为。
- 精确任务 ID 搜索兜底继续保留。如果普通标题/内容查询没有返回目标任务，通过详情接口解析后，按详情中的 `topicId` 放入正确主题分组，且按 `issueId` 去重。

### 3. Agent mention controller 使用动态主题分组状态

- 调整 `AgentMentionSearchContracts`、`AgentMentionSearchIndex`、`AgentMentionSearchModel`、`AgentMentionSearchController` 及其缓存结构，使任务分类能够保存动态的 `issue-topic:<encoded-topic-id>` 分组，而不是固定单一 `issues` 数组。动态 id 必须避免原始 topicId 中的特殊字符导致 entry key 冲突。
- 每个主题独立保存 ordered items、`totalCount`、`nextPageToken`、首屏/Load more 请求状态和错误状态。条目合并按 `issueId` 去重，保留后端的更新时间倒序，不得影响其他主题。
- 搜索继续沿用现有 120ms debounce、workspace/filter/query request identity 和过期响应保护。一次搜索的首批主题结果应按主题

## 提交
```
20720f51a fix(agent): complete issue topic mention pagination
952c4ee30 ship: implement plan (auto-commit)
```

## 审查备注（advisory，未阻塞合并）
- [packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchContracts.ts] (claude) 动态分组 id 的 'issue-topic:' 前缀被当作 magic string 在至少 6 处调用点各自硬编码判断：AgentMentionSearchController.expandGroup、AgentMentionSearchModel.buildAgentMentionGroups、AgentMentionLabels（agentMentionGroupLabel/agentMentionEmptyGroupLabel 两处）、agentMentionSearchHelpers（shouldShowEmptyGroup/resolveMentionGroupItems/resolveMentionGroupTotalCount 三处）、AgentFileMentionPalette.decorateMentionGroup 等，均通过 groupId.startsWith("issue-topic:") 分支。构造侧已经沉淀了 canonical 的 agentMentionIssueTopicGroupId()，但判定/解析侧却没有对应的 isAgentMentionIssueTopicGroupId() 守卫和共享前缀常量，导致同一个约定散落成一堆重复的字符串比较。后续任何调整（改前缀、增加第二种动态分组）都要人肉找齐所有 startsWith 调用点，容易漏改。建议抽出共享的前缀常量 + 类型守卫函数并在各处复用。属于可演进性/一致性问题，值得做但可后续处理。
- [apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopWorkspaceIssueAtContributor.ts] (claude) 精确任务 ID 兜底路径中，若命中的 issue 所属 topic 不在 listWorkspaceIssueTopics 返回的主题列表里，会 fabricate 一个 group 并用 label: item.topicId（原始 topicId）作为分组标题，而非主题 title。属于罕见边界下的展示降级（面板会显示裸 topicId 而非可读标题），不影响功能与 mention 协议。建议后续从详情或主题接口取回该 topic 的 title 再作为 label；当前非阻塞。

🤖 opened by ship harness

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups workspace tasks by topic in the @ panel, with per-topic search and independent pagination. Implements AB-46 by showing all topics and letting users load more within each topic without affecting others.

- New Features
  - `@` task picker: dynamic `issue-topic:*` groups appear in daemon order; each group has its own items, total, cursor, and Load more with loading/retry labels. Search spans all topics and keeps results grouped.
  - `@tutti-os/ui-rich-text`: adds optional `queryGroups` and `queryGroupPage` for grouped/cursor queries; existing providers stay the same.
  - Desktop workspace-issue provider: lists all topics, queries each first page with bounded concurrency (pageSize=10), builds one group per non-empty topic, and supports per-topic page loads. Exact ID fallback inserts the task into its correct topic. All requests use AbortSignal.

- Refactors
  - Agent GUI: adds dynamic `issue-topic:<encoded>` groups with isolated item lists and expand status; dedupes by `issueId`. Cancels orphaned browse loads on close and refetches on reopen. Per-group labels come from the provider.
  - `MentionPalette`: expand button disables during load and shows i18n loading/retry labels.
  - `@tutti-os/client-tuttid-ts`: forwards AbortSignal for `listWorkspaceIssueTopics` and `listWorkspaceIssues`.
  - Tests and docs expanded for grouped queries, per-topic pagination, and cancellation behavior.

<sup>Written for commit 6ef0ec0671b40e5b723385e281f745b431949fa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

