### PR TITLE
fix(desktop): expose packaged CLI on user PATH

### DIFF
--- a/apps/desktop/src/main/cli/cliInstaller.test.ts
+++ b/apps/desktop/src/main/cli/cliInstaller.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -14,6 +14,7 @@ test("ensureDesktopCliShim writes dev tutti-dev shim outside packaged app", asyn
 
   const state = await ensureDesktopCliShim({
     isPackaged: false,
+    pathEnv: "",
     platform: "darwin",
     repoRoot,
     resourcesPath: "/Applications/Tutti.app/Contents/Resources",
@@ -21,6 +22,7 @@ test("ensureDesktopCliShim writes dev tutti-dev shim outside packaged app", asyn
   });
 
   assert.equal(state.installed, true);
+  assert.equal(state.pathShimPath, null);
   assert.equal(state.shimPath, join(stateRootDir, "bin", "tutti-dev"));
   const content = await readFile(state.shimPath, "utf8");
   assert.match(content, /Tutti dev CLI shim/);
@@ -29,18 +31,25 @@ test("ensureDesktopCliShim writes dev tutti-dev shim outside packaged app", asyn
 
 test("ensureDesktopCliShim writes unix shim with state root", async () => {
   const stateRootDir = await mkdtemp(join(tmpdir(), "tutti-cli-state-"));
+  const homeDir = await mkdtemp(join(tmpdir(), "tutti-cli-home-"));
+  const localBinDir = join(homeDir, ".local", "bin");
+  await mkdir(localBinDir, { recursive: true });
   const shimPath = resolveUserShimPath(stateRootDir, "darwin");
   await mkdir(join(stateRootDir, "bin"), { recursive: true });
   await writeFile(shimPath, "stale", "utf8");
 
   const state = await ensureDesktopCliShim({
     isPackaged: true,
+    homeDir,
+    pathEnv: `${localBinDir}:/usr/bin:/bin`,
     platform: "darwin",
     resourcesPath: "/Applications/Tutti.app/Contents/Resources",
     stateRootDir
   });
 
   assert.equal(state.installed, true);
+  const pathShimPath = join(localBinDir, "tutti");
+  assert.equal(state.pathShimPath, pathShimPath);
   const content = await readFile(shimPath, "utf8");
   assert.match(content, /Tutti CLI shim/);
   assert.match(
@@ -48,23 +57,131 @@ test("ensureDesktopCliShim writes unix shim with state root", async () => {
     /\/Applications\/Tutti\.app\/Contents\/Resources\/bin\/tutti/
   );
   assert.match(content, new RegExp(escapeRegExp(stateRootDir)));
+  const pathShimContent = await readFile(pathShimPath, "utf8");
+  assert.match(pathShimContent, /Tutti CLI shim/);
+  assert.match(pathShimContent, new RegExp(escapeRegExp(shimPath)));
 });
 
 test("ensureDesktopCliShim writes windows command shim", async () => {
   const stateRootDir = await mkdtemp(join(tmpdir(), "tutti-cli-state-"));
+  const homeDir = await mkdtemp(join(tmpdir(), "tutti-cli-home-"));
+  const localBinDir = join(homeDir, ".local", "bin");
+  await mkdir(localBinDir, { recursive: true });
 
   const state = await ensureDesktopCliShim({
+    homeDir,
     isPackaged: true,
+    pathEnv: `${localBinDir};C:\\Windows\\System32`,
     platform: "win32",
     resourcesPath: "C:\\Program Files\\Tutti\\resources",
     stateRootDir
   });
 
   assert.equal(state.installed, true);
+  assert.equal(state.pathShimPath, null);
   assert.equal(state.shimPath, join(stateRootDir, "bin", "tutti.cmd"));
   const content = await readFile(state.shimPath, "utf8");
   assert.match(content, /tutti\.exe/);
   assert.match(content, new RegExp(escapeRegExp(stateRootDir)));
+});
+
+test("ensureDesktopCliShim keeps an existing non-Tutti PATH command", async () => {
+  const stateRootDir = await mkdtemp(join(tmpdir(), "tutti-cli-state-"));
+  const homeDir = await mkdtemp(join(tmpdir(), "tutti-cli-home-"));
+  const localBinDir = join(homeDir, ".local", "bin");
+  const existingCommandPath = join(localBinDir, "tutti");
+  const existingContent = "#!/bin/sh\necho external-tutti\n";
+  await mkdir(localBinDir, { recursive: true });
+  await writeFile(existingCommandPath, existingContent, "utf8");
+
+  const state = await ensureDesktopCliShim({
+    homeDir,
+    isPackaged: true,
+    pathEnv: `${localBinDir}:/usr/bin:/bin`,
+    platform: "darwin",
+    resourcesPath: "/Applications/Tutti.app/Contents/Resources",
+    stateRootDir
+  });
+
+  assert.equal(state.installed, true);
+  assert.equal(state.pathShimPath, null);
+  assert.equal(await readFile(existingCommandPath, "utf8"), existingContent);
+});
+
+test("ensureDesktopCliShim repairs an existing Tutti-owned PATH shim", async () => {
+  const stateRootDir = await mkdtemp(join(tmpdir(), "tutti-cli-state-"));
+  const homeDir = await mkdtemp(join(tmpdir(), "tutti-cli-home-"));
+  const localBinDir = join(homeDir, ".local", "bin");
+  const existingCommandPath = join(localBinDir, "tutti");
+  await mkdir(localBinDir, { recursive: true });
+  await writeFile(
+    existingCommandPath,
+    "#!/bin/sh\n# Tutti CLI shim\nexec '/stale/tutti' \"$@\"\n",
+    "utf8"
+  );
+
+  const state = await ensureDesktopCliShim({
+    homeDir,
+    isPackaged: true,
+    pathEnv: `${localBinDir}:/usr/bin:/bin`,
+    platform: "darwin",
+    resourcesPath: "/Applications/Tutti.app/Contents/Resources",
+    stateRootDir
+  });
+
+  assert.equal(state.pathShimPath, existingCommandPath);
+  const content = await readFile(existingCommandPath, "utf8");
+  assert.doesNotMatch(content, /\/stale\/tutti/);
+  assert.match(
+    content,
+    new RegExp(escapeRegExp(join(stateRootDir, "bin", "tutti")))
+  );
+});
+
+test("ensureDesktopCliShim uses the canonical shim when it is already on PATH", async () => {
+  const stateRootDir = await mkdtemp(join(tmpdir(), "tutti-cli-state-"));
+  const canonicalBinDir = join(stateRootDir, "bin");
+
+  const state = await ensureDesktopCliShim({
+    isPackaged: true,
+    pathEnv: `${canonicalBinDir}:/usr/bin:/bin`,
+    platform: "darwin",
+    resourcesPath: "/Applications/Tutti.app/Contents/Resources",
+    stateRootDir
+  });
+
+  assert.equal(state.pathShimPath, join(canonicalBinDir, "tutti"));
+});
+
+test("ensureDesktopCliShim recognizes a PATH symlink to the canonical bin directory", async () => {
+  const stateRootDir = await mkdtemp(join(tmpdir(), "tutti-cli-state-"));
+  const homeDir = await mkdtemp(join(tmpdir(), "tutti-cli-home-"));
+  const canonicalBinDir = join(stateRootDir, "bin");
+  const localDir = join(homeDir, ".local");
+  const linkedBinDir = join(localDir, "bin");
+  await mkdir(canonicalBinDir, { recursive: true });
+  await mkdir(localDir, { recursive: true });
+  await symlink(canonicalBinDir, linkedBinDir);
+
+  const state = await ensureDesktopCliShim({
+    homeDir,
+    isPackaged: true,
+    pathEnv: `${linkedBinDir}:/usr/bin:/bin`,
+    platform: "darwin",
+    resourcesPath: "/Applications/Tutti.app/Contents/Resources",
+    stateRootDir
+  });
+
+  assert.equal(state.pathShimPath, join(canonicalBinDir, "tutti"));
+  const content = await readFile(state.shimPath, "utf8");
+  assert.match(
+    content,
+    /\/Applications\/Tutti\.app\/Contents\/Resources\/bin\/tutti/
+  );
+  assert.doesNotMatch(
+    content,
+    new RegExp(`exec '${escapeRegExp(state.shimPath)}'`)
+  );
 });
 
 function escapeRegExp(value: string): string {

--- a/apps/desktop/src/main/cli/cliInstaller.ts
+++ b/apps/desktop/src/main/cli/cliInstaller.ts
@@ -1,12 +1,23 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync } from "node:fs";
-import { chmod, mkdir, rm, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { constants, existsSync, mkdirSync } from "node:fs";
+import {
+  access,
+  chmod,
+  mkdir,
+  readFile,
+  realpath,
+  rm,
+  writeFile
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveCachedUserShellEnv } from "../daemon/userShellEnv.ts";
 import { resolveDesktopDefaultsFromEnv } from "../defaults.ts";
 
 export interface DesktopCliShimState {
   installed: boolean;
+  pathShimPath: string | null;
   shimPath: string;
 }
 
@@ -14,6 +25,8 @@ export interface EnsureDesktopCliShimOptions {
   goBin?: string;
   isPackaged?: boolean;
   platform?: NodeJS.Platform;
+  homeDir?: string;
+  pathEnv?: string;
   repoRoot?: string;
   resourcesPath?: string;
   stateRootDir?: string;
@@ -32,6 +45,7 @@ export async function ensureDesktopCliShim(
   const shimPath = resolveUserShimPath(stateRootDir, platform, {
     development: !isPackaged
   });
+  let cliTargetPath = packagedCliPath;
 
   if (!isPackaged) {
     const repoRoot = options.repoRoot ?? resolveRepoRoot();
@@ -49,31 +63,37 @@ export async function ensureDesktopCliShim(
       repoRoot,
       targetPath: builtCliPath
     });
-    await mkdir(join(stateRootDir, "bin"), { recursive: true });
-    if (platform === "win32") {
-      await writeWindowsShim(shimPath, builtCliPath, stateRootDir, {
-        development: true
-      });
-    } else {
-      await writeUnixShim(shimPath, builtCliPath, stateRootDir, {
-        development: true
-      });
-    }
-    return {
-      installed: true,
-      shimPath
-    };
+    cliTargetPath = builtCliPath;
   }
 
   await mkdir(join(stateRootDir, "bin"), { recursive: true });
   if (platform === "win32") {
-    await writeWindowsShim(shimPath, packagedCliPath, stateRootDir);
+    await writeWindowsShim(shimPath, cliTargetPath, stateRootDir, {
+      development: !isPackaged
+    });
   } else {
-    await writeUnixShim(shimPath, packagedCliPath, stateRootDir);
+    await writeUnixShim(shimPath, cliTargetPath, stateRootDir, {
+      development: !isPackaged
+    });
+  }
+
+  let pathShimPath: string | null = null;
+  if (platform !== "win32") {
+    const pathEnv = options.pathEnv ?? (await resolveCliInstallPathEnv()) ?? "";
+    pathShimPath = await installPathShimIfPossible({
+      canonicalShimPath: shimPath,
+      commandName: isPackaged ? "tutti" : "tutti-dev",
+      development: !isPackaged,
+      homeDir: options.homeDir ?? homedir(),
+      pathEnv,
+      platform,
+      stateRootDir
+    });
   }
 
   return {
     installed: true,
+    pathShimPath,
     shimPath
   };
 }
@@ -125,8 +145,175 @@ async function writeWindowsShim(
     `"${packagedCliPath}" %*`,
     ""
   ].join("\r\n");
+  await rm(shimPath, { force: true, recursive: false });
   await writeFile(shimPath, body, "utf8");
   await chmod(shimPath, 0o755);
+}
+
+async function resolveCliInstallPathEnv(): Promise<string | null> {
+  try {
+    // Finder-launched apps can inherit a smaller PATH than the login shell.
+    const shellEnv = await resolveCachedUserShellEnv();
+    return shellEnv.PATH?.trim() || process.env.PATH?.trim() || null;
+  } catch {
+    return process.env.PATH?.trim() || null;
+  }
+}
+
+async function installPathShimIfPossible(input: {
+  canonicalShimPath: string;
+  commandName: string;
+  development: boolean;
+  homeDir: string;
+  pathEnv: string;
+  platform: NodeJS.Platform;
+  stateRootDir: string;
+}): Promise<string | null> {
+  const pathDirs = pathDirectories(input.pathEnv, input.platform);
+  if (await includesSamePath(pathDirs, dirname(input.canonicalShimPath))) {
+    return input.canonicalShimPath;
+  }
+
+  const existingCommand = await findExistingPathCommand(
+    pathDirs,
+    input.commandName
+  );
+  if (existingCommand) {
+    if (!(await isOwnedCliShim(existingCommand))) {
+      return null;
+    }
+    await writePathShim(existingCommand, input);
+    return existingCommand;
+  }
+
+  const targetDir = await firstWritableUserPathDir(pathDirs, input.homeDir);
+  if (!targetDir) {
+    return null;
+  }
+
+  const pathShimPath = join(targetDir, input.commandName);
+  await writePathShim(pathShimPath, input);
+  return pathShimPath;
+}
+
+async function writePathShim(
+  pathShimPath: string,
+  input: {
+    canonicalShimPath: string;
+    development: boolean;
+    platform: NodeJS.Platform;
+    stateRootDir: string;
+  }
+): Promise<void> {
+  if (input.platform === "win32") {
+    await writeWindowsShim(
+      pathShimPath,
+      input.canonicalShimPath,
+      input.stateRootDir,
+      { development: input.development }
+    );
+    return;
+  }
+  await writeUnixShim(
+    pathShimPath,
+    input.canonicalShimPath,
+    input.stateRootDir,
+    { development: input.development }
+  );
+}
+
+async function findExistingPathCommand(
+  pathDirs: readonly string[],
+  commandName: string
+): Promise<string | null> {
+  for (const pathDir of pathDirs) {
+    const candidate = join(pathDir, commandName);
+    if (await pathExists(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+async function firstWritableUserPathDir(
+  pathDirs: readonly string[],
+  homeDir: string
+): Promise<string | null> {
+  const resolvedPathDirs = new Set(pathDirs.map((pathDir) => resolve(pathDir)));
+  for (const candidate of [
+    join(homeDir, ".local", "bin"),
+    join(homeDir, "bin")
+  ]) {
+    const resolvedCandidate = resolve(candidate);
+    if (!resolvedPathDirs.has(resolvedCandidate)) {
+      continue;
+    }
+    try {
+      await mkdir(resolvedCandidate, { recursive: true });
+      await access(resolvedCandidate, constants.W_OK);
+      return resolvedCandidate;
+    } catch {
+      // Keep scanning stable user-owned PATH locations.
+    }
+  }
+  return null;
+}
+
+async function isOwnedCliShim(path: string): Promise<boolean> {
+  try {
+    const content = await readFile(path, "utf8");
+    return (
+      content.includes("Tutti CLI shim") ||
+      content.includes("Tutti dev CLI shim")
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pathDirectories(pathEnv: string, platform: NodeJS.Platform): string[] {
+  const separator = platform === "win32" ? ";" : delimiter;
+  return pathEnv
+    .split(separator)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+async function includesSamePath(
+  candidates: readonly string[],
+  expected: string
+): Promise<boolean> {
+  for (const candidate of candidates) {
+    if (await samePath(candidate, expected)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function samePath(left: string, right: string): Promise<boolean> {
+  const [resolvedLeft, resolvedRight] = await Promise.all([
+    canonicalizeExistingPath(left),
+    canonicalizeExistingPath(right)
+  ]);
+  return resolvedLeft === resolvedRight;
+}
+
+async function canonicalizeExistingPath(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch {
+    return resolve(path);
+  }
 }
 
 function shellQuoteValue(value: string): string {

--- a/apps/desktop/src/main/daemon/tuttidManager.ts
+++ b/apps/desktop/src/main/daemon/tuttidManager.ts
@@ -19,7 +19,7 @@ import {
   type DesktopDaemonEndpoint
 } from "../transport/paths.ts";
 import { applyUserShellProxyToSession } from "../net/sessionProxy.ts";
-import { resolveUserShellEnv } from "./userShellEnv.ts";
+import { resolveCachedUserShellEnv } from "./userShellEnv.ts";
 import {
   createDaemonRestartController,
   type DaemonRestartController
@@ -353,7 +353,7 @@ async function resolveManagedDaemonUserShellEnv(): Promise<
 > {
   const logger = getDesktopLogger();
   try {
-    const env = await resolveUserShellEnv();
+    const env = await resolveCachedUserShellEnv();
     const keys = Object.keys(env);
     if (keys.length > 0) {
       logger.info("resolved user shell env for managed tuttid", {

--- a/apps/desktop/src/main/daemon/userShellEnv.test.ts
+++ b/apps/desktop/src/main/daemon/userShellEnv.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   parseAllowedUserShellEnv,
+  resetCachedUserShellEnvForTest,
+  resolveCachedUserShellEnv,
   resolveUserShellEnvInvocation,
   userShellEnvTimeoutMs
 } from "./userShellEnv.ts";
@@ -60,4 +62,26 @@ test("parseAllowedUserShellEnv forwards proxy variables in both cases", () => {
     https_proxy: "http://127.0.0.1:7890",
     no_proxy: "localhost,.internal"
   });
+});
+
+test("cached user shell env retries after a failed resolution", async () => {
+  resetCachedUserShellEnvForTest();
+  let attempts = 0;
+
+  await assert.rejects(
+    resolveCachedUserShellEnv(async () => {
+      attempts += 1;
+      throw new Error("temporary shell failure");
+    }),
+    /temporary shell failure/
+  );
+
+  const env = await resolveCachedUserShellEnv(async () => {
+    attempts += 1;
+    return { PATH: "/Users/test/.local/bin:/usr/bin" };
+  });
+
+  assert.equal(attempts, 2);
+  assert.deepEqual(env, { PATH: "/Users/test/.local/bin:/usr/bin" });
+  resetCachedUserShellEnvForTest();
 });

--- a/apps/desktop/src/main/daemon/userShellEnv.ts
+++ b/apps/desktop/src/main/daemon/userShellEnv.ts
@@ -30,6 +30,7 @@ const allowedEnvKeys = new Set([
   "no_proxy"
 ]);
 const allowedEnvPrefixes = ["MISE_"];
+let cachedUserShellEnv: Promise<Record<string, string>> | null = null;
 
 export function resolveUserShellEnvInvocation(
   platform: NodeJS.Platform = process.platform,
@@ -130,6 +131,15 @@ export function resolveUserShellEnv(
       resolve(parseAllowedUserShellEnv(Buffer.concat(chunks)));
     });
   });
+}
+
+export function resolveCachedUserShellEnv(): Promise<Record<string, string>> {
+  cachedUserShellEnv ??= resolveUserShellEnv();
+  return cachedUserShellEnv;
+}
+
+export function resetCachedUserShellEnvForTest(): void {
+  cachedUserShellEnv = null;
 }
 
 function isAllowedUserShellEnvKey(key: string): boolean {

--- a/apps/desktop/src/main/daemon/userShellEnv.ts
+++ b/apps/desktop/src/main/daemon/userShellEnv.ts
@@ -133,8 +133,13 @@ export function resolveUserShellEnv(
   });
 }
 
-export function resolveCachedUserShellEnv(): Promise<Record<string, string>> {
-  cachedUserShellEnv ??= resolveUserShellEnv();
+export function resolveCachedUserShellEnv(
+  resolver: () => Promise<Record<string, string>> = resolveUserShellEnv
+): Promise<Record<string, string>> {
+  cachedUserShellEnv ??= resolver().catch((error) => {
+    cachedUserShellEnv = null;
+    throw error;
+  });
   return cachedUserShellEnv;
 }
 

--- a/apps/desktop/src/main/desktopAppServices.test.ts
+++ b/apps/desktop/src/main/desktopAppServices.test.ts
@@ -156,8 +156,9 @@ function createUpdateService(): AppUpdateService {
   };
 }
 
-test("createDesktopAppServices starts tuttid before creating host services", async () => {
+test("createDesktopAppServices does not wait for the CLI shim before creating host services", async () => {
   const events: string[] = [];
+  let finishCliShim: (() => void) | undefined;
   const daemonRuntime: DesktopDaemonRuntime = {
     daemonEndpoint: {
       accessToken: "token",
@@ -206,11 +207,14 @@ test("createDesktopAppServices starts tuttid before creating host services", asy
     },
     ensureCliShim() {
       events.push("cli-shim:ensure");
-      return {
-        installed: false,
-        pathShimPath: "/tmp/bin/tutti",
-        shimPath: "/tmp/tutti/bin/tutti"
-      };
+      return new Promise((resolve) => {
+        finishCliShim = () =>
+          resolve({
+            installed: false,
+            pathShimPath: "/tmp/bin/tutti",
+            shimPath: "/tmp/tutti/bin/tutti"
+          });
+      });
     }
   });
 
@@ -223,6 +227,9 @@ test("createDesktopAppServices starts tuttid before creating host services", asy
   ]);
   assert.equal(services.tuttid, daemonRuntime.tuttid);
   assert.equal(services.tuttidClient, daemonRuntime.tuttidClient);
+  assert.ok(finishCliShim);
+  finishCliShim();
+  await new Promise((resolve) => setImmediate(resolve));
 });
 
 test("createDesktopAppServices rejects when managed tuttid fails to start", async () => {

--- a/apps/desktop/src/main/desktopAppServices.test.ts
+++ b/apps/desktop/src/main/desktopAppServices.test.ts
@@ -208,6 +208,7 @@ test("createDesktopAppServices starts tuttid before creating host services", asy
       events.push("cli-shim:ensure");
       return {
         installed: false,
+        pathShimPath: "/tmp/bin/tutti",
         shimPath: "/tmp/tutti/bin/tutti"
       };
     }
@@ -273,6 +274,7 @@ test("createDesktopAppServices rejects when managed tuttid fails to start", asyn
           events.push("cli-shim:ensure");
           return {
             installed: false,
+            pathShimPath: null,
             shimPath: "/tmp/tutti/bin/tutti"
           };
         }

--- a/apps/desktop/src/main/desktopAppServices.ts
+++ b/apps/desktop/src/main/desktopAppServices.ts
@@ -84,9 +84,19 @@ export async function createDesktopAppServices(
   });
 
   try {
-    await resolveCliShim(factories, {
+    const cliShim = await resolveCliShim(factories, {
       isPackaged: Boolean(options.isPackaged)
     });
+    if (cliShim.pathShimPath) {
+      options.logger.info("tutti cli shim ready", {
+        path_shim_path: cliShim.pathShimPath,
+        shim_path: cliShim.shimPath
+      });
+    } else {
+      options.logger.warn("tutti cli shim is not discoverable on user PATH", {
+        shim_path: cliShim.shimPath
+      });
+    }
   } catch (error) {
     options.logger.warn("failed to install tutti cli shim", {
       error: formatErrorMessage(error),

--- a/apps/desktop/src/main/desktopAppServices.ts
+++ b/apps/desktop/src/main/desktopAppServices.ts
@@ -83,6 +83,31 @@ export async function createDesktopAppServices(
     });
   });
 
+  void ensureCliShimInBackground(options, factories);
+
+  const hostServices = await resolveHostServices(factories, {
+    browserNodeGuestPreloadPath: options.browserNodeGuestPreloadPath,
+    enableDevelopmentReloadShortcut: options.enableDevelopmentReloadShortcut,
+    appVersion: options.appVersion,
+    fallbackLocale: options.fallbackLocale,
+    logger: options.logger,
+    tuttidClient: daemonRuntime.tuttidClient,
+    preloadPath: options.preloadPath,
+    rendererUrl: options.rendererUrl,
+    workspaceAppPreloadPath: options.workspaceAppPreloadPath
+  });
+
+  return {
+    ...daemonRuntime,
+    ...hostServices,
+    updateService
+  };
+}
+
+async function ensureCliShimInBackground(
+  options: CreateDesktopAppServicesOptions,
+  factories?: Partial<DesktopAppServiceFactories>
+): Promise<void> {
   try {
     const cliShim = await resolveCliShim(factories, {
       isPackaged: Boolean(options.isPackaged)
@@ -103,24 +128,6 @@ export async function createDesktopAppServices(
       error_code: classifyDesktopErrorCode(error)
     });
   }
-
-  const hostServices = await resolveHostServices(factories, {
-    browserNodeGuestPreloadPath: options.browserNodeGuestPreloadPath,
-    enableDevelopmentReloadShortcut: options.enableDevelopmentReloadShortcut,
-    appVersion: options.appVersion,
-    fallbackLocale: options.fallbackLocale,
-    logger: options.logger,
-    tuttidClient: daemonRuntime.tuttidClient,
-    preloadPath: options.preloadPath,
-    rendererUrl: options.rendererUrl,
-    workspaceAppPreloadPath: options.workspaceAppPreloadPath
-  });
-
-  return {
-    ...daemonRuntime,
-    ...hostServices,
-    updateService
-  };
 }
 
 async function resolveDaemonRuntime(

--- a/docs/architecture/desktop-transport.md
+++ b/docs/architecture/desktop-transport.md
@@ -151,8 +151,12 @@ with restrictive permissions and contains the daemon loopback address plus the
 current per-run bearer token. CLI clients should read it directly and send the
 token in the HTTP `Authorization` header.
 
-The packaged desktop app may repair the user-level CLI shim during startup. The
-shim path derives from the same state root and must not mutate shell profiles or
+The packaged desktop app repairs the canonical user-level CLI shim during
+startup. The canonical shim path derives from the same state root. To expose the
+command to external shells on macOS and Linux, desktop may also install or
+repair a Tutti-owned forwarding shim in `~/.local/bin` or `~/bin`, but only
+when that directory is already present in the user's login-shell `PATH` and
+writable. It must not overwrite a non-Tutti command, mutate shell profiles, or
 write to global locations such as `/usr/local/bin`.
 
 Local development scripts install a separate `tutti-dev` command so developer

--- a/docs/architecture/desktop-transport.md
+++ b/docs/architecture/desktop-transport.md
@@ -157,7 +157,8 @@ command to external shells on macOS and Linux, desktop may also install or
 repair a Tutti-owned forwarding shim in `~/.local/bin` or `~/bin`, but only
 when that directory is already present in the user's login-shell `PATH` and
 writable. It must not overwrite a non-Tutti command, mutate shell profiles, or
-write to global locations such as `/usr/local/bin`.
+write to global locations such as `/usr/local/bin`. PATH exposure is a
+best-effort background startup task and must not delay desktop window creation.
 
 Local development scripts install a separate `tutti-dev` command so developer
 shells can target the development daemon without shadowing a packaged `tutti`

--- a/docs/conventions/local-state-storage.md
+++ b/docs/conventions/local-state-storage.md
@@ -226,7 +226,7 @@ Tutti provider startup.
 - desktop main-process operational logging defaults to `<state-dir>/logs/tutti-desktop.log`
 - desktop-to-daemon listener publication defaults to `<state-dir>/run/tuttid.listener.json`
 - the bundled CLI discovers the managed daemon by reading `<state-dir>/run/tuttid.listener.json`
-- packaged desktop shim install or repair uses `<state-dir>/bin/tutti` as the user-level command path and points it at the packaged CLI binary
+- packaged desktop shim install or repair uses `<state-dir>/bin/tutti` as the canonical user-level command path and points it at the packaged CLI binary; on macOS and Linux, when the login-shell `PATH` already contains writable `~/.local/bin` or `~/bin`, desktop also maintains a Tutti-owned forwarding shim there without replacing third-party commands
 - local development scripts install or repair `<state-dir>/bin/tutti-dev` as the development CLI command and default it to `TUTTI_ENV=development`
 - workspace app package cache, per-installation runtime/data/log state, and
   app factory job working directories live under `<state-dir>/apps`

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -25,6 +25,7 @@ Use the focused runtime index or open one area directly:
 
 Electron startup, daemon supervision, macOS packaging, updates, and performance diagnostics.
 
+- [Packaged Tutti starts but external shells cannot find `tutti`](./desktop-release.md#packaged-tutti-starts-but-external-shells-cannot-find-tutti)
 - [Desktop stable release alias disappears or is not first on Releases](./desktop-release.md#desktop-stable-release-alias-disappears-or-is-not-first-on-releases)
 - [Desktop dev GUI exits before opening](./desktop-release.md#desktop-dev-gui-exits-before-opening)
 - [Running a development tuttid breaks the production Agent session](./desktop-release.md#running-a-development-tuttid-breaks-the-production-agent-session)

--- a/docs/conventions/troubleshooting/desktop-release.md
+++ b/docs/conventions/troubleshooting/desktop-release.md
@@ -2,6 +2,38 @@
 
 [Back to troubleshooting index](./README.md)
 
+### Packaged Tutti starts but external shells cannot find `tutti`
+
+- Symptom:
+  The packaged desktop app starts normally and `~/.tutti/bin/tutti status`
+  succeeds, but a new terminal reports `command not found: tutti`.
+- Quick checks:
+  Run `command -v tutti`, print the login-shell `PATH`, and inspect
+  `~/.tutti/bin/tutti`. Check `~/.tutti/logs/tutti-desktop.log` for
+  `tutti cli shim is not discoverable on user PATH` and check whether an
+  unrelated `tutti` executable already exists earlier on `PATH`.
+- Root cause:
+  Creating the canonical shim under the state root does not make it shell
+  discoverable unless `<state-dir>/bin` is already on `PATH`. Desktop apps
+  launched from Finder may also inherit a smaller `PATH` than the user's login
+  shell, so using only the Electron process environment misses user bin
+  directories.
+- Fix:
+  Reuse the cached login-shell environment resolved for the managed daemon.
+  Keep `<state-dir>/bin/tutti` canonical, and install a forwarding shim only in
+  writable `~/.local/bin` or `~/bin` directories already present on the login
+  shell's `PATH`. Repair Tutti-owned shims on later startups, preserve unrelated
+  commands, and do not edit shell profiles or write `/usr/local/bin`.
+- Validation:
+  Start packaged Tutti, open a new login shell, and verify `command -v tutti`
+  resolves to a user bin directory and `tutti status` succeeds. Cover creation,
+  repair, canonical-PATH, no-supported-directory, and third-party-command
+  conflict cases in desktop tests.
+- References:
+  [cliInstaller.ts](../../../apps/desktop/src/main/cli/cliInstaller.ts)
+  [userShellEnv.ts](../../../apps/desktop/src/main/daemon/userShellEnv.ts)
+  [desktop-transport.md](../../architecture/desktop-transport.md)
+
 ### Desktop stable release alias disappears or is not first on Releases
 
 - Symptom:

--- a/docs/conventions/troubleshooting/desktop-release.md
+++ b/docs/conventions/troubleshooting/desktop-release.md
@@ -23,7 +23,9 @@
   Keep `<state-dir>/bin/tutti` canonical, and install a forwarding shim only in
   writable `~/.local/bin` or `~/bin` directories already present on the login
   shell's `PATH`. Repair Tutti-owned shims on later startups, preserve unrelated
-  commands, and do not edit shell profiles or write `/usr/local/bin`.
+  commands, and do not edit shell profiles or write `/usr/local/bin`. Keep this
+  installation best-effort so a slow or invalid shell environment cannot delay
+  desktop window creation.
 - Validation:
   Start packaged Tutti, open a new login shell, and verify `command -v tutti`
   resolves to a user bin directory and `tutti status` succeeds. Cover creation,


### PR DESCRIPTION
## Summary

- reuse the cached login-shell environment so Finder-launched desktop builds can see the user's normal PATH
- keep the state-root CLI shim canonical and install or repair a Tutti-owned forwarding shim only in an existing writable `~/.local/bin` or `~/bin`
- preserve unrelated `tutti` commands and resolve real directory identities so PATH symlinks cannot turn the canonical shim into a self-recursive wrapper
- keep PATH forwarding disabled on Windows for now while preserving the existing canonical Windows command shim
- add operational logging, architecture/state documentation, and a focused troubleshooting entry

## Verification

- `pnpm check:changed --tail-lines 80`
- `node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/main/cli/cliInstaller.test.ts`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm check:electron-runtime-boundaries`
- `pnpm --filter @tutti-os/desktop build`
- pre-commit formatting, lint, Electron/UI/renderer boundary hooks
- `pnpm check:full` was attempted; desktop checks passed, but the aggregate run was blocked by a missing local pinned `golangci-lint` and the unrelated untracked `packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.spec.ts`, which currently references a non-exported symbol and fails its five tests

## Fix Scope Justification

- Root cause: the canonical packaged CLI shim lives under the Tutti state root, which is normally absent from a login shell's PATH; Finder-launched apps also inherit a reduced process PATH, so desktop startup cannot select a safe user bin directory from `process.env.PATH` alone.
- Why can this not be fixed at a lower layer? CLI discovery and user-level shim installation are desktop host integration concerns. The daemon cannot change the parent desktop process environment, and editing shell profiles or writing global bin directories would violate the installation boundary. The additional lines are focused tests and durable documentation for creation, repair, conflict, and symlink-alias behavior.

## Fallback Three Questions

- Source: macOS Finder supplies a reduced PATH, and login-shell environment resolution can fail or time out.
- Why can it not be fixed at that source? Finder's launch environment is controlled by macOS, while user shell startup files are external and may be slow or invalid. Tutti must not mutate those files.
- Removal condition: remove the login-shell fallback and forwarding shim when the desktop installer provides a stable user-owned CLI directory that is guaranteed to be on PATH across supported shells.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source (not applicable; neither source changed).
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->