### PR TITLE
fix(agent-gui): handle login notices without path links

### DIFF
--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -899,6 +899,36 @@ invalid_grant`. Daemon logs may also show an extra `claude-code` process start
   [composer_live_model_discovery.go](../../../services/tuttid/service/agent/composer_live_model_discovery.go)
   [model_validation.go](../../../services/tuttid/service/agent/model_validation.go)
 
+### Claude Code `Not logged in` renders as a file link instead of sign-in guidance
+
+- Symptom:
+  A Claude Code turn renders the plain text
+  `Not logged in · Please run /login`. Clicking `/login` tries to open a local
+  file and may show a missing-file toast instead of the Agent login flow.
+- Quick checks:
+  Inspect the durable assistant message and owning Turn. If both are
+  `completed` even though the body is the standalone login notice, the Claude
+  SDK returned an authentication failure as successful assistant output. The
+  generic failed-message recovery path will not run for that shape.
+- Root cause:
+  The Claude SDK can pair its standalone login notice with a successful result.
+  AgentGUI previously recovered plain authentication errors only when the
+  message status was `failed`, so the completed notice fell through to Markdown
+  rendering, where `/login` also matched the local absolute-path link rule.
+- Fix:
+  Preserve provider-agnostic recovery for failed messages. Additionally, for
+  completed messages, recognize the short, whole-message standalone login
+  notice and recover it as `auth_required`. Match the provider-owned output
+  shape rather than branching on provider identity; keep the matcher
+  length-bounded and anchored so ordinary answers that discuss login text are
+  not reclassified.
+- Validation:
+  Cover the completed Claude notice rendering the authentication card and a
+  normal completed answer that quotes the notice remaining ordinary content.
+- References:
+  [agentErrorPresentation.ts](../../../packages/agent/gui/shared/agentEnv/agentErrorPresentation.ts)
+  [AgentMessageBlock.tsx](../../../packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx)
+
 ### Claude Code sessions fail with `effectiveSource: "none"` when CC-Switch or similar proxy tools are used
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -861,10 +861,11 @@ file or directory`. If the CLI path exists but `codex app-server` cannot
 - Quick checks:
   Capture `/v1/oauth/token` traffic (mitmproxy). A failure may show `Client
 disconnected` immediately before later refresh attempts return `400
-invalid_grant`. Daemon logs may also show an extra `claude-code` process start
-  with `cwd=/`, `hasModel=false`, and a different `agent_session_id` from the
-  real conversation session; that shape is the hidden live-model discovery
-  session.
+invalid_grant`. Search `tuttid.log` for
+  `event=agent.model_discovery.hidden_session_triggered provider=claude-code`;
+  this info-level event confirms that Tutti actually triggered a hidden Claude
+  live-model discovery session. The event intentionally includes only the
+  provider and random discovery-session id.
 - Root cause:
   Composer-options loading spawned a hidden, `visible:false` Claude live-model
   discovery session that shares the on-disk credential store with the real

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -32,6 +32,7 @@ Provider discovery, installation, authentication, models, configuration, and run
 - [Claude SDK model aliases resolve to configured Anthropic defaults](./agent-provider-setup.md#claude-sdk-model-aliases-resolve-to-configured-anthropic-defaults)
 - [Claude SDK rejects live bypassPermissions mode](./agent-provider-setup.md#claude-sdk-rejects-live-bypasspermissions-mode)
 - [Claude Code logs out after sending a message (invalid_grant, credentials wiped)](./agent-provider-setup.md#claude-code-logs-out-after-sending-a-message-invalidgrant-credentials-wiped)
+- [Claude Code `Not logged in` renders as a file link instead of sign-in guidance](./agent-provider-setup.md#claude-code-not-logged-in-renders-as-a-file-link-instead-of-sign-in-guidance)
 - [Claude Code sessions fail with `effectiveSource: "none"` when CC-Switch or similar proxy tools are used](./agent-provider-setup.md#claude-code-sessions-fail-with-effectivesource-none-when-cc-switch-or-similar-proxy-tools-are-used)
 - [Tutti Agent retries a 402 and shows generic provider setup](./agent-provider-setup.md#tutti-agent-retries-a-402-and-shows-generic-provider-setup)
 - [OpenCode effort changes fail with `effort not found`](./agent-provider-setup.md#opencode-effort-changes-fail-with-effort-not-found)

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -339,7 +339,7 @@ describe("AgentMessageMarkdown", () => {
     render(
       <AgentMessageMarkdown
         content={
-          "图片在这里： `/Users/local/.tutti-dev/agent/runs/session-1/codex-home/generated_images/imagegen/ig_123.png`"
+          "图片在这里： [/Users/local/.tutti-dev/agent/runs/session-1/codex-home/generated_images/imagegen/ig_123.png](/Users/local/.tutti-dev/agent/runs/session-1/codex-home/generated_images/imagegen/ig_123.png)"
         }
         onLinkAction={onLinkAction}
         workspaceLinkContext={{
@@ -1338,7 +1338,7 @@ describe("AgentMessageMarkdown", () => {
     expect(screen.queryByText(/mention:\/\/session/)).toBeNull();
   });
 
-  it("turns inline code paths into clickable links", () => {
+  it("keeps inline code paths as code instead of inferring links", () => {
     const onLinkClick = vi.fn();
     render(
       <AgentMessageMarkdown
@@ -1349,14 +1349,14 @@ describe("AgentMessageMarkdown", () => {
       />
     );
 
-    fireEvent.click(
-      screen.getByRole("link", { name: "/Users/example/demo/abc" })
-    );
-
-    expect(onLinkClick).toHaveBeenCalledWith("/Users/example/demo/abc");
+    expect(
+      screen.queryByRole("link", { name: "/Users/example/demo/abc" })
+    ).toBeNull();
+    expect(screen.getByText("/Users/example/demo/abc")).toBeInTheDocument();
+    expect(onLinkClick).not.toHaveBeenCalled();
   });
 
-  it("turns inline code home-relative paths into clickable links", () => {
+  it("keeps inline code home-relative paths as code", () => {
     const onLinkAction = vi.fn();
     render(
       <AgentMessageMarkdown
@@ -1370,18 +1370,12 @@ describe("AgentMessageMarkdown", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("link", { name: "~/docs/a.md" }));
-
-    expect(onLinkAction).toHaveBeenCalledWith({
-      type: "open-workspace-file",
-      path: "~/docs/a.md",
-      directoryPath: "~/docs",
-      workspaceRoot: "/Users/example/demo",
-      source: "agent-markdown"
-    });
+    expect(screen.queryByRole("link", { name: "~/docs/a.md" })).toBeNull();
+    expect(screen.getByText("~/docs/a.md")).toBeInTheDocument();
+    expect(onLinkAction).not.toHaveBeenCalled();
   });
 
-  it("turns inline code Windows absolute paths into clickable links", () => {
+  it("keeps inline code Windows absolute paths as code", () => {
     const onLinkAction = vi.fn();
     render(
       <AgentMessageMarkdown
@@ -1395,22 +1389,18 @@ describe("AgentMessageMarkdown", () => {
       />
     );
 
-    fireEvent.click(
-      screen.getByRole("link", {
+    expect(
+      screen.queryByRole("link", {
         name: "C:\\Users\\local\\project\\docs\\README.md"
       })
-    );
-
-    expect(onLinkAction).toHaveBeenCalledWith({
-      type: "open-workspace-file",
-      path: "C:/Users/local/project/docs/README.md",
-      directoryPath: "C:/Users/local/project/docs",
-      workspaceRoot: "C:/Users/local/project",
-      source: "agent-markdown"
-    });
+    ).toBeNull();
+    expect(
+      screen.getByText("C:\\Users\\local\\project\\docs\\README.md")
+    ).toBeInTheDocument();
+    expect(onLinkAction).not.toHaveBeenCalled();
   });
 
-  it("turns inline code http urls into clickable links", () => {
+  it("keeps inline code http urls as code", () => {
     const onLinkClick = vi.fn();
     render(
       <AgentMessageMarkdown
@@ -1419,11 +1409,11 @@ describe("AgentMessageMarkdown", () => {
       />
     );
 
-    fireEvent.click(
-      screen.getByRole("link", { name: "http://127.0.0.1:9999" })
-    );
-
-    expect(onLinkClick).toHaveBeenCalledWith("http://127.0.0.1:9999");
+    expect(
+      screen.queryByRole("link", { name: "http://127.0.0.1:9999" })
+    ).toBeNull();
+    expect(screen.getByText("http://127.0.0.1:9999")).toBeInTheDocument();
+    expect(onLinkClick).not.toHaveBeenCalled();
   });
 
   it("prevents default navigation for markdown http links", () => {
@@ -1455,26 +1445,30 @@ describe("AgentMessageMarkdown", () => {
     expect(onLinkClick).toHaveBeenCalledWith("http://127.0.0.1:9999");
   });
 
-  it("turns bare local absolute paths into clickable links", () => {
+  it("keeps bare local absolute paths and slash commands as plain text", () => {
     const onLinkClick = vi.fn();
     render(
       <AgentMessageMarkdown
         content={
-          "已创建空的 txt 文件：\n\n/Users/example/demo/83c66a52-4ff2-436a-a300-e346c9fdd9d2/note.txt\n\n当前大小：0 bytes。"
+          "已创建空的 txt 文件：\n\n/Users/example/demo/83c66a52-4ff2-436a-a300-e346c9fdd9d2/note.txt\n\nNot logged in · Please run /login"
         }
         onLinkClick={onLinkClick}
       />
     );
 
-    fireEvent.click(
-      screen.getByRole("link", {
+    expect(
+      screen.queryByRole("link", {
         name: "/Users/example/demo/83c66a52-4ff2-436a-a300-e346c9fdd9d2/note.txt"
       })
-    );
-
-    expect(onLinkClick).toHaveBeenCalledWith(
-      "/Users/example/demo/83c66a52-4ff2-436a-a300-e346c9fdd9d2/note.txt"
-    );
+    ).toBeNull();
+    expect(screen.queryByRole("link", { name: "/login" })).toBeNull();
+    expect(
+      screen.getByText(
+        "/Users/example/demo/83c66a52-4ff2-436a-a300-e346c9fdd9d2/note.txt"
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Please run \/login/)).toBeInTheDocument();
+    expect(onLinkClick).not.toHaveBeenCalled();
   });
 
   it("does not auto-link bare relative paths", () => {

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -53,7 +53,6 @@ import {
   isClickableMarkdownHref,
   isLocalAbsolutePath,
   isMentionOnlyMarkdownContent,
-  linkBareLocalAbsolutePaths,
   markdownUrlTransform,
   normalizeMentionMarkdownLinks,
   normalizeLocalPathMarkdownLinks,
@@ -194,15 +193,13 @@ export function AgentMessageMarkdown({
   const ContainerTag = inline ? "span" : "div";
   const normalizedContent = useMemo(
     () =>
-      linkBareLocalAbsolutePaths(
-        normalizeLocalPathMarkdownLinks(
-          normalizeMentionMarkdownLinks(
-            normalizePlainIssueMentionTitle
-              ? normalizePlainIssueMentionTitleContent(
-                  normalizePlainSessionMentionTitle(stabilizedContent)
-                )
-              : normalizePlainSessionMentionTitle(stabilizedContent)
-          )
+      normalizeLocalPathMarkdownLinks(
+        normalizeMentionMarkdownLinks(
+          normalizePlainIssueMentionTitle
+            ? normalizePlainIssueMentionTitleContent(
+                normalizePlainSessionMentionTitle(stabilizedContent)
+              )
+            : normalizePlainSessionMentionTitle(stabilizedContent)
         )
       ),
     [normalizePlainIssueMentionTitle, stabilizedContent]
@@ -249,9 +246,7 @@ export function AgentMessageMarkdown({
           previewMode={previewMode}
         />
       ),
-      code: (props: MarkdownDomProps<"code">) => (
-        <MarkdownCode {...props} onLinkClick={handleLinkClick} />
-      ),
+      code: (props: MarkdownDomProps<"code">) => <MarkdownCode {...props} />,
       img: (props: MarkdownDomProps<"img">) => (
         <MarkdownMedia {...props} enableZoom={enableImageZoom} />
       ),

--- a/packages/agent/gui/shared/AgentMessageMarkdownRenderers.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdownRenderers.tsx
@@ -1,6 +1,5 @@
 import {
   useCallback,
-  useContext,
   useRef,
   useState,
   type CSSProperties,
@@ -11,41 +10,14 @@ import { Check, Copy } from "lucide-react";
 import { translate } from "../i18n/index";
 import { cn } from "../app/renderer/lib/utils";
 import type { MarkdownDomProps } from "./AgentMessageMarkdown";
-import { MarkdownLinkContext } from "./agentMessageMarkdownContext";
-import {
-  isExplicitWorkspaceFilePath,
-  isHttpUrl
-} from "./agentMessageMarkdownLinks";
-import {
-  activateMarkdownLink,
-  activateMarkdownLinkFromKey,
-  activateMarkdownLinkFromPointer
-} from "./agentMessageMarkdownRuntime";
 
 export function MarkdownCode({
   node: _node,
   children,
   className,
-  onLinkClick,
   ...props
-}: MarkdownDomProps<"code"> & {
-  onLinkClick?: (href: string) => void;
-}): JSX.Element {
+}: MarkdownDomProps<"code">): JSX.Element {
   "use memo";
-  const isInsideLink = useContext(MarkdownLinkContext);
-  const text = textFromReactNode(children).trim();
-  const isLinkablePath =
-    !isInsideLink &&
-    onLinkClick &&
-    !className &&
-    (isExplicitWorkspaceFilePath(text) || isHttpUrl(text));
-  if (isLinkablePath) {
-    return (
-      <PathLink href={text} onLinkClick={onLinkClick}>
-        {children}
-      </PathLink>
-    );
-  }
   return (
     <code {...props} className={className}>
       {children}
@@ -127,37 +99,6 @@ export function MarkdownParagraph({
     return <span {...props} />;
   }
   return <p {...props} />;
-}
-
-function PathLink({
-  href,
-  children,
-  onLinkClick
-}: {
-  href: string;
-  children: ReactNode;
-  onLinkClick: (href: string) => void;
-}): JSX.Element {
-  "use memo";
-  return (
-    <a
-      className="cursor-pointer"
-      data-agent-link-href={href}
-      role="link"
-      tabIndex={0}
-      onClick={(event) => {
-        activateMarkdownLink(event, href, onLinkClick);
-      }}
-      onPointerDown={(event) => {
-        activateMarkdownLinkFromPointer(event, href, onLinkClick);
-      }}
-      onKeyDown={(event) => {
-        activateMarkdownLinkFromKey(event, href, onLinkClick);
-      }}
-    >
-      {children}
-    </a>
-  );
 }
 
 export function textFromReactNode(node: ReactNode): string {

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -26,7 +26,7 @@ import type {
 import { AgentMessageDetailsDisclosure } from "./AgentMessageDetailsDisclosure";
 import {
   AgentVisibleErrorMessage,
-  recoverVisibleErrorFromFailedMessage
+  recoverVisibleErrorFromMessage
 } from "./AgentVisibleErrorMessage";
 import { AgentThinkingDisclosure } from "./AgentThinkingDisclosure";
 import { RawTimelineJsonDisclosure } from "./RawTimelineJsonDisclosure";
@@ -146,12 +146,12 @@ export function AgentMessageBlock({
               label={rawTimelineJsonLabel}
             />
           ) : null;
-        // Recover a structured error card from a failed message that the provider
-        // reported as plain text (e.g. a dropped-login 401), so it still gets the
-        // wizard call-to-action instead of a dead red message.
+        // Recover a structured error card from a terminal message that the
+        // provider reported as plain text, including Claude SDK's completed
+        // standalone login notice.
         const recoveredError =
-          !isUser && !message.visibleError && message.statusKind === "failed"
-            ? recoverVisibleErrorFromFailedMessage(message, provider)
+          !isUser && !message.visibleError
+            ? recoverVisibleErrorFromMessage(message, provider)
             : null;
         const content =
           isUser && message.contentKind === "image-grid" ? (

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.visibleError.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.visibleError.spec.tsx
@@ -76,6 +76,15 @@ function buildFailedTextRow(body: string): AgentMessageRowVM {
   };
 }
 
+function buildCompletedTextRow(body: string): AgentMessageRowVM {
+  const row = buildFailedTextRow(body);
+  const message = row.messages[0];
+  if (message) {
+    message.statusKind = "completed";
+  }
+  return row;
+}
+
 afterEach(() => {
   closeAgentEnvPanel();
   vi.restoreAllMocks();
@@ -256,6 +265,19 @@ describe("AgentVisibleErrorMessage", () => {
     expect(store.open).toBe(true);
     expect(store.provider).toBe("claude-code");
     expect(store.focus).toBe("auth");
+  });
+
+  it("recovers Claude SDK's completed login notice into the wizard card", () => {
+    const { getByText, queryByText } = renderBlock(
+      buildCompletedTextRow("Not logged in · Please run /login"),
+      "claude-code"
+    );
+
+    expect(
+      getByText("Claude Code needs authentication or configuration")
+    ).toBeTruthy();
+    expect(getByText("Sign in")).toBeTruthy();
+    expect(queryByText("Not logged in · Please run /login")).toBeNull();
   });
 
   it("leaves a non-env failed message as plain text (no card)", () => {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -988,7 +988,7 @@ describe("AgentTranscriptView", () => {
     expect(onLinkAction).not.toHaveBeenCalled();
   });
 
-  it("opens local absolute paths inside the current workspace root", () => {
+  it("opens explicit Markdown links to local absolute paths", () => {
     const onLinkAction = vi.fn();
     render(
       <AgentTranscriptView
@@ -1002,7 +1002,7 @@ describe("AgentTranscriptView", () => {
                 agentMessages: [
                   {
                     id: "assistant-1",
-                    body: "工作区路径：`/Users/example/demo/output/imagegen/dancing-girl.png`"
+                    body: "工作区路径：[/Users/example/demo/output/imagegen/dancing-girl.png](/Users/example/demo/output/imagegen/dancing-girl.png)"
                   }
                 ],
                 agentItems: [
@@ -1010,7 +1010,7 @@ describe("AgentTranscriptView", () => {
                     kind: "message",
                     message: {
                       id: "assistant-1",
-                      body: "工作区路径：`/Users/example/demo/output/imagegen/dancing-girl.png`"
+                      body: "工作区路径：[/Users/example/demo/output/imagegen/dancing-girl.png](/Users/example/demo/output/imagegen/dancing-girl.png)"
                     }
                   }
                 ],
@@ -1046,7 +1046,7 @@ describe("AgentTranscriptView", () => {
     });
   });
 
-  it("opens generated HTML paths from no-project session directories", () => {
+  it("opens explicit Markdown links from no-project session directories", () => {
     const onLinkAction = vi.fn();
     render(
       <AgentTranscriptView
@@ -1076,7 +1076,7 @@ describe("AgentTranscriptView", () => {
                 agentMessages: [
                   {
                     id: "assistant-1",
-                    body: "打开 `/Users/example/Documents/tutti/session-1/index.html`"
+                    body: "打开 [/Users/example/Documents/tutti/session-1/index.html](/Users/example/Documents/tutti/session-1/index.html)"
                   }
                 ],
                 agentItems: [
@@ -1084,7 +1084,7 @@ describe("AgentTranscriptView", () => {
                     kind: "message",
                     message: {
                       id: "assistant-1",
-                      body: "打开 `/Users/example/Documents/tutti/session-1/index.html`"
+                      body: "打开 [/Users/example/Documents/tutti/session-1/index.html](/Users/example/Documents/tutti/session-1/index.html)"
                     }
                   }
                 ],

--- a/packages/agent/gui/shared/agentConversation/components/AgentVisibleErrorMessage.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentVisibleErrorMessage.tsx
@@ -4,7 +4,7 @@ import { translate } from "../../../i18n/index";
 import { workspaceAgentProviderLabel } from "../../workspaceAgentProviderLabel";
 import { openAgentEnvPanel } from "../../agentEnv/agentEnvPanelStore";
 import {
-  classifyFailedAgentMessage,
+  classifyRecoverableAgentMessage,
   isProviderPlanLimitMessage,
   resolveAgentErrorPresentation
 } from "../../agentEnv/agentErrorPresentation";
@@ -17,13 +17,16 @@ import { AgentMessageDetailsDisclosure } from "./AgentMessageDetailsDisclosure";
 const ERROR_BANNER_CLASS_NAME =
   "border-[var(--on-danger-hover)] bg-[var(--on-danger)] text-[var(--state-danger)]";
 
-// Builds a synthetic visibleError from a plain failed message whose text is a
-// recognizable env failure, so it renders as the structured remediation card.
-export function recoverVisibleErrorFromFailedMessage(
+// Builds a synthetic visibleError from a plain message whose text and terminal
+// status identify a recognizable environment failure.
+export function recoverVisibleErrorFromMessage(
   message: AgentMessageContentVM,
   provider: string | null | undefined
 ): AgentMessageContentVM | null {
-  const code = classifyFailedAgentMessage(message.body);
+  const code = classifyRecoverableAgentMessage({
+    body: message.body,
+    statusKind: message.statusKind
+  });
   if (!code) {
     return null;
   }

--- a/packages/agent/gui/shared/agentEnv/agentErrorPresentation.spec.ts
+++ b/packages/agent/gui/shared/agentEnv/agentErrorPresentation.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   classifyFailedAgentMessage,
+  classifyRecoverableAgentMessage,
   isProviderPlanLimitMessage,
   resolveAgentErrorPresentation
 } from "./agentErrorPresentation";
@@ -40,6 +41,35 @@ describe("classifyFailedAgentMessage", () => {
     expect(classifyFailedAgentMessage("Add a payment method to continue")).toBe(
       "quota_or_rate_limit"
     );
+  });
+});
+
+describe("classifyRecoverableAgentMessage", () => {
+  it("recovers the standalone Claude Code login notice even when SDK marks it completed", () => {
+    expect(
+      classifyRecoverableAgentMessage({
+        body: "Not logged in · Please run /login",
+        statusKind: "completed"
+      })
+    ).toBe("auth_required");
+  });
+
+  it("does not reinterpret other completed messages", () => {
+    expect(
+      classifyRecoverableAgentMessage({
+        body: "Authentication is configured and the request completed.",
+        statusKind: "completed"
+      })
+    ).toBeNull();
+  });
+
+  it("does not reinterpret a normal Claude answer that discusses the notice", () => {
+    expect(
+      classifyRecoverableAgentMessage({
+        body: 'The message "Not logged in · Please run /login" means authentication is required.',
+        statusKind: "completed"
+      })
+    ).toBeNull();
   });
 });
 

--- a/packages/agent/gui/shared/agentEnv/agentErrorPresentation.ts
+++ b/packages/agent/gui/shared/agentEnv/agentErrorPresentation.ts
@@ -189,6 +189,39 @@ export function classifyFailedAgentMessage(
   return null;
 }
 
+const COMPLETED_AUTH_MESSAGE_MAX_LENGTH = 160;
+const COMPLETED_AUTH_MESSAGE_PATTERN =
+  /^not logged in\s*(?:[·•:—-]|\.)?\s*please run\s+\/login[.!]?$/i;
+
+/**
+ * Resolves a plain assistant message that should be recovered into a visible
+ * error card. Failed messages keep the provider-agnostic fallback above.
+ *
+ * Claude Code demonstrates why completed messages need a narrow exception: its
+ * SDK can return the standalone "Not logged in · Please run /login" notice
+ * together with a successful result. Match the provider-owned output shape,
+ * rather than branching on provider identity, and keep it short and
+ * whole-message anchored so normal answers are not reclassified.
+ */
+export function classifyRecoverableAgentMessage(input: {
+  body: string | null | undefined;
+  statusKind: string | null | undefined;
+}): AgentRunErrorCode | null {
+  if (input.statusKind === "failed") {
+    return classifyFailedAgentMessage(input.body);
+  }
+  if (
+    input.statusKind !== "completed" ||
+    !input.body ||
+    input.body.length > COMPLETED_AUTH_MESSAGE_MAX_LENGTH
+  ) {
+    return null;
+  }
+  return COMPLETED_AUTH_MESSAGE_PATTERN.test(input.body.trim())
+    ? "auth_required"
+    : null;
+}
+
 /** True when detail text is a provider plan/payment gate (not a generic quota). */
 export function isProviderPlanLimitMessage(
   detail: string | null | undefined

--- a/packages/agent/gui/shared/agentMessageMarkdownLinks.ts
+++ b/packages/agent/gui/shared/agentMessageMarkdownLinks.ts
@@ -241,55 +241,6 @@ export function releaseCachedMarkdownMedia(
   }, CACHED_MARKDOWN_MEDIA_REVOKE_DELAY_MS);
 }
 
-export function isHttpUrl(value: string): boolean {
-  const candidate = value.trim();
-  if (!candidate || /\s/.test(candidate)) {
-    return false;
-  }
-  try {
-    const url = new URL(candidate);
-    return url.protocol === "http:" || url.protocol === "https:";
-  } catch {
-    return false;
-  }
-}
-
-export function linkBareLocalAbsolutePaths(content: string): string {
-  let out = "";
-  for (let index = 0; index < content.length; ) {
-    const markdownLinkEnd = markdownLinkEndIndex(content, index);
-    if (markdownLinkEnd > index) {
-      out += content.slice(index, markdownLinkEnd);
-      index = markdownLinkEnd;
-      continue;
-    }
-
-    const codeSpanEnd = codeSpanEndIndex(content, index);
-    if (codeSpanEnd > index) {
-      out += content.slice(index, codeSpanEnd);
-      index = codeSpanEnd;
-      continue;
-    }
-
-    if (isLocalPathStart(content, index)) {
-      const end = bareLocalPathEndIndex(content, index);
-      const rawPath = trimTrailingPathPunctuation(content.slice(index, end));
-      const trailing = content.slice(index + rawPath.length, end);
-      if (isLocalAbsolutePath(rawPath)) {
-        out += `[${escapeMarkdownLinkLabel(rawPath)}](${rawPath})${trailing}`;
-      } else {
-        out += content.slice(index, end);
-      }
-      index = end;
-      continue;
-    }
-
-    out += content[index];
-    index += 1;
-  }
-  return out;
-}
-
 export function normalizeLocalPathMarkdownLinks(content: string): string {
   let out = "";
   for (let index = 0; index < content.length; ) {
@@ -626,37 +577,4 @@ export function codeSpanEndIndex(content: string, index: number): number {
   const fence = "`".repeat(tickCount);
   const end = content.indexOf(fence, index + tickCount);
   return end < 0 ? -1 : end + tickCount;
