### PR TITLE
perf(agent-gui): stabilize traced render hot paths

### DIFF
--- a/.codex/skills/analyze-performance-traces/SKILL.md
+++ b/.codex/skills/analyze-performance-traces/SKILL.md
@@ -10,7 +10,24 @@ Turn a large trace into an evidence chain ending at concrete files, symbols, and
 ## Start safely
 
 1. Read repository instructions and relevant architecture docs before interpreting ownership or editing.
-2. Inspect file size and envelope; never print or load a huge trace into model context:
+2. If no trace is supplied or discoverable, ask the user to capture the smallest reproducible desktop window. For this repository, have them launch Tutti with tracing enabled:
+
+   ```sh
+   TUTTI_ELECTRON_REMOTE_DEBUGGING_PORT=9223 \
+   TUTTI_ELECTRON_JS_FLAGS=--max-old-space-size=8192 \
+   VITE_TUTTI_WHY_DID_YOU_RENDER=0 \
+   make dev-gui
+   ```
+
+   Then have them reproduce the issue while recording from another terminal:
+
+   ```sh
+   pnpm trace:desktop -- --duration 15
+   ```
+
+   Ask for the generated `TuttiTrace-<timestamp>.json` path before trace-backed analysis. Do not invent trace findings while waiting. If the user explicitly wants source-only analysis, proceed but label conclusions as hypotheses without trace evidence.
+
+3. Inspect file size and envelope; never print or load a huge trace into model context:
 
    ```sh
    ls -lh TRACE.json
@@ -18,13 +35,13 @@ Turn a large trace into an evidence chain ending at concrete files, symbols, and
    tail -c 512 TRACE.json
    ```
 
-3. Run the bundled bounded-memory summarizer:
+4. Run the bundled bounded-memory summarizer:
 
    ```sh
-   node <skill-dir>/scripts/summarize_trace.mjs TRACE.json --top 40 --min-ms 16
+   node <skill-dir>/scripts/summarize-trace TRACE.json --top 40 --min-ms 16
    ```
 
-4. Record whether the trace includes development-only profiling, React component tracks, source maps, screenshots, or multiple renderer processes. Treat profiler startup and instrumentation cost separately from product cost.
+5. Record whether the trace includes development-only profiling, React component tracks, source maps, screenshots, or multiple renderer processes. Treat profiler startup and instrumentation cost separately from product cost.
 
 ## Build the evidence chain
 
@@ -105,4 +122,4 @@ Never claim millisecond or frame-rate improvement without a comparable post-chan
 
 ## Bundled script
 
-`scripts/summarize_trace.mjs` streams `traceEvents`, keeps bounded top-event state, and outputs JSON containing thread metadata, event totals, long tasks, frame signals, and source hints. Use it for the first pass; write narrow follow-up scripts only after a specific hypothesis exists.
+`scripts/summarize-trace` streams `traceEvents`, keeps bounded top-event state, and outputs JSON containing thread metadata, event totals, long tasks, frame signals, and source hints. Use it for the first pass; write narrow follow-up scripts only after a specific hypothesis exists.

--- a/.codex/skills/analyze-performance-traces/SKILL.md
+++ b/.codex/skills/analyze-performance-traces/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: analyze-performance-traces
+description: Analyze large Chrome, Chromium, Electron, React DevTools, or Perfetto-compatible JSON performance traces without loading the whole file into context; locate concrete source-level bottlenecks, explain trigger-to-layout/render chains, classify behavior-preserving versus user-observable optimizations, implement safe fixes when requested, and verify semantic equivalence. Use for trace files, dropped frames, long tasks, resize jank, render storms, layout thrashing, selector hot paths, interaction latency, or requests to identify exact code choke points from profiling evidence.
+---
+
+# Analyze Performance Traces
+
+Turn a large trace into an evidence chain ending at concrete files, symbols, and lines. Optimize root causes only. Keep measured facts separate from inference.
+
+## Start safely
+
+1. Read repository instructions and relevant architecture docs before interpreting ownership or editing.
+2. Inspect file size and envelope; never print or load a huge trace into model context:
+
+   ```sh
+   ls -lh TRACE.json
+   head -c 512 TRACE.json
+   tail -c 512 TRACE.json
+   ```
+
+3. Run the bundled bounded-memory summarizer:
+
+   ```sh
+   node <skill-dir>/scripts/summarize_trace.mjs TRACE.json --top 40 --min-ms 16
+   ```
+
+4. Record whether the trace includes development-only profiling, React component tracks, source maps, screenshots, or multiple renderer processes. Treat profiler startup and instrumentation cost separately from product cost.
+
+## Build the evidence chain
+
+Work in this order:
+
+1. **Select process/thread**: use metadata to identify browser main, renderer main, compositor, workers, and GPU threads. Do not combine their durations.
+2. **Find symptoms**: quantify long tasks, worst interactions, dropped/begin frames, layout/style duration, scripting duration, and burst windows.
+3. **Correlate timestamps**: connect input/resize/timer events to state updates, React renders, style recalculation, layout, paint, and frame loss within the same window.
+4. **Measure fanout**: count repeated component events or DOM/layout objects. Express multiplicative patterns such as `34 sections × 67 parent updates = 2,278 renders`.
+5. **Map to source**: extract stack URLs/function names, then use `rg` to follow symbols through current source. If trace points to a bundle, use source maps, named component tracks, event handler names, or unique class names. Verify that current code matches the traced revision.
+6. **Inspect data cardinality**: use read-only DB/query inspection only when needed. Explain why an algorithm becomes hot using actual session/turn/item counts; remove local paths and personal data from durable output.
+7. **State one causal chain**: `trigger → state write → reference churn/computation → render fanout → DOM/style/layout → missed frame`.
+
+Do not rank functions only by inclusive time: nested trace events overlap and double-count. Report self time when available; otherwise label inclusive duration explicitly.
+
+## Recognize common root causes
+
+- Reducer recreates every entity during resize even when derived values are exactly equal.
+- Memoized child receives inline callbacks or objects, defeating referential equality.
+- Context provider publishes a fresh projection with unchanged rendered fields.
+- Selector scans/sorts all entities once per session, producing `O(S × (T + I))` work.
+- Layout read follows DOM mutation or repeats across a large subtree.
+- Development profiling or extension hooks create apparent long frames not present in production.
+
+Prefer fixing the earliest proven cause. Do not hide upstream churn with broad leaf memoization when stable ownership/projection can be fixed at the producer.
+
+## Classify optimization visibility
+
+Treat an optimization as strictly behavior-preserving only when rendered values, ordering, event timing, focus, lock scope, mounted state, and side effects remain equivalent.
+
+Usually safe after exact tests:
+
+- Reuse entity/array references when every derived value is exactly equal.
+- Stabilize callbacks while preserving event-time reads and dependency semantics.
+- Replace repeated scans with one-pass grouping while preserving filtering, orphan rules, stable ordering, and tie-breakers.
+- Memoize a presentation projection using every field that affects its output.
+- Replace full sort for latest-item selection with the identical comparator and a one-pass maximum.
+
+Potentially user-observable; exclude or request approval:
+
+- Debounce, throttle, or move work to `requestAnimationFrame`.
+- Reduce animation/carousel frame rate.
+- Pause work using visibility/intersection heuristics.
+- Remove global interaction locks, focus behavior, autofocus, or layout reads.
+- Virtualize/unmount content, drop events, delay updates, or return stale cached values.
+
+When unsure, classify as observable.
+
+## Implement without semantic drift
+
+1. Preserve existing architecture and module ownership.
+2. Add identity tests for structural sharing and output tests for selector ordering/filtering.
+3. Keep exact comparators in named helpers so old and optimized paths cannot diverge.
+4. Avoid new persistent indexes unless evidence shows ephemeral one-pass grouping is insufficient; persistent indexes expand reducer/state migration surface.
+5. Do not add compatibility, fallback, cache, or timing layers without evidence.
+6. Run formatter, targeted tests, typecheck/lint, architecture budgets, then changed-aware checks required by the repository.
+
+If asked only to analyze, stop before editing. If asked to optimize, implement only the authorized visibility class.
+
+## Validate and report
+
+Validate at three levels:
+
+- **Semantic**: same values, sort order, filters, lock transitions, focus, and event behavior.
+- **Structural**: unchanged values retain references; changed entities still receive new references.
+- **Performance**: complexity reduction or rerender containment is proven; recapture a comparable trace when practical.
+
+Report:
+
+1. Trace facts with counts/durations and process/thread.
+2. Concrete source locations and causal chain.
+3. Fixes grouped by strictly invisible versus potentially observable.
+4. Validation commands/results.
+5. What remains unverified, especially when no post-fix trace was captured.
+6. Any implementation-plan changes and documentation impact required by repository rules.
+
+Never claim millisecond or frame-rate improvement without a comparable post-change measurement. Complexity reduction and prevented rerenders may be stated as such.
+
+## Bundled script
+
+`scripts/summarize_trace.mjs` streams `traceEvents`, keeps bounded top-event state, and outputs JSON containing thread metadata, event totals, long tasks, frame signals, and source hints. Use it for the first pass; write narrow follow-up scripts only after a specific hypothesis exists.

