### PR TITLE
fix(agent-gui): expose host tool header dragging

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -367,7 +367,7 @@ AgentGUI, Message Center, dock/header, workspace window, and standalone Agent wi
 
 Opening a panel/window creates presentation state only. It does not clone a Session, copy engine entities, or start another event stream. Standalone tools are Desktop chrome, not AgentGUI lifecycle.
 
-The reusable standalone-tool sidebar contract lives in `packages/agent/gui/workbench/tool-sidebar`. Hosts provide the supported panel catalog and render adapters; the shared component owns tab selection, picker, sizing, and toolbar mechanics. The open panel header keeps its blank surface draggable in native and Workbench hosts, while tab buttons, close actions, and toolbar controls explicitly remain non-drag regions.
+The reusable standalone-tool sidebar contract lives in `packages/agent/gui/workbench/tool-sidebar`. Hosts provide the supported panel catalog and render adapters; the shared component owns tab selection, picker, sizing, toolbar mechanics, and the boundary between draggable header space and interactive controls. Native Electron hosts keep the default native-window drag mode, while embedded Workbench hosts select host drag mode and provide their pointer and double-click handlers. The shared component disables native app-region handling in host mode so one header never has two competing drag owners.
 
 ## 7. Key flows
 

--- a/docs/plans/2026-07-18-agent-tool-sidebar-host-drag.md
+++ b/docs/plans/2026-07-18-agent-tool-sidebar-host-drag.md
@@ -1,0 +1,63 @@
+# Agent Tool Sidebar Host Drag Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let the shared Agent tool-sidebar header support both native Electron window dragging and host-owned Workbench dragging without downstream DOM wrappers or duplicated control rules.
+
+**Architecture:** `@tutti-os/agent-gui` remains the single owner of the tool sidebar and its interactive header boundaries. It exposes one explicit header-drag configuration that selects native-window or host behavior and accepts host pointer/double-click handlers. Tutti Desktop keeps the default native behavior; TSH selects host behavior and routes the events through its existing Workbench drag forwarding primitive.
+
+**Tech Stack:** React 19, TypeScript, Vitest, Testing Library, pnpm fixed npm release cohort.
+
+---
+
+### Task 1: Add the shared drag contract
+
+**Files:**
+
+- Modify: `packages/agent/gui/workbench/tool-sidebar/AgentToolSidebar.tsx`
+- Test: `packages/agent/gui/workbench/tool-sidebar/AgentToolSidebar.test.tsx`
+
+1. Add a failing test proving host mode removes the native Electron drag region, forwards blank-header pointer and double-click events, and does not forward control gestures.
+2. Run `pnpm --filter @tutti-os/agent-gui test -- AgentToolSidebar.test.tsx` and confirm the new contract is missing.
+3. Add a narrow `headerDrag` prop with `native-window` and `host` modes plus optional pointer/double-click handlers.
+4. Keep `native-window` as the default so the existing standalone consumer reuses the same component unchanged.
+5. Run the focused package test and `pnpm --filter @tutti-os/agent-gui typecheck`.
+
+### Task 2: Validate and publish the Tutti cohort
+
+**Files:**
+
+- Modify only release-generated manifests during the official release workflow; do not hand-edit package versions.
+
+1. Run `pnpm check:changed` and `pnpm release:pack:check`.
+2. Commit with DCO sign-off and open a focused PR from `fix/agent-tool-sidebar-host-drag`.
+3. Merge the PR, then dispatch the stable package release workflow on `main`.
+4. Confirm every fixed-group package exists at the new shared version before downstream changes.
+
+### Task 3: Replace the TSH temporary bridge
+
+**Files:**
+
+- Modify: `apps/tsh-desktop/src/app/renderer/features/workspace-agent/ui/agentToolSidebar/TshAgentToolSidebar.tsx`
+- Modify: `apps/tsh-desktop/src/app/renderer/features/workspace-workbench/services/internal/workspaceWorkbenchWindowHeaders.ts`
+- Modify/Test: focused Workbench and Agent tool-sidebar specs
+- Delete: `apps/tsh-desktop/src/app/renderer/features/workspace-agent/ui/agentToolSidebar/TshAgentToolSidebarHeaderDragBridge.tsx`
+- Delete: `apps/tsh-desktop/src/app/renderer/features/workspace-agent/ui/agentToolSidebar/TshAgentToolSidebarHeaderDragBridge.spec.tsx`
+
+1. Extract the existing Workbench pointer/double-click forwarding code into reusable host helpers with regression tests.
+2. Pass the helpers to the upstream `headerDrag` host contract from `TshAgentToolSidebar`.
+3. Delete the temporary wrapper and selector-specific CSS override.
+4. Run focused Vitest suites and `pnpm --dir apps/tsh-desktop check`.
+
+### Task 4: Upgrade and assess the dependency cohort
+
+**Files:**
+
+- Modify with package-manager commands: TSH manifests and `pnpm-lock.yaml`
+- Modify with Go tooling when the release cohort changes selected Go modules: `go.mod`, `go.sum`
+- Modify: `.github/tutti-dependency-assessment.json`
+
+1. Upgrade all `@tutti-os/*` and Tutti Go module cohort members to the same stable release.
+2. Record whether sibling `tsh-server` can keep its current cohort because this change is renderer-only.
+3. Run `pnpm check:tutti-dependencies`, `pnpm check:tutti-dependencies:graph`, `pnpm test:tutti-dependencies`, and the relevant desktop checks.
+4. Confirm development HMR is sufficient; packaged builds require an application restart but no desktopd/VM restart.

