### PR TITLE
fix(claude-sidecar): ship complete runtime imports

### DIFF
--- a/.changeset/claude-sidecar-complete-runtime.md
+++ b/.changeset/claude-sidecar-complete-runtime.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/claude-sdk-sidecar": patch
+---
+
+Ship the complete Claude SDK sidecar runtime import closure and reject incomplete packed artifacts before publishing.

--- a/packages/agent/claude-sdk-sidecar/package.json
+++ b/packages/agent/claude-sdk-sidecar/package.json
@@ -27,6 +27,7 @@
     "src/sessionSettings.ts",
     "src/sessionRuntime.ts",
     "src/sessionConfiguration.ts",
+    "src/settingsEnv.ts",
     "src/taskNotification.ts",
     "src/taskPlan.ts",
     "src/testDriver.ts",

--- a/tools/scripts/check-package-packs.mjs
+++ b/tools/scripts/check-package-packs.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -7,6 +7,7 @@ import {
   getNpmReleasePackages,
   workspaceRoot
 } from "./npm-release-packages.mjs";
+import { missingPackedRelativeImports } from "./package-pack-relative-imports.mjs";
 
 const forbiddenPrefixes = [
   "package/src/",
@@ -42,7 +43,8 @@ async function checkPackage(packageConfig, destination) {
   });
 
   const tarball = await findNewTarball(destination, beforeFiles);
-  const entries = listTarballEntries(join(destination, tarball));
+  const tarballPath = join(destination, tarball);
+  const entries = listTarballEntries(tarballPath);
   const entrySet = new Set(entries);
   const violations = [];
   const requiredFiles = getRequiredFiles(packageConfig.manifest);
