### PR TITLE
fix(agent): return exact turn ids from CLI actions

### DIFF
--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -126,6 +126,13 @@ published. Existing-session consumers must validate `agentTargetId` before
 sending or attaching; provider equality is not sufficient because several
 Agent Targets may share one provider.
 
+Agent submission actions also return the exact top-level `turnId` established
+or targeted by that command. `agent start` returns the initial Turn created for
+its prompt, and `agent send` returns the Turn created by a normal send or
+targeted by active-turn guidance. Callers must use this exact identity for
+`agent turn-resources` and later Turn-scoped operations instead of inferring it
+from `session.activeTurnId` or querying the transcript.
+
 Agent session detail JSON uses the same protocol-v2 entities as HTTP/OpenAPI:
 `activeTurnId`, `activeTurn`, `latestTurn`, and pending Interaction records.
 It must not expose the provider-runtime `turnLifecycle` or
@@ -155,16 +162,19 @@ recovery.
 `agent wait --json` is the blocking progress helper for launched or continued
 agent sessions. It should wait for the next meaningful stop point such as turn
 completion, failure, cancellation, waiting for approval, waiting for user
-input, or timeout. Its JSON result stays narrow: compact session status, wait
+input, or timeout. Its JSON result stays narrow: compact session status, the
+exact top-level `turnId` associated with the stop point when one exists, wait
 reason, latest version, effective wait cursor, and timeout flag. A completed or
-failed turn additionally returns its last assistant text as `finalMessage`
-with the owning `turnId`; an approval or input stop additionally returns the
-pending `interactions` with self-described actions and a JSON input summary of
-at most 2 KiB. It must not return execution-message pagination or a full
-transcript; callers that need broader context should follow with
-`agent session-summary`. Keep message window controls such as `limit` out of
-the public wait command shape, and keep timeout output free of result or
-interaction detail.
+failed turn additionally returns its last assistant text as `finalMessage`;
+that nested record repeats the owning `turnId` for local correlation. An
+approval or input stop additionally returns the pending `interactions` with
+self-described actions and a JSON input summary of at most 2 KiB. It must not
+reuse a historical settled Turn for an idle timeout: timeout carries a
+`turnId` only while a Turn is active. It must not return execution-message
+pagination or a full transcript; callers that need
+broader context should follow with `agent session-summary`. Keep message window
+controls such as `limit` out of the public wait command shape, and keep timeout
+output free of result or interaction detail.
 The wait implementation skips transcript pagination and performs result
 enrichment separately. New settled turns carry a durable final-assistant
 resolution marker and, when present at settlement, the exact message anchor.

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -51,20 +51,27 @@ func NewService(runtime RuntimeController) *Service {
 }
 
 func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSessionInput) (Session, error) {
+	result, err := s.CreateWithResult(ctx, workspaceID, input)
+	return result.Session, err
+}
+
+// CreateWithResult creates a session while retaining the exact Turn identity
+// returned by Host for the optional initial submission.
+func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, input CreateSessionInput) (CreateSessionResult, error) {
 	workspaceID = strings.TrimSpace(workspaceID)
 	input.AgentTargetID = strings.TrimSpace(input.AgentTargetID)
 	launch, err := s.resolveCreateSessionLaunch(ctx, input)
 	if err != nil {
-		return Session{}, err
+		return CreateSessionResult{}, err
 	}
 	provider := launch.Provider
 	if workspaceID == "" || provider == "" {
-		return Session{}, ErrInvalidArgument
+		return CreateSessionResult{}, ErrInvalidArgument
 	}
 	input.Provider = provider
 	input.ProviderTargetRef = launch.ProviderTargetRef
 	if err := s.applyCreateSessionComposerDefaults(ctx, &input); err != nil {
-		return Session{}, err
+		return CreateSessionResult{}, err
 	}
 	input.ConversationDetailMode = preferencesbiz.NormalizeDesktopAgentConversationDetailMode(input.ConversationDetailMode)
 	normalizedPermissionModeID := normalizePermissionModeIDForLaunch(provider, input.ProviderTargetRef, value(input.PermissionModeID))
@@ -81,7 +88,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 		normalizedContent, _, err = normalizePromptContent(input.InitialContent)
 		if err != nil {
 			s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "content_normalized", provider, nodeStartedAt, err)
-			return Session{}, err
+			return CreateSessionResult{}, err
 		}
 		s.reportAgentServiceNodeSuccess(ctx, input.AgentSessionID, "session_create", "content_normalized", provider, nodeStartedAt)
 	}
