### PR TITLE
fix(agent-gui): split declaration build workers

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -81,6 +81,7 @@ CLI behavior, CI, package assets, skills, Browser Node, and terminal input.
 
 - [Dynamic CLI input rejects plausible flags](./toolchain-browser-terminal.md#dynamic-cli-input-rejects-plausible-flags)
 - [GitHub Actions pnpm setup fails with ERR_PNPM_BAD_PM_VERSION](./toolchain-browser-terminal.md#github-actions-pnpm-setup-fails-with-errpnpmbadpmversion)
+- [Multi-entry tsup declaration build exhausts its worker heap](./toolchain-browser-terminal.md#multi-entry-tsup-declaration-build-exhausts-its-worker-heap)
 - [Browser CLI cold start timeout looks like an unreachable daemon](./toolchain-browser-terminal.md#browser-cli-cold-start-timeout-looks-like-an-unreachable-daemon)
 - [Malformed user skill frontmatter breaks skill discovery](./toolchain-browser-terminal.md#malformed-user-skill-frontmatter-breaks-skill-discovery)
 - [Browser Node failed navigation renders a blank panel](./toolchain-browser-terminal.md#browser-node-failed-navigation-renders-a-blank-panel)

--- a/docs/conventions/troubleshooting/toolchain-browser-terminal.md
+++ b/docs/conventions/troubleshooting/toolchain-browser-terminal.md
@@ -84,6 +84,40 @@
   Search workflows for `pnpm/action-setup` and confirm no step still passes a
   `version` input. Push a new commit to rerun the PR checks.
 
+### Multi-entry tsup declaration build exhausts its worker heap
+
+- Symptom:
+  A package build finishes its ESM phase, then fails during `DTS Build start`
+  with `ERR_WORKER_OUT_OF_MEMORY`. The failure is more frequent when
+  `check:changed --push-ready` runs package builds beside tests and other
+  builds, while an isolated retry may pass.
+- Quick checks:
+  Confirm the error comes from tsup's declaration worker after the JavaScript
+  output reports success. Measure an isolated build with `/usr/bin/time -l`
+  and compare the package's declaration entry count; raising the parent Node
+  heap does not prove the worker's declaration graph is bounded.
+- Root cause:
+  tsup sends every configured declaration entry through one worker. A package
+  with many overlapping public entrypoints can keep repeated TypeScript and
+  Rollup declaration graphs in that worker until it approaches the V8 heap
+  limit. Concurrent validation makes the near-limit build unreliable.
+- Fix:
+  Keep the runtime bundle as one build, then partition declaration entrypoints
+  into complete, non-overlapping groups and build those groups concurrently in
+  separate workers. Keep the group manifest separate from tsup itself so a
+  normal unit test can prove every runtime entry appears exactly once. Do not
+  make a global `NODE_OPTIONS` increase the default fix; it preserves the
+  oversized declaration graph and moves the failure threshold.
+- Validation:
+  Measure the isolated package build before and after, run the entry-coverage
+  test, typecheck imports from both the root and a subpath declaration, run the
+  package pack check, and reproduce the original changed-aware concurrent
+  build without a heap override.
+- References:
+  [agentGuiBuildEntries.ts](../../../packages/agent/gui/build/agentGuiBuildEntries.ts)
+  [tsup.dts.config.ts](../../../packages/agent/gui/tsup.dts.config.ts)
+  [tsup.dts.config.test.ts](../../../packages/agent/gui/tsup.dts.config.test.ts)
+
 ### Browser CLI cold start timeout looks like an unreachable daemon
 
 - Symptom:

--- a/packages/agent/gui/build/agentGuiBuildEntries.ts
+++ b/packages/agent/gui/build/agentGuiBuildEntries.ts
@@ -1,0 +1,68 @@
+export const agentGUIBuildEntries = {
+  index: "index.ts",
+  "agent-gui": "AgentGUI.tsx",
+  "startup-shell": "AgentGUIStartupShell.tsx",
+  agents: "agents.ts",
+  "custom-mention": "custom-mention.ts",
+  "dock-icons": "dockIcons.ts",
+  "mention-search": "agent-gui/agentGuiNode/AgentMentionSearchController.ts",
+  "agent-message-center/index": "agent-message-center/index.ts",
+  "agent-conversation/index": "agent-conversation/index.ts",
+  "agent-env/index": "shared/agentEnv/index.ts",
+  "agent-env/ui": "shared/agentEnv/ui.ts",
+  "context-mention-palette/index": "context-mention-palette/index.ts",
+  "context-mention-provider":
+    "agent-gui/agentGuiNode/agentContextMentionProvider.ts",
+  "agent-title-text": "shared/utils/agentTitleText.ts",
+  "provider-identity": "provider-identity.ts",
+  "provider-icons": "provider-icons.ts",
+  "i18n/index": "i18n/index.ts",
+  "mention-file-presentation": "agent-gui/shared/mentionFilePresentation.ts",
+  "workbench/index": "workbench/index.ts",
+  "workbench/contribution": "workbench/contribution.ts",
+  "workbench/launch": "workbench/launch.ts",
+  "workbench/providerCatalog": "workbench/providerCatalog.ts",
+  "workbench/sessionTitle": "workbench/sessionTitle.ts",
+  "workbench/state": "workbench/state.ts",
+  "workbench/types": "workbench/types.ts",
+  "workspace-agent-generated-files": "shared/workspaceAgentGeneratedFiles.ts",
+  "workspace-query-cache": "shared/query/workspaceQueryCache.ts"
+} as const;
+
+type AgentGUIBuildEntry = keyof typeof agentGUIBuildEntries;
+
+export const agentGUIDtsEntryGroups = [
+  ["index"],
+  [
+    "agent-gui",
+    "startup-shell",
+    "agents",
+    "mention-search",
+    "agent-message-center/index",
+    "agent-conversation/index",
+    "context-mention-palette/index",
+    "context-mention-provider"
+  ],
+  [
+    "custom-mention",
+    "agent-env/index",
+    "agent-env/ui",
+    "provider-identity",
+    "provider-icons",
+    "i18n/index",
+    "mention-file-presentation",
+    "agent-title-text",
+    "workspace-agent-generated-files",
+    "workspace-query-cache"
+  ],
+  [
+    "dock-icons",
+    "workbench/index",
+    "workbench/contribution",
+    "workbench/launch",
+    "workbench/providerCatalog",
+    "workbench/sessionTitle",
+    "workbench/state",
+    "workbench/types"
+  ]
+] as const satisfies readonly (readonly AgentGUIBuildEntry[])[];

--- a/packages/agent/gui/package.json
+++ b/packages/agent/gui/package.json
@@ -47,7 +47,7 @@
     "directory": "packages/agent/gui"
   },
   "scripts": {
-    "build": "tsup --config tsup.config.ts && node ../../../tools/scripts/copy-package-assets.mjs app/renderer/agentactivity.css dist/app/renderer/agentactivity.css app/renderer/assets/icons dist/app/renderer/assets/icons",
+    "build": "tsup --config tsup.config.ts && tsup --config tsup.dts.config.ts && node ../../../tools/scripts/copy-package-assets.mjs app/renderer/agentactivity.css dist/app/renderer/agentactivity.css app/renderer/assets/icons dist/app/renderer/assets/icons",
     "test": "vitest run --environment jsdom --maxWorkers=3",
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },

--- a/packages/agent/gui/tsup.config.ts
+++ b/packages/agent/gui/tsup.config.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { defineConfig, type Options } from "tsup";
 
 import { cssSafeSvgDataUrl } from "./build/cssSafeSvgDataUrl";
+import { agentGUIBuildEntries } from "./build/agentGuiBuildEntries";
 
 const cssSafeSvgDataUrlPlugin: NonNullable<Options["esbuildPlugins"]>[number] =
   {
@@ -20,37 +21,7 @@ const cssSafeSvgDataUrlPlugin: NonNullable<Options["esbuildPlugins"]>[number] =
 
 export default defineConfig({
   clean: true,
-  dts: true,
-  entry: {
-    index: "index.ts",
-    "agent-gui": "AgentGUI.tsx",
-    "startup-shell": "AgentGUIStartupShell.tsx",
-    agents: "agents.ts",
-    "custom-mention": "custom-mention.ts",
-    "dock-icons": "dockIcons.ts",
-    "mention-search": "agent-gui/agentGuiNode/AgentMentionSearchController.ts",
-    "agent-message-center/index": "agent-message-center/index.ts",
-    "agent-conversation/index": "agent-conversation/index.ts",
-    "agent-env/index": "shared/agentEnv/index.ts",
-    "agent-env/ui": "shared/agentEnv/ui.ts",
-    "context-mention-palette/index": "context-mention-palette/index.ts",
-    "context-mention-provider":
-      "agent-gui/agentGuiNode/agentContextMentionProvider.ts",
-    "agent-title-text": "shared/utils/agentTitleText.ts",
-    "provider-identity": "provider-identity.ts",
-    "provider-icons": "provider-icons.ts",
-    "i18n/index": "i18n/index.ts",
-    "mention-file-presentation": "agent-gui/shared/mentionFilePresentation.ts",
-    "workbench/index": "workbench/index.ts",
-    "workbench/contribution": "workbench/contribution.ts",
-    "workbench/launch": "workbench/launch.ts",
-    "workbench/providerCatalog": "workbench/providerCatalog.ts",
-    "workbench/sessionTitle": "workbench/sessionTitle.ts",
-    "workbench/state": "workbench/state.ts",
-    "workbench/types": "workbench/types.ts",
-    "workspace-agent-generated-files": "shared/workspaceAgentGeneratedFiles.ts",
-    "workspace-query-cache": "shared/query/workspaceQueryCache.ts"
-  },
+  entry: agentGUIBuildEntries,
   external: ["react", "react-dom"],
   esbuildPlugins: [cssSafeSvgDataUrlPlugin],
   format: ["esm"],

--- a/packages/agent/gui/tsup.dts.config.test.ts
+++ b/packages/agent/gui/tsup.dts.config.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  agentGUIBuildEntries,
+  agentGUIDtsEntryGroups
+} from "./build/agentGuiBuildEntries";
+
+describe("Agent GUI declaration build groups", () => {
+  it("cover every runtime entry exactly once", () => {
+    const declarationEntries = agentGUIDtsEntryGroups.flat();
+    const runtimeEntries = Object.keys(agentGUIBuildEntries).sort();
+
+    expect(new Set(declarationEntries).size).toBe(declarationEntries.length);
+    expect([...declarationEntries].sort()).toEqual(runtimeEntries);
+  });
+});

--- a/packages/agent/gui/tsup.dts.config.ts
+++ b/packages/agent/gui/tsup.dts.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, type Options } from "tsup";
+
+import {
+  agentGUIBuildEntries,
+  agentGUIDtsEntryGroups
+} from "./build/agentGuiBuildEntries";
+
+export default defineConfig(
+  agentGUIDtsEntryGroups.map((entryNames, index): Options => {
+    const entry = Object.fromEntries(
+      entryNames.map((name) => [name, agentGUIBuildEntries[name]])
+    );
+
+    return {
+      name: `dts:${index + 1}`,
+      clean: false,
+      dts: { only: true },
+      entry,
+      external: ["react", "react-dom"],
+      format: ["esm"]
+    };
+  })
+);


### PR DESCRIPTION
## Summary

- keep AgentGUI runtime bundling in one tsup build
- split 27 declaration entrypoints across four independent DTS workers
- add manifest coverage test preventing missing or duplicated declaration entries
- document the recurring ERR_WORKER_OUT_OF_MEMORY diagnosis and fix

## Root cause

tsup processed every declaration entrypoint in one worker. Its heap approached the V8 worker limit, so changed-aware concurrent validation could fail even when the machine still had free memory. Raising global NODE_OPTIONS only moved the failure threshold.

## Performance

- isolated build: 20.26s -> 15.98s (about 21% faster)
- changed-aware push validation succeeds with the default heap
- aggregate RSS is similar; the fix bounds per-worker heap pressure rather than claiming lower total system memory

## User impact

None. This changes package build and declaration generation only; runtime output and user-visible behavior stay unchanged.

## Validation

- pnpm check:changed -- --push-ready (9 lanes)
- pnpm typecheck (27 packages)
- pnpm lint:ts
- AgentGUI tests (203 files, 1845 tests)
- pnpm release:pack:check
- root and subpath declaration import compatibility check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->