### PR TITLE
fix(workbench): persist dock retention

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceWorkbenchRepository.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceWorkbenchRepository.test.ts
@@ -13,6 +13,10 @@ import {
   hasWorkspaceOnboardingAutoOpened,
   writeWorkspaceOnboardingAutoOpenedToSnapshot
 } from "../../workspaceOnboarding.ts";
+import {
+  readWorkspaceDockRetentionByEntryId,
+  writeWorkspaceDockRetentionToSnapshot
+} from "../../workspaceDockRetention.ts";
 import { createDesktopWorkspaceWorkbenchRepository } from "./desktopWorkspaceWorkbenchRepository.ts";
 
 test("desktop workspace workbench repository caches loaded snapshots", async () => {
@@ -72,6 +76,95 @@ test("desktop workspace workbench repository preserves onboarding metadata on ho
   await repository.save("workspace-1", createSnapshot());
 
   assert.equal(hasWorkspaceOnboardingAutoOpened(savedSnapshot), true);
+});
+
+test("desktop workspace workbench repository preserves dock retention on host saves", async () => {
+  let savedSnapshot: WorkbenchSnapshot | null = null;
+  const repository = createDesktopWorkspaceWorkbenchRepository(
+    createTuttidClient({
+      initialSnapshot: writeWorkspaceDockRetentionToSnapshot(createSnapshot(), {
+        "workspace-app:calendar": false
+      }),
+      onSave(_workspaceID, snapshot) {
+        savedSnapshot = snapshot;
+      }
+    })
+  );
+
+  await repository.load("workspace-1");
+  await repository.save("workspace-1", createSnapshot());
+
+  assert.equal(
+    readWorkspaceDockRetentionByEntryId(savedSnapshot)[
+      "workspace-app:calendar"
+    ],
+    false
+  );
+});
+
+test("desktop workspace workbench repository reloads persisted dock removal", async () => {
+  let persistedSnapshot = createSnapshot();
+  const client = createTuttidClient({
+    initialSnapshot: persistedSnapshot,
+    onSave(_workspaceID, snapshot) {
+      persistedSnapshot = snapshot;
+    }
+  });
+  const firstRepository = createDesktopWorkspaceWorkbenchRepository(client);
+
+  await firstRepository.load("workspace-1");
+  await firstRepository.saveProductMetadata(
+    "workspace-1",
+    writeWorkspaceDockRetentionToSnapshot(
+      firstRepository.readCached("workspace-1") ?? createSnapshot(),
+      { "workspace-app:calendar": false }
+    ),
+    "dock"
+  );
+
+  const reopenedRepository = createDesktopWorkspaceWorkbenchRepository({
+    ...client,
+    async getWorkspaceWorkbench() {
+      return persistedSnapshot;
+    }
+  });
+  const reopenedSnapshot = await reopenedRepository.load("workspace-1");
+
+  assert.equal(
+    readWorkspaceDockRetentionByEntryId(reopenedSnapshot)[
+      "workspace-app:calendar"
+    ],
+    false
+  );
+});
+
+test("dock metadata writes preserve other product-owned metadata", async () => {
+  const initialSnapshot = writeWorkspaceWallpaperIdToSnapshot(
+    writeWorkspaceOnboardingAutoOpenedToSnapshot(
+      createSnapshot(),
+      "2026-07-18T00:00:00.000Z"
+    ),
+    "sky"
+  );
+  const repository = createDesktopWorkspaceWorkbenchRepository(
+    createTuttidClient({ initialSnapshot })
+  );
+
+  await repository.load("workspace-1");
+  const savedSnapshot = await repository.saveProductMetadata(
+    "workspace-1",
+    writeWorkspaceDockRetentionToSnapshot(initialSnapshot, {
+      browser: false
+    }),
+    "dock"
+  );
+
+  assert.equal(readWorkspaceWallpaperIdFromSnapshot(savedSnapshot), "sky");
+  assert.equal(hasWorkspaceOnboardingAutoOpened(savedSnapshot), true);
+  assert.equal(
+    readWorkspaceDockRetentionByEntryId(savedSnapshot).browser,
+    false
+  );
 });
 
 test("desktop workspace workbench repository keeps daemon calls workspace-scoped and preserves product metadata", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceWorkbenchRepository.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceWorkbenchRepository.ts
@@ -5,9 +5,11 @@ import {
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
 import { replaceWorkspaceWallpaperSnapshotMetadata } from "../../workspaceWallpaper.ts";
 import { replaceWorkspaceOnboardingSnapshotMetadata } from "../../workspaceOnboarding.ts";
+import { replaceWorkspaceDockSnapshotMetadata } from "../../workspaceDockRetention.ts";
 import type { WorkbenchSnapshotRepositoryPort } from "../workbenchHostPorts.ts";
 
 export type DesktopWorkspaceWorkbenchProductMetadataOwner =
+  | "dock"
   | "onboarding"
   | "wallpaper";
 
@@ -138,6 +140,12 @@ function mergeProductMetadata(input: {
   owner: DesktopWorkspaceWorkbenchProductMetadataOwner | null;
   snapshot: WorkbenchSnapshot;
 }): WorkbenchSnapshot {
+  if (input.owner === "dock") {
+    return replaceWorkspaceDockSnapshotMetadata(
+      input.snapshot,
+      input.cachedSnapshot ?? input.snapshot
+    );
+  }
   if (input.owner === "onboarding") {
     return replaceWorkspaceOnboardingSnapshotMetadata(
       input.snapshot,
@@ -155,9 +163,13 @@ function mergeProductMetadata(input: {
     input.cachedSnapshot,
     input.snapshot
   );
-  return replaceWorkspaceWallpaperSnapshotMetadata(
+  const snapshotWithWallpaper = replaceWorkspaceWallpaperSnapshotMetadata(
     input.cachedSnapshot,
     snapshotWithOnboarding
+  );
+  return replaceWorkspaceDockSnapshotMetadata(
+    input.cachedSnapshot,
+    snapshotWithWallpaper
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceDockRetentionController.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceDockRetentionController.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  type WorkbenchSnapshot,
+  workbenchSnapshotSchemaVersion
+} from "@tutti-os/workbench-snapshot";
+import { readWorkspaceDockRetentionByEntryId } from "../workspaceDockRetention.ts";
+import type { DesktopWorkspaceWorkbenchRepository } from "./adapters/desktopWorkspaceWorkbenchRepository.ts";
+import { createWorkspaceDockRetentionController } from "./workspaceDockRetentionController.ts";
+
+test("workspace dock retention controller updates optimistically and persists", async () => {
+  const fake = createRepository();
+  const controller = createWorkspaceDockRetentionController(fake.repository);
+
+  const writing = controller.setRetained(
+    "workspace-1",
+    "workspace-app:calendar",
+    false
+  );
+  assert.equal(
+    controller.readRetainedByEntryId("workspace-1")["workspace-app:calendar"],
+    false
+  );
+
+  await writing;
+
+  assert.equal(
+    readWorkspaceDockRetentionByEntryId(fake.snapshot)[
+      "workspace-app:calendar"
+    ],
+    false
+  );
+  controller.dispose();
+});
+
+test("workspace dock retention controller rolls back a failed write", async () => {
+  const fake = createRepository();
+  fake.failWrites = true;
+  const controller = createWorkspaceDockRetentionController(fake.repository);
+
+  await assert.rejects(
+    controller.setRetained("workspace-1", "workspace-app:calendar", false),
+    /save failed/
+  );
+
+  assert.equal(
+    controller.readRetainedByEntryId("workspace-1")["workspace-app:calendar"],
+    undefined
+  );
+  controller.dispose();
+});
+
+function createRepository(): {
+  failWrites: boolean;
+  repository: DesktopWorkspaceWorkbenchRepository;
+  readonly snapshot: WorkbenchSnapshot;
+} {
+  let snapshot = createSnapshot();
+  const listeners = new Set<() => void>();
+  const fake = {
+    failWrites: false,
+    repository: {
+      async load() {
+        return snapshot;
+      },
+      readCached() {
+        return snapshot;
+      },
+      async saveProductMetadata(
+        _workspaceId: string,
+        nextSnapshot: WorkbenchSnapshot
+      ) {
+        if (fake.failWrites) {
+          throw new Error("save failed");
+        }
+        snapshot = nextSnapshot;
+        for (const listener of listeners) {
+          listener();
+        }
+        return snapshot;
+      },
+      subscribe(listener: () => void) {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      }
+    } as unknown as DesktopWorkspaceWorkbenchRepository,
+    get snapshot() {
+      return snapshot;
+    }
+  };
+  return fake;
+}
+
+function createSnapshot(): WorkbenchSnapshot {
+  return {
+    activeNodeId: null,
+    nodeStack: [],
+    nodes: [],
+    schemaVersion: workbenchSnapshotSchemaVersion
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceDockRetentionController.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceDockRetentionController.test.ts
@@ -4,13 +4,20 @@ import {
   type WorkbenchSnapshot,
   workbenchSnapshotSchemaVersion
 } from "@tutti-os/workbench-snapshot";
-import { readWorkspaceDockRetentionByEntryId } from "../workspaceDockRetention.ts";
+import {
+  readWorkspaceDockRetentionByEntryId,
+  writeWorkspaceDockRetentionToSnapshot
+} from "../workspaceDockRetention.ts";
 import type { DesktopWorkspaceWorkbenchRepository } from "./adapters/desktopWorkspaceWorkbenchRepository.ts";
 import { createWorkspaceDockRetentionController } from "./workspaceDockRetentionController.ts";
 
 test("workspace dock retention controller updates optimistically and persists", async () => {
   const fake = createRepository();
   const controller = createWorkspaceDockRetentionController(fake.repository);
+  let notifications = 0;
+  controller.subscribe(() => {
+    notifications += 1;
+  });
 
   const writing = controller.setRetained(
     "workspace-1",
@@ -30,6 +37,7 @@ test("workspace dock retention controller updates optimistically and persists", 
     ],
     false
   );
+  assert.equal(notifications, 1);
   controller.dispose();
 });
 
@@ -50,34 +58,115 @@ test("workspace dock retention controller rolls back a failed write", async () =
   controller.dispose();
 });
 
+test("workspace dock retention controller ignores unrelated repository notifications and keeps snapshots stable", () => {
+  const fake = createRepository();
+  const controller = createWorkspaceDockRetentionController(fake.repository);
+  const first = controller.readRetainedByEntryId("workspace-1");
+  let notifications = 0;
+  controller.subscribe(() => {
+    notifications += 1;
+  });
+
+  fake.setSnapshot(
+    "workspace-2",
+    writeWorkspaceDockRetentionToSnapshot(createSnapshot(), {
+      "workspace-app:mail": false
+    })
+  );
+  fake.notify();
+
+  assert.equal(notifications, 0);
+  assert.equal(controller.readRetainedByEntryId("workspace-1"), first);
+  assert.equal(controller.readRetainedByEntryId("workspace-1"), first);
+  controller.dispose();
+});
+
+test("workspace dock retention controller notifies only when cached retention changes", () => {
+  const fake = createRepository();
+  const controller = createWorkspaceDockRetentionController(fake.repository);
+  const first = controller.readRetainedByEntryId("workspace-1");
+  let notifications = 0;
+  controller.subscribe(() => {
+    notifications += 1;
+  });
+
+  fake.setSnapshot(
+    "workspace-1",
+    writeWorkspaceDockRetentionToSnapshot(createSnapshot(), {
+      "workspace-app:calendar": false
+    })
+  );
+  fake.notify();
+
+  const second = controller.readRetainedByEntryId("workspace-1");
+  assert.equal(notifications, 1);
+  assert.notEqual(second, first);
+  assert.deepEqual(second, { "workspace-app:calendar": false });
+
+  fake.notify();
+
+  assert.equal(notifications, 1);
+  assert.equal(controller.readRetainedByEntryId("workspace-1"), second);
+  controller.dispose();
+});
+
+test("workspace dock retention controller unsubscribes on disposal", () => {
+  const fake = createRepository();
+  const controller = createWorkspaceDockRetentionController(fake.repository);
+  controller.readRetainedByEntryId("workspace-1");
+  let notifications = 0;
+  controller.subscribe(() => {
+    notifications += 1;
+  });
+
+  controller.dispose();
+  fake.setSnapshot(
+    "workspace-1",
+    writeWorkspaceDockRetentionToSnapshot(createSnapshot(), {
+      "workspace-app:calendar": false
+    })
+  );
+  fake.notify();
+
+  assert.equal(notifications, 0);
+});
+
 function createRepository(): {
   failWrites: boolean;
+  notify(): void;
   repository: DesktopWorkspaceWorkbenchRepository;
+  setSnapshot(workspaceId: string, snapshot: WorkbenchSnapshot): void;
   readonly snapshot: WorkbenchSnapshot;
 } {
-  let snapshot = createSnapshot();
+  const snapshots = new Map<string, WorkbenchSnapshot>([
+    ["workspace-1", createSnapshot()]
+  ]);
   const listeners = new Set<() => void>();
+  const notify = () => {
+    for (const listener of listeners) {
+      listener();
+    }
+  };
   const fake = {
     failWrites: false,
+    notify,
     repository: {
-      async load() {
-        return snapshot;
+      async load(workspaceId: string) {
+        return snapshots.get(workspaceId) ?? createSnapshot();
       },
-      readCached() {
-        return snapshot;
+      readCached(workspaceId: string) {
+        return snapshots.get(workspaceId) ?? null;
       },
       async saveProductMetadata(
-        _workspaceId: string,
+        workspaceId: string,
         nextSnapshot: WorkbenchSnapshot
       ) {
         if (fake.failWrites) {
           throw new Error("save failed");
         }
-        snapshot = nextSnapshot;
-        for (const listener of listeners) {
-          listener();
-        }
-        return snapshot;
+        snapshots.set(workspaceId, nextSnapshot);
+        notify();
+        return nextSnapshot;
       },
       subscribe(listener: () => void) {
         listeners.add(listener);
@@ -86,8 +175,11 @@ function createRepository(): {
         };
       }
     } as unknown as DesktopWorkspaceWorkbenchRepository,
+    setSnapshot(workspaceId: string, snapshot: WorkbenchSnapshot) {
+      snapshots.set(workspaceId, snapshot);
+    },
     get snapshot() {
-      return snapshot;
+      return snapshots.get("workspace-1") ?? createSnapshot();
     }
   };
   return fake;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceDockRetentionController.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceDockRetentionController.ts
@@ -10,6 +10,10 @@ export function createWorkspaceDockRetentionController(
 ): WorkspaceDockRetentionService {
   const listeners = new Set<() => void>();
   const pendingByWorkspaceId = new Map<string, Map<string, boolean>>();
+  const retainedByWorkspaceId = new Map<
+    string,
+    Readonly<Record<string, boolean>>
+  >();
   const writeQueues = new Map<string, Promise<void>>();
   let revision = 0;
 
@@ -19,7 +23,38 @@ export function createWorkspaceDockRetentionController(
       listener();
     }
   };
-  const unsubscribeRepository = repository.subscribe(notify);
+
+  const resolveRetainedByEntryId = (workspaceId: string) => {
+    const persisted = readWorkspaceDockRetentionByEntryId(
+      repository.readCached(workspaceId)
+    );
+    const pending = pendingByWorkspaceId.get(workspaceId);
+    return pending
+      ? {
+          ...persisted,
+          ...Object.fromEntries(pending)
+        }
+      : persisted;
+  };
+  const refreshWorkspace = (workspaceId: string) => {
+    const current = retainedByWorkspaceId.get(workspaceId);
+    const next = resolveRetainedByEntryId(workspaceId);
+    if (current && hasEqualRetention(current, next)) {
+      return false;
+    }
+    retainedByWorkspaceId.set(workspaceId, next);
+    return true;
+  };
+  const refreshKnownWorkspaces = () => {
+    let changed = false;
+    for (const workspaceId of retainedByWorkspaceId.keys()) {
+      changed = refreshWorkspace(workspaceId) || changed;
+    }
+    if (changed) {
+      notify();
+    }
+  };
+  const unsubscribeRepository = repository.subscribe(refreshKnownWorkspaces);
 
   const clearPersistedChanges = (
     workspaceId: string,
@@ -62,38 +97,42 @@ export function createWorkspaceDockRetentionController(
       );
     } catch (error) {
       clearPersistedChanges(workspaceId, changes);
-      notify();
+      if (refreshWorkspace(workspaceId)) {
+        notify();
+      }
       throw error;
     }
 
     clearPersistedChanges(workspaceId, changes);
+    if (refreshWorkspace(workspaceId)) {
+      notify();
+    }
   };
 
   return {
     dispose() {
       unsubscribeRepository();
       listeners.clear();
+      pendingByWorkspaceId.clear();
+      retainedByWorkspaceId.clear();
+      writeQueues.clear();
     },
     getRevision() {
       return revision;
     },
     readRetainedByEntryId(workspaceId) {
-      const persisted = readWorkspaceDockRetentionByEntryId(
-        repository.readCached(workspaceId)
-      );
-      const pending = pendingByWorkspaceId.get(workspaceId);
-      return pending
-        ? {
-            ...persisted,
-            ...Object.fromEntries(pending)
-          }
-        : persisted;
+      if (!retainedByWorkspaceId.has(workspaceId)) {
+        refreshWorkspace(workspaceId);
+      }
+      return retainedByWorkspaceId.get(workspaceId) ?? {};
     },
     setRetained(workspaceId, entryId, retained) {
       const pending = pendingByWorkspaceId.get(workspaceId) ?? new Map();
       pending.set(entryId, retained);
       pendingByWorkspaceId.set(workspaceId, pending);
-      notify();
+      if (refreshWorkspace(workspaceId)) {
+        notify();
+      }
 
       const previousWrite = writeQueues.get(workspaceId) ?? Promise.resolve();
       const nextWrite = previousWrite
@@ -118,3 +157,15 @@ export function createWorkspaceDockRetentionController(
 }
 
 function noop(): void {}
+
+function hasEqualRetention(
+  left: Readonly<Record<string, boolean>>,
+  right: Readonly<Record<string, boolean>>
+): boolean {
+  const leftEntries = Object.entries(left);
+  const rightKeys = Object.keys(right);
+  return (
+    leftEntries.length === rightKeys.length &&
+    leftEntries.every(([entryId, retained]) => right[entryId] === retained)
+  );
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceDockRetentionController.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceDockRetentionController.ts
@@ -1,0 +1,120 @@
+import type { WorkspaceDockRetentionService } from "../workspaceWorkbenchHostService.interface.ts";
+import {
+  readWorkspaceDockRetentionByEntryId,
+  writeWorkspaceDockRetentionToSnapshot
+} from "../workspaceDockRetention.ts";
+import type { DesktopWorkspaceWorkbenchRepository } from "./adapters/desktopWorkspaceWorkbenchRepository.ts";
+
+export function createWorkspaceDockRetentionController(
+  repository: DesktopWorkspaceWorkbenchRepository
+): WorkspaceDockRetentionService {
+  const listeners = new Set<() => void>();
+  const pendingByWorkspaceId = new Map<string, Map<string, boolean>>();
+  const writeQueues = new Map<string, Promise<void>>();
+  let revision = 0;
+
+  const notify = () => {
+    revision += 1;
+    for (const listener of listeners) {
+      listener();
+    }
+  };
+  const unsubscribeRepository = repository.subscribe(notify);
+
+  const clearPersistedChanges = (
+    workspaceId: string,
+    changes: ReadonlyMap<string, boolean>
+  ) => {
+    const pending = pendingByWorkspaceId.get(workspaceId);
+    if (!pending) {
+      return;
+    }
+    for (const [entryId, retained] of changes) {
+      if (pending.get(entryId) === retained) {
+        pending.delete(entryId);
+      }
+    }
+    if (pending.size === 0) {
+      pendingByWorkspaceId.delete(workspaceId);
+    }
+  };
+
+  const persistPending = async (workspaceId: string) => {
+    const pending = pendingByWorkspaceId.get(workspaceId);
+    if (!pending?.size) {
+      return;
+    }
+    const changes = new Map(pending);
+    const cachedSnapshot = repository.readCached(workspaceId);
+    const snapshot = cachedSnapshot
+      ? cachedSnapshot
+      : await repository.load(workspaceId);
+    const retainedByEntryId = {
+      ...readWorkspaceDockRetentionByEntryId(snapshot),
+      ...Object.fromEntries(changes)
+    };
+
+    try {
+      await repository.saveProductMetadata(
+        workspaceId,
+        writeWorkspaceDockRetentionToSnapshot(snapshot, retainedByEntryId),
+        "dock"
+      );
+    } catch (error) {
+      clearPersistedChanges(workspaceId, changes);
+      notify();
+      throw error;
+    }
+
+    clearPersistedChanges(workspaceId, changes);
+  };
+
+  return {
+    dispose() {
+      unsubscribeRepository();
+      listeners.clear();
+    },
+    getRevision() {
+      return revision;
+    },
+    readRetainedByEntryId(workspaceId) {
+      const persisted = readWorkspaceDockRetentionByEntryId(
+        repository.readCached(workspaceId)
+      );
+      const pending = pendingByWorkspaceId.get(workspaceId);
+      return pending
+        ? {
+            ...persisted,
+            ...Object.fromEntries(pending)
+          }
+        : persisted;
+    },
+    setRetained(workspaceId, entryId, retained) {
+      const pending = pendingByWorkspaceId.get(workspaceId) ?? new Map();
+      pending.set(entryId, retained);
+      pendingByWorkspaceId.set(workspaceId, pending);
+      notify();
+
+      const previousWrite = writeQueues.get(workspaceId) ?? Promise.resolve();
+      const nextWrite = previousWrite
+        .catch(noop)
+        .then(() => persistPending(workspaceId));
+      writeQueues.set(workspaceId, nextWrite);
+      const clearQueue = () => {
+        if (writeQueues.get(workspaceId) === nextWrite) {
+          writeQueues.delete(workspaceId);
+        }
+      };
+      void nextWrite.then(clearQueue, clearQueue);
+      return nextWrite;
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    }
+  };
+}
+
+function noop(): void {}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
@@ -92,29 +92,6 @@ test("workspace workbench host delegates workspace lifecycle to the DI coordinat
   assert.match(workspaceWorkbenchSource, /key=\{hostSession\.bindingId\}/);
 });
 
-test("workspace workbench host releases owned resources on disposal", () => {
-  assert.match(
-    workspaceWorkbenchHostServiceSource,
-    /dispose\(\): void \{\s+this\.dockRetention\.dispose\(\);\s+this\.wallpaperListeners\.clear\(\);\s+this\.clearCustomWallpaperUrls\(\);\s+\}/
-  );
-});
-
-test("workspace dock retention is persisted through workbench product metadata", () => {
-  assert.match(
-    readFileSync(
-      new URL("./workspaceDockRetentionController.ts", import.meta.url),
-      "utf8"
-    ),
-    /saveProductMetadata\(\s+workspaceId,\s+writeWorkspaceDockRetentionToSnapshot\(snapshot, retainedByEntryId\),\s+"dock"\s+\)/
-  );
-  assert.match(workspaceWorkbenchShellHookSource, /dockRetention\.subscribe/);
-  assert.match(workspaceWorkbenchSource, /runtime\.setDockEntryRetained/);
-  assert.doesNotMatch(
-    workspaceWorkbenchSource,
-    /temporaryDockRetentionByEntryId/
-  );
-});
-
 test("shouldCloseTerminalNodeAfterError closes stale terminal nodes", () => {
   assert.equal(
     shouldCloseTerminalNodeAfterError(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
@@ -92,10 +92,26 @@ test("workspace workbench host delegates workspace lifecycle to the DI coordinat
   assert.match(workspaceWorkbenchSource, /key=\{hostSession\.bindingId\}/);
 });
 
-test("workspace workbench host releases owned wallpaper URLs on disposal", () => {
+test("workspace workbench host releases owned resources on disposal", () => {
   assert.match(
     workspaceWorkbenchHostServiceSource,
-    /dispose\(\): void \{\s+this\.wallpaperListeners\.clear\(\);\s+this\.clearCustomWallpaperUrls\(\);\s+\}/
+    /dispose\(\): void \{\s+this\.dockRetention\.dispose\(\);\s+this\.wallpaperListeners\.clear\(\);\s+this\.clearCustomWallpaperUrls\(\);\s+\}/
+  );
+});
+
+test("workspace dock retention is persisted through workbench product metadata", () => {
+  assert.match(
+    readFileSync(
+      new URL("./workspaceDockRetentionController.ts", import.meta.url),
+      "utf8"
+    ),
+    /saveProductMetadata\(\s+workspaceId,\s+writeWorkspaceDockRetentionToSnapshot\(snapshot, retainedByEntryId\),\s+"dock"\s+\)/
+  );
+  assert.match(workspaceWorkbenchShellHookSource, /dockRetention\.subscribe/);
+  assert.match(workspaceWorkbenchSource, /runtime\.setDockEntryRetained/);
+  assert.doesNotMatch(
+    workspaceWorkbenchSource,
+    /temporaryDockRetentionByEntryId/
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -104,6 +104,7 @@ import {
   type CachedWorkspaceWorkbenchHostInput,
   type WorkspaceWorkbenchHostInputResolverDependencies
 } from "./workspaceWorkbenchHostInputResolver.ts";
+import { createWorkspaceDockRetentionController } from "./workspaceDockRetentionController.ts";
 
 export interface WorkspaceWorkbenchHostServiceDependencies extends WorkspaceWorkbenchHostInputResolverDependencies {
   hostNotificationsApi: Pick<DesktopHostNotificationsApi, "onNavigate">;
@@ -139,6 +140,7 @@ export interface WorkspaceWorkbenchHostExternalDependencies {
 
 export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostService {
   readonly _serviceBrand = undefined;
+  readonly dockRetention;
   private readonly dependencies: WorkspaceWorkbenchHostServiceDependencies;
   private hostSessionBindingSequence = 0;
   private readonly hostSessionConfiguration: WorkbenchHostSessionConfiguration<
@@ -183,6 +185,7 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
     workspaceUserProjectService: IWorkspaceUserProjectService
   ) {
     const repository = externalDependencies.snapshotRepository;
+    this.dockRetention = createWorkspaceDockRetentionController(repository);
     this.dependencies = {
       agentProviderStatusService,
       agentsService,
@@ -632,6 +635,7 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
   }
 
   dispose(): void {
+    this.dockRetention.dispose();
     this.wallpaperListeners.clear();
     this.clearCustomWallpaperUrls();
   }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceDockRetention.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceDockRetention.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { workbenchSnapshotSchemaVersion } from "@tutti-os/workbench-snapshot";
+import {
+  readWorkspaceDockRetentionByEntryId,
+  replaceWorkspaceDockSnapshotMetadata,
+  writeWorkspaceDockRetentionToSnapshot
+} from "./workspaceDockRetention.ts";
+
+test("workspace dock retention round-trips explicit removed entries", () => {
+  const snapshot = writeWorkspaceDockRetentionToSnapshot(createSnapshot(), {
+    "workspace-app:calendar": false,
+    browser: true
+  });
+
+  assert.deepEqual(readWorkspaceDockRetentionByEntryId(snapshot), {
+    "workspace-app:calendar": false,
+    browser: true
+  });
+});
+
+test("workspace dock retention ignores invalid metadata entries", () => {
+  const snapshot = {
+    ...createSnapshot(),
+    metadata: {
+      workspaceDock: {
+        retainedByEntryId: {
+          "": true,
+          browser: "yes",
+          terminal: false
+        },
+        schemaVersion: 1
+      }
+    }
+  };
+
+  assert.deepEqual(readWorkspaceDockRetentionByEntryId(snapshot), {
+    terminal: false
+  });
+});
+
+test("workspace dock metadata replacement preserves the authoritative owner", () => {
+  const authoritativeSnapshot = writeWorkspaceDockRetentionToSnapshot(
+    createSnapshot(),
+    { browser: false }
+  );
+  const nextSnapshot = {
+    ...writeWorkspaceDockRetentionToSnapshot(createSnapshot(), {
+      browser: true
+    }),
+    metadata: {
+      ...writeWorkspaceDockRetentionToSnapshot(createSnapshot(), {
+        browser: true
+      }).metadata,
+      testRevision: "next"
+    }
+  };
+
+  const replaced = replaceWorkspaceDockSnapshotMetadata(
+    authoritativeSnapshot,
+    nextSnapshot
+  );
+
+  assert.deepEqual(readWorkspaceDockRetentionByEntryId(replaced), {
+    browser: false
+  });
+  assert.equal(replaced.metadata?.testRevision, "next");
+});
+
+function createSnapshot() {
+  return {
+    activeNodeId: null,
+    nodeStack: [],
+    nodes: [],
+    schemaVersion: workbenchSnapshotSchemaVersion
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceDockRetention.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceDockRetention.ts
@@ -1,0 +1,77 @@
+import type { WorkbenchSnapshot } from "@tutti-os/workbench-snapshot";
+
+const workspaceDockMetadataKey = "workspaceDock";
+const workspaceDockMetadataSchemaVersion = 1;
+
+interface WorkspaceDockSnapshotMetadata {
+  retainedByEntryId: Record<string, boolean>;
+  schemaVersion: typeof workspaceDockMetadataSchemaVersion;
+}
+
+export function readWorkspaceDockRetentionByEntryId(
+  snapshot: WorkbenchSnapshot | null | undefined
+): Readonly<Record<string, boolean>> {
+  const metadata = snapshot?.metadata?.[workspaceDockMetadataKey];
+  if (!isRecord(metadata)) {
+    return {};
+  }
+  if (metadata.schemaVersion !== workspaceDockMetadataSchemaVersion) {
+    return {};
+  }
+  if (!isRecord(metadata.retainedByEntryId)) {
+    return {};
+  }
+
+  const retainedByEntryId: Record<string, boolean> = {};
+  for (const [entryId, retained] of Object.entries(
+    metadata.retainedByEntryId
+  )) {
+    if (entryId.length > 0 && typeof retained === "boolean") {
+      retainedByEntryId[entryId] = retained;
+    }
+  }
+  return retainedByEntryId;
+}
+
+export function writeWorkspaceDockRetentionToSnapshot(
+  snapshot: WorkbenchSnapshot,
+  retainedByEntryId: Readonly<Record<string, boolean>>
+): WorkbenchSnapshot {
+  return {
+    ...snapshot,
+    metadata: {
+      ...(snapshot.metadata ?? {}),
+      [workspaceDockMetadataKey]: {
+        retainedByEntryId: { ...retainedByEntryId },
+        schemaVersion: workspaceDockMetadataSchemaVersion
+      } satisfies WorkspaceDockSnapshotMetadata
+    }
+  };
+}
+
+export function replaceWorkspaceDockSnapshotMetadata(
+  authoritativeSnapshot: WorkbenchSnapshot | null | undefined,
+  nextSnapshot: WorkbenchSnapshot
+): WorkbenchSnapshot {
+  const authoritativeMetadata =
+    authoritativeSnapshot?.metadata?.[workspaceDockMetadataKey];
+  const {
+    [workspaceDockMetadataKey]: _discardedWorkspaceDockMetadata,
+    ...nextMetadata
+  } = nextSnapshot.metadata ?? {};
+
+  return {
+    ...nextSnapshot,
+    metadata:
+      authoritativeMetadata === undefined
+        ? nextMetadata
+        : {
+            ...nextMetadata,
+            [workspaceDockMetadataKey]: authoritativeMetadata
+          }
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
@@ -59,6 +59,18 @@ export interface WorkspaceCustomWallpaperSnapshot {
   thumbnailUrl: string | null;
 }
 
+export interface WorkspaceDockRetentionService {
+  dispose(): void;
+  getRevision(): number;
+  readRetainedByEntryId(workspaceId: string): Readonly<Record<string, boolean>>;
+  setRetained(
+    workspaceId: string,
+    entryId: string,
+    retained: boolean
+  ): Promise<void>;
+  subscribe(listener: () => void): () => void;
+}
+
 export interface WorkspaceOnboardingAutoOpenDiagnostic {
   details?: Record<string, unknown>;
   event: string;
@@ -147,6 +159,7 @@ export interface WorkspaceWorkbenchHostSessionBinding {
 
 export interface IWorkspaceWorkbenchHostService {
   readonly _serviceBrand: undefined;
+  readonly dockRetention: WorkspaceDockRetentionService;
 
   approveWindowClose(): Promise<void>;
   openHostSession(workspaceId: string): WorkspaceWorkbenchHostSessionBinding;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -120,8 +120,7 @@ import {
   openWorkspaceWorkbenchSameTypeWindowShortcut
 } from "../services/workspaceWorkbenchShortcutActions.ts";
 
-const temporaryWorkspaceAppDockRetentionActionPrefix =
-  "temporary-workspace-app-dock-retention:";
+const workspaceDockRetentionActionPrefix = "workspace-dock-retention:";
 
 interface WorkspaceWorkbenchProps {
   enableWindowCloseGuard: boolean;
@@ -284,8 +283,6 @@ function ReadyWorkspaceWorkbenchWithSession({
   const hostInput = runtime.hostInput;
   const [workbenchHost, setWorkbenchHost] =
     useState<WorkbenchHostHandle | null>(null);
-  const [temporaryDockRetentionByEntryId, setTemporaryDockRetentionByEntryId] =
-    useState<Record<string, boolean>>({});
   const [launchpadOpen, setLaunchpadOpen] = useState(false);
   const [launchpadOpenTrigger, setLaunchpadOpenTrigger] =
     useState<WorkspaceLaunchpadOpenTrigger>("dock");
@@ -337,31 +334,21 @@ function ReadyWorkspaceWorkbenchWithSession({
         setLaunchpadOpen(true);
         return;
       }
-      if (
-        request.actionId.startsWith(
-          temporaryWorkspaceAppDockRetentionActionPrefix
-        )
-      ) {
-        const entry = findTemporaryDockRetentionEntry({
+      if (request.actionId.startsWith(workspaceDockRetentionActionPrefix)) {
+        const entry = findWorkspaceDockRetentionEntry({
           contributions: hostInput.contributions,
           dockEntries: hostInput.dockEntries,
           entryId: request.entryId
         });
-        setTemporaryDockRetentionByEntryId((current) => {
-          const retained =
-            current[request.entryId] ??
-            (entry
-              ? resolveTemporaryDockRetentionDefault({
-                  appCenterService,
-                  entry
-                })
-              : false);
-          return {
-            ...current,
-            [request.entryId]: !retained
-          };
-        });
-        return;
+        const retained =
+          runtime.dockRetentionByEntryId[request.entryId] ??
+          (entry
+            ? resolveWorkspaceDockRetentionDefault({
+                appCenterService,
+                entry
+              })
+            : false);
+        return runtime.setDockEntryRetained(request.entryId, !retained);
       }
       return hostInput.onDockEntryAction?.(request);
     },
@@ -369,30 +356,32 @@ function ReadyWorkspaceWorkbenchWithSession({
       appCenterService,
       hostInput.contributions,
       hostInput.dockEntries,
-      hostInput.onDockEntryAction
+      hostInput.onDockEntryAction,
+      runtime.dockRetentionByEntryId,
+      runtime.setDockEntryRetained
     ]
   );
   const contributions = useMemo(
     () =>
       hostInput.contributions?.map((contribution) =>
-        resolveTemporaryDockRetentionContribution({
+        resolveWorkspaceDockRetentionContribution({
           appCenterService,
           contribution,
-          retainedByEntryId: temporaryDockRetentionByEntryId
+          retainedByEntryId: runtime.dockRetentionByEntryId
         })
       ),
-    [appCenterService, hostInput.contributions, temporaryDockRetentionByEntryId]
+    [appCenterService, hostInput.contributions, runtime.dockRetentionByEntryId]
   );
   const dockEntries = useMemo(
     () =>
       hostInput.dockEntries?.map((entry) =>
-        resolveTemporaryDockRetentionEntry({
+        resolveWorkspaceDockRetentionEntry({
           appCenterService,
           entry,
-          retainedByEntryId: temporaryDockRetentionByEntryId
+          retainedByEntryId: runtime.dockRetentionByEntryId
         })
       ),
-    [appCenterService, hostInput.dockEntries, temporaryDockRetentionByEntryId]
+    [appCenterService, hostInput.dockEntries, runtime.dockRetentionByEntryId]
   );
   const onDockEntryClick = useCallback(
     (request: Parameters<NonNullable<typeof hostInput.onDockEntryClick>>[0]) =>
@@ -896,7 +885,7 @@ function ReadyWorkspaceWorkbenchWithSession({
   );
 }
 
-function resolveTemporaryDockRetentionEntry({
+function resolveWorkspaceDockRetentionEntry({
   appCenterService,
   entry,
   retainedByEntryId
@@ -913,18 +902,18 @@ function resolveTemporaryDockRetentionEntry({
   }
   const retained =
     retainedByEntryId[entry.id] ??
-    resolveTemporaryDockRetentionDefault({ appCenterService, entry });
+    resolveWorkspaceDockRetentionDefault({ appCenterService, entry });
   return {
     ...entry,
     dockRetention: {
-      actionId: `${temporaryWorkspaceAppDockRetentionActionPrefix}${encodeURIComponent(entry.id)}`,
+      actionId: `${workspaceDockRetentionActionPrefix}${encodeURIComponent(entry.id)}`,
       retained
     },
     visibility: retained ? "always" : "when-open"
   };
 }
 
-function resolveTemporaryDockRetentionContribution({
+function resolveWorkspaceDockRetentionContribution({
   appCenterService,
   contribution,
   retainedByEntryId
@@ -939,7 +928,7 @@ function resolveTemporaryDockRetentionContribution({
   return {
     ...contribution,
     dockEntries: contribution.dockEntries.map((entry) =>
-      resolveTemporaryDockRetentionEntry({
+      resolveWorkspaceDockRetentionEntry({
         appCenterService,
         entry,
         retainedByEntryId
@@ -948,7 +937,7 @@ function resolveTemporaryDockRetentionContribution({
   };
 }
 
-function resolveTemporaryDockRetentionDefault({
+function resolveWorkspaceDockRetentionDefault({
   appCenterService,
   entry
 }: {
@@ -960,7 +949,7 @@ function resolveTemporaryDockRetentionDefault({
   return app?.installed ?? (entry.visibility ?? "always") === "always";
 }
 
-function findTemporaryDockRetentionEntry({
+function findWorkspaceDockRetentionEntry({
   contributions,
   dockEntries,
   entryId

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -15,8 +15,10 @@ import { defaultIssueManagerWorkbenchTypeId } from "@tutti-os/workspace-issue-ma
 import {
   isEditableShortcutTarget,
   type WorkbenchContribution,
-  type WorkbenchHostHandle,
   type WorkbenchHostDockEntry,
+  type WorkbenchHostDockEntryPresentationOverride,
+  type WorkbenchHostDockEntryPresentationOverrides,
+  type WorkbenchHostHandle,
   type WorkbenchWindowManagementConfig,
   WorkbenchHost
 } from "@tutti-os/workbench-surface";
@@ -361,27 +363,20 @@ function ReadyWorkspaceWorkbenchWithSession({
       runtime.setDockEntryRetained
     ]
   );
-  const contributions = useMemo(
+  const dockEntryPresentationOverrides = useMemo(
     () =>
-      hostInput.contributions?.map((contribution) =>
-        resolveWorkspaceDockRetentionContribution({
-          appCenterService,
-          contribution,
-          retainedByEntryId: runtime.dockRetentionByEntryId
-        })
-      ),
-    [appCenterService, hostInput.contributions, runtime.dockRetentionByEntryId]
-  );
-  const dockEntries = useMemo(
-    () =>
-      hostInput.dockEntries?.map((entry) =>
-        resolveWorkspaceDockRetentionEntry({
-          appCenterService,
-          entry,
-          retainedByEntryId: runtime.dockRetentionByEntryId
-        })
-      ),
-    [appCenterService, hostInput.dockEntries, runtime.dockRetentionByEntryId]
+      resolveWorkspaceDockEntryPresentationOverrides({
+        appCenterService,
+        contributions: hostInput.contributions,
+        dockEntries: hostInput.dockEntries,
+        retainedByEntryId: runtime.dockRetentionByEntryId
+      }),
+    [
+      appCenterService,
+      hostInput.contributions,
+      hostInput.dockEntries,
+      runtime.dockRetentionByEntryId
+    ]
   );
   const onDockEntryClick = useCallback(
     (request: Parameters<NonNullable<typeof hostInput.onDockEntryClick>>[0]) =>
@@ -791,11 +786,12 @@ function ReadyWorkspaceWorkbenchWithSession({
         <WorkbenchHost
           captureNodePreviewImage={hostInput.captureNodePreviewImage}
           className="h-full"
-          contributions={contributions}
+          contributions={hostInput.contributions}
           debugDiagnostics={hostInput.debugDiagnostics}
           dockPreviewCache={hostInput.dockPreviewCache}
           dockPlacement={runtime.dockPlacement}
-          dockEntries={dockEntries}
+          dockEntries={hostInput.dockEntries}
+          dockEntryPresentationOverrides={dockEntryPresentationOverrides}
           dockStateSource={hostInput.dockStateSource}
           externalStateSource={hostInput.externalStateSource}
           i18n={runtime.appI18n}
@@ -885,7 +881,41 @@ function ReadyWorkspaceWorkbenchWithSession({
   );
 }
 
-function resolveWorkspaceDockRetentionEntry({
+function resolveWorkspaceDockEntryPresentationOverrides({
+  appCenterService,
+  contributions,
+  dockEntries,
+  retainedByEntryId
+}: {
+  appCenterService: IWorkspaceAppCenterService;
+  contributions: readonly WorkbenchContribution[] | undefined;
+  dockEntries: readonly WorkbenchHostDockEntry[] | undefined;
+  retainedByEntryId: Readonly<Record<string, boolean>>;
+}): WorkbenchHostDockEntryPresentationOverrides {
+  const overrides = new Map<
+    string,
+    WorkbenchHostDockEntryPresentationOverride
+  >();
+  const entries = [
+    ...(contributions?.flatMap(
+      (contribution) => contribution.dockEntries ?? []
+    ) ?? []),
+    ...(dockEntries ?? [])
+  ];
+  for (const entry of entries) {
+    const presentationOverride = resolveWorkspaceDockRetentionPresentation({
+      appCenterService,
+      entry,
+      retainedByEntryId
+    });
+    if (presentationOverride) {
+      overrides.set(entry.id, presentationOverride);
+    }
+  }
+  return Object.fromEntries(overrides);
+}
+
+function resolveWorkspaceDockRetentionPresentation({
   appCenterService,
   entry,
   retainedByEntryId
@@ -893,47 +923,22 @@ function resolveWorkspaceDockRetentionEntry({
   appCenterService: IWorkspaceAppCenterService;
   entry: WorkbenchHostDockEntry;
   retainedByEntryId: Readonly<Record<string, boolean>>;
-}): WorkbenchHostDockEntry {
+}): WorkbenchHostDockEntryPresentationOverride | null {
   if (
     entry.id === workspaceLaunchpadDockEntryId ||
     entry.id === workspaceFilesNodeID
   ) {
-    return entry;
+    return null;
   }
   const retained =
     retainedByEntryId[entry.id] ??
     resolveWorkspaceDockRetentionDefault({ appCenterService, entry });
   return {
-    ...entry,
     dockRetention: {
       actionId: `${workspaceDockRetentionActionPrefix}${encodeURIComponent(entry.id)}`,
       retained
     },
     visibility: retained ? "always" : "when-open"
-  };
-}
-
-function resolveWorkspaceDockRetentionContribution({
-  appCenterService,
-  contribution,
-  retainedByEntryId
-}: {
-  appCenterService: IWorkspaceAppCenterService;
-  contribution: WorkbenchContribution;
-  retainedByEntryId: Readonly<Record<string, boolean>>;
-}): WorkbenchContribution {
-  if (!contribution.dockEntries?.length) {
-    return contribution;
-  }
-  return {
-    ...contribution,
-    dockEntries: contribution.dockEntries.map((entry) =>
-      resolveWorkspaceDockRetentionEntry({
-        appCenterService,
-        entry,
-        retainedByEntryId
-      })
-    )
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
@@ -79,6 +79,7 @@ export interface WorkspaceWorkbenchShellRuntime {
   dockIconStyle: DesktopDockIconStyle;
   dockPlacement: WorkbenchDockPlacement;
   defaultAgentProvider: WorkspaceAgentProvider;
+  dockRetentionByEntryId: Readonly<Record<string, boolean>>;
   featureFlags: DesktopFeatureFlags;
   minimizeAnimation: DesktopMinimizeAnimation;
   hostInput: ReturnType<
@@ -104,6 +105,7 @@ export interface WorkspaceWorkbenchShellRuntime {
   onWorkbenchHostHandleReady: (host: WorkbenchHostHandle | null) => void;
   onWorkbenchCloseGuardHostReady: (host: WorkbenchHostHandle | null) => void;
   requestWindowClose: () => Promise<"approved" | "blocked">;
+  setDockEntryRetained: (entryId: string, retained: boolean) => Promise<void>;
   selectWallpaper: (wallpaperId: WorkspaceWallpaperId) => void;
   selectWallpaperDisplayMode: (
     displayMode: WorkspaceWallpaperDisplayMode
@@ -154,6 +156,11 @@ export function useWorkspaceWorkbenchShellRuntime({
     (listener) => workbenchHostService.subscribeWallpaperChanges(listener),
     () => workbenchHostService.getWallpaperRevision(),
     () => workbenchHostService.getWallpaperRevision()
+  );
+  const dockRetentionRevision = useSyncExternalStore(
+    workbenchHostService.dockRetention.subscribe,
+    workbenchHostService.dockRetention.getRevision,
+    workbenchHostService.dockRetention.getRevision
   );
   const workbenchDesktopI18n = useMemo(
     () => createWorkspaceWorkbenchDesktopI18nRuntime(appI18n),
@@ -420,6 +427,22 @@ export function useWorkspaceWorkbenchShellRuntime({
     },
     [hostSession, shellRuntimeController]
   );
+  const setDockEntryRetained = useCallback(
+    (entryId: string, retained: boolean) =>
+      workbenchHostService.dockRetention.setRetained(
+        state.workspace.id,
+        entryId,
+        retained
+      ),
+    [state.workspace.id, workbenchHostService]
+  );
+  const dockRetentionByEntryId = useMemo(
+    () =>
+      workbenchHostService.dockRetention.readRetainedByEntryId(
+        state.workspace.id
+      ),
+    [dockRetentionRevision, state.workspace.id, workbenchHostService]
+  );
 
   return {
     appI18n,
@@ -430,6 +453,7 @@ export function useWorkspaceWorkbenchShellRuntime({
     },
     dockIconStyle: desktopPreferencesState.dockIconStyle,
     dockPlacement: desktopPreferencesState.dockPlacement,
+    dockRetentionByEntryId,
     defaultAgentProvider: desktopPreferencesState.defaultAgentProvider,
     featureFlags: desktopPreferencesState.featureFlags,
     hostInput: shellRuntimeSnapshot.hostInput,
@@ -448,6 +472,7 @@ export function useWorkspaceWorkbenchShellRuntime({
     onWorkbenchHostHandleReady: handleWorkbenchHostReady,
     onWorkbenchCloseGuardHostReady: handleWorkbenchCloseGuardHostReady,
     requestWindowClose: () => shellRuntimeController.requestWindowClose(),
+    setDockEntryRetained,
     selectWallpaper: shellRuntimeController.wallpaperSelection.selectWallpaper,
     selectWallpaperDisplayMode:
       shellRuntimeController.wallpaperSelection.selectDisplayMode,

--- a/docs/conventions/workbench.md
+++ b/docs/conventions/workbench.md
@@ -78,10 +78,14 @@ Rules:
 - adapter-specific durable state should remain behind generic contract fields
   unless the adapter detail is part of the shared snapshot contract
 - desktop-owned workspace Dock retention is product metadata in the workspace
-  Workbench snapshot. Preserve explicit `false` values as user choices instead
-  of re-deriving them from app installation state after reload, and merge this
-  metadata through the repository's product-owner path so ordinary host saves
-  cannot overwrite it
+  Workbench snapshot. Preserve explicit `false` values as user choices and
+  merge them through the repository's product-owner path so ordinary host
+  saves cannot overwrite them
+- treat retention as a Dock presentation override. Product hosts must pass it
+  through `dockEntryPresentationOverrides`; they must not rewrite contribution
+  Dock entries or let presentation state flow into contribution nodes/runtime
+  configuration. WorkbenchHost applies overrides in place after Dock entries
+  are merged so presentation changes preserve entry order and host sessions
 
 Breaking migration rule:
 

--- a/docs/conventions/workbench.md
+++ b/docs/conventions/workbench.md
@@ -77,6 +77,11 @@ Rules:
   render data before persistence
 - adapter-specific durable state should remain behind generic contract fields
   unless the adapter detail is part of the shared snapshot contract
+- desktop-owned workspace Dock retention is product metadata in the workspace
+  Workbench snapshot. Preserve explicit `false` values as user choices instead
+  of re-deriving them from app installation state after reload, and merge this
+  metadata through the repository's product-owner path so ordinary host saves
+  cannot overwrite it
 
 Breaking migration rule:
 

--- a/packages/workbench/surface/README.md
+++ b/packages/workbench/surface/README.md
@@ -61,6 +61,13 @@ Entries may also provide host-owned popup metadata through
 `resolvePopupItem(...)` and `capturePopupItemPreview(...)`, plus custom badge
 content when the default count or status shapes are not enough.
 
+Presentation-only changes to merged Dock entries belong in
+`dockEntryPresentationOverrides`. `WorkbenchHost` applies these overrides by
+entry id after contributions and explicit entries are merged, preserving Dock
+order without changing contribution nodes or rebuilding the host session. Use
+this seam for host-owned visibility and retention presentation; keep product
+preference persistence in the consuming host.
+
 Dock, shortcut, and command opens flow through `launchNode(...)` and the
 optional `onLaunchRequest(...)` callback. The host may create a business
 instance asynchronously, then return the shell identity, title, default frame,

--- a/packages/workbench/surface/package.json
+++ b/packages/workbench/surface/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts && node ../../../tools/scripts/copy-package-assets.mjs src/styles dist/styles",
-    "test": "node --test --experimental-strip-types ./src/**/*.test.ts && vitest run ./src/host/WorkbenchHostDock.render.test.tsx --environment jsdom",
+    "test": "node --test --experimental-strip-types ./src/**/*.test.ts && vitest run ./src/host/WorkbenchHostDock.render.test.tsx ./src/host/WorkbenchHost.render.test.tsx --environment jsdom",
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },
   "devDependencies": {

--- a/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
@@ -1,0 +1,98 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it, vi } from "vitest";
+import type { WorkbenchSnapshot } from "@tutti-os/workbench-snapshot";
+import { WorkbenchHost } from "./WorkbenchHost.tsx";
+import type {
+  WorkbenchContribution,
+  WorkbenchHostDockEntryPresentationOverrides,
+  WorkbenchHostHandle,
+  WorkbenchHostSnapshotRepository
+} from "./types.ts";
+
+describe("WorkbenchHost", () => {
+  it("keeps the host session when Dock presentation overrides change identity", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const onHandleReady = vi.fn<(handle: WorkbenchHostHandle | null) => void>();
+    const contribution: WorkbenchContribution = {
+      dockEntries: [
+        {
+          icon: null,
+          id: "browser",
+          label: "Browser",
+          typeId: "browser"
+        }
+      ],
+      id: "browser"
+    };
+    const contributions = [contribution];
+    const snapshotRepository: WorkbenchHostSnapshotRepository = {
+      async load() {
+        return null;
+      },
+      save(_workspaceId: string, snapshot: WorkbenchSnapshot) {
+        return snapshot;
+      }
+    };
+    const firstOverrides: WorkbenchHostDockEntryPresentationOverrides = {
+      browser: { visibility: "always" }
+    };
+    const secondOverrides: WorkbenchHostDockEntryPresentationOverrides = {
+      browser: {
+        dockRetention: {
+          actionId: "workspace-dock-retention:browser",
+          retained: false
+        },
+        visibility: "when-open"
+      }
+    };
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchHost
+            contributions={contributions}
+            dockEntryPresentationOverrides={firstOverrides}
+            onHandleReady={onHandleReady}
+            snapshotRepository={snapshotRepository}
+            workspaceId="workspace-1"
+          />
+        );
+      });
+      const firstHandle = onHandleReady.mock.calls[0]?.[0];
+      expect(firstHandle).toBeTruthy();
+      expect(onHandleReady).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        root.render(
+          <WorkbenchHost
+            contributions={contributions}
+            dockEntryPresentationOverrides={secondOverrides}
+            onHandleReady={onHandleReady}
+            snapshotRepository={snapshotRepository}
+            workspaceId="workspace-1"
+          />
+        );
+      });
+
+      expect(onHandleReady).toHaveBeenCalledTimes(1);
+      expect(onHandleReady.mock.calls[0]?.[0]).toBe(firstHandle);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+  });
+});

--- a/packages/workbench/surface/src/host/WorkbenchHost.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHost.tsx
@@ -23,6 +23,7 @@ export function WorkbenchHost({
   debugDiagnostics,
   dockPreviewCache,
   dockPlacement,
+  dockEntryPresentationOverrides,
   dockEntries,
   dockStateSource,
   externalStateSource,
@@ -68,9 +69,10 @@ export function WorkbenchHost({
     () =>
       resolveWorkbenchHostDockEntries({
         contributions,
+        dockEntryPresentationOverrides,
         dockEntries
       }),
-    [contributions, dockEntries]
+    [contributions, dockEntries, dockEntryPresentationOverrides]
   );
   const missionControlMode = missionControl?.mode ?? null;
   const missionControlNodeIds = missionControl?.nodeIds;

--- a/packages/workbench/surface/src/host/hostConfig.test.ts
+++ b/packages/workbench/surface/src/host/hostConfig.test.ts
@@ -70,6 +70,43 @@ test("resolveWorkbenchHostDockEntries merges dock entries without touching runti
   assert.deepEqual(resolved, [browserDockEntry, explicitDockEntry]);
 });
 
+test("resolveWorkbenchHostDockEntries applies presentation overrides without reordering merged entries", () => {
+  const browserDockEntry = createDockEntry("browser", "Browser");
+  const terminalDockEntry = createDockEntry("terminal", "Terminal");
+
+  const resolved = resolveWorkbenchHostDockEntries({
+    contributions: [
+      {
+        dockEntries: [browserDockEntry, terminalDockEntry],
+        id: "tools"
+      }
+    ],
+    dockEntryPresentationOverrides: {
+      browser: {
+        dockRetention: {
+          actionId: "dock-retention:browser",
+          retained: false
+        },
+        visibility: "when-open"
+      }
+    }
+  });
+
+  assert.deepEqual(
+    resolved.map((entry) => entry.id),
+    ["browser", "terminal"]
+  );
+  assert.deepEqual(resolved[0], {
+    ...browserDockEntry,
+    dockRetention: {
+      actionId: "dock-retention:browser",
+      retained: false
+    },
+    visibility: "when-open"
+  });
+  assert.equal(resolved[1], terminalDockEntry);
+});
+
 test("resolveWorkbenchHostRuntimeConfig supports contribution-only nodes", () => {
   const terminalNode = createNodeDefinition("terminal", "Terminal");
 

--- a/packages/workbench/surface/src/host/hostConfig.ts
+++ b/packages/workbench/surface/src/host/hostConfig.ts
@@ -29,6 +29,7 @@ export function resolveWorkbenchHostConfig(
   props: Pick<
     WorkbenchHostProps,
     | "contributions"
+    | "dockEntryPresentationOverrides"
     | "dockEntries"
     | "externalStateSource"
     | "nodes"
@@ -46,14 +47,25 @@ export function resolveWorkbenchHostConfig(
 }
 
 export function resolveWorkbenchHostDockEntries(
-  props: Pick<WorkbenchHostProps, "contributions" | "dockEntries">
+  props: Pick<
+    WorkbenchHostProps,
+    "contributions" | "dockEntryPresentationOverrides" | "dockEntries"
+  >
 ): readonly WorkbenchHostDockEntry[] {
   const contributions = props.contributions ?? [];
-  return mergeByKey(
+  const mergedEntries = mergeByKey(
     contributions.flatMap((contribution) => contribution.dockEntries ?? []),
     props.dockEntries ?? [],
     (entry) => entry.id
   );
+  const presentationOverrides = props.dockEntryPresentationOverrides;
+  if (!presentationOverrides) {
+    return mergedEntries;
+  }
+  return mergedEntries.map((entry) => {
+    const presentationOverride = presentationOverrides[entry.id];
+    return presentationOverride ? { ...entry, ...presentationOverride } : entry;
+  });
 }
 
 export function resolveWorkbenchHostRuntimeConfig(

--- a/packages/workbench/surface/src/host/types.ts
+++ b/packages/workbench/surface/src/host/types.ts
@@ -295,6 +295,14 @@ export interface WorkbenchHostDockEntry {
   visibility?: WorkbenchHostDockEntryVisibility;
 }
 
+export type WorkbenchHostDockEntryPresentationOverride = Readonly<
+  Partial<Pick<WorkbenchHostDockEntry, "dockRetention" | "visibility">>
+>;
+
+export type WorkbenchHostDockEntryPresentationOverrides = Readonly<
+  Record<string, WorkbenchHostDockEntryPresentationOverride>
+>;
+
 export type WorkbenchHostDockEntryDynamicState = Partial<
   Pick<
     WorkbenchHostDockEntry,
@@ -615,6 +623,7 @@ export interface WorkbenchHostProps {
   dockPreviewCache?: WorkbenchDockPreviewCache;
   dockPlacement?: WorkbenchDockPlacement;
   dockEntries?: readonly WorkbenchHostDockEntry[];
+  dockEntryPresentationOverrides?: WorkbenchHostDockEntryPresentationOverrides;
   dockStateSource?: WorkbenchHostDockEntryStateSource;
   externalStateSource?: WorkbenchHostExternalStateSource;
   i18n?: I18nRuntime<string>;

--- a/packages/workbench/surface/src/index.ts
+++ b/packages/workbench/surface/src/index.ts
@@ -44,6 +44,8 @@ export type {
   WorkbenchHostDockEntryBadge,
   WorkbenchHostDockEntryDynamicState,
   WorkbenchHostDockEntryLaunchBehavior,
+  WorkbenchHostDockEntryPresentationOverride,
+  WorkbenchHostDockEntryPresentationOverrides,
   WorkbenchHostDockEntryStateSource,
   WorkbenchHostDockPopupItemDescriptor,
   WorkbenchHostDockPopupItemInput,


### PR DESCRIPTION
## Summary

- persist each workspace's Dock retention choices in Workbench snapshot product metadata instead of renderer-only state
- preserve explicit removed entries across reloads and ordinary host snapshot saves while keeping optimistic UI updates with rollback on write failure
- document the durable Workbench ownership rule and add metadata, controller, repository, and reload regression coverage

## Verification

- `pnpm check:changed -- --tail-lines 80` (7 lanes passed)
- pre-push `pnpm check:changed -- --push-ready` (8 lanes passed)
- `pnpm --filter @tutti-os/desktop build`
- targeted Dock metadata/controller/repository/host tests (34 passed)

## Fix Scope Justification

- Root cause: Remove from Dock only changed `temporaryDockRetentionByEntryId` in the renderer. Reloading cleared that map and re-derived installed apps as retained.
- Why can this not be fixed at a lower layer? The shared Dock surface only emits generic actions and must remain product-neutral. Durable workspace state belongs behind the desktop Workbench repository and tuttid-backed snapshot boundary; renderer-local storage would create a second business-state owner. Most added lines are focused persistence and regression tests.

## Fallback Three Questions

- Source: pending state and the per-workspace write queue cover the interval between a Dock action and the authoritative snapshot save.
- Why can it not be fixed at that source? Workbench snapshots are whole-document writes, so product metadata changes must be serialized and merged with concurrent host saves at the repository boundary.
- Removal condition: the pending overlay and queue can be removed if the repository gains an atomic Dock-retention field update with equivalent ordering and failure rollback guarantees.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (Not applicable.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (Not applicable.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes durable Workbench snapshot merging and concurrent save behavior alongside user-facing dock state, but follows the existing product-metadata pattern with broad regression tests and no auth or data-exfiltration surface.
> 
> **Overview**
> **Dock “remove from dock” choices now survive reload** by storing per-entry retention in workspace Workbench snapshot product metadata (`workspaceDock.retainedByEntryId`), including explicit `false` for removed apps, instead of ephemeral React state that was lost on refresh.
> 
> A **`WorkspaceDockRetentionService`** on the workbench host performs optimistic UI updates, serializes writes per workspace, persists via `saveProductMetadata(..., "dock")`, and rolls back in-memory state if persistence fails. The shell runtime subscribes to retention revisions and exposes `dockRetentionByEntryId` / `setDockEntryRetained` to `WorkspaceWorkbench`, which still derives dock visibility from persisted values with the same install-based defaults when no override exists.
> 
> The **desktop workbench repository** treats dock like wallpaper/onboarding: dedicated merge on host saves so routine snapshot writes cannot clobber dock metadata, plus regression tests for reload, cross-metadata preservation, and concurrent save ordering. **Workbench conventions** document this ownership rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87f4d75f8c2520ccc31c451c0718e074f57ea6b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->