### PR TITLE
feat(agent): add worktree session isolation

### DIFF
--- a/docs/conventions/local-state-storage.md
+++ b/docs/conventions/local-state-storage.md
@@ -135,6 +135,10 @@ Migrated agent runtime state should derive from the same root:
           assets/
     sessions/
       <date>-<sequence>/
+    worktrees/
+      <agent-session-id>/
+      .metadata/
+        <agent-session-id>.json
     runs/
       <agent-session-id>/
         sidecar-manifest.json
@@ -189,6 +193,18 @@ live under the matching run directory. Codex sessions use `codex-home` and
 receive it through `CODEX_HOME`; Tutti Agent sessions use `tutti-agent-home`
 and receive it through `TUTTI_AGENT_HOME`. `agent/attachments` stores persisted
 prompt attachments by agent session.
+
+`agent/worktrees/<agent-session-id>` is a daemon-managed Git checkout for a
+worktree-isolated agent session. The tuttid agent adapter owns the corresponding
+`.metadata/<agent-session-id>.json` record used for enumeration, failed-create
+rollback, and orphan recovery; it records the repository root, branch, base
+commit, and session scope. Canonical isolation coordinates remain in the
+session's existing runtime-context/metadata JSON, so this layout does not add a
+SQLite schema. Host startup recovery and the periodic Host worker only schedule
+cleanup through the adapter port. A tree is deleted only when it is clean with
+no commits ahead of its base, its creator is absent or not resumable, and no
+session cwd is inside the tree. Turn/runtime completion and session end times
+must never trigger this cleanup.
 
 `agent/extensions` is daemon-owned verified Agent Extension state. Version
 directories are immutable after installation; `active.json` selects the

--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -214,6 +214,28 @@ change the created session's visibility. User-started sessions should stay on
 the normal visible default; only an explicit `--hidden` launcher input should
 create a hidden session.
 
+`agent start --isolation worktree` creates the session in
+`<state-dir>/agent/worktrees/<session-id>` on branch `tutti/<session-id>`, based
+on the resolved launch cwd's `HEAD`. The resolved cwd follows the normal
+explicit-cwd then caller-session-cwd chain. Isolation is fail-closed: a missing
+git executable, non-git cwd, nested repository or submodule, or failed
+`git worktree add` rejects the launch before a session is created. Source
+checkout changes are not copied; a dirty source checkout produces a warning.
+The session runtime context persists the worktree path, branch, and base commit,
+and compact session/action JSON exposes those coordinates as `isolation`.
+
+Successful isolated worktrees are reclaimed only by the startup and periodic
+agent worktree GC. GC retains a tree when it is dirty, its branch is ahead of
+the recorded base commit, its creating session remains resumable, or another
+session cwd points inside it. Runtime idleness, turn completion, and session
+end timestamps must not trigger worktree deletion. Every session create is
+synchronized with GC from cwd resolution through canonical session persistence
+or failure rollback. This prevents a sweep both from observing an isolated tree
+as an in-progress orphan and from deleting a managed tree while a non-isolated
+session is adopting a cwd inside it. Session creates remain concurrent with one
+another; only a GC sweep takes the exclusive side of this synchronization
+boundary.
+
 ## Naming Rules
 
 Command path segments and input names use lowercase kebab-case.

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -14,7 +14,7 @@ The module owns:
 - narrow canonical store, runtime, preparation, attachment, clock, scheduler,
   and post-commit observer ports;
 - the runtime-operation coordinator, worker, typed interactive dispositions,
-  and startup recovery order;
+  startup recovery order, and adapter-specific worktree GC scheduling;
 - the direct and typed goal-control saga, revision actor, durable operation and
   reconcile-inbox workers, provider evidence repair, and goal recovery policy;
 - typed conformance scenarios under `conformance`.
@@ -31,7 +31,8 @@ canonical settlement as separate facts. `GoalControl`, `GetGoalState`, and
 `ReconcileGoal` are provider-neutral Host APIs; typed `/goal` commands enter the
 same durable saga without opening a turn. `Recover` first requeues and recovers
 durable runtime operations, then goal operations and the goal reconcile inbox,
-and only then settles unrecoverable stale turns. Configuring a goal store
+then settles unrecoverable stale turns, and finally invokes the adapter's
+worktree-isolation sweep. Configuring a goal store
 without its runtime or inbox consumer fails recovery with
 `ErrGoalConsumerUnavailable` instead of silently accumulating work.
 
@@ -52,9 +53,11 @@ skill bundles intentionally remain outside the Host contract.
 `tuttid` production wiring constructs one long-lived `Host`, installs it on the
 agent service adapter, invokes `Host.Recover` before serving traffic, and starts
 the Host-owned runtime and goal workers. Adapters can use the supervised
-`Host.Run` entrypoint to start the runtime-operation, goal-operation, and goal
-reconcile-inbox workers as one lifecycle; an infrastructure-level worker exit
-cancels its siblings, while retryable item failures remain worker-local. The
+`Host.Run` entrypoint to start the runtime-operation, goal-operation, goal
+reconcile-inbox, and periodic worktree-GC workers as one lifecycle; an
+infrastructure-level worker exit cancels its siblings, while retryable item
+failures remain worker-local. Host owns when GC runs, while the adapter port
+retains all Git, filesystem, and eligibility decisions. The
 individual worker entrypoints remain available for existing focused wiring and
 tests. The service package translates
 HTTP/query/composer/analytics concerns and provider-specific preparation only;
@@ -86,7 +89,8 @@ runtime fakes in `Reset`, and runs every value returned by
 `conformance.Scenarios`. This lets `tuttid`, the extracted Host, and downstream
 adapters share one behavior baseline without importing one another.
 Coordinator, goal, and commit-observer scenario groups extend the same driver
