### PR TITLE
test(desktop): remove brittle source assertions

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentStartupShell.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentStartupShell.test.ts
@@ -5,17 +5,6 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
-const startupShellSource = readFileSync(
-  resolve(currentDirectory, "StandaloneAgentStartupShell.tsx"),
-  "utf8"
-);
-const startupBodyShellSource = readFileSync(
-  resolve(
-    currentDirectory,
-    "../../../../../../../../packages/agent/gui/AgentGUIStartupShell.tsx"
-  ),
-  "utf8"
-);
 const standaloneWorkbenchSource = readFileSync(
   resolve(currentDirectory, "StandaloneAgentWorkbench.tsx"),
   "utf8"
@@ -92,55 +81,6 @@ test("OS and standalone Agent routes statically own the AgentGUI body", () => {
     workspaceAgentGuiContributionSource,
     /createElement\(DesktopAgentGUIWorkbenchBody, \{/
   );
-});
-
-test("standalone Agent startup shell keeps the rail and new-conversation hero visible", () => {
-  assert.match(startupShellSource, /data-agent-gui-startup-shell="window"/);
-  assert.match(
-    startupShellSource,
-    /<AgentGUIStartupShell loadingLabel=\{loadingLabel\} \/>/
-  );
-  assert.doesNotMatch(startupBodyShellSource, /AgentGUIStartupSource|source:/);
-  assert.doesNotMatch(startupBodyShellSource, /data-agent-gui-source/);
-  assert.match(
-    startupBodyShellSource,
-    /gridTemplateColumns: "52px 280px minmax\(0, 1fr\)"/
-  );
-  assert.match(
-    startupBodyShellSource,
-    /agent-gui-node__conversation-list-skeleton-row/
-  );
-  assert.match(
-    startupBodyShellSource,
-    /agent-gui-node__empty-hero[\s\S]*?agent-gui-node__empty-hero-title/
-  );
-  assert.match(
-    startupBodyShellSource,
-    /agent-gui-node__timeline agent-gui-node__timeline-centered[\s\S]*?data-agent-gui-startup-timeline-content="true"/
-  );
-  assert.match(
-    startupBodyShellSource,
-    /agent-gui-node__empty-hero-icon-slot[\s\S]*?data-carousel-placeholder=\{true\}[\s\S]*?h-28/
-  );
-  assert.match(
-    startupBodyShellSource,
-    /agent-gui-node__composer-hero[\s\S]*?data-layout="hero"[\s\S]*?agent-gui-node__composer-hero-prompt-input-area[\s\S]*?<textarea[\s\S]*?disabled/
-  );
-  assert.match(
-    startupBodyShellSource,
-    /agent-gui-node__composer-footer[\s\S]*?agent-gui-node__composer-footer-left[\s\S]*?agent-gui-node__composer-footer-right/
-  );
-  assert.match(
-    startupBodyShellSource,
-    /agent-gui-node__composer-project-row[\s\S]*?agent-gui-node__composer-prompt-tips[\s\S]*?agent-gui-node__composer-prompt-tip/
-  );
-  assert.match(
-    startupBodyShellSource,
-    /agent-gui-node__empty-hero-suggestions[\s\S]*?agent-gui-node__empty-hero-suggestions-chips/
-  );
-  assert.doesNotMatch(startupBodyShellSource, /agent-gui-node__bottom-dock/);
-  assert.doesNotMatch(startupBodyShellSource, /data-layout="dock"/);
-  assert.match(startupBodyShellSource, /<Spinner/);
 });
 
 test("standalone Agent tool panels expose loading UI while deferred modules start", () => {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
@@ -252,14 +252,6 @@ test("standalone Agent hides home identity and shows it after local session star
   );
 });
 
-test("standalone Agent shows the generic app title", () => {
-  assert.match(standaloneWindowSource, /showAppTitle\b(?!=\{false\})/);
-  assert.match(
-    standaloneWindowSource,
-    /title=\{i18n\.t\("workspace\.agentGui\.fallbackAgentLabel"\)\}/
-  );
-});
-
 test("standalone Agent hides panel toggles until its content mounts", () => {
   assert.match(
     standaloneWindowSource,
@@ -276,21 +268,6 @@ test("standalone Agent hides panel toggles until its content mounts", () => {
   assert.match(
     standaloneWindowSource,
     /<StandaloneAgentWindowContentReady onReady=\{handleContentReady\}>[\s\S]*?<DesktopAgentGUISurface/
-  );
-});
-
-test("standalone Agent loads its body with the route instead of adding a second lazy boundary", () => {
-  assert.match(
-    standaloneWindowSource,
-    /import \{ DesktopAgentGUISurface \} from "@renderer\/features\/workspace-agent\/ui\/DesktopAgentGUIWorkbenchBody\.tsx"/
-  );
-  assert.doesNotMatch(
-    standaloneWindowSource,
-    /LazyDesktopAgentGUIWorkbenchBody/
-  );
-  assert.doesNotMatch(
-    standaloneWindowSource,
-    /import\("@renderer\/features\/workspace-agent\/ui\/DesktopAgentGUIWorkbenchBody\.tsx"\)/
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
@@ -37,13 +37,6 @@ test("workspace settings developer panel exposes analytics debug switch only whe
   );
 });
 
-test("workspace settings panel lists appearance below general", () => {
-  assert.match(
-    source,
-    /id: "general" as const,[\s\S]*id: "agent" as const,[\s\S]*id: "appearance" as const,[\s\S]*id: "apps" as const,[\s\S]*id: "account" as const,[\s\S]*id: "about" as const,[\s\S]*id: "developer" as const/
-  );
-});
-
 test("workspace settings gates account behind Tutti Agent Switch", () => {
   assert.match(source, /settingsState\.tuttiAgentSwitchEnabled/);
   assert.match(
@@ -58,40 +51,35 @@ test("workspace settings gates account behind Tutti Agent Switch", () => {
   assert.match(source, /<WorkspaceAccountSettingsSection \/>/);
 });
 
-test("workspace settings agent panel lists agent controls", () => {
+test("workspace settings forwards workspace mode and sleep prevention changes", () => {
   assert.match(
     source,
-    /function WorkspaceAgentSettingsSection[\s\S]*workspace\.settings\.general\.agentConversationDetailModeLabel[\s\S]*workspace\.externalImport\.settingsLabel[\s\S]*workspace\.settings\.general\.defaultAgentProviderLabel[\s\S]*workspace\.settings\.general\.browserUseConnectionModeLabel[\s\S]*<ComputerUseSetupRow/
+    /onSleepPreventionModeChange=\{\(mode\) => \{\s+void settingsService\.changeSleepPreventionMode\(mode\)/
   );
-  assert.match(source, /role="radiogroup"/);
-  assert.match(source, /role="radio"/);
-  assert.match(source, /aria-checked=\{selected\}/);
-  assert.match(source, /desktopAgentConversationDetailModes\.map/);
-  assert.match(source, /onAgentConversationDetailModeChange\(mode\)/);
-  const agentSectionStart = source.indexOf(
-    "function WorkspaceAgentSettingsSection"
-  );
-  const generalSectionStart = source.indexOf(
-    "function WorkspaceGeneralSettingsSection"
-  );
-  assert.ok(agentSectionStart >= 0);
-  assert.ok(generalSectionStart > agentSectionStart);
-  assert.doesNotMatch(
-    source.slice(agentSectionStart, generalSectionStart),
-    /agentDockLayout|agentDockLayoutLabel|desktopAgentDockLayouts/
+  assert.match(
+    source,
+    /onWorkspaceUiModeChange=\{\(mode\) => \{\s+void settingsService\.changeWorkspaceUiMode\(mode\)/
   );
 });
 
-test("workspace settings general panel lists system controls", () => {
+test("workspace settings unlocks developer mode after seven version taps", () => {
+  assert.match(source, /const developerPanelUnlockTaps = 7/);
   assert.match(
     source,
-    /function WorkspaceGeneralSettingsSection[\s\S]*workspace\.settings\.general\.workspaceUiModeLabel[\s\S]*desktopWorkspaceUiModes\.map[\s\S]*workspace\.settings\.general\.preventSleepLabel[\s\S]*workspace\.settings\.general\.languageLabel/
+    /versionTapCountRef\.current \+= 1;\s+if \(versionTapCountRef\.current >= developerPanelUnlockTaps\) \{\s+versionTapCountRef\.current = 0;\s+settingsService\.setDeveloperPanelVisible\(true\);\s+notifications\.success\(\{\s+title: t\("workspace\.settings\.about\.developerModeEnabled"\)/
   );
-  assert.doesNotMatch(
+  assert.match(source, /onVersionTap=\{handleVersionTap\}/);
+});
+
+test("workspace settings maps snapping off and presets without losing the preset", () => {
+  assert.match(
     source,
-    /workspace\.settings\.general\.workspaceUiModeDescription/
+    /pendingWorkbenchWindowSnapping\.enabled\s+\? pendingWorkbenchWindowSnapping\.shortcutPreset\s+: "off"/
   );
-  assert.match(source, /settingsService\.changeWorkspaceUiMode\(mode\)/);
+  assert.match(
+    source,
+    /enabled: nextValue !== "off",\s+shortcutPreset:\s+nextValue === "off"\s+\? pendingWorkbenchWindowSnapping\.shortcutPreset\s+: nextValue/
+  );
 });
 
 test("workspace settings default providers come from the provider descriptor catalog", () => {
@@ -263,152 +251,6 @@ test("workspace settings computer-use continues into the wizard after install", 
   assert.match(
     source,
     /diagnosticTrigger: "install-completed"[\s\S]{0,900}setWizardStep\("accessibility"\);\s*setPermissionDialogOpen\(true\);\s*startAutoCheck\(\);/
-  );
-});
-
-test("workspace settings general panel does not expose update preferences", () => {
-  const generalSectionStart = source.indexOf(
-    "function WorkspaceGeneralSettingsSection"
-  );
-  const appearanceSectionStart = source.indexOf(
-    "function WorkspaceAppearanceSettingsSection"
-  );
-  const generalSection = source.slice(
-    generalSectionStart,
-    appearanceSectionStart
-  );
-
-  assert.ok(generalSectionStart >= 0);
-  assert.ok(appearanceSectionStart > generalSectionStart);
-  assert.doesNotMatch(source, /WorkspaceUpdateSettingsSection/);
-  assert.doesNotMatch(
-    generalSection,
-    /workspace\.settings\.general\.updateTitle/
-  );
-  assert.doesNotMatch(
-    generalSection,
-    /workspace\.settings\.general\.updatePolicyLabel/
-  );
-  assert.doesNotMatch(
-    generalSection,
-    /workspace\.settings\.general\.updateChannelLabel/
-  );
-  assert.doesNotMatch(generalSection, /onUpdatePolicyChange/);
-  assert.doesNotMatch(generalSection, /onUpdateChannelChange/);
-  assert.doesNotMatch(generalSection, /app_update\.settings_rendered/);
-});
-
-test("workspace settings about panel owns product info and keeps developer unlock tap", () => {
-  const generalSectionStart = source.indexOf(
-    "function WorkspaceGeneralSettingsSection"
-  );
-  const aboutSectionStart = source.indexOf(
-    "function WorkspaceAboutSettingsSection"
-  );
-  const appearanceSectionStart = source.indexOf(
-    "function WorkspaceAppearanceSettingsSection"
-  );
-
-  assert.ok(generalSectionStart >= 0);
-  assert.ok(aboutSectionStart > generalSectionStart);
-  assert.ok(appearanceSectionStart > aboutSectionStart);
-  assert.doesNotMatch(
-    source.slice(generalSectionStart, aboutSectionStart),
-    /versionLabel/
-  );
-  assert.match(
-    source.slice(aboutSectionStart, appearanceSectionStart),
-    /tuttiDesktopIconUrl[\s\S]*onClick=\{onVersionTap\}[\s\S]*workspace\.settings\.about\.versionLabel/
-  );
-  assert.doesNotMatch(
-    source.slice(aboutSectionStart, appearanceSectionStart),
-    /workspace\.settings\.about\.(title|description)/
-  );
-  assert.match(
-    source,
-    /setDeveloperPanelVisible\(true\);[\s\S]*notifications\.success\(\{[\s\S]*workspace\.settings\.about\.developerModeEnabled/
-  );
-  assert.doesNotMatch(source, /selectSection\("developer"\)/);
-  assert.match(
-    source,
-    /const tuttiDesktopIconUrl = new URL\(\s*"[^"]*build\/icon\.png"/
-  );
-  assert.match(
-    source.slice(aboutSectionStart, appearanceSectionStart),
-    /WebIcon[\s\S]*openExternal\(tuttiWebsiteUrl\)[\s\S]*GitHubBrandIcon[\s\S]*openExternal\(tuttiGitHubUrl\)/
-  );
-  assert.doesNotMatch(
-    source.slice(aboutSectionStart, appearanceSectionStart),
-    /releaseNotesAction|checkForUpdates|checkUpdatesAction/
-  );
-});
-
-test("workspace settings window snapping is controlled by one dropdown", () => {
-  const appearanceSectionStart = source.indexOf(
-    "function WorkspaceAppearanceSettingsSection"
-  );
-  const wallpaperPickerStart = source.indexOf(
-    "function WorkspaceWallpaperPicker"
-  );
-  const appearanceSection = source.slice(
-    appearanceSectionStart,
-    wallpaperPickerStart
-  );
-
-  assert.ok(appearanceSectionStart >= 0);
-  assert.ok(wallpaperPickerStart > appearanceSectionStart);
-  assert.doesNotMatch(appearanceSection, /<Switch/);
-  assert.match(
-    appearanceSection,
-    /pendingWorkbenchWindowSnapping\.enabled[\s\S]*\? pendingWorkbenchWindowSnapping\.shortcutPreset[\s\S]*: "off"/
-  );
-  assert.match(appearanceSection, /enabled: nextValue !== "off"/);
-  assert.match(
-    appearanceSection,
-    /workbenchWindowSnappingShortcutOptions\.off/
-  );
-});
-
-test("workspace settings app source control lives in developer settings", () => {
-  const appsSectionStart = source.indexOf(
-    "function WorkspaceAppsSettingsSection"
-  );
-  const developerSectionStart = developerSource.indexOf(
-    "function WorkspaceDeveloperSettingsSection"
-  );
-  const controlStart = developerSource.indexOf(
-    "function AppCatalogChannelControl"
-  );
-
-  assert.ok(appsSectionStart >= 0);
-  assert.ok(developerSectionStart >= 0);
-  assert.ok(controlStart > developerSectionStart);
-  assert.doesNotMatch(source.slice(appsSectionStart), /appCatalogChannel/);
-  assert.match(
-    developerSource.slice(developerSectionStart, controlStart),
-    /<AppCatalogChannelControl/
-  );
-});
-
-test("workspace settings release channel control lives in developer settings", () => {
-  const developerSectionStart = developerSource.indexOf(
-    "function WorkspaceDeveloperSettingsSection"
-  );
-  const controlStart = developerSource.indexOf(
-    "function ReleaseChannelControl"
-  );
-  const generalSectionStart = source.indexOf(
-    "function WorkspaceGeneralSettingsSection"
-  );
-  const generalSection = source.slice(generalSectionStart, source.length);
-
-  assert.ok(generalSectionStart >= 0);
-  assert.ok(developerSectionStart >= 0);
-  assert.ok(controlStart > developerSectionStart);
-  assert.doesNotMatch(generalSection, /releaseChannelLabel/);
-  assert.match(
-    developerSource.slice(developerSectionStart, controlStart),
-    /<ReleaseChannelControl/
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.test.ts
@@ -99,21 +99,6 @@ test("standalone Agent tools load their OS node UI on demand", () => {
   );
 });
 
-test("standalone Agent terminal tab content appears without a reveal animation", () => {
-  assert.match(
-    standaloneAgentToolSidebarSource,
-    /panel !== "terminal" &&\s*"motion-safe:animate-in motion-safe:fade-in-0 motion-safe:duration-150 motion-reduce:animate-none"/
-  );
-  assert.doesNotMatch(
-    standaloneAgentToolSidebarSource,
-    /background-session-sidepanel\)\]\s+transition-\[height\]/
-  );
-  assert.doesNotMatch(
-    standaloneAgentToolSidebarSource,
-    /height: open \? "100%" : "0px"/
-  );
-});
-
 test("standalone Agent opens an empty right sidebar with the core tool picker", () => {
   assert.match(
     standaloneAgentToolSidebarSource,
@@ -164,41 +149,6 @@ test("standalone Agent quick actions open the apps and messages panel tabs", () 
   );
 });
 
-test("standalone Agent panel tabs keep the add menu in the panel header", () => {
-  assert.match(
-    standaloneAgentToolSidebarToolbarSource,
-    /<DropdownMenuTrigger asChild>[\s\S]*?<AddLinedIcon[\s\S]*?<\/Button>[\s\S]*?<\/DropdownMenuTrigger>[\s\S]*?data-standalone-agent-tool-sidebar-toggle="true"/
-  );
-});
-
-test("standalone Agent panel tabs render in the interactive window header", () => {
-  const renderHeaderStart =
-    standaloneAgentToolSidebarSource.indexOf("{renderHeader(");
-  const bodyStart = standaloneAgentToolSidebarSource.indexOf(
-    '<div className="workbench-window__body'
-  );
-  const tabBarCall = standaloneAgentToolSidebarSource.indexOf(
-    "<ToolSidebarTabBar",
-    renderHeaderStart
-  );
-
-  assert.ok(renderHeaderStart >= 0);
-  assert.ok(tabBarCall > renderHeaderStart);
-  assert.ok(tabBarCall < bodyStart);
-  assert.equal(
-    standaloneAgentToolSidebarSource.match(/<ToolSidebarTabBar/g)?.length,
-    1
-  );
-  assert.match(
-    standaloneAgentToolSidebarSource,
-    /data-standalone-agent-tool-sidebar-header="true"/
-  );
-  assert.match(
-    standaloneAgentToolSidebarSource,
-    /data-standalone-agent-tool-sidebar-header-spacer="true"[\s\S]*?var\(--agent-gui-workbench-header-height, 44px\)/
-  );
-});
-
 test("standalone Agent panel tab buttons switch the active mounted panel", () => {
   assert.match(
     standaloneAgentToolSidebarSource,
@@ -207,39 +157,6 @@ test("standalone Agent panel tab buttons switch the active mounted panel", () =>
   assert.match(
     standaloneAgentToolSidebarSource,
     /data-standalone-agent-tool-tab-list="true"[\s\S]*?role="tablist"/
-  );
-});
-
-test("standalone Agent panel tabs render semantic icons before their labels", () => {
-  assert.match(
-    standaloneAgentToolSidebarSource,
-    /resolveToolTabLabel\(tab, copy, app, locale\)/
-  );
-  assert.match(
-    standaloneAgentToolSidebarSource,
-    /<ToolSidebarTabIcon app=\{app\} tab=\{tab\} \/>[\s\S]*?<span className="truncate">\{label\}<\/span>/
-  );
-  assert.match(
-    standaloneAgentToolSidebarToolbarSource,
-    /const toolSidebarPanelIconById = \{[\s\S]*?apps: NavApplicationsLinedIcon,[\s\S]*?browser: WebIcon,[\s\S]*?files: FolderIcon,[\s\S]*?messages: ChatIcon,[\s\S]*?terminal: TerminalLinedIcon[\s\S]*?\} satisfies Record<StandaloneAgentToolPanelId, ComponentType<IconProps>>/
-  );
-});
-
-test("standalone Agent terminal menu uses the dedicated lined icon", () => {
-  assert.match(
-    standaloneAgentToolSidebarToolbarSource,
-    /onAddPanel\("terminal"\)[\s\S]{0,240}<ToolSidebarPanelIcon[\s\S]*?panel="terminal"/
-  );
-  assert.match(
-    standaloneAgentToolSidebarToolbarSource,
-    /terminal: TerminalLinedIcon/
-  );
-});
-
-test("standalone Agent constrains the session title to the conversation flow", () => {
-  assert.match(
-    standaloneAgentToolSidebarSource,
-    /--agent-gui-tool-sidebar-layout-width[\s\S]*?activePanelLayoutWidth/
   );
 });
 
@@ -273,102 +190,41 @@ test("standalone Agent hides internal open-with actions without changing the OS 
   );
 });
 
-test("standalone Agent right sidebar keeps tool-switch layout width stable", () => {
+test("standalone Agent resizes the native window when panels open, switch, and close", () => {
   assert.match(
     standaloneAgentToolSidebarSource,
-    /const shouldAnimateSidebarLayout =\s*state\.mountedTabs\.length === 0 \|\| isActivePanelContentReady/
-  );
-  assert.match(
-    standaloneAgentToolSidebarSource,
-    /const shouldAnimateSidebarWidth = isEmptySidebarSurface;/
+    /const scheduleResizeForPanel = useCallback\([\s\S]*?window\.requestAnimationFrame\(\(\) => \{[\s\S]*?resizeForPanel\(panel, preferredWidth, options\)/
   );
   assert.match(
     standaloneAgentToolSidebarSource,
-    /shouldAnimateSidebarWidth &&\s+"motion-safe:transition-\[width\] motion-safe:duration-\[260ms\] motion-safe:ease-in-out motion-reduce:transition-none"/
-  );
-  assert.doesNotMatch(
-    standaloneAgentToolSidebarSource,
-    /shouldAnimateSidebarLayout &&\s+"motion-safe:transition-\[width\]/
+    /const openPanel = useCallback\([\s\S]*?type: "open-panel"[\s\S]*?scheduleResizeForPanel\(panel\)/
   );
   assert.match(
     standaloneAgentToolSidebarSource,
-    /isSidebarOpen &&\s+!shouldAnimateSidebarLayout &&\s+"motion-safe:animate-in motion-safe:slide-in-from-right-3 motion-safe:duration-\[160ms\] motion-safe:ease-out motion-reduce:animate-none"/
+    /const activatePanelTab = useCallback\([\s\S]*?type: "activate-tab"[\s\S]*?scheduleResizeForPanel\(tab\.panel\)/
   );
   assert.match(
     standaloneAgentToolSidebarSource,
-    /overflow-hidden \[contain:layout_paint\]/
+    /const closePanel = useCallback\([\s\S]*?dispatch\(\{ type: "close" \}\)[\s\S]*?scheduleResizeForPanel\(null\)/
   );
   assert.match(
     standaloneAgentToolSidebarSource,
-    /tabId: resolveToolTabId\(state\.mountedTabs, panel\),\s*type: "open-panel"[\s\S]*?scheduleResizeForPanel\(panel\)/
-  );
-  assert.match(
-    standaloneAgentToolSidebarSource,
-    /window\.requestAnimationFrame\(\(\) => \{[\s\S]*?void resizeForPanel\(panel, preferredWidth, options\)/
-  );
-  assert.match(
-    standaloneAgentToolSidebarSource,
-    /standaloneAgentToolPanelContentMountDelayMs = 80/
-  );
-  assert.match(
-    standaloneAgentToolSidebarSource,
-    /contentReadyTabIds\.includes\(tab\.id\)[\s\S]*?motion-safe:animate-in[\s\S]*?<StandaloneAgentToolSidebarPanel/
-  );
-  assert.doesNotMatch(
-    standaloneAgentToolSidebarPickerSource,
-    /animate-in|slide-in-from-right|duration-\[/
+    /const closePanelTab = useCallback\([\s\S]*?nextTab === null[\s\S]*?scheduleResizeForPanel\("files", standaloneAgentEmptyToolSidebarWidth[\s\S]*?scheduleResizeForPanel\(nextTab\.panel\)/
   );
 });
 
-test("standalone Agent empty sidebar uses its compact width until a tool opens", () => {
+test("standalone Agent restores the resize baseline after closing the empty picker", () => {
   assert.match(
     standaloneAgentToolSidebarSource,
-    /activePanelPreferredWidth: isEmptySidebarSurface\s*\? standaloneAgentEmptyToolSidebarWidth\s*: undefined/
-  );
-  assert.match(
-    standaloneAgentToolSidebarSource,
-    /scheduleResizeForPanel\("files", standaloneAgentEmptyToolSidebarWidth, \{[\s\S]*?animateWindow: !reducedMotion/
+    /setIsEmptySidebarClosing\(true\);\s+scheduleResizeForPanel\(null, undefined, \{\s+animateWindow: true,\s+preserveBaseline: true/
   );
   assert.match(
     standaloneAgentToolSidebarSource,
-    /setIsEmptySidebarClosing\(true\)[\s\S]*?scheduleResizeForPanel\(null, undefined, \{[\s\S]*?animateWindow: true,[\s\S]*?preserveBaseline: true/
+    /setIsEmptySidebarClosing\(false\);\s+resetWindowResizeBaseline\(\)/
   );
   assert.match(
     standaloneAgentToolSidebarSource,
-    /event\.propertyName !== "width"[\s\S]*?resetWindowResizeBaseline\(\)[\s\S]*?onTransitionEnd=\{handleSidebarTransitionEnd\}/
-  );
-  assert.match(
-    standaloneAgentToolSidebarSource,
-    /!isSidebarOpen && !isEmptySidebarClosing && "invisible"/
-  );
-  assert.match(
-    standaloneAgentToolSidebarPickerSource,
-    /items-center justify-center[\s\S]*?max-w-\[340px\][\s\S]*?h-12/
-  );
-});
-
-test("standalone Agent exposes one unified right-panel trigger", () => {
-  const toggleStart = standaloneAgentToolSidebarToolbarSource.indexOf(
-    'data-standalone-agent-tool-sidebar-toggle="true"'
-  );
-  const toggleEnd = standaloneAgentToolSidebarToolbarSource.indexOf(
-    "</Button>",
-    toggleStart
-  );
-
-  assert.match(
-    standaloneAgentToolSidebarToolbarSource,
-    /data-standalone-agent-tool-sidebar-toggle="true"[\s\S]*?<PanelIcon[\s\S]*?aria-hidden[\s\S]*?className="size-\[18px\] -scale-x-100"/
-  );
-  assert.doesNotMatch(
-    standaloneAgentToolSidebarToolbarSource,
-    /data-standalone-agent-tool-menu-trigger|ToolsIcon/
-  );
-  assert.ok(toggleStart >= 0);
-  assert.ok(toggleEnd > toggleStart);
-  assert.doesNotMatch(
-    standaloneAgentToolSidebarToolbarSource.slice(toggleStart, toggleEnd),
-    /ReminderBadge/
+    /state\.mountedTabs\.length === 0[\s\S]*?scheduleResizeForPanel\("files", standaloneAgentEmptyToolSidebarWidth/
   );
 });
 


### PR DESCRIPTION
## Summary

- remove source-text assertions that locked Workspace Workbench tests to JSX structure, class names, icons, animation details, and retired UI names
- keep lifecycle, routing, permissions, presenter registration, panel mounting, and native resize behavior guarded
- replace broad source snapshots with narrow guards for settings event forwarding and the standalone resize scheduling chain

## Why

These tests read production source files and matched implementation spelling rather than executing observable behavior. They created maintenance cost during harmless UI refactors while providing weak regression protection.

## Impact and risk assessment

- **Risk:** Low
- **Scope:** 4 test files under apps/desktop/src/renderer/src/features/workspace-workbench/ui
- **Diff:** 27 additions, 412 deletions; no production files changed
- **Product behavior:** No change
- **Public API / protocol / persistence:** No impact
- **Potential regression:** A removed source assertion could have encoded a hidden interaction contract
- **Mitigation:** Independent behavior review restored or narrowed guards for workspace presenter registration, settings event forwarding, developer unlock, window snapping, and standalone native resize scheduling
- **Rollback:** Direct revert; no migration or generated artifacts

## Validation

- Desktop focused tests: passed
- Desktop full test suite: 1,499 tests, 1,496 passed, 3 skipped
- Desktop typecheck: passed
- pnpm check:changed --tail-lines 80: passed 7 lanes
- pre-push pnpm check:full: passed 19 tasks
- architecture review: no findings
- final behavior review: no unresolved findings

## Documentation

No durable documentation impact: this changes test expression only and does not alter ownership, data flow, user-visible behavior, public contracts, runtime configuration, or troubleshooting guidance.
