### PR TITLE
feat(agent-gui): warn on restored Codex full access

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -178,6 +178,8 @@ Host owns recovery for runtime operations, Goal operations, and the reconcile in
 
 On daemon restart, Host recovery first restores durable operations, then settles unrecoverable active Turns as `settled/interrupted` and supersedes pending Interactions.
 
+Codex's restored Full access warning is presentation-only, device-local safety chrome. Show it only when an empty home composer restores an unacknowledged Full access target default; do not show it for another provider or permission mode, an active or historical Session, preview chrome, or while defaults are loading. Explicit Full access confirmation and “Don't show again” persist the same browser-local acknowledgement, while the close action affects only the current mount. This acknowledgement must not enter Session lifecycle, target defaults, Workbench node data, or `AgentActivityRuntime` state.
+
 ### 3.5 Messages and ordering
 
 A durable message has two independent ordering values:

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -1,9 +1,13 @@
 import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { useState } from "react";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentPermissionModeDropdown } from "./AgentComposerSettingsMenus";
 import type { AgentGUIComposerSettingsVM } from "./model/agentGuiNodeTypes";
+import {
+  CODEX_FULL_ACCESS_WARNING_ACKNOWLEDGEMENT_STORAGE_KEY,
+  isCodexFullAccessWarningAcknowledged
+} from "./view/agentFullAccessWarningPreference";
 
 beforeAll(() => {
   Object.defineProperties(HTMLElement.prototype, {
@@ -11,6 +15,10 @@ beforeAll(() => {
     releasePointerCapture: { configurable: true, value: () => undefined },
     setPointerCapture: { configurable: true, value: () => undefined }
   });
+});
+
+beforeEach(() => {
+  globalThis.localStorage.clear();
 });
 
 describe("AgentPermissionModeDropdown", () => {
@@ -82,6 +90,12 @@ describe("AgentPermissionModeDropdown", () => {
       permissionModeId: "full-access",
       planMode: false
     });
+    expect(isCodexFullAccessWarningAcknowledged()).toBe(true);
+    expect(
+      globalThis.localStorage.getItem(
+        CODEX_FULL_ACCESS_WARNING_ACKNOWLEDGEMENT_STORAGE_KEY
+      )
+    ).toBe("1");
   });
 
   it("keeps full access selected after confirmation", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.tsx
@@ -42,6 +42,7 @@ import {
   permissionModeSelectionPatch
 } from "./model/composerModeSelection";
 import { requiresFullAccessSafetyConfirmation } from "./model/agentPermissionModeSafetyPolicy";
+import { acknowledgeCodexFullAccessWarning } from "./view/agentFullAccessWarningPreference";
 import {
   buildComposerModelMenuModel,
   type AgentComposerSettingsMenuLabels,
@@ -256,6 +257,7 @@ export function AgentPermissionModeDropdown({
           }
           const permissionModeId = pendingFullAccessModeId;
           setPendingFullAccessModeId(null);
+          acknowledgeCodexFullAccessWarning();
           commitPermissionModeId(permissionModeId);
         }}
         onLinkAction={onLinkAction}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFullAccessRestoredWarning.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFullAccessRestoredWarning.spec.tsx
@@ -1,0 +1,111 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { AgentFullAccessRestoredWarning } from "./AgentFullAccessRestoredWarning";
+import { CODEX_FULL_ACCESS_WARNING_ACKNOWLEDGEMENT_STORAGE_KEY } from "./view/agentFullAccessWarningPreference";
+
+describe("AgentFullAccessRestoredWarning", () => {
+  beforeEach(() => {
+    globalThis.localStorage.clear();
+  });
+
+  it("warns for an unacknowledged Codex full-access home default", () => {
+    renderWarning();
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Full access is on");
+  });
+
+  it("does not warn for another permission mode or provider", () => {
+    const { rerender } = renderWarning({ permissionModeId: "auto" });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    rerender(
+      <AgentFullAccessRestoredWarning
+        isSettingsLoading={false}
+        permissionModeId="full-access"
+        previewMode={false}
+        provider="opencode"
+        visibleOnHome
+      />
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("does not warn in history, previews, or while defaults are loading", () => {
+    const { rerender } = renderWarning({ visibleOnHome: false });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    rerender(
+      <AgentFullAccessRestoredWarning
+        isSettingsLoading={false}
+        permissionModeId="full-access"
+        previewMode
+        provider="codex"
+        visibleOnHome
+      />
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    rerender(
+      <AgentFullAccessRestoredWarning
+        isSettingsLoading
+        permissionModeId="full-access"
+        previewMode={false}
+        provider="codex"
+        visibleOnHome
+      />
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("persists Don't show again across mounts", () => {
+    const first = renderWarning();
+    fireEvent.click(screen.getByRole("button", { name: "Don't show again" }));
+
+    expect(
+      globalThis.localStorage.getItem(
+        CODEX_FULL_ACCESS_WARNING_ACKNOWLEDGEMENT_STORAGE_KEY
+      )
+    ).toBe("1");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    first.unmount();
+    renderWarning();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("dismisses the warning only for the current mount", () => {
+    const first = renderWarning();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Dismiss full access warning" })
+    );
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(
+      globalThis.localStorage.getItem(
+        CODEX_FULL_ACCESS_WARNING_ACKNOWLEDGEMENT_STORAGE_KEY
+      )
+    ).toBeNull();
+
+    first.unmount();
+    renderWarning();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+});
+
+function renderWarning(
+  overrides: Partial<
+    React.ComponentProps<typeof AgentFullAccessRestoredWarning>
+  > = {}
+) {
+  return render(
+    <AgentFullAccessRestoredWarning
+      isSettingsLoading={false}
+      permissionModeId="full-access"
+      previewMode={false}
+      provider="codex"
+      visibleOnHome
+      {...overrides}
+    />
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFullAccessRestoredWarning.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFullAccessRestoredWarning.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { ShieldAlert, X } from "lucide-react";
+import { useTranslation } from "../../i18n/index";
+import { cn } from "../../app/renderer/lib/utils";
+import { requiresFullAccessSafetyConfirmation } from "./model/agentPermissionModeSafetyPolicy";
+import {
+  acknowledgeCodexFullAccessWarning,
+  isCodexFullAccessWarningAcknowledged
+} from "./view/agentFullAccessWarningPreference";
+
+export function AgentFullAccessRestoredWarning({
+  isSettingsLoading,
+  permissionModeId,
+  previewMode,
+  provider,
+  visibleOnHome
+}: {
+  isSettingsLoading: boolean;
+  permissionModeId: string | null | undefined;
+  previewMode: boolean;
+  provider: string;
+  visibleOnHome: boolean;
+}): React.JSX.Element | null {
+  const { t } = useTranslation();
+  const [dismissedForCurrentOpen, setDismissedForCurrentOpen] = useState(false);
+  const acknowledged = isCodexFullAccessWarningAcknowledged();
+  const normalizedPermissionModeId = permissionModeId?.trim() ?? "";
+  const shouldShow =
+    visibleOnHome &&
+    !previewMode &&
+    !isSettingsLoading &&
+    !dismissedForCurrentOpen &&
+    !acknowledged &&
+    requiresFullAccessSafetyConfirmation(provider, normalizedPermissionModeId);
+
+  if (!shouldShow) {
+    return null;
+  }
+
+  return (
+    <section
+      className={cn(
+        "nodrag tsh-desktop-no-drag mb-2 flex flex-wrap items-center gap-3 rounded-[16px] px-4 py-3",
+        "bg-[color-mix(in_srgb,var(--state-danger)_9%,var(--background-panel))]",
+        "text-[var(--state-danger)] [-webkit-app-region:no-drag]"
+      )}
+      data-testid="agent-gui-restored-full-access-warning"
+      role="alert"
+    >
+      <ShieldAlert aria-hidden="true" className="size-5 shrink-0" />
+      <div className="min-w-[220px] flex-1">
+        <p className="m-0 font-semibold leading-[1.35]">
+          {t("agentHost.agentGui.fullAccessRestoredWarning.title")}
+        </p>
+        <p className="m-0 mt-0.5 text-[13px] leading-[1.45]">
+          {t("agentHost.agentGui.fullAccessRestoredWarning.description")}
+        </p>
+      </div>
+      <button
+        className={cn(
+          "ml-auto shrink-0 rounded-full px-4 py-2 text-[13px] font-medium",
+          "bg-[color-mix(in_srgb,var(--state-danger)_10%,transparent)]",
+          "transition-colors hover:bg-[color-mix(in_srgb,var(--state-danger)_16%,transparent)]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--state-danger)]"
+        )}
+        type="button"
+        onClick={() => {
+          acknowledgeCodexFullAccessWarning();
+          setDismissedForCurrentOpen(true);
+        }}
+      >
+        {t("agentHost.agentGui.fullAccessRestoredWarning.dontShowAgain")}
+      </button>
+      <button
+        aria-label={t(
+          "agentHost.agentGui.fullAccessRestoredWarning.dismissLabel"
+        )}
+        className={cn(
+          "flex size-8 shrink-0 items-center justify-center rounded-full",
+          "text-[var(--text-secondary)] transition-colors",
+          "hover:bg-[var(--transparency-subtle)] hover:text-[var(--text-primary)]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--state-danger)]"
+        )}
+        type="button"
+        onClick={() => setDismissedForCurrentOpen(true)}
+      >
+        <X aria-hidden="true" className="size-4" />
+      </button>
+    </section>
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
@@ -22,6 +22,7 @@ import {
   AgentProjectMissingStatusProbe
 } from "../AgentComposerSettingsMenus";
 import { AgentChromeNotice } from "../AgentSessionChrome";
+import { AgentFullAccessRestoredWarning } from "../AgentFullAccessRestoredWarning";
 import {
   AgentRichTextEditor,
   type AgentRichTextEditorHandle
@@ -297,6 +298,16 @@ export function AgentComposerView(input: Props): React.JSX.Element {
           onProjectMissingChange={input.setIsSelectedProjectMissing}
         />
       ) : null}
+      <AgentFullAccessRestoredWarning
+        isSettingsLoading={composerSettings.isSettingsLoading}
+        permissionModeId={
+          composerSettings.selectedPermissionModeValue ??
+          composerSettings.draftSettings.permissionModeId
+        }
+        previewMode={previewMode}
+        provider={provider}
+        visibleOnHome={isHeroLayout}
+      />
       <div
         className={cn(
           styles.composerInputGroup,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentFullAccessWarningPreference.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentFullAccessWarningPreference.ts
@@ -1,0 +1,17 @@
+export const CODEX_FULL_ACCESS_WARNING_ACKNOWLEDGEMENT_STORAGE_KEY =
+  "tutti.agentGui.codexFullAccessWarningAcknowledged.v1";
+
+export function isCodexFullAccessWarningAcknowledged(): boolean {
+  return (
+    globalThis.localStorage?.getItem(
+      CODEX_FULL_ACCESS_WARNING_ACKNOWLEDGEMENT_STORAGE_KEY
+    ) === "1"
+  );
+}
+
+export function acknowledgeCodexFullAccessWarning(): void {
+  globalThis.localStorage?.setItem(
+    CODEX_FULL_ACCESS_WARNING_ACKNOWLEDGEMENT_STORAGE_KEY,
+    "1"
+  );
+}

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -114,6 +114,13 @@ export const enAgentGui = {
     cancel: "Cancel",
     confirm: "Enable full access"
   },
+  fullAccessRestoredWarning: {
+    title: "Full access is on",
+    description:
+      "Codex can run commands, use the internet, and create, modify, upload, or delete files anywhere on this computer without asking. This can cause data loss and expose you to prompt-injection attacks.",
+    dontShowAgain: "Don't show again",
+    dismissLabel: "Dismiss full access warning"
+  },
   permissionSemantics: {
     "ask-before-write": {
       label: "Ask for approval",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -105,6 +105,13 @@ export const zhCNAgentGui = {
     cancel: "取消",
     confirm: "启用完全访问权限"
   },
+  fullAccessRestoredWarning: {
+    title: "完全访问权限已开启",
+    description:
+      "Codex 可以在未经你同意的情况下运行命令、使用互联网，以及在这台电脑的任意位置创建、修改、上传或删除文件。这可能导致数据丢失，也会带来提示词注入风险。",
+    dontShowAgain: "不再显示",
+    dismissLabel: "关闭完全访问权限警告"
+  },
   permissionSemantics: {
     "ask-before-write": {
       label: "请求批准",


### PR DESCRIPTION
## What changed

- show a Codex full-access safety banner only when an empty composer restores an unacknowledged full-access default
- persist acknowledgement from either explicit full-access confirmation or “Don’t show again”; keep the close-button dismissal limited to the current mount
- add localized English and Simplified Chinese copy, focused coverage, and an AgentGUI architecture note

## Why

A previously saved full-access default can be restored when Codex is reopened without passing through the explicit full-access confirmation dialog. The banner makes that restored state visible without warning users who chose another permission mode or already acknowledged the risk.

## Validation

- `pnpm --filter @tutti-os/agent-gui test`
- `pnpm check:changed --tail-lines 120`
- pre-push `pnpm check:changed -- --push-ready`
- `pnpm lint:ts`
- `pnpm typecheck`
- `pnpm check:i18n`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm --filter @tutti-os/desktop build`

Architecture review completed with no findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only safety messaging and localStorage acknowledgement; no changes to session, permissions persistence, or runtime state.
> 
> **Overview**
> Adds **presentation-only safety chrome** when an empty **home** Codex composer loads a saved **full-access** default without the user having gone through the enable dialog.
> 
> A new **`AgentFullAccessRestoredWarning`** banner sits above the composer (hero layout only). It appears when provider is Codex, permission mode needs full-access confirmation, settings are loaded, and the user has not acknowledged the risk. It is hidden for other providers/modes, previews, non-home layouts, and while defaults load.
> 
> **Acknowledgement** is stored in **browser `localStorage`** via `agentFullAccessWarningPreference`—the same flag is set when the user confirms full access in the permission dropdown or chooses **Don't show again** on the banner. The close (X) control hides the banner for the **current mount only** and does not persist.
> 
> Architecture docs state this acknowledgement must **not** enter session lifecycle, target defaults, Workbench node data, or `AgentActivityRuntime`. English and Simplified Chinese strings and component tests cover visibility rules and dismiss vs persist behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94bdd3d37ea90b5bd140d6dadae7870448560f74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->