### PR TITLE
fix(agent): support Codex goal continuation and timing

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -92,6 +92,29 @@ newer desired state or clear tombstone. Provider differences are normalized by
 the daemon `GoalAdapter`; GUI and service code use the typed Goal API rather
 than sending goal banner actions through the prompt pipeline.
 
+Codex Goal continuation provenance has two ordered paths. A
+`thread/goal/updated` notification with `turnId` remains exact provider
+evidence and takes precedence. Codex versions that omit that optional field use
+an adapter-local, single-use continuation claim instead: a successful
+`thread/goal/set` response seeds the first claim for its immutable durable Goal
+operation/revision, and settlement of an adopted Goal Turn may seed the next
+claim in the same chain. Goal control and ordinary submit setup share the
+session lifecycle lock, so a concurrent user submit cannot open a competing
+provider Turn while the initial claim is established. A newer Goal operation,
+inactive Goal status, adapter restart, multiple simultaneous unowned Turns, or
+any conflicting exact evidence invalidates the compatibility claim and fails
+closed. The claim is never reconstructed from the mutable latest Goal snapshot
+and is not durable across provider-process replacement.
+
+Provider Goal payloads are normalized at the daemon adapter boundary before
+they enter session state. In particular, Codex `timeUsedSeconds` and
+`tokensUsed` become the canonical `durationMs` and `tokens` fields. Durable
+storage, APIs, and renderer code consume only the canonical Goal contract; the
+provider-authored payload remains local to provenance matching. Optimistic Goal
+presentation does not start an elapsed timer. The timer becomes visible only
+after canonical provider state confirms the Goal, using `durationMs` as its
+baseline and ticking locally between authoritative updates.
+
 ## Workspace Engine Ownership
 
 One `AgentSessionEngine` instance owns agent state for one workspace and runtime

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -349,6 +349,72 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [codex_appserver_goal.go](../../../packages/agent/daemon/runtime/codex_appserver_goal.go)
   [codex_appserver_adapter_test.go](../../../packages/agent/daemon/runtime/codex_appserver_adapter_test.go)
 
+### Codex goal shows active but produces no response
+
+- Symptom:
+  Sending `/goal …` updates the Goal banner to active, but no assistant text or
+  tool activity appears. Logs show `turn/started`, followed shortly by
+  `agent_session.app_server.goal.turn_provenance_unproven` and an exact
+  `turn/interrupt`.
+- Quick checks:
+  Inspect the installed Codex app-server schema and the raw
+  `thread/goal/updated` payload. In affected versions, `turnId` is optional and
+  the external `thread/goal/set` update omits it. Verify the Goal operation and
+  generation fingerprint were persisted successfully before investigating
+  transport or model failures.
+- Root cause:
+  Tutti required `thread/goal/updated.turnId` as the only Goal-to-Turn
+  correlation signal. Codex externally applies the Goal, emits a session-scoped
+  update without `turnId`, then starts the continuation Turn. The adapter
+  therefore treated valid work as unproven and deliberately interrupted it
+  after the provenance grace window.
+- Fix:
+  Keep exact turn-scoped Goal evidence as the preferred path. For versions that
+  omit `turnId`, use an adapter-local, single-use continuation claim scoped to
+  the successful Goal RPC's immutable operation/revision. Chain the next claim
+  only from settlement of an adopted Goal Turn, serialize Goal control against
+  ordinary submit setup, and invalidate the claim on revision change, inactive
+  status, restart, or multiple unowned Turns. Never bind an arbitrary unowned
+  Turn from the mutable current Goal snapshot and do not fix this by merely
+  extending the provenance timeout.
+- Validation:
+  Reproduce the real protocol order
+  `goal/set response -> goal/updated without turnId -> turn/started` and verify
+  assistant output is persisted without an interrupt. Also cover chained
+  continuation Turns without another Goal RPC and a delayed old Turn after a
+  newer revision, which must still be interrupted.
+- References:
+  [codex_appserver_goal_provenance.go](../../../packages/agent/daemon/runtime/codex_appserver_goal_provenance.go)
+  [codex_appserver_goal.go](../../../packages/agent/daemon/runtime/codex_appserver_goal.go)
+  [controller_exec.go](../../../packages/agent/daemon/runtime/controller_exec.go)
+  [codex_appserver_adapter_test.go](../../../packages/agent/daemon/runtime/codex_appserver_adapter_test.go)
+
+### Active Codex goal has no elapsed timer
+
+- Symptom:
+  The Goal banner shows an active objective but no elapsed value, even though
+  Codex continues working and its Goal database reports non-zero usage time.
+- Root cause:
+  Codex exposes `timeUsedSeconds` and `tokensUsed`, while Tutti's canonical
+  session Goal contract exposes `durationMs` and `tokens`. Passing provider
+  fields through runtime context causes the typed durable session boundary to
+  discard them. A newly created Goal may also omit canonical `durationMs`
+  because zero is an optional counter.
+- Fix:
+  Normalize provider counters in the Codex adapter before publishing session
+  state or Goal observations. The renderer reads only `durationMs`, hides time
+  while the Goal is an optimistic projection, and starts only after canonical
+  provider state arrives. If that canonical state omits the optional zero
+  baseline, start at zero and advance locally between server updates.
+- Validation:
+  Verify provider-to-canonical normalization with non-zero counters, verify an
+  optimistic Goal shows no time, verify canonical confirmation adopts the
+  provider duration and advances, and verify a paused Goal without a duration
+  still omits the timer.
+- References:
+  [codex_appserver_goal.go](../../../packages/agent/daemon/runtime/codex_appserver_goal.go)
+  [AgentGoalBanner.tsx](../../../packages/agent/gui/agent-gui/agentGuiNode/AgentGoalBanner.tsx)
+
 ### Codex goal reappears after pause, edit, or clear
 
 - Symptom:

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -110,9 +110,9 @@ const startupModelSteadyRetryCount = 36
 const defaultCodexAppServerGoalContinuationGraceWindow = 1500 * time.Millisecond
 
 // defaultCodexAppServerGoalProvenanceGraceWindow bounds how long an
