### PR TITLE
Optimize macOS release pipeline

### DIFF
--- a/.github/workflows/desktop-release-promote.yml
+++ b/.github/workflows/desktop-release-promote.yml
@@ -537,12 +537,6 @@ jobs:
         with:
           node-version-file: .node-version
 
-      - name: Download promoted release assets
-        if: env.FEISHU_WEBHOOK_URL != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release download "${RELEASE_TAG}" --dir release-assets
-
       - name: Download release summary
         if: env.FEISHU_WEBHOOK_URL != ''
         uses: actions/download-artifact@v4
@@ -553,7 +547,6 @@ jobs:
       - name: Send release card
         if: env.FEISHU_WEBHOOK_URL != ''
         env:
-          RELEASE_ASSET_DIRECTORY: release-assets
           RELEASE_SUMMARY_PATH: release-summary/release-summary.json
         run: node apps/desktop/scripts/send-release-feishu-card.mjs
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -258,10 +258,15 @@ jobs:
           echo "publication_mode=${publication_mode}" >> "$GITHUB_OUTPUT"
 
   build-macos:
-    name: Build macOS
+    name: Build macOS (${{ matrix.arch }})
     needs: resolve
     runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, arm64, universal]
     env:
+      TUTTI_DESKTOP_MAC_ARCH: ${{ matrix.arch }}
       TUTTI_DESKTOP_RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
       TUTTI_DESKTOP_RELEASE_TARGET: ${{ needs.resolve.outputs.release_target }}
       TUTTI_DESKTOP_DRY_RUN: ${{ needs.resolve.outputs.release_dry_run }}
@@ -397,13 +402,12 @@ jobs:
       - name: Upload release artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: tutti-desktop-release-assets-macos
