### PR TITLE
feat(release): add draft promotion workflow

### DIFF
--- a/.github/workflows/desktop-release-promote.yml
+++ b/.github/workflows/desktop-release-promote.yml
@@ -1,0 +1,562 @@
+name: Promote Desktop Release
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: Existing GitHub draft release tag to promote
+        required: true
+        type: string
+      expected_target:
+        description: Optional expected commit SHA for caller-side consistency checks
+        required: false
+        type: string
+        default: ""
+      expected_channel:
+        description: Optional expected stable, rc, or beta channel
+        required: false
+        type: string
+        default: ""
+      source_ref:
+        description: Source ref recorded in public release metadata
+        required: false
+        type: string
+        default: ""
+      notify_feishu:
+        description: Send a Feishu card after promotion
+        required: false
+        type: boolean
+        default: true
+    outputs:
+      release_url:
+        description: Promoted GitHub release URL
+        value: ${{ jobs.promote.outputs.release_url }}
+    secrets:
+      AGNES_API_KEY:
+        required: false
+      FEISHU_RELEASE_WEBHOOK_URL:
+        required: false
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: GitHub draft release tag to promote, such as v0.1.25
+        required: true
+        type: string
+      notify_feishu:
+        description: Send a Feishu card after promotion
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: desktop-release-promotion
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  resolve:
+    name: Validate Draft Release
+    runs-on: ubuntu-latest
+    outputs:
+      release_channel: ${{ steps.release.outputs.release_channel }}
+      release_make_latest: ${{ steps.release.outputs.release_make_latest }}
+      release_prerelease: ${{ steps.release.outputs.release_prerelease }}
+      release_tag: ${{ steps.release.outputs.release_tag }}
+      release_target: ${{ steps.release.outputs.release_target }}
+      release_url: ${{ steps.release.outputs.release_url }}
+      release_version: ${{ steps.release.outputs.release_version }}
+      source_ref: ${{ steps.release.outputs.source_ref }}
+
+    steps:
+      - name: Checkout release tooling
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate release candidate
+        id: release
+        shell: bash
+        env:
+          EXPECTED_CHANNEL: ${{ inputs.expected_channel }}
+          EXPECTED_TARGET: ${{ inputs.expected_target }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          INPUT_SOURCE_REF: ${{ inputs.source_ref }}
+        run: |
+          release_tag="${INPUT_RELEASE_TAG}"
+          if [[ "${release_tag}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-rc\.(0|[1-9][0-9]*)$ ]]; then
+            release_channel=rc
+            release_prerelease=true
+            release_make_latest=false
+          elif [[ "${release_tag}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-beta\.(0|[1-9][0-9]*)$ ]]; then
+            release_channel=beta
+            release_prerelease=true
+            release_make_latest=false
+          elif [[ "${release_tag}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            release_channel=stable
+            release_prerelease=false
+            release_make_latest=true
+          else
+            echo "release_tag must be vX.Y.Z, vX.Y.Z-rc.N, or vX.Y.Z-beta.N." >&2
+            exit 1
+          fi
+
+          release_version="${release_tag#v}"
+          if [[ -n "${EXPECTED_CHANNEL}" && "${EXPECTED_CHANNEL}" != "${release_channel}" ]]; then
+            echo "Release channel mismatch: expected ${EXPECTED_CHANNEL}, got ${release_channel}." >&2
+            exit 1
+          fi
+
+          gh release view "${release_tag}" \
+            --json assets,isDraft,isPrerelease,tagName,targetCommitish,url > release.json
+          actual_tag="$(jq -r .tagName release.json)"
+          is_draft="$(jq -r .isDraft release.json)"
+          actual_prerelease="$(jq -r .isPrerelease release.json)"
+          asset_count="$(jq '.assets | length' release.json)"
+          if [[ "${actual_tag}" != "${release_tag}" ]]; then
+            echo "GitHub release tag mismatch: expected ${release_tag}, got ${actual_tag}." >&2
+            exit 1
+          fi
+          if [[ "${actual_prerelease}" != "${release_prerelease}" ]]; then
+            echo "GitHub release prerelease flag does not match ${release_channel}." >&2
+            exit 1
+          fi
+          if (( asset_count == 0 )); then
+            echo "GitHub release ${release_tag} has no staged assets." >&2
+            exit 1
+          fi
+          if [[ "${is_draft}" != "true" ]]; then
+            if [[ "${release_channel}" != "stable" ]]; then
+              echo "Prerelease ${release_tag} must remain a GitHub draft." >&2
+              exit 1
+            fi
+            latest_stable_tag="$(gh release list \
+              --exclude-drafts \
+              --exclude-pre-releases \
+              --limit 200 \
+              --json tagName,isLatest \
+              --jq '[.[] | select(.tagName != "stable")] | (map(select(.isLatest)) | first) // first | .tagName // ""')"
+            if [[ "${latest_stable_tag}" != "${release_tag}" ]]; then
+              echo "Only the current public stable release may be promoted again." >&2
+              exit 1
+            fi
+          fi
+          if ! jq -e '.assets[] | select(.name == "SHA256SUMS.txt")' release.json >/dev/null; then
+            echo "GitHub release ${release_tag} is missing SHA256SUMS.txt." >&2
+            exit 1
+          fi
+
+          git fetch --force origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
+          release_target="$(git rev-list -n 1 "${release_tag}")"
+          if [[ -n "${EXPECTED_TARGET}" ]]; then
+            expected_target_sha="$(git rev-parse "${EXPECTED_TARGET}^{commit}")"
+            if [[ "${release_target}" != "${expected_target_sha}" ]]; then
+              echo "Release target mismatch: expected ${expected_target_sha}, got ${release_target}." >&2
+              exit 1
+            fi
+          fi
+
+          source_ref="${INPUT_SOURCE_REF:-$(jq -r '.targetCommitish // ""' release.json)}"
+          release_url="$(jq -r .url release.json)"
+          echo "release_channel=${release_channel}" >> "$GITHUB_OUTPUT"
+          echo "release_make_latest=${release_make_latest}" >> "$GITHUB_OUTPUT"
+          echo "release_prerelease=${release_prerelease}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
+          echo "release_target=${release_target}" >> "$GITHUB_OUTPUT"
+          echo "release_url=${release_url}" >> "$GITHUB_OUTPUT"
+          echo "release_version=${release_version}" >> "$GITHUB_OUTPUT"
+          echo "source_ref=${source_ref}" >> "$GITHUB_OUTPUT"
+
+  promote:
+    name: Publish External Release
+    needs: resolve
+    runs-on: ubuntu-latest
+    outputs:
+      release_url: ${{ steps.release-url.outputs.release_url }}
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      TUTTI_ARTIFACTS_AWS_ROLE_ARN: ${{ vars.TUTTI_ARTIFACTS_AWS_ROLE_ARN }}
+      TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL }}
+      TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET }}
+      TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX }}
+      TUTTI_DESKTOP_RELEASE_CHANNEL: ${{ needs.resolve.outputs.release_channel }}
+      TUTTI_DESKTOP_RELEASE_MAKE_LATEST: ${{ needs.resolve.outputs.release_make_latest }}
+      TUTTI_DESKTOP_RELEASE_PRERELEASE: ${{ needs.resolve.outputs.release_prerelease }}
+      TUTTI_DESKTOP_RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+      TUTTI_DESKTOP_RELEASE_TARGET: ${{ needs.resolve.outputs.release_target }}
+      TUTTI_DESKTOP_RELEASE_VERSION: ${{ needs.resolve.outputs.release_version }}
+
+    steps:
+      - name: Checkout release target
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+
+      - name: Download staged GitHub release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release download "${TUTTI_DESKTOP_RELEASE_TAG}" --dir release-assets
+
+      - name: Verify staged release assets
+        run: |
+          test -f release-assets/SHA256SUMS.txt
+          if ! grep -Eq "  .+\.(dmg|zip|exe|AppImage)$" release-assets/SHA256SUMS.txt; then
+            echo "SHA256SUMS.txt does not contain an installable desktop artifact." >&2
+            exit 1
+          fi
+          (
+            cd release-assets
+            sha256sum --check SHA256SUMS.txt
+          )
+
+      - name: Install AWS CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends unzip
+          if ! command -v aws >/dev/null 2>&1; then
+            case "$(uname -m)" in
+              x86_64) awscli_arch="x86_64" ;;
+              aarch64|arm64) awscli_arch="aarch64" ;;
+              *)
+                echo "Unsupported architecture for AWS CLI installer: $(uname -m)" >&2
+                exit 1
+                ;;
+            esac
+            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${awscli_arch}.zip" -o /tmp/awscliv2.zip
+            unzip -q /tmp/awscliv2.zip -d /tmp
+            sudo /tmp/aws/install --update
+          fi
+          aws --version
+
+      - name: Validate AWS S3 release asset configuration
+        run: |
+          missing=()
+          for name in AWS_REGION TUTTI_ARTIFACTS_AWS_ROLE_ARN TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "Missing required AWS S3 release asset configuration: ${missing[*]}" >&2
+            exit 1
+          fi
+          if [[ -z "${TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL:-}" ]]; then
+            echo "TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL=https://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}.s3-accelerate.amazonaws.com/${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.TUTTI_ARTIFACTS_AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Prevent release channel rollback
+        env:
+          RELEASE_CHANNEL: ${{ env.TUTTI_DESKTOP_RELEASE_CHANNEL }}
+          RELEASE_VERSION: ${{ env.TUTTI_DESKTOP_RELEASE_VERSION }}
+        run: |
+          case "${RELEASE_CHANNEL}" in
+            stable) pointer_path=latest.json ;;
+            rc) pointer_path=channels/rc/latest.json ;;
+            beta) pointer_path=channels/beta/latest.json ;;
+          esac
+          prefix="${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}"
+          current_pointer="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${prefix}/${pointer_path}"
+          if aws s3 cp "${current_pointer}" current-release-pointer.json 2> current-pointer-download.err; then
+            node <<'NODE'
+          const fs = require("node:fs");
+          const current = JSON.parse(fs.readFileSync("current-release-pointer.json", "utf8"));
+          const candidate = process.env.RELEASE_VERSION;
+          const parse = (value) => {
+            const match = /^(\d+)\.(\d+)\.(\d+)(?:-(rc|beta)\.(\d+))?$/.exec(value);
+            if (!match) throw new Error(`Invalid release version: ${value}`);
+            return [Number(match[1]), Number(match[2]), Number(match[3]), Number(match[5] ?? -1)];
+          };
+          const currentParts = parse(String(current.version ?? ""));
+          const candidateParts = parse(candidate);
+          const comparison = candidateParts.findIndex((part, index) => part !== currentParts[index]);
+          if (comparison >= 0 && candidateParts[comparison] < currentParts[comparison]) {
+            throw new Error(`Refusing to move ${process.env.RELEASE_CHANNEL} from ${current.version} back to ${candidate}.`);
+          }
+          if (comparison < 0 && current.tag !== process.env.TUTTI_DESKTOP_RELEASE_TAG) {
+            throw new Error(`Release version ${candidate} is already published by ${current.tag}.`);
+          }
+          NODE
+          elif ! grep -Eq "(404|NoSuchKey|Not Found)" current-pointer-download.err; then
+            cat current-pointer-download.err >&2
+            exit 1
+          fi
+
+      - name: Upload immutable release assets to AWS S3
+        run: |
+          remote_dir="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}/${TUTTI_DESKTOP_RELEASE_TAG}"
+          aws s3 sync release-assets "${remote_dir}" \
+            --size-only \
+            --cache-control "public, max-age=31536000, immutable"
+
+      - name: Generate desktop release summary
+        env:
+          AGNES_API_KEY: ${{ secrets.AGNES_API_KEY }}
+          RELEASE_CHANNEL: ${{ env.TUTTI_DESKTOP_RELEASE_CHANNEL }}
+          RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
+          RELEASE_TARGET: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
+        run: node apps/desktop/scripts/generate-release-summary.mjs --output release-summary.json
+
+      - name: Upload desktop release summary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: promoted-desktop-release-summary-${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
+          path: release-summary.json
+
+      - name: Update release notes with summary and direct downloads
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
+        run: |
+          export RELEASE_ASSET_BASE_URL="${TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL}"
+          gh release view "${RELEASE_TAG}" --json body --jq .body > release-body.md
+          node apps/desktop/scripts/upsert-release-summary.mjs \
+            release-body.md \
+            release-summary.json \
+            release-body-with-summary.md
+          node apps/desktop/scripts/upsert-release-download-links.mjs \
+            release-body-with-summary.md \
+            release-assets \
+            updated-release-body.md
+          gh release edit "${RELEASE_TAG}" --notes-file updated-release-body.md
+
+      - name: Build public release pointer
+        env:
+          RELEASE_CHANNEL: ${{ env.TUTTI_DESKTOP_RELEASE_CHANNEL }}
+          RELEASE_GIT_SHA: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
+          RELEASE_SOURCE_REF: ${{ needs.resolve.outputs.source_ref }}
+          RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
+        run: |
+          export RELEASE_ASSET_BASE_URL="${TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL}"
+          node apps/desktop/scripts/build-release-latest.mjs release-assets release-latest.json
+
+      - name: Update stable changelog metadata
+        if: ${{ needs.resolve.outputs.release_channel == 'stable' }}
+        run: |
+          prefix="${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}"
+          s3_root="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${prefix}"
+          if ! aws s3 cp "${s3_root}/changelog.json" existing-changelog.json 2> changelog-download.err; then
+            if grep -Eq "(404|NoSuchKey|Not Found)" changelog-download.err; then
+              echo '{"schemaVersion":"tutti.desktop.changelog.v1","entries":[]}' > existing-changelog.json
+            else
+              cat changelog-download.err >&2
+              exit 1
+            fi
+          fi
+          node apps/desktop/scripts/upsert-release-changelog.mjs \
+            existing-changelog.json \
+            release-summary.json \
+            changelog.json
+          aws s3 cp changelog.json "${s3_root}/changelog.json" \
+            --content-type "application/json" \
+            --cache-control "public, max-age=60"
+
+      - name: Publish stable GitHub release
+        if: ${{ needs.resolve.outputs.release_channel == 'stable' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${TUTTI_DESKTOP_RELEASE_TAG}" --draft=false --latest
+
+      - name: Archive public GitHub prereleases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --paginate \
+            --jq '.[] | select(.prerelease and (.draft | not)) | .id' |
+            while IFS= read -r release_id; do
+              if [[ -n "${release_id}" ]]; then
+                gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+                  -F draft=true >/dev/null
+              fi
+            done
+
+      - name: Publish release pointer to AWS S3
+        run: |
+          prefix="${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}"
+          s3_root="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${prefix}"
+          if [[ "${TUTTI_DESKTOP_RELEASE_CHANNEL}" == "stable" ]]; then
+            aws s3 cp release-latest.json "${s3_root}/latest.json" \
+              --content-type "application/json" \
+              --cache-control "public, max-age=60"
+          elif [[ "${TUTTI_DESKTOP_RELEASE_CHANNEL}" == "rc" ]]; then
+            aws s3 cp release-latest.json "${s3_root}/channels/preview/latest.json" \
+              --content-type "application/json" \
+              --cache-control "public, max-age=60"
+            aws s3 cp release-latest.json "${s3_root}/channels/rc/latest.json" \
+              --content-type "application/json" \
+              --cache-control "public, max-age=60"
+          else
+            aws s3 cp release-latest.json "${s3_root}/channels/beta/latest.json" \
+              --content-type "application/json" \
+              --cache-control "public, max-age=60"
+          fi
+
+      - name: Refresh stable release alias
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "${TUTTI_DESKTOP_RELEASE_CHANNEL}" == "stable" ]]; then
+            stable_tag="${TUTTI_DESKTOP_RELEASE_TAG}"
+          else
+            stable_tag="$(gh release list \
+              --exclude-drafts \
+              --exclude-pre-releases \
+              --limit 200 \
+              --json tagName,isLatest,publishedAt \
+              --jq '[.[] | select(.tagName != "stable" and (.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")))] | (map(select(.isLatest)) | first) // first | .tagName // ""')"
+          fi
+          if [[ -z "${stable_tag}" ]]; then
+            echo "Could not resolve the current stable desktop release tag for the stable alias." >&2
+            exit 1
+          fi
+
+          git fetch --force origin "refs/tags/${stable_tag}:refs/tags/${stable_tag}"
+          stable_sha="$(git rev-list -n 1 "${stable_tag}")"
+          stable_tree="$(git rev-parse "${stable_sha}^{tree}")"
+          gh release view "${stable_tag}" --json body,name,tagName,url > stable-release.json
+          node apps/desktop/scripts/build-stable-release-alias-body.mjs \
+            stable-release.json \
+            stable-release-body.md
+
+          stable_alias_time="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          stable_alias_sha="$(
+            printf '%s\n' \
+              "chore(release): refresh stable alias for ${stable_tag}" \
+              "" \
+              "Canonical stable release: ${stable_tag}" \
+              "" \
+              "Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>" |
+              GIT_AUTHOR_NAME="github-actions[bot]" \
+              GIT_AUTHOR_EMAIL="41898282+github-actions[bot]@users.noreply.github.com" \
+              GIT_AUTHOR_DATE="${stable_alias_time}" \
+              GIT_COMMITTER_NAME="github-actions[bot]" \
+              GIT_COMMITTER_EMAIL="41898282+github-actions[bot]@users.noreply.github.com" \
+              GIT_COMMITTER_DATE="${stable_alias_time}" \
+              git commit-tree "${stable_tree}" -p "${stable_sha}"
+          )"
+          stable_alias_tree="$(git rev-parse "${stable_alias_sha}^{tree}")"
+          stable_alias_parent="$(git rev-parse "${stable_alias_sha}^")"
+          if [[ "${stable_alias_tree}" != "${stable_tree}" ]]; then
+            echo "Stable alias tree mismatch: expected ${stable_tree}, got ${stable_alias_tree}." >&2
+            exit 1
+          fi
+          if [[ "${stable_alias_parent}" != "${stable_sha}" ]]; then
+            echo "Stable alias parent mismatch: expected ${stable_sha}, got ${stable_alias_parent}." >&2
+            exit 1
+          fi
+
+          git tag -f stable "${stable_alias_sha}"
+          git push origin refs/tags/stable --force
+          if gh release view stable >/dev/null 2>&1; then
+            gh release delete stable --yes
+          fi
+          gh release create stable \
+            --verify-tag \
+            --title "Stable (Recommended)" \
+            --notes-file stable-release-body.md \
+            --latest=false
+          gh release edit "${stable_tag}" --latest
+
+      - name: Verify public release pointer
+        env:
+          RELEASE_CHANNEL: ${{ env.TUTTI_DESKTOP_RELEASE_CHANNEL }}
+          RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
+        run: |
+          case "${RELEASE_CHANNEL}" in
+            stable) pointer_path=latest.json ;;
+            rc) pointer_path=channels/rc/latest.json ;;
+            beta) pointer_path=channels/beta/latest.json ;;
+          esac
+          pointer_url="${TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL%/}/${pointer_path}"
+          for attempt in {1..13}; do
+            actual_tag="$(curl -fsSL "${pointer_url}" | jq -r '.tag // ""' || true)"
+            if [[ "${actual_tag}" == "${RELEASE_TAG}" ]]; then
+              exit 0
+            fi
+            if (( attempt < 13 )); then
+              sleep 5
+            fi
+          done
+          echo "Public release pointer did not resolve to ${RELEASE_TAG}: ${pointer_url}" >&2
+          exit 1
+
+      - name: Resolve final GitHub release URL
+        id: release-url
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          release_url="$(gh release view "${TUTTI_DESKTOP_RELEASE_TAG}" --json url --jq .url)"
+          echo "release_url=${release_url}" >> "$GITHUB_OUTPUT"
+
+  notify-feishu:
+    name: Notify Feishu
+    needs: [resolve, promote]
+    if: ${{ needs.promote.result == 'success' && inputs.notify_feishu == true }}
+    runs-on: ubuntu-latest
+    env:
+      FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_RELEASE_WEBHOOK_URL }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL }}
+      TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET }}
+      TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX }}
+      RELEASE_ACTOR: ${{ github.actor }}
+      RELEASE_BRANCH: ${{ needs.resolve.outputs.source_ref }}
+      RELEASE_PUBLICATION_STATUS: published
+      RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+      RELEASE_TARGET: ${{ needs.resolve.outputs.release_target }}
+      RELEASE_URL: ${{ needs.promote.outputs.release_url }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    steps:
+      - name: Checkout notification script
+        if: env.FEISHU_WEBHOOK_URL != ''
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve.outputs.release_target }}
+
+      - name: Setup Node.js
+        if: env.FEISHU_WEBHOOK_URL != ''
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+
+      - name: Download promoted release assets
+        if: env.FEISHU_WEBHOOK_URL != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release download "${RELEASE_TAG}" --dir release-assets
+
+      - name: Download release summary
+        if: env.FEISHU_WEBHOOK_URL != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: promoted-desktop-release-summary-${{ needs.resolve.outputs.release_tag }}
+          path: release-summary
+
+      - name: Send release card
+        if: env.FEISHU_WEBHOOK_URL != ''
+        env:
+          RELEASE_ASSET_DIRECTORY: release-assets
+          RELEASE_SUMMARY_PATH: release-summary/release-summary.json
+        run: node apps/desktop/scripts/send-release-feishu-card.mjs
+
+      - name: Skip Feishu card
+        if: env.FEISHU_WEBHOOK_URL == ''
+        run: echo "FEISHU_RELEASE_WEBHOOK_URL is not configured; skipping Feishu notification."

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -29,6 +29,14 @@ on:
         description: Optional commit-ish override
         required: false
         type: string
