### PR TITLE
style(agent-gui): drop plan-card expand shadow, fix image menu colors

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -209,7 +209,7 @@
   overflow: hidden;
   border: 1px solid var(--line-2);
   border-radius: 8px;
-  background: var(--background-panel);
+  background: var(--background-fronted);
   box-shadow: 0 18px 40px color-mix(in srgb, black 26%, transparent);
   color: var(--text-primary);
   padding: 4px;
@@ -274,9 +274,12 @@
 }
 
 .tsh-zoom-dialog__icon-button:hover,
-.tsh-zoom-dialog__image-actions button:hover,
-.tsh-image-context-menu button:hover {
+.tsh-zoom-dialog__image-actions button:hover {
   background: color-mix(in srgb, var(--background-panel) 82%, white 12%);
+}
+
+.tsh-image-context-menu button:hover {
+  background: var(--transparency-hover);
 }
 
 .tsh-zoom-dialog__zoom-controls button:not(:disabled):hover {

--- a/packages/agent/gui/shared/agentConversation/components/AgentPlanCard.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentPlanCard.tsx
@@ -110,7 +110,7 @@ export function AgentPlanCard({
             <button
               type="button"
               data-testid="agent-plan-card-expand"
-              className="pointer-events-auto inline-flex h-7 items-center rounded-full border border-[var(--line-2)] bg-[var(--background-fronted)] px-3 text-[12px] font-medium text-[var(--text-secondary)] shadow-sm transition-colors hover:text-[var(--text-primary)]"
+              className="pointer-events-auto inline-flex h-7 items-center rounded-full border border-[var(--line-2)] bg-[var(--background-fronted)] px-3 text-[12px] font-medium text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]"
               onClick={() => setCollapsed(false)}
             >
               {translate("agentHost.agentGui.planCardExpand")}


### PR DESCRIPTION
## Summary
Two small presentational fixes in the AgentGUI conversation view:

- **Plan card** – remove the `shadow-sm` box-shadow on the "Expand plan" button. Its border already uses `--line-2`, so the shadow was redundant.
- **Image right-click menu** (`.tsh-image-context-menu`) – use `--background-fronted` for the menu surface (was `--background-panel`) and `--transparency-hover` for the item hover. The hover rule was split out from the shared zoom-dialog button rule so the zoom-dialog icon/action buttons keep their existing treatment.

## Notes
Scoped intentionally to the two completed UI files. Unrelated in-progress feature work in the working tree was left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->