### PR TITLE
fix(agent): preserve explicit session titles

### DIFF
--- a/packages/agent/store-sqlite/activity_update.go
+++ b/packages/agent/store-sqlite/activity_update.go
@@ -41,9 +41,12 @@ func (s *Store) UpdateSessionPinned(
 	result, err := tx.ExecContext(ctx, `
 UPDATE workspace_agent_sessions
 SET pinned_at_unix_ms = ?,
-    updated_at_unix_ms = ?
+    updated_at_unix_ms = CASE
+      WHEN ? > updated_at_unix_ms THEN ?
+      ELSE updated_at_unix_ms + 1
+    END
 WHERE workspace_id = ? AND agent_session_id = ? AND deleted_at_unix_ms = 0
-`, pinnedAtUnixMS, now, workspaceID, agentSessionID)
+`, pinnedAtUnixMS, now, now, workspaceID, agentSessionID)
 	if err != nil {
 		return Session{}, false, fmt.Errorf("update workspace agent session pinned state: %w", err)
 	}
@@ -109,9 +112,12 @@ SET title = ?,
       '$.tuttiInitialTitleEstablished',
       json('true')
     ),
-    updated_at_unix_ms = ?
+    updated_at_unix_ms = CASE
+      WHEN ? > updated_at_unix_ms THEN ?
+      ELSE updated_at_unix_ms + 1
+    END
 WHERE workspace_id = ? AND agent_session_id = ? AND deleted_at_unix_ms = 0
-`, title, now, workspaceID, agentSessionID)
+`, title, now, now, workspaceID, agentSessionID)
 	if err != nil {
 		return Session{}, false, fmt.Errorf("update workspace agent session title: %w", err)
 	}
@@ -177,9 +183,12 @@ func (s *Store) UpdateSessionSettings(
 UPDATE workspace_agent_sessions
 SET model = ?,
     settings_json = ?,
-    updated_at_unix_ms = ?
+    updated_at_unix_ms = CASE
+      WHEN ? > updated_at_unix_ms THEN ?
+      ELSE updated_at_unix_ms + 1
+    END
 WHERE workspace_id = ? AND agent_session_id = ? AND deleted_at_unix_ms = 0
-`, strings.TrimSpace(model), settingsJSON, now, workspaceID, agentSessionID)
+`, strings.TrimSpace(model), settingsJSON, now, now, workspaceID, agentSessionID)
 	if err != nil {
 		return Session{}, false, fmt.Errorf("update workspace agent session settings: %w", err)
 	}

--- a/packages/agent/store-sqlite/canonical/projection.go
+++ b/packages/agent/store-sqlite/canonical/projection.go
@@ -166,7 +166,9 @@ func ProjectSessionState(
 		if session.CWD == "" {
 			session.CWD = existing.CWD
 		}
-		if session.Title == "" {
+		if sessionTitleEstablished(existing.RuntimeContext) {
+			session.Title = existing.Title
+		} else if session.Title == "" {
 			session.Title = existing.Title
 		}
 		if session.Status == "" {
@@ -194,12 +196,25 @@ func ProjectSessionState(
 		if existing.EndedAtUnixMS > session.EndedAtUnixMS {
 			session.EndedAtUnixMS = existing.EndedAtUnixMS
 		}
+		session.UpdatedAtUnixMS = nextSessionUpdateUnixMS(nowUnixMS, existing.UpdatedAtUnixMS)
 	}
 	return SessionProjection{
 		Accepted:        session.WorkspaceID != "" && session.AgentSessionID != "",
 		LastEventUnixMS: session.LastEventUnixMS,
 		Session:         session,
 	}
+}
+
+func sessionTitleEstablished(runtimeContext map[string]any) bool {
+	established, _ := runtimeContext["tuttiInitialTitleEstablished"].(bool)
+	return established
+}
+
+func nextSessionUpdateUnixMS(nowUnixMS int64, currentUnixMS int64) int64 {
+	if nowUnixMS > currentUnixMS {
+		return nowUnixMS
+	}
+	return currentUnixMS + 1
 }
 
 type MessageSnapshot struct {

--- a/packages/agent/store-sqlite/store_test.go
+++ b/packages/agent/store-sqlite/store_test.go
@@ -317,6 +317,27 @@ func TestStoreReportAndListSessionLifecycle(t *testing.T) {
 	if err != nil || !ok || renamed.Title != "final" || renamed.UpdatedAtUnixMS < pinned.UpdatedAtUnixMS {
 		t.Fatalf("UpdateSessionTitle() = %#v ok=%v error=%v", renamed, ok, err)
 	}
+	if _, err := store.db.ExecContext(ctx, `
+UPDATE workspace_agent_sessions
+SET updated_at_unix_ms = 9999999999999
+WHERE workspace_id = 'ws-1' AND agent_session_id = 'session-1'
+`); err != nil {
+		t.Fatalf("force session updated_at_unix_ms error = %v", err)
+	}
+	monotonicRenamed, ok, err := store.UpdateSessionTitle(ctx, "ws-1", "session-1", " monotonic ")
+	if err != nil || !ok || monotonicRenamed.Title != "monotonic" || monotonicRenamed.UpdatedAtUnixMS != 10000000000000 {
+		t.Fatalf("UpdateSessionTitle(monotonic) = %#v ok=%v error=%v", monotonicRenamed, ok, err)
+	}
+	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1",
+		Provider: "codex", Title: "runtime title", OccurredAtUnixMS: monotonicRenamed.UpdatedAtUnixMS + 1,
+	}); err != nil {
+		t.Fatalf("ReportSessionState(runtime title) error = %v", err)
+	}
+	sessionAfterRuntimeTitle, ok, err := store.GetSession(ctx, "ws-1", "session-1")
+	if err != nil || !ok || sessionAfterRuntimeTitle.Title != "monotonic" {
+		t.Fatalf("GetSession() after runtime title = %#v ok=%v error=%v, want explicit title", sessionAfterRuntimeTitle, ok, err)
+	}
 
 	updatedSettings, ok, err := store.UpdateSessionSettings(ctx, "ws-1", "session-1", "gpt-5.4", map[string]any{
 		"model":            "gpt-5.4",
@@ -324,7 +345,7 @@ func TestStoreReportAndListSessionLifecycle(t *testing.T) {
 	})
 	if err != nil || !ok || updatedSettings.Model != "gpt-5.4" ||
 		updatedSettings.Settings["permissionModeId"] != "full-access" ||
-		updatedSettings.UpdatedAtUnixMS < renamed.UpdatedAtUnixMS {
+		updatedSettings.UpdatedAtUnixMS < monotonicRenamed.UpdatedAtUnixMS {
 		t.Fatalf("UpdateSessionSettings() = %#v ok=%v error=%v", updatedSettings, ok, err)
 	}
 


### PR DESCRIPTION
## Summary
- preserve explicitly renamed session titles when live runtime state reports include a provider/runtime title
- make session metadata updates advance `updated_at_unix_ms` monotonically so stale snapshots cannot tie and overwrite newer metadata
- cover explicit rename followed by runtime title report in store tests

## Tests
- `go test ./packages/agent/store-sqlite`
- `pnpm check:changed -- --push-ready` (pre-push)

## Documentation impact
- No public API, UI copy, or durable workflow docs changed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->