### PR TITLE
fix(agent): prevent closed session resurrection

### DIFF
--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -5218,6 +5218,47 @@ func TestControllerFinishParentTurnDoesNotOverwriteSyntheticLifecycle(t *testing
 	}
 }
 
+func TestControllerFinishTurnDoesNotRestoreClosedSession(t *testing.T) {
+	t.Parallel()
+
+	adapter := &recordingStartAdapter{provider: ProviderCodex}
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderCodex,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	turnID := "turn-1"
+	staleTurnSession := started.Session
+	staleTurnSession.Status = SessionStatusCanceled
+	staleTurnSession.TurnLifecycle = &TurnLifecycle{
+		ActiveTurnID: &turnID,
+		Phase:        "running",
+	}
+	controller.store(staleTurnSession)
+	controller.mu.Lock()
+	controller.turns[sessionKey(staleTurnSession.RoomID, staleTurnSession.AgentSessionID)] = activeTurn{turnID: turnID}
+	controller.mu.Unlock()
+
+	if _, err := controller.Close(context.Background(), CloseInput{
+		RoomID:         staleTurnSession.RoomID,
+		AgentSessionID: staleTurnSession.AgentSessionID,
+	}); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// A turn goroutine can finish after Close has removed its session. Its stale
+	// snapshot must not recreate the closed session and shadow the next Start.
+	controller.finishTurn(staleTurnSession, turnID)
+	if restored, ok := controller.Session(staleTurnSession.RoomID, staleTurnSession.AgentSessionID); ok {
+		t.Fatalf("late turn finish restored closed session: %#v", restored)
+	}
+}
+
 func TestControllerFinishTurnReconcilesCreatedStatusToReady(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/controller_turn_finish.go
+++ b/packages/agent/daemon/runtime/controller_turn_finish.go
@@ -15,7 +15,12 @@ func (c *Controller) finishTurn(session Session, turnID string) {
 	if active, ok := c.turns[key]; ok && active.turnID == turnID {
 		delete(c.turns, key)
 	}
-	if current, ok := c.sessions[key]; ok && sessionHasDifferentLiveTurn(current, turnID) {
+	current, ok := c.sessions[key]
+	if !ok {
+		c.mu.Unlock()
+		return
+	}
+	if sessionHasDifferentLiveTurn(current, turnID) {
 		c.mu.Unlock()
 		return
 	}


### PR DESCRIPTION
## What changed\n\n- prevent a stale turn completion from writing an already-closed session back into the runtime controller\n- add a regression test that closes a session before its old turn finishes\n\n## Why\n\nRoot cause: finishTurn treated a missing session like a writable session snapshot. When Close deleted a session while its canceled turn goroutine was still unwinding, that goroutine could restore stale state and make the next Start return without launching the adapter.\n\nLower layer: session lifecycle ownership belongs to the shared agent runtime controller. Fixing an individual consumer would leave every other close-and-restart path vulnerable to the same resurrection race.\n\n## Risk / affected surfaces\n\nAgent session close, canceled-turn teardown, and immediate restart using the same session ID.\n\n## Verification\n\n- regression test failed before the fix\n- go test ./runtime -run TestControllerFinishTurnDoesNotRestoreClosedSession -count=20\n- go test ./runtime\n- pnpm check:changed --tail-lines 120\n- pre-push pnpm check:full: preparation and all 12 preflight checks passed; the Go lane hit the existing timing-sensitive TestControllerStartExecCancelPublishesAndReports condition wait failure, unrelated to these files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->