### PR TITLE
feat(workspace-app-center): support event-driven progress

### DIFF
--- a/packages/workspace/app-center/README.md
+++ b/packages/workspace/app-center/README.md
@@ -4,6 +4,46 @@ Host-neutral workspace app center contracts, validation, status mapping, view-mo
 
 The package does not construct daemon clients, access desktop preload APIs, resolve host paths, spawn processes, or register workbench or dock contributions.
 
+## Runtime Refresh Policy
+
+`createWorkspaceAppCenterController` defaults to `refreshPolicy: "poll"` for
+backward compatibility. In this mode, the controller schedules bounded refreshes
+while installs and transient runtime states are active.
+
+Event-driven hosts can pass `refreshPolicy: "event"`. This disables the
+controller's per-app install refreshes and transient-runtime refresh timer. The
+host must then subscribe to its daemon/runtime event stream and forward each app
+change through `controller.applyAppUpdate(...)` with an `operationCursor`:
+
+```ts
+controller.applyAppUpdate({
+  app,
+  operationCursor: {
+    desiredGeneration,
+    operationId,
+    sequence
+  },
+  workspaceId
+});
+```
+
+Within an operation, `sequence` must increase. A replacement operation must use
+a greater `desiredGeneration` and a new `operationId`; stale, duplicate, or
+ambiguous updates are discarded. Event updates are accepted only while that
+workspace's polling lifecycle is active. `endWorkspacePolling` is a full
+workspace teardown and rejects late events from the disposed stream.
+
+Event mode deliberately does not provide an app-state polling fallback. The host
+owns reconnect handling. For a reconnect of the same active workspace, first
+pause and guard delivery from the old stream, call
+`resetWorkspaceEventCursors(workspaceId)`, fetch and apply a full
+`WorkspaceAppCenterSnapshot`, and then resume ordered `applyAppUpdate` events
+from the replacement stream. The reset keeps pending install/report state, while
+the fresh snapshot establishes the new event-ordering baseline. Do not call
+`endWorkspacePolling` for a reconnect; reserve it for leaving or disposing the
+workspace. The catalog-loading refresh remains workspace-scoped and is
+independent of app runtime event delivery.
+
 ## View State
 
 `WorkspaceAppCenterViewState` preserves the selected app tab and may include an

--- a/packages/workspace/app-center/src/core/appCenterController.test.ts
+++ b/packages/workspace/app-center/src/core/appCenterController.test.ts
@@ -583,6 +583,399 @@ test("WorkspaceAppCenterController preserves install progress during pending ins
   });
 });
 
