### PR TITLE
[codex] fix AgentGUI cold-start conversation rail race

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2179,7 +2179,15 @@ User-visible rules:
   `idle -> loading -> partial -> ready` directory sequence cannot turn All into
   a target-scoped request or create a new rail cache key. Only an explicit
   `agentTarget` filter may add `agentTargetId` to section, pinned, search,
-  pagination, or batch-action requests. Filter normalization and list
+  pagination, or batch-action requests. Rail query identity must contain only
+  values present in that backend request protocol. In particular, asynchronously
+  hydrated `userProjects` update project section presentation but must not
+  create a second cache scope or duplicate an otherwise identical section
+  request. Runtime membership changes that arrive while the first section
+  request is pending must be queued until that response establishes the full
+  rail topology. A targeted page refresh may update an established section,
+  but it must never replace an unresolved full-section response or construct
+  the rail from a partial set of changed pages. Filter normalization and list
   projection helpers must not
   mutate workbench node `provider`, provider target fields, composer drafts,
   desktop default provider, or composer-default preferences. All-filter clicks

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2174,7 +2174,13 @@ User-visible rules:
 - Conversation target filters are also list-query concerns. The All rail filter
   applies no `agentTargetId` constraint; provider target rail filters such as
   Codex and Claude Code match sessions by `session.agentTargetId`, not by
-  `session.provider`. Filter normalization and list projection helpers must not
+  `session.provider`. Agent-directory loading, readiness, visibility, and
+  cardinality must not alter that query meaning: an
+  `idle -> loading -> partial -> ready` directory sequence cannot turn All into
+  a target-scoped request or create a new rail cache key. Only an explicit
+  `agentTarget` filter may add `agentTargetId` to section, pinned, search,
+  pagination, or batch-action requests. Filter normalization and list
+  projection helpers must not
   mutate workbench node `provider`, provider target fields, composer drafts,
   desktop default provider, or composer-default preferences. All-filter clicks
   must only clear the `agentTargetId` constraint. Provider target rail clicks
@@ -2184,9 +2190,7 @@ User-visible rules:
   should unactivate the current conversation and show the selected target's
   new-conversation empty composer. React view components must not dispatch
   separate filter and home-composer target actions for one rail click.
-  Apply them only for multi-provider conversation scopes. Single-provider
-  panels should let the node provider constrain the query and collapse target
-  filter actions back to All in the controller.
+  Apply them only for explicit target-filtered conversation scopes.
 - A pending create row can appear before the daemon-created session is
   authoritative. It must be replaced by the authoritative session or removed on
   create failure.

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -695,11 +695,18 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   one selected overlay may show
   Show more/Show less even when only six sessions exist, or a nine-session
   section may ignore the first Show more click. Restart can reproduce the same
-  selected-row loss.
+  selected-row loss. A cold AgentGUI launch may also show an empty project rail
+  until the user switches Agent tabs, even though the runtime snapshot and
+  section endpoint already contain history.
 - Quick checks:
   Inspect `workspace_agent_sessions.agent_target_id` and `rail_section_key`.
   Confirm section requests carry the selected `agentTargetId` before pagination
-  and responses preserve `totalCount`, `hasMore`, and `nextCursor`. In the
+  and that All requests omit it. Compare
+  `agent_gui.conversation_rail.first_pages_slow` with
+  `agent_provider_status.request.*`: if the section request returned rows while
+  the Agent directory was still moving through partial states, inspect whether
+  renderer scope keys changed with directory cardinality. Responses must
+  preserve `totalCount`, `hasMore`, and `nextCursor`. In the
   renderer, distinguish daemon-owned section membership ids from engine-owned
   session entities; activating or hydrating one session must not rewrite the
   loaded membership page. For latency, count repository section reads per
@@ -750,7 +757,11 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   A database opened by different worktrees or intermediate builds can retain a
   migration marker after a required physical index disappears; treating the
   marker alone as proof of the schema invariant makes every section bootstrap
-  fail while an active-session overlay can misleadingly remain visible.
+  fail while an active-session overlay can misleadingly remain visible. The
+  cold-launch variant comes from deriving All scope from the asynchronously
+  loaded Agent directory cardinality: temporary zero/one/many target states
+  create different request and cache scopes even though the user never changed
+  the filter.
 - Fix:
   Keep page sessions in the workspace engine. Cache only ordered membership ids,
   cursor, `hasMore`, and `totalCount` in the controller query, then join ids to
@@ -764,7 +775,10 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   Reassert required rail indexes with idempotent `CREATE INDEX IF NOT EXISTS`
   during every store migration pass, including when the corresponding marker is
   already recorded, so schema drift repairs itself without rewriting session
-  data.
+  data. Keep rail query semantics explicit: All never sends `agentTargetId`,
+  and only an explicit Agent-target filter may create a target-scoped request.
+  Agent-directory loading or visibility changes must not participate in the
+  section-query key.
   Do not add one `UNION ALL` arm per section; that restores section-count scaling
   and inherits SQLite's compound-select term limit.
 - Validation:
