### PR TITLE
fix(agent-gui): preserve prompt asset restore metadata

### DIFF
--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -517,6 +517,7 @@ export interface AgentPromptContentBlock {
   uri?: string;
   hostPath?: string;
   uploadStatus?: string;
+  storagePolicy?: string;
   assetId?: string;
   kind?: string;
   sizeBytes?: number;

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
@@ -395,7 +395,13 @@ describe("AgentQueuedPromptPanel", () => {
                 type: "image",
                 mimeType: "image/png",
                 path: "/agent-prompt-assets/staged.png",
-                name: "staged.png"
+                name: "staged.png",
+                uri: "workspace/user/local-assets/sha.png",
+                hostPath: "/Users/me/staged.png",
+                assetId: "asset-1",
+                kind: "image",
+                uploadStatus: "uploaded",
+                storagePolicy: "cloud-backed"
               }
             ],
             createdAtUnixMs: 1
@@ -417,7 +423,13 @@ describe("AgentQueuedPromptPanel", () => {
         agentSessionId: "session-1",
         mimeType: "image/png",
         name: "staged.png",
-        path: "/agent-prompt-assets/staged.png"
+        path: "/agent-prompt-assets/staged.png",
+        uri: "workspace/user/local-assets/sha.png",
+        hostPath: "/Users/me/staged.png",
+        assetId: "asset-1",
+        kind: "image",
+        uploadStatus: "uploaded",
+        storagePolicy: "cloud-backed"
       });
       expect(
         container.querySelector(".agent-gui-node__composer-queued-prompt-image")

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.tsx
@@ -194,6 +194,12 @@ class AgentQueuedPromptImage extends Component<
       mimeType: props.image.mimeType,
       name: props.image.name?.trim() ?? "",
       path: props.image.path?.trim() ?? "",
+      uri: props.image.uri?.trim() ?? "",
+      hostPath: props.image.hostPath?.trim() ?? "",
+      assetId: props.image.assetId?.trim() ?? "",
+      kind: props.image.kind?.trim() ?? "",
+      uploadStatus: props.image.uploadStatus?.trim() ?? "",
+      storagePolicy: props.image.storagePolicy?.trim() ?? "",
       remoteUrl: props.image.url?.trim() ?? "",
       workspaceId: props.workspaceId?.trim() ?? ""
     });
@@ -229,6 +235,12 @@ class AgentQueuedPromptImage extends Component<
         mimeType: image.mimeType,
         name: image.name?.trim() ?? "",
         path,
+        uri: image.uri?.trim() ?? "",
+        hostPath: image.hostPath?.trim() ?? "",
+        assetId: image.assetId?.trim() ?? "",
+        kind: image.kind?.trim() ?? "",
+        uploadStatus: image.uploadStatus?.trim() ?? "",
+        storagePolicy: image.storagePolicy?.trim() ?? "",
         remoteUrl,
         runtime,
         workspaceId

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftAttachments.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftAttachments.ts
@@ -54,6 +54,7 @@ import {
 } from "./composerDraftUtils";
 import { reportAgentComposerDiagnostic } from "./agentComposerDiagnostics";
 import type { AgentGUIComposerContentType } from "../engagement/agentGUIEngagement.types";
