### PR TITLE
fix(agent-gui): preserve SVG masks in published package

### DIFF
--- a/docs/conventions/npm-package-release.md
+++ b/docs/conventions/npm-package-release.md
@@ -216,6 +216,14 @@ following:
   unless that dependency is an intentional part of the public contract
 - a consumer-facing build emits or copies the asset only when the consumer
   explicitly imports the asset subpath
+- packed JavaScript does not contain raw XML SVG data URLs; SVGs interpolated
+  into CSS `url(...)` values must be emitted as files or encoded into a
+  CSS-safe data URL
+
+Do not use a workspace application build as the only validation for asset
+changes. Workspace exports can point at source while published exports point at
+`dist`, so the two paths may apply different asset transforms. The packed
+tarball is the consumer contract.
 
 ## Package Entrypoints
 

--- a/packages/agent/gui/tsup.config.ts
+++ b/packages/agent/gui/tsup.config.ts
@@ -36,8 +36,7 @@ export default defineConfig({
   external: ["react", "react-dom"],
   format: ["esm"],
   loader: {
-    ".png": "dataurl",
-    ".svg": "dataurl"
+    ".png": "dataurl"
   },
   sourcemap: true
 });

--- a/tools/scripts/check-package-packs.mjs
+++ b/tools/scripts/check-package-packs.mjs
@@ -8,6 +8,7 @@ import {
   workspaceRoot
 } from "./npm-release-packages.mjs";
 import { missingPackedRelativeImports } from "./package-pack-relative-imports.mjs";
+import { packedFilesWithRawSvgDataUrls } from "./package-pack-svg-data-urls.mjs";
 
 const forbiddenPrefixes = [
   "package/src/",
@@ -76,6 +77,18 @@ async function checkPackage(packageConfig, destination) {
     );
     for (const missingImport of missingImports) {
       violations.push(`missing runtime import ${missingImport}`);
+    }
+  }
+
+  if (packageConfig.name === "@tutti-os/agent-gui") {
+    const unpackedDirectory = join(destination, `${tarball}.unpacked`);
+    await mkdir(unpackedDirectory, { recursive: true });
+    execFileSync("tar", ["-xzf", tarballPath, "-C", unpackedDirectory]);
+    const rawSvgDataUrlFiles = await packedFilesWithRawSvgDataUrls(
+      join(unpackedDirectory, "package")
+    );
+    for (const file of rawSvgDataUrlFiles) {
+      violations.push(`raw SVG data URL in ${file}`);
     }
   }
 

--- a/tools/scripts/package-pack-svg-data-urls.mjs
+++ b/tools/scripts/package-pack-svg-data-urls.mjs
@@ -1,0 +1,41 @@
+import { readFile, readdir } from "node:fs/promises";
+import { extname, join, relative, resolve } from "node:path";
+
+const javascriptExtensions = new Set([".cjs", ".js", ".mjs"]);
+const rawSvgDataUrlPattern =
+  /data:image\/svg\+xml(?:;charset=[^,]+)?,\s*\x3csvg\b/i;
+
+export async function packedFilesWithRawSvgDataUrls(packageRoot) {
+  const normalizedRoot = resolve(packageRoot);
+  const files = await listFiles(normalizedRoot);
+  const violations = [];
+
+  for (const file of files) {
+    if (!javascriptExtensions.has(extname(file))) {
+      continue;
+    }
+
+    const source = await readFile(file, "utf8");
+    if (rawSvgDataUrlPattern.test(source)) {
+      violations.push(relative(normalizedRoot, file).replaceAll("\\", "/"));
+    }
+  }
+
+  return violations.sort();
+}
+
+async function listFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listFiles(path)));
+    } else if (entry.isFile()) {
+      files.push(path);
+    }
+  }
+
+  return files;
+}

--- a/tools/scripts/package-pack-svg-data-urls.test.mjs
+++ b/tools/scripts/package-pack-svg-data-urls.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { packedFilesWithRawSvgDataUrls } from "./package-pack-svg-data-urls.mjs";
+
+test("reports raw SVG data URLs in packed JavaScript", async () => {
+  const root = await mkdtemp(join(tmpdir(), "tutti-pack-svg-data-url-"));
+  try {
+    await mkdir(join(root, "dist"));
+    await writeFile(
+      join(root, "dist/index.js"),
+      'const icon = "data:image/svg+xml,' +
+        "<" +
+        'svg width=\\"24\\"></svg>";\n'
+    );
+
+    assert.deepEqual(await packedFilesWithRawSvgDataUrls(root), [
+      "dist/index.js"
+    ]);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("accepts emitted files and CSS-safe SVG data URLs", async () => {
+  const root = await mkdtemp(join(tmpdir(), "tutti-pack-svg-data-url-"));
+  try {
+    await mkdir(join(root, "dist"));
+    await writeFile(
+      join(root, "dist/index.js"),
+      [
+        'const emitted = "./icon-ABC123.svg";',
+        'const encoded = "data:image/svg+xml,%3Csvg%20width%3D%2724%27%3E%3C%2Fsvg%3E";',
+        'const base64 = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=";'
+      ].join("\n")
+    );
+
+    assert.deepEqual(await packedFilesWithRawSvgDataUrls(root), []);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

- emit Agent GUI SVG imports as package files instead of raw XML data URLs
- reject raw SVG data URLs in the packed `@tutti-os/agent-gui` artifact
- document why packed assets must be validated independently from workspace builds

## Root cause

The workspace desktop consumes Agent GUI source exports, so Vite produced CSS-safe asset URLs. Published consumers use the tsup-built `dist` exports, where the `.svg: "dataurl"` loader embedded unescaped XML. Those values were interpolated into quoted CSS `url(...)` masks, invalidating the mask while leaving the solid background visible.

## Validation

- `pnpm --filter @tutti-os/agent-gui test -- --run` (193 files, 1798 tests)
- `pnpm lint:ts`
- `pnpm typecheck`
- `pnpm check:ui-boundaries`
- `pnpm release:pack:check`
- `node --test tools/scripts/package-pack-svg-data-urls.test.mjs`

## Risk

Low. The public JavaScript API is unchanged; SVGs move from inline data URLs to hashed files included in the package `dist` directory.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->