### PR TITLE
fix(agent-gui): inline CSS-safe SVG mask URLs

### DIFF
--- a/docs/conventions/npm-package-release.md
+++ b/docs/conventions/npm-package-release.md
@@ -216,9 +216,14 @@ following:
   unless that dependency is an intentional part of the public contract
 - a consumer-facing build emits or copies the asset only when the consumer
   explicitly imports the asset subpath
-- packed JavaScript does not contain raw XML SVG data URLs; SVGs interpolated
-  into CSS `url(...)` values must be emitted as files or encoded into a
-  CSS-safe data URL
+- packed JavaScript does not contain raw XML SVG data URLs or bare relative SVG
+  strings; SVGs interpolated into runtime CSS `url(...)` values must use a
+  CSS-safe data URL or an absolute URL constructed relative to the module
+
+Emitting an SVG next to a bundled JavaScript file is not sufficient when the
+bundle only exports a string such as `./icon-HASH.svg`. CSS resolves that value
+relative to the consuming page, and consumer bundlers cannot discover the
+runtime string as an asset dependency.
 
 Do not use a workspace application build as the only validation for asset
 changes. Workspace exports can point at source while published exports point at

--- a/packages/agent/gui/build/cssSafeSvgDataUrl.spec.ts
+++ b/packages/agent/gui/build/cssSafeSvgDataUrl.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { cssSafeSvgDataUrl, svgDataUrlPrefix } from "./cssSafeSvgDataUrl";
+
+describe("cssSafeSvgDataUrl", () => {
+  it("encodes SVG markup for a quoted CSS url", () => {
+    const svg = "<" + 'svg viewBox="0 0 24 24"><path fill="#000" /></svg>';
+    const url = cssSafeSvgDataUrl(svg);
+
+    expect(url).toMatch(/^data:image\/svg\+xml,%3Csvg/);
+    expect(url).not.toContain("<" + "svg");
+    expect(url).not.toContain('"');
+    expect(url).not.toContain("#");
+    expect(decodeURIComponent(url.slice(svgDataUrlPrefix.length))).toBe(svg);
+
+    const style = document.createElement("span").style;
+    style.maskImage = `url("${svgDataUrlPrefix}${svg}")`;
+    expect(style.maskImage).toBe("");
+
+    style.maskImage = `url("${url}")`;
+    expect(style.maskImage).toBe(`url("${url}")`);
+  });
+});

--- a/packages/agent/gui/build/cssSafeSvgDataUrl.ts
+++ b/packages/agent/gui/build/cssSafeSvgDataUrl.ts
@@ -1,0 +1,5 @@
+export const svgDataUrlPrefix = "data:image/svg+xml,";
+
+export function cssSafeSvgDataUrl(svg: string): string {
+  return `${svgDataUrlPrefix}${encodeURIComponent(svg)}`;
+}

