### PR TITLE
feat(agent-host): expose owner recovery contracts

### DIFF
--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -35,8 +35,13 @@ and only then settles unrecoverable stale turns. Configuring a goal store
 without its runtime or inbox consumer fails recovery with
 `ErrGoalConsumerUnavailable` instead of silently accumulating work.
 
-`GetSession` reads canonical truth plus an optional live runtime observation
-without starting a provider. `UpdateSettings` serializes with runtime resume:
+`GetSession` reads canonical session truth plus an optional live runtime
+observation without starting a provider. `GetTurn` and
+`FindTurnByClientSubmitID` expose canonical turn queries without leaking an
+adapter's concrete store. `CreateSessionInput.ClientSubmitID` and
+`SendInput.ClientSubmitID` are the typed idempotency identities and override
+the legacy metadata value when both are present.
+`UpdateSettings` serializes with runtime resume:
 historical sessions persist settings only, while live sessions update the
 runtime. Provider-specific model, reasoning, and speed normalization stays
 behind `SettingsPolicy`. `UpdatePin` mutates canonical metadata only.

--- a/packages/agent/host/canonical_queries.go
+++ b/packages/agent/host/canonical_queries.go
@@ -3,7 +3,21 @@ package agenthost
 import (
 	"context"
 	"strings"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 )
+
+// GetTurn exposes canonical turn truth without requiring Host consumers to
+// retain or type-assert the concrete store used by the Host adapter.
+func (h *Host) GetTurn(ctx context.Context, ref SessionRef, turnID string) (storesqlite.Turn, bool, error) {
+	ref.WorkspaceID = strings.TrimSpace(ref.WorkspaceID)
+	ref.AgentSessionID = strings.TrimSpace(ref.AgentSessionID)
+	turnID = strings.TrimSpace(turnID)
+	if h == nil || h.store == nil || ref.WorkspaceID == "" || ref.AgentSessionID == "" || turnID == "" {
+		return storesqlite.Turn{}, false, ErrInvalidArgument
+	}
+	return h.store.GetTurn(ctx, ref.WorkspaceID, ref.AgentSessionID, turnID)
+}
 
 // FindTurnByClientSubmitID exposes the canonical idempotency lookup without
 // requiring callers to depend on a concrete SQLite store.

