### PR TITLE
fix(agent-gui): prefer collapsed session titles

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -254,9 +254,11 @@ generic Agent artwork instead of provider-branded entries. Workbench Agent node
 headers show the generic Agent title while the conversation rail is expanded;
 standalone native Agent window headers omit that redundant app title. When the
 conversation rail is collapsed, the title area shows the active conversation's
-agent icon and directory name as soon as a local session id exists; it must not
-wait for provider-side session creation or conversation-title persistence. An
-empty new-conversation home does not show this header identity. The standalone
+agent icon and conversation title as soon as a local session id exists. The
+engine-owned optimistic title bridges conversation-title persistence; the
+localized untitled label, then the Agent directory name, are presentation-only
+fallbacks and must never override an available conversation title. An empty
+new-conversation home does not show this header identity. The standalone
 window keeps engine subscription, identity projection, and header rendering in
 its header vertical module rather than growing the window shell. The conversation
 title remains the detail title while the rail is expanded and the identity used

--- a/packages/agent/gui/workbench/header.test.tsx
+++ b/packages/agent/gui/workbench/header.test.tsx
@@ -172,7 +172,7 @@ describe("AgentGuiWorkbenchHeader", () => {
     expect(primary).toContainElement(actions);
   });
 
-  it("shows the selected agent identity in the collapsed header", () => {
+  it("prefers the conversation title in the collapsed header", () => {
     render(
       <AgentGuiWorkbenchHeader
         agentTitle="Cursor"
@@ -191,8 +191,8 @@ describe("AgentGuiWorkbenchHeader", () => {
       />
     );
 
-    expect(screen.getByText("Cursor")).toBeInTheDocument();
-    expect(screen.queryByText("Fix the header")).not.toBeInTheDocument();
+    expect(screen.getByText("Fix the header")).toBeInTheDocument();
+    expect(screen.queryByText("Cursor")).not.toBeInTheDocument();
     expect(screen.getByTestId("agent-gui-window-session-icon")).toHaveAttribute(
       "src",
       "asset://cursor.png"

--- a/packages/agent/gui/workbench/header.ts
+++ b/packages/agent/gui/workbench/header.ts
@@ -125,7 +125,7 @@ export function AgentGuiWorkbenchHeader({
   const sessionTitleDisplayPrompt = hasBodyRenderError
     ? ""
     : conversationTitleDisplayPrompt?.trim() || "";
-  const collapsedTitle = agentTitle?.trim() || sessionTitle;
+  const collapsedTitle = sessionTitle || agentTitle?.trim() || "";
   const sessionIconUrl = conversationIconUrl?.trim() || "";
   const sessionIconFallbackUrl = conversationIconFallbackUrl?.trim() || "";
   const hasExpandedIdentity = Boolean(


### PR DESCRIPTION
## Summary

- prefer the active conversation title when the conversation rail is collapsed
- keep the Agent name only as a final fallback while preserving the Agent icon
- update the focused header test and durable AgentGUI architecture guidance

## Motivation

PR #1122 made the collapsed header always prefer the Agent name, so persisted and optimistic conversation titles were hidden after the rail collapsed. This restores the conversation title as the primary header identity.

## Validation

- `pnpm --filter @tutti-os/agent-gui exec vitest run workbench/header.test.tsx workbench/sessionTitle.test.ts workbench/conversationIdentity.test.ts`
- `pnpm check:full`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->