### PR TITLE
reorder workbench contributions: move agent-gui and files sidebar items earlier

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/agentGuiWorkbenchContributionFactory.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/agentGuiWorkbenchContributionFactory.ts
@@ -33,7 +33,7 @@ type AgentGuiWorkbenchContributionContext = Pick<
 export const agentGuiWorkbenchContributionFactory: DesktopWorkbenchContributionFactory<AgentGuiWorkbenchContributionContext> =
   {
     id: "workspace-agent-gui",
-    order: 25,
+    order: -10,
     create(context) {
       return createWorkspaceAgentGuiContribution({
         agentProviderStatusService: context.agentProviderStatusService,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/filesWorkbenchContributionFactory.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/filesWorkbenchContributionFactory.ts
@@ -20,7 +20,7 @@ type FilesWorkbenchContributionContext = Pick<
 export const filesWorkbenchContributionFactory: DesktopWorkbenchContributionFactory<FilesWorkbenchContributionContext> =
   {
     id: "workspace-files",
-    order: 10,
+    order: -5,
     create(context) {
       const filesLabel = context.i18n.t(
         workspaceWorkbenchDesktopI18nKeys.nodes.files

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchContributionRegistry.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchContributionRegistry.test.ts
@@ -25,7 +25,7 @@ test("Tutti workbench product profile keeps its product, scope, factory ids, and
     {
       exportName: "filesWorkbenchContributionFactory",
       id: "workspace-files",
-      order: 10
+      order: -5
     },
     {
       exportName: "filePreviewWorkbenchContributionFactory",
@@ -45,7 +45,7 @@ test("Tutti workbench product profile keeps its product, scope, factory ids, and
     {
       exportName: "agentGuiWorkbenchContributionFactory",
       id: "workspace-agent-gui",
-      order: 25
+      order: -10
     },
     {
       exportName: "issueManagerWorkbenchContributionFactory",
@@ -95,12 +95,12 @@ test("Tutti workbench product profile keeps its product, scope, factory ids, and
   assert.deepEqual(
     registry.contributions.map(({ id }) => id),
     [
-      "workspace-issue-manager",
+      "workspace-agent-gui",
       "workspace-files",
+      "workspace-issue-manager",
       "workspace-file-preview",
       "workspace-app-center",
       "workspace-browser",
-      "workspace-agent-gui",
       "workspace-terminal"
     ]
   );


### PR DESCRIPTION
## Summary
- Move the `workspace-agent-gui` and `workspace-files` workbench contributions earlier in sidebar order (agent-gui: 25 → -10, files: 10 → -5) so they render before `workspace-issue-manager`.
- Update the registry test to match the new contribution ordering.

## Test plan
- [x] Updated `workspaceWorkbenchContributionRegistry.test.ts` assertions for the new order values and resulting contribution sequence.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->