### PR TITLE
fix(agent): avoid blocking turn completion on context usage

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1268,6 +1268,13 @@ the user message or after the result settles; AgentGUI needs the sidecar to
 attach a durable `compact_completed` event to the compact command turn rather
 than only the currently active turn.
 
+Claude SDK Result success is the turn lifecycle terminal signal. Best-effort
+context-usage and session-title refreshes run after the sidecar emits that
+terminal event and must never delay it. A context snapshot is invalidated when
+a newer snapshot request starts or the SDK echoes a later root user prompt, so
+a slow control response cannot overwrite usage associated with newer work. A
+delayed title refresh is likewise ignored after a later root prompt begins.
+
 When Claude resumes root work after a child completes, the SDK continuation is
 another provider turn attached to the same canonical root turn. The adapter
 publishes its provider start and terminal facts, while `services/tuttid` keeps

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1593,7 +1593,9 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   window for a model that should have 1M context, or a 200k model keeps showing
   the prior 1M total after a model switch. After one Claude Code request runs
   several tools, the used-token count may also jump from the latest iteration's
-  value to nearly the sum of every iteration in that turn.
+  value to nearly the sum of every iteration in that turn. A related lifecycle
+  symptom is that Claude has rendered its final answer but Agent GUI remains in
+  the working state until a delayed context-usage control request returns.
 - Quick checks:
   Trace the provider update first: use
   `agent_session.claude_sdk.usage_update` for Claude SDK and
@@ -1612,7 +1614,10 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   window across models. For a tool-loop spike, compare the streamed
   `normalized_used_tokens` values with the final Result update. If the final
   value equals their sum, the cumulative Result usage was mistaken for current
-  context occupancy.
+  context occupancy. For a stuck working indicator, compare the Claude SDK
+  `result` lifecycle timestamp with the later `context_window` usage update and
+  `turn_completed`; a long result-to-completion gap isolates telemetry on the
+  terminal path rather than unfinished provider work.
 - Root cause:
   Protocol v2 intentionally removed raw `runtimeContext` from the public
   session model. If the refactor removes that legacy field without adding a
@@ -1629,7 +1634,10 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   `Query.getContextUsage()` snapshot must therefore win at Result time. Calling
   that method after detaching it from the Query object loses its `this` binding;
   if the best-effort error is swallowed, the cumulative fallback remains
-  visible as a false context spike.
+  visible as a false context spike. Conversely, awaiting a correctly bound
+  `getContextUsage()` call before emitting `turn_completed` makes optional
+  telemetry a lifecycle dependency and leaves the GUI working for the duration
+  of a slow control response.
 - Fix:
   Define usage in the protocol-v2 OpenAPI contract and carry it as typed durable
   session metadata through the generated client, desktop adapter, canonical
@@ -1639,9 +1647,11 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   context-window values. Track the model associated with a cached context
   window, and only reuse the previous total for the same model or when the model
   is unknown. Do not hard-code alias-to-model mappings in Tutti. Invoke
-  `getContextUsage()` through its owning Query object and emit that snapshot
-  before considering Result usage as a fallback, so cumulative billing totals
-  never overwrite an available context snapshot.
+  `getContextUsage()` through its owning Query object after the Result has
+  terminalized the turn. Keep the authoritative snapshot and cumulative Result
+  fallback in an asynchronous telemetry path, and invalidate a delayed snapshot
+  when a newer snapshot request starts or a later root user prompt begins so
+  older usage cannot overwrite newer work.
 - Validation:
   Cover runtime-context splitting and metadata persistence, generated API
   projection, desktop canonical-session adaptation, activity-core usage
@@ -1651,8 +1661,10 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   usage updates where the last payload lacks `totalTokens`. Add a sidecar query
   fixture whose `getContextUsage()` depends on `this`, and give its Result a
   multi-iteration cumulative usage total; assert that only the authoritative
