### PR TITLE
feat(desktop,tuttid): add lab feature-flag infrastructure

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceLabFeatureGateRows.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceLabFeatureGateRows.tsx
@@ -1,0 +1,81 @@
+import { Switch } from "@tutti-os/ui-system";
+import { useTranslation } from "@renderer/i18n";
+import {
+  LAB_AUTOMATION_RULES_FLAG,
+  LAB_MODEL_PLANS_FLAG,
+  LAB_TUTTI_MODE_FLAG,
+  LAB_WORKBENCH_SHORTCUTS_FLAG,
+  LAB_WORKSPACE_AGENTS_FLAG,
+  isFeatureEnabled
+} from "../../../../../shared/featureFlags/catalog.ts";
+import type { DesktopFeatureFlags } from "../../../../../shared/preferences/index.ts";
+
+const featureGateRows = [
+  {
+    key: LAB_TUTTI_MODE_FLAG,
+    labelKey: "workspace.settings.lab.tuttiModeLabel" as const,
+    descriptionKey: "workspace.settings.lab.tuttiModeDescription" as const
+  },
+  {
+    key: LAB_MODEL_PLANS_FLAG,
+    labelKey: "workspace.settings.lab.modelPlansLabel" as const,
+    descriptionKey: "workspace.settings.lab.modelPlansDescription" as const
+  },
+  {
+    key: LAB_WORKSPACE_AGENTS_FLAG,
+    labelKey: "workspace.settings.lab.workspaceAgentsLabel" as const,
+    descriptionKey: "workspace.settings.lab.workspaceAgentsDescription" as const
+  },
+  {
+    key: LAB_AUTOMATION_RULES_FLAG,
+    labelKey: "workspace.settings.lab.automationRulesLabel" as const,
+    descriptionKey: "workspace.settings.lab.automationRulesDescription" as const
+  },
+  {
+    key: LAB_WORKBENCH_SHORTCUTS_FLAG,
+    labelKey: "workspace.settings.lab.workbenchShortcutsLabel" as const,
+    descriptionKey:
+      "workspace.settings.lab.workbenchShortcutsDescription" as const
+  }
+] as const;
+
+export function WorkspaceLabFeatureGateRows({
+  changingFeatureFlags,
+  featureFlags,
+  onFeatureFlagsChange
+}: {
+  changingFeatureFlags: DesktopFeatureFlags | null;
+  featureFlags: DesktopFeatureFlags;
+  onFeatureFlagsChange: (flags: DesktopFeatureFlags) => void;
+}) {
+  const { t } = useTranslation();
+  const pendingFeatureFlags = changingFeatureFlags ?? featureFlags;
+  const disabled = changingFeatureFlags !== null;
+
+  return featureGateRows.map((row) => (
+    <div
+      key={row.key}
+      className="flex w-full items-center justify-between gap-4 max-[560px]:flex-col max-[560px]:items-stretch"
+    >
+      <div className="flex min-w-0 flex-1 flex-col gap-1 max-[560px]:w-full">
+        <strong className="text-[13px] font-semibold text-[var(--text-primary)]">
+          {t(row.labelKey)}
+        </strong>
+        <p className="m-0 text-[13px] leading-[1.3] text-[var(--text-secondary)]">
+          {t(row.descriptionKey)}
+        </p>
+      </div>
+      <Switch
+        aria-label={t(row.labelKey)}
+        checked={isFeatureEnabled(pendingFeatureFlags, row.key)}
+        disabled={disabled}
+        onCheckedChange={(enabled) => {
+          onFeatureFlagsChange({
+            ...pendingFeatureFlags,
+            [row.key]: enabled
+          });
+        }}
+      />
+    </div>
+  ));
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
@@ -25,6 +25,13 @@ const defaultProvidersSource = readFileSync(
   ),
   "utf8"
 );
