### PR TITLE
fix(agent): remove flaky runtime test races

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -301,6 +301,11 @@ provider request
 
 `call.started` / `call.completed` / `call.failed` continue to own historical
 tool-call messages, but they never create or restore an actionable Interaction.
+When acknowledging an interactive response can make the provider immediately
+settle its Turn, the adapter must serialize that acknowledgement and the
+matching call-resolution event with Turn finalization. The terminal Turn event
+must not overtake `call.completed` or `call.failed` and close the event stream
+before the historical call row resolves.
 Likewise, a runtime session snapshot may describe provider-local execution
 state but must not enrich a report with an Interaction transition. Runtime
 reports may submit only `pending` and `superseded`; `answered` belongs solely to

--- a/docs/conventions/troubleshooting/agent-approvals-subagents.md
+++ b/docs/conventions/troubleshooting/agent-approvals-subagents.md
@@ -67,6 +67,23 @@ session-level child summaries.
 - Validate: inject a database failure after provider success and confirm retry
   reaches one terminal operation without submitting the provider response twice.
 
+### Approved call remains waiting after the Turn completes
+
+- Symptom: the provider accepts an approval and completes the Turn, but the
+  historical approval row has no `call.completed` event or an adapter test
+  intermittently waits forever for that event.
+- Check: compare the write of the provider response, emission of the matching
+  call-resolution event, and handling of the provider's immediate Turn terminal.
+- Cause: provider acknowledgement and call resolution were not serialized with
+  Turn finalization. A fast terminal notification closed the event stream before
+  the response goroutine emitted `call.completed`.
+- Fix: hold the active Turn processing boundary across the response write and
+  call-resolution commit. Let the queued terminal notification finalize only
+  after that boundary is released.
+- Validate: use a transport that emits the terminal notification immediately
+  after receiving the approval response, then stress the test and assert the
+  call-resolution event always precedes the Turn terminal.
+
 ### Claude SDK ExitPlanMode is reported as interrupted after plan completion
 
 - Symptom: the plan is visible, but the approval row becomes interrupted or

--- a/packages/agent/daemon/runtime/codex_appserver_event_interactive.go
+++ b/packages/agent/daemon/runtime/codex_appserver_event_interactive.go
@@ -49,7 +49,8 @@ func (a *CodexAppServerAdapter) appServerServerRequest(
 	if len(events) > 0 {
 		emit(events)
 	}
-	go a.respondAppServerServerRequest(ctx, client, eventSession, eventTurnID, child, message, params, pending, emit)
+	processingTurn := a.activeTurnForNormalizer(session.AgentSessionID, normalizer)
+	go a.respondAppServerServerRequest(ctx, client, eventSession, eventTurnID, child, message, params, pending, processingTurn, emit)
 	return nil, nil
 }
 
