### PR TITLE
fix(agent): reuse extension runtimes by runtime identity

### DIFF
--- a/docs/architecture/agent-extensions.md
+++ b/docs/architecture/agent-extensions.md
@@ -154,13 +154,19 @@ exact package identity, install root, executable, launch arguments, and SHA-256
 plan digest. Renderer input cannot replace any execution field.
 
 Runtime roots use
-`~/.local/share/tutti/agent-runtimes/<agentKey>/<extensionVersion>`. This stable
-user-local root is shared by development and production; daemon state keeps
-only setup action metadata. `${platform}` resolves to Go's
-`<GOOS>-<GOARCH>` pair. Plan digests bind the Target, fixed extension
-installation, platform, and complete resolved command, so one managed
-installation is reused across workspaces. Every install action recomputes the
-plan and compares its digest before creating files or processes.
+`~/.local/share/tutti/agent-runtimes/<agentKey>/<runtimeIdentity>`, where
+`runtimeIdentity` is derived from the runtime contract: Agent key, runtime
+kind, platform, install runner and argv, exact package identity, launch
+executable and args, and discovery profile. Extension metadata changes such as
+localized copy or presentation assets do not force a reinstall when this
+runtime contract is unchanged. This stable user-local root is shared by
+development and production; daemon state keeps only setup action metadata.
+`${platform}` resolves to Go's `<GOOS>-<GOARCH>` pair. Plan digests still bind
+the Target and fixed extension installation in addition to the runtime
+identity, platform, and complete resolved command, so one managed runtime is
+reused across workspaces while setup actions remain tied to the exact Target
+installation that the user confirmed. Every install action recomputes the plan
+and compares its digest before creating files or processes.
 
 The validated manifest inside the installed extension package is authoritative
 for runtime commands. The copied manifest in `installation.json` is metadata,
@@ -186,7 +192,7 @@ file before activation and launch.
 Successful activation also publishes the manifest launch executable's basename
 at `~/.local/bin/<agent-command>`. The user entry is a Tutti-owned symlink to
 `~/.local/share/tutti/agent-runtimes/<agentKey>/bin/<agent-command>`; that
-stable per-Agent link points to the executable in the fixed version root and is
+stable per-Agent link points to the executable in the fixed runtime root and is
 atomically repointed on upgrade. A pre-existing regular file or foreign symlink
 at either entry is never overwritten. Feature disablement and daemon shutdown
 do not remove a published command, so it remains usable outside Tutti while the
@@ -197,12 +203,16 @@ through the managed activation record. It therefore remains `source=managed`
 and retains fingerprint verification instead of being mistaken for an
 independent local installation. Both links are activation integrity: a missing,
 foreign, broken, or unexpectedly repointed entry produces
-`runtime_integrity_failed` and an explicit reinstall plan. Existing managed
-runtimes from before this invariant are not silently migrated during discovery.
+`runtime_integrity_failed` and an explicit reinstall plan. Existing
+extension-version roots may be adopted into the runtime-identity root only when
+their Tutti activation record, package identity, executable fingerprint, and
+current discovery version check all match; otherwise they are ignored and the
+user receives an explicit reinstall plan.
 
 The managed-runtime activation record persists the resolved executable's
-SHA-256 and byte size. Every managed-runtime resolution recomputes both before
-the version or ACP probe. A replacement, even one reporting the same compatible
+runtime identity, package identity, SHA-256, and byte size. Every
+managed-runtime resolution recomputes both fingerprint fields before the
+version or ACP probe. A replacement, even one reporting the same compatible
 version, is rejected with `runtime_integrity_failed` and returns the exact
 reinstall plan.
 

--- a/docs/conventions/local-state-storage.md
+++ b/docs/conventions/local-state-storage.md
@@ -209,8 +209,8 @@ Agent Extension executables are user-local programs rather than daemon state:
 ~/.local/share/tutti/agent-runtimes/
   <agent-key>/
     bin/
-      <agent-command> -> ../<extension-version>/<runtime-executable>
-    <extension-version>/
+      <agent-command> -> ../<runtime-identity>/<runtime-executable>
+    <runtime-identity>/
       activation.json
       node_modules/
   claude-code/

--- a/docs/specs/2026-07-14-agent-extension-package-design.md
+++ b/docs/specs/2026-07-14-agent-extension-package-design.md
@@ -357,14 +357,16 @@ Discovery Profile 只允许声明受限的路径候选、argv、版本解析、A
 安装根目录固定为用户级 `~/.local` 下的 Tutti-owned 隔离目录：
 
 ```text
-~/.local/share/tutti/agent-runtimes/<agentKey>/<extensionVersion>/
+~/.local/share/tutti/agent-runtimes/<agentKey>/<runtimeIdentity>/
 ```
