### PR TITLE
fix(agent): avoid render churn during window resize

### DIFF
--- a/apps/desktop/src/main/ipc/hostWindow.ts
+++ b/apps/desktop/src/main/ipc/hostWindow.ts
@@ -195,13 +195,11 @@ export function registerHostWindowIpc(deps: HostWindowIpcDependencies): void {
         requestedWidth: input.width,
         workArea
       });
-      ownerWindow.setContentBounds(
-        nextBounds,
-        shouldAnimateStandaloneAgentWindowResize(
-          process.platform,
-          input.animate === true
-        )
+      const animate = shouldAnimateStandaloneAgentWindowResize(
+        process.platform,
+        input.animate === true
       );
+      ownerWindow.setContentBounds(nextBounds, animate);
       return { width: ownerWindow.getContentBounds().width };
     }
   );

--- a/apps/desktop/src/main/windows/workspaceWindow.ts
+++ b/apps/desktop/src/main/windows/workspaceWindow.ts
@@ -66,6 +66,22 @@ const agentWindowMinWidthPx = 420;
 const agentWindowMinHeightPx = 520;
 const agentWindowWorkAreaScale = 0.9;
 const agentWindowDuplicateOffsetPx = 25;
+const linuxWindowResizeSettleDelayMs = 150;
+
+function sendWorkspaceWindowLayout(workspaceWindow: BrowserWindow): void {
+  if (
+    workspaceWindow.isDestroyed() ||
+    workspaceWindow.webContents.isDestroyed()
+  ) {
+    return;
+  }
+
+  workspaceWindow.webContents.send(desktopIpcChannels.host.window.layout, {
+    compactTitlebar: workspaceWindow.isFullScreen(),
+    maximized: workspaceWindow.isMaximized() || workspaceWindow.isFullScreen()
+  });
+}
+
 export function createWorkspaceWindow(
   options: CreateWorkspaceWindowOptions
 ): BrowserWindow {
@@ -212,22 +228,17 @@ export function createWorkspaceWindow(
     workspaceWindows.unregister(workspaceWindow);
   });
 
