### PR TITLE
fix(agent-gui): keep project move optional

### DIFF
--- a/.changeset/agent-gui-optional-project-move.md
+++ b/.changeset/agent-gui-optional-project-move.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Keep the host user-project move capability optional in the public AgentGUI API, matching the runtime capability check and workspace-user-project contract.

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
@@ -355,7 +355,7 @@ test("desktop agent host api delegates user project calls to the workspace user 
     projectLocked: true,
     selectedPath: "/workspace/listed"
   });
-  await api.userProjects.move({
+  await api.userProjects.move?.({
     beforeProjectId: "project-listed",
     projectId: "project-used"
   });

--- a/packages/agent/gui/host/agentHostApi.ts
+++ b/packages/agent/gui/host/agentHostApi.ts
@@ -283,7 +283,7 @@ export type AgentHostUserProjectsApi = AgentHostRecord & {
   list: () => AgentHostAsyncResult<{
     projects: AgentHostUserProject[];
   }>;
-  move: (input: {
+  move?: (input: {
     beforeProjectId: string | null;
     projectId: string;
   }) => AgentHostAsyncResult<void>;


### PR DESCRIPTION
## What changed
- make the AgentGUI host user-project `move` capability optional
- align the public host type with the runtime capability guard and workspace-user-project contract
- update the desktop adapter test to call the optional capability safely

## Why
The 0.0.118 package exposed `move` as required even though AgentGUI treats it as an optional host capability. This caused downstream hosts without durable project reordering support to fail typechecking.

## Risk
Low. Hosts that provide `move` continue unchanged; hosts without it retain the existing no-op capability behavior in AgentGUI.

## Verification
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/agent-gui test -- --run agentGuiController.interactiveHelpers.spec.ts` (192 files, 1793 tests)
- pre-push `pnpm check:full` (18 tasks)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->