### PR TITLE
fix(tuttid): separate SQLite read and write pools

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1393,6 +1393,12 @@ current rail. Count, sort, and first-page trimming operate on narrow session-id
 rows; load full session entities only after that trimming. The query shape must
 not add one compound-select arm per requested section or inherit SQLite's
 compound-select term limit as a Rail project-count limit.
+Daemon rail reads use the shared SQLite read-only pool rather than the daemon's
+single write connection. Section pages and their turn/interaction hydration may
+therefore read committed WAL snapshots while an unrelated write transaction is
+in progress. Do not route these independent reads back through the write pool;
+queries that require read-after-write atomicity must instead remain inside the
+owning write transaction.
 When `agentTargetId` narrows the provider rail, use an exact target predicate
 and target-scoped ordinary/pinned composite indexes. An optional
 `(? = '' OR agent_target_id = ?)` predicate on an unscoped index only filters

--- a/docs/conventions/local-state-storage.md
+++ b/docs/conventions/local-state-storage.md
@@ -233,6 +233,23 @@ Tutti provider startup.
 - workspace apps receive `<state-dir>/app-toolchains` as the shared cache root
   for reusable app-managed binaries
 
+## SQLite Connection Governance
+
+The daemon owns one SQLite database file and opens separate `database/sql`
+pools for writes and reads. The write pool has exactly one connection because
+SQLite serializes writers and several migrations rely on connection-scoped
+PRAGMA state. The read-only pool uses WAL snapshots and may grow on demand to a
+small bounded number of connections; its connections use SQLite read-only and
+`query_only` modes.
+
+Route independent queries through the read pool. Writes, migrations,
+read-modify-write sequences, and reads that must share a write transaction's
+snapshot stay on the write connection or its `sql.Tx`. Configure
+connection-scoped PRAGMAs in the SQLite DSN so every dynamically opened
+connection receives the same settings; executing a PRAGMA once through
+`sql.DB` is not sufficient for a multi-connection pool. Long-lived read
+transactions must be avoided because they can delay WAL checkpoints.
+
 ## Validation
 
 The repository includes a transport smoke test:

--- a/services/tuttid/data/workspace/agent_store.go
+++ b/services/tuttid/data/workspace/agent_store.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
@@ -22,9 +23,11 @@ var _ agentactivitybiz.Repository = (*SQLiteStore)(nil)
 const legacyIDLocalCodex = "local-codex"
 const legacyIDLocalClaudeCode = "local-claude-code"
 
