### PR TITLE
fix(user-project): keep registered folders during list

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1363,7 +1363,10 @@ by `GET /v1/workspaces/{workspaceID}/agent-session-sections` and
 `GET /v1/workspaces/{workspaceID}/agent-session-sections/page`. Project
 sections come from current `userProjects` and use the stable
 `project:/canonical/path` `sectionKey`; the Chats section uses
-`conversations`. The daemon pages sessions by `rail_section_key`, so AgentGUI
+`conversations`. This inventory is the durable registered-project list; rail
+loading must not probe project paths or implicitly remove unavailable folders.
+Path availability and explicit removal belong to the user-project domain. The
+daemon pages sessions by `rail_section_key`, so AgentGUI
 must render returned section props and use backend `hasMore`/`nextCursor`
 rather than cwd grouping, root filters, excluded project paths, or local
 Show more heuristics. Page responses upsert their session entities into the

--- a/services/tuttid/service/userproject/service.go
+++ b/services/tuttid/service/userproject/service.go
@@ -46,25 +46,7 @@ func (s Service) List(ctx context.Context) ([]userprojectbiz.Project, error) {
 	if s.Store == nil {
 		return nil, errors.New("user project store is not configured")
 	}
-	projects, err := s.Store.ListUserProjects(ctx)
-	if err != nil {
-		return nil, err
-	}
-	result := make([]userprojectbiz.Project, 0, len(projects))
-	for _, project := range projects {
-		available, prune := projectDirectoryStatus(project.Path)
-		if available {
-			result = append(result, project)
-			continue
-		}
-		if !prune {
-			continue
-		}
-		if err := s.Store.DeleteUserProject(ctx, project.ID); err != nil {
-			return nil, fmt.Errorf("prune unavailable user project: %w", err)
-		}
-	}
-	return result, nil
+	return s.Store.ListUserProjects(ctx)
 }
 
 func (Service) CheckPath(_ context.Context, input CheckPathInput) (PathCheck, error) {
@@ -148,17 +130,6 @@ func normalizeDirectoryPath(path string) (string, error) {
 		absolute = evaluated
 	}
 	return absolute, nil
-}
-
-func projectDirectoryStatus(path string) (available bool, prune bool) {
-	info, err := os.Stat(strings.TrimSpace(path))
-	if err != nil {
-		return false, os.IsNotExist(err)
-	}
-	if !info.IsDir() {
-		return false, true
-	}
-	return true, false
 }
 
 func projectID(path string) string {

--- a/services/tuttid/service/userproject/service_test.go
+++ b/services/tuttid/service/userproject/service_test.go
@@ -141,7 +141,7 @@ func TestServiceDeleteRejectsInvalidPath(t *testing.T) {
 	}
 }
 
-func TestServiceListPrunesUnavailableProjects(t *testing.T) {
+func TestServiceListReturnsRegisteredProjectsWithoutFilesystemPruning(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
 	validDir := filepath.Join(root, "valid")
@@ -167,11 +167,11 @@ func TestServiceListPrunesUnavailableProjects(t *testing.T) {
 		t.Fatalf("List() error = %v", err)
 	}
 
-	if len(projects) != 1 || projects[0].ID != "valid" {
-		t.Fatalf("List() projects = %#v, want only valid project", projects)
+	if len(projects) != 3 || projects[0].ID != "valid" || projects[1].ID != "missing" || projects[2].ID != "file" {
+		t.Fatalf("List() projects = %#v, want every registered project", projects)
 	}
-	if strings.Join(store.deletedIDs, ",") != "missing,file" {
-		t.Fatalf("deleted IDs = %#v, want missing,file", store.deletedIDs)
+	if len(store.deletedIDs) != 0 {
+		t.Fatalf("deleted IDs = %#v, want none", store.deletedIDs)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make user-project listing return the durable registered-project inventory without probing each path
- stop list calls from implicitly deleting temporarily unavailable or non-directory entries
- keep explicit path validation in the user-project domain and document the AgentGUI rail ownership boundary

## Verification

- `cd services/tuttid && go test ./service/userproject ./service/agent`
- `cd services/tuttid && go test ./...`
- `cd services/tuttid && go build ./...`
- `cd services/tuttid && go vet ./...`
- development GUI reloaded once with the rebuilt daemon

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] README/CONTRIBUTING language variants are not applicable to this change.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->