### PR TITLE
refactor(workspace-apps): remove workspace root contract

### DIFF
--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/app-architecture.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/app-architecture.md
@@ -73,7 +73,7 @@ Tutti package startup:
 - Store durable data under `$TUTTI_APP_DATA_DIR`.
 - Store scratch files under `$TUTTI_APP_RUNTIME_DIR`.
 - Write file logs under `$TUTTI_APP_LOG_DIR` only when needed.
-- Read `$TUTTI_WORKSPACE_ROOT` only for explicit workspace features.
+- Do not expect a workspace-root environment variable. Use `$TUTTI_WORKSPACE_ID` and `$TUTTI_CLI` for explicit workspace-scoped capabilities; app-owned agents receive the selected project directory through their process `cwd`.
 
 ## Host Bridge
 

--- a/services/tuttid/service/workspace/app_factory.go
+++ b/services/tuttid/service/workspace/app_factory.go
@@ -554,12 +554,10 @@ func (s *AppFactoryService) validatePackage(ctx context.Context, workspaceID str
 	if err != nil {
 		return err
 	}
-	workspaceRoot, _ := s.workspaceRoot(ctx, workspaceID)
 	factoryWorkspaceID := "factory:" + job.JobID
 	state, err := s.runner().Start(ctx, AppStartInput{
 		WorkspaceID:     factoryWorkspaceID,
 		WorkspaceName:   workspace.Name,
-		WorkspaceRoot:   workspaceRoot.PhysicalRoot,
 		AppID:           manifest.AppID,
 		PackageDir:      draftPackageDir,
 		Bootstrap:       manifest.Runtime.Bootstrap,

--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -121,7 +121,7 @@ The runtime must:
 - Write logs only under `$TUTTI_APP_LOG_DIR` when backend/server-side file logs are needed.
 - Store reusable app-managed binaries only under `$TUTTI_APP_TOOLCHAIN_ROOT`.
 - Prefer `window.tuttiExternal?.logs?.write?.()` for browser-side diagnostics in Tutti Desktop; reserve `$TUTTI_APP_LOG_DIR` for backend process logs.
-- Read `$TUTTI_WORKSPACE_ROOT` only when the app needs workspace context.
+- Do not expect a workspace-root environment variable. Use `$TUTTI_WORKSPACE_ID` and `$TUTTI_CLI` for explicit workspace-scoped capabilities, and treat caller-supplied absolute file paths as opaque inputs rather than deriving a root from them.
 - Launch Python with `$TUTTI_APP_PYTHON` and Node with `$TUTTI_APP_NODE`; use `$TUTTI_APP_NPM` for npm install/build work.
 - When the app exposes an open command, support the routed pages in the app runtime itself: direct navigation to the route must render the intended page, and an already-mounted frontend should handle repeated open intents through `window.tuttiExternal?.workspace?.onLaunchIntent?.(...)`.
 - When the generated app calls another local Tutti capability at runtime, use `$TUTTI_CLI` and follow `references/tutti-cli-commands.md`.

--- a/services/tuttid/service/workspace/app_factory_reference/references/runtime-env.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/runtime-env.md
@@ -20,9 +20,13 @@ Use these environment variables:
 - `TUTTI_API_BASE_URL`: base URL for server-side calls to the Tutti daemon API.
 - `TUTTI_APP_SERVER_TOKEN`: bearer token for this app server's scoped Tutti API calls.
 - `TUTTI_CLI`: explicit command path for invoking local Tutti CLI capabilities. This is the stable app-runtime entrypoint across development and packaged production.
+- `TUTTI_CLI_CONFIG`: optional host-provided Tutti CLI routing configuration. Treat its value as opaque.
 - `TUTTI_WORKSPACE_ID`: current workspace id.
 - `TUTTI_WORKSPACE_NAME`: current workspace display name.
-- `TUTTI_WORKSPACE_ROOT`: workspace path, read-only unless the user explicitly asked the app to write workspace files.
+
+The host does not copy its complete daemon environment into an app process. It inherits only the operating-system baseline needed to launch child processes (path, home and user identity, temporary directories, locale, proxy, certificate, and platform runtime variables) plus the explicit credential, endpoint, provider-home, and command/config variables used by the supported Codex, Claude Code, Cursor, Tutti Agent, and OpenCode targets. App runtime values such as `TUTTI_APP_SERVER_TOKEN` and managed executable paths are added as explicit host-owned overrides. Do not depend on unrelated ambient daemon, database, release, or publishing variables being present.
+
+The runner does not inject a workspace filesystem root. Use `TUTTI_WORKSPACE_ID` only as identity metadata and use `TUTTI_CLI` for explicit workspace-scoped capabilities. When a caller supplies an absolute input path, treat it as opaque caller data; do not derive a workspace root or default output location from it. Relative path inputs must be resolved by the caller against its own working directory before invoking the app.
 
 `PATH` includes the managed runtime bin directories, but generated apps must still use the explicit `TUTTI_APP_NODE`, `TUTTI_APP_NPM`, and, when applicable, `TUTTI_APP_PYTHON` variables. Do not rely on system `node`, `npm`, `python`, or `python3` commands.
 

--- a/services/tuttid/service/workspace/app_runtime_env.go
+++ b/services/tuttid/service/workspace/app_runtime_env.go
@@ -1,10 +1,12 @@
 package workspace
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )
@@ -19,8 +21,118 @@ type AppRuntimeProfileResolver = managedruntime.ProfileResolver
 type ResolvedAppRuntime = managedruntime.ResolvedRuntime
 type DefaultManagedAppRuntimeResolver = managedruntime.DefaultResolver
 
+// Provider entries are intentionally exact; do not replace them with credential
+// or provider-prefix wildcards that could expose unrelated daemon secrets.
+var workspaceAppInheritedEnvKeys = map[string]struct{}{
+	"ALL_PROXY":               {},
+	"ANTHROPIC_API_BASE_URL":  {},
+	"ANTHROPIC_API_KEY":       {},
+	"ANTHROPIC_AUTH_TOKEN":    {},
+	"ANTHROPIC_BASE_URL":      {},
+	"APPDATA":                 {},
+	"CLAUDE_CONFIG_DIR":       {},
+	"CODEX_HOME":              {},
+	"COMMONPROGRAMFILES":      {},
+	"COMMONPROGRAMFILES(X86)": {},
+	"COMMONPROGRAMW6432":      {},
+	"COMSPEC":                 {},
+	"CURL_CA_BUNDLE":          {},
+	"CURSOR_ACP_BIN":          {},
+	"CURSOR_API_KEY":          {},
+	"GIT_SSL_CAINFO":          {},
+	"GIT_SSL_CAPATH":          {},
+	"HOME":                    {},
+	"HOMEDRIVE":               {},
+	"HOMEPATH":                {},
+	"HTTP_PROXY":              {},
+	"HTTPS_PROXY":             {},
+	"LANG":                    {},
+	"LANGUAGE":                {},
+	"LOCALAPPDATA":            {},
+	"LOGNAME":                 {},
+	"NODE_EXTRA_CA_CERTS":     {},
+	"NO_PROXY":                {},
+	"NPM_CONFIG_CAFILE":       {},
+	"NUMBER_OF_PROCESSORS":    {},
+	"OPENAI_API_BASE":         {},
+	"OPENAI_API_BASE_URL":     {},
+	"OPENAI_API_KEY":          {},
+	"OPENAI_BASE_URL":         {},
+	"OPENCODE_ACP_BIN":        {},
+	"OPENCODE_CONFIG":         {},
+	"OPENCODE_CONFIG_CONTENT": {},
+	"OPENCODE_CONFIG_DIR":     {},
+	"OPENCODE_PERMISSION":     {},
+	"OS":                      {},
+	"PATH":                    {},
+	"PATHEXT":                 {},
+	"PIP_CERT":                {},
+	"PROCESSOR_ARCHITECTURE":  {},
+	"PROCESSOR_ARCHITEW6432":  {},
+	"PROCESSOR_IDENTIFIER":    {},
+	"PROCESSOR_LEVEL":         {},
+	"PROCESSOR_REVISION":      {},
+	"PROGRAMDATA":             {},
+	"PROGRAMFILES":            {},
+	"PROGRAMFILES(X86)":       {},
+	"PROGRAMW6432":            {},
+	"REQUESTS_CA_BUNDLE":      {},
+	"SHELL":                   {},
+	"SSL_CERT_DIR":            {},
+	"SSL_CERT_FILE":           {},
+	"SYSTEMDRIVE":             {},
+	"SYSTEMROOT":              {},
+	"TEMP":                    {},
+	"TMP":                     {},
+	"TMPDIR":                  {},
+	"TUTTI_AGENT_HOME":        {},
+	"TZ":                      {},
+	"USER":                    {},
+	"USERNAME":                {},
+	"USERPROFILE":             {},
+	"WINDIR":                  {},
+	"XDG_CACHE_HOME":          {},
+	"XDG_CONFIG_HOME":         {},
+	"XDG_DATA_HOME":           {},
+	"XDG_RUNTIME_DIR":         {},
+	"XDG_STATE_HOME":          {},
+	"__CF_USER_TEXT_ENCODING": {},
+}
+
 func workspaceAppProcessEnv(overrides ...string) []string {
-	return managedruntime.ProcessEnv(overrides...)
+	env := make([]string, 0, len(workspaceAppInheritedEnvKeys)+len(overrides))
+	for _, item := range os.Environ() {
+		key, _, ok := strings.Cut(item, "=")
+		if !ok {
+			continue
+		}
+		normalizedKey := strings.ToUpper(key)
+		_, inherited := workspaceAppInheritedEnvKeys[normalizedKey]
+		if inherited || strings.HasPrefix(normalizedKey, "LC_") {
+			env = append(env, item)
+		}
+	}
+	env = runtimecmd.InjectSystemProxyEnv(env)
+	for _, override := range overrides {
+		key, _, ok := strings.Cut(override, "=")
+		if !ok {
+			continue
+		}
+		normalizedKey := strings.ToUpper(key)
+		if normalizedKey == "TUTTI_WORKSPACE_ROOT" || normalizedKey == "NEXTOP_WORKSPACE_ROOT" {
+			continue
+		}
+		next := env[:0]
+		for _, item := range env {
+			itemKey, _, ok := strings.Cut(item, "=")
+			if ok && strings.EqualFold(itemKey, key) {
+				continue
+			}
+			next = append(next, item)
+		}
+		env = append(next, override)
+	}
+	return env
 }
 
 func appRuntimeProfileForPackage(appPackage workspacebiz.AppPackage) string {

--- a/services/tuttid/service/workspace/app_runtime_env_test.go
+++ b/services/tuttid/service/workspace/app_runtime_env_test.go
@@ -1,0 +1,100 @@
+package workspace
+
+import "testing"
+
+func TestWorkspaceAppProcessEnvUsesAllowlistAndExplicitOverrides(t *testing.T) {
+	for key, value := range map[string]string{
+		"PATH":                     "/host/bin",
+		"HOME":                     "/home/tester",
+		"USER":                     "tester",
+		"TMPDIR":                   "/tmp/tester",
+		"LANG":                     "zh_CN.UTF-8",
+		"LC_MESSAGES":              "zh_CN.UTF-8",
+		"HTTPS_PROXY":              "http://proxy.example:8080",
+		"SSL_CERT_FILE":            "/etc/ssl/test.pem",
+		"SystemRoot":               `C:\Windows`,
+		"XDG_CONFIG_HOME":          "/home/tester/.config-custom",
+		"CODEX_HOME":               "/home/tester/.codex-custom",
+		"CLAUDE_CONFIG_DIR":        "/home/tester/.claude-custom",
+		"OPENAI_API_KEY":           "openai-test-key",
+		"OPENAI_BASE_URL":          "https://openai.example/v1",
+		"ANTHROPIC_AUTH_TOKEN":     "anthropic-test-token",
+		"ANTHROPIC_BASE_URL":       "https://anthropic.example",
+		"CURSOR_API_KEY":           "cursor-test-key",
+		"CURSOR_ACP_BIN":           "/home/tester/bin/cursor-agent",
+		"OPENCODE_CONFIG":          "/home/tester/opencode.json",
+		"OPENCODE_CONFIG_DIR":      "/home/tester/.config-custom/opencode",
+		"OPENCODE_CONFIG_CONTENT":  `{"provider":"test"}`,
+		"OPENCODE_PERMISSION":      `{"bash":"ask"}`,
+		"OPENCODE_ACP_BIN":         "/home/tester/bin/opencode",
+		"TUTTI_AGENT_HOME":         "/home/tester/.tutti-agent-custom",
+		"RANDOM_DAEMON_SECRET":     "must-not-leak",
+		"DATABASE_URL":             "sqlite:///daemon.db",
+		"RELEASE_SIGNING_KEY":      "must-not-leak",
+		"TUTTI_STATE_DIR":          "/daemon/state",
+		"TUTTI_APP_AMBIENT_SECRET": "must-not-leak",
+		"TUTTI_WORKSPACE_ROOT":     "/legacy/workspace",
+		"NEXTOP_WORKSPACE_ROOT":    "/legacy/workspace",
+	} {
+		t.Setenv(key, value)
+	}
+
+	env := workspaceAppProcessEnv(
+		"PATH=/managed/bin",
+		"TUTTI_APP_RUNTIME_ROOT=/managed/runtime",
+		"TUTTI_APP_NODE=/managed/node",
+		"TUTTI_APP_SERVER_TOKEN=app-scoped-token",
+		"CUSTOM_EXPLICIT_OVERRIDE=explicit-value",
+		"TUTTI_WORKSPACE_ROOT=/explicit/legacy-root",
+		"NEXTOP_WORKSPACE_ROOT=/explicit/legacy-root",
+	)
+
+	for key, want := range map[string]string{
+		"PATH":                     "/managed/bin",
+		"HOME":                     "/home/tester",
+		"USER":                     "tester",
+		"TMPDIR":                   "/tmp/tester",
+		"LANG":                     "zh_CN.UTF-8",
+		"LC_MESSAGES":              "zh_CN.UTF-8",
+		"HTTPS_PROXY":              "http://proxy.example:8080",
+		"SSL_CERT_FILE":            "/etc/ssl/test.pem",
+		"SystemRoot":               `C:\Windows`,
+		"XDG_CONFIG_HOME":          "/home/tester/.config-custom",
+		"CODEX_HOME":               "/home/tester/.codex-custom",
+		"CLAUDE_CONFIG_DIR":        "/home/tester/.claude-custom",
+		"OPENAI_API_KEY":           "openai-test-key",
+		"OPENAI_BASE_URL":          "https://openai.example/v1",
+		"ANTHROPIC_AUTH_TOKEN":     "anthropic-test-token",
+		"ANTHROPIC_BASE_URL":       "https://anthropic.example",
+		"CURSOR_API_KEY":           "cursor-test-key",
+		"CURSOR_ACP_BIN":           "/home/tester/bin/cursor-agent",
+		"OPENCODE_CONFIG":          "/home/tester/opencode.json",
+		"OPENCODE_CONFIG_DIR":      "/home/tester/.config-custom/opencode",
+		"OPENCODE_CONFIG_CONTENT":  `{"provider":"test"}`,
+		"OPENCODE_PERMISSION":      `{"bash":"ask"}`,
+		"OPENCODE_ACP_BIN":         "/home/tester/bin/opencode",
+		"TUTTI_AGENT_HOME":         "/home/tester/.tutti-agent-custom",
+		"TUTTI_APP_RUNTIME_ROOT":   "/managed/runtime",
+		"TUTTI_APP_NODE":           "/managed/node",
+		"TUTTI_APP_SERVER_TOKEN":   "app-scoped-token",
+		"CUSTOM_EXPLICIT_OVERRIDE": "explicit-value",
+	} {
+		if got := envValue(env, key); got != want {
+			t.Fatalf("env[%s] = %q, want %q", key, got, want)
+		}
+	}
+
+	for _, key := range []string{
+		"RANDOM_DAEMON_SECRET",
+		"DATABASE_URL",
+		"RELEASE_SIGNING_KEY",
+		"TUTTI_STATE_DIR",
+		"TUTTI_APP_AMBIENT_SECRET",
+		"TUTTI_WORKSPACE_ROOT",
+		"NEXTOP_WORKSPACE_ROOT",
+	} {
+		if got := envValue(env, key); got != "" {
+			t.Fatalf("env[%s] = %q, want omitted", key, got)
+		}
+	}
+}

--- a/services/tuttid/service/workspace/apps.go
+++ b/services/tuttid/service/workspace/apps.go
@@ -22,7 +22,6 @@ import (
 type AppCenterService struct {
 	Store                  workspacedata.AppStore
 	AppFactoryStore        workspacedata.AppFactoryStore
-	WorkspaceRootResolver  WorkspaceRootResolver
 	WorkspaceStore         workspacedata.CatalogStore
 	PreferencesStore       workspacedata.PreferencesStore
 	Runner                 *AppRunner
@@ -483,13 +482,6 @@ func (s *AppCenterService) workspaceSummary(ctx context.Context, workspaceID str
 	}
 
 	return s.WorkspaceStore.Get(ctx, workspaceID)
-}
-
-func (s *AppCenterService) workspaceRoot(ctx context.Context, workspaceID string) (workspacefiles.WorkspaceRoot, error) {
-	if s.WorkspaceRootResolver == nil {
-		return workspacefiles.WorkspaceRoot{}, nil
-	}
-	return s.WorkspaceRootResolver.ResolveWorkspaceRoot(ctx, workspaceID)
 }
 
 func (s *AppCenterService) runner() *AppRunner {

--- a/services/tuttid/service/workspace/apps_runner.go
+++ b/services/tuttid/service/workspace/apps_runner.go
@@ -44,7 +44,6 @@ type AppRunnerStateChanged func(workspaceID string, appID string, state workspac
 type AppStartInput struct {
 	WorkspaceID     string
 	WorkspaceName   string
-	WorkspaceRoot   string
 	AppID           string
 	PackageDir      string
 	Bootstrap       string
@@ -210,7 +209,6 @@ func (r *AppRunner) startProcess(ctx context.Context, key string, input AppStart
 		"TUTTI_APP_ID=" + input.AppID,
 		"TUTTI_WORKSPACE_ID=" + input.WorkspaceID,
 		"TUTTI_WORKSPACE_NAME=" + input.WorkspaceName,
-		"TUTTI_WORKSPACE_ROOT=" + input.WorkspaceRoot,
 		"TUTTI_APP_HOST=127.0.0.1",
 		"TUTTI_APP_PACKAGE_DIR=" + input.PackageDir,
 		"TUTTI_APP_RUNTIME_DIR=" + input.RuntimeDir,
@@ -532,7 +530,6 @@ func writeAppStartupDiagnostic(logFile *os.File, input AppStartInput, bootstrapP
 	_, _ = fmt.Fprintf(logFile, "  appId=%s\n", input.AppID)
 	_, _ = fmt.Fprintf(logFile, "  workspaceId=%s\n", input.WorkspaceID)
 	_, _ = fmt.Fprintf(logFile, "  workspaceName=%s\n", input.WorkspaceName)
-	_, _ = fmt.Fprintf(logFile, "  workspaceRoot=%s\n", input.WorkspaceRoot)
 	_, _ = fmt.Fprintf(logFile, "  bootstrap=%s\n", bootstrapPath)
 	_, _ = fmt.Fprintf(logFile, "  runtimeRoot=%s\n", appRuntime.Root)
 	_, _ = fmt.Fprintf(logFile, "  python=%s\n", appRuntime.Python)

--- a/services/tuttid/service/workspace/apps_runner_test.go
+++ b/services/tuttid/service/workspace/apps_runner_test.go
@@ -48,11 +48,12 @@ exec "$TUTTI_APP_PYTHON" "$TUTTI_APP_PACKAGE_DIR/server.py"
 	t.Setenv(tuttiAppRuntimeRootEnv, createManagedAppRuntimeFixture(t, root))
 	t.Setenv("TUTTI_ENV", "production")
 	t.Setenv("TUTTI_STATE_DIR", stateRoot)
+	t.Setenv("TUTTI_WORKSPACE_ROOT", "/inherited/workspace")
+	t.Setenv("NEXTOP_WORKSPACE_ROOT", "/inherited/workspace")
 	runner := &AppRunner{HealthcheckTimeout: 10 * time.Second}
 	state, err := runner.Start(context.Background(), AppStartInput{
 		WorkspaceID:     "ws-runner",
 		WorkspaceName:   "Runner Workspace",
-		WorkspaceRoot:   root,
 		AppID:           "hello",
 		PackageDir:      packageDir,
 		Bootstrap:       "bootstrap.sh",
@@ -96,10 +97,14 @@ exec "$TUTTI_APP_PYTHON" "$TUTTI_APP_PACKAGE_DIR/server.py"
 		"dataDir":       dataDir,
 		"logDir":        logDir,
 		"toolchainRoot": filepath.Join(stateRoot, "app-toolchains"),
-		"workspaceRoot": root,
 	} {
 		if probeValues[key] != want {
 			t.Fatalf("probe[%s] = %q, want %q", key, probeValues[key], want)
+		}
+	}
+	for _, key := range []string{"tuttiWorkspaceRoot", "nextopWorkspaceRoot"} {
+		if probeValues[key] != "" {
+			t.Fatalf("probe[%s] = %q, want absent root contract", key, probeValues[key])
 		}
 	}
 	for key, want := range map[string]string{
@@ -129,7 +134,7 @@ exec "$TUTTI_APP_PYTHON" "$TUTTI_APP_PACKAGE_DIR/server.py"
 	if !strings.Contains(string(logData), "runner-started") {
 		t.Fatalf("runtime.log = %q, want runner output", string(logData))
 	}
-	if !strings.Contains(string(logData), "tutti workspace app startup") || !strings.Contains(string(logData), "workspaceRoot="+root) {
+	if !strings.Contains(string(logData), "tutti workspace app startup") || strings.Contains(string(logData), "workspaceRoot=") {
 		t.Fatalf("runtime.log = %q, want startup diagnostic", string(logData))
 	}
 	if !strings.Contains(string(logData), "python=") || !strings.Contains(string(logData), "node=") {
@@ -179,7 +184,6 @@ exec python3 "$TUTTI_APP_PACKAGE_DIR/server.py"
 	state, err := runner.Start(context.Background(), AppStartInput{
 		WorkspaceID:     "ws-runner",
 		WorkspaceName:   "Runner Workspace",
-		WorkspaceRoot:   root,
 		AppID:           "standalone",
 		PackageDir:      packageDir,
 		Bootstrap:       "bootstrap.sh",
@@ -242,7 +246,6 @@ exec "$TUTTI_APP_PYTHON" "$TUTTI_APP_PACKAGE_DIR/server.py"
 	input := AppStartInput{
 		WorkspaceID:     "ws-runner",
 		WorkspaceName:   "Runner Workspace",
-		WorkspaceRoot:   root,
 		AppID:           "hello",
 		PackageDir:      packageDir,
 		Bootstrap:       "bootstrap.sh",
@@ -619,7 +622,6 @@ exec "$TUTTI_APP_NODE" "$TUTTI_APP_PACKAGE_DIR/server.js"
 	state, err := runner.Start(context.Background(), AppStartInput{
 		WorkspaceID:     "ws-fnm",
 		WorkspaceName:   "Fnm Workspace",
-		WorkspaceRoot:   root,
 		AppID:           "fnm-node",
 		PackageDir:      packageDir,
 		Bootstrap:       "bootstrap.sh",
@@ -885,7 +887,8 @@ func pythonAppReadyServerScript(healthcheckPath string, writeProbe bool) string 
                 "appId": os.environ["TUTTI_APP_ID"],
                 "workspaceId": os.environ["TUTTI_WORKSPACE_ID"],
                 "workspaceName": os.environ["TUTTI_WORKSPACE_NAME"],
-                "workspaceRoot": os.environ["TUTTI_WORKSPACE_ROOT"],
+                "tuttiWorkspaceRoot": os.environ.get("TUTTI_WORKSPACE_ROOT", ""),
+                "nextopWorkspaceRoot": os.environ.get("NEXTOP_WORKSPACE_ROOT", ""),
                 "appHost": os.environ["TUTTI_APP_HOST"],
                 "appBaseUrl": os.environ["TUTTI_APP_BASE_URL"],
                 "packageDir": os.environ["TUTTI_APP_PACKAGE_DIR"],

--- a/services/tuttid/service/workspace/apps_runtime.go
+++ b/services/tuttid/service/workspace/apps_runtime.go
@@ -267,15 +267,10 @@ func (s *AppCenterService) startPackage(ctx context.Context, workspaceID string,
 	if err != nil {
 		return workspacebiz.AppRuntimeState{}, err
 	}
-	workspaceRoot, err := s.workspaceRoot(ctx, workspaceID)
-	if err != nil {
-		slog.Warn("workspace app root resolution failed; app will start without TUTTI_WORKSPACE_ROOT", "workspaceId", workspaceID, "appId", appPackage.AppID, "error", err)
-	}
 	root := s.workspaceAppStateRoot(workspaceID, appPackage.AppID)
 	return s.runner().Start(ctx, AppStartInput{
 		WorkspaceID:     workspaceID,
 		WorkspaceName:   workspace.Name,
-		WorkspaceRoot:   workspaceRoot.PhysicalRoot,
 		AppID:           appPackage.AppID,
 		PackageDir:      appPackage.PackageDir,
 		Bootstrap:       appPackage.Manifest.Runtime.Bootstrap,

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -470,7 +470,6 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 	appCenterService := &workspaceservice.AppCenterService{
 		Store:                 appStore,
 		AppFactoryStore:       appFactoryStore,
-		WorkspaceRootResolver: workspaceservice.FileService{Adapter: fileAdapter},
 		WorkspaceStore:        store,
 		PreferencesStore:      preferencesStore,
 		Runner:                &workspaceservice.AppRunner{RuntimeResolver: managedRuntimeResolver},


### PR DESCRIPTION
## What changed

- Remove WorkspaceRoot from AppStartInput and AppRunner wiring.
- Stop injecting TUTTI_WORKSPACE_ROOT and NEXTOP_WORKSPACE_ROOT.
- Build the child environment from an explicit OS and supported-provider allowlist, then apply trusted runtime overrides.
- Reject legacy root variables even when supplied as overrides.
- Update App Factory runtime documentation and regression tests.

## Why

Copying the daemon environment made host implementation details and unrelated secrets visible to business apps. The workspace-root alias also conflicted with the actual app and Agent cwd.

## Risks

Apps that accidentally depended on unrelated daemon variables or the removed root aliases must migrate before this provider change is released.

## Verification

- go test ./services/tuttid/service/workspace -run TestWorkspaceAppProcessEnv|TestAppRunner|TestAppFactory
- go test ./services/tuttid -run ^$
- focused AppRunner, AppFactory, allowlist, and wiring tests
- git diff --check

Roll out consumer app releases before enabling this host-side removal.