+      publication_mode:
+        description: Publish externally now or keep the signed build as a GitHub draft
+        required: true
+        type: choice
+        default: publish
+        options:
+          - publish
+          - draft_only
       notify_feishu:
         description: Send a Feishu card after publishing
         required: false
@@ -54,6 +62,7 @@ jobs:
       release_target: ${{ steps.target.outputs.release_target }}
       release_version: ${{ steps.release.outputs.release_version }}
       release_channel: ${{ steps.release.outputs.release_channel }}
+      publication_mode: ${{ steps.publication.outputs.publication_mode }}
       notify_feishu: ${{ steps.notify.outputs.notify_feishu }}
 
     steps:
@@ -227,6 +236,27 @@ jobs:
         shell: bash
         run: echo "notify_feishu=${{ github.event_name != 'workflow_dispatch' || inputs.notify_feishu != false }}" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve publication mode
+        id: publication
+        shell: bash
+        env:
+          INPUT_PUBLICATION_MODE: ${{ inputs.publication_mode }}
+          RELEASE_EVENT_NAME: ${{ github.event_name }}
+        run: |
+          publication_mode=publish
+          if [[ "${RELEASE_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            publication_mode="${INPUT_PUBLICATION_MODE:-publish}"
+          fi
+          case "${publication_mode}" in
+            publish|draft_only)
+              ;;
+            *)
+              echo "Unknown publication_mode: ${publication_mode}" >&2
+              exit 1
+              ;;
+          esac
+          echo "publication_mode=${publication_mode}" >> "$GITHUB_OUTPUT"
+
   build-macos:
     name: Build macOS
     needs: resolve