@@ -92,7 +99,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	if providerTargetRefKind(input.ProviderTargetRef) != "agent_extension" {
 		if err := s.validateComposerModelForCreate(ctx, provider, workspaceID, value(input.Cwd), requestedModel); err != nil {
 			s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "model_validated", provider, nodeStartedAt, err)
-			return Session{}, err
+			return CreateSessionResult{}, err
 		}
 	}
 	s.reportAgentServiceNodeSuccess(ctx, input.AgentSessionID, "session_create", "model_validated", provider, nodeStartedAt)
@@ -108,7 +115,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	)
 	isolationMode := strings.TrimSpace(input.Isolation)
 	if isolationMode != "" && isolationMode != WorktreeIsolationMode {
-		return Session{}, fmt.Errorf("%w: unsupported session isolation mode %q", ErrInvalidArgument, isolationMode)
+		return CreateSessionResult{}, fmt.Errorf("%w: unsupported session isolation mode %q", ErrInvalidArgument, isolationMode)
 	}
 	s.worktreeIsolationMu.RLock()
 	defer s.worktreeIsolationMu.RUnlock()
@@ -116,12 +123,12 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	if isolationMode == WorktreeIsolationMode && strings.TrimSpace(value(input.Cwd)) == "" {
 		err := &WorktreeIsolationError{Kind: ErrNotAGitRepo}
 		s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "cwd_resolved", provider, nodeStartedAt, err)
-		return Session{}, err
+		return CreateSessionResult{}, err
 	}
 	cwd, err := s.resolveCwd(ctx, input.Cwd)
 	if err != nil {
 		s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "cwd_resolved", provider, nodeStartedAt, err)
