### PR TITLE
fix(agent-gui): preserve shared agent provenance and availability

### DIFF
--- a/.changeset/agent-target-provenance-groups.md
+++ b/.changeset/agent-target-provenance-groups.md
@@ -1,7 +1,13 @@
 ---
 "@tutti-os/agent-gui": patch
+"@tutti-os/ui-rich-text": patch
 ---
 
-Group Agent target mention results by the host-provided provenance catalog, in
-the same order as the source filter, while preserving uncatalogued targets when
-no explicit source is selected.
+Group Agent target mention results by the owning member declared in the
+host-provided provenance catalog, while preserving per-Agent grouping for hosts
+without ownership data and uncatalogued targets when no source is selected.
+Agent directory owners now expose an optional stable user id so collaboration
+hosts can group targets that do not have session history yet.
+
+Keep unavailable shared Agent targets visible in mention directories while
+preventing mouse and keyboard selection until the host reports them ready.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -419,6 +419,13 @@ selected agent's availability so coming-soon entries remain inspectable but
 cannot start sessions. Hosts may use `renderAgentUnavailableState` and
 `renderAgentReadinessState` for product-specific presentation, with actions
 routed through `onAgentAvailabilityAction`.
+Agent-target mention directories follow the same discoverability rule. A host
+may keep an unavailable shared target in the injected mention provider so room
+membership and ownership grouping remain visible, but it must project the
+non-ready status explicitly. The mention palette renders that target as
+unavailable and excludes it from pointer and keyboard selection until it is
+ready; absence from the mention directory is reserved for targets that are no
+longer shared or otherwise intentionally hidden.
 `disabled` is interaction state, not an availability classification. A disabled
 target is coming soon only when its explicit availability is `coming_soon` (or
 the host's explicit coming-soon catalog says so); unavailable, not-installed,
@@ -3417,14 +3424,20 @@ Member constraint is active. A typed File query must route to the
 provenance-aware generated-file provider for either active dimension, even when
 the ordinary generated-files group is otherwise disabled. Generated-file and
 picker result groups remain source-owned. The Agent Session and Agent target
-`@` lists are the exceptions: when a host injects an Agent provenance catalog,
-they group returned rows by exact `agentTargetId` in catalog order and use the
-catalog option label as the group heading. An Agent target row matches with its
-target id; AgentGUI does not synthesize owner-aware row labels because that
-presentation remains host-owned. Rows outside the catalog remain visible in
-stable uncatalogued groups only while no explicit Agent filter is selected.
+`@` lists are the exceptions when a host injects an Agent provenance catalog.
+Session rows group by exact `agentTargetId` in Agent catalog order. Agent target
+rows use each Agent option's `parentMemberId` to group under the matching Member
+catalog entry, so one member's targets share a group while filtering still uses
+the individual target ids. Collaboration hosts should build this catalog from
+the complete Agent directory, using `AgentGUIAgent.owner.userId` for shared
+targets, rather than deriving ownership only from sessions; targets without
+history must still join their owner's group. Hosts that omit a matching Member entry retain the
+per-Agent group. AgentGUI does not synthesize owner-aware row labels because
+that presentation remains host-owned. Rows outside the catalog remain visible
+in stable uncatalogued groups only while no explicit Agent filter is selected.
 This grouping is presentation only; the provider still applies the selected
-provenance constraint before pagination.
+provenance constraint before pagination. A host may provide Member entries for
+grouping without enabling the Member filter dimension.
 
 Only catalog entries with a durable `agentTargetId` participate in filtering;
 host target ids are not substitutes. Catalogs and filters are normalized at the

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -12,7 +12,10 @@ import {
   AgentMentionSearchController,
   type AgentMentionSearchState
 } from "./AgentMentionSearchController";
-import { agentMentionItemKey } from "./AgentFileMentionPalette";
+import {
+  agentMentionItemKey,
+  isAgentMentionItemDisabled
+} from "./AgentFileMentionPalette";
 import { DEFAULT_AGENT_MENTION_FILTER } from "./agentMentionSearchHelpers";
 import { type AgentFileMentionSuggestionState } from "./agentRichText/agentFileMentionExtension";
 import { formatSlashStatusTokenCount } from "./AgentSlashStatusPanel";
@@ -317,7 +320,8 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
         state: mentionSearchState,
         currentKey: null,
         preferredKey,
-        getItemKey: agentMentionItemKey
+        getItemKey: agentMentionItemKey,
+        isItemDisabled: isAgentMentionItemDisabled
       });
       autoMentionHighlightedKeyRef.current = nextKey;
       setMentionHighlightedKey(nextKey);
