### PR TITLE
perf(agent-gui): accelerate provider switching

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
@@ -3,6 +3,20 @@ import test from "node:test";
 import { createDesktopAgentActivityRuntime } from "./createDesktopAgentActivityRuntime.ts";
 import type { IWorkspaceAgentActivityService } from "./workspaceAgentActivityService.interface.ts";
 
+test("desktop agent activity runtime scopes section query caches by workspace", () => {
+  const runtime = createDesktopAgentActivityRuntime(
+    createWorkspaceAgentActivityService()
+  );
+
+  const first = runtime.getSessionSectionsQueryCache?.("workspace-1");
+  const same = runtime.getSessionSectionsQueryCache?.(" workspace-1 ");
+  const other = runtime.getSessionSectionsQueryCache?.("workspace-2");
+
+  assert.ok(first);
+  assert.equal(first, same);
+  assert.notEqual(first, other);
+});
+
 test("desktop agent activity runtime forwards package diagnostics to renderer diagnostics", () => {
   const rendererDiagnostics: unknown[] = [];
   const runtime = createDesktopAgentActivityRuntime(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts
@@ -1,4 +1,8 @@
 import type { AgentActivityRuntime } from "@tutti-os/agent-gui";
+import {
+  createWorkspaceQueryCache,
+  type WorkspaceQueryCache
+} from "@tutti-os/agent-gui/workspace-query-cache";
 import { AGENT_SESSION_ENGINE_LOCAL_ORIGIN } from "@tutti-os/agent-activity-core";
 import type {
   AgentActivityMessagePage,
@@ -66,6 +70,10 @@ export function createDesktopAgentActivityRuntime(
 ): AgentActivityRuntime {
   const runtimeSnapshotDiagnosticSignatures = new Map<string, string>();
   const runtimeMessagePageDiagnosticSignatures = new Map<string, string>();
+  const sessionSectionsQueryCaches = new Map<
+    string,
+    WorkspaceQueryCache<unknown>
+  >();
   const reportRuntimeDiagnostic = (input: {
     details?: Record<string, unknown>;
     event: string;
@@ -158,6 +166,14 @@ export function createDesktopAgentActivityRuntime(
     },
     getSessionEngine(workspaceId) {
       return workspaceAgentActivityService.getSessionEngine(workspaceId);
+    },
+    getSessionSectionsQueryCache(workspaceId) {
+      const key = workspaceId.trim();
+      const current = sessionSectionsQueryCaches.get(key);
+      if (current) return current;
+      const created = createWorkspaceQueryCache<unknown>();
+      sessionSectionsQueryCaches.set(key, created);
+      return created;
     },
     async activateSession(input) {
       reportAgentSubmitTraceDiagnostic(options.runtimeApi, {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -647,6 +647,7 @@ test("desktop agent activity adapter submits interactive responses through tutti
 
 test("desktop agent activity adapter normalizes provider composer options", async () => {
   const calls: unknown[] = [];
+  const diagnostics: unknown[] = [];
   const adapter = createDesktopAgentActivityAdapter({
     tuttidClient: createTuttidClient({
       async getAgentProviderComposerOptions(provider, request) {
@@ -724,7 +725,7 @@ test("desktop agent activity adapter normalizes provider composer options", asyn
         };
       }
     }),
-    runtimeApi: createRuntimeApi()
+    runtimeApi: createRuntimeApi(diagnostics)
   });
 
   const options = await adapter.loadComposerOptions({
@@ -779,6 +780,25 @@ test("desktop agent activity adapter normalizes provider composer options", asyn
   assert.equal(options.capabilities?.planMode, true);
   assert.equal(options.capabilities?.browserUse, true);
   assert.equal(options.capabilities?.activeTurnGuidance, true);
+  assert.equal(diagnostics.length, 1);
+  const diagnostic = diagnostics[0] as {
+    details: Record<string, unknown>;
+    event: string;
+    level: string;
+    workspaceId: string;
+  };
+  assert.equal(diagnostic.event, "agent.composer_options.load");
+  assert.equal(diagnostic.level, "info");
+  assert.equal(diagnostic.workspaceId, workspaceId);
+  assert.deepEqual(
+    { ...diagnostic.details, durationMs: typeof diagnostic.details.durationMs },
+    {
+      agentTargetId: null,
+      durationMs: "number",
+      provider: "codex",
+      status: "ready"
+    }
+  );
 });
 
 test("desktop agent activity adapter cancels composer options when caller aborts", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -107,30 +107,56 @@ export function createDesktopAgentActivityAdapter({
       }
     },
     async loadComposerOptions(input) {
+      const startedAt = Date.now();
       const cwd = input.cwd?.trim();
       const agentTargetId = input.agentTargetId?.trim();
-      const result = await withAbortableRequestTimeout(
-        (signal) =>
-          tuttidClient.getAgentProviderComposerOptions(
-            workspaceAgentProvider(input.provider),
-            {
-              ...(agentTargetId ? { agentTargetId } : {}),
-              ...(cwd ? { cwd } : {}),
-              workspaceId: input.workspaceId,
-              settings: input.settings ?? {}
-            },
-            { signal }
-          ),
-        {
-          signal: input.signal,
-          timeoutMessage: "Agent composer options request timed out.",
-          timeoutMs: composerOptionsRequestTimeoutMs
-        }
-      );
-      return agentActivityComposerOptionsFromTuttidResult(
-        input.provider,
-        result
-      );
+      try {
+        const result = await withAbortableRequestTimeout(
+          (signal) =>
+            tuttidClient.getAgentProviderComposerOptions(
+              workspaceAgentProvider(input.provider),
+              {
+                ...(agentTargetId ? { agentTargetId } : {}),
+                ...(cwd ? { cwd } : {}),
+                workspaceId: input.workspaceId,
+                settings: input.settings ?? {}
+              },
+              { signal }
+            ),
+          {
+            signal: input.signal,
+            timeoutMessage: "Agent composer options request timed out.",
+            timeoutMs: composerOptionsRequestTimeoutMs
+          }
+        );
+        reportDesktopAgentComposerOptionsDiagnostic(
+          runtimeApi,
+          input.workspaceId,
+          {
+            agentTargetId: agentTargetId ?? null,
+            durationMs: Date.now() - startedAt,
+            provider: input.provider,
+            status: "ready"
+          }
+        );
+        return agentActivityComposerOptionsFromTuttidResult(
+          input.provider,
+          result
+        );
+      } catch (error) {
+        reportDesktopAgentComposerOptionsDiagnostic(
+          runtimeApi,
+          input.workspaceId,
+          {
+            agentTargetId: agentTargetId ?? null,
+            durationMs: Date.now() - startedAt,
+            provider: input.provider,
+            status: "error",
+            ...normalizeDesktopAgentDiagnosticError(error)
+          }
+        );
+        throw error;
+      }
     },
     async createSession(input) {
       reportDesktopAgentSubmitTrace(runtimeApi, {
@@ -365,6 +391,25 @@ function reportDesktopAgentMessageListDiagnostic(
       .catch(() => {});
   } catch {
     // Diagnostic logging must not affect message loading.
+  }
+}
+
+function reportDesktopAgentComposerOptionsDiagnostic(
+  runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">,
+  workspaceId: string,
+  details: Record<string, string | number | boolean | null>
+): void {
+  try {
+    void runtimeApi
+      .logTerminalDiagnostic({
+        details,
+        event: "agent.composer_options.load",
+        level: details.status === "error" ? "warn" : "info",
+        workspaceId
+      })
+      .catch(() => {});
+  } catch {
+    // Diagnostic logging must not affect composer option loading.
   }
 }
 

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -135,6 +135,11 @@ Activating a conversation must not by itself call `listSessionSections` again.
 Likewise, active detail provider changes should not reload section first pages.
 Page sessions must be upserted into the workspace engine, while the rail query
 cache retains only ordered session ids, cursors, totals, and section metadata.
+Desktop keeps that cache on the workspace-scoped runtime rather than a mounted
+AgentGUI controller. Fresh first pages are reused for 30 seconds across panel
+remounts and repeated target switches; stale pages remain visible while one
+coalesced background request revalidates the scope. The cache never owns session
+entities, titles, lifecycle, or interaction state.
 Section first-page reloads should be tied to workspace, rail filter, user
 project, or session membership changes.
 Historical rows already owned by loaded section pages can be absent from a
@@ -433,6 +438,10 @@ erase a usable preloaded model or reasoning selection while live metadata is
 still arriving. Because the effective settings are request-dependent,
 composer-options cache freshness and in-flight reuse include normalized `cwd`
 and normalized requested settings in addition to the target key.
+Ordinary home-target and project switches use that signature-aware cache and
+must not force a second transport request from the click handler. Forced loads
+are reserved for explicit catalog invalidation, activation/creation settlement,
+or provider-declared draft-session prewarming.
 
 Composer-options loading may be suppressed while a new-session activation is
 pending, but that guard follows the current engine state rather than a

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1546,7 +1546,12 @@ place for short reloads. Provider/agent switching should not briefly unmount
 the project rail header or replace a populated rail with an empty/skeleton
 rail; if the new first page takes longer than the rail skeleton delay, show the
 skeleton so the user sees loading feedback. Only workspace changes may clear
-the section cache immediately. Local Show more/Show less expansion belongs to
+the section cache immediately. The desktop runtime shares bounded first-page
+query entries across AgentGUI controller mounts, keyed by workspace and exact
+rail scope. A fresh entry is restored without transport; a stale entry remains
+visible while one in-flight request is shared by every consumer. Cache entries
+contain membership, cursor, total, and section metadata only; canonical sessions
+remain in the workspace engine. Local Show more/Show less expansion belongs to
 the workspace-plus-filter query scope, not the backend section id alone. Reset
 its visible-item limit in the filter-change render so stale section chrome
 cannot flash pagination controls from the previous provider scope. Keep the

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -659,6 +659,14 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   `rail_visible_session_count` as the target-scoped total across requested
   sections and `returned_session_count` as only the bounded first-page rows;
   neither requires another full-workspace count query.
+  For provider switching, inspect `agent_gui.provider_switch.completed` or
+  `agent_gui.provider_switch.failed`. They report source/target ids, fresh/stale/
+  miss cache status, request time, controller-apply time, and total controller
+  readiness time. Correlate target and timestamp with
+  `agent.composer_options.load`, which records composer transport duration and
+  status. A fresh rail hit with no composer transport indicates both caches were
+  reused; a long rail request isolates section loading, while a long composer
+  event isolates target option discovery.
 - Root cause:
   A second React summary cache mixed entity data, section membership, active
   selection, and visible-item limits. Effects manually patched section rows

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
@@ -1,6 +1,7 @@
 import { normalizeAgentActivitySession } from "@tutti-os/agent-activity-core";
 import { describe, expect, it, vi } from "vitest";
 import { createTestAgentSessionEngine } from "../../../shared/testing/createTestAgentSessionEngine";
+import { createWorkspaceQueryCache } from "../../../shared/query/workspaceQueryCache";
 import {
   AgentGUIConversationRailQueryController,
   CONVERSATION_SEARCH_DEBOUNCE_MS,
@@ -171,7 +172,7 @@ describe("AgentGUIConversationRailQueryController", () => {
     engine.dispose();
   });
 
-  it("reattaches cleanly and follows preview-mode scope changes", async () => {
+  it("reuses fresh first pages across reattach and preview-mode scope changes", async () => {
     const engine = createTestAgentSessionEngine();
     const listSessionSections = vi.fn<
       NonNullable<ConversationRailQueryRuntime["listSessionSections"]>
@@ -210,18 +211,14 @@ describe("AgentGUIConversationRailQueryController", () => {
     detachFirst();
 
     const detachSecond = controller.attach();
-    await vi.waitFor(() =>
-      expect(listSessionSections).toHaveBeenCalledTimes(2)
-    );
+    expect(listSessionSections).toHaveBeenCalledTimes(1);
 
     controller.configure({ ...regularScope, previewMode: true });
     expect(controller.getSnapshot().runtimeSectionsEnabled).toBe(false);
-    expect(listSessionSections).toHaveBeenCalledTimes(2);
+    expect(listSessionSections).toHaveBeenCalledTimes(1);
 
     controller.configure(regularScope);
-    await vi.waitFor(() =>
-      expect(listSessionSections).toHaveBeenCalledTimes(3)
-    );
+    expect(listSessionSections).toHaveBeenCalledTimes(1);
     expect(controller.getSnapshot().runtimeSectionsEnabled).toBe(true);
 
     detachSecond();
@@ -251,6 +248,7 @@ describe("AgentGUIConversationRailQueryController", () => {
       };
     });
     const controller = new AgentGUIConversationRailQueryController({
+      cacheFreshMs: -1,
       engine,
       getActiveConversationId: () => null,
       runtime: {
@@ -303,6 +301,7 @@ describe("AgentGUIConversationRailQueryController", () => {
     const reportDiagnostic = vi.fn();
     const diagnosticTimes = [0, 300, 325];
     const controller = new AgentGUIConversationRailQueryController({
+      cacheFreshMs: -1,
       diagnosticNow: () => diagnosticTimes.shift() ?? 325,
       diagnosticSlowThresholdMs: 250,
       engine,
@@ -378,6 +377,7 @@ describe("AgentGUIConversationRailQueryController", () => {
     let requestCount = 0;
     const diagnosticTimes = [0, 100, 110, 110, 130];
     const controller = new AgentGUIConversationRailQueryController({
+      cacheFreshMs: -1,
       diagnosticLogger,
       diagnosticNow: () => diagnosticTimes.shift() ?? 130,
       diagnosticSlowThresholdMs: 250,
@@ -432,6 +432,172 @@ describe("AgentGUIConversationRailQueryController", () => {
     });
 
     detachSecond();
+    engine.dispose();
+  });
+
+  it("shares an in-flight scope request across controllers and restores it after remount", async () => {
+    const engine = createTestAgentSessionEngine();
+    const cache = createWorkspaceQueryCache<unknown>();
+    let resolveSections!: () => void;
+    const listSessionSections = vi.fn<
+      NonNullable<ConversationRailQueryRuntime["listSessionSections"]>
+    >((input) =>
+      new Promise<void>((resolve) => {
+        resolveSections = resolve;
+      }).then(() => ({
+        sections: [
+          {
+            hasMore: false,
+            kind: "conversations" as const,
+            sectionKey: "conversations",
+            sessions: [],
+            totalCount: 0
+          }
+        ],
+        workspaceId: input.workspaceId
+      }))
+    );
+    const runtime: ConversationRailQueryRuntime = {
+      getSessionSectionsQueryCache: () => cache,
+      listSessionSections,
+      listSessionSectionPage: async (input) => ({
+        hasMore: false,
+        kind: "conversations",
+        sectionKey: input.sectionKey,
+        sessions: [],
+        totalCount: 0
+      })
+    };
+    const scope = {
+      conversationFilter: {
+        agentTargetId: "local:codex",
+        kind: "agentTarget"
+      } as const,
+      previewMode: false,
+      sectionAgentTargetFallbackId: null,
+      userProjects: []
+    };
+    const first = new AgentGUIConversationRailQueryController({
+      engine,
+      getActiveConversationId: () => null,
+      runtime,
+      workspaceId: "test-workspace"
+    });
+    const second = new AgentGUIConversationRailQueryController({
+      engine,
+      getActiveConversationId: () => null,
+      runtime,
+      workspaceId: "test-workspace"
+    });
+    first.configure(scope);
+    second.configure(scope);
+    const detachFirst = first.attach();
+    const detachSecond = second.attach();
+
+    expect(listSessionSections).toHaveBeenCalledTimes(1);
+    resolveSections();
+    await vi.waitFor(() =>
+      expect(first.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
+    await vi.waitFor(() =>
+      expect(second.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
+    detachFirst();
+    detachSecond();
+
+    const remounted = new AgentGUIConversationRailQueryController({
+      engine,
+      getActiveConversationId: () => null,
+      runtime,
+      workspaceId: "test-workspace"
+    });
+    remounted.configure(scope);
+    const detachRemounted = remounted.attach();
+    expect(remounted.getSnapshot().runtimeRailMemberships).toHaveLength(1);
+    expect(remounted.getSnapshot().runtimeRailSectionsPending).toBe(false);
+    expect(listSessionSections).toHaveBeenCalledTimes(1);
+
+    detachRemounted();
+    engine.dispose();
+  });
+
+  it("restores a fresh target scope without refetching on A to B to A", async () => {
+    const engine = createTestAgentSessionEngine();
+    const diagnosticLogger = vi.fn();
+    const listSessionSections = vi.fn<
+      NonNullable<ConversationRailQueryRuntime["listSessionSections"]>
+    >(async (input) => ({
+      sections: [
+        {
+          hasMore: false,
+          kind: "conversations",
+          sectionKey: "conversations",
+          sessions: [],
+          totalCount: 0
+        }
+      ],
+      workspaceId: input.workspaceId
+    }));
+    const controller = new AgentGUIConversationRailQueryController({
+      diagnosticLogger,
+      engine,
+      getActiveConversationId: () => null,
+      runtime: {
+        listSessionSections,
+        listSessionSectionPage: async (input) => ({
+          hasMore: false,
+          kind: "conversations",
+          sectionKey: input.sectionKey,
+          sessions: [],
+          totalCount: 0
+        })
+      },
+      workspaceId: "test-workspace"
+    });
+    const scope = (agentTargetId: string) => ({
+      conversationFilter: { agentTargetId, kind: "agentTarget" as const },
+      previewMode: false,
+      sectionAgentTargetFallbackId: null,
+      userProjects: []
+    });
+    controller.configure(scope("local:codex"));
+    const detach = controller.attach();
+    await vi.waitFor(() =>
+      expect(listSessionSections).toHaveBeenCalledTimes(1)
+    );
+
+    controller.configure(scope("local:claude-code"));
+    await vi.waitFor(() =>
+      expect(listSessionSections).toHaveBeenCalledTimes(2)
+    );
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
+    expect(diagnosticLogger).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        cacheStatus: "miss",
+        event: "agent_gui.provider_switch.completed",
+        fromAgentTargetId: "local:codex",
+        status: "ready",
+        toAgentTargetId: "local:claude-code"
+      })
+    );
+
+    controller.configure(scope("local:codex"));
+    expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false);
+    expect(listSessionSections).toHaveBeenCalledTimes(2);
+    expect(diagnosticLogger).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        cacheStatus: "fresh",
+        event: "agent_gui.provider_switch.completed",
+        fromAgentTargetId: "local:claude-code",
+        requestMs: 0,
+        status: "ready",
+        toAgentTargetId: "local:codex"
+      })
+    );
+
+    detach();
     engine.dispose();
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -4,6 +4,10 @@ import {
   type AgentSessionEngineState
 } from "@tutti-os/agent-activity-core";
 import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
+import {
+  createWorkspaceQueryCache,
+  type WorkspaceQueryCache
+} from "../../../shared/query/workspaceQueryCache";
 import type { ConversationSection } from "../agentGuiNodeViewConversation";
 import {
   agentGuiScheduler,
@@ -15,22 +19,34 @@ import {
   CONVERSATION_RAIL_SLOW_DIAGNOSTIC_THRESHOLD_MS,
   createConversationRailDiagnosticLogger,
   emitConversationRailFirstPagesDiagnostic,
+  ConversationRailProviderSwitchDiagnosticTracker,
   type ConversationRailDiagnosticLogger,
   type ConversationRailRefreshReason
 } from "./agentGuiConversationRailDiagnostics";
 import {
   mergeConversationRailSessionIds,
-  planRuntimeRailMembershipRefresh,
-  projectRuntimeSectionsToConversationRailMemberships,
-  type ConversationRailQueryState,
-  type ConversationRailSectionMembership,
-  type ConversationRailSectionPageState
+  planRuntimeRailMembershipRefresh
 } from "../model/agentGuiConversationRail";
 import { projectConversationRailMembershipRecords } from "../model/agentGuiConversationRailMembershipRecords";
+import {
+  applyCachedConversationRailQuery,
+  cachedConversationRailQueryFromFirstPages,
+  updateConversationRailSectionPageState,
+  writeConversationRailQueryCache,
+  type CachedConversationRailQuery
+} from "./agentGuiConversationRailQueryCache";
+import {
+  buildConversationRailQuerySnapshot,
+  EMPTY_CONVERSATION_RAIL_QUERY_STATE,
+  type AgentGUIConversationRailQuerySnapshot
+} from "./agentGuiConversationRailQuerySnapshot";
+
+export type { AgentGUIConversationRailQuerySnapshot } from "./agentGuiConversationRailQuerySnapshot";
 
 const SECTION_PAGE_SIZE = 5;
 const SEARCH_PAGE_SIZE = 100;
 export const CONVERSATION_SEARCH_DEBOUNCE_MS = 300;
+export const CONVERSATION_RAIL_QUERY_CACHE_FRESH_MS = 30_000;
 
 interface ConversationSearchQueryState {
   failed: boolean;
@@ -54,14 +70,6 @@ const EMPTY_SEARCH_STATE: ConversationSearchQueryState = {
   sessionIds: []
 };
 
-const EMPTY_QUERY_STATE: ConversationRailQueryState = {
-  pending: false,
-  reconcilingSessionIds: [],
-  resolvedScopeKey: null,
-  sectionPageStates: new Map(),
-  sections: null
-};
-
 export interface ConversationRailQueryScope {
   conversationFilter: AgentGUINodeViewModel["rail"]["conversationFilter"];
   previewMode: boolean;
@@ -69,30 +77,16 @@ export interface ConversationRailQueryScope {
   userProjects: AgentGUINodeViewModel["rail"]["userProjects"];
 }
 
-export interface AgentGUIConversationRailQuerySnapshot {
-  railSearch: {
-    enabled: boolean;
-    failed: boolean;
-    hasMore: boolean;
-    loadingMore: boolean;
-    pending: boolean;
-    resolvedQuery: string;
-    sessionIds: readonly string[];
-  };
-  runtimeSectionsEnabled: boolean;
-  runtimeRailMemberships: ConversationRailSectionMembership[] | null;
-  runtimeRailReconcilingSessionIds: readonly string[];
-  runtimeRailSectionsPending: boolean;
-  sectionPageStates: ConversationRailQueryState["sectionPageStates"];
-}
-
 interface ControllerInput {
+  cacheNow?: () => number;
+  cacheFreshMs?: number;
   diagnosticLogger?: ConversationRailDiagnosticLogger;
   diagnosticNow?: () => number;
   diagnosticSlowThresholdMs?: number;
   engine: AgentSessionEngine;
   getActiveConversationId(): string | null;
   runtime: ConversationRailQueryRuntime;
+  sessionSectionsQueryCache?: WorkspaceQueryCache<CachedConversationRailQuery>;
   scheduler?: AgentGuiScheduler;
   workspaceId: string;
 }
@@ -103,6 +97,7 @@ export type ConversationRailQueryRuntime = Pick<
   | "listSessionSectionPage"
   | "listSessionSections"
   | "listSessionsPage"
+  | "getSessionSectionsQueryCache"
   | "reportDiagnostic"
 >;
 
@@ -121,6 +116,8 @@ export class AgentGUIConversationRailQueryController {
   };
 
   private readonly engine: AgentSessionEngine;
+  private readonly cacheFreshMs: number;
+  private readonly cacheNow: () => number;
   private readonly diagnosticLogger: ConversationRailDiagnosticLogger;
   private readonly diagnosticNow: () => number;
   private readonly diagnosticSlowThresholdMs: number;
@@ -129,10 +126,12 @@ export class AgentGUIConversationRailQueryController {
   private readonly runtime: ConversationRailQueryRuntime;
   private readonly scheduler: AgentGuiScheduler;
   private readonly workspaceId: string;
+  private readonly sessionSectionsQueryCache: WorkspaceQueryCache<CachedConversationRailQuery>;
+  private readonly providerSwitchDiagnostics: ConversationRailProviderSwitchDiagnosticTracker;
   private readonly pagingAbortControllers = new Map<string, AbortController>();
-  private queryState = EMPTY_QUERY_STATE;
+  private queryState = EMPTY_CONVERSATION_RAIL_QUERY_STATE;
   private searchState = EMPTY_SEARCH_STATE;
-  private snapshot: AgentGUIConversationRailQuerySnapshot;
+  private snapshot!: AgentGUIConversationRailQuerySnapshot;
   private scope: ConversationRailQueryScope | null = null;
   private sectionAgentTargetId = "";
   private railSectionQueryKey: string | null = null;
@@ -150,6 +149,9 @@ export class AgentGUIConversationRailQueryController {
   private unsubscribeEngine: (() => void) | null = null;
 
   constructor(input: ControllerInput) {
+    this.cacheFreshMs =
+      input.cacheFreshMs ?? CONVERSATION_RAIL_QUERY_CACHE_FRESH_MS;
+    this.cacheNow = input.cacheNow ?? Date.now;
     this.diagnosticLogger =
       input.diagnosticLogger ??
       createConversationRailDiagnosticLogger(input.runtime);
@@ -160,12 +162,24 @@ export class AgentGUIConversationRailQueryController {
     this.engine = input.engine;
     this.getActiveConversationId = input.getActiveConversationId;
     this.runtime = input.runtime;
+    this.providerSwitchDiagnostics =
+      new ConversationRailProviderSwitchDiagnosticTracker(
+        this.diagnosticLogger,
+        this.diagnosticNow,
+        input.workspaceId
+      );
+    this.sessionSectionsQueryCache =
+      input.sessionSectionsQueryCache ??
+      (input.runtime.getSessionSectionsQueryCache?.(input.workspaceId) as
+        | WorkspaceQueryCache<CachedConversationRailQuery>
+        | undefined) ??
+      createWorkspaceQueryCache<CachedConversationRailQuery>();
     this.scheduler = input.scheduler ?? agentGuiScheduler;
     this.workspaceId = input.workspaceId;
     this.previousMembershipRecords = projectConversationRailMembershipRecords(
       this.engine.getSnapshot()
     );
-    this.snapshot = this.buildSnapshot();
+    this.emit();
   }
 
   attach(): () => void {
@@ -180,6 +194,8 @@ export class AgentGUIConversationRailQueryController {
   }
 
   configure(scope: ConversationRailQueryScope): void {
+    const previousScopeKey = this.railSectionQueryKey;
+    const previousAgentTargetId = this.sectionAgentTargetId;
     const sectionAgentTargetId =
       scope.conversationFilter.kind === "agentTarget"
         ? scope.conversationFilter.agentTargetId.trim()
@@ -199,6 +215,13 @@ export class AgentGUIConversationRailQueryController {
       userProjectPathKey
     ]);
     const scopeChanged = nextScopeKey !== this.railSectionQueryKey;
+    this.providerSwitchDiagnostics.configure({
+      attached: this.attached,
+      nextAgentTargetId: sectionAgentTargetId,
+      nextScopeKey,
+      previousAgentTargetId,
+      previousScopeKey
+    });
     this.scope = scope;
     this.sectionAgentTargetId = sectionAgentTargetId;
     this.railSectionQueryKey = nextScopeKey;
@@ -257,7 +280,7 @@ export class AgentGUIConversationRailQueryController {
     this.pagingAbortControllers.set(section.id, abortController);
     this.queryState = {
       ...this.queryState,
-      sectionPageStates: updateSectionPageState(
+      sectionPageStates: updateConversationRailSectionPageState(
         this.queryState.sectionPageStates,
         section.id,
         { ...currentPageState, isLoading: true }
@@ -294,7 +317,7 @@ export class AgentGUIConversationRailQueryController {
         this.upsertSessions(page.sessions);
         this.queryState = {
           ...this.queryState,
-          sectionPageStates: updateSectionPageState(
+          sectionPageStates: updateConversationRailSectionPageState(
             this.queryState.sectionPageStates,
             section.id,
             {
@@ -317,6 +340,7 @@ export class AgentGUIConversationRailQueryController {
                 : candidate
             ) ?? null
         };
+        this.writeCurrentQueryCache();
         this.emit();
       })
       .catch(() => {
@@ -328,12 +352,13 @@ export class AgentGUIConversationRailQueryController {
         }
         this.queryState = {
           ...this.queryState,
-          sectionPageStates: updateSectionPageState(
+          sectionPageStates: updateConversationRailSectionPageState(
             this.queryState.sectionPageStates,
             section.id,
             { ...currentPageState, isLoading: false }
           )
         };
+        this.writeCurrentQueryCache();
         this.emit();
       })
       .finally(() => {
@@ -427,6 +452,7 @@ export class AgentGUIConversationRailQueryController {
     });
     this.previousMembershipRecords = next;
     if (plan.kind !== "refresh_first_pages") return;
+    this.sessionSectionsQueryCache.invalidate();
     this.queryState = {
       ...this.queryState,
       reconcilingSessionIds: mergeConversationRailSessionIds(
@@ -444,10 +470,39 @@ export class AgentGUIConversationRailQueryController {
     const listSections = this.runtime.listSessionSections;
     const scopeKey = this.railSectionQueryKey;
     if (!this.runtimeSectionsEnabled() || !listSections || !scopeKey) {
-      this.queryState = EMPTY_QUERY_STATE;
+      this.queryState = EMPTY_CONVERSATION_RAIL_QUERY_STATE;
       this.emit();
       return;
     }
+    const cached = this.sessionSectionsQueryCache.read(scopeKey);
+    const cacheApplyStartedAt =
+      cached && this.providerSwitchDiagnostics.hasPending(scopeKey)
+        ? this.diagnosticNow()
+        : null;
+    if (cached && this.queryState.resolvedScopeKey !== scopeKey) {
+      this.applyCachedFirstPages(scopeKey, cached);
+      this.emit();
+    }
+    if (
+      cached &&
+      !cached.stale &&
+      this.cacheNow() - cached.resolvedAtUnixMs <= this.cacheFreshMs
+    ) {
+      this.providerSwitchDiagnostics.complete(scopeKey, {
+        cacheStatus: "fresh",
+        controllerApplyMs:
+          cacheApplyStartedAt === null
+            ? 0
+            : Math.max(0, this.diagnosticNow() - cacheApplyStartedAt),
+        requestMs: 0,
+        returnedSessionCount: cached.value.returnedSessionCount,
+        sectionCount: cached.value.sectionCount,
+        status: "ready"
+      });
+      return;
+    }
+    const cacheStatus = cached ? "stale" : "miss";
+    this.providerSwitchDiagnostics.setCacheStatus(scopeKey, cacheStatus);
     this.pagingRequestSequence += 1;
     const requestSequence = this.pagingRequestSequence;
     const requestStartedAt = this.diagnosticNow();
@@ -455,55 +510,39 @@ export class AgentGUIConversationRailQueryController {
       this.queryState.resolvedScopeKey === scopeKey &&
       this.queryState.sections !== null;
     this.cancelPagingRequests(false);
-    const abortController = new AbortController();
-    this.pagingAbortControllers.set("__first_pages__", abortController);
     this.queryState = {
       ...this.queryState,
       pending: true
     };
     this.emit();
-    void listSections({
-      agentTargetId: this.sectionAgentTargetId || undefined,
-      limitPerSection: SECTION_PAGE_SIZE,
-      signal: abortController.signal,
-      workspaceId: this.workspaceId
-    })
-      .then((page) => {
+    void this.sessionSectionsQueryCache
+      .request(scopeKey, async () => {
+        const page = await listSections({
+          agentTargetId: this.sectionAgentTargetId || undefined,
+          limitPerSection: SECTION_PAGE_SIZE,
+          workspaceId: this.workspaceId
+        });
+        return cachedConversationRailQueryFromFirstPages(page, scopeKey);
+      })
+      .then((entry) => {
         if (
-          abortController.signal.aborted ||
           requestSequence !== this.pagingRequestSequence ||
           scopeKey !== this.railSectionQueryKey
         ) {
           return;
         }
         const requestResolvedAt = this.diagnosticNow();
-        const sections = projectRuntimeSectionsToConversationRailMemberships({
-          pinned: page.pinned,
-          sections: page.sections
-        });
-        this.upsertSessions([
-          ...(page.pinned?.sessions ?? []),
-          ...page.sections.flatMap((section) => section.sessions)
-        ]);
-        const sectionPageStates = new Map<
-          string,
-          ConversationRailSectionPageState
-        >();
-        if (page.pinned) {
-          sectionPageStates.set("pinned", pageState(page.pinned));
-        }
-        for (const section of page.sections) {
-          sectionPageStates.set(section.sectionKey, pageState(section));
-        }
-        this.queryState = {
-          pending: false,
-          reconcilingSessionIds: [],
-          resolvedScopeKey: scopeKey,
-          sectionPageStates,
-          sections
-        };
+        this.applyCachedFirstPages(scopeKey, entry);
         this.emit();
         const completedAt = this.diagnosticNow();
+        this.providerSwitchDiagnostics.complete(scopeKey, {
+          cacheStatus,
+          controllerApplyMs: Math.max(0, completedAt - requestResolvedAt),
+          requestMs: Math.max(0, requestResolvedAt - requestStartedAt),
+          returnedSessionCount: entry.value.returnedSessionCount,
+          sectionCount: entry.value.sectionCount,
+          status: "ready"
+        });
         emitConversationRailFirstPagesDiagnostic({
           agentTargetId: this.sectionAgentTargetId || null,
           controllerApplyMs: Math.max(0, completedAt - requestResolvedAt),
@@ -513,26 +552,29 @@ export class AgentGUIConversationRailQueryController {
           requestId: requestSequence,
           requestMs: Math.max(0, requestResolvedAt - requestStartedAt),
           refreshReason,
-          returnedSessionCount:
-            (page.pinned?.sessions.length ?? 0) +
-            page.sections.reduce(
-              (count, section) => count + section.sessions.length,
-              0
-            ),
-          sectionCount: page.sections.length + (page.pinned ? 1 : 0),
+          returnedSessionCount: entry.value.returnedSessionCount,
+          sectionCount: entry.value.sectionCount,
           status: "ready",
           workspaceId: this.workspaceId
         });
       })
       .catch((error: unknown) => {
         if (
-          abortController.signal.aborted ||
           requestSequence !== this.pagingRequestSequence ||
           scopeKey !== this.railSectionQueryKey
         ) {
           return;
         }
         const failedAt = this.diagnosticNow();
+        this.providerSwitchDiagnostics.complete(scopeKey, {
+          cacheStatus,
+          controllerApplyMs: 0,
+          error,
+          requestMs: Math.max(0, failedAt - requestStartedAt),
+          returnedSessionCount: 0,
+          sectionCount: 0,
+          status: "error"
+        });
         emitConversationRailFirstPagesDiagnostic({
           agentTargetId: this.sectionAgentTargetId || null,
           controllerApplyMs: 0,
@@ -562,14 +604,30 @@ export class AgentGUIConversationRailQueryController {
               sections: []
             };
         this.emit();
-      })
-      .finally(() => {
-        if (
-          this.pagingAbortControllers.get("__first_pages__") === abortController
-        ) {
-          this.pagingAbortControllers.delete("__first_pages__");
-        }
       });
+  }
+
+  private applyCachedFirstPages(
+    scopeKey: string,
+    entry: ReturnType<
+      WorkspaceQueryCache<CachedConversationRailQuery>["read"]
+    > &
+      object
+  ): void {
+    this.queryState = applyCachedConversationRailQuery({
+      cache: this.sessionSectionsQueryCache,
+      entry,
+      scopeKey,
+      upsertSessions: (sessions) => this.upsertSessions(sessions)
+    });
+  }
+
+  private writeCurrentQueryCache(): void {
+    writeConversationRailQueryCache({
+      cache: this.sessionSectionsQueryCache,
+      queryState: this.queryState,
+      scopeKey: this.railSectionQueryKey
+    });
   }
 
   private requestSearch(): void {
@@ -702,32 +760,15 @@ export class AgentGUIConversationRailQueryController {
     return Boolean(!this.scope?.previewMode && this.runtime.listSessionsPage);
   }
 
-  private buildSnapshot(): AgentGUIConversationRailQuerySnapshot {
-    const searchResolved =
-      this.searchState.requestKey === this.searchRequestKey &&
-      this.searchState.resolvedQuery === this.searchQuery;
-    return {
-      railSearch: {
-        enabled: this.searchEnabled(),
-        failed: searchResolved && this.searchState.failed,
-        hasMore: searchResolved && this.searchState.hasMore,
-        loadingMore: searchResolved && this.searchState.loadingMore,
-        pending:
-          Boolean(this.searchQuery) &&
-          (!searchResolved || this.searchState.pending),
-        resolvedQuery: searchResolved ? this.searchState.resolvedQuery : "",
-        sessionIds: searchResolved ? this.searchState.sessionIds : []
-      },
-      runtimeSectionsEnabled: this.runtimeSectionsEnabled(),
-      runtimeRailMemberships: this.queryState.sections,
-      runtimeRailReconcilingSessionIds: this.queryState.reconcilingSessionIds,
-      runtimeRailSectionsPending: this.queryState.pending,
-      sectionPageStates: this.queryState.sectionPageStates
-    };
-  }
-
   private emit(): void {
-    this.snapshot = this.buildSnapshot();
+    this.snapshot = buildConversationRailQuerySnapshot({
+      queryState: this.queryState,
+      runtimeSectionsEnabled: this.runtimeSectionsEnabled(),
+      searchEnabled: this.searchEnabled(),
+      searchQuery: this.searchQuery,
+      searchRequestKey: this.searchRequestKey,
+      searchState: this.searchState
+    });
     for (const listener of this.listeners) listener(this.snapshot);
   }
 
@@ -750,27 +791,4 @@ export class AgentGUIConversationRailQueryController {
     this.searchAbortController?.abort();
     this.searchAbortController = null;
   }
-}
-
-function pageState(page: {
-  hasMore: boolean;
-  nextCursor?: string | null;
-  totalCount: number;
-}): ConversationRailSectionPageState {
-  return {
-    hasMore: page.hasMore,
-    isLoading: false,
-    nextCursor: page.nextCursor ?? null,
-    totalCount: page.totalCount
-  };
-}
-
-function updateSectionPageState<T>(
-  current: ReadonlyMap<string, T>,
-  sectionId: string,
-  value: T
-): ReadonlyMap<string, T> {
-  const next = new Map(current);
-  next.set(sectionId, value);
-  return next;
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailDiagnostics.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailDiagnostics.ts
@@ -24,9 +24,152 @@ export interface ConversationRailFirstPagesDiagnostic {
   workspaceId: string;
 }
 
+export interface ConversationRailProviderSwitchDiagnostic {
+  cacheStatus: "fresh" | "miss" | "stale";
+  controllerApplyMs: number;
+  durationMs: number;
+  errorKind?: string;
+  event:
+    | "agent_gui.provider_switch.completed"
+    | "agent_gui.provider_switch.failed";
+  fromAgentTargetId: string | null;
+  requestMs: number;
+  returnedSessionCount: number;
+  sectionCount: number;
+  status: "ready" | "error";
+  toAgentTargetId: string | null;
+  workspaceId: string;
+}
+
 export type ConversationRailDiagnosticLogger = (
-  payload: ConversationRailFirstPagesDiagnostic
+  payload:
+    | ConversationRailFirstPagesDiagnostic
+    | ConversationRailProviderSwitchDiagnostic
 ) => void;
+
+interface PendingProviderSwitchDiagnostic {
+  cacheStatus: "fresh" | "miss" | "stale";
+  fromAgentTargetId: string | null;
+  scopeKey: string;
+  startedAtMs: number;
+  toAgentTargetId: string | null;
+}
+
+export class ConversationRailProviderSwitchDiagnosticTracker {
+  private pending: PendingProviderSwitchDiagnostic | null = null;
+
+  constructor(
+    private readonly diagnosticLogger: ConversationRailDiagnosticLogger,
+    private readonly now: () => number,
+    private readonly workspaceId: string
+  ) {}
+
+  configure(input: {
+    attached: boolean;
+    nextAgentTargetId: string;
+    nextScopeKey: string;
+    previousAgentTargetId: string;
+    previousScopeKey: string | null;
+  }): void {
+    if (
+      input.nextScopeKey !== input.previousScopeKey &&
+      this.pending?.scopeKey !== input.nextScopeKey
+    ) {
+      this.pending = null;
+    }
+    if (
+      input.attached &&
+      input.nextScopeKey !== input.previousScopeKey &&
+      input.previousScopeKey !== null &&
+      input.previousAgentTargetId !== input.nextAgentTargetId
+    ) {
+      this.pending = {
+        cacheStatus: "miss",
+        fromAgentTargetId: input.previousAgentTargetId || null,
+        scopeKey: input.nextScopeKey,
+        startedAtMs: this.now(),
+        toAgentTargetId: input.nextAgentTargetId || null
+      };
+    }
+  }
+
+  hasPending(scopeKey: string): boolean {
+    return this.pending?.scopeKey === scopeKey;
+  }
+
+  setCacheStatus(
+    scopeKey: string,
+    cacheStatus: PendingProviderSwitchDiagnostic["cacheStatus"]
+  ): void {
+    if (this.pending?.scopeKey === scopeKey) {
+      this.pending.cacheStatus = cacheStatus;
+    }
+  }
+
+  complete(
+    scopeKey: string,
+    result: Omit<
+      Parameters<typeof emitConversationRailProviderSwitchDiagnostic>[0],
+      | "diagnosticLogger"
+      | "durationMs"
+      | "fromAgentTargetId"
+      | "toAgentTargetId"
+      | "workspaceId"
+    >
+  ): void {
+    const pending = this.pending;
+    if (!pending || pending.scopeKey !== scopeKey) return;
+    this.pending = null;
+    emitConversationRailProviderSwitchDiagnostic({
+      ...result,
+      diagnosticLogger: this.diagnosticLogger,
+      durationMs: Math.max(0, this.now() - pending.startedAtMs),
+      fromAgentTargetId: pending.fromAgentTargetId,
+      toAgentTargetId: pending.toAgentTargetId,
+      workspaceId: this.workspaceId
+    });
+  }
+}
+
+export function emitConversationRailProviderSwitchDiagnostic(input: {
+  cacheStatus: ConversationRailProviderSwitchDiagnostic["cacheStatus"];
+  controllerApplyMs: number;
+  diagnosticLogger: ConversationRailDiagnosticLogger;
+  durationMs: number;
+  error?: unknown;
+  fromAgentTargetId: string | null;
+  requestMs: number;
+  returnedSessionCount: number;
+  sectionCount: number;
+  status: "ready" | "error";
+  toAgentTargetId: string | null;
+  workspaceId: string;
+}): void {
+  const payload: ConversationRailProviderSwitchDiagnostic = {
+    cacheStatus: input.cacheStatus,
+    controllerApplyMs: input.controllerApplyMs,
+    durationMs: input.durationMs,
+    ...(input.status === "error"
+      ? { errorKind: conversationRailErrorKind(input.error) }
+      : {}),
+    event:
+      input.status === "error"
+        ? "agent_gui.provider_switch.failed"
+        : "agent_gui.provider_switch.completed",
+    fromAgentTargetId: input.fromAgentTargetId,
+    requestMs: input.requestMs,
+    returnedSessionCount: input.returnedSessionCount,
+    sectionCount: input.sectionCount,
+    status: input.status,
+    toAgentTargetId: input.toAgentTargetId,
+    workspaceId: input.workspaceId
+  };
+  try {
+    input.diagnosticLogger(payload);
+  } catch (error) {
+    ignoreConversationRailDiagnosticFailure(error);
+  }
+}
 
 export function emitConversationRailFirstPagesDiagnostic(input: {
   agentTargetId: string | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryCache.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryCache.ts
@@ -1,0 +1,114 @@
+import type { AgentActivitySession } from "@tutti-os/agent-activity-core";
+import type { AgentActivityRuntimeSessionSectionsResult } from "../../../agentActivityRuntime";
+import type {
+  WorkspaceQueryCache,
+  WorkspaceQueryCacheEntry
+} from "../../../shared/query/workspaceQueryCache";
+import {
+  projectRuntimeSectionsToConversationRailMemberships,
+  type ConversationRailQueryState,
+  type ConversationRailSectionPageState
+} from "../model/agentGuiConversationRail";
+
+export interface CachedConversationRailQuery {
+  queryState: ConversationRailQueryState;
+  returnedSessionCount: number;
+  sectionCount: number;
+  sessions: readonly AgentActivitySession[];
+}
+
+export function cachedConversationRailQueryFromFirstPages(
+  page: AgentActivityRuntimeSessionSectionsResult,
+  scopeKey: string
+): CachedConversationRailQuery {
+  const sections = projectRuntimeSectionsToConversationRailMemberships({
+    pinned: page.pinned,
+    sections: page.sections
+  });
+  const sectionPageStates = new Map<string, ConversationRailSectionPageState>();
+  if (page.pinned) {
+    sectionPageStates.set("pinned", conversationRailPageState(page.pinned));
+  }
+  for (const section of page.sections) {
+    sectionPageStates.set(
+      section.sectionKey,
+      conversationRailPageState(section)
+    );
+  }
+  const sessions = [
+    ...(page.pinned?.sessions ?? []),
+    ...page.sections.flatMap((section) => section.sessions)
+  ];
+  return {
+    queryState: {
+      pending: false,
+      reconcilingSessionIds: [],
+      resolvedScopeKey: scopeKey,
+      sectionPageStates,
+      sections
+    },
+    returnedSessionCount: sessions.length,
+    sectionCount: page.sections.length + (page.pinned ? 1 : 0),
+    sessions
+  };
+}
+
+export function applyCachedConversationRailQuery(input: {
+  cache: WorkspaceQueryCache<CachedConversationRailQuery>;
+  entry: WorkspaceQueryCacheEntry<CachedConversationRailQuery>;
+  scopeKey: string;
+  upsertSessions(sessions: readonly AgentActivitySession[]): void;
+}): ConversationRailQueryState {
+  if (input.cache.claimIngestion(input.scopeKey, input.entry.version)) {
+    input.upsertSessions(input.entry.value.sessions);
+  }
+  return input.entry.value.queryState;
+}
+
+export function writeConversationRailQueryCache(input: {
+  cache: WorkspaceQueryCache<CachedConversationRailQuery>;
+  queryState: ConversationRailQueryState;
+  scopeKey: string | null;
+}): void {
+  const { queryState, scopeKey } = input;
+  if (
+    !scopeKey ||
+    queryState.pending ||
+    queryState.resolvedScopeKey !== scopeKey ||
+    queryState.sections === null
+  ) {
+    return;
+  }
+  input.cache.write(scopeKey, {
+    queryState,
+    returnedSessionCount: queryState.sections.reduce(
+      (count, section) => count + section.sessionIds.length,
+      0
+    ),
+    sectionCount: queryState.sections.length,
+    sessions: []
+  });
+}
+
+export function updateConversationRailSectionPageState<T>(
+  current: ReadonlyMap<string, T>,
+  sectionId: string,
+  value: T
+): ReadonlyMap<string, T> {
+  const next = new Map(current);
+  next.set(sectionId, value);
+  return next;
+}
+
+function conversationRailPageState(page: {
+  hasMore: boolean;
+  nextCursor?: string | null;
+  totalCount: number;
+}): ConversationRailSectionPageState {
+  return {
+    hasMore: page.hasMore,
+    isLoading: false,
+    nextCursor: page.nextCursor ?? null,
+    totalCount: page.totalCount
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQuerySnapshot.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQuerySnapshot.ts
@@ -1,0 +1,68 @@
+import type {
+  ConversationRailQueryState,
+  ConversationRailSectionMembership
+} from "../model/agentGuiConversationRail";
+
+export const EMPTY_CONVERSATION_RAIL_QUERY_STATE: ConversationRailQueryState = {
+  pending: false,
+  reconcilingSessionIds: [],
+  resolvedScopeKey: null,
+  sectionPageStates: new Map(),
+  sections: null
+};
+
+export interface AgentGUIConversationRailQuerySnapshot {
+  railSearch: {
+    enabled: boolean;
+    failed: boolean;
+    hasMore: boolean;
+    loadingMore: boolean;
+    pending: boolean;
+    resolvedQuery: string;
+    sessionIds: readonly string[];
+  };
+  runtimeSectionsEnabled: boolean;
+  runtimeRailMemberships: ConversationRailSectionMembership[] | null;
+  runtimeRailReconcilingSessionIds: readonly string[];
+  runtimeRailSectionsPending: boolean;
+  sectionPageStates: ConversationRailQueryState["sectionPageStates"];
+}
+
+export function buildConversationRailQuerySnapshot(input: {
+  queryState: ConversationRailQueryState;
+  runtimeSectionsEnabled: boolean;
+  searchEnabled: boolean;
+  searchQuery: string;
+  searchRequestKey: string | null;
+  searchState: {
+    failed: boolean;
+    hasMore: boolean;
+    loadingMore: boolean;
+    pending: boolean;
+    requestKey: string | null;
+    resolvedQuery: string;
+    sessionIds: readonly string[];
+  };
+}): AgentGUIConversationRailQuerySnapshot {
+  const searchResolved =
+    input.searchState.requestKey === input.searchRequestKey &&
+    input.searchState.resolvedQuery === input.searchQuery;
+  return {
+    railSearch: {
+      enabled: input.searchEnabled,
+      failed: searchResolved && input.searchState.failed,
+      hasMore: searchResolved && input.searchState.hasMore,
+      loadingMore: searchResolved && input.searchState.loadingMore,
+      pending:
+        Boolean(input.searchQuery) &&
+        (!searchResolved || input.searchState.pending),
+      resolvedQuery: searchResolved ? input.searchState.resolvedQuery : "",
+      sessionIds: searchResolved ? input.searchState.sessionIds : []
+    },
+    runtimeSectionsEnabled: input.runtimeSectionsEnabled,
+    runtimeRailMemberships: input.queryState.sections,
+    runtimeRailReconcilingSessionIds: input.queryState.reconcilingSessionIds,
+    runtimeRailSectionsPending: input.queryState.pending,
+    sectionPageStates: input.queryState.sectionPageStates
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.spec.tsx
@@ -1,12 +1,73 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
-import type { AgentGUINodeData } from "../../../types";
+import type { AgentGUIProvider, AgentGUINodeData } from "../../../types";
 import type { AgentSessionEngine } from "@tutti-os/agent-activity-core";
 import type { AgentGUIComposerTargetData } from "./agentGuiController.composerPresentation";
 import { useAgentGUIComposerOptionsSync } from "./useAgentGUIComposerOptionsSync";
 
 describe("useAgentGUIComposerOptionsSync", () => {
+  it("loads a switched target once without bypassing its cache", async () => {
+    const getComposerOptions = vi.fn(async () => ({}));
+    const activeConversationIdRef = { current: null };
+    const dataRef = { current: targetData("codex") };
+    const selectedTargetRef = { current: composerTarget("codex") };
+    const selectedProjectPathRef = { current: "/workspace/project" };
+    const { rerender } = renderHook(
+      ({ provider }) => {
+        const target = composerTarget(provider);
+        dataRef.current = target.data;
+        selectedTargetRef.current = target;
+        return useAgentGUIComposerOptionsSync({
+          activeConversationId: null,
+          activeConversationIdRef,
+          agentActivityRuntime: {
+            getComposerOptions
+          } as unknown as AgentActivityRuntime,
+          composerTargetData: target,
+          conversationFilter: null,
+          currentUserId: "user-1",
+          data: target.data,
+          dataRef,
+          defaultReasoningEffort: "high",
+          draftSettingsBySessionIdRef: { current: {} },
+          isComposerHome: true,
+          isComposerHomeRef: { current: true },
+          isCreatingConversation: false,
+          loadDraftComposerOptionsRef: { current: () => {} },
+          loadSessionState: vi.fn(),
+          previewMode: false,
+          providerComposerOptions: null,
+          reloadSelectedConversation: vi.fn(),
+          selectedComposerTargetDataRef: selectedTargetRef,
+          selectedProjectPath: "/workspace/project",
+          selectedProjectPathRef,
+          sessionEngine: {
+            getSnapshot: () => ({})
+          } as unknown as AgentSessionEngine,
+          syncConversationListProjection: vi.fn(async () => {}),
+          workspaceId: "workspace-1",
+          workspacePath: "/workspace"
+        });
+      },
+      { initialProps: { provider: "codex" as AgentGUIProvider } }
+    );
+
+    await waitFor(() => expect(getComposerOptions).toHaveBeenCalledTimes(1));
+    getComposerOptions.mockClear();
+
+    rerender({ provider: "claude-code" });
+
+    await waitFor(() => expect(getComposerOptions).toHaveBeenCalledTimes(1));
+    expect(getComposerOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentTargetId: "local:claude-code",
+        force: undefined,
+        provider: "claude-code"
+      })
+    );
+  });
+
   it("loads composer options after conversation creation settles", async () => {
     const getComposerOptions = vi.fn(async () => ({}));
     const data: AgentGUINodeData = {
@@ -33,7 +94,6 @@ describe("useAgentGUIComposerOptionsSync", () => {
           agentActivityRuntime: {
             getComposerOptions
           } as unknown as AgentActivityRuntime,
-          composerOptionsProjectKeyRef: { current: null },
           composerTargetData: target,
           conversationFilter: null,
           currentUserId: "user-1",
@@ -79,3 +139,22 @@ describe("useAgentGUIComposerOptionsSync", () => {
     });
   });
 });
+
+function targetData(provider: AgentGUIProvider): AgentGUINodeData {
+  return {
+    agentTargetId: `local:${provider}`,
+    lastActiveAgentSessionId: null,
+    provider
+  };
+}
+
+function composerTarget(
+  provider: AgentGUIProvider
+): AgentGUIComposerTargetData {
+  return {
+    agentTargetId: `local:${provider}`,
+    data: targetData(provider),
+    provider,
+    targetId: `local:${provider}`
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.ts
@@ -22,7 +22,6 @@ export function useAgentGUIComposerOptionsSync(input: {
   activeConversationId: string | null;
   activeConversationIdRef: RefObject<string | null>;
   agentActivityRuntime: AgentActivityRuntime;
-  composerOptionsProjectKeyRef: RefObject<string | null>;
   composerTargetData: AgentGUIComposerTargetData;
   conversationFilter: unknown;
   currentUserId: string | null | undefined;
@@ -111,22 +110,6 @@ export function useAgentGUIComposerOptionsSync(input: {
   input.loadDraftComposerOptionsRef.current = loadDraftComposerOptions;
 
   useEffect(() => {
-    if (input.previewMode) return;
-    const projectKey = `${input.composerTargetData.agentTargetId ?? input.composerTargetData.provider}\0${input.selectedProjectPath ?? ""}`;
-    const previous = input.composerOptionsProjectKeyRef.current;
-    input.composerOptionsProjectKeyRef.current = projectKey;
-    if (previous !== null && previous !== projectKey) {
-      loadDraftComposerOptions({ force: true });
-    }
-  }, [
-    input.composerTargetData.agentTargetId,
-    input.composerTargetData.provider,
-    input.previewMode,
-    input.selectedProjectPath,
-    loadDraftComposerOptions
-  ]);
-
-  useEffect(() => {
     if (input.previewMode) return undefined;
     return subscribeCoalesced(
       "agent-model-catalog-invalidated",
@@ -191,6 +174,7 @@ export function useAgentGUIComposerOptionsSync(input: {
     input.isCreatingConversation,
     input.previewMode,
     input.providerComposerOptions?.behavior?.prewarmDraftSession,
+    input.selectedProjectPath,
     loadDraftComposerOptions
   ]);
 
@@ -233,5 +217,5 @@ export function useAgentGUIComposerOptionsSync(input: {
     input.sessionEngine
   ]);
 
-  return { loadComposerOptionsForTarget, loadDraftComposerOptions };
+  return { loadDraftComposerOptions };
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIControllerRefs.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIControllerRefs.ts
@@ -47,7 +47,6 @@ export function useAgentGUIControllerRefs(
   const userProjectsRef = useRef(input.userProjects);
   const isNoProjectPathRef = useRef(input.isNoProjectPath);
   const userProjectsLoadSeqRef = useRef(0);
-  const composerOptionsProjectKeyRef = useRef<string | null>(null);
   const conversationsRef = useRef(input.conversations);
   const isMountedRef = useRef(true);
   const agentActivitySnapshotRef = useRef(input.agentActivitySnapshot);
@@ -140,7 +139,6 @@ export function useAgentGUIControllerRefs(
   return {
     activeConversationIdRef,
     agentActivitySnapshotRef,
-    composerOptionsProjectKeyRef,
     conversationIdsRef,
     conversationsRef,
     dataRef,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -345,7 +345,6 @@ export function useAgentGUINodeController({
   const {
     activeConversationIdRef,
     agentActivitySnapshotRef,
-    composerOptionsProjectKeyRef,
     conversationIdsRef,
     conversationsRef,
     dataRef,
@@ -616,35 +615,33 @@ export function useAgentGUINodeController({
     workspaceId
   });
 
-  const { loadComposerOptionsForTarget, loadDraftComposerOptions } =
-    useAgentGUIComposerOptionsSync({
-      activeConversationId,
-      activeConversationIdRef,
-      agentActivityRuntime,
-      composerOptionsProjectKeyRef,
-      composerTargetData,
-      conversationFilter,
-      currentUserId,
-      data,
-      dataRef,
-      defaultReasoningEffort,
-      draftSettingsBySessionIdRef,
-      isComposerHome,
-      isComposerHomeRef,
-      isCreatingConversation,
-      loadDraftComposerOptionsRef,
-      loadSessionState,
-      previewMode,
-      providerComposerOptions,
-      reloadSelectedConversation,
-      selectedComposerTargetDataRef,
-      selectedProjectPath,
-      selectedProjectPathRef,
-      sessionEngine,
-      syncConversationListProjection,
-      workspaceId,
-      workspacePath
-    });
+  const { loadDraftComposerOptions } = useAgentGUIComposerOptionsSync({
+    activeConversationId,
+    activeConversationIdRef,
+    agentActivityRuntime,
+    composerTargetData,
+    conversationFilter,
+    currentUserId,
+    data,
+    dataRef,
+    defaultReasoningEffort,
+    draftSettingsBySessionIdRef,
+    isComposerHome,
+    isComposerHomeRef,
+    isCreatingConversation,
+    loadDraftComposerOptionsRef,
+    loadSessionState,
+    previewMode,
+    providerComposerOptions,
+    reloadSelectedConversation,
+    selectedComposerTargetDataRef,
+    selectedProjectPath,
+    selectedProjectPathRef,
+    sessionEngine,
+    syncConversationListProjection,
+    workspaceId,
+    workspacePath
+  });
   const operationActions = useAgentGUIOperationActions({
     ...providerCatalogSelection,
     ...localState,
@@ -739,7 +736,6 @@ export function useAgentGUINodeController({
     isCreatingConversation,
     isLoadingConversations,
     isLoadingMessages,
-    loadComposerOptionsForTarget,
     normalizedComingSoonProviders,
     operationActions,
     persistActiveConversation,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIProviderHome.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIProviderHome.ts
@@ -58,10 +58,6 @@ interface UseAgentGUIProviderHomeInput {
   homeComposerTargetOverride: AgentGUIAgentTarget | null;
   isComposerHomeRef: CurrentValue<boolean>;
   isLoadingConversations: boolean;
-  loadComposerOptionsForTarget(
-    targetData: AgentGUIComposerTargetData,
-    options?: { force?: boolean }
-  ): void;
   normalizedExplicitProviderTargets: readonly AgentGUIAgentTarget[];
   normalizedProviderTargets: readonly AgentGUIAgentTarget[];
   onDataChangeRef: CurrentValue<
@@ -150,11 +146,6 @@ export function useAgentGUIProviderHome(input: UseAgentGUIProviderHomeInput) {
       ...nextTargetData.data,
       lastActiveAgentSessionId: null
     };
-    if (nextTarget.disabled !== true) {
-      currentInput.loadComposerOptionsForTarget(nextTargetData, {
-        force: true
-      });
-    }
   }, [resolveDefaultHomeComposerTarget]);
 
   const updateConversationFilter = useCallback(
@@ -194,11 +185,6 @@ export function useAgentGUIProviderHome(input: UseAgentGUIProviderHomeInput) {
             target.targetId === nextTarget.targetId &&
             agentGUIAgentTargetRefsEqual(target.ref, nextTarget.ref)
         );
-      const nextTargetData = composerTargetDataFromProviderTarget({
-        current: currentInput.dataRef.current,
-        isExplicit: nextTargetIsExplicit,
-        target: nextTarget
-      });
       const shouldSyncScopedRailFilter =
         currentInput.conversationFilterRef.current.kind === "agentTarget";
       currentInput.setHomeComposerTargetOverride(nextTarget);
@@ -253,11 +239,6 @@ export function useAgentGUIProviderHome(input: UseAgentGUIProviderHomeInput) {
         currentInput.dataRef.current = nextData;
         return nextData;
       });
-      if (nextTarget.disabled !== true) {
-        currentInput.loadComposerOptionsForTarget(nextTargetData, {
-          force: true
-        });
-      }
     },
     []
   );

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -29,6 +29,7 @@ import type {
   AgentHostAgentSessionComposerSettings,
   AgentHostUnactivateAgentSessionResult
 } from "./shared/contracts/dto";
+import type { WorkspaceQueryCache } from "./shared/query/workspaceQueryCache";
 
 export interface AgentActivityRuntimeUpdateSessionSettingsResult {
   agentSessionId: string;
@@ -372,6 +373,9 @@ export interface AgentActivityRuntime {
   ): Promise<AgentActivityRuntimeUpdateSessionSettingsResult>;
   getSnapshot(workspaceId: string): AgentActivitySnapshot;
   getSessionEngine(workspaceId: string): AgentSessionEngine;
+  getSessionSectionsQueryCache?(
+    workspaceId: string
+  ): WorkspaceQueryCache<unknown>;
   listSessionMessages(
     input: AgentActivityRuntimeListSessionMessagesInput
   ): Promise<AgentActivityMessagePage>;

--- a/packages/agent/gui/package.json
+++ b/packages/agent/gui/package.json
@@ -25,6 +25,7 @@
     "./provider-icons": "./provider-icons.ts",
     "./agentGuiSessionProviderIconUrls": "./agentGuiSessionProviderIconUrls.ts",
     "./workspace-agent-generated-files": "./shared/workspaceAgentGeneratedFiles.ts",
+    "./workspace-query-cache": "./shared/query/workspaceQueryCache.ts",
     "./i18n": "./i18n/index.ts",
     "./workbench": "./workbench/index.ts",
     "./workbench/contribution": "./workbench/contribution.ts",
@@ -176,6 +177,10 @@
         "types": "./dist/workspace-agent-generated-files.d.ts",
         "import": "./dist/workspace-agent-generated-files.js"
       },
+      "./workspace-query-cache": {
+        "types": "./dist/workspace-query-cache.d.ts",
+        "import": "./dist/workspace-query-cache.js"
+      },
       "./i18n": {
         "types": "./dist/i18n/index.d.ts",
         "import": "./dist/i18n/index.js"
@@ -260,6 +265,9 @@
         ],
         "workspace-agent-generated-files": [
           "./dist/workspace-agent-generated-files.d.ts"
+        ],
+        "workspace-query-cache": [
+          "./dist/workspace-query-cache.d.ts"
         ],
         "i18n": [
           "./dist/i18n/index.d.ts"

--- a/packages/agent/gui/shared/query/workspaceQueryCache.ts
+++ b/packages/agent/gui/shared/query/workspaceQueryCache.ts
@@ -1,0 +1,112 @@
+export interface WorkspaceQueryCacheEntry<TValue> {
+  readonly resolvedAtUnixMs: number;
+  readonly stale: boolean;
+  readonly value: TValue;
+  readonly version: number;
+}
+
+export interface WorkspaceQueryCache<TValue> {
+  claimIngestion(key: string, version: number): boolean;
+  invalidate(key?: string): void;
+  read(key: string): WorkspaceQueryCacheEntry<TValue> | null;
+  request(
+    key: string,
+    load: () => Promise<TValue>
+  ): Promise<WorkspaceQueryCacheEntry<TValue>>;
+  write(key: string, value: TValue): WorkspaceQueryCacheEntry<TValue>;
+}
+
+type MutableWorkspaceQueryCacheEntry<TValue> = Omit<
+  WorkspaceQueryCacheEntry<TValue>,
+  "stale"
+> & {
+  ingested: boolean;
+  stale: boolean;
+};
+
+const DEFAULT_MAX_ENTRIES = 24;
+
+export function createWorkspaceQueryCache<TValue>(options?: {
+  maxEntries?: number;
+  now?: () => number;
+}): WorkspaceQueryCache<TValue> {
+  const maxEntries = Math.max(1, options?.maxEntries ?? DEFAULT_MAX_ENTRIES);
+  const now = options?.now ?? Date.now;
+  const entries = new Map<string, MutableWorkspaceQueryCacheEntry<TValue>>();
+  const requests = new Map<string, Promise<WorkspaceQueryCacheEntry<TValue>>>();
+  let version = 0;
+
+  const touch = (
+    key: string,
+    entry: MutableWorkspaceQueryCacheEntry<TValue>
+  ): void => {
+    entries.delete(key);
+    entries.set(key, entry);
+  };
+
+  const trim = (): void => {
+    while (entries.size > maxEntries) {
+      const oldestKey = entries.keys().next().value;
+      if (typeof oldestKey !== "string") return;
+      entries.delete(oldestKey);
+    }
+  };
+
+  const write = (
+    key: string,
+    value: TValue,
+    ingested: boolean
+  ): MutableWorkspaceQueryCacheEntry<TValue> => {
+    const entry: MutableWorkspaceQueryCacheEntry<TValue> = {
+      ingested,
+      resolvedAtUnixMs: now(),
+      stale: false,
+      value,
+      version: ++version
+    };
+    touch(key, entry);
+    trim();
+    return entry;
+  };
+
+  return {
+    claimIngestion(key, expectedVersion) {
+      const entry = entries.get(key);
+      if (!entry || entry.version !== expectedVersion || entry.ingested) {
+        return false;
+      }
+      entry.ingested = true;
+      return true;
+    },
+    invalidate(key) {
+      if (key !== undefined) {
+        const entry = entries.get(key);
+        if (entry) entry.stale = true;
+        return;
+      }
+      for (const entry of entries.values()) entry.stale = true;
+    },
+    read(key) {
+      const entry = entries.get(key);
+      if (!entry) return null;
+      touch(key, entry);
+      return entry;
+    },
+    request(key, load) {
+      const active = requests.get(key);
+      if (active) return active;
+      const request = load()
+        .then((value): WorkspaceQueryCacheEntry<TValue> => {
+          return write(key, value, false);
+        })
+        .finally(() => {
+          if (requests.get(key) === request) requests.delete(key);
+        });
+      requests.set(key, request);
+      return request;
+    },
+    write(key, value) {
+      return write(key, value, true);
+    }
+  };
+}

--- a/packages/agent/gui/tsup.config.ts
+++ b/packages/agent/gui/tsup.config.ts
@@ -29,7 +29,8 @@ export default defineConfig({
     "workbench/sessionTitle": "workbench/sessionTitle.ts",
     "workbench/state": "workbench/state.ts",
     "workbench/types": "workbench/types.ts",
-    "workspace-agent-generated-files": "shared/workspaceAgentGeneratedFiles.ts"
+    "workspace-agent-generated-files": "shared/workspaceAgentGeneratedFiles.ts",
+    "workspace-query-cache": "shared/query/workspaceQueryCache.ts"
   },
   external: ["react", "react-dom"],
   format: ["esm"],

--- a/tools/degradation-baseline/agent-gui.json
+++ b/tools/degradation-baseline/agent-gui.json
@@ -21,7 +21,7 @@
       "packages/agent/gui/shared/AgentMessageMarkdown.tsx": 7,
       "packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx": 10
     },
-    "effectCount": 151,
+    "effectCount": 150,
     "fileLines": {
       "packages/agent/gui/app/renderer/i18n/locales/en.ts": 1893,
       "packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts": 1773


### PR DESCRIPTION
## Summary

- eliminate duplicate forced composer-options loads during target/project switches
- reuse workspace-scoped conversation rail queries across AgentGUI remounts, including stale-while-refresh and in-flight coalescing
- add provider-switch and composer-options timing diagnostics
- document cache ownership and troubleshooting signals

## Validation

- `pnpm check:full`
- focused AgentGUI rail/composer tests
- AgentGUI and desktop typecheck/build

## Notes

- based on current `origin/main`; independent of the original worktree uncommitted changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->