### PR TITLE
fix(agent): align durable cancel and activity vocabulary

### DIFF
--- a/.changeset/agent-durable-cancel-acceptance.md
+++ b/.changeset/agent-durable-cancel-acceptance.md
@@ -1,0 +1,7 @@
+---
+"@tutti-os/agent-activity-core": patch
+"@tutti-os/agent-gui": patch
+---
+
+Model durable turn-cancel acceptance separately from terminal cancellation so
+shared-agent callers remain blocked until the canonical turn settles.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1192,6 +1192,13 @@ keeps a workspace/session-scoped `awaitingTurn` cancel until the first canonical
 Turn arrives. That transition then emits an exact `turn/cancel`; a bounded
 expiry removes the detached operation so a later, unrelated Turn cannot be
 canceled. Empty reconcile snapshots must preserve this detached operation.
+An adapter may durably accept that exact-turn cancel before the Turn reaches a
+terminal outcome. It returns the official `cancel_requested` result with the
+same Turn projected in `settling` phase; the engine keeps cancellation in its
+`accepted` operation state and the GUI continues to present stopping until an
+authoritative settled Turn clears it. Acceptance must never be rewritten as
+`turn_canceled` or `already_settled`, and a transport failure must remain a
+failed command rather than manufacturing terminal state.
 When request cancellation causes create to fail, daemon rollback uses a bounded
 context detached from the canceled request so provisional runtime state is
 still closed and removed.

--- a/packages/agent/activity-core/src/engine/commandResult.validation.ts
+++ b/packages/agent/activity-core/src/engine/commandResult.validation.ts
@@ -41,22 +41,31 @@ export function validateCancelResult(
     return { kind: "invalid", reason: "cancel_result_malformed" };
   }
   const turn = response.turn;
+  const exactTurn =
+    turn?.agentSessionId === expected.agentSessionId &&
+    turn.turnId === expected.turnId;
+  const cancelRequested =
+    cancel.canceled === false &&
+    cancel.reason === "cancel_requested" &&
+    exactTurn &&
+    turn.phase === "settling" &&
+    turn.outcome == null;
   const canceled =
     cancel.canceled === true &&
     cancel.reason === "turn_canceled" &&
-    turn?.agentSessionId === expected.agentSessionId &&
-    turn.turnId === expected.turnId &&
+    exactTurn &&
     turn.phase === "settled" &&
     turn.outcome === "canceled";
   const alreadySettled =
     cancel.canceled === false &&
     cancel.reason === "already_settled" &&
-    expected.currentTurn?.phase === "settled";
+    ((exactTurn && turn.phase === "settled" && turn.outcome !== null) ||
+      expected.currentTurn?.phase === "settled");
   const targetAbsent =
     cancel.canceled === false &&
     cancel.reason === "not_found" &&
     expected.currentTurn === null;
-  return canceled || alreadySettled || targetAbsent
+  return cancelRequested || canceled || alreadySettled || targetAbsent
     ? { kind: "valid", response: response as AgentActivityTurnCancelResponse }
     : { kind: "invalid", reason: "cancel_target_mismatch" };
 }

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
@@ -19,7 +19,10 @@ import {
   selectEngineTurn
 } from "./sessionLifecycle.selectors.ts";
 import { createInitialAgentSessionEngineState } from "./rootReducer.ts";