--- a/.codex/skills/analyze-performance-traces/agents/openai.yaml
+++ b/.codex/skills/analyze-performance-traces/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Analyze Performance Traces"
+  short_description: "Find code hotspots in large Chromium traces"
+  default_prompt: "Use $analyze-performance-traces to locate concrete code hotspots in this performance trace and propose behavior-preserving optimizations."

--- a/.codex/skills/analyze-performance-traces/scripts/summarize-trace
+++ b/.codex/skills/analyze-performance-traces/scripts/summarize-trace
@@ -277,7 +277,7 @@ async function streamTraceEvents(path, onEvent) {
 function parseArguments(args) {
   if (args.length === 0 || args.includes("--help")) {
     process.stderr.write(
-      "Usage: summarize_trace.mjs TRACE.json [--top N] [--min-ms N]\n"
+      "Usage: summarize-trace TRACE.json [--top N] [--min-ms N]\n"
     );
     process.exit(args.includes("--help") ? 0 : 1);
   }

--- a/.codex/skills/analyze-performance-traces/scripts/summarize_trace.mjs
+++ b/.codex/skills/analyze-performance-traces/scripts/summarize_trace.mjs
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+
+import { createReadStream, statSync } from "node:fs";
+import { basename, resolve } from "node:path";
+
+const { tracePath, top, minMs } = parseArguments(process.argv.slice(2));
+const absoluteTracePath = resolve(tracePath);
+const minimumDurationUs = minMs * 1_000;
+const threadNames = new Map();
+const nameStats = new Map();
+const threadStats = new Map();
+const frameSignals = new Map();
+const longestEvents = [];
+let eventCount = 0;
+let completeEventCount = 0;
+let longEventCount = 0;
+let earliestTimestampUs = Number.POSITIVE_INFINITY;
+let latestTimestampUs = Number.NEGATIVE_INFINITY;
+
+await streamTraceEvents(absoluteTracePath, processEvent);
+
+const summary = {
+  file: basename(absoluteTracePath),
+  fileBytes: statSync(absoluteTracePath).size,
+  traceDurationMs:
+    Number.isFinite(earliestTimestampUs) && Number.isFinite(latestTimestampUs)
+      ? round((latestTimestampUs - earliestTimestampUs) / 1_000)
+      : null,
+  eventCount,
+  completeEventCount,
+  longEventThresholdMs: minMs,
+  longEventCount,
+  threads: [...threadNames.entries()]
+    .map(([key, name]) => ({ key, name }))
+    .sort((left, right) => left.key.localeCompare(right.key)),
+  topThreadsByInclusiveDuration: topEntries(threadStats, top).map(
+    ([key, stats]) => ({
+      key,
+      name: threadNames.get(key) ?? null,
+      count: stats.count,
+      totalMs: round(stats.totalUs / 1_000),
+      maxMs: round(stats.maxUs / 1_000)
+    })
+  ),
+  topEventNamesByInclusiveDuration: topEntries(nameStats, top).map(
+    ([name, stats]) => ({
+      name,
+      count: stats.count,
+      totalMs: round(stats.totalUs / 1_000),
+      maxMs: round(stats.maxUs / 1_000)
+    })
+  ),
+  frameSignals: [...frameSignals.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((left, right) => right.count - left.count),
+  longestEvents: longestEvents.map((event) => ({
+    ...event,
+    threadName: threadNames.get(event.thread) ?? null
+  })),
+  cautions: [
+    "Durations are inclusive and nested events may overlap.",
+    "Development profiler and extension overhead may not represent production.",
+    "Use timestamps and stacks to prove causality before editing code."
+  ]
+};
+
+process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+
+function processEvent(event) {
+  eventCount += 1;
+  const thread = `${event.pid ?? "?"}:${event.tid ?? "?"}`;
+  if (
+    event.ph === "M" &&
+    event.name === "thread_name" &&
+    typeof event.args?.name === "string"
+  ) {
+    threadNames.set(thread, event.args.name);
+  }
+
+  const timestampUs = finiteNumber(event.ts);
+  const durationUs = finiteNumber(event.dur) ?? 0;
+  const name = typeof event.name === "string" ? event.name : "<unnamed>";
+  if (/frame/i.test(name)) {
+    frameSignals.set(name, (frameSignals.get(name) ?? 0) + 1);
+  }
+  if (event.ph !== "X" || durationUs <= 0) return;
+
+  completeEventCount += 1;
+  if (timestampUs !== null) {
+    earliestTimestampUs = Math.min(earliestTimestampUs, timestampUs);
+    latestTimestampUs = Math.max(latestTimestampUs, timestampUs + durationUs);
+  }
+  updateDurationStats(nameStats, name, durationUs);
+  updateDurationStats(threadStats, thread, durationUs);
+  if (durationUs < minimumDurationUs) return;
+
+  longEventCount += 1;
+  longestEvents.push({
+    name,
+    category: typeof event.cat === "string" ? event.cat : null,
+    durationMs: round(durationUs / 1_000),
+    timestampMs: timestampUs === null ? null : round(timestampUs / 1_000),
+    thread,
+    details: collectEventDetails(event.args),
+    sourceHints: collectSourceHints(event.args)
+  });
+  longestEvents.sort((left, right) => right.durationMs - left.durationMs);
+  if (longestEvents.length > top) longestEvents.length = top;
+}
+
+function collectEventDetails(value) {
+  const allowedKeys = new Set([
+    "className",
+    "dirtyObjects",
+    "eventType",
+    "frame",
+    "functionName",
+    "id",
+    "nodeId",
+    "nodeName",
+    "reason",
+    "scriptName",
+    "totalObjects",
+    "type",
+    "url"
+  ]);
+  const details = {};
+  visit(value, "args", 0);
+  return details;
+
+  function visit(entry, path, depth) {
+    if (
+      depth > 7 ||
+      entry === null ||
+      entry === undefined ||
+      Object.keys(details).length >= 16
+    ) {
+      return;
+    }
+    if (Array.isArray(entry)) {
+      for (let index = 0; index < entry.length; index += 1) {
+        visit(entry[index], `${path}[${index}]`, depth + 1);
+      }
+      return;
+    }
+    if (typeof entry !== "object") return;
+    for (const [key, child] of Object.entries(entry)) {
+      const childPath = `${path}.${key}`;
+      if (
+        allowedKeys.has(key) &&
+        (typeof child === "string" || typeof child === "number")
+      ) {
+        details[childPath] =
+          typeof child === "string" ? child.slice(0, 300) : child;
+      }
+      visit(child, childPath, depth + 1);
+    }
+  }
+}
+
+function updateDurationStats(target, key, durationUs) {
+  const stats = target.get(key) ?? { count: 0, totalUs: 0, maxUs: 0 };
+  stats.count += 1;
+  stats.totalUs += durationUs;
+  stats.maxUs = Math.max(stats.maxUs, durationUs);
+  target.set(key, stats);
+}
+
+function topEntries(stats, limit) {
+  return [...stats.entries()]
+    .sort((left, right) => right[1].totalUs - left[1].totalUs)
+    .slice(0, limit);
+}
+
+function collectSourceHints(value) {
+  const hints = new Set();
+  visit(value, 0);
+  return [...hints].slice(0, 8);
+
+  function visit(entry, depth) {
+    if (depth > 7 || entry === null || entry === undefined || hints.size >= 8) {
+      return;
+    }
+    if (Array.isArray(entry)) {
+      for (const item of entry) visit(item, depth + 1);
+      return;
+    }
+    if (typeof entry !== "object") return;
+
+    const functionName = textValue(entry.functionName ?? entry.name);
+    const url = textValue(entry.url ?? entry.scriptName);
+    const line = finiteNumber(entry.lineNumber);
+    const column = finiteNumber(entry.columnNumber);
+    if (url) {
+      hints.add(
+        `${functionName ? `${functionName} ` : ""}${url}${
+          line === null ? "" : `:${line + 1}`
+        }${column === null ? "" : `:${column + 1}`}`
+      );
+    }
+    for (const child of Object.values(entry)) visit(child, depth + 1);
+  }
+}
+
+async function streamTraceEvents(path, onEvent) {
+  const marker = '"traceEvents"';
+  let state = "search-marker";
+  let searchTail = "";
+  let objectText = "";
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for await (const chunk of createReadStream(path, { encoding: "utf8" })) {
+    consume(chunk);
+    if (state === "done") break;
+  }
+  if (state === "search-marker" || state === "wait-array") {
+    throw new Error('Trace JSON does not contain a "traceEvents" array');
+  }
+  if (objectText) throw new Error("Trace ended inside a trace event");
+
+  function consume(chunk) {
+    let text = chunk;
+    if (state === "search-marker") {
+      const candidate = searchTail + text;
+      const markerIndex = candidate.indexOf(marker);
+      if (markerIndex < 0) {
+        searchTail = candidate.slice(-marker.length);
+        return;
+      }
+      text = candidate.slice(markerIndex + marker.length);
+      searchTail = "";
+      state = "wait-array";
+    }
+    if (state === "wait-array") {
+      const arrayIndex = text.indexOf("[");
+      if (arrayIndex < 0) return;
+      text = text.slice(arrayIndex + 1);
+      state = "read-array";
+    }
+    if (state !== "read-array") return;
+
+    for (const character of text) {
+      if (!objectText) {
+        if (character === "{") {
+          objectText = character;
+          depth = 1;
+          inString = false;
+          escaped = false;
+        } else if (character === "]") {
+          state = "done";
+          return;
+        }
+        continue;
+      }
+
+      objectText += character;
+      if (inString) {
+        if (escaped) escaped = false;
+        else if (character === "\\") escaped = true;
+        else if (character === '"') inString = false;
+        continue;
+      }
+      if (character === '"') inString = true;
+      else if (character === "{" || character === "[") depth += 1;
+      else if (character === "}" || character === "]") depth -= 1;
+
+      if (depth === 0) {
+        onEvent(JSON.parse(objectText));
+        objectText = "";
+      }
+    }
+  }
+}
+
+function parseArguments(args) {
+  if (args.length === 0 || args.includes("--help")) {
+    process.stderr.write(
+      "Usage: summarize_trace.mjs TRACE.json [--top N] [--min-ms N]\n"
+    );
+    process.exit(args.includes("--help") ? 0 : 1);
+  }
+  let top = 30;
+  let minMs = 16;
+  for (let index = 1; index < args.length; index += 1) {
+    if (args[index] === "--top") top = positiveNumber(args[++index], "--top");
+    else if (args[index] === "--min-ms") {
+      minMs = positiveNumber(args[++index], "--min-ms");
+    } else throw new Error(`Unknown argument: ${args[index]}`);
+  }
+  return { tracePath: args[0], top, minMs };
+}
+
+function positiveNumber(value, flag) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) {
+    throw new Error(`${flag} requires a positive number`);
+  }
+  return number;
+}
+
+function finiteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function textValue(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function round(value) {
+  return Math.round(value * 1_000) / 1_000;
+}

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -45,6 +45,7 @@ import { useDesktopAgentProbes } from "./useDesktopAgentProbes.ts";
 import {
   AGENT_PROBE_REFRESH_DEBOUNCE_MS,
   DESKTOP_AGENT_GUI_AGENT_SETTINGS,
+  DESKTOP_AGENT_GUI_EMPTY_CONTEXT_MENTION_PROVIDERS,
   DESKTOP_AGENT_GUI_NOOP,
   DESKTOP_AGENT_GUI_POSITION,
   areDesktopAgentGUIWorkbenchBodyPropsEqual,
@@ -60,6 +61,7 @@ import { useDesktopAgentGUIContextMentions } from "./useDesktopAgentGUIContextMe
 import { useDesktopAgentGUIReadiness } from "./useDesktopAgentGUIReadiness.ts";
 import { useDesktopAgentGUIOpenConversationWindow } from "./useDesktopAgentGUIOpenConversationWindow.ts";
 import { useDesktopAgentGUIWorkbenchEvents } from "./useDesktopAgentGUIWorkbenchEvents.ts";
+import { useStableDesktopAgentGUIHostProps } from "./useStableDesktopAgentGUIHostProps.ts";
 import { preloadDesktopAgentGuiMentionBrowse } from "../services/preloadDesktopAgentGuiMentionBrowse.ts";
 import { DESKTOP_AGENT_GUI_CURRENT_USER_ID } from "../services/desktopAgentGuiIdentity.ts";
 import {
@@ -601,6 +603,89 @@ function DesktopAgentGUISurfaceImpl({
     },
     [workspaceId]
   );
+  const agentGUIHostProps = useStableDesktopAgentGUIHostProps({
+    identity: {
+      nodeId: surface.nodeId,
+      workspaceId,
+      currentUserId: DESKTOP_AGENT_GUI_CURRENT_USER_ID,
+      title: surface.nodeTitle
+    },
+    workspace: {
+      path: "",
+      fileReferenceAdapter: previewMode ? null : workspaceFileReferenceAdapter,
+      onRequestGitBranches: previewMode ? null : onRequestGitBranches,
+      resolveDroppedFileReferences: previewMode
+        ? null
+        : resolveDroppedFileReferences,
+      referenceSourceAggregator: previewMode ? null : referenceSourceAggregator,
+      resolveReferenceEntryIconUrl: previewMode
+        ? undefined
+        : resolveWorkspaceReferenceEntryIconUrl,
+      resolveMentionReferenceTarget: previewMode
+        ? undefined
+        : resolveMentionReferenceTarget,
+      resolveReferenceInitialTarget: previewMode
+        ? undefined
+        : resolveWorkspaceReferenceInitialTarget,
+      onFileReferencesAdded: previewMode
+        ? undefined
+        : trackWorkspaceFileReferences,
+      agentSettings: DESKTOP_AGENT_GUI_AGENT_SETTINGS
+    },
+    runtimeRequests: {
+      composerAppend: composerAppendRequest,
+      composerFocusSequence: composerFocusRequestSequence,
+      newConversationSequence: newConversationRequestSequence,
+      openSession: openSessionRequest,
+      prefillPrompt: prefillPromptRequest,
+      agentProbes: workspaceAgentProbes,
+      onProbeDemandChange: previewMode
+        ? undefined
+        : handleAgentProbeDemandChange,
+      onProbeRefreshRequest: previewMode
+        ? undefined
+        : handleAgentProbeRefreshRequest
+    },
+    hostCapabilities: {
+      referenceProvenanceFilterEnabled,
+      capabilityMenuState,
+      accountMenuState: null,
+      comingSoonProviders: comingSoonAgentProviders,
+      providerReadinessGates,
+      defaultAgentTargetId,
+      providerAuthAccountLabels,
+      contextMentionProviders: previewMode
+        ? DESKTOP_AGENT_GUI_EMPTY_CONTEXT_MENTION_PROVIDERS
+        : effectiveContextMentionProviders,
+      workspaceAppIcons
+    },
+    hostActions: {
+      onAgentProviderLogin:
+        !previewMode && agentProviderStatusService
+          ? handleAgentProviderLogin
+          : undefined,
+      onCapabilitySettingsRequest: previewMode
+        ? undefined
+        : onCapabilitySettingsRequest,
+      onClose: DESKTOP_AGENT_GUI_NOOP,
+      onLinkAction: previewMode ? undefined : onLinkAction,
+      onHandoffConversation: previewMode
+        ? undefined
+        : handleHandoffConversation,
+      onResize: DESKTOP_AGENT_GUI_NOOP,
+      onShowMessage: handleDesktopAgentGUIShowMessage,
+      onUpdateNode: handleUpdateNode,
+      onRememberComposerDefaults: handleRememberComposerDefaults,
+      onEngagementEvent: previewMode ? undefined : onEngagementEvent,
+      onOpenConversationWindow:
+        previewMode || !onOpenAgentConversationWindow
+          ? undefined
+          : handleOpenConversationWindow
+    },
+    renderSlots: {
+      sidebarFooter: previewMode ? undefined : renderSidebarFooter
+    }
+  });
 
   return (
     <>
@@ -612,38 +697,8 @@ function DesktopAgentGUISurfaceImpl({
         agentHostApi={agentHostApiWithToast}
         i18n={i18n}
         locale={locale}
-        identity={{
-          nodeId: surface.nodeId,
-          workspaceId,
-          currentUserId: DESKTOP_AGENT_GUI_CURRENT_USER_ID,
-          title: surface.nodeTitle
-        }}
-        workspace={{
-          path: "",
-          fileReferenceAdapter: previewMode
-            ? null
-            : workspaceFileReferenceAdapter,
-          onRequestGitBranches: previewMode ? null : onRequestGitBranches,
-          resolveDroppedFileReferences: previewMode
-            ? null
-            : resolveDroppedFileReferences,
-          referenceSourceAggregator: previewMode
-            ? null
-            : referenceSourceAggregator,
-          resolveReferenceEntryIconUrl: previewMode
-            ? undefined
-            : resolveWorkspaceReferenceEntryIconUrl,
-          resolveMentionReferenceTarget: previewMode
-            ? undefined
-            : resolveMentionReferenceTarget,
-          resolveReferenceInitialTarget: previewMode
-            ? undefined
-            : resolveWorkspaceReferenceInitialTarget,
-          onFileReferencesAdded: previewMode
-            ? undefined
-            : trackWorkspaceFileReferences,
-          agentSettings: DESKTOP_AGENT_GUI_AGENT_SETTINGS
-        }}
+        identity={agentGUIHostProps.identity}
+        workspace={agentGUIHostProps.workspace}
         frame={{
           position: DESKTOP_AGENT_GUI_POSITION,
           width: frame.width,
@@ -659,59 +714,10 @@ function DesktopAgentGUISurfaceImpl({
           conversationRailAutoCollapseWidthPx
         }}
         state={nodeState}
-        runtimeRequests={{
-          composerAppend: composerAppendRequest,
-          composerFocusSequence: composerFocusRequestSequence,
-          newConversationSequence: newConversationRequestSequence,
-          openSession: openSessionRequest,
-          prefillPrompt: prefillPromptRequest,
-          agentProbes: workspaceAgentProbes,
-          onProbeDemandChange: previewMode
-            ? undefined
-            : handleAgentProbeDemandChange,
-          onProbeRefreshRequest: previewMode
-            ? undefined
-            : handleAgentProbeRefreshRequest
-        }}
-        hostCapabilities={{
-          referenceProvenanceFilterEnabled,
-          capabilityMenuState,
-          accountMenuState: null,
-          comingSoonProviders: comingSoonAgentProviders,
-          providerReadinessGates,
-          defaultAgentTargetId,
-          providerAuthAccountLabels,
-          contextMentionProviders: previewMode
-            ? []
-            : effectiveContextMentionProviders,
-          workspaceAppIcons
-        }}
-        hostActions={{
-          onAgentProviderLogin:
-            !previewMode && agentProviderStatusService
-              ? handleAgentProviderLogin
-              : undefined,
-          onCapabilitySettingsRequest: previewMode
-            ? undefined
-            : onCapabilitySettingsRequest,
-          onClose: DESKTOP_AGENT_GUI_NOOP,
-          onLinkAction: previewMode ? undefined : onLinkAction,
-          onHandoffConversation: previewMode
-            ? undefined
-            : handleHandoffConversation,
-          onResize: DESKTOP_AGENT_GUI_NOOP,
-          onShowMessage: handleDesktopAgentGUIShowMessage,
-          onUpdateNode: handleUpdateNode,
-          onRememberComposerDefaults: handleRememberComposerDefaults,
-          onEngagementEvent: previewMode ? undefined : onEngagementEvent,
-          onOpenConversationWindow:
-            previewMode || !onOpenAgentConversationWindow
-              ? undefined
-              : handleOpenConversationWindow
-        }}
-        renderSlots={{
-          sidebarFooter: previewMode ? undefined : renderSidebarFooter
-        }}
+        runtimeRequests={agentGUIHostProps.runtimeRequests}
+        hostCapabilities={agentGUIHostProps.hostCapabilities}
+        hostActions={agentGUIHostProps.hostActions}
+        renderSlots={agentGUIHostProps.renderSlots}
       />
     </>
   );

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import test from "node:test";
+import reactCompiler from "babel-plugin-react-compiler";
+
+const require = createRequire(import.meta.url);
+const { transformAsync } = require("@babel/core") as {
+  transformAsync: (
+    source: string,
+    options: Record<string, unknown>
+  ) => Promise<{ code?: string | null } | null>;
+};
+
+const sourceUrl = new URL(
+  "./useStableDesktopAgentGUIHostProps.ts",
+  import.meta.url
+);
+
+test("React Compiler preserves field-keyed Agent GUI host projections", async () => {
+  const source = await readFile(sourceUrl, "utf8");
+  const result = await transformAsync(source, {
+    babelrc: false,
+    configFile: false,
+    filename: sourceUrl.pathname,
+    parserOpts: { plugins: ["typescript"] },
+    plugins: [
+      [
+        reactCompiler,
+        {
+          compilationMode: "infer",
+          panicThreshold: "none"
+        }
+      ]
+    ]
+  });
+  const compiled = result?.code ?? "";
+
+  assert.doesNotMatch(compiled, /const identity\w* = nextIdentity;/);
+  assert.match(compiled, /nextIdentity\.nodeId/);
+  assert.match(compiled, /nextIdentity\.workspaceId/);
+  assert.match(compiled, /nextWorkspace\.fileReferenceAdapter/);
+  assert.match(compiled, /nextHostActions\.onOpenConversationWindow/);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.ts
@@ -1,0 +1,118 @@
+import type { AgentGUIProps } from "@tutti-os/agent-gui";
+
+export type DesktopAgentGUIHostProps = {
+  identity: AgentGUIProps["identity"];
+  workspace: Pick<
+    AgentGUIProps["workspace"],
+    | "path"
+    | "fileReferenceAdapter"
+    | "onRequestGitBranches"
+    | "resolveDroppedFileReferences"
+    | "referenceSourceAggregator"
+    | "resolveReferenceEntryIconUrl"
+    | "resolveMentionReferenceTarget"
+    | "resolveReferenceInitialTarget"
+    | "onFileReferencesAdded"
+    | "agentSettings"
+  >;
+  runtimeRequests: AgentGUIProps["runtimeRequests"];
+  hostCapabilities: Pick<
+    AgentGUIProps["hostCapabilities"],
+    | "referenceProvenanceFilterEnabled"
+    | "capabilityMenuState"
+    | "accountMenuState"
+    | "comingSoonProviders"
+    | "providerReadinessGates"
+    | "defaultAgentTargetId"
+    | "providerAuthAccountLabels"
+    | "contextMentionProviders"
+    | "workspaceAppIcons"
+  >;
+  hostActions: Pick<
+    AgentGUIProps["hostActions"],
+    | "onAgentProviderLogin"
+    | "onCapabilitySettingsRequest"
+    | "onClose"
+    | "onLinkAction"
+    | "onHandoffConversation"
+    | "onResize"
+    | "onShowMessage"
+    | "onUpdateNode"
+    | "onRememberComposerDefaults"
+    | "onEngagementEvent"
+    | "onOpenConversationWindow"
+  >;
+  renderSlots: Pick<AgentGUIProps["renderSlots"], "sidebarFooter">;
+};
+
+export function useStableDesktopAgentGUIHostProps({
+  identity: nextIdentity,
+  workspace: nextWorkspace,
+  runtimeRequests: nextRuntimeRequests,
+  hostCapabilities: nextHostCapabilities,
+  hostActions: nextHostActions,
+  renderSlots: nextRenderSlots
+}: DesktopAgentGUIHostProps): DesktopAgentGUIHostProps {
+  "use memo";
+
+  return {
+    identity: {
+      currentUserId: nextIdentity.currentUserId,
+      nodeId: nextIdentity.nodeId,
+      title: nextIdentity.title,
+      workspaceId: nextIdentity.workspaceId
+    },
+    workspace: {
+      path: nextWorkspace.path,
+      fileReferenceAdapter: nextWorkspace.fileReferenceAdapter,
+      onRequestGitBranches: nextWorkspace.onRequestGitBranches,
+      resolveDroppedFileReferences: nextWorkspace.resolveDroppedFileReferences,
+      referenceSourceAggregator: nextWorkspace.referenceSourceAggregator,
+      resolveReferenceEntryIconUrl: nextWorkspace.resolveReferenceEntryIconUrl,
+      resolveMentionReferenceTarget:
+        nextWorkspace.resolveMentionReferenceTarget,
+      resolveReferenceInitialTarget:
+        nextWorkspace.resolveReferenceInitialTarget,
+      onFileReferencesAdded: nextWorkspace.onFileReferencesAdded,
+      agentSettings: nextWorkspace.agentSettings
+    },
+    runtimeRequests: {
+      composerAppend: nextRuntimeRequests.composerAppend,
+      composerFocusSequence: nextRuntimeRequests.composerFocusSequence,
+      newConversationSequence: nextRuntimeRequests.newConversationSequence,
+      openSession: nextRuntimeRequests.openSession,
+      prefillPrompt: nextRuntimeRequests.prefillPrompt,
+      agentProbes: nextRuntimeRequests.agentProbes,
+      onProbeDemandChange: nextRuntimeRequests.onProbeDemandChange,
+      onProbeRefreshRequest: nextRuntimeRequests.onProbeRefreshRequest
+    },
+    hostCapabilities: {
+      referenceProvenanceFilterEnabled:
+        nextHostCapabilities.referenceProvenanceFilterEnabled,
+      capabilityMenuState: nextHostCapabilities.capabilityMenuState,
+      accountMenuState: nextHostCapabilities.accountMenuState,
+      comingSoonProviders: nextHostCapabilities.comingSoonProviders,
+      providerReadinessGates: nextHostCapabilities.providerReadinessGates,
+      defaultAgentTargetId: nextHostCapabilities.defaultAgentTargetId,
+      providerAuthAccountLabels: nextHostCapabilities.providerAuthAccountLabels,
+      contextMentionProviders: nextHostCapabilities.contextMentionProviders,
+      workspaceAppIcons: nextHostCapabilities.workspaceAppIcons
+    },
+    hostActions: {
+      onAgentProviderLogin: nextHostActions.onAgentProviderLogin,
+      onCapabilitySettingsRequest: nextHostActions.onCapabilitySettingsRequest,
+      onClose: nextHostActions.onClose,
+      onLinkAction: nextHostActions.onLinkAction,
+      onHandoffConversation: nextHostActions.onHandoffConversation,
+      onResize: nextHostActions.onResize,
+      onShowMessage: nextHostActions.onShowMessage,
+      onUpdateNode: nextHostActions.onUpdateNode,
+      onRememberComposerDefaults: nextHostActions.onRememberComposerDefaults,
+      onEngagementEvent: nextHostActions.onEngagementEvent,
+      onOpenConversationWindow: nextHostActions.onOpenConversationWindow
+    },
+    renderSlots: {
+      sidebarFooter: nextRenderSlots.sidebarFooter
+    }
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
@@ -52,7 +52,11 @@ test("standalone Agent reuses the OS account menu in the sidebar footer", () => 
   );
   assert.match(
     workbenchBodySource,
-    /renderSlots=\{\{[\s\S]*sidebarFooter: previewMode \? undefined : renderSidebarFooter[\s\S]*\}\}/
+    /renderSlots:\s*\{\s*sidebarFooter: previewMode \? undefined : renderSidebarFooter\s*\}/
+  );
+  assert.match(
+    workbenchBodySource,
+    /renderSlots=\{agentGUIHostProps\.renderSlots\}/
   );
 });
 

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -47,6 +47,7 @@ React rendering, Workbench state, external stores, input composition, and UI per
 - [Standalone Agent dev window stays black during cold startup](./workbench-renderer.md#standalone-agent-dev-window-stays-black-during-cold-startup)
 - [IME composition breaks fuzzy search or controlled search inputs](./workbench-renderer.md#ime-composition-breaks-fuzzy-search-or-controlled-search-inputs)
 - [External-store snapshots churn because derived reads lose reference stability](./workbench-renderer.md#external-store-snapshots-churn-because-derived-reads-lose-reference-stability)
+- [React Compiler removes a manual identity memo](./workbench-renderer.md#react-compiler-removes-a-manual-identity-memo)
 - [Workbench host rebuilds when dock business status changes](./workbench-renderer.md#workbench-host-rebuilds-when-dock-business-status-changes)
 - [Dock entry is open but its state indicator is missing](./workbench-renderer.md#dock-entry-is-open-but-its-state-indicator-is-missing)
 - [Dense list panel stutters when mounted or resized](./workbench-renderer.md#dense-list-panel-stutters-when-mounted-or-resized)

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -302,6 +302,32 @@
   [packages/workbench/surface/src/host/missionControlAdapter.ts](../../../packages/workbench/surface/src/host/missionControlAdapter.ts)
   [packages/workbench/surface/src/host/missionControlAdapter.test.ts](../../../packages/workbench/surface/src/host/missionControlAdapter.test.ts)
 
+### React Compiler removes a manual identity memo
+
+- Symptom:
+  React profiling reports a grouped prop as referentially unequal but deeply
+  equal on every render even though source code wraps it in `useMemo`.
+- Quick checks:
+  Inspect the renderer's dev transform and production bundle. A source pattern
+  such as `useMemo(() => nextValue, [nextValue.field])` may compile to
+  `const value = nextValue`, restoring the fresh input reference.
+- Root cause:
+  The memo callback returns an existing input object while its dependency list
+  intentionally describes selected fields. React Compiler infers the input
+  object as the value dependency and may remove this identity-only memo.
+- Fix:
+  Build an explicit projection object from every semantic field and let React
+  Compiler cache that allocation by those fields. Do not use a component ref or
+  `useMemo(() => freshInput)` to absorb upstream reference churn.
+- Validation:
+  Add a compiler regression test for the projection, run the desktop production
+  build, and inspect the emitted cache conditions. They must compare semantic
+  fields rather than assign the fresh input object directly. Re-record a React
+  performance trace to verify deeply-equal grouped-prop changes disappear.
+- References:
+  [useStableDesktopAgentGUIHostProps.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.ts)
+  [useStableDesktopAgentGUIHostProps.test.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.test.ts)
+
 ### Workbench host rebuilds when dock business status changes
 
 - Symptom:

--- a/packages/agent/gui/AgentGUI.spec.tsx
+++ b/packages/agent/gui/AgentGUI.spec.tsx
@@ -1,7 +1,27 @@
 import "@testing-library/jest-dom/vitest";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentGUI, type AgentGUIProps } from "./AgentGUI";
+
+const { agentGuiNodeSpy } = vi.hoisted(() => ({
+  agentGuiNodeSpy: vi.fn()
+}));
+
+interface AgentGUINodeProbeProps {
+  hostCapabilities: {
+    agentTargets?: readonly {
+      agentTargetId?: string;
+      availability: unknown;
+      ref: unknown;
+    }[];
+    disabledHomeSuggestions?: readonly string[];
+    handoffAgentTargets?: readonly {
+      agentTargetId?: string;
+      availability: unknown;
+      ref: unknown;
+    }[];
+  };
+}
 
 function createAgentGUIProps(locale: AgentGUIProps["locale"]): AgentGUIProps {
   return {
@@ -27,13 +47,8 @@ vi.mock("./agent-gui/agentGuiNode/AgentGUINode", async () => {
   >("@tutti-os/ui-system");
 
   return {
-    AgentGUINode: (props: {
-      hostCapabilities: {
-        agentTargets?: readonly { agentTargetId?: string }[];
-        disabledHomeSuggestions?: readonly string[];
-        handoffAgentTargets?: readonly { agentTargetId?: string }[];
-      };
-    }) => {
+    AgentGUINode: (props: AgentGUINodeProbeProps) => {
+      agentGuiNodeSpy(props);
       const { t } = useTranslation();
       const activityRuntime = useOptionalAgentActivityRuntime();
       return (
@@ -76,6 +91,10 @@ vi.mock("./agent-gui/agentGuiNode/AgentGUINode", async () => {
 });
 
 describe("AgentGUI i18n", () => {
+  beforeEach(() => {
+    agentGuiNodeSpy.mockClear();
+  });
+
   it("rerenders agent copy when the host locale changes", () => {
     const { rerender } = render(<AgentGUI {...createAgentGUIProps("en")} />);
 
@@ -152,6 +171,94 @@ describe("AgentGUI i18n", () => {
     expect(
       screen.getByTestId("agent-gui-handoff-targets-probe")
     ).toHaveTextContent('["local-codex","shared-agent:claude"]');
+  });
+
+  it("reuses agent target projections across frame-only renders", () => {
+    const agents = [agent("local-codex", "codex")];
+    const props = {
+      ...createAgentGUIProps("en"),
+      agentDirectory: {
+        agents,
+        capturedAtUnixMs: null,
+        error: null,
+        status: "ready" as const
+      }
+    };
+    const { rerender } = render(<AgentGUI {...props} />);
+    const first = agentGuiNodeSpy.mock.calls.at(-1)?.[0] as
+      | AgentGUINodeProbeProps
+      | undefined;
+
+    rerender(
+      <AgentGUI
+        {...props}
+        frame={{ ...props.frame, width: 960, height: 640 }}
+      />
+    );
+    const second = agentGuiNodeSpy.mock.calls.at(-1)?.[0] as
+      | AgentGUINodeProbeProps
+      | undefined;
+
+    expect(second?.hostCapabilities.agentTargets).toBe(
+      first?.hostCapabilities.agentTargets
+    );
+    expect(second?.hostCapabilities.handoffAgentTargets).toBe(
+      first?.hostCapabilities.handoffAgentTargets
+    );
+    expect(second?.hostCapabilities.handoffAgentTargets).toBe(
+      second?.hostCapabilities.agentTargets
+    );
+    expect(second?.hostCapabilities.agentTargets?.[0]?.availability).toBe(
+      first?.hostCapabilities.agentTargets?.[0]?.availability
+    );
+    expect(second?.hostCapabilities.agentTargets?.[0]?.ref).toBe(
+      first?.hostCapabilities.agentTargets?.[0]?.ref
+    );
+  });
+
+  it("rebuilds agent target projections when the directory changes", () => {
+    const firstAgent = agent("local-codex", "codex");
+    const props = {
+      ...createAgentGUIProps("en"),
+      agentDirectory: {
+        agents: [firstAgent],
+        capturedAtUnixMs: null,
+        error: null,
+        status: "ready" as const
+      }
+    };
+    const { rerender } = render(<AgentGUI {...props} />);
+    const first = agentGuiNodeSpy.mock.calls.at(-1)?.[0] as
+      | AgentGUINodeProbeProps
+      | undefined;
+
+    rerender(
+      <AgentGUI
+        {...props}
+        agentDirectory={{
+          ...props.agentDirectory,
+          agents: [
+            {
+              ...firstAgent,
+              availability: { status: "auth_required" as const }
+            }
+          ]
+        }}
+      />
+    );
+    const second = agentGuiNodeSpy.mock.calls.at(-1)?.[0] as
+      | AgentGUINodeProbeProps
+      | undefined;
+
+    expect(second?.hostCapabilities.agentTargets).not.toBe(
+      first?.hostCapabilities.agentTargets
+    );
+    expect(second?.hostCapabilities.agentTargets?.[0]?.availability).not.toBe(
+      first?.hostCapabilities.agentTargets?.[0]?.availability
+    );
+    expect(second?.hostCapabilities.agentTargets?.[0]?.ref).not.toBe(
+      first?.hostCapabilities.agentTargets?.[0]?.ref
+    );
   });
 });
 

--- a/packages/agent/gui/AgentGUI.tsx
+++ b/packages/agent/gui/AgentGUI.tsx
@@ -1,4 +1,4 @@
-import { memo, type JSX } from "react";
+import { memo, useMemo, type JSX } from "react";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import { TooltipProvider } from "@tutti-os/ui-system";
 import type { AgentActivityRuntime } from "./agentActivityRuntime";
@@ -73,26 +73,45 @@ export const AgentGUI = memo(function AgentGUI({
   locale,
   ...props
 }: AgentGUIProps): JSX.Element {
-  const normalizedAgents = normalizeAgentGUIAgents(agentDirectory.agents);
+  const normalizedAgents = useMemo(
+    () => normalizeAgentGUIAgents(agentDirectory.agents),
+    [agentDirectory.agents]
+  );
+  const agentTargets = useMemo(
+    () => projectAgentGUIAgentsToInternalTargets(normalizedAgents),
+    [normalizedAgents]
+  );
   const effectiveHandoffAgentDirectory =
     handoffAgentDirectory ?? agentDirectory;
-  const normalizedHandoffAgents = normalizeAgentGUIAgents(
-    effectiveHandoffAgentDirectory.agents
+  const normalizedHandoffAgents = useMemo(
+    () =>
+      effectiveHandoffAgentDirectory.agents === agentDirectory.agents
+        ? normalizedAgents
+        : normalizeAgentGUIAgents(effectiveHandoffAgentDirectory.agents),
+    [
+      agentDirectory.agents,
+      effectiveHandoffAgentDirectory.agents,
+      normalizedAgents
+    ]
+  );
+  const handoffAgentTargets = useMemo(
+    () =>
+      normalizedHandoffAgents === normalizedAgents
+        ? agentTargets
+        : projectAgentGUIAgentsToInternalTargets(normalizedHandoffAgents),
+    [agentTargets, normalizedAgents, normalizedHandoffAgents]
   );
   const hostCapabilities = props.hostCapabilities;
   const renderSlots = props.renderSlots;
-  const nodeProps: AgentGUINodeProps = {
-    ...props,
-    hostCapabilities: {
+  const nodeHostCapabilities = useMemo<AgentGUINodeProps["hostCapabilities"]>(
+    () => ({
       ...hostCapabilities,
-      agentTargets: projectAgentGUIAgentsToInternalTargets(normalizedAgents),
+      agentTargets,
       agentTargetsLoading:
         agentDirectory.agents.length === 0 &&
         (agentDirectory.status === "idle" ||
           agentDirectory.status === "loading"),
-      handoffAgentTargets: projectAgentGUIAgentsToInternalTargets(
-        normalizedHandoffAgents
-      ),
+      handoffAgentTargets,
       handoffAgentTargetsLoading:
         effectiveHandoffAgentDirectory.agents.length === 0 &&
         (effectiveHandoffAgentDirectory.status === "idle" ||
@@ -100,11 +119,30 @@ export const AgentGUI = memo(function AgentGUI({
       disabledHomeSuggestions: disabled,
       providerRailAllPresentation: allAgentsPresentation ?? null,
       providerRailMode: "exact"
-    },
-    renderSlots: {
+    }),
+    [
+      agentDirectory.agents.length,
+      agentDirectory.status,
+      agentTargets,
+      allAgentsPresentation,
+      disabled,
+      effectiveHandoffAgentDirectory.agents.length,
+      effectiveHandoffAgentDirectory.status,
+      handoffAgentTargets,
+      hostCapabilities
+    ]
+  );
+  const nodeRenderSlots = useMemo<AgentGUINodeProps["renderSlots"]>(
+    () => ({
       ...renderSlots,
       providerRailEmpty: renderAgentsEmpty
-    }
+    }),
+    [renderAgentsEmpty, renderSlots]
+  );
+  const nodeProps: AgentGUINodeProps = {
+    ...props,
+    hostCapabilities: nodeHostCapabilities,
+    renderSlots: nodeRenderSlots
   };
   const content = (
     <AgentGuiI18nProvider runtime={i18n} locale={locale}>

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.memo.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.memo.spec.tsx
@@ -14,6 +14,7 @@ import {
 import { AgentGUINode } from "./AgentGUINode";
 import { createLocalAgentGUIAgentTarget } from "../../agentTargets";
 import { buildAgentComposerDraft } from "./model/agentComposerDraft";
+import { resolveNextAgentGUIConversationRailWidthPx } from "./model/agentGuiRailLayout";
 
 const { agentGuiNodeViewSpy } = vi.hoisted(() => ({
   agentGuiNodeViewSpy: vi.fn()
@@ -212,6 +213,56 @@ describe("AgentGUINode memoization", () => {
     );
 
     expect(agentGuiNodeViewSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the rail resize callback stable and reads the latest frame width", () => {
+    mockViewModel = createViewModel();
+    const onUpdateNode = vi.fn();
+    const initial = createProps();
+    const props = {
+      ...initial,
+      hostActions: { ...initial.hostActions, onUpdateNode }
+    };
+    const { rerender } = render(<AgentGUINode {...props} />);
+    const firstViewProps = agentGuiNodeViewSpy.mock.calls.at(-1)?.[0] as
+      | {
+          onConversationRailWidthChanged: (widthPx: number) => void;
+        }
+      | undefined;
+    expect(firstViewProps).toBeDefined();
+    const firstCallback = firstViewProps!.onConversationRailWidthChanged;
+
+    rerender(
+      <AgentGUINode {...props} frame={{ ...props.frame, width: 640 }} />
+    );
+    const secondViewProps = agentGuiNodeViewSpy.mock.calls.at(-1)?.[0] as
+      | {
+          onConversationRailWidthChanged: (widthPx: number) => void;
+        }
+      | undefined;
+    expect(secondViewProps).toBeDefined();
+    const secondCallback = secondViewProps!.onConversationRailWidthChanged;
+
+    expect(secondCallback).toBe(firstCallback);
+    firstCallback(600);
+    const updater = onUpdateNode.mock.calls.at(-1)?.[0] as (
+      current: AgentGUINodeData
+    ) => AgentGUINodeData;
+    const current = createState({ conversationRailWidthPx: 320 });
+    expect(updater(current).conversationRailWidthPx).toBe(
+      resolveNextAgentGUIConversationRailWidthPx({
+        currentWidthPx: current.conversationRailWidthPx,
+        requestedWidthPx: 600,
+        containerWidthPx: 640
+      })
+    );
+    expect(updater(current).conversationRailWidthPx).not.toBe(
+      resolveNextAgentGUIConversationRailWidthPx({
+        currentWidthPx: current.conversationRailWidthPx,
+        requestedWidthPx: 600,
+        containerWidthPx: props.frame.width
+      })
+    );
   });
 });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef } from "react";
 import { createWorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-project/i18n";
 import { createWorkspaceFileManagerI18nRuntime } from "@tutti-os/workspace-file-manager";
 import { useReferenceProvenanceFilterCatalog } from "@tutti-os/workspace-file-reference/react";
@@ -98,6 +98,8 @@ export const AgentGUINode = memo(function AgentGUINode({
   } = frame;
   const railAutoCollapseWidthPx =
     conversationRailAutoCollapseWidthPx ?? undefined;
+  const widthRef = useRef(width);
+  widthRef.current = width;
   const {
     composerAppend: composerAppendRequest = null,
     composerFocusSequence: composerFocusRequestSequence = null,
@@ -217,7 +219,7 @@ export const AgentGUINode = memo(function AgentGUINode({
         const nextWidthPx = resolveNextAgentGUIConversationRailWidthPx({
           currentWidthPx: current.conversationRailWidthPx,
           requestedWidthPx: widthPx,
-          containerWidthPx: width
+          containerWidthPx: widthRef.current
         });
 
         if (current.conversationRailWidthPx === nextWidthPx) {
@@ -229,7 +231,7 @@ export const AgentGUINode = memo(function AgentGUINode({
         };
       });
     },
-    [onUpdateNode, previewMode, width]
+    [onUpdateNode, previewMode]
   );
   const isConversationRailManuallyCollapsed =
     state.conversationRailCollapsed === true;


### PR DESCRIPTION
## Summary

- add a repository-local `analyze-performance-traces` skill and bounded-memory Chrome/Electron trace summarizer
- preserve AgentGUI target projections across frame-only renders instead of rebuilding deeply equal target data
- stabilize Desktop AgentGUI grouped host props using explicit semantic projections that React Compiler retains in dev and production output
- keep the conversation-rail resize callback stable while reading the latest frame width
- document the React Compiler identity-memo trap and lock it with a compiler regression test

Trace comparison for the same interaction showed:

- events >= 8 ms: 1748 -> 608 (-65%)
- AgentGUI inclusive time: 1603.8 ms -> 365.7 ms (-77%)
- AgentGUINode inclusive time: 1584.5 ms -> 303.2 ms (-81%)
- DetailPane inclusive time: 385.0 ms -> 62.4 ms (-84%)
- ProviderRail renders: 279 -> 1

The follow-up compiler inspection found that `useMemo(() => nextIdentity, fieldDeps)` became `const identity = nextIdentity` in both dev and production transforms. The explicit field projection now compiles into semantic-field cache checks instead of retaining the fresh aggregate input reference.

## Verification

- `pnpm lint:ts`
- `pnpm typecheck`
- Desktop test suite: 1494 passed, 0 failed, 2 skipped
- `pnpm check:renderer-boundaries`
- `pnpm --filter @tutti-os/desktop build`
- compiler regression test against the repository React Compiler config
- `NODE_OPTIONS=--max-old-space-size=8192 git push` -> pre-push `pnpm check:changed -- --push-ready`: 13/13 lanes passed
- production bundle inspection confirmed field-keyed cache slots for all six Desktop AgentGUI host prop groups

## Fallback Three Questions

- Source: frame updates reconstructed grouped Desktop props and AgentGUI target projections, producing fresh references with unchanged semantics.
- Why not lower: Desktop owns host-prop projection; AgentGUI owns public-to-internal target projection. Stabilizing at those ownership boundaries avoids hiding churn behind component refs.
- Removal condition: remove only if these boundaries receive compiler-proven stable identities directly and regression traces/tests show no referential churn without the projections.

## Checklist

- [x] No agent lifecycle semantics changed.
- [x] Change is focused on trace-backed AgentGUI performance and reusable trace analysis.
- [x] Troubleshooting documentation updated.
- [x] README/CONTRIBUTING language variants not applicable.
- [x] Lowest meaningful local checks and push-ready gate passed.
- [x] Commits signed off with DCO.

## Remaining Work

Native viewport resize still triggers full-root layout independently of React prop churn. This PR does not change viewport resize behavior. A post-fix trace is still needed to quantify the final compiler-projection change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->