-  if (process.platform === "darwin") {
-    let resizeLayoutTimer: ReturnType<typeof setTimeout> | null = null;
-    const sendHostWindowLayout = () => {
-      if (
-        workspaceWindow.isDestroyed() ||
-        workspaceWindow.webContents.isDestroyed()
-      ) {
-        return;
-      }
+  const sendHostWindowLayout = () => {
+    sendWorkspaceWindowLayout(workspaceWindow);
+  };
+  workspaceWindow.on("maximize", sendHostWindowLayout);
+  workspaceWindow.on("unmaximize", sendHostWindowLayout);
+  workspaceWindow.on("enter-full-screen", sendHostWindowLayout);
+  workspaceWindow.on("leave-full-screen", sendHostWindowLayout);
+  workspaceWindow.webContents.on("did-finish-load", sendHostWindowLayout);
 
-      workspaceWindow.webContents.send(desktopIpcChannels.host.window.layout, {
-        compactTitlebar: workspaceWindow.isFullScreen(),
-        maximized:
-          workspaceWindow.isMaximized() || workspaceWindow.isFullScreen()
-      });
-    };
+  if (process.platform === "linux") {
+    let resizeLayoutTimer: ReturnType<typeof setTimeout> | null = null;
     const scheduleHostWindowLayout = () => {
       if (resizeLayoutTimer !== null) {
         clearTimeout(resizeLayoutTimer);
@@ -236,16 +247,20 @@ export function createWorkspaceWindow(
       resizeLayoutTimer = setTimeout(() => {
         resizeLayoutTimer = null;
         sendHostWindowLayout();
-      }, 50);
+      }, linuxWindowResizeSettleDelayMs);
     };
 
-    workspaceWindow.on("maximize", sendHostWindowLayout);
-    workspaceWindow.on("unmaximize", sendHostWindowLayout);
-    workspaceWindow.on("enter-full-screen", sendHostWindowLayout);
-    workspaceWindow.on("leave-full-screen", sendHostWindowLayout);
     workspaceWindow.on("resize", scheduleHostWindowLayout);
-    workspaceWindow.webContents.on("did-finish-load", sendHostWindowLayout);
+    workspaceWindow.once("closed", () => {
+      if (resizeLayoutTimer !== null) {
+        clearTimeout(resizeLayoutTimer);
+      }
+    });
+  } else {
+    workspaceWindow.on("resized", sendHostWindowLayout);
+  }
 
+  if (process.platform === "darwin") {
     const sendHostWindowMinimizeState = (minimized: boolean) => {
       if (
         workspaceWindow.isDestroyed() ||

--- a/apps/desktop/src/preload/api/host.ts
+++ b/apps/desktop/src/preload/api/host.ts
@@ -222,6 +222,18 @@ export function createHostDesktopApi(): DesktopHostApi {
           );
         };
       },
+      onLayout(listener): () => void {
+        const handler = (_event: IpcRendererEvent, payload: unknown) => {
+          listener(payload as Parameters<typeof listener>[0]);
+        };
+        ipcRenderer.on(desktopIpcChannels.host.window.layout, handler);
+        return () => {
+          ipcRenderer.removeListener(
+            desktopIpcChannels.host.window.layout,
+            handler
+          );
+        };
+      },
       onQuitShortcutToast(listener): () => void {
         const handler = () => {
           listener();

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -33,6 +33,7 @@ import type {
   DesktopHostOpenAgentWindowInput,
   DesktopHostWindowCloseRequestPayload,
   DesktopHostWindowCloseRequestResolutionPayload,
+  DesktopHostWindowLayoutPayload,
   DesktopHostWindowResizeContentWidthInput,
   DesktopHostWindowResizeContentWidthResult,
   DesktopRendererDiagnosticPayload,
@@ -123,6 +124,9 @@ export interface DesktopHostWindowApi {
   openAgentWindow(input: DesktopHostOpenAgentWindowInput): Promise<void>;
   onCloseRequest(
     listener: (payload: DesktopHostWindowCloseRequestPayload) => void
+  ): () => void;
+  onLayout(
+    listener: (payload: DesktopHostWindowLayoutPayload) => void
   ): () => void;
   onQuitShortcutToast(listener: () => void): () => void;
   resolveCloseRequest(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
@@ -9,6 +9,10 @@ const standaloneWindowSource = readFileSync(
   resolve(currentDirectory, "StandaloneAgentWindow.tsx"),
   "utf8"
 );
+const standaloneWindowLayoutSource = readFileSync(
+  resolve(currentDirectory, "useStandaloneAgentWindowLayout.ts"),
+  "utf8"
+);
 const standaloneWindowPanelHostsSource = readFileSync(
   resolve(currentDirectory, "StandaloneAgentWindowPanelHosts.tsx"),
   "utf8"
@@ -202,6 +206,21 @@ test("standalone Agent widens a narrow window before expanding the conversation 
   assert.match(
     standaloneWindowSource,
     /AGENT_GUI_EXPANDED_TARGET_WIDTH_PX[\s\S]*?frame\.width < 640[\s\S]*?resizeContentWidth\(\{\s*width: AGENT_GUI_EXPANDED_TARGET_WIDTH_PX\s*\}\)/
+  );
+});
+
+test("standalone Agent commits window frame only after host resize completion", () => {
+  assert.doesNotMatch(
+    `${standaloneWindowSource}\n${standaloneWindowLayoutSource}`,
+    /window\.addEventListener\("resize"/
+  );
+  assert.match(
+    standaloneWindowLayoutSource,
+    /const commitWindowFrame = useCallback\(\(\) => \{[\s\S]*?currentFrame\.width === nextFrame\.width[\s\S]*?currentFrame\.height === nextFrame\.height/
+  );
+  assert.match(
+    standaloneWindowLayoutSource,
+    /hostWindowApi\.onLayout\(\(\{ maximized \}\) => \{[\s\S]*?commitWindowFrame\(\);[\s\S]*?setIsWindowMaximized\(maximized\)/
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -68,9 +68,7 @@ import type { StandaloneAgentFileOpenRequest } from "./StandaloneAgentToolSideba
 import { WorkspaceAppExternalBridge } from "./WorkspaceAppExternalBridge";
 import {
   createStandaloneAgentDockPreviewCache,
-  createStandaloneAgentHost,
-  readStandaloneAgentWindowFrame,
-  readStandaloneAgentWindowMaximizedState
+  createStandaloneAgentHost
 } from "./standaloneAgentWindowHost.ts";
 import { useWorkspaceSettingsService } from "./useWorkspaceSettingsService";
 import type { WorkspaceWorkbenchCapabilitySettingsTarget } from "../services/workspaceWorkbenchHostService.interface";
@@ -83,6 +81,7 @@ import {
 import { StandaloneAgentWindowContentReady } from "./StandaloneAgentWindowContentReady.tsx";
 import { showWorkspaceFileMissingToast } from "../services/workspaceFilesLaunchFeedback.ts";
 import { Toast } from "@renderer/lib/toast";
+import { useStandaloneAgentWindowLayout } from "./useStandaloneAgentWindowLayout.ts";
 import { createStandaloneAgentWorkspaceAppSurfacePresenter } from "../services/standaloneAgentWorkspaceAppSurfacePresenter.ts";
 import { createStandaloneAgentWorkspaceFilePreviewPresenter } from "../services/standaloneAgentWorkspaceFilePreviewPresenter.ts";
 
@@ -116,6 +115,7 @@ export interface StandaloneAgentWindowProps {
     DesktopHostWindowApi,
     | "approveClose"
     | "minimize"
+    | "onLayout"
     | "openAgentWindow"
     | "resizeContentWidth"
     | "toggleMaximize"
@@ -290,10 +290,8 @@ export function StandaloneAgentWindow({
       null
     );
   }, [agents, launchAgentTargetId, launchProvider]);
-  const [frame, setFrame] = useState(readStandaloneAgentWindowFrame);
-  const [isWindowMaximized, setIsWindowMaximized] = useState(
-    readStandaloneAgentWindowMaximizedState
-  );
+  const { frame, isWindowMaximized, resizeContentWidth } =
+    useStandaloneAgentWindowLayout(hostWindowApi);
   const [nodeState, setNodeState] = useState<DesktopAgentGUIWorkbenchState>(
     () => ({
       agentTargetId: defaultAgentTargetId,
@@ -516,29 +514,6 @@ export function StandaloneAgentWindow({
   );
 
   useEffect(() => {
-    const handleResize = () => {
-      setFrame(readStandaloneAgentWindowFrame());
-    };
-    window.addEventListener("resize", handleResize);
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
-
-  useEffect(() => {
-    // The main process pushes maximize/fullscreen transitions through the host
-    // window layout event; keep the traffic-light icon in sync with it.
-    const handleLayout = (event: Event) => {
-      const detail = (event as CustomEvent<{ maximized?: boolean }>).detail;
-      setIsWindowMaximized(detail?.maximized === true);
-    };
-    window.addEventListener("tutti-host-window-layout", handleLayout);
-    return () => {
-      window.removeEventListener("tutti-host-window-layout", handleLayout);
-    };
-  }, []);
-
-  useEffect(() => {
     void agentsService.refresh().catch(() => undefined);
   }, [agentsService]);
   const handleConversationRailToggle = useCallback(
@@ -595,9 +570,8 @@ export function StandaloneAgentWindow({
     workspaceId
   });
   const resizeStandaloneAgentWindowContentWidth = useCallback(
-    (width: number, animate = false) =>
-      hostWindowApi.resizeContentWidth({ animate, width }),
-    [hostWindowApi]
+    (width: number, animate = false) => resizeContentWidth(width, animate),
+    [resizeContentWidth]
   );
   const handleCapabilitySettingsRequest = useCallback(
     (target: WorkspaceWorkbenchCapabilitySettingsTarget) => {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useStandaloneAgentWindowLayout.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useStandaloneAgentWindowLayout.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from "react";
+import type { DesktopHostWindowApi } from "@preload/types";
+import {
+  readStandaloneAgentWindowFrame,
+  readStandaloneAgentWindowMaximizedState
+} from "./standaloneAgentWindowHost.ts";
+
+type StandaloneAgentWindowLayoutApi = Pick<
+  DesktopHostWindowApi,
+  "onLayout" | "resizeContentWidth"
+>;
+
+export function useStandaloneAgentWindowLayout(
+  hostWindowApi: StandaloneAgentWindowLayoutApi
+) {
+  const [frame, setFrame] = useState(readStandaloneAgentWindowFrame);
+  const [isWindowMaximized, setIsWindowMaximized] = useState(
+    readStandaloneAgentWindowMaximizedState
+  );
+  const commitWindowFrame = useCallback(() => {
+    const nextFrame = readStandaloneAgentWindowFrame();
+    setFrame((currentFrame) =>
+      currentFrame.width === nextFrame.width &&
+      currentFrame.height === nextFrame.height
+        ? currentFrame
+        : nextFrame
+    );
+  }, []);
+
+  useEffect(
+    () =>
+      hostWindowApi.onLayout(({ maximized }) => {
+        commitWindowFrame();
+        setIsWindowMaximized(maximized);
+      }),
+    [commitWindowFrame, hostWindowApi]
+  );
+
+  const resizeContentWidth = useCallback(
+    async (width: number, animate = false) => {
+      const result = await hostWindowApi.resizeContentWidth({ animate, width });
+      if (!animate) {
+        commitWindowFrame();
+      }
+      return result;
+    },
+    [commitWindowFrame, hostWindowApi]
+  );
+
+  return { frame, isWindowMaximized, resizeContentWidth };
+}

--- a/apps/desktop/src/renderer/src/platform/desktop/web/createWebDesktopApi.ts
+++ b/apps/desktop/src/renderer/src/platform/desktop/web/createWebDesktopApi.ts
@@ -323,6 +323,9 @@ function createWebHostApi(): DesktopHostApi {
       onCloseRequest() {
         return () => {};
       },
+      onLayout() {
+        return () => {};
+      },
       onQuitShortcutToast() {
         return () => {};
       },

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -842,19 +842,20 @@ also reserved by layout and does not change the native window bounds. Closing
 the panel restores the captured baseline width.
 Opening must be renderer-first: update the active panel immediately and defer
 the host-window resize request until the next animation frame. Do not await
-native IPC before showing the panel. Commit the sidebar's final layout width in
-one step; do not animate `width`, `flex-basis`, or another layout property,
-because that repeatedly reflows both the panel and the adjacent conversation.
+native IPC before showing the panel. The desktop host may coordinate the native
+window and sidebar width transition so opening and closing remain smooth, but
+intermediate native resize frames are host chrome and must not enter the shared
+AgentGUI surface context. CSS follows the live window bounds; React commits the
+final frame from the host's resize-completion event so the conversation subtree
+does not rerender on every native resize tick.
 When a tool switch resolves to the current native content width, the host-window
 resize request must be skipped; a previously clamped native width must also be
 treated as settled for the same target so tool switching does not cause a
 redundant resize pulse.
-The sidebar may animate only its fixed-size inner surface with a short
-right-to-left `transform` and opacity entrance. Files, Browser, Apps, and other expensive first-use
-bodies mount after that short compositor entrance, then remain mounted while
-hidden for instant later switches. Native bounds changes are applied without a
-parallel window animation. Respect `prefers-reduced-motion` by removing the
-inner entrance and the content-mount delay.
+Files, Browser, Apps, and other expensive first-use bodies mount after the
+sidebar entrance, then remain mounted while hidden for instant later switches.
+Respect `prefers-reduced-motion` by removing the native/sidebar transition,
+inner entrance, and content-mount delay.
 Lazy mounting also applies to module loading. The standalone shell may derive a
 small reminder count from the activity engine, but it must not statically import
 BrowserNode, TerminalNode, File Manager, App Center, or the full Message Center


### PR DESCRIPTION
## Summary

- publish host window layout only when native resize settles (`resized`; Linux uses a settle debounce)
- expose the layout notification through the typed preload window API
- keep native/sidebar smooth resize behavior, while committing the expensive AgentGUI frame only once at the end
- document the host-chrome versus AgentGUI frame ownership rule

## Performance evidence

Compared `/Users/ryan/Downloads/TuttiTrace-20260717T104124.json` with `/Users/ryan/Downloads/TuttiTrace-20260717T105205.json`:

- resize dispatch average: 47.5 ms -> 5.0 ms
- resize dispatch max: 89.4 ms -> 7.9 ms
- resize dispatches over 50 ms: 14 -> 0
- AgentGUI renders in the captured interactions: 66 -> 4 final-frame commits
- renderer RunTask over 50 ms: 21 -> 5; none of the new resize dispatches exceeds 50 ms

The native window and sidebar still resize smoothly. Intermediate native frames no longer rebuild the conversation subtree.

## Validation

- `pnpm --filter @tutti-os/desktop test` (1484 passed, 2 skipped)
- focused standalone Agent tests (50 passed)
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm lint:ts`
- `pnpm check:electron-runtime-boundaries`
- `pnpm check:renderer-boundaries`
- `pnpm check:changed --tail-lines 40` (8 lanes)
- `pnpm --filter @tutti-os/desktop build`
- pre-push `pnpm check:full` (18 tasks)
- architecture review: no findings

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->