### PR TITLE
chore(agent-host): add boundary governance docs and ratchet check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,6 +28,7 @@ delete otherwise.
 
 ## Checklist
 
+- [ ] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
 - [ ] I kept the change focused on one concern.
 - [ ] I updated documentation when behavior, setup, or contributor workflow changed.
 - [ ] I updated all README/CONTRIBUTING language variants when changing their English source.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -377,6 +377,9 @@ jobs:
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check agent host boundary
+        run: pnpm check:agent-host-boundary
+
       - name: Generate builtin apps
         run: pnpm generate:builtin-apps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,53 @@ Read the closest `AGENTS.md` before editing:
 
 Use this root file for repository-wide defaults only. Area-specific files win.
 
+Route agent application-core requests to `packages/agent/host` first. If a
+request mentions agent session, turn, goal, or runtime-operation lifecycle,
+creation, resume, send, cancel, recovery, or the agent host boundary, read
+`packages/agent/host/README.md` and the `Agent Host Boundary` section below
+before planning or editing, then the nearest area `AGENTS.md`.
+
 Also route by module name, not only by path. If a request mentions AgentGUI,
 AgentGuiNode, Agent GUI, the agent conversation module, agent composer,
 workspace agent timeline, agent approvals, or interactive agent prompts, read
 `docs/architecture/agent-gui-node.md` first, then
 `packages/agent/gui/AGENTS.md`, before planning or editing, even when no file
 path is supplied.
