### PR TITLE
feat(agent-gui): support read-only header session actions

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -464,7 +464,10 @@ rename-and-copy menu; a copy-only surface does not render rename or an empty
 separator. Hosts that already own a complete canonical message projection may
 reuse the pure transcript serializer exported by the `agent-conversation`
 entrypoint, while clipboard access, toasts, and session loading remain
-host-owned capabilities.
+host-owned capabilities. Window-level Agent chrome applies only when that Header
+is rendered through the Workbench window's own header slot; a complete Header
+nested in another host window's body remains ordinary embedded content and must
+not alter the outer window's layout or drag layer.
 
 Copy as reference copies the session-mention markdown link the @ panel
 produces, so pasting into any composer reconstructs the session chip; it is

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -458,6 +458,14 @@ canonical rail entities under the rail interaction lock. While either row
 menu is open the row keeps its hover layout (short title truncation, actions
 visible) so titles cannot overlap the action cluster.
 
+Read-only host surfaces reuse the complete workbench header and declare the
+session actions they support. Omitting that capability list preserves the full
+rename-and-copy menu; a copy-only surface does not render rename or an empty
+separator. Hosts that already own a complete canonical message projection may
+reuse the pure transcript serializer exported by the `agent-conversation`
+entrypoint, while clipboard access, toasts, and session loading remain
+host-owned capabilities.
+
 Copy as reference copies the session-mention markdown link the @ panel
 produces, so pasting into any composer reconstructs the session chip; it is
 synchronous and only requires a writable host clipboard. Copy as Markdown

--- a/docs/plans/2026-07-19-agent-header-readonly-session-actions.md
+++ b/docs/plans/2026-07-19-agent-header-readonly-session-actions.md
@@ -1,0 +1,25 @@
+# Agent Header Read-Only Session Actions
+
+## Goal
+
+Let read-only host surfaces reuse the complete `AgentGuiWorkbenchHeader` while exposing only the session actions they can support. TSH Activity Center is the first consumer: it needs the canonical session title, Agent icon, copy-as-Markdown, copy-as-reference, and its host-owned close action, but it must not offer rename.
+
+## Design
+
+- `AgentGuiWorkbenchHeader` accepts an optional `sessionMenuActions` list.
+- Omitting the list preserves the existing rename and copy menu.
+- The shared menu renders only declared actions and emits separators only between visible action groups.
+- The existing `agent-conversation` entrypoint exports the pure transcript serializer so external read-only conversation surfaces can preserve AgentGUI's Markdown format without copying implementation.
+- Hosts retain ownership of canonical session/message loading, clipboard access, toasts, and window actions.
+
+## Invariants
+
+1. Existing AgentGUI headers keep their current menu when no capability list is supplied.
+2. A read-only host cannot expose rename when it declares only copy actions.
+3. Session identity comes from the host's canonical session projection; menu availability never changes the title.
+
+## Verification
+
+- Shared menu component tests for default and copy-only action sets.
+- Agent GUI package typecheck and packed-surface validation.
+- TSH Activity Center tests for shared title, menu contents, Markdown copy, reference copy, and close behavior.

--- a/docs/plans/2026-07-19-agent-header-readonly-session-actions.md
+++ b/docs/plans/2026-07-19-agent-header-readonly-session-actions.md
@@ -11,12 +11,14 @@ Let read-only host surfaces reuse the complete `AgentGuiWorkbenchHeader` while e
 - The shared menu renders only declared actions and emits separators only between visible action groups.
 - The existing `agent-conversation` entrypoint exports the pure transcript serializer so external read-only conversation surfaces can preserve AgentGUI's Markdown format without copying implementation.
 - Hosts retain ownership of canonical session/message loading, clipboard access, toasts, and window actions.
+- Workbench window-chrome selectors recognize the Header only when it occupies that window's header slot, so a complete Header embedded in another window's body cannot reclassify the outer window.
 
 ## Invariants
 
 1. Existing AgentGUI headers keep their current menu when no capability list is supplied.
 2. A read-only host cannot expose rename when it declares only copy actions.
 3. Session identity comes from the host's canonical session projection; menu availability never changes the title.
+4. A nested Header does not alter its containing host window's rows, drag layer, or body offsets.
 
 ## Verification
 

