### PR TITLE
feat(workspace-apps): expose agent activity automation

### DIFF
--- a/.changeset/workspace-app-agent-activity-automation.md
+++ b/.changeset/workspace-app-agent-activity-automation.md
@@ -1,0 +1,11 @@
+---
+"@tutti-os/desktop": patch
+"@tutti-os/workspace-external-core": minor
+---
+
+Expose a trusted workspace-app Agent Activity bridge that lists exact Agent
+targets, delegates session and turn operations to the host-owned Agent GUI
+runtime, and returns the same Activity snapshot used by Agent GUI.
+
+Document the boundary between host-owned Agent GUI automation and independent
+app-owned Agent runtimes.

--- a/apps/desktop/src/main/ipc/workspaceAppContext.test.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppContext.test.ts
@@ -37,3 +37,26 @@ test("workspace app at resolution is scoped by the registered guest context", ()
     /appExternal\.atResolve,[\s\S]*?requireWorkspaceAppGuestContext\(event\.sender\)[\s\S]*?normalizeTuttiExternalAtResolveInput\(payload\)[\s\S]*?appId: context\.appID,[\s\S]*?operation: "at\.resolve",[\s\S]*?workspaceId: context\.workspaceID/
   );
 });
+
+test("workspace app agent activity requests are scoped by the registered guest context", () => {
+  for (const [channel, operation] of [
+    ["agentActivityActivateSession", "agentActivity.activateSession"],
+    ["agentActivityCancelTurn", "agentActivity.cancelTurn"],
+    ["agentActivityGetComposerOptions", "agentActivity.getComposerOptions"],
+    ["agentActivityGetSnapshot", "agentActivity.getSnapshot"],
+    ["agentActivityListTargets", "agentActivity.listTargets"],
+    ["agentActivitySendInput", "agentActivity.sendInput"]
+  ] as const) {
+    const handlerPattern = new RegExp(
+      `appExternal\\.${channel},[\\s\\S]*?requireWorkspaceAppGuestContext\\(event\\.sender\\)[\\s\\S]*?operation: "${operation.replace(".", "\\.")}",[\\s\\S]*?workspaceId: context\\.workspaceID`
+    );
+    assert.match(workspaceAppContextSource, handlerPattern);
+  }
+});
+
+test("workspace app context advertises the Agent Activity automation capability", () => {
+  assert.match(
+    workspaceAppContextSource,
+    /capabilities:\s*\[[\s\S]*?"agentActivity@1"/
+  );
+});

--- a/apps/desktop/src/main/ipc/workspaceAppContext.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppContext.ts
@@ -24,6 +24,10 @@ import {
   normalizeTuttiExternalAtQueryInput,
   normalizeTuttiExternalAtResolveInput,
   normalizeTuttiExternalAtInvalidation,
+  normalizeTuttiExternalAgentActivityActivateSessionInput,
+  normalizeTuttiExternalAgentActivityCancelTurnInput,
+  normalizeTuttiExternalAgentActivityComposerOptionsInput,
+  normalizeTuttiExternalAgentActivitySendInput,
   normalizeTuttiExternalFileOpenInput,
   normalizeTuttiExternalFileSelectInput,
   normalizeTuttiExternalFileUploadInput,
@@ -42,6 +46,12 @@ import {
 import type {
   TuttiExternalAtQueryResult,
   TuttiExternalAtResolveResult,
+  TuttiExternalAgentActivityActivateSessionResult,
+  TuttiExternalAgentActivityCancelTurnResult,
+  TuttiExternalAgentActivityComposerOptions,
+  TuttiExternalAgentActivitySendResult,
+  TuttiExternalAgentActivitySnapshot,
+  TuttiExternalAgentTargetCatalog,
   TuttiExternalFileOpenInput,
   TuttiExternalFileSelectResult,
   TuttiExternalManagedAiModel,
@@ -166,6 +176,106 @@ export function registerWorkspaceAppContextIpc(
           workspaceId: context.workspaceID
         });
       }
+    }
+  );
+  registerDesktopIpcHandler(
+    desktopIpcChannels.appExternal.agentActivityActivateSession,
+    async (event, payload) => {
+      const context = requireWorkspaceAppGuestContext(event.sender);
+      const input =
+        normalizeTuttiExternalAgentActivityActivateSessionInput(payload);
+      return requestWorkspaceAppExternalRenderer<TuttiExternalAgentActivityActivateSessionResult>(
+        context,
+        {
+          appId: context.appID,
+          input,
+          operation: "agentActivity.activateSession",
+          requestId: randomUUID(),
+          workspaceId: context.workspaceID
+        }
+      );
+    }
+  );
+  registerDesktopIpcHandler(
+    desktopIpcChannels.appExternal.agentActivityCancelTurn,
+    async (event, payload) => {
+      const context = requireWorkspaceAppGuestContext(event.sender);
+      const input = normalizeTuttiExternalAgentActivityCancelTurnInput(payload);
+      return requestWorkspaceAppExternalRenderer<TuttiExternalAgentActivityCancelTurnResult>(
+        context,
+        {
+          appId: context.appID,
+          input,
+          operation: "agentActivity.cancelTurn",
+          requestId: randomUUID(),
+          workspaceId: context.workspaceID
+        }
+      );
+    }
+  );
+  registerDesktopIpcHandler(
+    desktopIpcChannels.appExternal.agentActivityGetComposerOptions,
+    async (event, payload) => {
+      const context = requireWorkspaceAppGuestContext(event.sender);
+      const input =
+        normalizeTuttiExternalAgentActivityComposerOptionsInput(payload);
+      return requestWorkspaceAppExternalRenderer<TuttiExternalAgentActivityComposerOptions>(
+        context,
+        {
+          appId: context.appID,
+          input,
+          operation: "agentActivity.getComposerOptions",
+          requestId: randomUUID(),
+          workspaceId: context.workspaceID
+        }
+      );
+    }
+  );
+  registerDesktopIpcHandler(
+    desktopIpcChannels.appExternal.agentActivityGetSnapshot,
+    (event) => {
+      const context = requireWorkspaceAppGuestContext(event.sender);
+      return requestWorkspaceAppExternalRenderer<TuttiExternalAgentActivitySnapshot>(
+        context,
+        {
+          appId: context.appID,
+          operation: "agentActivity.getSnapshot",
+          requestId: randomUUID(),
+          workspaceId: context.workspaceID
+        }
+      );
+    }
+  );
+  registerDesktopIpcHandler(
+    desktopIpcChannels.appExternal.agentActivityListTargets,
+    (event) => {
+      const context = requireWorkspaceAppGuestContext(event.sender);
+      return requestWorkspaceAppExternalRenderer<TuttiExternalAgentTargetCatalog>(
+        context,
+        {
+          appId: context.appID,
+          operation: "agentActivity.listTargets",
+          requestId: randomUUID(),
+          workspaceId: context.workspaceID
+        }
+      );
+    }
+  );
+  registerDesktopIpcHandler(
+    desktopIpcChannels.appExternal.agentActivitySendInput,
+    async (event, payload) => {
+      const context = requireWorkspaceAppGuestContext(event.sender);
+      const input = normalizeTuttiExternalAgentActivitySendInput(payload);
+      return requestWorkspaceAppExternalRenderer<TuttiExternalAgentActivitySendResult>(
+        context,
+        {
+          appId: context.appID,
+          input,
+          operation: "agentActivity.sendInput",
+          requestId: randomUUID(),
+          workspaceId: context.workspaceID
+        }
+      );
     }
   );
   registerDesktopIpcHandler(
@@ -1275,6 +1385,7 @@ function createWorkspaceAppContext(
   return {
     appId: context.appID,
     capabilities: [
+      "agentActivity@1",
       "browser.openUrl@1",
       "files.open@1",
       "files.upload@1",

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
@@ -36,6 +36,80 @@ test("workspace app external bridge proxies app context", async () => {
   assert.equal(await bridge.app.getContext(), context);
 });
 
+test("workspace app external bridge proxies agent activity without user activation", async () => {
+  const calls: Array<{ channel: string; payload?: unknown }> = [];
+  const bridge = createWorkspaceAppExternalBridge({
+    appContext: {
+      async get() {
+        return { locale: "en" };
+      },
+      subscribe() {
+        throw new Error("unexpected subscribe");
+      }
+    },
+    isUserActivationActive: () => false,
+    send: unexpectedSend,
+    async invoke<TResult>(channel: string, payload?: unknown) {
+      calls.push({ channel, payload });
+      return { channel } as TResult;
+    }
+  });
+  const activateInput = {
+    agentSessionId: "session-1",
+    agentTargetId: "codex",
+    clientSubmitId: "batch-1",
+    initialContent: [{ type: "text" as const, text: "Run test" }],
+    visible: true
+  };
+  const composerInput = {
+    agentTargetId: "codex",
+    provider: "codex"
+  };
+  const sendInput = {
+    agentSessionId: "session-1",
+    clientSubmitId: "turn-2",
+    content: [{ type: "text" as const, text: "Continue test" }]
+  };
+  const cancelInput = {
+    agentSessionId: "session-1",
+    turnId: "turn-1"
+  };
+
+  await bridge.agentActivity.listTargets();
+  await bridge.agentActivity.getComposerOptions(composerInput);
+  await bridge.agentActivity.activateSession(activateInput);
+  await bridge.agentActivity.sendInput(sendInput);
+  await bridge.agentActivity.cancelTurn(cancelInput);
+  await bridge.agentActivity.getSnapshot();
+
+  assert.deepEqual(calls, [
+    {
+      channel: workspaceAppExternalChannels.agentActivityListTargets,
+      payload: undefined
+    },
+    {
+      channel: workspaceAppExternalChannels.agentActivityGetComposerOptions,
+      payload: composerInput
+    },
+    {
+      channel: workspaceAppExternalChannels.agentActivityActivateSession,
+      payload: activateInput
+    },
+    {
+      channel: workspaceAppExternalChannels.agentActivitySendInput,
+      payload: sendInput
+    },
+    {
+      channel: workspaceAppExternalChannels.agentActivityCancelTurn,
+      payload: cancelInput
+    },
+    {
+      channel: workspaceAppExternalChannels.agentActivityGetSnapshot,
+      payload: undefined
+    }
+  ]);
+});
+
 test("workspace app external bridge subscribes to app context", () => {
   const context: DesktopWorkspaceAppContext = {
     appId: "automation",

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.ts
@@ -10,6 +10,16 @@ import type {
   TuttiExternalAtInvalidation,
   TuttiExternalAtResolveInput,
   TuttiExternalAtResolveResult,
+  TuttiExternalAgentActivityActivateSessionInput,
+  TuttiExternalAgentActivityActivateSessionResult,
+  TuttiExternalAgentActivityCancelTurnInput,
+  TuttiExternalAgentActivityCancelTurnResult,
+  TuttiExternalAgentActivityComposerOptions,
+  TuttiExternalAgentActivityComposerOptionsInput,
+  TuttiExternalAgentActivitySendInput,
+  TuttiExternalAgentActivitySendResult,
+  TuttiExternalAgentActivitySnapshot,
+  TuttiExternalAgentTargetCatalog,
   TuttiExternalBridge,
   TuttiExternalFileOpenInput,
   TuttiExternalFileSelectInput,
@@ -88,6 +98,13 @@ export interface WorkspaceAppUploadXMLHttpRequest {
 
 export const workspaceAppExternalChannels = {
   activityReportActive: "workspace-app-activity:report-active",
+  agentActivityActivateSession: "workspace-app-agent-activity:activate-session",
+  agentActivityCancelTurn: "workspace-app-agent-activity:cancel-turn",
+  agentActivityGetComposerOptions:
+    "workspace-app-agent-activity:get-composer-options",
+  agentActivityGetSnapshot: "workspace-app-agent-activity:get-snapshot",
+  agentActivityListTargets: "workspace-app-agent-activity:list-targets",
+  agentActivitySendInput: "workspace-app-agent-activity:send-input",
   atQuery: "workspace-app-at:query",
   atResolve: "workspace-app-at:resolve",
   browserOpenUrl: "workspace-app:open-url",
@@ -136,6 +153,44 @@ export function createWorkspaceAppExternalBridge(
       reportActive() {
         return dependencies.invoke<void>(
           workspaceAppExternalChannels.activityReportActive
+        );
+      }
+    },
+    agentActivity: {
+      activateSession(input: TuttiExternalAgentActivityActivateSessionInput) {
+        return dependencies.invoke<TuttiExternalAgentActivityActivateSessionResult>(
+          workspaceAppExternalChannels.agentActivityActivateSession,
+          input
+        );
+      },
+      cancelTurn(input: TuttiExternalAgentActivityCancelTurnInput) {
+        return dependencies.invoke<TuttiExternalAgentActivityCancelTurnResult>(
+          workspaceAppExternalChannels.agentActivityCancelTurn,
+          input
+        );
+      },
+      getComposerOptions(
+        input: TuttiExternalAgentActivityComposerOptionsInput
+      ) {
+        return dependencies.invoke<TuttiExternalAgentActivityComposerOptions>(
+          workspaceAppExternalChannels.agentActivityGetComposerOptions,
+          input
+        );
+      },
+      getSnapshot() {
+        return dependencies.invoke<TuttiExternalAgentActivitySnapshot>(
+          workspaceAppExternalChannels.agentActivityGetSnapshot
+        );
+      },
+      listTargets() {
+        return dependencies.invoke<TuttiExternalAgentTargetCatalog>(
+          workspaceAppExternalChannels.agentActivityListTargets
+        );
+      },
+      sendInput(input: TuttiExternalAgentActivitySendInput) {
+        return dependencies.invoke<TuttiExternalAgentActivitySendResult>(
+          workspaceAppExternalChannels.agentActivitySendInput,
+          input
         );
       }
     },

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAppExternalBridge.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAppExternalBridge.tsx
@@ -19,11 +19,16 @@ import type {
   DesktopWorkspaceAppExternalRendererEvent,
   DesktopWorkspaceAppExternalRendererRequest
 } from "@shared/contracts/ipc";
-import type { TuttiExternalFileOpenInput } from "@tutti-os/workspace-external-core/contracts";
+import type {
+  TuttiExternalAgentActivityComposerOptions,
+  TuttiExternalAgentTargetCatalog,
+  TuttiExternalFileOpenInput
+} from "@tutti-os/workspace-external-core/contracts";
 import { resolveWorkspaceMentionLinkAction } from "@contexts/workspace/presentation/renderer/actions/workspaceLinkActions";
 import { runDesktopAgentGUILinkAction } from "@renderer/features/workspace-agent/services/desktopAgentGUILinkActions.ts";
 import { IWorkspaceAgentActivityService } from "@renderer/features/workspace-agent/services/workspaceAgentActivityService.interface.ts";
 import { IAgentsService } from "@renderer/features/workspace-agent/services/agentsService.interface.ts";
+import type { AgentHostAgentSessionComposerSettings } from "@shared/contracts/dto";
 import { useService } from "@tutti-os/infra/di";
 import { requestGroupChatLaunch } from "../services/groupChatLaunchCoordinator.ts";
 import { requestWorkspaceAgentGuiLaunch } from "@renderer/features/workspace-agent/services/workspaceAgentGuiLaunchCoordinator.ts";
@@ -65,6 +70,36 @@ const workspaceFileReferenceLocaleKeyByPickerKey: Record<string, string> = {
     "agentHost.agentGui.referencePicker.selectedCount",
   "referencePicker.title": "agentHost.agentGui.referencePicker.title"
 };
+
+function toAgentHostComposerSettings(
+  settings:
+    | import("@tutti-os/agent-activity-core").AgentActivitySessionSettings
+    | null
+    | undefined
+): AgentHostAgentSessionComposerSettings | null | undefined {
+  if (settings === null || settings === undefined) {
+    return settings;
+  }
+  return {
+    ...(settings.model !== undefined ? { model: settings.model } : {}),
+    ...(settings.permissionModeId !== undefined
+      ? { permissionModeId: settings.permissionModeId }
+      : {}),
+    ...(typeof settings.planMode === "boolean"
+      ? { planMode: settings.planMode }
+      : {}),
+    ...(typeof settings.browserUse === "boolean"
+      ? { browserUse: settings.browserUse }
+      : {}),
+    ...(typeof settings.computerUse === "boolean"
+      ? { computerUse: settings.computerUse }
+      : {}),
+    ...(settings.reasoningEffort !== undefined
+      ? { reasoningEffort: settings.reasoningEffort }
+      : {}),
+    ...(settings.speed !== undefined ? { speed: settings.speed } : {})
+  };
+}
 
 interface WorkspaceAppExternalBridgeProps {
   api?: DesktopWorkspaceAppExternalHostApi;
@@ -225,6 +260,74 @@ export function WorkspaceAppExternalBridge({
         throw new Error("Workspace app external request workspace mismatch.");
       }
       switch (request.operation) {
+        case "agentActivity.listTargets": {
+          const snapshot = await agentsService.load();
+          return {
+            agents: snapshot.agents.map((agent) => ({
+              agentTargetId: agent.agentTargetId,
+              availability: { ...agent.availability },
+              ...(agent.description ? { description: agent.description } : {}),
+              iconUrl: agent.iconUrl,
+              name: agent.name,
+              provider: agent.provider
+            })),
+            capturedAtUnixMs: snapshot.capturedAtUnixMs,
+            error: snapshot.error,
+            status: snapshot.status
+          } satisfies TuttiExternalAgentTargetCatalog;
+        }
+        case "agentActivity.getComposerOptions":
+          return (await workspaceAgentActivityService.getComposerOptions({
+            agentTargetId: request.input.agentTargetId,
+            cwd: request.input.cwd,
+            provider: request.input.provider,
+            settings: toAgentHostComposerSettings(request.input.settings),
+            workspaceId
+          })) as TuttiExternalAgentActivityComposerOptions;
+        case "agentActivity.activateSession":
+          return workspaceAgentActivityService.activateSession({
+            agentSessionId: request.input.agentSessionId,
+            agentTargetId: request.input.agentTargetId,
+            clientSubmitId: request.input.clientSubmitId,
+            ...(request.input.cwd ? { cwd: request.input.cwd } : {}),
+            initialContent: request.input.initialContent,
+            ...(request.input.initialDisplayPrompt !== undefined
+              ? { initialDisplayPrompt: request.input.initialDisplayPrompt }
+              : {}),
+            mode: "new",
+            ...(request.input.settings
+              ? { settings: request.input.settings }
+              : {}),
+            ...(request.input.title ? { title: request.input.title } : {}),
+            ...(request.input.visible !== undefined
+              ? { visible: request.input.visible }
+              : {}),
+            workspaceId
+          });
+        case "agentActivity.sendInput":
+          return workspaceAgentActivityService.sendInput({
+            agentSessionId: request.input.agentSessionId,
+            clientSubmitId: request.input.clientSubmitId,
+            content: request.input.content,
+            ...(request.input.displayPrompt !== undefined
+              ? { displayPrompt: request.input.displayPrompt }
+              : {}),
+            ...(request.input.guidance !== undefined
+              ? { guidance: request.input.guidance }
+              : {}),
+            workspaceId
+          });
+        case "agentActivity.cancelTurn":
+          if (!workspaceAgentActivityService.cancelTurn) {
+            throw new Error("Agent activity cancellation is unavailable.");
+          }
+          return workspaceAgentActivityService.cancelTurn({
+            agentSessionId: request.input.agentSessionId,
+            turnId: request.input.turnId,
+            workspaceId
+          });
+        case "agentActivity.getSnapshot":
+          return workspaceAgentActivityService.load(workspaceId);
         case "at.query":
           return hostService.queryWorkspaceAppExternalAt({
             query: request.input,

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -57,6 +57,16 @@ import type {
   TuttiExternalAtResolveResult,
   TuttiExternalAtResolveInput,
   TuttiExternalAtInvalidation,
+  TuttiExternalAgentActivityActivateSessionResult,
+  TuttiExternalAgentActivityActivateSessionInput,
+  TuttiExternalAgentActivityCancelTurnResult,
+  TuttiExternalAgentActivityCancelTurnInput,
+  TuttiExternalAgentActivityComposerOptions,
+  TuttiExternalAgentActivityComposerOptionsInput,
+  TuttiExternalAgentActivitySendInput,
+  TuttiExternalAgentActivitySendResult,
+  TuttiExternalAgentActivitySnapshot,
+  TuttiExternalAgentTargetCatalog,
   TuttiExternalSettingsOpenInput,
   TuttiExternalUserProjectCreateInput,
   TuttiExternalUserProjectPathInput,
@@ -96,6 +106,14 @@ export const desktopIpcChannels = {
   },
   appExternal: {
     activityReportActive: "workspace-app-activity:report-active",
+    agentActivityActivateSession:
+      "workspace-app-agent-activity:activate-session",
+    agentActivityCancelTurn: "workspace-app-agent-activity:cancel-turn",
+    agentActivityGetComposerOptions:
+      "workspace-app-agent-activity:get-composer-options",
+    agentActivityGetSnapshot: "workspace-app-agent-activity:get-snapshot",
+    agentActivityListTargets: "workspace-app-agent-activity:list-targets",
+    agentActivitySendInput: "workspace-app-agent-activity:send-input",
     atQuery: "workspace-app-at:query",
     atResolve: "workspace-app-at:resolve",
     filesOpen: "workspace-app-files:open",
@@ -622,6 +640,12 @@ export type DesktopIpcResult<TResult> =
   | DesktopIpcFailure;
 
 export type DesktopWorkspaceAppExternalRendererResult =
+  | TuttiExternalAgentActivityActivateSessionResult
+  | TuttiExternalAgentActivityCancelTurnResult
+  | TuttiExternalAgentActivityComposerOptions
+  | TuttiExternalAgentActivitySendResult
+  | TuttiExternalAgentActivitySnapshot
+  | TuttiExternalAgentTargetCatalog
   | TuttiExternalAtQueryResult[]
   | TuttiExternalAtResolveResult
   | TuttiExternalFileSelectResult
@@ -839,6 +863,16 @@ export interface DesktopInvokePayloadByChannel {
     | undefined;
   [desktopIpcChannels.appContext.get]: undefined;
   [desktopIpcChannels.appExternal.activityReportActive]: undefined;
+  [desktopIpcChannels.appExternal
+    .agentActivityActivateSession]: TuttiExternalAgentActivityActivateSessionInput;
+  [desktopIpcChannels.appExternal
+    .agentActivityCancelTurn]: TuttiExternalAgentActivityCancelTurnInput;
+  [desktopIpcChannels.appExternal
+    .agentActivityGetComposerOptions]: TuttiExternalAgentActivityComposerOptionsInput;
+  [desktopIpcChannels.appExternal.agentActivityGetSnapshot]: undefined;
+  [desktopIpcChannels.appExternal.agentActivityListTargets]: undefined;
+  [desktopIpcChannels.appExternal
+    .agentActivitySendInput]: TuttiExternalAgentActivitySendInput;
   [desktopIpcChannels.appExternal.atQuery]: TuttiExternalAtQueryInput;
   [desktopIpcChannels.appExternal.atResolve]: TuttiExternalAtResolveInput;
   [desktopIpcChannels.appExternal.filesOpen]: TuttiExternalFileOpenInput;
@@ -995,6 +1029,18 @@ export interface DesktopInvokeResultByChannel {
     .restartDriver]: DesktopComputerUseRestartDriverResult;
   [desktopIpcChannels.appContext.get]: DesktopWorkspaceAppContext;
   [desktopIpcChannels.appExternal.activityReportActive]: void;
+  [desktopIpcChannels.appExternal
+    .agentActivityActivateSession]: TuttiExternalAgentActivityActivateSessionResult;
+  [desktopIpcChannels.appExternal
+    .agentActivityCancelTurn]: TuttiExternalAgentActivityCancelTurnResult;
+  [desktopIpcChannels.appExternal
+    .agentActivityGetComposerOptions]: TuttiExternalAgentActivityComposerOptions;
+  [desktopIpcChannels.appExternal
+    .agentActivityGetSnapshot]: TuttiExternalAgentActivitySnapshot;
+  [desktopIpcChannels.appExternal
+    .agentActivityListTargets]: TuttiExternalAgentTargetCatalog;
+  [desktopIpcChannels.appExternal
+    .agentActivitySendInput]: TuttiExternalAgentActivitySendResult;
   [desktopIpcChannels.appExternal.atQuery]: TuttiExternalAtQueryResult[];
   [desktopIpcChannels.appExternal
     .atResolve]: TuttiExternalAtResolveResult | null;

--- a/packages/workspace/external-core/README.md
+++ b/packages/workspace/external-core/README.md
@@ -10,6 +10,11 @@ trusted app APIs may read or update host workspace state directly.
 `window.tuttiExternal` currently exposes:
 
 - `app.getContext()` and `app.subscribe()` for host workspace/app context.
+- `agentActivity.*` for trusted automation apps to list exact Agent targets,
+  inspect composer options, create visible sessions, send or cancel turns, and
+  read the host-owned Activity snapshot. These calls delegate to the same
+  runtime and state used by Agent GUI; workspace apps must not create a second
+  Activity engine or provider adapter around this surface.
 - `at.query()` for host-provided mention candidates, plus optional
   `at.resolve()` and `at.subscribe()` for exact mention hydration and dirty
   invalidation.
@@ -28,6 +33,23 @@ trusted app APIs may read or update host workspace state directly.
 - `workspace.openFeature()` for user-activated host workspace navigation, such as opening the message center.
 - `logs.write()` for fire-and-forget frontend diagnostics that append to the workspace app `web.log`.
 
+## Agent Activity Automation
+
+`agentActivity` is intended for testing, orchestration, and other trusted apps
+that need to drive official Agent GUI sessions. Calls are scoped to the current
+workspace by the host; callers provide exact `agentTargetId` values returned by
+`listTargets()` and should set `visible: true` when users need to inspect the
+created sessions in Agent GUI.
+
+Supporting hosts advertise this surface as `agentActivity@1` in
+`app.getContext().capabilities`. Apps should also feature-detect the bridge when
+they need to remain usable in a normal browser or on an older host.
+
+Use `getSnapshot()` to observe session, turn, and message outcomes. The browser
+app may poll this method; the host remains the owner of synchronization and
+provider-specific transport. Apps that need an independent, app-owned Agent
+runtime should continue to use `@tutti-os/agent-acp-kit` instead.
+
 ## Rich Text At Providers
 
 Workspace apps that use `@tutti-os/ui-rich-text` should create one mention
@@ -38,7 +60,7 @@ import { createTuttiExternalRichTextMentionService } from "@tutti-os/workspace-e
 
 const mentionService = createTuttiExternalRichTextMentionService({
   getBridge: () => window.tuttiExternal,
-  providerIds: ["workspace-app", "agent-session", "agent-generated-file"]
+  providerIds: ["workspace-app", "agent-session", "agent-generated-file"],
 });
 ```
 

--- a/packages/workspace/external-core/package.json
+++ b/packages/workspace/external-core/package.json
@@ -25,6 +25,7 @@
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },
   "dependencies": {
+    "@tutti-os/agent-activity-core": "workspace:*",
     "@tutti-os/ui-rich-text": "workspace:*",
     "@tutti-os/workspace-file-reference": "workspace:*",
     "@tutti-os/workspace-user-project": "workspace:*"

--- a/packages/workspace/external-core/src/contracts/index.ts
+++ b/packages/workspace/external-core/src/contracts/index.ts
@@ -1,5 +1,14 @@
 import type { WorkspaceFileReference } from "@tutti-os/workspace-file-reference/contracts";
 import type {
+  AgentActivityActivateSessionResult,
+  AgentActivityComposerOptions,
+  AgentActivitySendInputResult,
+  AgentActivitySessionSettings,
+  AgentActivitySnapshot,
+  AgentActivityTurnCancelResponse,
+  AgentPromptContentBlock
+} from "@tutti-os/agent-activity-core";
+import type {
   WorkspaceUserProject,
   WorkspaceUserProjectDefaultSelection,
   WorkspaceUserProjectMoveInput,
@@ -214,6 +223,75 @@ export interface TuttiExternalReferenceOpenInput {
   href: string;
 }
 
+export type TuttiExternalAgentAvailabilityStatus =
+  | "ready"
+  | "checking"
+  | "coming_soon"
+  | "not_installed"
+  | "auth_required"
+  | "unavailable";
+
+export interface TuttiExternalAgentTarget {
+  agentTargetId: string;
+  availability: {
+    pendingAction?: "install" | "login" | "refresh" | null;
+    reason?: string | null;
+    status: TuttiExternalAgentAvailabilityStatus;
+  };
+  description?: string | null;
+  iconUrl: string;
+  name: string;
+  provider: string;
+}
+
+export interface TuttiExternalAgentTargetCatalog {
+  agents: TuttiExternalAgentTarget[];
+  capturedAtUnixMs: number | null;
+  error: string | null;
+  status: "idle" | "loading" | "ready" | "error";
+}
+
+export interface TuttiExternalAgentActivityComposerOptionsInput {
+  agentTargetId: string;
+  cwd?: string | null;
+  provider: string;
+  settings?: AgentActivitySessionSettings | null;
+}
+
+export interface TuttiExternalAgentActivityActivateSessionInput {
+  agentSessionId: string;
+  agentTargetId: string;
+  clientSubmitId: string;
+  cwd?: string | null;
+  initialContent: AgentPromptContentBlock[];
+  initialDisplayPrompt?: string | null;
+  settings?: AgentActivitySessionSettings;
+  title?: string;
+  visible?: boolean;
+}
+
+export interface TuttiExternalAgentActivitySendInput {
+  agentSessionId: string;
+  clientSubmitId: string;
+  content: AgentPromptContentBlock[];
+  displayPrompt?: string | null;
+  guidance?: boolean;
+}
+
+export interface TuttiExternalAgentActivityCancelTurnInput {
+  agentSessionId: string;
+  turnId: string;
+}
+
+export type TuttiExternalAgentActivityActivateSessionResult =
+  AgentActivityActivateSessionResult;
+export type TuttiExternalAgentActivityComposerOptions =
+  AgentActivityComposerOptions;
+export type TuttiExternalAgentActivitySendResult = AgentActivitySendInputResult;
+export type TuttiExternalAgentActivityCancelTurnResult =
+  AgentActivityTurnCancelResponse;
+export type TuttiExternalAgentActivitySnapshot = AgentActivitySnapshot;
+
 export interface TuttiExternalUserProjectCreateInput {
   name: string;
 }
@@ -277,6 +355,22 @@ export interface TuttiExternalBridge {
   };
   activity: {
     reportActive(): Promise<void>;
+  };
+  agentActivity: {
+    activateSession(
+      input: TuttiExternalAgentActivityActivateSessionInput
+    ): Promise<TuttiExternalAgentActivityActivateSessionResult>;
+    cancelTurn(
+      input: TuttiExternalAgentActivityCancelTurnInput
+    ): Promise<TuttiExternalAgentActivityCancelTurnResult>;
+    getComposerOptions(
+      input: TuttiExternalAgentActivityComposerOptionsInput
+    ): Promise<TuttiExternalAgentActivityComposerOptions>;
+    getSnapshot(): Promise<TuttiExternalAgentActivitySnapshot>;
+    listTargets(): Promise<TuttiExternalAgentTargetCatalog>;
+    sendInput(
+      input: TuttiExternalAgentActivitySendInput
+    ): Promise<TuttiExternalAgentActivitySendResult>;
   };
   browser: {
     openUrl(input: TuttiExternalBrowserOpenUrlInput): Promise<void>;
@@ -360,6 +454,46 @@ export interface TuttiExternalBridge {
 }
 
 export type TuttiExternalRendererRequest =
+  | {
+      appId: string;
+      input: TuttiExternalAgentActivityActivateSessionInput;
+      operation: "agentActivity.activateSession";
+      requestId: string;
+      workspaceId: string;
+    }
+  | {
+      appId: string;
+      input: TuttiExternalAgentActivityCancelTurnInput;
+      operation: "agentActivity.cancelTurn";
+      requestId: string;
+      workspaceId: string;
+    }
+  | {
+      appId: string;
+      input: TuttiExternalAgentActivityComposerOptionsInput;
+      operation: "agentActivity.getComposerOptions";
+      requestId: string;
+      workspaceId: string;
+    }
+  | {
+      appId: string;
+      operation: "agentActivity.getSnapshot";
+      requestId: string;
+      workspaceId: string;
+    }
+  | {
+      appId: string;
+      operation: "agentActivity.listTargets";
+      requestId: string;
+      workspaceId: string;
+    }
+  | {
+      appId: string;
+      input: TuttiExternalAgentActivitySendInput;
+      operation: "agentActivity.sendInput";
+      requestId: string;
+      workspaceId: string;
+    }
   | {
       appId: string;
       input: TuttiExternalAtResolveInput;

--- a/packages/workspace/external-core/src/core/index.test.ts
+++ b/packages/workspace/external-core/src/core/index.test.ts
@@ -4,6 +4,10 @@ import {
   normalizeTuttiExternalAtQueryInput,
   normalizeTuttiExternalAtResolveInput,
   normalizeTuttiExternalAtInvalidation,
+  normalizeTuttiExternalAgentActivityActivateSessionInput,
+  normalizeTuttiExternalAgentActivityCancelTurnInput,
+  normalizeTuttiExternalAgentActivityComposerOptionsInput,
+  normalizeTuttiExternalAgentActivitySendInput,
   normalizeTuttiExternalBrowserOpenUrlInput,
   normalizeTuttiExternalFileOpenInput,
   normalizeTuttiExternalFileSelectInput,
@@ -120,6 +124,130 @@ test("keeps the default provider set explicit", () => {
     "agent-session",
     "agent-generated-file"
   ]);
+});
+
+test("normalizes agent activity session inputs without dropping prompt assets", () => {
+  assert.deepEqual(
+    normalizeTuttiExternalAgentActivityActivateSessionInput({
+      agentSessionId: " session-1 ",
+      agentTargetId: " codex ",
+      clientSubmitId: " batch-1 ",
+      cwd: " /workspace/project ",
+      initialContent: [
+        { type: "text", text: "Run the provider smoke test." },
+        {
+          type: "file",
+          name: "fixture.txt",
+          path: "fixtures/fixture.txt",
+          sizeBytes: 42
+        }
+      ],
+      initialDisplayPrompt: " provider smoke test ",
+      settings: {
+        browserUse: false,
+        model: " test-model ",
+        planMode: null
+      },
+      title: " Provider Core Lab ",
+      visible: true
+    }),
+    {
+      agentSessionId: "session-1",
+      agentTargetId: "codex",
+      clientSubmitId: "batch-1",
+      cwd: "/workspace/project",
+      initialContent: [
+        { type: "text", text: "Run the provider smoke test." },
+        {
+          type: "file",
+          name: "fixture.txt",
+          path: "fixtures/fixture.txt",
+          sizeBytes: 42
+        }
+      ],
+      initialDisplayPrompt: "provider smoke test",
+      settings: {
+        browserUse: false,
+        model: "test-model",
+        planMode: null
+      },
+      title: "Provider Core Lab",
+      visible: true
+    }
+  );
+  assert.deepEqual(
+    normalizeTuttiExternalAgentActivitySendInput({
+      agentSessionId: " session-1 ",
+      clientSubmitId: " turn-2 ",
+      content: [{ type: "image", data: "base64", mimeType: "image/png" }],
+      displayPrompt: " image assertion ",
+      guidance: false
+    }),
+    {
+      agentSessionId: "session-1",
+      clientSubmitId: "turn-2",
+      content: [{ type: "image", data: "base64", mimeType: "image/png" }],
+      displayPrompt: "image assertion",
+      guidance: false
+    }
+  );
+});
+
+test("normalizes agent activity target inputs", () => {
+  assert.deepEqual(
+    normalizeTuttiExternalAgentActivityComposerOptionsInput({
+      agentTargetId: " codex ",
+      cwd: null,
+      provider: " codex ",
+      settings: null
+    }),
+    {
+      agentTargetId: "codex",
+      cwd: null,
+      provider: "codex"
+    }
+  );
+  assert.deepEqual(
+    normalizeTuttiExternalAgentActivityCancelTurnInput({
+      agentSessionId: " session-1 ",
+      turnId: " turn-1 "
+    }),
+    { agentSessionId: "session-1", turnId: "turn-1" }
+  );
+});
+
+test("rejects malformed agent activity inputs", () => {
+  assert.throws(
+    () =>
+      normalizeTuttiExternalAgentActivityActivateSessionInput({
+        agentSessionId: "session-1",
+        agentTargetId: "codex",
+        clientSubmitId: "batch-1",
+        initialContent: [],
+        visible: true
+      }),
+    /initialContent must be a non-empty array/
+  );
+  assert.throws(
+    () =>
+      normalizeTuttiExternalAgentActivitySendInput({
+        agentSessionId: "session-1",
+        clientSubmitId: "turn-2",
+        content: [{ type: "file", sizeBytes: -1 }]
+      }),
+    /sizeBytes must be a non-negative number/
+  );
+  assert.throws(
+    () =>
+      normalizeTuttiExternalAgentActivityActivateSessionInput({
+        agentSessionId: "session-1",
+        agentTargetId: "codex",
+        clientSubmitId: "batch-1",
+        initialContent: [{ type: "text", text: "test" }],
+        visible: "yes"
+      }),
+    /visible must be a boolean/
+  );
 });
 
 test("normalizes browser open URL input", () => {

--- a/packages/workspace/external-core/src/core/index.ts
+++ b/packages/workspace/external-core/src/core/index.ts
@@ -3,6 +3,10 @@ import {
   tuttiExternalAtProviderIds,
   tuttiExternalWorkspaceAgentProviders,
   type TuttiExternalAtProviderId,
+  type TuttiExternalAgentActivityActivateSessionInput,
+  type TuttiExternalAgentActivityCancelTurnInput,
+  type TuttiExternalAgentActivityComposerOptionsInput,
+  type TuttiExternalAgentActivitySendInput,
   type TuttiExternalAtQueryInput,
   type TuttiExternalAtResolveInput,
   type TuttiExternalAtInvalidation,
@@ -153,6 +157,113 @@ export function normalizeTuttiExternalAtInvalidation(
     ...(providerIds ? { providerIds } : {}),
     ...(entityIds ? { entityIds } : {}),
     ...(typeof input.revision === "number" ? { revision: input.revision } : {})
+  };
+}
+
+export function normalizeTuttiExternalAgentActivityActivateSessionInput(
+  input: unknown
+): TuttiExternalAgentActivityActivateSessionInput {
+  if (!isRecord(input)) {
+    throw new Error("agentActivity.activateSession input must be an object.");
+  }
+  return {
+    agentSessionId: normalizeRequiredString(
+      input.agentSessionId,
+      "agentActivity.activateSession agentSessionId"
+    ),
+    agentTargetId: normalizeRequiredString(
+      input.agentTargetId,
+      "agentActivity.activateSession agentTargetId"
+    ),
+    clientSubmitId: normalizeRequiredString(
+      input.clientSubmitId,
+      "agentActivity.activateSession clientSubmitId"
+    ),
+    ...normalizeAgentActivityOptionalString(input.cwd, "cwd"),
+    initialContent: normalizeAgentActivityContent(
+      input.initialContent,
+      "agentActivity.activateSession initialContent"
+    ),
+    ...normalizeAgentActivityOptionalString(
+      input.initialDisplayPrompt,
+      "initialDisplayPrompt",
+      true
+    ),
+    ...(input.settings === undefined || input.settings === null
+      ? {}
+      : { settings: normalizeAgentActivitySettings(input.settings) }),
+    ...normalizeAgentActivityTitle(input.title),
+    ...normalizeAgentActivityVisible(input.visible)
+  };
+}
+
+export function normalizeTuttiExternalAgentActivityCancelTurnInput(
+  input: unknown
+): TuttiExternalAgentActivityCancelTurnInput {
+  if (!isRecord(input)) {
+    throw new Error("agentActivity.cancelTurn input must be an object.");
+  }
+  return {
+    agentSessionId: normalizeRequiredString(
+      input.agentSessionId,
+      "agentActivity.cancelTurn agentSessionId"
+    ),
+    turnId: normalizeRequiredString(
+      input.turnId,
+      "agentActivity.cancelTurn turnId"
+    )
+  };
+}
+
+export function normalizeTuttiExternalAgentActivityComposerOptionsInput(
+  input: unknown
+): TuttiExternalAgentActivityComposerOptionsInput {
+  if (!isRecord(input)) {
+    throw new Error(
+      "agentActivity.getComposerOptions input must be an object."
+    );
+  }
+  return {
+    agentTargetId: normalizeRequiredString(
+      input.agentTargetId,
+      "agentActivity.getComposerOptions agentTargetId"
+    ),
+    ...normalizeAgentActivityOptionalString(input.cwd, "cwd"),
+    provider: normalizeRequiredString(
+      input.provider,
+      "agentActivity.getComposerOptions provider"
+    ),
+    ...(input.settings === undefined || input.settings === null
+      ? {}
+      : { settings: normalizeAgentActivitySettings(input.settings) })
+  };
+}
+
+export function normalizeTuttiExternalAgentActivitySendInput(
+  input: unknown
+): TuttiExternalAgentActivitySendInput {
+  if (!isRecord(input)) {
+    throw new Error("agentActivity.sendInput input must be an object.");
+  }
+  return {
+    agentSessionId: normalizeRequiredString(
+      input.agentSessionId,
+      "agentActivity.sendInput agentSessionId"
+    ),
+    clientSubmitId: normalizeRequiredString(
+      input.clientSubmitId,
+      "agentActivity.sendInput clientSubmitId"
+    ),
+    content: normalizeAgentActivityContent(
+      input.content,
+      "agentActivity.sendInput content"
+    ),
+    ...normalizeAgentActivityOptionalString(
+      input.displayPrompt,
+      "displayPrompt",
+      true
+    ),
+    ...(typeof input.guidance === "boolean" ? { guidance: input.guidance } : {})
   };
 }
 
@@ -725,6 +836,265 @@ function isFileUploadAbortSignal(value: unknown): value is AbortSignal {
     typeof value.addEventListener === "function" &&
     typeof value.removeEventListener === "function"
   );
+}
+
+type AgentActivityOptionalStringKey =
+  | "cwd"
+  | "displayPrompt"
+  | "initialDisplayPrompt";
+
+function normalizeAgentActivityOptionalString<
+  TKey extends AgentActivityOptionalStringKey
+>(
+  value: unknown,
+  key: TKey,
+  preserveEmpty = false
+): Partial<Record<TKey, string | null>> {
+  if (value === undefined) {
+    return {};
+  }
+  if (value === null) {
+    return { [key]: null } as Partial<Record<TKey, string | null>>;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`agentActivity ${key} must be a string.`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed && !preserveEmpty) {
+    return {};
+  }
+  return { [key]: trimmed } as Partial<Record<TKey, string | null>>;
+}
+
+function normalizeAgentActivityTitle(
+  value: unknown
+): Partial<Pick<TuttiExternalAgentActivityActivateSessionInput, "title">> {
+  if (value === undefined) {
+    return {};
+  }
+  if (typeof value !== "string") {
+    throw new Error("agentActivity title must be a string.");
+  }
+  const title = value.trim();
+  return title ? { title } : {};
+}
+
+function normalizeAgentActivityVisible(
+  value: unknown
+): Partial<Pick<TuttiExternalAgentActivityActivateSessionInput, "visible">> {
+  if (value === undefined) {
+    return {};
+  }
+  if (typeof value !== "boolean") {
+    throw new Error("agentActivity visible must be a boolean.");
+  }
+  return { visible: value };
+}
+
+function normalizeAgentActivityContent(
+  value: unknown,
+  field: string
+): TuttiExternalAgentActivitySendInput["content"] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${field} must be a non-empty array.`);
+  }
+  return value.map((entry, index) => {
+    if (!isRecord(entry)) {
+      throw new Error(`${field}[${index}] must be an object.`);
+    }
+    if (
+      entry.type !== "text" &&
+      entry.type !== "image" &&
+      entry.type !== "file" &&
+      entry.type !== "skill" &&
+      entry.type !== "mention"
+    ) {
+      throw new Error(`${field}[${index}] type is unsupported.`);
+    }
+    return {
+      type: entry.type,
+      ...normalizeAgentActivityContentBlockString(
+        entry.text,
+        "text",
+        field,
+        index
+      ),
+      ...normalizeAgentActivityContentBlockString(
+        entry.mimeType,
+        "mimeType",
+        field,
+        index
+      ),
+      ...normalizeAgentActivityContentBlockString(
+        entry.data,
+        "data",
+        field,
+        index
+      ),
+      ...normalizeAgentActivityContentBlockString(
+        entry.url,
+        "url",
+        field,
+        index
+      ),
+      ...normalizeAgentActivityContentBlockString(
+        entry.attachmentId,
+        "attachmentId",
+        field,
+        index
+      ),
+      ...normalizeAgentActivityContentBlockString(
+        entry.name,
+        "name",
+        field,
+        index
+      ),
+      ...normalizeAgentActivityContentBlockString(
+        entry.path,
+        "path",
+        field,
+        index
+      ),
+      ...normalizeAgentActivityContentBlockString(
+        entry.uri,
+        "uri",
+        field,
+        index
+      ),
+      ...normalizeAgentActivityContentBlockString(
+        entry.hostPath,
+        "hostPath",
+        field,
+        index
+      ),
+      ...normalizeAgentActivityContentBlockString(
+        entry.uploadStatus,
+        "uploadStatus",
+        field,
+        index
+      ),
+      ...normalizeAgentActivityContentBlockString(
+        entry.assetId,
+        "assetId",
+        field,
+        index
+      ),
+      ...normalizeAgentActivityContentBlockString(
+        entry.kind,
+        "kind",
+        field,
+        index
+      ),
+      ...normalizeAgentActivityContentBlockSize(entry.sizeBytes, field, index)
+    };
+  });
+}
+
+type AgentActivityContentBlockStringKey =
+  | "assetId"
+  | "attachmentId"
+  | "data"
+  | "hostPath"
+  | "kind"
+  | "mimeType"
+  | "name"
+  | "path"
+  | "text"
+  | "uploadStatus"
+  | "uri"
+  | "url";
+
+function normalizeAgentActivityContentBlockString<
+  TKey extends AgentActivityContentBlockStringKey
+>(
+  value: unknown,
+  key: TKey,
+  field: string,
+  index: number
+): Partial<Record<TKey, string>> {
+  if (value === undefined) {
+    return {};
+  }
+  if (typeof value !== "string") {
+    throw new Error(`${field}[${index}] ${key} must be a string.`);
+  }
+  return { [key]: value } as Partial<Record<TKey, string>>;
+}
+
+function normalizeAgentActivityContentBlockSize(
+  value: unknown,
+  field: string,
+  index: number
+): { sizeBytes?: number } {
+  if (value === undefined) {
+    return {};
+  }
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(
+      `${field}[${index}] sizeBytes must be a non-negative number.`
+    );
+  }
+  return { sizeBytes: value };
+}
+
+function normalizeAgentActivitySettings(
+  value: unknown
+): NonNullable<TuttiExternalAgentActivityActivateSessionInput["settings"]> {
+  if (!isRecord(value)) {
+    throw new Error("agentActivity settings must be an object.");
+  }
+  return {
+    ...normalizeAgentActivityNullableSetting(value.model, "model"),
+    ...normalizeAgentActivityNullableSetting(
+      value.permissionModeId,
+      "permissionModeId"
+    ),
+    ...normalizeAgentActivityNullableBoolean(value.planMode, "planMode"),
+    ...normalizeAgentActivityNullableBoolean(value.browserUse, "browserUse"),
+    ...normalizeAgentActivityNullableBoolean(value.computerUse, "computerUse"),
+    ...normalizeAgentActivityNullableSetting(
+      value.reasoningEffort,
+      "reasoningEffort"
+    ),
+    ...normalizeAgentActivityNullableSetting(value.speed, "speed")
+  };
+}
+
+type AgentActivityStringSettingKey =
+  | "model"
+  | "permissionModeId"
+  | "reasoningEffort"
+  | "speed";
+
+function normalizeAgentActivityNullableSetting(
+  value: unknown,
+  key: AgentActivityStringSettingKey
+): Partial<Record<AgentActivityStringSettingKey, string | null>> {
+  if (value === undefined) {
+    return {};
+  }
+  if (value === null) {
+    return { [key]: null };
+  }
+  if (typeof value !== "string") {
+    throw new Error(`agentActivity settings.${key} must be a string.`);
+  }
+  return { [key]: value.trim() || null };
+}
+
+type AgentActivityBooleanSettingKey = "browserUse" | "computerUse" | "planMode";
+
+function normalizeAgentActivityNullableBoolean(
+  value: unknown,
+  key: AgentActivityBooleanSettingKey
+): Partial<Record<AgentActivityBooleanSettingKey, boolean | null>> {
+  if (value === undefined) {
+    return {};
+  }
+  if (value === null || typeof value === "boolean") {
+    return { [key]: value };
+  }
+  throw new Error(`agentActivity settings.${key} must be a boolean.`);
 }
 
 function normalizeOptionalTrimmedString(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -822,6 +822,9 @@ importers:
 
   packages/workspace/external-core:
     dependencies:
+      "@tutti-os/agent-activity-core":
+        specifier: workspace:*
+        version: link:../../agent/activity-core
       "@tutti-os/ui-rich-text":
         specifier: workspace:*
         version: link:../../ui/rich-text

--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -144,7 +144,14 @@ For a full agent-enabled app repository, prefer `$tutti-agent-workspace-app` fir
 
 Agent app main flows must call `loadTuttiAgentCatalog` and lazy `loadTuttiAgentComposerOptions` from `@tutti-os/agent-acp-kit/tutti`. Do not use the deprecated provider-catalog projection because it cannot represent multiple agents sharing a provider. The kit automatically uses `TUTTI_CLI` inside Tutti and standalone runtime detection when the CLI is absent. App code must not pass a mode, app ID, daemon URL, token, provider alias map, or CLI arguments. Follow `$tutti-agent-workspace-app` and its `references/dynamic-agent-providers.md`. Show every returned agent, persist exact agent target ids, keep unavailable agents disabled with a reason, and treat provider as derived runtime metadata. A configured CLI failure is explicit; never synthesize a fixed catalog.
 
-Do not assume a Tutti API token, browser extension, daemon internals, or broad desktop APIs. The only browser-side host surface a generated app may optionally consume is the app context described in `references/runtime-env.md`.
+Do not assume a Tutti API token, browser extension, daemon internals, or
+undocumented desktop APIs. Generated apps may consume the documented
+`window.tuttiExternal` browser surfaces described in `references/runtime-env.md`.
+Use `agentActivity` only when the app intentionally orchestrates the official
+host-owned Agent GUI runtime, such as a provider test lab; do not use it to
+rebuild an app-owned Agent runtime. Apps that own their Agent policy or runtime
+must still follow `$tutti-agent-workspace-app` and
+`@tutti-os/agent-acp-kit`.
 
 ## Dependency Rules
 

--- a/services/tuttid/service/workspace/app_factory_reference/references/runtime-env.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/runtime-env.md
@@ -63,7 +63,41 @@ function subscribeHostLocale(listener) {
 }
 ```
 
-`subscribe` replays the latest context after registration, so apps do not need host-injected DOM events for initial locale delivery. Agent lists, default agent selection, and Agent composer options are not part of browser external context. Agent-enabled apps should expose an app-owned backend endpoint whose implementation calls `@tutti-os/agent-acp-kit/tutti`; the kit automatically uses `TUTTI_CLI` inside Tutti and standalone runtime discovery outside it. App code must not spawn or parse the Agent CLI itself. Follow `$tutti-agent-workspace-app` and its `references/dynamic-agent-providers.md`. The browser context remains optional so generated apps continue to run in a normal browser during development.
+`subscribe` replays the latest context after registration, so apps do not need host-injected DOM events for initial locale delivery. The browser context remains optional so generated apps continue to run in a normal browser during development.
+
+## Browser Agent Activity Automation
+
+Trusted automation apps may use `window.tuttiExternal.agentActivity` to drive
+the official host-owned Agent GUI runtime. This is the correct surface for an
+app that batches provider tests and observes the same sessions, turns, and
+messages shown in Agent GUI. It is not a general replacement for an app-owned
+Agent runtime.
+
+Supporting hosts advertise `agentActivity@1` through
+`app.getContext().capabilities`; keep bridge feature detection for normal-browser
+development and older hosts.
+
+The surface provides:
+
+- `listTargets()` for exact host target IDs and availability.
+- `getComposerOptions(input)` for target-specific composer capabilities.
+- `activateSession(input)` for creating a visible Agent GUI session.
+- `sendInput(input)` and `cancelTurn(input)` for subsequent turn control.
+- `getSnapshot()` for the current workspace Activity snapshot.
+
+The host injects the current workspace ID and ignores workspace identities from
+app input. Use exact `agentTargetId` values from `listTargets()` and set
+`visible: true` for sessions users should inspect. The app may poll
+`getSnapshot()` to aggregate terminal turn outcomes and message failures; it
+must not add a second Activity engine, provider adapter, or provider-specific
+transport.
+
+Apps that own Agent policy, run an independent local Agent, or need app-owned
+MCP/tool gateways should instead expose an app backend using
+`@tutti-os/agent-acp-kit/tutti`. The kit automatically uses `TUTTI_CLI` inside
+Tutti and standalone runtime discovery outside it. App code must not spawn or
+parse the Agent CLI itself. Follow `$tutti-agent-workspace-app` and its
+`references/dynamic-agent-providers.md`.
 
 For theme, use CSS media queries and `matchMedia`:
 
@@ -99,7 +133,7 @@ const uploaded = await window.tuttiExternal?.files?.upload?.(file, {
   onProgress(progress) {
     console.log(progress.loadedBytes, progress.totalBytes, progress.ratio);
   },
-  signal: abortController.signal
+  signal: abortController.signal,
 });
 ```
 
@@ -119,7 +153,7 @@ When a workspace app runs inside Tutti Desktop, prefer writing browser-side diag
 window.tuttiExternal?.logs?.write?.({
   event: "page.loaded",
   level: "info",
-  details: { route: location.pathname }
+  details: { route: location.pathname },
 });
 ```
 


### PR DESCRIPTION
## Summary

- expose a trusted workspace-app Agent Activity bridge for exact target discovery, composer options, visible session activation, follow-up input, exact-turn cancellation, and snapshot observation
- delegate every operation to the existing workspace Agent Activity service used by Agent GUI
- advertise the versioned agentActivity@1 capability and document the app-development boundary

## Architecture

This is a transport and public workspace-app contract change. It does not define session or turn lifecycle semantics; Tutti Desktop and downstream TSH adapters delegate to the existing AgentActivityRuntime/Agent Activity service. TSH needs a host adapter for its VM-owned runtime, but no lifecycle implementation is copied downstream.

## Validation

- pnpm check:changed -- --push-ready
- desktop typecheck, build, full test suite, Electron runtime boundary, renderer boundary, and external-core tests completed during implementation

## Documentation impact

Updated the workspace external-core README and workspace app factory runtime guidance to document host-owned Agent GUI automation versus an app-owned Agent runtime.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->