### PR TITLE
fix(agent): preserve Codex approvals with open network

### DIFF
--- a/packages/agent/daemon/README.md
+++ b/packages/agent/daemon/README.md
@@ -39,13 +39,12 @@ start or initialize failure, live-session close, idle release, and live process
 replacement. Cleanup failures are logged and do not replace the original close
 or start error.
 
-Hosts that already provide the authoritative outer execution sandbox can
-construct the Codex adapter with
-`CodexAppServerSandboxPolicyDangerFullAccess`. This changes only the Codex
-`sandbox` / `sandboxPolicy` request fields; the session permission mode still
-owns `approvalPolicy` and `approvalsReviewer`, so application approval requests
-continue through the host interaction flow. The default constructor keeps
-Codex sandbox selection coupled to the permission mode.
+Hosts that need unrestricted command networking while retaining Codex's
+permission-mode filesystem sandbox and approval UX can construct the adapter
+with `CodexAppServerAdapterOptions{CommandNetworkAccess: true}`. The option
+sets `sandboxPolicy.networkAccess` on read-only and workspace-write turns. It
+does not change `approvalPolicy`, `approvalsReviewer`, writable roots, or
+network-proxy policy. Full-access turns remain unrestricted by definition.
 
 ## Package Ownership
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -87,33 +87,23 @@ const (
 // Codex-compatible forks (Tutti Agent) without sharing brand, command, or
 // auth assumptions.
 type appServerAdapterConfig struct {
-	provider            string
-	runtimeName         string
-	displayName         string
-	command             []string
-	clientInfoName      string
-	authRequiredMessage string
-	sandboxPolicy       CodexAppServerSandboxPolicy
+	provider             string
+	runtimeName          string
+	displayName          string
+	command              []string
+	clientInfoName       string
+	authRequiredMessage  string
+	commandNetworkAccess bool
 }
 
-// CodexAppServerSandboxPolicy controls only the Codex process sandbox sent to
-// app-server. Application approval policy and reviewer routing continue to
-// come from the session permission mode.
-type CodexAppServerSandboxPolicy string
-
-const (
-	// CodexAppServerSandboxPolicyPermissionMode preserves the default Codex
-	// behavior: each application permission mode selects its matching sandbox.
-	// This is the zero value so existing hosts keep their current behavior.
-	CodexAppServerSandboxPolicyPermissionMode CodexAppServerSandboxPolicy = ""
-	// CodexAppServerSandboxPolicyDangerFullAccess disables the Codex process
-	// sandbox while leaving application approval and reviewer routing intact.
-	// Hosts should use this only when an outer execution sandbox is authoritative.
-	CodexAppServerSandboxPolicyDangerFullAccess CodexAppServerSandboxPolicy = "danger-full-access"
-)
-
+// CodexAppServerAdapterOptions controls host-owned app-server execution policy
+// without changing the provider-native permission-mode mapping.
 type CodexAppServerAdapterOptions struct {
-	SandboxPolicy CodexAppServerSandboxPolicy
+	// CommandNetworkAccess enables network access for commands and subprocesses
+	// in the read-only and workspace-write sandboxes. Filesystem access,
+	// approval policy, and approval reviewer remain owned by the selected
+	// permission mode. Network proxy configuration remains a separate concern.
+	CommandNetworkAccess bool
 }
 
 // defaultCodexAppServerCancelGraceWindow is how long Cancel waits for codex to
@@ -353,7 +343,7 @@ func NewCodexAppServerAdapterWithHostMetadataAndOptions(
 	options CodexAppServerAdapterOptions,
 ) *CodexAppServerAdapter {
 	adapter := NewCodexAppServerAdapterWithHostMetadataAndCommandResolver(transport, host, nil)
-	adapter.config.sandboxPolicy = validatedCodexAppServerSandboxPolicy(options.SandboxPolicy)
+	adapter.config.commandNetworkAccess = options.CommandNetworkAccess
 	return adapter
 }
 
@@ -412,15 +402,6 @@ func newAppServerAdapter(
 		sessions:          make(map[string]*codexAppServerSession),
 		lifecycleLocks:    make(map[string]*codexAppServerSessionLock),
 		cancelGraceWindow: defaultCodexAppServerCancelGraceWindow,
-	}
-}
-
-func validatedCodexAppServerSandboxPolicy(policy CodexAppServerSandboxPolicy) CodexAppServerSandboxPolicy {
-	switch policy {
-	case CodexAppServerSandboxPolicyPermissionMode, CodexAppServerSandboxPolicyDangerFullAccess:
-		return policy
-	default:
-		panic(fmt.Sprintf("unsupported Codex app-server sandbox policy %q", policy))
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -1201,17 +1201,36 @@ func TestCodexAppServerAdapterStartAppliesSettingsAndPermissionMode(t *testing.T
 	}
 }
 
-func TestCodexAppServerAdapterDangerFullAccessSandboxPreservesApplicationApprovals(t *testing.T) {
+func TestCodexAppServerAdapterCommandNetworkAccessPreservesPermissionModes(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		mode              string
+		threadSandbox     string
+		turnSandbox       string
 		approvalPolicy    string
 		approvalsReviewer string
 	}{
-		{mode: "read-only", approvalPolicy: "on-request", approvalsReviewer: "user"},
-		{mode: "auto", approvalPolicy: "on-request", approvalsReviewer: "auto_review"},
-		{mode: "full-access", approvalPolicy: "never"},
+		{
+			mode:              "read-only",
+			threadSandbox:     "read-only",
+			turnSandbox:       "readOnly",
+			approvalPolicy:    "on-request",
+			approvalsReviewer: "user",
+		},
+		{
+			mode:              "auto",
+			threadSandbox:     "workspace-write",
+			turnSandbox:       "workspaceWrite",
+			approvalPolicy:    "on-request",
+			approvalsReviewer: "auto_review",
+		},
+		{
+			mode:           "full-access",
+			threadSandbox:  "danger-full-access",
+			turnSandbox:    "dangerFullAccess",
+			approvalPolicy: "never",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.mode, func(t *testing.T) {
@@ -1221,9 +1240,7 @@ func TestCodexAppServerAdapterDangerFullAccessSandboxPreservesApplicationApprova
 			adapter := NewCodexAppServerAdapterWithHostMetadataAndOptions(
 				transport,
 				LegacyHostMetadata(),
-				CodexAppServerAdapterOptions{
-					SandboxPolicy: CodexAppServerSandboxPolicyDangerFullAccess,
-				},
+				CodexAppServerAdapterOptions{CommandNetworkAccess: true},
 			)
 			session := testAppServerSession()
 			session.PermissionModeID = test.mode
@@ -1233,85 +1250,54 @@ func TestCodexAppServerAdapterDangerFullAccessSandboxPreservesApplicationApprova
 				t.Fatalf("Start: %v", err)
 			}
 			threadStart := appServerRequestParams(t, transport.conn, appServerMethodThreadStart)
-			assertCodexAppServerApprovalAndSandboxParams(
-				t,
-				"thread/start",
-				threadStart,
-				"sandbox",
-				"danger-full-access",
-				test.approvalPolicy,
-				test.approvalsReviewer,
-			)
+			if got := asString(threadStart["sandbox"]); got != test.threadSandbox {
+				t.Fatalf("thread/start sandbox = %q, want %q", got, test.threadSandbox)
+			}
+			if got := asString(threadStart["approvalPolicy"]); got != test.approvalPolicy {
+				t.Fatalf("thread/start approvalPolicy = %q, want %q", got, test.approvalPolicy)
+			}
+			if got := asString(threadStart["approvalsReviewer"]); got != test.approvalsReviewer {
+				t.Fatalf("thread/start approvalsReviewer = %q, want %q", got, test.approvalsReviewer)
+			}
 
 			if _, err := adapter.Exec(context.Background(), session, textPrompt("go"), "", "turn-local-1", nil, nil); err != nil {
 				t.Fatalf("Exec: %v", err)
 			}
 			turnStart := appServerRequestParams(t, transport.conn, appServerMethodTurnStart)
-			sandboxPolicy, _ := turnStart["sandboxPolicy"].(map[string]any)
-			turnStart["sandboxPolicyType"] = asString(sandboxPolicy["type"])
-			assertCodexAppServerApprovalAndSandboxParams(
-				t,
-				"turn/start",
-				turnStart,
-				"sandboxPolicyType",
-				"dangerFullAccess",
-				test.approvalPolicy,
-				test.approvalsReviewer,
-			)
+			policy, _ := turnStart["sandboxPolicy"].(map[string]any)
+			if got := asString(policy["type"]); got != test.turnSandbox {
+				t.Fatalf("turn/start sandboxPolicy = %#v, want type %q", policy, test.turnSandbox)
+			}
+			if test.mode == "full-access" {
+				if _, ok := policy["networkAccess"]; ok {
+					t.Fatalf("turn/start sandboxPolicy = %#v, want implicit full-access networking", policy)
+				}
+			} else if enabled, _ := policy["networkAccess"].(bool); !enabled {
+				t.Fatalf("turn/start sandboxPolicy = %#v, want networkAccess=true", policy)
+			}
 		})
 	}
 }
 
