### PR TITLE
fix(agent): commit rail expansion resize frame

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
@@ -205,7 +205,7 @@ test("standalone Agent auto-hides the conversation rail below the standalone wid
 test("standalone Agent widens a narrow window before expanding the conversation rail", () => {
   assert.match(
     standaloneWindowSource,
-    /AGENT_GUI_EXPANDED_TARGET_WIDTH_PX[\s\S]*?frame\.width < 640[\s\S]*?resizeContentWidth\(\{\s*width: AGENT_GUI_EXPANDED_TARGET_WIDTH_PX\s*\}\)/
+    /frame\.width < 640[\s\S]*?resizeContentWidth\(AGENT_GUI_EXPANDED_TARGET_WIDTH_PX\)/
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -519,9 +519,7 @@ export function StandaloneAgentWindow({
   const handleConversationRailToggle = useCallback(
     (collapsed: boolean) => {
       if (!collapsed && frame.width < 640) {
-        void hostWindowApi.resizeContentWidth({
-          width: AGENT_GUI_EXPANDED_TARGET_WIDTH_PX
-        });
+        void resizeContentWidth(AGENT_GUI_EXPANDED_TARGET_WIDTH_PX);
       }
       setNodeState((current) => ({
         ...current,
@@ -539,7 +537,7 @@ export function StandaloneAgentWindow({
         )
       );
     },
-    [frame.width, hostWindowApi, instanceId]
+    [frame.width, instanceId, resizeContentWidth]
   );
   const handleCreateConversation = useCallback(() => {
     window.dispatchEvent(


### PR DESCRIPTION
## Summary

Follow-up to #1310 based on the completed Devin review.

- route narrow-window conversation rail expansion through the frame-committing resize wrapper
- keep the auto-collapse frame in sync after the native window widens
- update the structural regression test to require the wrapper path

## Validation

- focused `StandaloneAgentWindow.test.ts` (17 passed)
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm lint:ts`
- `pnpm check:changed --tail-lines 40` (7 lanes)
- pre-push `pnpm check:full` (18 tasks)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->