-		return Session{}, err
+		return CreateSessionResult{}, err
 	}
 	s.reportAgentServiceNodeSuccess(ctx, input.AgentSessionID, "session_create", "cwd_resolved", provider, nodeStartedAt)
 	logAgentSubmitTrace("service.create.cwd_resolved", workspaceID, input.AgentSessionID, input.Metadata, map[string]any{
@@ -133,7 +140,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	if isolationMode == WorktreeIsolationMode {
 		created, warnings, createErr := s.createSessionWorktree(ctx, workspaceID, cwd, input.AgentSessionID)
 		if createErr != nil {
-			return Session{}, createErr
+			return CreateSessionResult{}, createErr
 		}
 		isolation = &created
 		isolationWarnings = warnings
@@ -150,7 +157,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 		nodeStartedAt = time.Now()
 		if err := s.validateExtensionComposerSettingsForCreate(ctx, workspaceID, cwd, input); err != nil {
 			s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "settings_validated", provider, nodeStartedAt, err)
-			return Session{}, err
+			return CreateSessionResult{}, err
 		}
 		s.reportAgentServiceNodeSuccess(ctx, input.AgentSessionID, "session_create", "settings_validated", provider, nodeStartedAt)
 	}
@@ -158,7 +165,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	prepared, err := s.prepareRuntime(ctx, workspaceID, cwd, input)
 	if err != nil {
 		s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "runtime_prepared", provider, nodeStartedAt, err)
-		return Session{}, err
+		return CreateSessionResult{}, err
 	}
 	if isolation != nil {
 		prepared.Cwd = isolation.WorktreePath
@@ -192,7 +199,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	logAgentSubmitTrace("service.create.runtime_start_requested", workspaceID, input.AgentSessionID, input.Metadata, nil)
 	hostResult, err := s.ApplicationHost().CreateSession(ctx, workspaceID, hostInput)
 	if err != nil {
-		return Session{}, err
+		return CreateSessionResult{}, err
 	}
 	keepWorktree = true
 	session := hostResult.Session
@@ -200,27 +207,39 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	persistedSession := persistedSessionFromHost(hostResult.Canonical)
 	if strings.TrimSpace(session.ID) == "" && strings.TrimSpace(hostResult.TurnID) != "" {
 		result, getErr := s.Get(ctx, workspaceID, input.AgentSessionID)
-		return decorateIsolatedSession(result, isolation, isolationWarnings), getErr
+		return CreateSessionResult{
+			Session: decorateIsolatedSession(result, isolation, isolationWarnings),
+			TurnID:  strings.TrimSpace(hostResult.TurnID),
+		}, getErr
 	}
 	if hostResult.Kind == "goalControl" {
 		result, getErr := s.Get(ctx, workspaceID, session.ID)
-		return decorateIsolatedSession(result, isolation, isolationWarnings), getErr
+		return CreateSessionResult{
+			Session: decorateIsolatedSession(result, isolation, isolationWarnings),
+			TurnID:  strings.TrimSpace(hostResult.TurnID),
+		}, getErr
 	}
 	if len(normalizedContent) == 0 {
-		return decorateIsolatedSession(serviceSessionWithPersistedFreshness(
-			session,
-			persistedSession,
-			s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session)),
-		), isolation, isolationWarnings), nil
+		return CreateSessionResult{
+			Session: decorateIsolatedSession(serviceSessionWithPersistedFreshness(
+				session,
+				persistedSession,
+				s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session)),
+			), isolation, isolationWarnings),
+			TurnID: strings.TrimSpace(hostResult.TurnID),
+		}, nil
 	}
 	logAgentSubmitTrace("service.create.prompt_validated", workspaceID, session.ID, input.Metadata, nil)
 	logAgentSubmitTrace("service.create.prompt_prepared", workspaceID, session.ID, input.Metadata, map[string]any{"content_block_count": len(normalizedContent)})
 	logAgentSubmitTrace("service.create.exec_resolved", workspaceID, session.ID, input.Metadata, map[string]any{"turn_id": hostResult.TurnID})
