### PR TITLE
fix(agent-gui): preserve conversation icon roles

### DIFF
--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -832,18 +832,22 @@
   Confirm the SVG import resolves to a CSS-safe self-contained data URL, then
   inspect how that URL reaches the element. If the icon background applies but
   the mask does not, look for a dynamic URL passed through a custom property
-  into the `mask` or `-webkit-mask` shorthand.
+  into the `mask` or `-webkit-mask` shorthand. If both mask-image longhands are
+  present, verify that their source is the dedicated monochrome `maskIconUrl`,
+  not the target's primary color `iconUrl`.
 - Root cause:
-  The dynamic mask source crossed two parsing boundaries: React serialized a
-  custom-property token stream, then the stylesheet substituted that stream
-  into a mask shorthand. When that composed declaration was rejected, the
-  element retained its background color and dimensions without any mask, which
-  exposed the full box.
+  Either the dynamic mask source crossed two parsing boundaries and the
+  composed declaration was rejected, or the renderer conflated two Agent
+  Directory roles by using the primary identity image as a monochrome mask. An
+  opaque primary image produces a full-box alpha mask even when the CSS is
+  valid.
 - Fix:
   Keep the dynamic image source on the element through the explicit
   `maskImage` and `WebkitMaskImage` longhands. Keep static position, repeat, and
   size declarations in CSS longhands. Do not route dynamic image URLs through a
-  custom property into a shorthand.
+  custom property into a shorthand. Preserve Agent Directory icon roles: render
+  `maskIconUrl` through the mask element and render an `iconUrl` without a
+  matching mask as a normal image.
 - Validation:
   Assert the rendered element owns both mask-image longhands and that the
   packaged SVG remains a CSS-safe data URL. Verify the affected icon in the

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
@@ -75,7 +75,10 @@ const styles = {
   conversationList: "agent-gui-node__conversation-list",
   conversationMeta: "agent-gui-node__conversation-meta",
   conversationMoreButton: "agent-gui-node__conversation-more-button",
+  conversationProviderImage: "agent-gui-node__conversation-provider-image",
   conversationProviderIcon: "agent-gui-node__conversation-provider-icon",
+  conversationProviderMaskIcon:
+    "agent-gui-node__conversation-provider-mask-icon",
   conversationOpenWindowButton:
     "agent-gui-node__conversation-open-window-button",
   conversationPinButton: "agent-gui-node__conversation-pin-button",

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.spec.tsx
@@ -141,6 +141,35 @@ describe("AgentGUIConversationRailItem interaction lock", () => {
     ).toBe("");
   });
 
