### PR TITLE
fix(agent-gui): group session mentions by user

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -3551,13 +3551,13 @@ provenance-aware generated-file provider for either active dimension, even when
 the ordinary generated-files group is otherwise disabled. Generated-file and
 picker result groups remain source-owned. The Agent Session and Agent target
 `@` lists are the exceptions when a host injects an Agent provenance catalog.
-Session rows group by exact `agentTargetId` in Agent catalog order. Agent target
-rows use each Agent option's `parentMemberId` to group under the matching Member
-catalog entry, so one member's targets share a group while filtering still uses
-the individual target ids. Collaboration hosts should build this catalog from
-the complete Agent directory, using `AgentGUIAgent.owner.userId` for shared
-targets, rather than deriving ownership only from sessions; targets without
-history must still join their owner's group. Hosts that omit a matching Member entry retain the
+Session and Agent target rows use each Agent option's `parentMemberId` to group
+under the matching Member catalog entry, so one member's sessions and targets
+share a group across Agent targets while filtering still uses the individual
+target ids. Collaboration hosts should build this catalog from the complete
+Agent directory, using `AgentGUIAgent.owner.userId` for shared targets, rather
+than deriving ownership only from sessions; targets without history must still
+join their owner's group. Hosts that omit a matching Member entry retain the
 per-Agent group. AgentGUI does not synthesize owner-aware row labels because
 that presentation remains host-owned. Rows outside the catalog remain visible
 in stable uncatalogued groups only while no explicit Agent filter is selected.

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
@@ -563,10 +563,17 @@ describe("AgentMentionSearchController", () => {
     expect(queryIssues).not.toHaveBeenCalled();
   });
 
-  it("groups session mentions in provenance catalog order", async () => {
+  it("groups session mentions by member across agent targets", async () => {
     const controller = new AgentMentionSearchController({
       querySessions: vi.fn().mockResolvedValue({
         sessions: [
+          {
+            agentSessionId: "session-local-claude",
+            agentTargetId: "claude-main",
+            provider: "claude-code",
+            title: "Local Claude build",
+            userId: "user-1"
+          },
           ...Array.from({ length: 31 }, (_, index) => ({
             agentSessionId: `session-local-${index}`,
             agentTargetId: "codex-main",
@@ -596,13 +603,26 @@ describe("AgentMentionSearchController", () => {
     controller.setProvenanceCatalog({
       enabledDimensions: ["agent"],
       agentOptions: [
-        { id: "codex-main", label: "Me · Codex" },
+        {
+          id: "codex-main",
+          label: "Me · Codex",
+          parentMemberId: "user-1"
+        },
+        {
+          id: "claude-main",
+          label: "Me · Claude Code",
+          parentMemberId: "user-1"
+        },
         {
           id: "shared-agent:shared-codex",
-          label: "Lin · Codex"
+          label: "Lin · Codex",
+          parentMemberId: "user-2"
         }
       ],
-      memberOptions: []
+      memberOptions: [
+        { id: "user-1", label: "Me" },
+        { id: "user-2", label: "Lin" }
+      ]
     });
 
     controller.updateQuery({
@@ -617,17 +637,18 @@ describe("AgentMentionSearchController", () => {
         filter: "session",
         groups: [
           {
-            id: "agent:codex-main",
-            label: "Me · Codex",
+            id: "member:user-1",
+            label: "Me",
             items: expect.arrayContaining([
-              expect.objectContaining({ targetId: "session-local-0" })
+              expect.objectContaining({ targetId: "session-local-0" }),
+              expect.objectContaining({ targetId: "session-local-claude" })
             ]),
-            totalCount: 31,
+            totalCount: 32,
             hasMore: true
           },
           {
-            id: "agent:shared-agent%3Ashared-codex",
-            label: "Lin · Codex",
+            id: "member:user-2",
+            label: "Lin",
             items: [expect.objectContaining({ targetId: "session-shared" })]
           },
           {
@@ -640,11 +661,11 @@ describe("AgentMentionSearchController", () => {
         ]
       })
     );
-    controller.expandGroup("agent:codex-main");
+    controller.expandGroup("member:user-1");
     expect(
       (
         states.at(-1) as { groups: Array<{ id: string; items: unknown[] }> }
-      ).groups.find((group) => group.id === "agent:codex-main")?.items
+      ).groups.find((group) => group.id === "member:user-1")?.items
     ).toHaveLength(20);
     controller.setProvenanceFilter({
       agentTargetIds: ["shared-agent:shared-codex"],
@@ -655,7 +676,7 @@ describe("AgentMentionSearchController", () => {
         status: "ready",
         groups: [
           {
-            id: "agent:shared-agent%3Ashared-codex",
+            id: "member:user-2",
             items: [expect.objectContaining({ targetId: "session-shared" })]
           }
         ]

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
@@ -192,7 +192,6 @@ function buildAgentProvenanceGroups(input: {
     input.provenanceCatalog.agentOptions.map((option) => option.id)
   );
   const catalogGroups = agentProvenanceGroupSpecs(
-    input.currentFilter,
     input.provenanceCatalog
   ).flatMap((group) => {
     const items = sourceItems.filter((item) => {
@@ -253,22 +252,11 @@ function buildAgentProvenanceGroups(input: {
   ];
 }
 
-function agentProvenanceGroupSpecs(
-  currentFilter: AgentMentionFilterId,
-  catalog: ReferenceProvenanceCatalog
-): Array<{
+function agentProvenanceGroupSpecs(catalog: ReferenceProvenanceCatalog): Array<{
   id: AgentMentionGroupId;
   label: string;
   agentTargetIds: ReadonlySet<string>;
 }> {
-  if (currentFilter === "session") {
-    return catalog.agentOptions.map((option) => ({
-      id: agentProvenanceMentionGroupId(option.id),
-      label: option.label,
-      agentTargetIds: new Set([option.id])
-    }));
-  }
-
   const groupedAgentTargetIds = new Set<string>();
   const memberGroups = catalog.memberOptions.flatMap((member) => {
     const agentTargetIds = catalog.agentOptions.flatMap((option) =>


### PR DESCRIPTION
## Summary

- group Agent session mention results by the owning member instead of by Agent Target
- keep Agent Target filtering and uncatalogued fallback grouping unchanged
- document the member-grouping contract and cover cross-Agent pagination/filter behavior

## Verification

- `pnpm check:full` (Node.js 24.18.0)
- `pnpm --filter @tutti-os/agent-gui test`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:agent-activity-runtime-boundaries`

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->