### PR TITLE
feat(agent-gui): group sessions by source agent

### DIFF
--- a/.changeset/agent-session-provenance-groups.md
+++ b/.changeset/agent-session-provenance-groups.md
@@ -1,0 +1,8 @@
+---
+"@tutti-os/agent-gui": minor
+---
+
+Group Agent Session mention results by their exact source Agent when a host
+provides a provenance catalog. The session filter continues to constrain the
+cloud-backed provider before pagination, while group labels follow the host
+catalog order and names.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -3191,9 +3191,12 @@ directories. Ordinary opened-file and issue-summary records do not currently
 carry durable provenance and therefore fail closed when either an Agent or
 Member constraint is active. A typed File query must route to the
 provenance-aware generated-file provider for either active dimension, even when
-the ordinary generated-files group is otherwise disabled. Existing result
-groups remain unchanged; the filter narrows their contents and does not
-introduce a second grouping layer.
+the ordinary generated-files group is otherwise disabled. Generated-file and
+picker result groups remain source-owned. The Agent Session `@` list is the
+exception: when a host injects an Agent provenance catalog, it groups returned
+sessions by exact `agentTargetId` in catalog order and uses the catalog option
+label as the group heading. This grouping is presentation only; the provider
+still applies the selected provenance constraint before pagination.
 
 Only catalog entries with a durable `agentTargetId` participate in filtering;
 host target ids are not substitutes. Catalogs and filters are normalized at the

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -368,12 +368,6 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   }, [contextMentionProviders]);
 
   useEffect(() => {
-    mentionControllerRef.current?.setProvenanceCatalog(
-      referenceProvenanceFilter?.snapshot.catalog ?? null
-    );
-  }, [referenceProvenanceFilter?.snapshot.catalog]);
-
-  useEffect(() => {
     draftImagesRef.current = agentComposerDraftImages(draftContent);
     draftFilesRef.current = agentComposerDraftFiles(draftContent);
     draftLargeTextsRef.current = agentComposerDraftLargeTexts(draftContent);
@@ -392,10 +386,16 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   }, [draftContent, draftPrompt, goalDraftObjective]);
 
   useEffect(() => {
+    mentionControllerRef.current?.setProvenanceCatalog(
+      referenceProvenanceFilter?.snapshot.catalog ?? null
+    );
     mentionControllerRef.current?.setProvenanceFilter(
       referenceProvenanceFilter?.snapshot.value ?? null
     );
-  }, [referenceProvenanceFilter?.snapshot.value]);
+  }, [
+    referenceProvenanceFilter?.snapshot.catalog,
+    referenceProvenanceFilter?.snapshot.value
+  ]);
 
   useEffect(() => {
     if (

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -350,6 +350,9 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     const controller = new AgentMentionSearchController({
       contextMentionProviders
     });
+    controller.setProvenanceCatalog(
+      referenceProvenanceFilter?.snapshot.catalog ?? null
+    );
     // A provider replacement creates a fresh controller, so seed it with the
     // filter captured by the same render before exposing it through the ref.
     controller.setProvenanceFilter(
@@ -363,6 +366,12 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
       mentionControllerRef.current = null;
     };
   }, [contextMentionProviders]);
+
+  useEffect(() => {
+    mentionControllerRef.current?.setProvenanceCatalog(
+      referenceProvenanceFilter?.snapshot.catalog ?? null
+    );
+  }, [referenceProvenanceFilter?.snapshot.catalog]);
 
   useEffect(() => {
     draftImagesRef.current = agentComposerDraftImages(draftContent);

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
@@ -1331,6 +1331,78 @@ describe("AgentFileMentionPalette", () => {
     );
   });
 
+  it("renders provenance catalog labels for session groups", () => {
+    const session = (
+      targetId: string,
+      agentTargetId: string,
+      title: string
+    ): AgentContextMentionItem => ({
+      kind: "session",
+      href: `mention://agent-session/${targetId}?workspaceId=room-1`,
+      workspaceId: "room-1",
+      targetId,
+      agentTargetId,
+      name: title,
+      title,
+      scope: "my_sessions",
+      initiatorName: "User",
+      agentName: "Codex"
+    });
+    const state: AgentMentionSearchState = {
+      status: "ready",
+      query: "",
+      mode: "browse",
+      filter: "session",
+      categories: [],
+      groups: [
+        {
+          id: "agent:codex-main",
+          label: "Me · Codex",
+          items: [session("session-local", "codex-main", "Local build")],
+          totalCount: 1,
+          visibleCount: 1,
+          hasMore: false
+        },
+        {
+          id: "agent:shared-agent%3Ashared-codex",
+          label: "Lin · Codex",
+          items: [
+            session(
+              "session-shared",
+              "shared-agent:shared-codex",
+              "Shared build"
+            )
+          ],
+          totalCount: 1,
+          visibleCount: 1,
+          hasMore: false
+        }
+      ],
+      error: null
+    };
+
+    render(
+      <AgentFileMentionPalette
+        state={state}
+        highlightedKey={null}
+        label="mention palette"
+        loadingLabel="loading"
+        emptyLabel="empty"
+        errorLabel="error"
+        tabHintLabel="hint"
+        maxHeightPx={320}
+        onHighlightChange={vi.fn()}
+        onSelectItem={vi.fn()}
+        onSelectCategory={vi.fn()}
+        onSelectFilter={vi.fn()}
+        onExpandGroup={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Me · Codex")).toBeVisible();
+    expect(screen.getByText("Lin · Codex")).toBeVisible();
+  });
+
   it("hides a duplicate group heading when the active filter has one matching group", () => {
     const state: AgentMentionSearchState = {
       status: "ready",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
@@ -345,18 +345,16 @@ function decorateMentionGroup(
     filter,
     groupCount: groups.length,
     groupId,
+    groupLabel: group.label,
     query
   });
+  const groupLabel = group.label ?? agentMentionGroupLabel(groupId);
   return {
     ...group,
-    label: showLabel
-      ? groupId.startsWith("issue-topic:")
-        ? group.label
-        : agentMentionGroupLabel(groupId)
-      : undefined,
+    label: showLabel ? groupLabel : undefined,
     emptyLabel: suppressChrome
       ? undefined
-      : agentMentionEmptyGroupLabel(groupId, query),
+      : (group.emptyLabel ?? agentMentionEmptyGroupLabel(groupId, query)),
     expandLabel: group.hasMore
       ? translate("agentHost.agentGui.contextPickerExpandMore", {
           count: mentionGroupExpandCount(group, filter)
@@ -412,6 +410,7 @@ function shouldRenderMentionGroupLabel(input: {
   filter: AgentMentionFilterId;
   groupCount: number;
   groupId: AgentMentionGroupId;
+  groupLabel?: string;
   query: string;
 }): boolean {
   if (shouldSuppressFileSearchGroupChrome(input.filter, input.query)) {
@@ -420,8 +419,11 @@ function shouldRenderMentionGroupLabel(input: {
   if (input.groupCount !== 1) {
     return true;
   }
+  if (input.groupId.startsWith("agent:")) {
+    return true;
+  }
   return (
-    agentMentionGroupLabel(input.groupId) !==
+    (input.groupLabel ?? agentMentionGroupLabel(input.groupId)) !==
     agentMentionFilterLabel(input.filter)
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionLabels.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionLabels.ts
@@ -74,5 +74,8 @@ export function agentMentionEmptyGroupLabel(
   if (groupId === "collab_sessions") {
     return translate("agentHost.agentGui.mentionEmptyCollabSessions");
   }
+  if (groupId.startsWith("agent:")) {
+    return translate("agentHost.agentGui.mentionEmptyMySessions");
+  }
   return translate("agentHost.agentGui.mentionEmptyIssues");
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchContracts.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchContracts.ts
@@ -25,14 +25,19 @@ export type AgentMentionStaticGroupId =
   | "my_sessions"
   | "collab_sessions"
   | "issues";
+export type AgentMentionIssueTopicGroupId = `issue-topic:${string}`;
+export type AgentMentionProvenanceGroupId = `agent:${string}`;
 export type AgentMentionGroupId =
   | AgentMentionStaticGroupId
-  | `issue-topic:${string}`;
+  | AgentMentionIssueTopicGroupId
+  | AgentMentionProvenanceGroupId;
 
-export type AgentMentionRawGroupId = Exclude<
-  AgentMentionStaticGroupId,
-  "files"
->;
+export type AgentMentionRawGroupId =
+  | Exclude<
+      AgentMentionStaticGroupId,
+      "files" | "my_sessions" | "collab_sessions"
+    >
+  | "sessions";
 export type AgentMentionRawGroups = Record<
   AgentMentionRawGroupId,
   AgentContextMentionItem[]

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
@@ -297,7 +297,11 @@ function createTestSessionProvider(
         workspaceId,
         sessionOrigin: "WORKSPACE_AGENT_SESSION_ORIGIN_RUNTIME"
       });
-      const sessions = (snapshot.sessions ?? []).slice(0, maxResults);
+      const allSessions = snapshot.sessions ?? [];
+      const sessions =
+        maxResults === undefined
+          ? allSessions
+          : allSessions.slice(0, maxResults);
       const userIds = [
         ...new Set(
           sessions
@@ -560,6 +564,13 @@ describe("AgentMentionSearchController", () => {
     const controller = new AgentMentionSearchController({
       querySessions: vi.fn().mockResolvedValue({
         sessions: [
+          ...Array.from({ length: 31 }, (_, index) => ({
+            agentSessionId: `session-local-${index}`,
+            agentTargetId: "codex-main",
+            provider: "codex",
+            title: `Local build ${index}`,
+            userId: "user-1"
+          })),
           {
             agentSessionId: "session-shared",
             agentTargetId: "shared-agent:shared-codex",
@@ -568,11 +579,11 @@ describe("AgentMentionSearchController", () => {
             userId: "user-2"
           },
           {
-            agentSessionId: "session-local",
-            agentTargetId: "codex-main",
-            provider: "codex",
-            title: "Local build",
-            userId: "user-1"
+            agentSessionId: "session-uncatalogued",
+            agentTargetId: "legacy-gemini",
+            provider: "gemini",
+            title: "Legacy build",
+            userId: "user-3"
           }
         ]
       })
@@ -605,11 +616,43 @@ describe("AgentMentionSearchController", () => {
           {
             id: "agent:codex-main",
             label: "Me · Codex",
-            items: [expect.objectContaining({ targetId: "session-local" })]
+            items: expect.arrayContaining([
+              expect.objectContaining({ targetId: "session-local-0" })
+            ]),
+            totalCount: 31,
+            hasMore: true
           },
           {
             id: "agent:shared-agent%3Ashared-codex",
             label: "Lin · Codex",
+            items: [expect.objectContaining({ targetId: "session-shared" })]
+          },
+          {
+            id: "agent:uncatalogued%3Alegacy-gemini",
+            label: "gemini",
+            items: [
+              expect.objectContaining({ targetId: "session-uncatalogued" })
+            ]
+          }
+        ]
+      })
+    );
+    controller.expandGroup("agent:codex-main");
+    expect(
+      (
+        states.at(-1) as { groups: Array<{ id: string; items: unknown[] }> }
+      ).groups.find((group) => group.id === "agent:codex-main")?.items
+    ).toHaveLength(20);
+    controller.setProvenanceFilter({
+      agentTargetIds: ["shared-agent:shared-codex"],
+      memberIds: null
+    });
+    await vi.waitFor(() =>
+      expect(states.at(-1)).toMatchObject({
+        status: "ready",
+        groups: [
+          {
+            id: "agent:shared-agent%3Ashared-codex",
             items: [expect.objectContaining({ targetId: "session-shared" })]
           }
         ]

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
@@ -38,6 +38,7 @@ interface TestAgentTargetMentionItem {
 }
 
 interface TestSessionMentionItem {
+  agentTargetId?: string;
   agentName: string;
   id: string;
   initiatorName: string;
@@ -336,6 +337,7 @@ function createTestSessionProvider(
             })) ||
             session.agentSessionId;
           return {
+            agentTargetId: session.agentTargetId,
             agentName: testProviderLabel(session.provider),
             id: session.agentSessionId,
             initiatorAvatarUrl: profile?.avatar ?? "",
@@ -386,6 +388,7 @@ function createTestSessionProvider(
         entityId: item.id,
         label: item.title,
         scope: {
+          ...(item.agentTargetId ? { agentTargetId: item.agentTargetId } : {}),
           scope: item.scope ?? "",
           userId: item.userId,
           workspaceId: item.workspaceId
@@ -551,6 +554,68 @@ describe("AgentMentionSearchController", () => {
     });
     expect(queryFiles).not.toHaveBeenCalled();
     expect(queryIssues).not.toHaveBeenCalled();
+  });
+
+  it("groups session mentions in provenance catalog order", async () => {
+    const controller = new AgentMentionSearchController({
+      querySessions: vi.fn().mockResolvedValue({
+        sessions: [
+          {
+            agentSessionId: "session-shared",
+            agentTargetId: "shared-agent:shared-codex",
+            provider: "codex",
+            title: "Shared build",
+            userId: "user-2"
+          },
+          {
+            agentSessionId: "session-local",
+            agentTargetId: "codex-main",
+            provider: "codex",
+            title: "Local build",
+            userId: "user-1"
+          }
+        ]
+      })
+    });
+    const states: unknown[] = [];
+    controller.subscribe((state) => states.push(state));
+    controller.setProvenanceCatalog({
+      enabledDimensions: ["agent"],
+      agentOptions: [
+        { id: "codex-main", label: "Me · Codex" },
+        {
+          id: "shared-agent:shared-codex",
+          label: "Lin · Codex"
+        }
+      ],
+      memberOptions: []
+    });
+
+    controller.updateQuery({
+      workspaceId: "room-1",
+      currentUserId: "user-1",
+      query: ""
+    });
+
+    await vi.waitFor(() =>
+      expect(states.at(-1)).toMatchObject({
+        status: "ready",
+        filter: "session",
+        groups: [
+          {
+            id: "agent:codex-main",
+            label: "Me · Codex",
+            items: [expect.objectContaining({ targetId: "session-local" })]
+          },
+          {
+            id: "agent:shared-agent%3Ashared-codex",
+            label: "Lin · Codex",
+            items: [expect.objectContaining({ targetId: "session-shared" })]
+          }
+        ]
+      })
+    );
+    controller.dispose();
   });
 
   it("loads the app provider when switching to the app tab for blank queries", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.ts
@@ -26,7 +26,10 @@ import {
 } from "./agentMentionSearchDiagnostics";
 import { queryAgentMentionProviderGroupPage } from "./AgentMentionSearchIndex";
 import { AgentMentionSearchControllerBase } from "./AgentMentionSearchControllerBase";
-import type { ReferenceProvenanceFilter } from "@tutti-os/workspace-file-reference/contracts";
+import type {
+  ReferenceProvenanceCatalog,
+  ReferenceProvenanceFilter
+} from "@tutti-os/workspace-file-reference/contracts";
 import { referenceProvenanceFilterCacheKey } from "@tutti-os/workspace-file-reference/core";
 
 export type {
@@ -43,6 +46,21 @@ export class AgentMentionSearchController extends AgentMentionSearchControllerBa
     string,
     { abortController: AbortController; token: symbol }
   >();
+
+  setProvenanceCatalog(catalog: ReferenceProvenanceCatalog | null): void {
+    if (this.currentProvenanceCatalog === catalog) return;
+    this.currentProvenanceCatalog = catalog;
+    if (
+      this.currentFilter !== "session" ||
+      (this.state.status !== "ready" && this.state.status !== "loading")
+    ) {
+      return;
+    }
+    this.setState({
+      ...this.state,
+      groups: this.groupsFromRawGroups()
+    });
+  }
 
   setProvenanceFilter(filter: ReferenceProvenanceFilter | null): void {
     const previousKey = this.currentProvenanceFilter

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchControllerBase.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchControllerBase.ts
@@ -678,7 +678,8 @@ export class AgentMentionSearchControllerBase {
       rawGroups: this.rawGroups,
       totalCounts: this.totalCounts,
       issueTopicGroups: this.issueTopicGroups,
-      provenanceCatalog: this.currentProvenanceCatalog
+      provenanceCatalog: this.currentProvenanceCatalog,
+      provenanceFilter: this.currentProvenanceFilter
     });
   }
 
@@ -755,6 +756,7 @@ export class AgentMentionSearchControllerBase {
       fileLimit: this.fileLimit,
       currentFileSearchLimit: this.currentFileSearchLimit,
       currentIssueSearchLimit: this.currentIssueSearchLimit,
+      provenanceCatalog: this.currentProvenanceCatalog,
       provenanceFilter,
       queryProviderMentionGroupsById: (queryInput) =>
         this.queryProviderMentionGroupsById({ ...queryInput, abortSignal }),

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchControllerBase.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchControllerBase.ts
@@ -55,7 +55,10 @@ import {
   queryAgentMentionProviderGroups,
   queryAgentMentionProviderItems
 } from "./AgentMentionSearchIndex";
-import type { ReferenceProvenanceFilter } from "@tutti-os/workspace-file-reference/contracts";
+import type {
+  ReferenceProvenanceCatalog,
+  ReferenceProvenanceFilter
+} from "@tutti-os/workspace-file-reference/contracts";
 import { referenceProvenanceFilterCacheKey } from "@tutti-os/workspace-file-reference/core";
 import {
   agentGuiScheduler,
@@ -95,6 +98,7 @@ export class AgentMentionSearchControllerBase {
   protected currentQuery = "";
   protected currentSessionCwd = "";
   protected currentProvenanceFilter: ReferenceProvenanceFilter | null = null;
+  protected currentProvenanceCatalog: ReferenceProvenanceCatalog | null = null;
   protected currentFileSearchLimit: number;
   protected currentIssueSearchLimit: number;
   protected agentGeneratedBrowsePath: string | null = null;
@@ -607,6 +611,9 @@ export class AgentMentionSearchControllerBase {
   }
 
   protected resetExpandedCounts(): void {
+    for (const groupId of Object.keys(this.expandedCounts)) {
+      delete this.expandedCounts[groupId as AgentMentionGroupId];
+    }
     for (const groupId of [
       "files",
       "opened_files",
@@ -670,7 +677,8 @@ export class AgentMentionSearchControllerBase {
       expandedCounts: this.expandedCounts,
       rawGroups: this.rawGroups,
       totalCounts: this.totalCounts,
-      issueTopicGroups: this.issueTopicGroups
+      issueTopicGroups: this.issueTopicGroups,
+      provenanceCatalog: this.currentProvenanceCatalog
     });
   }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchIndex.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchIndex.ts
@@ -20,7 +20,10 @@ import {
   WORKSPACE_ISSUE_PROVIDER_ID
 } from "./AgentMentionSearchContracts";
 import type { AgentMentionBrowseFetchResult } from "./AgentMentionSearchCache";
-import type { ReferenceProvenanceFilter } from "@tutti-os/workspace-file-reference/contracts";
+import type {
+  ReferenceProvenanceCatalog,
+  ReferenceProvenanceFilter
+} from "@tutti-os/workspace-file-reference/contracts";
 import { referenceProvenanceFilterIsActive } from "@tutti-os/workspace-file-reference/core";
 
 export interface AgentMentionProviderQueryInput {
@@ -47,6 +50,7 @@ export async function fetchAgentMentionFilterResult(input: {
   fileLimit: number;
   currentFileSearchLimit: number;
   currentIssueSearchLimit: number;
+  provenanceCatalog?: ReferenceProvenanceCatalog | null;
   provenanceFilter: ReferenceProvenanceFilter | null;
   queryProviderMentionItemsById: (
     input: AgentMentionProviderQueryInput
@@ -110,7 +114,12 @@ export async function fetchAgentMentionFilterResult(input: {
         workspaceId: input.workspaceId,
         currentUserId: input.currentUserId,
         query: input.query,
-        limit: DEFAULT_SESSION_LIMIT,
+        // A provenance-aware host owns a room-scoped directory snapshot and
+        // grouping must see that complete snapshot. Legacy providers retain
+        // the bounded query contract.
+        limit: input.provenanceCatalog?.enabledDimensions.includes("agent")
+          ? undefined
+          : DEFAULT_SESSION_LIMIT,
         sessionCwd: input.sessionCwd,
         diagnostics: providerDiagnostics,
         provenanceFilter: input.provenanceFilter

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchIndex.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchIndex.ts
@@ -4,7 +4,7 @@ import type { AgentContextMentionProvider } from "./agentContextMentionProvider"
 import type { AgentMentionProviderQueryDiagnostic } from "./agentMentionSearchDiagnostics";
 import {
   emptyAgentMentionRawGroups,
-  normalizeSessionMentionItemsForMySessions,
+  normalizeSessionMentionItems,
   providerItemToAgentMentionItem,
   totalCountsFromRawGroups
 } from "./AgentMentionSearchModel";
@@ -116,8 +116,7 @@ export async function fetchAgentMentionFilterResult(input: {
         provenanceFilter: input.provenanceFilter
       });
       const rawGroups = emptyAgentMentionRawGroups();
-      rawGroups.my_sessions = normalizeSessionMentionItemsForMySessions({
-        currentUserId: input.currentUserId,
+      rawGroups.sessions = normalizeSessionMentionItems({
         items: sessionItems
       });
       return {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
@@ -23,7 +23,10 @@ import {
   type AgentMentionLifecycleDiagnosticLog
 } from "./AgentMentionSearchContracts";
 import { presentAgentGeneratedFileMentionItems } from "./agentMentionAgentGeneratedFilesPresentation";
-import type { ReferenceProvenanceCatalog } from "@tutti-os/workspace-file-reference/contracts";
+import type {
+  ReferenceProvenanceCatalog,
+  ReferenceProvenanceFilter
+} from "@tutti-os/workspace-file-reference/contracts";
 import {
   buildEmptyGroup,
   compactText,
@@ -44,6 +47,7 @@ export function buildAgentMentionGroups(input: {
   rawGroups: AgentMentionRawGroups;
   totalCounts: AgentMentionTotalCounts;
   provenanceCatalog: ReferenceProvenanceCatalog | null;
+  provenanceFilter: ReferenceProvenanceFilter | null;
 }): AgentMentionGroup[] {
   if (input.currentFilter === "issue" && input.issueTopicGroups !== null) {
     return input.issueTopicGroups.map((group) => ({
@@ -158,6 +162,7 @@ function buildSessionProvenanceGroups(input: {
   currentFilter: AgentMentionFilterId;
   expandedCounts: Partial<Record<AgentMentionGroupId, number>>;
   provenanceCatalog: ReferenceProvenanceCatalog | null;
+  provenanceFilter: ReferenceProvenanceFilter | null;
   rawGroups: AgentMentionRawGroups;
 }): AgentMentionGroup[] | null {
   if (
@@ -166,33 +171,98 @@ function buildSessionProvenanceGroups(input: {
   ) {
     return null;
   }
+  const selectedAgentTargetIds = input.provenanceFilter?.agentTargetIds ?? null;
+  const selectedAgentTargetIdSet =
+    selectedAgentTargetIds === null ? null : new Set(selectedAgentTargetIds);
   const sessionItems = input.rawGroups.sessions.filter(
-    (item) => item.kind === "session"
+    (item) =>
+      item.kind === "session" &&
+      (selectedAgentTargetIdSet === null ||
+        (item.agentTargetId
+          ? selectedAgentTargetIdSet.has(item.agentTargetId)
+          : false))
   );
-  return input.provenanceCatalog.agentOptions.flatMap((option) => {
-    const items = sessionItems.filter(
-      (item) => item.kind === "session" && item.agentTargetId === option.id
-    );
-    if (items.length === 0) {
-      return [];
-    }
-    const groupId = agentProvenanceMentionGroupId(option.id);
-    const pageSize = mentionGroupPageSize(input.currentFilter, groupId);
-    const visibleCount = Math.min(
-      items.length,
-      input.expandedCounts[groupId] ?? pageSize
-    );
-    return [
-      {
-        id: groupId,
-        label: option.label,
-        items: items.slice(0, visibleCount),
-        totalCount: items.length,
-        visibleCount,
-        hasMore: items.length > visibleCount
+  const catalogAgentTargetIds = new Set(
+    input.provenanceCatalog.agentOptions.map((option) => option.id)
+  );
+  const catalogGroups = input.provenanceCatalog.agentOptions.flatMap(
+    (option) => {
+      const items = sessionItems.filter(
+        (item) => item.kind === "session" && item.agentTargetId === option.id
+      );
+      if (items.length === 0) {
+        return [];
       }
-    ];
-  });
+      const groupId = agentProvenanceMentionGroupId(option.id);
+      const pageSize = mentionGroupPageSize(input.currentFilter, groupId);
+      const visibleCount = Math.min(
+        items.length,
+        input.expandedCounts[groupId] ?? pageSize
+      );
+      return [
+        {
+          id: groupId,
+          label: option.label,
+          items: items.slice(0, visibleCount),
+          totalCount: items.length,
+          visibleCount,
+          hasMore: items.length > visibleCount
+        }
+      ];
+    }
+  );
+  if (selectedAgentTargetIdSet !== null) {
+    return catalogGroups;
+  }
+  const unmatchedGroups = new Map<
+    string,
+    { id: `agent:${string}`; label: string; items: AgentContextMentionItem[] }
+  >();
+  for (const item of sessionItems) {
+    if (
+      item.kind !== "session" ||
+      (item.agentTargetId && catalogAgentTargetIds.has(item.agentTargetId))
+    ) {
+      continue;
+    }
+    const identity =
+      item.agentTargetId?.trim() ||
+      item.agentName.trim() ||
+      item.initiatorName.trim() ||
+      item.targetId;
+    const key = `uncatalogued:${identity}`;
+    const existing = unmatchedGroups.get(key);
+    if (existing) {
+      existing.items.push(item);
+      continue;
+    }
+    unmatchedGroups.set(key, {
+      id: agentProvenanceMentionGroupId(key),
+      label:
+        item.agentName.trim() ||
+        item.initiatorName.trim() ||
+        item.agentTargetId?.trim() ||
+        item.title,
+      items: [item]
+    });
+  }
+  return [
+    ...catalogGroups,
+    ...[...unmatchedGroups.values()].map((group) => {
+      const pageSize = mentionGroupPageSize(input.currentFilter, group.id);
+      const visibleCount = Math.min(
+        group.items.length,
+        input.expandedCounts[group.id] ?? pageSize
+      );
+      return {
+        ...group,
+        items: group.items.slice(0, visibleCount),
+        totalCount: group.items.length,
+        visibleCount,
+        hasMore: group.items.length > visibleCount
+      };
+    })
+  ];
 }
 
 export function agentProvenanceMentionGroupId(

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
@@ -23,6 +23,7 @@ import {
   type AgentMentionLifecycleDiagnosticLog
 } from "./AgentMentionSearchContracts";
 import { presentAgentGeneratedFileMentionItems } from "./agentMentionAgentGeneratedFilesPresentation";
+import type { ReferenceProvenanceCatalog } from "@tutti-os/workspace-file-reference/contracts";
 import {
   buildEmptyGroup,
   compactText,
@@ -42,6 +43,7 @@ export function buildAgentMentionGroups(input: {
   issueTopicGroups: readonly AgentMentionIssueTopicGroup[] | null;
   rawGroups: AgentMentionRawGroups;
   totalCounts: AgentMentionTotalCounts;
+  provenanceCatalog: ReferenceProvenanceCatalog | null;
 }): AgentMentionGroup[] {
   if (input.currentFilter === "issue" && input.issueTopicGroups !== null) {
     return input.issueTopicGroups.map((group) => ({
@@ -53,6 +55,10 @@ export function buildAgentMentionGroups(input: {
       hasMore: group.nextPageToken !== null,
       expandStatus: group.loadMoreStatus
     }));
+  }
+  const provenanceGroups = buildSessionProvenanceGroups(input);
+  if (provenanceGroups) {
+    return provenanceGroups;
   }
   const orderedGroupIds = groupIdsForFilter(input.currentFilter);
   return orderedGroupIds
@@ -148,14 +154,60 @@ export function issueTopicPaginationChanges(
   });
 }
 
+function buildSessionProvenanceGroups(input: {
+  currentFilter: AgentMentionFilterId;
+  expandedCounts: Partial<Record<AgentMentionGroupId, number>>;
+  provenanceCatalog: ReferenceProvenanceCatalog | null;
+  rawGroups: AgentMentionRawGroups;
+}): AgentMentionGroup[] | null {
+  if (
+    input.currentFilter !== "session" ||
+    !input.provenanceCatalog?.enabledDimensions.includes("agent")
+  ) {
+    return null;
+  }
+  const sessionItems = input.rawGroups.sessions.filter(
+    (item) => item.kind === "session"
+  );
+  return input.provenanceCatalog.agentOptions.flatMap((option) => {
+    const items = sessionItems.filter(
+      (item) => item.kind === "session" && item.agentTargetId === option.id
+    );
+    if (items.length === 0) {
+      return [];
+    }
+    const groupId = agentProvenanceMentionGroupId(option.id);
+    const pageSize = mentionGroupPageSize(input.currentFilter, groupId);
+    const visibleCount = Math.min(
+      items.length,
+      input.expandedCounts[groupId] ?? pageSize
+    );
+    return [
+      {
+        id: groupId,
+        label: option.label,
+        items: items.slice(0, visibleCount),
+        totalCount: items.length,
+        visibleCount,
+        hasMore: items.length > visibleCount
+      }
+    ];
+  });
+}
+
+export function agentProvenanceMentionGroupId(
+  agentTargetId: string
+): `agent:${string}` {
+  return `agent:${encodeURIComponent(agentTargetId)}`;
+}
+
 export function emptyAgentMentionRawGroups(): AgentMentionRawGroups {
   return {
     apps: [],
     agents: [],
     opened_files: [],
     agent_generated_files: [],
-    my_sessions: [],
-    collab_sessions: [],
+    sessions: [],
     issues: []
   };
 }
@@ -168,8 +220,7 @@ export function cloneAgentMentionRawGroups(
     agents: [...rawGroups.agents],
     opened_files: [...rawGroups.opened_files],
     agent_generated_files: [...rawGroups.agent_generated_files],
-    my_sessions: [...rawGroups.my_sessions],
-    collab_sessions: [...rawGroups.collab_sessions],
+    sessions: [...rawGroups.sessions],
     issues: [...rawGroups.issues]
   };
 }
@@ -182,8 +233,12 @@ export function totalCountsFromRawGroups(
     agents: rawGroups.agents.length,
     opened_files: rawGroups.opened_files.length,
     agent_generated_files: rawGroups.agent_generated_files.length,
-    my_sessions: rawGroups.my_sessions.length,
-    collab_sessions: rawGroups.collab_sessions.length,
+    my_sessions: rawGroups.sessions.filter(
+      (item) => item.kind === "session" && item.scope === "my_sessions"
+    ).length,
+    collab_sessions: rawGroups.sessions.filter(
+      (item) => item.kind === "session" && item.scope === "collab_sessions"
+    ).length,
     issues: rawGroups.issues.length
   };
 }
@@ -251,20 +306,10 @@ export function logAgentMentionLifecycleDiagnostic(
   }
 }
 
-export function normalizeSessionMentionItemsForMySessions(input: {
-  currentUserId: string;
+export function normalizeSessionMentionItems(input: {
   items: readonly AgentContextMentionItem[];
 }): AgentContextMentionItem[] {
-  return input.items
-    .filter((item) => item.kind === "session")
-    .filter((item) =>
-      input.currentUserId ? item.scope === "my_sessions" : true
-    )
-    .map((item) =>
-      item.scope === "my_sessions"
-        ? item
-        : { ...item, scope: "my_sessions" as const }
-    );
+  return input.items.filter((item) => item.kind === "session");
 }
 
 export function providerItemToAgentMentionItem(input: {
@@ -419,6 +464,7 @@ export function providerItemToAgentMentionItem(input: {
         presentation.agentIconUrl?.trim() ||
         presentation.iconUrl?.trim() ||
         undefined,
+      ...(scope.agentTargetId ? { agentTargetId: scope.agentTargetId } : {}),
       status: presentation.status?.trim() || undefined,
       inputPreview: description || undefined,
       summaryPreview

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentMentionSearchHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentMentionSearchHelpers.ts
@@ -20,6 +20,7 @@ import type {
   AgentMentionGroup,
   AgentMentionGroupId
 } from "./AgentMentionSearchController";
+import type { AgentMentionRawGroups } from "./AgentMentionSearchContracts";
 import type {
   AgentActivityMessage,
   AgentActivitySession
@@ -306,14 +307,9 @@ function emptyGroupLabel(groupId: AgentMentionGroupId, query: string): string {
   return agentMentionEmptyGroupLabel(groupId, query);
 }
 
-type AgentMentionRawGroupId = Exclude<
-  AgentMentionGroupId,
-  "files" | `issue-topic:${string}`
->;
-
 export function resolveMentionGroupItems(
   groupId: AgentMentionGroupId,
-  rawGroups: Record<AgentMentionRawGroupId, AgentContextMentionItem[]>
+  rawGroups: AgentMentionRawGroups
 ): AgentContextMentionItem[] {
   if (groupId.startsWith("issue-topic:")) {
     return [];
@@ -321,7 +317,24 @@ export function resolveMentionGroupItems(
   if (groupId === "files") {
     return [...rawGroups.opened_files, ...rawGroups.agent_generated_files];
   }
-  return rawGroups[groupId as AgentMentionRawGroupId] ?? [];
+  if (groupId === "my_sessions" || groupId === "collab_sessions") {
+    return rawGroups.sessions.filter(
+      (item) => item.kind === "session" && item.scope === groupId
+    );
+  }
+  if (groupId.startsWith("agent:")) {
+    return [];
+  }
+  if (
+    groupId === "apps" ||
+    groupId === "agents" ||
+    groupId === "opened_files" ||
+    groupId === "agent_generated_files" ||
+    groupId === "issues"
+  ) {
+    return rawGroups[groupId];
+  }
+  return [];
 }
 
 export function resolveMentionGroupTotalCount(


### PR DESCRIPTION
## Summary

- group Agent Session mention results by the exact source Agent in host catalog order
- preserve uncatalogued cloud sessions with concrete source labels instead of dropping them
- read the complete room-scoped session directory snapshot before client-side grouping and expansion
- keep active provenance filters fail-closed and compatible with Issue topic pagination

## Validation

- Agent GUI full suite: 183 files / 1663 tests passed before the final boundary-only adjustment
- focused AgentMentionSearchController suite: 39 tests passed
- @tutti-os/agent-gui typecheck passed
- TypeScript lint and formatting passed
- Agent GUI degradation check passed
- flaky Go runtime test rerun 3 times successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups Agent Session mentions by their exact source Agent using the host provenance catalog, with headings like “Me · Codex” in catalog order. Preserves full per‑agent groups and uncatalogued sessions; the provider still applies the provenance filter before pagination.

- **New Features**
  - Groups sessions by `agentTargetId` with catalog labels and stable order.
  - Preserves uncatalogued sessions in separate groups using agent or initiator names.
  - Reads the full room-scoped session directory when the catalog enables the agent dimension; legacy hosts keep the default limit.
  - Always shows headings for agent groups and supplies empty-state text for them.

- **Refactors**
  - Added `setProvenanceCatalog` to the controller and recompute groups when the catalog changes; `AgentComposer` now passes catalog and filter; threaded through search, index, and model; provenance filters stay fail-closed.
  - Consolidated session storage into a single `sessions` bucket and introduced dynamic group ids `agent:${encodedId}`.
  - Reset dynamic group expansion counts to keep pagination correct; other groups and issue-topic pagination remain unchanged.

<sup>Written for commit 04f3174e398c68c4f39508f506d7cb11201cc7bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

