### PR TITLE
fix(agent-gui): make rail selection follow conversation filter

### DIFF
--- a/.changeset/agent-gui-rail-filter-selection.md
+++ b/.changeset/agent-gui-rail-filter-selection.md
@@ -1,0 +1,7 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Keep provider rail selection owned by the canonical conversation filter so
+unavailable and compatibility Agent targets render the correct selected state
+without conflating readiness with rail scope.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -397,6 +397,16 @@ remembered session was deleted or belongs to another target, the click enters
 that agent's empty home composer. A remembered bounded-history session may be
 activated before its rail row is loaded, then reconciled through the normal
 session-authoritative detail path.
+The provider rail tab selection indicator has exactly one owner:
+`conversationFilter`. `All` is selected only for the `all` scope, and an Agent
+tile is selected only when the filter's `agentTargetId` exactly matches that
+tile's trimmed canonical `agentTargetId`. Availability, `disabled`, the home
+composer's `selectedAgentTarget`, and active or historical conversation detail
+must not override that selection. They continue to own readiness, send/create
+gates, unavailable detail, and historical presentation independently. Rail
+scope actions fail closed when a compatibility target lacks a canonical
+`agentTargetId`; `targetId` and provider identity are not rail selection
+fallbacks.
 Empty-home rail clicks may also sync the home composer launch target.
 The conversation rail keeps one in-memory view scope for each exact target and
 the all-target view. Returning to a visited scope restores its scroll offset,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIProviderHome.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIProviderHome.spec.tsx
