### PR TITLE
feat(agent): enable Cursor and OpenCode by default

### DIFF
--- a/apps/desktop/src/main/desktopHostPreferences.test.ts
+++ b/apps/desktop/src/main/desktopHostPreferences.test.ts
@@ -76,8 +76,8 @@ test("createDesktopHostPreferencesState initializes missing preferences with dar
         minimizeAnimation: "genie",
         sleepPreventionMode: "never",
         showAppDeveloperSources: false,
-        enableCursorAgent: false,
-        enableOpenCodeAgent: false,
+        enableCursorAgent: true,
+        enableOpenCodeAgent: true,
         themeSource: "dark",
         updateChannel: "stable",
         updatePolicy: "prompt"

--- a/apps/desktop/src/shared/preferences/core.ts
+++ b/apps/desktop/src/shared/preferences/core.ts
@@ -58,9 +58,9 @@ export const defaultDesktopAppCatalogChannel: DesktopAppCatalogChannel =
 
 export const defaultDesktopShowAppDeveloperSources = false;
 
-export const defaultDesktopEnableCursorAgent = false;
+export const defaultDesktopEnableCursorAgent = true;
 
-export const defaultDesktopEnableOpenCodeAgent = false;
+export const defaultDesktopEnableOpenCodeAgent = true;
 
 export type DesktopFeatureFlags = Record<string, boolean>;
 

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2976,9 +2976,11 @@ Desktop workbench feeds the renderer `AgentsService` `/agents` snapshot into
 AgentGUI. Product feature gates may filter that array before rendering; a
 loaded empty result remains empty. Availability states that should stay visible
 must remain in the array with the matching non-ready status instead of becoming
-synthetic provider placeholders. OpenCode remains gated by the
-`enableOpenCodeAgent` developer preference. Tutti Agent visibility is owned by
-the daemon's `local:tutti-agent` Agent Target: disabled daemon targets stay in
+synthetic provider placeholders. Cursor and OpenCode remain controlled by the
+`enableCursorAgent` and `enableOpenCodeAgent` developer preferences. Both are
+enabled by default for new desktop preferences, while an initialized stored
+opt-out remains authoritative. Tutti Agent visibility is owned by the daemon's
+`local:tutti-agent` Agent Target: disabled daemon targets stay in
 the presentation snapshot for history and settings, but are omitted from the
 new-session `agents` projection before the directory reaches AgentGUI.
 Provider slash commands must come from the runtime command snapshot or an

--- a/services/tuttid/biz/preferences/model.go
+++ b/services/tuttid/biz/preferences/model.go
@@ -24,8 +24,8 @@ const (
 	DefaultDesktopMinimizeAnimation           = "scale"
 	DefaultDesktopSleepPreventionMode         = "never"
 	DefaultDesktopShowAppDeveloperSources     = false
-	DefaultDesktopEnableCursorAgent           = false
-	DefaultDesktopEnableOpenCodeAgent         = false
+	DefaultDesktopEnableCursorAgent           = true
+	DefaultDesktopEnableOpenCodeAgent         = true
 	DefaultDesktopThemeSource                 = "dark"
 	DefaultDesktopUpdateChannel               = "rc"
 	DefaultDesktopUpdatePolicy                = "prompt"

--- a/services/tuttid/biz/preferences/model_test.go
+++ b/services/tuttid/biz/preferences/model_test.go
@@ -29,3 +29,13 @@ func TestDefaultDesktopPreferencesHasEmptyFlags(t *testing.T) {
 		t.Fatalf("want empty flags, got %v", d.FeatureFlags)
 	}
 }
+
+func TestDefaultDesktopPreferencesEnablesCursorAndOpenCodeAgents(t *testing.T) {
+	d := DefaultDesktopPreferences()
+	if !d.EnableCursorAgent {
+		t.Fatal("want Cursor agent enabled by default")
+	}
+	if !d.EnableOpenCodeAgent {
+		t.Fatal("want OpenCode agent enabled by default")
+	}
+}

--- a/services/tuttid/data/workspace/desktop_preferences_migrations.go
+++ b/services/tuttid/data/workspace/desktop_preferences_migrations.go
@@ -211,7 +211,7 @@ func (s *SQLiteStore) applyDesktopPreferencesEnableCursorAgentV1(ctx context.Con
 	if !hasEnableCursorAgent {
 		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
-  ADD COLUMN enable_cursor_agent INTEGER NOT NULL DEFAULT 0;`); err != nil {
+  ADD COLUMN enable_cursor_agent INTEGER NOT NULL DEFAULT 1;`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop enable cursor agent: %w", err)
 		}
 	}
@@ -243,7 +243,7 @@ func (s *SQLiteStore) applyDesktopPreferencesEnableOpenCodeAgentV1(ctx context.C
 	if !hasEnableOpenCodeAgent {
 		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
-  ADD COLUMN enable_opencode_agent INTEGER NOT NULL DEFAULT 0;`); err != nil {
+  ADD COLUMN enable_opencode_agent INTEGER NOT NULL DEFAULT 1;`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop enable opencode agent: %w", err)
 		}
 	}

--- a/services/tuttid/data/workspace/desktop_preferences_migrations_test.go
+++ b/services/tuttid/data/workspace/desktop_preferences_migrations_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 )
 
@@ -14,6 +15,45 @@ func TestFeatureFlagsMigrationAddsColumns(t *testing.T) {
 		ok, err := store.hasColumn(ctx, "desktop_preferences", col)
 		if err != nil || !ok {
 			t.Fatalf("column %s missing (err=%v)", col, err)
+		}
+	}
+}
+
+func TestAgentEnablementMigrationsDefaultToEnabled(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	for _, column := range []string{"enable_cursor_agent", "enable_opencode_agent"} {
+		var defaultValue sql.NullString
+		rows, err := store.readDB.Query(`PRAGMA table_info(desktop_preferences)`)
+		if err != nil {
+			t.Fatalf("inspect desktop_preferences: %v", err)
+		}
+
+		found := false
+		for rows.Next() {
+			var cid int
+			var name string
+			var columnType string
+			var notNull int
+			var primaryKey int
+			if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+				rows.Close()
+				t.Fatalf("scan desktop_preferences column: %v", err)
+			}
+			if name == column {
+				found = true
+				break
+			}
+		}
+		if err := rows.Close(); err != nil {
+			t.Fatalf("close desktop_preferences columns: %v", err)
+		}
+		if !found {
+			t.Fatalf("column %s missing", column)
+		}
+		if !defaultValue.Valid || defaultValue.String != "1" {
+			t.Fatalf("column %s default = %q, want 1", column, defaultValue.String)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- enable Cursor and OpenCode agents by default for new desktop preferences
- align daemon, desktop fallback, and SQLite column defaults
- preserve initialized stored opt-outs
- add regression coverage and document the preference behavior

## Impact

New or uninitialized desktop preferences expose Cursor and OpenCode by default. Existing users who explicitly disabled either agent remain opted out.

## Validation

- `pnpm check:changed --tail-lines 80` (8 lanes passed)
- `pnpm lint:go`
- desktop typecheck
- targeted desktop preferences, daemon preferences, and migration tests
- pre-push `check:full` passed preparation and preflight, then hit unrelated process timeouts in three Go tests; all three failed tests passed immediately when rerun individually:
  - `TestLocalProcessTransportFindsKnownNodeGlobalBin`
  - `TestServiceListReportsCodexChecksVersionAndLastError`
  - `TestServiceListRunsCodexLauncherWithManagedNodePath`
