### PR TITLE
fix(agent): align turn timing, disclosure, and stop attribution

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -394,9 +394,20 @@ never be applied as a partial Session entity. The old public `state_patch` and
 storage message row id are removed.
 
 Message `turnId` is explicitly nullable. Runtime execution messages should use
-the exact durable Turn id, while historical imports without trustworthy
-provider turn boundaries stay session-scoped (`turnId = null`); import must not
-manufacture one live synthetic Turn per transcript message.
+the exact durable Turn id. Historical import must preserve authoritative native
+provider boundaries when they exist: for Codex, `task_started` and
+`task_complete` provide the authoritative Turn timing, while
+`turn_context.turn_id` binds the intervening transcript messages to that native
+Turn. A started Turn without its native completion event remains turnless in a
+static import snapshot; the importer must not prematurely settle it from its
+latest visible message. Re-import may enrich an existing turnless message in
+place when its stable provider message id now resolves to that exact completed
+native Turn, but it must not replace an already assigned Turn identity.
+Histories without trustworthy provider turn boundaries stay session-scoped
+(`turnId = null`); import must not infer timing from visible transcript rows or
+manufacture one synthetic Turn per message. Turn duration and transcript
+disclosure therefore consume the same canonical Turn projection for both live
+and imported sessions.
 
 It should not know how a host connects to `tuttid`, opens SSE streams, resolves
 workspace paths, or talks to Electron.

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -395,8 +395,11 @@ storage message row id are removed.
 
 Message `turnId` is explicitly nullable. Runtime execution messages should use
 the exact durable Turn id. Historical import must preserve authoritative native
-provider boundaries when they exist: for Codex, `task_started` and
-`task_complete` provide the authoritative Turn timing, while
+provider boundaries when they exist: for Codex, `task_started` provides the
+authoritative Turn start, while `task_complete` and `turn_aborted` provide its
+terminal timing and outcome. A user-authored Codex `turn_aborted` normalizes to
+the canonical `canceled` outcome; `interrupted` remains available for
+provider-loss and recovery settlements that must not be attributed to the user.
 `turn_context.turn_id` binds the intervening transcript messages to that native
 Turn. A started Turn without its native completion event remains turnless in a
 static import snapshot; the importer must not prematurely settle it from its

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -230,18 +230,20 @@ Once the Turn settles, `activeTurnId` clears and its duration freezes at
 `settledAtUnixMs`, so time spent waiting for the user's next ordinary prompt is
 not added to the completed Turn. That second-level state stays inside the
 duration label so transcript rows do not re-render on every tick. A successfully
-completed Turn may start with tool calls, thinking, progress, and file summaries
-collapsed when the projection has a distinct final assistant text target
-independent of copy availability. Work classification is an explicit allowlist:
-thinking, tool groups, specific progress or turn-boundary messages, transient
-processing, and file summaries may collapse. Ordinary assistant content and
-every user message remain visible, including earlier assistant replies and
-mid-Turn user guidance before a later final answer. The disclosure model
-partitions that Turn in source order rather than globally separating user and
-agent rows: only the initial contiguous user prompt stays above the duration
-header, while the remaining visible and work segments retain their authoritative
-chronology. Split presentation rows keep their canonical row identity and use
-separate render keys.
+completed Turn may start with tool calls, thinking, progress, file summaries,
+and intermediate assistant replies collapsed when the projection has a distinct
+final assistant text target independent of copy availability. Assistant
+classification is target-based: only that final text target remains visible,
+while earlier assistant rows and assistant content before or after the target in
+the same row belong to the collapsible work. Every user message remains visible,
+including mid-Turn guidance before a later final answer. Non-assistant work rows
+remain an explicit allowlist of tool groups, transient processing, and file
+summaries so unknown row kinds fail open. The disclosure model partitions that
+Turn in source order rather than globally separating user and agent rows: only
+the initial contiguous user prompt stays above the duration header, while the
+remaining visible and work segments retain their authoritative chronology.
+Split presentation rows keep their canonical row identity and use separate
+render keys.
 
 Turn disclosure is a capability branch, not a transcript-wide container
 replacement. Only a Turn with valid canonical timing enters the Turn-level

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -252,7 +252,15 @@ owns inter-Turn spacing. A group without canonical timing renders through the
 legacy flat-row path, preserving direct-row DOM adjacency, CSS selectors, and
 virtualized spacing. Failed, canceled, interrupted, visible-error,
 generated-image, or final-text-free Turns fail open so important output is
-never hidden. Manual disclosure state is UI-local, keyed by session and Turn,
+never hidden. A settled canceled Turn freezes its canonical duration and
+does not use the ordinary completed-Turn total. Its localized stop attribution
+comes from canonical Turn provenance: a Turn with `legacy_unknown` origin uses
+neutral historical wording such as `The task stopped after 1m 23s`, while every
+other canonical origin uses the user-stop label such as `You stopped the task
+after 1m 23s`. This decision is per Turn, so a new `user_prompt` Turn created in
+Tutti after an imported session resumes still receives the user-stop label. The
+GUI must not inspect provider payloads or infer attribution from session-level
+import state. Manual disclosure state is UI-local, keyed by session and Turn,
 and may survive conversation switches while the Agent panel remains mounted;
 it is not persisted or written back to the engine.
 

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -522,6 +522,14 @@ export const enAgentGui = {
   turnTotalSeconds: "Total {{seconds}}s",
   turnTotalMinutes: "Total {{minutes}}m",
   turnTotalMinutesSeconds: "Total {{minutes}}m {{seconds}}s",
+  turnStoppedSeconds: "You stopped the task after {{seconds}}s",
+  turnStoppedMinutes: "You stopped the task after {{minutes}}m",
+  turnStoppedMinutesSeconds:
+    "You stopped the task after {{minutes}}m {{seconds}}s",
+  turnHistoricallyStoppedSeconds: "The task stopped after {{seconds}}s",
+  turnHistoricallyStoppedMinutes: "The task stopped after {{minutes}}m",
+  turnHistoricallyStoppedMinutesSeconds:
+    "The task stopped after {{minutes}}m {{seconds}}s",
   expandTurnWork: "Expand task details",
   collapseTurnWork: "Collapse task details",
   agentTargetRequired:

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -484,6 +484,13 @@ export const zhCNAgentGui = {
   turnTotalSeconds: "总用时 {{seconds}} 秒",
   turnTotalMinutes: "总用时 {{minutes}} 分钟",
   turnTotalMinutesSeconds: "总用时 {{minutes}} 分 {{seconds}} 秒",
+  turnStoppedSeconds: "您于 {{seconds}}s 后终止任务",
+  turnStoppedMinutes: "您于 {{minutes}}m 后终止任务",
+  turnStoppedMinutesSeconds: "您于 {{minutes}}m {{seconds}}s 后终止任务",
+  turnHistoricallyStoppedSeconds: "任务于 {{seconds}}s 后终止",
+  turnHistoricallyStoppedMinutes: "任务于 {{minutes}}m 后终止",
+  turnHistoricallyStoppedMinutesSeconds:
+    "任务于 {{minutes}}m {{seconds}}s 后终止",
   expandTurnWork: "展开任务详情",
   collapseTurnWork: "收起任务详情",
   agentTargetRequired: "请先选择可用的 Agent 目标。",

--- a/packages/agent/gui/shared/agentConversation/components/AgentTurnWorkSection.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTurnWorkSection.spec.tsx
@@ -203,7 +203,7 @@ describe("AgentTurnWorkSection", () => {
     ]);
   });
 
