### PR TITLE
style(agent-gui): make sub-agent row use text-secondary

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -10674,7 +10674,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 }
 
 .workspace-agents-status-panel__detail-subagent-name {
-  color: var(--text-primary);
+  color: var(--text-secondary);
   margin-left: 4px;
 }
 


### PR DESCRIPTION
## What

The sub-agent header row in the agent transcript rendered its task name in `text-primary` while the rest of the row (the "Sub-agent" label, elapsed time, status) inherited `text-secondary`. This made the row visually inconsistent.

Aligns the sub-agent task name to `text-secondary` so the entire sub-agent info row reads as one uniform secondary-color line.

## Change

- `packages/agent/gui/app/renderer/agentactivity.css`: `__detail-subagent-name` color `var(--text-primary)` → `var(--text-secondary)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->