+
+## Agent Host Boundary
+
+Agent application-core lifecycle semantics have a single owner:
+`packages/agent/host`. That package owns when a session, turn, goal, or
+runtime-operation is created, when it may be sent, when it reaches a terminal
+state, and how it is recovered. `services/tuttid/service/agent` and other Host
+consumers such as tsh `cmd/desktopd` are adapter surfaces that translate
+HTTP, query, composer, analytics, transport, and provider-preparation concerns
+and delegate lifecycle through `ApplicationHost()`.
+
+Before adding or changing agent behavior, answer the decision rule:
+
+> Does this change define or change the lifecycle semantics of a
+> session/turn/goal/runtime-operation (when it is created, when it may be sent,
+> when it is terminal, how it is recovered)?
+>
+> - Yes -> it must live in `packages/agent/host` (tuttid and tsh write only
+>   delegate/adapter code).
+> - No (transport, DTO, query, presentation, product policy) -> adapter.
+> - Unsure -> answer in the PR description: "Does tsh (or another Host consumer)
+>   also need this behavior?" If yes, it belongs in Host.
+
+New lifecycle semantics must first gain a scenario in
+`packages/agent/host/conformance`; scenarios may only program against the Host
+contract. When a consumer finds a missing Host capability, add the Host API in
+`packages/agent/host` and release it, rather than reimplementing it in the
+adapter. The `GetSession`, `UpdateSettings`, `UpdatePin`, and `DeleteSession`
+APIs were added to Host this way (PR #1329) after tsh's cutover surfaced them,
+instead of being reimplemented in tsh.
+
+`services/tuttid/service/agent/AGENTS.md` records the adapter-only rules for
+that directory, and `pnpm check:agent-host-boundary` ratchets against new
+`*Coordinator`/`*Worker`/`*Actor` orchestration surfaces landing in the
+adapter.
 
 ## Contribution Workflow
 

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -28,6 +28,7 @@ Repository entrypoints:
 - `pnpm typecheck`
 - `pnpm check:codexproto-generated`
 - `pnpm check:agent-gui-provider-catalog-generated`
+- `pnpm check:agent-host-boundary`
 - `pnpm check:agent-provider-strategy-boundaries`
 
 `pnpm check:full` remains the full local and CI validation command and includes linting and typechecking.
@@ -190,6 +191,26 @@ change touches `packages/agent/gui`, `packages/agent/activity-core`, Desktop's
 `workspace-agent` or `workspace-workbench` features, or the checker/fixture
 implementation itself. This keeps the same boundary in the normal changed-file
 loop instead of discovering violations only in `check:full`.
+
+`pnpm check:agent-host-boundary` protects the Agent Host boundary. Agent
+application-core lifecycle semantics (session/turn/goal/runtime-operation
+creation, sendability, terminal state, recovery) belong to
+`packages/agent/host`; `services/tuttid/service/agent` is an adapter that
+delegates through `ApplicationHost()`. The check scans production (non
+`_test.go`) Go files under `services/tuttid/service/agent` and rejects new
+`*Coordinator`, `*Worker`, or `*Actor` orchestration surfaces, detected as a
+type declaration whose name ends in one of those words or a file whose name
+ends in `_coordinator.go`, `_worker.go`, or `_actor.go`. It is a ratchet: the
+`ALLOWLIST` in the checker is the current snapshot (only
+`composer_live_model_coordinator.go`, a provider-catalog adapter concern), may
+only shrink, and rejects stale entries whose files no longer exist. A new
+violation fails until the orchestration moves to `packages/agent/host` or the
+file is added to `ALLOWLIST` with a reviewed ownership reason. The rule runs in
+`pnpm check:full`, in the `check:changed` `boundary:agent-host` lane whenever a
+change touches `services/tuttid/service/agent` or the checker/fixture itself,
+and in the PR `go-lint` job. The boundary rationale and adapter rules live in
+the root `AGENTS.md` `Agent Host Boundary` section and
+`services/tuttid/service/agent/AGENTS.md`.
 
 ## Agent GUI Degradation Ratchet
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "check:agent-gui-degradation": "node ./tools/scripts/check-agent-gui-degradation.mjs",
     "check:agent-gui-degradation:staged": "node ./tools/scripts/check-agent-gui-degradation.mjs --staged",
     "check:agent-gui-provider-catalog-generated": "node ./tools/scripts/check-agent-gui-provider-catalog.mjs",
+    "check:agent-host-boundary": "node ./tools/scripts/check-agent-host-boundary.mjs",
     "check:agent-provider-strategy-boundaries": "node ./tools/scripts/check-agent-provider-strategy-boundaries.mjs",
     "check:codexproto-generated": "node ./tools/scripts/check-codexproto-generated.mjs",
     "check:defaults-generated": "node ./tools/scripts/generate-defaults.mjs --check",

--- a/services/tuttid/service/agent/AGENTS.md
+++ b/services/tuttid/service/agent/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md
+
+## Scope
+
+This file applies to `services/tuttid/service/agent/*`.
+
+This directory is an **adapter** onto `packages/agent/host`. It translates
+HTTP, query, composer, analytics, transport, and provider-preparation concerns
+and delegates agent lifecycle through `ApplicationHost()`. It is not the agent
+application core. Read the root `Agent Host Boundary` section and
+`packages/agent/host/README.md` before editing here.
+
+## Decision rule
+
+> Does this change define or change the lifecycle semantics of a
+> session/turn/goal/runtime-operation (when it is created, when it may be sent,
+> when it is terminal, how it is recovered)?
+>
+> - Yes -> it belongs in `packages/agent/host`. Only delegate/adapter code
+>   lands here.
+> - No (transport, DTO, query, presentation, product policy) -> it may land
+>   here.
+> - Unsure -> answer in the PR description: "Does tsh (or another Host consumer)
+>   also need this behavior?" If yes, it belongs in Host.
+
+New lifecycle semantics must first gain a scenario in
+`packages/agent/host/conformance`. Conformance scenarios may only program
+against the Host contract, never against this adapter.
+
+## When Host is missing a capability
+
+Do not reimplement the missing behavior here. Add the API in
+`packages/agent/host`, cover it with a conformance scenario, release the Host
+package, then delegate to it from this adapter.
+
+`GetSession`, `UpdateSettings`, `UpdatePin`, and `DeleteSession` were missed
+during tsh's `cmd/desktopd` cutover. The correct fix was to add those Host APIs
+in `packages/agent/host` (PR #1329) so both tuttid and tsh delegate to one
+implementation, not to reimplement them in either adapter.
+
+## Forbidden patterns
+
+- Introducing a new `*Coordinator`, `*Worker`, or `*Actor` production type or
+  file that orchestrates session/turn/goal/runtime-operation lifecycle. These
+  belong in `packages/agent/host`. `pnpm check:agent-host-boundary` enforces a
+  ratchet: the current allowlist is a snapshot, and a new orchestration surface
+  fails the check until it is either moved to Host or explicitly added to the
+  allowlist with a reviewed ownership reason.
+- Bypassing `ApplicationHost()` to orchestrate lifecycle directly (open a
+  session, decide sendability, drive resume/cancel/recovery, or advance a goal
+  saga) inside this package.
+- Calling a canonical store write interface directly to make a lifecycle
+  decision. Semantic writes go through Host; adapters only repair re-derivable
+  projections while consuming canonical state.
+
+## Checks
+
+- `pnpm check:agent-host-boundary` runs the boundary ratchet for this
+  directory. It also runs in `pnpm check:full`, in the `check:changed`
+  `boundary:agent-host` lane when files here change, and in PR CI.
+- Daemon Go validation for this package follows `services/tuttid/AGENTS.md`.

--- a/tools/scripts/check-agent-host-boundary.mjs
+++ b/tools/scripts/check-agent-host-boundary.mjs
@@ -32,6 +32,14 @@ const ALLOWLIST = new Set([
 const ORCHESTRATION_TYPE =
   /^\s*type\s+[A-Za-z0-9_]*(?:Coordinator|Worker|Actor)\s+(?:struct|interface)\b/u;
 
+// The same declaration inside a grouped `type ( ... )` block, where the `type`
+// keyword is on the opening line instead of the declaration line.
+const GROUPED_ORCHESTRATION_TYPE =
+  /^\s*[A-Za-z0-9_]*(?:Coordinator|Worker|Actor)\s+(?:struct|interface)\b/u;
+
+// Opens a grouped `type ( ... )` declaration block.
+const TYPE_GROUP_OPEN = /^\s*type\s*\(/u;
+
 // A production file whose name ends in one of these words is treated as an
 // application-core orchestration file.
 const ORCHESTRATION_FILENAME = /_(?:coordinator|worker|actor)\.go$/iu;
@@ -59,13 +67,61 @@ export function findBoundaryViolations(path, source) {
     );
   }
 
+  // Track grouped `type ( ... )` blocks so declarations inside them are
+  // checked too. `braceDepth` keeps struct/interface bodies (and their fields)
+  // from being treated as top-level declarations of the group.
+  let inTypeGroup = false;
+  let braceDepth = 0;
+
   for (const [index, line] of source.split(/\r?\n/u).entries()) {
     if (ORCHESTRATION_TYPE.test(line)) {
       violations.push(`${path}:${index + 1}: ${line.trim()}`);
+      continue;
+    }
+
+    if (inTypeGroup) {
+      if (braceDepth === 0) {
+        if (/^\s*\)/u.test(line)) {
+          inTypeGroup = false;
+          continue;
+        }
+        if (GROUPED_ORCHESTRATION_TYPE.test(line)) {
+          violations.push(`${path}:${index + 1}: ${line.trim()}`);
+        }
+      }
+      braceDepth += countUnquotedBraces(line);
+      continue;
+    }
+
+    if (TYPE_GROUP_OPEN.test(line)) {
+      inTypeGroup = true;
+      braceDepth = 0;
+      const remainder = line.slice(line.indexOf("(") + 1);
+      if (GROUPED_ORCHESTRATION_TYPE.test(remainder)) {
+        violations.push(`${path}:${index + 1}: ${line.trim()}`);
+      }
+      braceDepth += countUnquotedBraces(remainder);
     }
   }
 
   return violations;
+}
+
+function countUnquotedBraces(line) {
+  const withoutComments = line.replace(/\/\/.*$/u, "");
+  const withoutStrings = withoutComments.replace(
+    /"(?:[^"\\]|\\.)*"|`[^`]*`/gu,
+    ""
+  );
+  let depth = 0;
+  for (const character of withoutStrings) {
+    if (character === "{") {
+      depth += 1;
+    } else if (character === "}") {
+      depth -= 1;
+    }
+  }
+  return depth;
 }
 
 export function findStaleAllowlistEntries(fileExists = existsSync) {

--- a/tools/scripts/check-agent-host-boundary.mjs
+++ b/tools/scripts/check-agent-host-boundary.mjs
@@ -1,0 +1,132 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const workspaceRoot = resolve(dirname(scriptPath), "../..");
+
+// Agent application lifecycle semantics (session/turn/goal/runtime-operation
+// creation, sendability, terminal state, recovery) belong to
+// `packages/agent/host`. `services/tuttid/service/agent` is an adapter surface:
+// HTTP/query/composer/analytics/transport translation that delegates through
+// `ApplicationHost()`. Introducing a new lifecycle orchestration type here
+// (a `*Coordinator`, `*Worker`, or `*Actor` production type/file) rebuilds the
+// application core in the adapter and is rejected. See
+// `packages/agent/host/README.md` and the conformance harness under
+// `packages/agent/host/conformance`.
+const scanRoot = "services/tuttid/service/agent";
+
+// Ratchet snapshot. These files predate the boundary check and are the only
+// production files permitted to carry a lifecycle-orchestration name. The list
+// may only shrink. Adding a new violation requires an explicit, reviewed edit
+// here with an ownership reason, which is the whole point of the ratchet: new
+// application-core orchestration must land in `packages/agent/host`, not here.
+const ALLOWLIST = new Set([
+  // Composer live-model discovery is a provider-catalog adapter concern, not
+  // session/turn/goal lifecycle. It predates this check.
+  "services/tuttid/service/agent/composer_live_model_coordinator.go"
+]);
+
+// A production type whose name ends in one of these words is treated as an
+// application-core orchestration type.
+const ORCHESTRATION_TYPE =
+  /^\s*type\s+[A-Za-z0-9_]*(?:Coordinator|Worker|Actor)\s+(?:struct|interface)\b/u;
+
+// A production file whose name ends in one of these words is treated as an
+// application-core orchestration file.
+const ORCHESTRATION_FILENAME = /_(?:coordinator|worker|actor)\.go$/iu;
+
+export function isTestSource(path) {
+  return path.endsWith("_test.go");
+}
+
+export function isAllowlisted(path) {
+  return ALLOWLIST.has(path);
+}
+
+export function findBoundaryViolations(path, source) {
+  if (isTestSource(path) || isAllowlisted(path)) {
+    return [];
+  }
+
+  const violations = [];
+
+  if (ORCHESTRATION_FILENAME.test(path)) {
+    violations.push(
+      `${path}: filename declares an agent application-core orchestration surface ` +
+        `(*Coordinator/*Worker/*Actor). Move session/turn/goal/runtime-operation ` +
+        `lifecycle into packages/agent/host and keep only delegate/adapter code here.`
+    );
+  }
+
+  for (const [index, line] of source.split(/\r?\n/u).entries()) {
+    if (ORCHESTRATION_TYPE.test(line)) {
+      violations.push(`${path}:${index + 1}: ${line.trim()}`);
+    }
+  }
+
+  return violations;
+}
+
+export function findStaleAllowlistEntries(fileExists = existsSync) {
+  const stale = [];
+  for (const entry of ALLOWLIST) {
+    if (!fileExists(join(workspaceRoot, entry))) {
+      stale.push(entry);
+    }
+  }
+  return stale;
+}
+
+function scanWorkspace() {
+  const violations = [];
+  for (const file of goFiles(join(workspaceRoot, scanRoot))) {
+    const path = relative(workspaceRoot, file).replaceAll("\\", "/");
+    violations.push(
+      ...findBoundaryViolations(path, readFileSync(file, "utf8"))
+    );
+  }
+  return violations;
+}
+
+function goFiles(directory) {
+  const result = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      result.push(...goFiles(path));
+    } else if (entry.isFile() && entry.name.endsWith(".go")) {
+      result.push(path);
+    }
+  }
+  return result;
+}
+
+function isMainModule() {
+  return Boolean(process.argv[1] && resolve(process.argv[1]) === scriptPath);
+}
+
+if (isMainModule()) {
+  const stale = findStaleAllowlistEntries();
+  if (stale.length > 0) {
+    console.error(
+      "Agent Host boundary allowlist has stale entries. Remove files that no " +
+        "longer exist so the ratchet cannot hide removed seams:\n" +
+        stale.join("\n")
+    );
+    process.exitCode = 1;
+  }
+
+  const violations = scanWorkspace();
+  if (violations.length > 0) {
+    console.error(
+      "Agent application lifecycle semantics must live in packages/agent/host, " +
+        "not in the services/tuttid/service/agent adapter. Remove the new " +
+        "*Coordinator/*Worker/*Actor orchestration surface, or, only with a " +
+        "reviewed ownership reason, add it to ALLOWLIST in " +
+        "tools/scripts/check-agent-host-boundary.mjs:\n" +
+        violations.join("\n")
+    );
+    process.exitCode = 1;
+  }
+}

