### PR TITLE
fix(agent-gui): lock permissions during active turns

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2796,6 +2796,11 @@ User-visible rules:
 - Model, permission, plan mode, reasoning, speed, project, branch, prompt image,
   file mention, and skill/capability controls must read from composer settings
   and provider options. They should not be reconstructed from transcript rows.
+- Permission mode remains fixed for the lifetime of an active Turn. AgentGUI
+  disables the permission selector from prompt submission through every
+  non-settled phase (including waiting and interrupting), regardless of whether
+  the provider can apply permission changes live, and explains the lock on
+  hover/focus. The selector becomes available again only after the Turn settles.
 - Reasoning options are model capabilities, not provider-wide constants. The
   daemon model catalog must preserve each model's advertised effort values and
   default, pre-session composer options must use the selected model's catalog

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -160,6 +160,39 @@ describe("AgentPermissionModeDropdown", () => {
       screen.queryByRole("dialog", { name: "Enable full access?" })
     ).not.toBeInTheDocument();
   });
+
+  it("explains why permission changes are disabled during a running turn", async () => {
+    const onSettingsChange = vi.fn();
+    render(
+      <AgentPermissionModeDropdown
+        composerSettings={composerSettings()}
+        disabled
+        disabledTooltip="Permissions cannot change during a running turn"
+        provider="codex"
+        labels={{
+          loadingOptions: "Loading permission modes",
+          permissionLabel: "Permission mode"
+        }}
+        onSettingsChange={onSettingsChange}
+      />
+    );
+
+    const trigger = screen.getByRole("combobox", {
+      name: "Permission mode"
+    });
+    expect(trigger).toBeDisabled();
+
+    const tooltipTarget = trigger.parentElement;
+    expect(tooltipTarget).not.toBeNull();
+    fireEvent.pointerMove(tooltipTarget as HTMLElement, {
+      pointerType: "mouse"
+    });
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Permissions cannot change during a running turn"
+    );
+    expect(onSettingsChange).not.toHaveBeenCalled();
+  });
 });
 
 async function selectPermissionOption(optionName: string): Promise<void> {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.tsx
@@ -27,6 +27,7 @@ import {
   SelectTrigger,
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
   cn
 } from "@tutti-os/ui-system";
@@ -58,6 +59,7 @@ export {
 export function AgentPermissionModeDropdown({
   composerSettings,
   disabled = false,
+  disabledTooltip,
   onLinkAction,
   previewMode = false,
   provider,
@@ -66,6 +68,7 @@ export function AgentPermissionModeDropdown({
 }: {
   composerSettings: AgentGUIComposerSettingsVM;
   disabled?: boolean;
+  disabledTooltip?: string;
   onLinkAction?: (action: WorkspaceLinkAction) => void;
   previewMode?: boolean;
   provider: string;
@@ -115,6 +118,11 @@ export function AgentPermissionModeDropdown({
   const triggerTone = selectDisabled
     ? undefined
     : resolvePermissionModeTriggerTone(selectedValue);
+  const selectDisabledTooltip = disabled
+    ? disabledTooltip
+    : isLoading
+      ? labels.loadingOptions
+      : undefined;
   const commitPermissionModeId = (permissionModeId: string): void => {
     if (selectDisabled) {
       return;
@@ -190,18 +198,22 @@ export function AgentPermissionModeDropdown({
         onOpenChange={setIsSelectOpen}
         onValueChange={applyPermissionModeId}
       >
-        {isLoading ? (
-          // The trigger is disabled while loading, so pointer events never reach
-          // it. Target the tooltip at a focusable wrapper span (Radix's pattern
-          // for disabled triggers) so hover/focus reliably surfaces the hint.
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex" tabIndex={0}>
-                {selectTrigger}
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="top">{labels.loadingOptions}</TooltipContent>
-          </Tooltip>
+        {selectDisabledTooltip ? (
+          // Disabled controls do not receive pointer events. Target the tooltip
+          // at a focusable wrapper span so hover/focus reliably surfaces the
+          // reason, both during loading and while a turn is active.
+          <TooltipProvider delayDuration={120}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex" tabIndex={0}>
+                  {selectTrigger}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                {selectDisabledTooltip}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         ) : (
           selectTrigger
         )}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.labels.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.labels.ts
@@ -212,6 +212,9 @@ export function useAgentGUIViewLabels(input: {
       permissionModeFullAccess: t(
         "agentHost.agentGui.permissionModeFullAccess"
       ),
+      permissionModeChangeUnavailableDuringTurn: t(
+        "agentHost.agentGui.permissionModeChangeUnavailableDuringTurn"
+      ),
       modelDescriptions: {
         frontierComplexCoding: t(
           "agentHost.agentGui.modelDescriptions.frontierComplexCoding"

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -121,6 +121,7 @@ export interface AgentComposerProps {
     permissionModeReadOnly: string;
     permissionModeAuto: string;
     permissionModeFullAccess: string;
+    permissionModeChangeUnavailableDuringTurn: string;
     modelDescriptions: {
       frontierComplexCoding: string;
       everydayCoding: string;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
@@ -490,6 +490,11 @@ export function ComposerFooter({
             <AgentPermissionModeDropdown
               composerSettings={composerSettings}
               disabled={permissionModeControlsDisabled}
+              disabledTooltip={
+                permissionModeControlsDisabled
+                  ? labels.permissionModeChangeUnavailableDuringTurn
+                  : undefined
+              }
               onLinkAction={onLinkAction}
               previewMode={previewMode}
               provider={provider}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashActions.ts
@@ -160,7 +160,6 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
   const settingsControlsDisabled =
     isSendingTurn || isSubmittingPrompt || showStopButton;
   const permissionModeControlsDisabled = resolvePermissionModeControlsDisabled({
-    changeDuringTurnSupported: composerSettings.permissionModeChangeDuringTurn,
     isSendingTurn,
     isSubmittingPrompt,
     showStopButton

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.spec.ts
@@ -39,21 +39,19 @@ describe("permissionModeSelectionPatch", () => {
 });
 
 describe("resolvePermissionModeControlsDisabled", () => {
-  it("stays enabled mid-turn when the provider applies permission changes live", () => {
+  it("stays disabled while a turn is actively running", () => {
     expect(
       resolvePermissionModeControlsDisabled({
-        changeDuringTurnSupported: true,
         isSendingTurn: true,
         isSubmittingPrompt: false,
         showStopButton: true
       })
-    ).toBe(false);
+    ).toBe(true);
   });
 
-  it("still blocks claude-code/codex during the brief prompt-submission race", () => {
+  it("blocks the brief prompt-submission race", () => {
     expect(
       resolvePermissionModeControlsDisabled({
-        changeDuringTurnSupported: true,
         isSendingTurn: false,
         isSubmittingPrompt: true,
         showStopButton: false
@@ -61,10 +59,9 @@ describe("resolvePermissionModeControlsDisabled", () => {
     ).toBe(true);
   });
 
-  it("keeps the broader turn-in-flight gate for other ACP-backed providers", () => {
+  it("blocks waiting and interrupting turns represented by the stop control", () => {
     expect(
       resolvePermissionModeControlsDisabled({
-        changeDuringTurnSupported: false,
         isSendingTurn: false,
         isSubmittingPrompt: false,
         showStopButton: true
@@ -72,10 +69,9 @@ describe("resolvePermissionModeControlsDisabled", () => {
     ).toBe(true);
   });
 
-  it("leaves ACP-backed providers enabled once no turn is in flight", () => {
+  it("enables permission changes once no turn is in flight", () => {
     expect(
       resolvePermissionModeControlsDisabled({
-        changeDuringTurnSupported: false,
         isSendingTurn: false,
         isSubmittingPrompt: false,
         showStopButton: false

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.ts
@@ -31,18 +31,14 @@ export function permissionModeSelectionPatch(
  * Decides whether the composer's permission-mode control should be disabled
  * while a turn is in flight.
  *
- * The runtime descriptor decides whether a permission change is safe while a
- * turn is active. Missing capability data keeps the conservative gate.
+ * AgentGUI keeps the permission contract stable for the whole active turn,
+ * even when the provider runtime can technically apply changes live.
  */
 export function resolvePermissionModeControlsDisabled(options: {
-  changeDuringTurnSupported?: boolean;
   isSendingTurn: boolean;
   isSubmittingPrompt: boolean;
   showStopButton: boolean;
 }): boolean {
-  if (options.changeDuringTurnSupported) {
-    return options.isSubmittingPrompt;
-  }
   return (
     options.isSendingTurn ||
     options.isSubmittingPrompt ||

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -102,6 +102,7 @@ export interface AgentGUIViewLabels {
   permissionModeReadOnly: string;
   permissionModeAuto: string;
   permissionModeFullAccess: string;
+  permissionModeChangeUnavailableDuringTurn: string;
   modelDescriptions: {
     frontierComplexCoding: string;
     everydayCoding: string;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
@@ -382,6 +382,8 @@ export function useAgentGUIDetailModel(input: Input) {
       permissionModeReadOnly: labels.permissionModeReadOnly,
       permissionModeAuto: labels.permissionModeAuto,
       permissionModeFullAccess: labels.permissionModeFullAccess,
+      permissionModeChangeUnavailableDuringTurn:
+        labels.permissionModeChangeUnavailableDuringTurn,
       modelDescriptions: labels.modelDescriptions,
       planModeLabel: labels.planModeLabel,
       planModeOnLabel: labels.planModeOnLabel,
@@ -513,6 +515,7 @@ export function useAgentGUIDetailModel(input: Input) {
       labels.modelTooltipVersionLabel,
       labels.permissionLabel,
       labels.permissionModeAuto,
+      labels.permissionModeChangeUnavailableDuringTurn,
       labels.permissionModeFullAccess,
       labels.permissionModeReadOnly,
       labels.planModeLabel,

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -95,6 +95,8 @@ export const enAgentGui = {
   permissionModeReadOnly: "Ask for approval",
   permissionModeAuto: "Approve for me",
   permissionModeFullAccess: "Full access",
+  permissionModeChangeUnavailableDuringTurn:
+    "Permissions can’t be changed while a conversation is running",
   fullAccessWarning: {
     title: "Enable full access?",
     description:

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -89,6 +89,7 @@ export const zhCNAgentGui = {
   permissionModeReadOnly: "请求批准",
   permissionModeAuto: "替我审批",
   permissionModeFullAccess: "完全访问权限",
+  permissionModeChangeUnavailableDuringTurn: "无法在运行过程中切换权限",
   fullAccessWarning: {
     title: "确定启用完全访问权限吗？",
     description: "完全访问权限允许 Codex 无需你的批准即可操作这台电脑。",


### PR DESCRIPTION
## Summary

- disable the permission selector for the full lifetime of an active turn, regardless of provider live-switch capability
- show a localized hover/focus tooltip explaining that permissions cannot change while the conversation is running
- add focused state and component coverage and document the AgentGUI interaction contract

## Testing

- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/model/composerModeSelection.spec.ts agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx --environment jsdom --maxWorkers=2`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:i18n`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:full` *(all preparation/preflight checks passed; validation is blocked by the unrelated main-branch Go failure `TestScanExternalImportsAppliesCodexSQLiteTitle`, which also fails when rerun alone)*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->