### PR TITLE
fix(agent): share Codex model cache across runs

### DIFF
--- a/packages/agent/runtimeprep/README.md
+++ b/packages/agent/runtimeprep/README.md
@@ -34,6 +34,14 @@ prepared, err := preparer.Prepare(ctx, runtimeprep.PrepareInput{
 process environment. `Cleanup` removes only paths recorded in the session
 manifest or the session-scoped runtime root.
 
+Codex preparation keeps session state isolated under the run-scoped
+`CODEX_HOME`, while linking its writable `models_cache.json` to the provider
+user's process-default `~/.codex/models_cache.json`. The link may initially be
+dangling: the first Codex refresh creates the shared VM- or host-local cache,
+and later sessions reuse it. Hosts must therefore run preparation with `HOME`
+set to the provider user's stable local Home, never a session runtime directory
+or a remote filesystem projection.
+
 ## Capability Packs
 
 A deployment capability resolves once into its policy, skills, and environment

--- a/packages/agent/runtimeprep/codex.go
+++ b/packages/agent/runtimeprep/codex.go
@@ -129,6 +129,9 @@ func exposeUserCodexFiles(codexHome string) error {
 			}
 		}
 	}
+	if err := exposeUserCodexModelsCache(codexHome, userCodexHome); err != nil {
+		return err
+	}
 	if err := exposeUserCodexPluginState(codexHome, userCodexHome); err != nil {
 		return err
 	}

--- a/packages/agent/runtimeprep/codex_models_cache.go
+++ b/packages/agent/runtimeprep/codex_models_cache.go
@@ -1,0 +1,50 @@
+package runtimeprep
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// exposeUserCodexModelsCache gives every run-scoped CODEX_HOME one shared,
+// process-default model cache. Codex refreshes models_cache.json before it emits
+// thread.started; keeping that writable cache behind a symlink lets a refresh
+// from one AgentGUI session remove the cold catalog request from later sessions.
+//
+// The link is installed even before the source exists. Codex treats the first
+// read as a cache miss, then its normal write creates the source file through
+// the link. An existing run-scoped cache remains authoritative for that run and
+// is never replaced during resume preparation.
+func exposeUserCodexModelsCache(codexHome, userCodexHome string) error {
+	target := filepath.Join(codexHome, "models_cache.json")
+	if _, err := os.Lstat(target); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect codex models cache: %w", err)
+	}
+
+	if err := os.MkdirAll(userCodexHome, 0o700); err != nil {
+		return fmt.Errorf("create shared codex home for models cache: %w", err)
+	}
+	source := filepath.Join(userCodexHome, "models_cache.json")
+	symlinkErr := os.Symlink(source, target)
+	if symlinkErr == nil {
+		return nil
+	}
+	info, statErr := os.Stat(source)
+	if os.IsNotExist(statErr) {
+		// Platforms that cannot create the link have no cache to copy yet. The
+		// run remains usable and Codex will create its ordinary local cache.
+		return nil
+	}
+	if statErr != nil {
+		return fmt.Errorf("inspect shared codex models cache after symlink failure: %w", statErr)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("shared codex models cache is a directory: %s", source)
+	}
+	if copyErr := copyFile(source, target, 0o600); copyErr != nil {
+		return fmt.Errorf("expose codex models cache: symlink failed: %v; copy failed: %w", symlinkErr, copyErr)
+	}
+	return nil
+}