+const labFeatureGateRowsSource = readFileSync(
+  resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "WorkspaceLabFeatureGateRows.tsx"
+  ),
+  "utf8"
+);
 
 test("workspace settings developer panel exposes analytics debug switch only when available", () => {
   assert.match(developerSource, /useAnalyticsDebugPreferenceService/);
@@ -282,4 +289,16 @@ test("workspace managed provider model rows keep stable keys while editing", () 
     source,
     /key=\{`\$\{model\.provider\}:\$\{model\.id\}:\$\{index\}`\}/
   );
+});
+
+test("Lab exposes independent default-off gates for experimental Agent features", () => {
+  assert.match(labFeatureGateRowsSource, /LAB_TUTTI_MODE_FLAG/);
+  assert.match(labFeatureGateRowsSource, /LAB_MODEL_PLANS_FLAG/);
+  assert.match(labFeatureGateRowsSource, /LAB_WORKSPACE_AGENTS_FLAG/);
+  assert.match(labFeatureGateRowsSource, /LAB_AUTOMATION_RULES_FLAG/);
+  assert.match(
+    labFeatureGateRowsSource,
+    /\.\.\.pendingFeatureFlags,[\s\S]*\[row\.key\]: enabled/
+  );
+  assert.match(source, /<WorkspaceLabFeatureGateRows/);
 });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -112,6 +112,7 @@ import { useWorkspaceSettingsService } from "./useWorkspaceSettingsService";
 import { useWorkspaceWorkbenchHostService } from "./useWorkspaceWorkbenchHostService";
 import { useAccountService } from "./useAccountService";
 import { WorkspaceDeveloperSettingsSection } from "./WorkspaceDeveloperSettingsSection";
