### PR TITLE
fix(agent-gui): preserve cold-start rail sessions

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1593,6 +1593,13 @@ reconciliation of one of those entities is not new rail membership and must
 preserve every loaded section page and cursor. Entity-list order or count must
 not serve directly as a section-query invalidation key; rail invalidation must
 account for membership already owned by loaded section pages.
+Workspace historical reconciliation is entity hydration, not a rail membership
+mutation. While `workspaceReconcile.status` is `loading`, the query controller
+must only advance its membership comparison baseline; it must not invalidate or
+target-refresh section pages for `session/snapshotReceived`. The initial section
+response owns bootstrap membership and must upsert returned entities into the
+workspace engine before publishing membership ids. Once reconciliation is ready,
+later canonical membership mutations continue through the targeted refresh path.
 The aggregate first-page section query is reserved for workspace, rail filter,
 or user-project inventory changes. Session membership changes use only the
 affected section/pinned first-page endpoints; Show more continues to use the

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -695,7 +695,8 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   one selected overlay may show
   Show more/Show less even when only six sessions exist, or a nine-session
   section may ignore the first Show more click. Restart can reproduce the same
-  selected-row loss.
+  selected-row loss. On cold startup, All may also show section headers without
+  session rows until selecting Codex and then returning to All.
 - Quick checks:
   Inspect `workspace_agent_sessions.agent_target_id` and `rail_section_key`.
   Confirm section requests carry the selected `agentTargetId` before pagination
@@ -736,6 +737,11 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   status. A fresh rail hit with no composer transport indicates both caches were
   reused; a long rail request isolates section loading, while a long composer
   event isolates target option discovery.
+  For the cold-start empty-row variant, compare
+  `agent.gui.runtime.snapshot_changed` session counts with
+  `agent_gui.conversation_rail.first_pages_slow`. If historical reconciliation
+  finishes while the first-page request is unresolved, confirm no section-page
+  request is emitted with `refreshReason=membership_change`.
 - Root cause:
   A second React summary cache mixed entity data, section membership, active
   selection, and visible-item limits. Effects manually patched section rows
@@ -751,6 +757,10 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   migration marker after a required physical index disappears; treating the
   marker alone as proof of the schema invariant makes every section bootstrap
   fail while an active-session overlay can misleadingly remain visible.
+  Historical `session/snapshotReceived` hydration can also be mistaken for a
+  live rail membership mutation, causing a targeted section refresh to race the
+  unresolved bootstrap request. Caching session payloads or a separate ingestion
+  marker makes that race worse by splitting entity ownership from the engine.
 - Fix:
   Keep page sessions in the workspace engine. Cache only ordered membership ids,
   cursor, `hasMore`, and `totalCount` in the controller query, then join ids to
@@ -765,6 +775,11 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   during every store migration pass, including when the corresponding marker is
   already recorded, so schema drift repairs itself without rewriting session
   data.
+  While workspace reconciliation is loading, update only the rail membership
+  comparison baseline; do not target-refresh pages for historical snapshot
+  hydration. Upsert first-page response entities into the workspace engine before
+  publishing their membership ids. Resolved query cache entries must not contain
+  session entities or ingestion ownership state.
   Do not add one `UNION ALL` arm per section; that restores section-count scaling
   and inherits SQLite's compound-select term limit.
 - Validation:
@@ -780,6 +795,9 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   requested-section histories. Cover Codex -> All -> Codex,
   client restart restore, active row outside first page, five-plus-active totals,
   nine-session Show more, slow provider refetch, and bounded snapshot omission.
