### PR TITLE
feat(agent): expose durable activity state reader

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -104,6 +104,12 @@ non-re-derivable deletion tombstones without exposing `*sql.Tx` to Host domain
 code. The seam is reserved for facts that must commit or roll back together;
 re-derivable projection gates are repaired by consumers instead.
 
+For durable workspace activity reads, `store-sqlite.AgentStateReader` returns
+the canonical root Sessions composed with each Session's latest Turn. It does
+not copy entity fields into a presentation model and does not include online
+Presence or host-owned execution attribution. Hosts that own those independent
+authorities compose them only at their API or product-view boundary.
+
 After commit, Host emits typed `CommittedDelta` values through one
 `CommitObserver`. Activity state, messages, root settlement, runtime and goal
 operation milestones, projection-dirty identities, and canonical view

--- a/packages/agent/store-sqlite/activity_state_read.go
+++ b/packages/agent/store-sqlite/activity_state_read.go
@@ -1,0 +1,43 @@
+package storesqlite
+
+import (
+	"context"
+	"strings"
+)
+
+var _ AgentStateReader = (*Store)(nil)
+
+// GetAgentState reads the canonical root sessions and their latest Turns for
+// one workspace. It intentionally excludes daemon relay presence and
+// host-owned execution attribution; callers may compose those independent
+// authorities at their API boundary.
+func (s *Store) GetAgentState(ctx context.Context, workspaceID string) (AgentState, bool, error) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	sessions, ok, err := s.ListSessions(ctx, workspaceID)
+	if err != nil || !ok {
+		return AgentState{}, ok, err
+	}
+
+	sessionIDs := make([]string, 0, len(sessions))
+	for _, session := range sessions {
+		sessionIDs = append(sessionIDs, session.ID)
+	}
+	latestTurns, err := s.ListLatestTurns(ctx, workspaceID, sessionIDs)
+	if err != nil {
+		return AgentState{}, false, err
+	}
+
+	state := AgentState{
+		WorkspaceID: workspaceID,
+		Sessions:    make([]AgentSessionState, 0, len(sessions)),
+	}
+	for _, session := range sessions {
+		entry := AgentSessionState{Session: session}
+		if turn, found := latestTurns[session.ID]; found {
+			turnCopy := turn
+			entry.LatestTurn = &turnCopy
+		}
+		state.Sessions = append(state.Sessions, entry)
+	}
+	return state, true, nil
+}

--- a/packages/agent/store-sqlite/activity_state_read_test.go
+++ b/packages/agent/store-sqlite/activity_state_read_test.go
@@ -1,0 +1,73 @@
+package storesqlite
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetAgentStateComposesCanonicalSessionsWithLatestTurns(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	for _, report := range []ActivityStateReport{
+		{
+			Session: SessionStateReport{
+				WorkspaceID: "ws-state", AgentSessionID: "session-with-turn", Kind: SessionKindRoot,
+				Origin: "runtime", Provider: "codex", Status: "working", OccurredAtUnixMS: 20,
+			},
+			Turn: &TurnTransition{
+				WorkspaceID: "ws-state", AgentSessionID: "session-with-turn", TurnID: "turn-latest",
+				Phase: TurnPhaseRunning, StartedAtUnixMS: 20, OccurredAtUnixMS: 20,
+			},
+		},
+		{
+			Session: SessionStateReport{
+				WorkspaceID: "ws-state", AgentSessionID: "session-without-turn", Kind: SessionKindRoot,
+				Origin: "runtime", Provider: "claude-code", Status: "idle", OccurredAtUnixMS: 10,
+			},
+		},
+	} {
+		if _, err := store.ReportActivityState(ctx, report); err != nil {
+			t.Fatalf("ReportActivityState(%s) error = %v", report.Session.AgentSessionID, err)
+		}
+	}
+	if _, err := store.db.ExecContext(ctx, `
+INSERT INTO workspace_agent_turns (
+  workspace_id, agent_session_id, turn_id, phase, outcome,
+  started_at_unix_ms, settled_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
+) VALUES ('ws-state', 'session-with-turn', 'turn-older', 'settled', 'completed', 1, 1, 1, 1)
+`); err != nil {
+		t.Fatalf("insert older turn: %v", err)
+	}
+
+	state, ok, err := store.GetAgentState(ctx, "  ws-state  ")
+	if err != nil || !ok {
+		t.Fatalf("GetAgentState() ok=%v error=%v", ok, err)
+	}
+	if state.WorkspaceID != "ws-state" || len(state.Sessions) != 2 {
+		t.Fatalf("GetAgentState() = %#v", state)
+	}
+	bySessionID := make(map[string]AgentSessionState, len(state.Sessions))
+	for _, sessionState := range state.Sessions {
+		bySessionID[sessionState.Session.ID] = sessionState
+	}
+	withTurn := bySessionID["session-with-turn"]
+	if withTurn.LatestTurn == nil || withTurn.LatestTurn.TurnID != "turn-latest" {
+		t.Fatalf("session-with-turn state = %#v", withTurn)
+	}
+	withoutTurn := bySessionID["session-without-turn"]
+	if withoutTurn.LatestTurn != nil {
+		t.Fatalf("session-without-turn state = %#v", withoutTurn)
+	}
+}
+
+func TestGetAgentStateRejectsBlankWorkspace(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	state, ok, err := store.GetAgentState(context.Background(), "  ")
+	if err != nil || ok || len(state.Sessions) != 0 {
+		t.Fatalf("GetAgentState(blank) state=%#v ok=%v error=%v", state, ok, err)
+	}
+}

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -63,6 +63,27 @@ type GoalProvenanceLedger interface {
 	LookupGoalProvenance(context.Context, LookupGoalProvenanceInput) (GoalProvenanceBinding, bool, error)
 }
 
+// AgentStateReader exposes the durable, canonical workspace activity read
+// model without coupling consumers to daemon/activity's in-memory relay state.
+// Presence and host-owned execution attribution are deliberately outside this
+// contract and remain the responsibility of the composing host.
+type AgentStateReader interface {
+	GetAgentState(context.Context, string) (AgentState, bool, error)
+}
+
+// AgentState is a workspace-scoped canonical activity snapshot.
+// AgentSessionState composes the existing Session and Turn entities instead of
+// copying their fields into another presentation DTO.
+type AgentState struct {
+	WorkspaceID string
+	Sessions    []AgentSessionState
+}
+
+type AgentSessionState struct {
+	Session    Session
+	LatestTurn *Turn
+}
+
 type ClearSessionsResult struct {
 	TransactionID     string           `json:"-"`
 	CommitDelta       TransactionDelta `json:"-"`


### PR DESCRIPTION
## What changed

- add a narrow `store-sqlite.AgentStateReader` contract
- expose `Store.GetAgentState` for canonical root Sessions composed with each
  Session's latest Turn
- reuse the existing `Session` and `Turn` entities instead of defining a
  parallel presentation DTO
- document that Presence and host-owned execution attribution stay outside the
  durable store contract

## Why

Downstream hosts need a durable workspace activity read model without depending
on `daemon/activity`'s in-memory relay state or reproducing canonical Store
queries and types. Keeping the contract in `store-sqlite` lets hosts inject the
official reader and compose their own independent ownership metadata only at
the product API boundary.

## Risk and scope

- additive API only; existing `Repository` implementations are not expanded
- no schema or migration changes
- no Presence, authorization, transport, or product-view policy added to the
  canonical store
- the read preserves `ListSessions` ordering and attaches the latest durable
  Turn when one exists

## Verification

- `cd packages/agent/store-sqlite && go test ./...`
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready` (6 lanes)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->