### PR TITLE
feat(mentions): centralize rich text mention resolution

### DIFF
--- a/.changeset/mention-icon-readonly-fallback.md
+++ b/.changeset/mention-icon-readonly-fallback.md
@@ -2,6 +2,7 @@
 "@tutti-os/agent-gui": patch
 "@tutti-os/ui-rich-text": minor
 "@tutti-os/ui-system": patch
+"@tutti-os/workspace-external-core": minor
 ---
 
 Hydrate mention presentation in readonly rich-text conversations from the same
@@ -10,3 +11,6 @@ without serializing presentation URLs into Markdown.
 
 Render semantic mention icons whenever a supplied image cannot load across the
 shared mention pill, AgentGUI composer, and AgentGUI Markdown surfaces.
+
+Add a host-agnostic mention service with bounded stale-while-revalidate cache,
+React context integration, exact external-host resolution, and invalidation.

--- a/.changeset/mention-icon-readonly-fallback.md
+++ b/.changeset/mention-icon-readonly-fallback.md
@@ -1,0 +1,12 @@
+---
+"@tutti-os/agent-gui": patch
+"@tutti-os/ui-rich-text": minor
+"@tutti-os/ui-system": patch
+---
+
+Hydrate mention presentation in readonly rich-text conversations from the same
+trigger providers used by the composer, so workspace app icons remain available
+without serializing presentation URLs into Markdown.
+
+Render semantic mention icons whenever a supplied image cannot load across the
+shared mention pill, AgentGUI composer, and AgentGUI Markdown surfaces.

--- a/apps/desktop/src/main/ipc/workspaceAppContext.test.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppContext.test.ts
@@ -1,9 +1,15 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
   createWorkspaceAppUserActiveTrackEvent,
   workspaceAppUserActiveEventName
 } from "./workspaceAppActivityAnalytics.ts";
+
+const workspaceAppContextSource = readFileSync(
+  new URL("./workspaceAppContext.ts", import.meta.url),
+  "utf8"
+);
 
 test("workspace app user active event uses host-owned app context", () => {
   assert.deepEqual(
@@ -22,5 +28,12 @@ test("workspace app user active event uses host-owned app context", () => {
         workspace_id: "workspace-1"
       }
     }
+  );
+});
+
+test("workspace app at resolution is scoped by the registered guest context", () => {
+  assert.match(
+    workspaceAppContextSource,
+    /appExternal\.atResolve,[\s\S]*?requireWorkspaceAppGuestContext\(event\.sender\)[\s\S]*?normalizeTuttiExternalAtResolveInput\(payload\)[\s\S]*?appId: context\.appID,[\s\S]*?operation: "at\.resolve",[\s\S]*?workspaceId: context\.workspaceID/
   );
 });

