### PR TITLE
[Tutloop] 清理低价值单测：移除 workspaceFilePaths 中的重复用例

### DIFF
--- a/apps/desktop/src/main/host/workspaceFilePaths.test.ts
+++ b/apps/desktop/src/main/host/workspaceFilePaths.test.ts
@@ -27,16 +27,6 @@ test("resolveWorkspaceFileAbsolutePath maps file paths under the local root", ()
   );
 });
 
-test("resolveWorkspaceFileAbsolutePath accepts absolute paths inside the local root", () => {
-  assert.equal(
-    resolveWorkspaceFileAbsolutePath({
-      logicalPath: "/tmp/demo/src/App.tsx",
-      rootDirectory: "/tmp/demo"
-    }),
-    path.resolve("/tmp/demo/src/App.tsx")
-  );
-});
-
 test("resolveWorkspaceFileAbsolutePath rejects absolute paths outside the local root", () => {
   assert.throws(
     () =>


### PR DESCRIPTION
## 候选分类

A. 重复代码单测 — 字面重复（identical inputs and expected output）

## 候选位置

- 删除：`apps/desktop/src/main/host/workspaceFilePaths.test.ts:30-38`
- 保留：`apps/desktop/src/main/host/workspaceFilePaths.test.ts:20-28`

## 低价值证据

以下两个测试用例为字面重复——输入与期望输出逐字节一致，覆盖同一条生产分支：

- `resolveWorkspaceFileAbsolutePath maps file paths under the local root`（保留）
- `resolveWorkspaceFileAbsolutePath accepts absolute paths inside the local root`（删除）

两者均调用：

```ts
resolveWorkspaceFileAbsolutePath({
  logicalPath: "/tmp/demo/src/App.tsx",
  rootDirectory: "/tmp/demo"
})
// 期望：path.resolve("/tmp/demo/src/App.tsx")
```

被测生产代码 `resolveWorkspaceFileAbsolutePath`（`apps/desktop/src/main/host/workspaceFilePaths.ts:31-53`）在这两个用例中走完全相同的路径：

1. `rootDirectoryInput` 非空 → 不抛 `root directory is required`
2. `rawPath` 为绝对路径 → `absolutePath = path.resolve(rawPath)`
3. `isPathWithinRoot("/tmp/demo", "/tmp/demo/src/App.tsx")` 返回 `true`（relative 为 `"src/App.tsx"`）
4. 返回 `absolutePath`

`git blame` 显示两处自初始提交 `e2120fb27`（2026-06-12）起就同时存在，属于意外重复，并非为状态隔离、失败可读性、平台差异、错误分支、协议顺序或并发回归而有意保留

## 保留的行为覆盖

删除后该文件仍覆盖以下分支（8 个用例）：

- 根目录映射（`maps the local workspace root`）
- 根目录下文件路径的绝对路径分支（`maps file paths under the local root` — 保留的规范用例）
- 根目录外绝对路径拒绝（`rejects absolute paths outside the local root`）
- 相对路径归一化（`normalizes relative-looking paths under the local root`，覆盖 `path.isAbsolute === false` 分支）
- 空根目录拒绝（`rejects empty workspace roots`）
- `/workspace` 作为普通绝对路径（`treats /workspace as an ordinary absolute path`）
- `resolveWorkspaceLogicalFilePath` 的 `/workspace` 映射
- `resolveTerminalLinkAbsolutePath` 的 home-relative / 绝对 / cwd-relative 三种路径

覆盖完全等价，无独特分支、错误、平台、并发、兼容性、可访问性、安全或协议覆盖损失

## 改动摘要

- 文件：`apps/desktop/src/main/host/workspaceFilePaths.test.ts`
- 变更：`1 file changed, 10 deletions(-)`
- 仅删除字面重复的 `accepts absolute paths inside the local root` 测试块及其前置空行，未修改任何生产代码、依赖、构建配置、生成文件、vendored 内容、fixture/golden 文件或其它测试

## 风险

- 极低。删除的用例与保留的 `maps file paths under the local root` 输入与期望逐字节一致，不损失任何分支覆盖
- 无契约、协议、i18n、可访问性或安全相关断言被移除
- 回归保护由保留的规范用例及其它 7 个分支用例继续承担

## 执行过的验证命令及结果

1. 聚焦测试（迭代）：

   ```
   cd apps/desktop && node --import ./test/register-asset-stub.mjs --test --experimental-strip-types "./src/main/host/workspaceFilePaths.test.ts"
   ```

   结果：`8 pass / 0 fail`（删除前为 9 tests）

2. 门禁计划检查：

   ```
   pnpm check:changed -- --dry-run
   ```

   结果：9 lanes — diff-check、lint:changed、repository naming policy、Electron runtime boundary、UI boundary、agent provider strategy boundary、i18n boundary、@tutti-os/desktop:typecheck、@tutti-os/desktop:test

3. 变更门禁：

   ```
   pnpm check:changed
   ```

   结果：`check:changed passed 9 lane(s) in 50.1s`

4. pre-commit hooks（lint-staged + Electron/UI/renderer/agent-gui 边界）：通过

5. DCO sign-off：`Signed-off-by: liying <422107224@qq.com>`

## 回滚方式

`git revert 6f227448e5efcdc5a2ca05e5cf75c60a68c98b86`，或手动将以下测试块重新插入 `apps/desktop/src/main/host/workspaceFilePaths.test.ts` 第 28 行之后：

```ts
test("resolveWorkspaceFileAbsolutePath accepts absolute paths inside the local root", () => {
  assert.equal(
    resolveWorkspaceFileAbsolutePath({
      logicalPath: "/tmp/demo/src/App.tsx",
      rootDirectory: "/tmp/demo"
    }),
    path.resolve("/tmp/demo/src/App.tsx")
  );
});
```

## 声明

- 本 PR 由 Tutloop Loop `81149dd8-2a87-478f-9971-95b8bfc54f1d` 自动创建，未自动合并、未关闭、未批准、未评论任何 PR
- 任意时刻未创建第二个匹配的 open PR
- 合并由用户完成，不是本轮完成条件

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->