+  it("renders a target identity image without treating it as a mask", () => {
+    const iconUrl = "data:image/png;base64,kilo-colored";
+    const { container } = renderRailItem({
+      agentTargets: [
+        {
+          agentTargetId: "extension:kilo",
+          iconUrl,
+          provider: "acp:kilo",
+          workspaceId: "workspace-1"
+        }
+      ],
+      isRailInteractionLocked: () => false,
+      item: {
+        agentTargetId: "extension:kilo",
+        provider: "acp:kilo"
+      }
+    });
+
+    const image = container.querySelector<HTMLImageElement>(
+      ".agent-gui-node__conversation-provider-image"
+    );
+    expect(image?.src).toBe(iconUrl);
+    expect(
+      container.querySelector(
+        ".agent-gui-node__conversation-provider-mask-icon"
+      )
+    ).toBeNull();
+  });
+
   it("blocks the div context-menu trigger while rail reconciliation is pending", () => {
     const onSelectConversation = vi.fn();
     renderRailItem({

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.tsx
@@ -26,21 +26,31 @@ import {
   useConversationActionGroups
 } from "./AgentGUIConversationActionsMenu";
 
-function agentGUIConversationIconUrl(
+type AgentGUIConversationIconPresentation =
+  | { kind: "image"; url: string }
+  | { kind: "mask"; url: string };
+
+function agentGUIConversationIconPresentation(
   provider: string | undefined,
   agentTargetId: string | null | undefined,
   workspaceId: string,
   agentTargets: ReturnType<typeof useAgentTargetPresentations>
-): string | null {
+): AgentGUIConversationIconPresentation | null {
   const targetPresentation = resolveAgentTargetPresentation({
     agentTargetId: agentTargetId ?? "",
     agentTargets,
     workspaceId
   });
-  const targetIconUrl =
-    targetPresentation?.maskIconUrl?.trim() ||
-    targetPresentation?.iconUrl?.trim();
-  return targetIconUrl || resolveAgentGuiSessionProviderFlatIconUrl(provider);
+  const maskIconUrl = targetPresentation?.maskIconUrl?.trim() ?? "";
+  if (maskIconUrl) {
+    return { kind: "mask", url: maskIconUrl };
+  }
+  const iconUrl = targetPresentation?.iconUrl?.trim() ?? "";
+  if (iconUrl) {
+    return { kind: "image", url: iconUrl };
+  }
+  const providerIconUrl = resolveAgentGuiSessionProviderFlatIconUrl(provider);
+  return providerIconUrl ? { kind: "mask", url: providerIconUrl } : null;
 }
 
 function agentGUIConversationRailTitle(
@@ -103,7 +113,7 @@ export const AgentGUIConversationRailItem = memo(
     "use memo";
     const pinned = (item.pinnedAtUnixMs ?? 0) > 0;
     const agentTargets = useAgentTargetPresentations();
-    const conversationIconUrl = agentGUIConversationIconUrl(
+    const conversationIcon = agentGUIConversationIconPresentation(
       item.provider,
       item.agentTargetId,
       workspaceId,
@@ -196,14 +206,28 @@ export const AgentGUIConversationRailItem = memo(
           }}
         >
           <span className={styles.conversationTitleRow}>
-            {conversationIconUrl ? (
+            {conversationIcon?.kind === "mask" ? (
               <span
                 aria-hidden="true"
-                className={styles.conversationProviderIcon}
+                className={cn(
+                  styles.conversationProviderIcon,
+                  styles.conversationProviderMaskIcon
+                )}
                 style={{
-                  WebkitMaskImage: `url("${conversationIconUrl}")`,
-                  maskImage: `url("${conversationIconUrl}")`
+                  WebkitMaskImage: `url("${conversationIcon.url}")`,
+                  maskImage: `url("${conversationIcon.url}")`
                 }}
+              />
+            ) : conversationIcon ? (
+              <img
+                alt=""
+                aria-hidden="true"
+                className={cn(
+                  styles.conversationProviderIcon,
+                  styles.conversationProviderImage
+                )}
+                draggable={false}
+                src={conversationIcon.url}
               />
             ) : null}
             {item.titleLeadingMentionKind === "task" ? (

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -6565,10 +6565,18 @@ button.agent-gui-node__conversation-section-toggle:hover
 }
 
 .agent-gui-node__conversation-provider-icon {
-  display: inline-block;
   flex: 0 0 14px;
   width: 14px;
   height: 14px;
+}
+
+.agent-gui-node__conversation-provider-image {
+  display: block;
+  object-fit: contain;
+}
+
+.agent-gui-node__conversation-provider-mask-icon {
+  display: inline-block;
   color: var(--text-tertiary);
   background-color: currentColor;
   mask-position: center;


### PR DESCRIPTION
## Summary

- render dedicated mask icons through CSS mask longhands
- render primary identity icons as normal images when no mask icon is supplied
- document the distinction between invalid mask declarations and opaque image masks

## Root cause

The conversation rail treated the Agent Directory primary iconUrl as a monochrome mask when maskIconUrl was absent. Hosts such as TSH provide opaque/color PNG identity icons, so their alpha channel produced a solid rectangular mask even though the CSS mask declarations were valid.

## Validation

- pnpm check:changed
- pnpm release:pack:check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->