+import { normalizeAgentPromptAssetRestoreMetadata } from "../model/agentPromptAssetRestoreMetadata";
 
 export interface WorkspaceReferencePickResult {
   files: readonly WorkspaceFileReference[];
@@ -342,6 +343,9 @@ export function useComposerDraftAttachments({
                         ...(uploadedImage.path
                           ? { path: uploadedImage.path }
                           : {}),
+                        ...normalizeAgentPromptAssetRestoreMetadata(
+                          uploadedImage
+                        ),
                         previewUrl: image.previewUrl,
                         uploading: false
                       }

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts
@@ -89,6 +89,29 @@ describe("agentComposerDraft", () => {
     ).toEqual([]);
   });
 
+  it("preserves prompt image restore metadata through composer draft round trips", () => {
+    const content = [
+      {
+        type: "image" as const,
+        mimeType: "image/png" as const,
+        path: "/agent-prompt-assets/staged.png",
+        name: "staged.png",
+        uri: "workspace/user/local-assets/sha.png",
+        hostPath: "/Users/me/staged.png",
+        assetId: "asset-1",
+        kind: "image",
+        uploadStatus: "uploaded",
+        storagePolicy: "cloud-backed"
+      }
+    ];
+
+    const draft = agentPromptContentToComposerDraft(content, "restored");
+
+    expect(agentComposerDraftToPromptContent({ draft, skills: [] })).toEqual(
+      content
+    );
+  });
+
   it("materializes prepared URL file locators as Markdown links", () => {
     const content = [
       {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
@@ -21,6 +21,7 @@ import {
   materializeAgentComposerFileMentions
 } from "./agentExternalPromptFiles";
 import { agentComposerFileMentionReferences } from "../agentRichText/agentMentionMarkdown";
+import { normalizeAgentPromptAssetRestoreMetadata } from "./agentPromptAssetRestoreMetadata";
 
 const PASTED_TEXT_MENTION_PREVIEW_MAX_CHARS = 10;
 
@@ -301,7 +302,8 @@ export function normalizeAgentPromptContentBlocks(
             : imagePath
               ? { path: imagePath }
               : {}),
-        ...(block.name?.trim() ? { name: block.name.trim() } : {})
+        ...(block.name?.trim() ? { name: block.name.trim() } : {}),
+        ...normalizeAgentPromptAssetRestoreMetadata(block)
       });
       continue;
     }
@@ -464,7 +466,8 @@ export function agentComposerDraftToPromptContent(input: {
           : image.path
             ? { path: image.path }
             : { data: image.data }),
-        name: image.name
+        name: image.name,
+        ...normalizeAgentPromptAssetRestoreMetadata(image)
       })),
     ...largeTextPromptContent(agentComposerDraftLargeTexts(input.draft))
   ]);