-	return decorateIsolatedSession(serviceSessionWithPersistedFreshness(
-		session,
-		persistedSession,
-		s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session)),
-	), isolation, isolationWarnings), nil
+	return CreateSessionResult{
+		Session: decorateIsolatedSession(serviceSessionWithPersistedFreshness(
+			session,
+			persistedSession,
+			s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session)),
+		), isolation, isolationWarnings),
+		TurnID: strings.TrimSpace(hostResult.TurnID),
+	}, nil
 }
 
 func decorateIsolatedSession(session Session, isolation *SessionIsolation, warnings []SessionWarning) Session {

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -134,7 +134,7 @@ func TestServiceCreateSynchronouslyPersistsRailSectionKey(t *testing.T) {
 	service.SessionInitializer = projection
 	service.SessionReader = projection
 
-	session, err := service.Create(ctx, "ws-rail-create", CreateSessionInput{
+	created, err := service.CreateWithResult(ctx, "ws-rail-create", CreateSessionInput{
 		AgentSessionID: "22222222-2222-4222-8222-222222222222",
 		AgentTargetID:  agenttargetbiz.IDLocalCodex,
 		Provider:       "codex",
@@ -142,7 +142,11 @@ func TestServiceCreateSynchronouslyPersistsRailSectionKey(t *testing.T) {
 		InitialContent: TextPromptContent("hello"),
 	})
 	if err != nil {
-		t.Fatalf("Create returned error: %v", err)
+		t.Fatalf("CreateWithResult returned error: %v", err)
+	}
+	session := created.Session
+	if created.TurnID != "turn-1" {
+		t.Fatalf("CreateWithResult turnId = %q, want turn-1", created.TurnID)
 	}
 	wantKey := userprojectbiz.SectionKeyFromPath(projectPath)
 	if session.RailSectionKey != wantKey {

--- a/services/tuttid/service/agent/service_wait.go
+++ b/services/tuttid/service/agent/service_wait.go
@@ -192,7 +192,7 @@ func (s *Service) waitResult(
 ) (WaitResult, error) {
 	result := WaitResult{
 		Session: cloneSession(session), Reason: reason, TimedOut: timedOut,
-		EffectiveAfter: effectiveAfter,
+		EffectiveAfter: effectiveAfter, TurnID: waitResultTurnID(session, reason),
 	}
 	if messageLimit < 0 {
 		latestVersion, err := s.latestSessionVersion(ctx, workspaceID, agentSessionID)
@@ -225,6 +225,23 @@ func (s *Service) waitResult(
 		result.Interactions = waitInteractions(session.PendingInteractions)
 	}
 	return result, nil
+}
+
+func waitResultTurnID(session Session, reason WaitReason) string {
+	switch reason {
+	case WaitReasonWaiting, WaitReasonWaitingApproval, WaitReasonWaitingInput, WaitReasonTimeout:
+		if turnID := strings.TrimSpace(session.ActiveTurnID); turnID != "" {
+			return turnID
+		}
+		if session.ActiveTurn != nil {
+			return strings.TrimSpace(session.ActiveTurn.TurnID)
+		}
+	case WaitReasonCompleted, WaitReasonFailed, WaitReasonCanceled:
+		if session.LatestTurn != nil {
+			return strings.TrimSpace(session.LatestTurn.TurnID)
+		}
+	}
+	return ""
 }
 
 func (s *Service) finalAssistantMessage(

--- a/services/tuttid/service/agent/service_wait_test.go
+++ b/services/tuttid/service/agent/service_wait_test.go
@@ -1235,3 +1235,53 @@ func TestWaitClosedStreamDoesNotReturnStaleStop(t *testing.T) {
 		t.Fatalf("Wait() did not return")
 	}
 }
+
+func TestWaitResultTurnIDUsesTurnAssociatedWithStopReason(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		session Session
+		reason  WaitReason
+		want    string
+	}{
+		{
+			name: "waiting uses canonical active turn reference",
+			session: Session{
+				ActiveTurnID: "active-reference",
+				ActiveTurn:   &agentactivitybiz.Turn{TurnID: "active-reference"},
+				LatestTurn:   &agentactivitybiz.Turn{TurnID: "latest-turn"},
+			},
+			reason: WaitReasonWaitingInput,
+			want:   "active-reference",
+		},
+		{
+			name:    "active timeout uses embedded turn fallback",
+			session: Session{ActiveTurn: &agentactivitybiz.Turn{TurnID: "active-entity"}, LatestTurn: &agentactivitybiz.Turn{TurnID: "latest-turn"}},
+			reason:  WaitReasonTimeout,
+			want:    "active-entity",
+		},
+		{
+			name:    "completion uses latest settled turn",
+			session: Session{LatestTurn: &agentactivitybiz.Turn{TurnID: "latest-turn"}},
+			reason:  WaitReasonCompleted,
+			want:    "latest-turn",
+		},
+		{
+			name:    "idle timeout does not reuse historical turn",
+			session: Session{LatestTurn: &agentactivitybiz.Turn{TurnID: "historical-turn"}},
+			reason:  WaitReasonTimeout,
+		},
+		{
+			name:    "ready does not target a turn",
+			session: Session{LatestTurn: &agentactivitybiz.Turn{TurnID: "historical-turn"}},
+			reason:  WaitReasonReady,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := waitResultTurnID(test.session, test.reason); got != test.want {
+				t.Fatalf("waitResultTurnID() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -485,6 +485,14 @@ type CreateSessionInput struct {
 	ExternalRolloutSourcePath string
 }
 
+// CreateSessionResult preserves the exact lifecycle identity returned by Host
+// for callers that need to correlate the initial submission. Create remains
+// the compatibility surface for consumers that only need the Session.
+type CreateSessionResult struct {
+	Session Session
+	TurnID  string
+}
+
 type SessionSkillBundle struct {
 	Name  string
 	Files map[string]string
@@ -558,6 +566,7 @@ const (
 
 type WaitResult struct {
 	Session        Session
+	TurnID         string
 	Messages       []SessionMessage
 	FinalMessage   *WaitFinalMessage
 	Interactions   []WaitInteraction

--- a/services/tuttid/service/cli/providers/agentcontext/provider.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider.go
@@ -16,7 +16,7 @@ const appID = "agent-context"
 
 type AgentSessions interface {
 	CancelTurn(context.Context, string, string, string) (agentservice.CancelTurnResult, error)
-	Create(context.Context, string, agentservice.CreateSessionInput) (agentservice.Session, error)
+	CreateWithResult(context.Context, string, agentservice.CreateSessionInput) (agentservice.CreateSessionResult, error)
 	Get(context.Context, string, string) (agentservice.Session, error)
 	GetComposerOptions(context.Context, agentservice.ComposerOptionsInput) (agentservice.ComposerOptions, error)
 	GetSkillBundle(context.Context, string, agentservice.SkillBundleInput) (agentservice.SkillBundle, error)

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -109,7 +109,7 @@ func (f *fakeAgentSessions) CancelTurn(_ context.Context, workspaceID string, se
 	return agentservice.CancelTurnResult{Canceled: true, Reason: agentservice.CancelTurnReasonTurnCanceled}, nil
 }
 
-func (f *fakeAgentSessions) Create(_ context.Context, workspaceID string, input agentservice.CreateSessionInput) (agentservice.Session, error) {
+func (f *fakeAgentSessions) CreateWithResult(_ context.Context, workspaceID string, input agentservice.CreateSessionInput) (agentservice.CreateSessionResult, error) {
 	f.workspaceID = workspaceID
 	f.createCallCount++
 	f.createInput = input
@@ -132,7 +132,7 @@ func (f *fakeAgentSessions) Create(_ context.Context, workspaceID string, input 
 		session.Isolation = &agentservice.SessionIsolation{Mode: "worktree", WorktreePath: "/state/worktree", Branch: "tutti/SESSION-NEW", BaseCommit: "abc123"}
 		session.Warnings = []agentservice.SessionWarning{{Code: "worktree_base_dirty", Message: "dirty source"}}
 	}
-	return session, nil
+	return agentservice.CreateSessionResult{Session: session, TurnID: "turn-new"}, nil
 }
 
 func (f *fakeAgentSessions) Get(_ context.Context, workspaceID string, sessionID string) (agentservice.Session, error) {
@@ -343,6 +343,7 @@ func (f *fakeAgentSessions) SendInput(_ context.Context, workspaceID string, ses
 	f.sendInput = input
 	return agentservice.SendInputResult{
 		Session: agentservice.Session{ID: sessionID, Provider: "codex", ActiveTurnID: "turn-1", Visible: true},
+		TurnID:  "turn-1",
 	}, nil
 }
 
@@ -364,6 +365,7 @@ func (f *fakeAgentSessions) Wait(_ context.Context, input agentservice.WaitInput
 			ActiveTurnID: "turn-1",
 			Visible:      true,
 		},
+		TurnID: "turn-1",
 		Messages: []agentservice.SessionMessage{{
 			AgentSessionID: input.AgentSessionID,
 			MessageID:      "message-2",
@@ -782,6 +784,7 @@ func TestWaitCommandReturnsFinalMessageAndDetailedInteractions(t *testing.T) {
 	t.Run("completed", func(t *testing.T) {
 		sessions := &fakeAgentSessions{waitResult: agentservice.WaitResult{
 			Session:      agentservice.Session{ID: "SESSION-1", Provider: "codex", Visible: true},
+			TurnID:       "turn-1",
 			Reason:       agentservice.WaitReasonCompleted,
 			FinalMessage: &agentservice.WaitFinalMessage{TurnID: "turn-1", Text: strings.Repeat("complete ", 600)},
 		}}
@@ -793,6 +796,9 @@ func TestWaitCommandReturnsFinalMessageAndDetailedInteractions(t *testing.T) {
 			t.Fatalf("Handler: %v", err)
 		}
 		final := output.Value["finalMessage"].(map[string]any)
+		if output.Value["turnId"] != "turn-1" {
+			t.Fatalf("turnId = %#v, want turn-1", output.Value["turnId"])
+		}
 		if final["turnId"] != "turn-1" || final["text"] != sessions.waitResult.FinalMessage.Text {
 			t.Fatalf("finalMessage = %#v", final)
 		}
@@ -804,6 +810,7 @@ func TestWaitCommandReturnsFinalMessageAndDetailedInteractions(t *testing.T) {
 	t.Run("waiting approval", func(t *testing.T) {
 		sessions := &fakeAgentSessions{waitResult: agentservice.WaitResult{
 			Session: agentservice.Session{ID: "SESSION-1", Provider: "claude-code", Visible: true},
+			TurnID:  "turn-1",
 			Reason:  agentservice.WaitReasonWaitingApproval,
 			Interactions: []agentservice.WaitInteraction{{
 				RequestID: "request-1", TurnID: "turn-1", Kind: "approval", ToolName: "Approval",
@@ -820,6 +827,9 @@ func TestWaitCommandReturnsFinalMessageAndDetailedInteractions(t *testing.T) {
 		}
 		interactions := output.Value["interactions"].([]any)
 		interaction := interactions[0].(map[string]any)
+		if output.Value["turnId"] != "turn-1" {
+			t.Fatalf("turnId = %#v, want turn-1", output.Value["turnId"])
+		}
 		action := interaction["actions"].([]any)[0].(map[string]any)
 		input := interaction["input"].(map[string]any)
 		if interaction["requestId"] != "request-1" || interaction["toolName"] != "Approval" ||
@@ -846,6 +856,9 @@ func TestWaitCommandReturnsFinalMessageAndDetailedInteractions(t *testing.T) {
 			if _, ok := output.Value[key]; ok {
 				t.Fatalf("timeout output should omit %q: %#v", key, output.Value)
 			}
+		}
+		if output.Value["turnId"] != nil {
+			t.Fatalf("idle timeout turnId = %#v, want null", output.Value["turnId"])
 		}
 	})
 }
@@ -917,13 +930,14 @@ func TestStartCommandPassesDisplayPrompt(t *testing.T) {
 	sessions := &fakeAgentSessions{}
 	command := newTestCodexStartCommand(newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
 
-	_, err := command.Handler(context.Background(), cliservice.InvokeRequest{
+	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input: map[string]any{
 			"agent-id":       agenttargetbiz.IDLocalCodex,
 			"model":          "gpt-5",
 			"prompt":         "real automation prompt",
 			"display-prompt": "Run Automation",
 		},
+		OutputMode: cliservice.OutputModeJSON,
 	})
 	if err != nil {
 		t.Fatalf("Handler: %v", err)
@@ -936,6 +950,9 @@ func TestStartCommandPassesDisplayPrompt(t *testing.T) {
 	}
 	if sessions.createInput.AgentTargetID != agenttargetbiz.IDLocalCodex {
 		t.Fatalf("agent target id = %q, want %s", sessions.createInput.AgentTargetID, agenttargetbiz.IDLocalCodex)
+	}
+	if output.Value["turnId"] != "turn-new" {
+		t.Fatalf("output turnId = %#v, want turn-new", output.Value["turnId"])
 	}
 }
 
@@ -1864,6 +1881,9 @@ func TestSendCommandReturnsWaitAfterVersionInJSON(t *testing.T) {
 	}
 	if output.Value["waitAfterVersion"] != uint64(2) {
 		t.Fatalf("output = %#v", output.Value)
+	}
+	if output.Value["turnId"] != "turn-1" {
+		t.Fatalf("output turnId = %#v, want turn-1", output.Value["turnId"])
 	}
 }
 

--- a/services/tuttid/service/cli/providers/agentcontext/session_commands.go
+++ b/services/tuttid/service/cli/providers/agentcontext/session_commands.go
@@ -64,6 +64,7 @@ type respondInput struct {
 
 type sessionActionResult struct {
 	Session          agentservice.Session
+	TurnID           string
 	LaunchRequested  bool
 	WaitAfterVersion *uint64
 	Warnings         []cliservice.CommandWarning
@@ -135,7 +136,7 @@ func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, 
 	if err != nil {
 		return nil, err
 	}
-	session, err := p.sessions.Create(ctx, invoke.WorkspaceID, agentservice.CreateSessionInput{
+	created, err := p.sessions.CreateWithResult(ctx, invoke.WorkspaceID, agentservice.CreateSessionInput{
 		Provider:               provider,
 		AgentTargetID:          agentTargetID,
 		Cwd:                    optionalStringPointer(cwd),
@@ -153,6 +154,7 @@ func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, 
 	if err != nil {
 		return nil, err
 	}
+	session := created.Session
 	launchRequested := false
 	if input.Show {
 		if err := p.publishLaunchRequested(ctx, invoke.WorkspaceID, session, "start_show", invoke.Request.Context.Source); err != nil {
@@ -164,7 +166,10 @@ func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, 
 	for _, warning := range session.Warnings {
 		warnings = append(warnings, cliservice.CommandWarning{Code: warning.Code, Message: warning.Message})
 	}
-	return sessionActionResult{Session: session, LaunchRequested: launchRequested, Warnings: warnings}, nil
+	return sessionActionResult{
+		Session: session, TurnID: strings.TrimSpace(created.TurnID),
+		LaunchRequested: launchRequested, Warnings: warnings,
+	}, nil
 }
 
 func (p Provider) composerConversationDetailMode(ctx context.Context) string {
@@ -311,7 +316,9 @@ func (p Provider) runSend(ctx context.Context, invoke framework.InvokeContext, i
 		return nil, err
 	}
 	session := result.Session
-	return sessionActionResult{Session: session, WaitAfterVersion: &waitAfterVersion}, nil
+	return sessionActionResult{
+		Session: session, TurnID: strings.TrimSpace(result.TurnID), WaitAfterVersion: &waitAfterVersion,
+	}, nil
 }
 
 func (p Provider) newRespondCommand() cliservice.Command {
@@ -489,6 +496,9 @@ func sessionActionOutputSpec() framework.OutputSpec {
 				value := map[string]any{
 					"launchRequested": action.LaunchRequested,
 					"session":         sessionActionValue(action.Session),
+				}
+				if turnID := strings.TrimSpace(action.TurnID); turnID != "" {
+					value["turnId"] = turnID
 				}
 				if action.WaitAfterVersion != nil {
 					value["waitAfterVersion"] = *action.WaitAfterVersion

--- a/services/tuttid/service/cli/providers/agentcontext/sessions.go
+++ b/services/tuttid/service/cli/providers/agentcontext/sessions.go
@@ -265,11 +265,15 @@ func waitJSONValue(result any) map[string]any {
 	waited := result.(waitCommandResult)
 	value := map[string]any{
 		"agentSessionId": waited.Result.Session.ID,
+		"turnId":         nil,
 		"session":        sessionSummaryValue(waited.Result.Session),
 		"latestVersion":  waited.Result.LatestVersion,
 		"effectiveAfter": waited.Result.EffectiveAfter,
 		"timedOut":       waited.Result.TimedOut,
 		"reason":         string(waited.Result.Reason),
+	}
+	if turnID := strings.TrimSpace(waited.Result.TurnID); turnID != "" {
+		value["turnId"] = turnID
 	}
 	if (waited.Result.Reason == agentservice.WaitReasonCompleted || waited.Result.Reason == agentservice.WaitReasonFailed) && waited.Result.FinalMessage != nil {
 		value["finalMessage"] = map[string]any{


### PR DESCRIPTION
## Summary

- return the authoritative top-level `turnId` from `agent start`, `agent send`, and `agent wait` JSON
- preserve the Host-created initial Turn identity through the tuttidd adapter instead of inferring it from session state
- select wait Turn identity by stop reason so idle timeouts return `null` rather than a historical settled Turn
- document the durable Tutti CLI contract

## Testing

- `pnpm check:changed -- --push-ready`
- `cd services/tuttid && go test ./...`
- `cd services/tuttid && go build ./...`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->