### PR TITLE
fix(agent): reduce diagnostic log churn

### DIFF
--- a/apps/desktop/src/main/ipc/computerUse.test.ts
+++ b/apps/desktop/src/main/ipc/computerUse.test.ts
@@ -116,6 +116,8 @@ test("computer use status checks emit diagnostic logs", () => {
   );
   assert.match(computerUseSource, /computer use permission status checked/);
   assert.match(computerUseSource, /summarizeComputerUseStatusForLog/);
+  assert.match(computerUseSource, /lastComputerUseStatusLogSignature/);
+  assert.match(computerUseSource, /logger\.debug\.bind\(logger\)/);
 });
 
 test("computer use status checks coalesce concurrent subprocess spawns", () => {

--- a/apps/desktop/src/main/ipc/computerUse.ts
+++ b/apps/desktop/src/main/ipc/computerUse.ts
@@ -55,6 +55,7 @@ let computerUseGrantActionState: ComputerUseGrantActionState | null = null;
 let computerUseRestartPromise: Promise<DesktopComputerUseRestartDriverResult> | null =
   null;
 let checkStatusInFlight: Promise<DesktopComputerUseStatus> | null = null;
+let lastComputerUseStatusLogSignature: string | null = null;
 
 function cuaDriverExecutableCandidates(): string[] {
   const candidates = [
@@ -270,6 +271,35 @@ function summarizeComputerUseStatusForLog(
   };
 }
 
+function logComputerUseStatusChecked(
+  status: DesktopComputerUseStatus,
+  level: "info" | "warn",
+  fields: Record<string, unknown>
+): void {
+  const statusFields = summarizeComputerUseStatusForLog(status);
+  const signature = [
+    status.installed ? "installed" : "not-installed",
+    status.authorization,
+    status.reason ?? "",
+    status.permissions?.accessibility ?? "",
+    status.permissions?.screenRecording ?? "",
+    status.permissions?.screenRecordingCapturable ?? "",
+    status.permissions?.source ?? ""
+  ].join(":");
+  const logger = getDesktopLogger();
+  const log =
+    signature === lastComputerUseStatusLogSignature
+      ? logger.debug.bind(logger)
+      : level === "warn"
+        ? logger.warn.bind(logger)
+        : logger.info.bind(logger);
+  lastComputerUseStatusLogSignature = signature;
+  log("computer use permission status checked", {
+    ...statusFields,
+    ...fields
+  });
+}
+
 function truncateComputerUseDiagnosticMessage(message: string): string {
   if (message.length <= COMPUTER_USE_DIAGNOSTIC_MESSAGE_MAX_LENGTH) {
     return message;
@@ -374,8 +404,7 @@ async function checkCuaDriverStatus(): Promise<DesktopComputerUseStatus> {
       installed: false,
       permissions: null
     });
-    getDesktopLogger().info("computer use permission status checked", {
-      ...summarizeComputerUseStatusForLog(status),
+    logComputerUseStatusChecked(status, "info", {
       elapsedMs: Date.now() - startedAtUnixMs
     });
     return status;
@@ -389,15 +418,14 @@ async function checkCuaDriverStatus(): Promise<DesktopComputerUseStatus> {
       reason: "status-command-failed",
       diagnosticMessage: "cua-driver executable was not found."
     });
-    getDesktopLogger().warn("computer use permission status checked", {
-      ...summarizeComputerUseStatusForLog(status),
+    logComputerUseStatusChecked(status, "warn", {
       elapsedMs: Date.now() - startedAtUnixMs,
       executablePresent: false
     });
     return status;
   }
 
-  getDesktopLogger().info("computer use permission status command started", {
+  getDesktopLogger().debug("computer use permission status command started", {
     executable
   });
   const commandStartedAtUnixMs = Date.now();
@@ -406,7 +434,7 @@ async function checkCuaDriverStatus(): Promise<DesktopComputerUseStatus> {
     "status",
     "--json"
   ]);
-  getDesktopLogger().info("computer use permission status command completed", {
+  getDesktopLogger().debug("computer use permission status command completed", {
     elapsedMs: Date.now() - commandStartedAtUnixMs,
     outputBytes: permissionsResult.output.length,
     success: permissionsResult.success
@@ -418,8 +446,7 @@ async function checkCuaDriverStatus(): Promise<DesktopComputerUseStatus> {
       reason: "status-command-failed",
       diagnosticMessage: permissionsResult.output
     });
-    getDesktopLogger().warn("computer use permission status checked", {
-      ...summarizeComputerUseStatusForLog(status),
+    logComputerUseStatusChecked(status, "warn", {
       elapsedMs: Date.now() - startedAtUnixMs
     });
     return status;
@@ -435,20 +462,13 @@ async function checkCuaDriverStatus(): Promise<DesktopComputerUseStatus> {
     diagnosticMessage: detail.diagnosticMessage
   });
   const logFields = {
-    ...summarizeComputerUseStatusForLog(status),
     elapsedMs: Date.now() - startedAtUnixMs
   };
-  if (status.authorization === "authorized") {
-    getDesktopLogger().info(
-      "computer use permission status checked",
-      logFields
-    );
-  } else {
-    getDesktopLogger().warn(
-      "computer use permission status checked",
-      logFields
-    );
-  }
+  logComputerUseStatusChecked(
+    status,
+    status.authorization === "authorized" ? "info" : "warn",
+    logFields
+  );
   return status;
 }
 

--- a/apps/desktop/src/main/rotatingFileWriter.ts
+++ b/apps/desktop/src/main/rotatingFileWriter.ts
@@ -6,7 +6,7 @@ import {
   renameSync,
   rmSync,
   statSync,
-  writeFileSync
+  writeFile
 } from "node:fs";
 import { stat } from "node:fs/promises";
 import { basename, dirname, extname, join, resolve } from "node:path";
@@ -82,7 +82,16 @@ export class RotatingFileWriter {
       throw new Error("log writer is not open");
     }
 
-    writeFileSync(this.fd, content, { encoding: "utf8", flag: "a" });
+    const fd = this.fd;
+    await new Promise<void>((resolve, reject) => {
+      writeFile(fd, content, { encoding: "utf8", flag: "a" }, (error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
     this.currentSize += Buffer.byteLength(content);
   }
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
@@ -53,6 +53,49 @@ test("desktop agent activity runtime forwards package diagnostics to renderer di
   ]);
 });
 
+test("desktop agent activity runtime keeps successful message reads at debug", async () => {
+  const rendererDiagnostics: Array<{ event: string; level?: string }> = [];
+  const service = createWorkspaceAgentActivityService();
+  service.listSessionMessages = async () => ({
+    hasMore: false,
+    latestVersion: 0,
+    messages: []
+  });
+  const runtime = createDesktopAgentActivityRuntime(service, {
+    runtimeApi: {
+      async logRendererDiagnostic(payload) {
+        rendererDiagnostics.push(payload);
+      },
+      async logTerminalDiagnostic() {}
+    }
+  });
+
+  await runtime.listSessionMessages({
+    agentSessionId: "session-1",
+    workspaceId: "workspace-1"
+  });
+
+  assert.deepEqual(rendererDiagnostics, [
+    {
+      details: {
+        afterVersion: null,
+        agentSessionId: "session-1",
+        beforeVersion: null,
+        cache: null,
+        hasMore: false,
+        lastMessage: null,
+        latestVersion: 0,
+        messageCount: 0,
+        order: null
+      },
+      event: "agent.gui.runtime.messages.resolved",
+      level: "debug",
+      source: "agent-gui",
+      workspaceId: "workspace-1"
+    }
+  ]);
+});
+
 test("desktop agent activity runtime hides prompt uploads without archive support", () => {
   const runtime = createDesktopAgentActivityRuntime(
     createWorkspaceAgentActivityService()

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts
@@ -140,7 +140,7 @@ export function createDesktopAgentActivityRuntime(
         order: input.order ?? null
       },
       event: "agent.gui.runtime.messages.resolved",
-      level: "info",
+      level: "debug",
       workspaceId: input.workspaceId
     });
   };

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentRuntimeStateDiagnostics.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentRuntimeStateDiagnostics.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AgentActivitySession } from "@tutti-os/agent-activity-core";
+import { agentActivitySessionDiagnosticSignature } from "./desktopAgentRuntimeStateDiagnostics.ts";
+
+function session(
+  overrides: Partial<AgentActivitySession> = {}
+): AgentActivitySession {
+  return {
+    activeTurn: null,
+    activeTurnId: null,
+    agentSessionId: "session-1",
+    latestTurn: null,
+    lastEventUnixMs: 10,
+    messageVersion: 1,
+    pendingInteractions: [],
+    provider: "codex",
+    updatedAtUnixMs: 10,
+    ...overrides
+  } as AgentActivitySession;
+}
+
+test("session diagnostic signature ignores streaming cursors and timestamps", () => {
+  const before = agentActivitySessionDiagnosticSignature(session());
+  const after = agentActivitySessionDiagnosticSignature(
+    session({
+      lastEventUnixMs: 30,
+      messageVersion: 8,
+      updatedAtUnixMs: 40
+    })
+  );
+
+  assert.equal(after, before);
+});
+
+test("session diagnostic signature retains actionable state transitions", () => {
+  const before = agentActivitySessionDiagnosticSignature(session());
+  const after = agentActivitySessionDiagnosticSignature(
+    session({
+      pendingInteractions: [
+        {
+          agentSessionId: "session-1",
+          createdAtUnixMs: 20,
+          kind: "approval",
+          requestId: "request-1",
+          status: "pending",
+          turnId: "turn-1",
+          updatedAtUnixMs: 20
+        }
+      ]
+    })
+  );
+
+  assert.notEqual(after, before);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentRuntimeStateDiagnostics.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentRuntimeStateDiagnostics.ts
@@ -42,15 +42,20 @@ export function agentActivitySessionDiagnosticSignature(
   session: AgentActivitySession
 ): string {
   const turn = session.activeTurn ?? session.latestTurn;
+  const pendingInteractionSignature = session.pendingInteractions
+    .map(
+      (interaction) =>
+        `${interaction.turnId}:${interaction.requestId}:${interaction.kind}:${interaction.status}`
+    )
+    .sort()
+    .join(",");
   return [
     session.agentSessionId,
     session.provider,
     session.activeTurnId ?? "",
     turn?.phase ?? "",
     turn?.outcome ?? "",
-    session.messageVersion ?? "",
-    session.lastEventUnixMs ?? "",
-    session.updatedAtUnixMs ?? ""
+    pendingInteractionSignature
   ].join(":");
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
@@ -260,7 +260,7 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
             ...(input.fields ?? {})
           },
           event: "agent.activity.reconcile.trace",
-          level: "info",
+          level: "debug",
           workspaceId: input.workspaceId
         })
         .catch((error: unknown) => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -1006,15 +1006,21 @@ test("WorkspaceAgentActivityService fetches detail before combined message recon
   ]);
   assert.equal(session?.activeTurn, null);
   assert.equal(session?.latestTurn?.phase, "settled");
+  const reconcileDiagnostics = diagnostics.filter(
+    (
+      entry
+    ): entry is {
+      details: { traceEvent?: string };
+      event: string;
+      level?: string;
+    } =>
+      typeof entry === "object" &&
+      entry !== null &&
+      (entry as { event?: unknown }).event === "agent.activity.reconcile.trace"
+  );
+  assert.ok(reconcileDiagnostics.every((entry) => entry.level === "debug"));
   assert.deepEqual(
-    diagnostics
-      .filter(
-        (entry): entry is { details: { traceEvent?: string }; event: string } =>
-          typeof entry === "object" &&
-          entry !== null &&
-          (entry as { event?: unknown }).event ===
-            "agent.activity.reconcile.trace"
-      )
+    reconcileDiagnostics
       .map((entry) => entry.details.traceEvent)
       .filter(
         (traceEvent) =>

--- a/docs/conventions/logging.md
+++ b/docs/conventions/logging.md
@@ -153,6 +153,26 @@ Default:
 
 - `TUTTI_DESKTOP_LOG_LEVEL` unset behaves as `info`
 
+### Hot-Path Diagnostics
+
+Streaming events, polling loops, renderer snapshots, and transport frames are
+hot paths. Their successful per-event diagnostics belong at `debug`; the
+default `info` level should contain a bounded summary per turn, short time
+window, or semantic state transition.
+
+Rules:
+
+- aggregate repeated success events and retain counts plus stable correlation
+  fields in the summary
+- keep failures, dropped data, and rare lifecycle transitions visible at
+  `warn` or `error`
+- exclude cursors, timestamps, token/message versions, and elapsed time from
+  change-detection signatures unless that value is the state being diagnosed
+- log a periodic poll at `info` or `warn` only when its semantic result changes;
+  unchanged results belong at `debug`
+- desktop file writes must stay ordered without performing one synchronous
+  filesystem write on the Electron main thread per line
+
 ## Rotation
 
 Both daemon and desktop main now follow the same rotation convention:

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1314,23 +1314,36 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   `agent.gui.node.render_state_changed` lines before blaming one visible click.
   Runtime event emissions should appear as
   `runtime.events_emitted.summary`/`runtime.async_events_emitted.summary`;
-  successful inline reconciles should appear as `inline.applied.summary`.
-  If the old per-event names dominate a new log, the running app is stale.
+  the old `runtime.events_emitted`/`runtime.async_events_emitted` names must not
+  appear at the default level. Successful reconcile steps, message-page reads,
+  ACP transport frames, and unchanged CuaDriver polls should appear only when
+  debug logging is enabled. A streaming message-version change alone must not
+  emit `agent.gui.node.render_state_changed` or
+  `agent.gui.runtime.snapshot_changed`.
 - Root cause:
   Per-token runtime events and renderer inline reconcile commits can produce
   thousands of diagnostic writes. Those writes compete with rendering and also
   inflate trace/log exports enough to obscure the actual session-switch work.
+  A later AgentGUI refactor can reintroduce this problem by replacing turn
+  summaries with per-batch logs or by adding message cursors to diagnostic
+  change keys.
 - Fix:
-  Keep success-path diagnostics aggregated by turn or short time window. Reserve
-  per-event logging for failures or rare state transitions.
+  Aggregate runtime emissions once per turn. Keep successful reconcile,
+  message-page, and ACP frame diagnostics at debug. Build renderer snapshot and
+  render-state keys from semantic lifecycle/interaction state rather than
+  streaming cursors. Log unchanged permission-poll results at debug, and keep
+  desktop log writes ordered through the asynchronous file writer.
 - Validation:
-  Reproduce a streaming turn and confirm the high-volume success paths collapse
-  to summary entries while `inline.not_applied` and submit failures still retain
-  event-level detail.
+  Reproduce a streaming turn at the default info level. Confirm each turn has
+  at most one runtime emission summary, semantic render/snapshot diagnostics do
+  not advance for token-only updates, and reconcile/ACP frame diagnostics are
+  absent. Repeat with debug enabled when per-frame evidence is needed. Submit,
+  reconcile, and protocol failures must remain visible.
 - References:
-  [controller.go](../../../packages/agent/daemon/runtime/controller.go)
-  [workspaceAgentActivityService.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts)
-  [useAgentGUINodeController.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts)
+  [controller_turn_exec.go](../../../packages/agent/daemon/runtime/controller_turn_exec.go)
+  [workspaceAgentActivityReconcileBridge.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts)
+  [desktopAgentRuntimeStateDiagnostics.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentRuntimeStateDiagnostics.ts)
+  [useAgentGUISessionPresentation.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts)
 
 ### Claude export leaks hidden data, flattens branches, or resumes as Claude Code
 

--- a/packages/agent/daemon/runtime/acp_client.go
+++ b/packages/agent/daemon/runtime/acp_client.go
@@ -500,7 +500,7 @@ func (c *acpClient) dispatchLine(line []byte) {
 		}
 		if benignACPStdoutLine(line) {
 			c.resetStdoutProtocolErrors()
-			slog.Warn("agent session ACP stdout ignored provider log line",
+			slog.Debug("agent session ACP stdout ignored provider log line",
 				"event", "agent_session.acp.stdout.provider_log",
 				"message", truncateACPLogValue(string(line), 1200),
 			)
@@ -515,7 +515,7 @@ func (c *acpClient) dispatchLine(line []byte) {
 		return
 	}
 	c.resetStdoutProtocolErrors()
-	slog.Info("agent session ACP stdout",
+	slog.Debug("agent session ACP stdout",
 		"event", "agent_session.acp.stdout",
 		"method", message.Method,
 		"id", strings.TrimSpace(string(message.ID)),
@@ -614,7 +614,7 @@ func benignACPStdoutLine(line []byte) bool {
 }
 
 func (c *acpClient) dispatchMessage(message acpMessage) {
-	slog.Info("agent session ACP message received",
+	slog.Debug("agent session ACP message received",
 		"event", "agent_session.acp.message.received",
 		"method", message.Method,
 		"id", strings.TrimSpace(string(message.ID)),

--- a/packages/agent/daemon/runtime/controller_turn_diagnostics.go
+++ b/packages/agent/daemon/runtime/controller_turn_diagnostics.go
@@ -1,0 +1,48 @@
+package agentruntime
+
+import (
+	"strings"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+type agentSubmitRuntimeEventSummary struct {
+	batchCount         int
+	activityEventCount int
+	eventTypeCounts    map[string]int
+	lastSessionStatus  string
+	lastTurnPhase      string
+}
+
+func (s *agentSubmitRuntimeEventSummary) observe(events []activityshared.Event, session Session) {
+	if len(events) == 0 {
+		return
+	}
+	s.batchCount++
+	s.activityEventCount += len(events)
+	if s.eventTypeCounts == nil {
+		s.eventTypeCounts = make(map[string]int)
+	}
+	for _, event := range events {
+		eventType := strings.TrimSpace(string(event.Type))
+		if eventType == "" {
+			eventType = "unknown"
+		}
+		s.eventTypeCounts[eventType]++
+	}
+	s.lastSessionStatus = strings.TrimSpace(string(session.Status))
+	s.lastTurnPhase = strings.TrimSpace(turnLifecyclePhaseFromEvents(events))
+}
+
+func (s agentSubmitRuntimeEventSummary) log(event string, session Session, turnID string, metadata map[string]any) {
+	if s.batchCount == 0 {
+		return
+	}
+	logAgentSubmitTrace(event, session, turnID, metadata, map[string]any{
+		"activity_event_count": s.activityEventCount,
+		"emit_batch_count":     s.batchCount,
+		"event_type_counts":    s.eventTypeCounts,
+		"session_status":       s.lastSessionStatus,
+		"turn_phase":           s.lastTurnPhase,
+	})
+}

--- a/packages/agent/daemon/runtime/controller_turn_diagnostics_test.go
+++ b/packages/agent/daemon/runtime/controller_turn_diagnostics_test.go
@@ -1,0 +1,34 @@
+package agentruntime
+
+import (
+	"testing"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+func TestAgentSubmitRuntimeEventSummaryAggregatesEmissionBatches(t *testing.T) {
+	var summary agentSubmitRuntimeEventSummary
+	summary.observe([]activityshared.Event{
+		{Type: activityshared.EventMessageAppended},
+		{Type: activityshared.EventMessageAppended},
+	}, Session{Status: SessionStatusWorking})
+	summary.observe([]activityshared.Event{
+		{Type: activityshared.EventTurnCompleted},
+	}, Session{Status: SessionStatusReady})
+
+	if summary.batchCount != 2 {
+		t.Fatalf("batch count = %d, want 2", summary.batchCount)
+	}
+	if summary.activityEventCount != 3 {
+		t.Fatalf("activity event count = %d, want 3", summary.activityEventCount)
+	}
+	if got := summary.eventTypeCounts[string(activityshared.EventMessageAppended)]; got != 2 {
+		t.Fatalf("message update count = %d, want 2", got)
+	}
+	if got := summary.eventTypeCounts[string(activityshared.EventTurnCompleted)]; got != 1 {
+		t.Fatalf("turn completed count = %d, want 1", got)
+	}
+	if summary.lastSessionStatus != string(SessionStatusReady) {
+		t.Fatalf("last session status = %q, want %q", summary.lastSessionStatus, SessionStatusReady)
+	}
+}

--- a/packages/agent/daemon/runtime/controller_turn_exec.go
+++ b/packages/agent/daemon/runtime/controller_turn_exec.go
@@ -52,6 +52,7 @@ func (c *Controller) runExecTurn(ctx context.Context, session Session, adapter A
 		return
 	}
 	var emitted []activityshared.Event
+	var emittedSummary agentSubmitRuntimeEventSummary
 	metadata := execMetadataFromContext(ctx)
 	logAgentSubmitTrace("runtime.turn_goroutine_started", session, turnID, metadata, nil)
 	emit := func(events []activityshared.Event) {
@@ -69,11 +70,7 @@ func (c *Controller) runExecTurn(ctx context.Context, session Session, adapter A
 		emitted = append(emitted, events...)
 		c.publish(session, events)
 		c.enqueueSessionReport(ctx, session, events)
-		logAgentSubmitTrace("runtime.events_emitted", session, turnID, metadata, map[string]any{
-			"activity_event_count": len(events),
-			"session_status":       session.Status,
-			"turn_phase":           turnLifecyclePhaseFromEvents(events),
-		})
+		emittedSummary.observe(events, session)
 	}
 	emitCommands := func(snapshot AgentSessionCommandSnapshot) {
 		c.applyTurnCommandSnapshot(session, turnID, snapshot)
@@ -123,6 +120,7 @@ func (c *Controller) runExecTurn(ctx context.Context, session Session, adapter A
 	if shouldAdvanceSessionUpdatedAtFromEvents(statusEvents) {
 		session.UpdatedAtUnixMS = unixMS(now())
 	}
+	emittedSummary.log("runtime.events_emitted.summary", session, turnID, metadata)
 	if rootProviderLifecycle {
 		// Exec returning closes only the provider invocation. The controller's
 		// active root turn remains addressable for guidance/cancel until the
@@ -143,12 +141,17 @@ func (c *Controller) runAsyncExecTurn(ctx context.Context, session Session, adap
 	logAgentSubmitTrace("runtime.async_turn_started", session, turnID, metadata, nil)
 	var mu sync.Mutex
 	finished := false
+	var emittedSummary agentSubmitRuntimeEventSummary
 	finish := func(next Session) bool {
 		if finished {
 			return false
 		}
 		finished = true
-		return c.finishTurn(next, turnID)
+		if !c.finishTurn(next, turnID) {
+			return false
+		}
+		emittedSummary.log("runtime.async_events_emitted.summary", next, turnID, metadata)
+		return true
 	}
 	emit := func(events []activityshared.Event) {
 		if len(events) == 0 {
@@ -172,6 +175,7 @@ func (c *Controller) runAsyncExecTurn(ctx context.Context, session Session, adap
 			// Remove the controller's active-turn record before publishing a
 			// terminal/ready session. Consumers must never observe a ready session
 			// while HasActiveTurn still reports the finished turn.
+			emittedSummary.observe(events, session)
 			if !finish(session) {
 				return
 			}
@@ -179,14 +183,10 @@ func (c *Controller) runAsyncExecTurn(ctx context.Context, session Session, adap
 			if !c.storeTurnSession(session, turnID) {
 				return
 			}
+			emittedSummary.observe(events, session)
 		}
 		c.publish(session, events)
 		c.enqueueSessionReport(ctx, session, events)
-		logAgentSubmitTrace("runtime.async_events_emitted", session, turnID, metadata, map[string]any{
-			"activity_event_count": len(events),
-			"session_status":       session.Status,
-			"turn_phase":           turnLifecyclePhaseFromEvents(events),
-		})
 	}
 	emitCommands := func(snapshot AgentSessionCommandSnapshot) {
 		mu.Lock()

--- a/packages/agent/daemon/runtime/standard_acp_stream.go
+++ b/packages/agent/daemon/runtime/standard_acp_stream.go
@@ -22,7 +22,7 @@ func (a *standardACPAdapter) handleACPMessage(
 	emit EventSink,
 	emitCommands CommandSnapshotSink,
 ) ([]activityshared.Event, error) {
-	slog.Info("agent session ACP handle message",
+	slog.Debug("agent session ACP handle message",
 		"event", "agent_session.acp.handle_message",
 		"provider", a.config.provider,
 		"adapter", a.config.adapterName,
@@ -59,17 +59,19 @@ func (a *standardACPAdapter) handleACPMessage(
 		}
 		a.emitConfigOptionsUpdate(session, message.Params)
 		events := standardACPUpdateEvents(a.config, session, turnID, message.Params, normalizer)
-		slog.Info("agent session ACP update projected events",
-			"event", "agent_session.acp.handle_message.update",
-			"provider", a.config.provider,
-			"adapter", a.config.adapterName,
-			"room_id", session.RoomID,
-			"agent_session_id", session.AgentSessionID,
-			"provider_session_id", session.ProviderSessionID,
-			"turn_id", turnID,
-			"event_count", len(events),
-			"event_type_counts", activityEventTypeCounts(events),
-		)
+		if slog.Default().Enabled(ctx, slog.LevelDebug) {
+			slog.Debug("agent session ACP update projected events",
+				"event", "agent_session.acp.handle_message.update",
+				"provider", a.config.provider,
+				"adapter", a.config.adapterName,
+				"room_id", session.RoomID,
+				"agent_session_id", session.AgentSessionID,
+				"provider_session_id", session.ProviderSessionID,
+				"turn_id", turnID,
+				"event_count", len(events),
+				"event_type_counts", activityEventTypeCounts(events),
+			)
+		}
 		if len(events) > 0 {
 			if emit == nil || hasACPCurrentModeUpdatedEvent(events) {
 				a.emitSessionEvents(session.AgentSessionID, events)

--- a/packages/agent/daemon/runtime/standard_acp_turn.go
+++ b/packages/agent/daemon/runtime/standard_acp_turn.go
@@ -90,7 +90,7 @@ execLoop:
 			"sessionId": acpSession.providerSessionID,
 			"prompt":    promptParams,
 		}, func(ctx context.Context, message acpMessage) error {
-			slog.Info("agent session ACP exec received message",
+			slog.Debug("agent session ACP exec received message",
 				"event", "agent_session.acp.exec.message",
 				"provider", a.config.provider,
 				"adapter", a.config.adapterName,
@@ -102,19 +102,21 @@ execLoop:
 				"message_id", rawMessageLogValue(message.ID),
 			)
 			next, err := a.handleACPMessage(ctx, acpSession.client, session, turnID, message, normalizer, emitEvents, emitCommands)
-			slog.Info("agent session ACP exec handled message",
-				"event", "agent_session.acp.exec.message_handled",
-				"provider", a.config.provider,
-				"adapter", a.config.adapterName,
-				"room_id", session.RoomID,
-				"agent_session_id", session.AgentSessionID,
-				"provider_session_id", session.ProviderSessionID,
-				"turn_id", turnID,
-				"message_method", message.Method,
-				"event_count", len(next),
-				"event_type_counts", activityEventTypeCounts(next),
-				"error", errString(err),
-			)
+			if slog.Default().Enabled(ctx, slog.LevelDebug) {
+				slog.Debug("agent session ACP exec handled message",
+					"event", "agent_session.acp.exec.message_handled",
+					"provider", a.config.provider,
+					"adapter", a.config.adapterName,
+					"room_id", session.RoomID,
+					"agent_session_id", session.AgentSessionID,
+					"provider_session_id", session.ProviderSessionID,
+					"turn_id", turnID,
+					"message_method", message.Method,
+					"event_count", len(next),
+					"event_type_counts", activityEventTypeCounts(next),
+					"error", errString(err),
+				)
+			}
 			emitEvents(next)
 			if err != nil {
 				return err

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.ts
@@ -44,10 +44,7 @@ import {
   EMPTY_AGENT_COMPOSER_DRAFT,
   readAgentComposerDraftContent
 } from "./agentGuiController.draftMessageHelpers";
-import {
-  maxFiniteMessageVersion,
-  minFiniteMessageVersion
-} from "./useAgentConversationMessagePaging";
+import { minFiniteMessageVersion } from "./useAgentConversationMessagePaging";
 import { resolveAgentComposerDraftScopeKey } from "../model/agentComposerDraftScope";
 import { agentComposerDraftPrompt } from "../model/agentComposerDraft";
 
@@ -218,7 +215,6 @@ export function useAgentGUIConversationDetail(
       return;
     }
     const firstVersion = minFiniteMessageVersion(input.activeMessages);
-    const lastVersion = maxFiniteMessageVersion(input.activeMessages);
     const diagnosticKey = [
       input.activeConversationId,
       input.activeMessages.length,
@@ -226,7 +222,6 @@ export function useAgentGUIConversationDetail(
       conversation.sourceDetail.turns.length,
       conversation.rows.length,
       firstVersion ?? "",
-      lastVersion ?? "",
       input.activeSessionView?.hasOlderMessages ? "1" : "0",
       input.activeSessionView?.isLoadingOlderMessages ? "1" : "0"
     ].join(":");

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
@@ -41,10 +41,6 @@ import {
 } from "./agentGuiController.promptHelpers";
 import { promptRequestId } from "./agentGuiController.diagnostics";
 import { reportAgentGUIRenderStateDiagnostic } from "./agentGuiController.reporting";
-import {
-  maxFiniteMessageVersion,
-  minFiniteMessageVersion
-} from "./useAgentConversationMessagePaging";
 
 interface CurrentValue<T> {
   current: T;
@@ -288,8 +284,6 @@ export function useAgentGUISessionPresentation(
   );
 
   useEffect(() => {
-    const firstVersion = minFiniteMessageVersion(input.activeMessages);
-    const lastVersion = maxFiniteMessageVersion(input.activeMessages);
     const diagnosticKey = [
       input.activeConversationId ?? "",
       input.activeConversation?.status ?? "",
@@ -308,10 +302,7 @@ export function useAgentGUISessionPresentation(
       activeSubmitBlocked ? "submit-blocked" : "submit-open",
       input.pendingApproval?.requestId ?? "",
       promptRequestId(pendingInteractivePrompt) ?? "",
-      input.conversation?.rows.length ?? "",
-      input.conversation?.sourceDetail.turns.length ?? "",
-      firstVersion ?? "",
-      lastVersion ?? "",
+      input.conversation?.activity.status ?? "",
       input.isCreatingConversation ? "creating" : "",
       input.isLoadingMessages ? "loading-messages" : "",
       input.isSubmitting ? "submitting" : "",
@@ -347,7 +338,6 @@ export function useAgentGUISessionPresentation(
     activeSubmitBlocked,
     canQueueWhileBusy,
     canSubmit,
-    hasSentUserMessage,
     input.activeConversation,
     input.activeConversationId,
     input.activeEngineActiveTurn,
@@ -355,7 +345,6 @@ export function useAgentGUISessionPresentation(
     input.activeEngineLatestTurn,
     input.activeEngineSession,
     input.activeLiveState,
-    input.activeMessages,
     input.activeSessionState,
     input.activityDisplayStatus,
     input.agentActivityRuntime,


### PR DESCRIPTION
## Summary

- aggregate per-event runtime emission diagnostics into one summary per turn
- keep successful ACP frames, reconcile traces, and message reads at debug while preserving failures and semantic transitions
- deduplicate unchanged CuaDriver poll results and make ordered desktop log writes asynchronous
- stop AgentGUI render and snapshot diagnostics from advancing on streaming cursors alone
- document the hot-path logging rules and recurring troubleshooting pattern

Historical developer logs show the directly affected daemon paths produced 346,946 lines (127.33 MiB), while fully demoted or deduplicated desktop paths produced 77,722 lines (35.26 MiB). Render and snapshot diagnostics receive additional semantic deduplication.

## Verification

- `pnpm check:changed --tail-lines 80`
- `pnpm lint:ts`
- `pnpm typecheck`
- `pnpm lint:go`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm --filter @tutti-os/agent-gui test`
- `cd packages/agent/daemon && go test ./...`
- `cd services/tuttid && go test ./... && go build ./...`
- targeted desktop logging, CuaDriver, runtime diagnostics, and activity reconcile tests

## Fix Scope Justification

- Root cause: streaming runtime batches, ACP protocol frames, renderer cursor changes, reconcile success traces, and unchanged permission polls were all logged at the default level; desktop also performed one synchronous filesystem write per line.
- Why this cannot be fixed at a lower layer: the churn is introduced independently at the runtime, transport, renderer diagnostic, polling, and desktop sink ownership boundaries. Each change is limited to logging policy or sink behavior at the layer that creates the work; session and runtime behavior are unchanged.

## Fallback Three Questions

- Source: the small retained signature records the latest semantic CuaDriver status returned by the existing periodic status poll.
- Why it cannot be fixed at that source: polling is required to detect macOS permission changes; only the logging consumer knows whether an unchanged result is duplicate diagnostic evidence.
- Removal condition: remove the signature when the desktop logging API provides equivalent semantic transition deduplication without suppressing the first warning or later recovery.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->