### PR TITLE
feat(agent-gui): export session handoff prompt

### DIFF
--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -85,6 +85,14 @@ accepted for host capabilities that are not agent activity data:
 AgentGUI has no host-API activity fallback. A host must inject the runtime and
 the grouped `AgentGUINodeProps` responsibility objects.
 
+## Session Handoff Drafts
+
+External AgentGUI hosts can use `createAgentSessionHandoffPrompt` to prefill a
+destination Agent composer with the same canonical complete-session mention as
+AgentGUI's built-in Handoff menu. The helper owns mention serialization and the
+trailing rich-text caret space; hosts continue to own destination selection and
+window launch behavior.
+
 ## Boundary Rule
 
 `AgentActivity*` types from `@tutti-os/agent-activity-core` are the canonical

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts
@@ -20,6 +20,7 @@ import { managedAgentRoundedIconUrl } from "../../../shared/managedAgentIcons";
 import {
   agentComposerFileMentionReferences,
   createAgentComposerFileMentionMarkdown,
+  createAgentSessionHandoffPrompt,
   updateAgentComposerFileMentions
 } from "./agentMentionMarkdown";
 
@@ -589,6 +590,19 @@ describe("agent session mention links", () => {
       })
     ).toBe(
       "[@Session 1](mention://agent-session/session-1?agentTargetId=local%3Aclaude-code&workspaceId=room-1)"
+    );
+  });
+
+  it("builds the canonical session handoff draft with a trailing cursor space", () => {
+    expect(
+      createAgentSessionHandoffPrompt({
+        agentSessionId: "session-1",
+        agentTargetId: "local:claude-code",
+        label: "Session 1",
+        workspaceId: "room-1"
+      })
+    ).toBe(
+      "[@Session 1](mention://agent-session/session-1?agentTargetId=local%3Aclaude-code&workspaceId=room-1) "
     );
   });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
@@ -45,6 +45,7 @@ export type {
 } from "./agentFileMentionContracts";
 export { attrsToMentionItem, mentionItemToAttrs } from "./agentMentionAttrs";
 export {
+  createAgentSessionHandoffPrompt,
   createAgentSessionMarkdownLink,
   createAgentSessionMentionHref,
   formatAgentFileMentionMarkdown,
@@ -53,6 +54,7 @@ export {
   parseAgentMentionMarkdown,
   parseMentionItemFromHref
 } from "./agentMentionMarkdown";
+export type { CreateAgentSessionHandoffPromptInput } from "./agentMentionMarkdown";
 export const agentFileMentionPluginKey = new PluginKey(
   "agentFileMentionSuggestion"
 );

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionMarkdown.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionMarkdown.ts
@@ -109,6 +109,27 @@ export function createAgentSessionMarkdownLink(input: {
   });
 }
 
+export interface CreateAgentSessionHandoffPromptInput {
+  agentSessionId: string;
+  agentTargetId?: string | null;
+  label: string;
+  workspaceId: string;
+}
+
+/**
+ * Builds the canonical composer draft for handing a complete Agent session to
+ * another Agent. The trailing space is the editable caret anchor used by the
+ * rich-text composer after the atomic session mention.
+ */
+export function createAgentSessionHandoffPrompt(
+  input: CreateAgentSessionHandoffPromptInput
+): string {
+  return `${createAgentSessionMarkdownLink({
+    ...input,
+    withAtPrefix: true
+  })} `;
+}
+
 export function formatAgentMentionMarkdown(
   item: AgentContextMentionItem
 ): string {

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
@@ -1,8 +1,45 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildAgentConversationHandoffPrompt,
   handoffProjectPathForConversation,
   shouldShowAgentGUIStopButton
 } from "./agentGUIDetailModelHelpers.ts";