+
+`runtimeIdentity` 由 Agent key、runtime kind、平台、安装 runner/argv、精确 runtime package、launch executable/args 和 discovery profile 计算。Extension 只改文案、资产或其他不影响 runtime contract 的 metadata 时，复用同一个托管 Runtime；plan digest 仍绑定固定 Extension installation，保证用户确认的 setup action 不跨 Target/版本漂移。
 
 标准安装命令在 daemon-owned scratch 目录运行，package manager 的 prefix、target 或 environment 必须指向 `<installRoot>`。安装不得修改任意项目的 `package.json`、lockfile、Python environment、`node_modules` 或全局 package manager 状态。
 
 安装完成后必须从 manifest 的 `runtime.launch` 解析托管 executable，再执行与本地候选相同的版本检查和 ACP handshake。只有 probe 成功才能原子切换为 active managed runtime binding。
 
-激活同时发布 `~/.local/bin/<agent-command>`。该入口只链接到 Tutti-owned 的 `~/.local/share/tutti/agent-runtimes/<agentKey>/bin/<agent-command>` 稳定入口，后者再链接到固定版本目录内的真实 executable。升级只原子切换稳定入口；不得覆盖已有普通文件或非 Tutti-owned symlink。dev/prod 和所有 workspace 共用同一入口与版本化 Runtime，环境隔离仅作用于 daemon state。Tutti 自己发布的 PATH 入口仍按 managed runtime 校验，不能降级为 local source；入口缺失、断链或指向异常时必须要求显式重装，不能在 discovery 读路径中静默迁移。
+激活同时发布 `~/.local/bin/<agent-command>`。该入口只链接到 Tutti-owned 的 `~/.local/share/tutti/agent-runtimes/<agentKey>/bin/<agent-command>` 稳定入口，后者再链接到固定 runtime identity 目录内的真实 executable。升级只原子切换稳定入口；不得覆盖已有普通文件或非 Tutti-owned symlink。dev/prod 和所有 workspace 共用同一入口与版本化 Runtime，环境隔离仅作用于 daemon state。Tutti 自己发布的 PATH 入口仍按 managed runtime 校验，不能降级为 local source；入口缺失、断链或指向异常时必须要求显式重装。旧 extension-version 目录只有在 activation、package identity、fingerprint 和当前 discovery 版本检查都匹配时，才可迁移到 runtime identity 目录。
 
 包管理器安装可能执行第三方 package lifecycle code。Agent 本体本来就是第三方可执行代码，因此首次托管安装前必须展示发布者、精确版本、最终命令、安装目录和风险，并要求用户确认；后台自动更新只能在用户明确启用该策略后发生。
 