@@ -780,6 +794,8 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   requested-section histories. Cover Codex -> All -> Codex,
   client restart restore, active row outside first page, five-plus-active totals,
   nine-session Show more, slow provider refetch, and bounded snapshot omission.
+  Also cover directory startup transitions from zero to one to multiple targets
+  and assert the All request remains unfiltered and is not restarted.
 - References:
   [useAgentGUIConversationRailQuery.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts)
   [agentGuiConversationRail.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts)

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -438,17 +438,6 @@ export function AgentGUINodeView({
     providerAuthAccountLabels,
     viewModel.shell.data.provider
   ]);
-  const enabledProviderTargets = viewModel.rail.agentTargets.filter(
-    (target) =>
-      target.disabled !== true &&
-      ((target.agentTargetId?.trim() ?? "") || (target.targetId?.trim() ?? ""))
-  );
-  const sectionAgentTargetFallbackId =
-    enabledProviderTargets.length <= 1
-      ? viewModel.rail.selectedAgentTarget.agentTargetId?.trim() ||
-        viewModel.rail.selectedAgentTarget.targetId?.trim() ||
-        null
-      : null;
   const openAgentEnvSetup = useCallback(() => {
     // In the "All" filter there is no single rail provider; pass it through as
     // null so the env panel host falls back to the default provider.
@@ -488,7 +477,6 @@ export function AgentGUINodeView({
       agentTargets: viewModel.rail.agentTargets,
       agentTargetsLoading: viewModel.rail.agentTargetsLoading,
       conversationFilter: viewModel.rail.conversationFilter,
-      sectionAgentTargetFallbackId,
       onCreateConversation: requestCreateConversation,
       onUpdateConversationFilter: actions.updateConversationFilter,
       onSelectConversationFilterTarget: actions.selectConversationFilterTarget,
@@ -525,7 +513,6 @@ export function AgentGUINodeView({
       requestRenameConversation,
       selectConversation,
       selectProjectDirectory,
-      sectionAgentTargetFallbackId,
       viewModel.rail.agentTargets,
       viewModel.rail.agentTargetsLoading,
       toggleConversationPinned,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailController.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailController.tsx
@@ -15,7 +15,6 @@ export const AgentGUIConversationRailController = memo(
       conversationFilter: props.conversationFilter,
       conversationQuery,
       previewMode: props.previewMode,
-      sectionAgentTargetFallbackId: props.sectionAgentTargetFallbackId,
       userProjects: props.userProjects,
       workspaceId: props.workspaceId
     });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailDeferredRefresh.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailDeferredRefresh.ts
@@ -1,0 +1,38 @@
+export interface ConversationRailDeferredRefreshPlan {
+  pageIds: readonly string[];
+  refreshSearch: boolean;
+}
+
+export class AgentGUIConversationRailDeferredRefresh {
+  private readonly pageIds = new Set<string>();
+  private refreshSearch = false;
+
+  constructor(
+    private readonly flush: (plan: ConversationRailDeferredRefreshPlan) => void
+  ) {}
+
+  clear(): void {
+    this.pageIds.clear();
+    this.refreshSearch = false;
+  }
+
+  deferIfPending(
+    pending: boolean,
+    plan: ConversationRailDeferredRefreshPlan
+  ): boolean {
+    if (!pending) return false;
+    for (const pageId of plan.pageIds) this.pageIds.add(pageId);
+    this.refreshSearch ||= plan.refreshSearch;
+    return true;
+  }
+
+  flushIfReady(ready: boolean): void {
+    if (!ready) return;
+    const plan = {
+      pageIds: [...this.pageIds],
+      refreshSearch: this.refreshSearch
+    };
+    this.clear();
+    if (plan.pageIds.length > 0 || plan.refreshSearch) this.flush(plan);
+  }
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
@@ -29,7 +29,6 @@ describe("AgentGUIConversationRailQueryController", () => {
       controller.configure({
         conversationFilter: { kind: "all" },
         previewMode: false,
-        sectionAgentTargetFallbackId: null,
         userProjects: []
       });
 
@@ -135,7 +134,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     controller.configure({
       conversationFilter: { kind: "all" },
       previewMode: false,
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
 
@@ -171,7 +169,6 @@ describe("AgentGUIConversationRailQueryController", () => {
         kind: "agentTarget"
       },
       previewMode: false,
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
     expect(controller.isInteractionLocked()).toBe(true);
@@ -207,7 +204,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     const regularScope = {
       conversationFilter: { kind: "all" } as const,
       previewMode: false,
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     };
 
@@ -230,6 +226,75 @@ describe("AgentGUIConversationRailQueryController", () => {
     expect(controller.getSnapshot().runtimeSectionsEnabled).toBe(true);
 
     detachSecond();
+    engine.dispose();
+  });
+
+  it("keeps the All scope unfiltered across repeated startup configuration", async () => {
+    const engine = createTestAgentSessionEngine();
+    const listSessionSections = vi.fn<
+      NonNullable<ConversationRailQueryRuntime["listSessionSections"]>
+    >(async (input) => ({
+      sections: [],
+      workspaceId: input.workspaceId
+    }));
+    const controller = new AgentGUIConversationRailQueryController({
+      engine,
+      getActiveConversationId: () => null,
+      runtime: {
+        listSessionSections,
+        listSessionSectionPage: async (input) => ({
+          hasMore: false,
+          kind: "conversations",
+          sectionKey: input.sectionKey,
+          sessions: [],
+          totalCount: 0
+        })
+      },
+      workspaceId: "test-workspace"
+    });
+
+    controller.configure({
+      conversationFilter: { kind: "all" },
+      previewMode: false,
+      userProjects: []
+    });
+    const detach = controller.attach();
+
+    controller.configure({
+      conversationFilter: { kind: "all" },
+      previewMode: false,
+      userProjects: []
+    });
+    controller.configure({
+      conversationFilter: { kind: "all" },
+      previewMode: false,
+      userProjects: []
+    });
+
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
+    expect(listSessionSections).toHaveBeenCalledTimes(1);
+    expect(listSessionSections.mock.calls[0]?.[0]).not.toHaveProperty(
+      "agentTargetId"
+    );
+
+    controller.configure({
+      conversationFilter: {
+        agentTargetId: "local:codex",
+        kind: "agentTarget"
+      },
+      previewMode: false,
+      userProjects: []
+    });
+    await vi.waitFor(() =>
+      expect(listSessionSections).toHaveBeenCalledTimes(2)
+    );
+    expect(listSessionSections.mock.calls[1]?.[0]).toMatchObject({
+      agentTargetId: "local:codex"
+    });
+
+    detach();
     engine.dispose();
   });
 
@@ -274,7 +339,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     controller.configure({
       conversationFilter: { kind: "all" },
       previewMode: false,
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
 
@@ -349,7 +413,6 @@ describe("AgentGUIConversationRailQueryController", () => {
         agentTargetId: "local:codex"
       },
       previewMode: false,
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
 
@@ -410,7 +473,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     const scope = {
       conversationFilter: { kind: "all" } as const,
       previewMode: false,
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     };
     controller.configure(scope);
@@ -482,7 +544,6 @@ describe("AgentGUIConversationRailQueryController", () => {
         kind: "agentTarget"
       } as const,
       previewMode: false,
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     };
     const first = new AgentGUIConversationRailQueryController({
@@ -565,7 +626,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     const scope = (agentTargetId: string) => ({
       conversationFilter: { agentTargetId, kind: "agentTarget" as const },
       previewMode: false,
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
     controller.configure(scope("local:codex"));

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
@@ -4,9 +4,9 @@ import { createTestAgentSessionEngine } from "../../../shared/testing/createTest
 import { createWorkspaceQueryCache } from "../../../shared/query/workspaceQueryCache";
 import {
   AgentGUIConversationRailQueryController,
-  CONVERSATION_SEARCH_DEBOUNCE_MS,
-  type ConversationRailQueryRuntime
+  CONVERSATION_SEARCH_DEBOUNCE_MS
 } from "./AgentGUIConversationRailQueryController";
+import type { ConversationRailQueryRuntime } from "./agentGuiConversationRailQueryControllerTypes";
 
 describe("AgentGUIConversationRailQueryController", () => {
   it("debounces conversation searches and immediately clears an active query", async () => {
@@ -177,6 +177,99 @@ describe("AgentGUIConversationRailQueryController", () => {
     engine.dispose();
   });
 
+  it("defers membership page refreshes until first pages establish the rail topology", async () => {
+    const engine = createTestAgentSessionEngine();
+    const session = normalizeAgentActivitySession({
+      activeTurnId: null,
+      agentSessionId: "session-1",
+      agentTargetId: "local:codex",
+      cwd: "/workspace",
+      latestTurnInteractions: [],
+      pendingInteractions: [],
+      provider: "codex",
+      railSectionKey: "conversations",
+      title: "Session",
+      updatedAtUnixMs: 1,
+      workspaceId: "test-workspace"
+    });
+    let resolveFirstPages!: () => void;
+    const listSessionSections = vi.fn<
+      NonNullable<ConversationRailQueryRuntime["listSessionSections"]>
+    >((input) =>
+      new Promise<void>((resolve) => {
+        resolveFirstPages = resolve;
+      }).then(() => ({
+        sections: [
+          {
+            hasMore: false,
+            kind: "project" as const,
+            sectionKey: "project:/workspace",
+            sessions: [],
+            totalCount: 0,
+            userProject: {
+              createdAtUnixMs: 1,
+              id: "workspace",
+              label: "Workspace",
+              path: "/workspace",
+              sectionKey: "project:/workspace",
+              updatedAtUnixMs: 1
+            }
+          },
+          {
+            hasMore: false,
+            kind: "conversations" as const,
+            sectionKey: "conversations",
+            sessions: [session],
+            totalCount: 1
+          }
+        ],
+        workspaceId: input.workspaceId
+      }))
+    );
+    const listSessionSectionPage = vi.fn(async (input) => ({
+      hasMore: false,
+      kind: "conversations" as const,
+      sectionKey: input.sectionKey,
+      sessions: [session],
+      totalCount: 1
+    }));
+    const controller = new AgentGUIConversationRailQueryController({
+      engine,
+      getActiveConversationId: () => null,
+      runtime: {
+        listSessionSections,
+        listSessionSectionPage
+      },
+      workspaceId: "test-workspace"
+    });
+    controller.configure({
+      conversationFilter: { kind: "all" },
+      previewMode: false,
+      userProjects: []
+    });
+
+    const detach = controller.attach();
+    engine.dispatch({ type: "session/upserted", session });
+
+    expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(true);
+    expect(listSessionSectionPage).not.toHaveBeenCalled();
+
+    resolveFirstPages();
+    await vi.waitFor(() =>
+      expect(listSessionSectionPage).toHaveBeenCalledTimes(1)
+    );
+    await vi.waitFor(() =>
+      expect(
+        controller
+          .getSnapshot()
+          .runtimeRailMemberships?.map((membership) => membership.id)
+      ).toEqual(["project:/workspace", "conversations"])
+    );
+
+    detach();
+    engine.dispose();
+  });
+
   it("reuses fresh first pages across reattach and preview-mode scope changes", async () => {
     const engine = createTestAgentSessionEngine();
     const listSessionSections = vi.fn<
@@ -229,7 +322,7 @@ describe("AgentGUIConversationRailQueryController", () => {
     engine.dispose();
   });
 
-  it("keeps the All scope unfiltered across repeated startup configuration", async () => {
+  it("keeps the All request stable while startup user projects hydrate", async () => {
     const engine = createTestAgentSessionEngine();
     const listSessionSections = vi.fn<
       NonNullable<ConversationRailQueryRuntime["listSessionSections"]>
@@ -263,12 +356,18 @@ describe("AgentGUIConversationRailQueryController", () => {
     controller.configure({
       conversationFilter: { kind: "all" },
       previewMode: false,
-      userProjects: []
-    });
-    controller.configure({
-      conversationFilter: { kind: "all" },
-      previewMode: false,
-      userProjects: []
+      userProjects: [
+        {
+          id: "workspace",
+          label: "workspace",
+          path: "/Users/local/workspace"
+        },
+        {
+          id: "team-shell",
+          label: "team-shell",
+          path: "/Users/local/team-shell"
+        }
+      ]
     });
 
     await vi.waitFor(() =>

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -42,6 +42,7 @@ import {
   EMPTY_CONVERSATION_RAIL_QUERY_STATE,
   type AgentGUIConversationRailQuerySnapshot
 } from "./agentGuiConversationRailQuerySnapshot";
+import { agentTargetQueryInput } from "./agentGuiConversationRailQueryInput";
 import { AgentGUIConversationRailTargetedPageRefresher } from "./AgentGUIConversationRailTargetedPageRefresher";
 
 export type { AgentGUIConversationRailQuerySnapshot } from "./agentGuiConversationRailQuerySnapshot";
@@ -49,10 +50,10 @@ export type { AgentGUIConversationRailQuerySnapshot } from "./agentGuiConversati
 const SECTION_PAGE_SIZE = 5;
 export const CONVERSATION_SEARCH_DEBOUNCE_MS = 300;
 export const CONVERSATION_RAIL_QUERY_CACHE_FRESH_MS = 30_000;
+
 export interface ConversationRailQueryScope {
   conversationFilter: AgentGUINodeViewModel["rail"]["conversationFilter"];
   previewMode: boolean;
-  sectionAgentTargetFallbackId: string | null;
   userProjects: AgentGUINodeViewModel["rail"]["userProjects"];
 }
 
@@ -193,7 +194,7 @@ export class AgentGUIConversationRailQueryController {
     const sectionAgentTargetId =
       scope.conversationFilter.kind === "agentTarget"
         ? scope.conversationFilter.agentTargetId.trim()
-        : (scope.sectionAgentTargetFallbackId?.trim() ?? "");
+        : "";
     const userProjectPathKey = JSON.stringify(
       scope.userProjects
         .map((project) => project.path.trim())
@@ -286,14 +287,14 @@ export class AgentGUIConversationRailQueryController {
     const request =
       membership.kind === "pinned"
         ? this.runtime.listPinnedSessionsPage!({
-            agentTargetId: this.sectionAgentTargetId || undefined,
+            ...agentTargetQueryInput(this.sectionAgentTargetId),
             cursor: currentPageState.nextCursor || undefined,
             limit: SECTION_PAGE_SIZE,
             signal: abortController.signal,
             workspaceId: this.workspaceId
           })
         : this.runtime.listSessionSectionPage!({
-            agentTargetId: this.sectionAgentTargetId || undefined,
+            ...agentTargetQueryInput(this.sectionAgentTargetId),
             cursor: currentPageState.nextCursor || undefined,
             limit: SECTION_PAGE_SIZE,
             sectionKey: section.id,
@@ -384,7 +385,7 @@ export class AgentGUIConversationRailQueryController {
     this.searchState = { ...this.searchState, loadingMore: true };
     this.emit();
     void listSessionsPage({
-      agentTargetId: this.sectionAgentTargetId || undefined,
+      ...agentTargetQueryInput(this.sectionAgentTargetId),
       cursor: this.searchState.nextCursor ?? undefined,
       limit: 100,
       searchQuery: this.searchQuery,
@@ -522,7 +523,7 @@ export class AgentGUIConversationRailQueryController {
     void this.sessionSectionsQueryCache
       .request(scopeKey, async () => {
         const page = await listSections({
-          agentTargetId: this.sectionAgentTargetId || undefined,
+          ...agentTargetQueryInput(this.sectionAgentTargetId),
           limitPerSection: SECTION_PAGE_SIZE,
           workspaceId: this.workspaceId
         });
@@ -665,7 +666,7 @@ export class AgentGUIConversationRailQueryController {
     };
     this.emit();
     void listSessionsPage({
-      agentTargetId: this.sectionAgentTargetId || undefined,
+      ...agentTargetQueryInput(this.sectionAgentTargetId),
       limit: 100,
       searchQuery: query,
       signal: abortController.signal,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -3,7 +3,6 @@ import {
   type AgentSessionEngine,
   type AgentSessionEngineState
 } from "@tutti-os/agent-activity-core";
-import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import {
   createWorkspaceQueryCache,
   type WorkspaceQueryCache
@@ -14,7 +13,6 @@ import {
   type AgentGuiScheduledTask,
   type AgentGuiScheduler
 } from "../agentGuiScheduler";
-import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
 import {
   CONVERSATION_RAIL_SLOW_DIAGNOSTIC_THRESHOLD_MS,
   createConversationRailDiagnosticLogger,
@@ -42,44 +40,23 @@ import {
   EMPTY_CONVERSATION_RAIL_QUERY_STATE,
   type AgentGUIConversationRailQuerySnapshot
 } from "./agentGuiConversationRailQuerySnapshot";
-import { agentTargetQueryInput } from "./agentGuiConversationRailQueryInput";
+import {
+  agentTargetQueryInput,
+  conversationRailScopeKey
+} from "./agentGuiConversationRailQueryInput";
+import { AgentGUIConversationRailDeferredRefresh } from "./AgentGUIConversationRailDeferredRefresh";
 import { AgentGUIConversationRailTargetedPageRefresher } from "./AgentGUIConversationRailTargetedPageRefresher";
+import type {
+  ConversationRailQueryControllerInput,
+  ConversationRailQueryRuntime,
+  ConversationRailQueryScope
+} from "./agentGuiConversationRailQueryControllerTypes";
 
 export type { AgentGUIConversationRailQuerySnapshot } from "./agentGuiConversationRailQuerySnapshot";
 
 const SECTION_PAGE_SIZE = 5;
 export const CONVERSATION_SEARCH_DEBOUNCE_MS = 300;
 export const CONVERSATION_RAIL_QUERY_CACHE_FRESH_MS = 30_000;
-
-export interface ConversationRailQueryScope {
-  conversationFilter: AgentGUINodeViewModel["rail"]["conversationFilter"];
-  previewMode: boolean;
-  userProjects: AgentGUINodeViewModel["rail"]["userProjects"];
-}
-
-interface ControllerInput {
-  cacheNow?: () => number;
-  cacheFreshMs?: number;
-  diagnosticLogger?: ConversationRailDiagnosticLogger;
-  diagnosticNow?: () => number;
-  diagnosticSlowThresholdMs?: number;
-  engine: AgentSessionEngine;
-  getActiveConversationId(): string | null;
-  runtime: ConversationRailQueryRuntime;
-  sessionSectionsQueryCache?: WorkspaceQueryCache<CachedConversationRailQuery>;
-  scheduler?: AgentGuiScheduler;
-  workspaceId: string;
-}
-
-export type ConversationRailQueryRuntime = Pick<
-  AgentActivityRuntime,
-  | "listPinnedSessionsPage"
-  | "listSessionSectionPage"
-  | "listSessionSections"
-  | "listSessionsPage"
-  | "getSessionSectionsQueryCache"
-  | "reportDiagnostic"
->;
 
 type Listener = (snapshot: AgentGUIConversationRailQuerySnapshot) => void;
 
@@ -110,6 +87,7 @@ export class AgentGUIConversationRailQueryController {
   private readonly providerSwitchDiagnostics: ConversationRailProviderSwitchDiagnosticTracker;
   private readonly pagingAbortControllers = new Map<string, AbortController>();
   private readonly targetedPageRefresher: AgentGUIConversationRailTargetedPageRefresher;
+  private readonly deferredMembershipRefresh: AgentGUIConversationRailDeferredRefresh;
   private queryState = EMPTY_CONVERSATION_RAIL_QUERY_STATE;
   private searchState = EMPTY_CONVERSATION_SEARCH_QUERY_STATE;
   private snapshot!: AgentGUIConversationRailQuerySnapshot;
@@ -129,7 +107,7 @@ export class AgentGUIConversationRailQueryController {
   >;
   private unsubscribeEngine: (() => void) | null = null;
 
-  constructor(input: ControllerInput) {
+  constructor(input: ConversationRailQueryControllerInput) {
     this.cacheFreshMs =
       input.cacheFreshMs ?? CONVERSATION_RAIL_QUERY_CACHE_FRESH_MS;
     this.cacheNow = input.cacheNow ?? Date.now;
@@ -171,6 +149,16 @@ export class AgentGUIConversationRailQueryController {
         runtime: this.runtime,
         workspaceId: this.workspaceId
       });
+    this.deferredMembershipRefresh =
+      new AgentGUIConversationRailDeferredRefresh((plan) => {
+        if (plan.refreshSearch) this.requestSearch();
+        if (plan.pageIds.length === 0) return;
+        this.cancelPagingRequests();
+        this.targetedPageRefresher.refresh({
+          agentTargetId: this.sectionAgentTargetId,
+          pageIds: plan.pageIds
+        });
+      });
     this.previousMembershipRecords = projectConversationRailMembershipRecords(
       this.engine.getSnapshot()
     );
@@ -195,20 +183,11 @@ export class AgentGUIConversationRailQueryController {
       scope.conversationFilter.kind === "agentTarget"
         ? scope.conversationFilter.agentTargetId.trim()
         : "";
-    const userProjectPathKey = JSON.stringify(
-      scope.userProjects
-        .map((project) => project.path.trim())
-        .filter((path) => path.length > 0)
-    );
-    const nextScopeKey = JSON.stringify([
-      this.workspaceId,
-      scope.conversationFilter.kind === "agentTarget"
-        ? `agentTarget:${scope.conversationFilter.agentTargetId.trim()}`
-        : "all",
-      scope.previewMode,
-      sectionAgentTargetId,
-      userProjectPathKey
-    ]);
+    const nextScopeKey = conversationRailScopeKey({
+      conversationFilter: scope.conversationFilter,
+      previewMode: scope.previewMode,
+      workspaceId: this.workspaceId
+    });
     const scopeChanged = nextScopeKey !== this.railSectionQueryKey;
     this.providerSwitchDiagnostics.configure({
       attached: this.attached,
@@ -224,6 +203,7 @@ export class AgentGUIConversationRailQueryController {
 
     this.cancelPagingRequests();
     this.targetedPageRefresher.cancel();
+    this.deferredMembershipRefresh.clear();
     this.queryState = {
       ...this.queryState,
       pending: this.runtimeSectionsEnabled(),
@@ -461,6 +441,13 @@ export class AgentGUIConversationRailQueryController {
       )
     };
     this.emit();
+    if (
+      this.deferredMembershipRefresh.deferIfPending(
+        this.queryState.pending,
+        plan
+      )
+    )
+      return;
     if (plan.refreshSearch) this.requestSearch();
     this.cancelPagingRequests();
     this.targetedPageRefresher.refresh({
@@ -504,6 +491,7 @@ export class AgentGUIConversationRailQueryController {
         sectionCount: cached.value.sectionCount,
         status: "ready"
       });
+      this.flushDeferredMembershipRefresh();
       return;
     }
     const cacheStatus = cached ? "stale" : "miss";
@@ -562,6 +550,7 @@ export class AgentGUIConversationRailQueryController {
           status: "ready",
           workspaceId: this.workspaceId
         });
+        this.flushDeferredMembershipRefresh();
       })
       .catch((error: unknown) => {
         if (
@@ -609,7 +598,16 @@ export class AgentGUIConversationRailQueryController {
               sections: []
             };
         this.emit();
+        this.flushDeferredMembershipRefresh();
       });
+  }
+
+  private flushDeferredMembershipRefresh(): void {
+    this.deferredMembershipRefresh.flushIfReady(
+      !this.queryState.pending &&
+        this.queryState.resolvedScopeKey === this.railSectionQueryKey &&
+        this.queryState.sections !== null
+    );
   }
 
   private applyCachedFirstPages(
@@ -791,6 +789,7 @@ export class AgentGUIConversationRailQueryController {
     this.unsubscribeEngine = null;
     this.cancelPagingRequests();
     this.targetedPageRefresher.cancel();
+    this.deferredMembershipRefresh.clear();
     this.clearSearchDebounceTimer();
     this.searchRequestSequence += 1;
     this.searchAbortController?.abort();

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -606,7 +606,8 @@ export class AgentGUIConversationRailQueryController {
     this.deferredMembershipRefresh.flushIfReady(
       !this.queryState.pending &&
         this.queryState.resolvedScopeKey === this.railSectionQueryKey &&
-        this.queryState.sections !== null
+        this.queryState.sections !== null &&
+        this.queryState.sections.length > 0
     );
   }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryControllerTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryControllerTypes.ts
@@ -1,0 +1,37 @@
+import type { AgentSessionEngine } from "@tutti-os/agent-activity-core";
+import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
+import type { WorkspaceQueryCache } from "../../../shared/query/workspaceQueryCache";
+import type { AgentGuiScheduler } from "../agentGuiScheduler";
+import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
+import type { ConversationRailDiagnosticLogger } from "./agentGuiConversationRailDiagnostics";
+import type { CachedConversationRailQuery } from "./agentGuiConversationRailQueryCache";
+
+export interface ConversationRailQueryScope {
+  conversationFilter: AgentGUINodeViewModel["rail"]["conversationFilter"];
+  previewMode: boolean;
+  userProjects: AgentGUINodeViewModel["rail"]["userProjects"];
+}
+
+export type ConversationRailQueryRuntime = Pick<
+  AgentActivityRuntime,
+  | "listPinnedSessionsPage"
+  | "listSessionSectionPage"
+  | "listSessionSections"
+  | "listSessionsPage"
+  | "getSessionSectionsQueryCache"
+  | "reportDiagnostic"
+>;
+
+export interface ConversationRailQueryControllerInput {
+  cacheNow?: () => number;
+  cacheFreshMs?: number;
+  diagnosticLogger?: ConversationRailDiagnosticLogger;
+  diagnosticNow?: () => number;
+  diagnosticSlowThresholdMs?: number;
+  engine: AgentSessionEngine;
+  getActiveConversationId(): string | null;
+  runtime: ConversationRailQueryRuntime;
+  sessionSectionsQueryCache?: WorkspaceQueryCache<CachedConversationRailQuery>;
+  scheduler?: AgentGuiScheduler;
+  workspaceId: string;
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryInput.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryInput.ts
@@ -1,5 +1,24 @@
+import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
+
 export function agentTargetQueryInput(agentTargetId: string): {
   agentTargetId?: string;
 } {
   return agentTargetId ? { agentTargetId } : {};
+}
+
+export function conversationRailScopeKey(input: {
+  conversationFilter: AgentGUINodeViewModel["rail"]["conversationFilter"];
+  previewMode: boolean;
+  workspaceId: string;
+}): string {
+  const agentTargetId =
+    input.conversationFilter.kind === "agentTarget"
+      ? input.conversationFilter.agentTargetId.trim()
+      : "";
+  return JSON.stringify([
+    input.workspaceId,
+    agentTargetId ? `agentTarget:${agentTargetId}` : "all",
+    input.previewMode,
+    agentTargetId
+  ]);
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryInput.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryInput.ts
@@ -1,0 +1,5 @@
+export function agentTargetQueryInput(agentTargetId: string): {
+  agentTargetId?: string;
+} {
+  return agentTargetId ? { agentTargetId } : {};
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.search.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.search.spec.tsx
@@ -63,7 +63,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
           },
           conversationQuery: " backend ",
           previewMode: false,
-          sectionAgentTargetFallbackId: null,
           userProjects: [],
           workspaceId: "workspace-1"
         }),
@@ -142,7 +141,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
           conversationFilter: { kind: "all" },
           conversationQuery: "backend",
           previewMode: false,
-          sectionAgentTargetFallbackId: null,
           userProjects: [],
           workspaceId: "workspace-1"
         }),
@@ -193,7 +191,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
           conversationFilter: { kind: "all" },
           conversationQuery: "",
           previewMode: true,
-          sectionAgentTargetFallbackId: null,
           userProjects: [],
           workspaceId: "workspace-1"
         });
@@ -245,7 +242,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
         conversationFilter: { kind: "all" },
         conversationQuery: "streaming",
         previewMode: true,
-        sectionAgentTargetFallbackId: null,
         userProjects: [],
         workspaceId: "workspace-1"
       });
@@ -274,7 +270,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
             pendingDeleteConversationId={null}
             previewMode
             railQuery={railQuery}
-            sectionAgentTargetFallbackId={null}
             uiLanguage="en"
             userProjects={[]}
             workspaceId="workspace-1"
@@ -342,7 +337,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
         conversationFilter: { kind: "all" },
         conversationQuery: "",
         previewMode: false,
-        sectionAgentTargetFallbackId: null,
         userProjects,
         workspaceId: "workspace-1"
       });
@@ -364,7 +358,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
           pendingDeleteConversationId={null}
           previewMode={false}
           railQuery={railQuery}
-          sectionAgentTargetFallbackId={null}
           uiLanguage="en"
           userProjects={userProjects}
           workspaceId="workspace-1"

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
@@ -20,7 +20,6 @@ export interface AgentGUIConversationRailInput {
   conversationFilter: AgentGUINodeViewModel["rail"]["conversationFilter"];
   conversationQuery: string;
   previewMode: boolean;
-  sectionAgentTargetFallbackId: string | null;
   userProjects: AgentGUINodeViewModel["rail"]["userProjects"];
   workspaceId: string;
 }
@@ -30,7 +29,6 @@ export function useAgentGUIConversationRailQuery({
   conversationFilter,
   conversationQuery,
   previewMode,
-  sectionAgentTargetFallbackId,
   userProjects,
   workspaceId
 }: AgentGUIConversationRailInput) {
@@ -57,7 +55,6 @@ export function useAgentGUIConversationRailQuery({
     controller.configure({
       conversationFilter,
       previewMode,
-      sectionAgentTargetFallbackId,
       userProjects
     });
     controller.setSearchQuery(conversationQuery);
@@ -66,7 +63,6 @@ export function useAgentGUIConversationRailQuery({
     conversationFilter,
     conversationQuery,
     previewMode,
-    sectionAgentTargetFallbackId,
     userProjects
   ]);
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
@@ -88,7 +88,6 @@ export interface AgentGUIConversationRailControllerProps {
   agentTargets: AgentGUINodeViewModel["rail"]["agentTargets"];
   agentTargetsLoading: AgentGUINodeViewModel["rail"]["agentTargetsLoading"];
   conversationFilter: AgentGUINodeViewModel["rail"]["conversationFilter"];
-  sectionAgentTargetFallbackId: string | null;
   onUpdateConversationFilter: (
     filter: AgentGUINodeViewModel["rail"]["conversationFilter"]
   ) => void;
@@ -172,7 +171,6 @@ export const AgentGUIConversationRailPane = memo(
     createConversationDisabled,
     isCollapsed,
     conversationFilter,
-    sectionAgentTargetFallbackId,
     conversationQuery,
     railQuery,
     onCreateConversation,
@@ -407,7 +405,7 @@ export const AgentGUIConversationRailPane = memo(
     const sectionPaginationScopeKey = `${
       conversationFilter.kind === "agentTarget"
         ? `${workspaceId}:agentTarget:${conversationFilter.agentTargetId.trim()}`
-        : `${workspaceId}:all:${sectionAgentTargetFallbackId?.trim() ?? ""}`
+        : `${workspaceId}:all`
     }:search:${conversationQuery.trim()}`;
     const toggleProjectSectionCollapsed = useCallback((sectionId: string) => {
       setCollapsedProjectSectionIds((current) => {
@@ -433,7 +431,7 @@ export const AgentGUIConversationRailPane = memo(
     const sectionAgentTargetId =
       conversationFilter.kind === "agentTarget"
         ? conversationFilter.agentTargetId.trim()
-        : (sectionAgentTargetFallbackId?.trim() ?? "");
+        : "";
     const requestSectionBatchDeletion = useCallback(
       (section: ConversationSection) => {
         if (


### PR DESCRIPTION
## Summary

Fix AgentGUI project conversation history appearing empty after a cold desktop startup until the user switches Agent filters.

## User impact

The conversation database and daemon response were intact, but the initial AgentGUI rail could show only the active project conversation and an empty second project. Switching Agent filters caused a full section request and made the missing history appear, which made the startup race look like data loss.

## Root cause

Two startup state flows were allowed to compete:

1. The controller started the full `listSessionSections` request that establishes the rail topology (`workspace`, `team-shell`, and `conversations`).
2. While that request was pending, runtime session hydration changed membership records and triggered a targeted page refresh.

The targeted refresh reused the controller's paging sequence. It invalidated the still-pending full response, then applied only its changed page (in the reproduced case, `conversations`) to a controller whose full section topology had not been established. Project section templates remained visible, but their canonical memberships were absent, so the UI showed the active overlay in one project and no history in the other.

Switching Agent filters created a new scope and issued another full section request, which is why the history appeared after interaction.

The branch also removes implicit Agent-target fallback behavior and keeps the All scope keyed only by values actually sent in the backend request. Asynchronously hydrated `userProjects` therefore cannot create a second equivalent query scope.

## Fix

- Defer runtime membership page refreshes while the full first-page request is pending.
- Merge affected page IDs and the pending search-refresh flag while deferred.
- Release the merged targeted refresh only after a successful full response has established a non-empty section topology.
- Never let a failed full request fall back to constructing the rail from partial targeted pages.
- Keep full section requests and targeted page updates as separate phases with explicit ordering.
- Keep All rail query identity stable across asynchronous project hydration.
- Document the startup ordering and scope invariants.

## Regression coverage

The new controller test reproduces the race by:

- holding the full section response unresolved;
- hydrating a runtime session that requests a targeted `conversations` refresh;
- verifying the targeted refresh does not run while the full response is pending;
- resolving the full response with a project and conversations section;
- verifying the targeted refresh runs afterward without removing the project topology.

## Validation

- Agent GUI test suite: 187 files passed, 1698 tests passed.
- Focused controller regression suite: 10 tests passed.
- Agent GUI typecheck passed.
- Changed TypeScript files passed oxlint.
- Agent GUI degradation/file-size guard passed.
- Pre-push `pnpm check:full`: 18 tasks passed, including TypeScript tests, Go tests, and lint checks.
- Production-data dev launch: `DEV_GUI_TUTTI_ENV=production make dev-gui`.
- Repeated cold-start verification after confirming the investigation Electron, daemon, and electron-vite process count was zero.
- On cold startup, without HMR or switching Agent filters, both `workspace` and `team-shell` histories were immediately visible.
