### PR TITLE
fix(cli): return structured JSON errors

### DIFF
--- a/apps/cli/internal/app/errors.go
+++ b/apps/cli/internal/app/errors.go
@@ -1,0 +1,96 @@
+package app
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/tutti-os/tutti/apps/cli/internal/daemon"
+)
+
+const (
+	reasonCommandNotFound      = "command_not_found"
+	reasonCommandOutputMissing = "command_output_missing"
+	reasonDaemonRequestFailed  = "daemon_request_failed"
+	reasonDaemonUnavailable    = "daemon_unavailable"
+	reasonInvalidInput         = "invalid_input"
+)
+
+type cliErrorEnvelope struct {
+	Error cliErrorDetails `json:"error"`
+}
+
+type cliErrorDetails struct {
+	ReasonCode    string `json:"reasonCode"`
+	Message       string `json:"message"`
+	Retryable     bool   `json:"retryable,omitempty"`
+	CorrelationID string `json:"correlationId,omitempty"`
+}
+
+func jsonRequested(args []string) bool {
+	for _, arg := range args {
+		if arg == "--json" {
+			return true
+		}
+	}
+	return false
+}
+
+func writeCLIError(
+	stdout io.Writer,
+	stderr io.Writer,
+	jsonOutput bool,
+	prefix string,
+	reasonCode string,
+	err error,
+	exitCode int,
+) int {
+	message := strings.TrimSpace(errorMessage(err))
+	if jsonOutput {
+		details := cliErrorDetails{
+			ReasonCode: strings.TrimSpace(reasonCode),
+			Message:    message,
+		}
+		if daemonDetails, ok := daemon.RequestErrorDetails(err); ok {
+			if daemonDetails.ReasonCode != "" {
+				details.ReasonCode = daemonDetails.ReasonCode
+			}
+			if daemonDetails.Message != "" {
+				details.Message = daemonDetails.Message
+			}
+			details.Retryable = daemonDetails.Retryable
+			details.CorrelationID = daemonDetails.CorrelationID
+		}
+		if details.ReasonCode == "" {
+			details.ReasonCode = reasonInvalidInput
+		}
+		if details.Message == "" {
+			details.Message = details.ReasonCode
+		}
+		if code := writeJSON(stdout, stderr, cliErrorEnvelope{Error: details}); code != 0 {
+			return code
+		}
+		return exitCode
+	}
+	if prefix == "" {
+		fmt.Fprintln(stderr, message)
+	} else {
+		fmt.Fprintf(stderr, "%s: %s\n", strings.TrimSpace(prefix), message)
+	}
+	return exitCode
+}
+
+func daemonErrorExitCode(err error) int {
+	details, ok := daemon.RequestErrorDetails(err)
+	if ok && details.StatusCode == 400 {
+		return 2
+	}
+	return 1
+}
+
+func errorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/apps/cli/internal/app/managed_model.go
+++ b/apps/cli/internal/app/managed_model.go
@@ -40,16 +40,14 @@ type managedModelCredentialInput struct {
 	Provider   string `json:"provider"`
 }
 