@@ -377,8 +407,8 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  publish:
-    name: Publish Release
+  stage:
+    name: Stage Release Draft
     needs: [resolve, build-macos]
     if: ${{ github.event_name == 'push' || needs.resolve.outputs.release_dry_run != 'true' }}
     runs-on: ubuntu-latest
@@ -386,12 +416,12 @@ jobs:
       release_url: ${{ steps.stage-release.outputs.url }}
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
-      TUTTI_DESKTOP_RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
-      TUTTI_DESKTOP_RELEASE_TARGET: ${{ needs.resolve.outputs.release_target }}
       TUTTI_ARTIFACTS_AWS_ROLE_ARN: ${{ vars.TUTTI_ARTIFACTS_AWS_ROLE_ARN }}
       TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL }}
       TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET }}
       TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX }}
+      TUTTI_DESKTOP_RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+      TUTTI_DESKTOP_RELEASE_TARGET: ${{ needs.resolve.outputs.release_target }}
 
     steps:
       - name: Checkout
@@ -415,8 +445,22 @@ jobs:
       - name: Generate checksums
         run: node apps/desktop/scripts/generate-checksums.mjs release-assets
 
+      - id: stage-release
+        name: Stage GitHub release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
+          target_commitish: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
+          name: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
+          draft: true
+          prerelease: ${{ needs.resolve.outputs.release_prerelease == 'true' }}
+          make_latest: ${{ needs.resolve.outputs.release_make_latest == 'true' }}
+          generate_release_notes: true
+          files: |
+            release-assets/*
+
       - name: Install AWS CLI
-        if: ${{ env.TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET != '' || env.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX != '' || env.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL != '' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends unzip
@@ -436,7 +480,6 @@ jobs:
           aws --version
 
       - name: Validate AWS S3 release asset configuration
-        if: ${{ env.TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET != '' || env.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX != '' || env.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL != '' }}
         run: |
           missing=()
           for name in AWS_REGION TUTTI_ARTIFACTS_AWS_ROLE_ARN TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX; do
@@ -444,40 +487,21 @@ jobs:
               missing+=("$name")
             fi
           done
-
           if (( ${#missing[@]} > 0 )); then
             echo "Missing required AWS S3 release asset configuration: ${missing[*]}" >&2
             exit 1
           fi
-
           if [[ -z "${TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL:-}" ]]; then
             echo "TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL=https://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}.s3-accelerate.amazonaws.com/${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}" >> "$GITHUB_ENV"
           fi
 
-      - id: stage-release
-        name: Stage GitHub release assets
-        uses: softprops/action-gh-release@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
-          target_commitish: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
-          name: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
-          draft: true
-          prerelease: ${{ needs.resolve.outputs.release_prerelease == 'true' }}
-          make_latest: ${{ needs.resolve.outputs.release_make_latest == 'true' }}
-          generate_release_notes: true
-          files: |
-            release-assets/*
-
       - name: Configure AWS credentials
-        if: ${{ env.TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET != '' || env.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX != '' || env.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL != '' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.TUTTI_ARTIFACTS_AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Upload release assets to AWS S3
-        if: ${{ env.TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET != '' || env.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX != '' || env.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL != '' }}
+      - name: Upload immutable draft assets to AWS S3
         run: |
           remote_dir="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}/${TUTTI_DESKTOP_RELEASE_TAG}"
           aws s3 cp release-assets "${remote_dir}" \
@@ -511,208 +535,23 @@ jobs:
             updated-release-body.md
           gh release edit "${TUTTI_DESKTOP_RELEASE_TAG}" --notes-file updated-release-body.md
 
-      - name: Build desktop release latest metadata
-        if: ${{ env.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL != '' && needs.resolve.outputs.release_make_latest == 'true' }}
-        env:
-          RELEASE_CHANNEL: stable
-          RELEASE_GIT_SHA: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
-          RELEASE_ASSET_BASE_URL: ${{ env.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL }}
-          RELEASE_SOURCE_REF: ${{ github.ref_name }}
-          RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
-        run: node apps/desktop/scripts/build-release-latest.mjs release-assets release-latest.json
+  promote:
+    name: Promote Release
+    needs: [resolve, stage]
+    if: ${{ needs.stage.result == 'success' && needs.resolve.outputs.publication_mode == 'publish' }}
+    uses: ./.github/workflows/desktop-release-promote.yml
+    with:
+      release_tag: ${{ needs.resolve.outputs.release_tag }}
+      expected_target: ${{ needs.resolve.outputs.release_target }}
+      expected_channel: ${{ needs.resolve.outputs.release_channel }}
+      source_ref: ${{ github.ref_name }}
+      notify_feishu: ${{ needs.resolve.outputs.notify_feishu == 'true' }}
+    secrets: inherit
 
-      - name: Upload desktop release latest metadata to AWS S3
-        if: ${{ env.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL != '' && needs.resolve.outputs.release_make_latest == 'true' }}
-        run: |
-          prefix="${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}"
-          if [ -n "${prefix}" ]; then
-            s3_root="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${prefix}"
-          else
-            s3_root="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}"
-          fi
-          aws s3 cp release-latest.json "${s3_root}/latest.json" \
-            --content-type "application/json" \
-            --cache-control "public, max-age=60"
-
-      - name: Build desktop prerelease channel latest metadata
-        if: ${{ env.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL != '' && needs.resolve.outputs.release_channel != 'stable' }}
-        env:
-          RELEASE_CHANNEL: ${{ needs.resolve.outputs.release_channel }}
-          RELEASE_GIT_SHA: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
-          RELEASE_ASSET_BASE_URL: ${{ env.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL }}
-          RELEASE_SOURCE_REF: ${{ github.ref_name }}
-          RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
-        run: node apps/desktop/scripts/build-release-latest.mjs release-assets release-channel-latest.json
-
-      - name: Upload desktop prerelease channel latest metadata to AWS S3
-        if: ${{ env.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL != '' && needs.resolve.outputs.release_channel != 'stable' }}
-        env:
-          RELEASE_CHANNEL: ${{ needs.resolve.outputs.release_channel }}
-        run: |
-          prefix="${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}"
-          if [ -n "${prefix}" ]; then
-            s3_root="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${prefix}"
-          else
-            s3_root="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}"
-          fi
-
-          if [[ "${RELEASE_CHANNEL}" == "rc" ]]; then
-            aws s3 cp release-channel-latest.json "${s3_root}/channels/preview/latest.json" \
-              --content-type "application/json" \
-              --cache-control "public, max-age=60"
-            aws s3 cp release-channel-latest.json "${s3_root}/channels/rc/latest.json" \
-              --content-type "application/json" \
-              --cache-control "public, max-age=60"
-          elif [[ "${RELEASE_CHANNEL}" == "beta" ]]; then
-            aws s3 cp release-channel-latest.json "${s3_root}/channels/beta/latest.json" \
-              --content-type "application/json" \
-              --cache-control "public, max-age=60"
-          else
-            echo "Unsupported prerelease channel: ${RELEASE_CHANNEL}" >&2
-            exit 1
-          fi
-
-      - name: Update desktop release changelog metadata
-        if: ${{ env.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL != '' && needs.resolve.outputs.release_make_latest == 'true' }}
-        run: |
-          prefix="${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}"
-          if [ -n "${prefix}" ]; then
-            s3_root="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${prefix}"
-          else
-            s3_root="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}"
-          fi
-          if ! aws s3 cp "${s3_root}/changelog.json" existing-changelog.json 2> changelog-download.err; then
-            if grep -Eq "(404|NoSuchKey|Not Found)" changelog-download.err; then
-              echo '{"schemaVersion":"tutti.desktop.changelog.v1","entries":[]}' > existing-changelog.json
-            else
-              cat changelog-download.err >&2
-              exit 1
-            fi
-          fi
-          node apps/desktop/scripts/upsert-release-changelog.mjs \
-            existing-changelog.json \
-            release-summary.json \
-            changelog.json
-          aws s3 cp changelog.json "${s3_root}/changelog.json" \
-            --content-type "application/json" \
-            --cache-control "public, max-age=60"
-
-      - name: Update release notes with direct downloads
-        if: ${{ env.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL != '' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_ASSET_BASE_URL: ${{ env.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL }}
-          RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
-        run: |
-          gh release view "${TUTTI_DESKTOP_RELEASE_TAG}" --json body --jq .body > release-body.md
-          node apps/desktop/scripts/upsert-release-download-links.mjs \
-            release-body.md \
-            release-assets \
-            updated-release-body.md
-          gh release edit "${TUTTI_DESKTOP_RELEASE_TAG}" --notes-file updated-release-body.md
-
-      - name: Publish stable GitHub release
-        if: ${{ needs.resolve.outputs.release_prerelease != 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TUTTI_DESKTOP_RELEASE_MAKE_LATEST: ${{ needs.resolve.outputs.release_make_latest }}
-        run: |
-          args=(gh release edit "${TUTTI_DESKTOP_RELEASE_TAG}" --draft=false)
-          if [[ "${TUTTI_DESKTOP_RELEASE_MAKE_LATEST}" == "true" ]]; then
-            args+=(--latest)
-          fi
-          "${args[@]}"
-
-      - name: Archive public GitHub prereleases
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --paginate \
-            --jq '.[] | select(.prerelease and (.draft | not)) | .id' |
-            while IFS= read -r release_id; do
-              if [[ -z "${release_id}" ]]; then
-                continue
-              fi
-
-              echo "Archiving published prerelease ${release_id} as a draft."
-              gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
-                -F draft=true >/dev/null
-            done
-
-      - name: Refresh stable release alias
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TUTTI_DESKTOP_RELEASE_CHANNEL: ${{ needs.resolve.outputs.release_channel }}
-        run: |
-          if [[ "${TUTTI_DESKTOP_RELEASE_CHANNEL}" == "stable" ]]; then
-            stable_tag="${TUTTI_DESKTOP_RELEASE_TAG}"
-          else
-            stable_tag="$(gh release list \
-              --exclude-drafts \
-              --exclude-pre-releases \
-              --limit 200 \
-              --json tagName,isLatest,publishedAt \
-              --jq '[.[] | select(.tagName != "stable" and (.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")))] | (map(select(.isLatest)) | first) // first | .tagName // ""')"
-          fi
-
-          if [[ -z "${stable_tag}" ]]; then
-            echo "Could not resolve the current stable desktop release tag for the stable alias." >&2
-            exit 1
-          fi
-
-          git fetch --force origin "refs/tags/${stable_tag}:refs/tags/${stable_tag}"
-          stable_sha="$(git rev-list -n 1 "${stable_tag}")"
-          stable_tree="$(git rev-parse "${stable_sha}^{tree}")"
-          gh release view "${stable_tag}" --json body,name,tagName,url > stable-release.json
-          node apps/desktop/scripts/build-stable-release-alias-body.mjs \
-            stable-release.json \
-            stable-release-body.md
-
-          stable_alias_time="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          stable_alias_sha="$(
-            printf '%s\n' \
-              "chore(release): refresh stable alias for ${stable_tag}" \
-              "" \
-              "Canonical stable release: ${stable_tag}" \
-              "" \
-              "Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>" |
-              GIT_AUTHOR_NAME="github-actions[bot]" \
-              GIT_AUTHOR_EMAIL="41898282+github-actions[bot]@users.noreply.github.com" \
-              GIT_AUTHOR_DATE="${stable_alias_time}" \
-              GIT_COMMITTER_NAME="github-actions[bot]" \
-              GIT_COMMITTER_EMAIL="41898282+github-actions[bot]@users.noreply.github.com" \
-              GIT_COMMITTER_DATE="${stable_alias_time}" \
-              git commit-tree "${stable_tree}" -p "${stable_sha}"
-          )"
-          stable_alias_tree="$(git rev-parse "${stable_alias_sha}^{tree}")"
-          stable_alias_parent="$(git rev-parse "${stable_alias_sha}^")"
-          if [[ "${stable_alias_tree}" != "${stable_tree}" ]]; then
-            echo "Stable alias tree mismatch: expected ${stable_tree}, got ${stable_alias_tree}." >&2
-            exit 1
-          fi
-          if [[ "${stable_alias_parent}" != "${stable_sha}" ]]; then
-            echo "Stable alias parent mismatch: expected ${stable_sha}, got ${stable_alias_parent}." >&2
-            exit 1
-          fi
-
-          git tag -f stable "${stable_alias_sha}"
-          git push origin refs/tags/stable --force
-
-          if gh release view stable >/dev/null 2>&1; then
-            gh release delete stable --yes
-          fi
-
-          gh release create stable \
-            --verify-tag \
-            --title "Stable (Recommended)" \
-            --notes-file stable-release-body.md \
-            --latest=false
-          gh release edit "${stable_tag}" --latest
-
-  notify-feishu:
-    name: Notify Feishu
-    needs: [resolve, publish]
-    if: ${{ needs.publish.result == 'success' && needs.resolve.outputs.notify_feishu == 'true' }}
+  notify-draft-feishu:
+    name: Notify Draft Release
+    needs: [resolve, stage]
+    if: ${{ needs.stage.result == 'success' && needs.resolve.outputs.publication_mode == 'draft_only' && needs.resolve.outputs.notify_feishu == 'true' }}
     runs-on: ubuntu-latest
     env:
       FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_RELEASE_WEBHOOK_URL }}
@@ -722,9 +561,10 @@ jobs:
       TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX }}
       RELEASE_ACTOR: ${{ github.actor }}
       RELEASE_BRANCH: ${{ github.ref_type == 'branch' && github.ref_name || '' }}
+      RELEASE_PUBLICATION_STATUS: draft
       RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
       RELEASE_TARGET: ${{ needs.resolve.outputs.release_target }}
-      RELEASE_URL: ${{ needs.publish.outputs.release_url }}
+      RELEASE_URL: ${{ needs.stage.outputs.release_url }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
     steps:
@@ -755,7 +595,7 @@ jobs:
           name: tutti-desktop-release-summary
           path: release-summary
 
-      - name: Send release card
+      - name: Send draft release card
         if: env.FEISHU_WEBHOOK_URL != ''
         env:
           RELEASE_ASSET_DIRECTORY: release-assets
@@ -764,4 +604,4 @@ jobs:
 
       - name: Skip Feishu card
         if: env.FEISHU_WEBHOOK_URL == ''
-        run: echo "FEISHU_RELEASE_WEBHOOK_URL is not configured; skipping Feishu notification."
+        run: echo "FEISHU_RELEASE_WEBHOOK_URL is not configured; skipping draft notification."

--- a/apps/desktop/scripts/send-release-feishu-card.mjs
+++ b/apps/desktop/scripts/send-release-feishu-card.mjs
@@ -46,17 +46,26 @@ function resolveDisplayValue(value, fallback = "unknown") {
   return value || fallback;
 }
 
-function resolveReleaseKind(tag) {
+function resolveReleaseKind(tag, publicationStatus = "published") {
   if (/-rc\.(0|[1-9]\d*)$/i.test(tag)) {
-    return "Release candidate prerelease";
+    return publicationStatus === "draft"
+      ? "Draft release candidate prerelease"
+      : "Release candidate prerelease";
   }
   if (/-beta\.(0|[1-9]\d*)$/i.test(tag)) {
-    return "Beta prerelease";
+    return publicationStatus === "draft"
+      ? "Draft beta prerelease"
+      : "Beta prerelease";
   }
-  return "Stable latest release";
+  return publicationStatus === "draft"
+    ? "Draft stable candidate"
+    : "Stable latest release";
 }
 
-function resolveIntroText(tag) {
+function resolveIntroText(tag, publicationStatus = "published") {
+  if (publicationStatus === "draft") {
+    return `**${tag}** 已构建并上传版本固定下载目录，GitHub Release 仍为 Draft，尚未更新公开下载通道。`;
+  }
   if (/-rc\.(0|[1-9]\d*)$/i.test(tag)) {
     return `**${tag}** 已构建并同步到 RC 预览通道，可从下方入口下载安装包。`;
   }
@@ -242,6 +251,7 @@ function buildCardPayload({
   actor,
   branch,
   macUrl,
+  publicationStatus = "published",
   releaseUrl,
   runUrl,
   summary,
@@ -271,7 +281,7 @@ function buildCardPayload({
         {
           tag: "div",
           text: {
-            content: resolveIntroText(tag),
+            content: resolveIntroText(tag, publicationStatus),
             tag: "lark_md"
           }
         },
@@ -286,7 +296,7 @@ function buildCardPayload({
             {
               is_short: true,
               text: {
-                content: `**构建类型**\n${resolveReleaseKind(tag)}`,
+                content: `**构建类型**\n${resolveReleaseKind(tag, publicationStatus)}`,
                 tag: "lark_md"
               }
             },
@@ -321,8 +331,14 @@ function buildCardPayload({
         { actions, tag: "action" }
       ],
       header: {
-        template: "blue",
-        title: { content: "Tutti 发布完成", tag: "plain_text" }
+        template: publicationStatus === "draft" ? "orange" : "blue",
+        title: {
+          content:
+            publicationStatus === "draft"
+              ? "Tutti Draft 构建完成"
+              : "Tutti 发布完成",
+          tag: "plain_text"
+        }
       }
     },
     msg_type: "interactive"
@@ -359,6 +375,15 @@ async function main() {
   const target = readOption(args, "target", "RELEASE_TARGET");
   const branch = readOption(args, "branch", "RELEASE_BRANCH");
   const actor = readOption(args, "actor", "RELEASE_ACTOR");
+  const publicationStatus = readOption(
+    args,
+    "publication-status",
+    "RELEASE_PUBLICATION_STATUS",
+    "published"
+  );
+  if (publicationStatus !== "draft" && publicationStatus !== "published") {
+    throw new Error("RELEASE_PUBLICATION_STATUS must be draft or published");
+  }
   const releaseUrl = readOption(
     args,
     "release-url",
@@ -407,6 +432,7 @@ async function main() {
     branch,
     macUrl:
       mirroredMacUrl || findAssetUrl(release, /\.dmg$/i, releaseAssetBaseUrl),
+    publicationStatus,
     releaseUrl,
     runUrl,
     summary,

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -58,6 +58,13 @@ Supported manual modes:
 - `explicit_version_release`: publish an explicit release semver such as `0.1.0`, `0.1.0-beta.0`, `0.1.0-rc.0`, `1.13.0-rc.0`, or `2.0.0`
 - `unsigned_dry_run`: build unsigned artifacts without publishing a GitHub Release
 
+Manual runs also expose `publication_mode`:
+
+- `publish` keeps the existing end-to-end behavior. The workflow stages a GitHub Draft Release, uploads immutable assets, then calls the promotion workflow to update public channel metadata and publish the stable GitHub Release.
+- `draft_only` builds the same signed and notarized artifacts, keeps the GitHub Release as a draft, uploads immutable assets under the versioned S3/CloudFront `<tag>/` directory, and stops before changing any public channel pointer, changelog, stable alias, or GitHub visibility.
+
+Draft-only assets are unlisted, not private. Anyone who knows the immutable CloudFront URL can download them. This is intentional so internal release notifications can carry working QA download links. Do not use the desktop release asset prefix for confidential artifacts.
+
 Manual RC and stable release modes (`patch_rc_release`, `patch_release`, `minor_release`, and `major_release`) are branch-gated before tag resolution or artifact builds:
 
 - the workflow dispatch branch must be `main` or `release/*`
@@ -177,12 +184,14 @@ Release notification is handled by:
 apps/desktop/scripts/send-release-feishu-card.mjs
 ```
 
-After a successful publish, the workflow sends a Feishu card when:
+After a successful stage or promotion, the workflow sends a Feishu card when:
 
 - `notify_feishu` is true
 - the `FEISHU_RELEASE_WEBHOOK_URL` secret is configured
 
 If the webhook secret is missing, the workflow skips notification instead of failing the release.
+
+For `draft_only`, the card links to the authorized GitHub Draft Release and uses the immutable AWS/CloudFront asset URLs. Sending the card does not update `latest.json`, a prerelease channel pointer, `changelog.json`, or the floating `stable` release.
 
 The card links to available macOS, Windows, Linux, GitHub Release, and workflow run URLs.
 
@@ -260,6 +269,21 @@ https://<asset-base-url>/changelog.json
 ```
 
 `changelog.json` is updated only for stable releases. RC and beta builds can still generate per-run summaries for Feishu and GitHub Release notes, but they should not appear on the public changelog feed unless that policy is changed explicitly.
+
+## Draft Promotion
+
+External publication is owned by `.github/workflows/desktop-release-promote.yml`. It can be called by the normal desktop release workflow for `publication_mode=publish`, or run manually with an existing Draft Release tag after a `draft_only` build has been approved.
+
+Promotion performs these checks before changing public state:
+
+- the GitHub Release exists and its stable, RC, or beta shape matches the tag
+- the tag still points to the staged commit
+- `SHA256SUMS.txt` exists and the downloaded draft assets match it
+- the target version does not move the selected public channel backwards
+
+It then repairs or uploads the immutable AWS objects, updates release notes, publishes a stable GitHub Release when applicable, writes the selected stable/RC/beta pointer, refreshes the stable alias, verifies the public CloudFront pointer, and sends the promoted release notification. Promotion is serialized with the `desktop-release-promotion` concurrency group because stable and prerelease pointers are mutable shared state.
+
+RC and beta promotions preserve the existing GitHub policy: their GitHub Releases remain drafts while their AWS channel pointers become available. Stable promotion changes the GitHub Release from draft to public and marks it Latest.
 
 ## Release Summaries
 

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -11,6 +11,10 @@ const workflowPath = new URL(
   "../../.github/workflows/desktop-release.yml",
   import.meta.url
 );
+const promoteWorkflowPath = new URL(
+  "../../.github/workflows/desktop-release-promote.yml",
+  import.meta.url
+);
 const buildScriptPath = new URL(
   "../../tools/scripts/build-desktop-package.sh",
   import.meta.url
@@ -183,7 +187,7 @@ test("desktop release workflow passes tsh-aligned Feishu card context", async ()
   );
   assert.match(
     workflow,
-    /RELEASE_URL:\s+\${{\s*needs\.publish\.outputs\.release_url\s*}}/
+    /RELEASE_URL:\s+\${{\s*needs\.stage\.outputs\.release_url\s*}}/
   );
   assert.match(workflow, /RELEASE_ASSET_DIRECTORY:\s+release-assets/);
 });
@@ -204,16 +208,16 @@ test("desktop release workflow defaults Feishu notifications on outside manual d
 test("desktop release workflow downloads Feishu artifacts after checkout", async () => {
   const workflow = await readFile(workflowPath, "utf8");
   const notifyJobMatch = workflow.match(
-    /notify-feishu:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
+    /notify-draft-feishu:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
   );
 
-  assert.ok(notifyJobMatch, "notify-feishu job should exist");
+  assert.ok(notifyJobMatch, "draft notify job should exist");
 
   const notifyJob = notifyJobMatch[0];
   const checkoutIndex = notifyJob.indexOf("name: Checkout notification script");
   const setupNodeIndex = notifyJob.indexOf("name: Setup Node.js");
   const downloadIndex = notifyJob.indexOf("name: Download built artifacts");
-  const sendIndex = notifyJob.indexOf("name: Send release card");
+  const sendIndex = notifyJob.indexOf("name: Send draft release card");
 
   assert.notEqual(checkoutIndex, -1, "notify job should checkout the script");
   assert.notEqual(setupNodeIndex, -1, "notify job should setup Node.js");
@@ -229,91 +233,77 @@ test("desktop release workflow downloads Feishu artifacts after checkout", async
 
 test("desktop release workflow can mirror release assets to S3 and upsert direct download links", async () => {
   const workflow = await readFile(workflowPath, "utf8");
+  const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
 
   assert.match(
     workflow,
     /permissions:\s*\n\s*contents:\s*write\s*\n\s*id-token:\s*write/
   );
-  assert.match(workflow, /Upload release assets to AWS S3/);
+  assert.match(workflow, /Upload immutable draft assets to AWS S3/);
   assert.match(workflow, /aws-actions\/configure-aws-credentials@v4/);
   assert.match(
     workflow,
     /TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL=https:\/\/\${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}\.s3-accelerate\.amazonaws\.com\/\${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%\/}/
   );
   assert.match(
-    workflow,
+    `${workflow}\n${promoteWorkflow}`,
     /apps\/desktop\/scripts\/upsert-release-download-links\.mjs/
   );
-  assert.match(workflow, /Build desktop release latest metadata/);
-  assert.match(workflow, /apps\/desktop\/scripts\/build-release-latest\.mjs/);
+  assert.match(promoteWorkflow, /Build public release pointer/);
   assert.match(
-    workflow,
+    promoteWorkflow,
+    /apps\/desktop\/scripts\/build-release-latest\.mjs/
+  );
+  assert.match(
+    promoteWorkflow,
     /aws s3 cp release-latest\.json "\$\{s3_root\}\/latest\.json"/
   );
 });
 
 test("desktop release workflow only publishes root latest metadata for stable releases", async () => {
   const workflow = await readFile(workflowPath, "utf8");
-  const latestBuildStep = workflow.match(
-    /- name: Build desktop release latest metadata[\s\S]*?run: node apps\/desktop\/scripts\/build-release-latest\.mjs[^\n]*/
-  )?.[0];
-  const latestUploadStep = workflow.match(
-    /- name: Upload desktop release latest metadata to AWS S3[\s\S]*?aws s3 cp release-latest\.json "\$\{s3_root\}\/latest\.json"/
-  )?.[0];
+  const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
 