--- a/services/tuttid/service/agentextension/install_plan.go
+++ b/services/tuttid/service/agentextension/install_plan.go
@@ -44,6 +44,7 @@ type InstallPlan struct {
 	ExtensionInstallationID string   `json:"extensionInstallationId"`
 	AgentKey                string   `json:"agentKey"`
 	ExtensionVersion        string   `json:"extensionVersion"`
+	RuntimeIdentity         string   `json:"runtimeIdentity"`
 	RuntimeKind             string   `json:"runtimeKind"`
 	Platform                string   `json:"platform"`
 	Runner                  string   `json:"runner"`
@@ -91,17 +92,26 @@ func (s InstallPlanService) GetInstallPlan(ctx context.Context, input InstallPla
 	if installation.Provider != target.Provider {
 		return InstallPlan{}, fmt.Errorf("%w: target provider does not match extension installation", ErrUnsupportedInstallTarget)
 	}
-	return buildInstallPlan(target.ID, s.Manager.managedRuntimeRoot(installation), s.Manager.RuntimeInstallDir, installation)
+	return buildInstallPlan(target.ID, s.Manager.RuntimeInstallDir, installation)
 }
 
-func buildInstallPlan(targetID, installRoot, runtimeInstallDir string, installation Installation) (InstallPlan, error) {
+func buildInstallPlan(targetID, runtimeInstallDir string, installation Installation) (InstallPlan, error) {
 	manifest := installation.Manifest
 	packageName, packageVersion, err := exactRuntimePackage(manifest.Runtime.Install.Runner, manifest.Runtime.Install.Args)
 	if err != nil {
 		return InstallPlan{}, err
 	}
 	platform := runtime.GOOS + "-" + runtime.GOARCH
-	if err := validateManagedRuntimeRoot(installRoot, runtimeInstallDir, installation); err != nil {
+	var profile DiscoveryProfile
+	if err := readJSON(filepath.Join(installation.PackageDir, installation.Manifest.Profiles.Discovery), &profile); err != nil {
+		return InstallPlan{}, fmt.Errorf("read discovery profile: %w", err)
+	}
+	runtimeIdentity, err := managedRuntimeIdentity(installation, profile, packageName, packageVersion, platform)
+	if err != nil {
+		return InstallPlan{}, err
+	}
+	installRoot := managedRuntimeRoot(runtimeInstallDir, installation.AgentKey, runtimeIdentity)
+	if err := validateManagedRuntimeRoot(installRoot, runtimeInstallDir, installation.AgentKey, runtimeIdentity); err != nil {
 		return InstallPlan{}, err
 	}
 	resolve := func(value string) string {
@@ -125,7 +135,7 @@ func buildInstallPlan(targetID, installRoot, runtimeInstallDir string, installat
 	plan := InstallPlan{
 		AgentTargetID:           targetID,
 		ExtensionInstallationID: installation.ID, AgentKey: installation.AgentKey,
-		ExtensionVersion: installation.Version, RuntimeKind: manifest.Runtime.Kind,
+		ExtensionVersion: installation.Version, RuntimeIdentity: runtimeIdentity, RuntimeKind: manifest.Runtime.Kind,
 		Platform: platform, Runner: manifest.Runtime.Install.Runner,
 		PackageName: packageName, PackageVersion: packageVersion, InstallRoot: installRoot,
 		InstallCommand: append([]string{manifest.Runtime.Install.Runner}, installArgs...),
@@ -138,6 +148,53 @@ func buildInstallPlan(targetID, installRoot, runtimeInstallDir string, installat
 	digest := sha256.Sum256(encoded)
 	plan.PlanDigest = hex.EncodeToString(digest[:])
 	return plan, nil
+}
+
+func managedRuntimeIdentity(
+	installation Installation,
+	profile DiscoveryProfile,
+	packageName string,
+	packageVersion string,
+	platform string,
+) (string, error) {
+	value := struct {
+		SchemaVersion  string           `json:"schemaVersion"`
+		AgentKey       string           `json:"agentKey"`
+		RuntimeKind    string           `json:"runtimeKind"`
+		Platform       string           `json:"platform"`
+		Runner         string           `json:"runner"`
+		PackageName    string           `json:"packageName"`
+		PackageVersion string           `json:"packageVersion"`
+		InstallArgs    []string         `json:"installArgs"`
+		Launch         runtimeLaunchKey `json:"launch"`
+		Discovery      DiscoveryProfile `json:"discovery"`
+	}{
+		SchemaVersion: "tutti.agent.managed-runtime-identity.v1",
+		AgentKey:      installation.AgentKey, RuntimeKind: installation.Manifest.Runtime.Kind,
+		Platform: platform, Runner: installation.Manifest.Runtime.Install.Runner,
+		PackageName: packageName, PackageVersion: packageVersion,
+		InstallArgs: append([]string(nil), installation.Manifest.Runtime.Install.Args...),
+		Launch: runtimeLaunchKey{
+			Executable: installation.Manifest.Runtime.Launch.Executable,
+			Args:       append([]string(nil), installation.Manifest.Runtime.Launch.Args...),
+		},
+		Discovery: profile,
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("encode managed runtime identity: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return "runtime-" + hex.EncodeToString(digest[:])[:16], nil
+}
+
+type runtimeLaunchKey struct {
+	Executable string   `json:"executable"`
+	Args       []string `json:"args"`
+}
+
+func managedRuntimeRoot(runtimeInstallDir, agentKey, runtimeIdentity string) string {
+	return filepath.Join(strings.TrimSpace(runtimeInstallDir), agentKey, runtimeIdentity)
 }
 
 func exactRuntimePackage(runner string, arguments []string) (string, string, error) {
@@ -185,12 +242,15 @@ func pathWithin(path, root string) bool {
 	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
 }
 
-func validateManagedRuntimeRoot(installRoot, runtimeInstallDir string, installation Installation) error {
+func validateManagedRuntimeRoot(installRoot, runtimeInstallDir, agentKey, runtimeIdentity string) error {
 	runtimeInstallDir = strings.TrimSpace(runtimeInstallDir)
 	if runtimeInstallDir == "" || !filepath.IsAbs(runtimeInstallDir) {
 		return fmt.Errorf("%w: managed runtime install directory is invalid", ErrInvalidInstallPlanRequest)
 	}
-	expected := filepath.Join(runtimeInstallDir, installation.AgentKey, installation.Version)
+	if strings.TrimSpace(agentKey) == "" || strings.TrimSpace(runtimeIdentity) == "" || strings.Contains(runtimeIdentity, string(filepath.Separator)) {
+		return fmt.Errorf("%w: managed runtime identity is invalid", ErrInvalidInstallPlanRequest)
+	}
+	expected := filepath.Join(runtimeInstallDir, agentKey, runtimeIdentity)
 	if filepath.Clean(installRoot) != expected {
 		return fmt.Errorf("%w: managed runtime root is invalid", ErrInvalidInstallPlanRequest)
 	}

--- a/services/tuttid/service/agentextension/install_plan_test.go
+++ b/services/tuttid/service/agentextension/install_plan_test.go
@@ -59,7 +59,10 @@ func TestInstallPlanServiceBuildsDeterministicTargetScopedPlan(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantRoot := filepath.Join(runtimeInstallDir, "gemini", "1.0.0")
+	if plan.RuntimeIdentity == "" {
+		t.Fatalf("plan runtime identity is empty: %#v", plan)
+	}
+	wantRoot := filepath.Join(runtimeInstallDir, "gemini", plan.RuntimeIdentity)
 	wantInstallCommand := []string{"npm", "install", "--prefix", wantRoot, "@google/gemini-cli@0.50.0"}
 	if plan.InstallRoot != wantRoot || !reflect.DeepEqual(plan.InstallCommand, wantInstallCommand) {
 		t.Fatalf("plan scope/command = %#v", plan)
@@ -86,8 +89,45 @@ func TestInstallPlanServiceBuildsDeterministicTargetScopedPlan(t *testing.T) {
 		t.Fatal("target-managed plan changed across workspaces")
 	}
 
-	if _, err := buildInstallPlan("extension:gemini", t.TempDir(), runtimeInstallDir, installation); !errors.Is(err, ErrInvalidInstallPlanRequest) {
+	if err := validateManagedRuntimeRoot(t.TempDir(), runtimeInstallDir, installation.AgentKey, plan.RuntimeIdentity); !errors.Is(err, ErrInvalidInstallPlanRequest) {
 		t.Fatalf("invalid managed install root error = %v", err)
+	}
+}
+
+func TestInstallPlanServiceReusesRuntimeIdentityAcrossExtensionVersions(t *testing.T) {
+	stateDir := t.TempDir()
+	runtimeInstallDir := filepath.Join(t.TempDir(), ".local", "share", "tutti", "agent-runtimes")
+	manager := &Manager{Installations: agentextensiondata.NewFileInstallationStore(stateDir), RuntimeInstallDir: runtimeInstallDir}
+	first, err := manager.install(Release{AgentKey: "gemini", Version: "1.0.0"}, testPackageZIP(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	nextManifest := testManifest()
+	nextManifest.Version = "1.0.1"
+	second, err := manager.install(Release{AgentKey: "gemini", Version: "1.0.1"}, testPackageZIPFor(
+		t,
+		nextManifest,
+		`{"schemaVersion":"tutti.agent.discovery.v1","candidates":[{"binaryNames":["gemini"],"version":{"args":["--version"],"constraint":">=0.50.0 <1.0.0"},"launchArgs":["--acp"],"probe":{"kind":"acp-initialize","timeoutMs":5000}}]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstPlan, err := buildInstallPlan("extension:gemini", runtimeInstallDir, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondPlan, err := buildInstallPlan("extension:gemini", runtimeInstallDir, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstPlan.RuntimeIdentity != secondPlan.RuntimeIdentity || firstPlan.InstallRoot != secondPlan.InstallRoot {
+		t.Fatalf("runtime identity changed across extension metadata update: first=%#v second=%#v", firstPlan, secondPlan)
+	}
+	if firstPlan.ExtensionInstallationID == secondPlan.ExtensionInstallationID {
+		t.Fatalf("fixture did not create distinct extension installations: %q", firstPlan.ExtensionInstallationID)
+	}
+	if firstPlan.PlanDigest == secondPlan.PlanDigest {
+		t.Fatal("plan digest did not retain extension installation binding")
 	}
 }
 

--- a/services/tuttid/service/agentextension/installer.go
+++ b/services/tuttid/service/agentextension/installer.go
@@ -154,7 +154,7 @@ func (s *SetupService) executeInstall(
 	}
 	activation := managedRuntimeActivation{
 		SchemaVersion: managedRuntimeActivationSchema, ExtensionInstallationID: installation.ID,
-		PackageName: plan.PackageName, PackageVersion: plan.PackageVersion,
+		RuntimeIdentity: plan.RuntimeIdentity, PackageName: plan.PackageName, PackageVersion: plan.PackageVersion,
 		ExecutableRelativePath: filepath.ToSlash(relativeExecutable), InstalledAt: time.Now().UTC(),
 	}
 	activation.ExecutableFingerprint, err = fingerprintRuntimeExecutable(realExecutable)
@@ -164,11 +164,11 @@ func (s *SetupService) executeInstall(
 	if err := writeJSONAtomic(filepath.Join(staging, "activation.json"), activation); err != nil {
 		return fmt.Errorf("%w: write activation: %w", ErrRuntimeActivateFailed, err)
 	}
-	entry, err := s.Plans.Manager.managedRuntimeEntry(installation, plan.Executable, activation.ExecutableRelativePath)
+	entry, err := s.Plans.Manager.managedRuntimeEntry(installation, plan.InstallRoot, plan.Executable, activation.ExecutableRelativePath)
 	if err != nil {
 		return fmt.Errorf("%w: derive user executable entry: %w", ErrRuntimeActivateFailed, err)
 	}
-	if err := activateManagedRuntime(installation, staging, plan.InstallRoot, s.Plans.Manager.RuntimeInstallDir, entry); err != nil {
+	if err := activateManagedRuntime(installation, staging, plan, s.Plans.Manager.RuntimeInstallDir, entry); err != nil {
 		return fmt.Errorf("%w: %w", ErrRuntimeActivateFailed, err)
 	}
 	return nil
@@ -213,8 +213,9 @@ func cleanInstallEnvironment(scratch string) []string {
 	)
 }
 
-func activateManagedRuntime(installation Installation, staging, finalRoot, runtimeInstallDir string, entry managedRuntimeEntry) error {
-	if err := validateManagedRuntimeRoot(finalRoot, runtimeInstallDir, installation); err != nil {
+func activateManagedRuntime(installation Installation, staging string, plan InstallPlan, runtimeInstallDir string, entry managedRuntimeEntry) error {
+	finalRoot := plan.InstallRoot
+	if err := validateManagedRuntimeRoot(finalRoot, runtimeInstallDir, installation.AgentKey, plan.RuntimeIdentity); err != nil {
 		return err
 	}
 	if err := validateManagedRuntimeEntry(entry); err != nil {

--- a/services/tuttid/service/agentextension/managed_runtime.go
+++ b/services/tuttid/service/agentextension/managed_runtime.go
@@ -16,6 +16,7 @@ const managedRuntimeActivationSchema = "tutti.agent.managed-runtime.v1"
 type managedRuntimeActivation struct {
 	SchemaVersion           string                       `json:"schemaVersion"`
 	ExtensionInstallationID string                       `json:"extensionInstallationId"`
+	RuntimeIdentity         string                       `json:"runtimeIdentity"`
 	PackageName             string                       `json:"packageName"`
 	PackageVersion          string                       `json:"packageVersion"`
 	ExecutableRelativePath  string                       `json:"executableRelativePath"`
@@ -29,16 +30,32 @@ func (m *Manager) resolveInstalledManagedRuntime(
 	profile DiscoveryProfile,
 	cwd string,
 ) (RuntimeBinding, error) {
-	root := m.managedRuntimeRoot(installation)
 	if strings.TrimSpace(m.RuntimeInstallDir) == "" {
 		return RuntimeBinding{}, errors.New("managed runtime install directory is not configured")
 	}
-	var activation managedRuntimeActivation
-	if err := readJSON(filepath.Join(root, "activation.json"), &activation); err != nil {
+	packageName, packageVersion, err := exactRuntimePackage(installation.Manifest.Runtime.Install.Runner, installation.Manifest.Runtime.Install.Args)
+	if err != nil {
 		return RuntimeBinding{}, err
 	}
-	if activation.SchemaVersion != managedRuntimeActivationSchema || activation.ExtensionInstallationID != installation.ID {
+	runtimeIdentity, err := managedRuntimeIdentity(installation, profile, packageName, packageVersion, runtimePlatform())
+	if err != nil {
+		return RuntimeBinding{}, err
+	}
+	root := managedRuntimeRoot(m.RuntimeInstallDir, installation.AgentKey, runtimeIdentity)
+	var activation managedRuntimeActivation
+	if err := readJSON(filepath.Join(root, "activation.json"), &activation); err != nil {
+		if adoptErr := m.adoptCompatibleManagedRuntime(ctx, installation, profile, packageName, packageVersion, runtimeIdentity, root); adoptErr != nil {
+			return RuntimeBinding{}, err
+		}
+		if err := readJSON(filepath.Join(root, "activation.json"), &activation); err != nil {
+			return RuntimeBinding{}, err
+		}
+	}
+	if activation.SchemaVersion != managedRuntimeActivationSchema || activation.RuntimeIdentity != runtimeIdentity {
 		return RuntimeBinding{}, errors.New("managed runtime activation identity is invalid")
+	}
+	if activation.PackageName != packageName || activation.PackageVersion != packageVersion {
+		return RuntimeBinding{}, errors.New("managed runtime package identity is invalid")
 	}
 	executable := filepath.Clean(filepath.Join(root, filepath.FromSlash(activation.ExecutableRelativePath)))
 	if !pathWithin(executable, root) {
@@ -54,6 +71,7 @@ func (m *Manager) resolveInstalledManagedRuntime(
 	}
 	entry, err := m.managedRuntimeEntry(
 		installation,
+		root,
 		installation.Manifest.Runtime.Launch.Executable,
 		activation.ExecutableRelativePath,
 	)
@@ -77,6 +95,90 @@ func (m *Manager) resolveInstalledManagedRuntime(
 		)
 	}
 	return RuntimeBinding{}, errors.New("managed runtime version is incompatible")
+}
+
+func (m *Manager) adoptCompatibleManagedRuntime(
+	ctx context.Context,
+	installation Installation,
+	profile DiscoveryProfile,
+	packageName string,
+	packageVersion string,
+	runtimeIdentity string,
+	targetRoot string,
+) error {
+	agentRoot := filepath.Join(strings.TrimSpace(m.RuntimeInstallDir), installation.AgentKey)
+	entries, err := os.ReadDir(agentRoot)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Name() == "bin" || entry.Name() == runtimeIdentity {
+			continue
+		}
+		sourceRoot := filepath.Join(agentRoot, entry.Name())
+		activation, executable, ok := compatibleManagedRuntimeCandidate(ctx, sourceRoot, profile, packageName, packageVersion)
+		if !ok {
+			continue
+		}
+		relativeExecutable, err := filepath.Rel(sourceRoot, executable)
+		if err != nil || relativeExecutable == "." || strings.HasPrefix(relativeExecutable, ".."+string(filepath.Separator)) {
+			return errors.New("managed runtime executable path is invalid")
+		}
+		runtimeEntry, err := m.managedRuntimeEntry(
+			installation,
+			targetRoot,
+			installation.Manifest.Runtime.Launch.Executable,
+			filepath.ToSlash(relativeExecutable),
+		)
+		if err != nil {
+			return err
+		}
+		if err := validateManagedRuntimeEntry(runtimeEntry); err != nil {
+			return err
+		}
+		activation.ExtensionInstallationID = installation.ID
+		activation.RuntimeIdentity = runtimeIdentity
+		if err := writeJSONAtomic(filepath.Join(sourceRoot, "activation.json"), activation); err != nil {
+			return err
+		}
+		if err := os.Rename(sourceRoot, targetRoot); err != nil {
+			return err
+		}
+		return publishManagedRuntimeEntry(runtimeEntry)
+	}
+	return os.ErrNotExist
+}
+
+func compatibleManagedRuntimeCandidate(
+	ctx context.Context,
+	root string,
+	profile DiscoveryProfile,
+	packageName string,
+	packageVersion string,
+) (managedRuntimeActivation, string, bool) {
+	var activation managedRuntimeActivation
+	if err := readJSON(filepath.Join(root, "activation.json"), &activation); err != nil {
+		return managedRuntimeActivation{}, "", false
+	}
+	if activation.SchemaVersion != managedRuntimeActivationSchema || activation.PackageName != packageName || activation.PackageVersion != packageVersion {
+		return managedRuntimeActivation{}, "", false
+	}
+	executable := filepath.Clean(filepath.Join(root, filepath.FromSlash(activation.ExecutableRelativePath)))
+	if !pathWithin(executable, root) {
+		return managedRuntimeActivation{}, "", false
+	}
+	info, err := os.Lstat(executable)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return managedRuntimeActivation{}, "", false
+	}
+	fingerprint, err := fingerprintRuntimeExecutable(executable)
+	if err != nil || fingerprint != activation.ExecutableFingerprint || fingerprint.SHA256 == "" {
+		return managedRuntimeActivation{}, "", false
+	}
+	if _, err := compatibleInstalledVersion(ctx, executable, profile); err != nil {
+		return managedRuntimeActivation{}, "", false
+	}
+	return activation, executable, true
 }
 
 func resolveRuntimeArguments(arguments []string, cwd, installRoot string) []string {

--- a/services/tuttid/service/agentextension/managed_runtime_entry.go
+++ b/services/tuttid/service/agentextension/managed_runtime_entry.go
@@ -17,6 +17,7 @@ type managedRuntimeEntry struct {
 
 func (m *Manager) managedRuntimeEntry(
 	installation Installation,
+	finalRoot string,
 	declaredExecutable string,
 	relativeExecutable string,
 ) (managedRuntimeEntry, error) {
@@ -29,7 +30,7 @@ func (m *Manager) managedRuntimeEntry(
 	if commandName == "" || commandName == "." || commandName == string(filepath.Separator) {
 		return managedRuntimeEntry{}, errors.New("managed runtime executable name is invalid")
 	}
-	finalRoot := m.managedRuntimeRoot(installation)
+	finalRoot = filepath.Clean(finalRoot)
 	finalExecutable := filepath.Clean(filepath.Join(finalRoot, filepath.FromSlash(relativeExecutable)))
 	if !pathWithin(finalExecutable, finalRoot) {
 		return managedRuntimeEntry{}, errors.New("managed runtime executable entry escapes install root")

--- a/services/tuttid/service/agentextension/manager.go
+++ b/services/tuttid/service/agentextension/manager.go
@@ -188,10 +188,6 @@ func (m *Manager) resolveRuntime(ctx context.Context, installationID, cwd string
 	return RuntimeBinding{}, fmt.Errorf("compatible local runtime for %s is not installed", installation.AgentKey)
 }
 
-func (m *Manager) managedRuntimeRoot(installation Installation) string {
-	return filepath.Join(strings.TrimSpace(m.RuntimeInstallDir), installation.AgentKey, installation.Version)
-}
-
 func (m *Manager) ensureDiscoveryRoot(ctx context.Context) (string, error) {
 	if m.Discovery == nil {
 		return "", errors.New("agent extension discovery directory is not configured")

--- a/services/tuttid/service/agentextension/setup_test.go
+++ b/services/tuttid/service/agentextension/setup_test.go
@@ -61,8 +61,8 @@ func TestAgentTargetSetupInstallsGenericExtensionRuntime(t *testing.T) {
 		t.Fatalf("resolve user executable entry %q: %v", userEntry, err)
 	}
 	wantEntry := filepath.Join(
-		service.Plans.Manager.RuntimeInstallDir,
-		"generic", "1.0.0", "node_modules", "@example", "generic-agent", "bin", "generic-agent",
+		initial.Plan.InstallRoot,
+		"node_modules", "@example", "generic-agent", "bin", "generic-agent",
 	)
 	resolvedWantEntry, err := filepath.EvalSymlinks(wantEntry)
 	if err != nil {
@@ -91,6 +91,87 @@ func TestAgentTargetSetupInstallsGenericExtensionRuntime(t *testing.T) {
 		if !environmentPathWithin(runner.env, key, runner.cwd) {
 			t.Fatalf("installer environment %s is not isolated under %q: %v", key, runner.cwd, runner.env)
 		}
+	}
+}
+
+func TestAgentTargetSetupReusesManagedRuntimeAcrossExtensionVersions(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	runner := &fixtureInstallRunner{binary: "generic-agent", packageName: "@example/generic-agent", version: "1.2.3"}
+	service, targetID := setupFixture(
+		t, "generic", "Generic Agent", "@example/generic-agent", "1.2.3", "generic-agent", ">=1.2.3 <2.0.0",
+		runner, &probeTransport{},
+	)
+	initial, err := service.GetSetup(context.Background(), InstallPlanInput{WorkspaceID: "workspace-1", AgentTargetID: targetID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Install(context.Background(), InstallInput{
+		WorkspaceID: "workspace-1", AgentTargetID: targetID,
+		PlanDigest: initial.Plan.PlanDigest, ClientActionID: "first-install",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	firstReady := waitForSetupStatus(t, service, targetID, SetupReady)
+	if firstReady.RuntimeSource != "managed" {
+		t.Fatalf("first ready setup = %#v", firstReady)
+	}
+	var legacyActivation managedRuntimeActivation
+	if err := readJSON(filepath.Join(initial.Plan.InstallRoot, "activation.json"), &legacyActivation); err != nil {
+		t.Fatal(err)
+	}
+	legacyActivation.RuntimeIdentity = ""
+	if err := writeJSONAtomic(filepath.Join(initial.Plan.InstallRoot, "activation.json"), legacyActivation); err != nil {
+		t.Fatal(err)
+	}
+	legacyRoot := filepath.Join(service.Plans.Manager.RuntimeInstallDir, "generic", "1.0.0")
+	if err := os.Rename(initial.Plan.InstallRoot, legacyRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest := testManifest()
+	manifest.AgentKey = "generic"
+	manifest.Version = "1.0.1"
+	manifest.Name = "Generic Agent"
+	manifest.Runtime.Install.Args = []string{"install", "--prefix", "${installRoot}", "@example/generic-agent@1.2.3"}
+	manifest.Runtime.Launch.Executable = "${installRoot}/node_modules/.bin/generic-agent"
+	discovery := `{"schemaVersion":"tutti.agent.discovery.v1","candidates":[{"binaryNames":["generic-agent"],"version":{"args":["--version"],"constraint":">=1.2.3 <2.0.0"},"launchArgs":["--acp"],"probe":{"kind":"acp-initialize","timeoutMs":5000}}]}`
+	next, err := service.Plans.Manager.install(Release{AgentKey: "generic", Version: "1.0.1"}, testPackageZIPFor(t, manifest, discovery))
+	if err != nil {
+		t.Fatal(err)
+	}
+	launchRef, err := agenttargetbiz.CanonicalLaunchRefJSON(next.Provider, agenttargetbiz.LaunchRef{
+		Type: agenttargetbiz.LaunchRefTypeAgentExtension, ExtensionInstallationID: next.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := service.Plans.Targets.(*targetStoreStub)
+	target := store.targets[targetID]
+	target.LaunchRefJSON = launchRef
+	store.targets[targetID] = target
+
+	snapshot, err := service.GetSetup(context.Background(), InstallPlanInput{WorkspaceID: "workspace-1", AgentTargetID: targetID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Status != SetupReady || snapshot.RuntimeSource != "managed" || snapshot.RuntimeVersion != "1.2.3" {
+		t.Fatalf("reused runtime setup = %#v", snapshot)
+	}
+	if _, err := os.Stat(filepath.Join(initial.Plan.InstallRoot, "activation.json")); err != nil {
+		t.Fatalf("adopted runtime root is unavailable: %v", err)
+	}
+	if _, err := os.Stat(legacyRoot); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("legacy runtime root was not adopted away: %v", err)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("runtime was reinstalled after extension metadata update: calls=%d", runner.calls)
+	}
+	nextPlan, err := service.Plans.GetInstallPlan(context.Background(), InstallPlanInput{WorkspaceID: "workspace-1", AgentTargetID: targetID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nextPlan.InstallRoot != initial.Plan.InstallRoot || nextPlan.RuntimeIdentity != initial.Plan.RuntimeIdentity {
+		t.Fatalf("runtime identity changed across extension versions: first=%#v next=%#v", initial.Plan, nextPlan)
 	}
 }
 
@@ -130,7 +211,7 @@ func TestAgentTargetSetupDoesNotOverwriteUserExecutable(t *testing.T) {
 	if string(content) != "user-owned\n" {
 		t.Fatalf("user executable was overwritten: %q", content)
 	}
-	if _, err := os.Stat(filepath.Join(service.Plans.Manager.RuntimeInstallDir, "generic", "1.0.0")); !errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(initial.Plan.InstallRoot); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("failed activation left managed runtime behind: %v", err)
 	}
 }
@@ -284,7 +365,7 @@ func TestAgentTargetSetupRejectsManagedRuntimeBinaryReplacement(t *testing.T) {
 		t.Fatal(err)
 	}
 	ready := waitForSetupStatus(t, service, targetID, SetupReady)
-	root := filepath.Join(service.Plans.Manager.RuntimeInstallDir, "gemini", "1.0.0")
+	root := initial.Plan.InstallRoot
 	var activation managedRuntimeActivation
 	if err := readJSON(filepath.Join(root, "activation.json"), &activation); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- derive Agent Extension managed runtime roots from a runtime contract identity instead of extension version
- adopt compatible legacy extension-version runtime roots only after activation, package, fingerprint, and version checks pass
- update Agent Extension architecture/local-state docs for runtime identity storage

## Fix Scope Justification
Root cause: Agent Extension managed runtime identity was incorrectly coupled to the extension package version, so a metadata-only extension update made Tutti look for a new runtime directory even when the actual CLI package, launch command, and discovery contract were unchanged.

Lower layer: this cannot be fixed in Agent GUI or setup copy because the wrong state boundary is created in daemon install-plan and managed-runtime resolution. The daemon is the lowest layer that owns the runtime root, activation record, symlink integrity, and reinstall/adoption decision.

## Checks
- pnpm check:changed --tail-lines 80
- pnpm lint:go
- pnpm test:go && pnpm build:go
- pnpm check:full