### PR TITLE
feat(agent-gui): project room attention targets

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -196,6 +196,21 @@ It owns:
 - Message Center snapshot model and UI while it shares AgentGUI activity and
   interaction ownership
 
+Room-scoped attention consumers that need every actionable target use the
+Agent GUI package's `selectWorkspaceAgentAttentionItems` projection. Unlike the
+conversation-shaped Message Center model, this projection returns one entry per
+canonical `(workspaceId, agentSessionId, turnId, requestId)` target, including
+multiple pending interactions in one root conversation. The display item keeps
+the root conversation identity for navigation, while the target keeps the exact
+child interaction identity for commands. Hosts may enrich or filter these
+entries for local owner/device authority, but must not rebuild prompts from
+transcript rows or collapse them by root session id.
+
+`WorkspaceAgentMessageCenterCard` keeps compact prompts and digest summaries by
+default. Dense room boards may opt into its full prompt variant and suppress the
+redundant digest only while a canonical prompt is present; both variants submit
+through the same exact target and shared prompt surface.
+
 It may depend on `@tutti-os/agent-activity-core`.
 
 Agent GUI must read and write agent session/activity data through

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.spec.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.spec.tsx
@@ -1,8 +1,9 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import {
   messageCenterStackPreviewNodes,
-  messageCenterStackPreviewText
+  messageCenterStackPreviewText,
+  WorkspaceAgentMessageCenterCard
 } from "./WorkspaceAgentMessageCenterCard";
 import type { WorkspaceAgentMessageCenterItem } from "./workspaceAgentMessageCenterModel";
 
