### PR TITLE
fix(desktop): skip update checks when remembering composer defaults

### DIFF
--- a/apps/desktop/src/main/desktopHostPreferencesEventStream.test.ts
+++ b/apps/desktop/src/main/desktopHostPreferencesEventStream.test.ts
@@ -15,6 +15,7 @@ test("desktop host preferences follows authoritative preference events", async (
   const preferences = createHostPreferencesState();
   const appliedThemeSources: DesktopThemeSource[] = [];
   let backgroundSyncs = 0;
+  const configureCalls: Array<{ channel: string; policy: string }> = [];
 
   const subscription = connectDesktopHostPreferencesEventStream({
     applyThemeSource(source) {
@@ -25,6 +26,29 @@ test("desktop host preferences follows authoritative preference events", async (
     preferences,
     syncWindowBackgroundColors() {
       backgroundSyncs += 1;
+    },
+    updateService: {
+      async configure(input) {
+        configureCalls.push({
+          channel: input.channel ?? "stable",
+          policy: input.policy
+        });
+        return {
+          channel: input.channel ?? "stable",
+          checkedAt: null,
+          currentVersion: "0.0.0",
+          downloadPercent: null,
+          downloadedBytes: null,
+          latestVersion: null,
+          message: null,
+          policy: input.policy,
+          releaseDate: null,
+          releaseName: null,
+          releaseNotesUrl: null,
+          status: "idle",
+          totalBytes: null
+        };
+      }
     }
   });
 
@@ -68,11 +92,17 @@ test("desktop host preferences follows authoritative preference events", async (
   assert.equal(preferences.getThemeSource(), "dark");
   assert.deepEqual(appliedThemeSources, ["dark"]);
   assert.equal(backgroundSyncs, 1);
+  // Channel/policy unchanged from host defaults — do not reconfigure updater.
+  assert.deepEqual(configureCalls, []);
 
   eventStreamClient.emitDesktopPreferencesUpdated({
     initialized: true,
     preferences: {
-      agentComposerDefaultsByProvider: {},
+      agentComposerDefaultsByProvider: {
+        "claude-code": {
+          permissionModeId: "bypassPermissions"
+        }
+      },
       agentGuiConversationRailCollapsedByProvider: {
         codex: true
       },
@@ -106,6 +136,43 @@ test("desktop host preferences follows authoritative preference events", async (
   assert.equal(preferences.getThemeSource(), "dark");
   assert.deepEqual(appliedThemeSources, ["dark"]);
   assert.equal(backgroundSyncs, 1);
+  // Composer-default / rail changes alone must not trigger update checks.
+  assert.deepEqual(configureCalls, []);
+
+  eventStreamClient.emitDesktopPreferencesUpdated({
+    initialized: true,
+    preferences: {
+      agentComposerDefaultsByProvider: {
+        "claude-code": {
+          permissionModeId: "bypassPermissions"
+        }
+      },
+      agentGuiConversationRailCollapsedByProvider: {
+        codex: true
+      },
+      agentConversationDetailMode: "coding",
+      agentDockLayout: "unified",
+      appCatalogChannel: "production",
+      browserUseConnectionMode: "isolated",
+      defaultAgentProvider: "codex",
+      featureFlags: {},
+      workbenchShortcuts: defaultDesktopWorkbenchShortcuts,
+      dockIconStyle: "default",
+      dockPlacement: "bottom",
+      fileDefaultOpenersByExtension: { html: "defaultBrowser" },
+      locale: "en",
+      minimizeAnimation: "scale",
+      sleepPreventionMode: "never",
+      showAppDeveloperSources: false,
+      themeSource: "dark",
+      updateChannel: "rc",
+      updatePolicy: "auto"
+    }
+  });
+
+  assert.deepEqual(configureCalls, [{ channel: "rc", policy: "auto" }]);
+  assert.equal(preferences.getUpdateChannel(), "rc");
+  assert.equal(preferences.getUpdatePolicy(), "auto");
 
   subscription.dispose();
   assert.equal(eventStreamClient.disposeCalls, 1);

--- a/apps/desktop/src/main/desktopHostPreferencesEventStream.ts
+++ b/apps/desktop/src/main/desktopHostPreferencesEventStream.ts
@@ -41,6 +41,12 @@ export function connectDesktopHostPreferencesEventStream(
       const nextPreferences = event.payload.preferences;
       const themeSourceChanged =
         deps.preferences.getThemeSource() !== nextPreferences.themeSource;
+      // Composer defaults and other non-update prefs also publish this event.
+      // Only reconfigure the updater when channel/policy actually change, so
+      // permission-mode switches do not flash "Checking for updates".
+      const updatePreferencesChanged =
+        deps.preferences.getUpdateChannel() !== nextPreferences.updateChannel ||
+        deps.preferences.getUpdatePolicy() !== nextPreferences.updatePolicy;
 
       deps.preferences.sync({
         agentComposerDefaultsByProvider:
@@ -65,16 +71,18 @@ export function connectDesktopHostPreferencesEventStream(
         workbenchWindowSnapping: nextPreferences.workbenchWindowSnapping
       });
 
-      void deps.updateService
-        ?.configure({
-          channel: nextPreferences.updateChannel,
-          policy: nextPreferences.updatePolicy
-        })
-        .catch((error: unknown) => {
-          deps.logger.warn("failed to apply desktop update preferences", {
-            error: error instanceof Error ? error.message : String(error)
+      if (updatePreferencesChanged) {
+        void deps.updateService
+          ?.configure({
+            channel: nextPreferences.updateChannel,
+            policy: nextPreferences.updatePolicy
+          })
+          .catch((error: unknown) => {
+            deps.logger.warn("failed to apply desktop update preferences", {
+              error: error instanceof Error ? error.message : String(error)
+            });
           });
-        });
+      }
 
       if (themeSourceChanged) {
         deps.applyThemeSource(nextPreferences.themeSource);

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -33,6 +33,7 @@ Electron startup, daemon supervision, macOS packaging, updates, and performance 
 - [macOS Gatekeeper dialogs appear during Codex provider probing](./desktop-release.md#macos-gatekeeper-dialogs-appear-during-codex-provider-probing)
 - [Electron main/preload crashes on a workspace package `.ts` export](./desktop-release.md#electron-mainpreload-crashes-on-a-workspace-package-ts-export)
 - [Desktop restart leaves an orphan tuttid](./desktop-release.md#desktop-restart-leaves-an-orphan-tuttid)
+- [Switching agent permission mode flashes Checking for updates](./desktop-release.md#switching-agent-permission-mode-flashes-checking-for-updates)
 - [App update diagnostics flood with identical download progress states](./desktop-release.md#app-update-diagnostics-flood-with-identical-download-progress-states)
 - [macOS in-app update closes Tutti but does not install the new version](./desktop-release.md#macos-in-app-update-closes-tutti-but-does-not-install-the-new-version)
 - [Desktop Performance trace export runs out of memory](./desktop-release.md#desktop-performance-trace-export-runs-out-of-memory)

--- a/docs/conventions/troubleshooting/desktop-release.md
+++ b/docs/conventions/troubleshooting/desktop-release.md
@@ -298,6 +298,38 @@ information is not available yet`, but `ps` or `lsof` still shows an older
   [tuttidManager.ts](../../../apps/desktop/src/main/daemon/tuttidManager.ts)
   [main.go](../../../services/tuttid/main.go)
 
+### Switching agent permission mode flashes Checking for updates
+
+- Symptom:
+  In a packaged build, changing composer permission mode (or other remembered
+  composer defaults) briefly shows the top-right **Checking for updates** /
+  **正在检查更新** badge. Rapid switches may spam updater checks in
+  `tutti-desktop.log` (`Checking for update` next to
+  `agent.gui.composer_defaults.remembered`). Local unpackaged dev usually hides
+  this because update checks are unsupported unless `TUTTI_APP_UPDATE_DEV` is set.
+- Quick checks:
+  Confirm packaged/`supportsUpdates`. Correlate
+  `agent.gui.composer_defaults.remembered` with
+  `checking for application updates` / `application updater static feed
+configured`. Verify `updateChannel` / `updatePolicy` did not change.
+- Root cause:
+  Remembering composer defaults writes desktop preferences and emits
+  `preferences.desktop.updated`. The main-process host preferences stream used
+  to call `updateService.configure()` on every preferences event; `configure()`
+  always runs a background update check and surfaces the checking status.
+- Fix:
+  Only call `updateService.configure()` when `updateChannel` or `updatePolicy`
+  actually changed. Other preference syncs (composer defaults, locale, rail,
+  theme) must not reconfigure the updater.
+- Validation:
+  In a packaged build, switch permission mode and confirm the update badge does
+  not appear and desktop logs do not emit a new update check. Cover
+  composer-default vs channel/policy changes in
+  `desktopHostPreferencesEventStream` tests.
+- References:
+  [desktopHostPreferencesEventStream.ts](../../../apps/desktop/src/main/desktopHostPreferencesEventStream.ts)
+  [appUpdateService.ts](../../../apps/desktop/src/main/update/appUpdateService.ts)
+
 ### App update diagnostics flood with identical download progress states
 
 - Symptom:


### PR DESCRIPTION
## Summary
- Stop calling `updateService.configure()` on every `preferences.desktop.updated` event; only reconfigure when `updateChannel` or `updatePolicy` actually change.
- Fixes packaged builds flashing top-right **Checking for updates** / **正在检查更新** when switching agent permission mode (composer defaults are remembered via preferences).
- Documents the trap in desktop-release troubleshooting.

## Test plan
- [x] `node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/main/desktopHostPreferencesEventStream.test.ts`
- [ ] Packaged build: switch Claude Code / Codex permission mode during a conversation and confirm the update badge does not appear
- [ ] Packaged build: change Settings update channel/policy and confirm an update check still runs
- [ ] Confirm `tutti-desktop.log` no longer pairs `composer_defaults.remembered` with `Checking for update`


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->