### PR TITLE
[codex] optimistically display goal panel

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiOptimisticGoal.test.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiOptimisticGoal.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalGoalConfirmsOptimisticGoal,
+  projectOptimisticGoalControl,
+  unresolvedOptimisticGoalControl
+} from "./agentGuiOptimisticGoal";
+
+describe("optimistic goal projection", () => {
+  it("projects goal controls without mutating the canonical goal", () => {
+    const current = { objective: "ship it", status: "active" as const };
+
+    expect(projectOptimisticGoalControl(current, "pause")).toEqual({
+      objective: "ship it",
+      status: "paused"
+    });
+    expect(current.status).toBe("active");
+    expect(projectOptimisticGoalControl(current, "clear")).toBeNull();
+  });
+
+  it("waits for exact status reconciliation for direct controls", () => {
+    const optimistic = { objective: "ship it", status: "paused" as const };
+
+    expect(
+      canonicalGoalConfirmsOptimisticGoal(
+        { objective: "ship it", status: "active" },
+        optimistic,
+        false
+      )
+    ).toBe(false);
+    expect(
+      canonicalGoalConfirmsOptimisticGoal(
+        { objective: "ship it", status: "paused" },
+        optimistic,
+        false
+      )
+    ).toBe(true);
+  });
+
+  it("accepts any authoritative status for a newly activated goal", () => {
+    expect(
+      canonicalGoalConfirmsOptimisticGoal(
+        { objective: "ship it", status: "blocked" },
+        { objective: "ship it", status: "active" },
+        true
+      )
+    ).toBe(true);
+  });
+
+  it("keeps the overlay until the active session confirms it", () => {
+    const optimistic = {
+      agentSessionId: "session-1",
+      goal: { objective: "ship it", status: "active" as const },
+      reconcileOnObjectiveMatch: true,
+      requestId: "goal-activation:1"
+    };
+
+    expect(unresolvedOptimisticGoalControl(optimistic, "session-1", null)).toBe(
+      optimistic
+    );
+    expect(
+      unresolvedOptimisticGoalControl(optimistic, "session-1", {
+        agentSessionId: "session-1",
+        goal: { objective: "ship it", status: "blocked" }
+      })
+    ).toBeNull();
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiOptimisticGoal.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiOptimisticGoal.ts
@@ -1,0 +1,68 @@
+import type {
+  AgentActivityGoalControlAction,
+  AgentActivitySessionGoal,
+  CanonicalAgentSession
+} from "@tutti-os/agent-activity-core";
+import type { AgentGUIOptimisticGoalControl } from "../model/agentGuiNodeTypes";
+
+export function projectOptimisticGoalControl(
+  currentGoal: AgentActivitySessionGoal | null,
+  action: AgentActivityGoalControlAction,
+  objective?: string
+): AgentActivitySessionGoal | null {
+  switch (action) {
+    case "clear":
+      return null;
+    case "pause":
+      return currentGoal ? { ...currentGoal, status: "paused" } : null;
+    case "resume":
+      return currentGoal ? { ...currentGoal, status: "active" } : null;
+    case "set": {
+      const normalizedObjective = objective?.trim() ?? "";
+      return normalizedObjective
+        ? { objective: normalizedObjective, status: "active" }
+        : currentGoal;
+    }
+  }
+}
+
+export function canonicalGoalConfirmsOptimisticGoal(
+  canonicalGoal: AgentActivitySessionGoal | null,
+  optimisticGoal: AgentActivitySessionGoal | null,
+  reconcileOnObjectiveMatch: boolean
+): boolean {
+  if (optimisticGoal === null) {
+    return canonicalGoal === null;
+  }
+  if (canonicalGoal?.objective !== optimisticGoal.objective) {
+    return false;
+  }
+  return (
+    reconcileOnObjectiveMatch || canonicalGoal.status === optimisticGoal.status
+  );
+}
+
+export function unresolvedOptimisticGoalControl(
+  optimisticGoalControl: AgentGUIOptimisticGoalControl | null,
+  agentSessionId: string | null,
+  canonicalSession: Pick<
+    CanonicalAgentSession,
+    "agentSessionId" | "goal"
+  > | null
+): AgentGUIOptimisticGoalControl | null {
+  if (
+    optimisticGoalControl?.agentSessionId !== agentSessionId ||
+    canonicalSession?.agentSessionId !== agentSessionId
+  ) {
+    return optimisticGoalControl?.agentSessionId === agentSessionId
+      ? optimisticGoalControl
+      : null;
+  }
+  return canonicalGoalConfirmsOptimisticGoal(
+    canonicalSession.goal,
+    optimisticGoalControl.goal,
+    optimisticGoalControl.reconcileOnObjectiveMatch
+  )
+    ? null
+    : optimisticGoalControl;
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIGoalControlActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIGoalControlActions.ts
@@ -1,0 +1,167 @@
+import {
+  selectEngineSession,
+  type AgentActivityGoalControlAction,
+  type AgentSessionEngine
+} from "@tutti-os/agent-activity-core";
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import { useCallback, useRef } from "react";
+import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
+import type {
+  AgentComposerDraft,
+  AgentGUIOptimisticGoalControl
+} from "../model/agentGuiNodeTypes";
+import {
+  emptyAgentComposerDraft,
+  snapshotAgentComposerDraft
+} from "../model/agentComposerDraft";
+import { clearSubmittedDraftIfUnchanged } from "./agentGuiController.draftMessageHelpers";
+import { getAgentGUIErrorMessage } from "./agentGuiController.errors";
+import {
+  projectOptimisticGoalControl,
+  unresolvedOptimisticGoalControl
+} from "./agentGuiOptimisticGoal";
+
+interface UseAgentGUIGoalControlActionsInput {
+  activeConversationIdRef: RefObject<string | null>;
+  agentActivityRuntime: AgentActivityRuntime;
+  draftByScopeKeyRef: RefObject<Record<string, AgentComposerDraft>>;
+  isCurrentConversation(agentSessionId: string): boolean;
+  optimisticGoalControl: AgentGUIOptimisticGoalControl | null;
+  previewMode: boolean;
+  sessionEngine: AgentSessionEngine;
+  setDetailError: Dispatch<SetStateAction<string | null>>;
+  setDraftByScopeKey: Dispatch<
+    SetStateAction<Record<string, AgentComposerDraft>>
+  >;
+  setGoalClearNoticeSequence: Dispatch<SetStateAction<number>>;
+  setOptimisticGoalControl: Dispatch<
+    SetStateAction<AgentGUIOptimisticGoalControl | null>
+  >;
+  workspaceId: string;
+}
+
+export function useAgentGUIGoalControlActions(
+  input: UseAgentGUIGoalControlActionsInput
+) {
+  const requestSequenceRef = useRef(0);
+  const beginOptimisticGoalControl = useCallback(
+    (
+      agentSessionId: string,
+      action: AgentActivityGoalControlAction,
+      objective?: string,
+      requestId?: string,
+      reconcileOnObjectiveMatch = false
+    ): string => {
+      const canonicalSession =
+        selectEngineSession(
+          input.sessionEngine.getSnapshot(),
+          agentSessionId
+        ) ?? null;
+      const pendingGoalControl = unresolvedOptimisticGoalControl(
+        input.optimisticGoalControl,
+        agentSessionId,
+        canonicalSession
+      );
+      const nextRequestId =
+        requestId ??
+        `goal-control:${Date.now()}:${++requestSequenceRef.current}`;
+      input.setOptimisticGoalControl({
+        agentSessionId,
+        goal: projectOptimisticGoalControl(
+          pendingGoalControl?.goal ?? canonicalSession?.goal ?? null,
+          action,
+          objective
+        ),
+        reconcileOnObjectiveMatch,
+        requestId: nextRequestId
+      });
+      return nextRequestId;
+    },
+    [
+      input.optimisticGoalControl,
+      input.sessionEngine,
+      input.setOptimisticGoalControl
+    ]
+  );
+  const clearOptimisticGoalControl = useCallback(
+    (requestId: string) => {
+      input.setOptimisticGoalControl((current) =>
+        current?.requestId === requestId ? null : current
+      );
+    },
+    [input.setOptimisticGoalControl]
+  );
+  const goalControl = useCallback(
+    (
+      action: AgentActivityGoalControlAction,
+      objective?: string,
+      submittedDraftScopeKey?: string
+    ) => {
+      if (input.previewMode) return;
+      const agentSessionId = input.activeConversationIdRef.current;
+      if (!agentSessionId) return;
+      const submittedDraftSnapshot = submittedDraftScopeKey
+        ? {
+            sourceScopeKey: submittedDraftScopeKey,
+            content: snapshotAgentComposerDraft(
+              input.draftByScopeKeyRef.current[submittedDraftScopeKey] ??
+                emptyAgentComposerDraft()
+            ),
+            targetAgentSessionId: agentSessionId
+          }
+        : null;
+      input.setDetailError(null);
+      const optimisticRequestId = beginOptimisticGoalControl(
+        agentSessionId,
+        action,
+        objective
+      );
+      void input.agentActivityRuntime
+        .goalControl({
+          workspaceId: input.workspaceId,
+          agentSessionId,
+          action,
+          ...(objective !== undefined ? { objective } : {})
+        })
+        .then(() => {
+          clearOptimisticGoalControl(optimisticRequestId);
+          if (submittedDraftSnapshot) {
+            input.setDraftByScopeKey((current) => {
+              const next = clearSubmittedDraftIfUnchanged({
+                drafts: current,
+                snapshot: submittedDraftSnapshot
+              });
+              input.draftByScopeKeyRef.current = next;
+              return next;
+            });
+          }
+          if (
+            action === "clear" &&
+            input.isCurrentConversation(agentSessionId)
+          ) {
+            input.setGoalClearNoticeSequence((current) => current + 1);
+          }
+        })
+        .catch((error: unknown) => {
+          clearOptimisticGoalControl(optimisticRequestId);
+          if (input.isCurrentConversation(agentSessionId)) {
+            input.setDetailError(getAgentGUIErrorMessage(error));
+          }
+        });
+    },
+    [
+      beginOptimisticGoalControl,
+      clearOptimisticGoalControl,
+      input.activeConversationIdRef,
+      input.agentActivityRuntime,
+      input.draftByScopeKeyRef,
+      input.isCurrentConversation,
+      input.previewMode,
+      input.setDetailError,
+      input.setDraftByScopeKey,
+      input.setGoalClearNoticeSequence,
+      input.workspaceId
+    ]
+  );
+  return { beginOptimisticGoalControl, goalControl };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUILocalState.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUILocalState.ts
@@ -5,6 +5,7 @@ import type { AgentGUINodeData } from "../../../types";
 import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
 import type {
   AgentComposerDraft,
+  AgentGUIOptimisticGoalControl,
   AgentGUIProjectConversationDeleteTarget,
   SubmittedDraftSnapshot
 } from "../model/agentGuiNodeTypes";
@@ -59,6 +60,8 @@ export function useAgentGUILocalState({
   const [listError, setListError] = useState<string | null>(null);
   const [detailError, setDetailError] = useState<string | null>(null);
   const [goalClearNoticeSequence, setGoalClearNoticeSequence] = useState(0);
+  const [optimisticGoalControl, setOptimisticGoalControl] =
+    useState<AgentGUIOptimisticGoalControl | null>(null);
 
   return {
     activeConversationId,
@@ -72,6 +75,7 @@ export function useAgentGUILocalState({
     isDeletingProjectConversations,
     isLoadingMessages,
     listError,
+    optimisticGoalControl,
     pendingDeleteConversation,
     pendingDeleteProjectConversations,
     selectedProjectPath,
@@ -86,6 +90,7 @@ export function useAgentGUILocalState({
     setIsDeletingProjectConversations,
     setIsLoadingMessages,
     setListError,
+    setOptimisticGoalControl,
     setPendingDeleteConversation,
     setPendingDeleteProjectConversations,
     setSelectedProjectPath,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
@@ -24,12 +24,16 @@ import type {
   AgentGUIConversationSummary,
   AgentGUIInteractivePrompt
 } from "../model/agentGuiConversationModel";
-import type { AgentGUISessionChrome } from "../model/agentGuiNodeTypes";
+import type {
+  AgentGUIOptimisticGoalControl,
+  AgentGUISessionChrome
+} from "../model/agentGuiNodeTypes";
 import { composerSettingsSupportFromOptions } from "../model/composerSettingsSupport";
 import {
   agentActivityDisplayStatusBusy,
   conversationBusyStatus
 } from "./agentGuiController.draftMessageHelpers";
+import { unresolvedOptimisticGoalControl } from "./agentGuiOptimisticGoal";
 import { isNonRetryableResumeErrorCode } from "./agentGuiController.errors";
 import {
   normalizeOptionalText,
@@ -78,6 +82,7 @@ interface UseAgentGUISessionPresentationInput {
   lastRenderStateDiagnosticKeyRef: CurrentValue<string | null>;
   pendingApproval: AgentApprovalItemVM | null;
   planImplementationTurnIdRef: CurrentValue<string | null>;
+  optimisticGoalControl: AgentGUIOptimisticGoalControl | null;
   agentTargetsLoading: boolean;
   serverInteractivePrompt: AgentGUIInteractivePrompt | null;
   sessionEngine: AgentSessionEngine;
@@ -169,16 +174,32 @@ export function useAgentGUISessionPresentation(
     input.activeConversationId !== null && input.activationState !== "active";
   const activeConversationResumeUnavailable =
     activeConversationRequiresResume && activeSessionResumable === false;
-  const sessionChromeRawState = useMemo<AgentGUISessionChrome["rawState"]>(
-    () =>
+  const sessionChromeRawState = useMemo<
+    AgentGUISessionChrome["rawState"]
+  >(() => {
+    const optimisticGoalControl = unresolvedOptimisticGoalControl(
+      input.optimisticGoalControl,
+      input.activeConversationId,
       input.activeEngineSession
-        ? {
-            agentSessionId: input.activeEngineSession.agentSessionId,
-            goal: input.activeEngineSession.goal
-          }
-        : null,
-    [input.activeEngineSession?.agentSessionId, input.activeEngineSession?.goal]
-  );
+    );
+    const agentSessionId =
+      input.activeEngineSession?.agentSessionId ??
+      optimisticGoalControl?.agentSessionId;
+    if (!agentSessionId) {
+      return null;
+    }
+    return {
+      agentSessionId,
+      goal: optimisticGoalControl
+        ? optimisticGoalControl.goal
+        : (input.activeEngineSession?.goal ?? null)
+    };
+  }, [
+    input.activeConversationId,
+    input.activeEngineSession?.agentSessionId,
+    input.activeEngineSession?.goal,
+    input.optimisticGoalControl
+  ]);
   const sessionChrome = useMemo<AgentGUISessionChrome>(() => {
     const normalizedError = input.activationError?.trim() ?? "";
     const authState = input.activeSessionState?.authState?.trim() ?? "";

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts
@@ -2,7 +2,10 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { createAgentSessionEngine } from "@tutti-os/agent-activity-core";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
-import type { AgentComposerDraft } from "../model/agentGuiNodeTypes";
+import type {
+  AgentComposerDraft,
+  AgentGUIOptimisticGoalControl
+} from "../model/agentGuiNodeTypes";
 import { agentComposerDraftPrompt } from "../model/agentComposerDraft";
 import {
   clearSubmittedAgentGUIHomeDraft,
@@ -27,6 +30,24 @@ function createGoalControlInput(
   });
   const setDetailError = vi.fn();
   const setGoalClearNoticeSequence = vi.fn();
+  const optimisticGoalControlRef = {
+    current: null as AgentGUIOptimisticGoalControl | null
+  };
+  const setOptimisticGoalControl = vi.fn(
+    (
+      update:
+        | AgentGUIOptimisticGoalControl
+        | null
+        | ((
+            current: AgentGUIOptimisticGoalControl | null
+          ) => AgentGUIOptimisticGoalControl | null)
+    ) => {
+      optimisticGoalControlRef.current =
+        typeof update === "function"
+          ? update(optimisticGoalControlRef.current)
+          : update;
+    }
+  );
   const draftByScopeKeyRef = {
     current: {} as Record<string, AgentComposerDraft>
   };
@@ -70,12 +91,14 @@ function createGoalControlInput(
     },
     previewMode: false,
     promptImagesSupported: true,
+    optimisticGoalControl: null,
     sessionEngine,
     setActiveConversationId: vi.fn(),
     setDetailError,
     setDraftByScopeKey,
     setGoalClearNoticeSequence,
     setIntent: vi.fn(),
+    setOptimisticGoalControl,
     submittedDraftSnapshotsRef: { current: {} },
     startConversation: vi.fn(() => null),
     submitPromptRef: { current: vi.fn() },
@@ -85,10 +108,12 @@ function createGoalControlInput(
   return {
     input,
     draftByScopeKeyRef,
+    optimisticGoalControlRef,
     sessionEngine,
     setDetailError,
     setDraftByScopeKey,
-    setGoalClearNoticeSequence
+    setGoalClearNoticeSequence,
+    setOptimisticGoalControl
   };
 }
 
@@ -137,6 +162,65 @@ describe("new-conversation home draft lifecycle", () => {
 });
 
 describe("goal controls", () => {
+  it("publishes an optimistic goal before the control API settles", async () => {
+    const goalControl = vi.fn(() => new Promise<void>(() => {}));
+    const { input, optimisticGoalControlRef } = createGoalControlInput(
+      goalControl as never
+    );
+    const { result } = renderHook(() =>
+      useAgentGUISubmitInteractionActions(input)
+    );
+
+    act(() =>
+      result.current.submitPrompt([
+        { type: "text", text: "/goal count to ten" }
+      ])
+    );
+
+    expect(optimisticGoalControlRef.current).toMatchObject({
+      agentSessionId: "session-1",
+      goal: { objective: "count to ten", status: "active" },
+      reconcileOnObjectiveMatch: false
+    });
+    await waitFor(() => expect(goalControl).toHaveBeenCalledTimes(1));
+  });
+
+  it("publishes a new-session goal as soon as activation starts", () => {
+    const goalControl = vi.fn(async () => undefined);
+    const { input, optimisticGoalControlRef } = createGoalControlInput(
+      goalControl as never
+    );
+    input.activeConversationIdRef.current = null;
+    input.isComposerHomeRef.current = true;
+    input.startConversation = vi.fn(() => ({
+      agentSessionId: "session-new",
+      requestId: "activation-1"
+    }));
+    const { result } = renderHook(() =>
+      useAgentGUISubmitInteractionActions(input)
+    );
+
+    act(() =>
+      result.current.submitPrompt([
+        { type: "text", text: "/goal count to ten" }
+      ])
+    );
+
+    expect(input.startConversation).toHaveBeenCalledWith(
+      [{ type: "text", text: "/goal count to ten" }],
+      undefined,
+      undefined,
+      false
+    );
+    expect(optimisticGoalControlRef.current).toEqual({
+      agentSessionId: "session-new",
+      goal: { objective: "count to ten", status: "active" },
+      reconcileOnObjectiveMatch: true,
+      requestId: "goal-activation:activation-1"
+    });
+    expect(goalControl).not.toHaveBeenCalled();
+  });
+
   it("clears a submitted goal draft after the control API accepts it", async () => {
     const goalControl = vi.fn(async () => undefined);
     const { input, draftByScopeKeyRef, sessionEngine, setDraftByScopeKey } =
@@ -205,8 +289,13 @@ describe("goal controls", () => {
     const goalControl = vi.fn(async () =>
       Promise.reject(new Error("goal failed"))
     );
-    const { input, draftByScopeKeyRef, setDetailError, setDraftByScopeKey } =
-      createGoalControlInput(goalControl as never);
+    const {
+      input,
+      draftByScopeKeyRef,
+      optimisticGoalControlRef,
+      setDetailError,
+      setDraftByScopeKey
+    } = createGoalControlInput(goalControl as never);
     const sessionDraftKey = "session:session-1";
     draftByScopeKeyRef.current = {
       [sessionDraftKey]: draft("/goal count to ten")
@@ -228,6 +317,7 @@ describe("goal controls", () => {
       agentComposerDraftPrompt(draftByScopeKeyRef.current[sessionDraftKey]!)
     ).toBe("/goal count to ten");
     expect(setDraftByScopeKey).not.toHaveBeenCalled();
+    expect(optimisticGoalControlRef.current).toBeNull();
   });
 
   it("clears through the control API without creating a prompt submit", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
@@ -22,6 +22,7 @@ import {
 } from "../model/agentComposerDraft";
 import type {
   AgentComposerDraft,
+  AgentGUIOptimisticGoalControl,
   SubmittedDraftSnapshot
 } from "../model/agentGuiNodeTypes";
 import { resolveAgentComposerDraftScopeKey } from "../model/agentComposerDraftScope";
@@ -62,6 +63,7 @@ import {
 } from "./useAgentConversationSelection";
 import type { useAgentGUIActivation } from "./useAgentGUIActivation";
 import type { AgentGUINewConversationActivationResult } from "./agentGuiNewConversationActivation.types";
+import { useAgentGUIGoalControlActions } from "./useAgentGUIGoalControlActions";
 
 interface UseAgentGUISubmitInteractionActionsInput {
   activation: ReturnType<typeof useAgentGUIActivation>;
@@ -99,6 +101,7 @@ interface UseAgentGUISubmitInteractionActionsInput {
   }>;
   previewMode: boolean;
   promptImagesSupported: boolean;
+  optimisticGoalControl: AgentGUIOptimisticGoalControl | null;
   sessionEngine: AgentSessionEngine;
   setActiveConversationId: Dispatch<SetStateAction<string | null>>;
   setDetailError: Dispatch<SetStateAction<string | null>>;
@@ -107,6 +110,9 @@ interface UseAgentGUISubmitInteractionActionsInput {
   >;
   setGoalClearNoticeSequence: Dispatch<SetStateAction<number>>;
   setIntent: Dispatch<SetStateAction<ConversationIntent>>;
+  setOptimisticGoalControl: Dispatch<
+    SetStateAction<AgentGUIOptimisticGoalControl | null>
+  >;
   submittedDraftSnapshotsRef: RefObject<Record<string, SubmittedDraftSnapshot>>;
   startConversation(
     content: AgentPromptContentBlock[],
@@ -176,18 +182,35 @@ export function useAgentGUISubmitInteractionActions(
     planActionsRef,
     previewMode,
     promptImagesSupported,
+    optimisticGoalControl,
     sessionEngine,
     setActiveConversationId,
     setDetailError,
     setDraftByScopeKey,
     setGoalClearNoticeSequence,
     setIntent,
+    setOptimisticGoalControl,
     submittedDraftSnapshotsRef,
     startConversation,
     submitPromptRef,
     transientConversation,
     workspaceId
   } = input;
+  const { beginOptimisticGoalControl, goalControl } =
+    useAgentGUIGoalControlActions({
+      activeConversationIdRef,
+      agentActivityRuntime,
+      draftByScopeKeyRef,
+      isCurrentConversation,
+      optimisticGoalControl,
+      previewMode,
+      sessionEngine,
+      setDetailError,
+      setDraftByScopeKey,
+      setGoalClearNoticeSequence,
+      setOptimisticGoalControl,
+      workspaceId
+    });
   const retryActivation = useCallback(() => {
     const agentSessionId = activeConversationIdRef.current;
     if (!agentSessionId) {
@@ -416,71 +439,6 @@ export function useAgentGUISubmitInteractionActions(
     [activation, executePrompt, isSessionMarkedNonResumable, workspaceId]
   );
 
-  const goalControl = useCallback(
-    (
-      action: AgentActivityGoalControlAction,
-      objective?: string,
-      submittedDraftScopeKey?: string
-    ) => {
-      if (previewMode) {
-        return;
-      }
-      const agentSessionId = activeConversationIdRef.current;
-      if (!agentSessionId) {
-        return;
-      }
-      const submittedDraftSnapshot = submittedDraftScopeKey
-        ? {
-            sourceScopeKey: submittedDraftScopeKey,
-            content: snapshotAgentComposerDraft(
-              draftByScopeKeyRef.current[submittedDraftScopeKey] ??
-                emptyAgentComposerDraft()
-            ),
-            targetAgentSessionId: agentSessionId
-          }
-        : null;
-      setDetailError(null);
-      void agentActivityRuntime
-        .goalControl({
-          workspaceId,
-          agentSessionId,
-          action,
-          ...(objective !== undefined ? { objective } : {})
-        })
-        .then(() => {
-          if (submittedDraftSnapshot) {
-            setDraftByScopeKey((current) => {
-              const next = clearSubmittedDraftIfUnchanged({
-                drafts: current,
-                snapshot: submittedDraftSnapshot
-              });
-              draftByScopeKeyRef.current = next;
-              return next;
-            });
-          }
-          if (action !== "clear" || !isCurrentConversation(agentSessionId)) {
-            return;
-          }
-          setGoalClearNoticeSequence((current) => current + 1);
-        })
-        .catch((error: unknown) => {
-          if (!isCurrentConversation(agentSessionId)) {
-            return;
-          }
-          setDetailError(getAgentGUIErrorMessage(error));
-        });
-    },
-    [
-      agentActivityRuntime,
-      isCurrentConversation,
-      previewMode,
-      setDraftByScopeKey,
-      setDetailError,
-      setGoalClearNoticeSequence,
-      workspaceId
-    ]
-  );
-
   const submitPrompt = useCallback(
     (
       content: AgentPromptContentBlock[],
@@ -573,6 +531,15 @@ export function useAgentGUISubmitInteractionActions(
           typedGoal ? false : undefined
         );
         if (activationResult) {
+          if (typedGoal) {
+            beginOptimisticGoalControl(
+              activationResult.agentSessionId,
+              typedGoal.action,
+              typedGoal.objective,
+              `goal-activation:${activationResult.requestId}`,
+              true
+            );
+          }
           draftByScopeKeyRef.current = clearSubmittedAgentGUIHomeDraft({
             draftKey: homeDraftKey,
             drafts: draftByScopeKeyRef.current,
@@ -608,6 +575,7 @@ export function useAgentGUISubmitInteractionActions(
     },
     [
       agentActivityRuntime,
+      beginOptimisticGoalControl,
       conversationListQuery,
       previewMode,
       promptImagesSupported,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentActivitySessionGoal,
   AgentActivityUsage,
   CanonicalAgentSession
 } from "@tutti-os/agent-activity-core";
@@ -54,6 +55,13 @@ export interface AgentGUISessionChrome {
       }
     | null;
   rawState: Pick<CanonicalAgentSession, "agentSessionId" | "goal"> | null;
+}
+
+export interface AgentGUIOptimisticGoalControl {
+  agentSessionId: string;
+  goal: AgentActivitySessionGoal | null;
+  reconcileOnObjectiveMatch: boolean;
+  requestId: string;
 }
 
 export interface AgentGUIInlineNotice {


### PR DESCRIPTION
## Issue

Submitting `/goal <objective>` did not show the bottom Goal panel until the session creation or goal-control request had fully completed. This left the interface without immediate feedback after the user explicitly started or changed a goal.

The observed “正在规划下一步…” flash was a separate state-boundary problem in the installed stale build: a new-session typed goal briefly entered the normal first-message Turn path, then disappeared when that temporary active Turn settled. Goal state is session metadata, while the processing row must only represent a real active Turn.

## Root cause

The Goal banner presentation read only the authoritative `CanonicalAgentSession.goal`. Agent GUI had no short-lived optimistic overlay for goal controls or new-session typed-goal activation.

The current `main` daemon already parses typed goals before creating a submit claim, starts the session without a provisional Turn, and routes the request directly through goal control. This PR preserves and verifies that boundary instead of representing a Goal as an optimistic prompt or Turn.

## Fix

- Add a request-scoped optimistic Goal overlay to Agent GUI local controller state.
- Project `set`, `pause`, `resume`, and `clear` immediately before the runtime request settles.
- Reconcile the overlay against the authoritative session Goal without adding another React effect.
- Roll back only the matching optimistic request on failure so older completions cannot clear newer UI state.
- Preserve the existing goal-draft lifecycle, clear success notice, and error handling.
- Publish the optimistic Goal immediately after a new-session activation result while retaining `initialTurnExpected=false`.
- Keep the processing indicator exclusively driven by canonical active Turn state.

## Validation

- `pnpm --filter @tutti-os/agent-gui test` — 186 test files and 1679 tests passed.
- `pnpm --filter @tutti-os/agent-gui typecheck` — passed.
- `pnpm check:changed` — 8 lanes passed.
- `go test ./service/agent -run TestServiceCreateWithTypedGoalCreatesNoInitialTurn -count=1` — passed.
- Pre-push `pnpm check:full` — 18 tasks passed, including the full TypeScript and Go test suites.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the Goal panel immediately when users set, pause, resume, or clear a goal by rendering an optimistic overlay that reconciles with the session once the request completes. Also removes the brief “planning next step” flicker and keeps the processing row tied to real Turns only.

- **New Features**
  - Added an optimistic Goal overlay in local state to show changes instantly.
  - Project `set`, `pause`, `resume`, and `clear` before the API settles, then reconcile with the canonical session Goal.
  - Request-scoped updates ensure older completions cannot overwrite newer UI state.
  - For new-session typed goals, publish the optimistic Goal at activation start (no provisional Turn).
  - Introduced `useAgentGUIGoalControlActions` and integrated it into submit actions and session presentation.

- **Bug Fixes**
  - Removed the transient “正在规划下一步…” row for typed goals; processing now reflects only actual active Turns.
  - Preserved draft and error behavior: keep drafts on failure and clear only after a successful control; show clear notice for the current conversation.

<sup>Written for commit 3bd8f397688f7632d649113ddcb4ae9a0906cf74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