@@ -62,6 +63,82 @@ describe("messageCenterStackPreviewNodes", () => {
       container.querySelector('[data-agent-mention-kind="workspace-app"]')
         ?.textContent
     ).toContain("AI 文档");
+  });
+});
+
+describe("WorkspaceAgentMessageCenterCard prompt presentation", () => {
+  it("supports a full prompt without repeating the digest summary", () => {
+    const pendingItem = item({ summary: "Allow the complete command?" });
+    pendingItem.status = "waiting";
+    pendingItem.pendingInteractionTarget = {
+      agentSessionId: "codex-1",
+      turnId: "turn-1",
+      requestId: "request-1"
+    };
+    pendingItem.pendingPrompt = {
+      kind: "approval",
+      id: "approval:request-1",
+      turnId: "turn-1",
+      requestId: "request-1",
+      callId: "call-1",
+      title: "Run command",
+      toolName: "Bash",
+      status: "pending",
+      input: { command: "printf a && printf b" },
+      options: [{ id: "allow", label: "Allow", kind: "allow" }],
+      output: null,
+      occurredAtUnixMs: 1
+    };
+
+    const { container } = render(
+      <WorkspaceAgentMessageCenterCard
+        item={pendingItem}
+        isSubmitting={false}
+        promptVariant="full"
+        showSummaryWithPrompt={false}
+        onOpenChat={() => undefined}
+        onSubmitPrompt={() => undefined}
+      />
+    );
+
+    expect(screen.getByText("printf a && printf b")).toBeTruthy();
+    expect(screen.queryByText("Allow the complete command?")).toBeNull();
+    expect(screen.getByRole("button", { name: "Allow" })).toBeTruthy();
+    expect(container.textContent).not.toContain("Allow the complete command?");
+  });
+
+  it("keeps the summary when a leaving or read-only card cannot render its prompt", () => {
+    const pendingItem = item({ summary: "Allow the complete command?" });
+    pendingItem.status = "waiting";
+    pendingItem.pendingPrompt = {
+      kind: "approval",
+      id: "approval:request-1",
+      turnId: "turn-1",
+      requestId: "request-1",
+      callId: "call-1",
+      title: "Run command",
+      toolName: "Bash",
+      status: "pending",
+      input: { command: "printf a && printf b" },
+      options: [{ id: "allow", label: "Allow", kind: "allow" }],
+      output: null,
+      occurredAtUnixMs: 1
+    };
+
+    render(
+      <WorkspaceAgentMessageCenterCard
+        interactive={false}
+        item={pendingItem}
+        isSubmitting={false}
+        promptVariant="full"
+        showSummaryWithPrompt={false}
+        onOpenChat={() => undefined}
+        onSubmitPrompt={() => undefined}
+      />
+    );
+
+    expect(screen.getByText("Allow the complete command?")).toBeTruthy();
+    expect(screen.queryByText("printf a && printf b")).toBeNull();
   });
 });
 

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -50,6 +50,8 @@ export interface WorkspaceAgentMessageCenterCardProps {
   interactive?: boolean;
   isSubmitting: boolean;
   lazySummary?: boolean;
+  promptVariant?: "compact" | "full";
+  showSummaryWithPrompt?: boolean;
   summaryAccessory?: ReactNode;
   onLinkAction?: (action: WorkspaceLinkAction) => void;
   onOpenChat: (input: { agentSessionId: string; provider: string }) => void;
@@ -92,6 +94,8 @@ export const WorkspaceAgentMessageCenterCard = memo(
     item,
     isSubmitting,
     lazySummary = false,
+    promptVariant = "compact",
+    showSummaryWithPrompt = true,
     summaryAccessory,
     onLinkAction,
     onOpenChat,
@@ -162,7 +166,7 @@ export const WorkspaceAgentMessageCenterCard = memo(
           </span>
         </div>
 
-        {summary ? (
+        {summary && (showSummaryWithPrompt || !prompt || !interactive) ? (
           <MessageCenterSummary
             item={item}
             lazy={lazySummary}
@@ -178,7 +182,7 @@ export const WorkspaceAgentMessageCenterCard = memo(
           <div className="min-w-0">
             <AgentInteractivePromptSurface
               embedded
-              variant="compact"
+              variant={promptVariant}
               keyboardShortcuts={false}
               prompt={prompt}
               isSubmitting={isSubmitting}

--- a/packages/agent/gui/agent-message-center/index.ts
+++ b/packages/agent/gui/agent-message-center/index.ts
@@ -53,15 +53,20 @@ export {
 } from "./workspaceAgentMessageCenterModel";
 export {
   buildWorkspaceAgentMessageCenterModelFromEngine,
+  selectWorkspaceAgentAttentionItems,
   selectWorkspaceAgentMessageCenterPresentation,
+  workspaceAgentAttentionItemsEqual,
   workspaceAgentMessageCenterPromptStatus,
   workspaceAgentMessageCenterPresentationEqual
 } from "./workspaceAgentMessageCenterEngineModel";
 export type {
+  WorkspaceAgentAttentionItem,
+  WorkspaceAgentAttentionTarget,
   WorkspaceAgentMessageCenterPresentation,
   WorkspaceAgentMessageCenterPromptStatus
 } from "./workspaceAgentMessageCenterEngineModel";
 export { stabilizeWorkspaceAgentMessageCenterModel } from "./workspaceAgentMessageCenterModelStability";
+export { workspaceAgentMessageCenterItemEqual } from "./workspaceAgentMessageCenterModelStability";
 export {
   selectWorkspaceAgentConsumerCounts,
   selectWorkspaceAgentConsumerSession,

--- a/packages/agent/gui/agent-message-center/workspaceAgentConsumerSelectors.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentConsumerSelectors.spec.ts
@@ -6,7 +6,9 @@ import {
 } from "@tutti-os/agent-activity-core";
 import {
   buildWorkspaceAgentMessageCenterModelFromEngine,
+  selectWorkspaceAgentAttentionItems,
   selectWorkspaceAgentMessageCenterPresentation,
+  workspaceAgentAttentionItemsEqual,
   workspaceAgentMessageCenterPromptStatus,
   workspaceAgentMessageCenterPresentationEqual
 } from "./workspaceAgentMessageCenterEngineModel";
@@ -17,6 +19,225 @@ import {
 } from "./workspaceAgentConsumerSelectors";
 
 describe("workspaceAgentConsumerSelectors", () => {
+  it("projects every pending target with exact target-level identity", () => {
+    const engine = createEngine();
+    engine.dispatch({
+      type: "session/snapshotReceived",
+      sessions: [
+        session({
+          activeTurnId: "turn-1",
+          activeTurn: {
+            turnId: "turn-1",
+            agentSessionId: "session-1",
+            origin: "user_prompt",
+            phase: "waiting",
+            startedAtUnixMs: 10,
+            updatedAtUnixMs: 22
+          },
+          pendingInteractions: [
+            {
+              requestId: "request-approval",
+              agentSessionId: "session-1",
+              turnId: "turn-1",
+              kind: "approval",
+              status: "pending",
+              toolName: "Bash",
+              input: {
+                command: "pnpm test",
+                options: [{ optionId: "allow", label: "Allow" }]
+              },
+              createdAtUnixMs: 21,
+              updatedAtUnixMs: 21
+            },
+            {
+              requestId: "request-question",
+              agentSessionId: "session-1",
+              turnId: "turn-1",
+              kind: "question",
+              status: "pending",
+              toolName: "AskUserQuestion",
+              input: {
+                questions: [
+                  {
+                    question: "Which option?",
+                    options: [{ label: "First" }]
+                  }
+                ]
+              },
+              createdAtUnixMs: 22,
+              updatedAtUnixMs: 22
+            }
+          ]
+        })
+      ]
+    });
+
+    const first = selectWorkspaceAgentAttentionItems(
+      selectWorkspaceAgentMessageCenterPresentation(engine.getSnapshot()),
+      { workspaceId: "workspace-1", sessionMessagesById: {} }
+    );
+    const second = selectWorkspaceAgentAttentionItems(
+      selectWorkspaceAgentMessageCenterPresentation(engine.getSnapshot()),
+      { workspaceId: "workspace-1", sessionMessagesById: {} }
+    );
+
+    expect(first).toHaveLength(2);
+    expect(first.map((entry) => entry.item.id)).toEqual([
+      "workspace-1\nsession-1\nturn-1\nrequest-approval",
+      "workspace-1\nsession-1\nturn-1\nrequest-question"
+    ]);
+    expect(first.map((entry) => entry.target)).toEqual([
+      {
+        kind: "interaction",
+        workspaceId: "workspace-1",
+        agentSessionId: "session-1",
+        turnId: "turn-1",
+        requestId: "request-approval"
+      },
+      {
+        kind: "interaction",
+        workspaceId: "workspace-1",
+        agentSessionId: "session-1",
+        turnId: "turn-1",
+        requestId: "request-question"
+      }
+    ]);
+    expect(workspaceAgentAttentionItemsEqual(first, second)).toBe(true);
+  });
+
+  it("normalizes canonical exit-plan interactions for the shared prompt surface", () => {
+    const engine = createEngine();
+    engine.dispatch({
+      type: "session/snapshotReceived",
+      sessions: [
+        session({
+          activeTurnId: "turn-1",
+          activeTurn: {
+            turnId: "turn-1",
+            agentSessionId: "session-1",
+            origin: "user_prompt",
+            phase: "waiting",
+            startedAtUnixMs: 10,
+            updatedAtUnixMs: 21
+          },
+          pendingInteractions: [
+            {
+              requestId: "request-exit-plan",
+              agentSessionId: "session-1",
+              turnId: "turn-1",
+              kind: "approval",
+              status: "pending",
+              toolName: "ExitPlanMode",
+              input: {
+                toolCall: { kind: "switch_mode" },
+                options: [
+                  { optionId: "acceptEdits", label: "Accept edits" },
+                  { optionId: "plan", label: "Keep planning" }
+                ]
+              },
+              createdAtUnixMs: 21,
+              updatedAtUnixMs: 21
+            }
+          ]
+        })
+      ]
+    });
+
+    const [entry] = selectWorkspaceAgentAttentionItems(
+      selectWorkspaceAgentMessageCenterPresentation(engine.getSnapshot()),
+      { workspaceId: "workspace-1", sessionMessagesById: {} }
+    );
+
+    expect(entry?.item.pendingPrompt).toEqual(
+      expect.objectContaining({
+        kind: "exit-plan",
+        requestId: "request-exit-plan",
+        keepPlanningOptionId: "plan",
+        options: [expect.objectContaining({ id: "acceptEdits" })]
+      })
+    );
+  });
+
+  it("projects an eligible completed plan turn as a canonical plan target", () => {
+    const engine = createEngine();
+    engine.dispatch({
+      type: "session/snapshotReceived",
+      sessions: [
+        session({
+          latestTurn: {
+            turnId: "turn-plan",
+            agentSessionId: "session-1",
+            origin: "user_prompt",
+            phase: "settled",
+            outcome: "completed",
+            startedAtUnixMs: 10,
+            settledAtUnixMs: 20,
+            updatedAtUnixMs: 20
+          },
+          capabilities: {
+            imageInput: false,
+            modelImageInputRequired: false,
+            skills: false,
+            compact: false,
+            tokenUsage: false,
+            rateLimits: false,
+            planMode: true,
+            interrupt: false,
+            activeTurnGuidance: false,
+            browserUse: false,
+            computerUse: false,
+            goalPause: false,
+            planImplementation: true,
+            permissionModeChangeDuringTurn: false,
+            permissionModeChangeDeferred: false,
+            review: false,
+            resumeRunningTurn: false
+          }
+        })
+      ]
+    });
+
+    const [entry] = selectWorkspaceAgentAttentionItems(
+      selectWorkspaceAgentMessageCenterPresentation(engine.getSnapshot()),
+      {
+        workspaceId: "workspace-1",
+        sessionMessagesById: {
+          "session-1": [
+            {
+              workspaceId: "workspace-1",
+              agentSessionId: "session-1",
+              messageId: "plan-message",
+              version: 1,
+              turnId: "turn-plan",
+              role: "agent",
+              kind: "message",
+              payload: { messageKind: "plan" },
+              occurredAtUnixMs: 19
+            }
+          ]
+        }
+      }
+    );
+
+    expect(entry).toMatchObject({
+      status: "idle",
+      target: {
+        kind: "plan-implementation",
+        workspaceId: "workspace-1",
+        agentSessionId: "session-1",
+        turnId: "turn-plan",
+        requestId: "turn-plan"
+      },
+      item: {
+        id: "workspace-1\nsession-1\nturn-plan\nturn-plan",
+        pendingPrompt: {
+          kind: "plan-implementation",
+          requestId: "turn-plan"
+        }
+      }
+    });
+  });
+
   it("keeps message-center presentation equal across unrelated engine changes", () => {
     const engine = createEngine();
     engine.dispatch({

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterEngineModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterEngineModel.ts
@@ -11,10 +11,20 @@ import {
   selectEngineInteractionResponse,
   selectPendingSubmitsForSession,
   selectPlanDecisionForTurn,
+  selectPlanTurnDismissed,
   selectWorkspaceAgentRootConversationSessions
 } from "@tutti-os/agent-activity-core";
 import type { AgentConversationPromptVM } from "../shared/agentConversation/contracts/agentConversationVM";
 import { normalizeAskUserQuestions } from "../shared/agentConversation/askUserQuestions";
+import {
+  extractExitPlanKeepPlanningOptionId,
+  extractExitPlanModeOptions,
+  isExitPlanSwitchModeInput
+} from "../shared/agentConversation/exitPlanOptions";
+import {
+  latestPlanTurnId,
+  planImplementationPromptFromPlanTurn
+} from "../shared/agentConversation/planImplementationPresentation";
 import {
   buildWorkspaceAgentMessageCenterItem,
   buildWorkspaceAgentMessageCenterModelFromItems,
@@ -22,6 +32,7 @@ import {
   type WorkspaceAgentMessageCenterModel,
   type WorkspaceAgentMessageCenterTurnOutcome
 } from "./workspaceAgentMessageCenterModel";
+import { workspaceAgentMessageCenterItemEqual } from "./workspaceAgentMessageCenterModelStability";
 
 /**
  * Canonical Message Center entrypoint. Session/turn/interaction truth comes
@@ -63,6 +74,7 @@ export function buildWorkspaceAgentMessageCenterModelFromEngine(
 
 export interface WorkspaceAgentMessageCenterPresentation {
   consumers: readonly WorkspaceAgentConsumerSession[];
+  dismissedPlanTurnKeys: Readonly<Record<string, true>>;
   promptStatusByKey: Readonly<
     Record<string, WorkspaceAgentMessageCenterPromptStatus>
   >;
@@ -76,6 +88,7 @@ export function selectWorkspaceAgentMessageCenterPresentation(
     string,
     WorkspaceAgentMessageCenterPromptStatus
   > = {};
+  const dismissedPlanTurnKeys: Record<string, true> = {};
   for (const consumer of consumers) {
     const sessionId = consumer.session.agentSessionId;
     for (const interaction of consumer.pendingInteractions) {
@@ -97,6 +110,9 @@ export function selectWorkspaceAgentMessageCenterPresentation(
     }
     const turnId = consumer.latestTurn?.turnId ?? "";
     if (!turnId) continue;
+    if (selectPlanTurnDismissed(state, sessionId, turnId)) {
+      dismissedPlanTurnKeys[promptStatusKey(sessionId, turnId, turnId)] = true;
+    }
     const decision = selectPlanDecisionForTurn(state, sessionId, turnId);
     if (decision) {
       promptStatusByKey[promptStatusKey(sessionId, turnId, turnId)] =
@@ -124,6 +140,7 @@ export function selectWorkspaceAgentMessageCenterPresentation(
   }
   return {
     consumers,
+    dismissedPlanTurnKeys,
     promptStatusByKey
   };
 }
@@ -133,6 +150,7 @@ export function workspaceAgentMessageCenterPresentationEqual(
   right: WorkspaceAgentMessageCenterPresentation
 ): boolean {
   return (
+    booleanMapsEqual(left.dismissedPlanTurnKeys, right.dismissedPlanTurnKeys) &&
     promptStatusMapsEqual(left.promptStatusByKey, right.promptStatusByKey) &&
     left.consumers.length === right.consumers.length &&
     left.consumers.every((item, index) => {
@@ -151,6 +169,185 @@ export function workspaceAgentMessageCenterPresentationEqual(
         )
       );
     })
+  );
+}
+
+export type WorkspaceAgentAttentionTarget =
+  | {
+      kind: "interaction";
+      workspaceId: string;
+      agentSessionId: string;
+      turnId: string;
+      requestId: string;
+    }
+  | {
+      kind: "plan-implementation";
+      workspaceId: string;
+      agentSessionId: string;
+      turnId: string;
+      requestId: string;
+    };
+
+export interface WorkspaceAgentAttentionItem {
+  item: import("./workspaceAgentMessageCenterModel").WorkspaceAgentMessageCenterItem;
+  status: WorkspaceAgentMessageCenterPromptStatus;
+  target: WorkspaceAgentAttentionTarget;
+}
+
+/**
+ * Projects every canonical actionable target instead of collapsing a root
+ * conversation to its latest interaction. The display item keeps the root
+ * conversation identity for navigation while target keeps the exact child
+ * session/turn/request identity used by the command.
+ */
+export function selectWorkspaceAgentAttentionItems(
+  presentation: WorkspaceAgentMessageCenterPresentation,
+  snapshot: Pick<AgentActivitySnapshot, "sessionMessagesById" | "workspaceId">,
+  options: BuildWorkspaceAgentMessageCenterOptions = {}
+): WorkspaceAgentAttentionItem[] {
+  const result: WorkspaceAgentAttentionItem[] = [];
+  for (const consumer of presentation.consumers) {
+    if (
+      consumer.session.visible === false ||
+      consumer.session.workspaceId !== snapshot.workspaceId
+    ) {
+      continue;
+    }
+    const messages = sessionMessages(snapshot.sessionMessagesById, consumer);
+    for (const interaction of consumer.pendingInteractions) {
+      const prompt = promptFromInteraction(interaction);
+      if (!prompt) continue;
+      const target: WorkspaceAgentAttentionTarget = {
+        kind: "interaction",
+        workspaceId: consumer.session.workspaceId,
+        agentSessionId: interaction.agentSessionId,
+        turnId: interaction.turnId,
+        requestId: interaction.requestId
+      };
+      const item = buildWorkspaceAgentMessageCenterItem({
+        session: consumer.session,
+        latestTurn: consumer.latestTurn,
+        messages,
+        status: "waiting",
+        needsAttention: needsAttentionFromInteraction(consumer, interaction),
+        pendingInteractionTarget: interactionTarget(interaction),
+        pendingPrompt: prompt,
+        latestTurnOutcome: null,
+        options
+      });
+      item.id = workspaceAgentAttentionKey(target);
+      item.sortTimeUnixMs = interaction.createdAtUnixMs;
+      result.push({
+        item,
+        status:
+          presentation.promptStatusByKey[
+            promptStatusKey(
+              interaction.agentSessionId,
+              interaction.turnId,
+              interaction.requestId
+            )
+          ] ?? "idle",
+        target
+      });
+    }
+
+    const latestTurn = consumer.latestTurn;
+    if (
+      latestTurn?.phase !== "settled" ||
+      latestTurn.outcome !== "completed" ||
+      consumer.session.capabilities?.planImplementation !== true ||
+      consumer.session.capabilities.planMode !== true ||
+      latestPlanTurnId(messages) !== latestTurn.turnId
+    ) {
+      continue;
+    }
+    const target: WorkspaceAgentAttentionTarget = {
+      kind: "plan-implementation",
+      workspaceId: consumer.session.workspaceId,
+      agentSessionId: consumer.session.agentSessionId,
+      turnId: latestTurn.turnId,
+      requestId: latestTurn.turnId
+    };
+    const statusKey = promptStatusKey(
+      target.agentSessionId,
+      target.turnId,
+      target.requestId
+    );
+    if (presentation.dismissedPlanTurnKeys[statusKey]) continue;
+    const prompt = planImplementationPromptFromPlanTurn(
+      latestTurn.turnId,
+      consumer.session.title
+    );
+    const needsAttention: AgentActivityNeedsAttentionItem = {
+      id: `plan-implementation:${latestTurn.turnId}`,
+      workspaceId: consumer.session.workspaceId,
+      agentSessionId: consumer.session.agentSessionId,
+      provider: consumer.session.provider,
+      title: prompt.title,
+      cwd: consumer.session.cwd,
+      kind: "constraint",
+      summary: prompt.title,
+      occurredAtUnixMs: latestTurn.settledAtUnixMs ?? latestTurn.updatedAtUnixMs
+    };
+    const item = buildWorkspaceAgentMessageCenterItem({
+      session: consumer.session,
+      latestTurn,
+      messages,
+      status: "waiting",
+      needsAttention,
+      pendingInteractionTarget: null,
+      pendingPrompt: prompt,
+      latestTurnOutcome: null,
+      options
+    });
+    item.id = workspaceAgentAttentionKey(target);
+    item.sortTimeUnixMs = needsAttention.occurredAtUnixMs;
+    result.push({
+      item,
+      status: presentation.promptStatusByKey[statusKey] ?? "idle",
+      target
+    });
+  }
+  return result;
+}
+
+export function workspaceAgentAttentionItemsEqual(
+  left: readonly WorkspaceAgentAttentionItem[],
+  right: readonly WorkspaceAgentAttentionItem[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((entry, index) => {
+      const candidate = right[index];
+      return (
+        candidate !== undefined &&
+        entry.status === candidate.status &&
+        workspaceAgentAttentionTargetEqual(entry.target, candidate.target) &&
+        workspaceAgentMessageCenterItemEqual(entry.item, candidate.item)
+      );
+    })
+  );
+}
+
+function workspaceAgentAttentionKey(target: WorkspaceAgentAttentionTarget) {
+  return [
+    target.workspaceId,
+    target.agentSessionId,
+    target.turnId,
+    target.requestId
+  ].join("\n");
+}
+
+function workspaceAgentAttentionTargetEqual(
+  left: WorkspaceAgentAttentionTarget,
+  right: WorkspaceAgentAttentionTarget
+): boolean {
+  return (
+    left.kind === right.kind &&
+    left.workspaceId === right.workspaceId &&
+    left.agentSessionId === right.agentSessionId &&
+    left.turnId === right.turnId &&
+    left.requestId === right.requestId
   );
 }
 
@@ -203,6 +400,17 @@ function promptStatusMapsEqual(
   return (
     keys.length === Object.keys(right).length &&
     keys.every((key) => left[key] === right[key])
+  );
+}
+
+function booleanMapsEqual(
+  left: Readonly<Record<string, true>>,
+  right: Readonly<Record<string, true>>
+): boolean {
+  const keys = Object.keys(left);
+  return (
+    keys.length === Object.keys(right).length &&
+    keys.every((key) => right[key] === true)
   );
 }
 
@@ -265,6 +473,24 @@ function promptFromInteraction(
   interaction: AgentActivityInteraction
 ): AgentConversationPromptVM | null {
   const input = interaction.input ?? {};
+  const normalizedToolName = (interaction.toolName ?? "")
+    .replace(/[_\s-]+/g, "")
+    .trim()
+    .toLowerCase();
+  if (
+    interaction.kind === "plan" ||
+    normalizedToolName === "exitplanmode" ||
+    isExitPlanSwitchModeInput(input)
+  ) {
+    const keepPlanningOptionId = extractExitPlanKeepPlanningOptionId(input);
+    return {
+      kind: "exit-plan",
+      requestId: interaction.requestId,
+      title: interactionSummary(interaction),
+      options: extractExitPlanModeOptions(input),
+      ...(keepPlanningOptionId ? { keepPlanningOptionId } : {})
+    };
+  }
   if (interaction.kind === "question") {
     const questions = normalizeAskUserQuestions(input.questions);
     return {
@@ -297,7 +523,10 @@ function promptFromInteraction(
           {
             id,
             label: textValue(option.label) ?? textValue(option.name) ?? id,
-            kind: textValue(option.kind) ?? id
+            kind: textValue(option.kind) ?? id,
+            ...(textValue(option.description)
+              ? { description: textValue(option.description) as string }
+              : {})
           }
         ]
       : [];

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModelStability.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModelStability.ts
@@ -29,7 +29,8 @@ export function stabilizeWorkspaceAgentMessageCenterModel(
   const items = next.items.map((nextItem, index) => {
     const previousItem = previousItemsById.get(nextItem.id);
     const stableItem =
-      previousItem && messageCenterItemsEqual(previousItem, nextItem)
+      previousItem &&
+      workspaceAgentMessageCenterItemEqual(previousItem, nextItem)
         ? previousItem
         : nextItem;
     if (stableItem !== previous.items[index]) {
@@ -57,7 +58,7 @@ export function stabilizeWorkspaceAgentMessageCenterModel(
   };
 }
 
-function messageCenterItemsEqual(
+export function workspaceAgentMessageCenterItemEqual(
   left: WorkspaceAgentMessageCenterItem,
   right: WorkspaceAgentMessageCenterItem
 ): boolean {


### PR DESCRIPTION
## Summary

- export a target-level Agent attention projection that preserves every pending interaction in a root conversation
- normalize approval, question, exit-plan, and eligible plan-implementation prompts with exact workspace/session/turn/request identities
- let room boards opt into the full canonical prompt surface and suppress only a visible prompt’s redundant digest while preserving compact defaults
- document the host boundary and add regression coverage for multi-target sessions, plan prompts, full cards, and non-interactive leaving cards

## Verification

- `pnpm --filter @tutti-os/agent-gui test` — 228 files, 1986 tests passed
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready` — 11 lanes passed
- independent subagent review completed; two P1 findings fixed and re-reviewed with no remaining blockers

## Checklist

- [x] This PR does not change agent lifecycle semantics; it adds a presentation projection over existing canonical entities.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit includes a DCO sign-off.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->