### PR TITLE
fix(desktop): align update channel with installed version

### DIFF
--- a/apps/desktop/src/main/desktopAppServices.test.ts
+++ b/apps/desktop/src/main/desktopAppServices.test.ts
@@ -159,6 +159,7 @@ function createUpdateService(): AppUpdateService {
 test("createDesktopAppServices does not wait for the CLI shim before creating host services", async () => {
   const events: string[] = [];
   let finishCliShim: (() => void) | undefined;
+  let hostServicesIsPackaged: boolean | undefined;
   const daemonRuntime: DesktopDaemonRuntime = {
     daemonEndpoint: {
       accessToken: "token",
@@ -192,31 +193,38 @@ test("createDesktopAppServices does not wait for the CLI shim before creating ho
     } as unknown as DesktopDaemonRuntime["tuttidClient"]
   };
 
-  const services = await createDesktopAppServices(createOptions(events), {
-    createDaemonRuntime() {
-      events.push("daemon-runtime:create");
-      return daemonRuntime;
+  const services = await createDesktopAppServices(
+    {
+      ...createOptions(events),
+      isPackaged: true
     },
-    async createHostServices() {
-      events.push("host-services:create");
-      return createHostServices();
-    },
-    createUpdateService() {
-      events.push("update-service:create");
-      return createUpdateService();
-    },
-    ensureCliShim() {
-      events.push("cli-shim:ensure");
-      return new Promise((resolve) => {
-        finishCliShim = () =>
-          resolve({
-            installed: false,
-            pathShimPath: "/tmp/bin/tutti",
-            shimPath: "/tmp/tutti/bin/tutti"
-          });
-      });
+    {
+      createDaemonRuntime() {
+        events.push("daemon-runtime:create");
+        return daemonRuntime;
+      },
+      async createHostServices(options) {
+        events.push("host-services:create");
+        hostServicesIsPackaged = options.isPackaged;
+        return createHostServices();
+      },
+      createUpdateService() {
+        events.push("update-service:create");
+        return createUpdateService();
+      },
+      ensureCliShim() {
+        events.push("cli-shim:ensure");
+        return new Promise((resolve) => {
+          finishCliShim = () =>
+            resolve({
+              installed: false,
+              pathShimPath: "/tmp/bin/tutti",
+              shimPath: "/tmp/tutti/bin/tutti"
+            });
+        });
+      }
     }
-  });
+  );
 
   assert.deepEqual(events, [
     "daemon-runtime:create",
@@ -227,6 +235,7 @@ test("createDesktopAppServices does not wait for the CLI shim before creating ho
   ]);
   assert.equal(services.tuttid, daemonRuntime.tuttid);
   assert.equal(services.tuttidClient, daemonRuntime.tuttidClient);
+  assert.equal(hostServicesIsPackaged, true);
   assert.ok(finishCliShim);
   finishCliShim();
   await new Promise((resolve) => setImmediate(resolve));

--- a/apps/desktop/src/main/desktopAppServices.ts
+++ b/apps/desktop/src/main/desktopAppServices.ts
@@ -90,6 +90,7 @@ export async function createDesktopAppServices(
     enableDevelopmentReloadShortcut: options.enableDevelopmentReloadShortcut,
     appVersion: options.appVersion,
     fallbackLocale: options.fallbackLocale,
+    isPackaged: options.isPackaged,
     logger: options.logger,
     tuttidClient: daemonRuntime.tuttidClient,
     preloadPath: options.preloadPath,

--- a/apps/desktop/src/main/desktopHostPreferences.test.ts
+++ b/apps/desktop/src/main/desktopHostPreferences.test.ts
@@ -508,6 +508,62 @@ test("createDesktopHostPreferencesState preserves a manual channel on the same p
   assert.equal(state.getUpdateChannel(), "stable");
 });
 
+test("createDesktopHostPreferencesState preserves manual rc on the same packaged stable version", async () => {
+  const migrationStateRootDir = await mkdtemp(
+    join(tmpdir(), "tutti-update-channel-installed-version-")
+  );
+  const migrationsDir = join(migrationStateRootDir, "migrations");
+  await mkdir(migrationsDir, { recursive: true });
+  await writeFile(
+    join(migrationsDir, "desktop-update-channel-installed-version-v1"),
+    "0.2.2",
+    "utf8"
+  );
+  let putCalls = 0;
+
+  const state = await createDesktopHostPreferencesState({
+    appVersion: "0.2.2",
+    fallbackLocale: "zh-CN",
+    isPackaged: true,
+    logger: createLogger(),
+    migrationStateRootDir,
+    tuttidClient: {
+      async getDesktopPreferences() {
+        return {
+          initialized: true,
+          preferences: {
+            agentComposerDefaultsByProvider: {},
+            agentGuiConversationRailCollapsedByProvider: {},
+            agentConversationDetailMode: "coding",
+            agentDockLayout: "legacySplit",
+            appCatalogChannel: "production",
+            defaultAgentProvider: "codex",
+            featureFlags: {},
+            workbenchShortcuts: defaultDesktopWorkbenchShortcuts,
+            dockIconStyle: "default",
+            dockPlacement: "bottom",
+            fileDefaultOpenersByExtension: { html: "defaultBrowser" },
+            locale: "zh-CN",
+            minimizeAnimation: "scale",
+            sleepPreventionMode: "never",
+            showAppDeveloperSources: false,
+            themeSource: "dark",
+            updateChannel: "rc",
+            updatePolicy: "prompt"
+          }
+        };
+      },
+      async putDesktopPreferences() {
+        putCalls += 1;
+        throw new Error("putDesktopPreferences should not be called");
+      }
+    }
+  });
+
+  assert.equal(putCalls, 0);
+  assert.equal(state.getUpdateChannel(), "rc");
+});
+
 test("createDesktopHostPreferencesState aligns a changed packaged stable version to stable", async () => {
   const migrationStateRootDir = await mkdtemp(
     join(tmpdir(), "tutti-update-channel-installed-version-")

--- a/apps/desktop/src/main/desktopHostPreferences.test.ts
+++ b/apps/desktop/src/main/desktopHostPreferences.test.ts
@@ -391,6 +391,246 @@ test("createDesktopHostPreferencesState preserves initialized rc channel on rc p
   assert.equal(state.getUpdateChannel(), "rc");
 });
 
+test("createDesktopHostPreferencesState aligns a changed packaged rc version to the rc channel", async () => {
+  const migrationStateRootDir = await mkdtemp(
+    join(tmpdir(), "tutti-update-channel-installed-version-")
+  );
+  const migrationsDir = join(migrationStateRootDir, "migrations");
+  const installedVersionStatePath = join(
+    migrationsDir,
+    "desktop-update-channel-installed-version-v1"
+  );
+  await mkdir(migrationsDir, { recursive: true });
+  await writeFile(installedVersionStatePath, "0.2.1", "utf8");
+  const putRequests: PutDesktopPreferencesRequest[] = [];
+
+  const state = await createDesktopHostPreferencesState({
+    appVersion: "v0.2.2-rc.1",
+    fallbackLocale: "zh-CN",
+    isPackaged: true,
+    logger: createLogger(),
+    migrationStateRootDir,
+    tuttidClient: {
+      async getDesktopPreferences() {
+        return {
+          initialized: true,
+          preferences: {
+            agentComposerDefaultsByProvider: {},
+            agentGuiConversationRailCollapsedByProvider: {},
+            agentConversationDetailMode: "coding",
+            agentDockLayout: "legacySplit",
+            appCatalogChannel: "production",
+            defaultAgentProvider: "codex",
+            featureFlags: {},
+            workbenchShortcuts: defaultDesktopWorkbenchShortcuts,
+            dockIconStyle: "default",
+            dockPlacement: "bottom",
+            fileDefaultOpenersByExtension: { html: "defaultBrowser" },
+            locale: "zh-CN",
+            minimizeAnimation: "scale",
+            sleepPreventionMode: "never",
+            showAppDeveloperSources: false,
+            themeSource: "dark",
+            updateChannel: "stable",
+            updatePolicy: "prompt"
+          }
+        };
+      },
+      async putDesktopPreferences(request) {
+        putRequests.push(request);
+        return {
+          initialized: true,
+          preferences: request.preferences
+        };
+      }
+    }
+  });
+
+  assert.equal(state.getUpdateChannel(), "rc");
+  assert.equal(putRequests.length, 1);
+  assert.equal(putRequests[0]?.preferences.updateChannel, "rc");
+  assert.equal(await readFile(installedVersionStatePath, "utf8"), "0.2.2-rc.1");
+});
+
+test("createDesktopHostPreferencesState preserves a manual channel on the same packaged version", async () => {
+  const migrationStateRootDir = await mkdtemp(
+    join(tmpdir(), "tutti-update-channel-installed-version-")
+  );
+  const migrationsDir = join(migrationStateRootDir, "migrations");
+  await mkdir(migrationsDir, { recursive: true });
+  await writeFile(
+    join(migrationsDir, "desktop-update-channel-installed-version-v1"),
+    "0.2.2-rc.1",
+    "utf8"
+  );
+  let putCalls = 0;
+
+  const state = await createDesktopHostPreferencesState({
+    appVersion: "0.2.2-rc.1",
+    fallbackLocale: "zh-CN",
+    isPackaged: true,
+    logger: createLogger(),
+    migrationStateRootDir,
+    tuttidClient: {
+      async getDesktopPreferences() {
+        return {
+          initialized: true,
+          preferences: {
+            agentComposerDefaultsByProvider: {},
+            agentGuiConversationRailCollapsedByProvider: {},
+            agentConversationDetailMode: "coding",
+            agentDockLayout: "legacySplit",
+            appCatalogChannel: "production",
+            defaultAgentProvider: "codex",
+            featureFlags: {},
+            workbenchShortcuts: defaultDesktopWorkbenchShortcuts,
+            dockIconStyle: "default",
+            dockPlacement: "bottom",
+            fileDefaultOpenersByExtension: { html: "defaultBrowser" },
+            locale: "zh-CN",
+            minimizeAnimation: "scale",
+            sleepPreventionMode: "never",
+            showAppDeveloperSources: false,
+            themeSource: "dark",
+            updateChannel: "stable",
+            updatePolicy: "prompt"
+          }
+        };
+      },
+      async putDesktopPreferences() {
+        putCalls += 1;
+        throw new Error("putDesktopPreferences should not be called");
+      }
+    }
+  });
+
+  assert.equal(putCalls, 0);
+  assert.equal(state.getUpdateChannel(), "stable");
+});
+
+test("createDesktopHostPreferencesState aligns a changed packaged stable version to stable", async () => {
+  const migrationStateRootDir = await mkdtemp(
+    join(tmpdir(), "tutti-update-channel-installed-version-")
+  );
+  const migrationsDir = join(migrationStateRootDir, "migrations");
+  const installedVersionStatePath = join(
+    migrationsDir,
+    "desktop-update-channel-installed-version-v1"
+  );
+  await mkdir(migrationsDir, { recursive: true });
+  await writeFile(
+    join(migrationsDir, "desktop-update-channel-default-stable-v1"),
+    "applied",
+    "utf8"
+  );
+  await writeFile(installedVersionStatePath, "0.2.2-rc.4", "utf8");
+  const putRequests: PutDesktopPreferencesRequest[] = [];
+
+  const state = await createDesktopHostPreferencesState({
+    appVersion: "0.2.2",
+    fallbackLocale: "zh-CN",
+    isPackaged: true,
+    logger: createLogger(),
+    migrationStateRootDir,
+    tuttidClient: {
+      async getDesktopPreferences() {
+        return {
+          initialized: true,
+          preferences: {
+            agentComposerDefaultsByProvider: {},
+            agentGuiConversationRailCollapsedByProvider: {},
+            agentConversationDetailMode: "coding",
+            agentDockLayout: "legacySplit",
+            appCatalogChannel: "production",
+            defaultAgentProvider: "codex",
+            featureFlags: {},
+            workbenchShortcuts: defaultDesktopWorkbenchShortcuts,
+            dockIconStyle: "default",
+            dockPlacement: "bottom",
+            fileDefaultOpenersByExtension: { html: "defaultBrowser" },
+            locale: "zh-CN",
+            minimizeAnimation: "scale",
+            sleepPreventionMode: "never",
+            showAppDeveloperSources: false,
+            themeSource: "dark",
+            updateChannel: "rc",
+            updatePolicy: "prompt"
+          }
+        };
+      },
+      async putDesktopPreferences(request) {
+        putRequests.push(request);
+        return {
+          initialized: true,
+          preferences: request.preferences
+        };
+      }
+    }
+  });
+
+  assert.equal(state.getUpdateChannel(), "stable");
+  assert.equal(putRequests.length, 1);
+  assert.equal(putRequests[0]?.preferences.updateChannel, "stable");
+  assert.equal(await readFile(installedVersionStatePath, "utf8"), "0.2.2");
+});
+
+test("createDesktopHostPreferencesState retries packaged channel alignment after persistence fails", async () => {
+  const migrationStateRootDir = await mkdtemp(
+    join(tmpdir(), "tutti-update-channel-installed-version-")
+  );
+  const migrationsDir = join(migrationStateRootDir, "migrations");
+  const installedVersionStatePath = join(
+    migrationsDir,
+    "desktop-update-channel-installed-version-v1"
+  );
+  await mkdir(migrationsDir, { recursive: true });
+  await writeFile(installedVersionStatePath, "0.2.1", "utf8");
+  let putCalls = 0;
+
+  const state = await createDesktopHostPreferencesState({
+    appVersion: "0.2.2-rc.1",
+    fallbackLocale: "zh-CN",
+    isPackaged: true,
+    logger: createLogger(),
+    migrationStateRootDir,
+    tuttidClient: {
+      async getDesktopPreferences() {
+        return {
+          initialized: true,
+          preferences: {
+            agentComposerDefaultsByProvider: {},
+            agentGuiConversationRailCollapsedByProvider: {},
+            agentConversationDetailMode: "coding",
+            agentDockLayout: "legacySplit",
+            appCatalogChannel: "production",
+            defaultAgentProvider: "codex",
+            featureFlags: {},
+            workbenchShortcuts: defaultDesktopWorkbenchShortcuts,
+            dockIconStyle: "default",
+            dockPlacement: "bottom",
+            fileDefaultOpenersByExtension: { html: "defaultBrowser" },
+            locale: "zh-CN",
+            minimizeAnimation: "scale",
+            sleepPreventionMode: "never",
+            showAppDeveloperSources: false,
+            themeSource: "dark",
+            updateChannel: "stable",
+            updatePolicy: "prompt"
+          }
+        };
+      },
+      async putDesktopPreferences() {
+        putCalls += 1;
+        throw new Error("tuttid unavailable");
+      }
+    }
+  });
+
+  assert.equal(putCalls, 1);
+  assert.equal(state.getUpdateChannel(), "stable");
+  assert.equal(await readFile(installedVersionStatePath, "utf8"), "0.2.1");
+});
+
 test("createDesktopHostPreferencesState preserves rc after the stable default migration ran", async () => {
   const migrationStateRootDir = await mkdtemp(
     join(tmpdir(), "tutti-update-channel-migration-")

--- a/apps/desktop/src/main/desktopHostPreferences.ts
+++ b/apps/desktop/src/main/desktopHostPreferences.ts
@@ -422,10 +422,13 @@ async function resolveInitialDesktopPreferences(
   try {
     const response = await options.tuttidClient.getDesktopPreferences();
     if (response.initialized) {
+      const shouldMigrateDefaultUpdateChannel =
+        await shouldMigrateDefaultDesktopUpdateChannel(options);
       const migratedPreferences = await migrateInitializedDesktopPreferences(
         options,
         response.preferences,
-        defaultUpdateChannel
+        defaultUpdateChannel,
+        shouldMigrateDefaultUpdateChannel
       );
       return alignUpdateChannelWithInstalledVersion(
         options,
@@ -556,7 +559,8 @@ async function alignUpdateChannelWithInstalledVersion(
 async function migrateInitializedDesktopPreferences(
   options: CreateDesktopHostPreferencesOptions,
   preferences: PutDesktopPreferencesRequest["preferences"],
-  defaultUpdateChannel: DesktopUpdateChannel
+  defaultUpdateChannel: DesktopUpdateChannel,
+  shouldMigrateDefaultUpdateChannel: boolean
 ): Promise<PutDesktopPreferencesRequest["preferences"]> {
   const normalizedMinimizeAnimation = isDesktopMinimizeAnimation(
     preferences.minimizeAnimation
@@ -576,7 +580,11 @@ async function migrateInitializedDesktopPreferences(
   const normalizedWorkbenchShortcuts = normalizeDesktopWorkbenchShortcuts(
     preferences.workbenchShortcuts
   );
-  if (preferences.updateChannel !== "rc" || defaultUpdateChannel !== "stable") {
+  if (
+    !shouldMigrateDefaultUpdateChannel ||
+    preferences.updateChannel !== "rc" ||
+    defaultUpdateChannel !== "stable"
+  ) {
     if (
       preferences.minimizeAnimation === normalizedMinimizeAnimation &&
       preferences.agentConversationDetailMode ===
@@ -650,6 +658,18 @@ async function migrateInitializedDesktopPreferences(
       workbenchShortcuts: normalizedWorkbenchShortcuts
     };
   }
+}
+
+async function shouldMigrateDefaultDesktopUpdateChannel(
+  options: CreateDesktopHostPreferencesOptions
+): Promise<boolean> {
+  const installedVersion = resolveInstalledDesktopVersion(options);
+  if (!options.isPackaged || !installedVersion) {
+    return true;
+  }
+
+  const statePath = resolveUpdateChannelInstalledVersionStatePath(options);
+  return (await readInstalledDesktopVersion(statePath)) !== installedVersion;
 }
 
 function resolveDefaultDesktopUpdateChannel(

--- a/apps/desktop/src/main/desktopHostPreferences.ts
+++ b/apps/desktop/src/main/desktopHostPreferences.ts
@@ -61,6 +61,8 @@ import { resolveDesktopDefaultsFromEnv } from "./defaults.ts";
 
 const updateChannelDefaultMigrationID =
   "desktop-update-channel-default-stable-v1";
+const updateChannelInstalledVersionStateID =
+  "desktop-update-channel-installed-version-v1";
 
 export interface DesktopHostPreferencesState {
   getAgentComposerDefaultsByProvider(): DesktopAgentComposerDefaultsByProvider;
@@ -107,6 +109,7 @@ export interface DesktopHostPreferencesState {
 export interface CreateDesktopHostPreferencesOptions {
   appVersion?: string;
   fallbackLocale: DesktopLocale;
+  isPackaged?: boolean;
   logger: DesktopLogger;
   migrationStateRootDir?: string;
   tuttidClient: Pick<
@@ -419,14 +422,18 @@ async function resolveInitialDesktopPreferences(
   try {
     const response = await options.tuttidClient.getDesktopPreferences();
     if (response.initialized) {
-      return migrateInitializedDesktopPreferences(
+      const migratedPreferences = await migrateInitializedDesktopPreferences(
         options,
         response.preferences,
         defaultUpdateChannel
       );
+      return alignUpdateChannelWithInstalledVersion(
+        options,
+        migratedPreferences
+      );
     }
 
-    return (
+    const initializedPreferences = (
       await options.tuttidClient.putDesktopPreferences({
         preferences: {
           agentComposerDefaultsByProvider: {},
@@ -455,6 +462,10 @@ async function resolveInitialDesktopPreferences(
         }
       })
     ).preferences;
+    return alignUpdateChannelWithInstalledVersion(
+      options,
+      initializedPreferences
+    );
   } catch (error) {
     options.logger.warn("failed to resolve desktop preferences from tuttid", {
       error: error instanceof Error ? error.message : String(error)
@@ -482,6 +493,64 @@ async function resolveInitialDesktopPreferences(
       workbenchShortcuts: defaultDesktopWorkbenchShortcuts
     };
   }
+}
+
+async function alignUpdateChannelWithInstalledVersion(
+  options: CreateDesktopHostPreferencesOptions,
+  preferences: PutDesktopPreferencesRequest["preferences"]
+): Promise<PutDesktopPreferencesRequest["preferences"]> {
+  const installedVersion = resolveInstalledDesktopVersion(options);
+  if (!options.isPackaged || !installedVersion) {
+    return preferences;
+  }
+
+  const statePath = resolveUpdateChannelInstalledVersionStatePath(options);
+  if ((await readInstalledDesktopVersion(statePath)) === installedVersion) {
+    return preferences;
+  }
+
+  const installedChannel = resolveDefaultDesktopUpdateChannel(options);
+  let alignedPreferences = preferences;
+  if (preferences.updateChannel !== installedChannel) {
+    try {
+      alignedPreferences = (
+        await options.tuttidClient.putDesktopPreferences({
+          preferences: {
+            ...preferences,
+            updateChannel: installedChannel
+          }
+        })
+      ).preferences;
+      options.logger.info(
+        "desktop update channel aligned with installed version",
+        {
+          app_version: installedVersion,
+          previous_channel: preferences.updateChannel,
+          update_channel: installedChannel
+        }
+      );
+    } catch (error) {
+      options.logger.warn(
+        "failed to align desktop update channel with installed version",
+        {
+          app_version: installedVersion,
+          error: error instanceof Error ? error.message : String(error),
+          update_channel: installedChannel
+        }
+      );
+      return preferences;
+    }
+  }
+
+  try {
+    await writeInstalledDesktopVersion(statePath, installedVersion);
+  } catch (error) {
+    options.logger.warn("failed to record installed desktop version", {
+      app_version: installedVersion,
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+  return alignedPreferences;
 }
 
 async function migrateInitializedDesktopPreferences(
@@ -586,7 +655,7 @@ async function migrateInitializedDesktopPreferences(
 function resolveDefaultDesktopUpdateChannel(
   options: CreateDesktopHostPreferencesOptions
 ): DesktopUpdateChannel {
-  const version = options.appVersion?.trim().replace(/^v/iu, "") ?? "";
+  const version = resolveInstalledDesktopVersion(options) ?? "";
   if (/^\d+\.\d+\.\d+-rc\.\d+$/u.test(version)) {
     return "rc";
   }
@@ -594,13 +663,53 @@ function resolveDefaultDesktopUpdateChannel(
   return defaultDesktopUpdateChannel;
 }
 
+function resolveInstalledDesktopVersion(
+  options: CreateDesktopHostPreferencesOptions
+): string | null {
+  const version = options.appVersion?.trim().replace(/^v/iu, "") ?? "";
+  return version.length > 0 ? version : null;
+}
+
 function resolveUpdateChannelDefaultMigrationMarkerPath(
   options: CreateDesktopHostPreferencesOptions
 ): string {
-  const stateRootDir =
-    options.migrationStateRootDir ??
-    resolveDesktopDefaultsFromEnv().state.rootDir;
+  const stateRootDir = resolveDesktopPreferencesStateRootDir(options);
   return join(stateRootDir, "migrations", updateChannelDefaultMigrationID);
+}
+
+function resolveUpdateChannelInstalledVersionStatePath(
+  options: CreateDesktopHostPreferencesOptions
+): string {
+  const stateRootDir = resolveDesktopPreferencesStateRootDir(options);
+  return join(stateRootDir, "migrations", updateChannelInstalledVersionStateID);
+}
+
+function resolveDesktopPreferencesStateRootDir(
+  options: CreateDesktopHostPreferencesOptions
+): string {
+  return (
+    options.migrationStateRootDir ??
+    resolveDesktopDefaultsFromEnv().state.rootDir
+  );
+}
+
+async function readInstalledDesktopVersion(
+  path: string
+): Promise<string | null> {
+  try {
+    const version = (await readFile(path, "utf8")).trim();
+    return version.length > 0 ? version : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeInstalledDesktopVersion(
+  path: string,
+  version: string
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, version, "utf8");
 }
 
 async function hasMigrationMarker(markerPath: string): Promise<boolean> {

--- a/apps/desktop/src/main/desktopHostServices.ts
+++ b/apps/desktop/src/main/desktopHostServices.ts
@@ -28,6 +28,7 @@ export interface CreateDesktopHostServicesOptions {
   browserNodeGuestPreloadPath?: string;
   enableDevelopmentReloadShortcut?: boolean;
   fallbackLocale: DesktopLocale;
+  isPackaged?: boolean;
   logger: DesktopLogger;
   tuttidClient: Pick<
     TuttidClient,
@@ -44,6 +45,7 @@ export async function createDesktopHostServices(
   const preferences = await createDesktopHostPreferencesState({
     appVersion: options.appVersion,
     fallbackLocale: options.fallbackLocale,
+    isPackaged: options.isPackaged,
     logger: options.logger,
     tuttidClient: options.tuttidClient
   });

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -162,7 +162,7 @@ Channel meanings:
 - `rc`: maps to electron-updater `channel="rc"` with `allowPrerelease=true`
 - `beta`: reserved for beta prerelease artifacts such as `v1.12.19-beta.0`; expose it in developer settings only if the team decides beta users should auto-update between beta builds
 
-When no desktop preference has been stored yet, the initial update channel follows the package version: plain stable versions use `stable`, `-rc.N` versions use `rc`, and `-beta.N` versions still use `stable` until beta auto-update is explicitly exposed. Existing stored `rc` defaults from older stable builds are migrated back to `stable` once. After that migration, users who explicitly select `rc` in developer settings keep that preference.
+The update channel follows the installed package whenever the packaged app version changes: plain stable versions use `stable`, `-rc.N` versions use `rc`, and `-beta.N` versions still use `stable` until beta auto-update is explicitly exposed. The desktop records the last installed version after aligning the persisted preference, so ordinary restarts of the same version preserve a user's manual channel selection. Existing stored `rc` defaults from older stable builds are migrated back to `stable` once; the installed-version alignment then applies the channel of the package that is actually running.
 
 Prerelease auto-update depends on both release shape and update metadata:
 


### PR DESCRIPTION
## Summary

- Align the persisted update channel whenever the packaged app version changes: `-rc.N` packages select `rc`, while stable and currently unsupported prerelease shapes select `stable`.
- Record the last installed version so same-version restarts preserve manual channel selections and failed preference writes retry on the next launch.
- Keep the product default channel as `stable` and document the installed-package behavior.

## Tests

- `pnpm --filter @tutti-os/desktop test` (1489 passed, 2 skipped)
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm lint:ts`
- `pnpm check:electron-runtime-boundaries`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:changed`