### PR TITLE
fix(issue-manager): match task search by title

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -3186,6 +3186,9 @@ into a dynamic `issue-topic:*` presentation key, then atomically replaces the
 ordered group list for each debounced search. Each group owns its items,
 query-scoped total, cursor, and load-more status; loading or retrying one topic
 must not replace sibling groups or put the whole palette into loading state.
+Search results in the Tasks tab match only the visible workspace-issue title.
+The daemon issue-list query owns that rule so its items, counts, and cursors all
+use the same title-only result set.
 
 ```text
 Agent mention query identity

--- a/docs/architecture/workspace-issue-manager.md
+++ b/docs/architecture/workspace-issue-manager.md
@@ -41,6 +41,7 @@ This Go package owns transport-agnostic issue-manager behavior:
 
 - issue, task, run, output, and context-reference models
 - status, priority, pagination, and search normalization
+- title-only issue and task list search; content does not produce list matches
 - task status projection onto issue summaries
 - run lifecycle orchestration
 - a `Store` interface for concrete persistence adapters

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -2677,6 +2677,9 @@ export type IssueManagerPageToken = string;
 
 export type IssueManagerStatusFilter2 = IssueManagerStatusFilter;
 
+/**
+ * Case-insensitive substring search over the visible title only.
+ */
 export type IssueManagerSearchQuery = string;
 
 export type GetHealthData = {
@@ -8612,6 +8615,9 @@ export type ListWorkspaceIssuesData = {
     pageToken?: string;
     topicId: string;
     statusFilter?: IssueManagerStatusFilter;
+    /**
+     * Case-insensitive substring search over the visible title only.
+     */
     searchQuery?: string;
   };
   url: "/v1/workspaces/{workspaceID}/issues";
@@ -9230,6 +9236,9 @@ export type ListWorkspaceIssueTasksData = {
     pageSize?: number;
     pageToken?: string;
     statusFilter?: IssueManagerStatusFilter;
+    /**
+     * Case-insensitive substring search over the visible title only.
+     */
     searchQuery?: string;
   };
   url: "/v1/workspaces/{workspaceID}/issues/{issueID}/tasks";

--- a/packages/workspace/issue-manager/openapi/issue-manager.v1.yaml
+++ b/packages/workspace/issue-manager/openapi/issue-manager.v1.yaml
@@ -935,6 +935,7 @@ components:
       name: searchQuery
       in: query
       required: false
+      description: Case-insensitive substring search over the visible title only.
       schema:
         type: string
   responses:

--- a/packages/workspace/issues/service_test.go
+++ b/packages/workspace/issues/service_test.go
@@ -1048,7 +1048,7 @@ func (s *fakeStore) ListIssues(_ context.Context, filter IssueListFilter) (Issue
 		if filter.StatusFilter != "" && issue.Status != filter.StatusFilter {
 			continue
 		}
-		if !matchesSearch(filter.SearchQuery, issue.Title, issue.SearchText) {
+		if !matchesSearch(filter.SearchQuery, issue.Title) {
 			continue
 		}
 		items = append(items, issue)
@@ -1133,7 +1133,7 @@ func (s *fakeStore) ListTasks(_ context.Context, filter TaskListFilter) (TaskLis
 		if filter.StatusFilter != "" && task.Status != filter.StatusFilter {
 			continue
 		}
-		if !matchesSearch(filter.SearchQuery, task.Title, task.SearchText) {
+		if !matchesSearch(filter.SearchQuery, task.Title) {
 			continue
 		}
 		items = append(items, task)

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -5030,7 +5030,9 @@ type ListWorkspaceIssuesParams struct {
 	PageToken    *IssueManagerPageToken    `form:"pageToken,omitempty" json:"pageToken,omitempty"`
 	TopicId      IssueManagerTopicIDQuery  `form:"topicId" json:"topicId"`
 	StatusFilter *IssueManagerStatusFilter `form:"statusFilter,omitempty" json:"statusFilter,omitempty"`
-	SearchQuery  *IssueManagerSearchQuery  `form:"searchQuery,omitempty" json:"searchQuery,omitempty"`
+
+	// SearchQuery Case-insensitive substring search over the visible title only.
+	SearchQuery *IssueManagerSearchQuery `form:"searchQuery,omitempty" json:"searchQuery,omitempty"`
 }
 
 // ListWorkspaceIssueTasksParams defines parameters for ListWorkspaceIssueTasks.
@@ -5038,7 +5040,9 @@ type ListWorkspaceIssueTasksParams struct {
 	PageSize     *IssueManagerPageSize     `form:"pageSize,omitempty" json:"pageSize,omitempty"`
 	PageToken    *IssueManagerPageToken    `form:"pageToken,omitempty" json:"pageToken,omitempty"`
 	StatusFilter *IssueManagerStatusFilter `form:"statusFilter,omitempty" json:"statusFilter,omitempty"`
-	SearchQuery  *IssueManagerSearchQuery  `form:"searchQuery,omitempty" json:"searchQuery,omitempty"`
+
+	// SearchQuery Case-insensitive substring search over the visible title only.
+	SearchQuery *IssueManagerSearchQuery `form:"searchQuery,omitempty" json:"searchQuery,omitempty"`
 }
 
 // AttachWorkspaceTerminalParams defines parameters for AttachWorkspaceTerminal.

--- a/services/tuttid/data/workspace/sqlite_issues_helpers.go
+++ b/services/tuttid/data/workspace/sqlite_issues_helpers.go
@@ -71,9 +71,9 @@ func issueListWhereForFilter(filter workspaceissues.IssueListFilter, includeStat
 		args = append(args, string(filter.StatusFilter))
 	}
 	if searchQuery := strings.TrimSpace(filter.SearchQuery); searchQuery != "" {
-		where = append(where, "(LOWER(title) LIKE ? OR LOWER(search_text) LIKE ?)")
+		where = append(where, "LOWER(title) LIKE ?")
 		like := "%" + strings.ToLower(searchQuery) + "%"
-		args = append(args, like, like)
+		args = append(args, like)
 	}
 	return where, args
 }
@@ -94,9 +94,9 @@ func taskListWhereForFilter(filter workspaceissues.TaskListFilter, includeStatus
 		args = append(args, string(filter.StatusFilter))
 	}
 	if searchQuery := strings.TrimSpace(filter.SearchQuery); searchQuery != "" {
-		where = append(where, "(LOWER(title) LIKE ? OR LOWER(search_text) LIKE ?)")
+		where = append(where, "LOWER(title) LIKE ?")
 		like := "%" + strings.ToLower(searchQuery) + "%"
-		args = append(args, like, like)
+		args = append(args, like)
 	}
 	return where, args
 }

--- a/services/tuttid/data/workspace/sqlite_issues_test.go
+++ b/services/tuttid/data/workspace/sqlite_issues_test.go
@@ -460,6 +460,90 @@ func TestSQLiteIssueStoreListIssuesPagination(t *testing.T) {
 	}
 }
 
+func TestSQLiteIssueStoreListSearchMatchesTitlesOnly(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	ctx := context.Background()
+	if err := store.Create(ctx, workspacebiz.Summary{
+		ID:   "ws-title-search",
+		Name: "Title Search Workspace",
+	}); err != nil {
+		t.Fatalf("Create() workspace error = %v", err)
+	}
+
+	service := testIssueService(store)
+	titleMatch, err := service.CreateIssue(ctx, workspaceissues.CreateIssueInput{
+		WorkspaceID: "ws-title-search",
+		TopicID:     workspaceissues.DefaultTopicID,
+		ActorUserID: "user-1",
+		Title:       "Build a toy website",
+		Content:     "Read the project first",
+	})
+	if err != nil {
+		t.Fatalf("CreateIssue() title match error = %v", err)
+	}
+	if _, err := service.CreateIssue(ctx, workspaceissues.CreateIssueInput{
+		WorkspaceID: "ws-title-search",
+		TopicID:     workspaceissues.DefaultTopicID,
+		ActorUserID: "user-1",
+		Title:       "Read the project",
+		Content:     "Build a toy website",
+	}); err != nil {
+		t.Fatalf("CreateIssue() content-only match error = %v", err)
+	}
+
+	issues, err := service.ListIssues(ctx, workspaceissues.IssueListFilter{
+		WorkspaceID: "ws-title-search",
+		TopicID:     workspaceissues.DefaultTopicID,
+		SearchQuery: "TOY",
+	})
+	if err != nil {
+		t.Fatalf("ListIssues() error = %v", err)
+	}
+	if len(issues.Items) != 1 || issues.Items[0].IssueID != titleMatch.IssueID {
+		t.Fatalf("ListIssues() items = %+v, want only title match %q", issues.Items, titleMatch.IssueID)
+	}
+	if issues.TotalCount != 1 || issues.StatusCounts.All != 1 {
+		t.Fatalf("ListIssues() counts = total:%d statuses:%+v, want one", issues.TotalCount, issues.StatusCounts)
+	}
+
+	titleTask, err := service.CreateTask(ctx, workspaceissues.CreateTaskInput{
+		WorkspaceID: "ws-title-search",
+		IssueID:     titleMatch.IssueID,
+		ActorUserID: "user-1",
+		Title:       "Paint the toy model",
+		Content:     "Use the reference image",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask() title match error = %v", err)
+	}
+	if _, err := service.CreateTask(ctx, workspaceissues.CreateTaskInput{
+		WorkspaceID: "ws-title-search",
+		IssueID:     titleMatch.IssueID,
+		ActorUserID: "user-1",
+		Title:       "Read the reference image",
+		Content:     "Paint the toy model",
+	}); err != nil {
+		t.Fatalf("CreateTask() content-only match error = %v", err)
+	}
+
+	tasks, err := service.ListTasks(ctx, workspaceissues.TaskListFilter{
+		WorkspaceID: "ws-title-search",
+		IssueID:     titleMatch.IssueID,
+		SearchQuery: "TOY",
+	})
+	if err != nil {
+		t.Fatalf("ListTasks() error = %v", err)
+	}
+	if len(tasks.Items) != 1 || tasks.Items[0].TaskID != titleTask.TaskID {
+		t.Fatalf("ListTasks() items = %+v, want only title match %q", tasks.Items, titleTask.TaskID)
+	}
+	if tasks.TotalCount != 1 || tasks.StatusCounts.All != 1 {
+		t.Fatalf("ListTasks() counts = total:%d statuses:%+v, want one", tasks.TotalCount, tasks.StatusCounts)
+	}
+}
+
 func TestSQLiteIssueStoreListStatusCountsIgnoreStatusFilter(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- make SQLite issue and subtask list searches match only the visible title
- remove `search_text` / content from the database `WHERE` predicates
- document the title-only `searchQuery` contract in OpenAPI and regenerate clients
- add SQLite regressions that verify content-only matches are excluded and counts stay consistent

## Root cause

The daemon's issue and task list queries used:

```sql
LOWER(title) LIKE ? OR LOWER(search_text) LIKE ?
```

Because `search_text` contains the task description, the Agent composer Tasks tab received rows whose visible titles did not match the query.

## Impact

Title-only matching is now enforced in the database query, so returned items, total counts, status counts, and pagination cursors all use the same result set. No frontend filtering remains in this PR.

## Validation

- `pnpm check:full` (18 tasks passed)
- `pnpm check:api-generated`
- `pnpm lint:go`
- `go test ./packages/workspace/issues ./services/tuttid/data/workspace`
