### PR TITLE
fix(agent-gui): keep beta badge visible on provider tile

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -9442,7 +9442,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   width: 32px;
   height: 32px;
   place-items: center;
-  overflow: hidden;
+  overflow: visible;
   border: 2px solid transparent;
   border-radius: 8px;
   background: transparent;
@@ -9499,7 +9499,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 .agent-gui-node__provider-rail-avatar-image {
   width: 28px;
   height: 28px;
-  border-radius: 0;
+  border-radius: 6px;
   object-fit: contain;
 }
 


### PR DESCRIPTION
## Summary

- Stop the selected provider avatar from clipping the Beta wordmark that straddles its bottom border.
- Keep extension sidebar artwork clipped at the image layer with the existing 6px inner radius.

## Verification

- Not run: this is a UI-presentation-only CSS change, covered by the repository UI-only validation exception.

## Checklist

- [x] Agent lifecycle semantics are unchanged.
- [x] I kept the change focused on one concern.
- [x] Documentation impact checked; no durable documentation change is needed.
- [x] README/CONTRIBUTING language variants are unaffected.
- [x] The UI-only validation exception applies; no local checks were run.
- [x] The commit is signed off with DCO.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->