-with recovery ordering and post-commit failure semantics.
+with recovery ordering through the worktree sweep, recovery failure
+propagation, and post-commit failure semantics.
 
 The Host release module depends on `store-sqlite` and
 `store-sqlite/canonical`, but not on `daemon`, sidecars, or `tuttid`. Canonical

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -51,6 +51,7 @@ type Fixture struct {
 	RecoverInteractive bool
 	DisableGoalInbox   bool
 	FailCommitObserver bool
+	WorktreeGCSweepErr error
 }
 
 type SessionObservation struct {
@@ -177,14 +178,17 @@ func TitlePolicyScenarios() []Scenario {
 }
 
 func CoordinatorScenarios() []Scenario {
-	result := make([]Scenario, 0, 4)
+	result := make([]Scenario, 0, 5)
 	for _, scenario := range Scenarios() {
 		switch scenario.Name {
 		case "exact turn cancel", "interactive response", "plan decision":
 			result = append(result, scenario)
 		}
 	}
-	return append(result, Scenario{Name: "recover operations before stale turns", run: runRecoveryOrder})
+	return append(result,
+		Scenario{Name: "recover operations before stale turns and worktree sweep", run: runRecoveryOrder},
+		Scenario{Name: "worktree sweep failure propagates", run: runWorktreeSweepFailure},
+	)
 }
 
 func GoalScenarios() []Scenario {
@@ -661,7 +665,7 @@ func runRecoveryOrder(ctx context.Context, driver Driver) error {
 		return fmt.Errorf("recover host: %w", err)
 	}
 	steps := driver.Metrics().RecoverySteps
-	want := []string{"runtime_requeue", "runtime_complete", "goal_requeue", "goal_inbox_requeue", "stale_settle"}
+	want := []string{"runtime_requeue", "runtime_complete", "goal_requeue", "goal_inbox_requeue", "stale_settle", "worktree_sweep"}
 	if len(steps) != len(want) {
 		return fmt.Errorf("recovery steps=%v, want %v", steps, want)
 	}

--- a/packages/agent/host/conformance/worktree_gc.go
+++ b/packages/agent/host/conformance/worktree_gc.go
@@ -1,0 +1,30 @@
+package conformance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+func runWorktreeSweepFailure(ctx context.Context, driver Driver) error {
+	sweepErr := errors.New("conformance worktree sweep failure")
+	fixture := liveSessionFixture("session-recovery-worktree-failure", "")
+	fixture.WorktreeGCSweepErr = sweepErr
+	if err := driver.Reset(ctx, fixture); err != nil {
+		return err
+	}
+	if err := driver.Recover(ctx); !errors.Is(err, sweepErr) {
+		return fmt.Errorf("recover worktree sweep error=%v, want %v", err, sweepErr)
+	}
+	steps := driver.Metrics().RecoverySteps
+	want := []string{"runtime_requeue", "goal_requeue", "goal_inbox_requeue", "stale_settle", "worktree_sweep"}
+	if len(steps) != len(want) {
+		return fmt.Errorf("failed recovery steps=%v, want %v", steps, want)
+	}
+	for index := range want {
+		if steps[index] != want[index] {
+			return fmt.Errorf("failed recovery steps=%v, want %v", steps, want)
+		}
+	}
+	return nil
+}

--- a/packages/agent/host/host.go
+++ b/packages/agent/host/host.go
@@ -22,6 +22,7 @@ type Config struct {
 	OperationOwner       string
 	Scheduler            Scheduler
 	StaleTurnSettler     StaleTurnSettler
+	WorktreeGC           WorktreeGarbageCollector
 	GoalStore            GoalStateStore
 	GoalRuntime          GoalRuntimeController
 	GoalInbox            GoalReconcileInboxStore
@@ -51,6 +52,7 @@ type Host struct {
 	owner                string
 	scheduler            Scheduler
 	staleTurns           StaleTurnSettler
+	worktreeGC           WorktreeGarbageCollector
 	goals                GoalStateStore
 	goalRuntime          GoalRuntimeController
 	goalInbox            GoalReconcileInboxStore
@@ -75,7 +77,8 @@ func New(config Config) *Host {
 		observer: config.LifecycleObserver, commitObserver: config.CommitObserver,
 		operations: config.RuntimeOperations, events: config.OperationEvents,
 		owner: config.OperationOwner, scheduler: config.Scheduler, staleTurns: config.StaleTurnSettler,
-		goals: config.GoalStore, goalRuntime: config.GoalRuntime, goalInbox: config.GoalInbox,
+		worktreeGC: config.WorktreeGC,
+		goals:      config.GoalStore, goalRuntime: config.GoalRuntime, goalInbox: config.GoalInbox,
 		goalOwner: config.GoalOwner, goalClock: config.GoalClock,
 		goalAttemptTimeout: config.GoalAttemptTimeout, goalRecoveryBudget: config.GoalRecoveryBudget,
 		goalMaxAttempts: config.GoalMaxAttempts, goalDispatchDeadline: config.GoalDispatchDeadline,

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -87,11 +87,18 @@ type RuntimeOperationEventPublisher interface {
 	PublishRuntimeOperationEvent(context.Context, storesqlite.RuntimeOperationEvent) error
 }
 
-// StaleTurnSettler is the final startup-recovery stage. Host invokes it only
-// after durable runtime operations, goal operations, and goal reconcile inbox
-// work have been recovered.
+// StaleTurnSettler runs after durable runtime operations, goal operations, and
+// goal reconcile inbox work have been recovered and before the adapter-specific
+// worktree-isolation sweep.
 type StaleTurnSettler interface {
 	SettleStaleTurnsOnStartup(context.Context) error
+}
+
+// WorktreeGarbageCollector owns adapter-specific git/filesystem cleanup. Host
+// schedules it during startup recovery and from the periodic Run worker so
+// cleanup cannot accidentally follow a turn or runtime terminal transition.
+type WorktreeGarbageCollector interface {
+	SweepWorktreeIsolation(context.Context) error
 }
 
 type GoalStateStore interface {

--- a/packages/agent/host/run.go
+++ b/packages/agent/host/run.go
@@ -5,10 +5,11 @@ import (
 	"errors"
 )
 
-// Run supervises every durable Host worker as one lifecycle. Per-item step
-// errors remain retryable inside their worker; an infrastructure-level worker
-// exit cancels its siblings so adapters cannot silently continue with a
-// partially running Host.
+// Run supervises the runtime-operation, goal-operation, goal-reconcile-inbox,
+// and periodic worktree-GC workers as one lifecycle. Per-item step errors
+// remain retryable inside their worker; an infrastructure-level worker exit
+// cancels its siblings so adapters cannot silently continue with a partially
+// running Host.
 func (h *Host) Run(ctx context.Context) error {
 	if h == nil {
 		return nil
@@ -17,6 +18,7 @@ func (h *Host) Run(ctx context.Context) error {
 		h.runRuntimeOperationWorker,
 		h.runGoalOperationWorker,
 		h.runGoalReconcileInboxWorker,
+		h.runWorktreeGarbageCollectionWorker,
 	})
 }
 

--- a/packages/agent/host/runtime_operations.go
+++ b/packages/agent/host/runtime_operations.go
@@ -341,7 +341,8 @@ func (h *Host) RecoverRuntimeOperations(ctx context.Context) error {
 }
 
 // Recover fixes startup order as durable runtime operations, goal operations,
-// the durable goal reconcile inbox, and only then unrecoverable stale turns.
+// the durable goal reconcile inbox, unrecoverable stale turns, and finally the
+// adapter-specific worktree-isolation sweep.
 func (h *Host) Recover(ctx context.Context) error {
 	if err := h.validateRecoveryConfiguration(); err != nil {
 		return err
@@ -356,9 +357,11 @@ func (h *Host) Recover(ctx context.Context) error {
 		return err
 	}
 	if h != nil && h.staleTurns != nil {
-		return h.staleTurns.SettleStaleTurnsOnStartup(ctx)
+		if err := h.staleTurns.SettleStaleTurnsOnStartup(ctx); err != nil {
+			return err
+		}
 	}
-	return nil
+	return h.RecoverWorktreeIsolation(ctx)
 }
 
 func (h *Host) validateRecoveryConfiguration() error {

--- a/packages/agent/host/worktree_gc.go
+++ b/packages/agent/host/worktree_gc.go
@@ -1,0 +1,40 @@
+package agenthost
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+const defaultWorktreeGCSweepInterval = 5 * time.Minute
+
+func (h *Host) RecoverWorktreeIsolation(ctx context.Context) error {
+	if h == nil || h.worktreeGC == nil {
+		return nil
+	}
+	return h.worktreeGC.SweepWorktreeIsolation(ctx)
+}
+
+func (h *Host) RunWorktreeGarbageCollectionWorker(ctx context.Context) {
+	_ = h.runWorktreeGarbageCollectionWorker(ctx)
+}
+
+func (h *Host) runWorktreeGarbageCollectionWorker(ctx context.Context) error {
+	if h == nil || h.worktreeGC == nil {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	ticker := time.NewTicker(defaultWorktreeGCSweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := h.worktreeGC.SweepWorktreeIsolation(ctx); err != nil {
+				slog.Warn("agent worktree garbage collection sweep failed",
+					"event", "agent_session.worktree_gc.sweep_failed", "error", err)
+			}
+		}
+	}
+}

--- a/packages/agent/host/worktree_gc_test.go
+++ b/packages/agent/host/worktree_gc_test.go
@@ -1,0 +1,36 @@
+package agenthost
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type recordingWorktreeGarbageCollector struct {
+	calls int
+	err   error
+}
+
+func (c *recordingWorktreeGarbageCollector) SweepWorktreeIsolation(context.Context) error {
+	c.calls++
+	return c.err
+}
+
+func TestRecoverSweepsWorktreeIsolation(t *testing.T) {
+	collector := &recordingWorktreeGarbageCollector{}
+	host := New(Config{WorktreeGC: collector})
+	if err := host.Recover(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if collector.calls != 1 {
+		t.Fatalf("sweep calls = %d, want 1", collector.calls)
+	}
+}
+
+func TestRecoverReturnsWorktreeIsolationSweepFailure(t *testing.T) {
+	sweepErr := errors.New("sweep failed")
+	host := New(Config{WorktreeGC: &recordingWorktreeGarbageCollector{err: sweepErr}})
+	if err := host.Recover(context.Background()); !errors.Is(err, sweepErr) {
+		t.Fatalf("Recover error = %v, want %v", err, sweepErr)
+	}
+}

--- a/services/tuttid/apierrors/apierrors.go
+++ b/services/tuttid/apierrors/apierrors.go
@@ -33,6 +33,10 @@ const (
 	ReasonEventStreamServiceUnavailable                  = "event_stream_service_unavailable"
 	ReasonInvalidEntryKind                               = "invalid_entry_kind"
 	ReasonInvalidPath                                    = "invalid_path"
+	ReasonNotAGitRepo                                    = "not_a_git_repo"
+	ReasonGitUnavailable                                 = "git_unavailable"
+	ReasonUnsupportedRepoLayout                          = "unsupported_repo_layout"
+	ReasonWorktreeCreateFailed                           = "worktree_create_failed"
 	ReasonInvalidUploadSource                            = "invalid_upload_source"
 	ReasonInvalidWorkbenchSnapshot                       = "invalid_workbench_snapshot"
 	ReasonMalformedRequest                               = "malformed_request"
@@ -324,6 +328,15 @@ func Classify(err error) *ProtocolError {
 		return InvalidRequest("agent.invalid_model", WithCause(err), WithParams(params))
 	}
 	switch {
+	case errors.Is(err, agentservice.ErrNotAGitRepo):
+		return InvalidRequest(ReasonNotAGitRepo, WithCause(err))
+	case errors.Is(err, agentservice.ErrGitUnavailable):
+		return ServiceUnavailable(ReasonGitUnavailable, WithCause(err))
+	case errors.Is(err, agentservice.ErrUnsupportedRepoLayout):
+		return InvalidRequest(ReasonUnsupportedRepoLayout, WithCause(err))
+	case errors.Is(err, agentservice.ErrWorktreeCreateFailed):
+		return New(StatusWorkspaceOperationFailed, tuttigenerated.WorkspaceOperationFailed, ReasonWorktreeCreateFailed,
+			WithCause(err), WithParams(map[string]any{"detail": err.Error()}))
 	case errors.Is(err, agentservice.ErrSubmitDeliveryUnknown):
 		return New(StatusWorkspaceOperationFailed, tuttigenerated.WorkspaceOperationFailed, ReasonAgentSubmitDeliveryUnknown, WithCause(err))
 	case errors.Is(err, workspacedata.ErrWorkspaceNotFound):

--- a/services/tuttid/apierrors/apierrors_test.go
+++ b/services/tuttid/apierrors/apierrors_test.go
@@ -1,6 +1,7 @@
 package apierrors
 
 import (
+	"errors"
 	"testing"
 
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
@@ -10,6 +11,28 @@ func TestClassifyRuntimeOperationReconciliationIsRetryable(t *testing.T) {
 	classified := Classify(agentservice.ErrRuntimeOperationInProgress)
 	if classified.Reason != ReasonAgentRuntimeOperationReconciling || !classified.Retryable {
 		t.Fatalf("classified = %#v, want stable retryable reconciliation reason", classified)
+	}
+}
+
+func TestClassifyWorktreeIsolationErrors(t *testing.T) {
+	tests := []struct {
+		err    error
+		reason string
+	}{
+		{agentservice.ErrNotAGitRepo, ReasonNotAGitRepo},
+		{agentservice.ErrGitUnavailable, ReasonGitUnavailable},
+		{agentservice.ErrUnsupportedRepoLayout, ReasonUnsupportedRepoLayout},
+		{&agentservice.WorktreeIsolationError{Kind: agentservice.ErrWorktreeCreateFailed, Detail: "git stderr"}, ReasonWorktreeCreateFailed},
+	}
+	for _, test := range tests {
+		classified := Classify(test.err)
+		if classified.Reason != test.reason || !errors.Is(classified, test.err) {
+			t.Fatalf("Classify(%v) = %#v, want reason %q", test.err, classified, test.reason)
+		}
+	}
+	classified := Classify(&agentservice.WorktreeIsolationError{Kind: agentservice.ErrWorktreeCreateFailed, Detail: "git stderr"})
+	if classified.Params["detail"] != "git stderr" {
+		t.Fatalf("worktree create detail = %#v", classified.Params)
 	}
 }
 

--- a/services/tuttid/service/agent/host_adapters.go
+++ b/services/tuttid/service/agent/host_adapters.go
@@ -430,6 +430,10 @@ func (p serviceHostRuntimeOperationEventPublisher) PublishRuntimeOperationEvent(
 // adapters. Production wiring constructs exactly one Host and installs it on
 // Service; isolated package consumers may use ApplicationHost for lazy setup.
 func NewApplicationHost(s *Service) *agenthost.Host {
+	return newApplicationHost(s, s)
+}
+
+func newApplicationHost(s *Service, worktreeGC agenthost.WorktreeGarbageCollector) *agenthost.Host {
 	if s == nil {
 		return nil
 	}
@@ -444,7 +448,8 @@ func NewApplicationHost(s *Service) *agenthost.Host {
 		CommitObserver:    serviceHostCommitObserver{service: s},
 		RuntimeOperations: s.RuntimeOperationStore, OperationEvents: serviceHostRuntimeOperationEventPublisher{service: s},
 		OperationOwner: s.RuntimeOperationOwner, StaleTurnSettler: s.StaleTurnSettler,
-		GoalStore: s.GoalStateStore, GoalRuntime: serviceHostGoalRuntime{service: s}, GoalInbox: s.GoalReconcileInboxStore,
+		WorktreeGC: worktreeGC,
+		GoalStore:  s.GoalStateStore, GoalRuntime: serviceHostGoalRuntime{service: s}, GoalInbox: s.GoalReconcileInboxStore,
 		GoalOwner: s.GoalOperationOwner, GoalClock: serviceHostGoalClock{service: s},
 		GoalAttemptTimeout: s.GoalOperationAttemptTimeout, GoalRecoveryBudget: s.GoalOperationRecoveryBudget,
 		GoalMaxAttempts: s.GoalOperationMaxAttempts, GoalDispatchDeadline: s.GoalOperationDispatchDeadline,

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -236,6 +236,10 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 	if fixture.DisableGoalInbox {
 		d.service.GoalReconcileInboxStore = nil
 	}
+	d.service.SetApplicationHost(newApplicationHost(d.service, conformanceWorktreeGarbageCollector{
+		steps: &steps,
+		err:   fixture.WorktreeGCSweepErr,
+	}))
 
 	var goalMu sync.Mutex
 	var providerGoal map[string]any
@@ -766,6 +770,16 @@ type conformanceStaleTurnSettler struct{ steps *[]string }
 func (s conformanceStaleTurnSettler) SettleStaleTurnsOnStartup(context.Context) error {
 	*s.steps = append(*s.steps, "stale_settle")
 	return nil
+}
+
+type conformanceWorktreeGarbageCollector struct {
+	steps *[]string
+	err   error
+}
+
+func (c conformanceWorktreeGarbageCollector) SweepWorktreeIsolation(context.Context) error {
+	*c.steps = append(*c.steps, "worktree_sweep")
+	return c.err
 }
 
 func (d *legacyHostConformanceDriver) recordSubmittedTurn(workspaceID, sessionID, turnID string) {

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -101,7 +101,18 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 		value(input.Model),
 		input.ReasoningEffort,
 	)
+	isolationMode := strings.TrimSpace(input.Isolation)
+	if isolationMode != "" && isolationMode != WorktreeIsolationMode {
+		return Session{}, fmt.Errorf("%w: unsupported session isolation mode %q", ErrInvalidArgument, isolationMode)
+	}
+	s.worktreeIsolationMu.RLock()
+	defer s.worktreeIsolationMu.RUnlock()
 	nodeStartedAt = time.Now()
+	if isolationMode == WorktreeIsolationMode && strings.TrimSpace(value(input.Cwd)) == "" {
+		err := &WorktreeIsolationError{Kind: ErrNotAGitRepo}
+		s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "cwd_resolved", provider, nodeStartedAt, err)
+		return Session{}, err
+	}
 	cwd, err := s.resolveCwd(ctx, input.Cwd)
 	if err != nil {
 		s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "cwd_resolved", provider, nodeStartedAt, err)
@@ -111,6 +122,25 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	logAgentSubmitTrace("service.create.cwd_resolved", workspaceID, input.AgentSessionID, input.Metadata, map[string]any{
 		"cwd": cwd,
 	})
+	var isolation *SessionIsolation
+	var isolationWarnings []SessionWarning
+	keepWorktree := false
+	if isolationMode == WorktreeIsolationMode {
+		created, warnings, createErr := s.createSessionWorktree(ctx, workspaceID, cwd, input.AgentSessionID)
+		if createErr != nil {
+			return Session{}, createErr
+		}
+		isolation = &created
+		isolationWarnings = warnings
+		cwd = created.WorktreePath
+		input.Cwd = stringPointer(cwd)
+		input.RuntimeContext = sessionIsolationRuntimeContext(input.RuntimeContext, created)
+		defer func() {
+			if !keepWorktree {
+				s.rollbackSessionWorktree(context.Background(), created)
+			}
+		}()
+	}
 	if providerTargetRefKind(input.ProviderTargetRef) == "agent_extension" {
 		nodeStartedAt = time.Now()
 		if err := s.validateExtensionComposerSettingsForCreate(ctx, workspaceID, cwd, input); err != nil {
@@ -124,6 +154,9 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	if err != nil {
 		s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "runtime_prepared", provider, nodeStartedAt, err)
 		return Session{}, err
+	}
+	if isolation != nil {
+		prepared.Cwd = isolation.WorktreePath
 	}
 	s.reportAgentServiceNodeSuccess(ctx, input.AgentSessionID, "session_create", "runtime_prepared", provider, nodeStartedAt)
 	logAgentSubmitTrace("service.create.runtime_prepared", workspaceID, input.AgentSessionID, input.Metadata, map[string]any{"cwd": prepared.Cwd, "env_count": len(prepared.Env)})
@@ -156,30 +189,44 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	if err != nil {
 		return Session{}, err
 	}
+	keepWorktree = true
 	session := hostResult.Session
 	logAgentSubmitTrace("service.create.runtime_start_resolved", workspaceID, session.ID, input.Metadata, map[string]any{"provider_runtime_status": session.Status})
 	persistedSession := persistedSessionFromHost(hostResult.Canonical)
 	if strings.TrimSpace(session.ID) == "" && strings.TrimSpace(hostResult.TurnID) != "" {
-		return s.Get(ctx, workspaceID, input.AgentSessionID)
+		result, getErr := s.Get(ctx, workspaceID, input.AgentSessionID)
+		return decorateIsolatedSession(result, isolation, isolationWarnings), getErr
 	}
 	if hostResult.Kind == "goalControl" {
-		return s.Get(ctx, workspaceID, session.ID)
+		result, getErr := s.Get(ctx, workspaceID, session.ID)
+		return decorateIsolatedSession(result, isolation, isolationWarnings), getErr
 	}
 	if len(normalizedContent) == 0 {
-		return serviceSessionWithPersistedFreshness(
+		return decorateIsolatedSession(serviceSessionWithPersistedFreshness(
 			session,
 			persistedSession,
 			s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session)),
-		), nil
+		), isolation, isolationWarnings), nil
 	}
 	logAgentSubmitTrace("service.create.prompt_validated", workspaceID, session.ID, input.Metadata, nil)
 	logAgentSubmitTrace("service.create.prompt_prepared", workspaceID, session.ID, input.Metadata, map[string]any{"content_block_count": len(normalizedContent)})
 	logAgentSubmitTrace("service.create.exec_resolved", workspaceID, session.ID, input.Metadata, map[string]any{"turn_id": hostResult.TurnID})
-	return serviceSessionWithPersistedFreshness(
+	return decorateIsolatedSession(serviceSessionWithPersistedFreshness(
 		session,
 		persistedSession,
 		s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session)),
-	), nil
+	), isolation, isolationWarnings), nil
+}
+
+func decorateIsolatedSession(session Session, isolation *SessionIsolation, warnings []SessionWarning) Session {
+	if isolation != nil {
+		copy := *isolation
+		session.Isolation = &copy
+	}
+	if len(warnings) > 0 {
+		session.Warnings = append([]SessionWarning(nil), warnings...)
+	}
+	return session
 }
 
 func (s *Service) applyCreateSessionComposerDefaults(ctx context.Context, input *CreateSessionInput) error {

--- a/services/tuttid/service/agent/service_helpers.go
+++ b/services/tuttid/service/agent/service_helpers.go
@@ -42,6 +42,11 @@ func cloneSession(session Session) Session {
 		title := *session.Title
 		cloned.Title = &title
 	}
+	if session.Isolation != nil {
+		isolation := *session.Isolation
+		cloned.Isolation = &isolation
+	}
+	cloned.Warnings = append([]SessionWarning(nil), session.Warnings...)
 	if session.UpdatedAt != nil {
 		updatedAt := *session.UpdatedAt
 		cloned.UpdatedAt = &updatedAt

--- a/services/tuttid/service/agent/service_session.go
+++ b/services/tuttid/service/agent/service_session.go
@@ -105,7 +105,7 @@ func serviceSession(session ProviderRuntimeSession, resumable bool) Session {
 		normalizedProvider,
 		cloneComposerSettingsPointerValue(session.Settings),
 	)
-	metadata, _, err := agentactivitybiz.SplitSessionRuntimeContext(session.RuntimeContext)
+	metadata, internalRuntimeContext, err := agentactivitybiz.SplitSessionRuntimeContext(session.RuntimeContext)
 	if err != nil {
 		metadata = agentactivitybiz.SessionMetadata{Visible: session.Visible, Capabilities: []string{}}
 	}
@@ -127,6 +127,7 @@ func serviceSession(session ProviderRuntimeSession, resumable bool) Session {
 		CreatedAt:         createdAt,
 		UpdatedAt:         updatedAt,
 		Metadata:          metadata,
+		Isolation:         sessionIsolationFromRuntimeContext(internalRuntimeContext),
 	}
 }
 
@@ -193,6 +194,7 @@ func sessionFromPersisted(session PersistedSession, resumable bool) Session {
 	result.ParentTurnID = strings.TrimSpace(session.ParentTurnID)
 	result.ParentToolCallID = strings.TrimSpace(session.ParentToolCallID)
 	result.Metadata = session.Metadata
+	result.Isolation = sessionIsolationFromRuntimeContext(session.InternalRuntimeContext)
 	return result
 }
 
@@ -236,6 +238,9 @@ func mergePersistedSessionState(session Session, persisted PersistedSession) Ses
 		session.UpdatedAt = timeFromUnixMSPointer(persisted.UpdatedAtUnixMS)
 	}
 	session.Metadata = persisted.Metadata
+	if isolation := sessionIsolationFromRuntimeContext(persisted.InternalRuntimeContext); isolation != nil {
+		session.Isolation = isolation
+	}
 	return session
 }
 

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -46,6 +46,8 @@ type Service struct {
 	GoalOperationMaxAttempts       int
 	GoalOperationDispatchDeadline  time.Duration
 	SessionDirectoryAllocator      SessionDirectoryAllocator
+	WorktreeStateDir               string
+	WorkspaceIDs                   func(context.Context) ([]string, error)
 	PromptAttachmentStore          PromptAttachmentStore
 	RuntimePreparer                runtimeprep.Preparer
 	ComputerUseAvailable           func() bool
@@ -71,6 +73,7 @@ type Service struct {
 	sessionSettingsLocks           map[string]*serviceSessionSettingsLock
 	applicationHostMu              sync.Mutex
 	applicationHost                *agenthost.Host
+	worktreeIsolationMu            sync.RWMutex
 	generatedFilesCacheMu          sync.Mutex
 	generatedFilesCache            map[string]generatedFilesCacheEntry
 	// liveModelPersistedScanMissAtUnixMS memoizes, per live-model cache key,
@@ -182,6 +185,8 @@ type Session struct {
 	UpdatedAt            *time.Time
 	EndedAt              *time.Time
 	Metadata             agentactivitybiz.SessionMetadata
+	Isolation            *SessionIsolation
+	Warnings             []SessionWarning
 	// Protocol v2 turn state (agent-gui refactor plan): the session keeps an
 	// activeTurnId reference; phase/outcome/error live on the turn entity.
 	ActiveTurnID           string
@@ -189,6 +194,18 @@ type Session struct {
 	LatestTurn             *agentactivitybiz.Turn
 	LatestTurnInteractions []agentactivitybiz.Interaction
 	PendingInteractions    []agentactivitybiz.Interaction
+}
+
+type SessionIsolation struct {
+	Mode         string `json:"mode"`
+	WorktreePath string `json:"worktreePath"`
+	Branch       string `json:"branch"`
+	BaseCommit   string `json:"baseCommit"`
+}
+
+type SessionWarning struct {
+	Code    string
+	Message string
 }
 
 type ListSessionsInput struct {
@@ -454,6 +471,7 @@ type CreateSessionInput struct {
 	ProviderTargetRef      map[string]any
 	ReasoningEffort        *string
 	RuntimeContext         map[string]any
+	Isolation              string
 	Speed                  *string
 	ConversationDetailMode string
 	Visible                *bool

--- a/services/tuttid/service/agent/worktree.go
+++ b/services/tuttid/service/agent/worktree.go
@@ -1,0 +1,488 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
+)
+
+const (
+	WorktreeIsolationMode        = "worktree"
+	worktreeIsolationContextKey  = "isolation"
+	worktreeDirtyBaseWarningCode = "worktree_base_dirty"
+	worktreeGitOperationTimeout  = 30 * time.Second
+)
+
+var (
+	ErrNotAGitRepo           = errors.New("cwd is not a git repository")
+	ErrGitUnavailable        = errors.New("git is unavailable")
+	ErrUnsupportedRepoLayout = errors.New("git repository layout is unsupported")
+	ErrWorktreeCreateFailed  = errors.New("git worktree creation failed")
+)
+
+type WorktreeIsolationError struct {
+	Kind   error
+	Detail string
+}
+
+func (e *WorktreeIsolationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if detail := strings.TrimSpace(e.Detail); detail != "" {
+		return detail
+	}
+	if e.Kind != nil {
+		return e.Kind.Error()
+	}
+	return "worktree isolation failed"
+}
+
+func (e *WorktreeIsolationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Kind
+}
+
+type sessionWorktreeRecord struct {
+	SessionIsolation
+	SessionID   string `json:"sessionId"`
+	WorkspaceID string `json:"workspaceId"`
+	RepoRoot    string `json:"repoRoot"`
+	// GitCommonDir anchors GC git operations to the main repository's git
+	// directory, which stays valid even when RepoRoot was itself a linked
+	// worktree that has since been garbage-collected.
+	GitCommonDir string `json:"gitCommonDir,omitempty"`
+}
+
+func worktreeGitAnchor(record sessionWorktreeRecord) (string, []string) {
+	if common := strings.TrimSpace(record.GitCommonDir); common != "" {
+		return common, []string{"--git-dir", common}
+	}
+	return record.RepoRoot, nil
+}
+
+func gitRepoOutput(ctx context.Context, record sessionWorktreeRecord, args ...string) (string, error) {
+	dir, prefix := worktreeGitAnchor(record)
+	return gitOutput(ctx, dir, append(append([]string(nil), prefix...), args...)...)
+}
+
+func (s *Service) worktreeStateDir() string {
+	if s != nil {
+		if stateDir := strings.TrimSpace(s.WorktreeStateDir); stateDir != "" {
+			return filepath.Clean(stateDir)
+		}
+	}
+	return tuttitypes.DefaultStateDir()
+}
+
+func (s *Service) createSessionWorktree(
+	ctx context.Context,
+	workspaceID string,
+	cwd string,
+	sessionID string,
+) (SessionIsolation, []SessionWarning, error) {
+	return createSessionWorktree(ctx, s.worktreeStateDir(), workspaceID, cwd, sessionID)
+}
+
+func createSessionWorktree(
+	ctx context.Context,
+	stateDir string,
+	workspaceID string,
+	cwd string,
+	sessionID string,
+) (SessionIsolation, []SessionWarning, error) {
+	if _, err := exec.LookPath("git"); err != nil {
+		return SessionIsolation{}, nil, &WorktreeIsolationError{Kind: ErrGitUnavailable, Detail: err.Error()}
+	}
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" {
+		return SessionIsolation{}, nil, &WorktreeIsolationError{Kind: ErrNotAGitRepo}
+	}
+	absCwd, err := filepath.Abs(cwd)
+	if err != nil {
+		return SessionIsolation{}, nil, &WorktreeIsolationError{Kind: ErrNotAGitRepo, Detail: err.Error()}
+	}
+	if resolved, resolveErr := filepath.EvalSymlinks(absCwd); resolveErr == nil {
+		absCwd = resolved
+	}
+	repoRoot, err := gitOutput(ctx, absCwd, "rev-parse", "--show-toplevel")
+	if err != nil || strings.TrimSpace(repoRoot) == "" {
+		return SessionIsolation{}, nil, &WorktreeIsolationError{Kind: ErrNotAGitRepo, Detail: gitErrorDetail(err)}
+	}
+	repoRoot = filepath.Clean(strings.TrimSpace(repoRoot))
+	if resolved, resolveErr := filepath.EvalSymlinks(repoRoot); resolveErr == nil {
+		repoRoot = resolved
+	}
+	if superproject, superErr := gitOutput(ctx, repoRoot, "rev-parse", "--show-superproject-working-tree"); superErr == nil && strings.TrimSpace(superproject) != "" {
+		return SessionIsolation{}, nil, &WorktreeIsolationError{Kind: ErrUnsupportedRepoLayout, Detail: "git submodules are not supported for worktree isolation"}
+	}
+	if outerRoot, outerErr := gitOutput(ctx, filepath.Dir(repoRoot), "rev-parse", "--show-toplevel"); outerErr == nil && strings.TrimSpace(outerRoot) != "" && filepath.Clean(strings.TrimSpace(outerRoot)) != repoRoot {
+		return SessionIsolation{}, nil, &WorktreeIsolationError{Kind: ErrUnsupportedRepoLayout, Detail: "nested git repositories are not supported for worktree isolation"}
+	}
+	commonDirOut, err := gitOutput(ctx, absCwd, "rev-parse", "--git-common-dir")
+	if err != nil || strings.TrimSpace(commonDirOut) == "" {
+		return SessionIsolation{}, nil, &WorktreeIsolationError{Kind: ErrWorktreeCreateFailed, Detail: gitErrorDetail(err)}
+	}
+	gitCommonDir := strings.TrimSpace(commonDirOut)
+	if !filepath.IsAbs(gitCommonDir) {
+		gitCommonDir = filepath.Join(absCwd, gitCommonDir)
+	}
+	gitCommonDir = filepath.Clean(gitCommonDir)
+	if resolved, resolveErr := filepath.EvalSymlinks(gitCommonDir); resolveErr == nil {
+		gitCommonDir = resolved
+	}
+	baseCommit, err := gitOutput(ctx, repoRoot, "rev-parse", "HEAD")
+	if err != nil || strings.TrimSpace(baseCommit) == "" {
+		return SessionIsolation{}, nil, &WorktreeIsolationError{Kind: ErrWorktreeCreateFailed, Detail: gitErrorDetail(err)}
+	}
+	baseCommit = strings.TrimSpace(baseCommit)
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" || filepath.Base(sessionID) != sessionID || strings.ContainsAny(sessionID, `/\\`) {
+		return SessionIsolation{}, nil, &WorktreeIsolationError{Kind: ErrWorktreeCreateFailed, Detail: "agent session id is unsafe for a worktree path"}
+	}
+	worktreesRoot := filepath.Join(filepath.Clean(stateDir), "agent", "worktrees")
+	worktreePath := filepath.Join(worktreesRoot, sessionID)
+	branch := "tutti/" + sessionID
+	if _, statErr := os.Lstat(worktreePath); statErr == nil || !errors.Is(statErr, os.ErrNotExist) {
+		return SessionIsolation{}, nil, &WorktreeIsolationError{Kind: ErrWorktreeCreateFailed, Detail: "session worktree path already exists"}
+	}
+	if _, statErr := os.Lstat(worktreeRecordPath(worktreesRoot, sessionID)); statErr == nil || !errors.Is(statErr, os.ErrNotExist) {
+		return SessionIsolation{}, nil, &WorktreeIsolationError{Kind: ErrWorktreeCreateFailed, Detail: "session worktree metadata already exists"}
+	}
+	if _, branchErr := gitOutput(ctx, repoRoot, "show-ref", "--verify", "refs/heads/"+branch); branchErr == nil {
+		return SessionIsolation{}, nil, &WorktreeIsolationError{Kind: ErrWorktreeCreateFailed, Detail: "session worktree branch already exists"}
+	}
+	info := SessionIsolation{Mode: WorktreeIsolationMode, WorktreePath: worktreePath, Branch: branch, BaseCommit: baseCommit}
+	record := sessionWorktreeRecord{
+		SessionIsolation: info,
+		SessionID:        sessionID, WorkspaceID: strings.TrimSpace(workspaceID),
+		RepoRoot: repoRoot, GitCommonDir: gitCommonDir,
+	}
+	if err := writeSessionWorktreeRecord(worktreesRoot, record); err != nil {
+		return SessionIsolation{}, nil, &WorktreeIsolationError{Kind: ErrWorktreeCreateFailed, Detail: err.Error()}
+	}
+	created := false
+	defer func() {
+		if !created {
+			rollbackSessionWorktree(context.Background(), worktreesRoot, record)
+		}
+	}()
+	if _, err := gitOutput(ctx, repoRoot, "worktree", "add", "-b", branch, worktreePath, baseCommit); err != nil {
+		return SessionIsolation{}, nil, &WorktreeIsolationError{Kind: ErrWorktreeCreateFailed, Detail: gitErrorDetail(err)}
+	}
+	created = true
+	warnings := []SessionWarning(nil)
+	if status, statusErr := gitOutput(ctx, repoRoot, "status", "--porcelain"); statusErr == nil && strings.TrimSpace(status) != "" {
+		warnings = append(warnings, SessionWarning{
+			Code:    worktreeDirtyBaseWarningCode,
+			Message: "The source checkout has uncommitted changes; the isolated worktree is based on HEAD and does not include them.",
+		})
+	}
+	return info, warnings, nil
+}
+
+type gitCommandError struct {
+	err    error
+	detail string
+}
+
+func (e *gitCommandError) Error() string { return strings.TrimSpace(e.detail) }
+func (e *gitCommandError) Unwrap() error { return e.err }
+
+func gitOutput(ctx context.Context, cwd string, args ...string) (string, error) {
+	commandCtx, cancel := context.WithTimeout(ctx, worktreeGitOperationTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(commandCtx, "git", args...)
+	cmd.Dir = cwd
+	cmd.Env = gitEnvScopedToDir()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(out))
+		if detail == "" {
+			detail = err.Error()
+		}
+		return "", &gitCommandError{err: err, detail: detail}
+	}
+	return string(out), nil
+}
+
+func gitErrorDetail(err error) string {
+	if err == nil {
+		return ""
+	}
+	return strings.TrimSpace(err.Error())
+}
+
+func sessionIsolationRuntimeContext(runtimeContext map[string]any, isolation SessionIsolation) map[string]any {
+	result := clonePayload(runtimeContext)
+	if result == nil {
+		result = map[string]any{}
+	}
+	result[worktreeIsolationContextKey] = map[string]any{
+		"mode": isolation.Mode, "worktreePath": isolation.WorktreePath,
+		"branch": isolation.Branch, "baseCommit": isolation.BaseCommit,
+	}
+	return result
+}
+
+func sessionIsolationFromRuntimeContext(runtimeContext map[string]any) *SessionIsolation {
+	raw := runtimeContext[worktreeIsolationContextKey]
+	if raw == nil {
+		return nil
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	var isolation SessionIsolation
+	if err := json.Unmarshal(data, &isolation); err != nil || strings.TrimSpace(isolation.Mode) == "" {
+		return nil
+	}
+	return &isolation
+}
+
+func worktreeRecordsDir(worktreesRoot string) string {
+	return filepath.Join(worktreesRoot, ".metadata")
+}
+
+func worktreeRecordPath(worktreesRoot string, sessionID string) string {
+	return filepath.Join(worktreeRecordsDir(worktreesRoot), sessionID+".json")
+}
+
+func writeSessionWorktreeRecord(worktreesRoot string, record sessionWorktreeRecord) error {
+	if err := os.MkdirAll(worktreeRecordsDir(worktreesRoot), 0o700); err != nil {
+		return fmt.Errorf("create worktree metadata directory: %w", err)
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("marshal worktree metadata: %w", err)
+	}
+	path := worktreeRecordPath(worktreesRoot, record.SessionID)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("write worktree metadata: %w", err)
+	}
+	written := false
+	defer func() {
+		_ = file.Close()
+		if !written {
+			_ = os.Remove(path)
+		}
+	}()
+	if _, err := file.Write(data); err != nil {
+		return fmt.Errorf("write worktree metadata: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("write worktree metadata: %w", err)
+	}
+	written = true
+	return nil
+}
+
+func rollbackSessionWorktree(ctx context.Context, worktreesRoot string, record sessionWorktreeRecord) {
+	_, _ = gitRepoOutput(ctx, record, "worktree", "remove", "--force", record.WorktreePath)
+	_ = os.RemoveAll(record.WorktreePath)
+	_, _ = gitRepoOutput(ctx, record, "branch", "-D", record.Branch)
+	_, _ = gitRepoOutput(ctx, record, "worktree", "prune")
+	_ = os.Remove(worktreeRecordPath(worktreesRoot, record.SessionID))
+}
+
+func (s *Service) rollbackSessionWorktree(ctx context.Context, isolation SessionIsolation) {
+	worktreesRoot := filepath.Join(s.worktreeStateDir(), "agent", "worktrees")
+	record, err := readSessionWorktreeRecord(worktreeRecordPath(worktreesRoot, filepath.Base(isolation.WorktreePath)))
+	if err == nil {
+		rollbackSessionWorktree(ctx, worktreesRoot, record)
+	}
+}
+
+func readSessionWorktreeRecord(path string) (sessionWorktreeRecord, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return sessionWorktreeRecord{}, err
+	}
+	var record sessionWorktreeRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		return sessionWorktreeRecord{}, err
+	}
+	return record, nil
+}
+
+func (s *Service) SweepWorktreeIsolation(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	s.worktreeIsolationMu.Lock()
+	defer s.worktreeIsolationMu.Unlock()
+	if s.WorkspaceIDs == nil || s.SessionReader == nil {
+		return nil
+	}
+	workspaceIDs, err := s.WorkspaceIDs(ctx)
+	if err != nil {
+		return err
+	}
+	var sessions []PersistedSession
+	for _, workspaceID := range workspaceIDs {
+		roots, ok := s.SessionReader.ListSessions(workspaceID)
+		if !ok {
+			continue
+		}
+		sessions = append(sessions, roots...)
+		childrenReader, hasChildren := s.SessionReader.(ChildSessionReader)
+		if !hasChildren {
+			continue
+		}
+		for _, root := range roots {
+			children, listErr := childrenReader.ListChildSessions(ctx, workspaceID, root.ID)
+			if listErr != nil {
+				return listErr
+			}
+			sessions = append(sessions, children...)
+		}
+	}
+	return sweepSessionWorktrees(ctx, s.worktreeStateDir(), sessions, func(session PersistedSession) bool {
+		return s.persistedSessionCanResume(ctx, session)
+	})
+}
+
+func sweepSessionWorktrees(
+	ctx context.Context,
+	stateDir string,
+	sessions []PersistedSession,
+	canResume func(PersistedSession) bool,
+) error {
+	worktreesRoot := filepath.Join(filepath.Clean(stateDir), "agent", "worktrees")
+	entries, err := os.ReadDir(worktreeRecordsDir(worktreesRoot))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		recordPath := filepath.Join(worktreeRecordsDir(worktreesRoot), entry.Name())
+		record, readErr := readSessionWorktreeRecord(recordPath)
+		if readErr != nil {
+			continue
+		}
+		creatorIndex := -1
+		for index := range sessions {
+			if sessions[index].ID == record.SessionID && sessions[index].WorkspaceID == record.WorkspaceID {
+				creatorIndex = index
+				break
+			}
+		}
+		if creatorIndex >= 0 && canResume != nil && canResume(sessions[creatorIndex]) {
+			continue
+		}
+		blockedBySession := false
+		for index := range sessions {
+			if pathInsideWorktree(sessions[index].Cwd, record.WorktreePath) {
+				blockedBySession = true
+				break
+			}
+		}
+		if blockedBySession {
+			continue
+		}
+		if _, statErr := os.Stat(record.WorktreePath); errors.Is(statErr, os.ErrNotExist) {
+			if _, branchErr := gitRepoOutput(ctx, record, "show-ref", "--verify", "refs/heads/"+record.Branch); branchErr != nil {
+				if _, pruneErr := gitRepoOutput(ctx, record, "worktree", "prune"); pruneErr == nil {
+					_ = os.Remove(recordPath)
+				}
+				continue
+			}
+			aheadText, aheadErr := gitRepoOutput(ctx, record, "rev-list", "--count", record.BaseCommit+"..refs/heads/"+record.Branch)
+			if aheadErr != nil {
+				continue
+			}
+			ahead, parseErr := strconv.Atoi(strings.TrimSpace(aheadText))
+			if parseErr != nil || ahead != 0 {
+				continue
+			}
+			if _, branchErr := gitRepoOutput(ctx, record, "branch", "-D", record.Branch); branchErr != nil {
+				continue
+			}
+			if _, pruneErr := gitRepoOutput(ctx, record, "worktree", "prune"); pruneErr != nil {
+				continue
+			}
+			_ = os.Remove(recordPath)
+			continue
+		}
+		status, statusErr := gitOutput(ctx, record.WorktreePath, "status", "--porcelain")
+		if statusErr != nil || strings.TrimSpace(status) != "" {
+			continue
+		}
+		aheadText, aheadErr := gitRepoOutput(ctx, record, "rev-list", "--count", record.BaseCommit+"..refs/heads/"+record.Branch)
+		if aheadErr != nil {
+			continue
+		}
+		ahead, parseErr := strconv.Atoi(strings.TrimSpace(aheadText))
+		if parseErr != nil || ahead != 0 {
+			continue
+		}
+		if _, removeErr := gitRepoOutput(ctx, record, "worktree", "remove", record.WorktreePath); removeErr != nil {
+			continue
+		}
+		if _, branchErr := gitRepoOutput(ctx, record, "branch", "-D", record.Branch); branchErr != nil {
+			_, _ = gitRepoOutput(ctx, record, "worktree", "prune")
+			continue
+		}
+		if _, pruneErr := gitRepoOutput(ctx, record, "worktree", "prune"); pruneErr != nil {
+			return pruneErr
+		}
+		_ = os.Remove(recordPath)
+	}
+	return nil
+}
+
+func pathInsideWorktree(path string, worktreePath string) bool {
+	path = canonicalWorktreePath(path)
+	worktreePath = canonicalWorktreePath(worktreePath)
+	if path == "" || worktreePath == "" {
+		return false
+	}
+	relative, err := filepath.Rel(worktreePath, path)
+	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) && !filepath.IsAbs(relative)
+}
+
+func canonicalWorktreePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return ""
+	}
+	existing := abs
+	var suffix []string
+	for {
+		if _, statErr := os.Stat(existing); statErr == nil {
+			break
+		}
+		parent := filepath.Dir(existing)
+		if parent == existing {
+			return filepath.Clean(abs)
+		}
+		suffix = append([]string{filepath.Base(existing)}, suffix...)
+		existing = parent
+	}
+	if resolved, resolveErr := filepath.EvalSymlinks(existing); resolveErr == nil {
+		abs = filepath.Join(append([]string{resolved}, suffix...)...)
+	}
+	return filepath.Clean(abs)
+}

--- a/services/tuttid/service/agent/worktree_test.go
+++ b/services/tuttid/service/agent/worktree_test.go
@@ -1,0 +1,534 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
+)
+
+type recordingSessionDirectoryAllocator struct {
+	calls int
+	path  string
+}
+
+type recordingWorktreeSessionInitializer struct {
+	sessions *fakeSessionReader
+}
+
+func (i recordingWorktreeSessionInitializer) InitializeRuntimeSession(
+	ctx context.Context,
+	session ProviderRuntimeSession,
+) (PersistedSession, error) {
+	persisted, err := (fakeSessionInitializer{}).InitializeRuntimeSession(ctx, session)
+	if err == nil {
+		i.sessions.sessions[persisted.WorkspaceID+":"+persisted.ID] = persisted
+	}
+	return persisted, err
+}
+
+func (a *recordingSessionDirectoryAllocator) CreateSessionDirectory(context.Context) (string, error) {
+	a.calls++
+	if err := os.MkdirAll(a.path, 0o755); err != nil {
+		return "", err
+	}
+	return a.path, nil
+}
+
+func initSessionWorktreeRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repo := t.TempDir()
+	runGitForTest(t, repo, "init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, repo, "add", "tracked.txt")
+	runGitForTest(t, repo, "commit", "-q", "-m", "initial")
+	return repo
+}
+
+func createWorktreeFixture(t *testing.T, sessionID string) (string, string, SessionIsolation) {
+	t.Helper()
+	stateDir := t.TempDir()
+	repo := initSessionWorktreeRepo(t)
+	isolation, _, err := createSessionWorktree(context.Background(), stateDir, "workspace-1", repo, sessionID)
+	if err != nil {
+		t.Fatalf("createSessionWorktree() error = %v", err)
+	}
+	record := sessionWorktreeRecord{
+		SessionIsolation: isolation,
+		SessionID:        sessionID, WorkspaceID: "workspace-1", RepoRoot: repo,
+	}
+	t.Cleanup(func() {
+		rollbackSessionWorktree(context.Background(), filepath.Join(stateDir, "agent", "worktrees"), record)
+	})
+	return stateDir, repo, isolation
+}
+
+func TestCreateSessionWorktree(t *testing.T) {
+	stateDir, _, isolation := createWorktreeFixture(t, "session-create")
+	if isolation.Mode != WorktreeIsolationMode || isolation.Branch != "tutti/session-create" {
+		t.Fatalf("isolation = %#v", isolation)
+	}
+	if isolation.WorktreePath != filepath.Join(stateDir, "agent", "worktrees", "session-create") {
+		t.Fatalf("worktree path = %q", isolation.WorktreePath)
+	}
+	if _, err := os.Stat(filepath.Join(isolation.WorktreePath, "tracked.txt")); err != nil {
+		t.Fatalf("worktree tracked file: %v", err)
+	}
+	branch, err := gitOutput(context.Background(), isolation.WorktreePath, "branch", "--show-current")
+	if err != nil || strings.TrimSpace(branch) != isolation.Branch {
+		t.Fatalf("worktree branch = %q, err = %v", branch, err)
+	}
+}
+
+func TestCreateSessionWorktreeReportsDirtySourceWarning(t *testing.T) {
+	stateDir := t.TempDir()
+	repo := initSessionWorktreeRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	isolation, warnings, err := createSessionWorktree(context.Background(), stateDir, "workspace-1", repo, "session-dirty-source")
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := sessionWorktreeRecord{SessionIsolation: isolation, SessionID: "session-dirty-source", WorkspaceID: "workspace-1", RepoRoot: repo}
+	t.Cleanup(func() {
+		rollbackSessionWorktree(context.Background(), filepath.Join(stateDir, "agent", "worktrees"), record)
+	})
+	if len(warnings) != 1 || warnings[0].Code != worktreeDirtyBaseWarningCode {
+		t.Fatalf("warnings = %#v", warnings)
+	}
+	if _, statErr := os.Stat(filepath.Join(isolation.WorktreePath, "dirty.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("dirty source file is visible in worktree, stat error = %v", statErr)
+	}
+}
+
+func TestCreateSessionWorktreeRejectsNonGitDirectory(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	_, _, err := createSessionWorktree(context.Background(), t.TempDir(), "workspace-1", t.TempDir(), "session-not-git")
+	if !errors.Is(err, ErrNotAGitRepo) {
+		t.Fatalf("error = %v, want ErrNotAGitRepo", err)
+	}
+}
+
+func TestCreateSessionWorktreeRejectsUnavailableGit(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	_, _, err := createSessionWorktree(context.Background(), t.TempDir(), "workspace-1", t.TempDir(), "session-no-git")
+	if !errors.Is(err, ErrGitUnavailable) {
+		t.Fatalf("error = %v, want ErrGitUnavailable", err)
+	}
+}
+
+func TestCreateSessionWorktreeRejectsSubmodule(t *testing.T) {
+	parent := initSessionWorktreeRepo(t)
+	submoduleSource := initSessionWorktreeRepo(t)
+	runGitForTest(t, parent, "-c", "protocol.file.allow=always", "submodule", "add", "-q", submoduleSource, "nested")
+	runGitForTest(t, parent, "commit", "-q", "-am", "add submodule")
+	_, _, err := createSessionWorktree(context.Background(), t.TempDir(), "workspace-1", filepath.Join(parent, "nested"), "session-submodule")
+	if !errors.Is(err, ErrUnsupportedRepoLayout) {
+		t.Fatalf("error = %v, want ErrUnsupportedRepoLayout", err)
+	}
+}
+
+func TestCreateSessionWorktreeRejectsNestedRepository(t *testing.T) {
+	outer := initSessionWorktreeRepo(t)
+	nested := filepath.Join(outer, "nested")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, nested, "init", "-q", "-b", "main")
+	runGitForTest(t, nested, "commit", "-q", "--allow-empty", "-m", "nested")
+	_, _, err := createSessionWorktree(context.Background(), t.TempDir(), "workspace-1", nested, "session-nested")
+	if !errors.Is(err, ErrUnsupportedRepoLayout) {
+		t.Fatalf("error = %v, want ErrUnsupportedRepoLayout", err)
+	}
+}
+
+func TestCreateSessionWorktreePersistsAndProjectsIsolation(t *testing.T) {
+	_, _, isolation := createWorktreeFixture(t, "session-context")
+	runtimeContext := sessionIsolationRuntimeContext(map[string]any{"existing": true}, isolation)
+	if runtimeContext["existing"] != true {
+		t.Fatalf("runtime context existing field was lost: %#v", runtimeContext)
+	}
+	session := serviceSession(ProviderRuntimeSession{
+		ID: "session-context", Provider: "codex", Cwd: isolation.WorktreePath,
+		Visible: true, RuntimeContext: runtimeContext,
+	}, true)
+	if session.Isolation == nil || *session.Isolation != isolation {
+		t.Fatalf("projected isolation = %#v, want %#v", session.Isolation, isolation)
+	}
+}
+
+func TestServiceCreateUsesIsolatedWorktreeAndRuntimeContext(t *testing.T) {
+	stateDir := t.TempDir()
+	repo := initSessionWorktreeRepo(t)
+	runtime := newFakeRuntime()
+	service := newTestService(runtime)
+	service.WorktreeStateDir = stateDir
+	session, err := service.Create(context.Background(), "workspace-1", CreateSessionInput{
+		AgentSessionID: "session-service-create", AgentTargetID: agenttargetbiz.IDLocalCodex,
+		Cwd: stringPointer(repo), Isolation: WorktreeIsolationMode, InitialContent: TextPromptContent("work"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.Isolation == nil || session.Cwd != session.Isolation.WorktreePath {
+		t.Fatalf("session = %#v", session)
+	}
+	t.Cleanup(func() { service.rollbackSessionWorktree(context.Background(), *session.Isolation) })
+	if len(runtime.startCalls) != 1 || runtime.startCalls[0].Cwd != session.Isolation.WorktreePath {
+		t.Fatalf("runtime start calls = %#v", runtime.startCalls)
+	}
+	projected := sessionIsolationFromRuntimeContext(runtime.startCalls[0].RuntimeContext)
+	if projected == nil || *projected != *session.Isolation {
+		t.Fatalf("runtime isolation = %#v, want %#v", projected, session.Isolation)
+	}
+}
+
+func TestServiceCreateWorktreeIsolationRejectsEmptyCwdBeforeAllocation(t *testing.T) {
+	stateDir := t.TempDir()
+	allocatedPath := filepath.Join(stateDir, "agent", "sessions", "allocated")
+	allocator := &recordingSessionDirectoryAllocator{path: allocatedPath}
+	runtime := newFakeRuntime()
+	service := newTestService(runtime)
+	service.WorktreeStateDir = stateDir
+	service.SessionDirectoryAllocator = allocator
+	_, err := service.Create(context.Background(), "workspace-1", CreateSessionInput{
+		AgentSessionID: "session-empty-cwd", AgentTargetID: agenttargetbiz.IDLocalCodex,
+		Isolation: WorktreeIsolationMode, InitialContent: TextPromptContent("work"),
+	})
+	if !errors.Is(err, ErrNotAGitRepo) {
+		t.Fatalf("Create error = %v, want ErrNotAGitRepo", err)
+	}
+	if allocator.calls != 0 {
+		t.Fatalf("session directory allocator calls = %d, want 0", allocator.calls)
+	}
+	if _, statErr := os.Stat(filepath.Join(stateDir, "agent")); !os.IsNotExist(statErr) {
+		t.Fatalf("empty-cwd isolation left agent state behind: %v", statErr)
+	}
+	if len(runtime.startCalls) != 0 {
+		t.Fatalf("runtime start calls = %#v, want none", runtime.startCalls)
+	}
+}
+
+func TestServiceCreateRollsBackWorktreeWhenHostStartFails(t *testing.T) {
+	stateDir := t.TempDir()
+	repo := initSessionWorktreeRepo(t)
+	startErr := errors.New("start failed")
+	runtime := newFakeRuntime()
+	runtime.startErr = startErr
+	service := newTestService(runtime)
+	service.WorktreeStateDir = stateDir
+	_, err := service.Create(context.Background(), "workspace-1", CreateSessionInput{
+		AgentSessionID: "session-service-fail", AgentTargetID: agenttargetbiz.IDLocalCodex,
+		Cwd: stringPointer(repo), Isolation: WorktreeIsolationMode, InitialContent: TextPromptContent("work"),
+	})
+	if !errors.Is(err, startErr) {
+		t.Fatalf("Create error = %v, want %v", err, startErr)
+	}
+	worktreePath := filepath.Join(stateDir, "agent", "worktrees", "session-service-fail")
+	if _, statErr := os.Stat(worktreePath); !os.IsNotExist(statErr) {
+		t.Fatalf("failed create worktree still exists: %v", statErr)
+	}
+	if len(runtime.sessions) != 0 {
+		t.Fatalf("runtime sessions = %#v, want none", runtime.sessions)
+	}
+	if _, branchErr := gitOutput(context.Background(), repo, "show-ref", "--verify", "refs/heads/tutti/session-service-fail"); branchErr == nil {
+		t.Fatal("failed create branch still exists")
+	}
+}
+
+func TestServiceCreateSerializesWorktreeWithSweep(t *testing.T) {
+	stateDir := t.TempDir()
+	repo := initSessionWorktreeRepo(t)
+	startEntered := make(chan struct{})
+	releaseStart := make(chan struct{})
+	runtime := newFakeRuntime()
+	runtime.startHook = func(input RuntimeStartInput, session ProviderRuntimeSession) ProviderRuntimeSession {
+		if err := os.WriteFile(filepath.Join(input.Cwd, "creating.txt"), []byte("creating\n"), 0o644); err != nil {
+			t.Errorf("write creating marker: %v", err)
+		}
+		close(startEntered)
+		<-releaseStart
+		return session
+	}
+	service := newTestService(runtime)
+	service.WorktreeStateDir = stateDir
+	service.WorkspaceIDs = func(context.Context) ([]string, error) { return []string{"workspace-1"}, nil }
+	service.SessionReader = fakeSessionReader{sessions: map[string]PersistedSession{}}
+
+	createDone := make(chan struct{})
+	var created Session
+	var createErr error
+	go func() {
+		defer close(createDone)
+		created, createErr = service.Create(context.Background(), "workspace-1", CreateSessionInput{
+			AgentSessionID: "session-concurrent-create", AgentTargetID: agenttargetbiz.IDLocalCodex,
+			Cwd: stringPointer(repo), Isolation: WorktreeIsolationMode, InitialContent: TextPromptContent("work"),
+		})
+	}()
+	select {
+	case <-startEntered:
+	case <-createDone:
+		t.Fatalf("Create finished before runtime start hook: %v", createErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for runtime start hook")
+	}
+	if service.worktreeIsolationMu.TryLock() {
+		service.worktreeIsolationMu.Unlock()
+		t.Fatal("worktree isolation lock was not held during session creation")
+	}
+
+	sweepStarted := make(chan struct{})
+	sweepDone := make(chan error, 1)
+	go func() {
+		close(sweepStarted)
+		sweepDone <- service.SweepWorktreeIsolation(context.Background())
+	}()
+	<-sweepStarted
+	select {
+	case err := <-sweepDone:
+		t.Fatalf("sweep completed during worktree creation: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(releaseStart)
+	select {
+	case <-createDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for isolated create")
+	}
+	if createErr != nil {
+		t.Fatalf("Create error = %v", createErr)
+	}
+	select {
+	case err := <-sweepDone:
+		if err != nil {
+			t.Fatalf("SweepWorktreeIsolation error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for worktree sweep")
+	}
+	if created.Isolation == nil {
+		t.Fatalf("created session isolation = %#v", created.Isolation)
+	}
+	t.Cleanup(func() { service.rollbackSessionWorktree(context.Background(), *created.Isolation) })
+	assertWorktreeExists(t, created.Isolation.WorktreePath)
+}
+
+func TestServiceCreateSerializesManagedCwdReferenceWithSweep(t *testing.T) {
+	stateDir, _, isolation := createWorktreeFixture(t, "session-gc-reference-race")
+	managedCwd := filepath.Join(isolation.WorktreePath, "nested")
+	if err := os.MkdirAll(managedCwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	startEntered := make(chan struct{})
+	releaseStart := make(chan struct{})
+	runtime := newFakeRuntime()
+	runtime.startHook = func(_ RuntimeStartInput, session ProviderRuntimeSession) ProviderRuntimeSession {
+		close(startEntered)
+		<-releaseStart
+		return session
+	}
+	service := newTestService(runtime)
+	service.WorktreeStateDir = stateDir
+	service.WorkspaceIDs = func(context.Context) ([]string, error) { return []string{"workspace-1"}, nil }
+	sessions := &fakeSessionReader{sessions: map[string]PersistedSession{}}
+	service.SessionReader = sessions
+	service.SessionInitializer = recordingWorktreeSessionInitializer{sessions: sessions}
+
+	createDone := make(chan error, 1)
+	go func() {
+		_, err := service.Create(context.Background(), "workspace-1", CreateSessionInput{
+			AgentSessionID: "session-referencing-managed-cwd", AgentTargetID: agenttargetbiz.IDLocalCodex,
+			Cwd: stringPointer(managedCwd),
+		})
+		createDone <- err
+	}()
+	select {
+	case <-startEntered:
+	case err := <-createDone:
+		t.Fatalf("Create finished before runtime start hook: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for runtime start hook")
+	}
+	if service.worktreeIsolationMu.TryLock() {
+		service.worktreeIsolationMu.Unlock()
+		t.Fatal("worktree GC lock was not held while creating a session with a managed cwd")
+	}
+
+	sweepDone := make(chan error, 1)
+	go func() { sweepDone <- service.SweepWorktreeIsolation(context.Background()) }()
+	select {
+	case err := <-sweepDone:
+		t.Fatalf("sweep completed while the managed cwd session was being created: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(releaseStart)
+	select {
+	case err := <-createDone:
+		if err != nil {
+			t.Fatalf("Create error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for managed cwd session create")
+	}
+	select {
+	case err := <-sweepDone:
+		if err != nil {
+			t.Fatalf("SweepWorktreeIsolation error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for worktree sweep")
+	}
+	assertWorktreeExists(t, isolation.WorktreePath)
+}
+
+func TestSweepSessionWorktreesKeepsDirtyWorktree(t *testing.T) {
+	stateDir, _, isolation := createWorktreeFixture(t, "session-gc-dirty")
+	if err := os.WriteFile(filepath.Join(isolation.WorktreePath, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := sweepSessionWorktrees(context.Background(), stateDir, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	assertWorktreeExists(t, isolation.WorktreePath)
+}
+
+func TestSweepSessionWorktreesKeepsAheadBranch(t *testing.T) {
+	stateDir, _, isolation := createWorktreeFixture(t, "session-gc-ahead")
+	if err := os.WriteFile(filepath.Join(isolation.WorktreePath, "committed.txt"), []byte("commit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, isolation.WorktreePath, "add", "committed.txt")
+	runGitForTest(t, isolation.WorktreePath, "commit", "-q", "-m", "worktree commit")
+	if err := sweepSessionWorktrees(context.Background(), stateDir, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	assertWorktreeExists(t, isolation.WorktreePath)
+}
+
+func TestSweepSessionWorktreesKeepsAheadRecordedBranchWhenHeadDetached(t *testing.T) {
+	stateDir, repo, isolation := createWorktreeFixture(t, "session-gc-ahead-detached")
+	if err := os.WriteFile(filepath.Join(isolation.WorktreePath, "committed.txt"), []byte("commit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, isolation.WorktreePath, "add", "committed.txt")
+	runGitForTest(t, isolation.WorktreePath, "commit", "-q", "-m", "worktree commit")
+	runGitForTest(t, isolation.WorktreePath, "checkout", "-q", "--detach", isolation.BaseCommit)
+	if err := sweepSessionWorktrees(context.Background(), stateDir, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	assertWorktreeExists(t, isolation.WorktreePath)
+	if _, err := gitOutput(context.Background(), repo, "show-ref", "--verify", "refs/heads/"+isolation.Branch); err != nil {
+		t.Fatalf("recorded branch %q was removed: %v", isolation.Branch, err)
+	}
+}
+
+func TestSweepSessionWorktreesKeepsResumableCreator(t *testing.T) {
+	stateDir, repo, isolation := createWorktreeFixture(t, "session-gc-resumable")
+	sessions := []PersistedSession{{ID: "session-gc-resumable", WorkspaceID: "workspace-1", Cwd: repo}}
+	canResumeCalled := false
+	if err := sweepSessionWorktrees(context.Background(), stateDir, sessions, func(PersistedSession) bool {
+		canResumeCalled = true
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !canResumeCalled {
+		t.Fatal("creator resumability was not evaluated")
+	}
+	assertWorktreeExists(t, isolation.WorktreePath)
+}
+
+func TestSweepSessionWorktreesKeepsTreeUsedByAnotherSession(t *testing.T) {
+	stateDir, repo, isolation := createWorktreeFixture(t, "session-gc-used")
+	sessions := []PersistedSession{
+		{ID: "session-gc-used", WorkspaceID: "workspace-1", Cwd: repo},
+		{ID: "other-session", WorkspaceID: "workspace-1", Cwd: filepath.Join(isolation.WorktreePath, "nested")},
+	}
+	if err := sweepSessionWorktrees(context.Background(), stateDir, sessions, func(PersistedSession) bool { return false }); err != nil {
+		t.Fatal(err)
+	}
+	assertWorktreeExists(t, isolation.WorktreePath)
+}
+
+func TestSweepSessionWorktreesKeepsTreeReferencedByUnresumableCreator(t *testing.T) {
+	stateDir, _, isolation := createWorktreeFixture(t, "session-gc-creator-cwd")
+	sessions := []PersistedSession{{ID: "session-gc-creator-cwd", WorkspaceID: "workspace-1", Cwd: isolation.WorktreePath}}
+	if err := sweepSessionWorktrees(context.Background(), stateDir, sessions, func(PersistedSession) bool { return false }); err != nil {
+		t.Fatal(err)
+	}
+	assertWorktreeExists(t, isolation.WorktreePath)
+}
+
+func TestSweepSessionWorktreesDeletesCleanOrphanAndBranch(t *testing.T) {
+	stateDir, repo, isolation := createWorktreeFixture(t, "session-gc-delete")
+	if err := sweepSessionWorktrees(context.Background(), stateDir, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(isolation.WorktreePath); !os.IsNotExist(err) {
+		t.Fatalf("worktree still exists, stat error = %v", err)
+	}
+	if _, err := gitOutput(context.Background(), repo, "show-ref", "--verify", "refs/heads/"+isolation.Branch); err == nil {
+		t.Fatalf("branch %q still exists", isolation.Branch)
+	}
+}
+
+func TestSweepSessionWorktreesCleansChildAfterParentWorktreeRemoved(t *testing.T) {
+	stateDir := t.TempDir()
+	repo := initSessionWorktreeRepo(t)
+	parent, _, err := createSessionWorktree(context.Background(), stateDir, "workspace-1", repo, "session-gc-parent")
+	if err != nil {
+		t.Fatalf("create parent worktree: %v", err)
+	}
+	child, _, err := createSessionWorktree(context.Background(), stateDir, "workspace-1", parent.WorktreePath, "session-gc-child")
+	if err != nil {
+		t.Fatalf("create child worktree from parent cwd: %v", err)
+	}
+	worktreesRoot := filepath.Join(stateDir, "agent", "worktrees")
+	childRecord, err := readSessionWorktreeRecord(worktreeRecordPath(worktreesRoot, "session-gc-child"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if childRecord.GitCommonDir == "" || pathInsideWorktree(childRecord.GitCommonDir, parent.WorktreePath) {
+		t.Fatalf("child GC anchor %q depends on collectable parent worktree %q", childRecord.GitCommonDir, parent.WorktreePath)
+	}
+	runGitForTest(t, repo, "worktree", "remove", parent.WorktreePath)
+	runGitForTest(t, repo, "branch", "-D", parent.Branch)
+	if err := os.Remove(worktreeRecordPath(worktreesRoot, "session-gc-parent")); err != nil {
+		t.Fatal(err)
+	}
+	if err := sweepSessionWorktrees(context.Background(), stateDir, nil, nil); err != nil {
+		t.Fatalf("sweep after parent removal: %v", err)
+	}
+	if _, statErr := os.Stat(child.WorktreePath); !os.IsNotExist(statErr) {
+		t.Fatalf("child worktree still exists, stat error = %v", statErr)
+	}
+	if _, branchErr := gitOutput(context.Background(), repo, "show-ref", "--verify", "refs/heads/"+child.Branch); branchErr == nil {
+		t.Fatalf("child branch %q still exists", child.Branch)
+	}
+	if _, statErr := os.Stat(worktreeRecordPath(worktreesRoot, "session-gc-child")); !os.IsNotExist(statErr) {
+		t.Fatalf("child record still exists, stat error = %v", statErr)
+	}
+}
+
+func assertWorktreeExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("worktree %q does not exist: %v", path, err)
+	}
+}

--- a/services/tuttid/service/cli/framework/register.go
+++ b/services/tuttid/service/cli/framework/register.go
@@ -40,7 +40,14 @@ func Register[T any](spec CommandSpec[T]) cliservice.Command {
 			if err != nil {
 				return cliservice.CommandOutput{}, err
 			}
-			return FormatOutput(spec.Output, request.OutputMode, result)
+			output, err := FormatOutput(spec.Output, request.OutputMode, result)
+			if err != nil {
+				return cliservice.CommandOutput{}, err
+			}
+			if spec.Output.Warnings != nil {
+				output.Warnings = spec.Output.Warnings(result)
+			}
+			return output, nil
 		},
 	}
 }

--- a/services/tuttid/service/cli/framework/spec.go
+++ b/services/tuttid/service/cli/framework/spec.go
@@ -82,6 +82,7 @@ type OutputSpec struct {
 	PlainText     func(any) string
 	Markdown      func(any) string
 	ListCompact   bool
+	Warnings      func(any) []cliservice.CommandWarning
 }
 
 type TableOutputSpec struct {

--- a/services/tuttid/service/cli/providers/agentcontext/compact_output.go
+++ b/services/tuttid/service/cli/providers/agentcontext/compact_output.go
@@ -41,6 +41,9 @@ func sessionSummaryValue(session agentservice.Session) map[string]any {
 	if session.Title != nil {
 		value["title"] = strings.TrimSpace(*session.Title)
 	}
+	if session.Isolation != nil {
+		value["isolation"] = isolationCompactValue(*session.Isolation)
+	}
 	return value
 }
 
@@ -65,7 +68,17 @@ func sessionActionValue(session agentservice.Session) map[string]any {
 			value["title"] = title
 		}
 	}
+	if session.Isolation != nil {
+		value["isolation"] = isolationCompactValue(*session.Isolation)
+	}
 	return value
+}
+
+func isolationCompactValue(isolation agentservice.SessionIsolation) map[string]any {
+	return map[string]any{
+		"mode": strings.TrimSpace(isolation.Mode), "worktreePath": strings.TrimSpace(isolation.WorktreePath),
+		"branch": strings.TrimSpace(isolation.Branch), "baseCommit": strings.TrimSpace(isolation.BaseCommit),
+	}
 }
 
 func sessionSummaryValues(sessions []agentservice.Session) []any {

--- a/services/tuttid/service/cli/providers/agentcontext/compact_output_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/compact_output_test.go
@@ -166,6 +166,24 @@ func TestSessionActionValueIncludesExactAgentTarget(t *testing.T) {
 	}
 }
 
+func TestSessionValuesIncludeWorktreeIsolation(t *testing.T) {
+	session := agentserviceSessionWithRuntime()
+	session.Isolation = &agentservice.SessionIsolation{
+		Mode: "worktree", WorktreePath: "/state/agent/worktrees/SESSION-1",
+		Branch: "tutti/SESSION-1", BaseCommit: "abc123",
+	}
+	for name, value := range map[string]map[string]any{
+		"summary": sessionSummaryValue(session),
+		"action":  sessionActionValue(session),
+	} {
+		isolation, ok := value["isolation"].(map[string]any)
+		if !ok || isolation["mode"] != "worktree" || isolation["worktreePath"] != "/state/agent/worktrees/SESSION-1" ||
+			isolation["branch"] != "tutti/SESSION-1" || isolation["baseCommit"] != "abc123" {
+			t.Fatalf("%s isolation = %#v", name, value["isolation"])
+		}
+	}
+}
+
 func TestSessionSummaryValueOmitsOptionalEmptyRuntimeProtocolFields(t *testing.T) {
 	value := sessionSummaryValue(agentservice.Session{
 		ID:           "SESSION-1",

--- a/services/tuttid/service/cli/providers/agentcontext/legacy_compat.go
+++ b/services/tuttid/service/cli/providers/agentcontext/legacy_compat.go
@@ -298,7 +298,11 @@ func (p Provider) newLegacyStartCommand(name string, targetID string) cliservice
 			if err != nil {
 				return nil, err
 			}
-			return p.runStart(ctx, invoke, target, startFields(input))
+			return p.runStart(ctx, invoke, target, startFields{
+				Cwd: input.Cwd, DisplayPrompt: input.DisplayPrompt, Hidden: input.Hidden, Images: input.Images,
+				Model: input.Model, PermissionMode: input.PermissionMode, Prompt: input.Prompt,
+				ReasoningEffort: input.ReasoningEffort, Show: input.Show, Speed: input.Speed, Title: input.Title,
+			})
 		},
 	})
 }

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -118,13 +118,18 @@ func (f *fakeAgentSessions) Create(_ context.Context, workspaceID string, input 
 	if input.Visible != nil {
 		visible = *input.Visible
 	}
-	return agentservice.Session{
+	session := agentservice.Session{
 		ID:            "SESSION-NEW",
 		AgentTargetID: input.AgentTargetID,
 		Provider:      input.Provider,
 		Cwd:           cwd,
 		Visible:       visible,
-	}, nil
+	}
+	if input.Isolation == "worktree" {
+		session.Isolation = &agentservice.SessionIsolation{Mode: "worktree", WorktreePath: "/state/worktree", Branch: "tutti/SESSION-NEW", BaseCommit: "abc123"}
+		session.Warnings = []agentservice.SessionWarning{{Code: "worktree_base_dirty", Message: "dirty source"}}
+	}
+	return session, nil
 }
 
 func (f *fakeAgentSessions) Get(_ context.Context, workspaceID string, sessionID string) (agentservice.Session, error) {
@@ -1288,6 +1293,33 @@ func TestStartCommandInheritsCallerSessionCwd(t *testing.T) {
 	}
 	if sessions.createInput.Cwd == nil || *sessions.createInput.Cwd != "/workspace/a" {
 		t.Fatalf("Cwd = %#v, want /workspace/a", sessions.createInput.Cwd)
+	}
+}
+
+func TestStartCommandExposesAndPassesWorktreeIsolation(t *testing.T) {
+	sessions := &fakeAgentSessions{}
+	command := newTestCodexStartCommand(newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
+	properties := command.Capability.InputSchema["properties"].(map[string]any)
+	isolationSchema, ok := properties["isolation"].(map[string]any)
+	if !ok {
+		t.Fatalf("isolation schema = %#v", properties["isolation"])
+	}
+	enum, ok := isolationSchema["enum"].([]string)
+	if !ok || len(enum) != 1 || enum[0] != "worktree" {
+		t.Fatalf("isolation enum = %#v", isolationSchema["enum"])
+	}
+	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
+		Input:      map[string]any{"agent-id": agenttargetbiz.IDLocalCodex, "cwd": "/workspace/a", "isolation": "worktree", "prompt": "do work"},
+		OutputMode: cliservice.OutputModeJSON,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions.createInput.Isolation != "worktree" {
+		t.Fatalf("CreateSessionInput.Isolation = %q", sessions.createInput.Isolation)
+	}
+	if len(output.Warnings) != 1 || output.Warnings[0].Code != "worktree_base_dirty" {
+		t.Fatalf("output warnings = %#v", output.Warnings)
 	}
 }
 

--- a/services/tuttid/service/cli/providers/agentcontext/session_commands.go
+++ b/services/tuttid/service/cli/providers/agentcontext/session_commands.go
@@ -30,6 +30,7 @@ type startInput struct {
 	DisplayPrompt   string   `cli:"display-prompt"`
 	Hidden          bool     `cli:"hidden"`
 	Images          []string `cli:"image" description:"Image file to attach to the initial prompt. May be passed multiple times."`
+	Isolation       string   `cli:"isolation" enum:"worktree" description:"Run the new session in a dedicated git worktree."`
 	Model           string   `cli:"model"`
 	PermissionMode  string   `cli:"permission-mode"`
 	Prompt          string   `cli:"prompt" validate:"required"`
@@ -55,6 +56,7 @@ type sessionActionResult struct {
 	Session          agentservice.Session
 	LaunchRequested  bool
 	WaitAfterVersion *uint64
+	Warnings         []cliservice.CommandWarning
 }
 
 func (p Provider) newStartCommand() cliservice.Command {
@@ -78,6 +80,7 @@ func (p Provider) newStartCommand() cliservice.Command {
 				DisplayPrompt:   input.DisplayPrompt,
 				Hidden:          input.Hidden,
 				Images:          input.Images,
+				Isolation:       input.Isolation,
 				Model:           input.Model,
 				PermissionMode:  input.PermissionMode,
 				Prompt:          input.Prompt,
@@ -95,6 +98,7 @@ type startFields struct {
 	DisplayPrompt   string
 	Hidden          bool
 	Images          []string
+	Isolation       string
 	Model           string
 	PermissionMode  string
 	Prompt          string
@@ -134,6 +138,7 @@ func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, 
 		Title:                  optionalStringPointer(input.Title),
 		Visible:                hiddenVisibleOverride(input.Hidden),
 		ConversationDetailMode: p.composerConversationDetailMode(ctx),
+		Isolation:              input.Isolation,
 	})
 	if err != nil {
 		return nil, err
@@ -145,7 +150,11 @@ func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, 
 		}
 		launchRequested = true
 	}
-	return sessionActionResult{Session: session, LaunchRequested: launchRequested}, nil
+	warnings := make([]cliservice.CommandWarning, 0, len(session.Warnings))
+	for _, warning := range session.Warnings {
+		warnings = append(warnings, cliservice.CommandWarning{Code: warning.Code, Message: warning.Message})
+	}
+	return sessionActionResult{Session: session, LaunchRequested: launchRequested, Warnings: warnings}, nil
 }
 
 func (p Provider) composerConversationDetailMode(ctx context.Context) string {
@@ -407,6 +416,9 @@ func sessionActionOutputSpec() framework.OutputSpec {
 				}
 				return value
 			},
+		},
+		Warnings: func(result any) []cliservice.CommandWarning {
+			return append([]cliservice.CommandWarning(nil), result.(sessionActionResult).Warnings...)
 		},
 	}
 }

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -400,6 +400,18 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 	agentSessionService.SessionDirectoryAllocator = agentservice.LocalSessionDirectoryAllocator{
 		StateDir: tuttitypes.DefaultStateDir(),
 	}
+	agentSessionService.WorktreeStateDir = tuttitypes.DefaultStateDir()
+	agentSessionService.WorkspaceIDs = func(ctx context.Context) ([]string, error) {
+		workspaces, err := store.List(ctx)
+		if err != nil {
+			return nil, err
+		}
+		ids := make([]string, 0, len(workspaces))
+		for _, workspace := range workspaces {
+			ids = append(ids, workspace.ID)
+		}
+		return ids, nil
+	}
 	agentSessionService.PromptAttachmentStore = agentservice.PromptAttachmentStore{
 		RootDir:       tuttitypes.DefaultStateDir(),
 		SourceRootDir: filepath.Join(tuttitypes.DefaultStateDir(), "agent-prompt-assets"),
@@ -419,6 +431,7 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 	go agentHost.RunRuntimeOperationWorker(ctx)
 	go agentHost.RunGoalOperationWorker(ctx)
 	go agentHost.RunGoalReconcileInboxWorker(ctx)
+	go agentHost.RunWorktreeGarbageCollectionWorker(ctx)
 
 	workspaceService := workspaceservice.CatalogService{
 		Store:            store,


### PR DESCRIPTION
## Summary

- Add daemon-owned `tutti agent start --isolation worktree` support while preserving the existing start behavior when isolation is omitted. Isolated sessions use `<state-dir>/agent/worktrees/<session-id>` on `tutti/<session-id>`, based on the resolved launch cwd's `HEAD`, and persist their coordinates in the existing runtime-context JSON.
- Fail closed for unavailable Git, non-Git cwd values, nested repositories/submodules, and worktree creation failures. Failed creates roll back worktree/branch metadata, while dirty source checkouts remain allowed and return a warning that uncommitted changes are not included.
- Expose isolation coordinates in compact session/action JSON and schedule conservative garbage collection from Host startup recovery plus a five-minute worker. The adapter removes a worktree only when it is clean with no commits ahead of its base, its creator is absent or non-resumable, and no session cwd is inside the tree.
- Cover creation, error classification, output projection, rollback, concurrency, Host recovery, and every GC retention/deletion condition with real Git fixtures and conformance tests. Document the CLI contract, Host ownership, and daemon local-state layout.

## Verification

- `go test ./services/tuttid/service/agent/... ./services/tuttid/service/cli/... ./services/tuttid/apierrors/... ./packages/agent/host/... -count=1`
- `go build ./services/tuttid/... ./packages/agent/host/...`
- `pnpm lint:go` (pinned `golangci-lint v2.12.0`; 0 issues in all 8 modules)
- `pnpm check:agent-host-boundary`
- `pnpm check:i18n`
- `pnpm check:full` (19 tasks passed in the pre-push hook)
- `git diff --check`
- No live-daemon end-to-end operation was run, as required; verification used tests and static/build checks only.

## 最终验收记录中的未验证项（原样保留）

- packages/agent/host 与 services/tuttid 的 golangci-lint 检查未验证：当前环境找不到 golangci-lint。

## Fallback Three Questions

- Source: worktrees become collectible only after repository state, creator resumability, and all session cwd references independently satisfy the cleanup conditions.
- Why can it not be fixed at that source? No turn/runtime terminal event can safely prove all three conditions, and deleting on `EndedAt` would break resumable sessions; the sweep must re-evaluate durable session and Git state.
- Removal condition: the timer can be removed if Host gains an equivalent durable scheduler or event source that guarantees startup recovery and eventual re-evaluation of all three conditions without attaching deletion to session or runtime termination.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->