### PR TITLE
fix(agent-gui): stop JSON fields leaking into autolinks

### DIFF
--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -334,6 +334,25 @@ describe("AgentMessageMarkdown", () => {
     );
   });
 
+  it("keeps JSON fields after a bare URL outside the link", () => {
+    const url = "https://github.com/tutti-os/tutti/pull/1355";
+    const content = JSON.stringify({
+      result: "mr_created",
+      prUrl: url,
+      branch: "feat/agent-worktree-isolation",
+      commit: "5f640250dc9565834ff4cec925104c05a02cd230",
+      checks: "focused Go tests/build"
+    });
+    render(<AgentMessageMarkdown content={content} />);
+
+    const link = screen.getByRole("link", { name: url });
+    expect(link).toHaveAttribute("data-agent-link-href", url);
+    expect(screen.getAllByRole("link")).toHaveLength(1);
+    expect(link.parentElement).toHaveTextContent(
+      `"prUrl":"${url}","branch":"feat/agent-worktree-isolation"`
+    );
+  });
+
   it("renders unsafe markdown links as plain text", () => {
     const onLinkClick = vi.fn();
     render(

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -66,7 +66,7 @@ import {
   textFromReactNode
 } from "./AgentMessageMarkdownRenderers";
 import { MarkdownMedia } from "./AgentMessageMarkdownMedia";
-import { remarkCjkAutolinkBoundary } from "./remarkCjkAutolinkBoundary";
+import { remarkLiteralAutolinkBoundary } from "./remarkLiteralAutolinkBoundary";
 export { resetCachedMarkdownImagesForTests } from "./AgentMessageMarkdownMedia";
 export type { StreamingMarkdownBlock } from "./agentMessageMarkdownRuntime";
 export { splitStreamingMarkdownBlocks } from "./agentMessageMarkdownRuntime";
@@ -308,7 +308,7 @@ export function AgentMessageMarkdown({
           />
         ) : (
           <ReactMarkdown
-            remarkPlugins={[remarkGfm, remarkCjkAutolinkBoundary]}
+            remarkPlugins={[remarkGfm, remarkLiteralAutolinkBoundary]}
             rehypePlugins={[[rehypeSanitize, MARKDOWN_SANITIZE_SCHEMA]]}
             urlTransform={markdownUrlTransform}
             components={markdownComponents}
@@ -363,7 +363,7 @@ const MemoizedMarkdownBlock = memo(function MemoizedMarkdownBlock({
 }): JSX.Element {
   return (
     <ReactMarkdown
-      remarkPlugins={[remarkGfm, remarkCjkAutolinkBoundary]}
+      remarkPlugins={[remarkGfm, remarkLiteralAutolinkBoundary]}
       rehypePlugins={[[rehypeSanitize, MARKDOWN_SANITIZE_SCHEMA]]}
       urlTransform={markdownUrlTransform}
       components={components}

--- a/packages/agent/gui/shared/remarkLiteralAutolinkBoundary.ts
+++ b/packages/agent/gui/shared/remarkLiteralAutolinkBoundary.ts
@@ -22,14 +22,15 @@ interface SplitAutolink {
   trailing: MarkdownNode;
 }
 
-const CJK_SENTENCE_BOUNDARY = /[，。；：！？、…）】》」』〉〕］｝”’]/u;
+const LITERAL_AUTOLINK_BOUNDARY = /["，。；：！？、…）】》」』〉〕］｝”’]/u;
 
 /**
- * GFM literal autolinks only recognize ASCII trailing punctuation. Repair the
- * product-facing CJK sentence boundary without changing explicit Markdown
- * links, angle autolinks, code, or deliberately authored link destinations.
+ * GFM literal autolinks do not stop at every boundary that is invalid inside a
+ * raw URL. Repair product-facing CJK sentence boundaries and JSON string
+ * boundaries without changing explicit Markdown links, angle autolinks, code,
+ * or deliberately authored link destinations.
  */
-export function remarkCjkAutolinkBoundary() {
+export function remarkLiteralAutolinkBoundary() {
   return (tree: unknown, file: unknown): void => {
     if (!isMarkdownNode(tree)) {
       return;
@@ -89,7 +90,7 @@ function splitLiteralAutolink(
     return null;
   }
 
-  const boundaryIndex = display.search(CJK_SENTENCE_BOUNDARY);
+  const boundaryIndex = display.search(LITERAL_AUTOLINK_BOUNDARY);
   if (boundaryIndex < 0) {
     return null;
   }


### PR DESCRIPTION
## Summary

- stop GFM literal autolinks at JSON string boundaries
- generalize the existing CJK boundary repair into a literal-autolink boundary plugin
- add a regression test for structured JSON responses containing a PR URL

## Validation

- pnpm --filter @tutti-os/agent-gui test (194 files, 1807 tests)
- pnpm typecheck
- pnpm check:changed -- --tail-lines 80 (13 lanes)
- git diff --check
- pre-commit formatting, lint, Electron/UI/renderer/AgentGUI boundary checks

## Unverified full-check lanes

- pnpm check:full could not complete because golangci-lint is unavailable in the current environment
- the unrelated Go test TestScanExternalImportsAppliesCodexSQLiteTitle also fails because its scan returns no external sessions; this PR changes only AgentGUI TypeScript files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->