### PR TITLE
docs(agent): document canonical store packages

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -30,7 +30,18 @@ packages/agent/gui
 
 packages/agent/activity-replication
   github.com/tutti-os/tutti/packages/agent/activity-replication
+
+packages/agent/store-sqlite
+  github.com/tutti-os/tutti/packages/agent/store-sqlite
+
+packages/agent/store-sqlite/canonical
+  github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical
 ```
+
+`packages/agent/store-sqlite/canonical` is the single authority for canonical
+activity contract vocabulary; other packages import its phase, outcome,
+origin, interaction-kind, and interaction-status definitions rather than
+redeclaring them.
 
 ## Responsibilities
 


### PR DESCRIPTION
## Summary

Add `packages/agent/store-sqlite` and `packages/agent/store-sqlite/canonical` to the Agent Activity package map, and state that the canonical submodule is the single authority for activity contract vocabulary.

## Verification

- `/Users/liying/project/tutti/node_modules/.bin/prettier --check --config packages/configs/prettier/base.mjs docs/architecture/agent-activity-packages.md`
- `git diff --check`

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (Not applicable: no README or CONTRIBUTING change.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->