--- a/packages/agent/gui/agent-conversation/index.ts
+++ b/packages/agent/gui/agent-conversation/index.ts
@@ -34,3 +34,12 @@ export type {
 export type { AgentConversationVM } from "../shared/agentConversation/contracts/agentConversationVM";
 export type { WorkspaceAgentActivityTimelineItem } from "../shared/workspaceAgentTimelineTypes";
 export type { WorkspaceAgentActivityCard } from "../shared/workspaceAgentActivityListViewModel";
+
+export {
+  serializeAgentConversationForClipboard,
+  type AgentGUIConversationAttachment,
+  type AgentGUIConversationCopyAction,
+  type AgentGUIConversationCopyLabels,
+  type AgentGUIConversationLocalImageReader,
+  type AgentGUIConversationSerializedTranscript
+} from "../agent-gui/agentGuiNode/model/agentConversationCopy";

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -4557,13 +4557,17 @@ aside.workspace-agents-status-panel
   transition: none;
 }
 
-.workbench-window:has([data-agent-gui-workbench-header="true"]) {
+.workbench-window:has(
+  > .workbench-window__header [data-agent-gui-workbench-header="true"]
+) {
   --agent-gui-workbench-header-height: 44px;
 
   grid-template-rows: minmax(0, 1fr);
 }
 
-.workbench-window:has([data-agent-gui-workbench-header="true"])
+.workbench-window:has(
+    > .workbench-window__header [data-agent-gui-workbench-header="true"]
+  )
   .workbench-window__header {
   position: absolute !important;
   top: 0 !important;
@@ -4583,41 +4587,48 @@ aside.workspace-agents-status-panel
 }
 
 .workbench-window:has(
-    .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
+    > .workbench-window__header
+      .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
   )
   .workbench-window__header {
   cursor: grab !important;
 }
 
 .workbench-window:has(
-    .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
+    > .workbench-window__header
+      .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
   )
   .workbench-window__header:active {
   cursor: grabbing !important;
 }
 
 .workbench-window:has(
-    .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
+    > .workbench-window__header
+      .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
   )
   .workbench-window__header {
   z-index: calc(var(--z-panel) + 1);
 }
 
 .workbench-window:has(
-    .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
+    > .workbench-window__header
+      .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
   )
   .agent-gui-workbench-header::after {
   display: none;
 }
 
-.workbench-window:has([data-agent-gui-workbench-header="true"])
+.workbench-window:has(
+    > .workbench-window__header [data-agent-gui-workbench-header="true"]
+  )
   .workbench-window__body {
   grid-row: 1;
   overflow: hidden;
 }
 
 .workbench-window:has(
-    .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
+    > .workbench-window__header
+      .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
   )
   .workbench-window__body {
   display: flex;
@@ -4680,7 +4691,9 @@ aside.workspace-agents-status-panel
   overscroll-behavior: contain;
 }
 
-.workbench-window:has([data-agent-gui-workbench-header="true"])
+.workbench-window:has(
+    > .workbench-window__header [data-agent-gui-workbench-header="true"]
+  )
   .agent-gui-node__provider-rail-panel {
   padding-top: var(--agent-gui-workbench-header-height);
 }
@@ -4689,22 +4702,30 @@ aside.workspace-agents-status-panel
    breathing room on the inner rail, so the "All" tile sits at header + 2px. The
    toolbar has no such wrapper, so fold the same 2px into its offset to keep the
    search field top aligned with the provider tiles. */
-.workbench-window:has([data-agent-gui-workbench-header="true"])
+.workbench-window:has(
+    > .workbench-window__header [data-agent-gui-workbench-header="true"]
+  )
   .agent-gui-node__rail-toolbar {
   padding-top: calc(var(--agent-gui-workbench-header-height) + 2px);
 }
 
-.workbench-window:has([data-agent-gui-workbench-header="true"])
+.workbench-window:has(
+    > .workbench-window__header [data-agent-gui-workbench-header="true"]
+  )
   .agent-gui-node__detail-panel {
   position: relative;
 }
 
-.workbench-window:has([data-agent-gui-workbench-header="true"])
+.workbench-window:has(
+    > .workbench-window__header [data-agent-gui-workbench-header="true"]
+  )
   .agent-gui-node__detail {
   padding-top: var(--agent-gui-workbench-header-height);
 }
 
-.workbench-window:has([data-agent-gui-workbench-header="true"])
+.workbench-window:has(
+    > .workbench-window__header [data-agent-gui-workbench-header="true"]
+  )
   .agent-gui-node__timeline-with-composer {
   padding-top: 20px;
 }
@@ -5198,11 +5219,13 @@ aside.workspace-agents-status-panel
 }
 
 .workbench-window:has(
-    .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
+    > .workbench-window__header
+      .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
   )
   .agent-gui-workbench-header__session-title,
 .workbench-window:has(
-    .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
+    > .workbench-window__header
+      .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
   )
   .agent-gui-workbench-header__detail-title {
   box-sizing: border-box;
@@ -5478,7 +5501,9 @@ aside.workspace-agents-status-panel
   );
 }
 
