### PR TITLE
fix(agent-gui): surface canonical turn errors

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentHostProjection.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentHostProjection.ts
@@ -1,4 +1,3 @@
-import type { AgentActivitySession } from "@tutti-os/agent-activity-core";
 import type { AgentHostAgentSessionComposerSettings as SharedAgentHostAgentSessionComposerSettings } from "@shared/contracts/dto";
 import {
   isDesktopAgentGUIProvider,
@@ -74,31 +73,6 @@ export function resolveDesktopAgentGUIProvider(
       debugMessage: `Unsupported desktop agent provider: ${rawProvider}`
     }
   );
-}
-
-export function agentSessionActivationError(session: AgentActivitySession):
-  | {
-      code: string;
-      debugMessage: string;
-      message: string;
-    }
-  | undefined {
-  const message =
-    session.activeTurn?.error?.message?.trim() ||
-    session.latestTurn?.error?.message?.trim() ||
-    null;
-  if (
-    !message ||
-    (session.activeTurn?.error === undefined &&
-      session.latestTurn?.outcome !== "failed")
-  ) {
-    return undefined;
-  }
-  return {
-    code: "agent_session_start_failed",
-    debugMessage: message,
-    message
-  };
 }
 
 export function unavailableHostMethod(name: string): () => Promise<never> {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -277,6 +277,51 @@ test("WorkspaceAgentActivityService reads existing session settings from the dae
   assert.equal(canonicalSession.settings?.model, "default");
 });
 
