### PR TITLE
fix(agent-gui): preserve shared target presentation

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -3282,8 +3282,13 @@ window boundary.
 
 The public directory entry owns its presentation and availability:
 
-- render `agents[].name` and `agents[].iconUrl` as the primary identity
-- render `owner.avatarUrl` separately as an ownership badge
+- keep `agents[].name` as the Agent name and `owner.name` as a separate owner
+  identity; AgentGUI composes their localized shared-Agent label at render time
+  so constrained lists can truncate only the owner while preserving the Agent
+  name suffix
+- render `agents[].iconUrl` as the primary identity and `owner.avatarUrl`
+  separately as an ownership badge, including on the selected center item in
+  the new-session carousel
 - preserve host array order; normalization keeps the first valid occurrence of
   each `agentTargetId`
 - use `availability.status` for ready, checking, coming-soon, install, login,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.labels.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.labels.ts
@@ -359,6 +359,9 @@ export function useAgentGUIViewLabels(input: {
       ),
       conversationFilterTutti: t("agentHost.agentGui.conversationFilterTutti"),
       providerSwitchLabel: t("agentHost.agentGui.providerSwitchLabel"),
+      sharedAgentOwnerSeparator: t(
+        "agentHost.agentGui.sharedAgentOwnerSeparator"
+      ),
       loadingConversation: t("agentHost.agentGui.loadingConversation"),
       scrollToBottom: t("agentHost.agentGui.scrollToBottom"),
       fallbackAgentTitle,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIVinylPlayer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIVinylPlayer.spec.tsx
@@ -1,0 +1,47 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AgentGUIVinylPlayer } from "./AgentGUIVinylPlayer";
+
+describe("AgentGUIVinylPlayer", () => {
+  it("renders the selected shared agent owner badge", () => {
+    const { container } = render(
+      <AgentGUIVinylPlayer
+        isPlaying={false}
+        selectedAgent={{
+          agentTargetId: "shared-agent:alice-codex",
+          targetId: "shared-agent:alice-codex",
+          provider: "codex",
+          label: "Codex",
+          iconUrl: "https://cdn.example.com/codex.png",
+          badge: {
+            iconUrl: "https://cdn.example.com/alice.png",
+            label: "Alice"
+          }
+        }}
+      />
+    );
+
+    expect(
+      container.querySelector('[data-agent-owner-badge="true"] img')
+    ).toHaveAttribute("src", "https://cdn.example.com/alice.png");
+  });
+
+  it("omits the owner badge for a local agent", () => {
+    const { container } = render(
+      <AgentGUIVinylPlayer
+        isPlaying={false}
+        selectedAgent={{
+          agentTargetId: "local:codex",
+          targetId: "local:codex",
+          provider: "codex",
+          label: "Codex",
+          iconUrl: "https://cdn.example.com/codex.png"
+        }}
+      />
+    );
+
+    expect(
+      container.querySelector('[data-agent-owner-badge="true"]')
+    ).toBeNull();
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIVinylPlayer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIVinylPlayer.tsx
@@ -85,6 +85,14 @@ export function AgentGUIVinylPlayer({
         <span />
         <span>◦</span>
       </div>
+      {selectedAgent?.badge?.iconUrl ? (
+        <span
+          className="agent-gui-vinyl-player__owner-badge"
+          data-agent-owner-badge="true"
+        >
+          <img src={selectedAgent.badge.iconUrl} alt="" draggable={false} />
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
@@ -2701,6 +2701,154 @@ describe("AgentMentionSearchController", () => {
     setAgentGuiI18nTestLocale("en");
   });
 
+  it("keeps workspace and agent-generated folder navigation independent", async () => {
+    setAgentGuiI18nTestLocale("zh-CN");
+    const queryFiles = vi.fn(
+      async ({ directoryPath }: { directoryPath?: string }) => ({
+        entries:
+          directoryPath === "/workspace/src"
+            ? [
+                {
+                  path: "/workspace/src/index.ts",
+                  name: "index.ts",
+                  kind: "file"
+                }
+              ]
+            : [
+                {
+                  path: "/workspace/src",
+                  name: "src",
+                  kind: "directory",
+                  childCount: 1
+                }
+              ]
+      })
+    );
+    const controller = new AgentMentionSearchController({
+      queryFiles,
+      queryAgentGeneratedFiles: vi.fn().mockResolvedValue({
+        entries: [
+          {
+            path: "/workspace/generated/app.js",
+            name: "app.js"
+          },
+          {
+            path: "/workspace/generated/index.html",
+            name: "index.html"
+          }
+        ]
+      })
+    });
+    const states: AgentMentionSearchState[] = [];
+    controller.subscribe((state) => states.push(state));
+
+    controller.updateQuery({ workspaceId: "room-1", query: "" });
+    controller.setFilter("file");
+
+    await vi.waitFor(() =>
+      expect(states.at(-1)?.groups).toEqual([
+        expect.objectContaining({
+          id: "opened_files",
+          items: [
+            expect.objectContaining({
+              mentionNavigation: "workspace-folder",
+              path: "/workspace/src"
+            })
+          ]
+        }),
+        expect.objectContaining({
+          id: "agent_generated_files",
+          items: [
+            expect.objectContaining({
+              mentionNavigation: "agent-generated-folder",
+              path: "/workspace/generated"
+            })
+          ]
+        })
+      ])
+    );
+
+    const workspaceFolder = states
+      .at(-1)
+      ?.groups.find((group) => group.id === "opened_files")
+      ?.items.find(
+        (item) =>
+          item.kind === "file" && item.mentionNavigation === "workspace-folder"
+      );
+    expect(workspaceFolder).toBeDefined();
+    expect(controller.selectFileMentionNavigationItem(workspaceFolder!)).toBe(
+      true
+    );
+
+    await vi.waitFor(() =>
+      expect(
+        states
+          .at(-1)
+          ?.groups.find((group) => group.id === "opened_files")
+          ?.items.at(0)
+      ).toMatchObject({ mentionNavigation: "workspace-folder-back" })
+    );
+
+    const generatedFolder = states
+      .at(-1)
+      ?.groups.find((group) => group.id === "agent_generated_files")
+      ?.items.find(
+        (item) =>
+          item.kind === "file" &&
+          item.mentionNavigation === "agent-generated-folder"
+      );
+    expect(generatedFolder).toBeDefined();
+    expect(controller.selectFileMentionNavigationItem(generatedFolder!)).toBe(
+      true
+    );
+
+    const bothNestedState = states.at(-1);
+    const workspaceBack = bothNestedState?.groups
+      .find((group) => group.id === "opened_files")
+      ?.items.find(
+        (item) =>
+          item.kind === "file" &&
+          item.mentionNavigation === "workspace-folder-back"
+      );
+    const generatedBack = bothNestedState?.groups
+      .find((group) => group.id === "agent_generated_files")
+      ?.items.find(
+        (item) =>
+          item.kind === "file" &&
+          item.mentionNavigation === "agent-generated-folder-back"
+      );
+    expect(workspaceBack).toBeDefined();
+    expect(generatedBack).toBeDefined();
+
+    expect(controller.selectFileMentionNavigationItem(workspaceBack!)).toBe(
+      true
+    );
+    await vi.waitFor(() =>
+      expect(
+        states
+          .at(-1)
+          ?.groups.find((group) => group.id === "opened_files")
+          ?.items.some(
+            (item) =>
+              item.kind === "file" &&
+              item.mentionNavigation === "workspace-folder-back"
+          )
+      ).toBe(false)
+    );
+    expect(
+      states
+        .at(-1)
+        ?.groups.find((group) => group.id === "agent_generated_files")
+        ?.items.at(0)
+    ).toMatchObject({ mentionNavigation: "agent-generated-folder-back" });
+
+    expect(controller.selectFileMentionNavigationItem(generatedBack!)).toBe(
+      true
+    );
+    controller.dispose();
+    setAgentGuiI18nTestLocale("en");
+  });
+
   it("loads default session items in browse mode when switching to the session tab", async () => {
     const querySessions = vi.fn().mockResolvedValue({
       presences: [],

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.ts
@@ -334,7 +334,6 @@ export class AgentMentionSearchController extends AgentMentionSearchControllerBa
       return false;
     }
     if (item.mentionNavigation === "agent-generated-folder") {
-      this.resetWorkspaceFileBrowsePaths();
       this.agentGeneratedBrowsePath = item.path;
       this.expandedCounts.agent_generated_files = mentionGroupPageSize(
         this.currentFilter,
@@ -369,7 +368,6 @@ export class AgentMentionSearchController extends AgentMentionSearchControllerBa
       if (!path || this.currentFilter !== "file" || this.currentQuery) {
         return false;
       }
-      this.resetAgentGeneratedBrowsePath();
       this.workspaceFileBrowsePaths.push(path);
       this.loadWorkspaceFileDirectory(path);
       return true;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerMentionActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerMentionActions.ts
@@ -117,11 +117,8 @@ export function useComposerMentionActions(input: Input) {
   } = input;
   const selectFileMention = useCallback(
     (entry: AgentContextMentionItem): void => {
-      if (
-        entry.kind === "file" &&
-        entry.mentionNavigation &&
-        mentionControllerRef.current?.selectFileMentionNavigationItem(entry)
-      ) {
+      if (entry.kind === "file" && entry.mentionNavigation) {
+        mentionControllerRef.current?.selectFileMentionNavigationItem(entry);
         return;
       }
       fileMentionSuggestion?.command(entry);

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAgentTargetName.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAgentTargetName.spec.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AgentGUIAgentTargetName } from "./AgentGUIAgentTargetName";
+
+describe("AgentGUIAgentTargetName", () => {
+  it("lets only the shared owner shrink while preserving the agent suffix", () => {
+    render(
+      <AgentGUIAgentTargetName
+        ownerSeparator=" 的 "
+        target={{
+          targetId: "shared-agent:alice-codex",
+          agentTargetId: "shared-agent:alice-codex",
+          provider: "codex",
+          ref: { kind: "agent-directory", provider: "codex" },
+          label: "Codex",
+          ownerLabel: "我是超长名称的用户我是超长名称的用户",
+          ownership: "shared"
+        }}
+      />
+    );
+
+    expect(screen.getByTestId("agent-target-owner-name")).toHaveClass(
+      "truncate"
+    );
+    expect(screen.getByTestId("agent-target-name-suffix")).toHaveClass(
+      "shrink-0"
+    );
+    expect(screen.getByTestId("agent-target-name-suffix").textContent).toBe(
+      " 的 Codex"
+    );
+    expect(
+      screen.getByTitle("我是超长名称的用户我是超长名称的用户 的 Codex")
+    ).toBeInTheDocument();
+  });
+
+  it("renders a local agent as one truncatable label", () => {
+    render(
+      <AgentGUIAgentTargetName
+        ownerSeparator=" 的 "
+        target={{
+          targetId: "local:codex",
+          provider: "codex",
+          ref: { kind: "local", provider: "codex" },
+          label: "Codex"
+        }}
+      />
+    );
+
+    expect(screen.queryByTestId("agent-target-owner-name")).toBeNull();
+    expect(screen.getByTestId("agent-target-name")).toHaveClass("truncate");
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAgentTargetName.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAgentTargetName.tsx
@@ -1,0 +1,73 @@
+import { cn } from "@tutti-os/ui-system";
+import type { AgentGUIAgentTarget } from "../../../types";
+
+export interface AgentGUIAgentTargetNamePresentation {
+  agentLabel: string;
+  fullLabel: string;
+  ownerLabel: string | null;
+  ownerSeparator: string;
+}
+
+export function projectAgentGUIAgentTargetName(input: {
+  ownerSeparator: string;
+  target: AgentGUIAgentTarget;
+}): AgentGUIAgentTargetNamePresentation {
+  const agentLabel = input.target.label.trim();
+  const ownerLabel =
+    input.target.ownership === "shared"
+      ? input.target.ownerLabel?.trim() || null
+      : null;
+  const ownerSeparator = ownerLabel ? input.ownerSeparator : "";
+  return {
+    agentLabel,
+    fullLabel: ownerLabel
+      ? `${ownerLabel}${ownerSeparator}${agentLabel}`
+      : agentLabel,
+    ownerLabel,
+    ownerSeparator
+  };
+}
+
+export function AgentGUIAgentTargetName({
+  className,
+  ownerSeparator,
+  target
+}: {
+  className?: string;
+  ownerSeparator: string;
+  target: AgentGUIAgentTarget;
+}): React.JSX.Element {
+  const presentation = projectAgentGUIAgentTargetName({
+    ownerSeparator,
+    target
+  });
+
+  return (
+    <span
+      className={cn("flex min-w-0 max-w-full items-baseline", className)}
+      title={presentation.fullLabel}
+    >
+      {presentation.ownerLabel ? (
+        <>
+          <span
+            className="min-w-0 flex-1 truncate"
+            data-testid="agent-target-owner-name"
+          >
+            {presentation.ownerLabel}
+          </span>
+          <span
+            className="shrink-0 whitespace-pre"
+            data-testid="agent-target-name-suffix"
+          >
+            {presentation.ownerSeparator}
+            {presentation.agentLabel}
+          </span>
+        </>
+      ) : (
+        <span className="min-w-0 truncate" data-testid="agent-target-name">
+          {presentation.agentLabel}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
@@ -45,6 +45,10 @@ import type {
 import type { ChromeLabels } from "./AgentGUIDetailHeader";
 import { AgentGUIEmptyHeroCarouselStage } from "./AgentGUIEmptyHeroCarouselStage";
 import { AgentTargetSetupGate } from "./AgentTargetSetupGate.tsx";
+import {
+  AgentGUIAgentTargetName,
+  projectAgentGUIAgentTargetName
+} from "./AgentGUIAgentTargetName";
 import styles from "../AgentGUINode.styles";
 
 export interface AgentGUIProviderIconPresentation {
@@ -122,7 +126,12 @@ export const AgentGUIEmptyHomePane = memo(function AgentGUIEmptyHomePane({
 
   const runtimeProviderLabel =
     labels.emptyProviderForProvider?.(provider) ?? labels.emptyProvider ?? "";
-  const providerLabel = selectedAgentTarget?.label ?? runtimeProviderLabel;
+  const providerLabel = selectedAgentTarget
+    ? projectAgentGUIAgentTargetName({
+        ownerSeparator: labels.sharedAgentOwnerSeparator,
+        target: selectedAgentTarget
+      }).fullLabel
+    : runtimeProviderLabel;
   const baseLabel = labels.emptyForProvider?.(provider) ?? labels.empty;
   const emptyLabel = runtimeProviderLabel
     ? baseLabel.replace(runtimeProviderLabel, providerLabel)
@@ -182,6 +191,7 @@ export const AgentGUIEmptyHomePane = memo(function AgentGUIEmptyHomePane({
             agentTargets={agentTargets}
             selectedAgentTarget={selectedAgentTarget}
             providerSelectLabel={labels.providerSwitchLabel}
+            sharedAgentOwnerSeparator={labels.sharedAgentOwnerSeparator}
           />
         )}
       </AgentTargetSetupGate>
@@ -207,6 +217,7 @@ interface AgentGUIEmptyHeroPaneProps {
   chromeLabels: ChromeLabels;
   composerProps: AgentComposerProps;
   providerSelectLabel: string;
+  sharedAgentOwnerSeparator: string;
   suggestions: readonly AgentHomeSuggestionCategory[];
   suggestionsCloseLabel?: string;
   onSelectSuggestion: (prompt: string) => void;
@@ -231,6 +242,7 @@ export const AgentGUIEmptyHeroPane = memo(function AgentGUIEmptyHeroPane({
   chromeLabels,
   composerProps,
   providerSelectLabel,
+  sharedAgentOwnerSeparator,
   suggestions,
   suggestionsCloseLabel,
   onSelectSuggestion,
@@ -288,6 +300,7 @@ export const AgentGUIEmptyHeroPane = memo(function AgentGUIEmptyHeroPane({
             agentTargets={agentTargets}
             selectedAgentTarget={selectedAgentTarget}
             onProviderSelect={onProviderSelect}
+            sharedAgentOwnerSeparator={sharedAgentOwnerSeparator}
           />
         </h2>
         {inlineNoticeChrome ? (
@@ -345,6 +358,7 @@ interface AgentGUIProviderReadinessGatePaneProps {
     | "providerGatePendingInstall"
     | "providerGatePendingLogin"
     | "providerGatePendingRefresh"
+    | "sharedAgentOwnerSeparator"
   >;
 }
 
@@ -437,6 +451,7 @@ export const AgentGUIProviderReadinessGatePane = memo(
               agentTargets={agentTargets}
               selectedAgentTarget={selectedAgentTarget}
               onProviderSelect={onProviderSelect}
+              sharedAgentOwnerSeparator={labels.sharedAgentOwnerSeparator}
             />
           </h2>
           <p className={styles.emptyProviderGateDescription}>
@@ -568,7 +583,8 @@ function EmptyHeroTitle({
   providerSelectLabel,
   agentTargets = [],
   selectedAgentTarget = null,
-  onProviderSelect
+  onProviderSelect,
+  sharedAgentOwnerSeparator
 }: {
   label: string;
   providerLabel: string;
@@ -576,6 +592,7 @@ function EmptyHeroTitle({
   agentTargets?: readonly AgentGUIAgentTarget[];
   selectedAgentTarget?: AgentGUIAgentTarget | null;
   onProviderSelect?: AgentGUINodeViewProps["actions"]["selectHomeComposerAgentTarget"];
+  sharedAgentOwnerSeparator: string;
 }): React.JSX.Element {
   const providerStart = providerLabel ? label.indexOf(providerLabel) : -1;
 
@@ -616,11 +633,18 @@ function EmptyHeroTitle({
             title={providerSelectLabel}
             className={styles.emptyHeroProviderSelect}
           >
-            <span className={styles.emptyHeroProvider}>{providerName}</span>
+            <AgentGUIAgentTargetName
+              className={cn(styles.emptyHeroProvider, "max-w-[240px]")}
+              ownerSeparator={sharedAgentOwnerSeparator}
+              target={selectedAgentTarget}
+            />
           </SelectTrigger>
           <SelectContent
             align="center"
-            className={cn(styles.composerMenuContent, "min-w-[190px]")}
+            className={cn(
+              styles.composerMenuContent,
+              "min-w-[190px] max-w-[min(420px,calc(100vw-32px))]"
+            )}
           >
             {agentTargets.map((target) => (
               <SelectItem
@@ -640,12 +664,21 @@ function EmptyHeroTitle({
                       ).iconUrl
                     }
                   />
-                  <span className="min-w-0 truncate">{target.label}</span>
+                  <AgentGUIAgentTargetName
+                    ownerSeparator={sharedAgentOwnerSeparator}
+                    target={target}
+                  />
                 </span>
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
+      ) : selectedAgentTarget ? (
+        <AgentGUIAgentTargetName
+          className={cn(styles.emptyHeroProvider, "max-w-[240px]")}
+          ownerSeparator={sharedAgentOwnerSeparator}
+          target={selectedAgentTarget}
+        />
       ) : (
         <span className={styles.emptyHeroProvider}>{providerName}</span>
       )}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -171,6 +171,7 @@ export interface AgentGUIViewLabels {
   conversationFilterClaudeCode: string;
   conversationFilterTutti: string;
   providerSwitchLabel: string;
+  sharedAgentOwnerSeparator: string;
   startConversation: string;
   selectConversation: string;
   loadingConversations: string;

--- a/packages/agent/gui/agent-gui/shared/mentionFilePresentation.spec.ts
+++ b/packages/agent/gui/agent-gui/shared/mentionFilePresentation.spec.ts
@@ -14,6 +14,15 @@ describe("mentionFilePresentation", () => {
     ).toBe("back");
   });
 
+  it("resolves workspace folder back rows as back visual kind", () => {
+    expect(
+      resolveAgentMentionFileVisualKind({
+        name: "返回",
+        mentionNavigation: "workspace-folder-back"
+      })
+    ).toBe("back");
+  });
+
   it("resolves image files as image visual kind", () => {
     expect(
       resolveAgentMentionFileVisualKind({

--- a/packages/agent/gui/agent-gui/shared/mentionFilePresentation.ts
+++ b/packages/agent/gui/agent-gui/shared/mentionFilePresentation.ts
@@ -16,7 +16,10 @@ export function resolveAgentMentionFileVisualKind(input: {
   name?: string | null;
   path?: string | null;
 }): AgentMentionFileVisualKind {
-  if (input.mentionNavigation === "agent-generated-folder-back") {
+  if (
+    input.mentionNavigation === "agent-generated-folder-back" ||
+    input.mentionNavigation === "workspace-folder-back"
+  ) {
     return "back";
   }
   if (input.entryKind === "directory") {

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -10039,6 +10039,31 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   box-shadow: inset 0 2px 5px rgb(0 0 0 / 30%);
 }
 
+/* Match the WebGL carousel's historical BADGE_DIAMETER (0.36) and
+   BADGE_OFFSET (0.4): the selected DOM player must keep the same owner-marker
+   geometry as the records that move into and out of the center slot. */
+.agent-gui-vinyl-player__owner-badge {
+  position: absolute;
+  right: -8%;
+  bottom: -8%;
+  z-index: 5;
+  box-sizing: border-box;
+  display: grid;
+  width: 36%;
+  aspect-ratio: 1;
+  place-items: center;
+  overflow: hidden;
+  border: 8px solid var(--background-fronted);
+  border-radius: 999px;
+  background: var(--background-fronted);
+}
+
+.agent-gui-vinyl-player__owner-badge > img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 .agent-gui-node__empty-hero-carousel:has(:focus-visible) {
   border-radius: 12px;
   box-shadow: 0 0 0 1.5px var(--tutti-purple);

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -416,6 +416,7 @@ export const enAgentGui = {
   conversationFilterAll: "All",
   ...enAgentGuiProviderIdentity,
   providerSwitchLabel: "Switch provider",
+  sharedAgentOwnerSeparator: "'s ",
   handoffConversation: "Handoff",
   handoffConversationTooltip: "Hand off to another agent",
   handoffConversationMenu: "Choose an agent for handoff",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -383,6 +383,7 @@ export const zhCNAgentGui = {
   conversationFilterAll: "全部",
   ...zhCNAgentGuiProviderIdentity,
   providerSwitchLabel: "切换 Provider",
+  sharedAgentOwnerSeparator: " 的 ",
   handoffConversation: "Handoff",
   handoffConversationTooltip: "交接给其他 Agent",
   handoffConversationMenu: "选择要交接的 Agent",

--- a/packages/ui/rich-text/src/at-panel/mentionFileVisualKind.test.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionFileVisualKind.test.ts
@@ -5,14 +5,19 @@ import {
   resolveMentionFileVisualKind
 } from "./mentionFileVisualKind.ts";
 
-test("resolveMentionFileVisualKind: back navigation overrides base kind", () => {
-  assert.equal(
-    resolveMentionFileVisualKind({
-      mentionNavigation: "agent-generated-folder-back",
-      baseVisualKind: "document"
-    }),
-    "back"
-  );
+test("resolveMentionFileVisualKind: every folder back action overrides base kind", () => {
+  for (const mentionNavigation of [
+    "agent-generated-folder-back",
+    "workspace-folder-back"
+  ]) {
+    assert.equal(
+      resolveMentionFileVisualKind({
+        mentionNavigation,
+        baseVisualKind: "document"
+      }),
+      "back"
+    );
+  }
 });
 
 test("resolveMentionFileVisualKind: directory entry resolves to folder", () => {

--- a/packages/ui/rich-text/src/at-panel/mentionFileVisualKind.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionFileVisualKind.ts
@@ -32,7 +32,10 @@ export interface MentionFileVisualKindInput {
 export function resolveMentionFileVisualKind(
   input: MentionFileVisualKindInput
 ): MentionFileVisualKind {
-  if (input.mentionNavigation === "agent-generated-folder-back") {
+  if (
+    input.mentionNavigation === "agent-generated-folder-back" ||
+    input.mentionNavigation === "workspace-folder-back"
+  ) {
     return "back";
   }
   if (input.entryKind === "directory") {


### PR DESCRIPTION
## Motivation

Shared Agent targets lost owner-aware presentation and mention folder navigation could mix navigation rows into selectable files when both sections were open.

## Changes

- render shared target names as structured owner + Agent labels so long owner names truncate before the Agent name
- restore the selected shared Agent owner badge using the established vinyl-card geometry
- isolate workspace and Agent-generated folder navigation state
- render both parent-directory rows as navigation-only actions and prevent them from entering the composer
- document the Agent GUI ownership and interaction rules

## Verification

- `pnpm check:changed`
- `pnpm check:full` (19 tasks passed)
- Agent GUI test suite: 196 files / 1808 tests
- Agent GUI and rich-text typechecks

## Documentation impact

Updated the Agent GUI architecture documentation to record structured shared-target presentation and navigation-only mention rows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->