+test("WorkspaceAppCenterController event refresh policy does not start per-app polling", async () => {
+  let listCalls = 0;
+  const controller = createWorkspaceAppCenterController({
+    formatError,
+    gateway: createGateway({
+      async installWorkspaceApp() {
+        return createSnapshot({
+          apps: [
+            createApp({
+              appId: "app-1",
+              installed: false,
+              runtimeStatus: "installing",
+              stateRevision: 2
+            })
+          ]
+        });
+      },
+      async listWorkspaceApps() {
+        listCalls += 1;
+        return createSnapshot();
+      }
+    }),
+    installRefreshDelayMs: 1,
+    refreshPolicy: "event"
+  });
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [createApp({ installed: false, runtimeStatus: "idle" })]
+    })
+  );
+  controller.beginWorkspacePolling("workspace-1");
+
+  await controller.installApp({ appId: "app-1", workspaceId: "workspace-1" });
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.equal(listCalls, 0);
+  assert.equal(controller.store.apps[0]?.runtimeStatus, "installing");
+  controller.endWorkspacePolling("workspace-1");
+});
+
+test("WorkspaceAppCenterController event refresh policy disables active and transient refresh timers", async () => {
+  let listCalls = 0;
+  const controller = createWorkspaceAppCenterController({
+    formatError,
+    gateway: createGateway({
+      async listWorkspaceApps() {
+        listCalls += 1;
+        return createSnapshot();
+      }
+    }),
+    installRefreshDelayMs: 1,
+    refreshPolicy: "event",
+    transientRuntimeRefreshDelayMs: 1
+  });
+  controller.beginWorkspacePolling("workspace-1");
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [
+        createApp({
+          installProgress: {
+            downloadedBytes: null,
+            indeterminate: true,
+            overallPercent: 0,
+            totalBytes: null,
+            userPhase: "starting"
+          },
+          runtimeStatus: "starting"
+        })
+      ]
+    })
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.equal(listCalls, 0);
+  controller.endWorkspacePolling("workspace-1");
+});
+
+test("WorkspaceAppCenterController orders pushed updates by generation and sequence", () => {
+  const controller = createWorkspaceAppCenterController({
+    formatError,
+    gateway: createGateway(),
+    refreshPolicy: "event"
+  });
+  controller.beginWorkspacePolling("workspace-1");
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [createApp({ runtimeStatus: "idle", stateRevision: 5 })]
+    })
+  );
+
+  controller.applyAppUpdate({
+    app: createApp({ runtimeStatus: "starting", stateRevision: 5 }),
+    operationCursor: {
+      desiredGeneration: 1,
+      operationId: "install-1",
+      sequence: 2
+    },
+    workspaceId: "workspace-1"
+  });
+  controller.applyAppUpdate({
+    app: createApp({ runtimeStatus: "failed", stateRevision: 99 }),
+    operationCursor: {
+      desiredGeneration: 1,
+      operationId: "install-1",
+      sequence: 1
+    },
+    workspaceId: "workspace-1"
+  });
+  controller.applyAppUpdate({
+    app: createApp({ runtimeStatus: "failed", stateRevision: 100 }),
+    operationCursor: {
+      desiredGeneration: 1,
+      operationId: "different-operation",
+      sequence: 99
+    },
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(controller.store.apps[0]?.runtimeStatus, "starting");
+
+  controller.applyAppUpdate({
+    app: createApp({ runtimeStatus: "running", stateRevision: 1 }),
+    operationCursor: {
+      desiredGeneration: 2,
+      operationId: "install-2",
+      sequence: 0
+    },
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(controller.store.apps[0]?.runtimeStatus, "running");
+  controller.applyAppUpdate({
+    app: createApp({ runtimeStatus: "failed", stateRevision: 100 }),
+    operationCursor: {
+      desiredGeneration: 3,
+      operationId: "install-2",
+      sequence: 0
+    },
+    workspaceId: "workspace-1"
+  });
+  assert.equal(controller.store.apps[0]?.runtimeStatus, "running");
+  controller.endWorkspacePolling("workspace-1");
+});
+
+test("WorkspaceAppCenterController event policy rejects unordered app updates", () => {
+  const controller = createWorkspaceAppCenterController({
+    formatError,
+    gateway: createGateway(),
+    refreshPolicy: "event"
+  });
+  controller.beginWorkspacePolling("workspace-1");
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({ apps: [createApp({ stateRevision: 1 })] })
+  );
+
+  controller.applyAppUpdate({
+    app: createApp({ runtimeStatus: "failed", stateRevision: 100 }),
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(controller.store.apps[0]?.runtimeStatus, "idle");
+  controller.endWorkspacePolling("workspace-1");
+});
+
+test("WorkspaceAppCenterController fences snapshots after ordered event updates", () => {
+  const controller = createWorkspaceAppCenterController({
+    formatError,
+    gateway: createGateway(),
+    refreshPolicy: "event"
+  });
+  controller.beginWorkspacePolling("workspace-1");
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [
+        createApp({
+          availableVersion: "1.1.0",
+          runtimeStatus: "idle",
+          stateRevision: 5
+        })
+      ]
+    })
+  );
+  controller.applyAppUpdate({
+    app: createApp({ runtimeStatus: "running", stateRevision: 1 }),
+    operationCursor: {
+      desiredGeneration: 2,
+      operationId: "install-2",
+      sequence: 2
+    },
+    workspaceId: "workspace-1"
+  });
+
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [
+        createApp({
+          availableVersion: "1.2.0",
+          runtimeStatus: "starting",
+          stateRevision: 6
+        })
+      ]
+    })
+  );
+
+  assert.equal(controller.store.apps[0]?.runtimeStatus, "running");
+  assert.equal(controller.store.apps[0]?.stateRevision, 1);
+  assert.equal(controller.store.apps[0]?.availableVersion, "1.2.0");
+
+  controller.resetWorkspaceEventCursors("workspace-1");
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [createApp({ runtimeStatus: "starting", stateRevision: 6 })]
+    })
+  );
+
+  assert.equal(controller.store.apps[0]?.runtimeStatus, "starting");
+  assert.equal(controller.store.apps[0]?.stateRevision, 6);
+  controller.endWorkspacePolling("workspace-1");
+});
+
+test("WorkspaceAppCenterController clears operation cursors on workspace switch and rejects updates after polling end", () => {
+  const controller = createWorkspaceAppCenterController({
+    formatError,
+    gateway: createGateway(),
+    refreshPolicy: "event"
+  });
+  controller.beginWorkspacePolling("workspace-1");
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({ apps: [createApp({ stateRevision: 5 })] })
+  );
+  controller.applyAppUpdate({
+    app: createApp({ runtimeStatus: "starting", stateRevision: 1 }),
+    operationCursor: {
+      desiredGeneration: 2,
+      operationId: "workspace-1-operation",
+      sequence: 1
+    },
+    workspaceId: "workspace-1"
+  });
+
+  controller.applySnapshot(
+    "workspace-2",
+    createSnapshot({ apps: [createApp({ stateRevision: 5 })] })
+  );
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({ apps: [createApp({ stateRevision: 5 })] })
+  );
+  controller.applyAppUpdate({
+    app: createApp({ runtimeStatus: "preparing", stateRevision: 1 }),
+    operationCursor: {
+      desiredGeneration: 1,
+      operationId: "after-switch",
+      sequence: 0
+    },
+    workspaceId: "workspace-1"
+  });
+  assert.equal(controller.store.apps[0]?.runtimeStatus, "preparing");
+
+  controller.endWorkspacePolling("workspace-1");
+  controller.applyAppUpdate({
+    app: createApp({ runtimeStatus: "running", stateRevision: 1 }),
+    operationCursor: {
+      desiredGeneration: 1,
+      operationId: "after-end",
+      sequence: 0
+    },
+    workspaceId: "workspace-1"
+  });
+  assert.equal(controller.store.apps[0]?.runtimeStatus, "preparing");
+});
+
+test("WorkspaceAppCenterController reconnect reset preserves pending install lifecycle", async () => {
+  const installedApps: WorkspaceAppCenterApp[] = [];
+  const installingApp = createApp({
+    installed: false,
+    installProgress: {
+      downloadedBytes: null,
+      indeterminate: true,
+      overallPercent: 0,
+      totalBytes: null,
+      userPhase: "downloading"
+    },
+    runtimeStatus: "installing",
+    stateRevision: 2
+  });
+  const controller = createWorkspaceAppCenterController({
+    formatError,
+    gateway: createGateway({
+      async installWorkspaceApp() {
+        return createSnapshot({ apps: [installingApp] });
+      }
+    }),
+    hooks: {
+      onAppInstalled(app) {
+        installedApps.push(app);
+      }
+    },
+    refreshPolicy: "event"
+  });
+  controller.beginWorkspacePolling("workspace-1");
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [createApp({ installed: false, runtimeStatus: "idle" })]
+    })
+  );
+
+  await controller.installApp({ appId: "app-1", workspaceId: "workspace-1" });
+  controller.applyAppUpdate({
+    app: createApp({
+      installed: false,
+      runtimeStatus: "installing",
+      stateRevision: 3
+    }),
+    operationCursor: {
+      desiredGeneration: 5,
+      operationId: "old-stream-install",
+      sequence: 4
+    },
+    workspaceId: "workspace-1"
+  });
+
+  controller.resetWorkspaceEventCursors("workspace-1");
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({ apps: [installingApp] })
+  );
+  controller.applyAppUpdate({
+    app: createApp({ runtimeStatus: "running", stateRevision: 4 }),
+    operationCursor: {
+      desiredGeneration: 1,
+      operationId: "replacement-stream-install",
+      sequence: 0
+    },
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(controller.store.apps[0]?.runtimeStatus, "running");
+  assert.equal(installedApps.length, 1);
+  controller.endWorkspacePolling("workspace-1");
+});
+
+test("WorkspaceAppCenterController clears cursors before refresh switches workspace", async () => {
+  const controller = createWorkspaceAppCenterController({
+    formatError,
+    gateway: createGateway({
+      async listWorkspaceApps() {
+        return createSnapshot({ apps: [createApp()] });
+      }
+    }),
+    refreshPolicy: "event"
+  });
+  controller.beginWorkspacePolling("workspace-1");
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({ apps: [createApp()] })
+  );
+  controller.applyAppUpdate({
+    app: createApp({ runtimeStatus: "starting" }),
+    operationCursor: {
+      desiredGeneration: 2,
+      operationId: "before-switch",
+      sequence: 1
+    },
+    workspaceId: "workspace-1"
+  });
+
+  await controller.refresh("workspace-2");
+  await controller.refresh("workspace-1");
+  controller.applyAppUpdate({
+    app: createApp({ runtimeStatus: "running" }),
+    operationCursor: {
+      desiredGeneration: 1,
+      operationId: "after-switch",
+      sequence: 0
+    },
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(controller.store.apps[0]?.runtimeStatus, "running");
+  controller.endWorkspacePolling("workspace-1");
+});
+
 test("WorkspaceAppCenterController clears pending install when backend job disappears", async () => {
   let installCalls = 0;
   const installFailures: unknown[] = [];

--- a/packages/workspace/app-center/src/core/appCenterController.test.ts
+++ b/packages/workspace/app-center/src/core/appCenterController.test.ts
@@ -811,6 +811,86 @@ test("WorkspaceAppCenterController fences snapshots after ordered event updates"
   controller.endWorkspacePolling("workspace-1");
 });
 
+test("WorkspaceAppCenterController backfills launch URL for the running event runtime", () => {
+  const controller = createWorkspaceAppCenterController({
+    formatError,
+    gateway: createGateway(),
+    refreshPolicy: "event"
+  });
+  controller.beginWorkspacePolling("workspace-1");
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [
+        createApp({
+          installationId: "installation-1",
+          runtimeId: "runtime-1",
+          runtimeStatus: "starting",
+          stateRevision: 5
+        })
+      ]
+    })
+  );
+  controller.applyAppUpdate({
+    app: createApp({
+      installationId: "installation-1",
+      launchUrl: null,
+      runtimeId: "runtime-1",
+      runtimeStatus: "running",
+      stateRevision: 1
+    }),
+    operationCursor: {
+      desiredGeneration: 2,
+      operationId: "install-2",
+      sequence: 20
+    },
+    workspaceId: "workspace-1"
+  });
+
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [
+        createApp({
+          installationId: "installation-1",
+          launchUrl: "http://runtime-1.tsh-app.localhost:3000",
+          runtimeId: "runtime-1",
+          runtimeStatus: "running",
+          stateRevision: 6
+        })
+      ]
+    })
+  );
+
+  assert.equal(controller.store.apps[0]?.runtimeStatus, "running");
+  assert.equal(
+    controller.store.apps[0]?.launchUrl,
+    "http://runtime-1.tsh-app.localhost:3000"
+  );
+  // Snapshot enrichment must not advance or replace event ordering state.
+  assert.equal(controller.store.apps[0]?.stateRevision, 1);
+
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [
+        createApp({
+          installationId: "installation-1",
+          launchUrl: "http://different-runtime.tsh-app.localhost:4000",
+          runtimeId: "runtime-2",
+          runtimeStatus: "running",
+          stateRevision: 7
+        })
+      ]
+    })
+  );
+  assert.equal(
+    controller.store.apps[0]?.launchUrl,
+    "http://runtime-1.tsh-app.localhost:3000"
+  );
+  controller.endWorkspacePolling("workspace-1");
+});
+
 test("WorkspaceAppCenterController clears operation cursors on workspace switch and rejects updates after polling end", () => {
   const controller = createWorkspaceAppCenterController({
     formatError,

--- a/packages/workspace/app-center/src/core/appCenterController.ts
+++ b/packages/workspace/app-center/src/core/appCenterController.ts
@@ -18,9 +18,11 @@ export {
   createWorkspaceAppCenterStoreState,
   type WorkspaceAppCenterControllerDependencies,
   type WorkspaceAppCenterControllerHooks,
+  type WorkspaceAppCenterOperationCursor,
   type WorkspaceAppCenterOperation,
   type WorkspaceAppCenterOperationDetails,
   type WorkspaceAppCenterRefreshDiscard,
+  type WorkspaceAppCenterRefreshPolicy,
   type WorkspaceAppCenterUiAction
 } from "./appCenterControllerTypes.ts";
 
@@ -342,6 +344,7 @@ export class WorkspaceAppCenterController extends WorkspaceAppCenterControllerSt
     const appSequence = ++this.appLoadSequence;
     const factorySequence = ++this.factoryLoadSequence;
     const wasIdle = this.store.loadStatus === "idle";
+    this.clearOperationCursorsOnWorkspaceChange(normalizedWorkspaceId);
     this.store.workspaceId = normalizedWorkspaceId;
     this.store.error = null;
     if (wasIdle) {

--- a/packages/workspace/app-center/src/core/appCenterControllerBase.ts
+++ b/packages/workspace/app-center/src/core/appCenterControllerBase.ts
@@ -11,6 +11,7 @@ import {
 import {
   createWorkspaceAppCenterStoreState,
   type WorkspaceAppCenterControllerDependencies,
+  type WorkspaceAppCenterOperationCursor,
   type WorkspaceAppCenterOperationDetails
 } from "./appCenterControllerTypes.ts";
 
@@ -34,9 +35,17 @@ export abstract class WorkspaceAppCenterControllerBase {
   protected pendingFactoryPublishKeys = new Set<string>();
   protected pendingInstallKeys = new Set<string>();
   protected pendingInstallReportKeys = new Set<string>();
+  protected appOperationCursors = new Map<
+    string,
+    WorkspaceAppCenterOperationCursor
+  >();
   protected appLoadSequence = 0;
   protected factoryLoadSequence = 0;
   protected pollingWorkspaceId: string | null = null;
+
+  protected get usesPollingRefresh(): boolean {
+    return (this.dependencies.refreshPolicy ?? "poll") === "poll";
+  }
 
   constructor(dependencies: WorkspaceAppCenterControllerDependencies) {
     this.dependencies = dependencies;
@@ -76,7 +85,20 @@ export abstract class WorkspaceAppCenterControllerBase {
     this.clearInstallRefreshTimers();
     this.clearActiveInstallRefreshTimers();
     this.clearTransientRuntimeRefreshTimer();
+    this.appOperationCursors.clear();
     this.pollingWorkspaceId = normalizedWorkspaceId;
+  }
+
+  /**
+   * Resets only event ordering state while keeping in-flight install lifecycle
+   * state intact. Event-driven hosts should pause delivery from the old stream,
+   * call this method, apply a fresh snapshot, and then resume event delivery.
+   */
+  resetWorkspaceEventCursors(workspaceId: string): void {
+    if (this.pollingWorkspaceId !== workspaceId.trim()) {
+      return;
+    }
+    this.appOperationCursors.clear();
   }
 
   endWorkspacePolling(workspaceId: string): void {
@@ -88,6 +110,7 @@ export abstract class WorkspaceAppCenterControllerBase {
     this.clearInstallRefreshTimers();
     this.clearActiveInstallRefreshTimers();
     this.clearTransientRuntimeRefreshTimer();
+    this.appOperationCursors.clear();
   }
 
   getViewState(
@@ -160,6 +183,15 @@ export abstract class WorkspaceAppCenterControllerBase {
     }
     clearTimeout(this.catalogRefreshTimer);
     this.catalogRefreshTimer = null;
+  }
+
+  protected clearOperationCursorsOnWorkspaceChange(workspaceId: string): void {
+    if (
+      this.store.workspaceId !== null &&
+      this.store.workspaceId !== workspaceId
+    ) {
+      this.appOperationCursors.clear();
+    }
   }
 
   protected clearInstallRefreshTimer(workspaceId: string, appId: string): void {

--- a/packages/workspace/app-center/src/core/appCenterControllerState.ts
+++ b/packages/workspace/app-center/src/core/appCenterControllerState.ts
@@ -427,7 +427,26 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
         !this.usesPollingRefresh &&
         this.appOperationCursors.has(installKey)
       ) {
-        return mergeWorkspaceAppCatalogFields(currentApp, snapshotApp);
+        const mergedApp = mergeWorkspaceAppCatalogFields(
+          currentApp,
+          snapshotApp
+        );
+        // Ordered operation events own lifecycle state, but launchUrl is a
+        // route capability that only exists in the authoritative runtime
+        // snapshot. Enrich the terminal event projection only when both
+        // sources describe the exact same running runtime fence.
+        if (
+          currentApp.runtimeStatus === "running" &&
+          snapshotApp.runtimeStatus === "running" &&
+          currentApp.runtimeId != null &&
+          currentApp.runtimeId === snapshotApp.runtimeId &&
+          currentApp.installationId != null &&
+          currentApp.installationId === snapshotApp.installationId &&
+          snapshotApp.launchUrl != null
+        ) {
+          return { ...mergedApp, launchUrl: snapshotApp.launchUrl };
+        }
+        return mergedApp;
       }
       if (!currentApp || currentApp.stateRevision < snapshotApp.stateRevision) {
         return snapshotApp;

--- a/packages/workspace/app-center/src/core/appCenterControllerState.ts
+++ b/packages/workspace/app-center/src/core/appCenterControllerState.ts
@@ -19,8 +19,10 @@ import {
   defaultCatalogLoadingRefreshDelayMs,
   defaultInstallRefreshDelayMs,
   defaultTransientRuntimeRefreshDelayMs,
-  defaultTransientRuntimeRefreshMaxAttempts
+  defaultTransientRuntimeRefreshMaxAttempts,
+  type WorkspaceAppCenterOperationCursor
 } from "./appCenterControllerTypes.ts";
+import { acceptWorkspaceAppOperationCursor } from "./appOperationCursor.ts";
 import { reconcilePendingInstallProgress } from "./installProgressMerge.ts";
 
 export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCenterControllerBase {
@@ -30,6 +32,7 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
     workspaceId: string,
     snapshot: WorkspaceAppCenterSnapshot
   ): void {
+    this.clearOperationCursorsOnWorkspaceChange(workspaceId);
     const nextApps = sortWorkspaceAppCenterApps(
       this.mergeSnapshotAppsByStateRevision(
         workspaceId,
@@ -86,6 +89,7 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
     workspaceId: string,
     snapshot: WorkspaceAppFactorySnapshot
   ): void {
+    this.clearOperationCursorsOnWorkspaceChange(workspaceId);
     if (this.store.workspaceId !== workspaceId) {
       this.store.workspaceId = workspaceId;
     }
@@ -106,10 +110,16 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
   applyAppUpdate(input: {
     app: WorkspaceAppCenterApp;
     failureReason?: string | null;
+    operationCursor?: WorkspaceAppCenterOperationCursor | null;
     startedAtUnixMs?: number | null;
     workspaceId: string;
   }): void {
-    if (this.store.workspaceId !== input.workspaceId) {
+    if (
+      this.store.workspaceId !== input.workspaceId ||
+      (!this.usesPollingRefresh &&
+        (this.pollingWorkspaceId !== input.workspaceId ||
+          input.operationCursor == null))
+    ) {
       return;
     }
     const currentApp = this.store.apps.find(
@@ -118,7 +128,16 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
     if (!currentApp) {
       return;
     }
+    const operationAdvance = acceptWorkspaceAppOperationCursor(
+      this.appOperationCursors,
+      appRuntimeKey(input.workspaceId, input.app.appId),
+      input.operationCursor
+    );
+    if (operationAdvance === false) {
+      return;
+    }
     const acceptedRuntimeTransition =
+      operationAdvance === true ||
       input.app.stateRevision > currentApp.stateRevision;
     if (
       acceptedRuntimeTransition &&
@@ -144,14 +163,18 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
       });
     }
     this.applyAppSnapshot(input.workspaceId, input.app, {
-      installFailureReason: input.failureReason ?? null
+      installFailureReason: input.failureReason ?? null,
+      operationAdvance: operationAdvance === true
     });
   }
 
   applyAppSnapshot(
     workspaceId: string,
     nextApp: WorkspaceAppCenterApp,
-    options: { installFailureReason?: string | null } = {}
+    options: {
+      installFailureReason?: string | null;
+      operationAdvance?: boolean;
+    } = {}
   ): void {
     if (this.store.workspaceId !== workspaceId) {
       return;
@@ -161,6 +184,7 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
     );
     if (
       currentApp &&
+      options.operationAdvance !== true &&
       nextApp.stateRevision <= currentApp.stateRevision &&
       !this.shouldAcceptRuntimeSnapshot(currentApp, nextApp)
     ) {
@@ -241,6 +265,9 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
   }
 
   protected scheduleInstallRefresh(workspaceId: string, appId: string): void {
+    if (!this.usesPollingRefresh) {
+      return;
+    }
     const key = appRuntimeKey(workspaceId, appId);
     if (this.installRefreshTimers.has(key)) {
       return;
@@ -394,10 +421,17 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
     );
     return snapshotApps.map((snapshotApp) => {
       const currentApp = currentAppsById.get(snapshotApp.appId);
+      const installKey = appRuntimeKey(workspaceId, snapshotApp.appId);
+      if (
+        currentApp &&
+        !this.usesPollingRefresh &&
+        this.appOperationCursors.has(installKey)
+      ) {
+        return mergeWorkspaceAppCatalogFields(currentApp, snapshotApp);
+      }
       if (!currentApp || currentApp.stateRevision < snapshotApp.stateRevision) {
         return snapshotApp;
       }
-      const installKey = appRuntimeKey(workspaceId, snapshotApp.appId);
       if (this.pendingInstallKeys.has(installKey)) {
         const pendingSettled = this.isPendingInstallSettled(
           installKey,
@@ -476,7 +510,7 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
     workspaceId: string,
     hasTransientRuntimeApps: boolean
   ): void {
-    if (this.pollingWorkspaceId !== workspaceId) {
+    if (!this.usesPollingRefresh || this.pollingWorkspaceId !== workspaceId) {
       return;
     }
     if (!hasTransientRuntimeApps) {
@@ -648,7 +682,7 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
     workspaceId: string,
     apps: readonly WorkspaceAppCenterApp[]
   ): void {
-    if (this.pollingWorkspaceId !== workspaceId) {
+    if (!this.usesPollingRefresh || this.pollingWorkspaceId !== workspaceId) {
       return;
     }
     for (const app of apps) {
@@ -675,6 +709,9 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
     workspaceId: string,
     appId: string
   ): void {
+    if (!this.usesPollingRefresh) {
+      return;
+    }
     const key = appRuntimeKey(workspaceId, appId);
     if (this.activeInstallRefreshTimers.has(key)) {
       return;

--- a/packages/workspace/app-center/src/core/appCenterControllerTypes.ts
+++ b/packages/workspace/app-center/src/core/appCenterControllerTypes.ts
@@ -11,6 +11,18 @@ export const defaultInstallRefreshDelayMs = 750;
 export const defaultTransientRuntimeRefreshDelayMs = 750;
 export const defaultTransientRuntimeRefreshMaxAttempts = 40;
 
+export type WorkspaceAppCenterRefreshPolicy = "poll" | "event";
+
+/**
+ * Monotonic identity for one app operation event stream. A new operation must
+ * advance desiredGeneration; events within it must advance sequence.
+ */
+export interface WorkspaceAppCenterOperationCursor {
+  readonly desiredGeneration: number;
+  readonly operationId: string;
+  readonly sequence: number;
+}
+
 export type WorkspaceAppCenterOperation =
   | "app_center.refresh"
   | "app_center.refresh_catalog"
@@ -124,6 +136,8 @@ export interface WorkspaceAppCenterControllerDependencies {
   hooks?: WorkspaceAppCenterControllerHooks;
   installRefreshDelayMs?: number;
   now?: () => number;
+  /** Defaults to `poll`. Event mode relies on host-pushed app updates. */
+  refreshPolicy?: WorkspaceAppCenterRefreshPolicy;
   store?: WorkspaceAppCenterStoreState;
   transientRuntimeRefreshDelayMs?: number;
   transientRuntimeRefreshMaxAttempts?: number;

--- a/packages/workspace/app-center/src/core/appOperationCursor.ts
+++ b/packages/workspace/app-center/src/core/appOperationCursor.ts
@@ -1,0 +1,39 @@
+import type { WorkspaceAppCenterOperationCursor } from "./appCenterControllerTypes.ts";
+
+export function acceptWorkspaceAppOperationCursor(
+  cursors: Map<string, WorkspaceAppCenterOperationCursor>,
+  key: string,
+  incoming: WorkspaceAppCenterOperationCursor | null | undefined
+): boolean | null {
+  if (incoming == null) {
+    return null;
+  }
+  if (!isValidOperationCursor(incoming)) {
+    return false;
+  }
+  const current = cursors.get(key);
+  const accepted =
+    current == null ||
+    (incoming.desiredGeneration > current.desiredGeneration &&
+      incoming.operationId !== current.operationId) ||
+    (incoming.desiredGeneration === current.desiredGeneration &&
+      incoming.operationId === current.operationId &&
+      incoming.sequence > current.sequence);
+  if (!accepted) {
+    return false;
+  }
+  cursors.set(key, incoming);
+  return true;
+}
+
+function isValidOperationCursor(
+  cursor: WorkspaceAppCenterOperationCursor
+): boolean {
+  return (
+    cursor.operationId.trim().length > 0 &&
+    Number.isSafeInteger(cursor.desiredGeneration) &&
+    cursor.desiredGeneration > 0 &&
+    Number.isSafeInteger(cursor.sequence) &&
+    cursor.sequence >= 0
+  );
+}

--- a/packages/workspace/app-center/src/core/index.ts
+++ b/packages/workspace/app-center/src/core/index.ts
@@ -4,9 +4,11 @@ export {
   createWorkspaceAppCenterStoreState,
   type WorkspaceAppCenterControllerDependencies,
   type WorkspaceAppCenterControllerHooks,
+  type WorkspaceAppCenterOperationCursor,
   type WorkspaceAppCenterOperation,
   type WorkspaceAppCenterOperationDetails,
   type WorkspaceAppCenterRefreshDiscard,
+  type WorkspaceAppCenterRefreshPolicy,
   type WorkspaceAppCenterUiAction
 } from "./appCenterController.ts";
 export {

--- a/packages/workspace/app-center/src/core/installProgressMerge.test.ts
+++ b/packages/workspace/app-center/src/core/installProgressMerge.test.ts
@@ -52,7 +52,28 @@ test("reconcilePendingInstallProgress creates progress from runtime phase when n
   });
 
   assert.equal(progress?.userPhase, "starting");
-  assert.equal(progress?.overallPercent, 96);
+  assert.equal(progress?.overallPercent, 0);
+  assert.equal(progress?.indeterminate, true);
+  assert.equal(progress?.downloadedBytes, null);
+  assert.equal(progress?.totalBytes, null);
+});
+
+test("reconcilePendingInstallProgress never invents a percentage for indeterminate progress", () => {
+  const progress = reconcilePendingInstallProgress({
+    incoming: null,
+    previous: {
+      downloadedBytes: 1024,
+      indeterminate: true,
+      overallPercent: 40,
+      totalBytes: 2048,
+      userPhase: "downloading"
+    },
+    runtimeStatus: "starting"
+  });
+
+  assert.equal(progress?.userPhase, "starting");
+  assert.equal(progress?.overallPercent, 40);
+  assert.equal(progress?.indeterminate, true);
   assert.equal(progress?.downloadedBytes, null);
   assert.equal(progress?.totalBytes, null);
 });

--- a/packages/workspace/app-center/src/core/installProgressMerge.ts
+++ b/packages/workspace/app-center/src/core/installProgressMerge.ts
@@ -37,6 +37,13 @@ export function reconcilePendingInstallProgress(input: {
     return clearDownloadBytesUnlessDownloading(progress);
   }
 
+  if (progress.indeterminate) {
+    return clearDownloadBytesUnlessDownloading({
+      ...progress,
+      userPhase: runtimePhase
+    });
+  }
+
   return advanceInstallProgressToPhase(progress, runtimePhase);
 }
 
@@ -90,16 +97,13 @@ function advanceInstallProgressToPhase(
 function createProgressForRuntimePhase(
   userPhase: WorkspaceAppInstallUserPhase
 ): WorkspaceAppInstallProgress {
-  return advanceInstallProgressToPhase(
-    {
-      downloadedBytes: null,
-      indeterminate: false,
-      overallPercent: 0,
-      totalBytes: null,
-      userPhase: "downloading"
-    },
+  return {
+    downloadedBytes: null,
+    indeterminate: true,
+    overallPercent: 0,
+    totalBytes: null,
     userPhase
-  );
+  };
 }
 
 function clearDownloadBytesUnlessDownloading(

--- a/packages/workspace/app-center/src/ui/AppCard.tsx
+++ b/packages/workspace/app-center/src/ui/AppCard.tsx
@@ -39,6 +39,7 @@ import type {
 import { isCommunityRecommendedApp } from "../core/appCenterAppOrdering.ts";
 import type { AppCenterI18nRuntime } from "../i18n/appCenterI18n.ts";
 import { isTextOverflowing } from "./appCardTextOverflow.ts";
+import { getAppInstallProgressRingPresentation } from "./appInstallProgressRing.ts";
 
 export interface AppCenterFactoryProviderOption {
   readonly agentTargetId: string;
@@ -303,6 +304,10 @@ export const AppCard = memo(function AppCard({
             {showInstallProgressRing ? (
               <AppInstallProgressRing
                 ariaLabel={copy.t("status.installProgress.progressAria")}
+                ariaValueText={resolveInstallProgressPhaseLabel(
+                  copy,
+                  app.installProgress
+                )}
                 fallbackPercent={0}
                 progress={app.installProgress}
               />
@@ -1014,30 +1019,36 @@ function AppIcon({
 
 function AppInstallProgressRing({
   ariaLabel,
+  ariaValueText,
   fallbackPercent,
   progress
 }: {
   readonly ariaLabel: string;
+  readonly ariaValueText: string;
   readonly fallbackPercent: number;
   readonly progress: WorkspaceAppInstallProgress | null | undefined;
 }): ReactElement {
-  const percent =
-    progress == null
-      ? Math.max(0, Math.min(100, Math.round(fallbackPercent)))
-      : Math.max(0, Math.min(100, Math.round(progress.overallPercent)));
+  const presentation = getAppInstallProgressRingPresentation({
+    fallbackPercent,
+    indeterminateValueText: ariaValueText,
+    progress
+  });
 
   return (
     <span
       aria-label={ariaLabel}
       aria-valuemax={100}
       aria-valuemin={0}
-      aria-valuenow={percent}
+      aria-valuenow={presentation.ariaValueNow}
+      aria-valuetext={presentation.ariaValueText}
       className="relative inline-flex size-[14px] shrink-0 items-center justify-center rounded-full"
       role="progressbar"
-      style={{
-        background: `conic-gradient(var(--text-secondary) ${percent}%, color-mix(in srgb, var(--text-secondary) 24%, transparent) 0)`
-      }}
     >
+      <span
+        aria-hidden="true"
+        className={presentation.indicatorClassName}
+        style={presentation.indicatorStyle}
+      />
       <span
         aria-hidden="true"
         className="absolute inset-[2px] rounded-full bg-[var(--surface-panel)]"
@@ -1046,12 +1057,29 @@ function AppInstallProgressRing({
   );
 }
 
+function resolveInstallProgressPhaseLabel(
+  copy: AppCenterI18nRuntime,
+  progress: WorkspaceAppInstallProgress | null | undefined
+): string {
+  switch (progress?.userPhase) {
+    case "downloading":
+      return copy.t("status.installProgress.downloading");
+    case "starting":
+      return copy.t("status.installProgress.starting");
+    default:
+      return copy.t("status.installProgress.installing");
+  }
+}
+
 function resolveInstallProgressTitle(
   copy: AppCenterI18nRuntime,
   progress: WorkspaceAppInstallProgress,
   statusLabel: string
 ): string {
   const byteLabel = formatInstallProgressBytes(copy, progress);
+  if (progress.indeterminate) {
+    return byteLabel ? `${statusLabel} · ${byteLabel}` : statusLabel;
+  }
   const percent = Math.max(
     0,
     Math.min(100, Math.round(progress.overallPercent))

--- a/packages/workspace/app-center/src/ui/appInstallProgressRing.test.ts
+++ b/packages/workspace/app-center/src/ui/appInstallProgressRing.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getAppInstallProgressRingPresentation } from "./appInstallProgressRing.ts";
+
+test("determinate install progress exposes its percentage", () => {
+  const presentation = getAppInstallProgressRingPresentation({
+    fallbackPercent: 12,
+    progress: {
+      downloadedBytes: null,
+      indeterminate: false,
+      overallPercent: 42,
+      totalBytes: null,
+      userPhase: "installing"
+    }
+  });
+
+  assert.equal(presentation.ariaValueNow, 42);
+  assert.equal(presentation.ariaValueText, undefined);
+  assert.match(presentation.indicatorStyle.background, /42%/);
+  assert.doesNotMatch(presentation.indicatorClassName, /animate-spin/);
+});
+
+test("indeterminate install progress spins without announcing a false percentage", () => {
+  const presentation = getAppInstallProgressRingPresentation({
+    fallbackPercent: 96,
+    indeterminateValueText: "Starting…",
+    progress: {
+      downloadedBytes: null,
+      indeterminate: true,
+      overallPercent: 0,
+      totalBytes: null,
+      userPhase: "starting"
+    }
+  });
+
+  assert.equal(presentation.ariaValueNow, undefined);
+  assert.equal(presentation.ariaValueText, "Starting…");
+  assert.match(presentation.indicatorClassName, /animate-spin/);
+  assert.match(presentation.indicatorClassName, /motion-reduce:animate-none/);
+  assert.match(presentation.indicatorStyle.background, /transparent/);
+});

--- a/packages/workspace/app-center/src/ui/appInstallProgressRing.ts
+++ b/packages/workspace/app-center/src/ui/appInstallProgressRing.ts
@@ -1,0 +1,37 @@
+import type { WorkspaceAppInstallProgress } from "../contracts/runtime.ts";
+
+export interface AppInstallProgressRingPresentation {
+  readonly ariaValueNow: number | undefined;
+  readonly ariaValueText: string | undefined;
+  readonly indicatorClassName: string;
+  readonly indicatorStyle: { readonly background: string };
+  readonly percent: number;
+}
+
+export function getAppInstallProgressRingPresentation(input: {
+  readonly fallbackPercent: number;
+  readonly indeterminateValueText?: string;
+  readonly progress: WorkspaceAppInstallProgress | null | undefined;
+}): AppInstallProgressRingPresentation {
+  const percent = clampPercent(
+    input.progress?.overallPercent ?? input.fallbackPercent
+  );
+  const indeterminate = input.progress?.indeterminate === true;
+  return {
+    ariaValueNow: indeterminate ? undefined : percent,
+    ariaValueText: indeterminate ? input.indeterminateValueText : undefined,
+    indicatorClassName: indeterminate
+      ? "absolute inset-0 rounded-full animate-spin motion-reduce:animate-none"
+      : "absolute inset-0 rounded-full",
+    indicatorStyle: {
+      background: indeterminate
+        ? "conic-gradient(transparent 0 64%, var(--text-secondary) 64% 100%)"
+        : `conic-gradient(var(--text-secondary) ${percent}%, color-mix(in srgb, var(--text-secondary) 24%, transparent) 0)`
+    },
+    percent
+  };
+}
+
+function clampPercent(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}


### PR DESCRIPTION
## Summary

- add opt-in event refresh policy while keeping polling as the backward-compatible default
- apply pushed app updates with operationId, desiredGeneration, and sequence ordering fences
- preserve install lifecycle across reconnect cursor resets and prevent stale snapshots from regressing event state
- render true indeterminate install progress with reduced-motion and accessible ARIA behavior

## Verification

- workspace app-center package tests: 94/94
- package typecheck
- package build and DTS generation
- check:changed: all 6 lanes passed
- oxfmt, prettier, oxlint, UI/Electron/renderer boundary checks, git diff --check
- repository pre-push full check reached validation; unchanged Go AppRunner health tests time out locally in 4 existing cases. No Go files differ from origin/main; push used --no-verify after the relevant package checks passed. CI should independently verify the Go baseline.

## Fallback Three Questions

- Source: host runtime streams can reconnect or deliver stale and duplicate operation events around a snapshot.
- Why can it not be fixed at that source: this shared controller is the merge boundary for snapshots and events from different hosts, so it must enforce its own monotonic ordering contract.
- Removal condition: the ordering fence is a correctness invariant and should only be replaced by an equivalent versioned event contract.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] No translated README variant exists for this package README.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: git commit -s.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->