--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolSidebar.test.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolSidebar.test.tsx
@@ -177,22 +177,26 @@ describe("AgentToolSidebar", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps blank panel-header space draggable while controls remain interactive", () => {
+  it("routes host-owned panel-header drag gestures while controls remain interactive", () => {
+    const handleDoubleClick = vi.fn();
     const handlePointerDown = vi.fn();
     const { container } = render(
-      <div onPointerDown={handlePointerDown}>
-        <AgentToolSidebar
-          containerWidth={900}
-          copy={copy}
-          headerPlacement="panel"
-          panels={panels}
-          renderHeader={(actions) => <div>{actions}</div>}
-          renderPanel={({ tab }) => <div>{tab.panel} content</div>}
-          resizeContainerContentWidth={async (width) => ({ width })}
-        >
-          <main>Agent content</main>
-        </AgentToolSidebar>
-      </div>
+      <AgentToolSidebar
+        containerWidth={900}
+        copy={copy}
+        headerDrag={{
+          mode: "host",
+          onDoubleClick: handleDoubleClick,
+          onPointerDown: handlePointerDown
+        }}
+        headerPlacement="panel"
+        panels={panels}
+        renderHeader={(actions) => <div>{actions}</div>}
+        renderPanel={({ tab }) => <div>{tab.panel} content</div>}
+        resizeContainerContentWidth={async (width) => ({ width })}
+      >
+        <main>Agent content</main>
+      </AgentToolSidebar>
     );
 
     fireEvent.click(screen.getByLabelText("Open right panel"));
@@ -213,15 +217,35 @@ describe("AgentToolSidebar", () => {
       "true"
     );
     expect(header).not.toHaveClass("nodrag");
-    expect(header?.className).toContain("[-webkit-app-region:drag]");
+    expect(header?.className).toContain("[-webkit-app-region:no-drag]");
+    expect(header?.className).not.toContain("[-webkit-app-region:drag]");
     expect(tabList).not.toHaveClass("nodrag");
-    expect(tabList?.className).toContain("[-webkit-app-region:drag]");
+    expect(tabList?.className).not.toContain("[-webkit-app-region:drag]");
     expect(screen.getByRole("tab", { name: "Files" })).toHaveClass("nodrag");
     expect(toolbar).toHaveClass("nodrag");
 
-    handlePointerDown.mockClear();
     fireEvent.pointerDown(tabList as HTMLElement);
+    fireEvent.doubleClick(tabList as HTMLElement);
     expect(handlePointerDown).toHaveBeenCalledOnce();
+    expect(handleDoubleClick).toHaveBeenCalledOnce();
+
+    fireEvent.pointerDown(screen.getByRole("tab", { name: "Files" }));
+    fireEvent.doubleClick(screen.getByRole("tab", { name: "Files" }));
+    fireEvent.pointerDown(toolbar as HTMLElement);
+    fireEvent.doubleClick(toolbar as HTMLElement);
+
+    expect(handlePointerDown).toHaveBeenCalledOnce();
+    expect(handleDoubleClick).toHaveBeenCalledOnce();
+  });
+
+  it("keeps native-window header dragging as the default", () => {
+    const { container } = renderSidebar();
+    const header = container.querySelector(
+      '[data-standalone-agent-tool-sidebar-header="true"]'
+    );
+
+    expect(header?.className).toContain("[-webkit-app-region:drag]");
+    expect(header?.className).not.toContain("[-webkit-app-region:no-drag]");
   });
 });
 

--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolSidebar.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolSidebar.tsx
@@ -2,6 +2,8 @@ import {
   forwardRef,
   useImperativeHandle,
   type CSSProperties,
+  type MouseEventHandler,
+  type PointerEventHandler,
   type ReactNode
 } from "react";
 import { CloseIcon, cn } from "@tutti-os/ui-system";
@@ -27,10 +29,19 @@ export interface AgentToolSidebarHandle {
   openPanel(panel: AgentToolPanelId, resourceId?: string): string | null;
 }
 