-  context snapshot is emitted. Then run the Claude SDK sidecar tests, daemon Go
-  tests, AgentGUI tests, and typechecks.
+  context snapshot is emitted. Also cover a context query that remains pending:
+  `turn_completed` must be emitted first, and a delayed snapshot must be dropped
+  after a newer snapshot request or the next root user prompt. Then run the
+  Claude SDK sidecar tests, daemon Go tests, AgentGUI tests, and typechecks.
 - References:
   [agent-activity-packages.md](../architecture/agent-activity-packages.md)
   [session_metadata.go](../../packages/agent/store-sqlite/session_metadata.go)

--- a/packages/agent/claude-sdk-sidecar/src/compaction.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/compaction.test.ts
@@ -25,3 +25,34 @@ test("compaction failure collapses a duplicated provider reason", () => {
     "Compacting failed: Not enough messages to compact."
   );
 });
+
+test("a newer context usage request supersedes an older delayed snapshot", async () => {
+  const events: ClaudeSDKSidecarEvent[] = [];
+  const resolvers: Array<(value: unknown) => void> = [];
+  const tracker = new CompactionTracker({
+    activeTurnId: () => "turn-1",
+    ensureActive: () => {},
+    clearPendingOrphans: () => {},
+    getQuery: () => ({
+      getContextUsage: () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        })
+    }),
+    emit: (event) => events.push(event as ClaudeSDKSidecarEvent)
+  });
+
+  const older = tracker.emitContextUsageSnapshot("turn-1");
+  const newer = tracker.emitContextUsageSnapshot("turn-1");
+  resolvers[1]?.({ totalTokens: 222, maxTokens: 200_000 });
+  assert.equal(await newer, "emitted");
+  resolvers[0]?.({ totalTokens: 111, maxTokens: 200_000 });
+  assert.equal(await older, "stale");
+
+  assert.equal(events.length, 1);
+  assert.deepEqual(events[0]?.payload?.contextWindow, {
+    usedTokens: 222,
+    totalTokens: 200_000,
+    compactsAutomatically: false
+  });
+});

--- a/packages/agent/claude-sdk-sidecar/src/compaction.ts
+++ b/packages/agent/claude-sdk-sidecar/src/compaction.ts
@@ -8,6 +8,8 @@ type ContextUsageQuery = {
   getContextUsage?: () => Promise<unknown>;
 };
 
