### PR TITLE
fix(agent-gui): use explicit handoff ownership

### DIFF
--- a/.changeset/agent-gui-explicit-handoff-ownership.md
+++ b/.changeset/agent-gui-explicit-handoff-ownership.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Use host-authoritative ownership metadata when labeling handoff targets so self-owned VM Agents remain distinguishable from other users' shared Agents.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -492,10 +492,12 @@ handoff catalog must not change rail contents, session queries, or empty-home
 provider selection, and it must not synthesize a provider catalog or infer
 runnable agents from provider metadata. Handoff row presentation keeps the
 directory-owned Agent name unchanged and renders ownership as separate metadata:
-targets without owner presentation are current-user Agents, while targets with
-`owner.name` or `owner.avatarUrl` are shared Agents and expose the available
-owner identity. Duplicate Agent names must therefore remain distinguishable
-without mutating launch identity or display names.
+the host projects authoritative `ownership: "self" | "shared"` from its Agent
+directory or launch reference. Owner name, avatar, badge, and other presentation
+fields must never determine ownership. Targets without explicit ownership remain
+unclassified. Shared targets expose the available owner identity without
+mutating launch identity or display names, so duplicate Agent names remain
+distinguishable.
 When provider selection happens from the empty-home composer or title control
 while the rail is already scoped to a provider target in multi-provider scope,
 it must update the rail conversation filter to the matching agent target so the

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -160,6 +160,7 @@ export interface AgentGUIAgent {
     name?: string | null;
     avatarUrl?: string | null;
   } | null;
