### PR TITLE
test(agent-gui): add performance trace runner

### DIFF
--- a/apps/desktop/src/main/defaults.test.ts
+++ b/apps/desktop/src/main/defaults.test.ts
@@ -137,6 +137,7 @@ test("resolveDesktopUserDataPath isolates development Electron storage", () => {
 
   try {
     process.env.TUTTI_ENV = "development";
+    delete process.env.TUTTI_DESKTOP_USER_DATA_DIR;
 
     assert.equal(
       resolveDesktopUserDataPath({
@@ -150,11 +151,32 @@ test("resolveDesktopUserDataPath isolates development Electron storage", () => {
   }
 });
 
+test("resolveDesktopUserDataPath honors an explicit diagnostic override", () => {
+  const previousEnv = { ...process.env };
+
+  try {
+    process.env.TUTTI_ENV = "development";
+    process.env.TUTTI_DESKTOP_USER_DATA_DIR =
+      " /tmp/tutti-desktop-performance-profile ";
+
+    assert.equal(
+      resolveDesktopUserDataPath({
+        appDataDir: "/tmp/app-data",
+        appName: "Tutti"
+      }),
+      "/tmp/tutti-desktop-performance-profile"
+    );
+  } finally {
+    restoreEnv(previousEnv);
+  }
+});
+
 test("resolveDesktopUserDataPath keeps production on Electron defaults", () => {
   const previousEnv = { ...process.env };
 
   try {
     process.env.TUTTI_ENV = "production";
+    delete process.env.TUTTI_DESKTOP_USER_DATA_DIR;
 
     assert.equal(
       resolveDesktopUserDataPath({

--- a/apps/desktop/src/main/defaults.ts
+++ b/apps/desktop/src/main/defaults.ts
@@ -51,6 +51,11 @@ export function resolveDesktopUserDataPath(options: {
   appDataDir: string;
   appName: string;
 }): string | null {
+  const override = process.env.TUTTI_DESKTOP_USER_DATA_DIR?.trim();
+  if (override) {
+    return override;
+  }
+
   if (resolveTuttiEnv() !== "development") {
     return null;
   }

--- a/apps/desktop/src/main/developerLogs.ts
+++ b/apps/desktop/src/main/developerLogs.ts
@@ -541,6 +541,7 @@ function collectRuntimeOverrides(): Record<string, string> {
     "TUTTI_DESKTOP_LOG_PATH",
     "TUTTI_DESKTOP_LOG_OUTPUT",
     "TUTTI_DESKTOP_LOG_LEVEL",
+    "TUTTI_DESKTOP_USER_DATA_DIR",
     "TUTTI_SESSION_ID"
   ] as const;
 

--- a/apps/desktop/src/main/ipc/hostWindow.ts
+++ b/apps/desktop/src/main/ipc/hostWindow.ts
@@ -14,6 +14,7 @@ import {
   resolveStandaloneAgentWindowContentWidth,
   shouldAnimateStandaloneAgentWindowResize
 } from "../windows/standaloneAgentWindowBounds";
+import { toggleHostWindowMaximize } from "../windows/hostWindowMaximize";
 
 const maxCapturePreviewDimensionPx = 512;
 const capturePreviewTimeoutMs = 2_000;
@@ -212,10 +213,10 @@ export function registerHostWindowIpc(deps: HostWindowIpcDependencies): void {
         return;
       }
 
-      // The standalone agent window's green control is a real (native)
-      // fullscreen toggle. Native maximize/zoom is disabled for this window
-      // (maximizable: false), so fullscreen is the only fill state to track.
-      ownerWindow.setFullScreen(!ownerWindow.isFullScreen());
+      toggleHostWindowMaximize(
+        ownerWindow,
+        getWorkspaceWindowKind(ownerWindow)
+      );
     }
   );
 }

--- a/apps/desktop/src/main/windows/hostWindowMaximize.test.ts
+++ b/apps/desktop/src/main/windows/hostWindowMaximize.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  toggleHostWindowMaximize,
+  type HostWindowMaximizePort
+} from "./hostWindowMaximize.ts";
+
+test("host window maximize toggles workspace maximize state", () => {
+  const state = createWindowState();
+  toggleHostWindowMaximize(state.window, "workspace");
+  assert.equal(state.maximized, true);
+  assert.equal(state.fullScreen, false);
+
+  toggleHostWindowMaximize(state.window, "workspace");
+  assert.equal(state.maximized, false);
+  assert.equal(state.fullScreen, false);
+});
+
+test("host window maximize keeps Agent windows on native fullscreen", () => {
+  const state = createWindowState();
+  toggleHostWindowMaximize(state.window, "agent");
+  assert.equal(state.fullScreen, true);
+  assert.equal(state.maximized, false);
+
+  toggleHostWindowMaximize(state.window, "agent");
+  assert.equal(state.fullScreen, false);
+});
+
+function createWindowState(): {
+  fullScreen: boolean;
+  maximized: boolean;
+  window: HostWindowMaximizePort;
+} {
+  const state = {
+    fullScreen: false,
+    maximized: false,
+    window: null as unknown as HostWindowMaximizePort
+  };
+  state.window = {
+    isFullScreen: () => state.fullScreen,
+    isMaximized: () => state.maximized,
+    maximize: () => {
+      state.maximized = true;
+    },
+    setFullScreen: (fullScreen) => {
+      state.fullScreen = fullScreen;
+    },
+    unmaximize: () => {
+      state.maximized = false;
+    }
+  };
+  return state;
+}

--- a/apps/desktop/src/main/windows/hostWindowMaximize.ts
+++ b/apps/desktop/src/main/windows/hostWindowMaximize.ts
@@ -1,0 +1,24 @@
+export interface HostWindowMaximizePort {
+  isFullScreen(): boolean;
+  isMaximized(): boolean;
+  maximize(): void;
+  setFullScreen(fullScreen: boolean): void;
+  unmaximize(): void;
+}
+
+export function toggleHostWindowMaximize(
+  hostWindow: HostWindowMaximizePort,
+  windowKind: "agent" | "workspace" | null
+): void {
+  if (windowKind === "agent") {
+    hostWindow.setFullScreen(!hostWindow.isFullScreen());
+    return;
+  }
+  if (windowKind === "workspace") {
+    if (hostWindow.isMaximized()) {
+      hostWindow.unmaximize();
+    } else {
+      hostWindow.maximize();
+    }
+  }
+}

--- a/docs/architecture/desktop-windows.md
+++ b/docs/architecture/desktop-windows.md
@@ -152,6 +152,9 @@ The renderer still shares one preload entry and one renderer bundle today. Separ
 Agent-only windows also share host-window preload capabilities; their
 AgentGUI header close, minimize, and maximize controls call typed host window
 IPC instead of relying on native traffic lights.
+The shared maximize capability preserves each native shell's semantics:
+Agent-only windows toggle fullscreen because native zoom is disabled, while OS
+workspace windows toggle BrowserWindow maximize and unmaximize.
 The Agent-only shell places Browser and other desktop-owned auxiliary tools in
 a right sidebar, while Terminal opens in a bottom tray below the conversation.
 When the sidebar is closed, its Apps and Message Center quick actions expose

--- a/docs/conventions/local-state-storage.md
+++ b/docs/conventions/local-state-storage.md
@@ -20,6 +20,8 @@ This rule applies to local databases, logs, caches, temporary runtime metadata, 
 - `TUTTI_ENV=development` uses `~/.tutti-dev`
 - `TUTTI_ENV=production` uses `~/.tutti`
 - `TUTTI_STATE_DIR=/custom/path` overrides both defaults
+- `TUTTI_DESKTOP_USER_DATA_DIR=/custom/path` overrides Electron `userData`
+  only, for isolated desktop diagnostics
 
 These environment variables are for development, test, packaging, and diagnostics overrides.
 They are not the primary source of product defaults.
@@ -37,6 +39,7 @@ Current supported override surface for local state and closely-related runtime p
 - `TUTTI_ENV`
 - `TUTTI_STATE_DIR`
 - `TUTTI_LOG_DIR`
+- `TUTTI_DESKTOP_USER_DATA_DIR`
 - `TUTTID_DB_PATH`
 - `TUTTID_RUN_DIR`
 - `TUTTID_PID_PATH`
@@ -47,6 +50,8 @@ Rules:
 
 - treat these variables as developer and operator escape hatches, not product settings
 - prefer `TUTTI_STATE_DIR` over adding new per-file overrides
+- keep `TUTTI_DESKTOP_USER_DATA_DIR` paired with an isolated
+  `TUTTI_STATE_DIR`; it does not redirect daemon-owned state
 - do not add a new environment variable when an existing shared root or generated default can express the same rule
 - if a new override is truly needed, update this document and the matching transport or logging convention document in the same change
 

--- a/docs/conventions/runtime-overrides.md
+++ b/docs/conventions/runtime-overrides.md
@@ -13,17 +13,18 @@ Use the owner documents linked below for detailed behavior. This file exists to 
 
 ## Local State And Runtime Paths
 
-| Variable                    | Owner document                                                                                             | Purpose                                                                              |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `TUTTI_ENV`                 | [Local State Storage](./local-state-storage.md)                                                            | Selects production or development default state roots.                               |
-| `TUTTI_STATE_DIR`           | [Local State Storage](./local-state-storage.md)                                                            | Overrides the shared local state root.                                               |
-| `TUTTI_LOG_DIR`             | [Local State Storage](./local-state-storage.md), [Logging](./logging.md)                                   | Overrides the shared log directory under the state model.                            |
-| `TUTTID_DB_PATH`            | [Local State Storage](./local-state-storage.md)                                                            | Overrides the daemon SQLite database path for narrow operational needs.              |
-| `TUTTID_RUN_DIR`            | [Local State Storage](./local-state-storage.md)                                                            | Overrides listener-info and pid paths, but not the state-root ownership lock.        |
-| `TUTTID_PID_PATH`           | [Local State Storage](./local-state-storage.md)                                                            | Overrides the daemon pid file, but not the state-root ownership lock.                |
-| `TUTTID_LISTENER_INFO_PATH` | [Local State Storage](./local-state-storage.md), [Desktop Transport](../architecture/desktop-transport.md) | Overrides the listener-info file path used by managed desktop-to-daemon transport.   |
-| `CODEX_HOME`                | [Local State Storage](./local-state-storage.md)                                                            | Injected per Codex agent run by tuttid; points at the run-scoped `codex-home`.       |
-| `TUTTI_AGENT_HOME`          | [Local State Storage](./local-state-storage.md)                                                            | Injected per Tutti Agent run by tuttid; points at the run-scoped `tutti-agent-home`. |
+| Variable                      | Owner document                                                                                             | Purpose                                                                              |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `TUTTI_ENV`                   | [Local State Storage](./local-state-storage.md)                                                            | Selects production or development default state roots.                               |
+| `TUTTI_STATE_DIR`             | [Local State Storage](./local-state-storage.md)                                                            | Overrides the shared local state root.                                               |
+| `TUTTI_DESKTOP_USER_DATA_DIR` | [Local State Storage](./local-state-storage.md), [Scripts](../../tools/scripts/README.md)                  | Overrides Electron `userData` for isolated desktop diagnostics.                      |
+| `TUTTI_LOG_DIR`               | [Local State Storage](./local-state-storage.md), [Logging](./logging.md)                                   | Overrides the shared log directory under the state model.                            |
+| `TUTTID_DB_PATH`              | [Local State Storage](./local-state-storage.md)                                                            | Overrides the daemon SQLite database path for narrow operational needs.              |
+| `TUTTID_RUN_DIR`              | [Local State Storage](./local-state-storage.md)                                                            | Overrides listener-info and pid paths, but not the state-root ownership lock.        |
+| `TUTTID_PID_PATH`             | [Local State Storage](./local-state-storage.md)                                                            | Overrides the daemon pid file, but not the state-root ownership lock.                |
+| `TUTTID_LISTENER_INFO_PATH`   | [Local State Storage](./local-state-storage.md), [Desktop Transport](../architecture/desktop-transport.md) | Overrides the listener-info file path used by managed desktop-to-daemon transport.   |
+| `CODEX_HOME`                  | [Local State Storage](./local-state-storage.md)                                                            | Injected per Codex agent run by tuttid; points at the run-scoped `codex-home`.       |
+| `TUTTI_AGENT_HOME`            | [Local State Storage](./local-state-storage.md)                                                            | Injected per Tutti Agent run by tuttid; points at the run-scoped `tutti-agent-home`. |
 
 ## Workspace App Catalog
 

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -76,6 +76,52 @@ without a second registry.
 Changed-aware validation must recognize every current `go.work` module so a Go
 file change selects the matching package lint and test lanes.
 
+## Local Performance Reports
+
+`pnpm perf:agent-gui` captures and analyzes an AgentGUI interaction scenario
+without requiring a manually started Desktop or manually exported trace. It
+makes a transactionally consistent SQLite backup of
+`~/.tutti-dev/tuttid.db`, clears recoverable operation queues and active AgentGUI
+session selection only in that copy, then starts an isolated daemon and
+Electron `userData` directory. The source database is never opened for writes.
+
+Reports and traces are written under
+`.tmp/perf/agent-gui/<scenario>/<timestamp>/`. Metric values are
+report-only and do not fail the command; startup, scenario, capture, or analysis
+failures return a non-zero exit code. This command is local diagnostics, not a
+CI performance gate or a stable benchmark fixture.
+
+The report separates semantic scenario assertions from performance metrics. It
+shows start-to-selection, selection-to-stable, and settling phases; restricts
+task, layout, paint, and event totals to the selected `CrRendererMain`; and
+labels the performance verdict `ungraded` when no comparable baseline or
+threshold exists. React component rows link to an unambiguous repository
+declaration when static symbol matching succeeds. Those links identify source
+ownership, not a runtime call stack or proof of causation.
+
+The capture runner ships `provider-switch`, `session-switch`,
+`provider-session-cycle`, `workbench-window-lifecycle`, and
+`desktop-window-state`. List them with `--list-scenarios`; select one with
+`--scenario <id>`. Scenario modules own preparation, completion conditions,
+semantic assertions, milestones, and metadata; runtime startup, trace capture,
+renderer analysis, and report rendering stay scenario-neutral.
+
+`workbench-window-lifecycle` measures the internal AgentGUI Workbench node's
+minimize, restore, maximize, unmaximize, close, and reopen mechanics.
+`desktop-window-state` measures the owning Electron window's minimize, restore,
+maximize, and unmaximize states through typed host-window APIs and is currently
+macOS-only because only that host emits typed minimize-state events. Native
+close/reopen is not part of that renderer-marked scenario because closing the
+owning native window destroys the renderer that owns the trace boundary
+markers. Every declared milestone is required in the captured trace; a missing
+marker fails capture instead of silently producing an incomplete phase table.
+
+Daemon migrations remain forward-only. If the personal dev database was last
+opened by a newer checkout with incompatible Agent target migrations, the
+command fails before Desktop startup and lists them; use a compatible checkout
+or pass a compatible snapshot with `--source-db`. The runner never attempts to
+downgrade or rewrite the source database.
+
 ## Agent Daemon Blocking Gate
 
 `packages/agent/daemon` is part of the blocking Go workspace test set. A failure

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "dev:web": "node ./tools/scripts/dev-web.mjs",
     "dev:ui-storyboard": "pnpm --filter @tutti-os/ui-storyboard dev",
     "preview:desktop": "pnpm --filter @tutti-os/desktop preview",
+    "perf:agent-gui": "node ./tools/scripts/run-agent-gui-performance.mjs",
     "push:checked": "node ./tools/scripts/push-checked.mjs",
     "generate:api": "node ./tools/scripts/generate-openapi.mjs",
     "generate:agent-gui-provider-catalog": "node ./tools/scripts/generate-agent-gui-provider-catalog.mjs",

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -29,6 +29,10 @@ Current examples include:
 - `capture-electron-trace.mjs` for recording desktop Electron performance
   traces through CDP stream mode without opening the DevTools Performance export
   UI
+- `run-agent-gui-performance.mjs` for starting an isolated Desktop from a
+  consistent backup of the developer database, running a selected AgentGUI or
+  window interaction, capturing its exact trace window, and generating
+  report-only JSON and Markdown summaries
 - `lark-log-tool.mjs` for fetching Feishu/Lark message file attachments or Base bug-record attachments with `lark-cli`, extracting Tutti log bundles, summarizing repeated log failures around an anchor time, and optionally watching appended warn/error lines in real time
 
   ```bash
@@ -69,3 +73,50 @@ make dev-gui
 
 pnpm trace:desktop -- --duration 15
 ```
+
+Automated AgentGUI performance reports:
+
+```bash
+pnpm perf:agent-gui
+pnpm perf:agent-gui -- --list-scenarios
+pnpm perf:agent-gui -- --scenario session-switch
+```
+
+The command reads `~/.tutti-dev/tuttid.db` by default and uses SQLite online
+backup to create a temporary copy. It never writes the source database. The
+copy keeps projects, sessions, and rail data, but clears recoverable operation
+queues and the selected AgentGUI session before starting an isolated daemon and
+Electron `userData` directory. This prevents the diagnostic run from resuming a
+real provider session while avoiding a schema-sensitive fixture.
+
+Outputs are stored under
+`.tmp/perf/agent-gui/<scenario>/<timestamp>/`: `trace.json`,
+`report.json`, `report.md`, and `desktop.log`. Metric values are report-only;
+only infrastructure, scenario, trace, or analysis failures return a non-zero
+exit code. Available scenarios cover one Provider switch, one Session switch,
+two Provider/Session switching rounds, internal Workbench window lifecycle, and
+native Electron window state changes. The native window scenario is currently
+macOS-only because its minimize completion signal comes from the typed macOS
+host event. Use `--source-db`, `--from-target-id`, or `--to-target-id` to
+override the defaults.
+
+The Markdown report contains scenario assertions, observed milestone phases,
+renderer-main `RunTask`/layout/paint metrics, React component fanout, and static
+repository declaration links for components that resolve unambiguously. It
+reports `ungraded` without a comparable baseline; it does not turn raw duration
+or render counts into a pass/fail verdict. Source links are ownership hints,
+not runtime stack attribution.
+
+`analyze-electron-trace.mjs` is marker- and scenario-neutral. Interactive
+automation lives in scenario modules registered by
+`agent-gui-performance-scenarios.mjs`; each owns preparation, execution,
+milestones, completion, and assertions. New scenarios should reuse the runner
+and analyzer through that boundary. Native close/reopen is intentionally not
+mixed into the renderer-marked native-window scenario because it destroys the
+renderer that owns the start/end markers.
+
+SQLite migrations are forward-only. If the developer database was last opened
+by a newer checkout with incompatible Agent target migrations, the command
+reports them before starting Desktop. Use the matching checkout or provide a
+compatible snapshot through `--source-db`; the runner does not downgrade the
+source.

--- a/tools/scripts/agent-gui-performance-helpers.mjs
+++ b/tools/scripts/agent-gui-performance-helpers.mjs
@@ -1,0 +1,326 @@
+import { setTimeout as delay } from "node:timers/promises";
+
+const conversationItemPrefix = "agent-gui-conversation-item-";
+
+export async function evaluate(client, expression, awaitPromise = false) {
+  const response = await client.send("Runtime.evaluate", {
+    expression,
+    awaitPromise,
+    returnByValue: true,
+    userGesture: true
+  });
+  if (response.exceptionDetails) {
+    const description =
+      response.exceptionDetails.exception?.description ??
+      response.exceptionDetails.text ??
+      "renderer evaluation failed";
+    throw new Error(description);
+  }
+  return response.result?.value;
+}
+
+export async function waitForEvaluation(
+  client,
+  expression,
+  timeoutMs,
+  label,
+  intervalMs = 250
+) {
+  const deadline = Date.now() + timeoutMs;
+  let latest;
+  while (Date.now() < deadline) {
+    latest = await evaluate(client, expression);
+    if (latest?.ready) return latest;
+    await delay(intervalMs);
+  }
+  throw new Error(`timed out waiting for ${label}: ${JSON.stringify(latest)}`);
+}
+
+export async function markRenderer(client, marker) {
+  await evaluate(client, `console.timeStamp(${JSON.stringify(marker)}); true`);
+}
+
+export async function startRendererScenario(client, marker) {
+  await markRenderer(client, marker);
+}
+
+export async function finishRendererScenario(client, marker) {
+  await evaluate(
+    client,
+    `new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(() => {
+      console.timeStamp(${JSON.stringify(marker)});
+      resolve(true);
+    }, 250))))`,
+    true
+  );
+}
+
+export async function waitForProviderTiles(client, timeoutMs) {
+  return waitForEvaluation(
+    client,
+    `(() => {
+      const elements = [...document.querySelectorAll('[data-provider-target-id]')];
+      const tiles = elements.map((element) => ({
+        targetID: element.dataset.providerTargetId ?? '',
+        disabled: element.hasAttribute('disabled') || element.dataset.disabled === 'true'
+      }));
+      return {
+        ready: tiles.filter((tile) => tile.targetID && !tile.disabled).length >= 2,
+        tiles,
+        selectedTargetID: elements.find((element) => element.dataset.selected === 'true')?.dataset.providerTargetId ?? null
+      };
+    })()`,
+    timeoutMs,
+    "provider rail with two enabled targets"
+  );
+}
+
+export async function clickProviderTarget(client, targetID) {
+  await evaluate(
+    client,
+    `(() => {
+      const target = [...document.querySelectorAll('[data-provider-target-id]')]
+        .find((element) => element.dataset.providerTargetId === ${JSON.stringify(targetID)});
+      if (!(target instanceof HTMLButtonElement)) throw new Error('provider target is unavailable');
+      target.click();
+      return true;
+    })()`
+  );
+}
+
+export async function waitForSelectedTarget(client, targetID, timeoutMs) {
+  return waitForEvaluation(
+    client,
+    `(() => {
+      const target = [...document.querySelectorAll('[data-provider-target-id]')]
+        .find((element) => element.dataset.providerTargetId === ${JSON.stringify(targetID)});
+      return { ready: target?.dataset.selected === 'true' };
+    })()`,
+    timeoutMs,
+    `selected Agent target ${targetID}`
+  );
+}
+
+export async function selectProvider(client, targetID, timeoutMs) {
+  await clickProviderTarget(client, targetID);
+  await waitForSelectedTarget(client, targetID, timeoutMs);
+  return waitForStableRail(client, targetID, timeoutMs);
+}
+
+export async function waitForStableRail(client, targetID, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let previousSignature = null;
+  let stablePolls = 0;
+  let latest = null;
+  while (Date.now() < deadline) {
+    latest = await readRail(client, targetID);
+    const signature = JSON.stringify(latest);
+    if (
+      latest.selected &&
+      latest.sectionCount > 0 &&
+      latest.loadingCount === 0 &&
+      signature === previousSignature
+    ) {
+      stablePolls += 1;
+      if (stablePolls >= 5) return latest;
+    } else {
+      stablePolls = 0;
+    }
+    previousSignature = signature;
+    await delay(200);
+  }
+  throw new Error(
+    `timed out waiting for stable AgentGUI rail: ${JSON.stringify(latest)}`
+  );
+}
+
+export async function waitForSessionItems(client, timeoutMs, minimum = 2) {
+  return waitForEvaluation(
+    client,
+    `(() => {
+      const rows = [...document.querySelectorAll('[data-testid^=${JSON.stringify(conversationItemPrefix)}]')];
+      const items = rows.map((row) => ({
+        id: row.dataset.testid?.slice(${conversationItemPrefix.length}) ?? '',
+        active: row.dataset.active === 'true'
+      })).filter((item) => item.id);
+      return {
+        ready: items.length >= ${minimum},
+        items,
+        activeSessionID: items.find((item) => item.active)?.id ?? null
+      };
+    })()`,
+    timeoutMs,
+    `AgentGUI rail with ${minimum} sessions`
+  );
+}
+
+export function selectSessionSwitchTargets(items, activeSessionID = null) {
+  const ids = items.map((item) => item.id).filter(Boolean);
+  if (ids.length < 2) {
+    throw new Error("session-switch requires at least two visible sessions");
+  }
+  const sourceSessionID = ids.includes(activeSessionID)
+    ? activeSessionID
+    : ids[0];
+  const targetSessionID = ids.find((id) => id !== sourceSessionID);
+  return { sourceSessionID, targetSessionID };
+}
+
+export async function clickSession(client, sessionID) {
+  await evaluate(
+    client,
+    `(() => {
+      const row = document.querySelector(${JSON.stringify(`[data-testid="${conversationItemPrefix}${sessionID}"]`)});
+      const button = row?.querySelector('button');
+      if (!(button instanceof HTMLButtonElement)) throw new Error('session is unavailable');
+      button.click();
+      return true;
+    })()`
+  );
+}
+
+export async function waitForActiveSession(client, sessionID, timeoutMs) {
+  return waitForEvaluation(
+    client,
+    `(() => {
+      const row = document.querySelector(${JSON.stringify(`[data-testid="${conversationItemPrefix}${sessionID}"]`)});
+      return { ready: row?.dataset.active === 'true' };
+    })()`,
+    timeoutMs,
+    `active Agent session ${sessionID}`
+  );
+}
+
+export async function selectSession(client, sessionID, targetID, timeoutMs) {
+  await clickSession(client, sessionID);
+  await waitForActiveSession(client, sessionID, timeoutMs);
+  return waitForStableRail(client, targetID, timeoutMs);
+}
+
+export async function readAgentWorkbenchWindow(client) {
+  return evaluate(
+    client,
+    `(() => {
+      const shell = [...document.querySelectorAll('[data-workbench-window-id]')]
+        .find((element) => element.dataset.workbenchNodeTypeId === 'agent-gui');
+      return shell ? {
+        id: shell.dataset.workbenchWindowId ?? '',
+        displayMode: shell.dataset.displayMode ?? '',
+        minimizedMount: shell.dataset.minimizedMount ?? '',
+        title: shell.querySelector('[data-agent-gui-workbench-header]')?.textContent?.trim() ?? ''
+      } : null;
+    })()`
+  );
+}
+
+export async function waitForStableAgentWorkbenchWindow(client, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let previousID = null;
+  let stablePolls = 0;
+  let latest = null;
+  while (Date.now() < deadline) {
+    latest = await readAgentWorkbenchWindow(client);
+    if (
+      latest?.id &&
+      latest.minimizedMount === "visible" &&
+      latest.id === previousID
+    ) {
+      stablePolls += 1;
+      if (stablePolls >= 5) return latest;
+    } else {
+      stablePolls = 0;
+    }
+    previousID = latest?.id ?? null;
+    await delay(200);
+  }
+  throw new Error(
+    `timed out waiting for stable AgentGUI Workbench window: ${JSON.stringify(latest)}`
+  );
+}
+
+export async function waitForStableViewport(client, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let previous = null;
+  let stablePolls = 0;
+  let latest = null;
+  while (Date.now() < deadline) {
+    latest = await evaluate(
+      client,
+      "({ height: window.innerHeight, width: window.innerWidth })"
+    );
+    const signature = `${latest.width}x${latest.height}`;
+    if (signature === previous) {
+      stablePolls += 1;
+      if (stablePolls >= 5) return latest;
+    } else {
+      stablePolls = 0;
+    }
+    previous = signature;
+    await delay(100);
+  }
+  throw new Error(
+    `timed out waiting for stable viewport: ${JSON.stringify(latest)}`
+  );
+}
+
+export async function waitForAgentWorkbenchWindow(
+  client,
+  timeoutMs,
+  predicateExpression = "Boolean(windowState)",
+  label = "AgentGUI Workbench window",
+  nodeID = null
+) {
+  const nodePredicate = nodeID
+    ? `element.dataset.workbenchWindowId === ${JSON.stringify(nodeID)}`
+    : "element.dataset.workbenchNodeTypeId === 'agent-gui'";
+  return waitForEvaluation(
+    client,
+    `(() => {
+      const shell = [...document.querySelectorAll('[data-workbench-window-id]')]
+        .find((element) => ${nodePredicate});
+      const windowState = shell ? {
+        id: shell.dataset.workbenchWindowId ?? '',
+        displayMode: shell.dataset.displayMode ?? '',
+        minimizedMount: shell.dataset.minimizedMount ?? ''
+      } : null;
+      return { ready: ${predicateExpression}, windowState };
+    })()`,
+    timeoutMs,
+    label
+  );
+}
+
+export async function clickAgentWindowControl(client, nodeID, testID) {
+  await evaluate(
+    client,
+    `(() => {
+      const shell = document.querySelector(${JSON.stringify(`[data-workbench-window-id="${nodeID}"]`)});
+      const button = shell?.querySelector(${JSON.stringify(`[data-testid="${testID}"]`)});
+      if (!(button instanceof HTMLButtonElement)) throw new Error('AgentGUI window control is unavailable');
+      button.click();
+      return true;
+    })()`
+  );
+}
+
+export function normalizeOptionalString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+async function readRail(client, targetID) {
+  return evaluate(
+    client,
+    `(() => {
+      const root = document.querySelector('#agent-gui-conversation-rail')?.parentElement ?? document;
+      const selected = [...document.querySelectorAll('[data-provider-target-id]')]
+        .find((element) => element.dataset.providerTargetId === ${JSON.stringify(targetID)})
+        ?.dataset.selected === 'true';
+      return {
+        selected,
+        sectionCount: root.querySelectorAll('section[data-kind]').length,
+        itemCount: root.querySelectorAll('[data-testid^=${JSON.stringify(conversationItemPrefix)}]').length,
+        loadingCount: root.querySelectorAll('[aria-busy="true"], [data-loading="true"]').length
+      };
+    })()`
+  );
+}

--- a/tools/scripts/agent-gui-performance-scenario.mjs
+++ b/tools/scripts/agent-gui-performance-scenario.mjs
@@ -1,0 +1,153 @@
+import {
+  clickProviderTarget,
+  finishRendererScenario,
+  markRenderer,
+  normalizeOptionalString,
+  selectProvider,
+  startRendererScenario,
+  waitForProviderTiles,
+  waitForSelectedTarget,
+  waitForStableRail
+} from "./agent-gui-performance-helpers.mjs";
+
+const markers = {
+  start: "tutti-perf:provider-switch:start",
+  selected: "tutti-perf:provider-switch:selected-observed",
+  stable: "tutti-perf:provider-switch:rail-stable-observed",
+  end: "tutti-perf:provider-switch:end"
+};
+
+export const providerSwitchScenario = {
+  id: "provider-switch",
+  markers,
+  milestones: [
+    {
+      key: "selected",
+      label: "target selected (observed)",
+      marker: markers.selected
+    },
+    {
+      key: "stable",
+      label: "rail stable (observed)",
+      marker: markers.stable
+    }
+  ],
+  prepare: prepareProviderSwitchScenario,
+  execute: executeProviderSwitchScenario,
+  describe(prepared) {
+    return `${prepared.sourceTargetID} -> ${prepared.targetTargetID}; ${prepared.sectionCount} sections`;
+  },
+  summarize(prepared, result) {
+    const assertions = [
+      {
+        name: "target changed",
+        passed: prepared.sourceTargetID !== prepared.targetTargetID
+      },
+      { name: "target selected", passed: result.selected === true },
+      { name: "rail contains sections", passed: result.sectionCount > 0 }
+    ];
+    return {
+      outcome: assertions.every((assertion) => assertion.passed)
+        ? "passed"
+        : "failed",
+      assertions,
+      details: [
+        {
+          label: "Provider switch",
+          value: `${prepared.sourceTargetID} → ${prepared.targetTargetID}`
+        },
+        {
+          label: "Sections",
+          value: `${prepared.sectionCount} → ${result.sectionCount}`
+        },
+        {
+          label: "Items",
+          value: `${prepared.itemCount} → ${result.itemCount}`
+        }
+      ],
+      stabilityCriterion:
+        "five identical rail snapshots at 200 ms intervals, then two animation frames plus 250 ms settling tail"
+    };
+  }
+};
+
+export async function prepareProviderSwitchScenario(context, options) {
+  const { pageClient } = context;
+  const initial = await waitForProviderTiles(pageClient, options.timeoutMs);
+  const targetSelection = selectProviderSwitchTargets(initial.tiles, {
+    fromTargetID: options.fromTargetID,
+    selectedTargetID: initial.selectedTargetID,
+    toTargetID: options.toTargetID
+  });
+  if (initial.selectedTargetID !== targetSelection.sourceTargetID) {
+    await selectProvider(
+      pageClient,
+      targetSelection.sourceTargetID,
+      options.timeoutMs
+    );
+  }
+  const stable = await waitForStableRail(
+    pageClient,
+    targetSelection.sourceTargetID,
+    options.timeoutMs
+  );
+  return {
+    ...targetSelection,
+    sectionCount: stable.sectionCount,
+    itemCount: stable.itemCount
+  };
+}
+
+export function selectProviderSwitchTargets(tiles, options = {}) {
+  const available = tiles.filter(
+    (tile) => tile.targetID && tile.disabled !== true
+  );
+  if (available.length < 2) {
+    throw new Error(
+      "provider-switch requires at least two enabled Agent targets"
+    );
+  }
+  const sourceTargetID =
+    normalizeOptionalString(options.fromTargetID) ??
+    (available.some((tile) => tile.targetID === options.selectedTargetID)
+      ? options.selectedTargetID
+      : available[0].targetID);
+  const targetTargetID =
+    normalizeOptionalString(options.toTargetID) ??
+    available.find((tile) => tile.targetID !== sourceTargetID)?.targetID;
+  if (!available.some((tile) => tile.targetID === sourceTargetID)) {
+    throw new Error(`source Agent target is not visible: ${sourceTargetID}`);
+  }
+  if (
+    !targetTargetID ||
+    targetTargetID === sourceTargetID ||
+    !available.some((tile) => tile.targetID === targetTargetID)
+  ) {
+    throw new Error(`target Agent target is not visible: ${targetTargetID}`);
+  }
+  return { sourceTargetID, targetTargetID };
+}
+
+export async function executeProviderSwitchScenario(
+  context,
+  prepared,
+  options
+) {
+  const { pageClient } = context;
+  await startRendererScenario(pageClient, markers.start);
+  await clickProviderTarget(pageClient, prepared.targetTargetID);
+  await waitForSelectedTarget(
+    pageClient,
+    prepared.targetTargetID,
+    options.timeoutMs
+  );
+  await markRenderer(pageClient, markers.selected);
+  const stable = await waitForStableRail(
+    pageClient,
+    prepared.targetTargetID,
+    options.timeoutMs
+  );
+  await markRenderer(pageClient, markers.stable);
+  await finishRendererScenario(pageClient, markers.end);
+  return stable;
+}

--- a/tools/scripts/agent-gui-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-performance-scenarios.mjs
@@ -1,0 +1,29 @@
+import { providerSwitchScenario } from "./agent-gui-performance-scenario.mjs";
+import {
+  providerSessionCycleScenario,
+  sessionSwitchScenario
+} from "./agent-gui-session-performance-scenarios.mjs";
+import {
+  desktopWindowStateScenario,
+  workbenchWindowLifecycleScenario
+} from "./agent-gui-window-performance-scenarios.mjs";
+
+export const agentGuiPerformanceScenarios = [
+  providerSwitchScenario,
+  sessionSwitchScenario,
+  providerSessionCycleScenario,
+  workbenchWindowLifecycleScenario,
+  desktopWindowStateScenario
+];
+
+export function resolveAgentGuiPerformanceScenario(id) {
+  const scenario = agentGuiPerformanceScenarios.find(
+    (candidate) => candidate.id === id
+  );
+  if (!scenario) {
+    throw new Error(
+      `unknown scenario: ${id}; available: ${agentGuiPerformanceScenarios.map((candidate) => candidate.id).join(", ")}`
+    );
+  }
+  return scenario;
+}

--- a/tools/scripts/agent-gui-session-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-session-performance-scenarios.mjs
@@ -1,0 +1,273 @@
+import {
+  clickSession,
+  finishRendererScenario,
+  markRenderer,
+  selectProvider,
+  selectSession,
+  selectSessionSwitchTargets,
+  startRendererScenario,
+  waitForActiveSession,
+  waitForProviderTiles,
+  waitForSessionItems,
+  waitForStableRail
+} from "./agent-gui-performance-helpers.mjs";
+import { selectProviderSwitchTargets } from "./agent-gui-performance-scenario.mjs";
+
+const sessionMarkers = {
+  start: "tutti-perf:session-switch:start",
+  selected: "tutti-perf:session-switch:selected-observed",
+  stable: "tutti-perf:session-switch:rail-stable-observed",
+  end: "tutti-perf:session-switch:end"
+};
+
+export const sessionSwitchScenario = {
+  id: "session-switch",
+  markers: sessionMarkers,
+  milestones: [
+    {
+      key: "selected",
+      label: "session selected (observed)",
+      marker: sessionMarkers.selected
+    },
+    {
+      key: "stable",
+      label: "rail stable (observed)",
+      marker: sessionMarkers.stable
+    }
+  ],
+  prepare: prepareSessionSwitch,
+  execute: executeSessionSwitch,
+  describe(prepared) {
+    return `${prepared.sourceSessionID} -> ${prepared.targetSessionID}`;
+  },
+  summarize(prepared, result) {
+    const assertions = [
+      {
+        name: "session changed",
+        passed: prepared.sourceSessionID !== prepared.targetSessionID
+      },
+      { name: "target session active", passed: result.targetActive },
+      { name: "rail contains sections", passed: result.sectionCount > 0 }
+    ];
+    return scenarioSummary(assertions, [
+      {
+        label: "Session switch",
+        value: `${prepared.sourceSessionID} → ${prepared.targetSessionID}`
+      },
+      { label: "Provider", value: prepared.targetID },
+      { label: "Rail items", value: String(result.itemCount) }
+    ]);
+  }
+};
+
+async function prepareSessionSwitch(context, options) {
+  const { pageClient } = context;
+  const providers = await waitForProviderTiles(pageClient, options.timeoutMs);
+  const targetID = providers.selectedTargetID ?? providers.tiles[0]?.targetID;
+  if (!targetID) throw new Error("session-switch has no selected Agent target");
+  await selectProvider(pageClient, targetID, options.timeoutMs);
+  const sessions = await waitForSessionItems(pageClient, options.timeoutMs);
+  const selection = selectSessionSwitchTargets(
+    sessions.items,
+    sessions.activeSessionID
+  );
+  if (sessions.activeSessionID !== selection.sourceSessionID) {
+    await selectSession(
+      pageClient,
+      selection.sourceSessionID,
+      targetID,
+      options.timeoutMs
+    );
+  }
+  return { ...selection, targetID };
+}
+
+async function executeSessionSwitch(context, prepared, options) {
+  const { pageClient } = context;
+  await startRendererScenario(pageClient, sessionMarkers.start);
+  await clickSession(pageClient, prepared.targetSessionID);
+  await waitForActiveSession(
+    pageClient,
+    prepared.targetSessionID,
+    options.timeoutMs
+  );
+  await markRenderer(pageClient, sessionMarkers.selected);
+  const stable = await waitForStableRail(
+    pageClient,
+    prepared.targetID,
+    options.timeoutMs
+  );
+  await markRenderer(pageClient, sessionMarkers.stable);
+  await finishRendererScenario(pageClient, sessionMarkers.end);
+  const active = await waitForActiveSession(
+    pageClient,
+    prepared.targetSessionID,
+    options.timeoutMs
+  );
+  return { ...stable, targetActive: active.ready };
+}
+
+const cycleStepDefinitions = [
+  ["provider-target-1", "provider target (round 1)"],
+  ["session-target-1", "target session (round 1)"],
+  ["provider-source-1", "provider source (round 1)"],
+  ["session-source-1", "source session (round 1)"],
+  ["provider-target-2", "provider target (round 2)"],
+  ["session-target-2", "target session (round 2)"],
+  ["provider-source-2", "provider source (round 2)"],
+  ["session-source-2", "source session (round 2)"]
+];
+
+const cycleMarkers = Object.fromEntries([
+  ["start", "tutti-perf:provider-session-cycle:start"],
+  ...cycleStepDefinitions.map(([key]) => [
+    key,
+    `tutti-perf:provider-session-cycle:${key}-observed`
+  ]),
+  ["end", "tutti-perf:provider-session-cycle:end"]
+]);
+
+export const providerSessionCycleScenario = {
+  id: "provider-session-cycle",
+  markers: cycleMarkers,
+  milestones: cycleStepDefinitions.map(([key, label]) => ({
+    key,
+    label,
+    marker: cycleMarkers[key]
+  })),
+  prepare: prepareProviderSessionCycle,
+  execute: executeProviderSessionCycle,
+  describe(prepared) {
+    return `${prepared.source.targetID} <-> ${prepared.target.targetID}; 2 rounds`;
+  },
+  summarize(prepared, result) {
+    const assertions = [
+      {
+        name: "two providers exercised",
+        passed: prepared.source.targetID !== prepared.target.targetID
+      },
+      {
+        name: "four provider switches completed",
+        passed: result.providerSwitches === 4
+      },
+      {
+        name: "four session switches completed",
+        passed: result.sessionSwitches === 4
+      },
+      {
+        name: "returned to source session",
+        passed: result.finalSessionID === prepared.source.sessions[0]
+      }
+    ];
+    return scenarioSummary(assertions, [
+      {
+        label: "Provider cycle",
+        value: `${prepared.source.targetID} ↔ ${prepared.target.targetID}`
+      },
+      { label: "Rounds", value: "2" },
+      { label: "Measured operations", value: "8" }
+    ]);
+  }
+};
+
+async function prepareProviderSessionCycle(context, options) {
+  const { pageClient } = context;
+  const providers = await waitForProviderTiles(pageClient, options.timeoutMs);
+  const selection = selectProviderSwitchTargets(providers.tiles, {
+    fromTargetID: options.fromTargetID,
+    selectedTargetID: providers.selectedTargetID,
+    toTargetID: options.toTargetID
+  });
+  const source = await prepareProviderSessions(
+    pageClient,
+    selection.sourceTargetID,
+    options.timeoutMs
+  );
+  const target = await prepareProviderSessions(
+    pageClient,
+    selection.targetTargetID,
+    options.timeoutMs
+  );
+  await selectProvider(pageClient, source.targetID, options.timeoutMs);
+  await selectSession(
+    pageClient,
+    source.sessions[0],
+    source.targetID,
+    options.timeoutMs
+  );
+  return { source, target };
+}
+
+async function prepareProviderSessions(pageClient, targetID, timeoutMs) {
+  await selectProvider(pageClient, targetID, timeoutMs);
+  const snapshot = await waitForSessionItems(pageClient, timeoutMs);
+  const selection = selectSessionSwitchTargets(
+    snapshot.items,
+    snapshot.activeSessionID
+  );
+  return {
+    targetID,
+    sessions: [selection.sourceSessionID, selection.targetSessionID]
+  };
+}
+
+async function executeProviderSessionCycle(context, prepared, options) {
+  const { pageClient } = context;
+  const operations = [
+    providerOperation(prepared.target.targetID),
+    sessionOperation(prepared.target.targetID, prepared.target.sessions[1]),
+    providerOperation(prepared.source.targetID),
+    sessionOperation(prepared.source.targetID, prepared.source.sessions[1]),
+    providerOperation(prepared.target.targetID),
+    sessionOperation(prepared.target.targetID, prepared.target.sessions[0]),
+    providerOperation(prepared.source.targetID),
+    sessionOperation(prepared.source.targetID, prepared.source.sessions[0])
+  ];
+  await startRendererScenario(pageClient, cycleMarkers.start);
+  let providerSwitches = 0;
+  let sessionSwitches = 0;
+  for (let index = 0; index < operations.length; index += 1) {
+    const operation = operations[index];
+    await operation.run(pageClient, options.timeoutMs);
+    providerSwitches += operation.kind === "provider" ? 1 : 0;
+    sessionSwitches += operation.kind === "session" ? 1 : 0;
+    await markRenderer(
+      pageClient,
+      cycleMarkers[cycleStepDefinitions[index][0]]
+    );
+  }
+  await finishRendererScenario(pageClient, cycleMarkers.end);
+  return {
+    finalSessionID: prepared.source.sessions[0],
+    providerSwitches,
+    sessionSwitches
+  };
+}
+
+function providerOperation(targetID) {
+  return {
+    kind: "provider",
+    run: (pageClient, timeoutMs) =>
+      selectProvider(pageClient, targetID, timeoutMs)
+  };
+}
+
+function sessionOperation(targetID, sessionID) {
+  return {
+    kind: "session",
+    run: (pageClient, timeoutMs) =>
+      selectSession(pageClient, sessionID, targetID, timeoutMs)
+  };
+}
+
+function scenarioSummary(assertions, details) {
+  return {
+    outcome: assertions.every((assertion) => assertion.passed)
+      ? "passed"
+      : "failed",
+    assertions,
+    details,
+    stabilityCriterion:
+      "each operation reaches its selected state and five identical rail snapshots at 200 ms intervals"
+  };
+}

--- a/tools/scripts/agent-gui-window-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-window-performance-scenarios.mjs
@@ -1,0 +1,380 @@
+import {
+  clickAgentWindowControl,
+  evaluate,
+  finishRendererScenario,
+  markRenderer,
+  selectProvider,
+  startRendererScenario,
+  waitForAgentWorkbenchWindow,
+  waitForProviderTiles,
+  waitForStableAgentWorkbenchWindow,
+  waitForStableViewport,
+  waitForEvaluation
+} from "./agent-gui-performance-helpers.mjs";
+
+const workbenchSteps = [
+  ["minimized", "internal window minimized"],
+  ["restored", "internal window restored"],
+  ["maximized", "internal window maximized"],
+  ["unmaximized", "internal window restored from maximized"],
+  ["closed", "internal window closed"],
+  ["reopened", "internal window reopened"]
+];
+const workbenchMarkers = buildMarkers(
+  "workbench-window-lifecycle",
+  workbenchSteps
+);
+
+export const workbenchWindowLifecycleScenario = {
+  id: "workbench-window-lifecycle",
+  markers: workbenchMarkers,
+  milestones: milestones(workbenchMarkers, workbenchSteps),
+  prepare: prepareWorkbenchWindow,
+  execute: executeWorkbenchWindow,
+  describe(prepared) {
+    return `${prepared.nodeID}; minimize/restore/maximize/restore/close/open`;
+  },
+  summarize(prepared, result) {
+    const assertions = [
+      { name: "window minimized", passed: result.minimized },
+      { name: "window restored", passed: result.restored },
+      { name: "window maximized", passed: result.maximized },
+      { name: "window unmaximized", passed: result.unmaximized },
+      { name: "window closed", passed: result.closed },
+      {
+        name: "window reopened",
+        passed: result.reopened && result.reopenedNodeID !== prepared.nodeID
+      }
+    ];
+    return summary(
+      assertions,
+      [
+        { label: "Window", value: "AgentGUI Workbench node" },
+        { label: "Original node", value: prepared.nodeID },
+        { label: "Reopened node", value: result.reopenedNodeID },
+        { label: "Measured operations", value: "6" }
+      ],
+      "each DOM shell/dock state observed before next operation; two animation frames plus 250 ms settling tail"
+    );
+  }
+};
+
+async function prepareWorkbenchWindow(context, options) {
+  const { pageClient } = context;
+  const providers = await waitForProviderTiles(pageClient, options.timeoutMs);
+  const targetID = providers.selectedTargetID ?? providers.tiles[0]?.targetID;
+  if (!targetID) {
+    throw new Error("workbench-window-lifecycle has no Agent target");
+  }
+  await selectProvider(pageClient, targetID, options.timeoutMs);
+  let windowState = await waitForStableAgentWorkbenchWindow(
+    pageClient,
+    options.timeoutMs
+  );
+  if (windowState.displayMode === "fullscreen") {
+    await clickAgentWindowControl(
+      pageClient,
+      windowState.id,
+      "agent-gui-window-toggle-display-mode"
+    );
+    const restored = await waitForAgentWorkbenchWindow(
+      pageClient,
+      options.timeoutMs,
+      "windowState?.displayMode === 'floating'",
+      "floating AgentGUI Workbench window",
+      windowState.id
+    );
+    windowState = { ...windowState, ...restored.windowState };
+  }
+  return { nodeID: windowState.id };
+}
+
+async function executeWorkbenchWindow(context, prepared, options) {
+  const { pageClient } = context;
+  const result = {};
+  await startRendererScenario(pageClient, workbenchMarkers.start);
+
+  await clickAgentWindowControl(
+    pageClient,
+    prepared.nodeID,
+    "agent-gui-window-minimize"
+  );
+  const minimized = await waitForEvaluation(
+    pageClient,
+    `(() => {
+      const slot = document.querySelector(${JSON.stringify(`[data-desktop-dock-anchor-key="minimized:${prepared.nodeID}"]`)});
+      return { ready: Boolean(slot) };
+    })()`,
+    options.timeoutMs,
+    "minimized AgentGUI Workbench dock item"
+  );
+  result.minimized = minimized.ready;
+  await markRenderer(pageClient, workbenchMarkers.minimized);
+
+  await evaluate(
+    pageClient,
+    `(() => {
+      const slot = document.querySelector(${JSON.stringify(`[data-desktop-dock-anchor-key="minimized:${prepared.nodeID}"]`)});
+      const button = slot?.querySelector('[role="button"]');
+      if (!(button instanceof HTMLElement)) throw new Error('minimized AgentGUI dock item is unavailable');
+      button.click();
+      return true;
+    })()`
+  );
+  const restored = await waitForAgentWorkbenchWindow(
+    pageClient,
+    options.timeoutMs,
+    "windowState?.minimizedMount === 'visible'",
+    "restored AgentGUI Workbench window",
+    prepared.nodeID
+  );
+  result.restored = restored.ready;
+  await markRenderer(pageClient, workbenchMarkers.restored);
+
+  await clickAgentWindowControl(
+    pageClient,
+    prepared.nodeID,
+    "agent-gui-window-toggle-display-mode"
+  );
+  const maximized = await waitForAgentWorkbenchWindow(
+    pageClient,
+    options.timeoutMs,
+    "windowState?.displayMode === 'fullscreen'",
+    "fullscreen AgentGUI Workbench window",
+    prepared.nodeID
+  );
+  result.maximized = maximized.ready;
+  await markRenderer(pageClient, workbenchMarkers.maximized);
+
+  await clickAgentWindowControl(
+    pageClient,
+    prepared.nodeID,
+    "agent-gui-window-toggle-display-mode"
+  );
+  const unmaximized = await waitForAgentWorkbenchWindow(
+    pageClient,
+    options.timeoutMs,
+    "windowState?.displayMode === 'floating'",
+    "unmaximized AgentGUI Workbench window",
+    prepared.nodeID
+  );
+  result.unmaximized = unmaximized.ready;
+  await waitForEvaluation(
+    pageClient,
+    `(() => {
+      const shell = document.querySelector(${JSON.stringify(`[data-workbench-window-id="${prepared.nodeID}"]`)});
+      return { ready: Boolean(shell?.querySelector('[data-testid="agent-gui-window-close"]')) };
+    })()`,
+    options.timeoutMs,
+    "AgentGUI close control after unmaximize"
+  );
+  await markRenderer(pageClient, workbenchMarkers.unmaximized);
+
+  await clickAgentWindowControl(
+    pageClient,
+    prepared.nodeID,
+    "agent-gui-window-close"
+  );
+  const closed = await waitForAgentWorkbenchWindow(
+    pageClient,
+    options.timeoutMs,
+    "windowState === null",
+    "closed AgentGUI Workbench window",
+    prepared.nodeID
+  );
+  result.closed = closed.ready;
+  await markRenderer(pageClient, workbenchMarkers.closed);
+
+  await evaluate(
+    pageClient,
+    `(() => {
+      const slot = document.querySelector('[data-desktop-dock-anchor-key="agent-gui:unified"]');
+      const button = slot?.querySelector('button');
+      if (!(button instanceof HTMLButtonElement)) throw new Error('AgentGUI dock launcher is unavailable');
+      button.click();
+      return true;
+    })()`
+  );
+  const reopened = await waitForAgentWorkbenchWindow(
+    pageClient,
+    options.timeoutMs,
+    `Boolean(windowState?.id && windowState.id !== ${JSON.stringify(prepared.nodeID)})`,
+    "reopened AgentGUI Workbench window"
+  );
+  result.reopened = reopened.ready;
+  result.reopenedNodeID = reopened.windowState?.id ?? "";
+  await markRenderer(pageClient, workbenchMarkers.reopened);
+  await finishRendererScenario(pageClient, workbenchMarkers.end);
+  return result;
+}
+
+const desktopSteps = [
+  ["minimized", "native window minimized"],
+  ["restored", "native window restored"],
+  ["maximized", "native window maximized"],
+  ["unmaximized", "native window restored from maximized"]
+];
+const desktopMarkers = buildMarkers("desktop-window-state", desktopSteps);
+
+export const desktopWindowStateScenario = {
+  id: "desktop-window-state",
+  markers: desktopMarkers,
+  milestones: milestones(desktopMarkers, desktopSteps),
+  prepare: prepareDesktopWindow,
+  execute: executeDesktopWindow,
+  describe(prepared) {
+    return `workspace ${prepared.workspaceID}; minimize/restore/maximize/restore`;
+  },
+  summarize(prepared, result) {
+    const assertions = [
+      { name: "window minimized", passed: result.minimized },
+      { name: "window restored", passed: result.restored },
+      { name: "window maximized", passed: result.maximized },
+      { name: "window unmaximized", passed: result.unmaximized }
+    ];
+    return summary(
+      assertions,
+      [
+        {
+          label: "Window",
+          value: "owning Electron BrowserWindow"
+        },
+        { label: "Workspace", value: prepared.workspaceID },
+        { label: "Measured operations", value: "4" },
+        {
+          label: "Excluded",
+          value: "native close/reopen destroys the marker-owning renderer"
+        }
+      ],
+      "typed host-window IPC performs each action; preload minimize/layout events confirm observed state"
+    );
+  }
+};
+
+async function prepareDesktopWindow(context, options) {
+  if (process.platform !== "darwin") {
+    throw new Error(
+      "desktop-window-state currently requires macOS host-window minimize events"
+    );
+  }
+  const { pageClient } = context;
+  const prepared = await waitForEvaluation(
+    pageClient,
+    `(() => {
+      const workspaceID = new URLSearchParams(location.search).get('workspaceId');
+      const hostWindow = window.tutti?.host?.window;
+      const hostWorkspace = window.tutti?.host?.workspace;
+      return {
+        ready: Boolean(workspaceID && hostWindow?.minimize && hostWindow?.toggleMaximize && hostWorkspace?.showWorkspace && document.querySelector('[data-app-header="true"]')),
+        workspaceID,
+        maximized: document.documentElement.dataset.tuttiWindowMaximized === 'true'
+      };
+    })()`,
+    options.timeoutMs,
+    "native host-window APIs"
+  );
+  if (prepared.maximized) {
+    await evaluate(
+      pageClient,
+      "window.tutti.host.window.toggleMaximize()",
+      true
+    );
+    await waitForEvaluation(
+      pageClient,
+      "({ ready: document.documentElement.dataset.tuttiWindowMaximized !== 'true' })",
+      options.timeoutMs,
+      "normal native window before scenario"
+    );
+    await waitForStableViewport(pageClient, options.timeoutMs);
+  }
+  return prepared;
+}
+
+async function executeDesktopWindow(context, prepared, options) {
+  const { pageClient } = context;
+  await evaluate(
+    pageClient,
+    `(() => {
+      window.__tuttiPerfWindowState = {
+        maximized: document.documentElement.dataset.tuttiWindowMaximized === 'true',
+        minimized: false
+      };
+      window.addEventListener('tutti-host-window-minimize', (event) => {
+        window.__tuttiPerfWindowState.minimized = event.detail?.minimized === true;
+      });
+      window.addEventListener('tutti-host-window-layout', (event) => {
+        window.__tuttiPerfWindowState.maximized = event.detail?.maximized === true;
+      });
+      return true;
+    })()`
+  );
+  await startRendererScenario(pageClient, desktopMarkers.start);
+  await evaluate(pageClient, "window.tutti.host.window.minimize()", true);
+  const minimized = await waitForEvaluation(
+    pageClient,
+    "({ ready: window.__tuttiPerfWindowState?.minimized === true })",
+    options.timeoutMs,
+    "minimized native window"
+  );
+  await markRenderer(pageClient, desktopMarkers.minimized);
+  await evaluate(
+    pageClient,
+    `window.tutti.host.workspace.showWorkspace(${JSON.stringify(prepared.workspaceID)})`,
+    true
+  );
+  const restored = await waitForEvaluation(
+    pageClient,
+    "({ ready: window.__tuttiPerfWindowState?.minimized === false })",
+    options.timeoutMs,
+    "restored native window"
+  );
+  await markRenderer(pageClient, desktopMarkers.restored);
+  await evaluate(pageClient, "window.tutti.host.window.toggleMaximize()", true);
+  const maximized = await waitForEvaluation(
+    pageClient,
+    "({ ready: window.__tuttiPerfWindowState?.maximized === true })",
+    options.timeoutMs,
+    "maximized native window"
+  );
+  await waitForStableViewport(pageClient, options.timeoutMs);
+  await markRenderer(pageClient, desktopMarkers.maximized);
+  await evaluate(pageClient, "window.tutti.host.window.toggleMaximize()", true);
+  const unmaximized = await waitForEvaluation(
+    pageClient,
+    "({ ready: window.__tuttiPerfWindowState?.maximized === false })",
+    options.timeoutMs,
+    "unmaximized native window"
+  );
+  await waitForStableViewport(pageClient, options.timeoutMs);
+  await markRenderer(pageClient, desktopMarkers.unmaximized);
+  await finishRendererScenario(pageClient, desktopMarkers.end);
+  return {
+    maximized: maximized.ready,
+    minimized: minimized.ready,
+    restored: restored.ready,
+    unmaximized: unmaximized.ready
+  };
+}
+
+function buildMarkers(scenarioID, steps) {
+  return Object.fromEntries([
+    ["start", `tutti-perf:${scenarioID}:start`],
+    ...steps.map(([key]) => [key, `tutti-perf:${scenarioID}:${key}-observed`]),
+    ["end", `tutti-perf:${scenarioID}:end`]
+  ]);
+}
+
+function milestones(markers, steps) {
+  return steps.map(([key, label]) => ({ key, label, marker: markers[key] }));
+}
+
+function summary(assertions, details, stabilityCriterion) {
+  return {
+    outcome: assertions.every((assertion) => assertion.passed)
+      ? "passed"
+      : "failed",
+    assertions,
+    details,
+    stabilityCriterion
+  };
+}

--- a/tools/scripts/analyze-electron-trace.mjs
+++ b/tools/scripts/analyze-electron-trace.mjs
@@ -1,0 +1,698 @@
+#!/usr/bin/env node
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveComponentSources } from "./resolve-component-sources.mjs";
+
+const defaultMinimumLongEventMs = 16;
+const reactTrackMessages = new Set([
+  "Blocking Track",
+  "Commit",
+  "Idle Track",
+  "Layout Effects",
+  "Passive Effects",
+  "Remaining Effects",
+  "Render",
+  "Suspense Track",
+  "Transition Track"
+]);
+const radixComponentPattern =
+  /(Collection|ContextMenu|DropdownMenu|MenuContent|MenuItem|MenuPortal|MenuRoot|Popper|Portal|Presence|Primitive|Slot|Tooltip)/u;
+
+if (isMainModule()) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+export async function main(argv) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printUsage();
+    return;
+  }
+  const summary = await analyzeElectronTrace({
+    tracePath: options.tracePath,
+    scenario: options.scenario,
+    startMarker: options.startMarker,
+    endMarker: options.endMarker,
+    minimumLongEventMs: options.minimumLongEventMs,
+    sourceRoot: options.sourceRoot ?? process.cwd()
+  });
+  if (options.format === "markdown") {
+    process.stdout.write(
+      renderElectronTraceMarkdown(summary, {
+        sourceRoot: options.sourceRoot ?? process.cwd()
+      })
+    );
+    return;
+  }
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+}
+
+export async function analyzeElectronTrace(input) {
+  const tracePath = resolve(input.tracePath);
+  const startMarker = input.startMarker.trim();
+  const endMarker = input.endMarker.trim();
+  const minimumLongEventMs =
+    input.minimumLongEventMs ?? defaultMinimumLongEventMs;
+  const minimumLongEventUs = minimumLongEventMs * 1_000;
+  const milestoneByMarker = new Map(
+    (input.milestones ?? []).map((milestone) => [milestone.marker, milestone])
+  );
+  const milestoneTimestamps = new Map();
+  const threadNames = new Map();
+  const componentThreadCounts = new Map();
+  const threadAnalyses = new Map();
+  const processIDs = new Set();
+  let traceEventCount = 0;
+  let scenarioEventCount = 0;
+  let scenarioStartUs = null;
+  let scenarioEndUs = null;
+
+  await streamTraceEvents(tracePath, (event) => {
+    traceEventCount += 1;
+    const thread = `${event.pid ?? "?"}:${event.tid ?? "?"}`;
+    if (event.pid != null) processIDs.add(event.pid);
+    if (
+      event.ph === "M" &&
+      event.name === "thread_name" &&
+      typeof event.args?.name === "string"
+    ) {
+      threadNames.set(thread, event.args.name);
+    }
+
+    const timestampUs = finiteNumber(event.ts);
+    const markerName = traceMarkerName(event);
+    if (markerName === startMarker && timestampUs !== null) {
+      scenarioStartUs = timestampUs;
+      return true;
+    }
+    const milestone = milestoneByMarker.get(markerName);
+    if (
+      scenarioStartUs !== null &&
+      milestone &&
+      timestampUs !== null &&
+      !milestoneTimestamps.has(milestone.key)
+    ) {
+      milestoneTimestamps.set(milestone.key, timestampUs);
+    }
+    if (
+      scenarioStartUs !== null &&
+      markerName === endMarker &&
+      timestampUs !== null
+    ) {
+      scenarioEndUs = timestampUs;
+      return false;
+    }
+    if (scenarioStartUs === null || timestampUs === null) {
+      return true;
+    }
+
+    scenarioEventCount += 1;
+    const threadAnalysis = getThreadAnalysis(threadAnalyses, thread);
+    threadAnalysis.eventCount += 1;
+    const componentName = traceComponentName(event);
+    if (componentName) {
+      threadAnalysis.componentMarkerCount += 1;
+      incrementCount(threadAnalysis.componentCounts, componentName);
+      incrementCount(componentThreadCounts, thread);
+      if (radixComponentPattern.test(componentName)) {
+        threadAnalysis.radixComponentMarkerCount += 1;
+      }
+    }
+
+    if (event.name === "EventDispatch") {
+      const eventType = event.args?.data?.type;
+      if (typeof eventType === "string") {
+        incrementCount(threadAnalysis.inputEventCounts, eventType);
+      }
+    }
+
+    const durationUs = finiteNumber(event.dur) ?? 0;
+    if (event.ph !== "X" || durationUs <= 0) {
+      return true;
+    }
+    const name = typeof event.name === "string" ? event.name : "<unnamed>";
+    updateDurationStats(threadAnalysis.eventStats, name, durationUs);
+    if (name === "RunTask" && durationUs >= minimumLongEventUs) {
+      threadAnalysis.longTaskCount += 1;
+      updateLongestTasks(threadAnalysis.longestTasks, {
+        durationMs: round(durationUs / 1_000),
+        timestampOffsetMs: round((timestampUs - scenarioStartUs) / 1_000)
+      });
+    }
+    return true;
+  });
+
+  if (scenarioStartUs === null) {
+    throw new Error(`trace marker not found: ${startMarker}`);
+  }
+  if (scenarioEndUs === null) {
+    throw new Error(`trace marker not found: ${endMarker}`);
+  }
+  const missingMilestones = (input.milestones ?? []).filter(
+    (milestone) => !milestoneTimestamps.has(milestone.key)
+  );
+  if (missingMilestones.length > 0) {
+    throw new Error(
+      `trace milestones not found: ${missingMilestones.map((milestone) => milestone.marker).join(", ")}`
+    );
+  }
+
+  const file = await stat(tracePath);
+  const rendererThread = selectRendererThread(
+    componentThreadCounts,
+    threadNames,
+    threadAnalyses
+  );
+  const renderer = rendererThread
+    ? (threadAnalyses.get(rendererThread) ?? createThreadAnalysis())
+    : createThreadAnalysis();
+  const unresolvedTopComponents = topCountEntries(
+    renderer.componentCounts,
+    30
+  ).map(([name, count]) => ({ name, count }));
+  const topComponents = input.sourceRoot
+    ? await resolveComponentSources(unresolvedTopComponents, input.sourceRoot)
+    : unresolvedTopComponents;
+  const topEvents = topDurationEntries(renderer.eventStats, 20).map(
+    ([name, value]) => ({
+      name,
+      count: value.count,
+      totalInclusiveMs: round(value.totalUs / 1_000),
+      maxMs: round(value.maxUs / 1_000)
+    })
+  );
+  const phases = buildPhases({
+    startUs: scenarioStartUs,
+    endUs: scenarioEndUs,
+    milestones: input.milestones ?? [],
+    milestoneTimestamps
+  });
+
+  return {
+    schemaVersion: 2,
+    mode: "report-only",
+    scenario: input.scenario,
+    verdict: {
+      status: "ungraded",
+      reason: "no comparable baseline or threshold configured"
+    },
+    trace: {
+      file: basename(tracePath),
+      bytes: file.size,
+      parsedEventCount: traceEventCount,
+      processCount: processIDs.size
+    },
+    window: {
+      startMarker,
+      endMarker,
+      durationMs: round((scenarioEndUs - scenarioStartUs) / 1_000),
+      eventCount: scenarioEventCount,
+      rendererEventCount: renderer.eventCount,
+      phases
+    },
+    rendererThread: rendererThread
+      ? {
+          key: rendererThread,
+          name: threadNames.get(rendererThread) ?? null,
+          selectionReason:
+            (componentThreadCounts.get(rendererThread) ?? 0) > 0
+              ? "most React component markers"
+              : "CrRendererMain fallback"
+        }
+      : null,
+    renders: {
+      componentMarkers: renderer.componentMarkerCount,
+      radixFamilyMarkers: renderer.radixComponentMarkerCount,
+      headerFrameMarkers: countComponentFamily(
+        renderer.componentCounts,
+        "HeaderFrame"
+      ),
+      sectionMarkers: countComponentFamily(
+        renderer.componentCounts,
+        "AgentGUIConversationRailSection"
+      ),
+      sectionHeaderMarkers: countComponentFamily(
+        renderer.componentCounts,
+        "AgentGUIConversationRailSectionHeader"
+      ),
+      topComponents
+    },
+    timing: {
+      longTaskThresholdMs: minimumLongEventMs,
+      longTaskCount: renderer.longTaskCount,
+      maxLongTaskMs: renderer.longestTasks[0]?.durationMs ?? 0,
+      functionCallInclusiveMs: inclusiveDurationForNames(renderer.eventStats, [
+        "FunctionCall"
+      ]),
+      updateLayoutTreeInclusiveMs: inclusiveDurationForNames(
+        renderer.eventStats,
+        ["UpdateLayoutTree"]
+      ),
+      layoutInclusiveMs: inclusiveDurationForNames(renderer.eventStats, [
+        "Layout"
+      ]),
+      prePaintInclusiveMs: inclusiveDurationForNames(renderer.eventStats, [
+        "PrePaint"
+      ]),
+      paintInclusiveMs: inclusiveDurationForNames(renderer.eventStats, [
+        "Paint"
+      ]),
+      topEvents,
+      longestTasks: renderer.longestTasks
+    },
+    inputEvents: Object.fromEntries(
+      [...renderer.inputEventCounts.entries()].sort(([left], [right]) =>
+        left.localeCompare(right)
+      )
+    ),
+    cautions: [
+      "Timing and event totals are restricted to the selected renderer main thread.",
+      "Inclusive duration totals may overlap; do not sum them into wall time.",
+      "React component counts come from development component tracks and include profiling overhead.",
+      "Component source links are static declaration matches, not runtime stack attribution.",
+      "Source links resolve against the current checkout and may drift from the revision that produced an imported trace.",
+      "Report-only mode never fails on metric values; scenario or trace failures still return a non-zero exit code."
+    ]
+  };
+}
+
+export function renderElectronTraceMarkdown(summary, options = {}) {
+  const lines = [
+    `# Desktop performance: ${summary.scenario}`,
+    "",
+    "## Summary",
+    "",
+    `- Performance verdict: ${summary.verdict.status} — ${summary.verdict.reason}`,
+    `- Mode: ${summary.mode}; metric values never fail the command`,
+    `- Scenario window: ${summary.window.durationMs} ms`,
+    `- Renderer thread: ${summary.rendererThread?.name ?? "unresolved"} (${summary.rendererThread?.key ?? "n/a"}; ${summary.rendererThread?.selectionReason ?? "n/a"})`,
+    `- Renderer events: ${summary.window.rendererEventCount.toLocaleString("en-US")} of ${summary.window.eventCount.toLocaleString("en-US")} trace-window events`,
+    "",
+    "## Phase timings",
+    "",
+    "Observed marker phases; polling-based milestones are not exact browser input latency.",
+    "",
+    "| Phase | Duration ms |",
+    "| --- | ---: |",
+    ...(summary.window.phases.length > 0
+      ? summary.window.phases.map(
+          (phase) =>
+            `| ${escapeMarkdown(phase.fromLabel)} → ${escapeMarkdown(phase.toLabel)} | ${phase.durationMs} |`
+        )
+      : ["| start → end | " + summary.window.durationMs + " |"]),
+    "",
+    "## Renderer main thread",
+    "",
+    `- RunTask >= ${summary.timing.longTaskThresholdMs} ms: ${summary.timing.longTaskCount.toLocaleString("en-US")}`,
+    `- Max RunTask: ${summary.timing.maxLongTaskMs} ms`,
+    `- FunctionCall inclusive: ${summary.timing.functionCallInclusiveMs} ms`,
+    `- UpdateLayoutTree inclusive: ${summary.timing.updateLayoutTreeInclusiveMs} ms`,
+    `- Layout inclusive: ${summary.timing.layoutInclusiveMs} ms`,
+    `- PrePaint inclusive: ${summary.timing.prePaintInclusiveMs} ms`,
+    `- Paint inclusive: ${summary.timing.paintInclusiveMs} ms`,
+    "",
+    "## React component fanout",
+    "",
+    `- Component markers: ${summary.renders.componentMarkers.toLocaleString("en-US")}`,
+    `- Radix-family markers: ${summary.renders.radixFamilyMarkers.toLocaleString("en-US")}`,
+    `- HeaderFrame markers: ${summary.renders.headerFrameMarkers.toLocaleString("en-US")}`,
+    `- Section markers: ${summary.renders.sectionMarkers.toLocaleString("en-US")}`,
+    `- Section header markers: ${summary.renders.sectionHeaderMarkers.toLocaleString("en-US")}`,
+    "",
+    "| Component | Markers | Static declaration |",
+    "| --- | ---: | --- |",
+    ...summary.renders.topComponents.map(
+      (entry) =>
+        `| ${escapeMarkdown(entry.name)} | ${entry.count} | ${formatComponentSource(entry, options.sourceRoot)} |`
+    ),
+    "",
+    "## Top renderer inclusive events",
+    "",
+    "| Event | Count | Total ms | Max ms |",
+    "| --- | ---: | ---: | ---: |",
+    ...summary.timing.topEvents.map(
+      (entry) =>
+        `| ${escapeMarkdown(entry.name)} | ${entry.count} | ${entry.totalInclusiveMs} | ${entry.maxMs} |`
+    ),
+    "",
+    "## Longest renderer RunTask events",
+    "",
+    "| Offset ms | Duration ms |",
+    "| ---: | ---: |",
+    ...(summary.timing.longestTasks.length > 0
+      ? summary.timing.longestTasks.map(
+          (entry) => `| ${entry.timestampOffsetMs} | ${entry.durationMs} |`
+        )
+      : ["| — | — |"]),
+    "",
+    "## Notes",
+    "",
+    ...summary.cautions.map((caution) => `- ${caution}`),
+    ""
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+function traceComponentName(event) {
+  if (event.name !== "TimeStamp") {
+    return null;
+  }
+  const message = event.args?.data?.message;
+  if (
+    typeof message !== "string" ||
+    !message.trim() ||
+    reactTrackMessages.has(message) ||
+    message.startsWith("tutti-perf:")
+  ) {
+    return null;
+  }
+  return message.trim();
+}
+
+function traceMarkerName(event) {
+  if (event.name !== "TimeStamp") return event.name;
+  const message = event.args?.data?.message;
+  return typeof message === "string" && message.startsWith("tutti-perf:")
+    ? message
+    : event.name;
+}
+
+async function streamTraceEvents(path, onEvent) {
+  const marker = '"traceEvents"';
+  let state = "search-marker";
+  let searchTail = "";
+  let objectText = "";
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for await (const chunk of createReadStream(path, { encoding: "utf8" })) {
+    consume(chunk);
+    if (state === "done") {
+      break;
+    }
+  }
+  if (state === "search-marker" || state === "wait-array") {
+    throw new Error('trace JSON does not contain a "traceEvents" array');
+  }
+  if (objectText) {
+    throw new Error("trace ended inside a trace event");
+  }
+
+  function consume(chunk) {
+    let text = chunk;
+    if (state === "search-marker") {
+      const candidate = searchTail + text;
+      const markerIndex = candidate.indexOf(marker);
+      if (markerIndex < 0) {
+        searchTail = candidate.slice(-marker.length);
+        return;
+      }
+      text = candidate.slice(markerIndex + marker.length);
+      searchTail = "";
+      state = "wait-array";
+    }
+    if (state === "wait-array") {
+      const arrayIndex = text.indexOf("[");
+      if (arrayIndex < 0) {
+        return;
+      }
+      text = text.slice(arrayIndex + 1);
+      state = "read-array";
+    }
+    if (state !== "read-array") {
+      return;
+    }
+
+    for (const character of text) {
+      if (!objectText) {
+        if (character === "{") {
+          objectText = character;
+          depth = 1;
+          inString = false;
+          escaped = false;
+        } else if (character === "]") {
+          state = "done";
+          return;
+        }
+        continue;
+      }
+
+      objectText += character;
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (character === "\\") {
+          escaped = true;
+        } else if (character === '"') {
+          inString = false;
+        }
+        continue;
+      }
+      if (character === '"') {
+        inString = true;
+      } else if (character === "{") {
+        depth += 1;
+      } else if (character === "}") {
+        depth -= 1;
+        if (depth === 0) {
+          const shouldContinue = onEvent(JSON.parse(objectText));
+          objectText = "";
+          if (shouldContinue === false) {
+            state = "done";
+            return;
+          }
+        }
+      }
+    }
+  }
+}
+
+function getThreadAnalysis(analyses, thread) {
+  let analysis = analyses.get(thread);
+  if (!analysis) {
+    analysis = createThreadAnalysis();
+    analyses.set(thread, analysis);
+  }
+  return analysis;
+}
+
+function createThreadAnalysis() {
+  return {
+    eventCount: 0,
+    eventStats: new Map(),
+    inputEventCounts: new Map(),
+    componentCounts: new Map(),
+    componentMarkerCount: 0,
+    radixComponentMarkerCount: 0,
+    longTaskCount: 0,
+    longestTasks: []
+  };
+}
+
+function selectRendererThread(componentCounts, threadNames, analyses) {
+  const componentThread = maxCountEntry(componentCounts)?.[0];
+  if (componentThread) return componentThread;
+  return [...threadNames.entries()]
+    .filter(([, name]) => name === "CrRendererMain")
+    .sort(
+      ([leftKey], [rightKey]) =>
+        (analyses.get(rightKey)?.eventCount ?? 0) -
+          (analyses.get(leftKey)?.eventCount ?? 0) ||
+        leftKey.localeCompare(rightKey)
+    )[0]?.[0];
+}
+
+function updateLongestTasks(tasks, task) {
+  tasks.push(task);
+  tasks.sort((left, right) => right.durationMs - left.durationMs);
+  if (tasks.length > 20) tasks.length = 20;
+}
+
+function buildPhases(input) {
+  const points = [
+    { key: "start", label: "scenario start", timestampUs: input.startUs },
+    ...input.milestones
+      .map((milestone) => ({
+        key: milestone.key,
+        label: milestone.label,
+        timestampUs: input.milestoneTimestamps.get(milestone.key) ?? null
+      }))
+      .filter((point) => point.timestampUs !== null),
+    { key: "end", label: "scenario end", timestampUs: input.endUs }
+  ].sort((left, right) => left.timestampUs - right.timestampUs);
+  return points.slice(1).map((point, index) => ({
+    from: points[index].key,
+    fromLabel: points[index].label,
+    to: point.key,
+    toLabel: point.label,
+    durationMs: round((point.timestampUs - points[index].timestampUs) / 1_000)
+  }));
+}
+
+function updateDurationStats(target, key, durationUs) {
+  const value = target.get(key) ?? { count: 0, totalUs: 0, maxUs: 0 };
+  value.count += 1;
+  value.totalUs += durationUs;
+  value.maxUs = Math.max(value.maxUs, durationUs);
+  target.set(key, value);
+}
+
+function incrementCount(target, key) {
+  target.set(key, (target.get(key) ?? 0) + 1);
+}
+
+function topCountEntries(values, limit) {
+  return [...values.entries()]
+    .sort(
+      (left, right) => right[1] - left[1] || left[0].localeCompare(right[0])
+    )
+    .slice(0, limit);
+}
+
+function topDurationEntries(values, limit) {
+  return [...values.entries()]
+    .sort(
+      (left, right) =>
+        right[1].totalUs - left[1].totalUs || left[0].localeCompare(right[0])
+    )
+    .slice(0, limit);
+}
+
+function maxCountEntry(values) {
+  return topCountEntries(values, 1)[0] ?? null;
+}
+
+function countComponentFamily(values, baseName) {
+  let count = 0;
+  for (const [name, value] of values) {
+    const suffix = name.slice(baseName.length);
+    if (
+      name === baseName ||
+      (name.startsWith(baseName) && /^\d+$/u.test(suffix))
+    ) {
+      count += value;
+    }
+  }
+  return count;
+}
+
+function inclusiveDurationForNames(values, names) {
+  const totalUs = names.reduce(
+    (total, name) => total + (values.get(name)?.totalUs ?? 0),
+    0
+  );
+  return round(totalUs / 1_000);
+}
+
+function finiteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function round(value) {
+  return Math.round(value * 100) / 100;
+}
+
+function escapeMarkdown(value) {
+  return String(value).replaceAll("|", "\\|");
+}
+
+function formatComponentSource(entry, sourceRoot) {
+  if (!entry.source) {
+    return entry.sourceResolution?.status === "ambiguous"
+      ? `ambiguous (${entry.sourceResolution.candidateCount} declarations)`
+      : "unresolved / external";
+  }
+  const label = `${entry.source.file}:${entry.source.line}`;
+  if (!sourceRoot) return escapeMarkdown(label);
+  const target = `${resolve(sourceRoot, entry.source.file)}:${entry.source.line}`;
+  const markdownTarget = target.includes(" ") ? `<${target}>` : target;
+  return `[${escapeMarkdown(label)}](${markdownTarget})`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    format: "json",
+    minimumLongEventMs: defaultMinimumLongEventMs,
+    scenario: "desktop-interaction"
+  };
+  const positional = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") continue;
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg === "--scenario") {
+      options.scenario = requiredValue(argv, (index += 1), arg);
+    } else if (arg === "--start-marker") {
+      options.startMarker = requiredValue(argv, (index += 1), arg);
+    } else if (arg === "--end-marker") {
+      options.endMarker = requiredValue(argv, (index += 1), arg);
+    } else if (arg === "--source-root") {
+      options.sourceRoot = resolve(requiredValue(argv, (index += 1), arg));
+    } else if (arg === "--min-ms") {
+      options.minimumLongEventMs = positiveNumber(
+        requiredValue(argv, (index += 1), arg),
+        arg
+      );
+    } else if (arg === "--format") {
+      options.format = requiredValue(argv, (index += 1), arg);
+      if (!new Set(["json", "markdown"]).has(options.format)) {
+        throw new Error("--format must be json or markdown");
+      }
+    } else if (arg.startsWith("--")) {
+      throw new Error(`unknown option: ${arg}`);
+    } else {
+      positional.push(arg);
+    }
+  }
+  if (options.help) return options;
+  if (positional.length !== 1) {
+    throw new Error("provide exactly one trace JSON path");
+  }
+  if (!options.startMarker || !options.endMarker) {
+    throw new Error("--start-marker and --end-marker are required");
+  }
+  options.tracePath = positional[0];
+  return options;
+}
+
+function requiredValue(argv, index, option) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+}
+
+function positiveNumber(value, option) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) {
+    throw new Error(`${option} must be a positive number`);
+  }
+  return number;
+}
+
+function isMainModule() {
+  return process.argv[1]
+    ? fileURLToPath(import.meta.url) === resolve(process.argv[1])
+    : false;
+}
+
+function printUsage() {
+  const usage = `Analyze one marker-bounded Electron trace window.\n\nUsage:\n  node tools/scripts/analyze-electron-trace.mjs TRACE.json \\\n+    --scenario provider-switch \\\n+    --start-marker tutti-perf:provider-switch:start \\\n+    --end-marker tutti-perf:provider-switch:end\n\nOptions:\n  --format <json|markdown>  Output format. Default: json\n  --min-ms <milliseconds>   Long event threshold. Default: 16\n  --scenario <name>         Scenario label\n  --start-marker <name>     performance.mark name at scenario start\n  --end-marker <name>       performance.mark name at scenario end\n`;
+  process.stdout.write(
+    usage
+      .replaceAll("\n+", "\n")
+      .replace("Long event threshold", "Renderer RunTask threshold")
+      .replace(
+        "  --scenario <name>         Scenario label",
+        "  --scenario <name>         Scenario label\n  --source-root <path>      Resolve local component declarations"
+      )
+  );
+}