+          name: tutti-desktop-release-assets-macos-${{ matrix.arch }}
           compression-level: 0
           path: |
             apps/desktop/dist/*.blockmap
             apps/desktop/dist/*.dmg
             apps/desktop/dist/*.zip
-            apps/desktop/dist/*.yml
           if-no-files-found: error
           retention-days: 7
 
@@ -420,8 +424,10 @@ jobs:
       TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL }}
       TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET }}
       TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX }}
+      TUTTI_DESKTOP_RELEASE_CHANNEL: ${{ needs.resolve.outputs.release_channel }}
       TUTTI_DESKTOP_RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
       TUTTI_DESKTOP_RELEASE_TARGET: ${{ needs.resolve.outputs.release_target }}
+      TUTTI_DESKTOP_RELEASE_VERSION: ${{ needs.resolve.outputs.release_version }}
 
     steps:
       - name: Checkout
@@ -438,9 +444,18 @@ jobs:
       - name: Download built artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: tutti-desktop-release-assets-macos
-          merge-multiple: true
-          path: release-assets
+          pattern: tutti-desktop-release-assets-macos-*
+          merge-multiple: false
+          path: release-assets-input
+
+      - name: Merge macOS release artifacts and updater metadata
+        env:
+          RELEASE_CHANNEL: ${{ env.TUTTI_DESKTOP_RELEASE_CHANNEL }}
+          RELEASE_VERSION: ${{ env.TUTTI_DESKTOP_RELEASE_VERSION }}
+        run: |
+          node apps/desktop/scripts/merge-macos-release-artifacts.mjs \
+            release-assets-input \
+            release-assets
 
       - name: Generate checksums
         run: node apps/desktop/scripts/generate-checksums.mjs release-assets
@@ -580,14 +595,6 @@ jobs:
         with:
           node-version-file: .node-version
 
-      - name: Download built artifacts
-        if: env.FEISHU_WEBHOOK_URL != ''
-        uses: actions/download-artifact@v4
-        with:
-          pattern: tutti-desktop-release-assets-macos
-          merge-multiple: true
-          path: release-assets
-
       - name: Download release summary
         if: env.FEISHU_WEBHOOK_URL != ''
         uses: actions/download-artifact@v4
@@ -598,7 +605,6 @@ jobs:
       - name: Send draft release card
         if: env.FEISHU_WEBHOOK_URL != ''
         env:
-          RELEASE_ASSET_DIRECTORY: release-assets
           RELEASE_SUMMARY_PATH: release-summary/release-summary.json
         run: node apps/desktop/scripts/send-release-feishu-card.mjs
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,5 +1,10 @@
 name: Desktop Release
 
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch'
+      && format('Desktop Release · {0} · {1} · {2}', inputs.release_mode, inputs.publication_mode, github.ref_name)
+      || format('Desktop Release · {0} · {1}', github.event_name, github.ref_name) }}
+
 on:
   push:
     tags:
@@ -66,6 +71,24 @@ jobs:
       notify_feishu: ${{ steps.notify.outputs.notify_feishu }}
 
     steps:
+      - name: Summarize workflow dispatch inputs
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        env:
+          WORKFLOW_INPUTS: ${{ toJSON(inputs) }}
+        run: |
+          {
+            echo "## Desktop release request"
+            echo
+            printf -- '- Triggered by: %s\n' "${GITHUB_ACTOR}"
+            printf -- '- Ref: %s\n' "${GITHUB_REF_NAME}"
+            printf -- '- Commit: %s\n' "${GITHUB_SHA}"
+            echo
+            echo "### Workflow dispatch inputs"
+            echo
+            printf '%s\n' "${WORKFLOW_INPUTS}" | sed 's/^/    /'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Resolve target commit
         id: target
         shell: bash

--- a/apps/desktop/scripts/merge-macos-release-artifacts.mjs
+++ b/apps/desktop/scripts/merge-macos-release-artifacts.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import {
+  copyFile,
+  mkdir,
+  readdir,
+  rm,
+  stat,
+  writeFile
+} from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const macArchitectures = ["x64", "arm64", "universal"];
+const copiedArtifactSuffixes = [".blockmap", ".dmg", ".zip"];
+
+function requireValue(value, label) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) {
+    throw new Error(`${label} is required`);
+  }
+  return normalized;
+}
+
+function resolveUpdaterFileName(channel) {
+  switch (channel) {
+    case "stable":
+      return "latest-mac.yml";
+    case "rc":
+      return "rc-mac.yml";
+    case "beta":
+      return "beta-mac.yml";
+    default:
+      throw new Error(`Unsupported desktop release channel: ${channel}`);
+  }
+}
+
+function resolveMacArchitecture(fileName) {
+  const match = /-mac-(x64|arm64|universal)\.zip$/i.exec(fileName);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+function shouldCopyArtifact(fileName) {
+  return copiedArtifactSuffixes.some((suffix) => fileName.endsWith(suffix));
+}
+
+function validateArchitectureArtifacts(artifactNames, releaseVersion) {
+  for (const architecture of macArchitectures) {
+    for (const suffix of [".dmg", ".zip", ".zip.blockmap"]) {
+      const expectedSuffix = `-${releaseVersion}-mac-${architecture}${suffix}`;
+      const matches = artifactNames.filter((fileName) =>
+        fileName.endsWith(expectedSuffix)
+      );
+      if (matches.length !== 1) {
+        throw new Error(
+          `Expected one macOS ${architecture}${suffix} artifact, found ${matches.length}`
+        );
+      }
+    }
+  }
+}
+
+async function listFilesRecursively(root) {
+  const files = [];
+  const entries = await readdir(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listFilesRecursively(entryPath)));
+    } else if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+async function sha512(filePath) {
+  const hash = createHash("sha512");
+  const bytes = createReadStream(filePath);
+  for await (const chunk of bytes) {
+    hash.update(chunk);
+  }
+  return hash.digest("base64");
+}
+
+function serializeUpdaterMetadata(metadata) {
+  const lines = [`version: ${JSON.stringify(metadata.version)}`, "files:"];
+  for (const file of metadata.files) {
+    lines.push(
+      `  - url: ${JSON.stringify(file.url)}`,
+      `    sha512: ${JSON.stringify(file.sha512)}`,
+      `    size: ${file.size}`
+    );
+  }
+  lines.push(
+    `path: ${JSON.stringify(metadata.path)}`,
+    `sha512: ${JSON.stringify(metadata.sha512)}`,
+    `releaseDate: ${JSON.stringify(metadata.releaseDate)}`,
+    ""
+  );
+  return lines.join("\n");
+}
+
+async function buildMacUpdaterMetadata({
+  releaseDate = new Date().toISOString(),
+  releaseVersion,
+  zipPaths
+}) {
+  const version = requireValue(releaseVersion, "releaseVersion");
+  const zipByArchitecture = new Map();
+
+  for (const zipPath of zipPaths) {
+    const fileName = path.basename(zipPath);
+    const architecture = resolveMacArchitecture(fileName);
+    if (!architecture) {
+      throw new Error(`Cannot resolve macOS architecture from ${fileName}`);
+    }
+    if (!fileName.includes(`-${version}-mac-${architecture}.zip`)) {
+      throw new Error(
+        `${fileName} does not match desktop release version ${version}`
+      );
+    }
+    if (zipByArchitecture.has(architecture)) {
+      throw new Error(`Duplicate macOS ${architecture} updater ZIP`);
+    }
+    zipByArchitecture.set(architecture, zipPath);
+  }
+
+  for (const architecture of macArchitectures) {
+    if (!zipByArchitecture.has(architecture)) {
+      throw new Error(`Missing macOS ${architecture} updater ZIP`);
+    }
+  }
+
+  const files = [];
+  for (const architecture of macArchitectures) {
+    const zipPath = zipByArchitecture.get(architecture);
+    const fileStat = await stat(zipPath);
+    files.push({
+      url: path.basename(zipPath),
+      sha512: await sha512(zipPath),
+      size: fileStat.size
+    });
+  }
+
+  const defaultFile = files[0];
+  return {
+    version,
+    files,
+    path: defaultFile.url,
+    sha512: defaultFile.sha512,
+    releaseDate: new Date(releaseDate).toISOString()
+  };
+}
+
+async function mergeMacosReleaseArtifacts({
+  inputDirectory,
+  outputDirectory,
+  releaseChannel,
+  releaseDate,
+  releaseVersion
+}) {
+  const inputRoot = path.resolve(
+    requireValue(inputDirectory, "inputDirectory")
+  );
+  const outputRoot = path.resolve(
+    requireValue(outputDirectory, "outputDirectory")
+  );
+  if (inputRoot === outputRoot || outputRoot === path.parse(outputRoot).root) {
+    throw new Error("outputDirectory must be a dedicated non-root directory");
+  }
+
+  const sourceFiles = (await listFilesRecursively(inputRoot)).filter(
+    (filePath) => shouldCopyArtifact(path.basename(filePath))
+  );
+  if (sourceFiles.length === 0) {
+    throw new Error(`No macOS release artifacts found under ${inputRoot}`);
+  }
+
+  await rm(outputRoot, { force: true, recursive: true });
+  await mkdir(outputRoot, { recursive: true });
+
+  const copiedNames = new Set();
+  const zipPaths = [];
+  for (const sourcePath of sourceFiles.sort()) {
+    const fileName = path.basename(sourcePath);
+    if (copiedNames.has(fileName)) {
+      throw new Error(`Duplicate macOS release artifact: ${fileName}`);
+    }
+    copiedNames.add(fileName);
+    const destinationPath = path.join(outputRoot, fileName);
+    await copyFile(sourcePath, destinationPath);
+    if (fileName.endsWith(".zip")) {
+      zipPaths.push(destinationPath);
+    }
+  }
+
+  validateArchitectureArtifacts(
+    [...copiedNames],
+    requireValue(releaseVersion, "releaseVersion")
+  );
+
+  const metadata = await buildMacUpdaterMetadata({
+    releaseDate,
+    releaseVersion,
+    zipPaths
+  });
+  const updaterFileName = resolveUpdaterFileName(
+    requireValue(releaseChannel, "releaseChannel")
+  );
+  await writeFile(
+    path.join(outputRoot, updaterFileName),
+    serializeUpdaterMetadata(metadata),
+    "utf8"
+  );
+
+  return {
+    artifactNames: [...copiedNames].sort(),
+    metadata,
+    updaterFileName
+  };
+}
+
+async function main() {
+  const [inputDirectory, outputDirectory] = process.argv.slice(2);
+  const result = await mergeMacosReleaseArtifacts({
+    inputDirectory,
+    outputDirectory,
+    releaseChannel: process.env.RELEASE_CHANNEL,
+    releaseDate: process.env.RELEASE_DATE,
+    releaseVersion: process.env.RELEASE_VERSION
+  });
+  console.log(
+    `[macos-release-merge] merged ${result.artifactNames.length} artifacts and wrote ${result.updaterFileName}`
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}
+
+export {
+  buildMacUpdaterMetadata,
+  macArchitectures,
+  mergeMacosReleaseArtifacts,
+  resolveUpdaterFileName,
+  serializeUpdaterMetadata
+};

--- a/apps/desktop/scripts/send-release-feishu-card.mjs
+++ b/apps/desktop/scripts/send-release-feishu-card.mjs
@@ -126,13 +126,42 @@ async function loadRelease(repository, tag, githubToken) {
       headers
     }
   );
-  if (!response.ok) {
+  if (response.ok) {
+    return response.json();
+  }
+  if (response.status !== 404) {
     throw new Error(
       `Unable to load release ${tag}: GitHub API returned ${response.status}`
     );
   }
 
-  return response.json();
+  // GitHub's release-by-tag endpoint does not return draft releases. The
+  // authenticated releases listing does, so fall back to it for draft-only,
+  // release-candidate, and beta notification paths.
+  for (let page = 1; ; page += 1) {
+    const releasesResponse = await fetch(
+      `https://api.github.com/repos/${repository}/releases?per_page=100&page=${page}`,
+      {
+        headers
+      }
+    );
+    if (!releasesResponse.ok) {
+      throw new Error(
+        `Unable to load release ${tag}: GitHub API returned ${releasesResponse.status}`
+      );
+    }
+
+    const releases = await releasesResponse.json();
+    const release = releases.find((candidate) => candidate.tag_name === tag);
+    if (release) {
+      return release;
+    }
+    if (releases.length < 100) {
+      break;
+    }
+  }
+
+  throw new Error(`Unable to load release ${tag}: release was not found`);
 }
 
 function findPreferredAssetName(assetNames, pattern) {
@@ -463,6 +492,7 @@ export {
   buildCardPayload,
   buildSummaryElements,
   findPreferredAssetName,
+  loadRelease,
   loadReleaseSummary,
   listAssetNames,
   resolveMirroredAssetUrl,

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -125,6 +125,14 @@ Expected release artifacts include:
 - update metadata such as `.yml` and `.blockmap`
 - `SHA256SUMS.txt`
 
+The release workflow builds macOS x64, arm64, and universal packages as a
+three-entry GitHub Actions matrix. Each architecture uploads an isolated
+intermediate artifact. The stage job flattens those artifacts and rebuilds one
+channel updater manifest (`latest-mac.yml`, `rc-mac.yml`, or `beta-mac.yml`)
+from the three signed ZIP files, including fresh SHA-512 digests and sizes.
+This prevents same-named per-architecture updater manifests from overwriting
+one another when matrix artifacts are downloaded.
+
 Release notes and Feishu notifications should point the primary macOS download at the universal `.dmg`. The x64 and arm64 artifacts remain attached to the GitHub Release for users or deployment tools that want an architecture-specific installer.
 
 ## Auto Update
@@ -168,6 +176,12 @@ macOS auto-update metadata must keep x64, arm64, and universal zip entries in `l
 
 For automatic updates, electron-updater should download the same-architecture zip first: Intel Macs use `mac-x64.zip`, Apple Silicon Macs use `mac-arm64.zip`, and `mac-universal.zip` remains a fallback and the primary manual download. Do not make universal the only auto-update zip while architecture-specific packages exist.
 
+The pinned `electron-updater` macOS selection behavior also accepts a
+universal-only updater manifest on both x64 and arm64. Keep this fallback under
+test so a future updater dependency change cannot silently break universal
+compatibility, even though normal releases continue to prefer matching
+architecture-specific ZIP files.
+
 Policy meanings:
 
 - `off`: update checks are disabled
@@ -196,6 +210,10 @@ For `draft_only`, the card links to the authorized GitHub Draft Release and uses
 The card links to available macOS, Windows, Linux, GitHub Release, and workflow run URLs.
 
 When `TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL` is configured, the download buttons prefer the mirrored release asset base URL instead of GitHub asset URLs. If the explicit base URL is absent but S3 mirroring is configured, the workflow falls back to the S3 accelerate base URL.
+
+Notification jobs must resolve release asset names through the authenticated
+GitHub Release API. They must not download the full promoted or draft artifact
+set again merely to construct mirrored download URLs.
 
 After a successful mirrored upload, the workflow also upserts a managed `Direct Downloads` section into the GitHub Release body so the release description matches the Feishu direct links.
 

--- a/tools/scripts/build-desktop-package.sh
+++ b/tools/scripts/build-desktop-package.sh
@@ -7,6 +7,8 @@ VARIANT="${1:-unpack}"
 DAEMON_BUNDLE_DIR="${APP_DIR}/build/tuttid"
 CLI_BUNDLE_DIR="${APP_DIR}/build/tutti"
 DESKTOP_BUILD_VERSION="${TUTTI_DESKTOP_BUILD_VERSION:-}"
+MAC_ARCH="${TUTTI_DESKTOP_MAC_ARCH:-all}"
+MAC_ARCH_ARGS=()
 
 release_timing_log() {
   echo "[release-timing] $*"
@@ -207,7 +209,29 @@ run_electron_builder_unpack() {
   CSC_IDENTITY_AUTO_DISCOVERY=false pnpm exec electron-builder --dir --publish never "-c.extraMetadata.version=${DESKTOP_BUILD_VERSION}"
 }
 
+resolve_macos_arch_args() {
+  case "${MAC_ARCH}" in
+    all)
+      MAC_ARCH_ARGS=(--x64 --arm64 --universal)
+      ;;
+    x64)
+      MAC_ARCH_ARGS=(--x64)
+      ;;
+    arm64)
+      MAC_ARCH_ARGS=(--arm64)
+      ;;
+    universal)
+      MAC_ARCH_ARGS=(--universal)
+      ;;
+    *)
+      echo "Unsupported macOS architecture: ${MAC_ARCH}" >&2
+      return 1
+      ;;
+  esac
+}
+
 run_electron_builder_mac_unsigned() {
+  resolve_macos_arch_args
   env \
     -u CSC_LINK \
     -u CSC_KEY_PASSWORD \
@@ -220,11 +244,12 @@ run_electron_builder_mac_unsigned() {
     -u APPLE_TEAM_ID \
     -u APPLE_KEYCHAIN_PROFILE \
     CSC_IDENTITY_AUTO_DISCOVERY=false \
-    pnpm exec electron-builder --mac --x64 --arm64 --universal --publish never -c.mac.notarize=false "-c.extraMetadata.version=${DESKTOP_BUILD_VERSION}"
+    pnpm exec electron-builder --mac "${MAC_ARCH_ARGS[@]}" --publish never -c.mac.notarize=false "-c.extraMetadata.version=${DESKTOP_BUILD_VERSION}"
 }
 
 run_electron_builder_mac_signed() {
-  pnpm exec electron-builder --mac --x64 --arm64 --universal --publish never -c.mac.notarize=true "-c.extraMetadata.version=${DESKTOP_BUILD_VERSION}"
+  resolve_macos_arch_args
+  pnpm exec electron-builder --mac "${MAC_ARCH_ARGS[@]}" --publish never -c.mac.notarize=true "-c.extraMetadata.version=${DESKTOP_BUILD_VERSION}"
 }
 
 run_electron_builder_win() {

--- a/tools/scripts/desktop-release-artifact-merge.test.mjs
+++ b/tools/scripts/desktop-release-artifact-merge.test.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile
+} from "node:fs/promises";
+import { createRequire } from "node:module";
+import test from "node:test";
+import os from "node:os";
+import path from "node:path";
+import YAML from "yaml";
+
+import {
+  mergeMacosReleaseArtifacts,
+  resolveUpdaterFileName
+} from "../../apps/desktop/scripts/merge-macos-release-artifacts.mjs";
+
+const desktopRequire = createRequire(
+  new URL("../../apps/desktop/package.json", import.meta.url)
+);
+const { findFile } = desktopRequire("electron-updater/out/providers/Provider");
+
+async function createArchitectureArtifacts(root, version, architecture) {
+  const artifactDir = path.join(
+    root,
+    `tutti-desktop-release-assets-macos-${architecture}`
+  );
+  await mkdir(artifactDir, { recursive: true });
+  const stem = `Tutti-${version}-mac-${architecture}`;
+  await Promise.all([
+    writeFile(path.join(artifactDir, `${stem}.dmg`), `dmg-${architecture}`),
+    writeFile(path.join(artifactDir, `${stem}.zip`), `zip-${architecture}`),
+    writeFile(
+      path.join(artifactDir, `${stem}.zip.blockmap`),
+      `blockmap-${architecture}`
+    )
+  ]);
+}
+
+function withProcessArchitecture(architecture, callback) {
+  const descriptor = Object.getOwnPropertyDescriptor(process, "arch");
+  Object.defineProperty(process, "arch", {
+    configurable: true,
+    enumerable: true,
+    value: architecture
+  });
+  try {
+    return callback();
+  } finally {
+    Object.defineProperty(process, "arch", descriptor);
+  }
+}
+
+function selectMacUpdaterZip(files, architecture) {
+  return withProcessArchitecture(architecture, () => {
+    let resolvedFiles = files.map((info) => ({
+      info,
+      url: new URL(info.url, "https://updates.example.test/")
+    }));
+    const isArm64 = (file) =>
+      file.url.pathname.includes("arm64") || file.info.url.includes("arm64");
+    if (architecture === "arm64" && resolvedFiles.some(isArm64)) {
+      resolvedFiles = resolvedFiles.filter(isArm64);
+    } else {
+      resolvedFiles = resolvedFiles.filter((file) => !isArm64(file));
+    }
+    return findFile(resolvedFiles, "zip", ["pkg", "dmg"]);
+  });
+}
+
+test("macOS matrix artifacts merge into one architecture-aware updater manifest", async () => {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "tutti-macos-release-merge-")
+  );
+  const inputDirectory = path.join(tempRoot, "input");
+  const outputDirectory = path.join(tempRoot, "output");
+  const version = "1.2.3-rc.4";
+
+  try {
+    await Promise.all(
+      ["x64", "arm64", "universal"].map((architecture) =>
+        createArchitectureArtifacts(inputDirectory, version, architecture)
+      )
+    );
+
+    const result = await mergeMacosReleaseArtifacts({
+      inputDirectory,
+      outputDirectory,
+      releaseChannel: "rc",
+      releaseDate: "2026-07-16T00:00:00.000Z",
+      releaseVersion: version
+    });
+    const metadata = YAML.parse(
+      await readFile(path.join(outputDirectory, "rc-mac.yml"), "utf8")
+    );
+    const outputNames = await readdir(outputDirectory);
+
+    assert.equal(result.updaterFileName, "rc-mac.yml");
+    assert.equal(outputNames.length, 10);
+    assert.deepEqual(
+      metadata.files.map((file) => file.url),
+      [
+        `Tutti-${version}-mac-x64.zip`,
+        `Tutti-${version}-mac-arm64.zip`,
+        `Tutti-${version}-mac-universal.zip`
+      ]
+    );
+    assert.equal(metadata.path, `Tutti-${version}-mac-x64.zip`);
+    assert.equal(metadata.sha512, metadata.files[0].sha512);
+    assert.equal(metadata.releaseDate, "2026-07-16T00:00:00.000Z");
+    for (const file of metadata.files) {
+      assert.equal(typeof file.sha512, "string");
+      assert.ok(file.sha512.length > 40);
+      assert.equal(typeof file.size, "number");
+    }
+
+    assert.match(
+      selectMacUpdaterZip(metadata.files, "x64").url.pathname,
+      /-mac-x64\.zip$/
+    );
+    assert.match(
+      selectMacUpdaterZip(metadata.files, "arm64").url.pathname,
+      /-mac-arm64\.zip$/
+    );
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("electron-updater accepts universal ZIP metadata on both macOS architectures", () => {
+  const universalFiles = [
+    {
+      sha512: "universal-sha512",
+      size: 123,
+      url: "Tutti-1.2.3-mac-universal.zip"
+    }
+  ];
+
+  assert.match(
+    selectMacUpdaterZip(universalFiles, "x64").url.pathname,
+    /-mac-universal\.zip$/
+  );
+  assert.match(
+    selectMacUpdaterZip(universalFiles, "arm64").url.pathname,
+    /-mac-universal\.zip$/
+  );
+});
+
+test("macOS updater channel names stay compatible with electron-updater", () => {
+  assert.equal(resolveUpdaterFileName("stable"), "latest-mac.yml");
+  assert.equal(resolveUpdaterFileName("rc"), "rc-mac.yml");
+  assert.equal(resolveUpdaterFileName("beta"), "beta-mac.yml");
+  assert.throws(
+    () => resolveUpdaterFileName("nightly"),
+    /Unsupported desktop release channel/
+  );
+});

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -162,10 +162,6 @@ test("desktop release workflow passes tsh-aligned Feishu card context", async ()
 
   assert.match(
     workflow,
-    /name:\s+Download built artifacts[\s\S]*pattern:\s+tutti-desktop-release-assets-macos/
-  );
-  assert.match(
-    workflow,
     /FEISHU_WEBHOOK_URL:\s+\${{\s*secrets\.FEISHU_RELEASE_WEBHOOK_URL\s*}}/
   );
   assert.match(workflow, /RELEASE_ACTOR:\s+\${{\s*github\.actor\s*}}/);
@@ -189,7 +185,7 @@ test("desktop release workflow passes tsh-aligned Feishu card context", async ()
     workflow,
     /RELEASE_URL:\s+\${{\s*needs\.stage\.outputs\.release_url\s*}}/
   );
-  assert.match(workflow, /RELEASE_ASSET_DIRECTORY:\s+release-assets/);
+  assert.doesNotMatch(workflow, /RELEASE_ASSET_DIRECTORY:\s+release-assets/);
 });
 
 test("desktop release workflow defaults Feishu notifications on outside manual dispatch", async () => {
@@ -205,7 +201,7 @@ test("desktop release workflow defaults Feishu notifications on outside manual d
   );
 });
 
-test("desktop release workflow downloads Feishu artifacts after checkout", async () => {
+test("desktop release workflow does not redownload release assets for Feishu", async () => {
   const workflow = await readFile(workflowPath, "utf8");
   const notifyJobMatch = workflow.match(
     /notify-draft-feishu:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
@@ -216,19 +212,33 @@ test("desktop release workflow downloads Feishu artifacts after checkout", async
   const notifyJob = notifyJobMatch[0];
   const checkoutIndex = notifyJob.indexOf("name: Checkout notification script");
   const setupNodeIndex = notifyJob.indexOf("name: Setup Node.js");
-  const downloadIndex = notifyJob.indexOf("name: Download built artifacts");
+  const summaryIndex = notifyJob.indexOf("name: Download release summary");
   const sendIndex = notifyJob.indexOf("name: Send draft release card");
 
   assert.notEqual(checkoutIndex, -1, "notify job should checkout the script");
   assert.notEqual(setupNodeIndex, -1, "notify job should setup Node.js");
-  assert.notEqual(downloadIndex, -1, "notify job should download artifacts");
+  assert.notEqual(summaryIndex, -1, "notify job should download the summary");
   assert.notEqual(sendIndex, -1, "notify job should send the release card");
-  assert.ok(
-    checkoutIndex < downloadIndex,
-    "checkout must run before artifact download because actions/checkout cleans the workspace"
+  assert.equal(notifyJob.indexOf("name: Download built artifacts"), -1);
+  assert.equal(notifyJob.indexOf("RELEASE_ASSET_DIRECTORY"), -1);
+  assert.ok(checkoutIndex < summaryIndex);
+  assert.ok(setupNodeIndex < summaryIndex);
+  assert.ok(summaryIndex < sendIndex);
+});
+
+test("desktop promotion workflow does not redownload release assets for Feishu", async () => {
+  const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
+  const notifyJobMatch = promoteWorkflow.match(
+    /notify-feishu:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
   );
-  assert.ok(setupNodeIndex < downloadIndex);
-  assert.ok(downloadIndex < sendIndex);
+
+  assert.ok(notifyJobMatch, "promotion notify job should exist");
+  assert.doesNotMatch(
+    notifyJobMatch[0],
+    /Download promoted release assets|RELEASE_ASSET_DIRECTORY/
+  );
+  assert.match(notifyJobMatch[0], /name:\s+Download release summary/);
+  assert.match(notifyJobMatch[0], /name:\s+Send release card/);
 });
 
 test("desktop release workflow can mirror release assets to S3 and upsert direct download links", async () => {
@@ -547,19 +557,12 @@ test("desktop release workflow publishes only macOS release assets for now", asy
   assert.doesNotMatch(stageJobMatch[0], /build-windows|build-linux/);
   assert.match(
     stageJobMatch[0],
-    /pattern:\s+tutti-desktop-release-assets-macos/
+    /pattern:\s+tutti-desktop-release-assets-macos-\*/
   );