-  it("keeps ordinary assistant replies and follow-up guidance visible by default", () => {
+  it("collapses ordinary assistant replies while keeping follow-up guidance visible", () => {
     render(
       <AgentTurnWorkSection
         group={interleavedTurnGroup()}
@@ -223,7 +223,7 @@ describe("AgentTurnWorkSection", () => {
       />
     );
 
-    expect(screen.getByText("Earlier answer")).toBeTruthy();
+    expect(screen.queryByText("Earlier answer")).toBeNull();
     expect(screen.getByText("Follow-up")).toBeTruthy();
     expect(screen.getByText("Final answer")).toBeTruthy();
     expect(screen.queryByText("tools")).toBeNull();

--- a/packages/agent/gui/shared/agentConversation/components/AgentTurnWorkSection.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTurnWorkSection.spec.tsx
@@ -13,10 +13,20 @@ vi.mock("../../../i18n/index", async (importOriginal) => {
   return {
     ...actual,
     useTranslation: () => ({
-      t: (key: string, options?: Record<string, unknown>) =>
-        key === "agentHost.agentGui.turnProcessedSeconds"
-          ? `Processed for ${String(options?.seconds)}s`
-          : key
+      t: (key: string, options?: Record<string, unknown>) => {
+        if (key === "agentHost.agentGui.turnProcessedSeconds") {
+          return `Processed for ${String(options?.seconds)}s`;
+        }
+        if (key === "agentHost.agentGui.turnStoppedMinutesSeconds") {
+          return `You stopped the task after ${String(options?.minutes)}m ${String(options?.seconds)}s`;
+        }
+        if (
+          key === "agentHost.agentGui.turnHistoricallyStoppedMinutesSeconds"
+        ) {
+          return `The task stopped after ${String(options?.minutes)}m ${String(options?.seconds)}s`;
+        }
+        return key;
+      }
     })
   };
 });
@@ -164,6 +174,49 @@ describe("AgentTurnWorkSection", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("shows when the user stopped a canceled turn", () => {
+    render(
+      <AgentTurnWorkSection
+        group={turnGroup()}
+        sessionId="session-1"
+        turn={canonicalTurn({
+          phase: "settled",
+          outcome: "canceled",
+          settledAtUnixMs: 88_000
+        })}
+        isActiveTurn={false}
+        disclosureStore={disclosureStore}
+        renderRow={(row, rowIndex) => (
+          <div key={`${row.id}:${rowIndex}`}>{row.id}</div>
+        )}
+      />
+    );
+
+    expect(screen.getByText("You stopped the task after 1m 23s")).toBeTruthy();
+  });
+
+  it("uses neutral attribution for a canceled imported turn", () => {
+    render(
+      <AgentTurnWorkSection
+        group={turnGroup()}
+        sessionId="session-1"
+        turn={canonicalTurn({
+          origin: "legacy_unknown",
+          phase: "settled",
+          outcome: "canceled",
+          settledAtUnixMs: 88_000
+        })}
+        isActiveTurn={false}
+        disclosureStore={disclosureStore}
+        renderRow={(row, rowIndex) => (
+          <div key={`${row.id}:${rowIndex}`}>{row.id}</div>
+        )}
+      />
+    );
+
+    expect(screen.getByText("The task stopped after 1m 23s")).toBeTruthy();
   });
 
   it("renders interleaved turn rows in their original chronology", () => {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTurnWorkSection.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTurnWorkSection.tsx
@@ -8,6 +8,7 @@ import { useElapsedSeconds } from "./useElapsedSeconds";
 import {
   formatAgentTurnDuration,
   type AgentTurnDuration,
+  type AgentTurnStopPresentation,
   type AgentTurnTiming,
   type AgentTurnWorkSectionModel,
   type AgentTurnWorkSectionRow
@@ -62,7 +63,10 @@ export function AgentTurnWorkSection({
         className="flex min-h-6 items-center gap-0.5 text-[12px] text-[var(--text-tertiary)]"
         data-agent-turn-work-header={turnKey}
       >
-        <AgentTurnDurationLabel timing={model.timing} />
+        <AgentTurnDurationLabel
+          timing={model.timing}
+          stopPresentation={model.stopPresentation}
+        />
         {model.collapseEligible ? (
           <BareIconButton
             size="sm"
@@ -120,9 +124,11 @@ function renderRows(
 }
 
 function AgentTurnDurationLabel({
-  timing
+  timing,
+  stopPresentation
 }: {
   timing: AgentTurnTiming;
+  stopPresentation: AgentTurnStopPresentation;
 }): JSX.Element {
   const { t } = useTranslation();
   const liveElapsedSeconds = useElapsedSeconds(
@@ -130,18 +136,76 @@ function AgentTurnDurationLabel({
   );
   const elapsedSeconds =
     timing.kind === "live" ? (liveElapsedSeconds ?? 0) : timing.elapsedSeconds;
-  return <span>{translateDuration(t, timing.kind, elapsedSeconds)}</span>;
+  return (
+    <span>
+      {translateDuration(t, timing.kind, elapsedSeconds, stopPresentation)}
+    </span>
+  );
 }
 
 function translateDuration(
   t: ReturnType<typeof useTranslation>["t"],
   kind: AgentTurnTiming["kind"],
-  elapsedSeconds: number
+  elapsedSeconds: number,
+  stopPresentation: AgentTurnStopPresentation
 ): string {
   const duration = formatAgentTurnDuration(elapsedSeconds);
+  if (kind === "settled" && stopPresentation) {
+    return translateStoppedDuration(t, duration, stopPresentation);
+  }
   return kind === "live"
     ? translateLiveDuration(t, duration)
     : translateSettledDuration(t, duration);
+}
+
+function translateStoppedDuration(
+  t: ReturnType<typeof useTranslation>["t"],
+  duration: AgentTurnDuration,
+  presentation: Exclude<AgentTurnStopPresentation, null>
+): string {
+  return presentation === "historical"
+    ? translateHistoricalStoppedDuration(t, duration)
+    : translateUserStoppedDuration(t, duration);
+}
+
+function translateUserStoppedDuration(
+  t: ReturnType<typeof useTranslation>["t"],
+  duration: AgentTurnDuration
+): string {
+  if (duration.kind === "seconds") {
+    return t("agentHost.agentGui.turnStoppedSeconds", {
+      seconds: duration.seconds
+    });
+  }
+  if (duration.kind === "minutes") {
+    return t("agentHost.agentGui.turnStoppedMinutes", {
+      minutes: duration.minutes
+    });
+  }
+  return t("agentHost.agentGui.turnStoppedMinutesSeconds", {
+    minutes: duration.minutes,
+    seconds: duration.seconds
+  });
+}
+
+function translateHistoricalStoppedDuration(
+  t: ReturnType<typeof useTranslation>["t"],
+  duration: AgentTurnDuration
+): string {
+  if (duration.kind === "seconds") {
+    return t("agentHost.agentGui.turnHistoricallyStoppedSeconds", {
+      seconds: duration.seconds
+    });
+  }
+  if (duration.kind === "minutes") {
+    return t("agentHost.agentGui.turnHistoricallyStoppedMinutes", {
+      minutes: duration.minutes
+    });
+  }
+  return t("agentHost.agentGui.turnHistoricallyStoppedMinutesSeconds", {
+    minutes: duration.minutes,
+    seconds: duration.seconds
+  });
 }
 
 function translateLiveDuration(

--- a/packages/agent/gui/shared/agentConversation/components/agentTurnWorkSectionModel.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTurnWorkSectionModel.spec.ts
@@ -350,6 +350,51 @@ describe("agentTurnWorkSectionModel", () => {
     expect(model.sections).toHaveLength(1);
     expect(model.sections[0]?.kind).toBe("visible");
   });
+
+  it.each([
+    ["user_prompt", "user"],
+    ["goal_arm", "user"],
+    ["goal_continuation", "user"],
+    ["provider_initiated", "user"],
+    ["legacy_unknown", "historical"]
+  ] as const)(
+    "uses %s provenance to derive the %s canceled-turn presentation",
+    (origin, stopPresentation) => {
+      const model = buildAgentTurnWorkSectionModel(
+        turnGroup([userRow(), assistantRow()]),
+        canonicalTurn({
+          origin,
+          phase: "settled",
+          outcome: "canceled",
+          settledAtUnixMs: 88_000
+        })
+      );
+
+      expect(model.timing).toEqual({
+        kind: "settled",
+        elapsedSeconds: 83
+      });
+      expect(model.stopPresentation).toBe(stopPresentation);
+      expect(model.collapseEligible).toBe(false);
+    }
+  );
+
+  it.each(["completed", "failed", "interrupted"] as const)(
+    "does not attribute a %s turn to a user stop",
+    (outcome) => {
+      const model = buildAgentTurnWorkSectionModel(
+        turnGroup([userRow(), assistantRow()]),
+        canonicalTurn({
+          origin: "user_prompt",
+          phase: "settled",
+          outcome,
+          settledAtUnixMs: 88_000
+        })
+      );
+
+      expect(model.stopPresentation).toBeNull();
+    }
+  );
 });
 
 function canonicalTurn(

--- a/packages/agent/gui/shared/agentConversation/components/agentTurnWorkSectionModel.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTurnWorkSectionModel.spec.ts
@@ -90,7 +90,8 @@ describe("agentTurnWorkSectionModel", () => {
           id: "assistant-row",
           messages: [
             message("draft", null),
-            message("final", "Final answer", true)
+            message("final", "Final answer", true),
+            message("epilogue", null)
           ],
           thinking: [thinking("Inspecting files")]
         }),
@@ -116,18 +117,25 @@ describe("agentTurnWorkSectionModel", () => {
     expect(finalRow?.kind).toBe("message");
     if (finalRow?.kind === "message") {
       expect(finalRow.id).toBe("assistant-row");
-      expect(finalRow.messages.map((item) => item.body)).toEqual([
-        "draft",
-        "final"
-      ]);
+      expect(finalRow.messages.map((item) => item.body)).toEqual(["final"]);
       expect(finalRow.thinking).toEqual([]);
     }
     expect(model.sections[0]?.rows[0]?.renderKey).toBe(
-      "assistant-row:turn-work-0"
+      "assistant-row:turn-work-before"
     );
     expect(model.sections[1]?.rows[0]?.renderKey).toBe(
-      "assistant-row:turn-visible-1"
+      "assistant-row:turn-final"
     );
+    expect(model.sections[2]?.rows[0]?.renderKey).toBe(
+      "assistant-row:turn-work-after"
+    );
+    const afterFinalRow = model.sections[2]?.rows[0]?.row;
+    expect(afterFinalRow?.kind).toBe("message");
+    if (afterFinalRow?.kind === "message") {
+      expect(afterFinalRow.messages.map((item) => item.body)).toEqual([
+        "epilogue"
+      ]);
+    }
   });
 
   it("uses an explicit final-text marker instead of copy availability", () => {
@@ -184,13 +192,14 @@ describe("agentTurnWorkSectionModel", () => {
         rowIds: section.rows.map(({ row }) => row.id)
       }))
     ).toEqual([
-      { kind: "visible", rowIds: ["assistant-1", "user-2"] },
+      { kind: "work", rowIds: ["assistant-1"] },
+      { kind: "visible", rowIds: ["user-2"] },
       { kind: "work", rowIds: ["tools"] },
       { kind: "visible", rowIds: ["assistant-2"] }
     ]);
   });
 
-  it("collapses only explicitly classified assistant progress", () => {
+  it("collapses all assistant work before the final answer", () => {
     const model = buildAgentTurnWorkSectionModel(
       turnGroup([
         userRow(),
@@ -232,11 +241,11 @@ describe("agentTurnWorkSectionModel", () => {
     ).toEqual([
       {
         kind: "work",
-        bodies: ["Inspecting files", "Compacting context"]
+        bodies: ["Inspecting files", "Compacting context", "Earlier answer"]
       },
       {
         kind: "visible",
-        bodies: ["Earlier answer", "Final answer"]
+        bodies: ["Final answer"]
       }
     ]);
     expect(model.collapseEligible).toBe(true);

--- a/packages/agent/gui/shared/agentConversation/components/agentTurnWorkSectionModel.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTurnWorkSectionModel.ts
@@ -91,7 +91,11 @@ export function buildAgentTurnWorkSectionModel(
   const leadingRowCount = countLeadingUserRows(group.rows);
   const leadingRows = group.rows.slice(0, leadingRowCount);
   const finalTarget = findFinalAssistantTextTarget(group.rows);
-  const sections = buildOrderedSections(group.rows, leadingRowCount);
+  const sections = buildOrderedSections(
+    group.rows,
+    leadingRowCount,
+    finalTarget
+  );
   const hasHiddenWork = sections.some(
     (section) => section.kind === "work" && section.rows.length > 0
   );
@@ -123,13 +127,18 @@ function countLeadingUserRows(
 
 function buildOrderedSections(
   rows: readonly AgentTurnWorkSectionRow[],
-  startIndex: number
+  startIndex: number,
+  finalTarget: { rowIndex: number; messageIndex: number } | null
 ): AgentTurnWorkSectionSegment[] {
   const sections: AgentTurnWorkSectionSegment[] = [];
   for (let rowIndex = startIndex; rowIndex < rows.length; rowIndex += 1) {
     const entry = rows[rowIndex]!;
     if (entry.row.kind === "message" && entry.row.speaker === "assistant") {
-      appendAssistantMessageSections(sections, entry);
+      if (finalTarget?.rowIndex === rowIndex) {
+        appendFinalAssistantSections(sections, entry, finalTarget.messageIndex);
+      } else {
+        appendSectionRow(sections, "work", entry);
+      }
       continue;
     }
     appendSectionRow(
@@ -141,48 +150,40 @@ function buildOrderedSections(
   return sections;
 }
 
-function appendAssistantMessageSections(
+function appendFinalAssistantSections(
   sections: AgentTurnWorkSectionSegment[],
-  sourceEntry: AgentTurnWorkSectionRow
+  sourceEntry: AgentTurnWorkSectionRow,
+  finalMessageIndex: number
 ): void {
   const sourceRow = sourceEntry.row as AgentMessageRowVM;
-  const parts: Array<{
-    kind: AgentTurnWorkSectionSegment["kind"];
-    messages: AgentMessageContentVM[];
-    thinking: AgentMessageRowVM["thinking"];
-  }> = [];
+  const messagesBeforeFinal = sourceRow.messages.slice(0, finalMessageIndex);
+  const messagesAfterFinal = sourceRow.messages.slice(finalMessageIndex + 1);
 
-  if (sourceRow.thinking.length > 0) {
-    parts.push({ kind: "work", messages: [], thinking: sourceRow.thinking });
-  }
-
-  for (const message of sourceRow.messages) {
-    const kind = isExplicitWorkMessage(message) ? "work" : "visible";
-    const previous = parts.at(-1);
-    if (previous?.kind === kind && previous.thinking.length === 0) {
-      previous.messages.push(message);
-      continue;
-    }
-    parts.push({ kind, messages: [message], thinking: [] });
-  }
-
-  if (parts.length === 0) {
-    appendSectionRow(sections, "visible", sourceEntry);
-    return;
-  }
-
-  if (parts.length === 1 && sourceRow.thinking.length === 0) {
-    appendSectionRow(sections, parts[0]!.kind, sourceEntry);
-    return;
-  }
-
-  parts.forEach((part, partIndex) => {
-    appendSectionRow(sections, part.kind, {
+  if (sourceRow.thinking.length > 0 || messagesBeforeFinal.length > 0) {
+    appendSectionRow(sections, "work", {
       ...sourceEntry,
-      renderKey: `${sourceRow.id}:turn-${part.kind}-${partIndex}`,
-      row: cloneAssistantRow(sourceRow, part.messages, part.thinking)
+      renderKey: `${sourceRow.id}:turn-work-before`,
+      row: cloneAssistantRow(sourceRow, messagesBeforeFinal, sourceRow.thinking)
     });
+  }
+
+  appendSectionRow(sections, "visible", {
+    ...sourceEntry,
+    renderKey: `${sourceRow.id}:turn-final`,
+    row: cloneAssistantRow(
+      sourceRow,
+      [sourceRow.messages[finalMessageIndex]!],
+      []
+    )
   });
+
+  if (messagesAfterFinal.length > 0) {
+    appendSectionRow(sections, "work", {
+      ...sourceEntry,
+      renderKey: `${sourceRow.id}:turn-work-after`,
+      row: cloneAssistantRow(sourceRow, messagesAfterFinal, [])
+    });
+  }
 }
 
 function appendSectionRow(
@@ -246,13 +247,6 @@ function isExplicitWorkRow(row: AgentTurnWorkSectionRow["row"]): boolean {
     row.kind === "tool-group" ||
     row.kind === "turn-summary" ||
     row.kind === "processing"
-  );
-}
-
-function isExplicitWorkMessage(message: AgentMessageContentVM): boolean {
-  return (
-    message.presentationKind === "specific-progress" ||
-    message.presentationKind === "turn-boundary"
   );
 }
 

--- a/packages/agent/gui/shared/agentConversation/components/agentTurnWorkSectionModel.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTurnWorkSectionModel.ts
@@ -14,6 +14,8 @@ export type AgentTurnDuration =
   | { kind: "minutes"; minutes: number }
   | { kind: "minutes-seconds"; minutes: number; seconds: number };
 
+export type AgentTurnStopPresentation = "user" | "historical" | null;
+
 export type AgentTurnWorkSectionRow =
   AgentTranscriptTurnGroup["rows"][number] & {
     renderKey?: string;
@@ -26,6 +28,7 @@ export interface AgentTurnWorkSectionSegment {
 
 export interface AgentTurnWorkSectionModel {
   timing: AgentTurnTiming;
+  stopPresentation: AgentTurnStopPresentation;
   leadingRows: AgentTurnWorkSectionRow[];
   sections: AgentTurnWorkSectionSegment[];
   collapseEligible: boolean;
@@ -109,6 +112,12 @@ export function buildAgentTurnWorkSectionModel(
 
   return {
     timing,
+    stopPresentation:
+      turn?.outcome === "canceled"
+        ? turn.origin === "legacy_unknown"
+          ? "historical"
+          : "user"
+        : null,
     leadingRows,
     sections,
     collapseEligible

--- a/services/tuttid/service/agent/external_import.go
+++ b/services/tuttid/service/agent/external_import.go
@@ -416,18 +416,22 @@ func (s *Service) importExternalSession(
 	projectPath string,
 ) (int, bool, error) {
 	agentSessionID := externalImportedSessionID(session.Provider, session.ProviderSessionID)
-	existingIDs, sessionExists, err := s.existingExternalImportMessageIDs(ctx, workspaceID, agentSessionID)
+	existingMessages, sessionExists, err := s.existingExternalImportMessages(ctx, workspaceID, agentSessionID)
 	if err != nil {
 		return 0, false, err
 	}
 	updates := make([]agentactivitybiz.MessageUpdate, 0, len(session.Messages))
 	for i, message := range session.Messages {
 		messageID := externalImportedMessageIDForMessage(session.Provider, session.ProviderSessionID, message, i)
-		if _, ok := existingIDs[messageID]; ok {
-			continue
+		if existingTurnID, ok := existingMessages[messageID]; ok {
+			desiredTurnID := strings.TrimSpace(message.TurnID)
+			if desiredTurnID == "" || strings.TrimSpace(existingTurnID) != "" {
+				continue
+			}
 		}
 		updates = append(updates, agentactivitybiz.MessageUpdate{
 			MessageID:         messageID,
+			TurnID:            message.TurnID,
 			Role:              message.Role,
 			Kind:              message.Kind,
 			Status:            message.Status,
@@ -446,7 +450,7 @@ func (s *Service) importExternalSession(
 	if session.ResumeSupported != nil {
 		runtimeContext["externalImportResumeSupported"] = *session.ResumeSupported
 	}
-	if _, err := s.ExternalImportStore.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+	sessionReport := agentactivitybiz.SessionStateReport{
 		WorkspaceID:       workspaceID,
 		AgentSessionID:    agentSessionID,
 		Origin:            WorkspaceAgentSessionOriginImported,
@@ -464,8 +468,27 @@ func (s *Service) importExternalSession(
 		OccurredAtUnixMS:  session.UpdatedAtUnixMS,
 		StartedAtUnixMS:   session.StartedAtUnixMS,
 		EndedAtUnixMS:     session.UpdatedAtUnixMS,
-	}); err != nil {
+	}
+	if _, err := s.ExternalImportStore.ReportSessionState(ctx, sessionReport); err != nil {
 		return 0, false, err
+	}
+	for _, turn := range session.Turns {
+		if _, err := s.ExternalImportStore.ReportActivityState(ctx, agentactivitybiz.ActivityStateReport{
+			Session: sessionReport,
+			Turn: &agentactivitybiz.TurnTransition{
+				WorkspaceID:      workspaceID,
+				AgentSessionID:   agentSessionID,
+				TurnID:           turn.TurnID,
+				Phase:            agentactivitybiz.TurnPhaseSettled,
+				Outcome:          agentactivitybiz.TurnOutcomeCompleted,
+				Origin:           agentactivitybiz.TurnOriginLegacyUnknown,
+				StartedAtUnixMS:  turn.StartedAtUnixMS,
+				SettledAtUnixMS:  turn.SettledAtUnixMS,
+				OccurredAtUnixMS: turn.SettledAtUnixMS,
+			},
+		}); err != nil {
+			return 0, false, err
+		}
 	}
 	if len(updates) == 0 && sessionExists {
 		return 0, false, nil
@@ -492,13 +515,13 @@ func (s *Service) importExternalSession(
 	return importedMessages, true, nil
 }
 
-func (s *Service) existingExternalImportMessageIDs(ctx context.Context, workspaceID string, agentSessionID string) (map[string]struct{}, bool, error) {
-	ids := map[string]struct{}{}
+func (s *Service) existingExternalImportMessages(ctx context.Context, workspaceID string, agentSessionID string) (map[string]string, bool, error) {
+	messages := map[string]string{}
 	if s == nil || s.ExternalImportStore == nil {
-		return ids, false, nil
+		return messages, false, nil
 	}
 	if _, ok, err := s.ExternalImportStore.GetSession(ctx, workspaceID, agentSessionID); err != nil || !ok {
-		return ids, ok, err
+		return messages, ok, err
 	}
 	var after uint64
 	for {
@@ -510,19 +533,19 @@ func (s *Service) existingExternalImportMessageIDs(ctx context.Context, workspac
 			Order:          agentactivitybiz.MessageOrderAsc,
 		})
 		if err != nil || !ok {
-			return ids, true, err
+			return messages, true, err
 		}
 		if len(page.Messages) == 0 {
-			return ids, true, nil
+			return messages, true, nil
 		}
 		for _, message := range page.Messages {
-			ids[strings.TrimSpace(message.MessageID)] = struct{}{}
+			messages[strings.TrimSpace(message.MessageID)] = strings.TrimSpace(message.TurnID)
 			if message.Version > after {
 				after = message.Version
 			}
 		}
 		if !page.HasMore {
-			return ids, true, nil
+			return messages, true, nil
 		}
 	}
 }

--- a/services/tuttid/service/agent/external_import.go
+++ b/services/tuttid/service/agent/external_import.go
@@ -480,7 +480,7 @@ func (s *Service) importExternalSession(
 				AgentSessionID:   agentSessionID,
 				TurnID:           turn.TurnID,
 				Phase:            agentactivitybiz.TurnPhaseSettled,
-				Outcome:          agentactivitybiz.TurnOutcomeCompleted,
+				Outcome:          turn.Outcome,
 				Origin:           agentactivitybiz.TurnOriginLegacyUnknown,
 				StartedAtUnixMS:  turn.StartedAtUnixMS,
 				SettledAtUnixMS:  turn.SettledAtUnixMS,

--- a/services/tuttid/service/agent/external_import_parse.go
+++ b/services/tuttid/service/agent/external_import_parse.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
+	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	agentproviderbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
 
@@ -69,8 +70,20 @@ func parseCodexJSONL(path string, reader io.Reader) (externalImportedSession, bo
 			case "task_complete":
 				if turnID != "" {
 					turn := ensureExternalImportedTurn(&session, turnIndexByID, turnID)
+					turn.Outcome = agentactivitybiz.TurnOutcomeCompleted
 					if turn.SettledAtUnixMS <= 0 || (timestamp > 0 && timestamp < turn.SettledAtUnixMS) {
 						turn.SettledAtUnixMS = timestamp
+					}
+				}
+			case "turn_aborted":
+				if turnID != "" {
+					turn := ensureExternalImportedTurn(&session, turnIndexByID, turnID)
+					turn.Outcome = agentactivitybiz.TurnOutcomeCanceled
+					if turn.SettledAtUnixMS <= 0 || (timestamp > 0 && timestamp < turn.SettledAtUnixMS) {
+						turn.SettledAtUnixMS = timestamp
+					}
+					if activeTurnID == turnID {
+						activeTurnID = ""
 					}
 				}
 			case "user_message":
@@ -390,7 +403,8 @@ func normalizeExternalImportedTurns(turns []externalImportedTurn, messages []ext
 	normalized := make([]externalImportedTurn, 0, len(turns))
 	for _, turn := range turns {
 		turn.TurnID = strings.TrimSpace(turn.TurnID)
-		if turn.TurnID == "" || turn.StartedAtUnixMS <= 0 || turn.SettledAtUnixMS < turn.StartedAtUnixMS {
+		turn.Outcome = strings.TrimSpace(turn.Outcome)
+		if turn.TurnID == "" || !isExternalImportedTurnOutcome(turn.Outcome) || turn.StartedAtUnixMS <= 0 || turn.SettledAtUnixMS < turn.StartedAtUnixMS {
 			continue
 		}
 		turnIndexByID[turn.TurnID] = len(normalized)
@@ -414,6 +428,10 @@ func normalizeExternalImportedTurns(turns []externalImportedTurn, messages []ext
 		result = append(result, turn)
 	}
 	return result
+}
+
+func isExternalImportedTurnOutcome(outcome string) bool {
+	return outcome == agentactivitybiz.TurnOutcomeCompleted || outcome == agentactivitybiz.TurnOutcomeCanceled
 }
 
 // resolveExternalImportSessionCwd resolves a session's recorded working

--- a/services/tuttid/service/agent/external_import_parse.go
+++ b/services/tuttid/service/agent/external_import_parse.go
@@ -16,6 +16,8 @@ import (
 
 func parseCodexJSONL(path string, reader io.Reader) (externalImportedSession, bool, error) {
 	session := externalImportedSession{Provider: agentproviderbiz.Codex, SourcePath: path}
+	activeTurnID := ""
+	turnIndexByID := map[string]int{}
 	err := readJSONLLines(reader, func(index int, raw map[string]any) {
 		timestamp := unixMSFromAny(raw["timestamp"])
 		switch stringField(raw, "type") {
@@ -40,20 +42,44 @@ func parseCodexJSONL(path string, reader io.Reader) (externalImportedSession, bo
 			if effort := stringField(payload, "effort"); effort != "" {
 				session.ReasoningEffort = effort
 			}
+			if turnID := strings.TrimSpace(firstNonEmptyString(stringField(payload, "turn_id"), stringField(payload, "turnId"))); turnID != "" {
+				activeTurnID = turnID
+				ensureExternalImportedTurn(&session, turnIndexByID, turnID)
+			}
 		case "response_item":
 			payload := mapField(raw, "payload")
 			message := codexMessageFromPayload(payload, index, timestamp)
 			if externalImportedMessageHasContent(message) {
+				message.TurnID = activeTurnID
 				session.Messages = append(session.Messages, message)
 			}
 		case "event_msg":
 			payload := mapField(raw, "payload")
-			if stringField(payload, "type") == "user_message" {
+			eventType := stringField(payload, "type")
+			turnID := strings.TrimSpace(firstNonEmptyString(stringField(payload, "turn_id"), stringField(payload, "turnId")))
+			switch eventType {
+			case "task_started":
+				if turnID != "" {
+					activeTurnID = turnID
+					turn := ensureExternalImportedTurn(&session, turnIndexByID, turnID)
+					if turn.StartedAtUnixMS <= 0 || (timestamp > 0 && timestamp < turn.StartedAtUnixMS) {
+						turn.StartedAtUnixMS = timestamp
+					}
+				}
+			case "task_complete":
+				if turnID != "" {
+					turn := ensureExternalImportedTurn(&session, turnIndexByID, turnID)
+					if turn.SettledAtUnixMS <= 0 || (timestamp > 0 && timestamp < turn.SettledAtUnixMS) {
+						turn.SettledAtUnixMS = timestamp
+					}
+				}
+			case "user_message":
 				messageText := externalContentText(payload["message"])
 				session.Title = firstNonEmptyString(session.Title, messageText)
 				if text, ok := externalImportDisplayTextCandidate(session.Provider, messageText); ok {
 					session.EventUserMessage = externalImportedMessage{
 						RawID:             "event:" + strconv.Itoa(index),
+						TurnID:            activeTurnID,
 						Role:              "user",
 						Kind:              "text",
 						Status:            "completed",
@@ -70,6 +96,17 @@ func parseCodexJSONL(path string, reader io.Reader) (externalImportedSession, bo
 		return externalImportedSession{}, false, err
 	}
 	return normalizeExternalParsedSession(session)
+}
+
+func ensureExternalImportedTurn(session *externalImportedSession, turnIndexByID map[string]int, turnID string) *externalImportedTurn {
+	if index, ok := turnIndexByID[turnID]; ok {
+		return &session.Turns[index]
+	}
+	turnIndexByID[turnID] = len(session.Turns)
+	session.Turns = append(session.Turns, externalImportedTurn{
+		TurnID: turnID,
+	})
+	return &session.Turns[len(session.Turns)-1]
 }
 
 func codexMessageFromPayload(payload map[string]any, index int, timestamp int64) externalImportedMessage {
@@ -341,10 +378,42 @@ func normalizeExternalParsedSession(session externalImportedSession) (externalIm
 		}
 	}
 	session.Messages = messages
+	session.Turns = normalizeExternalImportedTurns(session.Turns, messages)
 	session.StartedAtUnixMS = firstExternalMessageUnixMS(messages)
 	session.UpdatedAtUnixMS = lastExternalMessageUnixMS(messages)
 	session.Title = resolveExternalSessionTitle(session.Provider, session.SummaryTitle, session.Title, messages)
 	return session, true, nil
+}
+
+func normalizeExternalImportedTurns(turns []externalImportedTurn, messages []externalImportedMessage) []externalImportedTurn {
+	turnIndexByID := make(map[string]int, len(turns))
+	normalized := make([]externalImportedTurn, 0, len(turns))
+	for _, turn := range turns {
+		turn.TurnID = strings.TrimSpace(turn.TurnID)
+		if turn.TurnID == "" || turn.StartedAtUnixMS <= 0 || turn.SettledAtUnixMS < turn.StartedAtUnixMS {
+			continue
+		}
+		turnIndexByID[turn.TurnID] = len(normalized)
+		normalized = append(normalized, turn)
+	}
+	messageCountByTurn := make(map[string]int, len(normalized))
+	for index := range messages {
+		message := &messages[index]
+		turnIndex, ok := turnIndexByID[strings.TrimSpace(message.TurnID)]
+		if !ok {
+			message.TurnID = ""
+			continue
+		}
+		messageCountByTurn[normalized[turnIndex].TurnID]++
+	}
+	result := normalized[:0]
+	for _, turn := range normalized {
+		if messageCountByTurn[turn.TurnID] == 0 {
+			continue
+		}
+		result = append(result, turn)
+	}
+	return result
 }
 
 // resolveExternalImportSessionCwd resolves a session's recorded working

--- a/services/tuttid/service/agent/external_import_parse_test.go
+++ b/services/tuttid/service/agent/external_import_parse_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 )
 
@@ -102,6 +103,128 @@ func TestParseCodexJSONLCapturesLatestModelAndEffortFromTurnContext(t *testing.T
 	}
 	if session.ReasoningEffort != "xhigh" {
 		t.Fatalf("reasoningEffort = %q, want latest turn_context effort", session.ReasoningEffort)
+	}
+}
+
+func TestParseCodexJSONLPreservesNativeTurnBoundaries(t *testing.T) {
+	cwd := t.TempDir()
+	firstStart := time.Date(2026, time.July, 17, 10, 0, 0, 0, time.UTC)
+	firstSettled := firstStart.Add(12 * time.Second)
+	secondStart := firstStart.Add(time.Minute)
+	secondSettled := secondStart.Add(25 * time.Second)
+	thirdStart := secondStart.Add(time.Minute)
+	session, ok, err := parseCodexJSONL(
+		filepath.Join(cwd, "rollout.jsonl"),
+		strings.NewReader(testAgentJSONL(t,
+			map[string]any{
+				"timestamp": firstStart.Add(-time.Second).Format(time.RFC3339Nano),
+				"type":      "session_meta",
+				"payload":   map[string]any{"id": "codex-turns", "cwd": cwd},
+			},
+			map[string]any{
+				"timestamp": firstStart.Format(time.RFC3339Nano),
+				"type":      "event_msg",
+				"payload":   map[string]any{"type": "task_started", "turn_id": "turn-1"},
+			},
+			map[string]any{
+				"timestamp": firstStart.Add(10 * time.Millisecond).Format(time.RFC3339Nano),
+				"type":      "turn_context",
+				"payload":   map[string]any{"turn_id": "turn-1"},
+			},
+			map[string]any{
+				"timestamp": firstStart.Add(time.Second).Format(time.RFC3339Nano),
+				"type":      "response_item",
+				"payload": map[string]any{
+					"type": "message", "id": "user-1", "role": "user",
+					"content": []any{map[string]any{"type": "input_text", "text": "First prompt"}},
+				},
+			},
+			map[string]any{
+				"timestamp": firstStart.Add(5 * time.Second).Format(time.RFC3339Nano),
+				"type":      "turn_context",
+				"payload":   map[string]any{"turn_id": "turn-1"},
+			},
+			map[string]any{
+				"timestamp": firstStart.Add(10 * time.Second).Format(time.RFC3339Nano),
+				"type":      "response_item",
+				"payload": map[string]any{
+					"type": "message", "id": "assistant-1", "role": "assistant",
+					"content": []any{map[string]any{"type": "output_text", "text": "First answer"}},
+				},
+			},
+			map[string]any{
+				"timestamp": firstSettled.Format(time.RFC3339Nano),
+				"type":      "event_msg",
+				"payload":   map[string]any{"type": "task_complete", "turn_id": "turn-1"},
+			},
+			map[string]any{
+				"timestamp": secondStart.Format(time.RFC3339Nano),
+				"type":      "event_msg",
+				"payload":   map[string]any{"type": "task_started", "turn_id": "turn-2"},
+			},
+			map[string]any{
+				"timestamp": secondStart.Add(10 * time.Millisecond).Format(time.RFC3339Nano),
+				"type":      "turn_context",
+				"payload":   map[string]any{"turn_id": "turn-2"},
+			},
+			map[string]any{
+				"timestamp": secondStart.Add(time.Second).Format(time.RFC3339Nano),
+				"type":      "response_item",
+				"payload": map[string]any{
+					"type": "message", "id": "user-2", "role": "user",
+					"content": []any{map[string]any{"type": "input_text", "text": "Second prompt"}},
+				},
+			},
+			map[string]any{
+				"timestamp": secondStart.Add(20 * time.Second).Format(time.RFC3339Nano),
+				"type":      "response_item",
+				"payload": map[string]any{
+					"type": "message", "id": "assistant-2", "role": "assistant",
+					"content": []any{map[string]any{"type": "output_text", "text": "Second answer"}},
+				},
+			},
+			map[string]any{
+				"timestamp": secondSettled.Format(time.RFC3339Nano),
+				"type":      "event_msg",
+				"payload":   map[string]any{"type": "task_complete", "turn_id": "turn-2"},
+			},
+			map[string]any{
+				"timestamp": thirdStart.Format(time.RFC3339Nano),
+				"type":      "event_msg",
+				"payload":   map[string]any{"type": "task_started", "turn_id": "turn-3"},
+			},
+			map[string]any{
+				"timestamp": thirdStart.Add(10 * time.Millisecond).Format(time.RFC3339Nano),
+				"type":      "turn_context",
+				"payload":   map[string]any{"turn_id": "turn-3"},
+			},
+			map[string]any{
+				"timestamp": thirdStart.Add(time.Second).Format(time.RFC3339Nano),
+				"type":      "response_item",
+				"payload": map[string]any{
+					"type": "message", "id": "user-3", "role": "user",
+					"content": []any{map[string]any{"type": "input_text", "text": "Still running"}},
+				},
+			},
+		)),
+	)
+	if err != nil || !ok {
+		t.Fatalf("parseCodexJSONL ok=%v err=%v", ok, err)
+	}
+	if len(session.Turns) != 2 {
+		t.Fatalf("turns = %#v, want two native turns", session.Turns)
+	}
+	if session.Turns[0].TurnID != "turn-1" || session.Turns[0].StartedAtUnixMS != firstStart.UnixMilli() || session.Turns[0].SettledAtUnixMS != firstSettled.UnixMilli() {
+		t.Fatalf("first turn = %#v", session.Turns[0])
+	}
+	if session.Turns[1].TurnID != "turn-2" || session.Turns[1].StartedAtUnixMS != secondStart.UnixMilli() || session.Turns[1].SettledAtUnixMS != secondSettled.UnixMilli() {
+		t.Fatalf("second turn = %#v", session.Turns[1])
+	}
+	wantTurnIDs := []string{"turn-1", "turn-1", "turn-2", "turn-2", ""}
+	for index, message := range session.Messages {
+		if message.TurnID != wantTurnIDs[index] {
+			t.Fatalf("message %d turnId = %q, want %q", index, message.TurnID, wantTurnIDs[index])
+		}
 	}
 }
 

--- a/services/tuttid/service/agent/external_import_parse_test.go
+++ b/services/tuttid/service/agent/external_import_parse_test.go
@@ -228,6 +228,60 @@ func TestParseCodexJSONLPreservesNativeTurnBoundaries(t *testing.T) {
 	}
 }
 
+func TestParseCodexJSONLPreservesUserAbortedTurnBoundary(t *testing.T) {
+	cwd := t.TempDir()
+	startedAt := time.Date(2026, time.July, 17, 10, 0, 0, 0, time.UTC)
+	interruptedAt := startedAt.Add(83 * time.Second)
+	session, ok, err := parseCodexJSONL(
+		filepath.Join(cwd, "rollout.jsonl"),
+		strings.NewReader(testAgentJSONL(t,
+			map[string]any{
+				"timestamp": startedAt.Add(-time.Second).Format(time.RFC3339Nano),
+				"type":      "session_meta",
+				"payload":   map[string]any{"id": "codex-interrupted", "cwd": cwd},
+			},
+			map[string]any{
+				"timestamp": startedAt.Format(time.RFC3339Nano),
+				"type":      "event_msg",
+				"payload":   map[string]any{"type": "task_started", "turn_id": "turn-1"},
+			},
+			map[string]any{
+				"timestamp": startedAt.Add(time.Millisecond).Format(time.RFC3339Nano),
+				"type":      "turn_context",
+				"payload":   map[string]any{"turn_id": "turn-1"},
+			},
+			map[string]any{
+				"timestamp": startedAt.Add(time.Second).Format(time.RFC3339Nano),
+				"type":      "response_item",
+				"payload": map[string]any{
+					"type": "message", "id": "user-1", "role": "user",
+					"content": []any{map[string]any{"type": "input_text", "text": "Run the task"}},
+				},
+			},
+			map[string]any{
+				"timestamp": interruptedAt.Format(time.RFC3339Nano),
+				"type":      "event_msg",
+				"payload": map[string]any{
+					"type": "turn_aborted", "turn_id": "turn-1", "reason": "interrupted",
+				},
+			},
+		)),
+	)
+	if err != nil || !ok {
+		t.Fatalf("parseCodexJSONL ok=%v err=%v", ok, err)
+	}
+	if len(session.Turns) != 1 {
+		t.Fatalf("turns = %#v, want one interrupted turn", session.Turns)
+	}
+	turn := session.Turns[0]
+	if turn.TurnID != "turn-1" || turn.Outcome != "canceled" {
+		t.Fatalf("turn = %#v, want canceled turn-1", turn)
+	}
+	if turn.StartedAtUnixMS != startedAt.UnixMilli() || turn.SettledAtUnixMS != interruptedAt.UnixMilli() {
+		t.Fatalf("turn timing = %d..%d, want %d..%d", turn.StartedAtUnixMS, turn.SettledAtUnixMS, startedAt.UnixMilli(), interruptedAt.UnixMilli())
+	}
+}
+
 func TestParseCodexJSONLPreservesToolCallStructure(t *testing.T) {
 	cwd := t.TempDir()
 	session, ok, err := parseCodexJSONL(

--- a/services/tuttid/service/agent/external_import_types.go
+++ b/services/tuttid/service/agent/external_import_types.go
@@ -96,6 +96,7 @@ type externalImportedSession struct {
 	StartedAtUnixMS  int64
 	UpdatedAtUnixMS  int64
 	Messages         []externalImportedMessage
+	Turns            []externalImportedTurn
 	// Model and ReasoningEffort capture the provider-reported model/effort the
 	// local CLI was actually using (Codex `turn_context.model`/`effort`,
 	// Claude Code `message.model`) so imported sessions preserve the user's
@@ -112,6 +113,7 @@ type externalImportedSession struct {
 type externalImportedMessage struct {
 	RawID             string
 	MessageIDSeed     string
+	TurnID            string
 	Role              string
 	Kind              string
 	Status            string
@@ -120,6 +122,12 @@ type externalImportedMessage struct {
 	OccurredAtUnixMS  int64
 	StartedAtUnixMS   int64
 	CompletedAtUnixMS int64
+}
+
+type externalImportedTurn struct {
+	TurnID          string
+	StartedAtUnixMS int64
+	SettledAtUnixMS int64
 }
 
 type externalScanData struct {

--- a/services/tuttid/service/agent/external_import_types.go
+++ b/services/tuttid/service/agent/external_import_types.go
@@ -126,6 +126,7 @@ type externalImportedMessage struct {
 
 type externalImportedTurn struct {
 	TurnID          string
+	Outcome         string
 	StartedAtUnixMS int64
 	SettledAtUnixMS int64
 }

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -633,6 +633,154 @@ func TestServiceImportExternalSessionsOmitsProjectsWithoutValidSessions(t *testi
 	}
 }
 
+func TestServiceImportExternalCodexSessionRepairsNativeTurnIdentity(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-1", Name: "Workspace One"}); err != nil {
+		t.Fatalf("Create workspace error = %v", err)
+	}
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatalf("create project error = %v", err)
+	}
+	if canonical, ok := canonicalExistingDir(project); ok {
+		project = canonical
+	}
+	codexHome := filepath.Join(root, "codex-home")
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(root, "claude-home"))
+	startedAt := time.Date(2026, time.July, 17, 10, 0, 0, 0, time.UTC)
+	settledAt := startedAt.Add(12 * time.Second)
+	writeAgentServiceJSONL(t, filepath.Join(codexHome, "sessions", "native-turn.jsonl"),
+		map[string]any{
+			"timestamp": startedAt.Add(-time.Second).Format(time.RFC3339Nano),
+			"type":      "session_meta",
+			"payload":   map[string]any{"id": "native-turn-session", "cwd": project},
+		},
+		map[string]any{
+			"timestamp": startedAt.Format(time.RFC3339Nano),
+			"type":      "event_msg",
+			"payload":   map[string]any{"type": "task_started", "turn_id": "native-turn-1"},
+		},
+		map[string]any{
+			"timestamp": startedAt.Add(time.Millisecond).Format(time.RFC3339Nano),
+			"type":      "turn_context",
+			"payload":   map[string]any{"turn_id": "native-turn-1", "model": "gpt-5.4"},
+		},
+		map[string]any{
+			"timestamp": startedAt.Add(2 * time.Millisecond).Format(time.RFC3339Nano),
+			"type":      "response_item",
+			"payload": map[string]any{
+				"type": "message", "id": "user-1", "role": "user",
+				"content": []any{map[string]any{"type": "input_text", "text": "Inspect the repository"}},
+			},
+		},
+		map[string]any{
+			"timestamp": settledAt.Add(-time.Second).Format(time.RFC3339Nano),
+			"type":      "response_item",
+			"payload": map[string]any{
+				"type": "message", "id": "assistant-1", "role": "assistant",
+				"content": []any{map[string]any{"type": "output_text", "text": "Inspection complete"}},
+			},
+		},
+		map[string]any{
+			"timestamp": settledAt.Format(time.RFC3339Nano),
+			"type":      "event_msg",
+			"payload":   map[string]any{"type": "task_complete", "turn_id": "native-turn-1"},
+		},
+	)
+
+	agentSessionID := externalImportedSessionID("codex", "native-turn-session")
+	if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+		WorkspaceID:       "ws-1",
+		AgentSessionID:    agentSessionID,
+		Origin:            WorkspaceAgentSessionOriginImported,
+		Provider:          "codex",
+		ProviderSessionID: "native-turn-session",
+		RuntimeContext:    map[string]any{"imported": true},
+		Cwd:               project,
+		Title:             "Inspect the repository",
+		Status:            "completed",
+		CurrentPhase:      "completed",
+		OccurredAtUnixMS:  settledAt.UnixMilli(),
+	}); err != nil {
+		t.Fatalf("seed imported session error = %v", err)
+	}
+	legacyMessages := []agentactivitybiz.MessageUpdate{
+		{
+			MessageID:         externalImportedMessageID("codex", "native-turn-session", "user-1", 0),
+			Role:              "user",
+			Kind:              "text",
+			Status:            "completed",
+			Payload:           map[string]any{"text": "Inspect the repository"},
+			OccurredAtUnixMS:  startedAt.Add(2 * time.Millisecond).UnixMilli(),
+			StartedAtUnixMS:   startedAt.Add(2 * time.Millisecond).UnixMilli(),
+			CompletedAtUnixMS: startedAt.Add(2 * time.Millisecond).UnixMilli(),
+		},
+		{
+			MessageID:         externalImportedMessageID("codex", "native-turn-session", "assistant-1", 1),
+			Role:              "assistant",
+			Kind:              "text",
+			Status:            "completed",
+			Payload:           map[string]any{"text": "Inspection complete"},
+			OccurredAtUnixMS:  settledAt.Add(-time.Second).UnixMilli(),
+			StartedAtUnixMS:   settledAt.Add(-time.Second).UnixMilli(),
+			CompletedAtUnixMS: settledAt.Add(-time.Second).UnixMilli(),
+		},
+	}
+	if _, err := store.ReportSessionMessages(ctx, agentactivitybiz.SessionMessageReport{
+		WorkspaceID:      "ws-1",
+		AgentSessionID:   agentSessionID,
+		Origin:           WorkspaceAgentSessionOriginImported,
+		Provider:         "codex",
+		HistoricalImport: true,
+		Messages:         legacyMessages,
+	}); err != nil {
+		t.Fatalf("seed turnless imported messages error = %v", err)
+	}
+
+	service := newIsolatedAgentService(newFakeRuntime())
+	projection := NewActivityProjection(store)
+	service.SessionReader = projection
+	service.MessageReader = projection
+	service.ExternalImportStore = store
+	if _, err := service.ImportExternalSessions(ctx, "ws-1", ExternalImportInput{
+		Projects: []ExternalImportProjectSelection{{Path: project, SessionIDs: []string{agentSessionID}}},
+	}); err != nil {
+		t.Fatalf("ImportExternalSessions error = %v", err)
+	}
+
+	turns, err := store.ListSessionTurns(ctx, "ws-1", agentSessionID)
+	if err != nil {
+		t.Fatalf("ListSessionTurns error = %v", err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("turns = %#v, want one native Codex turn", turns)
+	}
+	turn := turns[0]
+	if turn.TurnID != "native-turn-1" || turn.Phase != agentactivitybiz.TurnPhaseSettled || turn.Outcome != agentactivitybiz.TurnOutcomeCompleted {
+		t.Fatalf("turn = %#v, want settled completed native turn", turn)
+	}
+	if turn.StartedAtUnixMS != startedAt.UnixMilli() || turn.SettledAtUnixMS != settledAt.UnixMilli() {
+		t.Fatalf("turn timing = %d..%d, want %d..%d", turn.StartedAtUnixMS, turn.SettledAtUnixMS, startedAt.UnixMilli(), settledAt.UnixMilli())
+	}
+	page, ok, err := store.ListSessionMessages(ctx, agentactivitybiz.ListSessionMessagesInput{
+		WorkspaceID: "ws-1", AgentSessionID: agentSessionID, Limit: 10,
+	})
+	if err != nil || !ok {
+		t.Fatalf("ListSessionMessages ok=%v error=%v", ok, err)
+	}
+	if len(page.Messages) != 2 {
+		t.Fatalf("messages = %#v, want two repaired messages without duplicates", page.Messages)
+	}
+	for _, message := range page.Messages {
+		if message.TurnID != "native-turn-1" {
+			t.Fatalf("message %q turnId = %q, want native-turn-1", message.MessageID, message.TurnID)
+		}
+	}
+}
+
 func TestServiceImportExternalSessionsRepairsSelectedNestedProjectRailMembership(t *testing.T) {
 	ctx := context.Background()
 	store := openAgentServiceSQLiteStore(t)

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -781,6 +781,57 @@ func TestServiceImportExternalCodexSessionRepairsNativeTurnIdentity(t *testing.T
 	}
 }
 
+func TestServiceImportExternalSessionPersistsUserCanceledTurnOutcome(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-1", Name: "Workspace One"}); err != nil {
+		t.Fatalf("Create workspace error = %v", err)
+	}
+	startedAt := time.Date(2026, time.July, 17, 10, 0, 0, 0, time.UTC)
+	interruptedAt := startedAt.Add(83 * time.Second)
+	session := externalImportedSession{
+		Provider:          "codex",
+		ProviderSessionID: "interrupted-session",
+		SourcePath:        filepath.Join(t.TempDir(), "rollout.jsonl"),
+		Cwd:               t.TempDir(),
+		Title:             "Run the task",
+		StartedAtUnixMS:   startedAt.UnixMilli(),
+		UpdatedAtUnixMS:   interruptedAt.UnixMilli(),
+		Turns: []externalImportedTurn{{
+			TurnID:          "turn-1",
+			Outcome:         agentactivitybiz.TurnOutcomeCanceled,
+			StartedAtUnixMS: startedAt.UnixMilli(),
+			SettledAtUnixMS: interruptedAt.UnixMilli(),
+		}},
+		Messages: []externalImportedMessage{{
+			RawID:             "user-1",
+			TurnID:            "turn-1",
+			Role:              "user",
+			Kind:              "text",
+			Status:            "completed",
+			Text:              "Run the task",
+			OccurredAtUnixMS:  startedAt.Add(time.Second).UnixMilli(),
+			StartedAtUnixMS:   startedAt.Add(time.Second).UnixMilli(),
+			CompletedAtUnixMS: startedAt.Add(time.Second).UnixMilli(),
+		}},
+	}
+
+	service := newIsolatedAgentService(newFakeRuntime())
+	service.ExternalImportStore = store
+	if _, _, err := service.importExternalSession(ctx, "ws-1", session, session.Cwd); err != nil {
+		t.Fatalf("importExternalSession error = %v", err)
+	}
+
+	agentSessionID := externalImportedSessionID("codex", "interrupted-session")
+	turns, err := store.ListSessionTurns(ctx, "ws-1", agentSessionID)
+	if err != nil {
+		t.Fatalf("ListSessionTurns error = %v", err)
+	}
+	if len(turns) != 1 || turns[0].Outcome != agentactivitybiz.TurnOutcomeCanceled {
+		t.Fatalf("turns = %#v, want one canceled turn", turns)
+	}
+}
+
 func TestServiceImportExternalSessionsRepairsSelectedNestedProjectRailMembership(t *testing.T) {
 	ctx := context.Background()
 	store := openAgentServiceSQLiteStore(t)


### PR DESCRIPTION
## Summary

- Display canonical elapsed time for active agent Turns and freeze the final duration when a Turn settles.
- Continue counting wall-clock time while an active Turn is waiting for user interaction, while excluding time spent waiting for the next ordinary prompt after settlement.
- Automatically collapse tool calls, thinking, progress, file summaries, and intermediate assistant replies for successfully completed Turns, while keeping the final assistant response visible.
- Keep failed, canceled, interrupted, error-bearing, image, and final-text-free Turns expanded so important output is not hidden.
- Preserve imported Codex `turn_aborted` events as canonical `canceled` Turns with accurate settlement timing.
- Attribute native canceled Turns to the user, while using neutral wording for imported or unknown historical Turns:
  - Native: `You stopped the task after 1m 23s`
  - Imported history: `The task stopped after 1m 23s`
- Update the Agent GUI architecture documentation to describe canonical timing, disclosure, waiting-time, and provenance rules.

## Verification

- `pnpm check:full`
  - Passed all 18 preparation, preflight, and validation tasks
  - Includes TypeScript tests, Go tests, TypeScript typecheck, and Go/TypeScript lint
- `pnpm --filter @tutti-os/agent-gui test`
  - 191 test files passed
  - 1800 tests passed
- Focused Agent Turn timing and disclosure tests
  - 2 test files passed
  - 27 tests passed
- `pnpm typecheck`
  - Passed for 27 packages
- `pnpm check:i18n`
  - Passed for 2 locales, 3483 keys, and 1544 source files
- `pnpm check:agent-activity-runtime-boundaries`
  - Passed
- Manually launched the desktop application and verified live timing, settled timing, automatic collapse, disclosure toggling, waiting-time behavior, and canceled-Turn presentation.

## Fix Scope Justification

- Root cause: after the Turn/session lifecycle refactor, Agent GUI could no longer safely derive Turn timing, completion, final-answer boundaries, or cancellation attribution from transcript rows and legacy session state. Imported Codex abort events also did not retain sufficient canonical outcome and provenance semantics for accurate presentation.
- Why can this not be fixed at a lower layer?
  - Provider-specific abort semantics are normalized at the daemon import boundary into canonical `canceled` Turns.
  - Canonical timestamps, outcome, origin, and active-Turn identity remain owned by the activity model.
  - Final-answer disclosure, localized attribution, animation, and user-controlled expansion are presentation concerns and therefore belong in Agent GUI. Moving them into the daemon would mix UI policy with durable lifecycle state.

## Fallback Three Questions

- Source: canonical Turns provide authoritative start and settlement timestamps only when lifecycle state changes. The local timer supplies the one-second display cadence between those authoritative events.
- Why can it not be fixed at that source? Emitting or persisting daemon updates every second would add unnecessary writes and event traffic for presentation-only state. Agent GUI can safely calculate elapsed wall-clock time from the canonical start timestamp.
- Removal condition: the local timer can be removed if the activity runtime provides a shared authoritative elapsed-time clock or if the UI no longer displays live second-level duration. It already stops immediately when the Turn settles and only updates the isolated duration label.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. No README or CONTRIBUTING files were changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->