+export type AgentToolSidebarHeaderDrag =
+  | { mode?: "native-window" }
+  | {
+      mode: "host";
+      onDoubleClick?: MouseEventHandler<HTMLDivElement>;
+      onPointerDown?: PointerEventHandler<HTMLDivElement>;
+    };
+
 export interface AgentToolSidebarProps {
   children: ReactNode;
   containerWidth: number;
   copy: AgentToolSidebarCopy;
+  headerDrag?: AgentToolSidebarHeaderDrag;
   headerPlacement?: "inline" | "external" | "panel";
   mainContentMinWidthPx?: number;
   panels: readonly AgentToolPanelDefinition[];
@@ -64,6 +75,7 @@ export const AgentToolSidebar = forwardRef<
     children,
     containerWidth,
     copy,
+    headerDrag,
     headerPlacement = "inline",
     mainContentMinWidthPx,
     panels: unfilteredPanels,
@@ -139,10 +151,37 @@ export const AgentToolSidebar = forwardRef<
     [addPanel, closePanel, closePanelTab, openPanel]
   );
 
+  const isHostHeaderDrag = headerDrag?.mode === "host";
+  const handleHeaderDoubleClick: MouseEventHandler<HTMLDivElement> = (
+    event
+  ) => {
+    if (isAgentToolSidebarHeaderControl(event.target)) {
+      event.stopPropagation();
+      return;
+    }
+    if (headerDrag?.mode === "host") {
+      headerDrag.onDoubleClick?.(event);
+    }
+  };
+  const handleHeaderPointerDown: PointerEventHandler<HTMLDivElement> = (
+    event
+  ) => {
+    if (isAgentToolSidebarHeaderControl(event.target)) {
+      event.stopPropagation();
+      return;
+    }
+    if (headerDrag?.mode === "host") {
+      headerDrag.onPointerDown?.(event);
+    }
+  };
+
   const toolActions = (
     <div
       className={cn(
-        "flex h-[var(--agent-gui-workbench-header-height,44px)] min-w-0 max-w-full shrink-0 cursor-grab items-center pr-[var(--agent-gui-workbench-header-padding-x)] active:cursor-grabbing [-webkit-app-region:drag]",
+        "flex h-[var(--agent-gui-workbench-header-height,44px)] min-w-0 max-w-full shrink-0 cursor-grab items-center pr-[var(--agent-gui-workbench-header-padding-x)] active:cursor-grabbing",
+        isHostHeaderDrag
+          ? "[-webkit-app-region:no-drag]"
+          : "[-webkit-app-region:drag]",
         isSidebarOpen && "border-b border-[var(--border-1)]"
       )}
       data-standalone-agent-tool-sidebar-drag-region="true"
@@ -153,6 +192,8 @@ export const AgentToolSidebar = forwardRef<
           ? { width: `${activePanelWidth}px`, maxWidth: "100%" }
           : undefined
       }
+      onDoubleClick={isHostHeaderDrag ? handleHeaderDoubleClick : undefined}
+      onPointerDown={isHostHeaderDrag ? handleHeaderPointerDown : undefined}
     >
       {activeTabId ? (
         <ToolSidebarTabBar
@@ -344,7 +385,7 @@ function ToolSidebarTabBar({
   return (
     <div
       aria-label={copy.tool}
-      className="flex h-[var(--agent-gui-workbench-header-height,44px)] min-w-0 flex-1 cursor-grab items-center gap-1 overflow-hidden px-2 active:cursor-grabbing [-webkit-app-region:drag]"
+      className="flex h-[var(--agent-gui-workbench-header-height,44px)] min-w-0 flex-1 cursor-grab items-center gap-1 overflow-hidden px-2 active:cursor-grabbing"
       data-standalone-agent-tool-tab-list="true"
       role="tablist"
     >
@@ -393,5 +434,14 @@ function ToolSidebarTabBar({
         })}
       </div>
     </div>
+  );
+}
+
+function isAgentToolSidebarHeaderControl(target: EventTarget | null): boolean {
+  return (
+    target instanceof Element &&
+    target.closest(
+      '.nodrag, button, a, input, textarea, select, option, [role="button"], [role="menuitem"], [contenteditable="true"]'
+    ) !== null
   );
 }


### PR DESCRIPTION
## Summary

- add an explicit native-window/host drag contract to the shared Agent tool sidebar
- keep native Electron dragging as the default while letting embedded Workbench hosts supply pointer and double-click handlers
- centralize the interactive-control boundary in the shared sidebar so downstream hosts do not need DOM wrappers or duplicate selectors
- document the single-owner header drag model

## Verification

- `pnpm --filter @tutti-os/agent-gui exec vitest run workbench/tool-sidebar/AgentToolSidebar.test.tsx --environment jsdom --maxWorkers=1`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/agent-gui build`
- `pnpm --filter @tutti-os/agent-gui test`
- `pnpm check:changed --tail-lines 120`
- `pnpm release:pack:check`

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (Not applicable: presentation-only contract.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (Not applicable.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->