### PR TITLE
fix(agent): preserve extension target resume identity

### DIFF
--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1060,6 +1060,10 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   Dynamic Agent Extension adapters are created on demand and cached only for
   the daemon lifetime. Computing `resumable` from that cache maps restart state
   to a false domain result before Resume can re-resolve the persisted Target.
+  The same false result occurs when an adapter rebuilds the runtime resume input
+  but drops `agentTargetId`: the fixed Target ref then fails the controller's
+  complete binding check even though persistence and Target resolution are
+  correct.
 - Fix:
   At the service boundary, re-derive `ProviderTargetRef` from the persisted
   session's enabled `agentTargetId`. At the runtime boundary, validate the
@@ -1068,6 +1072,10 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   Keep installation validation and ACP `session/load` in the actual Resume
   path. Never use an open provider id or adapter-cache presence as launch
   authority.
+  Every bridge from the Host resume input to the runtime resume input must
+  preserve `agentTargetId` and `ProviderTargetRef` together. Cover the complete
+  service-to-adapter-to-controller path instead of testing each endpoint with
+  independently constructed valid inputs.
 - Validation:
   Start from a controller with no cached extension adapter. Assert a persisted
   Target-bound session is resumable, malformed or mismatched bindings fail
@@ -1075,6 +1083,7 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   `go test ./packages/agent/daemon/runtime ./services/tuttid/service/agent`.
 - References:
   [controller_session_registry.go](../../../packages/agent/daemon/runtime/controller_session_registry.go)
+  [agent_runtime_adapter.go](../../../services/tuttid/agent_runtime_adapter.go)
   [service_session.go](../../../services/tuttid/service/agent/service_session.go)
   [agent-extensions.md](../../architecture/agent-extensions.md)
 

--- a/services/tuttid/agent_runtime_adapter.go
+++ b/services/tuttid/agent_runtime_adapter.go
@@ -121,6 +121,7 @@ func (a agentRuntimeAdapter) CanResume(input agentservice.RuntimeResumeInput) bo
 	return a.controller.CanResume(agentruntime.ResumeInput{
 		RoomID:            input.WorkspaceID,
 		AgentSessionID:    input.AgentSessionID,
+		AgentTargetID:     input.AgentTargetID,
 		Provider:          input.Provider,
 		ProviderSessionID: input.ProviderSessionID,
 		CWD:               input.Cwd,

--- a/services/tuttid/agent_runtime_adapter_test.go
+++ b/services/tuttid/agent_runtime_adapter_test.go
@@ -10,6 +10,12 @@ import (
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 )
 
+type unavailableAgentExtensionResumeResolver struct{}
+
+func (unavailableAgentExtensionResumeResolver) ResolveAdapter(context.Context, agentruntime.AdapterResolveInput) (agentruntime.Adapter, error) {
+	return nil, errors.New("adapter resolution must not run during resume eligibility checks")
+}
+
 func TestMapAgentRuntimeErrorPreservesInteractiveRecoveryCodes(t *testing.T) {
 	tests := []struct {
 		runtimeErr error
@@ -23,6 +29,27 @@ func TestMapAgentRuntimeErrorPreservesInteractiveRecoveryCodes(t *testing.T) {
 		if err := mapAgentRuntimeError(test.runtimeErr); !errors.Is(err, test.serviceErr) {
 			t.Fatalf("mapAgentRuntimeError(%v) = %v, want %v", test.runtimeErr, err, test.serviceErr)
 		}
+	}
+}
+
+func TestAgentRuntimeAdapterCanResumePreservesExtensionTargetBinding(t *testing.T) {
+	controller := agentruntime.NewControllerWithAdapterResolver(nil, nil, unavailableAgentExtensionResumeResolver{})
+	adapter := newAgentRuntimeAdapter(controller)
+
+	if !adapter.CanResume(agentservice.RuntimeResumeInput{
+		WorkspaceID:       "workspace-1",
+		AgentSessionID:    "session-1",
+		AgentTargetID:     "extension:codebuddy",
+		Provider:          "acp:codebuddy",
+		ProviderSessionID: "provider-session-1",
+		ProviderTargetRef: map[string]any{
+			"kind":                    "agent_extension",
+			"provider":                "acp:codebuddy",
+			"targetId":                "extension:codebuddy",
+			"extensionInstallationId": "codebuddy@1.0.0",
+		},
+	}) {
+		t.Fatal("CanResume() = false, want authorized extension session to remain resumable across the tuttid runtime adapter")
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve `agentTargetId` when the tuttid runtime adapter projects Host resume eligibility input into the daemon runtime
- keep fixed Target plus extension installation binding authoritative after daemon restart
- add a bridge-level regression test covering the service-to-adapter-to-controller gap
- extend Agent session troubleshooting guidance for dropped Target identity fields

Root cause: `agentRuntimeAdapter.CanResume` forwarded `ProviderTargetRef` but dropped `AgentTargetID`. The runtime correctly rejected the incomplete Extension binding, so every persisted `acp:*` session appeared non-resumable before the real Resume path could run.

## Verification

- `go test . -run ^'TestAgentRuntimeAdapterCanResumePreservesExtensionTargetBinding$' -count=1`
- `go test ./packages/agent/daemon/runtime -run ^'TestControllerCanResumeAuthorizedAgentExtensionBinding$' -count=1`
- `go test ./service/agent -run ^'TestServiceListRebuildsExtensionTargetRefForPersistedSessionResume$' -count=1`
- `cd services/tuttid && go test ./...`
- `cd services/tuttid && go build ./...`
- `pnpm lint:go`
- `pnpm check:agent-host-boundary`
- `pnpm check:changed -- --push-ready`

## Checklist

- [x] No agent lifecycle semantics changed; this adapter preserves the existing Host/runtime Target identity contract.
- [x] I kept the change focused on one concern.
- [x] I updated durable troubleshooting documentation.
- [x] README and CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->