--- a/tools/scripts/analyze-electron-trace.test.mjs
+++ b/tools/scripts/analyze-electron-trace.test.mjs
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  analyzeElectronTrace,
+  renderElectronTraceMarkdown
+} from "./analyze-electron-trace.mjs";
+
+test("analyzer bounds metrics by scenario markers", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "tutti-trace-analysis-"));
+  const tracePath = join(directory, "trace.json");
+  try {
+    await writeFile(
+      tracePath,
+      JSON.stringify({
+        traceEvents: [
+          metadata(1, 2, "CrRendererMain"),
+          component(900, "BeforeScenario"),
+          marker(1_000, "tutti-perf:provider-switch:start"),
+          component(1_100, "HeaderFrame"),
+          component(1_200, "Tooltip"),
+          component(1_225, "AgentGUIConversationRailSection2"),
+          component(1_240, "AgentGUIConversationRailSectionHeader3"),
+          component(1_250, "Render"),
+          complete(1_300, 20_000, "RunTask"),
+          complete(1_400, 5_000, "Layout"),
+          input(1_500, "click"),
+          completeOnThread(1_600, 80_000, "RunTask", 9, 3),
+          timestampMarker(
+            2_000,
+            "tutti-perf:provider-switch:selected-observed"
+          ),
+          marker(4_000, "tutti-perf:provider-switch:rail-stable-observed"),
+          marker(30_000, "tutti-perf:provider-switch:end"),
+          component(31_000, "AfterScenario")
+        ]
+      })
+    );
+
+    const summary = await analyzeElectronTrace({
+      tracePath,
+      scenario: "provider-switch",
+      startMarker: "tutti-perf:provider-switch:start",
+      endMarker: "tutti-perf:provider-switch:end",
+      milestones: [
+        {
+          key: "selected",
+          label: "target selected",
+          marker: "tutti-perf:provider-switch:selected-observed"
+        },
+        {
+          key: "stable",
+          label: "rail stable",
+          marker: "tutti-perf:provider-switch:rail-stable-observed"
+        }
+      ],
+      minimumLongEventMs: 16
+    });
+
+    assert.equal(summary.window.durationMs, 29);
+    assert.equal(summary.renders.componentMarkers, 4);
+    assert.equal(summary.renders.radixFamilyMarkers, 1);
+    assert.equal(summary.renders.headerFrameMarkers, 1);
+    assert.equal(summary.renders.sectionMarkers, 1);
+    assert.equal(summary.renders.sectionHeaderMarkers, 1);
+    assert.equal(summary.timing.longTaskCount, 1);
+    assert.equal(summary.timing.maxLongTaskMs, 20);
+    assert.equal(summary.timing.layoutInclusiveMs, 5);
+    assert.deepEqual(
+      summary.window.phases.map((phase) => phase.durationMs),
+      [1, 2, 26]
+    );
+    assert.deepEqual(summary.inputEvents, { click: 1 });
+    assert.match(renderElectronTraceMarkdown(summary), /report-only/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("analyzer rejects traces without the scenario end marker", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "tutti-trace-analysis-"));
+  const tracePath = join(directory, "trace.json");
+  try {
+    await writeFile(
+      tracePath,
+      JSON.stringify({
+        traceEvents: [marker(1_000, "start"), component(1_100, "Tooltip")]
+      })
+    );
+    await assert.rejects(
+      analyzeElectronTrace({
+        tracePath,
+        scenario: "missing-end",
+        startMarker: "start",
+        endMarker: "end"
+      }),
+      /trace marker not found: end/
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("analyzer rejects traces with a missing declared milestone", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "tutti-trace-analysis-"));
+  const tracePath = join(directory, "trace.json");
+  try {
+    await writeFile(
+      tracePath,
+      JSON.stringify({
+        traceEvents: [marker(1_000, "start"), marker(2_000, "end")]
+      })
+    );
+    await assert.rejects(
+      analyzeElectronTrace({
+        tracePath,
+        scenario: "missing-milestone",
+        startMarker: "start",
+        endMarker: "end",
+        milestones: [{ key: "middle", label: "middle", marker: "middle" }]
+      }),
+      /trace milestones not found: middle/
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function marker(ts, name) {
+  return { name, ph: "R", pid: 1, tid: 2, ts };
+}
+
+function timestampMarker(ts, message) {
+  return {
+    args: { data: { message } },
+    name: "TimeStamp",
+    ph: "I",
+    pid: 1,
+    tid: 2,
+    ts
+  };
+}
+
+function metadata(pid, tid, name) {
+  return { args: { name }, name: "thread_name", ph: "M", pid, tid, ts: 1 };
+}
+
+function component(ts, message) {
+  return {
+    args: { data: { message } },
+    cat: "devtools.timeline",
+    name: "TimeStamp",
+    ph: "I",
+    pid: 1,
+    tid: 2,
+    ts
+  };
+}
+
+function complete(ts, dur, name) {
+  return { dur, name, ph: "X", pid: 1, tid: 2, ts };
+}
+
+function completeOnThread(ts, dur, name, pid, tid) {
+  return { dur, name, ph: "X", pid, tid, ts };
+}
+
+function input(ts, type) {
+  return {
+    args: { data: { type } },
+    dur: 10,
+    name: "EventDispatch",
+    ph: "X",
+    pid: 1,
+    tid: 2,
+    ts
+  };
+}

--- a/tools/scripts/capture-electron-trace.mjs
+++ b/tools/scripts/capture-electron-trace.mjs
@@ -6,7 +6,7 @@ import { dirname, join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 
 const defaultPort = 9223;
-const defaultCategories = [
+export const defaultTraceCategories = [
   "devtools.timeline",
   "disabled-by-default-devtools.timeline",
   "disabled-by-default-devtools.timeline.frame",
@@ -41,7 +41,7 @@ export async function main(argv) {
   const outputPath = resolve(
     expandHome(options.output ?? defaultOutputPath(new Date()))
   );
-  const categories = options.categories ?? defaultCategories;
+  const categories = options.categories ?? defaultTraceCategories;
   if (durationMs == null && !process.stdin.isTTY) {
     throw new Error("stdin is not interactive; pass --duration <seconds>");
   }
@@ -87,7 +87,7 @@ export async function main(argv) {
   }
 }
 
-async function resolveBrowserWebSocketUrl(port) {
+export async function resolveBrowserWebSocketUrl(port) {
   const baseUrl = `http://127.0.0.1:${port}`;
   const version = await fetchJson(`${baseUrl}/json/version`).catch((error) => {
     throw new Error(
@@ -114,6 +114,21 @@ async function resolveBrowserWebSocketUrl(port) {
   throw new Error(`no browser or page websocket found at ${baseUrl}`);
 }
 
+export async function resolvePageWebSocketUrl(port) {
+  const targets = await fetchJson(`http://127.0.0.1:${port}/json/list`);
+  const pageTarget = Array.isArray(targets)
+    ? targets.find(
+        (target) =>
+          target?.type === "page" &&
+          typeof target.webSocketDebuggerUrl === "string"
+      )
+    : null;
+  if (!pageTarget) {
+    throw new Error(`no page websocket found at http://127.0.0.1:${port}`);
+  }
+  return pageTarget.webSocketDebuggerUrl;
+}
+
 async function fetchJson(url) {
   const response = await fetch(url);
   if (!response.ok) {
@@ -122,7 +137,7 @@ async function fetchJson(url) {
   return await response.json();
 }
 
-async function writeStreamToFile(client, stream, outputPath) {
+export async function writeStreamToFile(client, stream, outputPath) {
   const file = createWriteStream(outputPath, { flags: "w" });
   let bytes = 0;
 
@@ -160,7 +175,7 @@ async function writeStreamToFile(client, stream, outputPath) {
   return bytes;
 }
 
-class CdpClient {
+export class CdpClient {
   static async connect(url) {
     const socket = new WebSocket(url);
     const client = new CdpClient(socket);

--- a/tools/scripts/resolve-component-sources.mjs
+++ b/tools/scripts/resolve-component-sources.mjs
@@ -1,0 +1,172 @@
+import { execFile } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
+import { relative, resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const sourceGlobs = [
+  "*.ts",
+  "*.tsx",
+  "!**/*.d.ts",
+  "!**/*.test.*",
+  "!**/*.spec.*",
+  "!**/*.stories.*"
+];
+
+export async function resolveComponentSources(componentEntries, sourceRoot) {
+  const root = resolve(sourceRoot);
+  const entryCandidates = new Map(
+    componentEntries.map((entry) => [
+      entry.name,
+      componentSymbolCandidates(entry.name)
+    ])
+  );
+  const allCandidates = [
+    ...new Set([...entryCandidates.values()].flat())
+  ].sort();
+  if (allCandidates.length === 0) {
+    return componentEntries.map((entry) => ({ ...entry, source: null }));
+  }
+
+  const alternation = allCandidates.map(escapeRegex).join("|");
+  const declarationPattern =
+    `(?:function|class)\\s+(${alternation})\\b|` +
+    `(?:const|let|var)\\s+(${alternation})\\s*[:=]`;
+  const matches = await searchDeclarations(root, declarationPattern);
+  const matchesBySymbol = new Map();
+  const declarationRegex = new RegExp(declarationPattern, "u");
+
+  for (const match of matches) {
+    const declaration = declarationRegex.exec(match.text);
+    const symbol = declaration?.[1] ?? declaration?.[2] ?? null;
+    if (!symbol) continue;
+    const values = matchesBySymbol.get(symbol) ?? [];
+    values.push({
+      file: relative(root, match.path),
+      line: match.line,
+      symbol
+    });
+    matchesBySymbol.set(symbol, values);
+  }
+
+  return componentEntries.map((entry) => {
+    const candidates = entryCandidates.get(entry.name) ?? [];
+    const locations = uniqueLocations(
+      candidates.flatMap((candidate) => matchesBySymbol.get(candidate) ?? [])
+    );
+    const source =
+      locations.length > 0 &&
+      new Set(locations.map((location) => location.file)).size === 1
+        ? locations[0]
+        : null;
+    return {
+      ...entry,
+      source: source ? { ...source, confidence: "static-declaration" } : null,
+      sourceResolution:
+        locations.length > 1 && !source
+          ? { status: "ambiguous", candidateCount: locations.length }
+          : locations.length === 0
+            ? { status: "unresolved" }
+            : { status: "resolved" }
+    };
+  });
+}
+
+export function componentSymbolCandidates(componentName) {
+  const forwardRef = /^ForwardRef\((.+)\)$/u.exec(componentName.trim());
+  const rawName = forwardRef?.[1] ?? componentName.trim();
+  if (!/^[A-Z][A-Za-z0-9_$]*$/u.test(rawName)) return [];
+  const candidates = [rawName];
+  const withoutCompilerSuffix = rawName.replace(/\d+$/u, "");
+  if (withoutCompilerSuffix && withoutCompilerSuffix !== rawName) {
+    candidates.push(withoutCompilerSuffix);
+  }
+  return candidates;
+}
+
+async function searchDeclarations(root, pattern) {
+  const args = ["--json", "--line-number"];
+  for (const glob of sourceGlobs) args.push("--glob", glob);
+  args.push(pattern, root);
+  try {
+    const { stdout } = await execFileAsync("rg", args, {
+      maxBuffer: 4 * 1024 * 1024
+    });
+    return stdout
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line))
+      .filter((event) => event.type === "match")
+      .map((event) => ({
+        path: event.data.path.text,
+        line: event.data.line_number,
+        text: event.data.lines.text
+      }));
+  } catch (error) {
+    if (error.code === 1) return [];
+    if (error.code === "ENOENT") {
+      return searchDeclarationsWithNode(root, pattern);
+    }
+    throw new Error(`component source lookup failed: ${error.message}`);
+  }
+}
+
+async function searchDeclarationsWithNode(root, pattern) {
+  const regex = new RegExp(pattern, "u");
+  const matches = [];
+  for (const path of await collectSourceFiles(root)) {
+    const source = await readFile(path, "utf8");
+    const lines = source.split(/\r?\n/u);
+    lines.forEach((text, index) => {
+      if (!regex.test(text)) return;
+      matches.push({
+        path,
+        line: index + 1,
+        text
+      });
+    });
+  }
+  return matches;
+}
+
+async function collectSourceFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (entry.name === "node_modules" || entry.name === ".git") continue;
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectSourceFiles(path)));
+      continue;
+    }
+    if (!entry.isFile() || !isSearchableSourceFile(entry.name)) continue;
+    files.push(path);
+  }
+  return files;
+}
+
+function isSearchableSourceFile(fileName) {
+  return (
+    /\.(?:ts|tsx)$/u.test(fileName) &&
+    !fileName.endsWith('.d.ts') &&
+    !/\.(?:test|spec|stories)\.[^.]+$/u.test(fileName)
+  );
+}
+
+function uniqueLocations(locations) {
+  const values = new Map();
+  for (const location of locations) {
+    values.set(
+      `${location.file}:${location.line}:${location.symbol}`,
+      location
+    );
+  }
+  return [...values.values()].sort(
+    (left, right) =>
+      left.file.localeCompare(right.file) || left.line - right.line
+  );
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}

--- a/tools/scripts/resolve-component-sources.test.mjs
+++ b/tools/scripts/resolve-component-sources.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  componentSymbolCandidates,
+  resolveComponentSources
+} from "./resolve-component-sources.mjs";
+
+test("component symbol candidates unwrap React compiler names", () => {
+  assert.deepEqual(componentSymbolCandidates("AgentItem2"), [
+    "AgentItem2",
+    "AgentItem"
+  ]);
+  assert.deepEqual(componentSymbolCandidates("ForwardRef(BareButton2)"), [
+    "BareButton2",
+    "BareButton"
+  ]);
+  assert.deepEqual(componentSymbolCandidates("Primitive.span"), []);
+});
+
+test("component source resolver links only unambiguous declarations", async () => {
+  const root = await mkdtemp(join(tmpdir(), "tutti-component-sources-"));
+  try {
+    const packageDirectory = join(root, "packages", "demo");
+    await mkdir(packageDirectory, { recursive: true });
+    await writeFile(
+      join(packageDirectory, "AgentItem.tsx"),
+      [
+        "export const AgentItem = memo(function AgentItem() {",
+        "  return null;",
+        "});",
+        "function HeaderFrame() { return null; }",
+        ""
+      ].join("\n")
+    );
+    const resolved = await resolveComponentSources(
+      [
+        { name: "AgentItem2", count: 3 },
+        { name: "HeaderFrame", count: 1 },
+        { name: "Primitive.span", count: 9 }
+      ],
+      root
+    );
+
+    assert.deepEqual(resolved[0].source, {
+      confidence: "static-declaration",
+      file: "packages/demo/AgentItem.tsx",
+      line: 1,
+      symbol: "AgentItem"
+    });
+    assert.equal(resolved[1].source.line, 4);
+    assert.equal(resolved[2].source, null);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/tools/scripts/run-agent-gui-performance.mjs
+++ b/tools/scripts/run-agent-gui-performance.mjs
@@ -1,0 +1,655 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile
+} from "node:fs/promises";
+import { createServer } from "node:net";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import {
+  CdpClient,
+  defaultTraceCategories,
+  resolveBrowserWebSocketUrl,
+  resolvePageWebSocketUrl,
+  writeStreamToFile
+} from "./capture-electron-trace.mjs";
+import {
+  analyzeElectronTrace,
+  renderElectronTraceMarkdown
+} from "./analyze-electron-trace.mjs";
+import {
+  agentGuiPerformanceScenarios,
+  resolveAgentGuiPerformanceScenario
+} from "./agent-gui-performance-scenarios.mjs";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(scriptDirectory, "..", "..");
+const desktopReadyTimeoutMs = 120_000;
+const scenarioReadyTimeoutMs = 60_000;
+const recoverableQueueTables = [
+  "workspace_agent_runtime_operation_events",
+  "workspace_agent_runtime_operations",
+  "workspace_agent_goal_reconcile_inbox",
+  "workspace_agent_goal_control_operations",
+  "workspace_agent_submit_claims"
+];
+
+if (isMainModule()) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`[perf:agent-gui] ${error.stack ?? error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+export async function main(argv) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printUsage();
+    return;
+  }
+  if (options.listScenarios) {
+    process.stdout.write(
+      `${agentGuiPerformanceScenarios.map((scenario) => scenario.id).join("\n")}\n`
+    );
+    return;
+  }
+  const scenario = resolveAgentGuiPerformanceScenario(options.scenario);
+  const outputDirectory = resolve(
+    options.outputDirectory ?? defaultOutputDirectory(scenario.id, new Date())
+  );
+  const runtimeParent = join(workspaceRoot, ".tmp");
+  await mkdir(runtimeParent, { recursive: true });
+  await mkdir(outputDirectory, { recursive: true });
+  const runtimeDirectory = await mkdtemp(
+    join(runtimeParent, "agent-gui-perf-runtime-")
+  );
+  const stateDirectory = join(runtimeDirectory, "state");
+  const userDataDirectory = join(runtimeDirectory, "electron-user-data");
+  const databasePath = join(stateDirectory, "tuttid.db");
+  const daemonPath = join(runtimeDirectory, "tuttid");
+  const tracePath = join(outputDirectory, "trace.json");
+  const reportJSONPath = join(outputDirectory, "report.json");
+  const reportMarkdownPath = join(outputDirectory, "report.md");
+  const desktopLogPath = join(outputDirectory, "desktop.log");
+  let desktopProcess = null;
+  let pageClient = null;
+  let browserClient = null;
+  let primaryError = null;
+
+  log(`source snapshot: ${basename(options.sourceDatabase)}`);
+  log(`output: ${outputDirectory}`);
+  try {
+    await access(options.sourceDatabase);
+    await mkdir(stateDirectory, { recursive: true });
+    await snapshotSQLiteDatabase(options.sourceDatabase, databasePath);
+    const snapshotInfo = await prepareDatabaseSnapshot(databasePath);
+    log(
+      `snapshot ready: ${snapshotInfo.sessionCount} sessions, ${snapshotInfo.projectCount} projects`
+    );
+
+    await buildDaemon(daemonPath);
+    const cdpPort = await reservePort();
+    desktopProcess = startDesktop({
+      cdpPort,
+      daemonPath,
+      desktopLogPath,
+      stateDirectory,
+      userDataDirectory
+    });
+    const pageWebSocket = await waitForPageWebSocket(
+      cdpPort,
+      desktopProcess,
+      desktopReadyTimeoutMs
+    );
+    pageClient = await CdpClient.connect(pageWebSocket);
+    await pageClient.send("Runtime.enable");
+    browserClient = await CdpClient.connect(
+      await resolveBrowserWebSocketUrl(cdpPort)
+    );
+    const context = {
+      browserClient,
+      pageClient,
+      targetID: targetIDFromWebSocket(pageWebSocket)
+    };
+    const prepared = await scenario.prepare(context, {
+      fromTargetID: options.fromTargetID,
+      toTargetID: options.toTargetID,
+      timeoutMs: scenarioReadyTimeoutMs
+    });
+    log(`scenario ${scenario.id}: ${scenario.describe(prepared)}`);
+
+    await browserClient.send("Tracing.start", {
+      categories: defaultTraceCategories,
+      options: "sampling-frequency=10000",
+      transferMode: "ReturnAsStream"
+    });
+
+    let scenarioResult;
+    try {
+      scenarioResult = await scenario.execute(context, prepared, {
+        timeoutMs: scenarioReadyTimeoutMs
+      });
+    } finally {
+      await stopTrace(browserClient, tracePath);
+    }
+
+    const summary = await analyzeElectronTrace({
+      tracePath,
+      scenario: scenario.id,
+      startMarker: scenario.markers.start,
+      endMarker: scenario.markers.end,
+      milestones: scenario.milestones,
+      minimumLongEventMs: options.minimumLongEventMs,
+      sourceRoot: workspaceRoot
+    });
+    summary.run = {
+      ...scenario.summarize(prepared, scenarioResult),
+      sourceDatabase: basename(options.sourceDatabase),
+      sourceSessionCount: snapshotInfo.sessionCount,
+      sourceProjectCount: snapshotInfo.projectCount,
+      clearedRecoveryRows: snapshotInfo.clearedRecoveryRows
+    };
+    await writeFile(reportJSONPath, `${JSON.stringify(summary, null, 2)}\n`);
+    await writeFile(
+      reportMarkdownPath,
+      renderRunMarkdown(
+        summary,
+        renderElectronTraceMarkdown(summary, { sourceRoot: workspaceRoot })
+      )
+    );
+
+    log(
+      `report-only: ${summary.renders.componentMarkers} component markers, ${summary.renders.radixFamilyMarkers} Radix-family markers, ${summary.timing.longTaskCount} renderer long tasks`
+    );
+    log(`report: ${reportMarkdownPath}`);
+    log(`trace: ${tracePath}`);
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    pageClient?.close();
+    browserClient?.close();
+    if (desktopProcess) {
+      await stopProcessTree(desktopProcess);
+    }
+    if (!options.keepRuntime) {
+      try {
+        await rm(runtimeDirectory, {
+          recursive: true,
+          force: true,
+          maxRetries: 10,
+          retryDelay: 200
+        });
+      } catch (error) {
+        if (!primaryError) process.exitCode = 1;
+        log(`cleanup warning: ${error.message}`);
+      }
+    } else {
+      log(`runtime kept: ${runtimeDirectory}`);
+    }
+  }
+}
+
+async function snapshotSQLiteDatabase(sourcePath, destinationPath) {
+  const escapedDestination = destinationPath.replaceAll("'", "''");
+  await runCommand("sqlite3", [
+    "-readonly",
+    sourcePath,
+    ".timeout 10000",
+    `.backup '${escapedDestination}'`
+  ]);
+}
+
+export async function prepareDatabaseSnapshot(databasePath) {
+  const counts = await sqliteJSON(
+    databasePath,
+    `
+SELECT
+  (SELECT COUNT(*) FROM workspace_agent_sessions) AS sessionCount,
+  (SELECT COUNT(*) FROM user_projects) AS projectCount;
+`
+  );
+  const tableRows = await sqliteJSON(
+    databasePath,
+    `SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name;`
+  );
+  const existingTables = new Set(tableRows.map((row) => row.name));
+  if (existingTables.has("agent_store_schema_migrations")) {
+    const migrationRows = await sqliteJSON(
+      databasePath,
+      `SELECT id FROM agent_store_schema_migrations ORDER BY id;`
+    );
+    const migrationSource = await readFile(
+      join(workspaceRoot, "packages", "agent", "store-sqlite", "migrations.go"),
+      "utf8"
+    );
+    const unknownMigrationIDs = findUnknownAgentTargetMigrationIDs(
+      migrationRows.map((row) => row.id),
+      migrationSource
+    );
+    if (unknownMigrationIDs.length > 0) {
+      throw new Error(
+        `source dev DB has newer Agent target migrations (${unknownMigrationIDs.join(", ")}); SQLite migrations are forward-only, so switch to a compatible checkout or pass --source-db for a compatible snapshot`
+      );
+    }
+  }
+  const queueCounts = {};
+  for (const table of recoverableQueueTables) {
+    if (!existingTables.has(table)) continue;
+    const rows = await sqliteJSON(
+      databasePath,
+      `SELECT COUNT(*) AS count FROM ${table};`
+    );
+    queueCounts[table] = Number(rows[0]?.count ?? 0);
+  }
+
+  const startupRows = await sqliteJSON(
+    databasePath,
+    `
+SELECT workspace_id AS workspaceId, snapshot_json AS snapshotJSON
+FROM workspace_workbench_snapshots
+WHERE workspace_id = (
+  SELECT id
+  FROM workspaces
+  ORDER BY COALESCE(last_opened_at_unix_ms, 0) DESC, updated_at_unix_ms DESC, id ASC
+  LIMIT 1
+)
+LIMIT 1;
+`
+  );
+  const startup = startupRows[0];
+  if (!startup?.snapshotJSON) {
+    throw new Error("startup workspace has no durable Workbench snapshot");
+  }
+  const preparedSnapshot = prepareWorkbenchSnapshotForPerformance(
+    JSON.parse(startup.snapshotJSON)
+  );
+  const deleteStatements = recoverableQueueTables
+    .filter((table) => existingTables.has(table))
+    .map((table) => `DELETE FROM ${table};`)
+    .join("\n");
+  try {
+    await sqliteExec(
+      databasePath,
+      `
+PRAGMA foreign_keys = ON;
+${deleteStatements}
+UPDATE workspace_workbench_snapshots
+SET snapshot_json = '${sqlString(JSON.stringify(preparedSnapshot))}'
+WHERE workspace_id = '${sqlString(startup.workspaceId)}';
+`
+    );
+  } catch (error) {
+    throw new Error(`failed to sanitize isolated database: ${error.message}`);
+  }
+
+  return {
+    sessionCount: Number(counts[0]?.sessionCount ?? 0),
+    projectCount: Number(counts[0]?.projectCount ?? 0),
+    clearedRecoveryRows: Object.values(queueCounts).reduce(
+      (total, count) => total + count,
+      0
+    )
+  };
+}
+
+export function findUnknownAgentTargetMigrationIDs(
+  appliedMigrationIDs,
+  migrationSource
+) {
+  const knownMigrationIDs = new Set(
+    [
+      ...migrationSource.matchAll(/const schemaMigration\w+\s*=\s*"([^"]+)"/gu)
+    ].map((match) => match[1])
+  );
+  return appliedMigrationIDs
+    .filter(
+      (migrationID) =>
+        migrationID.startsWith("agent_targets_") &&
+        !knownMigrationIDs.has(migrationID)
+    )
+    .sort();
+}
+
+export function prepareWorkbenchSnapshotForPerformance(snapshot) {
+  if (
+    !snapshot ||
+    typeof snapshot !== "object" ||
+    !Array.isArray(snapshot.nodes)
+  ) {
+    throw new Error("invalid durable Workbench snapshot");
+  }
+  const nodes = snapshot.nodes.map((node) => structuredClone(node));
+  const candidates = nodes.filter((node) => node?.data?.typeId === "agent-gui");
+  const selected =
+    candidates.find((node) => node.id === snapshot.activeNodeId) ??
+    candidates.find((node) => node.isMinimized !== true) ??
+    candidates[0];
+  if (!selected) {
+    throw new Error("startup Workbench snapshot has no AgentGUI node");
+  }
+  const existingState =
+    selected.data?.snapshotNodeState &&
+    typeof selected.data.snapshotNodeState === "object"
+      ? selected.data.snapshotNodeState
+      : {};
+  selected.data = {
+    ...selected.data,
+    snapshotNodeState: {
+      ...existingState,
+      conversationRailCollapsed: false,
+      lastActiveAgentSessionId: null,
+      lastActiveAgentSessionIdByAgentTargetId: {}
+    }
+  };
+  selected.isMinimized = false;
+  const nodeStack = Array.isArray(snapshot.nodeStack)
+    ? snapshot.nodeStack.filter((nodeID) => nodeID !== selected.id)
+    : [];
+  nodeStack.push(selected.id);
+  return {
+    ...snapshot,
+    nodes,
+    nodeStack,
+    activeNodeId: selected.id
+  };
+}
+
+async function buildDaemon(outputPath) {
+  log("building isolated tuttid");
+  await runCommand(
+    "go",
+    ["build", "-buildvcs=false", "-o", outputPath, "."],
+    join(workspaceRoot, "services", "tuttid")
+  );
+}
+
+function startDesktop(input) {
+  log(`starting isolated Desktop on CDP ${input.cdpPort}`);
+  const logStream = createWriteStream(input.desktopLogPath, { flags: "w" });
+  const child = spawn("pnpm", ["dev:desktop"], {
+    cwd: workspaceRoot,
+    detached: process.platform !== "win32",
+    env: {
+      ...process.env,
+      TUTTI_ANALYTICS_DISABLED: "1",
+      TUTTI_DESKTOP_LOG_OUTPUT: "tee",
+      TUTTI_DESKTOP_USER_DATA_DIR: input.userDataDirectory,
+      TUTTI_ELECTRON_JS_FLAGS: "--max-old-space-size=8192",
+      TUTTI_ELECTRON_REMOTE_DEBUGGING_PORT: String(input.cdpPort),
+      TUTTI_ENV: "development",
+      TUTTI_STATE_DIR: input.stateDirectory,
+      TUTTID_ADDR: "127.0.0.1:0",
+      TUTTID_BIN: input.daemonPath,
+      TUTTID_LOG_OUTPUT: "tee",
+      VITE_TUTTI_REACT_PROFILER: "0",
+      VITE_TUTTI_WHY_DID_YOU_RENDER: "0"
+    },
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  const tail = createBoundedLogTail();
+  for (const stream of [child.stdout, child.stderr]) {
+    stream?.on("data", (chunk) => {
+      logStream.write(chunk);
+      tail.append(chunk.toString());
+    });
+  }
+  child.once("close", () => logStream.end());
+  child.performanceLogTail = tail;
+  return child;
+}
+
+async function waitForPageWebSocket(port, child, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(
+        `Desktop exited before CDP became ready\n${child.performanceLogTail.read()}`
+      );
+    }
+    try {
+      return await resolvePageWebSocketUrl(port);
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(250);
+  }
+  throw new Error(
+    `timed out waiting for Desktop CDP: ${lastError?.message ?? "unknown error"}\n${child.performanceLogTail.read()}`
+  );
+}
+
+async function stopTrace(client, tracePath) {
+  const complete = client.waitForEvent("Tracing.tracingComplete");
+  await client.send("Tracing.end");
+  const event = await complete;
+  const stream = event.params?.stream;
+  if (!stream) {
+    throw new Error("Tracing.tracingComplete did not include a stream handle");
+  }
+  await writeStreamToFile(client, stream, tracePath);
+}
+
+async function sqliteJSON(databasePath, sql) {
+  const output = await runCommand("sqlite3", ["-json", databasePath, sql]);
+  return output.trim() ? JSON.parse(output) : [];
+}
+
+async function sqliteExec(databasePath, sql) {
+  await runCommand("sqlite3", [databasePath, sql]);
+}
+
+function runCommand(command, args, cwd = workspaceRoot) {
+  return new Promise((resolveCommand, rejectCommand) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.once("error", rejectCommand);
+    child.once("exit", (code, signal) => {
+      if (code === 0) {
+        resolveCommand(stdout);
+      } else {
+        rejectCommand(
+          new Error(
+            `${command} failed (${code ?? signal ?? "unknown"})${stderr.trim() ? `: ${stderr.trim()}` : ""}`
+          )
+        );
+      }
+    });
+  });
+}
+
+async function reservePort() {
+  const server = createServer();
+  await new Promise((resolveListen, rejectListen) => {
+    server.once("error", rejectListen);
+    server.listen(0, "127.0.0.1", resolveListen);
+  });
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : null;
+  await new Promise((resolveClose) => server.close(resolveClose));
+  if (!port) throw new Error("failed to reserve a CDP port");
+  return port;
+}
+
+async function stopProcessTree(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  if (process.platform !== "win32") {
+    try {
+      process.kill(-child.pid, "SIGINT");
+    } catch {
+      child.kill("SIGINT");
+    }
+  } else {
+    child.kill("SIGINT");
+  }
+  await Promise.race([onceExit(child), delay(5_000)]);
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  if (process.platform !== "win32") {
+    try {
+      process.kill(-child.pid, "SIGKILL");
+    } catch {
+      child.kill("SIGKILL");
+    }
+  } else {
+    child.kill("SIGKILL");
+  }
+  await Promise.race([onceExit(child), delay(2_000)]);
+}
+
+function onceExit(child) {
+  return new Promise((resolveExit) => child.once("exit", resolveExit));
+}
+
+function createBoundedLogTail(limit = 20_000) {
+  let value = "";
+  return {
+    append(chunk) {
+      value = (value + chunk).slice(-limit);
+    },
+    read() {
+      return value;
+    }
+  };
+}
+
+function renderRunMarkdown(summary, traceMarkdown) {
+  const runLines = [
+    "## Scenario contract",
+    "",
+    `- Outcome: ${summary.run.outcome}`,
+    `- Source DB snapshot: ${summary.run.sourceDatabase}`,
+    `- Source sessions: ${summary.run.sourceSessionCount}`,
+    `- Source projects: ${summary.run.sourceProjectCount}`,
+    ...summary.run.details.map(
+      (detail) => `- ${detail.label}: ${detail.value}`
+    ),
+    `- Stability criterion: ${summary.run.stabilityCriterion}`,
+    `- Recovery rows removed from isolated copy: ${summary.run.clearedRecoveryRows}`,
+    "",
+    "| Assertion | Result |",
+    "| --- | --- |",
+    ...summary.run.assertions.map(
+      (assertion) =>
+        `| ${assertion.name} | ${assertion.passed ? "pass" : "fail"} |`
+    ),
+    ""
+  ].join("\n");
+  return traceMarkdown.replace(
+    "## Phase timings",
+    `${runLines}\n## Phase timings`
+  );
+}
+
+function sqlString(value) {
+  return String(value).replaceAll("'", "''");
+}
+
+function defaultOutputDirectory(scenarioID, date) {
+  const stamp = date
+    .toISOString()
+    .replaceAll(":", "")
+    .replaceAll("-", "")
+    .replace(/\.\d{3}Z$/u, "Z");
+  return join(workspaceRoot, ".tmp", "perf", "agent-gui", scenarioID, stamp);
+}
+
+function parseArgs(argv) {
+  const options = {
+    sourceDatabase: join(homedir(), ".tutti-dev", "tuttid.db"),
+    minimumLongEventMs: 16,
+    scenario: "provider-switch"
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") continue;
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg === "--source-db") {
+      options.sourceDatabase = resolve(requiredValue(argv, (index += 1), arg));
+    } else if (arg === "--output") {
+      options.outputDirectory = requiredValue(argv, (index += 1), arg);
+    } else if (arg === "--scenario") {
+      options.scenario = requiredValue(argv, (index += 1), arg);
+    } else if (arg === "--list-scenarios") {
+      options.listScenarios = true;
+    } else if (arg === "--from-target-id") {
+      options.fromTargetID = requiredValue(argv, (index += 1), arg);
+    } else if (arg === "--to-target-id") {
+      options.toTargetID = requiredValue(argv, (index += 1), arg);
+    } else if (arg === "--min-ms") {
+      options.minimumLongEventMs = positiveNumber(
+        requiredValue(argv, (index += 1), arg),
+        arg
+      );
+    } else if (arg === "--keep-runtime") {
+      options.keepRuntime = true;
+    } else {
+      throw new Error(`unknown option: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function requiredValue(argv, index, option) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+}
+
+function positiveNumber(value, option) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) {
+    throw new Error(`${option} must be a positive number`);
+  }
+  return number;
+}
+
+function isMainModule() {
+  return process.argv[1]
+    ? fileURLToPath(import.meta.url) === resolve(process.argv[1])
+    : false;
+}
+
+function targetIDFromWebSocket(webSocketURL) {
+  const targetID = new URL(webSocketURL).pathname
+    .split("/")
+    .filter(Boolean)
+    .at(-1);
+  if (!targetID) throw new Error("could not resolve CDP page target id");
+  return targetID;
+}
+
+function log(message) {
+  process.stderr.write(`[perf:agent-gui] ${message}\n`);
+}
+
+function printUsage() {
+  process.stdout.write(
+    `Run an isolated, report-only AgentGUI performance scenario.\n\nUsage:\n  pnpm perf:agent-gui\n  pnpm perf:agent-gui -- --scenario session-switch\n  pnpm perf:agent-gui -- --list-scenarios\n\nOptions:\n  --scenario <id>          Scenario. Default: provider-switch\n  --list-scenarios         Print available scenario ids\n  --source-db <path>       Source dev DB. Default: ~/.tutti-dev/tuttid.db\n  --output <directory>     Report/trace output directory under .tmp by default\n  --from-target-id <id>    Source Agent target for provider scenarios\n  --to-target-id <id>      Target Agent target for provider scenarios\n  --min-ms <milliseconds>  Long-event threshold. Default: 16\n  --keep-runtime           Keep isolated DB and Electron userData for debugging\n`
+  );
+  process.stdout.write(
+    "\n--min-ms applies to renderer-main RunTask duration, not all trace events.\n"
+  );
+}

--- a/tools/scripts/run-agent-gui-performance.test.mjs
+++ b/tools/scripts/run-agent-gui-performance.test.mjs
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  providerSwitchScenario,
+  selectProviderSwitchTargets
+} from "./agent-gui-performance-scenario.mjs";
+import { selectSessionSwitchTargets } from "./agent-gui-performance-helpers.mjs";
+import {
+  agentGuiPerformanceScenarios,
+  resolveAgentGuiPerformanceScenario
+} from "./agent-gui-performance-scenarios.mjs";
+import {
+  findUnknownAgentTargetMigrationIDs,
+  prepareWorkbenchSnapshotForPerformance
+} from "./run-agent-gui-performance.mjs";
+
+test("performance snapshot rejects newer Agent target migrations", () => {
+  assert.deepEqual(
+    findUnknownAgentTargetMigrationIDs(
+      ["agent_targets_v1", "agent_targets_v2", "workspace_agent_activity_v2"],
+      'const schemaMigrationAgentTargetsV1 = "agent_targets_v1"'
+    ),
+    ["agent_targets_v2"]
+  );
+});
+
+test("performance snapshot focuses AgentGUI without selecting a session", () => {
+  const source = {
+    schemaVersion: 1,
+    nodes: [
+      {
+        id: "files",
+        data: { instanceId: "files", typeId: "workspace-files" }
+      },
+      {
+        id: "agent",
+        isMinimized: true,
+        data: {
+          instanceId: "agent",
+          typeId: "agent-gui",
+          snapshotNodeState: {
+            agentTargetId: "local:codex",
+            conversationRailCollapsed: true,
+            lastActiveAgentSessionId: "session-1",
+            lastActiveAgentSessionIdByAgentTargetId: {
+              "local:codex": "session-1"
+            }
+          }
+        }
+      }
+    ],
+    nodeStack: ["agent", "files"],
+    activeNodeId: "files"
+  };
+
+  const prepared = prepareWorkbenchSnapshotForPerformance(source);
+  const agent = prepared.nodes.find((node) => node.id === "agent");
+  assert.equal(prepared.activeNodeId, "agent");
+  assert.deepEqual(prepared.nodeStack, ["files", "agent"]);
+  assert.equal(agent.isMinimized, false);
+  assert.deepEqual(agent.data.snapshotNodeState, {
+    agentTargetId: "local:codex",
+    conversationRailCollapsed: false,
+    lastActiveAgentSessionId: null,
+    lastActiveAgentSessionIdByAgentTargetId: {}
+  });
+  assert.equal(source.nodes[1].isMinimized, true);
+});
+
+test("provider switch target selection reuses selected target then chooses next", () => {
+  assert.deepEqual(
+    selectProviderSwitchTargets(
+      [
+        { targetID: "local:codex", disabled: false },
+        { targetID: "local:claude-code", disabled: false },
+        { targetID: "local:cursor", disabled: true }
+      ],
+      { selectedTargetID: "local:codex" }
+    ),
+    {
+      sourceTargetID: "local:codex",
+      targetTargetID: "local:claude-code"
+    }
+  );
+});
+
+test("provider switch summary separates semantic outcome from metrics", () => {
+  assert.deepEqual(
+    providerSwitchScenario.summarize(
+      {
+        sourceTargetID: "local:codex",
+        targetTargetID: "local:claude-code",
+        sectionCount: 30,
+        itemCount: 120
+      },
+      { selected: true, sectionCount: 30, itemCount: 118 }
+    ),
+    {
+      outcome: "passed",
+      assertions: [
+        { name: "target changed", passed: true },
+        { name: "target selected", passed: true },
+        { name: "rail contains sections", passed: true }
+      ],
+      details: [
+        {
+          label: "Provider switch",
+          value: "local:codex → local:claude-code"
+        },
+        { label: "Sections", value: "30 → 30" },
+        { label: "Items", value: "120 → 118" }
+      ],
+      stabilityCriterion:
+        "five identical rail snapshots at 200 ms intervals, then two animation frames plus 250 ms settling tail"
+    }
+  );
+});
+
+test("session switch target selection keeps active source and chooses another", () => {
+  assert.deepEqual(
+    selectSessionSwitchTargets(
+      [{ id: "session-1" }, { id: "session-2" }, { id: "session-3" }],
+      "session-2"
+    ),
+    { sourceSessionID: "session-2", targetSessionID: "session-1" }
+  );
+});
+
+test("performance scenario registry exposes renderer and window scenarios", () => {
+  assert.deepEqual(
+    agentGuiPerformanceScenarios.map((scenario) => scenario.id),
+    [
+      "provider-switch",
+      "session-switch",
+      "provider-session-cycle",
+      "workbench-window-lifecycle",
+      "desktop-window-state"
+    ]
+  );
+  assert.equal(
+    resolveAgentGuiPerformanceScenario("desktop-window-state").id,
+    "desktop-window-state"
+  );
+  assert.throws(
+    () => resolveAgentGuiPerformanceScenario("missing"),
+    /unknown scenario: missing/
+  );
+});


### PR DESCRIPTION
## Summary

- add `pnpm perf:agent-gui` for isolated AgentGUI performance trace capture and report generation
- add scenario modules for provider/session switching and desktop/window lifecycle flows
- add trace analysis/report utilities with component source resolution
- add desktop diagnostic userData override and typed host-window maximize helper needed by window scenarios

This PR is only the engineering/performance-analysis chain. It intentionally does not include the AgentGUI optimization changes that were evaluated separately.

## Validation

- `pnpm exec oxfmt --check ...`
- `node --test tools/scripts/analyze-electron-trace.test.mjs tools/scripts/resolve-component-sources.test.mjs tools/scripts/run-agent-gui-performance.test.mjs`
- `node --test --experimental-strip-types apps/desktop/src/main/defaults.test.ts apps/desktop/src/main/windows/hostWindowMaximize.test.ts`
- `pnpm --filter @tutti-os/desktop typecheck`
- pre-push `pnpm check:changed -- --push-ready`: passed 11 lanes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->