### PR TITLE
feat(agent): decouple Codex sandbox from approvals

### DIFF
--- a/packages/agent/daemon/README.md
+++ b/packages/agent/daemon/README.md
@@ -39,6 +39,14 @@ start or initialize failure, live-session close, idle release, and live process
 replacement. Cleanup failures are logged and do not replace the original close
 or start error.
 
+Hosts that already provide the authoritative outer execution sandbox can
+construct the Codex adapter with
+`CodexAppServerSandboxPolicyDangerFullAccess`. This changes only the Codex
+`sandbox` / `sandboxPolicy` request fields; the session permission mode still
+owns `approvalPolicy` and `approvalsReviewer`, so application approval requests
+continue through the host interaction flow. The default constructor keeps
+Codex sandbox selection coupled to the permission mode.
+
 ## Package Ownership
 
 This package owns:

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -93,6 +93,27 @@ type appServerAdapterConfig struct {
 	command             []string
 	clientInfoName      string
 	authRequiredMessage string
+	sandboxPolicy       CodexAppServerSandboxPolicy
+}
+
+// CodexAppServerSandboxPolicy controls only the Codex process sandbox sent to
+// app-server. Application approval policy and reviewer routing continue to
+// come from the session permission mode.
+type CodexAppServerSandboxPolicy string
+
+const (
+	// CodexAppServerSandboxPolicyPermissionMode preserves the default Codex
+	// behavior: each application permission mode selects its matching sandbox.
+	// This is the zero value so existing hosts keep their current behavior.
+	CodexAppServerSandboxPolicyPermissionMode CodexAppServerSandboxPolicy = ""
+	// CodexAppServerSandboxPolicyDangerFullAccess disables the Codex process
+	// sandbox while leaving application approval and reviewer routing intact.
+	// Hosts should use this only when an outer execution sandbox is authoritative.
+	CodexAppServerSandboxPolicyDangerFullAccess CodexAppServerSandboxPolicy = "danger-full-access"
+)
+
+type CodexAppServerAdapterOptions struct {
+	SandboxPolicy CodexAppServerSandboxPolicy
 }
 
 // defaultCodexAppServerCancelGraceWindow is how long Cancel waits for codex to
@@ -326,6 +347,16 @@ func NewCodexAppServerAdapterWithHostMetadata(transport ProcessTransport, host H
 	return NewCodexAppServerAdapterWithHostMetadataAndCommandResolver(transport, host, nil)
 }
 