-.workbench-window:has([data-agent-gui-workbench-header="true"])
+.workbench-window:has(
+    > .workbench-window__header [data-agent-gui-workbench-header="true"]
+  )
   .agent-gui-node__provider-rail-panel::after {
   top: var(--agent-gui-workbench-header-height);
 }

--- a/packages/agent/gui/workbench/AgentGuiWorkbenchSessionMenu.spec.tsx
+++ b/packages/agent/gui/workbench/AgentGuiWorkbenchSessionMenu.spec.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AgentGuiWorkbenchSessionMenu } from "./AgentGuiWorkbenchSessionMenu";
+import { AgentGuiWorkbenchHeader } from "./header";
 
 const copy = {
   copyAsMarkdown: "Copy as Markdown",
@@ -44,5 +45,70 @@ describe("AgentGuiWorkbenchSessionMenu", () => {
     fireEvent.click(markdown);
     await waitFor(() => expect(onAction).toHaveBeenCalledTimes(1));
     expect(onAction).toHaveBeenCalledWith("copy-markdown");
+  });
+
+  it("renders only the actions supported by a read-only host surface", async () => {
+    const onAction = vi.fn();
+    render(
+      <AgentGuiWorkbenchSessionMenu
+        actions={["copy-markdown", "copy-reference"]}
+        copy={copy}
+        onAction={onAction}
+      />
+    );
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: copy.moreSessionActions }),
+      { button: 0, ctrlKey: false }
+    );
+
+    expect(
+      await screen.findByRole("menuitem", { name: copy.copyAsMarkdown })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("menuitem", { name: copy.copyAsReference })
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("menuitem", { name: copy.renameSession })
+    ).toBeNull();
+    expect(screen.queryByRole("separator")).toBeNull();
+  });
+
+  it("lets the complete header constrain its session menu actions", async () => {
+    render(
+      <AgentGuiWorkbenchHeader
+        copy={{
+          collapseConversationRail: "Collapse",
+          expandConversationRail: "Expand",
+          fallbackAgentLabel: "Agent",
+          newConversation: "New conversation",
+          sessionMenu: copy
+        }}
+        conversationIconUrl="agent.png"
+        conversationTitle="Shared session title"
+        hasConversation
+        isConversationRailAutoCollapsed
+        isConversationRailCollapsed
+        nodeId="activity-center-session-1"
+        sessionMenuActions={["copy-markdown", "copy-reference"]}
+        showConversationRailToggle={false}
+        showWindowControls={false}
+        onSessionAction={vi.fn()}
+        onToggleConversationRail={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Shared session title")).toBeTruthy();
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: copy.moreSessionActions }),
+      { button: 0, ctrlKey: false }
+    );
+
+    expect(
+      await screen.findByRole("menuitem", { name: copy.copyAsMarkdown })
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("menuitem", { name: copy.renameSession })
+    ).toBeNull();
   });
 });

