### PR TITLE
chore(repo): share change classification rules

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,54 +29,10 @@ jobs:
         id: changed-files
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          run_go=false
-          run_pack=false
-          run_tooling=false
-          run_ts=false
-
-          while IFS= read -r path; do
-            [[ -z "${path}" ]] && continue
-
-            case "${path}" in
-              *.go|go.mod|go.sum|go.work|go.work.sum|*/go.mod|*/go.sum|services/tuttid/.golangci*)
-                run_go=true
-                run_tooling=true
-                ;;
-            esac
-
-            case "${path}" in
-              *.cjs|*.cts|*.js|*.jsx|*.mjs|*.mts|*.ts|*.tsx|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|tsconfig*.json|*/tsconfig*.json|packages/configs/**)
-                run_ts=true
-                run_pack=true
-                ;;
-            esac
-
-            case "${path}" in
-              package.json|pnpm-lock.yaml|pnpm-workspace.yaml|packages/*/package.json|packages/*/*/package.json)
-                run_pack=true
-                ;;
-            esac
-
-            case "${path}" in
-              .github/workflows/pr-checks.yml|tools/scripts/**|services/tuttid/.golangci-lint-version)
-                run_go=true
-                run_pack=true
-                run_tooling=true
-                run_ts=true
-                ;;
-            esac
-          done < <(git diff --name-only "${BASE_SHA}...HEAD")
-
-          {
-            echo "run_go=${run_go}"
-            echo "run_pack=${run_pack}"
-            echo "run_tooling=${run_tooling}"
-            echo "run_ts=${run_ts}"
-          } >> "${GITHUB_OUTPUT}"
-
-          printf 'change classification: run_go=%s run_pack=%s run_tooling=%s run_ts=%s\n' \
-            "${run_go}" "${run_pack}" "${run_tooling}" "${run_ts}"
+        run: >-
+          node ./tools/scripts/change-classification.mjs
+          --base "${BASE_SHA}"
+          --github-output "${GITHUB_OUTPUT}"
 
   tooling-consistency:
     name: Tooling Consistency

--- a/docs/conventions/local-git-hooks.md
+++ b/docs/conventions/local-git-hooks.md
@@ -58,6 +58,12 @@ selects only the relevant validation lanes, and adds build lanes for changed Go
 or package surfaces that require push-time build confidence. Unrelated
 TypeScript, Go, package, and boundary lanes do not run.
 
+Top-level TypeScript, Go, package, and tooling risk domains come from
+`tools/scripts/change-classification.mjs`, which is also called by the
+pull-request workflow. `check:changed` adds its more precise local lanes on top
+of that shared classification rather than maintaining a competing top-level
+path list.
+
 `check:full` remains the stable root command for explicit local full validation
 and CI. It is no longer the default gate for every push.
 

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -33,15 +33,20 @@ Repository entrypoints:
 
 `pnpm check:full` remains the full local and CI validation command and includes linting and typechecking.
 
-The pull-request workflow classifies changed files inline before running
-expensive validation jobs. TypeScript and JavaScript paths select TypeScript
-lint, typecheck, tests, and package packing; Go paths select Go tests and Go
-lint; package manifest and lockfile paths select package packing; CI and
-repository tooling paths conservatively select all affected lanes. Documentation
-only changes therefore skip code validation while still producing workflow check
-results through job-level conditions. Do not use workflow-level `paths-ignore`
-for this gate because missing required checks can leave documentation-only PRs
-waiting on branch protection.
+`tools/scripts/change-classification.mjs` owns the top-level changed-file risk
+domains shared by pull-request CI and `check:changed`: TypeScript and JavaScript
+paths select TypeScript validation and package packing; Go paths select Go and
+tooling validation; package manifest and lockfile paths select package packing;
+CI and repository tooling paths conservatively select every domain. The
+pull-request workflow invokes that script before starting expensive jobs, while
+`check:changed` builds its more precise package, boundary, test, and build lanes
+on top of the same classification. Do not duplicate these top-level path rules
+inside workflow YAML.
+
+Documentation-only changes therefore skip code validation while still
+producing workflow check results through job-level conditions. Do not use
+workflow-level `paths-ignore` for this gate because missing required checks can
+leave documentation-only PRs waiting on branch protection.
 
 Validation runners that spawn nested pnpm commands should read the root
 `packageManager` field and invoke that pinned version through Corepack. Do not

--- a/tools/scripts/change-classification.mjs
+++ b/tools/scripts/change-classification.mjs
@@ -1,0 +1,154 @@
+import { appendFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const TYPESCRIPT_CODE_PATTERN = /\.(?:cjs|cts|js|jsx|mjs|mts|ts|tsx)$/u;
+const TYPESCRIPT_CONFIG_PATTERN = /(?:^|\/)tsconfig[^/]*\.json$/u;
+const GO_MODULE_PATTERN = /(?:^|\/)go\.(?:mod|sum)$/u;
+
+export function classifyChangedFiles(changedFiles) {
+  const classification = {
+    runGo: false,
+    runPack: false,
+    runTooling: false,
+    runTs: false
+  };
+
+  for (const rawPath of changedFiles) {
+    const path = rawPath.replaceAll("\\", "/");
+    if (!path) {
+      continue;
+    }
+
+    if (isGoPath(path)) {
+      classification.runGo = true;
+      classification.runTooling = true;
+    }
+
+    if (isTypeScriptPath(path)) {
+      classification.runTs = true;
+      classification.runPack = true;
+    }
+
+    if (isPackagePackPath(path)) {
+      classification.runPack = true;
+    }
+
+    if (isConservativeToolingPath(path)) {
+      classification.runGo = true;
+      classification.runPack = true;
+      classification.runTooling = true;
+      classification.runTs = true;
+    }
+  }
+
+  return classification;
+}
+
+export function formatGitHubOutput(classification) {
+  return [
+    `run_go=${classification.runGo}`,
+    `run_pack=${classification.runPack}`,
+    `run_tooling=${classification.runTooling}`,
+    `run_ts=${classification.runTs}`
+  ].join("\n");
+}
+
+export function formatClassificationSummary(classification) {
+  return `change classification: ${formatGitHubOutput(classification).replaceAll("\n", " ")}`;
+}
+
+function isGoPath(path) {
+  return (
+    path.endsWith(".go") ||
+    GO_MODULE_PATTERN.test(path) ||
+    path === "go.work" ||
+    path === "go.work.sum" ||
+    path.startsWith("services/tuttid/.golangci")
+  );
+}
+
+function isTypeScriptPath(path) {
+  return (
+    TYPESCRIPT_CODE_PATTERN.test(path) ||
+    path === "package.json" ||
+    path === "pnpm-lock.yaml" ||
+    path === "pnpm-workspace.yaml" ||
+    TYPESCRIPT_CONFIG_PATTERN.test(path) ||
+    path.startsWith("packages/configs/")
+  );
+}
+
+function isPackagePackPath(path) {
+  if (
+    path === "package.json" ||
+    path === "pnpm-lock.yaml" ||
+    path === "pnpm-workspace.yaml"
+  ) {
+    return true;
+  }
+  const segments = path.split("/");
+  return (
+    segments[0] === "packages" &&
+    segments.at(-1) === "package.json" &&
+    (segments.length === 3 || segments.length === 4)
+  );
+}
+
+function isConservativeToolingPath(path) {
+  return (
+    path === ".github/workflows/pr-checks.yml" ||
+    path.startsWith("tools/scripts/") ||
+    path === "services/tuttid/.golangci-lint-version"
+  );
+}
+
+function listChangedFiles(baseRef) {
+  const result = spawnSync(
+    "git",
+    ["diff", "--name-only", `${baseRef}...HEAD`],
+    {
+      encoding: "utf8"
+    }
+  );
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || "unable to list changed files");
+  }
+  return result.stdout.split("\n").filter(Boolean);
+}
+
+function readOption(name) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) {
+    return null;
+  }
+  return process.argv[index + 1] ?? null;
+}
+
+function main() {
+  const baseRef = readOption("--base");
+  if (!baseRef) {
+    throw new Error(
+      "usage: node tools/scripts/change-classification.mjs --base <ref> [--github-output <path>]"
+    );
+  }
+
+  const classification = classifyChangedFiles(listChangedFiles(baseRef));
+  const githubOutput = formatGitHubOutput(classification);
+  const githubOutputPath = readOption("--github-output");
+  if (githubOutputPath) {
+    appendFileSync(githubOutputPath, `${githubOutput}\n`);
+  }
+  console.log(formatClassificationSummary(classification));
+}
+
+const currentPath = fileURLToPath(import.meta.url);
+if (process.argv[1] && resolve(process.argv[1]) === currentPath) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/tools/scripts/change-classification.test.mjs
+++ b/tools/scripts/change-classification.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  classifyChangedFiles,
+  formatClassificationSummary,
+  formatGitHubOutput
+} from "./change-classification.mjs";
+
+const noChecks = {
+  runGo: false,
+  runPack: false,
+  runTooling: false,
+  runTs: false
+};
+
+test("documentation and styles do not select code validation", () => {
+  assert.deepEqual(
+    classifyChangedFiles(["README.md", "packages/ui/system/src/button.css"]),
+    noChecks
+  );
+});
+
+test("TypeScript paths select TypeScript and package validation", () => {
+  assert.deepEqual(
+    classifyChangedFiles(["packages/ui/system/src/button.tsx"]),
+    {
+      ...noChecks,
+      runPack: true,
+      runTs: true
+    }
+  );
+  assert.deepEqual(
+    classifyChangedFiles(["packages/configs/typescript/base.json"]),
+    {
+      ...noChecks,
+      runPack: true,
+      runTs: true
+    }
+  );
+});
+
+test("Go paths select Go and tooling validation", () => {
+  assert.deepEqual(
+    classifyChangedFiles(["packages\\agent\\host\\session.go"]),
+    {
+      ...noChecks,
+      runGo: true,
+      runTooling: true
+    }
+  );
+});
+
+test("nested package manifests select package validation", () => {
+  assert.deepEqual(classifyChangedFiles(["packages/agent/gui/package.json"]), {
+    ...noChecks,
+    runPack: true
+  });
+});
+
+test("validation tooling changes conservatively select every domain", () => {
+  const allChecks = {
+    runGo: true,
+    runPack: true,
+    runTooling: true,
+    runTs: true
+  };
+  for (const path of [
+    ".github/workflows/pr-checks.yml",
+    "tools/scripts/change-classification.mjs",
+    "services/tuttid/.golangci-lint-version"
+  ]) {
+    assert.deepEqual(classifyChangedFiles([path]), allChecks, path);
+  }
+});
+
+test("GitHub output preserves workflow output names", () => {
+  const classification = {
+    runGo: true,
+    runPack: false,
+    runTooling: true,
+    runTs: false
+  };
+  const output = [
+    "run_go=true",
+    "run_pack=false",
+    "run_tooling=true",
+    "run_ts=false"
+  ].join("\n");
+
+  assert.equal(formatGitHubOutput(classification), output);
+  assert.equal(
+    formatClassificationSummary(classification),
+    `change classification: ${output.replaceAll("\n", " ")}`
+  );
+});

--- a/tools/scripts/run-check-changed.mjs
+++ b/tools/scripts/run-check-changed.mjs
@@ -16,6 +16,7 @@ import {
   isToolTestRelevant,
   resolveGoValidationTargets
 } from "./run-check-changed-targets.mjs";
+import { classifyChangedFiles } from "./change-classification.mjs";
 import { formatFailureExcerpt } from "./run-validation-lanes.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
@@ -35,7 +36,8 @@ const latestSummaryPath = join(tmpRoot, "latest.json");
 const packageInfos = loadPackageInfos();
 
 export async function main() {
-  const lanes = failedOnly ? readFailedLanes() : buildChangedLanes();
+  const plan = failedOnly ? null : buildChangedPlan();
+  const lanes = failedOnly ? readFailedLanes() : plan.lanes;
 
   if (lanes.length === 0) {
     console.log(
@@ -65,6 +67,7 @@ export async function main() {
   const durationMs = Date.now() - startedAt;
   const summary = {
     baseRef,
+    classification: plan?.classification ?? null,
     durationMs,
     failedOnly,
     pushReady,
@@ -88,8 +91,16 @@ export async function main() {
   }
 }
 
-function buildChangedLanes() {
+function buildChangedPlan() {
   const changedFiles = listChangedFiles(baseRef);
+  const classification = classifyChangedFiles(changedFiles);
+  return {
+    classification,
+    lanes: buildChangedLanes(changedFiles, classification)
+  };
+}
+
+function buildChangedLanes(changedFiles, classification) {
   const lanesByKey = new Map();
   const addLane = (lane) => {
     if (!lanesByKey.has(lane.key)) {
@@ -111,7 +122,9 @@ function buildChangedLanes() {
     ]
   });
 
-  const lintFiles = selectExistingLintFiles(changedFiles);
+  const lintFiles = classification.runTs
+    ? selectExistingLintFiles(changedFiles)
+    : [];
   if (lintFiles.length > 0) {
     addLane({
       key: "lint:changed",
@@ -184,7 +197,9 @@ function buildChangedLanes() {
     });
   }
 
-  const goValidationTargets = resolveGoValidationTargets(changedFiles);
+  const goValidationTargets = classification.runGo
+    ? resolveGoValidationTargets(changedFiles)
+    : null;
   const forceBuiltinGenerate = isBuiltinGenerateRequired(changedFiles);
   if (goValidationTargets) {
     for (const [moduleRoot, targets] of goValidationTargets.lintByModule) {
@@ -218,7 +233,8 @@ function buildChangedLanes() {
     }
   }
 
-  const rootGlobalChange = changedFiles.some(isGlobalTypecheckRelevant);
+  const rootGlobalChange =
+    classification.runTs && changedFiles.some(isGlobalTypecheckRelevant);
   if (rootGlobalChange) {
     addLane({
       key: "typecheck:all",


### PR DESCRIPTION
## Summary

- extract PR validation domain classification from workflow YAML into `tools/scripts/change-classification.mjs`
- make PR CI and `check:changed` consume the same top-level Go, TypeScript, package, and tooling classification
- keep local package, boundary, test, and build lane selection precise on top of the shared domains
- document the single-owner classification rule

## Verification

- `node --test tools/scripts/change-classification.test.mjs tools/scripts/run-check-changed.test.mjs` — 12 tests passed
- shared CLI against `origin/main...HEAD` — emitted `run_go=true`, `run_pack=true`, `run_tooling=true`, `run_ts=true`
- `pnpm check:changed -- --push-ready --base origin/main` — 4 lanes passed in 2.9s
- real pre-push hook — 4 lanes passed in 2.5s
- `pnpm check:full` — 19 tasks passed in 65.6s
- `git diff --check`

## Checklist

- [x] Agent lifecycle semantics are unchanged
- [x] I kept the change focused on one concern
- [x] I updated local-hook and static-analysis documentation
- [x] README/CONTRIBUTING language variants are unaffected
- [x] I ran focused tests, changed-aware validation, and full validation
- [x] The commit is signed off with DCO
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->