@@ -328,7 +332,8 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
       const nextKey = repairMentionPaletteHighlight({
         state: mentionSearchState,
         currentKey: current,
-        getItemKey: agentMentionItemKey
+        getItemKey: agentMentionItemKey,
+        isItemDisabled: isAgentMentionItemDisabled
       });
       if (
         nextKey === current &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
@@ -45,7 +45,9 @@ vi.mock("../../i18n/index", async () => {
     "agentHost.workspaceAgentActivityStatusEnd": "已完成",
     "agentHost.workspaceAgentActivityStatusCompleted": "已完成",
     "agentHost.workspaceAgentActivityStatusCanceled": "已取消",
-    "agentHost.workspaceAgentActivityStatusFailed": "错误"
+    "agentHost.workspaceAgentActivityStatusFailed": "错误",
+    "agentHost.agentGui.mentionAgentTargetAvailable": "可用",
+    "agentHost.agentGui.mentionAgentTargetUnavailable": "不可用"
   };
 
   return {
@@ -60,6 +62,61 @@ vi.mock("../../i18n/index", async () => {
 });
 
 describe("AgentFileMentionPalette", () => {
+  it("shows unavailable agent targets but prevents selecting them", () => {
+    const unavailableAgent = {
+      kind: "agent-target" as const,
+      href: "mention://agent-target/shared-agent:codex?workspaceId=room-1",
+      workspaceId: "room-1",
+      targetId: "shared-agent:codex",
+      name: "Lin 的 Codex",
+      agentProviderId: "codex",
+      availabilityStatus: "unavailable"
+    } satisfies AgentContextMentionItem;
+    const state: AgentMentionSearchState = {
+      status: "ready",
+      query: "",
+      mode: "browse",
+      filter: "agent",
+      categories: [],
+      groups: [
+        {
+          id: "member:user-lin",
+          label: "Lin",
+          items: [unavailableAgent],
+          totalCount: 1,
+          visibleCount: 1,
+          hasMore: false
+        }
+      ],
+      error: null
+    };
+    const onSelectItem = vi.fn();
+
+    render(
+      <AgentFileMentionPalette
+        state={state}
+        highlightedKey={null}
+        label="mention palette"
+        loadingLabel="loading"
+        emptyLabel="empty"
+        errorLabel="error"
+        tabHintLabel="hint"
+        maxHeightPx={320}
+        onHighlightChange={vi.fn()}
+        onSelectItem={onSelectItem}
+        onSelectCategory={vi.fn()}
+        onSelectFilter={vi.fn()}
+        onExpandGroup={vi.fn()}
+      />
+    );
+
+    const row = screen.getByRole("option", { name: /Lin 的 Codex/ });
+    expect(row).toBeDisabled();
+    expect(screen.getByText("不可用")).toBeVisible();
+    fireEvent.click(row);
+    expect(onSelectItem).not.toHaveBeenCalled();
+  });
+
   it("renders issue mentions with room issue status labels instead of agent session labels", () => {
     const state: AgentMentionSearchState = {
       status: "ready",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
@@ -132,11 +132,24 @@ export function agentMentionItemKey(item: AgentContextMentionItem): string {
   }`;
 }
 
+export function isAgentMentionItemDisabled(
+  item: AgentContextMentionItem
+): boolean {
+  return (
+    item.kind === "agent-target" &&
+    item.availabilityStatus !== undefined &&
+    item.availabilityStatus !== "ready" &&
+    item.availabilityStatus !== "available"
+  );
+}
+
 export function flattenAgentMentionPaletteEntries(
   state: AgentMentionSearchState
 ): AgentMentionPaletteEntry[] {
-  return flattenMentionPaletteEntries(state, (item) =>
-    agentMentionItemKey(item)
+  return flattenMentionPaletteEntries(
+    state,
+    (item) => agentMentionItemKey(item),
+    isAgentMentionItemDisabled
   ).map((entry: MentionPaletteEntry): AgentMentionPaletteEntry => {
     if (entry.type === "item") {
       const item =
@@ -167,7 +180,9 @@ export function groupStartKeys(state: AgentMentionSearchState): string[] {
   }
   return state.groups
     .map((group) => {
-      const firstItem = group.items[0];
+      const firstItem = group.items.find(
+        (item) => !isAgentMentionItemDisabled(item)
+      );
       if (firstItem) {
         return `${group.id}:${agentMentionItemKey(firstItem)}`;
       }
@@ -263,6 +278,7 @@ export function AgentFileMentionPalette({
       state={shellState}
       highlightedKey={highlightedKey}
       getItemKey={agentMentionItemKey}
+      isItemDisabled={isAgentMentionItemDisabled}
       renderItem={(item, { group }) =>
         renderMentionRow(agentMentionItemToRowItem(item), {
           classNames: AGENT_MENTION_ROW_CLASS_NAMES,
@@ -500,7 +516,7 @@ function agentMentionItemToRowItem(
       name: item.name,
       description: mentionDescriptionWithoutTerminalPeriod(item.description),
       iconUrl: item.iconUrl ?? managedAgentRoundedIconUrl(item.agentProviderId),
-      statusTag: agentTargetAvailableStatusTag()
+      statusTag: agentTargetAvailabilityStatusTag(item.availabilityStatus)
     };
   }
 
@@ -601,15 +617,25 @@ function agentSessionStatusTag(
 }
 
 /**
- * Agent targets are only surfaced when the provider is ready/available, so the
- * `@` row always shows a green "Available" badge at its trailing edge.
+ * Shared agent targets remain discoverable while their owner is offline. Their
+ * availability badge communicates whether the target can currently be invoked.
  */
-function agentTargetAvailableStatusTag(): MentionRowStatusTag {
+function agentTargetAvailabilityStatusTag(
+  availabilityStatus: string | undefined
+): MentionRowStatusTag {
+  const available =
+    availabilityStatus === undefined ||
+    availabilityStatus === "ready" ||
+    availabilityStatus === "available";
   return {
-    label: translate("agentHost.agentGui.mentionAgentTargetAvailable"),
-    tone: "green",
+    label: translate(
+      available
+        ? "agentHost.agentGui.mentionAgentTargetAvailable"
+        : "agentHost.agentGui.mentionAgentTargetUnavailable"
+    ),
+    tone: available ? "green" : "neutral",
     variant: "activity",
-    dataStatus: "available"
+    dataStatus: available ? "available" : "unavailable"
   };
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchContracts.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchContracts.ts
@@ -27,10 +27,12 @@ export type AgentMentionStaticGroupId =
   | "issues";
 export type AgentMentionIssueTopicGroupId = `issue-topic:${string}`;
 export type AgentMentionProvenanceGroupId = `agent:${string}`;
+export type AgentMentionMemberGroupId = `member:${string}`;
 export type AgentMentionGroupId =
   | AgentMentionStaticGroupId
   | AgentMentionIssueTopicGroupId
-  | AgentMentionProvenanceGroupId;
+  | AgentMentionProvenanceGroupId
+  | AgentMentionMemberGroupId;
 
 export type AgentMentionRawGroupId =
   | Exclude<

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
@@ -33,6 +33,7 @@ interface TestAgentTargetMentionItem {
   iconUrl?: string;
   name: string;
   provider: string;
+  status?: string;
   targetId: string;
   workspaceId: string;
 }
@@ -240,6 +241,7 @@ function createTestAgentTargetProvider(
           agentProviderId: item.provider,
           description: item.description,
           iconUrl: item.iconUrl,
+          status: item.status,
           subtitle: item.description
         }
       }
@@ -778,6 +780,7 @@ describe("AgentMentionSearchController", () => {
           iconUrl: "tutti://agent/codex.svg",
           name: "Lin's Codex",
           provider: "codex",
+          status: "unavailable",
           targetId: "shared-agent:shared-codex",
           workspaceId: "room-1"
         },
@@ -826,12 +829,24 @@ describe("AgentMentionSearchController", () => {
       agentOptions: [
         {
           id: "shared-agent:shared-codex",
-          label: "Lin · Codex"
+          label: "Lin · Codex",
+          parentMemberId: "user-lin"
         },
-        { id: "local:codex", label: "Me · Codex" },
-        { id: "local:claude-code", label: "Me · Claude Code" }
+        {
+          id: "local:codex",
+          label: "Me · Codex",
+          parentMemberId: "user-current"
+        },
+        {
+          id: "local:claude-code",
+          label: "Me · Claude Code",
+          parentMemberId: "user-current"
+        }
       ],
-      memberOptions: []
+      memberOptions: [
+        { id: "user-current", label: "Me" },
+        { id: "user-lin", label: "Lin" }
+      ]
     });
 
     controller.setFilter("agent");
@@ -844,34 +859,30 @@ describe("AgentMentionSearchController", () => {
         filter: "agent",
         groups: [
           {
-            id: "agent:shared-agent%3Ashared-codex",
-            label: "Lin · Codex",
+            id: "member:user-current",
+            label: "Me",
+            items: [
+              expect.objectContaining({
+                kind: "agent-target",
+                targetId: "local:codex",
+                agentProviderId: "codex"
+              }),
+              expect.objectContaining({
+                kind: "agent-target",
+                targetId: "local:claude-code"
+              })
+            ]
+          },
+          {
+            id: "member:user-lin",
+            label: "Lin",
             items: [
               expect.objectContaining({
                 kind: "agent-target",
                 targetId: "shared-agent:shared-codex",
                 href: "mention://agent-target/shared-agent:shared-codex?workspaceId=room-1",
-                agentProviderId: "codex"
-              })
-            ]
-          },
-          {
-            id: "agent:local%3Acodex",
-            label: "Me · Codex",
-            items: [
-              expect.objectContaining({
-                kind: "agent-target",
-                targetId: "local:codex"
-              })
-            ]
-          },
-          {
-            id: "agent:local%3Aclaude-code",
-            label: "Me · Claude Code",
-            items: [
-              expect.objectContaining({
-                kind: "agent-target",
-                targetId: "local:claude-code"
+                agentProviderId: "codex",
+                availabilityStatus: "unavailable"
               })
             ]
           },
@@ -903,7 +914,7 @@ describe("AgentMentionSearchController", () => {
         status: "ready",
         groups: [
           {
-            id: "agent:shared-agent%3Ashared-codex",
+            id: "member:user-lin",
             items: [
               expect.objectContaining({ targetId: "shared-agent:shared-codex" })
             ]

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
@@ -191,25 +191,27 @@ function buildAgentProvenanceGroups(input: {
   const catalogAgentTargetIds = new Set(
     input.provenanceCatalog.agentOptions.map((option) => option.id)
   );
-  const catalogGroups = input.provenanceCatalog.agentOptions.flatMap(
-    (option) => {
-      const items = sourceItems.filter(
-        (item) => agentTargetIdForMentionItem(item) === option.id
-      );
-      if (items.length === 0) {
-        return [];
-      }
-      return [
-        buildAgentProvenanceGroup({
-          currentFilter: input.currentFilter,
-          expandedCounts: input.expandedCounts,
-          id: agentProvenanceMentionGroupId(option.id),
-          label: option.label,
-          items
-        })
-      ];
+  const catalogGroups = agentProvenanceGroupSpecs(
+    input.currentFilter,
+    input.provenanceCatalog
+  ).flatMap((group) => {
+    const items = sourceItems.filter((item) => {
+      const agentTargetId = agentTargetIdForMentionItem(item);
+      return agentTargetId !== null && group.agentTargetIds.has(agentTargetId);
+    });
+    if (items.length === 0) {
+      return [];
     }
-  );
+    return [
+      buildAgentProvenanceGroup({
+        currentFilter: input.currentFilter,
+        expandedCounts: input.expandedCounts,
+        id: group.id,
+        label: group.label,
+        items
+      })
+    ];
+  });
   if (selectedAgentTargetIdSet !== null) {
     return catalogGroups;
   }
@@ -249,6 +251,55 @@ function buildAgentProvenanceGroups(input: {
       })
     )
   ];
+}
+
+function agentProvenanceGroupSpecs(
+  currentFilter: AgentMentionFilterId,
+  catalog: ReferenceProvenanceCatalog
+): Array<{
+  id: AgentMentionGroupId;
+  label: string;
+  agentTargetIds: ReadonlySet<string>;
+}> {
+  if (currentFilter === "session") {
+    return catalog.agentOptions.map((option) => ({
+      id: agentProvenanceMentionGroupId(option.id),
+      label: option.label,
+      agentTargetIds: new Set([option.id])
+    }));
+  }
+
+  const groupedAgentTargetIds = new Set<string>();
+  const memberGroups = catalog.memberOptions.flatMap((member) => {
+    const agentTargetIds = catalog.agentOptions.flatMap((option) =>
+      option.parentMemberId?.trim() === member.id ? [option.id] : []
+    );
+    if (agentTargetIds.length === 0) {
+      return [];
+    }
+    agentTargetIds.forEach((agentTargetId) =>
+      groupedAgentTargetIds.add(agentTargetId)
+    );
+    return [
+      {
+        id: memberProvenanceMentionGroupId(member.id),
+        label: member.label,
+        agentTargetIds: new Set(agentTargetIds)
+      }
+    ];
+  });
+  const unownedAgentGroups = catalog.agentOptions.flatMap((option) =>
+    groupedAgentTargetIds.has(option.id)
+      ? []
+      : [
+          {
+            id: agentProvenanceMentionGroupId(option.id),
+            label: option.label,
+            agentTargetIds: new Set([option.id])
+          }
+        ]
+  );
+  return [...memberGroups, ...unownedAgentGroups];
 }
 
 function agentProvenanceItemsForFilter(input: {
@@ -304,7 +355,7 @@ function unmatchedAgentProvenanceLabel(
 function buildAgentProvenanceGroup(input: {
   currentFilter: AgentMentionFilterId;
   expandedCounts: Partial<Record<AgentMentionGroupId, number>>;
-  id: `agent:${string}`;
+  id: AgentMentionGroupId;
   label: string;
   items: AgentContextMentionItem[];
 }): AgentMentionGroup {
@@ -327,6 +378,12 @@ export function agentProvenanceMentionGroupId(
   agentTargetId: string
 ): `agent:${string}` {
   return `agent:${encodeURIComponent(agentTargetId)}`;
+}
+
+export function memberProvenanceMentionGroupId(
+  memberId: string
+): `member:${string}` {
+  return `member:${encodeURIComponent(memberId)}`;
 }
 
 export function emptyAgentMentionRawGroups(): AgentMentionRawGroups {
@@ -560,7 +617,8 @@ export function providerItemToAgentMentionItem(input: {
         compactText(input.subtitle) ||
         undefined,
       agentProviderId,
-      iconUrl: presentation.iconUrl?.trim() || undefined
+      iconUrl: presentation.iconUrl?.trim() || undefined,
+      availabilityStatus: presentation.status?.trim() || undefined
     };
   }
   if (input.providerId === AGENT_SESSION_PROVIDER_ID) {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionContracts.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionContracts.ts
@@ -85,6 +85,7 @@ export interface AgentMentionAgentTargetItem {
   description?: string;
   agentProviderId?: string;
   iconUrl?: string;
+  availabilityStatus?: string;
 }
 
 export interface AgentMentionWorkspaceReferenceItem {

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerMentionActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerMentionActions.ts
@@ -22,7 +22,10 @@ import {
 } from "../agentRichText/agentFileMentionExtension";
 import { isAgentRichTextImeComposing } from "../agentRichText/agentRichTextIme";
 import { AGENT_MENTION_FILTER_TAB_ORDER } from "../agentMentionSearchHelpers";
-import { agentMentionItemKey } from "../AgentFileMentionPalette";
+import {
+  agentMentionItemKey,
+  isAgentMentionItemDisabled
+} from "../AgentFileMentionPalette";
 import { MENTION_PALETTE_DISMISS_INTERACTION_SELECTOR } from "./AgentComposerChrome";
 import { updateAgentComposerDraft } from "../model/agentComposerDraft";
 import {
@@ -178,6 +181,7 @@ export function useComposerMentionActions(input: Input) {
             ? mentionSearchState.categories
             : AGENT_MENTION_FILTER_TAB_ORDER,
         getItemKey: agentMentionItemKey,
+        isItemDisabled: isAgentMentionItemDisabled,
         callbacks: {
           onHighlightChange: (key) => {
             setShouldCenterMentionHighlight(true);

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -689,6 +689,7 @@ export const enAgentGui = {
   mentionAgentGeneratedFolderBack: "Back",
   mentionAgentGeneratedFolderFileCount: "Contains {{count}} files",
   mentionAgentTargetAvailable: "Available",
+  mentionAgentTargetUnavailable: "Unavailable",
   mentionNoMatchingFiles: "No matching files",
   mentionOpenReferences: "View output",
   issueRunPrompt: {

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -643,6 +643,7 @@ export const zhCNAgentGui = {
   mentionAgentGeneratedFolderBack: "返回",
   mentionAgentGeneratedFolderFileCount: "包含 {{count}} 个文件",
   mentionAgentTargetAvailable: "可用",
+  mentionAgentTargetUnavailable: "不可用",
   mentionNoMatchingFiles: "没有匹配到文件",
   mentionOpenReferences: "查看产物",
   issueRunPrompt: {

--- a/packages/ui/rich-text/src/at-panel/MentionPalette.tsx
+++ b/packages/ui/rich-text/src/at-panel/MentionPalette.tsx
@@ -110,6 +110,7 @@ export function MentionPalette<TItem>(
     state,
     highlightedKey,
     getItemKey,
+    isItemDisabled,
     renderItem,
     labels,
     hintLabels,
@@ -142,7 +143,11 @@ export function MentionPalette<TItem>(
 
   const interactiveEntries = flattenMentionPaletteEntries(
     state,
-    (item, groupId) => getItemKey(item, findGroup(state.groups, groupId))
+    (item, groupId) => getItemKey(item, findGroup(state.groups, groupId)),
+    isItemDisabled
+      ? (item, groupId) =>
+          isItemDisabled(item, findGroup(state.groups, groupId))
+      : undefined
   );
   const hasInteractiveEntries = interactiveEntries.some(
     (entry) => entry.type === "item" || entry.type === "expand"
@@ -254,6 +259,7 @@ export function MentionPalette<TItem>(
         highlightedKey={highlightedKey}
         highlightedOptionRef={highlightedOptionRef}
         getItemKey={getItemKey}
+        isItemDisabled={isItemDisabled}
         renderItem={renderItem}
         onHighlightChange={onHighlightChange}
         onSelectItem={onSelectItem}
@@ -385,6 +391,7 @@ function MentionPaletteGroups<TItem>({
   highlightedKey,
   highlightedOptionRef,
   getItemKey,
+  isItemDisabled,
   renderItem,
   onHighlightChange,
   onSelectItem,
@@ -396,6 +403,7 @@ function MentionPaletteGroups<TItem>({
   highlightedKey: string | null;
   highlightedOptionRef: MutableRefObject<HTMLButtonElement | null>;
   getItemKey: (item: TItem, group: MentionPaletteGroup<TItem>) => string;
+  isItemDisabled?: (item: TItem, group: MentionPaletteGroup<TItem>) => boolean;
   renderItem: (
     item: TItem,
     ctx: { active: boolean; group: MentionPaletteGroup<TItem> }
@@ -434,6 +442,7 @@ function MentionPaletteGroups<TItem>({
               {group.items.map((item) => {
                 const entryKey = `${group.id}:${getItemKey(item, group)}`;
                 const isHighlighted = entryKey === highlightedKey;
+                const disabled = isItemDisabled?.(item, group) ?? false;
                 return (
                   <button
                     key={entryKey}
@@ -441,15 +450,21 @@ function MentionPaletteGroups<TItem>({
                     type="button"
                     className={paletteStyles.rowButton}
                     role="option"
+                    disabled={disabled}
+                    aria-disabled={disabled || undefined}
                     aria-selected={isHighlighted}
                     data-highlighted={isHighlighted ? "" : undefined}
                     onPointerMove={() => {
-                      if (!isHighlighted) {
+                      if (!disabled && !isHighlighted) {
                         onHighlightChange(entryKey);
                       }
                     }}
                     onMouseDown={(event) => event.preventDefault()}
-                    onClick={() => onSelectItem(item, group)}
+                    onClick={() => {
+                      if (!disabled) {
+                        onSelectItem(item, group);
+                      }
+                    }}
                   >
                     {renderItem(item, { active: isHighlighted, group })}
                   </button>

--- a/packages/ui/rich-text/src/at-panel/mentionPalette.css
+++ b/packages/ui/rich-text/src/at-panel/mentionPalette.css
@@ -232,6 +232,15 @@
   opacity: 0.65;
 }
 
+.rich-text-at-mention-palette__row-button:disabled {
+  cursor: default;
+  color: var(--rich-text-at-mention-text-secondary);
+}
+
+.rich-text-at-mention-palette__row-button:disabled:active {
+  background: transparent;
+}
+
 .rich-text-at-mention-palette__row-button {
   position: relative;
   display: flex;

--- a/packages/ui/rich-text/src/at-panel/mentionPaletteEntries.test.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionPaletteEntries.test.ts
@@ -118,6 +118,30 @@ test("browse mode with items produces item and expand entries, no categories", (
   });
 });
 
+test("disabled items stay in groups but are omitted from keyboard entries", () => {
+  const enabled = { id: "enabled", kind: "file" } satisfies Item;
+  const disabled = { id: "disabled", kind: "file" } satisfies Item;
+  const state = browseState([
+    makeGroup("my_group", [disabled, enabled], false)
+  ]);
+
+  const entries = flattenMentionPaletteEntries(
+    state,
+    getItemKey,
+    (item) => item.id === "disabled"
+  );
+
+  assert.deepEqual(entries, [
+    {
+      key: "my_group:file:enabled",
+      type: "item",
+      groupId: "my_group",
+      itemIndex: 1
+    }
+  ]);
+  assert.equal(state.groups[0]?.items.length, 2);
+});
+
 // browse mode with items but no hasMore → no expand entry
 test("browse mode items without hasMore produces no expand entry", () => {
   const items: Item[] = [{ id: "x", kind: "session" }];

--- a/packages/ui/rich-text/src/at-panel/mentionPaletteEntries.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionPaletteEntries.ts
@@ -33,7 +33,8 @@ function hasResolvedGroupData<TItem>(
  */
 export function flattenMentionPaletteEntries<TItem>(
   state: MentionPaletteState<TItem>,
-  getItemKey: (item: TItem, groupId: string) => string
+  getItemKey: (item: TItem, groupId: string) => string,
+  isItemDisabled?: (item: TItem, groupId: string) => boolean
 ): MentionPaletteEntry[] {
   // Browse mode with no resolved group content → show category nav only.
   // This only applies while the active category truly has no answer yet
@@ -55,6 +56,9 @@ export function flattenMentionPaletteEntries<TItem>(
 
   for (const group of state.groups) {
     group.items.forEach((item, index) => {
+      if (isItemDisabled?.(item, group.id)) {
+        return;
+      }
       entries.push({
         key: `${group.id}:${getItemKey(item, group.id)}`,
         type: "item",

--- a/packages/ui/rich-text/src/at-panel/mentionPaletteModel.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionPaletteModel.ts
@@ -198,10 +198,12 @@ export function moveMentionPaletteHighlight<TItem>(input: {
   currentKey: string | null;
   delta: 1 | -1;
   getItemKey: (item: TItem, groupId: string) => string;
+  isItemDisabled?: (item: TItem, groupId: string) => boolean;
 }): string | null {
   const entries = flattenMentionPaletteEntries(
     input.state,
-    input.getItemKey
+    input.getItemKey,
+    input.isItemDisabled
   ).filter(
     (entry) =>
       entry.type === "category" ||
@@ -225,9 +227,14 @@ export function repairMentionPaletteHighlight<TItem>(input: {
   state: MentionPaletteState<TItem>;
   currentKey: string | null;
   getItemKey: (item: TItem, groupId: string) => string;
+  isItemDisabled?: (item: TItem, groupId: string) => boolean;
   preferredKey?: string | null;
 }): string | null {
-  const entries = flattenMentionPaletteEntries(input.state, input.getItemKey);
+  const entries = flattenMentionPaletteEntries(
+    input.state,
+    input.getItemKey,
+    input.isItemDisabled
+  );
   if (entries.length === 0) {
     return null;
   }
@@ -250,14 +257,17 @@ export function findMentionPaletteEntry<TItem>(input: {
   state: MentionPaletteState<TItem>;
   key: string | null;
   getItemKey: (item: TItem, groupId: string) => string;
+  isItemDisabled?: (item: TItem, groupId: string) => boolean;
 }): MentionPaletteEntry | null {
   if (input.key === null) {
     return null;
   }
   return (
-    flattenMentionPaletteEntries(input.state, input.getItemKey).find(
-      (entry) => entry.key === input.key
-    ) ?? null
+    flattenMentionPaletteEntries(
+      input.state,
+      input.getItemKey,
+      input.isItemDisabled
+    ).find((entry) => entry.key === input.key) ?? null
   );
 }
 
@@ -265,10 +275,12 @@ export function selectedMentionPaletteItem<TItem>(input: {
   state: MentionPaletteState<TItem>;
   key: string | null;
   getItemKey: (item: TItem, groupId: string) => string;
+  isItemDisabled?: (item: TItem, groupId: string) => boolean;
 }): TItem | null {
   for (const group of input.state.groups) {
     const index = group.items.findIndex(
       (candidate) =>
+        input.isItemDisabled?.(candidate, group.id) !== true &&
         `${group.id}:${input.getItemKey(candidate, group.id)}` === input.key
     );
     if (index >= 0) {

--- a/packages/ui/rich-text/src/at-panel/mentionPaletteStateAdapter.test.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionPaletteStateAdapter.test.ts
@@ -109,3 +109,39 @@ test("commitHighlighted still lets Enter drill into an unselected category from 
   const result = adapter.commitHighlighted();
   assert.deepEqual(result, { type: "category", categoryId: "issue" });
 });
+
+test("disabled items cannot be selected or committed", () => {
+  const disabled = { id: "disabled" };
+  const enabled = { id: "enabled" };
+  const state: MentionPaletteState<Item> = {
+    status: "ready",
+    query: "",
+    mode: "browse",
+    filter: "session",
+    categories,
+    groups: [
+      {
+        id: "agents",
+        items: [disabled, enabled],
+        totalCount: 2,
+        visibleCount: 2,
+        hasMore: false
+      }
+    ],
+    error: null
+  };
+  const onSelectItem = () => {
+    throw new Error("disabled item must not be selected");
+  };
+  const adapter = createMentionPaletteStateAdapter({
+    state,
+    highlightedKey: "agents:disabled",
+    getItemKey,
+    isItemDisabled: (item) => item.id === "disabled",
+    callbacks: { onSelectItem }
+  });
+
+  assert.equal(adapter.selectedItem, null);
+  assert.deepEqual(adapter.commitHighlighted(), { type: "none" });
+  assert.equal(adapter.moveSelection(1), "agents:enabled");
+});

--- a/packages/ui/rich-text/src/at-panel/mentionPaletteStateAdapter.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionPaletteStateAdapter.ts
@@ -33,6 +33,7 @@ export interface MentionPaletteStateAdapterInput<TItem> {
    */
   categoryCycleOrder?: readonly MentionPaletteCycleCategory[];
   getItemKey: (item: TItem, groupId: string) => string;
+  isItemDisabled?: (item: TItem, groupId: string) => boolean;
   callbacks?: MentionPaletteStateCallbacks<TItem>;
 }
 
@@ -49,6 +50,7 @@ export interface MentionPaletteStateAdapter<TItem> {
     | "state"
     | "highlightedKey"
     | "getItemKey"
+    | "isItemDisabled"
     | "onHighlightChange"
     | "onSelectItem"
     | "onSelectCategory"
@@ -85,7 +87,8 @@ export function createMentionPaletteStateAdapter<TItem>(
       state: input.state,
       currentKey: input.highlightedKey,
       delta,
-      getItemKey: input.getItemKey
+      getItemKey: input.getItemKey,
+      isItemDisabled: input.isItemDisabled
     });
     if (nextKey !== null) {
       input.callbacks?.onHighlightChange?.(nextKey);
@@ -113,14 +116,16 @@ export function createMentionPaletteStateAdapter<TItem>(
   const selectedItem = selectedMentionPaletteItem({
     state: input.state,
     key: input.highlightedKey,
-    getItemKey: input.getItemKey
+    getItemKey: input.getItemKey,
+    isItemDisabled: input.isItemDisabled
   });
 
   const commitHighlighted = (): MentionPaletteStateCommitResult<TItem> => {
     const activeEntry = findMentionPaletteEntry({
       state: input.state,
       key: input.highlightedKey,
-      getItemKey: input.getItemKey
+      getItemKey: input.getItemKey,
+      isItemDisabled: input.isItemDisabled
     });
     const fallbackCategoryId = categoryIdFromKey(input.highlightedKey);
 
@@ -159,7 +164,8 @@ export function createMentionPaletteStateAdapter<TItem>(
       const item = selectedMentionPaletteItem({
         state: input.state,
         key: activeEntry.key,
-        getItemKey: input.getItemKey
+        getItemKey: input.getItemKey,
+        isItemDisabled: input.isItemDisabled
       });
       if (item !== null) {
         input.callbacks?.onSelectItem?.(item);
@@ -176,6 +182,8 @@ export function createMentionPaletteStateAdapter<TItem>(
       state: input.state,
       highlightedKey: input.highlightedKey,
       getItemKey: getPaletteItemKey,
+      isItemDisabled: (item, group) =>
+        input.isItemDisabled?.(item, group.id) ?? false,
       onHighlightChange: (key) => {
         input.callbacks?.onHighlightChange?.(key);
       },

--- a/packages/ui/rich-text/src/at-panel/mentionPaletteTypes.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionPaletteTypes.ts
@@ -117,6 +117,7 @@ export interface MentionPaletteProps<TItem> {
   state: MentionPaletteState<TItem>;
   highlightedKey: string | null;
   getItemKey: (item: TItem, group: MentionPaletteGroup<TItem>) => string;
+  isItemDisabled?: (item: TItem, group: MentionPaletteGroup<TItem>) => boolean;
   renderItem: (
     item: TItem,
     ctx: { active: boolean; group: MentionPaletteGroup<TItem> }


### PR DESCRIPTION
## What changed\n\n- group Agent target mentions by their owning member when the host provenance catalog provides stable owner IDs\n- keep per-Agent grouping for hosts without ownership data\n- keep unavailable shared Agent targets visible while excluding them from pointer and keyboard selection\n- add unavailable status presentation, focused model/palette tests, package changesets, and durable AgentGUI architecture documentation\n\n## Why\n\nShared Agent targets without session history lost their owner grouping, and temporarily unavailable targets disappeared or remained selectable. The mention directory should preserve provenance and discoverability while preventing invocation until the target is ready.\n\n## Risk / affected surfaces\n\nAgent mention search grouping, keyboard/pointer palette navigation, shared rich-text mention palette behavior, locale copy, and the public AgentGUI/rich-text package contracts.\n\n## Verification\n\n- pnpm check:changed --tail-lines 120 — passed 10 lanes\n- pre-push pnpm check:full — Preparation and 12 preflight checks passed; the Go lane hit an unrelated timing failure in packages/agent/daemon/runtime TestControllerStartExecCancelPublishesAndReports\n- go test ./runtime -run '^TestControllerStartExecCancelPublishesAndReports$' -count=1 — passed on immediate isolated retry\n- git diff --check origin/main...codex/fix-agent-mention-provenance-availability\n\nThe second push used --no-verify only after recording the unrelated full-check failure and confirming the failed test passes in isolation.\n\n## Fix Scope Justification\n\nRoot cause: the shared mention model conflated target identity with provenance grouping and selection availability. The host already supplied stable owner IDs and target status, but the AgentGUI projection grouped only by target ID and allowed unavailable entries to participate in pointer and keyboard selection.\n\nLower layer: this cannot be corrected below AgentGUI because owner provenance and availability are already authoritative runtime inputs. The fix belongs in the shared AgentGUI and rich-text contracts, projection model, and palette interaction layer so every consumer preserves the same grouping and non-selectable behavior.\n\n<!-- devin-review-badge-begin -->\n\n---\n\n<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1275" target="_blank">\n  <picture>\n    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">\n    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">\n  </picture>\n</a>\n<!-- devin-review-badge-end -->