--- a/tools/scripts/check-agent-host-boundary.test.mjs
+++ b/tools/scripts/check-agent-host-boundary.test.mjs
@@ -40,6 +40,63 @@ test("flags new *Worker and *Actor type declarations, struct and interface", () 
   );
 });
 
+test("flags orchestration type declarations inside a grouped type block", () => {
+  const source = [
+    "package agent",
+    "",
+    "type (",
+    "\tsessionRef struct {",
+    "\t\tid string",
+    "\t}",
+    "\tturnResumeCoordinator struct {",
+    "\t\tstore CanonicalStore",
+    "\t}",
+    "\tgoalSagaWorker interface {",
+    "\t\tRun(ctx context.Context) error",
+    "\t}",
+    ")"
+  ].join("\n");
+  assert.deepEqual(
+    findBoundaryViolations(
+      "services/tuttid/service/agent/turn_orchestration.go",
+      source
+    ),
+    [
+      "services/tuttid/service/agent/turn_orchestration.go:7: turnResumeCoordinator struct {",
+      "services/tuttid/service/agent/turn_orchestration.go:10: goalSagaWorker interface {"
+    ]
+  );
+});
+
+test("allows non-orchestration types inside a grouped type block", () => {
+  const source = [
+    "package agent",
+    "",
+    "type (",
+    "\tsessionFilter struct {",
+    "\t\tworkerPool string",
+    "\t}",
+    "\tcoordinatorHandle struct {",
+    "\t\tref string",
+    "\t}",
+    "\tmodelCatalog interface {",
+    "\t\tList(ctx context.Context) ([]string, error)",
+    "\t}",
+    ")",
+    "",
+    "func afterGroup() {",
+    "\t// a later brace-heavy body must not leak group state",
+    "}"
+  ].join("\n");
+  assert.deepEqual(
+    findBoundaryViolations(
+      "services/tuttid/service/agent/composer_options.go",
+      source
+    ),
+    []
+  );
+});
+
 test("flags a new orchestration-named production file by filename", () => {
   const violations = findBoundaryViolations(
     "services/tuttid/service/agent/turn_send_worker.go",

--- a/tools/scripts/check-agent-host-boundary.test.mjs
+++ b/tools/scripts/check-agent-host-boundary.test.mjs
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  findBoundaryViolations,
+  findStaleAllowlistEntries,
+  isAllowlisted,
+  isTestSource
+} from "./check-agent-host-boundary.mjs";
+
+test("flags a new *Coordinator production type declaration", () => {
+  const source = [
+    "package agent",
+    "",
+    "type sessionLifecycleCoordinator struct {",
+    "\tstore CanonicalStore",
+    "}"
+  ].join("\n");
+  assert.deepEqual(
+    findBoundaryViolations(
+      "services/tuttid/service/agent/session_lifecycle.go",
+      source
+    ),
+    [
+      "services/tuttid/service/agent/session_lifecycle.go:3: type sessionLifecycleCoordinator struct {"
+    ]
+  );
+});
+
+test("flags new *Worker and *Actor type declarations, struct and interface", () => {
+  const source = [
+    "type turnResumeWorker struct {}",
+    "type GoalRevisionActor interface {}"
+  ].join("\n");
+  assert.equal(
+    findBoundaryViolations(
+      "services/tuttid/service/agent/turn_orchestration.go",
+      source
+    ).length,
+    2
+  );
+});
+
+test("flags a new orchestration-named production file by filename", () => {
+  const violations = findBoundaryViolations(
+    "services/tuttid/service/agent/turn_send_worker.go",
+    "package agent\n"
+  );
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /filename declares an agent application-core/u);
+});
+
+test("allows adapter code that does not orchestrate lifecycle", () => {
+  const source = [
+    "package agent",
+    "",
+    "func (s *Service) getSession(ctx context.Context, id string) error {",
+    "\treturn s.ApplicationHost().GetSession(ctx, id)",
+    "}"
+  ].join("\n");
+  assert.deepEqual(
+    findBoundaryViolations(
+      "services/tuttid/service/agent/service_session.go",
+      source
+    ),
+    []
+  );
+});
+
+test("does not treat non-suffix names as orchestration types", () => {
+  const source = [
+    "type coordinatorHandle struct {}",
+    "type workerPoolConfig struct {}",
+    "type actorGreeting struct {}"
+  ].join("\n");
+  assert.deepEqual(
+    findBoundaryViolations(
+      "services/tuttid/service/agent/composer_options.go",
+      source
+    ),
+    []
+  );
+});
+
+test("skips test sources", () => {
+  const source = "type goalReconcileInboxWorkerStore struct {}";
+  assert.deepEqual(
+    findBoundaryViolations(
+      "services/tuttid/service/agent/goal_reconcile_inbox_worker_test.go",
+      source
+    ),
+    []
+  );
+});
+
+test("exempts allowlisted existing files including their filename", () => {
+  assert.equal(
+    isAllowlisted(
+      "services/tuttid/service/agent/composer_live_model_coordinator.go"
+    ),
+    true
+  );
+  assert.deepEqual(
+    findBoundaryViolations(
+      "services/tuttid/service/agent/composer_live_model_coordinator.go",
+      "type liveModelDiscoveryCoordinator struct {}"
+    ),
+    []
+  );
+  assert.equal(
+    isAllowlisted("services/tuttid/service/agent/new_send_coordinator.go"),
+    false
+  );
+});
+
+test("identifies test sources", () => {
+  assert.equal(isTestSource("service/agent/service_test.go"), true);
+  assert.equal(isTestSource("service/agent/service.go"), false);
+});
+
+test("reports allowlist entries whose files no longer exist", () => {
+  assert.deepEqual(
+    findStaleAllowlistEntries(() => true),
+    []
+  );
+  const stale = findStaleAllowlistEntries(() => false);
+  assert.ok(stale.length >= 1);
+  assert.ok(
+    stale.includes(
+      "services/tuttid/service/agent/composer_live_model_coordinator.go"
+    )
+  );
+});

--- a/tools/scripts/run-check-changed.mjs
+++ b/tools/scripts/run-check-changed.mjs
@@ -162,6 +162,14 @@ function buildChangedLanes() {
     });
   }
 
