### PR TITLE
feat(agent-host): add session management APIs

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -61,6 +61,13 @@ hooks. The `conformance` subpackage owns reusable typed lifecycle scenarios so
 the legacy `tuttid` service, the extracted Host, and downstream adapters can be
 checked against the same behavior baseline.
 
+Session read and metadata commands follow the same boundary. `GetSession`
+returns canonical truth with an optional live observation. Settings updates
+are serialized with resume and split between historical persistence and live
+runtime mutation; provider normalization stays in an adapter policy. Pin and
+canonical delete are Host commands, while authorization, transport DTOs,
+shared bindings, and local view cleanup remain adapter-owned.
+
 `store-sqlite` owns the transaction implementation. Its caller-owned
 `TransactionParticipant` seam lets an adapter append a durable outbox marker
 to the same transaction as runtime/goal operation intent, canonical facts, and

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -2,7 +2,8 @@
 
 `packages/agent/host` is the provider-neutral application boundary for
 canonical agent session and turn lifecycle orchestration. The package now owns
-the create, resume, send, durable submit-claim, canonical title, cancel,
+the create, resume, send, durable submit-claim, canonical title, session read,
+settings, pin, delete, cancel,
 interactive response, plan decision, durable runtime-operation, and complete
 goal-control/reconcile application core. `tuttid` routes those commands through
 `Host`; transport and HTTP shapes remain unchanged.
@@ -33,6 +34,15 @@ durable runtime operations, then goal operations and the goal reconcile inbox,
 and only then settles unrecoverable stale turns. Configuring a goal store
 without its runtime or inbox consumer fails recovery with
 `ErrGoalConsumerUnavailable` instead of silently accumulating work.
+
+`GetSession` reads canonical truth plus an optional live runtime observation
+without starting a provider. `UpdateSettings` serializes with runtime resume:
+historical sessions persist settings only, while live sessions update the
+runtime. Provider-specific model, reasoning, and speed normalization stays
+behind `SettingsPolicy`. `UpdatePin` mutates canonical metadata only.
+`DeleteSession` closes a live runtime before writing the canonical tombstone;
+authorization, shared bindings, transport DTOs, and local view cleanup remain
+adapter responsibilities.
 
 Adapters retain authorization and identity, transport, runtime process or VM
 selection, desktop APIs, attachment ingress, and cloud inbox/outbox behavior.

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -26,6 +26,8 @@ type SessionSeed struct {
 	Origin                  string
 	Deleted                 bool
 	ExternalResumeSupported *bool
+	Settings                agenthost.ComposerSettings
+	Pinned                  bool
 }
 
 type TurnSeed struct {
@@ -57,6 +59,9 @@ type SessionObservation struct {
 	Title             string
 	ActiveTurnID      string
 	Resumable         bool
+	Settings          agenthost.ComposerSettings
+	Pinned            bool
+	Live              bool
 }
 
 type SendObservation struct {
@@ -94,6 +99,7 @@ type Metrics struct {
 	CancelCalls              int
 	InteractiveCalls         int
 	UpdateSettingsCalls      int
+	CloseCalls               int
 	GoalControlCalls         int
 	GoalReconcileCalls       int
 	RuntimeOperationCommits  int
@@ -119,6 +125,10 @@ type Driver interface {
 	SubmitInteractive(context.Context, agenthost.SessionRef, string, agenthost.SubmitInteractiveInput) (SessionObservation, error)
 	SubmitPlanDecision(context.Context, agenthost.SessionRef, string, string, agenthost.SubmitPlanDecisionInput) (OperationObservation, error)
 	UpdateTitle(context.Context, agenthost.UpdateTitleInput) (SessionObservation, error)
+	GetSession(context.Context, agenthost.SessionRef) (SessionObservation, error)
+	UpdateSettings(context.Context, agenthost.UpdateSettingsInput) (SessionObservation, error)
+	UpdatePin(context.Context, agenthost.UpdatePinInput) (SessionObservation, error)
+	DeleteSession(context.Context, agenthost.SessionRef) (agenthost.DeleteSessionResult, error)
 	GoalControl(context.Context, agenthost.GoalControlInput) (GoalObservation, error)
 	GetGoalState(context.Context, agenthost.SessionRef) (GoalObservation, error)
 	ReconcileGoal(context.Context, agenthost.SessionRef) (GoalObservation, error)
@@ -142,6 +152,10 @@ func Scenarios() []Scenario {
 		{Name: "interactive response", run: runInteractiveResponse},
 		{Name: "plan decision", run: runPlanDecision},
 		{Name: "initial title cas", run: runInitialTitleCAS},
+		{Name: "get session", run: runGetSession},
+		{Name: "historical and live settings", run: runHistoricalAndLiveSettings},
+		{Name: "pin session", run: runPinSession},
+		{Name: "delete session", run: runDeleteSession},
 	}
 }
 
@@ -523,6 +537,111 @@ func runClearCanonicalTitle(ctx context.Context, driver Driver) error {
 	}
 	if session.Title != "" {
 		return fmt.Errorf("cleared title=%q", session.Title)
+	}
+	return nil
+}
+
+func runGetSession(ctx context.Context, driver Driver) error {
+	fixture := liveSessionFixture("session-get", "")
+	fixture.Session.Title = "canonical title"
+	fixture.Session.Settings = agenthost.ComposerSettings{Model: "model-a", PermissionModeID: "auto", Speed: "standard"}
+	fixture.Session.Pinned = true
+	if err := driver.Reset(ctx, fixture); err != nil {
+		return err
+	}
+	result, err := driver.GetSession(ctx, agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-get"})
+	if err != nil {
+		return fmt.Errorf("get session: %w", err)
+	}
+	if result.SessionID != "session-get" || result.Title != "canonical title" || !result.Live || !result.Pinned ||
+		result.Settings.Model != "model-a" || result.Settings.PermissionModeID != "auto" {
+		return fmt.Errorf("get session=%#v", result)
+	}
+	return nil
+}
+
+func runHistoricalAndLiveSettings(ctx context.Context, driver Driver) error {
+	historical := Fixture{Session: &SessionSeed{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-settings-history", Provider: "claude-code",
+		ProviderSessionID: "provider-settings-history", Cwd: "/workspace",
+		Settings: agenthost.ComposerSettings{Model: "model-a", PermissionModeID: "review"},
+	}}
+	if err := driver.Reset(ctx, historical); err != nil {
+		return err
+	}
+	permissionMode := "acceptEdits"
+	result, err := driver.UpdateSettings(ctx, agenthost.UpdateSettingsInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-settings-history",
+		Settings: agenthost.ComposerSettingsPatch{PermissionModeID: &permissionMode},
+	})
+	if err != nil {
+		return fmt.Errorf("update historical settings: %w", err)
+	}
+	if result.Live || result.Settings.Model != "model-a" || result.Settings.PermissionModeID != "acceptEdits" ||
+		driver.Metrics().UpdateSettingsCalls != 0 || driver.Metrics().ResumeCalls != 0 {
+		return fmt.Errorf("historical settings=%#v metrics=%#v", result, driver.Metrics())
+	}
+
+	live := liveSessionFixture("session-settings-live", "")
+	live.Session.Settings = agenthost.ComposerSettings{Model: "model-a", PermissionModeID: "review"}
+	if err := driver.Reset(ctx, live); err != nil {
+		return err
+	}
+	planMode := true
+	result, err = driver.UpdateSettings(ctx, agenthost.UpdateSettingsInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-settings-live",
+		Settings: agenthost.ComposerSettingsPatch{PlanMode: &planMode},
+	})
+	if err != nil {
+		return fmt.Errorf("update live settings: %w", err)
+	}
+	if !result.Live || !result.Settings.PlanMode || result.Settings.Model != "model-a" ||
+		driver.Metrics().UpdateSettingsCalls != 1 {
+		return fmt.Errorf("live settings=%#v metrics=%#v", result, driver.Metrics())
+	}
+	return nil
+}
+
+func runPinSession(ctx context.Context, driver Driver) error {
+	if err := driver.Reset(ctx, Fixture{Session: &SessionSeed{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-pin", Provider: "codex", Cwd: "/workspace",
+	}}); err != nil {
+		return err
+	}
+	result, err := driver.UpdatePin(ctx, agenthost.UpdatePinInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-pin", Pinned: true,
+	})
+	if err != nil {
+		return fmt.Errorf("pin session: %w", err)
+	}
+	if !result.Pinned {
+		return fmt.Errorf("pinned session=%#v", result)
+	}
+	result, err = driver.UpdatePin(ctx, agenthost.UpdatePinInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-pin", Pinned: false,
+	})
+	if err != nil {
+		return fmt.Errorf("unpin session: %w", err)
+	}
+	if result.Pinned {
+		return fmt.Errorf("unpinned session=%#v", result)
+	}
+	return nil
+}
+
+func runDeleteSession(ctx context.Context, driver Driver) error {
+	if err := driver.Reset(ctx, liveSessionFixture("session-delete", "")); err != nil {
+		return err
+	}
+	result, err := driver.DeleteSession(ctx, agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-delete"})
+	if err != nil {
+		return fmt.Errorf("delete session: %w", err)
+	}
+	if !result.Deleted || !result.RuntimeClosed || !result.CanonicalRemoved || driver.Metrics().CloseCalls != 1 {
+		return fmt.Errorf("delete result=%#v metrics=%#v", result, driver.Metrics())
+	}
+	if _, err := driver.GetSession(ctx, agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-delete"}); !errors.Is(err, agenthost.ErrSessionNotFound) {
+		return fmt.Errorf("get deleted session error=%v", err)
 	}
 	return nil
 }

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -14,7 +14,7 @@ func TestPublishedScenariosHaveUniqueNames(t *testing.T) {
 		}
 		seen[scenario.Name] = struct{}{}
 	}
