### PR TITLE
fix(agent): allow retry after extension install failure

### DIFF
--- a/docs/architecture/agent-extensions.md
+++ b/docs/architecture/agent-extensions.md
@@ -269,7 +269,9 @@ by setup close; they are not discarded as background goroutine errors.
 AgentGUI recognizes target-runtime setup metadata on the exact Target. Its
 shared panel owns explicit confirmation and plan presentation,
 progress polling, runtime-advertised auth method selection, login progress, and
-retry. Background action polling preserves the established detection result
+retry. A failed or interrupted install keeps its durable error visible while
+the retained plan can start a new action with a new client action ID; refreshing
+the old action is not an installation retry. Background action polling preserves the established detection result
 instead of restarting the detection presentation on every snapshot request.
 Failed explicit authentication keeps the provider's ACP error on the durable
 action and presents it beside the localized failure summary while leaving the

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -1378,6 +1378,35 @@ invalid_grant`. Search `tuttid.log` for
   [AgentTargetSetupGate.tsx](../../../packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.tsx)
   [agentTargetSetupNotificationController.ts](../../../packages/agent/gui/shared/agentEnv/agentTargetSetupNotificationController.ts)
 
+### Extension runtime installation stays failed after restart
+
+- Symptom:
+  An Agent Extension runtime install fails once. Reopening Tutti restores the
+  same failure, and checking again never offers or starts another installation.
+- Quick checks:
+  Inspect the setup snapshot. If it contains a failed or interrupted install
+  action plus a non-null install plan, the daemon has enough information to
+  retry. Confirm the visible action starts `setup/install` with a new
+  `clientActionId`; a setup GET only refreshes the persisted failure.
+- Root cause:
+  Failed setup actions are durable by design. The setup panel rendered its
+  install button only for `not_installed`, while mapping failed/interrupted
+  install actions to `failed`. Its generic check-again action only fetched the
+  same durable snapshot, so restart could not change the state.
+- Fix:
+  Keep the failed action and provider error visible. When a failed or
+  interrupted install snapshot retains a plan, offer an explicit reinstall
+  action that submits the plan digest with a fresh client action ID. Do not
+  erase the previous failure or treat a GET refresh as a retry.
+- Validation:
+  Mount the setup panel from an initial persisted failed-install snapshot,
+  verify the error remains visible, and assert reinstall submits the retained
+  plan with a client action ID different from the failed action.
+- References:
+  [setup.go](../../../services/tuttid/service/agentextension/setup.go)
+  [AgentTargetSetupGate.tsx](../../../packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.tsx)
+  [agentTargetSetupController.tsx](../../../packages/agent/gui/shared/agentEnv/agentTargetSetupController.tsx)
+
 ### Vertex setup reports ready but the first prompt cannot load credentials
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -39,6 +39,7 @@ Provider discovery, installation, authentication, models, configuration, and run
 - [OpenCode effort changes fail with `effort not found`](./agent-provider-setup.md#opencode-effort-changes-fail-with-effort-not-found)
 - [OpenCode model picker has fewer models than the terminal](./agent-provider-setup.md#opencode-model-picker-has-fewer-models-than-the-terminal)
 - [Provider setup notice flashes after switching to an already-connected agent](./agent-provider-setup.md#provider-setup-notice-flashes-after-switching-to-an-already-connected-agent)
+- [Extension runtime installation stays failed after restart](./agent-provider-setup.md#extension-runtime-installation-stays-failed-after-restart)
 
 ## [Agent Sessions And Lifecycle](./agent-session-lifecycle.md)
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.spec.tsx
@@ -128,6 +128,28 @@ describe("AgentTargetSetupGate", () => {
     expect(await screen.findByRole("dialog")).toBeTruthy();
   });
 
+  it("reinstalls from a persisted failed install action", async () => {
+    const install = vi.fn<AgentHostAgentTargetSetupWatch["install"]>();
+    const setup = createWatch(failedInstall("extension:codebuddy"), {
+      install
+    });
+    installHost(new Map([["extension:codebuddy", setup.watch]]));
+
+    render(<Harness openDialog target={codebuddyTarget} />);
+
+    expect(await screen.findByText("Runtime setup failed")).toBeTruthy();
+    expect(screen.getByText("fixture install failed")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Reinstall runtime" }));
+
+    await waitFor(() => expect(install).toHaveBeenCalledTimes(1));
+    expect(install.mock.calls[0]?.[0]).toMatchObject({
+      planDigest: "a".repeat(64)
+    });
+    expect(install.mock.calls[0]?.[0].clientActionId).not.toBe(
+      "failed-client-action"
+    );
+  });
+
   it("authenticates with the selected method and renders action errors", async () => {
     const authenticate =
       vi.fn<AgentHostAgentTargetSetupWatch["authenticate"]>();
@@ -416,6 +438,27 @@ function authRequired(agentTargetId: string): AgentHostAgentTargetSetupState {
       reason: null,
       plan: null,
       action: null
+    },
+    loading: false,
+    failed: false
+  };
+}
+
+function failedInstall(agentTargetId: string): AgentHostAgentTargetSetupState {
+  return {
+    snapshot: {
+      ...notInstalled(agentTargetId).snapshot!,
+      status: "failed",
+      reason: "install_failed",
+      action: {
+        actionId: "failed-install-action",
+        clientActionId: "failed-client-action",
+        kind: "install",
+        status: "failed",
+        phase: "complete",
+        errorCode: "install_failed",
+        errorMessage: "fixture install failed"
+      }
     },
     loading: false,
     failed: false

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.tsx
@@ -73,6 +73,11 @@ export function AgentTargetSetupGate({
   };
   const actionRunning = isSetupActionRunning(snapshot?.action?.status);
   const actionFailed = isSetupActionFailed(snapshot?.action?.status);
+  const installRetryAvailable =
+    snapshot?.status === "failed" &&
+    snapshot.action?.kind === "install" &&
+    actionFailed &&
+    Boolean(snapshot.plan);
   const phase = actionRunning ? (snapshot?.action?.phase ?? null) : null;
   const statusLabel = phase
     ? targetSetupPhaseLabel(t, phase)
@@ -193,7 +198,9 @@ export function AgentTargetSetupGate({
                     : undefined
                 }
                 action={
-                  snapshot?.status === "not_installed" && snapshot.plan ? (
+                  (snapshot?.status === "not_installed" ||
+                    installRetryAvailable) &&
+                  snapshot.plan ? (
                     <Button
                       type="button"
                       size="sm"
@@ -202,7 +209,11 @@ export function AgentTargetSetupGate({
                     >
                       {installPending
                         ? t("agentHost.agentGui.targetSetupStarting")
-                        : t("agentHost.agentGui.targetSetupInstall")}
+                        : t(
+                            installRetryAvailable
+                              ? "agentHost.agentGui.targetSetupReinstall"
+                              : "agentHost.agentGui.targetSetupInstall"
+                          )}
                     </Button>
                   ) : undefined
                 }

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -50,6 +50,7 @@ export const enAgentGui = {
   },
   targetSetupChecking: "Checking local and Tutti-managed runtimes…",
   targetSetupInstall: "Install runtime",
+  targetSetupReinstall: "Reinstall runtime",
   targetSetupStarting: "Starting installation…",
   targetSetupAuthMethod: "Sign-in method",
   targetSetupAuthenticate: "Continue to sign in",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -46,6 +46,7 @@ export const zhCNAgentGui = {
   },
   targetSetupChecking: "正在检测本地和 Tutti 托管运行时…",
   targetSetupInstall: "安装运行时",
+  targetSetupReinstall: "重新安装运行时",
   targetSetupStarting: "正在启动安装…",
   targetSetupAuthMethod: "登录方式",
   targetSetupAuthenticate: "继续登录",


### PR DESCRIPTION
## Summary

- keep durable failed/interrupted Agent Extension install details visible
- expose an explicit reinstall action when the failed snapshot retains an install plan
- start retry with a fresh client action ID instead of refreshing the persisted failure
- document the retry invariant and troubleshooting path

## Verification

- `pnpm --filter @tutti-os/agent-gui test -- agent-gui/agentGuiNode/view/AgentTargetSetupGate.spec.tsx` (228 files, 1987 tests passed)
- `pnpm check:changed` (11 lanes passed)
- pre-push `pnpm check:changed -- --push-ready` (12 lanes passed)

## Fallback Three Questions

- Source: durable failed/interrupted Target runtime install action with a retained daemon-issued install plan.
- Why can it not be fixed at that source? Daemon state is correct and already accepts a new action ID; AgentGUI omitted the explicit retry command for `failed` snapshots.
- Removal condition: this is explicit user recovery, not an automatic fallback. It remains required while runtime installation may fail or be interrupted.

## Checklist

- [x] This PR does not change session/turn/goal/runtime-operation lifecycle semantics; it only restores the existing Target setup retry command in AgentGUI.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->