### PR TITLE
fix(agent-gui): render generated images as single artifacts

### DIFF
--- a/packages/agent/daemon/runtime/codex_appserver_event_items.go
+++ b/packages/agent/daemon/runtime/codex_appserver_event_items.go
@@ -2,6 +2,8 @@ package agentruntime
 
 import (
 	"log/slog"
+	"mime"
+	"path/filepath"
 	"strings"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
@@ -308,14 +310,35 @@ func appServerItemToolCallUpdate(item map[string]any, completed bool) (map[strin
 		update["kind"] = "other"
 		if completed {
 			output := map[string]any{}
+			content := make([]any, 0, 2)
+			if revisedPrompt := strings.TrimSpace(asStringRaw(item["revisedPrompt"])); revisedPrompt != "" {
+				if !strings.HasPrefix(strings.ToLower(revisedPrompt), "revised prompt:") {
+					revisedPrompt = "Revised prompt: " + revisedPrompt
+				}
+				content = append(content, map[string]any{
+					"type": "content",
+					"content": map[string]any{
+						"type": "text",
+						"text": revisedPrompt,
+					},
+				})
+			}
 			if savedPath := asString(item["savedPath"]); savedPath != "" {
 				output["savedPath"] = savedPath
-			}
-			if result := asStringRaw(item["result"]); result != "" {
-				output["result"] = result
+				content = append(content, map[string]any{
+					"type": "content",
+					"content": map[string]any{
+						"type":     "image",
+						"uri":      savedPath,
+						"mimeType": appServerImageMimeType(savedPath),
+					},
+				})
 			}
 			if len(output) > 0 {
 				update["rawOutput"] = output
+			}
+			if len(content) > 0 {
+				update["content"] = content
 			}
 		}
 	case "imageView":
@@ -328,6 +351,17 @@ func appServerItemToolCallUpdate(item map[string]any, completed bool) (map[strin
 		return nil, false
 	}
 	return update, true
+}
+
+func appServerImageMimeType(path string) string {
+	mimeType := strings.TrimSpace(mime.TypeByExtension(filepath.Ext(path)))
+	if separator := strings.IndexByte(mimeType, ';'); separator >= 0 {
+		mimeType = strings.TrimSpace(mimeType[:separator])
+	}
+	if strings.HasPrefix(strings.ToLower(mimeType), "image/") {
+		return mimeType
+	}
+	return "image/png"
 }
 
 func appServerAgentControlToolName(tool string) string {

--- a/packages/agent/daemon/runtime/codex_appserver_image_generation_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_image_generation_test.go
@@ -1,0 +1,106 @@
+package agentruntime
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+)
+
+func TestAppServerImageGenerationPublishesFileBackedContentWithoutBase64(t *testing.T) {
+	t.Parallel()
+
+	const (
+		savedPath = "/Users/demo/.tutti/agent/runs/session/codex-home/generated_images/thread/ig_123.png"
+		base64    = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
+	)
+	update, ok := appServerItemToolCallUpdate(map[string]any{
+		"id":            "ig_123",
+		"type":          "imageGeneration",
+		"status":        "completed",
+		"revisedPrompt": "a joyful little girl dancing",
+		"savedPath":     savedPath,
+		"result":        base64,
+	}, true)
+	if !ok {
+		t.Fatal("imageGeneration item did not produce a tool-call update")
+	}
+
+	rawOutput, ok := update["rawOutput"].(map[string]any)
+	if !ok {
+		t.Fatalf("rawOutput = %#v, want map", update["rawOutput"])
+	}
+	if got := asString(rawOutput["savedPath"]); got != savedPath {
+		t.Fatalf("rawOutput.savedPath = %q, want %q", got, savedPath)
+	}
+	if _, exists := rawOutput["result"]; exists {
+		t.Fatalf("rawOutput.result must not retain image base64: %#v", rawOutput["result"])
+	}
+
+	content, ok := update["content"].([]any)
+	if !ok || len(content) != 2 {
+		t.Fatalf("content = %#v, want prompt and image entries", update["content"])
+	}
+	prompt := payloadObject(payloadObject(content[0])["content"])
+	if got := asString(prompt["text"]); got != "Revised prompt: a joyful little girl dancing" {
+		t.Fatalf("prompt text = %q", got)
+	}
+	image := payloadObject(payloadObject(content[1])["content"])
+	if got := asString(image["type"]); got != "image" {
+		t.Fatalf("image type = %q, want image", got)
+	}
+	if got := asString(image["uri"]); got != savedPath {
+		t.Fatalf("image uri = %q, want %q", got, savedPath)
+	}
+	if got := asString(image["mimeType"]); got != "image/png" {
+		t.Fatalf("image mimeType = %q, want image/png", got)
+	}
+
+	session := Session{Provider: ProviderCodex, AgentSessionID: "agent-image", RoomID: "room-image"}
+	event, ok := acpToolCallEventWithID(session, "event-image", "turn-image", update)
+	if !ok {
+		t.Fatal("normalized imageGeneration update did not produce an event")
+	}
+	encoded, err := json.Marshal(event.Payload.Metadata)
+	if err != nil {
+		t.Fatalf("marshal normalized payload: %v", err)
+	}
+	if strings.Contains(string(encoded), base64) {
+		t.Fatalf("normalized payload retained image base64: %s", encoded)
+	}
+	if !strings.Contains(string(encoded), savedPath) {
+		t.Fatalf("normalized payload lost saved image path: %s", encoded)
+	}
+
+	messageUpdate, ok := messageUpdateFromSessionEvent(
+		agentsessionstore.EventSource{Provider: string(ProviderCodex)},
+		event,
+		session.AgentSessionID,
+		1,
+	)
+	if !ok {
+		t.Fatal("normalized imageGeneration event did not produce a durable message update")
+	}
+	encoded, err = json.Marshal(messageUpdate.Payload)
+	if err != nil {
+		t.Fatalf("marshal durable message payload: %v", err)
+	}
+	if strings.Contains(string(encoded), base64) {
+		t.Fatalf("durable message payload retained image base64: %s", encoded)
+	}
+	if !strings.Contains(string(encoded), savedPath) {
+		t.Fatalf("durable message payload lost saved image path: %s", encoded)
+	}
+}
+
+func TestAppServerImageGenerationInfersMimeTypeFromSavedPath(t *testing.T) {
+	t.Parallel()
+
+	if got := appServerImageMimeType("/tmp/generated.webp"); got != "image/webp" {
+		t.Fatalf("webp mime type = %q, want image/webp", got)
+	}
+	if got := appServerImageMimeType("/tmp/generated.unknown"); got != "image/png" {
+		t.Fatalf("unknown mime type = %q, want image/png", got)
+	}
+}

--- a/packages/agent/gui/shared/agentConversation/components/AgentGeneratedImagePreview.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentGeneratedImagePreview.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState, type JSX } from "react";
+import { resolveWorkspaceImageMimeType } from "@tutti-os/workspace-file-manager/services";
+import { useOptionalAgentHostApi } from "../../../agentActivityHost";
+import { ZoomableImage } from "../../../app/renderer/components/ZoomableImage";
+import { resolveImageGenerationPreviewSrc } from "../../imageGenerationTool";
+
+interface AgentGeneratedImagePreviewProps {
+  uri: string;
+  mimeType: string | null;
+  alt: string;
+  className: string;
+}
+
+export function AgentGeneratedImagePreview({
+  uri,
+  mimeType,
+  alt,
+  className
+}: AgentGeneratedImagePreviewProps): JSX.Element | null {
+  "use memo";
+  const agentHostApi = useOptionalAgentHostApi();
+  const localPath = isLocalImagePath(uri) ? uri.trim() : null;
+  const readWorkspaceImage = localPath
+    ? agentHostApi?.workspace?.readFile
+    : undefined;
+  const [src, setSrc] = useState<string | null>(() =>
+    !localPath ? resolveImageGenerationPreviewSrc(uri) : null
+  );
+
+  useEffect(() => {
+    if (!localPath || !readWorkspaceImage) {
+      setSrc(resolveImageGenerationPreviewSrc(uri));
+      return;
+    }
+
+    const resolvedLocalPath = localPath;
+    const resolvedReadWorkspaceImage = readWorkspaceImage;
+    let canceled = false;
+    let objectUrl: string | null = null;
+    const resolvedMimeType =
+      mimeType?.trim() ||
+      resolveWorkspaceImageMimeType(resolvedLocalPath) ||
+      "image/png";
+
+    async function loadWorkspaceImage(): Promise<void> {
+      try {
+        const result = await resolvedReadWorkspaceImage({
+          path: resolvedLocalPath
+        });
+        if (canceled) {
+          return;
+        }
+        const bytes =
+          result.bytes instanceof Uint8Array
+            ? result.bytes
+            : new Uint8Array(result.bytes);
+        const arrayBuffer = bytes.buffer.slice(
+          bytes.byteOffset,
+          bytes.byteOffset + bytes.byteLength
+        ) as ArrayBuffer;
+        objectUrl = URL.createObjectURL(
+          new Blob([arrayBuffer], { type: resolvedMimeType })
+        );
+        setSrc(objectUrl);
+      } catch {
+        if (!canceled) {
+          setSrc(null);
+        }
+      }
+    }
+
+    setSrc(null);
+    void loadWorkspaceImage();
+
+    return () => {
+      canceled = true;
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    };
+  }, [localPath, mimeType, readWorkspaceImage, uri]);
+
+  if (!src) {
+    return null;
+  }
+
+  return (
+    <ZoomableImage
+      alt={alt}
+      className={className}
+      downloadName={localPath ? localPath.split(/[\\/]/).pop() : "image.png"}
+      src={src}
+      wrapElement="span"
+    />
+  );
+}
+
+function isLocalImagePath(path: string): boolean {
+  const candidate = path.trim();
+  return (
+    (candidate.length > 1 &&
+      candidate.startsWith("/") &&
+      !candidate.startsWith("//") &&
+      !candidate.includes("://") &&
+      !/\s/.test(candidate)) ||
+    /^[a-zA-Z]:[\\/]/.test(candidate)
+  );
+}

--- a/packages/agent/gui/shared/agentConversation/components/AgentGeneratedImageRow.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentGeneratedImageRow.tsx
@@ -1,0 +1,25 @@
+import type { JSX } from "react";
+import { translate } from "../../../i18n/index";
+import type { AgentGeneratedImageRowVM } from "../contracts/agentGeneratedImageRowVM";
+import { AgentGeneratedImagePreview } from "./AgentGeneratedImagePreview";
+
+export function AgentGeneratedImageRow({
+  row
+}: {
+  row: AgentGeneratedImageRowVM;
+}): JSX.Element {
+  "use memo";
+  return (
+    <div
+      className="flex max-w-full justify-start"
+      data-testid="agent-generated-image-artifact"
+    >
+      <AgentGeneratedImagePreview
+        uri={row.uri}
+        mimeType={row.mimeType}
+        alt={translate("agentHost.agentTool.details.imagePreviewAlt")}
+        className="block max-h-[560px] max-w-full rounded-[10px] border border-[var(--line-2)] bg-[var(--background-panel)] object-contain"
+      />
+    </div>
+  );
+}

--- a/packages/agent/gui/shared/agentConversation/components/AgentToolCallCard.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentToolCallCard.spec.tsx
@@ -556,7 +556,7 @@ describe("Agent specialized tool cards", () => {
     expect(screen.getByText("completed")).toBeTruthy();
   });
 
-  it("renders image generation prompt and preview output", async () => {
+  it("renders the image generation prompt without duplicating artifact output", async () => {
     setAgentGuiI18nTestLocale("en");
     const readFile = vi.fn().mockResolvedValue({
       bytes: new Uint8Array([137, 80, 78, 71])
@@ -610,15 +610,13 @@ describe("Agent specialized tool cards", () => {
 
     expect(screen.getByText(/Revised prompt:/)).toBeTruthy();
     expect(
-      await screen.findByRole("img", { name: "Image generation preview" })
-    ).toHaveAttribute("src", "blob:tool-image-preview");
-    expect(screen.getByText("Output")).toBeTruthy();
-    expect(readFile).toHaveBeenCalledWith({
-      path: "/workspace/output/generated.png"
-    });
+      screen.queryByRole("img", { name: "Image generation preview" })
+    ).toBeNull();
+    expect(screen.queryByText("Output")).toBeNull();
+    expect(readFile).not.toHaveBeenCalled();
   });
 
-  it("renders historical Codex image output from savedPath", async () => {
+  it("does not duplicate historical Codex image output from savedPath", async () => {
     setAgentGuiI18nTestLocale("en");
     const savedPath =
       "/Users/demo/.tutti/agent/runs/session/codex-home/generated_images/thread/ig_legacy.png";
@@ -660,9 +658,9 @@ describe("Agent specialized tool cards", () => {
     );
 
     expect(
-      await screen.findByRole("img", { name: "Image generation preview" })
-    ).toHaveAttribute("src", "blob:legacy-tool-image-preview");
-    expect(readFile).toHaveBeenCalledWith({ path: savedPath });
+      screen.queryByRole("img", { name: "Image generation preview" })
+    ).toBeNull();
+    expect(readFile).not.toHaveBeenCalled();
   });
 
   it("does not show an output loading placeholder for active image generation cards", async () => {
@@ -716,14 +714,10 @@ describe("Agent specialized tool cards", () => {
     expect(
       screen.queryByRole("img", { name: "Image generation preview" })
     ).toBeNull();
-    await waitFor(() => {
-      expect(readFile).toHaveBeenCalledWith({
-        path: "/workspace/output/generated.png"
-      });
-    });
+    expect(readFile).not.toHaveBeenCalled();
   });
 
-  it("renders image generation preview even when the tool output has no prompt text", async () => {
+  it("does not render image-only output inside the tool call card", async () => {
     setAgentGuiI18nTestLocale("en");
     const readFile = vi.fn().mockResolvedValue({
       bytes: new Uint8Array([137, 80, 78, 71])
@@ -768,13 +762,11 @@ describe("Agent specialized tool cards", () => {
     );
 
     expect(
-      await screen.findByRole("img", { name: "Image generation preview" })
-    ).toHaveAttribute("src", "blob:image-only-preview");
+      screen.queryByRole("img", { name: "Image generation preview" })
+    ).toBeNull();
     expect(screen.queryByText("Input")).toBeNull();
-    expect(screen.getByText("Output")).toBeTruthy();
-    expect(readFile).toHaveBeenCalledWith({
-      path: "/workspace/output/generated-only.png"
-    });
+    expect(screen.queryByText("Output")).toBeNull();
+    expect(readFile).not.toHaveBeenCalled();
   });
 
   it("does not allow expanding web fetch cards without displayable content", async () => {

--- a/packages/agent/gui/shared/agentConversation/components/AgentToolCallCard.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentToolCallCard.spec.tsx
@@ -618,6 +618,53 @@ describe("Agent specialized tool cards", () => {
     });
   });
 
+  it("renders historical Codex image output from savedPath", async () => {
+    setAgentGuiI18nTestLocale("en");
+    const savedPath =
+      "/Users/demo/.tutti/agent/runs/session/codex-home/generated_images/thread/ig_legacy.png";
+    const readFile = vi.fn().mockResolvedValue({
+      bytes: new Uint8Array([137, 80, 78, 71])
+    });
+    window.agentHostApi = {
+      ...(window.agentHostApi ?? {}),
+      workspace: {
+        ...(window.agentHostApi?.workspace ?? {}),
+        readFile
+      }
+    } as typeof window.agentHostApi;
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:legacy-tool-image-preview")
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn()
+    });
+
+    render(
+      <AgentToolCallCard
+        defaultExpanded
+        call={projectAgentToolCall(
+          toolCall({
+            toolName: "ImageGeneration",
+            name: "Generate image",
+            payload: {
+              output: {
+                savedPath,
+                result: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
+              }
+            }
+          })
+        )}
+      />
+    );
+
+    expect(
+      await screen.findByRole("img", { name: "Image generation preview" })
+    ).toHaveAttribute("src", "blob:legacy-tool-image-preview");
+    expect(readFile).toHaveBeenCalledWith({ path: savedPath });
+  });
+
   it("does not show an output loading placeholder for active image generation cards", async () => {
     setAgentGuiI18nTestLocale("en");
     const readFile = vi

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -10,6 +10,7 @@ import { getAgentEnvPanelStore } from "../../agentEnv/agentEnvPanelStore";
 import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import { AgentMessageBlock } from "./AgentMessageBlock";
 import { AgentTranscriptItemView } from "./AgentTranscriptItemView";
+import type { AgentGeneratedImageRowVM } from "../contracts/agentGeneratedImageRowVM";
 import type { AgentMessageContentVM } from "../contracts/agentMessageRowVM";
 import type { AgentMessageRowVM } from "../contracts/agentMessageRowVM";
 import type { AgentToolCallVM } from "../contracts/agentToolCallVM";
@@ -72,6 +73,37 @@ vi.mock("./AgentToolGroupRow", () => ({
 }));
 
 describe("AgentTranscriptItemView render stability", () => {
+  it("renders a generated image artifact independently from tool-call expansion", () => {
+    const row: AgentGeneratedImageRowVM = {
+      kind: "generated-image",
+      id: "generated-image:call:image-1",
+      turnId: "turn-1",
+      sourceCallId: "call:image-1",
+      uri: "data:image/png;base64,aW1hZ2U=",
+      mimeType: "image/png",
+      prompt: "A friendly corgi",
+      occurredAtUnixMs: 1
+    };
+
+    render(
+      <AgentTranscriptItemView
+        workspaceRoot="/workspace/demo"
+        basePath="/workspace/demo"
+        row={row}
+        labels={transcriptLabels()}
+      />
+    );
+
+    expect(
+      screen.getByTestId("agent-generated-image-artifact")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", {
+        name: "agentHost.agentTool.details.imagePreviewAlt"
+      })
+    ).toHaveAttribute("src", row.uri);
+  });
+
   it("keeps tool link handlers stable when an unchanged tool row is reprojected", () => {
     const onLinkAction = vi.fn();
     const labels = transcriptLabels();

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.tsx
@@ -4,6 +4,7 @@ import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../AgentMessageMar
 import type { AgentGUIProviderSkillOption } from "../../../agent-gui/agentGuiNode/model/agentGuiNodeTypes";
 import { resolveAgentConversationLinkAction } from "../actions/agentConversationLinkActions";
 import type { AgentTranscriptRowVM } from "../contracts/agentTranscriptRowVM";
+import { AgentGeneratedImageRow } from "./AgentGeneratedImageRow";
 import { AgentMessageBlock } from "./AgentMessageBlock";
 import { AgentProcessingRow } from "./AgentProcessingRow";
 import { AgentToolGroupRow } from "./AgentToolGroupRow";
@@ -65,6 +66,8 @@ export const AgentTranscriptItemView = memo(function AgentTranscriptItemView({
     [basePath, onLinkAction, workspaceRoot]
   );
   switch (row.kind) {
+    case "generated-image":
+      return <AgentGeneratedImageRow row={row} />;
     case "message":
       return (
         <AgentMessageBlock

--- a/packages/agent/gui/shared/agentConversation/components/agentTranscriptComplexity.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTranscriptComplexity.ts
@@ -75,6 +75,10 @@ function calculateTurnScore(
 
   for (const { row } of rows) {
     rowCount += 1;
+    if (row.kind === "generated-image") {
+      imageCount += 1;
+      continue;
+    }
     if (row.kind === "message") {
       for (const message of row.messages) {
         charCount += message.body.length;

--- a/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.ts
@@ -123,7 +123,13 @@ export function hasAgentResponseForTurn(
   const turnId = userRow.turnId ?? null;
   for (let index = userRowIndex + 1; index < rows.length; index += 1) {
     const row = rows[index];
-    if (!row || row.kind !== "message") {
+    if (!row) {
+      continue;
+    }
+    if (row.kind === "generated-image") {
+      return !turnId || row.turnId === turnId;
+    }
+    if (row.kind !== "message") {
       continue;
     }
     if (row.speaker === "user") {

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentImageGenerationContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentImageGenerationContent.tsx
@@ -1,6 +1,5 @@
 import type { JSX } from "react";
 import { translate } from "../../../../i18n/index";
-import { AgentGeneratedImagePreview } from "../AgentGeneratedImagePreview";
 import type { AgentToolRendererProps } from "./agentToolContentShared";
 import { ToolMarkdownBlock, ToolSection } from "./agentToolContentShared";
 import { getImageGenerationRenderData } from "./render-data/agentToolRenderData";
@@ -11,31 +10,19 @@ export function AgentImageGenerationContent({
 }: AgentToolRendererProps): JSX.Element | null {
   "use memo";
   const image = getImageGenerationRenderData(call);
-  if (!image.prompt && !image.imageUri) {
+  if (!image.prompt) {
     return null;
   }
 
   return (
     <div className="workspace-agents-status-panel__detail-tool-body">
-      {image.prompt ? (
-        <ToolSection title={translate("agentHost.agentTool.details.input")}>
-          <ToolMarkdownBlock
-            content={image.prompt}
-            onLinkClick={onLinkClick}
-            collapsible
-          />
-        </ToolSection>
-      ) : null}
-      {image.imageUri ? (
-        <ToolSection title={translate("agentHost.agentTool.details.output")}>
-          <AgentGeneratedImagePreview
-            uri={image.imageUri}
-            mimeType={image.mimeType}
-            alt={translate("agentHost.agentTool.details.imagePreviewAlt")}
-            className="block max-h-[360px] max-w-full rounded-[8px] border border-[var(--line-2)] bg-[var(--background-panel)] object-contain"
-          />
-        </ToolSection>
-      ) : null}
+      <ToolSection title={translate("agentHost.agentTool.details.input")}>
+        <ToolMarkdownBlock
+          content={image.prompt}
+          onLinkClick={onLinkClick}
+          collapsible
+        />
+      </ToolSection>
     </div>
   );
 }

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentImageGenerationContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentImageGenerationContent.tsx
@@ -1,10 +1,6 @@
-import { useEffect, useState, type JSX } from "react";
-import { ZoomableImage } from "../../../../app/renderer/components/ZoomableImage";
-import { cn } from "../../../../app/renderer/lib/utils";
-import { resolveWorkspaceImageMimeType } from "@tutti-os/workspace-file-manager/services";
+import type { JSX } from "react";
 import { translate } from "../../../../i18n/index";
-import { useOptionalAgentHostApi } from "../../../../agentActivityHost";
-import { resolveImageGenerationPreviewSrc } from "../../../imageGenerationTool";
+import { AgentGeneratedImagePreview } from "../AgentGeneratedImagePreview";
 import type { AgentToolRendererProps } from "./agentToolContentShared";
 import { ToolMarkdownBlock, ToolSection } from "./agentToolContentShared";
 import { getImageGenerationRenderData } from "./render-data/agentToolRenderData";
@@ -31,112 +27,15 @@ export function AgentImageGenerationContent({
         </ToolSection>
       ) : null}
       {image.imageUri ? (
-        <ImageGenerationPreview
-          uri={image.imageUri}
-          mimeType={image.mimeType}
-        />
+        <ToolSection title={translate("agentHost.agentTool.details.output")}>
+          <AgentGeneratedImagePreview
+            uri={image.imageUri}
+            mimeType={image.mimeType}
+            alt={translate("agentHost.agentTool.details.imagePreviewAlt")}
+            className="block max-h-[360px] max-w-full rounded-[8px] border border-[var(--line-2)] bg-[var(--background-panel)] object-contain"
+          />
+        </ToolSection>
       ) : null}
     </div>
-  );
-}
-
-function ImageGenerationPreview({
-  uri,
-  mimeType
-}: {
-  uri: string;
-  mimeType: string | null;
-}): JSX.Element | null {
-  "use memo";
-  const agentHostApi = useOptionalAgentHostApi();
-  const localPath = isLocalImagePath(uri) ? uri.trim() : null;
-  const readWorkspaceImage = localPath
-    ? agentHostApi?.workspace?.readFile
-    : undefined;
-  const [src, setSrc] = useState<string | null>(() =>
-    !localPath ? resolveImageGenerationPreviewSrc(uri) : null
-  );
-
-  useEffect(() => {
-    if (!localPath || !readWorkspaceImage) {
-      setSrc(resolveImageGenerationPreviewSrc(uri));
-      return;
-    }
-
-    const resolvedLocalPath = localPath;
-    const resolvedReadWorkspaceImage = readWorkspaceImage;
-    let canceled = false;
-    let objectUrl: string | null = null;
-    const resolvedMimeType =
-      mimeType?.trim() ||
-      resolveWorkspaceImageMimeType(resolvedLocalPath) ||
-      "image/png";
-
-    async function loadWorkspaceImage(): Promise<void> {
-      try {
-        const result = await resolvedReadWorkspaceImage({
-          path: resolvedLocalPath
-        });
-        if (canceled) {
-          return;
-        }
-        const bytes =
-          result.bytes instanceof Uint8Array
-            ? result.bytes
-            : new Uint8Array(result.bytes);
-        const arrayBuffer = bytes.buffer.slice(
-          bytes.byteOffset,
-          bytes.byteOffset + bytes.byteLength
-        ) as ArrayBuffer;
-        objectUrl = URL.createObjectURL(
-          new Blob([arrayBuffer], { type: resolvedMimeType })
-        );
-        setSrc(objectUrl);
-      } catch {
-        if (!canceled) {
-          setSrc(null);
-        }
-      }
-    }
-
-    setSrc(null);
-    void loadWorkspaceImage();
-
-    return () => {
-      canceled = true;
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl);
-      }
-    };
-  }, [localPath, mimeType, readWorkspaceImage, uri]);
-
-  if (!src) {
-    return null;
-  }
-
-  return (
-    <ToolSection title={translate("agentHost.agentTool.details.output")}>
-      <ZoomableImage
-        alt={translate("agentHost.agentTool.details.imagePreviewAlt")}
-        className={cn(
-          "block max-h-[360px] max-w-full rounded-[8px] border border-[var(--line-2)] bg-[var(--background-panel)] object-contain"
-        )}
-        downloadName={localPath ? localPath.split(/[\\/]/).pop() : "image.png"}
-        src={src}
-        wrapElement="span"
-      />
-    </ToolSection>
-  );
-}
-
-function isLocalImagePath(path: string): boolean {
-  const candidate = path.trim();
-  return (
-    (candidate.length > 1 &&
-      candidate.startsWith("/") &&
-      !candidate.startsWith("//") &&
-      !candidate.includes("://") &&
-      !/\s/.test(candidate)) ||
-    /^[a-zA-Z]:[\\/]/.test(candidate)
   );
 }

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.spec.ts
@@ -3,6 +3,7 @@ import type { AgentToolCallVM } from "../../../contracts/agentToolCallVM";
 import {
   getCommandRenderData,
   getFileChangeRenderData,
+  getImageGenerationRenderData,
   getSearchRenderData,
   getSkillRenderData,
   getTaskRenderData,
@@ -12,6 +13,54 @@ import {
 } from "./agentToolRenderData";
 
 describe("agentToolRenderData", () => {
+  it("uses the historical Codex savedPath as an image preview fallback", () => {
+    const data = getImageGenerationRenderData(
+      makeCall({
+        toolName: "ImageGeneration",
+        name: "Generate image",
+        output: {
+          savedPath:
+            "/Users/demo/.tutti/agent/runs/session/codex-home/generated_images/thread/ig_123.png",
+          result: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
+        }
+      })
+    );
+
+    expect(data).toEqual({
+      prompt: null,
+      imageUri:
+        "/Users/demo/.tutti/agent/runs/session/codex-home/generated_images/thread/ig_123.png",
+      mimeType: null
+    });
+  });
+
+  it("prefers canonical image content over the historical savedPath fallback", () => {
+    const data = getImageGenerationRenderData(
+      makeCall({
+        toolName: "ImageGeneration",
+        content: [
+          {
+            type: "content",
+            content: {
+              type: "image",
+              uri: "/workspace/output/canonical.webp",
+              mimeType: "image/webp"
+            }
+          }
+        ],
+        output: {
+          savedPath: "/workspace/output/legacy.png"
+        }
+      })
+    );
+
+    expect(data).toEqual({
+      prompt: null,
+      imageUri: "/workspace/output/canonical.webp",
+      mimeType: "image/webp"
+    });
+  });
+
   it("extracts canonical command render data", () => {
     const data = getCommandRenderData(
       makeCall({

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.ts
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.ts
@@ -398,6 +398,7 @@ export function getImageGenerationRenderData(
     displayName: call.name,
     content: call.content,
     outputContent: call.output?.content,
+    outputSavedPath: call.output?.savedPath ?? call.output?.saved_path,
     inputPrompt: call.input?.prompt,
     payloadInputPrompt: recordValue(call.payload?.input)?.prompt
   });

--- a/packages/agent/gui/shared/agentConversation/contracts/agentGeneratedImageRowVM.ts
+++ b/packages/agent/gui/shared/agentConversation/contracts/agentGeneratedImageRowVM.ts
@@ -1,0 +1,10 @@
+export interface AgentGeneratedImageRowVM {
+  kind: "generated-image";
+  id: string;
+  turnId: string;
+  sourceCallId: string;
+  uri: string;
+  mimeType: string | null;
+  prompt: string | null;
+  occurredAtUnixMs: number | null;
+}

--- a/packages/agent/gui/shared/agentConversation/contracts/agentTranscriptRowVM.ts
+++ b/packages/agent/gui/shared/agentConversation/contracts/agentTranscriptRowVM.ts
@@ -1,9 +1,11 @@
+import type { AgentGeneratedImageRowVM } from "./agentGeneratedImageRowVM";
 import type { AgentMessageRowVM } from "./agentMessageRowVM";
 import type { AgentProcessingRowVM } from "./agentProcessingRowVM";
 import type { AgentToolGroupRowVM } from "./agentToolGroupRowVM";
 import type { AgentTurnSummaryRowVM } from "./agentTurnSummaryRowVM";
 
 export type AgentTranscriptRowVM =
+  | AgentGeneratedImageRowVM
   | AgentMessageRowVM
   | AgentToolGroupRowVM
   | AgentTurnSummaryRowVM

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
@@ -125,6 +125,122 @@ describe("projectAgentConversationVM", () => {
     ]);
   });
 
+  it("promotes a completed generated image beside its retained tool-call group", () => {
+    const imageCall = {
+      id: "call:image-1",
+      name: "Generate image",
+      toolName: "image_generation",
+      callType: "tool",
+      status: "Completed",
+      statusKind: "completed" as const,
+      summary: "Generated image",
+      payload: {
+        input: {
+          prompt: "A friendly corgi"
+        },
+        output: {
+          savedPath: "/workspace/output/generated-corgi.png",
+          content: [
+            {
+              type: "image",
+              uri: "/workspace/output/generated-corgi.png",
+              mimeType: "image/png"
+            }
+          ]
+        }
+      }
+    };
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        turns: [
+          {
+            id: "turn-image",
+            userMessage: { id: "user-image", body: "Generate a corgi" },
+            userMessages: [{ id: "user-image", body: "Generate a corgi" }],
+            agentMessages: [],
+            toolCalls: [imageCall],
+            toolCallCount: 1,
+            hasFailedToolCall: false,
+            agentItems: [
+              {
+                kind: "tool-calls",
+                id: "tools-image",
+                toolCalls: [imageCall],
+                toolCallCount: 1,
+                hasFailedToolCall: false
+              }
+            ]
+          }
+        ],
+        showProcessingIndicator: false
+      })
+    );
+
+    expect(
+      conversation.rows.filter((row) => row.kind === "tool-group")
+    ).toHaveLength(1);
+    expect(
+      conversation.rows.find((row) => row.kind === "generated-image")
+    ).toMatchObject({
+      kind: "generated-image",
+      id: "generated-image:call:image-1",
+      turnId: "turn-image",
+      sourceCallId: "call:image-1",
+      uri: "/workspace/output/generated-corgi.png",
+      mimeType: "image/png",
+      prompt: "A friendly corgi"
+    });
+  });
+
+  it("does not promote an image before generation completes", () => {
+    const imageCall = {
+      id: "call:image-running",
+      name: "Generate image",
+      toolName: "image_generation",
+      callType: "tool",
+      status: "Running",
+      statusKind: "working" as const,
+      summary: "Generating image",
+      payload: {
+        input: {
+          prompt: "A friendly corgi"
+        },
+        output: {
+          savedPath: "/workspace/output/generated-corgi.png"
+        }
+      }
+    };
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        turns: [
+          {
+            id: "turn-image-running",
+            userMessage: { id: "user-image", body: "Generate a corgi" },
+            userMessages: [{ id: "user-image", body: "Generate a corgi" }],
+            agentMessages: [],
+            toolCalls: [imageCall],
+            toolCallCount: 1,
+            hasFailedToolCall: false,
+            agentItems: [
+              {
+                kind: "tool-calls",
+                id: "tools-image",
+                toolCalls: [imageCall],
+                toolCallCount: 1,
+                hasFailedToolCall: false
+              }
+            ]
+          }
+        ],
+        showProcessingIndicator: false
+      })
+    );
+
+    expect(
+      conversation.rows.some((row) => row.kind === "generated-image")
+    ).toBe(false);
+  });
+
   const tailChainConversation = (latestTail: {
     status: string;
     statusKind: "completed" | "working" | "waiting";

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
@@ -241,6 +241,148 @@ describe("projectAgentConversationVM", () => {
     ).toBe(false);
   });
 
+  it("removes final Markdown that repeats a generated-image artifact", () => {
+    const savedPath = "/workspace/output/generated-corgi.png";
+    const imageCall = {
+      id: "call:image-deduplicated",
+      name: "Generate image",
+      toolName: "image_generation",
+      callType: "tool",
+      status: "Completed",
+      statusKind: "completed" as const,
+      summary: "Generated image",
+      payload: {
+        input: {
+          prompt: "A friendly corgi"
+        },
+        output: {
+          savedPath,
+          content: [
+            {
+              type: "image",
+              uri: savedPath,
+              mimeType: "image/png"
+            }
+          ]
+        }
+      }
+    };
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        turns: [
+          {
+            id: "turn-image-deduplicated",
+            userMessage: { id: "user-image", body: "Generate a corgi" },
+            userMessages: [{ id: "user-image", body: "Generate a corgi" }],
+            agentMessages: [
+              {
+                id: "assistant-image",
+                body: `Done.\n\n![generated corgi](${savedPath})`
+              }
+            ],
+            toolCalls: [imageCall],
+            toolCallCount: 1,
+            hasFailedToolCall: false,
+            agentItems: [
+              {
+                kind: "tool-calls",
+                id: "tools-image",
+                toolCalls: [imageCall],
+                toolCallCount: 1,
+                hasFailedToolCall: false
+              },
+              {
+                kind: "message",
+                message: {
+                  id: "assistant-image",
+                  body: `Done.\n\n![generated corgi](${savedPath})`
+                }
+              }
+            ]
+          }
+        ],
+        showProcessingIndicator: false
+      })
+    );
+
+    expect(
+      conversation.rows.filter((row) => row.kind === "generated-image")
+    ).toHaveLength(1);
+    expect(
+      conversation.rows
+        .filter(
+          (row): row is Extract<typeof row, { kind: "message" }> =>
+            row.kind === "message" && row.speaker === "assistant"
+        )
+        .flatMap((row) => row.messages.map((message) => message.body))
+    ).toEqual(["Done."]);
+  });
+
+  it("keeps assistant Markdown images that are not generated artifacts", () => {
+    const generatedPath = "/workspace/output/generated-corgi.png";
+    const otherPath = "/workspace/reference/reference-corgi.png";
+    const imageCall = {
+      id: "call:image-keep-other",
+      name: "Generate image",
+      toolName: "image_generation",
+      callType: "tool",
+      status: "Completed",
+      statusKind: "completed" as const,
+      summary: "Generated image",
+      payload: {
+        output: {
+          savedPath: generatedPath,
+          content: [
+            {
+              type: "image",
+              uri: generatedPath,
+              mimeType: "image/png"
+            }
+          ]
+        }
+      }
+    };
+    const body = `![generated](${generatedPath})\n\n![reference](${otherPath})`;
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        turns: [
+          {
+            id: "turn-image-keep-other",
+            userMessage: { id: "user-image", body: "Generate a corgi" },
+            userMessages: [{ id: "user-image", body: "Generate a corgi" }],
+            agentMessages: [{ id: "assistant-image", body }],
+            toolCalls: [imageCall],
+            toolCallCount: 1,
+            hasFailedToolCall: false,
+            agentItems: [
+              {
+                kind: "tool-calls",
+                id: "tools-image",
+                toolCalls: [imageCall],
+                toolCallCount: 1,
+                hasFailedToolCall: false
+              },
+              {
+                kind: "message",
+                message: { id: "assistant-image", body }
+              }
+            ]
+          }
+        ],
+        showProcessingIndicator: false
+      })
+    );
+
+    expect(
+      conversation.rows
+        .filter(
+          (row): row is Extract<typeof row, { kind: "message" }> =>
+            row.kind === "message" && row.speaker === "assistant"
+        )
+        .flatMap((row) => row.messages.map((message) => message.body))
+    ).toEqual([`![reference](${otherPath})`]);
+  });
+
   const tailChainConversation = (latestTail: {
     status: string;
     statusKind: "completed" | "working" | "waiting";

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
@@ -2,11 +2,14 @@ import type {
   WorkspaceAgentSessionDetailTurn,
   WorkspaceAgentSessionDetailViewModel
 } from "../../workspaceAgentSessionDetailViewModel";
+import { extractImageGenerationPreview } from "../../imageGenerationTool";
 import type { AgentConversationVM } from "../contracts/agentConversationVM";
+import type { AgentGeneratedImageRowVM } from "../contracts/agentGeneratedImageRowVM";
 import type {
   AgentMessageContentVM,
   AgentMessageRowVM
 } from "../contracts/agentMessageRowVM";
+import type { AgentToolCallVM } from "../contracts/agentToolCallVM";
 import type { AgentTranscriptRowVM } from "../contracts/agentTranscriptRowVM";
 import { computeAgentToolGroups } from "./agentToolGroupingProjection";
 import { buildAgentTurnSequenceItems } from "./agentTurnSequenceProjection";
@@ -604,11 +607,71 @@ function projectTurnConversationRows(
     options
   );
   const skippedIndices = new Set([...groupedIndices, ...suppressedIndices]);
-  return projectTurnRows(
-    sequence,
-    groups,
-    skippedIndices,
-    turn.id,
-    options.agentSessionId
+  return promoteGeneratedImageRows(
+    projectTurnRows(
+      sequence,
+      groups,
+      skippedIndices,
+      turn.id,
+      options.agentSessionId
+    )
   );
+}
+
+function promoteGeneratedImageRows(
+  rows: readonly AgentTranscriptRowVM[]
+): AgentTranscriptRowVM[] {
+  const promoted: AgentTranscriptRowVM[] = [];
+  for (const row of rows) {
+    promoted.push(row);
+    if (row.kind !== "tool-group") {
+      continue;
+    }
+    for (const call of row.calls) {
+      const artifact = projectGeneratedImageRow(call, row.turnId);
+      if (artifact) {
+        promoted.push(artifact);
+      }
+    }
+  }
+  return promoted;
+}
+
+function projectGeneratedImageRow(
+  call: AgentToolCallVM,
+  turnId: string
+): AgentGeneratedImageRowVM | null {
+  if (
+    call.rendererKind !== "image-generation" ||
+    call.statusKind !== "completed"
+  ) {
+    return null;
+  }
+  const image = extractImageGenerationPreview({
+    toolName: call.toolName,
+    displayName: call.name,
+    content: call.content,
+    outputContent: call.output?.content,
+    outputSavedPath: call.output?.savedPath ?? call.output?.saved_path,
+    inputPrompt: call.input?.prompt,
+    payloadInputPrompt:
+      call.payload?.input &&
+      typeof call.payload.input === "object" &&
+      !Array.isArray(call.payload.input)
+        ? (call.payload.input as Record<string, unknown>).prompt
+        : null
+  });
+  if (!image.imageUri) {
+    return null;
+  }
+  return {
+    kind: "generated-image",
+    id: `generated-image:${call.id}`,
+    turnId,
+    sourceCallId: call.id,
+    uri: image.imageUri,
+    mimeType: image.mimeType,
+    prompt: image.prompt,
+    occurredAtUnixMs: call.occurredAtUnixMs
+  };
 }

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
@@ -26,6 +26,8 @@ const CODEX_SKILLS_CONTEXT_BUDGET_NOTICE_FRAGMENT =
   "skill descriptions were shortened to fit the 2% skills context budget";
 const CODEX_MODEL_METADATA_FALLBACK_NOTICE_FRAGMENT =
   "defaulting to fallback metadata";
+const MARKDOWN_IMAGE_PATTERN =
+  /!\[[^\]]*]\(\s*(?:<([^>]+)>|([^)\s]+))(?:\s+["'][^"']*["'])?\s*\)/g;
 
 export function projectAgentConversationVM(
   detail: WorkspaceAgentSessionDetailViewModel,
@@ -634,7 +636,126 @@ function promoteGeneratedImageRows(
       }
     }
   }
-  return promoted;
+  return dropDuplicateGeneratedImageMarkdown(promoted);
+}
+
+function dropDuplicateGeneratedImageMarkdown(
+  rows: readonly AgentTranscriptRowVM[]
+): AgentTranscriptRowVM[] {
+  const generatedImagesByTurn = new Map<string, Set<string>>();
+  for (const row of rows) {
+    if (row.kind !== "generated-image") {
+      continue;
+    }
+    const reference = normalizeGeneratedImageReference(row.uri);
+    if (!reference) {
+      continue;
+    }
+    const references = generatedImagesByTurn.get(row.turnId) ?? new Set();
+    references.add(reference);
+    generatedImagesByTurn.set(row.turnId, references);
+  }
+  if (generatedImagesByTurn.size === 0) {
+    return [...rows];
+  }
+
+  const filtered: AgentTranscriptRowVM[] = [];
+  for (const row of rows) {
+    if (row.kind !== "message" || row.speaker !== "assistant") {
+      filtered.push(row);
+      continue;
+    }
+    const generatedImages = generatedImagesByTurn.get(row.turnId);
+    if (!generatedImages) {
+      filtered.push(row);
+      continue;
+    }
+    let changed = false;
+    const messages = row.messages.flatMap((message) => {
+      const body = removeGeneratedImageMarkdown(message.body, generatedImages);
+      if (body === message.body) {
+        return [message];
+      }
+      changed = true;
+      return body ? [{ ...message, body }] : [];
+    });
+    if (messages.length === 0 && row.thinking.length === 0) {
+      continue;
+    }
+    filtered.push(changed ? { ...row, messages } : row);
+  }
+  return filtered;
+}
+
+function removeGeneratedImageMarkdown(
+  body: string,
+  generatedImages: ReadonlySet<string>
+): string {
+  let removed = false;
+  const next = body.replace(
+    MARKDOWN_IMAGE_PATTERN,
+    (
+      match,
+      angleReference: string | undefined,
+      plainReference: string | undefined
+    ) => {
+      const reference = normalizeGeneratedImageReference(
+        angleReference ?? plainReference ?? ""
+      );
+      if (!reference || !generatedImages.has(reference)) {
+        return match;
+      }
+      removed = true;
+      return "";
+    }
+  );
+  return removed
+    ? next
+        .replace(/[ \t]+\n/g, "\n")
+        .replace(/\n{3,}/g, "\n\n")
+        .trim()
+    : body;
+}
+
+function normalizeGeneratedImageReference(reference: string): string | null {
+  let normalized = reference.trim();
+  if (!normalized) {
+    return null;
+  }
+  if (/^file:\/\//i.test(normalized)) {
+    if (!URL.canParse(normalized)) {
+      return null;
+    }
+    normalized = new URL(normalized).pathname;
+  } else if (/^[a-z][a-z\d+.-]*:\/\//i.test(normalized)) {
+    return URL.canParse(normalized) ? new URL(normalized).href : normalized;
+  }
+  normalized = decodePercentEncodedReference(normalized);
+  normalized = normalized.replaceAll("\\", "/");
+  const prefix = normalized.startsWith("/") ? "/" : "";
+  const parts: string[] = [];
+  for (const part of normalized.split("/")) {
+    if (!part || part === ".") {
+      continue;
+    }
+    if (part === ".." && parts.length > 0) {
+      parts.pop();
+      continue;
+    }
+    parts.push(part);
+  }
+  const collapsed = `${prefix}${parts.join("/")}`;
+  return /^[a-z]:\//i.test(collapsed) ? collapsed.toLowerCase() : collapsed;
+}
+
+function decodePercentEncodedReference(reference: string): string {
+  return reference.replace(/(?:%[a-f\d]{2})+/gi, (encodedRun) => {
+    const bytes = encodedRun
+      .slice(1)
+      .split("%")
+      .map((hex) => Number.parseInt(hex, 16));
+    return new TextDecoder().decode(Uint8Array.from(bytes));
+  });
 }
 
 function projectGeneratedImageRow(

--- a/packages/agent/gui/shared/agentConversation/projection/agentToolRendererKind.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentToolRendererKind.ts
@@ -66,6 +66,7 @@ export function resolveAgentToolRendererKind(
       displayName: call.displayName,
       content: call.content,
       outputContent: call.output?.content,
+      outputSavedPath: call.output?.savedPath ?? call.output?.saved_path,
       inputPrompt: call.input?.prompt
     })
   ) {

--- a/packages/agent/gui/shared/imageGenerationTool.ts
+++ b/packages/agent/gui/shared/imageGenerationTool.ts
@@ -3,6 +3,7 @@ interface ImageGenerationProbe {
   displayName?: string | null;
   content?: unknown;
   outputContent?: unknown;
+  outputSavedPath?: unknown;
   inputPrompt?: unknown;
   payloadInputPrompt?: unknown;
 }
@@ -78,7 +79,8 @@ export function extractImageGenerationPreview(
 
   return {
     prompt,
-    imageUri: imageEntry?.uri ?? null,
+    imageUri:
+      firstString(imageEntry?.uri, stringValue(probe.outputSavedPath)) ?? null,
     mimeType: imageEntry?.mimeType ?? null
   };
 }

--- a/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
@@ -1738,6 +1738,87 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
     ]);
   });
 
+  it("collects canonical and historical Codex image generation paths", () => {
+    const canonicalPath =
+      "/Users/demo/.tutti/agent/runs/session-20/codex-home/generated_images/thread/ig_canonical.webp";
+    const historicalPath =
+      "/Users/demo/.tutti/agent/runs/session-20/codex-home/generated_images/thread/ig_legacy.png";
+    const snapshot = {
+      workspaceId: "workspace-1",
+      presences: [],
+      sessions: [
+        {
+          agentSessionId: "session-20",
+          cwd: "/Users/demo/project",
+          provider: "codex",
+          status: "completed",
+          title: "Generate images",
+          workspaceId: "workspace-1"
+        }
+      ],
+      sessionMessagesById: {
+        "session-20": [
+          {
+            agentSessionId: "session-20",
+            kind: "tool_call",
+            messageId: "message-canonical",
+            payload: {
+              toolName: "ImageGeneration",
+              content: [
+                {
+                  type: "content",
+                  content: {
+                    type: "image",
+                    uri: canonicalPath,
+                    mimeType: "image/webp"
+                  }
+                }
+              ]
+            },
+            role: "assistant",
+            status: "completed",
+            turnId: "turn-canonical",
+            occurredAtUnixMs: 1,
+            version: 1
+          },
+          {
+            agentSessionId: "session-20",
+            kind: "tool_call",
+            messageId: "message-historical",
+            payload: {
+              toolName: "ImageGeneration",
+              name: "Generate image",
+              output: {
+                savedPath: historicalPath,
+                result: "legacy-base64"
+              }
+            },
+            role: "assistant",
+            status: "completed",
+            turnId: "turn-historical",
+            occurredAtUnixMs: 2,
+            version: 2
+          }
+        ]
+      }
+    };
+
+    expect(
+      collectWorkspaceAgentGeneratedFiles(canonicalSource(snapshot), {
+        workspaceRoot: "/Users/demo/project"
+      })
+    ).toEqual([
+      {
+        path: canonicalPath,
+        label: "ig_canonical.webp"
+      },
+      {
+        path: historicalPath,
+        label: "ig_legacy.png"
+      }
+    ]);
+  });
+
   it("collects agent-generated files from lightweight change maps", () => {
     const snapshot = {
       workspaceId: "workspace-1",

--- a/packages/agent/gui/shared/workspaceAgentGeneratedFiles.ts
+++ b/packages/agent/gui/shared/workspaceAgentGeneratedFiles.ts
@@ -8,6 +8,7 @@ import type {
   WorkspaceAgentChangedFile
 } from "./workspaceAgentActivityListTypes";
 import { workspaceAgentSessionMessageAliases } from "./workspaceAgentSessionMessageAliases.ts";
+import { isImageGenerationToolCall } from "./imageGenerationTool.ts";
 
 export interface WorkspaceAgentGeneratedFilesSource {
   sessionMessagesById: Readonly<Record<string, AgentActivityMessage[]>>;
@@ -274,9 +275,23 @@ function imageGenerationPathsFromMessages(
       continue;
     }
     const output = objectValue(payload.output);
+    const legacySavedPath =
+      stringValue(output?.savedPath) ?? stringValue(output?.saved_path);
+    const legacyImagePaths =
+      legacySavedPath &&
+      isImageGenerationToolCall({
+        toolName: stringValue(payload.toolName),
+        displayName: stringValue(payload.name),
+        content: payload.content,
+        outputContent: output?.content,
+        outputSavedPath: legacySavedPath
+      })
+        ? [legacySavedPath]
+        : [];
     for (const uri of [
       ...imageGenerationUris(payload.content),
-      ...imageGenerationUris(output?.content)
+      ...imageGenerationUris(output?.content),
+      ...legacyImagePaths
     ]) {
       const normalized = normalizePath(uri);
       if (normalized) {
@@ -297,8 +312,9 @@ function imageGenerationUris(value: unknown): string[] {
     if (!record) {
       continue;
     }
-    const type = stringValue(record.type)?.toLowerCase();
-    const uri = stringValue(record.uri) ?? stringValue(record.path);
+    const content = objectValue(record.content) ?? record;
+    const type = stringValue(content.type)?.toLowerCase();
+    const uri = stringValue(content.uri) ?? stringValue(content.path);
     if (!uri) {
       continue;
     }

--- a/packages/agent/gui/shared/workspaceAgentToolCallDisplay.ts
+++ b/packages/agent/gui/shared/workspaceAgentToolCallDisplay.ts
@@ -532,6 +532,7 @@ function toolCallDetail(
     displayName: visibleRawToolName,
     content: item.payload?.content,
     outputContent: payloadOutput?.content,
+    outputSavedPath: payloadOutput?.savedPath ?? payloadOutput?.saved_path,
     inputPrompt: payloadInput?.prompt,
     payloadInputPrompt: metadataInput?.prompt
   });

--- a/packages/agent/runtimeprep/capability.go
+++ b/packages/agent/runtimeprep/capability.go
@@ -149,7 +149,7 @@ func TuttiDesktopHostPack() CapabilityPack {
 				Key:      "host-app-context",
 				Order:    1000,
 				Delivery: PolicyDeliveryProviderRuntime,
-				Body:     hostAppContextPolicy(),
+				Body:     hostAppContextPolicy(input),
 			},
 		}}, nil
 	}}

--- a/packages/agent/runtimeprep/capability_test.go
+++ b/packages/agent/runtimeprep/capability_test.go
@@ -51,6 +51,22 @@ func TestDefaultPreparerResolvesInjectedPackAcrossPolicySkillsAndEnv(t *testing.
 	}
 }
 
+func TestHostAppContextUsesNativeGeneratedImageArtifactsOnlyForSupportedProviders(t *testing.T) {
+	codexPolicy := hostAppContextPolicy(PrepareInput{Provider: "codex"})
+	if !strings.Contains(codexPolicy, "rendered directly from `imageGeneration` tool output") ||
+		!strings.Contains(codexPolicy, "do not repeat generated images as Markdown image tags") ||
+		strings.Contains(codexPolicy, "final response must include Markdown image tag") {
+		t.Fatalf("codex host policy = %q, want native generated-image artifact contract", codexPolicy)
+	}
+
+	claudePolicy := hostAppContextPolicy(PrepareInput{Provider: "claude-code"})
+	if !strings.Contains(claudePolicy, "Generated/edited image output: final response must include Markdown image tag.") ||
+		!strings.Contains(claudePolicy, "Multiple final images: one Markdown image tag each.") ||
+		strings.Contains(claudePolicy, "rendered directly from `imageGeneration` tool output") {
+		t.Fatalf("claude host policy = %q, want Markdown image fallback contract", claudePolicy)
+	}
+}
+
 func TestCustomDeploymentProfileDoesNotInheritTuttiDesktopHostPolicy(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/runtimeprep/policy_templates/host-app-context.md
+++ b/packages/agent/runtimeprep/policy_templates/host-app-context.md
@@ -7,14 +7,15 @@ You are running inside the Tutti desktop app host, which can render local and we
 - Images/videos: use Markdown, e.g. `![alt](/absolute/path.png)`.
 - Local media/file links: absolute filesystem paths only.
 - Public direct image URL: render as image, e.g. `![alt](https://example.com/image.png)`.
-- Generated/edited image output: final response must include Markdown image tag.
+
+{{GENERATED_IMAGE_OUTPUT_POLICY}}
+
 - Localhost image URL (`127.0.0.1`, `localhost`, machine-local): download to readable local file, then render local path.
 - Prefer `$CODEX_HOME/generated_images/`; else session-local `generated_images/`.
 - Sandbox path like `/mnt/data/...`: copy/move before reference; never use unverified sandbox path.
 - Before final: verify local image path exists/readable, e.g. `test -f /absolute/path.png && test -r /absolute/path.png`.
 - No inline base64.
 - No plain-text-only image paths.
-- Multiple final images: one Markdown image tag each.
 
 ## References
 

--- a/packages/agent/runtimeprep/preparer_test.go
+++ b/packages/agent/runtimeprep/preparer_test.go
@@ -106,7 +106,9 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 	}
 	if !strings.Contains(string(codexAgents), "# Host App Context") ||
 		!strings.Contains(string(codexAgents), "Images/videos: use Markdown") ||
-		!strings.Contains(string(codexAgents), "Generated/edited image output: final response must include Markdown image tag.") ||
+		!strings.Contains(string(codexAgents), "Native image generation results are rendered directly from `imageGeneration` tool output as generated-image artifacts.") ||
+		!strings.Contains(string(codexAgents), "do not repeat generated images as Markdown image tags") ||
+		strings.Contains(string(codexAgents), "Generated/edited image output: final response must include Markdown image tag.") ||
 		!strings.Contains(string(codexAgents), "Prefer `$CODEX_HOME/generated_images/`") ||
 		!strings.Contains(string(codexAgents), "never use unverified sandbox path") ||
 		!strings.Contains(string(codexAgents), "No inline base64.") ||

--- a/packages/agent/runtimeprep/tutti_cli_policy.go
+++ b/packages/agent/runtimeprep/tutti_cli_policy.go
@@ -15,8 +15,36 @@ func tuttiCLIPolicy(input PrepareInput) string {
 	return tuttiRuntimePolicy(input)
 }
 
-func hostAppContextPolicy() string {
-	return strings.TrimSpace(renderProviderSkillTemplate("policy_templates/host-app-context.md", nil))
+func hostAppContextPolicy(input PrepareInput) string {
+	return strings.TrimSpace(renderProviderSkillTemplate(
+		"policy_templates/host-app-context.md",
+		map[string]string{
+			"{{GENERATED_IMAGE_OUTPUT_POLICY}}": generatedImageOutputPolicy(input.Provider),
+		},
+	))
+}
+
+func generatedImageOutputPolicy(provider string) string {
+	if providerSupportsNativeGeneratedImageArtifacts(provider) {
+		return strings.Join([]string{
+			"- Native image generation results are rendered directly from `imageGeneration` tool output as generated-image artifacts.",
+			"- After successful native image generation, do not repeat generated images as Markdown image tags, links, or plain-text paths in the final response.",
+			"- Use Markdown image tags only for images that were not already delivered as native generated-image artifacts.",
+		}, "\n")
+	}
+	return strings.Join([]string{
+		"- Generated/edited image output: final response must include Markdown image tag.",
+		"- Multiple final images: one Markdown image tag each.",
+	}, "\n")
+}
+
+func providerSupportsNativeGeneratedImageArtifacts(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "codex", "tutti-agent":
+		return true
+	default:
+		return false
+	}
 }
 
 func tuttiRuntimePolicy(input PrepareInput) string {


### PR DESCRIPTION
## Problem

Codex image generation completed successfully, but generated images were previously missing from the Agent conversation. After promoting the structured `imageGeneration` output to an artifact, the same image could then appear twice when Tutti also instructed the model to repeat it as a final Markdown image.

## Root cause

Two independent presentation paths existed for the same generated file:

- the Codex app-server `imageGeneration` item, normalized into canonical image content;
- the final assistant Markdown image required by Tutti's host-app instructions.

The image-generation Tool Call detail also rendered the output preview, adding another possible duplicate presentation surface.

## Fix

- Normalize completed Codex image-generation items into canonical text/image content without persisting base64 payloads.
- Promote completed image-generation output into a first-class generated-image artifact row.
- Make the host image-output contract provider-aware:
  - Codex and Tutti Agent use native generated-image artifacts and must not repeat them in final Markdown.
  - Providers without native image artifacts retain the Markdown image fallback.
- Remove generated image output previews from the Tool Call detail; it now retains prompt/status details only.
- Add a compatibility guard that removes only same-turn Markdown images whose normalized path matches a generated-image artifact. Other Markdown images remain unchanged.
- Preserve historical `savedPath` compatibility and generated-file discovery.

## User impact

Generated images appear once as conversation artifacts, while older conversations and non-native providers continue to render safely.

## Validation

- `pnpm check:changed` — 12 lanes passed
- pre-push `pnpm check:full` — 18 tasks passed
- `go test ./...` in `packages/agent/runtimeprep`
- Agent GUI tests — 186 files / 1679 tests passed
- targeted projection and Tool Call tests — 91 tests passed
- Agent GUI typecheck and Oxlint passed