+  if (changedFiles.some(isAgentHostBoundaryRelevant)) {
+    addLane({
+      key: "boundary:agent-host",
+      label: "boundary:agent-host",
+      command: [...pnpmCommand, "run", "check:agent-host-boundary"]
+    });
+  }
+
   if (
     changedFiles.some(
       (file) =>
@@ -574,6 +582,14 @@ export function isAgentActivityRuntimeBoundaryRelevant(file) {
     file === "tools/scripts/check-agent-activity-runtime-boundaries.mjs" ||
     file === "tools/scripts/check-agent-activity-runtime-boundaries.test.mjs" ||
     file.startsWith("tools/fixtures/agent-activity-runtime-boundaries/")
+  );
+}
+
+export function isAgentHostBoundaryRelevant(file) {
+  return (
+    file.startsWith("services/tuttid/service/agent/") ||
+    file === "tools/scripts/check-agent-host-boundary.mjs" ||
+    file === "tools/scripts/check-agent-host-boundary.test.mjs"
   );
 }
 

--- a/tools/scripts/run-check-full.mjs
+++ b/tools/scripts/run-check-full.mjs
@@ -49,6 +49,10 @@ const phases = [
         script: "check:agent-activity-runtime-boundaries"
       },
       {
+        label: "agent-host-boundary",
+        script: "check:agent-host-boundary"
+      },
+      {
         label: "agent-gui-degradation",
         script: "check:agent-gui-degradation"
       }


### PR DESCRIPTION
## Summary

The Agent Host extraction moved agent application-core lifecycle semantics
(session/turn/goal/runtime-operation creation, sendability, terminal state,
recovery) into `packages/agent/host`. `services/tuttid/service/agent` and tsh
`cmd/desktopd` are now adapters that delegate through `ApplicationHost()`. This
PR lands durable governance so those semantics cannot flow back into the
adapter layer and cannot diverge between Host consumers.

- **Root `AGENTS.md`** gains an `Agent Host Boundary` section: the decision
  rule (does this change lifecycle semantics? yes -> Host, no -> adapter,
  unsure -> "does tsh also need it?"), the conformance-first requirement, and
  the four-API case (`GetSession`/`UpdateSettings`/`UpdatePin`/`DeleteSession`,
  added to Host in PR #1329 rather than reimplemented in tsh). Routing now
  points agent-core requests at `packages/agent/host` first.
- **`services/tuttid/service/agent/AGENTS.md`** (new, directory-level): this
  directory is adapter-only; new semantics go to Host with a conformance
  scenario; the Host-missing-capability flow; and the forbidden patterns
  (new `*Coordinator`/`*Worker`/`*Actor` production types, bypassing
  `ApplicationHost()` for lifecycle orchestration, direct canonical store writes
  for semantic decisions).
- **`tools/scripts/check-agent-host-boundary.mjs`** (+ `.test.mjs`): a ratchet
  that scans production (non-`_test.go`) Go files under
  `services/tuttid/service/agent` and rejects new `*Coordinator`/`*Worker`/
  `*Actor` orchestration surfaces. Allowlist is a snapshot that may only shrink;
  stale entries fail. Wired into `check:full`, the `check:changed`
  `boundary:agent-host` lane, and the PR `go-lint` job.
- **PR template** adds a lifecycle-semantics checkbox; **static-analysis.md**
  documents the new check.

### Ratchet detection rules

- Type declaration whose name ends in `Coordinator`/`Worker`/`Actor`
  (`type Xxx{Coordinator,Worker,Actor} struct|interface`).
- Production file whose name ends in `_coordinator.go`/`_worker.go`/`_actor.go`.
- Test files (`_test.go`) are ignored; allowlisted files are exempt; stale
  allowlist entries (files that no longer exist) fail.

### Allowlist (current snapshot)

- `services/tuttid/service/agent/composer_live_model_coordinator.go` — a
  provider-catalog / live-model discovery adapter concern, not session/turn/goal
  lifecycle; predates the check.

## Verification

- `node --test tools/scripts/check-agent-host-boundary.test.mjs` -> 9 pass.
- `node tools/scripts/check-agent-host-boundary.mjs` on this branch -> 0
  violations.
- Injected a `*_coordinator.go` with a `type ...Coordinator struct` -> check
  fails red; removed -> green.
- `check:changed --dry-run` shows the `boundary:agent-host` and `test:tools`
  lanes.
- oxfmt/oxlint/prettier clean on changed files; pre-commit hooks passed.
- `lint:go` was not run locally (no `golangci-lint` binary in this
  environment); the diff contains zero Go source changes, so PR CI covers it.

## Notes

- No `CODEOWNERS` file exists in this repository, so the CODEOWNERS item was
  skipped.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->