### PR TITLE
fix(agent-gui): isolate host tool header gestures

### DIFF
--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolSidebar.test.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolSidebar.test.tsx
@@ -179,24 +179,31 @@ describe("AgentToolSidebar", () => {
 
   it("routes host-owned panel-header drag gestures while controls remain interactive", () => {
     const handleDoubleClick = vi.fn();
+    const handleParentDoubleClick = vi.fn();
+    const handleParentPointerDown = vi.fn();
     const handlePointerDown = vi.fn();
     const { container } = render(
-      <AgentToolSidebar
-        containerWidth={900}
-        copy={copy}
-        headerDrag={{
-          mode: "host",
-          onDoubleClick: handleDoubleClick,
-          onPointerDown: handlePointerDown
-        }}
-        headerPlacement="panel"
-        panels={panels}
-        renderHeader={(actions) => <div>{actions}</div>}
-        renderPanel={({ tab }) => <div>{tab.panel} content</div>}
-        resizeContainerContentWidth={async (width) => ({ width })}
+      <div
+        onDoubleClick={handleParentDoubleClick}
+        onPointerDown={handleParentPointerDown}
       >
-        <main>Agent content</main>
-      </AgentToolSidebar>
+        <AgentToolSidebar
+          containerWidth={900}
+          copy={copy}
+          headerDrag={{
+            mode: "host",
+            onDoubleClick: handleDoubleClick,
+            onPointerDown: handlePointerDown
+          }}
+          headerPlacement="panel"
+          panels={panels}
+          renderHeader={(actions) => <div>{actions}</div>}
+          renderPanel={({ tab }) => <div>{tab.panel} content</div>}
+          resizeContainerContentWidth={async (width) => ({ width })}
+        >
+          <main>Agent content</main>
+        </AgentToolSidebar>
+      </div>
     );
 
     fireEvent.click(screen.getByLabelText("Open right panel"));
@@ -228,6 +235,8 @@ describe("AgentToolSidebar", () => {
     fireEvent.doubleClick(tabList as HTMLElement);
     expect(handlePointerDown).toHaveBeenCalledOnce();
     expect(handleDoubleClick).toHaveBeenCalledOnce();
+    expect(handleParentPointerDown).not.toHaveBeenCalled();
+    expect(handleParentDoubleClick).not.toHaveBeenCalled();
 
     fireEvent.pointerDown(screen.getByRole("tab", { name: "Files" }));
     fireEvent.doubleClick(screen.getByRole("tab", { name: "Files" }));
@@ -236,6 +245,8 @@ describe("AgentToolSidebar", () => {
 
     expect(handlePointerDown).toHaveBeenCalledOnce();
     expect(handleDoubleClick).toHaveBeenCalledOnce();
+    expect(handleParentPointerDown).not.toHaveBeenCalled();
+    expect(handleParentDoubleClick).not.toHaveBeenCalled();
   });
 
   it("keeps native-window header dragging as the default", () => {

--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolSidebar.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolSidebar.tsx
@@ -160,6 +160,7 @@ export const AgentToolSidebar = forwardRef<
       return;
     }
     if (headerDrag?.mode === "host") {
+      event.stopPropagation();
       headerDrag.onDoubleClick?.(event);
     }
   };
@@ -171,6 +172,7 @@ export const AgentToolSidebar = forwardRef<
       return;
     }
     if (headerDrag?.mode === "host") {
+      event.stopPropagation();
       headerDrag.onPointerDown?.(event);
     }
   };


### PR DESCRIPTION
## Summary

- stop host-mode tool-header pointer and double-click gestures after the shared sidebar invokes its explicit host handler
- keep projected tool headers from bubbling the same gesture into a containing Workbench header and starting a second drag owner
- extend the shared sidebar regression test to prove blank areas route once and controls route zero times even inside another header handler

## Verification

- `pnpm --filter @tutti-os/agent-gui exec vitest run workbench/tool-sidebar/AgentToolSidebar.test.tsx --environment jsdom --maxWorkers=1`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:changed --tail-lines 120`
- `pnpm release:pack:check`

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (Not applicable: presentation-only event ownership.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed. (The single-owner model is already documented by #1386.)
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (Not applicable.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->