+import { WorkspaceLabFeatureGateRows } from "./WorkspaceLabFeatureGateRows";
 import { SettingsRows } from "./WorkspaceSettingsRows";
 import {
   normalizeWorkspaceSettingsDefaultAgentProvider,
@@ -1533,37 +1534,15 @@ function WorkspaceLabSettingsSection({
     pendingFeatureFlags,
     LAB_WORKBENCH_SHORTCUTS_FLAG
   );
-  const updateFeatureFlag = useCallback(
-    (key: string, enabled: boolean) => {
-      onFeatureFlagsChange({
-        ...featureFlags,
-        [key]: enabled
-      });
-    },
-    [featureFlags, onFeatureFlagsChange]
-  );
   const shortcutsDisabled = isUpdatingFlags || !workbenchShortcutsEnabled;
 
   return (
     <SettingsRows>
-      <div className="flex w-full items-center justify-between gap-4 max-[560px]:flex-col max-[560px]:items-stretch">
-        <div className="flex min-w-0 flex-1 flex-col gap-1 max-[560px]:w-full">
-          <strong className="text-[13px] font-semibold text-[var(--text-primary)]">
-            {t("workspace.settings.lab.workbenchShortcutsLabel")}
-          </strong>
-          <p className="m-0 text-[13px] leading-[1.3] text-[var(--text-secondary)]">
-            {t("workspace.settings.lab.workbenchShortcutsDescription")}
-          </p>
-        </div>
-        <Switch
-          aria-label={t("workspace.settings.lab.workbenchShortcutsLabel")}
-          checked={workbenchShortcutsEnabled}
-          disabled={isUpdatingFlags}
-          onCheckedChange={(enabled) => {
-            updateFeatureFlag(LAB_WORKBENCH_SHORTCUTS_FLAG, enabled);
-          }}
-        />
-      </div>
+      <WorkspaceLabFeatureGateRows
+        changingFeatureFlags={changingFeatureFlags}
+        featureFlags={featureFlags}
+        onFeatureFlagsChange={onFeatureFlagsChange}
+      />
 
       <WorkspaceLabShortcutRow
         disabled={shortcutsDisabled}

--- a/apps/desktop/src/shared/featureFlags/catalog.test.ts
+++ b/apps/desktop/src/shared/featureFlags/catalog.test.ts
@@ -11,6 +11,10 @@ import {
   isFeatureEnabled,
   labFeatureDefinitions,
   LAB_ENABLED_FLAG,
+  LAB_AUTOMATION_RULES_FLAG,
+  LAB_MODEL_PLANS_FLAG,
+  LAB_TUTTI_MODE_FLAG,
+  LAB_WORKSPACE_AGENTS_FLAG,
   resolveDesktopWorkspaceUiMode,
   withDesktopWorkspaceUiMode,
   WORKSPACE_STANDALONE_AGENT_MODE_FLAG
@@ -48,6 +52,20 @@ test("isFeatureEnabled returns false for unknown keys", () => {
 
 test("labFeatureDefinitions excludes the master switch", () => {
   assert.ok(labFeatureDefinitions().every((d) => d.group === "lab"));
+});
+
+test("experimental Agent features require independent Lab opt-ins", () => {
+  const flags = [
+    LAB_TUTTI_MODE_FLAG,
+    LAB_MODEL_PLANS_FLAG,
+    LAB_WORKSPACE_AGENTS_FLAG,
+    LAB_AUTOMATION_RULES_FLAG
+  ];
+
+  for (const flag of flags) {
+    assert.equal(isFeatureEnabled({}, flag), false);
+    assert.equal(isFeatureEnabled({ [flag]: true }, flag), true);
+  }
 });
 
 test("workspace UI mode defaults to OS and preserves explicit selections", () => {

--- a/apps/desktop/src/shared/featureFlags/catalog.ts
+++ b/apps/desktop/src/shared/featureFlags/catalog.ts
@@ -6,6 +6,10 @@ import {
 
 export const LAB_ENABLED_FLAG = "lab.enabled";
 export const BROWSER_CHROME_COOKIE_IMPORT_FLAG = "browser.chromeCookieImport";
+export const LAB_TUTTI_MODE_FLAG = "lab.tuttiMode";
+export const LAB_MODEL_PLANS_FLAG = "lab.modelPlans";
+export const LAB_WORKSPACE_AGENTS_FLAG = "lab.workspaceAgents";
+export const LAB_AUTOMATION_RULES_FLAG = "lab.automationRules";
 export const LAB_WORKBENCH_SHORTCUTS_FLAG = "lab.workbenchShortcuts";
 export const WORKSPACE_STANDALONE_AGENT_MODE_FLAG =
   "workspace.standaloneAgentMode";
@@ -72,11 +76,39 @@ export const FEATURE_FLAG_DEFINITIONS: readonly FeatureFlagDefinition[] = [
   },
   { key: LAB_ENABLED_FLAG, default: false, group: "lab-master" },
   {
+    key: LAB_TUTTI_MODE_FLAG,
+    default: false,
+    group: "lab",
+    labelKey: "workspace.settings.lab.tuttiModeLabel",
+    descriptionKey: "workspace.settings.lab.tuttiModeDescription"
+  },
+  {
+    key: LAB_MODEL_PLANS_FLAG,
+    default: false,
+    group: "lab",
+    labelKey: "workspace.settings.lab.modelPlansLabel",
+    descriptionKey: "workspace.settings.lab.modelPlansDescription"
+  },
+  {
+    key: LAB_WORKSPACE_AGENTS_FLAG,
+    default: false,
+    group: "lab",
+    labelKey: "workspace.settings.lab.workspaceAgentsLabel",
+    descriptionKey: "workspace.settings.lab.workspaceAgentsDescription"
+  },
+  {
+    key: LAB_AUTOMATION_RULES_FLAG,
+    default: false,
+    group: "lab",
+    labelKey: "workspace.settings.lab.automationRulesLabel",
+    descriptionKey: "workspace.settings.lab.automationRulesDescription"
+  },
+  {
     key: LAB_WORKBENCH_SHORTCUTS_FLAG,
     default: false,
     group: "lab",
-    labelKey: "workspaceSettings.lab.workbenchShortcuts.label",
-    descriptionKey: "workspaceSettings.lab.workbenchShortcuts.description"
+    labelKey: "workspace.settings.lab.workbenchShortcutsLabel",
+    descriptionKey: "workspace.settings.lab.workbenchShortcutsDescription"
   }
 ];
 

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -924,14 +924,25 @@ export const en = {
         visibilityLabel: "Show developer panel"
       },
       lab: {
+        automationRulesDescription:
+          "Shows Automation Rule configuration and session overrides.",
+        automationRulesLabel: "Automation Rules",
         clearShortcutLabel: "Clear {{label}}",
+        modelPlansDescription: "Shows Model settings for configuring plans.",
+        modelPlansLabel: "Model plans",
         newAgentConversationShortcutLabel: "New Agent conversation",
         newSameTypeWindowShortcutLabel: "New same-type window",
         preferencesSaveFailed: "We couldn't update Lab preferences.",
         shortcutUnbound: "Unbound",
+        tuttiModeDescription:
+          "Enables Tutti Mode planning and orchestration controls in Agent conversations.",
+        tuttiModeLabel: "Tutti Mode",
         workbenchShortcutsDescription:
           "Enables configurable workbench shortcut actions.",
-        workbenchShortcutsLabel: "Workbench shortcuts"
+        workbenchShortcutsLabel: "Workbench shortcuts",
+        workspaceAgentsDescription:
+          "Shows Custom Agent creation and configuration.",
+        workspaceAgentsLabel: "Custom Agents"
       },
       title: "Settings",
       trigger: "Settings"

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -873,13 +873,21 @@ export const zhCN = {
         visibilityLabel: "显示开发者面板"
       },
       lab: {
+        automationRulesDescription: "显示自动化规则配置与会话覆盖选项",
+        automationRulesLabel: "自动化规则",
         clearShortcutLabel: "清除 {{label}}",
+        modelPlansDescription: "显示用于配置模型方案的模型设置",
+        modelPlansLabel: "模型方案",
         newAgentConversationShortcutLabel: "新建 Agent 对话",
         newSameTypeWindowShortcutLabel: "新建同类型窗口",
         preferencesSaveFailed: "暂时无法更新实验室设置",
         shortcutUnbound: "未绑定",
+        tuttiModeDescription: "启用 Agent 对话中的 Tutti 模式规划与编排控制",
+        tuttiModeLabel: "Tutti 模式",
         workbenchShortcutsDescription: "启用可配置的工作台快捷键操作",
-        workbenchShortcutsLabel: "工作台快捷键"
+        workbenchShortcutsLabel: "工作台快捷键",
+        workspaceAgentsDescription: "显示自定义 Agent 的创建与配置",
+        workspaceAgentsLabel: "自定义 Agent"
       },
       title: "设置",
       trigger: "设置"

--- a/docs/conventions/README.md
+++ b/docs/conventions/README.md
@@ -11,6 +11,7 @@ Current documents:
 - [Desktop Release](./desktop-release.md)
 - [Desktop Visual Language](./desktop-visual-language.md)
 - [Deprecated Workspace App Agent APIs](./deprecated-workspace-app-agent-apis.md)
+- [Feature Flags](./feature-flags.md)
 - [Local Git Hooks](./local-git-hooks.md)
 - [Local State Storage](./local-state-storage.md)
 - [Logging](./logging.md)

--- a/docs/conventions/feature-flags.md
+++ b/docs/conventions/feature-flags.md
@@ -1,0 +1,62 @@
+# Feature Flags
+
+Feature flags in Tutti are **pure config distribution**: durable storage in
+daemon preferences, push to clients over the eventstream, a key registry, and
+a query helper. The infrastructure is semantics-free — it stores and
+distributes `map[string]bool` and nothing more. Each feature owns what "off"
+means; that logic never belongs to the flag infrastructure.
+
+## Taxonomy
+
+- **Capability flags** gate daemon-enforced behavior (writes, orchestration,
+  runtime operations). The daemon must enforce them server-side so toggling
+  the UI cannot bypass the gate. Query them through the daemon registry
+  helper, never by poking the raw map.
+- **UI-preference flags** only show or hide renderer surfaces. The renderer
+  catalog is sufficient; no daemon enforcement is required.
+
+A flag can start as UI-preference and gain daemon enforcement later; keep the
+same key when that happens.
+
+## Key contract
+
+The daemon registry is the key contract:
+
+- Go: `services/tuttid/biz/preferences/lab_flags.go`
+- Renderer mirror: `apps/desktop/src/shared/featureFlags/catalog.ts`
+
+Both must carry **identical keys and defaults**. When adding, renaming, or
+removing a flag, change both sides in the same change. Storage and push are
+already generic (`DesktopPreferences.FeatureFlags`,
+`NormalizeDesktopFeatureFlags`, preferences eventstream updates), so a new
+flag only needs registry entries and copy.
+
+Resolution rule on both sides: a stored value wins; absent keys fall back to
+the registry default; absent unregistered keys resolve to `false`
+(`IsLabFlagEnabled` in Go, `isFeatureEnabled` in TS).
+
+## Defaults and off semantics
+
+- Defaults are **fail-closed**: every Lab flag defaults to `false`. A flag
+  that must default on needs an explicit product decision recorded in the PR.
+- Recommended default-off semantics (guidance, not a mandate): while a flag is
+  off, new writes are rejected or hidden, but existing data and already
+  running behavior are left unaffected. The owning feature decides and
+  documents its exact semantics.
+
+## Naming
+
+- `lab.*` for Lab experiments surfaced in the Lab settings section.
+- Domain-scoped dotted keys for everything else, for example
+  `agent.extension.<source>` or `browser.chromeCookieImport`.
+- Keys are lowercase camelCase segments joined by dots.
+
+## Existing reference pattern
+
+`services/tuttid/service/agentextension/manager.go` is the existing example
+of feature-owned semantics: it reads the raw flag map, derives its own keys
+(`"agent.extension."+source.Key`), and decides what disabled means for Agent
+Extension sources (reconcile and stop). New consumers should prefer the
+registry constants and `IsLabFlagEnabled` over poking the raw map, while
+keeping their own off semantics in the owning feature, exactly as the Agent
+Extension manager does.

--- a/services/tuttid/biz/preferences/lab_flags.go
+++ b/services/tuttid/biz/preferences/lab_flags.go
@@ -1,0 +1,45 @@
+package preferences
+
+// Lab feature flag keys. This registry is the daemon-side key contract for
+// Lab experiments: it carries keys and defaults only, never semantics. Each
+// feature owns what "off" means; the renderer mirror lives in
+// apps/desktop/src/shared/featureFlags/catalog.ts and must carry identical
+// keys and defaults. See docs/conventions/feature-flags.md.
+const (
+	LabFlagTuttiMode       = "lab.tuttiMode"
+	LabFlagModelPlans      = "lab.modelPlans"
+	LabFlagWorkspaceAgents = "lab.workspaceAgents"
+	LabFlagAutomationRules = "lab.automationRules"
+)
+
+// labFlagDefaults is fail-closed: every Lab flag defaults to off.
+var labFlagDefaults = map[string]bool{
+	LabFlagTuttiMode:       false,
+	LabFlagModelPlans:      false,
+	LabFlagWorkspaceAgents: false,
+	LabFlagAutomationRules: false,
+}
+
+// IsLabFlag reports whether key is a registered Lab flag.
+func IsLabFlag(key string) bool {
+	_, ok := labFlagDefaults[key]
+	return ok
+}
+
+// LabFlagDefault returns the registered default for a Lab flag.
+func LabFlagDefault(key string) (bool, bool) {
+	defaultValue, ok := labFlagDefaults[key]
+	return defaultValue, ok
+}
+
+// IsLabFlagEnabled resolves a flag against stored desktop feature flags.
+// A stored value wins; absent keys fall back to the registry default
+// (fail-closed), and absent unregistered keys resolve to false. This mirrors
+// the renderer isFeatureEnabled resolution in
+// apps/desktop/src/shared/featureFlags/catalog.ts.
+func IsLabFlagEnabled(flags map[string]bool, key string) bool {
+	if enabled, ok := flags[key]; ok {
+		return enabled
+	}
+	return labFlagDefaults[key]
+}

--- a/services/tuttid/biz/preferences/lab_flags_test.go
+++ b/services/tuttid/biz/preferences/lab_flags_test.go
@@ -1,0 +1,68 @@
+package preferences
+
+import "testing"
+
+func TestLabFlagRegistryKeysAndDefaults(t *testing.T) {
+	keys := []string{
+		LabFlagTuttiMode,
+		LabFlagModelPlans,
+		LabFlagWorkspaceAgents,
+		LabFlagAutomationRules,
+	}
+	if len(labFlagDefaults) != len(keys) {
+		t.Fatalf("registry has %d entries, want %d", len(labFlagDefaults), len(keys))
+	}
+	for _, key := range keys {
+		if !IsLabFlag(key) {
+			t.Fatalf("IsLabFlag(%q) = false, want true", key)
+		}
+		defaultValue, ok := LabFlagDefault(key)
+		if !ok || defaultValue {
+			t.Fatalf("LabFlagDefault(%q) = (%v, %v), want (false, true)", key, defaultValue, ok)
+		}
+	}
+}
+
+func TestIsLabFlagRejectsUnregisteredKeys(t *testing.T) {
+	for _, key := range []string{"", "lab.unknown", "agent.extension.gemini"} {
+		if IsLabFlag(key) {
+			t.Fatalf("IsLabFlag(%q) = true, want false", key)
+		}
+		if _, ok := LabFlagDefault(key); ok {
+			t.Fatalf("LabFlagDefault(%q) ok = true, want false", key)
+		}
+	}
+}
+
+func TestIsLabFlagEnabledFailsClosed(t *testing.T) {
+	for _, key := range []string{
+		LabFlagTuttiMode,
+		LabFlagModelPlans,
+		LabFlagWorkspaceAgents,
+		LabFlagAutomationRules,
+	} {
+		if IsLabFlagEnabled(nil, key) {
+			t.Fatalf("IsLabFlagEnabled(nil, %q) = true, want false", key)
+		}
+		if IsLabFlagEnabled(map[string]bool{}, key) {
+			t.Fatalf("IsLabFlagEnabled({}, %q) = true, want false", key)
+		}
+		if !IsLabFlagEnabled(map[string]bool{key: true}, key) {
+			t.Fatalf("IsLabFlagEnabled({%q: true}, %q) = false, want true", key, key)
+		}
+	}
+}
+
+func TestIsLabFlagEnabledStoredValueWins(t *testing.T) {
+	if IsLabFlagEnabled(map[string]bool{LabFlagTuttiMode: false}, LabFlagTuttiMode) {
+		t.Fatalf("stored false must win over registry default")
+	}
+	// Matches the renderer catalog resolution: a stored value wins even for
+	// unregistered keys; absent unregistered keys resolve to false.
+	if !IsLabFlagEnabled(map[string]bool{"lab.unknown": true}, "lab.unknown") {
+		t.Fatalf("stored value must win for unregistered keys")
+	}
+	if IsLabFlagEnabled(map[string]bool{}, "lab.unknown") {
+		t.Fatalf("absent unregistered key must resolve to false")
+	}
+}


### PR DESCRIPTION
## What

Add a semantics-free Lab feature-flag foundation so experimental capabilities can ship dark and be gated uniformly across daemon and desktop:

- **daemon**: Lab flag registry in `biz/preferences` (`lab.tuttiMode`, `lab.modelPlans`, `lab.workspaceAgents`, `lab.automationRules`; all default-off / fail-closed) with an `IsLabFlagEnabled` query helper so services never poke the raw preferences map
- **desktop**: matching flag definitions in the feature-flag catalog, Lab settings gate rows, and i18n copy (en/zh-CN)
- **docs**: `docs/conventions/feature-flags.md` covering the taxonomy (daemon-enforced capability flags vs UI-preference flags), the Go/TS key contract, fail-closed defaults, recommended default-off semantics (writes rejected, existing data and running behavior unaffected — guidance, not mandate), and naming rules

## Why

PR #1412 bundles five experimental features behind renderer-only gates. Before those features land as separate stacked PRs, the flag infrastructure itself needs to exist on main: storage and push already exist (daemon preferences + eventstream); this PR adds only the missing registry, query helper, settings surface, and the convention.

The flag system is deliberately **config distribution only** — what "off" means is owned by each feature (see `services/tuttid/service/agentextension/manager.go` as the existing reference pattern). Per-feature gate wiring (daemon route guards + renderer entry points) lands with each feature PR.

## Notes for reviewers

- The daemon registry intentionally has no consumer yet; the first capability-flag consumer should use `IsLabFlagEnabled` rather than the raw map.
- Daemon-side enforcement applies consistently to all clients (desktop, tsh, future Host consumers); there is no client-side bypass.
- Heads-up for the hermes ACP branch: `lab.previewAgents` should migrate onto this registry + helper after this lands (its service-level sync pattern stays; only key registration and query path change).

## Validation

- `pnpm check:changed` — 13 lanes pass
- `pnpm typecheck` — 27 packages
- `pnpm check:i18n` — 2 locales, 3556 keys
- `go test ./biz/preferences/... ./service/preferences/...` — pass
- desktop targeted tests (`catalog.test.ts`, `WorkspaceSettingsPanel.test.ts`) — 24/24
- `pnpm generate:builtin-apps && pnpm build:go` — pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Infrastructure and settings UI only; flags default off and have no runtime consumers yet, so user-visible behavior is unchanged until follow-up PRs gate features.
> 
> **Overview**
> Adds a **shared Lab feature-flag contract** so experimental Agent capabilities can ship dark with matching daemon and desktop behavior.
> 
> **Daemon** introduces `lab_flags.go` with four new keys (`lab.tuttiMode`, `lab.modelPlans`, `lab.workspaceAgents`, `lab.automationRules`), all **default-off**, plus `IsLabFlagEnabled` resolution aligned with the renderer.
> 
> **Desktop** mirrors those keys in `catalog.ts`, adds **`WorkspaceLabFeatureGateRows`** for five independent Lab toggles (the four experiments plus workbench shortcuts), and wires it into the Lab settings section. Toggles now merge into **`pendingFeatureFlags`** while a save is in flight. Workbench shortcut i18n keys are aligned to `workspace.settings.lab.*`.
> 
> **Docs** add `feature-flags.md` (capability vs UI flags, Go/TS key parity, fail-closed defaults) and link it from conventions.
> 
> No feature entry points or daemon route guards consume the new flags yet—that wiring is expected in follow-up PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be868461bf27395efb8dc17f6fb3b2280b34a95c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->