### PR TITLE
fix(agent-gui): restore active setting inheritance

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2300,8 +2300,8 @@ User-visible rules:
   subprocess, and the renderer re-checks on window focus/visibility and keeps
   polling while the permission dialog is open and unauthorized.
 - User composer defaults are owned by desktop preferences. AgentGUI may request
-  a defaults write only from the home/new composer path, through an explicit host
-  callback.
+  a defaults write from the home/new composer path or after an explicit user
+  selection in an active session, through an explicit host callback.
 - Lab-mode AgentGUI affordances are desktop-preference driven through generic
   feature flags. AgentGUI must not receive experiment-specific props or create
   git worktrees itself; new experiments should add a desktop feature-flag
@@ -2311,9 +2311,10 @@ User-visible rules:
   by a directory-resolved `agentTargetId`. They have no provider-keyed fallback,
   so two targets under the same provider cannot share model, permission,
   reasoning, speed, or draft state by accident.
-- Active session settings are session state. Opening, restoring, or editing an
-  active session must not promote that session's model, permission mode, or
-  reasoning setting into user defaults.
+- Active session settings are session state. Opening or restoring an active
+  session must not promote its settings into user defaults. An explicit model,
+  permission, reasoning, or speed selection updates both the session and that
+  target's defaults so the next new conversation inherits the user's choice.
 - Workbench node `composerOverrides` are UI-local home/new composer draft state,
   not an authoritative source for desktop preferences.
 - Draft clearing happens only after the submitted content still matches the
@@ -3197,14 +3198,15 @@ provider capability/options
 Avoid fixing a menu label or disabled state without checking whether the same
 setting is also used by prompt creation, session continuation, and runtime
 tracking.