+  Add a cold-start ordering case where historical workspace hydration arrives
+  before the first section response and assert that no targeted membership refresh
+  is issued.
 - References:
   [useAgentGUIConversationRailQuery.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts)
   [agentGuiConversationRail.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts)

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
@@ -9,6 +9,99 @@ import {
 } from "./AgentGUIConversationRailQueryController";
 
 describe("AgentGUIConversationRailQueryController", () => {
+  it("does not treat workspace hydration as a rail membership mutation", async () => {
+    let resolveWorkspaceReconcile!: () => void;
+    const engine = createTestAgentSessionEngine("test-workspace", {
+      execute: async (command) => {
+        if (command.type !== "engine/reconcileWorkspace") return { ok: true };
+        await new Promise<void>((resolve) => {
+          resolveWorkspaceReconcile = resolve;
+        });
+        return { ok: true };
+      }
+    });
+    const session = normalizeAgentActivitySession({
+      activeTurnId: null,
+      agentSessionId: "historical-session",
+      agentTargetId: "local:codex",
+      cwd: "/workspace",
+      latestTurnInteractions: [],
+      pendingInteractions: [],
+      provider: "codex",
+      railSectionKey: "conversations",
+      title: "Historical session",
+      updatedAtUnixMs: 1,
+      workspaceId: "test-workspace"
+    });
+    let resolveFirstPages!: () => void;
+    const listSessionSections = vi.fn<
+      NonNullable<ConversationRailQueryRuntime["listSessionSections"]>
+    >((input) =>
+      new Promise<void>((resolve) => {
+        resolveFirstPages = resolve;
+      }).then(() => ({
+        sections: [
+          {
+            hasMore: false,
+            kind: "conversations" as const,
+            sectionKey: "conversations",
+            sessions: [session],
+            totalCount: 1
+          }
+        ],
+        workspaceId: input.workspaceId
+      }))
+    );
+    const listSessionSectionPage = vi.fn(async (input) => ({
+      hasMore: false,
+      kind: "conversations" as const,
+      sectionKey: input.sectionKey,
+      sessions: [session],
+      totalCount: 1
+    }));
+    const controller = new AgentGUIConversationRailQueryController({
+      engine,
+      getActiveConversationId: () => null,
+      runtime: { listSessionSections, listSessionSectionPage },
+      workspaceId: "test-workspace"
+    });
+    controller.configure({
+      conversationFilter: { kind: "all" },
+      previewMode: false,
+      sectionAgentTargetFallbackId: null,
+      userProjects: []
+    });
+
+    const detach = controller.attach();
+    expect(engine.getSnapshot().engineRuntime.workspaceReconcile.status).toBe(
+      "loading"
+    );
+    engine.dispatch({ sessions: [session], type: "session/snapshotReceived" });
+
+    expect(listSessionSectionPage).not.toHaveBeenCalled();
+
+    resolveWorkspaceReconcile();
+    await vi.waitFor(() =>
+      expect(engine.getSnapshot().engineRuntime.workspaceReconcile.status).toBe(
+        "ready"
+      )
+    );
+    resolveFirstPages();
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
+    expect(controller.getSnapshot().runtimeRailMemberships).toEqual([
+      expect.objectContaining({
+        id: "conversations",
+        sessionIds: ["historical-session"]
+      })
+    ]);
+    expect(listSessionSectionPage).not.toHaveBeenCalled();
+
+    detach();
+    engine.dispose();
+  });
+
   it("debounces conversation searches and immediately clears an active query", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -435,7 +435,11 @@ export class AgentGUIConversationRailQueryController {
 
   private handleEngineState(state: AgentSessionEngineState): void {
     const next = projectConversationRailMembershipRecords(state);
-    if (this.ingestingSessions || !this.runtimeSectionsEnabled()) {
+    if (
+      this.ingestingSessions ||
+      !this.runtimeSectionsEnabled() ||
+      state.engineRuntime.workspaceReconcile.status === "loading"
+    ) {
       this.previousMembershipRecords = next;
       return;
     }
@@ -484,7 +488,7 @@ export class AgentGUIConversationRailQueryController {
         ? this.diagnosticNow()
         : null;
     if (cached && this.queryState.resolvedScopeKey !== scopeKey) {
-      this.applyCachedFirstPages(scopeKey, cached);
+      this.applyCachedFirstPages(cached);
       this.emit();
     }
     if (
@@ -526,6 +530,10 @@ export class AgentGUIConversationRailQueryController {
           limitPerSection: SECTION_PAGE_SIZE,
           workspaceId: this.workspaceId
         });
+        this.upsertSessions([
+          ...(page.pinned?.sessions ?? []),
+          ...page.sections.flatMap((section) => section.sessions)
+        ]);
         return cachedConversationRailQueryFromFirstPages(page, scopeKey);
       })
       .then((entry) => {
@@ -536,7 +544,7 @@ export class AgentGUIConversationRailQueryController {
           return;
         }
         const requestResolvedAt = this.diagnosticNow();
-        this.applyCachedFirstPages(scopeKey, entry);
+        this.applyCachedFirstPages(entry);
         this.emit();
         const completedAt = this.diagnosticNow();
         this.providerSwitchDiagnostics.complete(scopeKey, {
@@ -612,18 +620,12 @@ export class AgentGUIConversationRailQueryController {
   }
 
   private applyCachedFirstPages(
-    scopeKey: string,
     entry: ReturnType<
       WorkspaceQueryCache<CachedConversationRailQuery>["read"]
     > &
       object
   ): void {
-    this.queryState = applyCachedConversationRailQuery({
-      cache: this.sessionSectionsQueryCache,
-      entry,
-      scopeKey,
-      upsertSessions: (sessions) => this.upsertSessions(sessions)
-    });
+    this.queryState = applyCachedConversationRailQuery({ entry });
   }
 
   private writeCurrentQueryCache(): void {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryCache.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryCache.ts
@@ -1,4 +1,3 @@
-import type { AgentActivitySession } from "@tutti-os/agent-activity-core";
 import type {
   AgentActivityRuntimeSessionPage,
   AgentActivityRuntimeSessionSection,
@@ -18,7 +17,6 @@ export interface CachedConversationRailQuery {
   queryState: ConversationRailQueryState;
   returnedSessionCount: number;
   sectionCount: number;
-  sessions: readonly AgentActivitySession[];
 }
 
 export type ConversationRailRefreshedPage =
@@ -47,10 +45,6 @@ export function cachedConversationRailQueryFromFirstPages(
       conversationRailPageState(section)
     );
   }
-  const sessions = [
-    ...(page.pinned?.sessions ?? []),
-    ...page.sections.flatMap((section) => section.sessions)
-  ];
   return {
     queryState: {
       pending: false,
@@ -59,21 +53,19 @@ export function cachedConversationRailQueryFromFirstPages(
       sectionPageStates,
       sections
     },
-    returnedSessionCount: sessions.length,
-    sectionCount: page.sections.length + (page.pinned ? 1 : 0),
-    sessions
+    returnedSessionCount:
+      (page.pinned?.sessions.length ?? 0) +
+      page.sections.reduce(
+        (count, section) => count + section.sessions.length,
+        0
+      ),
+    sectionCount: page.sections.length + (page.pinned ? 1 : 0)
   };
 }
 
 export function applyCachedConversationRailQuery(input: {
-  cache: WorkspaceQueryCache<CachedConversationRailQuery>;
   entry: WorkspaceQueryCacheEntry<CachedConversationRailQuery>;
-  scopeKey: string;
-  upsertSessions(sessions: readonly AgentActivitySession[]): void;
 }): ConversationRailQueryState {
-  if (input.cache.claimIngestion(input.scopeKey, input.entry.version)) {
-    input.upsertSessions(input.entry.value.sessions);
-  }
   return input.entry.value.queryState;
 }
 
@@ -97,8 +89,7 @@ export function writeConversationRailQueryCache(input: {
       (count, section) => count + section.sessionIds.length,
       0
     ),
-    sectionCount: queryState.sections.length,
-    sessions: []
+    sectionCount: queryState.sections.length
   });
 }
 

--- a/packages/agent/gui/shared/query/workspaceQueryCache.ts
+++ b/packages/agent/gui/shared/query/workspaceQueryCache.ts
@@ -6,7 +6,6 @@ export interface WorkspaceQueryCacheEntry<TValue> {
 }
 
 export interface WorkspaceQueryCache<TValue> {
-  claimIngestion(key: string, version: number): boolean;
   invalidate(key?: string): void;
   read(key: string): WorkspaceQueryCacheEntry<TValue> | null;
   request(
@@ -19,10 +18,7 @@ export interface WorkspaceQueryCache<TValue> {
 type MutableWorkspaceQueryCacheEntry<TValue> = Omit<
   WorkspaceQueryCacheEntry<TValue>,
   "stale"
-> & {
-  ingested: boolean;
-  stale: boolean;
-};
+> & { stale: boolean };
 
 const DEFAULT_MAX_ENTRIES = 24;
 
@@ -54,11 +50,9 @@ export function createWorkspaceQueryCache<TValue>(options?: {
 
   const write = (
     key: string,
-    value: TValue,
-    ingested: boolean
+    value: TValue
   ): MutableWorkspaceQueryCacheEntry<TValue> => {
     const entry: MutableWorkspaceQueryCacheEntry<TValue> = {
-      ingested,
       resolvedAtUnixMs: now(),
       stale: false,
       value,
@@ -70,14 +64,6 @@ export function createWorkspaceQueryCache<TValue>(options?: {
   };
 
   return {
-    claimIngestion(key, expectedVersion) {
-      const entry = entries.get(key);
-      if (!entry || entry.version !== expectedVersion || entry.ingested) {
-        return false;
-      }
-      entry.ingested = true;
-      return true;
-    },
     invalidate(key) {
       if (key !== undefined) {
         const entry = entries.get(key);
@@ -97,7 +83,7 @@ export function createWorkspaceQueryCache<TValue>(options?: {
       if (active) return active;
       const request = load()
         .then((value): WorkspaceQueryCacheEntry<TValue> => {
-          return write(key, value, false);
+          return write(key, value);
         })
         .finally(() => {
           if (requests.get(key) === request) requests.delete(key);
@@ -106,7 +92,7 @@ export function createWorkspaceQueryCache<TValue>(options?: {
       return request;
     },
     write(key, value) {
-      return write(key, value, true);
+      return write(key, value);
     }
   };
 }


### PR DESCRIPTION
## Summary

- Treat workspace historical reconciliation as entity hydration so it cannot invalidate the unresolved cold-start conversation rail request.
- Upsert first-page sessions into the workspace Engine before publishing cached membership.
- Keep the rail query cache limited to membership IDs and pagination metadata; remove duplicate ingestion ownership.
- Add a deterministic cold-start ordering regression test and update architecture/troubleshooting docs.

## Verification

- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts`
- `pnpm lint:ts`
- `pnpm typecheck`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:changed --tail-lines 80`
- `pnpm check:full` via pre-push hook

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->