### PR TITLE
feat(agent): track claude background tasks as child work and support targeted stop

### DIFF
--- a/docs/specs/2026-07-15-provider-native-subagents.md
+++ b/docs/specs/2026-07-15-provider-native-subagents.md
@@ -6,10 +6,17 @@ This spec covers provider-native child agents only:
 
 - Codex app-server multi-agent child threads.
 - Claude Code SDK `Task` / subagent sessions and turns.
+- Claude Code SDK task-system background work that is not a subagent launch,
+  such as `run_in_background` Bash shells. It follows the same child contract:
+  it gates the root turn, projects as a child, and is individually cancelable.
 - ACP providers that expose an equivalent nested/background agent concept.
 
 It does not cover Tutti launching another top-level AgentGUI session with
 `tutti-dev agent start`, handoff mentions, or another Codex/Claude Code process.
+A background command that merely tracks such a top-level session (for example
+`tutti agent wait` running in a background shell) is itself SDK task-system
+work and is covered: the tracked session stays out of scope, but the tracking
+task holds the root turn open for exactly as long as the wait runs.
 
 ## Product Contract
 
@@ -329,6 +336,12 @@ The fan-out target set is decided before entering the provider runtime:
   its root-query cancel primitive when the target set includes the root; that
   native operation covers the Task executions in the same query. Standard ACP
   remains root-only until a provider explicitly supports child sessions.
+- A Claude child-only target set does not interrupt the root query. The adapter
+  resolves each child to its SDK task identity (task id, agent id, or launching
+  tool-use id alias) and issues the SDK's targeted `stopTask`; the root provider
+  turn and every other task keep running. A target whose task is unknown or
+  already terminal is an idempotent no-op: it is simply not confirmed, and the
+  durable operation records it through the generic unconfirmed path.
 
 When a Codex target set includes the root, the adapter stops the root provider
 turn before waiting on child-thread interrupts. This closes the source of new
@@ -525,6 +538,21 @@ Mapping:
 - A foreground `Task` may settle its child turn from the terminal parent tool
   result. An async/background `Task` does not settle from the launch tool
   result; it waits for the matching task lifecycle terminal.
+- SDK task-system work that has no subagent launch result — most importantly a
+  `run_in_background` Bash shell — announces itself only through `task_started`
+  carrying a `tool_use_id` and `task_id`. The sidecar registers such an
+  unclaimed task as delegated child work keyed by that launching tool-use id,
+  so it gates the root turn, counts in the final-child continuation gate, and
+  can be stopped individually. A task event without a launching tool-use id is
+  not registered this way: it may be a racing alias for a not-yet-registered
+  subagent launch, and binding it would poison the alias maps.
+- Background task lifecycle events frequently arrive after the launching root
+  provider turn already reached its terminal. The sidecar attributes them to
+  the most recent turn instead of dropping them for lack of an active turn id.
+- A terminal `task_notification` for a task the current sidecar instance never
+  saw start — typically a task launched before a sidecar restart and reported
+  as `stopped` on the next prompt — is registered and settled in one step so
+  the child reaches a terminal state instead of the notice being dropped.
 - `parent_tool_use_id` is the canonical child scope marker for nested messages.
 - `taskId` and `agentId` are aliases. They must bind back to the existing child
   session/turn, never to "the only running task" when that would cross-bind
@@ -569,6 +597,10 @@ Mapping:
   `services/tuttid` root gate then remains unchanged: it observes a running
   provider turn when the last child becomes terminal and keeps the canonical
   root active.
+- A `stopped` task terminal is the exception: a user-initiated stop needs no
+  model follow-up, so the sidecar does not open the synthetic provider turn for
+  it. The child settles, and the root gate resolves from the ordinary
+  provider/child state without a reserved continuation or its timeout.
 - Opening at the notification boundary reserves the provider lifecycle; it
   does not claim that Claude has already emitted assistant output. The sidecar
   waits at most 30 seconds for the first root stream or assistant event. Once

--- a/packages/agent/claude-sdk-sidecar/src/main.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.ts
@@ -87,6 +87,17 @@ export async function handleRequest(
         emit({ id, type: "ok", payload: { canceled } });
         return;
       }
+      case "stop_task": {
+        const payload = request.payload ?? {};
+        const session = requireSession(stringValue(payload.agentSessionId));
+        const stopped = await session.stopTask(
+          stringValue(payload.taskId),
+          stringValue(payload.toolCallId) ||
+            stringValue(payload.parentToolUseId)
+        );
+        emit({ id, type: "ok", payload: { stopped } });
+        return;
+      }
       case "submit_interactive": {
         const payload = request.payload ?? {};
         const session = requireSession(stringValue(payload.agentSessionId));

--- a/packages/agent/claude-sdk-sidecar/src/protocol.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/protocol.test.ts
@@ -23,6 +23,17 @@ test("sidecar protocol accepts the current version", () => {
   );
 });
 
