### PR TITLE
fix(agent): propagate root turn settlement failure detail to live events

### DIFF
--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -41,6 +41,38 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [workspaceAgentTimelineCanonical.ts](../../../packages/agent/gui/shared/workspaceAgentTimelineCanonical.ts)
   [agent-gui-node.md](../../architecture/agent-gui-node.md)
 
+### Mid-turn provider failure renders a generic "request failed" card
+
+- Symptom:
+  A root-provider-lifecycle turn (Codex, Cursor, OpenCode) fails mid-turn —
+  for example quota exhaustion — but the conversation shows only a generic
+  "request failed" card with no detail and no classification code. The real
+  reason appears only in the durable Turn record and daemon logs.
+- Quick checks:
+  Confirm the canonical Turn settled with a non-empty `error.message`. If the
+  durable Turn carries the reason but the live card does not, inspect the
+  synthesized `daemonRootTurnSettlement` event metadata, not the provider
+  adapter — the adapter already reported the failure correctly.
+- Root cause:
+  Root-provider adapters do not emit `EventTurnFailed`; the daemon synthesizes
+  it in `ReconcileRootTurnSettlement` after the durable settle commits. The
+  settlement previously forwarded only `turnId` and `outcome`, so the
+  synthesized event had an empty detail and the visible-error projection
+  classified it as `unknown` instead of (for example) `quota_or_rate_limit`.
+- Fix:
+  Forward `Turn.ErrorMessage` through `RootTurnSettlement` and stamp it on the
+  synthesized event metadata under the `error` / `errorMessage` keys read by
+  `BestEffortErrorMessage`. Keep classification text-based in
+  `visibleFailureCode`; do not special-case providers at this layer.
+- Validation:
+  `TestReconcileRootTurnSettlementPublishesFailureDetail` settles a failed
+  root turn with a quota message and asserts the live stream emits a
+  `quota_or_rate_limit` visible error carrying the original detail.
+- References:
+  [controller_root_turn.go](../../../packages/agent/daemon/runtime/controller_root_turn.go)
+  [visible_error.go](../../../packages/agent/daemon/runtime/visible_error.go)
+  [agent_runtime_adapter.go](../../../services/tuttid/agent_runtime_adapter.go)
+
 ### Codex WebSocket reconnect rejects a long prompt metadata header
 
 - Symptom:

--- a/packages/agent/daemon/runtime/controller_root_turn.go
+++ b/packages/agent/daemon/runtime/controller_root_turn.go
@@ -11,6 +11,7 @@ type RootTurnSettlement struct {
 	AgentSessionID string
 	TurnID         string
 	Outcome        string
+	ErrorMessage   string
 }
 
 // ReconcileRootTurnSettlement applies daemon-owned durable root completion to
@@ -58,9 +59,19 @@ func (c *Controller) ReconcileRootTurnSettlement(settlement RootTurnSettlement) 
 	case "canceled", "interrupted":
 		eventType = EventTurnCanceled
 	}
