### PR TITLE
fix(agent-gui): reconcile message gaps after reconnect

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
@@ -25,7 +25,10 @@ import {
   agentActivitySessionFromTuttidSession,
   agentActivityTurnFromTuttidTurn
 } from "../desktopAgentActivityAdapter.ts";
-import { reconcileAgentSessionMessagePages } from "./workspaceAgentActivityReconcileMessages.ts";
+import {
+  analyzeInlineMessageVersionContinuity,
+  reconcileAgentSessionMessagePages
+} from "./workspaceAgentActivityReconcileMessages.ts";
 import type {
   AgentActivitySessionDetail,
   WorkspaceAgentActivityBridgeEvent,
@@ -56,6 +59,8 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
   private readonly eventStreamDisposables: Array<() => void> = [];
   private disposed = false;
   private eventStreamStarted = false;
+  private eventStreamConnectionState: "connected" | "disconnected" | null =
+    null;
 
   protected constructor(
     dependencies: WorkspaceAgentActivityReconcileDependencies
@@ -435,12 +440,19 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
       ),
       eventStreamClient.subscribeConnectionState((state) => {
         if (state !== "connected" && state !== "disconnected") return;
+        const recoveredFromDisconnect =
+          this.eventStreamConnectionState === "disconnected" &&
+          state === "connected";
+        this.eventStreamConnectionState = state;
         for (const [workspaceId, entry] of this.entries) {
           entry.engine.dispatch({
             status: state,
             type: "engine/connectionChanged",
             workspaceId
           });
+          if (recoveredFromDisconnect) {
+            this.reconcileCachedSessionMessagesAfterReconnect(workspaceId);
+          }
         }
       })
     );
@@ -451,6 +463,25 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
         level: "warn"
       });
     });
+  }
+
+  private reconcileCachedSessionMessagesAfterReconnect(
+    workspaceId: string
+  ): void {
+    const messagesBySessionId =
+      this.activitySnapshot(workspaceId).sessionMessagesById;
+    for (const [agentSessionId, messages] of Object.entries(
+      messagesBySessionId
+    )) {
+      if (messages.length === 0) continue;
+      this.entry(workspaceId).engine.dispatch({
+        agentSessionId,
+        needsMessages: true,
+        needsState: false,
+        type: "session/reconcileRequested",
+        workspaceId
+      });
+    }
   }
 
   private async reconcileAgentActivityUpdate(
@@ -501,7 +532,16 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
     }
     const hasCachedSession = this.hasCachedSession(workspaceId, agentSessionId);
     const messages = parseInlineActivityMessages(input);
