### PR TITLE
chore(repo): make pre-push validation changed-aware

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,1 @@
-pnpm check:full
+pnpm check:changed -- --push-ready

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ Avoid full validation unless it is necessary for the risk or requested workflow.
 Local hooks use Husky.
 
 - `pre-commit`: `lint-staged`, staged Electron/UI/renderer boundary checks
-- `pre-push`: `pnpm check:full`
+- `pre-push`: `pnpm check:changed -- --push-ready`
 
 Prefer `pnpm check:changed` before broader validation during normal AI iteration. It runs selected lanes concurrently, prints compact summaries, and stores full logs under `.tmp/check-runs`; use `--tail-lines <n>` to tune failure tails.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,13 +123,13 @@ This appends a `Signed-off-by: Your Name <your@email>` line to the commit messag
 1. Fork the repository and create a branch from `main`. Suggested branch naming: `feat/...`, `fix/...`, `docs/...`
 2. Make your changes; keep each PR focused on a single concern
 3. Open a PR with a clear description of the motivation and changes
-4. CI runs TypeScript linting, Go linting, typechecking, tests, and tooling consistency checks; all checks must pass
+4. CI classifies the changed files and runs the relevant TypeScript, Go, package, and tooling checks; all selected checks must pass
 5. A maintainer reviews your PR; please respond to feedback and keep the conversation in the PR
 
 Local hooks use `husky`:
 
 - `pre-commit` runs staged formatting and UI-boundary checks
-- `pre-push` runs `pnpm check:full`
+- `pre-push` runs changed-aware push validation with `pnpm check:changed -- --push-ready`
 
 ## Pull Request Review Gate
 

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -123,13 +123,13 @@ git commit -s -m "feat(scope): add something"
 1. Fork 仓库并从 `main` 创建分支。建议的分支命名：`feat/...`、`fix/...`、`docs/...`
 2. 完成你的改动；每个 PR 只关注一件事
 3. 提交 PR，清晰描述动机与改动内容
-4. CI 会运行 TypeScript lint、Go lint、类型检查、测试和工具一致性检查；所有检查必须通过
+4. CI 会根据变更文件运行相关的 TypeScript、Go、包和工具检查；所有选中的检查必须通过
 5. 维护者会 review 你的 PR；请回应反馈，并把讨论保留在 PR 中
 
 本地钩子使用 `husky`：
 
 - `pre-commit` 运行暂存区格式化和 UI 边界检查
-- `pre-push` 运行 `pnpm check:full`
+- `pre-push` 通过 `pnpm check:changed -- --push-ready` 运行变更感知的推送检查
 
 ## Pull Request 评审门禁
 

--- a/CONTRIBUTING.zh-TW.md
+++ b/CONTRIBUTING.zh-TW.md
@@ -123,13 +123,13 @@ git commit -s -m "feat(scope): add something"
 1. Fork 儲存庫並從 `main` 建立分支。建議的分支命名：`feat/...`、`fix/...`、`docs/...`
 2. 完成你的變更；每個 PR 只聚焦一件事
 3. 送出 PR，清楚描述動機與變更內容
-4. CI 會執行 TypeScript lint、Go lint、型別檢查、測試和工具一致性檢查；所有檢查必須通過
+4. CI 會根據變更檔案執行相關的 TypeScript、Go、套件和工具檢查；所有選取的檢查必須通過
 5. 維護者會 review 你的 PR；請回應回饋，並把討論保留在 PR 中
 
 本機鉤子使用 `husky`：
 
 - `pre-commit` 執行暫存區格式化和 UI 邊界檢查
-- `pre-push` 執行 `pnpm check:full`
+- `pre-push` 透過 `pnpm check:changed -- --push-ready` 執行變更感知的推送檢查
 
 ## Pull Request 評審門禁
 

--- a/docs/conventions/local-git-hooks.md
+++ b/docs/conventions/local-git-hooks.md
@@ -46,13 +46,20 @@ Rules:
 
 ## `pre-push`
 
-`pre-push` is the local full-validation gate before code leaves the machine.
+`pre-push` is the changed-aware push-readiness gate before code leaves the
+machine.
 
 Current behavior:
 
-- `pnpm check:full`
+- `pnpm check:changed -- --push-ready`
 
-`check:full` should remain the stable root command for local full validation.
+The hook compares the branch and working tree with the default base ref,
+selects only the relevant validation lanes, and adds build lanes for changed Go
+or package surfaces that require push-time build confidence. Unrelated
+TypeScript, Go, package, and boundary lanes do not run.
+
+`check:full` remains the stable root command for explicit local full validation
+and CI. It is no longer the default gate for every push.
 
 That root command now uses a repository-owned Node orchestration script so the stable entrypoint stays the same while independent checks can run in parallel in bounded phases:
 
