### PR TITLE
fix(agent-targets): seed built-in icon assets

### DIFF
--- a/apps/desktop/src/main/host/tuttiAssetProtocol.test.ts
+++ b/apps/desktop/src/main/host/tuttiAssetProtocol.test.ts
@@ -84,6 +84,31 @@ test("tutti asset protocol resolves packaged codex rounded asset", () => {
   }
 });
 
+test("tutti asset protocol resolves packaged codex mask asset", () => {
+  const appPath = mkdtempSync(join(tmpdir(), "tutti-asset-codex-mask-"));
+  const builtAssetPath = join(
+    appPath,
+    "out",
+    "renderer",
+    "assets",
+    "codex-flat-filled-abc123.svg"
+  );
+  mkdirSync(dirname(builtAssetPath), { recursive: true });
+  writeFileSync(builtAssetPath, "");
+
+  try {
+    assert.equal(
+      resolveTuttiAssetProtocolFilePath(
+        "tutti-asset://agent/codex-mask.svg",
+        appPath
+      ),
+      builtAssetPath
+    );
+  } finally {
+    rmSync(appPath, { force: true, recursive: true });
+  }
+});
+
 for (const [agent, builtFileName] of [
   ["cursor", "cursor-colorful-abc123.png"],
   ["hermes", "hermes-rounded-abc123.png"],

--- a/apps/desktop/src/main/host/tuttiAssetProtocolResolver.ts
+++ b/apps/desktop/src/main/host/tuttiAssetProtocolResolver.ts
@@ -3,52 +3,92 @@ import { join } from "node:path";
 import { tuttiAssetProtocolScheme } from "../../shared/tuttiAssetProtocol.ts";
 
 const tuttiAssetRoutes = {
+  "agent/claudecode-mask.svg": {
+    builtFileExtensions: [".svg"],
+    builtFilePrefixes: ["claudecode-flat-filled-"],
+    sourceRelativePath:
+      "../../packages/agent/gui/app/renderer/assets/icons/agents/claudecode-flat-filled.svg"
+  },
   "agent/claudecode.png": {
+    builtFileExtensions: [".png"],
     builtFilePrefixes: ["claude-rounded-", "claudecode-"],
     sourceRelativePath:
       "src/renderer/src/assets/workspace-canvas/dock/default/claudecode.png"
   },
+  "agent/codex-mask.svg": {
+    builtFileExtensions: [".svg"],
+    builtFilePrefixes: ["codex-flat-filled-"],
+    sourceRelativePath:
+      "../../packages/agent/gui/app/renderer/assets/icons/agents/codex-flat-filled.svg"
+  },
   "agent/codex.png": {
+    builtFileExtensions: [".png"],
     builtFilePrefixes: ["codex-rounded-", "codex-"],
     sourceRelativePath:
       "src/renderer/src/assets/workspace-canvas/dock/default/codex.png"
   },
+  "agent/cursor-mask.svg": {
+    builtFileExtensions: [".svg"],
+    builtFilePrefixes: ["cursor-flat-filled-"],
+    sourceRelativePath:
+      "../../packages/agent/gui/app/renderer/assets/icons/agents/cursor-flat-filled.svg"
+  },
   "agent/cursor.png": {
+    builtFileExtensions: [".png"],
     builtFilePrefixes: ["cursor-colorful-", "cursor-rounded-", "cursor-"],
     sourceRelativePath:
       "src/renderer/src/assets/workspace-canvas/dock/default/cursor.png"
   },
   "agent/hermes.png": {
+    builtFileExtensions: [".png"],
     builtFilePrefixes: ["hermes-rounded-", "hermes-"],
     sourceRelativePath:
       "src/renderer/src/assets/workspace-canvas/dock/default/hermes.png"
   },
   "agent/openclaw.png": {
+    builtFileExtensions: [".png"],
     builtFilePrefixes: ["openclaw-rounded-", "openclaw-"],
     sourceRelativePath:
       "src/renderer/src/assets/workspace-canvas/dock/default/openclaw.png"
   },
+  "agent/opencode-mask.svg": {
+    builtFileExtensions: [".svg"],
+    builtFilePrefixes: ["opencode-flat-filled-"],
+    sourceRelativePath:
+      "../../packages/agent/gui/app/renderer/assets/icons/agents/opencode-flat-filled.svg"
+  },
   "agent/opencode.png": {
+    builtFileExtensions: [".png"],
     builtFilePrefixes: ["opencode-rounded-", "opencode-"],
     sourceRelativePath:
       "src/renderer/src/assets/workspace-canvas/dock/default/opencode.png"
   },
+  "agent/tutti-mask.svg": {
+    builtFileExtensions: [".svg"],
+    builtFilePrefixes: ["tutti-flat-filled-"],
+    sourceRelativePath:
+      "../../packages/agent/gui/app/renderer/assets/icons/agents/tutti-flat-filled.svg"
+  },
   "agent/tutti.png": {
+    builtFileExtensions: [".png"],
     builtFilePrefixes: ["tutti-"],
     sourceRelativePath:
       "src/renderer/src/assets/workspace-canvas/dock/default/tutti.png"
   },
   "file/default.png": {
+    builtFileExtensions: [".png"],
     builtFilePrefixes: ["document-"],
     sourceRelativePath:
       "src/renderer/src/assets/workspace-canvas/dock/default/apps/document.png"
   },
   "folder/default.png": {
+    builtFileExtensions: [".png"],
     builtFilePrefixes: ["files-"],
     sourceRelativePath:
       "src/renderer/src/assets/workspace-canvas/dock/default/files.png"
   },
   "issue/default.png": {
+    builtFileExtensions: [".png"],
     builtFilePrefixes: ["issue-"],
     sourceRelativePath:
       "src/renderer/src/assets/workspace-canvas/dock/default/issue.png"
@@ -77,7 +117,9 @@ export function resolveTuttiAssetProtocolFilePath(
   const builtFileName = readdirSync(builtAssetsDirectory).find(
     (fileName) =>
       route.builtFilePrefixes.some((prefix) => fileName.startsWith(prefix)) &&
-      fileName.toLowerCase().endsWith(".png")
+      route.builtFileExtensions.some((extension) =>
+        fileName.toLowerCase().endsWith(extension)
+      )
   );
   return builtFileName ? join(builtAssetsDirectory, builtFileName) : null;
 }

--- a/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
@@ -32,8 +32,6 @@ import {
   userAvatarPlaceholderUrl,
   workspaceAgentActivityStatusLabel
 } from "@tutti-os/agent-gui/agent-message-center";
-import { resolveProviderIconAsset } from "@tutti-os/agent-gui/provider-icons";
-import { resolveAgentGUIProviderCatalogIdentity } from "@tutti-os/agent-gui/provider-catalog";
 import { normalizeAgentActivityDisplayStatus } from "@tutti-os/agent-activity-core";
 import { translate } from "../../../i18n";
 import { getActiveLocale } from "../../../i18n/runtime";
@@ -420,9 +418,5 @@ function logWorkspaceWindowRuntimeDiagnostic(
 }
 
 function resolveWorkspaceRichTextAgentIconUrl(provider: string | undefined) {
-  const identity = resolveAgentGUIProviderCatalogIdentity(provider);
-  return (
-    resolveProviderIconAsset(identity?.iconKey, "rounded") ??
-    managedAgentRoundedIconUrl(provider)
-  );
+  return managedAgentRoundedIconUrl(provider);
 }

--- a/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
@@ -210,7 +210,6 @@ export function createWorkspaceWindowContainer(): WorkspaceWindowContainerResult
     notifications: notificationService,
     reporterService,
     runtimeApi: desktopApi.runtime,
-    resolveAgentTargetIconUrl: resolveWorkspaceAgentTargetIconUrl,
     terminalCommandRunner: createAgentProviderTerminalCommandRunner(
       desktopApi.runtime
     ),
@@ -426,17 +425,4 @@ function resolveWorkspaceRichTextAgentIconUrl(provider: string | undefined) {
     resolveProviderIconAsset(identity?.iconKey, "rounded") ??
     managedAgentRoundedIconUrl(provider)
   );
-}
-
-function resolveWorkspaceAgentTargetIconUrl(identity: {
-  iconKey: string | null;
-  provider: string;
-}): string {
-  if (identity.iconKey) {
-    return (
-      resolveProviderIconAsset(identity.iconKey, "rounded") ??
-      managedAgentRoundedIconUrl(undefined)
-    );
-  }
-  return resolveWorkspaceRichTextAgentIconUrl(identity.provider);
 }

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
@@ -1267,7 +1267,7 @@ function createAgentTarget(input: {
     createdAtUnixMs: 1780272000000,
     enabled: input.enabled ?? true,
     iconKey: "",
-    iconUrl: input.iconUrl ?? null,
+    iconUrl: input.iconUrl ?? resolveTestAgentIconUrl(input.provider),
     id: input.id,
     launchRef: input.launchRef ?? {
       provider: input.provider,
@@ -1284,10 +1284,7 @@ function createAgentTarget(input: {
 function createAgentsService(
   targets: readonly AgentTarget[]
 ): Pick<IAgentsService, "load"> {
-  const agentTargets = mapAgentTargetsToPresentations(targets, {
-    resolveAgentTargetIconUrl: ({ provider }) =>
-      resolveTestAgentIconUrl(provider)
-  });
+  const agentTargets = mapAgentTargetsToPresentations(targets);
   const snapshot: AgentsSnapshot = {
     agentTargets,
     capturedAtUnixMs: 1780272000000,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.test.ts
@@ -113,30 +113,27 @@ test("desktop agents service hydrates a detached-window bootstrap snapshot befor
 });
 
 test("desktop agents service maps enabled daemon targets into the AgentGUI agents directory", () => {
-  const presentations = mapAgentTargetsToPresentations(
-    [
-      createAgentTarget({
-        enabled: false,
-        id: "local:claude-code",
-        name: "Claude Code",
-        provider: "claude-code",
-        sortOrder: 20
-      }),
-      createAgentTarget({
-        id: "local:codex",
-        heroImageUrl: "data:image/jpeg;base64,hero",
-        maskIconUrl: "data:image/svg+xml;base64,mask",
-        iconKey: "codex-descriptor",
-        name: "Codex",
-        provider: "codex",
-        sortOrder: 10
-      })
-    ],
-    {
-      resolveAgentTargetIconUrl: ({ iconKey, provider }) =>
-        `tutti-asset://agent/${iconKey ?? provider}.png`
-    }
-  );
+  const presentations = mapAgentTargetsToPresentations([
+    createAgentTarget({
+      enabled: false,
+      id: "local:claude-code",
+      iconUrl: "tutti-asset://agent/claudecode.png",
+      maskIconUrl: "tutti-asset://agent/claudecode-mask.svg",
+      name: "Claude Code",
+      provider: "claude-code",
+      sortOrder: 20
+    }),
+    createAgentTarget({
+      id: "local:codex",
+      heroImageUrl: "data:image/jpeg;base64,hero",
+      maskIconUrl: "data:image/svg+xml;base64,mask",
+      iconKey: "codex-descriptor",
+      iconUrl: "tutti-asset://agent/codex.png",
+      name: "Codex",
+      provider: "codex",
+      sortOrder: 10
+    })
+  ]);
 
   assert.deepEqual(
     presentations.map((target) => ({
@@ -150,7 +147,7 @@ test("desktop agents service maps enabled daemon targets into the AgentGUI agent
     [
       {
         agentTargetId: "local:codex",
-        iconUrl: "tutti-asset://agent/codex-descriptor.png",
+        iconUrl: "tutti-asset://agent/codex.png",
         maskIconUrl: "data:image/svg+xml;base64,mask",
         heroImageUrl: "data:image/jpeg;base64,hero",
         launchRefType: "builtin_local",
@@ -158,8 +155,8 @@ test("desktop agents service maps enabled daemon targets into the AgentGUI agent
       },
       {
         agentTargetId: "local:claude-code",
-        iconUrl: "tutti-asset://agent/claude-code.png",
-        maskIconUrl: null,
+        iconUrl: "tutti-asset://agent/claudecode.png",
+        maskIconUrl: "tutti-asset://agent/claudecode-mask.svg",
         heroImageUrl: null,
         launchRefType: "builtin_local",
         provider: "claude-code"
@@ -171,7 +168,7 @@ test("desktop agents service maps enabled daemon targets into the AgentGUI agent
     {
       agentTargetId: "local:codex",
       availability: { status: "ready" },
-      iconUrl: "tutti-asset://agent/codex-descriptor.png",
+      iconUrl: "tutti-asset://agent/codex.png",
       maskIconUrl: "data:image/svg+xml;base64,mask",
       heroImageUrl: "data:image/jpeg;base64,hero",
       name: "Codex",
@@ -239,6 +236,7 @@ function createAgentTarget(input: {
   enabled?: boolean;
   id: string;
   iconKey?: string | null;
+  iconUrl?: string | null;
   heroImageUrl?: string | null;
   maskIconUrl?: string | null;
   name: string;
@@ -249,6 +247,7 @@ function createAgentTarget(input: {
     createdAtUnixMs: 1780272000000,
     enabled: input.enabled ?? true,
     iconKey: input.iconKey ?? null,
+    iconUrl: input.iconUrl ?? `tutti-asset://agent/${input.provider}.png`,
     heroImageUrl: input.heroImageUrl ?? null,
     maskIconUrl: input.maskIconUrl ?? null,
     id: input.id,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.ts
@@ -9,10 +9,6 @@ import type {
 export interface DesktopAgentsServiceDependencies {
   clearTimeout?: (timer: ReturnType<typeof setTimeout>) => void;
   now?: () => number;
-  resolveAgentTargetIconUrl?: (identity: {
-    iconKey: string | null;
-    provider: string;
-  }) => string;
   retryDelayMs?: number;
   setTimeout?: (
     callback: () => void,
@@ -131,10 +127,7 @@ export class DesktopAgentsService implements IAgentsService {
         return this.snapshot;
       }
       const daemonAgentTargets = mapAgentTargetsToPresentations(
-        response.targets,
-        {
-          resolveAgentTargetIconUrl: this.dependencies.resolveAgentTargetIconUrl
-        }
+        response.targets
       );
       const agentTargets = daemonAgentTargets;
       const agents = mapAgentTargetPresentationsToAgents(daemonAgentTargets);
@@ -201,24 +194,10 @@ export class DesktopAgentsService implements IAgentsService {
 }
 
 export function mapAgentTargetsToPresentations(
-  targets: readonly AgentTarget[],
-  options: {
-    resolveAgentTargetIconUrl?: (identity: {
-      iconKey: string | null;
-      provider: string;
-    }) => string;
-  } = {}
+  targets: readonly AgentTarget[]
 ): readonly AgentTargetPresentation[] {
   return [...targets].sort(compareAgentTargetsForDisplay).map((target) => {
-    const isExtension = target.launchRef.type === "agent_extension";
-    const iconUrl =
-      target.iconUrl?.trim() ||
-      (isExtension
-        ? ""
-        : (options.resolveAgentTargetIconUrl?.({
-            iconKey: target.iconKey?.trim() || null,
-            provider: target.provider
-          }) ?? ""));
+    const iconUrl = target.iconUrl?.trim() ?? "";
     return {
       agentTargetId: target.id,
       createdAtUnixMs: target.createdAtUnixMs,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
@@ -36,10 +36,6 @@ export interface WorkspaceAgentServiceRegistrationInput {
     DesktopRuntimeApi,
     "logRendererDiagnostic" | "logTerminalDiagnostic"
   >;
-  resolveAgentTargetIconUrl?: (identity: {
-    iconKey: string | null;
-    provider: string;
-  }) => string;
   terminalCommandRunner: AgentProviderTerminalCommandRunner;
   workspaceId: string;
   workspaceUserProjectService?: IWorkspaceUserProjectService;
@@ -83,7 +79,6 @@ export function registerWorkspaceAgentServices(
     );
   startManagedAgentInstallBootstraps(agentProviderStatusService);
   const agentsService = new DesktopAgentsService({
-    resolveAgentTargetIconUrl: input.resolveAgentTargetIconUrl,
     tuttidClient: input.tuttidClient
   });
   registry.registerInstance(IAgentsService, agentsService);

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -220,8 +220,9 @@ targets from presentation metadata.
 
 Agent names, primary icons, optional conversation-mask icons, and optional
 home-carousel artwork come from `agents[].name`, `agents[].iconUrl`,
-`agents[].maskIconUrl`, and `agents[].heroImageUrl`. All identity surfaces use
-`iconUrl`; conversation rows use `maskIconUrl` where present.
+`agents[].maskIconUrl`, and `agents[].heroImageUrl`. Hosts must pass fully
+resolved presentation URLs from their authoritative directory. All identity
+surfaces use `iconUrl`; conversation rows use `maskIconUrl` where present.
 `owner.avatarUrl` is rendered separately as an ownership badge. Invalid entries
 and duplicate `agentTargetId` values are discarded by
 `normalizeAgentGUIAgents`, with the first occurrence preserving host order.
@@ -234,12 +235,10 @@ directly. With multiple agents, it shows `All` plus the host-ordered agent rail
 and empty-home carousel. Hosts may customize the aggregate icon with
 `allAgentsPresentation.iconUrl`.
 
-Hosts adapting daemon-owned agent targets must resolve the target's descriptor
-`iconKey` instead of assuming it equals the provider ID. The narrow
-`@tutti-os/agent-gui/provider-icons` subpath exports
-`resolveProviderIconAsset(iconKey, variant)` for that adapter seam. Unknown
-keys return `null`; hosts should render a neutral icon rather than silently
-substituting another provider's icon.
+Daemon-owned system targets seed and refresh their `iconUrl` and `maskIconUrl`
+from the target descriptor `iconKey`. AgentGUI consumers must not synthesize
+built-in target icons from provider IDs or `iconKey`; stale or missing directory
+presentation should be fixed in the source directory.
 
 Hosts that need provider identity presentation may call
 `resolveAgentGUIProviderIdentity(value)` from the narrow

--- a/packages/agent/store-sqlite/migrations_targets.go
+++ b/packages/agent/store-sqlite/migrations_targets.go
@@ -81,7 +81,10 @@ func (s *Store) applyAgentTargetsV4(ctx context.Context) error {
 func (s *Store) applyAgentTargetsV5(ctx context.Context) error {
 	applied, err := s.hasMigration(ctx, schemaMigrationAgentTargetsV5)
 	if err != nil || applied {
-		return err
+		if err != nil {
+			return err
+		}
+		return s.seedSystemAgentTargets(ctx, unixMs(time.Now().UTC()))
 	}
 	if _, err := s.db.ExecContext(ctx, `
 ALTER TABLE agent_targets RENAME COLUMN sidebar_icon_url TO mask_icon_url;
@@ -90,7 +93,10 @@ DELETE FROM agent_targets WHERE launch_ref_json LIKE '%"type":"agent_extension"%
 `); err != nil {
 		return fmt.Errorf("replace agent target sidebar icon with mask icon: %w", err)
 	}
-	return s.recordMigration(ctx, schemaMigrationAgentTargetsV5)
+	if err := s.recordMigration(ctx, schemaMigrationAgentTargetsV5); err != nil {
+		return err
+	}
+	return s.seedSystemAgentTargets(ctx, unixMs(time.Now().UTC()))
 }
 
 func (s *Store) seedSystemAgentTargets(ctx context.Context, now int64) error {
@@ -107,8 +113,105 @@ func (s *Store) seedSystemAgentTargets(ctx context.Context, now int64) error {
 	if s.opts.SeedSystemTargets == nil {
 		return nil
 	}
+	hasIconURL, err := s.hasColumn(ctx, "agent_targets", "icon_url")
+	if err != nil {
+		return err
+	}
+	hasMaskIconURL, err := s.hasColumn(ctx, "agent_targets", "mask_icon_url")
+	if err != nil {
+		return err
+	}
+	hasHeroImageURL, err := s.hasColumn(ctx, "agent_targets", "hero_image_url")
+	if err != nil {
+		return err
+	}
+	hasIconColumns := hasIconURL && hasMaskIconURL && hasHeroImageURL
 	for _, target := range s.opts.SeedSystemTargets(now) {
+		if !hasIconColumns {
+			if err := s.seedSystemAgentTargetWithoutIconColumns(ctx, target, now); err != nil {
+				return err
+			}
+			continue
+		}
 		if _, err := s.db.ExecContext(ctx, `
+INSERT OR IGNORE INTO agent_targets (
+  id,
+  provider,
+  launch_ref_json,
+  name,
+  icon_key,
+  icon_url,
+  mask_icon_url,
+  hero_image_url,
+  enabled,
+  source,
+  sort_order,
+  created_at_ms,
+  updated_at_ms
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`, target.ID, target.Provider, target.LaunchRefJSON, target.Name, target.IconKey, target.IconURL, target.MaskIconURL, target.HeroImageURL, target.Enabled, target.Source, target.SortOrder, target.CreatedAtUnixMS, target.UpdatedAtUnixMS); err != nil {
+			return fmt.Errorf("seed system agent target %q: %w", target.ID, err)
+		}
+		if target.Source != systemTargetSource {
+			continue
+		}
+		if _, err := s.db.ExecContext(ctx, `
+UPDATE agent_targets
+SET provider = ?,
+    launch_ref_json = ?,
+    name = ?,
+    icon_key = ?,
+    icon_url = ?,
+    mask_icon_url = ?,
+    hero_image_url = ?,
+    enabled = ?,
+    sort_order = ?,
+    updated_at_ms = ?
+WHERE id = ?
+  AND source = ?
+  AND (
+    provider != ? OR
+    launch_ref_json != ? OR
+    name != ? OR
+    COALESCE(icon_key, '') != ? OR
+    COALESCE(icon_url, '') != ? OR
+    COALESCE(mask_icon_url, '') != ? OR
+    COALESCE(hero_image_url, '') != ? OR
+    enabled != ? OR
+    sort_order != ?
+  )
+`,
+			target.Provider,
+			target.LaunchRefJSON,
+			target.Name,
+			target.IconKey,
+			target.IconURL,
+			target.MaskIconURL,
+			target.HeroImageURL,
+			target.Enabled,
+			target.SortOrder,
+			now,
+			target.ID,
+			systemTargetSource,
+			target.Provider,
+			target.LaunchRefJSON,
+			target.Name,
+			target.IconKey,
+			target.IconURL,
+			target.MaskIconURL,
+			target.HeroImageURL,
+			target.Enabled,
+			target.SortOrder,
+		); err != nil {
+			return fmt.Errorf("refresh system agent target %q: %w", target.ID, err)
+		}
+	}
+	return nil
+}
+
+func (s *Store) seedSystemAgentTargetWithoutIconColumns(ctx context.Context, target Target, now int64) error {
+	if _, err := s.db.ExecContext(ctx, `
 INSERT OR IGNORE INTO agent_targets (
   id,
   provider,
@@ -123,12 +226,12 @@ INSERT OR IGNORE INTO agent_targets (
 )
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `, target.ID, target.Provider, target.LaunchRefJSON, target.Name, target.IconKey, target.Enabled, target.Source, target.SortOrder, target.CreatedAtUnixMS, target.UpdatedAtUnixMS); err != nil {
-			return fmt.Errorf("seed system agent target %q: %w", target.ID, err)
-		}
-		if target.Source != systemTargetSource {
-			continue
-		}
-		if _, err := s.db.ExecContext(ctx, `
+		return fmt.Errorf("seed system agent target %q: %w", target.ID, err)
+	}
+	if target.Source != systemTargetSource {
+		return nil
+	}
+	if _, err := s.db.ExecContext(ctx, `
 UPDATE agent_targets
 SET provider = ?,
     launch_ref_json = ?,
@@ -148,24 +251,23 @@ WHERE id = ?
     sort_order != ?
   )
 `,
-			target.Provider,
-			target.LaunchRefJSON,
-			target.Name,
-			target.IconKey,
-			target.Enabled,
-			target.SortOrder,
-			now,
-			target.ID,
-			systemTargetSource,
-			target.Provider,
-			target.LaunchRefJSON,
-			target.Name,
-			target.IconKey,
-			target.Enabled,
-			target.SortOrder,
-		); err != nil {
-			return fmt.Errorf("refresh system agent target %q: %w", target.ID, err)
-		}
+		target.Provider,
+		target.LaunchRefJSON,
+		target.Name,
+		target.IconKey,
+		target.Enabled,
+		target.SortOrder,
+		now,
+		target.ID,
+		systemTargetSource,
+		target.Provider,
+		target.LaunchRefJSON,
+		target.Name,
+		target.IconKey,
+		target.Enabled,
+		target.SortOrder,
+	); err != nil {
+		return fmt.Errorf("refresh system agent target %q: %w", target.ID, err)
 	}
 	return nil
 }

--- a/packages/agent/store-sqlite/store_test.go
+++ b/packages/agent/store-sqlite/store_test.go
@@ -35,6 +35,8 @@ func testSeedTargets(now int64) []Target {
 			LaunchRefJSON:   `{"type":"local_cli","provider":"codex"}`,
 			Name:            "Codex",
 			IconKey:         "codex",
+			IconURL:         "tutti-asset://agent/codex.png",
+			MaskIconURL:     "tutti-asset://agent/codex-mask.svg",
 			Enabled:         true,
 			Source:          "system",
 			SortOrder:       10,
@@ -47,6 +49,8 @@ func testSeedTargets(now int64) []Target {
 			LaunchRefJSON:   `{"type":"local_cli","provider":"claude-code"}`,
 			Name:            "Claude Code",
 			IconKey:         "claude-code",
+			IconURL:         "tutti-asset://agent/claudecode.png",
+			MaskIconURL:     "tutti-asset://agent/claudecode-mask.svg",
 			Enabled:         true,
 			Source:          "system",
 			SortOrder:       20,
@@ -149,7 +153,9 @@ func TestStoreMigrateRefreshesOnlySystemSeedTargets(t *testing.T) {
 	if _, err := store.db.ExecContext(ctx, `
 UPDATE agent_targets
 SET provider = 'stale-provider', launch_ref_json = '{}', name = 'Stale Codex',
-    icon_key = 'stale', enabled = 0, sort_order = 999, created_at_ms = 7, updated_at_ms = 8
+    icon_key = 'stale', icon_url = 'stale.png', mask_icon_url = 'stale-mask.svg',
+    hero_image_url = 'stale-hero.jpg', enabled = 0, sort_order = 999,
+    created_at_ms = 7, updated_at_ms = 8
 WHERE id = ?;
 `, testTargetIDCodex); err != nil {
 		t.Fatalf("seed stale system target: %v", err)
@@ -170,13 +176,17 @@ WHERE id = ?;
 
 	var codex Target
 	if err := store.db.QueryRowContext(ctx, `
-SELECT id, provider, launch_ref_json, name, icon_key, enabled, source, sort_order, created_at_ms, updated_at_ms
+SELECT id, provider, launch_ref_json, name, icon_key, icon_url, mask_icon_url, hero_image_url,
+       enabled, source, sort_order, created_at_ms, updated_at_ms
 FROM agent_targets WHERE id = ?
-`, testTargetIDCodex).Scan(&codex.ID, &codex.Provider, &codex.LaunchRefJSON, &codex.Name, &codex.IconKey, &codex.Enabled, &codex.Source, &codex.SortOrder, &codex.CreatedAtUnixMS, &codex.UpdatedAtUnixMS); err != nil {
+`, testTargetIDCodex).Scan(&codex.ID, &codex.Provider, &codex.LaunchRefJSON, &codex.Name, &codex.IconKey, &codex.IconURL, &codex.MaskIconURL, &codex.HeroImageURL, &codex.Enabled, &codex.Source, &codex.SortOrder, &codex.CreatedAtUnixMS, &codex.UpdatedAtUnixMS); err != nil {
 		t.Fatalf("query refreshed codex target: %v", err)
 	}
 	if codex.Provider != "codex" || codex.LaunchRefJSON != `{"type":"local_cli","provider":"codex"}` ||
-		codex.Name != "Codex" || codex.IconKey != "codex" || !codex.Enabled || codex.SortOrder != 10 {
+		codex.Name != "Codex" || codex.IconKey != "codex" ||
+		codex.IconURL != "tutti-asset://agent/codex.png" ||
+		codex.MaskIconURL != "tutti-asset://agent/codex-mask.svg" ||
+		codex.HeroImageURL != "" || !codex.Enabled || codex.SortOrder != 10 {
 		t.Fatalf("refreshed system target = %#v", codex)
 	}
 	if codex.CreatedAtUnixMS != 7 || codex.Source != systemTargetSource || codex.UpdatedAtUnixMS == 8 {

--- a/services/tuttid/biz/agenttarget/model.go
+++ b/services/tuttid/biz/agenttarget/model.go
@@ -38,6 +38,21 @@ var (
 	agentTargetIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._:-]{0,127}$`)
 )
 
+type systemTargetIconAsset struct {
+	iconURL     string
+	maskIconURL string
+}
+
+var systemTargetIconAssetsByIconKey = map[string]systemTargetIconAsset{
+	"claude-code": {iconURL: "tutti-asset://agent/claudecode.png", maskIconURL: "tutti-asset://agent/claudecode-mask.svg"},
+	"codex":       {iconURL: "tutti-asset://agent/codex.png", maskIconURL: "tutti-asset://agent/codex-mask.svg"},
+	"cursor":      {iconURL: "tutti-asset://agent/cursor.png", maskIconURL: "tutti-asset://agent/cursor-mask.svg"},
+	"hermes":      {iconURL: "tutti-asset://agent/hermes.png", maskIconURL: "tutti-asset://agent/hermes.png"},
+	"openclaw":    {iconURL: "tutti-asset://agent/openclaw.png", maskIconURL: "tutti-asset://agent/openclaw.png"},
+	"opencode":    {iconURL: "tutti-asset://agent/opencode.png", maskIconURL: "tutti-asset://agent/opencode-mask.svg"},
+	"tutti":       {iconURL: "tutti-asset://agent/tutti.png", maskIconURL: "tutti-asset://agent/tutti-mask.svg"},
+}
+
 type Target struct {
 	ID                 string
 	Provider           string
@@ -83,12 +98,15 @@ func systemTargetFromProviderDescriptor(descriptor providerregistry.ProviderDesc
 	if descriptor.Target.LaunchRefType != launchRefTypeLegacyLocalCLI {
 		panic(fmt.Sprintf("provider %q has unsupported target launch ref type %q", descriptor.Identity.ID, descriptor.Target.LaunchRefType))
 	}
+	icons := systemTargetIconAssetsByIconKey[strings.TrimSpace(descriptor.Identity.IconKey)]
 	return Target{
 		ID:              descriptor.Target.ID,
 		Provider:        descriptor.Identity.ID,
 		LaunchRefJSON:   MustLocalCLILaunchRefJSON(descriptor.Identity.ID),
 		Name:            descriptor.Identity.DisplayName,
 		IconKey:         descriptor.Identity.IconKey,
+		IconURL:         icons.iconURL,
+		MaskIconURL:     icons.maskIconURL,
 		Enabled:         descriptor.Target.Enabled,
 		Source:          SourceSystem,
 		SortOrder:       descriptor.Target.SortOrder,

--- a/services/tuttid/biz/agenttarget/model.go
+++ b/services/tuttid/biz/agenttarget/model.go
@@ -47,8 +47,8 @@ var systemTargetIconAssetsByIconKey = map[string]systemTargetIconAsset{
 	"claude-code": {iconURL: "tutti-asset://agent/claudecode.png", maskIconURL: "tutti-asset://agent/claudecode-mask.svg"},
 	"codex":       {iconURL: "tutti-asset://agent/codex.png", maskIconURL: "tutti-asset://agent/codex-mask.svg"},
 	"cursor":      {iconURL: "tutti-asset://agent/cursor.png", maskIconURL: "tutti-asset://agent/cursor-mask.svg"},
-	"hermes":      {iconURL: "tutti-asset://agent/hermes.png", maskIconURL: "tutti-asset://agent/hermes.png"},
-	"openclaw":    {iconURL: "tutti-asset://agent/openclaw.png", maskIconURL: "tutti-asset://agent/openclaw.png"},
+	"hermes":      {iconURL: "tutti-asset://agent/hermes.png"},
+	"openclaw":    {iconURL: "tutti-asset://agent/openclaw.png"},
 	"opencode":    {iconURL: "tutti-asset://agent/opencode.png", maskIconURL: "tutti-asset://agent/opencode-mask.svg"},
 	"tutti":       {iconURL: "tutti-asset://agent/tutti.png", maskIconURL: "tutti-asset://agent/tutti-mask.svg"},
 }

--- a/services/tuttid/biz/agenttarget/model_test.go
+++ b/services/tuttid/biz/agenttarget/model_test.go
@@ -44,6 +44,9 @@ func TestDefaultSystemTargetsUseMigratedProviderDescriptors(t *testing.T) {
 		if target.Name != descriptor.Identity.DisplayName || target.IconKey != descriptor.Identity.IconKey {
 			t.Fatalf("target presentation = %#v", target)
 		}
+		if target.IconURL == "" || target.MaskIconURL == "" {
+			t.Fatalf("target icon presentation = %#v", target)
+		}
 		if target.SortOrder != descriptor.Target.SortOrder || target.CreatedAtUnixMS != 123 {
 			t.Fatalf("target ordering/timestamp = %#v", target)
 		}

--- a/services/tuttid/biz/agenttarget/model_test.go
+++ b/services/tuttid/biz/agenttarget/model_test.go
@@ -44,8 +44,15 @@ func TestDefaultSystemTargetsUseMigratedProviderDescriptors(t *testing.T) {
 		if target.Name != descriptor.Identity.DisplayName || target.IconKey != descriptor.Identity.IconKey {
 			t.Fatalf("target presentation = %#v", target)
 		}
-		if target.IconURL == "" || target.MaskIconURL == "" {
-			t.Fatalf("target icon presentation = %#v", target)
+		if target.IconURL == "" {
+			t.Fatalf("target icon URL missing = %#v", target)
+		}
+		if target.IconKey == "hermes" || target.IconKey == "openclaw" {
+			if target.MaskIconURL != "" {
+				t.Fatalf("target mask icon URL = %q, want empty image fallback for %s", target.MaskIconURL, target.IconKey)
+			}
+		} else if target.MaskIconURL == "" {
+			t.Fatalf("target mask icon URL missing = %#v", target)
 		}
 		if target.SortOrder != descriptor.Target.SortOrder || target.CreatedAtUnixMS != 123 {
 			t.Fatalf("target ordering/timestamp = %#v", target)

--- a/services/tuttid/data/workspace/sqlite_agent_targets_test.go
+++ b/services/tuttid/data/workspace/sqlite_agent_targets_test.go
@@ -44,8 +44,15 @@ func TestSQLiteStoreSeedsSystemAgentTargets(t *testing.T) {
 		if target.Source != agenttargetbiz.SourceSystem {
 			t.Fatalf("target %q source = %q, want system", target.ID, target.Source)
 		}
-		if target.IconURL == "" || target.MaskIconURL == "" {
-			t.Fatalf("target %q icon urls = %q / %q, want both", target.ID, target.IconURL, target.MaskIconURL)
+		if target.IconURL == "" {
+			t.Fatalf("target %q icon url missing", target.ID)
+		}
+		if target.IconKey == "hermes" || target.IconKey == "openclaw" {
+			if target.MaskIconURL != "" {
+				t.Fatalf("target %q mask icon url = %q, want empty image fallback", target.ID, target.MaskIconURL)
+			}
+		} else if target.MaskIconURL == "" {
+			t.Fatalf("target %q mask icon url missing", target.ID)
 		}
 		if _, err := agenttargetbiz.CanonicalLaunchRefJSONString(target.Provider, target.LaunchRefJSON); err != nil {
 			t.Fatalf("target %q launch ref invalid: %v", target.ID, err)

--- a/services/tuttid/data/workspace/sqlite_agent_targets_test.go
+++ b/services/tuttid/data/workspace/sqlite_agent_targets_test.go
@@ -44,6 +44,9 @@ func TestSQLiteStoreSeedsSystemAgentTargets(t *testing.T) {
 		if target.Source != agenttargetbiz.SourceSystem {
 			t.Fatalf("target %q source = %q, want system", target.ID, target.Source)
 		}
+		if target.IconURL == "" || target.MaskIconURL == "" {
+			t.Fatalf("target %q icon urls = %q / %q, want both", target.ID, target.IconURL, target.MaskIconURL)
+		}
 		if _, err := agenttargetbiz.CanonicalLaunchRefJSONString(target.Provider, target.LaunchRefJSON); err != nil {
 			t.Fatalf("target %q launch ref invalid: %v", target.ID, err)
 		}


### PR DESCRIPTION
## Summary
- seed built-in system agent targets with resolved iconUrl and maskIconUrl from descriptor iconKey
- refresh existing system target rows so old local databases pick up canonical icon assets
- remove desktop renderer fallback that synthesized built-in target icons from provider/iconKey
- add tutti-asset mask SVG routes and document the AgentGUI directory contract

## Validation
- go test ./services/tuttid/biz/agenttarget ./services/tuttid/data/workspace ./packages/agent/store-sqlite
- pnpm --filter @tutti-os/desktop test -- src/main/host/tuttiAssetProtocol.test.ts src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.test.ts src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
- pnpm --filter @tutti-os/desktop typecheck
- git diff --check
- pnpm check:changed -- --push-ready
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->