### PR TITLE
fix(agent-host): preserve structured provider errors

### DIFF
--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -42,6 +42,14 @@ observation without starting a provider. `GetTurn` and
 adapter's concrete store. `CreateSessionInput.ClientSubmitID` and
 `SendInput.ClientSubmitID` are the typed idempotency identities and override
 the legacy metadata value when both are present.
+Runtime adapters preserve explicit downstream failures as `ProviderError` so
+Host consumers can distinguish provider-owned rejection from preparation,
+canonical-store, timeout, and other local failures with `errors.As`. The
+provider code and diagnostic text remain local observations rather than a
+stable cross-service taxonomy; coordination layers persist only their own
+coarse product reason when needed. `NewProviderError` deliberately leaves
+cancellation and deadline failures unclassified because their delivery result
+is unknown and must remain recoverable.
 `UpdateSettings` serializes with runtime resume:
 historical sessions persist settings only, while live sessions update the
 runtime. Provider-specific model, reasoning, and speed normalization stays

--- a/packages/agent/host/errors.go
+++ b/packages/agent/host/errors.go
@@ -1,6 +1,9 @@
 package agenthost
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 var (
 	ErrInvalidArgument            = errors.New("invalid agent session request")
@@ -12,3 +15,59 @@ var (
 	ErrRuntimeOperationFailed     = errors.New("agent runtime operation failed")
 	ErrGoalConsumerUnavailable    = errors.New("agent goal reconcile consumer is unavailable")
 )
+
+// ProviderError preserves a provider-owned failure across the runtime adapter
+// and Host boundary. Consumers may use errors.As to distinguish an explicit
+// downstream failure from preparation, canonical-store, timeout, and other
+// Host-local errors without parsing error text or depending on provider codes.
+//
+// Code and diagnostic text remain local observations. They are not a stable
+// cross-service taxonomy and must not be persisted as coordination metadata.
+type ProviderError struct {
+	Code         string
+	Message      string
+	DebugMessage string
+	Cause        error
+}
+
+// NewProviderError converts an adapter's structured provider observation into
+// the Host contract. Cancellation and deadline errors remain unclassified
+// because their delivery result is unknown and consumers must keep them
+// recoverable.
+func NewProviderError(code, message, debugMessage string, cause error) error {
+	if cause == nil {
+		return nil
+	}
+	if errors.Is(cause, context.Canceled) || errors.Is(cause, context.DeadlineExceeded) {
+		return cause
+	}
+	return &ProviderError{
+		Code:         code,
+		Message:      message,
+		DebugMessage: debugMessage,
+		Cause:        cause,
+	}
+}
+
+func (e *ProviderError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Code != "" {
+		return e.Code
+	}
+	if e.Cause != nil {
+		return e.Cause.Error()
+	}
+	return "agent provider error"
+}
+
+func (e *ProviderError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}

--- a/packages/agent/host/errors_test.go
+++ b/packages/agent/host/errors_test.go
@@ -1,0 +1,60 @@
+package agenthost
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestProviderErrorPreservesStructuredDiagnosticsAndCause(t *testing.T) {
+	cause := errors.New("provider process rejected the request")
+	providerErr := &ProviderError{
+		Code:         "provider_auth_required",
+		Message:      "Agent provider needs authentication",
+		DebugMessage: "provider exited with status 1",
+		Cause:        cause,
+	}
+	wrapped := fmt.Errorf("create agent session: %w", providerErr)
+
+	var got *ProviderError
+	if !errors.As(wrapped, &got) {
+		t.Fatalf("errors.As(%v) did not preserve ProviderError", wrapped)
+	}
+	if got.Code != providerErr.Code || got.Message != providerErr.Message || got.DebugMessage != providerErr.DebugMessage {
+		t.Fatalf("ProviderError = %#v, want %#v", got, providerErr)
+	}
+	if !errors.Is(wrapped, cause) {
+		t.Fatalf("errors.Is(%v, cause) = false", wrapped)
+	}
+}
+
+func TestProviderErrorFallsBackWithoutInventingAStableCode(t *testing.T) {
+	cause := errors.New("provider unavailable")
+	providerErr := &ProviderError{Cause: cause}
+	if got := providerErr.Error(); got != cause.Error() {
+		t.Fatalf("Error() = %q, want %q", got, cause.Error())
+	}
+	if providerErr.Code != "" {
+		t.Fatalf("Code = %q, want no invented provider taxonomy", providerErr.Code)
+	}
+}
+
+func TestNewProviderErrorLeavesDeliveryUnknownContextErrorsRecoverable(t *testing.T) {
+	for _, cause := range []error{
+		fmt.Errorf("provider start: %w", context.Canceled),
+		fmt.Errorf("provider start: %w", context.DeadlineExceeded),
+	} {
+		mapped := NewProviderError("request_failed", "Provider request failed", "timeout", cause)
+		var providerErr *ProviderError
+		if errors.As(mapped, &providerErr) {
+			t.Fatalf("NewProviderError(%v) = %#v, want unclassified context error", cause, providerErr)
+		}
+		if !errors.Is(mapped, cause) {
+			t.Fatalf("NewProviderError(%v) did not preserve original error", cause)
+		}
+	}
+	if mapped := NewProviderError("request_failed", "Provider request failed", "", nil); mapped != nil {
+		t.Fatalf("NewProviderError(nil) = %v, want nil", mapped)
+	}
+}

--- a/services/tuttid/agent_runtime_adapter.go
+++ b/services/tuttid/agent_runtime_adapter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 )
@@ -548,6 +549,10 @@ func mapAgentRuntimeError(err error) error {
 	}
 	if errors.Is(err, agentruntime.ErrPromptImageUnsupported) {
 		return agentservice.ErrPromptImageUnsupported
+	}
+	var appErr *agentruntime.AppError
+	if errors.As(err, &appErr) && appErr != nil {
+		return agenthost.NewProviderError(appErr.Code, appErr.Message, appErr.DebugMessage, appErr)
 	}
 	return err
 }