@@ -772,6 +775,7 @@ function agentPromptImageBlockToDraftImage(
     ...(image.data ? { data: image.data } : {}),
     ...(image.url ? { url: image.url } : {}),
     ...(image.path ? { path: image.path } : {}),
+    ...normalizeAgentPromptAssetRestoreMetadata(image),
     previewUrl:
       typeof image.data === "string" && image.data
         ? `data:${image.mimeType};base64,${image.data}`

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -122,6 +122,12 @@ export interface AgentComposerImageBlock {
   data?: string;
   url?: string;
   path?: string;
+  uri?: string;
+  hostPath?: string;
+  assetId?: string;
+  kind?: string;
+  uploadStatus?: string;
+  storagePolicy?: string;
   previewUrl: string;
   uploading?: boolean;
   uploadError?: string;

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentPromptAssetRestoreMetadata.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentPromptAssetRestoreMetadata.ts
@@ -1,0 +1,27 @@
+export interface AgentPromptAssetRestoreMetadata {
+  assetId?: string;
+  hostPath?: string;
+  kind?: string;
+  storagePolicy?: string;
+  uploadStatus?: string;
+  uri?: string;
+}
+
+export function normalizeAgentPromptAssetRestoreMetadata(
+  input: AgentPromptAssetRestoreMetadata
+): AgentPromptAssetRestoreMetadata {
+  const assetId = input.assetId?.trim();
+  const hostPath = input.hostPath?.trim();
+  const kind = input.kind?.trim();
+  const storagePolicy = input.storagePolicy?.trim();
+  const uploadStatus = input.uploadStatus?.trim();
+  const uri = input.uri?.trim();
+  return {
+    ...(assetId ? { assetId } : {}),
+    ...(hostPath ? { hostPath } : {}),
+    ...(kind ? { kind } : {}),
+    ...(storagePolicy ? { storagePolicy } : {}),
+    ...(uploadStatus ? { uploadStatus } : {}),
+    ...(uri ? { uri } : {})
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/queuedPromptImageLoadOwner.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/queuedPromptImageLoadOwner.ts
@@ -7,6 +7,12 @@ export interface QueuedPromptImageLoadRequest {
   mimeType: string;
   name: string;
   path: string;
+  uri: string;
+  hostPath: string;
+  assetId: string;
+  kind: string;
+  uploadStatus: string;
+  storagePolicy: string;
   remoteUrl: string;
   runtime: AgentActivityRuntime;
   workspaceId: string;
@@ -21,6 +27,12 @@ export function queuedPromptImageLoadRequestIdentity(
     request.agentSessionId,
     request.attachmentId,
     request.path,
+    request.uri,
+    request.hostPath,
+    request.assetId,
+    request.kind,
+    request.uploadStatus,
+    request.storagePolicy,
     request.mimeType,
     request.name,
     request.remoteUrl
@@ -56,6 +68,12 @@ export class QueuedPromptImageLoadOwner {
       mimeType,
       name,
       path,
+      uri,
+      hostPath,
+      assetId,
+      kind,
+      uploadStatus,
+      storagePolicy,
       runtime,
       workspaceId
     } = this.request;
@@ -74,7 +92,13 @@ export class QueuedPromptImageLoadOwner {
         agentSessionId,
         mimeType,
         name,
-        path
+        path,
+        uri,
+        hostPath,
+        assetId,
+        kind,
+        uploadStatus,
+        storagePolicy
       });
     };
     void readAsset()

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -240,6 +240,7 @@ export interface AgentActivityRuntimeReadPromptAssetInput {
   name?: string | null;
   path?: string | null;
   sha256?: string | null;
+  storagePolicy?: string | null;
   uploadStatus?: string | null;
   uri?: string | null;
   workspaceId: string;

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageImages.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageImages.tsx
@@ -99,7 +99,13 @@ function useAgentMessageImageSources(images: readonly AgentMessageImageVM[]): {
             agentSessionId: image.agentSessionId,
             mimeType: image.mimeType,
             name: image.name,
-            path: image.path
+            path: image.path,
+            uri: image.uri,
+            hostPath: image.hostPath,
+            assetId: image.assetId,
+            kind: image.kind,
+            uploadStatus: image.uploadStatus,
+            storagePolicy: image.storagePolicy
           });
       if (!readImage) continue;
       setLoadingIds((current) => new Set(current).add(image.id));

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -416,7 +416,13 @@ describe("AgentTranscriptItemView render stability", () => {
           agentSessionId: "session-1",
           mimeType: "image/png",
           name: "screen.png",
-          path: "/prompt-assets/screen.png"
+          path: "/prompt-assets/screen.png",
+          uri: "workspace/user/local-assets/sha.png",
+          hostPath: "/Users/me/screen.png",
+          assetId: "asset-1",
+          kind: "image",
+          uploadStatus: "uploaded",
+          storagePolicy: "cloud-backed"
         }
       ],
       occurredAtUnixMs: 1
@@ -466,6 +472,19 @@ describe("AgentTranscriptItemView render stability", () => {
     );
     expect(screen.queryByTestId("agent-gui-message-image-loading")).toBeNull();
     expect(readPromptAsset).toHaveBeenCalledTimes(1);
+    expect(readPromptAsset).toHaveBeenCalledWith({
+      workspaceId: "room-1",
+      agentSessionId: "session-1",
+      mimeType: "image/png",
+      name: "screen.png",
+      path: "/prompt-assets/screen.png",
+      uri: "workspace/user/local-assets/sha.png",
+      hostPath: "/Users/me/screen.png",
+      assetId: "asset-1",
+      kind: "image",
+      uploadStatus: "uploaded",
+      storagePolicy: "cloud-backed"
+    });
     expect(readSessionAttachment).not.toHaveBeenCalled();
 
     delete (window as { agentActivityRuntime?: unknown }).agentActivityRuntime;

--- a/packages/agent/gui/shared/agentConversation/contracts/agentMessageRowVM.ts
+++ b/packages/agent/gui/shared/agentConversation/contracts/agentMessageRowVM.ts
@@ -45,6 +45,12 @@ export interface AgentMessageImageVM {
   data?: string | null;
   url?: string | null;
   path?: string | null;
+  uri?: string | null;
+  hostPath?: string | null;
+  assetId?: string | null;
+  kind?: string | null;
+  uploadStatus?: string | null;
+  storagePolicy?: string | null;
 }
 
 export interface AgentThinkingContentVM {

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationUserProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationUserProjection.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceAgentSessionDetailMessage } from "../../workspaceAgentSessionDetailViewModel";
+import { projectConversationUserRow } from "./agentConversationUserProjection";
+
+describe("projectConversationUserRow", () => {
+  it("preserves prompt image restore metadata from historical message content", () => {
+    const message: WorkspaceAgentSessionDetailMessage = {
+      id: "message-1",
+      body: "",
+      turnId: "turn-1",
+      sourceTimelineItems: [
+        {
+          id: 1,
+          workspaceId: "workspace-1",
+          agentSessionId: "session-1",
+          eventId: "event-1",
+          actorType: "user",
+          actorId: "user-1",
+          itemType: "message",
+          payload: {
+            content: [
+              {
+                type: "image",
+                mimeType: "image/png",
+                name: "screen.png",
+                path: "/agent-prompt-assets/screen.png",
+                uri: "workspace/user/local-assets/sha.png",
+                hostPath: "/Users/me/screen.png",
+                assetId: "asset-1",
+                kind: "image",
+                uploadStatus: "uploaded",
+                storagePolicy: "cloud-backed"
+              }
+            ]
+          }
+        }
+      ]
+    };
+
+    expect(
+      projectConversationUserRow(message, "turn-fallback", "workspace-fallback")
+        .messages[0]?.images?.[0]
+    ).toMatchObject({
+      workspaceId: "workspace-1",
+      agentSessionId: "session-1",
+      path: "/agent-prompt-assets/screen.png",
+      uri: "workspace/user/local-assets/sha.png",
+      hostPath: "/Users/me/screen.png",
+      assetId: "asset-1",
+      kind: "image",
+      uploadStatus: "uploaded",
+      storagePolicy: "cloud-backed"
+    });
+  });
+});

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationUserProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationUserProjection.ts
@@ -52,7 +52,13 @@ function projectUserMessageContentParts(
         name: image.name,
         data: image.data,
         url: image.url,
-        path: image.path
+        path: image.path,
+        uri: image.uri,
+        hostPath: image.hostPath,
+        assetId: image.assetId,
+        kind: image.kind,
+        uploadStatus: image.uploadStatus,
+        storagePolicy: image.storagePolicy
       })),
       occurredAtUnixMs: message.occurredAtUnixMs ?? null,
       sourceTimelineItems: message.sourceTimelineItems
@@ -107,6 +113,12 @@ interface UserPromptImageBlock {
   data?: string | null;
   url?: string | null;
   path?: string | null;
+  uri?: string | null;
+  hostPath?: string | null;
+  assetId?: string | null;
+  kind?: string | null;
+  uploadStatus?: string | null;
+  storagePolicy?: string | null;
 }
 
 function userPromptContentBlocks(
@@ -152,7 +164,13 @@ function userPromptContentBlocks(
         name: optionalString(block.name),
         data: optionalString(block.data),
         url: optionalString(block.url),
-        path: optionalString(block.path)
+        path: optionalString(block.path),
+        uri: optionalString(block.uri),
+        hostPath: optionalString(block.hostPath),
+        assetId: optionalString(block.assetId),
+        kind: optionalString(block.kind),
+        uploadStatus: optionalString(block.uploadStatus),
+        storagePolicy: optionalString(block.storagePolicy)
       }
     ];
   });

--- a/packages/agent/gui/shared/contracts/dto/agentSession.ts
+++ b/packages/agent/gui/shared/contracts/dto/agentSession.ts
@@ -116,6 +116,7 @@ export interface AgentPromptContentBlock {
   uri?: string;
   hostPath?: string;
   uploadStatus?: string;
+  storagePolicy?: string;
   assetId?: string;
   kind?: string;
   sizeBytes?: number;


### PR DESCRIPTION
## Summary

Preserve prompt asset identity, URI, upload state, and `storagePolicy` through Agent GUI input types, composer drafts, queued prompts, message projection, and history reads. `storagePolicy` is the sole durability contract; restore behavior is derived by the host adapter instead of carrying a separate restore-source field.

TSH uses this metadata to restore cloud-backed prompt images after runtime-local staged files disappear. This change only carries contract data; it does not change session, turn, goal, runtime-operation, upload, or recovery lifecycle semantics.

## Verification

- 4 targeted spec files passed
- Agent GUI and activity-core typechecks passed
- Agent GUI build passed
- Agent degradation-boundary check passed
- `pnpm check:changed -- --push-ready` passed all 13 lanes, including pre-push

## Checklist

- [x] Agent lifecycle semantics unchanged; no host/conformance scenario required.
- [x] I kept the change focused on one concern.
- [x] Documentation not required; this propagates existing internal prompt asset contract fields.
- [x] README/CONTRIBUTING language variants are unaffected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] Commit is signed off with DCO.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->