### PR TITLE
fix(agent): preserve imported project rail membership

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1509,6 +1509,18 @@ session id. Persist them in the no-project Chats section with
 presentation, but AgentGUI must keep the imported history read-only and route
 continued work through the existing "continue in a new conversation" flow.
 
+For a project-backed external import, the exact project selection matched by
+the import service is authoritative rail-classification input. It must reach
+the activity store with the session report before the API registers successful
+projects in the user-project inventory; otherwise an already registered parent
+project can capture a nested session permanently. The store accepts this hint
+only for imported, project-backed sessions and verifies that the selected path
+contains the imported cwd. Ordinary runtime-session membership remains
+immutable. Re-importing the same historical session may repair only a Chats or
+ancestor-project assignment to that explicit descendant selection; it must not
+reclassify from the current user-project inventory or move a correctly assigned
+child session back to a parent.
+
 ### Conversation List Loading
 
 ```text
@@ -1563,9 +1575,10 @@ visible from the current section inventory even when no exact membership rows
 exist or the initial membership request fails; preserving that chrome must not
 place any session into it. The daemon assigns the key before Create succeeds
 and treats it as immutable session identity metadata; later cwd observations do
-not move the session to another rail section. Removing a project removes that
-rail section from the section list; re-adding the same path reveals historical
-sessions with the same section key.
+not move the session to another rail section. The sole correction path is the
+explicit external-import selection repair described above. Removing a project
+removes that rail section from the section list; re-adding the same path reveals
+historical sessions with the same section key.
 The daemon first-page reader is a required production repository seam, not an
 optional fast path with a per-section fallback. Its SQLite query must be driven
 by the requested section keys: ordinary branches use the rail-section page

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -53,7 +53,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [Historical AgentGUI permission changes time out or stop responding](./agent-session-lifecycle.md#historical-agentgui-permission-changes-time-out-or-stop-responding)
 - [AgentGUI pin or unpin appears stuck for a live session](./agent-session-lifecycle.md#agentgui-pin-or-unpin-appears-stuck-for-a-live-session)
 - [Agent GUI provider tab shows fused or stale conversations](./agent-session-lifecycle.md#agent-gui-provider-tab-shows-fused-or-stale-conversations)
-- [Agent GUI no-project sessions appear under a user project](./agent-session-lifecycle.md#agent-gui-no-project-sessions-appear-under-a-user-project)
+- [Agent GUI sessions appear under the wrong user project](./agent-session-lifecycle.md#agent-gui-sessions-appear-under-the-wrong-user-project)
 - [Agent GUI context usage is absent or has the wrong total](./agent-session-lifecycle.md#agent-gui-context-usage-is-absent-or-has-the-wrong-total)
 - [Agent session restore breaks when durable snapshot ownership is split](./agent-session-lifecycle.md#agent-session-restore-breaks-when-durable-snapshot-ownership-is-split)
 - [Agent activity live updates fail after event schema changes](./agent-session-lifecycle.md#agent-activity-live-updates-fail-after-event-schema-changes)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -805,14 +805,18 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [sessionEntities.reducer.ts](../../../packages/agent/activity-core/src/engine/sessionEntities.reducer.ts)
   [service_session_sections.go](../../../services/tuttid/service/agent/service_session_sections.go)
 
-### Agent GUI no-project sessions appear under a user project
+### Agent GUI sessions appear under the wrong user project
 
 - Symptom:
   A conversation started with the "No project" selection appears in the Agent
   GUI rail under a parent user-project group such as the user's home directory.
   Imported Codex or Claude Code conversations with `cwd` equal to `$HOME`, and
   claude.ai data-export conversations that have no cwd at all, can show the
-  same symptom even though the user never selected a project.
+  same symptom even though the user never selected a project. A related nested-
+  project variant shows an imported conversation under a broad parent folder
+  while its explicitly selected child-project section says `No chats yet`.
+  Switching provider filters may briefly retain the previous scope's row before
+  the exact persisted membership makes the child section empty again.
 - Quick checks:
   Inspect the session `cwd` from the activity snapshot. Generated no-project
   sessions should carry `runtimeContext.noProject: true` in the daemon report
@@ -826,6 +830,10 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   recognizes `Documents/tutti/session-<uuid>`. Codex external history can also
   record its own scratch cwd under
   `Documents/Codex/<yyyy-mm-dd>/<conversation>`.
+  For the nested-project variant, compare `cwd`, `rail_project_path`, and
+  `rail_section_key` in `workspace_agent_sessions`. If the cwd is inside a
+  registered child project but the persisted key names an ancestor, check
+  whether that child was registered only after the original import completed.
 - Root cause:
   Rail membership is classified once by the daemon when the session is first
   persisted, using `cwd`, runtime no-project markers, and current user projects.
@@ -838,6 +846,10 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   rebuilding `runtimeContext` from only `cwd`, title, permissions, and visibility,
   or replacing it wholesale with `StateAdapter` output, drops launch-scoped
   markers such as `noProject` before durable rail classification runs.
+  For project-backed import, registering user projects only after valid session
+  writes creates another ordering trap: the store may see an existing parent
+  project but not the selected child while assigning the session's first,
+  normally immutable rail key.
 - Fix:
   Build runtime state from a clone of the session launch `RuntimeContext`, overlay
   canonical session fields, and merge provider `StateAdapter` context as a patch
@@ -848,9 +860,15 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   `services/tuttid/data/workspace` classifier. Migration and session-state
   upsert should both use that classifier, matching exact user projects first,
   then preserving no-project/provider scratch cwd shapes as conversations, then
-  applying longest parent-project matches. Do not rederive historical rail
-  assignment from the current user-project list or a later cwd observation;
-  preserve every valid existing rail key unconditionally. A successful Create
+  applying longest parent-project matches. Project-backed external import must
+  pass its exact matched selection into the initial session report, independent
+  of whether API-level project registration has completed. The store validates
+  that this is an imported, project-backed session whose cwd is contained by the
+  selected path. An idempotent re-import may repair only Chats or an ancestor
+  assignment to that explicit descendant; it must not infer a migration from
+  the current project inventory or move an ordinary runtime session. Apart from
+  this evidence-backed import correction, preserve valid existing rail keys
+  across later cwd and project-list changes. A successful Create
   response must synchronously read back the persisted session and its nonblank
   key rather than racing the runtime's asynchronous activity reporter. AgentGUI
   must project sessions only by exact key equality and must not retain a cwd-based
@@ -860,6 +878,7 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   `pnpm --filter @tutti-os/agent-gui test -- agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts`,
   `cd packages/agent/daemon && go test ./runtime`,
   `cd services/tuttid && go test ./service/agent ./api -run 'ExternalImport|ParseCodex|ParseClaude'`,
+  `go test ./packages/agent/store-sqlite -run 'ImportedRail|ClassifiesRail'`,
   `node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.test.ts`
   from `apps/desktop`, then run `pnpm check:changed`.
 - References:
@@ -867,6 +886,8 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [controller_state_test.go](../../../packages/agent/daemon/runtime/controller_state_test.go)
   [external_import_parse.go](../../../services/tuttid/service/agent/external_import_parse.go)
   [external_import_projects.go](../../../services/tuttid/service/agent/external_import_projects.go)
+  [external_import.go](../../../services/tuttid/service/agent/external_import.go)
+  [rail.go](../../../packages/agent/store-sqlite/rail.go)
   [agentGuiConversationModel.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.ts)
   [desktopWorkspaceUserProjectService.ts](../../../apps/desktop/src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.ts)
   [agentGuiConversationProjectResolver.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationProjectResolver.ts)

--- a/packages/agent/store-sqlite/activity_transaction.go
+++ b/packages/agent/store-sqlite/activity_transaction.go
@@ -139,6 +139,7 @@ func (s *Store) upsertAgentSessionTx(
 		agentSessionID,
 		session.CWD,
 		session.RuntimeContext,
+		input.ImportProjectPath,
 	)
 	if err != nil {
 		return false, false, 0, Session{}, err

--- a/packages/agent/store-sqlite/rail.go
+++ b/packages/agent/store-sqlite/rail.go
@@ -52,18 +52,62 @@ func (s *Store) resolveAgentSessionRailSectionTx(
 	agentSessionID string,
 	finalCWD string,
 	runtimeContext map[string]any,
+	importProjectPath string,
 ) (RailSection, error) {
 	existingRail, err := getExistingAgentSessionRailSectionTx(ctx, tx, workspaceID, agentSessionID)
 	if err != nil {
 		return RailSection{}, err
 	}
+	importRail, hasImportRail := importedAgentSessionRailSection(
+		finalCWD,
+		runtimeContext,
+		importProjectPath,
+	)
 	// Rail membership is assigned when the session is first persisted and is
 	// immutable afterwards. Runtime cwd changes must not silently move an
-	// existing conversation between rail sections.
+	// existing conversation between rail sections. Historical imports may
+	// repair an older ancestor assignment when the same import supplies its
+	// exact selected project path.
 	if existingRail.Found && existingRail.Valid {
+		if hasImportRail && shouldRepairImportedAgentSessionRailSection(existingRail.Section, importRail) {
+			return importRail, nil
+		}
 		return existingRail.Section, nil
 	}
+	if hasImportRail {
+		return importRail, nil
+	}
 	return s.classifyAgentSessionRailSectionTx(ctx, tx, finalCWD, runtimeContext)
+}
+
+func importedAgentSessionRailSection(
+	cwd string,
+	runtimeContext map[string]any,
+	projectPath string,
+) (RailSection, bool) {
+	if !runtimeContextBool(runtimeContext["imported"]) || isAgentSessionNoProjectRuntimeContext(runtimeContext) {
+		return RailSection{}, false
+	}
+	projectPath = NormalizeProjectPath(projectPath)
+	if projectPath == "" || !agentSessionRailPathContains(projectPath, cwd) {
+		return RailSection{}, false
+	}
+	return RailSection{
+		Kind:        RailSectionKindProject,
+		ProjectPath: projectPath,
+		Key:         RailSectionKeyForProject(projectPath),
+	}, true
+}
+
+func shouldRepairImportedAgentSessionRailSection(existing RailSection, requested RailSection) bool {
+	if existing.Key == requested.Key {
+		return false
+	}
+	if existing.Kind == RailSectionKindConversations {
+		return true
+	}
+	return existing.Kind == RailSectionKindProject &&
+		agentSessionRailPathContains(existing.ProjectPath, requested.ProjectPath)
 }
 
 func getExistingAgentSessionRailSectionTx(

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -422,14 +422,17 @@ type SessionStateReport struct {
 	Settings             map[string]any
 	RuntimeContext       map[string]any
 	Cwd                  string
-	Title                string
-	Status               string
-	CurrentPhase         string
-	LastError            string
-	OccurredAtUnixMS     int64
-	StartedAtUnixMS      int64
-	EndedAtUnixMS        int64
-	CreatedAtUnixMS      int64
+	// ImportProjectPath is the canonical selected project for a historical
+	// import. The store accepts it only for imported, project-backed sessions.
+	ImportProjectPath string
+	Title             string
+	Status            string
+	CurrentPhase      string
+	LastError         string
+	OccurredAtUnixMS  int64
+	StartedAtUnixMS   int64
+	EndedAtUnixMS     int64
+	CreatedAtUnixMS   int64
 }
 
 type StateReportResult struct {

--- a/packages/agent/store-sqlite/store_test.go
+++ b/packages/agent/store-sqlite/store_test.go
@@ -860,6 +860,132 @@ func TestStoreClassifiesRailSectionsWithInjectedProjectPaths(t *testing.T) {
 	}
 }
 
+func TestStoreImportedRailUsesSelectedNestedProjectAndRepairsAncestor(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	parent := filepath.Join(root, "dev")
+	nested := filepath.Join(parent, "kage")
+	if err := mkdirAll(nested); err != nil {
+		t.Fatalf("mkdir nested project error = %v", err)
+	}
+	parent = NormalizeProjectPath(parent)
+	nested = NormalizeProjectPath(nested)
+	projects := &staticProjectPaths{paths: []string{parent}}
+	store := openTestStore(t, testOptions(projects))
+	ctx := context.Background()
+	importedContext := map[string]any{"imported": true}
+
+	initial, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID:       "ws-import-rail",
+		AgentSessionID:    "selected-nested",
+		Origin:            "WORKSPACE_AGENT_SESSION_ORIGIN_IMPORTED",
+		Provider:          "codex",
+		RuntimeContext:    importedContext,
+		Cwd:               nested,
+		ImportProjectPath: nested,
+		Status:            "completed",
+		OccurredAtUnixMS:  100,
+	})
+	if err != nil {
+		t.Fatalf("ReportSessionState(selected nested) error = %v", err)
+	}
+	wantNestedKey := RailSectionKeyForProject(nested)
+	if initial.Session.RailSectionKey != wantNestedKey {
+		t.Fatalf("selected nested rail key = %q, want %q", initial.Session.RailSectionKey, wantNestedKey)
+	}
+
+	legacy, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID:      "ws-import-rail",
+		AgentSessionID:   "legacy-parent",
+		Origin:           "WORKSPACE_AGENT_SESSION_ORIGIN_IMPORTED",
+		Provider:         "codex",
+		RuntimeContext:   importedContext,
+		Cwd:              nested,
+		Status:           "completed",
+		OccurredAtUnixMS: 100,
+	})
+	if err != nil {
+		t.Fatalf("ReportSessionState(legacy parent) error = %v", err)
+	}
+	if legacy.Session.RailSectionKey != RailSectionKeyForProject(parent) {
+		t.Fatalf("legacy rail key = %q, want parent before repair", legacy.Session.RailSectionKey)
+	}
+
+	repaired, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID:       "ws-import-rail",
+		AgentSessionID:    "legacy-parent",
+		Origin:            "WORKSPACE_AGENT_SESSION_ORIGIN_IMPORTED",
+		Provider:          "codex",
+		RuntimeContext:    importedContext,
+		Cwd:               nested,
+		ImportProjectPath: nested,
+		Status:            "completed",
+		OccurredAtUnixMS:  50,
+	})
+	if err != nil {
+		t.Fatalf("ReportSessionState(repair nested) error = %v", err)
+	}
+	if repaired.Session.RailSectionKey != wantNestedKey {
+		t.Fatalf("repaired rail key = %q, want %q", repaired.Session.RailSectionKey, wantNestedKey)
+	}
+
+	preserved, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID:       "ws-import-rail",
+		AgentSessionID:    "legacy-parent",
+		Origin:            "WORKSPACE_AGENT_SESSION_ORIGIN_IMPORTED",
+		Provider:          "codex",
+		RuntimeContext:    importedContext,
+		Cwd:               nested,
+		ImportProjectPath: parent,
+		Status:            "completed",
+		OccurredAtUnixMS:  300,
+	})
+	if err != nil {
+		t.Fatalf("ReportSessionState(preserve nested) error = %v", err)
+	}
+	if preserved.Session.RailSectionKey != wantNestedKey {
+		t.Fatalf("ancestor reimport rail key = %q, want existing nested %q", preserved.Session.RailSectionKey, wantNestedKey)
+	}
+
+	ordinary, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID:       "ws-import-rail",
+		AgentSessionID:    "ordinary-runtime",
+		Origin:            "runtime",
+		Provider:          "codex",
+		RuntimeContext:    map[string]any{"imported": false},
+		Cwd:               nested,
+		ImportProjectPath: nested,
+		Status:            "completed",
+		OccurredAtUnixMS:  100,
+	})
+	if err != nil {
+		t.Fatalf("ReportSessionState(ordinary runtime) error = %v", err)
+	}
+	wantParentKey := RailSectionKeyForProject(parent)
+	if ordinary.Session.RailSectionKey != wantParentKey {
+		t.Fatalf("ordinary runtime rail key = %q, want injected parent %q", ordinary.Session.RailSectionKey, wantParentKey)
+	}
+
+	noProject, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID:       "ws-import-rail",
+		AgentSessionID:    "no-project-import",
+		Origin:            "WORKSPACE_AGENT_SESSION_ORIGIN_IMPORTED",
+		Provider:          "codex",
+		RuntimeContext:    map[string]any{"externalImportNoProject": true, "imported": true},
+		Cwd:               nested,
+		ImportProjectPath: nested,
+		Status:            "completed",
+		OccurredAtUnixMS:  100,
+	})
+	if err != nil {
+		t.Fatalf("ReportSessionState(no-project import) error = %v", err)
+	}
+	if noProject.Session.RailSectionKey != RailSectionKeyConversations {
+		t.Fatalf("no-project import rail key = %q, want conversations", noProject.Session.RailSectionKey)
+	}
+}
+
 func TestStoreListSessionSectionFiltersHiddenSessionsBeforePagination(t *testing.T) {
 	t.Parallel()
 

--- a/services/tuttid/service/agent/external_import.go
+++ b/services/tuttid/service/agent/external_import.go
@@ -64,7 +64,7 @@ func (s *Service) ImportExternalSessions(ctx context.Context, workspaceID string
 		if !selected {
 			continue
 		}
-		importedMessages, imported, err := s.importExternalSession(ctx, workspaceID, session)
+		importedMessages, imported, err := s.importExternalSession(ctx, workspaceID, session, projectPath)
 		if err != nil {
 			result.Errors = append(result.Errors, ExternalImportError{
 				Provider:   session.Provider,
@@ -409,7 +409,12 @@ func parseExternalProviderJSONL(descriptor providerregistry.ProviderDescriptor, 
 	return session, ok, err
 }
 
-func (s *Service) importExternalSession(ctx context.Context, workspaceID string, session externalImportedSession) (int, bool, error) {
+func (s *Service) importExternalSession(
+	ctx context.Context,
+	workspaceID string,
+	session externalImportedSession,
+	projectPath string,
+) (int, bool, error) {
 	agentSessionID := externalImportedSessionID(session.Provider, session.ProviderSessionID)
 	existingIDs, sessionExists, err := s.existingExternalImportMessageIDs(ctx, workspaceID, agentSessionID)
 	if err != nil {
@@ -452,6 +457,7 @@ func (s *Service) importExternalSession(ctx context.Context, workspaceID string,
 		Settings:          externalImportedSessionSettings(session),
 		RuntimeContext:    runtimeContext,
 		Cwd:               session.Cwd,
+		ImportProjectPath: projectPath,
 		Title:             session.Title,
 		Status:            "completed",
 		CurrentPhase:      "completed",

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -632,6 +632,91 @@ func TestServiceImportExternalSessionsOmitsProjectsWithoutValidSessions(t *testi
 	}
 }
 
+func TestServiceImportExternalSessionsRepairsSelectedNestedProjectRailMembership(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-1", Name: "Workspace One"}); err != nil {
+		t.Fatalf("Create workspace error = %v", err)
+	}
+	root := t.TempDir()
+	parentProject := filepath.Join(root, "dev")
+	nestedProject := filepath.Join(parentProject, "kage")
+	if err := os.MkdirAll(nestedProject, 0o755); err != nil {
+		t.Fatalf("create nested project error = %v", err)
+	}
+	if canonical, ok := canonicalExistingDir(parentProject); ok {
+		parentProject = canonical
+	}
+	if canonical, ok := canonicalExistingDir(nestedProject); ok {
+		nestedProject = canonical
+	}
+	if _, err := store.PutUserProject(ctx, userprojectbiz.Project{
+		ID:    "parent-project",
+		Path:  parentProject,
+		Label: "dev",
+	}); err != nil {
+		t.Fatalf("PutUserProject(parent) error = %v", err)
+	}
+
+	codexHome := filepath.Join(root, "codex-home")
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(root, "claude-home"))
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	writeAgentServiceJSONL(t, filepath.Join(codexHome, "sessions", "nested.jsonl"),
+		map[string]any{
+			"timestamp": now,
+			"type":      "session_meta",
+			"payload":   map[string]any{"id": "nested-session", "cwd": nestedProject},
+		},
+		map[string]any{"timestamp": now, "type": "response_item", "payload": map[string]any{
+			"type": "message", "id": "nested-message", "role": "user",
+			"content": []any{map[string]any{"type": "input_text", "text": "Nested prompt"}},
+		}},
+	)
+	legacy, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+		WorkspaceID:      "ws-1",
+		AgentSessionID:   externalImportedSessionID("codex", "nested-session"),
+		Origin:           WorkspaceAgentSessionOriginImported,
+		Provider:         "codex",
+		RuntimeContext:   map[string]any{"imported": true},
+		Cwd:              nestedProject,
+		Title:            "Nested prompt",
+		Status:           "completed",
+		CurrentPhase:     "completed",
+		OccurredAtUnixMS: time.Now().UTC().UnixMilli(),
+	})
+	if err != nil {
+		t.Fatalf("ReportSessionState(legacy parent membership) error = %v", err)
+	}
+	if legacy.Session.RailSectionKey != "project:"+parentProject {
+		t.Fatalf("legacy railSectionKey = %q, want parent before reimport", legacy.Session.RailSectionKey)
+	}
+
+	service := newIsolatedAgentService(newFakeRuntime())
+	projection := NewActivityProjection(store)
+	service.SessionReader = projection
+	service.MessageReader = projection
+	service.ExternalImportStore = store
+
+	result, err := service.ImportExternalSessions(ctx, "ws-1", ExternalImportInput{
+		Projects: []ExternalImportProjectSelection{{Path: nestedProject}},
+	})
+	if err != nil {
+		t.Fatalf("ImportExternalSessions error = %v", err)
+	}
+	if result.ImportedSessions != 1 {
+		t.Fatalf("import result = %#v, want one imported session", result)
+	}
+	persisted, ok, err := store.GetSession(ctx, "ws-1", externalImportedSessionID("codex", "nested-session"))
+	if err != nil || !ok {
+		t.Fatalf("GetSession() ok=%v error=%v", ok, err)
+	}
+	wantSectionKey := "project:" + nestedProject
+	if persisted.RailSectionKey != wantSectionKey {
+		t.Fatalf("railSectionKey = %q, want selected nested project %q", persisted.RailSectionKey, wantSectionKey)
+	}
+}
+
 // TestServiceImportExternalSessionsOmitsProjectWhenOnlySessionFailsToImport
 // covers the case where a project's only session is a real, valid import
 // candidate but the store write itself fails (a transient error, a write


### PR DESCRIPTION
## Summary
- classify project-backed external imports from the exact matched project selection before user-project registration
- let idempotent re-imports repair Chats or ancestor-project membership to an explicit descendant without moving ordinary runtime sessions
- add store/service regressions and document the daemon-owned import rail contract and troubleshooting path

## Verification
- `pnpm check:changed -- --push-ready`
- `pnpm check:full`
- `go test ./packages/agent/daemon/runtime -run '^TestLocalProcessTransportFindsKnownNodeGlobalBin$' -count=3 -v`

## Fix Scope Justification
- Root cause: external import persisted rail membership before the matched nested project was registered, so classification fell back to an already registered parent and the normally immutable rail key stayed wrong.
- Lower layer: this cannot be fixed at the renderer or SQLite query layer because neither owns the import selection; inferring from cwd there would violate daemon-owned exact membership. The narrow fix carries the import service's existing exact match into the activity store, the lowest layer that can validate and persist the rail key.

## Notes
- existing incorrectly classified sessions are repaired by re-importing the same selected project; this change does not perform an inventory-derived bulk migration

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