-  assert.ok(latestBuildStep, "latest metadata build step should exist");
-  assert.ok(latestUploadStep, "latest metadata upload step should exist");
-  assert.match(
-    latestBuildStep,
-    /needs\.resolve\.outputs\.release_make_latest\s*==\s*'true'/
-  );
-  assert.match(
-    latestUploadStep,
-    /needs\.resolve\.outputs\.release_make_latest\s*==\s*'true'/
-  );
-  assert.match(workflow, /Build desktop prerelease channel latest metadata/);
+  assert.match(workflow, /publication_mode:[\s\S]*?- publish\n\s*- draft_only/);
   assert.match(
     workflow,
-    /needs\.resolve\.outputs\.release_channel\s*!=\s*'stable'/
+    /needs\.resolve\.outputs\.publication_mode\s*==\s*'publish'/
+  );
+  assert.doesNotMatch(workflow, /channels\/rc\/latest\.json/);
+  assert.doesNotMatch(workflow, /aws s3 cp release-latest\.json/);
+  assert.match(
+    promoteWorkflow,
+    /if \[\[ "\$\{TUTTI_DESKTOP_RELEASE_CHANNEL\}" == "stable" \]\]; then[\s\S]*"\$\{s3_root\}\/latest\.json"/
   );
   assert.match(
-    workflow,
+    promoteWorkflow,
     /channels\/preview\/latest\.json[\s\S]*channels\/rc\/latest\.json/
   );
