### PR TITLE
fix(desktop): restore business funnel analytics on the engine send path

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -185,6 +185,56 @@ test("WorkspaceAgentActivityService.activateSession creates target-backed sessio
   });
 });
 
+test("WorkspaceAgentActivityService reports funnel analytics for engine-dispatched activations", async () => {
+  const reportedEvents: { name: string; params?: Record<string, unknown> }[] =
+    [];
+  const service = new WorkspaceAgentActivityService({
+    tuttidClient: {
+      createWorkspaceAgentSession: async () => ({
+        ...workspaceAgentSession({ status: "completed" }),
+        createdAtUnixMs: Date.now()
+      }),
+      listWorkspaceAgentSessions: async () => ({
+        hasMore: false,
+        sessions: [],
+        workspaceId: "ws-1"
+      })
+    } as unknown as TuttidClient,
+    reporterService: {
+      trackEvents: async (events) => {
+        reportedEvents.push(...events);
+      }
+    },
+    runtimeApi: { logTerminalDiagnostic: async () => {} }
+  });
+  const engine = service.getSessionEngine("ws-1");
+  const requestedAtUnixMs = Date.now();
+  engine.dispatch({
+    type: "activation/requested",
+    agentSessionId: "session-1",
+    agentTargetId: "local:codex",
+    clientSubmitId: "submit-1",
+    content: [{ type: "text", text: "hello agent" }],
+    expiresAtUnixMs: requestedAtUnixMs + 45_000,
+    mode: "new",
+    requestedAtUnixMs,
+    requestId: "activation-1",
+    workspaceId: "ws-1"
+  });
+  for (
+    let attempt = 0;
+    attempt < 20 &&
+    !reportedEvents.some((event) => event.name === "agent.message_sent");
+    attempt += 1
+  ) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+
+  const names = reportedEvents.map((event) => event.name);
+  assert.ok(names.includes("agent.session_started"));
+  assert.ok(names.includes("agent.message_sent"));
+});
+
 test("WorkspaceAgentActivityService confirms engine activation from the realtime session upsert", async () => {
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -24,11 +24,13 @@ import type {
   WorkspaceAgentActivityListMessagesInput
 } from "../workspaceAgentActivityService.interface.ts";
 import type { IAgentProviderStatusService } from "../agentProviderStatusService.interface.ts";
+import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
 import type { IWorkspaceUserProjectService } from "../../../workspace-user-project/index.ts";
 import {
   createWorkspaceAgentSessionEngineHost,
   type WorkspaceAgentSessionEngineHost
 } from "./workspaceAgentSessionEngineHost.ts";
+import { createWorkspaceAgentEngineSendAnalytics } from "./workspaceAgentEngineSendAnalytics.ts";
 import { WorkspaceAgentActivityReconcileBridge } from "./workspaceAgentActivityReconcileBridge.ts";
 import {
   agentActivitySessionReconcileDiagnosticDetails,
@@ -76,6 +78,7 @@ export interface WorkspaceAgentActivityServiceDependencies {
   tuttidClient: TuttidClient;
   runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">;
   agentProviderStatusService?: Pick<IAgentProviderStatusService, "refresh">;
+  reporterService?: Pick<IReporterService, "trackEvents">;
   workspaceUserProjectService?: IWorkspaceUserProjectService;
 }
 
@@ -96,9 +99,16 @@ export class WorkspaceAgentActivityService
   >();
   private composerOptionsCommandSequence = 1;
   private sessionMutationSequence = 1;
+  private readonly engineSendAnalytics: ReturnType<
+    typeof createWorkspaceAgentEngineSendAnalytics
+  >;
   constructor(dependencies: WorkspaceAgentActivityServiceDependencies) {
     super(dependencies);
     this.dependencies = dependencies;
+    this.engineSendAnalytics = createWorkspaceAgentEngineSendAnalytics({
+      reporterService: dependencies.reporterService,
+      workspaceUserProjectService: dependencies.workspaceUserProjectService
+    });
     this.queryOperations = new WorkspaceAgentActivityQueryOperations(
       dependencies.tuttidClient
     );
@@ -740,12 +750,52 @@ export class WorkspaceAgentActivityService
 
   protected createEntry(workspaceId: string): WorkspaceAgentActivityEntry {
     return createWorkspaceAgentSessionEngineHost({
-      activateSession: (input) => this.activateSession(input),
-      cancelTurn: (input) => this.cancelTurn(input),
+      // 引擎命令口不经过 createDesktopAgentActivityRuntime,业务漏斗埋点
+      // (agent.session_started / agent.message_sent)在这里补报。
+      activateSession: async (input) => {
+        let activation: Awaited<
+          ReturnType<IWorkspaceAgentActivityService["activateSession"]>
+        >;
+        try {
+          activation = await this.activateSession(input);
+        } catch (error) {
+          await this.engineSendAnalytics.trackSessionActivateFailed(
+            input,
+            error
+          );
+          throw error;
+        }
+        await this.engineSendAnalytics.trackSessionActivated(input, activation);
+        return activation;
+      },
+      cancelTurn: async (input) => {
+        const result = await this.cancelTurn(input);
+        if (result.cancel?.canceled) {
+          await this.engineSendAnalytics.trackTurnCanceled({
+            agentSessionId: input.agentSessionId,
+            provider: this.getSnapshot(workspaceId).sessions.find(
+              (session) => session.agentSessionId === input.agentSessionId
+            )?.provider
+          });
+        }
+        return result;
+      },
       reconcileSession: (command) =>
         this.executeSessionReconcileCommand(command),
       runtimeApi: this.dependencies.runtimeApi,
-      sendInput: (input) => this.sendInput(input),
+      sendInput: async (input) => {
+        let result: Awaited<
+          ReturnType<IWorkspaceAgentActivityService["sendInput"]>
+        >;
+        try {
+          result = await this.sendInput(input);
+        } catch (error) {
+          await this.engineSendAnalytics.trackSendInputFailed(input, error);
+          throw error;
+        }
+        await this.engineSendAnalytics.trackSendInputResolved(input, result);
+        return result;
+      },
       submitInteractive: (input) => this.submitInteractive(input),
       submitPlanDecision: (input) => this.submitPlanDecision(input),
       subscribeSessionEvents: (workspaceId, listener) =>

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentEngineSendAnalytics.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentEngineSendAnalytics.test.ts
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ReporterEventInput } from "../../../analytics/services/reporterService.interface.ts";
+import { createWorkspaceAgentEngineSendAnalytics } from "./workspaceAgentEngineSendAnalytics.ts";
+
+function collectingReporter() {
+  const events: ReporterEventInput[] = [];
+  return {
+    events,
+    reporterService: {
+      trackEvents: async (batch: ReporterEventInput[]) => {
+        events.push(...batch);
+      }
+    }
+  };
+}
+
+function eventNames(events: ReporterEventInput[]): string[] {
+  return events.map((event) => event.name);
+}
+
+const activatedSession = {
+  agentSessionId: "session-1",
+  cwd: "/projects/demo",
+  provider: "claude-code"
+};
+
+test("engine send analytics reports session_started and message_sent for new activations", async () => {
+  const { events, reporterService } = collectingReporter();
+  const analytics = createWorkspaceAgentEngineSendAnalytics({
+    reporterService
+  });
+
+  await analytics.trackSessionActivated(
+    {
+      agentSessionId: "session-1",
+      agentTargetId: "local:claude-code",
+      clientSubmitId: "submit-1",
+      initialContent: [{ type: "text", text: "hello agent" }],
+      mode: "new",
+      settings: { model: "opus", permissionModeId: "ask-before-write" },
+      workspaceId: "ws-1"
+    },
+    {
+      activation: { mode: "new", status: "attached" },
+      session: activatedSession as never
+    } as never
+  );
+
+  const names = eventNames(events);
+  assert.ok(names.includes("agent.session_started"));
+  assert.ok(names.includes("agent.message_sent"));
+  const sessionStarted = events.find(
+    (event) => event.name === "agent.session_started"
+  );
+  assert.equal(sessionStarted?.params?.provider, "claude-code");
+  assert.equal(sessionStarted?.params?.permission_mode, "ask-before-write");
+  assert.equal(sessionStarted?.params?.source, "launchpad");
+  const messageSent = events.find(
+    (event) => event.name === "agent.message_sent"
+  );
+  assert.equal(messageSent?.params?.provider, "claude-code");
+  assert.equal(messageSent?.params?.conversation_index, 1);
+  const nodeResults = events.filter(
+    (event) => event.name === "agent.node_result"
+  );
+  assert.deepEqual(
+    nodeResults.map((event) => event.params?.node),
+    ["activate_session", "session_started_reported", "message_sent_reported"]
+  );
+});
+
+test("engine send analytics skips funnel events for existing-session activations", async () => {
+  const { events, reporterService } = collectingReporter();
+  const analytics = createWorkspaceAgentEngineSendAnalytics({
+    reporterService
+  });
+
+  await analytics.trackSessionActivated(
+    {
+      agentSessionId: "session-1",
+      mode: "existing",
+      workspaceId: "ws-1"
+    },
+    {
+      activation: { mode: "existing", status: "already_attached" },
+      session: activatedSession as never
+    } as never
+  );
+
+  assert.deepEqual(eventNames(events), ["agent.node_result"]);
+});
+
+test("engine send analytics skips funnel events for failed activations", async () => {
+  const { events, reporterService } = collectingReporter();
+  const analytics = createWorkspaceAgentEngineSendAnalytics({
+    reporterService
+  });
+
+  await analytics.trackSessionActivated(
+    {
+      agentSessionId: "session-1",
+      agentTargetId: "local:claude-code",
+      clientSubmitId: "submit-1",
+      mode: "new",
+      workspaceId: "ws-1"
+    },
+    {
+      activation: { mode: "new", status: "failed" },
+      error: { code: "boom", message: "activation failed" },
+      session: activatedSession as never
+    } as never
+  );
+
+  const names = eventNames(events);
+  assert.ok(!names.includes("agent.session_started"));
+  assert.ok(!names.includes("agent.message_sent"));
+  const nodeResult = events.find((event) => event.name === "agent.node_result");
+  assert.equal(nodeResult?.params?.status, "failure");
+});
+
+test("engine send analytics reports message_sent with queue state for sends", async () => {
+  const { events, reporterService } = collectingReporter();
+  const analytics = createWorkspaceAgentEngineSendAnalytics({
+    reporterService
+  });
+
+  await analytics.trackSendInputResolved(
+    {
+      agentSessionId: "session-1",
+      clientSubmitId: "submit-2",
+      content: [{ type: "text", text: "/compact please" }],
+      submitDiagnostics: { queued: true },
+      workspaceId: "ws-1"
+    },
+    {
+      kind: "turn",
+      session: activatedSession,
+      turn: { phase: "submitted" },
+      turnId: "turn-1"
+    } as never
+  );
+
+  const messageSent = events.find(
+    (event) => event.name === "agent.message_sent"
+  );
+  assert.equal(messageSent?.params?.is_queued, true);
+  assert.equal(messageSent?.params?.has_slash_command, true);
+  assert.equal(messageSent?.params?.provider, "claude-code");
+  const nodeResults = events.filter(
+    (event) => event.name === "agent.node_result"
+  );
+  assert.deepEqual(
+    nodeResults.map((event) => event.params?.node),
+    ["send_input_request", "message_sent_reported"]
+  );
+});
+
+test("engine send analytics reports message_stopped for canceled turns", async () => {
+  const { events, reporterService } = collectingReporter();
+  const analytics = createWorkspaceAgentEngineSendAnalytics({
+    reporterService
+  });
+
+  await analytics.trackTurnCanceled({
+    agentSessionId: "session-1",
+    provider: "codex"
+  });
+
+  assert.deepEqual(eventNames(events), ["agent.message_stopped"]);
+  assert.equal(events[0]?.params?.provider, "codex");
+});
+
+test("engine send analytics reports a failed send_input_request node", async () => {
+  const { events, reporterService } = collectingReporter();
+  const analytics = createWorkspaceAgentEngineSendAnalytics({
+    reporterService
+  });
+
+  await analytics.trackSendInputFailed(
+    {
+      agentSessionId: "session-1",
+      clientSubmitId: "submit-3",
+      content: [{ type: "text", text: "hello" }],
+      workspaceId: "ws-1"
+    },
+    new Error("network down")
+  );
+
+  assert.deepEqual(eventNames(events), ["agent.node_result"]);
+  const nodeResult = events[0];
+  assert.equal(nodeResult?.params?.node, "send_input_request");
+  assert.equal(nodeResult?.params?.status, "failure");
+});

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentEngineSendAnalytics.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentEngineSendAnalytics.ts
@@ -1,0 +1,197 @@
+import type { AgentActivityRuntime } from "@tutti-os/agent-gui";
+import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
+import type { IWorkspaceUserProjectService } from "../../../workspace-user-project/index.ts";
+import type { IWorkspaceAgentActivityService } from "../workspaceAgentActivityService.interface.ts";
+import { promptContentDisplayText } from "../desktopAgentRuntimeSubmitDiagnostics.ts";
+import { createAgentMessageSentTracker } from "./agentMessageSentAnalytics.ts";
+import { createAgentMessageStoppedTracker } from "./agentMessageStoppedAnalytics.ts";
+import {
+  createAgentSessionStartedTracker,
+  resolveAgentSessionSource
+} from "./agentSessionStartedAnalytics.ts";
+import {
+  AgentAnalyticsErrorCode,
+  createAgentNodeResultTracker,
+  safeTrackAgentNodeResult
+} from "./agentNodeResultAnalytics.ts";
+import { resolveComposerPermissionMode } from "./desktopAgentHostProjection.ts";
+
+type ActivateSessionInput = Parameters<
+  AgentActivityRuntime["activateSession"]
+>[0];
+type ActivateSessionResult = Awaited<
+  ReturnType<IWorkspaceAgentActivityService["activateSession"]>
+>;
+type SendInputInput = Parameters<
+  IWorkspaceAgentActivityService["sendInput"]
+>[0];
+type SendInputResult = Awaited<
+  ReturnType<IWorkspaceAgentActivityService["sendInput"]>
+>;
+
+export interface WorkspaceAgentEngineSendAnalytics {
+  trackSessionActivateFailed(
+    input: ActivateSessionInput,
+    error: unknown
+  ): Promise<void>;
+  trackSessionActivated(
+    input: ActivateSessionInput,
+    activation: ActivateSessionResult
+  ): Promise<void>;
+  trackSendInputFailed(input: SendInputInput, error: unknown): Promise<void>;
+  trackSendInputResolved(
+    input: SendInputInput,
+    result: SendInputResult
+  ): Promise<void>;
+  trackTurnCanceled(input: {
+    agentSessionId: string;
+    provider: string | null | undefined;
+  }): Promise<void>;
+}
+
+/**
+ * Business-funnel analytics for the session-engine send boundary. The engine
+ * command port dispatches session/activate and queue/sendPrompt straight to
+ * WorkspaceAgentActivityService, bypassing createDesktopAgentActivityRuntime
+ * where agent.session_started / agent.message_sent were historically reported,
+ * so those events (and their renderer node_result probes) must be reported
+ * here to keep parity with the pre-engine funnel.
+ */
+export function createWorkspaceAgentEngineSendAnalytics(input: {
+  reporterNow?: () => number;
+  reporterService?: Pick<IReporterService, "trackEvents">;
+  workspaceUserProjectService?: Pick<
+    IWorkspaceUserProjectService,
+    "isNoProjectPath"
+  >;
+}): WorkspaceAgentEngineSendAnalytics {
+  const messageSentTracker = createAgentMessageSentTracker({
+    reporterNow: input.reporterNow,
+    reporterService: input.reporterService
+  });
+  const messageStoppedTracker = createAgentMessageStoppedTracker({
+    reporterNow: input.reporterNow,
+    reporterService: input.reporterService
+  });
+  const sessionStartedTracker = createAgentSessionStartedTracker({
+    reporterNow: input.reporterNow,
+    reporterService: input.reporterService
+  });
+  const nodeResultTracker = createAgentNodeResultTracker({
+    reporterNow: input.reporterNow,
+    reporterService: input.reporterService
+  });
+  const sessionHasProject = (cwd: string | null | undefined): boolean =>
+    Boolean(cwd?.trim()) &&
+    !(cwd && input.workspaceUserProjectService?.isNoProjectPath(cwd));
+  return {
+    async trackSessionActivateFailed(activateInput, error) {
+      await safeTrackAgentNodeResult(nodeResultTracker, {
+        agentSessionId: activateInput.agentSessionId,
+        error,
+        fallbackErrorCode:
+          activateInput.mode === "existing"
+            ? AgentAnalyticsErrorCode.SessionResumeFailed
+            : AgentAnalyticsErrorCode.SessionCreateFailed,
+        flow: "session_create",
+        node: "activate_session",
+        provider: null,
+        success: false
+      });
+    },
+    async trackSessionActivated(activateInput, activation) {
+      const activationFailed = activation.activation.status === "failed";
+      await safeTrackAgentNodeResult(nodeResultTracker, {
+        agentSessionId: activation.session.agentSessionId,
+        error: activationFailed
+          ? (activation.error?.message ??
+            activation.error?.code ??
+            "Agent session activation failed.")
+          : undefined,
+        fallbackErrorCode:
+          activateInput.mode === "existing"
+            ? AgentAnalyticsErrorCode.SessionResumeFailed
+            : AgentAnalyticsErrorCode.SessionCreateFailed,
+        flow: "session_create",
+        node: "activate_session",
+        provider: activation.session.provider,
+        success: !activationFailed
+      });
+      if (activateInput.mode !== "new" || activationFailed) {
+        return;
+      }
+      await sessionStartedTracker.track({
+        agentSessionId: activation.session.agentSessionId,
+        hasProject: sessionHasProject(activation.session.cwd),
+        model: activateInput.settings?.model,
+        permissionMode: resolveComposerPermissionMode(activateInput.settings),
+        provider: activation.session.provider,
+        source: resolveAgentSessionSource({ mode: activateInput.mode })
+      });
+      await safeTrackAgentNodeResult(nodeResultTracker, {
+        agentSessionId: activation.session.agentSessionId,
+        flow: "session_create",
+        node: "session_started_reported",
+        provider: activation.session.provider,
+        success: true
+      });
+      const initialPrompt = promptContentDisplayText(
+        activateInput.initialContent ?? []
+      );
+      if (!initialPrompt) {
+        return;
+      }
+      await messageSentTracker.track({
+        agentSessionId: activation.session.agentSessionId,
+        prompt: initialPrompt,
+        provider: activation.session.provider
+      });
+      await safeTrackAgentNodeResult(nodeResultTracker, {
+        agentSessionId: activation.session.agentSessionId,
+        flow: "session_create",
+        node: "message_sent_reported",
+        provider: activation.session.provider,
+        success: true
+      });
+    },
+    async trackSendInputFailed(sendInput, error) {
+      await safeTrackAgentNodeResult(nodeResultTracker, {
+        agentSessionId: sendInput.agentSessionId,
+        error,
+        fallbackErrorCode: AgentAnalyticsErrorCode.RuntimeExecFailed,
+        flow: "message_send",
+        node: "send_input_request",
+        provider: null,
+        success: false
+      });
+    },
+    async trackSendInputResolved(sendInput, result) {
+      await safeTrackAgentNodeResult(nodeResultTracker, {
+        agentSessionId: result.session.agentSessionId,
+        flow: "message_send",
+        node: "send_input_request",
+        provider: result.session.provider,
+        success: true
+      });
+      await messageSentTracker.track({
+        agentSessionId: result.session.agentSessionId,
+        isQueued: sendInput.submitDiagnostics?.queued === true,
+        prompt: promptContentDisplayText(sendInput.content),
+        provider: result.session.provider
+      });
+      await safeTrackAgentNodeResult(nodeResultTracker, {
+        agentSessionId: result.session.agentSessionId,
+        flow: "message_send",
+        node: "message_sent_reported",
+        provider: result.session.provider,
+        success: true
+      });
+    },
+    async trackTurnCanceled(cancelInput) {
+      await messageStoppedTracker.track({
+        agentSessionId: cancelInput.agentSessionId,
+        provider: cancelInput.provider ?? ""
+      });
+    }
+  };
+}


### PR DESCRIPTION
## 问题

0.2.x 起 agent-gui 会话引擎成为发送边界后，`session/activate` 和 `queue/sendPrompt` 从引擎命令口直达 `WorkspaceAgentActivityService`，绕过了原来上报业务漏斗埋点的 `createDesktopAgentActivityRuntime` 包装层，导致 0.2.x 版本完全停报：

- `agent.session_started`
- `agent.message_sent`
- `agent.message_stopped`

DataFinder 数据（2026-07-17，app 20004134）：`agent.message_sent` 在 0.1.x 上有 482 条 pv，0.2.x 上为 **0**；而 daemon 侧 `agent.node_result`（flow=message_send）显示 0.2.x 当天实际成功执行了 1138 次发送。新用户全部安装 0.2.x，因此「新用户-登录会话漏斗」的发送步骤归零（输入内容 35 人 → 发送会话 0 人）。

## 修复

在 `WorkspaceAgentActivityService.createEntry` 的引擎命令口边界补报业务漏斗事件（新增 `workspaceAgentEngineSendAnalytics.ts`），参数口径与 0.1.x reporter 完全对齐：

- `session/activate`（mode=new）→ `agent.session_started` + 首条 `agent.message_sent`，附带 `activate_session` 等 node_result 探针
- `queue/sendPrompt` → `agent.message_sent`（含 `conversation_index` / `is_queued` / `has_slash_command` / `provider`），附带 `send_input_request` / `message_sent_reported` node_result
- `turn/cancel` 成功 → `agent.message_stopped`

旧的 runtime 包装层与 promptSessionService 不经过引擎命令口，各自保留原有埋点，不会双报。

## 测试

- 新增 `workspaceAgentEngineSendAnalytics.test.ts`（6 个用例：新会话/已有会话/失败激活/发送含排队态/取消/发送失败节点）
- `workspaceAgentActivityService.test.ts` 新增引擎派发集成用例，验证 `activation/requested` 派发后真实上报 `agent.session_started` / `agent.message_sent`
- typecheck、oxlint、agent-activity-runtime / renderer / ui 边界检查全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->