### PR TITLE
fix(agent-gui): preserve handoff animation size

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -8774,6 +8774,8 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 .agent-gui-node__composer-handoff-icon-animated {
   position: absolute;
   inset: 0;
+  /* Match the APNG's padded 44px canvas to the static icon's visual size. */
+  transform: scale(1.3);
   filter: var(--agent-gui-handoff-animation-filter, none);
   opacity: 0;
   pointer-events: none;


### PR DESCRIPTION
## Summary

- scale the handoff APNG animation to compensate for its padded 44px canvas
- preserve the existing 18px layout box and static icon size

## Verification

- pre-commit formatting and staged boundary checks
- targeted Go retry: `go test ./service/agentextension -run "^TestAgentTargetSetupInstallsGenericExtensionRuntime$" -count=1`
- `pnpm check:full` (19 tasks passed)

## Checklist

- [x] Agent lifecycle semantics are unchanged
- [x] I kept the change focused on one concern
- [x] No durable documentation impact was found for this visual-only adjustment
- [x] README/CONTRIBUTING language variants are unaffected
- [x] I ran the repository-required checks
- [x] The commit is signed off with DCO
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->