### PR TITLE
fix(agent-gui): target rail mutation refreshes

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -1617,6 +1617,7 @@ test("WorkspaceAgentActivityService lists deletion candidates with exact section
 
 test("WorkspaceAgentActivityService deletes one exact session batch", async () => {
   const calls: unknown[] = [];
+  let listCalls = 0;
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
       deleteWorkspaceAgentSessionsBatch: async (
@@ -1628,18 +1629,19 @@ test("WorkspaceAgentActivityService deletes one exact session batch", async () =
         calls.push({ request, workspaceId });
         return {
           removedMessages: 3,
-          removedSessionIds: ["session-1"],
-          removedSessions: 1
+          removedSessionIds: ["session-1", "child-1"],
+          removedSessions: 2
         };
       },
-      listWorkspaceAgentSessions: async (workspaceId: string) => ({
-        hasMore: false,
-        sessions: [],
-        workspaceId
-      })
+      listWorkspaceAgentSessions: async (workspaceId: string) => {
+        listCalls += 1;
+        return { hasMore: false, sessions: [], workspaceId };
+      }
     } as unknown as TuttidClient,
     runtimeApi: { logTerminalDiagnostic: async () => {} }
   });
+  const engine = service.getSessionEngine("ws-1");
+  await new Promise((resolve) => setImmediate(resolve));
 
   const result = await service.deleteSessionsBatch({
     sessionIds: ["session-1", "session-2"],
@@ -1654,8 +1656,60 @@ test("WorkspaceAgentActivityService deletes one exact session batch", async () =
   ]);
   assert.deepEqual(result, {
     removedMessages: 3,
-    removedSessionIds: ["session-1"],
-    removedSessions: 1
+    removedSessionIds: ["session-1", "child-1"],
+    removedSessions: 2
+  });
+  assert.equal(listCalls, 1);
+  assert.deepEqual(engine.getSnapshot().sessionLifecycle.deletedSessionIds, {
+    "child-1": true,
+    "session-1": true
+  });
+});
+
+test("WorkspaceAgentActivityService single delete uses the authoritative batch result without reloading", async () => {
+  const calls: unknown[] = [];
+  let listCalls = 0;
+  const service = new WorkspaceAgentActivityService({
+    tuttidClient: {
+      deleteWorkspaceAgentSessionsBatch: async (
+        workspaceId: string,
+        request: Parameters<
+          TuttidClient["deleteWorkspaceAgentSessionsBatch"]
+        >[1]
+      ) => {
+        calls.push({ request, workspaceId });
+        return {
+          removedMessages: 2,
+          removedSessionIds: ["session-1", "child-1"],
+          removedSessions: 2
+        };
+      },
+      listWorkspaceAgentSessions: async (workspaceId: string) => {
+        listCalls += 1;
+        return { hasMore: false, sessions: [], workspaceId };
+      }
+    } as unknown as TuttidClient,
+    runtimeApi: { logTerminalDiagnostic: async () => {} }
+  });
+  const engine = service.getSessionEngine("ws-1");
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const result = await service.deleteSession({
+    agentSessionId: "session-1",
+    workspaceId: "ws-1"
+  });
+
+  assert.deepEqual(result, { removed: true });
+  assert.deepEqual(calls, [
+    {
+      request: { sessionIds: ["session-1"] },
+      workspaceId: "ws-1"
+    }
+  ]);
+  assert.equal(listCalls, 1);
+  assert.deepEqual(engine.getSnapshot().sessionLifecycle.deletedSessionIds, {
+    "child-1": true,
+    "session-1": true
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -305,9 +305,6 @@ export class WorkspaceAgentActivityService
         workspaceId
       });
     }
-    if (removedSessionIds.length > 0) {
-      await this.load(workspaceId, input.signal);
-    }
     return {
       removedMessages: response.removedMessages,
       removedSessionIds,
@@ -627,17 +624,12 @@ export class WorkspaceAgentActivityService
   ) {
     const workspaceId = normalizeWorkspaceId(input.workspaceId);
     const agentSessionId = input.agentSessionId.trim();
-    const entry = this.entry(workspaceId);
-    const result = await entry.adapter.deleteSession(input);
-    if (result.removed) {
-      this.markSessionDeleted({
-        agentSessionId,
-        data: { deletedAtUnixMs: Date.now() },
-        workspaceId
-      });
-      await this.load(workspaceId, input.signal);
-    }
-    return result;
+    const result = await this.deleteSessionsBatch({
+      sessionIds: [agentSessionId],
+      signal: input.signal,
+      workspaceId
+    });
+    return { removed: result.removedSessionIds.includes(agentSessionId) };
   }
 
   async renameSession(

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1474,13 +1474,23 @@ cursor, and totals; only an unresolved or newly selected scope may resolve to an
 empty failure state.
 Section-query `pending` has two presentation meanings. An unresolved first page
 is blocking and may reveal the delayed rail skeleton. A same-scope membership
-refresh, including pin or unpin invalidation, is non-blocking: keep the resolved
-membership visible and interactive until the authoritative daemon page replaces
-it. A scope change may also keep the previous page visible to avoid destructive
-layout churn, but actions whose section or target scope could be stale remain
-locked until the new scope resolves. Derive these meanings inside the dedicated
-rail query controller from its current and resolved scope keys; do not add engine
-state, manually move rows, or make the view reinterpret raw request state.
+refresh is non-blocking: keep the resolved membership visible and interactive
+until authoritative daemon pages replace it. Session mutation responses first
+update or tombstone canonical engine entities. The rail query controller then
+compares before/after membership and reloads only affected first pages: ordinary
+delete reloads its section, pinned delete reloads pinned, and pin/unpin reloads
+both pinned and the session's ordinary section. Rename does not reload section
+pages; an active backend search is reissued because title changes can alter its
+membership. Targeted pages resolve together before replacing cache state. A
+targeted failure keeps old page state and transient canonical overlays, and
+leaves that scope cache stale for later authoritative bootstrap. It must not
+fall back to `listSessionSections` or a workspace activity `load`. A scope
+change may also keep the previous page visible to avoid destructive layout
+churn, but actions whose section or target scope could be stale remain locked
+until the new scope resolves. Derive these meanings inside the dedicated rail
+query controller from its current and resolved scope keys; do not add engine
+mutation state, manually move rows, or make the view reinterpret raw request
+state.
 The active conversation is a
 display overlay, not a pageable row: it may render beside the first five rows,
 but it must not consume the local visible-item limit or advance the cursor.
@@ -1535,17 +1545,18 @@ reconciliation of one of those entities is not new rail membership and must
 preserve every loaded section page and cursor. Entity-list order or count must
 not serve directly as a section-query invalidation key; rail invalidation must
 account for membership already owned by loaded section pages.
-First-page section refetches are reserved for workspace, rail filter, user
-project, or session membership changes; Show more continues to use the section
-page endpoint.
+The aggregate first-page section query is reserved for workspace, rail filter,
+or user-project inventory changes. Session membership changes use only the
+affected section/pinned first-page endpoints; Show more continues to use the
+same page endpoints with its cursor.
 Pending activation becoming canonical is one of those session membership
 changes, even while that session remains active. The rail query controller must
-retain the session id as reconciliation metadata, refetch section first pages,
-and let the pure display projection join and sort the canonical engine entity
-until a successful daemon response replaces the membership cache. Active
-selection alone must never suppress this invalidation; historical active-detail
-hydration without pending-activation provenance remains an entity update and
-must preserve loaded pages and cursors.
+retain the session id as reconciliation metadata, refetch its exact section
+first page, and let the pure display projection join and sort the canonical
+engine entity until a successful daemon response replaces the membership cache.
+Active selection alone must never suppress this invalidation; historical
+active-detail hydration without pending-activation provenance remains an entity
+update and must preserve loaded pages and cursors.
 During rail-filter refetches, keep the previously rendered section chrome in
 place for short reloads. Provider/agent switching should not briefly unmount
 the project rail header or replace a populated rail with an empty/skeleton

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -486,26 +486,29 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   as `pinnedAtUnixMs` into the runtime projection. If that merge keeps the older
   runtime timestamp, the frontend's monotonic session reducer correctly rejects
   the whole stale response, including the new pin value.
-  When the entity update is accepted, pin membership still requires an
-  authoritative section refresh. Treating every pending section request as an
-  unresolved list load turns that same-scope background refresh into a blocking
-  skeleton even though valid membership is already available.
+  When the entity update is accepted, pin membership still requires
+  authoritative pinned and ordinary first-page reads. Triggering an aggregate
+  section query or workspace activity load turns that narrow reconciliation
+  into a multi-second blocking reload on large histories.
 - Fix:
   Merge session freshness monotonically across runtime and persistence using
   the newer timestamp. Pin responses that advance the session version must also
   include protocol-v2 active/latest turn state so accepting the metadata update
   cannot clear a running turn. Do not weaken frontend version checks or hide the
-  mismatch behind delayed refetches. For an accepted membership update, keep the
-  resolved section page visible during the same-scope refresh and reveal the rail
-  skeleton only when no first page has resolved. Lock scope-sensitive actions
-  only while the displayed membership belongs to a different or unresolved
-  scope; do not patch daemon-owned membership locally.
+  mismatch behind delayed refetches. For an accepted membership update, compare
+  canonical before/after membership and request only pinned plus the exact
+  ordinary section page. Keep resolved pages visible and use the canonical row
+  as a transient overlay until both responses apply atomically. Do not call
+  `listSessionSections` or workspace `load` from delete, pin/unpin, or rename.
+  Lock scope-sensitive actions only while displayed membership belongs to a
+  different or unresolved scope; do not patch daemon-owned membership locally.
 - Validation:
   Cover a live runtime session whose persisted pin update is newer, a newer
   runtime snapshot that must not regress, and a running turn that remains
   attached to the pin response. Run `go test ./services/tuttid/service/agent`
-  plus daemon lint, tests, and build. Add controller coverage for initial load,
-  same-scope membership refresh, scope change, and stale request cancellation.
+  plus daemon lint, tests, and build. Add controller coverage proving a
+  same-scope pin/unpin calls only the pinned and exact ordinary page endpoints,
+  keeps `pending=false`, and does not call the aggregate section endpoint.
 - References:
   [service.go](../../../services/tuttid/service/agent/service.go)
   [service_session.go](../../../services/tuttid/service/agent/service_session.go)

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
@@ -64,7 +64,7 @@ describe("AgentGUIConversationRailQueryController", () => {
     }
   });
 
-  it("locks unresolved scopes but keeps same-scope pin refreshes interactive", async () => {
+  it("keeps pin refreshes interactive and reloads only affected pages", async () => {
     const engine = createTestAgentSessionEngine();
     const session = normalizeAgentActivitySession({
       activeTurnId: null,
@@ -74,42 +74,56 @@ describe("AgentGUIConversationRailQueryController", () => {
       latestTurnInteractions: [],
       pendingInteractions: [],
       provider: "codex",
+      railSectionKey: "conversations",
       title: "Session",
       updatedAtUnixMs: 1,
       workspaceId: "test-workspace"
     });
     const sectionResolvers: Array<() => void> = [];
-    const diagnosticLogger = vi.fn();
+    const listPinnedSessionsPage = vi.fn(async () => ({
+      hasMore: false,
+      sessions: [{ ...session, pinnedAtUnixMs: 100, updatedAtUnixMs: 2 }],
+      totalCount: 1
+    }));
+    const listSessionSectionPage = vi.fn(async (input) => ({
+      hasMore: false,
+      kind: "conversations" as const,
+      sectionKey: input.sectionKey,
+      sessions: [],
+      totalCount: 0
+    }));
+    const listSessionSections = vi.fn(
+      (input) =>
+        new Promise<
+          Awaited<
+            ReturnType<
+              NonNullable<ConversationRailQueryRuntime["listSessionSections"]>
+            >
+          >
+        >((resolve) => {
+          sectionResolvers.push(() =>
+            resolve({
+              sections: [
+                {
+                  hasMore: false,
+                  kind: "conversations",
+                  sectionKey: "conversations",
+                  sessions: [session],
+                  totalCount: 1
+                }
+              ],
+              workspaceId: input.workspaceId
+            })
+          );
+        })
+    );
     const controller = new AgentGUIConversationRailQueryController({
-      diagnosticLogger,
-      diagnosticSlowThresholdMs: 0,
       engine,
       getActiveConversationId: () => null,
       runtime: {
-        listSessionSections: (input) =>
-          new Promise((resolve) => {
-            sectionResolvers.push(() =>
-              resolve({
-                sections: [
-                  {
-                    hasMore: false,
-                    kind: "conversations",
-                    sectionKey: "conversations",
-                    sessions: [session],
-                    totalCount: 1
-                  }
-                ],
-                workspaceId: input.workspaceId
-              })
-            );
-          }),
-        listSessionSectionPage: async (input) => ({
-          hasMore: false,
-          kind: "conversations",
-          sectionKey: input.sectionKey,
-          sessions: [],
-          totalCount: 0
-        }),
+        listPinnedSessionsPage,
+        listSessionSections,
+        listSessionSectionPage,
         listSessionsPage: async (input) => ({
           hasMore: false,
           sessions: [],
@@ -142,20 +156,14 @@ describe("AgentGUIConversationRailQueryController", () => {
         updatedAtUnixMs: 2
       }
     });
-    expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(true);
+    expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false);
     expect(controller.getSnapshot().runtimeRailMemberships).toHaveLength(1);
     expect(controller.isInteractionLocked()).toBe(false);
-
-    sectionResolvers.shift()?.();
     await vi.waitFor(() =>
-      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
+      expect(listPinnedSessionsPage).toHaveBeenCalledTimes(1)
     );
-    expect(diagnosticLogger).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        refreshReason: "membership_change",
-        returnedSessionCount: 1
-      })
-    );
+    expect(listSessionSectionPage).toHaveBeenCalledTimes(1);
+    expect(listSessionSections).toHaveBeenCalledTimes(1);
 
     controller.configure({
       conversationFilter: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -31,45 +31,24 @@ import { projectConversationRailMembershipRecords } from "../model/agentGuiConve
 import {
   applyCachedConversationRailQuery,
   cachedConversationRailQueryFromFirstPages,
+  replaceConversationRailFirstPages,
   updateConversationRailSectionPageState,
   writeConversationRailQueryCache,
   type CachedConversationRailQuery
 } from "./agentGuiConversationRailQueryCache";
 import {
   buildConversationRailQuerySnapshot,
+  EMPTY_CONVERSATION_SEARCH_QUERY_STATE,
   EMPTY_CONVERSATION_RAIL_QUERY_STATE,
   type AgentGUIConversationRailQuerySnapshot
 } from "./agentGuiConversationRailQuerySnapshot";
+import { AgentGUIConversationRailTargetedPageRefresher } from "./AgentGUIConversationRailTargetedPageRefresher";
 
 export type { AgentGUIConversationRailQuerySnapshot } from "./agentGuiConversationRailQuerySnapshot";
 
 const SECTION_PAGE_SIZE = 5;
-const SEARCH_PAGE_SIZE = 100;
 export const CONVERSATION_SEARCH_DEBOUNCE_MS = 300;
 export const CONVERSATION_RAIL_QUERY_CACHE_FRESH_MS = 30_000;
-
-interface ConversationSearchQueryState {
-  failed: boolean;
-  hasMore: boolean;
-  loadingMore: boolean;
-  nextCursor: string | null;
-  pending: boolean;
-  requestKey: string | null;
-  resolvedQuery: string;
-  sessionIds: readonly string[];
-}
-
-const EMPTY_SEARCH_STATE: ConversationSearchQueryState = {
-  failed: false,
-  hasMore: false,
-  loadingMore: false,
-  nextCursor: null,
-  pending: false,
-  requestKey: null,
-  resolvedQuery: "",
-  sessionIds: []
-};
-
 export interface ConversationRailQueryScope {
   conversationFilter: AgentGUINodeViewModel["rail"]["conversationFilter"];
   previewMode: boolean;
@@ -129,8 +108,9 @@ export class AgentGUIConversationRailQueryController {
   private readonly sessionSectionsQueryCache: WorkspaceQueryCache<CachedConversationRailQuery>;
   private readonly providerSwitchDiagnostics: ConversationRailProviderSwitchDiagnosticTracker;
   private readonly pagingAbortControllers = new Map<string, AbortController>();
+  private readonly targetedPageRefresher: AgentGUIConversationRailTargetedPageRefresher;
   private queryState = EMPTY_CONVERSATION_RAIL_QUERY_STATE;
-  private searchState = EMPTY_SEARCH_STATE;
+  private searchState = EMPTY_CONVERSATION_SEARCH_QUERY_STATE;
   private snapshot!: AgentGUIConversationRailQuerySnapshot;
   private scope: ConversationRailQueryScope | null = null;
   private sectionAgentTargetId = "";
@@ -176,6 +156,20 @@ export class AgentGUIConversationRailQueryController {
       createWorkspaceQueryCache<CachedConversationRailQuery>();
     this.scheduler = input.scheduler ?? agentGuiScheduler;
     this.workspaceId = input.workspaceId;
+    this.targetedPageRefresher =
+      new AgentGUIConversationRailTargetedPageRefresher({
+        onResolved: (pages) => {
+          this.upsertSessions(pages.flatMap(({ page }) => page.sessions));
+          this.queryState = replaceConversationRailFirstPages({
+            pages,
+            queryState: this.queryState
+          });
+          this.writeCurrentQueryCache();
+          this.emit();
+        },
+        runtime: this.runtime,
+        workspaceId: this.workspaceId
+      });
     this.previousMembershipRecords = projectConversationRailMembershipRecords(
       this.engine.getSnapshot()
     );
@@ -228,6 +222,7 @@ export class AgentGUIConversationRailQueryController {
     if (!scopeChanged) return;
 
     this.cancelPagingRequests();
+    this.targetedPageRefresher.cancel();
     this.queryState = {
       ...this.queryState,
       pending: this.runtimeSectionsEnabled(),
@@ -391,7 +386,7 @@ export class AgentGUIConversationRailQueryController {
     void listSessionsPage({
       agentTargetId: this.sectionAgentTargetId || undefined,
       cursor: this.searchState.nextCursor ?? undefined,
-      limit: SEARCH_PAGE_SIZE,
+      limit: 100,
       searchQuery: this.searchQuery,
       signal: abortController.signal,
       workspaceId: this.workspaceId
@@ -446,13 +441,17 @@ export class AgentGUIConversationRailQueryController {
     }
     const plan = planRuntimeRailMembershipRefresh({
       activeConversationId: this.getActiveConversationId(),
+      agentTargetId: this.sectionAgentTargetId || null,
       loadedSections: this.queryState.sections,
       next,
-      previous: this.previousMembershipRecords
+      previous: this.previousMembershipRecords,
+      searchActive: Boolean(this.searchQuery && this.searchEnabled())
     });
     this.previousMembershipRecords = next;
-    if (plan.kind !== "refresh_first_pages") return;
-    this.sessionSectionsQueryCache.invalidate();
+    if (plan.kind !== "refresh_pages") return;
+    if (plan.pageIds.length > 0 && this.railSectionQueryKey) {
+      this.sessionSectionsQueryCache.invalidate(this.railSectionQueryKey);
+    }
     this.queryState = {
       ...this.queryState,
       reconcilingSessionIds: mergeConversationRailSessionIds(
@@ -461,7 +460,12 @@ export class AgentGUIConversationRailQueryController {
       )
     };
     this.emit();
-    this.refreshFirstPages("membership_change");
+    if (plan.refreshSearch) this.requestSearch();
+    this.cancelPagingRequests();
+    this.targetedPageRefresher.refresh({
+      agentTargetId: this.sectionAgentTargetId,
+      pageIds: plan.pageIds
+    });
   }
 
   private refreshFirstPages(
@@ -646,7 +650,7 @@ export class AgentGUIConversationRailQueryController {
     this.searchAbortController = null;
     const listSessionsPage = this.runtime.listSessionsPage;
     if (!this.searchRequestKey || !listSessionsPage) {
-      this.searchState = EMPTY_SEARCH_STATE;
+      this.searchState = EMPTY_CONVERSATION_SEARCH_QUERY_STATE;
       this.emit();
       return;
     }
@@ -655,14 +659,14 @@ export class AgentGUIConversationRailQueryController {
     const abortController = new AbortController();
     this.searchAbortController = abortController;
     this.searchState = {
-      ...EMPTY_SEARCH_STATE,
+      ...EMPTY_CONVERSATION_SEARCH_QUERY_STATE,
       pending: true,
       requestKey
     };
     this.emit();
     void listSessionsPage({
       agentTargetId: this.sectionAgentTargetId || undefined,
-      limit: SEARCH_PAGE_SIZE,
+      limit: 100,
       searchQuery: query,
       signal: abortController.signal,
       workspaceId: this.workspaceId
@@ -697,7 +701,7 @@ export class AgentGUIConversationRailQueryController {
           return;
         }
         this.searchState = {
-          ...EMPTY_SEARCH_STATE,
+          ...EMPTY_CONVERSATION_SEARCH_QUERY_STATE,
           failed: true,
           requestKey,
           resolvedQuery: query
@@ -735,11 +739,10 @@ export class AgentGUIConversationRailQueryController {
   }
 
   private upsertSessions(sessions: readonly AgentActivitySession[]): void {
+    if (sessions.length === 0) return;
     this.ingestingSessions = true;
     try {
-      for (const session of sessions) {
-        this.engine.dispatch({ type: "session/upserted", session });
-      }
+      this.engine.dispatch({ type: "session/snapshotReceived", sessions });
     } finally {
       this.ingestingSessions = false;
       this.previousMembershipRecords = projectConversationRailMembershipRecords(
@@ -786,6 +789,7 @@ export class AgentGUIConversationRailQueryController {
     this.unsubscribeEngine?.();
     this.unsubscribeEngine = null;
     this.cancelPagingRequests();
+    this.targetedPageRefresher.cancel();
     this.clearSearchDebounceTimer();
     this.searchRequestSequence += 1;
     this.searchAbortController?.abort();

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailTargetedPageRefresher.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailTargetedPageRefresher.ts
@@ -1,0 +1,106 @@
+import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
+import type { ConversationRailRefreshedPage } from "./agentGuiConversationRailQueryCache";
+
+const SECTION_PAGE_SIZE = 5;
+
+type TargetedPageRuntime = Pick<
+  AgentActivityRuntime,
+  "listPinnedSessionsPage" | "listSessionSectionPage"
+>;
+
+export class AgentGUIConversationRailTargetedPageRefresher {
+  private abortController: AbortController | null = null;
+  private readonly pendingPageIds = new Set<string>();
+  private requestSequence = 0;
+
+  constructor(
+    private readonly input: {
+      onFailed?(): void;
+      onResolved(pages: readonly ConversationRailRefreshedPage[]): void;
+      runtime: TargetedPageRuntime;
+      workspaceId: string;
+    }
+  ) {}
+
+  refresh(input: { agentTargetId: string; pageIds: readonly string[] }): void {
+    for (const pageId of input.pageIds) this.pendingPageIds.add(pageId);
+    if (this.pendingPageIds.size === 0) return;
+
+    this.abortController?.abort();
+    const abortController = new AbortController();
+    this.abortController = abortController;
+    const requestSequence = ++this.requestSequence;
+    const pageIds = [...this.pendingPageIds];
+    const requests = pageIds.flatMap((id) => {
+      if (id === "pinned") {
+        const listPage = this.input.runtime.listPinnedSessionsPage;
+        return listPage
+          ? [
+              listPage({
+                agentTargetId: input.agentTargetId || undefined,
+                limit: SECTION_PAGE_SIZE,
+                signal: abortController.signal,
+                workspaceId: this.input.workspaceId
+              }).then(
+                (page): ConversationRailRefreshedPage => ({
+                  kind: "pinned",
+                  page
+                })
+              )
+            ]
+          : [];
+      }
+      const listPage = this.input.runtime.listSessionSectionPage;
+      return listPage
+        ? [
+            listPage({
+              agentTargetId: input.agentTargetId || undefined,
+              limit: SECTION_PAGE_SIZE,
+              sectionKey: id,
+              signal: abortController.signal,
+              workspaceId: this.input.workspaceId
+            }).then(
+              (page): ConversationRailRefreshedPage => ({
+                id,
+                kind: "section",
+                page
+              })
+            )
+          ]
+        : [];
+    });
+    if (requests.length !== pageIds.length) {
+      for (const id of pageIds) this.pendingPageIds.delete(id);
+      this.input.onFailed?.();
+      return;
+    }
+    void Promise.all(requests)
+      .then((pages) => {
+        if (
+          abortController.signal.aborted ||
+          requestSequence !== this.requestSequence
+        ) {
+          return;
+        }
+        for (const id of pageIds) this.pendingPageIds.delete(id);
+        this.input.onResolved(pages);
+      })
+      .catch(() => {
+        if (
+          abortController.signal.aborted ||
+          requestSequence !== this.requestSequence
+        ) {
+          return;
+        }
+        for (const id of pageIds) this.pendingPageIds.delete(id);
+        this.input.onFailed?.();
+      });
+  }
+
+  cancel(): void {
+    this.requestSequence += 1;
+    this.abortController?.abort();
+    this.abortController = null;
+    this.pendingPageIds.clear();
+  }
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryCache.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryCache.ts
@@ -1,5 +1,9 @@
 import type { AgentActivitySession } from "@tutti-os/agent-activity-core";
-import type { AgentActivityRuntimeSessionSectionsResult } from "../../../agentActivityRuntime";
+import type {
+  AgentActivityRuntimeSessionPage,
+  AgentActivityRuntimeSessionSection,
+  AgentActivityRuntimeSessionSectionsResult
+} from "../../../agentActivityRuntime";
 import type {
   WorkspaceQueryCache,
   WorkspaceQueryCacheEntry
@@ -16,6 +20,14 @@ export interface CachedConversationRailQuery {
   sectionCount: number;
   sessions: readonly AgentActivitySession[];
 }
+
+export type ConversationRailRefreshedPage =
+  | { kind: "pinned"; page: AgentActivityRuntimeSessionPage }
+  | {
+      id: string;
+      kind: "section";
+      page: AgentActivityRuntimeSessionSection;
+    };
 
 export function cachedConversationRailQueryFromFirstPages(
   page: AgentActivityRuntimeSessionSectionsResult,
@@ -88,6 +100,61 @@ export function writeConversationRailQueryCache(input: {
     sectionCount: queryState.sections.length,
     sessions: []
   });
+}
+
+export function replaceConversationRailFirstPages(input: {
+  pages: readonly ConversationRailRefreshedPage[];
+  queryState: ConversationRailQueryState;
+}): ConversationRailQueryState {
+  let sections = [...(input.queryState.sections ?? [])];
+  let sectionPageStates = input.queryState.sectionPageStates;
+  for (const refreshed of input.pages) {
+    const sectionId = refreshed.kind === "pinned" ? "pinned" : refreshed.id;
+    sectionPageStates = updateConversationRailSectionPageState(
+      sectionPageStates,
+      sectionId,
+      conversationRailPageState(refreshed.page)
+    );
+    const projected =
+      refreshed.kind === "pinned"
+        ? projectRuntimeSectionsToConversationRailMemberships({
+            pinned: refreshed.page,
+            sections: []
+          })[0]
+        : projectRuntimeSectionsToConversationRailMemberships({
+            sections: [refreshed.page]
+          })[0];
+    const existingIndex = sections.findIndex(
+      (section) => section.id === sectionId
+    );
+    if (!projected) {
+      if (existingIndex >= 0) sections.splice(existingIndex, 1);
+      continue;
+    }
+    if (existingIndex >= 0) {
+      sections[existingIndex] = projected;
+      continue;
+    }
+    if (projected.kind === "pinned") {
+      sections.unshift(projected);
+      continue;
+    }
+    const conversationsIndex = sections.findIndex(
+      (section) => section.kind === "conversations"
+    );
+    if (projected.kind === "project" && conversationsIndex >= 0) {
+      sections.splice(conversationsIndex, 0, projected);
+    } else {
+      sections.push(projected);
+    }
+  }
+  return {
+    ...input.queryState,
+    pending: false,
+    reconcilingSessionIds: [],
+    sectionPageStates,
+    sections
+  };
 }
 
 export function updateConversationRailSectionPageState<T>(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQuerySnapshot.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQuerySnapshot.ts
@@ -11,6 +11,29 @@ export const EMPTY_CONVERSATION_RAIL_QUERY_STATE: ConversationRailQueryState = {
   sections: null
 };
 
+export interface ConversationSearchQueryState {
+  failed: boolean;
+  hasMore: boolean;
+  loadingMore: boolean;
+  nextCursor: string | null;
+  pending: boolean;
+  requestKey: string | null;
+  resolvedQuery: string;
+  sessionIds: readonly string[];
+}
+
+export const EMPTY_CONVERSATION_SEARCH_QUERY_STATE: ConversationSearchQueryState =
+  {
+    failed: false,
+    hasMore: false,
+    loadingMore: false,
+    nextCursor: null,
+    pending: false,
+    requestKey: null,
+    resolvedQuery: "",
+    sessionIds: []
+  };
+
 export interface AgentGUIConversationRailQuerySnapshot {
   railSearch: {
     enabled: boolean;
@@ -34,15 +57,7 @@ export function buildConversationRailQuerySnapshot(input: {
   searchEnabled: boolean;
   searchQuery: string;
   searchRequestKey: string | null;
-  searchState: {
-    failed: boolean;
-    hasMore: boolean;
-    loadingMore: boolean;
-    pending: boolean;
-    requestKey: string | null;
-    resolvedQuery: string;
-    sessionIds: readonly string[];
-  };
+  searchState: ConversationSearchQueryState;
 }): AgentGUIConversationRailQuerySnapshot {
   const searchResolved =
     input.searchState.requestKey === input.searchRequestKey &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.spec.ts
@@ -27,6 +27,7 @@ function conversation(
   pinnedAtUnixMs: number | null = null
 ): AgentGUIConversationSummary {
   return {
+    agentTargetId: "local:codex",
     cwd: "/workspace",
     id,
     pinnedAtUnixMs,
@@ -143,7 +144,12 @@ describe("planRuntimeRailMembershipRefresh", () => {
         next: [conversation("brand-new"), recent],
         previous: [recent]
       })
-    ).toEqual({ kind: "refresh_first_pages", reconcilingSessionIds: [] });
+    ).toEqual({
+      kind: "refresh_pages",
+      pageIds: ["project:/workspace"],
+      reconcilingSessionIds: [],
+      refreshSearch: false
+    });
   });
 
   it("refreshes for removal and pin membership changes", () => {
@@ -156,14 +162,24 @@ describe("planRuntimeRailMembershipRefresh", () => {
         next: [first],
         previous: [first, second]
       })
-    ).toEqual({ kind: "refresh_first_pages", reconcilingSessionIds: [] });
+    ).toEqual({
+      kind: "refresh_pages",
+      pageIds: ["project:/workspace"],
+      reconcilingSessionIds: [],
+      refreshSearch: false
+    });
     expect(
       planRuntimeRailMembershipRefresh({
         loadedSections: membership([first]),
         next: [conversation("first", 100)],
         previous: [first]
       })
-    ).toEqual({ kind: "refresh_first_pages", reconcilingSessionIds: [] });
+    ).toEqual({
+      kind: "refresh_pages",
+      pageIds: ["project:/workspace", "pinned"],
+      reconcilingSessionIds: [],
+      refreshSearch: false
+    });
   });
 
   it("ignores pending activation add and removal", () => {
@@ -217,8 +233,28 @@ describe("planRuntimeRailMembershipRefresh", () => {
         previous: [pending, recent]
       })
     ).toEqual({
-      kind: "refresh_first_pages",
-      reconcilingSessionIds: ["new-session"]
+      kind: "refresh_pages",
+      pageIds: ["project:/workspace"],
+      reconcilingSessionIds: ["new-session"],
+      refreshSearch: false
+    });
+  });
+
+  it("refreshes search only when a title changes under an active query", () => {
+    const previous = conversation("session-1");
+
+    expect(
+      planRuntimeRailMembershipRefresh({
+        loadedSections: membership([previous]),
+        next: [{ ...previous, title: "Renamed" }],
+        previous: [previous],
+        searchActive: true
+      })
+    ).toEqual({
+      kind: "refresh_pages",
+      pageIds: [],
+      reconcilingSessionIds: [],
+      refreshSearch: true
     });
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts
@@ -40,6 +40,12 @@ export interface ConversationRailQueryState {
   sections: ConversationRailSectionMembership[] | null;
 }
 
+export {
+  planRuntimeRailMembershipRefresh,
+  type ConversationRailMembershipRecord,
+  type ConversationRailMembershipRefreshPlan
+} from "./agentGuiConversationRailMembershipRefresh";
+
 export function isConversationRailInitialLoadPending(input: {
   pending: boolean;
   runtimeSectionsEnabled: boolean;
@@ -408,97 +414,6 @@ export function projectConversationRailSectionsByExactKey(input: {
     sections,
     includeEmptySections: input.includeEmptySections
   });
-}
-
-export type ConversationRailMembershipRefreshPlan =
-  | { kind: "none" }
-  | {
-      kind: "refresh_first_pages";
-      reconcilingSessionIds: readonly string[];
-    };
-
-export interface ConversationRailMembershipRecord {
-  id: string;
-  pinnedAtUnixMs?: number | null;
-  projectionSource?: "pending_activation";
-}
-
-export function planRuntimeRailMembershipRefresh(input: {
-  activeConversationId?: string | null;
-  loadedSections: readonly ConversationRailSectionMembership[] | null;
-  next: readonly ConversationRailMembershipRecord[];
-  previous: readonly ConversationRailMembershipRecord[];
-}): ConversationRailMembershipRefreshPlan {
-  const previousPendingIds = new Set(
-    input.previous.flatMap((conversation) => {
-      const id = conversation.id.trim();
-      return conversation.projectionSource === "pending_activation" && id
-        ? [id]
-        : [];
-    })
-  );
-  const previousConversations = input.previous.filter(
-    (conversation) => conversation.projectionSource !== "pending_activation"
-  );
-  const nextConversations = input.next.filter(
-    (conversation) => conversation.projectionSource !== "pending_activation"
-  );
-  const previousById = new Map(
-    previousConversations.flatMap((conversation) => {
-      const id = conversation.id.trim();
-      return id ? [[id, conversation] as const] : [];
-    })
-  );
-  const nextById = new Map(
-    nextConversations.flatMap((conversation) => {
-      const id = conversation.id.trim();
-      return id ? [[id, conversation] as const] : [];
-    })
-  );
-  const loadedIds = new Set(
-    (input.loadedSections ?? []).flatMap((section) =>
-      section.sessionIds.map((id) => id.trim()).filter(Boolean)
-    )
-  );
-
-  let requiresRefresh = false;
-  const reconcilingSessionIds: string[] = [];
-  for (const id of previousById.keys()) {
-    if (!nextById.has(id)) {
-      requiresRefresh = true;
-    }
-  }
-  for (const [id, conversation] of nextById) {
-    const previous = previousById.get(id);
-    if (!previous) {
-      if (previousPendingIds.has(id)) {
-        if (!loadedIds.has(id)) {
-          requiresRefresh = true;
-          reconcilingSessionIds.push(id);
-        }
-        continue;
-      }
-      if (id === (input.activeConversationId?.trim() ?? "")) {
-        continue;
-      }
-      // Section pages can expose historical rows outside the engine's bounded
-      // session snapshot. Hydrating one of those rows adds an entity, not rail
-      // membership; keep every already-loaded page and cursor intact.
-      if (!loadedIds.has(id)) {
-        requiresRefresh = true;
-      }
-      continue;
-    }
-    if ((previous.pinnedAtUnixMs ?? 0) !== (conversation.pinnedAtUnixMs ?? 0)) {
-      requiresRefresh = true;
-    }
-  }
-  return requiresRefresh
-    ? {
-        kind: "refresh_first_pages",
-        reconcilingSessionIds
-      }
-    : { kind: "none" };
 }
 
 export function mergeConversationRailSessionIds(

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailMembershipRecords.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailMembershipRecords.ts
@@ -14,8 +14,11 @@ export function projectConversationRailMembershipRecords(
   );
   return [
     ...sessions.map((item) => ({
+      agentTargetId: item.session.agentTargetId,
       id: item.session.agentSessionId,
-      pinnedAtUnixMs: item.session.pinnedAtUnixMs ?? null
+      pinnedAtUnixMs: item.session.pinnedAtUnixMs ?? null,
+      railSectionKey: item.session.railSectionKey?.trim() || null,
+      title: item.session.title
     })),
     ...selectPendingActivations(state)
       .filter(
@@ -25,9 +28,12 @@ export function projectConversationRailMembershipRecords(
           !canonicalIds.has(record.agentSessionId)
       )
       .map((record) => ({
+        agentTargetId: record.agentTargetId,
         id: record.agentSessionId,
         pinnedAtUnixMs: null,
-        projectionSource: "pending_activation" as const
+        projectionSource: "pending_activation" as const,
+        railSectionKey: null,
+        title: record.title ?? ""
       }))
   ];
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailMembershipRefresh.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailMembershipRefresh.ts
@@ -1,0 +1,110 @@
+import type { ConversationRailSectionMembership } from "./agentGuiConversationRail";
+
+export interface ConversationRailMembershipRecord {
+  agentTargetId?: string | null;
+  id: string;
+  pinnedAtUnixMs?: number | null;
+  projectionSource?: "pending_activation";
+  railSectionKey?: string | null;
+  title: string;
+}
+
+export type ConversationRailMembershipRefreshPlan =
+  | { kind: "none" }
+  | {
+      kind: "refresh_pages";
+      pageIds: readonly string[];
+      reconcilingSessionIds: readonly string[];
+      refreshSearch: boolean;
+    };
+
+export function planRuntimeRailMembershipRefresh(input: {
+  activeConversationId?: string | null;
+  agentTargetId?: string | null;
+  loadedSections: readonly ConversationRailSectionMembership[] | null;
+  next: readonly ConversationRailMembershipRecord[];
+  previous: readonly ConversationRailMembershipRecord[];
+  searchActive?: boolean;
+}): ConversationRailMembershipRefreshPlan {
+  const targetId = input.agentTargetId?.trim() ?? "";
+  const visible = (record: ConversationRailMembershipRecord) =>
+    !targetId || record.agentTargetId?.trim() === targetId;
+  const previousPendingIds = new Set(
+    input.previous
+      .filter(
+        (record) =>
+          record.projectionSource === "pending_activation" && visible(record)
+      )
+      .map((record) => record.id)
+  );
+  const canonical = (records: readonly ConversationRailMembershipRecord[]) =>
+    new Map(
+      records
+        .filter(
+          (record) =>
+            record.projectionSource !== "pending_activation" && visible(record)
+        )
+        .map((record) => [record.id, record] as const)
+    );
+  const previousById = canonical(input.previous);
+  const nextById = canonical(input.next);
+  const loadedIds = new Set(
+    (input.loadedSections ?? []).flatMap((section) => section.sessionIds)
+  );
+  const pageIds = new Set<string>();
+  const reconcilingSessionIds: string[] = [];
+  let refreshSearch = false;
+
+  const addPage = (record: ConversationRailMembershipRecord) => {
+    const pageId =
+      record.pinnedAtUnixMs != null ? "pinned" : record.railSectionKey?.trim();
+    if (pageId) pageIds.add(pageId);
+  };
+
+  for (const [id, previous] of previousById) {
+    const next = nextById.get(id);
+    if (!next) {
+      addPage(previous);
+      refreshSearch ||= Boolean(input.searchActive);
+      continue;
+    }
+    if (
+      (previous.pinnedAtUnixMs ?? 0) !== (next.pinnedAtUnixMs ?? 0) ||
+      previous.railSectionKey !== next.railSectionKey
+    ) {
+      addPage(previous);
+      addPage(next);
+    }
+    if (previous.title !== next.title) {
+      refreshSearch ||= Boolean(input.searchActive);
+    }
+  }
+
+  for (const [id, next] of nextById) {
+    if (previousById.has(id)) continue;
+    if (previousPendingIds.has(id)) {
+      if (!loadedIds.has(id)) {
+        addPage(next);
+        reconcilingSessionIds.push(id);
+      }
+      continue;
+    }
+    if (
+      id === (input.activeConversationId?.trim() ?? "") ||
+      loadedIds.has(id)
+    ) {
+      continue;
+    }
+    addPage(next);
+    refreshSearch ||= Boolean(input.searchActive);
+  }
+
+  return pageIds.size > 0 || refreshSearch
+    ? {
+        kind: "refresh_pages",
+        pageIds: [...pageIds],
+        reconcilingSessionIds,
+        refreshSearch
+      }
+    : { kind: "none" };
+}


### PR DESCRIPTION
## Summary

- stop delete mutations from triggering a full workspace activity reload
- reuse the batch-delete response for single deletes so root and child tombstones come from one authoritative result
- reconcile rail membership through exact pinned or section first pages while keeping resolved pages interactive
- refresh backend search only when a title or visible membership change can affect active search results
- document the targeted mutation and recovery data flow

## Verification

- `pnpm check:full` — 18/18 tasks passed
- `pnpm check:changed --tail-lines 100` — 11/11 lanes passed
- `pnpm --filter @tutti-os/agent-gui test` — 186 files, 1675 tests passed
- focused desktop activity service tests — 33 tests passed
- `pnpm --filter @tutti-os/desktop build`
- architecture review planner plus local desktop/package boundary review — no remaining findings
- hot reload intentionally skipped per request

## Fix Scope Justification

- Root cause: successful delete and membership mutations triggered workspace `load` or aggregate `listSessionSections` reconciliation. On large histories, those broad reads dominated mutation latency and replaced an already-resolved rail with blocking load state.
- Why can this not be fixed at a lower layer? The daemon mutation was already fast and returned authoritative deleted or updated entities. The excess work came from desktop mutation orchestration and AgentGUI page-cache invalidation, so daemon changes would not stop the renderer from issuing broad follow-up reads.

## Fallback Three Questions

- Source: targeted page requests can fail, or a preview host can omit an optional page method.
- Why can it not be fixed at that source? Production desktop provides the page methods, while preview runtimes intentionally expose a smaller optional query surface. Transport failures also cannot be made impossible.
- Removal condition: the defensive missing-method path can be removed if pinned and section page methods become required for every AgentGUI runtime. Failed targeted reads retain resolved state and mark cache stale; they never broaden into an aggregate mutation-time reload.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->