### PR TITLE
fix(ci): classify repository checks by responsibility

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,9 +14,11 @@ jobs:
     name: PR Change Classification
     runs-on: ubuntu-latest
     outputs:
+      run_boundaries: ${{ steps.changed-files.outputs.run_boundaries }}
+      run_contracts: ${{ steps.changed-files.outputs.run_contracts }}
+      run_generated: ${{ steps.changed-files.outputs.run_generated }}
       run_go: ${{ steps.changed-files.outputs.run_go }}
       run_pack: ${{ steps.changed-files.outputs.run_pack }}
-      run_tooling: ${{ steps.changed-files.outputs.run_tooling }}
       run_ts: ${{ steps.changed-files.outputs.run_ts }}
 
     steps:
@@ -29,105 +31,91 @@ jobs:
         id: changed-files
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          run_go=false
-          run_pack=false
-          run_tooling=false
-          run_ts=false
-
-          while IFS= read -r path; do
-            [[ -z "${path}" ]] && continue
-
-            case "${path}" in
-              *.go|go.mod|go.sum|go.work|go.work.sum|*/go.mod|*/go.sum|services/tuttid/.golangci*)
-                run_go=true
-                run_tooling=true
-                ;;
-            esac
-
-            case "${path}" in
-              *.cjs|*.cts|*.js|*.jsx|*.mjs|*.mts|*.ts|*.tsx|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|tsconfig*.json|*/tsconfig*.json|packages/configs/**)
-                run_ts=true
-                run_pack=true
-                ;;
-            esac
-
-            case "${path}" in
-              package.json|pnpm-lock.yaml|pnpm-workspace.yaml|packages/*/package.json|packages/*/*/package.json)
-                run_pack=true
-                ;;
-            esac
-
-            case "${path}" in
-              .github/workflows/pr-checks.yml|tools/scripts/**|services/tuttid/.golangci-lint-version)
-                run_go=true
-                run_pack=true
-                run_tooling=true
-                run_ts=true
-                ;;
-            esac
-          done < <(git diff --name-only "${BASE_SHA}...HEAD")
-
-          {
-            echo "run_go=${run_go}"
-            echo "run_pack=${run_pack}"
-            echo "run_tooling=${run_tooling}"
-            echo "run_ts=${run_ts}"
-          } >> "${GITHUB_OUTPUT}"
-
-          printf 'change classification: run_go=%s run_pack=%s run_tooling=%s run_ts=%s\n' \
-            "${run_go}" "${run_pack}" "${run_tooling}" "${run_ts}"
+        run: >-
+          node ./tools/scripts/change-classification.mjs
+          --base "${BASE_SHA}"
+          --github-output "${GITHUB_OUTPUT}"
 
   tooling-consistency:
     name: Tooling Consistency
     needs: changes
-    if: needs.changes.outputs.run_tooling == 'true'
+    if: always()
     runs-on: ubuntu-latest
 
     steps:
+      - name: Require change classification
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+        run: test "${CHANGES_RESULT}" = "success"
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: .node-version
 
+      - name: Check changed-file whitespace
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: git diff --check "${BASE_SHA}...HEAD"
+
+      - name: Check repository naming policy
+        run: node ./tools/scripts/check-tutti-names.mjs
+
+      - name: Set up pnpm
+        if: >-
+          needs.changes.outputs.run_contracts == 'true' ||
+          needs.changes.outputs.run_generated == 'true' ||
+          needs.changes.outputs.run_boundaries == 'true'
+        uses: pnpm/action-setup@v4
+
       - name: Set up Go
+        if: >-
+          needs.changes.outputs.run_generated == 'true' ||
+          needs.changes.outputs.run_boundaries == 'true'
         uses: actions/setup-go@v5
         with:
           go-version: "1.24.5"
           cache-dependency-path: |
             go.work
             go.work.sum
-            packages/agent/activity-replication/go.mod
-            packages/agent/daemon/go.mod
             packages/agent/daemon/go.sum
-            packages/agent/host/go.mod
-            packages/agent/host/go.sum
-            packages/agent/runtimeprep/go.mod
-            packages/agent/store-sqlite/go.mod
-            packages/agent/store-sqlite/canonical/go.mod
-            packages/auth/bridge-go/go.mod
-            packages/appcli/core/go.mod
-            packages/events/stream-go/go.mod
-            packages/workbench/service/go.mod
-            packages/workspace/files/go.mod
-            packages/workspace/issues/go.mod
-            apps/cli/go.mod
-            services/tuttid/go.mod
             services/tuttid/go.sum
 
-      - name: Install pinned golangci-lint
-        run: |
-          version=$(tr -d '\n' < services/tuttid/.golangci-lint-version)
-          install_dir="${HOME}/.local/bin"
-          mkdir -p "${install_dir}"
-          curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b "${install_dir}" "${version}"
-          echo "${install_dir}" >> "${GITHUB_PATH}"
+      - name: Install workspace dependencies
+        if: >-
+          needs.changes.outputs.run_contracts == 'true' ||
+          needs.changes.outputs.run_generated == 'true' ||
+          needs.changes.outputs.run_boundaries == 'true'
+        run: pnpm install --frozen-lockfile
 
-      - name: Check golangci-lint version pin
-        run: node ./tools/scripts/setup-dev.mjs --only=golangci-lint
+      - name: Run repository contract tests
+        if: needs.changes.outputs.run_contracts == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: >-
+          node ./tools/scripts/run-repository-checks.mjs
+          --group contracts --base "${BASE_SHA}"
+
+      - name: Run generated contract checks
+        if: needs.changes.outputs.run_generated == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: >-
+          node ./tools/scripts/run-repository-checks.mjs
+          --group generated --base "${BASE_SHA}"
+
+      - name: Run repository boundary checks
+        if: needs.changes.outputs.run_boundaries == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: >-
+          node ./tools/scripts/run-repository-checks.mjs
+          --group boundaries --base "${BASE_SHA}"
 
   fix-scope:
     name: Fix Scope Soft Gate
@@ -173,27 +161,6 @@ jobs:
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Check generated defaults
-        run: pnpm check:defaults-generated
-
-      - name: Check generated API artifacts
-        run: pnpm check:api-generated
-
-      - name: Check generated event protocol artifacts
-        run: pnpm check:event-protocol-generated
-
-      - name: Check UI boundaries
-        run: pnpm check:ui-boundaries
-
-      - name: Check renderer feature boundaries
-        run: pnpm check:renderer-boundaries
-
-      - name: Check agent GUI degradation baseline
-        run: pnpm check:agent-gui-degradation
-
-      - name: Check i18n
-        run: pnpm check:i18n
 
       - name: Run TypeScript lint
         env:
@@ -329,9 +296,6 @@ jobs:
       - name: Generate builtin apps
         run: pnpm generate:builtin-apps
 
-      - name: Check Codex app-server protocol generation
-        run: pnpm check:codexproto-generated
-
       - name: Run Go workspace tests
         run: pnpm test:go:prepared
 
@@ -376,9 +340,6 @@ jobs:
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Check agent host boundary
-        run: pnpm check:agent-host-boundary
 
       - name: Generate builtin apps
         run: pnpm generate:builtin-apps

--- a/docs/conventions/local-git-hooks.md
+++ b/docs/conventions/local-git-hooks.md
@@ -58,8 +58,9 @@ selects only the relevant validation lanes, and adds build lanes for changed Go
 or package surfaces that require push-time build confidence. Unrelated
 TypeScript, Go, package, and boundary lanes do not run.
 
-`check:full` remains the stable root command for explicit local full validation
-and CI. It is no longer the default gate for every push.
+`check:full` remains the stable root command for explicit local full validation.
+It is no longer the default gate for every push; PR CI selects affected lanes
+from the same repository check registry used by `check:changed`.
 
 That root command now uses a repository-owned Node orchestration script so the stable entrypoint stays the same while independent checks can run in parallel in bounded phases:
 
@@ -83,13 +84,21 @@ That full validation currently includes:
 - `pnpm check:agent-gui-provider-catalog-generated`
 - `pnpm check:api-generated`
 - `pnpm check:event-protocol-generated`
+- `pnpm check:workbench-go-contract`
+- `pnpm check:codexproto-generated`
+- `pnpm check:tutti-names`
 - `pnpm check:i18n`
 - `pnpm check:electron-runtime-boundaries`
 - `pnpm check:ui-boundaries`
 - `pnpm check:renderer-boundaries`
+- `pnpm check:agent-activity-runtime-boundaries`
+- `pnpm check:agent-host-boundary`
+- `pnpm check:agent-provider-strategy-boundaries`
+- `pnpm check:agent-gui-degradation`
 - `pnpm lint`
 - `pnpm typecheck`
 - `pnpm test:ts`
+- `pnpm test:tools`
 - `pnpm test:go`
 
 The lint and typecheck steps in `check:full` should follow the repository's
@@ -132,7 +141,9 @@ changed-aware runner and hook behavior.
 
 The runner selects checks from the changed file set, runs independent lanes
 concurrently, prints compact summaries, and stores full logs under
-`.tmp/check-runs`.
+`.tmp/check-runs`. Repository policy, tool contracts, generated contracts, and
+architecture boundaries come from `tools/scripts/repository-checks.mjs`; PR CI
+uses the same selectors.
 
 `pnpm check:changed -- --push-ready` is the `pre-push` mode. In addition to the
 normal changed-aware lanes, it schedules Go or package builds when the changed

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -31,17 +31,26 @@ Repository entrypoints:
 - `pnpm check:agent-host-boundary`
 - `pnpm check:agent-provider-strategy-boundaries`
 
-`pnpm check:full` remains the full local and CI validation command and includes linting and typechecking.
+`pnpm check:full` remains the full local validation command and includes
+linting, typechecking, repository checks, and blocking tests. PR CI selects the
+equivalent affected surfaces instead of running `check:full` as one job.
 
-The pull-request workflow classifies changed files inline before running
-expensive validation jobs. TypeScript and JavaScript paths select TypeScript
-lint, typecheck, tests, and package packing; Go paths select Go tests and Go
-lint; package manifest and lockfile paths select package packing; CI and
-repository tooling paths conservatively select all affected lanes. Documentation
-only changes therefore skip code validation while still producing workflow check
-results through job-level conditions. Do not use workflow-level `paths-ignore`
-for this gate because missing required checks can leave documentation-only PRs
-waiting on branch protection.
+The pull-request workflow and `check:changed` share changed-file classification
+from `tools/scripts/change-classification.mjs` and repository-check ownership
+from `tools/scripts/repository-checks.mjs`. Repository checks are grouped by
+responsibility: policy, tool contracts, generated contracts, and architecture
+boundaries. TypeScript and Go jobs own language lint/tests only; a check written
+in TypeScript does not make it a TypeScript check. Package sources and assets
+select packing independently of language. Documentation-only changes skip code
+validation while still producing workflow check results through job-level
+conditions. Do not use workflow-level `paths-ignore` for this gate because
+missing required checks can leave documentation-only PRs waiting on branch
+protection.
+
+PR CI keeps the existing `Tooling Consistency` required context as the owner of
+repository policy, contract, generated, and boundary checks. This preserves
+branch-protection compatibility while keeping those checks out of language
+jobs.
 
 Validation runners that spawn nested pnpm commands should read the root
 `packageManager` field and invoke that pinned version through Corepack. Do not
@@ -98,9 +107,9 @@ open, bounded identifier contracts that accept extension providers. It runs as p
 `pnpm generate:agent-gui-provider-catalog`; do not hand-edit the generated
 catalog.
 
-The provider catalog check also runs
-`pnpm check:agent-provider-strategy-boundaries`. Cross-provider daemon,
-service, and desktop production code must dispatch behavior through
+Provider strategy is an independent architecture boundary enforced by
+`pnpm check:agent-provider-strategy-boundaries`. Cross-provider daemon, service,
+and desktop production code must dispatch behavior through
 `providerregistry` strategy, capability, and integration descriptors instead
 of branching on Codex, Claude, Cursor, Hermes, Nexight, OpenClaw, OpenCode, or
 Tutti Agent identity. The checker reads the complete provider ID set from the

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -4,7 +4,7 @@ This document defines the repository-managed test discovery and gate policy.
 
 ## Commands
 
-- `pnpm test:ts`: all TypeScript/JavaScript workspace package tests plus repository tool tests
+- `pnpm test:ts`: all TypeScript/JavaScript workspace package tests
 - `pnpm test:tools`: repository tool tests only
 - `pnpm test:go`: generate builtin app assets, then run the blocking Go workspace test set
 - `pnpm test:go:prepared`: run the blocking Go workspace test set when builtin app assets are already prepared
@@ -61,7 +61,13 @@ add a real package test.
 
 Repository tool tests are discovered from `tools/scripts/*.test.mjs`. Tool
 tests that exercise package release helpers remain tool-owned instead of being
-duplicated through a package-level test script.
+duplicated through a package-level test script. They are repository contract
+tests, not TypeScript package tests, and run through `test:tools` only.
+
+Repository policy, tool contracts, generated contracts, and architecture
+boundaries are selected from `tools/scripts/repository-checks.mjs`. Both PR CI
+and `check:changed` consume this registry; do not attach a repository-wide
+check to a TypeScript or Go lane based on its implementation language.
 
 Go tests are discovered from the modules declared in `go.work`. The blocking
 lane includes every module, so additions to `go.work` join the root test gate

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -80,6 +80,7 @@ App Center, workspace-app lifecycle, App Factory, file references, and File Mana
 
 CLI behavior, CI, package assets, skills, Browser Node, and terminal input.
 
+- [Go-only PR skips a repository contract that later fails](./toolchain-browser-terminal.md#go-only-pr-skips-a-repository-contract-that-later-fails)
 - [Dynamic CLI input rejects plausible flags](./toolchain-browser-terminal.md#dynamic-cli-input-rejects-plausible-flags)
 - [GitHub Actions pnpm setup fails with ERR_PNPM_BAD_PM_VERSION](./toolchain-browser-terminal.md#github-actions-pnpm-setup-fails-with-errpnpmbadpmversion)
 - [Multi-entry tsup declaration build exhausts its worker heap](./toolchain-browser-terminal.md#multi-entry-tsup-declaration-build-exhausts-its-worker-heap)

--- a/docs/conventions/troubleshooting/toolchain-browser-terminal.md
+++ b/docs/conventions/troubleshooting/toolchain-browser-terminal.md
@@ -2,6 +2,34 @@
 
 [Back to troubleshooting index](./README.md)
 
+### Go-only PR skips a repository contract that later fails
+
+- Symptom:
+  A Go-only PR is green, but a later TypeScript PR fails an unrelated
+  repository-wide check or tool test against the Go change.
+- Quick checks:
+  Inspect whether the failing command scans repository-wide files, generated
+  artifacts, workflows, hooks, or architecture boundaries. Then check whether
+  CI attached it to `run_ts` only because the checker is implemented in
+  JavaScript or TypeScript.
+- Root cause:
+  Check ownership was classified by implementation language instead of checked
+  responsibility. Generated-source paths and non-code package assets could also
+  be absent from inline workflow path predicates.
+- Fix:
+  Register repository policy, tool contract, generated contract, or boundary
+  checks in `repository-checks.mjs`. Keep TypeScript and Go jobs limited to
+  language-owned lint and tests. Reuse `change-classification.mjs` in local and
+  PR validation.
+- Validation:
+  Add selector fixtures for every source-of-truth path and a narrow workflow
+  contract test that verifies repository groups stay outside language jobs.
+  Confirm a Go-only fixture does not select TypeScript validation.
+- References:
+  [repository-checks.mjs](../../../tools/scripts/repository-checks.mjs)
+  [change-classification.mjs](../../../tools/scripts/change-classification.mjs)
+  [testing.md](../testing.md)
+
 ### Temporary Git fixture turns a linked worktree bare
 
 - Symptom:

--- a/tools/scripts/change-classification.mjs
+++ b/tools/scripts/change-classification.mjs
@@ -1,0 +1,147 @@
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+
+import { selectedRepositoryCheckGroups } from "./repository-checks.mjs";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(scriptDirectory, "../..");
+
+export function classifyChangedFiles(
+  changedFiles,
+  { releasePackageRoots = discoverReleasePackageRoots() } = {}
+) {
+  const normalizedFiles = changedFiles.map((file) =>
+    file.replaceAll("\\", "/")
+  );
+  const groups = selectedRepositoryCheckGroups(normalizedFiles);
+
+  return {
+    runBoundaries: groups.has("boundaries"),
+    runContracts: groups.has("contracts"),
+    runGenerated: groups.has("generated"),
+    runGo: normalizedFiles.some(isGoRelevant),
+    runPack: normalizedFiles.some((file) =>
+      isPackRelevant(file, releasePackageRoots)
+    ),
+    runTs: normalizedFiles.some(isTypeScriptRelevant)
+  };
+}
+
+export function discoverReleasePackageRoots(root = workspaceRoot) {
+  const packagesRoot = join(root, "packages");
+  const roots = [];
+
+  for (const group of readDirectories(packagesRoot)) {
+    const groupRoot = join(packagesRoot, group);
+    for (const packageName of readDirectories(groupRoot)) {
+      const packageRoot = join(groupRoot, packageName);
+      const manifestPath = join(packageRoot, "package.json");
+      try {
+        const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+        if (
+          manifest.private === false &&
+          manifest.publishConfig?.access === "public"
+        ) {
+          roots.push(packageRoot.slice(root.length + 1).replaceAll("\\", "/"));
+        }
+      } catch {
+        // Non-package directories are outside the release surface.
+      }
+    }
+  }
+
+  return roots.sort();
+}
+
+export function formatClassificationOutputs(classification) {
+  return [
+    ["run_boundaries", classification.runBoundaries],
+    ["run_contracts", classification.runContracts],
+    ["run_generated", classification.runGenerated],
+    ["run_go", classification.runGo],
+    ["run_pack", classification.runPack],
+    ["run_ts", classification.runTs]
+  ]
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+}
+
+function isGoRelevant(file) {
+  return (
+    file.endsWith(".go") ||
+    /(?:^|\/)go\.(?:mod|sum)$/u.test(file) ||
+    ["go.work", "go.work.sum"].includes(file) ||
+    file.startsWith("services/tuttid/.golangci")
+  );
+}
+
+function isTypeScriptRelevant(file) {
+  return (
+    /\.(?:cjs|cts|js|jsx|mjs|mts|ts|tsx)$/u.test(file) ||
+    /(?:^|\/)(?:package\.json|tsconfig[^/]*\.json)$/u.test(file) ||
+    ["pnpm-lock.yaml", "pnpm-workspace.yaml"].includes(file) ||
+    file.startsWith("packages/configs/")
+  );
+}
+
+function isPackRelevant(file, releasePackageRoots) {
+  return (
+    ["package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml"].includes(file) ||
+    /^packages\/[^/]+\/[^/]+\/package\.json$/u.test(file) ||
+    file === ".changeset/config.json" ||
+    file === "tools/scripts/build-npm-packages.mjs" ||
+    file === "tools/scripts/check-package-packs.mjs" ||
+    file === "tools/scripts/npm-release-packages.mjs" ||
+    releasePackageRoots.some(
+      (packageRoot) =>
+        file === packageRoot || file.startsWith(`${packageRoot}/`)
+    )
+  );
+}
+
+function readDirectories(root) {
+  try {
+    return readdirSync(root, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+}
+
+function readOption(name) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? null : (process.argv[index + 1] ?? null);
+}
+
+function isMainModule() {
+  return Boolean(
+    process.argv[1] &&
+    resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  );
+}
+
+if (isMainModule()) {
+  const base = readOption("--base");
+  if (!base) {
+    throw new Error("--base is required");
+  }
+  const changedFiles = execFileSync(
+    "git",
+    ["diff", "--name-only", `${base}...HEAD`],
+    { cwd: workspaceRoot, encoding: "utf8" }
+  )
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const output = formatClassificationOutputs(
+    classifyChangedFiles(changedFiles)
+  );
+  const githubOutput = readOption("--github-output");
+  if (githubOutput) {
+    writeFileSync(githubOutput, `${output}\n`, { flag: "a" });
+  }
+  console.log(output);
+}

--- a/tools/scripts/change-classification.test.mjs
+++ b/tools/scripts/change-classification.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { classifyChangedFiles } from "./change-classification.mjs";
+import { selectRepositoryChecks } from "./repository-checks.mjs";
+
+const releasePackageRoots = ["packages/agent/gui", "packages/ui/system"];
+
+test("Go-only changes do not select TypeScript validation", () => {
+  const classification = classifyChangedFiles(
+    ["services/tuttid/service/workspace/apps.go"],
+    { releasePackageRoots }
+  );
+
+  assert.equal(classification.runGo, true);
+  assert.equal(classification.runTs, false);
+  assert.equal(classification.runPack, false);
+  assert.equal(classification.runBoundaries, true);
+});
+
+test("generated source files select generated contracts before outputs change", () => {
+  for (const file of [
+    "config/tutti.defaults.json",
+    "services/tuttid/api/openapi/tuttid.v1.yaml",
+    "packages/events/protocol/definitions/agent/activity.updated.event.json",
+    "packages/workbench/snapshot/src/schema.json"
+  ]) {
+    const classification = classifyChangedFiles([file], {
+      releasePackageRoots
+    });
+    assert.equal(classification.runGenerated, true, file);
+  }
+});
+
+test("workflow and hook changes select repository tool contracts", () => {
+  for (const file of [
+    ".github/workflows/desktop-release.yml",
+    ".github/workflows/publish-tutti-app-release.yml",
+    ".husky/pre-push"
+  ]) {
+    const classification = classifyChangedFiles([file], {
+      releasePackageRoots
+    });
+    assert.equal(classification.runContracts, true, file);
+  }
+});
+
+test("published CSS and assets select package packing and UI boundaries", () => {
+  for (const file of [
+    "packages/agent/gui/app/renderer/agentactivity.css",
+    "packages/ui/system/src/icons/recent-lined.svg"
+  ]) {
+    const classification = classifyChangedFiles([file], {
+      releasePackageRoots
+    });
+    assert.equal(classification.runPack, true, file);
+    assert.equal(classification.runBoundaries, true, file);
+    assert.equal(classification.runTs, false, file);
+  }
+});
+
+test("deleted package manifests still select package packing", () => {
+  const classification = classifyChangedFiles(
+    ["packages/example/removed/package.json"],
+    { releasePackageRoots }
+  );
+
+  assert.equal(classification.runPack, true);
+});
+
+test("repository check registry selects only relevant generated checks", () => {
+  const checks = selectRepositoryChecks(
+    ["packages/events/protocol/schemas/core/event-envelope.schema.json"],
+    { group: "generated" }
+  );
+
+  assert.deepEqual(
+    checks.map((check) => check.key),
+    ["generated:event-protocol"]
+  );
+});
+
+test("provider source changes select catalog and strategy checks", () => {
+  const checks = selectRepositoryChecks([
+    "packages/agent/daemon/providerregistry/providers.go"
+  ]);
+  const keys = checks.map((check) => check.key);
+
+  assert.ok(keys.includes("generated:agent-provider-catalog"));
+  assert.ok(keys.includes("boundary:agent-provider-strategy"));
+});

--- a/tools/scripts/check-agent-gui-provider-catalog.mjs
+++ b/tools/scripts/check-agent-gui-provider-catalog.mjs
@@ -24,15 +24,6 @@ execFileSync(
 );
 
 execFileSync(
-  process.execPath,
-  [join(scriptDirectory, "check-agent-provider-strategy-boundaries.mjs")],
-  {
-    cwd: workspaceRoot,
-    stdio: "inherit"
-  }
-);
-
-execFileSync(
   process.platform === "win32" ? "corepack.cmd" : "corepack",
   [
     `pnpm@${match[1]}`,

--- a/tools/scripts/check-tutti-names.mjs
+++ b/tools/scripts/check-tutti-names.mjs
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, join, relative } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
@@ -27,45 +27,67 @@ const ignoredPrefixes = [
 
 const allowedLegacyContentFiles = new Set([
   "packages/auth/bridge/src/shared.ts",
-  "packages/auth/bridge-go/authbridge.go"
+  "packages/auth/bridge-go/authbridge.go",
+  // Removed workspace-root contracts are still explicitly stripped so old
+  // inherited or caller-provided environment values cannot reach apps.
+  "services/tuttid/service/workspace/app_runtime_env.go",
+  "services/tuttid/service/workspace/app_runtime_env_test.go",
+  "services/tuttid/service/workspace/apps_runner_test.go"
 ]);
 
-const files = execFileSync(
-  "git",
-  ["ls-files", "--cached", "--others", "--exclude-standard"],
-  {
-    cwd: workspaceRoot,
-    encoding: "utf8"
-  }
-)
-  .split("\n")
-  .map((line) => line.trim())
-  .filter(Boolean)
-  .filter((file) => !ignoredPrefixes.some((prefix) => file.startsWith(prefix)))
-  .filter((file) => existsSync(join(workspaceRoot, file)));
+export function findLegacyNameViolations(files, readFile) {
+  const violations = [];
 
-const violations = [];
+  for (const file of files) {
+    if (legacyTokens.some((token) => file.includes(token))) {
+      violations.push(file);
+      continue;
+    }
+    const content = readFile(file);
+    if (!legacyTokens.some((token) => content.includes(token))) {
+      continue;
+    }
+    if (!allowedLegacyContentFiles.has(file)) {
+      violations.push(file);
+    }
+  }
 
-for (const file of files) {
-  if (legacyTokens.some((token) => file.includes(token))) {
-    violations.push(file);
-    continue;
-  }
-  const content = readFileSync(join(workspaceRoot, file), "utf8");
-  if (!legacyTokens.some((token) => content.includes(token))) {
-    continue;
-  }
-  if (allowedLegacyContentFiles.has(file)) {
-    continue;
-  }
-  violations.push(file);
+  return violations;
 }
 
-if (violations.length > 0) {
-  console.error("Unexpected legacy product tokens found:");
-  for (const file of violations) {
-    console.error(`- ${relative(workspaceRoot, join(workspaceRoot, file))}`);
+if (isMainModule()) {
+  const files = execFileSync(
+    "git",
+    ["ls-files", "--cached", "--others", "--exclude-standard"],
+    {
+      cwd: workspaceRoot,
+      encoding: "utf8"
+    }
+  )
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter(
+      (file) => !ignoredPrefixes.some((prefix) => file.startsWith(prefix))
+    )
+    .filter((file) => existsSync(join(workspaceRoot, file)));
+  const violations = findLegacyNameViolations(files, (file) =>
+    readFileSync(join(workspaceRoot, file), "utf8")
+  );
+
+  if (violations.length > 0) {
+    console.error("Unexpected legacy product tokens found:");
+    for (const file of violations) {
+      console.error(`- ${relative(workspaceRoot, join(workspaceRoot, file))}`);
+    }
+    console.error("Move references to Tutti naming before merging.");
+    process.exitCode = 1;
   }
-  console.error("Move references to Tutti naming before merging.");
-  process.exitCode = 1;
+}
+
+function isMainModule() {
+  return Boolean(
+    process.argv[1] &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
 }

--- a/tools/scripts/check-tutti-names.test.mjs
+++ b/tools/scripts/check-tutti-names.test.mjs
@@ -1,44 +1,37 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
-import { mkdir, rm, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-const scriptDirectory = dirname(fileURLToPath(import.meta.url));
-const scriptPath = resolve(scriptDirectory, "check-tutti-names.mjs");
-const workspaceRoot = resolve(scriptDirectory, "..", "..");
+import { findLegacyNameViolations } from "./check-tutti-names.mjs";
 
-test("allows legacy OAuth app id compatibility constants", () => {
-  const result = spawnSync("node", [scriptPath], {
-    cwd: workspaceRoot,
-    encoding: "utf8"
-  });
+test("allows only declared legacy compatibility contracts", () => {
+  const legacyUpperName = ["N", "E", "X", "T", "O", "P"].join("");
+  const files = new Map([
+    [
+      "packages/auth/bridge/src/shared.ts",
+      `export const id = '${legacyUpperName}_APP_ID'`
+    ],
+    [
+      "services/tuttid/service/workspace/app_runtime_env.go",
+      `const removedRoot = "${legacyUpperName}_WORKSPACE_ROOT"`
+    ],
+    ["packages/example/src/index.ts", "export const product = 'Tutti'"]
+  ]);
 
-  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(
+    findLegacyNameViolations([...files.keys()], (file) => files.get(file)),
+    []
+  );
 });
 
-test("rejects legacy product tokens in file paths", async () => {
-  const forbiddenPathSegment = ["n", "e", "x", "t", "o", "p"].join("");
-  const fixtureDir = join(
-    workspaceRoot,
-    `.tmp-tutti-name-check-${Date.now()}-${forbiddenPathSegment}`
+test("rejects legacy product tokens in paths and undeclared content", () => {
+  const legacyName = ["n", "e", "x", "t", "o", "p"].join("");
+  const files = new Map([
+    [`packages/${legacyName}/clean.txt`, "clean"],
+    ["packages/example/src/index.ts", `export const product = '${legacyName}'`]
+  ]);
+
+  assert.deepEqual(
+    findLegacyNameViolations([...files.keys()], (file) => files.get(file)),
+    [...files.keys()]
   );
-  const fixturePath = join(fixtureDir, "clean.txt");
-
-  try {
-    await mkdir(fixtureDir, { recursive: true });
-    await writeFile(fixturePath, "clean content\n", "utf8");
-
-    const result = spawnSync("node", [scriptPath], {
-      cwd: workspaceRoot,
-      encoding: "utf8"
-    });
-
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /Unexpected legacy product tokens found/);
-    assert.match(result.stderr, /clean\.txt/);
-  } finally {
-    await rm(fixtureDir, { recursive: true, force: true });
-  }
 });

--- a/tools/scripts/pr-checks-workflow.test.mjs
+++ b/tools/scripts/pr-checks-workflow.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import YAML from "yaml";
+
+const workspaceRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const workflow = YAML.parse(
+  readFileSync(join(workspaceRoot, ".github/workflows/pr-checks.yml"), "utf8")
+);
+
+test("PR checks route repository groups through shared scripts", () => {
+  const changes = workflow.jobs.changes;
+  const classificationStep = changes.steps.find(
+    (step) => step.name === "Classify changed files"
+  );
+  const toolingScripts = stepScripts(workflow.jobs["tooling-consistency"]);
+
+  assert.match(
+    classificationStep.run,
+    /tools\/scripts\/change-classification\.mjs/u
+  );
+  for (const group of ["contracts", "generated", "boundaries"]) {
+    assert.match(toolingScripts, new RegExp(`--group ${group}`, "u"));
+  }
+});
+
+test("language jobs do not own repository checks", () => {
+  for (const jobName of ["ts-lint", "ts-tests", "go-tests", "go-lint"]) {
+    assert.doesNotMatch(
+      stepScripts(workflow.jobs[jobName]),
+      /run-repository-checks|test:tools|pnpm check:/u,
+      jobName
+    );
+  }
+});
+
+function stepScripts(job) {
+  return job.steps.map((step) => step.run ?? "").join("\n");
+}

--- a/tools/scripts/repository-checks.mjs
+++ b/tools/scripts/repository-checks.mjs
@@ -1,0 +1,328 @@
+const scriptInfrastructureFiles = new Set([
+  "tools/scripts/change-classification.mjs",
+  "tools/scripts/change-classification.test.mjs",
+  "tools/scripts/repository-checks.mjs",
+  "tools/scripts/run-repository-checks.mjs"
+]);
+
+const javascriptExtensions = /\.(?:cjs|cts|js|jsx|mjs|mts|ts|tsx)$/u;
+const uiBoundaryExtensions =
+  /\.(?:cjs|css|cts|js|json|jsx|mjs|mts|svg|ts|tsx)$/u;
+
+export const repositoryCheckDefinitions = [
+  {
+    group: "policy",
+    key: "policy:tutti-names",
+    label: "repository naming policy",
+    script: "check:tutti-names",
+    matches: () => true
+  },
+  {
+    group: "contracts",
+    key: "contracts:tool-tests",
+    label: "repository tool contracts",
+    script: "test:tools",
+    matches: isToolContractRelevant
+  },
+  {
+    group: "generated",
+    key: "generated:defaults",
+    label: "generated defaults",
+    script: "check:defaults-generated",
+    matches: isDefaultsContractRelevant
+  },
+  {
+    group: "generated",
+    key: "generated:api",
+    label: "generated API",
+    script: "check:api-generated",
+    matches: isApiContractRelevant
+  },
+  {
+    group: "generated",
+    key: "generated:event-protocol",
+    label: "generated event protocol",
+    script: "check:event-protocol-generated",
+    matches: isEventProtocolContractRelevant
+  },
+  {
+    group: "generated",
+    key: "generated:workbench-go-contract",
+    label: "generated workbench Go contract",
+    script: "check:workbench-go-contract",
+    matches: isWorkbenchGoContractRelevant
+  },
+  {
+    group: "generated",
+    key: "generated:agent-provider-catalog",
+    label: "generated agent provider catalog",
+    script: "check:agent-gui-provider-catalog-generated",
+    matches: isAgentProviderCatalogRelevant
+  },
+  {
+    group: "generated",
+    key: "generated:codexproto",
+    label: "generated Codex protocol",
+    script: "check:codexproto-generated",
+    matches: isCodexProtocolRelevant
+  },
+  {
+    group: "boundaries",
+    key: "boundary:electron",
+    label: "Electron runtime boundary",
+    script: "check:electron-runtime-boundaries",
+    matches: isElectronRuntimeBoundaryRelevant
+  },
+  {
+    group: "boundaries",
+    key: "boundary:ui",
+    label: "UI boundary",
+    script: "check:ui-boundaries",
+    matches: isUiBoundaryRelevant
+  },
+  {
+    group: "boundaries",
+    key: "boundary:renderer",
+    label: "renderer feature boundary",
+    script: "check:renderer-boundaries",
+    matches: isRendererBoundaryRelevant
+  },
+  {
+    group: "boundaries",
+    key: "boundary:agent-activity-runtime",
+    label: "Agent activity runtime boundary",
+    script: "check:agent-activity-runtime-boundaries",
+    matches: isAgentActivityRuntimeBoundaryRelevant
+  },
+  {
+    group: "boundaries",
+    key: "boundary:agent-host",
+    label: "Agent Host boundary",
+    script: "check:agent-host-boundary",
+    matches: isAgentHostBoundaryRelevant
+  },
+  {
+    group: "boundaries",
+    key: "boundary:agent-provider-strategy",
+    label: "agent provider strategy boundary",
+    script: "check:agent-provider-strategy-boundaries",
+    matches: isAgentProviderStrategyRelevant
+  },
+  {
+    group: "boundaries",
+    key: "boundary:agent-gui-degradation",
+    label: "Agent GUI degradation boundary",
+    script: "check:agent-gui-degradation",
+    matches: isAgentGuiDegradationRelevant
+  },
+  {
+    group: "boundaries",
+    key: "boundary:i18n",
+    label: "i18n boundary",
+    script: "check:i18n",
+    matches: isI18nRelevant
+  }
+];
+
+export function selectRepositoryChecks(changedFiles, { group } = {}) {
+  if (changedFiles.length === 0) {
+    return [];
+  }
+
+  return repositoryCheckDefinitions.filter(
+    (definition) =>
+      (!group || definition.group === group) &&
+      changedFiles.some(
+        (file) =>
+          isCheckInfrastructure(file) || definition.matches(normalize(file))
+      )
+  );
+}
+
+export function selectedRepositoryCheckGroups(changedFiles) {
+  return new Set(
+    selectRepositoryChecks(changedFiles).map((definition) => definition.group)
+  );
+}
+
+export function isToolContractRelevant(file) {
+  const normalized = normalize(file);
+  return (
+    normalized.startsWith("tools/scripts/") ||
+    normalized.startsWith("packages/workspace/app-release-tools/") ||
+    normalized.startsWith("apps/desktop/scripts/") ||
+    normalized.startsWith(".github/workflows/") ||
+    normalized.startsWith(".husky/") ||
+    normalized === "package.json" ||
+    normalized === "apps/desktop/package.json" ||
+    normalized === "apps/desktop/electron.vite.config.ts" ||
+    normalized === "apps/desktop/build/icon.png" ||
+    normalized === "apps/desktop/src/preload/entries/browserNodeGuest.ts" ||
+    normalized ===
+      "packages/browser/workbench-node/src/electron-main/loopbackPreviewProxy.ts" ||
+    normalized === "docs/conventions/desktop-release.md" ||
+    normalized ===
+      "services/tuttid/service/workspace/agent_workspace_app_reference/references/github-actions-release.md"
+  );
+}
+
+function isDefaultsContractRelevant(file) {
+  return (
+    file === "config/tutti.defaults.json" ||
+    file === "services/tuttid/types/defaults_generated.go" ||
+    file === "apps/cli/internal/defaults/defaults_generated.go" ||
+    file === "apps/desktop/src/main/generated/defaults.ts" ||
+    file === "packages/configs/prettier/base.mjs" ||
+    file === "tools/scripts/generate-defaults.mjs"
+  );
+}
+
+function isApiContractRelevant(file) {
+  return (
+    file.startsWith("services/tuttid/api/openapi/") ||
+    file.startsWith("services/tuttid/api/generated/") ||
+    file.startsWith("packages/clients/tuttid-ts/src/generated/") ||
+    file === "packages/workbench/snapshot/src/schema.json" ||
+    file === "tools/scripts/generate-openapi.mjs" ||
+    file === "tools/scripts/sync-workbench-openapi-schema.mjs" ||
+    file === "tools/scripts/check-agent-protocol-enums.mjs"
+  );
+}
+
+function isEventProtocolContractRelevant(file) {
+  return (
+    file.startsWith("packages/events/protocol/definitions/") ||
+    file.startsWith("packages/events/protocol/schemas/") ||
+    file.startsWith("packages/events/protocol/src/generated/") ||
+    file === "services/tuttid/api/events/generated/protocol.gen.go" ||
+    file === "packages/configs/prettier/base.mjs" ||
+    file === "tools/scripts/generate-event-protocol.mjs" ||
+    file === "tools/scripts/check-agent-protocol-enums.mjs"
+  );
+}
+
+function isWorkbenchGoContractRelevant(file) {
+  return (
+    file === "packages/workbench/snapshot/src/schema.json" ||
+    file === "packages/workbench/snapshot/src/limits.ts" ||
+    file === "packages/workbench/service/workbench_snapshot_contract.gen.go" ||
+    file === "tools/scripts/generate-workbench-go-contract.mjs"
+  );
+}
+
+function isAgentProviderCatalogRelevant(file) {
+  return (
+    file.startsWith("packages/agent/daemon/providerregistry/") ||
+    file === "services/tuttid/api/openapi/tuttid.v1.yaml" ||
+    file === "packages/agent/gui/generated/providerIdentityCatalog.ts" ||
+    file ===
+      "packages/agent/activity-core/src/generated/agentCapabilityKeys.ts" ||
+    file.startsWith("packages/agent/gui/app/renderer/assets/icons/") ||
+    file.startsWith("packages/agent/gui/app/renderer/i18n/locales/") ||
+    file === "packages/agent/gui/providerIconAssets.spec.ts" ||
+    file === "packages/agent/gui/providerIdentityCatalog.spec.ts" ||
+    file === "tools/scripts/generate-agent-gui-provider-catalog.mjs" ||
+    file === "tools/scripts/check-agent-gui-provider-catalog.mjs"
+  );
+}
+
+function isCodexProtocolRelevant(file) {
+  return (
+    file.startsWith("packages/agent/daemon/runtime/codexproto/") ||
+    file === "tools/scripts/check-codexproto-generated.mjs" ||
+    file === "tools/scripts/git-environment.mjs"
+  );
+}
+
+function isElectronRuntimeBoundaryRelevant(file) {
+  return (
+    file === "apps/desktop/electron.vite.config.ts" ||
+    file.startsWith("apps/desktop/src/main/") ||
+    file.startsWith("apps/desktop/src/preload/") ||
+    file.startsWith("apps/desktop/src/shared/") ||
+    file.startsWith("packages/") ||
+    file === "tools/scripts/check-electron-runtime-boundaries.mjs" ||
+    file === "tools/scripts/check-electron-runtime-boundaries.test.mjs"
+  );
+}
+
+function isUiBoundaryRelevant(file) {
+  return (
+    (file.startsWith("apps/") ||
+      file.startsWith("packages/") ||
+      file.startsWith("tools/")) &&
+    uiBoundaryExtensions.test(file)
+  );
+}
+
+export function isRendererBoundaryRelevant(file) {
+  return (
+    file.startsWith("apps/desktop/src/renderer/src/") ||
+    file === "tools/scripts/check-renderer-feature-boundaries.mjs" ||
+    file === "tools/scripts/check-renderer-feature-boundaries.test.mjs"
+  );
+}
+
+export function isAgentActivityRuntimeBoundaryRelevant(file) {
+  return (
+    file.startsWith("packages/agent/gui/") ||
+    file.startsWith("packages/agent/activity-core/") ||
+    file.startsWith(
+      "apps/desktop/src/renderer/src/features/workspace-agent/"
+    ) ||
+    file.startsWith(
+      "apps/desktop/src/renderer/src/features/workspace-workbench/"
+    ) ||
+    file === "tools/scripts/check-agent-activity-runtime-boundaries.mjs" ||
+    file === "tools/scripts/check-agent-activity-runtime-boundaries.test.mjs" ||
+    file.startsWith("tools/fixtures/agent-activity-runtime-boundaries/")
+  );
+}
+
+function isAgentHostBoundaryRelevant(file) {
+  return (
+    file.startsWith("services/tuttid/service/agent/") ||
+    file === "tools/scripts/check-agent-host-boundary.mjs" ||
+    file === "tools/scripts/check-agent-host-boundary.test.mjs"
+  );
+}
+
+function isAgentProviderStrategyRelevant(file) {
+  return (
+    ((file.startsWith("services/tuttid/") ||
+      file.startsWith("packages/agent/daemon/") ||
+      file.startsWith("apps/desktop/src/")) &&
+      /\.(?:go|ts|tsx)$/u.test(file)) ||
+    file === "tools/scripts/check-agent-provider-strategy-boundaries.mjs" ||
+    file === "tools/scripts/check-agent-provider-strategy-boundaries.test.mjs"
+  );
+}
+
+function isAgentGuiDegradationRelevant(file) {
+  return (
+    file.startsWith("packages/agent/") ||
+    file.startsWith("tools/degradation-baseline/") ||
+    file === "tools/scripts/check-agent-gui-degradation.mjs" ||
+    file === "tools/scripts/check-agent-gui-degradation.test.mjs"
+  );
+}
+
+function isI18nRelevant(file) {
+  return (
+    ((file.startsWith("apps/desktop/src/main/") ||
+      file.startsWith("apps/desktop/src/renderer/src/") ||
+      file.startsWith("apps/desktop/src/shared/i18n/") ||
+      file.startsWith("packages/")) &&
+      javascriptExtensions.test(file)) ||
+    file === "tools/scripts/check-i18n.mjs" ||
+    file === "tools/scripts/check-i18n.test.mjs"
+  );
+}
+
+function isCheckInfrastructure(file) {
+  return scriptInfrastructureFiles.has(normalize(file));
+}
+
+function normalize(file) {
+  return file.replaceAll("\\", "/");
+}

--- a/tools/scripts/run-check-changed-targets.mjs
+++ b/tools/scripts/run-check-changed-targets.mjs
@@ -44,14 +44,6 @@ export function isBuiltinGenerateRequired(changedFiles) {
   });
 }
 
-export function isToolTestRelevant(file) {
-  const normalized = file.replaceAll("\\", "/");
-  return (
-    normalized.startsWith("tools/scripts/") ||
-    normalized.startsWith("packages/workspace/app-release-tools/")
-  );
-}
-
 export function resolveGoValidationTargets(
   changedFiles,
   { pathExists = existsSync } = {}

--- a/tools/scripts/run-check-changed-targets.test.mjs
+++ b/tools/scripts/run-check-changed-targets.test.mjs
@@ -5,21 +5,9 @@ import {
   buildGoTestLane,
   buildPackageTestCommand,
   isBuiltinGenerateRequired,
-  isToolTestRelevant,
   resolveGoModuleRoot,
   resolveGoValidationTargets
 } from "./run-check-changed-targets.mjs";
-
-describe("isToolTestRelevant", () => {
-  it("keeps app release package changes covered by tool-owned tests", () => {
-    assert.equal(
-      isToolTestRelevant("packages/workspace/app-release-tools/bin/build.mjs"),
-      true
-    );
-    assert.equal(isToolTestRelevant("tools/scripts/build.test.mjs"), true);
-    assert.equal(isToolTestRelevant("packages/workspace/files/file.go"), false);
-  });
-});
 
 describe("resolveGoModuleRoot", () => {
   it("maps changed files to their Go module root", () => {

--- a/tools/scripts/run-check-changed.mjs
+++ b/tools/scripts/run-check-changed.mjs
@@ -13,9 +13,10 @@ import {
   buildGoTestLane,
   buildPackageTestCommand,
   isBuiltinGenerateRequired,
-  isToolTestRelevant,
   resolveGoValidationTargets
 } from "./run-check-changed-targets.mjs";
+import { classifyChangedFiles } from "./change-classification.mjs";
+import { selectRepositoryChecks } from "./repository-checks.mjs";
 import { formatFailureExcerpt } from "./run-validation-lanes.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
@@ -90,6 +91,7 @@ export async function main() {
 
 function buildChangedLanes() {
   const changedFiles = listChangedFiles(baseRef);
+  const classification = classifyChangedFiles(changedFiles);
   const lanesByKey = new Map();
   const addLane = (lane) => {
     if (!lanesByKey.has(lane.key)) {
@@ -111,7 +113,9 @@ function buildChangedLanes() {
     ]
   });
 
-  const lintFiles = selectExistingLintFiles(changedFiles);
+  const lintFiles = classification.runTs
+    ? selectExistingLintFiles(changedFiles)
+    : [];
   if (lintFiles.length > 0) {
     addLane({
       key: "lint:changed",
@@ -126,65 +130,17 @@ function buildChangedLanes() {
     });
   }
 
-  if (changedFiles.some(isElectronRuntimeBoundaryRelevant)) {
+  for (const check of selectRepositoryChecks(changedFiles)) {
     addLane({
-      key: "boundary:electron",
-      label: "boundary:electron",
-      command: [...pnpmCommand, "run", "check:electron-runtime-boundaries"]
+      key: check.key,
+      label: check.label,
+      command: [...pnpmCommand, "run", check.script]
     });
   }
 
-  if (changedFiles.some(isUiBoundaryRelevant)) {
-    addLane({
-      key: "boundary:ui",
-      label: "boundary:ui",
-      command: [...pnpmCommand, "run", "check:ui-boundaries"]
-    });
-  }
-
-  if (changedFiles.some(isRendererBoundaryRelevant)) {
-    addLane({
-      key: "boundary:renderer",
-      label: "boundary:renderer",
-      command: [...pnpmCommand, "run", "check:renderer-boundaries"]
-    });
-  }
-
-  if (changedFiles.some(isAgentActivityRuntimeBoundaryRelevant)) {
-    addLane({
-      key: "boundary:agent-activity-runtime",
-      label: "boundary:agent-activity-runtime",
-      command: [
-        ...pnpmCommand,
-        "run",
-        "check:agent-activity-runtime-boundaries"
-      ]
-    });
-  }
-
-  if (changedFiles.some(isAgentHostBoundaryRelevant)) {
-    addLane({
-      key: "boundary:agent-host",
-      label: "boundary:agent-host",
-      command: [...pnpmCommand, "run", "check:agent-host-boundary"]
-    });
-  }
-
-  if (
-    changedFiles.some(
-      (file) =>
-        file.startsWith("packages/agent/") ||
-        file.startsWith("tools/degradation-baseline/")
-    )
-  ) {
-    addLane({
-      key: "degradation:agent-gui",
-      label: "degradation:agent-gui",
-      command: [...pnpmCommand, "run", "check:agent-gui-degradation"]
-    });
-  }
-
-  const goValidationTargets = resolveGoValidationTargets(changedFiles);
+  const goValidationTargets = classification.runGo
+    ? resolveGoValidationTargets(changedFiles)
+    : null;
   const forceBuiltinGenerate = isBuiltinGenerateRequired(changedFiles);
   if (goValidationTargets) {
     for (const [moduleRoot, targets] of goValidationTargets.lintByModule) {
@@ -218,7 +174,8 @@ function buildChangedLanes() {
     }
   }
 
-  const rootGlobalChange = changedFiles.some(isGlobalTypecheckRelevant);
+  const rootGlobalChange =
+    classification.runTs && changedFiles.some(isGlobalTypecheckRelevant);
   if (rootGlobalChange) {
     addLane({
       key: "typecheck:all",
@@ -267,6 +224,7 @@ function buildChangedLanes() {
 
     if (
       pushReady &&
+      !classification.runPack &&
       packageInfo.scripts.build &&
       packageFiles.some(isBuildRelevant)
     ) {
@@ -278,11 +236,11 @@ function buildChangedLanes() {
     }
   }
 
-  if (changedFiles.some(isToolTestRelevant)) {
+  if (pushReady && classification.runPack) {
     addLane({
-      key: "test:tools",
-      label: "test:tools",
-      command: [...pnpmCommand, "run", "test:tools"]
+      key: "pack:npm",
+      label: "npm package pack",
+      command: [...pnpmCommand, "run", "release:pack:check"]
     });
   }
 
@@ -548,57 +506,6 @@ function isGlobalTypecheckRelevant(file) {
     "pnpm-workspace.yaml",
     "tsconfig.json"
   ].includes(file);
-}
-
-function isElectronRuntimeBoundaryRelevant(file) {
-  return (
-    file === "apps/desktop/electron.vite.config.ts" ||
-    file.startsWith("apps/desktop/src/main/") ||
-    file.startsWith("apps/desktop/src/preload/") ||
-    file.startsWith("apps/desktop/src/shared/") ||
-    file.startsWith("packages/")
-  );
-}
-
-function isUiBoundaryRelevant(file) {
-  return (
-    (file.startsWith("apps/") ||
-      file.startsWith("packages/") ||
-      file.startsWith("tools/")) &&
-    /\.(?:css|json|js|jsx|mjs|ts|tsx)$/u.test(file)
-  );
-}
-
-export function isAgentActivityRuntimeBoundaryRelevant(file) {
-  return (
-    file.startsWith("packages/agent/gui/") ||
-    file.startsWith("packages/agent/activity-core/") ||
-    file.startsWith(
-      "apps/desktop/src/renderer/src/features/workspace-agent/"
-    ) ||
-    file.startsWith(
-      "apps/desktop/src/renderer/src/features/workspace-workbench/"
-    ) ||
-    file === "tools/scripts/check-agent-activity-runtime-boundaries.mjs" ||
-    file === "tools/scripts/check-agent-activity-runtime-boundaries.test.mjs" ||
-    file.startsWith("tools/fixtures/agent-activity-runtime-boundaries/")
-  );
-}
-
-export function isAgentHostBoundaryRelevant(file) {
-  return (
-    file.startsWith("services/tuttid/service/agent/") ||
-    file === "tools/scripts/check-agent-host-boundary.mjs" ||
-    file === "tools/scripts/check-agent-host-boundary.test.mjs"
-  );
-}
-
-export function isRendererBoundaryRelevant(file) {
-  return (
-    file.startsWith("apps/desktop/src/renderer/src/") ||
-    file === "tools/scripts/check-renderer-feature-boundaries.mjs" ||
-    file === "tools/scripts/check-renderer-feature-boundaries.test.mjs"
-  );
 }
 
 function fileExistsWithinWorkspace(file) {

--- a/tools/scripts/run-check-changed.test.mjs
+++ b/tools/scripts/run-check-changed.test.mjs
@@ -4,12 +4,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
-  isAgentActivityRuntimeBoundaryRelevant,
-  isRendererBoundaryRelevant,
   printSummary,
   runLanes,
   selectExistingLintFiles
 } from "./run-check-changed.mjs";
+import {
+  isAgentActivityRuntimeBoundaryRelevant,
+  isRendererBoundaryRelevant
+} from "./repository-checks.mjs";
 
 test("renderer boundary lane covers renderer and checker changes", () => {
   for (const file of [

--- a/tools/scripts/run-check-full.mjs
+++ b/tools/scripts/run-check-full.mjs
@@ -12,6 +12,7 @@ import {
   formatFailureExcerpt,
   formatSlowestLanes
 } from "./run-validation-lanes.mjs";
+import { repositoryCheckDefinitions } from "./repository-checks.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = join(scriptDirectory, "..", "..");
@@ -27,36 +28,10 @@ const phases = [
   },
   {
     title: "Preflight checks",
-    tasks: [
-      { label: "defaults", script: "check:defaults-generated" },
-      {
-        label: "agent-gui-provider-catalog",
-        script: "check:agent-gui-provider-catalog-generated"
-      },
-      { label: "api", script: "check:api-generated" },
-      { label: "event-protocol", script: "check:event-protocol-generated" },
-      { label: "codexproto", script: "check:codexproto-generated" },
-      { label: "tutti-names", script: "check:tutti-names" },
-      { label: "i18n", script: "check:i18n" },
-      {
-        label: "electron-runtime-boundaries",
-        script: "check:electron-runtime-boundaries"
-      },
-      { label: "ui-boundaries", script: "check:ui-boundaries" },
-      { label: "renderer-boundaries", script: "check:renderer-boundaries" },
-      {
-        label: "agent-activity-runtime-boundaries",
-        script: "check:agent-activity-runtime-boundaries"
-      },
-      {
-        label: "agent-host-boundary",
-        script: "check:agent-host-boundary"
-      },
-      {
-        label: "agent-gui-degradation",
-        script: "check:agent-gui-degradation"
-      }
-    ]
+    tasks: repositoryCheckDefinitions.map(({ key, script }) => ({
+      label: key,
+      script
+    }))
   },
   {
     title: "Validation checks",

--- a/tools/scripts/run-repository-checks.mjs
+++ b/tools/scripts/run-repository-checks.mjs
@@ -1,0 +1,69 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { selectRepositoryChecks } from "./repository-checks.mjs";
+import { runValidationLanes } from "./run-validation-lanes.mjs";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(scriptDirectory, "../..");
+const group = readOption("--group");
+const base = readOption("--base");
+
+if (!group || !base) {
+  throw new Error("--group and --base are required");
+}
+
+const changedFiles = execFileSync(
+  "git",
+  ["diff", "--name-only", `${base}...HEAD`],
+  { cwd: workspaceRoot, encoding: "utf8" }
+)
+  .split("\n")
+  .map((line) => line.trim())
+  .filter(Boolean);
+const checks = selectRepositoryChecks(changedFiles, { group });
+
+if (checks.length === 0) {
+  console.log(`repository checks skipped for ${group}`);
+  process.exit(0);
+}
+
+const pnpmCommand = resolvePnpmCommand();
+const result = await runValidationLanes({
+  lanes: checks.map((check) => ({
+    command: [...pnpmCommand, "run", check.script],
+    key: check.key,
+    label: check.label
+  })),
+  maxParallel: 3,
+  summaryLabel: `${group} repository checks`,
+  tailLines: 100,
+  tmpDirectoryName: `repository-checks/${group}`,
+  workspaceRoot
+});
+process.exit(result.exitCode);
+
+function resolvePnpmCommand() {
+  const fallback = [process.platform === "win32" ? "pnpm.cmd" : "pnpm"];
+  try {
+    const packageJson = JSON.parse(
+      readFileSync(join(workspaceRoot, "package.json"), "utf8")
+    );
+    const match = /^pnpm@(.+)$/u.exec(String(packageJson.packageManager ?? ""));
+    return match
+      ? [
+          process.platform === "win32" ? "corepack.cmd" : "corepack",
+          `pnpm@${match[1]}`
+        ]
+      : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function readOption(name) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? null : (process.argv[index + 1] ?? null);
+}

--- a/tools/scripts/run-workspace-tests.mjs
+++ b/tools/scripts/run-workspace-tests.mjs
@@ -78,11 +78,14 @@ export function buildWorkspaceTestPlan({
   trackedFiles
 }) {
   const testFilePattern = /(?:^|\/)[^/]+\.(?:spec|test)\.[cm]?[jt]sx?$/u;
-  const toolTests = trackedFiles
-    .filter(
-      (file) => file.startsWith("tools/scripts/") && file.endsWith(".test.mjs")
-    )
-    .sort();
+  const toolTests = toolsOnly
+    ? trackedFiles
+        .filter(
+          (file) =>
+            file.startsWith("tools/scripts/") && file.endsWith(".test.mjs")
+        )
+        .sort()
+    : [];
   const packages = [];
   const errors = [];
 
@@ -107,7 +110,7 @@ export function buildWorkspaceTestPlan({
     }
   }
 
-  if (toolTests.length === 0) {
+  if (toolsOnly && toolTests.length === 0) {
     errors.push("tools/scripts contains no *.test.mjs files");
   }
 

--- a/tools/scripts/run-workspace-tests.test.mjs
+++ b/tools/scripts/run-workspace-tests.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { buildWorkspaceTestPlan } from "./run-workspace-tests.mjs";
 
-test("workspace test plan discovers package and tool tests", () => {
+test("workspace test plan discovers package tests without repository tools", () => {
   const plan = buildWorkspaceTestPlan({
     packageJsonEntries: [
       {
@@ -29,7 +29,7 @@ test("workspace test plan discovers package and tool tests", () => {
       testFileCount: 1
     }
   ]);
-  assert.deepEqual(plan.toolTests, ["tools/scripts/example.test.mjs"]);
+  assert.deepEqual(plan.toolTests, []);
 });
 
 test("workspace test plan rejects stale zero-test scripts", () => {
@@ -65,4 +65,5 @@ test("tools-only plans skip package completeness checks", () => {
 
   assert.deepEqual(plan.errors, []);
   assert.deepEqual(plan.packages, []);
+  assert.deepEqual(plan.toolTests, ["tools/scripts/example.test.mjs"]);
 });


### PR DESCRIPTION
## Summary

- classify repository policy, tool contracts, generated contracts, and architecture boundaries through one shared registry
- reuse the same changed-file selectors in PR CI and local `check:changed`
- keep `test:ts` package-owned, move repository tool tests to `test:tools`, and preserve the required `Tooling Consistency` context
- cover generated source files, package assets, provider boundaries, naming policy, and deleted package manifests

## Verification

- `pnpm check:changed` (18 lanes)
- `pnpm check:changed -- --push-ready` (18 lanes)
- `pnpm test:tools`
- `pnpm test:ts` (23 workspace package lanes)
- `pnpm check:tutti-names`
- `git diff --check`

## Fix Scope Justification

- Root cause: repository-wide checks were routed by checker implementation language inside PR workflow jobs, so Go-only and generated-source changes could skip checks that scanned those files. Local and CI selectors also had separate path rules.
- Why can this not be fixed at a lower layer? The defect is the repository validation ownership model across CI, local changed-aware validation, full validation, and test discovery. Fixing one checker or one workflow condition would preserve the other divergent selectors.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->