-// unowned provider turn may wait for the app-server's turn-scoped
-// thread/goal/updated evidence. turn/started alone carries no Goal generation
-// and must never inherit the session's latest desired Goal identity.
+// unowned provider turn may wait for exact turn-scoped goal evidence or an
+// operation-scoped continuation claim. turn/started alone carries no Goal
+// generation and must never inherit the session's latest desired Goal identity.
 const defaultCodexAppServerGoalProvenanceGraceWindow = 250 * time.Millisecond
 
 type CodexAppServerAdapter struct {
@@ -184,12 +184,21 @@ type codexAppServerSession struct {
 	// Goal provenance is deliberately separate from the mutable desired Goal
 	// identity above. A provider turn may only consume an immutable association
 	// established by matching a provider Goal generation observed in both a
-	// successful goal/set response and a turn-scoped goal/updated notification.
+	// successful goal/set response and a turn-scoped goal/updated notification,
+	// or by consuming the bounded continuation claim for versions that omit
+	// notification.turnId.
 	goalGenerationBindings           map[string]codexGoalGenerationBinding
 	goalGenerationOrder              []string
 	currentGoalGenerationFingerprint string
 	goalTurnEvidence                 map[string]*codexGoalTurnEvidence
 	pendingGoalTurns                 map[string]*codexPendingGoalTurn
+	// goalContinuationClaim is an in-process, single-use compatibility fence
+	// for Codex versions whose thread/goal/updated notification omits turnId.
+	// A successful Goal RPC seeds the first claim; each adopted Goal turn may
+	// seed the next one after settlement. The claim is usable only while its
+	// immutable operation identity is still current, so a newer set/clear
+	// invalidates delayed work without rebinding it to the latest Goal.
+	goalContinuationClaim *codexGoalContinuationClaim
 	// provenanceDegraded is fail-closed for the lifetime of this provider
 	// session. Once bounded evidence can no longer preserve ambiguity, no later
 	// notification may rebuild a partial cache and become adoptable.
@@ -280,6 +289,8 @@ type codexAppServerActiveTurn struct {
 	emitCommands   CommandSnapshotSink
 	kind           codexAppServerTurnKind
 	phase          codexAppServerTurnPhase
+	goalIdentity   goalOperationIdentity
+	goalProvenance string
 	terminal       chan codexAppServerTurnTerminal
 	// terminated is closed exactly once when the Exec goroutine for this turn
 	// returns (turn fully finalized). Cancel waits on it so it only responds

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -101,6 +101,7 @@ type scriptedAppServerConnection struct {
 	goal                            map[string]any
 	goalStartsTurn                  bool
 	goalNotificationsBeforeResponse bool
+	goalUpdatedOmitsTurnID          bool
 	goalTurnsStarted                int
 	goalCompletionAfterTurns        int
 	goalTurnFailAtTurn              int // goal-driven turn number (1-based) that settles as "failed" instead of "completed"
@@ -647,14 +648,17 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 				if goalStatus == "complete" && goalTurnNumber > 1 {
 					messageText = "Goal complete."
 				}
-				// Real Codex exposes the only turn-scoped Goal provenance on
-				// thread/goal/updated. Tests must not let turn/started inherit
-				// the adapter's mutable current Goal identity.
-				c.notify(appServerNotifyThreadGoalUpdated, map[string]any{
+				goalUpdate := map[string]any{
 					"threadId": "codex-thread-1",
-					"turnId":   turnID,
 					"goal":     goal,
-				})
+				}
+				c.mu.Lock()
+				omitTurnID := c.goalUpdatedOmitsTurnID
+				c.mu.Unlock()
+				if !omitTurnID {
+					goalUpdate["turnId"] = turnID
+				}
+				c.notify(appServerNotifyThreadGoalUpdated, goalUpdate)
 				c.notify(appServerNotifyTurnStarted, map[string]any{
 					"threadId": "codex-thread-1",
 					"turn":     map[string]any{"id": turnID, "status": "inProgress", "items": []any{}},
@@ -3694,6 +3698,227 @@ func TestCodexGoalContinuationNudgeDropsSupersededRevision(t *testing.T) {
 	}
 }
 
+func TestCodexGoalSetAdoptsTurnWhenGoalUpdatedOmitsTurnID(t *testing.T) {
+	adapter, transport, session := startedAppServerAdapter(t)
+	adapter.goalContinuationGraceWindow = time.Hour
+	transport.conn.mu.Lock()
+	transport.conn.goalStartsTurn = true
+	transport.conn.goalCompletionAfterTurns = 2
+	transport.conn.goalUpdatedOmitsTurnID = true
+	transport.conn.mu.Unlock()
+
+	var sinkMu sync.Mutex
+	var sinkEvents []activityshared.Event
+	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
+		sinkMu.Lock()
+		defer sinkMu.Unlock()
+		sinkEvents = append(sinkEvents, events...)
+	})
+
+	_, err := adapter.ApplyGoal(context.Background(), session, GoalApplyInput{
+		Action: GoalControlSet, Objective: "ship the compatibility fix",
+		OperationID: "goal-op-no-turn-id", Revision: 1,
+	})
+	if err != nil {
+		t.Fatalf("ApplyGoal: %v", err)
+	}
+
+	waitForCondition(t, func() bool {
+		sinkMu.Lock()
+		defer sinkMu.Unlock()
+		for _, event := range sinkEvents {
+			if event.Type == activityshared.EventMessageAppended &&
+				event.Payload.Role == activityshared.MessageRoleAssistant &&
+				event.Payload.Content == "I'll work on the goal." {
+				return true
+			}
+		}
+		return false
+	})
+
+	sinkMu.Lock()
+	foundClaimedTurn := false
+	for _, event := range sinkEvents {
+		if event.Type == activityshared.EventTurnStarted &&
+			event.Payload.Metadata["sourceGoalOperationId"] == "goal-op-no-turn-id" &&
+			event.Payload.Metadata["goalProvenanceMode"] == "ordered_goal_continuation_claim" {
+			foundClaimedTurn = true
+		}
+	}
+	sinkMu.Unlock()
+	if !foundClaimedTurn {
+		t.Fatalf("missing compatibility-provenance turn start: %#v", sinkEvents)
+	}
+	if requests := appServerRequestParamsList(t, transport.conn, appServerMethodTurnInterrupt); len(requests) != 0 {
+		t.Fatalf("goal turn without notification turnId was interrupted: %#v", requests)
+	}
+}
+
+func TestNormalizeCodexGoalObservationUsesCanonicalSessionFields(t *testing.T) {
+	t.Parallel()
+
+	goal := normalizedCodexGoal(map[string]any{
+		"threadId":        "codex-thread-1",
+		"objective":       "ship it",
+		"status":          "usage_limited",
+		"tokenBudget":     int64(200000),
+		"tokensUsed":      int64(116818),
+		"timeUsedSeconds": int64(163),
+		"createdAt":       int64(1750000000),
+		"updatedAt":       int64(1750000001),
+	})
+
+	if got := asString(goal["objective"]); got != "ship it" {
+		t.Fatalf("objective = %q, want ship it", got)
+	}
+	if got := asString(goal["status"]); got != "usageLimited" {
+		t.Fatalf("status = %q, want usageLimited", got)
+	}
+	if got, ok := int64Value(goal["durationMs"]); !ok || got != 163000 {
+		t.Fatalf("durationMs = %#v, want 163000", goal["durationMs"])
+	}
+	if got, ok := int64Value(goal["tokens"]); !ok || got != 116818 {
+		t.Fatalf("tokens = %#v, want 116818", goal["tokens"])
+	}
+	for _, providerField := range []string{
+		"threadId", "tokenBudget", "tokensUsed", "timeUsedSeconds", "createdAt", "updatedAt",
+	} {
+		if _, exists := goal[providerField]; exists {
+			t.Fatalf("canonical goal retained provider field %q: %#v", providerField, goal)
+		}
+	}
+
+	// Normalization is idempotent because status-only local updates may pass a
+	// previously normalized snapshot back through applyGoalUpdate.
+	normalizedAgain := normalizedCodexGoal(goal)
+	if got, ok := int64Value(normalizedAgain["durationMs"]); !ok || got != 163000 {
+		t.Fatalf("idempotent durationMs = %#v, want 163000", normalizedAgain["durationMs"])
+	}
+	if got, ok := int64Value(normalizedAgain["tokens"]); !ok || got != 116818 {
+		t.Fatalf("idempotent tokens = %#v, want 116818", normalizedAgain["tokens"])
+	}
+}
+
+func TestCodexGoalContinuationClaimChainsAcrossSettledTurns(t *testing.T) {
+	adapter, _, session := startedAppServerAdapter(t)
+	identity := goalOperationIdentity{operationID: "goal-op-chain", revision: 3}
+	adapter.replaceGoalOperationIdentity(session.AgentSessionID, identity.operationID, identity.revision, 0)
+	adapter.applyGoalUpdate(session.AgentSessionID, map[string]any{
+		"threadId":  session.ProviderSessionID,
+		"objective": "finish the chain",
+		"status":    "active",
+	})
+	adapter.armGoalContinuationClaim(session.AgentSessionID, identity)
+
+	appSession := adapter.getSession(session.AgentSessionID)
+	reducer := newCodexAppServerReducer(adapter)
+	startTurn := func(providerTurnID string) {
+		reducer.ReduceNotification(appSession.client, session, "", acpMessage{
+			Method: appServerNotifyTurnStarted,
+			Params: mustJSONRawMessage(t, map[string]any{
+				"threadId": session.ProviderSessionID,
+				"turn":     map[string]any{"id": providerTurnID, "status": "inProgress", "items": []any{}},
+			}),
+		}, nil, nil)
+	}
+
+	startTurn("provider-goal-chain-1")
+	waitForCondition(t, func() bool {
+		return adapter.sessionActiveTurnID(session.AgentSessionID) == "provider-goal-chain-1"
+	})
+	reducer.ReduceNotification(appSession.client, session, "", acpMessage{
+		Method: appServerNotifyTurnCompleted,
+		Params: mustJSONRawMessage(t, map[string]any{
+			"threadId": session.ProviderSessionID,
+			"turn":     map[string]any{"id": "provider-goal-chain-1", "status": "completed", "items": []any{}},
+		}),
+	}, nil, nil)
+	waitForCondition(t, func() bool {
+		return adapter.sessionActiveTurn(session.AgentSessionID) == nil
+	})
+
+	startTurn("provider-goal-chain-2")
+	waitForCondition(t, func() bool {
+		active := adapter.sessionActiveTurn(session.AgentSessionID)
+		return active != nil &&
+			adapter.sessionActiveTurnID(session.AgentSessionID) == "provider-goal-chain-2" &&
+			active.goalIdentity == identity &&
+			active.goalProvenance == "ordered_goal_continuation_claim"
+	})
+}
+
+func TestCodexGoalContinuationClaimRejectsSupersededRevision(t *testing.T) {
+	adapter, transport, session := startedAppServerAdapter(t)
+	adapter.goalProvenanceGraceWindow = 10 * time.Millisecond
+	oldIdentity := goalOperationIdentity{operationID: "goal-op-old-claim", revision: 1}
+	adapter.replaceGoalOperationIdentity(session.AgentSessionID, oldIdentity.operationID, oldIdentity.revision, 0)
+	adapter.applyGoalUpdate(session.AgentSessionID, map[string]any{
+		"threadId":  session.ProviderSessionID,
+		"objective": "old",
+		"status":    "active",
+	})
+	adapter.armGoalContinuationClaim(session.AgentSessionID, oldIdentity)
+	adapter.replaceGoalOperationIdentity(session.AgentSessionID, "goal-op-new-claim", 2, 0)
+
+	appSession := adapter.getSession(session.AgentSessionID)
+	reducer := newCodexAppServerReducer(adapter)
+	reducer.ReduceNotification(appSession.client, session, "", acpMessage{
+		Method: appServerNotifyTurnStarted,
+		Params: mustJSONRawMessage(t, map[string]any{
+			"threadId": session.ProviderSessionID,
+			"turn":     map[string]any{"id": "provider-delayed-old", "status": "inProgress", "items": []any{}},
+		}),
+	}, nil, nil)
+
+	waitForCondition(t, func() bool {
+		for _, request := range appServerRequestParamsList(t, transport.conn, appServerMethodTurnInterrupt) {
+			if asString(request["turnId"]) == "provider-delayed-old" {
+				return true
+			}
+		}
+		return false
+	})
+	if active := adapter.sessionActiveTurn(session.AgentSessionID); active != nil {
+		t.Fatalf("superseded claim adopted delayed turn: %#v", active)
+	}
+}
+
+func TestCodexPreparedGoalContinuationClaimDefersPendingTurnExpiry(t *testing.T) {
+	adapter, transport, session := startedAppServerAdapter(t)
+	adapter.goalProvenanceGraceWindow = 10 * time.Millisecond
+	identity := goalOperationIdentity{operationID: "goal-op-preparing", revision: 1}
+	adapter.replaceGoalOperationIdentity(session.AgentSessionID, identity.operationID, identity.revision, 0)
+	adapter.applyGoalUpdate(session.AgentSessionID, map[string]any{
+		"threadId":  session.ProviderSessionID,
+		"objective": "wait for durable binding",
+		"status":    "active",
+	})
+	adapter.prepareGoalContinuationClaim(session.AgentSessionID, identity)
+
+	appSession := adapter.getSession(session.AgentSessionID)
+	reducer := newCodexAppServerReducer(adapter)
+	reducer.ReduceNotification(appSession.client, session, "", acpMessage{
+		Method: appServerNotifyTurnStarted,
+		Params: mustJSONRawMessage(t, map[string]any{
+			"threadId": session.ProviderSessionID,
+			"turn":     map[string]any{"id": "provider-preparing", "status": "inProgress", "items": []any{}},
+		}),
+	}, nil, nil)
+
+	time.Sleep(35 * time.Millisecond)
+	if requests := appServerRequestParamsList(t, transport.conn, appServerMethodTurnInterrupt); len(requests) != 0 {
+		t.Fatalf("prepared claim allowed pending turn to expire: %#v", requests)
+	}
+	if active := adapter.sessionActiveTurn(session.AgentSessionID); active != nil {
+		t.Fatalf("prepared claim adopted before durable binding: %#v", active)
+	}
+
+	adapter.armGoalContinuationClaim(session.AgentSessionID, identity)
+	waitForCondition(t, func() bool {
+		return adapter.sessionActiveTurnID(session.AgentSessionID) == "provider-preparing"
+	})
+}
+
 // A server-initiated turn/started with no registered turn context and no goal
 // keeps the legacy drop behavior (stray turns such as compaction).
 func TestCodexAppServerAdapterUnownedTurnIgnoredWithoutGoal(t *testing.T) {
@@ -4938,7 +5163,12 @@ func TestCodexLateSupersededGoalTurnKeepsOriginalIdentityAndContinues(t *testing
 	}); err != nil {
 		t.Fatalf("set1: %v", err)
 	}
-	oldGoal := adapter.sessionGoal(session.AgentSessionID)
+	// Keep the provider-authored generation payload for the delayed
+	// notification. sessionGoal intentionally exposes only canonical public
+	// fields and therefore omits immutable provenance fields.
+	transport.conn.mu.Lock()
+	oldGoal := clonePayload(transport.conn.goal)
+	transport.conn.mu.Unlock()
 	if _, err := adapter.ApplyGoal(context.Background(), session, GoalApplyInput{
 		Action: GoalControlClear, OperationID: "goal-clear", Revision: 2,
 	}); err != nil {

--- a/packages/agent/daemon/runtime/codex_appserver_event_state.go
+++ b/packages/agent/daemon/runtime/codex_appserver_event_state.go
@@ -104,6 +104,7 @@ func (a *CodexAppServerAdapter) applyAccountUpdate(agentSessionID string, params
 // transition so callers can emit user-visible notices when the goal stops
 // progressing (paused/blocked/usageLimited/budgetLimited).
 func (a *CodexAppServerAdapter) applyGoalUpdate(agentSessionID string, goal map[string]any) (oldStatus, newStatus string, statusChanged bool) {
+	goal = normalizedCodexGoal(goal)
 	if len(goal) == 0 {
 		return "", "", false
 	}
@@ -116,6 +117,9 @@ func (a *CodexAppServerAdapter) applyGoalUpdate(agentSessionID string, goal map[
 	oldStatus = strings.TrimSpace(asString(appSession.goal["status"]))
 	appSession.goal = clonePayload(goal)
 	newStatus = strings.TrimSpace(asString(appSession.goal["status"]))
+	if newStatus != "active" {
+		appSession.goalContinuationClaim = nil
+	}
 	if oldStatus != newStatus {
 		slog.Info("agent session app-server goal status changed",
 			"event", "agent_session.app_server.goal.status_changed",
@@ -142,6 +146,7 @@ func (a *CodexAppServerAdapter) applyGoalClear(agentSessionID string) {
 		)
 	}
 	appSession.goal = nil
+	appSession.goalContinuationClaim = nil
 }
 
 func appServerRateLimitQuotas(snapshot map[string]any) []map[string]any {

--- a/packages/agent/daemon/runtime/codex_appserver_goal.go
+++ b/packages/agent/daemon/runtime/codex_appserver_goal.go
@@ -89,6 +89,15 @@ func (a *CodexAppServerAdapter) ApplyGoal(
 		return GoalAdapterResult{}, fmt.Errorf("unsupported goal control action %q", action)
 	}
 	previousOperationID, previousRevision, previousRepairEpoch := a.replaceGoalOperationIdentity(session.AgentSessionID, input.OperationID, input.Revision, input.RepairEpoch)
+	expectedIdentity := goalOperationIdentity{
+		operationID: strings.TrimSpace(input.OperationID),
+		revision:    input.Revision,
+		repairEpoch: input.RepairEpoch,
+	}
+	if action == GoalControlSet || action == GoalControlResume {
+		a.prepareGoalContinuationClaim(session.AgentSessionID, expectedIdentity)
+		defer a.clearPreparedGoalContinuationClaim(session.AgentSessionID, expectedIdentity)
+	}
 	slog.Info("agent session app-server goal control",
 		"event", "agent_session.app_server.goal.control",
 		"agent_session_id", session.AgentSessionID,
@@ -107,19 +116,11 @@ func (a *CodexAppServerAdapter) ApplyGoal(
 	} else {
 		goal = appServerGoalFromResult(result)
 		if len(goal) > 0 {
-			if bindErr := a.bindGoalGeneration(ctx, session, goal, goalOperationIdentity{
-				operationID: strings.TrimSpace(input.OperationID),
-				revision:    input.Revision,
-				repairEpoch: input.RepairEpoch,
-			}); bindErr != nil {
+			if bindErr := a.bindGoalGeneration(ctx, session, goal, expectedIdentity); bindErr != nil {
 				return GoalAdapterResult{}, fmt.Errorf("persist goal provenance: %w", bindErr)
 			}
 			a.applyGoalUpdate(session.AgentSessionID, goal)
-		} else if action == GoalControlSet && (goalOperationIdentity{
-			operationID: strings.TrimSpace(input.OperationID),
-			revision:    input.Revision,
-			repairEpoch: input.RepairEpoch,
-		}).valid() {
+		} else if action == GoalControlSet && expectedIdentity.valid() {
 			err := errors.New("provider returned no Goal generation for durable Goal set")
 			a.failGoalProvenanceSession(session, err)
 			return GoalAdapterResult{}, err
@@ -136,6 +137,9 @@ func (a *CodexAppServerAdapter) ApplyGoal(
 				a.applyGoalUpdate(session.AgentSessionID, goal)
 			}
 		}
+	}
+	if (action == GoalControlSet || action == GoalControlResume) && len(goal) > 0 {
+		a.armGoalContinuationClaim(session.AgentSessionID, expectedIdentity)
 	}
 	var events []activityshared.Event
 	if event, ok := normalizedGoalUpdatedEvent(session, goalUpdateType); ok {
@@ -190,7 +194,44 @@ func (a *CodexAppServerAdapter) ReconcileGoal(ctx context.Context, session Sessi
 }
 
 func (*CodexAppServerAdapter) NormalizeGoalObservation(raw map[string]any) map[string]any {
-	return clonePayload(raw)
+	return normalizedCodexGoal(raw)
+}
+
+// normalizedCodexGoal translates provider-specific app-server fields into the
+// canonical Tutti SessionGoal contract. Provider payloads use seconds and
+// tokensUsed; the durable/public model uses milliseconds and tokens.
+func normalizedCodexGoal(raw map[string]any) map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	goal := map[string]any{}
+	if objective := strings.TrimSpace(asStringRaw(raw["objective"])); objective != "" {
+		goal["objective"] = objective
+	}
+	status := appServerGoalStatus(asString(raw["status"]))
+	if status == "" {
+		status = strings.TrimSpace(asString(raw["status"]))
+	}
+	if status != "" {
+		goal["status"] = status
+	}
+	if reason := strings.TrimSpace(asStringRaw(raw["reason"])); reason != "" {
+		goal["reason"] = reason
+	}
+	if iterations, ok := int64Value(raw["iterations"]); ok && iterations >= 0 {
+		goal["iterations"] = iterations
+	}
+	if durationMS, ok := int64Value(raw["durationMs"]); ok && durationMS >= 0 {
+		goal["durationMs"] = durationMS
+	} else if timeUsedSeconds, ok := int64Value(raw["timeUsedSeconds"]); ok && timeUsedSeconds >= 0 {
+		goal["durationMs"] = timeUsedSeconds * int64(time.Second/time.Millisecond)
+	}
+	if tokens, ok := int64Value(raw["tokens"]); ok && tokens >= 0 {
+		goal["tokens"] = tokens
+	} else if tokensUsed, ok := int64Value(raw["tokensUsed"]); ok && tokensUsed >= 0 {
+		goal["tokens"] = tokensUsed
+	}
+	return goal
 }
 
 // ExecGoalControl executes a /goal control command as a thread-level
@@ -544,6 +585,7 @@ func (a *CodexAppServerAdapter) adoptServerInitiatedTurn(session Session, provid
 		"agent_session_id", session.AgentSessionID,
 		"provider_turn_id", providerTurnID,
 		"turn_id", turnID,
+		"provenance_mode", appTurn.goalProvenance,
 	)
 	emitEvents([]activityshared.Event{
 		newTurnActivityEvent(session, EventTurnStarted, turnID, SessionStatusWorking, "", "", map[string]any{
@@ -552,6 +594,7 @@ func (a *CodexAppServerAdapter) adoptServerInitiatedTurn(session Session, provid
 			"sourceGoalOperationId": identity.operationID,
 			"sourceGoalRevision":    identity.revision,
 			"sourceGoalRepairEpoch": identity.repairEpoch,
+			"goalProvenanceMode":    appTurn.goalProvenance,
 		}),
 	})
 	if a.goalHandoffCommittedHook != nil {
@@ -582,6 +625,11 @@ func (a *CodexAppServerAdapter) beginGoalTurnHandoff(agentSessionID, providerTur
 	pending.state = codexGoalTurnAdopting
 	appSession.activeTurn = turn
 	appSession.activeTurnID = strings.TrimSpace(providerTurnID)
+	turn.goalIdentity = identity
+	turn.goalProvenance = strings.TrimSpace(pending.provenanceMode)
+	if turn.goalProvenance == "" {
+		turn.goalProvenance = "turn_scoped_goal_update"
+	}
 	// Main's provider-turn lifecycle is emitted from appTurn, while Goal
 	// provenance settlement matches through the session slot. Bind both sides
 	// atomically so an adopted turn never falls back to its local Turn ID when
@@ -706,6 +754,8 @@ func (a *CodexAppServerAdapter) scheduleGoalContinuationNudge(session Session) {
 		)
 		nudgeCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
+		a.prepareGoalContinuationClaim(agentSessionID, expectedIdentity)
+		defer a.clearPreparedGoalContinuationClaim(agentSessionID, expectedIdentity)
 		// NoHandler: the continuation turn's notifications must keep flowing
 		// to the session-level handler while this RPC is in flight.
 		result, err := client.ThreadGoalSetNoHandler(nudgeCtx, params)
@@ -731,6 +781,7 @@ func (a *CodexAppServerAdapter) scheduleGoalContinuationNudge(session Session) {
 			// session teardown/replacement and future lock implementations.
 			if current := a.goalOperationIdentity(agentSessionID); current == expectedIdentity {
 				a.applyGoalUpdate(agentSessionID, nextGoal)
+				a.armGoalContinuationClaim(agentSessionID, expectedIdentity)
 			}
 		}
 	}()

--- a/packages/agent/daemon/runtime/codex_appserver_goal_claim.go
+++ b/packages/agent/daemon/runtime/codex_appserver_goal_claim.go
@@ -1,0 +1,89 @@
+package agentruntime
+
+import "strings"
+
+type codexGoalContinuationClaim struct {
+	identity goalOperationIdentity
+	ready    bool
+}
+
+// armGoalContinuationClaim establishes a single-use compatibility claim for
+// the next unowned provider turn. Codex orders external Goal mutation as:
+// response, session-scoped goal update, then any continuation turn. Current
+// releases omit turnId from that update, so the successful RPC plus the
+// immutable durable operation identity is the narrowest available causal
+// boundary. Claims never survive adapter restart and cannot cross a newer Goal
+// operation identity.
+func (a *CodexAppServerAdapter) armGoalContinuationClaim(agentSessionID string, identity goalOperationIdentity) {
+	if a == nil || !identity.valid() {
+		return
+	}
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	a.mu.Lock()
+	appSession := a.sessions[agentSessionID]
+	if appSession == nil || appSession.provenanceDegraded {
+		a.mu.Unlock()
+		return
+	}
+	current := goalOperationIdentity{
+		operationID: appSession.goalOperationID,
+		revision:    appSession.goalRevision,
+		repairEpoch: appSession.goalRepairEpoch,
+	}
+	if current != identity || strings.TrimSpace(asString(appSession.goal["status"])) != "active" {
+		a.mu.Unlock()
+		return
+	}
+	appSession.goalContinuationClaim = &codexGoalContinuationClaim{
+		identity: identity,
+		ready:    true,
+	}
+	pendingTurnIDs := make([]string, 0, len(appSession.pendingGoalTurns))
+	for providerTurnID := range appSession.pendingGoalTurns {
+		pendingTurnIDs = append(pendingTurnIDs, providerTurnID)
+	}
+	a.mu.Unlock()
+	for _, providerTurnID := range pendingTurnIDs {
+		a.tryResolvePendingGoalTurn(agentSessionID, providerTurnID)
+	}
+}
+
+// prepareGoalContinuationClaim keeps an unowned turn buffered while the
+// triggering Goal RPC response and durable generation binding are still in
+// flight. A prepared claim is never adoptable; armGoalContinuationClaim is the
+// only transition that makes it consumable.
+func (a *CodexAppServerAdapter) prepareGoalContinuationClaim(agentSessionID string, identity goalOperationIdentity) {
+	if a == nil || !identity.valid() {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	appSession := a.sessions[strings.TrimSpace(agentSessionID)]
+	if appSession == nil || appSession.provenanceDegraded {
+		return
+	}
+	current := goalOperationIdentity{
+		operationID: appSession.goalOperationID,
+		revision:    appSession.goalRevision,
+		repairEpoch: appSession.goalRepairEpoch,
+	}
+	if current == identity {
+		appSession.goalContinuationClaim = &codexGoalContinuationClaim{identity: identity}
+	}
+}
+
+func (a *CodexAppServerAdapter) clearPreparedGoalContinuationClaim(agentSessionID string, identity goalOperationIdentity) {
+	if a == nil || !identity.valid() {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	appSession := a.sessions[strings.TrimSpace(agentSessionID)]
+	if appSession == nil {
+		return
+	}
+	claim := appSession.goalContinuationClaim
+	if claim != nil && claim.identity == identity && !claim.ready {
+		appSession.goalContinuationClaim = nil
+	}
+}

--- a/packages/agent/daemon/runtime/codex_appserver_goal_provenance.go
+++ b/packages/agent/daemon/runtime/codex_appserver_goal_provenance.go
@@ -40,6 +40,7 @@ type codexPendingGoalTurn struct {
 	session        Session
 	notifications  []acpMessage
 	state          string
+	provenanceMode string
 }
 
 const (
@@ -185,9 +186,10 @@ func (a *CodexAppServerAdapter) bindGoalGeneration(_ context.Context, session Se
 	return nil
 }
 
-// observeGoalTurnGeneration consumes the only turn-scoped Goal provenance in
-// the Codex protocol: ThreadGoalUpdatedNotification.turnId + goal snapshot.
-// turn/started alone is deliberately insufficient.
+// observeGoalTurnGeneration consumes exact turn-scoped Goal provenance from
+// ThreadGoalUpdatedNotification.turnId + goal snapshot. turn/started alone is
+// deliberately insufficient; the compatibility path additionally requires a
+// single-use claim established by a successful ordered Goal mutation.
 func (a *CodexAppServerAdapter) observeGoalTurnGeneration(session Session, providerTurnID string, goal map[string]any) {
 	providerTurnID = strings.TrimSpace(providerTurnID)
 	fingerprint := codexGoalGenerationFingerprint(goal)
@@ -612,18 +614,45 @@ func (a *CodexAppServerAdapter) tryResolvePendingGoalTurn(agentSessionID, provid
 	if evidence != nil {
 		a.resolveGoalTurnEvidenceLocked(appSession, evidence)
 	}
-	if evidence == nil || (!evidence.bound && !evidence.ambiguous) {
+	identity := goalOperationIdentity{}
+	provenanceMode := ""
+	switch {
+	case evidence != nil && evidence.bound:
+		identity = evidence.identity
+		provenanceMode = "turn_scoped_goal_update"
+	case evidence != nil && evidence.ambiguous:
+		// Exact provider evidence always wins over compatibility inference.
+	case evidence != nil:
 		a.mu.Unlock()
 		return false
-	}
-	identity := goalOperationIdentity{}
-	if evidence.bound {
-		identity = evidence.identity
+	default:
+		claim := appSession.goalContinuationClaim
+		current := goalOperationIdentity{
+			operationID: appSession.goalOperationID,
+			revision:    appSession.goalRevision,
+			repairEpoch: appSession.goalRepairEpoch,
+		}
+		if claim == nil || !claim.ready || claim.identity != current || !claim.identity.valid() ||
+			strings.TrimSpace(asString(appSession.goal["status"])) != "active" {
+			a.mu.Unlock()
+			return false
+		}
+		if len(appSession.pendingGoalTurns) != 1 {
+			// More than one unowned provider turn cannot be causally ordered
+			// against a single-use claim. Leave all of them to fail closed.
+			appSession.goalContinuationClaim = nil
+			a.mu.Unlock()
+			return false
+		}
+		identity = claim.identity
+		provenanceMode = "ordered_goal_continuation_claim"
+		appSession.goalContinuationClaim = nil
 	}
 	// A newer set/clear changes future Goal scheduling, not work the provider
 	// already accepted. Provenance is immutable, so a superseded but fully
 	// proven Turn is adopted with its original identity and allowed to settle.
 	shouldAdopt := identity.valid() && appSession.activeTurn == nil
+	pending.provenanceMode = provenanceMode
 	session := pending.session
 	a.mu.Unlock()
 
@@ -661,6 +690,20 @@ func (a *CodexAppServerAdapter) expirePendingGoalTurn(agentSessionID, providerTu
 	}
 	evidence := appSession.goalTurnEvidence[strings.TrimSpace(providerTurnID)]
 	if evidence != nil && evidence.lookupInFlight > 0 {
+		grace := a.goalProvenanceGraceWindow
+		if grace <= 0 {
+			grace = defaultCodexAppServerGoalProvenanceGraceWindow
+		}
+		a.mu.Unlock()
+		a.schedulePendingGoalTurnExpiry(agentSessionID, providerTurnID, grace)
+		return
+	}
+	current := goalOperationIdentity{
+		operationID: appSession.goalOperationID,
+		revision:    appSession.goalRevision,
+		repairEpoch: appSession.goalRepairEpoch,
+	}
+	if claim := appSession.goalContinuationClaim; claim != nil && !claim.ready && claim.identity == current {
 		grace := a.goalProvenanceGraceWindow
 		if grace <= 0 {
 			grace = defaultCodexAppServerGoalProvenanceGraceWindow

--- a/packages/agent/daemon/runtime/codex_appserver_turn.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn.go
@@ -168,6 +168,9 @@ func (a *CodexAppServerAdapter) finalizeSettledTurn(agentSessionID string, appTu
 	appTurn.processMu.Unlock()
 	a.endActiveTurn(agentSessionID, appTurn)
 	appTurn.markTerminated()
+	if appTurn.kind == codexAppServerTurnKindGoalAdopted && appTurn.goalIdentity.valid() {
+		a.armGoalContinuationClaim(agentSessionID, appTurn.goalIdentity)
+	}
 	// With an active goal, codex normally auto-starts the next turn; the
 	// nudge covers the case where it does not. This must run regardless of
 	// how the turn settled: a mid-goal turn can end failed (a transient tool

--- a/packages/agent/daemon/runtime/controller_exec.go
+++ b/packages/agent/daemon/runtime/controller_exec.go
@@ -194,6 +194,11 @@ type GoalControlResult struct {
 // session-level control operation — like Cancel, it never opens a turn, so it
 // works regardless of what is currently running.
 func (c *Controller) GoalControl(ctx context.Context, input GoalControlInput) (GoalControlResult, error) {
+	releaseLifecycleLock, err := c.acquireLifecycleLockContext(ctx, input.RoomID, input.AgentSessionID)
+	if err != nil {
+		return GoalControlResult{}, err
+	}
+	defer releaseLifecycleLock()
 	session, adapter, err := c.sessionAndAdapter(input.RoomID, input.AgentSessionID)
 	if err != nil {
 		return GoalControlResult{}, err

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -5822,6 +5822,24 @@ func TestGoalCapabilitiesWaitObservesContextCancellation(t *testing.T) {
 	}
 }
 
+func TestGoalControlWaitObservesContextCancellation(t *testing.T) {
+	controller := NewController(nil, nil)
+	release := controller.acquireLifecycleLock("room-1", "session-1")
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err := controller.GoalControl(ctx, GoalControlInput{RoomID: "room-1", AgentSessionID: "session-1"})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("GoalControl error = %v", err)
+	}
+	release()
+	controller.mu.Lock()
+	remaining := len(controller.lifecycleLocks)
+	controller.mu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("lifecycle lock references leaked: %d", remaining)
+	}
+}
+
 // TestControllerCancelLeavesSettledSessionUntouched guards against the
 // reconciliation disturbing healthy sessions: a session that is already settled
 // must not be re-settled or re-reported when stop is pressed with no active turn.

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGoalBanner.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGoalBanner.spec.tsx
@@ -82,7 +82,7 @@ describe("AgentGoalBanner", () => {
       <AgentGoalBanner
         objective="Finish the migration"
         status="active"
-        timeUsedSeconds={2}
+        durationMs={2000}
         labels={labels}
       />
     );
@@ -240,7 +240,7 @@ describe("AgentGoalBanner", () => {
         <AgentGoalBanner
           objective="Ship it"
           status="active"
-          timeUsedSeconds={2}
+          durationMs={2000}
           labels={labels}
         />
       );
@@ -259,7 +259,7 @@ describe("AgentGoalBanner", () => {
         <AgentGoalBanner
           objective="Ship it"
           status="paused"
-          timeUsedSeconds={40}
+          durationMs={40000}
           labels={labels}
         />
       );
@@ -270,6 +270,55 @@ describe("AgentGoalBanner", () => {
       expect(
         screen.getByTestId("agent-gui-goal-banner-description").textContent
       ).toBe("Ship it · 40s");
+    });
+
+    it("starts an active goal at zero when the optional duration is omitted", () => {
+      render(
+        <AgentGoalBanner objective="Ship it" status="active" labels={labels} />
+      );
+
+      const description = () =>
+        screen.getByTestId("agent-gui-goal-banner-description").textContent;
+      expect(description()).toBe("Ship it · 0s");
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
+      expect(description()).toBe("Ship it · 3s");
+    });
+
+    it("does not show or start elapsed time for an optimistic goal", () => {
+      const { rerender } = render(
+        <AgentGoalBanner
+          objective="Ship it"
+          status="active"
+          durationMs={4000}
+          optimistic={true}
+          labels={labels}
+        />
+      );
+
+      const description = () =>
+        screen.getByTestId("agent-gui-goal-banner-description").textContent;
+      expect(description()).toBe("Ship it");
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
+      expect(description()).toBe("Ship it");
+
+      rerender(
+        <AgentGoalBanner
+          objective="Ship it"
+          status="active"
+          durationMs={7000}
+          optimistic={false}
+          labels={labels}
+        />
+      );
+      expect(description()).toBe("Ship it · 7s");
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(description()).toBe("Ship it · 9s");
     });
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGoalBanner.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGoalBanner.tsx
@@ -23,7 +23,8 @@ export interface AgentGoalBannerProps {
   status: string;
   tokenBudget?: number;
   tokensUsed?: number;
-  timeUsedSeconds?: number;
+  durationMs?: number;
+  optimistic?: boolean;
   labels: AgentGoalBannerLabels;
   /** Called with the edited objective when the inline edit is confirmed. */
   onEditObjective?: (objective: string) => void;
@@ -129,16 +130,18 @@ export function describeGoal(input: {
  * with the codex desktop goal bar: "<status title> <objective> · <elapsed>"
  * plus icon controls for edit / pause-resume / delete.
  *
- * The elapsed time is the server-reported timeUsedSeconds; while the goal is
- * active the banner ticks it forward locally between goal updates. Without
- * action callbacks the banner falls back to the read-only "/goal clear" hint.
+ * The elapsed time is the server-reported canonical durationMs; while the goal
+ * is active the banner ticks it forward locally between goal updates.
+ * Optimistic Goal projections never show or start the timer; after canonical
+ * provider state arrives, an omitted zero-valued duration starts from zero.
  */
 export function AgentGoalBanner({
   objective,
   status,
   tokenBudget,
   tokensUsed,
-  timeUsedSeconds,
+  durationMs,
+  optimistic = false,
   labels,
   onEditObjective,
   onPauseGoal,
@@ -150,10 +153,13 @@ export function AgentGoalBanner({
   const [editDraft, setEditDraft] = useState<string | null>(null);
   const normalizedStatus = normalizeGoalStatus(status);
   const isActive = normalizedStatus === "" || normalizedStatus === "active";
-  const serverSeconds =
-    typeof timeUsedSeconds === "number" && timeUsedSeconds >= 0
-      ? Math.floor(timeUsedSeconds)
-      : null;
+  const serverSeconds = optimistic
+    ? null
+    : typeof durationMs === "number" && durationMs >= 0
+      ? Math.floor(durationMs / 1000)
+      : isActive
+        ? 0
+        : null;
   const [localElapsed, setLocalElapsed] = useState(0);
   useEffect(() => {
     setLocalElapsed(0);

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
@@ -192,7 +192,8 @@ export function useAgentGUISessionPresentation(
       agentSessionId,
       goal: optimisticGoalControl
         ? optimisticGoalControl.goal
-        : (input.activeEngineSession?.goal ?? null)
+        : (input.activeEngineSession?.goal ?? null),
+      goalIsOptimistic: optimisticGoalControl !== null
     };
   }, [
     input.activeConversationId,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -54,7 +54,11 @@ export interface AgentGUISessionChrome {
         canRetry?: never;
       }
     | null;
-  rawState: Pick<CanonicalAgentSession, "agentSessionId" | "goal"> | null;
+  rawState:
+    | (Pick<CanonicalAgentSession, "agentSessionId" | "goal"> & {
+        goalIsOptimistic: boolean;
+      })
+    | null;
 }
 
 export interface AgentGUIOptimisticGoalControl {

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIBottomDockPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIBottomDockPane.tsx
@@ -85,8 +85,9 @@ export const AgentGUIBottomDockPane = memo(function AgentGUIBottomDockPane({
   const goalObjective = goal ? stringValue(goal.objective) : "";
   const goalStatus = goal ? stringValue(goal.status) : "";
   const goalTokenBudget = goal ? numberValue(goal.tokenBudget) : null;
-  const goalTokensUsed = goal ? numberValue(goal.tokensUsed) : null;
-  const goalTimeUsedSeconds = goal ? numberValue(goal.timeUsedSeconds) : null;
+  const goalTokensUsed = goal ? numberValue(goal.tokens) : null;
+  const goalDurationMs = goal ? numberValue(goal.durationMs) : null;
+  const goalIsOptimistic = sessionChrome.rawState?.goalIsOptimistic === true;
   const showGoalBanner = isGoalBannerVisible(goalObjective, goalStatus);
 
   return (
@@ -154,7 +155,8 @@ export const AgentGUIBottomDockPane = memo(function AgentGUIBottomDockPane({
           status={goalStatus}
           tokenBudget={goalTokenBudget ?? undefined}
           tokensUsed={goalTokensUsed ?? undefined}
-          timeUsedSeconds={goalTimeUsedSeconds ?? undefined}
+          durationMs={goalDurationMs ?? undefined}
+          optimistic={goalIsOptimistic}
           labels={goalBannerLabels}
           onPauseGoal={
             goalPauseSupported ? () => onGoalControl("pause") : undefined


### PR DESCRIPTION
## Summary

- support Codex Goal continuation turns when `thread/goal/updated` omits `turnId`
- normalize Codex Goal counters into the canonical Tutti Goal contract
- show elapsed time only after canonical provider confirmation, using the provider duration as the baseline

## Root cause

External Codex Goal mutations can emit a session-scoped Goal update without a turn identifier before starting the continuation turn. Tutti previously treated the turn as unproven and interrupted it after the provenance grace window.

Codex also reports `timeUsedSeconds` and `tokensUsed`, while Tutti persists and exposes `durationMs` and `tokens`. The provider-specific fields were discarded at the typed session boundary, so the Goal banner had no authoritative timer value.

## Fix Scope Justification

- Root cause: the first incorrect state is created at the Codex adapter boundary. A session-scoped `thread/goal/updated` event can establish a new Goal revision without a `turnId`, so the following continuation turn has no exact turn-scoped provenance and is incorrectly interrupted. At the same boundary, Codex Goal counters use provider-specific fields that were not mapped into the canonical Tutti Goal model.
- Why this cannot be fixed at a lower layer: the lower layer is the external Codex app-server protocol, which Tutti does not control and which legitimately omits `turnId` from this event. The adapter is the lowest owned layer that sees both the session-scoped Goal operation identity and the subsequent turn lifecycle, so it must create and consume the narrowly scoped continuation claim there. The adapter is also the lowest owned translation boundary for mapping Codex counters into the canonical contract. Controller locking and UI presentation changes only preserve those canonical semantics across lifecycle concurrency and optimistic rendering; they do not infer provider state independently.

## Implementation

- preserve exact turn-scoped Goal evidence as the preferred provenance path
- add an adapter-local, single-use continuation claim bound to immutable Goal operation identity
- invalidate compatibility claims on revision changes, inactive state, restart, ambiguity, or competing unowned turns
- serialize Goal control with session setup through the lifecycle lock
- map `timeUsedSeconds` to `durationMs` and `tokensUsed` to `tokens` at the adapter boundary
- explicitly distinguish optimistic Goal presentation so its timer remains hidden until canonical state arrives
- add regression coverage and troubleshooting/architecture documentation

## Validation

- `go test ./...` in `packages/agent/daemon`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/agent-gui test -- AgentGoalBanner.spec.tsx` — 186 files, 1676 tests
- `pnpm lint:go`
- `pnpm check:changed --tail-lines 160`
- pre-push `pnpm check:full` — 18 tasks passed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->