### PR TITLE
fix(agent-store): scope project rail paths by workspace

### DIFF
--- a/packages/agent/store-sqlite/migrations_rail.go
+++ b/packages/agent/store-sqlite/migrations_rail.go
@@ -58,12 +58,6 @@ CREATE INDEX IF NOT EXISTS idx_workspace_agent_sessions_rail_section_page
 }
 
 func (s *Store) backfillAgentSessionRailSections(ctx context.Context) error {
-	projects, err := s.listRailProjectPaths(ctx, s.db)
-	if err != nil {
-		return err
-	}
-	projects = normalizeRailProjectPaths(projects)
-
 	rows, err := s.db.QueryContext(ctx, `
 SELECT workspace_id, agent_session_id, cwd, runtime_context_json
 FROM workspace_agent_sessions
@@ -74,12 +68,13 @@ WHERE rail_section_key = ?
 	}
 	defer rows.Close()
 
-	type railBackfill struct {
+	type railCandidate struct {
 		WorkspaceID    string
 		AgentSessionID string
-		Section        RailSection
+		CWD            string
+		RuntimeContext map[string]any
 	}
-	backfills := make([]railBackfill, 0)
+	candidates := make([]railCandidate, 0)
 	for rows.Next() {
 		var workspaceID string
 		var agentSessionID string
@@ -92,14 +87,11 @@ WHERE rail_section_key = ?
 		if err != nil {
 			return fmt.Errorf("decode workspace agent session runtime context for rail section backfill: %w", err)
 		}
-		section := ClassifyRailSection(cwd, runtimeContext, projects)
-		if section.Kind != RailSectionKindProject {
-			continue
-		}
-		backfills = append(backfills, railBackfill{
+		candidates = append(candidates, railCandidate{
 			WorkspaceID:    workspaceID,
 			AgentSessionID: agentSessionID,
-			Section:        section,
+			CWD:            cwd,
+			RuntimeContext: runtimeContext,
 		})
 	}
 	if err := rows.Err(); err != nil {
@@ -107,6 +99,33 @@ WHERE rail_section_key = ?
 	}
 	if err := rows.Close(); err != nil {
 		return fmt.Errorf("close workspace agent sessions rail section backfill rows: %w", err)
+	}
+
+	type railBackfill struct {
+		WorkspaceID    string
+		AgentSessionID string
+		Section        RailSection
+	}
+	projectsByWorkspace := make(map[string][]string)
+	backfills := make([]railBackfill, 0, len(candidates))
+	for _, candidate := range candidates {
+		projects, found := projectsByWorkspace[candidate.WorkspaceID]
+		if !found {
+			projects, err = s.listRailProjectPaths(ctx, s.db, candidate.WorkspaceID)
+			if err != nil {
+				return err
+			}
+			projects = normalizeRailProjectPaths(projects)
+			projectsByWorkspace[candidate.WorkspaceID] = projects
+		}
+		section := ClassifyRailSection(candidate.CWD, candidate.RuntimeContext, projects)
+		if section.Kind == RailSectionKindProject {
+			backfills = append(backfills, railBackfill{
+				WorkspaceID:    candidate.WorkspaceID,
+				AgentSessionID: candidate.AgentSessionID,
+				Section:        section,
+			})
+		}
 	}
 
 	for _, backfill := range backfills {

--- a/packages/agent/store-sqlite/migrations_test.go
+++ b/packages/agent/store-sqlite/migrations_test.go
@@ -632,12 +632,15 @@ INSERT INTO workspace_agent_sessions (workspace_id, agent_session_id, provider, 
 VALUES
   ('ws-rail-backfill', 'session-project', 'codex', ?, '{}', 1, 1),
   ('ws-rail-backfill', 'session-no-project', 'codex', ?, '{"externalImportNoProject":true}', 1, 1),
-  ('ws-rail-backfill', 'session-conversations', 'codex', ?, '{}', 1, 1);
-`, repoSubdir, repoSubdir, otherDir); err != nil {
+  ('ws-rail-backfill', 'session-conversations', 'codex', ?, '{}', 1, 1),
+  ('ws-without-project', 'session-same-cwd', 'codex', ?, '{}', 1, 1);
+`, repoSubdir, repoSubdir, otherDir, repoSubdir); err != nil {
 		t.Fatalf("insert pre-rail sessions: %v", err)
 	}
 
-	store := New(db, testOptions(&staticProjectPaths{paths: []string{repo}}))
+	store := New(db, testOptions(&staticProjectPaths{pathsByWorkspace: map[string][]string{
+		"ws-rail-backfill": {repo},
+	}}))
 	ctx := context.Background()
 	if err := store.Migrate(ctx); err != nil {
 		t.Fatalf("Migrate() error = %v", err)
@@ -660,5 +663,15 @@ WHERE workspace_id = 'ws-rail-backfill' AND agent_session_id = ?
 		if key != wantKey {
 			t.Fatalf("rail key for %s = %q, want %q", sessionID, key, wantKey)
 		}
+	}
+	var otherWorkspaceKey string
+	if err := db.QueryRowContext(ctx, `
+SELECT rail_section_key FROM workspace_agent_sessions
+WHERE workspace_id = 'ws-without-project' AND agent_session_id = 'session-same-cwd'
+`).Scan(&otherWorkspaceKey); err != nil {
+		t.Fatalf("read other workspace rail key: %v", err)
+	}
+	if otherWorkspaceKey != RailSectionKeyConversations {
+		t.Fatalf("other workspace rail key = %q, want conversations", otherWorkspaceKey)
 	}
 }

--- a/packages/agent/store-sqlite/rail.go
+++ b/packages/agent/store-sqlite/rail.go
@@ -35,10 +35,11 @@ type existingAgentSessionRailSection struct {
 func (s *Store) classifyAgentSessionRailSectionTx(
 	ctx context.Context,
 	tx *sql.Tx,
+	workspaceID string,
 	cwd string,
 	runtimeContext map[string]any,
 ) (RailSection, error) {
-	projects, err := s.listRailProjectPaths(ctx, tx)
+	projects, err := s.listRailProjectPaths(ctx, tx, workspaceID)
 	if err != nil {
 		return RailSection{}, err
 	}
@@ -77,7 +78,7 @@ func (s *Store) resolveAgentSessionRailSectionTx(
 	if hasImportRail {
 		return importRail, nil
 	}
-	return s.classifyAgentSessionRailSectionTx(ctx, tx, finalCWD, runtimeContext)
+	return s.classifyAgentSessionRailSectionTx(ctx, tx, workspaceID, finalCWD, runtimeContext)
 }
 
 func importedAgentSessionRailSection(
@@ -172,11 +173,11 @@ func ClassifyRailSection(
 	return conversationsAgentSessionRailSection()
 }
 
-func (s *Store) listRailProjectPaths(ctx context.Context, q Querier) ([]string, error) {
+func (s *Store) listRailProjectPaths(ctx context.Context, q Querier, workspaceID string) ([]string, error) {
 	if s.opts.ProjectPaths == nil {
 		return nil, nil
 	}
-	return s.opts.ProjectPaths.ProjectPaths(ctx, q)
+	return s.opts.ProjectPaths.ProjectPaths(ctx, q, strings.TrimSpace(workspaceID))
 }
 
 func normalizeRailProjectPaths(paths []string) []string {

--- a/packages/agent/store-sqlite/store.go
+++ b/packages/agent/store-sqlite/store.go
@@ -21,7 +21,7 @@ type Querier interface {
 // sessions into rail sections. Hosts typically back this with their own
 // project table in the same database.
 type ProjectPathsQuerier interface {
-	ProjectPaths(ctx context.Context, q Querier) ([]string, error)
+	ProjectPaths(ctx context.Context, q Querier, workspaceID string) ([]string, error)
 }
 
 // Options injects the host concerns the store was decoupled from. Every
@@ -33,8 +33,8 @@ type Options struct {
 	// rows for it (and before generated-file listings). It must return an
 	// error for unknown workspaces; nil disables validation.
 	WorkspaceExists func(ctx context.Context, workspaceID string) error
-	// ProjectPaths supplies project roots for rail section classification;
-	// nil classifies every session into the conversations section.
+	// ProjectPaths supplies workspace-scoped project roots for rail section
+	// classification; nil classifies every session into the conversations section.
 	ProjectPaths ProjectPathsQuerier
 	// NormalizeTarget canonicalizes agent targets on write and on read;
 	// nil stores and returns targets verbatim.

--- a/packages/agent/store-sqlite/store_test.go
+++ b/packages/agent/store-sqlite/store_test.go
@@ -20,10 +20,14 @@ const (
 )
 
 type staticProjectPaths struct {
-	paths []string
+	paths            []string
+	pathsByWorkspace map[string][]string
 }
 
-func (s *staticProjectPaths) ProjectPaths(context.Context, Querier) ([]string, error) {
+func (s *staticProjectPaths) ProjectPaths(_ context.Context, _ Querier, workspaceID string) ([]string, error) {
+	if paths, found := s.pathsByWorkspace[workspaceID]; found {
+		return append([]string(nil), paths...), nil
+	}
 	return append([]string(nil), s.paths...), nil
 }
 
@@ -857,6 +861,44 @@ func TestStoreClassifiesRailSectionsWithInjectedProjectPaths(t *testing.T) {
 	}
 	if len(conversationsPage.Sessions) != 1 || conversationsPage.Sessions[0].ID != "session-other" || conversationsPage.Sessions[0].RailSectionKey != RailSectionKeyConversations {
 		t.Fatalf("conversations page = %#v, want session-other", conversationsPage.Sessions)
+	}
+}
+
+func TestStoreScopesInjectedProjectPathsByWorkspace(t *testing.T) {
+	t.Parallel()
+
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := mkdirAll(repo); err != nil {
+		t.Fatalf("mkdir repo error = %v", err)
+	}
+	projects := &staticProjectPaths{pathsByWorkspace: map[string][]string{
+		"ws-with-project": {repo},
+	}}
+	store := openTestStore(t, testOptions(projects))
+	ctx := context.Background()
+
+	for _, workspaceID := range []string{"ws-with-project", "ws-without-project"} {
+		if _, err := store.ReportSessionState(ctx, SessionStateReport{
+			WorkspaceID: workspaceID, AgentSessionID: "session-1", Origin: "runtime",
+			Provider: "codex", Cwd: repo, Status: "completed", OccurredAtUnixMS: 100,
+		}); err != nil {
+			t.Fatalf("ReportSessionState(%s) error = %v", workspaceID, err)
+		}
+	}
+
+	withProject, found, err := store.GetSession(ctx, "ws-with-project", "session-1")
+	if err != nil || !found {
+		t.Fatalf("GetSession(ws-with-project) found=%v error=%v", found, err)
+	}
+	if want := RailSectionKeyForProject(repo); withProject.RailSectionKey != want {
+		t.Fatalf("ws-with-project rail key = %q, want %q", withProject.RailSectionKey, want)
+	}
+	withoutProject, found, err := store.GetSession(ctx, "ws-without-project", "session-1")
+	if err != nil || !found {
+		t.Fatalf("GetSession(ws-without-project) found=%v error=%v", found, err)
+	}
+	if withoutProject.RailSectionKey != RailSectionKeyConversations {
+		t.Fatalf("ws-without-project rail key = %q, want conversations", withoutProject.RailSectionKey)
 	}
 }
 

--- a/services/tuttid/data/workspace/agent_store.go
+++ b/services/tuttid/data/workspace/agent_store.go
@@ -73,7 +73,7 @@ func (s *SQLiteStore) agentReadStore() *agentstore.Store {
 // or database) the store is currently running on.
 type userProjectPathsQuerier struct{}
 
-func (userProjectPathsQuerier) ProjectPaths(ctx context.Context, q agentstore.Querier) ([]string, error) {
+func (userProjectPathsQuerier) ProjectPaths(ctx context.Context, q agentstore.Querier, _ string) ([]string, error) {
 	rows, err := q.QueryContext(ctx, `
 SELECT path
 FROM user_projects


### PR DESCRIPTION
## Summary

- pass the owning workspace ID into project-path lookup during rail classification
- keep one canonical SQLite store while preventing cross-workspace project leakage
- cover live classification and legacy rail backfill with workspace-isolation tests

## Validation

- `go test ./...` in `packages/agent/store-sqlite`
- `go test ./data/workspace` in `services/tuttid`
- `pnpm check:full` (Node 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->