@@ -7,18 +7,22 @@ import { useAgentGUIProviderHome } from "./useAgentGUIProviderHome";
 
 describe("useAgentGUIProviderHome", () => {
   it("restores the selected target's last session in the current node", () => {
-    const codexTarget = target("codex", "local:codex");
-    const claudeTarget = target("claude-code", "local:claude-code");
+    const codexTarget = target("codex", "agent:codex", "provider-target:codex");
+    const claudeTarget = target(
+      "claude-code",
+      "agent:claude-code",
+      "provider-target:claude-code"
+    );
     const conversations = [
-      conversation("codex-session", "codex", "local:codex"),
-      conversation("claude-session", "claude-code", "local:claude-code")
+      conversation("codex-session", "codex", "agent:codex"),
+      conversation("claude-session", "claude-code", "agent:claude-code")
     ];
     let data: AgentGUINodeData = {
-      agentTargetId: "local:codex",
+      agentTargetId: "agent:codex",
       lastActiveAgentSessionId: "codex-session",
       lastActiveAgentSessionIdByAgentTargetId: {
-        "local:claude-code": "claude-session",
-        "local:codex": "codex-session"
+        "agent:claude-code": "claude-session",
+        "agent:codex": "codex-session"
       },
       provider: "codex"
     };
@@ -39,12 +43,12 @@ describe("useAgentGUIProviderHome", () => {
         clearRailRevealRequest: vi.fn(),
         conversationFilter: {
           kind: "agentTarget",
-          agentTargetId: "local:codex"
+          agentTargetId: "agent:codex"
         },
         conversationFilterRef: {
           current: {
             kind: "agentTarget",
-            agentTargetId: "local:codex"
+            agentTargetId: "agent:codex"
           }
         },
         conversationListInitialized: true,
@@ -52,7 +56,7 @@ describe("useAgentGUIProviderHome", () => {
         conversationsRef: { current: conversations },
         data,
         dataRef,
-        defaultAgentTargetId: "local:codex",
+        defaultAgentTargetId: "agent:codex",
         effectiveSelectedProviderTarget: codexTarget,
         firstReadyHomeComposerProviderTarget: codexTarget,
         homeComposerTargetOverride: null,
@@ -71,10 +75,10 @@ describe("useAgentGUIProviderHome", () => {
         providerReadinessGates: null,
         selectedComposerTargetDataRef: {
           current: {
-            agentTargetId: "local:codex",
+            agentTargetId: "agent:codex",
             data,
             provider: "codex",
-            targetId: "local:codex"
+            targetId: "provider-target:codex"
           }
         },
         selectConversation,
@@ -95,7 +99,7 @@ describe("useAgentGUIProviderHome", () => {
 
     act(() =>
       result.current.selectConversationFilterTarget({
-        agentTargetId: "local:claude-code",
+        agentTargetId: "  agent:claude-code  ",
         provider: "claude-code"
       })
     );
@@ -103,25 +107,43 @@ describe("useAgentGUIProviderHome", () => {
     expect(unactivate).toHaveBeenCalledWith("codex-session");
     expect(setConversationFilter).toHaveBeenCalledWith({
       kind: "agentTarget",
-      agentTargetId: "local:claude-code"
+      agentTargetId: "agent:claude-code"
     });
     expect(selectConversation).toHaveBeenCalledWith("claude-session", {
       reloadConversations: false
     });
     expect(data.lastActiveAgentSessionIdByAgentTargetId).toEqual({
-      "local:claude-code": "claude-session",
-      "local:codex": "codex-session"
+      "agent:claude-code": "claude-session",
+      "agent:codex": "codex-session"
     });
+    const filterCallCount = setConversationFilter.mock.calls.length;
+    const selectionCallCount = selectConversation.mock.calls.length;
+    const unactivateCallCount = unactivate.mock.calls.length;
+
+    act(() =>
+      result.current.selectConversationFilterTarget({
+        agentTargetId: "   ",
+        provider: "claude-code"
+      })
+    );
+
+    expect(setConversationFilter).toHaveBeenCalledTimes(filterCallCount);
+    expect(selectConversation).toHaveBeenCalledTimes(selectionCallCount);
+    expect(unactivate).toHaveBeenCalledTimes(unactivateCallCount);
   });
 });
 
-function target(provider: string, agentTargetId: string): AgentGUIAgentTarget {
+function target(
+  provider: string,
+  agentTargetId: string,
+  targetId: string
+): AgentGUIAgentTarget {
   return {
     agentTargetId,
     label: agentTargetId,
     provider,
     ref: { kind: "local", provider },
-    targetId: agentTargetId
+    targetId
   };
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIProviderHome.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIProviderHome.ts
@@ -335,13 +335,22 @@ export function useAgentGUIProviderHome(input: UseAgentGUIProviderHomeInput) {
   ]);
 
   const selectConversationFilterTarget = useCallback(
-    (selection: {
-      provider: AgentGUIProvider;
-      agentTargetId?: string | null;
-    }) => {
+    (selection: { provider: AgentGUIProvider; agentTargetId: string }) => {
       const current = inputRef.current;
+      const agentTargetId = selection.agentTargetId.trim();
+      if (!agentTargetId) {
+        reportAgentGUIConversationFilterTargetUnresolved({
+          provider: selection.provider,
+          agentTargetId: null,
+          providerTargetCount: current.normalizedProviderTargets.length,
+          reason: "unresolved",
+          runtime: current.agentActivityRuntime,
+          workspaceId: current.workspaceId
+        });
+        return;
+      }
       const nextTarget = resolveAgentGUIAgentTarget({
-        agentTargetId: selection.agentTargetId,
+        agentTargetId,
         defaultAgentTargetId: current.defaultAgentTargetId,
         provider: selection.provider,
         agentTargets: current.normalizedProviderTargets,
@@ -350,7 +359,7 @@ export function useAgentGUIProviderHome(input: UseAgentGUIProviderHomeInput) {
       if (!nextTarget) {
         reportAgentGUIConversationFilterTargetUnresolved({
           provider: selection.provider,
-          agentTargetId: selection.agentTargetId ?? null,
+          agentTargetId,
           providerTargetCount: current.normalizedProviderTargets.length,
           reason: "unresolved",
           runtime: current.agentActivityRuntime,
@@ -359,10 +368,7 @@ export function useAgentGUIProviderHome(input: UseAgentGUIProviderHomeInput) {
         return;
       }
       current.clearRailRevealRequest();
-      const agentTargetId = nextTarget.agentTargetId?.trim() ?? "";
-      const nextFilter = agentTargetId
-        ? { kind: "agentTarget" as const, agentTargetId }
-        : { kind: "all" as const };
+      const nextFilter = { kind: "agentTarget" as const, agentTargetId };
       current.setConversationFilter(nextFilter);
       const activeId = current.activeConversationIdRef.current;
       const activeSummary = resolveConversationSummaryById(
@@ -405,7 +411,10 @@ export function useAgentGUIProviderHome(input: UseAgentGUIProviderHomeInput) {
         targetAgentTargetId: agentTargetId || null
       });
       if (rememberedSelection.kind === "restore") {
-        selectHomeComposerAgentTarget(selection);
+        selectHomeComposerAgentTarget({
+          provider: nextTarget.provider,
+          agentTargetId
+        });
         current.selectConversation(rememberedSelection.agentSessionId, {
           reloadConversations: false
         });
@@ -421,7 +430,10 @@ export function useAgentGUIProviderHome(input: UseAgentGUIProviderHomeInput) {
           staleIds
         );
       }
-      selectHomeComposerAgentTarget(selection);
+      selectHomeComposerAgentTarget({
+        provider: nextTarget.provider,
+        agentTargetId
+      });
     },
     [selectHomeComposerAgentTarget]
   );
@@ -455,7 +467,7 @@ export function useAgentGUIProviderHome(input: UseAgentGUIProviderHomeInput) {
     if (!target) return;
     selectHomeComposerAgentTarget({
       provider: target.provider,
-      agentTargetId: target.targetId
+      agentTargetId: filterAgentTargetId
     });
   }, [
     input.activeConversationId,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -418,7 +418,7 @@ export interface AgentGUINodeViewProps {
     ) => void;
     selectConversationFilterTarget: (input: {
       provider: AgentGUIProvider;
-      agentTargetId?: string | null;
+      agentTargetId: string;
     }) => void;
     createConversation: (options?: {
       projectPath?: string | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIProviderRail.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIProviderRail.spec.tsx
@@ -1,0 +1,246 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@tutti-os/ui-system";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentGUIAgentTarget } from "../../../types";
+import type { AgentGUIViewLabels } from "./AgentGUINodeView.types";
+import { AgentGUIProviderRail } from "./AgentGUIProviderRail";
+
+describe("AgentGUIProviderRail selection", () => {
+  beforeEach(() => {
+    globalThis.localStorage.clear();
+  });
+
+  it("derives mutually exclusive aria and visual selection only from conversationFilter", () => {
+    const readyTarget = target({
+      agentTargetId: "agent:ready",
+      label: "Ready Agent",
+      provider: "ready-provider",
+      targetId: "legacy:ready"
+    });
+    const unavailableTarget = target({
+      agentTargetId: "agent:offline",
+      availability: { status: "unavailable" },
+      disabled: true,
+      label: "Offline Agent",
+      provider: "offline-provider",
+      targetId: "legacy:offline"
+    });
+    const placeholderTarget = target({
+      agentTargetId: "agent:placeholder",
+      disabled: true,
+      label: "Placeholder Agent",
+      provider: "placeholder-provider",
+      targetId: "local:placeholder-provider"
+    });
+    const props = providerRailProps({
+      agentTargets: [readyTarget, unavailableTarget, placeholderTarget],
+      conversationFilter: {
+        kind: "agentTarget",
+        agentTargetId: "agent:offline"
+      },
+      selectedAgentTarget: placeholderTarget
+    });
+    const view = render(providerRail(props));
+
+    expectOnlySelectedTab("Offline Agent");
+
+    view.rerender(
+      providerRail({
+        ...props,
+        conversationFilter: { kind: "all" },
+        selectedAgentTarget: unavailableTarget
+      })
+    );
+
+    expectOnlySelectedTab("All agents");
+
+    view.rerender(
+      providerRail({
+        ...props,
+        conversationFilter: {
+          kind: "agentTarget" as const,
+          agentTargetId: "agent:placeholder"
+        },
+        selectedAgentTarget: readyTarget
+      })
+    );
+
+    expectOnlySelectedTab("Placeholder Agent");
+  });
+
+  it("uses canonical agentTargetId for tile clicks and fails closed without it", () => {
+    const onSelectConversationFilterTarget = vi.fn();
+    const canonicalTarget = target({
+      agentTargetId: "  agent:canonical  ",
+      disabled: true,
+      label: "Canonical Agent",
+      provider: "canonical-provider",
+      targetId: "legacy-provider-target"
+    });
+    const compatibilityTarget = target({
+      label: "Compatibility Agent",
+      provider: "compatibility-provider",
+      targetId: "legacy-only-target"
+    });
+    render(
+      providerRail(
+        providerRailProps({
+          agentTargets: [canonicalTarget, compatibilityTarget],
+          onSelectConversationFilterTarget
+        })
+      )
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "Canonical Agent" }));
+
+    expect(onSelectConversationFilterTarget).toHaveBeenCalledTimes(1);
+    expect(onSelectConversationFilterTarget).toHaveBeenLastCalledWith({
+      provider: "canonical-provider",
+      agentTargetId: "agent:canonical"
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Compatibility Agent" }));
+
+    expect(onSelectConversationFilterTarget).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps All clicks aggregate and uses canonical identity for manager fallback", () => {
+    const onSelectConversationFilterTarget = vi.fn();
+    const onSelectHomeComposerAgentTarget = vi.fn();
+    const onUpdateConversationFilter = vi.fn();
+    const selectedTarget = target({
+      agentTargetId: "agent:selected",
+      disabled: true,
+      label: "Selected Agent",
+      provider: "selected-provider",
+      targetId: "legacy:selected"
+    });
+    const fallbackTarget = target({
+      agentTargetId: "agent:fallback",
+      label: "Fallback Agent",
+      provider: "fallback-provider",
+      targetId: "legacy:fallback"
+    });
+    const props = providerRailProps({
+      agentTargets: [selectedTarget, fallbackTarget],
+      conversationFilter: { kind: "all" },
+      onSelectConversationFilterTarget,
+      onSelectHomeComposerAgentTarget,
+      onUpdateConversationFilter,
+      selectedAgentTarget: selectedTarget
+    });
+    const view = render(providerRail(props));
+
+    fireEvent.click(screen.getByRole("tab", { name: "All agents" }));
+
+    expect(onUpdateConversationFilter).toHaveBeenLastCalledWith({
+      kind: "all"
+    });
+    expect(onSelectConversationFilterTarget).not.toHaveBeenCalled();
+
+    view.rerender(
+      providerRail({
+        ...props,
+        conversationFilter: {
+          kind: "agentTarget" as const,
+          agentTargetId: "agent:selected"
+        },
+        managerOpen: true
+      })
+    );
+    fireEvent.contextMenu(
+      screen.getByRole("listitem", { name: "Reorder Selected Agent" })
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove Selected Agent" })
+    );
+
+    expect(onSelectHomeComposerAgentTarget).toHaveBeenCalledWith({
+      provider: "fallback-provider",
+      agentTargetId: "agent:fallback"
+    });
+    expect(onUpdateConversationFilter).toHaveBeenLastCalledWith({
+      kind: "all"
+    });
+  });
+});
+
+function expectOnlySelectedTab(name: string): void {
+  const tabs = screen.getAllByRole("tab");
+  const selectedTabs = tabs.filter(
+    (tab) => tab.getAttribute("aria-selected") === "true"
+  );
+  expect(selectedTabs).toHaveLength(1);
+  expect(selectedTabs[0]).toBe(screen.getByRole("tab", { name }));
+  for (const tab of tabs) {
+    const selected = tab === selectedTabs[0];
+    expect(tab).toHaveAttribute("aria-selected", selected ? "true" : "false");
+    expect(tab).toHaveAttribute("data-selected", selected ? "true" : "false");
+  }
+}
+
+function target(
+  input: Pick<AgentGUIAgentTarget, "label" | "provider" | "targetId"> &
+    Partial<AgentGUIAgentTarget>
+): AgentGUIAgentTarget {
+  return {
+    ref: { kind: "local", provider: input.provider },
+    ...input
+  };
+}
+
+function providerRailProps(
+  overrides: Partial<React.ComponentProps<typeof AgentGUIProviderRail>> = {}
+): React.ComponentProps<typeof AgentGUIProviderRail> {
+  return {
+    activeConversation: null,
+    activeConversationId: null,
+    agentTargets: [],
+    agentTargetsLoading: false,
+    comingSoonProviders: [],
+    conversationFilter: { kind: "all" },
+    conversations: [],
+    labels: LABELS,
+    managerOpen: false,
+    onManagerOpenChange: vi.fn(),
+    onRequestComposerFocus: vi.fn(),
+    onSelectConversationFilterTarget: vi.fn(),
+    onSelectHomeComposerAgentTarget: vi.fn(),
+    onUpdateConversationFilter: vi.fn(),
+    previewMode: false,
+    providerRailMode: "exact",
+    selectedAgentTarget: target({
+      agentTargetId: "agent:default",
+      label: "Default Agent",
+      provider: "default-provider",
+      targetId: "legacy:default"
+    }),
+    ...overrides
+  };
+}
+
+function providerRail(
+  props: React.ComponentProps<typeof AgentGUIProviderRail>
+): React.ReactElement {
+  return (
+    <TooltipProvider>
+      <AgentGUIProviderRail {...props} />
+    </TooltipProvider>
+  );
+}
+
+const LABELS = {
+  addAgentToSidebar: (agent: string) => `Add ${agent}`,
+  conversationFilterAll: "All agents",
+  dragAgentToReorder: (agent: string) => `Reorder ${agent}`,
+  manageAgentsAvailable: "Available",
+  manageAgentsDescription: "Manage rail agents",
+  manageAgentsDisabled: "Hidden",
+  manageAgentsKeepOneAvailable: "Keep one available",
+  manageAgentsNoAvailable: "No available agents",
+  manageAgentsNoDisabled: "No hidden agents",
+  manageAgentsRunningBlocked: (agent: string) => `Cannot remove ${agent}`,
+  manageAgentsTitle: "Manage agents",
+  providerSwitchLabel: "Agent filters",
+  removeAgentFromSidebar: (agent: string) => `Remove ${agent}`
+} as AgentGUIViewLabels;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIProviderRail.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIProviderRail.tsx
@@ -294,36 +294,20 @@ export const AgentGUIProviderRail = memo(function AgentGUIProviderRail({
       ),
     [effectiveHiddenTargetIds, providerTiles]
   );
-  const selectedAgentTargetIsPlaceholder =
-    selectedAgentTarget?.disabled === true &&
-    selectedAgentTarget.targetId === `local:${selectedAgentTarget.provider}`;
-  const allTileSelected =
-    conversationFilter.kind === "all" && !selectedAgentTargetIsPlaceholder;
+  const allTileSelected = conversationFilter.kind === "all";
   const selectAllProviders = useCallback(() => {
     onUpdateConversationFilter({ kind: "all" });
-    if (selectedAgentTargetIsPlaceholder) {
-      const fallbackTarget =
-        railProviderTargets.find((target) => target.disabled !== true) ?? null;
-      if (fallbackTarget) {
-        onSelectConversationFilterTarget({
-          provider: fallbackTarget.provider,
-          agentTargetId: fallbackTarget.targetId
-        });
-      }
-    }
     onRequestComposerFocus();
-  }, [
-    onSelectConversationFilterTarget,
-    onRequestComposerFocus,
-    onUpdateConversationFilter,
-    railProviderTargets,
-    selectedAgentTargetIsPlaceholder
-  ]);
+  }, [onRequestComposerFocus, onUpdateConversationFilter]);
   const selectAgentTargetTile = useCallback(
     (target: AgentGUINodeViewModel["rail"]["agentTargets"][number]) => {
+      const agentTargetId = target.agentTargetId?.trim() ?? "";
+      if (!agentTargetId) {
+        return;
+      }
       onSelectConversationFilterTarget({
         provider: target.provider,
-        agentTargetId: target.targetId
+        agentTargetId
       });
       onRequestComposerFocus();
     },
@@ -541,10 +525,14 @@ export const AgentGUIProviderRail = memo(function AgentGUIProviderRail({
         fallbackTargets.find((target) => target.disabled !== true) ??
         fallbackTargets[0];
       if (fallbackTarget && fallbackTarget.targetId !== targetId) {
-        onSelectHomeComposerAgentTarget({
-          provider: fallbackTarget.provider,
-          agentTargetId: fallbackTarget.targetId
-        });
+        const fallbackAgentTargetId =
+          fallbackTarget.agentTargetId?.trim() ?? "";
+        if (fallbackAgentTargetId) {
+          onSelectHomeComposerAgentTarget({
+            provider: fallbackTarget.provider,
+            agentTargetId: fallbackAgentTargetId
+          });
+        }
       }
     }
     if (
@@ -699,14 +687,10 @@ export const AgentGUIProviderRail = memo(function AgentGUIProviderRail({
           : null}
         {visibleProviderTiles.map((target) => {
           const providerSelected =
-            target.disabled === true
-              ? selectedAgentTargetIsPlaceholder &&
-                selectedAgentTarget?.provider === target.provider &&
-                selectedAgentTarget?.targetId === target.targetId
-              : agentGUIProviderTargetMatchesConversationFilter(
-                  target,
-                  conversationFilter
-                );
+            agentGUIProviderTargetMatchesConversationFilter(
+              target,
+              conversationFilter
+            );
           const label = agentGUIProviderRailLabel(
             target.provider,
             target.label


### PR DESCRIPTION
## Summary

- Make `conversationFilter` the sole source for provider rail tab selection, keeping `aria-selected` and `data-selected` mutually exclusive and aligned for All, ready, unavailable, disabled, and placeholder targets.
- Remove the placeholder/disabled selection branches and the All-click fallback target compensation so availability and composer/detail state remain orthogonal to rail scope.
- Pass trimmed canonical `agentTargetId` values through rail tile selection, provider manager fallback, and the provider-home controller; compatibility targets without canonical identity fail closed.
- Add focused DOM and controller regressions, a patch changeset for `@tutti-os/agent-gui`, and improve the Agent GUI architecture ownership documentation.

## Verification

- `pnpm --filter @tutti-os/agent-gui test` — 191 files and 1789 tests passed.
- `pnpm typecheck` — 27 packages passed.
- `pnpm check:agent-activity-runtime-boundaries` — passed.
- `pnpm check:changed` — 8 lanes passed before commit and again after rebasing onto the latest `origin/main`.
- `pnpm check:full` — all 18 tasks passed in the pre-push hook.
- `git diff --check` and staged formatting/lint/boundary hooks — passed.

## Unverified Items

- 未进行真实 Electron 窗口的人工视觉点击；DOM 属性与回调已由聚焦测试覆盖，既有 `data-selected` CSS 未修改。
- 提交、DCO、push 和 PR 创建留待后续 workflow 阶段。

## Fix Scope Justification

- Root cause: the provider rail still derived visual selection from the legacy disabled/placeholder target state instead of the canonical conversation filter.
- Why can this not be fixed at a lower layer? The filter, unavailable detail, and conversation behavior were already correct; ownership drift existed in the rail rendering and rail-specific identity handoff, so changing engine, session, daemon, or desktop behavior would violate those boundaries.

## Fallback Three Questions

- Source: compatibility rail targets may still omit a canonical `agentTargetId` while the exported compatibility model remains optional.
- Why can it not be fixed at that source? This change is intentionally scoped to the rail contract and does not perform the package-wide legacy target migration.
- Removal condition: remove the fail-closed compatibility guard once `AgentGUIAgentTarget.agentTargetId` is required across the package and legacy entries can no longer reach the rail.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. No README or CONTRIBUTING files changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->