--- a/packages/agent/host/canonical_queries_test.go
+++ b/packages/agent/host/canonical_queries_test.go
@@ -1,0 +1,62 @@
+package agenthost
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+type canonicalQueryStore struct {
+	CanonicalStore
+	wantWorkspaceID string
+	wantSessionID   string
+	wantTurnID      string
+	turn            storesqlite.Turn
+	err             error
+}
+
+func (s canonicalQueryStore) GetTurn(_ context.Context, workspaceID, sessionID, turnID string) (storesqlite.Turn, bool, error) {
+	if workspaceID != s.wantWorkspaceID || sessionID != s.wantSessionID || turnID != s.wantTurnID {
+		return storesqlite.Turn{}, false, errors.New("unexpected canonical turn key")
+	}
+	return s.turn, true, s.err
+}
+
+func TestGetTurnDelegatesCanonicalQueryWithNormalizedIdentity(t *testing.T) {
+	want := storesqlite.Turn{WorkspaceID: "workspace-1", AgentSessionID: "session-1", TurnID: "turn-1"}
+	host := New(Config{CanonicalStore: canonicalQueryStore{
+		wantWorkspaceID: want.WorkspaceID,
+		wantSessionID:   want.AgentSessionID,
+		wantTurnID:      want.TurnID,
+		turn:            want,
+	}})
+
+	got, found, err := host.GetTurn(t.Context(), SessionRef{
+		WorkspaceID: " workspace-1 ", AgentSessionID: " session-1 ",
+	}, " turn-1 ")
+	if err != nil || !found || !reflect.DeepEqual(got, want) {
+		t.Fatalf("GetTurn() = (%#v, %v, %v), want (%#v, true, nil)", got, found, err, want)
+	}
+}
+
+func TestGetTurnRejectsIncompleteIdentity(t *testing.T) {
+	host := New(Config{CanonicalStore: canonicalQueryStore{}})
+	for _, test := range []struct {
+		name   string
+		ref    SessionRef
+		turnID string
+	}{
+		{name: "workspace", ref: SessionRef{AgentSessionID: "session-1"}, turnID: "turn-1"},
+		{name: "session", ref: SessionRef{WorkspaceID: "workspace-1"}, turnID: "turn-1"},
+		{name: "turn", ref: SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, _, err := host.GetTurn(t.Context(), test.ref, test.turnID); !errors.Is(err, ErrInvalidArgument) {
+				t.Fatalf("GetTurn() error = %v, want %v", err, ErrInvalidArgument)
+			}
+		})
+	}
+}

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -260,16 +260,20 @@ func runCreateWithInitialContent(ctx context.Context, driver Driver) error {
 	if err := driver.Reset(ctx, Fixture{}); err != nil {
 		return err
 	}
-	session, turnID, err := driver.Create(ctx, "workspace-1", agenthost.CreateSessionInput{
+	input := agenthost.CreateSessionInput{
 		AgentSessionID: "session-initial", AgentTargetID: "target-1", Provider: "codex",
 		InitialContent: []agenthost.PromptContentBlock{{Type: "text", Text: "build the feature"}},
 		Metadata:       map[string]any{"clientSubmitId": "caller-controlled"}, ClientSubmitID: "create-submit-1",
-	})
+	}
+	session, turnID, err := driver.Create(ctx, "workspace-1", input)
 	if err != nil {
 		return fmt.Errorf("create with initial content: %w", err)
 	}
 	if session.SessionID != "session-initial" || turnID == "" {
 		return fmt.Errorf("create with initial content = %#v turn %q", session, turnID)
+	}
+	if err := verifyRetriedInitialCreate(ctx, driver, input, session, turnID); err != nil {
+		return err
 	}
 	metrics := driver.Metrics()
 	if metrics.StartCalls != 1 || metrics.ExecCalls != 1 {

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -263,7 +263,7 @@ func runCreateWithInitialContent(ctx context.Context, driver Driver) error {
 	session, turnID, err := driver.Create(ctx, "workspace-1", agenthost.CreateSessionInput{
 		AgentSessionID: "session-initial", AgentTargetID: "target-1", Provider: "codex",
 		InitialContent: []agenthost.PromptContentBlock{{Type: "text", Text: "build the feature"}},
-		Metadata:       map[string]any{"clientSubmitId": "create-submit-1"},
+		Metadata:       map[string]any{"clientSubmitId": "caller-controlled"}, ClientSubmitID: "create-submit-1",
 	})
 	if err != nil {
 		return fmt.Errorf("create with initial content: %w", err)
@@ -379,14 +379,17 @@ func runDuplicateClientSubmitID(ctx context.Context, driver Driver) error {
 	}
 	ref := agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-duplicate"}
 	input := agenthost.SendInput{
-		Content:  []agenthost.PromptContentBlock{{Type: "text", Text: "only once"}},
-		Metadata: map[string]any{"clientSubmitId": "submit-duplicate-1"},
+		Content:        []agenthost.PromptContentBlock{{Type: "text", Text: "only once"}},
+		Metadata:       map[string]any{"clientSubmitId": "caller-controlled"},
+		ClientSubmitID: "submit-duplicate-1",
 	}
 	first, err := driver.SendInput(ctx, ref, input)
 	if err != nil {
 		return fmt.Errorf("first idempotent send: %w", err)
 	}
-	duplicate, err := driver.SendInput(ctx, ref, input)
+	duplicateInput := input
+	duplicateInput.Metadata = map[string]any{"clientSubmitId": "different-caller-controlled"}
+	duplicate, err := driver.SendInput(ctx, ref, duplicateInput)
 	if err != nil {
 		return fmt.Errorf("duplicate idempotent send: %w", err)
 	}

--- a/packages/agent/host/conformance/submission_scenarios.go
+++ b/packages/agent/host/conformance/submission_scenarios.go
@@ -1,0 +1,23 @@
+package conformance
+
+import (
+	"context"
+	"fmt"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+)
+
+// verifyRetriedInitialCreate models an accepted create whose response was
+// lost. Untrusted legacy metadata must not override the typed identity.
+func verifyRetriedInitialCreate(ctx context.Context, driver Driver, input agenthost.CreateSessionInput, session SessionObservation, turnID string) error {
+	retry := input
+	retry.Metadata = map[string]any{"clientSubmitId": "different-caller-controlled"}
+	retriedSession, retriedTurnID, err := driver.Create(ctx, "workspace-1", retry)
+	if err != nil {
+		return fmt.Errorf("retry accepted create with initial content: %w", err)
+	}
+	if retriedSession.SessionID != session.SessionID || retriedTurnID != turnID {
+		return fmt.Errorf("retried create session=%q turn=%q, want session=%q turn=%q", retriedSession.SessionID, retriedTurnID, session.SessionID, turnID)
+	}
+	return nil
+}

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -23,8 +23,9 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 		return CreateSessionResult{}, err
 	}
 	typedGoal, isTypedGoal := ParseTypedGoalControl(normalized, false)
-	goalMetadata := clonePayload(input.Metadata)
-	claimMetadata := input.Metadata
+	metadata := submissionMetadata(input.Metadata, input.ClientSubmitID)
+	goalMetadata := clonePayload(metadata)
+	claimMetadata := metadata
 	if isTypedGoal {
 		normalized = nil
 		claimMetadata = nil
@@ -160,7 +161,7 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	execResult, err := h.runtime.Exec(ctx, RuntimeExecInput{
 		WorkspaceID: workspaceID, AgentSessionID: session.ID, Content: content,
 		DisplayPrompt: displayPrompt, InitialTitle: initialTitle, InitialTitleBase: session.Title,
-		Metadata: cloneMap(input.Metadata),
+		Metadata: cloneMap(metadata),
 	})
 	if err != nil {
 		h.observeStep(ctx, "session_create", "runtime_exec", session.ID, session.Provider, startedAt, err)
@@ -267,11 +268,12 @@ func (h *Host) SendInput(ctx context.Context, ref SessionRef, input SendInput) (
 	if err != nil {
 		return SendInputResult{}, err
 	}
+	metadata := submissionMetadata(input.Metadata, input.ClientSubmitID)
 	if typedGoal, ok := ParseTypedGoalControl(normalized, input.Guidance); ok {
 		goalResult, goalErr := h.goalControl(ctx, GoalControlInput{
 			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
 			Action: typedGoal.Action, Objective: typedGoal.Objective,
-			SubmissionMetadata: input.Metadata,
+			SubmissionMetadata: metadata,
 		})
 		if goalErr != nil {
 			return SendInputResult{}, goalErr
@@ -282,7 +284,7 @@ func (h *Host) SendInput(ctx context.Context, ref SessionRef, input SendInput) (
 			Kind: "goalControl", GoalControl: &goalResult,
 		}, nil
 	}
-	claim, claimPending, err := h.prepareSubmitClaim(ctx, ref, input.Metadata)
+	claim, claimPending, err := h.prepareSubmitClaim(ctx, ref, metadata)
 	if err != nil {
 		return SendInputResult{}, err
 	}
@@ -337,7 +339,7 @@ func (h *Host) SendInput(ctx context.Context, ref SessionRef, input SendInput) (
 		return h.runtime.Exec(ctx, RuntimeExecInput{
 			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, Content: content,
 			DisplayPrompt: displayPrompt, InitialTitle: initialTitle, InitialTitleBase: session.Title,
-			Guidance: input.Guidance, Metadata: cloneMap(input.Metadata),
+			Guidance: input.Guidance, Metadata: cloneMap(metadata),
 		})
 	}()
 	if err != nil {

--- a/packages/agent/host/submit_claims.go
+++ b/packages/agent/host/submit_claims.go
@@ -8,13 +8,26 @@ import (
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 )
 
-func clientSubmitID(metadata map[string]any) string {
+func legacyClientSubmitID(metadata map[string]any) string {
 	value, _ := metadata["clientSubmitId"].(string)
 	return strings.TrimSpace(value)
 }
 
+func submissionMetadata(metadata map[string]any, typedClientSubmitID string) map[string]any {
+	clientID := strings.TrimSpace(typedClientSubmitID)
+	if clientID == "" {
+		return metadata
+	}
+	result := cloneMap(metadata)
+	if result == nil {
+		result = make(map[string]any, 1)
+	}
+	result["clientSubmitId"] = clientID
+	return result
+}
+
 func (h *Host) prepareSubmitClaim(ctx context.Context, ref SessionRef, metadata map[string]any) (storesqlite.SubmitClaim, bool, error) {
-	clientID := clientSubmitID(metadata)
+	clientID := legacyClientSubmitID(metadata)
 	if h == nil || h.store == nil || clientID == "" {
 		return storesqlite.SubmitClaim{}, false, nil
 	}

--- a/packages/agent/host/submit_claims_test.go
+++ b/packages/agent/host/submit_claims_test.go
@@ -1,0 +1,21 @@
+package agenthost
+
+import "testing"
+
+func TestSubmissionMetadataUsesTypedClientSubmitIDWithoutMutatingCallerMap(t *testing.T) {
+	legacy := map[string]any{"clientSubmitId": "caller-controlled", "trace": "trace-1"}
+	got := submissionMetadata(legacy, " canonical-submit-1 ")
+	if got["clientSubmitId"] != "canonical-submit-1" || got["trace"] != "trace-1" {
+		t.Fatalf("submission metadata = %#v", got)
+	}
+	if legacy["clientSubmitId"] != "caller-controlled" {
+		t.Fatalf("caller metadata was mutated = %#v", legacy)
+	}
+}
+
+func TestSubmissionMetadataPreservesLegacyIdentityWhenTypedValueIsEmpty(t *testing.T) {
+	legacy := map[string]any{"clientSubmitId": "legacy-submit-1"}
+	if got := submissionMetadata(legacy, " "); got["clientSubmitId"] != "legacy-submit-1" {
+		t.Fatalf("submission metadata = %#v", got)
+	}
+}

--- a/packages/agent/host/testdata/external-consumer/consumer.go
+++ b/packages/agent/host/testdata/external-consumer/consumer.go
@@ -10,6 +10,7 @@ var (
 	_ = (*agenthost.Host).UpdateSettings
 	_ = (*agenthost.Host).UpdatePin
 	_ = (*agenthost.Host).DeleteSession
+	_ = (*agenthost.Host).GetTurn
 	_ = (*agenthost.Host).FindTurnByClientSubmitID
 	_ = (*agenthost.Host).CancelTurn
 	_ = (*agenthost.Host).SubmitInteractive

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -235,12 +235,15 @@ type PromptAttachment struct {
 // import paths, workspace resolution, identity, and transport state are not
 // part of this type.
 type CreateSessionInput struct {
-	AgentSessionID         string
-	AgentTargetID          string
-	Provider               string
-	InitialContent         []PromptContentBlock
-	InitialDisplayPrompt   string
-	Metadata               map[string]any
+	AgentSessionID       string
+	AgentTargetID        string
+	Provider             string
+	InitialContent       []PromptContentBlock
+	InitialDisplayPrompt string
+	Metadata             map[string]any
+	// ClientSubmitID is the caller-owned idempotency identity for the optional
+	// initial turn and overrides legacy Metadata["clientSubmitId"].
+	ClientSubmitID         string
 	Title                  *string
 	Cwd                    *string
 	PermissionModeID       *string
@@ -260,7 +263,10 @@ type SendInput struct {
 	Content       []PromptContentBlock
 	DisplayPrompt string
 	Metadata      map[string]any
-	Guidance      bool
+	// ClientSubmitID is the caller-owned idempotency identity. When present it
+	// overrides any legacy clientSubmitId value carried in Metadata.
+	ClientSubmitID string
+	Guidance       bool
 }
 
 type SubmitInteractiveInput struct {

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -201,6 +202,7 @@ type legacyHostConformanceDriver struct {
 	goalInbox      *conformanceGoalInboxStore
 	commitObserver *conformanceCommitObserver
 	recoverySteps  *[]string
+	createdTurns   map[string]string
 	directHost     bool
 }
 
@@ -213,6 +215,7 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 		interactions: map[string][]agentactivitybiz.Interaction{},
 	}
 	d.operations = &runtimeOperationMemoryStore{}
+	d.createdTurns = make(map[string]string)
 	steps := make([]string, 0)
 	d.recoverySteps = &steps
 	d.operationPort = &conformanceRuntimeOperationStore{runtimeOperationMemoryStore: d.operations, steps: &steps}
@@ -402,6 +405,14 @@ func (d *legacyHostConformanceDriver) Create(
 	if len(d.runtime.execCalls) > beforeExec {
 		turnID = "turn-1"
 		d.recordSubmittedTurn(workspaceID, session.ID, turnID)
+		if clientSubmitID := strings.TrimSpace(input.ClientSubmitID); clientSubmitID != "" {
+			d.createdTurns[clientSubmitID] = turnID
+		}
+	} else if clientSubmitID := strings.TrimSpace(input.ClientSubmitID); clientSubmitID != "" {
+		turnID = d.createdTurns[clientSubmitID]
+		if turnID == "" {
+			return hostconformance.SessionObservation{}, "", fmt.Errorf("typed create submit %q has no canonical turn", clientSubmitID)
+		}
 	}
 	return legacyHostSessionObservation(session), turnID, nil
 }

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -388,7 +388,7 @@ func (d *legacyHostConformanceDriver) Create(
 	session, err := d.service.Create(ctx, workspaceID, CreateSessionInput{
 		AgentSessionID: input.AgentSessionID, AgentTargetID: agentTargetID, Provider: input.Provider,
 		InitialContent: input.InitialContent, InitialDisplayPrompt: input.InitialDisplayPrompt,
-		Metadata: input.Metadata, Title: input.Title, Cwd: input.Cwd,
+		Metadata: input.Metadata, ClientSubmitID: input.ClientSubmitID, Title: input.Title, Cwd: input.Cwd,
 		PermissionModeID: input.PermissionModeID, Model: input.Model, PlanMode: input.PlanMode,
 		BrowserUse: input.BrowserUse, ComputerUse: input.ComputerUse,
 		ProviderTargetRef: input.ProviderTargetRef, ReasoningEffort: input.ReasoningEffort,

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -140,7 +140,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	hostInput := agenthost.CreateSessionInput{
 		AgentSessionID: input.AgentSessionID, AgentTargetID: input.AgentTargetID, Provider: input.Provider,
 		InitialContent: normalizedContent, InitialDisplayPrompt: input.InitialDisplayPrompt,
-		Metadata: input.Metadata, Title: input.Title, Cwd: stringPointer(prepared.Cwd),
+		Metadata: input.Metadata, ClientSubmitID: input.ClientSubmitID, Title: input.Title, Cwd: stringPointer(prepared.Cwd),
 		PermissionModeID: input.PermissionModeID,
 		Model:            stringPointer(runtimeSettings.Model),
 		PlanMode:         boolPointer(runtimeSettings.PlanMode),

--- a/services/tuttid/service/agent/service_send_input.go
+++ b/services/tuttid/service/agent/service_send_input.go
@@ -23,7 +23,10 @@ func (s *Service) SendInput(ctx context.Context, workspaceID string, agentSessio
 	})
 	hostResult, err := s.ApplicationHost().SendInput(ctx,
 		agenthost.SessionRef{WorkspaceID: workspaceID, AgentSessionID: agentSessionID},
-		agenthost.SendInput{Content: normalizedContent, DisplayPrompt: input.DisplayPrompt, Metadata: input.Metadata, Guidance: input.Guidance},
+		agenthost.SendInput{
+			Content: normalizedContent, DisplayPrompt: input.DisplayPrompt,
+			Metadata: input.Metadata, ClientSubmitID: input.ClientSubmitID, Guidance: input.Guidance,
+		},
 	)
 	if err != nil {
 		return SendInputResult{}, err

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -444,6 +444,7 @@ type CreateSessionInput struct {
 	InitialContent         []PromptContentBlock
 	InitialDisplayPrompt   string
 	Metadata               map[string]any
+	ClientSubmitID         string
 	Title                  *string
 	Cwd                    *string
 	PermissionModeID       *string


### PR DESCRIPTION
## Summary

- expose `Host.GetTurn` as the canonical turn read boundary
- add typed `ClientSubmitID` to initial create and send contracts; typed identity overrides legacy `Metadata["clientSubmitId"]`
- normalize and validate query identities before delegating to the configured canonical store
- forward the typed field through tuttid's thin legacy delegate without changing its wire surface
- extend duplicate-submit conformance so differing untrusted metadata cannot override the typed idempotency identity
- document the public contracts and extend the external compile fixture

## Why

TSH shared-owner recovery must inspect already-linked canonical turns and resubmit a claimed invocation with `invocationId` as its authoritative idempotency identity, while keeping the owner loop entirely on public Host APIs. Hiding a SQLite read behind a downstream adapter or continuing to encode identity only in a loose metadata map would preserve the application-layer coupling this Host extraction track is removing.

Both changes reuse existing Host behavior: `GetTurn` delegates the existing `CanonicalTurnStore.GetTurn` port, and typed submit identity feeds the existing durable submit-claim mechanism. There are no new lifecycle decisions.

## Compatibility

Existing callers that only set `Metadata["clientSubmitId"]` retain the same behavior. New callers can use `ClientSubmitID`; when both are supplied, the typed field is authoritative and is also projected into runtime/canonical metadata. tuttid HTTP/OpenAPI shapes are unchanged.

## Risk

Low and localized to the Host contract and tuttid's existing delegate. No schema, HTTP/OpenAPI, provider, persistence, or worker behavior changes.

## Verification

- `go test ./...` in `packages/agent/host`
- `go test ./service/agent -count=1` in `services/tuttid`
- duplicate submit conformance uses the same typed ID with conflicting legacy metadata values and still performs exactly one provider exec
- external consumer compile/dependency fixture (included in Host tests)
- repository `check:full`: every available lane passed; local `lint:go` could not start because the pinned `golangci-lint` binary is not installed, so CI remains the final lint authority

## Documentation impact

Updated `packages/agent/host/README.md` because this adds public Host API surface.
