### PR TITLE
fix(agent-gui): pin turn disclosure row during expansion

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -272,10 +272,17 @@ reveal height. Do not place a conditionally mounted reveal directly in a parent
 a terminal height jump. A reveal that has settled to `height: auto` must keep
 tracking content resizes and lock its current rendered height before collapse,
 so streaming or asynchronously rendered work cannot collapse from a stale
-measurement. In virtualized transcripts, the virtualizer is the sole scroll
-anchor owner; opt its measured subtree out of browser-native scroll anchoring
-to avoid two independent corrections moving the whole timeline and then
-snapping it back.
+measurement. In virtualized transcripts, the virtualizer owns scroll anchoring
+during normal rendering and streaming; opt its measured subtree out of
+browser-native scroll anchoring to avoid two independent corrections moving the
+whole timeline and then snapping it back. An explicit user Turn-disclosure
+animation temporarily transfers that ownership to the disclosure-motion
+controller, which captures the trigger row's viewport position and holds it
+until every affected reveal height settles. During that motion it opts out of
+both browser-native scroll anchoring and the virtualizer's end anchor and
+item-size adjustment, and it corrects any outer timeline scroll change against
+the captured row. When the motion settles, ownership returns to the virtualizer
+for subsequent rendering and streaming updates.
 
 Generic processing fallback is decided only after transcript normalization has
 removed diagnostic-only notices and merged presentation rows. Canonical live

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
@@ -18,6 +18,7 @@ import { useAgentTurnDisclosureStore } from "./AgentTurnDisclosureContext";
 import { AgentTurnWorkSection } from "./AgentTurnWorkSection";
 import { buildAgentTurnWorkSectionModel } from "./agentTurnWorkSectionModel";
 import { assessAgentTranscriptComplexity } from "./agentTranscriptComplexity";