-func (s *SQLiteStore) newAgentStore() *agentstore.Store {
-	return agentstore.New(s.db, agentstore.Options{
-		WorkspaceExists:        s.ensureWorkspaceExists,
+func (s *SQLiteStore) newAgentStore(db *sql.DB) *agentstore.Store {
+	return agentstore.New(db, agentstore.Options{
+		WorkspaceExists: func(ctx context.Context, workspaceID string) error {
+			return ensureWorkspaceExistsOn(ctx, db, workspaceID)
+		},
 		ProjectPaths:           userProjectPathsQuerier{},
 		NormalizeTarget:        normalizeStoreAgentTarget,
 		IsSkippableTargetError: isSkippableAgentTargetRowError,
@@ -52,7 +55,17 @@ func (s *SQLiteStore) agentStore() *agentstore.Store {
 	if s == nil {
 		return nil
 	}
-	return s.agent
+	return s.agentWriter
+}
+
+func (s *SQLiteStore) agentReadStore() *agentstore.Store {
+	if s == nil {
+		return nil
+	}
+	if s.agentReader != nil {
+		return s.agentReader
+	}
+	return s.agentWriter
 }
 
 // userProjectPathsQuerier feeds the user_projects table into the agent
@@ -98,7 +111,7 @@ func (s *SQLiteStore) BindGoalProvenance(ctx context.Context, input agentactivit
 }
 
 func (s *SQLiteStore) LookupGoalProvenance(ctx context.Context, input agentactivitybiz.LookupGoalProvenanceInput) (agentactivitybiz.GoalProvenanceBinding, bool, error) {
-	return s.agentStore().LookupGoalProvenance(ctx, input)
+	return s.agentReadStore().LookupGoalProvenance(ctx, input)
 }
 
 func (s *SQLiteStore) ReportActivityState(ctx context.Context, input agentactivitybiz.ActivityStateReport) (agentactivitybiz.ActivityStateReportResult, error) {
@@ -114,7 +127,7 @@ func (s *SQLiteStore) PutGoalReconcileInbox(ctx context.Context, input agentacti
 }
 
 func (s *SQLiteStore) ListClaimableGoalReconcileInbox(ctx context.Context, now int64, limit int) ([]agentactivitybiz.GoalReconcileInboxItem, error) {
-	return s.agentStore().ListClaimableGoalReconcileInbox(ctx, now, limit)
+	return s.agentReadStore().ListClaimableGoalReconcileInbox(ctx, now, limit)
 }
 
 func (s *SQLiteStore) ClaimGoalReconcileInbox(ctx context.Context, input agentactivitybiz.ClaimGoalReconcileInboxInput) (agentactivitybiz.GoalReconcileInboxItem, bool, error) {
@@ -134,39 +147,39 @@ func (s *SQLiteStore) RequeueLeasedGoalReconcileInboxOnStartup(ctx context.Conte
 }
 
 func (s *SQLiteStore) GetSession(ctx context.Context, workspaceID string, agentSessionID string) (agentactivitybiz.Session, bool, error) {
-	return s.agentStore().GetSession(ctx, workspaceID, agentSessionID)
+	return s.agentReadStore().GetSession(ctx, workspaceID, agentSessionID)
 }
 
 func (s *SQLiteStore) ListChildSessions(ctx context.Context, workspaceID string, agentSessionID string) ([]agentactivitybiz.Session, error) {
-	return s.agentStore().ListChildSessions(ctx, workspaceID, agentSessionID)
+	return s.agentReadStore().ListChildSessions(ctx, workspaceID, agentSessionID)
 }
 
 func (s *SQLiteStore) SessionDeleted(ctx context.Context, workspaceID string, agentSessionID string) (bool, error) {
-	return s.agentStore().SessionDeleted(ctx, workspaceID, agentSessionID)
+	return s.agentReadStore().SessionDeleted(ctx, workspaceID, agentSessionID)
 }
 
 func (s *SQLiteStore) ListSessions(ctx context.Context, workspaceID string) ([]agentactivitybiz.Session, bool, error) {
-	return s.agentStore().ListSessions(ctx, workspaceID)
+	return s.agentReadStore().ListSessions(ctx, workspaceID)
 }
 
 func (s *SQLiteStore) ListSessionSection(ctx context.Context, input agentactivitybiz.ListSessionSectionInput) (agentactivitybiz.SessionSectionPage, bool, error) {
-	return s.agentStore().ListSessionSection(ctx, input)
+	return s.agentReadStore().ListSessionSection(ctx, input)
 }
 
 func (s *SQLiteStore) ListSessionSections(ctx context.Context, input agentactivitybiz.ListSessionSectionsInput) (agentactivitybiz.SessionSectionsPage, bool, error) {
-	return s.agentStore().ListSessionSections(ctx, input)
+	return s.agentReadStore().ListSessionSections(ctx, input)
 }
 
 func (s *SQLiteStore) ListSessionSectionDeletionCandidates(ctx context.Context, input agentactivitybiz.ListSessionSectionDeletionCandidatesInput) (agentactivitybiz.SessionSectionDeletionCandidates, bool, error) {
-	return s.agentStore().ListSessionSectionDeletionCandidates(ctx, input)
+	return s.agentReadStore().ListSessionSectionDeletionCandidates(ctx, input)
 }
 
 func (s *SQLiteStore) ListSessionMessages(ctx context.Context, input agentactivitybiz.ListSessionMessagesInput) (agentactivitybiz.MessagePage, bool, error) {
-	return s.agentStore().ListSessionMessages(ctx, input)
+	return s.agentReadStore().ListSessionMessages(ctx, input)
 }
 
 func (s *SQLiteStore) ListWorkspaceGeneratedFiles(ctx context.Context, input agentactivitybiz.ListWorkspaceGeneratedFilesInput) (agentactivitybiz.GeneratedFileList, bool, error) {
-	return s.agentStore().ListWorkspaceGeneratedFiles(ctx, input)
+	return s.agentReadStore().ListWorkspaceGeneratedFiles(ctx, input)
 }
 
 func (s *SQLiteStore) DeleteSession(ctx context.Context, workspaceID string, agentSessionID string) (bool, error) {
@@ -194,31 +207,31 @@ func (s *SQLiteStore) UpdateSessionTitle(ctx context.Context, workspaceID string
 }
 
 func (s *SQLiteStore) GetTurn(ctx context.Context, workspaceID string, agentSessionID string, turnID string) (agentactivitybiz.Turn, bool, error) {
-	return s.agentStore().GetTurn(ctx, workspaceID, agentSessionID, turnID)
+	return s.agentReadStore().GetTurn(ctx, workspaceID, agentSessionID, turnID)
 }
 
 func (s *SQLiteStore) GetLatestTurn(ctx context.Context, workspaceID string, agentSessionID string) (agentactivitybiz.Turn, bool, error) {
-	return s.agentStore().GetLatestTurn(ctx, workspaceID, agentSessionID)
+	return s.agentReadStore().GetLatestTurn(ctx, workspaceID, agentSessionID)
 }
 
 func (s *SQLiteStore) ListLatestTurns(ctx context.Context, workspaceID string, agentSessionIDs []string) (map[string]agentactivitybiz.Turn, error) {
-	return s.agentStore().ListLatestTurns(ctx, workspaceID, agentSessionIDs)
+	return s.agentReadStore().ListLatestTurns(ctx, workspaceID, agentSessionIDs)
 }
 
 func (s *SQLiteStore) ListLatestTurnInteractions(ctx context.Context, workspaceID string, agentSessionIDs []string) (map[string][]agentactivitybiz.Interaction, error) {
-	return s.agentStore().ListLatestTurnInteractions(ctx, workspaceID, agentSessionIDs)
+	return s.agentReadStore().ListLatestTurnInteractions(ctx, workspaceID, agentSessionIDs)
 }
 
 func (s *SQLiteStore) ListTurnsBySession(ctx context.Context, workspaceID string, turnIDBySessionID map[string]string) (map[string]agentactivitybiz.Turn, error) {
-	return s.agentStore().ListTurnsBySession(ctx, workspaceID, turnIDBySessionID)
+	return s.agentReadStore().ListTurnsBySession(ctx, workspaceID, turnIDBySessionID)
 }
 
 func (s *SQLiteStore) ListPendingInteractionsBySession(ctx context.Context, workspaceID string, agentSessionIDs []string) (map[string][]agentactivitybiz.Interaction, error) {
-	return s.agentStore().ListPendingInteractionsBySession(ctx, workspaceID, agentSessionIDs)
+	return s.agentReadStore().ListPendingInteractionsBySession(ctx, workspaceID, agentSessionIDs)
 }
 
 func (s *SQLiteStore) ListSessionTurns(ctx context.Context, workspaceID string, agentSessionID string) ([]agentactivitybiz.Turn, error) {
-	return s.agentStore().ListSessionTurns(ctx, workspaceID, agentSessionID)
+	return s.agentReadStore().ListSessionTurns(ctx, workspaceID, agentSessionID)
 }
 
 func (s *SQLiteStore) SettleStaleTurns(ctx context.Context) ([]agentactivitybiz.StaleTurnSettlement, error) {
@@ -226,7 +239,7 @@ func (s *SQLiteStore) SettleStaleTurns(ctx context.Context) ([]agentactivitybiz.
 }
 
 func (s *SQLiteStore) ListSessionInteractions(ctx context.Context, input agentactivitybiz.ListSessionInteractionsInput) ([]agentactivitybiz.Interaction, error) {
-	return s.agentStore().ListSessionInteractions(ctx, input)
+	return s.agentReadStore().ListSessionInteractions(ctx, input)
 }
 
 func (s *SQLiteStore) PrepareRuntimeOperation(ctx context.Context, input agentactivitybiz.RuntimeOperationPrepare) (agentactivitybiz.RuntimeOperation, bool, error) {
@@ -238,7 +251,7 @@ func (s *SQLiteStore) PrepareGoalControlOperation(ctx context.Context, input age
 }
 
 func (s *SQLiteStore) GetGoalControlAudit(ctx context.Context, workspaceID string, agentSessionID string, operationID string) (agentactivitybiz.Message, bool, error) {
-	return s.agentStore().GetGoalControlAudit(ctx, workspaceID, agentSessionID, operationID)
+	return s.agentReadStore().GetGoalControlAudit(ctx, workspaceID, agentSessionID, operationID)
 }
 
 func (s *SQLiteStore) MarkGoalControlOperationDispatched(ctx context.Context, workspaceID, operationID string, occurredAtUnixMS int64) (agentactivitybiz.GoalControlOperation, bool, error) {
@@ -254,7 +267,7 @@ func (s *SQLiteStore) CompleteGoalControlOperation(ctx context.Context, input ag
 }
 
 func (s *SQLiteStore) GetSessionGoalState(ctx context.Context, workspaceID, agentSessionID string) (agentactivitybiz.SessionGoalState, bool, error) {
-	return s.agentStore().GetSessionGoalState(ctx, workspaceID, agentSessionID)
+	return s.agentReadStore().GetSessionGoalState(ctx, workspaceID, agentSessionID)
 }
 
 func (s *SQLiteStore) ReconcileSessionGoalObservation(ctx context.Context, input agentactivitybiz.GoalObservationReconcile) (agentactivitybiz.SessionGoalState, error) {
@@ -262,11 +275,11 @@ func (s *SQLiteStore) ReconcileSessionGoalObservation(ctx context.Context, input
 }
 
 func (s *SQLiteStore) GetGoalControlOperation(ctx context.Context, workspaceID, operationID string) (agentactivitybiz.GoalControlOperation, bool, error) {
-	return s.agentStore().GetGoalControlOperation(ctx, workspaceID, operationID)
+	return s.agentReadStore().GetGoalControlOperation(ctx, workspaceID, operationID)
 }
 
 func (s *SQLiteStore) ListClaimableGoalControlOperations(ctx context.Context, input agentactivitybiz.ListClaimableGoalControlOperationsInput) ([]agentactivitybiz.GoalControlOperation, error) {
-	return s.agentStore().ListClaimableGoalControlOperations(ctx, input)
+	return s.agentReadStore().ListClaimableGoalControlOperations(ctx, input)
 }
 
 func (s *SQLiteStore) ClaimGoalControlOperation(ctx context.Context, input agentactivitybiz.ClaimGoalControlOperationInput) (agentactivitybiz.GoalControlOperation, bool, error) {
@@ -306,11 +319,11 @@ func (s *SQLiteStore) DeleteSubmitClaim(ctx context.Context, workspaceID, agentS
 }
 
 func (s *SQLiteStore) GetRuntimeOperation(ctx context.Context, workspaceID string, operationID string) (agentactivitybiz.RuntimeOperation, bool, error) {
-	return s.agentStore().GetRuntimeOperation(ctx, workspaceID, operationID)
+	return s.agentReadStore().GetRuntimeOperation(ctx, workspaceID, operationID)
 }
 
 func (s *SQLiteStore) ListClaimableRuntimeOperations(ctx context.Context, input agentactivitybiz.ListClaimableRuntimeOperationsInput) ([]agentactivitybiz.RuntimeOperation, error) {
-	return s.agentStore().ListClaimableRuntimeOperations(ctx, input)
+	return s.agentReadStore().ListClaimableRuntimeOperations(ctx, input)
 }
 
 func (s *SQLiteStore) ClaimRuntimeOperationLease(ctx context.Context, input agentactivitybiz.ClaimRuntimeOperationLeaseInput) (agentactivitybiz.RuntimeOperation, bool, error) {
@@ -342,11 +355,11 @@ func (s *SQLiteStore) CompletePlanDecisionRuntimeOperation(ctx context.Context, 
 }
 
 func (s *SQLiteStore) FindTurnByClientSubmitID(ctx context.Context, workspaceID string, agentSessionID string, clientSubmitID string) (string, bool, error) {
-	return s.agentStore().FindTurnByClientSubmitID(ctx, workspaceID, agentSessionID, clientSubmitID)
+	return s.agentReadStore().FindTurnByClientSubmitID(ctx, workspaceID, agentSessionID, clientSubmitID)
 }
 
 func (s *SQLiteStore) ListPendingRuntimeOperationEvents(ctx context.Context, workspaceID string, limit int) ([]agentactivitybiz.RuntimeOperationEvent, error) {
-	return s.agentStore().ListPendingRuntimeOperationEvents(ctx, workspaceID, limit)
+	return s.agentReadStore().ListPendingRuntimeOperationEvents(ctx, workspaceID, limit)
 }
 
 func (s *SQLiteStore) MarkRuntimeOperationEventPublished(ctx context.Context, workspaceID string, eventID int64, publishedAtUnixMS int64) (bool, error) {
@@ -354,7 +367,7 @@ func (s *SQLiteStore) MarkRuntimeOperationEventPublished(ctx context.Context, wo
 }
 
 func (s *SQLiteStore) ListAgentTargets(ctx context.Context) ([]agenttargetbiz.Target, error) {
-	targets, err := s.agentStore().ListAgentTargets(ctx)
+	targets, err := s.agentReadStore().ListAgentTargets(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -366,7 +379,7 @@ func (s *SQLiteStore) ListAgentTargets(ctx context.Context) ([]agenttargetbiz.Ta
 }
 
 func (s *SQLiteStore) GetAgentTarget(ctx context.Context, id string) (agenttargetbiz.Target, error) {
-	target, err := s.agentStore().GetAgentTarget(ctx, id)
+	target, err := s.agentReadStore().GetAgentTarget(ctx, id)
 	if err != nil {
 		return agenttargetbiz.Target{}, err
 	}

--- a/services/tuttid/data/workspace/agent_store_upgrade_test.go
+++ b/services/tuttid/data/workspace/agent_store_upgrade_test.go
@@ -201,7 +201,7 @@ func TestSQLiteStoreMigrateUpgradesLegacyDatabaseWithoutReplayingAgentMigrations
 		"workspace_agent_activity_rail_v1": 27,
 	} {
 		var appliedAt int64
-		if err := store.db.QueryRowContext(ctx, `
+		if err := store.writeDB.QueryRowContext(ctx, `
 SELECT applied_at_unix_ms FROM agent_store_schema_migrations WHERE id = ?
 `, migrationID).Scan(&appliedAt); err != nil {
 			t.Fatalf("claimed migration %s missing from agent store ledger: %v", migrationID, err)
@@ -275,7 +275,7 @@ SELECT applied_at_unix_ms FROM agent_store_schema_migrations WHERE id = ?
 
 	// The final entity migration normalizes the claimed legacy table onto the
 	// package-owned schema and replaces host coupling with the active-turn FK.
-	rows, err := store.db.QueryContext(ctx, `PRAGMA foreign_key_list(workspace_agent_sessions)`)
+	rows, err := store.writeDB.QueryContext(ctx, `PRAGMA foreign_key_list(workspace_agent_sessions)`)
 	if err != nil {
 		t.Fatalf("foreign_key_list error = %v", err)
 	}
@@ -311,7 +311,7 @@ SELECT applied_at_unix_ms FROM agent_store_schema_migrations WHERE id = ?
 		t.Fatalf("Delete() error = %v", err)
 	}
 	var sessionCount int
-	if err := store.db.QueryRowContext(ctx, `
+	if err := store.writeDB.QueryRowContext(ctx, `
 SELECT COUNT(*) FROM workspace_agent_sessions WHERE workspace_id = 'ws-upgrade'
 `).Scan(&sessionCount); err != nil {
 		t.Fatalf("count sessions after delete: %v", err)
@@ -349,7 +349,7 @@ func TestSQLiteStoreWorkspaceDeleteClearsAgentSessionsWithoutForeignKey(t *testi
 	}
 
 	var sessionCount int
-	if err := store.db.QueryRowContext(ctx, `
+	if err := store.writeDB.QueryRowContext(ctx, `
 SELECT COUNT(*) FROM workspace_agent_sessions WHERE workspace_id = ?
 `, "ws-delete-cascade").Scan(&sessionCount); err != nil {
 		t.Fatalf("count sessions after delete: %v", err)

--- a/services/tuttid/data/workspace/desktop_preferences_migrations.go
+++ b/services/tuttid/data/workspace/desktop_preferences_migrations.go
@@ -20,7 +20,7 @@ func (s *SQLiteStore) applyDesktopPreferencesV1(ctx context.Context) error {
 	}
 
 	now := unixMs(time.Now().UTC())
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 CREATE TABLE IF NOT EXISTS desktop_preferences (
   id TEXT PRIMARY KEY,
   agent_dock_layout TEXT NOT NULL DEFAULT 'unified',
@@ -71,13 +71,13 @@ func (s *SQLiteStore) applyDesktopPreferencesAgentDockLayoutV1(ctx context.Conte
 		return err
 	}
 	if !hasAgentDockLayout {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN agent_dock_layout TEXT NOT NULL DEFAULT 'unified';`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop agent dock layout: %w", err)
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesAgentDockLayoutV1, now)
@@ -103,13 +103,13 @@ func (s *SQLiteStore) applyDesktopPreferencesAgentConversationDetailModeV1(ctx c
 		return err
 	}
 	if !hasAgentConversationDetailMode {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN agent_conversation_detail_mode TEXT NOT NULL DEFAULT 'coding';`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop agent conversation detail mode: %w", err)
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesAgentConversationDetailModeV1, now)
@@ -145,13 +145,13 @@ func (s *SQLiteStore) applyDesktopPreferencesFeatureFlagsV1(ctx context.Context)
 		if hasColumn {
 			continue
 		}
-		if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+		if _, err := s.writeDB.ExecContext(ctx, fmt.Sprintf(`
 ALTER TABLE desktop_preferences
   ADD COLUMN %s %s;`, column.name, column.definition)); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop feature flags preferences %s: %w", column.name, err)
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesFeatureFlagsV1, now)
@@ -177,13 +177,13 @@ func (s *SQLiteStore) applyDesktopPreferencesShowAppDeveloperSourcesV1(ctx conte
 		return err
 	}
 	if !hasShowAppDeveloperSources {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN show_app_developer_sources INTEGER NOT NULL DEFAULT 0;`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop app developer sources: %w", err)
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesShowAppDeveloperSourcesV1, now)
@@ -209,13 +209,13 @@ func (s *SQLiteStore) applyDesktopPreferencesEnableCursorAgentV1(ctx context.Con
 		return err
 	}
 	if !hasEnableCursorAgent {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN enable_cursor_agent INTEGER NOT NULL DEFAULT 0;`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop enable cursor agent: %w", err)
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesEnableCursorAgentV1, now)
@@ -241,13 +241,13 @@ func (s *SQLiteStore) applyDesktopPreferencesEnableOpenCodeAgentV1(ctx context.C
 		return err
 	}
 	if !hasEnableOpenCodeAgent {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN enable_opencode_agent INTEGER NOT NULL DEFAULT 0;`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop enable opencode agent: %w", err)
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesEnableOpenCodeAgentV1, now)
@@ -273,13 +273,13 @@ func (s *SQLiteStore) applyDesktopPreferencesFileDefaultOpenersV1(ctx context.Co
 		return err
 	}
 	if !hasFileDefaultOpeners {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN file_default_openers_by_extension_json TEXT NOT NULL DEFAULT '{"htm":"appBrowser","html":"appBrowser","shtml":"appBrowser","xhtml":"appBrowser"}';`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop file default openers: %w", err)
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesFileDefaultOpenersV1, now)
@@ -305,13 +305,13 @@ func (s *SQLiteStore) applyDesktopPreferencesAppCatalogChannelV1(ctx context.Con
 		return err
 	}
 	if !hasAppCatalogChannel {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN app_catalog_channel TEXT NOT NULL DEFAULT 'production';`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop app catalog channel: %w", err)
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesAppCatalogChannelV1, now)
@@ -338,7 +338,7 @@ func (s *SQLiteStore) applyDesktopPreferencesMinimizeAnimationV1(ctx context.Con
 
 	now := unixMs(time.Now().UTC())
 	if !hasMinimizeAnimation {
-		_, err = s.db.ExecContext(ctx, `
+		_, err = s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences ADD COLUMN minimize_animation TEXT NOT NULL DEFAULT 'scale';
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
@@ -349,7 +349,7 @@ INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 		return nil
 	}
 
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesMinimizeAnimationV1, now)
@@ -374,13 +374,13 @@ func (s *SQLiteStore) applyDesktopPreferencesAgentGUIConversationRailV1(ctx cont
 		return err
 	}
 	if !hasAgentGUIConversationRail {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN agent_gui_conversation_rail_collapsed_by_provider_json TEXT NOT NULL DEFAULT '{}';`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop agent gui conversation rail: %w", err)
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesAgentGUIConversationRailV1, now)
@@ -406,7 +406,7 @@ func (s *SQLiteStore) applyDesktopPreferencesWindowSnappingV1(ctx context.Contex
 		return err
 	}
 	if !hasWindowSnappingEnabled {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN workbench_window_snapping_enabled INTEGER NOT NULL DEFAULT 0;`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop workbench window snapping enabled: %w", err)
@@ -417,13 +417,13 @@ ALTER TABLE desktop_preferences
 		return err
 	}
 	if !hasWindowSnappingShortcutPreset {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN workbench_window_snapping_shortcut_preset TEXT NOT NULL DEFAULT 'commandArrows';`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop workbench window snapping shortcut preset: %w", err)
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesWindowSnappingV1, now)
@@ -449,7 +449,7 @@ func (s *SQLiteStore) applyDesktopPreferencesUpdateSettingsV1(ctx context.Contex
 		return err
 	}
 	if !hasUpdateChannel {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN update_channel TEXT NOT NULL DEFAULT 'stable';`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop update channel: %w", err)
@@ -460,13 +460,13 @@ ALTER TABLE desktop_preferences
 		return err
 	}
 	if !hasUpdatePolicy {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN update_policy TEXT NOT NULL DEFAULT 'prompt';`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop update policy: %w", err)
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesUpdateSettingsV1, now)
@@ -496,13 +496,13 @@ func (s *SQLiteStore) applyDesktopPreferencesSleepPreventionModeV1(ctx context.C
 		return err
 	}
 	if !hasSleepPreventionMode {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN sleep_prevention_mode TEXT NOT NULL DEFAULT 'never';`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop sleep prevention mode: %w", err)
 		}
 		if hasLegacyPreventSleepEnabled {
-			if _, err := s.db.ExecContext(ctx, `
+			if _, err := s.writeDB.ExecContext(ctx, `
 UPDATE desktop_preferences
 SET sleep_prevention_mode = 'whileAgentRunning'
 WHERE prevent_sleep_while_agent_running_enabled = 1;`); err != nil {
@@ -510,7 +510,7 @@ WHERE prevent_sleep_while_agent_running_enabled = 1;`); err != nil {
 			}
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesSleepPreventionModeV1, now)
@@ -536,13 +536,13 @@ func (s *SQLiteStore) applyDesktopPreferencesDockPlacementV1(ctx context.Context
 		return err
 	}
 	if !hasDockPlacement {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN dock_placement TEXT NOT NULL DEFAULT 'bottom';`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop dock placement: %w", err)
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesDockPlacementV1, now)
@@ -568,13 +568,13 @@ func (s *SQLiteStore) applyDesktopPreferencesDockIconStyleV1(ctx context.Context
 		return err
 	}
 	if !hasDockIconStyle {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN dock_icon_style TEXT NOT NULL DEFAULT 'flat';`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop dock icon style: %w", err)
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesDockIconStyleV1, now)
@@ -600,13 +600,13 @@ func (s *SQLiteStore) applyDesktopPreferencesDefaultAgentProviderV1(ctx context.
 		return err
 	}
 	if !hasDefaultAgentProvider {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN default_agent_provider TEXT NOT NULL DEFAULT 'codex';`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop default agent provider: %w", err)
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesDefaultAgentProviderV1, now)
@@ -632,13 +632,13 @@ func (s *SQLiteStore) applyDesktopPreferencesAgentComposerDefaultsV1(ctx context
 		return err
 	}
 	if !hasAgentComposerDefaults {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN agent_composer_defaults_by_provider_json TEXT NOT NULL DEFAULT '{}';`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop agent composer defaults: %w", err)
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesAgentComposerDefaultsV1, now)
@@ -664,7 +664,7 @@ func (s *SQLiteStore) applyDesktopPreferencesAgentComposerDefaultsByAgentTargetV
 		return err
 	}
 	if !hasColumn {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN agent_composer_defaults_by_agent_target_json TEXT NOT NULL DEFAULT '{}';`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop agent composer defaults by agent target: %w", err)
@@ -673,7 +673,7 @@ ALTER TABLE desktop_preferences
 	if err := s.backfillAgentComposerDefaultsByAgentTarget(ctx); err != nil {
 		return fmt.Errorf("migrate workspace database for desktop agent composer defaults by agent target: %w", err)
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesAgentComposerDefaultsByAgentTargetV1, now)
@@ -689,7 +689,7 @@ INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 // this data migration nothing reads the legacy column anymore, so remembered
 // defaults (including explicit clears) are fully owned by the new column.
 func (s *SQLiteStore) backfillAgentComposerDefaultsByAgentTarget(ctx context.Context) error {
-	row := s.db.QueryRowContext(ctx, `
+	row := s.writeDB.QueryRowContext(ctx, `
 SELECT agent_composer_defaults_by_provider_json, agent_composer_defaults_by_agent_target_json
 FROM desktop_preferences
 WHERE id = ?
@@ -729,7 +729,7 @@ WHERE id = ?
 	if err != nil {
 		return err
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 UPDATE desktop_preferences
 SET agent_composer_defaults_by_agent_target_json = ?
 WHERE id = ?
@@ -752,13 +752,13 @@ func (s *SQLiteStore) applyDesktopPreferencesBrowserUseConnectionModeV1(ctx cont
 		return err
 	}
 	if !hasBrowserUseConnectionMode {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
   ADD COLUMN browser_use_connection_mode TEXT NOT NULL DEFAULT 'isolated';`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop browser use connection mode: %w", err)
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationDesktopPreferencesBrowserUseConnectionModeV1, now)

--- a/services/tuttid/data/workspace/migrations.go
+++ b/services/tuttid/data/workspace/migrations.go
@@ -48,11 +48,11 @@ const schemaMigrationAppFactoryJobsV2 = "app_factory_jobs_v2"
 const schemaMigrationAppFactoryJobsV3 = "app_factory_jobs_v3"
 
 func (s *SQLiteStore) Migrate(ctx context.Context) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
 
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.writeDB.ExecContext(ctx, `
 CREATE TABLE IF NOT EXISTS tuttid_schema_migrations (
   id TEXT PRIMARY KEY,
   applied_at_unix_ms INTEGER NOT NULL
@@ -201,7 +201,10 @@ INSERT OR IGNORE INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 	if err := s.applyAppFactoryJobsV2(ctx); err != nil {
 		return err
 	}
-	return s.applyAppFactoryJobsV3(ctx)
+	if err := s.applyAppFactoryJobsV3(ctx); err != nil {
+		return err
+	}
+	return s.openReadPool(ctx)
 }
 
 func (s *SQLiteStore) applyWorkspacesV2(ctx context.Context) error {
@@ -214,7 +217,7 @@ func (s *SQLiteStore) applyWorkspacesV2(ctx context.Context) error {
 	}
 
 	now := unixMs(time.Now().UTC())
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 ALTER TABLE workspaces ADD COLUMN last_opened_at_unix_ms INTEGER;
 CREATE INDEX IF NOT EXISTS idx_workspaces_last_opened_at
   ON workspaces(last_opened_at_unix_ms DESC);
@@ -238,7 +241,7 @@ func (s *SQLiteStore) applyWorkspacesV3(ctx context.Context) error {
 	}
 
 	now := unixMs(time.Now().UTC())
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 CREATE TABLE IF NOT EXISTS workspace_workbench_snapshots (
   workspace_id TEXT PRIMARY KEY,
   schema_version INTEGER NOT NULL,
@@ -273,7 +276,7 @@ func (s *SQLiteStore) applyWorkspacesV4(ctx context.Context) error {
 
 	now := unixMs(time.Now().UTC())
 	if !hasLocalPath {
-		_, err = s.db.ExecContext(ctx, `
+		_, err = s.writeDB.ExecContext(ctx, `
 CREATE INDEX IF NOT EXISTS idx_workspaces_last_opened_at
   ON workspaces(last_opened_at_unix_ms DESC);
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
@@ -285,14 +288,14 @@ INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 		return nil
 	}
 
-	if _, err := s.db.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
+	if _, err := s.writeDB.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
 		return fmt.Errorf("disable sqlite foreign keys for workspace v4 migration: %w", err)
 	}
 	defer func() {
-		_, _ = s.db.ExecContext(context.Background(), `PRAGMA foreign_keys = ON`)
+		_, _ = s.writeDB.ExecContext(context.Background(), `PRAGMA foreign_keys = ON`)
 	}()
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.writeDB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin workspace database v4 migration: %w", err)
 	}
@@ -331,7 +334,7 @@ INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 		return fmt.Errorf("commit workspace database v4 migration: %w", err)
 	}
 
-	if _, err := s.db.ExecContext(ctx, `PRAGMA foreign_keys = ON`); err != nil {
+	if _, err := s.writeDB.ExecContext(ctx, `PRAGMA foreign_keys = ON`); err != nil {
 		return fmt.Errorf("re-enable sqlite foreign keys for workspace v4 migration: %w", err)
 	}
 
@@ -348,7 +351,7 @@ func (s *SQLiteStore) applyWorkspaceIssuesV1(ctx context.Context) error {
 	}
 
 	now := unixMs(time.Now().UTC())
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 CREATE TABLE IF NOT EXISTS workspace_issues (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   issue_id TEXT NOT NULL,
@@ -494,7 +497,7 @@ func (s *SQLiteStore) applyWorkspaceIssuesV2(ctx context.Context) error {
 	}
 
 	now := unixMs(time.Now().UTC())
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 PRAGMA foreign_keys = OFF;
 
 ALTER TABLE workspace_issue_run_outputs RENAME TO workspace_issue_run_outputs_v1;
@@ -593,7 +596,7 @@ func (s *SQLiteStore) applyUserProjectsV1(ctx context.Context) error {
 	}
 
 	now := unixMs(time.Now().UTC())
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 CREATE TABLE IF NOT EXISTS user_projects (
   id TEXT PRIMARY KEY,
   path TEXT NOT NULL UNIQUE,
@@ -615,7 +618,7 @@ INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 }
 
 func (s *SQLiteStore) hasMigration(ctx context.Context, migrationID string) (bool, error) {
-	row := s.db.QueryRowContext(ctx, `
+	row := s.writeDB.QueryRowContext(ctx, `
 SELECT 1
 FROM tuttid_schema_migrations
 WHERE id = ?
@@ -633,7 +636,7 @@ WHERE id = ?
 }
 
 func (s *SQLiteStore) hasColumn(ctx context.Context, tableName string, columnName string) (bool, error) {
-	rows, err := s.db.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", tableName))
+	rows, err := s.writeDB.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", tableName))
 	if err != nil {
 		return false, fmt.Errorf("inspect workspace table %s: %w", tableName, err)
 	}

--- a/services/tuttid/data/workspace/migrations_apps.go
+++ b/services/tuttid/data/workspace/migrations_apps.go
@@ -16,7 +16,7 @@ func (s *SQLiteStore) applyWorkspaceAppsV1(ctx context.Context) error {
 	}
 
 	now := unixMs(time.Now().UTC())
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 CREATE TABLE IF NOT EXISTS app_packages (
   app_id TEXT PRIMARY KEY,
   version TEXT NOT NULL,
@@ -65,14 +65,14 @@ func (s *SQLiteStore) applyWorkspaceAppsV2(ctx context.Context) error {
 
 	now := unixMs(time.Now().UTC())
 	if !hasManifestJSON {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE app_packages ADD COLUMN manifest_json TEXT NOT NULL DEFAULT '';
 `); err != nil {
 			return fmt.Errorf("migrate workspace database apps v2: %w", err)
 		}
 	}
 
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationWorkspaceAppsV2, now)
@@ -92,14 +92,14 @@ func (s *SQLiteStore) applyWorkspaceAppsV3(ctx context.Context) error {
 	}
 
 	now := unixMs(time.Now().UTC())
-	if _, err := s.db.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
+	if _, err := s.writeDB.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
 		return fmt.Errorf("disable sqlite foreign keys for workspace apps v3 migration: %w", err)
 	}
 	defer func() {
-		_, _ = s.db.ExecContext(context.Background(), `PRAGMA foreign_keys = ON`)
+		_, _ = s.writeDB.ExecContext(context.Background(), `PRAGMA foreign_keys = ON`)
 	}()
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.writeDB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin workspace apps v3 migration: %w", err)
 	}
@@ -181,7 +181,7 @@ INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit workspace apps v3 migration: %w", err)
 	}
-	if _, err := s.db.ExecContext(ctx, `PRAGMA foreign_keys = ON`); err != nil {
+	if _, err := s.writeDB.ExecContext(ctx, `PRAGMA foreign_keys = ON`); err != nil {
 		return fmt.Errorf("re-enable sqlite foreign keys for workspace apps v3 migration: %w", err)
 	}
 	return nil
@@ -197,7 +197,7 @@ func (s *SQLiteStore) applyAppFactoryJobsV1(ctx context.Context) error {
 	}
 
 	now := unixMs(time.Now().UTC())
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 CREATE TABLE IF NOT EXISTS app_factory_jobs (
   workspace_id TEXT NOT NULL,
   job_id TEXT NOT NULL,
@@ -245,7 +245,7 @@ func (s *SQLiteStore) applyAppFactoryJobsV2(ctx context.Context) error {
 	}
 
 	now := unixMs(time.Now().UTC())
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 ALTER TABLE app_factory_jobs
   ADD COLUMN reasoning_effort TEXT NOT NULL DEFAULT '';
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
@@ -271,7 +271,7 @@ func (s *SQLiteStore) applyAppFactoryJobsV3(ctx context.Context) error {
 		return err
 	}
 	if !hasAgentTargetID {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE app_factory_jobs ADD COLUMN agent_target_id TEXT NOT NULL DEFAULT '';
 `); err != nil {
 			return fmt.Errorf("migrate workspace app factory jobs agent target id: %w", err)
@@ -284,7 +284,7 @@ ALTER TABLE app_factory_jobs ADD COLUMN agent_target_id TEXT NOT NULL DEFAULT ''
 	if codexTargetID == "" {
 		return fmt.Errorf("migrate workspace app factory jobs agent target id: codex target descriptor is missing")
 	}
-	if _, err := s.db.ExecContext(ctx, `
+	if _, err := s.writeDB.ExecContext(ctx, `
 UPDATE app_factory_jobs
 SET agent_target_id = CASE provider
   WHEN ? THEN ?
@@ -295,7 +295,7 @@ WHERE agent_target_id = '';
 `, "codex", codexTargetID); err != nil {
 		return fmt.Errorf("backfill workspace app factory job agent target ids: %w", err)
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationAppFactoryJobsV3, now)

--- a/services/tuttid/data/workspace/migrations_issue_topics.go
+++ b/services/tuttid/data/workspace/migrations_issue_topics.go
@@ -22,7 +22,7 @@ func (s *SQLiteStore) applyWorkspaceIssuesV3(ctx context.Context) error {
 		return s.ensureDefaultIssueTopics(ctx)
 	}
 	if v3SchemaPresent {
-		if _, err := s.db.ExecContext(ctx, `
+		if _, err := s.writeDB.ExecContext(ctx, `
 INSERT OR IGNORE INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationWorkspaceIssuesV3, now); err != nil {
@@ -31,14 +31,14 @@ INSERT OR IGNORE INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 		return s.ensureDefaultIssueTopics(ctx)
 	}
 
-	if _, err := s.db.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
+	if _, err := s.writeDB.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
 		return fmt.Errorf("disable sqlite foreign keys for workspace issue topics migration: %w", err)
 	}
 	defer func() {
-		_, _ = s.db.ExecContext(context.Background(), `PRAGMA foreign_keys = ON`)
+		_, _ = s.writeDB.ExecContext(context.Background(), `PRAGMA foreign_keys = ON`)
 	}()
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.writeDB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin workspace issue topics migration: %w", err)
 	}
@@ -284,7 +284,7 @@ INSERT OR IGNORE INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 		return fmt.Errorf("commit workspace issue topics migration: %w", err)
 	}
 
-	if _, err := s.db.ExecContext(ctx, `PRAGMA foreign_keys = ON`); err != nil {
+	if _, err := s.writeDB.ExecContext(ctx, `PRAGMA foreign_keys = ON`); err != nil {
 		return fmt.Errorf("re-enable sqlite foreign keys for workspace issue topics migration: %w", err)
 	}
 
@@ -307,11 +307,11 @@ func (s *SQLiteStore) applyWorkspaceIssuesV4(ctx context.Context) error {
 
 	now := unixMs(time.Now().UTC())
 	if !hasExecutionDirectory {
-		if _, err := s.db.ExecContext(ctx, `ALTER TABLE workspace_issue_runs ADD COLUMN execution_directory TEXT NOT NULL DEFAULT '';`); err != nil {
+		if _, err := s.writeDB.ExecContext(ctx, `ALTER TABLE workspace_issue_runs ADD COLUMN execution_directory TEXT NOT NULL DEFAULT '';`); err != nil {
 			return fmt.Errorf("migrate workspace issue runs execution directory: %w", err)
 		}
 	}
-	if _, err := s.db.ExecContext(ctx, `
+	if _, err := s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationWorkspaceIssuesV4, now); err != nil {
@@ -336,7 +336,7 @@ func (s *SQLiteStore) applyWorkspaceIssuesV5(ctx context.Context) error {
 
 	now := unixMs(time.Now().UTC())
 	if !hasAgentTargetID {
-		if _, err := s.db.ExecContext(ctx, `ALTER TABLE workspace_issue_runs ADD COLUMN agent_target_id TEXT NOT NULL DEFAULT '';`); err != nil {
+		if _, err := s.writeDB.ExecContext(ctx, `ALTER TABLE workspace_issue_runs ADD COLUMN agent_target_id TEXT NOT NULL DEFAULT '';`); err != nil {
 			return fmt.Errorf("migrate workspace issue runs agent target id: %w", err)
 		}
 	}
@@ -345,7 +345,7 @@ func (s *SQLiteStore) applyWorkspaceIssuesV5(ctx context.Context) error {
 	if codexTargetID == "" {
 		return fmt.Errorf("migrate workspace issue runs agent target id: codex target descriptor is missing")
 	}
-	if _, err := s.db.ExecContext(ctx, `
+	if _, err := s.writeDB.ExecContext(ctx, `
 UPDATE workspace_issue_runs
 SET agent_target_id = CASE agent_provider
   WHEN ? THEN ?
@@ -356,7 +356,7 @@ WHERE agent_target_id = '';
 `, "codex", codexTargetID); err != nil {
 		return fmt.Errorf("backfill workspace issue run agent target ids: %w", err)
 	}
-	if _, err := s.db.ExecContext(ctx, `
+	if _, err := s.writeDB.ExecContext(ctx, `
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationWorkspaceIssuesV5, now); err != nil {
@@ -367,7 +367,7 @@ INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 
 func (s *SQLiteStore) ensureDefaultIssueTopics(ctx context.Context) error {
 	now := unixMs(time.Now().UTC())
-	if _, err := s.db.ExecContext(ctx, `
+	if _, err := s.writeDB.ExecContext(ctx, `
 UPDATE workspace_issue_topics
 SET is_default = 1, updated_at_unix_ms = ?
 WHERE topic_id = ?
@@ -382,7 +382,7 @@ WHERE topic_id = ?
 		return fmt.Errorf("repair default workspace issue topic flags: %w", err)
 	}
 
-	if _, err := s.db.ExecContext(ctx, `
+	if _, err := s.writeDB.ExecContext(ctx, `
 INSERT INTO workspace_issue_topics (
   topic_id, workspace_id, title, summary, is_default, pinned_at_unix_ms,
   last_activity_at_unix_ms, created_at_unix_ms, updated_at_unix_ms

--- a/services/tuttid/data/workspace/migrations_managed_credentials.go
+++ b/services/tuttid/data/workspace/migrations_managed_credentials.go
@@ -16,7 +16,7 @@ func (s *SQLiteStore) applyManagedCredentialsV1(ctx context.Context) error {
 	}
 
 	now := unixMs(time.Now().UTC())
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 CREATE TABLE IF NOT EXISTS managed_model_provider_credentials (
   workspace_id TEXT NOT NULL,
   provider_id TEXT NOT NULL,

--- a/services/tuttid/data/workspace/migrations_workbench.go
+++ b/services/tuttid/data/workspace/migrations_workbench.go
@@ -27,7 +27,7 @@ func (s *SQLiteStore) applyWorkspaceWorkbenchAgentGUIUnifiedDockV1(ctx context.C
 		return nil
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.writeDB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin AgentGUI workbench dock migration: %w", err)
 	}

--- a/services/tuttid/data/workspace/migrations_workbench_test.go
+++ b/services/tuttid/data/workspace/migrations_workbench_test.go
@@ -50,14 +50,14 @@ func TestSQLiteStoreMigrationUnifiesAgentGUIDockIdentity(t *testing.T) {
 	}
 
 	var originalUpdatedAt int64
-	if err := store.db.QueryRowContext(ctx, `
+	if err := store.writeDB.QueryRowContext(ctx, `
 SELECT updated_at_unix_ms
 FROM workspace_workbench_snapshots
 WHERE workspace_id = ?
 `, workspaceID).Scan(&originalUpdatedAt); err != nil {
 		t.Fatalf("read original snapshot timestamp: %v", err)
 	}
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 DELETE FROM tuttid_schema_migrations
 WHERE id = ?
 `, schemaMigrationWorkspaceWorkbenchAgentGUIUnifiedDockV1); err != nil {
@@ -87,7 +87,7 @@ WHERE id = ?
 	}
 
 	var migratedUpdatedAt int64
-	if err := store.db.QueryRowContext(ctx, `
+	if err := store.writeDB.QueryRowContext(ctx, `
 SELECT updated_at_unix_ms
 FROM workspace_workbench_snapshots
 WHERE workspace_id = ?
@@ -123,7 +123,7 @@ func TestSQLiteStoreAgentGUIDockMigrationRollsBackInvalidSnapshotJSON(t *testing
 	}); err != nil {
 		t.Fatalf("PutWorkbenchSnapshot() error = %v", err)
 	}
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 DELETE FROM tuttid_schema_migrations
 WHERE id = ?
 `, schemaMigrationWorkspaceWorkbenchAgentGUIUnifiedDockV1); err != nil {
@@ -210,7 +210,7 @@ func readTestWorkbenchSnapshotJSON(t *testing.T, store *SQLiteStore, workspaceID
 	t.Helper()
 
 	var snapshotJSON string
-	if err := store.db.QueryRowContext(context.Background(), `
+	if err := store.writeDB.QueryRowContext(context.Background(), `
 SELECT snapshot_json
 FROM workspace_workbench_snapshots
 WHERE workspace_id = ?

--- a/services/tuttid/data/workspace/sqlite_agent_targets_test.go
+++ b/services/tuttid/data/workspace/sqlite_agent_targets_test.go
@@ -56,7 +56,7 @@ func TestSQLiteStoreListAgentTargetsSkipsInvalidRows(t *testing.T) {
 	ctx := context.Background()
 	store := openTestSQLiteStore(t)
 	now := int64(1700000000000)
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 	INSERT INTO agent_targets (
 	  id,
 	  provider,
@@ -96,13 +96,13 @@ func TestSQLiteStoreSeedReconcilesLegacySystemAgentTargetIDs(t *testing.T) {
 	ctx := context.Background()
 	store := openTestSQLiteStore(t)
 	now := int64(1700000000000)
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 INSERT INTO workspaces (id, name, created_at_unix_ms, updated_at_unix_ms)
 VALUES ('ws-legacy-targets', 'Legacy Targets', ?, ?);
 `, now, now); err != nil {
 		t.Fatalf("insert legacy workspace fixture: %v", err)
 	}
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 INSERT INTO agent_targets (
   id,
   provider,
@@ -119,7 +119,7 @@ VALUES (?, 'codex', ?, 'Legacy Codex', 'codex', 1, 'system', 10, ?, ?);
 `, legacyIDLocalCodex, agenttargetbiz.MustLocalCLILaunchRefJSON("codex"), now, now); err != nil {
 		t.Fatalf("insert legacy agent target fixture: %v", err)
 	}
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 INSERT INTO workspace_agent_sessions (
   workspace_id,
   agent_session_id,

--- a/services/tuttid/data/workspace/sqlite_app_factory.go
+++ b/services/tuttid/data/workspace/sqlite_app_factory.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *SQLiteStore) PutAppFactoryJob(ctx context.Context, job workspacebiz.AppFactoryJob) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
 
@@ -33,7 +33,7 @@ func (s *SQLiteStore) PutAppFactoryJob(ctx context.Context, job workspacebiz.App
 		updatedAt = now
 	}
 
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.writeDB.ExecContext(ctx, `
 INSERT INTO app_factory_jobs (
   workspace_id, job_id, status, prompt, app_id, display_name, description,
   agent_target_id, provider, model, reasoning_effort, agent_session_id, draft_dir, runtime_dir, data_dir, log_dir,
@@ -77,7 +77,7 @@ ON CONFLICT(workspace_id, job_id) DO UPDATE SET
 }
 
 func (s *SQLiteStore) GetAppFactoryJob(ctx context.Context, workspaceID string, jobID string) (workspacebiz.AppFactoryJob, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return workspacebiz.AppFactoryJob{}, errors.New("workspace database is not initialized")
 	}
 	workspaceID = strings.TrimSpace(workspaceID)
@@ -86,7 +86,7 @@ func (s *SQLiteStore) GetAppFactoryJob(ctx context.Context, workspaceID string, 
 		return workspacebiz.AppFactoryJob{}, errors.New("workspace id and app factory job id are required")
 	}
 
-	row := s.db.QueryRowContext(ctx, `
+	row := s.readDB.QueryRowContext(ctx, `
 SELECT workspace_id, job_id, status, prompt, app_id, display_name, description,
   agent_target_id, provider, model, reasoning_effort, agent_session_id, draft_dir, runtime_dir, data_dir, log_dir,
   package_dir, validation_result_json, failure_reason, published_version,
@@ -105,7 +105,7 @@ WHERE workspace_id = ? AND job_id = ?
 }
 
 func (s *SQLiteStore) ListAppFactoryJobs(ctx context.Context, workspaceID string) ([]workspacebiz.AppFactoryJob, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return nil, errors.New("workspace database is not initialized")
 	}
 	workspaceID = strings.TrimSpace(workspaceID)
@@ -113,7 +113,7 @@ func (s *SQLiteStore) ListAppFactoryJobs(ctx context.Context, workspaceID string
 		return nil, errors.New("workspace id is required")
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB.QueryContext(ctx, `
 SELECT workspace_id, job_id, status, prompt, app_id, display_name, description,
   agent_target_id, provider, model, reasoning_effort, agent_session_id, draft_dir, runtime_dir, data_dir, log_dir,
   package_dir, validation_result_json, failure_reason, published_version,
@@ -142,7 +142,7 @@ ORDER BY updated_at_unix_ms DESC, job_id ASC
 }
 
 func (s *SQLiteStore) DeleteAppFactoryJob(ctx context.Context, workspaceID string, jobID string) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
 	workspaceID = strings.TrimSpace(workspaceID)
@@ -151,7 +151,7 @@ func (s *SQLiteStore) DeleteAppFactoryJob(ctx context.Context, workspaceID strin
 		return errors.New("workspace id and app factory job id are required")
 	}
 
-	result, err := s.db.ExecContext(ctx, `
+	result, err := s.writeDB.ExecContext(ctx, `
 DELETE FROM app_factory_jobs
 WHERE workspace_id = ? AND job_id = ?
 `, workspaceID, jobID)

--- a/services/tuttid/data/workspace/sqlite_apps.go
+++ b/services/tuttid/data/workspace/sqlite_apps.go
@@ -23,7 +23,7 @@ func (s *SQLiteStore) PutAppPackageVersion(ctx context.Context, appPackage works
 }
 
 func (s *SQLiteStore) putAppPackage(ctx context.Context, appPackage workspacebiz.AppPackage, activate bool) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
 
@@ -59,7 +59,7 @@ func (s *SQLiteStore) putAppPackage(ctx context.Context, appPackage workspacebiz
 		source = string(workspacebiz.AppPackageSourceBuiltin)
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.writeDB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin workspace app package write: %w", err)
 	}
@@ -117,7 +117,7 @@ ON CONFLICT(app_id) DO NOTHING
 }
 
 func (s *SQLiteStore) GetAppPackage(ctx context.Context, appID string) (workspacebiz.AppPackage, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return workspacebiz.AppPackage{}, errors.New("workspace database is not initialized")
 	}
 
@@ -126,7 +126,7 @@ func (s *SQLiteStore) GetAppPackage(ctx context.Context, appID string) (workspac
 		return workspacebiz.AppPackage{}, errors.New("workspace app id is required")
 	}
 
-	row := s.db.QueryRowContext(ctx, `
+	row := s.readDB.QueryRowContext(ctx, `
 SELECT p.app_id, p.version, p.package_dir, p.manifest_json, p.source, p.factory_job_id, p.created_in_workspace_id, c.created_at_unix_ms
 FROM app_catalog_entries c
 JOIN app_packages p ON p.app_id = c.app_id AND p.version = c.active_version
@@ -144,7 +144,7 @@ WHERE c.app_id = ?
 }
 
 func (s *SQLiteStore) GetAppPackageVersion(ctx context.Context, appID string, version string) (workspacebiz.AppPackage, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return workspacebiz.AppPackage{}, errors.New("workspace database is not initialized")
 	}
 
@@ -154,7 +154,7 @@ func (s *SQLiteStore) GetAppPackageVersion(ctx context.Context, appID string, ve
 		return workspacebiz.AppPackage{}, errors.New("workspace app id and version are required")
 	}
 
-	row := s.db.QueryRowContext(ctx, `
+	row := s.readDB.QueryRowContext(ctx, `
 SELECT app_id, version, package_dir, manifest_json, source, factory_job_id, created_in_workspace_id, created_at_unix_ms
 FROM app_packages
 WHERE app_id = ? AND version = ?
@@ -171,11 +171,11 @@ WHERE app_id = ? AND version = ?
 }
 
 func (s *SQLiteStore) ListAppPackages(ctx context.Context) ([]workspacebiz.AppPackage, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return nil, errors.New("workspace database is not initialized")
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB.QueryContext(ctx, `
 SELECT p.app_id, p.version, p.package_dir, p.manifest_json, p.source, p.factory_job_id, p.created_in_workspace_id, c.created_at_unix_ms
 FROM app_catalog_entries c
 JOIN app_packages p ON p.app_id = c.app_id AND p.version = c.active_version
@@ -245,11 +245,11 @@ type invalidAppPackageScan struct {
 func (s *SQLiteStore) repairInvalidActiveAppPackage(ctx context.Context, invalidPackage workspacebiz.AppPackage, scanErr error) (workspacebiz.AppPackage, bool) {
 	appID := strings.TrimSpace(invalidPackage.AppID)
 	activeVersion := strings.TrimSpace(invalidPackage.Version)
-	if s == nil || s.db == nil || appID == "" || activeVersion == "" {
+	if s == nil || s.writeDB == nil || appID == "" || activeVersion == "" {
 		return workspacebiz.AppPackage{}, false
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.writeDB.QueryContext(ctx, `
 SELECT app_id, version, package_dir, manifest_json, source, factory_job_id, created_in_workspace_id, created_at_unix_ms
 FROM app_packages
 WHERE app_id = ? AND version <> ?
@@ -336,7 +336,7 @@ ORDER BY updated_at_unix_ms DESC, version DESC
 }
 
 func (s *SQLiteStore) ListAppPackageVersions(ctx context.Context, appID string) ([]workspacebiz.AppPackage, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return nil, errors.New("workspace database is not initialized")
 	}
 	appID = strings.TrimSpace(appID)
@@ -344,7 +344,7 @@ func (s *SQLiteStore) ListAppPackageVersions(ctx context.Context, appID string) 
 		return nil, errors.New("workspace app id is required")
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB.QueryContext(ctx, `
 SELECT app_id, version, package_dir, manifest_json, source, factory_job_id, created_in_workspace_id, created_at_unix_ms
 FROM app_packages
 WHERE app_id = ?
@@ -370,7 +370,7 @@ ORDER BY updated_at_unix_ms DESC, version DESC
 }
 
 func (s *SQLiteStore) ListAppPackageFileRecords(ctx context.Context, appID string) ([]workspacebiz.AppPackageFileRecord, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return nil, errors.New("workspace database is not initialized")
 	}
 	appID = strings.TrimSpace(appID)
@@ -378,7 +378,7 @@ func (s *SQLiteStore) ListAppPackageFileRecords(ctx context.Context, appID strin
 		return nil, errors.New("workspace app id is required")
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB.QueryContext(ctx, `
 SELECT app_id, version, package_dir, source
 FROM app_packages
 WHERE app_id = ?
@@ -410,7 +410,7 @@ ORDER BY updated_at_unix_ms DESC, version DESC
 }
 
 func (s *SQLiteStore) SetActiveAppPackageVersion(ctx context.Context, appID string, version string) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
 	appID = strings.TrimSpace(appID)
@@ -424,7 +424,7 @@ func (s *SQLiteStore) SetActiveAppPackageVersion(ctx context.Context, appID stri
 		return err
 	}
 	now := unixMs(time.Now().UTC())
-	result, err := s.db.ExecContext(ctx, `
+	result, err := s.writeDB.ExecContext(ctx, `
 UPDATE app_catalog_entries
 SET active_version = ?, source = ?, created_in_workspace_id = ?, updated_at_unix_ms = ?
 WHERE app_id = ?
@@ -443,7 +443,7 @@ WHERE app_id = ?
 }
 
 func (s *SQLiteStore) DeleteAppPackage(ctx context.Context, appID string) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
 
@@ -452,7 +452,7 @@ func (s *SQLiteStore) DeleteAppPackage(ctx context.Context, appID string) error 
 		return errors.New("workspace app id is required")
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.writeDB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin workspace app package delete: %w", err)
 	}
@@ -489,7 +489,7 @@ WHERE app_id = ?
 }
 
 func (s *SQLiteStore) DeleteAppPackageVersion(ctx context.Context, appID string, version string) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
 
@@ -499,7 +499,7 @@ func (s *SQLiteStore) DeleteAppPackageVersion(ctx context.Context, appID string,
 		return errors.New("workspace app id and version are required")
 	}
 
-	result, err := s.db.ExecContext(ctx, `
+	result, err := s.writeDB.ExecContext(ctx, `
 DELETE FROM app_packages
 WHERE app_id = ? AND version = ?
   AND NOT EXISTS (
@@ -528,7 +528,7 @@ WHERE app_id = ? AND version = ?
 }
 
 func (s *SQLiteStore) PutWorkspaceAppInstallation(ctx context.Context, installation workspacebiz.AppInstallation) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
 
@@ -539,7 +539,7 @@ func (s *SQLiteStore) PutWorkspaceAppInstallation(ctx context.Context, installat
 	}
 
 	now := unixMs(time.Now().UTC())
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.writeDB.ExecContext(ctx, `
 INSERT INTO workspace_app_installations (
   workspace_id, app_id, enabled, created_at_unix_ms, updated_at_unix_ms
 )
@@ -556,7 +556,7 @@ ON CONFLICT(workspace_id, app_id) DO UPDATE SET
 }
 
 func (s *SQLiteStore) DeleteWorkspaceAppInstallation(ctx context.Context, workspaceID string, appID string) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
 
@@ -566,7 +566,7 @@ func (s *SQLiteStore) DeleteWorkspaceAppInstallation(ctx context.Context, worksp
 		return errors.New("workspace id and app id are required")
 	}
 
-	result, err := s.db.ExecContext(ctx, `
+	result, err := s.writeDB.ExecContext(ctx, `
 DELETE FROM workspace_app_installations
 WHERE workspace_id = ? AND app_id = ?
 `, workspaceID, appID)
@@ -586,7 +586,7 @@ WHERE workspace_id = ? AND app_id = ?
 }
 
 func (s *SQLiteStore) ListWorkspaceAppInstallations(ctx context.Context, workspaceID string) ([]workspacebiz.AppInstallation, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return nil, errors.New("workspace database is not initialized")
 	}
 
@@ -595,7 +595,7 @@ func (s *SQLiteStore) ListWorkspaceAppInstallations(ctx context.Context, workspa
 		return nil, errors.New("workspace id is required")
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB.QueryContext(ctx, `
 SELECT workspace_id, app_id, enabled
 FROM workspace_app_installations
 WHERE workspace_id = ?
@@ -624,7 +624,7 @@ ORDER BY app_id ASC
 }
 
 func (s *SQLiteStore) ListWorkspaceAppInstallationsByApp(ctx context.Context, appID string) ([]workspacebiz.AppInstallation, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return nil, errors.New("workspace database is not initialized")
 	}
 
@@ -633,7 +633,7 @@ func (s *SQLiteStore) ListWorkspaceAppInstallationsByApp(ctx context.Context, ap
 		return nil, errors.New("workspace app id is required")
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB.QueryContext(ctx, `
 SELECT workspace_id, app_id, enabled
 FROM workspace_app_installations
 WHERE app_id = ?

--- a/services/tuttid/data/workspace/sqlite_apps_test.go
+++ b/services/tuttid/data/workspace/sqlite_apps_test.go
@@ -158,14 +158,14 @@ func TestSQLiteStoreListAppPackagesSkipsInvalidActivePackage(t *testing.T) {
 	}
 
 	const invalidManifestJSON = `{"schemaVersion":"tutti.app.manifest.v1","appId":"invalid-app","version":"1.0.0","name":"Invalid App","description":"Invalid app","runtime":{"bootstrap":"start.sh","healthcheckPath":"/ready"},"references":{"searchEndpoint":"/references/search"}}`
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 INSERT INTO app_packages (
   app_id, version, package_dir, manifest_json, source, factory_job_id, created_in_workspace_id, created_at_unix_ms, updated_at_unix_ms
 ) VALUES (?, ?, ?, ?, ?, '', '', 1, 1)
 `, "invalid-app", "1.0.0", "/tmp/invalid-app", invalidManifestJSON, string(workspacebiz.AppPackageSourceBuiltin)); err != nil {
 		t.Fatalf("insert invalid app package error = %v", err)
 	}
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 INSERT INTO app_catalog_entries (
   app_id, active_version, source, created_in_workspace_id, created_at_unix_ms, updated_at_unix_ms
 ) VALUES (?, ?, ?, '', 1, 1)
@@ -188,7 +188,7 @@ func TestSQLiteStoreListAppPackageFileRecordsAllowsInvalidManifest(t *testing.T)
 	store := openTestSQLiteStore(t)
 	ctx := context.Background()
 	const invalidManifestJSON = `{"schemaVersion":"tutti.app.manifest.v1","appId":"invalid-app","version":"1.0.0","name":"Invalid App","description":"Invalid app","runtime":{"bootstrap":"start.sh","healthcheckPath":"/ready"},"references":{"searchEndpoint":"/references/search"}}`
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 INSERT INTO app_packages (
   app_id, version, package_dir, manifest_json, source, factory_job_id, created_in_workspace_id, created_at_unix_ms, updated_at_unix_ms
 ) VALUES (?, ?, ?, ?, ?, '', '', 1, 1)
@@ -238,14 +238,14 @@ func TestSQLiteStoreListAppPackagesRepairsInvalidActivePackageToValidVersion(t *
 	}
 
 	const invalidManifestJSON = `{"schemaVersion":"tutti.app.manifest.v1","appId":"repair-app","version":"1.1.0","name":"Repair App","description":"Repair app","runtime":{"bootstrap":"start.sh","healthcheckPath":"/ready"},"references":{"searchEndpoint":"/references/search"}}`
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 INSERT INTO app_packages (
   app_id, version, package_dir, manifest_json, source, factory_job_id, created_in_workspace_id, created_at_unix_ms, updated_at_unix_ms
 ) VALUES (?, ?, ?, ?, ?, '', '', 2, 2)
 `, "repair-app", "1.1.0", "/tmp/repair-app-1.1.0", invalidManifestJSON, string(workspacebiz.AppPackageSourceBuiltin)); err != nil {
 		t.Fatalf("insert invalid app package error = %v", err)
 	}
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 UPDATE app_catalog_entries
 SET active_version = ?, updated_at_unix_ms = 2
 WHERE app_id = ?

--- a/services/tuttid/data/workspace/sqlite_issue_run_outputs.go
+++ b/services/tuttid/data/workspace/sqlite_issue_run_outputs.go
@@ -48,7 +48,7 @@ LIMIT ?
 `, strings.Join(where, " AND "))
 	args = append(args, params.Limit)
 
-	rows, err := s.db.QueryContext(ctx, query, args...)
+	rows, err := s.readDB.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("search workspace issue run outputs: %w", err)
 	}

--- a/services/tuttid/data/workspace/sqlite_issue_tasks.go
+++ b/services/tuttid/data/workspace/sqlite_issue_tasks.go
@@ -52,7 +52,7 @@ ORDER BY sort_index ASC, id ASC%s
 		args = append(args, limit)
 	}
 
-	rows, err := s.db.QueryContext(ctx, query, args...)
+	rows, err := s.readDB.QueryContext(ctx, query, args...)
 	if err != nil {
 		return workspaceissues.TaskList{}, fmt.Errorf("list workspace issue tasks: %w", err)
 	}
@@ -89,7 +89,7 @@ func (s *SQLiteStore) AppendTasks(ctx context.Context, tasks []workspaceissues.T
 
 	workspaceID := tasks[0].WorkspaceID
 	issueID := tasks[0].IssueID
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.writeDB.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("begin append workspace issue tasks: %w", err)
 	}
@@ -158,7 +158,7 @@ func (s *SQLiteStore) GetTask(ctx context.Context, workspaceID string, issueID s
 		return workspaceissues.Task{}, err
 	}
 
-	row := s.db.QueryRowContext(ctx, `
+	row := s.readDB.QueryRowContext(ctx, `
 SELECT `+taskSelectColumns+`
 FROM workspace_issue_tasks
 WHERE workspace_id = ? AND issue_id = ? AND task_id = ?
@@ -178,7 +178,7 @@ func (s *SQLiteStore) UpdateTask(ctx context.Context, task workspaceissues.Task)
 		return workspaceissues.Task{}, err
 	}
 
-	result, err := s.db.ExecContext(ctx, `
+	result, err := s.writeDB.ExecContext(ctx, `
 UPDATE workspace_issue_tasks
 SET title = ?, content = ?, search_text = ?, status = ?, priority = ?,
     sort_index = ?, due_at_unix_ms = ?, latest_run_id = ?, updated_at_unix_ms = ?
@@ -199,7 +199,7 @@ func (s *SQLiteStore) DeleteTask(ctx context.Context, workspaceID string, issueI
 		return false, err
 	}
 
-	result, err := s.db.ExecContext(ctx, `
+	result, err := s.writeDB.ExecContext(ctx, `
 DELETE FROM workspace_issue_tasks
 WHERE workspace_id = ? AND issue_id = ? AND task_id = ?
 `, workspaceID, issueID, taskID)

--- a/services/tuttid/data/workspace/sqlite_issue_topics_test.go
+++ b/services/tuttid/data/workspace/sqlite_issue_topics_test.go
@@ -81,7 +81,7 @@ func TestSQLiteStoreIssueTopicsMigrationRepairsMissingDefaultTopic(t *testing.T)
 		t.Fatalf("Create() workspace error = %v", err)
 	}
 
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 DELETE FROM workspace_issue_topics
 WHERE workspace_id = ?;
 `, "ws-repair-default-topic"); err != nil {
@@ -194,7 +194,7 @@ func TestSQLiteStoreIssueTopicsMigrationRepairsMissingMarker(t *testing.T) {
 		t.Fatalf("Migrate() initial error = %v", err)
 	}
 
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 DELETE FROM tuttid_schema_migrations
 WHERE id = ?;
 INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)

--- a/services/tuttid/data/workspace/sqlite_issues.go
+++ b/services/tuttid/data/workspace/sqlite_issues.go
@@ -46,7 +46,7 @@ func (s *SQLiteStore) ListTopics(ctx context.Context, workspaceID string) (works
 		return workspaceissues.TopicList{}, err
 	}
 
-	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+	rows, err := s.readDB.QueryContext(ctx, fmt.Sprintf(`
 SELECT %s
 FROM workspace_issue_topics
 WHERE workspace_id = ?
@@ -76,7 +76,7 @@ func (s *SQLiteStore) CreateTopic(ctx context.Context, topic workspaceissues.Top
 		return workspaceissues.Topic{}, err
 	}
 
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.writeDB.ExecContext(ctx, `
 INSERT INTO workspace_issue_topics (
   topic_id, workspace_id, title, summary, is_default, pinned_at_unix_ms,
   last_activity_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
@@ -97,7 +97,7 @@ func (s *SQLiteStore) GetTopic(ctx context.Context, workspaceID string, topicID 
 		return workspaceissues.Topic{}, err
 	}
 
-	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+	row := s.readDB.QueryRowContext(ctx, fmt.Sprintf(`
 SELECT %s
 FROM workspace_issue_topics
 WHERE workspace_id = ? AND topic_id = ?
@@ -117,7 +117,7 @@ func (s *SQLiteStore) UpdateTopic(ctx context.Context, topic workspaceissues.Top
 		return workspaceissues.Topic{}, err
 	}
 
-	result, err := s.db.ExecContext(ctx, `
+	result, err := s.writeDB.ExecContext(ctx, `
 UPDATE workspace_issue_topics
 SET title = ?, summary = ?, pinned_at_unix_ms = ?, updated_at_unix_ms = ?
 WHERE workspace_id = ? AND topic_id = ?
@@ -136,7 +136,7 @@ func (s *SQLiteStore) DeleteTopic(ctx context.Context, workspaceID string, topic
 		return false, err
 	}
 
-	result, err := s.db.ExecContext(ctx, `
+	result, err := s.writeDB.ExecContext(ctx, `
 DELETE FROM workspace_issue_topics
 WHERE workspace_id = ? AND topic_id = ?
 `, workspaceID, topicID)
@@ -150,7 +150,7 @@ func (s *SQLiteStore) TouchTopicActivity(ctx context.Context, workspaceID string
 	if err := s.ensureIssueDatabase(); err != nil {
 		return err
 	}
-	result, err := s.db.ExecContext(ctx, `
+	result, err := s.writeDB.ExecContext(ctx, `
 UPDATE workspace_issue_topics
 SET last_activity_at_unix_ms = ?
 WHERE workspace_id = ? AND topic_id = ?
@@ -203,7 +203,7 @@ ORDER BY updated_at_unix_ms DESC, id DESC%s
 		args = append(args, limit)
 	}
 
-	rows, err := s.db.QueryContext(ctx, query, args...)
+	rows, err := s.readDB.QueryContext(ctx, query, args...)
 	if err != nil {
 		return workspaceissues.IssueList{}, fmt.Errorf("list workspace issues: %w", err)
 	}
@@ -241,7 +241,7 @@ func (s *SQLiteStore) CreateIssue(ctx context.Context, issue workspaceissues.Iss
 		return workspaceissues.Issue{}, err
 	}
 
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.writeDB.ExecContext(ctx, `
 INSERT INTO workspace_issues (
   issue_id, topic_id, workspace_id, title, content, search_text, status,
   task_count, not_started_count, running_count, pending_acceptance_count,
@@ -267,7 +267,7 @@ func (s *SQLiteStore) GetIssue(ctx context.Context, workspaceID string, issueID 
 		return workspaceissues.Issue{}, err
 	}
 
-	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+	row := s.readDB.QueryRowContext(ctx, fmt.Sprintf(`
 SELECT %s
 FROM workspace_issues
 WHERE workspace_id = ? AND issue_id = ?
@@ -287,7 +287,7 @@ func (s *SQLiteStore) UpdateIssue(ctx context.Context, issue workspaceissues.Iss
 		return workspaceissues.Issue{}, err
 	}
 
-	result, err := s.db.ExecContext(ctx, `
+	result, err := s.writeDB.ExecContext(ctx, `
 UPDATE workspace_issues
 SET title = ?, content = ?, search_text = ?, status = ?, updated_at_unix_ms = ?
 WHERE workspace_id = ? AND issue_id = ?
@@ -307,7 +307,7 @@ func (s *SQLiteStore) DeleteIssue(ctx context.Context, workspaceID string, issue
 		return false, err
 	}
 
-	result, err := s.db.ExecContext(ctx, `
+	result, err := s.writeDB.ExecContext(ctx, `
 DELETE FROM workspace_issues
 WHERE workspace_id = ? AND issue_id = ?
 `, workspaceID, issueID)
@@ -328,7 +328,7 @@ func (s *SQLiteStore) RecalculateIssueProjection(ctx context.Context, workspaceI
 	}
 	status := workspaceissues.ProjectIssueStatus(counts)
 	now := unixMs(time.Now().UTC())
-	result, err := s.db.ExecContext(ctx, `
+	result, err := s.writeDB.ExecContext(ctx, `
 UPDATE workspace_issues
 SET status = ?, task_count = ?, not_started_count = ?, running_count = ?,
     pending_acceptance_count = ?, completed_count = ?, failed_count = ?,
@@ -356,7 +356,7 @@ func (s *SQLiteStore) AddContextRefs(ctx context.Context, refs []workspaceissues
 		return nil, err
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.writeDB.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("begin workspace issue context refs transaction: %w", err)
 	}
@@ -403,7 +403,7 @@ func (s *SQLiteStore) ListContextRefs(
 		return nil, err
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB.QueryContext(ctx, `
 SELECT id, context_ref_id, workspace_id, issue_id, task_id, parent_kind,
        ref_type, path, display_name, created_at_unix_ms
 FROM workspace_issue_context_refs
@@ -441,7 +441,7 @@ func (s *SQLiteStore) RemoveContextRef(
 		return false, err
 	}
 
-	result, err := s.db.ExecContext(ctx, `
+	result, err := s.writeDB.ExecContext(ctx, `
 DELETE FROM workspace_issue_context_refs
 WHERE workspace_id = ? AND issue_id = ? AND task_id = ? AND parent_kind = ? AND context_ref_id = ?
 `, workspaceID, issueID, taskID, string(parentKind), contextRefID)
@@ -463,7 +463,7 @@ func (s *SQLiteStore) CreateRun(ctx context.Context, run workspaceissues.Run) (w
 		return workspaceissues.Run{}, err
 	}
 
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.writeDB.ExecContext(ctx, `
 INSERT INTO workspace_issue_runs (
   run_id, task_id, issue_id, workspace_id, requester_user_id, agent_user_id,
   agent_target_id, agent_session_id, agent_provider, status, summary,
@@ -488,7 +488,7 @@ func (s *SQLiteStore) CompleteRun(ctx context.Context, run workspaceissues.Run, 
 		return workspaceissues.Run{}, nil, err
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.writeDB.BeginTx(ctx, nil)
 	if err != nil {
 		return workspaceissues.Run{}, nil, fmt.Errorf("begin workspace issue run transaction: %w", err)
 	}
@@ -564,7 +564,7 @@ ORDER BY created_at_unix_ms DESC, id DESC
 		args = append(args, taskID)
 	}
 	query = strings.Replace(query, "FROM workspace_issue_runs\n", "FROM workspace_issue_runs\n"+where+"\n", 1)
-	rows, err := s.db.QueryContext(ctx, query, args...)
+	rows, err := s.readDB.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list workspace issue runs: %w", err)
 	}
@@ -592,7 +592,7 @@ func (s *SQLiteStore) ListRunningRuns(ctx context.Context, workspaceID string, l
 		limit = 100
 	}
 
-	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+	rows, err := s.readDB.QueryContext(ctx, fmt.Sprintf(`
 SELECT %s
 FROM workspace_issue_runs
 WHERE workspace_id = ? AND status = ? AND TRIM(agent_session_id) <> ''
@@ -623,7 +623,7 @@ func (s *SQLiteStore) GetRun(ctx context.Context, workspaceID string, issueID st
 		return workspaceissues.Run{}, err
 	}
 
-	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+	row := s.readDB.QueryRowContext(ctx, fmt.Sprintf(`
 SELECT %s
 FROM workspace_issue_runs
 WHERE workspace_id = ? AND issue_id = ? AND task_id = ? AND run_id = ?
@@ -643,7 +643,7 @@ func (s *SQLiteStore) ListRunOutputs(ctx context.Context, workspaceID string, is
 		return nil, err
 	}
 
-	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+	rows, err := s.readDB.QueryContext(ctx, fmt.Sprintf(`
 SELECT %s
 FROM workspace_issue_run_outputs
 WHERE workspace_id = ? AND issue_id = ? AND task_id = ? AND run_id = ?

--- a/services/tuttid/data/workspace/sqlite_issues_helpers.go
+++ b/services/tuttid/data/workspace/sqlite_issues_helpers.go
@@ -17,7 +17,7 @@ type issueScanner interface {
 }
 
 func (s *SQLiteStore) ensureIssueDatabase() error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return workspaceissues.ErrStoreNotConfigured
 	}
 	return nil
@@ -126,7 +126,7 @@ func issueLimitClause(limit int) string {
 }
 
 func (s *SQLiteStore) countIssueRows(ctx context.Context, tableName string, where string, args []any) (int, error) {
-	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+	row := s.readDB.QueryRowContext(ctx, fmt.Sprintf(`
 SELECT COUNT(*)
 FROM %s
 WHERE %s
@@ -140,7 +140,7 @@ WHERE %s
 }
 
 func (s *SQLiteStore) countIssueStatuses(ctx context.Context, tableName string, where string, args []any) (workspaceissues.StatusCounts, error) {
-	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+	rows, err := s.readDB.QueryContext(ctx, fmt.Sprintf(`
 SELECT status, COUNT(*)
 FROM %s
 WHERE %s

--- a/services/tuttid/data/workspace/sqlite_managed_credentials.go
+++ b/services/tuttid/data/workspace/sqlite_managed_credentials.go
@@ -20,10 +20,10 @@ import (
 )
 
 func (s *SQLiteStore) ListManagedModelProviderConfigs(ctx context.Context, workspaceID string) ([]managedcredentialsbiz.ProviderConfig, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return nil, errors.New("workspace database is not initialized")
 	}
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB.QueryContext(ctx, `
 SELECT workspace_id, provider_id, enabled, api_key_ciphertext, base_url, models_json, updated_at_unix_ms
 FROM managed_model_provider_credentials
 WHERE workspace_id = ?
@@ -49,10 +49,10 @@ ORDER BY provider_id
 }
 
 func (s *SQLiteStore) GetManagedModelProviderConfig(ctx context.Context, workspaceID string, providerID managedcredentialsbiz.ProviderID) (managedcredentialsbiz.ProviderConfig, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return managedcredentialsbiz.ProviderConfig{}, errors.New("workspace database is not initialized")
 	}
-	row := s.db.QueryRowContext(ctx, `
+	row := s.readDB.QueryRowContext(ctx, `
 SELECT workspace_id, provider_id, enabled, api_key_ciphertext, base_url, models_json, updated_at_unix_ms
 FROM managed_model_provider_credentials
 WHERE workspace_id = ? AND provider_id = ?
@@ -68,7 +68,7 @@ WHERE workspace_id = ? AND provider_id = ?
 }
 
 func (s *SQLiteStore) PutManagedModelProviderConfig(ctx context.Context, config managedcredentialsbiz.ProviderConfig) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
 	modelsJSON, err := json.Marshal(config.Models)
@@ -80,7 +80,7 @@ func (s *SQLiteStore) PutManagedModelProviderConfig(ctx context.Context, config 
 		return err
 	}
 	now := unixMs(time.Now().UTC())
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO managed_model_provider_credentials (
   workspace_id, provider_id, enabled, api_key_ciphertext, base_url, models_json, updated_at_unix_ms
 ) VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -98,10 +98,10 @@ ON CONFLICT(workspace_id, provider_id) DO UPDATE SET
 }
 
 func (s *SQLiteStore) DeleteManagedModelProviderConfig(ctx context.Context, workspaceID string, providerID managedcredentialsbiz.ProviderID) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.writeDB.ExecContext(ctx, `
 DELETE FROM managed_model_provider_credentials
 WHERE workspace_id = ? AND provider_id = ?
 `, workspaceID, providerID)
@@ -112,7 +112,7 @@ WHERE workspace_id = ? AND provider_id = ?
 }
 
 func (s *SQLiteStore) PutManagedModelGrant(ctx context.Context, grant managedcredentialsbiz.Grant) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
 	providersJSON, err := json.Marshal(grant.ProviderIDs)
@@ -123,7 +123,7 @@ func (s *SQLiteStore) PutManagedModelGrant(ctx context.Context, grant managedcre
 	if err != nil {
 		return fmt.Errorf("marshal managed grant scopes: %w", err)
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO managed_model_app_grants (
   workspace_id, app_id, grant_ref, provider_ids_json, scopes_json, created_at_unix_ms, expires_at_unix_ms, revoked_at_unix_ms
 ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
@@ -140,10 +140,10 @@ ON CONFLICT(workspace_id, app_id, grant_ref) DO UPDATE SET
 }
 
 func (s *SQLiteStore) GetManagedModelGrant(ctx context.Context, workspaceID string, appID string, grantRef string) (managedcredentialsbiz.Grant, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return managedcredentialsbiz.Grant{}, errors.New("workspace database is not initialized")
 	}
-	row := s.db.QueryRowContext(ctx, `
+	row := s.readDB.QueryRowContext(ctx, `
 SELECT workspace_id, app_id, grant_ref, provider_ids_json, scopes_json, created_at_unix_ms, expires_at_unix_ms, revoked_at_unix_ms
 FROM managed_model_app_grants
 WHERE workspace_id = ? AND app_id = ? AND grant_ref = ?
@@ -166,10 +166,10 @@ WHERE workspace_id = ? AND app_id = ? AND grant_ref = ?
 }
 
 func (s *SQLiteStore) RevokeManagedModelGrant(ctx context.Context, workspaceID string, appID string, grantRef string) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.writeDB.ExecContext(ctx, `
 UPDATE managed_model_app_grants
 SET revoked_at_unix_ms = ?
 WHERE workspace_id = ? AND app_id = ? AND grant_ref = ?
@@ -181,10 +181,10 @@ WHERE workspace_id = ? AND app_id = ? AND grant_ref = ?
 }
 
 func (s *SQLiteStore) DeleteManagedModelGrant(ctx context.Context, workspaceID string, appID string, grantRef string) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.writeDB.ExecContext(ctx, `
 DELETE FROM managed_model_app_grants
 WHERE workspace_id = ? AND app_id = ? AND grant_ref = ?
 `, workspaceID, appID, grantRef)

--- a/services/tuttid/data/workspace/sqlite_preferences.go
+++ b/services/tuttid/data/workspace/sqlite_preferences.go
@@ -15,11 +15,11 @@ import (
 const desktopPreferencesRowID = "desktop"
 
 func (s *SQLiteStore) GetDesktopPreferences(ctx context.Context) (preferencesbiz.DesktopPreferences, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return preferencesbiz.DesktopPreferences{}, errors.New("workspace database is not initialized")
 	}
 
-	row := s.db.QueryRowContext(ctx, `
+	row := s.readDB.QueryRowContext(ctx, `
 SELECT default_agent_provider, agent_conversation_detail_mode, agent_dock_layout, dock_icon_style, dock_placement, locale, theme_source, sleep_prevention_mode, update_channel, update_policy, agent_composer_defaults_by_provider_json, agent_composer_defaults_by_agent_target_json, agent_gui_conversation_rail_collapsed_by_provider_json, browser_use_connection_mode, file_default_openers_by_extension_json, app_catalog_channel, minimize_animation, show_app_developer_sources, enable_cursor_agent, enable_opencode_agent, workbench_window_snapping_enabled, workbench_window_snapping_shortcut_preset, feature_flags_json, workbench_shortcuts_json
 FROM desktop_preferences
 WHERE id = ?
@@ -107,7 +107,7 @@ WHERE id = ?
 }
 
 func (s *SQLiteStore) PutDesktopPreferences(ctx context.Context, preferences preferencesbiz.DesktopPreferences) (preferencesbiz.DesktopPreferences, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return preferencesbiz.DesktopPreferences{}, errors.New("workspace database is not initialized")
 	}
 
@@ -136,7 +136,7 @@ func (s *SQLiteStore) PutDesktopPreferences(ctx context.Context, preferences pre
 	if err != nil {
 		return preferencesbiz.DesktopPreferences{}, fmt.Errorf("encode desktop preferences workbench shortcuts: %w", err)
 	}
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.writeDB.ExecContext(ctx, `
 INSERT INTO desktop_preferences (
   id,
   default_agent_provider,

--- a/services/tuttid/data/workspace/sqlite_preferences_test.go
+++ b/services/tuttid/data/workspace/sqlite_preferences_test.go
@@ -179,7 +179,7 @@ func TestSQLiteStoreDesktopPreferencesAgentConversationDetailModeMigrationAndNor
 		t.Fatal("desktop_preferences.agent_conversation_detail_mode column missing after migration")
 	}
 
-	_, err = store.db.ExecContext(ctx, `
+	_, err = store.writeDB.ExecContext(ctx, `
 INSERT INTO desktop_preferences (
   id,
   default_agent_provider,
@@ -294,7 +294,7 @@ func TestSQLiteStoreMigrationBackfillsAgentComposerDefaultsByAgentTarget(t *test
 	if _, err := store.PutDesktopPreferences(context.Background(), legacy); err != nil {
 		t.Fatalf("PutDesktopPreferences() error = %v", err)
 	}
-	if _, err := store.db.ExecContext(context.Background(), `
+	if _, err := store.writeDB.ExecContext(context.Background(), `
 DELETE FROM tuttid_schema_migrations WHERE id = ?
 `, schemaMigrationDesktopPreferencesAgentComposerDefaultsByAgentTargetV1); err != nil {
 		t.Fatalf("reset migration marker: %v", err)

--- a/services/tuttid/data/workspace/sqlite_store.go
+++ b/services/tuttid/data/workspace/sqlite_store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,10 +19,14 @@ import (
 )
 
 const defaultSQLiteBusyTimeoutMillisec = 5000
+const defaultSQLiteReaderConnections = 4
 
 type SQLiteStore struct {
-	db    *sql.DB
-	agent *agentstore.Store
+	dbPath      string
+	writeDB     *sql.DB
+	readDB      *sql.DB
+	agentWriter *agentstore.Store
+	agentReader *agentstore.Store
 }
 
 func OpenSQLiteStore(dbPath string) (*SQLiteStore, error) {
@@ -33,23 +38,16 @@ func OpenSQLiteStore(dbPath string) (*SQLiteStore, error) {
 		return nil, fmt.Errorf("create tutti database directory: %w", err)
 	}
 
-	db, err := sql.Open("sqlite", dbPath)
+	db, err := sql.Open("sqlite", sqliteWriterDSN(dbPath))
 	if err != nil {
 		return nil, fmt.Errorf("open tutti database: %w", err)
 	}
 
 	db.SetMaxOpenConns(1)
-	store := &SQLiteStore{db: db}
-	store.agent = store.newAgentStore()
+	db.SetMaxIdleConns(1)
+	store := &SQLiteStore{dbPath: dbPath, writeDB: db}
+	store.agentWriter = store.newAgentStore(db)
 
-	if _, err := db.Exec(fmt.Sprintf("PRAGMA busy_timeout = %d", defaultSQLiteBusyTimeoutMillisec)); err != nil {
-		_ = store.Close()
-		return nil, fmt.Errorf("set sqlite busy timeout: %w", err)
-	}
-	if _, err := db.Exec("PRAGMA foreign_keys = ON"); err != nil {
-		_ = store.Close()
-		return nil, fmt.Errorf("enable sqlite foreign keys: %w", err)
-	}
 	if _, err := db.Exec("PRAGMA journal_mode = WAL"); err != nil {
 		_ = store.Close()
 		return nil, fmt.Errorf("enable sqlite wal mode: %w", err)
@@ -63,14 +61,65 @@ func DefaultDBPath() string {
 }
 
 func (s *SQLiteStore) Close() error {
-	if s == nil || s.db == nil {
+	if s == nil {
 		return nil
 	}
-	return s.db.Close()
+	var readErr error
+	if s.readDB != nil {
+		readErr = s.readDB.Close()
+	}
+	var writeErr error
+	if s.writeDB != nil {
+		writeErr = s.writeDB.Close()
+	}
+	return errors.Join(readErr, writeErr)
+}
+
+func sqliteWriterDSN(dbPath string) string {
+	return sqliteDSN(dbPath, false)
+}
+
+func sqliteReaderDSN(dbPath string) string {
+	return sqliteDSN(dbPath, true)
+}
+
+func sqliteDSN(dbPath string, readOnly bool) string {
+	query := url.Values{}
+	query.Add("_pragma", fmt.Sprintf("busy_timeout(%d)", defaultSQLiteBusyTimeoutMillisec))
+	query.Add("_pragma", "foreign_keys(1)")
+	if readOnly {
+		query.Set("mode", "ro")
+		query.Add("_pragma", "query_only(1)")
+	}
+	return (&url.URL{Scheme: "file", Path: dbPath, RawQuery: query.Encode()}).String()
+}
+
+func (s *SQLiteStore) openReadPool(ctx context.Context) error {
+	if s == nil || s.writeDB == nil {
+		return errors.New("workspace database is not initialized")
+	}
+	if s.readDB != nil {
+		return nil
+	}
+
+	db, err := sql.Open("sqlite", sqliteReaderDSN(s.dbPath))
+	if err != nil {
+		return fmt.Errorf("open tutti database read pool: %w", err)
+	}
+	db.SetMaxOpenConns(defaultSQLiteReaderConnections)
+	db.SetMaxIdleConns(defaultSQLiteReaderConnections)
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return fmt.Errorf("ping tutti database read pool: %w", err)
+	}
+
+	s.readDB = db
+	s.agentReader = s.newAgentStore(db)
+	return nil
 }
 
 func (s *SQLiteStore) Create(ctx context.Context, item workspacebiz.Summary) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
 
@@ -81,7 +130,7 @@ func (s *SQLiteStore) Create(ctx context.Context, item workspacebiz.Summary) err
 	}
 
 	now := unixMs(time.Now().UTC())
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.writeDB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin create workspace: %w", err)
 	}
@@ -115,7 +164,7 @@ INSERT INTO workspace_issue_topics (
 }
 
 func (s *SQLiteStore) Delete(ctx context.Context, workspaceID string) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
 
@@ -124,7 +173,7 @@ func (s *SQLiteStore) Delete(ctx context.Context, workspaceID string) error {
 		return errors.New("workspace id is required")
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.writeDB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin delete workspace: %w", err)
 	}
@@ -167,7 +216,7 @@ WHERE id = ?
 }
 
 func (s *SQLiteStore) Get(ctx context.Context, workspaceID string) (workspacebiz.Summary, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return workspacebiz.Summary{}, errors.New("workspace database is not initialized")
 	}
 
@@ -176,7 +225,7 @@ func (s *SQLiteStore) Get(ctx context.Context, workspaceID string) (workspacebiz
 		return workspacebiz.Summary{}, errors.New("workspace id is required")
 	}
 
-	row := s.db.QueryRowContext(ctx, `
+	row := s.readDB.QueryRowContext(ctx, `
 SELECT id, name
      , last_opened_at_unix_ms
 FROM workspaces
@@ -197,11 +246,11 @@ WHERE id = ?
 }
 
 func (s *SQLiteStore) List(ctx context.Context) ([]workspacebiz.Summary, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return nil, errors.New("workspace database is not initialized")
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB.QueryContext(ctx, `
 SELECT id, name, last_opened_at_unix_ms
 FROM workspaces
 ORDER BY COALESCE(last_opened_at_unix_ms, 0) DESC, updated_at_unix_ms DESC, id ASC`)
@@ -229,11 +278,11 @@ ORDER BY COALESCE(last_opened_at_unix_ms, 0) DESC, updated_at_unix_ms DESC, id A
 }
 
 func (s *SQLiteStore) GetStartup(ctx context.Context) (*workspacebiz.Summary, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return nil, errors.New("workspace database is not initialized")
 	}
 
-	row := s.db.QueryRowContext(ctx, `
+	row := s.readDB.QueryRowContext(ctx, `
 SELECT id, name, last_opened_at_unix_ms
 FROM workspaces
 WHERE last_opened_at_unix_ms IS NOT NULL
@@ -254,7 +303,7 @@ LIMIT 1`)
 }
 
 func (s *SQLiteStore) Update(ctx context.Context, item workspacebiz.Summary) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
 
@@ -264,7 +313,7 @@ func (s *SQLiteStore) Update(ctx context.Context, item workspacebiz.Summary) err
 		return errors.New("workspace id and name are required")
 	}
 
-	result, err := s.db.ExecContext(ctx, `
+	result, err := s.writeDB.ExecContext(ctx, `
 UPDATE workspaces
 SET name = ?, updated_at_unix_ms = ?
 WHERE id = ?
@@ -285,7 +334,7 @@ WHERE id = ?
 }
 
 func (s *SQLiteStore) Open(ctx context.Context, workspaceID string) (workspacebiz.Summary, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return workspacebiz.Summary{}, errors.New("workspace database is not initialized")
 	}
 
@@ -295,7 +344,7 @@ func (s *SQLiteStore) Open(ctx context.Context, workspaceID string) (workspacebi
 	}
 
 	now := unixMs(time.Now().UTC())
-	result, err := s.db.ExecContext(ctx, `
+	result, err := s.writeDB.ExecContext(ctx, `
 UPDATE workspaces
 SET last_opened_at_unix_ms = ?, updated_at_unix_ms = ?
 WHERE id = ?

--- a/services/tuttid/data/workspace/sqlite_store_test.go
+++ b/services/tuttid/data/workspace/sqlite_store_test.go
@@ -33,6 +33,93 @@ func TestSQLiteStoreListEmptyDatabase(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreConfiguresSeparateReadAndWritePools(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	if got := store.writeDB.Stats().MaxOpenConnections; got != 1 {
+		t.Fatalf("write pool max open connections = %d, want 1", got)
+	}
+	if got := store.readDB.Stats().MaxOpenConnections; got != defaultSQLiteReaderConnections {
+		t.Fatalf("read pool max open connections = %d, want %d", got, defaultSQLiteReaderConnections)
+	}
+
+	ctx := context.Background()
+	connections := make([]*sql.Conn, 0, defaultSQLiteReaderConnections)
+	defer func() {
+		for _, connection := range connections {
+			_ = connection.Close()
+		}
+	}()
+	for index := 0; index < defaultSQLiteReaderConnections; index++ {
+		connection, err := store.readDB.Conn(ctx)
+		if err != nil {
+			t.Fatalf("read pool connection %d: %v", index, err)
+		}
+		connections = append(connections, connection)
+
+		var queryOnly int
+		if err := connection.QueryRowContext(ctx, "PRAGMA query_only").Scan(&queryOnly); err != nil {
+			t.Fatalf("read pool connection %d query_only: %v", index, err)
+		}
+		if queryOnly != 1 {
+			t.Fatalf("read pool connection %d query_only = %d, want 1", index, queryOnly)
+		}
+
+		var busyTimeout int
+		if err := connection.QueryRowContext(ctx, "PRAGMA busy_timeout").Scan(&busyTimeout); err != nil {
+			t.Fatalf("read pool connection %d busy_timeout: %v", index, err)
+		}
+		if busyTimeout != defaultSQLiteBusyTimeoutMillisec {
+			t.Fatalf("read pool connection %d busy_timeout = %d, want %d", index, busyTimeout, defaultSQLiteBusyTimeoutMillisec)
+		}
+	}
+
+	if _, err := connections[0].ExecContext(ctx, "CREATE TABLE read_pool_must_not_write (id INTEGER)"); err == nil {
+		t.Fatal("read pool write succeeded, want read-only error")
+	}
+}
+
+func TestSQLiteStoreReadsCommittedDataWhileWriterConnectionIsBusy(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	ctx := context.Background()
+	const workspaceID = "ws-read-write-pools"
+	if err := store.Create(ctx, workspacebiz.Summary{ID: workspaceID, Name: "Committed"}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+		WorkspaceID:      workspaceID,
+		AgentSessionID:   "session-visible-to-reader",
+		Origin:           agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Provider:         "codex",
+		Status:           "running",
+		OccurredAtUnixMS: 100,
+	}); err != nil {
+		t.Fatalf("ReportSessionState() error = %v", err)
+	}
+
+	tx, err := store.writeDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, "UPDATE workspaces SET name = ? WHERE id = ?", "Uncommitted", workspaceID); err != nil {
+		t.Fatalf("hold writer transaction: %v", err)
+	}
+
+	readCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	sessions, ok, err := store.ListSessions(readCtx, workspaceID)
+	if err != nil {
+		t.Fatalf("ListSessions() while writer is busy error = %v", err)
+	}
+	if !ok || len(sessions) != 1 || sessions[0].ID != "session-visible-to-reader" {
+		t.Fatalf("ListSessions() while writer is busy = %#v, ok=%v", sessions, ok)
+	}
+}
+
 func TestSQLiteStoreMigrationDropsLegacyLocalPathColumn(t *testing.T) {
 	t.Parallel()
 
@@ -718,7 +805,7 @@ func TestSQLiteStoreAgentSessionRailPreservesKeyAcrossCwdChangesAndRepairsMissin
 	}); err != nil {
 		t.Fatalf("ReportSessionState(empty rail initial) error = %v", err)
 	}
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 UPDATE workspace_agent_sessions
 SET rail_section_kind = '',
     rail_project_path = '',
@@ -950,7 +1037,7 @@ func TestSQLiteStoreMigrationBackfillsAgentSessionRailSectionsFromUserProjects(t
 	repoCanonical := normalizeAgentSessionRailPath(repo)
 
 	ctx := context.Background()
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 CREATE TABLE tuttid_schema_migrations (
   id TEXT PRIMARY KEY,
   applied_at_unix_ms INTEGER NOT NULL
@@ -977,13 +1064,13 @@ CREATE TABLE workspace_agent_sessions (
 `); err != nil {
 		t.Fatalf("create legacy rail schema error = %v", err)
 	}
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 INSERT INTO user_projects (id, path, label, created_at_unix_ms, updated_at_unix_ms, last_used_at_unix_ms)
 VALUES ('project-repo', ?, 'repo', 1, 1, 1);
 `, repo); err != nil {
 		t.Fatalf("insert legacy user project error = %v", err)
 	}
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 INSERT INTO workspace_agent_sessions (workspace_id, agent_session_id, runtime_context_json, cwd, deleted_at_unix_ms, updated_at_unix_ms)
 VALUES
   ('ws-agent-rail-migration', 'session-project', '{}', ?, 0, 1),
@@ -2464,7 +2551,7 @@ func getTestAgentSessionRailSection(
 ) testAgentSessionRailSection {
 	t.Helper()
 
-	row := store.db.QueryRowContext(context.Background(), `
+	row := store.writeDB.QueryRowContext(context.Background(), `
 SELECT rail_section_kind, rail_project_path, rail_section_key
 FROM workspace_agent_sessions
 WHERE workspace_id = ? AND agent_session_id = ?

--- a/services/tuttid/data/workspace/sqlite_user_projects.go
+++ b/services/tuttid/data/workspace/sqlite_user_projects.go
@@ -10,11 +10,11 @@ import (
 )
 
 func (s *SQLiteStore) ListUserProjects(ctx context.Context) ([]userprojectbiz.Project, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return nil, errors.New("workspace database is not initialized")
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB.QueryContext(ctx, `
 SELECT id, path, label, created_at_unix_ms, updated_at_unix_ms, last_used_at_unix_ms
 FROM user_projects
 ORDER BY last_used_at_unix_ms DESC, updated_at_unix_ms DESC, label ASC, id ASC
@@ -48,10 +48,10 @@ ORDER BY last_used_at_unix_ms DESC, updated_at_unix_ms DESC, label ASC, id ASC
 }
 
 func (s *SQLiteStore) DeleteUserProject(ctx context.Context, id string) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.writeDB.ExecContext(ctx, `
 DELETE FROM user_projects
 WHERE id = ?
 `, id)
@@ -68,10 +68,10 @@ WHERE id = ?
 // on every call can silently miss the row if that derivation ever drifts from
 // what was actually stored, leaving the "removed" project in place.
 func (s *SQLiteStore) DeleteUserProjectByPath(ctx context.Context, path string) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.writeDB.ExecContext(ctx, `
 DELETE FROM user_projects
 WHERE path = ?
 `, path)
@@ -82,7 +82,7 @@ WHERE path = ?
 }
 
 func (s *SQLiteStore) PutUserProject(ctx context.Context, project userprojectbiz.Project) (userprojectbiz.Project, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return userprojectbiz.Project{}, errors.New("workspace database is not initialized")
 	}
 
@@ -94,7 +94,7 @@ func (s *SQLiteStore) PutUserProject(ctx context.Context, project userprojectbiz
 		project.LastUsedAtUnixMS = now
 	}
 	project.UpdatedAtUnixMS = project.LastUsedAtUnixMS
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.writeDB.ExecContext(ctx, `
 INSERT INTO user_projects (
   id, path, label, created_at_unix_ms, updated_at_unix_ms, last_used_at_unix_ms
 )
@@ -108,7 +108,7 @@ ON CONFLICT(path) DO UPDATE SET
 		return userprojectbiz.Project{}, fmt.Errorf("put user project: %w", err)
 	}
 
-	row := s.db.QueryRowContext(ctx, `
+	row := s.writeDB.QueryRowContext(ctx, `
 SELECT id, path, label, created_at_unix_ms, updated_at_unix_ms, last_used_at_unix_ms
 FROM user_projects
 WHERE path = ?
@@ -129,13 +129,13 @@ WHERE path = ?
 }
 
 func (s *SQLiteStore) TouchUserProject(ctx context.Context, id string, atUnixMS int64) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
 	if atUnixMS <= 0 {
 		atUnixMS = unixMs(time.Now().UTC())
 	}
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.writeDB.ExecContext(ctx, `
 UPDATE user_projects
 SET last_used_at_unix_ms = ?, updated_at_unix_ms = ?
 WHERE id = ?

--- a/services/tuttid/data/workspace/sqlite_workbench.go
+++ b/services/tuttid/data/workspace/sqlite_workbench.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *SQLiteStore) GetWorkbenchSnapshot(ctx context.Context, workspaceID string) (workspacebiz.WorkbenchSnapshot, error) {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return workspacebiz.WorkbenchSnapshot{}, errors.New("workspace database is not initialized")
 	}
 
@@ -21,11 +21,11 @@ func (s *SQLiteStore) GetWorkbenchSnapshot(ctx context.Context, workspaceID stri
 		return workspacebiz.WorkbenchSnapshot{}, errors.New("workspace id is required")
 	}
 
-	if err := s.ensureWorkspaceExists(ctx, workspaceID); err != nil {
+	if err := ensureWorkspaceExistsOn(ctx, s.readDB, workspaceID); err != nil {
 		return workspacebiz.WorkbenchSnapshot{}, err
 	}
 
-	row := s.db.QueryRowContext(ctx, `
+	row := s.readDB.QueryRowContext(ctx, `
 SELECT workspace_id, schema_version, snapshot_json
 FROM workspace_workbench_snapshots
 WHERE workspace_id = ?
@@ -45,7 +45,7 @@ WHERE workspace_id = ?
 }
 
 func (s *SQLiteStore) PutWorkbenchSnapshot(ctx context.Context, snapshot workspacebiz.WorkbenchSnapshot) error {
-	if s == nil || s.db == nil {
+	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
 	}
 
@@ -60,12 +60,12 @@ func (s *SQLiteStore) PutWorkbenchSnapshot(ctx context.Context, snapshot workspa
 		return errors.New("workbench snapshot json is required")
 	}
 
-	if err := s.ensureWorkspaceExists(ctx, workspaceID); err != nil {
+	if err := ensureWorkspaceExistsOn(ctx, s.writeDB, workspaceID); err != nil {
 		return err
 	}
 
 	now := unixMs(time.Now().UTC())
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.writeDB.ExecContext(ctx, `
 INSERT INTO workspace_workbench_snapshots (
   workspace_id,
   schema_version,
@@ -86,8 +86,8 @@ ON CONFLICT(workspace_id) DO UPDATE SET
 	return nil
 }
 
-func (s *SQLiteStore) ensureWorkspaceExists(ctx context.Context, workspaceID string) error {
-	row := s.db.QueryRowContext(ctx, `
+func ensureWorkspaceExistsOn(ctx context.Context, db *sql.DB, workspaceID string) error {
+	row := db.QueryRowContext(ctx, `
 SELECT 1
 FROM workspaces
 WHERE id = ?


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Verification

<!-- Commands run, manual checks, or why verification is not applicable. -->

## Fix Scope Justification

<!--
Required when a fix-titled PR changes more than 300 lines; delete otherwise.

- Root cause: which event or state is the actual source of the bug?
- Why can this not be fixed at a lower layer?
-->

## Fallback Three Questions

<!--
Required when this change adds a timer, retry, cache, or defensive branch;
delete otherwise.

- Source: which event or state does this fallback compensate for?
- Why can it not be fixed at that source?
- Removal condition: when can this fallback be deleted?
-->

## Checklist

- [ ] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [ ] I ran the lowest meaningful local checks for the changed surface.
- [ ] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->