-Active-session settings are first-class session state, not composer defaults.
-The controller should submit exactly one engine intent for one menu selection;
-it must not also promote the active value into target defaults. The engine owns
-the operation state. A timed-out update remains `unknown`, and the next explicit
-user selection carries retry intent instead of being silently dropped. That
-retry merges the unresolved in-flight patch, any queued patch, and the latest
-selection in that order, so the newest value wins without losing settings that
-the daemon may not have applied before the timeout.
+Active-session settings are first-class session state. The controller submits
+exactly one engine intent for one menu selection. The same explicit user
+selection may independently update the target default and the node-local default
+draft; merely opening or restoring a session must not. The engine owns the
+operation state. A timed-out update remains `unknown`, and the next explicit user
+selection carries retry intent instead of being silently dropped. That retry
+merges the unresolved in-flight patch, any queued patch, and the latest selection
+in that order, so the newest value wins without losing settings that the daemon
+may not have applied before the timeout.
 
 The daemon selects the mutation path from session liveness. A live session
 updates through its provider adapter. A historical session updates the durable

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.spec.tsx
@@ -12,7 +12,7 @@ import type { useAgentGUIActivation } from "./useAgentGUIActivation";
 import { useAgentGUIComposerSettingsActions } from "./useAgentGUIComposerSettingsActions";
 
 describe("useAgentGUIComposerSettingsActions", () => {
-  it("retries an unknown active-session update without changing target defaults", () => {
+  it("retries an unknown active-session update and remembers the explicit selection", () => {
     const execute = vi.fn(() => new Promise<unknown>(() => undefined));
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
@@ -25,6 +25,7 @@ describe("useAgentGUIComposerSettingsActions", () => {
       sessions: [
         normalizeAgentActivitySession({
           activeTurnId: null,
+          agentTargetId: "local:claude-code",
           agentSessionId: "session-1",
           cwd: "/workspace",
           latestTurnInteractions: [],
@@ -65,6 +66,9 @@ describe("useAgentGUIComposerSettingsActions", () => {
     const onDataChange = vi.fn();
     const onRememberComposerDefaults = vi.fn();
     const setDraftSettingsBySessionId = vi.fn();
+    const draftSettingsBySessionIdRef: {
+      current: Record<string, AgentSessionComposerSettings>;
+    } = { current: {} };
     const dispatch = vi.spyOn(sessionEngine, "dispatch");
     const activeSettings: AgentSessionComposerSettings = {
       browserUse: true,
@@ -85,8 +89,9 @@ describe("useAgentGUIComposerSettingsActions", () => {
           getSnapshot: () => ({})
         } as unknown as AgentActivityRuntime,
         composerSupportPermissionModeChangeDeferred: false,
+        dataRef: { current: data },
         defaultReasoningEffort: null,
-        draftSettingsBySessionIdRef: { current: {} },
+        draftSettingsBySessionIdRef,
         loadDraftComposerOptions: vi.fn(),
         onDataChangeRef: { current: onDataChange },
         onRememberComposerDefaultsRef: {
@@ -123,8 +128,25 @@ describe("useAgentGUIComposerSettingsActions", () => {
       })
     );
     expect(execute).toHaveBeenCalledTimes(2);
-    expect(onRememberComposerDefaults).not.toHaveBeenCalled();
-    expect(onDataChange).not.toHaveBeenCalled();
-    expect(setDraftSettingsBySessionId).not.toHaveBeenCalled();
+    expect(onRememberComposerDefaults).toHaveBeenCalledWith({
+      agentTargetId: "local:claude-code",
+      provider: "claude-code",
+      defaults: { permissionModeId: "acceptEdits" }
+    });
+    expect(
+      draftSettingsBySessionIdRef.current[
+        "__agent_gui_node_defaults__:target:local:claude-code"
+      ]
+    ).toMatchObject({ permissionModeId: "acceptEdits" });
+    expect(setDraftSettingsBySessionId).toHaveBeenCalledTimes(1);
+    expect(onDataChange).toHaveBeenCalledTimes(1);
+    const updateNode = onDataChange.mock.calls[0]?.[0] as
+      | ((current: AgentGUINodeData) => AgentGUINodeData)
+      | undefined;
+    expect(updateNode?.(data)).toMatchObject({
+      composerOverridesByAgentTargetId: {
+        "local:claude-code": { permissionModeId: "acceptEdits" }
+      }
+    });
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.ts
@@ -33,6 +33,7 @@ import {
 import {
   composerDefaultsPatchFromSettings,
   composerOptionsForTarget,
+  rememberComposerDefaultsFields,
   type AgentGUIRememberComposerDefaultsInput
 } from "./agentGuiController.providerHelpers";
 import type { useAgentGUIActivation } from "./useAgentGUIActivation";
@@ -44,6 +45,7 @@ interface UseAgentGUIComposerSettingsActionsInput {
   activeEngineActiveTurn: AgentActivityTurn | null;
   agentActivityRuntime: AgentActivityRuntime;
   composerSupportPermissionModeChangeDeferred: boolean;
+  dataRef: RefObject<AgentGUINodeData>;
   defaultReasoningEffort: AgentSessionReasoningEffort | null;
   draftSettingsBySessionIdRef: RefObject<
     Record<string, AgentSessionComposerSettings>
@@ -79,6 +81,7 @@ export function useAgentGUIComposerSettingsActions(
     activeConversationIdRef,
     activeEngineActiveTurn,
     agentActivityRuntime,
+    dataRef,
     defaultReasoningEffort,
     draftSettingsBySessionIdRef,
     loadDraftComposerOptions,
@@ -272,6 +275,66 @@ export function useAgentGUIComposerSettingsActions(
         Object.keys(sessionSettingsPatch).length > 0 &&
         (canonicalSession !== null || isPreActivationSession)
       ) {
+        const rememberedDefaultsPatch = composerDefaultsPatchFromSettings(
+          sessionSettingsPatch,
+          sessionSettingsPatch
+        );
+        if (rememberedDefaultsPatch) {
+          const defaultAgentTargetId =
+            normalizeOptionalText(canonicalSession?.agentTargetId) ??
+            normalizeOptionalText(dataRef.current.agentTargetId);
+          const defaultProvider =
+            canonicalSession?.provider ?? dataRef.current.provider;
+          void onRememberComposerDefaultsRef.current?.({
+            agentTargetId: defaultAgentTargetId,
+            provider: defaultProvider,
+            defaults: rememberedDefaultsPatch
+          });
+
+          const durableNodeDefaultsPatch: Partial<AgentSessionComposerSettings> =
+            {};
+          for (const field of rememberComposerDefaultsFields) {
+            if (sessionSettingsPatch[field] !== undefined) {
+              durableNodeDefaultsPatch[field] = sessionSettingsPatch[field];
+            }
+          }
+          const defaultDraftKey = nodeDefaultDraftKey(
+            defaultProvider,
+            defaultAgentTargetId
+          );
+          const defaultData: AgentGUINodeData = {
+            ...dataRef.current,
+            provider: defaultProvider,
+            agentTargetId: defaultAgentTargetId
+          };
+          const storedNodeDefaults = readNodeDefaultDraftSettings({
+            data: defaultData,
+            defaultReasoningEffort,
+            drafts: draftSettingsBySessionIdRef.current
+          });
+          const nextNodeDefaults = {
+            ...storedNodeDefaults,
+            ...durableNodeDefaultsPatch
+          };
+          draftSettingsBySessionIdRef.current = {
+            ...draftSettingsBySessionIdRef.current,
+            [defaultDraftKey]: nextNodeDefaults
+          };
+          setDraftSettingsBySessionId((current) => ({
+            ...current,
+            [defaultDraftKey]: nextNodeDefaults
+          }));
+          onDataChangeRef.current((current) =>
+            nodeDataFromComposerSettings(
+              {
+                ...current,
+                provider: defaultProvider,
+                agentTargetId: defaultAgentTargetId
+              },
+              nextNodeDefaults
+            )
+          );
+        }
         if (isPreActivationSession) {
           sessionEngine.dispatch({
             type: "activation/settingsPatched",


### PR DESCRIPTION
## Summary

- remember explicit model, permission, reasoning, and speed selections made in active or historical sessions as target defaults
- synchronize node-local default drafts so the next new conversation immediately inherits the selection
- preserve the historical-session direct persistence, retry, and serialization behavior from #1186
- document that opening or restoring a session does not promote settings; only explicit user selections do

## Verification

- `pnpm --filter @tutti-os/agent-gui test` (182 files, 1651 tests)
- `pnpm typecheck`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:changed --tail-lines 60`
- `pnpm check:full` (18 tasks)
- focused Go retry after one unrelated process stdout timeout: `go test ./runtime -run TestLocalProcessTransportFindsKnownNodeGlobalBin -count=1 -v`
- desktop development renderer reloaded once

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores inheritance of explicit composer setting changes (model, permission, reasoning, speed) into per-target defaults and syncs node-local drafts so new conversations pick up the user’s choice. Opening or restoring a session no longer promotes settings; only explicit selections do.

- **Bug Fixes**
  - Remembers explicit selections as target defaults and updates node-local default drafts immediately.
  - Retries unknown active-session updates without dropping the user’s selection.
  - Clarifies docs on when defaults are promoted and how session state is handled.

<sup>Written for commit 714e3295f199355d5d005d3369f27b1d6a8af238. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

