### PR TITLE
feat(agent-gui): expose conversation rail layout changes

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -385,6 +385,12 @@ Workspace picker results and internal workspace-reference drags remain live refe
 | `renderSlots`      | narrow product-neutral presentation slots |
 
 Do not restore flat compatibility props or hide workflow inside a render slot.
+Host chrome that aligns to AgentGUI's internal layout must consume explicit
+package signals such as `hostActions.onConversationRailLayoutChange`; it must
+not observe package DOM, CSS variables, or class names with
+`MutationObserver`. Composer affordances belong in AgentGUI itself or a
+narrow `renderSlots` contract, not in host-owned portals inserted into package
+DOM.
 
 ### 6.3 `AgentActivityRuntime` and `AgentHostApi`
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.memo.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.memo.spec.tsx
@@ -266,6 +266,47 @@ describe("AgentGUINode memoization", () => {
     );
   });
 
+  it("passes host rail layout observers through the memo boundary", () => {
+    mockViewModel = createViewModel();
+    const firstObserver = vi.fn();
+    const secondObserver = vi.fn();
+    const initial = createProps();
+    const props = {
+      ...initial,
+      hostActions: {
+        ...initial.hostActions,
+        onConversationRailLayoutChange: firstObserver
+      }
+    };
+    const { rerender } = render(<AgentGUINode {...props} />);
+    const firstViewProps = agentGuiNodeViewSpy.mock.calls.at(-1)?.[0] as
+      | {
+          onConversationRailLayoutChange?: (layout: unknown) => void;
+        }
+      | undefined;
+    expect(firstViewProps?.onConversationRailLayoutChange).toBe(firstObserver);
+
+    agentGuiNodeViewSpy.mockClear();
+    rerender(
+      <AgentGUINode
+        {...props}
+        hostActions={{
+          ...props.hostActions,
+          onConversationRailLayoutChange: secondObserver
+        }}
+      />
+    );
+    expect(agentGuiNodeViewSpy).toHaveBeenCalledTimes(1);
+    const secondViewProps = agentGuiNodeViewSpy.mock.calls.at(-1)?.[0] as
+      | {
+          onConversationRailLayoutChange?: (layout: unknown) => void;
+        }
+      | undefined;
+    expect(secondViewProps?.onConversationRailLayoutChange).toBe(
+      secondObserver
+    );
+  });
+
   it("keeps rail labels stable when provider-facing labels change", () => {
     mockViewModel = createViewModel();
     const props = createProps();

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -163,7 +163,8 @@ export const AgentGUINode = memo(function AgentGUINode({
     onMinimize,
     onToggleMaximize,
     onShowMessage,
-    onEngagementEvent
+    onEngagementEvent,
+    onConversationRailLayoutChange
   } = hostActions;
   const {
     providerRailEmpty: renderProviderRailEmpty,
@@ -684,6 +685,7 @@ export const AgentGUINode = memo(function AgentGUINode({
               onConversationRailWidthChanged={
                 handleConversationRailWidthChanged
               }
+              onConversationRailLayoutChange={onConversationRailLayoutChange}
               labels={labels}
               conversationRailLabels={conversationRailLabels}
               workspaceUserProjectI18n={workspaceUserProjectI18n}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
@@ -34,6 +34,7 @@ import type {
 } from "./controller/useAgentGUINodeController";
 import type {
   AgentGUISidebarFooterContext,
+  AgentGUIConversationRailLayout,
   AgentGUIAgentsEmptyRenderer,
   AgentGUIProviderUnavailableStateRenderer,
   AgentMentionReferenceTargetResolver,
@@ -175,6 +176,14 @@ export interface AgentGUINodeHostActions {
     tone?: "info" | "warning" | "error"
   ) => void;
   onEngagementEvent?: AgentGUIEngagementEventSink;
+  /**
+   * Reports live left-side rail layout width while the conversation rail is
+   * being resized. Hosts with external chrome aligned to the rail can consume
+   * this instead of observing package DOM/style mutations.
+   */
+  onConversationRailLayoutChange?: (
+    layout: AgentGUIConversationRailLayout
+  ) => void;
 }
 
 export interface AgentGUINodeRenderSlots {
@@ -392,6 +401,7 @@ export function areAgentGUINodePropsEqual(
     pa.onToggleMaximize === na.onToggleMaximize &&
     pa.onShowMessage === na.onShowMessage &&
     pa.onEngagementEvent === na.onEngagementEvent &&
+    pa.onConversationRailLayoutChange === na.onConversationRailLayoutChange &&
     ps.providerRailEmpty === ns.providerRailEmpty &&
     ps.providerUnavailableState === ns.providerUnavailableState &&
     ps.sidebarFooter === ns.sidebarFooter

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -47,6 +47,10 @@ import { useAgentGUIWorkspaceReferencePicker } from "./view/useAgentGUIWorkspace
 import type { AgentGUINodeViewProps } from "./view/AgentGUINodeView.types";
 import { useAgentGUINodeEngagement } from "./engagement/useAgentGUINodeEngagement";
 import { isAgentGUIProviderReady } from "./model/agentGuiProviderReadiness";
+import {
+  useAgentGUIConversationRailResizePointerMove,
+  type AgentGUIConversationRailResizeInteraction
+} from "./view/useAgentGUIConversationRailResizePointerMove";
 
 export type {
   AgentGUINodeViewProps,
@@ -151,18 +155,11 @@ export function AgentGUINodeView({
     viewModel
   });
   const [providerManagerOpen, setProviderManagerOpen] = useState(false);
-  const railResizeInteractionRef = useRef<{
-    lastWidthPx: number;
-    pointerId: number;
-    startClientX: number;
-    startWidthPx: number;
-  } | null>(null);
+  const railResizeInteractionRef =
+    useRef<AgentGUIConversationRailResizeInteraction | null>(null);
   const [isRailResizing, setIsRailResizing] = useState(false);
   const [railResizeWidthPx, setRailResizeWidthPx] = useState<number | null>(
     null
-  );
-  const reportConversationRailLayoutChange = useOptionalStableEventCallback(
-    onConversationRailLayoutChange
   );
   const [
     localComposerFocusRequestSequence,
@@ -304,41 +301,15 @@ export function AgentGUINodeView({
     [conversationRailCollapsed, conversationRailWidthPx, previewMode]
   );
 
-  const handleConversationRailResizePointerMove = useCallback(
-    (event: PointerEvent<HTMLDivElement>): void => {
-      if (previewMode) {
-        return;
-      }
-      const resizeState = railResizeInteractionRef.current;
-      if (!resizeState || resizeState.pointerId !== event.pointerId) {
-        return;
-      }
-
-      const nextWidthPx = clampConversationRailWidth(
-        resizeState.startWidthPx + event.clientX - resizeState.startClientX
-      );
-      if (resizeState.lastWidthPx !== nextWidthPx) {
-        resizeState.lastWidthPx = nextWidthPx;
-        layoutElementRef.current?.style.setProperty(
-          "--agent-gui-conversation-rail-width",
-          `${nextWidthPx}px`
-        );
-        reportConversationRailLayoutChange?.({
-          providerRailWidthPx,
-          conversationRailWidthPx: nextWidthPx,
-          leftPanelWidthPx: providerRailWidthPx + nextWidthPx,
-          resizing: true
-        });
-        event.currentTarget.setAttribute("aria-valuenow", String(nextWidthPx));
-      }
-    },
-    [
+  const handleConversationRailResizePointerMove =
+    useAgentGUIConversationRailResizePointerMove({
       clampConversationRailWidth,
+      layoutElementRef,
+      onConversationRailLayoutChange,
       previewMode,
       providerRailWidthPx,
-      reportConversationRailLayoutChange
-    ]
-  );
+      railResizeInteractionRef
+    });
 
   const endConversationRailResize = useCallback(
     (event?: PointerEvent<HTMLDivElement>): void => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -47,9 +47,11 @@ import { useAgentGUIWorkspaceReferencePicker } from "./view/useAgentGUIWorkspace
 import type { AgentGUINodeViewProps } from "./view/AgentGUINodeView.types";
 import { useAgentGUINodeEngagement } from "./engagement/useAgentGUINodeEngagement";
 import { isAgentGUIProviderReady } from "./model/agentGuiProviderReadiness";
+
 export type {
   AgentGUINodeViewProps,
   AgentGUIAgentsEmptyRenderer,
+  AgentGUIConversationRailLayout,
   AgentGUIProviderUnavailableStateContext,
   AgentGUIProviderUnavailableStateRenderer,
   AgentGUISidebarFooterContext,
@@ -119,6 +121,7 @@ export function AgentGUINodeView({
   prepareExternalPromptFiles = null,
   promptAssetLimit = null,
   onConversationRailWidthChanged,
+  onConversationRailLayoutChange,
   labels,
   conversationRailLabels,
   workspaceUserProjectI18n,
@@ -157,6 +160,9 @@ export function AgentGUINodeView({
   const [isRailResizing, setIsRailResizing] = useState(false);
   const [railResizeWidthPx, setRailResizeWidthPx] = useState<number | null>(
     null
+  );
+  const reportConversationRailLayoutChange = useOptionalStableEventCallback(
+    onConversationRailLayoutChange
   );
   const [
     localComposerFocusRequestSequence,
@@ -273,6 +279,7 @@ export function AgentGUINodeView({
       ),
     [conversationRailMaxWidthPx, conversationRailMinWidthPx]
   );
+  const providerRailWidthPx = conversationRailCollapsed ? 0 : 52;
 
   const handleConversationRailResizePointerDown = useCallback(
     (event: PointerEvent<HTMLDivElement>): void => {
@@ -316,10 +323,21 @@ export function AgentGUINodeView({
           "--agent-gui-conversation-rail-width",
           `${nextWidthPx}px`
         );
+        reportConversationRailLayoutChange?.({
+          providerRailWidthPx,
+          conversationRailWidthPx: nextWidthPx,
+          leftPanelWidthPx: providerRailWidthPx + nextWidthPx,
+          resizing: true
+        });
         event.currentTarget.setAttribute("aria-valuenow", String(nextWidthPx));
       }
     },
-    [clampConversationRailWidth, previewMode]
+    [
+      clampConversationRailWidth,
+      previewMode,
+      providerRailWidthPx,
+      reportConversationRailLayoutChange
+    ]
   );
 
   const endConversationRailResize = useCallback(
@@ -398,13 +416,12 @@ export function AgentGUINodeView({
   const effectiveConversationRailWidthPx = conversationRailCollapsed
     ? 0
     : visualConversationRailWidthPx;
-  const renderProviderRail = !conversationRailCollapsed;
 
   const layoutStyle = {
     "--agent-gui-conversation-rail-width": `${effectiveConversationRailWidthPx}px`,
     "--agent-gui-conversation-rail-content-width": `${visualConversationRailWidthPx}px`,
     "--agent-gui-detail-min-width": `${detailMinWidthPx}px`,
-    "--agent-gui-provider-rail-width": renderProviderRail ? "52px" : "0px",
+    "--agent-gui-provider-rail-width": `${providerRailWidthPx}px`,
     gridTemplateColumns:
       "var(--agent-gui-provider-rail-width) var(--agent-gui-conversation-rail-width) minmax(var(--agent-gui-detail-min-width), 1fr)"
   } as CSSProperties;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
@@ -196,14 +196,15 @@ export function ComposerFooter({
                     className={cn(
                       styles.composerMenuTrigger,
                       styles.composerReferenceTrigger,
-                      "group w-auto justify-center text-[var(--agent-gui-text-secondary)] disabled:pointer-events-none disabled:opacity-50 [&_svg]:shrink-0"
+                      "group w-auto justify-center text-[var(--agent-gui-text-secondary)] hover:text-[var(--agent-gui-text-primary)] focus-visible:text-[var(--agent-gui-text-primary)] disabled:pointer-events-none disabled:opacity-50 [&_svg]:shrink-0"
                     )}
+                    data-testid="agent-gui-composer-mention-trigger"
                     onMouseDown={(event) => event.preventDefault()}
                     onClick={handleMentionPaletteButton}
                   >
                     <span
                       aria-hidden
-                      className="inline-block size-3.5 bg-[var(--text-secondary)] transition-colors group-hover:bg-[var(--text-primary)] group-focus-visible:bg-[var(--text-primary)]"
+                      className="inline-block size-3.5 bg-current transition-colors"
                       style={{
                         WebkitMaskImage: `url("${atLinedIconUrl}")`,
                         WebkitMaskPosition: "center",

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -51,6 +51,13 @@ export type AgentWorkspaceReferenceInitialTargetResolver = (
   input: AgentWorkspaceReferenceInitialTargetInput
 ) => ReferenceLocateTarget | null;
 
+export interface AgentGUIConversationRailLayout {
+  providerRailWidthPx: number;
+  conversationRailWidthPx: number;
+  leftPanelWidthPx: number;
+  resizing: boolean;
+}
+
 export interface AgentGUIViewLabels {
   initialPlaceholder: string;
   followupPlaceholder: string;
@@ -617,6 +624,9 @@ export interface AgentGUINodeViewProps {
   prepareExternalPromptFiles?: AgentComposerProps["prepareExternalPromptFiles"];
   promptAssetLimit?: number | null;
   onConversationRailWidthChanged: (widthPx: number) => void;
+  onConversationRailLayoutChange?: (
+    layout: AgentGUIConversationRailLayout
+  ) => void;
   labels: AgentGUIViewLabels;
   conversationRailLabels: AgentGUIConversationRailLabels;
   workspaceUserProjectI18n: WorkspaceUserProjectI18nRuntime;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIConversationRailResizePointerMove.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIConversationRailResizePointerMove.spec.tsx
@@ -1,0 +1,57 @@
+import { act, renderHook } from "@testing-library/react";
+import type { PointerEvent } from "react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  useAgentGUIConversationRailResizePointerMove,
+  type AgentGUIConversationRailResizeInteraction
+} from "./useAgentGUIConversationRailResizePointerMove";
+
+describe("useAgentGUIConversationRailResizePointerMove", () => {
+  it("reports live host layout from the clamped drag width", () => {
+    const layoutElement = document.createElement("div");
+    const resizeHandle = document.createElement("div");
+    const onConversationRailLayoutChange = vi.fn();
+    const railResizeInteractionRef: {
+      current: AgentGUIConversationRailResizeInteraction | null;
+    } = {
+      current: {
+        lastWidthPx: 240,
+        pointerId: 7,
+        startClientX: 100,
+        startWidthPx: 240
+      }
+    };
+    const { result } = renderHook(() =>
+      useAgentGUIConversationRailResizePointerMove({
+        clampConversationRailWidth: (widthPx) => Math.min(280, widthPx),
+        layoutElementRef: { current: layoutElement },
+        onConversationRailLayoutChange,
+        previewMode: false,
+        providerRailWidthPx: 52,
+        railResizeInteractionRef
+      })
+    );
+
+    act(() => {
+      result.current({
+        clientX: 160,
+        currentTarget: resizeHandle,
+        pointerId: 7
+      } as unknown as PointerEvent<HTMLDivElement>);
+    });
+
+    expect(railResizeInteractionRef.current?.lastWidthPx).toBe(280);
+    expect(
+      layoutElement.style.getPropertyValue(
+        "--agent-gui-conversation-rail-width"
+      )
+    ).toBe("280px");
+    expect(resizeHandle.getAttribute("aria-valuenow")).toBe("280");
+    expect(onConversationRailLayoutChange).toHaveBeenCalledWith({
+      providerRailWidthPx: 52,
+      conversationRailWidthPx: 280,
+      leftPanelWidthPx: 332,
+      resizing: true
+    });
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIConversationRailResizePointerMove.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIConversationRailResizePointerMove.ts
@@ -1,0 +1,70 @@
+import { useCallback, type PointerEvent } from "react";
+import type { AgentGUINodeViewProps } from "./AgentGUINodeView.types";
+import { useOptionalStableEventCallback } from "./agentGUIViewUtils";
+
+export interface AgentGUIConversationRailResizeInteraction {
+  lastWidthPx: number;
+  pointerId: number;
+  startClientX: number;
+  startWidthPx: number;
+}
+
+interface UseAgentGUIConversationRailResizePointerMoveInput {
+  clampConversationRailWidth: (widthPx: number) => number;
+  layoutElementRef: { current: HTMLElement | null };
+  onConversationRailLayoutChange: AgentGUINodeViewProps["onConversationRailLayoutChange"];
+  previewMode: boolean;
+  providerRailWidthPx: number;
+  railResizeInteractionRef: {
+    current: AgentGUIConversationRailResizeInteraction | null;
+  };
+}
+
+export function useAgentGUIConversationRailResizePointerMove({
+  clampConversationRailWidth,
+  layoutElementRef,
+  onConversationRailLayoutChange,
+  previewMode,
+  providerRailWidthPx,
+  railResizeInteractionRef
+}: UseAgentGUIConversationRailResizePointerMoveInput): (
+  event: PointerEvent<HTMLDivElement>
+) => void {
+  const reportConversationRailLayoutChange = useOptionalStableEventCallback(
+    onConversationRailLayoutChange
+  );
+
+  return useCallback(
+    (event: PointerEvent<HTMLDivElement>): void => {
+      if (previewMode) return;
+      const resizeState = railResizeInteractionRef.current;
+      if (!resizeState || resizeState.pointerId !== event.pointerId) return;
+
+      const nextWidthPx = clampConversationRailWidth(
+        resizeState.startWidthPx + event.clientX - resizeState.startClientX
+      );
+      if (resizeState.lastWidthPx === nextWidthPx) return;
+
+      resizeState.lastWidthPx = nextWidthPx;
+      layoutElementRef.current?.style.setProperty(
+        "--agent-gui-conversation-rail-width",
+        `${nextWidthPx}px`
+      );
+      reportConversationRailLayoutChange?.({
+        providerRailWidthPx,
+        conversationRailWidthPx: nextWidthPx,
+        leftPanelWidthPx: providerRailWidthPx + nextWidthPx,
+        resizing: true
+      });
+      event.currentTarget.setAttribute("aria-valuenow", String(nextWidthPx));
+    },
+    [
+      clampConversationRailWidth,
+      layoutElementRef,
+      previewMode,
+      providerRailWidthPx,
+      railResizeInteractionRef,
+      reportConversationRailLayoutChange
+    ]
+  );
+}

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -102,6 +102,7 @@ export {
 } from "./agent-gui/agentGuiNode/model/agentGuiRailLayout";
 export type {
   AgentGUIAgentsEmptyRenderer,
+  AgentGUIConversationRailLayout,
   AgentGUIProviderUnavailableStateContext,
   AgentGUIProviderUnavailableStateRenderer,
   AgentGUISidebarFooterContext,

--- a/tools/degradation-baseline/agent-gui.json
+++ b/tools/degradation-baseline/agent-gui.json
@@ -9,7 +9,7 @@
   "metrics": {
     "componentMemoOverages": {
       "packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx": 22,
-      "packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx": 11,
+      "packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx": 10,
       "packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx": 6,
       "packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerChrome.tsx": 8,
       "packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx": 9,


### PR DESCRIPTION
## Summary
- add `hostActions.onConversationRailLayoutChange` for live conversation rail resize layout updates
- re-export the rail layout type from `@tutti-os/agent-gui`
- keep the package-owned composer mention trigger visible with AgentGUI text tokens and a stable test id
- document that hosts should consume AgentGUI signals/slots instead of MutationObserver or portal patches
- isolate the hot pointer-move/reporting path in a view-local hook; keep `AgentGUINodeView.tsx` below the 800-line gate and lock the improved memo-overage baseline (11 -> 10)

## Tests
- `pnpm --dir packages/agent/gui exec vitest run agent-gui/agentGuiNode/view/useAgentGUIConversationRailResizePointerMove.spec.tsx agent-gui/agentGuiNode/AgentGUINode.memo.spec.tsx` (7 passed)
- targeted `oxlint --deny-warnings`
- `pnpm check:agent-gui-degradation`
- `pnpm check:changed -- --push-ready` (11 lanes passed)
- built and packed successfully through the downstream TSH local Tutti cohort workflow