+test("WorkspaceAgentActivityService does not reinterpret a failed Turn as activation failure", async () => {
+  const failedSession = workspaceAgentSession({
+    latestTurn: {
+      ...workspaceAgentTurn({ outcome: "failed", phase: "settled" }),
+      error: { message: "Selected model is at capacity" }
+    },
+    status: "failed"
+  });
+  const service = new WorkspaceAgentActivityService({
+    tuttidClient: {
+      createWorkspaceAgentSession: async () => failedSession,
+      getWorkspaceAgentSession: async () => ({
+        childSessions: [],
+        session: failedSession,
+        turns: []
+      })
+    } as unknown as TuttidClient,
+    runtimeApi: { logTerminalDiagnostic: async () => {} }
+  });
+
+  const created = await service.activateSession({
+    agentSessionId: "session-1",
+    agentTargetId: "local:codex",
+    clientSubmitId: "submit-create-failed-turn",
+    initialContent: [{ type: "text", text: "Run it" }],
+    mode: "new",
+    visible: true,
+    workspaceId: "ws-1"
+  });
+  const reopened = await service.activateSession({
+    agentSessionId: "session-1",
+    mode: "existing",
+    visible: true,
+    workspaceId: "ws-1"
+  });
+
+  assert.deepEqual(created.activation, { mode: "new", status: "attached" });
+  assert.equal(created.error, undefined);
+  assert.deepEqual(reopened.activation, {
+    mode: "existing",
+    status: "already_attached"
+  });
+  assert.equal(reopened.error, undefined);
+});
+
 test("WorkspaceAgentActivityService returns the authoritative canonical session after settings update", async () => {
   const updatedSession = workspaceAgentSession({
     provider: "claude-code",

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -15,7 +15,6 @@ import type {
 import type { DesktopHostFilesApi, DesktopRuntimeApi } from "@preload/types";
 import { agentActivitySessionFromTuttidSession } from "../desktopAgentActivityAdapter.ts";
 import {
-  agentSessionActivationError,
   normalizeComposerSettings,
   resolveComposerPermissionMode,
   resolveDesktopAgentGUIProvider
@@ -490,8 +489,6 @@ export class WorkspaceAgentActivityService
         fields: { activeTurnPhase: session.activeTurn?.phase ?? null }
       });
     }
-    const activationError = agentSessionActivationError(session);
-    const activationFailed = activationError !== undefined;
     reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
       agentSessionId: session.agentSessionId,
       clientSubmitId: input.mode === "new" ? input.clientSubmitId : null,
@@ -508,13 +505,8 @@ export class WorkspaceAgentActivityService
     return {
       activation: {
         mode: input.mode,
-        status: activationFailed
-          ? "failed"
-          : input.mode === "existing"
-            ? "already_attached"
-            : "attached"
+        status: input.mode === "existing" ? "already_attached" : "attached"
       },
-      ...(activationError ? { error: activationError } : {}),
       session
     };
   }

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2336,7 +2336,17 @@ completes. Outer status badges should keep authoritative non-error lifecycle
 states, but when the outer projection is `failed`, they should let the latest
 turn's message status clear or confirm that failure. Keep unrecoverable
 activation/resume failures session-scoped; keep ordinary historical turn
-failures on the transcript row that produced them.
+failures on the transcript row that produced them. A terminal
+`AgentActivityTurn.error` is authoritative even when the provider emitted no
+assistant error message. The shared transcript projection must attach that
+error to the exact `turnId`: reuse an existing structured visible-error
+message, upgrade a matching plain assistant failure, or create one view-only
+error row keyed by `(agentSessionId, turnId)`. That fallback row is derived
+state, not a durable message or a replacement session-level `lastError`.
+Engine selectors for session operation errors must never fall back to active or
+latest Turn errors. Likewise, a successful create/attach response remains an
+attached session even when its initial or historical Turn failed; activation
+failure must come from the activation operation itself, not from Turn outcome.
 
 ### Message Parsing And Rendering
 
@@ -2347,6 +2357,10 @@ AgentActivityMessage payloads
   -> shared/agentConversation/projection
   -> transcript rows, tool calls, plans, approvals, interactive prompts
   -> AgentConversationFlow inside AgentGUINodeView
+
+AgentActivityTurn.error
+  -> shared transcript projection, reconciled with message errors by turnId
+  -> one fallback visible-error row on the owning Turn when messages lack one
 ```
 
 Message parsing belongs in shared projection/model helpers. React components

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -45,6 +45,7 @@ Provider discovery, installation, authentication, models, configuration, and run
 Turn state, loading, cancel, restore, rail projection, event updates, imports, and performance.
 
 - [AgentGUI turn actions return plain-text route 404s](./agent-session-lifecycle.md#agentgui-turn-actions-return-plain-text-route-404s)
+- [AgentGUI rail shows a failed Turn but the detail has no error](./agent-session-lifecycle.md#agentgui-rail-shows-a-failed-turn-but-the-detail-has-no-error)
 - [AgentGUI Stop reports no active turn after cancel succeeds](./agent-session-lifecycle.md#agentgui-stop-reports-no-active-turn-after-cancel-succeeds)
 - [AgentGUI send blocked by active_turn after settled snapshot](./agent-session-lifecycle.md#agentgui-send-blocked-by-activeturn-after-settled-snapshot)
 - [AgentGUI rejects a pasted image as unsupported before send](./agent-session-lifecycle.md#agentgui-rejects-a-pasted-image-as-unsupported-before-send)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -4,6 +4,43 @@
 
 Turn state, loading, cancel, restore, file-change undo, rail projection, event updates, imports, and performance.
 
+### AgentGUI rail shows a failed Turn but the detail has no error
+
+- Symptom:
+  The AgentGUI rail marks a conversation failed, but opening the conversation
+  shows only the preceding tool or assistant rows. Reloading the session does
+  not reveal why the Turn failed.
+- Quick checks:
+  Inspect the canonical Turn snapshot before debugging React state. Confirm the
+  owning Turn is terminal with `outcome = failed` or `interrupted` and has a
+  non-empty `error.message`. Then inspect that Turn's timeline messages for a
+  structured `visibleError` or a plain assistant message with the same error
+  text.
+- Root cause:
+  Turn outcome and error are durable canonical state, while provider transcript
+  messages are optional evidence. If detail rendering only projects transcript
+  messages, a runtime that settles `AgentActivityTurn.error` without emitting a
+  visible-error message leaves the rail and detail inconsistent. Reading only
+  the active Turn also loses the error as soon as settlement clears
+  `activeTurnId`.
+- Fix:
+  Reconcile terminal `AgentActivityTurn.error` in the shared transcript
+  projection by exact `turnId`. Reuse a structured visible error, upgrade a
+  matching plain assistant failure, or synthesize one view-only row with a
+  stable `(agentSessionId, turnId)` identity. Do not restore session
+  `lastError`, let session-operation selectors fall back to Turn errors,
+  reinterpret a successful attach as activation failure, persist a duplicate
+  message, or add component-local failure state.
+- Validation:
+  Cover a failed Turn with no provider error message, a matching plain failure,
+  and an existing structured visible error. The first must render one fallback
+  row and the latter two must remain single rows. Verify the result from both a
+  live snapshot and rebuilt session history.
+- References:
+  [workspaceAgentTurnErrorProjection.ts](../../../packages/agent/gui/shared/workspaceAgentTurnErrorProjection.ts)
+  [workspaceAgentTimelineCanonical.ts](../../../packages/agent/gui/shared/workspaceAgentTimelineCanonical.ts)
+  [agent-gui-node.md](../../architecture/agent-gui-node.md)
+
 ### Codex WebSocket reconnect rejects a long prompt metadata header
 
 - Symptom:

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.test.ts
@@ -5,6 +5,7 @@ import {
   rootEngineReducer
 } from "./rootReducer.ts";
 import {
+  selectEngineSessionOperationError,
   selectEngineSubmitAvailability,
   selectEngineSessionDeleted,
   selectRootAgentSessionIdsWithPendingInteractions,
@@ -12,6 +13,45 @@ import {
   selectWorkspaceAgentConsumerSession,
   selectWorkspaceAgentRootConversationSessions
 } from "./sessionLifecycle.selectors.ts";
+
+test("session operation errors do not fall back to canonical Turn errors", () => {
+  let state = rootEngineReducer(createInitialAgentSessionEngineState(), {
+    sessions: [
+      {
+        activeTurn: {
+          agentSessionId: "session-1",
+          error: { message: "Selected model is at capacity" },
+          origin: "user_prompt",
+          phase: "running",
+          startedAtUnixMs: 10,
+          turnId: "turn-1",
+          updatedAtUnixMs: 20
+        },
+        activeTurnId: "turn-1",
+        agentSessionId: "session-1",
+        cwd: "/workspace",
+        latestTurnInteractions: [],
+        pendingInteractions: [],
+        provider: "codex",
+        title: "Canonical session",
+        workspaceId: "workspace-1"
+      }
+    ],
+    type: "session/snapshotReceived"
+  }).state;
+
+  assert.equal(selectEngineSessionOperationError(state, "session-1"), null);
+
+  state = rootEngineReducer(state, {
+    agentSessionId: "session-1",
+    errorMessage: "Settings update failed",
+    type: "session/errorRecorded"
+  }).state;
+  assert.equal(
+    selectEngineSessionOperationError(state, "session-1"),
+    "Settings update failed"
+  );
+});
 
 test("deleted session selector normalizes ids and hides tombstone storage", () => {
   const state = rootEngineReducer(createInitialAgentSessionEngineState(), {

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
@@ -273,16 +273,17 @@ export function selectEngineHasPendingInteractions(
   return selectEnginePendingInteractions(state, agentSessionId).length > 0;
 }
 
-export function selectEngineSessionError(
+/**
+ * Returns only failures from session-scoped commands. Canonical Turn failures
+ * belong to the owning Turn and must not be promoted into session chrome.
+ */
+export function selectEngineSessionOperationError(
   state: AgentSessionEngineState,
   agentSessionId: string | null | undefined
 ): string | null {
   const id = agentSessionId?.trim() ?? "";
-  const record = state.sessionLifecycle.operationBySessionId[id];
   return (
-    record?.operationError ??
-    selectEngineActiveTurn(state, id)?.error?.message ??
-    null
+    state.sessionLifecycle.operationBySessionId[id]?.operationError ?? null
   );
 }
 

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -127,7 +127,7 @@ export {
   selectEngineSessionDeleted,
   selectEngineSessionIsRespondingToInteraction,
   selectEngineSessionSettingsUpdate,
-  selectEngineSessionError,
+  selectEngineSessionOperationError,
   selectEngineSessionOperation,
   selectEngineSubmitAvailability,
   selectEngineTurnsForSession,
@@ -299,7 +299,4 @@ export type {
   AgentActivityUpdatedApplyResult,
   AgentActivityUpdatedEvent
 } from "./types.ts";
-export {
-  workspaceAgentSessionLastError,
-  workspaceAgentSessionStatus
-} from "./workspaceAgentSessionProjection.ts";
+export { workspaceAgentSessionStatus } from "./workspaceAgentSessionProjection.ts";

--- a/packages/agent/activity-core/src/workspaceAgentSessionProjection.ts
+++ b/packages/agent/activity-core/src/workspaceAgentSessionProjection.ts
@@ -36,16 +36,3 @@ export function workspaceAgentSessionStatus(
       return "unknown";
   }
 }
-
-export function workspaceAgentSessionLastError(
-  session: Pick<
-    WorkspaceAgentSessionProjectionInput,
-    "activeTurn" | "latestTurn"
-  >
-): string | null {
-  return (
-    session.activeTurn?.error?.message?.trim() ||
-    session.latestTurn?.error?.message?.trim() ||
-    null
-  );
-}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionEngineState.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionEngineState.ts
@@ -12,7 +12,7 @@ import {
   selectEngineSessionDeleted,
   selectEngineSessionDetailHydrated,
   selectEngineSessionDetailLoading,
-  selectEngineSessionError,
+  selectEngineSessionOperationError,
   selectEngineSessionIsRespondingToInteraction,
   selectEngineSessionReconcile,
   selectEngineSessionSettingsUpdate,
@@ -150,8 +150,8 @@ export function useAgentGUISessionEngineState(input: {
     activeEngineActiveTurn,
     activeEngineSession
   ]);
-  const activeEngineLifecycleError = useEngineSelector(sessionEngine, (state) =>
-    selectEngineSessionError(state, activeConversationId)
+  const activeEngineOperationError = useEngineSelector(sessionEngine, (state) =>
+    selectEngineSessionOperationError(state, activeConversationId)
   );
   const activeEngineQueueError = useEngineSelector(sessionEngine, (state) =>
     selectEnginePromptQueueError(state, activeConversationId)
@@ -164,7 +164,7 @@ export function useAgentGUISessionEngineState(input: {
     selectEngineSessionSettingsUpdate(state, activeConversationId)
   );
   const activeEngineError =
-    activeEngineLifecycleError ??
+    activeEngineOperationError ??
     activeEngineInteractionError ??
     activeEngineSettingsUpdate?.errorMessage ??
     activeEngineQueueError;

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentTimelineProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentTimelineProjection.spec.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   normalizeAgentActivitySession,
-  type AgentActivitySession
+  type AgentActivitySession,
+  type AgentActivityTurn
 } from "@tutti-os/agent-activity-core";
 import type { WorkspaceAgentActivityTimelineItem } from "../../workspaceAgentTimelineTypes";
 import type { WorkspaceAgentActivityCard } from "../../workspaceAgentActivityListViewModel";
@@ -278,6 +279,156 @@ describe("projectWorkspaceAgentTimelineToConversationVM", () => {
       detail: "Config invalid",
       retryable: false
     });
+  });
+
+  it("projects a terminal canonical Turn error when the provider emitted no error message", () => {
+    const failed = failedTurn({
+      error: {
+        message: "Selected model is at capacity. Please try a different model."
+      }
+    });
+    const input = {
+      activity: activity(),
+      session: session({ latestTurn: failed }),
+      sessionTurns: [failed],
+      workspaceRoot: "/workspace/demo",
+      timelineItems: [timelineItems()[0]!]
+    };
+    const detail = buildCanonicalWorkspaceAgentDetailView(input);
+    const conversation = projectWorkspaceAgentTimelineToConversationVM(input);
+
+    expect(detail.turns[0]?.agentMessages).toEqual([
+      expect.objectContaining({
+        id: "turn-error:session-1:turn-1",
+        body: "Selected model is at capacity. Please try a different model.",
+        statusKind: "failed",
+        visibleError: {
+          code: null,
+          phase: "turn",
+          provider: "codex",
+          detail:
+            "Selected model is at capacity. Please try a different model.",
+          retryable: null
+        }
+      })
+    ]);
+    expect(
+      conversation.rows.flatMap((row) =>
+        row.kind === "message" && row.speaker === "assistant"
+          ? row.messages
+          : []
+      )
+    ).toEqual([
+      expect.objectContaining({
+        id: "turn-error:session-1:turn-1",
+        visibleError: expect.objectContaining({
+          detail: "Selected model is at capacity. Please try a different model."
+        })
+      })
+    ]);
+  });
+
+  it("upgrades a matching assistant failure instead of duplicating the Turn error", () => {
+    const failed = failedTurn({
+      error: { code: "provider_error", message: "Provider unavailable" }
+    });
+    const detail = buildCanonicalWorkspaceAgentDetailView({
+      activity: activity(),
+      session: session({ latestTurn: failed }),
+      sessionTurns: [failed],
+      workspaceRoot: "/workspace/demo",
+      timelineItems: [
+        timelineItems()[0]!,
+        {
+          ...timelineItems()[1]!,
+          content: "Provider unavailable",
+          status: "failed"
+        }
+      ]
+    });
+
+    expect(detail.turns[0]?.agentMessages).toHaveLength(1);
+    expect(detail.turns[0]?.agentMessages[0]).toEqual(
+      expect.objectContaining({
+        id: "event-2",
+        visibleError: expect.objectContaining({
+          code: "provider_error",
+          detail: "Provider unavailable"
+        })
+      })
+    );
+  });
+
+  it("keeps an existing structured visible error as the single Turn failure row", () => {
+    const failed = failedTurn({
+      error: { code: "provider_error", message: "Canonical provider failure" }
+    });
+    const detail = buildCanonicalWorkspaceAgentDetailView({
+      activity: activity(),
+      session: session({ latestTurn: failed }),
+      sessionTurns: [failed],
+      workspaceRoot: "/workspace/demo",
+      timelineItems: [
+        timelineItems()[0]!,
+        {
+          ...timelineItems()[1]!,
+          status: "failed",
+          content: "Provider request failed",
+          payload: {
+            kind: "agent_visible_error",
+            code: "provider_error",
+            phase: "run",
+            provider: "codex",
+            detail: "Provider request failed",
+            retryable: true
+          }
+        }
+      ]
+    });
+
+    expect(detail.turns[0]?.agentMessages).toHaveLength(1);
+    expect(detail.turns[0]?.agentMessages[0]?.id).toBe("event-2");
+    expect(detail.turns[0]?.agentMessages[0]?.visibleError?.detail).toBe(
+      "Provider request failed"
+    );
+  });
+
+  it("keeps a historical Turn error attached to its owning Turn", () => {
+    const failed = failedTurn();
+    const completed: AgentActivityTurn = {
+      ...failed,
+      error: null,
+      outcome: "completed",
+      turnId: "turn-2",
+      startedAtUnixMs: 20,
+      settledAtUnixMs: 30,
+      updatedAtUnixMs: 30
+    };
+    const detail = buildCanonicalWorkspaceAgentDetailView({
+      activity: activity(),
+      session: session({ latestTurn: completed }),
+      sessionTurns: [failed, completed],
+      workspaceRoot: "/workspace/demo",
+      timelineItems: [
+        timelineItems()[0]!,
+        {
+          ...timelineItems()[0]!,
+          id: 20,
+          seq: 20,
+          eventId: "event-20",
+          turnId: "turn-2",
+          content: "Try again",
+          occurredAtUnixMs: 20,
+          createdAtUnixMs: 20
+        }
+      ]
+    });
+
+    expect(detail.turns.map((turn) => turn.id)).toEqual(["turn-1", "turn-2"]);
+    expect(detail.turns[0]?.agentMessages[0]?.visibleError?.detail).toBe(
+      "Turn failed"
+    );
+    expect(detail.turns[1]?.agentMessages).toHaveLength(0);
   });
 
   it("projects transport notices without merging them into assistant content", () => {
@@ -640,6 +791,23 @@ function activeTurn(phase: "running" | "settled") {
     startedAtUnixMs: 1,
     turnId: "turn-1",
     updatedAtUnixMs: 10
+  };
+}
+
+function failedTurn(
+  overrides: Partial<AgentActivityTurn> = {}
+): AgentActivityTurn {
+  return {
+    agentSessionId: "session-1",
+    error: { message: "Turn failed" },
+    origin: "user_prompt",
+    outcome: "failed",
+    phase: "settled",
+    settledAtUnixMs: 10,
+    startedAtUnixMs: 1,
+    turnId: "turn-1",
+    updatedAtUnixMs: 10,
+    ...overrides
   };
 }
 

--- a/packages/agent/gui/shared/workspaceAgentTimelineCanonical.ts
+++ b/packages/agent/gui/shared/workspaceAgentTimelineCanonical.ts
@@ -38,6 +38,7 @@ import {
   visibleErrorFromPayload,
   withSourceTimelineItems
 } from "./workspaceAgentTimelineProjectionHelpers";
+import { projectCanonicalTurnErrors } from "./workspaceAgentTurnErrorProjection";
 
 export function buildCanonicalWorkspaceAgentDetailView({
   activity,
@@ -183,6 +184,18 @@ export function buildCanonicalWorkspaceAgentDetailView({
       turn.agentItems.push({ kind: "message", message });
     }
   }
+
+  projectCanonicalTurnErrors({
+    turns,
+    sessionTurns:
+      sessionTurns.length > 0
+        ? sessionTurns
+        : session.latestTurn
+          ? [session.latestTurn]
+          : [],
+    provider: session.provider,
+    agentSessionId: session.agentSessionId
+  });
 
   const visibleTurns = [...turns.values()].filter(
     (turn) => turn.userMessages.length > 0 || turn.agentItems.length > 0

--- a/packages/agent/gui/shared/workspaceAgentTurnErrorProjection.ts
+++ b/packages/agent/gui/shared/workspaceAgentTurnErrorProjection.ts
@@ -1,0 +1,96 @@
+import type { AgentActivityTurn } from "@tutti-os/agent-activity-core";
+import type {
+  WorkspaceAgentSessionDetailMessage,
+  WorkspaceAgentSessionDetailTurn
+} from "./workspaceAgentSessionDetailViewModel";
+
+export function projectCanonicalTurnErrors({
+  turns,
+  sessionTurns,
+  provider,
+  agentSessionId
+}: {
+  turns: Map<string, WorkspaceAgentSessionDetailTurn>;
+  sessionTurns: readonly AgentActivityTurn[];
+  provider: string;
+  agentSessionId: string;
+}): void {
+  for (const canonicalTurn of sessionTurns) {
+    if (
+      canonicalTurn.outcome !== "failed" &&
+      canonicalTurn.outcome !== "interrupted"
+    ) {
+      continue;
+    }
+    const detail = canonicalTurn.error?.message.trim() ?? "";
+    if (!detail) {
+      continue;
+    }
+
+    const turn = getOrCreateTurn(turns, canonicalTurn.turnId);
+    if (turn.agentMessages.some((message) => message.visibleError)) {
+      continue;
+    }
+
+    const matchingMessage = turn.agentMessages.find(
+      (message) => message.body.trim() === detail
+    );
+    if (matchingMessage) {
+      matchingMessage.status = "failed";
+      matchingMessage.statusKind = "failed";
+      matchingMessage.visibleError = visibleErrorFromCanonicalTurn(
+        canonicalTurn,
+        provider
+      );
+      continue;
+    }
+
+    const message: WorkspaceAgentSessionDetailMessage = {
+      id: `turn-error:${agentSessionId}:${canonicalTurn.turnId}`,
+      body: detail,
+      status: "failed",
+      statusKind: "failed",
+      turnId: canonicalTurn.turnId,
+      occurredAtUnixMs:
+        canonicalTurn.settledAtUnixMs ?? canonicalTurn.updatedAtUnixMs,
+      visibleError: visibleErrorFromCanonicalTurn(canonicalTurn, provider)
+    };
+    turn.agentMessages.push(message);
+    turn.agentItems.push({ kind: "message", message });
+  }
+}
+
+function getOrCreateTurn(
+  turns: Map<string, WorkspaceAgentSessionDetailTurn>,
+  turnId: string
+): WorkspaceAgentSessionDetailTurn {
+  const existing = turns.get(turnId);
+  if (existing) {
+    return existing;
+  }
+  const turn: WorkspaceAgentSessionDetailTurn = {
+    id: turnId,
+    userMessage: null,
+    userMessages: [],
+    agentMessages: [],
+    toolCalls: [],
+    toolCallCount: 0,
+    hasFailedToolCall: false,
+    agentItems: []
+  };
+  turns.set(turnId, turn);
+  return turn;
+}
+
+function visibleErrorFromCanonicalTurn(
+  turn: AgentActivityTurn,
+  provider: string
+): NonNullable<WorkspaceAgentSessionDetailMessage["visibleError"]> {
+  return {
+    code: turn.error?.code?.trim() || null,
+    phase: "turn",
+    provider: provider.trim() || null,
+    detail: turn.error?.message.trim() || null,
+    retryable: null
+  };
+}


### PR DESCRIPTION
## Summary

- project terminal canonical Turn errors into the owning AgentGUI transcript Turn, including providers that emit no visible-error message
- reuse structured visible errors, upgrade matching plain assistant failures, and deduplicate the view-only fallback row
- remove legacy paths that promoted active Turn failures into session operation errors or reinterpreted failed Turns as activation failures
- document the Turn-versus-session error ownership rule and the troubleshooting workflow

Expected behavior:
- a failed Turn always has an error card in the right detail panel
- historical errors stay attached to their original Turn and survive reload
- later successful Turns can clear the rail failure state without moving or erasing the older error
- successful create or attach operations stay attached even when the initial or historical Turn failed
- genuine activation, recovery, and session operation errors continue through their dedicated session-scoped channels

## Verification

- `pnpm check:full` — passed 18 tasks
- `pnpm --filter @tutti-os/agent-gui test` — 194 files, 1806 tests passed
- `pnpm --filter @tutti-os/agent-activity-core test` — 207 tests passed
- focused desktop activity service tests — 36 tests passed
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm lint:ts`
- `pnpm typecheck`
- `pnpm --filter @tutti-os/desktop build`

## Fix Scope Justification

- Root cause: the daemon already persisted the failure on canonical `AgentActivityTurn.error`, but AgentGUI detail projection only rendered transcript messages. Providers are not required to emit a separate visible-error message, while legacy selectors incorrectly mixed Turn errors into session operation and activation state.
- Why can this not be fixed at a lower layer? The durable Turn is already correct at the daemon/runtime boundary. Requiring every provider to synthesize another durable message would duplicate state and would not repair existing history. Shared transcript projection is the lowest common layer that can reconcile canonical Turn state with optional provider messages without introducing a second business-state owner.

## Fallback Three Questions

- Source: a terminal `failed` or `interrupted` Turn with a non-empty canonical `error.message` but no structured or matching assistant error message.
- Why can it not be fixed at that source? Provider transcript capabilities differ, message emission is optional, and previously persisted sessions cannot be backfilled safely. The canonical Turn already carries the authoritative error.
- Removal condition: the fallback can be removed only if the runtime contract requires and backfills exactly one durable visible-error message for every failed or interrupted Turn across all providers and historical sessions.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