+  ownership?: "self" | "shared" | null;
   availability: {
     status:
       | "ready"
@@ -190,6 +191,9 @@ Agent names, primary icons, and optional home-carousel artwork come from
 `owner.avatarUrl` is rendered separately as an ownership badge. Invalid entries
 and duplicate `agentTargetId` values are discarded by
 `normalizeAgentGUIAgents`, with the first occurrence preserving host order.
+Hosts set `agents[].ownership` to `"self"` or `"shared"` from their authoritative
+directory or launch reference. Owner name and avatar are presentation metadata
+and do not determine ownership.
 
 With one agent, AgentGUI hides the aggregate `All` entry and renders that agent
 directly. With multiple agents, it shows `All` plus the host-ordered agent rail
@@ -232,9 +236,11 @@ Hosts that launch handoffs across session-runtime boundaries may also pass
 Handoff menu; the conversation rail, session queries, and empty composer remain
 owned by `agentDirectory`. When omitted, Handoff uses `agentDirectory`. Handoff
 rows keep the Agent name as the primary identity and render ownership separately:
-entries without owner presentation are labeled as the current user's Agent,
-while entries with `owner.name` or `owner.avatarUrl` are labeled as shared and
-show the available owner identity.
+entries with `ownership: "self"` are labeled as the current user's Agent, while
+entries with `ownership: "shared"` are labeled as shared and show the available
+owner identity. Entries without explicit ownership remain unclassified; AgentGUI
+does not infer ownership from `owner.name`, `owner.avatarUrl`, or other
+presentation metadata.
 
 The old public `providerTargets`, `providerRailMode`, provider-target renderers,
 and `defaultProviderTargetId` contract is intentionally unsupported. Workbench

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
@@ -273,42 +273,52 @@ export function ComposerFooter({
                 )}
                 aria-label={effectiveHandoffMenuLabel}
               >
-                {handoffMenuTargets.map((target) => (
-                  <SelectItem
-                    key={`${target.provider}:${target.targetId}`}
-                    value={target.targetId}
-                    className={cn(styles.composerMenuItem, "gap-2 py-1.5")}
-                    disabled={target.disabled === true}
-                  >
-                    <span className="flex min-w-0 items-center gap-2">
-                      <span className="relative size-5 shrink-0">
-                        <img
-                          alt=""
-                          aria-hidden="true"
-                          className="size-5 rounded-[4px]"
-                          src={resolveComposerProviderTargetIconUrl(target)}
-                        />
-                        {target.badge?.iconUrl ? (
+                {handoffMenuTargets.map((target) => {
+                  const ownershipLabel = resolveHandoffTargetOwnershipLabel(
+                    target,
+                    {
+                      self: labels.handoffTargetSelf,
+                      shared: labels.handoffTargetShared
+                    }
+                  );
+                  return (
+                    <SelectItem
+                      key={`${target.provider}:${target.targetId}`}
+                      value={target.targetId}
+                      className={cn(styles.composerMenuItem, "gap-2 py-1.5")}
+                      disabled={target.disabled === true}
+                    >
+                      <span className="flex min-w-0 items-center gap-2">
+                        <span className="relative size-5 shrink-0">
                           <img
                             alt=""
                             aria-hidden="true"
-                            className="absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full border border-[var(--background-fronted)] bg-[var(--background-fronted)] object-cover"
-                            src={target.badge.iconUrl}
+                            className="size-5 rounded-[4px]"
+                            src={resolveComposerProviderTargetIconUrl(target)}
                           />
-                        ) : null}
-                      </span>
-                      <span className="flex min-w-0 flex-col gap-0.5">
-                        <span className="min-w-0 truncate">{target.label}</span>
-                        <span className="min-w-0 truncate text-[11px] leading-none text-[var(--agent-gui-text-secondary)]">
-                          {resolveHandoffTargetOwnershipLabel(target, {
-                            self: labels.handoffTargetSelf,
-                            shared: labels.handoffTargetShared
-                          })}
+                          {target.badge?.iconUrl ? (
+                            <img
+                              alt=""
+                              aria-hidden="true"
+                              className="absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full border border-[var(--background-fronted)] bg-[var(--background-fronted)] object-cover"
+                              src={target.badge.iconUrl}
+                            />
+                          ) : null}
+                        </span>
+                        <span className="flex min-w-0 flex-col gap-0.5">
+                          <span className="min-w-0 truncate">
+                            {target.label}
+                          </span>
+                          {ownershipLabel ? (
+                            <span className="min-w-0 truncate text-[11px] leading-none text-[var(--agent-gui-text-secondary)]">
+                              {ownershipLabel}
+                            </span>
+                          ) : null}
                         </span>
                       </span>
-                    </span>
-                  </SelectItem>
-                ))}
+                    </SelectItem>
+                  );
+                })}
               </SelectContent>
             </Select>
           ) : showProviderSelect && selectedProviderSwitchTarget ? (

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/handoffTargetPresentation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/handoffTargetPresentation.spec.ts
@@ -4,22 +4,33 @@ import { resolveHandoffTargetOwnershipLabel } from "./handoffTargetPresentation"
 const labels = { self: "My Agent", shared: "Shared Agent" };
 
 describe("resolveHandoffTargetOwnershipLabel", () => {
-  it("identifies targets without an external owner as the current user's agent", () => {
-    expect(resolveHandoffTargetOwnershipLabel({}, labels)).toBe("My Agent");
+  it("keeps a self-owned target local even when owner presentation is present", () => {
+    expect(
+      resolveHandoffTargetOwnershipLabel(
+        { ownership: "self", ownerLabel: "Current User" },
+        labels
+      )
+    ).toBe("My Agent");
   });
 
   it("identifies shared targets by owner name without changing the agent name", () => {
     expect(
-      resolveHandoffTargetOwnershipLabel({ ownerLabel: " Ricky " }, labels)
+      resolveHandoffTargetOwnershipLabel(
+        { ownership: "shared", ownerLabel: " Ricky " },
+        labels
+      )
     ).toBe("Ricky · Shared Agent");
   });
 
-  it("still identifies a shared target when only its owner badge is available", () => {
+  it("identifies a shared target when owner presentation is unavailable", () => {
     expect(
-      resolveHandoffTargetOwnershipLabel(
-        { badge: { iconUrl: "app://owner.png" } },
-        labels
-      )
+      resolveHandoffTargetOwnershipLabel({ ownership: "shared" }, labels)
     ).toBe("Shared Agent");
+  });
+
+  it("does not infer ownership from owner presentation", () => {
+    expect(
+      resolveHandoffTargetOwnershipLabel({ ownerLabel: "Current User" }, labels)
+    ).toBeNull();
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/handoffTargetPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/handoffTargetPresentation.ts
@@ -5,18 +5,16 @@ export interface HandoffTargetOwnershipLabels {
   shared: string;
 }
 
-/**
- * Directory entries with owner presentation belong to another user's shared
- * runtime. Entries without owner presentation are local to the current user.
- */
 export function resolveHandoffTargetOwnershipLabel(
-  target: Pick<AgentGUIAgentTarget, "badge" | "ownerLabel">,
+  target: Pick<AgentGUIAgentTarget, "ownerLabel" | "ownership">,
   labels: HandoffTargetOwnershipLabels
-): string {
+): string | null {
   const ownerLabel = target.ownerLabel?.trim() ?? "";
-  const isShared = ownerLabel.length > 0 || target.badge != null;
-  if (!isShared) {
+  if (target.ownership === "self") {
     return labels.self;
   }
-  return ownerLabel ? `${ownerLabel} · ${labels.shared}` : labels.shared;
+  if (target.ownership === "shared") {
+    return ownerLabel ? `${ownerLabel} · ${labels.shared}` : labels.shared;
+  }
+  return null;
 }

--- a/packages/agent/gui/agents.test.ts
+++ b/packages/agent/gui/agents.test.ts
@@ -42,6 +42,7 @@ describe("normalizeAgentGUIAgents", () => {
         heroImageUrl: " app://agents/alice-hero.jpg ",
         description: " Shared agent ",
         owner: { name: " Owner ", avatarUrl: " app://owner.png " },
+        ownership: "shared",
         availability: { status: "unavailable", reason: " Offline " }
       }),
       createAgent("alice"),
@@ -58,6 +59,7 @@ describe("normalizeAgentGUIAgents", () => {
         heroImageUrl: "app://agents/alice-hero.jpg",
         description: "Shared agent",
         owner: { name: "Owner", avatarUrl: "app://owner.png" },
+        ownership: "shared",
         availability: { status: "unavailable", reason: "Offline" },
         provider: "codex"
       }
@@ -66,6 +68,21 @@ describe("normalizeAgentGUIAgents", () => {
 });
 
 describe("projectAgentGUIAgentsToInternalTargets", () => {
+  it("preserves explicit ownership independently from owner presentation", () => {
+    const [target] = projectAgentGUIAgentsToInternalTargets([
+      createAgent("agent-a", {
+        owner: { name: "Current User", avatarUrl: "app://owner.png" },
+        ownership: "self"
+      })
+    ]);
+
+    expect(target).toMatchObject({
+      ownership: "self",
+      ownerLabel: "Current User",
+      badge: { iconUrl: "app://owner.png" }
+    });
+  });
+
   it("preserves availability separately from disabled interaction state", () => {
     const [target] = projectAgentGUIAgentsToInternalTargets([
       createAgent("agent-a", {

--- a/packages/agent/gui/agents.ts
+++ b/packages/agent/gui/agents.ts
@@ -42,6 +42,9 @@ export function normalizeAgentGUIAgents(
             }
           }
         : {}),
+      ...(agent.ownership === "self" || agent.ownership === "shared"
+        ? { ownership: agent.ownership }
+        : {}),
       availability: {
         status: normalizeAgentGUIAgentAvailabilityStatus(
           agent.availability.status
@@ -113,6 +116,7 @@ export function projectAgentGUIAgentsToInternalTargets(
         }
       : {}),
     ...(agent.owner?.name ? { ownerLabel: agent.owner.name } : {}),
+    ...(agent.ownership ? { ownership: agent.ownership } : {}),
     ...(agent.availability.status !== "ready" && !agent.setupKind
       ? { disabled: true }
       : {}),

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -49,6 +49,7 @@ export type {
   AgentGUIAgentAvailabilityAction,
   AgentGUIAgentAvailabilityStatus,
   AgentGUIAgentOwner,
+  AgentGUIAgentOwnership,
   AgentGUIHomeSuggestionId,
   AgentGUIAllAgentsPresentation,
   AgentGUIProvider,

--- a/packages/agent/gui/types.ts
+++ b/packages/agent/gui/types.ts
@@ -101,6 +101,9 @@ export interface AgentGUIAgentOwner {
   avatarUrl?: string | null;
 }
 
+/** Host-authoritative ownership classification for Agent directory entries. */
+export type AgentGUIAgentOwnership = "self" | "shared";
+
 /**
  * Host-projected entry from the workspace `/agents` directory.
  *
@@ -115,6 +118,7 @@ export interface AgentGUIAgent {
   heroImageUrl?: string | null;
   description?: string | null;
   owner?: AgentGUIAgentOwner | null;
+  ownership?: AgentGUIAgentOwnership | null;
   availability: AgentGUIAgentAvailability;
   provider: AgentGUIProvider;
   setupKind?: "target_runtime" | null;
@@ -164,6 +168,7 @@ export interface AgentGUIAgentTarget {
   heroImageUrl?: string | null;
   badge?: AgentGUIAgentTargetBadge | null;
   ownerLabel?: string;
+  ownership?: AgentGUIAgentOwnership;
   availability?: AgentGUIAgentAvailability;
   disabled?: boolean;
   unavailableReason?: string;


### PR DESCRIPTION
## Summary

- add an explicit `self | shared` ownership contract to AgentGUI directory entries
- render handoff ownership only from host-authoritative metadata instead of inferring it from owner name/avatar
- preserve current-user VM Agents as self-owned even when owner presentation is present
- document the ownership boundary and add regression coverage

## Verification

- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 agents.test.ts agent-gui/agentGuiNode/composer/handoffTargetPresentation.spec.ts`
- `pnpm --filter @tutti-os/agent-gui test` (193 files, 1798 tests)
- `pnpm typecheck`
- `pnpm lint:ts`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:changed --tail-lines 80`

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] README/CONTRIBUTING language variants are not applicable; no repository root README or CONTRIBUTING source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->