### PR TITLE
fix(agent-gui): reduce trace render hotspots

### DIFF
--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
@@ -74,11 +74,7 @@ export function selectEngineTurnsForSession(
   if (!state.sessionLifecycle.sessionsById[id]) return [];
   return Object.values(state.sessionLifecycle.turnsById)
     .filter((turn) => turn.agentSessionId === id)
-    .sort(
-      (left, right) =>
-        left.startedAtUnixMs - right.startedAtUnixMs ||
-        left.turnId.localeCompare(right.turnId)
-    );
+    .sort(compareTurnsByOccurrence);
 }
 
 export function selectEngineActiveTurn(
@@ -190,7 +186,18 @@ export function selectEngineLatestTurn(
   state: AgentSessionEngineState,
   agentSessionId: string | null | undefined
 ): AgentActivityTurn | null {
-  return selectEngineTurnsForSession(state, agentSessionId).at(-1) ?? null;
+  const id = agentSessionId?.trim() ?? "";
+  if (!state.sessionLifecycle.sessionsById[id]) return null;
+  let latestTurn: AgentActivityTurn | null = null;
+  for (const turn of Object.values(state.sessionLifecycle.turnsById)) {
+    if (
+      turn.agentSessionId === id &&
+      (!latestTurn || compareTurnsByOccurrence(latestTurn, turn) < 0)
+    ) {
+      latestTurn = turn;
+    }
+  }
+  return latestTurn;
 }
 
 export function selectEngineInteractionsForSession(
@@ -298,12 +305,22 @@ export function selectWorkspaceAgentConsumerSessions(
 export function selectRootAgentSessionIdsWithPendingInteractions(
   state: AgentSessionEngineState
 ): readonly string[] {
+  const sessionIdsWithPendingInteractions = new Set<string>();
+  for (const interaction of Object.values(
+    state.sessionLifecycle.interactionsById
+  )) {
+    if (
+      interaction.status === "pending" &&
+      state.sessionLifecycle.turnsById[
+        canonicalTurnKey(interaction.agentSessionId, interaction.turnId)
+      ]
+    ) {
+      sessionIdsWithPendingInteractions.add(interaction.agentSessionId);
+    }
+  }
   const rootAgentSessionIds = new Set<string>();
   for (const session of Object.values(state.sessionLifecycle.sessionsById)) {
-    if (
-      selectEnginePendingInteractions(state, session.agentSessionId).length ===
-      0
-    ) {
+    if (!sessionIdsWithPendingInteractions.has(session.agentSessionId)) {
       continue;
     }
     const rootAgentSessionId =
@@ -364,13 +381,53 @@ export function selectWorkspaceAgentRootConversationSessions(
 export function selectAllWorkspaceAgentConsumerSessions(
   state: AgentSessionEngineState
 ): readonly WorkspaceAgentConsumerSession[] {
-  return Object.values(state.sessionLifecycle.sessionsById).map((session) => {
-    const activeTurn = selectEngineActiveTurn(state, session.agentSessionId);
-    const latestTurn = selectEngineLatestTurn(state, session.agentSessionId);
-    const pendingInteractions = selectEnginePendingInteractions(
-      state,
-      session.agentSessionId
+  const latestTurnsBySessionId = new Map<string, AgentActivityTurn>();
+  for (const turn of Object.values(state.sessionLifecycle.turnsById)) {
+    if (!state.sessionLifecycle.sessionsById[turn.agentSessionId]) continue;
+    const latestTurn = latestTurnsBySessionId.get(turn.agentSessionId);
+    if (!latestTurn || compareTurnsByOccurrence(latestTurn, turn) < 0) {
+      latestTurnsBySessionId.set(turn.agentSessionId, turn);
+    }
+  }
+
+  const pendingInteractionsBySessionId = new Map<
+    string,
+    AgentActivityInteraction[]
+  >();
+  for (const interaction of Object.values(
+    state.sessionLifecycle.interactionsById
+  )) {
+    if (
+      interaction.status !== "pending" ||
+      !state.sessionLifecycle.sessionsById[interaction.agentSessionId] ||
+      !state.sessionLifecycle.turnsById[
+        canonicalTurnKey(interaction.agentSessionId, interaction.turnId)
+      ]
+    ) {
+      continue;
+    }
+    const pendingInteractions =
+      pendingInteractionsBySessionId.get(interaction.agentSessionId) ?? [];
+    pendingInteractions.push(interaction);
+    pendingInteractionsBySessionId.set(
+      interaction.agentSessionId,
+      pendingInteractions
     );
+  }
+  for (const pendingInteractions of pendingInteractionsBySessionId.values()) {
+    pendingInteractions.sort(compareSessionInteractionsByOccurrence);
+  }
+
+  return Object.values(state.sessionLifecycle.sessionsById).map((session) => {
+    const activeTurn = session.activeTurnId
+      ? (state.sessionLifecycle.turnsById[
+          canonicalTurnKey(session.agentSessionId, session.activeTurnId)
+        ] ?? null)
+      : null;
+    const latestTurn =
+      latestTurnsBySessionId.get(session.agentSessionId) ?? null;
+    const pendingInteractions =
+      pendingInteractionsBySessionId.get(session.agentSessionId) ?? [];
     return {
       activeTurn,
       displayStatus: displayStatusFromCanonicalState({
@@ -496,5 +553,25 @@ function compareInteractionsByOccurrence(
     left.agentSessionId.localeCompare(right.agentSessionId) ||
     left.turnId.localeCompare(right.turnId) ||
     left.requestId.localeCompare(right.requestId)
+  );
+}
+
+function compareSessionInteractionsByOccurrence(
+  left: AgentActivityInteraction,
+  right: AgentActivityInteraction
+): number {
+  return (
+    left.createdAtUnixMs - right.createdAtUnixMs ||
+    left.requestId.localeCompare(right.requestId)
+  );
+}
+
+function compareTurnsByOccurrence(
+  left: AgentActivityTurn,
+  right: AgentActivityTurn
+): number {
+  return (
+    left.startedAtUnixMs - right.startedAtUnixMs ||
+    left.turnId.localeCompare(right.turnId)
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -554,6 +554,14 @@ export function AgentGUINodeView({
       workspaceUserProjectI18n
     ]
   );
+  const agentTargetPresentationKey = JSON.stringify(
+    viewModel.rail.agentTargets.map((target) => [
+      target.agentTargetId ?? null,
+      target.iconUrl ?? null,
+      target.label,
+      target.provider
+    ])
+  );
   const agentTargetPresentations = useMemo<
     readonly AgentMessageMarkdownAgentTarget[]
   >(
@@ -571,7 +579,7 @@ export function AgentGUINodeView({
             ]
           : []
       ),
-    [viewModel.rail.agentTargets, viewModel.shell.workspaceId]
+    [agentTargetPresentationKey, viewModel.shell.workspaceId]
   );
 
   const content = (

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
@@ -50,6 +50,7 @@ import {
 } from "./agentGUIViewUtils";
 import styles from "../AgentGUINode.styles";
 import { useAgentGUIConversationRailViewState } from "./useAgentGUIConversationRailViewState";
+import { useAgentGUIProjectMenuState } from "./useAgentGUIProjectMenuState";
 
 function useDelayedBoolean(value: boolean, delayMs: number): boolean {
   const [delayedValue, setDelayedValue] = useState(false);
@@ -205,9 +206,6 @@ export const AgentGUIConversationRailPane = memo(
       useState<AgentGUIProjectActionDialog | null>(null);
     const [isRequestingBatchDeletion, setIsRequestingBatchDeletion] =
       useState(false);
-    const [openProjectMenuSectionId, setOpenProjectMenuSectionId] = useState<
-      string | null
-    >(null);
     const { railSearch } = railQuery;
     const railElementRef = useRef<HTMLElement | null>(null);
     const railActiveConversationRef = useRef<
@@ -225,6 +223,11 @@ export const AgentGUIConversationRailPane = memo(
       runtimeRailSectionsPending,
       sectionPageStates
     } = railQuery;
+    const { isProjectActionLocked, onProjectMenuOpenChange, projectMenuOpen } =
+      useAgentGUIProjectMenuState(
+        isInteractionLocked,
+        isUserProjectMutationPending
+      );
 
     const railConversationEntitiesById = new Map(
       runtimeRailConversations.map((conversation) => [
@@ -247,7 +250,7 @@ export const AgentGUIConversationRailPane = memo(
       isUserProjectMutationPending ||
       pendingDeleteConversationId !== null ||
       pendingProjectAction !== null ||
-      openProjectMenuSectionId !== null ||
+      projectMenuOpen ||
       previewMode;
     const backendSearchConversations = backendSearchActive
       ? railSearch.sessionIds.flatMap((id) => {
@@ -697,9 +700,7 @@ export const AgentGUIConversationRailPane = memo(
                           : (sectionPageState?.isLoading ?? false)
                       }
                       isRailInteractionLocked={isInteractionLocked}
-                      isProjectActionLocked={() =>
-                        isInteractionLocked() || isUserProjectMutationPending
-                      }
+                      isProjectActionLocked={isProjectActionLocked}
                       projectDragDisabled={projectDragLocked}
                       projectDragging={
                         projectDragState !== null &&
@@ -757,15 +758,7 @@ export const AgentGUIConversationRailPane = memo(
                       onProjectDragEnd={clearProjectDrag}
                       onProjectDragOver={updateProjectDropTarget}
                       onProjectDrop={dropProject}
-                      onProjectMenuOpenChange={(open) => {
-                        setOpenProjectMenuSectionId((current) =>
-                          open
-                            ? section.id
-                            : current === section.id
-                              ? null
-                              : current
-                        );
-                      }}
+                      onProjectMenuOpenChange={onProjectMenuOpenChange}
                     />
                   </Fragment>
                 );

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailSection.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailSection.tsx
@@ -87,7 +87,7 @@ interface AgentGUIConversationRailSectionProps {
     event: React.DragEvent<HTMLElement>
   ) => void;
   onProjectDrop: (event: React.DragEvent<HTMLElement>) => void;
-  onProjectMenuOpenChange: (open: boolean) => void;
+  onProjectMenuOpenChange: (sectionId: string, open: boolean) => void;
 }
 
 export const AgentGUIConversationRailSection = memo(
@@ -146,6 +146,10 @@ export const AgentGUIConversationRailSection = memo(
     const isProjectSection = section.kind === "project";
     const projectPinned = (section.project?.pinnedAtUnixMs ?? 0) > 0;
     const projectId = section.project?.id?.trim() ?? "";
+    const handleProjectMenuOpenChange = useCallback(
+      (open: boolean) => onProjectMenuOpenChange(section.id, open),
+      [onProjectMenuOpenChange, section.id]
+    );
     const pageableItems = section.items.filter(
       (item) => item.projectionSource !== "pending_activation"
     );
@@ -360,7 +364,7 @@ export const AgentGUIConversationRailSection = memo(
                 </Tooltip>
               )}
               {projectPath ? (
-                <DropdownMenu onOpenChange={onProjectMenuOpenChange}>
+                <DropdownMenu onOpenChange={handleProjectMenuOpenChange}>
                   {previewMode ? (
                     <DropdownMenuTrigger asChild>
                       <span

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIProjectMenuState.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIProjectMenuState.spec.tsx
@@ -1,0 +1,24 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useAgentGUIProjectMenuState } from "./useAgentGUIProjectMenuState";
+
+describe("useAgentGUIProjectMenuState", () => {
+  it("keeps the active menu lock when an older section closes", () => {
+    const isRailInteractionLocked = () => false;
+    const { result } = renderHook(() =>
+      useAgentGUIProjectMenuState(isRailInteractionLocked, false)
+    );
+    const onProjectMenuOpenChange = result.current.onProjectMenuOpenChange;
+
+    act(() => onProjectMenuOpenChange("project-a", true));
+    act(() => onProjectMenuOpenChange("project-b", true));
+    act(() => onProjectMenuOpenChange("project-a", false));
+    expect(result.current.projectMenuOpen).toBe(true);
+
+    act(() => onProjectMenuOpenChange("project-b", false));
+    expect(result.current.projectMenuOpen).toBe(false);
+    expect(result.current.onProjectMenuOpenChange).toBe(
+      onProjectMenuOpenChange
+    );
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIProjectMenuState.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIProjectMenuState.ts
@@ -1,0 +1,29 @@
+import { useCallback, useState } from "react";
+
+export function useAgentGUIProjectMenuState(
+  isRailInteractionLocked: () => boolean,
+  isUserProjectMutationPending: boolean
+): {
+  isProjectActionLocked: () => boolean;
+  onProjectMenuOpenChange: (sectionId: string, open: boolean) => void;
+  projectMenuOpen: boolean;
+} {
+  const [openSectionId, setOpenSectionId] = useState<string | null>(null);
+  const isProjectActionLocked = useCallback(
+    () => isRailInteractionLocked() || isUserProjectMutationPending,
+    [isRailInteractionLocked, isUserProjectMutationPending]
+  );
+  const onProjectMenuOpenChange = useCallback(
+    (sectionId: string, open: boolean) => {
+      setOpenSectionId((current) =>
+        open ? sectionId : current === sectionId ? null : current
+      );
+    },
+    []
+  );
+  return {
+    isProjectActionLocked,
+    onProjectMenuOpenChange,
+    projectMenuOpen: openSectionId !== null
+  };
+}

--- a/packages/workbench/surface/src/core/reducer.test.ts
+++ b/packages/workbench/surface/src/core/reducer.test.ts
@@ -390,6 +390,23 @@ test("recomputes fullscreen nodes against the bottom edge when surface size chan
   });
 });
 
+test("preserves unchanged floating node references when surface size changes", () => {
+  const state = createWorkbenchInitialState({
+    surfaceSize: { width: 900, height: 600 },
+    nodes: [makeNode("floating")],
+    nodeStack: ["floating"]
+  });
+  const nextState = reduceWorkbenchState(state, {
+    type: "setSurfaceSize",
+    size: { width: 960, height: 640 }
+  });
+
+  assert.notEqual(nextState, state);
+  assert.equal(nextState.nodes, state.nodes);
+  assert.equal(nextState.nodes[0], state.nodes[0]);
+  assert.equal(nextState.nodes[0]?.frame, state.nodes[0]?.frame);
+});
+
 test("keeps floating nodes visible near the bottom when surface size changes", () => {
   let state = createWorkbenchInitialState({
     surfaceSize: { width: 900, height: 600 },

--- a/packages/workbench/surface/src/core/reducer.ts
+++ b/packages/workbench/surface/src/core/reducer.ts
@@ -356,30 +356,29 @@ export function reduceWorkbenchState<TData>(
       ) {
         return state;
       }
+      const resizedNodes = state.nodes.map((node) => {
+        const frame =
+          node.displayMode === "fullscreen"
+            ? getWorkbenchFullscreenRect(
+                action.size,
+                state.layoutConstraints,
+                node.sizeConstraints
+              )
+            : clampWorkbenchRectToVisibleArea(
+                node.frame,
+                action.size,
+                state.layoutConstraints,
+                undefined,
+                node.sizeConstraints
+              );
+        return rectsEqual(node.frame, frame) ? node : { ...node, frame };
+      });
       const resizedState: WorkbenchState<TData> = {
         ...state,
         surfaceSize: action.size,
-        nodes: state.nodes.map((node) =>
-          node.displayMode === "fullscreen"
-            ? {
-                ...node,
-                frame: getWorkbenchFullscreenRect(
-                  action.size,
-                  state.layoutConstraints,
-                  node.sizeConstraints
-                )
-              }
-            : {
-                ...node,
-                frame: clampWorkbenchRectToVisibleArea(
-                  node.frame,
-                  action.size,
-                  state.layoutConstraints,
-                  undefined,
-                  node.sizeConstraints
-                )
-              }
-        )
+        nodes: resizedNodes.every((node, index) => node === state.nodes[index])
+          ? state.nodes
+          : resizedNodes
       };
       // When a layout is locked, re-apply the layout at the new surface size so
       // the locked nodes keep scaling proportionally with the window. Preserve


### PR DESCRIPTION
## Summary

- Preserve Workbench node and node-array identity when a surface resize leaves frames unchanged, preventing deep AgentGUI rerenders from referentially new but equal frames.
- Stabilize project-menu callbacks and Agent Target presentation projections while preserving menu locking and rendered values.
- Replace repeated per-session Turn and Interaction scans in workspace activity selectors with one-pass grouping; preserve canonical filtering and ordering.
- Add regression coverage for Workbench structural sharing and project-menu state semantics.
- Add a repository-local `analyze-performance-traces` skill plus a bounded-memory Chromium trace summarizer, extracting the evidence-first and behavior-preserving optimization workflow used for this fix.

Trace evidence showed 34 conversation rail sections rerendering 67 times during resize bursts, full-root layouts across roughly 8,000 elements, and repeated Turn scans against a large session history. This change targets those sources without changing scheduling, animation rate, interaction behavior, or visible output.

Agent Host boundary decision: no session, Turn, goal, or runtime-operation lifecycle semantics change. Changes are canonical selector and presentation-performance work only.

## Verification

- `pnpm check:changed --tail-lines 80` — 12 lanes passed
- `pnpm check:full` — 19 tasks passed after each pushed commit
- `pnpm lint:ts`
- `pnpm --filter @tutti-os/workbench-surface test` — 217 tests passed
- `pnpm --filter @tutti-os/agent-activity-core test` — 208 tests passed
- Targeted AgentGUI Vitest coverage for rail sections, view-model render budgets, and project-menu state
- Typecheck passed for `@tutti-os/workbench-surface`, `@tutti-os/agent-activity-core`, and `@tutti-os/agent-gui`
- Skill validation passed with `quick_validate.py`
- Trace summarizer streamed the original 188 MB trace: 732,526 events, 15.005 seconds, and 218 events at or above 50 ms

## Checklist

- [x] No agent lifecycle semantics changed; Agent Host conformance changes are not applicable.
- [x] I kept the change focused on one performance-analysis and optimization concern.
- [x] Durable performance-analysis guidance is captured by the repository-local skill; no other documentation is affected.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the meaningful local checks for the changed surface.
- [x] Both commits are signed off with DCO.
