### PR TITLE
fix(agent): allow stopping sessions during activation

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1029,6 +1029,15 @@ The session engine owns activation deadlines. It passes one cancellation signal
 through the desktop command port and HTTP adapter. Adapters must not race the
 engine with an independent timeout budget; command timeout, cancellation, and
 uncertain-delivery reconciliation are one engine workflow.
+Stop is also engine-owned during activation. The provider-neutral
+`session/stopRequested` intent aborts the exact in-flight activation command and
+keeps a workspace/session-scoped `awaitingTurn` cancel until the first canonical
+Turn arrives. That transition then emits an exact `turn/cancel`; a bounded
+expiry removes the detached operation so a later, unrelated Turn cannot be
+canceled. Empty reconcile snapshots must preserve this detached operation.
+When request cancellation causes create to fail, daemon rollback uses a bounded
+context detached from the canceled request so provisional runtime state is
+still closed and removed.
 The outer new-session activation deadline must also leave room for process spawn
 and `initialize` before ACP `session/new` starts its own full 30-second timeout;
 an activation timer that starts at the user's click must not cancel
@@ -2459,12 +2468,14 @@ still fails the submit immediately, while a timed-out delivery keeps its
 uncertain reconciliation and terminal expiry behavior.
 
 A user stop is an intent, not just a turn cancel: `interruptCurrentTurn`
-suspends the session's prompt queue (`suspendReason: "user_stop"`) before
-issuing the cancel, so the drainer must not fire the next queued prompt the
-moment the session becomes available. Only an explicit user send lifts the
-hold — composer submit resumes the queue, and a send-now intent clears the
-suspension in the queue core. The send-now cancel path never suspends: intent is
-captured at its source, never inferred from the cancel outcome.
+dispatches one provider-neutral `session/stopRequested` intent. The engine
+atomically suspends the session's prompt queue (`suspendReason: "user_stop"`),
+aborts any matching activation command, and requests or awaits exact-turn
+cancel. The drainer therefore cannot fire the next queued prompt the moment the
+session becomes available. Only an explicit user send lifts the hold — composer
+submit resumes the queue, and a send-now intent clears the suspension in the
+queue core. The send-now cancel path never suspends: intent is captured at its
+source, never inferred from the cancel outcome.
 
 Queue suspension must also remain visible in the presentation projection.
 AgentGUI controllers map the queue record's `suspendReason` to the internal

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1342,6 +1342,44 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [controller_session_lifecycle.go](../../packages/agent/daemon/runtime/controller_session_lifecycle.go)
   [agent_runtime_adapter.go](../../services/tuttid/agent_runtime_adapter.go)
 
+### AgentGUI cannot stop Cursor immediately after the first message
+
+- Symptom:
+  The first Cursor message enters an activating state, but Stop is absent or
+  does nothing until a canonical session and Turn appear. Codex and Claude Code
+  often appear unaffected because their startup completes before a user can hit
+  the same window.
+- Quick checks:
+  Correlate the activation request with process spawn, ACP `initialize`,
+  `session/new`, and the first Turn. If Stop becomes available only after the
+  Turn id is known, the UI and engine are treating cancellation as turn-only.
+  Also inspect failed-create cleanup after request cancellation for provisional
+  runtime state left under the session id.
+- Root cause:
+  New-session activation is an abortable engine command before it becomes a
+  canonical Turn. A turn-only Stop gate cannot target that command, and a cancel
+  operation stored only under existing session entities is lost on an empty
+  reconciliation snapshot. Cleanup that reuses the canceled request context
+  can then fail to close the provisional runtime.
+- Fix:
+  Dispatch one provider-neutral session Stop intent. Abort the exact activation
+  command by command id, preserve a detached workspace/session-scoped
+  `awaitingTurn` cancel through snapshots, and convert it to exact-turn cancel
+  when the first Turn arrives. Expire the detached operation after a bounded
+  window. Run failed-create close and cleanup with a bounded context detached
+  from request cancellation.
+- Validation:
+  Cover immediate activation abort, empty-snapshot preservation, late first-Turn
+  cancel, expiry before an unrelated future Turn, and identical lifecycle
+  behavior for Cursor, Codex, and Claude Code. Verify AgentGUI exposes Stop
+  while new-conversation activation is still submitting.
+- References:
+  [createAgentSessionEngine.ts](../../../packages/agent/activity-core/src/engine/createAgentSessionEngine.ts)
+  [sessionLifecycle.reducer.ts](../../../packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts)
+  [pendingIntents.reducer.ts](../../../packages/agent/activity-core/src/engine/pendingIntents.reducer.ts)
+  [useAgentGUIDetailModel.tsx](../../../packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx)
+  [service.go](../../../services/tuttid/service/agent/service.go)
+
 ### Cursor session/new is canceled before its 30-second timeout
 
 - Symptom:

--- a/packages/agent/activity-core/src/engine/createAgentSessionEngine.test.ts
+++ b/packages/agent/activity-core/src/engine/createAgentSessionEngine.test.ts
@@ -344,6 +344,87 @@ test("rescheduling an expiry id replaces the previous deadline", () => {
   assert.equal(engine.getSnapshot().engineRuntime.lastExpiredIntentId, "e-3");
 });
 
