### PR TITLE
fix(agent-gui): enforce exact rail section grouping

### DIFF
--- a/apps/desktop/src/main/agentPowerSaveBlocker.test.ts
+++ b/apps/desktop/src/main/agentPowerSaveBlocker.test.ts
@@ -223,6 +223,7 @@ function createSession(id: string, status: string): WorkspaceAgentSession {
     pendingInteractions: [],
     permissionConfig: { configurable: false, modes: [] },
     pinnedAtUnixMs: null,
+    railSectionKey: "conversations",
     provider: "codex",
     providerSessionId: null,
     resumable: true,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -20,7 +20,8 @@ test("desktop agent activity adapter rejects missing protocol v2 session fields"
   for (const field of [
     "activeTurnId",
     "latestTurnInteractions",
-    "pendingInteractions"
+    "pendingInteractions",
+    "railSectionKey"
   ] as const) {
     const malformed = { ...createSession() } as Record<string, unknown>;
     delete malformed[field];
@@ -33,6 +34,17 @@ test("desktop agent activity adapter rejects missing protocol v2 session fields"
       new RegExp(`Protocol v2 contract error:.*${field}`)
     );
   }
+});
+
+test("desktop agent activity adapter rejects a blank rail section key", () => {
+  assert.throws(
+    () =>
+      agentActivitySessionFromTuttidSession(
+        workspaceId,
+        createSession({ railSectionKey: "  " })
+      ),
+    /railSectionKey must be a non-empty string/
+  );
 });
 
 test("desktop agent activity adapter preserves a settled latest turn on reload", () => {
@@ -104,6 +116,7 @@ test("desktop agent activity adapter maps typed canonical session control fields
       endedAtUnixMs: 30,
       goal: { objective: "Ship it", status: "active" },
       imported: true,
+      railSectionKey: "project:repo-1",
       permissionConfig: {
         configurable: true,
         defaultValue: "ask",
@@ -130,6 +143,7 @@ test("desktop agent activity adapter maps typed canonical session control fields
   assert.equal(session.endedAtUnixMs, 30);
   assert.deepEqual(session.goal, { objective: "Ship it", status: "active" });
   assert.equal(session.imported, true);
+  assert.equal(session.railSectionKey, "project:repo-1");
   assert.equal(session.permissionConfig?.defaultValue, "ask");
   assert.deepEqual(session.settings, { model: "gpt-5", planMode: true });
   assert.deepEqual(session.usage, {
@@ -1634,6 +1648,7 @@ function createSession(
     pinnedAtUnixMs: null,
     provider: "codex",
     providerSessionId: null,
+    railSectionKey: "conversations",
     resumable: true,
     settings: {},
     title: "Agent session",

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -478,6 +478,7 @@ export function agentActivitySessionFromTuttidSession(
     providerSessionId: session.providerSessionId ?? session.id,
     userId: DESKTOP_AGENT_GUI_CURRENT_USER_ID,
     cwd: session.cwd ?? "/",
+    railSectionKey: session.railSectionKey,
     title: session.title ?? "",
     activeTurnId: session.activeTurnId,
     activeTurn: session.activeTurn ?? null,
@@ -509,7 +510,8 @@ function assertProtocolV2SessionContract(session: WorkspaceAgentSession): void {
   const missing = [
     "activeTurnId",
     "latestTurnInteractions",
-    "pendingInteractions"
+    "pendingInteractions",
+    "railSectionKey"
   ].filter((field) => !Object.prototype.hasOwnProperty.call(value, field));
   if (missing.length > 0) {
     throw new Error(
@@ -522,6 +524,14 @@ function assertProtocolV2SessionContract(session: WorkspaceAgentSession): void {
   ) {
     throw new Error(
       "Protocol v2 contract error: workspace agent interaction collections must be arrays"
+    );
+  }
+  if (
+    typeof value.railSectionKey !== "string" ||
+    value.railSectionKey.trim().length === 0
+  ) {
+    throw new Error(
+      "Protocol v2 contract error: workspace agent railSectionKey must be a non-empty string"
     );
   }
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -1785,6 +1785,7 @@ function workspaceAgentSession(overrides: {
     pendingInteractions: [],
     permissionConfig: { configurable: false, modes: [] },
     pinnedAtUnixMs: null,
+    railSectionKey: "conversations",
     resumable: true,
     settings: overrides.settings ?? {},
     title: "Session 1",

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -94,6 +94,15 @@ Hosts must pass those calls through to the daemon section endpoints so project
 sections come from current user projects and session membership comes from
 persisted `rail_section_key`, not frontend cwd grouping or project-root
 filters.
+Every daemon `WorkspaceAgentSession` response carries the persisted membership
+as required `railSectionKey`. The desktop adapter rejects a missing or blank
+value as a protocol contract error; it must not manufacture `conversations` or
+derive a project key from `cwd`.
+The session service synchronously persists and reads back the initial runtime
+session before returning a successful Create response, so the response never
+races the runtime's asynchronous activity reporter. The store assigns
+`railSectionKey` on that first persistence and preserves it for the lifetime of
+the session, even if later runtime reports change `cwd` or the user-project list.
 Section and pinned-page results include required `totalCount` for the complete
 target-filtered scope before cursor pagination. AgentGUI uses it to subtract a
 transient active-row overlay from remaining unseen rows; hosts must preserve the
@@ -114,7 +123,11 @@ before cursor pagination; this is not a filter over already-loaded section
 pages. Search pages follow the same normalized ownership rule as section pages:
 returned sessions are upserted into the workspace engine, while the search
 query retains only ordered ids, cursor, and request state. The UI joins those
-ids to canonical engine entities. Hosts without this optional query may keep a
+ids to canonical engine entities. Search rows are placed by exact equality
+between the session's `railSectionKey` and a daemon-returned section key;
+`pinnedAtUnixMs` remains the independent pinned projection. Missing keys are
+invalid desktop protocol data, not a signal to infer membership from cwd or a
+resolved project. Hosts without this optional query may keep a
 loaded-row-only local title filter for previews, but desktop hosts must pass the
 backend query and pagination fields through unchanged.
 Activating a conversation must not by itself call `listSessionSections` again.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1313,8 +1313,18 @@ Show more heuristics. Page responses upsert their session entities into the
 workspace engine; the rail query cache stores only ordered session ids,
 section metadata, cursors, and totals. A pure projection joins those ids back
 to engine entities. Do not keep a second summary cache or manually patch
-section rows from conversation summaries. Removing a project removes that rail
-section from the section list; re-adding the same path reveals historical
+section rows from conversation summaries. Every daemon session carries its
+required persisted `railSectionKey`. An active session outside loaded pages and
+backend search results enter a section only when that key exactly equals the
+section key; pinned state remains independent. AgentGUI must not manufacture a
+session membership fallback or infer membership from cwd and resolved
+user-project paths. Empty project and Conversations section chrome remains
+visible from the current section inventory even when no exact membership rows
+exist or the initial membership request fails; preserving that chrome must not
+place any session into it. The daemon assigns the key before Create succeeds
+and treats it as immutable session identity metadata; later cwd observations do
+not move the session to another rail section. Removing a project removes that
+rail section from the section list; re-adding the same path reveals historical
 sessions with the same section key.
 The daemon first-page reader is a required production repository seam, not an
 optional fast path with a per-section fallback. Its SQLite query must be driven
@@ -1552,15 +1562,14 @@ enter the workspace engine's prompt queue instead of calling `sendInput`
 directly.
 Pending new-session activation is request- and session-scoped, not a
 workspace-wide creation lock. A workspace may have multiple pending new
-activations, and the conversation rail projects every optimistic session.
+activations, and conversation state retains every optimistic session.
 The engine's `pendingIntents` is the only owner. The conversation-list selector
 projects each missing session once and marks its row as a pending-activation
-projection. Runtime section pagination caches canonical session ids only; a pure
-rail display projection overlays the complete pending set into matching
-project/conversations sections and sorts it by conversation time. Pending rows
-must never be written into section pages, cursors, or membership invalidation,
-and the rail must not rely on the currently active row as its only optimistic
-overlay.
+projection. A pending intent has no persisted `railSectionKey`, so it remains
+outside formal rail sections until the canonical daemon session arrives; the
+frontend must not guess a section from its cwd. Runtime section pagination
+caches canonical session ids only. Pending rows must never be written into
+section pages, cursors, or membership invalidation.
 The pending row itself does not invalidate membership. Its transition to a
 canonical engine session does, and the query controller may keep only that
 session id—not a duplicate summary—as temporary reconciliation metadata.

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -643,7 +643,11 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   must instead use `idx_workspace_agent_sessions_rail_section_target_page` and
   `idx_workspace_agent_sessions_pinned_target_page` with an exact target
   predicate; an optional `OR` predicate cannot narrow the index range. For a
-  reported slow switch, correlate
+  rail that shows only the active/new session, inspect `*_failed` events for
+  `no such index`, then compare those required indexes with `sqlite_master`
+  even when their migration markers exist. Store startup must idempotently
+  restore missing rail pagination indexes; do not weaken `INDEXED BY` or fall
+  back to a full session scan. For a reported slow switch, correlate
   `agent_gui.conversation_rail.first_pages_slow` with
   `workspace.agent_session.sections.list_slow`: the renderer event separates
   request and controller-apply time, while the daemon event separates current
@@ -666,6 +670,10 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   the workspace DB retains history for removed projects. Scanning that full
   history or repeating canonical turn / interaction hydration per section makes
   the rail wait scale with project count even when every leaf query looks fast.
+  A database opened by different worktrees or intermediate builds can retain a
+  migration marker after a required physical index disappears; treating the
+  marker alone as proof of the schema invariant makes every section bootstrap
+  fail while an active-session overlay can misleadingly remain visible.
 - Fix:
   Keep page sessions in the workspace engine. Cache only ordered membership ids,
   cursor, `hasMore`, and `totalCount` in the controller query, then join ids to
@@ -676,6 +684,10 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   bootstrap as a required narrow repository seam: one requested-section-driven
   batch query, independent pinned and ordinary index branches, count/sort/limit
   on narrow session ids, then one cross-section canonical entity hydration.
+  Reassert required rail indexes with idempotent `CREATE INDEX IF NOT EXISTS`
+  during every store migration pass, including when the corresponding marker is
+  already recorded, so schema drift repairs itself without rewriting session
+  data.
   Do not add one `UNION ALL` arm per section; that restores section-count scaling
   and inherits SQLite's compound-select term limit.
 - Validation:
@@ -720,17 +732,14 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   record its own scratch cwd under
   `Documents/Codex/<yyyy-mm-dd>/<conversation>`.
 - Root cause:
-  Conversation project grouping is a view-model join of `cwd x userProjects`.
-  If a generated no-project cwd is not recognized before prefix/parent project
-  matching, the longest-parent project match can assign the session to a broad
-  project such as `$HOME`. Keep generated-path recognition in the host
-  `isNoProjectPath` callback because it has the user home-directory context;
-  a package-level suffix check would misclassify real projects that contain a
-  `Documents/tutti/session-<uuid>` subdirectory. External import has a similar
-  trap because provider transcripts may record `$HOME` or a provider-owned
-  scratch working directory as the cwd when no project was selected; that intent
-  must be persisted as session metadata rather than inferred later from
-  user-project prefix matching. A second loss point is runtime state projection:
+  Rail membership is classified once by the daemon when the session is first
+  persisted, using `cwd`, runtime no-project markers, and current user projects.
+  If a generated no-project marker is lost before that write, longest-parent
+  matching can assign the immutable `railSectionKey` to a broad project such as
+  `$HOME`. External import has a similar trap because provider transcripts may
+  record `$HOME` or a provider-owned scratch working directory as the cwd when
+  no project was selected; that intent must reach initial persistence as session
+  metadata. A second loss point is runtime state projection:
   rebuilding `runtimeContext` from only `cwd`, title, permissions, and visibility,
   or replacing it wholesale with `StateAdapter` output, drops launch-scoped
   markers such as `noProject` before durable rail classification runs.
@@ -745,8 +754,12 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   upsert should both use that classifier, matching exact user projects first,
   then preserving no-project/provider scratch cwd shapes as conversations, then
   applying longest parent-project matches. Do not rederive historical rail
-  assignment from the current user-project list during read pagination; keep
-  existing rail fields stable when a session's final cwd has not changed.
+  assignment from the current user-project list or a later cwd observation;
+  preserve every valid existing rail key unconditionally. A successful Create
+  response must synchronously read back the persisted session and its nonblank
+  key rather than racing the runtime's asynchronous activity reporter. AgentGUI
+  must project sessions only by exact key equality and must not retain a cwd-based
+  grouping fallback.
 - Validation:
   Run
   `pnpm --filter @tutti-os/agent-gui test -- agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts`,

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -24,6 +24,8 @@ export interface AgentActivitySession {
   model?: string | null;
   noProject?: boolean | null;
   cwd: string;
+  /** Backend-owned conversation-rail membership; absent for non-rail runtimes. */
+  railSectionKey?: string;
   title: string;
   activeTurnId: string | null;
   activeTurn: AgentActivityTurn | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiNodeViewConversation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiNodeViewConversation.spec.ts
@@ -4,178 +4,36 @@ import { describe, expect, it } from "vitest";
 import type { AgentGUIConversationSummary } from "./model/agentGuiConversationModel";
 import {
   ConversationMeta,
-  filterConversationSectionsBySearchMatches,
-  groupConversations
+  filterConversationSectionsBySearchMatches
 } from "./agentGuiNodeViewConversation";
 
-describe("groupConversations", () => {
-  it("places pinned conversations in a top pinned section ordered by pin time", () => {
-    const nowMs = new Date("2026-06-05T12:00:00Z").getTime();
-    const conversations: AgentGUIConversationSummary[] = [
-      conversation("project-chat", nowMs - 1000, {
-        project: project("/workspace/app", "App")
-      }),
-      conversation("older-pinned", nowMs - 3 * 24 * 60 * 60 * 1000, {
-        pinnedAtUnixMs: nowMs - 2000
-      }),
-      conversation("newer-pinned", nowMs - 24 * 60 * 60 * 1000, {
-        pinnedAtUnixMs: nowMs - 1000
-      })
-    ];
+describe("filterConversationSectionsBySearchMatches", () => {
+  it("removes sections without exact conversation id matches", () => {
+    const matching = conversation("matching", 2);
+    const unrelated = conversation("unrelated", 1);
 
-    const groups = groupConversations(conversations, labels);
-
-    expect(groups.map((group) => group.id)).toEqual([
-      "pinned",
-      "project:/workspace/app"
-    ]);
-    expect(groups.map((group) => group.kind)).toEqual(["pinned", "project"]);
-    expect(groups[0]?.items.map((item) => item.id)).toEqual([
-      "newer-pinned",
-      "older-pinned"
-    ]);
-    expect(groups[1]?.items.map((item) => item.id)).toEqual(["project-chat"]);
-  });
-
-  it("groups unpinned conversations by project updated time", () => {
-    const nowMs = new Date("2026-06-05T12:00:00Z").getTime();
-    const conversations: AgentGUIConversationSummary[] = [
-      conversation("older-app-chat", nowMs - 1000, {
-        project: project("/workspace/app", "App"),
-        sortTimeUnixMs: nowMs - 2_000
-      }),
-      conversation("newer-site-chat", nowMs - 10_000, {
-        project: project("/workspace/site", "Site"),
-        sortTimeUnixMs: nowMs - 20_000
-      }),
-      conversation("older-sort-pinned", nowMs, {
-        pinnedAtUnixMs: 1,
-        sortTimeUnixMs: 1
-      }),
-      conversation("unmatched-chat", nowMs - 3_000, {
-        sortTimeUnixMs: nowMs - 3_000
-      }),
-      conversation("newer-sort-pinned", nowMs - 1000, {
-        pinnedAtUnixMs: 1,
-        sortTimeUnixMs: 2
-      })
-    ];
-
-    const groups = groupConversations(conversations, labels, [
-      project("/workspace/app", "App", { updatedAtUnixMs: nowMs - 100_000 }),
-      project("/workspace/site", "Site", { updatedAtUnixMs: nowMs - 50_000 })
-    ]);
-
-    expect(groups.map((group) => group.id)).toEqual([
-      "pinned",
-      "project:/workspace/site",
-      "project:/workspace/app",
-      "conversations"
-    ]);
-    expect(groups.map((group) => group.kind)).toEqual([
-      "pinned",
-      "project",
-      "project",
-      "conversations"
-    ]);
-    expect(groups[0]?.items.map((item) => item.id)).toEqual([
-      "newer-sort-pinned",
-      "older-sort-pinned"
-    ]);
-    expect(groups[1]?.items.map((item) => item.id)).toEqual([
-      "newer-site-chat"
-    ]);
-    expect(groups[2]?.items.map((item) => item.id)).toEqual(["older-app-chat"]);
-    expect(groups[3]?.items.map((item) => item.id)).toEqual(["unmatched-chat"]);
-    expect(groups[3]?.label).toBe("Chats");
-  });
-
-  it("keeps user project sections visible when they have no conversations", () => {
-    const nowMs = new Date("2026-06-05T12:00:00Z").getTime();
-    const conversations: AgentGUIConversationSummary[] = [
-      conversation("app-chat", nowMs, {
-        project: project("/workspace/app", "App"),
-        sortTimeUnixMs: nowMs
-      })
-    ];
-
-    const groups = groupConversations(
-      conversations,
-      labels,
-      [project("/workspace/app", "App"), project("/workspace/empty", "Empty")],
-      { includeEmptyConversations: true }
-    );
-
-    expect(groups.map((group) => group.id)).toEqual([
-      "project:/workspace/app",
-      "project:/workspace/empty",
-      "conversations"
-    ]);
-    expect(groups[0]?.items.map((item) => item.id)).toEqual(["app-chat"]);
-    expect(groups[1]?.items).toEqual([]);
-    expect(groups[1]?.label).toBe("Empty");
-    expect(groups[2]?.items).toEqual([]);
-    expect(groups[2]?.label).toBe("Chats");
-  });
-
-  it("keeps the conversations section visible when it has no conversations", () => {
-    const groups = groupConversations([], labels, [], {
-      includeEmptyConversations: true
-    });
-
-    expect(groups.map((group) => group.id)).toEqual(["conversations"]);
-    expect(groups[0]?.items).toEqual([]);
-    expect(groups[0]?.label).toBe("Chats");
-  });
-
-  it("omits user project sections without matching conversations", () => {
-    const matching = conversation("weather", 100, {
-      project: project("/workspace/proj2", "proj2")
-    });
-
-    const groups = groupConversations(
-      [matching],
-      labels,
+    const filtered = filterConversationSectionsBySearchMatches(
       [
-        project("/workspace/proj2", "proj2"),
-        project("/workspace/empty", "empty")
+        {
+          id: "project:app",
+          kind: "project",
+          label: "App",
+          project: null,
+          items: [matching]
+        },
+        {
+          id: "conversations",
+          kind: "conversations",
+          label: "Chats",
+          project: null,
+          items: [unrelated]
+        }
       ],
-      { includeEmptyConversations: false }
+      [matching]
     );
 
-    expect(groups.map((group) => group.id)).toEqual([
-      "project:/workspace/proj2"
-    ]);
-    expect(groups[0]?.items.map((item) => item.id)).toEqual(["weather"]);
-  });
-
-  it("removes empty rail sections after applying search matches", () => {
-    const nowMs = new Date("2026-06-05T12:00:00Z").getTime();
-    const matching = conversation("hello-friend", nowMs, {
-      project: project("/workspace/app", "App")
-    });
-    const unrelated = conversation("other-chat", nowMs - 1_000, {
-      project: project("/workspace/other", "Other")
-    });
-    const sections = groupConversations(
-      [matching, unrelated],
-      labels,
-      [
-        project("/workspace/app", "App"),
-        project("/workspace/empty", "Empty"),
-        project("/workspace/other", "Other")
-      ],
-      { includeEmptyConversations: true }
-    );
-
-    const filtered = filterConversationSectionsBySearchMatches(sections, [
-      matching
-    ]);
-
-    expect(filtered.map((section) => section.id)).toEqual([
-      "project:/workspace/app"
-    ]);
-    expect(filtered[0]?.items.map((item) => item.id)).toEqual(["hello-friend"]);
+    expect(filtered.map((section) => section.id)).toEqual(["project:app"]);
+    expect(filtered[0]?.items.map((item) => item.id)).toEqual(["matching"]);
   });
 });
 
@@ -218,11 +76,6 @@ describe("ConversationMeta", () => {
   });
 });
 
-const labels = {
-  sectionPinned: "Pinned",
-  sectionConversations: "Chats"
-};
-
 const relativeLabels = {
   relativeTimeJustNow: "Just now",
   relativeTimeMinutes: (value: number) => `${value} minutes`,
@@ -244,19 +97,6 @@ function conversation(
     status: "ready",
     cwd: "/workspace",
     updatedAtUnixMs,
-    ...overrides
-  };
-}
-
-function project(
-  path: string,
-  label: string,
-  overrides: Partial<NonNullable<AgentGUIConversationSummary["project"]>> = {}
-) {
-  return {
-    id: path,
-    path,
-    label,
     ...overrides
   };
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiNodeViewConversation.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiNodeViewConversation.tsx
@@ -1,5 +1,4 @@
 import { Spinner } from "@tutti-os/ui-system";
-import { normalizeAgentGUIProjectPath } from "./model/agentGuiConversationProjectResolver";
 import { AskLinedIcon } from "@tutti-os/ui-system/icons";
 import { resolveAgentGUIConversationSortTimeUnixMs } from "./model/agentGuiConversationModel";
 import type { AgentGUINodeViewModel } from "./model/agentGuiNodeTypes";
@@ -102,135 +101,6 @@ export function ConversationMeta({
   );
 }
 
-export function groupConversations(
-  conversations: AgentGUINodeViewModel["rail"]["conversations"],
-  labels: Pick<AgentGUIViewLabels, "sectionPinned" | "sectionConversations">,
-  userProjects: AgentGUINodeViewModel["rail"]["userProjects"] = [],
-  options: { includeEmptyConversations?: boolean } = {}
-): ConversationSection[] {
-  const groups: ConversationSection[] = [];
-  const pinned = conversations
-    .filter((conversation) => (conversation.pinnedAtUnixMs ?? 0) > 0)
-    .sort(
-      (left, right) =>
-        (right.pinnedAtUnixMs ?? 0) - (left.pinnedAtUnixMs ?? 0) ||
-        resolveAgentGUIConversationSortTimeUnixMs(right) -
-          resolveAgentGUIConversationSortTimeUnixMs(left) ||
-        left.id.localeCompare(right.id)
-    );
-  if (pinned.length > 0) {
-    groups.push({
-      id: "pinned",
-      kind: "pinned",
-      label: labels.sectionPinned,
-      project: null,
-      items: pinned
-    });
-  }
-  const projectGroups = new Map<string, ConversationSectionWithSort>();
-  const normalizedProjectPathByPath = new Map<string, string>();
-  const normalizeProjectPath = (path: string) =>
-    normalizeConversationProjectPathCached(path, normalizedProjectPathByPath);
-  userProjects.forEach((project, projectOrder) => {
-    const normalizedPath = normalizeProjectPath(project.path);
-    const sectionId = conversationProjectSectionId(project, normalizedPath);
-    if (projectGroups.has(sectionId)) {
-      return;
-    }
-    projectGroups.set(sectionId, {
-      id: sectionId,
-      kind: "project",
-      label: project.label,
-      project,
-      items: [],
-      projectOrder,
-      sectionOrder: 0,
-      projectUpdatedAtUnixMs: resolveConversationProjectUpdatedAtUnixMs(project)
-    });
-  });
-  if (options.includeEmptyConversations) {
-    projectGroups.set("conversations", {
-      id: "conversations",
-      kind: "conversations",
-      label: labels.sectionConversations,
-      project: null,
-      items: [],
-      projectOrder: Number.MAX_SAFE_INTEGER,
-      sectionOrder: 1,
-      projectUpdatedAtUnixMs: 0
-    });
-  }
-  for (const conversation of conversations) {
-    if ((conversation.pinnedAtUnixMs ?? 0) > 0) {
-      continue;
-    }
-    if (!conversation.project) {
-      const existing = projectGroups.get("conversations");
-      if (existing) {
-        existing.items.push(conversation);
-        continue;
-      }
-      projectGroups.set("conversations", {
-        id: "conversations",
-        kind: "conversations",
-        label: labels.sectionConversations,
-        project: null,
-        items: [conversation],
-        projectOrder: Number.MAX_SAFE_INTEGER,
-        sectionOrder: 1,
-        projectUpdatedAtUnixMs: 0
-      });
-      continue;
-    }
-
-    const normalizedPath = normalizeProjectPath(conversation.project.path);
-    const sectionId = conversationProjectSectionId(
-      conversation.project,
-      normalizedPath
-    );
-    const existing = projectGroups.get(sectionId);
-    if (existing) {
-      existing.items.push(conversation);
-      continue;
-    }
-    projectGroups.set(sectionId, {
-      id: sectionId,
-      kind: "project",
-      label: conversation.project.label,
-      project: conversation.project,
-      items: [conversation],
-      projectOrder: Number.MAX_SAFE_INTEGER - 1,
-      sectionOrder: 0,
-      projectUpdatedAtUnixMs: resolveConversationProjectUpdatedAtUnixMs(
-        conversation.project
-      )
-    });
-  }
-  groups.push(
-    ...[...projectGroups.values()]
-      .filter(
-        (group) => options.includeEmptyConversations || group.items.length > 0
-      )
-      .sort(
-        (left, right) =>
-          left.sectionOrder - right.sectionOrder ||
-          right.projectUpdatedAtUnixMs - left.projectUpdatedAtUnixMs ||
-          left.projectOrder - right.projectOrder ||
-          left.label.localeCompare(right.label) ||
-          left.id.localeCompare(right.id)
-      )
-      .map(
-        ({
-          projectOrder: _projectOrder,
-          sectionOrder: _sectionOrder,
-          projectUpdatedAtUnixMs: _projectUpdatedAtUnixMs,
-          ...group
-        }) => group
-      )
-  );
-  return groups;
-}
-
 export function filterConversationSectionsBySearchMatches(
   sections: readonly ConversationSection[],
   matchingConversations: AgentGUINodeViewModel["rail"]["conversations"]
@@ -246,46 +116,6 @@ export function filterConversationSectionsBySearchMatches(
       )
     }))
     .filter((section) => section.items.length > 0);
-}
-
-type ConversationSectionWithSort = ConversationSection & {
-  projectOrder: number;
-  sectionOrder: number;
-  projectUpdatedAtUnixMs: number;
-};
-
-function resolveConversationProjectUpdatedAtUnixMs(
-  project: ConversationSection["project"]
-): number {
-  if (!project) {
-    return 0;
-  }
-  return (
-    project.updatedAtUnixMs ??
-    project.lastUsedAtUnixMs ??
-    project.createdAtUnixMs ??
-    0
-  );
-}
-
-function normalizeConversationProjectPathCached(
-  path: string,
-  normalizedPathByPath: Map<string, string>
-): string {
-  const cached = normalizedPathByPath.get(path);
-  if (cached !== undefined) {
-    return cached;
-  }
-  const normalized = normalizeAgentGUIProjectPath(path);
-  normalizedPathByPath.set(path, normalized);
-  return normalized;
-}
-
-function conversationProjectSectionId(
-  project: NonNullable<ConversationSection["project"]>,
-  normalizedPath: string
-): string {
-  return project.sectionKey?.trim() || `project:${normalizedPath}`;
 }
 
 function conversationMetaKind(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.stableHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.stableHelpers.ts
@@ -226,6 +226,7 @@ export function conversationSummariesRenderEqual(
     ) &&
     left.status === right.status &&
     left.cwd === right.cwd &&
+    left.railSectionKey === right.railSectionKey &&
     left.pinnedAtUnixMs === right.pinnedAtUnixMs &&
     left.sortTimeUnixMs === right.sortTimeUnixMs &&
     left.updatedAtUnixMs === right.updatedAtUnixMs &&
@@ -257,6 +258,7 @@ export function conversationProjectsRenderEqual(
       ? !left && !right
       : left.id === right.id &&
         left.path === right.path &&
+        left.sectionKey === right.sectionKey &&
         left.label === right.label &&
         left.createdAtUnixMs === right.createdAtUnixMs &&
         left.updatedAtUnixMs === right.updatedAtUnixMs &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.search.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.search.spec.tsx
@@ -2,6 +2,7 @@ import {
   normalizeAgentActivitySession,
   type AgentActivityTurn
 } from "@tutti-os/agent-activity-core";
+import { TooltipProvider } from "@tutti-os/ui-system";
 import {
   act,
   render,
@@ -168,6 +169,7 @@ describe("useAgentGUIConversationRailQuery search", () => {
         latestTurnInteractions: [],
         pendingInteractions: [],
         provider: "codex",
+        railSectionKey: "conversations",
         title: "streaming session",
         updatedAtUnixMs: 1,
         workspaceId: "workspace-1"
@@ -225,6 +227,7 @@ describe("useAgentGUIConversationRailQuery search", () => {
         latestTurnInteractions: [],
         pendingInteractions: [],
         provider: "codex",
+        railSectionKey: "conversations",
         title: "streaming session",
         updatedAtUnixMs: 1,
         workspaceId: "workspace-1"
@@ -308,6 +311,94 @@ describe("useAgentGUIConversationRailQuery search", () => {
     });
 
     expect(railCommitCount).toBe(previousRailCommitCount);
+  });
+
+  it("keeps empty section chrome visible when the first membership request fails", async () => {
+    const engine = createTestAgentSessionEngine("workspace-1");
+    const runtime = {
+      getSessionEngine: () => engine,
+      async listSessionSections() {
+        throw new Error("section membership unavailable");
+      },
+      async listSessionSectionPage() {
+        throw new Error("section membership unavailable");
+      }
+    } as unknown as AgentActivityRuntime;
+    const userProjects = [
+      {
+        id: "workspace-project",
+        label: "Workspace",
+        path: "/workspace",
+        sectionKey: "project:/workspace",
+        createdAtUnixMs: 1,
+        updatedAtUnixMs: 1,
+        lastUsedAtUnixMs: 1
+      }
+    ];
+
+    function RailHarness(): React.JSX.Element {
+      const railQuery = useAgentGUIConversationRailQuery({
+        activeConversationId: null,
+        conversationFilter: { kind: "all" },
+        conversationQuery: "",
+        previewMode: false,
+        sectionAgentTargetFallbackId: null,
+        userProjects,
+        workspaceId: "workspace-1"
+      });
+      return (
+        <AgentGUIConversationRailPane
+          activeConversation={null}
+          activeConversationId={null}
+          agentTargets={[]}
+          agentTargetsLoading={false}
+          conversationFilter={{ kind: "all" }}
+          conversationQuery=""
+          conversations={[]}
+          createConversationDisabled={false}
+          isCollapsed={false}
+          isDeletingConversation={false}
+          isDeletingProjectConversations={false}
+          isLoadingConversations={false}
+          labels={RAIL_LABELS}
+          pendingDeleteConversationId={null}
+          previewMode={false}
+          railQuery={railQuery}
+          sectionAgentTargetFallbackId={null}
+          uiLanguage="en"
+          userProjects={userProjects}
+          workspaceId="workspace-1"
+          workspaceUserProjectI18n={RAIL_PROJECT_I18N}
+          onCancelDeleteConversation={() => {}}
+          onConfirmDeleteConversation={() => {}}
+          onConfirmDeleteConversations={() => {}}
+          onConfirmDeleteProjectConversations={async () => []}
+          onConversationQueryChange={() => {}}
+          onCreateConversation={() => {}}
+          onMarkConversationUnread={() => {}}
+          onRemoveProject={() => {}}
+          onRequestDeleteConversation={() => {}}
+          onRequestRenameConversation={() => {}}
+          onSelectConversation={() => {}}
+          onSelectConversationFilterTarget={() => {}}
+          onToggleConversationPinned={() => {}}
+          onUpdateConversationFilter={() => {}}
+        />
+      );
+    }
+
+    render(
+      <AgentActivityRuntimeProvider runtime={runtime}>
+        <TooltipProvider>
+          <RailHarness />
+        </TooltipProvider>
+      </AgentActivityRuntimeProvider>
+    );
+
+    await screen.findByText("Workspace");
+    expect(screen.getByText("Conversations")).toBeTruthy();
+    expect(screen.getAllByText("No conversations")).toHaveLength(2);
+    expect(screen.queryByText("Conversation unavailable")).toBeNull();
   });
 });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -490,7 +490,7 @@ export function useAgentGUINodeController({
   // NOTE: project metadata is intentionally NOT written back into the shared
   // conversation store. `conversation.project` is a per-window JOIN of cwd ×
   // userProjects; deriving it here and persisting it caused cross-window update
-  // storms. It is now derived in the view layer (groupConversations) instead.
+  // storms. Rail membership now comes from the backend railSectionKey contract.
 
   useEffect(() => {
     if (activeConversationId === null && isComposerHome) {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.ts
@@ -325,6 +325,7 @@ export function conversationSummaryFromAgentSession(
       session.activeTurnId ? "working" : "idle"
     ),
     cwd: session.cwd?.trim() ?? "",
+    railSectionKey: session.railSectionKey,
     project: resolveConversationProject(session, projectResolver),
     ...(isExternalImportNoProjectSession(session)
       ? { projectMode: "none" }
@@ -453,6 +454,7 @@ function conversationSummaryFromActivity(
     titleFallback,
     status,
     cwd: session?.cwd.trim() ?? "",
+    ...(session ? { railSectionKey: session.railSectionKey } : {}),
     project: resolveConversationProject(session, options.projectResolver),
     ...(isExternalImportNoProjectSession(session)
       ? { projectMode: "none" }

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.spec.ts
@@ -5,6 +5,9 @@ import {
   insertConversationRailSectionOverlay,
   conversationSummariesRenderEqual,
   isConversationRailInitialLoadPending,
+  projectConversationRailMemberships,
+  projectConversationRailSearchSections,
+  projectConversationRailSectionsByExactKey,
   projectConversationRailSectionsWithActiveConversation,
   planRuntimeRailMembershipRefresh,
   projectRuntimeSectionsToConversationRailMemberships,
@@ -12,6 +15,12 @@ import {
   resolveConversationRailActiveConversation
 } from "./agentGuiConversationRail";
 import type { ConversationRailSectionMembership } from "./agentGuiConversationRail";
+import { preserveConversationRailSectionTemplates } from "./agentGuiConversationRailSectionTemplates";
+
+const railLabels = {
+  sectionConversations: "Conversations",
+  sectionPinned: "Pinned"
+};
 
 function conversation(
   id: string,
@@ -22,6 +31,7 @@ function conversation(
     id,
     pinnedAtUnixMs,
     provider: "codex",
+    railSectionKey: "project:/workspace",
     status: "ready",
     title: id,
     updatedAtUnixMs: 1
@@ -239,19 +249,41 @@ describe("projectRuntimeSectionsToConversationRailMemberships", () => {
   });
 });
 
+describe("projectConversationRailMemberships", () => {
+  it("requires exact agreement between the session key and section key", () => {
+    const exact = conversation("exact");
+    const conflicting = {
+      ...conversation("conflicting"),
+      railSectionKey: "conversations"
+    };
+
+    const projected = projectConversationRailMemberships({
+      conversations: [exact, conflicting],
+      labels: {
+        sectionConversations: "Conversations",
+        sectionPinned: "Pinned"
+      },
+      sections: membership([exact, conflicting])
+    });
+
+    expect(projected[0]?.items.map((item) => item.id)).toEqual(["exact"]);
+  });
+});
+
 describe("projectConversationRailSectionsWithTransientConversations", () => {
   const labels = {
     sectionConversations: "Conversations",
     sectionPinned: "Pinned"
   };
 
-  it("overlays every pending row newest-first without mutating canonical sections", () => {
+  it("keeps pending rows out of project sections until exact membership arrives", () => {
     const canonical = section([conversation("canonical")]);
     const project = canonical[0]?.project ?? null;
     const first = {
       ...conversation("session-1"),
       project,
       projectionSource: "pending_activation" as const,
+      railSectionKey: undefined,
       sortTimeUnixMs: 10,
       updatedAtUnixMs: 10
     };
@@ -259,6 +291,7 @@ describe("projectConversationRailSectionsWithTransientConversations", () => {
       ...conversation("session-2"),
       project,
       projectionSource: "pending_activation" as const,
+      railSectionKey: undefined,
       sortTimeUnixMs: 20,
       updatedAtUnixMs: 20
     };
@@ -272,11 +305,8 @@ describe("projectConversationRailSectionsWithTransientConversations", () => {
       }
     );
 
-    expect(projected[0]?.items.map((item) => item.id)).toEqual([
-      "session-2",
-      "session-1",
-      "canonical"
-    ]);
+    expect(projected[0]?.items.map((item) => item.id)).toEqual(["canonical"]);
+    expect(projected).toHaveLength(1);
     expect(canonical[0]?.items.map((item) => item.id)).toEqual(["canonical"]);
   });
 
@@ -293,6 +323,7 @@ describe("projectConversationRailSectionsWithTransientConversations", () => {
       ...conversation("session-2"),
       project,
       projectionSource: "pending_activation" as const,
+      railSectionKey: undefined,
       sortTimeUnixMs: 30,
       updatedAtUnixMs: 30
     };
@@ -306,8 +337,8 @@ describe("projectConversationRailSectionsWithTransientConversations", () => {
       }
     );
 
+    expect(projected).toHaveLength(1);
     expect(projected[0]?.items.map((item) => item.id)).toEqual([
-      "session-2",
       "session-1",
       "older"
     ]);
@@ -341,7 +372,7 @@ describe("projectConversationRailSectionsWithActiveConversation", () => {
 
     const projected = projectConversationRailSectionsWithActiveConversation({
       activeConversation: active,
-      labels,
+      labels: railLabels,
       sections
     });
 
@@ -368,14 +399,14 @@ describe("projectConversationRailSectionsWithActiveConversation", () => {
 
     const projected = projectConversationRailSectionsWithActiveConversation({
       activeConversation: active,
-      labels,
+      labels: railLabels,
       sections: section([active])
     });
 
     expect(projected.activeOverlay?.conversation).toBe(active);
   });
 
-  it("overlays only the missing active row into its matching server section", () => {
+  it("uses the active row's exact key instead of its resolved project", () => {
     const active = {
       ...conversation("active"),
       project: {
@@ -383,7 +414,8 @@ describe("projectConversationRailSectionsWithActiveConversation", () => {
         label: "Workspace",
         path: "/workspace",
         sectionKey: "project:/workspace"
-      }
+      },
+      railSectionKey: "conversations"
     };
     const sections = section([conversation("recent")]);
 
@@ -393,13 +425,17 @@ describe("projectConversationRailSectionsWithActiveConversation", () => {
       sections
     });
 
-    expect(projected.sections).toBe(sections);
     expect(projected.activeOverlay?.conversation.id).toBe("active");
-    expect(projected.activeOverlay?.sectionId).toBe("project:/workspace");
+    expect(projected.activeOverlay?.sectionId).toBe("conversations");
+    expect(projected.activeOverlay?.conversation.project).toBeNull();
+    expect(projected.sections.map((item) => item.id)).toEqual([
+      "project:/workspace",
+      "conversations"
+    ]);
     expect(sections[0]?.items.map((item) => item.id)).toEqual(["recent"]);
   });
 
-  it("creates a transient project section when the server page omits it", () => {
+  it("creates an exact project overlay when its keyed section is not loaded", () => {
     const active = {
       ...conversation("active"),
       project: {
@@ -407,7 +443,8 @@ describe("projectConversationRailSectionsWithActiveConversation", () => {
         label: "Other",
         path: "/other",
         sectionKey: "project:/other"
-      }
+      },
+      railSectionKey: "project:/other"
     };
 
     const projected = projectConversationRailSectionsWithActiveConversation({
@@ -425,6 +462,211 @@ describe("projectConversationRailSectionsWithActiveConversation", () => {
       conversation: active,
       sectionId: "project:/other"
     });
+  });
+
+  it("does not project an active row whose backend key is absent", () => {
+    const active = {
+      ...conversation("active"),
+      railSectionKey: undefined
+    };
+    const sections = section([conversation("recent")]);
+
+    const projected = projectConversationRailSectionsWithActiveConversation({
+      activeConversation: active,
+      labels,
+      sections
+    });
+
+    expect(projected).toEqual({ activeOverlay: null, sections });
+  });
+});
+
+describe("projectConversationRailSearchSections", () => {
+  it("uses exact loaded membership and never infers missing membership from cwd", () => {
+    const loaded = conversation("loaded");
+    const resolvedProject = section([])[0]?.project ?? null;
+    const missing = {
+      ...conversation("missing"),
+      cwd: "/workspace/packages/app",
+      project: resolvedProject,
+      railSectionKey: "conversations"
+    };
+
+    const groups = projectConversationRailSearchSections({
+      conversations: [loaded, missing],
+      labels: {
+        sectionConversations: "Conversations",
+        sectionPinned: "Pinned"
+      },
+      sections: section([loaded])
+    });
+
+    expect(
+      groups.map((group) => [group.id, group.items.map((item) => item.id)])
+    ).toEqual([
+      ["project:/workspace", ["loaded"]],
+      ["conversations", ["missing"]]
+    ]);
+  });
+
+  it("preserves pinned and authoritative section order", () => {
+    const projectA = conversation("project-a");
+    const projectB = {
+      ...conversation("project-b"),
+      railSectionKey: "project:/b",
+      project: {
+        id: "b",
+        label: "B",
+        path: "/b",
+        sectionKey: "project:/b"
+      }
+    };
+    const pinned = {
+      ...conversation("pinned"),
+      pinnedAtUnixMs: 1,
+      updatedAtUnixMs: 0
+    };
+
+    const groups = projectConversationRailSearchSections({
+      conversations: [projectA, projectB, pinned],
+      labels: railLabels,
+      sections: [
+        {
+          id: "project:/b",
+          kind: "project",
+          label: "B",
+          project: projectB.project,
+          items: []
+        },
+        ...section([])
+      ]
+    });
+
+    expect(groups.map((group) => group.id)).toEqual([
+      "pinned",
+      "project:/b",
+      "project:/workspace"
+    ]);
+  });
+});
+
+describe("projectConversationRailSectionsByExactKey", () => {
+  it("uses only exact backend keys and keeps empty authoritative sections", () => {
+    const projectSummary = {
+      id: "workspace",
+      label: "Workspace",
+      path: "/workspace",
+      sectionKey: "project:/workspace"
+    };
+    const exactProject = {
+      ...conversation("exact-project"),
+      project: projectSummary
+    };
+    const conversations = {
+      ...conversation("general"),
+      cwd: "/workspace/nested",
+      project: projectSummary,
+      railSectionKey: "conversations"
+    };
+    const missingKey = {
+      ...conversation("missing-key"),
+      project: projectSummary,
+      railSectionKey: undefined
+    };
+
+    const groups = projectConversationRailSectionsByExactKey({
+      conversations: [conversations, missingKey, exactProject],
+      labels: railLabels,
+      userProjects: [
+        {
+          ...projectSummary,
+          createdAtUnixMs: 1,
+          updatedAtUnixMs: 1,
+          lastUsedAtUnixMs: 1
+        },
+        {
+          id: "empty",
+          label: "Empty",
+          path: "/empty",
+          sectionKey: "project:/empty",
+          createdAtUnixMs: 1,
+          updatedAtUnixMs: 1,
+          lastUsedAtUnixMs: 1
+        }
+      ],
+      includeEmptySections: true
+    });
+
+    expect(
+      groups.map((group) => [group.id, group.items.map((item) => item.id)])
+    ).toEqual([
+      ["project:/workspace", ["exact-project"]],
+      ["project:/empty", []],
+      ["conversations", ["general"]]
+    ]);
+  });
+});
+
+describe("preserveConversationRailSectionTemplates", () => {
+  it("keeps project and conversations sections visible when membership is empty", () => {
+    const groups = preserveConversationRailSectionTemplates({
+      labels: railLabels,
+      sections: [],
+      userProjects: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: "/workspace",
+          sectionKey: "project:/workspace",
+          createdAtUnixMs: 1,
+          updatedAtUnixMs: 1,
+          lastUsedAtUnixMs: 1
+        }
+      ]
+    });
+
+    expect(
+      groups.map((group) => [group.id, group.items.map((item) => item.id)])
+    ).toEqual([
+      ["project:/workspace", []],
+      ["conversations", []]
+    ]);
+  });
+
+  it("preserves exact projected items without inferring missing membership", () => {
+    const exact = conversation("exact");
+    const groups = preserveConversationRailSectionTemplates({
+      labels: railLabels,
+      sections: section([exact]),
+      userProjects: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: "/workspace",
+          sectionKey: "project:/workspace",
+          createdAtUnixMs: 1,
+          updatedAtUnixMs: 1,
+          lastUsedAtUnixMs: 1
+        },
+        {
+          id: "empty",
+          label: "Empty",
+          path: "/empty",
+          sectionKey: "project:/empty",
+          createdAtUnixMs: 1,
+          updatedAtUnixMs: 1,
+          lastUsedAtUnixMs: 1
+        }
+      ]
+    });
+
+    expect(
+      groups.map((group) => [group.id, group.items.map((item) => item.id)])
+    ).toEqual([
+      ["project:/workspace", ["exact"]],
+      ["project:/empty", []],
+      ["conversations", []]
+    ]);
   });
 });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts
@@ -3,10 +3,7 @@ import type {
   AgentActivityRuntimeSessionSection
 } from "../../../agentActivityRuntime";
 import type { AgentGUINodeViewModel } from "./agentGuiNodeTypes";
-import {
-  groupConversations,
-  type ConversationSection
-} from "../agentGuiNodeViewConversation";
+import type { ConversationSection } from "../agentGuiNodeViewConversation";
 import { resolveAgentGUIConversationSortTimeUnixMs } from "./agentGuiConversationModel";
 import { normalizeAgentGUIProjectPath } from "./agentGuiConversationProjectResolver";
 
@@ -91,12 +88,13 @@ export function projectConversationRailSectionsWithTransientConversations(input:
   const loadedIds = new Set(
     input.sections.flatMap((section) => section.items.map((item) => item.id))
   );
-  const transientSections = groupConversations(
-    transientConversations.filter(
+  const transientSections = projectConversationsByExactRailSectionKey({
+    conversations: transientConversations.filter(
       (conversation) => !loadedIds.has(conversation.id)
     ),
-    input.labels
-  );
+    labels: input.labels,
+    sections: input.sections
+  });
   if (transientSections.length === 0) {
     return input.sections;
   }
@@ -176,52 +174,37 @@ export function projectConversationRailSectionsWithActiveConversation(input: {
     return { activeOverlay: null, sections: input.sections };
   }
 
-  const loadedSection = input.sections.find((section) =>
-    section.items.some((item) => item.id === activeConversationId)
-  );
-  if (loadedSection) {
-    return {
-      activeOverlay: {
-        conversation:
-          loadedSection.kind === "project"
-            ? conversationWithRailProject(
-                activeConversation,
-                loadedSection.project
-              )
-            : activeConversation,
-        sectionId: loadedSection.id
-      },
-      sections: input.sections
-    };
-  }
-
-  const activeSection = groupConversations(
-    [activeConversation],
-    input.labels
-  )[0];
-  if (!activeSection) {
+  const activeSectionId = conversationRailSectionId(activeConversation);
+  if (!activeSectionId) {
     return { activeOverlay: null, sections: input.sections };
   }
-
-  const matchingSectionIndex = input.sections.findIndex(
-    (section) => section.id === activeSection.id
+  const matchingSection = input.sections.find(
+    (section) => section.id === activeSectionId
   );
-  if (matchingSectionIndex >= 0) {
-    const matchingSection = input.sections[matchingSectionIndex];
+  if (matchingSection) {
     return {
       activeOverlay: {
         conversation:
-          matchingSection?.kind === "project"
+          matchingSection.kind === "project"
             ? conversationWithRailProject(
                 activeConversation,
                 matchingSection.project
               )
             : activeConversation,
-        sectionId: activeSection.id
+        sectionId: matchingSection.id
       },
       sections: input.sections
     };
   }
+
+  const activeSection = createExactConversationRailSection(
+    activeConversation,
+    input.labels
+  );
+  if (!activeSection) {
+    return { activeOverlay: null, sections: input.sections };
+  }
+  const projectedConversation = activeSection.items[0] ?? activeConversation;
 
   const transientSection = { ...activeSection, items: [] };
   let sections: ConversationSection[];
@@ -246,7 +229,7 @@ export function projectConversationRailSectionsWithActiveConversation(input: {
   }
   return {
     activeOverlay: {
-      conversation: activeConversation,
+      conversation: projectedConversation,
       sectionId: activeSection.id
     },
     sections
@@ -260,6 +243,171 @@ function conversationWithRailProject(
   return conversationProjectsRenderEqual(conversation.project, project)
     ? conversation
     : { ...conversation, project };
+}
+
+function conversationRailSectionId(
+  conversation: AgentGUINodeViewModel["rail"]["conversations"][number]
+): string | null {
+  if ((conversation.pinnedAtUnixMs ?? 0) > 0) {
+    return "pinned";
+  }
+  const sectionKey = conversation.railSectionKey?.trim() ?? "";
+  return sectionKey || null;
+}
+
+function createExactConversationRailSection(
+  conversation: AgentGUINodeViewModel["rail"]["conversations"][number],
+  labels: ConversationRailLabels
+): ConversationSection | null {
+  const sectionId = conversationRailSectionId(conversation);
+  if (!sectionId) {
+    return null;
+  }
+  if (sectionId === "pinned") {
+    return {
+      id: sectionId,
+      kind: "pinned",
+      label: labels.sectionPinned,
+      project: null,
+      items: [{ ...conversation, project: null }]
+    };
+  }
+  if (sectionId === "conversations") {
+    return {
+      id: sectionId,
+      kind: "conversations",
+      label: labels.sectionConversations,
+      project: null,
+      items: [{ ...conversation, project: null }]
+    };
+  }
+  const project = conversation.project;
+  if (project?.sectionKey?.trim() !== sectionId) {
+    return null;
+  }
+  return {
+    id: sectionId,
+    kind: "project",
+    label: project.label,
+    project,
+    items: [conversationWithRailProject(conversation, project)]
+  };
+}
+
+function projectConversationsByExactRailSectionKey(input: {
+  conversations: AgentGUINodeViewModel["rail"]["conversations"];
+  labels: ConversationRailLabels;
+  sections: readonly ConversationSection[];
+  includeEmptySections?: boolean;
+}): ConversationSection[] {
+  const sectionTemplates = new Map(
+    input.sections.map((section) => [section.id, section] as const)
+  );
+  const projected = new Map<string, ConversationSection>();
+  if (input.includeEmptySections) {
+    for (const section of input.sections) {
+      if (section.kind === "pinned") continue;
+      projected.set(section.id, { ...section, items: [] });
+    }
+  }
+  for (const conversation of input.conversations) {
+    const sectionId = conversationRailSectionId(conversation);
+    if (!sectionId) continue;
+    const template = sectionTemplates.get(sectionId);
+    const section =
+      template ??
+      createExactConversationRailSection(conversation, input.labels);
+    if (!section) continue;
+    const projectedConversation =
+      section.kind === "project"
+        ? conversationWithRailProject(conversation, section.project)
+        : conversation.project
+          ? { ...conversation, project: null }
+          : conversation;
+    const existing = projected.get(sectionId);
+    if (existing) {
+      existing.items.push(projectedConversation);
+      continue;
+    }
+    projected.set(sectionId, {
+      ...section,
+      items: [projectedConversation]
+    });
+  }
+  const sorted = new Map(
+    [...projected].map(([id, section]) => [
+      id,
+      {
+        ...section,
+        items:
+          section.kind === "pinned"
+            ? sortPinnedConversations(section.items)
+            : sortConversations(section.items)
+      }
+    ])
+  );
+  const result: ConversationSection[] = [];
+  const append = (id: string) => {
+    const section = sorted.get(id);
+    if (!section) return;
+    result.push(section);
+    sorted.delete(id);
+  };
+  append("pinned");
+  for (const section of input.sections) {
+    if (section.kind === "pinned" || section.kind === "conversations") {
+      continue;
+    }
+    append(section.id);
+  }
+  [...sorted.values()]
+    .filter((section) => section.kind === "project")
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .forEach((section) => append(section.id));
+  for (const section of input.sections) {
+    if (section.kind === "conversations") append(section.id);
+  }
+  append("conversations");
+  [...sorted.keys()].sort().forEach(append);
+  return result;
+}
+
+export function projectConversationRailSectionsByExactKey(input: {
+  conversations: AgentGUINodeViewModel["rail"]["conversations"];
+  labels: ConversationRailLabels;
+  userProjects: AgentGUINodeViewModel["rail"]["userProjects"];
+  includeEmptySections?: boolean;
+}): ConversationSection[] {
+  const seen = new Set<string>();
+  const sections: ConversationSection[] = input.userProjects.flatMap(
+    (project) => {
+      const sectionKey = project.sectionKey?.trim() ?? "";
+      if (!sectionKey || seen.has(sectionKey)) return [];
+      seen.add(sectionKey);
+      return [
+        {
+          id: sectionKey,
+          kind: "project" as const,
+          label: project.label,
+          project,
+          items: []
+        }
+      ];
+    }
+  );
+  sections.push({
+    id: "conversations",
+    kind: "conversations",
+    label: input.labels.sectionConversations,
+    project: null,
+    items: []
+  });
+  return projectConversationsByExactRailSectionKey({
+    conversations: input.conversations,
+    labels: input.labels,
+    sections,
+    includeEmptySections: input.includeEmptySections
+  });
 }
 
 export type ConversationRailMembershipRefreshPlan =
@@ -426,6 +574,8 @@ export function projectConversationRailMemberships(input: {
     items: section.sessionIds.flatMap((id) => {
       const conversation = conversationsById.get(id);
       if (!conversation) return [];
+      const exactSectionId = conversationRailSectionId(conversation);
+      if (exactSectionId !== section.id) return [];
       return [
         section.kind === "project"
           ? { ...conversation, project: section.project }
@@ -433,6 +583,14 @@ export function projectConversationRailMemberships(input: {
       ];
     })
   }));
+}
+
+export function projectConversationRailSearchSections(input: {
+  conversations: AgentGUINodeViewModel["rail"]["conversations"];
+  labels: ConversationRailLabels;
+  sections: readonly ConversationSection[];
+}): ConversationSection[] {
+  return projectConversationsByExactRailSectionKey(input);
 }
 
 export function stabilizeConversationSections(
@@ -581,6 +739,7 @@ export function conversationSummariesRenderEqual(
     left.titleFallback === right.titleFallback &&
     left.status === right.status &&
     left.cwd === right.cwd &&
+    left.railSectionKey === right.railSectionKey &&
     left.pinnedAtUnixMs === right.pinnedAtUnixMs &&
     left.sortTimeUnixMs === right.sortTimeUnixMs &&
     left.updatedAtUnixMs === right.updatedAtUnixMs &&
@@ -602,6 +761,7 @@ export function conversationProjectsRenderEqual(
       ? !left && !right
       : left.id === right.id &&
         left.path === right.path &&
+        left.sectionKey === right.sectionKey &&
         left.label === right.label &&
         left.createdAtUnixMs === right.createdAtUnixMs &&
         left.updatedAtUnixMs === right.updatedAtUnixMs &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailSectionTemplates.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailSectionTemplates.ts
@@ -1,0 +1,60 @@
+import type { ConversationSection } from "../agentGuiNodeViewConversation";
+import type { ConversationRailLabels } from "./agentGuiConversationRail";
+import type { AgentGUINodeViewModel } from "./agentGuiNodeTypes";
+
+export function preserveConversationRailSectionTemplates(input: {
+  labels: ConversationRailLabels;
+  sections: readonly ConversationSection[];
+  userProjects: AgentGUINodeViewModel["rail"]["userProjects"];
+}): ConversationSection[] {
+  const existingById = new Map(
+    input.sections.map((section) => [section.id, section] as const)
+  );
+  const result: ConversationSection[] = [];
+  const pinned = existingById.get("pinned");
+  if (pinned && pinned.items.length > 0) {
+    result.push(pinned);
+  }
+  existingById.delete("pinned");
+
+  const projectSectionKeys = new Set<string>();
+  for (const project of input.userProjects) {
+    const sectionKey = project.sectionKey?.trim() ?? "";
+    if (!sectionKey || projectSectionKeys.has(sectionKey)) continue;
+    projectSectionKeys.add(sectionKey);
+    const existing = existingById.get(sectionKey);
+    result.push({
+      id: sectionKey,
+      kind: "project",
+      label: project.label,
+      project,
+      items: existing?.items ?? []
+    });
+    existingById.delete(sectionKey);
+  }
+
+  for (const section of input.sections) {
+    if (section.kind !== "project" || !existingById.has(section.id)) continue;
+    result.push(section);
+    existingById.delete(section.id);
+  }
+
+  const conversations = existingById.get("conversations");
+  result.push(
+    conversations ?? {
+      id: "conversations",
+      kind: "conversations",
+      label: input.labels.sectionConversations,
+      project: null,
+      items: []
+    }
+  );
+  existingById.delete("conversations");
+
+  for (const section of input.sections) {
+    if (!existingById.has(section.id)) continue;
+    result.push(section);
+    existingById.delete(section.id);
+  }
+  return result;
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationTypes.ts
@@ -42,6 +42,7 @@ export interface AgentGUIConversationSummary {
   titleFallback?: AgentGUIConversationTitleFallback;
   status: AgentGUIConversationStatus;
   cwd: string;
+  railSectionKey?: string;
   project?: AgentGUIConversationProjectSummary | null;
   projectMode?: "none";
   pinnedAtUnixMs?: number | null;
@@ -65,6 +66,7 @@ export type AgentGUIConversationProjectionSource = Pick<
   | "titleFallback"
   | "status"
   | "cwd"
+  | "railSectionKey"
   | "project"
   | "projectMode"
   | "pinnedAtUnixMs"

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
@@ -26,19 +26,19 @@ import type {
   AgentGUINodeViewProps,
   AgentGUIViewLabels
 } from "../AgentGUINodeView";
-import {
-  groupConversations,
-  type ConversationSection
-} from "../agentGuiNodeViewConversation";
+import type { ConversationSection } from "../agentGuiNodeViewConversation";
 import {
   isConversationRailInitialLoadPending,
   projectConversationRailMemberships,
+  projectConversationRailSectionsByExactKey,
+  projectConversationRailSearchSections,
   projectConversationRailSectionsWithActiveConversation,
   projectConversationRailSectionsWithTransientConversations,
   resolveConversationRailActiveConversation,
   stabilizeConversationSectionItems,
   stabilizeConversationSections
 } from "../model/agentGuiConversationRail";
+import { preserveConversationRailSectionTemplates } from "../model/agentGuiConversationRailSectionTemplates";
 import type { useAgentGUIConversationRailQuery } from "../controller/useAgentGUIConversationRailQuery";
 import { AgentGUIConversationRailSection } from "./AgentGUIConversationRailSection";
 import { AgentGUIProjectRailHeader } from "./AgentGUIConversationRailItem";
@@ -275,7 +275,11 @@ export const AgentGUIConversationRailPane = memo(
         labels,
         sections: runtimeSectionsWithTransientConversations
       });
-    const runtimeDisplaySections = runtimeDisplayProjection.sections;
+    const runtimeDisplaySections = preserveConversationRailSectionTemplates({
+      labels,
+      sections: runtimeDisplayProjection.sections,
+      userProjects
+    });
     const railActiveOverlay = runtimeDisplayProjection.activeOverlay;
 
     useEffect(() => {
@@ -344,8 +348,10 @@ export const AgentGUIConversationRailPane = memo(
       const startedAtMs = agentGuiPerfNowMs();
       const query = conversationQuery.trim();
       const rawGroups = backendSearchActive
-        ? groupConversations(filteredConversations, labels, userProjects, {
-            includeEmptyConversations: false
+        ? projectConversationRailSearchSections({
+            conversations: filteredConversations,
+            labels,
+            sections: runtimeDisplaySections
           })
         : runtimeSectionsEnabled || runtimeRailSections
           ? runtimeDisplaySections.length > 0
@@ -371,8 +377,11 @@ export const AgentGUIConversationRailPane = memo(
                         ))
                   )
             : []
-          : groupConversations(filteredConversations, labels, userProjects, {
-              includeEmptyConversations: !query
+          : projectConversationRailSectionsByExactKey({
+              conversations: filteredConversations,
+              labels,
+              userProjects,
+              includeEmptySections: !query
             });
       const groups = stabilizeConversationSections(
         groupedConversationsRef.current,

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.ts
@@ -72,6 +72,7 @@ export function projectCanonicalAgentGUIConversationSummaries(
       id: item.session.agentSessionId,
       pinnedAtUnixMs: item.session.pinnedAtUnixMs ?? null,
       provider,
+      railSectionKey: item.session.railSectionKey,
       resumable: item.session.resumable,
       sortTimeUnixMs: resolveWorkspaceAgentSessionSortTimeUnixMs({
         createdAtUnixMs: item.session.createdAtUnixMs,

--- a/packages/agent/store-sqlite/activity_scan.go
+++ b/packages/agent/store-sqlite/activity_scan.go
@@ -131,6 +131,7 @@ func scanAgentSessionWithTrailingValues(
 		&metadataJSON,
 		&internalRuntimeContextJSON,
 		&session.Cwd,
+		&session.RailSectionKey,
 		&session.Title,
 		&session.MessageVersion,
 		&session.LastEventUnixMS,

--- a/packages/agent/store-sqlite/activity_sections.go
+++ b/packages/agent/store-sqlite/activity_sections.go
@@ -84,7 +84,8 @@ SELECT workspace_id, agent_session_id, session_kind, root_agent_session_id, root
        parent_agent_session_id, parent_turn_id, parent_tool_call_id,
        origin, agent_target_id, provider, provider_session_id, model,
        user_id, settings_json, session_metadata_json, internal_runtime_context_json, cwd,
-	       title, message_version, last_event_at_unix_ms,
+       rail_section_key,
+       title, message_version, last_event_at_unix_ms,
        started_at_unix_ms, ended_at_unix_ms, pinned_at_unix_ms,
        created_at_unix_ms, updated_at_unix_ms, active_turn_id,
        conversation_sort_time_unix_ms
@@ -336,6 +337,7 @@ SELECT sessions.workspace_id, sessions.agent_session_id, sessions.session_kind,
        sessions.agent_target_id, sessions.provider, sessions.provider_session_id, sessions.model,
        sessions.user_id, sessions.settings_json, sessions.session_metadata_json,
        sessions.internal_runtime_context_json, sessions.cwd,
+       sessions.rail_section_key,
        sessions.title, sessions.message_version, sessions.last_event_at_unix_ms,
        sessions.started_at_unix_ms, sessions.ended_at_unix_ms, sessions.pinned_at_unix_ms,
        sessions.created_at_unix_ms, sessions.updated_at_unix_ms, sessions.active_turn_id,
@@ -464,7 +466,8 @@ SELECT workspace_id, agent_session_id, session_kind, root_agent_session_id, root
        parent_agent_session_id, parent_turn_id, parent_tool_call_id,
        origin, agent_target_id, provider, provider_session_id, model,
        user_id, settings_json, session_metadata_json, internal_runtime_context_json, cwd,
-	       title, message_version, last_event_at_unix_ms,
+       rail_section_key,
+       title, message_version, last_event_at_unix_ms,
        started_at_unix_ms, ended_at_unix_ms, pinned_at_unix_ms,
        created_at_unix_ms, updated_at_unix_ms, active_turn_id
 FROM workspace_agent_sessions INDEXED BY ` + indexName + `

--- a/packages/agent/store-sqlite/activity_sections_batch_test.go
+++ b/packages/agent/store-sqlite/activity_sections_batch_test.go
@@ -173,15 +173,17 @@ func TestStoreListSessionSectionsPropagatesCanceledContext(t *testing.T) {
 	}
 }
 
-func TestStoreMigrationRestoresPinnedPageIndexAfterSessionTableRebuild(t *testing.T) {
+func TestStoreMigrationRepairsMissingPinnedPageIndexWithAppliedMarker(t *testing.T) {
 	t.Parallel()
 
 	store := openTestStore(t, testOptions(&staticProjectPaths{}))
 	ctx := context.Background()
+	if applied, err := store.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV9); err != nil || !applied {
+		t.Fatalf("pinned index migration marker applied = %v, error = %v", applied, err)
+	}
 	if _, err := store.db.ExecContext(ctx, `
 DROP INDEX idx_workspace_agent_sessions_pinned_page;
-DELETE FROM agent_store_schema_migrations WHERE id = ?;
-`, schemaMigrationWorkspaceAgentActivityV9); err != nil {
+`); err != nil {
 		t.Fatalf("prepare missing pinned index error = %v", err)
 	}
 	if err := store.Migrate(ctx); err != nil {
@@ -200,16 +202,18 @@ WHERE type = 'index' AND name = 'idx_workspace_agent_sessions_pinned_page'
 	}
 }
 
-func TestStoreMigrationAddsTargetScopedRailIndexes(t *testing.T) {
+func TestStoreMigrationRepairsMissingTargetRailIndexesWithAppliedMarker(t *testing.T) {
 	t.Parallel()
 
 	store := openTestStore(t, testOptions(&staticProjectPaths{}))
 	ctx := context.Background()
+	if applied, err := store.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV10); err != nil || !applied {
+		t.Fatalf("target index migration marker applied = %v, error = %v", applied, err)
+	}
 	if _, err := store.db.ExecContext(ctx, `
 DROP INDEX idx_workspace_agent_sessions_rail_section_target_page;
 DROP INDEX idx_workspace_agent_sessions_pinned_target_page;
-DELETE FROM agent_store_schema_migrations WHERE id = ?;
-`, schemaMigrationWorkspaceAgentActivityV10); err != nil {
+`); err != nil {
 		t.Fatalf("prepare missing target-scoped indexes error = %v", err)
 	}
 	if err := store.Migrate(ctx); err != nil {

--- a/packages/agent/store-sqlite/activity_session_read.go
+++ b/packages/agent/store-sqlite/activity_session_read.go
@@ -26,7 +26,8 @@ SELECT workspace_id, agent_session_id, session_kind, root_agent_session_id, root
        parent_agent_session_id, parent_turn_id, parent_tool_call_id,
        origin, agent_target_id, provider, provider_session_id, model,
        user_id, settings_json, session_metadata_json, internal_runtime_context_json, cwd,
-	       title, message_version, last_event_at_unix_ms,
+       rail_section_key,
+       title, message_version, last_event_at_unix_ms,
        started_at_unix_ms, ended_at_unix_ms, pinned_at_unix_ms,
        created_at_unix_ms, updated_at_unix_ms, active_turn_id
 FROM workspace_agent_sessions
@@ -86,7 +87,8 @@ SELECT workspace_id, agent_session_id, session_kind, root_agent_session_id, root
        parent_agent_session_id, parent_turn_id, parent_tool_call_id,
        origin, agent_target_id, provider, provider_session_id, model,
        user_id, settings_json, session_metadata_json, internal_runtime_context_json, cwd,
-	       title, message_version, last_event_at_unix_ms,
+       rail_section_key,
+       title, message_version, last_event_at_unix_ms,
        started_at_unix_ms, ended_at_unix_ms, pinned_at_unix_ms,
        created_at_unix_ms, updated_at_unix_ms, active_turn_id
 FROM workspace_agent_sessions
@@ -144,7 +146,8 @@ SELECT session.workspace_id, session.agent_session_id, session.session_kind,
        session.parent_agent_session_id, session.parent_turn_id, session.parent_tool_call_id,
        session.origin, session.agent_target_id, session.provider, session.provider_session_id, session.model,
        session.user_id, session.settings_json, session.session_metadata_json,
-       session.internal_runtime_context_json, session.cwd, session.title, session.message_version,
+       session.internal_runtime_context_json, session.cwd, session.rail_section_key,
+       session.title, session.message_version,
        session.last_event_at_unix_ms, session.started_at_unix_ms, session.ended_at_unix_ms,
        session.pinned_at_unix_ms, session.created_at_unix_ms, session.updated_at_unix_ms,
        session.active_turn_id

--- a/packages/agent/store-sqlite/activity_transaction.go
+++ b/packages/agent/store-sqlite/activity_transaction.go
@@ -92,8 +92,27 @@ func (s *Store) upsertAgentSessionTx(
 		now,
 	)
 	if !projected.Accepted {
+		existingRail, railErr := getExistingAgentSessionRailSectionTx(
+			ctx,
+			tx,
+			workspaceID,
+			agentSessionID,
+		)
+		if railErr != nil {
+			return false, false, 0, Session{}, railErr
+		}
 		dto, dtoErr := projectionSessionToDTO(projected.Session)
-		return false, false, projected.LastEventUnixMS, dto, dtoErr
+		if dtoErr != nil {
+			return false, false, projected.LastEventUnixMS, Session{}, dtoErr
+		}
+		if !existingRail.Found || !existingRail.Valid {
+			return false, false, projected.LastEventUnixMS, Session{}, fmt.Errorf(
+				"workspace agent session %q has no valid rail section",
+				agentSessionID,
+			)
+		}
+		dto.RailSectionKey = existingRail.Section.Key
+		return false, false, projected.LastEventUnixMS, dto, nil
 	}
 	session := projected.Session
 	settingsJSON, err := marshalJSONMap(session.Settings)
@@ -117,8 +136,6 @@ func (s *Store) upsertAgentSessionTx(
 		tx,
 		workspaceID,
 		agentSessionID,
-		hasExisting,
-		existing.CWD,
 		session.CWD,
 		session.RuntimeContext,
 	)
@@ -174,5 +191,6 @@ WHERE workspace_agent_sessions.deleted_at_unix_ms = 0
 	if err != nil {
 		return false, false, 0, Session{}, err
 	}
+	dto.RailSectionKey = railSection.Key
 	return accepted, sessionStateReportApplied(input, projected.Session), projected.LastEventUnixMS, dto, nil
 }

--- a/packages/agent/store-sqlite/migrations_activity.go
+++ b/packages/agent/store-sqlite/migrations_activity.go
@@ -257,15 +257,17 @@ func (s *Store) applyWorkspaceAgentActivityV9(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if applied {
-		return nil
-	}
 
+	// Reassert the physical index even when the marker exists. Databases opened
+	// by different builds can retain the marker after a table rebuild drops it.
 	if _, err := s.db.ExecContext(ctx, `
 CREATE INDEX IF NOT EXISTS idx_workspace_agent_sessions_pinned_page
   ON workspace_agent_sessions(workspace_id, deleted_at_unix_ms, pinned_at_unix_ms DESC, agent_session_id ASC);
 `); err != nil {
 		return fmt.Errorf("migrate workspace agent activity to v9 pinned pagination index: %w", err)
+	}
+	if applied {
+		return nil
 	}
 
 	return s.recordMigration(ctx, schemaMigrationWorkspaceAgentActivityV9)
@@ -279,10 +281,9 @@ func (s *Store) applyWorkspaceAgentActivityV10(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if applied {
-		return nil
-	}
 
+	// Keep the target-scoped query contract self-healing for the same
+	// marker-without-index schema drift covered by v9.
 	if _, err := s.db.ExecContext(ctx, `
 CREATE INDEX IF NOT EXISTS idx_workspace_agent_sessions_rail_section_target_page
   ON workspace_agent_sessions(workspace_id, rail_section_key, agent_target_id, deleted_at_unix_ms, pinned_at_unix_ms, agent_session_id);
@@ -290,6 +291,9 @@ CREATE INDEX IF NOT EXISTS idx_workspace_agent_sessions_pinned_target_page
   ON workspace_agent_sessions(workspace_id, agent_target_id, deleted_at_unix_ms, pinned_at_unix_ms DESC, agent_session_id ASC);
 `); err != nil {
 		return fmt.Errorf("migrate workspace agent activity to v10 target-scoped rail indexes: %w", err)
+	}
+	if applied {
+		return nil
 	}
 
 	return s.recordMigration(ctx, schemaMigrationWorkspaceAgentActivityV10)

--- a/packages/agent/store-sqlite/rail.go
+++ b/packages/agent/store-sqlite/rail.go
@@ -50,8 +50,6 @@ func (s *Store) resolveAgentSessionRailSectionTx(
 	tx *sql.Tx,
 	workspaceID string,
 	agentSessionID string,
-	hasExisting bool,
-	existingCWD string,
 	finalCWD string,
 	runtimeContext map[string]any,
 ) (RailSection, error) {
@@ -59,7 +57,10 @@ func (s *Store) resolveAgentSessionRailSectionTx(
 	if err != nil {
 		return RailSection{}, err
 	}
-	if hasExisting && existingRail.Found && existingRail.Valid && strings.TrimSpace(existingCWD) == strings.TrimSpace(finalCWD) {
+	// Rail membership is assigned when the session is first persisted and is
+	// immutable afterwards. Runtime cwd changes must not silently move an
+	// existing conversation between rail sections.
+	if existingRail.Found && existingRail.Valid {
 		return existingRail.Section, nil
 	}
 	return s.classifyAgentSessionRailSectionTx(ctx, tx, finalCWD, runtimeContext)

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -173,6 +173,7 @@ type Session struct {
 	Metadata               SessionMetadata
 	InternalRuntimeContext map[string]any
 	Cwd                    string
+	RailSectionKey         string
 	Title                  string
 	// ActiveTurnID is the protocol v2 turn reference: the id of the turn
 	// currently in flight, empty when the session is idle.

--- a/packages/agent/store-sqlite/store_test.go
+++ b/packages/agent/store-sqlite/store_test.go
@@ -500,7 +500,7 @@ func TestStoreClassifiesRailSectionsWithInjectedProjectPaths(t *testing.T) {
 	projects.paths = []string{repo}
 	repoCanonical := NormalizeProjectPath(repo)
 
-	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+	projectResult, err := store.ReportSessionState(ctx, SessionStateReport{
 		WorkspaceID:      "ws-rail",
 		AgentSessionID:   "session-project",
 		Origin:           "runtime",
@@ -508,9 +508,35 @@ func TestStoreClassifiesRailSectionsWithInjectedProjectPaths(t *testing.T) {
 		Cwd:              repoSubdir,
 		Status:           "completed",
 		OccurredAtUnixMS: 100,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("ReportSessionState(project) error = %v", err)
 	}
+	wantProjectKey := RailSectionKeyForProject(repoCanonical)
+	if projectResult.Session.RailSectionKey != wantProjectKey {
+		t.Fatalf("ReportSessionState(project) rail key = %q, want %q", projectResult.Session.RailSectionKey, wantProjectKey)
+	}
+	projects.paths = []string{otherDir}
+	updatedProjectResult, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID:      "ws-rail",
+		AgentSessionID:   "session-project",
+		Origin:           "runtime",
+		Provider:         "codex",
+		Cwd:              otherDir,
+		Status:           "completed",
+		OccurredAtUnixMS: 200,
+	})
+	if err != nil {
+		t.Fatalf("ReportSessionState(project cwd changed) error = %v", err)
+	}
+	if updatedProjectResult.Session.RailSectionKey != wantProjectKey {
+		t.Fatalf(
+			"ReportSessionState(project cwd changed) rail key = %q, want immutable %q",
+			updatedProjectResult.Session.RailSectionKey,
+			wantProjectKey,
+		)
+	}
+	projects.paths = []string{repo}
 	if _, err := store.ReportSessionState(ctx, SessionStateReport{
 		WorkspaceID:      "ws-rail",
 		AgentSessionID:   "session-other",
@@ -525,14 +551,18 @@ func TestStoreClassifiesRailSectionsWithInjectedProjectPaths(t *testing.T) {
 
 	projectPage, ok, err := store.ListSessionSection(ctx, ListSessionSectionInput{
 		WorkspaceID: "ws-rail",
-		SectionKey:  RailSectionKeyForProject(repoCanonical),
+		SectionKey:  wantProjectKey,
 		Limit:       10,
 	})
 	if err != nil || !ok {
 		t.Fatalf("ListSessionSection(project) ok=%v error=%v", ok, err)
 	}
-	if len(projectPage.Sessions) != 1 || projectPage.Sessions[0].ID != "session-project" {
+	if len(projectPage.Sessions) != 1 || projectPage.Sessions[0].ID != "session-project" || projectPage.Sessions[0].RailSectionKey != wantProjectKey {
 		t.Fatalf("project page = %#v, want session-project", projectPage.Sessions)
+	}
+	projectSession, ok, err := store.GetSession(ctx, "ws-rail", "session-project")
+	if err != nil || !ok || projectSession.RailSectionKey != wantProjectKey {
+		t.Fatalf("GetSession(project) = %#v ok=%v error=%v, want rail key %q", projectSession, ok, err, wantProjectKey)
 	}
 
 	conversationsPage, ok, err := store.ListSessionSection(ctx, ListSessionSectionInput{
@@ -543,7 +573,7 @@ func TestStoreClassifiesRailSectionsWithInjectedProjectPaths(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("ListSessionSection(conversations) ok=%v error=%v", ok, err)
 	}
-	if len(conversationsPage.Sessions) != 1 || conversationsPage.Sessions[0].ID != "session-other" {
+	if len(conversationsPage.Sessions) != 1 || conversationsPage.Sessions[0].ID != "session-other" || conversationsPage.Sessions[0].RailSectionKey != RailSectionKeyConversations {
 		t.Fatalf("conversations page = %#v, want session-other", conversationsPage.Sessions)
 	}
 }

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -1305,6 +1305,10 @@ export type WorkspaceAgentSession = {
   providerSessionId: string | null;
   cwd: string | null;
   /**
+   * Persisted conversation-rail membership key. Clients must use this exact key for section placement and must not infer membership from cwd or project paths.
+   */
+  railSectionKey: string;
+  /**
    * Protocol v2. The only turn reference kept on the session; null when no turn is in flight.
    */
   activeTurnId: string | null;

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -721,6 +721,7 @@ func generatedAgentSession(session agentservice.Session) tuttigenerated.Workspac
 		Provider:               tuttigenerated.WorkspaceAgentProvider(session.Provider),
 		ProviderSessionId:      stringPointer(strings.TrimSpace(session.ProviderSessionID)),
 		PinnedAtUnixMs:         int64Pointer(session.PinnedAtUnixMS),
+		RailSectionKey:         strings.TrimSpace(session.RailSectionKey),
 		Resumable:              session.Resumable,
 		RootAgentSessionId:     optionalStringPointer(strings.TrimSpace(session.RootAgentSessionID)),
 		RootTurnId:             optionalStringPointer(strings.TrimSpace(session.RootTurnID)),

--- a/services/tuttid/api/daemon_agent_sessions_latest_turn_test.go
+++ b/services/tuttid/api/daemon_agent_sessions_latest_turn_test.go
@@ -35,6 +35,7 @@ func TestGeneratedAgentSessionIncludesIndependentLatestTurnProjection(t *testing
 		ID:                     "session-1",
 		Kind:                   agentactivitybiz.SessionKindRoot,
 		Provider:               "codex",
+		RailSectionKey:         "project:repo-1",
 		CreatedAt:              time.UnixMilli(10),
 		LatestTurn:             &latest,
 		LatestTurnInteractions: latestInteractions,
@@ -64,6 +65,9 @@ func TestGeneratedAgentSessionIncludesIndependentLatestTurnProjection(t *testing
 		generated.Goal == nil || !generated.Imported {
 		t.Fatalf("v2 session fields = %#v", generated)
 	}
+	if generated.RailSectionKey != "project:repo-1" {
+		t.Fatalf("rail section key = %q, want project:repo-1", generated.RailSectionKey)
+	}
 	encoded, err := json.Marshal(generated)
 	if err != nil {
 		t.Fatal(err)
@@ -77,6 +81,9 @@ func TestGeneratedAgentSessionIncludesIndependentLatestTurnProjection(t *testing
 	}
 	if interactions, ok := payload["pendingInteractions"].([]any); !ok || len(interactions) != 0 {
 		t.Fatalf("pendingInteractions payload=%#v", payload)
+	}
+	if payload["railSectionKey"] != "project:repo-1" {
+		t.Fatalf("railSectionKey payload=%#v", payload)
 	}
 	for _, removed := range []string{"status", "turnLifecycle", "submitAvailability", "runtimeContext", "createdAt", "updatedAt", "endedAt", "lastError"} {
 		if _, ok := payload[removed]; ok {

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -3895,7 +3895,10 @@ type WorkspaceAgentSession struct {
 	PinnedAtUnixMs      *int64                      `json:"pinnedAtUnixMs"`
 	Provider            WorkspaceAgentProvider      `json:"provider"`
 	ProviderSessionId   *string                     `json:"providerSessionId"`
-	Resumable           bool                        `json:"resumable"`
+
+	// RailSectionKey Persisted conversation-rail membership key. Clients must use this exact key for section placement and must not infer membership from cwd or project paths.
+	RailSectionKey string `json:"railSectionKey"`
+	Resumable      bool   `json:"resumable"`
 
 	// RootAgentSessionId Root session that owns this child session. Null when kind is root.
 	RootAgentSessionId *string `json:"rootAgentSessionId"`

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -7025,6 +7025,7 @@ components:
         - provider
         - providerSessionId
         - cwd
+        - railSectionKey
         - visible
         - settings
         - permissionConfig
@@ -7095,6 +7096,13 @@ components:
         cwd:
           type: string
           nullable: true
+        railSectionKey:
+          type: string
+          minLength: 1
+          description: >-
+            Persisted conversation-rail membership key. Clients must use this
+            exact key for section placement and must not infer membership from
+            cwd or project paths.
         activeTurnId:
           type: string
           nullable: true

--- a/services/tuttid/data/workspace/sqlite_store_test.go
+++ b/services/tuttid/data/workspace/sqlite_store_test.go
@@ -641,7 +641,7 @@ func TestSQLiteStoreAgentSessionRailProjectDeletionDoesNotRewriteHistory(t *test
 	}
 }
 
-func TestSQLiteStoreAgentSessionRailReclassifiesWhenCwdChangesOrRailMissing(t *testing.T) {
+func TestSQLiteStoreAgentSessionRailPreservesKeyAcrossCwdChangesAndRepairsMissingRail(t *testing.T) {
 	t.Parallel()
 
 	store := openTestSQLiteStore(t)
@@ -683,6 +683,12 @@ func TestSQLiteStoreAgentSessionRailReclassifiesWhenCwdChangesOrRailMissing(t *t
 	}); err != nil {
 		t.Fatalf("ReportSessionState(project cwd) error = %v", err)
 	}
+	initial := getTestAgentSessionRailSection(t, store, "ws-agent-rail-reclassify", "session-cwd-change")
+	if initial.Kind != agentSessionRailSectionKindProject ||
+		initial.ProjectPath != repoCanonical ||
+		initial.Key != agentSessionRailSectionKeyForProject(repoCanonical) {
+		t.Fatalf("initial rail = %#v, want project %q", initial, repoCanonical)
+	}
 	if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
 		WorkspaceID:      "ws-agent-rail-reclassify",
 		AgentSessionID:   "session-cwd-change",
@@ -695,10 +701,8 @@ func TestSQLiteStoreAgentSessionRailReclassifiesWhenCwdChangesOrRailMissing(t *t
 		t.Fatalf("ReportSessionState(other cwd) error = %v", err)
 	}
 	changed := getTestAgentSessionRailSection(t, store, "ws-agent-rail-reclassify", "session-cwd-change")
-	if changed.Kind != agentSessionRailSectionKindConversations ||
-		changed.ProjectPath != "" ||
-		changed.Key != agentSessionRailSectionKeyConversations {
-		t.Fatalf("changed cwd rail = %#v, want conversations", changed)
+	if changed != initial {
+		t.Fatalf("changed cwd rail = %#v, want immutable %#v", changed, initial)
 	}
 
 	if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{

--- a/services/tuttid/service/agent/activity_projection_session.go
+++ b/services/tuttid/service/agent/activity_projection_session.go
@@ -22,6 +22,7 @@ func persistedSessionFromActivity(session agentactivitybiz.Session) PersistedSes
 		Provider:               strings.TrimSpace(session.Provider),
 		ProviderSessionID:      strings.TrimSpace(session.ProviderSessionID),
 		Cwd:                    strings.TrimSpace(session.Cwd),
+		RailSectionKey:         strings.TrimSpace(session.RailSectionKey),
 		Settings:               composerSettingsFromPayload(session.Settings),
 		Metadata:               session.Metadata,
 		InternalRuntimeContext: clonePayload(session.InternalRuntimeContext),

--- a/services/tuttid/service/agent/activity_projection_session_initialize.go
+++ b/services/tuttid/service/agent/activity_projection_session_initialize.go
@@ -1,0 +1,112 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
+)
+
+// InitializeRuntimeSession is the synchronous Create boundary. Runtime
+// reporting remains asynchronous for subsequent observations, but a successful
+// Create response must already have a durable session and immutable rail key.
+func (p *ActivityProjection) InitializeRuntimeSession(
+	ctx context.Context,
+	session ProviderRuntimeSession,
+) (PersistedSession, error) {
+	if p == nil || p.repo == nil {
+		return PersistedSession{}, fmt.Errorf("agent activity repository is unavailable")
+	}
+	workspaceID := strings.TrimSpace(session.WorkspaceID)
+	agentSessionID := strings.TrimSpace(session.ID)
+	if workspaceID == "" || agentSessionID == "" {
+		return PersistedSession{}, ErrInvalidArgument
+	}
+	runtimeContext := clonePayload(session.RuntimeContext)
+	if runtimeContext == nil {
+		runtimeContext = map[string]any{}
+	}
+	runtimeContext["visible"] = session.Visible
+	settings := cloneComposerSettingsPointerValue(session.Settings)
+	occurredAtUnixMS := session.UpdatedAtUnixMS
+	if occurredAtUnixMS <= 0 {
+		occurredAtUnixMS = session.CreatedAtUnixMS
+	}
+	if occurredAtUnixMS <= 0 {
+		occurredAtUnixMS = time.Now().UnixMilli()
+	}
+
+	_, err := p.ReportSessionState(ctx, agentsessionstore.ReportSessionStateInput{
+		WorkspaceID:    workspaceID,
+		AgentSessionID: agentSessionID,
+		AgentTargetID:  strings.TrimSpace(session.AgentTargetID),
+		SessionOrigin:  agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Source: agentsessionstore.EventSource{
+			Provider:          strings.TrimSpace(session.Provider),
+			ProviderSessionID: strings.TrimSpace(session.ProviderSessionID),
+			AgentID:           agentSessionID,
+			AgentTargetID:     strings.TrimSpace(session.AgentTargetID),
+			CWD:               strings.TrimSpace(session.Cwd),
+			SessionOrigin:     agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+			UserID:            strings.TrimSpace(session.UserID),
+		},
+		State: agentsessionstore.WorkspaceAgentSessionStateUpdate{
+			Kind:              agentactivitybiz.SessionKindRoot,
+			AgentTargetID:     strings.TrimSpace(session.AgentTargetID),
+			Provider:          strings.TrimSpace(session.Provider),
+			ProviderSessionID: strings.TrimSpace(session.ProviderSessionID),
+			Model:             strings.TrimSpace(settings.Model),
+			Settings:          composerSettingsToStatePayload(settings),
+			RuntimeContext:    runtimeContext,
+			CWD:               strings.TrimSpace(session.Cwd),
+			Title:             strings.TrimSpace(session.Title),
+			LifecycleStatus:   runtimeSessionLifecycleStatus(session.Status),
+			CurrentPhase:      runtimeSessionCurrentPhase(session.Status),
+			LastError:         strings.TrimSpace(session.LastError),
+			OccurredAtUnixMS:  occurredAtUnixMS,
+			StartedAtUnixMS:   session.CreatedAtUnixMS,
+		},
+	})
+	if err != nil {
+		return PersistedSession{}, err
+	}
+	persisted, ok, err := p.repo.GetSession(ctx, workspaceID, agentSessionID)
+	if err != nil {
+		return PersistedSession{}, fmt.Errorf("read initialized agent session: %w", err)
+	}
+	if !ok {
+		return PersistedSession{}, fmt.Errorf("initialized agent session was not persisted")
+	}
+	result := p.projectPersistedSession(ctx, persistedSessionFromActivity(persisted))
+	if strings.TrimSpace(result.RailSectionKey) == "" {
+		return PersistedSession{}, fmt.Errorf("initialized agent session has no rail section key")
+	}
+	return result, nil
+}
+
+func runtimeSessionLifecycleStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "failed":
+		return "failed"
+	case "completed", "canceled":
+		return "ended"
+	default:
+		return "active"
+	}
+}
+
+func runtimeSessionCurrentPhase(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "working":
+		return "working"
+	case "waiting":
+		return "waiting"
+	case "failed":
+		return "failed"
+	default:
+		return "idle"
+	}
+}

--- a/services/tuttid/service/agent/external_import_parse.go
+++ b/services/tuttid/service/agent/external_import_parse.go
@@ -365,9 +365,8 @@ func resolveExternalImportSessionCwd(raw string) (string, bool) {
 		// independent project rooted at the worktree instead of lining up
 		// with the main checkout the user actually registered as their
 		// project. Resolve it upfront so every downstream consumer of this
-		// cwd (project-path grouping, selection matching, and the persisted
-		// session record the GUI groups conversations by) agrees on the same
-		// canonical project identity.
+		// cwd (project selection, initial rail classification, and the persisted
+		// session record) agrees on the same canonical project identity.
 		if resolved, ok := resolveExternalImportWorktreeCwd(canonical); ok {
 			return resolved, true
 		}

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -207,11 +207,21 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	logAgentSubmitTrace("service.create.runtime_start_resolved", workspaceID, session.ID, input.Metadata, map[string]any{
 		"provider_runtime_status": session.Status,
 	})
+	persistedSession, err := s.initializeRuntimeSession(ctx, session)
+	if err != nil {
+		s.reportAgentServiceNodeFailure(ctx, session.ID, "session_create", "session_persisted", session.Provider, nodeStartedAt, err)
+		closeErr := s.controller().Close(ctx, RuntimeCloseInput{
+			WorkspaceID:    workspaceID,
+			AgentSessionID: session.ID,
+		})
+		return Session{}, cleanupPrepared(errors.Join(err, closeErr))
+	}
+	s.reportAgentServiceNodeSuccess(ctx, session.ID, "session_create", "session_persisted", session.Provider, nodeStartedAt)
 	if len(normalizedContent) == 0 {
-		return serviceSessionWithComposerSkillOptions(
+		return serviceSessionWithPersistedFreshness(
 			session,
+			persistedSession,
 			s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session)),
-			s.discoverComposerSkillOptions(session.Provider, session.Cwd, session.Env),
 		), nil
 	}
 	nodeStartedAt = time.Now()
@@ -276,10 +286,10 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	if refreshed, ok := s.controller().Session(workspaceID, session.ID); ok {
 		session = refreshed
 	}
-	return serviceSessionWithComposerSkillOptions(
+	return serviceSessionWithPersistedFreshness(
 		session,
+		persistedSession,
 		s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session)),
-		s.discoverComposerSkillOptions(session.Provider, session.Cwd, session.Env),
 	), nil
 }
 
@@ -495,14 +505,22 @@ func (s *Service) get(ctx context.Context, workspaceID string, agentSessionID st
 		resumable := s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session))
 		service := serviceSession(session, resumable)
 		if s.SessionReader != nil {
-			if persisted, ok := s.SessionReader.GetSession(workspaceID, agentSessionID); ok {
-				service = serviceSessionWithPersistedFreshness(session, persisted, resumable)
+			persisted, ok := s.SessionReader.GetSession(workspaceID, agentSessionID)
+			if !ok {
+				return Session{}, errors.New("live workspace agent session has no persisted session")
 			}
+			if err := validatePersistedRailSectionKey(persisted); err != nil {
+				return Session{}, err
+			}
+			service = serviceSessionWithPersistedFreshness(session, persisted, resumable)
 		}
 		return s.withProtocolV2TurnState(ctx, workspaceID, service)
 	}
 	if s.SessionReader != nil {
 		if persisted, ok := s.SessionReader.GetSession(workspaceID, agentSessionID); ok {
+			if err := validatePersistedRailSectionKey(persisted); err != nil {
+				return Session{}, err
+			}
 			if isStaleHiddenLiveModelDiscoverySession(persisted) {
 				if _, err := s.Delete(ctx, workspaceID, agentSessionID); err != nil && !errors.Is(err, ErrSessionNotFound) {
 					return Session{}, err

--- a/services/tuttid/service/agent/service_session.go
+++ b/services/tuttid/service/agent/service_session.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -119,13 +121,32 @@ func serviceSession(session ProviderRuntimeSession, resumable bool) Session {
 	}
 }
 
-func serviceSessionWithComposerSkillOptions(
+func (s *Service) initializeRuntimeSession(
+	ctx context.Context,
 	session ProviderRuntimeSession,
-	resumable bool,
-	options []ComposerSkillOption,
-) Session {
-	_ = options
-	return serviceSession(session, resumable)
+) (PersistedSession, error) {
+	if s == nil || s.SessionInitializer == nil {
+		return PersistedSession{}, fmt.Errorf("initialize workspace agent session: session initializer is unavailable")
+	}
+	persisted, err := s.SessionInitializer.InitializeRuntimeSession(ctx, session)
+	if err != nil {
+		return PersistedSession{}, fmt.Errorf("initialize workspace agent session: %w", err)
+	}
+	if strings.TrimSpace(persisted.ID) != strings.TrimSpace(session.ID) ||
+		strings.TrimSpace(persisted.WorkspaceID) != strings.TrimSpace(session.WorkspaceID) {
+		return PersistedSession{}, fmt.Errorf("initialize workspace agent session: persisted session identity mismatch")
+	}
+	if strings.TrimSpace(persisted.RailSectionKey) == "" {
+		return PersistedSession{}, fmt.Errorf("initialize workspace agent session: persisted rail section key is empty")
+	}
+	return persisted, nil
+}
+
+func validatePersistedRailSectionKey(session PersistedSession) error {
+	if strings.TrimSpace(session.RailSectionKey) == "" {
+		return fmt.Errorf("workspace agent session %q has no persisted rail section key", strings.TrimSpace(session.ID))
+	}
+	return nil
 }
 
 func sessionFromPersisted(session PersistedSession, resumable bool) Session {
@@ -152,6 +173,7 @@ func sessionFromPersisted(session PersistedSession, resumable bool) Session {
 		Visible:           session.Metadata.Visible,
 	}, resumable)
 	result.ActiveTurnID = strings.TrimSpace(session.ActiveTurnID)
+	result.RailSectionKey = strings.TrimSpace(session.RailSectionKey)
 	result.Kind = strings.TrimSpace(session.Kind)
 	if result.Kind == "" {
 		result.Kind = agentactivitybiz.SessionKindRoot
@@ -188,6 +210,7 @@ func mergePersistedSessionState(session Session, persisted PersistedSession) Ses
 	session.ParentAgentSessionID = strings.TrimSpace(persisted.ParentAgentSessionID)
 	session.ParentTurnID = strings.TrimSpace(persisted.ParentTurnID)
 	session.ParentToolCallID = strings.TrimSpace(persisted.ParentToolCallID)
+	session.RailSectionKey = strings.TrimSpace(persisted.RailSectionKey)
 	if strings.TrimSpace(session.UserID) == "" {
 		session.UserID = strings.TrimSpace(persisted.UserID)
 	}

--- a/services/tuttid/service/agent/service_session_child_test.go
+++ b/services/tuttid/service/agent/service_session_child_test.go
@@ -24,3 +24,37 @@ func TestPersistedChildSessionCannotResumeIndependently(t *testing.T) {
 		t.Fatal("root session resumable = false, want provider resume capability")
 	}
 }
+
+func TestSessionFromPersistedPreservesRailSectionKey(t *testing.T) {
+	t.Parallel()
+
+	session := sessionFromPersisted(PersistedSession{
+		ID:             "session-1",
+		Kind:           agentactivitybiz.SessionKindRoot,
+		Provider:       "codex",
+		RailSectionKey: " project:repo-1 ",
+	}, false)
+
+	if session.RailSectionKey != "project:repo-1" {
+		t.Fatalf("rail section key = %q, want project:repo-1", session.RailSectionKey)
+	}
+}
+
+func TestServiceSessionResponseMergesPersistedRailSectionKey(t *testing.T) {
+	t.Parallel()
+
+	session := serviceSessionWithPersistedFreshness(
+		ProviderRuntimeSession{ID: "session-1", WorkspaceID: "workspace-1", Provider: "codex"},
+		PersistedSession{
+			ID:             "session-1",
+			WorkspaceID:    "workspace-1",
+			Provider:       "codex",
+			RailSectionKey: "project:repo-1",
+		},
+		false,
+	)
+
+	if session.RailSectionKey != "project:repo-1" {
+		t.Fatalf("rail section key = %q, want project:repo-1", session.RailSectionKey)
+	}
+}

--- a/services/tuttid/service/agent/service_session_list.go
+++ b/services/tuttid/service/agent/service_session_list.go
@@ -61,6 +61,9 @@ func (s *Service) listFilteredSortedSessions(ctx context.Context, workspaceID st
 	if s.SessionReader != nil {
 		if persisted, ok := s.SessionReader.ListSessions(workspaceID); ok {
 			for _, session := range persisted {
+				if err := validatePersistedRailSectionKey(session); err != nil {
+					return nil, err
+				}
 				sessionID := strings.TrimSpace(session.ID)
 				if isStaleHiddenLiveModelDiscoverySession(session) {
 					if _, ok := s.controller().Session(workspaceID, sessionID); !ok {
@@ -91,9 +94,14 @@ func (s *Service) listFilteredSortedSessions(ctx context.Context, workspaceID st
 		resumable := s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session))
 		service := serviceSession(session, resumable)
 		if s.SessionReader != nil {
-			if persisted, ok := s.SessionReader.GetSession(workspaceID, session.ID); ok {
-				service = serviceSessionWithPersistedFreshness(session, persisted, resumable)
+			persisted, ok := s.SessionReader.GetSession(workspaceID, session.ID)
+			if !ok {
+				return nil, errors.New("live workspace agent session has no persisted session")
 			}
+			if err := validatePersistedRailSectionKey(persisted); err != nil {
+				return nil, err
+			}
+			service = serviceSessionWithPersistedFreshness(session, persisted, resumable)
 		}
 		sessionByID[strings.TrimSpace(session.ID)] = service
 	}

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -63,6 +63,72 @@ func TestServiceCreatesAndListsSessions(t *testing.T) {
 	}
 }
 
+func TestServiceCreateSynchronouslyPersistsRailSectionKey(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-rail-create", Name: "Rail Create"}); err != nil {
+		t.Fatalf("Create workspace error = %v", err)
+	}
+	projectPath := t.TempDir()
+	if canonical, ok := canonicalExistingDir(projectPath); ok {
+		projectPath = canonical
+	}
+	if _, err := store.PutUserProject(ctx, userprojectbiz.Project{
+		ID:         "project-1",
+		Path:       projectPath,
+		Label:      "Project",
+		SectionKey: userprojectbiz.SectionKeyFromPath(projectPath),
+	}); err != nil {
+		t.Fatalf("PutUserProject error = %v", err)
+	}
+	runtime := newFakeRuntime()
+	service := newTestService(runtime)
+	projection := NewActivityProjection(store)
+	service.SessionInitializer = projection
+	service.SessionReader = projection
+
+	session, err := service.Create(ctx, "ws-rail-create", CreateSessionInput{
+		AgentSessionID: "22222222-2222-4222-8222-222222222222",
+		AgentTargetID:  agenttargetbiz.IDLocalCodex,
+		Provider:       "codex",
+		Cwd:            stringRef(projectPath),
+		InitialContent: TextPromptContent("hello"),
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	wantKey := userprojectbiz.SectionKeyFromPath(projectPath)
+	if session.RailSectionKey != wantKey {
+		t.Fatalf("Create railSectionKey = %q, want %q", session.RailSectionKey, wantKey)
+	}
+	persisted, ok := projection.GetSession("ws-rail-create", session.ID)
+	if !ok || persisted.RailSectionKey != wantKey {
+		t.Fatalf("persisted session = %#v ok=%v, want rail key %q", persisted, ok, wantKey)
+	}
+}
+
+func TestServiceCreateClosesRuntimeWhenSessionInitializationFails(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := newTestService(runtime)
+	want := errors.New("persist session shell")
+	service.SessionInitializer = fakeSessionInitializer{err: want}
+
+	_, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
+		AgentSessionID: "33333333-3333-4333-8333-333333333333",
+		AgentTargetID:  agenttargetbiz.IDLocalCodex,
+		Provider:       "codex",
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("Create error = %v, want %v", err, want)
+	}
+	if len(runtime.closeCalls) != 1 || runtime.closeCalls[0].AgentSessionID != "33333333-3333-4333-8333-333333333333" {
+		t.Fatalf("runtime close calls = %#v, want failed session closed", runtime.closeCalls)
+	}
+	if _, ok := runtime.Session("ws-1", "33333333-3333-4333-8333-333333333333"); ok {
+		t.Fatal("runtime session still exists after initialization failure")
+	}
+}
+
 func TestServiceUpdateTitleReturnsPersistedTitleForLiveRuntimeSession(t *testing.T) {
 	runtime := newFakeRuntime()
 	runtime.sessions["ws-1:session-1"] = ProviderRuntimeSession{
@@ -484,6 +550,7 @@ func TestServiceCreateReportsNodeResults(t *testing.T) {
 		"cwd_resolved",
 		"runtime_prepared",
 		"runtime_started",
+		"session_persisted",
 		"prompt_validated",
 		"prompt_prepared",
 		"runtime_exec",
@@ -946,7 +1013,7 @@ func TestServiceImportedCodexWorktreeSessionGroupsUnderExistingMainCheckoutProje
 	}
 	if session.Cwd != mainRoot {
 		t.Fatalf(
-			"session.Cwd = %q, want it resolved to the main checkout %q so the GUI groups the conversation under the existing project instead of the ungrouped bucket",
+			"session.Cwd = %q, want it resolved to the main checkout %q before durable rail classification",
 			session.Cwd, mainRoot,
 		)
 	}
@@ -5772,6 +5839,7 @@ func (isolatedComposerCapabilityLister) ListComposerCapabilityOptions(
 func newIsolatedAgentService(runtime RuntimeController) *Service {
 	service := NewService(runtime)
 	service.CapabilityLister = isolatedComposerCapabilityLister{}
+	service.SessionInitializer = fakeSessionInitializer{}
 	return service
 }
 
@@ -5815,6 +5883,40 @@ type fakeSessionReader struct {
 	sessions   map[string]PersistedSession
 	tombstoned map[string]bool
 	children   map[string][]PersistedSession
+}
+
+type fakeSessionInitializer struct {
+	err error
+}
+
+func (f fakeSessionInitializer) InitializeRuntimeSession(
+	_ context.Context,
+	session ProviderRuntimeSession,
+) (PersistedSession, error) {
+	if f.err != nil {
+		return PersistedSession{}, f.err
+	}
+	settings := cloneComposerSettingsPointerValue(session.Settings)
+	return PersistedSession{
+		ID:                     strings.TrimSpace(session.ID),
+		WorkspaceID:            strings.TrimSpace(session.WorkspaceID),
+		Kind:                   agentactivitybiz.SessionKindRoot,
+		UserID:                 strings.TrimSpace(session.UserID),
+		AgentTargetID:          strings.TrimSpace(session.AgentTargetID),
+		Provider:               strings.TrimSpace(session.Provider),
+		ProviderSessionID:      strings.TrimSpace(session.ProviderSessionID),
+		Cwd:                    strings.TrimSpace(session.Cwd),
+		RailSectionKey:         "conversations",
+		Settings:               settings,
+		Metadata:               agentactivitybiz.SessionMetadata{Visible: session.Visible, Capabilities: []string{}},
+		InternalRuntimeContext: clonePayload(session.RuntimeContext),
+		Title:                  strings.TrimSpace(session.Title),
+		PinnedAtUnixMS:         session.PinnedAtUnixMS,
+		LastEventUnixMS:        session.UpdatedAtUnixMS,
+		StartedAtUnixMS:        session.CreatedAtUnixMS,
+		CreatedAtUnixMS:        session.CreatedAtUnixMS,
+		UpdatedAtUnixMS:        session.UpdatedAtUnixMS,
+	}, nil
 }
 
 type fakeSectionReader struct {
@@ -6108,6 +6210,9 @@ func (f *fakeRuntime) Sessions(workspaceID string) []ProviderRuntimeSession {
 
 func (f fakeSessionReader) GetSession(workspaceID string, agentSessionID string) (PersistedSession, bool) {
 	session, ok := f.sessions[workspaceID+":"+agentSessionID]
+	if ok && strings.TrimSpace(session.RailSectionKey) == "" {
+		session.RailSectionKey = "conversations"
+	}
 	return session, ok
 }
 
@@ -6119,6 +6224,9 @@ func (f fakeSessionReader) ListSessions(workspaceID string) ([]PersistedSession,
 	result := make([]PersistedSession, 0)
 	for _, session := range f.sessions {
 		if session.WorkspaceID == workspaceID {
+			if strings.TrimSpace(session.RailSectionKey) == "" {
+				session.RailSectionKey = "conversations"
+			}
 			result = append(result, session)
 		}
 	}

--- a/services/tuttid/service/agent/service_visibility.go
+++ b/services/tuttid/service/agent/service_visibility.go
@@ -19,9 +19,13 @@ func (s *Service) UpdateVisible(ctx context.Context, workspaceID string, agentSe
 	if err != nil {
 		return Session{}, normalizeRuntimeError(err)
 	}
-	return serviceSessionWithComposerSkillOptions(
+	persisted, err := s.initializeRuntimeSession(ctx, session)
+	if err != nil {
+		return Session{}, err
+	}
+	return serviceSessionWithPersistedFreshness(
 		session,
+		persisted,
 		s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session)),
-		s.discoverComposerSkillOptions(session.Provider, session.Cwd, session.Env),
 	), nil
 }

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -22,6 +22,7 @@ type Service struct {
 	ModelCatalog                   AgentModelCatalog
 	ModelCapabilities              ModelCapabilitiesResolver
 	AgentTargetStore               AgentTargetStore
+	SessionInitializer             SessionInitializer
 	SessionReader                  SessionReader
 	UserProjectReader              UserProjectReader
 	MessageReader                  MessageReader
@@ -129,6 +130,7 @@ type Session struct {
 	Provider             string
 	ProviderSessionID    string
 	Cwd                  string
+	RailSectionKey       string
 	Visible              bool
 	Resumable            bool
 	Settings             *ComposerSettings
@@ -241,6 +243,7 @@ type PersistedSession struct {
 	Provider               string
 	ProviderSessionID      string
 	Cwd                    string
+	RailSectionKey         string
 	Settings               ComposerSettings
 	Metadata               agentactivitybiz.SessionMetadata
 	InternalRuntimeContext map[string]any
@@ -275,6 +278,13 @@ type SessionReader interface {
 	GetSession(workspaceID string, agentSessionID string) (PersistedSession, bool)
 	ListSessions(workspaceID string) ([]PersistedSession, bool)
 	SessionDeleted(ctx context.Context, workspaceID string, agentSessionID string) (bool, error)
+}
+
+// SessionInitializer synchronously persists the canonical session shell that
+// every successful Create response must expose. In particular, it assigns the
+// immutable railSectionKey before the response leaves the daemon.
+type SessionInitializer interface {
+	InitializeRuntimeSession(context.Context, ProviderRuntimeSession) (PersistedSession, error)
 }
 
 type ChildSessionReader interface {

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -317,6 +317,7 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 	agentSessionService.ExtensionComposerProfiles = agentExtensionComposerProfileResolver{
 		manager: agentExtensionManager,
 	}
+	agentSessionService.SessionInitializer = agentActivityProjection
 	agentSessionService.SessionReader = agentActivityProjection
 	agentSessionService.UserProjectReader = userProjectService
 	agentSessionService.MessageReader = agentActivityProjection


### PR DESCRIPTION
## Summary

- persist and expose a required, nonblank `railSectionKey` across the store, daemon API, generated clients, desktop adapter, and AgentGUI models
- synchronously initialize the durable session before Create succeeds, keep the assigned rail key immutable across later cwd changes, and fail closed when canonical persistence is missing
- remove `groupConversations` and route fallback, search, membership, transient, and active projections through exact key equality with stable section ordering
- preserve empty project and Conversations section chrome when exact membership is empty or its initial request fails, without assigning any session locally
- make required rail pagination indexes self-healing when physical schema drifts from recorded migration markers, without rewriting session data
- update architecture and troubleshooting documentation for daemon-owned rail membership

## Verification

- `pnpm check:full`
- `pnpm --filter @tutti-os/agent-gui test`
- targeted desktop agent activity tests
- targeted store, agent service, daemon API, and Go build checks

## Fix Scope Justification

- Root cause: the durable store already classified rail membership, but session read/API projections omitted the key and Create could respond before asynchronous persistence completed. AgentGUI then retained cwd/project-based grouping paths that could disagree with backend membership.
- Why can this not be fixed at a lower layer? The invariant is daemon-owned, but enforcing it requires carrying the same persisted key through the public schema, generated clients, desktop adapter, canonical UI entities, and every rail projection path. The generated and test changes are direct consequences of that single contract correction.

## Fallback Three Questions

- Source: the first section-membership request can fail while the current project section inventory is already available to the rail.
- Why can it not be fixed at that source? A request failure should not erase independently known section chrome, while guessing session membership would violate the daemon-owned exact-key contract.
- Removal condition: this presentation guard can be removed when section inventory is delivered through an independently durable contract that remains available when membership paging fails.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces exact conversation-rail grouping by persisting a non-empty `railSectionKey` from the daemon and using it end-to-end. Create and visibility now synchronously return sessions with an immutable rail key; the UI groups strictly by that key and keeps section chrome when membership fails to load.

- **Bug Fixes**
  - Require and expose `railSectionKey` across the store, OpenAPI, generated client `@tuttid-ts`, and the desktop adapter; reject missing or blank values; validate on list and repair missing keys.
  - Keep the rail key immutable across cwd changes; daemon Get/List fail if the key is absent.
  - Replace UI grouping with exact-key sections for runtime pages, search, and transient/active overlays; remove cwd/project inference and `groupConversations`; pinned stays independent; preserve empty section chrome via templates.
  - Synchronously persist and read back the session in Create/UpdateVisible; close the runtime if initialization fails; responses include the persisted key.
  - Reassert required rail pagination indexes on startup even when migration markers exist to avoid full scans and blank rails.

<sup>Written for commit f0f7c1dcff89dc1bb7124ae3ad9d0ed2d3a829b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

