### PR TITLE
fix(workbench): preserve dock hook order

### DIFF
--- a/packages/workbench/surface/package.json
+++ b/packages/workbench/surface/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts && node ../../../tools/scripts/copy-package-assets.mjs src/styles dist/styles",
-    "test": "node --test --experimental-strip-types ./src/**/*.test.ts",
+    "test": "node --test --experimental-strip-types ./src/**/*.test.ts && vitest run ./src/host/WorkbenchHostDock.render.test.tsx --environment jsdom",
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },
   "devDependencies": {
@@ -28,9 +28,11 @@
     "@types/node": "^24.0.1",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",
+    "jsdom": "^27.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^4.0.13"
   },
   "dependencies": {
     "@tutti-os/ui-i18n-runtime": "workspace:*",

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.render.test.tsx
@@ -1,0 +1,120 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it } from "vitest";
+import type { WorkbenchState } from "../core/types.ts";
+import type { WorkbenchDockContext } from "../react/types.ts";
+import type { WorkbenchController } from "../store/types.ts";
+import { WorkbenchHostDock } from "./WorkbenchHostDock.tsx";
+import type { WorkbenchHostHandle, WorkbenchHostNodeData } from "./types.ts";
+import { createWorkbenchHostI18nRuntime } from "./workbenchHostI18n.ts";
+
+describe("WorkbenchHostDock", () => {
+  it("preserves hook order while dock entries appear and disappear", async () => {
+    const props = createDockProps();
+    const dockEntry = {
+      icon: null,
+      id: "agent-gui",
+      label: "Agent",
+      typeId: "agent-gui",
+      visibility: "always" as const
+    };
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(<WorkbenchHostDock {...props} dockEntries={[]} />);
+      });
+      expect(container.querySelector('[role="toolbar"]')).toBeNull();
+
+      await act(async () => {
+        root.render(<WorkbenchHostDock {...props} dockEntries={[dockEntry]} />);
+      });
+      expect(container.querySelector('[role="toolbar"]')).not.toBeNull();
+
+      await act(async () => {
+        root.render(<WorkbenchHostDock {...props} dockEntries={[]} />);
+      });
+      expect(container.querySelector('[role="toolbar"]')).toBeNull();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+  });
+});
+
+function createDockProps() {
+  const state: WorkbenchState<WorkbenchHostNodeData> = {
+    activeDragNodeId: null,
+    activeResizeNodeId: null,
+    activeSnapTarget: null,
+    layoutConstraints: {
+      minHeight: 160,
+      minWidth: 280,
+      safeArea: { bottom: 0, left: 0, right: 0, top: 0 },
+      surfacePadding: 0
+    },
+    lockedLayout: null,
+    nodes: [],
+    nodeStack: [],
+    surfaceSize: { height: 800, width: 1200 }
+  };
+  const controller: WorkbenchController<WorkbenchHostNodeData> = {
+    commands: {} as WorkbenchController<WorkbenchHostNodeData>["commands"],
+    dispatch() {},
+    getSnapshot: () => state,
+    subscribe: () => () => {}
+  };
+  const context: WorkbenchDockContext<WorkbenchHostNodeData> = {
+    controller,
+    focusedNodeId: null,
+    genie: {
+      isPendingMinimizedDockNode: () => false,
+      launchNodeFromAnchor(_anchorKey, _nodeId, launch) {
+        void launch();
+      },
+      registerDockAnchor() {},
+      shouldAnimateMinimizedDockEnter: () => false
+    },
+    minimizedNodes: [],
+    nodes: []
+  };
+  const host: WorkbenchHostHandle = {
+    activateNode() {},
+    closeNode() {},
+    collectWindowCloseEffects: async () => [],
+    dispose() {},
+    exitFullscreenNode() {},
+    focusNode() {},
+    getSnapshot: () => state,
+    launchNode: async () => null,
+    load: async () => {},
+    minimizeNode() {},
+    reconcileProjectedNodes() {},
+    requestNodeClose() {},
+    setNodeRuntimeState() {},
+    setNodeSizeConstraints() {},
+    setNodeTitle() {},
+    setSnapshotNodeState() {}
+  };
+
+  return {
+    context,
+    host,
+    i18n: createWorkbenchHostI18nRuntime(undefined),
+    nodeDefinitions: new Map(),
+    workspaceId: "workspace-hook-order"
+  };
+}

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -1244,10 +1244,6 @@ export function WorkbenchHostDock({
     [nodeDefinitions, provideMinimizedNodePreview]
   );
 
-  if (dockItems.length === 0 && presentDockItems.length === 0) {
-    return null;
-  }
-
   const closePopup = () => {
     clearHoverPanelCloseTimer();
     clearHoverPanelOpenTimer();
@@ -1343,6 +1339,10 @@ export function WorkbenchHostDock({
     },
     [host, onDockEntryAction, pendingActionKeys]
   );
+
+  if (dockItems.length === 0 && presentDockItems.length === 0) {
+    return null;
+  }
 
   const popupEntry =
     activePopup === null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -764,6 +764,9 @@ importers:
       "@types/react-dom":
         specifier: ^19.1.5
         version: 19.2.3(@types/react@19.2.15)
+      jsdom:
+        specifier: ^27.2.0
+        version: 27.4.0
       react:
         specifier: ^19.1.0
         version: 19.2.6
@@ -773,6 +776,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.13
+        version: 4.1.7(@types/node@24.12.4)(jsdom@27.4.0)(vite@6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/workspace/app-center:
     dependencies:


### PR DESCRIPTION
## Summary

- keep `WorkbenchHostDock` hooks ahead of the empty-dock return
- add a React/jsdom regression test covering `empty -> populated -> empty` dock transitions
- run the render regression alongside the existing workbench surface tests

## Problem

`WorkbenchHostDock` returned early while both current and exiting dock item lists were empty. Two `useCallback` hooks appeared after that return, so the first transition from an empty dock to populated entries rendered more hooks than the previous render. React then rebuilt the workbench surface through its error boundary, which could blank the room surface and dock.

## Validation

- `pnpm --filter @tutti-os/workbench-surface test`
- `pnpm --filter @tutti-os/workbench-surface typecheck`
- `pnpm --filter @tutti-os/workbench-surface build`
- `pnpm check:changed -- --push-ready`

## Documentation

No documentation impact: this restores the existing dock transition behavior without changing public APIs, user-facing copy, or package ownership.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->