+export type ContextUsageSnapshotResult = "emitted" | "unavailable" | "stale";
+
 export class CompactionTracker {
   private inProgress = false;
   private commandTurnId = "";
@@ -17,6 +19,7 @@ export class CompactionTracker {
   private readonly clearPendingOrphans: () => void;
   private readonly getQuery: () => ContextUsageQuery | undefined;
   private readonly emit: ClaudeSDKSidecarEventEmitter;
+  private contextUsageRequestGeneration = 0;
 
   constructor(options: {
     activeTurnId: () => string;
@@ -55,23 +58,30 @@ export class CompactionTracker {
 
   async emitContextUsageSnapshot(
     turnId: string,
-    options: { modelUsage?: unknown } = {}
-  ): Promise<boolean> {
+    options: { modelUsage?: unknown; shouldEmit?: () => boolean } = {}
+  ): Promise<ContextUsageSnapshotResult> {
+    const requestGeneration = ++this.contextUsageRequestGeneration;
+    const isCurrent = () =>
+      requestGeneration === this.contextUsageRequestGeneration &&
+      (!options.shouldEmit || options.shouldEmit());
     const query = this.getQuery();
     if (!query?.getContextUsage) {
-      return false;
+      return "unavailable";
     }
     try {
       const contextUsage = recordValue(await query.getContextUsage());
+      if (!isCurrent()) {
+        return "stale";
+      }
       if (!contextUsage) {
-        return false;
+        return "unavailable";
       }
       const usedTokens = numberValue(contextUsage.totalTokens);
       const contextWindowTokens =
         contextWindowTokensFromModelUsage(options.modelUsage) ||
         numberValue(contextUsage.maxTokens);
       if (usedTokens <= 0 && contextWindowTokens <= 0) {
-        return false;
+        return "unavailable";
       }
       emitUsageUpdated(this.emit, turnId, {
         contextWindow: {
@@ -82,10 +92,10 @@ export class CompactionTracker {
           compactsAutomatically: contextUsage.isAutoCompactEnabled === true
         }
       });
-      return true;
+      return "emitted";
     } catch {
       // Context usage is best-effort; result usage remains available.
-      return false;
+      return isCurrent() ? "unavailable" : "stale";
     }
   }
 

--- a/packages/agent/claude-sdk-sidecar/src/messageRouter.ts
+++ b/packages/agent/claude-sdk-sidecar/src/messageRouter.ts
@@ -29,20 +29,21 @@ export class SDKMessageRouter {
   private readonly setProviderSessionId: (value: string) => void;
   private readonly onAssistantUuid: (value: string) => void;
   private readonly onSessionState: () => void;
-  private readonly onMaybeTitle: () => Promise<void>;
+  private readonly onMaybeTitle: (shouldEmit?: () => boolean) => Promise<void>;
   private readonly turns: TurnLifecycle;
   private readonly assistant: AssistantStreamProjector;
   private readonly activities: ToolActivityProjector;
   private readonly projection: MessageProjection;
   private readonly compaction: CompactionTracker;
   private readonly emit: ClaudeSDKSidecarEventEmitter;
+  private contextUsageGeneration = 0;
 
   constructor(options: {
     getProviderSessionId: () => string;
     setProviderSessionId: (value: string) => void;
     onAssistantUuid: (value: string) => void;
     onSessionState: () => void;
-    onMaybeTitle: () => Promise<void>;
+    onMaybeTitle: (shouldEmit?: () => boolean) => Promise<void>;
     turns: TurnLifecycle;
     assistant: AssistantStreamProjector;
     activities: ToolActivityProjector;
@@ -308,7 +309,15 @@ export class SDKMessageRouter {
     if (notificationText.includes("<task-notification>")) {
       this.activities.handleTaskNotificationFromText(notificationText);
     }
+    const activeTurnIdBefore = this.turns.activeId;
     this.turns.activateForUserMessage(readSDKMessageUuid(message));
+    if (
+      !parentToolUseID &&
+      this.turns.activeId &&
+      this.turns.activeId !== activeTurnIdBefore
+    ) {
+      this.contextUsageGeneration += 1;
+    }
     const blocks = contentBlocksFromMessage(message);
     if (
       this.turns.pendingOrphans > 0 &&
@@ -350,29 +359,46 @@ export class SDKMessageRouter {
     ) {
       return;
     }
-    const contextSnapshotEmitted =
-      await this.compaction.emitContextUsageSnapshot(this.turns.activeId, {
-        modelUsage: result.modelUsage
+    const turnId = this.turns.activeId;
+    const contextUsageGeneration = this.contextUsageGeneration;
+    if (this.turns.cancelled) {
+      this.turns.settleActive("turn_canceled");
+      this.turns.clearCancelled();
+    } else if (result.subtype === "success") {
+      this.turns.settleActive("turn_completed", { stopReason: "end_turn" });
+    } else {
+      this.turns.settleActive("turn_failed", {
+        error: result.errors?.[0] ?? "Claude SDK turn failed"
       });
-    if (!contextSnapshotEmitted) {
-      emitUsageUpdated(this.emit, this.turns.activeId, {
+    }
+    void this.emitResultUsage(turnId, contextUsageGeneration, result);
+    void this.onMaybeTitle(
+      () => this.contextUsageGeneration === contextUsageGeneration
+    );
+  }
+
+  private async emitResultUsage(
+    turnId: string,
+    contextUsageGeneration: number,
+    result: {
+      usage?: unknown;
+      modelUsage?: unknown;
+      total_cost_usd?: unknown;
+    }
+  ): Promise<void> {
+    const shouldEmit = () =>
+      this.contextUsageGeneration === contextUsageGeneration;
+    const contextSnapshotResult =
+      await this.compaction.emitContextUsageSnapshot(turnId, {
+        modelUsage: result.modelUsage,
+        shouldEmit
+      });
+    if (contextSnapshotResult === "unavailable" && shouldEmit()) {
+      emitUsageUpdated(this.emit, turnId, {
         usage: result.usage,
         modelUsage: result.modelUsage,
         totalCostUsd: result.total_cost_usd
       });
     }
-    await this.onMaybeTitle();
-    if (this.turns.cancelled) {
-      this.turns.settleActive("turn_canceled");
-      this.turns.clearCancelled();
-      return;
-    }
-    if (result.subtype === "success") {
-      this.turns.settleActive("turn_completed", { stopReason: "end_turn" });
-      return;
-    }
-    this.turns.settleActive("turn_failed", {
-      error: result.errors?.[0] ?? "Claude SDK turn failed"
-    });
   }
 }

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.session.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.session.test.ts
@@ -11,6 +11,7 @@ import {
 import { fakeQueryWithInitializationModels } from "./sessionRuntimeTestQueries.assistant.ts";
 import {
   fakeCompactBoundaryQuery,
+  fakeDeferredContextUsageQuery,
   fakeFailedCompactQuery,
   fakeGuidancePromptQuery,
   fakePermissionCheckQuery,
@@ -62,6 +63,20 @@ test("guidance prompt stays on the active SDK turn", async () => {
     restoreSink();
   }
 });
+
+async function waitForCondition(
+  predicate: () => boolean,
+  description: string
+): Promise<void> {
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.fail(`timed out waiting for ${description}`);
+}
 
 test("goal set scheduling ack followed by immediate clear coalesces before SDK activation", async () => {
   const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
@@ -275,6 +290,7 @@ test("context usage prefers result modelUsage window over SDK maxTokens", async 
     await session.start();
     session.exec("turn-1", "hi");
     await waitForEvent(events, "turn_completed");
+    await waitForEvent(events, "usage_updated");
 
     const usage = events.find(
       (event) =>
@@ -292,6 +308,85 @@ test("context usage prefers result modelUsage window over SDK maxTokens", async 
       ),
       false,
       "cumulative result usage must not replace the authoritative context snapshot"
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
+test("turn completion does not wait for context usage and stale snapshots are dropped", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const contextUsageResolvers: Array<(value: unknown) => void> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "haiku",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) =>
+        fakeDeferredContextUsageQuery(prompt, contextUsageResolvers)
+    );
+
+    await session.start();
+    session.exec("turn-1", "first");
+    await waitForCondition(
+      () =>
+        events.some(
+          (event) =>
+            event.type === "turn_completed" &&
+            event.payload?.turnId === "turn-1"
+        ),
+      "first turn completion"
+    );
+    assert.equal(contextUsageResolvers.length, 1);
+
+    session.exec("turn-2", "second");
+    await waitForCondition(
+      () =>
+        events.some(
+          (event) =>
+            event.type === "turn_completed" &&
+            event.payload?.turnId === "turn-2"
+        ) && contextUsageResolvers.length === 2,
+      "second turn completion and context usage request"
+    );
+
+    contextUsageResolvers[1]?.({ totalTokens: 222, maxTokens: 200_000 });
+    await waitForCondition(
+      () =>
+        events.some(
+          (event) =>
+            event.type === "usage_updated" &&
+            event.payload?.turnId === "turn-2" &&
+            isRecord(event.payload?.contextWindow)
+        ),
+      "second turn context usage"
+    );
+
+    contextUsageResolvers[0]?.({ totalTokens: 111, maxTokens: 200_000 });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(
+      events.some(
+        (event) =>
+          event.type === "usage_updated" &&
+          event.payload?.turnId === "turn-1" &&
+          isRecord(event.payload?.contextWindow)
+      ),
+      false,
+      "the delayed first-turn snapshot must not overwrite the newer turn"
     );
   } finally {
     restoreSink();

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
@@ -192,7 +192,8 @@ export class SessionRuntime {
         this.lastAssistantUuid = value;
       },
       onSessionState: () => this.emitSessionState(),
-      onMaybeTitle: () => this.maybeEmitSessionTitleUpdated(),
+      onMaybeTitle: (shouldEmit) =>
+        this.maybeEmitSessionTitleUpdated(shouldEmit),
       turns: this.turns,
       assistant: this.assistantStream,
       activities: this.activities,
@@ -766,7 +767,9 @@ export class SessionRuntime {
     return this.configuration.sessionStatePayload();
   }
 
-  private async maybeEmitSessionTitleUpdated(): Promise<void> {
+  private async maybeEmitSessionTitleUpdated(
+    shouldEmit: () => boolean = () => true
+  ): Promise<void> {
     if (this.driver || !this.providerSessionId) {
       return;
     }
@@ -780,7 +783,7 @@ export class SessionRuntime {
       const title = normalizeTitle(
         stringValue(info?.customTitle) || stringValue(info?.summary)
       );
-      if (!title || title === this.lastTitle) {
+      if (!shouldEmit() || !title || title === this.lastTitle) {
         return;
       }
       this.lastTitle = title;

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntimeTestQueries.session.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntimeTestQueries.session.ts
@@ -73,6 +73,47 @@ export function userPromptText(message: SDKUserMessage): string {
     .join("");
 }
 
+export function fakeDeferredContextUsageQuery(
+  prompt: AsyncIterable<SDKUserMessage>,
+  contextUsageResolvers: Array<(value: unknown) => void>
+): AsyncIterable<SDKMessage> & {
+  getContextUsage: () => Promise<unknown>;
+  close: () => void;
+} {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const iterator = prompt[Symbol.asyncIterator]();
+      for (let index = 0; index < 2; index += 1) {
+        const nextPrompt = await iterator.next();
+        const promptMessage = nextPrompt.value as SDKUserMessage & {
+          uuid?: string;
+        };
+        yield {
+          ...promptMessage,
+          uuid: promptMessage.uuid,
+          type: "user",
+          parent_tool_use_id: null,
+          session_id: "provider-session-1"
+        } as SDKMessage;
+        yield {
+          type: "result",
+          subtype: "success",
+          usage: {
+            input_tokens: 120,
+            output_tokens: 8,
+            cache_read_input_tokens: 72,
+            cache_creation_input_tokens: 0
+          }
+        } as unknown as SDKMessage;
+      }
+    },
+    getContextUsage() {
+      return new Promise((resolve) => contextUsageResolvers.push(resolve));
+    },
+    close() {}
+  };
+}
+
 export function fakeCompactBoundaryQuery(
   prompt: AsyncIterable<SDKUserMessage>,
   options: { boundaryAfterResult?: boolean } = {}


### PR DESCRIPTION
## Summary

- settle Claude turns as soon as the SDK Result arrives instead of waiting for the best-effort context usage query
- refresh context usage and session titles asynchronously while dropping stale responses from superseded turns or compaction requests
- add regression coverage for delayed and out-of-order context usage snapshots
- document the terminal-event ordering and troubleshooting pattern

## Verification

- `pnpm --filter @tutti-os/claude-sdk-sidecar test` (84 passed)
- `pnpm --filter @tutti-os/claude-sdk-sidecar typecheck`
- `go test ./packages/agent/daemon/runtime`
- `pnpm check:changed` (7 lanes passed)
- `git diff --check`

## Fix Scope Justification

- Root cause: Claude SDK Result handling awaited the authoritative `getContextUsage()` snapshot before emitting the terminal turn event, so a slow provider query kept the UI in a working state after the final answer was already visible.
- Why can this not be fixed at a lower layer? Context usage is an optional, best-effort SDK query, while turn completion is owned by the sidecar lifecycle router. The router must establish the ordering boundary and allow the auxiliary refresh to finish independently. Tests and documentation are included to preserve that behavior.

## Fallback Three Questions

- Source: asynchronous context usage and title requests can resolve after a newer root turn or a newer compaction snapshot request.
- Why can it not be fixed at that source? The Claude SDK query has no request identity or cancellation contract that the sidecar can use to prevent late resolution.
- Removal condition: the generation guards can be removed if the SDK exposes cancellable or monotonically identified context/title snapshots and the sidecar adopts that contract.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->