### PR TITLE
fix(agent): recover queued prompts after no-active-turn race

### DIFF
--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -48,6 +48,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [AgentGUI send blocked by active_turn after settled snapshot](./agent-session-lifecycle.md#agentgui-send-blocked-by-activeturn-after-settled-snapshot)
 - [AgentGUI rejects a pasted image as unsupported before send](./agent-session-lifecycle.md#agentgui-rejects-a-pasted-image-as-unsupported-before-send)
 - [AgentGUI loading disappears before active turn settles](./agent-session-lifecycle.md#agentgui-loading-disappears-before-active-turn-settles)
+- [Queued AgentGUI prompt stalls after no-active-turn failure](./agent-session-lifecycle.md#queued-agentgui-prompt-stalls-after-no-active-turn-failure)
 - [Agent session stays loading after a completed turn](./agent-session-lifecycle.md#agent-session-stays-loading-after-a-completed-turn)
 - [AgentGUI model switch changes defaults but not the active session](./agent-session-lifecycle.md#agentgui-model-switch-changes-defaults-but-not-the-active-session)
 - [Historical AgentGUI permission changes time out or stop responding](./agent-session-lifecycle.md#historical-agentgui-permission-changes-time-out-or-stop-responding)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -257,6 +257,44 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [sessionLifecycle.reducer.ts](../../../packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts)
   [controller_exec.go](../../../packages/agent/daemon/runtime/controller_exec.go)
 
+### Queued AgentGUI prompt stalls after no-active-turn failure
+
+- Symptom:
+  A prompt submitted while an AgentGUI turn is busy appears in the local queue
+  or as an optimistic user row, but does not start after the previous turn
+  settles. Submit traces show the same `clientSubmitId` first failing with
+  `errorReason = agent.no_active_turn`, then succeeding only after a later
+  manual retry or another queue-draining trigger.
+- Quick checks:
+  Search desktop and daemon logs for the queued `clientSubmitId`. A local queue
+  acceptance has `send_input.requested` with `queued=true` and
+  `optimistic_user_message_painted`. The failure pattern is a delayed
+  `renderer_adapter.send.failed` with `errorCode=invalid_request` and
+  `errorReason=agent.no_active_turn`, plus daemon `runtime_adapter.exec.failed`
+  with `agent session has no active turn`.
+- Root cause:
+  The daemon exposes the domain-specific reason as the protocol error
+  `reason`, while the Agent session engine previously kept only the generic
+  `errorCode`. The queue reducer therefore treated the race like a permanent
+  send failure, set `failedPromptId`, and stopped automatic drain until
+  send-now or another retry path cleared the failure.
+- Fix:
+  Preserve protocol `reason` on `EngineCommandResultIntent`. For
+  `queue/sendPrompt` failures whose reason is `agent.no_active_turn`, clear the
+  in-flight send, request a session reconcile, and skip same-reducer drain so
+  the queued prompt retries only after canonical state refresh. Keep ordinary
+  send failures blocked until explicit send-now retry.
+- Validation:
+  Add reducer coverage where a queued send fails with
+  `errorReason = agent.no_active_turn`: it should emit one
+  `session/reconcile`, leave the prompt queued without `failedPromptId`, and
+  avoid an immediate second `queue/sendPrompt` until a later canonical lifecycle
+  update. Keep the existing generic failure test blocked until send-now.
+- References:
+  [promptQueue.reducer.ts](../../../packages/agent/activity-core/src/engine/promptQueue.reducer.ts)
+  [effectExecutor.ts](../../../packages/agent/activity-core/src/engine/effectExecutor.ts)
+  [daemon_agent_submit_handlers.go](../../../services/tuttid/api/daemon_agent_submit_handlers.go)
+
 ### Cursor or OpenCode turn settles before late ACP activity arrives
 
 - Symptom:

--- a/packages/agent/activity-core/src/engine/effectExecutor.ts
+++ b/packages/agent/activity-core/src/engine/effectExecutor.ts
@@ -162,6 +162,7 @@ function commandCorrelationFields(command: EngineExternalCommand): {
 
 function engineCommandErrorFields(error: unknown): {
   errorCode?: string;
+  errorReason?: string;
   errorMessage: string;
 } {
   const record =
@@ -169,6 +170,7 @@ function engineCommandErrorFields(error: unknown): {
       ? (error as Record<string, unknown>)
       : null;
   const code = typeof record?.code === "string" ? record.code.trim() : "";
+  const reason = typeof record?.reason === "string" ? record.reason.trim() : "";
   const message =
     error instanceof Error
       ? error.message
@@ -177,6 +179,7 @@ function engineCommandErrorFields(error: unknown): {
         : String(error);
   return {
     ...(code ? { errorCode: code } : {}),
+    ...(reason ? { errorReason: reason } : {}),
     errorMessage: message
   };
 }

--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts
@@ -315,6 +315,39 @@ test("send failure stays blocked until send-now retry clears it", () => {
   assert.equal(retried.commands[0]?.type, "queue/sendPrompt");
 });
 
+test("no-active-turn send failure reconciles before retrying queued prompt", () => {
+  const available = canonicalLifecycle("settled", 1);
+  const sending = reduce(
+    createInitialPromptQueueState(),
+    enqueue("prompt-1"),
+    available
+  );
+  const failed = reduce(
+    sending.state,
+    commandResult(
+      commandId(sending.commands[0]),
+      "queue/sendPrompt",
+      "failed",
+      { errorReason: "agent.no_active_turn" }
+    ),
+    available
+  );
+  assert.equal(failed.commands.length, 1);
+  assert.equal(failed.commands[0]?.type, "session/reconcile");
+  assert.equal(
+    failed.state.recordsBySessionId["session-1"]?.failedPromptId,
+    null
+  );
+  assert.equal(failed.state.recordsBySessionId["session-1"]?.inFlight, null);
+
+  const reconciled = reduce(
+    failed.state,
+    turnUpserted(settledTurn("turn-2", 2)),
+    canonicalLifecycle("settled", 2, "turn-2")
+  );
+  assert.equal(reconciled.commands[0]?.type, "queue/sendPrompt");
+});
+
 test("timeout confirmation waits for its exact canonical turn to settle", () => {
   const available = canonicalLifecycle("settled", 1, "turn-0");
   const first = reduce(
@@ -628,9 +661,19 @@ const submitDiagnostics = {
 function commandResult(
   commandId: string,
   commandType: EngineCommandResultIntent["commandType"],
-  outcome: EngineCommandResultIntent["outcome"]
+  outcome: EngineCommandResultIntent["outcome"],
+  options: Pick<
+    EngineCommandResultIntent,
+    "errorCode" | "errorMessage" | "errorReason"
+  > = {}
 ): EngineCommandResultIntent {
-  return { type: "engine/commandResult", commandId, commandType, outcome };
+  return {
+    type: "engine/commandResult",
+    commandId,
+    commandType,
+    outcome,
+    ...options
+  };
 }
 
 function commandId(command: EngineCommand | undefined): string {

--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
@@ -61,6 +61,9 @@ export function promptQueueReducer(
   if (intent.type === "submit/requested" && intent.routing === "immediate") {
     return reduced;
   }
+  if (isNoActiveTurnSendFailure(intent)) {
+    return reduced;
+  }
   return drainAffectedSessions(
     reduced,
     affectedSessionIds(state, intent, context),
@@ -405,6 +408,17 @@ function settleQueueCommand(
       state: replaceRecord(state, agentSessionId, record)
     };
   }
+  if (isNoActiveTurnSendFailure(intent)) {
+    return {
+      commands: [reconcileCommand(agentSessionId, current.workspaceId, intent)],
+      state: replaceRecord(state, agentSessionId, {
+        ...current,
+        failedPromptId: null,
+        failureMessage: null,
+        inFlight: null
+      })
+    };
+  }
   return result(
     replaceRecord(state, agentSessionId, {
       ...current,
@@ -428,6 +442,16 @@ function reconcileCommand(
     type: "session/reconcile",
     workspaceId
   };
+}
+
+function isNoActiveTurnSendFailure(intent: EngineIntent): boolean {
+  return (
+    intent.type === "engine/commandResult" &&
+    intent.commandType === "queue/sendPrompt" &&
+    intent.outcome === "failed" &&
+    (intent.errorReason?.trim() === "agent.no_active_turn" ||
+      intent.errorCode?.trim() === "agent.no_active_turn")
+  );
 }
 
 function confirmDeliveredPrompts(

--- a/packages/agent/activity-core/src/engine/types.ts
+++ b/packages/agent/activity-core/src/engine/types.ts
@@ -78,6 +78,7 @@ export interface EngineCommandResultIntent {
   outcome: EngineCommandOutcome;
   value?: unknown;
   errorCode?: string;
+  errorReason?: string;
   errorMessage?: string;
 }
 


### PR DESCRIPTION
## Summary

- preserve daemon protocol error `reason` on engine command results
- recover queued prompt sends that fail with `agent.no_active_turn` by reconciling before retrying
- document the queue/no-active-turn troubleshooting pattern

## Validation

- `pnpm exec prettier --check docs/conventions/troubleshooting/agent-runtime.md docs/conventions/troubleshooting/agent-session-lifecycle.md`
- `pnpm exec oxfmt --check packages/agent/activity-core/src/engine/types.ts packages/agent/activity-core/src/engine/effectExecutor.ts packages/agent/activity-core/src/engine/promptQueue.reducer.ts packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts`
- `pnpm --filter @tutti-os/agent-activity-core test`
- `pnpm --filter @tutti-os/agent-activity-core typecheck`
- `pnpm lint:ts`
- `pnpm typecheck`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->