### PR TITLE
Codex/fix file change approval

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -337,7 +337,16 @@ A provider's read-only tier must map to its actual non-writing execution mode,
 not to a planning workflow that can advance into implementation. For Cursor,
 the durable `read-only` tier maps to ACP `ask`, while the independent
 `planMode` flag maps to ACP `plan`; leaving plan mode restores the runtime mode
-derived from the durable permission tier.
+derived from the durable permission tier. OpenCode keeps ACP `build` and `plan`
+exclusively as workflow modes controlled by `planMode`. Its `read-only`, `ask`,
+and `full-access` permission tiers resolve OpenCode ACP permission requests and
+must never call `session/set_mode`. OpenCode's plan agent must retain its edit
+denial even when the independent permission tier is `full-access`; one-shot
+approval choices keep a later live switch to `read-only` enforceable. For
+OpenCode processes launched by AgentGUI, the selected tier is authoritative:
+the adapter merges unrelated `OPENCODE_CONFIG_CONTENT` fields but replaces its
+permission policy and neutralizes `OPENCODE_PERMISSION` so external overrides
+cannot collapse the permission/workflow boundary.
 Host feature switches that disable an agent for new conversations should keep
 the entry present with a non-ready `availability.status` when another surface
 still needs to show it. Filter the entry out only for surfaces that should

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -230,7 +230,11 @@ gap, the pending activation record in `AgentSessionEngine` owns one optimistic
 title projected from the submitted visible prompt; the rail and every header
 read that same record. Optimistic projection and daemon persistence use the same
 whitespace and Markdown-link-label normalization so engine reconciliation does
-not visibly rewrite valid rich-prompt titles. The localized untitled label is
+not visibly rewrite valid rich-prompt titles. In header and conversation-rail
+titles, Agent handoff/session, Agent-target, and workspace-app mentions render
+as normalized `@label` text without a second mention glyph; the active Agent's
+identity icon remains separate, while task and file references may keep their
+compact title markers. The localized untitled label is
 used only when this projection is unavailable, while canonical `session.title`
 remains empty until the daemon establishes it and then takes precedence. Runtime
 owns the initial-title-established bit and persists it in private runtime

