### PR TITLE
fix(agent): aggregate child approvals in message center

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -795,8 +795,12 @@ test("WorkspaceAgentActivityService preserves live provenance across a transient
     tuttidClient: {
       getWorkspaceAgentSession: async () => {
         getCalls += 1;
-        if (getCalls === 1) throw new Error("temporary reconcile failure");
-        return { session: settled, childSessions: [], turns: [] };
+        if (getCalls === 2) throw new Error("temporary reconcile failure");
+        return {
+          session: getCalls === 1 ? running : settled,
+          childSessions: [],
+          turns: []
+        };
       },
       listWorkspaceAgentSessionMessages: async () => ({
         hasMore: false,
@@ -836,7 +840,9 @@ test("WorkspaceAgentActivityService preserves live provenance across a transient
   await new Promise((resolve) => setImmediate(resolve));
   await new Promise((resolve) => setImmediate(resolve));
 
-  assert.equal(getCalls, 3);
+  // Initial active-root hydration + failed live pull + combined detail/message
+  // synchronization (detail before and after messages).
+  assert.equal(getCalls, 4);
   assert.equal(
     selectSessionAttention(
       service.getSessionEngine("ws-1").getSnapshot(),
@@ -1046,7 +1052,12 @@ test("WorkspaceAgentActivityService fetches detail before combined message recon
   await new Promise((resolve) => setImmediate(resolve));
 
   const session = service.getSnapshot("ws-1").sessions[0];
-  assert.deepEqual(calls, ["getSession", "listMessages", "getSession"]);
+  assert.deepEqual(calls, [
+    "getSession", // initial active-root child hydration
+    "getSession",
+    "listMessages",
+    "getSession"
+  ]);
   assert.equal(session?.activeTurn, null);
   assert.equal(session?.latestTurn?.phase, "settled");
   assert.deepEqual(
@@ -1148,6 +1159,15 @@ test("WorkspaceAgentActivityService reconciles child sessions and their messages
   });
 
   await service.load("ws-1");
+  assert.deepEqual(
+    service
+      .getSnapshot("ws-1")
+      .sessions.map((session) => session.agentSessionId)
+      .sort(),
+    ["child-1", "session-1"]
+  );
+  assert.deepEqual(messageRequests, []);
+
   service.ensureSessionSynchronized({
     agentSessionId: "session-1",
     workspaceId: "ws-1"

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/IssueManagerLatestRunMessageCenterCard.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/IssueManagerLatestRunMessageCenterCard.tsx
@@ -343,6 +343,7 @@ function createIssueManagerFallbackMessageCenterItem({
     },
     needsAttentionKind: null,
     needsAttentionSummary: null,
+    pendingInteractionTarget: null,
     pendingPrompt: null,
     provider,
     sortTimeUnixMs,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentMessageCenterToolPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentMessageCenterToolPanel.tsx
@@ -6,7 +6,7 @@ import {
   useSyncExternalStore,
   type ReactNode
 } from "react";
-import { selectEnginePendingInteractions } from "@tutti-os/agent-activity-core";
+import { selectEngineInteraction } from "@tutti-os/agent-activity-core";
 import {
   buildWorkspaceAgentMessageCenterModelFromEngine,
   dispatchAgentPlanPromptAction,
@@ -135,6 +135,7 @@ export function StandaloneAgentMessageCenterToolPanel({
       payload?: Record<string, unknown>;
       promptKind?: string;
       requestId: string;
+      turnId?: string;
     }) => {
       const engine = activityService.getSessionEngine(workspaceId);
       if (input.promptKind === "plan-implementation") {
@@ -157,22 +158,25 @@ export function StandaloneAgentMessageCenterToolPanel({
         }
         return;
       }
-      const interaction = selectEnginePendingInteractions(
+      if (!input.turnId) return;
+      const interaction = selectEngineInteraction(
         engine.getSnapshot(),
-        input.agentSessionId
-      ).find((candidate) => candidate.requestId === input.requestId);
-      if (!interaction) return;
+        input.agentSessionId,
+        input.turnId,
+        input.requestId
+      );
+      if (interaction?.status !== "pending") return;
       engine.dispatch({
         type: "interaction/responseRequested",
         agentSessionId: input.agentSessionId,
         commandId: [
           workspaceId,
           input.agentSessionId,
-          interaction.turnId,
+          input.turnId,
           input.requestId
         ].join(":"),
         requestId: input.requestId,
-        turnId: interaction.turnId,
+        turnId: input.turnId,
         workspaceId,
         ...(input.action ? { action: input.action } : {}),
         ...(input.optionId ? { optionId: input.optionId } : {}),

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentMessageCenterAction.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentMessageCenterAction.tsx
@@ -20,7 +20,7 @@ import {
 import {
   type AgentActivityMessage,
   type CanonicalAgentSession,
-  selectEnginePendingInteractions
+  selectEngineInteraction
 } from "@tutti-os/agent-activity-core";
 import type { WorkspaceSummary } from "@tutti-os/client-tuttid-ts";
 import type { WorkbenchHostChromeRenderContext } from "@tutti-os/workbench-surface";
@@ -354,6 +354,7 @@ export function WorkspaceAgentMessageCenterAction({
       payload?: Record<string, unknown>;
       promptKind?: string;
       requestId: string;
+      turnId?: string;
     }) => {
       if (input.promptKind === "plan-implementation") {
         if (
@@ -375,21 +376,25 @@ export function WorkspaceAgentMessageCenterAction({
         }
         return;
       }
-      const interaction = selectEnginePendingInteractions(
+      if (!input.turnId) return;
+      const interaction = selectEngineInteraction(
         sessionEngine.getSnapshot(),
-        input.agentSessionId
-      ).find((candidate) => candidate.requestId === input.requestId);
-      if (!interaction) return;
+        input.agentSessionId,
+        input.turnId,
+        input.requestId
+      );
+      if (interaction?.status !== "pending") return;
       sessionEngine.dispatch({
         type: "interaction/responseRequested",
         agentSessionId: input.agentSessionId,
         commandId: interactionCommandId({
           workspaceId: workspace.id,
           agentSessionId: input.agentSessionId,
-          requestId: input.requestId
+          requestId: input.requestId,
+          turnId: input.turnId
         }),
         requestId: input.requestId,
-        turnId: interaction.turnId,
+        turnId: input.turnId,
         workspaceId: workspace.id,
         ...(input.action ? { action: input.action } : {}),
         ...(input.optionId ? { optionId: input.optionId } : {}),

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.test.ts
@@ -84,10 +84,13 @@ test("workspace chrome does not call updateSessionSettings or sendInput from the
   assert.doesNotMatch(handler, /sendInput/);
   assert.doesNotMatch(handler, /submitInteractive/);
   assert.match(handler, /interaction\/responseRequested/);
-  assert.match(handler, /selectEnginePendingInteractions\(/);
-  assert.match(handler, /candidate\.requestId === input\.requestId/);
+  assert.match(handler, /selectEngineInteraction\(/);
+  assert.match(
+    handler,
+    /input\.agentSessionId,[\s\S]*input\.turnId,[\s\S]*input\.requestId/
+  );
   assert.match(handler, /requestId: input\.requestId/);
-  assert.match(handler, /turnId: interaction\.turnId/);
+  assert.match(handler, /turnId: input\.turnId/);
   assert.match(
     handler,
     /input\.payload \? \{ payload: input\.payload \} : \{\}/
@@ -122,6 +125,17 @@ test("workspace chrome gates the agent decision toast on window focus, message c
   assert.match(
     decisionNotificationsSource,
     /createDocumentNotificationVisibilityState\(\{\s*hasFocus: \(\) => document\.hasFocus\(\),\s*visibilityState: \(\) => document\.visibilityState\s*\}\)/
+  );
+});
+
+test("workspace decision toast routes child prompts by exact interaction identity", () => {
+  assert.match(
+    decisionNotificationsSource,
+    /const target = item\.pendingInteractionTarget;[\s\S]*?selectEngineInteraction\([\s\S]*?target\.agentSessionId,[\s\S]*?target\.turnId,[\s\S]*?target\.requestId/
+  );
+  assert.match(
+    decisionNotificationsSource,
+    /type: "interaction\/responseRequested",[\s\S]*?agentSessionId: target\.agentSessionId,[\s\S]*?requestId: target\.requestId,[\s\S]*?turnId: target\.turnId/
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceAgentDecisionNotifications.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceAgentDecisionNotifications.tsx
@@ -7,7 +7,7 @@ import {
   type WorkspaceAgentMessageCenterModel
 } from "@tutti-os/agent-gui/agent-message-center";
 import {
-  selectEnginePendingInteractions,
+  selectEngineInteraction,
   type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
 import { Button, CloseIcon, StatusDot, toast } from "@tutti-os/ui-system";
@@ -187,23 +187,26 @@ export function useWorkspaceAgentDecisionNotifications(input: {
               toast.dismiss(id);
             }}
             onSubmit={async (submitInput) => {
-              const interaction = selectEnginePendingInteractions(
+              const target = item.pendingInteractionTarget;
+              if (!target || target.requestId !== submitInput.requestId) return;
+              const interaction = selectEngineInteraction(
                 sessionEngine.getSnapshot(),
-                item.agentSessionId
-              ).find(
-                (candidate) => candidate.requestId === submitInput.requestId
+                target.agentSessionId,
+                target.turnId,
+                target.requestId
               );
-              if (!interaction) return;
+              if (interaction?.status !== "pending") return;
               sessionEngine.dispatch({
                 type: "interaction/responseRequested",
                 workspaceId,
-                agentSessionId: item.agentSessionId,
-                requestId: submitInput.requestId,
-                turnId: interaction.turnId,
+                agentSessionId: target.agentSessionId,
+                requestId: target.requestId,
+                turnId: target.turnId,
                 commandId: interactionCommandId({
                   workspaceId,
-                  agentSessionId: item.agentSessionId,
-                  requestId: submitInput.requestId
+                  agentSessionId: target.agentSessionId,
+                  requestId: target.requestId,
+                  turnId: target.turnId
                 }),
                 ...(submitInput.action ? { action: submitInput.action } : {}),
                 ...(submitInput.optionId
@@ -332,6 +335,15 @@ function WorkspaceAgentDecisionToast({
 }
 
 function waitingNotificationKey(item: WorkspaceAgentMessageCenterItem): string {
+  const target = item.pendingInteractionTarget;
+  if (target) {
+    return [
+      target.agentSessionId,
+      "interaction",
+      target.turnId,
+      target.requestId
+    ].join(":");
+  }
   const requestId = item.pendingPrompt?.requestId.trim();
   if (requestId) {
     return `${item.agentSessionId}:prompt:${requestId}`;

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -143,6 +143,13 @@ bridge keeps the one-shot realtime provenance outside reducer state while that
 pull is in flight. `AgentActivitySnapshot` is a memoized projection of the
 engine state, not a separately mutable controller snapshot.
 
+The workspace list is root-only. After a successful workspace reconcile, the
+engine requests a state detail reconcile for every active root session. Session
+detail hydrates that root plus all nested child sessions into the same engine;
+this is required before root-conversation consumers can project child activity
+or pending interactions after restart. The command executor only performs these
+requests; active-root selection and reconcile scope remain engine decisions.
+
 Actionable interaction UI has one read path:
 
 ```text
@@ -158,6 +165,15 @@ root session and its child sessions onto the root conversation. A `waiting`
 Turn phase without a pending interaction represents background/delegated work
 and keeps the working presentation; it must not imply that the user has an
 answerable prompt.
+
+Message Center presents one card per root conversation, not one card per child.
+Its engine selector aggregates pending interactions and non-terminal activity
+from the root and every descendant. Any descendant pending interaction makes
+the root card waiting; any descendant still working prevents a terminal root
+card. The card keeps root identity for conversation navigation, but each
+actionable prompt carries its exact child `(agentSessionId, turnId, requestId)`
+target. Inline card and decision-toast submissions dispatch against that exact
+target.
 
 The workspace shell and standalone Agent window share one decision-notification
 controller and card presentation. When a new pending interaction arrives while

--- a/packages/agent/activity-core/src/engine/engineRuntime.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/engineRuntime.reducer.test.ts
@@ -138,6 +138,47 @@ test("workspace start loads once and failed load requires explicit retry", () =>
   assert.equal(retry.commands.length, 1);
 });
 
+test("successful workspace reconcile hydrates state for active root sessions", () => {
+  const requested = rootEngineReducer(createInitialAgentSessionEngineState(), {
+    type: "workspace/reconcileRequested",
+    workspaceId: "workspace-1"
+  });
+  const snapshotted = rootEngineReducer(requested.state, {
+    sessions: [
+      runningSession(capabilities({})),
+      {
+        activeTurnId: null,
+        agentSessionId: "session-settled",
+        cwd: "/workspace",
+        latestTurnInteractions: [],
+        pendingInteractions: [],
+        provider: "claude-code",
+        title: "Settled",
+        workspaceId: "workspace-1"
+      }
+    ],
+    type: "session/snapshotReceived"
+  });
+
+  const reconciled = rootEngineReducer(snapshotted.state, {
+    commandId: requested.state.engineRuntime.workspaceReconcile.commandId ?? "",
+    commandType: "engine/reconcileWorkspace",
+    outcome: "succeeded",
+    type: "engine/commandResult"
+  });
+
+  assert.deepEqual(reconciled.commands, [
+    {
+      agentSessionId: "session-1",
+      commandId: "session:reconcile:session-1:1",
+      scope: "state",
+      timeoutMs: 30_000,
+      type: "session/reconcile",
+      workspaceId: "workspace-1"
+    }
+  ]);
+});
+
 test("expiry request and cancellation emit internal clock commands", () => {
   const requested = engineRuntimeReducer(createInitialEngineRuntimeState(), {
     dueAtUnixMs: 500,

--- a/packages/agent/activity-core/src/engine/rootReducer.ts
+++ b/packages/agent/activity-core/src/engine/rootReducer.ts
@@ -332,7 +332,12 @@ export function rootEngineReducer(
   const sessionReconcile = sessionReconcileReducer(
     state.sessionReconcile,
     intent,
-    { deletedSessionIds: state.sessionLifecycle.deletedSessionIds }
+    {
+      deletedSessionIds: state.sessionLifecycle.deletedSessionIds,
+      sessionsById: sessionLifecycle.state.sessionsById,
+      workspaceReconcileCommandId:
+        state.engineRuntime.workspaceReconcile.commandId
+    }
   );
   const sessionMessages = sessionMessagesReducer(
     state.sessionMessages,

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.test.ts
@@ -9,7 +9,8 @@ import {
   selectEngineSessionDeleted,
   selectRootAgentSessionIdsWithPendingInteractions,
   selectWorkspaceAgentConsumerCounts,
-  selectWorkspaceAgentConsumerSession
+  selectWorkspaceAgentConsumerSession,
+  selectWorkspaceAgentRootConversationSessions
 } from "./sessionLifecycle.selectors.ts";
 
 test("deleted session selector normalizes ids and hides tombstone storage", () => {
@@ -349,5 +350,137 @@ test("new goal control activation stays idle without a provider Turn", () => {
   assert.equal(
     selectWorkspaceAgentConsumerSession(state, "session-goal")?.displayStatus,
     "idle"
+  );
+});
+
+test("root conversation selector aggregates descendant pending interactions", () => {
+  const state = rootEngineReducer(createInitialAgentSessionEngineState(), {
+    sessions: [
+      {
+        activeTurn: {
+          agentSessionId: "root",
+          origin: "user_prompt",
+          phase: "running",
+          startedAtUnixMs: 10,
+          turnId: "root-turn",
+          updatedAtUnixMs: 20
+        },
+        activeTurnId: "root-turn",
+        agentSessionId: "root",
+        cwd: "/workspace",
+        latestTurnInteractions: [],
+        pendingInteractions: [],
+        provider: "claude-code",
+        title: "Root",
+        workspaceId: "workspace-1"
+      },
+      {
+        activeTurn: {
+          agentSessionId: "child",
+          origin: "provider_initiated",
+          phase: "waiting",
+          startedAtUnixMs: 15,
+          turnId: "child-turn",
+          updatedAtUnixMs: 25
+        },
+        activeTurnId: "child-turn",
+        agentSessionId: "child",
+        cwd: "/workspace",
+        kind: "child",
+        latestTurnInteractions: [],
+        parentAgentSessionId: "root",
+        parentToolCallId: "toolu-1",
+        parentTurnId: "root-turn",
+        pendingInteractions: [
+          {
+            agentSessionId: "child",
+            createdAtUnixMs: 26,
+            input: { question: "Allow Bash?" },
+            kind: "approval",
+            requestId: "approval-1",
+            status: "pending",
+            toolName: "Bash",
+            turnId: "child-turn",
+            updatedAtUnixMs: 26
+          }
+        ],
+        provider: "claude-code",
+        rootAgentSessionId: "root",
+        rootTurnId: "root-turn",
+        title: "Child",
+        workspaceId: "workspace-1"
+      }
+    ],
+    type: "session/snapshotReceived"
+  }).state;
+
+  const conversations = selectWorkspaceAgentRootConversationSessions(state);
+  assert.equal(conversations.length, 1);
+  assert.equal(conversations[0]?.session.agentSessionId, "root");
+  assert.equal(conversations[0]?.displayStatus, "waiting");
+  assert.deepEqual(
+    conversations[0]?.pendingInteractions.map((interaction) => [
+      interaction.agentSessionId,
+      interaction.turnId,
+      interaction.requestId
+    ]),
+    [["child", "child-turn", "approval-1"]]
+  );
+});
+
+test("root conversation stays working while a descendant turn is running", () => {
+  const state = rootEngineReducer(createInitialAgentSessionEngineState(), {
+    sessions: [
+      {
+        activeTurnId: null,
+        agentSessionId: "root",
+        cwd: "/workspace",
+        latestTurn: {
+          agentSessionId: "root",
+          origin: "user_prompt",
+          outcome: "completed",
+          phase: "settled",
+          settledAtUnixMs: 20,
+          startedAtUnixMs: 10,
+          turnId: "root-turn",
+          updatedAtUnixMs: 20
+        },
+        latestTurnInteractions: [],
+        pendingInteractions: [],
+        provider: "claude-code",
+        title: "Root",
+        workspaceId: "workspace-1"
+      },
+      {
+        activeTurn: {
+          agentSessionId: "child",
+          origin: "provider_initiated",
+          phase: "running",
+          startedAtUnixMs: 15,
+          turnId: "child-turn",
+          updatedAtUnixMs: 25
+        },
+        activeTurnId: "child-turn",
+        agentSessionId: "child",
+        cwd: "/workspace",
+        kind: "child",
+        latestTurnInteractions: [],
+        parentAgentSessionId: "root",
+        parentToolCallId: "toolu-1",
+        parentTurnId: "root-turn",
+        pendingInteractions: [],
+        provider: "claude-code",
+        rootAgentSessionId: "root",
+        rootTurnId: "root-turn",
+        title: "Child",
+        workspaceId: "workspace-1"
+      }
+    ],
+    type: "session/snapshotReceived"
+  }).state;
+
+  assert.equal(
+    selectWorkspaceAgentRootConversationSessions(state)[0]?.displayStatus,
+    "working"
   );
 });

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
@@ -312,6 +312,52 @@ export function selectRootAgentSessionIdsWithPendingInteractions(
   return [...rootAgentSessionIds];
 }
 
+export function selectWorkspaceAgentRootConversationSessions(
+  state: AgentSessionEngineState
+): readonly WorkspaceAgentConsumerSession[] {
+  const consumers = selectAllWorkspaceAgentConsumerSessions(state);
+  const rootSessionIds = new Set(
+    consumers
+      .filter((consumer) => consumer.session.kind === "root")
+      .map((consumer) => consumer.session.agentSessionId)
+  );
+  const consumersByRootSessionId = new Map<
+    string,
+    WorkspaceAgentConsumerSession[]
+  >();
+
+  for (const consumer of consumers) {
+    const rootSessionId =
+      consumer.session.kind === "child"
+        ? (consumer.session.rootAgentSessionId?.trim() ?? "")
+        : consumer.session.agentSessionId;
+    if (!rootSessionIds.has(rootSessionId)) continue;
+    const conversationConsumers =
+      consumersByRootSessionId.get(rootSessionId) ?? [];
+    conversationConsumers.push(consumer);
+    consumersByRootSessionId.set(rootSessionId, conversationConsumers);
+  }
+
+  return consumers
+    .filter((consumer) => consumer.session.kind === "root")
+    .map((consumer) => {
+      const conversationConsumers =
+        consumersByRootSessionId.get(consumer.session.agentSessionId) ?? [];
+      const pendingInteractions = conversationConsumers
+        .flatMap((item) => item.pendingInteractions)
+        .sort(compareInteractionsByOccurrence);
+      return {
+        ...consumer,
+        displayStatus: rootConversationDisplayStatus(
+          consumer,
+          conversationConsumers,
+          pendingInteractions
+        ),
+        pendingInteractions
+      };
+    });
+}
+
 export function selectAllWorkspaceAgentConsumerSessions(
   state: AgentSessionEngineState
 ): readonly WorkspaceAgentConsumerSession[] {
@@ -419,5 +465,33 @@ function initialActivationTurnIsPending(
     activation?.mode === "new" &&
     activation.initialTurnExpected &&
     isPendingActivationViable(activation)
+  );
+}
+
+function rootConversationDisplayStatus(
+  root: WorkspaceAgentConsumerSession,
+  consumers: readonly WorkspaceAgentConsumerSession[],
+  pendingInteractions: readonly AgentActivityInteraction[]
+): AgentActivityDisplayStatus {
+  if (pendingInteractions.length > 0) return "waiting";
+  if (consumers.some((consumer) => consumer.displayStatus === "working")) {
+    return "working";
+  }
+  if (consumers.some((consumer) => consumer.displayStatus === "waiting")) {
+    return "waiting";
+  }
+  return root.displayStatus;
+}
+
+function compareInteractionsByOccurrence(
+  left: AgentActivityInteraction,
+  right: AgentActivityInteraction
+): number {
+  return (
+    left.createdAtUnixMs - right.createdAtUnixMs ||
+    left.updatedAtUnixMs - right.updatedAtUnixMs ||
+    left.agentSessionId.localeCompare(right.agentSessionId) ||
+    left.turnId.localeCompare(right.turnId) ||
+    left.requestId.localeCompare(right.requestId)
   );
 }

--- a/packages/agent/activity-core/src/engine/sessionReconcile.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionReconcile.reducer.ts
@@ -8,6 +8,7 @@ import type {
   SessionReconcileRecord,
   SessionReconcileState
 } from "./sessionReconcile.types.ts";
+import type { CanonicalAgentSession } from "./sessionLifecycle.types.ts";
 
 const NO_COMMANDS: readonly EngineCommand[] = [];
 
@@ -18,8 +19,14 @@ export function createInitialSessionReconcileState(): SessionReconcileState {
 export function sessionReconcileReducer(
   state: SessionReconcileState,
   intent: EngineIntent,
-  context: { deletedSessionIds: Readonly<Record<string, true>> } = {
-    deletedSessionIds: {}
+  context: {
+    deletedSessionIds: Readonly<Record<string, true>>;
+    sessionsById: Readonly<Record<string, CanonicalAgentSession>>;
+    workspaceReconcileCommandId: string | null;
+  } = {
+    deletedSessionIds: {},
+    sessionsById: {},
+    workspaceReconcileCommandId: null
   }
 ): EngineReducerResult<SessionReconcileState> {
   switch (intent.type) {
@@ -50,12 +57,48 @@ export function sessionReconcileReducer(
     case "session/removed":
       return removeRecord(state, intent.agentSessionId);
     case "engine/commandResult":
+      if (
+        intent.commandType === "engine/reconcileWorkspace" &&
+        intent.outcome === "succeeded" &&
+        intent.commandId === context.workspaceReconcileCommandId
+      ) {
+        return hydrateActiveRootSessions(state, context.sessionsById);
+      }
       return intent.commandType === "session/reconcile"
         ? settleReconcile(state, intent)
         : unchanged(state);
     default:
       return unchanged(state);
   }
+}
+
+function hydrateActiveRootSessions(
+  state: SessionReconcileState,
+  sessionsById: Readonly<Record<string, CanonicalAgentSession>>
+): EngineReducerResult<SessionReconcileState> {
+  let next = state;
+  const commands: EngineCommand[] = [];
+  const activeRoots = Object.values(sessionsById)
+    .filter(
+      (session) =>
+        session.kind === "root" && Boolean(session.activeTurnId?.trim())
+    )
+    .sort((left, right) =>
+      left.agentSessionId.localeCompare(right.agentSessionId)
+    );
+
+  for (const session of activeRoots) {
+    const requested = requestReconcile(next, {
+      agentSessionId: session.agentSessionId,
+      needsMessages: false,
+      needsState: true,
+      workspaceId: session.workspaceId
+    });
+    next = requested.state;
+    commands.push(...requested.commands);
+  }
+
+  return { commands, state: next };
 }
 
 function requestReconcile(

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -118,7 +118,8 @@ export {
   selectRootAgentSessionIdsWithPendingInteractions,
   selectWorkspaceAgentConsumerCounts,
   selectWorkspaceAgentConsumerSession,
-  selectWorkspaceAgentConsumerSessions
+  selectWorkspaceAgentConsumerSessions,
+  selectWorkspaceAgentRootConversationSessions
 } from "./engine/sessionLifecycle.selectors.ts";
 export {
   selectEngineSessionDetailHydrated,

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterAttentionDeck.spec.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterAttentionDeck.spec.tsx
@@ -27,6 +27,7 @@ function promptItem(
     },
     lastAgentMessageSummary: "",
     lastAgentMessageAtUnixMs: 1,
+    pendingInteractionTarget: null,
     needsAttentionKind: null,
     needsAttentionSummary: null,
     sortTimeUnixMs: 1,

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.spec.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.spec.tsx
@@ -84,6 +84,7 @@ function item(overrides: { summary: string }): WorkspaceAgentMessageCenterItem {
     },
     lastAgentMessageSummary: "",
     lastAgentMessageAtUnixMs: 1,
+    pendingInteractionTarget: null,
     pendingPrompt: null,
     needsAttentionKind: null,
     needsAttentionSummary: null,

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.tsx
@@ -100,6 +100,7 @@ export interface WorkspaceAgentMessageCenterPanelProps {
     payload?: Record<string, unknown>;
     promptKind?: string;
     requestId: string;
+    turnId?: string;
   }) => Promise<void> | void;
 }
 
@@ -308,7 +309,11 @@ function WorkspaceAgentMessageCenterPanelContent({
       }
       await onSubmitPrompt({
         ...input,
-        agentSessionId: item.agentSessionId,
+        agentSessionId:
+          item.pendingInteractionTarget?.agentSessionId ?? item.agentSessionId,
+        ...(item.pendingInteractionTarget
+          ? { turnId: item.pendingInteractionTarget.turnId }
+          : {}),
         promptKind: item.pendingPrompt?.kind
       });
     },

--- a/packages/agent/gui/agent-message-center/index.ts
+++ b/packages/agent/gui/agent-message-center/index.ts
@@ -101,6 +101,7 @@ export type {
   WorkspaceAgentMessageCenterAgentPresentation,
   WorkspaceAgentMessageCenterCounts,
   WorkspaceAgentMessageCenterIdentity,
+  WorkspaceAgentMessageCenterInteractionTarget,
   WorkspaceAgentMessageCenterItem,
   WorkspaceAgentMessageCenterModel
 } from "./workspaceAgentMessageCenterModel";

--- a/packages/agent/gui/agent-message-center/workspaceAgentConsumerSelectors.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentConsumerSelectors.spec.ts
@@ -7,6 +7,7 @@ import {
 import {
   buildWorkspaceAgentMessageCenterModelFromEngine,
   selectWorkspaceAgentMessageCenterPresentation,
+  workspaceAgentMessageCenterPromptStatus,
   workspaceAgentMessageCenterPresentationEqual
 } from "./workspaceAgentMessageCenterEngineModel";
 import { selectMessageCenterAttentionDeckItems } from "./workspaceAgentMessageCenterModel";
@@ -110,6 +111,174 @@ describe("workspaceAgentConsumerSelectors", () => {
     expect(selectMessageCenterAttentionDeckItems(resolvedModel.items)).toEqual(
       []
     );
+  });
+
+  it("aggregates a child approval into its root conversation card", () => {
+    const engine = createEngine();
+    engine.dispatch({
+      type: "session/snapshotReceived",
+      sessions: [
+        session({
+          activeTurnId: "root-turn-1",
+          activeTurn: {
+            turnId: "root-turn-1",
+            agentSessionId: "session-1",
+            origin: "user_prompt",
+            phase: "running",
+            startedAtUnixMs: 10,
+            updatedAtUnixMs: 20
+          },
+          provider: "claude-code"
+        }),
+        session({
+          activeTurnId: "child-turn-1",
+          activeTurn: {
+            turnId: "child-turn-1",
+            agentSessionId: "child-1",
+            origin: "provider_initiated",
+            phase: "waiting",
+            startedAtUnixMs: 15,
+            updatedAtUnixMs: 25
+          },
+          agentSessionId: "child-1",
+          kind: "child",
+          parentAgentSessionId: "session-1",
+          parentToolCallId: "toolu-agent-1",
+          parentTurnId: "root-turn-1",
+          pendingInteractions: [
+            {
+              requestId: "child-approval-1",
+              agentSessionId: "child-1",
+              turnId: "child-turn-1",
+              kind: "approval",
+              status: "pending",
+              toolName: "Bash",
+              input: {
+                question: "Allow Bash?",
+                options: [{ optionId: "allow", label: "Allow" }]
+              },
+              createdAtUnixMs: 26,
+              updatedAtUnixMs: 26
+            }
+          ],
+          provider: "claude-code",
+          providerSessionId: "agent-1",
+          rootAgentSessionId: "session-1",
+          rootTurnId: "root-turn-1",
+          title: "Child"
+        })
+      ]
+    });
+
+    const presentation = selectWorkspaceAgentMessageCenterPresentation(
+      engine.getSnapshot()
+    );
+    const model = buildWorkspaceAgentMessageCenterModelFromEngine(
+      presentation,
+      { workspaceId: "workspace-1", sessionMessagesById: {} }
+    );
+
+    expect(model.items).toHaveLength(1);
+    expect(model.items[0]).toMatchObject({
+      agentSessionId: "session-1",
+      status: "waiting",
+      pendingInteractionTarget: {
+        agentSessionId: "child-1",
+        requestId: "child-approval-1",
+        turnId: "child-turn-1"
+      },
+      pendingPrompt: {
+        kind: "approval",
+        requestId: "child-approval-1",
+        turnId: "child-turn-1"
+      }
+    });
+    expect(model.waitingCount).toBe(1);
+    expect(selectMessageCenterAttentionDeckItems(model.items)).toHaveLength(1);
+
+    engine.dispatch({
+      type: "interaction/responseRequested",
+      agentSessionId: "child-1",
+      commandId: "respond-child-approval-1",
+      requestId: "child-approval-1",
+      turnId: "child-turn-1",
+      workspaceId: "workspace-1",
+      optionId: "allow"
+    });
+    const respondingPresentation =
+      selectWorkspaceAgentMessageCenterPresentation(engine.getSnapshot());
+    expect(
+      workspaceAgentMessageCenterPromptStatus(
+        respondingPresentation,
+        model.items[0]!
+      )
+    ).toBe("responding");
+
+    engine.dispatch({
+      type: "interaction/upserted",
+      interaction: {
+        requestId: "child-approval-1",
+        agentSessionId: "child-1",
+        turnId: "child-turn-1",
+        kind: "approval",
+        status: "answered",
+        toolName: "Bash",
+        input: { question: "Allow Bash?" },
+        createdAtUnixMs: 26,
+        updatedAtUnixMs: 30
+      }
+    });
+    engine.dispatch({
+      type: "session/snapshotReceived",
+      sessions: [
+        session({
+          activeTurnId: null,
+          latestTurn: {
+            turnId: "root-turn-1",
+            agentSessionId: "session-1",
+            origin: "user_prompt",
+            phase: "settled",
+            outcome: "completed",
+            startedAtUnixMs: 10,
+            settledAtUnixMs: 30,
+            updatedAtUnixMs: 30
+          },
+          provider: "claude-code"
+        }),
+        session({
+          activeTurnId: "child-turn-1",
+          activeTurn: {
+            turnId: "child-turn-1",
+            agentSessionId: "child-1",
+            origin: "provider_initiated",
+            phase: "running",
+            startedAtUnixMs: 15,
+            updatedAtUnixMs: 31
+          },
+          agentSessionId: "child-1",
+          kind: "child",
+          parentAgentSessionId: "session-1",
+          parentToolCallId: "toolu-agent-1",
+          parentTurnId: "root-turn-1",
+          provider: "claude-code",
+          providerSessionId: "agent-1",
+          rootAgentSessionId: "session-1",
+          rootTurnId: "root-turn-1",
+          title: "Child"
+        })
+      ]
+    });
+    const resumedModel = buildWorkspaceAgentMessageCenterModelFromEngine(
+      selectWorkspaceAgentMessageCenterPresentation(engine.getSnapshot()),
+      { workspaceId: "workspace-1", sessionMessagesById: {} }
+    );
+    expect(resumedModel.items).toHaveLength(1);
+    expect(resumedModel.items[0]).toMatchObject({
+      agentSessionId: "session-1",
+      latestTurnOutcome: null,
+      pendingPrompt: null,
+      status: "working"
+    });
   });
 
   it("projects signed Agent Target presentation for open-provider sessions", () => {

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterEngineModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterEngineModel.ts
@@ -10,7 +10,8 @@ import { normalizeAgentApprovalPurpose } from "../shared/agentConversation/agent
 import {
   selectEngineInteractionResponse,
   selectPendingSubmitsForSession,
-  selectPlanDecisionForTurn
+  selectPlanDecisionForTurn,
+  selectWorkspaceAgentRootConversationSessions
 } from "@tutti-os/agent-activity-core";
 import type { AgentConversationPromptVM } from "../shared/agentConversation/contracts/agentConversationVM";
 import { normalizeAskUserQuestions } from "../shared/agentConversation/askUserQuestions";
@@ -21,7 +22,6 @@ import {
   type WorkspaceAgentMessageCenterModel,
   type WorkspaceAgentMessageCenterTurnOutcome
 } from "./workspaceAgentMessageCenterModel";
-import { selectWorkspaceAgentConsumerSessions } from "./workspaceAgentConsumerSelectors";
 
 /**
  * Canonical Message Center entrypoint. Session/turn/interaction truth comes
@@ -47,6 +47,9 @@ export function buildWorkspaceAgentMessageCenterModelFromEngine(
         messages: sessionMessages(snapshot.sessionMessagesById, consumer),
         status: consumer.displayStatus,
         needsAttention,
+        pendingInteractionTarget: interaction
+          ? interactionTarget(interaction)
+          : null,
         pendingPrompt: interaction ? promptFromInteraction(interaction) : null,
         latestTurnOutcome: turnOutcome(consumer),
         options
@@ -68,7 +71,7 @@ export interface WorkspaceAgentMessageCenterPresentation {
 export function selectWorkspaceAgentMessageCenterPresentation(
   state: AgentSessionEngineState
 ): WorkspaceAgentMessageCenterPresentation {
-  const consumers = selectWorkspaceAgentConsumerSessions(state);
+  const consumers = selectWorkspaceAgentRootConversationSessions(state);
   const promptStatusByKey: Record<
     string,
     WorkspaceAgentMessageCenterPromptStatus
@@ -78,20 +81,25 @@ export function selectWorkspaceAgentMessageCenterPresentation(
     for (const interaction of consumer.pendingInteractions) {
       const response = selectEngineInteractionResponse(
         state,
-        sessionId,
+        interaction.agentSessionId,
         interaction.turnId,
         interaction.requestId
       );
       if (response) {
-        promptStatusByKey[promptStatusKey(sessionId, interaction.requestId)] =
-          response.status;
+        promptStatusByKey[
+          promptStatusKey(
+            interaction.agentSessionId,
+            interaction.turnId,
+            interaction.requestId
+          )
+        ] = response.status;
       }
     }
     const turnId = consumer.latestTurn?.turnId ?? "";
     if (!turnId) continue;
     const decision = selectPlanDecisionForTurn(state, sessionId, turnId);
     if (decision) {
-      promptStatusByKey[promptStatusKey(sessionId, turnId)] =
+      promptStatusByKey[promptStatusKey(sessionId, turnId, turnId)] =
         decision.status === "requested" ? "responding" : decision.status;
       continue;
     }
@@ -106,7 +114,7 @@ export function selectWorkspaceAgentMessageCenterPresentation(
       (record) => record.clientSubmitId.startsWith(feedbackPrefix)
     );
     if (submit) {
-      promptStatusByKey[promptStatusKey(sessionId, turnId)] =
+      promptStatusByKey[promptStatusKey(sessionId, turnId, turnId)] =
         submit.status === "failed"
           ? "failed"
           : submit.status === "uncertain"
@@ -156,20 +164,35 @@ export function workspaceAgentMessageCenterPromptStatus(
   presentation: WorkspaceAgentMessageCenterPresentation,
   item: Pick<
     import("./workspaceAgentMessageCenterModel").WorkspaceAgentMessageCenterItem,
-    "agentSessionId" | "pendingPrompt"
+    "agentSessionId" | "pendingInteractionTarget" | "pendingPrompt"
   >
 ): WorkspaceAgentMessageCenterPromptStatus {
   const prompt = item.pendingPrompt;
   if (!prompt) return "idle";
+  const target = item.pendingInteractionTarget;
   return (
     presentation.promptStatusByKey[
-      promptStatusKey(item.agentSessionId, prompt.requestId)
+      target
+        ? promptStatusKey(
+            target.agentSessionId,
+            target.turnId,
+            target.requestId
+          )
+        : promptStatusKey(
+            item.agentSessionId,
+            prompt.requestId,
+            prompt.requestId
+          )
     ] ?? "idle"
   );
 }
 
-function promptStatusKey(agentSessionId: string, requestId: string): string {
-  return `${agentSessionId}\0${requestId}`;
+function promptStatusKey(
+  agentSessionId: string,
+  turnId: string,
+  requestId: string
+): string {
+  return `${agentSessionId}\0${turnId}\0${requestId}`;
 }
 
 function promptStatusMapsEqual(
@@ -203,6 +226,16 @@ function latestPendingInteraction(
   consumer: WorkspaceAgentConsumerSession
 ): AgentActivityInteraction | null {
   return consumer.pendingInteractions.at(-1) ?? null;
+}
+
+function interactionTarget(
+  interaction: AgentActivityInteraction
+): import("./workspaceAgentMessageCenterModel").WorkspaceAgentMessageCenterInteractionTarget {
+  return {
+    agentSessionId: interaction.agentSessionId,
+    requestId: interaction.requestId,
+    turnId: interaction.turnId
+  };
 }
 
 function needsAttentionFromInteraction(
@@ -292,6 +325,12 @@ function promptFromInteraction(
 function turnOutcome(
   consumer: WorkspaceAgentConsumerSession
 ): WorkspaceAgentMessageCenterTurnOutcome | null {
+  if (
+    consumer.displayStatus !== "completed" &&
+    consumer.displayStatus !== "failed"
+  ) {
+    return null;
+  }
   const turn = consumer.latestTurn;
   if (!turn || turn.phase !== "settled") return null;
   const status =

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
@@ -59,11 +59,18 @@ export interface WorkspaceAgentMessageCenterItem {
   digest: WorkspaceAgentMessageCenterDigest;
   lastAgentMessageSummary: string;
   lastAgentMessageAtUnixMs: number | null;
+  pendingInteractionTarget: WorkspaceAgentMessageCenterInteractionTarget | null;
   pendingPrompt: AgentConversationPromptVM | null;
   needsAttentionKind: AgentActivityNeedsAttentionItem["kind"] | null;
   needsAttentionSummary: string | null;
   latestTurnOutcome?: WorkspaceAgentMessageCenterTurnOutcome | null;
   sortTimeUnixMs: number;
+}
+
+export interface WorkspaceAgentMessageCenterInteractionTarget {
+  agentSessionId: string;
+  requestId: string;
+  turnId: string;
 }
 
 export interface WorkspaceAgentMessageCenterTurnOutcome {
@@ -107,6 +114,7 @@ export interface BuildWorkspaceAgentMessageCenterItemInput {
   messages: readonly AgentActivityMessage[];
   status: WorkspaceAgentActivityStatus;
   needsAttention: AgentActivityNeedsAttentionItem | null;
+  pendingInteractionTarget: WorkspaceAgentMessageCenterInteractionTarget | null;
   pendingPrompt: AgentConversationPromptVM | null;
   latestTurnOutcome: WorkspaceAgentMessageCenterTurnOutcome | null;
   options?: BuildWorkspaceAgentMessageCenterOptions;
@@ -122,6 +130,7 @@ export function buildWorkspaceAgentMessageCenterItem({
   messages,
   status,
   needsAttention,
+  pendingInteractionTarget,
   pendingPrompt,
   latestTurnOutcome,
   options = {}
@@ -163,6 +172,7 @@ export function buildWorkspaceAgentMessageCenterItem({
     lastAgentMessageSummary:
       lastAgentMessage?.summary ?? needsAttention?.summary ?? title,
     lastAgentMessageAtUnixMs: lastAgentMessage?.occurredAtUnixMs ?? null,
+    pendingInteractionTarget,
     pendingPrompt,
     needsAttentionKind: needsAttention?.kind ?? null,
     needsAttentionSummary: needsAttention?.summary ?? null,

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModelStability.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModelStability.ts
@@ -75,6 +75,10 @@ function messageCenterItemsEqual(
     left.status === right.status &&
     left.lastAgentMessageSummary === right.lastAgentMessageSummary &&
     left.lastAgentMessageAtUnixMs === right.lastAgentMessageAtUnixMs &&
+    messageCenterInteractionTargetEqual(
+      left.pendingInteractionTarget,
+      right.pendingInteractionTarget
+    ) &&
     left.needsAttentionKind === right.needsAttentionKind &&
     left.needsAttentionSummary === right.needsAttentionSummary &&
     left.sortTimeUnixMs === right.sortTimeUnixMs &&
@@ -85,6 +89,20 @@ function messageCenterItemsEqual(
       left.latestTurnOutcome ?? null,
       right.latestTurnOutcome ?? null
     )
+  );
+}
+
+function messageCenterInteractionTargetEqual(
+  left: WorkspaceAgentMessageCenterItem["pendingInteractionTarget"],
+  right: WorkspaceAgentMessageCenterItem["pendingInteractionTarget"]
+): boolean {
+  return (
+    left === right ||
+    (left !== null &&
+      right !== null &&
+      left.agentSessionId === right.agentSessionId &&
+      left.turnId === right.turnId &&
+      left.requestId === right.requestId)
   );
 }
 

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterViewModel.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterViewModel.spec.ts
@@ -279,6 +279,7 @@ function item(
     },
     lastAgentMessageSummary: `${agentSessionId} summary`,
     lastAgentMessageAtUnixMs: 1,
+    pendingInteractionTarget: null,
     pendingPrompt: null,
     needsAttentionKind: null,
     needsAttentionSummary: null,


### PR DESCRIPTION
## Summary

- project child-session approvals and questions into the root Message Center conversation card
- preserve the exact child `(agentSessionId, turnId, requestId)` target for card and decision-toast responses
- keep root conversation status non-terminal while any descendant is still working
- hydrate active root session detail after workspace reconciliation so child sessions are restored after restart
- document the root-conversation aggregation and exact interaction-routing contract

## Verification

- `pnpm check:changed --tail-lines 120`
- `pnpm check:full`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm --filter @tutti-os/agent-activity-core test` (196 tests)
- `pnpm --filter @tutti-os/agent-gui test` (1694 tests)
- targeted desktop Message Center and activity-service tests

Manual Claude Code provider E2E was not run because no reproducible runtime/log fixture was available.

## Fix Scope Justification

- Root cause: provider-native child support moved canonical interaction ownership onto child sessions while Message Center continued selecting root sessions only. Root status and interaction response lookup therefore ignored child canonical state.
- Why can this not be fixed at a lower layer? The daemon already models child interactions on the correct session and exposes children through root detail. Message Center intentionally presents one card per root conversation, so aggregation belongs in the shared engine selector. Moving child interactions back onto the root would destroy exact ownership; reconstructing them in React would create a second orchestration path.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->