-import { validateSendInputResult } from "./commandResult.validation.ts";
+import {
+  validateCancelResult,
+  validateSendInputResult
+} from "./commandResult.validation.ts";
 
 test("snapshot decomposes protocol v2 session and turn entities", () => {
   const result = reduce(createInitialSessionLifecycleState(), {
@@ -827,6 +830,98 @@ test("idempotent not-found cancel clears only its target and requests reconcile"
       workspaceId: "workspace-1"
     }
   ]);
+});
+
+test("durably accepted cancel stays pending until the canonical turn settles", () => {
+  let state = reduce(createInitialSessionLifecycleState(), {
+    type: "session/snapshotReceived",
+    sessions: [session(activeTurn(2), 2)]
+  }).state;
+  state = reduce(state, {
+    type: "session/cancelRequested",
+    workspaceId: "workspace-1",
+    agentSessionId: "session-1",
+    awaitingTurnExpiresAtUnixMs: 30_000,
+    commandId: "cancel-1"
+  }).state;
+  const settlingTurn: AgentActivityTurn = {
+    ...activeTurn(3),
+    phase: "settling"
+  };
+  const value = {
+    cancel: { canceled: false as const, reason: "cancel_requested" as const },
+    turn: settlingTurn
+  };
+  const accepted = sessionLifecycleReducer(
+    state,
+    {
+      type: "engine/commandResult",
+      commandId: "cancel-1",
+      commandType: "turn/cancel",
+      outcome: "succeeded",
+      value
+    },
+    {
+      queueSendNowRequiresCancel: false,
+      cancelResultValidation: validateCancelResult(value, {
+        agentSessionId: "session-1",
+        currentTurn: activeTurn(2),
+        turnId: "turn-1",
+        workspaceMatches: true
+      })
+    }
+  );
+  assert.equal(
+    accepted.state.operationBySessionId["session-1"]?.cancel.status,
+    "accepted"
+  );
+  assert.equal(
+    accepted.state.turnsById[canonicalTurnKey("session-1", "turn-1")]?.phase,
+    "settling"
+  );
+  assert.equal(
+    accepted.state.sessionsById["session-1"]?.activeTurnId,
+    "turn-1"
+  );
+
+  const settled = reduce(accepted.state, {
+    type: "turn/upserted",
+    turn: {
+      ...settlingTurn,
+      phase: "settled",
+      outcome: "canceled",
+      settledAtUnixMs: 4,
+      updatedAtUnixMs: 4
+    }
+  });
+  assert.equal(
+    settled.state.operationBySessionId["session-1"]?.cancel.status,
+    "idle"
+  );
+});
+
+test("already-settled cancel result may carry the exact raced terminal turn", () => {
+  const turn = {
+    ...activeTurn(3),
+    phase: "settled" as const,
+    outcome: "completed" as const,
+    settledAtUnixMs: 3
+  };
+  assert.equal(
+    validateCancelResult(
+      {
+        cancel: { canceled: false, reason: "already_settled" },
+        turn
+      },
+      {
+        agentSessionId: "session-1",
+        currentTurn: activeTurn(2),
+        turnId: "turn-1",
+        workspaceMatches: true
+      }
+    ).kind,
+    "valid"
+  );
 });
 
 test("authoritative settled state clears a cancel timeout failure", () => {

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
@@ -832,6 +832,59 @@ test("idempotent not-found cancel clears only its target and requests reconcile"
   ]);
 });
 