-	event := newTurnActivityEvent(session, eventType, turnID, session.Status, "", "", map[string]any{
+	metadata := map[string]any{
 		"daemonRootTurnSettlement": true,
-	})
+	}
+	if eventType == EventTurnFailed {
+		// Carry the durable failure reason on the live event so the
+		// visible-error projection can classify and render it; an empty
+		// detail degrades to a generic card with no recoverable signal.
+		if message := strings.TrimSpace(settlement.ErrorMessage); message != "" {
+			metadata["error"] = message
+			metadata["errorMessage"] = message
+		}
+	}
+	event := newTurnActivityEvent(session, eventType, turnID, session.Status, "", "", metadata)
 	if event.Type != "" {
 		if event.Payload.TurnOutcome == "" {
 			event.Payload.TurnOutcome = outcome

--- a/packages/agent/daemon/runtime/controller_root_turn_test.go
+++ b/packages/agent/daemon/runtime/controller_root_turn_test.go
@@ -1,0 +1,82 @@
+package agentruntime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+)
+
+// A failed daemon root settlement must carry the durable failure reason into
+// the live event stream: mid-turn provider failures (for example Codex quota
+// exhaustion) settle through this path, and without the detail the
+// visible-error projection can only render a generic card.
+func TestReconcileRootTurnSettlementPublishesFailureDetail(t *testing.T) {
+	t.Parallel()
+
+	reporter := &recordingReporter{}
+	controller := NewDefaultControllerWithProcessTransport(reporter, newScriptedACPTransport())
+	ctx := context.Background()
+
+	started, err := controller.Start(ctx, StartInput{
+		RoomID:   "room-1",
+		Provider: ProviderCodex,
+		CWD:      "/workspace",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	events, unsubscribe, ok := controller.Subscribe("room-1", started.Session.AgentSessionID)
+	if !ok {
+		t.Fatal("Subscribe returned ok=false")
+	}
+	defer unsubscribe()
+
+	execResult, err := controller.Exec(ctx, ExecInput{
+		RoomID:         "room-1",
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("hello"),
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if !execResult.Accepted || execResult.TurnID == "" {
+		t.Fatalf("Exec result = %#v, want accepted result with turn id", execResult)
+	}
+
+	const failureDetail = "You've hit your usage limit. Upgrade to Pro or try again later."
+	controller.ReconcileRootTurnSettlement(RootTurnSettlement{
+		RoomID:         "room-1",
+		AgentSessionID: started.Session.AgentSessionID,
+		TurnID:         execResult.TurnID,
+		Outcome:        "failed",
+		ErrorMessage:   failureDetail,
+	})
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case event := <-events:
+			if event.EventType != StreamEventMessageUpdate {
+				continue
+			}
+			update, ok := event.Data.(agentsessionstore.WorkspaceAgentMessageUpdate)
+			if !ok || update.Payload["kind"] != visibleErrorKind {
+				continue
+			}
+			if update.Payload["phase"] != "turn" {
+				t.Fatalf("visible failure phase = %#v, want turn", update.Payload["phase"])
+			}
+			if update.Payload["code"] != "quota_or_rate_limit" {
+				t.Fatalf("visible failure code = %#v, want quota_or_rate_limit", update.Payload["code"])
+			}
+			if update.Payload["detail"] != failureDetail {
+				t.Fatalf("visible failure detail = %#v, want %q", update.Payload["detail"], failureDetail)
+			}
+			return
+		case <-deadline:
+			t.Fatal("expected visible failure message for failed root turn settlement")
+		}
+	}
+}

--- a/services/tuttid/agent_runtime_adapter.go
+++ b/services/tuttid/agent_runtime_adapter.go
@@ -20,6 +20,7 @@ func (a agentRuntimeAdapter) ObserveRootTurnSettled(_ context.Context, workspace
 		AgentSessionID: agentSessionID,
 		TurnID:         turn.TurnID,
 		Outcome:        turn.Outcome,
+		ErrorMessage:   turn.ErrorMessage,
 	})
 }
 


### PR DESCRIPTION
## Problem

Users with an exhausted Codex quota saw nothing actionable: a mid-turn failure ended in a generic "Codex request failed." card (or the turn looked stuck), with the real reason only in the durable Turn record and daemon logs.

Root cause: root-provider-lifecycle adapters (Codex, Cursor, OpenCode) do not emit `EventTurnFailed` from the adapter. After the durable settle commits, the daemon synthesizes `turn.failed` in `ReconcileRootTurnSettlement` — but the settlement forwarded only `turnId`/`outcome`, dropping `Turn.ErrorMessage` at the adapter boundary. The synthesized event had an empty detail, so the visible-error projection classified it `unknown` and rendered a generic card with no guidance.

## Change

- `packages/agent/daemon/runtime/controller_root_turn.go`: `RootTurnSettlement` gains `ErrorMessage`; a failed settlement stamps it on the synthesized event metadata under the `error`/`errorMessage` keys read by `BestEffortErrorMessage`.
- `services/tuttid/agent_runtime_adapter.go`: forward `Turn.ErrorMessage` into the settlement.
- `docs/conventions/troubleshooting/agent-session-lifecycle.md`: durable note for the trap.

Classification stays text-based in `visibleFailureCode`; no provider special-casing at this layer.

## Validation

- New `TestReconcileRootTurnSettlementPublishesFailureDetail`: a failed settlement with a quota message makes the live stream emit a `quota_or_rate_limit` visible error carrying the original detail.
- `go test ./...` in `packages/agent/daemon`: all pass.
- `go test . ./service/agent/` in `services/tuttid`: pass. Full-module run shows only the pre-existing `service/workspace` App Center failures (missing generated `tutti-onboarding` artifact in a fresh worktree; fails identically on `origin/main`).
- `gofmt`, `go vet`, `golangci-lint run`: clean on the changed packages.

## Out of scope (follow-ups)

- Map the structured `codexErrorInfo: usageLimitExceeded` marker to `quota_or_rate_limit` instead of relying on text alone.
- Escalate long `willRetry` retry loops to a visible warning; make the passive usage probe notify proactively on exhaustion.
- Renderer: widen recoverable-quota text markers and surface reconcile-delivered failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow daemon bridge change on an existing settlement path; failure metadata is additive and covered by a new integration test.
> 
> **Overview**
> Fixes **mid-turn root-provider failures** (Codex/Cursor/OpenCode) that settled durably with a real `error.message` but showed only a generic “request failed” card in AgentGUI.
> 
> **`RootTurnSettlement`** now carries **`ErrorMessage`**. When `ReconcileRootTurnSettlement` synthesizes `turn.failed` after durable settle, it stamps that text on event metadata as **`error`** / **`errorMessage`** (what **`BestEffortErrorMessage`** and visible-error projection already read), so text-based codes like **`quota_or_rate_limit`** can render with the original detail.
> 
> **`agent_runtime_adapter.ObserveRootTurnSettled`** forwards **`turn.ErrorMessage`** into the settlement. New **`TestReconcileRootTurnSettlementPublishesFailureDetail`** locks the live-stream behavior; troubleshooting docs document the trap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc7167eef534200eae86b0d9b7182c5ffde6016d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->