--- a/services/tuttid/agent_runtime_adapter_test.go
+++ b/services/tuttid/agent_runtime_adapter_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 )
 
@@ -29,6 +31,45 @@ func TestMapAgentRuntimeErrorPreservesInteractiveRecoveryCodes(t *testing.T) {
 		if err := mapAgentRuntimeError(test.runtimeErr); !errors.Is(err, test.serviceErr) {
 			t.Fatalf("mapAgentRuntimeError(%v) = %v, want %v", test.runtimeErr, err, test.serviceErr)
 		}
+	}
+}
+
+func TestMapAgentRuntimeErrorPreservesStructuredProviderFailure(t *testing.T) {
+	cause := errors.New("provider process rejected startup")
+	runtimeErr := &agentruntime.AppError{
+		Code:         "provider_auth_required",
+		Message:      "Agent provider needs authentication",
+		DebugMessage: "provider exited with status 1",
+		Cause:        cause,
+	}
+
+	mapped := mapAgentRuntimeError(fmt.Errorf("runtime start: %w", runtimeErr))
+	var providerErr *agenthost.ProviderError
+	if !errors.As(mapped, &providerErr) {
+		t.Fatalf("mapped error = %v, want ProviderError", mapped)
+	}
+	if providerErr.Code != runtimeErr.Code || providerErr.Message != runtimeErr.Message || providerErr.DebugMessage != runtimeErr.DebugMessage {
+		t.Fatalf("ProviderError = %#v, want diagnostics from %#v", providerErr, runtimeErr)
+	}
+	if !errors.Is(mapped, cause) || !errors.Is(mapped, runtimeErr) {
+		t.Fatalf("mapped error did not preserve runtime error chain: %v", mapped)
+	}
+}
+
+func TestMapAgentRuntimeErrorDoesNotClassifyProviderTimeoutAsDefinitive(t *testing.T) {
+	runtimeErr := &agentruntime.AppError{
+		Code:    "request_failed",
+		Message: "Agent provider request failed",
+		Cause:   fmt.Errorf("provider response: %w", context.DeadlineExceeded),
+	}
+
+	mapped := mapAgentRuntimeError(runtimeErr)
+	var providerErr *agenthost.ProviderError
+	if errors.As(mapped, &providerErr) {
+		t.Fatalf("mapped error = %#v, want recoverable timeout", providerErr)
+	}
+	if !errors.Is(mapped, context.DeadlineExceeded) {
+		t.Fatalf("mapped error = %v, want deadline in error chain", mapped)
 	}
 }
 


### PR DESCRIPTION
## What changed

- add the provider-neutral `agenthost.ProviderError` contract for structured downstream failures
- add `NewProviderError`, which deliberately leaves cancellation and deadline errors unclassified because delivery remains unknown
- translate daemon runtime `AppError` values at the tuttid runtime adapter boundary while preserving code, safe message, debug detail, and the original error chain
- document that provider diagnostics remain local observations and are not a cross-service error taxonomy

## Why

Host consumers currently receive the same `error` shape for explicit provider rejection and for preparation, canonical-store, timeout, or other local failures. A downstream consumer such as TSH cannot safely terminalize a pre-canonical provider failure without parsing strings or incorrectly treating retryable infrastructure errors as definitive.

This is intentionally a minimal classification contract. It does not add provider-specific codes or change session/Turn lifecycle semantics; it preserves an existing runtime `AppError` marker across the Host boundary.

Does tsh or another Host consumer need this behavior? Yes. That is why the contract lives in `packages/agent/host`, while each runtime adapter owns translation from its concrete runtime error type.

## Impact and risk

- existing untyped errors remain unchanged
- context cancellation and deadline failures remain recoverable/unclassified
- `errors.As` and `errors.Is` continue to work through wrapping
- no transport, persistence, generated API, or provider-specific behavior changes

## Verification

- `go test ./packages/agent/host/...`
- `go test ./services/tuttid -run 'TestMapAgentRuntimeError' -count=1`
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`