+import { useTurnDisclosureMotion } from "./useTurnDisclosureMotion";
 import {
   AgentMessageLocatorRail,
   findMessageLocatorScrollParent,
@@ -39,6 +40,7 @@ const AGENT_TRANSCRIPT_ESTIMATED_TURN_HEIGHT_PX = 280;
 const AGENT_TRANSCRIPT_DISCLOSURE_TURN_GAP_PX = 24;
 const AGENT_TRANSCRIPT_LEGACY_TURN_GAP_PX = 12;
 const AGENT_TRANSCRIPT_FALLBACK_TURN_COUNT = 3;
+const preventVirtualScrollAdjustment = () => false;
 interface AgentTranscriptViewProps {
   conversation: AgentConversationVM;
   onLinkAction?: (action: WorkspaceLinkAction) => void;
@@ -163,6 +165,8 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
   const [expandedToolRows, setExpandedToolRows] = useState<
     Record<string, boolean>
   >({});
+  const [hasMovingTurnDisclosure, handleDisclosureMotionChange] =
+    useTurnDisclosureMotion();
   const turnDisclosureStore = useAgentTurnDisclosureStore();
   const virtualizerHostRef = useRef<HTMLDivElement | null>(null);
   const [virtualScrollElement, setVirtualScrollElement] =
@@ -247,7 +251,7 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
     [turnGroups]
   );
   const rowVirtualizer = useVirtualizer({
-    anchorTo: "end",
+    anchorTo: shouldVirtualize && hasMovingTurnDisclosure ? "start" : "end",
     count: turnGroups.length,
     estimateSize: () => AGENT_TRANSCRIPT_ESTIMATED_TURN_HEIGHT_PX,
     getItemKey: (index) => turnGroups[index]?.key ?? index,
@@ -255,6 +259,10 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
     overscan: AGENT_TRANSCRIPT_VIRTUALIZATION_OVERSCAN,
     scrollEndThreshold: 24
   });
+  rowVirtualizer.shouldAdjustScrollPositionOnItemSizeChange =
+    shouldVirtualize && hasMovingTurnDisclosure
+      ? preventVirtualScrollAdjustment
+      : undefined;
   const handleLocateUserMessage = useCallback(
     (item: AgentMessageLocatorItem) => {
       const scrollParent = virtualizerHostRef.current
@@ -386,6 +394,7 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
           dividerRowIndexes.has(rowIndex)
         )}
         disclosureStore={turnDisclosureStore}
+        onDisclosureMotionChange={handleDisclosureMotionChange}
         renderRow={renderRow}
       />
     );

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.virtual.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.virtual.spec.tsx
@@ -12,7 +12,12 @@ import type { AgentTranscriptRowVM } from "../contracts/agentTranscriptRowVM";
 
 const virtualizerMockState = vi.hoisted(() => ({
   virtualIndexes: [100, 101, 102, 103, 104],
-  scrollToIndex: vi.fn()
+  scrollToIndex: vi.fn(),
+  instance: {
+    shouldAdjustScrollPositionOnItemSizeChange: undefined as
+      | undefined
+      | (() => boolean)
+  }
 }));
 
 vi.mock("../../../i18n/index", () => ({
@@ -24,18 +29,20 @@ vi.mock("../../../i18n/index", () => ({
 }));
 
 vi.mock("@tanstack/react-virtual", () => ({
-  useVirtualizer: vi.fn(() => ({
-    getTotalSize: () => 20000,
-    getVirtualItems: () =>
-      virtualizerMockState.virtualIndexes.map((index) => ({
-        index,
-        key: `virtual-${index}`,
-        start: index * 100,
-        size: 100
-      })),
-    measureElement: vi.fn(),
-    scrollToIndex: virtualizerMockState.scrollToIndex
-  }))
+  useVirtualizer: vi.fn(() =>
+    Object.assign(virtualizerMockState.instance, {
+      getTotalSize: () => 20000,
+      getVirtualItems: () =>
+        virtualizerMockState.virtualIndexes.map((index) => ({
+          index,
+          key: `virtual-${index}`,
+          start: index * 100,
+          size: 100
+        })),
+      measureElement: vi.fn(),
+      scrollToIndex: virtualizerMockState.scrollToIndex
+    })
+  )
 }));
 
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -44,6 +51,8 @@ import { AgentTranscriptView } from "./AgentTranscriptView";
 describe("AgentTranscriptView virtual rendering", () => {
   beforeEach(() => {
     virtualizerMockState.scrollToIndex.mockClear();
+    virtualizerMockState.instance.shouldAdjustScrollPositionOnItemSizeChange =
+      undefined;
   });
 
   it("does not virtualize normal short conversations", () => {
@@ -144,6 +153,14 @@ describe("AgentTranscriptView virtual rendering", () => {
     expect(
       screen.queryByRole("button", { name: "Thought process" })
     ).toBeNull();
+    const timeline = screen.getByTestId("agent-gui-timeline");
+    const header = document.querySelector<HTMLElement>(
+      "[data-agent-turn-work-header='turn-10']"
+    )!;
+    timeline.scrollTop = 900;
+    vi.spyOn(header, "getBoundingClientRect").mockImplementation(
+      () => ({ top: 80 - (timeline.scrollTop - 900) }) as DOMRect
+    );
 
     fireEvent.click(
       screen.getByRole("button", {
@@ -151,10 +168,21 @@ describe("AgentTranscriptView virtual rendering", () => {
       })
     );
 
-    await flushCollapsibleRevealFrames();
+    expect(vi.mocked(useVirtualizer).mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({ anchorTo: "start" })
+    );
     expect(
-      screen.getByRole("button", { name: "Thought process" })
-    ).toBeTruthy();
+      virtualizerMockState.instance.shouldAdjustScrollPositionOnItemSizeChange?.()
+    ).toBe(false);
+    expect(timeline.style.getPropertyValue("overflow-anchor")).toBe("none");
+    timeline.scrollTop = 940;
+    fireEvent.scroll(timeline);
+    expect(timeline.scrollTop).toBe(900);
+
+    await flushCollapsibleRevealFrames();
+    const reveal = screen
+      .getByRole("button", { name: "Thought process" })
+      .closest(".agent-collapsible-reveal");
     expect(
       document.querySelector("[data-agent-transcript-virtual-turn='turn-10']")
     ).toBeTruthy();
@@ -163,6 +191,59 @@ describe("AgentTranscriptView virtual rendering", () => {
         "[data-agent-transcript-virtual-turn='turn-10']"
       )?.style.paddingBottom
     ).toBe("24px");
+    fireEvent.transitionEnd(reveal as HTMLElement, {
+      propertyName: "height"
+    });
+
+    await waitFor(() => {
+      expect(vi.mocked(useVirtualizer).mock.calls.at(-1)?.[0]).toEqual(
+        expect.objectContaining({ anchorTo: "end" })
+      );
+      expect(
+        virtualizerMockState.instance.shouldAdjustScrollPositionOnItemSizeChange
+      ).toBeUndefined();
+    });
+    timeline.scrollTop = 940;
+    fireEvent.scroll(timeline);
+    expect(timeline.scrollTop).toBe(940);
+    expect(timeline.style.getPropertyValue("overflow-anchor")).toBe("");
+  });
+
+  it("pins a disclosure row in a non-virtual transcript", () => {
+    render(
+      <div
+        data-testid="agent-gui-timeline"
+        style={{ height: "480px", overflow: "auto" }}
+      >
+        <AgentTranscriptView
+          conversation={conversationWithCollapsibleTurns(2)}
+          labels={{
+            thinkingLabel: "Thought process",
+            toolCallsLabel: (count) => `Tool calls (${count})`,
+            processing: "Planning next moves",
+            turnSummary: "Changed files"
+          }}
+        />
+      </div>
+    );
+    const timeline = screen.getByTestId("agent-gui-timeline");
+    const header = document.querySelector<HTMLElement>(
+      "[data-agent-turn-work-header='turn-0']"
+    )!;
+    timeline.scrollTop = 200;
+    vi.spyOn(header, "getBoundingClientRect").mockImplementation(
+      () => ({ top: 40 - (timeline.scrollTop - 200) }) as DOMRect
+    );
+
+    fireEvent.click(
+      screen.getAllByRole("button", {
+        name: "agentHost.agentGui.expandTurnWork"
+      })[0]!
+    );
+    timeline.scrollTop = 240;
+    fireEvent.scroll(timeline);
+
+    expect(timeline.scrollTop).toBe(200);
   });
 
   it("enables virtualization once the transcript reaches 30 turns", () => {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTurnWorkSection.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTurnWorkSection.spec.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { AgentActivityTurn } from "@tutti-os/agent-activity-core";
 import type { JSX } from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -227,6 +227,37 @@ describe("AgentTurnWorkSection", () => {
     expect(screen.getByText("Follow-up")).toBeTruthy();
     expect(screen.getByText("Final answer")).toBeTruthy();
     expect(screen.queryByText("tools")).toBeNull();
+  });
+
+  it("makes the duration text part of the turn disclosure button", () => {
+    const setExpandedOverride = vi.fn();
+    render(
+      <AgentTurnWorkSection
+        group={interleavedTurnGroup()}
+        sessionId="session-1"
+        turn={canonicalTurn({
+          phase: "settled",
+          outcome: "completed",
+          settledAtUnixMs: 15_000
+        })}
+        isActiveTurn={false}
+        disclosureStore={{
+          expandedOverrides: {},
+          setExpandedOverride
+        }}
+        renderRow={(row) => <div key={row.id}>{row.id}</div>}
+      />
+    );
+
+    const duration = screen.getByText("agentHost.agentGui.turnTotalSeconds");
+    const toggle = screen.getByRole("button", {
+      name: "agentHost.agentGui.expandTurnWork"
+    });
+    expect(toggle).toContainElement(duration);
+
+    fireEvent.click(duration);
+
+    expect(setExpandedOverride).toHaveBeenCalledWith("session-1:turn-1", true);
   });
 
   it("keeps dynamic section spacing inside the animated height", () => {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTurnWorkSection.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTurnWorkSection.tsx
@@ -1,5 +1,5 @@
-import type { JSX, ReactNode } from "react";
-import { BareIconButton } from "@tutti-os/ui-system/components";
+import { useCallback, useRef, type JSX, type ReactNode } from "react";
+import { Button } from "@tutti-os/ui-system/components";
 import { ChevronDownIcon } from "@tutti-os/ui-system/icons";
 import { useTranslation } from "../../../i18n/index";
 import { CollapsibleReveal } from "./CollapsibleReveal";
@@ -19,6 +19,11 @@ interface AgentTurnWorkSectionProps {
   turnKey: string;
   showDivider?: boolean;
   disclosureStore: AgentTurnDisclosureStore;
+  onDisclosureMotionChange?: (
+    turnKey: string,
+    active: boolean,
+    anchorElement?: HTMLElement | null
+  ) => void;
   renderRow: (
     row: AgentTurnWorkSectionRow["row"],
     rowIndex: number,
@@ -32,6 +37,7 @@ export function AgentTurnWorkSection({
   turnKey,
   showDivider = false,
   disclosureStore,
+  onDisclosureMotionChange,
   renderRow
 }: AgentTurnWorkSectionProps): JSX.Element {
   const { t } = useTranslation();
@@ -43,6 +49,41 @@ export function AgentTurnWorkSection({
   const toggleLabel = expanded
     ? t("agentHost.agentGui.collapseTurnWork")
     : t("agentHost.agentGui.expandTurnWork");
+  const pendingRevealTransitionsRef = useRef(0);
+  const disclosureMotionActiveRef = useRef(false);
+  const collapsibleSectionCount = model.sections.reduce(
+    (count, section) =>
+      count + (section.kind === "work" && model.collapseEligible ? 1 : 0),
+    0
+  );
+  const finishDisclosureMotion = useCallback(() => {
+    if (!disclosureMotionActiveRef.current) {
+      return;
+    }
+    disclosureMotionActiveRef.current = false;
+    pendingRevealTransitionsRef.current = 0;
+    onDisclosureMotionChange?.(turnKey, false);
+  }, [onDisclosureMotionChange, turnKey]);
+  const startDisclosureMotion = useCallback(
+    (anchorElement: HTMLElement | null) => {
+      pendingRevealTransitionsRef.current = collapsibleSectionCount;
+      if (collapsibleSectionCount === 0) {
+        return;
+      }
+      disclosureMotionActiveRef.current = true;
+      onDisclosureMotionChange?.(turnKey, true, anchorElement);
+    },
+    [collapsibleSectionCount, onDisclosureMotionChange, turnKey]
+  );
+  const handleRevealTransitionEnd = useCallback(() => {
+    if (!disclosureMotionActiveRef.current) {
+      return;
+    }
+    pendingRevealTransitionsRef.current -= 1;
+    if (pendingRevealTransitionsRef.current <= 0) {
+      finishDisclosureMotion();
+    }
+  }, [finishDisclosureMotion]);
 
   return (
     <div className="grid min-w-0" data-agent-turn-work-section={turnKey}>
@@ -62,25 +103,36 @@ export function AgentTurnWorkSection({
         className="flex min-h-6 items-center gap-0.5 text-[12px] text-[var(--text-tertiary)]"
         data-agent-turn-work-header={turnKey}
       >
-        <AgentTurnDurationLabel timing={model.timing} />
         {model.collapseEligible ? (
-          <BareIconButton
-            size="sm"
+          <Button
+            type="button"
+            variant="chrome"
+            size="xs"
+            className="-ml-2 gap-0.5 px-2 text-[12px] font-normal"
             aria-label={toggleLabel}
             aria-expanded={expanded}
             title={toggleLabel}
-            onClick={() =>
-              disclosureStore.setExpandedOverride(disclosureKey, !expanded)
-            }
+            onClick={(event) => {
+              startDisclosureMotion(
+                event.currentTarget.closest<HTMLElement>(
+                  "[data-agent-turn-work-header]"
+                )
+              );
+              disclosureStore.setExpandedOverride(disclosureKey, !expanded);
+            }}
           >
+            <AgentTurnDurationLabel timing={model.timing} />
             <ChevronDownIcon
               aria-hidden="true"
+              data-icon="inline-end"
               className={`transition-transform duration-150 ${
                 expanded ? "rotate-0" : "-rotate-90"
               }`}
             />
-          </BareIconButton>
-        ) : null}
+          </Button>
+        ) : (
+          <AgentTurnDurationLabel timing={model.timing} />
+        )}
       </div>
       {model.sections.map((section, sectionIndex) => {
         const content = renderRows(section.rows, renderRow);
@@ -101,6 +153,7 @@ export function AgentTurnWorkSection({
             key={`work:${firstRow?.renderKey ?? firstRow?.row.id ?? sectionIndex}`}
             expanded={expanded}
             innerClassName="grid gap-4 pt-4"
+            onHeightTransitionEnd={handleRevealTransitionEnd}
           >
             {content}
           </CollapsibleReveal>

--- a/packages/agent/gui/shared/agentConversation/components/CollapsibleReveal.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/CollapsibleReveal.spec.tsx
@@ -233,4 +233,57 @@ describe("CollapsibleReveal", () => {
 
     expect(reveal).toHaveStyle({ height: "84px" });
   });
+
+  it("reports a collapsing height transition once when content unmounts", () => {
+    const onHeightTransitionEnd = vi.fn();
+    const { rerender } = render(
+      <CollapsibleReveal expanded onHeightTransitionEnd={onHeightTransitionEnd}>
+        <div>detail content</div>
+      </CollapsibleReveal>
+    );
+    const reveal = screen
+      .getByText("detail content")
+      .closest(".agent-collapsible-reveal");
+
+    rerender(
+      <CollapsibleReveal
+        expanded={false}
+        onHeightTransitionEnd={onHeightTransitionEnd}
+      >
+        <div>detail content</div>
+      </CollapsibleReveal>
+    );
+    fireEvent.transitionEnd(reveal as HTMLElement, { propertyName: "height" });
+
+    expect(onHeightTransitionEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an expansion canceled before its mount frame", () => {
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation(() => 1);
+    const onHeightTransitionEnd = vi.fn();
+    const { rerender } = render(
+      <CollapsibleReveal
+        expanded={false}
+        onHeightTransitionEnd={onHeightTransitionEnd}
+      >
+        <div>detail content</div>
+      </CollapsibleReveal>
+    );
+
+    rerender(
+      <CollapsibleReveal expanded onHeightTransitionEnd={onHeightTransitionEnd}>
+        <div>detail content</div>
+      </CollapsibleReveal>
+    );
+    rerender(
+      <CollapsibleReveal
+        expanded={false}
+        onHeightTransitionEnd={onHeightTransitionEnd}
+      >
+        <div>detail content</div>
+      </CollapsibleReveal>
+    );
+
+    expect(onHeightTransitionEnd).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/agent/gui/shared/agentConversation/components/CollapsibleReveal.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/CollapsibleReveal.tsx
@@ -15,6 +15,7 @@ interface CollapsibleRevealProps {
   children: ReactNode;
   className?: string;
   innerClassName?: string;
+  onHeightTransitionEnd?: () => void;
   preMountOnIdle?: boolean;
 }
 
@@ -23,6 +24,7 @@ export function CollapsibleReveal({
   children,
   className,
   innerClassName,
+  onHeightTransitionEnd,
   preMountOnIdle = false
 }: CollapsibleRevealProps): JSX.Element | null {
   "use memo";
@@ -34,6 +36,22 @@ export function CollapsibleReveal({
   const heightRef = useRef(height);
   const measuredHeightRef = useRef<number | null>(null);
   const previousExpandedRef = useRef(expanded);
+  const heightTransitionPendingRef = useRef(false);
+
+  const setRootRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (
+        rootRef.current !== null &&
+        node === null &&
+        heightTransitionPendingRef.current
+      ) {
+        heightTransitionPendingRef.current = false;
+        onHeightTransitionEnd?.();
+      }
+      rootRef.current = node;
+    },
+    [onHeightTransitionEnd]
+  );
 
   const setRevealHeight = useCallback((nextHeight: string) => {
     heightRef.current = nextHeight;
@@ -48,11 +66,18 @@ export function CollapsibleReveal({
       setMounted(true);
       return undefined;
     }
+    let mountFrameStarted = false;
     const animationFrame = requestAnimationFrame(() => {
+      mountFrameStarted = true;
       setMounted(true);
     });
-    return () => cancelAnimationFrame(animationFrame);
-  }, [expanded, mounted, preMountOnIdle]);
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      if (!mountFrameStarted) {
+        onHeightTransitionEnd?.();
+      }
+    };
+  }, [expanded, mounted, onHeightTransitionEnd, preMountOnIdle]);
 
   useEffect(() => {
     if (!preMountOnIdle || mounted || expanded) {
@@ -88,6 +113,7 @@ export function CollapsibleReveal({
       if (wasExpanded && visible && height === "auto") {
         return undefined;
       }
+      heightTransitionPendingRef.current = true;
       setVisible(false);
       setRevealHeight("0px");
       const animationFrame = requestAnimationFrame(() => {
@@ -99,6 +125,7 @@ export function CollapsibleReveal({
     }
 
     if (!wasExpanded) {
+      heightTransitionPendingRef.current = false;
       setVisible(false);
       setRevealHeight("0px");
       return undefined;
@@ -109,6 +136,7 @@ export function CollapsibleReveal({
     const measuredHeight =
       renderedHeight > 0 ? renderedHeight : (cachedHeight ?? root.scrollHeight);
     measuredHeightRef.current = measuredHeight;
+    heightTransitionPendingRef.current = true;
     setRevealHeight(`${measuredHeight}px`);
     setVisible(false);
     const animationFrame = requestAnimationFrame(() => {
@@ -178,10 +206,12 @@ export function CollapsibleReveal({
     }
     if (visible) {
       setRevealHeight("auto");
-      return;
-    }
-    if (!expanded && !preMountOnIdle) {
+    } else if (!expanded && !preMountOnIdle) {
       setMounted(false);
+    }
+    if (heightTransitionPendingRef.current) {
+      heightTransitionPendingRef.current = false;
+      onHeightTransitionEnd?.();
     }
   };
 
@@ -189,7 +219,7 @@ export function CollapsibleReveal({
 
   return (
     <div
-      ref={rootRef}
+      ref={setRootRef}
       className={["agent-collapsible-reveal", className ?? ""]
         .filter(Boolean)
         .join(" ")}

--- a/packages/agent/gui/shared/agentConversation/components/useTurnDisclosureMotion.ts
+++ b/packages/agent/gui/shared/agentConversation/components/useTurnDisclosureMotion.ts
@@ -1,0 +1,104 @@
+import { useCallback, useRef, useState } from "react";
+import { findMessageLocatorScrollParent } from "./AgentMessageLocatorRail";
+
+interface TurnDisclosureScrollAnchor {
+  release: () => void;
+}
+
+class TurnDisclosureMotionController {
+  private readonly movingTurnKeys = new Set<string>();
+  private scrollAnchor: TurnDisclosureScrollAnchor | null = null;
+
+  setTurnMotionActive(
+    turnKey: string,
+    active: boolean,
+    anchorElement?: HTMLElement | null
+  ): boolean {
+    if (active) {
+      this.movingTurnKeys.add(turnKey);
+      if (anchorElement) {
+        this.scrollAnchor?.release();
+        this.scrollAnchor = lockDisclosureRowPosition(anchorElement);
+      }
+    } else {
+      this.movingTurnKeys.delete(turnKey);
+      if (this.movingTurnKeys.size === 0) {
+        this.scrollAnchor?.release();
+        this.scrollAnchor = null;
+      }
+    }
+    return this.movingTurnKeys.size > 0;
+  }
+}
+
+function lockDisclosureRowPosition(
+  anchorElement: HTMLElement
+): TurnDisclosureScrollAnchor | null {
+  const scrollParent = findMessageLocatorScrollParent(anchorElement);
+  if (!scrollParent) {
+    return null;
+  }
+
+  const anchorTop = anchorElement.getBoundingClientRect().top;
+  const previousOverflowAnchor =
+    scrollParent.style.getPropertyValue("overflow-anchor");
+  const previousOverflowAnchorPriority =
+    scrollParent.style.getPropertyPriority("overflow-anchor");
+  scrollParent.style.setProperty("overflow-anchor", "none");
+
+  const preserveAnchorTop = (): void => {
+    if (!anchorElement.isConnected) {
+      return;
+    }
+    const topDelta = anchorElement.getBoundingClientRect().top - anchorTop;
+    if (Math.abs(topDelta) < 0.5) {
+      return;
+    }
+    scrollParent.scrollTop += topDelta;
+  };
+  scrollParent.addEventListener("scroll", preserveAnchorTop);
+
+  return {
+    release: () => {
+      preserveAnchorTop();
+      scrollParent.removeEventListener("scroll", preserveAnchorTop);
+      if (previousOverflowAnchor) {
+        scrollParent.style.setProperty(
+          "overflow-anchor",
+          previousOverflowAnchor,
+          previousOverflowAnchorPriority
+        );
+      } else {
+        scrollParent.style.removeProperty("overflow-anchor");
+      }
+    }
+  };
+}
+
+export function useTurnDisclosureMotion(): readonly [
+  active: boolean,
+  setTurnMotionActive: (
+    turnKey: string,
+    active: boolean,
+    anchorElement?: HTMLElement | null
+  ) => void
+] {
+  const motionControllerRef = useRef<TurnDisclosureMotionController | null>(
+    null
+  );
+  if (!motionControllerRef.current) {
+    motionControllerRef.current = new TurnDisclosureMotionController();
+  }
+  const motionController = motionControllerRef.current;
+  const [active, setActive] = useState(false);
+  const setTurnMotionActive = useCallback(
+    (turnKey: string, moving: boolean, anchorElement?: HTMLElement | null) => {
+      setActive(
+        motionController.setTurnMotionActive(turnKey, moving, anchorElement)
+      );
+    },
+    [motionController]
+  );
+
+  return [active, setTurnMotionActive];
+}


### PR DESCRIPTION
## Summary

- Expand the Turn-disclosure hit area to include both the duration text and chevron.
- Keep the disclosure trigger row stationary while work content expands below it.
- Coordinate browser scroll anchoring and transcript virtualization during disclosure animations, then return ownership to the virtualizer after the motion settles.
- Preserve existing imported-history behavior; collapsing remains limited to eligible Tutti conversations.
- Add regression coverage for virtualized and non-virtualized transcripts, disclosure controls, and transition cancellation.
- Document scroll-anchor ownership during normal rendering and disclosure animations.

## Verification

- `pnpm --filter @tutti-os/agent-gui test`
- `pnpm lint:ts`
- `pnpm typecheck`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:agent-gui-degradation`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:changed --tail-lines 120`
- Full pre-push validation with Go 1.24.3:
  - `check:full` passed all 19 tasks before the final rebase.
  - `check:changed --push-ready` passed all 9 selected lanes after rebasing onto the latest `main`.

## Fix Scope Justification

- Root cause: expanding a collapsed Turn changes the measured transcript height while browser scroll anchoring and the virtualizer's end anchoring may independently adjust the outer timeline scroll position. This moves the disclosure trigger upward instead of keeping it stationary while content opens below it. The previous icon-only control also excluded the duration text from the clickable area.
- Why can this not be fixed at a lower layer? The generic reveal component owns only its height transition. It does not know the triggering row, the outer timeline scroll container, or the transcript virtualizer. Correct behavior requires the AgentGUI transcript layer to coordinate temporary scroll-anchor ownership, while the reveal component reports transition completion.

## Fallback Three Questions

- Source: the defensive branches handle a disclosure trigger that has been detached or cannot resolve an outer timeline scroll container while React is mounting, unmounting, or replacing transcript content.
- Why can it not be fixed at that source? DOM attachment and scroll-container availability are controlled by the React and host layout lifecycle. The disclosure controller must safely tolerate teardown and non-standard embedding without retaining an invalid anchor.
- Removal condition: these guards can be removed if the disclosure-motion contract guarantees that every active trigger remains connected to a valid timeline scroll container until its transition and cleanup have completed.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. This PR changes presentation behavior only.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. No README or CONTRIBUTING source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->