### PR TITLE
fix(agent-gui): publish workspace settings panel contract

### DIFF
--- a/docs/conventions/npm-package-release.md
+++ b/docs/conventions/npm-package-release.md
@@ -247,6 +247,7 @@ The stable package entrypoints are:
 @tutti-os/agent-gui/workbench
 @tutti-os/agent-gui/workbench/browser-element-context
 @tutti-os/agent-gui/workbench/tool-sidebar
+@tutti-os/agent-gui/workspace-settings-panel
 @tutti-os/browser-node
 @tutti-os/browser-node/assets/workspace-dock-website.png
 @tutti-os/browser-node/bridge

--- a/packages/agent/gui/build/agentGuiBuildEntries.ts
+++ b/packages/agent/gui/build/agentGuiBuildEntries.ts
@@ -10,6 +10,8 @@ export const agentGUIBuildEntries = {
   "agent-conversation/index": "agent-conversation/index.ts",
   "agent-env/index": "shared/agentEnv/index.ts",
   "agent-env/ui": "shared/agentEnv/ui.ts",
+  "workspace-settings-panel":
+    "shared/workspaceSettingsPanel/workspaceSettingsPanelStore.ts",
   "context-mention-palette/index": "context-mention-palette/index.ts",
   "context-mention-provider":
     "agent-gui/agentGuiNode/agentContextMentionProvider.ts",
@@ -50,6 +52,7 @@ export const agentGUIDtsEntryGroups = [
     "custom-mention",
     "agent-env/index",
     "agent-env/ui",
+    "workspace-settings-panel",
     "provider-identity",
     "provider-icons",
     "i18n/index",

--- a/packages/agent/gui/package.json
+++ b/packages/agent/gui/package.json
@@ -157,6 +157,10 @@
         "types": "./dist/agent-env/ui.d.ts",
         "import": "./dist/agent-env/ui.js"
       },
+      "./workspace-settings-panel": {
+        "types": "./dist/workspace-settings-panel.d.ts",
+        "import": "./dist/workspace-settings-panel.js"
+      },
       "./context-mention-palette": {
         "types": "./dist/context-mention-palette/index.d.ts",
         "import": "./dist/context-mention-palette/index.js"

--- a/packages/agent/gui/tsup.dts.config.test.ts
+++ b/packages/agent/gui/tsup.dts.config.test.ts
@@ -1,9 +1,20 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import {
   agentGUIBuildEntries,
   agentGUIDtsEntryGroups
 } from "./build/agentGuiBuildEntries";
+
+const packageManifest = JSON.parse(
+  readFileSync(resolve(process.cwd(), "package.json"), "utf8")
+) as {
+  publishConfig: {
+    exports: Record<string, unknown>;
+  };
+};
 
 describe("Agent GUI declaration build groups", () => {
   it("cover every runtime entry exactly once", () => {
@@ -12,5 +23,17 @@ describe("Agent GUI declaration build groups", () => {
 
     expect(new Set(declarationEntries).size).toBe(declarationEntries.length);
     expect([...declarationEntries].sort()).toEqual(runtimeEntries);
+  });
+
+  it("builds and publishes the workspace settings panel contract", () => {
+    expect(agentGUIBuildEntries["workspace-settings-panel"]).toBe(
+      "shared/workspaceSettingsPanel/workspaceSettingsPanelStore.ts"
+    );
+    expect(
+      packageManifest.publishConfig.exports["./workspace-settings-panel"]
+    ).toEqual({
+      types: "./dist/workspace-settings-panel.d.ts",
+      import: "./dist/workspace-settings-panel.js"
+    });
   });
 });


### PR DESCRIPTION
## Summary

- publish the existing workspace settings panel store as a built `@tutti-os/agent-gui` subpath
- cover the build-entry and published-export contract with a regression test
- document the stable package entrypoint used by downstream desktop hosts

## Verification

- `pnpm exec vitest run tsup.dts.config.test.ts --environment jsdom --maxWorkers=1`
- `pnpm --filter @tutti-os/agent-gui build`
- `pnpm release:pack:check`
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`

## Checklist

- [x] This PR does not change agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation for the published contract.
- [x] No README/CONTRIBUTING translation source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->