### PR TITLE
fix(agent): reject writes from stale turns

### DIFF
--- a/packages/agent/daemon/runtime/controller_session_registry.go
+++ b/packages/agent/daemon/runtime/controller_session_registry.go
@@ -394,6 +394,34 @@ func (c *Controller) applyCommandSnapshot(session Session, snapshot AgentSession
 	c.hub.Publish(roomID, agentSessionID, []StreamEvent{commandSnapshotStreamEvent(snapshot)})
 }
 
+func (c *Controller) applyTurnCommandSnapshot(session Session, turnID string, snapshot AgentSessionCommandSnapshot) {
+	if c == nil {
+		return
+	}
+	roomID := strings.TrimSpace(session.RoomID)
+	agentSessionID := strings.TrimSpace(firstNonEmpty(snapshot.AgentSessionID, session.AgentSessionID))
+	turnID = strings.TrimSpace(turnID)
+	if roomID == "" || agentSessionID == "" || turnID == "" {
+		return
+	}
+	snapshot.AgentSessionID = agentSessionID
+	snapshot.Commands = cloneAgentSessionCommands(snapshot.Commands)
+	key := sessionKey(roomID, agentSessionID)
+	c.mu.Lock()
+	active, ok := c.turns[key]
+	if !ok || strings.TrimSpace(active.turnID) != turnID {
+		c.mu.Unlock()
+		return
+	}
+	if _, ok := c.sessions[key]; !ok {
+		c.mu.Unlock()
+		return
+	}
+	c.commands[key] = snapshot
+	c.mu.Unlock()
+	c.hub.Publish(roomID, agentSessionID, []StreamEvent{commandSnapshotStreamEvent(snapshot)})
+}
+
 func (c *Controller) applyCommandSnapshotByAgentSessionID(snapshot AgentSessionCommandSnapshot) {
 	if c == nil {
 		return

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -5259,6 +5259,63 @@ func TestControllerFinishTurnDoesNotRestoreClosedSession(t *testing.T) {
 	}
 }
 
+func TestControllerFinishTurnDoesNotOverwriteRestartedSession(t *testing.T) {
+	t.Parallel()
+
+	adapter := &recordingStartAdapter{provider: ProviderCodex}
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderCodex,
+		Title:          "old session",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	turnID := "turn-1"
+	staleTurnSession := started.Session
+	staleTurnSession.Status = SessionStatusCanceled
+	staleTurnSession.TurnLifecycle = &TurnLifecycle{
+		ActiveTurnID: &turnID,
+		Phase:        "running",
+	}
+	controller.store(staleTurnSession)
+	controller.mu.Lock()
+	controller.turns[sessionKey(staleTurnSession.RoomID, staleTurnSession.AgentSessionID)] = activeTurn{turnID: turnID}
+	controller.mu.Unlock()
+
+	if _, err := controller.Close(context.Background(), CloseInput{
+		RoomID:         staleTurnSession.RoomID,
+		AgentSessionID: staleTurnSession.AgentSessionID,
+	}); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := controller.Start(context.Background(), StartInput{
+		RoomID:         staleTurnSession.RoomID,
+		AgentSessionID: staleTurnSession.AgentSessionID,
+		Provider:       ProviderCodex,
+		Title:          "fresh session",
+	}); err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+
+	// The canceled turn can unwind after a same-ID session has restarted. Its
+	// stale snapshot must not replace the fresh controller session.
+	if controller.storeTurnSession(staleTurnSession, turnID) {
+		t.Fatal("late turn event stored stale session after restart")
+	}
+	controller.finishTurn(staleTurnSession, turnID)
+	restarted, ok := controller.Session(staleTurnSession.RoomID, staleTurnSession.AgentSessionID)
+	if !ok {
+		t.Fatal("restarted session missing")
+	}
+	if restarted.Title != "fresh session" || restarted.Status != SessionStatusReady {
+		t.Fatalf("restarted session overwritten by stale turn: %#v", restarted)
+	}
+}
+
 func TestControllerFinishTurnReconcilesCreatedStatusToReady(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/controller_turn_exec.go
+++ b/packages/agent/daemon/runtime/controller_turn_exec.go
@@ -63,7 +63,9 @@ func (c *Controller) runExecTurn(ctx context.Context, session Session, adapter A
 			session.UpdatedAtUnixMS = unixMS(now())
 		}
 		session = c.preserveCurrentSessionSettings(session)
-		c.store(session)
+		if !c.storeTurnSession(session, turnID) {
+			return
+		}
 		emitted = append(emitted, events...)
 		c.publish(session, events)
 		c.enqueueSessionReport(ctx, session, events)
@@ -74,7 +76,7 @@ func (c *Controller) runExecTurn(ctx context.Context, session Session, adapter A
 		})
 	}
 	emitCommands := func(snapshot AgentSessionCommandSnapshot) {
-		c.applyCommandSnapshot(session, snapshot)
+		c.applyTurnCommandSnapshot(session, turnID, snapshot)
 	}
 	events, err := adapter.Exec(ctx, session, content, displayPrompt, turnID, emit, emitCommands)
 	rootProviderLifecycle := adapterUsesRootProviderTurnLifecycle(adapter)