-func TestCodexAppServerAdapterDangerFullAccessSandboxAppliesOnResume(t *testing.T) {
+func TestCodexAppServerAdapterDefaultCommandNetworkAccessRemainsDisabled(t *testing.T) {
 	t.Parallel()
 
 	transport := newScriptedAppServerTransport()
-	adapter := NewCodexAppServerAdapterWithHostMetadataAndOptions(
-		transport,
-		LegacyHostMetadata(),
-		CodexAppServerAdapterOptions{
-			SandboxPolicy: CodexAppServerSandboxPolicyDangerFullAccess,
-		},
-	)
+	adapter := NewCodexAppServerAdapter(transport)
 	session := testAppServerSession()
-	session.ProviderSessionID = "codex-thread-1"
 	session.PermissionModeID = "read-only"
 	session.Settings = &SessionSettings{PermissionModeID: "read-only"}
 
-	if err := adapter.Resume(context.Background(), session); err != nil {
-		t.Fatalf("Resume: %v", err)
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
 	}
-	threadResume := appServerRequestParams(t, transport.conn, appServerMethodThreadResume)
-	assertCodexAppServerApprovalAndSandboxParams(
-		t,
-		"thread/resume",
-		threadResume,
-		"sandbox",
-		"danger-full-access",
-		"on-request",
-		"user",
-	)
-}
-
-func assertCodexAppServerApprovalAndSandboxParams(
-	t *testing.T,
-	requestName string,
-	params map[string]any,
-	sandboxKey string,
-	expectedSandbox string,
-	expectedApprovalPolicy string,
-	expectedApprovalsReviewer string,
-) {
-	t.Helper()
-
-	if got := asString(params[sandboxKey]); got != expectedSandbox {
-		t.Fatalf("%s %s = %q, want %q", requestName, sandboxKey, got, expectedSandbox)
+	if _, err := adapter.Exec(context.Background(), session, textPrompt("go"), "", "turn-local-1", nil, nil); err != nil {
+		t.Fatalf("Exec: %v", err)
 	}
-	if got := asString(params["approvalPolicy"]); got != expectedApprovalPolicy {
-		t.Fatalf("%s approvalPolicy = %q, want %q", requestName, got, expectedApprovalPolicy)
-	}
-	if got := asString(params["approvalsReviewer"]); got != expectedApprovalsReviewer {
-		t.Fatalf("%s approvalsReviewer = %q, want %q", requestName, got, expectedApprovalsReviewer)
+	turnStart := appServerRequestParams(t, transport.conn, appServerMethodTurnStart)
+	policy, _ := turnStart["sandboxPolicy"].(map[string]any)
+	if _, ok := policy["networkAccess"]; ok {
+		t.Fatalf("turn/start sandboxPolicy = %#v, want legacy network default", policy)
 	}
 }
 
@@ -1732,6 +1718,7 @@ func TestCodexAppServerTurnStartKeepsLargePromptInInputOnly(t *testing.T) {
 		nil,
 		nil,
 		"",
+		false,
 	)
 	if _, ok := params["responsesapiClientMetadata"]; ok {
 		t.Fatalf("responsesapiClientMetadata = %#v, want omitted", params["responsesapiClientMetadata"])
@@ -6568,7 +6555,17 @@ func TestCodexAppServerAdapterApplyPermissionModeUpdatesState(t *testing.T) {
 func TestCodexAppServerAdapterApplyPermissionModeSucceedsMidTurnAndAppliesNextTurn(t *testing.T) {
 	t.Parallel()
 
-	adapter, transport, session := startedAppServerAdapter(t)
+	transport := newScriptedAppServerTransport()
+	adapter := NewCodexAppServerAdapterWithHostMetadataAndOptions(
+		transport,
+		LegacyHostMetadata(),
+		CodexAppServerAdapterOptions{CommandNetworkAccess: true},
+	)
+	session := testAppServerSession()
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session.ProviderSessionID = "codex-thread-1"
 	session.PermissionModeID = "read-only"
 	transport.conn.holdTurn = true
 
@@ -6586,6 +6583,13 @@ func TestCodexAppServerAdapterApplyPermissionModeSucceedsMidTurnAndAppliesNextTu
 	firstTurnStart := appServerRequestParams(t, transport.conn, appServerMethodTurnStart)
 	if asString(firstTurnStart["approvalPolicy"]) != "on-request" {
 		t.Fatalf("first turn/start approvalPolicy = %#v, want on-request", firstTurnStart["approvalPolicy"])
+	}
+	firstPolicy, _ := firstTurnStart["sandboxPolicy"].(map[string]any)
+	if asString(firstPolicy["type"]) != "readOnly" {
+		t.Fatalf("first turn/start sandboxPolicy = %#v, want readOnly", firstPolicy)
+	}
+	if enabled, _ := firstPolicy["networkAccess"].(bool); !enabled {
+		t.Fatalf("first turn/start sandboxPolicy = %#v, want networkAccess=true", firstPolicy)
 	}
 
 	session.PermissionModeID = "full-access"
@@ -6615,6 +6619,13 @@ func TestCodexAppServerAdapterApplyPermissionModeSucceedsMidTurnAndAppliesNextTu
 	}
 	if asString(turnStarts[1]["approvalPolicy"]) != "never" {
 		t.Fatalf("second turn/start approvalPolicy = %#v, want never", turnStarts[1]["approvalPolicy"])
+	}
+	secondPolicy, _ := turnStarts[1]["sandboxPolicy"].(map[string]any)
+	if asString(secondPolicy["type"]) != "dangerFullAccess" {
+		t.Fatalf("second turn/start sandboxPolicy = %#v, want dangerFullAccess", secondPolicy)
+	}
+	if _, ok := secondPolicy["networkAccess"]; ok {
+		t.Fatalf("second turn/start sandboxPolicy = %#v, want implicit full-access networking", secondPolicy)
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_event_params.go
+++ b/packages/agent/daemon/runtime/codex_appserver_event_params.go
@@ -16,18 +16,6 @@ func appServerThreadReasoningSummaryConfig(model string) string {
 }
 
 func appServerThreadStartParams(session Session, cwd string) map[string]any {
-	return appServerThreadStartParamsWithSandboxPolicy(
-		session,
-		cwd,
-		CodexAppServerSandboxPolicyPermissionMode,
-	)
-}
-
-func appServerThreadStartParamsWithSandboxPolicy(
-	session Session,
-	cwd string,
-	sandboxPolicy CodexAppServerSandboxPolicy,
-) map[string]any {
 	settings := session.SettingsValue()
 	params := map[string]any{
 		"cwd": firstNonEmpty(cwd, "/"),
@@ -51,7 +39,7 @@ func appServerThreadStartParamsWithSandboxPolicy(
 	if approvalPolicy := codexAppServerApprovalPolicy(session.PermissionModeID); approvalPolicy != "" {
 		params["approvalPolicy"] = approvalPolicy
 	}
-	if sandbox := codexAppServerSandboxMode(session.PermissionModeID, sandboxPolicy); sandbox != "" {
+	if sandbox := codexAppServerSandboxMode(session.PermissionModeID); sandbox != "" {
 		params["sandbox"] = sandbox
 	}
 	if approvalsReviewer := codexAppServerApprovalsReviewer(session.PermissionModeID); approvalsReviewer != "" {
@@ -67,26 +55,7 @@ func appServerTurnStartParams(
 	planModeMask map[string]any,
 	defaultModeMask map[string]any,
 	defaultModel string,
-) map[string]any {
-	return appServerTurnStartParamsWithSandboxPolicy(
-		session,
-		threadID,
-		content,
-		planModeMask,
-		defaultModeMask,
-		defaultModel,
-		CodexAppServerSandboxPolicyPermissionMode,
-	)
-}
-
-func appServerTurnStartParamsWithSandboxPolicy(
-	session Session,
-	threadID string,
-	content []PromptContentBlock,
-	planModeMask map[string]any,
-	defaultModeMask map[string]any,
-	defaultModel string,
-	sandboxPolicy CodexAppServerSandboxPolicy,
+	commandNetworkAccess bool,
 ) map[string]any {
 	settings := session.SettingsValue()
 	params := map[string]any{
@@ -108,8 +77,8 @@ func appServerTurnStartParamsWithSandboxPolicy(
 	if approvalPolicy := codexAppServerApprovalPolicy(session.PermissionModeID); approvalPolicy != "" {
 		params["approvalPolicy"] = approvalPolicy
 	}
-	if policy := codexAppServerTurnSandboxPolicy(session.PermissionModeID, sandboxPolicy); policy != nil {
-		params["sandboxPolicy"] = policy
+	if sandboxPolicy := codexAppServerSandboxPolicy(session.PermissionModeID, commandNetworkAccess); sandboxPolicy != nil {
+		params["sandboxPolicy"] = sandboxPolicy
 	}
 	if approvalsReviewer := codexAppServerApprovalsReviewer(session.PermissionModeID); approvalsReviewer != "" {
 		params["approvalsReviewer"] = approvalsReviewer
@@ -339,15 +308,8 @@ func codexAppServerApprovalPolicy(modeID string) string {
 	}
 }
 
-func codexAppServerSandboxMode(modeID string, policy CodexAppServerSandboxPolicy) string {
-	modeID = codexACPModeID(modeID)
-	if modeID == "" {
-		return ""
-	}
-	if policy == CodexAppServerSandboxPolicyDangerFullAccess {
-		return "danger-full-access"
-	}
-	switch modeID {
+func codexAppServerSandboxMode(modeID string) string {
+	switch codexACPModeID(modeID) {
 	case "read-only":
 		return "read-only"
 	case "auto":
@@ -359,24 +321,22 @@ func codexAppServerSandboxMode(modeID string, policy CodexAppServerSandboxPolicy
 	}
 }
 
-func codexAppServerTurnSandboxPolicy(modeID string, policy CodexAppServerSandboxPolicy) map[string]any {
-	modeID = codexACPModeID(modeID)
-	if modeID == "" {
-		return nil
-	}
-	if policy == CodexAppServerSandboxPolicyDangerFullAccess {
-		return map[string]any{"type": "dangerFullAccess"}
-	}
-	switch modeID {
+func codexAppServerSandboxPolicy(modeID string, commandNetworkAccess bool) map[string]any {
+	var policy map[string]any
+	switch codexACPModeID(modeID) {
 	case "read-only":
-		return map[string]any{"type": "readOnly"}
+		policy = map[string]any{"type": "readOnly"}
 	case "auto":
-		return map[string]any{"type": "workspaceWrite"}
+		policy = map[string]any{"type": "workspaceWrite"}
 	case "full-access":
 		return map[string]any{"type": "dangerFullAccess"}
 	default:
 		return nil
 	}
+	if commandNetworkAccess {
+		policy["networkAccess"] = true
+	}
+	return policy
 }
 
 func codexAppServerApprovalsReviewer(modeID string) string {

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -77,7 +77,7 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 	}
 	planModeMask, defaultModeMask := a.fetchCollaborationModeMasks(ctx, client, session, trace)
 
-	threadParams := appServerThreadStartParamsWithSandboxPolicy(session, a.sessionCWD(session), a.config.sandboxPolicy)
+	threadParams := appServerThreadStartParams(session, a.sessionCWD(session))
 	trace.Log("thread.start.params", codexAppServerTraceThreadStartParams(session, threadParams, false))
 	threadResult, err := trace.TypedCall(acpStartCallTimeout, appServerMethodThreadStart, func() (json.RawMessage, error) {
 		return client.ThreadStart(ctx, acpStartCallTimeout, threadParams,
@@ -232,7 +232,7 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) (er
 	}
 	planModeMask, defaultModeMask := a.fetchCollaborationModeMasks(ctx, client, session, trace)
 
-	params := appServerThreadStartParamsWithSandboxPolicy(session, a.sessionCWD(session), a.config.sandboxPolicy)
+	params := appServerThreadStartParams(session, a.sessionCWD(session))
 	params["threadId"] = strings.TrimSpace(session.ProviderSessionID)
 	trace.Log("thread.start.params", codexAppServerTraceThreadStartParams(session, params, true))
 	// codex replays thread/tokenUsage/updated during thread/resume so the GUI

--- a/packages/agent/daemon/runtime/codex_appserver_turn.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn.go
@@ -356,7 +356,15 @@ func (a *CodexAppServerAdapter) execBlocking(
 	a.markTurnSettleEmits(appTurn)
 
 	trace := newCodexAppServerTurnTrace(session, turnID, execMetadataFromContext(ctx))
-	turnParams := appServerTurnStartParamsWithSandboxPolicy(session, appSession.threadID, providerContent, appSession.planModeMask, appSession.defaultModeMask, execState.defaultModel, a.config.sandboxPolicy)
+	turnParams := appServerTurnStartParams(
+		session,
+		appSession.threadID,
+		providerContent,
+		appSession.planModeMask,
+		appSession.defaultModeMask,
+		execState.defaultModel,
+		a.config.commandNetworkAccess,
+	)
 	trace.Log("turn.start.params", codexAppServerTraceTurnStartParams(session, turnParams, providerContent))
 	turnStartedAt := time.Now()
 	result, err := appSession.client.TurnStart(ctx, turnParams,


### PR DESCRIPTION
## Summary
- replace the Codex danger-full-access adapter override with command-only network access
- preserve permission-mode sandbox, approval policy, and reviewer routing
- cover read-only, auto, full-access, default compatibility, and mid-turn mode changes

## Validation
- pnpm check:changed
- push-ready changed-aware checks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->