### PR TITLE
test(workspace-launch): remove transport mock noise

### DIFF
--- a/apps/desktop/src/main/host/workspaceLaunch.test.ts
+++ b/apps/desktop/src/main/host/workspaceLaunch.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type {
   TuttidClient,
-  WorkbenchSnapshot,
   WorkspaceSummary
 } from "@tutti-os/client-tuttid-ts";
 import {
@@ -10,6 +9,8 @@ import {
   type WorkspaceLaunchAdapters,
   type WorkspaceLaunchOwnerWindow
 } from "./workspaceLaunch.ts";
+
+type StartupWorkspaceClient = Pick<TuttidClient, "getStartupWorkspace">;
 
 function createWorkspaceSummary(id: string): WorkspaceSummary {
   return {
@@ -19,13 +20,11 @@ function createWorkspaceSummary(id: string): WorkspaceSummary {
   };
 }
 
-function createWorkbenchSnapshot(): WorkbenchSnapshot {
-  return {
-    schemaVersion: 1,
-    nodes: [],
-    nodeStack: [],
-    activeNodeId: null
-  };
+function createStartupWorkspaceClient(
+  getStartupWorkspace: StartupWorkspaceClient["getStartupWorkspace"] = async () =>
+    null
+): StartupWorkspaceClient {
+  return { getStartupWorkspace };
 }
 
 function createAdapters(
@@ -39,586 +38,9 @@ function createAdapters(
   };
 }
 
-function createTransportClient(
-  overrides: Partial<TuttidClient> = {}
-): TuttidClient {
-  const client: TuttidClient = {
-    async listAgentTargets() {
-      throw new Error("not used");
-    },
-    async setSystemAgentTargetEnabled() {
-      throw new Error("not used");
-    },
-    async getAgentTargetSetup() {
-      throw new Error("not used");
-    },
-    async installAgentTargetRuntime() {
-      throw new Error("not used");
-    },
-    async authenticateAgentTargetRuntime() {
-      throw new Error("not used");
-    },
-    async startAccountLogin() {
-      throw new Error("not used");
-    },
-    async getAccountLoginStatus() {
-      throw new Error("not used");
-    },
-    async getAccountUserInfo() {
-      throw new Error("not used");
-    },
-    async getAccountProductSummary() {
-      throw new Error("not used");
-    },
-    async dismissAccountRegistrationCreditsReward() {
-      throw new Error("not used");
-    },
-    async logoutAccount() {
-      throw new Error("not used");
-    },
-    async applyWorkspaceGitPatch() {
-      throw new Error("not used");
-    },
-    async listCliCapabilities() {
-      throw new Error("not used");
-    },
-    async listWorkspaceAppMentionCandidates() {
-      throw new Error("not used");
-    },
-    async addWorkspaceIssueContextRefs() {
-      throw new Error("not used");
-    },
-    async addWorkspaceIssueTaskContextRefs() {
-      throw new Error("not used");
-    },
-    async listWorkspaceAppReferences() {
-      throw new Error("not used");
-    },
-    async searchWorkspaceAppReferences() {
-      throw new Error("not used");
-    },
-    async prepareWorkspaceAppUpload() {
-      throw new Error("not used");
-    },
-    async completeWorkspaceAppUpload() {
-      throw new Error("not used");
-    },
-    async cancelWorkspaceAppUpload() {
-      throw new Error("not used");
-    },
-    async installWorkspaceApp() {
-      throw new Error("not used");
-    },
-    async exportWorkspaceApp() {
-      throw new Error("not used");
-    },
-    async importWorkspaceApp() {
-      throw new Error("not used");
-    },
-    async loadLocalWorkspaceApp() {
-      throw new Error("not used");
-    },
-    async replaceWorkspaceAppIcon() {
-      throw new Error("not used");
-    },
-    async reloadLocalWorkspaceApp() {
-      throw new Error("not used");
-    },
-    async cancelWorkspaceAppFactoryJob() {
-      throw new Error("not used");
-    },
-    async deleteWorkspaceAppFactoryJob() {
-      throw new Error("not used");
-    },
-    async deleteWorkspaceApp() {
-      throw new Error("not used");
-    },
-    async checkWorkspaceTerminalCloseGuard() {
-      throw new Error("not used");
-    },
-    async completeWorkspaceIssueTaskRun() {
-      throw new Error("not used");
-    },
-    async completeWorkspaceIssueRun() {
-      throw new Error("not used");
-    },
-    async createWorkspace() {
-      return createWorkspaceSummary("unused");
-    },
-    async createWorkspaceIssueTopic() {
-      throw new Error("not used");
-    },
-    async createWorkspaceAgentSession() {
-      throw new Error("not used");
-    },
-    async updateWorkspaceAgentSessionVisibility() {
-      throw new Error("not used");
-    },
-    async createWorkspaceAppFactoryJob() {
-      throw new Error("not used");
-    },
-    async createWorkspaceFile(_workspaceID, path) {
-      return {
-        entry: {
-          createdTimeMs: null,
-          hasChildren: false,
-          kind: "file",
-          lastOpenedMs: null,
-          mtimeMs: null,
-          name: path.split("/").at(-1) ?? path,
-          path,
-          sizeBytes: 0
-        },
-        root: "/workspace",
-        workspaceId: _workspaceID
-      };
-    },
-    async readWorkspaceFilePreview(_workspaceID, path) {
-      return {
-        bytesBase64: "",
-        name: path.split("/").at(-1) ?? path,
-        path,
-        root: "/workspace",
-        sizeBytes: 0,
-        workspaceId: _workspaceID
-      };
-    },
-    async writeWorkspaceFileText(_workspaceID, request) {
-      return {
-        entry: {
-          createdTimeMs: null,
-          hasChildren: false,
-          kind: "file",
-          lastOpenedMs: null,
-          mtimeMs: null,
-          name: request.path.split("/").at(-1) ?? request.path,
-          path: request.path,
-          sizeBytes: request.content.length
-        },
-        root: "/workspace",
-        workspaceId: _workspaceID
-      };
-    },
-    async createWorkspaceFileDirectory(_workspaceID, path) {
-      return {
-        entry: {
-          createdTimeMs: null,
-          hasChildren: false,
-          kind: "directory",
-          lastOpenedMs: null,
-          mtimeMs: null,
-          name: path.split("/").at(-1) ?? path,
-          path,
-          sizeBytes: null
-        },
-        root: "/workspace",
-        workspaceId: _workspaceID
-      };
-    },
-    async createWorkspaceIssue() {
-      throw new Error("not used");
-    },
-    async createWorkspaceIssueTask() {
-      throw new Error("not used");
-    },
-    async createWorkspaceIssueTasks() {
-      throw new Error("not used");
-    },
-    async createWorkspaceIssueTaskRun() {
-      throw new Error("not used");
-    },
-    async createWorkspaceIssueRun() {
-      throw new Error("not used");
-    },
-    async createWorkspaceTerminal() {
-      throw new Error("not used");
-    },
-    async deleteWorkspaceAgentSession() {
-      throw new Error("not used");
-    },
-    async deleteWorkspaceAgentSessionsBatch() {
-      throw new Error("not used");
-    },
-    async updateWorkspaceAgentSessionTitle() {
-      throw new Error("not used");
-    },
-    async clearWorkspaceAgentSessions() {
-      throw new Error("not used");
-    },
-    async deleteWorkspace(workspaceID) {
-      return { workspaceId: workspaceID };
-    },
-    async deleteWorkspaceFileEntry(workspaceID, request) {
-      return { path: request.path, workspaceId: workspaceID };
-    },
-    async moveWorkspaceFileEntry(workspaceID, request) {
-      return {
-        entry: {
-          createdTimeMs: null,
-          hasChildren: false,
-          kind: "file",
-          lastOpenedMs: null,
-          mtimeMs: null,
-          name: request.path.split("/").at(-1) ?? request.path,
-          path: `${request.targetDirectoryPath}/${request.path.split("/").at(-1) ?? request.path}`,
-          sizeBytes: 0
-        },
-        root: "/workspace",
-        workspaceId: workspaceID
-      };
-    },
-    async renameWorkspaceFileEntry(workspaceID, request) {
-      return {
-        entry: {
-          createdTimeMs: null,
-          hasChildren: false,
-          kind: "file",
-          lastOpenedMs: null,
-          mtimeMs: null,
-          name: request.newName,
-          path: `${request.path.split("/").slice(0, -1).join("/")}/${request.newName}`,
-          sizeBytes: 0
-        },
-        root: "/workspace",
-        workspaceId: workspaceID
-      };
-    },
-    async copyWorkspaceFileEntry(workspaceID, request) {
-      const baseName = request.path.split("/").at(-1) ?? request.path;
-      return {
-        entry: {
-          createdTimeMs: null,
-          hasChildren: false,
-          kind: "file",
-          lastOpenedMs: null,
-          mtimeMs: null,
-          name: `${baseName} copy`,
-          path: `${request.path.split("/").slice(0, -1).join("/")}/${baseName} copy`,
-          sizeBytes: 0
-        },
-        root: "/workspace",
-        workspaceId: workspaceID
-      };
-    },
-    async deleteWorkspaceIssue() {
-      throw new Error("not used");
-    },
-    async deleteWorkspaceIssueTopic() {
-      throw new Error("not used");
-    },
-    async deleteWorkspaceIssueTask() {
-      throw new Error("not used");
-    },
-    async getDesktopPreferences() {
-      throw new Error("not used");
-    },
-    async getHealth() {
-      return { service: "tuttid", status: "ok" as const };
-    },
-    async getStartupWorkspace() {
-      return null;
-    },
-    async getWorkspace(workspaceID) {
-      return createWorkspaceSummary(workspaceID);
-    },
-    async getWorkspaceAgentSession() {
-      throw new Error("not used");
-    },
-    async getWorkspaceAppFactoryJob() {
-      throw new Error("not used");
-    },
-    async getWorkspaceAppFactoryAgentTargetComposerOptions() {
-      throw new Error("not used");
-    },
-    async getAgentProviderComposerOptions() {
-      throw new Error("not used");
-    },
-    async getAgentProviderStatuses() {
-      throw new Error("not used");
-    },
-    async probeAgentProvider() {
-      throw new Error("not used");
-    },
-    async runAgentProviderAction() {
-      throw new Error("not used");
-    },
-    async getWorkspaceIssueDetail() {
-      throw new Error("not used");
-    },
-    async searchWorkspaceIssueReferences() {
-      throw new Error("not used");
-    },
-    async getWorkspaceIssueTaskDetail() {
-      throw new Error("not used");
-    },
-    async getWorkspaceIssueTaskRun() {
-      throw new Error("not used");
-    },
-    async getWorkspaceIssueRun() {
-      throw new Error("not used");
-    },
-    async getWorkspaceTerminal() {
-      throw new Error("not used");
-    },
-    async getWorkspaceTerminalSnapshot() {
-      throw new Error("not used");
-    },
-    async getWorkspaceWorkbench() {
-      return createWorkbenchSnapshot();
-    },
-    async getWorkspaceFileTreeSnapshot(workspaceID, request) {
-      const path = request?.path ?? "/workspace";
-      return {
-        budgetExceeded: false,
-        directory: {
-          directoryPath: path,
-          entries: [],
-          prefetchState: "loaded" as const
-        },
-        prefetchBudgetMs: request?.prefetchBudgetMs ?? 500,
-        prefetchDepth: request?.prefetchDepth ?? 4,
-        root: "/workspace",
-        workspaceId: workspaceID
-      };
-    },
-    async listWorkspaceFileDirectory(workspaceID, request) {
-      const path = request?.path ?? "/workspace";
-      return {
-        directoryPath: path,
-        entries: [],
-        root: "/workspace",
-        workspaceId: workspaceID
-      };
-    },
-    async listWorkspaceRecentFiles(workspaceID) {
-      return {
-        directoryPath: "/workspace",
-        entries: [],
-        root: "/workspace",
-        workspaceId: workspaceID
-      };
-    },
-    async listWorkspaceIssueTaskRuns() {
-      throw new Error("not used");
-    },
-    async listWorkspaceIssueRuns() {
-      throw new Error("not used");
-    },
-    async listWorkspaceIssueTasks() {
-      throw new Error("not used");
-    },
-    async listWorkspaceIssues() {
-      throw new Error("not used");
-    },
-    async listWorkspaceIssueTopics() {
-      throw new Error("not used");
-    },
-    async listWorkspaceAgentSessionMessages() {
-      throw new Error("not used");
-    },
-    async listWorkspaceAgentGeneratedFiles() {
-      throw new Error("not used");
-    },
-    async listUserProjects() {
-      throw new Error("not used");
-    },
-    async moveUserProject() {
-      throw new Error("not used");
-    },
-    async pinUserProject() {
-      throw new Error("not used");
-    },
-    async deleteUserProject() {
-      throw new Error("not used");
-    },
-    async checkUserProjectPath() {
-      throw new Error("not used");
-    },
-    async listWorkspaceTerminals(workspaceID) {
-      return { terminals: [], workspaceId: workspaceID };
-    },
-    async listWorkspaceAgentSessions(workspaceID) {
-      return { hasMore: false, sessions: [], workspaceId: workspaceID };
-    },
-    async listWorkspaceAgentSessionSections(workspaceID) {
-      return {
-        pinned: { hasMore: false, sessions: [], totalCount: 0 },
-        sections: [],
-        workspaceId: workspaceID
-      };
-    },
-    async listWorkspaceAgentSessionSectionPage() {
-      throw new Error("not used");
-    },
-    async listWorkspaceAgentSessionSectionDeletionCandidates() {
-      throw new Error("not used");
-    },
-    async listWorkspaceAgentPinnedSessionPage() {
-      throw new Error("not used");
-    },
-    async scanWorkspaceExternalAgentSessionImports() {
-      throw new Error("not used");
-    },
-    async importWorkspaceExternalAgentSessions() {
-      throw new Error("not used");
-    },
-    async listWorkspaces() {
-      return { workspaces: [], totalCount: 0 };
-    },
-    async listWorkspaceApps() {
-      throw new Error("not used");
-    },
-    async refreshWorkspaceAppCatalog() {
-      throw new Error("not used");
-    },
-    async listWorkspaceAppFactoryJobs() {
-      throw new Error("not used");
-    },
-    async openWorkspace(workspaceID) {
-      return createWorkspaceSummary(workspaceID);
-    },
-    async preflightUploadWorkspaceFiles(workspaceID, request) {
-      return {
-        conflicts: [],
-        root: "/workspace",
-        targetDirectoryPath: request.targetDirectoryPath,
-        workspaceId: workspaceID
-      };
-    },
-    async putWorkspaceWorkbench(_workspaceID, snapshot) {
-      return snapshot;
-    },
-    async uninstallWorkspaceApp() {
-      throw new Error("not used");
-    },
-    async removeWorkspaceIssueContextRef() {
-      throw new Error("not used");
-    },
-    async removeWorkspaceIssueTaskContextRef() {
-      throw new Error("not used");
-    },
-    async resizeWorkspaceTerminal() {
-      throw new Error("not used");
-    },
-    async cancelWorkspaceAgentTurn() {
-      throw new Error("not used");
-    },
-    async goalControlWorkspaceAgentSession() {
-      throw new Error("not used");
-    },
-    async getWorkspaceAgentSessionGoal() {
-      throw new Error("not used");
-    },
-    async reconcileWorkspaceAgentSessionGoal() {
-      throw new Error("not used");
-    },
-    async sendWorkspaceAgentSessionInput() {
-      throw new Error("not used");
-    },
-    async submitWorkspaceAgentPlanDecision() {
-      throw new Error("not used");
-    },
-    async readWorkspaceAgentSessionAttachment() {
-      throw new Error("not used");
-    },
-    async listWorkspaceAgentSessionGitBranches() {
-      throw new Error("not used");
-    },
-    async listWorkspaceGitBranches() {
-      throw new Error("not used");
-    },
-    async resolveWorkspaceGitPatchSupport() {
-      throw new Error("not used");
-    },
-    async updateWorkspaceAgentSessionSettings() {
-      throw new Error("not used");
-    },
-    async updateWorkspaceAgentSessionPin() {
-      throw new Error("not used");
-    },
-    async submitWorkspaceAgentInteractive() {
-      throw new Error("not used");
-    },
-    async launchWorkspaceApp() {
-      throw new Error("not used");
-    },
-    async retryWorkspaceApp() {
-      throw new Error("not used");
-    },
-    async retryWorkspaceAppFactoryJobValidation() {
-      throw new Error("not used");
-    },
-    async fixWorkspaceAppFactoryJob() {
-      throw new Error("not used");
-    },
-    async prepareWorkspaceAppFactoryJobModification() {
-      throw new Error("not used");
-    },
-    async publishWorkspaceAppFactoryJob() {
-      throw new Error("not used");
-    },
-    async rollbackWorkspaceApp() {
-      throw new Error("not used");
-    },
-    async searchWorkspaceFiles(workspaceID) {
-      return {
-        entries: [],
-        root: "/workspace",
-        workspaceId: workspaceID
-      };
-    },
-    async startEnabledWorkspaceApps() {
-      throw new Error("not used");
-    },
-    async stopAllWorkspaceApps() {
-      throw new Error("not used");
-    },
-    async putDesktopPreferences() {
-      throw new Error("not used");
-    },
-    async terminateWorkspaceTerminal() {
-      throw new Error("not used");
-    },
-    async trackEvents() {},
-    async useUserProject() {
-      throw new Error("not used");
-    },
-    async updateWorkspace(workspaceID) {
-      return createWorkspaceSummary(workspaceID);
-    },
-    async updateWorkspaceIssue() {
-      throw new Error("not used");
-    },
-    async updateWorkspaceIssueTask() {
-      throw new Error("not used");
-    },
-    async updateWorkspaceIssueTopic() {
-      throw new Error("not used");
-    },
-    async uploadWorkspaceFiles(workspaceID, request) {
-      return {
-        entries: request.sourcePaths.map((sourcePath) => ({
-          createdTimeMs: null,
-          hasChildren: false,
-          kind: "file",
-          lastOpenedMs: null,
-          mtimeMs: null,
-          name: sourcePath.split("/").at(-1) ?? sourcePath,
-          path: `${request.targetDirectoryPath}/${sourcePath.split("/").at(-1) ?? sourcePath}`,
-          sizeBytes: 0
-        })),
-        root: "/workspace",
-        targetDirectoryPath: request.targetDirectoryPath,
-        workspaceId: workspaceID
-      };
-    }
-  };
-  return Object.assign(client, overrides);
-}
-
-test("workspace launch opens daemon-provided startup workspace", async () => {
+test("workspace launch opens the daemon-resolved startup workspace", async () => {
+  let startupCalls = 0;
   let openedWorkspaceID: string | null = null;
-  let listCalled = false;
 
   const launch = createWorkspaceLaunch({
     adapters: createAdapters({
@@ -626,98 +48,45 @@ test("workspace launch opens daemon-provided startup workspace", async () => {
         openedWorkspaceID = workspaceID;
       }
     }),
-    tuttidClient: createTransportClient({
-      async getStartupWorkspace() {
-        return createWorkspaceSummary("ws-start");
-      },
-      async listWorkspaces() {
-        listCalled = true;
-        return { totalCount: 0, workspaces: [] };
-      }
+    tuttidClient: createStartupWorkspaceClient(async () => {
+      startupCalls += 1;
+      return createWorkspaceSummary("ws-start");
     })
   });
 
   await launch.openStartupWindow();
 
+  assert.equal(startupCalls, 1);
   assert.equal(openedWorkspaceID, "ws-start");
-  assert.equal(listCalled, false);
-});
-
-test("workspace launch opens the existing personal workspace when no startup workspace is set", async () => {
-  const events: string[] = [];
-
-  const launch = createWorkspaceLaunch({
-    adapters: createAdapters({
-      async showWorkspaceWindow(workspaceID) {
-        events.push(`show:${workspaceID}`);
-      }
-    }),
-    tuttidClient: createTransportClient({
-      async getStartupWorkspace() {
-        events.push("startup");
-        return createWorkspaceSummary("ws-existing");
-      }
-    })
-  });
-
-  await launch.openStartupWindow();
-
-  assert.deepEqual(events, ["startup", "show:ws-existing"]);
-});
-
-test("workspace launch creates and opens the default workspace when the catalog is empty", async () => {
-  const events: string[] = [];
-
-  const launch = createWorkspaceLaunch({
-    adapters: createAdapters({
-      async showWorkspaceWindow(workspaceID) {
-        events.push(`show:${workspaceID}`);
-      }
-    }),
-    tuttidClient: createTransportClient({
-      async getStartupWorkspace() {
-        events.push("startup");
-        return createWorkspaceSummary("ws-default");
-      }
-    })
-  });
-
-  await launch.openStartupWindow();
-
-  assert.deepEqual(events, ["startup", "show:ws-default"]);
 });
 
 test("workspace launch warns and rejects when startup resolution fails", async () => {
+  const error = new Error("boom");
   let warnedError: unknown = null;
 
   const launch = createWorkspaceLaunch({
     adapters: createAdapters({
-      warnStartupWindowResolutionFailure(error) {
-        warnedError = error;
+      warnStartupWindowResolutionFailure(receivedError) {
+        warnedError = receivedError;
       }
     }),
-    tuttidClient: createTransportClient({
-      async getStartupWorkspace() {
-        throw new Error("boom");
-      }
+    tuttidClient: createStartupWorkspaceClient(async () => {
+      throw error;
     })
   });
 
-  await assert.rejects(launch.openStartupWindow(), /boom/);
-  assert.ok(warnedError instanceof Error);
-  assert.equal(warnedError.message, "boom");
+  await assert.rejects(launch.openStartupWindow(), error);
+  assert.equal(warnedError, error);
 });
 
 test("workspace launch waits for replacement workspace window before closing owner", async () => {
   let ownerWindowClosed = false;
-  let resolveWorkspaceWindow: (() => void) | null = null;
-
+  let resolveWorkspaceWindow: (() => void) | undefined;
   const ownerWindow: WorkspaceLaunchOwnerWindow = {
     close() {
       ownerWindowClosed = true;
     }
   };
-
   const launch = createWorkspaceLaunch({
     adapters: createAdapters({
       async showWorkspaceWindow() {
@@ -726,18 +95,15 @@ test("workspace launch waits for replacement workspace window before closing own
         });
       }
     }),
-    tuttidClient: createTransportClient()
+    tuttidClient: createStartupWorkspaceClient()
   });
 
   const openPromise = launch.showWorkspace(ownerWindow, "ws-alpha");
   await Promise.resolve();
 
   assert.equal(ownerWindowClosed, false);
-  if (!resolveWorkspaceWindow) {
-    throw new Error("workspace window open resolver was not assigned");
-  }
-  const finishWorkspaceWindowOpen = resolveWorkspaceWindow as () => void;
-  finishWorkspaceWindowOpen();
+  assert.ok(resolveWorkspaceWindow);
+  resolveWorkspaceWindow();
 
   await openPromise;
   assert.equal(ownerWindowClosed, true);
@@ -756,7 +122,7 @@ test("workspace launch replacement uses the requested native window kind", async
         events.push(`${workspaceID}:${options?.windowKind}`);
       }
     }),
-    tuttidClient: createTransportClient()
+    tuttidClient: createStartupWorkspaceClient()
   });
 
   await launch.replaceWorkspaceWindow(ownerWindow, "ws-alpha", "agent");
@@ -766,7 +132,6 @@ test("workspace launch replacement uses the requested native window kind", async
 
 test("workspace launch prefers destroying owner windows after workspace handoff", async () => {
   const events: string[] = [];
-
   const ownerWindow: WorkspaceLaunchOwnerWindow = {
     close() {
       events.push("owner:closed");
@@ -775,14 +140,13 @@ test("workspace launch prefers destroying owner windows after workspace handoff"
       events.push("owner:destroyed");
     }
   };
-
   const launch = createWorkspaceLaunch({
     adapters: createAdapters({
       async showWorkspaceWindow(workspaceID) {
         events.push(`workspace:${workspaceID}`);
       }
     }),
-    tuttidClient: createTransportClient()
+    tuttidClient: createStartupWorkspaceClient()
   });
 
   await launch.showWorkspace(ownerWindow, "ws-destroy");
@@ -807,7 +171,7 @@ test("workspace launch keeps a reused durable workspace owner open", async () =>
         return ownerWindow;
       }
     }),
-    tuttidClient: createTransportClient()
+    tuttidClient: createStartupWorkspaceClient()
   });
 
   await launch.showWorkspace(ownerWindow, "ws-existing-owner");
@@ -817,20 +181,18 @@ test("workspace launch keeps a reused durable workspace owner open", async () =>
 
 test("workspace launch keeps owner open when replacement workspace window fails", async () => {
   let ownerWindowClosed = false;
-
   const ownerWindow: WorkspaceLaunchOwnerWindow = {
     close() {
       ownerWindowClosed = true;
     }
   };
-
   const launch = createWorkspaceLaunch({
     adapters: createAdapters({
       async showWorkspaceWindow() {
         throw new Error("renderer failed");
       }
     }),
-    tuttidClient: createTransportClient()
+    tuttidClient: createStartupWorkspaceClient()
   });
 
   await assert.rejects(
@@ -841,25 +203,22 @@ test("workspace launch keeps owner open when replacement workspace window fails"
 });
 
 test("workspace launch warns and rejects when startup workspace window fails", async () => {
+  const error = new Error("workspace failed");
   let warnedError: unknown = null;
-
   const launch = createWorkspaceLaunch({
     adapters: createAdapters({
       async showWorkspaceWindow() {
-        throw new Error("workspace failed");
+        throw error;
       },
-      warnStartupWindowResolutionFailure(error) {
-        warnedError = error;
+      warnStartupWindowResolutionFailure(receivedError) {
+        warnedError = receivedError;
       }
     }),
-    tuttidClient: createTransportClient({
-      async getStartupWorkspace() {
-        return createWorkspaceSummary("ws-start");
-      }
-    })
+    tuttidClient: createStartupWorkspaceClient(async () =>
+      createWorkspaceSummary("ws-start")
+    )
   });
 
-  await assert.rejects(launch.openStartupWindow(), /workspace failed/);
-  assert.ok(warnedError instanceof Error);
-  assert.equal(warnedError.message, "workspace failed");
+  await assert.rejects(launch.openStartupWindow(), error);
+  assert.equal(warnedError, error);
 });


### PR DESCRIPTION
## Summary

- replace an over-generated full Tuttid client mock with the exact startup-workspace dependency used by the production module
- remove one duplicate success case whose catalog wording no longer maps to any Desktop production branch
- retain explicit startup resolution, warning, rejection, and window-handoff assertions
- reduce the test file by 641 net lines

## Impact scope

- Test-only change in `apps/desktop/src/main/host/workspaceLaunch.test.ts`
- No Electron main-process behavior, daemon API, catalog policy, IPC, or user-visible flow changes
- Desktop continues to consume the daemon-resolved startup workspace through the existing dependency seam

## Risk assessment

**Risk: low to medium.** The main risk is removing a test that appears to cover catalog behavior. The production module has no catalog/list/create branch: it only calls `getStartupWorkspace` and opens the returned ID. The retained tests explicitly assert one startup lookup, exact ID forwarding, error identity, warnings, and replacement-window lifecycle behavior.

Rollback is a single test-only commit revert.

## Validation

- focused workspace-launch test: 8/8 passed
- Desktop typecheck passed
- full Desktop test suite passed
- `pnpm lint:ts` passed
- `pnpm check:changed` passed
- pre-push `pnpm check:changed -- --push-ready` passed
- architecture review: no findings
- behavior coverage review: no findings
- `git diff --check` passed

## Documentation impact

No durable documentation impact: this removes test-only mock noise and stale test wording without changing architecture, contracts, runtime behavior, or troubleshooting guidance. AutoSkill decision: discard.