--- a/packages/agent/gui/workbench/AgentGuiWorkbenchSessionMenu.tsx
+++ b/packages/agent/gui/workbench/AgentGuiWorkbenchSessionMenu.tsx
@@ -23,14 +23,20 @@ const menuContentClassName =
   "w-max min-w-44 nodrag [-webkit-app-region:no-drag]";
 
 export interface AgentGuiWorkbenchSessionMenuProps {
+  actions?: readonly AgentGuiWorkbenchSessionAction[];
   copy: AgentGuiWorkbenchSessionMenuCopy;
   onAction: (action: AgentGuiWorkbenchSessionAction) => void;
 }
 
 export function AgentGuiWorkbenchSessionMenu({
+  actions = ["rename", "copy-markdown", "copy-reference"],
   copy,
   onAction
 }: AgentGuiWorkbenchSessionMenuProps): ReactNode {
+  const showRename = actions.includes("rename");
+  const showCopyMarkdown = actions.includes("copy-markdown");
+  const showCopyReference = actions.includes("copy-reference");
+  const showCopyActions = showCopyMarkdown || showCopyReference;
   const pendingActionRef = useRef(false);
   const select = useCallback(
     (action: AgentGuiWorkbenchSessionAction) => {
@@ -97,19 +103,25 @@ export function AgentGuiWorkbenchSessionMenu({
         onPointerUp={stopPointerPropagation}
         sideOffset={6}
       >
-        <DropdownMenuItem {...actionProps("rename")}>
-          <Pencil aria-hidden="true" />
-          <span>{copy.renameSession}</span>
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem {...actionProps("copy-markdown")}>
-          <FileText aria-hidden="true" />
-          <span>{copy.copyAsMarkdown}</span>
-        </DropdownMenuItem>
-        <DropdownMenuItem {...actionProps("copy-reference")}>
-          <AtSign aria-hidden="true" />
-          <span>{copy.copyAsReference}</span>
-        </DropdownMenuItem>
+        {showRename ? (
+          <DropdownMenuItem {...actionProps("rename")}>
+            <Pencil aria-hidden="true" />
+            <span>{copy.renameSession}</span>
+          </DropdownMenuItem>
+        ) : null}
+        {showRename && showCopyActions ? <DropdownMenuSeparator /> : null}
+        {showCopyMarkdown ? (
+          <DropdownMenuItem {...actionProps("copy-markdown")}>
+            <FileText aria-hidden="true" />
+            <span>{copy.copyAsMarkdown}</span>
+          </DropdownMenuItem>
+        ) : null}
+        {showCopyReference ? (
+          <DropdownMenuItem {...actionProps("copy-reference")}>
+            <AtSign aria-hidden="true" />
+            <span>{copy.copyAsReference}</span>
+          </DropdownMenuItem>
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -1957,7 +1957,21 @@ describe("agent GUI workbench contribution copy", () => {
       /\.tsh-zoom-dialog\[data-rmiz-modal\]\s*{[^}]*z-index:\s*var\(--z-dialog\);/s
     );
     expect(css).toMatch(
-      /\.workbench-window:has\(\s*\.agent-gui-workbench-header\[data-agent-gui-standalone-window-header="true"\]\s*\)\s*\.workbench-window__header\s*{[^}]*z-index:\s*calc\(var\(--z-panel\) \+ 1\);/s
+      /\.workbench-window:has\(\s*> \.workbench-window__header\s+\.agent-gui-workbench-header\[data-agent-gui-standalone-window-header="true"\]\s*\)\s*\.workbench-window__header\s*{[^}]*z-index:\s*calc\(var\(--z-panel\) \+ 1\);/s
+    );
+  });
+
+  it("only applies Agent window chrome when the Header occupies the window header slot", () => {
+    const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
+
+    expect(css).toMatch(
+      /\.workbench-window:has\(\s*> \.workbench-window__header \[data-agent-gui-workbench-header="true"\]\s*\)\s*{/s
+    );
+    expect(css).not.toMatch(
+      /\.workbench-window:has\(\s*\[data-agent-gui-workbench-header="true"\]/s
+    );
+    expect(css).not.toMatch(
+      /\.workbench-window:has\(\s*\.agent-gui-workbench-header\[data-agent-gui-standalone-window-header="true"\]/s
     );
   });
 

--- a/packages/agent/gui/workbench/header.ts
+++ b/packages/agent/gui/workbench/header.ts
@@ -74,6 +74,7 @@ export interface AgentGuiWorkbenchHeaderProps extends HTMLAttributes<HTMLElement
   providerRailWidthPx?: number | null;
   primaryAccessory?: ReactNode;
   secondaryAccessory?: ReactNode;
+  sessionMenuActions?: readonly AgentGuiWorkbenchSessionAction[];
   conversationTitle?: string | null;
   conversationTitleDisplayPrompt?: string | null;
   nodeId: string;
@@ -106,6 +107,7 @@ export function AgentGuiWorkbenchHeader({
   providerRailWidthPx,
   primaryAccessory,
   secondaryAccessory,
+  sessionMenuActions,
   conversationTitle,
   conversationTitleDisplayPrompt,
   nodeId,
@@ -142,6 +144,7 @@ export function AgentGuiWorkbenchHeader({
   const sessionMenu =
     onSessionAction && copy.sessionMenu && sessionTitle && !hasBodyRenderError
       ? createElement(AgentGuiWorkbenchSessionMenu, {
+          actions: sessionMenuActions,
           copy: copy.sessionMenu,
           onAction: onSessionAction
         })


### PR DESCRIPTION
## Summary
- let `AgentGuiWorkbenchHeader` constrain its session menu to host-supported actions while preserving the existing default menu
- export the canonical conversation Markdown serializer from the public `agent-conversation` entrypoint
- document the read-only host contract for TSH Activity Center and shared Agent sessions

## Verification
- `pnpm check:changed` (8 lanes)
- `pnpm check:changed -- --push-ready` (9 lanes)
- `pnpm release:pack:check`
- focused `AgentGuiWorkbenchSessionMenu` tests (3/3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->