### PR TITLE
fix(mentions): preserve icons in readonly conversations

### DIFF
--- a/.changeset/mention-icon-readonly-fallback.md
+++ b/.changeset/mention-icon-readonly-fallback.md
@@ -1,0 +1,12 @@
+---
+"@tutti-os/agent-gui": patch
+"@tutti-os/ui-rich-text": minor
+"@tutti-os/ui-system": patch
+---
+
+Hydrate mention presentation in readonly rich-text conversations from the same
+trigger providers used by the composer, so workspace app icons remain available
+without serializing presentation URLs into Markdown.
+
+Render semantic mention icons whenever a supplied image cannot load across the
+shared mention pill, AgentGUI composer, and AgentGUI Markdown surfaces.

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
@@ -274,9 +274,22 @@ describe("AgentQueuedPromptPanel", () => {
       "data-agent-mention-href",
       "mention://workspace-app/ai-media-canvas?workspaceId=workspace-1"
     );
+    const image = mention?.querySelector(
+      '[data-agent-mention-app-icon="true"] img'
+    );
+    expect(image).toHaveAttribute("src", iconUrl);
+    expect(
+      mention?.querySelector('[data-agent-mention-fallback-icon="true"]')
+    ).not.toBeInTheDocument();
+
+    fireEvent.error(image!);
+
     expect(
       mention?.querySelector('[data-agent-mention-app-icon="true"] img')
-    ).toHaveAttribute("src", iconUrl);
+    ).not.toBeInTheDocument();
+    expect(
+      mention?.querySelector('[data-agent-mention-fallback-icon="true"]')
+    ).toBeInTheDocument();
     expect(mention).toHaveTextContent("AI Media Canvas");
     expect(screen.queryByText(/mention:\/\/workspace-app/)).toBeNull();
   });

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
@@ -394,6 +394,7 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
   const withTooltipProvider = useContext(AgentMentionTooltipProviderContext);
   const mention = mentionViewModel(node.attrs ?? {}, t);
   const [isEditable, setIsEditable] = useState(editor.isEditable);
+  const [failedIconUrl, setFailedIconUrl] = useState<string>();
   const extensionOptions = extension.options as {
     removeActionAriaLabel?: string;
   };
@@ -461,11 +462,11 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
             data-agent-mention-app-icon="true"
             data-workspace-app-icon="true"
           >