-  assert.match(workflow, /channels\/beta\/latest\.json/);
+  assert.match(promoteWorkflow, /channels\/beta\/latest\.json/);
 });
 
 test("desktop release workflow publishes immutable updater files before channel pointers", async () => {
   const workflow = await readFile(workflowPath, "utf8");
-  const publishJobMatch = workflow.match(
-    /publish:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
+  const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
+  const draftAssetsIndex = workflow.indexOf(
+    "name: Upload immutable draft assets to AWS S3"
+  );
+  const promoteAssetsIndex = promoteWorkflow.indexOf(
+    "name: Upload immutable release assets to AWS S3"
+  );
+  const pointerBuildIndex = promoteWorkflow.indexOf(
+    "name: Build public release pointer"
+  );
+  const pointerUploadIndex = promoteWorkflow.indexOf(
+    "name: Publish release pointer to AWS S3"
   );
 
-  assert.ok(publishJobMatch, "publish job should exist");
-  const publishJob = publishJobMatch[0];
-  const assetsIndex = publishJob.indexOf(
-    "name: Upload release assets to AWS S3"
-  );
-  const stableBuildIndex = publishJob.indexOf(
-    "name: Build desktop release latest metadata"
-  );
-  const stablePointerIndex = publishJob.indexOf(
-    "name: Upload desktop release latest metadata to AWS S3"
-  );
-  const rcBuildIndex = publishJob.indexOf(
-    "name: Build desktop prerelease channel latest metadata"
-  );
-  const rcPointerIndex = publishJob.indexOf(
-    "name: Upload desktop prerelease channel latest metadata to AWS S3"
-  );
-
-  assert.ok(assetsIndex >= 0, "immutable release assets should upload");
-  assert.ok(stableBuildIndex > assetsIndex);
-  assert.ok(stablePointerIndex > stableBuildIndex);
-  assert.ok(rcBuildIndex > assetsIndex);
-  assert.ok(rcPointerIndex > rcBuildIndex);
-  assert.match(publishJob, /channels\/rc\/latest\.json/);
-  assert.match(publishJob, /--cache-control "public, max-age=60"/);
+  assert.ok(draftAssetsIndex >= 0, "draft assets should upload immutably");
+  assert.ok(promoteAssetsIndex >= 0, "promotion should repair missing assets");
+  assert.ok(pointerBuildIndex > promoteAssetsIndex);
+  assert.ok(pointerUploadIndex > pointerBuildIndex);
+  assert.match(promoteWorkflow, /channels\/rc\/latest\.json/);
+  assert.match(promoteWorkflow, /--cache-control "public, max-age=60"/);
 });
 
 test("desktop package uses the CloudFront generic updater provider", async () => {
@@ -329,58 +319,67 @@ test("desktop package uses the CloudFront generic updater provider", async () =>
 
 test("desktop release workflow generates summaries and stable changelog metadata", async () => {
   const workflow = await readFile(workflowPath, "utf8");
+  const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
+  const releaseWorkflows = `${workflow}\n${promoteWorkflow}`;
 
-  assert.match(workflow, /Generate desktop release summary/);
+  assert.match(releaseWorkflows, /Generate desktop release summary/);
   assert.match(
-    workflow,
+    releaseWorkflows,
     /apps\/desktop\/scripts\/generate-release-summary\.mjs/
   );
-  assert.match(workflow, /secrets\.AGNES_API_KEY/);
-  assert.match(workflow, /Upload desktop release summary artifact/);
-  assert.match(workflow, /Update release notes with summary/);
-  assert.match(workflow, /apps\/desktop\/scripts\/upsert-release-summary\.mjs/);
-  assert.match(workflow, /Update desktop release changelog metadata/);
+  assert.match(releaseWorkflows, /secrets\.AGNES_API_KEY/);
+  assert.match(releaseWorkflows, /Upload desktop release summary artifact/);
+  assert.match(releaseWorkflows, /Update release notes with summary/);
   assert.match(
-    workflow,
+    releaseWorkflows,
+    /apps\/desktop\/scripts\/upsert-release-summary\.mjs/
+  );
+  assert.match(promoteWorkflow, /Update stable changelog metadata/);
+  assert.match(
+    promoteWorkflow,
     /apps\/desktop\/scripts\/upsert-release-changelog\.mjs/
   );
   assert.match(
-    workflow,
+    promoteWorkflow,
     /grep -Eq "\(404\|NoSuchKey\|Not Found\)" changelog-download\.err/
   );
-  assert.match(workflow, /"schemaVersion":"tutti\.desktop\.changelog\.v1"/);
-  assert.match(workflow, /"\$\{s3_root\}\/changelog\.json"/);
-  assert.match(workflow, /Download release summary/);
   assert.match(
-    workflow,
+    promoteWorkflow,
+    /"schemaVersion":"tutti\.desktop\.changelog\.v1"/
+  );
+  assert.match(promoteWorkflow, /"\$\{s3_root\}\/changelog\.json"/);
+  assert.match(releaseWorkflows, /Download release summary/);
+  assert.match(
+    releaseWorkflows,
     /RELEASE_SUMMARY_PATH:\s+release-summary\/release-summary\.json/
   );
 });
 
 test("desktop release workflow keeps prereleases as drafts and reserves the public list for stable", async () => {
   const workflow = await readFile(workflowPath, "utf8");
-  const publishJobMatch = workflow.match(
-    /publish:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
+  const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
+  const stageJobMatch = workflow.match(
+    /stage:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
   );
 
-  assert.ok(publishJobMatch, "publish job should exist");
-  const publishJob = publishJobMatch[0];
-  const stageIndex = publishJob.indexOf("name: Stage GitHub release assets");
-  const s3Index = publishJob.indexOf("name: Upload release assets to AWS S3");
-  const notesIndex = publishJob.indexOf(
-    "name: Update release notes with direct downloads"
+  assert.ok(stageJobMatch, "stage job should exist");
+  const stageJob = stageJobMatch[0];
+  const stageIndex = stageJob.indexOf("name: Stage GitHub release assets");
+  const s3Index = stageJob.indexOf(
+    "name: Upload immutable draft assets to AWS S3"
   );
-  const publishIndex = publishJob.indexOf(
+  const publishIndex = promoteWorkflow.indexOf(
     "name: Publish stable GitHub release"
   );
-  const archiveIndex = publishJob.indexOf(
+  const archiveIndex = promoteWorkflow.indexOf(
     "name: Archive public GitHub prereleases"
   );
-  const stableAliasIndex = publishJob.indexOf(
+  const stableAliasIndex = promoteWorkflow.indexOf(
     "name: Refresh stable release alias"
   );
 
   assert.notEqual(stageIndex, -1, "release assets should be staged");
+  assert.notEqual(s3Index, -1, "draft assets should be uploaded to AWS");
   assert.notEqual(
     publishIndex,
     -1,
@@ -392,43 +391,65 @@ test("desktop release workflow keeps prereleases as drafts and reserves the publ
     "legacy public prereleases should be archived"
   );
   assert.notEqual(stableAliasIndex, -1, "stable release alias should refresh");
-  assert.match(publishJob, /draft:\s*true/);
+  assert.match(stageJob, /draft:\s*true/);
+  assert.doesNotMatch(stageJob, /latest\.json/);
+  assert.doesNotMatch(stageJob, /--draft=false/);
   assert.match(
-    publishJob,
-    /gh release edit "\$\{TUTTI_DESKTOP_RELEASE_TAG\}" --draft=false/
+    workflow,
+    /uses:\s+\.\/\.github\/workflows\/desktop-release-promote\.yml/
   );
   assert.match(
-    publishJob,
-    /if:\s*\$\{\{\s*needs\.resolve\.outputs\.release_prerelease\s*!=\s*'true'\s*\}\}/
+    workflow,
+    /needs\.resolve\.outputs\.publication_mode\s*==\s*'publish'/
   );
   assert.match(
-    publishJob,
+    promoteWorkflow,
+    /if:\s*\$\{\{\s*needs\.resolve\.outputs\.release_channel\s*==\s*'stable'\s*\}\}/
+  );
+  assert.match(
+    promoteWorkflow,
+    /gh release edit "\$\{TUTTI_DESKTOP_RELEASE_TAG\}" --draft=false --latest/
+  );
+  assert.match(
+    promoteWorkflow,
     /gh api "repos\/\$\{GITHUB_REPOSITORY\}\/releases\?per_page=100" --paginate/
   );
   assert.match(
-    publishJob,
+    promoteWorkflow,
     /select\(\.prerelease and \(\.draft \| not\)\) \| \.id/
   );
   assert.match(
-    publishJob,
+    promoteWorkflow,
     /gh api --method PATCH "repos\/\$\{GITHUB_REPOSITORY\}\/releases\/\$\{release_id\}"[\s\\]*-F draft=true/
   );
   assert.ok(stageIndex < s3Index);
-  assert.ok(s3Index < notesIndex);
-  assert.ok(notesIndex < publishIndex);
   assert.ok(publishIndex < archiveIndex);
   assert.ok(archiveIndex < stableAliasIndex);
 });
 
-test("desktop release workflow refreshes the stable alias without taking Latest", async () => {
-  const workflow = await readFile(workflowPath, "utf8");
-  const publishJobMatch = workflow.match(
-    /publish:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
-  );
+test("desktop promotion validates draft identity, checksums, and channel ordering", async () => {
+  const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
 
-  assert.ok(publishJobMatch, "publish job should exist");
-  const publishJob = publishJobMatch[0];
-  const stableAliasStep = publishJob.match(
+  assert.match(promoteWorkflow, /workflow_call:/);
+  assert.match(promoteWorkflow, /workflow_dispatch:/);
+  assert.match(promoteWorkflow, /group:\s+desktop-release-promotion/);
+  assert.match(
+    promoteWorkflow,
+    /gh release view "\$\{release_tag\}"[\s\S]*assets,isDraft,isPrerelease,tagName,targetCommitish,url/
+  );
+  assert.match(
+    promoteWorkflow,
+    /git fetch --force origin "refs\/tags\/\$\{release_tag\}:refs\/tags\/\$\{release_tag\}"/
+  );
+  assert.match(promoteWorkflow, /sha256sum --check SHA256SUMS\.txt/);
+  assert.match(promoteWorkflow, /name:\s+Prevent release channel rollback/);
+  assert.match(promoteWorkflow, /Refusing to move/);
+  assert.match(promoteWorkflow, /name:\s+Verify public release pointer/);
+});
+
+test("desktop release workflow refreshes the stable alias without taking Latest", async () => {
+  const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
+  const stableAliasStep = promoteWorkflow.match(
     /- name: Refresh stable release alias[\s\S]*?(?=\n\s{6}- name:|\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
   )?.[0];
 
@@ -511,25 +532,25 @@ test("desktop release workflow refreshes the stable alias without taking Latest"
 
 test("desktop release workflow publishes only macOS release assets for now", async () => {
   const workflow = await readFile(workflowPath, "utf8");
-  const publishJobMatch = workflow.match(
-    /publish:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
+  const stageJobMatch = workflow.match(
+    /stage:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
   );
   const notifyJobMatch = workflow.match(
-    /notify-feishu:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
+    /notify-draft-feishu:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
   );
 
-  assert.ok(publishJobMatch, "publish job should exist");
-  assert.ok(notifyJobMatch, "notify-feishu job should exist");
+  assert.ok(stageJobMatch, "stage job should exist");
+  assert.ok(notifyJobMatch, "draft notify job should exist");
   assert.doesNotMatch(workflow, /\n\s{2}build-windows:\n/);
   assert.doesNotMatch(workflow, /\n\s{2}build-linux:\n/);
-  assert.match(publishJobMatch[0], /needs:\s+\[resolve, build-macos\]/);
-  assert.doesNotMatch(publishJobMatch[0], /build-windows|build-linux/);
+  assert.match(stageJobMatch[0], /needs:\s+\[resolve, build-macos\]/);
+  assert.doesNotMatch(stageJobMatch[0], /build-windows|build-linux/);
   assert.match(
-    publishJobMatch[0],
+    stageJobMatch[0],
     /pattern:\s+tutti-desktop-release-assets-macos/
   );
   assert.doesNotMatch(
-    publishJobMatch[0],
+    stageJobMatch[0],
     /pattern:\s+tutti-desktop-release-assets-\*/
   );
   assert.match(

--- a/tools/scripts/desktop-release-feishu-card.test.mjs
+++ b/tools/scripts/desktop-release-feishu-card.test.mjs
@@ -39,6 +39,33 @@ test("release Feishu card marks beta tags as prereleases", () => {
   assert.match(resolveIntroText("v1.12.19-beta.0"), /Beta 预览通道/);
 });
 
+test("release Feishu card clearly marks draft builds without claiming public publication", () => {
+  assert.equal(
+    resolveReleaseKind("v1.12.20", "draft"),
+    "Draft stable candidate"
+  );
+  assert.match(resolveIntroText("v1.12.20", "draft"), /仍为 Draft/);
+  assert.match(resolveIntroText("v1.12.20", "draft"), /尚未更新公开下载通道/);
+
+  const payload = buildCardPayload({
+    actor: "jomeswang",
+    branch: "release/0704",
+    macUrl: "https://example.com/tutti.dmg",
+    publicationStatus: "draft",
+    releaseUrl: "https://github.com/tutti-os/tutti/releases/tag/v1.12.20",
+    runUrl: "https://github.com/tutti-os/tutti/actions/runs/1",
+    tag: "v1.12.20",
+    target: "4039186abcdef0"
+  });
+
+  assert.equal(payload.card.header.title.content, "Tutti Draft 构建完成");
+  assert.equal(payload.card.header.template, "orange");
+  assert.equal(
+    extractFieldMap(payload).get("构建类型"),
+    "Draft stable candidate"
+  );
+});
+
 test("release Feishu card includes tsh-aligned release context fields", () => {
   const payload = buildCardPayload({
     actor: "jomeswang",


### PR DESCRIPTION
## Summary

- add `publish` and `draft_only` modes to the existing Desktop Release workflow
- upload draft artifacts to immutable AWS tag paths without updating public channel pointers
- retain Feishu notifications with a clearly labeled draft card
- add a reusable/manual Promote Desktop Release workflow that validates and publishes an existing draft

## Why

Desktop packaging previously changed GitHub and AWS/CloudFront public state in the same run, leaving no approval window between artifact creation and external publication.

## Behavior

- `publish` preserves the existing one-step release behavior
- `draft_only` creates a GitHub Draft Release, uploads exact-version AWS artifacts, and sends a draft Feishu notification, but does not update `latest.json`, channel pointers, stable aliases, changelog, or GitHub visibility
- Promote Desktop Release later validates the draft assets and checksums, prevents channel rollback, updates public pointers, and publishes stable GitHub releases

## Validation

- 58 release-related tests passed
- workflow YAML parse passed
- `git diff --check` passed
- `pnpm check:changed --tail-lines 80` passed all 6 lanes
- targeted reruns of initially flaky Go tests passed; two full pre-push runs were blocked by unrelated intermittent tests in `packages/agent/daemon/runtime`