@@ -61,6 +63,19 @@ async function checkPackage(packageConfig, destination) {
   for (const entry of entries) {
     if (packageForbiddenPrefixes.some((prefix) => entry.startsWith(prefix))) {
       violations.push(`unexpected ${entry}`);
+    }
+  }
+
+  if (packageConfig.name === "@tutti-os/claude-sdk-sidecar") {
+    const unpackedDirectory = join(destination, `${tarball}.unpacked`);
+    await mkdir(unpackedDirectory, { recursive: true });
+    execFileSync("tar", ["-xzf", tarballPath, "-C", unpackedDirectory]);
+    const missingImports = await missingPackedRelativeImports(
+      join(unpackedDirectory, "package"),
+      "src/main.ts"
+    );
+    for (const missingImport of missingImports) {
+      violations.push(`missing runtime import ${missingImport}`);
     }
   }
 

--- a/tools/scripts/package-pack-relative-imports.mjs
+++ b/tools/scripts/package-pack-relative-imports.mjs
@@ -1,0 +1,97 @@
+import { readFile, stat } from "node:fs/promises";
+import {
+  dirname,
+  extname,
+  join,
+  normalize,
+  relative,
+  resolve
+} from "node:path";
+
+const relativeImportPattern =
+  /(?:import|export)\s+(?:type\s+)?(?:[^'";]*?\s+from\s+)?["'](\.[^"']+)["']|import\s*\(\s*["'](\.[^"']+)["']\s*\)/g;
+
+const extensionCandidates = [".ts", ".tsx", ".js", ".mjs", ".cjs", ".json"];
+
+export async function missingPackedRelativeImports(packageRoot, entryPath) {
+  const normalizedRoot = resolve(packageRoot);
+  const entry = resolve(normalizedRoot, entryPath);
+  const pending = [entry];
+  const visited = new Set();
+  const missing = new Set();
+
+  while (pending.length > 0) {
+    const sourcePath = pending.pop();
+    if (!sourcePath || visited.has(sourcePath)) {
+      continue;
+    }
+    visited.add(sourcePath);
+    if (!(await isFile(sourcePath))) {
+      missing.add(asPackagePath(normalizedRoot, sourcePath));
+      continue;
+    }
+
+    const source = await readFile(sourcePath, "utf8");
+    for (const specifier of relativeImportSpecifiers(source)) {
+      const importedPath = await resolveRelativeImport(sourcePath, specifier);
+      if (!importedPath || !isInside(normalizedRoot, importedPath)) {
+        missing.add(
+          `${asPackagePath(normalizedRoot, sourcePath)} -> ${specifier}`
+        );
+        continue;
+      }
+      pending.push(importedPath);
+    }
+  }
+
+  return [...missing].sort();
+}
+
+function relativeImportSpecifiers(source) {
+  const specifiers = [];
+  relativeImportPattern.lastIndex = 0;
+  for (const match of source.matchAll(relativeImportPattern)) {
+    specifiers.push(match[1] ?? match[2]);
+  }
+  return specifiers;
+}
+
+async function resolveRelativeImport(sourcePath, specifier) {
+  const cleanSpecifier = specifier.split(/[?#]/, 1)[0];
+  const basePath = resolve(dirname(sourcePath), cleanSpecifier);
+  const candidates = extname(basePath)
+    ? [basePath]
+    : [
+        basePath,
+        ...extensionCandidates.map((extension) => `${basePath}${extension}`),
+        ...extensionCandidates.map((extension) =>
+          join(basePath, `index${extension}`)
+        )
+      ];
+  for (const candidate of candidates) {
+    if (await isFile(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+async function isFile(path) {
+  try {
+    return (await stat(path)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function isInside(root, path) {
+  const child = relative(root, path);
+  return (
+    child !== ".." &&
+    !child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`)
+  );
+}
+
+function asPackagePath(root, path) {
+  return normalize(relative(root, path)).replaceAll("\\", "/");
+}

--- a/tools/scripts/package-pack-relative-imports.test.mjs
+++ b/tools/scripts/package-pack-relative-imports.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { missingPackedRelativeImports } from "./package-pack-relative-imports.mjs";
+
+test("reports a runtime-relative import omitted from a packed package", async () => {
+  const root = await mkdtemp(join(tmpdir(), "tutti-pack-imports-"));
+  try {
+    await mkdir(join(root, "src"));
+    await writeFile(
+      join(root, "src/main.ts"),
+      'import { value } from "./runtime.ts";\nprocess.stdout.write(value);\n'
+    );
+
+    assert.deepEqual(await missingPackedRelativeImports(root, "src/main.ts"), [
+      "src/main.ts -> ./runtime.ts"
+    ]);
+
+    await writeFile(
+      join(root, "src/runtime.ts"),
+      'export const value = "ok";\n'
+    );
+    assert.deepEqual(
+      await missingPackedRelativeImports(root, "src/main.ts"),
+      []
+    );
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("follows re-exports and nested relative imports", async () => {
+  const root = await mkdtemp(join(tmpdir(), "tutti-pack-imports-"));
+  try {
+    await mkdir(join(root, "src/nested"), { recursive: true });
+    await writeFile(
+      join(root, "src/main.ts"),
+      'export { value } from "./nested/index.ts";\n'
+    );
+    await writeFile(
+      join(root, "src/nested/index.ts"),
+      'export { value } from "./value.ts";\n'
+    );
+
+    assert.deepEqual(await missingPackedRelativeImports(root, "src/main.ts"), [
+      "src/nested/index.ts -> ./value.ts"
+    ]);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## What changed
- include src/settingsEnv.ts in the Claude SDK sidecar package
- validate the packed sidecar tarball by walking the complete relative import and re-export closure from src/main.ts
- add regression tests and a patch changeset

## Why
The published sidecar omitted a runtime dependency imported by sessionRuntime.ts. TSH installed the tarball successfully but Node failed at startup with ERR_MODULE_NOT_FOUND, so Claude conversations could still use other paths while cold model discovery returned no models.

## Risk
The pack check is intentionally scoped to the Claude SDK sidecar and may reject future unresolved relative imports until their files are included.

## Verification
- node --test tools/scripts/package-pack-relative-imports.test.mjs
- pnpm release:pack:check
- pnpm check:changed
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->