-            {mention.iconUrl ? (
+            {mention.iconUrl && failedIconUrl !== mention.iconUrl ? (
               <img
                 src={mention.iconUrl}
                 alt=""
-                className={`size-full object-cover transition-opacity ${
+                className={`col-start-1 row-start-1 size-full object-cover transition-opacity ${
                   isEditable
                     ? "group-hover:opacity-0 group-focus-within:opacity-0"
                     : ""
@@ -473,14 +474,18 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
                 decoding="async"
                 loading="lazy"
                 draggable={false}
+                onError={() => {
+                  setFailedIconUrl(mention.iconUrl);
+                }}
               />
             ) : (
               <span
-                className={`tsh-agent-object-token__kind-icon size-4 transition-opacity ${
+                className={`tsh-agent-object-token__kind-icon col-start-1 row-start-1 size-4 transition-opacity ${
                   isEditable
                     ? "group-hover:opacity-0 group-focus-within:opacity-0"
                     : ""
                 }`}
+                data-agent-mention-fallback-icon="true"
               />
             )}
             {isEditable ? (

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -1311,9 +1311,22 @@ describe("AgentMessageMarkdown", () => {
     expect(
       mention?.querySelector('[data-agent-mention-app-icon="true"]')
     ).toHaveClass("h-4", "w-4");
+    const image = mention?.querySelector(
+      '[data-agent-mention-app-icon="true"] img'
+    );
+    expect(image).toHaveAttribute("src", iconUrl);
+    expect(
+      mention?.querySelector('[data-agent-mention-fallback-icon="true"]')
+    ).not.toBeInTheDocument();
+
+    fireEvent.error(image!);
+
     expect(
       mention?.querySelector('[data-agent-mention-app-icon="true"] img')
-    ).toHaveAttribute("src", iconUrl);
+    ).not.toBeInTheDocument();
+    expect(
+      mention?.querySelector('[data-agent-mention-fallback-icon="true"]')
+    ).toBeInTheDocument();
     expect(mention).toHaveTextContent("Weather");
   });
 

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -619,8 +619,10 @@ function MentionLink({
   // 标签截断时,hover 用设计系统 Tooltip 展示完整文本。trigger = 整个 chip(<a>),
   // 截断发生在内部 __main span,故在那上面测溢出。
   const tooltipText = mention.label;
+  const [failedIconUrl, setFailedIconUrl] = useState<string>();
   const { ref: mainRef, overflowing } =
     useTextOverflow<HTMLSpanElement>(tooltipText);
+
   const link = (
     <a
       {...props}
@@ -671,17 +673,23 @@ function MentionLink({
             mention.kind === "session" ? undefined : "true"
           }
         >
-          {mention.iconUrl ? (
+          {mention.iconUrl && failedIconUrl !== mention.iconUrl ? (
             <img
               src={mention.iconUrl}
               alt=""
-              className="h-full w-full object-cover"
+              className="col-start-1 row-start-1 h-full w-full object-cover"
               decoding="async"
               loading="lazy"
               draggable={false}
+              onError={() => {
+                setFailedIconUrl(mention.iconUrl);
+              }}
             />
           ) : (
-            <span className="tsh-agent-object-token__kind-icon h-4 w-4" />
+            <span
+              className="tsh-agent-object-token__kind-icon col-start-1 row-start-1 h-4 w-4"
+              data-agent-mention-fallback-icon="true"
+            />
           )}
         </span>
       ) : (

--- a/packages/ui/rich-text/README.md
+++ b/packages/ui/rich-text/README.md
@@ -129,6 +129,10 @@ Interpretation:
   insertion
 - `resolveMention` restores editor-only label or presentation data from the
   stored mention identity
+- readonly conversation surfaces pass the same providers to
+  `RichTextReadonlyContent.triggerProviders`; it calls `resolveMention` to
+  restore presentation such as app icons while keeping serialized Markdown
+  limited to durable identity and scope
 - group ids, labels, totals, and cursors are candidate-panel metadata only;
   they must not be copied into mention identity, href, or persisted scope
 

--- a/packages/ui/rich-text/src/editor/RichTextMentionReadonly.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextMentionReadonly.tsx
@@ -1,8 +1,10 @@
 import type { CSSProperties, JSX, MouseEvent, ReactNode } from "react";
+import { MentionPill } from "@tutti-os/ui-system/components";
+import { resolveRichTextMentionView } from "../plugins/mention.ts";
 import {
-  getRichTextMentionDisplayText,
-  resolveRichTextMentionView
-} from "../plugins/mention.ts";
+  resolveMentionPillIconUrl,
+  resolveMentionPillKind
+} from "../extensions/mentionPillPresentation.ts";
 import type {
   RichTextMentionAttrs,
   RichTextResolvedMention,
@@ -27,14 +29,8 @@ export interface RichTextMentionReadonlyProps<TResolved = unknown> {
 
 const baseStyle: CSSProperties = {
   alignItems: "center",
-  border: "1px solid transparent",
-  borderRadius: "999px",
   display: "inline-flex",
-  fontSize: "0.95em",
-  gap: "0.25rem",
-  lineHeight: 1.4,
   maxWidth: "100%",
-  padding: "0.05rem 0.45rem",
   textDecoration: "none",
   verticalAlign: "baseline",
   whiteSpace: "nowrap"
@@ -43,30 +39,22 @@ const baseStyle: CSSProperties = {
 const stateStyles: Record<RichTextResolvedMentionView["state"], CSSProperties> =
   {
     active: {
-      background:
-        "var(--tutti-rich-text-mention-active-bg, color-mix(in srgb, currentColor 12%, transparent))",
       color: "var(--tutti-rich-text-mention-active-fg, inherit)",
       cursor: "pointer"
     },
     missing: {
-      background:
-        "var(--tutti-rich-text-mention-missing-bg, color-mix(in srgb, currentColor 6%, transparent))",
       color:
         "var(--tutti-rich-text-mention-missing-fg, color-mix(in srgb, currentColor 48%, transparent))",
       cursor: "default",
       textDecoration: "line-through"
     },
     disabled: {
-      background:
-        "var(--tutti-rich-text-mention-disabled-bg, color-mix(in srgb, currentColor 6%, transparent))",
       color:
         "var(--tutti-rich-text-mention-disabled-fg, color-mix(in srgb, currentColor 58%, transparent))",
       cursor: "not-allowed",
       opacity: 0.88
     },
     loading: {
-      background:
-        "var(--tutti-rich-text-mention-loading-bg, color-mix(in srgb, currentColor 8%, transparent))",
       color:
         "var(--tutti-rich-text-mention-loading-fg, color-mix(in srgb, currentColor 82%, transparent))",
       cursor: "progress",
@@ -94,12 +82,21 @@ export function RichTextMentionReadonly<TResolved = unknown>({
     mention,
     resolved: view as RichTextResolvedMentionView<TResolved>
   };
-  const label =
-    renderLabel?.(payload) ??
-    getRichTextMentionDisplayText({
-      ...mention,
-      label: view.label
-    });
+  const label = renderLabel?.(payload) ?? view.label;
+  const content = (
+    <MentionPill
+      className="top-0"
+      iconUrl={
+        resolveMentionPillIconUrl({
+          presentation: view.presentation,
+          scope: mention.scope
+        }) ?? undefined
+      }
+      kind={resolveMentionPillKind(mention.providerId, mention.scope)}
+      label={label}
+      removable={false}
+    />
+  );
   const elementTitle = title ?? view.tooltip;
   const handleClick = (event: MouseEvent<HTMLElement>) => {
     if (!view.interactive) {
@@ -136,14 +133,17 @@ export function RichTextMentionReadonly<TResolved = unknown>({
         style={{
           ...sharedProps.style,
           appearance: "none",
-          font: "inherit"
+          background: "transparent",
+          border: 0,
+          font: "inherit",
+          padding: 0
         }}
         type="button"
       >
-        {label}
+        {content}
       </button>
     );
   }
 
-  return <span {...sharedProps}>{label}</span>;
+  return <span {...sharedProps}>{content}</span>;
 }

--- a/packages/ui/rich-text/src/editor/RichTextReadonlyContent.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextReadonlyContent.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from "react";
+import { useEffect, useState, type JSX } from "react";
 import {
   MentionPill,
   Tooltip,
@@ -16,6 +16,8 @@ import { getWorkspaceReferencePresentation } from "../extensions/workspaceRefere
 import { RichTextMentionReadonly } from "./RichTextMentionReadonly.tsx";
 import { buildRichTextReadonlyInlineSegments } from "./richTextReadonlyContentModel.ts";
 import type { RichTextMentionAttrs } from "../types/mention.ts";
+import type { RichTextMentionResolved } from "../types/mention.ts";
+import type { RichTextTriggerProvider } from "../types/trigger.ts";
 
 export interface RichTextReadonlyWorkspaceReference {
   kind: "file" | "folder";
@@ -27,6 +29,7 @@ export interface RichTextReadonlyContentProps {
   value: string;
   className?: string;
   paragraphClassName?: string;
+  triggerProviders?: readonly RichTextTriggerProvider[];
   onMentionAction?: (mention: RichTextMentionAttrs) => void | Promise<void>;
   onOpenWorkspaceReference?: (
     reference: RichTextReadonlyWorkspaceReference
@@ -40,6 +43,7 @@ export function RichTextReadonlyContent({
   value,
   className,
   paragraphClassName,
+  triggerProviders,
   onMentionAction,
   onOpenWorkspaceReference
 }: RichTextReadonlyContentProps): JSX.Element | null {
@@ -64,7 +68,8 @@ export function RichTextReadonlyContent({
           {renderReadonlyInlineMarkdown(
             paragraph,
             onOpenWorkspaceReference,
-            onMentionAction
+            onMentionAction,
+            triggerProviders
           )}
         </p>
       ))}
@@ -77,7 +82,8 @@ function renderReadonlyInlineMarkdown(
   onOpenWorkspaceReference?: (
     reference: RichTextReadonlyWorkspaceReference
   ) => void | Promise<void>,
-  onMentionAction?: (mention: RichTextMentionAttrs) => void | Promise<void>
+  onMentionAction?: (mention: RichTextMentionAttrs) => void | Promise<void>,
+  triggerProviders?: readonly RichTextTriggerProvider[]
 ): JSX.Element[] {
   const parts: JSX.Element[] = [];
   const segments = buildRichTextReadonlyInlineSegments(content);
@@ -95,6 +101,7 @@ function renderReadonlyInlineMarkdown(
         label={segment.label}
         onMentionAction={onMentionAction}
         onOpenWorkspaceReference={onOpenWorkspaceReference}
+        triggerProviders={triggerProviders}
       />
     );
   });
@@ -106,7 +113,8 @@ function RichTextReadonlyInlineLink({
   href,
   label,
   onMentionAction,
-  onOpenWorkspaceReference
+  onOpenWorkspaceReference,
+  triggerProviders
 }: {
   href: string;
   label: string;
@@ -114,13 +122,14 @@ function RichTextReadonlyInlineLink({
   onOpenWorkspaceReference?: (
     reference: RichTextReadonlyWorkspaceReference
   ) => void | Promise<void>;
+  triggerProviders?: readonly RichTextTriggerProvider[];
 }): JSX.Element {
   const trimmedHref = href.trim();
   const mention = parseRichTextMentionHref(trimmedHref, label);
 
   if (mention) {
     return (
-      <RichTextMentionReadonly
+      <HydratedRichTextMentionReadonly
         mention={mention}
         onClick={
           onMentionAction
@@ -129,6 +138,9 @@ function RichTextReadonlyInlineLink({
               }
             : undefined
         }
+        provider={triggerProviders?.find(
+          (provider) => provider.id.trim() === mention.providerId
+        )}
       />
     );
   }
@@ -164,6 +176,69 @@ function RichTextReadonlyInlineLink({
         path
       }}
       onOpenWorkspaceReference={onOpenWorkspaceReference}
+    />
+  );
+}
+
+function HydratedRichTextMentionReadonly({
+  mention,
+  onClick,
+  provider
+}: {
+  mention: RichTextMentionAttrs;
+  onClick?: (payload: { mention: RichTextMentionAttrs }) => void;
+  provider?: RichTextTriggerProvider;
+}): JSX.Element {
+  const [resolved, setResolved] = useState<RichTextMentionResolved | null>(
+    null
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    setResolved(null);
+    const resolveMention = provider?.resolveMention;
+    if (!resolveMention) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    void Promise.resolve()
+      .then(() =>
+        resolveMention({
+          providerId: mention.providerId,
+          entityId: mention.entityId,
+          label: mention.label,
+          scope: mention.scope
+        })
+      )
+      .then((nextResolved) => {
+        if (!cancelled) {
+          setResolved(nextResolved);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setResolved(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    mention.entityId,
+    mention.label,
+    mention.providerId,
+    mention.scope,
+    provider
+  ]);
+
+  return (
+    <RichTextMentionReadonly
+      mention={mention}
+      onClick={onClick}
+      resolved={resolved ? { state: "active", ...resolved } : undefined}
     />
   );
 }

--- a/packages/ui/rich-text/src/extensions/MentionReferenceNodeView.tsx
+++ b/packages/ui/rich-text/src/extensions/MentionReferenceNodeView.tsx
@@ -1,62 +1,15 @@
 import type { JSX } from "react";
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
+import { MentionPill } from "@tutti-os/ui-system/components";
 import {
-  MentionPill,
-  type MentionPillKind
-} from "@tutti-os/ui-system/components";
+  resolveMentionPillIconUrl,
+  resolveMentionPillKind
+} from "./mentionPillPresentation.ts";
 
 const richTextMentionReferencePillClassName = "max-w-[16rem]";
 
 function readStringAttr(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
-}
-
-function readMentionPresentationUrl(presentation: unknown): string | null {
-  if (!presentation || typeof presentation !== "object") {
-    return null;
-  }
-  const value =
-    (presentation as { iconUrl?: unknown; thumbnailUrl?: unknown }).iconUrl ??
-    (presentation as { thumbnailUrl?: unknown }).thumbnailUrl;
-  if (typeof value !== "string") {
-    return null;
-  }
-  const trimmed = value.trim();
-  return trimmed || null;
-}
-
-// 句柄类 mention(如 workspace-reference 项目引用)的图标随 href 的 scope 编码,
-// markdown 带不了 presentation,故回退读 scope.icon,使 chip 与 agent 一样显示来源图标。
-function readMentionScopeValue(scope: unknown, key: string): string {
-  if (!scope || typeof scope !== "object") {
-    return "";
-  }
-  return readStringAttr((scope as Record<string, unknown>)[key]);
-}
-
-// providerId(+ workspace-reference 的 source)映射到设计系统 MentionPill 的 kind,
-// 让颜色/图标与 agent GUI 的 mention chip 完全一致。
-function resolveMentionPillKind(
-  providerId: string,
-  scope: unknown
-): MentionPillKind {
-  const id = providerId.trim();
-  if (id === "agent-session" || id === "session") {
-    return "session";
-  }
-  if (id === "workspace-app") {
-    return "app";
-  }
-  if (id === "workspace-issue") {
-    return "issue";
-  }
-  if (id === "workspace-reference") {
-    return readMentionScopeValue(scope, "source") === "task" ? "issue" : "app";
-  }
-  if (id === "file") {
-    return "file";
-  }
-  return "issue";
 }
 
 export function MentionReferenceNodeView({
@@ -67,9 +20,10 @@ export function MentionReferenceNodeView({
     typeof node.attrs.label === "string"
       ? node.attrs.label.trim().replace(/^@+/, "").trim()
       : "";
-  const iconUrl =
-    readMentionPresentationUrl(node.attrs.presentation) ||
-    readMentionScopeValue(node.attrs.scope, "icon");
+  const iconUrl = resolveMentionPillIconUrl({
+    presentation: node.attrs.presentation,
+    scope: node.attrs.scope
+  });
   const kind = resolveMentionPillKind(
     readStringAttr(node.attrs.providerId),
     node.attrs.scope

--- a/packages/ui/rich-text/src/extensions/mentionPillPresentation.test.ts
+++ b/packages/ui/rich-text/src/extensions/mentionPillPresentation.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveMentionPillIconUrl,
+  resolveMentionPillKind
+} from "./mentionPillPresentation.ts";
+
+test("resolves mention pill kinds from provider identity", () => {
+  assert.equal(resolveMentionPillKind("workspace-app", undefined), "app");
+  assert.equal(resolveMentionPillKind("agent-session", undefined), "session");
+  assert.equal(
+    resolveMentionPillKind("workspace-reference", { source: "task" }),
+    "issue"
+  );
+  assert.equal(
+    resolveMentionPillKind("workspace-reference", { source: "app" }),
+    "app"
+  );
+});
+
+test("prefers hydrated presentation icons over legacy scope icons", () => {
+  assert.equal(
+    resolveMentionPillIconUrl({
+      presentation: { iconUrl: " app://weather.png " },
+      scope: { icon: "app://legacy.png" }
+    }),
+    "app://weather.png"
+  );
+  assert.equal(
+    resolveMentionPillIconUrl({ scope: { icon: " app://legacy.png " } }),
+    "app://legacy.png"
+  );
+});

--- a/packages/ui/rich-text/src/extensions/mentionPillPresentation.ts
+++ b/packages/ui/rich-text/src/extensions/mentionPillPresentation.ts
@@ -1,0 +1,58 @@
+import type { MentionPillKind } from "@tutti-os/ui-system/components";
+import type {
+  RichTextMentionIdentity,
+  RichTextMentionPresentation
+} from "../types/mention.ts";
+
+function readStringAttr(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function readMentionPresentationUrl(
+  presentation: RichTextMentionPresentation | null | undefined
+): string | null {
+  const value = presentation?.iconUrl ?? presentation?.thumbnailUrl;
+  const trimmed = readStringAttr(value);
+  return trimmed || null;
+}
+
+export function readMentionScopeValue(
+  scope: RichTextMentionIdentity["scope"] | null | undefined,
+  key: string
+): string {
+  return readStringAttr(scope?.[key]);
+}
+
+export function resolveMentionPillKind(
+  providerId: string,
+  scope: RichTextMentionIdentity["scope"] | null | undefined
+): MentionPillKind {
+  const id = providerId.trim();
+  if (id === "agent-session" || id === "session") {
+    return "session";
+  }
+  if (id === "workspace-app") {
+    return "app";
+  }
+  if (id === "workspace-issue") {
+    return "issue";
+  }
+  if (id === "workspace-reference") {
+    return readMentionScopeValue(scope, "source") === "task" ? "issue" : "app";
+  }
+  if (id === "file") {
+    return "file";
+  }
+  return "issue";
+}
+
+export function resolveMentionPillIconUrl(input: {
+  presentation?: RichTextMentionPresentation | null;
+  scope?: RichTextMentionIdentity["scope"] | null;
+}): string | null {
+  return (
+    readMentionPresentationUrl(input.presentation) ||
+    readMentionScopeValue(input.scope, "icon") ||
+    null
+  );
+}

--- a/packages/ui/system/src/components/mention-pill/mention-pill.spec.tsx
+++ b/packages/ui/system/src/components/mention-pill/mention-pill.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { TooltipProvider } from "../tooltip/tooltip";
 import { MentionPill } from "./mention-pill";
@@ -27,6 +27,28 @@ describe("MentionPill", () => {
     expect(screen.getByText("README.md")).toBeInTheDocument();
     expect(
       document.querySelector('[data-slot="tooltip-trigger"]')
+    ).toBeInTheDocument();
+  });
+
+  it("reveals the semantic fallback when a custom icon fails", () => {
+    const { container } = render(
+      <MentionPill
+        iconUrl="https://example.test/missing.png"
+        kind="app"
+        label="Weather"
+      />
+    );
+    const image = container.querySelector("img");
+
+    expect(
+      container.querySelector('[data-mention-pill-fallback-icon="true"]')
+    ).not.toBeInTheDocument();
+
+    fireEvent.error(image!);
+
+    expect(container.querySelector("img")).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-mention-pill-fallback-icon="true"]')
     ).toBeInTheDocument();
   });
 });

--- a/packages/ui/system/src/components/mention-pill/mention-pill.tsx
+++ b/packages/ui/system/src/components/mention-pill/mention-pill.tsx
@@ -71,6 +71,7 @@ function MentionPill({
       : mentionPillTokenByKind[kind];
   const dataKind = mentionPillDataKindByKind[kind];
   const normalizedIconUrl = iconUrl?.trim() ?? "";
+  const [failedIconUrl, setFailedIconUrl] = React.useState<string | null>(null);
   const iconSizeClassName = "size-4";
   const iconShellClassName = isFile ? "size-4" : "size-[18px]";
 
@@ -104,25 +105,29 @@ function MentionPill({
           iconShellClassName
         )}
       >
-        {normalizedIconUrl ? (
+        {normalizedIconUrl && failedIconUrl !== normalizedIconUrl ? (
           <img
             src={normalizedIconUrl}
             alt=""
             className={cn(
-              "size-full rounded-[3px] object-cover transition-opacity",
+              "col-start-1 row-start-1 size-full rounded-[3px] object-cover transition-opacity",
               removable && "group-hover:opacity-0 group-focus-within:opacity-0"
             )}
             decoding="async"
             loading="lazy"
             draggable={false}
+            onError={() => {
+              setFailedIconUrl(normalizedIconUrl);
+            }}
           />
         ) : (
           <Icon
             className={cn(
-              "text-current transition-opacity",
+              "col-start-1 row-start-1 text-current transition-opacity",
               removable && "group-hover:opacity-0 group-focus-within:opacity-0",
               iconSizeClassName
             )}
+            data-mention-pill-fallback-icon="true"
           />
         )}
         {removable ? (


### PR DESCRIPTION
## Summary

- hydrate readonly rich-text mentions through the same trigger provider resolveMention contract used by the composer
- render shared MentionPill tokens in readonly content with workspace app, issue, session, and file semantics
- replace failed custom icon images with semantic fallback glyphs in UI System and AgentGUI surfaces
- keep icon presentation out of serialized mention Markdown

## Why

Workspace apps already resolve icon presentation while composing a mention, but app-owned conversation history only retained durable mention identity. The generic readonly renderer did not invoke the provider resolver, so sent messages lost their app icons. Separately, a non-empty but broken icon URL suppressed fallback glyphs in multiple shared surfaces.

## Verification

- pnpm check:changed
- pnpm check:ui-boundaries
- UI System tests and typecheck
- UI rich-text: 94 tests and typecheck
- AgentGUI: 192 files, 1793 tests and typecheck
- repository check:full preflight passed; its parallel Go lane hit unrelated timeout and goal-state flakes, and every reported failing Go test passed immediately when rerun individually

## Release

Includes a changeset for agent-gui, ui-rich-text, and ui-system.