+test("sidecar protocol accepts stop_task requests", () => {
+  assert.equal(
+    parseClaudeSDKSidecarRequest({
+      version: CLAUDE_SDK_SIDECAR_PROTOCOL_VERSION,
+      type: "stop_task",
+      payload: { agentSessionId: "session-1", taskId: "task-1" }
+    }).type,
+    "stop_task"
+  );
+});
+
 test("sidecar protocol rejects missing and unknown versions", () => {
   assert.throws(
     () => parseClaudeSDKSidecarRequest({ type: "exec" }),

--- a/packages/agent/claude-sdk-sidecar/src/protocol.ts
+++ b/packages/agent/claude-sdk-sidecar/src/protocol.ts
@@ -5,6 +5,7 @@ export type ClaudeSDKSidecarRequestType =
   | "exec"
   | "guide"
   | "cancel"
+  | "stop_task"
   | "submit_interactive"
   | "interactive_disposition"
   | "apply_settings"
@@ -71,6 +72,7 @@ const REQUEST_TYPES = new Set<ClaudeSDKSidecarRequestType>([
   "exec",
   "guide",
   "cancel",
+  "stop_task",
   "submit_interactive",
   "interactive_disposition",
   "apply_settings",

--- a/packages/agent/claude-sdk-sidecar/src/queryGeneration.ts
+++ b/packages/agent/claude-sdk-sidecar/src/queryGeneration.ts
@@ -14,6 +14,7 @@ import { stringValue } from "./runtimeValues.ts";
 export type ClaudeQueryRuntime = AsyncIterable<SDKMessage> & {
   initializationResult?: () => Promise<unknown>;
   interrupt?: () => Promise<void>;
+  stopTask?: (taskId: string) => Promise<void>;
   setPermissionMode?: (mode: PermissionMode) => Promise<void>;
   setModel?: (model?: string) => Promise<void>;
   applyFlagSettings?: (settings: PendingFlagSettings) => Promise<void>;

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.cancel.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.cancel.test.ts
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  Options as ClaudeQueryOptions,
+  PermissionResult,
+  SDKMessage,
+  SDKUserMessage
+} from "@anthropic-ai/claude-agent-sdk";
+import { withSidecarEventSinkForTest } from "./eventSink.ts";
+import { sidecarClaudeOptionsFromPayload } from "./options.ts";
+import { SessionRuntime } from "./sessionRuntime.ts";
+import {
+  consolidatedAssistant,
+  testCanUseToolOptions
+} from "./sessionRuntimeTestCommon.ts";
+import { waitForEvent } from "./sessionRuntimeTestQueries.nested.ts";
+
+for (const permissionModeId of ["default", "bypassPermissions"] as const) {
+  test(`cancel retires ${permissionModeId} query before background completion can run another tool`, async () => {
+    const events: Array<{ type: string; payload?: Record<string, unknown> }> =
+      [];
+    const restoreSink = withSidecarEventSinkForTest((event) =>
+      events.push(event)
+    );
+    let queryCount = 0;
+    let closeCount = 0;
+    const shutdownOrder: string[] = [];
+    let latePermissionResult: PermissionResult | undefined;
+    let resumedOptions: ClaudeQueryOptions | undefined;
+    let releaseBackground: () => void = () => {};
+    let markFirstPromptObserved: () => void = () => {};
+    let markLatePermissionChecked: () => void = () => {};
+    const backgroundCompletion = new Promise<void>((resolve) => {
+      releaseBackground = resolve;
+    });
+    const firstPromptObserved = new Promise<void>((resolve) => {
+      markFirstPromptObserved = resolve;
+    });
+    const latePermissionChecked = new Promise<void>((resolve) => {
+      markLatePermissionChecked = resolve;
+    });
+
+    try {
+      const session = new SessionRuntime(
+        "provider-session-1",
+        "/repo",
+        {},
+        false,
+        false,
+        {
+          model: "",
+          permissionModeId,
+          planMode: false,
+          effort: "",
+          speed: ""
+        },
+        sidecarClaudeOptionsFromPayload({}),
+        undefined,
+        ({ prompt, options }) => {
+          queryCount += 1;
+          if (queryCount === 1) {
+            return backgroundCompletionQuery({
+              prompt,
+              options,
+              backgroundCompletion,
+              onPromptObserved: markFirstPromptObserved,
+              onInterrupt: () => {
+                shutdownOrder.push("interrupt");
+                releaseBackground();
+              },
+              onInterruptSettled: () => {
+                shutdownOrder.push("interrupt-settled");
+              },
+              onPermissionResult: (result) => {
+                latePermissionResult = result;
+                markLatePermissionChecked();
+              },
+              onClose: () => {
+                shutdownOrder.push("close");
+                closeCount += 1;
+              },
+              permissionChecked: latePermissionChecked
+            });
+          }
+          resumedOptions = options;
+          return resumedQuery(prompt, () => {
+            closeCount += 1;
+          });
+        }
+      );
+
+      await session.start();
+      session.exec("turn-1", "create a site in the background");
+      await firstPromptObserved;
+      await session.cancel();
+      await waitForEvent(events, "turn_canceled");
+
+      assert.equal(closeCount, 1);
+      assert.deepEqual(shutdownOrder, [
+        "interrupt",
+        "interrupt-settled",
+        "close"
+      ]);
+      assert.deepEqual(latePermissionResult, {
+        behavior: "deny",
+        message: "Tool use aborted"
+      });
+      assert.equal(
+        events.some((event) => event.type === "turn_started"),
+        false
+      );
+      assert.equal(
+        events.some((event) => event.type === "approval_requested"),
+        false
+      );
+      assert.equal(
+        events.some(
+          (event) =>
+            event.type === "assistant_completed" &&
+            event.payload?.content === "Running ls after background completion"
+        ),
+        false
+      );
+
+      session.exec("turn-2", "continue with a real user prompt");
+      await waitForEvent(events, "turn_completed");
+
+      assert.equal(queryCount, 2);
+      assert.equal(resumedOptions?.resume, "provider-session-1");
+      assert.equal(Object.hasOwn(resumedOptions ?? {}, "sessionId"), false);
+      assert.equal(
+        events.some(
+          (event) =>
+            event.type === "assistant_completed" &&
+            event.payload?.content === "Resumed after cancellation"
+        ),
+        true
+      );
+      const completedTurns = events.filter(
+        (event) => event.type === "turn_completed"
+      );
+      assert.equal(completedTurns.length, 1);
+      assert.equal(completedTurns[0]?.payload?.turnId, "turn-2");
+      assert.equal(
+        events.some((event) => event.type === "turn_started"),
+        false
+      );
+      assert.equal(
+        events.some(
+          (event) =>
+            event.type === "sdk_lifecycle_observed" &&
+            event.payload?.sdkMessageSubtype === "task_notification"
+        ),
+        false
+      );
+    } finally {
+      restoreSink();
+    }
+  });
+}
+
+function backgroundCompletionQuery(options: {
+  prompt: AsyncIterable<SDKUserMessage>;
+  options: ClaudeQueryOptions;
+  backgroundCompletion: Promise<void>;
+  onPromptObserved: () => void;
+  onInterrupt: () => void;
+  onInterruptSettled: () => void;
+  onPermissionResult: (result: PermissionResult | undefined) => void;
+  onClose: () => void;
+  permissionChecked: Promise<void>;
+}): AsyncIterable<SDKMessage> & {
+  interrupt: () => Promise<void>;
+  close: () => void;
+} {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const firstPrompt = await options.prompt[Symbol.asyncIterator]().next();
+      const promptMessage = firstPrompt.value as SDKUserMessage & {
+        uuid?: string;
+      };
+      yield {
+        ...promptMessage,
+        uuid: promptMessage.uuid,
+        type: "user",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1"
+      } as SDKMessage;
+      options.onPromptObserved();
+      await options.backgroundCompletion;
+      const result = await options.options.canUseTool?.(
+        "Bash",
+        { command: "ls -la /repo/site" },
+        testCanUseToolOptions({
+          requestId: "late-background-ls",
+          toolUseID: "toolu-late-background-ls"
+        })
+      );
+      options.onPermissionResult(result ?? undefined);
+      if (result?.behavior === "allow") {
+        yield consolidatedAssistant("assistant-late", "msg-late", [
+          {
+            type: "text",
+            text: "Running ls after background completion"
+          }
+        ]);
+      }
+    },
+    async interrupt() {
+      options.onInterrupt();
+      await options.permissionChecked;
+      options.onInterruptSettled();
+    },
+    close() {
+      options.onClose();
+    }
+  };
+}
+
+function resumedQuery(
+  prompt: AsyncIterable<SDKUserMessage>,
+  onClose: () => void
+): AsyncIterable<SDKMessage> & { close: () => void } {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const next = await prompt[Symbol.asyncIterator]().next();
+      yield {
+        ...next.value,
+        type: "user",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1"
+      } as SDKMessage;
+      yield {
+        type: "system",
+        subtype: "task_notification",
+        task_id: "old-background-task",
+        tool_use_id: "toolu-old-background-task",
+        status: "stopped"
+      } as unknown as SDKMessage;
+      yield { type: "result", subtype: "success" } as unknown as SDKMessage;
+      yield consolidatedAssistant("assistant-resumed", "msg-resumed", [
+        { type: "text", text: "Resumed after cancellation" }
+      ]);
+      yield { type: "result", subtype: "success" } as unknown as SDKMessage;
+    },
+    close: onClose
+  };
+}

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.delegated.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.delegated.test.ts
@@ -1,0 +1,845 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withSidecarEventSinkForTest } from "./eventSink.ts";
+import { SessionRuntime } from "./sessionRuntime.ts";
+import { sidecarClaudeOptionsFromPayload } from "./options.ts";
+import {
+  fakeBackgroundBashAndSubagentQuery,
+  fakeDelegatedAssistantParentQuery,
+  fakeDelegatedTaskQuery,
+  fakeGuidedDelegatedContinuationQuery,
+  fakeRacedDelegatedTaskAliasQuery,
+  fakeStoppableDelegatedTaskQuery,
+  fakeTimedOutDelegatedTaskQuery
+} from "./sessionRuntimeTestQueries.delegated.ts";
+import {
+  fakeConcurrentDelegatedTaskCreatedHookQuery,
+  fakeDelegatedTaskCompletedHookQuery,
+  fakeFoldInTaskNotificationQuery,
+  fakeUserTaskNotificationQuery
+} from "./sessionRuntimeTestQueries.session.ts";
+import { waitForEvent } from "./sessionRuntimeTestQueries.nested.ts";
+
+test("late delegated task notification keeps original parent turn id", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => fakeDelegatedTaskQuery(prompt)
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+
+    const taskCompleted = events.find(
+      (event) => event.type === "task_completed"
+    );
+    assert.equal(taskCompleted?.payload?.turnId, "turn-1");
+    assert.equal(taskCompleted?.payload?.parentToolUseId, "toolu-agent");
+
+    const parentToolCompleted = events.find(
+      (event) =>
+        event.type === "tool_completed" &&
+        event.payload?.toolCallId === "toolu-agent" &&
+        event.payload?.status === "completed"
+    );
+    assert.equal(parentToolCompleted?.payload?.turnId, "turn-1");
+  } finally {
+    restoreSink();
+  }
+});
+
+test("delegated child result completes background agent, not mid-run child assistant messages", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      fakeDelegatedAssistantParentQuery
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+
+    const completedEvents = events.filter(
+      (event) => event.type === "task_completed"
+    );
+    assert.equal(completedEvents.length, 1);
+    const taskCompleted = completedEvents[0];
+    assert.equal(taskCompleted?.payload?.parentToolUseId, "toolu-agent");
+    assert.equal(taskCompleted?.payload?.summary, "Child result ready");
+
+    // The mid-run child assistant message streams before the task_progress
+    // event; completion must come only after progress, from the child result.
+    const progressIndex = events.findIndex(
+      (event) => event.type === "task_progress"
+    );
+    const completedIndex = events.findIndex(
+      (event) => event.type === "task_completed"
+    );
+    assert.ok(progressIndex >= 0);
+    assert.ok(completedIndex > progressIndex);
+
+    const parentToolCompleted = events.find(
+      (event) =>
+        event.type === "tool_completed" &&
+        event.payload?.toolCallId === "toolu-agent" &&
+        event.payload?.status === "completed"
+    );
+    assert.equal(parentToolCompleted?.payload?.turnId, "turn-1");
+  } finally {
+    restoreSink();
+  }
+});
+
+test("trailing task_progress does not resurrect a settled delegated task", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) =>
+        fakeDelegatedTaskQuery(prompt, { progressAfterNotification: true })
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+    // Let the fake stream drain the trailing task_progress message.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const completedIndex = events.findIndex(
+      (event) => event.type === "task_completed"
+    );
+    assert.ok(completedIndex >= 0);
+    const resurrected = events
+      .slice(completedIndex + 1)
+      .find((event) => event.type === "task_progress");
+    assert.equal(resurrected, undefined);
+  } finally {
+    restoreSink();
+  }
+});
+
+test("fold-in queued_command task notification completes running delegated task", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      fakeFoldInTaskNotificationQuery
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+
+    const completed = events.find((event) => event.type === "task_completed");
+    assert.equal(completed?.payload?.parentToolUseId, "toolu-agent");
+    assert.equal(completed?.payload?.summary, "7");
+  } finally {
+    restoreSink();
+  }
+});
+
+test("user task-notification string completes running delegated task", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      fakeUserTaskNotificationQuery
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+
+    const completed = events.find((event) => event.type === "task_completed");
+    assert.equal(completed?.payload?.parentToolUseId, "toolu-agent");
+  } finally {
+    restoreSink();
+  }
+});
+
+test("delegated task continuation emits synthetic turn started", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) =>
+        fakeDelegatedTaskQuery(prompt, { continueAfterNotification: true })
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "turn_started");
+
+    const started = events.find((event) => event.type === "turn_started");
+    assert.equal(started?.payload?.synthetic, true);
+    assert.match(String(started?.payload?.turnId ?? ""), /^synthetic-/);
+
+    const continuation = events.find(
+      (event) =>
+        event.type === "assistant_completed" &&
+        event.payload?.content === "Continuing after child agent."
+    );
+    assert.equal(continuation?.payload?.turnId, started?.payload?.turnId);
+
+    const taskNotificationObservedIndex = events.findIndex(
+      (event) =>
+        event.type === "sdk_lifecycle_observed" &&
+        event.payload?.sdkMessageType === "system" &&
+        event.payload?.sdkMessageSubtype === "task_notification"
+    );
+    const taskCompletedIndex = events.findIndex(
+      (event) => event.type === "task_completed"
+    );
+    const continuationObservedIndex = events.findIndex(
+      (event) =>
+        event.type === "sdk_lifecycle_observed" &&
+        event.payload?.sdkMessageType === "assistant" &&
+        event.payload?.rootContinuationCandidate === true
+    );
+    const syntheticStartedIndex = events.findIndex(
+      (event) => event.type === "turn_started"
+    );
+    assert.ok(taskNotificationObservedIndex >= 0);
+    assert.ok(taskCompletedIndex > taskNotificationObservedIndex);
+    assert.ok(syntheticStartedIndex > taskNotificationObservedIndex);
+    assert.ok(taskCompletedIndex > syntheticStartedIndex);
+    assert.ok(continuationObservedIndex > taskCompletedIndex);
+
+    const observed = events[taskNotificationObservedIndex]?.payload;
+    assert.equal(Object.hasOwn(observed ?? {}, "summary"), false);
+    assert.equal(Object.hasOwn(observed ?? {}, "content"), false);
+  } finally {
+    restoreSink();
+  }
+});
+
+test("delegated continuation start timeout interrupts and closes its synthetic turn", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  let interrupts = 0;
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) =>
+        fakeTimedOutDelegatedTaskQuery(prompt, () => {
+          interrupts += 1;
+        }),
+      5
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const timedOut = events.find(
+      (event) =>
+        event.type === "turn_completed" &&
+        event.payload?.syntheticTimeout === true
+    );
+    assert.match(String(timedOut?.payload?.turnId ?? ""), /^synthetic-/);
+    assert.equal(
+      timedOut?.payload?.stopReason,
+      "background_agent_continuation_timeout"
+    );
+    assert.equal(interrupts, 1);
+  } finally {
+    restoreSink();
+  }
+});
+
+test("cancel during delegated continuation wait disarms timeout", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  let interrupts = 0;
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) =>
+        fakeTimedOutDelegatedTaskQuery(prompt, () => {
+          interrupts += 1;
+        }),
+      100
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+    await session.cancel();
+    await waitForEvent(events, "turn_canceled");
+    await new Promise((resolve) => setTimeout(resolve, 120));
+
+    const canceled = events.find(
+      (event) =>
+        event.type === "turn_canceled" &&
+        String(event.payload?.turnId ?? "").startsWith("synthetic-")
+    );
+    assert.ok(canceled);
+    assert.equal(
+      events.some((event) => event.payload?.syntheticTimeout === true),
+      false
+    );
+    assert.equal(interrupts, 1);
+  } finally {
+    restoreSink();
+  }
+});
+
+test("guidance during delegated continuation wait stays on reserved synthetic turn", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => fakeGuidedDelegatedContinuationQuery(prompt),
+      100
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+    const reserved = events.find((event) => event.type === "turn_started");
+    session.guide("include the child result");
+    await waitForEvent(events, "assistant_completed");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    assert.match(String(reserved?.payload?.turnId ?? ""), /^synthetic-/);
+    assert.equal(
+      events.filter((event) => event.type === "turn_started").length,
+      1
+    );
+    const assistant = events.find(
+      (event) =>
+        event.type === "assistant_completed" &&
+        event.payload?.content === "Guided continuation."
+    );
+    assert.equal(assistant?.payload?.turnId, reserved?.payload?.turnId);
+    const completed = events.find(
+      (event) =>
+        event.type === "turn_completed" &&
+        event.payload?.turnId === reserved?.payload?.turnId
+    );
+    assert.ok(completed);
+  } finally {
+    restoreSink();
+  }
+});
+
+test("background bash registers as a delegated task and defers the synthetic continuation", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => fakeBackgroundBashAndSubagentQuery(prompt),
+      50
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate and background");
+    await waitForEvent(events, "turn_started");
+
+    // The background shell's task_started arrives after the provider turn
+    // settled, yet it must register and attribute to the launching turn.
+    const bashStarted = events.find(
+      (event) =>
+        event.type === "task_started" && event.payload?.taskId === "bs-1"
+    );
+    assert.equal(bashStarted?.payload?.turnId, "turn-1");
+    assert.equal(bashStarted?.payload?.parentToolUseId, "toolu-bash");
+
+    const agentCompletedIndex = events.findIndex(
+      (event) =>
+        event.type === "task_completed" && event.payload?.taskId === "task-1"
+    );
+    const bashCompletedIndex = events.findIndex(
+      (event) =>
+        event.type === "task_completed" && event.payload?.taskId === "bs-1"
+    );
+    const syntheticStartedIndex = events.findIndex(
+      (event) =>
+        event.type === "turn_started" && event.payload?.synthetic === true
+    );
+    assert.ok(agentCompletedIndex >= 0);
+    assert.ok(bashCompletedIndex > agentCompletedIndex);
+    // The subagent finishing first must not reserve the continuation while
+    // the background shell still runs; only the final bash completion may
+    // (the synthetic turn is reserved just before its task_completed).
+    assert.ok(syntheticStartedIndex > agentCompletedIndex);
+    assert.ok(bashCompletedIndex > syntheticStartedIndex);
+    assert.equal(events[bashCompletedIndex]?.payload?.turnId, "turn-1");
+    // Disarm the short continuation timer so it cannot leak into later tests.
+    await session.close();
+  } finally {
+    restoreSink();
+  }
+});
+
+test("stopTask stops a running delegated task without opening a synthetic continuation", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const stopCalls: string[] = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) =>
+        fakeStoppableDelegatedTaskQuery(prompt, (taskId) =>
+          stopCalls.push(taskId)
+        ),
+      5
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "turn_completed");
+
+    const stopped = await session.stopTask("task-1");
+    assert.equal(stopped, true);
+    assert.deepEqual(stopCalls, ["task-1"]);
+    await waitForEvent(events, "task_completed");
+    // Leave room for an (incorrect) synthetic continuation timer to fire.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const taskCompleted = events.find(
+      (event) => event.type === "task_completed"
+    );
+    assert.equal(taskCompleted?.payload?.status, "stopped");
+    assert.equal(taskCompleted?.payload?.parentToolUseId, "toolu-agent");
+
+    const syntheticStarted = events.find(
+      (event) =>
+        event.type === "turn_started" && event.payload?.synthetic === true
+    );
+    assert.equal(syntheticStarted, undefined);
+    assert.equal(
+      events.some((event) => event.payload?.syntheticTimeout === true),
+      false
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
+test("stopTask resolves the task id from the parent tool call id", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const stopCalls: string[] = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) =>
+        fakeStoppableDelegatedTaskQuery(prompt, (taskId) =>
+          stopCalls.push(taskId)
+        )
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "turn_completed");
+
+    assert.equal(await session.stopTask("", "toolu-agent"), true);
+    assert.deepEqual(stopCalls, ["task-1"]);
+
+    // Unknown ids must not dispatch a stop.
+    assert.equal(await session.stopTask("task-unknown"), false);
+    assert.equal(await session.stopTask("", "toolu-unknown"), false);
+    assert.deepEqual(stopCalls, ["task-1"]);
+  } finally {
+    restoreSink();
+  }
+});
+
+test("late delegated task notification without ids resolves single running task", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) =>
+        fakeDelegatedTaskQuery(prompt, { omitNotificationIds: true })
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+
+    const taskCompleted = events.find(
+      (event) => event.type === "task_completed"
+    );
+    assert.equal(taskCompleted?.payload?.turnId, "turn-1");
+    assert.equal(taskCompleted?.payload?.parentToolUseId, "toolu-agent");
+
+    const parentToolCompleted = events.find(
+      (event) =>
+        event.type === "tool_completed" &&
+        event.payload?.toolCallId === "toolu-agent" &&
+        event.payload?.status === "completed"
+    );
+    assert.equal(parentToolCompleted?.payload?.turnId, "turn-1");
+  } finally {
+    restoreSink();
+  }
+});
+
+test("late delegated task completion hook clears single running task", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      fakeDelegatedTaskCompletedHookQuery
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+
+    const taskCompleted = events.find(
+      (event) => event.type === "task_completed"
+    );
+    assert.equal(taskCompleted?.payload?.turnId, "turn-1");
+    assert.equal(taskCompleted?.payload?.parentToolUseId, "toolu-agent");
+    assert.equal(taskCompleted?.payload?.status, "completed");
+
+    const parentToolCompleted = events.find(
+      (event) =>
+        event.type === "tool_completed" &&
+        event.payload?.toolCallId === "toolu-agent" &&
+        event.payload?.status === "completed"
+    );
+    assert.equal(parentToolCompleted?.payload?.turnId, "turn-1");
+  } finally {
+    restoreSink();
+  }
+});
+
+test("task created hook does not bind unrelated running delegated task", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      fakeConcurrentDelegatedTaskCreatedHookQuery
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate tasks");
+    await waitForEvent(events, "task_completed");
+
+    const taskCompleted = events.find(
+      (event) => event.type === "task_completed"
+    );
+    assert.equal(taskCompleted?.payload?.taskId, "task-2");
+    assert.equal(taskCompleted?.payload?.parentToolUseId, "toolu-agent-2");
+
+    const completedParents = events
+      .filter((event) => {
+        const metadata = event.payload?.metadata as
+          | Record<string, unknown>
+          | undefined;
+        return (
+          event.type === "tool_completed" &&
+          event.payload?.status === "completed" &&
+          metadata?.subagentStatus === "completed"
+        );
+      })
+      .map((event) => event.payload?.toolCallId);
+    assert.deepEqual(completedParents, ["toolu-agent-2"]);
+  } finally {
+    restoreSink();
+  }
+});
+
+test("unknown task alias does not bind to another running delegated task", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => fakeRacedDelegatedTaskAliasQuery(prompt)
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate tasks");
+    await waitForEvent(events, "task_completed");
+
+    const taskCompleted = events.find(
+      (event) => event.type === "task_completed"
+    );
+    assert.equal(taskCompleted?.payload?.parentToolUseId, "toolu-agent-2");
+
+    const completedParents = events
+      .filter((event) => {
+        const metadata = event.payload?.metadata as
+          | Record<string, unknown>
+          | undefined;
+        return (
+          event.type === "tool_completed" &&
+          event.payload?.status === "completed" &&
+          metadata?.subagentStatus === "completed"
+        );
+      })
+      .map((event) => event.payload?.toolCallId);
+    assert.deepEqual(completedParents, ["toolu-agent-2"]);
+
+    const firstAgentTaskEvents = events.filter(
+      (event) =>
+        (event.type === "task_started" ||
+          event.type === "task_progress" ||
+          event.type === "task_completed") &&
+        event.payload?.parentToolUseId === "toolu-agent-1"
+    );
+    assert.deepEqual(firstAgentTaskEvents, []);
+  } finally {
+    restoreSink();
+  }
+});

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.nested.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.nested.test.ts
@@ -1,0 +1,311 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withSidecarEventSinkForTest } from "./eventSink.ts";
+import { SessionRuntime } from "./sessionRuntime.ts";
+import { sidecarClaudeOptionsFromPayload } from "./options.ts";
+import { fakeDelegatedTextOnlyCompletionQuery } from "./sessionRuntimeTestQueries.session.ts";
+import {
+  fakeNestedDelegatedLaunchQuery,
+  fakeNestedLaunchWithoutToolUseQuery,
+  fakeNestedApprovalQuery,
+  fakeNestedDeferredParentCompletionQuery,
+  fakeNestedToolUseAndEndTurnQuery,
+  waitForEvent
+} from "./sessionRuntimeTestQueries.nested.ts";
+
+test("nested end_turn assistant completes delegated task without child result", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      fakeDelegatedTextOnlyCompletionQuery
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+
+    const completed = events.find((event) => event.type === "task_completed");
+    assert.equal(completed?.payload?.parentToolUseId, "toolu-agent");
+    assert.equal(completed?.payload?.summary, "7");
+  } finally {
+    restoreSink();
+  }
+});
+
+test("nested agent launch registers grandchild task with inherited turn id", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      fakeNestedDelegatedLaunchQuery
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+
+    const childCompleted = events.find(
+      (event) =>
+        event.type === "task_completed" &&
+        event.payload?.parentToolUseId === "toolu-child"
+    );
+    assert.equal(childCompleted?.payload?.turnId, "turn-1");
+    assert.equal(childCompleted?.payload?.agentId, "agent-child");
+
+    const childToolCompleted = events.find(
+      (event) =>
+        event.type === "tool_completed" &&
+        event.payload?.toolCallId === "toolu-child" &&
+        event.payload?.status === "completed"
+    );
+    assert.equal(childToolCompleted?.payload?.turnId, "turn-1");
+  } finally {
+    restoreSink();
+  }
+});
+
+test("nested launch without observed tool_use block still registers task", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      fakeNestedLaunchWithoutToolUseQuery
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+
+    const childCompleted = events.find(
+      (event) =>
+        event.type === "task_completed" &&
+        event.payload?.parentToolUseId === "toolu-child"
+    );
+    assert.equal(childCompleted?.payload?.turnId, "turn-1");
+
+    const launchToolCompleted = events.find(
+      (event) =>
+        event.type === "tool_completed" &&
+        event.payload?.toolCallId === "toolu-child" &&
+        (event.payload?.metadata as Record<string, unknown> | undefined)
+          ?.subagentAsync === true
+    );
+    assert.equal(launchToolCompleted?.payload?.turnId, "turn-1");
+  } finally {
+    restoreSink();
+  }
+});
+
+test("nested approval after parent task completed still carries a turn id", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  let permissionResult: unknown;
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt, options }) =>
+        fakeNestedApprovalQuery(prompt, options, (result) => {
+          permissionResult = result;
+        })
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "approval_requested");
+
+    const request = events.find((event) => event.type === "approval_requested");
+    assert.equal(request?.payload?.turnId, "turn-1");
+    assert.equal(request?.payload?.agentId, "agent-parent");
+
+    session.submitInteractive(
+      "turn-1",
+      String(request?.payload?.requestId ?? ""),
+      "submit",
+      "allow",
+      {}
+    );
+    await waitForEvent(events, "approval_resolved");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    assert.deepEqual(permissionResult, {
+      behavior: "allow",
+      updatedInput: { command: "ls" }
+    });
+  } finally {
+    restoreSink();
+  }
+});
+
+test("nested end_turn assistant defers parent completion while grandchild runs", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      fakeNestedDeferredParentCompletionQuery
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+    // Let the fake stream drain the remaining nested messages.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const parentCompletions = events.filter(
+      (event) =>
+        event.type === "task_completed" &&
+        event.payload?.parentToolUseId === "toolu-parent"
+    );
+    assert.equal(parentCompletions.length, 1);
+    assert.equal(parentCompletions[0]?.payload?.summary, "Parent finished.");
+
+    const childCompletedIndex = events.findIndex(
+      (event) =>
+        event.type === "task_completed" &&
+        event.payload?.parentToolUseId === "toolu-child"
+    );
+    const parentCompletedIndex = events.findIndex(
+      (event) =>
+        event.type === "task_completed" &&
+        event.payload?.parentToolUseId === "toolu-parent"
+    );
+    assert.ok(childCompletedIndex >= 0);
+    assert.ok(parentCompletedIndex > childCompletedIndex);
+  } finally {
+    restoreSink();
+  }
+});
+
+test("nested end_turn assistant defers parent completion while child tool result is pending", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      fakeNestedToolUseAndEndTurnQuery
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+    // Let the fake stream drain the grandchild result and final parent end.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const parentCompletions = events.filter(
+      (event) =>
+        event.type === "task_completed" &&
+        event.payload?.parentToolUseId === "toolu-parent"
+    );
+    assert.equal(parentCompletions.length, 1);
+    assert.equal(parentCompletions[0]?.payload?.summary, "Parent finished.");
+
+    const childCompletedIndex = events.findIndex(
+      (event) =>
+        event.type === "task_completed" &&
+        event.payload?.parentToolUseId === "toolu-child"
+    );
+    const parentCompletedIndex = events.findIndex(
+      (event) =>
+        event.type === "task_completed" &&
+        event.payload?.parentToolUseId === "toolu-parent"
+    );
+    assert.ok(childCompletedIndex >= 0);
+    assert.ok(parentCompletedIndex > childCompletedIndex);
+  } finally {
+    restoreSink();
+  }
+});

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.session.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.session.test.ts
@@ -1,0 +1,721 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withSidecarEventSinkForTest } from "./eventSink.ts";
+import { SessionRuntime } from "./sessionRuntime.ts";
+import { sidecarClaudeOptionsFromPayload } from "./options.ts";
+import { isRecord, testCanUseToolOptions } from "./sessionRuntimeTestCommon.ts";
+import {
+  fakeContextUsageQuery,
+  fakeSimpleResultQuery
+} from "./sessionRuntimeTestQueries.delegated.ts";
+import { fakeQueryWithInitializationModels } from "./sessionRuntimeTestQueries.assistant.ts";
+import {
+  fakeCompactBoundaryQuery,
+  fakeDeferredContextUsageQuery,
+  fakeFailedCompactQuery,
+  fakeGuidancePromptQuery,
+  fakePermissionCheckQuery,
+  fakeStatusOnlyCompactQuery
+} from "./sessionRuntimeTestQueries.session.ts";
+import { waitForEvent } from "./sessionRuntimeTestQueries.nested.ts";
+
+test("guidance prompt stays on the active SDK turn", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const prompts: string[] = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => fakeGuidancePromptQuery(prompt, prompts)
+    );
+
+    await session.start();
+    session.exec("turn-1", "start working");
+    session.guide("prefer the focused path");
+    await waitForEvent(events, "turn_completed");
+
+    assert.deepEqual(prompts, ["start working", "prefer the focused path"]);
+    const completed = events.find((event) => event.type === "turn_completed");
+    assert.equal(completed?.payload?.turnId, "turn-1");
+    assert.equal(
+      events.some(
+        (event) =>
+          event.type === "turn_completed" && event.payload?.turnId !== "turn-1"
+      ),
+      false
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
+async function waitForCondition(
+  predicate: () => boolean,
+  description: string
+): Promise<void> {
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.fail(`timed out waiting for ${description}`);
+}
+
+test("goal set scheduling ack followed by immediate clear coalesces before SDK activation", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-goal",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => fakeSimpleResultQuery(prompt)
+    );
+
+    await session.start();
+    // Both calls have crossed the sidecar scheduling/ACK boundary before the
+    // deferred Goal dispatcher hands either command to the SDK iterable.
+    session.exec("goal-set-turn", "/goal ship it", undefined, "goal_arm", {
+      operationId: "goal-op-set",
+      revision: 1,
+      action: "set"
+    });
+    session.exec("goal-clear-command", "/goal clear", undefined, undefined, {
+      operationId: "goal-op-clear",
+      revision: 2,
+      action: "clear"
+    });
+
+    await waitForEvent(events, "goal_command_started");
+    await waitForEvent(events, "turn_completed");
+
+    assert.equal(
+      events.some(
+        (event) =>
+          event.type === "turn_started" &&
+          event.payload?.turnId === "goal-set-turn"
+      ),
+      false
+    );
+    const superseded = events.find(
+      (event) => event.type === "goal_command_superseded"
+    );
+    assert.equal(superseded?.payload?.operationId, "goal-op-set");
+    const started = events.find(
+      (event) => event.type === "goal_command_started"
+    );
+    assert.equal(started?.payload?.operationId, "goal-op-clear");
+    assert.equal(started?.payload?.revision, 2);
+  } finally {
+    restoreSink();
+  }
+});
+
+test("query enables bypass permission capability for later live mode switch", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  const previousSandbox = process.env.IS_SANDBOX;
+  let capturedOptions:
+    | {
+        allowDangerouslySkipPermissions?: boolean;
+        permissionMode?: string;
+      }
+    | undefined;
+  process.env.IS_SANDBOX = "1";
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt, options }) => {
+        capturedOptions = options;
+        return fakeSimpleResultQuery(prompt);
+      }
+    );
+
+    await session.start();
+    session.exec("turn-1", "hello");
+    await waitForEvent(events, "turn_completed");
+
+    assert.equal(capturedOptions?.permissionMode, "default");
+    assert.equal(capturedOptions?.allowDangerouslySkipPermissions, true);
+  } finally {
+    if (previousSandbox === undefined) {
+      delete process.env.IS_SANDBOX;
+    } else {
+      process.env.IS_SANDBOX = previousSandbox;
+    }
+    restoreSink();
+  }
+});
+
+test("session start emits SDK model config options from initialization", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "mimo-v2.5-pro",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) =>
+        fakeQueryWithInitializationModels(prompt, [
+          {
+            value: "default",
+            displayName: "Default",
+            description: "Provider default"
+          },
+          {
+            value: "mimo-v2.5-pro",
+            displayName: "Mimo v2.5 Pro",
+            description: "Custom Mimo model"
+          }
+        ])
+    );
+
+    await session.start();
+
+    const started = events.find((event) => event.type === "session_started");
+    const configOptions = started?.payload?.configOptions as
+      | Array<Record<string, unknown>>
+      | undefined;
+    const modelOption = configOptions?.find((option) => option.id === "model");
+    const modelOptions = modelOption?.options as
+      | Array<Record<string, unknown>>
+      | undefined;
+    assert.equal(modelOption?.currentValue, "mimo-v2.5-pro");
+    assert.deepEqual(
+      modelOptions?.map((option) => ({
+        value: option.value,
+        name: option.name,
+        description: option.description
+      })),
+      [
+        {
+          value: "default",
+          name: "Default",
+          description: "Provider default"
+        },
+        {
+          value: "mimo-v2.5-pro",
+          name: "Mimo v2.5 Pro",
+          description: "Custom Mimo model"
+        }
+      ]
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
+test("context usage prefers result modelUsage window over SDK maxTokens", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "sonnet",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => fakeContextUsageQuery(prompt)
+    );
+
+    await session.start();
+    session.exec("turn-1", "hi");
+    await waitForEvent(events, "turn_completed");
+    await waitForEvent(events, "usage_updated");
+
+    const usage = events.find(
+      (event) =>
+        event.type === "usage_updated" && isRecord(event.payload?.contextWindow)
+    );
+    const contextWindow = isRecord(usage?.payload?.contextWindow)
+      ? usage.payload.contextWindow
+      : undefined;
+    assert.equal(contextWindow?.usedTokens, 36_092);
+    assert.equal(contextWindow?.totalTokens, 1_000_000);
+    assert.equal(
+      events.some(
+        (event) =>
+          event.type === "usage_updated" && isRecord(event.payload?.usage)
+      ),
+      false,
+      "cumulative result usage must not replace the authoritative context snapshot"
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
+test("turn completion does not wait for context usage and stale snapshots are dropped", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const contextUsageResolvers: Array<(value: unknown) => void> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "haiku",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) =>
+        fakeDeferredContextUsageQuery(prompt, contextUsageResolvers)
+    );
+
+    await session.start();
+    session.exec("turn-1", "first");
+    await waitForCondition(
+      () =>
+        events.some(
+          (event) =>
+            event.type === "turn_completed" &&
+            event.payload?.turnId === "turn-1"
+        ),
+      "first turn completion"
+    );
+    assert.equal(contextUsageResolvers.length, 1);
+
+    session.exec("turn-2", "second");
+    await waitForCondition(
+      () =>
+        events.some(
+          (event) =>
+            event.type === "turn_completed" &&
+            event.payload?.turnId === "turn-2"
+        ) && contextUsageResolvers.length === 2,
+      "second turn completion and context usage request"
+    );
+
+    contextUsageResolvers[1]?.({ totalTokens: 222, maxTokens: 200_000 });
+    await waitForCondition(
+      () =>
+        events.some(
+          (event) =>
+            event.type === "usage_updated" &&
+            event.payload?.turnId === "turn-2" &&
+            isRecord(event.payload?.contextWindow)
+        ),
+      "second turn context usage"
+    );
+
+    contextUsageResolvers[0]?.({ totalTokens: 111, maxTokens: 200_000 });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(
+      events.some(
+        (event) =>
+          event.type === "usage_updated" &&
+          event.payload?.turnId === "turn-1" &&
+          isRecord(event.payload?.contextWindow)
+      ),
+      false,
+      "the delayed first-turn snapshot must not overwrite the newer turn"
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
+test("result usage remains available when context snapshot is unavailable", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "haiku",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) =>
+        fakeSimpleResultQuery(prompt, {
+          usage: {
+            input_tokens: 120,
+            output_tokens: 8,
+            cache_read_input_tokens: 72,
+            cache_creation_input_tokens: 0
+          }
+        })
+    );
+
+    await session.start();
+    session.exec("turn-usage-fallback", "hi");
+    await waitForEvent(events, "turn_completed");
+
+    const usage = events.find(
+      (event) =>
+        event.type === "usage_updated" && isRecord(event.payload?.usage)
+    );
+    assert.ok(
+      usage,
+      "expected result usage when no context query is available"
+    );
+    assert.equal(usage.payload?.turnId, "turn-usage-fallback");
+  } finally {
+    restoreSink();
+  }
+});
+
+test("late compact boundary still attaches to slash compact turn", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) =>
+        fakeCompactBoundaryQuery(prompt, { boundaryAfterResult: true })
+    );
+
+    await session.start();
+    session.exec("turn-late", "/compact");
+    await waitForEvent(events, "turn_completed");
+    await waitForEvent(events, "compact_completed");
+
+    const compactEvent = events.find(
+      (event) => event.type === "compact_completed"
+    );
+    assert.equal(compactEvent?.payload?.turnId, "turn-late");
+
+    const usage = events.find((event) => event.type === "usage_updated");
+    assert.equal(usage?.payload?.turnId, "turn-late");
+  } finally {
+    restoreSink();
+  }
+});
+
+test("compact success reported only via status message still refreshes usage", async () => {
+  // Real Claude Code compaction can report completion via the `status`
+  // system message (`compact_result: "success"`) without a `compact_boundary`
+  // message ever following it in a given ordering/timing window. Before this
+  // fix, that path emitted "Compacting completed." without ever refreshing
+  // the context-usage percentage, so the GUI usage chip stayed pinned at its
+  // pre-compaction value (e.g. 100%) until some unrelated later turn happened
+  // to report fresh usage.
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => fakeStatusOnlyCompactQuery(prompt)
+    );
+
+    await session.start();
+    session.exec("turn-status-only", "/compact");
+    await waitForEvent(events, "turn_completed");
+    await waitForEvent(events, "compact_completed");
+
+    const usage = events.find(
+      (event) =>
+        event.type === "usage_updated" && isRecord(event.payload?.contextWindow)
+    );
+    const contextWindow = isRecord(usage?.payload?.contextWindow)
+      ? usage.payload.contextWindow
+      : undefined;
+    assert.ok(usage, "expected a usage_updated event carrying contextWindow");
+    assert.equal(usage?.payload?.turnId, "turn-status-only");
+    assert.equal(contextWindow?.usedTokens, 4_061);
+    assert.equal(contextWindow?.totalTokens, 1_000_000);
+  } finally {
+    restoreSink();
+  }
+});
+
+test("compact failure preserves the status reason and assistant response", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => fakeFailedCompactQuery(prompt)
+    );
+
+    await session.start();
+    session.exec("turn-compact-failed", "/compact");
+    await waitForEvent(events, "compact_failed");
+    await waitForEvent(events, "turn_completed");
+
+    assert.equal(
+      events.find((event) => event.type === "compact_failed")?.payload?.content,
+      "Compacting failed: Not enough messages to compact."
+    );
+    assert.equal(
+      events.find((event) => event.type === "compact_failed")?.payload?.reason,
+      "Not enough messages to compact."
+    );
+    assert.equal(
+      events.find((event) => event.type === "assistant_completed")?.payload
+        ?.content,
+      "Not enough messages to compact."
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
+test("bypass permission mode allows ordinary tools without approval", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  let permissionResult: unknown;
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "bypassPermissions",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt, options }) =>
+        fakePermissionCheckQuery(prompt, options, async (queryOptions) => {
+          permissionResult = await queryOptions.canUseTool?.(
+            "Bash",
+            { command: "rm -rf /repo/*" },
+            testCanUseToolOptions({
+              requestId: "request-bash",
+              toolUseID: "toolu-bash"
+            })
+          );
+        })
+    );
+
+    await session.start();
+    session.exec("turn-1", "delete everything");
+    await waitForEvent(events, "turn_completed");
+
+    assert.equal(
+      events.some((event) => event.type === "approval_requested"),
+      false
+    );
+    assert.deepEqual(permissionResult, {
+      behavior: "allow",
+      updatedInput: { command: "rm -rf /repo/*" }
+    });
+  } finally {
+    restoreSink();
+  }
+});
+
+test("bypass permission mode still surfaces AskUserQuestion", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  let permissionResult: unknown;
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "bypassPermissions",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt, options }) =>
+        fakePermissionCheckQuery(prompt, options, async (queryOptions) => {
+          permissionResult = await queryOptions.canUseTool?.(
+            "AskUserQuestion",
+            {
+              questions: [
+                {
+                  header: "Confirm",
+                  question: "Delete everything?",
+                  options: [{ label: "Yes", description: "Delete files" }]
+                }
+              ]
+            },
+            testCanUseToolOptions({
+              requestId: "request-ask",
+              toolUseID: "toolu-ask"
+            })
+          );
+        })
+    );
+
+    await session.start();
+    session.exec("turn-1", "delete everything");
+    await waitForEvent(events, "user_input_requested");
+
+    const request = events.find(
+      (event) => event.type === "user_input_requested"
+    );
+    session.submitInteractive(
+      "turn-1",
+      String(request?.payload?.requestId ?? ""),
+      "submit",
+      "Yes",
+      {
+        answers: ["Yes"],
+        answersByQuestionId: { "question-1": "Yes" }
+      }
+    );
+    await waitForEvent(events, "turn_completed");
+
+    assert.equal(
+      events.some((event) => event.type === "approval_requested"),
+      false
+    );
+    assert.deepEqual(permissionResult, {
+      behavior: "allow",
+      updatedInput: {
+        questions: [
+          {
+            header: "Confirm",
+            question: "Delete everything?",
+            options: [{ label: "Yes", description: "Delete files" }]
+          }
+        ],
+        answers: { "Delete everything?": "Yes" }
+      }
+    });
+  } finally {
+    restoreSink();
+  }
+});

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
@@ -135,7 +135,8 @@ export class SessionRuntime {
     this.activities = new ToolActivityProjector(
       () => this.turns.activeId,
       emit,
-      () => this.turns.expectSyntheticContinuation()
+      () => this.turns.expectSyntheticContinuation(),
+      () => this.turns.lastTurnId
     );
     this.compaction = new CompactionTracker({
       activeTurnId: () => this.turns.activeId,
@@ -422,6 +423,24 @@ export class SessionRuntime {
       this.turns.clearCancelled();
     }
     return hasActiveTurn;
+  }
+
+  async stopTask(taskId: string, parentToolUseId = ""): Promise<boolean> {
+    if (this.sessionClosed) {
+      return false;
+    }
+    const resolvedTaskId = this.activities.resolveDelegatedTaskIdForStop(
+      taskId,
+      parentToolUseId
+    );
+    const stopTask = this.query?.stopTask;
+    if (!resolvedTaskId || !stopTask) {
+      return false;
+    }
+    // The stopped task_notification that follows settles the task's activity
+    // state; no local bookkeeping happens here so a failed stop stays running.
+    await stopTask.call(this.query, resolvedTaskId);
+    return true;
   }
 
   async close(): Promise<void> {

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntimeTestQueries.delegated.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntimeTestQueries.delegated.ts
@@ -191,6 +191,112 @@ export function fakeTimedOutDelegatedTaskQuery(
   };
 }
 
+export function fakeBackgroundBashAndSubagentQuery(
+  prompt: AsyncIterable<SDKUserMessage>
+): AsyncIterable<SDKMessage> & {
+  interrupt: () => Promise<void>;
+  close: () => void;
+} {
+  let releaseHold: () => void = () => {};
+  const hold = new Promise<void>((resolve) => {
+    releaseHold = resolve;
+  });
+  return {
+    async *[Symbol.asyncIterator]() {
+      const firstPrompt = await prompt[Symbol.asyncIterator]().next();
+      const promptMessage = firstPrompt.value as SDKUserMessage & {
+        uuid?: string;
+      };
+      yield {
+        ...promptMessage,
+        uuid: promptMessage.uuid,
+        type: "user",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1"
+      } as SDKMessage;
+      yield delegatedAgentToolUse("toolu-agent", "Slow child");
+      yield delegatedAgentToolResult("toolu-agent", "agent-1");
+      yield {
+        type: "system",
+        subtype: "task_started",
+        task_id: "task-1",
+        agent_id: "agent-1",
+        description: "Slow child"
+      } as unknown as SDKMessage;
+      yield {
+        type: "result",
+        subtype: "success"
+      } as unknown as SDKMessage;
+      // A run_in_background Bash announces itself only through the task
+      // system, after the provider turn already settled.
+      yield {
+        type: "system",
+        subtype: "task_started",
+        task_id: "bs-1",
+        tool_use_id: "toolu-bash",
+        description: "sleep 60"
+      } as unknown as SDKMessage;
+      yield {
+        type: "system",
+        subtype: "task_notification",
+        task_id: "task-1",
+        status: "completed",
+        summary: "Child done"
+      } as unknown as SDKMessage;
+      yield {
+        type: "system",
+        subtype: "task_notification",
+        task_id: "bs-1",
+        status: "completed",
+        summary: "Command done"
+      } as unknown as SDKMessage;
+      await hold;
+    },
+    async interrupt() {
+      releaseHold();
+    },
+    close() {
+      releaseHold();
+    }
+  };
+}
+
+export function fakeStoppableDelegatedTaskQuery(
+  prompt: AsyncIterable<SDKUserMessage>,
+  onStopTask: (taskId: string) => void
+): AsyncIterable<SDKMessage> & {
+  stopTask: (taskId: string) => Promise<void>;
+  close: () => void;
+} {
+  let releaseStop: (taskId: string) => void = () => {};
+  const stopped = new Promise<string>((resolve) => {
+    releaseStop = resolve;
+  });
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield* fakeDelegatedTaskQuery(prompt, { skipNotification: true });
+      const taskId = await stopped;
+      if (!taskId) {
+        return;
+      }
+      yield {
+        type: "system",
+        subtype: "task_notification",
+        task_id: taskId,
+        status: "stopped",
+        summary: "Task stopped by user"
+      } as unknown as SDKMessage;
+    },
+    async stopTask(taskId: string) {
+      onStopTask(taskId);
+      releaseStop(taskId);
+    },
+    close() {
+      releaseStop("");
+    }
+  };
+}
+
 export function fakeGuidedDelegatedContinuationQuery(
   prompt: AsyncIterable<SDKUserMessage>
 ): AsyncIterable<SDKMessage> & { close: () => void } {

--- a/packages/agent/claude-sdk-sidecar/src/toolActivity.ts
+++ b/packages/agent/claude-sdk-sidecar/src/toolActivity.ts
@@ -29,15 +29,18 @@ export class ToolActivityProjector {
   private readonly activeTurnId: () => string;
   private readonly emit: ClaudeSDKSidecarEventEmitter;
   private readonly onFinalDelegatedTaskSettling: () => void;
+  private readonly lastTurnId: () => string;
 
   constructor(
     activeTurnId: () => string,
     emit: ClaudeSDKSidecarEventEmitter,
-    onFinalDelegatedTaskSettling: () => void = () => {}
+    onFinalDelegatedTaskSettling: () => void = () => {},
+    lastTurnId: () => string = activeTurnId
   ) {
     this.activeTurnId = activeTurnId;
     this.emit = emit;
     this.onFinalDelegatedTaskSettling = onFinalDelegatedTaskSettling;
+    this.lastTurnId = lastTurnId;
     this.taskPlan = new TaskPlanTracker(activeTurnId, emit);
     this.tools = new ToolEventProjector(
       (tool) => this.resolveToolEventTurnId(tool),
@@ -83,6 +86,21 @@ export class ToolActivityProjector {
     return latest;
   }
 
+  resolveDelegatedTaskIdForStop(
+    taskId: string,
+    parentToolUseId: string
+  ): string {
+    // Callers may only hold one identifier, and the daemon's child key can be
+    // the SDK task id, the agent id, or the launching tool use id; try all.
+    const parentByAlias = taskId
+      ? this.delegatedParentByAlias(taskId, taskId)
+      : "";
+    const task = parentByAlias
+      ? this.delegatedTasksByParentToolUseID.get(parentByAlias)
+      : this.delegatedTasksByParentToolUseID.get(parentToolUseId || taskId);
+    return task?.status === "running" ? (task.taskId ?? "") : "";
+  }
+
   handleTaskNotificationFromText(text: string): void {
     const parsed = parseTaskNotification(text);
     if (!parsed) {
@@ -98,7 +116,14 @@ export class ToolActivityProjector {
     subtype: "task_started" | "task_progress" | "task_notification",
     message: Record<string, unknown>
   ): void {
-    const task = this.resolveDelegatedTaskFromMessage(message);
+    // task_notification is included so a terminal notice for a task launched
+    // before a sidecar restart (reported e.g. as stopped on the next prompt)
+    // still settles a card instead of being dropped by the fresh instance.
+    const task =
+      this.resolveDelegatedTaskFromMessage(message) ??
+      (subtype === "task_started" || subtype === "task_notification"
+        ? this.rememberBackgroundTask(message)
+        : undefined);
     if (!task) {
       return;
     }
@@ -116,8 +141,13 @@ export class ToolActivityProjector {
       if (task.status !== "running") {
         return;
       }
-      this.prepareDelegatedTaskTerminal(task);
-      task.status = delegatedTaskStatus(message.status);
+      const status = delegatedTaskStatus(message.status);
+      // A user-initiated stop needs no model follow-up, so it must not open a
+      // synthetic continuation turn (which would time out and interrupt).
+      if (status !== "stopped") {
+        this.prepareDelegatedTaskTerminal(task);
+      }
+      task.status = status;
       this.emitDelegatedTaskLifecycleEvent("task_completed", task, message);
       this.emitDelegatedTaskParentUpdate(task, message);
       return;
@@ -211,13 +241,16 @@ export class ToolActivityProjector {
     if (!task) {
       return;
     }
-    this.prepareDelegatedTaskTerminal(task);
+    const status = delegatedTaskStatus(hookInput.status);
+    if (status !== "stopped") {
+      this.prepareDelegatedTaskTerminal(task);
+    }
     const taskId = stringValue(hookInput.task_id) || task.taskId;
     if (taskId && !task.taskId) {
       task.taskId = taskId;
       this.delegatedParentByTaskID.set(taskId, task.parentToolUseId);
     }
-    task.status = delegatedTaskStatus(hookInput.status);
+    task.status = status;
     task.subject = stringValue(hookInput.task_subject) || task.subject;
     task.description =
       stringValue(hookInput.task_description) || task.description;
@@ -263,8 +296,11 @@ export class ToolActivityProjector {
     if (!task || task.status !== "running") {
       return;
     }
-    this.prepareDelegatedTaskTerminal(task);
-    task.status = delegatedTaskStatus(message.status);
+    const status = delegatedTaskStatus(message.status);
+    if (status !== "stopped") {
+      this.prepareDelegatedTaskTerminal(task);
+    }
+    task.status = status;
     this.emitDelegatedTaskLifecycleEvent("task_completed", task, message);
     this.emitDelegatedTaskParentUpdate(task, message);
   }
@@ -367,6 +403,39 @@ export class ToolActivityProjector {
     if (agentId) {
       this.delegatedParentByAgentID.set(agentId, parentToolUseId);
     }
+  }
+
+  // Background launches the launch-result path does not register (most
+  // importantly `run_in_background` Bash) still announce themselves through
+  // the SDK task system. Registering them here puts them on the same
+  // delegated-task rails as background subagents, so they gate the root turn,
+  // show up as child sessions, and can be stopped individually — instead of
+  // running invisibly after the turn settled.
+  private rememberBackgroundTask(
+    message: Record<string, unknown>
+  ): DelegatedTaskState | undefined {
+    const parentToolUseId =
+      stringValue(message.tool_use_id) || stringValue(message.toolCallId);
+    const taskId = stringValue(message.task_id) || stringValue(message.taskId);
+    if (!parentToolUseId || !taskId) {
+      // Without a launching tool use id this could be a racing alias for a
+      // not-yet-registered subagent launch; binding it here would poison the
+      // alias maps, so leave it for the launch result to register.
+      return undefined;
+    }
+    const task: DelegatedTaskState = {
+      parentToolUseId,
+      // Background task_started frequently arrives after the launching
+      // provider turn already settled; fall back to that turn so lifecycle
+      // events are not dropped for lack of a turn id.
+      turnId: this.activeTurnId() || this.lastTurnId(),
+      input: {},
+      taskId,
+      status: "running"
+    };
+    this.delegatedTasksByParentToolUseID.set(parentToolUseId, task);
+    this.delegatedParentByTaskID.set(taskId, parentToolUseId);
+    return task;
   }
 
   private resolveDelegatedTaskFromMessage(

--- a/packages/agent/claude-sdk-sidecar/src/turnLifecycle.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/turnLifecycle.test.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ClaudeSDKSidecarEvent } from "./protocol.ts";
+import { TurnLifecycle } from "./turnLifecycle.ts";
+
+test("turn lifecycle activates and settles a queued turn", () => {
+  const { lifecycle, events, activations, settlements } = createLifecycle();
+  lifecycle.enqueue({
+    turnId: "turn-1",
+    promptUuid: "prompt-1",
+    settled: false
+  });
+
+  lifecycle.activateForUserMessage("prompt-1");
+  lifecycle.settleActive("turn_completed", { stopReason: "end_turn" });
+
+  assert.equal(lifecycle.activeId, "");
+  assert.equal(lifecycle.turnCount, 1);
+  assert.equal(activations.count, 1);
+  assert.equal(settlements.count, 1);
+  assert.deepEqual(events[0], {
+    type: "turn_completed",
+    payload: { stopReason: "end_turn", turnId: "turn-1" }
+  });
+});
+
+test("turn lifecycle announces a goal arm before its first output", () => {
+  const { lifecycle, events } = createLifecycle();
+  lifecycle.enqueue({
+    turnId: "goal-arm-1",
+    promptUuid: "prompt-goal",
+    origin: "goal_arm",
+    settled: false
+  });
+
+  lifecycle.activateForUserMessage("prompt-goal");
+
+  assert.deepEqual(events[0], {
+    type: "turn_started",
+    payload: { turnId: "goal-arm-1", turnOrigin: "goal_arm" }
+  });
+});
+
+test("goal activation carries its immutable command identity", () => {
+  const { lifecycle, events } = createLifecycle();
+  lifecycle.enqueue({
+    turnId: "goal-arm-immutable",
+    promptUuid: "prompt-goal-immutable",
+    origin: "goal_arm",
+    goalOperationId: "goal-op-1",
+    goalRevision: 1,
+    goalRepairEpoch: 7,
+    goalAction: "set",
+    settled: false
+  });
+
+  lifecycle.activateForUserMessage("prompt-goal-immutable");
+
+  const applied = events.find((event) => event.type === "goal_command_started");
+  assert.equal(applied?.payload?.operationId, "goal-op-1");
+  assert.equal(applied?.payload?.revision, 1);
+  assert.equal(applied?.payload?.repairEpoch, 7);
+  const started = events.find((event) => event.type === "turn_started");
+  assert.equal(started?.payload?.sourceGoalOperationId, "goal-op-1");
+  assert.equal(started?.payload?.sourceGoalRevision, 1);
+  assert.equal(started?.payload?.sourceGoalRepairEpoch, 7);
+});
+
+test("turn lifecycle creates an explicit synthetic turn for orphan assistant output", () => {
+  const { lifecycle, events } = createLifecycle();
+
+  const turn = lifecycle.ensureActive("assistant");
+
+  assert.equal(turn?.synthetic, true);
+  assert.match(turn?.turnId ?? "", /^synthetic-/u);
+  assert.equal(events[0]?.type, "turn_started");
+  assert.equal(events[0]?.payload?.synthetic, true);
+});
+
+test("turn lifecycle cancels queued turns and consumes their orphan results", () => {
+  const { lifecycle, events } = createLifecycle();
+  lifecycle.enqueue({
+    turnId: "turn-1",
+    promptUuid: "prompt-1",
+    settled: false
+  });
+  lifecycle.enqueue({
+    turnId: "turn-2",
+    promptUuid: "prompt-2",
+    settled: false
+  });
+  lifecycle.activateForUserMessage("prompt-1");
+
+  assert.equal(lifecycle.cancelQueued(), true);
+  assert.equal(lifecycle.pendingOrphans, 1);
+  assert.equal(lifecycle.consumePendingOrphan(), true);
+  assert.equal(lifecycle.consumePendingOrphan(), false);
+  assert.equal(events.at(-1)?.type, "turn_canceled");
+  assert.equal(events.at(-1)?.payload?.turnId, "turn-2");
+});
+
+test("notification-reserved synthetic turn times out and rejects late continuation", async () => {
+  const timeouts = { count: 0 };
+  const { lifecycle, events } = createLifecycle({
+    continuationStartTimeoutMs: 5,
+    onContinuationStartTimeout: () => {
+      timeouts.count += 1;
+    }
+  });
+
+  const reserved = lifecycle.expectSyntheticContinuation();
+  assert.equal(reserved?.synthetic, true);
+  assert.equal(lifecycle.awaitingContinuation, true);
+  assert.equal(events[0]?.type, "turn_started");
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.equal(timeouts.count, 1);
+  assert.equal(lifecycle.activeId, "");
+  assert.deepEqual(events.at(-1), {
+    type: "turn_completed",
+    payload: {
+      stopReason: "background_agent_continuation_timeout",
+      syntheticTimeout: true,
+      turnId: reserved?.turnId
+    }
+  });
+  assert.equal(lifecycle.ensureActive("assistant"), undefined);
+  assert.equal(lifecycle.consumeTimedOutContinuationResult(), true);
+
+  lifecycle.enqueue({
+    turnId: "turn-after-timeout",
+    promptUuid: "prompt-after-timeout",
+    settled: false
+  });
+  lifecycle.activateForUserMessage("prompt-after-timeout");
+  assert.equal(lifecycle.activeId, "turn-after-timeout");
+  assert.equal(lifecycle.consumeTimedOutContinuationResult(), false);
+});
+
+test("root output confirms a reserved continuation and disarms its start timeout", async () => {
+  const timeouts = { count: 0 };
+  const { lifecycle, events } = createLifecycle({
+    continuationStartTimeoutMs: 5,
+    onContinuationStartTimeout: () => {
+      timeouts.count += 1;
+    }
+  });
+  const reserved = lifecycle.expectSyntheticContinuation();
+
+  assert.equal(lifecycle.ensureActive("assistant"), reserved);
+  assert.equal(lifecycle.awaitingContinuation, false);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.equal(timeouts.count, 0);
+  assert.equal(
+    events.filter((event) => event.type === "turn_started").length,
+    1
+  );
+  assert.equal(
+    events.some((event) => event.type === "turn_completed"),
+    false
+  );
+  lifecycle.settleActive("turn_completed");
+});
+
+test("cancel and guidance preserve reserved continuation ownership", async () => {
+  const timeouts = { count: 0 };
+  const { lifecycle, events } = createLifecycle({
+    continuationStartTimeoutMs: 5,
+    onContinuationStartTimeout: () => {
+      timeouts.count += 1;
+    }
+  });
+  const reserved = lifecycle.expectSyntheticContinuation();
+
+  lifecycle.activateForUserMessage("guidance-prompt");
+  assert.equal(lifecycle.activeTurn, reserved);
+  assert.equal(
+    events.filter((event) => event.type === "turn_started").length,
+    1
+  );
+
+  assert.equal(lifecycle.cancelQueued(), true);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(timeouts.count, 0);
+  lifecycle.settleActive("turn_canceled");
+  assert.equal(events.at(-1)?.type, "turn_canceled");
+  assert.equal(events.at(-1)?.payload?.turnId, reserved?.turnId);
+});
+
+function createLifecycle(
+  options: {
+    continuationStartTimeoutMs?: number;
+    onContinuationStartTimeout?: () => void;
+  } = {}
+): {
+  lifecycle: TurnLifecycle;
+  events: Array<Omit<ClaudeSDKSidecarEvent, "version">>;
+  activations: { count: number };
+  settlements: { count: number };
+} {
+  const events: Array<Omit<ClaudeSDKSidecarEvent, "version">> = [];
+  const activations = { count: 0 };
+  const settlements = { count: 0 };
+  const lifecycle = new TurnLifecycle({
+    emit: (event) => events.push(event),
+    onActivate: () => {
+      activations.count += 1;
+    },
+    onSettled: () => {
+      settlements.count += 1;
+    },
+    ...options
+  });
+  return { lifecycle, events, activations, settlements };
+}

--- a/packages/agent/claude-sdk-sidecar/src/turnLifecycle.ts
+++ b/packages/agent/claude-sdk-sidecar/src/turnLifecycle.ts
@@ -24,6 +24,7 @@ export class TurnLifecycle {
   private readonly continuationStartTimeoutMs: number;
   private active: RuntimeTurn | undefined;
   private activeIdValue = "";
+  private lastTurnIdValue = "";
   private pendingOrphanCount = 0;
   private cancelledValue = false;
   private completedTurnCount = 0;
@@ -48,6 +49,15 @@ export class TurnLifecycle {
 
   get activeId(): string {
     return this.activeIdValue;
+  }
+
+  /**
+   * The most recent turn id, kept after the turn settles. Lets late background
+   * task events (which often arrive after the provider turn ended) attribute
+   * to the turn that launched them instead of being dropped.
+   */
+  get lastTurnId(): string {
+    return this.activeIdValue || this.lastTurnIdValue;
   }
 
   get activeTurn(): RuntimeTurn | undefined {
@@ -280,6 +290,7 @@ export class TurnLifecycle {
     }
     this.active = turn;
     this.activeIdValue = turn.turnId;
+    this.lastTurnIdValue = turn.turnId;
     this.cancelledValue = false;
     this.pendingOrphanCount = 0;
     this.onActivate();

--- a/packages/agent/daemon/runtime/claude_sdk_execution.go
+++ b/packages/agent/daemon/runtime/claude_sdk_execution.go
@@ -2,7 +2,6 @@ package agentruntime
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
@@ -220,5 +219,39 @@ func (a *ClaudeCodeSDKAdapter) CancelTargets(ctx context.Context, rootSession Se
 			}, nil
 		}
 	}
-	return TargetedCancelResult{}, fmt.Errorf("claude SDK does not support canceling a child turn independently of its root turn")
+	return a.stopClaudeSDKChildTargets(ctx, rootSession, targets)
+}
+
+// stopClaudeSDKChildTargets stops individual background delegated tasks via
+// the SDK's targeted stopTask, leaving the root query and any other running
+// tasks untouched. The stopped task settles asynchronously through its own
+// task_notification, which projects the child turn canceled; a target whose
+// task is unknown or already settled is skipped, making the child cancel an
+// idempotent no-op (TargetAbsent) rather than an error.
+func (a *ClaudeCodeSDKAdapter) stopClaudeSDKChildTargets(ctx context.Context, rootSession Session, targets []CancelTarget) (TargetedCancelResult, error) {
+	adapterSession := a.getSession(rootSession.AgentSessionID)
+	if adapterSession == nil {
+		return TargetedCancelResult{}, ErrSessionDisconnected
+	}
+	confirmed := make([]CancelTarget, 0, len(targets))
+	for _, target := range targets {
+		a.mu.Lock()
+		child, ok := adapterSession.claudeSDKChildByAgentSessionID(target.AgentSessionID)
+		a.mu.Unlock()
+		if !ok {
+			continue
+		}
+		taskID := firstNonEmptyString(child.TaskID, child.AgentID, child.ParentToolUseID, child.Key)
+		if taskID == "" {
+			continue
+		}
+		stopped, err := a.StopTask(ctx, rootSession, taskID)
+		if err != nil {
+			return TargetedCancelResult{}, err
+		}
+		if stopped {
+			confirmed = append(confirmed, target)
+		}
+	}
+	return TargetedCancelResult{ConfirmedTargets: confirmed}, nil
 }

--- a/packages/agent/daemon/runtime/claude_sdk_stop_task.go
+++ b/packages/agent/daemon/runtime/claude_sdk_stop_task.go
@@ -1,0 +1,31 @@
+package agentruntime
+
+import (
+	"context"
+)
+
+// StopTask asks the sidecar to stop one background delegated task via the
+// SDK's targeted stopTask, leaving the root query and other tasks running.
+// The task id may be either the provider task id or the launching tool call
+// id; the sidecar resolves both.
+func (a *ClaudeCodeSDKAdapter) StopTask(ctx context.Context, session Session, taskID string) (bool, error) {
+	adapterSession := a.getSession(session.AgentSessionID)
+	if adapterSession == nil {
+		return false, ErrSessionDisconnected
+	}
+	stopCtx, cancel := context.WithTimeout(ctx, claudeSDKGoalCommandTimeout)
+	defer cancel()
+	response, err := a.roundTripClaudeSDKResponse(stopCtx, session.AgentSessionID, adapterSession, claudeSDKSidecarRequest{
+		ID:   newID(),
+		Type: "stop_task",
+		Payload: map[string]any{
+			"agentSessionId": session.AgentSessionID,
+			"taskId":         taskID,
+			"toolCallId":     taskID,
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+	return payloadBoolValue(response.Payload, "stopped"), nil
+}

--- a/packages/agent/daemon/runtime/claude_sdk_stop_task_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_stop_task_test.go
@@ -1,0 +1,160 @@
+package agentruntime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// stopTaskAckConnection acks every request; stop_task acks carry the stopped
+// flag in the payload like the real sidecar response.
+type stopTaskAckConnection struct {
+	mu      sync.Mutex
+	sent    []claudeSDKSidecarRequest
+	frames  []ProcessFrame
+	stopped bool
+}
+
+func (c *stopTaskAckConnection) Send(data []byte) error {
+	var request claudeSDKSidecarRequest
+	if err := json.Unmarshal(data, &request); err != nil {
+		return err
+	}
+	event := claudeSDKSidecarEvent{Version: claudeSDKSidecarProtocolVersion, ID: request.ID, Type: "ok"}
+	if request.Type == "stop_task" {
+		event.Payload = map[string]any{"stopped": c.stopped}
+	}
+	response, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.sent = append(c.sent, request)
+	c.frames = append(c.frames, ProcessFrame{Stdout: append(response, '\n')})
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *stopTaskAckConnection) Recv() (ProcessFrame, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.frames) == 0 {
+		return ProcessFrame{}, errors.New("stop task ack connection has no frames")
+	}
+	frame := versionClaudeSDKTestFrame(c.frames[0])
+	c.frames = c.frames[1:]
+	return frame, nil
+}
+
+func (*stopTaskAckConnection) Close() error {
+	return nil
+}
+
+func (c *stopTaskAckConnection) sentRequests() []claudeSDKSidecarRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]claudeSDKSidecarRequest(nil), c.sent...)
+}
+
+func TestClaudeCodeSDKAdapterCancelTargetsStopsChildTaskWithoutRootInterrupt(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	conn := &stopTaskAckConnection{stopped: true}
+	adapterSession := &claudeSDKAdapterSession{
+		conn:            conn,
+		reader:          &claudeSDKLineReader{conn: conn},
+		pendingRequests: make(map[string]*pendingInteractiveRequest),
+		liveState:       newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+	child, _, _, ok := adapterSession.updateClaudeSDKChild(session, claudeSDKChildUpdate{
+		Key:             "toolu-agent",
+		ParentToolUseID: "toolu-agent",
+		RootTurnID:      "turn-1",
+		TaskID:          "task-1",
+		Async:           true,
+		Started:         true,
+	})
+	if !ok || child.AgentSessionID == "" {
+		t.Fatalf("child session not registered: %#v", child)
+	}
+
+	result, err := adapter.CancelTargets(context.Background(), session, []CancelTarget{
+		{AgentSessionID: child.AgentSessionID, TurnID: child.TurnID},
+	}, "user_request")
+	if err != nil {
+		t.Fatalf("CancelTargets: %v", err)
+	}
+	if len(result.ConfirmedTargets) != 1 || result.ConfirmedTargets[0].AgentSessionID != child.AgentSessionID {
+		t.Fatalf("confirmed targets = %#v, want the child target", result.ConfirmedTargets)
+	}
+	sent := conn.sentRequests()
+	if len(sent) != 1 || sent[0].Type != "stop_task" {
+		t.Fatalf("sent requests = %#v, want a single stop_task", sent)
+	}
+	if sent[0].Payload["taskId"] != "task-1" || sent[0].Payload["agentSessionId"] != session.AgentSessionID {
+		t.Fatalf("stop_task payload = %#v, want task-1 on the root session", sent[0].Payload)
+	}
+}
+
+func TestClaudeCodeSDKAdapterCancelTargetsUnknownChildIsIdempotentNoop(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	conn := &stopTaskAckConnection{stopped: true}
+	adapterSession := &claudeSDKAdapterSession{
+		conn:            conn,
+		reader:          &claudeSDKLineReader{conn: conn},
+		pendingRequests: make(map[string]*pendingInteractiveRequest),
+		liveState:       newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+
+	result, err := adapter.CancelTargets(context.Background(), session, []CancelTarget{
+		{AgentSessionID: "child-unknown", TurnID: "turn-unknown"},
+	}, "user_request")
+	if err != nil {
+		t.Fatalf("CancelTargets: %v", err)
+	}
+	if len(result.ConfirmedTargets) != 0 {
+		t.Fatalf("confirmed targets = %#v, want none", result.ConfirmedTargets)
+	}
+	if sent := conn.sentRequests(); len(sent) != 0 {
+		t.Fatalf("sent requests = %#v, want none", sent)
+	}
+}
+
+func TestClaudeCodeSDKAdapterCancelTargetsSettledStopIsUnconfirmed(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	conn := &stopTaskAckConnection{stopped: false}
+	adapterSession := &claudeSDKAdapterSession{
+		conn:            conn,
+		reader:          &claudeSDKLineReader{conn: conn},
+		pendingRequests: make(map[string]*pendingInteractiveRequest),
+		liveState:       newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+	child, _, _, ok := adapterSession.updateClaudeSDKChild(session, claudeSDKChildUpdate{
+		Key:             "toolu-agent",
+		ParentToolUseID: "toolu-agent",
+		RootTurnID:      "turn-1",
+		TaskID:          "task-1",
+		Async:           true,
+		Started:         true,
+	})
+	if !ok {
+		t.Fatalf("child session not registered: %#v", child)
+	}
+
+	result, err := adapter.CancelTargets(context.Background(), session, []CancelTarget{
+		{AgentSessionID: child.AgentSessionID, TurnID: child.TurnID},
+	}, "user_request")
+	if err != nil {
+		t.Fatalf("CancelTargets: %v", err)
+	}
+	if len(result.ConfirmedTargets) != 0 {
+		t.Fatalf("confirmed targets = %#v, want none for an already settled task", result.ConfirmedTargets)
+	}
+}


### PR DESCRIPTION
## Problem

From a user-reported incident (log bundle `tutti-logs-20260717-204558`, session "评估项目功能迭代建议"): a claude session dispatched work to a codex session via the tutti CLI and tracked it with a background Bash `tutti agent wait` watcher. The root turn then settled while both the codex session and the watcher were still running — the conversation looked finished while the delegated work was still in flight.

Root cause: SDK task-system background work (most importantly `run_in_background` Bash) was invisible to the whole stack. The sidecar only registers subagent launches (`Async agent launched successfully`), so a background shell:

- never became a child session, so it never gated the canonical root turn (the provider-native-subagents hold did not apply);
- kept running invisibly after the turn settled;
- could not be stopped individually — claude `CancelTargets` rejected child-only targets outright;
- was exposed to the continuation-timeout `interrupt()` misfire when mixed with background subagents (its run was not counted).

## Change

**Sidecar** (`claude-sdk-sidecar`)

- Register unclaimed `task_started` / terminal `task_notification` events that carry a launching `tool_use_id` + `task_id` as delegated tasks. Background shells now ride the same rails as background subagents: child session, root-turn gate, final-child continuation gate, individual stop. Events without a launching tool-use id are left for the launch result to register (racing subagent aliases must not poison the alias maps).
- Attribute late background task events to the most recent turn (`TurnLifecycle.lastTurnId`) instead of dropping them when the launching provider turn already settled — background `task_started` routinely arrives after the provider turn terminal.
- Register-and-settle terminal notices for tasks launched before a sidecar restart (reported `stopped` on the next prompt), so stale tasks reach a terminal card state instead of the notice being dropped.
- User-initiated `stopped` terminals do not open the synthetic continuation provider turn — a stop needs no model follow-up, and the reserved continuation would only time out and interrupt.
- New `stop_task` sidecar request: resolves task id / agent id / launching tool-use id aliases and calls the SDK's targeted `Query.stopTask` for running tasks only.
- Restore the `sessionRuntime.{delegated,nested,cancel,session}` and `turnLifecycle` test suites pruned in `3f60cb4ce` and extend them: background-bash registration and turn attribution, deferred continuation while a background shell still runs, `stopTask` alias resolution and idempotent no-ops, stopped-without-continuation.

**Daemon** (`packages/agent/daemon/runtime`)

- `ClaudeCodeSDKAdapter.CancelTargets`: child-only target sets now resolve each child to its SDK task identity and issue `stop_task` instead of returning an error. The root query and other tasks keep running; unknown or already-terminal targets are idempotent no-ops (unconfirmed, not failed). Root-inclusive target sets keep the existing full-cancel path. This makes the existing `turns/{turnID}/cancel` HTTP route work for claude child turns with no API changes.

**Spec** (`docs/specs/2026-07-15-provider-native-subagents.md`)

- Background task-system work is documented as provider-native child work, including the registration and turn-attribution rules, the restart terminal-notice rule, the `stopped` continuation exception, and the claude child-only cancel path. Also documents that a background command tracking an out-of-scope top-level session holds the root turn for as long as the wait runs.

## Verification

- `claude-sdk-sidecar`: 83 tests green (includes the restored suites), typecheck clean.
- `daemon/runtime`: full package green, `go vet` clean.
- Manual end-to-end in dev: background `sleep 60` registers, holds the turn for the full 60s, completes with an automatic continuation; incident-shaped repro (dispatch codex via tutti CLI + background `tutti agent wait`) holds the turn from dispatch until codex finished and the model reported its review — the incident's early settlement no longer reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->