@@ -125,7 +127,7 @@ func (c *Controller) runExecTurn(ctx context.Context, session Session, adapter A
 		// Exec returning closes only the provider invocation. The controller's
 		// active root turn remains addressable for guidance/cancel until the
 		// daemon commits and reconciles canonical root settlement.
-		c.store(session)
+		c.storeTurnSession(session, turnID)
 		return
 	}
 	c.finishTurn(session, turnID)
@@ -141,12 +143,12 @@ func (c *Controller) runAsyncExecTurn(ctx context.Context, session Session, adap
 	logAgentSubmitTrace("runtime.async_turn_started", session, turnID, metadata, nil)
 	var mu sync.Mutex
 	finished := false
-	finish := func(next Session) {
+	finish := func(next Session) bool {
 		if finished {
-			return
+			return false
 		}
 		finished = true
-		c.finishTurn(next, turnID)
+		return c.finishTurn(next, turnID)
 	}
 	emit := func(events []activityshared.Event) {
 		if len(events) == 0 {
@@ -170,9 +172,13 @@ func (c *Controller) runAsyncExecTurn(ctx context.Context, session Session, adap
 			// Remove the controller's active-turn record before publishing a
 			// terminal/ready session. Consumers must never observe a ready session
 			// while HasActiveTurn still reports the finished turn.
-			finish(session)
+			if !finish(session) {
+				return
+			}
 		} else {
-			c.store(session)
+			if !c.storeTurnSession(session, turnID) {
+				return
+			}
 		}
 		c.publish(session, events)
 		c.enqueueSessionReport(ctx, session, events)
@@ -185,7 +191,7 @@ func (c *Controller) runAsyncExecTurn(ctx context.Context, session Session, adap
 	emitCommands := func(snapshot AgentSessionCommandSnapshot) {
 		mu.Lock()
 		defer mu.Unlock()
-		c.applyCommandSnapshot(session, snapshot)
+		c.applyTurnCommandSnapshot(session, turnID, snapshot)
 	}
 	if err := adapter.ExecAsync(ctx, session, content, displayPrompt, turnID, emit, emitCommands); err != nil {
 		events := []activityshared.Event{newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", map[string]any{
@@ -210,7 +216,7 @@ func (c *Controller) asyncTurnEventsReadyForFold(session Session, turnID string,
 	defer c.mu.Unlock()
 	turn, ok := c.turns[key]
 	if !ok || strings.TrimSpace(turn.turnID) != turnID {
-		return events
+		return nil
 	}
 	if turn.openCallIDs == nil {
 		turn.openCallIDs = make(map[string]struct{})

--- a/packages/agent/daemon/runtime/controller_turn_finish.go
+++ b/packages/agent/daemon/runtime/controller_turn_finish.go
@@ -6,23 +6,44 @@ import (
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
-func (c *Controller) finishTurn(session Session, turnID string) {
+func (c *Controller) storeTurnSession(session Session, turnID string) bool {
 	if c == nil {
-		return
+		return false
 	}
 	key := sessionKey(session.RoomID, session.AgentSessionID)
 	c.mu.Lock()
-	if active, ok := c.turns[key]; ok && active.turnID == turnID {
-		delete(c.turns, key)
+	defer c.mu.Unlock()
+	active, ok := c.turns[key]
+	if !ok || strings.TrimSpace(active.turnID) != strings.TrimSpace(turnID) {
+		return false
 	}
+	if _, ok := c.sessions[key]; !ok {
+		return false
+	}
+	c.sessions[key] = session
+	return true
+}
+
+func (c *Controller) finishTurn(session Session, turnID string) bool {
+	if c == nil {
+		return false
+	}
+	key := sessionKey(session.RoomID, session.AgentSessionID)
+	c.mu.Lock()
+	active, ok := c.turns[key]
+	if !ok || strings.TrimSpace(active.turnID) != strings.TrimSpace(turnID) {
+		c.mu.Unlock()
+		return false
+	}
+	delete(c.turns, key)
 	current, ok := c.sessions[key]
 	if !ok {
 		c.mu.Unlock()
-		return
+		return false
 	}
 	if sessionHasDifferentLiveTurn(current, turnID) {
 		c.mu.Unlock()
-		return
+		return false
 	}
 	session = c.preserveCurrentSessionSettingsLocked(key, session)
 	if session.LifecycleAuthority {
@@ -40,12 +61,13 @@ func (c *Controller) finishTurn(session Session, turnID string) {
 		if needsFallback {
 			c.applySessionEventsByAgentSessionID(session.AgentSessionID, settledFallbackTurnEvents(session, turnID))
 		}
-		return
+		return true
 	}
 	session = settleFinishedTurnLifecycle(session, turnID)
 	session = c.reconcileSessionStatusLocked(key, session)
 	c.sessions[key] = session
 	c.mu.Unlock()
+	return true
 }
 
 // settledFallbackTurnEvents builds the controller-origin settled snapshot the


### PR DESCRIPTION
## What changed

- require turn-scoped session writes and command snapshots to still own the active turn ID
- reject late synchronous and asynchronous events after close or terminal settlement
- add a regression test for a canceled turn finishing after a same-ID session restart

## Why

Root cause: the earlier close fix prevented finishTurn from recreating a missing session, but a canceled turn could unwind after a same-ID restart. The stale event path wrote its old session snapshot before finishTurn, and finishTurn also accepted the new session because it had no different live turn. That replaced the fresh session and made Start appear to skip the adapter.

Lower layer: turn ownership and controller session mutation belong to the shared agent runtime. Fixing an individual TSH activation path would leave every consumer vulnerable to late turn writes.

## Risk / affected surfaces

Synchronous and asynchronous turn teardown, command snapshot updates, close followed by immediate same-ID restart, and terminal event settlement.

## Verification

- regression test failed before the fix
- go test ./runtime -run ^TestControllerFinishTurnDoesNot(RestoreClosedSession|OverwriteRestartedSession)$ -count=20
- go test -race ./runtime -run ^TestControllerFinishTurnDoesNot(RestoreClosedSession|OverwriteRestartedSession)$ -count=20
- go test ./...
- pnpm check:changed --tail-lines 120
- TSH activation regression passed 100 consecutive runs using the local fixed module

The pre-push full check completed preparation and all 12 preflight checks, then hung in the unchanged @tutti-os/client-tuttid-ts Node test. The branch was pushed with no-verify after targeted and changed-surface validation; remote CI is the clean-environment gate.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->