-  assert.doesNotMatch(
-    stageJobMatch[0],
-    /pattern:\s+tutti-desktop-release-assets-\*/
-  );
-  assert.match(
-    notifyJobMatch[0],
-    /pattern:\s+tutti-desktop-release-assets-macos/
-  );
+  assert.match(stageJobMatch[0], /merge-multiple:\s+false/);
   assert.doesNotMatch(
     notifyJobMatch[0],
-    /pattern:\s+tutti-desktop-release-assets-\*/
+    /pattern:\s+tutti-desktop-release-assets-macos/
   );
 });
 
@@ -601,7 +604,15 @@ test("desktop macOS packaging builds architecture-specific and universal artifac
     buildScript,
     /lipo\s+"\$\{output_path\}"\s+-verify_arch\s+arm64\s+x86_64\s+\|\|\s+\{/
   );
-  assert.match(buildScript, /electron-builder --mac --x64 --arm64 --universal/);
+  assert.match(buildScript, /MAC_ARCH="\$\{TUTTI_DESKTOP_MAC_ARCH:-all\}"/);
+  assert.match(buildScript, /MAC_ARCH_ARGS=\(--x64 --arm64 --universal\)/);
+  assert.match(buildScript, /MAC_ARCH_ARGS=\(--x64\)/);
+  assert.match(buildScript, /MAC_ARCH_ARGS=\(--arm64\)/);
+  assert.match(buildScript, /MAC_ARCH_ARGS=\(--universal\)/);
+  assert.match(
+    buildScript,
+    /electron-builder --mac "\$\{MAC_ARCH_ARGS\[@\]\}"/
+  );
   // The native claude binaries are provisioned at runtime by tuttid
   // (services/tuttid/service/agentstatus/claude_binary.go); the vendored
   // sidecar bundle must stay JS-only so every architecture ships identical
@@ -646,6 +657,15 @@ test("desktop package verifies channel-specific prerelease updater metadata", as
   assert.match(
     workflow,
     /updater_metadata="apps\/desktop\/dist\/\$\{TUTTI_DESKTOP_RELEASE_CHANNEL\}-mac\.yml"/
+  );
+  assert.match(workflow, /matrix:\s*\n\s*arch:\s*\[x64, arm64, universal\]/);
+  assert.match(
+    workflow,
+    /name:\s+Merge macOS release artifacts and updater metadata/
+  );
+  assert.match(
+    workflow,
+    /node apps\/desktop\/scripts\/merge-macos-release-artifacts\.mjs/
   );
   assert.doesNotMatch(workflow, /cp apps\/desktop\/dist\/latest-mac\.yml/);
 });