+
+describe("buildAgentConversationHandoffPrompt", () => {
+  it("delegates the active conversation to the canonical session handoff draft", () => {
+    expect(
+      buildAgentConversationHandoffPrompt({
+        activeConversation: {
+          id: "session-1",
+          agentTargetId: "local:claude-code",
+          provider: "claude-code",
+          title: "Session 1",
+          titleFallback: null,
+          status: "completed",
+          cwd: "/workspace/project-a",
+          updatedAtUnixMs: 1
+        },
+        currentUserId: "user-1",
+        labels: { untitledConversationTitle: "Untitled conversation" },
+        selectedAgentTarget: {
+          targetId: "local:claude-code",
+          agentTargetId: "local:claude-code",
+          label: "Claude Code",
+          provider: "claude-code",
+          ref: {
+            kind: "agent-directory",
+            provider: "claude-code",
+            agentTargetId: "local:claude-code"
+          }
+        },
+        uiLanguage: "en",
+        workspaceId: "room-1"
+      })
+    ).toBe(
+      "[@Session 1](mention://agent-session/session-1?agentTargetId=local%3Aclaude-code&workspaceId=room-1) "
+    );
+  });
+});
 
 describe("shouldShowAgentGUIStopButton", () => {
   const idle = {

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
@@ -2,10 +2,7 @@ import { useRef } from "react";
 import { normalizeOptionalWorkspaceAgentStatus } from "../../../shared/workspaceAgentStatusNormalizer";
 import type { UiLanguage } from "../../../contexts/settings/domain/agentSettings";
 import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
-import {
-  createAgentSessionMentionHref,
-  formatAgentMentionMarkdown
-} from "../agentRichText/agentFileMentionExtension";
+import { createAgentSessionHandoffPrompt } from "../agentRichText/agentFileMentionExtension";
 import type {
   AgentComposerSlashStatus,
   AgentComposerSlashStatusLimit
@@ -278,26 +275,12 @@ export function buildAgentConversationHandoffPrompt(input: {
     input.uiLanguage
   );
   const mentionLabel = title || sourceAgentLabel;
-  const href = createAgentSessionMentionHref({
+  return createAgentSessionHandoffPrompt({
     agentTargetId: conversation.agentTargetId,
     agentSessionId: conversation.id,
     label: mentionLabel,
     workspaceId: input.workspaceId
   });
-  return `${formatAgentMentionMarkdown({
-    kind: "session",
-    href,
-    workspaceId: input.workspaceId,
-    targetId: conversation.id,
-    agentTargetId: conversation.agentTargetId ?? undefined,
-    name: mentionLabel,
-    title: title || sourceAgentLabel,
-    scope: "my_sessions",
-    initiatorName: input.currentUserId?.trim() || sourceAgentLabel,
-    agentName: sourceAgentLabel,
-    status: conversation.status,
-    updatedAtUnixMs: conversation.updatedAtUnixMs
-  })} `;
 }
 
 export function handoffProjectPathForConversation(

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -17,6 +17,8 @@ export type {
   AgentGUIReferenceProvenanceFilterCatalog
 } from "./AgentGUI";
 export type { AgentGUIComposerAppendRequest } from "./agent-gui/agentGuiNode/controller/useAgentGUIComposerAppendRequest";
+export { createAgentSessionHandoffPrompt } from "./agent-gui/agentGuiNode/agentRichText/agentMentionMarkdown";
+export type { CreateAgentSessionHandoffPromptInput } from "./agent-gui/agentGuiNode/agentRichText/agentMentionMarkdown";
 export type { AgentComposerDraftFile } from "./agent-gui/agentGuiNode/model/agentGuiNodeTypes";
 export type {
   AgentExternalPromptFilePreparationErrorCode,


### PR DESCRIPTION
## Summary

- export a canonical `createAgentSessionHandoffPrompt` helper from `@tutti-os/agent-gui`
- make the built-in AgentGUI Handoff draft delegate to the same helper
- document the public host integration contract and preserve the rich-text caret suffix

## Verification

- `pnpm --filter @tutti-os/agent-gui test`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm release:pack:check`
- pre-push `pnpm check:changed -- --push-ready` (9 lanes)

## Checklist

- [x] Agent lifecycle semantics are unchanged; this is a composer serialization helper only.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior or integration changed.
- [x] Package README has no language variants to update.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->