### PR TITLE
fix(tuttid): finish workspace write pool migration

### DIFF
--- a/services/tuttid/data/workspace/migrations_workbench.go
+++ b/services/tuttid/data/workspace/migrations_workbench.go
@@ -121,7 +121,7 @@ func (s *SQLiteStore) applyWorkspaceWorkbenchAgentTargetIdentityV1(ctx context.C
 		return nil
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.writeDB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin AgentGUI target identity migration: %w", err)
 	}

--- a/services/tuttid/data/workspace/migrations_workbench_test.go
+++ b/services/tuttid/data/workspace/migrations_workbench_test.go
@@ -154,7 +154,7 @@ func TestSQLiteStoreMigrationFiltersAgentGUINodesWithoutValidTargetIdentity(t *t
 	if err := store.Create(ctx, workspacebiz.Summary{ID: workspaceID, Name: "Agent GUI Target Migration"}); err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 INSERT OR IGNORE INTO agent_targets (
   id, provider, launch_ref_json, name, icon_key, enabled, source,
   sort_order, created_at_ms, updated_at_ms
@@ -182,7 +182,7 @@ INSERT OR IGNORE INTO agent_targets (
 	}); err != nil {
 		t.Fatalf("PutWorkbenchSnapshot() error = %v", err)
 	}
-	if _, err := store.db.ExecContext(ctx, `
+	if _, err := store.writeDB.ExecContext(ctx, `
 DELETE FROM tuttid_schema_migrations WHERE id = ?
 `, schemaMigrationWorkspaceWorkbenchAgentTargetIdentityV1); err != nil {
 		t.Fatalf("delete migration marker: %v", err)


### PR DESCRIPTION
## Summary

- use the SQLite writer pool for the remaining workbench migration transaction
- update migration fixtures to write through the writer pool

## Root cause

PR #1236 replaced `SQLiteStore.db` with separate `writeDB` and `readDB` pools, but the workbench target-identity migration and two test fixtures retained references to the removed `db` field. This makes current `main` fail Go compilation, including unrelated PRs rebased onto it.

## Fix Scope Justification

- Root cause: the first incorrect state is at the workspace SQLite storage boundary, where three remaining write operations reference a field removed by the read/write pool split.
- Why this cannot be fixed at a lower layer: `database/sql` and SQLite are functioning correctly; the invalid field references are in Tutti-owned migration code. Mapping these operations to the existing `writeDB` is the smallest owned-layer correction and preserves the pool architecture introduced by #1236.

## Validation

- `go test ./services/tuttid/data/workspace/...`
- `git diff --check`

The full Go workspace runner was also attempted without the generated builtin app artifact and failed only because `generated/tutti-onboarding/tutti-onboarding-0.1.0.zip` was absent; the affected package passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->