### PR TITLE
feat(agent-gui): warn before Codex full access

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
@@ -105,6 +105,18 @@ test("standalone Agent opens files like Finder and routes links into the right s
   );
   assert.match(
     standaloneWindowSource,
+    /openExternalUrl: desktopApi\.host\.files\.openExternal/
+  );
+  assert.match(
+    standaloneLaunchRoutingSource,
+    /openBrowserUrl: async \(\{ url \}\) => \{[\s\S]*?await openExternalUrl\(url\);[\s\S]*?return true;/
+  );
+  assert.doesNotMatch(
+    standaloneLaunchRoutingSource,
+    /openBrowserUrl: \(\) => false/
+  );
+  assert.match(
+    standaloneWindowSource,
     /validateExists &&[\s\S]*?workspaceFileManagerService\.entryExists\([\s\S]*?showWorkspaceFileMissingToast\(\)/
   );
   assert.match(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -586,6 +586,7 @@ export function StandaloneAgentWindow({
     headerProvider,
     homeDirectory: desktopApi.platform.homeDirectory,
     hostWindowApi,
+    openExternalUrl: desktopApi.host.files.openExternal,
     openFileInSidebar,
     setActivation,
     setNodeState,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useStandaloneAgentLaunchRouting.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useStandaloneAgentLaunchRouting.ts
@@ -39,6 +39,7 @@ interface StandaloneAgentLaunchRoutingInput {
   headerProvider: DesktopAgentGUIProvider;
   homeDirectory: string;
   hostWindowApi: Pick<DesktopHostWindowApi, "openAgentWindow">;
+  openExternalUrl(url: string): Promise<void>;
   openFileInSidebar(
     path: string,
     validateExists?: boolean
@@ -58,6 +59,7 @@ export function useStandaloneAgentLaunchRouting({
   headerProvider,
   homeDirectory,
   hostWindowApi,
+  openExternalUrl,
   openFileInSidebar,
   setActivation,
   setNodeState,
@@ -164,13 +166,21 @@ export function useStandaloneAgentLaunchRouting({
           return true;
         },
         launchGroupChat: () => false,
-        openBrowserUrl: () => false,
+        openBrowserUrl: async ({ url }) => {
+          try {
+            await openExternalUrl(url);
+            return true;
+          } catch {
+            return false;
+          }
+        },
         workspaceId
       });
     },
     [
       homeDirectory,
       openFileInSidebar,
+      openExternalUrl,
       workspaceAgentActivityService,
       workspaceAppCenterService,
       workspaceId

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -496,6 +496,16 @@ When an empty composer has an `agentTargetId`, model, permission, reasoning,
 and speed options are target-scoped. Do not fall back to provider-level options
 for that target; a missing target-scoped option snapshot should remain a
 loading/missing state until the target options arrive.
+An explicit permission choice from the currently rendered target-scoped menu
+must also survive a concurrent options refresh. The settings action may use a
+runtime options snapshot to clean up older stored defaults, but it must not
+erase the user's current or just-selected permission merely because that
+snapshot lags the menu render. Unrelated patches such as clearing plan mode must
+not mutate permission as collateral cleanup; the daemon remains the authority
+that validates provider settings.
+Controlled permission selects may emit a transient empty value while closing or
+restoring focus. This is presentation state, not a user request to clear the
+permission default, and must be rejected at the selection boundary.
 Providers whose model catalog exists only after runtime session bootstrap must
 declare hidden live-model probing and its cache scope in their provider
 descriptor. The daemon may
@@ -3624,6 +3634,17 @@ selection carries retry intent instead of being silently dropped. That retry
 merges the unresolved in-flight patch, any queued patch, and the latest selection
 in that order, so the newest value wins without losing settings that the daemon
 may not have applied before the timeout.
+
+Provider-specific safety confirmation belongs at the composer setting selection
+boundary, before the settings change reaches the engine. Selecting Codex
+`full-access` opens a localized warning and must not dispatch a settings change
+until the user confirms; canceling preserves the previous selection. Confirmation
+still dispatches exactly one ordinary settings patch, so the engine and daemon do
+not acquire a second safety-dialog state machine. Other providers' modes continue
+to follow their provider contracts without inheriting this Codex-specific gate.
+The warning's safety-reference link uses the host link-action boundary. Workspace
+surfaces may route it to their Browser node; the standalone Agent window must fall
+back to the desktop external-browser bridge rather than silently dropping the URL.
 
 The daemon selects the mutation path from session liveness. A live session
 updates through its provider adapter. A historical session updates the durable

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { AgentPermissionModeDropdown } from "./AgentComposerSettingsMenus";
 import type { AgentGUIComposerSettingsVM } from "./model/agentGuiNodeTypes";
@@ -18,6 +19,7 @@ describe("AgentPermissionModeDropdown", () => {
     render(
       <AgentPermissionModeDropdown
         composerSettings={composerSettings()}
+        provider="claude-code"
         labels={{
           loadingOptions: "Loading permission modes",
           permissionLabel: "Permission mode"
@@ -40,7 +42,150 @@ describe("AgentPermissionModeDropdown", () => {
       planMode: false
     });
   });
+
+  it("requires confirmation before enabling Codex full access", async () => {
+    const onLinkAction = vi.fn();
+    const onSettingsChange = vi.fn();
+    render(
+      <AgentPermissionModeDropdown
+        composerSettings={composerSettingsWithFullAccess()}
+        onLinkAction={onLinkAction}
+        provider="codex"
+        labels={{
+          loadingOptions: "Loading permission modes",
+          permissionLabel: "Permission mode"
+        }}
+        onSettingsChange={onSettingsChange}
+      />
+    );
+
+    await selectPermissionOption("Full access");
+
+    expect(onSettingsChange).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("dialog", { name: "Enable full access?" })
+    ).toBeInTheDocument();
+
+    const learnMoreLink = screen.getByRole("link", { name: "Learn more" });
+    expect(learnMoreLink).toHaveClass("text-primary");
+    fireEvent.click(learnMoreLink);
+    expect(onLinkAction).toHaveBeenCalledWith({
+      source: "agent-full-access-warning",
+      type: "open-url",
+      url: "https://deploymentsafety.openai.com/gpt-5-6"
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Enable full access" }));
+
+    expect(onSettingsChange).toHaveBeenCalledTimes(1);
+    expect(onSettingsChange).toHaveBeenCalledWith({
+      permissionModeId: "full-access",
+      planMode: false
+    });
+  });
+
+  it("keeps full access selected after confirmation", async () => {
+    function Harness() {
+      const [permissionModeId, setPermissionModeId] = useState("read-only");
+      const settings = composerSettingsWithFullAccess();
+      settings.draftSettings.permissionModeId = permissionModeId;
+      settings.selectedPermissionModeValue = permissionModeId;
+      return (
+        <AgentPermissionModeDropdown
+          composerSettings={settings}
+          provider="codex"
+          labels={{
+            loadingOptions: "Loading permission modes",
+            permissionLabel: "Permission mode"
+          }}
+          onSettingsChange={(patch) => {
+            if (patch.permissionModeId) {
+              setPermissionModeId(patch.permissionModeId);
+            }
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+    await selectPermissionOption("Full access");
+    fireEvent.click(screen.getByRole("button", { name: "Enable full access" }));
+
+    expect(
+      screen.getByRole("combobox", {
+        hidden: true,
+        name: "Permission mode"
+      })
+    ).toHaveTextContent("Full access");
+  });
+
+  it("keeps the current Codex mode when full access is canceled", async () => {
+    const onSettingsChange = vi.fn();
+    render(
+      <AgentPermissionModeDropdown
+        composerSettings={composerSettingsWithFullAccess()}
+        provider="codex"
+        labels={{
+          loadingOptions: "Loading permission modes",
+          permissionLabel: "Permission mode"
+        }}
+        onSettingsChange={onSettingsChange}
+      />
+    );
+
+    await selectPermissionOption("Full access");
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onSettingsChange).not.toHaveBeenCalled();
+  });
+
+  it("does not gate another provider's full-access mode", async () => {
+    const onSettingsChange = vi.fn();
+    render(
+      <AgentPermissionModeDropdown
+        composerSettings={composerSettingsWithFullAccess()}
+        provider="opencode"
+        labels={{
+          loadingOptions: "Loading permission modes",
+          permissionLabel: "Permission mode"
+        }}
+        onSettingsChange={onSettingsChange}
+      />
+    );
+
+    await selectPermissionOption("Full access");
+
+    expect(onSettingsChange).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole("dialog", { name: "Enable full access?" })
+    ).not.toBeInTheDocument();
+  });
 });
+
+async function selectPermissionOption(optionName: string): Promise<void> {
+  fireEvent.pointerDown(
+    screen.getByRole("combobox", { name: "Permission mode" }),
+    { button: 0, ctrlKey: false, pointerType: "mouse" }
+  );
+  const option = await screen.findByRole("option", { name: optionName });
+  fireEvent.pointerDown(option, { button: 0, ctrlKey: false });
+  fireEvent.click(option);
+}
+
+function composerSettingsWithFullAccess(): AgentGUIComposerSettingsVM {
+  return {
+    ...composerSettings(),
+    availablePermissionModes: [
+      { label: "Ask for approval", value: "read-only" },
+      { label: "Full access", value: "full-access" }
+    ],
+    draftSettings: {
+      ...composerSettings().draftSettings,
+      permissionModeId: "read-only"
+    },
+    selectedPermissionModeValue: "read-only"
+  };
+}
 
 function composerSettings(): AgentGUIComposerSettingsVM {
   return {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.tsx
@@ -34,7 +34,13 @@ import type {
   AgentGUIComposerSettingOption,
   AgentGUIComposerSettingsVM
 } from "./model/agentGuiNodeTypes";
-import { permissionModeSelectionPatch } from "./model/composerModeSelection";
+import type { WorkspaceLinkAction } from "../../actions/workspaceLinkActions";
+import { AgentFullAccessWarningDialog } from "./AgentFullAccessWarningDialog";
+import {
+  normalizePermissionModeSelection,
+  permissionModeSelectionPatch
+} from "./model/composerModeSelection";
+import { requiresFullAccessSafetyConfirmation } from "./model/agentPermissionModeSafetyPolicy";
 import {
   buildComposerModelMenuModel,
   type AgentComposerSettingsMenuLabels,
@@ -52,13 +58,17 @@ export {
 export function AgentPermissionModeDropdown({
   composerSettings,
   disabled = false,
+  onLinkAction,
   previewMode = false,
+  provider,
   labels,
   onSettingsChange
 }: {
   composerSettings: AgentGUIComposerSettingsVM;
   disabled?: boolean;
+  onLinkAction?: (action: WorkspaceLinkAction) => void;
   previewMode?: boolean;
+  provider: string;
   labels: Pick<
     AgentComposerSettingsMenuLabels,
     "permissionLabel" | "loadingOptions"
@@ -70,6 +80,9 @@ export function AgentPermissionModeDropdown({
 }): React.JSX.Element {
   "use memo";
   const [isSelectOpen, setIsSelectOpen] = useState(false);
+  const [pendingFullAccessModeId, setPendingFullAccessModeId] = useState<
+    string | null
+  >(null);
   // While the daemon's composer options load, the permission options are empty
   // and the trigger is disabled; surface a hover hint so the user knows it is
   // still loading rather than permanently unavailable.
@@ -102,7 +115,7 @@ export function AgentPermissionModeDropdown({
   const triggerTone = selectDisabled
     ? undefined
     : resolvePermissionModeTriggerTone(selectedValue);
-  const applyPermissionModeId = (permissionModeId: string): void => {
+  const commitPermissionModeId = (permissionModeId: string): void => {
     if (selectDisabled) {
       return;
     }
@@ -112,6 +125,19 @@ export function AgentPermissionModeDropdown({
           composerSettings.planExclusiveWithPermissionMode === true
       })
     );
+  };
+  const applyPermissionModeId = (rawPermissionModeId: string): void => {
+    const permissionModeId =
+      normalizePermissionModeSelection(rawPermissionModeId);
+    if (!permissionModeId) {
+      return;
+    }
+    if (requiresFullAccessSafetyConfirmation(provider, permissionModeId)) {
+      setIsSelectOpen(false);
+      setPendingFullAccessModeId(permissionModeId);
+      return;
+    }
+    commitPermissionModeId(permissionModeId);
   };
   const trigger = (
     <button
@@ -156,60 +182,79 @@ export function AgentPermissionModeDropdown({
   );
 
   return (
-    <Select
-      open={isSelectOpen}
-      value={selectedValue ?? undefined}
-      disabled={selectDisabled}
-      onOpenChange={setIsSelectOpen}
-      onValueChange={applyPermissionModeId}
-    >
-      {isLoading ? (
-        // The trigger is disabled while loading, so pointer events never reach
-        // it. Target the tooltip at a focusable wrapper span (Radix's pattern
-        // for disabled triggers) so hover/focus reliably surfaces the hint.
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex" tabIndex={0}>
-              {selectTrigger}
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="top">{labels.loadingOptions}</TooltipContent>
-        </Tooltip>
-      ) : (
-        selectTrigger
-      )}
-      {isSelectOpen ? (
-        <SelectContent
-          align="end"
-          side="top"
-          sideOffset={4}
-          collisionPadding={16}
-          className={cn(
-            styles.composerMenuContent,
-            "w-max min-w-[220px] max-w-[calc(100vw-32px)] data-[side=top]:!translate-y-0"
-          )}
-        >
-          {permissionOptions.map((option) => (
-            <SelectItem
-              key={option.value}
-              value={option.value}
-              disabled={selectDisabled}
-              className={cn(styles.composerMenuItem, "group/composer-option")}
-            >
-              <span className="flex min-w-0 items-center gap-1.5">
-                <span className="min-w-0 truncate">{option.label}</span>
-                {option.description ? (
-                  <ComposerOptionInfoTooltip
-                    description={option.description}
-                    tooltipsEnabled={!previewMode}
-                  />
-                ) : null}
+    <Fragment>
+      <Select
+        open={isSelectOpen}
+        value={selectedValue ?? undefined}
+        disabled={selectDisabled}
+        onOpenChange={setIsSelectOpen}
+        onValueChange={applyPermissionModeId}
+      >
+        {isLoading ? (
+          // The trigger is disabled while loading, so pointer events never reach
+          // it. Target the tooltip at a focusable wrapper span (Radix's pattern
+          // for disabled triggers) so hover/focus reliably surfaces the hint.
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex" tabIndex={0}>
+                {selectTrigger}
               </span>
-            </SelectItem>
-          ))}
-        </SelectContent>
-      ) : null}
-    </Select>
+            </TooltipTrigger>
+            <TooltipContent side="top">{labels.loadingOptions}</TooltipContent>
+          </Tooltip>
+        ) : (
+          selectTrigger
+        )}
+        {isSelectOpen ? (
+          <SelectContent
+            align="end"
+            side="top"
+            sideOffset={4}
+            collisionPadding={16}
+            className={cn(
+              styles.composerMenuContent,
+              "w-max min-w-[220px] max-w-[calc(100vw-32px)] data-[side=top]:!translate-y-0"
+            )}
+          >
+            {permissionOptions.map((option) => (
+              <SelectItem
+                key={option.value}
+                value={option.value}
+                disabled={selectDisabled}
+                className={cn(styles.composerMenuItem, "group/composer-option")}
+              >
+                <span className="flex min-w-0 items-center gap-1.5">
+                  <span className="min-w-0 truncate">{option.label}</span>
+                  {option.description ? (
+                    <ComposerOptionInfoTooltip
+                      description={option.description}
+                      tooltipsEnabled={!previewMode}
+                    />
+                  ) : null}
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        ) : null}
+      </Select>
+      <AgentFullAccessWarningDialog
+        onConfirm={() => {
+          if (!pendingFullAccessModeId) {
+            return;
+          }
+          const permissionModeId = pendingFullAccessModeId;
+          setPendingFullAccessModeId(null);
+          commitPermissionModeId(permissionModeId);
+        }}
+        onLinkAction={onLinkAction}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingFullAccessModeId(null);
+          }
+        }}
+        open={pendingFullAccessModeId !== null}
+      />
+    </Fragment>
   );
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFullAccessWarningDialog.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFullAccessWarningDialog.tsx
@@ -1,0 +1,124 @@
+import { FolderOpen, Globe2, Terminal, TriangleAlert } from "lucide-react";
+import { ConfirmationDialog } from "@tutti-os/ui-system";
+import { useTranslation } from "../../i18n/index";
+import type { WorkspaceLinkAction } from "../../actions/workspaceLinkActions";
+
+export const CODEX_FULL_ACCESS_SAFETY_URL =
+  "https://deploymentsafety.openai.com/gpt-5-6";
+
+export function AgentFullAccessWarningDialog({
+  onConfirm,
+  onLinkAction,
+  onOpenChange,
+  open
+}: {
+  onConfirm: () => void;
+  onLinkAction?: (action: WorkspaceLinkAction) => void;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+}): React.JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <ConfirmationDialog
+      cancelLabel={t("agentHost.agentGui.fullAccessWarning.cancel")}
+      className="nodrag tsh-desktop-no-drag gap-4 [-webkit-app-region:no-drag] sm:max-w-[520px]"
+      confirmLabel={t("agentHost.agentGui.fullAccessWarning.confirm")}
+      onConfirm={onConfirm}
+      onOpenChange={onOpenChange}
+      open={open}
+      tone="destructive"
+      title={
+        <span className="flex items-center gap-2.5 text-[18px]">
+          <TriangleAlert
+            aria-hidden="true"
+            className="size-5 shrink-0 text-[var(--state-danger)]"
+          />
+          {t("agentHost.agentGui.fullAccessWarning.title")}
+        </span>
+      }
+      description={t("agentHost.agentGui.fullAccessWarning.description")}
+    >
+      <div className="overflow-hidden rounded-[12px] bg-[var(--transparency-subtle)] px-4">
+        <FullAccessCapabilityRow
+          description={t(
+            "agentHost.agentGui.fullAccessWarning.filesDescription"
+          )}
+          icon={<FolderOpen aria-hidden="true" />}
+          title={t("agentHost.agentGui.fullAccessWarning.filesTitle")}
+        />
+        <FullAccessCapabilityRow
+          description={t(
+            "agentHost.agentGui.fullAccessWarning.commandsDescription"
+          )}
+          icon={<Terminal aria-hidden="true" />}
+          title={t("agentHost.agentGui.fullAccessWarning.commandsTitle")}
+        />
+        <FullAccessCapabilityRow
+          description={t(
+            "agentHost.agentGui.fullAccessWarning.internetDescription"
+          )}
+          icon={<Globe2 aria-hidden="true" />}
+          last
+          title={t("agentHost.agentGui.fullAccessWarning.internetTitle")}
+        />
+      </div>
+      <p className="m-0 leading-[1.45] text-[var(--text-secondary)]">
+        {t("agentHost.agentGui.fullAccessWarning.riskDescription")}{" "}
+        <a
+          className="text-primary underline-offset-2 hover:underline"
+          href={CODEX_FULL_ACCESS_SAFETY_URL}
+          rel="noreferrer"
+          target="_blank"
+          onClick={(event) => {
+            if (!onLinkAction) {
+              return;
+            }
+            event.preventDefault();
+            onLinkAction({
+              source: "agent-full-access-warning",
+              type: "open-url",
+              url: CODEX_FULL_ACCESS_SAFETY_URL
+            });
+          }}
+        >
+          {t("agentHost.agentGui.fullAccessWarning.learnMore")}
+        </a>
+      </p>
+    </ConfirmationDialog>
+  );
+}
+
+function FullAccessCapabilityRow({
+  description,
+  icon,
+  last = false,
+  title
+}: {
+  description: string;
+  icon: React.ReactNode;
+  last?: boolean;
+  title: string;
+}): React.JSX.Element {
+  return (
+    <div
+      className={
+        last
+          ? "flex items-start gap-3 py-3"
+          : "flex items-start gap-3 border-b border-[var(--border-1)] py-3"
+      }
+    >
+      <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center text-[var(--text-secondary)] [&>svg]:size-5">
+        {icon}
+      </span>
+      <span className="min-w-0">
+        <span className="block font-medium text-[var(--text-primary)]">
+          {title}
+        </span>
+        <span className="mt-0.5 block text-[var(--text-secondary)]">
+          {description}
+        </span>
+      </span>
+    </div>
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
@@ -102,6 +102,7 @@ interface Props {
 
 export function AgentComposerView(input: Props): React.JSX.Element {
   const {
+    provider,
     slashStatus = null,
     usage = null,
     draftContent,
@@ -130,6 +131,7 @@ export function AgentComposerView(input: Props): React.JSX.Element {
     selectProjectDirectory,
     onProjectPathChange = () => {},
     onSettingsChange,
+    onLinkAction,
     onSubmit,
     onProviderSelect,
     onHandoffConversation,
@@ -560,6 +562,7 @@ export function AgentComposerView(input: Props): React.JSX.Element {
           </Popover>
           <ComposerFooter
             labels={labels}
+            provider={provider}
             composerSettings={composerSettings}
             usage={usage}
             previewMode={previewMode}
@@ -588,6 +591,7 @@ export function AgentComposerView(input: Props): React.JSX.Element {
             selectedProviderLabel={selectedProviderLabel}
             providerMenuTargets={providerMenuTargets}
             onProviderSelect={onProviderSelect}
+            onLinkAction={onLinkAction}
             onRequestWorkspaceReferences={onRequestWorkspaceReferences}
             onWorkspaceReferencePicker={handleWorkspaceReferencePicker}
             onMentionPaletteButton={handleMentionPaletteButton}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
@@ -37,6 +37,7 @@ import {
 
 interface Props {
   labels: AgentComposerProps["labels"];
+  provider: AgentComposerProps["provider"];
   composerSettings: AgentComposerProps["composerSettings"];
   usage: AgentComposerUsage | null;
   previewMode: boolean;
@@ -65,6 +66,7 @@ interface Props {
   selectedProviderLabel: string;
   providerMenuTargets: readonly AgentGUIAgentTarget[];
   onProviderSelect: AgentComposerProps["onProviderSelect"];
+  onLinkAction: AgentComposerProps["onLinkAction"];
   onRequestWorkspaceReferences: AgentComposerProps["onRequestWorkspaceReferences"];
   onWorkspaceReferencePicker: () => void;
   onMentionPaletteButton: () => void;
@@ -75,6 +77,7 @@ interface Props {
 
 export function ComposerFooter({
   labels,
+  provider,
   composerSettings,
   usage,
   previewMode,
@@ -103,6 +106,7 @@ export function ComposerFooter({
   selectedProviderLabel,
   providerMenuTargets,
   onProviderSelect,
+  onLinkAction,
   onRequestWorkspaceReferences,
   onWorkspaceReferencePicker: handleWorkspaceReferencePicker,
   onMentionPaletteButton: handleMentionPaletteButton,
@@ -457,7 +461,9 @@ export function ComposerFooter({
             <AgentPermissionModeDropdown
               composerSettings={composerSettings}
               disabled={permissionModeControlsDisabled}
+              onLinkAction={onLinkAction}
               previewMode={previewMode}
+              provider={provider}
               labels={{
                 permissionLabel: labels.permissionLabel,
                 loadingOptions: labels.loadingOptions

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.spec.tsx
@@ -12,6 +12,113 @@ import type { useAgentGUIActivation } from "./useAgentGUIActivation";
 import { useAgentGUIComposerSettingsActions } from "./useAgentGUIComposerSettingsActions";
 
 describe("useAgentGUIComposerSettingsActions", () => {
+  it("preserves a home permission across explicit and unrelated patches with stale options", () => {
+    const sessionEngine = createAgentSessionEngine({
+      clock: { nowUnixMs: () => 1 },
+      commandPort: { execute: vi.fn() },
+      identity: { origin: "test", workspaceId: "workspace-1" },
+      scheduler: { schedule: () => ({ cancel() {} }) }
+    });
+    const data: AgentGUINodeData = {
+      agentTargetId: "local:codex",
+      lastActiveAgentSessionId: null,
+      provider: "codex",
+      composerOverridesByAgentTargetId: {
+        "local:codex": { permissionModeId: "auto" }
+      }
+    };
+    const onDataChange = vi.fn();
+    const onRememberComposerDefaults = vi.fn();
+    const draftSettingsBySessionIdRef: {
+      current: Record<string, AgentSessionComposerSettings>;
+    } = { current: {} };
+    const target = {
+      agentTargetId: "local:codex",
+      data,
+      provider: "codex" as const,
+      targetId: "local:codex"
+    };
+    const rendered = renderHook(() =>
+      useAgentGUIComposerSettingsActions({
+        activation: {
+          stateFor: vi.fn(() => "inactive" as const)
+        } as unknown as ReturnType<typeof useAgentGUIActivation>,
+        activeCanonicalComposerSettings: {},
+        activeConversationIdRef: { current: null },
+        activeEngineActiveTurn: null,
+        agentActivityRuntime: {
+          getSnapshot: () => ({
+            composerOptionsByTargetKey: {
+              "local:codex": {
+                behavior: { refreshModelOptionsAfterSettings: false },
+                models: [],
+                permissionConfig: {
+                  configurable: true,
+                  defaultValue: "auto",
+                  modes: [{ id: "auto", label: "Approve for me" }]
+                },
+                reasoningConfigurable: false,
+                reasoningEfforts: [],
+                speeds: []
+              }
+            }
+          }),
+          trackDraftComposerSettingsChange: vi.fn()
+        } as unknown as AgentActivityRuntime,
+        composerSupportPermissionModeChangeDeferred: false,
+        dataRef: { current: data },
+        defaultReasoningEffort: null,
+        draftSettingsBySessionIdRef,
+        loadDraftComposerOptions: vi.fn(),
+        onDataChangeRef: { current: onDataChange },
+        onRememberComposerDefaultsRef: {
+          current: onRememberComposerDefaults
+        },
+        onShowMessageRef: { current: vi.fn() },
+        selectedComposerTargetDataRef: { current: target },
+        sessionEngine,
+        setDraftSettingsBySessionId: vi.fn(),
+        updateComposerSettingsRef: { current: vi.fn() },
+        workspaceId: "workspace-1"
+      })
+    );
+
+    act(() => {
+      rendered.result.current.updateComposerSettings({
+        permissionModeId: "full-access"
+      });
+    });
+
+    expect(
+      draftSettingsBySessionIdRef.current[
+        "__agent_gui_node_defaults__:target:local:codex"
+      ]
+    ).toMatchObject({ permissionModeId: "full-access" });
+    expect(onRememberComposerDefaults).toHaveBeenCalledWith({
+      agentTargetId: "local:codex",
+      provider: "codex",
+      defaults: { permissionModeId: "full-access" }
+    });
+    const updateNode = onDataChange.mock.calls[0]?.[0] as
+      | ((current: AgentGUINodeData) => AgentGUINodeData)
+      | undefined;
+    expect(updateNode?.(data)).toMatchObject({
+      composerOverridesByAgentTargetId: {
+        "local:codex": { permissionModeId: "full-access" }
+      }
+    });
+
+    act(() => {
+      rendered.result.current.updateComposerSettings({ planMode: false });
+    });
+
+    expect(
+      draftSettingsBySessionIdRef.current[
+        "__agent_gui_node_defaults__:target:local:codex"
+      ]
+    ).toMatchObject({ permissionModeId: "full-access" });
+  });
+
   it("retries an unknown active-session update and remembers the explicit selection", () => {
     const execute = vi.fn(() => new Promise<unknown>(() => undefined));
     const sessionEngine = createAgentSessionEngine({

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.ts
@@ -133,11 +133,25 @@ export function useAgentGUIComposerSettingsActions(
           snapshot: agentActivityRuntime.getSnapshot(workspaceId),
           target: targetData
         });
-        const targetSafeMerged = sanitizeComposerSettingsForTarget({
+        const sanitizedMerged = sanitizeComposerSettingsForTarget({
           settings: merged,
           target: targetData,
           options: snapshotComposerOptions
         });
+        // The runtime snapshot read here can lag the rendered target options
+        // while a refresh is in flight. It may clean up other stored defaults,
+        // but it must not erase the current permission as collateral damage
+        // from an unrelated patch (for example, clearing plan mode), nor erase
+        // an explicit permission selection before the daemon performs
+        // authoritative provider validation.
+        const targetSafeMerged = {
+          ...sanitizedMerged,
+          permissionModeId: normalizePermissionModeId(
+            supportedNextSettings.permissionModeId === undefined
+              ? merged.permissionModeId
+              : supportedNextSettings.permissionModeId
+          )
+        };
         draftSettingsBySessionIdRef.current = {
           ...draftSettingsBySessionIdRef.current,
           [defaultDraftKey]: targetSafeMerged

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentPermissionModeSafetyPolicy.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentPermissionModeSafetyPolicy.ts
@@ -1,0 +1,16 @@
+const fullAccessConfirmationModesByProvider: Readonly<
+  Record<string, readonly string[]>
+> = {
+  codex: ["full-access"]
+};
+
+export function requiresFullAccessSafetyConfirmation(
+  provider: string,
+  permissionModeId: string
+): boolean {
+  return (
+    fullAccessConfirmationModesByProvider[provider]?.includes(
+      permissionModeId
+    ) ?? false
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.spec.ts
@@ -1,9 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
+  normalizePermissionModeSelection,
   permissionModeSelectionPatch,
   resolvePermissionModeControlsDisabled,
   shouldRetrySessionSettingsUpdate
 } from "./composerModeSelection";
+
+describe("normalizePermissionModeSelection", () => {
+  it("rejects transient empty select values instead of clearing permission", () => {
+    expect(normalizePermissionModeSelection("")).toBeNull();
+    expect(normalizePermissionModeSelection("   ")).toBeNull();
+  });
+
+  it("normalizes a real permission mode id", () => {
+    expect(normalizePermissionModeSelection(" full-access ")).toBe(
+      "full-access"
+    );
+  });
+});
 
 describe("permissionModeSelectionPatch", () => {
   it("clears plan mode for mutually-exclusive providers (claude-code)", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.ts
@@ -1,4 +1,17 @@
 /**
+ * Normalizes a value emitted by the permission select.
+ *
+ * Radix can emit an empty value while a controlled select closes and restores
+ * focus. That is transient UI state, not a user request to clear permissions.
+ */
+export function normalizePermissionModeSelection(
+  permissionModeId: string
+): string | null {
+  const normalized = permissionModeId.trim();
+  return normalized || null;
+}
+
+/**
  * Maps a permission-mode dropdown selection onto a settings patch.
  *
  * Plan mode is no longer a dropdown option — it is an independent toggle

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -58,6 +58,23 @@ export const enAgentGui = {
   permissionModeReadOnly: "Ask for approval",
   permissionModeAuto: "Approve for me",
   permissionModeFullAccess: "Full access",
+  fullAccessWarning: {
+    title: "Enable full access?",
+    description:
+      "Full access lets Codex act on your computer without asking for approval.",
+    filesTitle: "Files and folders",
+    filesDescription:
+      "Read, create, modify, or delete files anywhere on this computer.",
+    commandsTitle: "Terminal commands",
+    commandsDescription: "Run commands and change system settings.",
+    internetTitle: "Internet access",
+    internetDescription: "Access websites and send data over the internet.",
+    riskDescription:
+      "Recent Codex releases, especially when using GPT-5.6 models, may go beyond your intent and accidentally delete or overwrite files. Only continue if you understand and accept this risk.",
+    learnMore: "Learn more",
+    cancel: "Cancel",
+    confirm: "Enable full access"
+  },
   permissionSemantics: {
     "ask-before-write": {
       label: "Ask for approval",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -56,6 +56,21 @@ export const zhCNAgentGui = {
   permissionModeReadOnly: "请求批准",
   permissionModeAuto: "替我审批",
   permissionModeFullAccess: "完全访问权限",
+  fullAccessWarning: {
+    title: "确定启用完全访问权限吗？",
+    description: "完全访问权限允许 Codex 无需你的批准即可操作这台电脑。",
+    filesTitle: "文件和文件夹",
+    filesDescription: "读取、创建、修改或删除这台电脑上任意位置的文件。",
+    commandsTitle: "终端命令",
+    commandsDescription: "运行命令并更改系统设置。",
+    internetTitle: "互联网访问",
+    internetDescription: "访问网站并通过互联网发送数据。",
+    riskDescription:
+      "近期版本的 Codex，尤其在使用 GPT-5.6 系列模型时，可能会超出你的意图，误删或覆盖文件。仅在你理解并接受此风险时继续。",
+    learnMore: "了解详情",
+    cancel: "取消",
+    confirm: "启用完全访问权限"
+  },
   permissionSemantics: {
     "ask-before-write": {
       label: "请求批准",


### PR DESCRIPTION
## Summary

- show a localized safety confirmation before Codex switches to `full-access`
- explain file, terminal, and internet capabilities and link to the GPT-5.6 deployment safety guidance
- route the safety link through the workspace host, including an external-browser fallback for standalone Agent windows
- preserve confirmed permission selections across transient empty select events and stale composer-option snapshots

## Why

Codex full access can read, modify, and delete files without per-action approval. Recent Codex and GPT-5.6 behavior warrants an explicit warning so users understand the risk and can cancel before enabling the mode.

During validation, confirmed selections could also appear to remain on the automatic approval mode. The draft settings path sanitized against a runtime options snapshot that could lag the rendered menu, and transient controlled-select values could clear the permission. This change rejects transient empty values and keeps the current or explicitly selected permission until the daemon performs authoritative validation.

## User impact

Selecting Codex “Full access” now opens a warning dialog. Cancel leaves the existing mode unchanged; confirm applies and persists full access. The “Learn more” link opens the deployment safety page.

Other providers and non-full-access Codex modes keep their existing behavior.

## Validation

- `pnpm check:full` — 18 tasks passed
- `pnpm check:changed` — 11 lanes passed
- AgentGUI focused tests — 20 passed
- standalone Agent routing tests — 16 passed
- `pnpm check:agent-activity-runtime-boundaries`
- manual Dev verification: confirmed selection survived composer-option refresh, database persistence, and renderer reload

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches permission-mode UX and composer draft persistence (safety-sensitive), but changes are gated to Codex full-access with confirm/cancel and narrower permission preservation logic.
> 
> **Overview**
> Adds a **Codex-only confirmation** before applying `full-access` in the permission dropdown: a localized `AgentFullAccessWarningDialog` blocks the settings patch until the user confirms; cancel leaves the prior mode unchanged. Other providers’ full-access modes are unchanged.
> 
> **Learn more** routes through `onLinkAction` (`open-url`); standalone Agent windows now implement `openBrowserUrl` via `desktopApi.host.files.openExternal` instead of returning false.
> 
> Composer settings handling **no longer drops permission** when the runtime options snapshot is stale or on unrelated patches (e.g. `planMode: false`); empty Radix select values are ignored via `normalizePermissionModeSelection`. Architecture docs describe the selection boundary and external-link fallback.
> 
> EN/zh-CN strings cover the warning copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45a9343f25471bc54b000c6dce92ce73f6c9b1da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->