### PR TITLE
refactor(builtin-apps): remove legacy catalog wrappers

### DIFF
--- a/services/tuttid/builtin-apps/catalog.go
+++ b/services/tuttid/builtin-apps/catalog.go
@@ -83,10 +83,6 @@ func Catalog() ([]App, error) {
 	return CatalogForHost(CatalogHost{})
 }
 
-func CatalogForTuttiVersion(tuttiVersion string) ([]App, error) {
-	return CatalogForHost(CatalogHost{TuttiVersion: tuttiVersion})
-}
-
 func CatalogForHost(host CatalogHost) ([]App, error) {
 	snapshot, err := snapshot(false, host)
 	if err != nil {
@@ -99,44 +95,16 @@ func Snapshot() (CatalogSnapshot, error) {
 	return SnapshotForHost(CatalogHost{})
 }
 
-func SnapshotForTuttiVersion(tuttiVersion string) (CatalogSnapshot, error) {
-	return SnapshotForHost(CatalogHost{TuttiVersion: tuttiVersion})
-}
-
 func SnapshotForHost(host CatalogHost) (CatalogSnapshot, error) {
 	return snapshot(false, host)
-}
-
-func SnapshotForRemoteURL(catalogURL string) (CatalogSnapshot, error) {
-	return SnapshotForRemoteURLAndHost(catalogURL, CatalogHost{})
-}
-
-func SnapshotForRemoteURLAndTuttiVersion(catalogURL string, tuttiVersion string) (CatalogSnapshot, error) {
-	return SnapshotForRemoteURLAndHost(catalogURL, CatalogHost{TuttiVersion: tuttiVersion})
 }
 
 func SnapshotForRemoteURLAndHost(catalogURL string, host CatalogHost) (CatalogSnapshot, error) {
 	return snapshotWithSource(remoteCatalogSourceForURL(catalogURL, host), false)
 }
 
-func RefreshRemoteCatalogAndWait(ctx context.Context) (CatalogSnapshot, error) {
-	return RefreshRemoteCatalogAndWaitForHost(ctx, CatalogHost{})
-}
-
-func RefreshRemoteCatalogAndWaitForTuttiVersion(ctx context.Context, tuttiVersion string) (CatalogSnapshot, error) {
-	return RefreshRemoteCatalogAndWaitForHost(ctx, CatalogHost{TuttiVersion: tuttiVersion})
-}
-
 func RefreshRemoteCatalogAndWaitForHost(ctx context.Context, host CatalogHost) (CatalogSnapshot, error) {
 	return snapshotAndWaitWithSource(ctx, currentRemoteCatalogSource(host))
-}
-
-func RefreshRemoteCatalogAndWaitForRemoteURL(ctx context.Context, catalogURL string) (CatalogSnapshot, error) {
-	return RefreshRemoteCatalogAndWaitForRemoteURLAndHost(ctx, catalogURL, CatalogHost{})
-}
-
-func RefreshRemoteCatalogAndWaitForRemoteURLAndTuttiVersion(ctx context.Context, catalogURL string, tuttiVersion string) (CatalogSnapshot, error) {
-	return RefreshRemoteCatalogAndWaitForRemoteURLAndHost(ctx, catalogURL, CatalogHost{TuttiVersion: tuttiVersion})
 }
 
 func RefreshRemoteCatalogAndWaitForRemoteURLAndHost(ctx context.Context, catalogURL string, host CatalogHost) (CatalogSnapshot, error) {

--- a/services/tuttid/builtin-apps/catalog_test.go
+++ b/services/tuttid/builtin-apps/catalog_test.go
@@ -229,7 +229,7 @@ func TestRefreshRemoteCatalogAndWaitReturnsReadyCatalog(t *testing.T) {
 		err      error
 	}, 1)
 	go func() {
-		snapshot, err := RefreshRemoteCatalogAndWait(context.Background())
+		snapshot, err := RefreshRemoteCatalogAndWaitForHost(context.Background(), CatalogHost{})
 		resultCh <- struct {
 			snapshot CatalogSnapshot
 			err      error
@@ -238,14 +238,14 @@ func TestRefreshRemoteCatalogAndWaitReturnsReadyCatalog(t *testing.T) {
 
 	select {
 	case result := <-resultCh:
-		t.Fatalf("RefreshRemoteCatalogAndWait() returned before response: %#v", result)
+		t.Fatalf("RefreshRemoteCatalogAndWaitForHost() returned before response: %#v", result)
 	case <-time.After(50 * time.Millisecond):
 	}
 	release()
 	select {
 	case result := <-resultCh:
 		if result.err != nil {
-			t.Fatalf("RefreshRemoteCatalogAndWait() error = %v", result.err)
+			t.Fatalf("RefreshRemoteCatalogAndWaitForHost() error = %v", result.err)
 		}
 		if result.snapshot.RemoteCatalog.Status != RemoteCatalogLoadStatusReady {
 			t.Fatalf("remote catalog status = %q, want ready", result.snapshot.RemoteCatalog.Status)
@@ -254,7 +254,7 @@ func TestRefreshRemoteCatalogAndWaitReturnsReadyCatalog(t *testing.T) {
 			t.Fatalf("remote app missing from waited snapshot: %#v", result.snapshot.Apps)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("RefreshRemoteCatalogAndWait() did not return after response")
+		t.Fatal("RefreshRemoteCatalogAndWaitForHost() did not return after response")
 	}
 }
 
@@ -267,9 +267,9 @@ func TestRefreshRemoteCatalogAndWaitReturnsFailedCatalog(t *testing.T) {
 	t.Cleanup(server.Close)
 	t.Setenv(remoteCatalogURLEnv, server.URL+"/catalog.json")
 
-	snapshot, err := RefreshRemoteCatalogAndWait(context.Background())
+	snapshot, err := RefreshRemoteCatalogAndWaitForHost(context.Background(), CatalogHost{})
 	if err != nil {
-		t.Fatalf("RefreshRemoteCatalogAndWait() error = %v", err)
+		t.Fatalf("RefreshRemoteCatalogAndWaitForHost() error = %v", err)
 	}
 	if snapshot.RemoteCatalog.Status != RemoteCatalogLoadStatusFailed {
 		t.Fatalf("remote catalog status = %q, want failed", snapshot.RemoteCatalog.Status)


### PR DESCRIPTION
## Summary

- remove eight legacy catalog convenience wrappers with no in-repository production callers
- migrate two tests to the retained Host-aware refresh API

## Impact scope

- Changes `services/tuttid/builtin-apps` catalog API surface only
- Daemon production callers retain the five Host-aware APIs; runtime behavior is unchanged

## Risk assessment

**Risk: low to medium.** The removed Go exports could have out-of-repository direct callers. In-repository scans found no production callers, Host-aware APIs remain, and the daemon module has no independent published module contract. Rollback is a single revert.

## Validation

- `go test ./builtin-apps` passed
- `pnpm lint:go`, `pnpm check:changed`, and `go build ./...` passed
- push-ready passed
- diff check passed

## Documentation impact

No documentation impact; no runtime contract or supported override changed.