--- a/tools/scripts/desktop-release-feishu-card.test.mjs
+++ b/tools/scripts/desktop-release-feishu-card.test.mjs
@@ -4,11 +4,46 @@ import assert from "node:assert/strict";
 import {
   buildCardPayload,
   buildSummaryElements,
+  loadRelease,
   resolveMirroredAssetUrl,
   resolveReleaseAssetBaseUrl,
   resolveIntroText,
   resolveReleaseKind
 } from "../../apps/desktop/scripts/send-release-feishu-card.mjs";
+
+test("release Feishu card loads draft releases from the authenticated listing", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const requests = [];
+  globalThis.fetch = async (url, options) => {
+    requests.push({ url, options });
+    if (url.includes("/releases/tags/")) {
+      return new Response(null, { status: 404 });
+    }
+    return Response.json([
+      {
+        assets: [{ name: "Tutti-0.1.0-rc.4-mac-universal.dmg" }],
+        draft: true,
+        tag_name: "v0.1.0-rc.4"
+      }
+    ]);
+  };
+
+  const release = await loadRelease(
+    "tutti-os/tutti",
+    "v0.1.0-rc.4",
+    "test-token"
+  );
+
+  assert.equal(release.draft, true);
+  assert.equal(release.tag_name, "v0.1.0-rc.4");
+  assert.equal(requests.length, 2);
+  assert.match(requests[1].url, /\/releases\?per_page=100&page=1$/);
+  assert.equal(requests[1].options.headers.authorization, "Bearer test-token");
+});
 
 function extractFieldMap(payload) {
   const fieldEntries = payload.card.elements


### PR DESCRIPTION
## What changed

- build macOS x64, arm64, and universal release packages in a three-entry GitHub Actions matrix
- keep matrix artifacts isolated, then flatten them in the stage job and generate one channel updater manifest from the signed ZIP files
- recompute updater SHA-512 digests and sizes from the staged artifacts and preserve x64, arm64, universal selection order
- remove full release-asset downloads from draft and promoted Feishu notification jobs; the existing authenticated GitHub Release API path now supplies asset names
- expose manual release mode, publication mode, and branch in the Actions run name, and record the complete workflow dispatch inputs in the run summary
- document and test the macOS updater contract, including universal-only fallback on both x64 and arm64

## Why

The previous release job packaged and notarized all three macOS architectures serially in one runner. In the measured release, `electron-builder` occupied 17m46s of a 26m17s workflow. The notification jobs also downloaded the complete ~1.56 GB artifact set again only to derive download links.

The matrix moves architecture packaging and Apple notarization onto parallel runners without removing any release artifact. The expected wall-clock improvement is roughly 5-8 minutes; the actual gain should be confirmed on the first signed release run.

Manual workflow inputs were only recoverable by inspecting individual step logs. The descriptive run name and job summary make the selected release parameters directly visible for future runs.

## Updater compatibility

The stage job emits `latest-mac.yml`, `rc-mac.yml`, or `beta-mac.yml` with all three ZIP entries. Tests exercise the selection helper from the pinned `electron-updater` 6.8.3 dependency:

- x64 selects the x64 ZIP
- arm64 selects the arm64 ZIP
- a universal-only manifest remains selectable on both architectures

## Validation

- `node --test tools/scripts/desktop-release-artifact-merge.test.mjs tools/scripts/desktop-release-config.test.mjs tools/scripts/desktop-release-feishu-card.test.mjs`
- `pnpm test:tools`
- `pnpm check:changed`
- `pnpm check:full`
- `bash -n tools/scripts/build-desktop-package.sh`
- `pnpm exec prettier --check .github/workflows/desktop-release.yml`
- `actionlint .github/workflows/desktop-release.yml`
- workflow YAML parse and repository formatting checks