-}
-
-export function isLocalPathStart(content: string, index: number): boolean {
-  if (content[index] !== "/" || content[index + 1] === "/") {
-    return false;
-  }
-  const previous = content[index - 1];
-  return (
-    previous === undefined ||
-    /\s/.test(previous) ||
-    previous === "(" ||
-    previous === "["
-  );
-}
-
-export function bareLocalPathEndIndex(content: string, index: number): number {
-  let end = index;
-  while (end < content.length) {
-    const char = content[end];
-    if (!char || /[\s<>[\](){}"'`]/.test(char)) {
-      break;
-    }
-    end += 1;
-  }
-  return end;
-}
-
-export function trimTrailingPathPunctuation(path: string): string {
-  return path.replace(/[.,;:!?，。；：！？]+$/g, "");
-}
-
-export function escapeMarkdownLinkLabel(label: string): string {
-  return label.replace(/([\\[\]])/g, "\\$1");
 }

--- a/services/tuttid/data/workspace/agent_store.go
+++ b/services/tuttid/data/workspace/agent_store.go
@@ -23,7 +23,7 @@ var _ agentactivitybiz.Repository = (*SQLiteStore)(nil)
 const legacyIDLocalCodex = "local-codex"
 const legacyIDLocalClaudeCode = "local-claude-code"
 
-func (s *SQLiteStore) newAgentStore(db *sql.DB) *agentstore.Store {
+func newAgentStore(db *sql.DB) *agentstore.Store {
 	return agentstore.New(db, agentstore.Options{
 		WorkspaceExists: func(ctx context.Context, workspaceID string) error {
 			return ensureWorkspaceExistsOn(ctx, db, workspaceID)

--- a/services/tuttid/data/workspace/migrations_workbench.go
+++ b/services/tuttid/data/workspace/migrations_workbench.go
@@ -121,7 +121,7 @@ func (s *SQLiteStore) applyWorkspaceWorkbenchAgentTargetIdentityV1(ctx context.C
 		return nil
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.writeDB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin AgentGUI target identity migration: %w", err)
 	}

--- a/services/tuttid/data/workspace/migrations_workbench_test.go
+++ b/services/tuttid/data/workspace/migrations_workbench_test.go
@@ -154,7 +154,7 @@ func TestSQLiteStoreMigrationFiltersAgentGUINodesWithoutValidTargetIdentity(t *t
 	if err := store.Create(ctx, workspacebiz.Summary{ID: workspaceID, Name: "Agent GUI Target Migration"}); err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 INSERT OR IGNORE INTO agent_targets (
   id, provider, launch_ref_json, name, icon_key, enabled, source,
   sort_order, created_at_ms, updated_at_ms
@@ -182,7 +182,7 @@ INSERT OR IGNORE INTO agent_targets (
 	}); err != nil {
 		t.Fatalf("PutWorkbenchSnapshot() error = %v", err)
 	}
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 DELETE FROM tuttid_schema_migrations WHERE id = ?
 `, schemaMigrationWorkspaceWorkbenchAgentTargetIdentityV1); err != nil {
 		t.Fatalf("delete migration marker: %v", err)

--- a/services/tuttid/data/workspace/sqlite_store.go
+++ b/services/tuttid/data/workspace/sqlite_store.go
@@ -46,7 +46,7 @@ func OpenSQLiteStore(dbPath string) (*SQLiteStore, error) {
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
 	store := &SQLiteStore{dbPath: dbPath, writeDB: db}
-	store.agentWriter = store.newAgentStore(db)
+	store.agentWriter = newAgentStore(db)
 
 	if _, err := db.Exec("PRAGMA journal_mode = WAL"); err != nil {
 		_ = store.Close()
@@ -114,7 +114,7 @@ func (s *SQLiteStore) openReadPool(ctx context.Context) error {
 	}
 
 	s.readDB = db
-	s.agentReader = s.newAgentStore(db)
+	s.agentReader = newAgentStore(db)
 	return nil
 }
 

--- a/services/tuttid/data/workspace/sqlite_store_test.go
+++ b/services/tuttid/data/workspace/sqlite_store_test.go
@@ -104,7 +104,7 @@ func TestSQLiteStoreReadsCommittedDataWhileWriterConnectionIsBusy(t *testing.T) 
 	if err != nil {
 		t.Fatalf("BeginTx() error = %v", err)
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 	if _, err := tx.ExecContext(ctx, "UPDATE workspaces SET name = ? WHERE id = ?", "Uncommitted", workspaceID); err != nil {
 		t.Fatalf("hold writer transaction: %v", err)
 	}

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -20,6 +20,7 @@ const liveModelDiscoveryDeleteDelay = 10 * time.Minute
 const liveModelDiscoveryLifecycleTimeout = 10 * time.Minute
 const claudeModelCatalogInvalidationDebugPrefix = "CLAUDE_MODEL_CATALOG_INVALIDATION_DEBUG"
 const agentExtensionComposerDebugPrefix = "AGENT_EXTENSION_COMPOSER_DEBUG"
+const hiddenModelDiscoveryTriggeredEvent = "agent.model_discovery.hidden_session_triggered"
 
 func logAgentExtensionComposerDebug(stage string, payload map[string]any) {
 	payload["stage"] = stage
@@ -28,6 +29,15 @@ func logAgentExtensionComposerDebug(stage string, payload map[string]any) {
 		encoded = []byte(`{"stage":"debug_payload_unavailable"}`)
 	}
 	slog.Info(agentExtensionComposerDebugPrefix, "payload_json", string(encoded))
+}
+
+func logHiddenModelDiscoveryTriggered(provider string, agentSessionID string) {
+	slog.Info(
+		"agent hidden model discovery session triggered",
+		"event", hiddenModelDiscoveryTriggeredEvent,
+		"provider", agentprovider.NormalizeOpen(provider),
+		"agent_session_id", strings.TrimSpace(agentSessionID),
+	)
 }
 
 var claudeModelCatalogDebugSafeFields = map[string]struct{}{
@@ -245,6 +255,7 @@ func (s *Service) discoverLiveComposerModelsUncachedForScope(
 		Speed:             stringPointer(strings.TrimSpace(settings.Speed)),
 		Visible:           &visible,
 	}
+	logHiddenModelDiscoveryTriggered(scope.provider, startInput.AgentSessionID)
 	session, err = func() (ProviderRuntimeSession, error) {
 		defer releaseStartup()
 		prepared, prepareErr := s.prepareRuntime(ctx, scope.workspaceID, resolvedCwd, startInput)

--- a/services/tuttid/service/agent/composer_live_model_discovery_test.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery_test.go
@@ -1,12 +1,43 @@
 package agent
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 )
+
+func TestHiddenModelDiscoveryTriggeredLogIsInfoAndSanitized(t *testing.T) {
+	var output bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&output, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	logHiddenModelDiscoveryTriggered("claude-code", "discovery-session-1")
+
+	logLine := output.String()
+	for _, expected := range []string{
+		"level=INFO",
+		"event=" + hiddenModelDiscoveryTriggeredEvent,
+		"provider=claude-code",
+		"agent_session_id=discovery-session-1",
+	} {
+		if !strings.Contains(logLine, expected) {
+			t.Fatalf("discovery trigger log %q does not contain %q", logLine, expected)
+		}
+	}
+	for _, sensitiveKey := range []string{"cwd=", "workspace_id=", "model=", "token="} {
+		if strings.Contains(logLine, sensitiveKey) {
+			t.Fatalf("discovery trigger log contains sensitive field %q: %q", sensitiveKey, logLine)
+		}
+	}
+}
 
 func TestClaudeModelCatalogDebugPayloadDropsSensitiveDiagnostics(t *testing.T) {
 	payload := claudeModelCatalogDebugPayload("discovery_uncached_failed", map[string]any{


### PR DESCRIPTION
## Summary

- stop auto-linking bare absolute paths, inline code, and URL-looking code; only explicit Markdown links remain actionable
- recover the standalone Claude Code `Not logged in · Please run /login` completed message as an authentication error card
- add regression coverage and document the recurring provider/runtime troubleshooting case

## Verification

- `pnpm --filter @tutti-os/agent-gui test` (186 files, 1676 tests)
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:changed` (8 lanes)
- staged Electron, UI, renderer, and Agent GUI degradation boundary hooks

## Fix Scope Justification

- Root cause: the Claude SDK can return its standalone login notice as successful completed output, while AgentGUI recovered environment errors only from failed messages; the Markdown layer also auto-linked bare slash-prefixed text such as `/login`.
- Why can this not be fixed at a lower layer? The canonical provider outcome should continue reflecting the SDK result. Error recovery and link actionability are presentation semantics already owned by AgentGUI, so changing daemon turn state would create a competing interpretation of provider lifecycle.

## Fallback Three Questions

- Source: a provider-owned standalone authentication notice can arrive as a completed assistant message without a typed visible error.
- Why can it not be fixed at that source? The third-party SDK controls the result shape, and changing canonical completion state would misrepresent the provider lifecycle.
- Removal condition: remove the narrow completed-message matcher once the provider or daemon emits a typed authentication error for this case; explicit Markdown link behavior remains the durable renderer rule.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source (not applicable; none changed).
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->