### PR TITLE
fix(desktop): preserve model input focus

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
@@ -418,3 +418,11 @@ test("workspace managed provider API key is masked until toggled visible", () =>
   assert.match(source, /workspace\.settings\.apps\.managedModels\.showApiKey/);
   assert.match(source, /workspace\.settings\.apps\.managedModels\.hideApiKey/);
 });
+
+test("workspace managed provider model rows keep stable keys while editing", () => {
+  assert.match(source, /key=\{`\$\{model\.provider\}:\$\{index\}`\}/);
+  assert.doesNotMatch(
+    source,
+    /key=\{`\$\{model\.provider\}:\$\{model\.id\}:\$\{index\}`\}/
+  );
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -1440,7 +1440,7 @@ function ManagedModelProviderFields({
         <div className="flex flex-col gap-1.5">
           {draft.models.map((model, index) => (
             <div
-              key={`${model.provider}:${model.id}:${index}`}
+              key={`${model.provider}:${index}`}
               className="grid grid-cols-[minmax(0,1fr)_32px] items-center gap-1.5"
             >
               <Input

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -261,6 +261,29 @@
   [WorkspaceFileReferencePickerTree.tsx](../../../packages/workspace/file-reference/src/ui/internal/reference/WorkspaceFileReferencePickerTree.tsx)
   [IssueManagerSidebarSections.tsx](../../../packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerSidebarSections.tsx)
 
+### Controlled list input loses focus after every edit
+
+- Symptom:
+  Typing or deleting one character in a controlled input inside a rendered list
+  immediately ends the input state or clears focus.
+- Quick checks:
+  Inspect the nearest mapped row's React `key`. Confirm the key does not include
+  the input value or another field that changes in the input's `onChange` path.
+- Root cause:
+  Each edit changes the row key, so React treats the row as a different element
+  and unmounts the focused input before mounting its replacement.
+- Fix:
+  Build list-row keys only from stable row identity. For append/remove-only
+  drafts without a persisted row ID, a stable parent identity plus the row
+  position is acceptable; do not include editable values merely to make the key
+  look unique.
+- Validation:
+  Keep a regression test that rejects editable values in the row key. Manually
+  type and backspace repeatedly in each affected input and confirm that focus
+  and selection remain in the same field.
+- References:
+  [WorkspaceSettingsPanel.tsx](../../../apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx)
+
 ### External-store snapshots churn because derived reads lose reference stability
 
 - Symptom:


### PR DESCRIPTION
## Summary

- keep managed model rows mounted while their model IDs are edited
- add a regression test that prevents editable model IDs from being used in React row keys
- document the controlled-list input remount trap in the renderer troubleshooting guide

The model ID input previously used `model.id` as part of its React row key. Every keystroke changed the key, so React unmounted the focused input and mounted a replacement. Using the stable provider and row position preserves focus during typing and deletion.

## Verification

- `node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm check:renderer-boundaries`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:changed --tail-lines 80`
- `pnpm check:full` (18 tasks passed via pre-push hook)

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (Not applicable; no README or CONTRIBUTING changes.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI key fix in workspace settings with a regression test and docs; no auth, persistence, or API behavior changes.
> 
> **Overview**
> Fixes **managed model ID** inputs in workspace Apps settings losing focus after each keystroke.
> 
> Row `key` values no longer include **`model.id`** (now `provider` + row index only). Including the editable ID made React remount the row on every change and drop focus.
> 
> Adds a **source regression test** that blocks editable fields in list row keys, and documents the **controlled-list input remount** pattern in the workbench renderer troubleshooting guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ff2ea07e5b77fa217b0bb0c3f37de2e9c8452c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->