+test("terminal cancel keeps immediate personal-agent behavior", () => {
+  let state = reduce(createInitialSessionLifecycleState(), {
+    type: "session/snapshotReceived",
+    sessions: [session(activeTurn(2), 2)]
+  }).state;
+  state = reduce(state, {
+    type: "session/cancelRequested",
+    workspaceId: "workspace-1",
+    agentSessionId: "session-1",
+    awaitingTurnExpiresAtUnixMs: 30_000,
+    commandId: "cancel-1"
+  }).state;
+  const terminalTurn: AgentActivityTurn = {
+    ...activeTurn(3),
+    phase: "settled",
+    outcome: "canceled",
+    settledAtUnixMs: 3
+  };
+  const value = {
+    cancel: { canceled: true as const, reason: "turn_canceled" as const },
+    turn: terminalTurn
+  };
+  const canceled = sessionLifecycleReducer(
+    state,
+    {
+      type: "engine/commandResult",
+      commandId: "cancel-1",
+      commandType: "turn/cancel",
+      outcome: "succeeded",
+      value
+    },
+    {
+      queueSendNowRequiresCancel: false,
+      cancelResultValidation: validateCancelResult(value, {
+        agentSessionId: "session-1",
+        currentTurn: activeTurn(2),
+        turnId: "turn-1",
+        workspaceMatches: true
+      })
+    }
+  );
+
+  assert.equal(
+    canceled.state.operationBySessionId["session-1"]?.cancel.status,
+    "idle"
+  );
+  assert.equal(canceled.state.sessionsById["session-1"]?.activeTurnId, null);
+  assert.equal(
+    canceled.state.turnsById[canonicalTurnKey("session-1", "turn-1")]?.outcome,
+    "canceled"
+  );
+});
+
 test("durably accepted cancel stays pending until the canonical turn settles", () => {
   let state = reduce(createInitialSessionLifecycleState(), {
     type: "session/snapshotReceived",

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts
@@ -548,6 +548,7 @@ function settleCancel(
   const targetGone =
     response?.cancel.reason === "not_found" ||
     response?.cancel.reason === "already_settled";
+  const cancelAccepted = response.cancel.reason === "cancel_requested";
   const target = targetId
     ? next.turnsById[canonicalTurnKey(id, targetId)]
     : null;
@@ -565,7 +566,14 @@ function settleCancel(
   }
   next = setOperation(next, id, {
     ...operation,
-    cancel: initialCancel(),
+    cancel: cancelAccepted
+      ? {
+          ...operation.cancel,
+          errorCode: null,
+          errorMessage: null,
+          status: "accepted"
+        }
+      : initialCancel(),
     operationError: null
   });
   const commands: EngineCommand[] =

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
@@ -245,7 +245,9 @@ export function selectEngineCancelPending(
 ): boolean {
   const id = agentSessionId?.trim() ?? "";
   const status = state.sessionLifecycle.operationBySessionId[id]?.cancel.status;
-  return status === "requested" || status === "awaitingTurn";
+  return (
+    status === "requested" || status === "accepted" || status === "awaitingTurn"
+  );
 }
 
 export function selectEngineCancelState(

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.types.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.types.ts
@@ -10,6 +10,7 @@ export type SessionCancelStatus =
   | "idle"
   | "awaitingTurn"
   | "requested"
+  | "accepted"
   | "unknown"
   | "failed";
 

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -723,7 +723,11 @@ export interface AgentActivitySessionUsage {
 export interface AgentActivityTurnCancelResponse {
   cancel: {
     canceled: boolean;
-    reason: "turn_canceled" | "already_settled" | "not_found";
+    reason:
+      | "cancel_requested"
+      | "turn_canceled"
+      | "already_settled"
+      | "not_found";
   };
   turn?: AgentActivityTurn;
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.spec.tsx
@@ -5,50 +5,75 @@ import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import { createTestAgentSessionEngine } from "../../../shared/testing/createTestAgentSessionEngine";
 import { useAgentGUIConversationDetail } from "./useAgentGUIConversationDetail";
 
+type ConversationDetailInput = Parameters<
+  typeof useAgentGUIConversationDetail
+>[0];
+
+function conversationDetailInput(
+  overrides: Partial<ConversationDetailInput> = {}
+): ConversationDetailInput {
+  return {
+    activeCancelStatus: null,
+    activeConversation: null,
+    activeConversationId: "session-1",
+    activeConversationLiveState: "inactive",
+    activeEngineError: null,
+    activeMessages: [],
+    activePendingInteractions: [],
+    activeQueuedPromptInFlight: null,
+    activeQueuedPrompts: [],
+    activeQueueStatus: "active",
+    agentActivitySnapshot: createEmptyAgentActivitySnapshot("workspace-1"),
+    activeSessionReconcileError: null,
+    activeSessionView: null,
+    activeTimelineItems: [],
+    activeTurn: null,
+    agentActivityRuntime: {} as AgentActivityRuntime,
+    avoidGroupingEdits: false,
+    codeFor: () => null,
+    detailError: null,
+    draftByScopeKey: {},
+    errorFor: () => null,
+    providerComposerOptions: null,
+    selectedComposerTargetData: {
+      agentTargetId: null,
+      data: {
+        conversationRailWidthPx: null,
+        lastActiveAgentSessionId: "session-1",
+        provider: "codex"
+      },
+      provider: "codex",
+      targetId: "local:codex"
+    },
+    selectedProjectPath: "/workspace",
+    sessionEngine: createTestAgentSessionEngine("workspace-1"),
+    workspaceId: "workspace-1",
+    workspacePath: "/workspace",
+    ...overrides
+  };
+}
+
 describe("useAgentGUIConversationDetail", () => {
   it("restores provider commands from composer options before an engine event is available", () => {
     const { result } = renderHook(() =>
-      useAgentGUIConversationDetail({
-        activeCancelStatus: null,
-        activeConversation: null,
-        activeConversationId: "session-1",
-        activeConversationLiveState: "inactive",
-        activeEngineError: null,
-        activeMessages: [],
-        activePendingInteractions: [],
-        activeQueuedPromptInFlight: null,
-        activeQueuedPrompts: [],
-        activeQueueStatus: "active",
-        agentActivitySnapshot: createEmptyAgentActivitySnapshot("workspace-1"),
-        activeSessionReconcileError: null,
-        activeSessionView: null,
-        activeTimelineItems: [],
-        activeTurn: null,
-        agentActivityRuntime: {} as AgentActivityRuntime,
-        avoidGroupingEdits: false,
-        codeFor: () => null,
-        detailError: null,
-        draftByScopeKey: {},
-        errorFor: () => null,
-        providerComposerOptions: {
-          commands: [{ name: "memory", description: "Manage memory" }],
-          skills: []
-        } as never,
-        selectedComposerTargetData: {
-          agentTargetId: "extension:gemini",
-          data: {
-            conversationRailWidthPx: null,
-            lastActiveAgentSessionId: "session-1",
-            provider: "acp:gemini"
-          },
-          provider: "acp:gemini",
-          targetId: "extension:gemini"
-        },
-        selectedProjectPath: "/workspace",
-        sessionEngine: createTestAgentSessionEngine("workspace-1"),
-        workspaceId: "workspace-1",
-        workspacePath: "/workspace"
-      })
+      useAgentGUIConversationDetail(
+        conversationDetailInput({
+          providerComposerOptions: {
+            commands: [{ name: "memory", description: "Manage memory" }],
+            skills: []
+          } as never,
+          selectedComposerTargetData: {
+            agentTargetId: "extension:gemini",
+            data: {
+              conversationRailWidthPx: null,
+              lastActiveAgentSessionId: "session-1",
+              provider: "acp:gemini"
+            },
+            provider: "acp:gemini",
+            targetId: "extension:gemini"
+          }
+        })
+      )
     );
 
     expect(result.current.availableCommands).toEqual([
@@ -58,46 +83,23 @@ describe("useAgentGUIConversationDetail", () => {
 
   it("surfaces session reconcile errors through the detail error channel", () => {
     const { result } = renderHook(() =>
-      useAgentGUIConversationDetail({
-        activeCancelStatus: null,
-        activeConversation: null,
-        activeConversationId: "session-1",
-        activeConversationLiveState: "inactive",
-        activeEngineError: null,
-        activeMessages: [],
-        activePendingInteractions: [],
-        activeQueuedPromptInFlight: null,
-        activeQueuedPrompts: [],
-        activeQueueStatus: "active",
-        agentActivitySnapshot: createEmptyAgentActivitySnapshot("workspace-1"),
-        activeSessionReconcileError: "detail reconcile failed",
-        activeSessionView: null,
-        activeTimelineItems: [],
-        activeTurn: null,
-        agentActivityRuntime: {} as AgentActivityRuntime,
-        avoidGroupingEdits: false,
-        codeFor: () => null,
-        detailError: null,
-        draftByScopeKey: {},
-        errorFor: () => null,
-        providerComposerOptions: null,
-        selectedComposerTargetData: {
-          agentTargetId: null,
-          data: {
-            conversationRailWidthPx: null,
-            lastActiveAgentSessionId: "session-1",
-            provider: "codex"
-          },
-          provider: "codex",
-          targetId: "local:codex"
-        },
-        selectedProjectPath: "/workspace",
-        sessionEngine: createTestAgentSessionEngine("workspace-1"),
-        workspaceId: "workspace-1",
-        workspacePath: "/workspace"
-      })
+      useAgentGUIConversationDetail(
+        conversationDetailInput({
+          activeSessionReconcileError: "detail reconcile failed"
+        })
+      )
     );
 
     expect(result.current.effectiveDetailError).toBe("detail reconcile failed");
+  });
+
+  it("keeps the composer in interrupting state after durable cancel acceptance", () => {
+    const { result } = renderHook(() =>
+      useAgentGUIConversationDetail(
+        conversationDetailInput({ activeCancelStatus: "accepted" })
+      )
+    );
+
+    expect(result.current.isInterrupting).toBe(true);
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.ts
@@ -319,7 +319,9 @@ export function useAgentGUIConversationDetail(
       (input.activeConversationId !== null ? input.activeEngineError : null),
     hasProviderSessionNotFoundError,
     isCancelPending: input.activeCancelStatus === "awaitingTurn",
-    isInterrupting: input.activeCancelStatus === "requested",
+    isInterrupting:
+      input.activeCancelStatus === "requested" ||
+      input.activeCancelStatus === "accepted",
     pendingApproval: hasProviderSessionNotFoundError
       ? null
       : rawPendingApproval,

--- a/packages/agent/store-sqlite/canonical/vocabulary.go
+++ b/packages/agent/store-sqlite/canonical/vocabulary.go
@@ -23,6 +23,22 @@ const (
 	TurnOutcomeInterrupted = "interrupted"
 )
 
+var (
+	turnPhases = [...]string{
+		TurnPhaseSubmitted,
+		TurnPhaseRunning,
+		TurnPhaseWaiting,
+		TurnPhaseSettling,
+		TurnPhaseSettled,
+	}
+	turnOutcomes = [...]string{
+		TurnOutcomeCompleted,
+		TurnOutcomeFailed,
+		TurnOutcomeCanceled,
+		TurnOutcomeInterrupted,
+	}
+)
+
 const (
 	TurnOriginUserPrompt        = "user_prompt"
 	TurnOriginGoalArm           = "goal_arm"
@@ -49,21 +65,33 @@ const (
 )
 
 func IsKnownTurnPhase(phase string) bool {
-	switch phase {
-	case TurnPhaseSubmitted, TurnPhaseRunning, TurnPhaseWaiting, TurnPhaseSettling, TurnPhaseSettled:
-		return true
-	default:
-		return false
+	for _, known := range turnPhases {
+		if phase == known {
+			return true
+		}
 	}
+	return false
 }
 
 func IsKnownTurnOutcome(outcome string) bool {
-	switch outcome {
-	case TurnOutcomeCompleted, TurnOutcomeFailed, TurnOutcomeCanceled, TurnOutcomeInterrupted:
-		return true
-	default:
-		return false
+	for _, known := range turnOutcomes {
+		if outcome == known {
+			return true
+		}
 	}
+	return false
+}
+
+// TurnPhases returns the complete closed phase vocabulary. Callers receive a
+// copy so the canonical package remains the only owner of the set.
+func TurnPhases() []string {
+	return append([]string(nil), turnPhases[:]...)
+}
+
+// TurnOutcomes returns the complete closed outcome vocabulary. Callers receive
+// a copy so the canonical package remains the only owner of the set.
+func TurnOutcomes() []string {
+	return append([]string(nil), turnOutcomes[:]...)
 }
 
 func IsKnownTurnOrigin(origin string) bool {

--- a/packages/agent/store-sqlite/canonical/vocabulary_test.go
+++ b/packages/agent/store-sqlite/canonical/vocabulary_test.go
@@ -10,8 +10,8 @@ func TestClosedVocabularyValidation(t *testing.T) {
 		values []string
 		known  func(string) bool
 	}{
-		{"turn phase", []string{TurnPhaseSubmitted, TurnPhaseRunning, TurnPhaseWaiting, TurnPhaseSettling, TurnPhaseSettled}, IsKnownTurnPhase},
-		{"turn outcome", []string{TurnOutcomeCompleted, TurnOutcomeFailed, TurnOutcomeCanceled, TurnOutcomeInterrupted}, IsKnownTurnOutcome},
+		{"turn phase", TurnPhases(), IsKnownTurnPhase},
+		{"turn outcome", TurnOutcomes(), IsKnownTurnOutcome},
 		{"turn origin", []string{TurnOriginUserPrompt, TurnOriginGoalArm, TurnOriginGoalContinuation, TurnOriginProviderInitiated, TurnOriginLegacyUnknown}, IsKnownTurnOrigin},
 		{"interaction kind", []string{InteractionKindApproval, InteractionKindQuestion, InteractionKindPlan}, IsKnownInteractionKind},
 		{"interaction status", []string{InteractionStatusPending, InteractionStatusAnswered, InteractionStatusSuperseded}, IsKnownInteractionStatus},
@@ -25,5 +25,18 @@ func TestClosedVocabularyValidation(t *testing.T) {
 		if test.known("unknown") {
 			t.Errorf("%s validator accepted unknown value", test.name)
 		}
+	}
+}
+
+func TestClosedTurnVocabularyReturnsCopies(t *testing.T) {
+	phases := TurnPhases()
+	outcomes := TurnOutcomes()
+	phases[0] = "mutated"
+	outcomes[0] = "mutated"
+	if TurnPhases()[0] != TurnPhaseSubmitted {
+		t.Fatal("TurnPhases exposed mutable canonical storage")
+	}
+	if TurnOutcomes()[0] != TurnOutcomeCompleted {
+		t.Fatal("TurnOutcomes exposed mutable canonical storage")
 	}
 }

--- a/services/tuttid/api/activity_vocabulary_sync_test.go
+++ b/services/tuttid/api/activity_vocabulary_sync_test.go
@@ -1,40 +1,52 @@
 package api_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
+	"gopkg.in/yaml.v3"
 )
 
 func TestGeneratedActivityVocabularyMatchesCanonicalStore(t *testing.T) {
 	t.Parallel()
 
-	assertSameVocabulary(t, "turn phase", []string{
-		string(tuttigenerated.WorkspaceAgentTurnPhaseSubmitted),
-		string(tuttigenerated.WorkspaceAgentTurnPhaseRunning),
-		string(tuttigenerated.WorkspaceAgentTurnPhaseWaiting),
-		string(tuttigenerated.WorkspaceAgentTurnPhaseSettling),
-		string(tuttigenerated.WorkspaceAgentTurnPhaseSettled),
-	}, []string{
-		canonical.TurnPhaseSubmitted,
-		canonical.TurnPhaseRunning,
-		canonical.TurnPhaseWaiting,
-		canonical.TurnPhaseSettling,
-		canonical.TurnPhaseSettled,
-	})
+	vocabulary := loadOpenAPIActivityVocabulary(t)
+	assertSameVocabulary(t, "turn phase", vocabulary["WorkspaceAgentTurnPhase"], canonical.TurnPhases())
+	assertSameVocabulary(t, "turn outcome", vocabulary["WorkspaceAgentTurnOutcome"], canonical.TurnOutcomes())
+	for _, value := range vocabulary["WorkspaceAgentTurnPhase"] {
+		if !tuttigenerated.WorkspaceAgentTurnPhase(value).Valid() {
+			t.Errorf("generated turn phase rejected OpenAPI value %q", value)
+		}
+	}
+	for _, value := range vocabulary["WorkspaceAgentTurnOutcome"] {
+		if !tuttigenerated.WorkspaceAgentTurnOutcome(value).Valid() {
+			t.Errorf("generated turn outcome rejected OpenAPI value %q", value)
+		}
+	}
+}
 
-	assertSameVocabulary(t, "turn outcome", []string{
-		string(tuttigenerated.Completed),
-		string(tuttigenerated.Failed),
-		string(tuttigenerated.Canceled),
-		string(tuttigenerated.Interrupted),
-	}, []string{
-		canonical.TurnOutcomeCompleted,
-		canonical.TurnOutcomeFailed,
-		canonical.TurnOutcomeCanceled,
-		canonical.TurnOutcomeInterrupted,
-	})
+func loadOpenAPIActivityVocabulary(t *testing.T) map[string][]string {
+	t.Helper()
+	raw, err := os.ReadFile("openapi/tuttid.v1.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Components struct {
+			Schemas map[string]struct {
+				Enum []string `yaml:"enum"`
+			} `yaml:"schemas"`
+		} `yaml:"components"`
+	}
+	if err := yaml.Unmarshal(raw, &document); err != nil {
+		t.Fatal(err)
+	}
+	return map[string][]string{
+		"WorkspaceAgentTurnPhase":   document.Components.Schemas["WorkspaceAgentTurnPhase"].Enum,
+		"WorkspaceAgentTurnOutcome": document.Components.Schemas["WorkspaceAgentTurnOutcome"].Enum,
+	}
 }
 
 func assertSameVocabulary(t *testing.T, name string, generated, canonicalValues []string) {

--- a/services/tuttid/api/activity_vocabulary_sync_test.go
+++ b/services/tuttid/api/activity_vocabulary_sync_test.go
@@ -1,0 +1,58 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
+	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
+)
+
+func TestGeneratedActivityVocabularyMatchesCanonicalStore(t *testing.T) {
+	t.Parallel()
+
+	assertSameVocabulary(t, "turn phase", []string{
+		string(tuttigenerated.WorkspaceAgentTurnPhaseSubmitted),
+		string(tuttigenerated.WorkspaceAgentTurnPhaseRunning),
+		string(tuttigenerated.WorkspaceAgentTurnPhaseWaiting),
+		string(tuttigenerated.WorkspaceAgentTurnPhaseSettling),
+		string(tuttigenerated.WorkspaceAgentTurnPhaseSettled),
+	}, []string{
+		canonical.TurnPhaseSubmitted,
+		canonical.TurnPhaseRunning,
+		canonical.TurnPhaseWaiting,
+		canonical.TurnPhaseSettling,
+		canonical.TurnPhaseSettled,
+	})
+
+	assertSameVocabulary(t, "turn outcome", []string{
+		string(tuttigenerated.Completed),
+		string(tuttigenerated.Failed),
+		string(tuttigenerated.Canceled),
+		string(tuttigenerated.Interrupted),
+	}, []string{
+		canonical.TurnOutcomeCompleted,
+		canonical.TurnOutcomeFailed,
+		canonical.TurnOutcomeCanceled,
+		canonical.TurnOutcomeInterrupted,
+	})
+}
+
+func assertSameVocabulary(t *testing.T, name string, generated, canonicalValues []string) {
+	t.Helper()
+	if len(generated) != len(canonicalValues) {
+		t.Fatalf("%s vocabulary size: generated=%d canonical=%d", name, len(generated), len(canonicalValues))
+	}
+	canonicalSet := make(map[string]struct{}, len(canonicalValues))
+	for _, value := range canonicalValues {
+		canonicalSet[value] = struct{}{}
+	}
+	for _, value := range generated {
+		if _, ok := canonicalSet[value]; !ok {
+			t.Errorf("generated %s value %q is absent from canonical store vocabulary", name, value)
+		}
+		delete(canonicalSet, value)
+	}
+	for value := range canonicalSet {
+		t.Errorf("canonical %s value %q is absent from generated OpenAPI vocabulary", name, value)
+	}
+}

--- a/services/tuttid/go.mod
+++ b/services/tuttid/go.mod
@@ -24,6 +24,7 @@ require (
 	golang.org/x/mod v0.33.0
 	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.41.0
+	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.45.0
 )
 
@@ -92,7 +93,6 @@ require (
 	golang.org/x/tools v0.42.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.67.6 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/services/tuttid/go.mod
+++ b/services/tuttid/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/tutti-os/tutti/packages/agent/daemon v0.0.0
 	github.com/tutti-os/tutti/packages/agent/runtimeprep v0.0.0
 	github.com/tutti-os/tutti/packages/agent/store-sqlite v0.0.0
+	github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical v0.0.0
 	github.com/tutti-os/tutti/packages/appcli/core v0.0.0
 	github.com/tutti-os/tutti/packages/auth/bridge-go v0.0.0
 	github.com/tutti-os/tutti/packages/events/stream-go v0.0.0
@@ -35,6 +36,8 @@ replace github.com/tutti-os/tutti/packages/agent/daemon => ../../packages/agent/
 replace github.com/tutti-os/tutti/packages/agent/runtimeprep => ../../packages/agent/runtimeprep
 
 replace github.com/tutti-os/tutti/packages/agent/store-sqlite => ../../packages/agent/store-sqlite
+
+replace github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical => ../../packages/agent/store-sqlite/canonical
 
 replace github.com/tutti-os/tutti/packages/workspace/files => ../../packages/workspace/files
 


### PR DESCRIPTION
## Summary

- add the official `cancel_requested` result for durable cancel acceptance without claiming a terminal turn
- keep cancel state accepted and composer interruption gated until the canonical turn settles
- accept an exact terminal turn for raced `already_settled` results
- assert generated OpenAPI phase/outcome enums against exported store-sqlite canonical vocabularies
- add package changesets for `@tutti-os/agent-activity-core` and `@tutti-os/agent-gui`

## Why

Shared-agent cancel is a durable coordination intent. Acceptance is not proof that the owner canonical turn has settled, and transport failures must not be rewritten as terminal outcomes. The same support PR also closes the previous enum synchronization gap without a second handwritten enum list.

## Architecture

The adapter may return `cancel_requested` only with the exact requested turn in `settling`. The engine retains `accepted` state and blocks submission until an authoritative canonical settled turn arrives. Terminal outcomes still come only from canonical activity.

## Verification

- `pnpm --filter @tutti-os/agent-activity-core test`
- `pnpm --filter @tutti-os/agent-activity-core typecheck`
- `pnpm --filter @tutti-os/agent-gui test`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `go test ./...` in `packages/agent/store-sqlite/canonical`
- `go test ./api` in `services/tuttid`
- repository pre-push `pnpm check:full`

## Scope

Support PR for tsh/tsh-server Shared Invocation PR6. No database schema change.