-	if len(seen) != 9 {
-		t.Fatalf("scenario count=%d, want 9", len(seen))
+	if len(seen) != 13 {
+		t.Fatalf("scenario count=%d, want 13", len(seen))
 	}
 }

--- a/packages/agent/host/contracts_test.go
+++ b/packages/agent/host/contracts_test.go
@@ -40,6 +40,8 @@ func TestPublicCommandTypesContainNoAdapterIdentityOrTransportFields(t *testing.
 		reflect.TypeOf(SubmitPlanDecisionInput{}),
 		reflect.TypeOf(CancelTurnInput{}),
 		reflect.TypeOf(UpdateTitleInput{}),
+		reflect.TypeOf(UpdateSettingsInput{}),
+		reflect.TypeOf(UpdatePinInput{}),
 		reflect.TypeOf(GoalControlInput{}),
 		reflect.TypeOf(GoalReconcileRequiredInput{}),
 		reflect.TypeOf(RuntimeGoalControlInput{}),

--- a/packages/agent/host/host.go
+++ b/packages/agent/host/host.go
@@ -7,8 +7,10 @@ import (
 
 type Config struct {
 	CanonicalStore       CanonicalStore
+	SessionManagement    SessionManagementStore
 	Runtime              RuntimeController
 	RuntimePreparation   RuntimePreparationPort
+	SettingsPolicy       SettingsPolicy
 	Attachments          AttachmentMaterializer
 	Clock                Clock
 	SessionLocker        SessionLocker
@@ -34,8 +36,10 @@ type Config struct {
 
 type Host struct {
 	store                CanonicalStore
+	sessionManagement    SessionManagementStore
 	runtime              RuntimeController
 	preparation          RuntimePreparationPort
+	settingsPolicy       SettingsPolicy
 	attachments          AttachmentMaterializer
 	clock                Clock
 	locker               SessionLocker
@@ -65,8 +69,8 @@ func New(config Config) *Host {
 		goalActor = NewGoalActor()
 	}
 	host := &Host{
-		store: config.CanonicalStore, runtime: config.Runtime,
-		preparation: config.RuntimePreparation, attachments: config.Attachments,
+		store: config.CanonicalStore, sessionManagement: config.SessionManagement, runtime: config.Runtime,
+		preparation: config.RuntimePreparation, settingsPolicy: config.SettingsPolicy, attachments: config.Attachments,
 		clock: config.Clock, locker: config.SessionLocker, startupGate: config.RuntimeStartGate,
 		observer: config.LifecycleObserver, commitObserver: config.CommitObserver,
 		operations: config.RuntimeOperations, events: config.OperationEvents,

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -37,6 +37,15 @@ type CanonicalStore interface {
 	CanonicalSubmitClaimStore
 }
 
+// SessionManagementStore is the narrow canonical mutation surface for session
+// metadata commands. It stays separate from lifecycle storage so read/create
+// consumers are not forced to implement unrelated mutations.
+type SessionManagementStore interface {
+	UpdateSessionSettings(context.Context, string, string, ComposerSettings) (storesqlite.Session, bool, error)
+	UpdateSessionPinned(context.Context, string, string, bool) (storesqlite.Session, bool, error)
+	DeleteSession(context.Context, string, string) (bool, error)
+}
+
 // RuntimeController is the provider-neutral live-runtime surface needed by
 // create, resume, send, exact cancel, interactive, plan, title, and visibility
 // workflows. Process transport and provider implementations stay behind it.
@@ -166,6 +175,14 @@ type RuntimeCleanupInput struct {
 type RuntimePreparationPort interface {
 	Prepare(context.Context, RuntimePreparationInput) (PreparedRuntime, error)
 	Cleanup(context.Context, RuntimeCleanupInput) error
+}
+
+// SettingsPolicy keeps provider-specific model, reasoning, and speed
+// normalization in adapters while Host owns the application decision between
+// a durable historical update and a live runtime update.
+type SettingsPolicy interface {
+	NormalizePersistedSettings(context.Context, storesqlite.Session, ComposerSettings, ComposerSettingsPatch) ComposerSettings
+	NormalizeRuntimeSettingsPatch(context.Context, ProviderRuntimeSession, ComposerSettingsPatch) ComposerSettingsPatch
 }
 
 type AttachmentMaterializer interface {

--- a/packages/agent/host/session_management.go
+++ b/packages/agent/host/session_management.go
@@ -1,0 +1,173 @@
+package agenthost
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// GetSession reads canonical truth and, when present, the current provider
+// observation without starting or resuming a runtime.
+func (h *Host) GetSession(ctx context.Context, ref SessionRef) (GetSessionResult, error) {
+	ref = normalizedSessionRef(ref)
+	if h == nil || h.store == nil || h.runtime == nil || ref.WorkspaceID == "" || ref.AgentSessionID == "" {
+		return GetSessionResult{}, ErrSessionNotFound
+	}
+	deleted, err := h.store.SessionDeleted(ctx, ref.WorkspaceID, ref.AgentSessionID)
+	if err != nil {
+		return GetSessionResult{}, err
+	}
+	if deleted {
+		return GetSessionResult{}, ErrSessionNotFound
+	}
+	canonical, found, err := h.store.GetSession(ctx, ref.WorkspaceID, ref.AgentSessionID)
+	if err != nil {
+		return GetSessionResult{}, err
+	}
+	live, liveFound := h.runtime.Session(ref.WorkspaceID, ref.AgentSessionID)
+	if !found {
+		if liveFound {
+			return GetSessionResult{}, fmt.Errorf("live workspace agent session has no persisted session")
+		}
+		return GetSessionResult{}, ErrSessionNotFound
+	}
+	return GetSessionResult{Session: live, Canonical: canonical, Live: liveFound}, nil
+}
+
+// UpdateSettings preserves the established split: historical sessions update
+// canonical settings only, while live sessions route the patch to the runtime.
+// The same per-session lock used by resume protects both paths.
+func (h *Host) UpdateSettings(ctx context.Context, input UpdateSettingsInput) (UpdateSettingsResult, error) {
+	ref := normalizedSessionRef(SessionRef{WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID})
+	if h == nil || h.store == nil || h.sessionManagement == nil || h.runtime == nil || ref.WorkspaceID == "" || ref.AgentSessionID == "" {
+		return UpdateSettingsResult{}, ErrInvalidArgument
+	}
+	release, err := h.acquireSession(ctx, ref)
+	if err != nil {
+		return UpdateSettingsResult{}, err
+	}
+	defer release()
+
+	if _, live := h.runtime.Session(ref.WorkspaceID, ref.AgentSessionID); live {
+		session, err := h.ensureRuntimeSessionLocked(ctx, ref)
+		if err != nil {
+			return UpdateSettingsResult{}, err
+		}
+		patch := input.Settings
+		if h.settingsPolicy != nil {
+			patch = h.settingsPolicy.NormalizeRuntimeSettingsPatch(ctx, session, patch)
+		}
+		if err := h.runtime.UpdateSettings(ctx, RuntimeUpdateSettingsInput{
+			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, Settings: patch,
+		}); err != nil {
+			return UpdateSettingsResult{}, err
+		}
+		result, err := h.GetSession(ctx, ref)
+		if err != nil {
+			return UpdateSettingsResult{}, err
+		}
+		return UpdateSettingsResult(result), nil
+	}
+
+	canonical, found, err := h.store.GetSession(ctx, ref.WorkspaceID, ref.AgentSessionID)
+	if err != nil {
+		return UpdateSettingsResult{}, err
+	}
+	if !found {
+		return UpdateSettingsResult{}, ErrSessionNotFound
+	}
+	settings := applyComposerSettingsPatch(composerSettingsFromMap(canonical.Settings), input.Settings)
+	if h.settingsPolicy != nil {
+		settings = h.settingsPolicy.NormalizePersistedSettings(ctx, canonical, settings, input.Settings)
+	}
+	canonical, updated, err := h.sessionManagement.UpdateSessionSettings(ctx, ref.WorkspaceID, ref.AgentSessionID, settings)
+	if err != nil {
+		return UpdateSettingsResult{}, err
+	}
+	if !updated {
+		return UpdateSettingsResult{}, ErrSessionNotFound
+	}
+	return UpdateSettingsResult{Canonical: canonical}, nil
+}
+
+func (h *Host) UpdatePin(ctx context.Context, input UpdatePinInput) (UpdatePinResult, error) {
+	ref := normalizedSessionRef(SessionRef{WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID})
+	if h == nil || h.sessionManagement == nil || h.runtime == nil || ref.WorkspaceID == "" || ref.AgentSessionID == "" {
+		return UpdatePinResult{}, ErrInvalidArgument
+	}
+	canonical, updated, err := h.sessionManagement.UpdateSessionPinned(ctx, ref.WorkspaceID, ref.AgentSessionID, input.Pinned)
+	if err != nil {
+		return UpdatePinResult{}, err
+	}
+	if !updated {
+		return UpdatePinResult{}, ErrSessionNotFound
+	}
+	live, ok := h.runtime.Session(ref.WorkspaceID, ref.AgentSessionID)
+	return UpdatePinResult{Session: live, Canonical: canonical, Live: ok}, nil
+}
+
+// DeleteSession closes a live runtime before writing the canonical tombstone.
+// Authorization, binding deletion, and local view cleanup remain adapter work.
+func (h *Host) DeleteSession(ctx context.Context, ref SessionRef) (DeleteSessionResult, error) {
+	ref = normalizedSessionRef(ref)
+	if h == nil || h.sessionManagement == nil || h.runtime == nil || ref.WorkspaceID == "" || ref.AgentSessionID == "" {
+		return DeleteSessionResult{}, ErrInvalidArgument
+	}
+	result := DeleteSessionResult{}
+	if _, live := h.runtime.Session(ref.WorkspaceID, ref.AgentSessionID); live {
+		if err := h.runtime.Close(ctx, RuntimeCloseInput(ref)); err != nil {
+			return DeleteSessionResult{}, err
+		}
+		result.RuntimeClosed = true
+	}
+	removed, err := h.sessionManagement.DeleteSession(ctx, ref.WorkspaceID, ref.AgentSessionID)
+	if err != nil {
+		return DeleteSessionResult{}, err
+	}
+	result.CanonicalRemoved = removed
+	result.Deleted = removed || result.RuntimeClosed
+	if !result.Deleted {
+		return DeleteSessionResult{}, ErrSessionNotFound
+	}
+	if h.preparation != nil {
+		if err := h.preparation.Cleanup(ctx, RuntimeCleanupInput{
+			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+		}); err != nil {
+			return DeleteSessionResult{}, err
+		}
+	}
+	return result, nil
+}
+
+func normalizedSessionRef(ref SessionRef) SessionRef {
+	ref.WorkspaceID = strings.TrimSpace(ref.WorkspaceID)
+	ref.AgentSessionID = strings.TrimSpace(ref.AgentSessionID)
+	return ref
+}
+
+func applyComposerSettingsPatch(settings ComposerSettings, patch ComposerSettingsPatch) ComposerSettings {
+	if patch.Model != nil {
+		settings.Model = strings.TrimSpace(*patch.Model)
+	}
+	if patch.PermissionModeID != nil {
+		settings.PermissionModeID = strings.TrimSpace(*patch.PermissionModeID)
+	}
+	if patch.PlanMode != nil {
+		settings.PlanMode = *patch.PlanMode
+	}
+	if patch.BrowserUse != nil {
+		value := *patch.BrowserUse
+		settings.BrowserUse = &value
+	}
+	if patch.ComputerUse != nil {
+		value := *patch.ComputerUse
+		settings.ComputerUse = &value
+	}
+	if patch.ReasoningEffort != nil {
+		settings.ReasoningEffort = strings.TrimSpace(*patch.ReasoningEffort)
+	}
+	if patch.Speed != nil {
+		settings.Speed = strings.TrimSpace(*patch.Speed)
+	}
+	return settings
+}

--- a/packages/agent/host/testdata/external-consumer/consumer.go
+++ b/packages/agent/host/testdata/external-consumer/consumer.go
@@ -6,6 +6,10 @@ var (
 	_ = agenthost.New
 	_ = (*agenthost.Host).CreateSession
 	_ = (*agenthost.Host).SendInput
+	_ = (*agenthost.Host).GetSession
+	_ = (*agenthost.Host).UpdateSettings
+	_ = (*agenthost.Host).UpdatePin
+	_ = (*agenthost.Host).DeleteSession
 	_ = (*agenthost.Host).FindTurnByClientSubmitID
 	_ = (*agenthost.Host).CancelTurn
 	_ = (*agenthost.Host).SubmitInteractive

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -318,6 +318,18 @@ type UpdateTitleInput struct {
 	Title          string
 }
 
+type UpdateSettingsInput struct {
+	WorkspaceID    string
+	AgentSessionID string
+	Settings       ComposerSettingsPatch
+}
+
+type UpdatePinInput struct {
+	WorkspaceID    string
+	AgentSessionID string
+	Pinned         bool
+}
+
 type CreateSessionResult struct {
 	Session     ProviderRuntimeSession
 	Canonical   storesqlite.Session
@@ -340,6 +352,33 @@ type SendInputResult struct {
 type UpdateTitleResult struct {
 	Session   ProviderRuntimeSession
 	Canonical storesqlite.Session
+}
+
+// GetSessionResult carries canonical truth together with an optional live
+// runtime observation. Adapters remain responsible for transport DTOs and
+// presentation-only derived fields.
+type GetSessionResult struct {
+	Session   ProviderRuntimeSession
+	Canonical storesqlite.Session
+	Live      bool
+}
+
+type UpdateSettingsResult struct {
+	Session   ProviderRuntimeSession
+	Canonical storesqlite.Session
+	Live      bool
+}
+
+type UpdatePinResult struct {
+	Session   ProviderRuntimeSession
+	Canonical storesqlite.Session
+	Live      bool
+}
+
+type DeleteSessionResult struct {
+	Deleted          bool
+	RuntimeClosed    bool
+	CanonicalRemoved bool
 }
 
 type RuntimeGoalControlInput struct {

--- a/services/tuttid/service/agent/host_adapters.go
+++ b/services/tuttid/service/agent/host_adapters.go
@@ -8,6 +8,7 @@ import (
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
 
 type serviceHostStore struct{ service *Service }
@@ -83,6 +84,32 @@ func (a serviceHostStore) UpdateSessionTitle(ctx context.Context, workspaceID, s
 	return activitySessionFromPersisted(persisted), updated, err
 }
 
+func (a serviceHostStore) UpdateSessionSettings(ctx context.Context, workspaceID, sessionID string, settings agenthost.ComposerSettings) (storesqlite.Session, bool, error) {
+	updater, ok := a.service.SessionReader.(SessionSettingsUpdater)
+	if !ok {
+		return storesqlite.Session{}, false, nil
+	}
+	persisted, updated, err := updater.UpdateSessionSettings(ctx, workspaceID, sessionID, settings)
+	return activitySessionFromPersisted(persisted), updated, err
+}
+
+func (a serviceHostStore) UpdateSessionPinned(ctx context.Context, workspaceID, sessionID string, pinned bool) (storesqlite.Session, bool, error) {
+	updater, ok := a.service.SessionReader.(SessionPinUpdater)
+	if !ok {
+		return storesqlite.Session{}, false, nil
+	}
+	persisted, updated, err := updater.UpdateSessionPinned(ctx, workspaceID, sessionID, pinned)
+	return activitySessionFromPersisted(persisted), updated, err
+}
+
+func (a serviceHostStore) DeleteSession(ctx context.Context, workspaceID, sessionID string) (bool, error) {
+	deleter, ok := a.service.SessionReader.(SessionDeleter)
+	if !ok {
+		return false, nil
+	}
+	return deleter.DeleteSession(ctx, workspaceID, sessionID)
+}
+
 func (a serviceHostStore) ListChildSessions(ctx context.Context, workspaceID, sessionID string) ([]storesqlite.Session, error) {
 	reader, ok := a.service.SessionReader.(ChildSessionReader)
 	if !ok {
@@ -143,6 +170,66 @@ func (a serviceHostStore) DeleteSubmitClaim(ctx context.Context, workspaceID, se
 
 type serviceHostPreparation struct {
 	service *Service
+}
+
+type serviceHostSettingsPolicy struct{ service *Service }
+
+func (p serviceHostSettingsPolicy) NormalizePersistedSettings(
+	ctx context.Context,
+	session storesqlite.Session,
+	settings agenthost.ComposerSettings,
+	patch agenthost.ComposerSettingsPatch,
+) agenthost.ComposerSettings {
+	settings = normalizeObservedComposerSettingsForProvider(session.Provider, settings)
+	if patch.Model != nil || patch.ReasoningEffort != nil {
+		settings.ReasoningEffort = p.service.clampReasoningEffortForModel(
+			ctx,
+			session.Provider,
+			settings.Model,
+			settings.ReasoningEffort,
+		)
+	}
+	return settings
+}
+
+func (p serviceHostSettingsPolicy) NormalizeRuntimeSettingsPatch(
+	ctx context.Context,
+	session agenthost.ProviderRuntimeSession,
+	settings agenthost.ComposerSettingsPatch,
+) agenthost.ComposerSettingsPatch {
+	provider := strings.TrimSpace(session.Provider)
+	selectedModel := ""
+	selectedReasoningEffort := ""
+	if session.Settings != nil {
+		selectedModel = session.Settings.Model
+		selectedReasoningEffort = session.Settings.ReasoningEffort
+	}
+	if settings.Model != nil {
+		selectedModel = strings.TrimSpace(*settings.Model)
+	}
+	if settings.ReasoningEffort != nil {
+		selectedReasoningEffort = *settings.ReasoningEffort
+	}
+	// A live Codex-derived runtime owns the freshest per-model reasoning
+	// catalog. Other providers keep tuttid's established catalog policy.
+	if (settings.Model != nil || settings.ReasoningEffort != nil) &&
+		!composerProviderUsesModelReasoningCatalog(provider) {
+		clamped := strings.TrimSpace(selectedReasoningEffort)
+		if agentprovider.Normalize(provider) != "" {
+			clamped = p.service.clampReasoningEffortForModel(ctx, provider, selectedModel, selectedReasoningEffort)
+		}
+		if settings.ReasoningEffort != nil || clamped != selectedReasoningEffort {
+			settings.ReasoningEffort = &clamped
+		}
+	}
+	if settings.Speed != nil {
+		normalized := strings.TrimSpace(*settings.Speed)
+		if agentprovider.Normalize(provider) != "" {
+			normalized = normalizeSpeedForProvider(provider, normalized)
+		}
+		settings.Speed = &normalized
+	}
+	return settings
 }
 
 type servicePreparedRuntimeContext struct {
@@ -347,9 +434,11 @@ func NewApplicationHost(s *Service) *agenthost.Host {
 		return nil
 	}
 	return agenthost.New(agenthost.Config{
-		CanonicalStore: serviceHostStore{service: s}, Runtime: serviceHostRuntime{service: s},
+		CanonicalStore: serviceHostStore{service: s}, SessionManagement: serviceHostStore{service: s},
+		Runtime:            serviceHostRuntime{service: s},
 		RuntimePreparation: serviceHostPreparation{service: s}, Attachments: s.PromptAttachmentStore,
-		Clock: serviceHostClock{service: s}, SessionLocker: serviceHostLocker{service: s},
+		SettingsPolicy: serviceHostSettingsPolicy{service: s},
+		Clock:          serviceHostClock{service: s}, SessionLocker: serviceHostLocker{service: s},
 		RuntimeStartGate:  serviceHostStartupGate{service: s},
 		LifecycleObserver: serviceHostLifecycleObserver{service: s},
 		CommitObserver:    serviceHostCommitObserver{service: s},

--- a/services/tuttid/service/agent/host_adapters.go
+++ b/services/tuttid/service/agent/host_adapters.go
@@ -27,11 +27,11 @@ func (a serviceHostStore) GetSession(ctx context.Context, workspaceID, sessionID
 			return session, ok, err
 		}
 	}
-	// Runtime-only Service configurations predate the canonical store port and
-	// remain useful to isolated consumers and tests. Once either durable reader
-	// is configured, absence is authoritative and must never fall back to a
-	// provider observation.
-	if a.service.SessionReader == nil && a.service.TurnStore == nil {
+	// Service configurations without the legacy SessionReader have always
+	// allowed a live provider session to supply the session observation. A
+	// TurnStore may still be present for turn lifecycle operations, so its
+	// absence must not suppress that established fallback.
+	if a.service.SessionReader == nil {
 		if session, ok := a.service.controller().Session(workspaceID, sessionID); ok {
 			activeTurnID := ""
 			if session.TurnLifecycle != nil && session.TurnLifecycle.ActiveTurnID != nil {
@@ -353,7 +353,7 @@ func (a serviceHostRuntime) SetVisible(ctx context.Context, input RuntimeSetVisi
 	return a.service.controller().SetVisible(ctx, input)
 }
 func (a serviceHostRuntime) Close(ctx context.Context, input RuntimeCloseInput) error {
-	return a.service.controller().Close(ctx, input)
+	return normalizeRuntimeError(a.service.controller().Close(ctx, input))
 }
 
 type serviceHostGoalRuntime struct{ service *Service }

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -285,7 +285,11 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 	if kind == "" {
 		kind = agentactivitybiz.SessionKindRoot
 	}
-	settings := ComposerSettings{PlanMode: true}
+	settings := seed.Settings
+	if settings.Model == "" && settings.PermissionModeID == "" && !settings.PlanMode &&
+		settings.BrowserUse == nil && settings.ComputerUse == nil && settings.ReasoningEffort == "" && settings.Speed == "" {
+		settings.PlanMode = true
+	}
 	runtimeContext := map[string]any{"tuttiInitialTitleEstablished": seed.InitialTitleEstablished}
 	if seed.ExternalResumeSupported != nil {
 		runtimeContext["externalImportResumeSupported"] = *seed.ExternalResumeSupported
@@ -297,6 +301,7 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 		Metadata:               agentactivitybiz.SessionMetadata{Visible: true, Capabilities: []string{}},
 		InternalRuntimeContext: runtimeContext,
 		Title:                  seed.Title, ActiveTurnID: seed.ActiveTurnID,
+		PinnedAtUnixMS:  boolUnixMS(seed.Pinned),
 		CreatedAtUnixMS: 1, UpdatedAtUnixMS: 2, LastEventUnixMS: 2,
 	}
 	d.sessions.sessions[seed.WorkspaceID+":"+seed.AgentSessionID] = persisted
@@ -321,7 +326,7 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 			ID: seed.AgentSessionID, WorkspaceID: seed.WorkspaceID, Provider: seed.Provider,
 			ProviderSessionID: seed.ProviderSessionID, Cwd: seed.Cwd, Status: "ready",
 			Settings: &settings, Title: seed.Title, InitialTitleEstablished: seed.InitialTitleEstablished,
-			Visible: true, CreatedAtUnixMS: 1, UpdatedAtUnixMS: 2,
+			Visible: true, PinnedAtUnixMS: boolUnixMS(seed.Pinned), CreatedAtUnixMS: 1, UpdatedAtUnixMS: 2,
 		}
 	}
 	if fixture.Turn != nil {
@@ -541,6 +546,60 @@ func (d *legacyHostConformanceDriver) UpdateTitle(ctx context.Context, input age
 	return legacyHostSessionObservation(session), err
 }
 
+func (d *legacyHostConformanceDriver) GetSession(ctx context.Context, ref agenthost.SessionRef) (hostconformance.SessionObservation, error) {
+	if d.directHost {
+		result, err := d.service.ApplicationHost().GetSession(ctx, ref)
+		if err != nil {
+			return hostconformance.SessionObservation{}, err
+		}
+		session, err := d.service.projectHostSessionResult(ctx, result.Canonical, result.Session, result.Live, false)
+		return legacyHostSessionObservationWithLive(session, result.Live), err
+	}
+	session, err := d.service.Get(ctx, ref.WorkspaceID, ref.AgentSessionID)
+	_, live := d.runtime.Session(ref.WorkspaceID, ref.AgentSessionID)
+	return legacyHostSessionObservationWithLive(session, live), err
+}
+
+func (d *legacyHostConformanceDriver) UpdateSettings(ctx context.Context, input agenthost.UpdateSettingsInput) (hostconformance.SessionObservation, error) {
+	if d.directHost {
+		result, err := d.service.ApplicationHost().UpdateSettings(ctx, input)
+		if err != nil {
+			return hostconformance.SessionObservation{}, err
+		}
+		session, err := d.service.projectHostSessionResult(ctx, result.Canonical, result.Session, result.Live, false)
+		return legacyHostSessionObservationWithLive(session, result.Live), err
+	}
+	session, err := d.service.UpdateSettings(ctx, input.WorkspaceID, input.AgentSessionID, input.Settings)
+	_, live := d.runtime.Session(input.WorkspaceID, input.AgentSessionID)
+	return legacyHostSessionObservationWithLive(session, live), err
+}
+
+func (d *legacyHostConformanceDriver) UpdatePin(ctx context.Context, input agenthost.UpdatePinInput) (hostconformance.SessionObservation, error) {
+	if d.directHost {
+		result, err := d.service.ApplicationHost().UpdatePin(ctx, input)
+		if err != nil {
+			return hostconformance.SessionObservation{}, err
+		}
+		session, err := d.service.projectHostSessionResult(ctx, result.Canonical, result.Session, result.Live, false)
+		return legacyHostSessionObservationWithLive(session, result.Live), err
+	}
+	session, err := d.service.UpdatePin(ctx, input.WorkspaceID, input.AgentSessionID, input.Pinned)
+	_, live := d.runtime.Session(input.WorkspaceID, input.AgentSessionID)
+	return legacyHostSessionObservationWithLive(session, live), err
+}
+
+func (d *legacyHostConformanceDriver) DeleteSession(ctx context.Context, ref agenthost.SessionRef) (agenthost.DeleteSessionResult, error) {
+	if d.directHost {
+		return d.service.ApplicationHost().DeleteSession(ctx, ref)
+	}
+	_, live := d.runtime.Session(ref.WorkspaceID, ref.AgentSessionID)
+	_, persisted := d.sessions.GetSession(ref.WorkspaceID, ref.AgentSessionID)
+	deleted, err := d.service.Delete(ctx, ref.WorkspaceID, ref.AgentSessionID)
+	return agenthost.DeleteSessionResult{
+		Deleted: deleted, RuntimeClosed: live && deleted, CanonicalRemoved: persisted && deleted,
+	}, err
+}
+
 func (d *legacyHostConformanceDriver) GoalControl(ctx context.Context, input agenthost.GoalControlInput) (hostconformance.GoalObservation, error) {
 	if d.directHost {
 		result, err := d.service.ApplicationHost().GoalControl(ctx, input)
@@ -605,6 +664,7 @@ func (d *legacyHostConformanceDriver) Metrics() hostconformance.Metrics {
 		StartCalls: len(d.runtime.startCalls), ResumeCalls: len(d.runtime.resumeCalls),
 		ExecCalls: len(d.runtime.execCalls), CancelCalls: len(d.runtime.cancelCalls),
 		InteractiveCalls: len(d.runtime.submitInteractiveCalls), UpdateSettingsCalls: len(d.runtime.updateSettingsCalls),
+		CloseCalls:       len(d.runtime.closeCalls),
 		GoalControlCalls: len(d.runtime.goalControlCalls), GoalReconcileCalls: len(d.runtime.goalReconcileCalls),
 		RecoverySteps: append([]string(nil), (*d.recoverySteps)...),
 	}
@@ -810,8 +870,24 @@ func (s *legacyHostConformanceTurnStore) ListPendingInteractionsBySession(_ cont
 }
 
 func legacyHostSessionObservation(session Session) hostconformance.SessionObservation {
+	return legacyHostSessionObservationWithLive(session, false)
+}
+
+func legacyHostSessionObservationWithLive(session Session, live bool) hostconformance.SessionObservation {
+	settings := ComposerSettings{}
+	if session.Settings != nil {
+		settings = *session.Settings
+	}
 	return hostconformance.SessionObservation{
 		SessionID: session.ID, ProviderSessionID: session.ProviderSessionID,
 		Title: value(session.Title), ActiveTurnID: session.ActiveTurnID, Resumable: session.Resumable,
+		Settings: settings, Pinned: session.PinnedAtUnixMS > 0, Live: live,
 	}
+}
+
+func boolUnixMS(value bool) int64 {
+	if value {
+		return 1
+	}
+	return 0
 }

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -398,88 +398,27 @@ func (s *Service) LocalAttachmentPath(ctx context.Context, workspaceID string, a
 }
 
 func (s *Service) get(ctx context.Context, workspaceID string, agentSessionID string, _ bool) (Session, error) {
-	if s.SessionReader != nil {
-		deleted, err := s.SessionReader.SessionDeleted(ctx, workspaceID, agentSessionID)
-		if err != nil {
+	result, err := s.ApplicationHost().GetSession(ctx, agenthost.SessionRef{
+		WorkspaceID: workspaceID, AgentSessionID: agentSessionID,
+	})
+	if err != nil {
+		return Session{}, err
+	}
+	persisted := persistedSessionFromHost(result.Canonical)
+	if !result.Live && s.SessionReader != nil && isStaleHiddenLiveModelDiscoverySession(persisted) {
+		if _, err := s.Delete(ctx, workspaceID, agentSessionID); err != nil && !errors.Is(err, ErrSessionNotFound) {
 			return Session{}, err
 		}
-		if deleted {
-			return Session{}, ErrSessionNotFound
-		}
+		return Session{}, ErrSessionNotFound
 	}
-	session, ok := s.controller().Session(workspaceID, agentSessionID)
-	if ok {
-		resumable := s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session))
-		service := serviceSession(session, resumable)
-		if s.SessionReader != nil {
-			persisted, ok := s.SessionReader.GetSession(workspaceID, agentSessionID)
-			if !ok {
-				return Session{}, errors.New("live workspace agent session has no persisted session")
-			}
-			if err := validatePersistedRailSectionKey(persisted); err != nil {
-				return Session{}, err
-			}
-			service = serviceSessionWithPersistedFreshness(session, persisted, resumable)
-		}
-		return s.withProtocolV2TurnState(ctx, workspaceID, service)
-	}
-	if s.SessionReader != nil {
-		if persisted, ok := s.SessionReader.GetSession(workspaceID, agentSessionID); ok {
-			if err := validatePersistedRailSectionKey(persisted); err != nil {
-				return Session{}, err
-			}
-			if isStaleHiddenLiveModelDiscoverySession(persisted) {
-				if _, err := s.Delete(ctx, workspaceID, agentSessionID); err != nil && !errors.Is(err, ErrSessionNotFound) {
-					return Session{}, err
-				}
-				return Session{}, ErrSessionNotFound
-			}
-			return s.withProtocolV2TurnState(ctx, workspaceID, sessionFromPersisted(
-				persisted,
-				s.persistedSessionCanResume(ctx, persisted),
-			))
-		}
-	}
-	return Session{}, ErrSessionNotFound
+	return s.projectHostSessionResult(ctx, result.Canonical, result.Session, result.Live, true)
 }
 
 func (s *Service) Delete(ctx context.Context, workspaceID string, agentSessionID string) (bool, error) {
-	workspaceID = strings.TrimSpace(workspaceID)
-	agentSessionID = strings.TrimSpace(agentSessionID)
-	if workspaceID == "" || agentSessionID == "" {
-		return false, ErrInvalidArgument
-	}
-	runtimeClosed := false
-	if _, ok := s.controller().Session(workspaceID, agentSessionID); ok {
-		if err := s.controller().Close(ctx, RuntimeCloseInput{
-			WorkspaceID:    workspaceID,
-			AgentSessionID: agentSessionID,
-		}); err != nil {
-			return false, normalizeRuntimeError(err)
-		}
-		runtimeClosed = true
-	}
-	deleter, ok := s.SessionReader.(SessionDeleter)
-	if !ok {
-		if runtimeClosed {
-			if err := s.cleanupRuntime(ctx, workspaceID, agentSessionID); err != nil {
-				return false, err
-			}
-			return true, nil
-		}
-		return false, ErrSessionNotFound
-	}
-	removed, err := deleter.DeleteSession(ctx, workspaceID, agentSessionID)
-	if err != nil {
-		return false, err
-	}
-	if !removed && !runtimeClosed {
-		return false, ErrSessionNotFound
-	}
-	if err := s.cleanupRuntime(ctx, workspaceID, agentSessionID); err != nil {
-		return false, err
-	}
-	return removed || runtimeClosed, nil
+	result, err := s.ApplicationHost().DeleteSession(ctx, agenthost.SessionRef{
+		WorkspaceID: workspaceID, AgentSessionID: agentSessionID,
+	})
+	return result.Deleted, err
 }
 
 func (s *Service) Clear(ctx context.Context, workspaceID string) (ClearSessionsResult, error) {
@@ -506,26 +445,17 @@ func (s *Service) Clear(ctx context.Context, workspaceID string) (ClearSessionsR
 }
 
 func (s *Service) UpdatePin(ctx context.Context, workspaceID string, agentSessionID string, pinned bool) (Session, error) {
-	workspaceID = strings.TrimSpace(workspaceID)
-	agentSessionID = strings.TrimSpace(agentSessionID)
-	if workspaceID == "" || agentSessionID == "" {
-		return Session{}, ErrInvalidArgument
-	}
-	updater, ok := s.SessionReader.(SessionPinUpdater)
-	if !ok {
-		return Session{}, ErrSessionNotFound
-	}
-	persisted, updated, err := updater.UpdateSessionPinned(ctx, workspaceID, agentSessionID, pinned)
+	result, err := s.ApplicationHost().UpdatePin(ctx, agenthost.UpdatePinInput{
+		WorkspaceID: workspaceID, AgentSessionID: agentSessionID, Pinned: pinned,
+	})
 	if err != nil {
 		return Session{}, err
 	}
-	if !updated {
-		return Session{}, ErrSessionNotFound
-	}
-	if runtime, ok := s.controller().Session(workspaceID, agentSessionID); ok {
+	persisted := persistedSessionFromHost(result.Canonical)
+	if result.Live {
 		service := serviceSession(
-			runtime,
-			s.controller().CanResume(runtimeResumeInputFromRuntimeSession(runtime)),
+			result.Session,
+			s.controller().CanResume(runtimeResumeInputFromRuntimeSession(result.Session)),
 		)
 		return s.withProtocolV2TurnState(
 			ctx,

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -445,6 +445,8 @@ func (s *Service) Clear(ctx context.Context, workspaceID string) (ClearSessionsR
 }
 
 func (s *Service) UpdatePin(ctx context.Context, workspaceID string, agentSessionID string, pinned bool) (Session, error) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	agentSessionID = strings.TrimSpace(agentSessionID)
 	result, err := s.ApplicationHost().UpdatePin(ctx, agenthost.UpdatePinInput{
 		WorkspaceID: workspaceID, AgentSessionID: agentSessionID, Pinned: pinned,
 	})

--- a/services/tuttid/service/agent/service_resume_helpers.go
+++ b/services/tuttid/service/agent/service_resume_helpers.go
@@ -41,14 +41,3 @@ func (s *Service) ensureRuntimeSessionResult(
 	})
 	return ensuredRuntimeSession{Session: session}, err
 }
-
-func (s *Service) ensureRuntimeSessionResultLocked(
-	ctx context.Context,
-	workspaceID string,
-	agentSessionID string,
-) (ensuredRuntimeSession, error) {
-	ref := agenthost.SessionRef{WorkspaceID: workspaceID, AgentSessionID: agentSessionID}
-	ctx = withServiceHeldSessionLock(ctx, s, ref)
-	session, err := s.ApplicationHost().EnsureRuntimeSession(ctx, ref)
-	return ensuredRuntimeSession{Session: session}, err
-}

--- a/services/tuttid/service/agent/service_session.go
+++ b/services/tuttid/service/agent/service_session.go
@@ -256,6 +256,32 @@ func serviceSessionWithPersistedFreshness(session ProviderRuntimeSession, persis
 	return service
 }
 
+func (s *Service) projectHostSessionResult(
+	ctx context.Context,
+	canonical agentactivitybiz.Session,
+	runtime ProviderRuntimeSession,
+	live bool,
+	requireRailSection bool,
+) (Session, error) {
+	persisted := persistedSessionFromHost(canonical)
+	if requireRailSection && s.SessionReader != nil {
+		if err := validatePersistedRailSectionKey(persisted); err != nil {
+			return Session{}, err
+		}
+	}
+	var result Session
+	if live {
+		resumable := s.controller().CanResume(runtimeResumeInputFromRuntimeSession(runtime))
+		result = serviceSession(runtime, resumable)
+		if s.SessionReader != nil {
+			result = serviceSessionWithPersistedFreshness(runtime, persisted, resumable)
+		}
+	} else {
+		result = sessionFromPersisted(persisted, s.persistedSessionCanResume(ctx, persisted))
+	}
+	return s.withProtocolV2TurnState(ctx, canonical.WorkspaceID, result)
+}
+
 func persistedSessionIsNewerThanRuntime(persisted PersistedSession, session ProviderRuntimeSession) bool {
 	persistedUpdatedAtUnixMS := firstNonZeroInt64(persisted.LastEventUnixMS, persisted.UpdatedAtUnixMS)
 	return persistedUpdatedAtUnixMS > 0 &&

--- a/services/tuttid/service/agent/service_settings.go
+++ b/services/tuttid/service/agent/service_settings.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
 
@@ -96,128 +97,13 @@ func (s *Service) UpdateSettings(ctx context.Context, workspaceID string, agentS
 		return Session{}, err
 	}
 	defer release()
-	if _, live := s.controller().Session(workspaceID, agentSessionID); !live {
-		return s.updatePersistedSessionSettings(ctx, workspaceID, agentSessionID, settings)
-	}
-	ensured, err := s.ensureRuntimeSessionResultLocked(ctx, workspaceID, agentSessionID)
+	ref := agenthost.SessionRef{WorkspaceID: workspaceID, AgentSessionID: agentSessionID}
+	ctx = withServiceHeldSessionLock(ctx, s, ref)
+	result, err := s.ApplicationHost().UpdateSettings(ctx, agenthost.UpdateSettingsInput{
+		WorkspaceID: workspaceID, AgentSessionID: agentSessionID, Settings: settings,
+	})
 	if err != nil {
 		return Session{}, err
 	}
-	provider := strings.TrimSpace(ensured.Session.Provider)
-	selectedModel := ""
-	selectedReasoningEffort := ""
-	if ensured.Session.Settings != nil {
-		selectedModel = ensured.Session.Settings.Model
-		selectedReasoningEffort = ensured.Session.Settings.ReasoningEffort
-	}
-	if settings.Model != nil {
-		selectedModel = strings.TrimSpace(*settings.Model)
-	}
-	if settings.ReasoningEffort != nil {
-		selectedReasoningEffort = *settings.ReasoningEffort
-	}
-	// A live Codex-derived runtime owns the freshest per-model reasoning
-	// catalog. Let its adapter resolve active updates; the daemon-side catalog
-	// remains the authority for pre-session create/resume only.
-	if (settings.Model != nil || settings.ReasoningEffort != nil) &&
-		!composerProviderUsesModelReasoningCatalog(provider) {
-		clampedReasoningEffort := strings.TrimSpace(selectedReasoningEffort)
-		if agentprovider.Normalize(provider) != "" {
-			clampedReasoningEffort = s.clampReasoningEffortForModel(ctx, provider, selectedModel, selectedReasoningEffort)
-		}
-		if settings.ReasoningEffort != nil || clampedReasoningEffort != selectedReasoningEffort {
-			settings.ReasoningEffort = &clampedReasoningEffort
-		}
-	}
-	if settings.Speed != nil {
-		normalizedSpeed := strings.TrimSpace(*settings.Speed)
-		if agentprovider.Normalize(provider) != "" {
-			normalizedSpeed = normalizeSpeedForProvider(provider, normalizedSpeed)
-		}
-		settings.Speed = &normalizedSpeed
-	}
-	if err := s.controller().UpdateSettings(ctx, RuntimeUpdateSettingsInput{
-		WorkspaceID:    workspaceID,
-		AgentSessionID: agentSessionID,
-		Settings:       settings,
-	}); err != nil {
-		return Session{}, normalizeRuntimeError(err)
-	}
-	session, err := s.Get(ctx, workspaceID, agentSessionID)
-	if err != nil {
-		return Session{}, err
-	}
-	return session, nil
-}
-
-func (s *Service) updatePersistedSessionSettings(
-	ctx context.Context,
-	workspaceID string,
-	agentSessionID string,
-	patch ComposerSettingsPatch,
-) (Session, error) {
-	if s.SessionReader == nil {
-		return Session{}, ErrSessionNotFound
-	}
-	persisted, ok := s.SessionReader.GetSession(workspaceID, agentSessionID)
-	if !ok {
-		return Session{}, ErrSessionNotFound
-	}
-	updater, ok := s.SessionReader.(SessionSettingsUpdater)
-	if !ok {
-		return Session{}, ErrSessionNotFound
-	}
-	settings := applyComposerSettingsPatch(persisted.Settings, patch)
-	settings = normalizeObservedComposerSettingsForProvider(persisted.Provider, settings)
-	if patch.Model != nil || patch.ReasoningEffort != nil {
-		settings.ReasoningEffort = s.clampReasoningEffortForModel(
-			ctx,
-			persisted.Provider,
-			settings.Model,
-			settings.ReasoningEffort,
-		)
-	}
-	updated, ok, err := updater.UpdateSessionSettings(
-		ctx,
-		workspaceID,
-		agentSessionID,
-		settings,
-	)
-	if err != nil {
-		return Session{}, err
-	}
-	if !ok {
-		return Session{}, ErrSessionNotFound
-	}
-	return s.withProtocolV2TurnState(ctx, workspaceID, sessionFromPersisted(
-		updated,
-		s.persistedSessionCanResume(ctx, updated),
-	))
-}
-
-func applyComposerSettingsPatch(settings ComposerSettings, patch ComposerSettingsPatch) ComposerSettings {
-	if patch.Model != nil {
-		settings.Model = strings.TrimSpace(*patch.Model)
-	}
-	if patch.PermissionModeID != nil {
-		settings.PermissionModeID = strings.TrimSpace(*patch.PermissionModeID)
-	}
-	if patch.PlanMode != nil {
-		settings.PlanMode = *patch.PlanMode
-	}
-	if patch.BrowserUse != nil {
-		value := *patch.BrowserUse
-		settings.BrowserUse = &value
-	}
-	if patch.ComputerUse != nil {
-		value := *patch.ComputerUse
-		settings.ComputerUse = &value
-	}
-	if patch.ReasoningEffort != nil {
-		settings.ReasoningEffort = strings.TrimSpace(*patch.ReasoningEffort)
-	}
-	if patch.Speed != nil {
-		settings.Speed = strings.TrimSpace(*patch.Speed)
-	}
-	return settings
+	return s.projectHostSessionResult(ctx, result.Canonical, result.Session, result.Live, result.Live)
 }

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -7538,6 +7538,33 @@ func (f *fakeSessionReader) UpdateSessionTitle(_ context.Context, workspaceID st
 	return session, true, nil
 }
 
+func (f *fakeSessionReader) UpdateSessionSettings(_ context.Context, workspaceID string, agentSessionID string, settings ComposerSettings) (PersistedSession, bool, error) {
+	key := workspaceID + ":" + agentSessionID
+	session, ok := f.sessions[key]
+	if !ok {
+		return PersistedSession{}, false, nil
+	}
+	session.Settings = settings
+	session.UpdatedAtUnixMS = time.Now().UnixMilli()
+	f.sessions[key] = session
+	return session, true, nil
+}
+
+func (f *fakeSessionReader) UpdateSessionPinned(_ context.Context, workspaceID string, agentSessionID string, pinned bool) (PersistedSession, bool, error) {
+	key := workspaceID + ":" + agentSessionID
+	session, ok := f.sessions[key]
+	if !ok {
+		return PersistedSession{}, false, nil
+	}
+	session.PinnedAtUnixMS = 0
+	if pinned {
+		session.PinnedAtUnixMS = time.Now().UnixMilli()
+	}
+	session.UpdatedAtUnixMS = time.Now().UnixMilli()
+	f.sessions[key] = session
+	return session, true, nil
+}
+
 func (f fakeSessionReader) DeleteSession(_ context.Context, workspaceID string, agentSessionID string) (bool, error) {
 	key := workspaceID + ":" + agentSessionID
 	if _, ok := f.sessions[key]; !ok {

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -5336,6 +5337,35 @@ func TestServiceDeletesPersistedSession(t *testing.T) {
 	}
 	if _, err := service.Get(context.Background(), "ws-1", "session-1"); err != ErrSessionNotFound {
 		t.Fatalf("Get after delete error = %v, want %v", err, ErrSessionNotFound)
+	}
+}
+
+func TestServiceGetReturnsLiveSessionWithoutLegacySessionReader(t *testing.T) {
+	runtime := newFakeRuntime()
+	runtime.sessions["ws-1:session-1"] = ProviderRuntimeSession{
+		ID: "session-1", WorkspaceID: "ws-1", Provider: "codex", Title: "Live session",
+	}
+	service := newIsolatedAgentService(runtime)
+	service.TurnStore = failingTurnStore{sessionMissing: true}
+
+	session, err := service.Get(context.Background(), "ws-1", "session-1")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if session.ID != "session-1" || value(session.Title) != "Live session" {
+		t.Fatalf("Get() session = %#v, want live runtime observation", session)
+	}
+}
+
+func TestServiceDeleteNormalizesWrappedRuntimeSessionNotFound(t *testing.T) {
+	runtime := newFakeRuntime()
+	runtime.sessions["ws-1:session-1"] = ProviderRuntimeSession{ID: "session-1", WorkspaceID: "ws-1"}
+	runtime.closeErr = fmt.Errorf("runtime close: %w", ErrSessionNotFound)
+	service := newIsolatedAgentService(runtime)
+
+	_, err := service.Delete(context.Background(), "ws-1", "session-1")
+	if err != ErrSessionNotFound {
+		t.Fatalf("Delete() error = %v, want canonical ErrSessionNotFound", err)
 	}
 }
 

--- a/services/tuttid/service/agent/service_turns_error_test.go
+++ b/services/tuttid/service/agent/service_turns_error_test.go
@@ -150,6 +150,7 @@ type failingTurnStore struct {
 	latestTurn                 agentactivitybiz.Turn
 	listInteractionsErr        error
 	session                    agentactivitybiz.Session
+	sessionMissing             bool
 	turn                       agentactivitybiz.Turn
 	latestListCalls            *int
 	activeListCalls            *int
@@ -217,6 +218,9 @@ func (s failingTurnStore) GetTurn(context.Context, string, string, string) (agen
 }
 
 func (s failingTurnStore) GetSession(context.Context, string, string) (agentactivitybiz.Session, bool, error) {
+	if s.sessionMissing {
+		return agentactivitybiz.Session{}, false, nil
+	}
 	return s.session, true, nil
 }
 

--- a/services/tuttid/service/agent/service_update_pin_test.go
+++ b/services/tuttid/service/agent/service_update_pin_test.go
@@ -46,7 +46,7 @@ func TestServiceUpdatePinReturnsFreshPersistedVersionAndLiveTurn(t *testing.T) {
 	}
 	service := newIsolatedAgentService(runtime)
 	service.SessionReader = reader
-	service.TurnStore = failingTurnStore{
+	turnStore := &workspaceRecordingTurnStore{failingTurnStore: failingTurnStore{
 		latestTurn: turn,
 		session: agentactivitybiz.Session{
 			ID:           "session-1",
@@ -54,9 +54,10 @@ func TestServiceUpdatePinReturnsFreshPersistedVersionAndLiveTurn(t *testing.T) {
 			ActiveTurnID: "turn-1",
 		},
 		turn: turn,
-	}
+	}}
+	service.TurnStore = turnStore
 
-	session, err := service.UpdatePin(context.Background(), "ws-1", "session-1", true)
+	session, err := service.UpdatePin(context.Background(), " ws-1 ", " session-1 ", true)
 	if err != nil {
 		t.Fatalf("UpdatePin returned error: %v", err)
 	}
@@ -68,6 +69,14 @@ func TestServiceUpdatePinReturnsFreshPersistedVersionAndLiveTurn(t *testing.T) {
 	}
 	if session.ActiveTurnID != "turn-1" || session.ActiveTurn == nil || session.ActiveTurn.TurnID != "turn-1" {
 		t.Fatalf("UpdatePin active turn = %#v id=%q, want turn-1", session.ActiveTurn, session.ActiveTurnID)
+	}
+	if len(turnStore.workspaceIDs) == 0 {
+		t.Fatal("UpdatePin did not query canonical turn state")
+	}
+	for _, workspaceID := range turnStore.workspaceIDs {
+		if workspaceID != "ws-1" {
+			t.Fatalf("UpdatePin turn-state workspace id = %q, want normalized ws-1", workspaceID)
+		}
 	}
 
 	reader.updatedAtUnixMS = 250
@@ -103,6 +112,26 @@ func TestMergePersistedSessionStateDoesNotRegressNewerRuntimeVersion(t *testing.
 type pinUpdateSessionReader struct {
 	*fakeSessionReader
 	updatedAtUnixMS int64
+}
+
+type workspaceRecordingTurnStore struct {
+	failingTurnStore
+	workspaceIDs []string
+}
+
+func (s *workspaceRecordingTurnStore) GetLatestTurn(ctx context.Context, workspaceID string, agentSessionID string) (agentactivitybiz.Turn, bool, error) {
+	s.workspaceIDs = append(s.workspaceIDs, workspaceID)
+	return s.failingTurnStore.GetLatestTurn(ctx, workspaceID, agentSessionID)
+}
+
+func (s *workspaceRecordingTurnStore) ListLatestTurnInteractions(ctx context.Context, workspaceID string, agentSessionIDs []string) (map[string][]agentactivitybiz.Interaction, error) {
+	s.workspaceIDs = append(s.workspaceIDs, workspaceID)
+	return s.failingTurnStore.ListLatestTurnInteractions(ctx, workspaceID, agentSessionIDs)
+}
+
+func (s *workspaceRecordingTurnStore) GetSession(ctx context.Context, workspaceID string, agentSessionID string) (agentactivitybiz.Session, bool, error) {
+	s.workspaceIDs = append(s.workspaceIDs, workspaceID)
+	return s.failingTurnStore.GetSession(ctx, workspaceID, agentSessionID)
 }
 
 func (r *pinUpdateSessionReader) UpdateSessionPinned(


### PR DESCRIPTION
## Summary

- add provider-neutral Host APIs for `GetSession`, `UpdateSettings`, `UpdatePin`, and `DeleteSession`
- preserve tuttid semantics: historical settings persist without runtime resume, live settings update the runtime under the existing settings lock, and live deletion closes before canonical tombstoning
- keep provider-specific settings normalization, HTTP DTOs, authorization, shared bindings, and view cleanup in adapters
- delegate the existing tuttid Service methods to Host without changing HTTP/OpenAPI contracts
- extend the reusable conformance harness with get, historical/live settings, pin, and delete scenarios that run against both the Service adapter and direct Host path

## Behavior compatibility

- `GetSession` never starts or resumes a provider
- historical `UpdateSettings` performs canonical persistence only
- live `UpdateSettings` keeps the existing settings-lock critical section and provider normalization rules
- `UpdatePin` retains the legacy live/historical projection behavior
- `DeleteSession` closes a live runtime before writing the canonical tombstone and then cleans runtime preparation state
- no wire, schema, HTTP, or OpenAPI changes

## Validation

- `go test -race ./packages/agent/host/... ./services/tuttid/service/agent`
- `PATH="/Users/liying/go/bin:$PATH" pnpm lint:go:prepared`
- `pnpm test:go:prepared`
- `pnpm build:go`
- `PATH="/Users/liying/go/bin:$PATH" pnpm check:changed`
- pre-push `pnpm check:full` (18 tasks passed)

## Documentation

- update the Host package README and agent activity package architecture guide with the new API ownership boundary

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->