-func runManagedModel(ctx context.Context, commandName string, _ options, args []string, stdout io.Writer, stderr io.Writer) int {
+func runManagedModel(ctx context.Context, commandName string, opts options, args []string, stdout io.Writer, stderr io.Writer) int {
 	commandID, input, err := parseManagedModelInput(args)
 	if err != nil {
-		fmt.Fprintf(stderr, "%s managed-model: %v\n", commandName, err)
-		return 2
+		return writeCLIError(stdout, stderr, opts.json, commandName+" managed-model", reasonInvalidInput, err, 2)
 	}
 	client, err := discoverClient()
 	if err != nil {
-		fmt.Fprintf(stderr, "%s managed-model: %v\n", commandName, err)
-		return 1
+		return writeCLIError(stdout, stderr, opts.json, commandName+" managed-model", reasonDaemonUnavailable, err, 1)
 	}
 	response, err := client.Invoke(ctx, commandID, daemon.InvokeRequest{
 		Input:      input,
@@ -57,12 +55,13 @@ func runManagedModel(ctx context.Context, commandName string, _ options, args []
 		Context:    cliInvokeContextFromEnv(),
 	})
 	if err != nil {
-		fmt.Fprintf(stderr, "%s managed-model: %v\n", commandName, err)
-		return 1
+		return writeCLIError(stdout, stderr, opts.json, commandName+" managed-model", reasonDaemonRequestFailed, err, daemonErrorExitCode(err))
 	}
 	if response.Output == nil {
-		fmt.Fprintf(stderr, "%s managed-model: command returned no output\n", commandName)
-		return 1
+		return writeCLIError(
+			stdout, stderr, opts.json, commandName+" managed-model", reasonCommandOutputMissing,
+			fmt.Errorf("command returned no output"), 1,
+		)
 	}
 	return writeDynamicJSON(stdout, stderr, *response.Output)
 }

--- a/apps/cli/internal/app/run.go
+++ b/apps/cli/internal/app/run.go
@@ -24,8 +24,7 @@ func RunWithProgram(ctx context.Context, program string, args []string, stdout i
 	commandName := displayCommandName(program)
 	opts, rest, err := parseOptions(args)
 	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 2
+		return writeCLIError(stdout, stderr, jsonRequested(args), "", reasonInvalidInput, err, 2)
 	}
 	if len(rest) == 0 || rest[0] == "help" || rest[0] == "--help" || rest[0] == "-h" {
 		return runHelp(ctx, commandName, stdout)
@@ -34,8 +33,10 @@ func RunWithProgram(ctx context.Context, program string, args []string, stdout i
 	switch rest[0] {
 	case "status":
 		if len(rest) != 1 {
-			fmt.Fprintf(stderr, "usage: %s status [--json]\n", commandName)
-			return 2
+			return writeCLIError(
+				stdout, stderr, opts.json, "", reasonInvalidInput,
+				fmt.Errorf("usage: %s status [--json]", commandName), 2,
+			)
 		}
 		return runStatus(ctx, commandName, opts, stdout, stderr)
 	case "managed-model":
@@ -83,13 +84,11 @@ func parseOptions(args []string) (options, []string, error) {
 func runStatus(ctx context.Context, commandName string, opts options, stdout io.Writer, stderr io.Writer) int {
 	client, err := discoverClient()
 	if err != nil {
-		fmt.Fprintf(stderr, "%s status: %v\n", commandName, err)
-		return 1
+		return writeCLIError(stdout, stderr, opts.json, commandName+" status", reasonDaemonUnavailable, err, 1)
 	}
 	health, err := client.GetHealth(ctx)
 	if err != nil {
-		fmt.Fprintf(stderr, "%s status: %v\n", commandName, err)
-		return 1
+		return writeCLIError(stdout, stderr, opts.json, commandName+" status", reasonDaemonRequestFailed, err, daemonErrorExitCode(err))
 	}
 
 	if opts.json {
@@ -101,18 +100,17 @@ func runStatus(ctx context.Context, commandName string, opts options, stdout io.
 }
 
 func runDynamic(ctx context.Context, commandName string, opts options, args []string, stdout io.Writer, stderr io.Writer) int {
+	invocationPrefix := strings.TrimSpace(commandName + " " + strings.Join(args, " "))
 	client, err := discoverClient()
 	if err != nil {
-		fmt.Fprintf(stderr, "%s %s: %v\n", commandName, strings.Join(args, " "), err)
-		return 1
+		return writeCLIError(stdout, stderr, opts.json, invocationPrefix, reasonDaemonUnavailable, err, 1)
 	}
 	invokeContext := cliInvokeContextFromEnv()
 	capabilities, err := client.ListCapabilitiesForWorkspaceWithOptions(ctx, invokeContext.WorkspaceID, daemon.CapabilityListOptions{
 		IncludeIntegration: includeIntegrationCapabilitiesFromEnv(),
 	})
 	if err != nil {
-		fmt.Fprintf(stderr, "%s %s: %v\n", commandName, strings.Join(args, " "), err)
-		return 1
+		return writeCLIError(stdout, stderr, opts.json, invocationPrefix, reasonDaemonRequestFailed, err, daemonErrorExitCode(err))
 	}
 	command, commandArgs, ok := matchCapability(capabilities.Commands, args)
 	if !ok && legacyAgentCompatibilityInvocation(args) && !includeIntegrationCapabilitiesFromEnv() {
@@ -129,11 +127,13 @@ func runDynamic(ctx context.Context, commandName string, opts options, args []st
 				return 0
 			}
 		}
-		if printCommandPrefixHelp(stdout, commandName, args, capabilities.Commands) {
+		if !opts.json && printCommandPrefixHelp(stdout, commandName, args, capabilities.Commands) {
 			return 2
 		}
-		fmt.Fprintf(stderr, "unknown command: %s\n", strings.Join(args, " "))
-		return 2
+		return writeCLIError(
+			stdout, stderr, opts.json, "", reasonCommandNotFound,
+			fmt.Errorf("unknown command: %s", strings.Join(args, " ")), 2,
+		)
 	}
 	if isCommandHelpRequest(commandArgs) {
 		printDynamicCommandHelp(stdout, commandName, command)
@@ -141,8 +141,8 @@ func runDynamic(ctx context.Context, commandName string, opts options, args []st
 	}
 	input, err := parseCommandInput(command, commandArgs)
 	if err != nil {
-		fmt.Fprintf(stderr, "%s %s: %v\n", commandName, strings.Join(command.Path, " "), err)
-		return 2
+		prefix := strings.TrimSpace(commandName + " " + strings.Join(command.Path, " "))
+		return writeCLIError(stdout, stderr, opts.json, prefix, reasonInvalidInput, err, 2)
 	}
 	outputMode := command.Output.DefaultMode
 	if opts.json {
@@ -154,8 +154,8 @@ func runDynamic(ctx context.Context, commandName string, opts options, args []st
 		Context:    invokeContext,
 	})
 	if err != nil {
-		fmt.Fprintf(stderr, "%s %s: %v\n", commandName, strings.Join(command.Path, " "), err)
-		return 1
+		prefix := strings.TrimSpace(commandName + " " + strings.Join(command.Path, " "))
+		return writeCLIError(stdout, stderr, opts.json, prefix, reasonDaemonRequestFailed, err, daemonErrorExitCode(err))
 	}
 	if response.Output == nil {
 		return 0

--- a/apps/cli/internal/app/run_test.go
+++ b/apps/cli/internal/app/run_test.go
@@ -237,6 +237,39 @@ func TestRunStatusAuthFailure(t *testing.T) {
 	}
 }
 
+func TestRunStatusJSONAuthFailureIsStructured(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	writeEndpoint(t, server.URL, "token-1")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := runDefaultProgram(t, []string{"status", "--json"}, &stdout, &stderr); code != 1 {
+		t.Fatalf("code = %d, want 1", code)
+	}
+	assertCLIJSONError(t, stdout.Bytes(), "unauthorized", "daemon authentication failed")
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunStatusJSONDaemonUnavailableIsStructured(t *testing.T) {
+	t.Setenv("TUTTID_LISTENER_INFO_PATH", filepath.Join(t.TempDir(), "missing-listener.json"))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := runDefaultProgram(t, []string{"status", "--json"}, &stdout, &stderr); code != 1 {
+		t.Fatalf("code = %d, want 1", code)
+	}
+	assertCLIJSONError(t, stdout.Bytes(), "daemon_unavailable", "daemon endpoint is not available")
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestRunDynamicCommandRendersTable(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -618,6 +651,133 @@ func TestRunDynamicCommandRejectsUnexpectedPositionalArgument(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), `unexpected argument "ISS-1"`) {
 		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunDynamicJSONRejectsInvalidInputWithStructuredError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/cli/capabilities" {
+			_, _ = w.Write([]byte(`{"commands":[{"id":"issue-manager.issue.get","path":["issue","get"],"summary":"Get issue","output":{"defaultMode":"json","json":true}}]}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	writeEndpoint(t, server.URL, "token-1")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := runDefaultProgram(t, []string{"--json", "issue", "get", "ISS-1"}, &stdout, &stderr); code != 2 {
+		t.Fatalf("code = %d, want 2", code)
+	}
+	assertCLIJSONError(t, stdout.Bytes(), "invalid_input", `unexpected argument "ISS-1"`)
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunDynamicJSONPreservesDaemonReasonCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/cli/capabilities":
+			_, _ = w.Write([]byte(`{"commands":[{"id":"agent-context.agent.get","path":["agent","get"],"summary":"Get agent session","output":{"defaultMode":"json","json":true}}]}`))
+		case "/v1/cli/commands/agent-context.agent.get/invoke":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code":"workspace_not_found","reason":"workspace_agent_session_not_found","developerMessage":"agent session was not found"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	writeEndpoint(t, server.URL, "token-1")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := runDefaultProgram(t, []string{"--json", "agent", "get"}, &stdout, &stderr); code != 1 {
+		t.Fatalf("code = %d, want 1", code)
+	}
+	assertCLIJSONError(t, stdout.Bytes(), "workspace_agent_session_not_found", "agent session was not found")
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunDynamicJSONMapsDaemonInvalidInputToExitCodeTwo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/cli/capabilities":
+			_, _ = w.Write([]byte(`{"commands":[{"id":"agent-context.agent.get","path":["agent","get"],"summary":"Get agent session","output":{"defaultMode":"json","json":true}}]}`))
+		case "/v1/cli/commands/agent-context.agent.get/invoke":
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"code":"invalid_request","reason":"malformed_request","developerMessage":"session id is required"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	writeEndpoint(t, server.URL, "token-1")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := runDefaultProgram(t, []string{"--json", "agent", "get"}, &stdout, &stderr); code != 2 {
+		t.Fatalf("code = %d, want 2", code)
+	}
+	assertCLIJSONError(t, stdout.Bytes(), "malformed_request", "session id is required")
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunDynamicJSONUnknownCommandIsStructured(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/cli/capabilities" {
+			_, _ = w.Write([]byte(`{"commands":[]}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	writeEndpoint(t, server.URL, "token-1")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := runDefaultProgram(t, []string{"--json", "unknown", "command"}, &stdout, &stderr); code != 2 {
+		t.Fatalf("code = %d, want 2", code)
+	}
+	assertCLIJSONError(t, stdout.Bytes(), "command_not_found", "unknown command: unknown command")
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunManagedModelJSONInvalidInputIsStructured(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := runDefaultProgram(t, []string{"--json", "managed-model", "unknown"}, &stdout, &stderr); code != 2 {
+		t.Fatalf("code = %d, want 2", code)
+	}
+	assertCLIJSONError(t, stdout.Bytes(), "invalid_input", "expected grant exchange, models, credential, or revoke")
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func assertCLIJSONError(t *testing.T, content []byte, reasonCode string, message string) {
+	t.Helper()
+	var envelope cliErrorEnvelope
+	if err := json.Unmarshal(content, &envelope); err != nil {
+		t.Fatalf("decode CLI error: %v\n%s", err, content)
+	}
+	if envelope.Error.ReasonCode != reasonCode || !strings.Contains(envelope.Error.Message, message) {
+		t.Fatalf("error = %#v, want reasonCode %q message containing %q", envelope.Error, reasonCode, message)
 	}
 }
 

--- a/apps/cli/internal/daemon/client.go
+++ b/apps/cli/internal/daemon/client.go
@@ -111,6 +111,16 @@ type CommandWarning struct {
 	Message string `json:"message"`
 }
 
+type apiErrorEnvelope struct {
+	Error struct {
+		Code             string `json:"code"`
+		Reason           string `json:"reason"`
+		Retryable        bool   `json:"retryable"`
+		DeveloperMessage string `json:"developerMessage"`
+		CorrelationID    string `json:"correlationId"`
+	} `json:"error"`
+}
+
 func NewClient(endpoint Endpoint) (*Client, error) {
 	baseURL, err := endpoint.BaseURL()
 	if err != nil {
@@ -169,7 +179,7 @@ func (client *Client) DoJSON(ctx context.Context, method string, path string, bo
 	if body != nil {
 		encoded, err := json.Marshal(body)
 		if err != nil {
-			return fmt.Errorf("encode request body: %w", err)
+			return newRequestError(ErrorDetails{ReasonCode: "daemon_request_invalid", Message: fmt.Sprintf("encode request body: %v", err)})
 		}
 		requestBody = bytes.NewReader(encoded)
 	}
@@ -177,7 +187,7 @@ func (client *Client) DoJSON(ctx context.Context, method string, path string, bo
 	url := client.baseURL + path
 	request, err := http.NewRequestWithContext(ctx, method, url, requestBody)
 	if err != nil {
-		return fmt.Errorf("create daemon request: %w", err)
+		return newRequestError(ErrorDetails{ReasonCode: "daemon_request_invalid", Message: fmt.Sprintf("create daemon request: %v", err)})
 	}
 	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Authorization", "Bearer "+client.token)
@@ -193,38 +203,64 @@ func (client *Client) DoJSON(ctx context.Context, method string, path string, bo
 
 	content, err := io.ReadAll(response.Body)
 	if err != nil {
-		return fmt.Errorf("read daemon response: %w", err)
-	}
-	if response.StatusCode == http.StatusUnauthorized {
-		return fmt.Errorf("daemon authentication failed")
+		return newRequestError(ErrorDetails{ReasonCode: "daemon_response_read_failed", Message: fmt.Sprintf("read daemon response: %v", err)})
 	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		message := strings.TrimSpace(string(content))
-		if message == "" {
-			message = response.Status
-		}
-		return fmt.Errorf("daemon request failed: %s", message)
+		return daemonResponseError(response.StatusCode, response.Status, content)
 	}
 	if result == nil {
 		return nil
 	}
 	if err := json.Unmarshal(content, result); err != nil {
-		return fmt.Errorf("decode daemon response: %w", err)
+		return newRequestError(ErrorDetails{ReasonCode: "daemon_response_invalid", Message: fmt.Sprintf("decode daemon response: %v", err)})
 	}
 	return nil
 }
 
+func daemonResponseError(statusCode int, status string, content []byte) error {
+	var envelope apiErrorEnvelope
+	if err := json.Unmarshal(content, &envelope); err == nil {
+		reasonCode := strings.TrimSpace(envelope.Error.Reason)
+		if reasonCode == "" {
+			reasonCode = strings.TrimSpace(envelope.Error.Code)
+		}
+		if reasonCode != "" {
+			message := strings.TrimSpace(envelope.Error.DeveloperMessage)
+			if message == "" {
+				message = reasonCode
+			}
+			return newRequestError(ErrorDetails{
+				ReasonCode: reasonCode, Message: message, Retryable: envelope.Error.Retryable,
+				CorrelationID: strings.TrimSpace(envelope.Error.CorrelationID), StatusCode: statusCode,
+			})
+		}
+	}
+	if statusCode == http.StatusUnauthorized {
+		return newRequestError(ErrorDetails{ReasonCode: "unauthorized", Message: "daemon authentication failed", StatusCode: statusCode})
+	}
+	message := strings.TrimSpace(string(content))
+	if message == "" {
+		message = strings.TrimSpace(status)
+	}
+	return newRequestError(ErrorDetails{
+		ReasonCode: "daemon_request_failed", Message: "daemon request failed: " + message, StatusCode: statusCode,
+	})
+}
+
 func daemonRequestError(err error) error {
 	if errors.Is(err, context.Canceled) {
-		return fmt.Errorf("daemon request canceled")
+		return newRequestError(ErrorDetails{ReasonCode: "daemon_request_canceled", Message: "daemon request canceled"})
 	}
 	if errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err) {
-		return fmt.Errorf("daemon request timed out")
+		return newRequestError(ErrorDetails{ReasonCode: "daemon_request_timed_out", Message: "daemon request timed out", Retryable: true})
 	}
 	if runningInAgentEnvironment() {
-		return fmt.Errorf("daemon is not reachable from this agent execution environment; rerun the command in an execution environment with localhost/IPC access")
+		return newRequestError(ErrorDetails{
+			ReasonCode: "daemon_unavailable", Retryable: true,
+			Message: "daemon is not reachable from this agent execution environment; rerun the command in an execution environment with localhost/IPC access",
+		})
 	}
-	return fmt.Errorf("daemon is not reachable")
+	return newRequestError(ErrorDetails{ReasonCode: "daemon_unavailable", Message: "daemon is not reachable", Retryable: true})
 }
 
 func runningInAgentEnvironment() bool {

--- a/apps/cli/internal/daemon/client_test.go
+++ b/apps/cli/internal/daemon/client_test.go
@@ -48,6 +48,30 @@ func TestDoJSONReportsTimeoutSeparatelyFromUnreachable(t *testing.T) {
 	if strings.Contains(err.Error(), "daemon is not reachable") {
 		t.Fatalf("error = %q, should not report daemon as unreachable", err.Error())
 	}
+	details, ok := RequestErrorDetails(err)
+	if !ok || details.ReasonCode != "daemon_request_timed_out" || !details.Retryable {
+		t.Fatalf("details = %#v ok=%t", details, ok)
+	}
+}
+
+func TestDoJSONPreservesStructuredDaemonError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":"workspace_not_found","reason":"workspace_agent_session_not_found","retryable":true,"developerMessage":"agent session was not found","correlationId":"corr-1"}}`))
+	}))
+	defer server.Close()
+
+	client := &Client{baseURL: server.URL, token: "token-1", httpClient: server.Client()}
+	err := client.DoJSON(context.Background(), http.MethodGet, healthPath, nil, &HealthStatus{})
+	details, ok := RequestErrorDetails(err)
+	if !ok {
+		t.Fatalf("RequestErrorDetails(%v) did not match", err)
+	}
+	if details.ReasonCode != "workspace_agent_session_not_found" || details.Message != "agent session was not found" ||
+		!details.Retryable || details.CorrelationID != "corr-1" || details.StatusCode != http.StatusNotFound {
+		t.Fatalf("details = %#v", details)
+	}
 }
 
 func TestDaemonRequestErrorKeepsPlainUnreachableOutsideAgent(t *testing.T) {

--- a/apps/cli/internal/daemon/errors.go
+++ b/apps/cli/internal/daemon/errors.go
@@ -1,0 +1,45 @@
+package daemon
+
+import (
+	"errors"
+	"strings"
+)
+
+type ErrorDetails struct {
+	ReasonCode    string
+	Message       string
+	Retryable     bool
+	CorrelationID string
+	StatusCode    int
+}
+
+type requestError struct {
+	details ErrorDetails
+}
+
+func (e *requestError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.details.Message
+}
+
+func RequestErrorDetails(err error) (ErrorDetails, bool) {
+	var requestErr *requestError
+	if !errors.As(err, &requestErr) || requestErr == nil {
+		return ErrorDetails{}, false
+	}
+	return requestErr.details, true
+}
+
+func newRequestError(details ErrorDetails) error {
+	details.ReasonCode = strings.TrimSpace(details.ReasonCode)
+	details.Message = strings.TrimSpace(details.Message)
+	if details.ReasonCode == "" {
+		details.ReasonCode = "daemon_request_failed"
+	}
+	if details.Message == "" {
+		details.Message = details.ReasonCode
+	}
+	return &requestError{details: details}
+}

--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -8,6 +8,34 @@ The bundled CLI is a thin client. It discovers command capabilities from
 `InputSchema`, invokes the daemon command endpoint, and renders the returned
 `CommandOutput`.
 
+## Error Output
+
+`--json` applies to failure output as well as successful command output.
+Expected invocation, transport, and domain failures write one JSON object to
+stdout and do not fall back to free-form stderr text:
+
+```json
+{
+  "error": {
+    "reasonCode": "workspace_agent_session_not_found",
+    "message": "agent session was not found"
+  }
+}
+```
+
+The CLI preserves the daemon protocol `reason` as `reasonCode`, falling back to
+the daemon error `code` when no narrower reason exists. Optional daemon
+`retryable` and `correlationId` fields are preserved. Errors detected before a
+daemon invocation use stable CLI-owned reason codes such as `invalid_input`,
+`command_not_found`, and `daemon_unavailable`.
+
+Exit codes stay intentionally small and stable: `0` means success, `2` means
+the command invocation or input was invalid, and `1` means authentication,
+transport, domain, or runtime failure. A daemon HTTP 400 response is invalid
+input and therefore exits with `2`; other daemon failures exit with `1`.
+Without `--json`, ordinary human-facing failures continue to write concise
+text to stderr.
+
 ## Boundaries
 
 The daemon has two CLI command surfaces:


### PR DESCRIPTION
## Summary

- emit a stable JSON error envelope for CLI failures when JSON output is requested
- preserve daemon reason, retryable, correlation ID, and map invalid input to exit code 2
- keep human-facing non-JSON errors on stderr and document the public CLI contract

## Architecture

- keeps the CLI as a thin transport and presentation adapter over the existing daemon error protocol
- does not change daemon APIs, generated contracts, or Agent Host lifecycle semantics

## Testing

- cd apps/cli && go test ./...
- cd apps/cli && go build ./...
- pnpm check:defaults-generated
- pnpm check:changed -- --push-ready --tail-lines 80
- isolated TUTTI_STATE_DIR make dev-web acceptance covering status success, local invalid input, daemon HTTP 400, missing session, JSON stdout/stderr separation, and non-JSON compatibility
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->