+test("stop aborts activation immediately and cancels the first turn when it arrives", () => {
+  const { commandPort, engine } = createHarness();
+  engine.dispatch({
+    agentSessionId: "session-1",
+    agentTargetId: "cursor",
+    clientSubmitId: "submit-1",
+    content: [{ type: "text", text: "hello" }],
+    cwd: "/workspace",
+    expiresAtUnixMs: 60_000,
+    mode: "new",
+    requestedAtUnixMs: 1,
+    requestId: "activation-1",
+    type: "activation/requested",
+    workspaceId: "ws-1"
+  });
+  assert.equal(
+    commandPort.abortSignalsByCommandId.get("activate:activation-1")?.aborted,
+    false
+  );
+
+  engine.dispatch({
+    agentSessionId: "session-1",
+    awaitingTurnExpiresAtUnixMs: 30_000,
+    commandId: "stop-1",
+    type: "session/stopRequested",
+    workspaceId: "ws-1"
+  });
+
+  assert.equal(
+    commandPort.abortSignalsByCommandId.get("activate:activation-1")?.aborted,
+    true
+  );
+  assert.equal(
+    engine.getSnapshot().pendingIntents.activationsByRequestId["activation-1"]
+      ?.status,
+    "canceled"
+  );
+  assert.equal(
+    engine.getSnapshot().sessionLifecycle.operationBySessionId["session-1"]
+      ?.cancel.status,
+    "awaitingTurn"
+  );
+
+  engine.dispatch({
+    session: {
+      activeTurn: {
+        agentSessionId: "session-1",
+        origin: "user_prompt",
+        phase: "running",
+        startedAtUnixMs: 2,
+        turnId: "turn-1",
+        updatedAtUnixMs: 2
+      },
+      activeTurnId: "turn-1",
+      agentSessionId: "session-1",
+      cwd: "/workspace",
+      latestTurnInteractions: [],
+      pendingInteractions: [],
+      provider: "cursor",
+      title: "Session",
+      updatedAtUnixMs: 2,
+      workspaceId: "ws-1"
+    },
+    type: "session/upserted"
+  });
+
+  assert.deepEqual(
+    commandPort.executedCommands.find(
+      (command) => command.type === "turn/cancel"
+    ),
+    {
+      agentSessionId: "session-1",
+      commandId: "stop-1",
+      timeoutMs: 30_000,
+      turnId: "turn-1",
+      type: "turn/cancel",
+      workspaceId: "ws-1"
+    }
+  );
+});
+
 test("interleaving: expiry firing between probe start and probe result", async () => {
   const { commandPort, engine, timer } = createHarness();
   engine.dispatch({ probeId: "p-4", type: "engine/probeRequested" });

--- a/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
+++ b/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
@@ -124,7 +124,9 @@ export function createAgentSessionEngine({
         const result = rootEngineReducer(state, intent);
         state = result.state;
         for (const command of result.commands) {
-          if (isEngineInternalCommand(command)) {
+          if (command.type === "engine/abortExternalCommand") {
+            effectExecutor.abort(command.targetCommandId, command.reason);
+          } else if (isEngineInternalCommand(command)) {
             expiryClock.apply(command);
           } else {
             effectExecutor.execute(command);

--- a/packages/agent/activity-core/src/engine/effectExecutor.ts
+++ b/packages/agent/activity-core/src/engine/effectExecutor.ts
@@ -22,6 +22,7 @@ export interface CreateEngineEffectExecutorInput {
 }
 
 export interface EngineEffectExecutor {
+  abort(commandId: string, reason: string): void;
   dispose(): void;
   execute(command: EngineExternalCommand): void;
 }
@@ -34,7 +35,7 @@ export function createEngineEffectExecutor({
 }: CreateEngineEffectExecutorInput): EngineEffectExecutor {
   let disposed = false;
   const timeoutTasks = new Set<EngineScheduledTask>();
-  const abortControllers = new Set<AbortController>();
+  const abortControllersByCommandId = new Map<string, AbortController>();
 
   const settle = (intent: EngineCommandResultIntent): void => {
     if (disposed) {
@@ -48,25 +49,34 @@ export function createEngineEffectExecutor({
   };
 
   return {
+    abort(commandId, reason) {
+      const controller = abortControllersByCommandId.get(commandId.trim());
+      if (!controller || controller.signal.aborted) return;
+      controller.abort(new Error(reason.trim() || "engine command aborted"));
+    },
     dispose() {
       disposed = true;
       for (const task of timeoutTasks) {
         task.cancel();
       }
       timeoutTasks.clear();
-      for (const controller of abortControllers) {
+      for (const controller of abortControllersByCommandId.values()) {
         controller.abort(new Error("engine disposed"));
       }
-      abortControllers.clear();
+      abortControllersByCommandId.clear();
     },
     execute(command) {
       let settled = false;
       let timeoutTask: EngineScheduledTask | null = null;
       const abortController = new AbortController();
-      abortControllers.add(abortController);
+      abortControllersByCommandId.set(command.commandId, abortController);
 
       const finishTimeoutTask = (): void => {
-        abortControllers.delete(abortController);
+        if (
+          abortControllersByCommandId.get(command.commandId) === abortController
+        ) {
+          abortControllersByCommandId.delete(command.commandId);
+        }
         if (timeoutTask !== null) {
           timeoutTasks.delete(timeoutTask);
           timeoutTask.cancel();

--- a/packages/agent/activity-core/src/engine/expiryClock.ts
+++ b/packages/agent/activity-core/src/engine/expiryClock.ts
@@ -1,7 +1,7 @@
 import type {
   EngineClock,
+  EngineExpiryCommand,
   EngineIntentExpiredIntent,
-  EngineInternalCommand,
   EngineScheduledTask,
   EngineScheduler
 } from "./types.ts";
@@ -18,7 +18,7 @@ export interface CreateEngineExpiryClockInput {
 }
 
 export interface EngineExpiryClock {
-  apply(command: EngineInternalCommand): void;
+  apply(command: EngineExpiryCommand): void;
   dispose(): void;
 }
 

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.ts
@@ -1,10 +1,11 @@
 import type { AgentActivitySessionInput } from "../sessionNormalization.ts";
 import type { SendInputResultValidation } from "./commandResult.validation.ts";
 import type { ScopedSessionResultValidation } from "./commandResult.validation.ts";
-import type {
-  PendingActivationIntentRecord,
-  PendingIntentsState,
-  SessionActivationRequestedIntent
+import {
+  isPendingActivationViable,
+  type PendingActivationIntentRecord,
+  type PendingIntentsState,
+  type SessionActivationRequestedIntent
 } from "./pendingIntents.types.ts";
 import {
   confirmFromMessages,
@@ -74,6 +75,8 @@ export function pendingIntentsReducer(
       return clearActivationFailure(state, intent.agentSessionId);
     case "activation/unactivateRequested":
       return requestUnactivation(state, intent);
+    case "session/stopRequested":
+      return stopPendingActivation(state, intent);
     case "submit/requested":
       if (context.submitRequestAccepted === false) return unchanged(state);
       if (context.deletedSessionIds[intent.agentSessionId.trim()]) {
@@ -149,7 +152,7 @@ function patchActivationSettings(
       (candidate) =>
         candidate.agentSessionId === agentSessionId &&
         candidate.mode === "new" &&
-        candidate.status !== "failed"
+        isPendingActivationViable(candidate)
     )
     .sort((left, right) => right.requestedAtUnixMs - left.requestedAtUnixMs)[0];
   if (!record) return unchanged(state);
@@ -413,6 +416,38 @@ function requestUnactivation(
   };
 }
 
+function stopPendingActivation(
+  state: PendingIntentsState,
+  intent: Extract<EngineIntent, { type: "session/stopRequested" }>
+): EngineReducerResult<PendingIntentsState> {
+  const agentSessionId = intent.agentSessionId.trim();
+  const workspaceId = intent.workspaceId.trim();
+  const activation = Object.values(state.activationsByRequestId)
+    .filter(
+      (record) =>
+        record.agentSessionId === agentSessionId &&
+        record.workspaceId === workspaceId &&
+        (record.status === "requested" || record.status === "uncertain")
+    )
+    .sort((left, right) => right.requestedAtUnixMs - left.requestedAtUnixMs)[0];
+  if (!activation) return unchanged(state);
+  return {
+    commands: [
+      {
+        type: "engine/abortExternalCommand",
+        reason: "agent session activation canceled by user",
+        targetCommandId: `activate:${activation.requestId}`
+      }
+    ],
+    state: replaceActivation(state, {
+      ...activation,
+      errorCode: null,
+      errorMessage: null,
+      status: "canceled"
+    })
+  };
+}
+
 function settleActivationCommand(
   state: PendingIntentsState,
   intent: EngineCommandResultIntent
@@ -422,6 +457,7 @@ function settleActivationCommand(
   if (!record) {
     return unchanged(state);
   }
+  if (record.status === "canceled") return unchanged(state);
   if (
     intent.outcome === "succeeded" &&
     isActivationCommandResult(intent.value)
@@ -592,6 +628,9 @@ function expireActivation(
   }
   if (record.status === "confirmed") {
     return unchanged(state);
+  }
+  if (record.status === "canceled") {
+    return { commands: NO_COMMANDS, state: deleteActivation(state, requestId) };
   }
   return {
     commands: NO_COMMANDS,

--- a/packages/agent/activity-core/src/engine/pendingIntents.selectors.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.selectors.ts
@@ -152,7 +152,9 @@ export function selectSessionActivationPresentations(
             ? "active"
             : activation.status === "failed"
               ? "failed"
-              : "activating"
+              : activation.status === "canceled"
+                ? "inactive"
+                : "activating"
     };
   }
   for (const agentSessionId of Object.keys(

--- a/packages/agent/activity-core/src/engine/pendingIntents.types.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.types.ts
@@ -9,8 +9,21 @@ import type {
 export type PendingActivationStatus =
   | "requested"
   | "confirmed"
+  | "canceled"
   | "uncertain"
   | "failed";
+
+/** True while an activation may still yield, or already yielded, a session. */
+export function isPendingActivationViable(
+  activation: { status: PendingActivationStatus } | null | undefined
+): boolean {
+  return (
+    activation !== null &&
+    activation !== undefined &&
+    activation.status !== "failed" &&
+    activation.status !== "canceled"
+  );
+}
 
 interface PendingActivationIntentRecordBase {
   agentSessionId: string;

--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts
@@ -251,9 +251,11 @@ test("user stop suspension blocks drain until explicit resume", () => {
   state = reduce(
     state,
     {
-      type: "queue/suspended",
       agentSessionId: "session-1",
-      reason: "user_stop"
+      awaitingTurnExpiresAtUnixMs: 30_000,
+      commandId: "stop-1",
+      type: "session/stopRequested",
+      workspaceId: "workspace-1"
     },
     running
   ).state;

--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
@@ -135,6 +135,8 @@ function reduceQueueOwnedState(
       );
     case "queue/suspended":
       return suspendQueue(state, intent.agentSessionId, intent.reason);
+    case "session/stopRequested":
+      return suspendQueue(state, intent.agentSessionId, "user_stop");
     case "queue/resumed":
       return context.deletedSessionIds[intent.agentSessionId.trim()]
         ? unchanged(state)

--- a/packages/agent/activity-core/src/engine/sessionEntities.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionEntities.reducer.ts
@@ -64,6 +64,14 @@ export function replaceCanonicalSessionSnapshot(
         state.operationBySessionId[id] ?? createOperation();
     }
   }
+  for (const [id, operation] of Object.entries(state.operationBySessionId)) {
+    if (
+      !operationBySessionId[id] &&
+      operation.cancel.status === "awaitingTurn"
+    ) {
+      operationBySessionId[id] = operation;
+    }
+  }
   for (const turn of Object.values(state.turnsById)) {
     const key = canonicalTurnKey(turn.agentSessionId, turn.turnId);
     if (sessionsById[turn.agentSessionId] && !turnsById[key]) {

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
@@ -655,6 +655,7 @@ test("cancel request targets the exact active turn and deduplicates", () => {
   }).state;
   const requested = reduce(state, {
     type: "session/cancelRequested",
+    workspaceId: "workspace-1",
     agentSessionId: "session-1",
     awaitingTurnExpiresAtUnixMs: 30_000,
     commandId: "cancel-1"
@@ -670,6 +671,7 @@ test("cancel request targets the exact active turn and deduplicates", () => {
   assert.equal(
     reduce(requested.state, {
       type: "session/cancelRequested",
+      workspaceId: "workspace-1",
       agentSessionId: "session-1",
       awaitingTurnExpiresAtUnixMs: 30_000,
       commandId: "cancel-2"
@@ -685,6 +687,7 @@ test("cancel requested before turn creation waits for a v2 turn entity", () => {
   }).state;
   const waiting = reduce(state, {
     type: "session/cancelRequested",
+    workspaceId: "workspace-1",
     agentSessionId: "session-1",
     awaitingTurnExpiresAtUnixMs: 30_000,
     commandId: "cancel-1"
@@ -700,6 +703,42 @@ test("cancel requested before turn creation waits for a v2 turn entity", () => {
   assert.ok(started.commands.some((command) => command.type === "turn/cancel"));
 });
 
+for (const provider of ["cursor", "codex", "claude-code"]) {
+  test(`stop requested before ${provider} activation survives snapshots and cancels the first turn`, () => {
+    const waiting = reduce(createInitialSessionLifecycleState(), {
+      type: "session/stopRequested",
+      agentSessionId: "session-1",
+      awaitingTurnExpiresAtUnixMs: 30_000,
+      commandId: `stop-${provider}`,
+      workspaceId: "workspace-1"
+    });
+    assert.equal(
+      waiting.state.operationBySessionId["session-1"]?.cancel.status,
+      "awaitingTurn"
+    );
+
+    const reconciled = reduce(waiting.state, {
+      type: "session/snapshotReceived",
+      sessions: []
+    });
+    assert.equal(
+      reconciled.state.operationBySessionId["session-1"]?.cancel.status,
+      "awaitingTurn"
+    );
+
+    const started = reduce(reconciled.state, {
+      type: "session/upserted",
+      session: session(activeTurn(2), 2, provider)
+    });
+    assert.ok(
+      started.commands.some(
+        (command) =>
+          command.type === "turn/cancel" && command.turnId === "turn-1"
+      )
+    );
+  });
+}
+
 test("metadata updates do not abandon an awaiting cancel before its expiry", () => {
   let state = reduce(createInitialSessionLifecycleState(), {
     type: "session/snapshotReceived",
@@ -707,6 +746,7 @@ test("metadata updates do not abandon an awaiting cancel before its expiry", () 
   }).state;
   state = reduce(state, {
     type: "session/cancelRequested",
+    workspaceId: "workspace-1",
     agentSessionId: "session-1",
     awaitingTurnExpiresAtUnixMs: 30_000,
     commandId: "cancel-1"
@@ -728,6 +768,7 @@ test("awaiting cancel expires deterministically and cannot cancel a future turn"
   }).state;
   const waiting = reduce(state, {
     type: "session/cancelRequested",
+    workspaceId: "workspace-1",
     agentSessionId: "session-1",
     awaitingTurnExpiresAtUnixMs: 100,
     commandId: "cancel-1"
@@ -762,6 +803,7 @@ test("idempotent not-found cancel clears only its target and requests reconcile"
   }).state;
   state = reduce(state, {
     type: "session/cancelRequested",
+    workspaceId: "workspace-1",
     agentSessionId: "session-1",
     awaitingTurnExpiresAtUnixMs: 30_000,
     commandId: "cancel-1"
@@ -794,6 +836,7 @@ test("authoritative settled state clears a cancel timeout failure", () => {
   }).state;
   state = reduce(state, {
     type: "session/cancelRequested",
+    workspaceId: "workspace-1",
     agentSessionId: "session-1",
     awaitingTurnExpiresAtUnixMs: 30_000,
     commandId: "cancel-1"
@@ -829,6 +872,7 @@ test("cancel result for another session cannot enter canonical turn state", () =
   }).state;
   state = reduce(state, {
     type: "session/cancelRequested",
+    workspaceId: "workspace-1",
     agentSessionId: "session-1",
     awaitingTurnExpiresAtUnixMs: 30_000,
     commandId: "cancel-1"
@@ -862,6 +906,7 @@ test("late cancel result for turn A cannot overwrite newer turn B", () => {
   }).state;
   state = reduce(state, {
     type: "session/cancelRequested",
+    workspaceId: "workspace-1",
     agentSessionId: "session-1",
     awaitingTurnExpiresAtUnixMs: 30_000,
     commandId: "cancel-1"
@@ -1107,7 +1152,8 @@ function reduce(
 
 function session(
   turn: AgentActivityTurn | null,
-  updatedAtUnixMs: number
+  updatedAtUnixMs: number,
+  provider = "codex"
 ): AgentActivitySession {
   return normalizeAgentActivitySession({
     ...{
@@ -1117,7 +1163,7 @@ function session(
     },
     workspaceId: "workspace-1",
     agentSessionId: "session-1",
-    provider: "codex",
+    provider,
     cwd: "/workspace",
     title: "Session",
     activeTurnId: turn?.turnId ?? null,

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts
@@ -110,6 +110,8 @@ export function sessionLifecycleReducer(
       }));
     case "session/cancelRequested":
       return requestCancel(state, intent);
+    case "session/stopRequested":
+      return requestCancel(state, intent);
     case "session/settingsUpdateRequested":
       return requestSettingsUpdate(state, intent);
     case "submit/requested":
@@ -120,7 +122,8 @@ export function sessionLifecycleReducer(
             commandId: `submit:cancel:${intent.clientSubmitId}`,
             awaitingTurnExpiresAtUnixMs:
               intent.requestedAtUnixMs + TURN_CANCEL_TIMEOUT_MS,
-            timeoutMs: TURN_CANCEL_TIMEOUT_MS
+            timeoutMs: TURN_CANCEL_TIMEOUT_MS,
+            workspaceId: intent.workspaceId
           })
         : unchanged(state);
     case "queue/sendNowRequested":
@@ -130,7 +133,10 @@ export function sessionLifecycleReducer(
             agentSessionId: intent.agentSessionId,
             commandId: intent.cancelCommandId,
             awaitingTurnExpiresAtUnixMs: intent.awaitingTurnExpiresAtUnixMs,
-            timeoutMs: intent.timeoutMs
+            timeoutMs: intent.timeoutMs,
+            workspaceId:
+              state.sessionsById[intent.agentSessionId.trim()]?.workspaceId ??
+              ""
           })
         : unchanged(state);
     case "session/cancelAbandoned":
@@ -374,40 +380,51 @@ function patchSessionMetadata(
 
 function requestCancel(
   state: SessionLifecycleState,
-  intent: Extract<EngineIntent, { type: "session/cancelRequested" }>
+  intent: Extract<
+    EngineIntent,
+    { type: "session/cancelRequested" | "session/stopRequested" }
+  >
 ): EngineReducerResult<SessionLifecycleState> {
   const id = intent.agentSessionId.trim();
-  const operation = state.operationBySessionId[id];
   const session = state.sessionsById[id];
-  if (!operation || !session || cancelPending(operation.cancel))
+  const workspaceId = intent.workspaceId.trim();
+  if (
+    !id ||
+    !workspaceId ||
+    state.deletedSessionIds[id] ||
+    (session && session.workspaceId !== workspaceId)
+  ) {
     return unchanged(state);
-  const turn = session.activeTurnId
-    ? state.turnsById[canonicalTurnKey(id, session.activeTurnId)]
+  }
+  let nextState = state;
+  let operation = state.operationBySessionId[id];
+  if (!operation) {
+    operation = initialOperation();
+    nextState = setOperation(state, id, operation);
+  }
+  if (cancelPending(operation.cancel)) return unchanged(nextState);
+  const activeTurnId = session?.activeTurnId ?? null;
+  const turn = activeTurnId
+    ? state.turnsById[canonicalTurnKey(id, activeTurnId)]
     : null;
   if (turn && turn.phase !== "settled") {
     const next = setCancel(
-      state,
+      nextState,
       id,
-      requestedCancel(intent.commandId, turn.turnId, session.workspaceId)
+      requestedCancel(intent.commandId, turn.turnId, workspaceId)
     );
     return {
       commands: [
-        cancelCommand(
-          session.workspaceId,
-          id,
-          turn,
-          intent.commandId,
-          intent.timeoutMs
-        )
+        cancelCommand(workspaceId, id, turn, intent.commandId, intent.timeoutMs)
       ],
       state: next
     };
   }
   const expiryId = `cancel:awaiting-turn:${intent.commandId}`;
-  const next = setCancel(state, id, {
-    ...requestedCancel(intent.commandId, null, session.workspaceId),
+  const next = setCancel(nextState, id, {
+    ...requestedCancel(intent.commandId, null, workspaceId),
     expiryId,
-    requestedSessionVersion: sessionVersion(session),
+    requestedSessionVersion: session ? sessionVersion(session) : null,
     status: "awaitingTurn"
   });
   return {
@@ -605,12 +622,24 @@ function clearCancel(
 ): EngineReducerResult<SessionLifecycleState> {
   const operation = state.operationBySessionId[id];
   if (!operation || operation.cancel.status === "idle") return unchanged(state);
+  const nextState = state.sessionsById[id]
+    ? setCancel(state, id, initialCancel())
+    : removeDetachedOperation(state, id);
   return {
     commands: operation.cancel.expiryId
       ? [{ type: "engine/cancelExpiry", expiryId: operation.cancel.expiryId }]
       : NO_COMMANDS,
-    state: setCancel(state, id, initialCancel())
+    state: nextState
   };
+}
+
+function removeDetachedOperation(
+  state: SessionLifecycleState,
+  id: string
+): SessionLifecycleState {
+  const operationBySessionId = { ...state.operationBySessionId };
+  delete operationBySessionId[id];
+  return { ...state, operationBySessionId };
 }
 
 function updateOperation(

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
@@ -15,6 +15,7 @@ import {
   canonicalTurnKey
 } from "./sessionEntityKeys.ts";
 import { selectLatestActivationForSession } from "./pendingIntents.selectors.ts";
+import { isPendingActivationViable } from "./pendingIntents.types.ts";
 import { deriveCanonicalSubmitAvailability } from "./sessionLifecycle.availability.ts";
 
 export interface WorkspaceAgentConsumerSession {
@@ -397,6 +398,6 @@ function initialActivationTurnIsPending(
   return (
     activation?.mode === "new" &&
     activation.initialTurnExpected &&
-    activation.status !== "failed"
+    isPendingActivationViable(activation)
   );
 }

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.types.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.types.ts
@@ -146,6 +146,16 @@ export interface SessionCancelRequestedIntent {
   commandId: string;
   awaitingTurnExpiresAtUnixMs: number;
   timeoutMs?: number;
+  workspaceId: string;
+}
+
+export interface SessionStopRequestedIntent {
+  type: "session/stopRequested";
+  agentSessionId: string;
+  commandId: string;
+  awaitingTurnExpiresAtUnixMs: number;
+  timeoutMs?: number;
+  workspaceId: string;
 }
 
 export interface SessionCancelAbandonedIntent {
@@ -174,6 +184,7 @@ export type SessionLifecycleIntent =
   | SessionRemovedIntent
   | SessionSettingsUpdateRequestedIntent
   | SessionSnapshotReceivedIntent
+  | SessionStopRequestedIntent
   | SessionUpsertedIntent
   | TurnUpsertedIntent;
 

--- a/packages/agent/activity-core/src/engine/types.ts
+++ b/packages/agent/activity-core/src/engine/types.ts
@@ -124,6 +124,13 @@ export interface EngineCancelExpiryCommand {
   expiryId: string;
 }
 
+/** Cancels one in-flight external command without coupling reducers to I/O. */
+export interface EngineAbortExternalCommand {
+  type: "engine/abortExternalCommand";
+  reason: string;
+  targetCommandId: string;
+}
+
 export interface EngineExternalCommandBase {
   commandId: string;
   timeoutMs?: number;
@@ -139,9 +146,13 @@ export interface EngineReconcileWorkspaceCommand extends EngineExternalCommandBa
   workspaceId: string;
 }
 
-export type EngineInternalCommand =
+export type EngineExpiryCommand =
   | EngineCancelExpiryCommand
   | EngineScheduleExpiryCommand;
+
+export type EngineInternalCommand =
+  | EngineAbortExternalCommand
+  | EngineExpiryCommand;
 
 export type EngineExternalCommand =
   | AttentionReadCommand
@@ -163,6 +174,7 @@ export function isEngineInternalCommand(
   command: EngineCommand
 ): command is EngineInternalCommand {
   return (
+    command.type === "engine/abortExternalCommand" ||
     command.type === "engine/cancelExpiry" ||
     command.type === "engine/scheduleExpiry"
   );

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -198,6 +198,7 @@ export type {
   SubmitDismissedIntent,
   SubmitRequestedIntent
 } from "./engine/pendingIntents.types.ts";
+export { isPendingActivationViable } from "./engine/pendingIntents.types.ts";
 export {
   pendingSubmitRecordListsEqual,
   selectPendingActivationByRequestId,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -1,6 +1,4 @@
 import {
-  selectPendingActivations,
-  selectWorkspaceAgentConsumerSessions,
   type AgentActivitySession,
   type AgentSessionEngine,
   type AgentSessionEngineState
@@ -28,6 +26,7 @@ import {
   type ConversationRailSectionMembership,
   type ConversationRailSectionPageState
 } from "../model/agentGuiConversationRail";
+import { projectConversationRailMembershipRecords } from "../model/agentGuiConversationRailMembershipRecords";
 
 const SECTION_PAGE_SIZE = 5;
 const SEARCH_PAGE_SIZE = 100;
@@ -145,7 +144,9 @@ export class AgentGUIConversationRailQueryController {
   private searchRequestSequence = 0;
   private attached = false;
   private ingestingSessions = false;
-  private previousMembershipRecords: ReturnType<typeof membershipRecords>;
+  private previousMembershipRecords: ReturnType<
+    typeof projectConversationRailMembershipRecords
+  >;
   private unsubscribeEngine: (() => void) | null = null;
 
   constructor(input: ControllerInput) {
@@ -161,7 +162,7 @@ export class AgentGUIConversationRailQueryController {
     this.runtime = input.runtime;
     this.scheduler = input.scheduler ?? agentGuiScheduler;
     this.workspaceId = input.workspaceId;
-    this.previousMembershipRecords = membershipRecords(
+    this.previousMembershipRecords = projectConversationRailMembershipRecords(
       this.engine.getSnapshot()
     );
     this.snapshot = this.buildSnapshot();
@@ -413,7 +414,7 @@ export class AgentGUIConversationRailQueryController {
   };
 
   private handleEngineState(state: AgentSessionEngineState): void {
-    const next = membershipRecords(state);
+    const next = projectConversationRailMembershipRecords(state);
     if (this.ingestingSessions || !this.runtimeSectionsEnabled()) {
       this.previousMembershipRecords = next;
       return;
@@ -683,7 +684,7 @@ export class AgentGUIConversationRailQueryController {
       }
     } finally {
       this.ingestingSessions = false;
-      this.previousMembershipRecords = membershipRecords(
+      this.previousMembershipRecords = projectConversationRailMembershipRecords(
         this.engine.getSnapshot()
       );
     }
@@ -749,31 +750,6 @@ export class AgentGUIConversationRailQueryController {
     this.searchAbortController?.abort();
     this.searchAbortController = null;
   }
-}
-
-function membershipRecords(state: AgentSessionEngineState) {
-  const sessions = selectWorkspaceAgentConsumerSessions(state);
-  const canonicalIds = new Set(
-    sessions.map((item) => item.session.agentSessionId)
-  );
-  return [
-    ...sessions.map((item) => ({
-      id: item.session.agentSessionId,
-      pinnedAtUnixMs: item.session.pinnedAtUnixMs ?? null
-    })),
-    ...selectPendingActivations(state)
-      .filter(
-        (record) =>
-          record.mode === "new" &&
-          record.status !== "failed" &&
-          !canonicalIds.has(record.agentSessionId)
-      )
-      .map((record) => ({
-        id: record.agentSessionId,
-        pinnedAtUnixMs: null,
-        projectionSource: "pending_activation" as const
-      }))
-  ];
 }
 
 function pageState(page: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIHomeDraftSettlementController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIHomeDraftSettlementController.ts
@@ -57,7 +57,8 @@ export class AgentGUIHomeDraftSettlementController {
       const activation = activationsByClientSubmitId.get(clientSubmitId);
       if (
         activation?.status === "confirmed" ||
-        activation?.status === "failed"
+        activation?.status === "failed" ||
+        activation?.status === "canceled"
       ) {
         this.applyDraftUpdate((drafts) =>
           activation.status === "confirmed"

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationMessagePaging.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationMessagePaging.ts
@@ -422,6 +422,7 @@ export function useAgentConversationMessagePaging(
         current.reload.getActivationStatus(agentSessionId);
       if (
         activationStatus === "failed" ||
+        activationStatus === "canceled" ||
         activationStatus === "requested" ||
         activationStatus === "uncertain"
       )

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActiveMessages.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActiveMessages.ts
@@ -1,4 +1,5 @@
 import {
+  isPendingActivationViable,
   selectLatestActivationForSession,
   selectPendingSubmitsForSession,
   type AgentActivityMessage,
@@ -62,7 +63,7 @@ export function useAgentGUIActiveMessages(input: {
       );
     const pendingActivationMessage =
       activePendingActivation?.mode === "new" &&
-      activePendingActivation.status !== "failed" &&
+      isPendingActivationViable(activePendingActivation) &&
       activePendingActivation.clientSubmitId &&
       activePendingActivation.content.length > 0
         ? createOptimisticPromptMessage({

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.ts
@@ -216,6 +216,7 @@ export function useAgentGUIComposerOptionsSync(input: {
     );
     if (
       activation?.status === "failed" ||
+      activation?.status === "canceled" ||
       activation?.status === "requested" ||
       activation?.status === "uncertain"
     ) {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.ts
@@ -1,4 +1,5 @@
 import {
+  isPendingActivationViable,
   selectEngineSessionReconcile,
   selectLatestActivationForSession,
   selectWorkspaceAgentConsumerSession,
@@ -137,10 +138,13 @@ export function useAgentGUIConversationRouting(
         sessionEngine.getSnapshot(),
         intent.id
       );
-      if (activation?.mode === "new" && activation.status === "failed") {
-        // Failure settlement clears the optimistic selection in an earlier
-        // effect. Do not let this effect's stale active/requested intent select
-        // the failed provisional session again during the same effect flush.
+      if (
+        activation?.mode === "new" &&
+        !isPendingActivationViable(activation)
+      ) {
+        // Terminal activation settlement clears the optimistic selection in an
+        // earlier effect. Do not let this effect's stale active/requested intent
+        // select the provisional session again during the same effect flush.
         setIntent({ tag: "home" });
         return;
       }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts
@@ -1,4 +1,5 @@
 import {
+  isPendingActivationViable,
   selectEngineSessionDetailHydrated,
   selectLatestActivationForSession,
   type AgentSessionEngine,
@@ -122,7 +123,7 @@ export function useAgentGUIConversationSelectionController(
   useEffect(() => {
     if (
       activePendingActivation?.mode === "new" &&
-      activePendingActivation.status === "failed" &&
+      !isPendingActivationViable(activePendingActivation) &&
       activeConversationIdRef.current === activePendingActivation.agentSessionId
     ) {
       activeConversationIdRef.current = null;
@@ -136,10 +137,12 @@ export function useAgentGUIConversationSelectionController(
           activePendingActivation.agentSessionId
         )
       );
-      setDetailError(
-        activePendingActivation.errorMessage ||
-          translate("agentHost.agentGui.sessionActivationFailed")
-      );
+      if (activePendingActivation.status === "failed") {
+        setDetailError(
+          activePendingActivation.errorMessage ||
+            translate("agentHost.agentGui.sessionActivationFailed")
+        );
+      }
       return;
     }
     if (!activeConversationId) return;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
@@ -1,4 +1,7 @@
-import { selectLatestActivationForSession } from "@tutti-os/agent-activity-core";
+import {
+  isPendingActivationViable,
+  selectLatestActivationForSession
+} from "@tutti-os/agent-activity-core";
 import { useCallback } from "react";
 import { translate } from "../../../i18n/index";
 import type { AgentPromptContentBlock } from "../../../shared/contracts/dto";
@@ -185,10 +188,12 @@ export function useAgentGUINewConversationActivation(
       const agentSessionId =
         prewarmedSessionId &&
         activation.stateFor(prewarmedSessionId) === "inactive" &&
-        selectLatestActivationForSession(
-          sessionEngine.getSnapshot(),
-          prewarmedSessionId
-        )?.status !== "failed"
+        isPendingActivationViable(
+          selectLatestActivationForSession(
+            sessionEngine.getSnapshot(),
+            prewarmedSessionId
+          )
+        )
           ? prewarmedSessionId
           : createAgentGUIConversationId();
       const submitTrace = createAgentSubmitTraceState({

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts
@@ -161,6 +161,30 @@ describe("new-conversation home draft lifecycle", () => {
   });
 });
 
+describe("conversation stop", () => {
+  it("dispatches one unified stop intent for activation and active-turn states", () => {
+    const goalControl = vi.fn(async () => undefined);
+    const { input, sessionEngine } = createGoalControlInput(
+      goalControl as never
+    );
+    const dispatch = vi.spyOn(sessionEngine, "dispatch");
+    const { result } = renderHook(() =>
+      useAgentGUISubmitInteractionActions(input)
+    );
+
+    act(() => result.current.interruptCurrentTurn("not running"));
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentSessionId: "session-1",
+        type: "session/stopRequested",
+        workspaceId: "workspace-1"
+      })
+    );
+  });
+});
+
 describe("goal controls", () => {
   it("publishes an optimistic goal before the control API settles", async () => {
     const goalControl = vi.fn(() => new Promise<void>(() => {}));

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
@@ -713,25 +713,17 @@ export function useAgentGUISubmitInteractionActions(
         return;
       }
       void noRunningResponseMessage;
-      // A user stop means "stop everything": hold the queued prompts instead
-      // of letting the drainer fire the next one the moment the session
-      // becomes available. An explicit user send (submit or send-now on a
-      // queued item) lifts the hold.
-      sessionEngine.dispatch({
-        agentSessionId,
-        reason: "user_stop",
-        type: "queue/suspended"
-      });
       setDetailError(null);
       sessionEngine.dispatch({
         agentSessionId,
         awaitingTurnExpiresAtUnixMs: Date.now() + 30_000,
         commandId: createAgentGUIConversationId(),
         timeoutMs: 30_000,
-        type: "session/cancelRequested"
+        type: "session/stopRequested",
+        workspaceId
       });
     },
-    [sessionEngine]
+    [sessionEngine, workspaceId]
   );
 
   const updateDraftContent = useCallback(

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailMembershipRecords.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailMembershipRecords.ts
@@ -1,0 +1,33 @@
+import {
+  isPendingActivationViable,
+  selectPendingActivations,
+  selectWorkspaceAgentConsumerSessions,
+  type AgentSessionEngineState
+} from "@tutti-os/agent-activity-core";
+
+export function projectConversationRailMembershipRecords(
+  state: AgentSessionEngineState
+) {
+  const sessions = selectWorkspaceAgentConsumerSessions(state);
+  const canonicalIds = new Set(
+    sessions.map((item) => item.session.agentSessionId)
+  );
+  return [
+    ...sessions.map((item) => ({
+      id: item.session.agentSessionId,
+      pinnedAtUnixMs: item.session.pinnedAtUnixMs ?? null
+    })),
+    ...selectPendingActivations(state)
+      .filter(
+        (record) =>
+          record.mode === "new" &&
+          isPendingActivationViable(record) &&
+          !canonicalIds.has(record.agentSessionId)
+      )
+      .map((record) => ({
+        id: record.agentSessionId,
+        pinnedAtUnixMs: null,
+        projectionSource: "pending_activation" as const
+      }))
+  ];
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -466,7 +466,8 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       providerSelectLabel: labels.providerSwitchLabel,
       handoffLabel: labels.handoffConversation,
       handoffMenuLabel: labels.handoffConversationMenu,
-      isInterrupting: viewModel.composer.isInterrupting,
+      isInterrupting:
+        viewModel.composer.isInterrupting || viewModel.composer.isCancelPending,
       isSendingTurn: isComposerSending,
       isSubmittingPrompt: viewModel.interaction.isRespondingApproval,
       uiLanguage,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
@@ -1,5 +1,48 @@
 import { describe, expect, it } from "vitest";
-import { handoffProjectPathForConversation } from "./agentGUIDetailModelHelpers.ts";
+import {
+  handoffProjectPathForConversation,
+  shouldShowAgentGUIStopButton
+} from "./agentGUIDetailModelHelpers.ts";
+
+describe("shouldShowAgentGUIStopButton", () => {
+  const idle = {
+    hasPendingApproval: false,
+    hasPendingInteractivePrompt: false,
+    isAuthBlocked: false,
+    isCancelPending: false,
+    isConversationBusy: false,
+    isCreatingConversation: false,
+    isInterrupting: false,
+    isSubmitting: false,
+    isUnavailable: false
+  };
+
+  it("allows immediate stop while a new conversation is still activating", () => {
+    expect(
+      shouldShowAgentGUIStopButton({
+        ...idle,
+        isCreatingConversation: true,
+        isSubmitting: true
+      })
+    ).toBe(true);
+  });
+
+  it("keeps ordinary submission races hidden when there is no stoppable work", () => {
+    expect(shouldShowAgentGUIStopButton({ ...idle, isSubmitting: true })).toBe(
+      false
+    );
+  });
+
+  it("keeps authentication and availability gates authoritative", () => {
+    expect(
+      shouldShowAgentGUIStopButton({
+        ...idle,
+        isAuthBlocked: true,
+        isCreatingConversation: true
+      })
+    ).toBe(false);
+  });
+});
 
 describe("handoffProjectPathForConversation", () => {
   it("keeps the canonical project path for the destination session", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
@@ -236,6 +236,28 @@ export function resolveActiveConversationBusyStatus(input: {
   return null;
 }
 
+export function shouldShowAgentGUIStopButton(input: {
+  hasPendingApproval: boolean;
+  hasPendingInteractivePrompt: boolean;
+  isAuthBlocked: boolean;
+  isCancelPending: boolean;
+  isConversationBusy: boolean;
+  isCreatingConversation: boolean;
+  isInterrupting: boolean;
+  isSubmitting: boolean;
+  isUnavailable: boolean;
+}): boolean {
+  if (input.isUnavailable || input.isAuthBlocked) return false;
+  if (input.isCreatingConversation || input.isCancelPending) return true;
+  return (
+    !input.isSubmitting &&
+    (input.isConversationBusy ||
+      input.hasPendingApproval ||
+      input.hasPendingInteractivePrompt ||
+      input.isInterrupting)
+  );
+}
+
 export function buildAgentConversationHandoffPrompt(input: {
   activeConversation: AgentGUINodeViewModel["rail"]["activeConversation"];
   currentUserId?: string | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
@@ -15,6 +15,7 @@ import {
   resolveActiveConversationBusyStatus,
   resolveConversationDetailStatus,
   resolveSlashStatus,
+  shouldShowAgentGUIStopButton,
   useStableSlashStatus
 } from "./agentGUIDetailModelHelpers";
 import { useAgentGUITimelineTransition } from "./useAgentGUITimelineTransition";
@@ -208,14 +209,18 @@ export function useAgentGUIDetailModel(input: Input) {
         viewModel.composer.isSubmitting ||
         viewModel.composer.isInterrupting ||
         viewModel.composer.isCreatingConversation));
-  const showStopButton =
-    !viewModel.composer.isSubmitting &&
-    viewModel.readiness.activeLiveState !== "failed" &&
-    sessionChrome.auth === null &&
-    (activeConversationTurnBusy ||
-      viewModel.interaction.pendingApproval !== null ||
-      viewModel.interaction.pendingInteractivePrompt !== null ||
-      viewModel.composer.isInterrupting);
+  const showStopButton = shouldShowAgentGUIStopButton({
+    hasPendingApproval: viewModel.interaction.pendingApproval !== null,
+    hasPendingInteractivePrompt:
+      viewModel.interaction.pendingInteractivePrompt !== null,
+    isAuthBlocked: sessionChrome.auth !== null,
+    isCancelPending: viewModel.composer.isCancelPending,
+    isConversationBusy: activeConversationTurnBusy,
+    isCreatingConversation: viewModel.composer.isCreatingConversation,
+    isInterrupting: viewModel.composer.isInterrupting,
+    isSubmitting: viewModel.composer.isSubmitting,
+    isUnavailable: viewModel.readiness.activeLiveState === "failed"
+  });
   const conversationFlowLabels = useMemo(
     () => ({
       thinkingLabel: labels.thinkingLabel,

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import {
+  isPendingActivationViable,
   selectWorkspaceAgentConsumerSessions,
   selectPendingActivations,
   selectWorkspaceReconcileState,
@@ -125,7 +126,7 @@ export function useAgentGuiConversationList(
       pendingActivations
         .filter(
           (activation) =>
-            activation.mode === "new" && activation.status !== "failed"
+            activation.mode === "new" && isPendingActivationViable(activation)
         )
         .map((activation) => [activation.agentSessionId, activation] as const)
     );
@@ -133,7 +134,7 @@ export function useAgentGuiConversationList(
       .filter(
         (activation) =>
           activation.mode === "new" &&
-          activation.status !== "failed" &&
+          isPendingActivationViable(activation) &&
           !canonicalIds.has(activation.agentSessionId)
       )
       .map((activation): AgentGUIConversationSummary => {

--- a/packages/agent/gui/shared/agentConversationTitleProjection.ts
+++ b/packages/agent/gui/shared/agentConversationTitleProjection.ts
@@ -1,7 +1,9 @@
 import { AGENT_PROVIDER_LABEL } from "../contexts/settings/domain/agentSettings.providerMeta.ts";
-import type {
-  AgentActivityMessage,
-  AgentPromptContentBlock
+import {
+  isPendingActivationViable,
+  type PendingActivationStatus,
+  type AgentActivityMessage,
+  type AgentPromptContentBlock
 } from "@tutti-os/agent-activity-core";
 import {
   extractRichTextLinksFromContent,
@@ -131,7 +133,7 @@ export function resolveAgentGUIConversationTitleDisplayPrompt(input: {
     content: readonly AgentPromptContentBlock[];
     displayPrompt?: string;
     mode: "existing" | "new";
-    status: string;
+    status: PendingActivationStatus;
   } | null;
   allowEmptyTitle?: boolean;
   firstUserDisplayPrompt?: string | null;
@@ -158,7 +160,7 @@ export function resolveAgentGUIConversationBrowserFreeTitle(input: {
     content: readonly AgentPromptContentBlock[];
     displayPrompt?: string;
     mode: "existing" | "new";
-    status: string;
+    status: PendingActivationStatus;
   } | null;
   allowEmptyTitle?: boolean;
   firstUserDisplayPrompt?: string | null;
@@ -248,13 +250,14 @@ function resolveAgentGUIConversationTitlePrompt(input: {
     content: readonly AgentPromptContentBlock[];
     displayPrompt?: string;
     mode: "existing" | "new";
-    status: string;
+    status: PendingActivationStatus;
   } | null;
   firstUserDisplayPrompt?: string | null;
   messages?: readonly AgentActivityMessage[];
 }): string {
   const activationPrompt =
-    input.activation?.mode === "new" && input.activation.status !== "failed"
+    input.activation?.mode === "new" &&
+    isPendingActivationViable(input.activation)
       ? agentGUIActivationPromptText(
           input.activation.content,
           input.activation.displayPrompt ?? null

--- a/packages/agent/gui/workbench/conversationIdentity.ts
+++ b/packages/agent/gui/workbench/conversationIdentity.ts
@@ -1,4 +1,5 @@
 import {
+  isPendingActivationViable,
   selectLatestActivationForSession,
   selectSessionMessages,
   selectWorkspaceAgentConsumerSession,
@@ -50,7 +51,7 @@ export function resolveAgentGuiWorkbenchConversationIdentity(input: {
     agentSessionId
   );
   const optimisticTitle =
-    activation?.mode === "new" && activation.status !== "failed"
+    activation?.mode === "new" && isPendingActivationViable(activation)
       ? activation.optimisticTitle
       : null;
   const agentTargetId =
@@ -107,7 +108,7 @@ export function resolveAgentGuiWorkbenchTitleDisplayPrompt(input: {
     content: readonly AgentPromptContentBlock[];
     displayPrompt?: string;
     mode: "existing" | "new";
-    status: string;
+    status: import("@tutti-os/agent-activity-core").PendingActivationStatus;
   } | null;
   allowEmptyTitle?: boolean;
   messages: readonly AgentActivityMessage[];

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -149,12 +149,18 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 		"cwd":       prepared.Cwd,
 		"env_count": len(prepared.Env),
 	})
-	cleanupPrepared := func(cause error) error {
-		cleanupErr := s.cleanupRuntime(ctx, workspaceID, strings.TrimSpace(input.AgentSessionID))
-		if cleanupErr == nil {
-			return cause
+	cleanupCreateFailure := func(cause error, startedSessionID string) error {
+		cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		defer cancelCleanup()
+		var closeErr error
+		if startedSessionID = strings.TrimSpace(startedSessionID); startedSessionID != "" {
+			closeErr = s.controller().Close(cleanupCtx, RuntimeCloseInput{
+				WorkspaceID:    workspaceID,
+				AgentSessionID: startedSessionID,
+			})
 		}
-		return errors.Join(cause, cleanupErr)
+		cleanupErr := s.cleanupRuntime(cleanupCtx, workspaceID, strings.TrimSpace(input.AgentSessionID))
+		return errors.Join(cause, closeErr, cleanupErr)
 	}
 	logAgentSubmitTrace("service.create.runtime_start_requested", workspaceID, input.AgentSessionID, input.Metadata, nil)
 	nodeStartedAt = time.Now()
@@ -163,7 +169,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	// as soon as this session has started.
 	releaseStartup, err := s.awaitClaudeStartupSlot(ctx, provider)
 	if err != nil {
-		return Session{}, cleanupPrepared(err)
+		return Session{}, cleanupCreateFailure(err, "")
 	}
 	session, err := func() (ProviderRuntimeSession, error) {
 		defer releaseStartup()
@@ -200,7 +206,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 		s.invalidateProviderAvailability(provider)
 		normalizedErr := normalizeRuntimeError(err)
 		s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "runtime_started", provider, nodeStartedAt, normalizedErr)
-		return Session{}, cleanupPrepared(normalizedErr)
+		return Session{}, cleanupCreateFailure(normalizedErr, "")
 	}
 	s.reportAgentServiceNodeSuccess(ctx, session.ID, "session_create", "runtime_started", session.Provider, nodeStartedAt)
 	logAgentSubmitTrace("service.create.runtime_start_resolved", workspaceID, session.ID, input.Metadata, map[string]any{
@@ -209,18 +215,13 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	persistedSession, err := s.initializeRuntimeSession(ctx, session)
 	if err != nil {
 		s.reportAgentServiceNodeFailure(ctx, session.ID, "session_create", "session_persisted", session.Provider, nodeStartedAt, err)
-		closeErr := s.controller().Close(ctx, RuntimeCloseInput{
-			WorkspaceID:    workspaceID,
-			AgentSessionID: session.ID,
-		})
-		return Session{}, cleanupPrepared(errors.Join(err, closeErr))
+		return Session{}, cleanupCreateFailure(err, session.ID)
 	}
 	s.reportAgentServiceNodeSuccess(ctx, session.ID, "session_create", "session_persisted", session.Provider, nodeStartedAt)
 	if isTypedGoal {
 		result, goalErr := s.goalControl(ctx, workspaceID, session.ID, typedGoal.Action, typedGoal.Objective, input.Metadata)
 		if goalErr != nil {
-			closeErr := s.controller().Close(ctx, RuntimeCloseInput{WorkspaceID: workspaceID, AgentSessionID: session.ID})
-			return Session{}, cleanupPrepared(errors.Join(goalErr, closeErr))
+			return Session{}, cleanupCreateFailure(goalErr, session.ID)
 		}
 		return result.Session, nil
 	}
@@ -234,11 +235,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	nodeStartedAt = time.Now()
 	if err := s.validatePromptContentForExec(ctx, workspaceID, session.ID, normalizedContent); err != nil {
 		s.reportAgentServiceNodeFailure(ctx, session.ID, "session_create", "prompt_validated", session.Provider, nodeStartedAt, err)
-		closeErr := s.controller().Close(ctx, RuntimeCloseInput{
-			WorkspaceID:    workspaceID,
-			AgentSessionID: session.ID,
-		})
-		return Session{}, cleanupPrepared(errors.Join(err, closeErr))
+		return Session{}, cleanupCreateFailure(err, session.ID)
 	}
 	s.reportAgentServiceNodeSuccess(ctx, session.ID, "session_create", "prompt_validated", session.Provider, nodeStartedAt)
 	logAgentSubmitTrace("service.create.prompt_validated", workspaceID, session.ID, input.Metadata, nil)
@@ -246,11 +243,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	content, preparedDisplayPrompt, err := s.prepareNormalizedPromptContentForExec(workspaceID, session.ID, normalizedContent, "")
 	if err != nil {
 		s.reportAgentServiceNodeFailure(ctx, session.ID, "session_create", "prompt_prepared", session.Provider, nodeStartedAt, err)
-		closeErr := s.controller().Close(ctx, RuntimeCloseInput{
-			WorkspaceID:    workspaceID,
-			AgentSessionID: session.ID,
-		})
-		return Session{}, cleanupPrepared(errors.Join(err, closeErr))
+		return Session{}, cleanupCreateFailure(err, session.ID)
 	}
 	s.reportAgentServiceNodeSuccess(ctx, session.ID, "session_create", "prompt_prepared", session.Provider, nodeStartedAt)
 	logAgentSubmitTrace("service.create.prompt_prepared", workspaceID, session.ID, input.Metadata, map[string]any{
@@ -276,11 +269,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	if err != nil {
 		normalizedErr := normalizeRuntimeError(err)
 		s.reportAgentServiceNodeFailure(ctx, session.ID, "session_create", "runtime_exec", session.Provider, nodeStartedAt, normalizedErr)
-		closeErr := s.controller().Close(ctx, RuntimeCloseInput{
-			WorkspaceID:    workspaceID,
-			AgentSessionID: session.ID,
-		})
-		return Session{}, cleanupPrepared(errors.Join(normalizedErr, closeErr))
+		return Session{}, cleanupCreateFailure(normalizedErr, session.ID)
 	}
 	if submitClaim.ClientSubmitID != "" {
 		claimPending = false


### PR DESCRIPTION
## Summary

- route AgentGUI Stop through one provider-neutral session intent during both activation and active turns
- abort the exact in-flight activation command, preserve a bounded awaiting-turn cancel, and cancel the first canonical turn if it wins the startup race
- keep queued prompts suspended, settle canceled optimistic UI state, and clean provisional daemon runtime state with a bounded non-canceled cleanup context
- document the activation-cancel data flow and the Cursor first-message troubleshooting pattern

## Verification

- pnpm check:changed --tail-lines 80
- pnpm lint:ts
- pnpm typecheck
- pnpm --filter @tutti-os/agent-activity-core test
- pnpm --filter @tutti-os/agent-gui test -- useAgentGUISubmitInteractionActions.spec.ts
- cd services/tuttid && go test ./service/agent && go build ./...
- pnpm --filter @tutti-os/desktop build
- manual Cursor first-message Stop validation in the development app

## Fix Scope Justification

- Root cause: AgentGUI exposed and dispatched cancellation only after a canonical Turn existed, while Cursor can spend a visible interval in abortable ACP activation before the first Turn id is available.
- Why can this not be fixed at a lower layer? The race crosses the composer presentation, the session engine command executor, canonical session reconciliation, prompt queue ownership, and daemon failed-create rollback. A provider adapter-only change cannot expose Stop or preserve user intent while session identity is still provisional.

## Fallback Three Questions

- Source: Stop can arrive after activation starts but before the runtime publishes the canonical session and first Turn.
- Why can it not be fixed at that source? The provider protocol has no canonical Tutti Turn id at that point, and abort delivery can race successful session creation.
- Removal condition: the bounded awaiting-turn cancel can be removed if activation cancellation gains an authoritative acknowledgement that also guarantees no session or Turn can be published after abort.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: git commit -s.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->