### PR TITLE
fix(mentions): render and deliver a single usable icon

### DIFF
--- a/apps/desktop/src/main/host/tuttiAssetProtocol.test.ts
+++ b/apps/desktop/src/main/host/tuttiAssetProtocol.test.ts
@@ -84,6 +84,38 @@ test("tutti asset protocol resolves packaged codex rounded asset", () => {
   }
 });
 
+for (const [agent, builtFileName] of [
+  ["cursor", "cursor-colorful-abc123.png"],
+  ["hermes", "hermes-rounded-abc123.png"],
+  ["openclaw", "openclaw-rounded-abc123.png"],
+  ["opencode", "opencode-rounded-abc123.png"]
+] as const) {
+  test(`tutti asset protocol resolves packaged ${agent} asset`, () => {
+    const appPath = mkdtempSync(join(tmpdir(), `tutti-asset-${agent}-`));
+    const builtAssetPath = join(
+      appPath,
+      "out",
+      "renderer",
+      "assets",
+      builtFileName
+    );
+    mkdirSync(dirname(builtAssetPath), { recursive: true });
+    writeFileSync(builtAssetPath, "");
+
+    try {
+      assert.equal(
+        resolveTuttiAssetProtocolFilePath(
+          `tutti-asset://agent/${agent}.png`,
+          appPath
+        ),
+        builtAssetPath
+      );
+    } finally {
+      rmSync(appPath, { force: true, recursive: true });
+    }
+  });
+}
+
 test("tutti asset protocol resolves issue default asset route", () => {
   const appPath = mkdtempSync(join(tmpdir(), "tutti-asset-issue-"));
   const sourcePath = join(

--- a/apps/desktop/src/main/host/tuttiAssetProtocolResolver.ts
+++ b/apps/desktop/src/main/host/tuttiAssetProtocolResolver.ts
@@ -13,6 +13,26 @@ const tuttiAssetRoutes = {
     sourceRelativePath:
       "src/renderer/src/assets/workspace-canvas/dock/default/codex.png"
   },
+  "agent/cursor.png": {
+    builtFilePrefixes: ["cursor-colorful-", "cursor-rounded-", "cursor-"],
+    sourceRelativePath:
+      "src/renderer/src/assets/workspace-canvas/dock/default/cursor.png"
+  },
+  "agent/hermes.png": {
+    builtFilePrefixes: ["hermes-rounded-", "hermes-"],
+    sourceRelativePath:
+      "src/renderer/src/assets/workspace-canvas/dock/default/hermes.png"
+  },
+  "agent/openclaw.png": {
+    builtFilePrefixes: ["openclaw-rounded-", "openclaw-"],
+    sourceRelativePath:
+      "src/renderer/src/assets/workspace-canvas/dock/default/openclaw.png"
+  },
+  "agent/opencode.png": {
+    builtFilePrefixes: ["opencode-rounded-", "opencode-"],
+    sourceRelativePath:
+      "src/renderer/src/assets/workspace-canvas/dock/default/opencode.png"
+  },
   "agent/tutti.png": {
     builtFilePrefixes: ["tutti-"],
     sourceRelativePath:

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAppExternalAtSerialization.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAppExternalAtSerialization.test.ts
@@ -238,6 +238,79 @@ test("serializes mention item id from insert identity for external restore", () 
   });
 });
 
+test("replaces managed Agent file icons with guest-loadable asset urls", () => {
+  const match: RichTextTriggerQueryMatch = {
+    providerId: "agent-target",
+    trigger: "@",
+    key: "local:cursor",
+    label: "Cursor",
+    iconUrl: "file:///Applications/Tutti.app/cursor-colorful-abc123.png",
+    item: {},
+    insertResult: {
+      kind: "mention",
+      mention: {
+        entityId: "local:cursor",
+        label: "Cursor",
+        presentation: {
+          agentProviderId: "cursor",
+          iconUrl: "file:///Applications/Tutti.app/cursor-colorful-abc123.png"
+        }
+      }
+    }
+  };
+
+  assert.deepEqual(serializeWorkspaceAppExternalAtMatch(match), {
+    providerId: "agent-target",
+    itemId: "local:cursor",
+    label: "Cursor",
+    thumbnailUrl: "tutti-asset://agent/cursor.png",
+    insert: {
+      kind: "mention",
+      mention: {
+        entityId: "local:cursor",
+        label: "Cursor",
+        presentation: {
+          agentProviderId: "cursor",
+          iconUrl: "tutti-asset://agent/cursor.png",
+          thumbnailUrl: "tutti-asset://agent/cursor.png"
+        }
+      }
+    }
+  });
+});
+
+test("preserves remote and data Agent icons for external apps", () => {
+  for (const iconUrl of [
+    "https://cdn.example.com/gemini.png",
+    "data:image/svg+xml;base64,gemini"
+  ]) {
+    const match: RichTextTriggerQueryMatch = {
+      providerId: "agent-target",
+      trigger: "@",
+      key: "extension:gemini",
+      label: "Gemini",
+      iconUrl,
+      item: {},
+      insertResult: {
+        kind: "mention",
+        mention: {
+          entityId: "extension:gemini",
+          label: "Gemini",
+          presentation: {
+            agentProviderId: "acp:gemini",
+            iconUrl
+          }
+        }
+      }
+    };
+
+    assert.equal(
+      serializeWorkspaceAppExternalAtMatch(match)?.thumbnailUrl,
+      iconUrl
+    );
+  }
+});
+
 function createMatch(
   input: Partial<RichTextTriggerQueryMatch> = {}
 ): RichTextTriggerQueryMatch {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAppExternalAtSerialization.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAppExternalAtSerialization.ts
@@ -8,6 +8,8 @@ import type {
   RichTextTriggerInsertResult,
   RichTextTriggerQueryMatch
 } from "@tutti-os/ui-rich-text/types";
+import { resolveAgentGUIProviderCatalogIdentity } from "@tutti-os/agent-gui/provider-catalog";
+import { tuttiAgentAssetUrlsByIconKey } from "../../../../../../shared/tuttiAssetProtocol.ts";
 
 export function serializeWorkspaceAppExternalAtMatch(
   match: RichTextTriggerQueryMatch
@@ -54,12 +56,16 @@ export function serializeWorkspaceAppExternalAtMatch(
     return null;
   }
   const itemId = resolveWorkspaceAppExternalAtItemId(match, insert);
+  const thumbnailUrl = serializeWorkspaceAppExternalAtIconUrl(
+    match.iconUrl,
+    match.insertResult
+  );
   return {
     providerId: match.providerId,
     itemId,
     label: match.label,
     ...(match.subtitle ? { subtitle: match.subtitle } : {}),
-    ...(match.iconUrl ? { thumbnailUrl: match.iconUrl } : {}),
+    ...(thumbnailUrl ? { thumbnailUrl } : {}),
     insert
   };
 }
@@ -82,10 +88,44 @@ function serializeWorkspaceAppExternalAtPresentation(
     >["mention"]["presentation"]
   >
 ): TuttiExternalAtMentionPresentation {
-  const iconUrl = presentation.iconUrl?.trim() ?? "";
-  const thumbnailUrl = presentation.thumbnailUrl?.trim() || iconUrl;
+  const iconUrl = serializeWorkspaceAppExternalAtPresentationIconUrl(
+    presentation.iconUrl,
+    presentation.agentProviderId
+  );
+  const thumbnailUrl = serializeWorkspaceAppExternalAtPresentationIconUrl(
+    presentation.thumbnailUrl?.trim() || iconUrl,
+    presentation.agentProviderId
+  );
   return {
     ...presentation,
+    ...(iconUrl ? { iconUrl } : {}),
     ...(thumbnailUrl ? { thumbnailUrl } : {})
   };
+}
+
+function serializeWorkspaceAppExternalAtIconUrl(
+  iconUrl: string | null | undefined,
+  insertResult: RichTextTriggerInsertResult
+): string {
+  const agentProviderId =
+    insertResult.kind === "mention"
+      ? insertResult.mention.presentation?.agentProviderId
+      : undefined;
+  return serializeWorkspaceAppExternalAtPresentationIconUrl(
+    iconUrl,
+    agentProviderId
+  );
+}
+
+function serializeWorkspaceAppExternalAtPresentationIconUrl(
+  iconUrl: string | null | undefined,
+  agentProviderId: string | null | undefined
+): string {
+  const normalizedIconUrl = iconUrl?.trim() ?? "";
+  if (!normalizedIconUrl.startsWith("file:")) {
+    return normalizedIconUrl;
+  }
+  const iconKey =
+    resolveAgentGUIProviderCatalogIdentity(agentProviderId)?.iconKey ?? "";
+  return tuttiAgentAssetUrlsByIconKey[iconKey] ?? normalizedIconUrl;
 }

--- a/apps/desktop/src/shared/tuttiAssetProtocol.ts
+++ b/apps/desktop/src/shared/tuttiAssetProtocol.ts
@@ -3,8 +3,22 @@ export const tuttiAssetProtocolScheme = "tutti-asset";
 export const tuttiAgentAssetUrls = {
   claudeCode: `${tuttiAssetProtocolScheme}://agent/claudecode.png`,
   codex: `${tuttiAssetProtocolScheme}://agent/codex.png`,
+  cursor: `${tuttiAssetProtocolScheme}://agent/cursor.png`,
+  hermes: `${tuttiAssetProtocolScheme}://agent/hermes.png`,
+  openclaw: `${tuttiAssetProtocolScheme}://agent/openclaw.png`,
+  opencode: `${tuttiAssetProtocolScheme}://agent/opencode.png`,
   tuttiAgent: `${tuttiAssetProtocolScheme}://agent/tutti.png`
 } as const;
+
+export const tuttiAgentAssetUrlsByIconKey: Readonly<Record<string, string>> = {
+  "claude-code": tuttiAgentAssetUrls.claudeCode,
+  codex: tuttiAgentAssetUrls.codex,
+  cursor: tuttiAgentAssetUrls.cursor,
+  hermes: tuttiAgentAssetUrls.hermes,
+  openclaw: tuttiAgentAssetUrls.openclaw,
+  opencode: tuttiAgentAssetUrls.opencode,
+  tutti: tuttiAgentAssetUrls.tuttiAgent
+};
 
 export const tuttiIssueAssetUrls = {
   default: `${tuttiAssetProtocolScheme}://issue/default.png`

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
@@ -280,7 +280,12 @@ describe("AgentQueuedPromptPanel", () => {
     expect(image).toHaveAttribute("src", iconUrl);
     expect(
       mention?.querySelector('[data-agent-mention-fallback-icon="true"]')
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
+    expect(
+      mention?.querySelectorAll(
+        '[data-agent-mention-app-icon="true"] img, [data-agent-mention-app-icon="true"] svg'
+      )
+    ).toHaveLength(1);
 
     fireEvent.error(image!);
 
@@ -290,6 +295,11 @@ describe("AgentQueuedPromptPanel", () => {
     expect(
       mention?.querySelector('[data-agent-mention-fallback-icon="true"]')
     ).toBeInTheDocument();
+    expect(
+      mention?.querySelectorAll(
+        '[data-agent-mention-app-icon="true"] img, [data-agent-mention-app-icon="true"] svg'
+      )
+    ).toHaveLength(1);
     expect(mention).toHaveTextContent("AI Media Canvas");
     expect(screen.queryByText(/mention:\/\/workspace-app/)).toBeNull();
   });

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -19,7 +19,7 @@ import {
 import { RichTextMentionReadonly } from "@tutti-os/ui-rich-text/editor";
 
 describe("RichTextMentionReadonly compatibility", () => {
-  it("keeps the persisted @ prefix while using MentionPill", () => {
+  it("uses the resolved label without adding the persisted trigger", () => {
     render(
       <RichTextMentionReadonly
         mention={{
@@ -31,7 +31,8 @@ describe("RichTextMentionReadonly compatibility", () => {
       />
     );
 
-    expect(screen.getByText("@Canvas")).toBeInTheDocument();
+    expect(screen.getByText("Canvas")).toBeInTheDocument();
+    expect(screen.queryByText("@Canvas")).not.toBeInTheDocument();
     expect(document.querySelector('[data-slot="mention-pill"]')).not.toBeNull();
   });
 });
@@ -1355,7 +1356,12 @@ describe("AgentMessageMarkdown", () => {
     expect(image).toHaveAttribute("src", iconUrl);
     expect(
       mention?.querySelector('[data-agent-mention-fallback-icon="true"]')
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
+    expect(
+      mention?.querySelectorAll(
+        '[data-agent-mention-app-icon="true"] img, [data-agent-mention-app-icon="true"] svg'
+      )
+    ).toHaveLength(1);
 
     fireEvent.error(image!);
 
@@ -1365,6 +1371,11 @@ describe("AgentMessageMarkdown", () => {
     expect(
       mention?.querySelector('[data-agent-mention-fallback-icon="true"]')
     ).toBeInTheDocument();
+    expect(
+      mention?.querySelectorAll(
+        '[data-agent-mention-app-icon="true"] img, [data-agent-mention-app-icon="true"] svg'
+      )
+    ).toHaveLength(1);
     expect(mention).toHaveTextContent("Weather");
   });
 

--- a/packages/ui/rich-text/src/editor/RichTextMentionReadonly.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextMentionReadonly.tsx
@@ -1,9 +1,6 @@
 import type { CSSProperties, JSX, MouseEvent, ReactNode } from "react";
 import { MentionPill } from "@tutti-os/ui-system/components";
-import {
-  getRichTextMentionDisplayText,
-  resolveRichTextMentionView
-} from "../plugins/mention.ts";
+import { resolveRichTextMentionView } from "../plugins/mention.ts";
 import {
   resolveMentionPillIconUrl,
   resolveMentionPillKind
@@ -85,9 +82,7 @@ export function RichTextMentionReadonly<TResolved = unknown>({
     mention,
     resolved: view as RichTextResolvedMentionView<TResolved>
   };
-  const label =
-    renderLabel?.(payload) ??
-    getRichTextMentionDisplayText({ ...mention, label: view.label });
+  const label = renderLabel?.(payload) ?? view.label;
   const content = (
     <MentionPill
       className="top-0"

--- a/packages/ui/system/src/components/mention-pill/mention-pill.spec.tsx
+++ b/packages/ui/system/src/components/mention-pill/mention-pill.spec.tsx
@@ -40,9 +40,11 @@ describe("MentionPill", () => {
     );
     const image = container.querySelector("img");
 
+    expect(image).toBeInTheDocument();
     expect(
       container.querySelector('[data-mention-pill-fallback-icon="true"]')
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
+    expect(container.querySelectorAll("img, svg")).toHaveLength(1);
 
     fireEvent.error(image!);
 
@@ -50,6 +52,7 @@ describe("MentionPill", () => {
     expect(
       container.querySelector('[data-mention-pill-fallback-icon="true"]')
     ).toBeInTheDocument();
+    expect(container.querySelectorAll("img, svg")).toHaveLength(1);
   });
 
   it("retries image loading when the resolved URL changes", () => {
@@ -75,9 +78,13 @@ describe("MentionPill", () => {
       "src",
       "https://example.test/new.png"
     );
+    expect(
+      container.querySelector('[data-mention-pill-fallback-icon="true"]')
+    ).not.toBeInTheDocument();
+    expect(container.querySelectorAll("img, svg")).toHaveLength(1);
   });
 
-  it("keeps the semantic icon underneath a transparent image", () => {
+  it("renders only the custom icon for a transparent image", () => {
     const transparentPixel =
       "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
     const { container } = render(
@@ -90,7 +97,8 @@ describe("MentionPill", () => {
     );
     expect(
       container.querySelector('[data-mention-pill-fallback-icon="true"]')
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
+    expect(container.querySelectorAll("img, svg")).toHaveLength(1);
   });
 
   it("uses a semantic icon when no image URL is available", () => {
@@ -100,5 +108,6 @@ describe("MentionPill", () => {
     expect(
       container.querySelector('[data-mention-pill-fallback-icon="true"]')
     ).toBeInTheDocument();
+    expect(container.querySelectorAll("img, svg")).toHaveLength(1);
   });
 });

--- a/packages/ui/system/src/components/mention-pill/mention-pill.tsx
+++ b/packages/ui/system/src/components/mention-pill/mention-pill.tsx
@@ -119,16 +119,6 @@ function MentionPill({
           iconContainerProps?.className
         )}
       >
-        <Icon
-          {...fallbackIconProps}
-          className={cn(
-            "col-start-1 row-start-1 text-current transition-opacity",
-            removable && "group-hover:opacity-0 group-focus-within:opacity-0",
-            iconSizeClassName,
-            fallbackIconProps?.className
-          )}
-          data-mention-pill-fallback-icon="true"
-        />
         {normalizedIconUrl && failedIconUrl !== normalizedIconUrl ? (
           <img
             src={normalizedIconUrl}
@@ -144,7 +134,18 @@ function MentionPill({
               setFailedIconUrl(normalizedIconUrl);
             }}
           />
-        ) : null}
+        ) : (
+          <Icon
+            {...fallbackIconProps}
+            className={cn(
+              "col-start-1 row-start-1 text-current transition-opacity",
+              removable && "group-hover:opacity-0 group-focus-within:opacity-0",
+              iconSizeClassName,
+              fallbackIconProps?.className
+            )}
+            data-mention-pill-fallback-icon="true"
+          />
+        )}
         {removable ? (
           <button
             aria-label={removeButtonProps?.["aria-label"]}


### PR DESCRIPTION
## Summary

- Make `MentionPill` render the custom image and semantic fallback icon as mutually exclusive DOM branches.
- Keep resolved mention labels unchanged in readonly rich text so app pills render without an extra `@` prefix.
- Replace bundled managed-Agent `file://` icon URLs with guest-loadable `tutti-asset://` URLs at the external workspace-app bridge.
- Add local asset routes for Cursor, Hermes, OpenClaw, and OpenCode while preserving remote and data URLs for extension Agents.

The double-icon root cause was that `MentionPill` mounted both the fallback SVG and app image. The broken Agent icon root cause was that the external JS bridge forwarded renderer-bundled `file://` URLs into an isolated HTTP workspace app, which cannot load host filesystem URLs. The bridge now returns a short, cacheable local asset URL without embedding multi-megabyte base64 images in every query result.

Affected surfaces: public `@tutti-os/ui-system` mention pills, readonly rich-text/AgentGUI mention rendering, and external workspace-app `@` Agent results. There are no Agent lifecycle or persisted-data changes.

## Verification

- `pnpm --filter @tutti-os/ui-system test -- mention-pill.spec.tsx` (10 tests across 4 files)
- `pnpm --filter @tutti-os/ui-rich-text test -- RichTextMentionReadonly` (107 tests)
- `pnpm --filter @tutti-os/agent-gui test -- AgentMessageMarkdown.spec.tsx AgentQueuedPromptPanel.spec.tsx` (217 files, 1898 tests)
- `pnpm --filter @tutti-os/desktop test -- tuttiAssetProtocol.test.ts workspaceAppExternalAtSerialization.test.ts` (1466 passed, 2 skipped)
- `pnpm --filter @tutti-os/desktop typecheck`
- pre-push `pnpm check:changed -- --push-ready` (19 lanes)
- `git diff --check`

Documentation impact: none. This restores existing UI/bridge contracts and extends an existing desktop-local asset route; it does not change ownership, setup, or public API shape.

## Checklist

- [x] Agent lifecycle conformance is not applicable; no lifecycle semantics changed.
- [x] I kept the change focused on Mention icon rendering and delivery.
- [x] I assessed documentation impact.
- [x] README/CONTRIBUTING translations are not applicable.
- [x] I ran the lowest meaningful checks for the changed surfaces.
- [x] All commits are signed off for DCO.