--- a/packages/agent/gui/tsup.config.ts
+++ b/packages/agent/gui/tsup.config.ts
@@ -1,4 +1,22 @@
-import { defineConfig } from "tsup";
+import { readFile } from "node:fs/promises";
+
+import { defineConfig, type Options } from "tsup";
+
+import { cssSafeSvgDataUrl } from "./build/cssSafeSvgDataUrl";
+
+const cssSafeSvgDataUrlPlugin: NonNullable<Options["esbuildPlugins"]>[number] =
+  {
+    name: "css-safe-svg-data-url",
+    setup(build) {
+      build.onLoad({ filter: /\.svg$/ }, async ({ path }) => {
+        const svg = await readFile(path, "utf8");
+        return {
+          contents: `export default ${JSON.stringify(cssSafeSvgDataUrl(svg))};`,
+          loader: "js"
+        };
+      });
+    }
+  };
 
 export default defineConfig({
   clean: true,
@@ -34,6 +52,7 @@ export default defineConfig({
     "workspace-query-cache": "shared/query/workspaceQueryCache.ts"
   },
   external: ["react", "react-dom"],
+  esbuildPlugins: [cssSafeSvgDataUrlPlugin],
   format: ["esm"],
   loader: {
     ".png": "dataurl"

--- a/tools/scripts/check-package-packs.mjs
+++ b/tools/scripts/check-package-packs.mjs
@@ -8,7 +8,10 @@ import {
   workspaceRoot
 } from "./npm-release-packages.mjs";
 import { missingPackedRelativeImports } from "./package-pack-relative-imports.mjs";
-import { packedFilesWithRawSvgDataUrls } from "./package-pack-svg-data-urls.mjs";
+import {
+  packedFilesWithRawSvgDataUrls,
+  packedFilesWithRelativeSvgUrls
+} from "./package-pack-svg-data-urls.mjs";
 
 const forbiddenPrefixes = [
   "package/src/",
@@ -89,6 +92,12 @@ async function checkPackage(packageConfig, destination) {
     );
     for (const file of rawSvgDataUrlFiles) {
       violations.push(`raw SVG data URL in ${file}`);
+    }
+    const relativeSvgUrlFiles = await packedFilesWithRelativeSvgUrls(
+      join(unpackedDirectory, "package")
+    );
+    for (const file of relativeSvgUrlFiles) {
+      violations.push(`consumer-unresolvable relative SVG URL in ${file}`);
     }
   }
 

--- a/tools/scripts/package-pack-svg-data-urls.mjs
+++ b/tools/scripts/package-pack-svg-data-urls.mjs
@@ -4,6 +4,7 @@ import { extname, join, relative, resolve } from "node:path";
 const javascriptExtensions = new Set([".cjs", ".js", ".mjs"]);
 const rawSvgDataUrlPattern =
   /data:image\/svg\+xml(?:;charset=[^,]+)?,\s*\x3csvg\b/i;
+const relativeSvgUrlPattern = /["']\.\/[^"']+\.svg["']/gi;
 
 export async function packedFilesWithRawSvgDataUrls(packageRoot) {
   const normalizedRoot = resolve(packageRoot);
@@ -22,6 +23,35 @@ export async function packedFilesWithRawSvgDataUrls(packageRoot) {
   }
 
   return violations.sort();
+}
+
+export async function packedFilesWithRelativeSvgUrls(packageRoot) {
+  const normalizedRoot = resolve(packageRoot);
+  const files = await listFiles(normalizedRoot);
+  const violations = [];
+
+  for (const file of files) {
+    if (!javascriptExtensions.has(extname(file))) {
+      continue;
+    }
+
+    const source = await readFile(file, "utf8");
+    if (hasConsumerUnresolvableRelativeSvgUrl(source)) {
+      violations.push(relative(normalizedRoot, file).replaceAll("\\", "/"));
+    }
+  }
+
+  return violations.sort();
+}
+
+function hasConsumerUnresolvableRelativeSvgUrl(source) {
+  for (const match of source.matchAll(relativeSvgUrlPattern)) {
+    const prefix = source.slice(Math.max(0, match.index - 32), match.index);
+    if (!/new URL\(\s*$/.test(prefix)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 async function listFiles(directory) {

--- a/tools/scripts/package-pack-svg-data-urls.test.mjs
+++ b/tools/scripts/package-pack-svg-data-urls.test.mjs
@@ -4,7 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import { packedFilesWithRawSvgDataUrls } from "./package-pack-svg-data-urls.mjs";
+import {
+  packedFilesWithRawSvgDataUrls,
+  packedFilesWithRelativeSvgUrls
+} from "./package-pack-svg-data-urls.mjs";
 
 test("reports raw SVG data URLs in packed JavaScript", async () => {
   const root = await mkdtemp(join(tmpdir(), "tutti-pack-svg-data-url-"));
@@ -25,20 +28,38 @@ test("reports raw SVG data URLs in packed JavaScript", async () => {
   }
 });
 
-test("accepts emitted files and CSS-safe SVG data URLs", async () => {
+test("reports relative SVG URLs that consumers cannot resolve", async () => {
+  const root = await mkdtemp(join(tmpdir(), "tutti-pack-svg-data-url-"));
+  try {
+    await mkdir(join(root, "dist"));
+    await writeFile(
+      join(root, "dist/index.js"),
+      'const icon = "./icon-ABC123.svg";\n'
+    );
+
+    assert.deepEqual(await packedFilesWithRelativeSvgUrls(root), [
+      "dist/index.js"
+    ]);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("accepts CSS-safe SVG data URLs", async () => {
   const root = await mkdtemp(join(tmpdir(), "tutti-pack-svg-data-url-"));
   try {
     await mkdir(join(root, "dist"));
     await writeFile(
       join(root, "dist/index.js"),
       [
-        'const emitted = "./icon-ABC123.svg";',
         'const encoded = "data:image/svg+xml,%3Csvg%20width%3D%2724%27%3E%3C%2Fsvg%3E";',
-        'const base64 = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=";'
+        'const base64 = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=";',
+        'const moduleRelative = new URL("./icon.svg", import.meta.url).href;'
       ].join("\n")
     );
 
     assert.deepEqual(await packedFilesWithRawSvgDataUrls(root), []);
+    assert.deepEqual(await packedFilesWithRelativeSvgUrls(root), []);
   } finally {
     await rm(root, { force: true, recursive: true });
   }


### PR DESCRIPTION
## Summary

- encode published Agent GUI SVG imports as CSS-safe, self-contained data URLs
- reject both raw SVG data URLs and consumer-unresolvable relative SVG strings in package tarballs
- add CSSOM coverage proving mask declarations accept the encoded URL

## Root cause

`0.0.122` emitted SVG files next to the package bundle, but tsup exported them as strings such as `./handoff-lined-HASH.svg`. When Agent GUI interpolated that string into runtime `mask-image`, CSS resolved it relative to the consuming page instead of the npm module. Consumer bundlers could not discover the runtime string as an asset dependency, so the mask image disappeared.

The package build now emits percent-encoded SVG data URLs. They contain neither raw XML quotes that invalidate CSS nor relative paths that depend on consumer asset handling.

## Validation

- `pnpm --filter @tutti-os/agent-gui test -- --run` (194 files, 1799 tests)
- `pnpm lint:ts`
- `pnpm typecheck`
- `pnpm check:ui-boundaries`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm release:pack:check`
- packed JS contains encoded `data:image/svg+xml,%3Csvg...` values and no raw XML or unresolved relative SVG strings

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->