### PR TITLE
fix(agent-gui): render conversation icons with mask longhands

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -59,6 +59,7 @@ React rendering, Workbench state, external stores, input composition, and UI per
 - [Inline custom-header menu is clipped to the Workbench title bar](./workbench-renderer.md#inline-custom-header-menu-is-clipped-to-the-workbench-title-bar)
 - [Dialog action reacts to Enter but ignores pointer clicks](./workbench-renderer.md#dialog-action-reacts-to-enter-but-ignores-pointer-clicks)
 - [Daemon validation error appears as untranslated developer text](./workbench-renderer.md#daemon-validation-error-appears-as-untranslated-developer-text)
+- [Mask-backed icon renders as a solid color block](./workbench-renderer.md#mask-backed-icon-renders-as-a-solid-color-block)
 
 ## [Workspace Apps And Files](./workspace-apps-files.md)
 

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -821,3 +821,33 @@
 - References:
   [apierrors.go](../../../services/tuttid/apierrors/apierrors.go)
   [agentGuiController.errors.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.errors.ts)
+
+### Mask-backed icon renders as a solid color block
+
+- Symptom:
+  A monochrome icon has the expected size and color but renders as a solid
+  square or rectangle. Other icons backed by the same packaged SVG still render
+  normally.
+- Quick checks:
+  Confirm the SVG import resolves to a CSS-safe self-contained data URL, then
+  inspect how that URL reaches the element. If the icon background applies but
+  the mask does not, look for a dynamic URL passed through a custom property
+  into the `mask` or `-webkit-mask` shorthand.
+- Root cause:
+  The dynamic mask source crossed two parsing boundaries: React serialized a
+  custom-property token stream, then the stylesheet substituted that stream
+  into a mask shorthand. When that composed declaration was rejected, the
+  element retained its background color and dimensions without any mask, which
+  exposed the full box.
+- Fix:
+  Keep the dynamic image source on the element through the explicit
+  `maskImage` and `WebkitMaskImage` longhands. Keep static position, repeat, and
+  size declarations in CSS longhands. Do not route dynamic image URLs through a
+  custom property into a shorthand.
+- Validation:
+  Assert the rendered element owns both mask-image longhands and that the
+  packaged SVG remains a CSS-safe data URL. Verify the affected icon in the
+  consuming renderer rather than inferring success from unrelated icon paths.
+- References:
+  [AgentGUIConversationRailItem.tsx](../../../packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.tsx)
+  [agentactivity.css](../../../packages/agent/gui/app/renderer/agentactivity.css)

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.spec.tsx
@@ -135,9 +135,10 @@ describe("AgentGUIConversationRailItem interaction lock", () => {
       ".agent-gui-node__conversation-provider-icon"
     );
     expect(icon).not.toBeNull();
+    expect(icon?.style.maskImage).toBe(`url("${maskIconUrl}")`);
     expect(
       icon?.style.getPropertyValue("--agent-gui-conversation-provider-icon-url")
-    ).toBe(`url("${maskIconUrl}")`);
+    ).toBe("");
   });
 
   it("blocks the div context-menu trigger while rail reconciliation is pending", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, type CSSProperties } from "react";
+import { memo, useCallback, useMemo } from "react";
 import { ExternalLink } from "lucide-react";
 import { IssueIcon, NewWorkspaceLinedIcon, cn } from "@tutti-os/ui-system";
 import { WorkspaceUserProjectSelect } from "@tutti-os/workspace-user-project/ui";
@@ -200,11 +200,10 @@ export const AgentGUIConversationRailItem = memo(
               <span
                 aria-hidden="true"
                 className={styles.conversationProviderIcon}
-                style={
-                  {
-                    "--agent-gui-conversation-provider-icon-url": `url("${conversationIconUrl}")`
-                  } as CSSProperties
-                }
+                style={{
+                  WebkitMaskImage: `url("${conversationIconUrl}")`,
+                  maskImage: `url("${conversationIconUrl}")`
+                }}
               />
             ) : null}
             {item.titleLeadingMentionKind === "task" ? (

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -6571,10 +6571,12 @@ button.agent-gui-node__conversation-section-toggle:hover
   height: 14px;
   color: var(--text-tertiary);
   background-color: currentColor;
-  mask: var(--agent-gui-conversation-provider-icon-url) center / contain
-    no-repeat;
-  -webkit-mask: var(--agent-gui-conversation-provider-icon-url) center / contain
-    no-repeat;
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-position: center;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
 }
 
 .agent-gui-node__conversation-title-mention-icon {


### PR DESCRIPTION
## Summary

- render conversation-rail provider icons with direct `maskImage` and `WebkitMaskImage` longhands
- keep static mask position, repeat, and size in CSS longhands
- document the solid-color mask failure mode and cover the rendering contract with a focused test

The affected rail path passed a dynamic SVG URL through a CSS custom property into the `mask` shorthand. When the composed declaration was rejected, the element kept its dimensions and background color but lost its mask, so the icon appeared as a solid square. Other icons such as Handoff use direct mask-image longhands and were unaffected.

## Verification

- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.spec.tsx` (11 tests passed)
- `pnpm --filter @tutti-os/agent-gui build`
- `pnpm check:changed`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm release:pack:check`
- inspected the built package: direct mask-image longhands are present and the removed custom property is absent
- consumer visual verification deferred to TSH after publishing; no browser automation was run

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (Not applicable.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (Not applicable.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->