--- a/apps/desktop/src/main/ipc/workspaceAppContext.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppContext.ts
@@ -22,6 +22,8 @@ import {
 } from "../../shared/contracts/ipc";
 import {
   normalizeTuttiExternalAtQueryInput,
+  normalizeTuttiExternalAtResolveInput,
+  normalizeTuttiExternalAtInvalidation,
   normalizeTuttiExternalFileOpenInput,
   normalizeTuttiExternalFileSelectInput,
   normalizeTuttiExternalFileUploadInput,
@@ -39,6 +41,7 @@ import {
 } from "@tutti-os/workspace-external-core/core";
 import type {
   TuttiExternalAtQueryResult,
+  TuttiExternalAtResolveResult,
   TuttiExternalFileOpenInput,
   TuttiExternalFileSelectResult,
   TuttiExternalManagedAiModel,
@@ -176,6 +179,23 @@ export function registerWorkspaceAppContextIpc(
           appId: context.appID,
           input,
           operation: "at.query",
+          requestId: randomUUID(),
+          workspaceId: context.workspaceID
+        }
+      );
+    }
+  );
+  registerDesktopIpcHandler(
+    desktopIpcChannels.appExternal.atResolve,
+    async (event, payload) => {
+      const context = requireWorkspaceAppGuestContext(event.sender);
+      const input = normalizeTuttiExternalAtResolveInput(payload);
+      return requestWorkspaceAppExternalRenderer<TuttiExternalAtResolveResult | null>(
+        context,
+        {
+          appId: context.appID,
+          input,
+          operation: "at.resolve",
           requestId: randomUUID(),
           workspaceId: context.workspaceID
         }
@@ -1379,6 +1399,14 @@ function isWorkspaceAppExternalRendererEvent(
       typeof value.appId === "string" &&
       isWorkspaceAppOpenRouteIntent(value.intent)
     );
+  }
+  if (value.type === "at.invalidated") {
+    try {
+      normalizeTuttiExternalAtInvalidation(value.invalidation);
+      return true;
+    } catch {
+      return false;
+    }
   }
   if (value.type !== "userProjects.changed") {
     return false;

--- a/apps/desktop/src/preload/entries/workspaceApp.ts
+++ b/apps/desktop/src/preload/entries/workspaceApp.ts
@@ -4,7 +4,10 @@ import type {
   DesktopWorkspaceAppContext,
   DesktopWorkspaceAppExternalRendererEvent
 } from "../../shared/contracts/ipc";
-import type { TuttiExternalWorkspaceOpenRouteIntent } from "@tutti-os/workspace-external-core/contracts";
+import type {
+  TuttiExternalAtInvalidation,
+  TuttiExternalWorkspaceOpenRouteIntent
+} from "@tutti-os/workspace-external-core/contracts";
 import { createWorkspaceAppExternalBridge } from "./workspaceAppExternalBridge.ts";
 import { installWorkspaceAppInteractionForwarding } from "./workspaceAppInteractionForwarding.ts";
 import { installWorkspaceAppLinkInterception } from "./workspaceAppLinks.ts";
@@ -59,6 +62,9 @@ function installWorkspaceAppMainFrameBridge(): void {
   const launchIntentListeners = new Set<
     (intent: TuttiExternalWorkspaceOpenRouteIntent) => void
   >();
+  const atInvalidationListeners = new Set<
+    (event: TuttiExternalAtInvalidation) => void
+  >();
   const userProjectSnapshots = createWorkspaceAppUserProjectSnapshotBridge();
   let cachedContext: DesktopWorkspaceAppContext | null = null;
   let pendingContext: Promise<DesktopWorkspaceAppContext> | null = null;
@@ -110,6 +116,12 @@ function installWorkspaceAppMainFrameBridge(): void {
     send(channel, payload) {
       ipcRenderer.send(channel, payload);
     },
+    subscribeToAtInvalidations(listener) {
+      atInvalidationListeners.add(listener);
+      return () => {
+        atInvalidationListeners.delete(listener);
+      };
+    },
     subscribeToWorkspaceLaunchIntents(listener) {
       launchIntentListeners.add(listener);
       return () => {
@@ -141,6 +153,12 @@ function installWorkspaceAppMainFrameBridge(): void {
       }
       if (payload.type === "userProjects.changed") {
         userProjectSnapshots.publish(payload.snapshot);
+        return;
+      }
+      if (payload.type === "at.invalidated") {
+        for (const listener of atInvalidationListeners) {
+          listener(payload.invalidation);
+        }
         return;
       }
       if (payload.type === "workspace.launchIntent") {
@@ -220,10 +238,14 @@ function isWorkspaceAppExternalRendererEvent(
   const record = value as Record<string, unknown>;
   if (record.type !== "userProjects.changed") {
     return (
-      record.type === "workspace.launchIntent" &&
-      typeof record.workspaceId === "string" &&
-      typeof record.appId === "string" &&
-      isWorkspaceAppOpenRouteIntent(record.intent)
+      (record.type === "workspace.launchIntent" &&
+        typeof record.workspaceId === "string" &&
+        typeof record.appId === "string" &&
+        isWorkspaceAppOpenRouteIntent(record.intent)) ||
+      (record.type === "at.invalidated" &&
+        typeof record.workspaceId === "string" &&
+        typeof record.invalidation === "object" &&
+        record.invalidation !== null)
     );
   }
   if (typeof record.workspaceId !== "string") {

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
@@ -164,6 +164,87 @@ test("workspace app external bridge invokes at query without user activation", a
   ]);
 });
 
+test("workspace app external bridge resolves mentions without user activation", async () => {
+  const calls: Array<{ channel: string; payload?: unknown }> = [];
+  const bridge = createWorkspaceAppExternalBridge({
+    appContext: {
+      async get() {
+        return { locale: "en" };
+      },
+      subscribe() {
+        throw new Error("unexpected subscribe");
+      }
+    },
+    isUserActivationActive: () => false,
+    send: unexpectedSend,
+    async invoke<TResult>(channel: string, payload?: unknown) {
+      calls.push({ channel, payload });
+      return {
+        label: "Canvas",
+        presentation: { iconUrl: "tutti://app-icon/canvas" }
+      } as TResult;
+    }
+  });
+
+  assert.deepEqual(
+    await bridge.at.resolve?.({
+      providerId: "workspace-app",
+      entityId: "canvas",
+      scope: { workspaceId: "untrusted-workspace" }
+    }),
+    {
+      label: "Canvas",
+      presentation: { iconUrl: "tutti://app-icon/canvas" }
+    }
+  );
+  assert.deepEqual(calls, [
+    {
+      channel: workspaceAppExternalChannels.atResolve,
+      payload: {
+        providerId: "workspace-app",
+        entityId: "canvas",
+        scope: { workspaceId: "untrusted-workspace" }
+      }
+    }
+  ]);
+});
+
+test("workspace app external bridge subscribes to mention invalidation", () => {
+  let publish:
+    | ((event: { providerIds?: readonly ["workspace-app"] }) => void)
+    | undefined;
+  let unsubscribed = false;
+  const bridge = createWorkspaceAppExternalBridge({
+    appContext: {
+      async get() {
+        return { locale: "en" };
+      },
+      subscribe() {
+        throw new Error("unexpected subscribe");
+      }
+    },
+    isUserActivationActive: () => false,
+    send: unexpectedSend,
+    subscribeToAtInvalidations(listener) {
+      publish = listener;
+      return () => {
+        unsubscribed = true;
+      };
+    },
+    async invoke() {
+      throw new Error("unexpected invoke");
+    }
+  });
+  const events: unknown[] = [];
+
+  const unsubscribe = bridge.at.subscribe?.((event) => events.push(event));
+  publish?.({ providerIds: ["workspace-app"] });
+  unsubscribe?.();
+
+  assert.deepEqual(events, [{ providerIds: ["workspace-app"] }]);
+  assert.equal(unsubscribed, true);
+});
+
 test("workspace app external bridge reports active without user activation", async () => {
   const calls: Array<{ channel: string; payload?: unknown }> = [];
   const bridge = createWorkspaceAppExternalBridge({

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.ts
@@ -7,6 +7,9 @@ import type {
 import type {
   TuttiExternalAtQueryInput,
   TuttiExternalAtQueryResult,
+  TuttiExternalAtInvalidation,
+  TuttiExternalAtResolveInput,
+  TuttiExternalAtResolveResult,
   TuttiExternalBridge,
   TuttiExternalFileOpenInput,
   TuttiExternalFileSelectInput,
@@ -55,6 +58,9 @@ export interface WorkspaceAppExternalBridgeDependencies {
   subscribeToUserProjects?(
     listener: (snapshot: WorkspaceUserProjectServiceSnapshot) => void
   ): () => void;
+  subscribeToAtInvalidations?(
+    listener: (event: TuttiExternalAtInvalidation) => void
+  ): () => void;
   subscribeToWorkspaceLaunchIntents?(
     listener: (intent: TuttiExternalWorkspaceOpenRouteIntent) => void
   ): () => void;
@@ -83,6 +89,7 @@ export interface WorkspaceAppUploadXMLHttpRequest {
 export const workspaceAppExternalChannels = {
   activityReportActive: "workspace-app-activity:report-active",
   atQuery: "workspace-app-at:query",
+  atResolve: "workspace-app-at:resolve",
   browserOpenUrl: "workspace-app:open-url",
   filesOpen: "workspace-app-files:open",
   filesSelect: "workspace-app-files:select",
@@ -148,6 +155,15 @@ export function createWorkspaceAppExternalBridge(
           workspaceAppExternalChannels.atQuery,
           input
         );
+      },
+      resolve(input: TuttiExternalAtResolveInput) {
+        return dependencies.invoke<TuttiExternalAtResolveResult | null>(
+          workspaceAppExternalChannels.atResolve,
+          input
+        );
+      },
+      subscribe(listener) {
+        return dependencies.subscribeToAtInvalidations?.(listener) ?? noop;
       }
     },
     files: {

--- a/apps/desktop/src/renderer/src/features/rich-text-at/index.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/index.ts
@@ -13,3 +13,4 @@ export {
   type DesktopAgentSessionStatusView
 } from "./providers/desktopAgentSessionMentionProvider.ts";
 export { createDesktopAgentSessionStatusViewResolver } from "./providers/desktopAgentSessionStatusView.ts";
+export { createDesktopRichTextMentionService } from "./services/internal/createDesktopRichTextMentionService.ts";

--- a/apps/desktop/src/renderer/src/features/rich-text-at/index.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/index.ts
@@ -13,4 +13,7 @@ export {
   type DesktopAgentSessionStatusView
 } from "./providers/desktopAgentSessionMentionProvider.ts";
 export { createDesktopAgentSessionStatusViewResolver } from "./providers/desktopAgentSessionStatusView.ts";
-export { createDesktopRichTextMentionService } from "./services/internal/createDesktopRichTextMentionService.ts";
+export {
+  createDesktopRichTextMentionService,
+  type DesktopRichTextMentionInvalidationSource
+} from "./services/internal/createDesktopRichTextMentionService.ts";

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/createDesktopRichTextMentionService.test.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/createDesktopRichTextMentionService.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { RichTextTriggerProvider } from "@tutti-os/ui-rich-text/types";
+import { createDesktopRichTextMentionService } from "./createDesktopRichTextMentionService.ts";
+
+test("desktop mention service shares one workspace-scoped resolver", async () => {
+  let resolveCalls = 0;
+  const provider: RichTextTriggerProvider = {
+    id: "workspace-app",
+    trigger: "@",
+    query: () => [],
+    getItemKey: () => "",
+    getItemLabel: () => "",
+    toInsertResult: () => ({ kind: "text", text: "" }),
+    resolveMention: async () => {
+      resolveCalls += 1;
+      await Promise.resolve();
+      return { presentation: { iconUrl: "tutti://app-icon/canvas" } };
+    }
+  };
+  const requests: unknown[] = [];
+  const service = createDesktopRichTextMentionService({
+    richTextAtService: {
+      _serviceBrand: undefined,
+      getProviders(input) {
+        requests.push(input);
+        return [provider];
+      }
+    },
+    workspaceId: "workspace-1"
+  });
+  const identity = {
+    providerId: "workspace-app",
+    entityId: "canvas",
+    label: "Canvas",
+    scope: { workspaceId: "workspace-1" }
+  };
+
+  const snapshots = await Promise.all([
+    service.resolve(identity),
+    service.resolve(identity),
+    service.resolve(identity)
+  ]);
+
+  assert.equal(resolveCalls, 1);
+  assert.equal(
+    snapshots.every((snapshot) => snapshot.state === "ready"),
+    true
+  );
+  assert.deepEqual(requests, [
+    {
+      capabilities: [
+        "file",
+        "workspace-app",
+        "workspace-issue",
+        "agent-target",
+        "agent-session"
+      ],
+      surface: "desktop-workspace-root",
+      target: "workspace",
+      workspaceId: "workspace-1"
+    }
+  ]);
+  service.dispose();
+});

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/createDesktopRichTextMentionService.test.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/createDesktopRichTextMentionService.test.ts
@@ -63,3 +63,80 @@ test("desktop mention service shares one workspace-scoped resolver", async () =>
   ]);
   service.dispose();
 });
+
+test("desktop mention service refreshes shared mounted consumers and releases event sources", async () => {
+  let resolveCalls = 0;
+  let sourceListener: (() => void) | undefined;
+  let sourceUnsubscribeCalls = 0;
+  const provider: RichTextTriggerProvider = {
+    id: "workspace-app",
+    trigger: "@",
+    query: () => [],
+    getItemKey: () => "",
+    getItemLabel: () => "",
+    toInsertResult: () => ({ kind: "text", text: "" }),
+    resolveMention: async () => {
+      resolveCalls += 1;
+      return {
+        presentation: { iconUrl: `tutti://app-icon/canvas-${resolveCalls}` }
+      };
+    }
+  };
+  const service = createDesktopRichTextMentionService({
+    invalidationSources: [
+      {
+        selector: {
+          providerId: "workspace-app",
+          workspaceId: "workspace-1"
+        },
+        subscribe(listener) {
+          sourceListener = listener;
+          return () => {
+            sourceUnsubscribeCalls += 1;
+          };
+        }
+      }
+    ],
+    richTextAtService: {
+      _serviceBrand: undefined,
+      getProviders: () => [provider]
+    },
+    workspaceId: "workspace-1"
+  });
+  const identity = {
+    providerId: "workspace-app",
+    entityId: "canvas",
+    label: "Canvas",
+    scope: { workspaceId: "workspace-1" }
+  };
+  const consumerNotifications = [0, 0, 0];
+  const unsubscribeConsumers = consumerNotifications.map((_, index) =>
+    service.subscribe(() => {
+      consumerNotifications[index] = (consumerNotifications[index] ?? 0) + 1;
+    }, identity)
+  );
+
+  await Promise.all([
+    service.resolve(identity),
+    service.resolve(identity),
+    service.resolve(identity)
+  ]);
+  assert.equal(resolveCalls, 1);
+
+  sourceListener?.();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal(resolveCalls, 2);
+  assert.deepEqual(service.getSnapshot(identity).resolved?.presentation, {
+    iconUrl: "tutti://app-icon/canvas-2"
+  });
+  assert.equal(
+    consumerNotifications.every((count) => count > 0),
+    true
+  );
+
+  for (const unsubscribe of unsubscribeConsumers) unsubscribe();
+  service.dispose();
+  service.dispose();
+  assert.equal(sourceUnsubscribeCalls, 1);
+});

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/createDesktopRichTextMentionService.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/createDesktopRichTextMentionService.ts
@@ -1,0 +1,23 @@
+import { createRichTextMentionService } from "@tutti-os/ui-rich-text/service";
+import type { RichTextMentionService } from "@tutti-os/ui-rich-text/service";
+import type { IDesktopRichTextAtService } from "../richTextAtService.interface.ts";
+
+export function createDesktopRichTextMentionService(input: {
+  richTextAtService: IDesktopRichTextAtService;
+  workspaceId: string;
+}): RichTextMentionService {
+  return createRichTextMentionService({
+    providers: input.richTextAtService.getProviders({
+      capabilities: [
+        "file",
+        "workspace-app",
+        "workspace-issue",
+        "agent-target",
+        "agent-session"
+      ],
+      surface: "desktop-workspace-root",
+      target: "workspace",
+      workspaceId: input.workspaceId
+    })
+  });
+}

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/createDesktopRichTextMentionService.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/createDesktopRichTextMentionService.ts
@@ -1,12 +1,22 @@
-import { createRichTextMentionService } from "@tutti-os/ui-rich-text/service";
-import type { RichTextMentionService } from "@tutti-os/ui-rich-text/service";
+import {
+  createRichTextMentionService,
+  type RichTextMentionInvalidationSelector,
+  type RichTextMentionService
+} from "@tutti-os/ui-rich-text/service";
 import type { IDesktopRichTextAtService } from "../richTextAtService.interface.ts";
 
+export interface DesktopRichTextMentionInvalidationSource {
+  debounceMs?: number;
+  selector: RichTextMentionInvalidationSelector;
+  subscribe(listener: () => void): () => void;
+}
+
 export function createDesktopRichTextMentionService(input: {
+  invalidationSources?: readonly DesktopRichTextMentionInvalidationSource[];
   richTextAtService: IDesktopRichTextAtService;
   workspaceId: string;
 }): RichTextMentionService {
-  return createRichTextMentionService({
+  const service = createRichTextMentionService({
     providers: input.richTextAtService.getProviders({
       capabilities: [
         "file",
@@ -20,4 +30,39 @@ export function createDesktopRichTextMentionService(input: {
       workspaceId: input.workspaceId
     })
   });
+  const sourceDisposers = (input.invalidationSources ?? []).map((source) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const unsubscribe = source.subscribe(() => {
+      if (!source.debounceMs) {
+        service.invalidate(source.selector);
+        return;
+      }
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = undefined;
+        service.invalidate(source.selector);
+      }, source.debounceMs);
+    });
+    return () => {
+      clearTimeout(timer);
+      unsubscribe();
+    };
+  });
+  let disposed = false;
+
+  return {
+    ...service,
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      for (const disposeSource of sourceDisposers) {
+        try {
+          disposeSource();
+        } catch {
+          // One host event source must not prevent the remaining cleanup.
+        }
+      }
+      service.dispose();
+    }
+  };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
@@ -270,3 +270,10 @@ test("workspace app external at query preserves explicit provider filters", () =
     /input\.query\.providers !== undefined\s+\?\s+input\.query\.providers\s+:\s+tuttiExternalAtProviderIds/
   );
 });
+
+test("workspace app external at resolve overrides caller workspace scope", () => {
+  assert.match(
+    workspaceWorkbenchHostServiceSource,
+    /resolveWorkspaceAppExternalAt\([\s\S]*?scope: \{[\s\S]*?\.\.\.input\.mention\.scope,[\s\S]*?workspaceId: input\.workspaceId[\s\S]*?\}/
+  );
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -76,7 +76,9 @@ import type { RichTextTriggerProvider } from "@tutti-os/ui-rich-text/types";
 import { tuttiExternalAtProviderIds } from "@tutti-os/workspace-external-core/core";
 import type {
   TuttiExternalAtQueryInput,
-  TuttiExternalAtQueryResult
+  TuttiExternalAtQueryResult,
+  TuttiExternalAtResolveInput,
+  TuttiExternalAtResolveResult
 } from "@tutti-os/workspace-external-core/contracts";
 import type { WorkspaceFileReferenceAdapter } from "@tutti-os/workspace-file-reference/contracts";
 import type { WorkspaceUserProjectApi } from "@tutti-os/workspace-user-project/contracts";
@@ -287,28 +289,10 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
         ? input.query.providers
         : tuttiExternalAtProviderIds
     );
-    const richTextCapabilities = [...providerIds].filter(
-      (providerId) => providerId !== "agent-generated-file"
+    const providers = this.createWorkspaceAppExternalAtProviders(
+      providerIds,
+      input.workspaceId
     );
-    const providers: RichTextTriggerProvider[] = [
-      ...this.dependencies.richTextAtService.getProviders({
-        capabilities: richTextCapabilities,
-        surface: "workspace-app-external",
-        target: "workspace-app",
-        workspaceId: input.workspaceId
-      })
-    ];
-    if (providerIds.has("agent-generated-file")) {
-      const agentGeneratedFileProvider =
-        createDesktopAgentGeneratedFileMentionProvider({
-          agentActivityRuntime: this.dependencies.workspaceAgentActivityService,
-          workspaceId: input.workspaceId
-        });
-      providers.push({
-        ...agentGeneratedFileProvider,
-        trigger: "@"
-      });
-    }
     const registry = createRichTextTriggerRegistry(providers);
     const matches = await registry.query({
       keyword: input.query.keyword,
@@ -325,6 +309,55 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
       .filter(
         (result): result is TuttiExternalAtQueryResult => result !== null
       );
+  }
+
+  async resolveWorkspaceAppExternalAt(input: {
+    mention: TuttiExternalAtResolveInput;
+    workspaceId: string;
+  }): Promise<TuttiExternalAtResolveResult | null> {
+    const providers = this.createWorkspaceAppExternalAtProviders(
+      new Set([input.mention.providerId]),
+      input.workspaceId
+    );
+    const provider = providers.find(
+      (candidate) => candidate.id === input.mention.providerId
+    );
+    if (!provider?.resolveMention) return null;
+    return provider.resolveMention({
+      providerId: input.mention.providerId,
+      entityId: input.mention.entityId,
+      label: "",
+      scope: {
+        ...input.mention.scope,
+        workspaceId: input.workspaceId
+      }
+    });
+  }
+
+  private createWorkspaceAppExternalAtProviders(
+    providerIds: ReadonlySet<(typeof tuttiExternalAtProviderIds)[number]>,
+    workspaceId: string
+  ): RichTextTriggerProvider[] {
+    const richTextCapabilities = [...providerIds].filter(
+      (providerId) => providerId !== "agent-generated-file"
+    );
+    const providers: RichTextTriggerProvider[] = [
+      ...this.dependencies.richTextAtService.getProviders({
+        capabilities: richTextCapabilities,
+        surface: "workspace-app-external",
+        target: "workspace-app",
+        workspaceId
+      })
+    ];
+    if (providerIds.has("agent-generated-file")) {
+      const agentGeneratedFileProvider =
+        createDesktopAgentGeneratedFileMentionProvider({
+          agentActivityRuntime: this.dependencies.workspaceAgentActivityService,
+          workspaceId
+        });
+      providers.push({ ...agentGeneratedFileProvider, trigger: "@" });
+    }
+    return providers;
   }
 
   onOpenFileRequest(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
@@ -40,7 +40,9 @@ import type {
 } from "@shared/contracts/ipc";
 import type {
   TuttiExternalAtQueryInput,
-  TuttiExternalAtQueryResult
+  TuttiExternalAtQueryResult,
+  TuttiExternalAtResolveInput,
+  TuttiExternalAtResolveResult
 } from "@tutti-os/workspace-external-core/contracts";
 import type { WorkspaceFileReferenceAdapter } from "@tutti-os/workspace-file-reference/contracts";
 import type { WorkspaceUserProjectApi } from "@tutti-os/workspace-user-project/contracts";
@@ -157,6 +159,10 @@ export interface IWorkspaceWorkbenchHostService {
     query: TuttiExternalAtQueryInput;
     workspaceId: string;
   }): Promise<TuttiExternalAtQueryResult[]>;
+  resolveWorkspaceAppExternalAt(input: {
+    mention: TuttiExternalAtResolveInput;
+    workspaceId: string;
+  }): Promise<TuttiExternalAtResolveResult | null>;
   onWindowCloseRequest(
     listener: (payload: DesktopHostWindowCloseRequestPayload) => void
   ): () => void;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -16,6 +16,7 @@ import {
   shouldAutoCollapseAgentGUIConversationRail
 } from "@tutti-os/agent-gui";
 import type { AgentGUIComposerAppendRequest } from "@tutti-os/agent-gui";
+import { RichTextMentionServiceProvider } from "@tutti-os/ui-rich-text/editor";
 import type { WorkspaceSummary } from "@tutti-os/client-tuttid-ts";
 import {
   AGENT_GUI_WORKBENCH_CONVERSATION_RAIL_TOGGLE_EVENT,
@@ -56,7 +57,10 @@ import type {
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
 import type { TuttiExternalFileOpenInput } from "@tutti-os/workspace-external-core/contracts";
 import type { IReporterService } from "@renderer/features/analytics";
-import type { IDesktopRichTextAtService } from "@renderer/features/rich-text-at";
+import {
+  createDesktopRichTextMentionService,
+  type IDesktopRichTextAtService
+} from "@renderer/features/rich-text-at";
 import type { IWorkspaceUserProjectService } from "@renderer/features/workspace-user-project";
 import { createAgentGuiWorkbenchInstanceId } from "@tutti-os/agent-gui/workbench";
 import { DesktopAgentGUISurface } from "@renderer/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx";
@@ -159,6 +163,26 @@ export function StandaloneAgentWindow({
   const workspaceFileManagerService = useService(IWorkspaceFileManagerService);
   const { service: workspaceSettingsService } = useWorkspaceSettingsService();
   const workspaceId = workspace.id;
+  const mentionService = useMemo(
+    () =>
+      createDesktopRichTextMentionService({
+        richTextAtService,
+        workspaceId
+      }),
+    [richTextAtService, workspaceId]
+  );
+  useEffect(() => () => mentionService.dispose(), [mentionService]);
+  const appCenterRevision = useSyncExternalStore(
+    (listener) => workspaceAppCenterService.subscribe(listener),
+    () => workspaceAppCenterService.store.revision,
+    () => workspaceAppCenterService.store.revision
+  );
+  useEffect(() => {
+    mentionService.invalidate({
+      providerId: "workspace-app",
+      workspaceId
+    });
+  }, [appCenterRevision, mentionService, workspaceId]);
   const [panelHostsReady, setPanelHostsReady] = useState(false);
   useEffect(() => {
     const animationFrame = window.requestAnimationFrame(() => {
@@ -605,179 +629,183 @@ export function StandaloneAgentWindow({
   ]);
 
   return (
-    <main
-      className="workbench-window h-screen min-h-0 overflow-hidden bg-background"
-      data-agent-gui-standalone-window="true"
-      data-display-mode="floating"
-      data-focused="true"
-      style={{
-        border: 0,
-        borderRadius: 0,
-        boxShadow: "none",
-        height: "100vh",
-        maxHeight: "100vh",
-        maxWidth: "100vw",
-        overflow: "hidden",
-        width: "100vw"
-      }}
-    >
-      <StandaloneAgentToolSidebar
-        activityService={workspaceAgentActivityService}
-        appOpenId={openAppId}
-        appI18n={toolWorkbench.appI18n}
-        browserApi={desktopApi.browser}
-        contributions={toolWorkbench.contributions}
-        fileOpenRequest={fileOpenRequest}
-        issueManagerOpenRequest={issueManagerOpenRequest}
-        mainContentMinWidthPx={
-          isConversationRailCollapsed
-            ? AGENT_GUI_DETAIL_MIN_WIDTH_PX
-            : headerConversationRailWidthPx +
-              agentGuiWorkbenchProviderRailWidthPx
-        }
-        renderHeader={(toolActions) => (
-          <StandaloneAgentWindowHeader
-            copy={{
-              collapseConversationRail: i18n.t(
-                "workspace.agentGui.collapseConversationRail"
-              ),
-              expandConversationRail: i18n.t(
-                "workspace.agentGui.expandConversationRail"
-              ),
-              fallbackAgentLabel: i18n.t(
-                "workspace.agentGui.fallbackAgentLabel"
-              ),
-              newConversation: i18n.t("workspace.agentGui.newConversation"),
-              openDetachedWindow: i18n.t("workspace.agentGui.openNewWindow"),
-              untitledConversation: i18n.t(
-                "workspace.agentGui.untitledConversation"
-              )
-            }}
-            conversationRailWidthPx={headerConversationRailWidthPx}
-            data-agent-gui-standalone-window-content-loading={
-              isContentLoading ? "true" : "false"
-            }
-            displayMode={isWindowMaximized ? "fullscreen" : "floating"}
-            data-agent-gui-standalone-window-header="true"
-            data-workbench-drag-handle="true"
-            isConversationRailAutoCollapsed={isConversationRailAutoCollapsed}
-            isConversationRailCollapsed={isConversationRailCollapsed}
-            identity={headerIdentity}
-            nodeId={standaloneAgentNodeId}
-            providerRailWidthPx={agentGuiWorkbenchProviderRailWidthPx}
-            primaryAccessory={<AppUpdateStatus presentation="standalone" />}
-            secondaryAccessory={isContentLoading ? null : toolActions}
-            showConversationRailToggle={!isContentLoading}
-            showAppTitle
-            title={i18n.t("workspace.agentGui.fallbackAgentLabel")}
-            windowActions={{
-              close: () => {
-                void toolWorkbench.requestWindowClose();
-              },
-              minimize: () => {
-                void hostWindowApi.minimize();
-              },
-              toggleDisplayMode: () => {
-                void hostWindowApi.toggleMaximize();
-              }
-            }}
-            onCreateConversation={handleCreateConversation}
-            onOpenDetachedWindow={handleDuplicateStandaloneWindow}
-            onToggleConversationRail={handleConversationRailToggle}
-          />
-        )}
-        onOpenMessageCenterChat={handleOpenMessageCenterChat}
-        onAppsOpen={ensureWorkspaceAppPolling}
-        onAppendBrowserElementMention={appendBrowserElementMention}
-        onBrowserElementError={Toast.Error}
-        onToolHostReady={toolWorkbench.onHostReady}
-        resizeWindowContentWidth={resizeStandaloneAgentWindowContentWidth}
-        workspaceId={workspaceId}
+    <RichTextMentionServiceProvider service={mentionService}>
+      <main
+        className="workbench-window h-screen min-h-0 overflow-hidden bg-background"
+        data-agent-gui-standalone-window="true"
+        data-display-mode="floating"
+        data-focused="true"
+        style={{
+          border: 0,
+          borderRadius: 0,
+          boxShadow: "none",
+          height: "100vh",
+          maxHeight: "100vh",
+          maxWidth: "100vw",
+          overflow: "hidden",
+          width: "100vw"
+        }}
       >
-        <StandaloneAgentWindowContentReady onReady={handleContentReady}>
-          <DesktopAgentGUISurface
-            agentActivityRuntime={agentGuiHostInput.agentActivityRuntime}
-            agentHostApi={agentGuiHostInput.agentHostApi}
-            appCenterService={workspaceAppCenterService}
-            agentProviderStatusService={agentProviderStatusService}
-            surface={surface}
-            computerUseApi={desktopApi.computerUse}
-            composerAppendRequest={composerAppendRequest}
-            conversationRailAutoCollapseWidthPx={
-              AGENT_GUI_STANDALONE_AUTO_COLLAPSE_WIDTH_PX
-            }
-            dockPreviewCache={dockPreviewCache}
-            onLinkAction={handleLinkAction}
-            onCapabilitySettingsRequest={handleCapabilitySettingsRequest}
-            onOpenAgentConversationWindow={({
-              agentSessionId,
-              agentTargetId,
-              provider
-            }) => {
-              // Duplicate the complete live snapshot so the new window can
-              // hydrate before its first local refresh.
-              void hostWindowApi.openAgentWindow({
+        <StandaloneAgentToolSidebar
+          activityService={workspaceAgentActivityService}
+          appOpenId={openAppId}
+          appI18n={toolWorkbench.appI18n}
+          browserApi={desktopApi.browser}
+          contributions={toolWorkbench.contributions}
+          fileOpenRequest={fileOpenRequest}
+          issueManagerOpenRequest={issueManagerOpenRequest}
+          mainContentMinWidthPx={
+            isConversationRailCollapsed
+              ? AGENT_GUI_DETAIL_MIN_WIDTH_PX
+              : headerConversationRailWidthPx +
+                agentGuiWorkbenchProviderRailWidthPx
+          }
+          renderHeader={(toolActions) => (
+            <StandaloneAgentWindowHeader
+              copy={{
+                collapseConversationRail: i18n.t(
+                  "workspace.agentGui.collapseConversationRail"
+                ),
+                expandConversationRail: i18n.t(
+                  "workspace.agentGui.expandConversationRail"
+                ),
+                fallbackAgentLabel: i18n.t(
+                  "workspace.agentGui.fallbackAgentLabel"
+                ),
+                newConversation: i18n.t("workspace.agentGui.newConversation"),
+                openDetachedWindow: i18n.t("workspace.agentGui.openNewWindow"),
+                untitledConversation: i18n.t(
+                  "workspace.agentGui.untitledConversation"
+                )
+              }}
+              conversationRailWidthPx={headerConversationRailWidthPx}
+              data-agent-gui-standalone-window-content-loading={
+                isContentLoading ? "true" : "false"
+              }
+              displayMode={isWindowMaximized ? "fullscreen" : "floating"}
+              data-agent-gui-standalone-window-header="true"
+              data-workbench-drag-handle="true"
+              isConversationRailAutoCollapsed={isConversationRailAutoCollapsed}
+              isConversationRailCollapsed={isConversationRailCollapsed}
+              identity={headerIdentity}
+              nodeId={standaloneAgentNodeId}
+              providerRailWidthPx={agentGuiWorkbenchProviderRailWidthPx}
+              primaryAccessory={<AppUpdateStatus presentation="standalone" />}
+              secondaryAccessory={isContentLoading ? null : toolActions}
+              showConversationRailToggle={!isContentLoading}
+              showAppTitle
+              title={i18n.t("workspace.agentGui.fallbackAgentLabel")}
+              windowActions={{
+                close: () => {
+                  void toolWorkbench.requestWindowClose();
+                },
+                minimize: () => {
+                  void hostWindowApi.minimize();
+                },
+                toggleDisplayMode: () => {
+                  void hostWindowApi.toggleMaximize();
+                }
+              }}
+              onCreateConversation={handleCreateConversation}
+              onOpenDetachedWindow={handleDuplicateStandaloneWindow}
+              onToggleConversationRail={handleConversationRailToggle}
+            />
+          )}
+          onOpenMessageCenterChat={handleOpenMessageCenterChat}
+          onAppsOpen={ensureWorkspaceAppPolling}
+          onAppendBrowserElementMention={appendBrowserElementMention}
+          onBrowserElementError={Toast.Error}
+          onToolHostReady={toolWorkbench.onHostReady}
+          resizeWindowContentWidth={resizeStandaloneAgentWindowContentWidth}
+          workspaceId={workspaceId}
+        >
+          <StandaloneAgentWindowContentReady onReady={handleContentReady}>
+            <DesktopAgentGUISurface
+              agentActivityRuntime={agentGuiHostInput.agentActivityRuntime}
+              agentHostApi={agentGuiHostInput.agentHostApi}
+              appCenterService={workspaceAppCenterService}
+              agentProviderStatusService={agentProviderStatusService}
+              surface={surface}
+              computerUseApi={desktopApi.computerUse}
+              composerAppendRequest={composerAppendRequest}
+              conversationRailAutoCollapseWidthPx={
+                AGENT_GUI_STANDALONE_AUTO_COLLAPSE_WIDTH_PX
+              }
+              dockPreviewCache={dockPreviewCache}
+              onLinkAction={handleLinkAction}
+              onCapabilitySettingsRequest={handleCapabilitySettingsRequest}
+              onOpenAgentConversationWindow={({
                 agentSessionId,
                 agentTargetId,
-                providerStatusSnapshot:
-                  agentProviderStatusService.getSnapshot(),
-                agentDirectorySnapshot,
-                provider,
-                workspaceId
-              });
-            }}
-            onStateChange={setNodeState}
-            prefillPromptBootstrapRequest={prefillPromptBootstrapRequest}
-            providerStatusBootstrapSnapshot={providerStatusBootstrapSnapshot}
-            agentDirectory={agentDirectorySnapshot}
-            defaultAgentTargetId={defaultAgentTargetId}
-            contextMentionProviders={agentGuiHostInput.contextMentionProviders}
-            runtimeApi={desktopApi.runtime}
-            trackAgentProviderChatReady={
-              agentGuiHostInput.trackAgentProviderChatReady
-            }
-            onEngagementEvent={trackStandaloneAgentGUIEngagement}
-            trackWorkspaceFileReferences={
-              agentGuiHostInput.trackWorkspaceFileReferences
-            }
-            workspaceFileReferenceAdapter={
-              agentGuiHostInput.workspaceFileReferenceAdapter
-            }
-            resolveDroppedFileReferences={
-              agentGuiHostInput.resolveDroppedFileReferences
-            }
-            onRequestGitBranches={agentGuiHostInput.onRequestGitBranches}
-            referenceSourceAggregator={
-              agentGuiHostInput.referenceSourceAggregator
-            }
-            renderSidebarFooter={renderStandaloneAgentSidebarFooter}
-            resolveWorkspaceReferenceEntryIconUrl={
-              agentGuiHostInput.resolveWorkspaceReferenceEntryIconUrl
-            }
-            resolveMentionReferenceTarget={
-              agentGuiHostInput.resolveMentionReferenceTarget
-            }
-            resolveWorkspaceReferenceInitialTarget={
-              agentGuiHostInput.resolveWorkspaceReferenceInitialTarget
-            }
-            workspaceId={workspaceId}
-          />
-        </StandaloneAgentWindowContentReady>
-      </StandaloneAgentToolSidebar>
-      {panelHostsReady ? (
-        <Suspense fallback={null}>
-          <LazyStandaloneAgentWindowPanelHosts
-            agentProviderStatusService={agentProviderStatusService}
-            host={host}
-            workspace={workspace}
-          />
-        </Suspense>
-      ) : null}
-      <WorkspaceAppExternalBridge
-        api={workspaceAppExternalApi}
-        openFile={openWorkspaceAppExternalFile}
-        workspaceId={workspaceId}
-      />
-    </main>
+                provider
+              }) => {
+                // Duplicate the complete live snapshot so the new window can
+                // hydrate before its first local refresh.
+                void hostWindowApi.openAgentWindow({
+                  agentSessionId,
+                  agentTargetId,
+                  providerStatusSnapshot:
+                    agentProviderStatusService.getSnapshot(),
+                  agentDirectorySnapshot,
+                  provider,
+                  workspaceId
+                });
+              }}
+              onStateChange={setNodeState}
+              prefillPromptBootstrapRequest={prefillPromptBootstrapRequest}
+              providerStatusBootstrapSnapshot={providerStatusBootstrapSnapshot}
+              agentDirectory={agentDirectorySnapshot}
+              defaultAgentTargetId={defaultAgentTargetId}
+              contextMentionProviders={
+                agentGuiHostInput.contextMentionProviders
+              }
+              runtimeApi={desktopApi.runtime}
+              trackAgentProviderChatReady={
+                agentGuiHostInput.trackAgentProviderChatReady
+              }
+              onEngagementEvent={trackStandaloneAgentGUIEngagement}
+              trackWorkspaceFileReferences={
+                agentGuiHostInput.trackWorkspaceFileReferences
+              }
+              workspaceFileReferenceAdapter={
+                agentGuiHostInput.workspaceFileReferenceAdapter
+              }
+              resolveDroppedFileReferences={
+                agentGuiHostInput.resolveDroppedFileReferences
+              }
+              onRequestGitBranches={agentGuiHostInput.onRequestGitBranches}
+              referenceSourceAggregator={
+                agentGuiHostInput.referenceSourceAggregator
+              }
+              renderSidebarFooter={renderStandaloneAgentSidebarFooter}
+              resolveWorkspaceReferenceEntryIconUrl={
+                agentGuiHostInput.resolveWorkspaceReferenceEntryIconUrl
+              }
+              resolveMentionReferenceTarget={
+                agentGuiHostInput.resolveMentionReferenceTarget
+              }
+              resolveWorkspaceReferenceInitialTarget={
+                agentGuiHostInput.resolveWorkspaceReferenceInitialTarget
+              }
+              workspaceId={workspaceId}
+            />
+          </StandaloneAgentWindowContentReady>
+        </StandaloneAgentToolSidebar>
+        {panelHostsReady ? (
+          <Suspense fallback={null}>
+            <LazyStandaloneAgentWindowPanelHosts
+              agentProviderStatusService={agentProviderStatusService}
+              host={host}
+              workspace={workspace}
+            />
+          </Suspense>
+        ) : null}
+        <WorkspaceAppExternalBridge
+          api={workspaceAppExternalApi}
+          openFile={openWorkspaceAppExternalFile}
+          workspaceId={workspaceId}
+        />
+      </main>
+    </RichTextMentionServiceProvider>
   );
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -166,23 +166,35 @@ export function StandaloneAgentWindow({
   const mentionService = useMemo(
     () =>
       createDesktopRichTextMentionService({
+        invalidationSources: [
+          {
+            selector: { providerId: "workspace-app", workspaceId },
+            subscribe: (listener) =>
+              workspaceAppCenterService.subscribe(listener)
+          },
+          {
+            selector: { providerId: "agent-target", workspaceId },
+            subscribe: (listener) => agentsService.subscribe(listener)
+          },
+          {
+            debounceMs: 100,
+            selector: { providerId: "agent-session", workspaceId },
+            subscribe: (listener) =>
+              workspaceAgentActivityService.subscribe(workspaceId, listener)
+          }
+        ],
         richTextAtService,
         workspaceId
       }),
-    [richTextAtService, workspaceId]
+    [
+      agentsService,
+      richTextAtService,
+      workspaceAgentActivityService,
+      workspaceAppCenterService,
+      workspaceId
+    ]
   );
   useEffect(() => () => mentionService.dispose(), [mentionService]);
-  const appCenterRevision = useSyncExternalStore(
-    (listener) => workspaceAppCenterService.subscribe(listener),
-    () => workspaceAppCenterService.store.revision,
-    () => workspaceAppCenterService.store.revision
-  );
-  useEffect(() => {
-    mentionService.invalidate({
-      providerId: "workspace-app",
-      workspaceId
-    });
-  }, [appCenterRevision, mentionService, workspaceId]);
   const [panelHostsReady, setPanelHostsReady] = useState(false);
   useEffect(() => {
     const animationFrame = window.requestAnimationFrame(() => {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAppExternalBridge.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAppExternalBridge.tsx
@@ -83,7 +83,8 @@ export function WorkspaceAppExternalBridge({
 }: WorkspaceAppExternalBridgeProps): ReactElement | null {
   const hostService = useWorkspaceWorkbenchHostService();
   const { service: settingsService } = useWorkspaceSettingsService();
-  const { service: appCenterService } = useWorkspaceAppCenterService();
+  const { service: appCenterService, state: appCenterState } =
+    useWorkspaceAppCenterService();
   const workspaceAgentActivityService = useService(
     IWorkspaceAgentActivityService
   );
@@ -142,6 +143,18 @@ export function WorkspaceAppExternalBridge({
     };
   }, [api, userProjectsApi, workspaceId]);
 
+  useEffect(() => {
+    if (!api) return;
+    api.sendEvent({
+      invalidation: {
+        providerIds: ["workspace-app"],
+        revision: appCenterState.revision
+      },
+      type: "at.invalidated",
+      workspaceId
+    });
+  }, [api, appCenterState.revision, workspaceId]);
+
   const resolvePendingFileSelect = useCallback(
     (refs: WorkspaceFileReference[]) => {
       const pending = pendingFileSelectRef.current;
@@ -177,6 +190,11 @@ export function WorkspaceAppExternalBridge({
         case "at.query":
           return hostService.queryWorkspaceAppExternalAt({
             query: request.input,
+            workspaceId
+          });
+        case "at.resolve":
+          return hostService.resolveWorkspaceAppExternalAt({
+            mention: request.input,
             workspaceId
           });
         case "files.select":

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAppExternalBridge.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAppExternalBridge.tsx
@@ -23,6 +23,7 @@ import type { TuttiExternalFileOpenInput } from "@tutti-os/workspace-external-co
 import { resolveWorkspaceMentionLinkAction } from "@contexts/workspace/presentation/renderer/actions/workspaceLinkActions";
 import { runDesktopAgentGUILinkAction } from "@renderer/features/workspace-agent/services/desktopAgentGUILinkActions.ts";
 import { IWorkspaceAgentActivityService } from "@renderer/features/workspace-agent/services/workspaceAgentActivityService.interface.ts";
+import { IAgentsService } from "@renderer/features/workspace-agent/services/agentsService.interface.ts";
 import { useService } from "@tutti-os/infra/di";
 import { requestGroupChatLaunch } from "../services/groupChatLaunchCoordinator.ts";
 import { requestWorkspaceAgentGuiLaunch } from "@renderer/features/workspace-agent/services/workspaceAgentGuiLaunchCoordinator.ts";
@@ -88,6 +89,7 @@ export function WorkspaceAppExternalBridge({
   const workspaceAgentActivityService = useService(
     IWorkspaceAgentActivityService
   );
+  const agentsService = useService(IAgentsService);
   const { t } = useTranslation();
   const [pendingFileSelect, setPendingFileSelect] =
     useState<PendingFileSelect | null>(null);
@@ -154,6 +156,42 @@ export function WorkspaceAppExternalBridge({
       workspaceId
     });
   }, [api, appCenterState.revision, workspaceId]);
+
+  useEffect(() => {
+    if (!api) return;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const unsubscribe = workspaceAgentActivityService.subscribe(
+      workspaceId,
+      () => {
+        clearTimeout(timer);
+        timer = setTimeout(() => {
+          timer = undefined;
+          api.sendEvent({
+            invalidation: {
+              providerIds: ["agent-session", "agent-generated-file"]
+            },
+            type: "at.invalidated",
+            workspaceId
+          });
+        }, 100);
+      }
+    );
+    return () => {
+      clearTimeout(timer);
+      unsubscribe();
+    };
+  }, [api, workspaceAgentActivityService, workspaceId]);
+
+  useEffect(() => {
+    if (!api) return;
+    return agentsService.subscribe(() => {
+      api.sendEvent({
+        invalidation: { providerIds: ["agent-target"] },
+        type: "at.invalidated",
+        workspaceId
+      });
+    });
+  }, [agentsService, api, workspaceId]);
 
   const resolvePendingFileSelect = useCallback(
     (refs: WorkspaceFileReference[]) => {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -39,6 +39,11 @@ import {
   normalizeDesktopAgentGUIProvider
 } from "@renderer/features/workspace-agent/desktopAgentGUINodeState";
 import { useService } from "@tutti-os/infra/di";
+import { RichTextMentionServiceProvider } from "@tutti-os/ui-rich-text/editor";
+import {
+  createDesktopRichTextMentionService,
+  IDesktopRichTextAtService
+} from "@renderer/features/rich-text-at";
 import { useTranslation } from "@renderer/i18n";
 import { cn } from "@renderer/lib/format";
 import {
@@ -217,7 +222,24 @@ function ReadyWorkspaceWorkbenchWithSession({
 }: ReadyWorkspaceWorkbenchProps & {
   hostSession: WorkspaceWorkbenchHostSessionBinding;
 }) {
-  const { service: appCenterService } = useWorkspaceAppCenterService();
+  const { service: appCenterService, state: appCenterState } =
+    useWorkspaceAppCenterService();
+  const richTextAtService = useService(IDesktopRichTextAtService);
+  const mentionService = useMemo(
+    () =>
+      createDesktopRichTextMentionService({
+        richTextAtService,
+        workspaceId: state.workspace.id
+      }),
+    [richTextAtService, state.workspace.id]
+  );
+  useEffect(() => () => mentionService.dispose(), [mentionService]);
+  useEffect(() => {
+    mentionService.invalidate({
+      providerId: "workspace-app",
+      workspaceId: state.workspace.id
+    });
+  }, [appCenterState.revision, mentionService, state.workspace.id]);
   const agentProviderStatusService = useService(IAgentProviderStatusService);
   const runtime = useWorkspaceWorkbenchShellRuntime({
     enableWindowCloseGuard,
@@ -721,108 +743,112 @@ function ReadyWorkspaceWorkbenchWithSession({
   ]);
 
   return (
-    <main
-      className={cn(
-        "relative h-screen min-h-0 overflow-hidden bg-background",
-        launchpadOpen && "workspace-workbench-shell--launchpad-open"
-      )}
-    >
-      <WorkspaceAppCenterIntegration workspaceId={state.workspace.id} />
-      <WorkbenchHost
-        captureNodePreviewImage={hostInput.captureNodePreviewImage}
-        className="h-full"
-        contributions={contributions}
-        debugDiagnostics={hostInput.debugDiagnostics}
-        dockPreviewCache={hostInput.dockPreviewCache}
-        dockPlacement={runtime.dockPlacement}
-        dockEntries={dockEntries}
-        dockStateSource={hostInput.dockStateSource}
-        externalStateSource={hostInput.externalStateSource}
-        i18n={runtime.appI18n}
-        layoutConstraints={layoutConstraints}
-        missionControl={{
-          mode: runtime.missionControl.mode,
-          nodeIds: runtime.missionControl.nodeIds ?? undefined,
-          onRequestClose: runtime.missionControl.close,
-          onRequestMode: (mode) => runtime.missionControl.open(mode, "button")
-        }}
-        minimizeAnimation={runtime.minimizeAnimation}
-        nodes={hostInput.nodes}
-        onDockEntryAction={onDockEntryAction}
-        onDockEntryClick={onDockEntryClick}
-        onHandleReady={onWorkbenchHostHandleReady}
-        onLaunchRequest={hostInput.onLaunchRequest}
-        onMissionControlAdapterReady={runtime.onMissionControlAdapterReady}
-        onMissionControlRequestOpen={(mode, request) => {
-          runtime.missionControl.open(
-            mode,
-            request
-              ? {
-                  nodeIds: request.nodeIds,
-                  trigger:
-                    request.trigger === "dock-context-menu"
-                      ? "button"
-                      : undefined
-                }
-              : "button"
-          );
-        }}
-        onNodeCloseRequest={hostInput.onNodeCloseRequest}
-        renderTopChrome={(chromeContext) => (
-          <WorkspaceChrome
-            headerSlot={headerSlot}
-            launchNode={chromeContext.launchNode}
-            missionControl={runtime.missionControl}
-            onSelectWallpaper={runtime.selectWallpaper}
-            onSelectWallpaperDisplayMode={runtime.selectWallpaperDisplayMode}
-            platform={state.platform}
-            selectedWallpaperDisplayMode={runtime.selectedWallpaperDisplayMode}
-            selectedWallpaperID={runtime.selectedWallpaperID}
-            wallpaperAppearance={runtime.wallpaper.appearance}
-            workbenchController={chromeContext.controller}
-            workspace={state.workspace}
-          />
+    <RichTextMentionServiceProvider service={mentionService}>
+      <main
+        className={cn(
+          "relative h-screen min-h-0 overflow-hidden bg-background",
+          launchpadOpen && "workspace-workbench-shell--launchpad-open"
         )}
-        snapshotRepository={hostInput.snapshotRepository}
-        shortcutsEnabled={runtime.shortcutsEnabled}
-        wallpaper={runtime.wallpaper}
-        windowManagement={windowManagement}
-        workspaceId={hostInput.workspaceId}
-      />
-      <WorkspaceAppExternalBridge
-        api={workspaceAppExternalApi}
-        openFile={openWorkspaceAppExternalFile}
-        workspaceId={state.workspace.id}
-      />
-      <DesktopAgentProviderManageDialog
-        agentProviderStatusService={agentProviderStatusService}
-        focusedProvider={agentProviderManageFocusedProvider}
-        open={agentProviderManageDialogOpen}
-        workbenchHost={workbenchHost}
-        workspaceId={state.workspace.id}
-        onOpenChange={setAgentProviderManageDialogOpen}
-      />
-      <WorkspaceLaunchpadOverlay
-        dockIconStyle={runtime.dockIconStyle}
-        dockPlacement={runtime.dockPlacement}
-        host={workbenchHost}
-        open={launchpadOpen}
-        openTrigger={launchpadOpenTrigger}
-        themeAppearance={runtime.themeAppearance}
-        workspaceId={state.workspace.id}
-        onClose={closeLaunchpad}
-      />
-      <WorkspaceCloseGuardDialog
-        request={runtime.closeDialog.request}
-        onCancel={runtime.closeDialog.onCancel}
-        onConfirm={runtime.closeDialog.onConfirm}
-      />
-      <AgentEnvPanel
-        agentProviderStatusService={agentProviderStatusService}
-        workspaceId={state.workspace.id}
-        workbenchHost={workbenchHost ?? undefined}
-      />
-    </main>
+      >
+        <WorkspaceAppCenterIntegration workspaceId={state.workspace.id} />
+        <WorkbenchHost
+          captureNodePreviewImage={hostInput.captureNodePreviewImage}
+          className="h-full"
+          contributions={contributions}
+          debugDiagnostics={hostInput.debugDiagnostics}
+          dockPreviewCache={hostInput.dockPreviewCache}
+          dockPlacement={runtime.dockPlacement}
+          dockEntries={dockEntries}
+          dockStateSource={hostInput.dockStateSource}
+          externalStateSource={hostInput.externalStateSource}
+          i18n={runtime.appI18n}
+          layoutConstraints={layoutConstraints}
+          missionControl={{
+            mode: runtime.missionControl.mode,
+            nodeIds: runtime.missionControl.nodeIds ?? undefined,
+            onRequestClose: runtime.missionControl.close,
+            onRequestMode: (mode) => runtime.missionControl.open(mode, "button")
+          }}
+          minimizeAnimation={runtime.minimizeAnimation}
+          nodes={hostInput.nodes}
+          onDockEntryAction={onDockEntryAction}
+          onDockEntryClick={onDockEntryClick}
+          onHandleReady={onWorkbenchHostHandleReady}
+          onLaunchRequest={hostInput.onLaunchRequest}
+          onMissionControlAdapterReady={runtime.onMissionControlAdapterReady}
+          onMissionControlRequestOpen={(mode, request) => {
+            runtime.missionControl.open(
+              mode,
+              request
+                ? {
+                    nodeIds: request.nodeIds,
+                    trigger:
+                      request.trigger === "dock-context-menu"
+                        ? "button"
+                        : undefined
+                  }
+                : "button"
+            );
+          }}
+          onNodeCloseRequest={hostInput.onNodeCloseRequest}
+          renderTopChrome={(chromeContext) => (
+            <WorkspaceChrome
+              headerSlot={headerSlot}
+              launchNode={chromeContext.launchNode}
+              missionControl={runtime.missionControl}
+              onSelectWallpaper={runtime.selectWallpaper}
+              onSelectWallpaperDisplayMode={runtime.selectWallpaperDisplayMode}
+              platform={state.platform}
+              selectedWallpaperDisplayMode={
+                runtime.selectedWallpaperDisplayMode
+              }
+              selectedWallpaperID={runtime.selectedWallpaperID}
+              wallpaperAppearance={runtime.wallpaper.appearance}
+              workbenchController={chromeContext.controller}
+              workspace={state.workspace}
+            />
+          )}
+          snapshotRepository={hostInput.snapshotRepository}
+          shortcutsEnabled={runtime.shortcutsEnabled}
+          wallpaper={runtime.wallpaper}
+          windowManagement={windowManagement}
+          workspaceId={hostInput.workspaceId}
+        />
+        <WorkspaceAppExternalBridge
+          api={workspaceAppExternalApi}
+          openFile={openWorkspaceAppExternalFile}
+          workspaceId={state.workspace.id}
+        />
+        <DesktopAgentProviderManageDialog
+          agentProviderStatusService={agentProviderStatusService}
+          focusedProvider={agentProviderManageFocusedProvider}
+          open={agentProviderManageDialogOpen}
+          workbenchHost={workbenchHost}
+          workspaceId={state.workspace.id}
+          onOpenChange={setAgentProviderManageDialogOpen}
+        />
+        <WorkspaceLaunchpadOverlay
+          dockIconStyle={runtime.dockIconStyle}
+          dockPlacement={runtime.dockPlacement}
+          host={workbenchHost}
+          open={launchpadOpen}
+          openTrigger={launchpadOpenTrigger}
+          themeAppearance={runtime.themeAppearance}
+          workspaceId={state.workspace.id}
+          onClose={closeLaunchpad}
+        />
+        <WorkspaceCloseGuardDialog
+          request={runtime.closeDialog.request}
+          onCancel={runtime.closeDialog.onCancel}
+          onConfirm={runtime.closeDialog.onConfirm}
+        />
+        <AgentEnvPanel
+          agentProviderStatusService={agentProviderStatusService}
+          workspaceId={state.workspace.id}
+          workbenchHost={workbenchHost ?? undefined}
+        />
+      </main>
+    </RichTextMentionServiceProvider>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -30,6 +30,8 @@ import { useWorkspaceCatalogService } from "@renderer/features/workspace-catalog
 import { AgentEnvPanel } from "@renderer/features/workspace-agent/ui/AgentEnvPanel.tsx";
 import { DesktopAgentProviderManageDialog } from "@renderer/features/workspace-agent/ui/DesktopAgentProviderManageDialog.tsx";
 import { IAgentProviderStatusService } from "@renderer/features/workspace-agent/services/agentProviderStatusService.interface.ts";
+import { IAgentsService } from "@renderer/features/workspace-agent/services/agentsService.interface.ts";
+import { IWorkspaceAgentActivityService } from "@renderer/features/workspace-agent/services/workspaceAgentActivityService.interface.ts";
 import {
   registerWorkspaceAgentGuiLaunchHandler,
   requestWorkspaceAgentGuiLaunch
@@ -222,24 +224,55 @@ function ReadyWorkspaceWorkbenchWithSession({
 }: ReadyWorkspaceWorkbenchProps & {
   hostSession: WorkspaceWorkbenchHostSessionBinding;
 }) {
-  const { service: appCenterService, state: appCenterState } =
-    useWorkspaceAppCenterService();
+  const { service: appCenterService } = useWorkspaceAppCenterService();
+  const agentsService = useService(IAgentsService);
+  const workspaceAgentActivityService = useService(
+    IWorkspaceAgentActivityService
+  );
   const richTextAtService = useService(IDesktopRichTextAtService);
   const mentionService = useMemo(
     () =>
       createDesktopRichTextMentionService({
+        invalidationSources: [
+          {
+            selector: {
+              providerId: "workspace-app",
+              workspaceId: state.workspace.id
+            },
+            subscribe: (listener) => appCenterService.subscribe(listener)
+          },
+          {
+            selector: {
+              providerId: "agent-target",
+              workspaceId: state.workspace.id
+            },
+            subscribe: (listener) => agentsService.subscribe(listener)
+          },
+          {
+            debounceMs: 100,
+            selector: {
+              providerId: "agent-session",
+              workspaceId: state.workspace.id
+            },
+            subscribe: (listener) =>
+              workspaceAgentActivityService.subscribe(
+                state.workspace.id,
+                listener
+              )
+          }
+        ],
         richTextAtService,
         workspaceId: state.workspace.id
       }),
-    [richTextAtService, state.workspace.id]
+    [
+      agentsService,
+      appCenterService,
+      richTextAtService,
+      state.workspace.id,
+      workspaceAgentActivityService
+    ]
   );
   useEffect(() => () => mentionService.dispose(), [mentionService]);
-  useEffect(() => {
-    mentionService.invalidate({
-      providerId: "workspace-app",
-      workspaceId: state.workspace.id
-    });
-  }, [appCenterState.revision, mentionService, state.workspace.id]);
   const agentProviderStatusService = useService(IAgentProviderStatusService);
   const runtime = useWorkspaceWorkbenchShellRuntime({
     enableWindowCloseGuard,

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -54,6 +54,9 @@ import type {
   TuttiExternalPdfPrintHtmlResult,
   TuttiExternalReferenceOpenInput,
   TuttiExternalRendererRequest,
+  TuttiExternalAtResolveResult,
+  TuttiExternalAtResolveInput,
+  TuttiExternalAtInvalidation,
   TuttiExternalSettingsOpenInput,
   TuttiExternalUserProjectCreateInput,
   TuttiExternalUserProjectPathInput,
@@ -94,6 +97,7 @@ export const desktopIpcChannels = {
   appExternal: {
     activityReportActive: "workspace-app-activity:report-active",
     atQuery: "workspace-app-at:query",
+    atResolve: "workspace-app-at:resolve",
     filesOpen: "workspace-app-files:open",
     filesSelect: "workspace-app-files:select",
     filesUploadCancel: "workspace-app-files:upload-cancel",
@@ -619,6 +623,7 @@ export type DesktopIpcResult<TResult> =
 
 export type DesktopWorkspaceAppExternalRendererResult =
   | TuttiExternalAtQueryResult[]
+  | TuttiExternalAtResolveResult
   | TuttiExternalFileSelectResult
   | WorkspaceUserProject
   | WorkspaceUserProjectDefaultSelection
@@ -636,6 +641,11 @@ export interface DesktopWorkspaceAppExternalRendererResponse {
 }
 
 export type DesktopWorkspaceAppExternalRendererEvent =
+  | {
+      invalidation: TuttiExternalAtInvalidation;
+      type: "at.invalidated";
+      workspaceId: string;
+    }
   | {
       snapshot: WorkspaceUserProjectServiceSnapshot;
       type: "userProjects.changed";
@@ -830,6 +840,7 @@ export interface DesktopInvokePayloadByChannel {
   [desktopIpcChannels.appContext.get]: undefined;
   [desktopIpcChannels.appExternal.activityReportActive]: undefined;
   [desktopIpcChannels.appExternal.atQuery]: TuttiExternalAtQueryInput;
+  [desktopIpcChannels.appExternal.atResolve]: TuttiExternalAtResolveInput;
   [desktopIpcChannels.appExternal.filesOpen]: TuttiExternalFileOpenInput;
   [desktopIpcChannels.appExternal.filesSelect]: TuttiExternalFileSelectInput;
   [desktopIpcChannels.appExternal
@@ -985,6 +996,8 @@ export interface DesktopInvokeResultByChannel {
   [desktopIpcChannels.appContext.get]: DesktopWorkspaceAppContext;
   [desktopIpcChannels.appExternal.activityReportActive]: void;
   [desktopIpcChannels.appExternal.atQuery]: TuttiExternalAtQueryResult[];
+  [desktopIpcChannels.appExternal
+    .atResolve]: TuttiExternalAtResolveResult | null;
   [desktopIpcChannels.appExternal.filesOpen]: void;
   [desktopIpcChannels.appExternal.filesSelect]: TuttiExternalFileSelectResult;
   [desktopIpcChannels.appExternal.filesUploadCancel]: void;

--- a/docs/architecture/agent-reference-mention-resolution.md
+++ b/docs/architecture/agent-reference-mention-resolution.md
@@ -43,6 +43,13 @@ The Markdown label and optional `count` query value are presentation metadata.
 They are not resolution authority. New mentions do not embed file paths,
 credentials, app commands, or serialized `files` arrays.
 
+UI presentation hydration is also separate from artifact resolution. A
+workspace-scoped `RichTextMentionService` may resolve the current label and app
+icon into an in-memory snapshot for composer, conversation, and AgentGUI
+surfaces. That snapshot is never written back to the mention URI or Markdown;
+if it is unavailable, the stored label and `MentionPill` semantic glyph are the
+required fallback.
+
 `workspace-reference` is a passive artifact reference. It is distinct from:
 
 - `workspace-app`, which routes an agent to an app command surface;

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIMentionServiceBoundary.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIMentionServiceBoundary.tsx
@@ -1,0 +1,38 @@
+import { useMemo, type ReactNode } from "react";
+import {
+  RichTextMentionServiceProvider,
+  useRichTextMentionService
+} from "@tutti-os/ui-rich-text/editor";
+import {
+  createRichTextMentionService,
+  type RichTextMentionService
+} from "@tutti-os/ui-rich-text/service";
+import type { RichTextTriggerProvider } from "@tutti-os/ui-rich-text/types";
+
+export function AgentGUIMentionServiceBoundary({
+  children,
+  legacyProviders,
+  service
+}: {
+  children: ReactNode;
+  legacyProviders?: readonly RichTextTriggerProvider[];
+  service?: RichTextMentionService;
+}): ReactNode {
+  const inheritedService = useRichTextMentionService();
+  const legacyService = useMemo(
+    () =>
+      service || inheritedService || !legacyProviders?.length
+        ? null
+        : createRichTextMentionService({ providers: legacyProviders }),
+    [inheritedService, legacyProviders, service]
+  );
+  const effectiveService = service ?? inheritedService ?? legacyService;
+
+  return effectiveService && effectiveService !== inheritedService ? (
+    <RichTextMentionServiceProvider service={effectiveService}>
+      {children}
+    </RichTextMentionServiceProvider>
+  ) : (
+    children
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIMentionServiceBoundary.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIMentionServiceBoundary.tsx
@@ -1,12 +1,10 @@
-import { useMemo, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import {
   RichTextMentionServiceProvider,
+  useEffectiveRichTextMentionService,
   useRichTextMentionService
 } from "@tutti-os/ui-rich-text/editor";
-import {
-  createRichTextMentionService,
-  type RichTextMentionService
-} from "@tutti-os/ui-rich-text/service";
+import type { RichTextMentionService } from "@tutti-os/ui-rich-text/service";
 import type { RichTextTriggerProvider } from "@tutti-os/ui-rich-text/types";
 
 export function AgentGUIMentionServiceBoundary({
@@ -19,16 +17,16 @@ export function AgentGUIMentionServiceBoundary({
   service?: RichTextMentionService;
 }): ReactNode {
   const inheritedService = useRichTextMentionService();
-  const legacyService = useMemo(
-    () =>
-      service || inheritedService || !legacyProviders?.length
-        ? null
-        : createRichTextMentionService({ providers: legacyProviders }),
-    [inheritedService, legacyProviders, service]
-  );
-  const effectiveService = service ?? inheritedService ?? legacyService;
+  const effectiveService = useEffectiveRichTextMentionService({
+    mentionService: service,
+    triggerProviders: legacyProviders
+  });
 
-  return effectiveService && effectiveService !== inheritedService ? (
+  if (!service && !inheritedService && !legacyProviders?.length) {
+    return children;
+  }
+
+  return effectiveService !== inheritedService ? (
     <RichTextMentionServiceProvider service={effectiveService}>
       {children}
     </RichTextMentionServiceProvider>

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -1,4 +1,6 @@
-import { memo, useCallback, useEffect, useMemo } from "react";
+import { memo, useCallback, useEffect, useMemo, type ReactNode } from "react";
+import { RichTextMentionServiceProvider } from "@tutti-os/ui-rich-text/editor";
+import type { RichTextMentionService } from "@tutti-os/ui-rich-text/service";
 import { createWorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-project/i18n";
 import { createWorkspaceFileManagerI18nRuntime } from "@tutti-os/workspace-file-manager";
 import { useReferenceProvenanceFilterCatalog } from "@tutti-os/workspace-file-reference/react";
@@ -121,6 +123,7 @@ export const AgentGUINode = memo(function AgentGUINode({
     defaultAgentTargetId = null,
     providerAuthAccountLabels,
     contextMentionProviders,
+    mentionService,
     workspaceAppIcons,
     disabledHomeSuggestions,
     referenceProvenanceFilterCatalog: injectedReferenceProvenanceFilterCatalog,
@@ -539,154 +542,176 @@ export const AgentGUINode = memo(function AgentGUINode({
   ]);
 
   return (
-    <WorkspaceNodeWindow
-      nodeId={nodeId}
-      kind="agentGui"
-      title={windowTitle}
-      titleIcon={null}
-      position={position}
-      width={width}
-      height={height}
-      desktopSize={desktopSize}
-      minSize={minSize}
-      appearance={embedded ? "embedded" : "window"}
-      className="size-full bg-transparent"
-      bodyClassName={`${styles.shell} nodrag size-full min-h-0 min-w-0 !bg-transparent p-0`}
-      hideHeader={embedded}
-      titleAccessory={
-        <span className="inline-flex flex-none items-center gap-1">
-          <AgentProbeInfoPopover
-            lines={agentProbeLines}
-            testId="agent-gui-window-agent-info"
-            className={styles.windowAgentInfo}
-            onOpen={handleAgentProbeInfoOpen}
-          />
-          <CanvasNodeGhostIconButton
-            aria-label={
-              isConversationRailCollapsed
-                ? t("agentHost.agentGui.expandConversationRail")
-                : t("agentHost.agentGui.collapseConversationRail")
-            }
-            title={
-              isConversationRailCollapsed
-                ? t("agentHost.agentGui.expandConversationRail")
-                : t("agentHost.agentGui.collapseConversationRail")
-            }
-            data-testid="agent-gui-toggle-conversation-rail"
-            data-agent-gui-conversation-rail-collapsed={
-              isConversationRailCollapsed ? "true" : "false"
-            }
-            data-agent-gui-conversation-rail-auto-collapsed={
-              isConversationRailAutoCollapsed ? "true" : "false"
-            }
-            onClick={(event) => {
-              event.stopPropagation();
-              handleConversationRailToggle();
-            }}
-          >
-            <CanvasNodePanelLinedIcon
-              width={18}
-              height={18}
-              aria-hidden="true"
+    <AgentGUIMentionServiceBoundary service={mentionService}>
+      <WorkspaceNodeWindow
+        nodeId={nodeId}
+        kind="agentGui"
+        title={windowTitle}
+        titleIcon={null}
+        position={position}
+        width={width}
+        height={height}
+        desktopSize={desktopSize}
+        minSize={minSize}
+        appearance={embedded ? "embedded" : "window"}
+        className="size-full bg-transparent"
+        bodyClassName={`${styles.shell} nodrag size-full min-h-0 min-w-0 !bg-transparent p-0`}
+        hideHeader={embedded}
+        titleAccessory={
+          <span className="inline-flex flex-none items-center gap-1">
+            <AgentProbeInfoPopover
+              lines={agentProbeLines}
+              testId="agent-gui-window-agent-info"
+              className={styles.windowAgentInfo}
+              onOpen={handleAgentProbeInfoOpen}
             />
-          </CanvasNodeGhostIconButton>
-        </span>
-      }
-      onClose={onClose}
-      onResize={onResize}
-      isMaximized={isMaximized}
-      isMuted={isMuted}
-      hideMaximizeButton
-      onMinimize={onMinimize}
-      onToggleMaximize={onToggleMaximize}
-    >
-      {(renderFrame) => {
-        const renderedWidth = renderFrame.size.width;
-        const isRenderedConversationRailCollapsed =
-          isConversationRailCollapsed ||
-          shouldAutoCollapseAgentGUIConversationRail(
-            renderedWidth,
-            railAutoCollapseWidthPx
-          );
+            <CanvasNodeGhostIconButton
+              aria-label={
+                isConversationRailCollapsed
+                  ? t("agentHost.agentGui.expandConversationRail")
+                  : t("agentHost.agentGui.collapseConversationRail")
+              }
+              title={
+                isConversationRailCollapsed
+                  ? t("agentHost.agentGui.expandConversationRail")
+                  : t("agentHost.agentGui.collapseConversationRail")
+              }
+              data-testid="agent-gui-toggle-conversation-rail"
+              data-agent-gui-conversation-rail-collapsed={
+                isConversationRailCollapsed ? "true" : "false"
+              }
+              data-agent-gui-conversation-rail-auto-collapsed={
+                isConversationRailAutoCollapsed ? "true" : "false"
+              }
+              onClick={(event) => {
+                event.stopPropagation();
+                handleConversationRailToggle();
+              }}
+            >
+              <CanvasNodePanelLinedIcon
+                width={18}
+                height={18}
+                aria-hidden="true"
+              />
+            </CanvasNodeGhostIconButton>
+          </span>
+        }
+        onClose={onClose}
+        onResize={onResize}
+        isMaximized={isMaximized}
+        isMuted={isMuted}
+        hideMaximizeButton
+        onMinimize={onMinimize}
+        onToggleMaximize={onToggleMaximize}
+      >
+        {(renderFrame) => {
+          const renderedWidth = renderFrame.size.width;
+          const isRenderedConversationRailCollapsed =
+            isConversationRailCollapsed ||
+            shouldAutoCollapseAgentGUIConversationRail(
+              renderedWidth,
+              railAutoCollapseWidthPx
+            );
 
-        return (
-          <AgentGUINodeView
-            viewModel={viewModel}
-            renderSidebarFooter={renderSidebarFooter}
-            renderProviderRailEmpty={renderProviderRailEmpty}
-            renderProviderUnavailableState={renderProviderUnavailableState}
-            providerRailAllPresentation={providerRailAllPresentation}
-            actions={viewActions}
-            isActive={isActive}
-            isVisible={isVisible}
-            onEngagementEvent={onEngagementEvent}
-            composerFocusRequestSequence={composerFocusRequestSequence}
-            newConversationRequestSequence={newConversationRequestSequence}
-            slashStatusLimits={slashStatusLimits}
-            slashStatusLimitsLoading={
-              workspaceAgentProbes?.isLoadingUsage ?? false
-            }
-            slashStatusLimitsUnavailable={slashStatusLimitsUnavailable}
-            railConfigProvider={railStatusProvider}
-            railSlashStatusLimits={railSlashStatusLimits}
-            slashStatusUsageCapturedAtUnixMs={slashStatusUsageCapturedAtUnixMs}
-            slashStatusUsageDidFail={slashStatusUsageDidFail}
-            slashStatusUsageAttempted={slashStatusUsageAttempted}
-            providerAuthAccountLabels={providerAuthAccountLabels}
-            onAgentConfigMenuOpen={handleAgentConfigMenuOpen}
-            onAgentUsageRefresh={handleAgentUsageRefresh}
-            onSlashStatusOpen={handleAgentProbeInfoOpen}
-            previewMode={previewMode}
-            onLinkAction={handleLinkAction}
-            onHandoffConversation={onHandoffConversation}
-            capabilityMenuState={capabilityMenuState}
-            onCapabilitySettingsRequest={onCapabilitySettingsRequest}
-            onAgentProviderLogin={
-              onAgentProviderLogin ? handleAgentProviderLogin : undefined
-            }
-            accountMenuState={accountMenuState}
-            conversationRailCollapsed={isRenderedConversationRailCollapsed}
-            conversationRailWidthPx={clampAgentGUIConversationRailWidthPx(
-              state.conversationRailWidthPx,
-              renderedWidth
-            )}
-            conversationRailMinWidthPx={
-              AGENT_GUI_CONVERSATION_RAIL_MIN_WIDTH_PX
-            }
-            conversationRailMaxWidthPx={resolveAgentGUIConversationRailMaxWidthPx(
-              renderedWidth
-            )}
-            detailMinWidthPx={AGENT_GUI_DETAIL_MIN_WIDTH_PX}
-            uiLanguage={locale}
-            onWorkspaceFileReferencesAdded={
-              onWorkspaceFileReferencesAdded
-                ? handleWorkspaceFileReferencesAdded
-                : undefined
-            }
-            resolveDroppedFileReferences={resolveDroppedFileReferences}
-            onConversationRailWidthChanged={handleConversationRailWidthChanged}
-            labels={labels}
-            workspaceUserProjectI18n={workspaceUserProjectI18n}
-            workspaceFileManagerCopy={workspaceFileManagerI18n}
-            workspaceFileReferenceAdapter={workspaceFileReferenceAdapter}
-            onOpenConversationWindow={onOpenConversationWindow}
-            onRequestGitBranches={onRequestGitBranches}
-            selectProjectDirectory={selectProjectDirectory}
-            referenceSourceAggregator={referenceSourceAggregator}
-            resolveWorkspaceReferenceEntryIconUrl={
-              resolveWorkspaceReferenceEntryIconUrl
-            }
-            resolveMentionReferenceTarget={resolveMentionReferenceTarget}
-            resolveWorkspaceReferenceInitialTarget={
-              resolveWorkspaceReferenceInitialTarget
-            }
-            workspaceFileReferenceCopy={workspaceFileReferenceCopy}
-            contextMentionProviders={contextMentionProviders}
-            workspaceAppIcons={workspaceAppIcons}
-            referenceProvenanceFilter={referenceProvenanceFilter}
-          />
-        );
-      }}
-    </WorkspaceNodeWindow>
+          return (
+            <AgentGUINodeView
+              viewModel={viewModel}
+              renderSidebarFooter={renderSidebarFooter}
+              renderProviderRailEmpty={renderProviderRailEmpty}
+              renderProviderUnavailableState={renderProviderUnavailableState}
+              providerRailAllPresentation={providerRailAllPresentation}
+              actions={viewActions}
+              isActive={isActive}
+              isVisible={isVisible}
+              onEngagementEvent={onEngagementEvent}
+              composerFocusRequestSequence={composerFocusRequestSequence}
+              newConversationRequestSequence={newConversationRequestSequence}
+              slashStatusLimits={slashStatusLimits}
+              slashStatusLimitsLoading={
+                workspaceAgentProbes?.isLoadingUsage ?? false
+              }
+              slashStatusLimitsUnavailable={slashStatusLimitsUnavailable}
+              railConfigProvider={railStatusProvider}
+              railSlashStatusLimits={railSlashStatusLimits}
+              slashStatusUsageCapturedAtUnixMs={
+                slashStatusUsageCapturedAtUnixMs
+              }
+              slashStatusUsageDidFail={slashStatusUsageDidFail}
+              slashStatusUsageAttempted={slashStatusUsageAttempted}
+              providerAuthAccountLabels={providerAuthAccountLabels}
+              onAgentConfigMenuOpen={handleAgentConfigMenuOpen}
+              onAgentUsageRefresh={handleAgentUsageRefresh}
+              onSlashStatusOpen={handleAgentProbeInfoOpen}
+              previewMode={previewMode}
+              onLinkAction={handleLinkAction}
+              onHandoffConversation={onHandoffConversation}
+              capabilityMenuState={capabilityMenuState}
+              onCapabilitySettingsRequest={onCapabilitySettingsRequest}
+              onAgentProviderLogin={
+                onAgentProviderLogin ? handleAgentProviderLogin : undefined
+              }
+              accountMenuState={accountMenuState}
+              conversationRailCollapsed={isRenderedConversationRailCollapsed}
+              conversationRailWidthPx={clampAgentGUIConversationRailWidthPx(
+                state.conversationRailWidthPx,
+                renderedWidth
+              )}
+              conversationRailMinWidthPx={
+                AGENT_GUI_CONVERSATION_RAIL_MIN_WIDTH_PX
+              }
+              conversationRailMaxWidthPx={resolveAgentGUIConversationRailMaxWidthPx(
+                renderedWidth
+              )}
+              detailMinWidthPx={AGENT_GUI_DETAIL_MIN_WIDTH_PX}
+              uiLanguage={locale}
+              onWorkspaceFileReferencesAdded={
+                onWorkspaceFileReferencesAdded
+                  ? handleWorkspaceFileReferencesAdded
+                  : undefined
+              }
+              resolveDroppedFileReferences={resolveDroppedFileReferences}
+              onConversationRailWidthChanged={
+                handleConversationRailWidthChanged
+              }
+              labels={labels}
+              workspaceUserProjectI18n={workspaceUserProjectI18n}
+              workspaceFileManagerCopy={workspaceFileManagerI18n}
+              workspaceFileReferenceAdapter={workspaceFileReferenceAdapter}
+              onOpenConversationWindow={onOpenConversationWindow}
+              onRequestGitBranches={onRequestGitBranches}
+              selectProjectDirectory={selectProjectDirectory}
+              referenceSourceAggregator={referenceSourceAggregator}
+              resolveWorkspaceReferenceEntryIconUrl={
+                resolveWorkspaceReferenceEntryIconUrl
+              }
+              resolveMentionReferenceTarget={resolveMentionReferenceTarget}
+              resolveWorkspaceReferenceInitialTarget={
+                resolveWorkspaceReferenceInitialTarget
+              }
+              workspaceFileReferenceCopy={workspaceFileReferenceCopy}
+              contextMentionProviders={contextMentionProviders}
+              workspaceAppIcons={workspaceAppIcons}
+              referenceProvenanceFilter={referenceProvenanceFilter}
+            />
+          );
+        }}
+      </WorkspaceNodeWindow>
+    </AgentGUIMentionServiceBoundary>
   );
 }, areAgentGUINodePropsEqual);
+
+function AgentGUIMentionServiceBoundary({
+  children,
+  service
+}: {
+  children: ReactNode;
+  service?: RichTextMentionService;
+}): ReactNode {
+  return service ? (
+    <RichTextMentionServiceProvider service={service}>
+      {children}
+    </RichTextMentionServiceProvider>
+  ) : (
+    children
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -1,6 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, type ReactNode } from "react";
-import { RichTextMentionServiceProvider } from "@tutti-os/ui-rich-text/editor";
-import type { RichTextMentionService } from "@tutti-os/ui-rich-text/service";
+import { memo, useCallback, useEffect, useMemo } from "react";
 import { createWorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-project/i18n";
 import { createWorkspaceFileManagerI18nRuntime } from "@tutti-os/workspace-file-manager";
 import { useReferenceProvenanceFilterCatalog } from "@tutti-os/workspace-file-reference/react";
@@ -41,6 +39,7 @@ import {
 import { resolveAgentGUIReferenceProvenanceFilterCatalog } from "./model/agentReferenceProvenanceCatalog";
 import type { AgentGUINodeProps } from "./AgentGUINode.types";
 import { areAgentGUINodePropsEqual } from "./AgentGUINode.types";
+import { AgentGUIMentionServiceBoundary } from "./AgentGUIMentionServiceBoundary";
 import {
   useAgentGUIViewLabels,
   useAgentGUIWorkspaceFileReferenceCopy
@@ -542,7 +541,10 @@ export const AgentGUINode = memo(function AgentGUINode({
   ]);
 
   return (
-    <AgentGUIMentionServiceBoundary service={mentionService}>
+    <AgentGUIMentionServiceBoundary
+      legacyProviders={contextMentionProviders}
+      service={mentionService}
+    >
       <WorkspaceNodeWindow
         nodeId={nodeId}
         kind="agentGui"
@@ -699,19 +701,3 @@ export const AgentGUINode = memo(function AgentGUINode({
     </AgentGUIMentionServiceBoundary>
   );
 }, areAgentGUINodePropsEqual);
-
-function AgentGUIMentionServiceBoundary({
-  children,
-  service
-}: {
-  children: ReactNode;
-  service?: RichTextMentionService;
-}): ReactNode {
-  return service ? (
-    <RichTextMentionServiceProvider service={service}>
-      {children}
-    </RichTextMentionServiceProvider>
-  ) : (
-    children
-  );
-}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
@@ -46,6 +46,7 @@ import type {
 } from "./AgentComposer";
 import type { AgentContextMentionProvider } from "./agentContextMentionProvider";
 import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../shared/AgentMessageMarkdown";
+import type { RichTextMentionService } from "@tutti-os/ui-rich-text/service";
 import type { AgentGUIEngagementEventSink } from "./engagement/agentGUIEngagement.types";
 import type { AgentGUIComposerAppendRequest } from "./controller/useAgentGUIComposerAppendRequest";
 
@@ -131,6 +132,7 @@ export interface AgentGUINodeHostCapabilities {
   defaultAgentTargetId?: string | null;
   providerAuthAccountLabels?: Partial<Record<string, string>>;
   contextMentionProviders?: readonly AgentContextMentionProvider[];
+  mentionService?: RichTextMentionService;
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
   disabledHomeSuggestions?: readonly AgentGUIHomeSuggestionId[];
 }
@@ -359,6 +361,7 @@ export function areAgentGUINodePropsEqual(
     pc.defaultAgentTargetId === nc.defaultAgentTargetId &&
     pc.providerAuthAccountLabels === nc.providerAuthAccountLabels &&
     pc.contextMentionProviders === nc.contextMentionProviders &&
+    pc.mentionService === nc.mentionService &&
     pc.workspaceAppIcons === nc.workspaceAppIcons &&
     pc.disabledHomeSuggestions === nc.disabledHomeSuggestions &&
     pa.onLinkAction === na.onLinkAction &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
@@ -274,9 +274,22 @@ describe("AgentQueuedPromptPanel", () => {
       "data-agent-mention-href",
       "mention://workspace-app/ai-media-canvas?workspaceId=workspace-1"
     );
+    const image = mention?.querySelector(
+      '[data-agent-mention-app-icon="true"] img'
+    );
+    expect(image).toHaveAttribute("src", iconUrl);
+    expect(
+      mention?.querySelector('[data-agent-mention-fallback-icon="true"]')
+    ).not.toBeInTheDocument();
+
+    fireEvent.error(image!);
+
     expect(
       mention?.querySelector('[data-agent-mention-app-icon="true"] img')
-    ).toHaveAttribute("src", iconUrl);
+    ).not.toBeInTheDocument();
+    expect(
+      mention?.querySelector('[data-agent-mention-fallback-icon="true"]')
+    ).toBeInTheDocument();
     expect(mention).toHaveTextContent("AI Media Canvas");
     expect(screen.queryByText(/mention:\/\/workspace-app/)).toBeNull();
   });

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
@@ -280,7 +280,7 @@ describe("AgentQueuedPromptPanel", () => {
     expect(image).toHaveAttribute("src", iconUrl);
     expect(
       mention?.querySelector('[data-agent-mention-fallback-icon="true"]')
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
 
     fireEvent.error(image!);
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
@@ -8,10 +8,7 @@ import {
   type ReactNode
 } from "react";
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
-import {
-  MentionPill,
-  TruncatingPillLabel
-} from "@tutti-os/ui-system/components";
+import { MentionPill } from "@tutti-os/ui-system/components";
 import { CloseIcon } from "@tutti-os/ui-system/icons";
 import { useTranslation } from "../../../i18n/index";
 import {
@@ -394,7 +391,6 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
   const withTooltipProvider = useContext(AgentMentionTooltipProviderContext);
   const mention = mentionViewModel(node.attrs ?? {}, t);
   const [isEditable, setIsEditable] = useState(editor.isEditable);
-  const [failedIconUrl, setFailedIconUrl] = useState<string>();
   const extensionOptions = extension.options as {
     removeActionAriaLabel?: string;
   };
@@ -451,61 +447,26 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
         data-agent-mention-icon-url={mention.iconUrl}
         data-agent-mention-kind={mention.kind}
       >
-        <span
-          className="group relative top-0 inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] cursor-pointer items-center gap-1 overflow-hidden rounded-[4px] border border-transparent bg-transparent px-1 py-0 align-middle text-[13px] font-medium leading-6 text-[var(--agent-gui-mention-app-color,var(--tutti-purple))] no-underline transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,currentColor_12%,transparent)]"
+        <MentionPill
+          aria-label={mention.ariaLabel}
+          className="top-0 h-6 max-w-[min(100%,var(--agent-mention-max-width,16rem))] py-0 align-middle leading-6"
+          data-agent-mention-app-icon="true"
           data-agent-mention-kind={mention.kind}
-          data-slot="mention-pill"
-        >
-          <span
-            aria-hidden={isEditable ? undefined : true}
-            className="relative grid size-4 shrink-0 place-items-center overflow-hidden rounded-[4px] bg-block"
-            data-agent-mention-app-icon="true"
-            data-workspace-app-icon="true"
-          >
-            {mention.iconUrl && failedIconUrl !== mention.iconUrl ? (
-              <img
-                src={mention.iconUrl}
-                alt=""
-                className={`col-start-1 row-start-1 size-full object-cover transition-opacity ${
-                  isEditable
-                    ? "group-hover:opacity-0 group-focus-within:opacity-0"
-                    : ""
-                }`}
-                decoding="async"
-                loading="lazy"
-                draggable={false}
-                onError={() => {
-                  setFailedIconUrl(mention.iconUrl);
-                }}
-              />
-            ) : (
-              <span
-                className={`tsh-agent-object-token__kind-icon col-start-1 row-start-1 size-4 transition-opacity ${
-                  isEditable
-                    ? "group-hover:opacity-0 group-focus-within:opacity-0"
-                    : ""
-                }`}
-                data-agent-mention-fallback-icon="true"
-              />
-            )}
-            {isEditable ? (
-              <button
-                aria-label={removeActionAriaLabel}
-                className="absolute left-1/2 top-1/2 inline-flex size-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center text-[var(--text-secondary)] opacity-0 transition-opacity hover:text-[var(--text-primary)] focus-visible:opacity-100 group-hover:opacity-100"
-                type="button"
-                onMouseDown={handleRemove}
-              >
-                <CloseIcon className="size-3.5" />
-              </button>
-            ) : null}
-          </span>
-          <TruncatingPillLabel
-            tooltip={mention.label}
-            withTooltipProvider={withTooltipProvider}
-          >
-            {mention.label}
-          </TruncatingPillLabel>
-        </span>
+          data-workspace-app-icon="true"
+          iconUrl={mention.iconUrl}
+          kind={mention.kind === "agent-target" ? "session" : "app"}
+          label={mention.label}
+          removable={isEditable}
+          removeButtonProps={
+            isEditable
+              ? {
+                  "aria-label": removeActionAriaLabel,
+                  onMouseDown: handleRemove
+                }
+              : undefined
+          }
+          withTooltipProvider={withTooltipProvider}
+        />
       </NodeViewWrapper>
     );
   }

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
@@ -394,6 +394,7 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
   const withTooltipProvider = useContext(AgentMentionTooltipProviderContext);
   const mention = mentionViewModel(node.attrs ?? {}, t);
   const [isEditable, setIsEditable] = useState(editor.isEditable);
+  const [failedIconUrl, setFailedIconUrl] = useState<string>();
   const extensionOptions = extension.options as {
     removeActionAriaLabel?: string;
   };
@@ -461,11 +462,11 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
             data-agent-mention-app-icon="true"
             data-workspace-app-icon="true"
           >
-            {mention.iconUrl ? (
+            {mention.iconUrl && failedIconUrl !== mention.iconUrl ? (
               <img
                 src={mention.iconUrl}
                 alt=""
-                className={`size-full object-cover transition-opacity ${
+                className={`col-start-1 row-start-1 size-full object-cover transition-opacity ${
                   isEditable
                     ? "group-hover:opacity-0 group-focus-within:opacity-0"
                     : ""
@@ -473,14 +474,18 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
                 decoding="async"
                 loading="lazy"
                 draggable={false}
+                onError={() => {
+                  setFailedIconUrl(mention.iconUrl);
+                }}
               />
             ) : (
               <span
-                className={`tsh-agent-object-token__kind-icon size-4 transition-opacity ${
+                className={`tsh-agent-object-token__kind-icon col-start-1 row-start-1 size-4 transition-opacity ${
                   isEditable
                     ? "group-hover:opacity-0 group-focus-within:opacity-0"
                     : ""
                 }`}
+                data-agent-mention-fallback-icon="true"
               />
             )}
             {isEditable ? (

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
@@ -450,10 +450,16 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
         <MentionPill
           aria-label={mention.ariaLabel}
           className="top-0 h-6 max-w-[min(100%,var(--agent-mention-max-width,16rem))] py-0 align-middle leading-6"
-          data-agent-mention-app-icon="true"
           data-agent-mention-kind={mention.kind}
-          data-workspace-app-icon="true"
           iconUrl={mention.iconUrl}
+          iconContainerProps={{
+            "data-agent-mention-app-icon":
+              mention.kind === "agent-target" ? undefined : "true",
+            "data-agent-mention-session-icon":
+              mention.kind === "agent-target" ? "true" : undefined,
+            "data-workspace-app-icon":
+              mention.kind === "agent-target" ? undefined : "true"
+          }}
           kind={mention.kind === "agent-target" ? "session" : "app"}
           label={mention.label}
           removable={isEditable}

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -1311,9 +1311,22 @@ describe("AgentMessageMarkdown", () => {
     expect(
       mention?.querySelector('[data-agent-mention-app-icon="true"]')
     ).toHaveClass("h-4", "w-4");
+    const image = mention?.querySelector(
+      '[data-agent-mention-app-icon="true"] img'
+    );
+    expect(image).toHaveAttribute("src", iconUrl);
+    expect(
+      mention?.querySelector('[data-agent-mention-fallback-icon="true"]')
+    ).not.toBeInTheDocument();
+
+    fireEvent.error(image!);
+
     expect(
       mention?.querySelector('[data-agent-mention-app-icon="true"] img')
-    ).toHaveAttribute("src", iconUrl);
+    ).not.toBeInTheDocument();
+    expect(
+      mention?.querySelector('[data-agent-mention-fallback-icon="true"]')
+    ).toBeInTheDocument();
     expect(mention).toHaveTextContent("Weather");
   });
 

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -1336,7 +1336,7 @@ describe("AgentMessageMarkdown", () => {
     expect(image).toHaveAttribute("src", iconUrl);
     expect(
       mention?.querySelector('[data-agent-mention-fallback-icon="true"]')
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
 
     fireEvent.error(image!);
 

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -16,6 +16,25 @@ import {
   MANAGED_AGENT_ICON_ROUNDED_URLS,
   managedAgentRoundedIconUrl
 } from "./managedAgentIcons";
+import { RichTextMentionReadonly } from "@tutti-os/ui-rich-text/editor";
+
+describe("RichTextMentionReadonly compatibility", () => {
+  it("keeps the persisted @ prefix while using MentionPill", () => {
+    render(
+      <RichTextMentionReadonly
+        mention={{
+          trigger: "@",
+          providerId: "workspace-app",
+          entityId: "canvas",
+          label: "Canvas"
+        }}
+      />
+    );
+
+    expect(screen.getByText("@Canvas")).toBeInTheDocument();
+    expect(document.querySelector('[data-slot="mention-pill"]')).not.toBeNull();
+  });
+});
 
 describe("AgentMessageMarkdown", () => {
   afterEach(() => {

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -8,7 +8,6 @@ import {
   useMemo,
   useState
 } from "react";
-import { FileText } from "lucide-react";
 import { useTranslation } from "../i18n/index";
 import { cn } from "../app/renderer/lib/utils";
 import ReactMarkdown from "react-markdown";
@@ -21,13 +20,8 @@ import {
   resolveWorkspaceFileExtension,
   workspaceFileName as basenameWorkspacePath
 } from "@tutti-os/workspace-file-manager/services";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-  useTextOverflow
-} from "@tutti-os/ui-system/components";
+import { MentionPill } from "@tutti-os/ui-system/components";
+import { useResolvedRichTextMention } from "@tutti-os/ui-rich-text/editor";
 import {
   resolveWorkspaceLinkAction,
   type WorkspaceLinkAction,
@@ -616,14 +610,31 @@ function MentionLink({
   previewMode: boolean;
 }): JSX.Element {
   "use memo";
-  // 标签截断时,hover 用设计系统 Tooltip 展示完整文本。trigger = 整个 chip(<a>),
-  // 截断发生在内部 __main span,故在那上面测溢出。
-  const tooltipText = mention.label;
-  const [failedIconUrl, setFailedIconUrl] = useState<string>();
-  const { ref: mainRef, overflowing } =
-    useTextOverflow<HTMLSpanElement>(tooltipText);
+  const snapshot = useResolvedRichTextMention({
+    providerId: mention.providerId,
+    entityId: mention.entityId,
+    label: mention.label,
+    scope: mention.scope
+  });
+  const resolved = snapshot.state === "ready" ? snapshot.resolved : undefined;
+  const label = resolved?.label?.trim() || mention.label;
+  const presentation = resolved?.presentation;
+  const iconUrl =
+    presentation?.iconUrl?.trim() ||
+    presentation?.thumbnailUrl?.trim() ||
+    presentation?.agentIconUrl?.trim() ||
+    mention.iconUrl;
+  const pillKind =
+    mention.kind === "workspace-issue" || mention.referenceSource === "task"
+      ? "issue"
+      : mention.kind === "session" || mention.kind === "agent-target"
+        ? "session"
+        : mention.kind === "pasted-text"
+          ? "file"
+          : "app";
+  const usesSessionIcon = mention.kind === "session";
 
-  const link = (
+  return (
     <a
       {...props}
       className={cn(
@@ -632,11 +643,11 @@ function MentionLink({
       )}
       data-agent-file-mention="true"
       data-agent-link-href={href}
-      data-agent-mention-icon-url={mention.iconUrl}
+      data-agent-mention-icon-url={iconUrl}
       data-agent-mention-href={href}
       data-agent-mention-kind={mention.kind}
       data-agent-reference-source={mention.referenceSource}
-      aria-label={mention.label}
+      aria-label={label}
       role="link"
       tabIndex={0}
       onClick={(event) => {
@@ -649,77 +660,26 @@ function MentionLink({
         activateMarkdownLinkFromKey(event, href, onLinkClick);
       }}
     >
-      {mention.kind === "pasted-text" ? (
-        <span
-          className="grid h-4 w-4 shrink-0 place-items-center text-[var(--text-tertiary)]"
-          aria-hidden="true"
-        >
-          <FileText size={14} strokeWidth={2} />
-        </span>
-      ) : mention.kind === "workspace-app" ||
-        mention.kind === "workspace-reference" ||
-        mention.kind === "agent-target" ||
-        (mention.kind === "session" && mention.iconUrl) ? (
-        <span
-          className="grid h-4 w-4 shrink-0 place-items-center overflow-hidden rounded-[4px] bg-block"
-          aria-hidden="true"
-          data-agent-mention-app-icon={
-            mention.kind === "session" ? undefined : "true"
-          }
-          data-agent-mention-session-icon={
-            mention.kind === "session" ? "true" : undefined
-          }
-          data-workspace-app-icon={
-            mention.kind === "session" ? undefined : "true"
-          }
-        >
-          {mention.iconUrl && failedIconUrl !== mention.iconUrl ? (
-            <img
-              src={mention.iconUrl}
-              alt=""
-              className="col-start-1 row-start-1 h-full w-full object-cover"
-              decoding="async"
-              loading="lazy"
-              draggable={false}
-              onError={() => {
-                setFailedIconUrl(mention.iconUrl);
-              }}
-            />
-          ) : (
-            <span
-              className="tsh-agent-object-token__kind-icon col-start-1 row-start-1 h-4 w-4"
-              data-agent-mention-fallback-icon="true"
-            />
-          )}
-        </span>
-      ) : (
-        <span className="tsh-agent-object-token__kind" aria-hidden="true">
-          <span
-            className="tsh-agent-object-token__kind-icon"
-            aria-hidden="true"
-          />
-        </span>
-      )}
-      <span className="tsh-agent-object-token__main" ref={mainRef}>
-        {mention.label}
-      </span>
+      <MentionPill
+        className="max-w-full"
+        iconUrl={iconUrl}
+        iconContainerProps={{
+          className: "h-4 w-4",
+          "data-agent-mention-app-icon": usesSessionIcon ? undefined : "true",
+          "data-agent-mention-session-icon": usesSessionIcon
+            ? "true"
+            : undefined,
+          "data-workspace-app-icon": usesSessionIcon ? undefined : "true"
+        }}
+        fallbackIconProps={{
+          "data-agent-mention-fallback-icon": "true"
+        }}
+        kind={pillKind}
+        label={<span className="tsh-agent-object-token__main">{label}</span>}
+        removable={false}
+        tooltipEnabled={!previewMode}
+        withTooltipProvider={!previewMode}
+      />
     </a>
-  );
-
-  if (previewMode) {
-    return link;
-  }
-
-  return (
-    <TooltipProvider delayDuration={200}>
-      <Tooltip>
-        <TooltipTrigger asChild>{link}</TooltipTrigger>
-        {overflowing ? (
-          <TooltipContent className="max-w-[min(420px,calc(100vw-32px))] whitespace-normal text-left [overflow-wrap:anywhere]">
-            {tooltipText}
-          </TooltipContent>
-        ) : null}
-      </Tooltip>
-    </TooltipProvider>
   );
 }

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -619,8 +619,10 @@ function MentionLink({
   // 标签截断时,hover 用设计系统 Tooltip 展示完整文本。trigger = 整个 chip(<a>),
   // 截断发生在内部 __main span,故在那上面测溢出。
   const tooltipText = mention.label;
+  const [failedIconUrl, setFailedIconUrl] = useState<string>();
   const { ref: mainRef, overflowing } =
     useTextOverflow<HTMLSpanElement>(tooltipText);
+
   const link = (
     <a
       {...props}
@@ -671,17 +673,23 @@ function MentionLink({
             mention.kind === "session" ? undefined : "true"
           }
         >
-          {mention.iconUrl ? (
+          {mention.iconUrl && failedIconUrl !== mention.iconUrl ? (
             <img
               src={mention.iconUrl}
               alt=""
-              className="h-full w-full object-cover"
+              className="col-start-1 row-start-1 h-full w-full object-cover"
               decoding="async"
               loading="lazy"
               draggable={false}
+              onError={() => {
+                setFailedIconUrl(mention.iconUrl);
+              }}
             />
           ) : (
-            <span className="tsh-agent-object-token__kind-icon h-4 w-4" />
+            <span
+              className="tsh-agent-object-token__kind-icon col-start-1 row-start-1 h-4 w-4"
+              data-agent-mention-fallback-icon="true"
+            />
           )}
         </span>
       ) : (

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -661,7 +661,7 @@ function MentionLink({
       }}
     >
       <MentionPill
-        className="max-w-full"
+        className="top-0 max-w-full"
         iconUrl={iconUrl}
         iconContainerProps={{
           className: "h-4 w-4",

--- a/packages/agent/gui/shared/agentMessageMarkdownLinks.ts
+++ b/packages/agent/gui/shared/agentMessageMarkdownLinks.ts
@@ -397,10 +397,13 @@ type MentionKind =
 export interface ParsedMentionLink {
   agentProviderId?: string;
   appId?: string;
+  entityId: string;
   kind: MentionKind;
   label: string;
   iconUrl?: string;
+  providerId: string;
   referenceSource?: string;
+  scope?: Readonly<Record<string, string>>;
   /** 引用文件数量(workspace-reference 专用,来自 href 的 count 参数)。 */
   fileCount?: number;
 }
@@ -451,13 +454,19 @@ export function parseMentionLink(
   const label =
     rawLabel.trim().replace(/^@+/, "").trim() ||
     (kind === "workspace-app-factory" ? appFactoryFallbackLabel : "");
+  const identity = {
+    entityId,
+    providerId: mention.providerId,
+    ...(mention.scope ? { scope: mention.scope } : {})
+  };
   if (kind === "pasted-text") {
-    return { kind, label };
+    return { ...identity, kind, label };
   }
   if (kind === "workspace-app" || kind === "workspace-app-factory") {
     const appId = kind === "workspace-app" ? entityId : "";
     const workspaceId = mention.scope?.workspaceId?.trim() || "";
     return {
+      ...identity,
       kind,
       ...(kind === "workspace-app" ? { appId } : {}),
       label,
@@ -482,6 +491,7 @@ export function parseMentionLink(
     const agentProviderId = target?.provider?.trim() || undefined;
     const targetLabel = target?.name?.trim() || label;
     return {
+      ...identity,
       agentProviderId,
       kind,
       label: targetLabel,
@@ -501,6 +511,7 @@ export function parseMentionLink(
       ? agentTargetId.slice("local:".length).trim()
       : "";
     return {
+      ...identity,
       kind,
       label,
       iconUrl:
@@ -520,6 +531,7 @@ export function parseMentionLink(
           })
         : undefined;
     return {
+      ...identity,
       kind,
       label,
       iconUrl: mention.scope?.icon?.trim() || appIconUrl,
@@ -529,11 +541,13 @@ export function parseMentionLink(
   }
   if (kind === "workspace-issue") {
     return {
+      ...identity,
       kind,
       label
     };
   }
   return {
+    ...identity,
     kind,
     label
   };

--- a/packages/ui/rich-text/README.md
+++ b/packages/ui/rich-text/README.md
@@ -156,6 +156,53 @@ Markdown serialization includes only `providerId`, `entityId`, `label`, and
 short `scope` fields. It does not serialize `presentation`, `href`, `kind`,
 `version`, or arbitrary metadata.
 
+## Mention Service
+
+`RichTextMentionService` is the host-agnostic owner of provider lookup, query,
+reverse resolution, presentation caching, invalidation, and subscriptions.
+Create one service at the host or app root and reuse it across composer,
+readonly conversation, preview, and AgentGUI surfaces:
+
+```tsx
+import {
+  RichTextMentionServiceProvider,
+  RichTextReadonlyContent,
+  RichTextTriggerEditor
+} from "@tutti-os/ui-rich-text/editor";
+import { createRichTextMentionService } from "@tutti-os/ui-rich-text/service";
+
+const mentionService = createRichTextMentionService({ providers });
+
+<RichTextMentionServiceProvider service={mentionService}>
+  <RichTextTriggerEditor value={draft} onChange={setDraft} />
+  <RichTextReadonlyContent value={savedMarkdown} />
+</RichTextMentionServiceProvider>;
+
+// Dispose when the owning host/workspace root is destroyed.
+mentionService.dispose();
+```
+
+Non-React consumers use the same instance directly through `query`, `resolve`,
+`getSnapshot`, `invalidate`, and `subscribe`. The React Provider never creates
+a network client or a global singleton; it only injects an existing service.
+
+Resolution precedence is fixed: an explicit `mentionService` prop wins, then
+the nearest `RichTextMentionServiceProvider`, then the deprecated
+`triggerProviders` compatibility path. If no resolver exists, persisted label
+text and the semantic `MentionPill` icon remain available.
+
+The service uses a normalized `providerId + entityId + canonical scope` key.
+Labels and presentation URLs are deliberately excluded. Ready entries are
+cached for 5 minutes, missing entries for 30 seconds, and errors retry after 5
+seconds. The cache is capped at 1000 identities, concurrent resolution is
+single-flight, and stale ready presentation remains visible during refresh.
+Explicit invalidation may target all entries, a provider, a workspace, or an
+entity.
+
+Never persist a resolved snapshot or copy `presentation` into Markdown. Icon
+URLs and runtime cache state stay in memory; durable mention content remains
+limited to provider identity, entity identity, fallback label, and short scope.
+
 Helpers now exported:
 
 - `createRichTextMentionPlugin`
@@ -199,13 +246,17 @@ Tutti workspace apps that already receive mention candidates from
 `@tutti-os/workspace-external-core/rich-text`:
 
 ```ts
-import { createTuttiExternalAtRichTextTriggerProviders } from "@tutti-os/workspace-external-core/rich-text";
+import { createTuttiExternalRichTextMentionService } from "@tutti-os/workspace-external-core/rich-text";
 
-const providers = createTuttiExternalAtRichTextTriggerProviders({
-  bridge: window.tuttiExternal,
+const mentionService = createTuttiExternalRichTextMentionService({
+  getBridge: () => window.tuttiExternal,
   providerIds: ["workspace-app", "agent-session"]
 });
 ```
+
+The older trigger-provider factory remains available for compatibility, but a
+root-owned service is the preferred integration because editor and readonly
+surfaces share resolution, caching, and invalidation automatically.
 
 Use a custom `RichTextTriggerProvider` only for app-local mention sources or for
 apps that do not use the Tutti external bridge.

--- a/packages/ui/rich-text/README.md
+++ b/packages/ui/rich-text/README.md
@@ -129,6 +129,10 @@ Interpretation:
   insertion
 - `resolveMention` restores editor-only label or presentation data from the
   stored mention identity
+- readonly conversation surfaces pass the same providers to
+  `RichTextReadonlyContent.triggerProviders`; it calls `resolveMention` to
+  restore presentation such as app icons while keeping serialized Markdown
+  limited to durable identity and scope
 - group ids, labels, totals, and cursors are candidate-panel metadata only;
   they must not be copied into mention identity, href, or persisted scope
 

--- a/packages/ui/rich-text/package.json
+++ b/packages/ui/rich-text/package.json
@@ -12,6 +12,7 @@
     "./core": "./src/core/index.ts",
     "./editor": "./src/editor/index.ts",
     "./plugins": "./src/plugins/index.ts",
+    "./service": "./src/service/index.ts",
     "./types": "./src/types/index.ts"
   },
   "files": [
@@ -88,6 +89,11 @@
         "import": "./dist/plugins/index.js",
         "default": "./dist/plugins/index.js"
       },
+      "./service": {
+        "types": "./dist/service/index.d.ts",
+        "import": "./dist/service/index.js",
+        "default": "./dist/service/index.js"
+      },
       "./types": {
         "types": "./dist/types/index.d.ts",
         "import": "./dist/types/index.js",
@@ -111,6 +117,9 @@
         ],
         "plugins": [
           "./dist/plugins/index.d.ts"
+        ],
+        "service": [
+          "./dist/service/index.d.ts"
         ],
         "types": [
           "./dist/types/index.d.ts"

--- a/packages/ui/rich-text/src/editor/RichTextMentionReadonly.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextMentionReadonly.tsx
@@ -1,8 +1,10 @@
 import type { CSSProperties, JSX, MouseEvent, ReactNode } from "react";
+import { MentionPill } from "@tutti-os/ui-system/components";
+import { resolveRichTextMentionView } from "../plugins/mention.ts";
 import {
-  getRichTextMentionDisplayText,
-  resolveRichTextMentionView
-} from "../plugins/mention.ts";
+  resolveMentionPillIconUrl,
+  resolveMentionPillKind
+} from "../extensions/mentionPillPresentation.ts";
 import type {
   RichTextMentionAttrs,
   RichTextResolvedMention,
@@ -27,14 +29,8 @@ export interface RichTextMentionReadonlyProps<TResolved = unknown> {
 
 const baseStyle: CSSProperties = {
   alignItems: "center",
-  border: "1px solid transparent",
-  borderRadius: "999px",
   display: "inline-flex",
-  fontSize: "0.95em",
-  gap: "0.25rem",
-  lineHeight: 1.4,
   maxWidth: "100%",
-  padding: "0.05rem 0.45rem",
   textDecoration: "none",
   verticalAlign: "baseline",
   whiteSpace: "nowrap"
@@ -43,30 +39,22 @@ const baseStyle: CSSProperties = {
 const stateStyles: Record<RichTextResolvedMentionView["state"], CSSProperties> =
   {
     active: {
-      background:
-        "var(--tutti-rich-text-mention-active-bg, color-mix(in srgb, currentColor 12%, transparent))",
       color: "var(--tutti-rich-text-mention-active-fg, inherit)",
       cursor: "pointer"
     },
     missing: {
-      background:
-        "var(--tutti-rich-text-mention-missing-bg, color-mix(in srgb, currentColor 6%, transparent))",
       color:
         "var(--tutti-rich-text-mention-missing-fg, color-mix(in srgb, currentColor 48%, transparent))",
       cursor: "default",
       textDecoration: "line-through"
     },
     disabled: {
-      background:
-        "var(--tutti-rich-text-mention-disabled-bg, color-mix(in srgb, currentColor 6%, transparent))",
       color:
         "var(--tutti-rich-text-mention-disabled-fg, color-mix(in srgb, currentColor 58%, transparent))",
       cursor: "not-allowed",
       opacity: 0.88
     },
     loading: {
-      background:
-        "var(--tutti-rich-text-mention-loading-bg, color-mix(in srgb, currentColor 8%, transparent))",
       color:
         "var(--tutti-rich-text-mention-loading-fg, color-mix(in srgb, currentColor 82%, transparent))",
       cursor: "progress",
@@ -94,12 +82,21 @@ export function RichTextMentionReadonly<TResolved = unknown>({
     mention,
     resolved: view as RichTextResolvedMentionView<TResolved>
   };
-  const label =
-    renderLabel?.(payload) ??
-    getRichTextMentionDisplayText({
-      ...mention,
-      label: view.label
-    });
+  const label = renderLabel?.(payload) ?? view.label;
+  const content = (
+    <MentionPill
+      className="top-0"
+      iconUrl={
+        resolveMentionPillIconUrl({
+          presentation: view.presentation,
+          scope: mention.scope
+        }) ?? undefined
+      }
+      kind={resolveMentionPillKind(mention.providerId, mention.scope)}
+      label={label}
+      removable={false}
+    />
+  );
   const elementTitle = title ?? view.tooltip;
   const handleClick = (event: MouseEvent<HTMLElement>) => {
     if (!view.interactive) {
@@ -136,14 +133,17 @@ export function RichTextMentionReadonly<TResolved = unknown>({
         style={{
           ...sharedProps.style,
           appearance: "none",
-          font: "inherit"
+          background: "transparent",
+          border: 0,
+          font: "inherit",
+          padding: 0
         }}
         type="button"
       >
-        {label}
+        {content}
       </button>
     );
   }
 
-  return <span {...sharedProps}>{label}</span>;
+  return <span {...sharedProps}>{content}</span>;
 }

--- a/packages/ui/rich-text/src/editor/RichTextMentionReadonly.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextMentionReadonly.tsx
@@ -1,6 +1,9 @@
 import type { CSSProperties, JSX, MouseEvent, ReactNode } from "react";
 import { MentionPill } from "@tutti-os/ui-system/components";
-import { resolveRichTextMentionView } from "../plugins/mention.ts";
+import {
+  getRichTextMentionDisplayText,
+  resolveRichTextMentionView
+} from "../plugins/mention.ts";
 import {
   resolveMentionPillIconUrl,
   resolveMentionPillKind
@@ -82,7 +85,9 @@ export function RichTextMentionReadonly<TResolved = unknown>({
     mention,
     resolved: view as RichTextResolvedMentionView<TResolved>
   };
-  const label = renderLabel?.(payload) ?? view.label;
+  const label =
+    renderLabel?.(payload) ??
+    getRichTextMentionDisplayText({ ...mention, label: view.label });
   const content = (
     <MentionPill
       className="top-0"

--- a/packages/ui/rich-text/src/editor/RichTextMentionServiceProvider.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextMentionServiceProvider.tsx
@@ -1,0 +1,93 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useSyncExternalStore,
+  type JSX,
+  type ReactNode
+} from "react";
+import {
+  createRichTextMentionIdentityKey,
+  createRichTextMentionService,
+  type RichTextMentionService,
+  type RichTextMentionSnapshot
+} from "../service/index.ts";
+import type { RichTextMentionIdentity } from "../types/mention.ts";
+import type { RichTextTriggerProvider } from "../types/trigger.ts";
+
+const RichTextMentionServiceContext =
+  createContext<RichTextMentionService | null>(null);
+const idleSnapshot: RichTextMentionSnapshot = Object.freeze({ state: "idle" });
+
+export interface RichTextMentionServiceProviderProps {
+  service: RichTextMentionService;
+  children?: ReactNode;
+}
+
+export function RichTextMentionServiceProvider({
+  service,
+  children
+}: RichTextMentionServiceProviderProps): JSX.Element {
+  return (
+    <RichTextMentionServiceContext.Provider value={service}>
+      {children}
+    </RichTextMentionServiceContext.Provider>
+  );
+}
+
+export function useRichTextMentionService(
+  explicitService?: RichTextMentionService
+): RichTextMentionService | null {
+  const contextService = useContext(RichTextMentionServiceContext);
+  return explicitService ?? contextService;
+}
+
+export function useEffectiveRichTextMentionService(input: {
+  mentionService?: RichTextMentionService;
+  triggerProviders?: readonly RichTextTriggerProvider[];
+}): RichTextMentionService {
+  const contextService = useRichTextMentionService();
+  const legacyService = useMemo(
+    () =>
+      input.mentionService || contextService
+        ? null
+        : createRichTextMentionService({
+            providers: input.triggerProviders ?? []
+          }),
+    [contextService, input.mentionService, input.triggerProviders]
+  );
+  useEffect(() => () => legacyService?.dispose(), [legacyService]);
+  return input.mentionService ?? contextService ?? legacyService!;
+}
+
+export function useResolvedRichTextMention(
+  identity: RichTextMentionIdentity,
+  explicitService?: RichTextMentionService
+): RichTextMentionSnapshot {
+  const service = useRichTextMentionService(explicitService);
+  const identityKey = createRichTextMentionIdentityKey(identity);
+  const stableIdentity = useMemo(
+    () => identity,
+    // Identity presentation fallback changes must still refresh the hook input.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [identityKey, identity.label]
+  );
+  const subscribe = useCallback(
+    (listener: () => void) =>
+      service?.subscribe(listener, stableIdentity) ?? (() => {}),
+    [service, stableIdentity]
+  );
+  const getSnapshot = useCallback(
+    () => service?.getSnapshot(stableIdentity) ?? idleSnapshot,
+    [service, stableIdentity]
+  );
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  useEffect(() => {
+    if (service) void service.resolve(stableIdentity);
+  }, [service, stableIdentity]);
+
+  return snapshot;
+}

--- a/packages/ui/rich-text/src/editor/RichTextReadonlyContent.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextReadonlyContent.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type JSX } from "react";
+import { type JSX } from "react";
 import {
   MentionPill,
   Tooltip,
@@ -16,8 +16,12 @@ import { getWorkspaceReferencePresentation } from "../extensions/workspaceRefere
 import { RichTextMentionReadonly } from "./RichTextMentionReadonly.tsx";
 import { buildRichTextReadonlyInlineSegments } from "./richTextReadonlyContentModel.ts";
 import type { RichTextMentionAttrs } from "../types/mention.ts";
-import type { RichTextMentionResolved } from "../types/mention.ts";
 import type { RichTextTriggerProvider } from "../types/trigger.ts";
+import type { RichTextMentionService } from "../service/index.ts";
+import {
+  useEffectiveRichTextMentionService,
+  useResolvedRichTextMention
+} from "./RichTextMentionServiceProvider.tsx";
 
 export interface RichTextReadonlyWorkspaceReference {
   kind: "file" | "folder";
@@ -29,7 +33,9 @@ export interface RichTextReadonlyContentProps {
   value: string;
   className?: string;
   paragraphClassName?: string;
+  /** @deprecated Prefer mentionService or RichTextMentionServiceProvider. */
   triggerProviders?: readonly RichTextTriggerProvider[];
+  mentionService?: RichTextMentionService;
   onMentionAction?: (mention: RichTextMentionAttrs) => void | Promise<void>;
   onOpenWorkspaceReference?: (
     reference: RichTextReadonlyWorkspaceReference
@@ -44,10 +50,15 @@ export function RichTextReadonlyContent({
   className,
   paragraphClassName,
   triggerProviders,
+  mentionService,
   onMentionAction,
   onOpenWorkspaceReference
 }: RichTextReadonlyContentProps): JSX.Element | null {
   const normalizedValue = normalizeRichTextContent(value).trim();
+  const effectiveMentionService = useEffectiveRichTextMentionService({
+    mentionService,
+    triggerProviders
+  });
 
   if (!normalizedValue) {
     return null;
@@ -67,9 +78,9 @@ export function RichTextReadonlyContent({
         >
           {renderReadonlyInlineMarkdown(
             paragraph,
+            effectiveMentionService,
             onOpenWorkspaceReference,
-            onMentionAction,
-            triggerProviders
+            onMentionAction
           )}
         </p>
       ))}
@@ -79,11 +90,11 @@ export function RichTextReadonlyContent({
 
 function renderReadonlyInlineMarkdown(
   content: string,
+  mentionService: RichTextMentionService,
   onOpenWorkspaceReference?: (
     reference: RichTextReadonlyWorkspaceReference
   ) => void | Promise<void>,
-  onMentionAction?: (mention: RichTextMentionAttrs) => void | Promise<void>,
-  triggerProviders?: readonly RichTextTriggerProvider[]
+  onMentionAction?: (mention: RichTextMentionAttrs) => void | Promise<void>
 ): JSX.Element[] {
   const parts: JSX.Element[] = [];
   const segments = buildRichTextReadonlyInlineSegments(content);
@@ -101,7 +112,7 @@ function renderReadonlyInlineMarkdown(
         label={segment.label}
         onMentionAction={onMentionAction}
         onOpenWorkspaceReference={onOpenWorkspaceReference}
-        triggerProviders={triggerProviders}
+        mentionService={mentionService}
       />
     );
   });
@@ -114,7 +125,7 @@ function RichTextReadonlyInlineLink({
   label,
   onMentionAction,
   onOpenWorkspaceReference,
-  triggerProviders
+  mentionService
 }: {
   href: string;
   label: string;
@@ -122,7 +133,7 @@ function RichTextReadonlyInlineLink({
   onOpenWorkspaceReference?: (
     reference: RichTextReadonlyWorkspaceReference
   ) => void | Promise<void>;
-  triggerProviders?: readonly RichTextTriggerProvider[];
+  mentionService: RichTextMentionService;
 }): JSX.Element {
   const trimmedHref = href.trim();
   const mention = parseRichTextMentionHref(trimmedHref, label);
@@ -138,9 +149,7 @@ function RichTextReadonlyInlineLink({
               }
             : undefined
         }
-        provider={triggerProviders?.find(
-          (provider) => provider.id.trim() === mention.providerId
-        )}
+        mentionService={mentionService}
       />
     );
   }
@@ -183,62 +192,27 @@ function RichTextReadonlyInlineLink({
 function HydratedRichTextMentionReadonly({
   mention,
   onClick,
-  provider
+  mentionService
 }: {
   mention: RichTextMentionAttrs;
   onClick?: (payload: { mention: RichTextMentionAttrs }) => void;
-  provider?: RichTextTriggerProvider;
+  mentionService: RichTextMentionService;
 }): JSX.Element {
-  const [resolved, setResolved] = useState<RichTextMentionResolved | null>(
-    null
-  );
-
-  useEffect(() => {
-    let cancelled = false;
-    setResolved(null);
-    const resolveMention = provider?.resolveMention;
-    if (!resolveMention) {
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    void Promise.resolve()
-      .then(() =>
-        resolveMention({
-          providerId: mention.providerId,
-          entityId: mention.entityId,
-          label: mention.label,
-          scope: mention.scope
-        })
-      )
-      .then((nextResolved) => {
-        if (!cancelled) {
-          setResolved(nextResolved);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setResolved(null);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    mention.entityId,
-    mention.label,
-    mention.providerId,
-    mention.scope,
-    provider
-  ]);
+  const snapshot = useResolvedRichTextMention(mention, mentionService);
+  const resolved =
+    snapshot.state === "ready"
+      ? { state: "active" as const, ...snapshot.resolved }
+      : snapshot.state === "loading"
+        ? { state: "loading" as const }
+        : snapshot.state === "missing"
+          ? { state: "missing" as const }
+          : undefined;
 
   return (
     <RichTextMentionReadonly
       mention={mention}
       onClick={onClick}
-      resolved={resolved ? { state: "active", ...resolved } : undefined}
+      resolved={resolved}
     />
   );
 }

--- a/packages/ui/rich-text/src/editor/RichTextReadonlyContent.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextReadonlyContent.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from "react";
+import { useEffect, useState, type JSX } from "react";
 import {
   MentionPill,
   Tooltip,
@@ -16,6 +16,8 @@ import { getWorkspaceReferencePresentation } from "../extensions/workspaceRefere
 import { RichTextMentionReadonly } from "./RichTextMentionReadonly.tsx";
 import { buildRichTextReadonlyInlineSegments } from "./richTextReadonlyContentModel.ts";
 import type { RichTextMentionAttrs } from "../types/mention.ts";
+import type { RichTextMentionResolved } from "../types/mention.ts";
+import type { RichTextTriggerProvider } from "../types/trigger.ts";
 
 export interface RichTextReadonlyWorkspaceReference {
   kind: "file" | "folder";
@@ -27,6 +29,7 @@ export interface RichTextReadonlyContentProps {
   value: string;
   className?: string;
   paragraphClassName?: string;
+  triggerProviders?: readonly RichTextTriggerProvider[];
   onMentionAction?: (mention: RichTextMentionAttrs) => void | Promise<void>;
   onOpenWorkspaceReference?: (
     reference: RichTextReadonlyWorkspaceReference
@@ -40,6 +43,7 @@ export function RichTextReadonlyContent({
   value,
   className,
   paragraphClassName,
+  triggerProviders,
   onMentionAction,
   onOpenWorkspaceReference
 }: RichTextReadonlyContentProps): JSX.Element | null {
@@ -64,7 +68,8 @@ export function RichTextReadonlyContent({
           {renderReadonlyInlineMarkdown(
             paragraph,
             onOpenWorkspaceReference,
-            onMentionAction
+            onMentionAction,
+            triggerProviders
           )}
         </p>
       ))}
@@ -77,7 +82,8 @@ function renderReadonlyInlineMarkdown(
   onOpenWorkspaceReference?: (
     reference: RichTextReadonlyWorkspaceReference
   ) => void | Promise<void>,
-  onMentionAction?: (mention: RichTextMentionAttrs) => void | Promise<void>
+  onMentionAction?: (mention: RichTextMentionAttrs) => void | Promise<void>,
+  triggerProviders?: readonly RichTextTriggerProvider[]
 ): JSX.Element[] {
   const parts: JSX.Element[] = [];
   const segments = buildRichTextReadonlyInlineSegments(content);
@@ -95,6 +101,7 @@ function renderReadonlyInlineMarkdown(
         label={segment.label}
         onMentionAction={onMentionAction}
         onOpenWorkspaceReference={onOpenWorkspaceReference}
+        triggerProviders={triggerProviders}
       />
     );
   });
@@ -106,7 +113,8 @@ function RichTextReadonlyInlineLink({
   href,
   label,
   onMentionAction,
-  onOpenWorkspaceReference
+  onOpenWorkspaceReference,
+  triggerProviders
 }: {
   href: string;
   label: string;
@@ -114,13 +122,14 @@ function RichTextReadonlyInlineLink({
   onOpenWorkspaceReference?: (
     reference: RichTextReadonlyWorkspaceReference
   ) => void | Promise<void>;
+  triggerProviders?: readonly RichTextTriggerProvider[];
 }): JSX.Element {
   const trimmedHref = href.trim();
   const mention = parseRichTextMentionHref(trimmedHref, label);
 
   if (mention) {
     return (
-      <RichTextMentionReadonly
+      <HydratedRichTextMentionReadonly
         mention={mention}
         onClick={
           onMentionAction
@@ -129,6 +138,9 @@ function RichTextReadonlyInlineLink({
               }
             : undefined
         }
+        provider={triggerProviders?.find(
+          (provider) => provider.id.trim() === mention.providerId
+        )}
       />
     );
   }
@@ -164,6 +176,69 @@ function RichTextReadonlyInlineLink({
         path
       }}
       onOpenWorkspaceReference={onOpenWorkspaceReference}
+    />
+  );
+}
+
+function HydratedRichTextMentionReadonly({
+  mention,
+  onClick,
+  provider
+}: {
+  mention: RichTextMentionAttrs;
+  onClick?: (payload: { mention: RichTextMentionAttrs }) => void;
+  provider?: RichTextTriggerProvider;
+}): JSX.Element {
+  const [resolved, setResolved] = useState<RichTextMentionResolved | null>(
+    null
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    setResolved(null);
+    const resolveMention = provider?.resolveMention;
+    if (!resolveMention) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    void Promise.resolve()
+      .then(() =>
+        resolveMention({
+          providerId: mention.providerId,
+          entityId: mention.entityId,
+          label: mention.label,
+          scope: mention.scope
+        })
+      )
+      .then((nextResolved) => {
+        if (!cancelled) {
+          setResolved(nextResolved);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setResolved(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    mention.entityId,
+    mention.label,
+    mention.providerId,
+    mention.scope,
+    provider
+  ]);
+
+  return (
+    <RichTextMentionReadonly
+      mention={mention}
+      onClick={onClick}
+      resolved={resolved ? { state: "active", ...resolved } : undefined}
     />
   );
 }

--- a/packages/ui/rich-text/src/editor/RichTextTriggerEditor.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextTriggerEditor.tsx
@@ -31,7 +31,7 @@ import {
   type MentionPaletteState
 } from "../at-panel/index.ts";
 import { createRichTextMentionAttrs } from "../plugins/index.ts";
-import { createRichTextTriggerRegistry } from "../plugins/triggerRegistry.ts";
+import { useEffectiveRichTextMentionService } from "./RichTextMentionServiceProvider.tsx";
 import type {
   RichTextMentionAttrs,
   RichTextMentionPresentation
@@ -43,6 +43,7 @@ import type {
   RichTextTrigger,
   RichTextTriggerConfig
 } from "../types/trigger.ts";
+import type { RichTextMentionService } from "../service/index.ts";
 import {
   normalizeRichTextContent,
   normalizeRichTextLinkHref,
@@ -77,7 +78,9 @@ import {
 export interface RichTextTriggerEditorProps {
   value: string;
   onChange: (value: string) => void;
+  /** @deprecated Prefer mentionService or RichTextMentionServiceProvider. */
   triggerProviders?: readonly RichTextTriggerProvider[];
+  mentionService?: RichTextMentionService;
   placeholder?: string;
   disabled?: boolean;
   className?: string;
@@ -135,7 +138,8 @@ const RICH_TEXT_MENTION_PRESENTATION_KEYS = [
 export function RichTextTriggerEditor({
   value,
   onChange,
-  triggerProviders = [],
+  triggerProviders,
+  mentionService,
   placeholder,
   disabled = false,
   className,
@@ -166,10 +170,10 @@ export function RichTextTriggerEditor({
   const mentionHydrationRequestRef = useRef(0);
   const suppressPastedAtQueryRef = useRef(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const registry = useMemo(
-    () => createRichTextTriggerRegistry(triggerProviders),
-    [triggerProviders]
-  );
+  const registry = useEffectiveRichTextMentionService({
+    mentionService,
+    triggerProviders
+  });
   const activeTriggerConfigs = useMemo(
     () => registry.listTriggerConfigs(),
     [registry]
@@ -280,13 +284,11 @@ export function RichTextTriggerEditor({
     }
 
     for (const mention of mentions) {
-      const provider = registry.getProvider(mention.attrs.providerId);
-      if (!provider?.resolveMention) {
-        continue;
-      }
-
-      void Promise.resolve(provider.resolveMention(mention.attrs))
-        .then((resolved) => {
+      void registry
+        .resolve(mention.attrs)
+        .then((snapshot) => {
+          const resolved =
+            snapshot.state === "ready" ? snapshot.resolved : undefined;
           if (
             !resolved ||
             mentionHydrationRequestRef.current !== requestId ||

--- a/packages/ui/rich-text/src/editor/RichTextTriggerEditor.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextTriggerEditor.tsx
@@ -276,36 +276,37 @@ export function RichTextTriggerEditor({
       return;
     }
 
-    const requestId = mentionHydrationRequestRef.current + 1;
-    mentionHydrationRequestRef.current = requestId;
-    const mentions = collectHydratableMentionNodes(editor);
-    if (mentions.length === 0) {
-      return;
-    }
+    const hydrateMentions = (): void => {
+      const requestId = mentionHydrationRequestRef.current + 1;
+      mentionHydrationRequestRef.current = requestId;
+      const mentions = collectHydratableMentionNodes(editor);
+      for (const mention of mentions) {
+        void registry
+          .resolve(mention.attrs)
+          .then((snapshot) => {
+            const resolved =
+              snapshot.state === "ready" ? snapshot.resolved : undefined;
+            if (
+              !resolved ||
+              mentionHydrationRequestRef.current !== requestId ||
+              editor.isDestroyed
+            ) {
+              return;
+            }
 
-    for (const mention of mentions) {
-      void registry
-        .resolve(mention.attrs)
-        .then((snapshot) => {
-          const resolved =
-            snapshot.state === "ready" ? snapshot.resolved : undefined;
-          if (
-            !resolved ||
-            mentionHydrationRequestRef.current !== requestId ||
-            editor.isDestroyed
-          ) {
-            return;
-          }
-
-          applyResolvedMentionAttrs(editor, mention.pos, mention.attrs, {
-            label: resolved.label,
-            presentation: resolved.presentation
+            applyResolvedMentionAttrs(editor, mention.pos, mention.attrs, {
+              label: resolved.label,
+              presentation: resolved.presentation
+            });
+          })
+          .catch(() => {
+            // Resolver failures keep the fallback label-only mention.
           });
-        })
-        .catch(() => {
-          // Resolver failures keep the fallback label-only mention.
-        });
-    }
+      }
+    };
+
+    hydrateMentions();
+    return registry.subscribe(hydrateMentions);
   }, [editor, registry, normalizedValue]);
 
   useEffect(() => {

--- a/packages/ui/rich-text/src/editor/RichTextTriggerTextarea.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextTriggerTextarea.tsx
@@ -11,12 +11,13 @@ import {
 } from "react";
 import { ViewportMenuSurface } from "@tutti-os/ui-system/components";
 import { cn } from "@tutti-os/ui-system/utils";
-import { createRichTextTriggerRegistry } from "../plugins/triggerRegistry.ts";
+import { useEffectiveRichTextMentionService } from "./RichTextMentionServiceProvider.tsx";
 import { renderRichTextTriggerInsertResult } from "../plugins/trigger.ts";
 import type {
   RichTextTriggerProvider,
   RichTextTriggerQueryMatch
 } from "../types/trigger.ts";
+import type { RichTextMentionService } from "../service/index.ts";
 import {
   findRichTextTriggerQuery,
   queryRichTextTriggerMatches
@@ -41,7 +42,9 @@ import type { CSSProperties } from "react";
 export interface RichTextTriggerTextareaProps {
   value: string;
   onChange: (value: string) => void;
+  /** @deprecated Prefer mentionService or RichTextMentionServiceProvider. */
   triggerProviders?: readonly RichTextTriggerProvider[];
+  mentionService?: RichTextMentionService;
   placeholder?: string;
   disabled?: boolean;
   className?: string;
@@ -58,7 +61,8 @@ export interface RichTextTriggerTextareaProps {
 export function RichTextTriggerTextarea({
   value,
   onChange,
-  triggerProviders = [],
+  triggerProviders,
+  mentionService,
   placeholder,
   disabled = false,
   className,
@@ -93,10 +97,10 @@ export function RichTextTriggerTextarea({
     useState<CSSProperties | null>(null);
   const pendingSelectionRef = useRef<number | null>(null);
   const suppressPastedAtQueryRef = useRef(false);
-  const registry = useMemo(
-    () => createRichTextTriggerRegistry(triggerProviders),
-    [triggerProviders]
-  );
+  const registry = useEffectiveRichTextMentionService({
+    mentionService,
+    triggerProviders
+  });
   const activeTriggerConfigs = useMemo(
     () => registry.listTriggerConfigs(),
     [registry]

--- a/packages/ui/rich-text/src/editor/index.ts
+++ b/packages/ui/rich-text/src/editor/index.ts
@@ -22,6 +22,13 @@ export {
   type RichTextReadonlyWorkspaceReference
 } from "./RichTextReadonlyContent.tsx";
 export {
+  RichTextMentionServiceProvider,
+  useEffectiveRichTextMentionService,
+  useResolvedRichTextMention,
+  useRichTextMentionService,
+  type RichTextMentionServiceProviderProps
+} from "./RichTextMentionServiceProvider.tsx";
+export {
   findRichTextTriggerQuery,
   isRichTextTriggerPrefixBoundary,
   queryRichTextTriggerMatches,

--- a/packages/ui/rich-text/src/extensions/MentionReferenceNodeView.tsx
+++ b/packages/ui/rich-text/src/extensions/MentionReferenceNodeView.tsx
@@ -1,62 +1,15 @@
 import type { JSX } from "react";
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
+import { MentionPill } from "@tutti-os/ui-system/components";
 import {
-  MentionPill,
-  type MentionPillKind
-} from "@tutti-os/ui-system/components";
+  resolveMentionPillIconUrl,
+  resolveMentionPillKind
+} from "./mentionPillPresentation.ts";
 
 const richTextMentionReferencePillClassName = "max-w-[16rem]";
 
 function readStringAttr(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
-}
-
-function readMentionPresentationUrl(presentation: unknown): string | null {
-  if (!presentation || typeof presentation !== "object") {
-    return null;
-  }
-  const value =
-    (presentation as { iconUrl?: unknown; thumbnailUrl?: unknown }).iconUrl ??
-    (presentation as { thumbnailUrl?: unknown }).thumbnailUrl;
-  if (typeof value !== "string") {
-    return null;
-  }
-  const trimmed = value.trim();
-  return trimmed || null;
-}
-
-// 句柄类 mention(如 workspace-reference 项目引用)的图标随 href 的 scope 编码,
-// markdown 带不了 presentation,故回退读 scope.icon,使 chip 与 agent 一样显示来源图标。
-function readMentionScopeValue(scope: unknown, key: string): string {
-  if (!scope || typeof scope !== "object") {
-    return "";
-  }
-  return readStringAttr((scope as Record<string, unknown>)[key]);
-}
-
-// providerId(+ workspace-reference 的 source)映射到设计系统 MentionPill 的 kind,
-// 让颜色/图标与 agent GUI 的 mention chip 完全一致。
-function resolveMentionPillKind(
-  providerId: string,
-  scope: unknown
-): MentionPillKind {
-  const id = providerId.trim();
-  if (id === "agent-session" || id === "session") {
-    return "session";
-  }
-  if (id === "workspace-app") {
-    return "app";
-  }
-  if (id === "workspace-issue") {
-    return "issue";
-  }
-  if (id === "workspace-reference") {
-    return readMentionScopeValue(scope, "source") === "task" ? "issue" : "app";
-  }
-  if (id === "file") {
-    return "file";
-  }
-  return "issue";
 }
 
 export function MentionReferenceNodeView({
@@ -67,9 +20,10 @@ export function MentionReferenceNodeView({
     typeof node.attrs.label === "string"
       ? node.attrs.label.trim().replace(/^@+/, "").trim()
       : "";
-  const iconUrl =
-    readMentionPresentationUrl(node.attrs.presentation) ||
-    readMentionScopeValue(node.attrs.scope, "icon");
+  const iconUrl = resolveMentionPillIconUrl({
+    presentation: node.attrs.presentation,
+    scope: node.attrs.scope
+  });
   const kind = resolveMentionPillKind(
     readStringAttr(node.attrs.providerId),
     node.attrs.scope

--- a/packages/ui/rich-text/src/extensions/mentionPillPresentation.test.ts
+++ b/packages/ui/rich-text/src/extensions/mentionPillPresentation.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveMentionPillIconUrl,
+  resolveMentionPillKind
+} from "./mentionPillPresentation.ts";
+
+test("resolves mention pill kinds from provider identity", () => {
+  assert.equal(resolveMentionPillKind("workspace-app", undefined), "app");
+  assert.equal(resolveMentionPillKind("agent-session", undefined), "session");
+  assert.equal(
+    resolveMentionPillKind("workspace-reference", { source: "task" }),
+    "issue"
+  );
+  assert.equal(
+    resolveMentionPillKind("workspace-reference", { source: "app" }),
+    "app"
+  );
+});
+
+test("prefers hydrated presentation icons over legacy scope icons", () => {
+  assert.equal(
+    resolveMentionPillIconUrl({
+      presentation: { iconUrl: " app://weather.png " },
+      scope: { icon: "app://legacy.png" }
+    }),
+    "app://weather.png"
+  );
+  assert.equal(
+    resolveMentionPillIconUrl({ scope: { icon: " app://legacy.png " } }),
+    "app://legacy.png"
+  );
+});

--- a/packages/ui/rich-text/src/extensions/mentionPillPresentation.ts
+++ b/packages/ui/rich-text/src/extensions/mentionPillPresentation.ts
@@ -1,0 +1,58 @@
+import type { MentionPillKind } from "@tutti-os/ui-system/components";
+import type {
+  RichTextMentionIdentity,
+  RichTextMentionPresentation
+} from "../types/mention.ts";
+
+function readStringAttr(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function readMentionPresentationUrl(
+  presentation: RichTextMentionPresentation | null | undefined
+): string | null {
+  const value = presentation?.iconUrl ?? presentation?.thumbnailUrl;
+  const trimmed = readStringAttr(value);
+  return trimmed || null;
+}
+
+export function readMentionScopeValue(
+  scope: RichTextMentionIdentity["scope"] | null | undefined,
+  key: string
+): string {
+  return readStringAttr(scope?.[key]);
+}
+
+export function resolveMentionPillKind(
+  providerId: string,
+  scope: RichTextMentionIdentity["scope"] | null | undefined
+): MentionPillKind {
+  const id = providerId.trim();
+  if (id === "agent-session" || id === "session") {
+    return "session";
+  }
+  if (id === "workspace-app") {
+    return "app";
+  }
+  if (id === "workspace-issue") {
+    return "issue";
+  }
+  if (id === "workspace-reference") {
+    return readMentionScopeValue(scope, "source") === "task" ? "issue" : "app";
+  }
+  if (id === "file") {
+    return "file";
+  }
+  return "issue";
+}
+
+export function resolveMentionPillIconUrl(input: {
+  presentation?: RichTextMentionPresentation | null;
+  scope?: RichTextMentionIdentity["scope"] | null;
+}): string | null {
+  return (
+    readMentionPresentationUrl(input.presentation) ||
+    readMentionScopeValue(input.scope, "icon") ||
+    null
+  );
+}

--- a/packages/ui/rich-text/src/index.ts
+++ b/packages/ui/rich-text/src/index.ts
@@ -21,3 +21,4 @@ export {
   type RichTextI18nKey,
   type RichTextI18nRuntime
 } from "./i18n/index.ts";
+export * from "./service/index.ts";

--- a/packages/ui/rich-text/src/service/RichTextMentionService.test.ts
+++ b/packages/ui/rich-text/src/service/RichTextMentionService.test.ts
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { RichTextMentionResolved } from "../types/mention.ts";
+import type { RichTextTriggerProvider } from "../types/trigger.ts";
+import {
+  RICH_TEXT_MENTION_CACHE_CAPACITY,
+  RICH_TEXT_MENTION_ERROR_RETRY_MS,
+  RICH_TEXT_MENTION_MISSING_TTL_MS,
+  RICH_TEXT_MENTION_READY_TTL_MS,
+  createRichTextMentionService
+} from "./RichTextMentionService.ts";
+import { createRichTextMentionIdentityKey } from "./richTextMentionIdentityKey.ts";
+
+const identity = {
+  providerId: " workspace-app ",
+  entityId: " app-1 ",
+  label: "Canvas",
+  scope: { workspaceId: "workspace-1", z: "last", a: "first" }
+};
+
+function createProvider(
+  resolveMention: RichTextTriggerProvider["resolveMention"]
+): RichTextTriggerProvider {
+  return {
+    id: "workspace-app",
+    trigger: "@",
+    query: () => [],
+    getItemKey: () => "",
+    getItemLabel: () => "",
+    toInsertResult: () => ({ kind: "text", text: "" }),
+    resolveMention
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+test("identity key normalizes identity and canonicalizes scope", () => {
+  const left = createRichTextMentionIdentityKey(identity);
+  const right = createRichTextMentionIdentityKey({
+    ...identity,
+    providerId: "workspace-app",
+    entityId: "app-1",
+    label: "Renamed",
+    scope: { a: "first", workspaceId: "workspace-1", z: "last" }
+  });
+  assert.equal(left, right);
+  assert.notEqual(
+    left,
+    createRichTextMentionIdentityKey({ ...identity, entityId: "app-2" })
+  );
+});
+
+test("ready, missing, and error snapshots honor fixed TTLs", async () => {
+  let time = 1_000;
+  let calls = 0;
+  let result: RichTextMentionResolved | null = {
+    presentation: { iconUrl: "first.png" }
+  };
+  let shouldReject = false;
+  const service = createRichTextMentionService({
+    now: () => time,
+    providers: [
+      createProvider(() => {
+        calls += 1;
+        if (shouldReject) throw new Error("offline");
+        return result;
+      })
+    ]
+  });
+
+  assert.equal((await service.resolve(identity)).state, "ready");
+  time += RICH_TEXT_MENTION_READY_TTL_MS - 1;
+  await service.resolve(identity);
+  assert.equal(calls, 1);
+  time += 1;
+  result = { presentation: { iconUrl: "second.png" } };
+  const stale = await service.resolve(identity);
+  assert.equal(stale.resolved?.presentation?.iconUrl, "first.png");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(
+    service.getSnapshot(identity).resolved?.presentation?.iconUrl,
+    "second.png"
+  );
+
+  service.invalidate();
+  result = null;
+  await service.resolve(identity);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(service.getSnapshot(identity).state, "missing");
+  const afterMissing = calls;
+  time += RICH_TEXT_MENTION_MISSING_TTL_MS - 1;
+  await service.resolve(identity);
+  assert.equal(calls, afterMissing);
+  time += 1;
+  await service.resolve(identity);
+  assert.equal(calls, afterMissing + 1);
+
+  service.invalidate();
+  shouldReject = true;
+  await service.resolve(identity);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(service.getSnapshot(identity).state, "error");
+  const afterError = calls;
+  time += RICH_TEXT_MENTION_ERROR_RETRY_MS - 1;
+  await service.resolve(identity);
+  assert.equal(calls, afterError);
+  time += 1;
+  await service.resolve(identity);
+  assert.equal(calls, afterError + 1);
+});
+
+test("concurrent resolves are single-flight", async () => {
+  const pending = deferred<RichTextMentionResolved | null>();
+  let calls = 0;
+  const service = createRichTextMentionService({
+    providers: [
+      createProvider(() => {
+        calls += 1;
+        return pending.promise;
+      })
+    ]
+  });
+  const resolutions = Array.from({ length: 100 }, () =>
+    service.resolve(identity)
+  );
+  await Promise.resolve();
+  assert.equal(calls, 1);
+  pending.resolve({ presentation: { iconUrl: "resolved.png" } });
+  const snapshots = await Promise.all(resolutions);
+  assert.equal(
+    snapshots.every((snapshot) => snapshot.state === "ready"),
+    true
+  );
+});
+
+test("in-flight invalidation schedules exactly one trailing resolve", async () => {
+  const first = deferred<RichTextMentionResolved | null>();
+  const second = deferred<RichTextMentionResolved | null>();
+  let calls = 0;
+  const service = createRichTextMentionService({
+    providers: [
+      createProvider(() => {
+        calls += 1;
+        return calls === 1 ? first.promise : second.promise;
+      })
+    ]
+  });
+  const initial = service.resolve(identity);
+  await Promise.resolve();
+  service.invalidate({ providerId: "workspace-app" });
+  service.invalidate({ entityId: "app-1" });
+  service.invalidate({ workspaceId: "workspace-1" });
+  first.resolve({ presentation: { iconUrl: "stale.png" } });
+  await initial;
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(calls, 2);
+  second.resolve({ presentation: { iconUrl: "fresh.png" } });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(calls, 2);
+  assert.equal(
+    service.getSnapshot(identity).resolved?.presentation?.iconUrl,
+    "fresh.png"
+  );
+});
+
+test("dispose is idempotent and ignores late resolver completion", async () => {
+  const pending = deferred<RichTextMentionResolved | null>();
+  const service = createRichTextMentionService({
+    providers: [createProvider(() => pending.promise)]
+  });
+  let notifications = 0;
+  service.subscribe(() => {
+    notifications += 1;
+  });
+  const resolution = service.resolve(identity);
+  service.dispose();
+  service.dispose();
+  pending.resolve({ presentation: { iconUrl: "late.png" } });
+  await resolution;
+  assert.equal(service.getSnapshot(identity).state, "idle");
+  assert.equal(notifications, 1);
+});
+
+test("capacity eviction preserves subscribed and in-flight identities", async () => {
+  const pending = deferred<RichTextMentionResolved | null>();
+  const calls = new Map<string, number>();
+  const service = createRichTextMentionService({
+    providers: [
+      createProvider((currentIdentity) => {
+        calls.set(
+          currentIdentity.entityId,
+          (calls.get(currentIdentity.entityId) ?? 0) + 1
+        );
+        return currentIdentity.entityId === "in-flight"
+          ? pending.promise
+          : { label: currentIdentity.entityId };
+      })
+    ]
+  });
+  const retainedIdentity = { ...identity, entityId: "retained" };
+  const unsubscribe = service.subscribe(() => {}, retainedIdentity);
+  await service.resolve(retainedIdentity);
+  const inFlightIdentity = { ...identity, entityId: "in-flight" };
+  const inFlight = service.resolve(inFlightIdentity);
+
+  for (let index = 0; index < RICH_TEXT_MENTION_CACHE_CAPACITY; index += 1) {
+    await service.resolve({ ...identity, entityId: `entry-${index}` });
+  }
+
+  await service.resolve(retainedIdentity);
+  assert.equal(calls.get("retained"), 1);
+  assert.equal(calls.get("in-flight"), 1);
+  pending.resolve({ label: "completed" });
+  await inFlight;
+  unsubscribe();
+});
+
+test("invalidation refreshes a subscribed identity", async () => {
+  let calls = 0;
+  const service = createRichTextMentionService({
+    providers: [
+      createProvider(() => ({
+        presentation: { iconUrl: `icon-${++calls}.png` }
+      }))
+    ]
+  });
+  const unsubscribe = service.subscribe(() => {}, identity);
+  await service.resolve(identity);
+
+  service.invalidate({ workspaceId: "workspace-1" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(calls, 2);
+  assert.equal(
+    service.getSnapshot(identity).resolved?.presentation?.iconUrl,
+    "icon-2.png"
+  );
+  unsubscribe();
+});

--- a/packages/ui/rich-text/src/service/RichTextMentionService.test.ts
+++ b/packages/ui/rich-text/src/service/RichTextMentionService.test.ts
@@ -57,6 +57,39 @@ test("identity key normalizes identity and canonicalizes scope", () => {
     left,
     createRichTextMentionIdentityKey({ ...identity, entityId: "app-2" })
   );
+  assert.equal(
+    createRichTextMentionIdentityKey({
+      ...identity,
+      scope: { é: "composed", é: "decomposed" }
+    }),
+    createRichTextMentionIdentityKey({
+      ...identity,
+      scope: { é: "decomposed", é: "composed" }
+    })
+  );
+});
+
+test("diagnostic failures never change query or resolution results", async () => {
+  const service = createRichTextMentionService({
+    diagnostics() {
+      throw new Error("diagnostics offline");
+    },
+    providers: [
+      {
+        ...createProvider(() => ({ label: "resolved" })),
+        query: () => ["match"],
+        getItemKey: (item) => String(item),
+        getItemLabel: (item) => String(item),
+        toInsertResult: (item) => ({ kind: "text", text: String(item) })
+      }
+    ]
+  });
+
+  assert.equal((await service.resolve(identity)).state, "ready");
+  assert.equal(
+    (await service.query({ context: {}, keyword: "", trigger: "@" })).length,
+    1
+  );
 });
 
 test("ready, missing, and error snapshots honor fixed TTLs", async () => {
@@ -221,6 +254,131 @@ test("capacity eviction preserves subscribed and in-flight identities", async ()
   assert.equal(calls.get("in-flight"), 1);
   pending.resolve({ label: "completed" });
   await inFlight;
+  unsubscribe();
+});
+
+test("capacity is enforced after an in-flight burst settles", async () => {
+  const requests = Array.from(
+    { length: RICH_TEXT_MENTION_CACHE_CAPACITY + 1 },
+    () => deferred<RichTextMentionResolved | null>()
+  );
+  const calls = new Map<string, number>();
+  const service = createRichTextMentionService({
+    providers: [
+      createProvider((currentIdentity) => {
+        const index = Number(currentIdentity.entityId.slice("burst-".length));
+        calls.set(
+          currentIdentity.entityId,
+          (calls.get(currentIdentity.entityId) ?? 0) + 1
+        );
+        return requests[index]!.promise;
+      })
+    ]
+  });
+  const resolutions = requests
+    .slice(0, -1)
+    .map((_, index) =>
+      service.resolve({ ...identity, entityId: `burst-${index}` })
+    );
+  await Promise.resolve();
+  const lastIdentity = {
+    ...identity,
+    entityId: `burst-${RICH_TEXT_MENTION_CACHE_CAPACITY}`
+  };
+  const unsubscribe = service.subscribe(() => {}, lastIdentity);
+  resolutions.push(service.resolve(lastIdentity));
+  requests.forEach((request, index) =>
+    request.resolve({ label: `item-${index}` })
+  );
+  await Promise.all(resolutions);
+
+  const firstIdentity = { ...identity, entityId: "burst-0" };
+  const retry = service.resolve(firstIdentity);
+  await Promise.resolve();
+  assert.equal(calls.get("burst-0"), 2);
+  requests[0]!.resolve({ label: "retried" });
+  await retry;
+  unsubscribe();
+});
+
+test("duplicate listener subscriptions unsubscribe independently", async () => {
+  const service = createRichTextMentionService({
+    providers: [createProvider(() => ({ label: "resolved" }))]
+  });
+  let notifications = 0;
+  const listener = () => {
+    notifications += 1;
+  };
+  const firstUnsubscribe = service.subscribe(listener, identity);
+  const secondUnsubscribe = service.subscribe(listener, {
+    ...identity,
+    entityId: "app-2"
+  });
+  firstUnsubscribe();
+
+  await service.resolve({ ...identity, entityId: "app-2" });
+  assert.equal(notifications > 0, true);
+  const afterResolve = notifications;
+  secondUnsubscribe();
+  service.invalidate();
+  assert.equal(notifications, afterResolve);
+});
+
+test("identity subscriptions only receive matching entry updates", async () => {
+  const service = createRichTextMentionService({
+    providers: [createProvider(() => ({ label: "resolved" }))]
+  });
+  let firstNotifications = 0;
+  let secondNotifications = 0;
+  const firstIdentity = { ...identity, entityId: "first" };
+  const secondIdentity = { ...identity, entityId: "second" };
+  const unsubscribeFirst = service.subscribe(() => {
+    firstNotifications += 1;
+  }, firstIdentity);
+  const unsubscribeSecond = service.subscribe(() => {
+    secondNotifications += 1;
+  }, secondIdentity);
+
+  await service.resolve(firstIdentity);
+
+  assert.equal(firstNotifications > 0, true);
+  assert.equal(secondNotifications, 0);
+  unsubscribeFirst();
+  unsubscribeSecond();
+});
+
+test("loading notifications cannot start a duplicate resolver", async () => {
+  const pending = deferred<RichTextMentionResolved | null>();
+  let calls = 0;
+  const service = createRichTextMentionService({
+    providers: [
+      createProvider(() => {
+        calls += 1;
+        return pending.promise;
+      })
+    ]
+  });
+  const unsubscribe = service.subscribe(() => {
+    void service.resolve(identity);
+  }, identity);
+
+  const resolution = service.resolve(identity);
+  await Promise.resolve();
+  assert.equal(calls, 1);
+  pending.resolve({ label: "resolved" });
+  await resolution;
+  unsubscribe();
+});
+
+test("throwing listeners do not change resolution state", async () => {
+  const service = createRichTextMentionService({
+    providers: [createProvider(() => ({ label: "resolved" }))]
+  });
+  const unsubscribe = service.subscribe(() => {
+    throw new Error("broken observer");
+  }, identity);
+
+  assert.equal((await service.resolve(identity)).state, "ready");
   unsubscribe();
 });
 

--- a/packages/ui/rich-text/src/service/RichTextMentionService.ts
+++ b/packages/ui/rich-text/src/service/RichTextMentionService.ts
@@ -1,0 +1,374 @@
+import { createRichTextTriggerRegistry } from "../plugins/triggerRegistry.ts";
+import type {
+  RichTextMentionIdentity,
+  RichTextMentionResolved
+} from "../types/mention.ts";
+import type {
+  RichTextTriggerConfig,
+  RichTextTriggerProvider,
+  RichTextTriggerQueryInput,
+  RichTextTriggerQueryMatch
+} from "../types/trigger.ts";
+import {
+  createRichTextMentionIdentityKey,
+  normalizeRichTextMentionIdentity,
+  type NormalizedRichTextMentionIdentity
+} from "./richTextMentionIdentityKey.ts";
+
+export const RICH_TEXT_MENTION_READY_TTL_MS = 300_000;
+export const RICH_TEXT_MENTION_MISSING_TTL_MS = 30_000;
+export const RICH_TEXT_MENTION_ERROR_RETRY_MS = 5_000;
+export const RICH_TEXT_MENTION_CACHE_CAPACITY = 1_000;
+
+export type RichTextMentionResolutionState =
+  | "idle"
+  | "loading"
+  | "ready"
+  | "missing"
+  | "error";
+
+export interface RichTextMentionSnapshot {
+  state: RichTextMentionResolutionState;
+  resolved?: RichTextMentionResolved;
+  updatedAtUnixMs?: number;
+}
+
+export interface RichTextMentionInvalidationSelector {
+  providerId?: string;
+  workspaceId?: string;
+  entityId?: string;
+}
+
+export type RichTextMentionDiagnosticEventName =
+  | "mention_query_completed"
+  | "mention_resolve_completed"
+  | "mention_cache_invalidated";
+
+export interface RichTextMentionDiagnosticEvent {
+  name: RichTextMentionDiagnosticEventName;
+  providerId: string;
+  outcome: "success" | "missing" | "error";
+  cacheStatus: "hit" | "miss" | "stale" | "invalidated";
+  durationMs: number;
+}
+
+export interface CreateRichTextMentionServiceInput {
+  providers: readonly RichTextTriggerProvider[];
+  now?: () => number;
+  diagnostics?: (event: RichTextMentionDiagnosticEvent) => void;
+}
+
+export interface RichTextMentionService {
+  listProviders(): readonly RichTextTriggerProvider[];
+  getProvider(providerId: string): RichTextTriggerProvider | undefined;
+  listTriggerConfigs(): readonly RichTextTriggerConfig[];
+  query(
+    input: RichTextTriggerQueryInput
+  ): Promise<readonly RichTextTriggerQueryMatch[]>;
+  resolve(identity: RichTextMentionIdentity): Promise<RichTextMentionSnapshot>;
+  getSnapshot(identity: RichTextMentionIdentity): RichTextMentionSnapshot;
+  invalidate(selector?: RichTextMentionInvalidationSelector): void;
+  subscribe(
+    listener: () => void,
+    identity?: RichTextMentionIdentity
+  ): () => void;
+  dispose(): void;
+}
+
+interface MentionCacheEntry {
+  identity: NormalizedRichTextMentionIdentity;
+  key: string;
+  snapshot: RichTextMentionSnapshot;
+  expiresAt: number;
+  lastAccess: number;
+  revision: number;
+  subscriberCount: number;
+  inFlight?: Promise<RichTextMentionSnapshot>;
+  invalidatedWhileInFlight: boolean;
+}
+
+const idleSnapshot: RichTextMentionSnapshot = Object.freeze({ state: "idle" });
+
+export function createRichTextMentionService(
+  input: CreateRichTextMentionServiceInput
+): RichTextMentionService {
+  const registry = createRichTextTriggerRegistry(input.providers);
+  const now = input.now ?? Date.now;
+  const entries = new Map<string, MentionCacheEntry>();
+  const listeners = new Set<() => void>();
+  let disposed = false;
+
+  const emit = (event: RichTextMentionDiagnosticEvent): void => {
+    input.diagnostics?.(event);
+  };
+
+  const notify = (): void => {
+    if (disposed) return;
+    for (const listener of [...listeners]) listener();
+  };
+
+  const evictIfNeeded = (): void => {
+    if (entries.size <= RICH_TEXT_MENTION_CACHE_CAPACITY) return;
+    const candidates = [...entries.values()]
+      .filter((entry) => !entry.inFlight && entry.subscriberCount === 0)
+      .sort((left, right) => left.lastAccess - right.lastAccess);
+    while (
+      entries.size > RICH_TEXT_MENTION_CACHE_CAPACITY &&
+      candidates.length > 0
+    ) {
+      const entry = candidates.shift();
+      if (entry) entries.delete(entry.key);
+    }
+  };
+
+  const getOrCreateEntry = (
+    identity: RichTextMentionIdentity
+  ): MentionCacheEntry => {
+    const normalized = normalizeRichTextMentionIdentity(identity);
+    const key = createRichTextMentionIdentityKey(normalized);
+    const existing = entries.get(key);
+    if (existing) {
+      existing.identity = normalized;
+      existing.lastAccess = now();
+      return existing;
+    }
+    const created: MentionCacheEntry = {
+      identity: normalized,
+      key,
+      snapshot: idleSnapshot,
+      expiresAt: 0,
+      lastAccess: now(),
+      revision: 0,
+      subscriberCount: 0,
+      invalidatedWhileInFlight: false
+    };
+    entries.set(key, created);
+    evictIfNeeded();
+    return created;
+  };
+
+  const startResolve = (
+    entry: MentionCacheEntry
+  ): Promise<RichTextMentionSnapshot> => {
+    if (entry.inFlight) return entry.inFlight;
+    if (disposed) return Promise.resolve(entry.snapshot);
+
+    const startedAt = now();
+    const requestRevision = entry.revision;
+    const previousReady =
+      entry.snapshot.state === "ready" ? entry.snapshot : undefined;
+    if (!previousReady) {
+      entry.snapshot = Object.freeze({ state: "loading" });
+      notify();
+    }
+
+    const promise = Promise.resolve()
+      .then(async () => {
+        const provider = registry.getProvider(entry.identity.providerId);
+        const resolved = provider?.resolveMention
+          ? await provider.resolveMention(entry.identity)
+          : null;
+        if (disposed) return entry.snapshot;
+
+        const completedAt = now();
+        if (resolved) {
+          entry.snapshot = Object.freeze({
+            state: "ready",
+            resolved,
+            updatedAtUnixMs: completedAt
+          });
+          entry.expiresAt = completedAt + RICH_TEXT_MENTION_READY_TTL_MS;
+          emit({
+            name: "mention_resolve_completed",
+            providerId: entry.identity.providerId,
+            outcome: "success",
+            cacheStatus: previousReady ? "stale" : "miss",
+            durationMs: Math.max(0, completedAt - startedAt)
+          });
+        } else {
+          entry.snapshot = Object.freeze({
+            state: "missing",
+            updatedAtUnixMs: completedAt
+          });
+          entry.expiresAt = completedAt + RICH_TEXT_MENTION_MISSING_TTL_MS;
+          emit({
+            name: "mention_resolve_completed",
+            providerId: entry.identity.providerId,
+            outcome: "missing",
+            cacheStatus: previousReady ? "stale" : "miss",
+            durationMs: Math.max(0, completedAt - startedAt)
+          });
+        }
+        notify();
+        return entry.snapshot;
+      })
+      .catch(() => {
+        if (disposed) return entry.snapshot;
+        const completedAt = now();
+        if (previousReady) {
+          entry.snapshot = previousReady;
+        } else {
+          entry.snapshot = Object.freeze({
+            state: "error",
+            updatedAtUnixMs: completedAt
+          });
+        }
+        entry.expiresAt = completedAt + RICH_TEXT_MENTION_ERROR_RETRY_MS;
+        emit({
+          name: "mention_resolve_completed",
+          providerId: entry.identity.providerId,
+          outcome: "error",
+          cacheStatus: previousReady ? "stale" : "miss",
+          durationMs: Math.max(0, completedAt - startedAt)
+        });
+        notify();
+        return entry.snapshot;
+      })
+      .finally(() => {
+        entry.inFlight = undefined;
+        const needsTrailingResolve =
+          !disposed &&
+          (entry.invalidatedWhileInFlight ||
+            entry.revision !== requestRevision);
+        entry.invalidatedWhileInFlight = false;
+        if (needsTrailingResolve) {
+          void startResolve(entry);
+        }
+      });
+    entry.inFlight = promise;
+    return promise;
+  };
+
+  const service: RichTextMentionService = {
+    listProviders: registry.listProviders,
+    getProvider: registry.getProvider,
+    listTriggerConfigs: registry.listTriggerConfigs,
+    async query(queryInput) {
+      const startedAt = now();
+      try {
+        const matches = await registry.query(queryInput);
+        emit({
+          name: "mention_query_completed",
+          providerId: "*",
+          outcome: "success",
+          cacheStatus: "miss",
+          durationMs: Math.max(0, now() - startedAt)
+        });
+        return matches;
+      } catch (error) {
+        emit({
+          name: "mention_query_completed",
+          providerId: "*",
+          outcome: "error",
+          cacheStatus: "miss",
+          durationMs: Math.max(0, now() - startedAt)
+        });
+        throw error;
+      }
+    },
+    resolve(identity) {
+      const entry = getOrCreateEntry(identity);
+      const currentTime = now();
+      if (
+        entry.snapshot.state !== "idle" &&
+        entry.snapshot.state !== "loading" &&
+        currentTime < entry.expiresAt
+      ) {
+        emit({
+          name: "mention_resolve_completed",
+          providerId: entry.identity.providerId,
+          outcome:
+            entry.snapshot.state === "ready"
+              ? "success"
+              : entry.snapshot.state === "missing"
+                ? "missing"
+                : "error",
+          cacheStatus: "hit",
+          durationMs: 0
+        });
+        return Promise.resolve(entry.snapshot);
+      }
+      if (entry.inFlight) {
+        return entry.snapshot.state === "ready"
+          ? Promise.resolve(entry.snapshot)
+          : entry.inFlight;
+      }
+      if (entry.snapshot.state === "ready") {
+        void startResolve(entry);
+        return Promise.resolve(entry.snapshot);
+      }
+      return startResolve(entry);
+    },
+    getSnapshot(identity) {
+      const key = createRichTextMentionIdentityKey(identity);
+      const entry = entries.get(key);
+      if (!entry) return idleSnapshot;
+      entry.lastAccess = now();
+      return entry.snapshot;
+    },
+    invalidate(selector) {
+      if (disposed) return;
+      const normalizedProviderId = selector?.providerId?.trim();
+      const normalizedEntityId = selector?.entityId?.trim();
+      const entriesToRefresh: MentionCacheEntry[] = [];
+      let invalidated = 0;
+      for (const entry of entries.values()) {
+        if (
+          normalizedProviderId &&
+          entry.identity.providerId !== normalizedProviderId
+        ) {
+          continue;
+        }
+        if (
+          normalizedEntityId &&
+          entry.identity.entityId !== normalizedEntityId
+        ) {
+          continue;
+        }
+        if (
+          selector?.workspaceId &&
+          entry.identity.scope?.workspaceId !== selector.workspaceId
+        ) {
+          continue;
+        }
+        entry.revision += 1;
+        entry.expiresAt = 0;
+        if (entry.inFlight) entry.invalidatedWhileInFlight = true;
+        if (entry.subscriberCount > 0 && !entry.inFlight) {
+          entriesToRefresh.push(entry);
+        }
+        invalidated += 1;
+      }
+      emit({
+        name: "mention_cache_invalidated",
+        providerId: normalizedProviderId ?? "*",
+        outcome: "success",
+        cacheStatus: "invalidated",
+        durationMs: 0
+      });
+      if (invalidated > 0) notify();
+      for (const entry of entriesToRefresh) void startResolve(entry);
+    },
+    subscribe(listener, identity) {
+      if (disposed) return () => {};
+      listeners.add(listener);
+      const entry = identity ? getOrCreateEntry(identity) : undefined;
+      if (entry) entry.subscriberCount += 1;
+      return () => {
+        listeners.delete(listener);
+        if (entry) {
+          entry.subscriberCount = Math.max(0, entry.subscriberCount - 1);
+          evictIfNeeded();
+        }
+      };
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      listeners.clear();
+      entries.clear();
+    }
+  };
+
+  return service;
+}

--- a/packages/ui/rich-text/src/service/RichTextMentionService.ts
+++ b/packages/ui/rich-text/src/service/RichTextMentionService.ts
@@ -95,16 +95,35 @@ export function createRichTextMentionService(
   const registry = createRichTextTriggerRegistry(input.providers);
   const now = input.now ?? Date.now;
   const entries = new Map<string, MentionCacheEntry>();
-  const listeners = new Set<() => void>();
+  const subscriptions = new Set<{
+    key?: string;
+    listener: () => void;
+  }>();
   let disposed = false;
 
   const emit = (event: RichTextMentionDiagnosticEvent): void => {
-    input.diagnostics?.(event);
+    try {
+      input.diagnostics?.(event);
+    } catch {
+      // Diagnostics are observational and must never change mention behavior.
+    }
   };
 
-  const notify = (): void => {
+  const notify = (changedKeys?: ReadonlySet<string>): void => {
     if (disposed) return;
-    for (const listener of [...listeners]) listener();
+    for (const subscription of [...subscriptions]) {
+      if (
+        !subscription.key ||
+        !changedKeys ||
+        changedKeys.has(subscription.key)
+      ) {
+        try {
+          subscription.listener();
+        } catch {
+          // One observer must not interrupt cache transitions or other observers.
+        }
+      }
+    }
   };
 
   const evictIfNeeded = (): void => {
@@ -157,11 +176,6 @@ export function createRichTextMentionService(
     const requestRevision = entry.revision;
     const previousReady =
       entry.snapshot.state === "ready" ? entry.snapshot : undefined;
-    if (!previousReady) {
-      entry.snapshot = Object.freeze({ state: "loading" });
-      notify();
-    }
-
     const promise = Promise.resolve()
       .then(async () => {
         const provider = registry.getProvider(entry.identity.providerId);
@@ -199,7 +213,7 @@ export function createRichTextMentionService(
             durationMs: Math.max(0, completedAt - startedAt)
           });
         }
-        notify();
+        notify(new Set([entry.key]));
         return entry.snapshot;
       })
       .catch(() => {
@@ -221,7 +235,7 @@ export function createRichTextMentionService(
           cacheStatus: previousReady ? "stale" : "miss",
           durationMs: Math.max(0, completedAt - startedAt)
         });
-        notify();
+        notify(new Set([entry.key]));
         return entry.snapshot;
       })
       .finally(() => {
@@ -234,8 +248,13 @@ export function createRichTextMentionService(
         if (needsTrailingResolve) {
           void startResolve(entry);
         }
+        evictIfNeeded();
       });
     entry.inFlight = promise;
+    if (!previousReady) {
+      entry.snapshot = Object.freeze({ state: "loading" });
+      notify(new Set([entry.key]));
+    }
     return promise;
   };
 
@@ -311,6 +330,7 @@ export function createRichTextMentionService(
       const normalizedProviderId = selector?.providerId?.trim();
       const normalizedEntityId = selector?.entityId?.trim();
       const entriesToRefresh: MentionCacheEntry[] = [];
+      const invalidatedKeys = new Set<string>();
       let invalidated = 0;
       for (const entry of entries.values()) {
         if (
@@ -337,6 +357,7 @@ export function createRichTextMentionService(
         if (entry.subscriberCount > 0 && !entry.inFlight) {
           entriesToRefresh.push(entry);
         }
+        invalidatedKeys.add(entry.key);
         invalidated += 1;
       }
       emit({
@@ -346,16 +367,24 @@ export function createRichTextMentionService(
         cacheStatus: "invalidated",
         durationMs: 0
       });
-      if (invalidated > 0) notify();
+      if (invalidated > 0) notify(invalidatedKeys);
       for (const entry of entriesToRefresh) void startResolve(entry);
     },
     subscribe(listener, identity) {
       if (disposed) return () => {};
-      listeners.add(listener);
       const entry = identity ? getOrCreateEntry(identity) : undefined;
-      if (entry) entry.subscriberCount += 1;
+      const subscription = { listener, key: entry?.key };
+      subscriptions.add(subscription);
+      if (entry) {
+        entry.subscriberCount += 1;
+        if (!entries.has(entry.key)) entries.set(entry.key, entry);
+        evictIfNeeded();
+      }
+      let subscribed = true;
       return () => {
-        listeners.delete(listener);
+        if (!subscribed) return;
+        subscribed = false;
+        subscriptions.delete(subscription);
         if (entry) {
           entry.subscriberCount = Math.max(0, entry.subscriberCount - 1);
           evictIfNeeded();
@@ -365,7 +394,7 @@ export function createRichTextMentionService(
     dispose() {
       if (disposed) return;
       disposed = true;
-      listeners.clear();
+      subscriptions.clear();
       entries.clear();
     }
   };

--- a/packages/ui/rich-text/src/service/index.ts
+++ b/packages/ui/rich-text/src/service/index.ts
@@ -1,0 +1,20 @@
+export {
+  RICH_TEXT_MENTION_CACHE_CAPACITY,
+  RICH_TEXT_MENTION_ERROR_RETRY_MS,
+  RICH_TEXT_MENTION_MISSING_TTL_MS,
+  RICH_TEXT_MENTION_READY_TTL_MS,
+  createRichTextMentionService,
+  type CreateRichTextMentionServiceInput,
+  type RichTextMentionDiagnosticEvent,
+  type RichTextMentionDiagnosticEventName,
+  type RichTextMentionInvalidationSelector,
+  type RichTextMentionResolutionState,
+  type RichTextMentionService,
+  type RichTextMentionSnapshot
+} from "./RichTextMentionService.ts";
+export {
+  canonicalizeRichTextMentionScope,
+  createRichTextMentionIdentityKey,
+  normalizeRichTextMentionIdentity,
+  type NormalizedRichTextMentionIdentity
+} from "./richTextMentionIdentityKey.ts";

--- a/packages/ui/rich-text/src/service/richTextMentionIdentityKey.ts
+++ b/packages/ui/rich-text/src/service/richTextMentionIdentityKey.ts
@@ -1,0 +1,52 @@
+import type { RichTextMentionIdentity } from "../types/mention.ts";
+
+export interface NormalizedRichTextMentionIdentity extends RichTextMentionIdentity {
+  providerId: string;
+  entityId: string;
+  scope?: Readonly<Record<string, string>>;
+}
+
+export function canonicalizeRichTextMentionScope(
+  scope: RichTextMentionIdentity["scope"]
+): string {
+  if (!scope) {
+    return "{}";
+  }
+
+  const sortedScope = Object.fromEntries(
+    Object.entries(scope).sort(([left], [right]) => left.localeCompare(right))
+  );
+  return JSON.stringify(sortedScope);
+}
+
+export function normalizeRichTextMentionIdentity(
+  identity: RichTextMentionIdentity
+): NormalizedRichTextMentionIdentity {
+  const providerId = identity.providerId.trim();
+  const entityId = identity.entityId.trim();
+  if (!providerId) {
+    throw new Error("Rich text mention provider id is required.");
+  }
+  if (!entityId) {
+    throw new Error("Rich text mention entity id is required.");
+  }
+
+  const scopeEntries = Object.entries(identity.scope ?? {}).sort(
+    ([left], [right]) => left.localeCompare(right)
+  );
+  return {
+    providerId,
+    entityId,
+    label: identity.label,
+    ...(scopeEntries.length > 0
+      ? { scope: Object.freeze(Object.fromEntries(scopeEntries)) }
+      : {})
+  };
+}
+
+export function createRichTextMentionIdentityKey(
+  identity: RichTextMentionIdentity
+): string {
+  const normalized = normalizeRichTextMentionIdentity(identity);
+  return `${normalized.providerId}\0${normalized.entityId}\0${canonicalizeRichTextMentionScope(normalized.scope)}`;
+}

--- a/packages/ui/rich-text/src/service/richTextMentionIdentityKey.ts
+++ b/packages/ui/rich-text/src/service/richTextMentionIdentityKey.ts
@@ -6,6 +6,10 @@ export interface NormalizedRichTextMentionIdentity extends RichTextMentionIdenti
   scope?: Readonly<Record<string, string>>;
 }
 
+function compareScopeKeys(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
 export function canonicalizeRichTextMentionScope(
   scope: RichTextMentionIdentity["scope"]
 ): string {
@@ -14,7 +18,9 @@ export function canonicalizeRichTextMentionScope(
   }
 
   const sortedScope = Object.fromEntries(
-    Object.entries(scope).sort(([left], [right]) => left.localeCompare(right))
+    Object.entries(scope).sort(([left], [right]) =>
+      compareScopeKeys(left, right)
+    )
   );
   return JSON.stringify(sortedScope);
 }
@@ -32,7 +38,7 @@ export function normalizeRichTextMentionIdentity(
   }
 
   const scopeEntries = Object.entries(identity.scope ?? {}).sort(
-    ([left], [right]) => left.localeCompare(right)
+    ([left], [right]) => compareScopeKeys(left, right)
   );
   return {
     providerId,

--- a/packages/ui/rich-text/tsup.config.ts
+++ b/packages/ui/rich-text/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     "core/index": "src/core/index.ts",
     "editor/index": "src/editor/index.ts",
     "plugins/index": "src/plugins/index.ts",
+    "service/index": "src/service/index.ts",
     "types/index": "src/types/index.ts"
   },
   format: ["esm"],

--- a/packages/ui/system/src/components/mention-pill/mention-pill.spec.tsx
+++ b/packages/ui/system/src/components/mention-pill/mention-pill.spec.tsx
@@ -51,4 +51,38 @@ describe("MentionPill", () => {
       container.querySelector('[data-mention-pill-fallback-icon="true"]')
     ).toBeInTheDocument();
   });
+
+  it("retries image loading when the resolved URL changes", () => {
+    const { container, rerender } = render(
+      <MentionPill
+        iconUrl="https://example.test/old.png"
+        kind="app"
+        label="Weather"
+      />
+    );
+
+    fireEvent.error(container.querySelector("img")!);
+    expect(container.querySelector("img")).not.toBeInTheDocument();
+
+    rerender(
+      <MentionPill
+        iconUrl="https://example.test/new.png"
+        kind="app"
+        label="Weather"
+      />
+    );
+    expect(container.querySelector("img")).toHaveAttribute(
+      "src",
+      "https://example.test/new.png"
+    );
+  });
+
+  it("uses a semantic icon when no image URL is available", () => {
+    const { container } = render(<MentionPill kind="issue" label="Issue" />);
+
+    expect(container.querySelector("img")).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-mention-pill-fallback-icon="true"]')
+    ).toBeInTheDocument();
+  });
 });

--- a/packages/ui/system/src/components/mention-pill/mention-pill.spec.tsx
+++ b/packages/ui/system/src/components/mention-pill/mention-pill.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { TooltipProvider } from "../tooltip/tooltip";
 import { MentionPill } from "./mention-pill";
@@ -27,6 +27,28 @@ describe("MentionPill", () => {
     expect(screen.getByText("README.md")).toBeInTheDocument();
     expect(
       document.querySelector('[data-slot="tooltip-trigger"]')
+    ).toBeInTheDocument();
+  });
+
+  it("reveals the semantic fallback when a custom icon fails", () => {
+    const { container } = render(
+      <MentionPill
+        iconUrl="https://example.test/missing.png"
+        kind="app"
+        label="Weather"
+      />
+    );
+    const image = container.querySelector("img");
+
+    expect(
+      container.querySelector('[data-mention-pill-fallback-icon="true"]')
+    ).not.toBeInTheDocument();
+
+    fireEvent.error(image!);
+
+    expect(container.querySelector("img")).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-mention-pill-fallback-icon="true"]')
     ).toBeInTheDocument();
   });
 });

--- a/packages/ui/system/src/components/mention-pill/mention-pill.spec.tsx
+++ b/packages/ui/system/src/components/mention-pill/mention-pill.spec.tsx
@@ -42,7 +42,7 @@ describe("MentionPill", () => {
 
     expect(
       container.querySelector('[data-mention-pill-fallback-icon="true"]')
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
 
     fireEvent.error(image!);
 
@@ -75,6 +75,22 @@ describe("MentionPill", () => {
       "src",
       "https://example.test/new.png"
     );
+  });
+
+  it("keeps the semantic icon underneath a transparent image", () => {
+    const transparentPixel =
+      "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+    const { container } = render(
+      <MentionPill iconUrl={transparentPixel} kind="app" label="Weather" />
+    );
+
+    expect(container.querySelector("img")).toHaveAttribute(
+      "src",
+      transparentPixel
+    );
+    expect(
+      container.querySelector('[data-mention-pill-fallback-icon="true"]')
+    ).toBeInTheDocument();
   });
 
   it("uses a semantic icon when no image URL is available", () => {

--- a/packages/ui/system/src/components/mention-pill/mention-pill.tsx
+++ b/packages/ui/system/src/components/mention-pill/mention-pill.tsx
@@ -13,6 +13,9 @@ import { TruncatingPillLabel } from "./truncating-pill-label";
 
 type MentionPillKind = "app" | "issue" | "session" | "file";
 type MentionPillFileKind = "file" | "folder";
+type MentionPillDataAttributes = {
+  [key: `data-${string}`]: string | number | boolean | undefined;
+};
 
 const mentionPillTokenByKind: Record<MentionPillKind, string> = {
   app: "var(--rich-text-folder)",
@@ -34,11 +37,14 @@ export interface MentionPillProps extends Omit<
 > {
   fileKind?: MentionPillFileKind;
   iconUrl?: string | null;
+  iconContainerProps?: React.ComponentProps<"span"> & MentionPillDataAttributes;
+  fallbackIconProps?: React.SVGProps<SVGSVGElement> & MentionPillDataAttributes;
   kind: MentionPillKind;
   label: React.ReactNode;
   removable?: boolean;
   removeButtonProps?: React.ComponentProps<"button">;
   summary?: React.ReactNode;
+  tooltipEnabled?: boolean;
   withTooltipProvider?: boolean;
 }
 
@@ -46,12 +52,15 @@ function MentionPill({
   className,
   fileKind = "file",
   iconUrl,
+  iconContainerProps,
+  fallbackIconProps,
   kind,
   label,
   removable = kind === "file",
   removeButtonProps,
   style,
   summary,
+  tooltipEnabled = true,
   withTooltipProvider = true,
   ...props
 }: MentionPillProps): React.JSX.Element {
@@ -102,10 +111,12 @@ function MentionPill({
       {...props}
     >
       <span
+        {...iconContainerProps}
         aria-hidden={removable ? undefined : true}
         className={cn(
           "relative grid shrink-0 place-items-center",
-          iconShellClassName
+          iconShellClassName,
+          iconContainerProps?.className
         )}
       >
         {normalizedIconUrl && failedIconUrl !== normalizedIconUrl ? (
@@ -125,10 +136,12 @@ function MentionPill({
           />
         ) : (
           <Icon
+            {...fallbackIconProps}
             className={cn(
               "col-start-1 row-start-1 text-current transition-opacity",
               removable && "group-hover:opacity-0 group-focus-within:opacity-0",
-              iconSizeClassName
+              iconSizeClassName,
+              fallbackIconProps?.className
             )}
             data-mention-pill-fallback-icon="true"
           />
@@ -148,7 +161,7 @@ function MentionPill({
         ) : null}
       </span>
       <TruncatingPillLabel
-        tooltip={tooltipText}
+        tooltip={tooltipEnabled ? tooltipText : ""}
         withTooltipProvider={withTooltipProvider}
       >
         <span>{label}</span>

--- a/packages/ui/system/src/components/mention-pill/mention-pill.tsx
+++ b/packages/ui/system/src/components/mention-pill/mention-pill.tsx
@@ -71,6 +71,7 @@ function MentionPill({
       : mentionPillTokenByKind[kind];
   const dataKind = mentionPillDataKindByKind[kind];
   const normalizedIconUrl = iconUrl?.trim() ?? "";
+  const [failedIconUrl, setFailedIconUrl] = React.useState<string | null>(null);
   const iconSizeClassName = "size-4";
   // session mentions align their icon shell with the @agent (agent-target)
   // mention, which uses a 16px (size-4) shell; other non-file kinds keep 18px.
@@ -107,25 +108,29 @@ function MentionPill({
           iconShellClassName
         )}
       >
-        {normalizedIconUrl ? (
+        {normalizedIconUrl && failedIconUrl !== normalizedIconUrl ? (
           <img
             src={normalizedIconUrl}
             alt=""
             className={cn(
-              "size-full rounded-[3px] object-cover transition-opacity",
+              "col-start-1 row-start-1 size-full rounded-[3px] object-cover transition-opacity",
               removable && "group-hover:opacity-0 group-focus-within:opacity-0"
             )}
             decoding="async"
             loading="lazy"
             draggable={false}
+            onError={() => {
+              setFailedIconUrl(normalizedIconUrl);
+            }}
           />
         ) : (
           <Icon
             className={cn(
-              "text-current transition-opacity",
+              "col-start-1 row-start-1 text-current transition-opacity",
               removable && "group-hover:opacity-0 group-focus-within:opacity-0",
               iconSizeClassName
             )}
+            data-mention-pill-fallback-icon="true"
           />
         )}
         {removable ? (

--- a/packages/ui/system/src/components/mention-pill/mention-pill.tsx
+++ b/packages/ui/system/src/components/mention-pill/mention-pill.tsx
@@ -119,6 +119,16 @@ function MentionPill({
           iconContainerProps?.className
         )}
       >
+        <Icon
+          {...fallbackIconProps}
+          className={cn(
+            "col-start-1 row-start-1 text-current transition-opacity",
+            removable && "group-hover:opacity-0 group-focus-within:opacity-0",
+            iconSizeClassName,
+            fallbackIconProps?.className
+          )}
+          data-mention-pill-fallback-icon="true"
+        />
         {normalizedIconUrl && failedIconUrl !== normalizedIconUrl ? (
           <img
             src={normalizedIconUrl}
@@ -134,18 +144,7 @@ function MentionPill({
               setFailedIconUrl(normalizedIconUrl);
             }}
           />
-        ) : (
-          <Icon
-            {...fallbackIconProps}
-            className={cn(
-              "col-start-1 row-start-1 text-current transition-opacity",
-              removable && "group-hover:opacity-0 group-focus-within:opacity-0",
-              iconSizeClassName,
-              fallbackIconProps?.className
-            )}
-            data-mention-pill-fallback-icon="true"
-          />
-        )}
+        ) : null}
         {removable ? (
           <button
             aria-label={removeButtonProps?.["aria-label"]}

--- a/packages/workspace/external-core/README.md
+++ b/packages/workspace/external-core/README.md
@@ -10,7 +10,9 @@ trusted app APIs may read or update host workspace state directly.
 `window.tuttiExternal` currently exposes:
 
 - `app.getContext()` and `app.subscribe()` for host workspace/app context.
-- `at.query()` for host-provided mention candidates.
+- `at.query()` for host-provided mention candidates, plus optional
+  `at.resolve()` and `at.subscribe()` for exact mention hydration and dirty
+  invalidation.
 - `files.select()` for user-activated workspace file picking.
 - `files.open()` for user-activated host opening/revealing of a known workspace file path.
 - `files.upload()` for trusted app upload of a browser `File`/`Blob` into the
@@ -28,23 +30,33 @@ trusted app APIs may read or update host workspace state directly.
 
 ## Rich Text At Providers
 
-Workspace apps that use `@tutti-os/ui-rich-text` can adapt host mention
-candidates from `window.tuttiExternal.at.query()` directly into rich-text trigger
-providers:
+Workspace apps that use `@tutti-os/ui-rich-text` should create one mention
+service at the app root:
 
 ```ts
-import { createTuttiExternalAtRichTextTriggerProviders } from "@tutti-os/workspace-external-core/rich-text";
+import { createTuttiExternalRichTextMentionService } from "@tutti-os/workspace-external-core/rich-text";
 
-const triggerProviders = createTuttiExternalAtRichTextTriggerProviders({
-  bridge: window.tuttiExternal,
+const mentionService = createTuttiExternalRichTextMentionService({
+  getBridge: () => window.tuttiExternal,
   providerIds: ["workspace-app", "agent-session", "agent-generated-file"]
 });
 ```
 
-Each external at provider becomes one `RichTextTriggerProvider` with the same
-provider id. This keeps rich-text categories and sections aligned with the host
-contract, while the app still owns local-only mention sources, caching policy,
-i18n labels, palette categories, row rendering, and insertion side effects.
+Pass that instance to `RichTextMentionServiceProvider` and dispose it with the
+app root. App-local providers can be supplied once through
+`appLocalProviders`; leaf inputs and message lists should not recreate adapters.
+
+The adapter feature-detects optional bridge methods. New hosts use exact
+`at.resolve()` and `at.subscribe()`. On an older query-only host, resolution
+falls back to a bounded empty-keyword query and exact provider/entity/scope
+match, while the service TTL supplies eventual refresh. The existing
+`createTuttiExternalAtRichTextTriggerProviders` factory remains available for
+older bundles.
+
+Provider ids and palette sections stay aligned with the host contract. The app
+still owns local-only mention sources, i18n labels, palette categories, row
+rendering, and insertion side effects; the shared service owns caching and
+invalidation.
 
 See `@tutti-os/ui-rich-text` for the generic trigger-provider and at-panel
 contracts.

--- a/packages/workspace/external-core/README.md
+++ b/packages/workspace/external-core/README.md
@@ -48,8 +48,9 @@ app root. App-local providers can be supplied once through
 
 The adapter feature-detects optional bridge methods. New hosts use exact
 `at.resolve()` and `at.subscribe()`. On an older query-only host, resolution
-falls back to a bounded empty-keyword query and exact provider/entity/scope
-match, while the service TTL supplies eventual refresh. The existing
+first queries by the persisted fallback label, then uses a bounded empty-keyword
+query and exact provider/entity/scope match. The service TTL supplies eventual
+refresh for hosts or provider sources without a real-time dirty event. The existing
 `createTuttiExternalAtRichTextTriggerProviders` factory remains available for
 older bundles.
 

--- a/packages/workspace/external-core/src/contracts/index.ts
+++ b/packages/workspace/external-core/src/contracts/index.ts
@@ -45,6 +45,23 @@ export interface TuttiExternalAtQueryResult {
   insert: TuttiExternalAtInsertResult;
 }
 
+export interface TuttiExternalAtResolveInput {
+  providerId: TuttiExternalAtProviderId;
+  entityId: string;
+  scope?: Readonly<Record<string, string>>;
+}
+
+export interface TuttiExternalAtResolveResult {
+  label?: string;
+  presentation?: TuttiExternalAtMentionPresentation;
+}
+
+export interface TuttiExternalAtInvalidation {
+  providerIds?: readonly TuttiExternalAtProviderId[];
+  entityIds?: readonly string[];
+  revision?: number;
+}
+
 export interface TuttiExternalAtMentionPresentation {
   agentProviderId?: string;
   agentIconUrl?: string;
@@ -268,6 +285,12 @@ export interface TuttiExternalBridge {
     query(
       input: TuttiExternalAtQueryInput
     ): Promise<TuttiExternalAtQueryResult[]>;
+    resolve?(
+      input: TuttiExternalAtResolveInput
+    ): Promise<TuttiExternalAtResolveResult | null>;
+    subscribe?(
+      listener: (event: TuttiExternalAtInvalidation) => void
+    ): () => void;
   };
   files: {
     select(
@@ -337,6 +360,13 @@ export interface TuttiExternalBridge {
 }
 
 export type TuttiExternalRendererRequest =
+  | {
+      appId: string;
+      input: TuttiExternalAtResolveInput;
+      operation: "at.resolve";
+      requestId: string;
+      workspaceId: string;
+    }
   | {
       appId: string;
       input: TuttiExternalAtQueryInput;

--- a/packages/workspace/external-core/src/core/index.test.ts
+++ b/packages/workspace/external-core/src/core/index.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   normalizeTuttiExternalAtQueryInput,
+  normalizeTuttiExternalAtResolveInput,
+  normalizeTuttiExternalAtInvalidation,
   normalizeTuttiExternalBrowserOpenUrlInput,
   normalizeTuttiExternalFileOpenInput,
   normalizeTuttiExternalFileSelectInput,
@@ -55,6 +57,57 @@ test("rejects unsupported at providers", () => {
         providers: ["file", "not-supported"]
       }),
     /unsupported provider/
+  );
+});
+
+test("normalizes exact at resolve identity and invalidation", () => {
+  assert.deepEqual(
+    normalizeTuttiExternalAtResolveInput({
+      providerId: "workspace-app",
+      entityId: " canvas ",
+      scope: { workspaceId: "workspace-1" }
+    }),
+    {
+      providerId: "workspace-app",
+      entityId: "canvas",
+      scope: { workspaceId: "workspace-1" }
+    }
+  );
+  assert.deepEqual(
+    normalizeTuttiExternalAtInvalidation({
+      providerIds: ["workspace-app", "workspace-app"],
+      entityIds: [" canvas ", "canvas"],
+      revision: 2
+    }),
+    {
+      providerIds: ["workspace-app"],
+      entityIds: ["canvas"],
+      revision: 2
+    }
+  );
+});
+
+test("rejects malformed at resolve identity and invalidation", () => {
+  assert.throws(
+    () =>
+      normalizeTuttiExternalAtResolveInput({
+        providerId: "unknown",
+        entityId: "canvas"
+      }),
+    /providerId is unsupported/
+  );
+  assert.throws(
+    () =>
+      normalizeTuttiExternalAtResolveInput({
+        providerId: "workspace-app",
+        entityId: "canvas",
+        scope: { workspaceId: 1 }
+      }),
+    /scope must contain string values/
+  );
+  assert.throws(
+    () => normalizeTuttiExternalAtInvalidation({ revision: Number.NaN }),
+    /revision must be finite/
   );
 });
 

--- a/packages/workspace/external-core/src/core/index.ts
+++ b/packages/workspace/external-core/src/core/index.ts
@@ -4,6 +4,8 @@ import {
   tuttiExternalWorkspaceAgentProviders,
   type TuttiExternalAtProviderId,
   type TuttiExternalAtQueryInput,
+  type TuttiExternalAtResolveInput,
+  type TuttiExternalAtInvalidation,
   type TuttiExternalBrowserOpenUrlInput,
   type TuttiExternalFileOpenInput,
   type TuttiExternalFileSelectInput,
@@ -99,6 +101,58 @@ export function normalizeTuttiExternalAtQueryInput(
     keyword: keywordValue,
     maxResults: normalizeMaxResults(input.maxResults),
     providers: normalizeProviders(input.providers)
+  };
+}
+
+export function normalizeTuttiExternalAtResolveInput(
+  input: unknown
+): TuttiExternalAtResolveInput {
+  if (!isRecord(input)) {
+    throw new Error("at.resolve input must be an object.");
+  }
+  if (!isTuttiExternalAtProviderId(input.providerId)) {
+    throw new Error("at.resolve providerId is unsupported.");
+  }
+  const entityId = normalizeRequiredString(
+    input.entityId,
+    "at.resolve entityId"
+  );
+  return {
+    providerId: input.providerId,
+    entityId,
+    ...(input.scope === undefined || input.scope === null
+      ? {}
+      : { scope: normalizeTuttiExternalAtScope(input.scope) })
+  };
+}
+
+export function normalizeTuttiExternalAtInvalidation(
+  input: unknown
+): TuttiExternalAtInvalidation {
+  if (!isRecord(input)) {
+    throw new Error("at invalidation must be an object.");
+  }
+  const providerIds =
+    input.providerIds === undefined
+      ? undefined
+      : normalizeProviders(input.providerIds);
+  const entityIds =
+    input.entityIds === undefined
+      ? undefined
+      : normalizeRequiredStringList(
+          input.entityIds,
+          "at invalidation entityIds"
+        );
+  if (
+    input.revision !== undefined &&
+    (typeof input.revision !== "number" || !Number.isFinite(input.revision))
+  ) {
+    throw new Error("at invalidation revision must be finite.");
+  }
+  return {
+    ...(providerIds ? { providerIds } : {}),
+    ...(entityIds ? { entityIds } : {}),
+    ...(typeof input.revision === "number" ? { revision: input.revision } : {})
   };
 }
 
@@ -696,6 +750,23 @@ function normalizeRequiredString(value: unknown, field: string): string {
     throw new Error(`${field} is required.`);
   }
   return value.trim();
+}
+
+function normalizeTuttiExternalAtScope(
+  value: unknown
+): Readonly<Record<string, string>> {
+  if (!isRecord(value)) {
+    throw new Error("at.resolve scope must be an object.");
+  }
+  const scope: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    const normalizedKey = key.trim();
+    if (!normalizedKey || typeof entry !== "string") {
+      throw new Error("at.resolve scope must contain string values.");
+    }
+    scope[normalizedKey] = entry;
+  }
+  return scope;
 }
 
 function normalizeRequiredStringList(value: unknown, field: string): string[] {

--- a/packages/workspace/external-core/src/rich-text/index.test.ts
+++ b/packages/workspace/external-core/src/rich-text/index.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   createTuttiExternalAtRichTextTriggerProvider,
   createTuttiExternalAtRichTextTriggerProviders,
+  createTuttiExternalRichTextMentionService,
   queryTuttiExternalAtRichTextTriggerItems
 } from "./index.ts";
 import type {
@@ -173,6 +174,146 @@ test("uses mention presentation icons when thumbnailUrl is absent", () => {
   assert.equal(
     provider.getItemIconUrl?.(item),
     "https://example.test/icon.png"
+  );
+});
+
+test("uses exact host resolve when the optional bridge capability exists", async () => {
+  const provider = createTuttiExternalAtRichTextTriggerProvider({
+    providerId: "workspace-app",
+    getBridge: () => ({
+      at: {
+        query: () => [],
+        resolve(input) {
+          assert.deepEqual(input, {
+            providerId: "workspace-app",
+            entityId: "canvas",
+            scope: { workspaceId: "workspace-1" }
+          });
+          return {
+            label: "Canvas",
+            presentation: { iconUrl: "canvas.png" }
+          };
+        }
+      }
+    })
+  });
+
+  assert.deepEqual(
+    await provider.resolveMention?.({
+      providerId: "workspace-app",
+      entityId: "canvas",
+      label: "Old canvas",
+      scope: { workspaceId: "workspace-1" }
+    }),
+    { label: "Canvas", presentation: { iconUrl: "canvas.png" } }
+  );
+});
+
+test("falls back to an exact identity and scope match on old hosts", async () => {
+  const calls: TuttiExternalAtQueryInput[] = [];
+  const provider = createTuttiExternalAtRichTextTriggerProvider({
+    providerId: "workspace-app",
+    bridge: {
+      at: {
+        query(input) {
+          calls.push(input);
+          return [
+            createQueryResult("workspace-app", "canvas", "Wrong scope", {
+              insert: {
+                kind: "mention",
+                mention: {
+                  entityId: "canvas",
+                  label: "Wrong scope",
+                  scope: { workspaceId: "workspace-2" }
+                }
+              }
+            }),
+            createQueryResult("workspace-app", "canvas", "Canvas", {
+              insert: {
+                kind: "mention",
+                mention: {
+                  entityId: "canvas",
+                  label: "Canvas",
+                  scope: { workspaceId: "workspace-1" },
+                  presentation: { iconUrl: "canvas.png" }
+                }
+              }
+            })
+          ];
+        }
+      }
+    }
+  });
+
+  const resolved = await provider.resolveMention?.({
+    providerId: "workspace-app",
+    entityId: "canvas",
+    label: "Old canvas",
+    scope: { workspaceId: "workspace-1" }
+  });
+  assert.deepEqual(calls, [
+    { keyword: "", maxResults: 100, providers: ["workspace-app"] }
+  ]);
+  assert.deepEqual(resolved, {
+    label: "Canvas",
+    presentation: { iconUrl: "canvas.png" }
+  });
+});
+
+test("external service invalidates from bridge events and unsubscribes", async () => {
+  let listener:
+    | ((event: { providerIds?: readonly ["workspace-app"] }) => void)
+    | undefined;
+  let unsubscribeCalls = 0;
+  let icon = "first.png";
+  const service = createTuttiExternalRichTextMentionService({
+    providerIds: ["workspace-app"],
+    getBridge: () => ({
+      at: {
+        query: () => [],
+        resolve: () => ({ presentation: { iconUrl: icon } }),
+        subscribe(nextListener) {
+          listener = nextListener;
+          return () => {
+            unsubscribeCalls += 1;
+          };
+        }
+      }
+    })
+  });
+  const mention = {
+    providerId: "workspace-app",
+    entityId: "canvas",
+    label: "Canvas"
+  };
+  await service.resolve(mention);
+  icon = "second.png";
+  listener?.({ providerIds: ["workspace-app"] });
+  await service.resolve(mention);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(
+    service.getSnapshot(mention).resolved?.presentation?.iconUrl,
+    "second.png"
+  );
+  service.dispose();
+  service.dispose();
+  assert.equal(unsubscribeCalls, 1);
+});
+
+test("external service getBridge remains SSR-safe when unavailable", async () => {
+  const service = createTuttiExternalRichTextMentionService({
+    getBridge: () => undefined,
+    providerIds: ["workspace-app"]
+  });
+  assert.equal(
+    (
+      await service.resolve({
+        providerId: "workspace-app",
+        entityId: "canvas",
+        label: "Canvas"
+      })
+    ).state,
+    "missing"
   );
 });
 

--- a/packages/workspace/external-core/src/rich-text/index.test.ts
+++ b/packages/workspace/external-core/src/rich-text/index.test.ts
@@ -252,12 +252,54 @@ test("falls back to an exact identity and scope match on old hosts", async () =>
     scope: { workspaceId: "workspace-1" }
   });
   assert.deepEqual(calls, [
-    { keyword: "", maxResults: 100, providers: ["workspace-app"] }
+    { keyword: "Old canvas", maxResults: 50, providers: ["workspace-app"] }
   ]);
   assert.deepEqual(resolved, {
     label: "Canvas",
     presentation: { iconUrl: "canvas.png" }
   });
+});
+
+test("old host resolution retries with an empty keyword after a label miss", async () => {
+  const calls: TuttiExternalAtQueryInput[] = [];
+  const provider = createTuttiExternalAtRichTextTriggerProvider({
+    providerId: "workspace-app",
+    bridge: {
+      at: {
+        query(input) {
+          calls.push(input);
+          return input.keyword
+            ? []
+            : [
+                createQueryResult("workspace-app", "canvas", "Renamed", {
+                  insert: {
+                    kind: "mention",
+                    mention: {
+                      entityId: "canvas",
+                      label: "Renamed",
+                      scope: { workspaceId: "workspace-1" }
+                    }
+                  }
+                })
+              ];
+        }
+      }
+    }
+  });
+
+  assert.deepEqual(
+    await provider.resolveMention?.({
+      providerId: "workspace-app",
+      entityId: "canvas",
+      label: "Old canvas",
+      scope: { workspaceId: "workspace-1" }
+    }),
+    { label: "Renamed", presentation: undefined }
+  );
+  assert.deepEqual(calls, [
+    { keyword: "Old canvas", maxResults: 50, providers: ["workspace-app"] },
+    { keyword: "", maxResults: 50, providers: ["workspace-app"] }
+  ]);
 });
 
 test("external service invalidates from bridge events and unsubscribes", async () => {

--- a/packages/workspace/external-core/src/rich-text/index.ts
+++ b/packages/workspace/external-core/src/rich-text/index.ts
@@ -1,13 +1,22 @@
 import {
   tuttiExternalAtProviderIds,
+  type TuttiExternalAtInvalidation,
   type TuttiExternalAtProviderId,
   type TuttiExternalAtQueryInput,
-  type TuttiExternalAtQueryResult
+  type TuttiExternalAtQueryResult,
+  type TuttiExternalAtResolveInput,
+  type TuttiExternalAtResolveResult
 } from "../contracts/index.ts";
 import type {
+  RichTextMentionIdentity,
   RichTextTriggerInsertResult,
   RichTextTriggerProvider
 } from "@tutti-os/ui-rich-text/types";
+import {
+  createRichTextMentionService,
+  canonicalizeRichTextMentionScope,
+  type RichTextMentionService
+} from "@tutti-os/ui-rich-text/service";
 
 export interface TuttiExternalAtRichTextBridge {
   at?: {
@@ -16,32 +25,51 @@ export interface TuttiExternalAtRichTextBridge {
     ):
       | Promise<readonly TuttiExternalAtQueryResult[]>
       | readonly TuttiExternalAtQueryResult[];
+    resolve?(
+      input: TuttiExternalAtResolveInput
+    ):
+      | Promise<TuttiExternalAtResolveResult | null>
+      | TuttiExternalAtResolveResult
+      | null;
+    subscribe?(
+      listener: (event: TuttiExternalAtInvalidation) => void
+    ): () => void;
   };
 }
 
 export interface CreateTuttiExternalAtRichTextTriggerProviderInput {
-  bridge: TuttiExternalAtRichTextBridge | null | undefined;
+  bridge?: TuttiExternalAtRichTextBridge | null;
+  getBridge?: () => TuttiExternalAtRichTextBridge | null | undefined;
   providerId: TuttiExternalAtProviderId;
   maxResults?: number;
 }
 
 export interface CreateTuttiExternalAtRichTextTriggerProvidersInput {
-  bridge: TuttiExternalAtRichTextBridge | null | undefined;
+  bridge?: TuttiExternalAtRichTextBridge | null;
+  getBridge?: () => TuttiExternalAtRichTextBridge | null | undefined;
   providerIds?: readonly TuttiExternalAtProviderId[];
   maxResults?: number;
 }
 
 export interface QueryTuttiExternalAtRichTextTriggerItemsInput {
-  bridge: TuttiExternalAtRichTextBridge | null | undefined;
+  bridge?: TuttiExternalAtRichTextBridge | null;
+  getBridge?: () => TuttiExternalAtRichTextBridge | null | undefined;
   keyword: string;
   providerIds?: readonly TuttiExternalAtProviderId[];
+  maxResults?: number;
+}
+
+export interface CreateTuttiExternalRichTextMentionServiceInput {
+  getBridge: () => TuttiExternalAtRichTextBridge | null | undefined;
+  providerIds?: readonly TuttiExternalAtProviderId[];
+  appLocalProviders?: readonly RichTextTriggerProvider[];
   maxResults?: number;
 }
 
 export async function queryTuttiExternalAtRichTextTriggerItems(
   input: QueryTuttiExternalAtRichTextTriggerItemsInput
 ): Promise<readonly TuttiExternalAtQueryResult[]> {
-  const bridge = input.bridge?.at;
+  const bridge = (input.getBridge?.() ?? input.bridge)?.at;
   if (!bridge) return [];
 
   const providerIds =
@@ -66,10 +94,37 @@ export function createTuttiExternalAtRichTextTriggerProvider(
     async query(queryInput) {
       return queryTuttiExternalAtRichTextTriggerItems({
         bridge: input.bridge,
+        getBridge: input.getBridge,
         keyword: queryInput.keyword,
         maxResults: queryInput.maxResults ?? input.maxResults,
         providerIds: [input.providerId]
       });
+    },
+    async resolveMention(identity) {
+      const bridge = (input.getBridge?.() ?? input.bridge)?.at;
+      if (!bridge) return null;
+      if (bridge.resolve) {
+        return bridge.resolve({
+          providerId: input.providerId,
+          entityId: identity.entityId,
+          ...(identity.scope ? { scope: identity.scope } : {})
+        });
+      }
+      const matches = await queryTuttiExternalAtRichTextTriggerItems({
+        bridge: input.bridge,
+        getBridge: input.getBridge,
+        keyword: "",
+        maxResults: 100,
+        providerIds: [input.providerId]
+      });
+      const match = matches.find((item) =>
+        matchesExternalMentionIdentity(item, identity)
+      );
+      if (!match || match.insert.kind !== "mention") return null;
+      return {
+        label: match.insert.mention.label,
+        presentation: match.insert.mention.presentation
+      };
     },
     getItemKey: (item) => item.itemId,
     getItemLabel: (item) => item.label,
@@ -95,8 +150,66 @@ export function createTuttiExternalAtRichTextTriggerProviders(
   return providerIds.map((providerId) =>
     createTuttiExternalAtRichTextTriggerProvider({
       bridge: input.bridge,
+      getBridge: input.getBridge,
       providerId,
       maxResults: input.maxResults
     })
   );
+}
+
+export function createTuttiExternalRichTextMentionService(
+  input: CreateTuttiExternalRichTextMentionServiceInput
+): RichTextMentionService {
+  const hostProviders = createTuttiExternalAtRichTextTriggerProviders({
+    getBridge: input.getBridge,
+    providerIds: input.providerIds,
+    maxResults: input.maxResults
+  });
+  const service = createRichTextMentionService({
+    providers: [...hostProviders, ...(input.appLocalProviders ?? [])]
+  });
+  const unsubscribe = input.getBridge()?.at?.subscribe?.((event) => {
+    invalidateFromExternalEvent(service, event);
+  });
+  const disposeService = service.dispose.bind(service);
+  let disposed = false;
+  service.dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    unsubscribe?.();
+    disposeService();
+  };
+  return service;
+}
+
+function matchesExternalMentionIdentity(
+  item: TuttiExternalAtQueryResult,
+  identity: RichTextMentionIdentity
+): boolean {
+  if (
+    item.providerId !== identity.providerId ||
+    item.insert.kind !== "mention"
+  ) {
+    return false;
+  }
+  return (
+    item.insert.mention.entityId.trim() === identity.entityId.trim() &&
+    canonicalizeRichTextMentionScope(item.insert.mention.scope) ===
+      canonicalizeRichTextMentionScope(identity.scope)
+  );
+}
+
+function invalidateFromExternalEvent(
+  service: RichTextMentionService,
+  event: TuttiExternalAtInvalidation
+): void {
+  const providerIds = event.providerIds?.length
+    ? event.providerIds
+    : [undefined];
+  const entityIds = event.entityIds?.length ? event.entityIds : [undefined];
+  for (const providerId of providerIds) {
+    for (const entityId of entityIds) {
+      service.invalidate({ providerId, entityId });
+    }
+  }
 }

--- a/packages/workspace/external-core/src/rich-text/index.ts
+++ b/packages/workspace/external-core/src/rich-text/index.ts
@@ -110,21 +110,29 @@ export function createTuttiExternalAtRichTextTriggerProvider(
           ...(identity.scope ? { scope: identity.scope } : {})
         });
       }
-      const matches = await queryTuttiExternalAtRichTextTriggerItems({
-        bridge: input.bridge,
-        getBridge: input.getBridge,
-        keyword: "",
-        maxResults: 100,
-        providerIds: [input.providerId]
-      });
-      const match = matches.find((item) =>
-        matchesExternalMentionIdentity(item, identity)
-      );
-      if (!match || match.insert.kind !== "mention") return null;
-      return {
-        label: match.insert.mention.label,
-        presentation: match.insert.mention.presentation
-      };
+      const fallbackKeywords = [
+        identity.label.trim().replace(/^@+/, "").trim(),
+        ""
+      ].filter((keyword, index, values) => values.indexOf(keyword) === index);
+      for (const keyword of fallbackKeywords) {
+        const matches = await queryTuttiExternalAtRichTextTriggerItems({
+          bridge: input.bridge,
+          getBridge: input.getBridge,
+          keyword,
+          maxResults: 50,
+          providerIds: [input.providerId]
+        });
+        const match = matches.find((item) =>
+          matchesExternalMentionIdentity(item, identity)
+        );
+        if (match?.insert.kind === "mention") {
+          return {
+            label: match.insert.mention.label,
+            presentation: match.insert.mention.presentation
+          };
+        }
+      }
+      return null;
     },
     getItemKey: (item) => item.itemId,
     getItemLabel: (item) => item.label,

--- a/tools/scripts/check-ui-boundaries.mjs
+++ b/tools/scripts/check-ui-boundaries.mjs
@@ -257,6 +257,7 @@ function inspectSvgAsset(relativePath) {
 
 function inspectCodeFile(relativePath, content) {
   inspectDevViteImports(relativePath, content);
+  inspectRichTextMentionBoundaries(relativePath, content);
 
   const lines = content.split("\n");
 
@@ -323,6 +324,57 @@ function inspectCodeFile(relativePath, content) {
         rule: "icon-import"
       });
     }
+  }
+}
+
+function inspectRichTextMentionBoundaries(relativePath, content) {
+  if (relativePath.startsWith("packages/ui/rich-text/src/service/")) {
+    for (const match of matchImportSpecifierLocations(content)) {
+      if (
+        match.specifier === "@tutti-os/workspace-external-core" ||
+        match.specifier.startsWith("@tutti-os/workspace-external-core/") ||
+        match.specifier.includes("apps/desktop") ||
+        /(?:^|\/)tsh(?:\/|$)/.test(match.specifier)
+      ) {
+        violations.push({
+          file: relativePath,
+          line: match.line,
+          message:
+            "ui-rich-text service must remain host agnostic; move host bridge imports into an adapter",
+          rule: "mention-service-host-import"
+        });
+      }
+    }
+  }
+
+  if (relativePath === "packages/agent/gui/shared/AgentMessageMarkdown.tsx") {
+    reportDirectMentionImages(relativePath, content, false);
+  }
+  if (
+    relativePath ===
+    "packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx"
+  ) {
+    reportDirectMentionImages(relativePath, content, true);
+  }
+}
+
+function reportDirectMentionImages(relativePath, content, allowFileThumbnail) {
+  for (const match of content.matchAll(/<img\b/g)) {
+    const index = match.index ?? 0;
+    const nearbyPrefix = content.slice(Math.max(0, index - 500), index);
+    if (
+      allowFileThumbnail &&
+      nearbyPrefix.includes('data-agent-mention-file-thumb="true"')
+    ) {
+      continue;
+    }
+    violations.push({
+      file: relativePath,
+      line: lineNumberAt(content, index),
+      message:
+        "AgentGUI mention icons must render through MentionPill so image failures keep a semantic fallback",
+      rule: "mention-icon-primitive"
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

- add a host-scoped `RichTextMentionService` with exact identity resolution, single-flight caching, bounded TTL/LRU behavior, keyed invalidation, diagnostics, and React adapters
- extend workspace external contracts with optional `at.resolve` / `at.subscribe`, preserving old-host query fallback and enforcing workspace-app host boundaries
- wire Desktop workspace and standalone roots, AgentGUI Markdown/node views, and the shared `MentionPill` fallback so app/group-chat/readonly mentions render icons consistently
- document the durable identity-only Markdown contract and add package boundary protection

Supersedes #1314.

## Validation

- `pnpm check:full` — 18/18 tasks passed
- `pnpm check:changed` — 18/18 lanes passed
- AgentGUI full suite — 1,796 tests passed
- Desktop full suite — 1,489 passed, 2 skipped
- ui-rich-text — 107 tests passed
- workspace-external-core — 44 tests passed
- package builds and packed export verification passed
- three independent review passes completed; all correctness/security blockers resolved

## Compatibility

Legacy providers and old workspace-app hosts continue to work. New consumers can register the service once at the host root; presentation metadata remains runtime-only and is not serialized into Markdown.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->