@@ -79,6 +80,7 @@ func (*CodexAppServerAdapter) respondAppServerServerRequest(
 	message acpMessage,
 	params map[string]any,
 	pending *pendingInteractiveRequest,
+	processingTurn *codexAppServerActiveTurn,
 	emit EventSink,
 ) {
 	if pending == nil {
@@ -108,6 +110,14 @@ func (*CodexAppServerAdapter) respondAppServerServerRequest(
 			emit(resolved)
 		}
 		return
+	}
+	// A provider may complete the turn immediately after accepting this
+	// response. Serialize the acknowledgement and its resolution events with
+	// turn finalization so call.completed cannot arrive after the terminal event
+	// and get dropped by the turn's closed-event guard.
+	if processingTurn != nil {
+		processingTurn.processMu.Lock()
+		defer processingTurn.processMu.Unlock()
 	}
 	result, responseErr := appServerApprovalResult(message.Method, params, selection)
 	if err := client.Respond(ctx, message.ID, result, responseErr); err != nil {

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -1163,7 +1163,7 @@ func TestControllerHiddenSessionPublishesLiveEventsAndReportsActivity(t *testing
 	}
 }
 
-func TestControllerStartExecCancelPublishesAndReports(t *testing.T) {
+func TestControllerStartExecPublishesAndReports(t *testing.T) {
 	t.Parallel()
 
 	reporter := &recordingReporter{}
@@ -1245,14 +1245,6 @@ userMessagePublished:
 			updatedSession.Status == SessionStatusReady &&
 			updatedSession.Title == "Inspect repository structure"
 	})
-
-	cancelResult, err := controller.Cancel(ctx, rootCancelInput("room-1", started.Session.AgentSessionID, execResult.TurnID, "user"))
-	if err != nil {
-		t.Fatalf("Cancel: %v", err)
-	}
-	if cancelResult.Canceled {
-		t.Fatalf("Cancel result = %#v, want no active turn cancel", cancelResult)
-	}
 	var hasSessionStartedPatch bool
 	for _, call := range reportCalls {
 		for _, patch := range call.report.StatePatches {

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -1,5 +1,11 @@
 import "@testing-library/jest-dom/vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   AgentMessageMarkdown,
@@ -13,6 +19,7 @@ import {
 
 describe("AgentMessageMarkdown", () => {
   afterEach(() => {
+    vi.useRealTimers();
     resetCachedMarkdownImagesForTests();
   });
 
@@ -915,6 +922,7 @@ describe("AgentMessageMarkdown", () => {
   });
 
   it("copies and downloads a workspace markdown image from preview actions", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     const readFile = vi.fn().mockResolvedValue({
       bytes: new Uint8Array([137, 80, 78, 71])
     });
@@ -997,6 +1005,13 @@ describe("AgentMessageMarkdown", () => {
     fireEvent.click(screen.getByRole("button", { name: "Download image" }));
     expect(clickDownload).toHaveBeenCalledTimes(1);
     expect(downloadedName).toMatch(/^dance-\d{8}-\d{6}-[a-z0-9]{4}\.png$/);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1600);
+    });
+    expect(
+      document.querySelector('[data-tsh-image-copy-status="true"]')
+    ).toBeNull();
 
     clickDownload.mockRestore();
   });

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.virtual.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.virtual.spec.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { normalizeAgentActivitySession } from "@tutti-os/agent-activity-core";
 import type { AgentConversationVM } from "../contracts/agentConversationVM";
@@ -145,11 +151,10 @@ describe("AgentTranscriptView virtual rendering", () => {
       })
     );
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: "Thought process" })
-      ).toBeTruthy();
-    });
+    await flushCollapsibleRevealFrames();
+    expect(
+      screen.getByRole("button", { name: "Thought process" })
+    ).toBeTruthy();
     expect(
       document.querySelector("[data-agent-transcript-virtual-turn='turn-10']")
     ).toBeTruthy();
@@ -509,6 +514,19 @@ function conversationWithCollapsibleTurns(
       }))
     }
   };
+}
+
+async function flushCollapsibleRevealFrames(): Promise<void> {
+  await flushAnimationFrame();
+  await flushAnimationFrame();
+}
+
+async function flushAnimationFrame(): Promise<void> {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
 }
 
 function messageRow(


### PR DESCRIPTION
## Summary
- keep the controller Start/Exec stream-and-reporter integration test, but remove its unrelated post-settlement cancel assertion; dedicated cancel tests retain that coverage
- serialize Codex approval acknowledgement and call-resolution emission with Turn finalization so an immediate provider terminal cannot drop `call.completed`
- make the markdown image action test finish the Radix Toast timer lifecycle before jsdom teardown
- synchronize the virtual transcript disclosure test with its two animation-frame mount/visibility contract instead of polling under load

## Root cause
- the controller test manually settled durable state before provider-owned active-turn cleanup completed, so its extra cancel assertion observed a transient stale handle
- Codex may emit `turn/completed` immediately after reading an approval response; terminal processing could close the event stream before the response goroutine emitted `call.completed`
- Radix Toast retained a 1600 ms callback after the image test completed; under fast CI teardown it accessed `document` after jsdom disposal
- `CollapsibleReveal` mounts and reveals content over two animation frames; the virtual transcript test used a generic one-second `waitFor`, which could expire under full-suite CPU contention

## Verification
- `go test ./runtime -run "^TestCodexAppServerAdapterCommandApprovalApprove$" -count=200`
- `go test -race ./runtime -run "^TestCodexAppServerAdapterCommandApprovalApprove$" -count=20`
- `go test ./runtime -count=5`
- virtual transcript focused file repeated 20 times: 8/8 each run
- `pnpm --filter @tutti-os/agent-gui test`: 184 files / 1709 tests
- earlier AgentGUI full suite repeated 3 times after the Toast fix
- `pnpm check:changed -- --push-ready`
- `pnpm check:full`: 18/18

## Documentation
- record approval response / call-resolution / Turn-terminal ordering in Agent Activity architecture
- add the matching approval race troubleshooting entry

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->