### PR TITLE
feat(agent-gui): export session reference serializer

### DIFF
--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -93,6 +93,12 @@ AgentGUI's built-in Handoff menu. The helper owns mention serialization and the
 trailing rich-text caret space; hosts continue to own destination selection and
 window launch behavior.
 
+Hosts that copy a session reference without launching a handoff must use
+`createAgentSessionMarkdownLink`. This is the same canonical serializer used by
+AgentGUI's Copy as reference action. Pass `withAtPrefix: true` when the copied
+value should paste back into Agent and room-chat composers as an `@` session
+mention; unlike the handoff helper, it does not append a trailing caret space.
+
 ## Boundary Rule
 
 `AgentActivity*` types from `@tutti-os/agent-activity-core` are the canonical

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionMarkdown.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionMarkdown.ts
@@ -89,13 +89,17 @@ export function createAgentSessionMentionHref(input: {
   });
 }
 
-export function createAgentSessionMarkdownLink(input: {
+export interface CreateAgentSessionMarkdownLinkInput {
   agentSessionId: string;
   agentTargetId?: string | null;
   label: string;
   workspaceId: string;
   withAtPrefix: boolean;
-}): string {
+}
+
+export function createAgentSessionMarkdownLink(
+  input: CreateAgentSessionMarkdownLinkInput
+): string {
   const label = normalizeAgentSessionMarkdownLabel(input.label);
   const href = createAgentSessionMentionHref({
     agentSessionId: input.agentSessionId,

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -22,8 +22,14 @@ export {
   type AgentHandoffMenuLabels,
   type AgentHandoffMenuProps
 } from "./agent-gui/agentGuiNode/composer/AgentHandoffMenu";
-export { createAgentSessionHandoffPrompt } from "./agent-gui/agentGuiNode/agentRichText/agentMentionMarkdown";
-export type { CreateAgentSessionHandoffPromptInput } from "./agent-gui/agentGuiNode/agentRichText/agentMentionMarkdown";
+export {
+  createAgentSessionHandoffPrompt,
+  createAgentSessionMarkdownLink
+} from "./agent-gui/agentGuiNode/agentRichText/agentMentionMarkdown";
+export type {
+  CreateAgentSessionHandoffPromptInput,
+  CreateAgentSessionMarkdownLinkInput
+} from "./agent-gui/agentGuiNode/agentRichText/agentMentionMarkdown";
 export type { AgentComposerDraftFile } from "./agent-gui/agentGuiNode/model/agentGuiNodeTypes";
 export type {
   AgentExternalPromptFilePreparationErrorCode,


### PR DESCRIPTION
## Summary

- export the canonical Agent session Markdown reference serializer from @tutti-os/agent-gui
- expose its typed input contract for downstream hosts
- document the distinction between copied references and handoff drafts

This lets TSH reuse the exact serializer behind AgentGUI Copy as reference instead of reconstructing mention://agent-session links downstream.

## Verification

- pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts
- pnpm --filter @tutti-os/agent-gui build
- pnpm check:changed -- --push-ready (pre-push hook)

## Checklist

- [x] This does not change agent lifecycle semantics; it only exposes an existing presentation serializer.
- [x] I kept the change focused on one concern.
- [x] I updated documentation for the new public package API.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->