+func NewCodexAppServerAdapterWithHostMetadataAndOptions(
+	transport ProcessTransport,
+	host HostMetadata,
+	options CodexAppServerAdapterOptions,
+) *CodexAppServerAdapter {
+	adapter := NewCodexAppServerAdapterWithHostMetadataAndCommandResolver(transport, host, nil)
+	adapter.config.sandboxPolicy = validatedCodexAppServerSandboxPolicy(options.SandboxPolicy)
+	return adapter
+}
+
 func NewCodexAppServerAdapterWithHostMetadataAndCommandResolver(
 	transport ProcessTransport,
 	host HostMetadata,
@@ -381,6 +412,15 @@ func newAppServerAdapter(
 		sessions:          make(map[string]*codexAppServerSession),
 		lifecycleLocks:    make(map[string]*codexAppServerSessionLock),
 		cancelGraceWindow: defaultCodexAppServerCancelGraceWindow,
+	}
+}
+
+func validatedCodexAppServerSandboxPolicy(policy CodexAppServerSandboxPolicy) CodexAppServerSandboxPolicy {
+	switch policy {
+	case CodexAppServerSandboxPolicyPermissionMode, CodexAppServerSandboxPolicyDangerFullAccess:
+		return policy
+	default:
+		panic(fmt.Sprintf("unsupported Codex app-server sandbox policy %q", policy))
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -1201,6 +1201,120 @@ func TestCodexAppServerAdapterStartAppliesSettingsAndPermissionMode(t *testing.T
 	}
 }
 
+func TestCodexAppServerAdapterDangerFullAccessSandboxPreservesApplicationApprovals(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		mode              string
+		approvalPolicy    string
+		approvalsReviewer string
+	}{
+		{mode: "read-only", approvalPolicy: "on-request", approvalsReviewer: "user"},
+		{mode: "auto", approvalPolicy: "on-request", approvalsReviewer: "auto_review"},
+		{mode: "full-access", approvalPolicy: "never"},
+	}
+	for _, test := range tests {
+		t.Run(test.mode, func(t *testing.T) {
+			t.Parallel()
+
+			transport := newScriptedAppServerTransport()
+			adapter := NewCodexAppServerAdapterWithHostMetadataAndOptions(
+				transport,
+				LegacyHostMetadata(),
+				CodexAppServerAdapterOptions{
+					SandboxPolicy: CodexAppServerSandboxPolicyDangerFullAccess,
+				},
+			)
+			session := testAppServerSession()
+			session.PermissionModeID = test.mode
+			session.Settings = &SessionSettings{PermissionModeID: test.mode}
+
+			if _, err := adapter.Start(context.Background(), session); err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+			threadStart := appServerRequestParams(t, transport.conn, appServerMethodThreadStart)
+			assertCodexAppServerApprovalAndSandboxParams(
+				t,
+				"thread/start",
+				threadStart,
+				"sandbox",
+				"danger-full-access",
+				test.approvalPolicy,
+				test.approvalsReviewer,
+			)
+
+			if _, err := adapter.Exec(context.Background(), session, textPrompt("go"), "", "turn-local-1", nil, nil); err != nil {
+				t.Fatalf("Exec: %v", err)
+			}
+			turnStart := appServerRequestParams(t, transport.conn, appServerMethodTurnStart)
+			sandboxPolicy, _ := turnStart["sandboxPolicy"].(map[string]any)
+			turnStart["sandboxPolicyType"] = asString(sandboxPolicy["type"])
+			assertCodexAppServerApprovalAndSandboxParams(
+				t,
+				"turn/start",
+				turnStart,
+				"sandboxPolicyType",
+				"dangerFullAccess",
+				test.approvalPolicy,
+				test.approvalsReviewer,
+			)
+		})
+	}
+}
+
+func TestCodexAppServerAdapterDangerFullAccessSandboxAppliesOnResume(t *testing.T) {
+	t.Parallel()
+
+	transport := newScriptedAppServerTransport()
+	adapter := NewCodexAppServerAdapterWithHostMetadataAndOptions(
+		transport,
+		LegacyHostMetadata(),
+		CodexAppServerAdapterOptions{
+			SandboxPolicy: CodexAppServerSandboxPolicyDangerFullAccess,
+		},
+	)
+	session := testAppServerSession()
+	session.ProviderSessionID = "codex-thread-1"
+	session.PermissionModeID = "read-only"
+	session.Settings = &SessionSettings{PermissionModeID: "read-only"}
+
+	if err := adapter.Resume(context.Background(), session); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	threadResume := appServerRequestParams(t, transport.conn, appServerMethodThreadResume)
+	assertCodexAppServerApprovalAndSandboxParams(
+		t,
+		"thread/resume",
+		threadResume,
+		"sandbox",
+		"danger-full-access",
+		"on-request",
+		"user",
+	)
+}
+
+func assertCodexAppServerApprovalAndSandboxParams(
+	t *testing.T,
+	requestName string,
+	params map[string]any,
+	sandboxKey string,
+	expectedSandbox string,
+	expectedApprovalPolicy string,
+	expectedApprovalsReviewer string,
+) {
+	t.Helper()
+
+	if got := asString(params[sandboxKey]); got != expectedSandbox {
+		t.Fatalf("%s %s = %q, want %q", requestName, sandboxKey, got, expectedSandbox)
+	}
+	if got := asString(params["approvalPolicy"]); got != expectedApprovalPolicy {
+		t.Fatalf("%s approvalPolicy = %q, want %q", requestName, got, expectedApprovalPolicy)
+	}
+	if got := asString(params["approvalsReviewer"]); got != expectedApprovalsReviewer {
+		t.Fatalf("%s approvalsReviewer = %q, want %q", requestName, got, expectedApprovalsReviewer)
+	}
+}
+
 func TestCodexAppServerReasoningEffortValuePreservesCatalogValues(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/codex_appserver_event_params.go
+++ b/packages/agent/daemon/runtime/codex_appserver_event_params.go
@@ -16,6 +16,18 @@ func appServerThreadReasoningSummaryConfig(model string) string {
 }
 
 func appServerThreadStartParams(session Session, cwd string) map[string]any {
+	return appServerThreadStartParamsWithSandboxPolicy(
+		session,
+		cwd,
+		CodexAppServerSandboxPolicyPermissionMode,
+	)
+}
+
+func appServerThreadStartParamsWithSandboxPolicy(
+	session Session,
+	cwd string,
+	sandboxPolicy CodexAppServerSandboxPolicy,
+) map[string]any {
 	settings := session.SettingsValue()
 	params := map[string]any{
 		"cwd": firstNonEmpty(cwd, "/"),
@@ -39,7 +51,7 @@ func appServerThreadStartParams(session Session, cwd string) map[string]any {
 	if approvalPolicy := codexAppServerApprovalPolicy(session.PermissionModeID); approvalPolicy != "" {
 		params["approvalPolicy"] = approvalPolicy
 	}
-	if sandbox := codexAppServerSandboxMode(session.PermissionModeID); sandbox != "" {
+	if sandbox := codexAppServerSandboxMode(session.PermissionModeID, sandboxPolicy); sandbox != "" {
 		params["sandbox"] = sandbox
 	}
 	if approvalsReviewer := codexAppServerApprovalsReviewer(session.PermissionModeID); approvalsReviewer != "" {
@@ -55,6 +67,26 @@ func appServerTurnStartParams(
 	planModeMask map[string]any,
 	defaultModeMask map[string]any,
 	defaultModel string,
+) map[string]any {
+	return appServerTurnStartParamsWithSandboxPolicy(
+		session,
+		threadID,
+		content,
+		planModeMask,
+		defaultModeMask,
+		defaultModel,
+		CodexAppServerSandboxPolicyPermissionMode,
+	)
+}
+
+func appServerTurnStartParamsWithSandboxPolicy(
+	session Session,
+	threadID string,
+	content []PromptContentBlock,
+	planModeMask map[string]any,
+	defaultModeMask map[string]any,
+	defaultModel string,
+	sandboxPolicy CodexAppServerSandboxPolicy,
 ) map[string]any {
 	settings := session.SettingsValue()
 	params := map[string]any{
@@ -76,8 +108,8 @@ func appServerTurnStartParams(
 	if approvalPolicy := codexAppServerApprovalPolicy(session.PermissionModeID); approvalPolicy != "" {
 		params["approvalPolicy"] = approvalPolicy
 	}
-	if sandboxPolicy := codexAppServerSandboxPolicy(session.PermissionModeID); sandboxPolicy != nil {
-		params["sandboxPolicy"] = sandboxPolicy
+	if policy := codexAppServerTurnSandboxPolicy(session.PermissionModeID, sandboxPolicy); policy != nil {
+		params["sandboxPolicy"] = policy
 	}
 	if approvalsReviewer := codexAppServerApprovalsReviewer(session.PermissionModeID); approvalsReviewer != "" {
 		params["approvalsReviewer"] = approvalsReviewer
@@ -307,8 +339,15 @@ func codexAppServerApprovalPolicy(modeID string) string {
 	}
 }
 
-func codexAppServerSandboxMode(modeID string) string {
-	switch codexACPModeID(modeID) {
+func codexAppServerSandboxMode(modeID string, policy CodexAppServerSandboxPolicy) string {
+	modeID = codexACPModeID(modeID)
+	if modeID == "" {
+		return ""
+	}
+	if policy == CodexAppServerSandboxPolicyDangerFullAccess {
+		return "danger-full-access"
+	}
+	switch modeID {
 	case "read-only":
 		return "read-only"
 	case "auto":
@@ -320,8 +359,15 @@ func codexAppServerSandboxMode(modeID string) string {
 	}
 }
 
-func codexAppServerSandboxPolicy(modeID string) map[string]any {
-	switch codexACPModeID(modeID) {
+func codexAppServerTurnSandboxPolicy(modeID string, policy CodexAppServerSandboxPolicy) map[string]any {
+	modeID = codexACPModeID(modeID)
+	if modeID == "" {
+		return nil
+	}
+	if policy == CodexAppServerSandboxPolicyDangerFullAccess {
+		return map[string]any{"type": "dangerFullAccess"}
+	}
+	switch modeID {
 	case "read-only":
 		return map[string]any{"type": "readOnly"}
 	case "auto":

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -77,7 +77,7 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 	}
 	planModeMask, defaultModeMask := a.fetchCollaborationModeMasks(ctx, client, session, trace)
 
-	threadParams := appServerThreadStartParams(session, a.sessionCWD(session))
+	threadParams := appServerThreadStartParamsWithSandboxPolicy(session, a.sessionCWD(session), a.config.sandboxPolicy)
 	trace.Log("thread.start.params", codexAppServerTraceThreadStartParams(session, threadParams, false))
 	threadResult, err := trace.TypedCall(acpStartCallTimeout, appServerMethodThreadStart, func() (json.RawMessage, error) {
 		return client.ThreadStart(ctx, acpStartCallTimeout, threadParams,
@@ -232,7 +232,7 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) (er
 	}
 	planModeMask, defaultModeMask := a.fetchCollaborationModeMasks(ctx, client, session, trace)
 
-	params := appServerThreadStartParams(session, a.sessionCWD(session))
+	params := appServerThreadStartParamsWithSandboxPolicy(session, a.sessionCWD(session), a.config.sandboxPolicy)
 	params["threadId"] = strings.TrimSpace(session.ProviderSessionID)
 	trace.Log("thread.start.params", codexAppServerTraceThreadStartParams(session, params, true))
 	// codex replays thread/tokenUsage/updated during thread/resume so the GUI

--- a/packages/agent/daemon/runtime/codex_appserver_turn.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn.go
@@ -356,7 +356,7 @@ func (a *CodexAppServerAdapter) execBlocking(
 	a.markTurnSettleEmits(appTurn)
 
 	trace := newCodexAppServerTurnTrace(session, turnID, execMetadataFromContext(ctx))
-	turnParams := appServerTurnStartParams(session, appSession.threadID, providerContent, appSession.planModeMask, appSession.defaultModeMask, execState.defaultModel)
+	turnParams := appServerTurnStartParamsWithSandboxPolicy(session, appSession.threadID, providerContent, appSession.planModeMask, appSession.defaultModeMask, execState.defaultModel, a.config.sandboxPolicy)
 	trace.Log("turn.start.params", codexAppServerTraceTurnStartParams(session, turnParams, providerContent))
 	turnStartedAt := time.Now()
 	result, err := appSession.client.TurnStart(ctx, turnParams,


### PR DESCRIPTION
## Summary

- add an immutable Codex app-server adapter option for hosts whose outer execution sandbox is authoritative
- keep the default Codex sandbox mapping unchanged for existing Tutti consumers
- let opted-in hosts send `danger-full-access` / `dangerFullAccess` while permission modes continue to own `approvalPolicy` and `approvalsReviewer`
- cover `thread/start`, `thread/resume`, and `turn/start` request shapes across all Codex permission modes

This separates process isolation from application approval routing. TSH can disable Codex's redundant inner sandbox without losing AgentGUI approval requests or permission-mode behavior.

## Verification

- `go test ./runtime -run 'TestCodexAppServerAdapter(DangerFullAccessSandbox|StartAppliesSettingsAndPermissionMode|Exec(ReadOnlyPermissionUsesUserReviewer|AutoPermissionUsesAutoReviewer|SendsTurnOverrides))'`
- `pnpm check:changed` (4/5 lanes passed; the Electron boundary lane could not find TypeScript in the temporary worktree)
- `pnpm check:changed -- --failed-only` after linking the existing workspace dependencies (passed)

## Checklist

- [x] This does not change Agent Host lifecycle semantics; it changes provider request policy at the Codex adapter boundary.
- [x] I kept the change focused on one concern.
- [x] I updated package documentation for the new host integration option.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->