--- a/packages/agent/daemon/providerregistry/opencode.go
+++ b/packages/agent/daemon/providerregistry/opencode.go
@@ -20,11 +20,9 @@ func openCodeDescriptor() ProviderDescriptor {
 			Command:             []string{"opencode", "acp"},
 			AuthRequiredMessage: "OpenCode ACP requires authentication; run `opencode auth login` on the host, then retry this session.",
 			StandardACP: StandardACPRuntimeDescriptor{
-				PermissionModes: []RuntimePermissionModeDescriptor{
-					{InputID: "", RuntimeID: "build"},
-					{InputID: "build", RuntimeID: "build"},
-					{InputID: "plan", RuntimeID: "plan"},
-				},
+				AdapterStrategy:           StandardACPAdapterStrategyOpenCode,
+				PlanModeRuntimeID:         "plan",
+				PlanModeDisabledRuntimeID: "build",
 				SettingsEnvironment: RuntimeSettingsEnvironmentDescriptor{
 					Variable: "OPENCODE_CONFIG_CONTENT",
 					JSONFields: []RuntimeSettingsJSONFieldDescriptor{
@@ -88,6 +86,14 @@ func openCodeDescriptor() ProviderDescriptor {
 				CapabilityModelImageInputRequired,
 				CapabilityPlanMode,
 				CapabilityInterrupt,
+				CapabilityPermissionModeChangeDuringTurn,
+			},
+			PermissionConfigurable:  true,
+			DefaultPermissionModeID: "ask",
+			PermissionModes: []PermissionModeDescriptor{
+				{ID: "read-only", Semantic: "locked-down"},
+				{ID: "ask", Semantic: "ask-before-write"},
+				{ID: "full-access", Semantic: "full-access"},
 			},
 			ConfigOptionIDs: ComposerConfigOptionIDs{
 				Model:     "model",

--- a/packages/agent/daemon/providerregistry/registry.go
+++ b/packages/agent/daemon/providerregistry/registry.go
@@ -552,9 +552,12 @@ func validateExternalImportDescriptor(descriptor ExternalImportDescriptor) error
 
 func validateStandardACPRuntime(descriptor StandardACPRuntimeDescriptor) error {
 	switch descriptor.AdapterStrategy {
-	case "", StandardACPAdapterStrategyGeneric, StandardACPAdapterStrategyCursor, StandardACPAdapterStrategyNexight, StandardACPAdapterStrategyOpenClaw:
+	case "", StandardACPAdapterStrategyGeneric, StandardACPAdapterStrategyCursor, StandardACPAdapterStrategyNexight, StandardACPAdapterStrategyOpenClaw, StandardACPAdapterStrategyOpenCode:
 	default:
 		return fmt.Errorf("adapter strategy %q is unsupported", descriptor.AdapterStrategy)
+	}
+	if strings.TrimSpace(descriptor.PlanModeDisabledRuntimeID) != "" && strings.TrimSpace(descriptor.PlanModeRuntimeID) == "" {
+		return fmt.Errorf("plan-mode disabled runtime id requires a plan-mode runtime id")
 	}
 	modeIDs := make(map[string]struct{}, len(descriptor.PermissionModes))
 	for index, mode := range descriptor.PermissionModes {

--- a/packages/agent/daemon/providerregistry/registry_test.go
+++ b/packages/agent/daemon/providerregistry/registry_test.go
@@ -250,7 +250,7 @@ func TestMigratedReturnsOpenCodeNestedClones(t *testing.T) {
 	if !ok {
 		t.Fatal("opencode descriptor missing")
 	}
-	first.Runtime.StandardACP.PermissionModes[0].RuntimeID = "mutated"
+	first.Runtime.StandardACP.PlanModeDisabledRuntimeID = "mutated"
 	first.Runtime.StandardACP.SettingsEnvironment.JSONFields[0].JSONKey = "mutated"
 	first.Status.AuthWatch.Sources[0].PathEnvVars[0] = "MUTATED"
 	first.Status.AuthWatch.Sources[1].RootCandidates[0].EnvVar = "MUTATED"
@@ -260,7 +260,7 @@ func TestMigratedReturnsOpenCodeNestedClones(t *testing.T) {
 	if !ok {
 		t.Fatal("opencode descriptor missing after mutation")
 	}
-	if second.Runtime.StandardACP.PermissionModes[0].RuntimeID != "build" ||
+	if second.Runtime.StandardACP.PlanModeDisabledRuntimeID != "build" ||
 		second.Runtime.StandardACP.SettingsEnvironment.JSONFields[0].JSONKey != "model" {
 		t.Fatalf("Runtime.StandardACP leaked mutation: %#v", second.Runtime.StandardACP)
 	}
@@ -366,11 +366,20 @@ func TestValidateRejectsInvalidStandardACPDescriptorStrategies(t *testing.T) {
 		name   string
 		mutate func(*ProviderDescriptor)
 	}{
-		{name: "blank runtime mode", mutate: func(value *ProviderDescriptor) {
-			value.Runtime.StandardACP.PermissionModes[0].RuntimeID = " "
+		{name: "blank permission runtime mode", mutate: func(value *ProviderDescriptor) {
+			value.Runtime.StandardACP.PermissionModes = append(
+				value.Runtime.StandardACP.PermissionModes,
+				RuntimePermissionModeDescriptor{InputID: "ask", RuntimeID: " "},
+			)
 		}},
-		{name: "duplicate input mode", mutate: func(value *ProviderDescriptor) {
-			value.Runtime.StandardACP.PermissionModes[1].InputID = ""
+		{name: "plan disabled mode without plan mode", mutate: func(value *ProviderDescriptor) {
+			value.Runtime.StandardACP.PlanModeRuntimeID = ""
+		}},
+		{name: "duplicate permission input mode", mutate: func(value *ProviderDescriptor) {
+			value.Runtime.StandardACP.PermissionModes = []RuntimePermissionModeDescriptor{
+				{InputID: "ask", RuntimeID: "ask"},
+				{InputID: "ask", RuntimeID: "prompt"},
+			}
 		}},
 		{name: "missing settings environment variable", mutate: func(value *ProviderDescriptor) {
 			value.Runtime.StandardACP.SettingsEnvironment.Variable = ""

--- a/packages/agent/daemon/providerregistry/types.go
+++ b/packages/agent/daemon/providerregistry/types.go
@@ -18,6 +18,7 @@ const (
 	StandardACPAdapterStrategyCursor   StandardACPAdapterStrategy = "cursor"
 	StandardACPAdapterStrategyNexight  StandardACPAdapterStrategy = "nexight"
 	StandardACPAdapterStrategyOpenClaw StandardACPAdapterStrategy = "openclaw"
+	StandardACPAdapterStrategyOpenCode StandardACPAdapterStrategy = "opencode"
 )
 
 // EndpointConfigKind identifies an optional provider-owned config source for
@@ -137,6 +138,7 @@ type StandardACPRuntimeDescriptor struct {
 	DefaultPermissionModeRuntimeID string
 	SettingsEnvironment            RuntimeSettingsEnvironmentDescriptor
 	PlanModeRuntimeID              string
+	PlanModeDisabledRuntimeID      string
 	ProjectCurrentMode             bool
 	StartupDiagnostics             bool
 	DeriveImageInputFromPrompt     bool

--- a/packages/agent/daemon/runtime/acp_pending.go
+++ b/packages/agent/daemon/runtime/acp_pending.go
@@ -10,12 +10,19 @@ import (
 // ACP permission requests carry provider-defined option IDs. This file owns
 // only ACP decoding and response-envelope details; shared interactive state
 // and activity projection live in interactive_projection.go.
-func acpPermissionRequestDecisionOptionID(raw json.RawMessage, decision string) (string, bool) {
+func acpPermissionRequestDecisionOptionID(
+	raw json.RawMessage,
+	decision string,
+	filter func([]map[string]any) []map[string]any,
+) (string, bool) {
 	var params struct {
 		Options []map[string]any `json:"options"`
 	}
 	if err := json.Unmarshal(raw, &params); err != nil {
 		return "", false
+	}
+	if filter != nil {
+		params.Options = filter(params.Options)
 	}
 	return resolveACPPermissionDecisionOptionID(params.Options, decision)
 }

--- a/packages/agent/daemon/runtime/acp_provider_cursor.go
+++ b/packages/agent/daemon/runtime/acp_provider_cursor.go
@@ -124,7 +124,7 @@ func newCursorAdapterFromProviderDescriptor(
 ) *standardACPAdapter {
 	adapter := newStandardACPAdapterFromProviderDescriptor(descriptor, transport, host, commandResolver)
 	adapter.config.commandWithSettings = cursorACPCommandWithPluginDir
-	adapter.config.autoApprovePermissionDecision = cursorAutoApprovePermissionDecision
+	adapter.config.automaticPermissionDecision = cursorAutoApprovePermissionDecision
 	adapter.config.autoContinueRetriableTurnError = true
 	adapter.config.messageDiagnostics = &standardACPMessageDiagnostics{
 		method:         cursorACPMethodTask,

--- a/packages/agent/daemon/runtime/acp_provider_opencode.go
+++ b/packages/agent/daemon/runtime/acp_provider_opencode.go
@@ -1,0 +1,173 @@
+package agentruntime
+
+// OpenCode exposes build/plan as ACP session modes. Those modes select a
+// workflow agent and are intentionally independent from Tutti's permission
+// tiers. Permissions are enforced through OpenCode's permission config plus
+// client-side resolution of ACP permission requests.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
+)
+
+const (
+	openCodePermissionReadOnly   = "read-only"
+	openCodePermissionAsk        = "ask"
+	openCodePermissionFullAccess = "full-access"
+	openCodePermissionEnv        = "OPENCODE_PERMISSION"
+)
+
+func newOpenCodeAdapterFromProviderDescriptor(
+	descriptor providerregistry.ProviderDescriptor,
+	transport ProcessTransport,
+	host HostMetadata,
+	commandResolver ProviderCommandResolver,
+) *standardACPAdapter {
+	adapter := newStandardACPAdapterFromProviderDescriptor(descriptor, transport, host, commandResolver)
+	settingsEnvironment := descriptor.Runtime.StandardACP.SettingsEnvironment
+	adapter.config.env = func(session Session) []string {
+		return standardACPEnv(session, host)
+	}
+	adapter.config.finalizeEnv = func(env []string, session Session) ([]string, error) {
+		return openCodeFinalEnv(settingsEnvironment, session, os.Getenv(settingsEnvironment.Variable), env)
+	}
+	adapter.config.automaticPermissionDecision = openCodeAutomaticPermissionDecision
+	adapter.config.filterPermissionOptions = openCodePermissionOptions
+	return adapter
+}
+
+func openCodeConfigContent(
+	descriptor providerregistry.RuntimeSettingsEnvironmentDescriptor,
+	session Session,
+	baseContent string,
+) (string, error) {
+	config := map[string]any{}
+	if strings.TrimSpace(baseContent) != "" {
+		if err := json.Unmarshal([]byte(baseContent), &config); err != nil {
+			return "", fmt.Errorf("decode %s: %w", descriptor.Variable, err)
+		}
+		if config == nil {
+			config = map[string]any{}
+		}
+	}
+	if settings := runtimeSettingsEnvironmentValue(descriptor, session); settings != "" {
+		var generated map[string]any
+		if err := json.Unmarshal([]byte(settings), &generated); err != nil {
+			return "", fmt.Errorf("decode generated %s: %w", descriptor.Variable, err)
+		}
+		for key, value := range generated {
+			config[key] = value
+		}
+	}
+	config["permission"] = openCodeInteractivePermissionRules()
+	agents, _ := config["agent"].(map[string]any)
+	if agents == nil {
+		agents = map[string]any{}
+	}
+	plan, _ := agents["plan"].(map[string]any)
+	if plan == nil {
+		plan = map[string]any{}
+	}
+	planPermission, _ := plan["permission"].(map[string]any)
+	if planPermission == nil {
+		planPermission = map[string]any{}
+	}
+	planPermission["edit"] = "deny"
+	plan["permission"] = planPermission
+	agents["plan"] = plan
+	config["agent"] = agents
+	data, err := json.Marshal(config)
+	if err != nil {
+		return "", fmt.Errorf("encode %s: %w", descriptor.Variable, err)
+	}
+	return string(data), nil
+}
+
+func openCodeFinalEnv(
+	descriptor providerregistry.RuntimeSettingsEnvironmentDescriptor,
+	session Session,
+	inheritedContent string,
+	env []string,
+) ([]string, error) {
+	variable := strings.TrimSpace(descriptor.Variable)
+	baseContent := inheritedContent
+	for index := len(env) - 1; index >= 0; index-- {
+		key, value, ok := strings.Cut(env[index], "=")
+		if ok && strings.EqualFold(strings.TrimSpace(key), variable) {
+			baseContent = value
+			break
+		}
+	}
+	content, err := openCodeConfigContent(descriptor, session, baseContent)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]string, 0, len(env)+1)
+	for _, item := range env {
+		key, _, ok := strings.Cut(item, "=")
+		if ok && (strings.EqualFold(strings.TrimSpace(key), variable) ||
+			strings.EqualFold(strings.TrimSpace(key), openCodePermissionEnv)) {
+			continue
+		}
+		result = append(result, item)
+	}
+	return append(result, openCodePermissionEnv+"={}", variable+"="+content), nil
+}
+
+// OpenCode's default policy allows most tools without consulting the ACP
+// client. This baseline keeps local read/search operations immediate while
+// routing every other tool through session/request_permission, which lets the
+// selected Tutti tier ask, approve, or deny it live. The protected .env rules
+// mirror OpenCode's built-in defaults.
+func openCodeInteractivePermissionRules() map[string]any {
+	return map[string]any{
+		"*":          "ask",
+		"glob":       "allow",
+		"grep":       "allow",
+		"list":       "allow",
+		"lsp":        "allow",
+		"plan_enter": "allow",
+		"plan_exit":  "allow",
+		"question":   "allow",
+		"read": map[string]any{
+			"*":             "allow",
+			"*.env":         "deny",
+			"*.env.*":       "deny",
+			"*.env.example": "allow",
+		},
+		"skill":     "allow",
+		"todowrite": "allow",
+	}
+}
+
+func openCodeAutomaticPermissionDecision(permissionModeID string) string {
+	switch strings.TrimSpace(permissionModeID) {
+	case openCodePermissionReadOnly:
+		return "denied"
+	case openCodePermissionFullAccess:
+		return "approved"
+	case openCodePermissionAsk:
+		return ""
+	default:
+		return ""
+	}
+}
+
+// "Always allow" mutates OpenCode's in-memory permission rules and cannot be
+// revoked by an ACP permission-tier change. Keep approvals one-shot so moving
+// from Ask or Full access to Read-only takes effect on the next request.
+func openCodePermissionOptions(options []map[string]any) []map[string]any {
+	result := make([]map[string]any, 0, len(options))
+	for _, option := range options {
+		kind := normalizePermissionOptionToken(asString(option["kind"]))
+		if kind == "allowalways" {
+			continue
+		}
+		result = append(result, option)
+	}
+	return result
+}

--- a/packages/agent/daemon/runtime/acp_provider_opencode_test.go
+++ b/packages/agent/daemon/runtime/acp_provider_opencode_test.go
@@ -2,8 +2,10 @@ package agentruntime
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 )
@@ -13,7 +15,7 @@ func newOpenCodeTestAdapter(transport ProcessTransport) *standardACPAdapter {
 	if !ok {
 		panic("opencode provider descriptor is missing")
 	}
-	return newStandardACPAdapterFromProviderDescriptor(
+	return newOpenCodeAdapterFromProviderDescriptor(
 		descriptor,
 		transport,
 		LegacyHostMetadata(),
@@ -31,17 +33,13 @@ func TestOpenCodeAdapterUsesOfficialACPCommand(t *testing.T) {
 	if len(adapter.config.command) != 2 || adapter.config.command[0] != "opencode" || adapter.config.command[1] != "acp" {
 		t.Fatalf("command = %#v, want opencode acp", adapter.config.command)
 	}
-	if got := adapter.config.permissionModeID("plan"); got != "plan" {
-		t.Fatalf("plan mode id = %q, want plan", got)
+	if adapter.config.planModeRuntimeID != "plan" || adapter.config.planModeDisabledRuntimeID != "build" {
+		t.Fatalf("plan mode ids = %q/%q, want plan/build", adapter.config.planModeRuntimeID, adapter.config.planModeDisabledRuntimeID)
 	}
-	if got := adapter.config.permissionModeID(""); got != "build" {
-		t.Fatalf("default mode id = %q, want build", got)
-	}
-	if got := adapter.config.permissionModeID("build"); got != "build" {
-		t.Fatalf("build mode id = %q, want build", got)
-	}
-	if got := adapter.config.permissionModeID("anything"); got != "" {
-		t.Fatalf("unknown mode id = %q, want empty", got)
+	for _, permissionModeID := range []string{"read-only", "ask", "full-access"} {
+		if got := adapter.config.permissionModeID(permissionModeID); got != "" {
+			t.Fatalf("permission mode %q mapped to ACP mode %q", permissionModeID, got)
+		}
 	}
 }
 
@@ -51,18 +49,185 @@ func TestOpenCodeACPEnvInjectsModelConfigContent(t *testing.T) {
 	session := standardTestSession(ProviderOpenCode)
 	session.Settings = &SessionSettings{Model: "anthropic/claude-sonnet-4-5"}
 
-	env := newOpenCodeTestAdapter(nil).config.env(session)
+	adapter := newOpenCodeTestAdapter(nil)
+	env, err := adapter.config.finalizeEnv(adapter.config.env(session), session)
+	if err != nil {
+		t.Fatalf("finalize OpenCode env: %v", err)
+	}
 	found := false
 	for _, item := range env {
 		if strings.HasPrefix(item, "OPENCODE_CONFIG_CONTENT=") {
 			found = true
-			if item != `OPENCODE_CONFIG_CONTENT={"model":"anthropic/claude-sonnet-4-5"}` {
-				t.Fatalf("OPENCODE_CONFIG_CONTENT = %q", item)
+			var config map[string]any
+			if err := json.Unmarshal([]byte(strings.TrimPrefix(item, "OPENCODE_CONFIG_CONTENT=")), &config); err != nil {
+				t.Fatalf("decode OPENCODE_CONFIG_CONTENT: %v", err)
+			}
+			if config["model"] != "anthropic/claude-sonnet-4-5" {
+				t.Fatalf("model config = %#v", config["model"])
+			}
+			permission, _ := config["permission"].(map[string]any)
+			if permission["*"] != "ask" || permission["glob"] != "allow" {
+				t.Fatalf("permission config = %#v", permission)
+			}
+			read, _ := permission["read"].(map[string]any)
+			if read["*.env"] != "deny" || read["*.env.example"] != "allow" {
+				t.Fatalf("read permission config = %#v", read)
+			}
+			agents, _ := config["agent"].(map[string]any)
+			plan, _ := agents["plan"].(map[string]any)
+			planPermission, _ := plan["permission"].(map[string]any)
+			if planPermission["edit"] != "deny" {
+				t.Fatalf("plan permission config = %#v", planPermission)
 			}
 		}
 	}
 	if !found {
 		t.Fatalf("env = %#v, want OPENCODE_CONFIG_CONTENT", env)
+	}
+}
+
+func TestOpenCodeACPEnvMergesUserConfigBeforeApplyingAuthoritativePermissions(t *testing.T) {
+	t.Parallel()
+
+	descriptor, ok := providerregistry.Find(ProviderOpenCode)
+	if !ok {
+		t.Fatal("opencode provider descriptor is missing")
+	}
+	session := standardTestSession(ProviderOpenCode)
+	session.Settings = &SessionSettings{Model: "openai/gpt-5"}
+	base := `{"theme":"system","model":"user/model","permission":{"bash":"allow"},"agent":{"plan":{"temperature":0.2,"permission":{"bash":"ask"}}}}`
+	env, err := openCodeFinalEnv(
+		descriptor.Runtime.StandardACP.SettingsEnvironment,
+		session,
+		`{"theme":"inherited"}`,
+		[]string{"KEEP=1", `OPENCODE_PERMISSION={"bash":"allow"}`, "OPENCODE_CONFIG_CONTENT=" + base},
+	)
+	if err != nil {
+		t.Fatalf("openCodeFinalEnv: %v", err)
+	}
+	if len(env) != 3 || env[0] != "KEEP=1" || env[1] != "OPENCODE_PERMISSION={}" || !strings.HasPrefix(env[2], "OPENCODE_CONFIG_CONTENT=") {
+		t.Fatalf("env = %#v, want neutral permission override and one final OpenCode config entry", env)
+	}
+	var config map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(env[2], "OPENCODE_CONFIG_CONTENT=")), &config); err != nil {
+		t.Fatalf("decode final OpenCode config: %v", err)
+	}
+	if config["theme"] != "system" || config["model"] != "openai/gpt-5" {
+		t.Fatalf("preserved/generated config = %#v", config)
+	}
+	permission, _ := config["permission"].(map[string]any)
+	if permission["*"] != "ask" || permission["bash"] == "allow" {
+		t.Fatalf("authoritative permission config = %#v", permission)
+	}
+	agents, _ := config["agent"].(map[string]any)
+	plan, _ := agents["plan"].(map[string]any)
+	planPermission, _ := plan["permission"].(map[string]any)
+	if plan["temperature"] != 0.2 || planPermission["bash"] != "ask" || planPermission["edit"] != "deny" {
+		t.Fatalf("merged plan config = %#v", plan)
+	}
+}
+
+func TestOpenCodeACPEnvRejectsInvalidUserConfig(t *testing.T) {
+	t.Parallel()
+
+	descriptor, ok := providerregistry.Find(ProviderOpenCode)
+	if !ok {
+		t.Fatal("opencode provider descriptor is missing")
+	}
+	_, err := openCodeFinalEnv(
+		descriptor.Runtime.StandardACP.SettingsEnvironment,
+		standardTestSession(ProviderOpenCode),
+		"",
+		[]string{"OPENCODE_CONFIG_CONTENT={invalid"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "decode OPENCODE_CONFIG_CONTENT") {
+		t.Fatalf("invalid config error = %v", err)
+	}
+}
+
+func TestOpenCodePermissionTiersResolveACPRequestsIndependentlyFromPlanMode(t *testing.T) {
+	t.Parallel()
+
+	adapter := newOpenCodeTestAdapter(nil)
+	if got := adapter.config.automaticPermissionDecision("read-only"); got != "denied" {
+		t.Fatalf("read-only decision = %q, want denied", got)
+	}
+	if got := adapter.config.automaticPermissionDecision("ask"); got != "" {
+		t.Fatalf("ask decision = %q, want prompt", got)
+	}
+	if got := adapter.config.automaticPermissionDecision("full-access"); got != "approved" {
+		t.Fatalf("full-access decision = %q, want approved", got)
+	}
+	if got := adapter.effectiveModeID(Session{PermissionModeID: "full-access", Settings: &SessionSettings{PlanMode: false}}); got != "build" {
+		t.Fatalf("build workflow mode = %q, want build", got)
+	}
+	if got := adapter.effectiveModeID(Session{PermissionModeID: "read-only", Settings: &SessionSettings{PlanMode: true}}); got != "plan" {
+		t.Fatalf("plan workflow mode = %q, want plan", got)
+	}
+}
+
+func TestOpenCodeAskPermissionOptionsExcludeIrrevocableAlwaysAllow(t *testing.T) {
+	t.Parallel()
+
+	options := openCodePermissionOptions([]map[string]any{
+		{"optionId": "once", "kind": "allow_once"},
+		{"optionId": "always", "kind": "allow_always"},
+		{"optionId": "reject", "kind": "reject_once"},
+	})
+	if len(options) != 2 || options[0]["optionId"] != "once" || options[1]["optionId"] != "reject" {
+		t.Fatalf("permission options = %#v, want once/reject", options)
+	}
+}
+
+func TestOpenCodeFullAccessSelectsOneShotApproval(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"options":[{"optionId":"always","kind":"allow_always"},{"optionId":"once","kind":"allow_once"}]}`)
+	optionID, ok := acpPermissionRequestDecisionOptionID(raw, "approved", openCodePermissionOptions)
+	if !ok || optionID != "once" {
+		t.Fatalf("automatic approval = %q/%t, want once/true", optionID, ok)
+	}
+}
+
+func TestOpenCodeAutomaticPermissionTiersResolveWithoutPrompt(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name     string
+		tier     string
+		optionID string
+	}{
+		{name: "read-only denies", tier: "read-only", optionID: "reject"},
+		{name: "full-access approves", tier: "full-access", optionID: "allow"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			transport := newStandardACPTransport("OpenCode", "opencode-session-automatic-permission")
+			transport.conn.promptPermission = true
+			adapter := newOpenCodeTestAdapter(transport)
+			session := standardTestSession(ProviderOpenCode)
+			session.PermissionModeID = testCase.tier
+			if _, err := adapter.Start(context.Background(), session); err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+			session.ProviderSessionID = "opencode-session-automatic-permission"
+
+			execDone := make(chan error, 1)
+			go func() {
+				_, err := adapter.Exec(context.Background(), session, textPrompt("run the build"), "", "turn-1", nil, nil)
+				execDone <- err
+			}()
+			select {
+			case err := <-execDone:
+				if err != nil {
+					t.Fatalf("Exec: %v", err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("Exec did not finish for %s", testCase.tier)
+			}
+			if got := transport.conn.permissionOptionID(); got != testCase.optionID {
+				t.Fatalf("permission option id = %q, want %q", got, testCase.optionID)
+			}
+		})
 	}
 }
 
@@ -129,6 +294,34 @@ func TestOpenCodeAdapterApplySessionSettingsTogglesPlanMode(t *testing.T) {
 	}
 	if transport.conn.lastModeID() != "build" {
 		t.Fatalf("mode id = %q, want build", transport.conn.lastModeID())
+	}
+}
+
+func TestOpenCodePermissionChangeDoesNotChangeACPWorkflowMode(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("OpenCode", "opencode-session-permission")
+	adapter := newOpenCodeTestAdapter(transport)
+	session := standardTestSession(ProviderOpenCode)
+	session.PermissionModeID = "ask"
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if transport.conn.lastModeID() != "build" {
+		t.Fatalf("initial mode id = %q, want build", transport.conn.lastModeID())
+	}
+
+	transport.conn.setModeError = &acpError{Code: -32000, Message: "session/set_mode must not be called"}
+	session.ProviderSessionID = "opencode-session-permission"
+	session.PermissionModeID = "full-access"
+	if err := adapter.ApplyPermissionMode(context.Background(), session); err != nil {
+		t.Fatalf("ApplyPermissionMode called ACP session/set_mode: %v", err)
+	}
+	if got := adapter.automaticPermissionDecision(session.AgentSessionID); got != "approved" {
+		t.Fatalf("live permission decision = %q, want approved", got)
+	}
+	if transport.conn.lastModeID() != "build" {
+		t.Fatalf("workflow mode changed to %q, want build", transport.conn.lastModeID())
 	}
 }
 

--- a/packages/agent/daemon/runtime/provider_descriptors.go
+++ b/packages/agent/daemon/runtime/provider_descriptors.go
@@ -62,6 +62,8 @@ func newAdapterFromProviderDescriptor(
 			return newNexightAdapterFromProviderDescriptor(descriptor, transport, host, commandResolver)
 		case providerregistry.StandardACPAdapterStrategyOpenClaw:
 			return newOpenClawAdapterFromProviderDescriptor(descriptor, transport, host, commandResolver)
+		case providerregistry.StandardACPAdapterStrategyOpenCode:
+			return newOpenCodeAdapterFromProviderDescriptor(descriptor, transport, host, commandResolver)
 		default:
 			return nil
 		}
@@ -107,8 +109,11 @@ func newStandardACPAdapterFromProviderDescriptor(
 				}
 				return env
 			},
-			commandResolver:    commandResolver,
-			planModeRuntimeID:  strings.TrimSpace(standardACP.PlanModeRuntimeID),
+			commandResolver:   commandResolver,
+			planModeRuntimeID: strings.TrimSpace(standardACP.PlanModeRuntimeID),
+			planModeDisabledRuntimeID: strings.TrimSpace(
+				standardACP.PlanModeDisabledRuntimeID,
+			),
 			projectCurrentMode: standardACP.ProjectCurrentMode,
 			startupDiagnostics: standardACP.StartupDiagnostics,
 		},

--- a/packages/agent/daemon/runtime/provider_descriptors_test.go
+++ b/packages/agent/daemon/runtime/provider_descriptors_test.go
@@ -1,6 +1,7 @@
 package agentruntime
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -90,6 +91,22 @@ func TestMigratedCodexDescriptorOwnsPermissionModes(t *testing.T) {
 	}
 }
 
+func TestMigratedOpenCodeDescriptorOwnsPermissionModes(t *testing.T) {
+	if got := defaultPermissionModeIDForProvider(ProviderOpenCode); got != "ask" {
+		t.Fatalf("default permission mode = %q, want ask", got)
+	}
+	for _, mode := range []string{"read-only", "ask", "full-access"} {
+		if !permissionModeIDAllowedForProvider(ProviderOpenCode, mode) {
+			t.Fatalf("permission mode %q rejected", mode)
+		}
+	}
+	for _, workflowMode := range []string{"build", "plan"} {
+		if permissionModeIDAllowedForProvider(ProviderOpenCode, workflowMode) {
+			t.Fatalf("workflow mode %q accepted as a permission mode", workflowMode)
+		}
+	}
+}
+
 func TestMigratedOpenCodeDescriptorBuildsStandardACPAdapter(t *testing.T) {
 	descriptor, ok := providerregistry.Find(ProviderOpenCode)
 	if !ok {
@@ -97,7 +114,7 @@ func TestMigratedOpenCodeDescriptorBuildsStandardACPAdapter(t *testing.T) {
 	}
 	descriptor.Runtime.Name = "descriptor-opencode-acp"
 	descriptor.Runtime.Command = []string{"descriptor-opencode", "acp"}
-	descriptor.Runtime.StandardACP.PermissionModes[0].RuntimeID = "descriptor-build"
+	descriptor.Runtime.StandardACP.PlanModeDisabledRuntimeID = "descriptor-build"
 	descriptor.Runtime.StandardACP.SettingsEnvironment.Variable = "DESCRIPTOR_CONFIG"
 	descriptor.Runtime.StandardACP.SettingsEnvironment.JSONFields[0].JSONKey = "descriptorModel"
 	adapter := newAdapterFromProviderDescriptor(
@@ -113,16 +130,26 @@ func TestMigratedOpenCodeDescriptorBuildsStandardACPAdapter(t *testing.T) {
 	if standardAdapter.Provider() != ProviderOpenCode ||
 		standardAdapter.config.adapterName != "descriptor-opencode-acp" ||
 		standardAdapter.config.command[0] != "descriptor-opencode" ||
-		standardAdapter.config.permissionModeID("") != "descriptor-build" {
+		standardAdapter.config.planModeDisabledRuntimeID != "descriptor-build" ||
+		standardAdapter.config.permissionModeID("ask") != "" {
 		t.Fatalf("adapter config = %#v", standardAdapter.config)
 	}
 	session := standardTestSession(ProviderOpenCode)
 	session.Settings = &SessionSettings{Model: "openai/descriptor-model"}
-	environment := standardAdapter.config.env(session)
-	if !containsStringWithPrefix(
-		environment,
-		`DESCRIPTOR_CONFIG={"descriptorModel":"openai/descriptor-model"}`,
-	) {
+	environment, err := standardAdapter.config.finalizeEnv(standardAdapter.config.env(session), session)
+	if err != nil {
+		t.Fatalf("finalize descriptor environment: %v", err)
+	}
+	var descriptorConfig map[string]any
+	for _, item := range environment {
+		if !strings.HasPrefix(item, "DESCRIPTOR_CONFIG=") {
+			continue
+		}
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(item, "DESCRIPTOR_CONFIG=")), &descriptorConfig); err != nil {
+			t.Fatalf("decode descriptor config: %v", err)
+		}
+	}
+	if descriptorConfig["descriptorModel"] != "openai/descriptor-model" {
 		t.Fatalf("adapter environment = %#v", environment)
 	}
 }
@@ -157,13 +184,4 @@ func TestDefaultControllerRegistersEveryMigratedProviderDescriptor(t *testing.T)
 	if len(controller.adapters) != len(providerregistry.Migrated()) {
 		t.Fatalf("controller adapters = %d, migrated descriptors = %d", len(controller.adapters), len(providerregistry.Migrated()))
 	}
-}
-
-func containsStringWithPrefix(values []string, prefix string) bool {
-	for _, value := range values {
-		if strings.HasPrefix(value, prefix) {
-			return true
-		}
-	}
-	return false
 }

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -40,21 +40,29 @@ type standardACPConfig struct {
 	// the resolved command (e.g. codex-acp `--config model=...` flags that can
 	// only be applied at process start).
 	commandWithSettings func([]string, Session) []string
+	// finalizeEnv applies provider-owned environment composition after session,
+	// target, and managed-runtime overrides have been resolved.
+	finalizeEnv func([]string, Session) ([]string, error)
 	// requiresNewSessionForSettings reports settings patches that can only
 	// take effect via a fresh process/session (spawn-time-only flags).
 	requiresNewSessionForSettings func(Session, SessionSettingsPatch) bool
-	// autoApprovePermissionDecision lets a provider resolve incoming
+	// automaticPermissionDecision lets a provider resolve incoming
 	// session/request_permission requests without prompting, from the live
-	// permission tier (e.g. Cursor "full access"). It returns a decision
+	// permission tier. It returns a decision
 	// token ("approved" / "denied") to apply automatically, or "" to prompt
 	// the user as usual. Nil (the default) always prompts.
-	autoApprovePermissionDecision func(permissionModeID string) string
+	automaticPermissionDecision func(permissionModeID string) string
+	// filterPermissionOptions narrows provider-offered approval choices before
+	// they become a durable interaction. Providers use it only when an option
+	// would conflict with live permission-tier semantics.
+	filterPermissionOptions func([]map[string]any) []map[string]any
 	// autoContinueRetriableTurnError resumes turns the agent ends "normally"
 	// right after streaming a transient network error as plain text (Cursor's
 	// "Error: RetriableError: ..." tail). See acp_auto_continue.go.
 	autoContinueRetriableTurnError bool
 	applySessionMeta               func(map[string]any, Session, HostMetadata)
 	planModeRuntimeID              string
+	planModeDisabledRuntimeID      string
 	projectCurrentMode             bool
 	startupDiagnostics             bool
 	toolAliases                    map[string]string
@@ -96,9 +104,9 @@ type standardACPSession struct {
 	// lifecycleSeq orders provider-agnostic authoritative turn snapshots
 	// emitted by the standard ACP adapter (ADR 0008).
 	lifecycleSeq uint64
-	// permissionModeID tracks the session's live permission tier so an
-	// auto-approve tier (e.g. Cursor "full access") applies to permission
-	// requests immediately after a mid-session tier change, without a respawn.
+	// permissionModeID tracks the session's live permission tier so automatic
+	// approval or denial applies immediately after a mid-session tier change,
+	// without a respawn.
 	permissionModeID string
 }
 

--- a/packages/agent/daemon/runtime/standard_acp_events.go
+++ b/packages/agent/daemon/runtime/standard_acp_events.go
@@ -299,6 +299,9 @@ func standardACPPermissionRequested(
 	if err := json.Unmarshal(raw, &params); err != nil {
 		return nil, nil, fmt.Errorf("invalid permission request: %w", err)
 	}
+	if adapter != nil && adapter.config.filterPermissionOptions != nil {
+		params.Options = adapter.config.filterPermissionOptions(params.Options)
+	}
 	requestID := acpRequestID(rawRequestID)
 	if requestID == "" {
 		return nil, nil, errors.New("permission request id is required")

--- a/packages/agent/daemon/runtime/standard_acp_session.go
+++ b/packages/agent/daemon/runtime/standard_acp_session.go
@@ -118,8 +118,8 @@ func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]acti
 		})
 		return nil, err
 	}
-	if err := a.applyPermissionMode(ctx, client, session); err != nil {
-		a.logHermesStartupDiagnostics("permission_mode.failed", map[string]any{
+	if err := a.applyACPMode(ctx, client, session, a.effectiveModeID(session)); err != nil {
+		a.logHermesStartupDiagnostics("session_mode.failed", map[string]any{
 			"room_id":             session.RoomID,
 			"agent_session_id":    session.AgentSessionID,
 			"provider_session_id": session.ProviderSessionID,
@@ -209,7 +209,7 @@ func (a *standardACPAdapter) Resume(ctx context.Context, session Session) error 
 	if err := a.applySessionConfigOptions(ctx, client, session, loadSessionResult); err != nil {
 		return err
 	}
-	if err := a.applyPermissionMode(ctx, client, session); err != nil {
+	if err := a.applyACPMode(ctx, client, session, a.effectiveModeID(session)); err != nil {
 		return err
 	}
 	started = true
@@ -358,6 +358,13 @@ func (a *standardACPAdapter) startInitializedClient(
 			"error":            err.Error(),
 		})
 		return nil, nil, err
+	}
+	if a.config.finalizeEnv != nil {
+		spec.Env, err = a.config.finalizeEnv(spec.Env, session)
+		if err != nil {
+			cleanupPreparedLaunch(cleanup)
+			return nil, nil, err
+		}
 	}
 	processStartedAt := time.Now()
 	a.logHermesStartupDiagnostics("process_start.start", map[string]any{

--- a/packages/agent/daemon/runtime/standard_acp_settings.go
+++ b/packages/agent/daemon/runtime/standard_acp_settings.go
@@ -10,10 +10,9 @@ import (
 	"time"
 )
 
-func (a *standardACPAdapter) applyPermissionMode(ctx context.Context, client *acpClient, session Session) error {
-	modeID := a.effectiveModeID(session)
+func (a *standardACPAdapter) applyACPMode(ctx context.Context, client *acpClient, session Session, modeID string) error {
 	if modeID == "" {
-		a.logHermesStartupDiagnostics("permission_mode.skipped", map[string]any{
+		a.logHermesStartupDiagnostics("session_mode.skipped", map[string]any{
 			"room_id":             session.RoomID,
 			"agent_session_id":    session.AgentSessionID,
 			"provider_session_id": session.ProviderSessionID,
@@ -31,8 +30,8 @@ func (a *standardACPAdapter) applyPermissionMode(ctx context.Context, client *ac
 		}
 	}
 	setModeStartedAt := time.Now()
-	slog.Info("agent session ACP permission mode update started",
-		"event", "agent_session.acp.permission_mode.start",
+	slog.Info("agent session ACP mode update started",
+		"event", "agent_session.acp.session_mode.start",
 		"provider", a.config.provider,
 		"agent_session_id", session.AgentSessionID,
 		"provider_session_id", session.ProviderSessionID,
@@ -40,7 +39,7 @@ func (a *standardACPAdapter) applyPermissionMode(ctx context.Context, client *ac
 		"mode_id", modeID,
 		"timeout_ms", acpPermissionModeTimeout.Milliseconds(),
 	)
-	a.logHermesStartupDiagnostics("permission_mode.start", map[string]any{
+	a.logHermesStartupDiagnostics("session_mode.start", map[string]any{
 		"room_id":             session.RoomID,
 		"agent_session_id":    session.AgentSessionID,
 		"provider_session_id": session.ProviderSessionID,
@@ -53,7 +52,7 @@ func (a *standardACPAdapter) applyPermissionMode(ctx context.Context, client *ac
 		return err
 	})
 	if err != nil {
-		a.logHermesStartupDiagnostics("permission_mode.unconfirmed", map[string]any{
+		a.logHermesStartupDiagnostics("session_mode.unconfirmed", map[string]any{
 			"room_id":             session.RoomID,
 			"agent_session_id":    session.AgentSessionID,
 			"provider_session_id": session.ProviderSessionID,
@@ -63,10 +62,10 @@ func (a *standardACPAdapter) applyPermissionMode(ctx context.Context, client *ac
 			"error":               err.Error(),
 		})
 		if a.config.failOnSetModeError {
-			return fmt.Errorf("agent session ACP permission mode confirmation failed: %w", err)
+			return fmt.Errorf("agent session ACP mode confirmation failed: %w", err)
 		}
-		slog.Warn("agent session ACP permission mode was not confirmed; continuing",
-			"event", "agent_session.acp.permission_mode.unconfirmed",
+		slog.Warn("agent session ACP mode was not confirmed; continuing",
+			"event", "agent_session.acp.session_mode.unconfirmed",
 			"provider", a.config.provider,
 			"agent_session_id", session.AgentSessionID,
 			"provider_session_id", session.ProviderSessionID,
@@ -76,8 +75,8 @@ func (a *standardACPAdapter) applyPermissionMode(ctx context.Context, client *ac
 		)
 		return nil
 	}
-	slog.Info("agent session ACP permission mode update succeeded",
-		"event", "agent_session.acp.permission_mode.succeeded",
+	slog.Info("agent session ACP mode update succeeded",
+		"event", "agent_session.acp.session_mode.succeeded",
 		"provider", a.config.provider,
 		"agent_session_id", session.AgentSessionID,
 		"provider_session_id", session.ProviderSessionID,
@@ -85,7 +84,7 @@ func (a *standardACPAdapter) applyPermissionMode(ctx context.Context, client *ac
 		"mode_id", modeID,
 		"elapsed_ms", time.Since(setModeStartedAt).Milliseconds(),
 	)
-	a.logHermesStartupDiagnostics("permission_mode.succeeded", map[string]any{
+	a.logHermesStartupDiagnostics("session_mode.succeeded", map[string]any{
 		"room_id":             session.RoomID,
 		"agent_session_id":    session.AgentSessionID,
 		"provider_session_id": session.ProviderSessionID,
@@ -320,7 +319,7 @@ func (a *standardACPAdapter) ApplySessionSettings(
 	}
 
 	if patch.PlanMode != nil {
-		if err := a.applyPermissionMode(ctx, acpSession.client, session); err != nil {
+		if err := a.applyACPMode(ctx, acpSession.client, session, a.effectiveModeID(session)); err != nil {
 			return err
 		}
 	}
@@ -397,10 +396,13 @@ func (a *standardACPAdapter) ApplyPermissionMode(ctx context.Context, session Se
 	if strings.TrimSpace(session.ProviderSessionID) == "" {
 		session.ProviderSessionID = acpSession.providerSessionID
 	}
-	// Track the live tier so auto-approve tiers (Cursor "full access") take
-	// effect on subsequent permission requests without a respawn.
+	// Track the live tier so automatic decisions (for example full-access
+	// approval or read-only denial) affect subsequent requests without respawn.
 	a.setSessionPermissionModeID(session.AgentSessionID, session.PermissionModeID)
-	return a.applyPermissionMode(ctx, acpSession.client, session)
+	if a.config.permissionModeID == nil || a.config.permissionModeID(session.PermissionModeID) == "" {
+		return nil
+	}
+	return a.applyACPMode(ctx, acpSession.client, session, a.effectiveModeID(session))
 }
 
 func (a *standardACPAdapter) setSessionPermissionModeID(agentSessionID string, permissionModeID string) {
@@ -414,11 +416,10 @@ func (a *standardACPAdapter) setSessionPermissionModeID(agentSessionID string, p
 	}
 }
 
-// autoApprovePermissionDecision resolves the decision the provider's
-// auto-approve tier applies to a permission request for this session, or ""
-// to prompt the user. Reads the live tier so a mid-session change is honored.
-func (a *standardACPAdapter) autoApprovePermissionDecision(agentSessionID string) string {
-	if a == nil || a.config.autoApprovePermissionDecision == nil {
+// automaticPermissionDecision resolves the decision the provider's live
+// permission tier applies to a permission request, or "" to prompt the user.
+func (a *standardACPAdapter) automaticPermissionDecision(agentSessionID string) string {
+	if a == nil || a.config.automaticPermissionDecision == nil {
 		return ""
 	}
 	a.mu.Lock()
@@ -428,7 +429,7 @@ func (a *standardACPAdapter) autoApprovePermissionDecision(agentSessionID string
 		permissionModeID = session.permissionModeID
 	}
 	a.mu.Unlock()
-	return a.config.autoApprovePermissionDecision(permissionModeID)
+	return a.config.automaticPermissionDecision(permissionModeID)
 }
 
 func (a *standardACPAdapter) effectiveModeID(session Session) string {
@@ -442,6 +443,9 @@ func (a *standardACPAdapter) effectiveModeID(session Session) string {
 		if modeID := a.config.permissionModeID("plan"); modeID != "" {
 			return modeID
 		}
+	}
+	if a.config.planModeDisabledRuntimeID != "" {
+		return a.config.planModeDisabledRuntimeID
 	}
 	return a.config.permissionModeID(session.PermissionModeID)
 }

--- a/packages/agent/daemon/runtime/standard_acp_stream.go
+++ b/packages/agent/daemon/runtime/standard_acp_stream.go
@@ -97,14 +97,18 @@ func (a *standardACPAdapter) handleACPMessage(
 			_ = client.Respond(ctx, message.ID, nil, &acpError{Code: -32000, Message: err.Error()})
 			return nil, err
 		}
-		// Auto-approve tiers (e.g. Cursor "full access") resolve the request
-		// from the live permission tier without prompting; the tool call still
-		// streams its own activity via session/update.
-		if decision := a.autoApprovePermissionDecision(session.AgentSessionID); decision != "" {
-			if optionID, ok := acpPermissionRequestDecisionOptionID(message.Params, decision); ok {
+		// Automatic tiers resolve the request from the live permission tier
+		// without prompting; the tool call still streams its own activity via
+		// session/update.
+		if decision := a.automaticPermissionDecision(session.AgentSessionID); decision != "" {
+			if optionID, ok := acpPermissionRequestDecisionOptionID(
+				message.Params,
+				decision,
+				a.config.filterPermissionOptions,
+			); ok {
 				if err := client.Respond(ctx, message.ID, acpPermissionResponseResult(optionID), nil); err != nil {
-					slog.Warn("agent session ACP auto-approve response failed",
-						"event", "agent_session.acp.permission.auto_approve_response_failed",
+					slog.Warn("agent session ACP automatic permission response failed",
+						"event", "agent_session.acp.permission.automatic_response_failed",
 						"provider", a.config.provider,
 						"adapter", a.config.adapterName,
 						"room_id", session.RoomID,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.spec.ts
@@ -101,6 +101,43 @@ describe("permissionModeOptions", () => {
       }
     ]);
   });
+
+  it("presents OpenCode permissions independently from Plan mode", () => {
+    const permissionConfig: AgentSessionPermissionConfig = {
+      configurable: true,
+      defaultValue: "ask",
+      modes: [
+        {
+          id: "read-only",
+          label: "Read-only",
+          description: "Read-only",
+          semantic: "locked-down"
+        },
+        {
+          id: "ask",
+          label: "Ask",
+          description: "Ask",
+          semantic: "ask-before-write"
+        },
+        {
+          id: "full-access",
+          label: "Full access",
+          description: "Full access",
+          semantic: "full-access"
+        }
+      ]
+    };
+
+    expect(permissionModeOptions("opencode", permissionConfig)).toEqual([
+      expect.objectContaining({ value: "read-only", label: "Read-only" }),
+      expect.objectContaining({ value: "ask", label: "Ask" }),
+      expect.objectContaining({
+        value: "full-access",
+        label: "Full access",
+        description: expect.stringContaining("separate Plan mode")
+      })
+    ]);
+  });
 });
 
 describe("model reasoning options", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.spec.tsx
@@ -27,7 +27,7 @@ describe("AgentGUIConversationRailItem interaction lock", () => {
     expect(container.querySelector(".agent-rich-text-readonly")).toBeNull();
   });
 
-  it("adds the conversation icon only for a projected session reference", () => {
+  it("keeps a projected session reference as @ text without a mention icon", () => {
     const { container } = renderRailItem({
       isRailInteractionLocked: () => false,
       item: {
@@ -40,23 +40,22 @@ describe("AgentGUIConversationRailItem interaction lock", () => {
       container.querySelector(
         '[data-agent-gui-conversation-title-mention-icon="session"]'
       )
-    ).not.toBeNull();
+    ).toBeNull();
     expect(
       container.querySelectorAll(
         "[data-agent-gui-conversation-title-mention-icon]"
       )
-    ).toHaveLength(1);
-    expect(container.textContent).toContain("读一下我本地的桌面");
-    expect(container.textContent).not.toContain("@读一下我本地的桌面");
+    ).toHaveLength(0);
+    expect(container.textContent).toContain("@读一下我本地的桌面");
   });
 
-  it.each(["app", "file", "agent"] as const)(
-    "adds the %s icon for that projected reference",
+  it.each(["app", "agent"] as const)(
+    "keeps a projected %s reference as @ text without a mention icon",
     (kind) => {
       const { container } = renderRailItem({
         isRailInteractionLocked: () => false,
         item: {
-          title: "Inspect reference",
+          title: "@Inspect reference",
           titleLeadingMentionKind: kind
         }
       });
@@ -65,9 +64,28 @@ describe("AgentGUIConversationRailItem interaction lock", () => {
         container.querySelector(
           `[data-agent-gui-conversation-title-mention-icon="${kind}"]`
         )
-      ).not.toBeNull();
+      ).toBeNull();
+      expect(container.textContent).toContain("@Inspect reference");
     }
   );
+
+  it("keeps the file marker for a projected file reference", () => {
+    const { container } = renderRailItem({
+      isRailInteractionLocked: () => false,
+      item: {
+        title: "@notes.md inspect",
+        titleLeadingMentionKind: "file"
+      }
+    });
+
+    expect(
+      container.querySelector(
+        '[data-agent-gui-conversation-title-mention-icon="file"]'
+      )
+    ).not.toBeNull();
+    expect(container.textContent).toContain("notes.md inspect");
+    expect(container.textContent).not.toContain("@notes.md inspect");
+  });
 
   it("leaves an ordinary conversation row unchanged", () => {
     const { container } = renderRailItem({

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.tsx
@@ -13,11 +13,8 @@ import {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuTrigger,
-  AgentSessionsIcon,
   FileIcon,
   IssueIcon,
-  NavAgentsIcon,
-  NavApplicationsLinedIcon,
   NewWorkspaceLinedIcon,
   cn
 } from "@tutti-os/ui-system";
@@ -43,6 +40,10 @@ import type { UiLanguage } from "../../../contexts/settings/domain/agentSettings
 import type { AgentGUIViewLabels } from "../AgentGUINodeView";
 import styles from "../AgentGUINode.styles";
 import { conversationPlainTitle } from "./agentGUIViewUtils";
+import {
+  isAgentGUIConversationTitleIconMentionKind,
+  type AgentGUIConversationTitleIconMentionKind
+} from "../../../shared/agentConversationTitleProjection";
 
 function agentGUIConversationIconUrl(
   provider: string | undefined,
@@ -68,7 +69,11 @@ function agentGUIConversationRailTitle(
   uiLanguage: UiLanguage
 ): string {
   const title = conversationPlainTitle(item, labels, uiLanguage);
-  return item.titleLeadingMentionKind ? title.replace(/^@\s*/, "") : title;
+  return isAgentGUIConversationTitleIconMentionKind(
+    item.titleLeadingMentionKind
+  )
+    ? title.replace(/^@\s*/, "")
+    : title;
 }
 
 interface AgentGUIConversationRailItemProps {
@@ -299,7 +304,9 @@ export const AgentGUIConversationRailItem = memo(
                 }
               />
             ) : null}
-            {item.titleLeadingMentionKind ? (
+            {isAgentGUIConversationTitleIconMentionKind(
+              item.titleLeadingMentionKind
+            ) ? (
               <span
                 aria-hidden="true"
                 className={styles.conversationTitleMentionIcon}
@@ -469,15 +476,10 @@ export const AgentGUIConversationRailItem = memo(
 function ConversationTitleMentionIcon({
   kind
 }: {
-  kind: NonNullable<
-    AgentGUINodeViewModel["rail"]["conversations"][number]["titleLeadingMentionKind"]
-  >;
+  kind: AgentGUIConversationTitleIconMentionKind;
 }): ReactNode {
   if (kind === "task") return <IssueIcon />;
-  if (kind === "app") return <NavApplicationsLinedIcon />;
-  if (kind === "file") return <FileIcon />;
-  if (kind === "agent") return <NavAgentsIcon />;
-  return <AgentSessionsIcon />;
+  return <FileIcon />;
 }
 
 export function AgentGUIProjectRailHeader({

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -3933,6 +3933,14 @@ aside.workspace-agents-status-panel
 }
 
 .workspace-agents-status-panel__detail-user-message
+  .agent-rich-text-mention-node {
+  /* Avoid a percentage max-width feeding the mention's untruncated intrinsic
+     width back into the fit-content message bubble. The nested pill still
+     shrinks against this wrapper when the available line is narrower. */
+  max-width: var(--agent-mention-max-width, 16rem);
+}
+
+.workspace-agents-status-panel__detail-user-message
   .tsh-agent-object-token--file {
   --agent-mention-file-icon-size: 16px;
 }

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -120,6 +120,23 @@ export const enAgentGui = {
           "Runs commands without asking, unless explicitly denied by your Cursor permission rules."
       }
     },
+    opencode: {
+      "read-only": {
+        label: "Read-only",
+        description:
+          "Reads and searches the local project, but denies edits, commands, network access, and other approval-gated actions."
+      },
+      ask: {
+        label: "Ask",
+        description:
+          "Reads and searches directly, then asks before edits, commands, network access, and other gated actions."
+      },
+      "full-access": {
+        label: "Full access",
+        description:
+          "Automatically allows gated actions without changing OpenCode's separate Plan mode restrictions."
+      }
+    },
     nexight: {
       "read-only": {
         label: "Ask for approval",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -113,6 +113,22 @@ export const zhCNAgentGui = {
           "无需询问直接运行命令，除非被你的 Cursor 权限规则明确拒绝。"
       }
     },
+    opencode: {
+      "read-only": {
+        label: "只读",
+        description:
+          "允许读取和搜索本地项目，拒绝修改、命令、网络及其他需授权操作"
+      },
+      ask: {
+        label: "询问",
+        description: "读取和搜索直接执行，修改、命令、网络及其他操作会先询问你"
+      },
+      "full-access": {
+        label: "完全访问",
+        description:
+          "自动允许需授权操作，但不会改变 OpenCode 独立的 Plan 模式限制"
+      }
+    },
     nexight: {
       "read-only": {
         label: "请求批准",

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.spec.tsx
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.spec.tsx
@@ -233,7 +233,7 @@ describe("useAgentGuiConversationList", () => {
     expect(result.current?.conversations[0]).toEqual(
       expect.objectContaining({
         title: "@Previous chat 看看",
-        titleLeadingMentionKind: "session"
+        titleLeadingMentionKind: null
       })
     );
   });

--- a/packages/agent/gui/shared/agentConversationTitleProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversationTitleProjection.spec.ts
@@ -38,19 +38,22 @@ describe("resolveAgentGUIConversationTitleLeadingMentionKind", () => {
   });
 
   it("keeps session, app, and Agent references out of rich titles", () => {
-    for (const [displayPrompt, title] of [
-      [
-        "[@Conversation](mention://agent-session/session-1?workspaceId=workspace-1) follow up",
-        "@Conversation follow up"
-      ],
-      [
-        "[@Weather](mention://workspace-app/weather?workspaceId=workspace-1) inspect",
-        "@Weather inspect"
-      ],
-      [
-        "[@Codex](mention://agent-target/local%3Acodex?workspaceId=workspace-1) inspect",
-        "@Codex inspect"
-      ]
+    for (const { displayPrompt, title } of [
+      {
+        displayPrompt:
+          "[@Conversation](mention://agent-session/session-1?workspaceId=workspace-1) follow up",
+        title: "@Conversation follow up"
+      },
+      {
+        displayPrompt:
+          "[@Weather](mention://workspace-app/weather?workspaceId=workspace-1) inspect",
+        title: "@Weather inspect"
+      },
+      {
+        displayPrompt:
+          "[@Codex](mention://agent-target/local%3Acodex?workspaceId=workspace-1) inspect",
+        title: "@Codex inspect"
+      }
     ]) {
       expect(
         resolveAgentGUIConversationTitleDisplayPrompt({

--- a/packages/agent/gui/shared/agentConversationTitleProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversationTitleProjection.spec.ts
@@ -6,12 +6,12 @@ import {
 } from "./agentConversationTitleProjection";
 
 describe("resolveAgentGUIConversationTitleLeadingMentionKind", () => {
-  it("maps the first session and task references to rail marker kinds", () => {
+  it("keeps session references textual while mapping task references to rail markers", () => {
     expect(
       resolveAgentGUIConversationTitleLeadingMentionKind(
         "[@Conversation](mention://agent-session/session-1?workspaceId=workspace-1) follow up"
       )
-    ).toBe("session");
+    ).toBeNull();
     expect(
       resolveAgentGUIConversationTitleLeadingMentionKind(
         "[@Task](mention://workspace-issue/issue-1?workspaceId=workspace-1) inspect"
@@ -19,12 +19,12 @@ describe("resolveAgentGUIConversationTitleLeadingMentionKind", () => {
     ).toBe("task");
   });
 
-  it("maps app, file, and Agent references to rail marker kinds", () => {
+  it("keeps app and Agent references textual while mapping files to rail markers", () => {
     expect(
       resolveAgentGUIConversationTitleLeadingMentionKind(
         "[@Weather](mention://workspace-app/weather?workspaceId=workspace-1) inspect"
       )
-    ).toBe("app");
+    ).toBeNull();
     expect(
       resolveAgentGUIConversationTitleLeadingMentionKind(
         "[@notes.md](/workspace/notes.md) inspect"
@@ -34,7 +34,31 @@ describe("resolveAgentGUIConversationTitleLeadingMentionKind", () => {
       resolveAgentGUIConversationTitleLeadingMentionKind(
         "[@Codex](mention://agent-target/local%3Acodex?workspaceId=workspace-1) inspect"
       )
-    ).toBe("agent");
+    ).toBeNull();
+  });
+
+  it("keeps session, app, and Agent references out of rich titles", () => {
+    for (const [displayPrompt, title] of [
+      [
+        "[@Conversation](mention://agent-session/session-1?workspaceId=workspace-1) follow up",
+        "@Conversation follow up"
+      ],
+      [
+        "[@Weather](mention://workspace-app/weather?workspaceId=workspace-1) inspect",
+        "@Weather inspect"
+      ],
+      [
+        "[@Codex](mention://agent-target/local%3Acodex?workspaceId=workspace-1) inspect",
+        "@Codex inspect"
+      ]
+    ]) {
+      expect(
+        resolveAgentGUIConversationTitleDisplayPrompt({
+          firstUserDisplayPrompt: displayPrompt,
+          title
+        })
+      ).toBeNull();
+    }
   });
 
   it("keeps browser elements in the rich header title without adding a rail marker", () => {

--- a/packages/agent/gui/shared/agentConversationTitleProjection.ts
+++ b/packages/agent/gui/shared/agentConversationTitleProjection.ts
@@ -23,6 +23,10 @@ export type AgentGUIConversationTitleLeadingMentionKind =
   | "file"
   | "session"
   | "task";
+export type AgentGUIConversationTitleIconMentionKind = Extract<
+  AgentGUIConversationTitleLeadingMentionKind,
+  "file" | "task"
+>;
 
 const AGENT_GUI_UNRESOLVED_PROVIDER: AgentGUIResolvedProvider = "unknown";
 const AGENT_GUI_MAX_OPTIMISTIC_TITLE_CODE_POINTS = 120;
@@ -189,11 +193,19 @@ export function resolveAgentGUIConversationTitleLeadingMentionKind(
   const mentionKind = firstMention
     ? agentGUIConversationTitleMentionKind(firstMention)
     : null;
-  if (mentionKind) return mentionKind;
+  if (isAgentGUIConversationTitleIconMentionKind(mentionKind)) {
+    return mentionKind;
+  }
   if (firstMention) return null;
   return extractRichTextLinksFromContent(displayPrompt).length > 0
     ? "file"
     : null;
+}
+
+export function isAgentGUIConversationTitleIconMentionKind(
+  kind: AgentGUIConversationTitleLeadingMentionKind | null | undefined
+): kind is AgentGUIConversationTitleIconMentionKind {
+  return kind === "file" || kind === "task";
 }
 
 function agentGUIConversationTitleMentionKind(
@@ -230,9 +242,14 @@ function isAgentGUIConversationTitleDisplayPromptEligible(
   const mentions = extractRichTextMentionsFromContent(displayPrompt);
   if (
     mentions.some(
-      (mention) =>
-        mention.providerId !== "browser-element" &&
-        agentGUIConversationTitleMentionKind(mention) === null
+      (mention) => {
+        if (mention.providerId === "browser-element") {
+          return false;
+        }
+        return !isAgentGUIConversationTitleIconMentionKind(
+          agentGUIConversationTitleMentionKind(mention)
+        );
+      }
     )
   ) {
     return false;

--- a/services/tuttid/service/agent/composer_options_test.go
+++ b/services/tuttid/service/agent/composer_options_test.go
@@ -211,6 +211,34 @@ func TestComposerPermissionConfigForCursor(t *testing.T) {
 	}
 }
 
+func TestComposerPermissionConfigForOpenCodeIsIndependentFromPlanMode(t *testing.T) {
+	t.Parallel()
+	config := composerPermissionConfig("opencode", "", "en")
+	if !config.Configurable {
+		t.Fatal("opencode permission config must be configurable")
+	}
+	if config.DefaultValue != "ask" {
+		t.Fatalf("opencode default permission mode = %q, want ask", config.DefaultValue)
+	}
+	ids := make([]string, 0, len(config.Modes))
+	for _, mode := range config.Modes {
+		ids = append(ids, mode.ID)
+	}
+	if !slices.Equal(ids, []string{"read-only", "ask", "full-access"}) {
+		t.Fatalf("opencode permission mode ids = %v, want [read-only ask full-access]", ids)
+	}
+	if got := normalizePermissionModeIDForProvider("opencode", "plan"); got != "ask" {
+		t.Fatalf("OpenCode workflow mode leaked into permission mode: %q", got)
+	}
+	settings := normalizeComposerSettingsForProvider("opencode", ComposerSettings{
+		PermissionModeID: "full-access",
+		PlanMode:         true,
+	})
+	if settings.PermissionModeID != "full-access" || !settings.PlanMode {
+		t.Fatalf("OpenCode permission/plan settings are not independent: %#v", settings)
+	}
+}
+
 func TestComposerConfigConfigurableTruthTable(t *testing.T) {
 	t.Parallel()
 	// Pins the backend configurable flags so the GUI can derive support from
@@ -225,6 +253,7 @@ func TestComposerConfigConfigurableTruthTable(t *testing.T) {
 		{"codex", true, true, true},
 		{"tutti-agent", true, true, true},
 		{"cursor", true, false, true},
+		{"opencode", true, false, true},
 		{"hermes", false, false, false},
 		{"nexight", false, false, true},
 		{"openclaw", false, false, false},

--- a/services/tuttid/service/agent/locales/en.json
+++ b/services/tuttid/service/agent/locales/en.json
@@ -46,6 +46,20 @@
         "description": "Runs commands without asking, unless explicitly denied by your Cursor permission rules."
       }
     },
+    "opencode": {
+      "read-only": {
+        "description": "Reads and searches the local project, but denies edits, commands, network access, and other approval-gated actions.",
+        "label": "Read-only"
+      },
+      "ask": {
+        "description": "Reads and searches directly, then asks before edits, commands, network access, and other gated actions.",
+        "label": "Ask"
+      },
+      "full-access": {
+        "description": "Automatically allows gated actions without changing OpenCode's separate Plan mode restrictions.",
+        "label": "Full access"
+      }
+    },
     "hermes": {
       "yolo": {
         "description": "This provider does not support changing permission mode here.",

--- a/services/tuttid/service/agent/locales/zh-CN.json
+++ b/services/tuttid/service/agent/locales/zh-CN.json
@@ -46,6 +46,20 @@
         "description": "无需询问直接运行命令，除非被你的 Cursor 权限规则明确拒绝。"
       }
     },
+    "opencode": {
+      "read-only": {
+        "description": "允许读取和搜索本地项目，拒绝修改、命令、网络及其他需授权操作",
+        "label": "只读"
+      },
+      "ask": {
+        "description": "读取和搜索直接执行，修改、命令、网络及其他操作会先询问你",
+        "label": "询问"
+      },
+      "full-access": {
+        "description": "自动允许需授权操作，但不会改变 OpenCode 独立的 Plan 模式限制",
+        "label": "完全访问"
+      }
+    },
     "hermes": {
       "yolo": {
         "description": "当前 provider 不支持在这里调整权限模式。",


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Verification

<!-- Commands run, manual checks, or why verification is not applicable. -->

## Fix Scope Justification

<!--
Required when a fix-titled PR changes more than 300 lines; delete otherwise.

- Root cause: which event or state is the actual source of the bug?
- Why can this not be fixed at a lower layer?
-->

## Fallback Three Questions

<!--
Required when this change adds a timer, retry, cache, or defensive branch;
delete otherwise.

- Source: which event or state does this fallback compensate for?
- Why can it not be fixed at that source?
- Removal condition: when can this fallback be deleted?
-->

## Checklist

- [ ] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [ ] I ran the lowest meaningful local checks for the changed surface.
- [ ] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes file‑change approvals for `opencode` by decoupling permission tiers from Plan mode and enforcing one‑shot approvals; also normalizes conversation title mentions and adds `opencode` permission controls in the Agent GUI.

- **New Features**
  - Added `opencode` ACP adapter with independent permission tiers (`read-only`, `ask`, `full-access`) separate from Plan/Build workflow modes. Merges `OPENCODE_CONFIG_CONTENT`, neutralizes `OPENCODE_PERMISSION`, and keeps the Plan agent’s edit permission denied.
  - Automatic permission decisions: `read-only` auto‑denies and `full-access` auto‑approves; filters out “allow always” to keep approvals revocable.
  - Agent GUI: permission controls for `opencode` with EN/ZH‑CN copy; architecture docs updated on permission/workflow boundaries and title rendering.

- **Bug Fixes**
  - File‑change approvals now follow the live tier without switching ACP mode; moving to `read-only` takes effect on the next request.
  - Conversation titles: render session/app/agent mentions as plain `@label` text without a mention icon; keep file/task markers; shrink mention bubbles to avoid overflow.

<sup>Written for commit 938027f0becf287ede1e83fc4be0dc61ed8bad11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