-    if (messages.length > 0) {
+    const cachedMessages =
+      this.activitySnapshot(workspaceId).sessionMessagesById[agentSessionId] ??
+      [];
+    const inlineContinuity = analyzeInlineMessageVersionContinuity(
+      cachedMessages,
+      messages
+    );
+    const canApplyInlineMessages =
+      messages.length > 0 && inlineContinuity.continuous;
+    if (canApplyInlineMessages) {
       this.entry(workspaceId).engine.dispatch(
         {
           messages,
@@ -513,6 +553,13 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
       for (const message of messages) {
         this.emitSessionEvent(workspaceId, hostMessageEventFromCore(message));
       }
+    } else if (messages.length > 0) {
+      this.reportReconcileTrace({
+        agentSessionId,
+        traceEvent: "realtime.message_version_gap_detected",
+        workspaceId,
+        fields: { ...inlineContinuity }
+      });
     }
     if (
       input.eventType === "turn_update" ||
@@ -520,7 +567,7 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
     ) {
       this.markNextReconcileLive(workspaceId, agentSessionId);
     }
-    const inlineApplied = hasCachedSession && messages.length > 0;
+    const inlineApplied = hasCachedSession && canApplyInlineMessages;
     this.entry(workspaceId).engine.dispatch({
       agentSessionId,
       eventType: input.eventType,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AgentActivityMessage } from "@tutti-os/agent-activity-core";
+import { analyzeInlineMessageVersionContinuity } from "./workspaceAgentActivityReconcileMessages.ts";
+
+test("inline message continuity accepts snapshot cursor gaps already present in the cache", () => {
+  const result = analyzeInlineMessageVersionContinuity(
+    [message(1), message(5)],
+    [message(6), message(7)]
+  );
+
+  assert.deepEqual(result, {
+    cachedVersion: 5,
+    continuous: true,
+    firstUnseenVersion: 6,
+    latestIncomingVersion: 7
+  });
+});
+
+test("inline message continuity rejects an unseen version hole", () => {
+  const result = analyzeInlineMessageVersionContinuity(
+    [message(1)],
+    [message(3)]
+  );
+
+  assert.deepEqual(result, {
+    cachedVersion: 1,
+    continuous: false,
+    firstUnseenVersion: 3,
+    latestIncomingVersion: 3
+  });
+});
+
+test("inline message continuity accepts duplicate or stale delivery", () => {
+  assert.equal(
+    analyzeInlineMessageVersionContinuity(
+      [message(3)],
+      [message(2), message(3)]
+    ).continuous,
+    true
+  );
+});
+
+function message(version: number): AgentActivityMessage {
+  return {
+    workspaceId: "ws-1",
+    agentSessionId: "session-1",
+    messageId: `message-${version}`,
+    version,
+    turnId: "turn-1",
+    role: "assistant",
+    kind: "text",
+    payload: { text: String(version) },
+    occurredAtUnixMs: version
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.ts
@@ -14,6 +14,47 @@ interface ReconcileAgentSessionMessagePagesInput {
   workspaceId: string;
 }
 
+export interface InlineMessageVersionContinuity {
+  cachedVersion: number;
+  continuous: boolean;
+  firstUnseenVersion: number | null;
+  latestIncomingVersion: number;
+}
+
+/**
+ * Realtime messages may be folded directly only when they extend the cached
+ * per-session change cursor without a hole. Advancing the cache past a missed
+ * mutable snapshot would make every later `afterVersion` pull skip that
+ * snapshot forever, because message rows retain only their latest version.
+ */
+export function analyzeInlineMessageVersionContinuity(
+  cached: readonly AgentActivityMessage[],
+  incoming: readonly AgentActivityMessage[]
+): InlineMessageVersionContinuity {
+  const cachedVersion = latestMessageVersion(cached);
+  const incomingVersions = [
+    ...new Set(incoming.map((message) => message.version))
+  ].sort((left, right) => left - right);
+  const latestIncomingVersion = incomingVersions.at(-1) ?? 0;
+  const unseenVersions = incomingVersions.filter(
+    (version) => version > cachedVersion
+  );
+  const versionsAreValid = incomingVersions.every(
+    (version) => Number.isSafeInteger(version) && version > 0
+  );
+  const continuous =
+    versionsAreValid &&
+    unseenVersions.every(
+      (version, index) => version === cachedVersion + index + 1
+    );
+  return {
+    cachedVersion,
+    continuous,
+    firstUnseenVersion: unseenVersions[0] ?? null,
+    latestIncomingVersion
+  };
+}
+
 export async function reconcileAgentSessionMessagePages(
   input: ReconcileAgentSessionMessagePagesInput
 ): Promise<AgentActivityMessagePage> {
@@ -46,4 +87,13 @@ export async function reconcileAgentSessionMessagePages(
     ),
     messages: result.messages
   };
+}
+
+function latestMessageVersion(
+  messages: readonly AgentActivityMessage[]
+): number {
+  return messages.reduce(
+    (latest, message) => Math.max(latest, message.version),
+    0
+  );
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -595,6 +595,300 @@ test("WorkspaceAgentActivityService starts session-event streams and preserves u
   assert.deepEqual(await receivedTurnEvent, turnEvent);
 });
 
+test("WorkspaceAgentActivityService reconciles a realtime message version gap before advancing the cursor", async () => {
+  const listenersByTopic = new Map<string, (event: unknown) => void>();
+  const messageRequests: Array<Record<string, unknown>> = [];
+  const diagnostics: Array<{
+    details?: Record<string, unknown>;
+    event?: string;
+  }> = [];
+  const session = workspaceAgentSession({ status: "completed" });
+  const userMessage = {
+    agentSessionId: "session-1",
+    kind: "text",
+    messageId: "user-1",
+    occurredAtUnixMs: 1,
+    payload: { text: "Please investigate" },
+    role: "user",
+    status: "completed",
+    turnId: "turn-1",
+    version: 1
+  };
+  const runningCompaction = {
+    agentSessionId: "session-1",
+    kind: "text",
+    messageId: "compaction:turn-1",
+    occurredAtUnixMs: 2,
+    payload: {
+      noticeCommand: "compact",
+      noticeCommandStatus: "running",
+      text: "Compacting context.",
+      title: "Compacting context."
+    },
+    role: "assistant",
+    semantics: {
+      noticeCommand: "compact",
+      noticeCommandStatus: "running"
+    },
+    status: "completed",
+    turnId: "turn-1",
+    version: 2
+  };
+  const completedCompaction = {
+    ...runningCompaction,
+    occurredAtUnixMs: 3,
+    payload: {
+      noticeCommand: "compact",
+      noticeCommandStatus: "completed",
+      text: "Context compacted.",
+      title: "Context compacted."
+    },
+    semantics: {
+      noticeCommand: "compact",
+      noticeCommandStatus: "completed"
+    },
+    version: 3
+  };
+  const laterAssistantMessage = {
+    agentSessionId: "session-1",
+    kind: "text",
+    messageId: "assistant-later",
+    occurredAtUnixMs: 4,
+    payload: { text: "Later output" },
+    role: "assistant",
+    status: "completed",
+    turnId: "turn-1",
+    version: 4
+  };
+  const service = new WorkspaceAgentActivityService({
+    eventStreamClient: {
+      connect: async () => {},
+      dispose: () => {},
+      publishIntent: async () => {},
+      subscribe: (topic: string, listener: (event: unknown) => void) => {
+        listenersByTopic.set(topic, listener);
+        return () => {};
+      },
+      subscribeConnectionState: () => () => {}
+    } as never,
+    tuttidClient: {
+      getWorkspaceAgentSession: async () => ({
+        session,
+        childSessions: [],
+        turns: []
+      }),
+      listWorkspaceAgentSessionMessages: async (
+        _workspaceId: string,
+        _agentSessionId: string,
+        request: Record<string, unknown>
+      ) => {
+        messageRequests.push(request);
+        return messageRequests.length === 1
+          ? {
+              hasMore: false,
+              latestVersion: 2,
+              messages: [userMessage, runningCompaction]
+            }
+          : {
+              hasMore: false,
+              latestVersion: 4,
+              messages: [completedCompaction, laterAssistantMessage]
+            };
+      },
+      listWorkspaceAgentSessions: async () => ({
+        hasMore: false,
+        sessions: [session],
+        workspaceId: "ws-1"
+      })
+    } as unknown as TuttidClient,
+    runtimeApi: {
+      logTerminalDiagnostic: async (payload) => {
+        diagnostics.push(payload);
+      }
+    }
+  });
+
+  await service.load("ws-1");
+  await service.listSessionMessages({
+    agentSessionId: "session-1",
+    workspaceId: "ws-1"
+  });
+  assert.equal(
+    service
+      .getSnapshot("ws-1")
+      .sessionMessagesById["session-1"]?.find(
+        (message) => message.messageId === "compaction:turn-1"
+      )?.semantics?.noticeCommandStatus,
+    "running"
+  );
+
+  const activityUpdated = listenersByTopic.get("agent.activity.updated");
+  assert.ok(activityUpdated);
+  activityUpdated({
+    payload: {
+      agentSessionId: "session-1",
+      data: {
+        acceptedCount: 1,
+        agentSessionId: "session-1",
+        eventType: "message_update",
+        latestVersion: 4,
+        messages: [laterAssistantMessage],
+        workspaceId: "ws-1"
+      },
+      eventType: "message_update",
+      workspaceId: "ws-1"
+    }
+  });
+
+  for (let attempt = 0; attempt < 10 && messageRequests.length < 2; attempt++) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(messageRequests.length, 2);
+  assert.equal(messageRequests[1]?.afterVersion, 2);
+  assert.equal(
+    service
+      .getSnapshot("ws-1")
+      .sessionMessagesById["session-1"]?.find(
+        (message) => message.messageId === "compaction:turn-1"
+      )?.semantics?.noticeCommandStatus,
+    "completed"
+  );
+  assert.ok(
+    diagnostics.some(
+      (entry) =>
+        entry.event === "agent.activity.reconcile.trace" &&
+        entry.details?.traceEvent === "realtime.message_version_gap_detected" &&
+        entry.details.cachedVersion === 2 &&
+        entry.details.firstUnseenVersion === 4
+    )
+  );
+});
+
+test("WorkspaceAgentActivityService reconciles cached messages after reconnect without waiting for another event", async () => {
+  let connectionListener:
+    | ((state: "connected" | "disconnected") => void)
+    | undefined;
+  const messageRequests: Array<Record<string, unknown>> = [];
+  const session = workspaceAgentSession({ status: "completed" });
+  const userMessage = {
+    agentSessionId: "session-1",
+    kind: "text",
+    messageId: "user-1",
+    occurredAtUnixMs: 1,
+    payload: { text: "Please investigate" },
+    role: "user",
+    status: "completed",
+    turnId: "turn-1",
+    version: 1
+  };
+  const runningCompaction = {
+    agentSessionId: "session-1",
+    kind: "text",
+    messageId: "compaction:turn-1",
+    occurredAtUnixMs: 2,
+    payload: {
+      noticeCommand: "compact",
+      noticeCommandStatus: "running"
+    },
+    role: "assistant",
+    semantics: {
+      noticeCommand: "compact",
+      noticeCommandStatus: "running"
+    },
+    status: "completed",
+    turnId: "turn-1",
+    version: 2
+  };
+  const completedCompaction = {
+    ...runningCompaction,
+    occurredAtUnixMs: 3,
+    payload: {
+      noticeCommand: "compact",
+      noticeCommandStatus: "completed"
+    },
+    semantics: {
+      noticeCommand: "compact",
+      noticeCommandStatus: "completed"
+    },
+    version: 3
+  };
+  const service = new WorkspaceAgentActivityService({
+    eventStreamClient: {
+      connect: async () => {},
+      dispose: () => {},
+      publishIntent: async () => {},
+      subscribe: () => () => {},
+      subscribeConnectionState: (
+        listener: (state: "connected" | "disconnected") => void
+      ) => {
+        connectionListener = listener;
+        return () => {};
+      }
+    } as never,
+    tuttidClient: {
+      getWorkspaceAgentSession: async () => ({
+        session,
+        childSessions: [],
+        turns: []
+      }),
+      listWorkspaceAgentSessionMessages: async (
+        _workspaceId: string,
+        _agentSessionId: string,
+        request: Record<string, unknown>
+      ) => {
+        messageRequests.push(request);
+        return messageRequests.length === 1
+          ? {
+              hasMore: false,
+              latestVersion: 2,
+              messages: [userMessage, runningCompaction]
+            }
+          : {
+              hasMore: false,
+              latestVersion: 3,
+              messages: [completedCompaction]
+            };
+      },
+      listWorkspaceAgentSessions: async () => ({
+        hasMore: false,
+        sessions: [session],
+        workspaceId: "ws-1"
+      })
+    } as unknown as TuttidClient,
+    runtimeApi: { logTerminalDiagnostic: async () => {} }
+  });
+
+  await service.load("ws-1");
+  await service.listSessionMessages({
+    agentSessionId: "session-1",
+    workspaceId: "ws-1"
+  });
+  assert.ok(connectionListener);
+  connectionListener("connected");
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(messageRequests.length, 1);
+
+  connectionListener("disconnected");
+  connectionListener("connected");
+  for (let attempt = 0; attempt < 10 && messageRequests.length < 2; attempt++) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(messageRequests.length, 2);
+  assert.equal(messageRequests[1]?.afterVersion, 2);
+  assert.equal(
+    service
+      .getSnapshot("ws-1")
+      .sessionMessagesById["session-1"]?.find(
+        (message) => message.messageId === "compaction:turn-1"
+      )?.semantics?.noticeCommandStatus,
+    "completed"
+  );
+});
+
 test("WorkspaceAgentActivityService dispose releases every event stream subscription", () => {
   const activeSubscriptions = new Set<symbol>();
   const subscribe = () => {

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -571,10 +571,12 @@ invocation. UI packages must keep `provider` as the real provider identity and
 must not synthesize providers for shared or remote targets.
 
 The desktop service owns the event-stream connection. Its reconcile bridge
-maps normalized events to engine intents: append-only messages are folded
-inline, while turn, interaction, and state changes schedule authoritative HTTP
-reconciliation through the engine command port. UI consumers never retain a
-second per-session stream or merge canonical entities themselves.
+maps normalized events to engine intents: continuous versions of mutable message
+snapshots are folded inline, while a message-version gap or recovered connection
+schedules authoritative incremental message reconciliation through the engine
+command port. Turn, interaction, and state changes also schedule their
+authoritative HTTP reconciliation through that port. UI consumers never retain
+a second per-session stream or merge canonical entities themselves.
 
 Hosts may accept older provider/runtime reports with missing transcript
 ownership or ordering fields, but those gaps must be filled before events enter

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -141,12 +141,21 @@ ID.
 Historical pull and realtime push are distinct engine inputs. Workspace/session
 list pulls dispatch `session/snapshotReceived`; these hydrate history without
 creating unread completion attention. Realtime `message_update` events may fold
-their normalized append-only messages inline. Realtime turn, interaction, and
-legacy state invalidations perform an authoritative session pull, then dispatch
-`session/upserted` followed by `turn/upserted` for the realtime turn. The desktop
-bridge keeps the one-shot realtime provenance outside reducer state while that
-pull is in flight. `AgentActivitySnapshot` is a memoized projection of the
-engine state, not a separately mutable controller snapshot.
+their normalized versioned mutable message snapshots inline only when the unseen
+event versions continue from the cached high-water mark. A gap at that boundary
+means a mutable message snapshot may have been missed: the bridge must leave the
+cache at its pre-gap cursor and request an authoritative incremental pull. A
+recovered event-stream connection must also incrementally reconcile every
+session whose messages are already hydrated, so a missed final mutation does not
+depend on a later event to expose the gap. Do not require the rows already
+present in a current snapshot to be internally contiguous, because updating one
+`messageId` replaces its earlier version. Realtime turn,
+interaction, and legacy state invalidations perform an authoritative session
+pull, then dispatch `session/upserted` followed by `turn/upserted` for the
+realtime turn. The desktop bridge keeps the one-shot realtime provenance outside
+reducer state while that pull is in flight. `AgentActivitySnapshot` is a
+memoized projection of the engine state, not a separately mutable controller
+snapshot.
 
 The workspace list is root-only. After a successful workspace reconcile, the
 engine requests a state detail reconcile for every active root session. Session
@@ -2260,7 +2269,8 @@ contract from the ACP path.
 
 ```text
 agent.activity.updated
-  -> message_update parses and batches append-only messages inline
+  -> continuous message_update versions batch mutable snapshots inline
+  -> a version gap or recovered connection triggers authoritative message reconcile
   -> turn_update / interaction_update triggers authoritative session reconcile
   -> legacy state_patch triggers authoritative state reconcile
   -> live reconcile dispatches session/upserted then turn/upserted
@@ -2272,8 +2282,8 @@ agent.activity.updated
   -> AgentGUINodeView renders the new view model
 ```
 
-Only append-only `message_update` payloads use the inline fast path. Turn,
-interaction, and state changes reconcile through the authoritative session
+Only continuous versioned `message_update` payloads use the inline fast path.
+Turn, interaction, and state changes reconcile through the authoritative session
 endpoint so `activeTurnId`, pending interactions, and turn provenance stay
 consistent. UI code should debug both the event payload and the reconcile fetch
 before treating a missing transcript row as a rendering-only bug.

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -62,6 +62,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [Agent activity live updates fail after event schema changes](./agent-session-lifecycle.md#agent-activity-live-updates-fail-after-event-schema-changes)
 - [AgentGUI file-change undo reports a generic failure](./agent-session-lifecycle.md#agentgui-file-change-undo-reports-a-generic-failure)
 - [Cursor deleted files appear as created or modified](./agent-session-lifecycle.md#cursor-deleted-files-appear-as-created-or-modified)
+- [AgentGUI compaction timer keeps running after compaction completed](./agent-session-lifecycle.md#agentgui-compaction-timer-keeps-running-after-compaction-completed)
 - [AgentActivity replication repeatedly rejects message batches as invalid](./agent-session-lifecycle.md#agentactivity-replication-repeatedly-rejects-message-batches-as-invalid)
 - [Remote agent cancel does not stop the local turn](./agent-session-lifecycle.md#remote-agent-cancel-does-not-stop-the-local-turn)
 - [Claude Code cancel leaves Write/tool cards stuck in progress](./agent-session-lifecycle.md#claude-code-cancel-leaves-writetool-cards-stuck-in-progress)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1842,6 +1842,53 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [messageRouter.ts](../../../packages/agent/claude-sdk-sidecar/src/messageRouter.ts)
   [sessionRuntime.session.test.ts](../../../packages/agent/claude-sdk-sidecar/src/sessionRuntime.session.test.ts)
 
+### AgentGUI compaction timer keeps running after compaction completed
+
+- Symptom:
+  AgentGUI continues to show an increasing `Compacting context` duration after
+  the provider finished compaction. The durable compaction message and Turn are
+  already terminal, but the mounted renderer still projects the earlier
+  `noticeCommandStatus=running` snapshot.
+- Quick checks:
+  Compare the message-list requests in desktop reconcile diagnostics with the
+  durable message versions. If the renderer pulled a running compaction at
+  version N, missed its terminal update at N+1, then next requested
+  `afterVersion` at a much higher value, the local cache advanced across a
+  version hole. Confirm that the terminal row uses the same `messageId`; a new
+  compaction row or a timer-specific state bug is a different failure.
+- Root cause:
+  The realtime bridge treated the maximum version of materialized message rows
+  as a contiguous acknowledged change cursor. After an event-stream loss, it
+  applied a later inline message and advanced that maximum past the missed
+  terminal mutation. Every later `afterVersion` pull then started beyond the
+  mutation, so the authoritative completed snapshot could never repair the
+  cached running snapshot. The timer correctly kept rendering the stale running
+  lifecycle.
+- Fix:
+  Before folding realtime messages inline, compare only their unseen versions
+  with the cached high-water boundary. If the first unseen version is not the
+  next cursor, do not apply any of that event's messages; retain the old cursor
+  and request an authoritative incremental reconcile. After a disconnected
+  event stream reconnects, also incrementally reconcile every session whose
+  messages are already cached; otherwise a missed final mutation has no later
+  event that can reveal its gap. Do not require the materialized cache itself to
+  contain every historical cursor value, because mutable message rows replace
+  older versions.
+- Validation:
+  Cache a user message and a running compaction, omit the next terminal
+  compaction mutation, then deliver a later assistant message. Assert that the
+  later message is not applied inline, reconciliation requests from the
+  pre-gap cursor, and the stable compaction `messageId` becomes completed from
+  the authoritative response. Also cover valid snapshot gaps already present in
+  the cache plus duplicate and stale event delivery. Finally, omit the terminal
+  mutation as the last event, disconnect and reconnect without another activity
+  event, and verify the reconnect reconcile retrieves it from the pre-disconnect
+  cursor.
+- References:
+  [workspaceAgentActivityReconcileBridge.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts)
+  [workspaceAgentActivityReconcileMessages.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.ts)
+  [agent-gui-node.md](../../architecture/agent-gui-node.md)
+
 ### AgentActivity replication repeatedly rejects message batches as invalid
 
 - Symptom:

--- a/packages/agent/activity-core/src/inlineActivityMessages.ts
+++ b/packages/agent/activity-core/src/inlineActivityMessages.ts
@@ -14,12 +14,13 @@ import type {
 /**
  * Parse the inline `messages` array carried by a realtime `message_update`
  * event into canonical {@link AgentActivityMessage} values. This is the only
- * inline delta the bridge applies without a follow-up pull: messages are
- * append-only and self-describing, so the engine's message reducer can fold
- * them (including alias-bucket collapse) on its own. Turn and interaction
- * deltas take the authoritative reconcile path instead, so their session-level
- * effects (activeTurnId, pending-interaction pruning) come from a full session
- * fetch rather than being reconstructed here.
+ * inline delta the bridge may apply without a follow-up pull: message snapshots
+ * are versioned and self-describing, so after the bridge verifies cursor
+ * continuity, the engine's version-guarded message reducer can fold them
+ * (including alias-bucket collapse) on its own. Turn and interaction deltas take
+ * the authoritative reconcile path instead, so their session-level effects
+ * (activeTurnId, pending-interaction pruning) come from a full session fetch
+ * rather than being reconstructed here.
  */
 export function parseInlineActivityMessages(
   event: AgentActivityUpdatedEvent


### PR DESCRIPTION
## Summary

- detect unseen realtime message-version gaps before advancing the renderer cache cursor
- incrementally reconcile hydrated session messages after a disconnected-to-connected transition so a missed final mutation is recovered without waiting for another event
- document mutable message snapshot semantics and add regression coverage for both gap-triggered and reconnect-triggered recovery

## Verification

- `pnpm check:changed --tail-lines 120`
- `pnpm check:full`
- focused desktop activity tests: 38 passed
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:renderer-boundaries`

## Fix Scope Justification

- Root cause: the renderer treated the maximum version in its materialized message snapshot as a contiguous acknowledged cursor. After an event-stream loss, applying a later inline message advanced `afterVersion` beyond a missed mutable terminal update, making that update permanently unreachable.
- Why can this not be fixed at a lower layer? The daemon and SQLite projection already contain the correct terminal snapshot and version. The faulty cursor advancement and realtime-versus-pull orchestration occur at the desktop reconcile seam, so that seam must reject non-contiguous inline advancement and request the existing authoritative HTTP reconcile.

## Fallback Three Questions

- Source: loss of one or more `agent.activity.updated` events during an event-stream disconnect or reconnect.
- Why can it not be fixed at that source? The current event stream has no durable per-session replay acknowledgement that proves every message mutation was delivered before reporting connected. The renderer must therefore reconcile its durable cursor with the authoritative endpoint after a gap or recovered connection.
- Removal condition: this recovery can be removed only when the event stream provides durable resume tokens or equivalent acknowledgement semantics that guarantee all per-session message mutations are replayed in order before connection recovery completes.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->