--- a/packages/agent/runtimeprep/preparer_test.go
+++ b/packages/agent/runtimeprep/preparer_test.go
@@ -20,6 +20,9 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 	if err := os.WriteFile(filepath.Join(userCodexHome, "auth.json"), []byte(`{"token":"test"}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(userCodexHome, "models_cache.json"), []byte(`{"models":["cached"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	userCodexConfig := strings.Join([]string{
 		`notify = ["say", "done"]`,
 		`model_provider = "proxy"`,
@@ -119,6 +122,49 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 	}
 	if _, err := os.Lstat(filepath.Join(codexHome, "auth.json")); err != nil {
 		t.Fatalf("codex auth not exposed: %v", err)
+	}
+	modelsCachePath := filepath.Join(codexHome, "models_cache.json")
+	modelsCacheInfo, err := os.Lstat(modelsCachePath)
+	if err != nil {
+		t.Fatalf("codex models cache not exposed: %v", err)
+	}
+	if modelsCacheInfo.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("codex models cache should be a symlink, got mode %v", modelsCacheInfo.Mode())
+	}
+	modelsCacheTarget, err := os.Readlink(modelsCachePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(userCodexHome, "models_cache.json"); modelsCacheTarget != want {
+		t.Fatalf("codex models cache symlink target = %q, want %q", modelsCacheTarget, want)
+	}
+	if err := os.WriteFile(modelsCachePath, []byte(`{"models":["refreshed"]}`), 0o600); err != nil {
+		t.Fatalf("refresh run-scoped codex models cache: %v", err)
+	}
+	sharedModelsCache, err := os.ReadFile(filepath.Join(userCodexHome, "models_cache.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(sharedModelsCache), `{"models":["refreshed"]}`; got != want {
+		t.Fatalf("shared codex models cache = %q, want %q", got, want)
+	}
+	secondPrepared, err := NewDefaultPreparer(t.TempDir()).Prepare(t.Context(), PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-2",
+		AgentTargetID:  "local:codex",
+		Provider:       "codex",
+		Cwd:            cwd,
+	})
+	if err != nil {
+		t.Fatalf("prepare second Codex session: %v", err)
+	}
+	secondModelsCachePath := filepath.Join(envValue(secondPrepared.Env, "CODEX_HOME"), "models_cache.json")
+	secondModelsCache, err := os.ReadFile(secondModelsCachePath)
+	if err != nil {
+		t.Fatalf("read second session Codex models cache: %v", err)
+	}
+	if got, want := string(secondModelsCache), `{"models":["refreshed"]}`; got != want {
+		t.Fatalf("second session Codex models cache = %q, want %q", got, want)
 	}
 	catalogLink, err := os.Lstat(filepath.Join(codexHome, "cc-switch-model-catalog.json"))
 	if err != nil {
@@ -328,6 +374,69 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 	}
 	if envValue(prepared.Env, "TUTTI_WORKSPACE_ID") != "workspace-1" {
 		t.Fatalf("prepared env = %#v, want workspace id", prepared.Env)
+	}
+}
+
+func TestExposeUserCodexModelsCacheSharesFirstRefreshAcrossSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	userCodexHome := filepath.Join(home, ".codex")
+	firstCodexHome := t.TempDir()
+	if err := exposeUserCodexModelsCache(firstCodexHome, userCodexHome); err != nil {
+		t.Fatal(err)
+	}
+
+	firstCachePath := filepath.Join(firstCodexHome, "models_cache.json")
+	info, err := os.Lstat(firstCachePath)
+	if err != nil {
+		t.Fatalf("first session models cache link missing: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("first session models cache mode = %v, want symlink", info.Mode())
+	}
+	if _, err := os.Stat(filepath.Join(userCodexHome, "models_cache.json")); !os.IsNotExist(err) {
+		t.Fatalf("shared models cache should not exist before first provider refresh, err = %v", err)
+	}
+	if err := os.WriteFile(firstCachePath, []byte(`{"models":["first-refresh"]}`), 0o600); err != nil {
+		t.Fatalf("write first session models cache: %v", err)
+	}
+
+	secondCodexHome := t.TempDir()
+	if err := exposeUserCodexModelsCache(secondCodexHome, userCodexHome); err != nil {
+		t.Fatal(err)
+	}
+	secondCache, err := os.ReadFile(filepath.Join(secondCodexHome, "models_cache.json"))
+	if err != nil {
+		t.Fatalf("read second session models cache: %v", err)
+	}
+	if got, want := string(secondCache), `{"models":["first-refresh"]}`; got != want {
+		t.Fatalf("second session models cache = %q, want %q", got, want)
+	}
+}
+
+func TestExposeUserCodexModelsCachePreservesExistingRunCache(t *testing.T) {
+	userCodexHome := filepath.Join(t.TempDir(), ".codex")
+	codexHome := t.TempDir()
+	target := filepath.Join(codexHome, "models_cache.json")
+	if err := os.WriteFile(target, []byte(`{"models":["session-local"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := exposeUserCodexModelsCache(codexHome, userCodexHome); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("existing run cache mode = %v, want regular file", info.Mode())
+	}
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(content), `{"models":["session-local"]}`; got != want {
+		t.Fatalf("existing run cache = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- expose the provider user's stable `~/.codex/models_cache.json` inside every run-scoped `CODEX_HOME`
- create the symlink before the shared cache exists so the first Codex refresh warms later AgentGUI and embedded-app sessions
- preserve existing run-local caches when resuming a session and retain a copy fallback where symlinks are unavailable
- document the stable provider Home contract and cover existing-cache, first-refresh, and cross-session reuse

## Why

AgentGUI and embedded apps intentionally launch Codex with a session-scoped `CODEX_HOME`. Auth, config, plugins, and skills were projected from the stable provider Home, but `models_cache.json` was omitted. Every new agent session therefore fetched the model catalog before `thread.started`, even when `~/.codex/models_cache.json` was already warm.

## Validation

- `go test -race ./...` (`packages/agent/runtimeprep`)
- `go vet ./...` (`packages/agent/runtimeprep`)
- `git diff --check origin/main...HEAD`

## Documentation impact

Updated `packages/agent/runtimeprep/README.md`; no AgentGUI protocol or UI contract changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->