### PR TITLE
chore(agents): remove obsolete operating rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,6 @@ DCO sign-off, PR workflow, review gates, and multilingual documentation updates.
 ## Hard Rules
 
 - Published workspace packages use `@tutti-os/*`; keep manifests, imports, docs, and release config aligned.
-- Do not start subagents unless the user explicitly approves it first.
-- Do not invoke or use Superdesign.
-- Do not hot-reload while editing files or during intermediate iterations. Complete the entire task, including edits and validation, then hot-reload the relevant development environment exactly once. Skip it when the user explicitly asks not to reload or restart.
 - All new requirements and features across Tutti projects must first reuse existing `@tutti-os/ui-system` components, semantic color tokens, typography, spacing, and other established UI conventions. Before introducing bespoke UI or raw color values, inspect the existing UI System exports and tokens; if the required capability is missing, prefer extending the shared UI System with a reusable primitive or token and document the rationale.
 - User-visible copy must go through the relevant i18n layer. Do not hardcode UI text, dialog text, status labels, empty states, or user-facing errors.
 - Chinese user-facing UI copy must not end with a Chinese full stop (。); keep this punctuation rule consistent across settings and other product surfaces.


### PR DESCRIPTION
## Summary

- Remove obsolete subagent approval restriction
- Remove obsolete Superdesign prohibition
- Remove forced single hot-reload instruction
- Keep root agent guidance focused on durable repository rules

## Verification

- `pnpm check:full` — 18 tasks passed
- `go test ./runtime -run "^TestLocalProcessTransportFindsKnownNodeGlobalBin$" -count=3 -v` — passed after one transient pre-push timeout

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] README/CONTRIBUTING language variants are unaffected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->