### PR TITLE
refactor(workbench): subscribe to external state by slice

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/desktopAgentGUINodeState.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/desktopAgentGUINodeState.test.ts
@@ -228,9 +228,17 @@ test("desktop agent gui node state source consumes instance launch state after n
   });
   let notified = 0;
   const unsubscribe =
-    source.externalStateSource.subscribe?.(() => {
-      notified += 1;
-    }) ?? (() => undefined);
+    source.externalStateSource.subscribeNodeState?.(
+      {
+        instanceId: "agent-gui",
+        nodeId: "agent-gui",
+        typeId: "agent-gui",
+        workspaceId: "workspace-1"
+      },
+      () => {
+        notified += 1;
+      }
+    ) ?? (() => undefined);
   t.after(unsubscribe);
 
   source.writeNodeState({

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts
@@ -18,11 +18,13 @@ import {
   readWorkspaceAppIdFromNodeId,
   reportWorkspaceAppOpenedFromDockEntry,
   resolveWorkspaceAppCenterLaunchRequest,
+  workspaceAppCenterNodeID,
   workspaceAppDockEntryId,
   workspaceAppInlineBrowserNodeId,
   workspaceAppWebviewInstanceId,
   workspaceAppWebviewTypeID
 } from "./workspaceAppCenterLaunchRequest.ts";
+import { createWorkspaceAppWebviewExternalStateSource } from "./workspaceAppCenterContribution.tsx";
 
 test("workspace app node ids resolve app ids from dock, inline, and webview node formats", () => {
   assert.equal(
@@ -40,6 +42,49 @@ test("workspace app node ids resolve app ids from dock, inline, and webview node
     "group-chat"
   );
   assert.equal(readWorkspaceAppIdFromNodeId("browser:browser-1"), null);
+});
+
+test("workspace app external state source preserves unchanged snapshot references", () => {
+  const app = createApp({
+    appId: "ready",
+    launchUrl: "http://127.0.0.1:3000"
+  });
+  const source = createWorkspaceAppWebviewExternalStateSource({
+    appCenterService: createAppCenterService([app], {
+      getViewState: () => ({
+        activeAppTab: "recommended",
+        openAppId: null,
+        openAppIds: []
+      })
+    }),
+    runtimeStore: {
+      getSnapshot: () => ({}),
+      subscribe: () => () => {}
+    }
+  });
+  const webviewRequest = {
+    instanceId: workspaceAppWebviewInstanceId("ready"),
+    instanceKey: workspaceAppWebviewInstanceId("ready"),
+    nodeId: `${workspaceAppWebviewTypeID}:${workspaceAppWebviewInstanceId("ready")}`,
+    typeId: workspaceAppWebviewTypeID,
+    workspaceId: "workspace-1"
+  };
+  const appCenterRequest = {
+    instanceId: workspaceAppCenterNodeID,
+    instanceKey: workspaceAppCenterNodeID,
+    nodeId: workspaceAppCenterNodeID,
+    typeId: workspaceAppCenterNodeID,
+    workspaceId: "workspace-1"
+  };
+
+  assert.equal(
+    source.getNodeState(webviewRequest),
+    source.getNodeState(webviewRequest)
+  );
+  assert.equal(
+    source.getNodeState(appCenterRequest),
+    source.getNodeState(appCenterRequest)
+  );
 });
 
 test("workspace app contribution reports app open from dock launch requests", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts
@@ -24,7 +24,7 @@ import {
   workspaceAppWebviewInstanceId,
   workspaceAppWebviewTypeID
 } from "./workspaceAppCenterLaunchRequest.ts";
-import { createWorkspaceAppWebviewExternalStateSource } from "./workspaceAppCenterContribution.tsx";
+import { createWorkspaceAppWebviewExternalStateSource } from "./workspaceAppCenterExternalState.ts";
 
 test("workspace app node ids resolve app ids from dock, inline, and webview node formats", () => {
   assert.equal(

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
@@ -755,7 +755,13 @@ function createWorkspaceAppWebviewExternalStateSource(input: {
     getWorkspaceState() {
       return null;
     },
-    subscribe(listener) {
+    subscribeNodeState(request, listener) {
+      if (
+        request.typeId !== workspaceAppCenterNodeID &&
+        request.typeId !== workspaceAppWebviewTypeID
+      ) {
+        return () => {};
+      }
       const unsubscribeRuntime = input.runtimeStore.subscribe(listener);
       const unsubscribeAppCenter = input.appCenterService.subscribe(listener);
       return () => {

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
@@ -729,7 +729,7 @@ type WorkspaceAppCenterExternalNodeState =
   | WorkspaceAppWebviewExternalState
   | null;
 
-function createWorkspaceAppWebviewExternalStateSource(input: {
+export function createWorkspaceAppWebviewExternalStateSource(input: {
   appCenterService: IWorkspaceAppCenterService;
   runtimeStore: {
     getSnapshot(): Record<string, BrowserNodeRuntimeState | undefined>;
@@ -739,18 +739,43 @@ function createWorkspaceAppWebviewExternalStateSource(input: {
   WorkspaceAppCenterExternalNodeState,
   null
 > {
+  const appCenterViewStateByWorkspaceId = new Map<
+    string,
+    WorkspaceAppCenterViewState
+  >();
+  const appWebviewStateByNodeId = new Map<
+    string,
+    WorkspaceAppWebviewExternalState
+  >();
+
   return {
     getNodeState(request) {
       if (request.typeId === workspaceAppCenterNodeID) {
-        return input.appCenterService.getViewState(request.workspaceId);
+        return reuseWorkspaceAppCenterViewState(
+          appCenterViewStateByWorkspaceId,
+          request.workspaceId,
+          input.appCenterService.getViewState(request.workspaceId)
+        );
       }
-      return readWorkspaceAppExternalState(input, request);
+      return reuseWorkspaceAppWebviewExternalState(
+        appWebviewStateByNodeId,
+        request.nodeId,
+        readWorkspaceAppExternalState(input, request)
+      );
     },
     getSnapshotNodeState(request) {
       if (request.typeId === workspaceAppCenterNodeID) {
-        return input.appCenterService.getViewState(request.workspaceId);
+        return reuseWorkspaceAppCenterViewState(
+          appCenterViewStateByWorkspaceId,
+          request.workspaceId,
+          input.appCenterService.getViewState(request.workspaceId)
+        );
       }
-      return readWorkspaceAppExternalState(input, request);
+      return reuseWorkspaceAppWebviewExternalState(
+        appWebviewStateByNodeId,
+        request.nodeId,
+        readWorkspaceAppExternalState(input, request)
+      );
     },
     getWorkspaceState() {
       return null;
@@ -770,6 +795,43 @@ function createWorkspaceAppWebviewExternalStateSource(input: {
       };
     }
   };
+}
+
+function reuseWorkspaceAppCenterViewState(
+  stateByWorkspaceId: Map<string, WorkspaceAppCenterViewState>,
+  workspaceId: string,
+  next: WorkspaceAppCenterViewState
+): WorkspaceAppCenterViewState {
+  const previous = stateByWorkspaceId.get(workspaceId);
+  if (
+    previous?.activeAppTab === next.activeAppTab &&
+    previous.openAppId === next.openAppId &&
+    previous.openAppIds?.length === next.openAppIds?.length &&
+    previous.openAppIds?.every(
+      (appId, index) => appId === next.openAppIds?.[index]
+    )
+  ) {
+    return previous;
+  }
+  stateByWorkspaceId.set(workspaceId, next);
+  return next;
+}
+
+function reuseWorkspaceAppWebviewExternalState(
+  stateByNodeId: Map<string, WorkspaceAppWebviewExternalState>,
+  nodeId: string,
+  next: WorkspaceAppWebviewExternalState | null
+): WorkspaceAppWebviewExternalState | null {
+  const previous = stateByNodeId.get(nodeId) ?? null;
+  if (!next) {
+    stateByNodeId.delete(nodeId);
+    return null;
+  }
+  if (previous?.title === next.title && previous.url === next.url) {
+    return previous;
+  }
+  stateByNodeId.set(nodeId, next);
+  return next;
 }
 
 function readWorkspaceAppExternalState(

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
@@ -1,7 +1,6 @@
 import { createElement, useEffect, useRef, type ReactNode } from "react";
 import {
   type BrowserNodeNavigationPolicy,
-  type BrowserNodeRuntimeState,
   type BrowserNodeFeature
 } from "@tutti-os/browser-node";
 import { BrowserNode } from "@tutti-os/browser-node/react";
@@ -19,8 +18,6 @@ import { createAppCenterI18nRuntime } from "@tutti-os/workspace-app-center/i18n"
 import type {
   WorkbenchContribution,
   WorkbenchHostDockEntry,
-  WorkbenchHostExternalStateLookupInput,
-  WorkbenchHostExternalStateSource,
   WorkbenchHostNodeBodyContext,
   WorkbenchHostNodeHeaderContext,
   WorkbenchHostNodeDefinition
@@ -39,6 +36,7 @@ import type {
   WorkspaceAppCenterViewState
 } from "@tutti-os/workspace-app-center";
 import { createWorkspaceAppCenterOpenedLease } from "./workspaceAppCenterAnalytics.ts";
+import { createWorkspaceAppWebviewExternalStateSource } from "./workspaceAppCenterExternalState.ts";
 import {
   WorkspaceAppCenterInlineAppBody,
   workspaceAppBrowserPartitionPrefix
@@ -63,7 +61,6 @@ import {
 import {
   findWorkspaceApp,
   readWorkspaceAppIdFromInstanceId,
-  readWorkspaceAppIdFromNodeId,
   resolveWorkspaceAppCenterLaunchRequest,
   resolveWorkspaceAppDisplayName,
   workspaceAppCenterNodeID,
@@ -722,149 +719,6 @@ function WorkspaceAppWebviewLoadingState({
       </div>
     </div>
   );
-}
-
-type WorkspaceAppCenterExternalNodeState =
-  | WorkspaceAppCenterViewState
-  | WorkspaceAppWebviewExternalState
-  | null;
-
-export function createWorkspaceAppWebviewExternalStateSource(input: {
-  appCenterService: IWorkspaceAppCenterService;
-  runtimeStore: {
-    getSnapshot(): Record<string, BrowserNodeRuntimeState | undefined>;
-    subscribe(listener: () => void): () => void;
-  };
-}): WorkbenchHostExternalStateSource<
-  WorkspaceAppCenterExternalNodeState,
-  null
-> {
-  const appCenterViewStateByWorkspaceId = new Map<
-    string,
-    WorkspaceAppCenterViewState
-  >();
-  const appWebviewStateByNodeId = new Map<
-    string,
-    WorkspaceAppWebviewExternalState
-  >();
-
-  return {
-    getNodeState(request) {
-      if (request.typeId === workspaceAppCenterNodeID) {
-        return reuseWorkspaceAppCenterViewState(
-          appCenterViewStateByWorkspaceId,
-          request.workspaceId,
-          input.appCenterService.getViewState(request.workspaceId)
-        );
-      }
-      return reuseWorkspaceAppWebviewExternalState(
-        appWebviewStateByNodeId,
-        request.nodeId,
-        readWorkspaceAppExternalState(input, request)
-      );
-    },
-    getSnapshotNodeState(request) {
-      if (request.typeId === workspaceAppCenterNodeID) {
-        return reuseWorkspaceAppCenterViewState(
-          appCenterViewStateByWorkspaceId,
-          request.workspaceId,
-          input.appCenterService.getViewState(request.workspaceId)
-        );
-      }
-      return reuseWorkspaceAppWebviewExternalState(
-        appWebviewStateByNodeId,
-        request.nodeId,
-        readWorkspaceAppExternalState(input, request)
-      );
-    },
-    getWorkspaceState() {
-      return null;
-    },
-    subscribeNodeState(request, listener) {
-      if (
-        request.typeId !== workspaceAppCenterNodeID &&
-        request.typeId !== workspaceAppWebviewTypeID
-      ) {
-        return () => {};
-      }
-      const unsubscribeRuntime = input.runtimeStore.subscribe(listener);
-      const unsubscribeAppCenter = input.appCenterService.subscribe(listener);
-      return () => {
-        unsubscribeRuntime();
-        unsubscribeAppCenter();
-      };
-    }
-  };
-}
-
-function reuseWorkspaceAppCenterViewState(
-  stateByWorkspaceId: Map<string, WorkspaceAppCenterViewState>,
-  workspaceId: string,
-  next: WorkspaceAppCenterViewState
-): WorkspaceAppCenterViewState {
-  const previous = stateByWorkspaceId.get(workspaceId);
-  if (
-    previous?.activeAppTab === next.activeAppTab &&
-    previous.openAppId === next.openAppId &&
-    previous.openAppIds?.length === next.openAppIds?.length &&
-    previous.openAppIds?.every(
-      (appId, index) => appId === next.openAppIds?.[index]
-    )
-  ) {
-    return previous;
-  }
-  stateByWorkspaceId.set(workspaceId, next);
-  return next;
-}
-
-function reuseWorkspaceAppWebviewExternalState(
-  stateByNodeId: Map<string, WorkspaceAppWebviewExternalState>,
-  nodeId: string,
-  next: WorkspaceAppWebviewExternalState | null
-): WorkspaceAppWebviewExternalState | null {
-  const previous = stateByNodeId.get(nodeId) ?? null;
-  if (!next) {
-    stateByNodeId.delete(nodeId);
-    return null;
-  }
-  if (previous?.title === next.title && previous.url === next.url) {
-    return previous;
-  }
-  stateByNodeId.set(nodeId, next);
-  return next;
-}
-
-function readWorkspaceAppExternalState(
-  input: {
-    appCenterService: IWorkspaceAppCenterService;
-    runtimeStore: {
-      getSnapshot(): Record<string, BrowserNodeRuntimeState | undefined>;
-    };
-  },
-  request: WorkbenchHostExternalStateLookupInput
-): WorkspaceAppWebviewExternalState | null {
-  if (request.typeId !== workspaceAppWebviewTypeID) {
-    return null;
-  }
-  const runtime = input.runtimeStore.getSnapshot()[request.nodeId];
-  const runtimeUrl = runtime?.url?.trim();
-  if (runtimeUrl) {
-    return {
-      title: runtime?.title?.trim() || null,
-      url: runtimeUrl
-    };
-  }
-
-  const appId =
-    readWorkspaceAppIdFromNodeId(request.nodeId) ??
-    readWorkspaceAppIdFromInstanceId(request.instanceId);
-  const app = appId ? findWorkspaceApp(input.appCenterService, appId) : null;
-  return app?.launchUrl
-    ? {
-        title: resolveWorkspaceAppDisplayName(app),
-        url: app.launchUrl
-      }
-    : null;
 }
 
 function resolveWorkspaceAppWebviewNavigationPolicy(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterExternalState.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterExternalState.ts
@@ -1,0 +1,159 @@
+import type { BrowserNodeRuntimeState } from "@tutti-os/browser-node";
+import type {
+  WorkbenchHostExternalStateLookupInput,
+  WorkbenchHostExternalStateSource
+} from "@tutti-os/workbench-surface";
+import type { WorkspaceAppCenterViewState } from "@tutti-os/workspace-app-center";
+import type { IWorkspaceAppCenterService } from "../workspaceAppCenterService.interface.ts";
+import {
+  findWorkspaceApp,
+  readWorkspaceAppIdFromInstanceId,
+  readWorkspaceAppIdFromNodeId,
+  resolveWorkspaceAppDisplayName,
+  workspaceAppCenterNodeID,
+  workspaceAppWebviewTypeID
+} from "./workspaceAppCenterLaunchRequest.ts";
+import type { WorkspaceAppWebviewExternalState } from "./workspaceAppCenterWebviewUrl.ts";
+
+type WorkspaceAppCenterExternalNodeState =
+  | WorkspaceAppCenterViewState
+  | WorkspaceAppWebviewExternalState
+  | null;
+
+export function createWorkspaceAppWebviewExternalStateSource(input: {
+  appCenterService: IWorkspaceAppCenterService;
+  runtimeStore: {
+    getSnapshot(): Record<string, BrowserNodeRuntimeState | undefined>;
+    subscribe(listener: () => void): () => void;
+  };
+}): WorkbenchHostExternalStateSource<
+  WorkspaceAppCenterExternalNodeState,
+  null
+> {
+  const appCenterViewStateByWorkspaceId = new Map<
+    string,
+    WorkspaceAppCenterViewState
+  >();
+  const appWebviewStateByNodeId = new Map<
+    string,
+    WorkspaceAppWebviewExternalState
+  >();
+
+  return {
+    getNodeState(request) {
+      if (request.typeId === workspaceAppCenterNodeID) {
+        return reuseWorkspaceAppCenterViewState(
+          appCenterViewStateByWorkspaceId,
+          request.workspaceId,
+          input.appCenterService.getViewState(request.workspaceId)
+        );
+      }
+      return reuseWorkspaceAppWebviewExternalState(
+        appWebviewStateByNodeId,
+        request.nodeId,
+        readWorkspaceAppExternalState(input, request)
+      );
+    },
+    getSnapshotNodeState(request) {
+      if (request.typeId === workspaceAppCenterNodeID) {
+        return reuseWorkspaceAppCenterViewState(
+          appCenterViewStateByWorkspaceId,
+          request.workspaceId,
+          input.appCenterService.getViewState(request.workspaceId)
+        );
+      }
+      return reuseWorkspaceAppWebviewExternalState(
+        appWebviewStateByNodeId,
+        request.nodeId,
+        readWorkspaceAppExternalState(input, request)
+      );
+    },
+    getWorkspaceState() {
+      return null;
+    },
+    subscribeNodeState(request, listener) {
+      if (
+        request.typeId !== workspaceAppCenterNodeID &&
+        request.typeId !== workspaceAppWebviewTypeID
+      ) {
+        return () => {};
+      }
+      const unsubscribeRuntime = input.runtimeStore.subscribe(listener);
+      const unsubscribeAppCenter = input.appCenterService.subscribe(listener);
+      return () => {
+        unsubscribeRuntime();
+        unsubscribeAppCenter();
+      };
+    }
+  };
+}
+
+function reuseWorkspaceAppCenterViewState(
+  stateByWorkspaceId: Map<string, WorkspaceAppCenterViewState>,
+  workspaceId: string,
+  next: WorkspaceAppCenterViewState
+): WorkspaceAppCenterViewState {
+  const previous = stateByWorkspaceId.get(workspaceId);
+  if (
+    previous?.activeAppTab === next.activeAppTab &&
+    previous.openAppId === next.openAppId &&
+    previous.openAppIds?.length === next.openAppIds?.length &&
+    previous.openAppIds?.every(
+      (appId, index) => appId === next.openAppIds?.[index]
+    )
+  ) {
+    return previous;
+  }
+  stateByWorkspaceId.set(workspaceId, next);
+  return next;
+}
+
+function reuseWorkspaceAppWebviewExternalState(
+  stateByNodeId: Map<string, WorkspaceAppWebviewExternalState>,
+  nodeId: string,
+  next: WorkspaceAppWebviewExternalState | null
+): WorkspaceAppWebviewExternalState | null {
+  const previous = stateByNodeId.get(nodeId) ?? null;
+  if (!next) {
+    stateByNodeId.delete(nodeId);
+    return null;
+  }
+  if (previous?.title === next.title && previous.url === next.url) {
+    return previous;
+  }
+  stateByNodeId.set(nodeId, next);
+  return next;
+}
+
+function readWorkspaceAppExternalState(
+  input: {
+    appCenterService: IWorkspaceAppCenterService;
+    runtimeStore: {
+      getSnapshot(): Record<string, BrowserNodeRuntimeState | undefined>;
+    };
+  },
+  request: WorkbenchHostExternalStateLookupInput
+): WorkspaceAppWebviewExternalState | null {
+  if (request.typeId !== workspaceAppWebviewTypeID) {
+    return null;
+  }
+  const runtime = input.runtimeStore.getSnapshot()[request.nodeId];
+  const runtimeUrl = runtime?.url?.trim();
+  if (runtimeUrl) {
+    return {
+      title: runtime?.title?.trim() || null,
+      url: runtimeUrl
+    };
+  }
+
+  const appId =
+    readWorkspaceAppIdFromNodeId(request.nodeId) ??
+    readWorkspaceAppIdFromInstanceId(request.instanceId);
+  const app = appId ? findWorkspaceApp(input.appCenterService, appId) : null;
+  return app?.launchUrl
+    ? {
+        title: resolveWorkspaceAppDisplayName(app),
+        url: app.launchUrl
+      }
+    : null;
+}

--- a/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/desktopIssueManagerNodeState.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/desktopIssueManagerNodeState.test.ts
@@ -213,6 +213,33 @@ test("desktop issue-manager node state source drops non-whitelisted updates", (t
   assert.equal(notifyCount, 2);
 });
 
+test("desktop issue-manager node state source preserves identity for equal live state", (t) => {
+  const restore = installFailingLocalStorage();
+  t.after(restore);
+  const source = createDesktopIssueManagerNodeStateSource({
+    workspaceId: "workspace-1"
+  });
+  const request = {
+    instanceId: "node-1",
+    nodeId: "node-1",
+    typeId: "issue-manager",
+    workspaceId: "workspace-1"
+  };
+  const state = {
+    issueSearchQuery: "render",
+    issueStatusFilter: "all" as const,
+    selectedAgentTargetId: "local:codex",
+    selectedIssueId: "issue-1",
+    selectedTaskId: null
+  };
+
+  source.writeNodeState({ ...request, state });
+  const first = source.externalStateSource.getNodeState(request);
+  source.writeNodeState({ ...request, state: { ...state } });
+
+  assert.equal(source.externalStateSource.getNodeState(request), first);
+});
+
 function installFailingLocalStorage(): () => void {
   const original = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
   Object.defineProperty(globalThis, "localStorage", {

--- a/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/desktopIssueManagerNodeState.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/desktopIssueManagerNodeState.test.ts
@@ -124,9 +124,17 @@ test("desktop issue-manager node state source drops non-whitelisted updates", (t
     workspaceId: "workspace-1"
   });
   let notifyCount = 0;
-  const unsubscribe = source.externalStateSource.subscribe?.(() => {
-    notifyCount += 1;
-  });
+  const unsubscribe = source.externalStateSource.subscribeNodeState?.(
+    {
+      instanceId: "issue-manager",
+      nodeId: "issue-manager",
+      typeId: "issue-manager",
+      workspaceId: "workspace-1"
+    },
+    () => {
+      notifyCount += 1;
+    }
+  );
   assert.ok(unsubscribe);
   t.after(unsubscribe);
 

--- a/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/desktopIssueManagerNodeState.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/desktopIssueManagerNodeState.ts
@@ -84,10 +84,10 @@ export function createDesktopIssueManagerNodeStateSource(input: {
       }
       const previous = nodeStateByInstanceId.get(request.instanceId);
       const next = liveIssueManagerNodeState(request.state);
-      nodeStateByInstanceId.set(request.instanceId, next);
       if (previous && areIssueManagerLiveNodeStatesEqual(previous, next)) {
         return;
       }
+      nodeStateByInstanceId.set(request.instanceId, next);
       notify();
     }
   };

--- a/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/desktopIssueManagerNodeState.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/desktopIssueManagerNodeState.ts
@@ -41,6 +41,7 @@ export function createDesktopIssueManagerNodeStateSource(input: {
     DesktopIssueManagerLiveNodeState
   >();
   const listeners = new Set<() => void>();
+  const workspaceState = { workspaceId: input.workspaceId };
 
   const notify = () => {
     for (const listener of listeners) {
@@ -55,7 +56,7 @@ export function createDesktopIssueManagerNodeStateSource(input: {
           return null;
         }
         const state = nodeStateByInstanceId.get(request.instanceId);
-        return state ? { ...state } : null;
+        return state ?? null;
       },
       getSnapshotNodeState(request) {
         if (request.typeId !== "issue-manager") {
@@ -65,11 +66,12 @@ export function createDesktopIssueManagerNodeStateSource(input: {
         return state ? restorableIssueManagerNodeState(state) : null;
       },
       getWorkspaceState() {
-        return {
-          workspaceId: input.workspaceId
-        };
+        return workspaceState;
       },
-      subscribe(listener) {
+      subscribeNodeState(request, listener) {
+        if (request.typeId !== "issue-manager") {
+          return () => {};
+        }
         listeners.add(listener);
         return () => {
           listeners.delete(listener);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserContributionCore.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserContributionCore.test.ts
@@ -102,7 +102,15 @@ test("createWorkspaceBrowserNodeExternalStateSource exposes runtime state for wo
       null
     );
 
-    const dispose = source.subscribe?.(() => {});
+    const dispose = source.subscribeNodeState?.(
+      {
+        instanceId: "node-2",
+        nodeId: "browser:node-2",
+        typeId: workspaceBrowserNodeID,
+        workspaceId: "workspace-1"
+      },
+      () => {}
+    );
     runtimeSnapshot["browser:node-2:tab:1"] = createBrowserRuntimeState({
       title: "Tutti",
       url: "https://tutti.example"

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserContributionCore.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserContributionCore.ts
@@ -24,12 +24,15 @@ export function createWorkspaceBrowserNodeExternalStateSource(input: {
   WorkspaceBrowserNodeExternalState | null,
   null
 > {
+  const stateByNodeId = new Map<string, WorkspaceBrowserNodeExternalState>();
   return {
     getNodeState(request) {
       if (!isBrowserNodeExternalStateRequest(request)) {
         return null;
       }
-      return readWorkspaceBrowserRuntimeNodeState(
+      return reuseWorkspaceBrowserRuntimeNodeState(
+        stateByNodeId,
+        request.nodeId,
         input.runtimeStore.getSnapshot(),
         input.tabsStore.getActiveNodeId(request.nodeId)
       );
@@ -38,7 +41,9 @@ export function createWorkspaceBrowserNodeExternalStateSource(input: {
       if (!isBrowserNodeExternalStateRequest(request)) {
         return null;
       }
-      return readWorkspaceBrowserRuntimeNodeState(
+      return reuseWorkspaceBrowserRuntimeNodeState(
+        stateByNodeId,
+        request.nodeId,
         input.runtimeStore.getSnapshot(),
         input.tabsStore.getActiveNodeId(request.nodeId)
       );
@@ -46,7 +51,10 @@ export function createWorkspaceBrowserNodeExternalStateSource(input: {
     getWorkspaceState() {
       return null;
     },
-    subscribe(listener) {
+    subscribeNodeState(request, listener) {
+      if (!isBrowserNodeExternalStateRequest(request)) {
+        return () => {};
+      }
       const unsubscribeRuntime = input.runtimeStore.subscribe(listener);
       const unsubscribeTabs = input.tabsStore.subscribe(listener);
       return () => {
@@ -55,6 +63,28 @@ export function createWorkspaceBrowserNodeExternalStateSource(input: {
       };
     }
   };
+}
+
+function reuseWorkspaceBrowserRuntimeNodeState(
+  stateByNodeId: Map<string, WorkspaceBrowserNodeExternalState>,
+  nodeId: string,
+  runtimeSnapshot: Record<string, BrowserNodeRuntimeState | undefined>,
+  activeNodeId: string
+): WorkspaceBrowserNodeExternalState | null {
+  const next = readWorkspaceBrowserRuntimeNodeState(
+    runtimeSnapshot,
+    activeNodeId
+  );
+  const previous = stateByNodeId.get(nodeId) ?? null;
+  if (!next) {
+    stateByNodeId.delete(nodeId);
+    return null;
+  }
+  if (previous?.title === next.title && previous.url === next.url) {
+    return previous;
+  }
+  stateByNodeId.set(nodeId, next);
+  return next;
 }
 
 function isBrowserNodeExternalStateRequest(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.test.ts
@@ -126,6 +126,37 @@ test("workspace files contribution exposes file manager state through runtime an
   dispose?.();
 });
 
+test("workspace files external state preserves unchanged snapshot references", () => {
+  const snapshotState: WorkspaceFileManagerPersistedState = {
+    currentDirectoryPath: "/workspace/docs",
+    navigationBackStack: ["/workspace"],
+    navigationForwardStack: [],
+    selectedLocationId: null,
+    schemaVersion: 3
+  };
+  const contribution = createWorkspaceFilesContribution({
+    filesLabel: "Files",
+    icon: null,
+    renderFilesNodeBody: () => null,
+    renderTrafficLights,
+    workspaceFileManagerService: createFileManagerServiceStub(snapshotState, {
+      cloneSnapshots: true
+    }),
+    workspaceId: "workspace-1"
+  });
+  const request = {
+    instanceId: workspaceFilesNodeID,
+    nodeId: workspaceFilesNodeID,
+    typeId: workspaceFilesNodeID,
+    workspaceId: "workspace-1"
+  };
+
+  assert.equal(
+    contribution.externalStateSource?.getNodeState(request),
+    contribution.externalStateSource?.getNodeState(request)
+  );
+});
+
 test("workspace files contribution passes restored state to the node body renderer", () => {
   const restoredState: WorkspaceFileManagerPersistedState = {
     currentDirectoryPath: "/workspace/docs",
@@ -228,7 +259,8 @@ function createLaunchRequestContext(): Pick<
 }
 
 function createFileManagerServiceStub(
-  snapshotState: WorkspaceFileManagerPersistedState | null
+  snapshotState: WorkspaceFileManagerPersistedState | null,
+  options: { cloneSnapshots?: boolean } = {}
 ): IWorkspaceFileManagerService & { emit(): void } {
   const listeners = new Set<() => void>();
   return {
@@ -249,7 +281,14 @@ function createFileManagerServiceStub(
       throw new Error("getReferenceSourceAggregator should not be called");
     },
     getSnapshotState() {
-      return snapshotState;
+      if (!snapshotState || !options.cloneSnapshots) {
+        return snapshotState;
+      }
+      return {
+        ...snapshotState,
+        navigationBackStack: [...snapshotState.navigationBackStack],
+        navigationForwardStack: [...snapshotState.navigationForwardStack]
+      };
     },
     async openCanvasFilePreview() {
       return false;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.test.ts
@@ -110,9 +110,17 @@ test("workspace files contribution exposes file manager state through runtime an
   );
 
   let notified = false;
-  const dispose = contribution.externalStateSource?.subscribe?.(() => {
-    notified = true;
-  });
+  const dispose = contribution.externalStateSource?.subscribeNodeState?.(
+    {
+      instanceId: workspaceFilesNodeID,
+      nodeId: workspaceFilesNodeID,
+      typeId: workspaceFilesNodeID,
+      workspaceId: "workspace-1"
+    },
+    () => {
+      notified = true;
+    }
+  );
   service.emit();
   assert.equal(notified, true);
   dispose?.();

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.ts
@@ -186,7 +186,10 @@ function createWorkspaceFilesExternalStateSource(input: {
     getWorkspaceState() {
       return null;
     },
-    subscribe(listener) {
+    subscribeNodeState(request, listener) {
+      if (!isWorkspaceFilesExternalStateRequest(request)) {
+        return () => {};
+      }
       return input.workspaceFileManagerService.subscribe(
         input.workspaceId,
         listener

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.ts
@@ -166,21 +166,30 @@ function createWorkspaceFilesExternalStateSource(input: {
   WorkspaceFileManagerPersistedState | null,
   null
 > {
+  const stateByWorkspaceId = new Map<
+    string,
+    WorkspaceFileManagerPersistedState
+  >();
+
   return {
     getNodeState(request) {
       if (!isWorkspaceFilesExternalStateRequest(request)) {
         return null;
       }
-      return input.workspaceFileManagerService.getSnapshotState(
-        input.workspaceId
+      return reuseWorkspaceFilesExternalState(
+        stateByWorkspaceId,
+        input.workspaceId,
+        input.workspaceFileManagerService.getSnapshotState(input.workspaceId)
       );
     },
     getSnapshotNodeState(request) {
       if (!isWorkspaceFilesExternalStateRequest(request)) {
         return null;
       }
-      return input.workspaceFileManagerService.getSnapshotState(
-        input.workspaceId
+      return reuseWorkspaceFilesExternalState(
+        stateByWorkspaceId,
+        input.workspaceId,
+        input.workspaceFileManagerService.getSnapshotState(input.workspaceId)
       );
     },
     getWorkspaceState() {
@@ -196,6 +205,45 @@ function createWorkspaceFilesExternalStateSource(input: {
       );
     }
   };
+}
+
+function reuseWorkspaceFilesExternalState(
+  stateByWorkspaceId: Map<string, WorkspaceFileManagerPersistedState>,
+  workspaceId: string,
+  next: WorkspaceFileManagerPersistedState | null
+): WorkspaceFileManagerPersistedState | null {
+  const previous = stateByWorkspaceId.get(workspaceId) ?? null;
+  if (!next) {
+    stateByWorkspaceId.delete(workspaceId);
+    return null;
+  }
+  if (
+    previous?.currentDirectoryPath === next.currentDirectoryPath &&
+    previous.selectedLocationId === next.selectedLocationId &&
+    previous.schemaVersion === next.schemaVersion &&
+    sameWorkspaceFilesPathStack(
+      previous.navigationBackStack,
+      next.navigationBackStack
+    ) &&
+    sameWorkspaceFilesPathStack(
+      previous.navigationForwardStack,
+      next.navigationForwardStack
+    )
+  ) {
+    return previous;
+  }
+  stateByWorkspaceId.set(workspaceId, next);
+  return next;
+}
+
+function sameWorkspaceFilesPathStack(
+  left: readonly string[],
+  right: readonly string[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((path, index) => path === right[index])
+  );
 }
 
 function isWorkspaceFilesExternalStateRequest(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceTerminalContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceTerminalContribution.ts
@@ -271,7 +271,10 @@ function createWorkspaceTerminalNodeExternalStateSource(input: {
     getWorkspaceState() {
       return null;
     },
-    subscribe(listener) {
+    subscribeNodeState(request, listener) {
+      if (request.typeId !== defaultWorkspaceTerminalWorkbenchTypeId) {
+        return () => {};
+      }
       const unsubscribeAdapter =
         input.adapter.externalStateSource.subscribe(listener);
       const unsubscribePreview = input.previewStore.subscribe(listener);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentIssueManagerToolPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentIssueManagerToolPanel.tsx
@@ -55,7 +55,16 @@ export function StandaloneAgentIssueManagerToolPanel({
       );
     };
     updateState();
-    return source.subscribe?.(updateState);
+    return source.subscribeNodeState?.(
+      {
+        instanceId: standaloneAgentIssueManagerNodeId,
+        instanceKey: standaloneAgentIssueManagerNodeId,
+        nodeId: standaloneAgentIssueManagerNodeId,
+        typeId: defaultIssueManagerWorkbenchTypeId,
+        workspaceId
+      },
+      updateState
+    );
   }, [resolved, workspaceId]);
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.test.ts
@@ -298,7 +298,7 @@ test("standalone Agent toolbar exposes task management in the unified panel", ()
   );
   assert.match(
     standaloneAgentIssueManagerToolPanelSource,
-    /source\.subscribe\?\.\(updateState\)/
+    /source\.subscribeNodeState\?\.\([\s\S]*?updateState/
   );
 });
 

--- a/docs/architecture/workbench-contributions.md
+++ b/docs/architecture/workbench-contributions.md
@@ -137,6 +137,20 @@ They must not own:
 - app-specific daemon client creation
 - product-specific enablement or routing policy
 
+### External State Subscription
+
+External state is node-scoped. `WorkbenchHostExternalStateSource` exposes
+`subscribeNodeState(input, listener)` and, when a node renderer consumes shared
+workspace state, `subscribeWorkspaceState(input, listener)`. The host binds
+those subscriptions at node-renderer leaves; it does not maintain a host-wide
+external-state revision.
+
+Source snapshots returned by `getNodeState(...)` and `getWorkspaceState(...)`
+must preserve reference identity until their observable slice changes. A
+contribution must not aggregate unrelated capability, room, or shell state into
+one workspace snapshot. If a capability has no live state, it omits the
+corresponding subscription method.
+
 ### Consuming hosts such as `apps/desktop`
 
 The consuming host should continue to own:

--- a/packages/agent/gui/workbench/state.test.ts
+++ b/packages/agent/gui/workbench/state.test.ts
@@ -178,9 +178,17 @@ describe("agent gui workbench state", () => {
     });
     let notified = 0;
     const unsubscribe =
-      source.externalStateSource.subscribe?.(() => {
-        notified += 1;
-      }) ?? (() => undefined);
+      source.externalStateSource.subscribeNodeState?.(
+        {
+          instanceId: "agent-gui:hermes",
+          nodeId: "node-1",
+          typeId: "agent-gui",
+          workspaceId: "workspace-1"
+        },
+        () => {
+          notified += 1;
+        }
+      ) ?? (() => undefined);
 
     source.writeNodeState({
       instanceId: "agent-gui:hermes",
@@ -260,9 +268,17 @@ describe("agent gui workbench state", () => {
     });
     let notified = 0;
     const unsubscribe =
-      source.externalStateSource.subscribe?.(() => {
-        notified += 1;
-      }) ?? (() => undefined);
+      source.externalStateSource.subscribeNodeState?.(
+        {
+          instanceId: "agent-gui",
+          nodeId: "node-1",
+          typeId: "agent-gui",
+          workspaceId: "workspace-1"
+        },
+        () => {
+          notified += 1;
+        }
+      ) ?? (() => undefined);
 
     source.writeNodeState({
       instanceId: "agent-gui",

--- a/packages/agent/gui/workbench/state.test.ts
+++ b/packages/agent/gui/workbench/state.test.ts
@@ -329,6 +329,25 @@ describe("agent gui workbench state", () => {
     });
   });
 
+  it("preserves node state identity for an equal write", () => {
+    const source = createAgentGuiWorkbenchNodeStateSource({
+      workspaceId: "workspace-1"
+    });
+    const request = {
+      instanceId: "agent-gui:hermes",
+      nodeId: "node-1",
+      typeId: "agent-gui" as const,
+      workspaceId: "workspace-1"
+    };
+    const state = { lastActiveAgentSessionId: "session-1" };
+
+    source.writeNodeState({ ...request, state });
+    const first = source.externalStateSource.getNodeState(request);
+    source.writeNodeState({ ...request, state: { ...state } });
+
+    expect(source.externalStateSource.getNodeState(request)).toBe(first);
+  });
+
   it("locates a node launch instanceId by the session it is showing", () => {
     const source = createAgentGuiWorkbenchNodeStateSource({
       workspaceId: "workspace-1"

--- a/packages/agent/gui/workbench/state.ts
+++ b/packages/agent/gui/workbench/state.ts
@@ -304,7 +304,6 @@ export function createAgentGuiWorkbenchNodeStateSource(input: {
       const next = {
         ...normalizeAgentGuiWorkbenchState(request.state)
       };
-      nodeStateByKey.set(key, next);
       if (
         !clearedInstanceSeed &&
         previous &&
@@ -312,6 +311,7 @@ export function createAgentGuiWorkbenchNodeStateSource(input: {
       ) {
         return;
       }
+      nodeStateByKey.set(key, next);
       notify();
     }
   };

--- a/packages/agent/gui/workbench/state.ts
+++ b/packages/agent/gui/workbench/state.ts
@@ -225,6 +225,7 @@ export function createAgentGuiWorkbenchNodeStateSource(input: {
   // by the session it is currently showing, even when its key is node-scoped.
   const instanceIdByKey = new Map<string, string>();
   const listeners = new Set<() => void>();
+  const workspaceState = { workspaceId: input.workspaceId };
 
   const lookupState = (request: AgentGuiWorkbenchStateLookupRequest) => {
     const nodeState = request.nodeId
@@ -233,7 +234,7 @@ export function createAgentGuiWorkbenchNodeStateSource(input: {
     const state =
       nodeState ??
       nodeStateByKey.get(agentGuiWorkbenchInstanceStateKey(request));
-    return state ? { ...state } : null;
+    return state ?? null;
   };
 
   const notify = () => {
@@ -257,11 +258,12 @@ export function createAgentGuiWorkbenchNodeStateSource(input: {
         return lookupState(request);
       },
       getWorkspaceState() {
-        return {
-          workspaceId: input.workspaceId
-        };
+        return workspaceState;
       },
-      subscribe(listener) {
+      subscribeNodeState(request, listener) {
+        if (request.typeId !== typeId) {
+          return () => {};
+        }
         listeners.add(listener);
         return () => {
           listeners.delete(listener);

--- a/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
@@ -181,6 +181,84 @@ describe("WorkbenchHost", () => {
       ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
     }
   });
+
+  it("retries a node render after its external state recovers", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const listeners = new Set<() => void>();
+    let nodeState: { status: "bad" | "ready" } = { status: "bad" };
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchHost
+            externalStateSource={{
+              getNodeState() {
+                return nodeState;
+              },
+              getWorkspaceState() {
+                return null;
+              },
+              subscribeNodeState(_input, listener) {
+                listeners.add(listener);
+                return () => listeners.delete(listener);
+              }
+            }}
+            nodes={[
+              {
+                frame: { x: 0, y: 0, width: 320, height: 240 },
+                renderBody: (context) => {
+                  if (
+                    (context.externalNodeState as { status: string } | null)
+                      ?.status === "bad"
+                  ) {
+                    throw new Error("transient external state");
+                  }
+                  return <div data-node-recovered="true" />;
+                },
+                title: "Recoverable",
+                typeId: "recoverable",
+                window: { defaultOpen: true }
+              }
+            ]}
+            snapshotRepository={createSnapshotRepository()}
+            workspaceId="workspace-1"
+          />
+        );
+      });
+
+      expect(
+        container.querySelector("[data-workbench-node-render-error]")
+      ).not.toBeNull();
+      nodeState = { status: "ready" };
+      await act(async () => {
+        for (const listener of listeners) {
+          listener();
+        }
+      });
+
+      expect(container.querySelector("[data-node-recovered]")).not.toBeNull();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      consoleError.mockRestore();
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+  });
 });
 
 function createSnapshotRepository(): WorkbenchHostSnapshotRepository {

--- a/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
@@ -95,4 +95,101 @@ describe("WorkbenchHost", () => {
       ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
     }
   });
+
+  it("refreshes only the node subscribed to external state", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const listenersByTypeId = new Map<string, Set<() => void>>();
+    const nodeStateByTypeId = new Map<string, { value: string }>([
+      ["node-a", { value: "A" }],
+      ["node-b", { value: "B" }]
+    ]);
+    const renderA = vi.fn();
+    const renderB = vi.fn();
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchHost
+            externalStateSource={{
+              getNodeState(input) {
+                return nodeStateByTypeId.get(input.typeId) ?? null;
+              },
+              getWorkspaceState() {
+                return null;
+              },
+              subscribeNodeState(input, listener) {
+                const listeners =
+                  listenersByTypeId.get(input.typeId) ?? new Set<() => void>();
+                listeners.add(listener);
+                listenersByTypeId.set(input.typeId, listeners);
+                return () => listeners.delete(listener);
+              }
+            }}
+            nodes={[
+              {
+                frame: { x: 0, y: 0, width: 320, height: 240 },
+                renderBody: (context) => {
+                  renderA(context.externalNodeState);
+                  return null;
+                },
+                title: "A",
+                typeId: "node-a",
+                window: { defaultOpen: true }
+              },
+              {
+                frame: { x: 20, y: 20, width: 320, height: 240 },
+                renderBody: (context) => {
+                  renderB(context.externalNodeState);
+                  return null;
+                },
+                title: "B",
+                typeId: "node-b",
+                window: { defaultOpen: true }
+              }
+            ]}
+            snapshotRepository={createSnapshotRepository()}
+            workspaceId="workspace-1"
+          />
+        );
+      });
+
+      const rendersBeforeNodeBChange = renderA.mock.calls.length;
+      nodeStateByTypeId.set("node-b", { value: "B2" });
+      await act(async () => {
+        for (const listener of listenersByTypeId.get("node-b") ?? []) {
+          listener();
+        }
+      });
+
+      expect(renderA).toHaveBeenCalledTimes(rendersBeforeNodeBChange);
+      expect(renderB).toHaveBeenLastCalledWith({ value: "B2" });
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+  });
 });
+
+function createSnapshotRepository(): WorkbenchHostSnapshotRepository {
+  return {
+    async load() {
+      return null;
+    },
+    save(_workspaceId: string, snapshot: WorkbenchSnapshot) {
+      return snapshot;
+    }
+  };
+}

--- a/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
@@ -120,8 +120,7 @@ describe("WorkbenchHost", () => {
           <WorkbenchHost
             externalStateSource={{
               getNodeState(input) {
-                const state = nodeStateByTypeId.get(input.typeId);
-                return state ? { ...state } : null;
+                return nodeStateByTypeId.get(input.typeId) ?? null;
               },
               getWorkspaceState() {
                 return null;

--- a/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
@@ -120,7 +120,8 @@ describe("WorkbenchHost", () => {
           <WorkbenchHost
             externalStateSource={{
               getNodeState(input) {
-                return nodeStateByTypeId.get(input.typeId) ?? null;
+                const state = nodeStateByTypeId.get(input.typeId);
+                return state ? { ...state } : null;
               },
               getWorkspaceState() {
                 return null;

--- a/packages/workbench/surface/src/host/WorkbenchHost.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHost.tsx
@@ -82,7 +82,6 @@ export function WorkbenchHost({
     missionControlMode !== null || onMissionControlAdapterReady !== undefined;
   const {
     chromeContext,
-    externalStateRevision,
     hostI18n,
     hostSession,
     isHydrating,
@@ -113,7 +112,6 @@ export function WorkbenchHost({
     dockStateSource,
     dockEntries: hostDockEntries,
     externalStateSource: hostRuntimeConfig.externalStateSource,
-    externalStateRevision,
     hostI18n,
     hostSession,
     nodeDefinitionByType,

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -44,7 +44,10 @@ import {
   resolveWorkbenchHostDockScrollState,
   type WorkbenchHostDockScrollState
 } from "./dockScrollState.ts";
-import { readWorkbenchHostExternalState } from "./externalState.ts";
+import {
+  createWorkbenchHostExternalStateLookupInput,
+  readWorkbenchHostExternalState
+} from "./externalState.ts";
 import {
   resolveWorkbenchMinimizedDockSlots,
   type WorkbenchMinimizedDockNode,
@@ -1097,13 +1100,29 @@ export function WorkbenchHostDock({
 
   useEffect(() => {
     const shouldSubscribe = activePopup !== null || hasMinimizedPreviewCapture;
-    if (!shouldSubscribe || !externalStateSource?.subscribe) {
+    if (!shouldSubscribe || !externalStateSource?.subscribeNodeState) {
       return undefined;
     }
-    return externalStateSource.subscribe(() => {
-      setExternalStateRevision((revision) => revision + 1);
-    });
-  }, [activePopup, externalStateSource, hasMinimizedPreviewCapture]);
+    const nodes = activePopup ? context.nodes : context.minimizedNodes;
+    const disposers = nodes.map((node) =>
+      externalStateSource.subscribeNodeState?.(
+        createWorkbenchHostExternalStateLookupInput({ node, workspaceId }),
+        () => setExternalStateRevision((revision) => revision + 1)
+      )
+    );
+    return () => {
+      for (const dispose of disposers) {
+        dispose?.();
+      }
+    };
+  }, [
+    activePopup,
+    context.minimizedNodes,
+    context.nodes,
+    externalStateSource,
+    hasMinimizedPreviewCapture,
+    workspaceId
+  ]);
 
   useEffect(() => {
     const nextAttentionIds = new Set<string>();

--- a/packages/workbench/surface/src/host/externalState.ts
+++ b/packages/workbench/surface/src/host/externalState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
 import type { WorkbenchNode } from "../core/types.ts";
 import type {
   WorkbenchHostExternalStateLookupInput,
@@ -12,6 +12,35 @@ export interface WorkbenchHostExternalState {
 }
 
 const noopSubscribe = () => () => {};
+
+function useCachedExternalSnapshot<T>(input: {
+  getSnapshot: () => T;
+  subscribe: (listener: () => void) => () => void;
+}): T {
+  const cacheRef = useRef<{ hasValue: boolean; value: T | null }>({
+    hasValue: false,
+    value: null
+  });
+  const getSnapshot = useCallback(() => {
+    if (!cacheRef.current.hasValue) {
+      cacheRef.current = {
+        hasValue: true,
+        value: input.getSnapshot()
+      };
+    }
+    return cacheRef.current.value as T;
+  }, [input.getSnapshot]);
+  const subscribe = useCallback(
+    (listener: () => void) =>
+      input.subscribe(() => {
+        cacheRef.current.hasValue = false;
+        listener();
+      }),
+    [input.subscribe]
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
 
 export function createWorkbenchHostExternalStateLookupInput(input: {
   node: WorkbenchNode<WorkbenchHostNodeData>;
@@ -78,16 +107,14 @@ export function useWorkbenchHostExternalState(input: {
   );
 
   return {
-    externalNodeState: useSyncExternalStore(
-      subscribeNodeState,
-      getNodeState,
-      getNodeState
-    ),
-    externalWorkspaceState: useSyncExternalStore(
-      subscribeWorkspaceState,
-      getWorkspaceState,
-      getWorkspaceState
-    )
+    externalNodeState: useCachedExternalSnapshot({
+      getSnapshot: getNodeState,
+      subscribe: subscribeNodeState
+    }),
+    externalWorkspaceState: useCachedExternalSnapshot({
+      getSnapshot: getWorkspaceState,
+      subscribe: subscribeWorkspaceState
+    })
   };
 }
 

--- a/packages/workbench/surface/src/host/externalState.ts
+++ b/packages/workbench/surface/src/host/externalState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
 import type { WorkbenchNode } from "../core/types.ts";
 import type {
   WorkbenchHostExternalStateLookupInput,
@@ -12,35 +12,6 @@ export interface WorkbenchHostExternalState {
 }
 
 const noopSubscribe = () => () => {};
-
-function useCachedExternalSnapshot<T>(input: {
-  getSnapshot: () => T;
-  subscribe: (listener: () => void) => () => void;
-}): T {
-  const cacheRef = useRef<{ hasValue: boolean; value: T | null }>({
-    hasValue: false,
-    value: null
-  });
-  const getSnapshot = useCallback(() => {
-    if (!cacheRef.current.hasValue) {
-      cacheRef.current = {
-        hasValue: true,
-        value: input.getSnapshot()
-      };
-    }
-    return cacheRef.current.value as T;
-  }, [input.getSnapshot]);
-  const subscribe = useCallback(
-    (listener: () => void) =>
-      input.subscribe(() => {
-        cacheRef.current.hasValue = false;
-        listener();
-      }),
-    [input.subscribe]
-  );
-
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
-}
 
 export function createWorkbenchHostExternalStateLookupInput(input: {
   node: WorkbenchNode<WorkbenchHostNodeData>;
@@ -107,14 +78,16 @@ export function useWorkbenchHostExternalState(input: {
   );
 
   return {
-    externalNodeState: useCachedExternalSnapshot({
-      getSnapshot: getNodeState,
-      subscribe: subscribeNodeState
-    }),
-    externalWorkspaceState: useCachedExternalSnapshot({
-      getSnapshot: getWorkspaceState,
-      subscribe: subscribeWorkspaceState
-    })
+    externalNodeState: useSyncExternalStore(
+      subscribeNodeState,
+      getNodeState,
+      getNodeState
+    ),
+    externalWorkspaceState: useSyncExternalStore(
+      subscribeWorkspaceState,
+      getWorkspaceState,
+      getWorkspaceState
+    )
   };
 }
 

--- a/packages/workbench/surface/src/host/externalState.ts
+++ b/packages/workbench/surface/src/host/externalState.ts
@@ -1,5 +1,7 @@
+import { useCallback, useMemo, useSyncExternalStore } from "react";
 import type { WorkbenchNode } from "../core/types.ts";
 import type {
+  WorkbenchHostExternalStateLookupInput,
   WorkbenchHostExternalStateSource,
   WorkbenchHostNodeData
 } from "./types.ts";
@@ -7,6 +9,86 @@ import type {
 export interface WorkbenchHostExternalState {
   externalNodeState: unknown;
   externalWorkspaceState: unknown;
+}
+
+const noopSubscribe = () => () => {};
+
+export function createWorkbenchHostExternalStateLookupInput(input: {
+  node: WorkbenchNode<WorkbenchHostNodeData>;
+  workspaceId: string;
+}): WorkbenchHostExternalStateLookupInput {
+  return {
+    instanceId: input.node.data.instanceId,
+    instanceKey: input.node.data.instanceKey ?? null,
+    nodeId: input.node.id,
+    typeId: input.node.data.typeId,
+    workspaceId: input.workspaceId,
+    ...(input.node.data.projectionSubject
+      ? { subject: input.node.data.projectionSubject }
+      : {})
+  };
+}
+
+/**
+ * Binds a node renderer to only the external state it consumes. The source
+ * contract requires stable snapshots, so unrelated source changes do not
+ * invalidate the surrounding Workbench host.
+ */
+export function useWorkbenchHostExternalState(input: {
+  externalStateSource?: WorkbenchHostExternalStateSource;
+  node: WorkbenchNode<WorkbenchHostNodeData>;
+  workspaceId: string;
+}): WorkbenchHostExternalState {
+  const lookupInput = useMemo(
+    () =>
+      createWorkbenchHostExternalStateLookupInput({
+        node: input.node,
+        workspaceId: input.workspaceId
+      }),
+    [input.node, input.workspaceId]
+  );
+  const workspaceInput = useMemo(
+    () => ({ workspaceId: input.workspaceId }),
+    [input.workspaceId]
+  );
+  const subscribeNodeState = useCallback(
+    (listener: () => void) =>
+      input.externalStateSource?.subscribeNodeState?.(lookupInput, listener) ??
+      noopSubscribe(),
+    [input.externalStateSource, lookupInput]
+  );
+  const getNodeState = useCallback(
+    () =>
+      input.externalStateSource?.getNodeState(lookupInput) ??
+      input.node.data.snapshotNodeState ??
+      null,
+    [input.externalStateSource, input.node.data.snapshotNodeState, lookupInput]
+  );
+  const subscribeWorkspaceState = useCallback(
+    (listener: () => void) =>
+      input.externalStateSource?.subscribeWorkspaceState?.(
+        workspaceInput,
+        listener
+      ) ?? noopSubscribe(),
+    [input.externalStateSource, workspaceInput]
+  );
+  const getWorkspaceState = useCallback(
+    () => input.externalStateSource?.getWorkspaceState(workspaceInput) ?? null,
+    [input.externalStateSource, workspaceInput]
+  );
+
+  return {
+    externalNodeState: useSyncExternalStore(
+      subscribeNodeState,
+      getNodeState,
+      getNodeState
+    ),
+    externalWorkspaceState: useSyncExternalStore(
+      subscribeWorkspaceState,
+      getWorkspaceState,
+      getWorkspaceState
+    )
+  };
 }
 
 export function readWorkbenchHostExternalState(input: {
@@ -21,16 +103,7 @@ export function readWorkbenchHostExternalState(input: {
     };
   }
 
-  const nodeStateInput = {
-    instanceId: input.node.data.instanceId,
-    instanceKey: input.node.data.instanceKey ?? null,
-    nodeId: input.node.id,
-    typeId: input.node.data.typeId,
-    workspaceId: input.workspaceId,
-    ...(input.node.data.projectionSubject
-      ? { subject: input.node.data.projectionSubject }
-      : {})
-  };
+  const nodeStateInput = createWorkbenchHostExternalStateLookupInput(input);
 
   const sourceNodeState =
     input.externalStateSource.getNodeState(nodeStateInput);

--- a/packages/workbench/surface/src/host/hostConfig.test.ts
+++ b/packages/workbench/surface/src/host/hostConfig.test.ts
@@ -138,7 +138,7 @@ test("resolveWorkbenchHostConfig combines contribution external state in order",
           getWorkspaceState() {
             return undefined;
           },
-          subscribe() {
+          subscribeNodeState() {
             subscribeCount += 1;
             return () => {
               disposeCount += 1;
@@ -158,7 +158,7 @@ test("resolveWorkbenchHostConfig combines contribution external state in order",
           getWorkspaceState() {
             return { workspaceId: "workspace-1" };
           },
-          subscribe() {
+          subscribeNodeState() {
             subscribeCount += 1;
             return () => {
               disposeCount += 1;
@@ -195,7 +195,15 @@ test("resolveWorkbenchHostConfig combines contribution external state in order",
     { title: "Persisted Browser" }
   );
 
-  const dispose = resolved.externalStateSource?.subscribe?.(() => {});
+  const dispose = resolved.externalStateSource?.subscribeNodeState?.(
+    {
+      instanceId: "browser-1",
+      nodeId: "browser:browser-1",
+      typeId: "browser",
+      workspaceId: "workspace-1"
+    },
+    () => {}
+  );
   assert.equal(subscribeCount, 2);
   dispose?.();
   assert.equal(disposeCount, 2);

--- a/packages/workbench/surface/src/host/hostConfig.ts
+++ b/packages/workbench/surface/src/host/hostConfig.ts
@@ -155,9 +155,19 @@ function combineContributionExternalStateSources(
       }
       return null;
     },
-    subscribe(listener) {
+    subscribeNodeState(input, listener) {
       const disposers = sources
-        .map((source) => source.subscribe?.(listener))
+        .map((source) => source.subscribeNodeState?.(input, listener))
+        .filter((dispose): dispose is () => void => Boolean(dispose));
+      return () => {
+        for (const dispose of disposers) {
+          dispose();
+        }
+      };
+    },
+    subscribeWorkspaceState(input, listener) {
+      const disposers = sources
+        .map((source) => source.subscribeWorkspaceState?.(input, listener))
         .filter((dispose): dispose is () => void => Boolean(dispose));
       return () => {
         for (const dispose of disposers) {

--- a/packages/workbench/surface/src/host/hostNodeContext.ts
+++ b/packages/workbench/surface/src/host/hostNodeContext.ts
@@ -3,7 +3,10 @@ import type {
   WorkbenchRenderNodeContext,
   WorkbenchRenderWindowHeader
 } from "../react/types.ts";
-import { readWorkbenchHostExternalState } from "./externalState.ts";
+import {
+  readWorkbenchHostExternalState,
+  type WorkbenchHostExternalState
+} from "./externalState.ts";
 import { createWorkbenchHostNodeHeaderWindowActions } from "./windowActions.ts";
 import type {
   WorkbenchHostExternalStateSource,
@@ -19,6 +22,7 @@ export function createWorkbenchHostNodeBodyContext<
   TExternalWorkspaceState
 >({
   context,
+  externalState,
   externalStateSource,
   host,
   workspaceId
@@ -28,21 +32,25 @@ export function createWorkbenchHostNodeBodyContext<
     TExternalNodeState,
     TExternalWorkspaceState
   >;
+  externalState?: WorkbenchHostExternalState;
   externalStateSource?: WorkbenchHostExternalStateSource;
   host: WorkbenchHostHandle;
   workspaceId: string;
 }): WorkbenchHostNodeBodyContext<TExternalNodeState, TExternalWorkspaceState> {
-  const externalState = readWorkbenchHostExternalState({
-    externalStateSource,
-    node: context.node,
-    workspaceId
-  });
+  const resolvedExternalState =
+    externalState ??
+    readWorkbenchHostExternalState({
+      externalStateSource,
+      node: context.node,
+      workspaceId
+    });
   return {
     activation: context.node.data.activation ?? null,
     displayMode: context.node.displayMode,
-    externalNodeState: externalState.externalNodeState as TExternalNodeState,
+    externalNodeState:
+      resolvedExternalState.externalNodeState as TExternalNodeState,
     externalWorkspaceState:
-      externalState.externalWorkspaceState as TExternalWorkspaceState,
+      resolvedExternalState.externalWorkspaceState as TExternalWorkspaceState,
     focus() {
       host.focusNode(context.node.id);
     },
@@ -69,6 +77,7 @@ export function createWorkbenchHostNodeHeaderContext<
   TExternalWorkspaceState
 >({
   context,
+  externalState,
   externalStateSource,
   host,
   workspaceId
@@ -78,6 +87,7 @@ export function createWorkbenchHostNodeHeaderContext<
     TExternalNodeState,
     TExternalWorkspaceState
   >;
+  externalState?: WorkbenchHostExternalState;
   externalStateSource?: WorkbenchHostExternalStateSource;
   host: WorkbenchHostHandle;
   workspaceId: string;
@@ -85,20 +95,23 @@ export function createWorkbenchHostNodeHeaderContext<
   TExternalNodeState,
   TExternalWorkspaceState
 > {
-  const externalState = readWorkbenchHostExternalState({
-    externalStateSource,
-    node: context.node,
-    workspaceId
-  });
+  const resolvedExternalState =
+    externalState ??
+    readWorkbenchHostExternalState({
+      externalStateSource,
+      node: context.node,
+      workspaceId
+    });
 
   return {
     activation: context.node.data.activation ?? null,
     defaultActions: context.defaultActions,
     displayMode: context.node.displayMode,
     dragHandleProps: context.dragHandleProps,
-    externalNodeState: externalState.externalNodeState as TExternalNodeState,
+    externalNodeState:
+      resolvedExternalState.externalNodeState as TExternalNodeState,
     externalWorkspaceState:
-      externalState.externalWorkspaceState as TExternalWorkspaceState,
+      resolvedExternalState.externalWorkspaceState as TExternalWorkspaceState,
     instanceId: context.node.data.instanceId,
     instanceKey: context.node.data.instanceKey ?? null,
     isFocused:

--- a/packages/workbench/surface/src/host/session.test.ts
+++ b/packages/workbench/surface/src/host/session.test.ts
@@ -249,6 +249,59 @@ test("snapshot node state persists through the workbench host snapshot", async (
   restoredSession.dispose();
 });
 
+test("external state persistence subscriptions ignore frame-only node updates", async () => {
+  let subscribeCount = 0;
+  let unsubscribeCount = 0;
+  const session = createWorkbenchHostSession({
+    externalStateSource: {
+      getNodeState() {
+        return null;
+      },
+      getSnapshotNodeState() {
+        return null;
+      },
+      getWorkspaceState() {
+        return null;
+      },
+      subscribeNodeState() {
+        subscribeCount += 1;
+        return () => {
+          unsubscribeCount += 1;
+        };
+      }
+    },
+    nodes: [filesNodeDefinition],
+    snapshotRepository: {
+      async load() {
+        return createWorkbenchSnapshotFromState({
+          nodeStack: [],
+          nodes: []
+        });
+      },
+      save(_workspaceId, snapshot) {
+        return snapshot;
+      }
+    },
+    workspaceId: "workspace-1"
+  });
+
+  await session.load();
+  assert.equal(subscribeCount, 1);
+  session.controller.commands.resizeNode("workspace-files", {
+    height: 500,
+    width: 650,
+    x: 100,
+    y: 80
+  });
+
+  assert.equal(subscribeCount, 1);
+  assert.equal(unsubscribeCount, 0);
+  session.controller.commands.closeNode("workspace-files");
+
+  assert.equal(unsubscribeCount, 1);
+  session.dispose();
+});
+
 test("setNodeTitle updates an existing workbench node title", async () => {
   const session = createWorkbenchHostSession({
     nodes: [filesNodeDefinition],

--- a/packages/workbench/surface/src/host/session.ts
+++ b/packages/workbench/surface/src/host/session.ts
@@ -25,7 +25,10 @@ import {
   updateProjectedNodeFromInput,
   writeClosedDockWindowFrameEntries
 } from "./sessionState.ts";
-import { readWorkbenchHostExternalState } from "./externalState.ts";
+import {
+  createWorkbenchHostExternalStateLookupInput,
+  readWorkbenchHostExternalState
+} from "./externalState.ts";
 import { sanitizeWorkbenchHostSnapshot } from "./snapshotSanitizer.ts";
 import type { WorkbenchHostNodeData } from "./types.ts";
 import type {
@@ -1073,19 +1076,35 @@ class WorkbenchHostSessionController implements WorkbenchHostRuntimeHandle {
 
     this.unsubscribe = this.controller.subscribe(() => {
       this.schedulePersistedSnapshotWrite();
+      this.refreshExternalStatePersistenceSubscription();
     });
-    if (this.externalStateUnsubscribe === null) {
-      const source = this.input.externalStateSource;
-      const canReadSnapshotNodeState =
-        typeof source?.getSnapshotNodeState === "function";
-      if (!canReadSnapshotNodeState) {
-        return;
-      }
-      this.externalStateUnsubscribe =
-        source?.subscribe?.(() => {
-          this.schedulePersistedSnapshotWrite();
-        }) ?? null;
+    this.refreshExternalStatePersistenceSubscription();
+  }
+
+  private refreshExternalStatePersistenceSubscription(): void {
+    this.externalStateUnsubscribe?.();
+    this.externalStateUnsubscribe = null;
+    const source = this.input.externalStateSource;
+    if (
+      typeof source?.getSnapshotNodeState !== "function" ||
+      !source.subscribeNodeState
+    ) {
+      return;
     }
+    const disposers = this.controller.getSnapshot().nodes.map((node) =>
+      source.subscribeNodeState?.(
+        createWorkbenchHostExternalStateLookupInput({
+          node,
+          workspaceId: this.input.workspaceId
+        }),
+        () => this.schedulePersistedSnapshotWrite()
+      )
+    );
+    this.externalStateUnsubscribe = () => {
+      for (const dispose of disposers) {
+        dispose?.();
+      }
+    };
   }
 
   private disposeNodeLeases(): void {

--- a/packages/workbench/surface/src/host/session.ts
+++ b/packages/workbench/surface/src/host/session.ts
@@ -35,6 +35,7 @@ import type {
   WorkbenchHostActivation,
   WorkbenchHostActivationTarget,
   WorkbenchHostCloseEffect,
+  WorkbenchHostExternalStateLookupInput,
   WorkbenchHostExternalStateSource,
   WorkbenchHostLaunchInput,
   WorkbenchHostLaunchRequest,
@@ -129,7 +130,13 @@ class WorkbenchHostSessionController implements WorkbenchHostRuntimeHandle {
   private saveTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
   private appliedSaveSequence = 0;
   private saveSequence = 0;
-  private externalStateUnsubscribe: (() => void) | null = null;
+  private readonly externalStatePersistenceSubscriptions = new Map<
+    string,
+    {
+      lookupInput: WorkbenchHostExternalStateLookupInput;
+      unsubscribe: () => void;
+    }
+  >();
   private leaseUnsubscribe: (() => void) | null = null;
   private unsubscribe: (() => void) | null = null;
 
@@ -314,8 +321,7 @@ class WorkbenchHostSessionController implements WorkbenchHostRuntimeHandle {
     this.leaseUnsubscribe = null;
     this.unsubscribe?.();
     this.unsubscribe = null;
-    this.externalStateUnsubscribe?.();
-    this.externalStateUnsubscribe = null;
+    this.disposeExternalStatePersistenceSubscriptions();
     if (this.saveTimer !== null) {
       globalThis.clearTimeout(this.saveTimer);
       this.saveTimer = null;
@@ -436,8 +442,7 @@ class WorkbenchHostSessionController implements WorkbenchHostRuntimeHandle {
   private async loadInitialSnapshot(generation: number): Promise<void> {
     this.unsubscribe?.();
     this.unsubscribe = null;
-    this.externalStateUnsubscribe?.();
-    this.externalStateUnsubscribe = null;
+    this.disposeExternalStatePersistenceSubscriptions();
     if (this.saveTimer !== null) {
       globalThis.clearTimeout(this.saveTimer);
       this.saveTimer = null;
@@ -1082,29 +1087,54 @@ class WorkbenchHostSessionController implements WorkbenchHostRuntimeHandle {
   }
 
   private refreshExternalStatePersistenceSubscription(): void {
-    this.externalStateUnsubscribe?.();
-    this.externalStateUnsubscribe = null;
     const source = this.input.externalStateSource;
     if (
       typeof source?.getSnapshotNodeState !== "function" ||
       !source.subscribeNodeState
     ) {
+      this.disposeExternalStatePersistenceSubscriptions();
       return;
     }
-    const disposers = this.controller.getSnapshot().nodes.map((node) =>
-      source.subscribeNodeState?.(
-        createWorkbenchHostExternalStateLookupInput({
-          node,
-          workspaceId: this.input.workspaceId
-        }),
-        () => this.schedulePersistedSnapshotWrite()
-      )
-    );
-    this.externalStateUnsubscribe = () => {
-      for (const dispose of disposers) {
-        dispose?.();
+
+    const activeNodeIDs = new Set<string>();
+    for (const node of this.controller.getSnapshot().nodes) {
+      activeNodeIDs.add(node.id);
+      const lookupInput = createWorkbenchHostExternalStateLookupInput({
+        node,
+        workspaceId: this.input.workspaceId
+      });
+      const existing = this.externalStatePersistenceSubscriptions.get(node.id);
+      if (
+        existing &&
+        sameExternalStateLookupInput(existing.lookupInput, lookupInput)
+      ) {
+        continue;
       }
-    };
+      existing?.unsubscribe();
+      const unsubscribe = source.subscribeNodeState(lookupInput, () =>
+        this.schedulePersistedSnapshotWrite()
+      );
+      this.externalStatePersistenceSubscriptions.set(node.id, {
+        lookupInput,
+        unsubscribe
+      });
+    }
+
+    for (const [nodeID, subscription] of this
+      .externalStatePersistenceSubscriptions) {
+      if (activeNodeIDs.has(nodeID)) {
+        continue;
+      }
+      subscription.unsubscribe();
+      this.externalStatePersistenceSubscriptions.delete(nodeID);
+    }
+  }
+
+  private disposeExternalStatePersistenceSubscriptions(): void {
+    for (const subscription of this.externalStatePersistenceSubscriptions.values()) {
+      subscription.unsubscribe();
+    }
+    this.externalStatePersistenceSubscriptions.clear();
   }
 
   private disposeNodeLeases(): void {
@@ -1187,6 +1217,20 @@ function withoutRuntimeNodeState(
   const next = { ...data };
   delete next.runtimeNodeState;
   return next;
+}
+
+function sameExternalStateLookupInput(
+  left: WorkbenchHostExternalStateLookupInput,
+  right: WorkbenchHostExternalStateLookupInput
+): boolean {
+  return (
+    left.instanceId === right.instanceId &&
+    left.instanceKey === right.instanceKey &&
+    left.nodeId === right.nodeId &&
+    left.subject === right.subject &&
+    left.typeId === right.typeId &&
+    left.workspaceId === right.workspaceId
+  );
 }
 
 function withoutSnapshotNodeState(

--- a/packages/workbench/surface/src/host/types.ts
+++ b/packages/workbench/surface/src/host/types.ts
@@ -84,7 +84,22 @@ export interface WorkbenchHostExternalStateSource<
   getNodeState(input: WorkbenchHostExternalStateLookupInput): TNodeState;
   getSnapshotNodeState?(input: WorkbenchHostExternalStateLookupInput): unknown;
   getWorkspaceState(input: { workspaceId: string }): TWorkspaceState;
-  subscribe?(listener: () => void): () => void;
+  /**
+   * Subscribe to one node's live state. `getNodeState` must return the same
+   * reference until this node's observable state changes.
+   */
+  subscribeNodeState?(
+    input: WorkbenchHostExternalStateLookupInput,
+    listener: () => void
+  ): () => void;
+  /**
+   * Subscribe to workspace state consumed by a node renderer. `getWorkspaceState`
+   * must return the same reference until this workspace state changes.
+   */
+  subscribeWorkspaceState?(
+    input: { workspaceId: string },
+    listener: () => void
+  ): () => void;
 }
 
 export type WorkbenchHostNodeCloseDecision = "close" | "keep-open";

--- a/packages/workbench/surface/src/host/useWorkbenchHostRuntime.ts
+++ b/packages/workbench/surface/src/host/useWorkbenchHostRuntime.ts
@@ -41,7 +41,6 @@ export function useWorkbenchHostRuntime({
   > & {
     missionControlEnabled: boolean;
   }) {
-  const [externalStateRevision, bumpExternalStateRevision] = useState(0);
   const [, bumpHydrationRevision] = useState(0);
   const hostSession = useMemo(() => {
     logWorkbenchHostDebug("create-session", debugDiagnostics, {
@@ -148,19 +147,8 @@ export function useWorkbenchHostRuntime({
     hostSession.reconcileProjectedNodes(projectedNodes ?? []);
   }, [hostSession, projectedNodes]);
 
-  useEffect(() => {
-    if (!externalStateSource?.subscribe) {
-      return undefined;
-    }
-
-    return externalStateSource.subscribe(() => {
-      bumpExternalStateRevision((revision) => revision + 1);
-    });
-  }, [externalStateSource, workspaceId]);
-
   return {
     chromeContext,
-    externalStateRevision,
     hostI18n,
     isHydrating,
     hostSession,

--- a/packages/workbench/surface/src/host/useWorkbenchHostSurfaceRenderers.tsx
+++ b/packages/workbench/surface/src/host/useWorkbenchHostSurfaceRenderers.tsx
@@ -22,7 +22,10 @@ import {
   createWorkbenchHostNodeHeaderContext
 } from "./hostNodeContext.ts";
 import { WorkbenchHostWindowActions } from "./WorkbenchHostWindowActions.tsx";
-import { readWorkbenchHostExternalState } from "./externalState.ts";
+import {
+  readWorkbenchHostExternalState,
+  useWorkbenchHostExternalState
+} from "./externalState.ts";
 import {
   isWorkbenchMinimizedDockEligibleNode,
   resolveWorkbenchMinimizedDockAnchorKeyForNode,
@@ -49,7 +52,6 @@ export function useWorkbenchHostSurfaceRenderers(input: {
   dockEntries: readonly WorkbenchHostDockEntry[];
   dockStateSource?: WorkbenchHostProps["dockStateSource"];
   externalStateSource?: WorkbenchHostExternalStateSource;
-  externalStateRevision: number;
   hostI18n: WorkbenchHostI18nRuntime;
   hostSession: WorkbenchHostRuntimeHandle;
   nodeDefinitionByType: Map<string, WorkbenchHostNodeDefinition>;
@@ -213,38 +215,20 @@ export function useWorkbenchHostSurfaceRenderers(input: {
         return null;
       }
 
-      const bodyContext = createWorkbenchHostNodeBodyContext({
-        context,
-        definition,
-        externalStateSource: input.externalStateSource,
-        host: input.hostSession,
-        workspaceId: input.workspaceId
-      });
-
       return (
-        <WorkbenchHostNodeRenderErrorBoundary
+        <WorkbenchHostNodeRenderer
           debugDiagnostics={input.debugDiagnostics}
-          node={context.node}
-          onErrorChange={(hasError) =>
-            definition.onBodyRenderErrorChange?.({
-              hasError,
-              node: context.node
-            })
-          }
-          resetKey={`${context.node.id}:${context.node.data.typeId}:${input.externalStateRevision}`}
+          context={context}
+          definition={definition}
+          externalStateSource={input.externalStateSource}
+          host={input.hostSession}
           workspaceId={input.workspaceId}
-        >
-          <WorkbenchHostNodeBodyRenderer
-            context={bodyContext}
-            definition={definition}
-          />
-        </WorkbenchHostNodeRenderErrorBoundary>
+        />
       );
     },
     [
       input.debugDiagnostics,
       input.externalStateSource,
-      input.externalStateRevision,
       input.hostSession,
       input.nodeDefinitionByType,
       input.workspaceId
@@ -274,19 +258,18 @@ export function useWorkbenchHostSurfaceRenderers(input: {
         return null;
       }
 
-      return definition.renderHeader(
-        createWorkbenchHostNodeHeaderContext({
-          context,
-          definition,
-          externalStateSource: input.externalStateSource,
-          host: input.hostSession,
-          workspaceId: input.workspaceId
-        })
+      return (
+        <WorkbenchHostNodeHeaderRenderer
+          context={context}
+          definition={definition}
+          externalStateSource={input.externalStateSource}
+          host={input.hostSession}
+          workspaceId={input.workspaceId}
+        />
       );
     },
     [
       input.externalStateSource,
-      input.externalStateRevision,
       input.hostSession,
       input.nodeDefinitionByType,
       input.workspaceId
@@ -467,6 +450,73 @@ interface WorkbenchHostNodeRenderErrorBoundaryProps {
   onErrorChange?: (hasError: boolean) => void;
   resetKey: string;
   workspaceId: string;
+}
+
+function WorkbenchHostNodeRenderer(input: {
+  context: WorkbenchRenderNodeContext<WorkbenchHostNodeData>;
+  debugDiagnostics?: WorkbenchHostProps["debugDiagnostics"];
+  definition: WorkbenchHostNodeDefinition;
+  externalStateSource?: WorkbenchHostExternalStateSource;
+  host: WorkbenchHostRuntimeHandle;
+  workspaceId: string;
+}): ReactNode {
+  const externalState = useWorkbenchHostExternalState({
+    externalStateSource: input.externalStateSource,
+    node: input.context.node,
+    workspaceId: input.workspaceId
+  });
+  const bodyContext = createWorkbenchHostNodeBodyContext({
+    context: input.context,
+    definition: input.definition,
+    externalState,
+    externalStateSource: input.externalStateSource,
+    host: input.host,
+    workspaceId: input.workspaceId
+  });
+
+  return (
+    <WorkbenchHostNodeRenderErrorBoundary
+      debugDiagnostics={input.debugDiagnostics}
+      node={input.context.node}
+      onErrorChange={(hasError) =>
+        input.definition.onBodyRenderErrorChange?.({
+          hasError,
+          node: input.context.node
+        })
+      }
+      resetKey={`${input.context.node.id}:${input.context.node.data.typeId}`}
+      workspaceId={input.workspaceId}
+    >
+      <WorkbenchHostNodeBodyRenderer
+        context={bodyContext}
+        definition={input.definition}
+      />
+    </WorkbenchHostNodeRenderErrorBoundary>
+  );
+}
+
+function WorkbenchHostNodeHeaderRenderer(input: {
+  context: Parameters<WorkbenchRenderWindowHeader<WorkbenchHostNodeData>>[0];
+  definition: WorkbenchHostNodeDefinition;
+  externalStateSource?: WorkbenchHostExternalStateSource;
+  host: WorkbenchHostRuntimeHandle;
+  workspaceId: string;
+}): ReactNode {
+  const externalState = useWorkbenchHostExternalState({
+    externalStateSource: input.externalStateSource,
+    node: input.context.node,
+    workspaceId: input.workspaceId
+  });
+  return input.definition.renderHeader?.(
+    createWorkbenchHostNodeHeaderContext({
+      context: input.context,
+      definition: input.definition,
+      externalState,
+      externalStateSource: input.externalStateSource,
+      host: input.host,
+      workspaceId: input.workspaceId
+    })
+  );
 }
 
 interface WorkbenchHostSurfaceRenderErrorBoundaryProps {

--- a/packages/workbench/surface/src/host/useWorkbenchHostSurfaceRenderers.tsx
+++ b/packages/workbench/surface/src/host/useWorkbenchHostSurfaceRenderers.tsx
@@ -448,7 +448,7 @@ interface WorkbenchHostNodeRenderErrorBoundaryProps {
   debugDiagnostics?: WorkbenchHostProps["debugDiagnostics"];
   node: WorkbenchNode<WorkbenchHostNodeData>;
   onErrorChange?: (hasError: boolean) => void;
-  resetKey: string;
+  resetKey: unknown;
   workspaceId: string;
 }
 
@@ -473,6 +473,20 @@ function WorkbenchHostNodeRenderer(input: {
     host: input.host,
     workspaceId: input.workspaceId
   });
+  const resetKey = useMemo(
+    () => [
+      input.context.node.id,
+      input.context.node.data.typeId,
+      externalState.externalNodeState,
+      externalState.externalWorkspaceState
+    ],
+    [
+      externalState.externalNodeState,
+      externalState.externalWorkspaceState,
+      input.context.node.data.typeId,
+      input.context.node.id
+    ]
+  );
 
   return (
     <WorkbenchHostNodeRenderErrorBoundary
@@ -484,7 +498,7 @@ function WorkbenchHostNodeRenderer(input: {
           node: input.context.node
         })
       }
-      resetKey={`${input.context.node.id}:${input.context.node.data.typeId}`}
+      resetKey={resetKey}
       workspaceId={input.workspaceId}
     >
       <WorkbenchHostNodeBodyRenderer
@@ -607,7 +621,10 @@ class WorkbenchHostNodeRenderErrorBoundary extends Component<
   override componentDidUpdate(
     previousProps: WorkbenchHostNodeRenderErrorBoundaryProps
   ): void {
-    if (this.state.hasError && previousProps.resetKey !== this.props.resetKey) {
+    if (
+      this.state.hasError &&
+      !Object.is(previousProps.resetKey, this.props.resetKey)
+    ) {
       this.setState({ hasError: false });
       this.props.onErrorChange?.(false);
     }


### PR DESCRIPTION
## What changed
- Replace host-wide external-state revisions with node/workspace slice subscriptions.
- Keep unchanged node snapshots referentially stable and migrate desktop, browser, Agent GUI, and issue-manager sources.
- Add a regression test proving an update to one node does not rerender another.

## Why
TSH aggregates room state at a high update rate; the old host-wide subscription rerendered the entire workbench for each update.

## Risk
Breaking external-state-source contract. All contributions in this repository were migrated. TSH integration must follow after this is released.

## Verification
- `pnpm check:changed -- --push-ready`
- Earlier focused workbench surface, agent GUI, and desktop typechecks/tests passed before the final rebase.

## Follow-up
- Publish this Tutti release and atomically upgrade the TSH dependency cohort.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->