### PR TITLE
refactor(agent-gui): decouple workbench nodes from provider identity

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/desktopAgentGUINodeState.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/desktopAgentGUINodeState.test.ts
@@ -4,7 +4,6 @@ import {
   areDesktopAgentGUIWorkbenchStatesEqual,
   createDesktopAgentGUINodeStateSource,
   createDefaultDesktopAgentGUINodeState,
-  desktopAgentGUIProviderFromInstanceId,
   migrateLegacyDesktopAgentGUIWorkbenchState,
   normalizeDesktopAgentGUINodeState,
   normalizeDesktopAgentGUIWorkbenchState,
@@ -259,25 +258,6 @@ test("desktop agent gui node state ignores removed legacy composer defaults", ()
       ...createDefaultDesktopAgentGUINodeState("hermes"),
       lastActiveAgentSessionId: "session-1"
     }
-  );
-});
-
-test("desktop agent gui provider derives from workbench instance id", () => {
-  assert.throws(
-    () => desktopAgentGUIProviderFromInstanceId("agent-gui"),
-    /agent_gui_workbench.instance_provider_required/
-  );
-  assert.equal(
-    desktopAgentGUIProviderFromInstanceId("agent-gui:claude-code"),
-    "claude-code"
-  );
-  assert.equal(
-    desktopAgentGUIProviderFromInstanceId("agent-gui:hermes:panel:abc"),
-    "hermes"
-  );
-  assert.equal(
-    desktopAgentGUIProviderFromInstanceId("agent-gui:unsupported"),
-    "unsupported"
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/desktopAgentGUINodeState.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/desktopAgentGUINodeState.ts
@@ -16,7 +16,6 @@ export {
 } from "@tutti-os/agent-gui/workbench/providerCatalog";
 
 export {
-  agentGuiWorkbenchProviderFromInstanceId as desktopAgentGUIProviderFromInstanceId,
   areAgentGuiWorkbenchNodeStatesEqual as areDesktopAgentGUINodeStatesEqual,
   areAgentGuiWorkbenchStatesEqual as areDesktopAgentGUIWorkbenchStatesEqual,
   createAgentGuiWorkbenchNodeStateSource as createDesktopAgentGUINodeStateSource,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/index.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/index.ts
@@ -23,7 +23,6 @@ export { DesktopAgentProviderManageDialog } from "./ui/DesktopAgentProviderManag
 export {
   createDesktopAgentGUINodeStateSource,
   desktopAgentGUIOpenSessionActivationType,
-  desktopAgentGUIProviderFromInstanceId,
   normalizeDesktopAgentGUINodeState,
   normalizeDesktopAgentGUIProvider,
   normalizeDesktopAgentGUIWorkbenchState

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -1,7 +1,6 @@
 import {
   useCallback,
   useEffect,
-  useLayoutEffect,
   memo,
   useMemo,
   useRef,
@@ -10,10 +9,6 @@ import {
 } from "react";
 import { AgentGUI } from "@tutti-os/agent-gui/agent-gui";
 import type { AgentGUIProps, AgentHostInputApi } from "@tutti-os/agent-gui";
-import {
-  AGENT_GUI_WORKBENCH_NEW_CONVERSATION_EVENT,
-  type AgentGuiWorkbenchNewConversationDetail
-} from "@tutti-os/agent-gui/workbench/contribution";
 import { requestWorkspaceAgentGuiLaunch } from "../services/workspaceAgentGuiLaunchCoordinator.ts";
 import { registerWorkspaceAgentGuiOpenSession } from "../../workspace-workbench/services/workspaceAgentGuiOpenSessionCoordinator.ts";
 import { workbenchFocusInputActivationType } from "@tutti-os/workbench-surface";
@@ -50,20 +45,22 @@ import {
 import { useDesktopAgentProbes } from "./useDesktopAgentProbes.ts";
 import {
   AGENT_PROBE_REFRESH_DEBOUNCE_MS,
-  DESKTOP_AGENT_GUI_CONVERSATION_RAIL_TOGGLE_EVENT,
   DESKTOP_AGENT_GUI_AGENT_SETTINGS,
   DESKTOP_AGENT_GUI_NOOP,
   DESKTOP_AGENT_GUI_POSITION,
   areDesktopAgentGUIWorkbenchBodyPropsEqual,
   handleDesktopAgentGUIShowMessage,
   resolveComputerUseAuthorizationState,
-  type DesktopAgentGUIConversationRailToggleDetail,
+  type DesktopAgentGUISurfaceContext,
+  type DesktopAgentGUISurfaceProps,
   type DesktopAgentGUIWorkbenchBodyProps
 } from "./desktopAgentGUIWorkbenchModel.ts";
 export { DESKTOP_AGENT_GUI_CONVERSATION_RAIL_TOGGLE_EVENT } from "./desktopAgentGUIWorkbenchModel.ts";
 export type { DesktopAgentGUIConversationRailToggleDetail } from "./desktopAgentGUIWorkbenchModel.ts";
 import { useDesktopAgentGUIContextMentions } from "./useDesktopAgentGUIContextMentions.ts";
 import { useDesktopAgentGUIReadiness } from "./useDesktopAgentGUIReadiness.ts";
+import { useDesktopAgentGUIOpenConversationWindow } from "./useDesktopAgentGUIOpenConversationWindow.ts";
+import { useDesktopAgentGUIWorkbenchEvents } from "./useDesktopAgentGUIWorkbenchEvents.ts";
 import { preloadDesktopAgentGuiMentionBrowse } from "../services/preloadDesktopAgentGuiMentionBrowse.ts";
 import { DESKTOP_AGENT_GUI_CURRENT_USER_ID } from "../services/desktopAgentGuiIdentity.ts";
 import {
@@ -71,12 +68,12 @@ import {
   isFeatureEnabled
 } from "../../../../../shared/featureFlags/catalog.ts";
 
-function DesktopAgentGUIWorkbenchBodyImpl({
+function DesktopAgentGUISurfaceImpl({
   agentActivityRuntime,
   agentHostApi,
   appCenterService,
   agentProviderStatusService,
-  context,
+  surface,
   computerUseApi,
   composerAppendRequest = null,
   conversationRailAutoCollapseWidthPx = null,
@@ -107,11 +104,19 @@ function DesktopAgentGUIWorkbenchBodyImpl({
   resolveMentionReferenceTarget,
   resolveWorkspaceReferenceInitialTarget,
   workspaceId
-}: DesktopAgentGUIWorkbenchBodyProps): JSX.Element {
+}: DesktopAgentGUISurfaceProps): JSX.Element {
   const agents = agentDirectory.agents;
   const { i18n, locale } = useTranslation();
   const { service: desktopPreferencesService, state: desktopPreferencesState } =
     useDesktopPreferencesService();
+  const rawWorkbenchState = normalizeDesktopAgentGUIWorkbenchState(
+    surface.state
+  );
+  const requestedAgentTargetId =
+    rawWorkbenchState.agentTargetId?.trim() || defaultAgentTargetId;
+  const readinessProvider =
+    agents.find((agent) => agent.agentTargetId === requestedAgentTargetId)
+      ?.provider ?? null;
   const {
     computerUseStatus,
     handleAgentProviderLogin,
@@ -122,8 +127,8 @@ function DesktopAgentGUIWorkbenchBodyImpl({
     agentActivityRuntime,
     agentProviderStatusService,
     computerUseApi,
-    host: context.host,
-    instanceId: context.instanceId,
+    host: surface.host,
+    provider: readinessProvider,
     previewMode,
     providerStatusBootstrapSnapshot,
     trackAgentProviderChatReady,
@@ -135,7 +140,7 @@ function DesktopAgentGUIWorkbenchBodyImpl({
       appCenterService,
       contextMentionProviders,
       dockPreviewCache,
-      host: context.host,
+      host: surface.host,
       previewMode,
       workspaceId
     });
@@ -146,14 +151,6 @@ function DesktopAgentGUIWorkbenchBodyImpl({
       workspaceId
     });
   }, [agentActivityRuntime, effectiveContextMentionProviders, workspaceId]);
-  const rawWorkbenchStateSource = useMemo(
-    () => context.externalNodeState ?? context.node.data.runtimeNodeState,
-    [context.externalNodeState, context.node.data.runtimeNodeState]
-  );
-  const rawWorkbenchState = useMemo(
-    () => normalizeDesktopAgentGUIWorkbenchState(rawWorkbenchStateSource),
-    [rawWorkbenchStateSource]
-  );
   // Pin the host's defensive state copy so downstream work tracks real changes.
   const workbenchStateRef = useRef(rawWorkbenchState);
   if (
@@ -171,7 +168,7 @@ function DesktopAgentGUIWorkbenchBodyImpl({
       resolveDesktopAgentGUIProviderForAgentTarget(
         workbenchAgentTargetId,
         agents,
-        provider
+        provider ?? "unknown"
       ),
     [agents, provider, workbenchAgentTargetId]
   );
@@ -183,7 +180,7 @@ function DesktopAgentGUIWorkbenchBodyImpl({
       ] ?? null)
     : null;
   const hasExplicitConversationRailCollapsedState =
-    hasDesktopAgentGUIConversationRailCollapsedState(rawWorkbenchStateSource);
+    hasDesktopAgentGUIConversationRailCollapsedState(surface.state);
   const preferredConversationRailCollapsed =
     isDesktopAgentProvider(nodeProvider) &&
     desktopPreferencesState.agentGuiConversationRailCollapsedByProvider[
@@ -220,12 +217,12 @@ function DesktopAgentGUIWorkbenchBodyImpl({
   // already visible, so it can skip a redundant in-app interruption.
   useEffect(() => {
     const agentSessionId = workbenchState.lastActiveAgentSessionId?.trim();
-    if (previewMode || !agentSessionId || context.node.isMinimized) {
+    if (previewMode || !agentSessionId || surface.isMinimized) {
       return undefined;
     }
     return registerWorkspaceAgentGuiOpenSession(workspaceId, agentSessionId);
   }, [
-    context.node.isMinimized,
+    surface.isMinimized,
     previewMode,
     workbenchState.lastActiveAgentSessionId,
     workspaceId
@@ -244,8 +241,6 @@ function DesktopAgentGUIWorkbenchBodyImpl({
     useState<DesktopAgentGUIPrefillPromptRequest | null>(
       () => prefillPromptBootstrapRequest
     );
-  const [newConversationRequestSequence, setNewConversationRequestSequence] =
-    useState(0);
   const handledOpenSessionActivationSequenceRef = useRef<number | null>(null);
   const handledPrefillPromptActivationSequenceRef = useRef<number | null>(null);
   // onStateChange is recreated on every host render; pin it so the writer stays
@@ -391,15 +386,18 @@ function DesktopAgentGUIWorkbenchBodyImpl({
   );
 
   useEffect(() => {
+    if (!provider) {
+      return;
+    }
     consumeDesktopAgentGUIOpenSessionActivation({
-      activation: context.activation,
+      activation: surface.activation,
       agentActivityRuntime,
-      clearNodeActivation: context.host.clearNodeActivation?.bind(context.host),
+      clearNodeActivation: surface.host.clearNodeActivation?.bind(surface.host),
       handledSequence: handledOpenSessionActivationSequenceRef.current,
       markHandled: (sequence) => {
         handledOpenSessionActivationSequenceRef.current = sequence;
       },
-      nodeId: context.node.id,
+      nodeId: surface.nodeId,
       onActivationError: handleOpenSessionActivationError,
       onOpenSessionRequest: setOpenSessionRequest,
       // Persistence is owned by handleUpdateNode (the single writer).
@@ -416,9 +414,9 @@ function DesktopAgentGUIWorkbenchBodyImpl({
     });
   }, [
     agentActivityRuntime,
-    context.activation,
-    context.host,
-    context.node.id,
+    surface.activation,
+    surface.host,
+    surface.nodeId,
     handleOpenSessionActivationError,
     handleUpdateNode,
     provider,
@@ -431,13 +429,13 @@ function DesktopAgentGUIWorkbenchBodyImpl({
       return;
     }
     const request = consumeDesktopAgentGUIPrefillPromptActivation({
-      activation: context.activation,
-      clearNodeActivation: context.host.clearNodeActivation?.bind(context.host),
+      activation: surface.activation,
+      clearNodeActivation: surface.host.clearNodeActivation?.bind(surface.host),
       handledSequence: handledPrefillPromptActivationSequenceRef.current,
       markHandled: (sequence) => {
         handledPrefillPromptActivationSequenceRef.current = sequence;
       },
-      nodeId: context.node.id
+      nodeId: surface.nodeId
     });
     if (request) {
       if (request.agentTargetId || request.provider) {
@@ -460,120 +458,33 @@ function DesktopAgentGUIWorkbenchBodyImpl({
       setPrefillPromptRequest(request);
     }
   }, [
-    context.activation,
-    context.host,
-    context.node.id,
+    surface.activation,
+    surface.host,
+    surface.nodeId,
     handleUpdateNode,
     previewMode
   ]);
 
-  useEffect(() => {
-    if (previewMode) {
-      return;
-    }
-    const handleOptimisticConversationRailToggle = (event: Event) => {
-      const detail = (event as CustomEvent<unknown>).detail;
-      if (
-        !detail ||
-        typeof detail !== "object" ||
-        !("instanceId" in detail) ||
-        !("conversationRailCollapsed" in detail)
-      ) {
-        return;
-      }
-
-      const toggle = detail as DesktopAgentGUIConversationRailToggleDetail;
-      if (
-        toggle.instanceId !== context.instanceId ||
-        typeof toggle.conversationRailCollapsed !== "boolean"
-      ) {
-        return;
-      }
-
+  const newConversationRequestSequence = useDesktopAgentGUIWorkbenchEvents({
+    instanceId: surface.instanceId,
+    onConversationRailToggle: (conversationRailCollapsed) => {
       handleUpdateNode((current) => ({
         ...current,
-        conversationRailCollapsed: toggle.conversationRailCollapsed
+        conversationRailCollapsed
       }));
-    };
-
-    window.addEventListener(
-      DESKTOP_AGENT_GUI_CONVERSATION_RAIL_TOGGLE_EVENT,
-      handleOptimisticConversationRailToggle
-    );
-    return () => {
-      window.removeEventListener(
-        DESKTOP_AGENT_GUI_CONVERSATION_RAIL_TOGGLE_EVENT,
-        handleOptimisticConversationRailToggle
-      );
-    };
-  }, [context.instanceId, handleUpdateNode, previewMode]);
-
-  useEffect(() => {
-    if (previewMode) {
-      return;
-    }
-    const handleNewConversationRequest = (event: Event) => {
-      const detail = (event as CustomEvent<unknown>).detail;
-      if (!detail || typeof detail !== "object" || !("instanceId" in detail)) {
-        return;
-      }
-
-      const request = detail as AgentGuiWorkbenchNewConversationDetail;
-      if (request.instanceId !== context.instanceId) {
-        return;
-      }
-
-      setNewConversationRequestSequence((current) => current + 1);
-    };
-
-    window.addEventListener(
-      AGENT_GUI_WORKBENCH_NEW_CONVERSATION_EVENT,
-      handleNewConversationRequest
-    );
-    return () => {
-      window.removeEventListener(
-        AGENT_GUI_WORKBENCH_NEW_CONVERSATION_EVENT,
-        handleNewConversationRequest
-      );
-    };
-  }, [context.instanceId, previewMode]);
-
-  const openConversationWindowRef = useRef({
-    onOpenAgentConversationWindow,
-    previewMode,
-    provider,
-    workspaceId
+    },
+    previewMode
   });
-  useLayoutEffect(() => {
-    openConversationWindowRef.current = {
+
+  const handleOpenConversationWindow = useDesktopAgentGUIOpenConversationWindow(
+    {
+      agentTargetId: workbenchAgentTargetId,
       onOpenAgentConversationWindow,
       previewMode,
-      provider,
+      provider: nodeProvider,
       workspaceId
-    };
-  }, [onOpenAgentConversationWindow, previewMode, provider, workspaceId]);
-  const canOpenConversationWindow =
-    !previewMode && Boolean(onOpenAgentConversationWindow);
-  const handleOpenConversationWindow = useMemo(() => {
-    if (!canOpenConversationWindow) {
-      return undefined;
     }
-    return (agentSessionId: string) => {
-      const current = openConversationWindowRef.current;
-      if (current.previewMode || !current.onOpenAgentConversationWindow) {
-        return;
-      }
-      const trimmedAgentSessionId = agentSessionId.trim();
-      if (!trimmedAgentSessionId) {
-        return;
-      }
-      void current.onOpenAgentConversationWindow({
-        agentSessionId: trimmedAgentSessionId,
-        provider: current.provider,
-        workspaceId: current.workspaceId
-      });
-    };
-  }, [canOpenConversationWindow]);
+  );
 
   useEffect(() => {
     if (
@@ -643,7 +554,7 @@ function DesktopAgentGUIWorkbenchBodyImpl({
     [desktopPreferencesService, previewMode, runtimeApi, workspaceId]
   );
 
-  const frame = context.node.frame;
+  const frame = surface.frame;
   const agentHostApiWithToast = useMemo<AgentHostInputApi>(
     () => ({
       ...agentHostApi,
@@ -664,9 +575,9 @@ function DesktopAgentGUIWorkbenchBodyImpl({
   );
   const composerFocusRequestSequence =
     composerAppendRequest?.sequence ??
-    (context.activation?.type === workbenchFocusInputActivationType ||
-    context.activation?.type === desktopAgentGUIPrefillPromptActivationType
-      ? context.activation.sequence
+    (surface.activation?.type === workbenchFocusInputActivationType ||
+    surface.activation?.type === desktopAgentGUIPrefillPromptActivationType
+      ? surface.activation.sequence
       : (prefillPromptRequest?.sequence ?? null));
   const capabilityMenuState = useMemo<
     AgentGUIProps["hostCapabilities"]["capabilityMenuState"]
@@ -725,10 +636,10 @@ function DesktopAgentGUIWorkbenchBodyImpl({
         i18n={i18n}
         locale={locale}
         identity={{
-          nodeId: context.node.id,
+          nodeId: surface.nodeId,
           workspaceId,
           currentUserId: DESKTOP_AGENT_GUI_CURRENT_USER_ID,
-          title: context.node.title
+          title: surface.nodeTitle
         }}
         workspace={{
           path: "",
@@ -761,11 +672,11 @@ function DesktopAgentGUIWorkbenchBodyImpl({
           width: frame.width,
           height: frame.height,
           desktopSize,
-          isMaximized: context.displayMode === "fullscreen",
-          isActive: context.isFocused,
+          isMaximized: surface.displayMode === "fullscreen",
+          isActive: surface.isFocused,
           isVisible:
-            context.presentationMode !== "mission-control" &&
-            context.node.isMinimized !== true,
+            surface.presentationMode !== "mission-control" &&
+            surface.isMinimized !== true,
           embedded: true,
           previewMode,
           conversationRailAutoCollapseWidthPx
@@ -829,7 +740,30 @@ function DesktopAgentGUIWorkbenchBodyImpl({
   );
 }
 
+export const DesktopAgentGUISurface = DesktopAgentGUISurfaceImpl;
+
+function DesktopAgentGUIWorkbenchBodyAdapter({
+  context,
+  ...props
+}: DesktopAgentGUIWorkbenchBodyProps): JSX.Element {
+  const surface: DesktopAgentGUISurfaceContext = {
+    activation: context.activation,
+    displayMode: context.displayMode,
+    frame: context.node.frame,
+    host: context.host,
+    instanceId: context.instanceId,
+    isFocused: context.isFocused,
+    isMinimized: context.node.isMinimized === true,
+    nodeId: context.node.id,
+    nodeTitle: context.node.title,
+    presentationMode: context.presentationMode,
+    state:
+      context.externalNodeState ?? context.node.data.runtimeNodeState ?? null
+  };
+  return <DesktopAgentGUISurface {...props} surface={surface} />;
+}
+
 export const DesktopAgentGUIWorkbenchBody = memo(
-  DesktopAgentGUIWorkbenchBodyImpl,
+  DesktopAgentGUIWorkbenchBodyAdapter,
   areDesktopAgentGUIWorkbenchBodyPropsEqual
 );

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchModel.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchModel.ts
@@ -37,6 +37,20 @@ export const DESKTOP_AGENT_GUI_CONVERSATION_RAIL_TOGGLE_EVENT =
 export type DesktopAgentGUIConversationRailToggleDetail =
   AgentGuiWorkbenchConversationRailToggleDetail;
 
+export interface DesktopAgentGUISurfaceContext {
+  activation: WorkbenchHostNodeBodyContext["activation"];
+  displayMode: WorkbenchHostNodeBodyContext["displayMode"];
+  frame: WorkbenchHostNodeBodyContext["node"]["frame"];
+  host: WorkbenchHostNodeBodyContext["host"];
+  instanceId: string;
+  isFocused: boolean;
+  isMinimized: boolean;
+  nodeId: string;
+  nodeTitle: string;
+  presentationMode: WorkbenchHostNodeBodyContext["presentationMode"];
+  state: unknown;
+}
+
 export interface DesktopAgentGUIWorkbenchBodyProps {
   agentActivityRuntime: AgentActivityRuntime;
   agentHostApi: AgentHostInputApi;
@@ -51,6 +65,7 @@ export interface DesktopAgentGUIWorkbenchBodyProps {
   onCapabilitySettingsRequest?: AgentGUIProps["hostActions"]["onCapabilitySettingsRequest"];
   onOpenAgentConversationWindow?: (input: {
     agentSessionId: string;
+    agentTargetId: string | null;
     provider: DesktopAgentGUINodeState["provider"];
     workspaceId: string;
   }) => Promise<void> | void;
@@ -86,6 +101,13 @@ export interface DesktopAgentGUIWorkbenchBodyProps {
   resolveWorkspaceReferenceInitialTarget?: AgentGUIProps["workspace"]["resolveReferenceInitialTarget"];
   workspaceId: string;
 }
+
+export type DesktopAgentGUISurfaceProps = Omit<
+  DesktopAgentGUIWorkbenchBodyProps,
+  "context"
+> & {
+  surface: DesktopAgentGUISurfaceContext;
+};
 
 export function resolveComputerUseAuthorizationState(
   status: DesktopComputerUseStatus | null

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentGUIOpenConversationWindow.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentGUIOpenConversationWindow.ts
@@ -1,0 +1,40 @@
+import { useLayoutEffect, useMemo, useRef } from "react";
+import type { DesktopAgentGUIProvider } from "../desktopAgentGUINodeState.ts";
+import type { DesktopAgentGUIWorkbenchBodyProps } from "./desktopAgentGUIWorkbenchModel.ts";
+
+export function useDesktopAgentGUIOpenConversationWindow(input: {
+  agentTargetId: string | null;
+  onOpenAgentConversationWindow: DesktopAgentGUIWorkbenchBodyProps["onOpenAgentConversationWindow"];
+  previewMode: boolean;
+  provider: DesktopAgentGUIProvider;
+  workspaceId: string;
+}): ((agentSessionId: string) => void) | undefined {
+  const currentInputRef = useRef(input);
+  useLayoutEffect(() => {
+    currentInputRef.current = input;
+  }, [input]);
+
+  const enabled =
+    !input.previewMode && Boolean(input.onOpenAgentConversationWindow);
+  return useMemo(() => {
+    if (!enabled) {
+      return undefined;
+    }
+    return (agentSessionId: string) => {
+      const current = currentInputRef.current;
+      if (current.previewMode || !current.onOpenAgentConversationWindow) {
+        return;
+      }
+      const normalizedSessionId = agentSessionId.trim();
+      if (!normalizedSessionId) {
+        return;
+      }
+      void current.onOpenAgentConversationWindow({
+        agentSessionId: normalizedSessionId,
+        agentTargetId: current.agentTargetId,
+        provider: current.provider,
+        workspaceId: current.workspaceId
+      });
+    };
+  }, [enabled]);
+}

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentGUIReadiness.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentGUIReadiness.ts
@@ -19,7 +19,6 @@ import {
   desktopComputerUseStatusesEqual,
   type DesktopComputerUseStatus
 } from "@shared/contracts/ipc";
-import { desktopAgentGUIProviderFromInstanceId } from "../desktopAgentGUINodeState";
 import type {
   AgentProviderStatusSnapshot,
   IAgentProviderStatusService
@@ -47,7 +46,7 @@ export function useDesktopAgentGUIReadiness(input: {
   agentProviderStatusService?: IAgentProviderStatusService;
   computerUseApi?: Pick<DesktopComputerUseApi, "checkStatus">;
   host: WorkbenchHostNodeBodyContext["host"];
-  instanceId: string;
+  provider: AgentGUIProvider | null;
   previewMode: boolean;
   providerStatusBootstrapSnapshot?: AgentProviderStatusSnapshot | null;
   trackAgentProviderChatReady?: (input: { provider: string }) => Promise<void>;
@@ -58,7 +57,7 @@ export function useDesktopAgentGUIReadiness(input: {
     agentProviderStatusService,
     computerUseApi,
     host,
-    instanceId,
+    provider,
     previewMode,
     providerStatusBootstrapSnapshot,
     trackAgentProviderChatReady,
@@ -69,9 +68,8 @@ export function useDesktopAgentGUIReadiness(input: {
   const previousAccountUserIdRef = useRef<string | null>(null);
   const [computerUseStatus, setComputerUseStatus] =
     useState<DesktopComputerUseStatus | null>(null);
-  const provider = desktopAgentGUIProviderFromInstanceId(instanceId);
   useEffect(() => {
-    if (previewMode || !agentProviderStatusService) {
+    if (previewMode || !agentProviderStatusService || !provider) {
       return;
     }
     void ensureDesktopManagedAgentProviderStatuses(agentProviderStatusService, [
@@ -91,14 +89,17 @@ export function useDesktopAgentGUIReadiness(input: {
     !providerStatusSnapshot.capturedAt && providerStatusBootstrapSnapshot
       ? providerStatusBootstrapSnapshot
       : providerStatusSnapshot;
-  const activeProviderAvailabilityStatus =
-    effectiveProviderStatusSnapshot.statuses.find(
-      (status) => status.provider === provider
-    )?.availability.status ?? null;
-  const activeProviderRecheckKey = activeProviderNotReadyRecheckKey({
-    availabilityStatus: activeProviderAvailabilityStatus,
-    provider
-  });
+  const activeProviderAvailabilityStatus = provider
+    ? (effectiveProviderStatusSnapshot.statuses.find(
+        (status) => status.provider === provider
+      )?.availability.status ?? null)
+    : null;
+  const activeProviderRecheckKey = provider
+    ? activeProviderNotReadyRecheckKey({
+        availabilityStatus: activeProviderAvailabilityStatus,
+        provider
+      })
+    : null;
   const [settledActiveProviderRecheckKey, setSettledActiveProviderRecheckKey] =
     useState<string | null>(null);
   const activeProviderRecheckGenerationRef = useRef(0);
@@ -109,7 +110,7 @@ export function useDesktopAgentGUIReadiness(input: {
       settledRecheckKey: settledActiveProviderRecheckKey
     });
   useEffect(() => {
-    if (previewMode || !agentProviderStatusService) {
+    if (previewMode || !agentProviderStatusService || !provider) {
       setSettledActiveProviderRecheckKey(null);
       return;
     }
@@ -143,6 +144,7 @@ export function useDesktopAgentGUIReadiness(input: {
   // no agent surface is open; this fires only when the user is actually here.
   const isActiveAgentProviderChatReady =
     !previewMode &&
+    provider !== null &&
     agentProviderStatusService?.getStatus(provider)?.availability.status ===
       "ready";
   const chatReadyReportedProvidersRef = useRef<Set<string>>(new Set());
@@ -150,7 +152,8 @@ export function useDesktopAgentGUIReadiness(input: {
     if (
       previewMode ||
       !isActiveAgentProviderChatReady ||
-      !trackAgentProviderChatReady
+      !trackAgentProviderChatReady ||
+      !provider
     ) {
       return;
     }
@@ -169,7 +172,7 @@ export function useDesktopAgentGUIReadiness(input: {
   // status is pull-based, so re-probe immediately to flip the dock/wizard to
   // "needs login" without the user having to re-detect manually.
   useEffect(() => {
-    if (previewMode || !agentProviderStatusService) {
+    if (previewMode || !agentProviderStatusService || !provider) {
       return;
     }
     return agentActivityRuntime.subscribeSessionEvents(workspaceId, (event) => {
@@ -341,10 +344,7 @@ export function useDesktopAgentGUIReadiness(input: {
       status: "checking",
       pendingAction: null
     };
-    return {
-      ...gates,
-      [provider]: checkingGate
-    };
+    return provider ? { ...gates, [provider]: checkingGate } : gates;
   }, [
     effectiveProviderStatusSnapshot,
     handleProviderReadinessGateAction,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentGUIWorkbenchEvents.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentGUIWorkbenchEvents.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  AGENT_GUI_WORKBENCH_NEW_CONVERSATION_EVENT,
+  type AgentGuiWorkbenchNewConversationDetail
+} from "@tutti-os/agent-gui/workbench/contribution";
+import {
+  DESKTOP_AGENT_GUI_CONVERSATION_RAIL_TOGGLE_EVENT,
+  type DesktopAgentGUIConversationRailToggleDetail
+} from "./desktopAgentGUIWorkbenchModel.ts";
+
+export function useDesktopAgentGUIWorkbenchEvents(input: {
+  instanceId: string;
+  onConversationRailToggle(collapsed: boolean): void;
+  previewMode: boolean;
+}): number {
+  const [newConversationSequence, setNewConversationSequence] = useState(0);
+  const onConversationRailToggleRef = useRef(input.onConversationRailToggle);
+  onConversationRailToggleRef.current = input.onConversationRailToggle;
+
+  useEffect(() => {
+    if (input.previewMode) {
+      return;
+    }
+    const handleConversationRailToggle = (event: Event) => {
+      const detail = (event as CustomEvent<unknown>).detail;
+      if (!detail || typeof detail !== "object") {
+        return;
+      }
+      const toggle =
+        detail as Partial<DesktopAgentGUIConversationRailToggleDetail>;
+      if (
+        toggle.instanceId === input.instanceId &&
+        typeof toggle.conversationRailCollapsed === "boolean"
+      ) {
+        onConversationRailToggleRef.current(toggle.conversationRailCollapsed);
+      }
+    };
+    const handleNewConversation = (event: Event) => {
+      const request = (event as CustomEvent<unknown>)
+        .detail as Partial<AgentGuiWorkbenchNewConversationDetail> | null;
+      if (request?.instanceId === input.instanceId) {
+        setNewConversationSequence((current) => current + 1);
+      }
+    };
+    window.addEventListener(
+      DESKTOP_AGENT_GUI_CONVERSATION_RAIL_TOGGLE_EVENT,
+      handleConversationRailToggle
+    );
+    window.addEventListener(
+      AGENT_GUI_WORKBENCH_NEW_CONVERSATION_EVENT,
+      handleNewConversation
+    );
+    return () => {
+      window.removeEventListener(
+        DESKTOP_AGENT_GUI_CONVERSATION_RAIL_TOGGLE_EVENT,
+        handleConversationRailToggle
+      );
+      window.removeEventListener(
+        AGENT_GUI_WORKBENCH_NEW_CONVERSATION_EVENT,
+        handleNewConversation
+      );
+    };
+  }, [input.instanceId, input.previewMode]);
+
+  return newConversationSequence;
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchComposition.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchComposition.test.ts
@@ -16,10 +16,8 @@ import {
   createWorkspaceAgentGuiInstanceId,
   createWorkspaceFilesDockEntry,
   toWorkspaceFilesActivation,
-  workspaceAgentGuiInstanceId,
   workspaceAgentGuiNodeID,
   workspaceAgentGuiNodeFrame,
-  workspaceAgentGuiProviderFromIdentifier,
   workspaceAgentGuiProviderFromLaunchRequest,
   workspaceBrowserNodeID,
   workspaceFilePreviewNodeFrame,
@@ -70,38 +68,13 @@ test("createWorkspaceFilesDockEntry configures the files dock entry", () => {
   );
 });
 
-test("workspace agent GUI identifiers keep providers in instance identities", () => {
-  assert.equal(workspaceAgentGuiInstanceId("codex"), "agent-gui:codex");
-  assert.equal(workspaceAgentGuiInstanceId("hermes"), "agent-gui:hermes");
-  assert.equal(workspaceAgentGuiProviderFromIdentifier("agent-gui"), null);
-  assert.equal(
-    workspaceAgentGuiProviderFromIdentifier("agent-gui:codex:panel:1"),
-    "codex"
-  );
-  assert.equal(
-    workspaceAgentGuiProviderFromIdentifier("agent-gui:openclaw"),
-    "openclaw"
-  );
-  assert.equal(
-    workspaceAgentGuiProviderFromIdentifier("agent-gui:unknown"),
-    "unknown"
-  );
-});
-
-test("workspace agent GUI creates multi-open panel instance ids", () => {
-  const first = createWorkspaceAgentGuiInstanceId({ provider: "codex" });
-  const second = createWorkspaceAgentGuiInstanceId({ provider: "codex" });
+test("workspace agent GUI creates opaque multi-open instance ids", () => {
+  const first = createWorkspaceAgentGuiInstanceId();
+  const second = createWorkspaceAgentGuiInstanceId();
 
   assert.notEqual(first, second);
-  assert.equal(workspaceAgentGuiProviderFromIdentifier(first), "codex");
-  assert.equal(workspaceAgentGuiProviderFromIdentifier(second), "codex");
-  assert.equal(
-    createWorkspaceAgentGuiInstanceId({
-      agentSessionId: "session:1",
-      provider: "hermes"
-    }),
-    "agent-gui:hermes:session:session%3A1"
-  );
+  assert.match(first, /^agent-gui:instance:/);
+  assert.match(second, /^agent-gui:instance:/);
 });
 
 test("workspace files open in the wide three-column frame", () => {
@@ -170,7 +143,7 @@ test("workspace agent GUI session launches use container instances", () => {
   assert.equal(descriptor.provider, "codex");
   assert.equal(descriptor.targetAgentSessionId, "session-2");
   assert.equal(descriptor.dockEntryId, "agent-gui:unified");
-  assert.match(descriptor.instanceId, /^agent-gui:codex:panel:/);
+  assert.match(descriptor.instanceId, /^agent-gui:instance:/);
   assert.equal(descriptor.reuseDockEntryNode, false);
   assert.deepEqual(descriptor.activation, {
     payload: {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchComposition.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchComposition.ts
@@ -12,9 +12,7 @@ export {
   createWorkspaceAgentGuiLaunchDescriptor,
   createWorkspaceAgentGuiInstanceId,
   createWorkspaceAgentGuiSessionLaunchRequest,
-  workspaceAgentGuiInstanceId,
   workspaceAgentGuiNodeID,
-  workspaceAgentGuiProviderFromIdentifier,
   workspaceAgentGuiProviderFromLaunchRequest,
   type WorkspaceAgentGuiProvider
 } from "../workspaceAgentGuiLaunch.ts";

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentGuiLaunch.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentGuiLaunch.ts
@@ -1,6 +1,4 @@
 import {
-  agentGuiWorkbenchInstanceId,
-  agentGuiWorkbenchProviderFromIdentifier,
   agentGuiWorkbenchProviderFromLaunchRequest,
   agentGuiWorkbenchTypeId,
   agentGuiWorkbenchUnifiedDockEntryId,
@@ -11,8 +9,6 @@ import {
 } from "@tutti-os/agent-gui/workbench/launch";
 
 export {
-  agentGuiWorkbenchInstanceId as workspaceAgentGuiInstanceId,
-  agentGuiWorkbenchProviderFromIdentifier as workspaceAgentGuiProviderFromIdentifier,
   agentGuiWorkbenchProviderFromLaunchRequest as workspaceAgentGuiProviderFromLaunchRequest,
   agentGuiWorkbenchTypeId as workspaceAgentGuiNodeID,
   agentGuiWorkbenchUnifiedDockEntryId as workspaceAgentGuiUnifiedDockEntryId,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchShortcutActions.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchShortcutActions.ts
@@ -8,10 +8,7 @@ import {
   type AgentGuiWorkbenchNewConversationDetail
 } from "@tutti-os/agent-gui/workbench/contribution";
 import { requestWorkspaceAgentGuiLaunch } from "@renderer/features/workspace-agent/services/workspaceAgentGuiLaunchCoordinator.ts";
-import {
-  workspaceAgentGuiNodeID,
-  workspaceAgentGuiProviderFromIdentifier
-} from "./workspaceAgentGuiLaunch.ts";
+import { workspaceAgentGuiNodeID } from "./workspaceAgentGuiLaunch.ts";
 import { createWorkspaceAgentGuiSameTypeWindowLaunchRequest } from "./workspaceWorkbenchShortcutAgentLaunch.ts";
 export {
   resolveWorkspaceAgentGuiNodeAgentTargetId,
@@ -31,10 +28,7 @@ export function resolveActiveWorkspaceWorkbenchNode(
 export function isWorkspaceAgentGuiWorkbenchNode(
   node: WorkspaceWorkbenchNode
 ): boolean {
-  return (
-    node.data.typeId === workspaceAgentGuiNodeID ||
-    workspaceAgentGuiProviderFromIdentifier(node.data.instanceId) !== null
-  );
+  return node.data.typeId === workspaceAgentGuiNodeID;
 }
 
 export async function openWorkspaceWorkbenchAgentConversationShortcut(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchShortcutAgentLaunch.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchShortcutAgentLaunch.ts
@@ -1,9 +1,6 @@
 import type { WorkspaceAgentProvider } from "@tutti-os/client-tuttid-ts";
 import { normalizeDesktopAgentGUIProvider } from "../../workspace-agent/desktopAgentGUINodeState.ts";
-import {
-  createWorkspaceAgentGuiSessionLaunchRequest,
-  workspaceAgentGuiProviderFromIdentifier
-} from "./workspaceAgentGuiLaunch.ts";
+import { createWorkspaceAgentGuiSessionLaunchRequest } from "./workspaceAgentGuiLaunch.ts";
 
 interface WorkspaceAgentGuiShortcutNode {
   data: {
@@ -18,7 +15,6 @@ export function resolveWorkspaceAgentGuiNodeProvider(
   fallback: WorkspaceAgentProvider
 ): WorkspaceAgentProvider {
   return (
-    workspaceAgentGuiProviderFromIdentifier(node.data.instanceId) ??
     workspaceAgentGuiProviderFromState(node.data.snapshotNodeState) ??
     workspaceAgentGuiProviderFromState(node.data.runtimeNodeState) ??
     fallback

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
@@ -148,7 +148,7 @@ test("standalone Agent handles task and app Agent launch requests", () => {
   );
   assert.match(
     standaloneWindowSource,
-    /<DesktopAgentGUIWorkbenchBody[\s\S]*?prefillPromptBootstrapRequest=\{prefillPromptBootstrapRequest\}/
+    /<DesktopAgentGUISurface[\s\S]*?prefillPromptBootstrapRequest=\{prefillPromptBootstrapRequest\}/
   );
   assert.match(
     workbenchBodySource,
@@ -243,14 +243,14 @@ test("standalone Agent hides panel toggles until its content mounts", () => {
   );
   assert.match(
     standaloneWindowSource,
-    /<StandaloneAgentWindowContentReady onReady=\{handleContentReady\}>[\s\S]*?<DesktopAgentGUIWorkbenchBody/
+    /<StandaloneAgentWindowContentReady onReady=\{handleContentReady\}>[\s\S]*?<DesktopAgentGUISurface/
   );
 });
 
 test("standalone Agent loads its body with the route instead of adding a second lazy boundary", () => {
   assert.match(
     standaloneWindowSource,
-    /import \{ DesktopAgentGUIWorkbenchBody \} from "@renderer\/features\/workspace-agent\/ui\/DesktopAgentGUIWorkbenchBody\.tsx"/
+    /import \{ DesktopAgentGUISurface \} from "@renderer\/features\/workspace-agent\/ui\/DesktopAgentGUIWorkbenchBody\.tsx"/
   );
   assert.doesNotMatch(
     standaloneWindowSource,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -26,8 +26,7 @@ import {
 } from "@tutti-os/agent-gui/workbench/contribution";
 import type {
   WorkbenchContribution,
-  WorkbenchHostHandle,
-  WorkbenchHostNodeBodyContext
+  WorkbenchHostHandle
 } from "@tutti-os/workbench-surface";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import { createDesktopAgentGUIWorkbenchHostInput } from "@renderer/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts";
@@ -35,11 +34,9 @@ import { IAgentsService } from "@renderer/features/workspace-agent/services/agen
 import type { IAgentProviderStatusService as AgentProviderStatusService } from "@renderer/features/workspace-agent/services/agentProviderStatusService.interface.ts";
 import type { IWorkspaceAgentActivityService as WorkspaceAgentActivityService } from "@renderer/features/workspace-agent/services/workspaceAgentActivityService.interface.ts";
 import type { DesktopAgentGUIPrefillPromptRequest } from "@renderer/features/workspace-agent/services/desktopAgentGUIPrefillPromptActivation.ts";
-import { isDesktopAgentGUIProvider } from "@renderer/features/workspace-agent/desktopAgentGUINodeState.ts";
 import {
   desktopAgentGUIOpenSessionActivationType,
   normalizeDesktopAgentGUIProvider,
-  type DesktopAgentGUIProvider,
   type DesktopAgentGUIWorkbenchState
 } from "@renderer/features/workspace-agent/desktopAgentGUINodeState.ts";
 import {
@@ -61,7 +58,9 @@ import type { TuttiExternalFileOpenInput } from "@tutti-os/workspace-external-co
 import type { IReporterService } from "@renderer/features/analytics";
 import type { IDesktopRichTextAtService } from "@renderer/features/rich-text-at";
 import type { IWorkspaceUserProjectService } from "@renderer/features/workspace-user-project";
-import { DesktopAgentGUIWorkbenchBody } from "@renderer/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx";
+import { createAgentGuiWorkbenchInstanceId } from "@tutti-os/agent-gui/workbench";
+import { DesktopAgentGUISurface } from "@renderer/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx";
+import type { DesktopAgentGUISurfaceContext } from "@renderer/features/workspace-agent/ui/desktopAgentGUIWorkbenchModel.ts";
 import { useTranslation } from "@renderer/i18n";
 import { AppUpdateStatus } from "@renderer/features/app-update";
 import { StandaloneAgentToolSidebar } from "./StandaloneAgentToolSidebar";
@@ -101,7 +100,6 @@ const LazyStandaloneAgentWindowPanelHosts = lazy(() =>
 );
 
 const standaloneAgentNodeId = "standalone-agent-window-node";
-const standaloneAgentInstanceKey = "standalone-agent-window";
 const standaloneAgentDefaultConversationRailWidthPx = 280;
 function renderStandaloneAgentSidebarFooter(): ReactNode {
   return (
@@ -273,17 +271,45 @@ export function StandaloneAgentWindow({
     getAgentDirectorySnapshot
   );
   const agents = agentDirectorySnapshot.agents;
+  const defaultAgentTargetId = useMemo(() => {
+    const requestedTargetId = launchAgentTargetId?.trim() || null;
+    if (
+      requestedTargetId &&
+      agents.some((agent) => agent.agentTargetId === requestedTargetId)
+    ) {
+      return requestedTargetId;
+    }
+    return (
+      agents.find(
+        (agent) =>
+          agent.provider === launchProvider &&
+          agent.availability.status === "ready"
+      )?.agentTargetId ??
+      agents.find((agent) => agent.availability.status === "ready")
+        ?.agentTargetId ??
+      null
+    );
+  }, [agents, launchAgentTargetId, launchProvider]);
   const [frame, setFrame] = useState(readStandaloneAgentWindowFrame);
   const [isWindowMaximized, setIsWindowMaximized] = useState(
     readStandaloneAgentWindowMaximizedState
   );
   const [nodeState, setNodeState] = useState<DesktopAgentGUIWorkbenchState>(
     () => ({
-      agentTargetId: launchAgentTargetId,
-      lastActiveAgentSessionId: launchAgentSessionId,
-      provider: launchProvider
+      agentTargetId: defaultAgentTargetId,
+      lastActiveAgentSessionId: launchAgentSessionId
     })
   );
+  useEffect(() => {
+    if (!defaultAgentTargetId) {
+      return;
+    }
+    setNodeState((current) =>
+      current.agentTargetId?.trim()
+        ? current
+        : { ...current, agentTargetId: defaultAgentTargetId }
+    );
+  }, [defaultAgentTargetId]);
   const [isContentLoading, setIsContentLoading] = useState(true);
   const handleContentReady = useCallback(() => {
     setIsContentLoading(false);
@@ -295,7 +321,7 @@ export function StandaloneAgentWindow({
     () => workspaceAgentActivityService.getSnapshot(workspaceId)
   );
   const [activation, setActivation] = useState<
-    WorkbenchHostNodeBodyContext["activation"]
+    DesktopAgentGUISurfaceContext["activation"]
   >(() =>
     launchAgentSessionId
       ? {
@@ -428,15 +454,15 @@ export function StandaloneAgentWindow({
     () => createStandaloneAgentDockPreviewCache(desktopApi.dockPreviewCache),
     [desktopApi.dockPreviewCache]
   );
-  const instanceId = useMemo(
-    () => `agent-gui:${launchProvider}:standalone:${workspaceId}`,
-    [launchProvider, workspaceId]
-  );
+  const instanceId = useMemo(() => createAgentGuiWorkbenchInstanceId(), []);
   const activeAgentTargetId = nodeState.agentTargetId?.trim() || null;
+  const activeAgent = agents.find(
+    (agent) => agent.agentTargetId === activeAgentTargetId
+  );
   const headerIdentity = useStandaloneAgentWindowHeaderIdentity({
     activeAgentTargetId,
     agents,
-    fallbackProvider: readStandaloneNodeProvider(nodeState, launchProvider),
+    fallbackProvider: activeAgent?.provider ?? launchProvider,
     nodeState,
     sessions: activitySnapshot.sessions,
     workspaceAgentActivityService,
@@ -469,43 +495,20 @@ export function StandaloneAgentWindow({
       }),
     []
   );
-  const context = useMemo<
-    WorkbenchHostNodeBodyContext<DesktopAgentGUIWorkbenchState, null>
-  >(
+  const surface = useMemo<DesktopAgentGUISurfaceContext>(
     () => ({
       activation,
       displayMode: "floating",
-      externalNodeState: nodeState,
-      externalWorkspaceState: null,
-      focus: () => undefined,
+      frame,
       host,
       instanceId,
-      instanceKey: standaloneAgentInstanceKey,
       // Standalone has one node; document focus is tracked live by engagement.
       isFocused: true,
-      node: {
-        data: {
-          activation,
-          instanceId,
-          instanceKey: standaloneAgentInstanceKey,
-          runtimeNodeState: nodeState,
-          snapshotNodeState: null,
-          typeId: "agent-gui"
-        },
-        displayMode: "floating",
-        frame,
-        id: standaloneAgentNodeId,
-        isMinimized: false,
-        kind: "window",
-        restoreFrame: null,
-        title: i18n.t("workspace.agentGui.fallbackAgentLabel")
-      },
-      setNodeRuntimeState: (state) => {
-        setNodeState((state ?? {}) as DesktopAgentGUIWorkbenchState);
-      },
-      setSnapshotNodeState: (state) => {
-        setNodeState((state ?? {}) as DesktopAgentGUIWorkbenchState);
-      }
+      isMinimized: false,
+      nodeId: standaloneAgentNodeId,
+      nodeTitle: i18n.t("workspace.agentGui.fallbackAgentLabel"),
+      presentationMode: undefined,
+      state: nodeState
     }),
     [activation, frame, host, i18n, instanceId, nodeState]
   );
@@ -716,12 +719,12 @@ export function StandaloneAgentWindow({
         workspaceId={workspaceId}
       >
         <StandaloneAgentWindowContentReady onReady={handleContentReady}>
-          <DesktopAgentGUIWorkbenchBody
+          <DesktopAgentGUISurface
             agentActivityRuntime={agentGuiHostInput.agentActivityRuntime}
             agentHostApi={agentGuiHostInput.agentHostApi}
             appCenterService={workspaceAppCenterService}
             agentProviderStatusService={agentProviderStatusService}
-            context={context}
+            surface={surface}
             computerUseApi={desktopApi.computerUse}
             composerAppendRequest={composerAppendRequest}
             conversationRailAutoCollapseWidthPx={
@@ -730,11 +733,16 @@ export function StandaloneAgentWindow({
             dockPreviewCache={dockPreviewCache}
             onLinkAction={handleLinkAction}
             onCapabilitySettingsRequest={handleCapabilitySettingsRequest}
-            onOpenAgentConversationWindow={({ agentSessionId, provider }) => {
+            onOpenAgentConversationWindow={({
+              agentSessionId,
+              agentTargetId,
+              provider
+            }) => {
               // Duplicate the complete live snapshot so the new window can
               // hydrate before its first local refresh.
               void hostWindowApi.openAgentWindow({
                 agentSessionId,
+                agentTargetId,
                 providerStatusSnapshot:
                   agentProviderStatusService.getSnapshot(),
                 agentDirectorySnapshot,
@@ -746,6 +754,7 @@ export function StandaloneAgentWindow({
             prefillPromptBootstrapRequest={prefillPromptBootstrapRequest}
             providerStatusBootstrapSnapshot={providerStatusBootstrapSnapshot}
             agentDirectory={agentDirectorySnapshot}
+            defaultAgentTargetId={defaultAgentTargetId}
             contextMentionProviders={agentGuiHostInput.contextMentionProviders}
             runtimeApi={desktopApi.runtime}
             trackAgentProviderChatReady={
@@ -795,12 +804,4 @@ export function StandaloneAgentWindow({
       />
     </main>
   );
-}
-
-function readStandaloneNodeProvider(
-  state: DesktopAgentGUIWorkbenchState,
-  fallbackProvider: DesktopAgentGUIProvider
-): DesktopAgentGUIProvider {
-  const provider = (state as { provider?: unknown }).provider;
-  return isDesktopAgentGUIProvider(provider) ? provider : fallbackProvider;
 }

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -174,13 +174,16 @@ older stored values, but the desktop host pins it to `unified`. Unified is the
 only Agent dock presentation: it exposes one Agent dock entry, and every
 AgentGUI launch result and persisted Workbench node uses
 `agent-gui:unified` as its stable `dockEntryId`. Launches still create
-provider-specific multi-instance AgentGUI nodes; provider identity belongs in
-the launch payload, `agentTargetId`, provider-specific `instanceId`, and node or
-session state rather than the Dock identity. The unified entry may choose a
-default target or provider for its launch payload; that selection must not
-synthesize a provider or replace the provider identity recorded on the
-node/session. Legacy persisted AgentGUI Dock identities are normalized by the
-daemon snapshot migration instead of renderer-side fallback matching.
+multi-instance AgentGUI nodes, but `instanceId` is an opaque Workbench lifecycle
+token (`agent-gui:instance:<nonce>`). It must never encode or be parsed for a
+provider, target, session, or surface kind. `agentTargetId` is the canonical
+node selection and launch identity; provider is execution metadata resolved
+from that target or from the durable session. The unified entry may choose a
+default ready target for its launch payload, but that selection must not
+synthesize a provider or replace the target recorded on the node/session.
+Legacy persisted Dock identities are normalized, and AgentGUI cache nodes with
+no currently valid `agentTargetId` are removed, by daemon snapshot migrations
+instead of renderer-side fallback matching.
 Workspace Launchpad is a broad launcher surface, not a mirror of the dock
 entry list; it should show one generic Agent tile that resolves to the default
 or first ready provider instead of duplicating provider-specific Agent dock
@@ -189,12 +192,10 @@ Agent launches from Launchpad/All must still use the unified Agent dock entry
 identity (`agent-gui:unified`) so the resulting AgentGUI node appears under the
 same Dock icon as direct Dock launches.
 The unified dock identity is a reserved aggregate identifier, not a provider
-identifier. Provider extraction parses the provider-specific
-`agent-gui:<provider>` instance namespace and must not use `dockEntryId`, even
-though provider metadata accepts extension-defined strings. Provider-specific
-dock status must never override the unified entry's visibility; an aggregate
-status, if needed, must be modeled explicitly instead of synthesizing an
-`unified` provider.
+identifier. Neither Dock identity nor instance identity is a provider parser
+surface. Provider-specific dock status must never override the unified entry's
+visibility; an aggregate status, if needed, must be modeled explicitly instead
+of synthesizing an `unified` provider.
 Empty launches from the unified Agent dock entry should set dock-entry reuse so
 the second dock click restores/focuses the existing AgentGUI node; draft
 prefill launches and explicit session launches keep their narrower reuse rules
@@ -320,6 +321,10 @@ selected agent's availability so coming-soon entries remain inspectable but
 cannot start sessions. Hosts may use `renderAgentUnavailableState` and
 `renderAgentReadinessState` for product-specific presentation, with actions
 routed through `onAgentAvailabilityAction`.
+`disabled` is interaction state, not an availability classification. A disabled
+target is coming soon only when its explicit availability is `coming_soon` (or
+the host's explicit coming-soon catalog says so); unavailable, not-installed,
+auth-required, and checking targets retain their own readiness state.
 Daemon-managed extension targets use this same host-projected availability.
 Their signed target name, icon URL, and open provider identity flow through the
 host `agents` array; AgentGUI must not add extension keys, provider fallbacks,
@@ -497,12 +502,13 @@ the current Tutti workspace surface: `DesktopAgentGUIWorkbenchBody` calls
 `host.launchNode`, and AgentGUI opens the requested session through an
 `agent-gui:open-session` activation. Normal session launches may reuse an
 already-open node only when workbench node state says that node is currently
-showing the requested session. A session-keyed instance id from older snapshots
-is only a legacy window identity hint, not proof of the node's current session.
-If no current-session match exists, the launch should use a provider target or
-panel-scoped AgentGUI container and then activate the durable session. The
+showing the requested session. An instance id from older snapshots is only a
+legacy window identity hint, not proof of the node's current session or target.
+If no current-session match exists, the launch uses an opaque AgentGUI container
+bound to the requested target in contribution-local memory and then activates
+the durable session. The
 explicit new-window action must pass `openInNewWindow` so the descriptor creates
-a fresh panel-scoped AgentGUI instance while still activating the same durable
+a fresh opaque AgentGUI instance while still activating the same durable
 session.
 The detached Agent button in desktop chrome is a different window boundary: it
 asks main to create an Electron `BrowserWindow` with the `view=agent` renderer
@@ -522,10 +528,12 @@ When the conversation rail collapses, the standalone Agent header remains a
 full-width window control surface and keeps its secondary tool actions anchored
 to the right window edge. Content-width caps belong to the conversation body,
 not to the header control row.
-Standalone Agent window state may keep a minimal UI-local workbench node
-context, but durable conversations, session activation, login, provider
-readiness, and file/project data must still flow through the shared desktop
-AgentGUI host input and activity runtime.
+Standalone Agent windows mount the shared desktop AgentGUI surface through a
+standalone adapter. They must not fabricate a Workbench node/context or mirror
+Workbench runtime and snapshot setters. Their minimal window state is UI-local;
+durable conversations, session activation, login, provider readiness, and
+file/project data still flow through the shared desktop AgentGUI host input and
+activity runtime.
 Standalone-window tools are desktop host chrome, not AgentGUI state.
 The desktop host owns tool identity, toolbar buttons and reminder badges,
 Browser/Terminal grouping, panel placement, lazy mounting, and tool content

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import type { AgentGUIProviderReadinessGate } from "../../../types";
+import { isAgentGUIAgentTargetComingSoon } from "../../../agentTargets";
 import { UnavailableChatIcon } from "../../../app/renderer/components/icons/UnavailableChatIcon";
 import { useProjectedAgentConversation } from "../../../shared/agentConversation/projection/useProjectedAgentConversation";
 import type { AgentComposerSlashStatusLimit } from "../AgentComposer";
@@ -58,8 +59,10 @@ export function useAgentGUIDetailModel(input: Input) {
     conversation: targetConversation
   });
   const hasActiveConversation = viewModel.rail.activeConversationId !== null;
-  const selectedAgentTargetComingSoon =
-    viewModel.rail.selectedAgentTarget?.disabled === true;
+  const selectedAgentTargetComingSoon = isAgentGUIAgentTargetComingSoon(
+    viewModel.rail.selectedAgentTarget,
+    viewModel.rail.comingSoonProviders
+  );
   const emptyProviderReadinessGate = !hasActiveConversation
     ? selectedAgentTargetComingSoon
       ? ({ status: "coming_soon" } satisfies AgentGUIProviderReadinessGate)

--- a/packages/agent/gui/agentTargets.spec.ts
+++ b/packages/agent/gui/agentTargets.spec.ts
@@ -4,11 +4,29 @@ import {
   createLocalAgentGUIAgentTarget,
   createLocalAgentGUIAgentTargets,
   createSharedAgentGUIAgentTarget,
+  isAgentGUIAgentTargetComingSoon,
   normalizeAgentGUIAgentTargets,
   resolveAgentGUIAgentTarget
 } from "./agentTargets";
 
 describe("agent gui provider targets", () => {
+  it("does not classify every disabled target as coming soon", () => {
+    const unavailable = {
+      ...createLocalAgentGUIAgentTarget("codex"),
+      availability: { status: "unavailable" as const },
+      disabled: true
+    };
+    const comingSoon = {
+      ...createLocalAgentGUIAgentTarget("codex"),
+      availability: { status: "coming_soon" as const },
+      disabled: true
+    };
+
+    expect(isAgentGUIAgentTargetComingSoon(unavailable)).toBe(false);
+    expect(isAgentGUIAgentTargetComingSoon(comingSoon)).toBe(true);
+    expect(isAgentGUIAgentTargetComingSoon(unavailable, ["codex"])).toBe(true);
+  });
+
   it("keeps migration-window default providers unique", () => {
     const providers = createLocalAgentGUIAgentTargets().map(
       (target) => target.provider

--- a/packages/agent/gui/agentTargets.ts
+++ b/packages/agent/gui/agentTargets.ts
@@ -201,6 +201,17 @@ export function resolveAgentGUIAgentTarget(input: {
   );
 }
 
+export function isAgentGUIAgentTargetComingSoon(
+  target: AgentGUIAgentTarget | null | undefined,
+  comingSoonProviders: readonly AgentGUIProvider[] = []
+): boolean {
+  return Boolean(
+    target &&
+    (target.availability?.status === "coming_soon" ||
+      comingSoonProviders.includes(target.provider))
+  );
+}
+
 export function agentGUIAgentTargetRefsEqual(
   left: AgentGUIAgentTargetRef | null | undefined,
   right: AgentGUIAgentTargetRef | null | undefined

--- a/packages/agent/gui/agents.test.ts
+++ b/packages/agent/gui/agents.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   normalizeAgentGUIAgents,
+  projectAgentGUIAgentsToInternalTargets,
   resolveAgentGUISelectedDirectoryAgent
 } from "./agents";
 import type { AgentGUIAgent } from "./types";
@@ -61,6 +62,24 @@ describe("normalizeAgentGUIAgents", () => {
         provider: "codex"
       }
     ]);
+  });
+});
+
+describe("projectAgentGUIAgentsToInternalTargets", () => {
+  it("preserves availability separately from disabled interaction state", () => {
+    const [target] = projectAgentGUIAgentsToInternalTargets([
+      createAgent("agent-a", {
+        availability: { status: "unavailable", reason: "Offline" }
+      })
+    ]);
+
+    expect(target).toMatchObject({
+      agentTargetId: "agent-a",
+      availability: { status: "unavailable", reason: "Offline" },
+      disabled: true,
+      unavailableReason: "Offline"
+    });
+    expect(target?.availability?.status).not.toBe("coming_soon");
   });
 });
 

--- a/packages/agent/gui/agents.ts
+++ b/packages/agent/gui/agents.ts
@@ -96,6 +96,7 @@ export function projectAgentGUIAgentsToInternalTargets(
       agentTargetId: agent.agentTargetId
     },
     label: agent.name,
+    availability: agent.availability,
     ...(agent.description ? { description: agent.description } : {}),
     iconUrl: agent.iconUrl,
     ...(agent.heroImageUrl ? { heroImageUrl: agent.heroImageUrl } : {}),

--- a/packages/agent/gui/types.ts
+++ b/packages/agent/gui/types.ts
@@ -162,6 +162,7 @@ export interface AgentGUIAgentTarget {
   heroImageUrl?: string | null;
   badge?: AgentGUIAgentTargetBadge | null;
   ownerLabel?: string;
+  availability?: AgentGUIAgentAvailability;
   disabled?: boolean;
   unavailableReason?: string;
 }

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -272,7 +272,7 @@ describe("agent GUI workbench contribution copy", () => {
       dockEntryId: agentGuiWorkbenchUnifiedDockEntryId(),
       title: "Agent"
     });
-    expect(launchResult?.instanceId).toContain("agent-gui:claude-code:panel:");
+    expect(launchResult?.instanceId).toMatch(/^agent-gui:instance:/);
   });
 
   it("clears stale target state when opening a session without a target payload", () => {
@@ -441,9 +441,7 @@ describe("agent GUI workbench contribution copy", () => {
       reuseDockEntryNode: true,
       title: "Agent"
     });
-    expect(launchResult?.instanceId).toBe(
-      "agent-gui:claude-code:target:local%3Aclaude-code"
-    );
+    expect(launchResult?.instanceId).toMatch(/^agent-gui:instance:/);
     expect(
       contribution.externalStateSource?.getSnapshotNodeState?.({
         instanceId: launchResult?.instanceId ?? "",
@@ -519,9 +517,7 @@ describe("agent GUI workbench contribution copy", () => {
       ["local:codex"],
       ["local:claude-code"]
     ]);
-    expect(launchResult?.instanceId).toBe(
-      "agent-gui:claude-code:target:local%3Aclaude-code"
-    );
+    expect(launchResult?.instanceId).toMatch(/^agent-gui:instance:/);
     unsubscribe();
   });
 
@@ -555,9 +551,7 @@ describe("agent GUI workbench contribution copy", () => {
       reuseDockEntryNode: true,
       title: "Agent"
     });
-    expect(launchResult?.instanceId).toBe(
-      "agent-gui:claude-code:target:local%3Aclaude-code"
-    );
+    expect(launchResult?.instanceId).toMatch(/^agent-gui:instance:/);
     expect(
       contribution.externalStateSource?.getSnapshotNodeState?.({
         instanceId: launchResult?.instanceId ?? "",
@@ -581,7 +575,7 @@ describe("agent GUI workbench contribution copy", () => {
     });
     const [dockEntry] = contribution.dockEntries ?? [];
 
-    // The regular launch reuses the target-keyed instance...
+    // The regular launch can reuse the contribution's opaque target binding...
     expect(dockEntry?.launchPayload).not.toHaveProperty("openInNewWindow");
     // ...while the "New window" payload forces a fresh window.
     expect(dockEntry?.newWindowLaunchPayload).toMatchObject({
@@ -604,12 +598,9 @@ describe("agent GUI workbench contribution copy", () => {
       | null
       | undefined;
 
-    // A unique per-launch panel instance (not the shared target-keyed id) so
+    // A unique opaque per-launch instance so
     // the workbench opens a new node instead of re-focusing the existing one.
-    expect(launchResult?.instanceId).toMatch(/^agent-gui:claude-code:panel:/);
-    expect(launchResult?.instanceId).not.toBe(
-      "agent-gui:claude-code:target:local%3Aclaude-code"
-    );
+    expect(launchResult?.instanceId).toMatch(/^agent-gui:instance:/);
     expect(launchResult?.cascadeOffset).toBeDefined();
     // The new window still commits to the resolved target/provider.
     expect(
@@ -1046,8 +1037,8 @@ describe("agent GUI workbench contribution copy", () => {
       }
     });
 
-    expect(existingLaunch?.instanceId).toContain("agent-gui:codex:panel:");
-    expect(newWindowLaunch?.instanceId).toContain("agent-gui:codex:panel:");
+    expect(existingLaunch?.instanceId).toMatch(/^agent-gui:instance:/);
+    expect(newWindowLaunch?.instanceId).toMatch(/^agent-gui:instance:/);
     expect(newWindowLaunch?.instanceId).not.toBe(existingLaunch?.instanceId);
     expect(existingLaunch?.cascadeOffset).toBeUndefined();
     expect(newWindowLaunch?.cascadeOffset).toEqual(
@@ -1100,7 +1091,7 @@ describe("agent GUI workbench contribution copy", () => {
       payload
     });
 
-    expect(firstLaunch?.instanceId).toContain("agent-gui:codex:panel:");
+    expect(firstLaunch?.instanceId).toMatch(/^agent-gui:instance:/);
     expect(relaunch?.instanceId).toBe(firstLaunch?.instanceId);
     expect(firstLaunch?.preserveExistingNodeFrame).not.toBe(true);
     expect(relaunch?.preserveExistingNodeFrame).toBe(true);
@@ -1154,7 +1145,7 @@ describe("agent GUI workbench contribution copy", () => {
     });
 
     expect(relaunch?.instanceId).not.toBe("agent-gui:codex:session:session-1");
-    expect(relaunch?.instanceId).toContain("agent-gui:codex:panel:");
+    expect(relaunch?.instanceId).toMatch(/^agent-gui:instance:/);
     expect(relaunch?.preserveExistingNodeFrame).not.toBe(true);
   });
 
@@ -1671,6 +1662,7 @@ describe("agent GUI workbench contribution copy", () => {
         displayMode: "floating",
         dragHandleProps: {},
         externalNodeState: {
+          agentTargetId: "local:codex",
           conversationRailCollapsed: false,
           conversationRailWidthPx: 360,
           lastActiveAgentSessionId: "session-1"
@@ -1750,7 +1742,7 @@ describe("agent GUI workbench contribution copy", () => {
     fireEvent.click(detachedWindowButton);
     expect(openDetachedWindow).toHaveBeenCalledWith({
       agentSessionId: "session-1",
-      agentTargetId: null,
+      agentTargetId: "local:codex",
       provider: "codex",
       workspaceId: "workspace-1"
     });

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -10,7 +10,6 @@ import {
   resolveAgentGUIExpandedWindowFrame,
   shouldAutoCollapseAgentGUIConversationRail
 } from "../agent-gui/agentGuiNode/model/agentGuiRailLayout.ts";
-import { resolveAgentGuiSessionProviderIconUrl } from "../agentGuiSessionProviderIconUrls.ts";
 import { AgentGuiWorkbenchReactiveHeader } from "./AgentGuiWorkbenchReactiveHeader.tsx";
 import { setAgentGuiWorkbenchBodyRenderError } from "./bodyRenderErrorRegistry.ts";
 import {
@@ -23,8 +22,6 @@ import {
   createAgentGuiWorkbenchLaunchDescriptor
 } from "./launch.ts";
 import {
-  agentGuiWorkbenchProviderFromInstanceId,
-  agentGuiWorkbenchProviderFromInstanceIdOrNull,
   createAgentGuiWorkbenchNodeStateSource,
   migrateLegacyAgentGuiWorkbenchState,
   normalizeAgentGuiWorkbenchNodeState,
@@ -81,9 +78,10 @@ export type AgentGuiWorkbenchContributionCopyOverrides =
 
 export interface AgentGuiWorkbenchRenderBodyHelpers {
   agentDirectory: AgentGUIAgentDirectoryPort;
+  agentTargetId: string | null;
   nodeTypeId: string;
   onStateChange(state: AgentGuiWorkbenchState): void;
-  provider: AgentGuiWorkbenchProvider;
+  provider: AgentGuiWorkbenchProvider | null;
 }
 
 export interface CreateAgentGuiWorkbenchContributionInput {
@@ -141,6 +139,7 @@ export function createAgentGuiWorkbenchContribution(
   });
   const frame = input.frame ?? agentGuiWorkbenchDefaultNodeFrame;
   const copy = resolveAgentGuiWorkbenchContributionCopy(input.copy);
+  const instanceIdByAgentTargetId = new Map<string, string>();
   return {
     dockEntries: buildAgentGuiDockEntries({
       agentDirectory: input.agentDirectory,
@@ -163,30 +162,49 @@ export function createAgentGuiWorkbenchContribution(
         onBodyRenderErrorChange: ({ hasError, node }) => {
           setAgentGuiWorkbenchBodyRenderError(node.id, hasError);
         },
-        renderBody: (context) =>
-          input.renderBody(
+        renderBody: (context) => {
+          const persistedState = normalizeAgentGuiWorkbenchState(
+            context.externalNodeState ?? context.node?.data.snapshotNodeState
+          );
+          const activationAgentTargetId = agentTargetIdFromActivation(
+            context.activation
+          );
+          const state =
+            activationAgentTargetId && !persistedState.agentTargetId
+              ? { ...persistedState, agentTargetId: activationAgentTargetId }
+              : persistedState;
+          const agent = resolveAgentGuiWorkbenchStateAgent(
+            state,
+            input.agentDirectory
+          );
+          if (agent) {
+            instanceIdByAgentTargetId.set(
+              agent.agentTargetId,
+              context.instanceId
+            );
+          }
+          return input.renderBody(
             context as WorkbenchHostNodeBodyContext<
               AgentGuiWorkbenchState | null,
               unknown
             >,
             {
               agentDirectory: input.agentDirectory,
+              agentTargetId: state.agentTargetId ?? null,
               nodeTypeId: agentGuiWorkbenchTypeId,
-              onStateChange: (state) => {
+              onStateChange: (nextState) => {
                 nodeStateSource.writeNodeState({
                   instanceId: context.instanceId,
                   nodeId: context.node.id,
-                  state,
+                  state: nextState,
                   typeId: agentGuiWorkbenchTypeId
                 });
               },
-              provider:
-                providerFromActivation(context.activation) ??
-                agentGuiWorkbenchProviderFromInstanceId(context.instanceId)
+              provider: agent?.provider ?? null
             }
-          ),
+          );
+        },
         renderHeader: ({
-          activation,
           dragHandleProps,
           displayMode,
           externalNodeState,
@@ -196,9 +214,6 @@ export function createAgentGuiWorkbenchContribution(
           surfaceSize,
           windowActions
         }) => {
-          const provider =
-            providerFromActivation(activation) ??
-            agentGuiWorkbenchProviderFromInstanceId(instanceId);
           const headerTitle = copy.nodeTitle;
           const rawWorkbenchState = (externalNodeState ??
             node.data.runtimeNodeState) as
@@ -210,6 +225,11 @@ export function createAgentGuiWorkbenchContribution(
           const workbenchState = normalizeAgentGuiWorkbenchState(
             migratedWorkbenchState
           );
+          const selectedAgent = resolveAgentGuiWorkbenchStateAgent(
+            workbenchState,
+            input.agentDirectory
+          );
+          const provider = selectedAgent?.provider ?? "unknown";
           const nodeState = normalizeAgentGuiWorkbenchNodeState(
             migratedWorkbenchState,
             provider
@@ -235,20 +255,11 @@ export function createAgentGuiWorkbenchContribution(
           // must not inherit the provider icon from the workbench instance.
           // Once a local session id exists, keep the provider icon available
           // while the canonical conversation title is still being persisted.
-          const iconProvider =
-            providerFromActivation(activation) ??
-            agentGuiWorkbenchProviderFromInstanceIdOrNull(instanceId);
           const hasConversation = Boolean(
             workbenchState.lastActiveAgentSessionId?.trim()
           );
           const conversationIconFallbackUrl =
-            hasConversation && iconProvider
-              ? (resolveAgentGuiSessionProviderIconUrl(iconProvider) ??
-                resolveAgentGuiWorkbenchProviderIconUrl({
-                  dockIconUrls: input.dockIconUrls,
-                  provider: iconProvider
-                }))
-              : null;
+            hasConversation && selectedAgent ? selectedAgent.iconUrl : null;
           const conversationIconUrl =
             conversationIdentity?.iconUrl ?? conversationIconFallbackUrl;
           const persistConversationRailCollapsed = (collapsed: boolean) => {
@@ -306,14 +317,16 @@ export function createAgentGuiWorkbenchContribution(
             ...dragHandleProps,
             onCreateConversation: announceNewConversation,
             onOpenDetachedWindow: input.onOpenDetachedWindow
-              ? () => {
-                  void input.onOpenDetachedWindow?.({
-                    agentSessionId: workbenchState.lastActiveAgentSessionId,
-                    agentTargetId: nodeState.agentTargetId,
-                    provider,
-                    workspaceId: input.workspaceId
-                  });
-                }
+              ? selectedAgent
+                ? () => {
+                    void input.onOpenDetachedWindow?.({
+                      agentSessionId: workbenchState.lastActiveAgentSessionId,
+                      agentTargetId: selectedAgent.agentTargetId,
+                      provider: selectedAgent.provider,
+                      workspaceId: input.workspaceId
+                    });
+                  }
+                : undefined
               : undefined,
             onPointerDown: (event) => {
               dragHandleProps.onPointerDown?.(event);
@@ -421,6 +434,15 @@ export function createAgentGuiWorkbenchContribution(
         ...request,
         payload: launchPayload
       });
+      const providerTarget = providerTargetLaunchPayloadFromRequest(
+        launchPayload,
+        provider
+      );
+      const reusableTargetInstanceId =
+        !openInNewWindow && providerTarget.agentTargetId
+          ? (instanceIdByAgentTargetId.get(providerTarget.agentTargetId) ??
+            null)
+          : null;
       // Locate an already-open node currently showing this session (its launch
       // instanceId may differ from the session-keyed one, e.g. a conversation
       // started fresh as a draft) so we focus it instead of opening a duplicate.
@@ -428,12 +450,12 @@ export function createAgentGuiWorkbenchContribution(
         targetAgentSessionId && reuseExistingSessionNode
           ? nodeStateSource.findInstanceIdByAgentSessionId(targetAgentSessionId)
           : null;
-      const instanceId = existingInstanceId ?? descriptorInstanceId;
+      const instanceId =
+        existingInstanceId ?? reusableTargetInstanceId ?? descriptorInstanceId;
+      if (!openInNewWindow && providerTarget.agentTargetId) {
+        instanceIdByAgentTargetId.set(providerTarget.agentTargetId, instanceId);
+      }
       const title = copy.nodeTitle;
-      const providerTarget = providerTargetLaunchPayloadFromRequest(
-        launchPayload,
-        provider
-      );
       const launchAgentTargetId = providerTarget.agentTargetId;
       if (targetAgentSessionId) {
         const previousState = nodeStateSource.readNodeState({
@@ -495,6 +517,35 @@ export function createAgentGuiWorkbenchContribution(
   };
 }
 
+function resolveAgentGuiWorkbenchStateAgent(
+  state: AgentGuiWorkbenchState | null,
+  directory: AgentGUIAgentDirectoryPort
+) {
+  const agentTargetId = state?.agentTargetId?.trim();
+  if (!agentTargetId) {
+    return null;
+  }
+  return (
+    directory
+      .getSnapshot()
+      .agents.find((agent) => agent.agentTargetId === agentTargetId) ?? null
+  );
+}
+
+function agentTargetIdFromActivation(activation: unknown): string | null {
+  if (!activation || typeof activation !== "object") {
+    return null;
+  }
+  const payload = (activation as { payload?: unknown }).payload;
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const agentTargetId = (payload as { agentTargetId?: unknown }).agentTargetId;
+  return typeof agentTargetId === "string" && agentTargetId.trim()
+    ? agentTargetId.trim()
+    : null;
+}
+
 function hasAgentSessionId(payload: unknown): boolean {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     return false;
@@ -513,11 +564,9 @@ import {
   buildAgentGuiDockEntries,
   createAgentGuiWorkbenchPreviewContent,
   isAgentGuiWorkbenchCompactVisibleFrame,
-  providerFromActivation,
   providerFromState,
   providerTargetLaunchPayloadFromRequest,
   resolveAgentGuiWorkbenchLaunchPayload,
-  resolveAgentGuiWorkbenchProviderIconUrl,
   resolveAgentGuiWorkbenchContributionCopy,
   resolveAgentGuiWorkbenchDefaultLaunchFrame
 } from "./contributionDock.tsx";

--- a/packages/agent/gui/workbench/contributionDock.tsx
+++ b/packages/agent/gui/workbench/contributionDock.tsx
@@ -11,14 +11,10 @@ import {
 import { agentGuiDockIconUrls } from "../dockIcons.ts";
 import {
   agentGuiWorkbenchDockIdentityFromIdentifier,
-  agentGuiWorkbenchProviderFromIdentifier,
   agentGuiWorkbenchTypeId,
   agentGuiWorkbenchUnifiedDockEntryId
 } from "./launch.ts";
-import {
-  agentGuiWorkbenchProviderFromInstanceId,
-  normalizeAgentGuiWorkbenchState
-} from "./state.ts";
+import { normalizeAgentGuiWorkbenchState } from "./state.ts";
 import {
   agentGuiWorkbenchDefaultDockProviders,
   isAgentGuiWorkbenchProvider,
@@ -544,11 +540,15 @@ export function createAgentGuiWorkbenchPreviewContent(input: {
     input.resolveDockPopupIdentity?.(state)?.title ??
     input.resolveDockPopupTitle?.(state) ??
     node.title;
-  const provider =
-    input.provider ??
-    agentGuiWorkbenchProviderFromIdentifier(node.data.instanceId) ??
-    agentGuiWorkbenchProviderFromInstanceId(node.data.instanceId);
-  const label = input.label ?? resolveAgentGuiWorkbenchProviderLabel(provider);
+  const agentTargetId = state.agentTargetId?.trim() ?? "";
+  const agent = input.agentDirectory
+    .getSnapshot()
+    .agents.find((candidate) => candidate.agentTargetId === agentTargetId);
+  const provider = input.provider ?? agent?.provider ?? null;
+  const label =
+    input.label ??
+    agent?.name ??
+    (provider ? resolveAgentGuiWorkbenchProviderLabel(provider) : node.title);
   const lines = [label, state.lastActiveAgentSessionId].filter(
     (line): line is string => Boolean(line?.trim())
   );
@@ -559,11 +559,12 @@ export function createAgentGuiWorkbenchPreviewContent(input: {
         agentDirectory: input.agentDirectory,
         nodeTypeId: agentGuiWorkbenchTypeId,
         onStateChange: () => undefined,
+        agentTargetId: agentTargetId || null,
         provider
       }
     ),
     kind: "component",
-    revision: `${provider}\n${title}\n${lines.join("\n")}`
+    revision: `${agentTargetId}\n${provider ?? ""}\n${title}\n${lines.join("\n")}`
   };
 }
 

--- a/packages/agent/gui/workbench/index.ts
+++ b/packages/agent/gui/workbench/index.ts
@@ -39,8 +39,6 @@ export {
 export {
   agentGuiWorkbenchDockEntryId,
   agentGuiWorkbenchDockIdentityFromIdentifier,
-  agentGuiWorkbenchInstanceId,
-  agentGuiWorkbenchProviderFromIdentifier,
   agentGuiWorkbenchProviderFromLaunchRequest,
   agentGuiWorkbenchTypeId,
   agentGuiWorkbenchUnifiedDockEntryId,
@@ -52,7 +50,6 @@ export {
 } from "./launch.ts";
 export type { AgentGuiWorkbenchLaunchDescriptor } from "./launch.ts";
 export {
-  agentGuiWorkbenchProviderFromInstanceId,
   areAgentGuiWorkbenchNodeStatesEqual,
   areAgentGuiWorkbenchStatesEqual,
   createAgentGuiWorkbenchNodeStateSource,

--- a/packages/agent/gui/workbench/launch.test.ts
+++ b/packages/agent/gui/workbench/launch.test.ts
@@ -3,8 +3,6 @@ import {
   agentGuiWorkbenchDockEntryId,
   agentGuiWorkbenchPrefillPromptActivationType,
   agentGuiWorkbenchDockIdentityFromIdentifier,
-  agentGuiWorkbenchInstanceId,
-  agentGuiWorkbenchProviderFromIdentifier,
   agentGuiWorkbenchProviderFromLaunchRequest,
   agentGuiWorkbenchUnifiedDockEntryId,
   createAgentGuiWorkbenchDraftLaunchRequest,
@@ -15,48 +13,13 @@ import {
 } from "./launch.ts";
 
 describe("agent gui workbench launch contract", () => {
-  it("keeps provider identity in instance ids instead of dock ids", () => {
+  it("keeps runtime instance ids opaque", () => {
     expect(agentGuiWorkbenchUnifiedDockEntryId()).toBe("agent-gui:unified");
-    expect(agentGuiWorkbenchInstanceId("codex")).toBe("agent-gui:codex");
-    expect(agentGuiWorkbenchProviderFromIdentifier("agent-gui")).toBeNull();
-    expect(agentGuiWorkbenchProviderFromIdentifier("agent-gui:codex")).toBe(
-      "codex"
-    );
-    expect(agentGuiWorkbenchProviderFromIdentifier("agent-gui:openclaw")).toBe(
-      "openclaw"
-    );
-    expect(agentGuiWorkbenchProviderFromIdentifier("agent-gui:unknown")).toBe(
-      "unknown"
-    );
-  });
-
-  it("creates stable session instance ids", () => {
-    expect(
-      createAgentGuiWorkbenchInstanceId({
-        agentSessionId: "session:1",
-        provider: "hermes"
-      })
-    ).toBe("agent-gui:hermes:session:session%3A1");
-  });
-
-  it("round trips encoded and legacy provider ids containing colons", () => {
-    const instanceId = createAgentGuiWorkbenchInstanceId({
-      agentTargetId: "extension:gemini",
-      provider: "acp:gemini"
-    });
-
-    expect(instanceId).toBe("agent-gui:acp%3Agemini:target:extension%3Agemini");
-    expect(agentGuiWorkbenchProviderFromIdentifier(instanceId)).toBe(
-      "acp:gemini"
-    );
-    expect(
-      agentGuiWorkbenchProviderFromIdentifier(
-        "agent-gui:acp:gemini:target:extension%3Agemini"
-      )
-    ).toBe("acp:gemini");
-    expect(
-      agentGuiWorkbenchProviderFromIdentifier("agent-gui:acp:gemini")
-    ).toBe("acp:gemini");
+    const first = createAgentGuiWorkbenchInstanceId();
+    const second = createAgentGuiWorkbenchInstanceId();
+    expect(first).toMatch(/^agent-gui:instance:/);
+    expect(second).toMatch(/^agent-gui:instance:/);
+    expect(first).not.toBe(second);
   });
 
   it("keeps deprecated dock identity helpers canonical", () => {
@@ -109,7 +72,7 @@ describe("agent gui workbench launch contract", () => {
     });
 
     expect(descriptor.dockEntryId).toBe("agent-gui:unified");
-    expect(descriptor.instanceId).toContain("agent-gui:codex:panel:");
+    expect(descriptor.instanceId).toMatch(/^agent-gui:instance:/);
     expect(descriptor.provider).toBe("codex");
   });
 
@@ -118,17 +81,10 @@ describe("agent gui workbench launch contract", () => {
     expect(
       agentGuiWorkbenchDockIdentityFromIdentifier("agent-gui:unified")
     ).toEqual({ kind: "unifiedAggregate" });
-    expect(
-      agentGuiWorkbenchProviderFromIdentifier("agent-gui:unified")
-    ).toBeNull();
-    expect(agentGuiWorkbenchProviderFromIdentifier("agent-gui")).toBeNull();
     expect(agentGuiWorkbenchDockIdentityFromIdentifier("agent-gui")).toBeNull();
     expect(
       agentGuiWorkbenchDockIdentityFromIdentifier("agent-gui:claude-code")
     ).toBeNull();
-    expect(
-      agentGuiWorkbenchProviderFromIdentifier("agent-gui:extension-provider")
-    ).toBe("extension-provider");
   });
 
   it("launches sessions into provider panels until current session state can reuse a node", () => {
@@ -155,7 +111,7 @@ describe("agent gui workbench launch contract", () => {
       reuseExistingSessionNode: true,
       targetAgentSessionId: "session-2"
     });
-    expect(descriptor.instanceId).toContain("agent-gui:codex:panel:");
+    expect(descriptor.instanceId).toMatch(/^agent-gui:instance:/);
   });
 
   it("launches sessions with target metadata into target panels", () => {
@@ -170,7 +126,6 @@ describe("agent gui workbench launch contract", () => {
         typeId: "agent-gui"
       })
     ).toMatchObject({
-      instanceId: "agent-gui:codex:target:local%3Acodex",
       openInNewWindow: false,
       reuseExistingSessionNode: true,
       targetAgentSessionId: "session-2"
@@ -194,14 +149,14 @@ describe("agent gui workbench launch contract", () => {
       },
       type: "agent-gui:open-session"
     });
-    expect(descriptor.instanceId).toContain("agent-gui:codex:panel:");
+    expect(descriptor.instanceId).toMatch(/^agent-gui:instance:/);
     expect(descriptor.openInNewWindow).toBe(true);
     expect(descriptor.reuseDockEntryNode).toBe(false);
     expect(descriptor.reuseExistingSessionNode).toBe(false);
     expect(descriptor.targetAgentSessionId).toBe("session-2");
   });
 
-  it("keeps unified aggregate dock launches provider-specific at the instance layer", () => {
+  it("keeps provider metadata separate from opaque aggregate instances", () => {
     const descriptor = createAgentGuiWorkbenchLaunchDescriptor({
       dockEntryId: agentGuiWorkbenchUnifiedDockEntryId(),
       payload: {
@@ -211,7 +166,7 @@ describe("agent gui workbench launch contract", () => {
     });
 
     expect(descriptor.dockEntryId).toBe("agent-gui:unified");
-    expect(descriptor.instanceId).toContain("agent-gui:claude-code:panel:");
+    expect(descriptor.instanceId).toMatch(/^agent-gui:instance:/);
     expect(descriptor.provider).toBe("claude-code");
     expect(descriptor.reuseDockEntryNode).toBe(true);
   });
@@ -345,7 +300,7 @@ describe("agent gui workbench launch contract", () => {
       reuseExistingSessionNode: false,
       targetAgentSessionId: null
     });
-    expect(descriptor.instanceId).toContain("agent-gui:codex:panel:");
+    expect(descriptor.instanceId).toMatch(/^agent-gui:instance:/);
   });
 
   it("creates session launch requests for the unified dock entry", () => {

--- a/packages/agent/gui/workbench/launch.ts
+++ b/packages/agent/gui/workbench/launch.ts
@@ -21,7 +21,6 @@ type AgentGuiWorkbenchLaunchRequestInput = Pick<
 
 export const agentGuiWorkbenchTypeId = "agent-gui";
 
-const agentGuiWorkbenchDockEntryPrefix = "agent-gui:";
 const agentGuiWorkbenchUnifiedDockEntryIdValue = "agent-gui:unified";
 const agentGuiWorkbenchDockPopupNewWindowLaunchSource = "dock-popup-new-window";
 let agentGuiWorkbenchInstanceSequence = 0;
@@ -44,60 +43,9 @@ export function agentGuiWorkbenchUnifiedDockEntryId(): string {
   return agentGuiWorkbenchUnifiedDockEntryIdValue;
 }
 
-export function agentGuiWorkbenchInstanceId(
-  provider: AgentGuiWorkbenchProvider
-): string {
-  return `${agentGuiWorkbenchDockEntryPrefix}${encodeAgentGuiWorkbenchInstanceSegment(
-    provider
-  )}`;
-}
-
-export function createAgentGuiWorkbenchInstanceId(input: {
-  agentSessionId?: string | null;
-  agentTargetId?: string | null;
-  provider: AgentGuiWorkbenchProvider;
-}): string {
-  const prefix = agentGuiWorkbenchInstanceId(input.provider);
-  const agentSessionId = input.agentSessionId?.trim();
-  if (agentSessionId) {
-    return `${prefix}:session:${encodeAgentGuiWorkbenchInstanceSegment(
-      agentSessionId
-    )}`;
-  }
-  const agentTargetId = input.agentTargetId?.trim();
-  if (agentTargetId) {
-    return `${prefix}:target:${encodeAgentGuiWorkbenchInstanceSegment(
-      agentTargetId
-    )}`;
-  }
-
+export function createAgentGuiWorkbenchInstanceId(): string {
   agentGuiWorkbenchInstanceSequence += 1;
-  return [
-    prefix,
-    "panel",
-    `${Date.now().toString(36)}-${agentGuiWorkbenchInstanceSequence.toString(36)}`
-  ].join(":");
-}
-
-export function agentGuiWorkbenchProviderFromIdentifier(
-  value: string | null | undefined
-): AgentGuiWorkbenchProvider | null {
-  if (agentGuiWorkbenchDockIdentityFromIdentifier(value)) {
-    return null;
-  }
-  const normalized = value?.trim();
-  if (!normalized?.startsWith(agentGuiWorkbenchDockEntryPrefix)) {
-    return null;
-  }
-  const identifier = normalized.slice(agentGuiWorkbenchDockEntryPrefix.length);
-  const structuredSuffix = identifier.match(
-    /:(?:panel|session|target):[^:]*$/u
-  );
-  const encodedProvider = structuredSuffix
-    ? identifier.slice(0, structuredSuffix.index)
-    : identifier;
-  const provider = decodeAgentGuiWorkbenchInstanceSegment(encodedProvider);
-  return isAgentGuiWorkbenchProvider(provider) ? provider : null;
+  return `agent-gui:instance:${Date.now().toString(36)}-${agentGuiWorkbenchInstanceSequence.toString(36)}`;
 }
 
 export function agentGuiWorkbenchDockIdentityFromIdentifier(
@@ -215,12 +163,7 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
         type: agentGuiWorkbenchPrefillPromptActivationType
       },
       dockEntryId,
-      instanceId: createAgentGuiWorkbenchInstanceId({
-        agentTargetId: openInNewWindow
-          ? null
-          : agentTargetIdFromLaunchPayload(request.payload),
-        provider
-      }),
+      instanceId: createAgentGuiWorkbenchInstanceId(),
       openInNewWindow,
       provider,
       reuseDockEntryNode:
@@ -236,13 +179,7 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
 
   const targetAgentSessionId = agentSessionIdFromLaunchPayload(request.payload);
   const openInNewWindow = openInNewWindowFromLaunchRequest(request);
-  const instanceId = createAgentGuiWorkbenchInstanceId({
-    agentSessionId: null,
-    agentTargetId: openInNewWindow
-      ? null
-      : agentTargetIdFromLaunchPayload(request.payload),
-    provider
-  });
+  const instanceId = createAgentGuiWorkbenchInstanceId();
 
   return {
     activation: targetAgentSessionId
@@ -293,18 +230,6 @@ export function resolveAgentGuiWorkbenchLaunchDockEntryId(_input: {
   requestedDockEntryId?: string | null;
 }): string {
   return agentGuiWorkbenchUnifiedDockEntryId();
-}
-
-function encodeAgentGuiWorkbenchInstanceSegment(value: string): string {
-  return encodeURIComponent(value.trim());
-}
-
-function decodeAgentGuiWorkbenchInstanceSegment(value: string): string | null {
-  try {
-    return decodeURIComponent(value).trim();
-  } catch {
-    return null;
-  }
 }
 
 function prefillPromptFromLaunchPayload(

--- a/packages/agent/gui/workbench/state.test.ts
+++ b/packages/agent/gui/workbench/state.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  agentGuiWorkbenchProviderFromInstanceId,
-  agentGuiWorkbenchProviderFromInstanceIdOrNull,
   areAgentGuiWorkbenchStatesEqual,
   createAgentGuiWorkbenchNodeStateSource,
   createDefaultAgentGuiWorkbenchNodeState,
@@ -143,45 +141,6 @@ describe("agent gui workbench state", () => {
         })
       )
     ).toBe(true);
-  });
-
-  it("derives providers from workbench instance ids", () => {
-    expect(() => agentGuiWorkbenchProviderFromInstanceId("agent-gui")).toThrow(
-      "agent_gui_workbench.instance_provider_required"
-    );
-    expect(
-      agentGuiWorkbenchProviderFromInstanceId("agent-gui:claude-code")
-    ).toBe("claude-code");
-    expect(
-      agentGuiWorkbenchProviderFromInstanceId("agent-gui:hermes:panel:abc")
-    ).toBe("hermes");
-    expect(
-      agentGuiWorkbenchProviderFromInstanceId(
-        "agent-gui:acp%3Agemini:target:extension%3Agemini"
-      )
-    ).toBe("acp:gemini");
-    expect(
-      agentGuiWorkbenchProviderFromInstanceId(
-        "agent-gui:acp:gemini:target:extension%3Agemini"
-      )
-    ).toBe("acp:gemini");
-    expect(
-      agentGuiWorkbenchProviderFromInstanceId("agent-gui:unsupported")
-    ).toBe("unsupported");
-  });
-
-  it("returns null instead of defaulting when the provider is unresolved", () => {
-    expect(
-      agentGuiWorkbenchProviderFromInstanceIdOrNull("agent-gui")
-    ).toBeNull();
-    expect(agentGuiWorkbenchProviderFromInstanceIdOrNull("")).toBeNull();
-    expect(agentGuiWorkbenchProviderFromInstanceIdOrNull(undefined)).toBeNull();
-    expect(
-      agentGuiWorkbenchProviderFromInstanceIdOrNull("agent-gui:unsupported")
-    ).toBe("unsupported");
-    expect(
-      agentGuiWorkbenchProviderFromInstanceIdOrNull("agent-gui:tutti-agent")
-    ).toBe("tutti-agent");
   });
 
   it("uses instance launch state only until node state is written", () => {
@@ -330,20 +289,20 @@ describe("agent gui workbench state", () => {
       workspaceId: "workspace-1"
     });
 
-    // A conversation started fresh: its launch instanceId is panel-scoped (not
-    // session-keyed), and its live state is written under a node-scoped key.
+    // Instance identity stays opaque; the live session binding is written
+    // under a node-scoped state key.
     source.writeNodeState({
-      instanceId: "agent-gui:codex:panel:abc123",
+      instanceId: "agent-gui:instance:abc123",
       nodeId: "node-1",
       state: { lastActiveAgentSessionId: "session-xyz" },
       typeId: "agent-gui"
     });
 
     expect(source.findInstanceIdByAgentSessionId("session-xyz")).toBe(
-      "agent-gui:codex:panel:abc123"
+      "agent-gui:instance:abc123"
     );
     expect(source.findInstanceIdByAgentSessionId("  session-xyz  ")).toBe(
-      "agent-gui:codex:panel:abc123"
+      "agent-gui:instance:abc123"
     );
     expect(source.findInstanceIdByAgentSessionId("other-session")).toBeNull();
     expect(source.findInstanceIdByAgentSessionId("")).toBeNull();

--- a/packages/agent/gui/workbench/state.ts
+++ b/packages/agent/gui/workbench/state.ts
@@ -6,7 +6,6 @@ import {
   agentGuiWorkbenchProviders,
   normalizeAgentGuiWorkbenchProvider
 } from "./providerCatalog.ts";
-import { agentGuiWorkbenchProviderFromIdentifier } from "./launch.ts";
 import type {
   AgentGuiWorkbenchComposerOverrides,
   AgentGuiWorkbenchComposerOverridesByAgentTargetId,
@@ -168,30 +167,6 @@ export function areAgentGuiWorkbenchNodeStatesEqual(
     left.provider === right.provider &&
     (left.agentTargetId ?? null) === (right.agentTargetId ?? null)
   );
-}
-
-export function agentGuiWorkbenchProviderFromInstanceId(
-  instanceId: string | null | undefined
-): AgentGuiWorkbenchProvider {
-  const provider = agentGuiWorkbenchProviderFromInstanceIdOrNull(instanceId);
-  if (!provider) {
-    throw new Error("agent_gui_workbench.instance_provider_required");
-  }
-  return provider;
-}
-
-/**
- * Like {@link agentGuiWorkbenchProviderFromInstanceId} but returns `null`
- * instead of defaulting to `"codex"` when the provider cannot be determined
- * yet (e.g. a freshly created session whose instanceId does not encode a
- * provider). Callers that render a provider icon use this so they can show a
- * neutral placeholder during that transient window instead of flashing the
- * wrong provider's icon.
- */
-export function agentGuiWorkbenchProviderFromInstanceIdOrNull(
-  instanceId: string | null | undefined
-): AgentGuiWorkbenchProvider | null {
-  return agentGuiWorkbenchProviderFromIdentifier(instanceId);
 }
 
 export function createAgentGuiWorkbenchNodeStateSource(input: {

--- a/services/tuttid/data/workspace/migrations.go
+++ b/services/tuttid/data/workspace/migrations.go
@@ -13,6 +13,7 @@ const schemaMigrationWorkspacesV2 = "workspaces_v2"
 const schemaMigrationWorkspacesV3 = "workspaces_v3"
 const schemaMigrationWorkspacesV4 = "workspaces_v4"
 const schemaMigrationWorkspaceWorkbenchAgentGUIUnifiedDockV1 = "workspace_workbench_agent_gui_unified_dock_v1"
+const schemaMigrationWorkspaceWorkbenchAgentTargetIdentityV1 = "workspace_workbench_agent_target_identity_v1"
 const schemaMigrationWorkspaceIssuesV1 = "workspace_issues_v1"
 const schemaMigrationWorkspaceIssuesV2 = "workspace_issues_v2"
 const schemaMigrationWorkspaceIssuesV3 = "workspace_issues_v3"
@@ -180,6 +181,9 @@ INSERT OR IGNORE INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 	// store. They must run after user_projects_v1: the rail section backfill
 	// reads project paths through userProjectPathsQuerier.
 	if err := s.agentStore().Migrate(ctx); err != nil {
+		return err
+	}
+	if err := s.applyWorkspaceWorkbenchAgentTargetIdentityV1(ctx); err != nil {
 		return err
 	}
 

--- a/services/tuttid/data/workspace/migrations_workbench.go
+++ b/services/tuttid/data/workspace/migrations_workbench.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -108,6 +109,244 @@ VALUES (?, ?)
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit AgentGUI workbench dock migration: %w", err)
 	}
+	return nil
+}
+
+func (s *SQLiteStore) applyWorkspaceWorkbenchAgentTargetIdentityV1(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceWorkbenchAgentTargetIdentityV1)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin AgentGUI target identity migration: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var snapshotTableCount int
+	if err := tx.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM sqlite_master
+WHERE type = 'table' AND name = 'workspace_workbench_snapshots'
+`).Scan(&snapshotTableCount); err != nil {
+		return fmt.Errorf("inspect workbench snapshot table for target identity migration: %w", err)
+	}
+	if snapshotTableCount == 0 {
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms) VALUES (?, ?)
+`, schemaMigrationWorkspaceWorkbenchAgentTargetIdentityV1, unixMs(time.Now().UTC())); err != nil {
+			return fmt.Errorf("record empty AgentGUI target identity migration: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit empty AgentGUI target identity migration: %w", err)
+		}
+		return nil
+	}
+
+	validAgentTargetIDs := make(map[string]struct{})
+	targetRows, err := tx.QueryContext(ctx, `SELECT id FROM agent_targets`)
+	if err != nil {
+		return fmt.Errorf("list agent targets for workbench migration: %w", err)
+	}
+	for targetRows.Next() {
+		var targetID string
+		if err := targetRows.Scan(&targetID); err != nil {
+			_ = targetRows.Close()
+			return fmt.Errorf("scan agent target for workbench migration: %w", err)
+		}
+		validAgentTargetIDs[strings.TrimSpace(targetID)] = struct{}{}
+	}
+	if err := targetRows.Close(); err != nil {
+		return fmt.Errorf("close agent target rows for workbench migration: %w", err)
+	}
+	if err := targetRows.Err(); err != nil {
+		return fmt.Errorf("iterate agent targets for workbench migration: %w", err)
+	}
+
+	rows, err := tx.QueryContext(ctx, `
+SELECT workspace_id, snapshot_json
+FROM workspace_workbench_snapshots
+WHERE schema_version = 1
+ORDER BY workspace_id ASC
+`)
+	if err != nil {
+		return fmt.Errorf("list snapshots for AgentGUI target identity migration: %w", err)
+	}
+	var snapshots []storedWorkbenchSnapshotMigrationRow
+	for rows.Next() {
+		var snapshot storedWorkbenchSnapshotMigrationRow
+		if err := rows.Scan(&snapshot.workspaceID, &snapshot.snapshotJSON); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan snapshot for AgentGUI target identity migration: %w", err)
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close snapshot rows for AgentGUI target identity migration: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate snapshots for AgentGUI target identity migration: %w", err)
+	}
+
+	for _, snapshot := range snapshots {
+		normalizedJSON, changed, err := filterAgentGUIWorkbenchNodesWithoutValidTarget(
+			[]byte(snapshot.snapshotJSON), validAgentTargetIDs,
+		)
+		if err != nil {
+			return fmt.Errorf("filter AgentGUI cache for workspace %q: %w", snapshot.workspaceID, err)
+		}
+		if !changed {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `
+UPDATE workspace_workbench_snapshots
+SET snapshot_json = ?
+WHERE workspace_id = ?
+`, string(normalizedJSON), snapshot.workspaceID); err != nil {
+			return fmt.Errorf("update AgentGUI cache for workspace %q: %w", snapshot.workspaceID, err)
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
+VALUES (?, ?)
+`, schemaMigrationWorkspaceWorkbenchAgentTargetIdentityV1, unixMs(time.Now().UTC())); err != nil {
+		return fmt.Errorf("record AgentGUI target identity migration: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit AgentGUI target identity migration: %w", err)
+	}
+	return nil
+}
+
+func filterAgentGUIWorkbenchNodesWithoutValidTarget(
+	snapshotJSON []byte,
+	validAgentTargetIDs map[string]struct{},
+) ([]byte, bool, error) {
+	var snapshot map[string]json.RawMessage
+	if err := json.Unmarshal(snapshotJSON, &snapshot); err != nil {
+		return nil, false, fmt.Errorf("decode snapshot json: %w", err)
+	}
+	var nodes []map[string]json.RawMessage
+	if err := json.Unmarshal(snapshot["nodes"], &nodes); err != nil {
+		return nil, false, fmt.Errorf("decode snapshot nodes: %w", err)
+	}
+
+	removedNodeIDs := make(map[string]struct{})
+	filteredNodes := make([]map[string]json.RawMessage, 0, len(nodes))
+	for _, node := range nodes {
+		remove, err := shouldRemoveAgentGUIWorkbenchNode(node, validAgentTargetIDs)
+		if err != nil {
+			return nil, false, err
+		}
+		if !remove {
+			filteredNodes = append(filteredNodes, node)
+			continue
+		}
+		var nodeID string
+		if err := json.Unmarshal(node["id"], &nodeID); err == nil && nodeID != "" {
+			removedNodeIDs[nodeID] = struct{}{}
+		}
+	}
+	if len(removedNodeIDs) == 0 {
+		return snapshotJSON, false, nil
+	}
+	normalizedNodes, err := json.Marshal(filteredNodes)
+	if err != nil {
+		return nil, false, fmt.Errorf("encode filtered snapshot nodes: %w", err)
+	}
+	snapshot["nodes"] = normalizedNodes
+	filterSnapshotNodeIDList(snapshot, "nodeStack", removedNodeIDs)
+	filterSnapshotActiveNodeID(snapshot, removedNodeIDs)
+	if err := filterSnapshotSpaceNodeIDs(snapshot, removedNodeIDs); err != nil {
+		return nil, false, err
+	}
+	normalizedSnapshot, err := json.Marshal(snapshot)
+	if err != nil {
+		return nil, false, fmt.Errorf("encode filtered snapshot: %w", err)
+	}
+	return normalizedSnapshot, true, nil
+}
+
+func shouldRemoveAgentGUIWorkbenchNode(
+	node map[string]json.RawMessage,
+	validAgentTargetIDs map[string]struct{},
+) (bool, error) {
+	var data map[string]json.RawMessage
+	if err := json.Unmarshal(node["data"], &data); err != nil {
+		return false, nil
+	}
+	if !rawJSONStringEquals(data["typeId"], agentGUIWorkbenchTypeID) {
+		return false, nil
+	}
+	var snapshotState map[string]json.RawMessage
+	if err := json.Unmarshal(data["snapshotNodeState"], &snapshotState); err != nil {
+		return true, nil
+	}
+	var agentTargetID string
+	if err := json.Unmarshal(snapshotState["agentTargetId"], &agentTargetID); err != nil {
+		return true, nil
+	}
+	_, valid := validAgentTargetIDs[strings.TrimSpace(agentTargetID)]
+	return !valid, nil
+}
+
+func filterSnapshotNodeIDList(
+	snapshot map[string]json.RawMessage,
+	key string,
+	removedNodeIDs map[string]struct{},
+) {
+	var nodeIDs []string
+	if json.Unmarshal(snapshot[key], &nodeIDs) != nil {
+		return
+	}
+	filtered := nodeIDs[:0]
+	for _, nodeID := range nodeIDs {
+		if _, removed := removedNodeIDs[nodeID]; !removed {
+			filtered = append(filtered, nodeID)
+		}
+	}
+	encoded, err := json.Marshal(filtered)
+	if err == nil {
+		snapshot[key] = encoded
+	}
+}
+
+func filterSnapshotActiveNodeID(
+	snapshot map[string]json.RawMessage,
+	removedNodeIDs map[string]struct{},
+) {
+	var activeNodeID string
+	if json.Unmarshal(snapshot["activeNodeId"], &activeNodeID) != nil {
+		return
+	}
+	if _, removed := removedNodeIDs[activeNodeID]; removed {
+		snapshot["activeNodeId"] = json.RawMessage("null")
+	}
+}
+
+func filterSnapshotSpaceNodeIDs(
+	snapshot map[string]json.RawMessage,
+	removedNodeIDs map[string]struct{},
+) error {
+	spacesJSON, ok := snapshot["spaces"]
+	if !ok {
+		return nil
+	}
+	var spaces []map[string]json.RawMessage
+	if err := json.Unmarshal(spacesJSON, &spaces); err != nil {
+		return fmt.Errorf("decode snapshot spaces: %w", err)
+	}
+	for _, space := range spaces {
+		filterSnapshotNodeIDList(space, "nodeIds", removedNodeIDs)
+	}
+	encoded, err := json.Marshal(spaces)
+	if err != nil {
+		return fmt.Errorf("encode snapshot spaces: %w", err)
+	}
+	snapshot["spaces"] = encoded
 	return nil
 }
 

--- a/services/tuttid/data/workspace/migrations_workbench_test.go
+++ b/services/tuttid/data/workspace/migrations_workbench_test.go
@@ -145,6 +145,79 @@ WHERE id = ?
 	}
 }
 
+func TestSQLiteStoreMigrationFiltersAgentGUINodesWithoutValidTargetIdentity(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	ctx := context.Background()
+	const workspaceID = "ws-agent-gui-target-migration"
+	if err := store.Create(ctx, workspacebiz.Summary{ID: workspaceID, Name: "Agent GUI Target Migration"}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+INSERT OR IGNORE INTO agent_targets (
+  id, provider, launch_ref_json, name, icon_key, enabled, source,
+  sort_order, created_at_ms, updated_at_ms
+) VALUES (
+  'local:codex', 'codex', '{"type":"local_cli","provider":"codex"}',
+  'Codex', 'codex', 1, 'system', 10, 1, 1
+)
+`); err != nil {
+		t.Fatalf("insert target fixture: %v", err)
+	}
+	const snapshotJSON = `{
+  "schemaVersion": 1,
+  "nodes": [
+    {"id":"agent-valid","kind":"agent-gui","data":{"typeId":"agent-gui","snapshotNodeState":{"agentTargetId":"local:codex"}}},
+    {"id":"agent-missing","kind":"agent-gui","data":{"typeId":"agent-gui","snapshotNodeState":{}}},
+    {"id":"agent-unknown","kind":"agent-gui","data":{"typeId":"agent-gui","snapshotNodeState":{"agentTargetId":"missing-target"}}},
+    {"id":"app","kind":"workspace-app-webview","data":{"typeId":"workspace-app-webview"}}
+  ],
+  "nodeStack": ["agent-valid", "agent-missing", "agent-unknown", "app"],
+  "activeNodeId": "agent-unknown",
+  "spaces": [{"id":"space-1","name":"One","nodeIds":["agent-valid","agent-missing","agent-unknown","app"]}]
+}`
+	if err := store.PutWorkbenchSnapshot(ctx, workspacebiz.WorkbenchSnapshot{
+		JSON: []byte(snapshotJSON), SchemaVersion: 1, WorkspaceID: workspaceID,
+	}); err != nil {
+		t.Fatalf("PutWorkbenchSnapshot() error = %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+DELETE FROM tuttid_schema_migrations WHERE id = ?
+`, schemaMigrationWorkspaceWorkbenchAgentTargetIdentityV1); err != nil {
+		t.Fatalf("delete migration marker: %v", err)
+	}
+
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+	var migrated struct {
+		Nodes []struct {
+			ID string `json:"id"`
+		} `json:"nodes"`
+		NodeStack    []string `json:"nodeStack"`
+		ActiveNodeID *string  `json:"activeNodeId"`
+		Spaces       []struct {
+			NodeIDs []string `json:"nodeIds"`
+		} `json:"spaces"`
+	}
+	if err := json.Unmarshal([]byte(readTestWorkbenchSnapshotJSON(t, store, workspaceID)), &migrated); err != nil {
+		t.Fatalf("decode migrated snapshot: %v", err)
+	}
+	if len(migrated.Nodes) != 2 || migrated.Nodes[0].ID != "agent-valid" || migrated.Nodes[1].ID != "app" {
+		t.Fatalf("nodes = %+v, want valid AgentGUI node and app", migrated.Nodes)
+	}
+	if got := migrated.NodeStack; len(got) != 2 || got[0] != "agent-valid" || got[1] != "app" {
+		t.Fatalf("nodeStack = %v, want [agent-valid app]", got)
+	}
+	if migrated.ActiveNodeID != nil {
+		t.Fatalf("activeNodeId = %v, want null", migrated.ActiveNodeID)
+	}
+	if len(migrated.Spaces) != 1 || len(migrated.Spaces[0].NodeIDs) != 2 {
+		t.Fatalf("spaces = %+v, want only retained node ids", migrated.Spaces)
+	}
+}
+
 type testWorkbenchSnapshotMigration struct {
 	Nodes        []testWorkbenchSnapshotMigrationNode
 	ClosedFrames []testWorkbenchSnapshotMigrationClosedFrame


### PR DESCRIPTION
## Summary

- make Agent GUI Workbench instance IDs opaque lifecycle tokens instead of encoding provider, target, or session identity
- use `agentTargetId` as the canonical node selection and reuse identity, while resolving provider and presentation metadata from the agent directory
- add a daemon snapshot migration that normalizes legacy dock identities and removes invalid cached Agent GUI nodes
- simplify the shared desktop Agent GUI surface for Workbench and standalone windows, with focused event and detached-window hooks
- preserve explicit availability states for disabled agent targets and document the updated Agent GUI ownership rules

## Verification

- `pnpm check:changed` — 13 lanes passed
- `pnpm check:changed -- --failed-only` — desktop typecheck passed after the pre-commit adjustment
- staged Electron runtime, UI, renderer, and Agent GUI degradation checks passed
- pre-push `pnpm check:full` — 18 tasks passed
- `git diff --cached --check` passed before commit

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples Agent GUI Workbench node identity from provider identity by making instance IDs opaque and using `agentTargetId` as the canonical selector. Cleans up legacy state via a migration and simplifies the desktop Agent GUI surface and events.

- **Refactors**
  - Replaced provider-encoded instance IDs with opaque tokens (`agent-gui:instance:<nonce>`).
  - Provider and presentation now resolve from the directory and `agentTargetId`; removed `providerFromInstanceId`/`providerFromIdentifier` and `agentGuiWorkbenchInstanceId`.
  - Added `useDesktopAgentGUIWorkbenchEvents` and `useDesktopAgentGUIOpenConversationWindow`; unified the desktop surface for Workbench and standalone windows.
  - Preserved explicit availability state and separated “coming soon” from “unavailable” via `isAgentGUIAgentTargetComingSoon`; availability now flows through `projectAgentGUIAgentsToInternalTargets`.
  - Simplified Workbench checks to `typeId` only; removed legacy provider derivations in shortcuts and composition.
  - Updated docs to define opaque instance IDs and clarified ownership rules.

- **Migration**
  - Introduces `workspace_workbench_agent_target_identity_v1` to:
    - Normalize legacy Agent GUI dock identities to `agent-gui:unified`.
    - Remove cached Agent GUI nodes without a valid `agentTargetId`.
  - Runs automatically; no manual steps required.

<sup>Written for commit 0d1902533259c096388e6e4a9c0fe6f22011b7cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