@@ -91,9 +98,12 @@ typechecking uses native TypeScript via `tsgo`.
 
 Rules:
 
-- `pre-push` should stay aligned with first-pass pull-request CI checks
-- slower cross-workspace validation belongs here rather than in `pre-commit`
-- if a check is too expensive for `pre-commit`, keep it in `pre-push` and CI
+- `pre-push` should stay aligned with first-pass pull-request CI through
+  changed-file risk selection
+- slower cross-workspace validation should run only when the changed surface
+  selects it
+- explicit full validation remains available for releases, broad migrations,
+  manual confidence checks, and checked force-push workflows
 
 TypeScript package tests and Go workspace tests use discovery-based runners
 instead of root package/module whitelists. Successful runs print compact
@@ -121,6 +131,10 @@ broader validation. It selects checks from the changed file set, runs
 independent lanes concurrently, prints compact summaries, and stores full logs
 under `.tmp/check-runs`.
 
+`pnpm check:changed -- --push-ready` is the `pre-push` mode. In addition to the
+normal changed-aware lanes, it schedules Go or package builds when the changed
+surface requires them.
+
 Failure output prints an 80-line tail by default. Use
 `pnpm check:changed -- --tail-lines <n>` when a larger or smaller tail is more
 useful; full logs remain in `.tmp/check-runs`.
@@ -140,7 +154,7 @@ boundary checks and package validation.
 The shared UI boundary is enforced in two modes:
 
 - `pnpm check:ui-boundaries:staged` for `pre-commit`
-- `pnpm check:ui-boundaries` for `pre-push` and CI
+- `pnpm check:ui-boundaries` when selected by changed-aware `pre-push` or CI
 
 This keeps commit-time feedback narrow to the staged change while still preserving a full-repository guard later in the flow.
 The durable details of what the script enforces, including the single allowed non-UI-system workbench stylesheet, belong in the script output and [UI System](../../packages/ui/system/ui-system.md), not duplicated here.
@@ -150,7 +164,7 @@ The durable details of what the script enforces, including the single allowed no
 Renderer feature internals are enforced in two modes:
 
 - `pnpm check:renderer-boundaries:staged` for `pre-commit`
-- `pnpm check:renderer-boundaries` for `pre-push` and CI
+- `pnpm check:renderer-boundaries` when selected by changed-aware `pre-push` or CI
 
 The script prevents files outside a feature from importing that feature's `services/internal/**` implementation surface. It also prevents ordinary renderer files from reading `window.tutti` directly; window container files pass that preload API into feature registrations instead.
 
@@ -159,7 +173,8 @@ The script prevents files outside a feature from importing that feature's `servi
 Electron runtime import boundaries are enforced in two modes:
 
 - `pnpm check:electron-runtime-boundaries:staged` for `pre-commit`
-- `pnpm check:electron-runtime-boundaries` for `pre-push` and CI
+- `pnpm check:electron-runtime-boundaries` when selected by changed-aware
+  `pre-push` or CI
 
 The script walks the runtime import graph reachable from `apps/desktop/src/main/**` and `apps/desktop/src/preload/**`.
 It rejects:

--- a/tools/scripts/local-git-hooks.test.mjs
+++ b/tools/scripts/local-git-hooks.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = join(scriptDirectory, "..", "..");
+
+test("pre-push uses changed-aware push-ready validation", () => {
+  const hook = readFileSync(join(workspaceRoot, ".husky", "pre-push"), "utf8");
+
+  assert.equal(hook.trim(), "pnpm check:changed -- --push-ready");
+});


### PR DESCRIPTION
## Summary

- replace unconditional pre-push `check:full` with changed-aware `check:changed -- --push-ready`
- add a hook contract test so the push gate cannot silently regress to full validation
- align AGENTS, hook conventions, and all CONTRIBUTING language variants with the changed-aware workflow

## Verification

- `node --test tools/scripts/local-git-hooks.test.mjs`
- `pnpm check:changed -- --push-ready --base origin/main` — 4 lanes passed in 2.8s
- real pre-push hook — 4 lanes passed in 2.7s
- `pnpm check:full` — 19 tasks passed in 69.6s
- `git diff --check`

## Checklist

- [x] Agent lifecycle semantics are unchanged
- [x] I kept the change focused on one concern
- [x] I updated the durable local-hook documentation
- [x] I updated all CONTRIBUTING language variants
- [x] I ran the changed-aware push gate and full validation
- [x] The commit is signed off with DCO
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->