### PR TITLE
feat(computer): align CLI with native cua-driver capabilities

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -96,3 +96,9 @@ CLI behavior, CI, package assets, skills, Browser Node, and terminal input.
 - [New release CDN namespace returns an S3 403](./toolchain-browser-terminal.md#new-release-cdn-namespace-returns-an-s3-403)
 - [Browser Node focus pings miss iframe-hosted editors](./toolchain-browser-terminal.md#browser-node-focus-pings-miss-iframe-hosted-editors)
 - [Temporary Git fixture turns a linked worktree bare](./toolchain-browser-terminal.md#temporary-git-fixture-turns-a-linked-worktree-bare)
+
+## [Computer Use](./computer-use.md)
+
+cua-driver discovery, targeting, capture, input delivery, and result verification.
+
+- [A computer click reports success but the UI does not change](./computer-use.md#a-computer-click-reports-success-but-the-ui-does-not-change)

--- a/docs/conventions/troubleshooting/computer-use.md
+++ b/docs/conventions/troubleshooting/computer-use.md
@@ -1,0 +1,62 @@
+# Computer Use Troubleshooting
+
+Use this guide for recurring cua-driver and `tutti computer` failures. Keep
+stable CLI and authorization contracts in
+[Tutti CLI Contract](../tutti-cli-contract.md); keep symptom-driven diagnosis
+and recovery here.
+
+## A computer click reports success but the UI does not change
+
+### Symptom
+
+A stable or native computer click reports that it was posted, but a fresh
+screenshot shows no UI change. This commonly affects Electron-based apps. The
+agent-cursor overlay may also appear offset from the intended point after a
+display-configuration change.
+
+### Quick checks
+
+1. Capture a fresh target-window screenshot with the same explicit `pid` and
+   `window-id` used for the action.
+2. Treat a posted-click response as dispatch confirmation only. Do not use the
+   agent-cursor overlay as evidence that the event landed at the displayed
+   point.
+3. Inspect the screenshot structured content for the target's
+   `element_token`. If no suitable element exists, confirm that pixel
+   coordinates came from the latest screenshot of the same window.
+4. Use `computer tool describe --name click --json` before native escalation so
+   the live cua-driver schema remains the source of truth.
+
+### Root cause
+
+Pixel clicks use background CGEvent delivery. cua-driver can confirm that the
+event was dispatched, but it cannot read back the UI effect. Focus-sensitive or
+Electron surfaces may silently discard a background synthetic click. The
+agent-cursor overlay is rendered through a separate visual channel and may have
+a stale display offset, so its apparent position does not validate event
+delivery.
+
+### Fix
+
+1. Prefer the native `click` element-token path from the latest screenshot when
+   an actionable element is available.
+2. Verify the result with another fresh screenshot.
+3. If a background pixel click had no effect, do not repeat the same click.
+   Follow the live native schema and retry once with
+   `delivery_mode: "foreground"`, which briefly fronts the target window.
+4. If foreground delivery still has no visible effect, re-snapshot and
+   re-resolve the target instead of reusing stale coordinates or tokens.
+
+### Validation
+
+- The post-action screenshot shows the expected state change.
+- The action used the same `pid` and `window-id` as its source screenshot.
+- Element-token retries use a token from the latest snapshot; stale-token
+  errors trigger a new snapshot.
+- Pixel escalation follows background, verify, foreground, verify rather than
+  repeated unverified clicks.
+
+### References
+
+- [Tutti CLI Contract: Computer command surfaces](../tutti-cli-contract.md#computer-command-surfaces)
+- [Injected Computer Use skill](../../../packages/agent/runtimeprep/skill_templates/computer-use.md)

--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -145,6 +145,73 @@ the user asks to open or show an app window, or confirms that an app window
 should be opened. For ordinary app work, agents should prefer the app-specific
 CLI capability over opening the app UI.
 
+### Computer command surfaces
+
+The builtin `computer` provider has two intentionally different layers, both
+owned by `services/tuttid/service/computer` and exposed through daemon command
+specs:
+
+- stable aliases such as `computer screenshot`, `click`, `type`, and `scroll`
+  provide a small window-oriented compatibility contract and may normalize
+  legacy tool names;
+- `computer tool list|describe|call` discovers and invokes the native
+  cua-driver MCP catalog without adding a Tutti binding for every driver tool;
+  this is the complete extensible entry point for authorized native
+  capabilities that do not have a stable alias.
+
+Stable screenshot-coordinate commands (`screenshot`, `click`, `double-click`,
+`right-click`, and `scroll`) expose only the window workflow. They do not expose
+a synthetic shared `scope`. `pid` and `window-id` are accepted only as a pair;
+when both are omitted, the service may select an eligible visible window.
+Coordinates for pointer and scroll commands are local to the selected window
+screenshot. Keyboard commands accept the same explicit pid/window pair to
+avoid target drift. `move-cursor` is deliberately target- and scope-less: it
+accepts agent-cursor screen points, not pixels copied from either screenshot
+surface.
+
+Desktop automation follows each native cua-driver tool's real contract rather
+than a Tutti-wide scope model:
+
+- `get_config` reads cua-driver's host-global persisted `capture_scope`;
+- `get_desktop_state` captures the desktop only when that persisted setting is
+  already `desktop`; the call does not choose a capture scope;
+- native `click` has its own per-call `scope: "desktop"` contract;
+- native `scroll` requires a PID and has no true desktop-coordinate mode, so
+  Tutti must not advertise desktop scrolling.
+
+Stable commands and native calls must not implement a hidden set/call/restore
+sequence around `capture_scope`. The `system.config.write` capability used by
+native `set_config` is authorized by Tutti's default computer policy, so an
+agent may explicitly set `capture_scope` to `desktop` through `computer tool
+call` before invoking `get_desktop_state`. The mutation is host-global and
+persisted by cua-driver; the agent must not disguise that fact or automatically
+restore the previous value after capture. Stable `computer screenshot` remains
+window-only regardless of the persisted scope.
+
+The native catalog is also the policy input. Tutti applies a default-deny
+capability allowlist in `service/computer`. `tool list` and `tool describe`
+retain the complete live catalog and annotate every tool with the Tutti-owned
+`allowed` decision and `denialReason`; `tool call` enforces the same policy.
+MCP effect annotations are descriptive hints and never grant authority. Both
+the catalog `schema_version` and `capability_version` are breaking-contract
+boundaries; missing or unknown versions fail closed before any tool is listed,
+described, or invoked. Every advertised capability must be explicitly
+recognized and allowed before invocation. Tools with no capability metadata,
+any unknown or denied capability, or a name absent from the live catalog remain
+unavailable even when another capability on that tool is allowed. Stable
+aliases enumerate their supported operations and must not fall through to raw
+native invocation.
+
+Stable aliases return compact, explicitly projected JSON. Native `tool call`
+is the narrow exception: its JSON mode preserves the complete MCP tool result,
+including unknown and future content variants, so extending cua-driver does
+not require a Tutti result adapter. Plain mode may still project the collected
+text for terminal use. A valid MCP result with `isError: true` is still emitted
+unchanged by native JSON mode so callers retain its structured diagnostics;
+transport and protocol failures remain CLI errors. Stable aliases continue to
+translate `isError` results into their compatibility error behavior. Do not use
+the native surface to bypass stable alias validation or the capability policy.
+
 ## Command Kinds
 
 Builtin commands must declare one command kind.

--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -169,6 +169,16 @@ avoid target drift. `move-cursor` is deliberately target- and scope-less: it
 accepts agent-cursor screen points, not pixels copied from either screenshot
 surface.
 
+Pointer delivery is dispatch-only: pixel clicks post background CGEvents that
+cua-driver cannot verify, and Electron-based apps may drop them silently. The
+skill contract therefore prefers element-token actions (native `click` with an
+`element_token` from screenshot structured content), requires effect
+verification through a fresh screenshot rather than the agent-cursor overlay
+(a separate visual channel that can render offset after display-configuration
+changes), and escalates unresponsive background clicks via the native
+`delivery_mode: "foreground"` contract instead of repeating the same pixel
+click.
+
 Desktop automation follows each native cua-driver tool's real contract rather
 than a Tutti-wide scope model:
 

--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -177,7 +177,9 @@ verification through a fresh screenshot rather than the agent-cursor overlay
 (a separate visual channel that can render offset after display-configuration
 changes), and escalates unresponsive background clicks via the native
 `delivery_mode: "foreground"` contract instead of repeating the same pixel
-click.
+click. See
+[Computer Use Troubleshooting](./troubleshooting/computer-use.md#a-computer-click-reports-success-but-the-ui-does-not-change)
+for the symptom-driven verification and recovery checklist.
 
 Desktop automation follows each native cua-driver tool's real contract rather
 than a Tutti-wide scope model:

--- a/packages/agent/runtimeprep/provider_skill_test.go
+++ b/packages/agent/runtimeprep/provider_skill_test.go
@@ -387,6 +387,10 @@ func TestRenderProviderSkillBundleGatesOptionalSkills(t *testing.T) {
 		"Desktop scrolling is not supported",
 		"computer move-cursor --x <screen-point-x> --y <screen-point-y>",
 		"`move-cursor` is scope-less",
+		"element_token",
+		"never driver-verified",
+		`"delivery_mode":"foreground"`,
+		"not evidence of where a click landed",
 	} {
 		if !strings.Contains(computerSkill.Content, want) {
 			t.Fatalf("computer skill missing %q: %q", want, computerSkill.Content)

--- a/packages/agent/runtimeprep/provider_skill_test.go
+++ b/packages/agent/runtimeprep/provider_skill_test.go
@@ -371,10 +371,40 @@ func TestRenderProviderSkillBundleGatesOptionalSkills(t *testing.T) {
 		t.Fatalf("browser skill content = %q", browserSkill.Content)
 	}
 	computerSkill := skillBundleRecord(withOptional.Skills, "computer-use")
-	if !strings.Contains(computerSkill.Content, "tutti-dev computer screenshot") ||
-		strings.Contains(computerSkill.Content, "{{CLI_COMMAND}}") ||
-		strings.Contains(computerSkill.Content, "tutti computer") {
-		t.Fatalf("computer skill content = %q", computerSkill.Content)
+	for _, want := range []string{
+		"tutti-dev computer screenshot --json",
+		"tutti-dev computer click --pid <pid> --window-id <window-id>",
+		"tutti-dev computer scroll --pid <pid> --window-id <window-id>",
+		"tutti-dev computer tool list --json",
+		"tutti-dev computer tool describe --name <tool> --json",
+		"--name get_config",
+		"--name set_config",
+		"--name get_desktop_state",
+		"--name click",
+		`{"capture_scope":"desktop"}`,
+		`"scope":"desktop"`,
+		"persists globally",
+		"Desktop scrolling is not supported",
+		"computer move-cursor --x <screen-point-x> --y <screen-point-y>",
+		"`move-cursor` is scope-less",
+	} {
+		if !strings.Contains(computerSkill.Content, want) {
+			t.Fatalf("computer skill missing %q: %q", want, computerSkill.Content)
+		}
+	}
+	for _, forbidden := range []string{
+		"computer screenshot --scope",
+		"computer click --scope",
+		"computer scroll --scope",
+		"cua-driver config set capture_scope desktop",
+		"operator must",
+		"`set_config` is not authorized",
+		"{{CLI_COMMAND}}",
+		"tutti computer",
+	} {
+		if strings.Contains(computerSkill.Content, forbidden) {
+			t.Fatalf("computer skill retains synthetic scope or unresolved command %q: %q", forbidden, computerSkill.Content)
+		}
 	}
 }
 

--- a/packages/agent/runtimeprep/skill_templates/computer-use.md
+++ b/packages/agent/runtimeprep/skill_templates/computer-use.md
@@ -27,6 +27,18 @@ Common forms:
 - `{{CLI_COMMAND}} computer scroll --pid <pid> --window-id <window-id> --x <n> --y <n> --direction <up|down|left|right> --amount <n>`
 - `{{CLI_COMMAND}} computer move-cursor --x <screen-point-x> --y <screen-point-y>`
 
+## Click Reliability
+
+Pixel clicks are posted as background CGEvents and are never driver-verified: a `✅ Posted click` result only confirms dispatch, not effect. Electron-based apps (Discord, Feishu, VS Code) frequently drop background synthetic clicks entirely.
+
+1. Prefer element actions over pixel coordinates. `screenshot --json` structured content lists interactive elements with an `element_token`; click through the native tool with that token:
+
+   `{{CLI_COMMAND}} computer tool call --name click --arguments-json '{"pid":<pid>,"element_token":"<token>"}' --json`
+
+2. Verify every click with a fresh `screenshot` of the target window. The blue agent cursor is a visual overlay on a separate channel — after a display-configuration change it can render at a fixed offset from the true event point, so its on-screen position is not evidence of where a click landed.
+
+3. If a background pixel click produced no visible change, do not re-click the same coordinates. Escalate delivery through the native `click` schema with `"delivery_mode":"foreground"` (briefly fronts the target window), or switch to the element-token path above.
+
 ## Native Driver Capabilities
 
 The native tool surface is the complete entry point for authorized cua-driver capabilities that have no stable alias. Discover the live contract instead of guessing arguments or assuming that different tools share a scope model:

--- a/packages/agent/runtimeprep/skill_templates/computer-use.md
+++ b/packages/agent/runtimeprep/skill_templates/computer-use.md
@@ -7,24 +7,71 @@ description: Use to operate the macOS desktop — take screenshots, click, type,
 
 Use this skill for macOS desktop automation: screenshot, click, type, press keys, scroll, or move the cursor.
 
-Drive the desktop only through `{{CLI_COMMAND}} computer`. The Tutti daemon owns the cua-driver session. Do not use AppleScript, `osascript`, `xdotool`, or direct accessibility APIs; those are outside the managed session.
+Drive the desktop only through `{{CLI_COMMAND}} computer`. The Tutti daemon owns the cua-driver session. Do not use AppleScript, `osascript`, `xdotool`, direct accessibility APIs, or the standalone cua-driver CLI; those are outside the managed session.
 
-## Protocol
+## Stable Window Workflow
 
-1. Start with `{{CLI_COMMAND}} computer screenshot` to read screen state.
-2. Choose coordinates from that screenshot; coordinates are logical screen points.
-3. Act with `click`, `double-click`, `right-click`, `type`, `press-key`, `scroll`, or `move-cursor`.
-4. Re-run `screenshot` after actions that change the UI because coordinates can shift.
+Stable commands implement a window-coordinate workflow. They do not have a shared `--scope` flag.
+
+1. Start with `{{CLI_COMMAND}} computer screenshot --json`. Prefer an explicit `--pid <pid> --window-id <window-id>` pair; omit both only when automatic visible-window selection is intentional.
+2. Choose `click`, `double-click`, `right-click`, and `scroll` coordinates from that window screenshot. Coordinates are local to its image, so reuse the same explicit pid/window pair for the action.
+3. Act with `click`, `double-click`, `right-click`, `type`, `press-key`, or `scroll`. Re-run `screenshot` after actions that change the UI because coordinates can shift.
+4. `move-cursor` is scope-less. Its coordinates are agent-cursor screen points, not pixels from a window or desktop screenshot.
 
 Common forms:
 
-- `{{CLI_COMMAND}} computer click --x <n> --y <n>`
-- `{{CLI_COMMAND}} computer type --text <text>`
-- `{{CLI_COMMAND}} computer press-key --key <key>`
-- `{{CLI_COMMAND}} computer scroll --x <n> --y <n> --direction <up|down|left|right> --amount <n>`
+- `{{CLI_COMMAND}} computer screenshot --pid <pid> --window-id <window-id> --json`
+- `{{CLI_COMMAND}} computer click --pid <pid> --window-id <window-id> --x <n> --y <n>`
+- `{{CLI_COMMAND}} computer type --pid <pid> --window-id <window-id> --text <text>`
+- `{{CLI_COMMAND}} computer press-key --pid <pid> --window-id <window-id> --key <key>`
+- `{{CLI_COMMAND}} computer scroll --pid <pid> --window-id <window-id> --x <n> --y <n> --direction <up|down|left|right> --amount <n>`
+- `{{CLI_COMMAND}} computer move-cursor --x <screen-point-x> --y <screen-point-y>`
+
+## Native Driver Capabilities
+
+The native tool surface is the complete entry point for authorized cua-driver capabilities that have no stable alias. Discover the live contract instead of guessing arguments or assuming that different tools share a scope model:
+
+1. Run `{{CLI_COMMAND}} computer tool list --json`.
+2. Run `{{CLI_COMMAND}} computer tool describe --name <tool> --json` and follow its returned `inputSchema`.
+3. Run `{{CLI_COMMAND}} computer tool call --name <tool> --arguments-json '<object>' --json`.
+
+### Desktop workflow
+
+Desktop capture and input are not one uniform scope:
+
+1. When the user asks to inspect the screen, desktop, or entire display rather than a specific app window, use this desktop workflow instead of the stable `screenshot` command. Inspect `get_config`, then read the persisted driver configuration:
+
+   `{{CLI_COMMAND}} computer tool describe --name get_config --json`
+
+   `{{CLI_COMMAND}} computer tool call --name get_config --arguments-json '{}' --json`
+
+2. `get_desktop_state` works only when the host-global persisted `capture_scope` is `desktop`. If it is not enabled, describe the allowed `set_config` tool and change it through the managed native surface:
+
+   `{{CLI_COMMAND}} computer tool describe --name set_config --json`
+
+   `{{CLI_COMMAND}} computer tool call --name set_config --arguments-json '{"capture_scope":"desktop"}' --json`
+
+   This setting persists globally in cua-driver. Do not hide the mutation inside a set/call/restore sequence, and do not restore it automatically after capture. Re-read `get_config` if the result does not clearly confirm the new value.
+
+3. Describe and call `get_desktop_state` using its live schema:
+
+   `{{CLI_COMMAND}} computer tool describe --name get_desktop_state --json`
+
+   `{{CLI_COMMAND}} computer tool call --name get_desktop_state --arguments-json '{"screenshot_out_file":"/tmp/desktop.png"}' --json`
+
+4. The native `click` tool has its own per-call desktop contract. Confirm its live schema, then call it directly:
+
+   `{{CLI_COMMAND}} computer tool describe --name click --json`
+
+   `{{CLI_COMMAND}} computer tool call --name click --arguments-json '{"scope":"desktop","x":1200,"y":700}' --json`
+
+   Do not infer that contract for other tools.
+
+5. Desktop scrolling is not supported by the current driver contract: native `scroll` requires a PID and has no true desktop-coordinate mode. Use the stable window workflow when scrolling.
 
 ## Guardrails
 
-- The computer session is shared per workspace and reused across commands.
-- Automation is background and should not steal focus.
+- The Tutti computer session is shared per workspace and reused across commands. cua-driver's persisted `capture_scope` is broader global state and is never a hidden per-call switch. Native `set_config` may change it explicitly when the requested workflow requires desktop capture.
+- Prefer explicit `--pid <pid> --window-id <window-id>` for stable window commands. Omit both only when automatic visible-window selection is intentional.
+- Native `tool list` and `tool describe` preserve the live catalog and show Tutti's `allowed` and `denialReason` decision. `tool call` enforces that decision; never try to invoke an entry with `allowed: false`.
 - If cua-driver is missing or Screen Recording/Accessibility permission is denied, report that error instead of falling back to AppleScript or shell automation.

--- a/services/tuttid/service/cli/providers/computer/commands.go
+++ b/services/tuttid/service/cli/providers/computer/commands.go
@@ -2,74 +2,133 @@ package computer
 
 import (
 	"context"
+	"fmt"
 
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
 	"github.com/tutti-os/tutti/services/tuttid/service/cli/framework"
+	computersvc "github.com/tutti-os/tutti/services/tuttid/service/computer"
 )
 
 type coordinatesInput struct {
-	X string `cli:"x" validate:"required"`
-	Y string `cli:"y" validate:"required"`
+	X        int `cli:"x" validate:"required" description:"X coordinate in screenshot pixels."`
+	Y        int `cli:"y" validate:"required" description:"Y coordinate in screenshot pixels."`
+	PID      int `cli:"pid" validate:"min=1" description:"Target process ID; defaults to the selected visible window."`
+	WindowID int `cli:"window-id" validate:"min=1" description:"Target window ID; defaults to the selected visible window."`
+}
+
+type cursorCoordinatesInput struct {
+	X int `cli:"x" validate:"required" description:"X coordinate in screen points."`
+	Y int `cli:"y" validate:"required" description:"Y coordinate in screen points."`
+}
+
+type screenshotInput struct {
+	PID      int `cli:"pid" validate:"min=1" description:"Target process ID; defaults to the selected visible window."`
+	WindowID int `cli:"window-id" validate:"min=1" description:"Target window ID; defaults to the selected visible window."`
 }
 
 type typeInput struct {
-	Text string `cli:"text" validate:"required"`
+	Text     string `cli:"text" validate:"required"`
+	PID      int    `cli:"pid" validate:"min=1" description:"Target process ID; defaults to the selected visible window."`
+	WindowID int    `cli:"window-id" validate:"min=1" description:"Target window ID; defaults to the selected visible window."`
 }
 
 type pressKeyInput struct {
-	Key string `cli:"key" validate:"required"`
+	Key      string `cli:"key" validate:"required"`
+	PID      int    `cli:"pid" validate:"min=1" description:"Target process ID; defaults to the selected visible window."`
+	WindowID int    `cli:"window-id" validate:"min=1" description:"Target window ID; defaults to the selected visible window."`
 }
 
 type scrollInput struct {
-	X         string `cli:"x" validate:"required"`
-	Y         string `cli:"y" validate:"required"`
-	Direction string `cli:"direction" validate:"required"`
-	Amount    string `cli:"amount"`
+	X         int    `cli:"x" validate:"required" description:"X coordinate in screenshot pixels."`
+	Y         int    `cli:"y" validate:"required" description:"Y coordinate in screenshot pixels."`
+	Direction string `cli:"direction" validate:"required" enum:"up,down,left,right"`
+	Amount    int    `cli:"amount" validate:"min=1,max=50"`
+	PID       int    `cli:"pid" validate:"min=1" description:"Target process ID; defaults to the selected visible window."`
+	WindowID  int    `cli:"window-id" validate:"min=1" description:"Target window ID; defaults to the selected visible window."`
 }
 
 func plainOutputSpec() framework.OutputSpec {
 	return framework.OutputSpec{
 		DefaultMode: cliservice.OutputModePlain,
+		DefaultView: framework.ViewSummary,
+		JSON:        true,
 		PlainText: func(result any) string {
-			return result.(string)
+			return result.(computersvc.ToolResult).Text
+		},
+		JSONViews: map[framework.OutputView]func(any) map[string]any{
+			framework.ViewSummary: func(result any) map[string]any {
+				return plainToolResultJSON(result.(computersvc.ToolResult))
+			},
 		},
 	}
 }
 
+func plainToolResultJSON(toolResult computersvc.ToolResult) map[string]any {
+	output := map[string]any{"text": toolResult.Text}
+	if len(toolResult.StructuredContent) > 0 {
+		output["structuredContent"] = toolResult.StructuredContent
+	}
+	if len(toolResult.Images) > 0 {
+		images := make([]map[string]any, 0, len(toolResult.Images))
+		for _, image := range toolResult.Images {
+			images = append(images, map[string]any{"mimeType": image.MimeType})
+		}
+		output["images"] = images
+	}
+	return output
+}
+
 func (p Provider) newScreenshotCommand() cliservice.Command {
-	return framework.Register(framework.CommandSpec[struct{}]{
+	return framework.Register(framework.CommandSpec[screenshotInput]{
 		ID:          "computer.screenshot",
 		Path:        []string{"computer", "screenshot"},
-		Summary:     "Take a screenshot of the macOS desktop",
-		Description: "Capture the current screen, save it as a PNG file, and return its path.",
+		Summary:     "Take a screenshot of a macOS window",
+		Description: "Capture the selected visible window, save it as a PNG file, and return its path.",
 		Kind:        framework.KindAction,
 		Workspace:   framework.WorkspaceRequired,
 		Workspaces:  p.workspaces,
-		Inputs:      framework.FromStruct[struct{}](),
+		Inputs:      framework.FromStruct[screenshotInput](),
 		Output:      plainOutputSpec(),
-		Run: func(ctx context.Context, invoke framework.InvokeContext, _ struct{}) (any, error) {
-			return p.call(ctx, invoke.WorkspaceID, "screenshot", map[string]any{})
+		Run: func(ctx context.Context, invoke framework.InvokeContext, input screenshotInput) (any, error) {
+			args, err := targetArgs(input.PID, input.WindowID)
+			if err != nil {
+				return nil, err
+			}
+			return p.call(ctx, invoke.WorkspaceID, "screenshot", args)
 		},
 	})
 }
 
 func (p Provider) newClickCommand() cliservice.Command {
-	return p.coordinatesCommand("computer.click", []string{"computer", "click"}, "Left-click at screen coordinates", "Left-click at the given (x, y) screen coordinates.", "left_click")
+	return p.coordinatesCommand("computer.click", []string{"computer", "click"}, "Left-click at window coordinates", "Left-click at the given (x, y) coordinates from a window screenshot.", map[string]any{})
 }
 
 func (p Provider) newDoubleClickCommand() cliservice.Command {
-	return p.coordinatesCommand("computer.double-click", []string{"computer", "double-click"}, "Double-click at screen coordinates", "Double-click at the given (x, y) screen coordinates.", "double_click")
+	return p.coordinatesCommand("computer.double-click", []string{"computer", "double-click"}, "Double-click at window coordinates", "Double-click at the given (x, y) coordinates from a window screenshot.", map[string]any{"count": 2})
 }
 
 func (p Provider) newRightClickCommand() cliservice.Command {
-	return p.coordinatesCommand("computer.right-click", []string{"computer", "right-click"}, "Right-click at screen coordinates", "Right-click at the given (x, y) screen coordinates.", "right_click")
+	return p.coordinatesCommand("computer.right-click", []string{"computer", "right-click"}, "Right-click at window coordinates", "Right-click at the given (x, y) coordinates from a window screenshot.", map[string]any{"button": "right"})
 }
 
 func (p Provider) newMoveCursorCommand() cliservice.Command {
-	return p.coordinatesCommand("computer.move-cursor", []string{"computer", "move-cursor"}, "Move the cursor without clicking", "Move the mouse cursor to the given (x, y) screen coordinates without clicking.", "move_cursor")
+	return framework.Register(framework.CommandSpec[cursorCoordinatesInput]{
+		ID:          "computer.move-cursor",
+		Path:        []string{"computer", "move-cursor"},
+		Summary:     "Move the agent cursor without clicking",
+		Description: "Move the visible agent cursor to the given (x, y) screen coordinates without clicking.",
+		Kind:        framework.KindAction,
+		Workspace:   framework.WorkspaceRequired,
+		Workspaces:  p.workspaces,
+		Inputs:      framework.FromStruct[cursorCoordinatesInput](),
+		Output:      plainOutputSpec(),
+		Run: func(ctx context.Context, invoke framework.InvokeContext, input cursorCoordinatesInput) (any, error) {
+			return p.call(ctx, invoke.WorkspaceID, "move_cursor", map[string]any{"x": input.X, "y": input.Y})
+		},
+	})
 }
 
-func (p Provider) coordinatesCommand(id string, path []string, summary string, description string, tool string) cliservice.Command {
+func (p Provider) coordinatesCommand(id string, path []string, summary string, description string, actionArgs map[string]any) cliservice.Command {
 	return framework.Register(framework.CommandSpec[coordinatesInput]{
 		ID:          id,
 		Path:        path,
@@ -81,7 +140,16 @@ func (p Provider) coordinatesCommand(id string, path []string, summary string, d
 		Inputs:      framework.FromStruct[coordinatesInput](),
 		Output:      plainOutputSpec(),
 		Run: func(ctx context.Context, invoke framework.InvokeContext, input coordinatesInput) (any, error) {
-			return p.call(ctx, invoke.WorkspaceID, tool, map[string]any{"x": input.X, "y": input.Y})
+			args, err := targetArgs(input.PID, input.WindowID)
+			if err != nil {
+				return nil, err
+			}
+			args["x"] = input.X
+			args["y"] = input.Y
+			for key, value := range actionArgs {
+				args[key] = value
+			}
+			return p.call(ctx, invoke.WorkspaceID, "click", args)
 		},
 	})
 }
@@ -98,7 +166,12 @@ func (p Provider) newTypeCommand() cliservice.Command {
 		Inputs:      framework.FromStruct[typeInput](),
 		Output:      plainOutputSpec(),
 		Run: func(ctx context.Context, invoke framework.InvokeContext, input typeInput) (any, error) {
-			return p.call(ctx, invoke.WorkspaceID, "type_text", map[string]any{"text": input.Text})
+			args, err := targetArgs(input.PID, input.WindowID)
+			if err != nil {
+				return nil, err
+			}
+			args["text"] = input.Text
+			return p.call(ctx, invoke.WorkspaceID, "type_text", args)
 		},
 	})
 }
@@ -115,7 +188,12 @@ func (p Provider) newPressKeyCommand() cliservice.Command {
 		Inputs:      framework.FromStruct[pressKeyInput](),
 		Output:      plainOutputSpec(),
 		Run: func(ctx context.Context, invoke framework.InvokeContext, input pressKeyInput) (any, error) {
-			return p.call(ctx, invoke.WorkspaceID, "press_key", map[string]any{"key": input.Key})
+			args, err := targetArgs(input.PID, input.WindowID)
+			if err != nil {
+				return nil, err
+			}
+			args["key"] = input.Key
+			return p.call(ctx, invoke.WorkspaceID, "press_key", args)
 		},
 	})
 }
@@ -124,8 +202,8 @@ func (p Provider) newScrollCommand() cliservice.Command {
 	return framework.Register(framework.CommandSpec[scrollInput]{
 		ID:          "computer.scroll",
 		Path:        []string{"computer", "scroll"},
-		Summary:     "Scroll at screen coordinates",
-		Description: "Scroll at the given (x, y) coordinates in the given direction.",
+		Summary:     "Scroll the selected window",
+		Description: "Scroll the selected window in the given direction; coordinates identify the source window screenshot.",
 		Kind:        framework.KindAction,
 		Workspace:   framework.WorkspaceRequired,
 		Workspaces:  p.workspaces,
@@ -136,9 +214,27 @@ func (p Provider) newScrollCommand() cliservice.Command {
 }
 
 func (p Provider) runScroll(ctx context.Context, invoke framework.InvokeContext, input scrollInput) (any, error) {
-	args := map[string]any{"x": input.X, "y": input.Y, "direction": input.Direction}
-	if input.Amount != "" {
+	args, err := targetArgs(input.PID, input.WindowID)
+	if err != nil {
+		return nil, err
+	}
+	args["x"] = input.X
+	args["y"] = input.Y
+	args["direction"] = input.Direction
+	if input.Amount != 0 {
 		args["amount"] = input.Amount
 	}
 	return p.call(ctx, invoke.WorkspaceID, "scroll", args)
+}
+
+func targetArgs(pid, windowID int) (map[string]any, error) {
+	if (pid == 0) != (windowID == 0) {
+		return nil, fmt.Errorf("%w: pid and window-id must be provided together", cliservice.ErrInvalidInput)
+	}
+	args := map[string]any{}
+	if pid != 0 {
+		args["pid"] = pid
+		args["window_id"] = windowID
+	}
+	return args, nil
 }

--- a/services/tuttid/service/cli/providers/computer/commands_test.go
+++ b/services/tuttid/service/cli/providers/computer/commands_test.go
@@ -1,0 +1,292 @@
+package computer
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
+	computersvc "github.com/tutti-os/tutti/services/tuttid/service/computer"
+)
+
+type recordedToolCall struct {
+	workspaceID string
+	tool        string
+	args        map[string]any
+}
+
+type fakeComputerService struct {
+	calls       []recordedToolCall
+	nativeCalls []recordedToolCall
+	result      computersvc.ToolResult
+	catalog     computersvc.ToolCatalog
+}
+
+func (f *fakeComputerService) CallTool(_ context.Context, workspaceID, _ string, tool string, args map[string]any) (computersvc.ToolResult, error) {
+	f.calls = append(f.calls, recordedToolCall{workspaceID: workspaceID, tool: tool, args: args})
+	if f.result.Text == "" {
+		f.result.Text = "ok"
+	}
+	return f.result, nil
+}
+
+func (f *fakeComputerService) CallNativeTool(_ context.Context, workspaceID, _ string, tool string, args map[string]any) (computersvc.ToolResult, error) {
+	f.nativeCalls = append(f.nativeCalls, recordedToolCall{workspaceID: workspaceID, tool: tool, args: args})
+	if f.result.Text == "" {
+		f.result.Text = "ok"
+	}
+	return f.result, nil
+}
+
+func (f *fakeComputerService) ListTools(context.Context, string, string) (computersvc.ToolCatalog, error) {
+	return f.catalog, nil
+}
+
+func TestStableComputerCommandSchemasExposeWindowTargetsWithoutSyntheticScope(t *testing.T) {
+	provider := NewProvider(nil, &fakeComputerService{})
+
+	screenshot := commandByID(t, provider.Commands(), "computer.screenshot")
+	assertNoSchemaProperty(t, screenshot, "scope")
+	assertSchemaProperty(t, screenshot, "pid", "integer")
+	assertSchemaProperty(t, screenshot, "window-id", "integer")
+
+	for _, commandID := range []string{"computer.click", "computer.double-click", "computer.right-click", "computer.scroll"} {
+		command := commandByID(t, provider.Commands(), commandID)
+		assertSchemaProperty(t, command, "x", "integer")
+		assertSchemaProperty(t, command, "y", "integer")
+		assertNoSchemaProperty(t, command, "scope")
+		assertSchemaProperty(t, command, "pid", "integer")
+		assertSchemaProperty(t, command, "window-id", "integer")
+	}
+
+	scroll := commandByID(t, provider.Commands(), "computer.scroll")
+	assertSchemaProperty(t, scroll, "amount", "integer")
+}
+
+func TestStableScreenshotRoutesOnlyWindowTargets(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]any
+		want  map[string]any
+	}{
+		{
+			name:  "explicit window",
+			input: map[string]any{"pid": "42", "window-id": "99"},
+			want:  map[string]any{"pid": 42, "window_id": 99},
+		},
+		{
+			name:  "compatible automatic window",
+			input: map[string]any{},
+			want:  map[string]any{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			computer := &fakeComputerService{}
+			command := commandByID(t, NewProvider(nil, computer).Commands(), "computer.screenshot")
+			invokeCommand(t, command, tt.input)
+			assertSingleToolCall(t, computer, "screenshot", tt.want)
+		})
+	}
+}
+
+func TestPointerCommandsPassNativeNumericArguments(t *testing.T) {
+	tests := []struct {
+		name      string
+		commandID string
+		tool      string
+		input     map[string]any
+		want      map[string]any
+	}{
+		{
+			name:      "explicit window click",
+			commandID: "computer.click",
+			tool:      "click",
+			input:     map[string]any{"pid": "42", "window-id": "99", "x": "120", "y": "240"},
+			want:      map[string]any{"pid": 42, "window_id": 99, "x": 120, "y": 240},
+		},
+		{
+			name:      "explicit window double click",
+			commandID: "computer.double-click",
+			tool:      "click",
+			input:     map[string]any{"pid": "42", "window-id": "99", "x": "120", "y": "240"},
+			want:      map[string]any{"pid": 42, "window_id": 99, "x": 120, "y": 240, "count": 2},
+		},
+		{
+			name:      "explicit window right click",
+			commandID: "computer.right-click",
+			tool:      "click",
+			input:     map[string]any{"pid": "42", "window-id": "99", "x": "120", "y": "240"},
+			want:      map[string]any{"pid": 42, "window_id": 99, "x": 120, "y": 240, "button": "right"},
+		},
+		{
+			name:      "move cursor",
+			commandID: "computer.move-cursor",
+			tool:      "move_cursor",
+			input:     map[string]any{"x": "120", "y": "240"},
+			want:      map[string]any{"x": 120, "y": 240},
+		},
+		{
+			name:      "window scroll",
+			commandID: "computer.scroll",
+			tool:      "scroll",
+			input:     map[string]any{"pid": "42", "window-id": "99", "x": "120", "y": "240", "direction": "down", "amount": "4"},
+			want:      map[string]any{"pid": 42, "window_id": 99, "x": 120, "y": 240, "direction": "down", "amount": 4},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			computer := &fakeComputerService{}
+			command := commandByID(t, NewProvider(nil, computer).Commands(), tt.commandID)
+			invokeCommand(t, command, tt.input)
+			assertSingleToolCall(t, computer, tt.tool, tt.want)
+		})
+	}
+}
+
+func TestKeyboardCommandsPassExplicitWindowTarget(t *testing.T) {
+	tests := []struct {
+		commandID string
+		input     map[string]any
+		tool      string
+		want      map[string]any
+	}{
+		{
+			commandID: "computer.type",
+			input:     map[string]any{"text": "hello", "pid": "42", "window-id": "99"},
+			tool:      "type_text",
+			want:      map[string]any{"text": "hello", "pid": 42, "window_id": 99},
+		},
+		{
+			commandID: "computer.press-key",
+			input:     map[string]any{"key": "cmd+c", "pid": "42", "window-id": "99"},
+			tool:      "press_key",
+			want:      map[string]any{"key": "cmd+c", "pid": 42, "window_id": 99},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.commandID, func(t *testing.T) {
+			computer := &fakeComputerService{}
+			command := commandByID(t, NewProvider(nil, computer).Commands(), tt.commandID)
+			invokeCommand(t, command, tt.input)
+			assertSingleToolCall(t, computer, tt.tool, tt.want)
+		})
+	}
+}
+
+func TestComputerCommandsRejectPartialWindowTargets(t *testing.T) {
+	tests := []struct {
+		name      string
+		commandID string
+		input     map[string]any
+	}{
+		{
+			name:      "partial window target",
+			commandID: "computer.screenshot",
+			input:     map[string]any{"pid": "42"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			computer := &fakeComputerService{}
+			command := commandByID(t, NewProvider(nil, computer).Commands(), tt.commandID)
+			_, err := command.Handler(context.Background(), cliservice.InvokeRequest{
+				Input:      tt.input,
+				OutputMode: cliservice.OutputModePlain,
+				Context:    cliservice.InvokeContext{WorkspaceID: "workspace-1"},
+			})
+			if !errors.Is(err, cliservice.ErrInvalidInput) {
+				t.Fatalf("err = %v, want ErrInvalidInput", err)
+			}
+			if len(computer.calls) != 0 {
+				t.Fatalf("unexpected tool calls: %#v", computer.calls)
+			}
+		})
+	}
+}
+
+func TestComputerCommandsSupportJSONOutput(t *testing.T) {
+	computer := &fakeComputerService{result: computersvc.ToolResult{
+		Text:              "Screenshot saved to /tmp/screenshot.png",
+		StructuredContent: map[string]any{"screenshot_file_path": "/tmp/screenshot.png"},
+	}}
+	commands := NewProvider(nil, computer).Commands()
+	for _, command := range commands {
+		if !command.Capability.Output.JSON {
+			t.Errorf("%s does not advertise JSON output", command.Capability.ID)
+		}
+	}
+
+	screenshot := commandByID(t, commands, "computer.screenshot")
+	output, err := screenshot.Handler(context.Background(), cliservice.InvokeRequest{
+		OutputMode: cliservice.OutputModeJSON,
+		Context:    cliservice.InvokeContext{WorkspaceID: "workspace-1"},
+	})
+	if err != nil {
+		t.Fatalf("invoke screenshot JSON: %v", err)
+	}
+	want := map[string]any{
+		"text": "Screenshot saved to /tmp/screenshot.png",
+		"structuredContent": map[string]any{
+			"screenshot_file_path": "/tmp/screenshot.png",
+		},
+	}
+	if !reflect.DeepEqual(output.Value, want) {
+		t.Fatalf("JSON output = %#v, want %#v", output.Value, want)
+	}
+}
+
+func commandByID(t *testing.T, commands []cliservice.Command, id string) cliservice.Command {
+	t.Helper()
+	for _, command := range commands {
+		if command.Capability.ID == id {
+			return command
+		}
+	}
+	t.Fatalf("command %q not found", id)
+	return cliservice.Command{}
+}
+
+func invokeCommand(t *testing.T, command cliservice.Command, input map[string]any) {
+	t.Helper()
+	if _, err := command.Handler(context.Background(), cliservice.InvokeRequest{
+		Input:      input,
+		OutputMode: cliservice.OutputModePlain,
+		Context:    cliservice.InvokeContext{WorkspaceID: "workspace-1"},
+	}); err != nil {
+		t.Fatalf("invoke %s: %v", command.Capability.ID, err)
+	}
+}
+
+func assertSingleToolCall(t *testing.T, computer *fakeComputerService, tool string, args map[string]any) {
+	t.Helper()
+	if len(computer.calls) != 1 {
+		t.Fatalf("calls = %#v, want one", computer.calls)
+	}
+	call := computer.calls[0]
+	if call.workspaceID != "workspace-1" || call.tool != tool || !reflect.DeepEqual(call.args, args) {
+		t.Fatalf("call = %#v, want workspace-1 %s %#v", call, tool, args)
+	}
+}
+
+func assertSchemaProperty(t *testing.T, command cliservice.Command, name, propertyType string) {
+	t.Helper()
+	properties := command.Capability.InputSchema["properties"].(map[string]any)
+	property, ok := properties[name].(map[string]any)
+	if !ok || property["type"] != propertyType {
+		t.Fatalf("%s property %q = %#v, want type %q", command.Capability.ID, name, properties[name], propertyType)
+	}
+}
+
+func assertNoSchemaProperty(t *testing.T, command cliservice.Command, name string) {
+	t.Helper()
+	properties := command.Capability.InputSchema["properties"].(map[string]any)
+	if _, ok := properties[name]; ok {
+		t.Fatalf("%s unexpectedly exposes property %q: %#v", command.Capability.ID, name, properties[name])
+	}
+}

--- a/services/tuttid/service/cli/providers/computer/provider.go
+++ b/services/tuttid/service/cli/providers/computer/provider.go
@@ -18,6 +18,8 @@ var errComputerUnavailable = errors.New("computer service is unavailable")
 // ComputerService is the subset of the daemon computer service the CLI needs.
 type ComputerService interface {
 	CallTool(ctx context.Context, workspaceID, cwd, tool string, args map[string]any) (computersvc.ToolResult, error)
+	CallNativeTool(ctx context.Context, workspaceID, cwd, tool string, args map[string]any) (computersvc.ToolResult, error)
+	ListTools(ctx context.Context, workspaceID, cwd string) (computersvc.ToolCatalog, error)
 }
 
 type Provider struct {
@@ -41,17 +43,20 @@ func (p Provider) Commands() []cliservice.Command {
 		p.newPressKeyCommand(),
 		p.newScrollCommand(),
 		p.newMoveCursorCommand(),
+		p.newToolListCommand(),
+		p.newToolDescribeCommand(),
+		p.newToolCallCommand(),
 	}
 }
 
-// call invokes the mapped cua-driver tool and returns the tool's text.
-func (p Provider) call(ctx context.Context, workspaceID string, tool string, args map[string]any) (string, error) {
+// call invokes the mapped cua-driver tool and preserves its structured result.
+func (p Provider) call(ctx context.Context, workspaceID string, tool string, args map[string]any) (computersvc.ToolResult, error) {
 	if p.computer == nil {
-		return "", errComputerUnavailable
+		return computersvc.ToolResult{}, errComputerUnavailable
 	}
 	result, err := p.computer.CallTool(ctx, workspaceID, "", tool, args)
 	if err != nil {
-		return "", err
+		return computersvc.ToolResult{}, err
 	}
-	return result.Text, nil
+	return result, nil
 }

--- a/services/tuttid/service/cli/providers/computer/tools.go
+++ b/services/tuttid/service/cli/providers/computer/tools.go
@@ -1,0 +1,259 @@
+package computer
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
+	"github.com/tutti-os/tutti/services/tuttid/service/cli/framework"
+	computersvc "github.com/tutti-os/tutti/services/tuttid/service/computer"
+)
+
+type toolNameInput struct {
+	Name string `cli:"name" validate:"required" description:"Native cua-driver tool name from computer tool list."`
+}
+
+type toolCallInput struct {
+	Name          string `cli:"name" validate:"required" description:"Native cua-driver tool name from computer tool list."`
+	ArgumentsJSON string `cli:"arguments-json" description:"Tool arguments as one JSON object. Defaults to {}."`
+}
+
+type toolListResult struct {
+	Catalog computersvc.ToolCatalog
+	Tools   []computersvc.ToolDefinition
+}
+
+func (p Provider) newToolListCommand() cliservice.Command {
+	return framework.Register(framework.CommandSpec[struct{}]{
+		ID:          "computer.tool.list",
+		Path:        []string{"computer", "tool", "list"},
+		Summary:     "List native computer tools",
+		Description: "List the live cua-driver catalog with Tutti's authorization decision for every tool.",
+		Kind:        framework.KindList,
+		Workspace:   framework.WorkspaceRequired,
+		Workspaces:  p.workspaces,
+		Inputs:      framework.FromStruct[struct{}](),
+		Output: framework.OutputSpec{
+			DefaultMode: cliservice.OutputModeTable,
+			DefaultView: framework.ViewSummary,
+			JSON:        true,
+			Table: &framework.TableOutputSpec{
+				Columns: []cliservice.TableColumn{
+					{Key: "name", Label: "NAME"},
+					{Key: "allowed", Label: "ALLOWED"},
+					{Key: "capabilities", Label: "CAPABILITIES"},
+					{Key: "effects", Label: "EFFECTS"},
+					{Key: "denialReason", Label: "DENIAL REASON"},
+				},
+				Rows: func(result any) []map[string]any {
+					return toolListRows(result.(toolListResult).Tools)
+				},
+			},
+			JSONViews: map[framework.OutputView]func(any) map[string]any{
+				framework.ViewSummary: func(result any) map[string]any {
+					listed := result.(toolListResult)
+					return map[string]any{
+						"schemaVersion":     listed.Catalog.SchemaVersion,
+						"capabilityVersion": listed.Catalog.CapabilityVersion,
+						"tools":             toolDetails(listed.Tools),
+					}
+				},
+			},
+			ListCompact: true,
+		},
+		Run: func(ctx context.Context, invoke framework.InvokeContext, _ struct{}) (any, error) {
+			catalog, err := p.listNativeTools(ctx, invoke.WorkspaceID)
+			if err != nil {
+				return nil, err
+			}
+			return toolListResult{Catalog: catalog, Tools: catalog.Tools}, nil
+		},
+	})
+}
+
+func (p Provider) newToolDescribeCommand() cliservice.Command {
+	return framework.Register(framework.CommandSpec[toolNameInput]{
+		ID:          "computer.tool.describe",
+		Path:        []string{"computer", "tool", "describe"},
+		Summary:     "Describe a native computer tool",
+		Description: "Return one live cua-driver tool definition and Tutti's authorization decision.",
+		Kind:        framework.KindGet,
+		Workspace:   framework.WorkspaceRequired,
+		Workspaces:  p.workspaces,
+		Inputs:      framework.FromStruct[toolNameInput](),
+		Output: framework.OutputSpec{
+			DefaultMode: cliservice.OutputModeJSON,
+			DefaultView: framework.ViewDetail,
+			JSON:        true,
+			JSONViews: map[framework.OutputView]func(any) map[string]any{
+				framework.ViewDetail: func(result any) map[string]any {
+					return toolDetail(result.(computersvc.ToolDefinition))
+				},
+			},
+		},
+		Run: func(ctx context.Context, invoke framework.InvokeContext, input toolNameInput) (any, error) {
+			catalog, err := p.listNativeTools(ctx, invoke.WorkspaceID)
+			if err != nil {
+				return nil, err
+			}
+			return catalogTool(catalog.Tools, input.Name)
+		},
+	})
+}
+
+func (p Provider) newToolCallCommand() cliservice.Command {
+	return framework.Register(framework.CommandSpec[toolCallInput]{
+		ID:          "computer.tool.call",
+		Path:        []string{"computer", "tool", "call"},
+		Summary:     "Call a native computer tool",
+		Description: "Ask the computer service to authorize and call one live cua-driver tool using its native JSON arguments.",
+		Kind:        framework.KindAction,
+		Workspace:   framework.WorkspaceRequired,
+		Workspaces:  p.workspaces,
+		Inputs:      framework.FromStruct[toolCallInput](),
+		Output:      nativeToolOutputSpec(),
+		Run: func(ctx context.Context, invoke framework.InvokeContext, input toolCallInput) (any, error) {
+			catalog, err := p.listNativeTools(ctx, invoke.WorkspaceID)
+			if err != nil {
+				return nil, err
+			}
+			tool, err := catalogTool(catalog.Tools, input.Name)
+			if err != nil {
+				return nil, err
+			}
+			arguments, err := parseToolArguments(input.ArgumentsJSON)
+			if err != nil {
+				return nil, err
+			}
+			return p.computer.CallNativeTool(ctx, invoke.WorkspaceID, "", tool.Name, arguments)
+		},
+	})
+}
+
+func nativeToolOutputSpec() framework.OutputSpec {
+	return framework.OutputSpec{
+		DefaultMode: cliservice.OutputModePlain,
+		DefaultView: framework.ViewSummary,
+		JSON:        true,
+		RawJSON:     true,
+		RawJSONReason: "native computer tool results preserve the complete MCP result envelope, " +
+			"including future content variants",
+		PlainText: func(result any) string {
+			return result.(computersvc.ToolResult).Text
+		},
+		JSONViews: map[framework.OutputView]func(any) map[string]any{
+			framework.ViewSummary: func(result any) map[string]any {
+				toolResult := result.(computersvc.ToolResult)
+				if len(toolResult.Raw) > 0 {
+					var native map[string]any
+					decoder := json.NewDecoder(bytes.NewReader(toolResult.Raw))
+					decoder.UseNumber()
+					if err := decoder.Decode(&native); err == nil && native != nil {
+						return native
+					}
+				}
+				return plainToolResultJSON(toolResult)
+			},
+		},
+	}
+}
+
+func (p Provider) listNativeTools(ctx context.Context, workspaceID string) (computersvc.ToolCatalog, error) {
+	if p.computer == nil {
+		return computersvc.ToolCatalog{}, errComputerUnavailable
+	}
+	return p.computer.ListTools(ctx, workspaceID, "")
+}
+
+func parseToolArguments(value string) (map[string]any, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		value = "{}"
+	}
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.UseNumber()
+	var arguments map[string]any
+	if err := decoder.Decode(&arguments); err != nil {
+		return nil, fmt.Errorf("%w: arguments-json must be a JSON object: %v", cliservice.ErrInvalidInput, err)
+	}
+	if arguments == nil {
+		return nil, fmt.Errorf("%w: arguments-json must be a JSON object", cliservice.ErrInvalidInput)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("%w: arguments-json must contain one JSON object", cliservice.ErrInvalidInput)
+	}
+	return arguments, nil
+}
+
+func catalogTool(tools []computersvc.ToolDefinition, name string) (computersvc.ToolDefinition, error) {
+	name = strings.TrimSpace(name)
+	for _, tool := range tools {
+		if tool.Name != name {
+			continue
+		}
+		return tool, nil
+	}
+	return computersvc.ToolDefinition{}, fmt.Errorf("%w: computer tool %q is not in the live cua-driver catalog", cliservice.ErrInvalidInput, name)
+}
+
+func toolListRows(tools []computersvc.ToolDefinition) []map[string]any {
+	rows := make([]map[string]any, 0, len(tools))
+	for _, tool := range tools {
+		rows = append(rows, map[string]any{
+			"name":         tool.Name,
+			"allowed":      tool.Allowed,
+			"capabilities": strings.Join(tool.Capabilities, ","),
+			"effects":      toolEffects(tool.Annotations),
+			"denialReason": tool.DenialReason,
+		})
+	}
+	return rows
+}
+
+func toolDetails(tools []computersvc.ToolDefinition) []map[string]any {
+	details := make([]map[string]any, 0, len(tools))
+	for _, tool := range tools {
+		details = append(details, toolDetail(tool))
+	}
+	return details
+}
+
+func toolDetail(tool computersvc.ToolDefinition) map[string]any {
+	return map[string]any{
+		"name":         tool.Name,
+		"description":  tool.Description,
+		"inputSchema":  tool.InputSchema,
+		"capabilities": tool.Capabilities,
+		"allowed":      tool.Allowed,
+		"denialReason": tool.DenialReason,
+		"annotations": map[string]any{
+			"readOnlyHint":    tool.Annotations.ReadOnly,
+			"destructiveHint": tool.Annotations.Destructive,
+			"idempotentHint":  tool.Annotations.Idempotent,
+			"openWorldHint":   tool.Annotations.OpenWorld,
+		},
+	}
+}
+
+func toolEffects(annotations computersvc.ToolAnnotations) string {
+	effects := make([]string, 0, 3)
+	if annotations.ReadOnly {
+		effects = append(effects, "read-only")
+	}
+	if annotations.Destructive {
+		effects = append(effects, "destructive")
+	}
+	if annotations.OpenWorld {
+		effects = append(effects, "open-world")
+	}
+	if len(effects) == 0 {
+		return "local mutation"
+	}
+	return strings.Join(effects, ",")
+}

--- a/services/tuttid/service/cli/providers/computer/tools_test.go
+++ b/services/tuttid/service/cli/providers/computer/tools_test.go
@@ -1,0 +1,155 @@
+package computer
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
+	computersvc "github.com/tutti-os/tutti/services/tuttid/service/computer"
+)
+
+func TestNativeToolCommandsAreRegistered(t *testing.T) {
+	commands := NewProvider(nil, &fakeComputerService{}).Commands()
+	for _, id := range []string{"computer.tool.list", "computer.tool.describe", "computer.tool.call"} {
+		commandByID(t, commands, id)
+	}
+}
+
+func TestNativeToolListRendersCompleteCatalogAuthorization(t *testing.T) {
+	computer := &fakeComputerService{catalog: testToolCatalog()}
+	command := commandByID(t, NewProvider(nil, computer).Commands(), "computer.tool.list")
+	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
+		OutputMode: cliservice.OutputModeJSON,
+		Context:    cliservice.InvokeContext{WorkspaceID: "workspace-1"},
+	})
+	if err != nil {
+		t.Fatalf("tool list: %v", err)
+	}
+	tools := output.Value["tools"].([]map[string]any)
+	if len(tools) != 3 || tools[0]["name"] != "click" || tools[1]["name"] != "get_desktop_state" || tools[2]["name"] != "set_config" {
+		t.Fatalf("tools = %#v", tools)
+	}
+	if tools[0]["allowed"] != true || tools[0]["denialReason"] != "" {
+		t.Fatalf("allowed row = %#v", tools[0])
+	}
+	if tools[2]["allowed"] != true || tools[2]["denialReason"] != "" {
+		t.Fatalf("config row = %#v", tools[2])
+	}
+	if !reflect.DeepEqual(tools[2]["inputSchema"], map[string]any{"type": "object"}) || !reflect.DeepEqual(tools[2]["capabilities"], []string{"system.config.write"}) {
+		t.Fatalf("catalog metadata = %#v", tools[2])
+	}
+
+	tableRows := toolListRows(computer.catalog.Tools)
+	if tableRows[2]["allowed"] != true || tableRows[2]["denialReason"] != "" {
+		t.Fatalf("table row = %#v", tableRows[2])
+	}
+}
+
+func TestNativeToolDescribeReturnsAllowedConfigWriteAuthorization(t *testing.T) {
+	computer := &fakeComputerService{catalog: testToolCatalog()}
+	command := commandByID(t, NewProvider(nil, computer).Commands(), "computer.tool.describe")
+	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
+		Input:      map[string]any{"name": "set_config"},
+		OutputMode: cliservice.OutputModeJSON,
+		Context:    cliservice.InvokeContext{WorkspaceID: "workspace-1"},
+	})
+	if err != nil {
+		t.Fatalf("tool describe: %v", err)
+	}
+	if output.Value["name"] != "set_config" || output.Value["allowed"] != true || output.Value["denialReason"] != "" {
+		t.Fatalf("output = %#v", output.Value)
+	}
+}
+
+func TestNativeToolCallForwardsJSONArgumentsWithoutPerToolBinding(t *testing.T) {
+	computer := &fakeComputerService{
+		catalog: testToolCatalog(),
+		result: computersvc.ToolResult{
+			Text:              "clicked",
+			StructuredContent: map[string]any{"verified": false},
+			Raw:               json.RawMessage(`{"isError":true,"content":[{"type":"text","text":"clicked"},{"type":"resource_link","uri":"file:///tmp/result"}],"structuredContent":{"verified":false},"futureField":true,"largeId":9007199254740993}`),
+			IsError:           true,
+		},
+	}
+	command := commandByID(t, NewProvider(nil, computer).Commands(), "computer.tool.call")
+	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
+		Input: map[string]any{
+			"name":           "click",
+			"arguments-json": `{"scope":"desktop","x":120,"y":240}`,
+		},
+		OutputMode: cliservice.OutputModeJSON,
+		Context:    cliservice.InvokeContext{WorkspaceID: "workspace-1"},
+	})
+	if err != nil {
+		t.Fatalf("tool call: %v", err)
+	}
+	if len(computer.nativeCalls) != 1 {
+		t.Fatalf("native calls = %#v", computer.nativeCalls)
+	}
+	call := computer.nativeCalls[0]
+	wantArgs := map[string]any{
+		"scope": "desktop",
+		"x":     json.Number("120"),
+		"y":     json.Number("240"),
+	}
+	if call.tool != "click" || !reflect.DeepEqual(call.args, wantArgs) {
+		t.Fatalf("call = %#v, want click %#v", call, wantArgs)
+	}
+	content := output.Value["content"].([]any)
+	if len(content) != 2 || output.Value["isError"] != true || output.Value["futureField"] != true || output.Value["largeId"] != json.Number("9007199254740993") || !reflect.DeepEqual(output.Value["structuredContent"], map[string]any{"verified": false}) {
+		t.Fatalf("output = %#v", output.Value)
+	}
+}
+
+func TestNativeToolCallForwardsGlobalConfigWriteToServicePolicy(t *testing.T) {
+	computer := &fakeComputerService{catalog: testToolCatalog()}
+	command := commandByID(t, NewProvider(nil, computer).Commands(), "computer.tool.call")
+	_, err := command.Handler(context.Background(), cliservice.InvokeRequest{
+		Input: map[string]any{
+			"name":           "set_config",
+			"arguments-json": `{"capture_scope":"desktop"}`,
+		},
+		OutputMode: cliservice.OutputModePlain,
+		Context:    cliservice.InvokeContext{WorkspaceID: "workspace-1"},
+	})
+	if err != nil {
+		t.Fatalf("tool call: %v", err)
+	}
+	if len(computer.nativeCalls) != 1 || computer.nativeCalls[0].tool != "set_config" ||
+		computer.nativeCalls[0].args["capture_scope"] != "desktop" {
+		t.Fatalf("native calls: %#v", computer.nativeCalls)
+	}
+}
+
+func testToolCatalog() computersvc.ToolCatalog {
+	return computersvc.ToolCatalog{
+		SchemaVersion:     "1",
+		CapabilityVersion: "1",
+		Tools: []computersvc.ToolDefinition{
+			{
+				Name:         "click",
+				Description:  "Click",
+				InputSchema:  map[string]any{"type": "object"},
+				Capabilities: []string{"input.pointer.click"},
+				Allowed:      true,
+			},
+			{
+				Name:         "get_desktop_state",
+				Description:  "Capture desktop",
+				InputSchema:  map[string]any{"type": "object"},
+				Capabilities: []string{"screen.capture"},
+				Annotations:  computersvc.ToolAnnotations{ReadOnly: true},
+				Allowed:      true,
+			},
+			{
+				Name:         "set_config",
+				Description:  "Set global driver config",
+				InputSchema:  map[string]any{"type": "object"},
+				Capabilities: []string{"system.config.write"},
+				Allowed:      true,
+			},
+		},
+	}
+}

--- a/services/tuttid/service/computer/adapter.go
+++ b/services/tuttid/service/computer/adapter.go
@@ -89,6 +89,13 @@ func (s *computerSession) adaptScreenshot(ctx context.Context, args map[string]a
 func (s *computerSession) adaptWindowTargetedTool(ctx context.Context, tool string, args map[string]any) (ToolResult, error) {
 	out := cloneToolArgs(args)
 	delete(out, "scope")
+	if tool == "scroll" {
+		if amount, ok := numericArg(out, "amount"); ok {
+			out["amount"] = int(amount)
+		} else {
+			out["amount"] = 3
+		}
+	}
 	target, err := s.resolveWindowTarget(ctx, args)
 	if err != nil {
 		return ToolResult{}, err
@@ -136,17 +143,8 @@ func (s *computerSession) adaptPIDRequiredTool(ctx context.Context, tool string,
 		switch key {
 		case "x", "y", "scope", "pid", "window_id":
 			continue
-		case "amount":
-			if amount, ok := numericArg(args, "amount"); ok {
-				out["amount"] = int(amount)
-			}
 		default:
 			out[key] = value
-		}
-	}
-	if tool == "scroll" {
-		if _, ok := out["amount"]; !ok {
-			out["amount"] = 3
 		}
 	}
 	return s.callTool(ctx, tool, out)

--- a/services/tuttid/service/computer/adapter.go
+++ b/services/tuttid/service/computer/adapter.go
@@ -3,6 +3,7 @@ package computer
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -26,31 +27,33 @@ type windowStatePayload struct {
 
 var accessibilityWindowLinePattern = regexp.MustCompile(`^- (.+) \(pid (\d+)\)(?: "(.*)"| \(no title\)) \[window_id: (\d+)\]$`)
 
-// adaptToolCall translates legacy tutti computer CLI tool names and arguments
-// to the cua-driver 0.5.x MCP API (pid/window_id scoped actions).
+// adaptToolCall implements Tutti's explicitly supported stable aliases over
+// cua-driver. Native discovery/invocation uses the separate policy-enforced
+// Service methods and never falls through this switch.
 func (s *computerSession) adaptToolCall(ctx context.Context, tool string, args map[string]any) (ToolResult, error) {
 	switch tool {
 	case "screenshot":
-		return s.adaptScreenshot(ctx)
+		return s.adaptScreenshot(ctx, args)
 	case "left_click":
-		return s.adaptPointerAction(ctx, "click", args)
-	case "double_click", "right_click":
-		return s.adaptPointerAction(ctx, tool, args)
+		return s.adaptWindowTargetedTool(ctx, "click", args)
+	case "double_click":
+		return s.adaptWindowTargetedTool(ctx, "click", withToolArg(args, "count", 2))
+	case "right_click":
+		return s.adaptWindowTargetedTool(ctx, "click", withToolArg(args, "button", "right"))
+	case "click", "scroll":
+		return s.adaptWindowTargetedTool(ctx, tool, args)
 	case "press_key":
 		return s.adaptPressKey(ctx, args)
-	case "type_text", "scroll":
+	case "type_text":
 		return s.adaptPIDRequiredTool(ctx, tool, args)
-	default:
+	case "move_cursor":
 		return s.callTool(ctx, tool, args)
+	default:
+		return ToolResult{}, fmt.Errorf("unsupported stable computer tool %q", tool)
 	}
 }
 
-func (s *computerSession) adaptScreenshot(ctx context.Context) (ToolResult, error) {
-	target, err := s.resolveFrontmostWindow(ctx)
-	if err != nil {
-		return ToolResult{}, err
-	}
-
+func (s *computerSession) adaptScreenshot(ctx context.Context, args map[string]any) (ToolResult, error) {
 	file, err := os.CreateTemp("", "tutti-computer-*.png")
 	if err != nil {
 		return ToolResult{}, err
@@ -58,6 +61,11 @@ func (s *computerSession) adaptScreenshot(ctx context.Context) (ToolResult, erro
 	path := file.Name()
 	_ = file.Close()
 
+	target, targetErr := s.resolveWindowTarget(ctx, args)
+	if targetErr != nil {
+		_ = os.Remove(path)
+		return ToolResult{}, targetErr
+	}
 	raw, err := s.callTool(ctx, "get_window_state", map[string]any{
 		"pid":                 target.PID,
 		"window_id":           target.WindowID,
@@ -73,25 +81,20 @@ func (s *computerSession) adaptScreenshot(ctx context.Context) (ToolResult, erro
 		return ToolResult{}, fmt.Errorf("screenshot file missing after capture: %w (tool output: %s)", statErr, truncateForError(raw.Text))
 	}
 
-	return ToolResult{Text: fmt.Sprintf("Screenshot saved to %s", path)}, nil
+	structured := cloneStructuredContent(raw.StructuredContent)
+	structured["screenshot_file_path"] = path
+	return ToolResult{Text: fmt.Sprintf("Screenshot saved to %s", path), StructuredContent: structured}, nil
 }
 
-func (s *computerSession) adaptPointerAction(ctx context.Context, tool string, args map[string]any) (ToolResult, error) {
-	target, err := s.resolveFrontmostWindow(ctx)
+func (s *computerSession) adaptWindowTargetedTool(ctx context.Context, tool string, args map[string]any) (ToolResult, error) {
+	out := cloneToolArgs(args)
+	delete(out, "scope")
+	target, err := s.resolveWindowTarget(ctx, args)
 	if err != nil {
 		return ToolResult{}, err
 	}
-
-	out := map[string]any{
-		"pid":       target.PID,
-		"window_id": target.WindowID,
-	}
-	if x, ok := numericArg(args, "x"); ok {
-		out["x"] = x
-	}
-	if y, ok := numericArg(args, "y"); ok {
-		out["y"] = y
-	}
+	out["pid"] = target.PID
+	out["window_id"] = target.WindowID
 	return s.callTool(ctx, tool, out)
 }
 
@@ -101,7 +104,7 @@ func (s *computerSession) adaptPressKey(ctx context.Context, args map[string]any
 		return ToolResult{}, fmt.Errorf("missing required string field: key")
 	}
 
-	target, err := s.resolveFrontmostWindow(ctx)
+	target, err := s.resolveWindowTarget(ctx, args)
 	if err != nil {
 		return ToolResult{}, err
 	}
@@ -121,7 +124,7 @@ func (s *computerSession) adaptPressKey(ctx context.Context, args map[string]any
 }
 
 func (s *computerSession) adaptPIDRequiredTool(ctx context.Context, tool string, args map[string]any) (ToolResult, error) {
-	target, err := s.resolveFrontmostWindow(ctx)
+	target, err := s.resolveWindowTarget(ctx, args)
 	if err != nil {
 		return ToolResult{}, err
 	}
@@ -129,7 +132,7 @@ func (s *computerSession) adaptPIDRequiredTool(ctx context.Context, tool string,
 	out := map[string]any{"pid": target.PID}
 	for key, value := range args {
 		switch key {
-		case "x", "y":
+		case "x", "y", "scope", "pid", "window_id":
 			continue
 		case "amount":
 			if amount, ok := numericArg(args, "amount"); ok {
@@ -148,17 +151,70 @@ func (s *computerSession) adaptPIDRequiredTool(ctx context.Context, tool string,
 }
 
 func (s *computerSession) resolveFrontmostWindow(ctx context.Context) (windowRecord, error) {
-	raw, err := s.callTool(ctx, "get_accessibility_tree", nil)
+	raw, listErr := s.callTool(ctx, "list_windows", map[string]any{"on_screen_only": true})
+	var structuredErr error
+	if listErr == nil {
+		payload, decodeErr := structuredPayload[struct {
+			Windows []windowRecord `json:"windows"`
+		}](raw.StructuredContent)
+		if decodeErr == nil {
+			window, selectErr := selectAutomationWindow(payload.Windows)
+			if selectErr == nil {
+				return window, nil
+			}
+			structuredErr = selectErr
+		} else {
+			structuredErr = decodeErr
+		}
+	}
+
+	legacy, legacyErr := s.callTool(ctx, "get_accessibility_tree", nil)
+	if legacyErr != nil {
+		return windowRecord{}, errors.Join(listErr, structuredErr, legacyErr)
+	}
+	windows, err := parseAccessibilityTreeWindows(legacy.Text)
 	if err != nil {
 		return windowRecord{}, err
 	}
 
-	windows, err := parseAccessibilityTreeWindows(raw.Text)
-	if err != nil {
-		return windowRecord{}, err
-	}
+	return selectAutomationWindow(windows)
+}
 
-	return windows[0], nil
+func (s *computerSession) resolveWindowTarget(ctx context.Context, args map[string]any) (windowRecord, error) {
+	pid, hasPID := integerArg(args, "pid")
+	windowID, hasWindowID := integerArg(args, "window_id")
+	if hasPID != hasWindowID {
+		return windowRecord{}, fmt.Errorf("pid and window_id must be provided together")
+	}
+	if hasPID {
+		return windowRecord{PID: pid, WindowID: windowID}, nil
+	}
+	return s.resolveFrontmostWindow(ctx)
+}
+
+func selectAutomationWindow(windows []windowRecord) (windowRecord, error) {
+	candidates := make([]windowRecord, 0, len(windows))
+	desktopPID, _ := strconv.Atoi(strings.TrimSpace(os.Getenv("TUTTI_DESKTOP_PARENT_PID")))
+	for _, window := range windows {
+		if !window.IsOnScreen && window.ZIndex != 0 {
+			continue
+		}
+		name := strings.ToLower(strings.TrimSpace(window.AppName))
+		if name == "cua driver" || strings.Contains(name, "tutti") || desktopPID > 0 && window.PID == desktopPID {
+			continue
+		}
+		if window.PID <= 0 || window.WindowID <= 0 {
+			continue
+		}
+		candidates = append(candidates, window)
+	}
+	if len(candidates) == 0 {
+		return windowRecord{}, fmt.Errorf("no eligible visible windows found")
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].ZIndex > candidates[j].ZIndex
+	})
+	return candidates[0], nil
 }
 
 func parseAccessibilityTreeWindows(text string) ([]windowRecord, error) {
@@ -285,6 +341,51 @@ func numericArg(args map[string]any, key string) (float64, bool) {
 	default:
 		return 0, false
 	}
+}
+
+func integerArg(args map[string]any, key string) (int, bool) {
+	value, ok := numericArg(args, key)
+	if !ok || value != float64(int(value)) {
+		return 0, false
+	}
+	return int(value), true
+}
+
+func withToolArg(args map[string]any, key string, value any) map[string]any {
+	out := cloneToolArgs(args)
+	out[key] = value
+	return out
+}
+
+func cloneToolArgs(args map[string]any) map[string]any {
+	out := make(map[string]any, len(args))
+	for key, value := range args {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneStructuredContent(content map[string]any) map[string]any {
+	out := make(map[string]any, len(content)+2)
+	for key, value := range content {
+		out[key] = value
+	}
+	return out
+}
+
+func structuredPayload[T any](content map[string]any) (T, error) {
+	var zero T
+	if len(content) == 0 {
+		return zero, fmt.Errorf("structured tool result is empty")
+	}
+	data, err := json.Marshal(content)
+	if err != nil {
+		return zero, fmt.Errorf("encode structured tool result: %w", err)
+	}
+	if err := json.Unmarshal(data, &zero); err != nil {
+		return zero, fmt.Errorf("decode structured tool result: %w", err)
+	}
+	return zero, nil
 }
 
 func truncateForError(text string) string {

--- a/services/tuttid/service/computer/adapter.go
+++ b/services/tuttid/service/computer/adapter.go
@@ -112,14 +112,16 @@ func (s *computerSession) adaptPressKey(ctx context.Context, args map[string]any
 	parts := splitKeySpec(keySpec)
 	if len(parts) > 1 {
 		return s.callTool(ctx, "hotkey", map[string]any{
-			"pid":  target.PID,
-			"keys": parts,
+			"pid":       target.PID,
+			"window_id": target.WindowID,
+			"keys":      parts,
 		})
 	}
 
 	return s.callTool(ctx, "press_key", map[string]any{
-		"pid": target.PID,
-		"key": parts[0],
+		"pid":       target.PID,
+		"window_id": target.WindowID,
+		"key":       parts[0],
 	})
 }
 
@@ -129,7 +131,7 @@ func (s *computerSession) adaptPIDRequiredTool(ctx context.Context, tool string,
 		return ToolResult{}, err
 	}
 
-	out := map[string]any{"pid": target.PID}
+	out := map[string]any{"pid": target.PID, "window_id": target.WindowID}
 	for key, value := range args {
 		switch key {
 		case "x", "y", "scope", "pid", "window_id":

--- a/services/tuttid/service/computer/adapter_test.go
+++ b/services/tuttid/service/computer/adapter_test.go
@@ -169,6 +169,17 @@ func TestStableWindowActionsNeverUseDesktopScope(t *testing.T) {
 				"x": float64(120), "y": float64(240), "direction": "down", "amount": float64(4),
 			}},
 		},
+		{
+			name: "scroll defaults omitted amount",
+			tool: "scroll",
+			args: map[string]any{
+				"pid": 42, "window_id": 99, "x": 120, "y": 240, "direction": "down",
+			},
+			want: recordedNativeToolCall{name: "scroll", args: map[string]any{
+				"pid": float64(42), "window_id": float64(99),
+				"x": float64(120), "y": float64(240), "direction": "down", "amount": float64(3),
+			}},
+		},
 	}
 
 	for _, tt := range tests {

--- a/services/tuttid/service/computer/adapter_test.go
+++ b/services/tuttid/service/computer/adapter_test.go
@@ -1,6 +1,189 @@
 package computer
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+)
+
+type recordedNativeToolCall struct {
+	name string
+	args map[string]any
+}
+
+type adapterRecordingConn struct {
+	mu        sync.Mutex
+	frames    chan agentruntime.ProcessFrame
+	closeOnce sync.Once
+	calls     []recordedNativeToolCall
+}
+
+func newAdapterRecordingConn() *adapterRecordingConn {
+	return &adapterRecordingConn{frames: make(chan agentruntime.ProcessFrame, 8)}
+}
+
+func (c *adapterRecordingConn) Send(data []byte) error {
+	var message struct {
+		ID     any            `json:"id"`
+		Method string         `json:"method"`
+		Params map[string]any `json:"params"`
+	}
+	if err := json.Unmarshal(data, &message); err != nil {
+		return err
+	}
+	if message.Method != "tools/call" {
+		return nil
+	}
+	name, _ := message.Params["name"].(string)
+	args, _ := message.Params["arguments"].(map[string]any)
+	c.mu.Lock()
+	c.calls = append(c.calls, recordedNativeToolCall{name: name, args: args})
+	c.mu.Unlock()
+	response, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      message.ID,
+		"result": map[string]any{
+			"isError":           false,
+			"content":           []map[string]any{{"type": "text", "text": "ok"}},
+			"structuredContent": map[string]any{"driver": "kept"},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	c.frames <- agentruntime.ProcessFrame{Stdout: append(response, '\n')}
+	return nil
+}
+
+func (c *adapterRecordingConn) Recv() (agentruntime.ProcessFrame, error) {
+	frame, ok := <-c.frames
+	if !ok {
+		return agentruntime.ProcessFrame{}, context.Canceled
+	}
+	return frame, nil
+}
+
+func (c *adapterRecordingConn) Close() error {
+	c.closeOnce.Do(func() { close(c.frames) })
+	return nil
+}
+
+func (c *adapterRecordingConn) recordedCalls() []recordedNativeToolCall {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]recordedNativeToolCall(nil), c.calls...)
+}
+
+func newAdapterTestSession(t *testing.T) (*computerSession, *adapterRecordingConn) {
+	t.Helper()
+	conn := newAdapterRecordingConn()
+	session := &computerSession{client: newMCPClient(conn)}
+	t.Cleanup(func() { _ = conn.Close() })
+	return session, conn
+}
+
+func TestStableAdapterRejectsUnknownToolInsteadOfFallingThrough(t *testing.T) {
+	_, err := (&computerSession{}).adaptToolCall(context.Background(), "kill_app", nil)
+	if err == nil || !strings.Contains(err.Error(), "unsupported stable computer tool") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestStableAdapterExplicitlyRoutesMoveCursor(t *testing.T) {
+	_, err := (&computerSession{}).adaptToolCall(context.Background(), "move_cursor", map[string]any{"x": 12, "y": 34})
+	if err == nil || strings.Contains(err.Error(), "unsupported stable computer tool") {
+		t.Fatalf("err = %v, want routed session-not-started error", err)
+	}
+}
+
+func TestStableScreenshotAlwaysUsesWindowCapture(t *testing.T) {
+	session, conn := newAdapterTestSession(t)
+
+	result, err := session.adaptToolCall(context.Background(), "screenshot", map[string]any{
+		"scope": "desktop", "pid": 42, "window_id": 99,
+	})
+	if err != nil {
+		t.Fatalf("adaptToolCall(screenshot): %v", err)
+	}
+	path, _ := result.StructuredContent["screenshot_file_path"].(string)
+	if path == "" {
+		t.Fatalf("structured content = %#v, want screenshot_file_path", result.StructuredContent)
+	}
+	defer os.Remove(path)
+	if _, ok := result.StructuredContent["scope"]; ok {
+		t.Fatalf("structured content unexpectedly contains synthetic scope: %#v", result.StructuredContent)
+	}
+	if result.StructuredContent["driver"] != "kept" {
+		t.Fatalf("structured content = %#v, want native fields preserved", result.StructuredContent)
+	}
+
+	calls := conn.recordedCalls()
+	if len(calls) != 1 || calls[0].name != "get_window_state" {
+		t.Fatalf("calls = %#v, want one get_window_state call", calls)
+	}
+	wantFixedArgs := map[string]any{
+		"pid":          float64(42),
+		"window_id":    float64(99),
+		"capture_mode": "vision",
+	}
+	for key, want := range wantFixedArgs {
+		if !reflect.DeepEqual(calls[0].args[key], want) {
+			t.Fatalf("get_window_state argument %q = %#v, want %#v", key, calls[0].args[key], want)
+		}
+	}
+	if _, ok := calls[0].args["scope"]; ok {
+		t.Fatalf("get_window_state arguments unexpectedly contain scope: %#v", calls[0].args)
+	}
+}
+
+func TestStableWindowActionsNeverUseDesktopScope(t *testing.T) {
+	tests := []struct {
+		name string
+		tool string
+		args map[string]any
+		want recordedNativeToolCall
+	}{
+		{
+			name: "click keeps window coordinates",
+			tool: "click",
+			args: map[string]any{"scope": "desktop", "pid": 42, "window_id": 99, "x": 120, "y": 240},
+			want: recordedNativeToolCall{name: "click", args: map[string]any{
+				"pid": float64(42), "window_id": float64(99), "x": float64(120), "y": float64(240),
+			}},
+		},
+		{
+			name: "scroll keeps targeted pixel wheel coordinates",
+			tool: "scroll",
+			args: map[string]any{
+				"scope": "desktop", "pid": 42, "window_id": 99,
+				"x": 120, "y": 240, "direction": "down", "amount": 4,
+			},
+			want: recordedNativeToolCall{name: "scroll", args: map[string]any{
+				"pid": float64(42), "window_id": float64(99),
+				"x": float64(120), "y": float64(240), "direction": "down", "amount": float64(4),
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session, conn := newAdapterTestSession(t)
+			if _, err := session.adaptToolCall(context.Background(), tt.tool, tt.args); err != nil {
+				t.Fatalf("adaptToolCall(%s): %v", tt.tool, err)
+			}
+			calls := conn.recordedCalls()
+			if len(calls) != 1 || !reflect.DeepEqual(calls[0], tt.want) {
+				t.Fatalf("calls = %#v, want %#v", calls, []recordedNativeToolCall{tt.want})
+			}
+		})
+	}
+}
 
 func TestSplitKeySpec(t *testing.T) {
 	tests := []struct {
@@ -46,6 +229,40 @@ func TestParseAccessibilityTreeWindows(t *testing.T) {
 	}
 	if windows[0].AppName != "Warp" || windows[0].PID != 40206 || windows[0].WindowID != 6392 {
 		t.Fatalf("frontmost window = %+v, want Warp 40206/6392", windows[0])
+	}
+}
+
+func TestSelectAutomationWindowUsesStructuredZOrderAndFiltersDriverWindows(t *testing.T) {
+	t.Setenv("TUTTI_DESKTOP_PARENT_PID", "11")
+	windows := []windowRecord{
+		{PID: 10, WindowID: 100, ZIndex: 100, AppName: "Cua Driver", Title: "Overlay", IsOnScreen: true},
+		{PID: 11, WindowID: 101, ZIndex: 90, AppName: "Electron", Title: "Tutti", IsOnScreen: true},
+		{PID: 12, WindowID: 102, ZIndex: 80, AppName: "Lark", Title: "Chat", IsOnScreen: true},
+		{PID: 13, WindowID: 103, ZIndex: 70, AppName: "Safari", Title: "Off Space", IsOnScreen: false},
+	}
+
+	window, err := selectAutomationWindow(windows)
+	if err != nil {
+		t.Fatalf("selectAutomationWindow: %v", err)
+	}
+	if window.PID != 12 || window.WindowID != 102 {
+		t.Fatalf("window = %#v, want Lark 12/102", window)
+	}
+}
+
+func TestSelectAutomationWindowKeepsUnrelatedElectronApps(t *testing.T) {
+	t.Setenv("TUTTI_DESKTOP_PARENT_PID", "99")
+	windows := []windowRecord{
+		{PID: 11, WindowID: 101, ZIndex: 90, AppName: "Electron", Title: "VS Code", IsOnScreen: true},
+		{PID: 12, WindowID: 102, ZIndex: 80, AppName: "Safari", Title: "Docs", IsOnScreen: true},
+	}
+
+	window, err := selectAutomationWindow(windows)
+	if err != nil {
+		t.Fatalf("selectAutomationWindow: %v", err)
+	}
+	if window.PID != 11 {
+		t.Fatalf("window = %#v, want unrelated Electron pid 11", window)
 	}
 }
 

--- a/services/tuttid/service/computer/adapter_test.go
+++ b/services/tuttid/service/computer/adapter_test.go
@@ -185,6 +185,53 @@ func TestStableWindowActionsNeverUseDesktopScope(t *testing.T) {
 	}
 }
 
+func TestStableKeyboardActionsPreserveExplicitWindowTarget(t *testing.T) {
+	tests := []struct {
+		name string
+		tool string
+		args map[string]any
+		want recordedNativeToolCall
+	}{
+		{
+			name: "type text",
+			tool: "type_text",
+			args: map[string]any{"pid": 42, "window_id": 99, "text": "hello"},
+			want: recordedNativeToolCall{name: "type_text", args: map[string]any{
+				"pid": float64(42), "window_id": float64(99), "text": "hello",
+			}},
+		},
+		{
+			name: "single key",
+			tool: "press_key",
+			args: map[string]any{"pid": 42, "window_id": 99, "key": "return"},
+			want: recordedNativeToolCall{name: "press_key", args: map[string]any{
+				"pid": float64(42), "window_id": float64(99), "key": "return",
+			}},
+		},
+		{
+			name: "hotkey",
+			tool: "press_key",
+			args: map[string]any{"pid": 42, "window_id": 99, "key": "cmd+w"},
+			want: recordedNativeToolCall{name: "hotkey", args: map[string]any{
+				"pid": float64(42), "window_id": float64(99), "keys": []any{"cmd", "w"},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session, conn := newAdapterTestSession(t)
+			if _, err := session.adaptToolCall(context.Background(), tt.tool, tt.args); err != nil {
+				t.Fatalf("adaptToolCall(%s): %v", tt.tool, err)
+			}
+			calls := conn.recordedCalls()
+			if len(calls) != 1 || !reflect.DeepEqual(calls[0], tt.want) {
+				t.Fatalf("calls = %#v, want %#v", calls, []recordedNativeToolCall{tt.want})
+			}
+		})
+	}
+}
+
 func TestSplitKeySpec(t *testing.T) {
 	tests := []struct {
 		in   string

--- a/services/tuttid/service/computer/policy.go
+++ b/services/tuttid/service/computer/policy.go
@@ -1,0 +1,116 @@
+package computer
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrNativeToolNotAllowed marks a native tool that is absent from the live
+// catalog or not authorized by Tutti's computer-use capability policy.
+var ErrNativeToolNotAllowed = errors.New("native computer tool is not allowed")
+
+// ErrNativeToolCatalogUnsupported marks a missing or breaking version of the
+// cua-driver discovery contract. Authorization must fail closed in this case.
+var ErrNativeToolCatalogUnsupported = errors.New("native computer tool catalog version is unsupported")
+
+var allowedNativeCapabilities = map[string]struct{}{
+	"accessibility.element_tokens":            {},
+	"accessibility.tree":                      {},
+	"accessibility.tree.bounded":              {},
+	"accessibility.tree.structured":           {},
+	"accessibility.window_state":              {},
+	"agent_cursor.move":                       {},
+	"agent_cursor.set_enabled":                {},
+	"agent_cursor.set_motion":                 {},
+	"agent_cursor.set_style":                  {},
+	"agent_cursor.state":                      {},
+	"app.launch":                              {},
+	"app.list":                                {},
+	"input.keyboard.hotkey":                   {},
+	"input.keyboard.press":                    {},
+	"input.keyboard.type":                     {},
+	"input.keyboard.type.terminal_safe":       {},
+	"input.pointer.button":                    {},
+	"input.pointer.click":                     {},
+	"input.pointer.click.double":              {},
+	"input.pointer.click.left":                {},
+	"input.pointer.click.right":               {},
+	"input.pointer.drag":                      {},
+	"input.pointer.scroll":                    {},
+	"screen.capture":                          {},
+	"screen.capture.region":                   {},
+	"screen.capture.window":                   {},
+	"screen.cursor.position":                  {},
+	"screen.dimensions":                       {},
+	"system.config.read":                      {},
+	"system.config.write":                     {},
+	"system.permissions.tcc":                  {},
+	"system.permissions.tcc.accessibility":    {},
+	"system.permissions.tcc.screen_recording": {},
+	"window.activate":                         {},
+	"window.list":                             {},
+}
+
+func annotateNativeToolCatalog(catalog ToolCatalog) (ToolCatalog, error) {
+	if err := validateNativeToolCatalog(catalog); err != nil {
+		return ToolCatalog{}, err
+	}
+	annotated := catalog
+	annotated.Tools = make([]ToolDefinition, 0, len(catalog.Tools))
+	for _, tool := range catalog.Tools {
+		allowed, denialReason := authorizeNativeTool(tool)
+		tool.Allowed = allowed
+		tool.DenialReason = denialReason
+		annotated.Tools = append(annotated.Tools, tool)
+	}
+	return annotated, nil
+}
+
+func requireAllowedNativeTool(catalog ToolCatalog, name string) (ToolDefinition, error) {
+	if err := validateNativeToolCatalog(catalog); err != nil {
+		return ToolDefinition{}, err
+	}
+	name = strings.TrimSpace(name)
+	for _, tool := range catalog.Tools {
+		if tool.Name != name {
+			continue
+		}
+		allowed, denialReason := authorizeNativeTool(tool)
+		if !allowed {
+			return ToolDefinition{}, fmt.Errorf("%w: %q: %s", ErrNativeToolNotAllowed, name, denialReason)
+		}
+		tool.Allowed = true
+		tool.DenialReason = ""
+		return tool, nil
+	}
+	return ToolDefinition{}, fmt.Errorf("%w: %q was not reported by cua-driver", ErrNativeToolNotAllowed, name)
+}
+
+func validateNativeToolCatalog(catalog ToolCatalog) error {
+	if catalog.SchemaVersion != "1" || catalog.CapabilityVersion != "1" {
+		return fmt.Errorf(
+			"%w: schema_version=%q capability_version=%q",
+			ErrNativeToolCatalogUnsupported,
+			catalog.SchemaVersion,
+			catalog.CapabilityVersion,
+		)
+	}
+	return nil
+}
+
+func authorizeNativeTool(tool ToolDefinition) (bool, string) {
+	if len(tool.Capabilities) == 0 {
+		return false, "tool has no capability metadata"
+	}
+	var denied []string
+	for _, capability := range tool.Capabilities {
+		if _, ok := allowedNativeCapabilities[capability]; !ok {
+			denied = append(denied, capability)
+		}
+	}
+	if len(denied) > 0 {
+		return false, fmt.Sprintf("tool has denied or unknown capabilities: %s", strings.Join(denied, ", "))
+	}
+	return true, ""
+}

--- a/services/tuttid/service/computer/policy_test.go
+++ b/services/tuttid/service/computer/policy_test.go
@@ -1,0 +1,109 @@
+package computer
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAnnotateNativeToolCatalogPreservesEveryToolAndAuthorization(t *testing.T) {
+	catalog := ToolCatalog{
+		SchemaVersion:     "1",
+		CapabilityVersion: "1",
+		Tools: []ToolDefinition{
+			{Name: "click", Capabilities: []string{"input.pointer.click", "input.pointer.click.left"}},
+			{Name: "mixed_future", Capabilities: []string{"input.pointer.click", "future.privileged"}},
+			{Name: "kill_app", Capabilities: []string{"app.kill"}},
+			{Name: "missing_metadata"},
+		},
+	}
+
+	annotated, err := annotateNativeToolCatalog(catalog)
+	if err != nil {
+		t.Fatalf("annotateNativeToolCatalog: %v", err)
+	}
+	if len(annotated.Tools) != len(catalog.Tools) {
+		t.Fatalf("annotated tools = %#v", annotated.Tools)
+	}
+	if !annotated.Tools[0].Allowed || annotated.Tools[0].DenialReason != "" {
+		t.Fatalf("allowed tool = %#v", annotated.Tools[0])
+	}
+	for _, tool := range annotated.Tools[1:] {
+		if tool.Allowed || tool.DenialReason == "" {
+			t.Fatalf("denied tool lacks authorization metadata: %#v", tool)
+		}
+	}
+	if annotated.SchemaVersion != "1" || annotated.CapabilityVersion != "1" {
+		t.Fatalf("annotated catalog lost versions: %#v", annotated)
+	}
+}
+
+func TestNativeToolPolicyRejectsUnknownOrMissingCatalogVersions(t *testing.T) {
+	for _, catalog := range []ToolCatalog{
+		{SchemaVersion: "2", CapabilityVersion: "1"},
+		{SchemaVersion: "1", CapabilityVersion: "2"},
+		{},
+	} {
+		if _, err := annotateNativeToolCatalog(catalog); !errors.Is(err, ErrNativeToolCatalogUnsupported) {
+			t.Fatalf("annotate err = %v, want ErrNativeToolCatalogUnsupported for %#v", err, catalog)
+		}
+		if _, err := requireAllowedNativeTool(catalog, "click"); !errors.Is(err, ErrNativeToolCatalogUnsupported) {
+			t.Fatalf("require err = %v, want ErrNativeToolCatalogUnsupported for %#v", err, catalog)
+		}
+	}
+}
+
+func TestRequireAllowedNativeToolRejectsUnknownAndDeniedCapabilities(t *testing.T) {
+	for _, tool := range []ToolDefinition{
+		{Name: "mixed_future", Capabilities: []string{"screen.capture", "future.privileged"}},
+		{Name: "missing_metadata"},
+	} {
+		t.Run(tool.Name, func(t *testing.T) {
+			_, err := requireAllowedNativeTool(ToolCatalog{
+				SchemaVersion:     "1",
+				CapabilityVersion: "1",
+				Tools:             []ToolDefinition{tool},
+			}, tool.Name)
+			if !errors.Is(err, ErrNativeToolNotAllowed) {
+				t.Fatalf("err = %v, want ErrNativeToolNotAllowed", err)
+			}
+		})
+	}
+}
+
+func TestNativeToolPolicyAllowsGlobalConfigWrites(t *testing.T) {
+	tool := ToolDefinition{
+		Name:         "set_config",
+		Capabilities: []string{"system.config.write"},
+	}
+	catalog, err := annotateNativeToolCatalog(ToolCatalog{
+		SchemaVersion:     "1",
+		CapabilityVersion: "1",
+		Tools:             []ToolDefinition{tool},
+	})
+	if err != nil {
+		t.Fatalf("annotateNativeToolCatalog(set_config): %v", err)
+	}
+	if len(catalog.Tools) != 1 || !catalog.Tools[0].Allowed || catalog.Tools[0].DenialReason != "" {
+		t.Fatalf("tool = %#v", catalog.Tools)
+	}
+	got, err := requireAllowedNativeTool(ToolCatalog{
+		SchemaVersion:     "1",
+		CapabilityVersion: "1",
+		Tools:             []ToolDefinition{tool},
+	}, tool.Name)
+	if err != nil || got.Name != tool.Name || !got.Allowed {
+		t.Fatalf("tool = %#v, err = %v", got, err)
+	}
+}
+
+func TestNativeToolPolicyAllowsConfigReads(t *testing.T) {
+	tool := ToolDefinition{Name: "get_config", Capabilities: []string{"system.config.read"}}
+	got, err := requireAllowedNativeTool(ToolCatalog{
+		SchemaVersion:     "1",
+		CapabilityVersion: "1",
+		Tools:             []ToolDefinition{tool},
+	}, tool.Name)
+	if err != nil || got.Name != tool.Name {
+		t.Fatalf("tool = %#v, err = %v", got, err)
+	}
+}

--- a/services/tuttid/service/computer/service.go
+++ b/services/tuttid/service/computer/service.go
@@ -36,10 +36,44 @@ func NewService() *Service {
 // CallTool invokes a cua-driver MCP tool against the workspace's computer
 // session, lazily starting it on first use.
 func (s *Service) CallTool(ctx context.Context, workspaceID, cwd, tool string, args map[string]any) (ToolResult, error) {
-	workspaceID = strings.TrimSpace(workspaceID)
+	return withComputerSession(s, ctx, workspaceID, cwd, func(session *computerSession) (ToolResult, error) {
+		return session.adaptToolCall(ctx, tool, args)
+	})
+}
 
+// CallNativeTool forwards one live-catalog tool allowed by Tutti's capability
+// policy without applying stable CLI aliases or automatic target selection.
+func (s *Service) CallNativeTool(ctx context.Context, workspaceID, cwd, tool string, args map[string]any) (ToolResult, error) {
+	return withComputerSession(s, ctx, workspaceID, cwd, func(session *computerSession) (ToolResult, error) {
+		catalog, err := session.listTools(ctx)
+		if err != nil {
+			return ToolResult{}, err
+		}
+		definition, err := requireAllowedNativeTool(catalog, tool)
+		if err != nil {
+			return ToolResult{}, err
+		}
+		return session.callNativeTool(ctx, definition.Name, args)
+	})
+}
+
+// ListTools returns the complete versioned cua-driver tool catalog annotated
+// with Tutti-owned authorization decisions.
+func (s *Service) ListTools(ctx context.Context, workspaceID, cwd string) (ToolCatalog, error) {
+	return withComputerSession(s, ctx, workspaceID, cwd, func(session *computerSession) (ToolCatalog, error) {
+		catalog, err := session.listTools(ctx)
+		if err != nil {
+			return ToolCatalog{}, err
+		}
+		return annotateNativeToolCatalog(catalog)
+	})
+}
+
+func withComputerSession[T any](s *Service, ctx context.Context, workspaceID, cwd string, call func(*computerSession) (T, error)) (T, error) {
+	var zero T
+	workspaceID = strings.TrimSpace(workspaceID)
 	if err := validateComputerReady(); err != nil {
-		return ToolResult{}, err
+		return zero, err
 	}
 
 	session := s.getOrCreate(workspaceID)
@@ -50,9 +84,9 @@ func (s *Service) CallTool(ctx context.Context, workspaceID, cwd, tool string, a
 		// A failed start should not be cached; drop the session so the next
 		// call retries (e.g. transient failure).
 		s.Shutdown(workspaceID)
-		return ToolResult{}, err
+		return zero, err
 	}
-	result, err := session.adaptToolCall(ctx, tool, args)
+	result, err := call(session)
 	if err != nil && session.client != nil && session.client.isClosed() {
 		s.Shutdown(workspaceID)
 	}

--- a/services/tuttid/service/computer/session.go
+++ b/services/tuttid/service/computer/session.go
@@ -21,15 +21,45 @@ const mcpProtocolVersion = "2025-06-18"
 
 // ToolResult is the flattened result of an MCP tools/call.
 type ToolResult struct {
-	Text    string
-	Images  []ToolImage
-	IsError bool
+	Text              string
+	Images            []ToolImage
+	StructuredContent map[string]any
+	Raw               json.RawMessage
+	IsError           bool
 }
 
 // ToolImage is a base64 image returned by a tool (e.g. take_screenshot).
 type ToolImage struct {
 	Data     string
 	MimeType string
+}
+
+// ToolCatalog is the versioned native tool surface reported by cua-driver.
+type ToolCatalog struct {
+	SchemaVersion     string           `json:"schemaVersion"`
+	CapabilityVersion string           `json:"capabilityVersion"`
+	Tools             []ToolDefinition `json:"tools"`
+}
+
+// ToolDefinition preserves the MCP schema and semantic metadata needed for
+// generic discovery, policy, and argument forwarding.
+type ToolDefinition struct {
+	Name         string          `json:"name"`
+	Description  string          `json:"description"`
+	InputSchema  map[string]any  `json:"inputSchema"`
+	Annotations  ToolAnnotations `json:"annotations"`
+	Capabilities []string        `json:"capabilities"`
+	Allowed      bool            `json:"allowed"`
+	DenialReason string          `json:"denialReason"`
+}
+
+// ToolAnnotations mirrors the MCP tool hints. These hints describe effects;
+// Tutti-owned policy remains the authorization boundary.
+type ToolAnnotations struct {
+	ReadOnly    bool `json:"readOnlyHint"`
+	Destructive bool `json:"destructiveHint"`
+	Idempotent  bool `json:"idempotentHint"`
+	OpenWorld   bool `json:"openWorldHint"`
 }
 
 // computerSession owns one cua-driver subprocess. Tool calls are serialized
@@ -108,6 +138,17 @@ func (s *computerSession) inFlightCount() int32 {
 }
 
 func (s *computerSession) callTool(ctx context.Context, name string, args map[string]any) (ToolResult, error) {
+	result, err := s.callNativeTool(ctx, name, args)
+	if err != nil {
+		return ToolResult{}, err
+	}
+	if result.IsError {
+		return result, toolResultError(result)
+	}
+	return result, nil
+}
+
+func (s *computerSession) callNativeTool(ctx context.Context, name string, args map[string]any) (ToolResult, error) {
 	if s.client == nil || s.client.isClosed() {
 		return ToolResult{}, errors.New("computer session not started")
 	}
@@ -121,6 +162,22 @@ func (s *computerSession) callTool(ctx context.Context, name string, args map[st
 		return ToolResult{}, err
 	}
 	return parseToolResult(raw)
+}
+
+func (s *computerSession) listTools(ctx context.Context) (ToolCatalog, error) {
+	if s.client == nil || s.client.isClosed() {
+		return ToolCatalog{}, errors.New("computer session not started")
+	}
+	s.callMu.Lock()
+	defer s.callMu.Unlock()
+	if s.client == nil || s.client.isClosed() {
+		return ToolCatalog{}, errors.New("computer session not started")
+	}
+	raw, err := s.client.call(ctx, "tools/list", map[string]any{})
+	if err != nil {
+		return ToolCatalog{}, err
+	}
+	return parseToolCatalog(raw)
 }
 
 func (s *computerSession) close() {
@@ -138,8 +195,9 @@ func (s *computerSession) closeLocked() {
 }
 
 type mcpToolCallResult struct {
-	IsError bool `json:"isError"`
-	Content []struct {
+	IsError           bool           `json:"isError"`
+	StructuredContent map[string]any `json:"structuredContent"`
+	Content           []struct {
 		Type     string `json:"type"`
 		Text     string `json:"text"`
 		Data     string `json:"data"`
@@ -152,7 +210,11 @@ func parseToolResult(raw json.RawMessage) (ToolResult, error) {
 	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return ToolResult{}, fmt.Errorf("decode computer tool result: %w", err)
 	}
-	result := ToolResult{IsError: parsed.IsError}
+	result := ToolResult{
+		IsError:           parsed.IsError,
+		StructuredContent: parsed.StructuredContent,
+		Raw:               append(json.RawMessage(nil), raw...),
+	}
 	var texts []string
 	for _, item := range parsed.Content {
 		switch item.Type {
@@ -163,12 +225,30 @@ func parseToolResult(raw json.RawMessage) (ToolResult, error) {
 		}
 	}
 	result.Text = strings.Join(texts, "\n")
-	if result.IsError {
-		msg := strings.TrimSpace(result.Text)
-		if msg == "" {
-			msg = "computer tool reported an error"
-		}
-		return result, errors.New(msg)
-	}
 	return result, nil
+}
+
+func toolResultError(result ToolResult) error {
+	message := strings.TrimSpace(result.Text)
+	if message == "" {
+		message = "computer tool reported an error"
+	}
+	return errors.New(message)
+}
+
+type mcpToolCatalog struct {
+	SchemaVersion     string           `json:"schema_version"`
+	CapabilityVersion string           `json:"capability_version"`
+	Tools             []ToolDefinition `json:"tools"`
+}
+
+func parseToolCatalog(raw json.RawMessage) (ToolCatalog, error) {
+	var parsed mcpToolCatalog
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return ToolCatalog{}, fmt.Errorf("decode computer tool catalog: %w", err)
+	}
+	if parsed.Tools == nil {
+		parsed.Tools = []ToolDefinition{}
+	}
+	return ToolCatalog(parsed), nil
 }

--- a/services/tuttid/service/computer/session_test.go
+++ b/services/tuttid/service/computer/session_test.go
@@ -1,0 +1,115 @@
+package computer
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestParseToolResultPreservesStructuredContent(t *testing.T) {
+	raw := json.RawMessage(`{
+  "isError": false,
+  "content": [
+    {"type": "text", "text": "captured"},
+    {"type": "image", "data": "aW1hZ2U=", "mimeType": "image/png"}
+  ],
+  "structuredContent": {
+    "screenshot_file_path": "/tmp/screenshot.png",
+    "screen_width": 1512,
+    "scale_factor": 2
+  }
+}`)
+
+	result, err := parseToolResult(raw)
+	if err != nil {
+		t.Fatalf("parseToolResult: %v", err)
+	}
+	if result.Text != "captured" || len(result.Images) != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	want := map[string]any{
+		"screenshot_file_path": "/tmp/screenshot.png",
+		"screen_width":         float64(1512),
+		"scale_factor":         float64(2),
+	}
+	if !reflect.DeepEqual(result.StructuredContent, want) {
+		t.Fatalf("structured content = %#v, want %#v", result.StructuredContent, want)
+	}
+}
+
+func TestParseToolResultPreservesUnknownNativeContent(t *testing.T) {
+	raw := json.RawMessage(`{
+  "isError": false,
+  "content": [{"type":"resource_link","uri":"file:///tmp/state.json","name":"state"}],
+  "structuredContent": {"revision": 7},
+  "futureField": {"kept": true}
+}`)
+
+	result, err := parseToolResult(raw)
+	if err != nil {
+		t.Fatalf("parseToolResult: %v", err)
+	}
+	if !reflect.DeepEqual(result.Raw, raw) {
+		t.Fatalf("raw result = %s, want %s", result.Raw, raw)
+	}
+}
+
+func TestParseToolResultPreservesNativeErrorResultWithoutTransportError(t *testing.T) {
+	raw := json.RawMessage(`{
+  "isError": true,
+  "content": [{"type":"text","text":"target disappeared"}],
+  "structuredContent": {"code":"stale_target"}
+}`)
+
+	result, err := parseToolResult(raw)
+	if err != nil {
+		t.Fatalf("parseToolResult returned transport error: %v", err)
+	}
+	if !result.IsError || result.Text != "target disappeared" || !reflect.DeepEqual(result.Raw, raw) {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestParseToolCatalogPreservesDriverMetadata(t *testing.T) {
+	raw := json.RawMessage(`{
+  "schema_version": "1",
+  "capability_version": "1",
+  "tools": [{
+    "name": "get_desktop_state",
+    "description": "Capture the display",
+    "inputSchema": {
+      "type": "object",
+      "properties": {"screenshot_out_file": {"type": "string"}}
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false
+    },
+    "capabilities": ["screen.capture", "screen.dimensions"]
+  }]
+}`)
+
+	catalog, err := parseToolCatalog(raw)
+	if err != nil {
+		t.Fatalf("parseToolCatalog: %v", err)
+	}
+	if catalog.SchemaVersion != "1" || catalog.CapabilityVersion != "1" || len(catalog.Tools) != 1 {
+		t.Fatalf("catalog = %#v", catalog)
+	}
+	tool := catalog.Tools[0]
+	if tool.Name != "get_desktop_state" || tool.Description != "Capture the display" {
+		t.Fatalf("tool = %#v", tool)
+	}
+	if !tool.Annotations.ReadOnly || tool.Annotations.Destructive || tool.Annotations.Idempotent || tool.Annotations.OpenWorld {
+		t.Fatalf("annotations = %#v", tool.Annotations)
+	}
+	if !reflect.DeepEqual(tool.Capabilities, []string{"screen.capture", "screen.dimensions"}) {
+		t.Fatalf("capabilities = %#v", tool.Capabilities)
+	}
+	properties := tool.InputSchema["properties"].(map[string]any)
+	if properties["screenshot_out_file"].(map[string]any)["type"] != "string" {
+		t.Fatalf("input schema = %#v", tool.InputSchema)
+	}
+}


### PR DESCRIPTION
## Summary\n\n- keep stable , click, and scroll commands as a window-only compatibility workflow with optional explicit  /  targeting\n- fix stable JSON output and numeric coordinate decoding, including \n- add native  commands backed by the live cua-driver MCP catalog, without adding one Tutti binding per driver tool\n- preserve complete native MCP results, including future content variants, , and large JSON integers\n- show every live tool with daemon-owned  and  decisions while re-authorizing every native call against a fresh catalog\n- authorize the known  capability so agents can configure host-global cua-driver state through the managed native surface\n- document cua-driver actual desktop model: global persisted  for , per-call desktop scope only on native , and no desktop-coordinate mode on macOS \n\n## Why\n\nThe previous adapter always selected a window and hid the native catalog. Treating screenshot, click, and scroll as if they shared one stateless  scope would invent a contract cua-driver 0.7.0 does not provide.\n\nThis change keeps stable aliases intentionally small and window-oriented. Advanced behavior follows each native tool live schema. Tutti remains the authorization seam, while the CLI avoids per-tool wrappers.\n\n## Desktop and configuration behavior\n\nWhen a user asks to inspect the screen, desktop, or entire display, the injected computer skill now follows this managed sequence:\n\n1. call \n2. when needed, call  with \n3. call \n4. use native  with its own per-call  contract\n\n persists globally in cua-driver. Tutti does not hide the mutation in a set/call/restore sequence and does not automatically restore it. Stable  remains window-only. Desktop scrolling is not advertised because cua-driver 0.7.0 requires PID/window-local targeting.\n\n## User impact\n\n-  works\n- window automation can pin  and \n-  sends numeric coordinates\n- agents can discover and call the complete authorized driver surface\n- agents can enable desktop capture without leaving the managed Tutti CLI or invoking the standalone cua-driver CLI\n\n## Validation\n\n- 
> tutti@ check:full /Users/asdf/Repo/tutti-worktree-cua-capability-passthrough-20260716
> node ./tools/scripts/run-check-full.mjs


==> Preparation
Preparation passed 1 task(s) in 2.1s

==> Preflight checks
Preflight checks passed 12 task(s) in 2.8s

==> Validation checks
Validation checks passed 5 task(s) in 55.1s

check:full passed 18 task(s) in 60.0s
slowest tasks: test:ts 55.1s, test:go 15.6s, lint:go 9.2s (details: .tmp/check-full-runs/latest.json) — 18 tasks passed after rebasing onto the latest \n- 
> tutti@ check:changed /Users/asdf/Repo/tutti-worktree-cua-capability-passthrough-20260716
> node ./tools/scripts/run-check-changed.mjs

check:changed passed 7 lane(s) in 1.7s — 7 lanes passed after rebase\n- targeted computer policy, CLI provider, adapter, session, and runtime-skill tests\n- tuttid layering, cross-cutting architecture, package-boundary, and contract review: no findings\n\n## External dependency\n\nNo cua-driver source change or unreleased upstream behavior is required. The earlier experimental driver PR was closed.\n

## Click reliability contract (second commit)

Field debugging of misplaced-looking agent clicks isolated three independent behaviors: pixel clicks are dispatch-only background CGEvents that Electron apps (Discord, Feishu) may drop silently; the agent-cursor overlay is a separate visual channel that renders at a fixed offset after display-configuration changes (stale fullscreen overlay window in cua-driver, upstream issue); and the underlying coordinate translation was verified correct end to end.

The injected computer-use skill and the persistent CLI contract now codify the reliable ladder:

1. prefer native `click` with an `element_token` from screenshot structured content over pixel coordinates
2. verify click effects with a fresh screenshot — never with the on-screen agent-cursor overlay position
3. escalate unresponsive background clicks via `delivery_mode: "foreground"` instead of repeating the same pixel click

No daemon code changes; template + contract doc + template tests only.
