### PR TITLE
fix(agent-gui): handle CJK bare-link boundaries

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -3668,6 +3668,16 @@ Agent window host routes must honor that validation intent and surface the same
 localized missing-target feedback instead of opening an empty files surface or
 silently doing nothing.
 
+Bare HTTP links use the GFM literal-autolink parser, but transcript rendering
+also repairs CJK sentence punctuation boundaries after Markdown parsing because
+the upstream GFM boundary set is ASCII-oriented. This repair applies only to
+literal autolinks and must preserve explicit Markdown links, angle autolinks,
+code, and intentionally authored Unicode link destinations. Streaming and
+settled transcript rendering must use the same boundary transform so an href
+does not change when a turn finishes. Raw CJK punctuation in a literal autolink
+is a sentence boundary; a URL that intentionally contains that punctuation must
+percent-encode it or use an explicit Markdown link destination.
+
 Provider host-app-context prompts should mirror that contract: when agents
 reference code or workspace files in responses, instruct them to emit Markdown
 links with filename labels and absolute filesystem targets such as

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -193,6 +193,121 @@ describe("AgentMessageMarkdown", () => {
     }
   });
 
+  it.each([
+    "，",
+    "。",
+    "；",
+    "：",
+    "！",
+    "？",
+    "、",
+    "…",
+    "）",
+    "】",
+    "》",
+    "」",
+    "』",
+    "〉",
+    "〕",
+    "］",
+    "｝",
+    "”",
+    "’"
+  ])(
+    "keeps the CJK %s sentence boundary outside bare http links",
+    (punctuation) => {
+      const onLinkClick = vi.fn();
+      const url = "https://github.com/settings/applications";
+      render(
+        <AgentMessageMarkdown
+          content={`请打开 ${url}${punctuation}然后继续`}
+          onLinkClick={onLinkClick}
+        />
+      );
+
+      const link = screen.getByRole("link", { name: url });
+      expect(link).toHaveAttribute("data-agent-link-href", url);
+      expect(link).not.toHaveTextContent(`${punctuation}然后继续`);
+      expect(link.parentElement).toHaveTextContent(
+        `请打开 ${url}${punctuation}然后继续`
+      );
+
+      fireEvent.click(link);
+      expect(onLinkClick).toHaveBeenCalledWith(url);
+    }
+  );
+
+  it.each([",", ".", ";", ":", "!", "?", ")", "]"])(
+    "keeps the ASCII %s sentence boundary outside bare http links",
+    (punctuation) => {
+      const url = "https://github.com/settings/applications";
+      render(
+        <AgentMessageMarkdown
+          content={`请打开 ${url}${punctuation} 然后继续`}
+        />
+      );
+
+      const link = screen.getByRole("link", { name: url });
+      expect(link).toHaveAttribute("data-agent-link-href", url);
+      expect(link).not.toHaveTextContent(`${punctuation} 然后继续`);
+    }
+  );
+
+  it("preserves explicit markdown links containing CJK punctuation", () => {
+    const target = "https://example.com/发布，版本";
+    render(<AgentMessageMarkdown content={`打开 [发布记录](${target})`} />);
+
+    expect(screen.getByRole("link", { name: "发布记录" })).toHaveAttribute(
+      "data-agent-link-href",
+      new URL(target).toString()
+    );
+  });
+
+  it("preserves percent-encoded CJK punctuation in bare http links", () => {
+    const target = "https://example.com/search?q=%E7%94%B2%EF%BC%8C%E4%B9%99";
+    render(<AgentMessageMarkdown content={`打开 ${target}，继续`} />);
+
+    expect(screen.getByRole("link", { name: target })).toHaveAttribute(
+      "data-agent-link-href",
+      target
+    );
+  });
+
+  it("preserves explicitly authored angle autolinks", () => {
+    const target = "https://example.com/releases/a,b";
+    render(<AgentMessageMarkdown content={`打开 <${target}>`} />);
+
+    expect(screen.getByRole("link", { name: target })).toHaveAttribute(
+      "data-agent-link-href",
+      target
+    );
+  });
+
+  it("applies CJK sentence boundaries to www literal autolinks", () => {
+    const label = "www.example.com/releases";
+    render(<AgentMessageMarkdown content={`打开 ${label}，继续`} />);
+
+    expect(screen.getByRole("link", { name: label })).toHaveAttribute(
+      "data-agent-link-href",
+      `http://${label}`
+    );
+  });
+
+  it("applies CJK bare-link boundaries while streaming markdown", () => {
+    const url = "https://github.com/settings/applications";
+    render(
+      <AgentMessageMarkdown content={`请打开 ${url}，然后继续`} streaming />
+    );
+
+    expect(screen.getByRole("link", { name: url })).toHaveAttribute(
+      "data-agent-link-href",
+      url
+    );
+    expect(screen.getByRole("link", { name: url })).not.toHaveTextContent(
+      "，然后继续"
+    );
+  });
+
   it("renders unsafe markdown links as plain text", () => {
     const onLinkClick = vi.fn();
     render(

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -72,6 +72,7 @@ import {
   textFromReactNode
 } from "./AgentMessageMarkdownRenderers";
 import { MarkdownMedia } from "./AgentMessageMarkdownMedia";
+import { remarkCjkAutolinkBoundary } from "./remarkCjkAutolinkBoundary";
 export { resetCachedMarkdownImagesForTests } from "./AgentMessageMarkdownMedia";
 export type { StreamingMarkdownBlock } from "./agentMessageMarkdownRuntime";
 export { splitStreamingMarkdownBlocks } from "./agentMessageMarkdownRuntime";
@@ -313,7 +314,7 @@ export function AgentMessageMarkdown({
           />
         ) : (
           <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
+            remarkPlugins={[remarkGfm, remarkCjkAutolinkBoundary]}
             rehypePlugins={[[rehypeSanitize, MARKDOWN_SANITIZE_SCHEMA]]}
             urlTransform={markdownUrlTransform}
             components={markdownComponents}
@@ -368,7 +369,7 @@ const MemoizedMarkdownBlock = memo(function MemoizedMarkdownBlock({
 }): JSX.Element {
   return (
     <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={[remarkGfm, remarkCjkAutolinkBoundary]}
       rehypePlugins={[[rehypeSanitize, MARKDOWN_SANITIZE_SCHEMA]]}
       urlTransform={markdownUrlTransform}
       components={components}

--- a/packages/agent/gui/shared/remarkCjkAutolinkBoundary.ts
+++ b/packages/agent/gui/shared/remarkCjkAutolinkBoundary.ts
@@ -1,0 +1,176 @@
+interface MarkdownPoint {
+  line: number;
+  column: number;
+  offset?: number;
+}
+
+interface MarkdownPosition {
+  start: MarkdownPoint;
+  end: MarkdownPoint;
+}
+
+interface MarkdownNode {
+  type: string;
+  children?: MarkdownNode[];
+  position?: MarkdownPosition;
+  url?: string;
+  value?: string;
+}
+
+interface SplitAutolink {
+  link: MarkdownNode;
+  trailing: MarkdownNode;
+}
+
+const CJK_SENTENCE_BOUNDARY = /[，。；：！？、…）】》」』〉〕］｝”’]/u;
+
+/**
+ * GFM literal autolinks only recognize ASCII trailing punctuation. Repair the
+ * product-facing CJK sentence boundary without changing explicit Markdown
+ * links, angle autolinks, code, or deliberately authored link destinations.
+ */
+export function remarkCjkAutolinkBoundary() {
+  return (tree: unknown, file: unknown): void => {
+    if (!isMarkdownNode(tree)) {
+      return;
+    }
+    const source = markdownSourceFromFile(file);
+    if (source === null) {
+      return;
+    }
+    splitCjkAutolinks(tree, source);
+  };
+}
+
+function splitCjkAutolinks(parent: MarkdownNode, source: string): void {
+  if (!parent.children) {
+    return;
+  }
+
+  for (let index = 0; index < parent.children.length; index += 1) {
+    const child = parent.children[index];
+    if (!child) {
+      continue;
+    }
+    const split = splitLiteralAutolink(child, source);
+    if (split) {
+      parent.children.splice(index, 1, split.link, split.trailing);
+      index += 1;
+      continue;
+    }
+    splitCjkAutolinks(child, source);
+  }
+}
+
+function splitLiteralAutolink(
+  node: MarkdownNode,
+  source: string
+): SplitAutolink | null {
+  const textNode = node.children?.[0];
+  if (
+    node.type !== "link" ||
+    typeof node.url !== "string" ||
+    node.children?.length !== 1 ||
+    textNode?.type !== "text" ||
+    typeof textNode.value !== "string" ||
+    !node.position
+  ) {
+    return null;
+  }
+
+  const display = textNode.value;
+  const sourceStart = node.position.start.offset;
+  const sourceEnd = node.position.end.offset;
+  if (
+    sourceStart === undefined ||
+    sourceEnd === undefined ||
+    source.slice(sourceStart, sourceEnd) !== display
+  ) {
+    return null;
+  }
+
+  const boundaryIndex = display.search(CJK_SENTENCE_BOUNDARY);
+  if (boundaryIndex < 0) {
+    return null;
+  }
+
+  const displayUrl = display.slice(0, boundaryIndex);
+  const trailingText = display.slice(boundaryIndex);
+  if (!node.url.endsWith(trailingText)) {
+    return null;
+  }
+  const targetUrl = node.url.slice(0, -trailingText.length);
+  if (!isHttpUrl(targetUrl)) {
+    return null;
+  }
+
+  const boundaryPoint = advancePoint(node.position.start, displayUrl.length);
+  return {
+    link: {
+      ...node,
+      url: targetUrl,
+      position: {
+        start: node.position.start,
+        end: boundaryPoint
+      },
+      children: [
+        {
+          ...textNode,
+          value: displayUrl,
+          position: textNode.position
+            ? {
+                start: textNode.position.start,
+                end: boundaryPoint
+              }
+            : undefined
+        }
+      ]
+    },
+    trailing: {
+      type: "text",
+      value: trailingText,
+      position: {
+        start: boundaryPoint,
+        end: node.position.end
+      }
+    }
+  };
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function advancePoint(point: MarkdownPoint, characters: number): MarkdownPoint {
+  return {
+    line: point.line,
+    column: point.column + characters,
+    ...(point.offset === undefined ? {} : { offset: point.offset + characters })
+  };
+}
+
+function markdownSourceFromFile(file: unknown): string | null {
+  if (
+    typeof file !== "object" ||
+    file === null ||
+    !("value" in file) ||
+    typeof file.value !== "string"
+  ) {
+    return null;
+  }
+  return file.value;
+}
+
+function isMarkdownNode(value: unknown): value is MarkdownNode {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    typeof value.type === "string"
+  );
+}


### PR DESCRIPTION
## Summary

- repair CJK punctuation boundaries on GFM literal HTTP and www autolinks
- apply the same AST transform to settled and streaming AgentGUI Markdown
- preserve explicit Markdown links, angle autolinks, code, and percent-encoded punctuation
- document the literal-autolink punctuation contract and regression coverage

## Verification

- pnpm exec vitest run --environment jsdom shared/AgentMessageMarkdown.spec.tsx
- pnpm --filter @tutti-os/agent-gui typecheck
- pnpm exec oxlint packages/agent/gui/shared/remarkCjkAutolinkBoundary.ts packages/agent/gui/shared/AgentMessageMarkdown.tsx packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
- pnpm --filter @tutti-os/agent-gui test
- pnpm --filter @tutti-os/desktop build
- pre-push pnpm check:full: 18 tasks passed

## Fix Scope Justification

- Root cause: the upstream GFM literal-autolink tokenizer trims ASCII trailing punctuation but treats raw CJK sentence punctuation and following prose as part of the URL.
- Why can this not be fixed at a lower layer: changing provider text or the standards-compliant GFM dependency would either be unreliable or alter Markdown semantics globally. The post-parse literal-link transform is the narrowest shared AgentGUI boundary and can distinguish literal links from explicitly authored destinations using source positions.

## Fallback Three Questions

- Source: GFM literal-autolink AST nodes that include raw CJK sentence punctuation.
- Why can it not be fixed at that source: the dependency implements the GFM ASCII-oriented boundary set and does not expose a configurable Unicode boundary policy.
- Removal condition: remove the transform if the parser gains a configurable CJK boundary policy or AgentGUI adopts a parser that provides the same behavior natively.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: git commit -s.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->