### PR TITLE
feat(browser): unify desktop BrowserNode automation

### DIFF
--- a/.changeset/browser-node-unified-automation.md
+++ b/.changeset/browser-node-unified-automation.md
@@ -1,0 +1,6 @@
+---
+"@tutti-os/browser-node": patch
+"@tutti-os/agent-gui": patch
+---
+
+Add host-rendered Browser Home support and an authenticated Electron BrowserNode automation projection for User and Agent Browser tabs, including stable page selection, leases, network authorization, and explicit `tutti browser` desktop routing.

--- a/apps/desktop/src/main/bootstrap.ts
+++ b/apps/desktop/src/main/bootstrap.ts
@@ -236,7 +236,7 @@ export async function bootstrapDesktopApp(): Promise<void> {
         : undefined
   });
 
-  registerIpcHandlers({
+  const ipcDisposables = await registerIpcHandlers({
     daemonEndpoint: desktopAppServices.daemonEndpoint,
     fileDialogs: desktopAppServices.fileDialogs,
     logger,
@@ -287,6 +287,7 @@ export async function bootstrapDesktopApp(): Promise<void> {
     logger,
     tuttid: desktopAppServices.tuttid,
     disposables: [
+      ...ipcDisposables,
       hostPreferencesEventStream,
       agentPowerSaveBlocker,
       {

--- a/apps/desktop/src/main/daemon/tuttidManager.test.ts
+++ b/apps/desktop/src/main/daemon/tuttidManager.test.ts
@@ -221,6 +221,12 @@ test("resolveManagedDaemonProcessEnv seeds the managed runtime cache root", () =
       got.TUTTI_APP_RUNTIME_CACHE_ROOT?.endsWith("/app-runtimes"),
       true
     );
+    assert.equal(
+      got.TUTTI_BROWSER_NODE_LISTENER_INFO?.endsWith(
+        "/run/browser-node-automation.json"
+      ),
+      true
+    );
   } finally {
     restoreEnv(previousEnv);
   }

--- a/apps/desktop/src/main/daemon/tuttidManager.ts
+++ b/apps/desktop/src/main/daemon/tuttidManager.ts
@@ -15,6 +15,7 @@ import {
 } from "../../shared/errors/desktopErrors.ts";
 import { getDesktopLogger, getDesktopLogSessionID } from "../logging.ts";
 import {
+  resolveBrowserNodeAutomationListenerInfoPath,
   resolveDesktopLogsDir,
   type DesktopDaemonEndpoint
 } from "../transport/paths.ts";
@@ -340,6 +341,8 @@ export function resolveManagedDaemonProcessEnv(
     ...resolveBrowserMcpDaemonEnv(),
     ...resolveClaudeSDKSidecarDaemonEnv(),
     TUTTI_APP_VERSION: process.env.TUTTI_APP_VERSION?.trim() ?? "",
+    TUTTI_BROWSER_NODE_LISTENER_INFO:
+      resolveBrowserNodeAutomationListenerInfoPath(),
     TUTTI_DESKTOP_PARENT_PID: String(input.parentPID ?? process.pid),
     TUTTI_LOG_DIR: input.logDir ?? resolveDesktopLogsDir(),
     TUTTI_SESSION_ID: input.sessionID ?? getDesktopLogSessionID(),

--- a/apps/desktop/src/main/desktopAppLifecycle.test.ts
+++ b/apps/desktop/src/main/desktopAppLifecycle.test.ts
@@ -29,6 +29,7 @@ function createLogger(events: string[]): DesktopLogger {
 
 function createWorkspaceLaunch(): WorkspaceLaunch {
   return {
+    async ensureAgentBrowserHost() {},
     async openStartupWindow() {},
     async replaceWorkspaceWindow() {},
     async showAgentWindow() {},

--- a/apps/desktop/src/main/desktopAppServices.test.ts
+++ b/apps/desktop/src/main/desktopAppServices.test.ts
@@ -121,6 +121,7 @@ function createHostServices(): DesktopHostServices {
       }
     },
     workspaceLaunch: {
+      async ensureAgentBrowserHost() {},
       async openStartupWindow() {},
       async replaceWorkspaceWindow() {},
       async showAgentWindow() {},

--- a/apps/desktop/src/main/host/workspaceHostAccess.test.ts
+++ b/apps/desktop/src/main/host/workspaceHostAccess.test.ts
@@ -13,6 +13,7 @@ function createAdapters(
   overrides: Partial<WorkspaceLaunchAdapters> = {}
 ): WorkspaceLaunchAdapters {
   return {
+    async ensureAgentBrowserHost() {},
     async showAgentWindow() {},
     async showWorkspaceWindow() {},
     warnStartupWindowResolutionFailure() {},

--- a/apps/desktop/src/main/host/workspaceLaunch.test.ts
+++ b/apps/desktop/src/main/host/workspaceLaunch.test.ts
@@ -31,6 +31,7 @@ function createAdapters(
   overrides: Partial<WorkspaceLaunchAdapters> = {}
 ): WorkspaceLaunchAdapters {
   return {
+    async ensureAgentBrowserHost() {},
     async showAgentWindow() {},
     async showWorkspaceWindow() {},
     warnStartupWindowResolutionFailure() {},

--- a/apps/desktop/src/main/host/workspaceLaunch.ts
+++ b/apps/desktop/src/main/host/workspaceLaunch.ts
@@ -8,6 +8,7 @@ export interface WorkspaceLaunchOwnerWindow {
 }
 
 export interface WorkspaceLaunchAdapters {
+  ensureAgentBrowserHost(input: WorkspaceLaunchAgentWindowInput): Promise<void>;
   showAgentWindow(input: WorkspaceLaunchAgentWindowInput): Promise<void>;
   showWorkspaceWindow(
     workspaceID: string,
@@ -36,6 +37,7 @@ export interface WorkspaceLaunchAgentWindowInput {
 }
 
 export interface WorkspaceLaunch {
+  ensureAgentBrowserHost(input: WorkspaceLaunchAgentWindowInput): Promise<void>;
   openStartupWindow(): Promise<void>;
   showAgentWindow(input: WorkspaceLaunchAgentWindowInput): Promise<void>;
   showWorkspace(
@@ -58,6 +60,9 @@ export function createWorkspaceLaunch(
   deps: WorkspaceLaunchDependencies
 ): WorkspaceLaunch {
   return {
+    ensureAgentBrowserHost(input) {
+      return deps.adapters.ensureAgentBrowserHost(input);
+    },
     async openStartupWindow() {
       try {
         const workspaceID = await resolveStartupWorkspaceID();

--- a/apps/desktop/src/main/host/workspaceLaunchDesktopAdapters.test.ts
+++ b/apps/desktop/src/main/host/workspaceLaunchDesktopAdapters.test.ts
@@ -56,6 +56,21 @@ test("workspace window readiness can show without maximizing", async () => {
   assert.equal(target.showCount, 1);
 });
 
+test("workspace window readiness can keep a background Browser host hidden", async () => {
+  const target = createWorkspaceWindowReadyTarget();
+
+  await awaitWorkspaceWindowReady(
+    target.window,
+    () => {
+      target.emit("ready-to-show");
+    },
+    { maximizeOnShow: false, showOnReady: false }
+  );
+
+  assert.equal(target.maximizeCount, 0);
+  assert.equal(target.showCount, 0);
+});
+
 interface WorkspaceWindowReadyTargetFixture {
   closeCount: number;
   emit: (event: string, ...args: unknown[]) => void;

--- a/apps/desktop/src/main/host/workspaceLaunchDesktopAdapters.ts
+++ b/apps/desktop/src/main/host/workspaceLaunchDesktopAdapters.ts
@@ -35,6 +35,7 @@ export interface WorkspaceLaunchDesktopAdapterOptions {
 export function createWorkspaceLaunchDesktopAdapters(
   options: WorkspaceLaunchDesktopAdapterOptions
 ): WorkspaceLaunchAdapters {
+  const pendingAgentBrowserHosts = new Map<string, Promise<void>>();
   const durableWorkspaceWindows = createDurableWorkspaceWindowCoordinator({
     activate: activateWorkspaceWindow,
     find: (workspaceID: string) =>
@@ -43,6 +44,22 @@ export function createWorkspaceLaunchDesktopAdapters(
       createAndShowWorkspaceWindow(options, workspaceID)
   });
   return {
+    async ensureAgentBrowserHost(input) {
+      if (findWorkspaceWindow(input.workspaceID, "agent")) return;
+      const existing = pendingAgentBrowserHosts.get(input.workspaceID);
+      if (existing) return existing;
+      const opening = showStandaloneAgentWindow(options, input, {
+        showOnReady: false
+      }).then(() => undefined);
+      pendingAgentBrowserHosts.set(input.workspaceID, opening);
+      try {
+        await opening;
+      } finally {
+        if (pendingAgentBrowserHosts.get(input.workspaceID) === opening) {
+          pendingAgentBrowserHosts.delete(input.workspaceID);
+        }
+      }
+    },
     async showAgentWindow(input) {
       await showStandaloneAgentWindow(options, input);
     },
@@ -106,7 +123,8 @@ function activateWorkspaceWindow(
 
 async function showStandaloneAgentWindow(
   options: WorkspaceLaunchDesktopAdapterOptions,
-  input: WorkspaceLaunchAgentWindowInput
+  input: WorkspaceLaunchAgentWindowInput,
+  readyOptions: { showOnReady?: boolean } = {}
 ): Promise<Electron.BrowserWindow> {
   const agentWindow = createWorkspaceWindow({
     browserNodeGuestPreloadPath: options.browserNodeGuestPreloadPath,
@@ -142,7 +160,7 @@ async function showStandaloneAgentWindow(
         workspaceID: input.workspaceID
       });
     },
-    { maximizeOnShow: false }
+    { maximizeOnShow: false, showOnReady: readyOptions.showOnReady }
   );
   return agentWindow;
 }

--- a/apps/desktop/src/main/host/workspaceWindowReady.ts
+++ b/apps/desktop/src/main/host/workspaceWindowReady.ts
@@ -23,6 +23,7 @@ export interface WorkspaceWindowReadyTarget {
 
 export interface AwaitWorkspaceWindowReadyOptions {
   maximizeOnShow?: boolean;
+  showOnReady?: boolean;
 }
 
 export async function awaitWorkspaceWindowReady(
@@ -60,7 +61,7 @@ export async function awaitWorkspaceWindowReady(
 
     const handleReadyToShow = () => {
       settle(() => {
-        if (!window.isDestroyed()) {
+        if (!window.isDestroyed() && options.showOnReady !== false) {
           if (options.maximizeOnShow !== false) {
             window.maximize();
           }
@@ -72,7 +73,7 @@ export async function awaitWorkspaceWindowReady(
 
     const handleDidFinishLoad = () => {
       settle(() => {
-        if (!window.isDestroyed()) {
+        if (!window.isDestroyed() && options.showOnReady !== false) {
           if (options.maximizeOnShow !== false) {
             window.maximize();
           }

--- a/apps/desktop/src/main/ipc/browser.ts
+++ b/apps/desktop/src/main/ipc/browser.ts
@@ -14,7 +14,12 @@ import { fileURLToPath } from "node:url";
 import { resolveBrowserSessionPartition } from "@tutti-os/browser-node";
 import { createMacosChromeCookieImportAdapter } from "@tutti-os/browser-node/chrome-cookie-import/macos";
 import { registerBrowserNodeElectronMain } from "@tutti-os/browser-node/electron-main";
-import type { BrowserNodeElectronLogger } from "@tutti-os/browser-node/electron-main";
+import {
+  createBrowserNodeAutomationRegistry,
+  createBrowserNodeAutomationNetworkAuthorizer,
+  createBrowserNodeAutomationServer,
+  type BrowserNodeElectronLogger
+} from "@tutti-os/browser-node/electron-main";
 import {
   desktopIpcChannels,
   type DesktopInvokeChannel
@@ -38,6 +43,7 @@ import {
   BROWSER_CHROME_COOKIE_IMPORT_FLAG,
   isFeatureEnabled
 } from "../../shared/featureFlags/catalog.ts";
+import { resolveBrowserNodeAutomationListenerInfoPath } from "../transport/paths.ts";
 
 type BrowserInvokeChannel = Exclude<
   (typeof desktopIpcChannels.browser)[keyof typeof desktopIpcChannels.browser],
@@ -58,8 +64,13 @@ function getPreferredColorScheme(
 
 export function registerBrowserIpc(
   preferences: DesktopHostPreferencesState
-): void {
+): Promise<{ dispose(): void }> {
   const logger = getDesktopLogger();
+  const automationRegistry = createBrowserNodeAutomationRegistry({
+    authorize: createBrowserNodeAutomationNetworkAuthorizer({
+      allowLoopback: true
+    })
+  });
   const preparedDownloadSessions = new WeakSet<Electron.Session>();
   const chromeCookieImport = createMacosChromeCookieImportAdapter({
     isEnabled: () =>
@@ -72,6 +83,7 @@ export function registerBrowserIpc(
 
   registerBrowserNodeElectronMain({
     ...chromeCookieImport,
+    automationRegistry,
     channels: {
       ...desktopIpcChannels.browser,
       openDevTools: isBrowserDevToolsEnabled()
@@ -248,6 +260,12 @@ export function registerBrowserIpc(
       payload: normalizeBrowserGuestDiagnosticPayload(payload),
       webContentsId: event.sender.id
     });
+  });
+
+  return createBrowserNodeAutomationServer({
+    listenerInfoPath: resolveBrowserNodeAutomationListenerInfoPath(),
+    logger,
+    registry: automationRegistry
   });
 }
 

--- a/apps/desktop/src/main/ipc/browser.ts
+++ b/apps/desktop/src/main/ipc/browser.ts
@@ -1,5 +1,6 @@
 import {
   app,
+  BrowserWindow,
   dialog,
   ipcMain,
   nativeTheme,
@@ -8,6 +9,7 @@ import {
   shell,
   webContents
 } from "electron";
+import { randomUUID } from "node:crypto";
 import { readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -45,9 +47,14 @@ import {
 } from "../../shared/featureFlags/catalog.ts";
 import { resolveBrowserNodeAutomationListenerInfoPath } from "../transport/paths.ts";
 import { createDesktopBrowserAutomationCoordinator } from "./browserAutomationCoordinator.ts";
+import {
+  getWorkspaceWindowKind,
+  getWorkspaceWindowWorkspaceID
+} from "../windows/workspaceWindow.ts";
 
 type BrowserInvokeChannel = Exclude<
   (typeof desktopIpcChannels.browser)[keyof typeof desktopIpcChannels.browser],
+  | typeof desktopIpcChannels.browser.automationHostReady
   | typeof desktopIpcChannels.browser.automationRequest
   | typeof desktopIpcChannels.browser.automationResponse
   | typeof desktopIpcChannels.browser.event
@@ -66,14 +73,32 @@ function getPreferredColorScheme(
 }
 
 export async function registerBrowserIpc(
-  preferences: DesktopHostPreferencesState
+  preferences: DesktopHostPreferencesState,
+  options: {
+    ensureAgentBrowserHost(input: {
+      agentSessionId: string;
+      workspaceId: string;
+    }): Promise<void>;
+  }
 ): Promise<{ dispose(): void }> {
   const logger = getDesktopLogger();
-  const automationCoordinator = createDesktopBrowserAutomationCoordinator();
+  const automationCoordinator = createDesktopBrowserAutomationCoordinator({
+    ...options,
+    runtime: {
+      ipc: ipcMain,
+      randomId: randomUUID,
+      resolveHostContext(sender) {
+        const ownerWindow = BrowserWindow.fromWebContents(sender);
+        if (!ownerWindow) return null;
+        const kind = getWorkspaceWindowKind(ownerWindow);
+        const workspaceId = getWorkspaceWindowWorkspaceID(ownerWindow);
+        return kind && workspaceId ? { kind, workspaceId } : null;
+      },
+      resolveWebContents: (id) => webContents.fromId(id) ?? null
+    }
+  });
   const automationNetworkAuthorizer =
-    createBrowserNodeAutomationNetworkAuthorizer({
-      allowLoopback: false
-    });
+    createBrowserNodeAutomationNetworkAuthorizer();
   const automationRegistry = createBrowserNodeAutomationRegistry({
     authorize: automationNetworkAuthorizer,
     authorizeRequest: automationNetworkAuthorizer,

--- a/apps/desktop/src/main/ipc/browser.ts
+++ b/apps/desktop/src/main/ipc/browser.ts
@@ -44,10 +44,13 @@ import {
   isFeatureEnabled
 } from "../../shared/featureFlags/catalog.ts";
 import { resolveBrowserNodeAutomationListenerInfoPath } from "../transport/paths.ts";
+import { createDesktopBrowserAutomationCoordinator } from "./browserAutomationCoordinator.ts";
 
 type BrowserInvokeChannel = Exclude<
   (typeof desktopIpcChannels.browser)[keyof typeof desktopIpcChannels.browser],
-  typeof desktopIpcChannels.browser.event
+  | typeof desktopIpcChannels.browser.automationRequest
+  | typeof desktopIpcChannels.browser.automationResponse
+  | typeof desktopIpcChannels.browser.event
 >;
 
 const prefersColorSchemeFeatureName = "prefers-color-scheme";
@@ -62,14 +65,32 @@ function getPreferredColorScheme(
   });
 }
 
-export function registerBrowserIpc(
+export async function registerBrowserIpc(
   preferences: DesktopHostPreferencesState
 ): Promise<{ dispose(): void }> {
   const logger = getDesktopLogger();
+  const automationCoordinator = createDesktopBrowserAutomationCoordinator();
+  const automationNetworkAuthorizer =
+    createBrowserNodeAutomationNetworkAuthorizer({
+      allowLoopback: false
+    });
   const automationRegistry = createBrowserNodeAutomationRegistry({
-    authorize: createBrowserNodeAutomationNetworkAuthorizer({
-      allowLoopback: true
-    })
+    authorize: automationNetworkAuthorizer,
+    authorizeRequest: automationNetworkAuthorizer,
+    closeTarget: automationCoordinator.closeTarget,
+    requestTarget: async (input) => {
+      const nodeId = await automationCoordinator.requestTarget(input);
+      if (nodeId) {
+        await waitForAutomationTarget(
+          automationRegistry,
+          input.workspaceId,
+          input.agentSessionId,
+          nodeId
+        );
+      }
+      return nodeId;
+    },
+    selectTarget: automationCoordinator.selectTarget
   });
   const preparedDownloadSessions = new WeakSet<Electron.Session>();
   const chromeCookieImport = createMacosChromeCookieImportAdapter({
@@ -262,11 +283,37 @@ export function registerBrowserIpc(
     });
   });
 
-  return createBrowserNodeAutomationServer({
+  const automationServer = await createBrowserNodeAutomationServer({
     listenerInfoPath: resolveBrowserNodeAutomationListenerInfoPath(),
     logger,
     registry: automationRegistry
   });
+  return {
+    dispose() {
+      automationCoordinator.dispose();
+      automationServer.dispose();
+    }
+  };
+}
+
+async function waitForAutomationTarget(
+  registry: ReturnType<typeof createBrowserNodeAutomationRegistry>,
+  workspaceId: string,
+  agentSessionId: string | null,
+  nodeId: string
+): Promise<void> {
+  const deadline = Date.now() + 8_000;
+  while (Date.now() < deadline) {
+    if (
+      registry
+        .list({ agentSessionId, workspaceId })
+        .some((target) => target.nodeId === nodeId)
+    ) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`In-app Browser page did not attach: ${nodeId}`);
 }
 
 function isBrowserDevToolsEnabled(): boolean {

--- a/apps/desktop/src/main/ipc/browserAutomationCoordinator.test.ts
+++ b/apps/desktop/src/main/ipc/browserAutomationCoordinator.test.ts
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+import type {
+  DesktopBrowserAutomationRequest,
+  DesktopBrowserAutomationResponse
+} from "../../shared/contracts/ipc.ts";
+import { desktopIpcChannels } from "../../shared/contracts/ipc.ts";
+import { createDesktopBrowserAutomationCoordinator } from "./browserAutomationCoordinator.ts";
+
+interface FakeHost {
+  context: { kind: "agent" | "workspace"; workspaceId: string };
+  destroyed: boolean;
+  id: number;
+  requests: DesktopBrowserAutomationRequest[];
+}
+
+function createHarness() {
+  const ipc = new EventEmitter();
+  const hosts = new Map<number, FakeHost>();
+  let nextRequestId = 0;
+  const ensureCalls: Array<{ agentSessionId: string; workspaceId: string }> =
+    [];
+  const responses = new Map<
+    number,
+    (
+      request: DesktopBrowserAutomationRequest
+    ) => DesktopBrowserAutomationResponse
+  >();
+
+  const sender = (host: FakeHost) =>
+    ({
+      id: host.id,
+      isDestroyed: () => host.destroyed,
+      send(_channel: string, request: DesktopBrowserAutomationRequest) {
+        host.requests.push(request);
+        const response = responses.get(host.id)?.(request);
+        if (response) {
+          queueMicrotask(() =>
+            ipc.emit(
+              desktopIpcChannels.browser.automationResponse,
+              { sender: sender(host) },
+              response
+            )
+          );
+        }
+      }
+    }) as never;
+
+  const addHost = (
+    id: number,
+    context: FakeHost["context"],
+    respond: (
+      request: DesktopBrowserAutomationRequest
+    ) => DesktopBrowserAutomationResponse
+  ): FakeHost => {
+    const host = { context, destroyed: false, id, requests: [] };
+    hosts.set(id, host);
+    responses.set(id, respond);
+    return host;
+  };
+
+  const announceReady = (
+    host: FakeHost,
+    input = {
+      surfaceRole:
+        host.context.kind === "agent" ? ("agent" as const) : ("user" as const),
+      workspaceId: host.context.workspaceId
+    }
+  ) => {
+    ipc.emit(
+      desktopIpcChannels.browser.automationHostReady,
+      { sender: sender(host) },
+      input
+    );
+  };
+
+  const coordinator = createDesktopBrowserAutomationCoordinator({
+    async ensureAgentBrowserHost(input) {
+      ensureCalls.push(input);
+      const host = addHost(
+        99,
+        { kind: "agent", workspaceId: input.workspaceId },
+        (request) => ({
+          nodeId:
+            request.action === "create" ? "background-page" : request.nodeId,
+          ok: true,
+          requestId: request.requestId
+        })
+      );
+      announceReady(host);
+    },
+    runtime: {
+      ipc: ipc as never,
+      randomId: () => `request-${++nextRequestId}`,
+      resolveHostContext: (webContents) =>
+        hosts.get((webContents as unknown as { id: number }).id)?.context ??
+        null,
+      resolveWebContents: (id) => {
+        const host = hosts.get(id);
+        return host ? sender(host) : null;
+      }
+    }
+  });
+
+  return { addHost, announceReady, coordinator, ensureCalls, ipc };
+}
+
+test("Agent new_page starts and waits for a background Browser host", async () => {
+  const harness = createHarness();
+  const nodeId = await harness.coordinator.requestTarget({
+    agentSessionId: "session-a",
+    url: "https://example.com",
+    workspaceId: "workspace-a"
+  });
+
+  assert.equal(nodeId, "background-page");
+  assert.deepEqual(harness.ensureCalls, [
+    { agentSessionId: "session-a", workspaceId: "workspace-a" }
+  ]);
+  harness.coordinator.dispose();
+});
+
+test("created targets remain routed to the exact Agent host that owns them", async () => {
+  const harness = createHarness();
+  const first = harness.addHost(
+    1,
+    { kind: "agent", workspaceId: "workspace-a" },
+    (request) => ({
+      nodeId: request.action === "create" ? "page-a" : request.nodeId,
+      ok: true,
+      requestId: request.requestId
+    })
+  );
+  const second = harness.addHost(
+    2,
+    { kind: "agent", workspaceId: "workspace-a" },
+    (request) => ({
+      nodeId: request.action === "create" ? "page-b" : request.nodeId,
+      ok: true,
+      requestId: request.requestId
+    })
+  );
+  harness.announceReady(first);
+  harness.announceReady(second);
+
+  const nodeId = await harness.coordinator.requestTarget({
+    agentSessionId: "session-b",
+    workspaceId: "workspace-a"
+  });
+  assert.equal(nodeId, "page-b");
+  await harness.coordinator.selectTarget({
+    agentSessionId: "session-b",
+    nodeId: "page-b",
+    selected: true,
+    surfaceId: "agent-surface",
+    surfaceRole: "agent",
+    tabId: "page-b",
+    title: "",
+    url: "about:blank",
+    workspaceId: "workspace-a"
+  });
+
+  assert.deepEqual(first.requests, []);
+  assert.deepEqual(
+    second.requests.map((request) => request.action),
+    ["create", "select"]
+  );
+  harness.coordinator.dispose();
+});
+
+test("ready announcements cannot claim another workspace or surface role", async () => {
+  const harness = createHarness();
+  const forged = harness.addHost(
+    3,
+    { kind: "workspace", workspaceId: "workspace-a" },
+    (request) => ({
+      nodeId: "forged-page",
+      ok: true,
+      requestId: request.requestId
+    })
+  );
+  harness.announceReady(forged, {
+    surfaceRole: "agent",
+    workspaceId: "workspace-b"
+  });
+
+  const nodeId = await harness.coordinator.requestTarget({
+    agentSessionId: "session-a",
+    workspaceId: "workspace-a"
+  });
+  assert.equal(nodeId, "background-page");
+  assert.deepEqual(forged.requests, []);
+  assert.equal(harness.ensureCalls.length, 1);
+  harness.coordinator.dispose();
+});

--- a/apps/desktop/src/main/ipc/browserAutomationCoordinator.ts
+++ b/apps/desktop/src/main/ipc/browserAutomationCoordinator.ts
@@ -1,20 +1,20 @@
-import { ipcMain, type BrowserWindow, type IpcMainEvent } from "electron";
-import { randomUUID } from "node:crypto";
+import type { IpcMain, IpcMainEvent } from "electron";
 import type {
   BrowserNodeAutomationTargetRequest,
   BrowserNodeAutomationTargetSummary
 } from "@tutti-os/browser-node/electron-main";
 import {
   desktopIpcChannels,
+  type DesktopBrowserAutomationHostReady,
   type DesktopBrowserAutomationRequest,
   type DesktopBrowserAutomationResponse
 } from "../../shared/contracts/ipc.ts";
-import { findWorkspaceWindow } from "../windows/workspaceWindow.ts";
 
 const requestTimeoutMs = 10_000;
 
 interface PendingRequest {
   reject(error: Error): void;
+  request: Omit<DesktopBrowserAutomationRequest, "requestId">;
   resolve(nodeId: string | null): void;
   senderId: number;
   timeout: ReturnType<typeof setTimeout>;
@@ -29,8 +29,58 @@ export interface DesktopBrowserAutomationCoordinator {
   selectTarget(target: BrowserNodeAutomationTargetSummary): Promise<void>;
 }
 
-export function createDesktopBrowserAutomationCoordinator(): DesktopBrowserAutomationCoordinator {
+export interface DesktopBrowserAutomationCoordinatorOptions {
+  ensureAgentBrowserHost(input: {
+    agentSessionId: string;
+    workspaceId: string;
+  }): Promise<void>;
+  runtime: {
+    ipc: Pick<IpcMain, "off" | "on">;
+    randomId(): string;
+    resolveHostContext(sender: Electron.WebContents): {
+      kind: "agent" | "workspace";
+      workspaceId: string;
+    } | null;
+    resolveWebContents(id: number): Electron.WebContents | null;
+  };
+}
+
+export function createDesktopBrowserAutomationCoordinator(
+  options: DesktopBrowserAutomationCoordinatorOptions
+): DesktopBrowserAutomationCoordinator {
+  const runtime = options.runtime;
   const pending = new Map<string, PendingRequest>();
+  const readyHostIds = new Map<string, Set<number>>();
+  const readyWaiters = new Map<string, Set<() => void>>();
+  const targetOwnerIds = new Map<string, number>();
+
+  const handleHostReady = (
+    event: IpcMainEvent,
+    input: DesktopBrowserAutomationHostReady
+  ): void => {
+    if (
+      (input?.surfaceRole !== "agent" && input?.surfaceRole !== "user") ||
+      !input.workspaceId?.trim()
+    ) {
+      return;
+    }
+    const hostContext = runtime.resolveHostContext(event.sender);
+    const expectedKind = input?.surfaceRole === "agent" ? "agent" : "workspace";
+    if (
+      !hostContext ||
+      hostContext.kind !== expectedKind ||
+      hostContext.workspaceId !== input?.workspaceId
+    ) {
+      return;
+    }
+    const key = hostKey(input.workspaceId, input.surfaceRole);
+    const hostIds = readyHostIds.get(key) ?? new Set<number>();
+    hostIds.add(event.sender.id);
+    readyHostIds.set(key, hostIds);
+    for (const resolve of readyWaiters.get(key) ?? []) resolve();
+    readyWaiters.delete(key);
+  };
+
   const handleResponse = (
     event: IpcMainEvent,
     response: DesktopBrowserAutomationResponse
@@ -43,22 +93,34 @@ export function createDesktopBrowserAutomationCoordinator(): DesktopBrowserAutom
       request.reject(new Error(response.error));
       return;
     }
-    request.resolve(response.nodeId);
-  };
-  ipcMain.on(desktopIpcChannels.browser.automationResponse, handleResponse);
-
-  const send = (
-    request: Omit<DesktopBrowserAutomationRequest, "requestId">
-  ): Promise<string | null> => {
-    const ownerWindow = resolveOwnerWindow(request);
-    if (!ownerWindow || ownerWindow.webContents.isDestroyed()) {
-      return Promise.reject(
-        new Error(
-          `No ${request.surfaceRole} Browser surface host is available for workspace ${request.workspaceId}`
-        )
+    if (request.request.action === "create" && response.nodeId) {
+      targetOwnerIds.set(
+        targetKey(request.request.workspaceId, response.nodeId),
+        event.sender.id
+      );
+    } else if (request.request.action === "close" && request.request.nodeId) {
+      targetOwnerIds.delete(
+        targetKey(request.request.workspaceId, request.request.nodeId)
       );
     }
-    const requestId = randomUUID();
+    request.resolve(response.nodeId);
+  };
+  runtime.ipc.on(
+    desktopIpcChannels.browser.automationHostReady,
+    handleHostReady
+  );
+  runtime.ipc.on(desktopIpcChannels.browser.automationResponse, handleResponse);
+
+  const sendToHost = (
+    senderId: number,
+    request: Omit<DesktopBrowserAutomationRequest, "requestId">
+  ): Promise<string | null> => {
+    const sender = runtime.resolveWebContents(senderId);
+    if (!sender || sender.isDestroyed()) {
+      removeReadyHost(readyHostIds, senderId);
+      return Promise.reject(new Error("In-app Browser surface host closed"));
+    }
+    const requestId = runtime.randomId();
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
         pending.delete(requestId);
@@ -66,15 +128,80 @@ export function createDesktopBrowserAutomationCoordinator(): DesktopBrowserAutom
       }, requestTimeoutMs);
       pending.set(requestId, {
         reject,
+        request,
         resolve,
-        senderId: ownerWindow.webContents.id,
+        senderId,
         timeout
       });
-      ownerWindow.webContents.send(
-        desktopIpcChannels.browser.automationRequest,
-        { ...request, requestId } satisfies DesktopBrowserAutomationRequest
-      );
+      try {
+        sender.send(desktopIpcChannels.browser.automationRequest, {
+          ...request,
+          requestId
+        } satisfies DesktopBrowserAutomationRequest);
+      } catch (error) {
+        clearTimeout(timeout);
+        pending.delete(requestId);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
     });
+  };
+
+  const send = async (
+    request: Omit<DesktopBrowserAutomationRequest, "requestId">
+  ): Promise<string | null> => {
+    const mappedOwnerId = request.nodeId
+      ? targetOwnerIds.get(targetKey(request.workspaceId, request.nodeId))
+      : undefined;
+    if (mappedOwnerId !== undefined) {
+      return sendToHost(mappedOwnerId, request);
+    }
+
+    let hostIds = resolveReadyHostIds(
+      runtime,
+      readyHostIds,
+      request.workspaceId,
+      request.surfaceRole
+    );
+    if (hostIds.length === 0 && request.surfaceRole === "agent") {
+      const agentSessionId = request.agentSessionId?.trim() ?? "";
+      if (!agentSessionId) {
+        throw new Error("Agent Browser request requires an agent session");
+      }
+      await options.ensureAgentBrowserHost({
+        agentSessionId,
+        workspaceId: request.workspaceId
+      });
+      await waitForReadyHost(
+        runtime,
+        readyHostIds,
+        readyWaiters,
+        request.workspaceId,
+        request.surfaceRole
+      );
+      hostIds = resolveReadyHostIds(
+        runtime,
+        readyHostIds,
+        request.workspaceId,
+        request.surfaceRole
+      );
+    }
+    if (hostIds.length === 0) {
+      throw new Error(
+        `No ${request.surfaceRole} Browser surface host is available for workspace ${request.workspaceId}`
+      );
+    }
+
+    let lastError: unknown;
+    for (const senderId of hostIds) {
+      try {
+        return await sendToHost(senderId, request);
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError instanceof Error
+      ? lastError
+      : new Error("In-app Browser surface request failed");
   };
 
   return {
@@ -89,7 +216,11 @@ export function createDesktopBrowserAutomationCoordinator(): DesktopBrowserAutom
       });
     },
     dispose() {
-      ipcMain.off(
+      runtime.ipc.off(
+        desktopIpcChannels.browser.automationHostReady,
+        handleHostReady
+      );
+      runtime.ipc.off(
         desktopIpcChannels.browser.automationResponse,
         handleResponse
       );
@@ -98,6 +229,12 @@ export function createDesktopBrowserAutomationCoordinator(): DesktopBrowserAutom
         request.reject(new Error("In-app Browser automation stopped"));
       }
       pending.clear();
+      readyHostIds.clear();
+      for (const waiters of readyWaiters.values()) {
+        for (const resolve of waiters) resolve();
+      }
+      readyWaiters.clear();
+      targetOwnerIds.clear();
     },
     requestTarget(input) {
       return send({
@@ -122,11 +259,72 @@ export function createDesktopBrowserAutomationCoordinator(): DesktopBrowserAutom
   };
 }
 
-function resolveOwnerWindow(
-  request: Pick<DesktopBrowserAutomationRequest, "surfaceRole" | "workspaceId">
-): BrowserWindow | null {
-  return findWorkspaceWindow(
-    request.workspaceId,
-    request.surfaceRole === "agent" ? "agent" : "workspace"
-  );
+function hostKey(workspaceId: string, surfaceRole: "agent" | "user"): string {
+  return `${workspaceId}\u0000${surfaceRole}`;
+}
+
+function targetKey(workspaceId: string, nodeId: string): string {
+  return `${workspaceId}\u0000${nodeId}`;
+}
+
+function resolveReadyHostIds(
+  runtime: NonNullable<DesktopBrowserAutomationCoordinatorOptions["runtime"]>,
+  readyHostIds: Map<string, Set<number>>,
+  workspaceId: string,
+  surfaceRole: "agent" | "user"
+): number[] {
+  const key = hostKey(workspaceId, surfaceRole);
+  const hostIds = readyHostIds.get(key);
+  if (!hostIds) return [];
+  const active: number[] = [];
+  for (const senderId of hostIds) {
+    const sender = runtime.resolveWebContents(senderId);
+    if (!sender || sender.isDestroyed()) {
+      hostIds.delete(senderId);
+    } else {
+      active.push(senderId);
+    }
+  }
+  if (hostIds.size === 0) readyHostIds.delete(key);
+  return active.reverse();
+}
+
+function removeReadyHost(
+  readyHostIds: Map<string, Set<number>>,
+  senderId: number
+): void {
+  for (const [key, hostIds] of readyHostIds) {
+    hostIds.delete(senderId);
+    if (hostIds.size === 0) readyHostIds.delete(key);
+  }
+}
+
+async function waitForReadyHost(
+  runtime: NonNullable<DesktopBrowserAutomationCoordinatorOptions["runtime"]>,
+  readyHostIds: Map<string, Set<number>>,
+  readyWaiters: Map<string, Set<() => void>>,
+  workspaceId: string,
+  surfaceRole: "agent" | "user"
+): Promise<void> {
+  if (
+    resolveReadyHostIds(runtime, readyHostIds, workspaceId, surfaceRole)
+      .length > 0
+  ) {
+    return;
+  }
+  const key = hostKey(workspaceId, surfaceRole);
+  await new Promise<void>((resolve, reject) => {
+    const waiters = readyWaiters.get(key) ?? new Set<() => void>();
+    const handleReady = () => {
+      clearTimeout(timeout);
+      resolve();
+    };
+    const timeout = setTimeout(() => {
+      waiters.delete(handleReady);
+      if (waiters.size === 0) readyWaiters.delete(key);
+      reject(new Error("In-app Browser surface host did not become ready"));
+    }, requestTimeoutMs);
+    waiters.add(handleReady);
+    readyWaiters.set(key, waiters);
+  });
 }

--- a/apps/desktop/src/main/ipc/browserAutomationCoordinator.ts
+++ b/apps/desktop/src/main/ipc/browserAutomationCoordinator.ts
@@ -1,0 +1,132 @@
+import { ipcMain, type BrowserWindow, type IpcMainEvent } from "electron";
+import { randomUUID } from "node:crypto";
+import type {
+  BrowserNodeAutomationTargetRequest,
+  BrowserNodeAutomationTargetSummary
+} from "@tutti-os/browser-node/electron-main";
+import {
+  desktopIpcChannels,
+  type DesktopBrowserAutomationRequest,
+  type DesktopBrowserAutomationResponse
+} from "../../shared/contracts/ipc.ts";
+import { findWorkspaceWindow } from "../windows/workspaceWindow.ts";
+
+const requestTimeoutMs = 10_000;
+
+interface PendingRequest {
+  reject(error: Error): void;
+  resolve(nodeId: string | null): void;
+  senderId: number;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+export interface DesktopBrowserAutomationCoordinator {
+  closeTarget(target: BrowserNodeAutomationTargetSummary): Promise<void>;
+  dispose(): void;
+  requestTarget(
+    input: BrowserNodeAutomationTargetRequest
+  ): Promise<string | null>;
+  selectTarget(target: BrowserNodeAutomationTargetSummary): Promise<void>;
+}
+
+export function createDesktopBrowserAutomationCoordinator(): DesktopBrowserAutomationCoordinator {
+  const pending = new Map<string, PendingRequest>();
+  const handleResponse = (
+    event: IpcMainEvent,
+    response: DesktopBrowserAutomationResponse
+  ): void => {
+    const request = pending.get(response?.requestId);
+    if (!request || request.senderId !== event.sender.id) return;
+    pending.delete(response.requestId);
+    clearTimeout(request.timeout);
+    if (!response.ok) {
+      request.reject(new Error(response.error));
+      return;
+    }
+    request.resolve(response.nodeId);
+  };
+  ipcMain.on(desktopIpcChannels.browser.automationResponse, handleResponse);
+
+  const send = (
+    request: Omit<DesktopBrowserAutomationRequest, "requestId">
+  ): Promise<string | null> => {
+    const ownerWindow = resolveOwnerWindow(request);
+    if (!ownerWindow || ownerWindow.webContents.isDestroyed()) {
+      return Promise.reject(
+        new Error(
+          `No ${request.surfaceRole} Browser surface host is available for workspace ${request.workspaceId}`
+        )
+      );
+    }
+    const requestId = randomUUID();
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pending.delete(requestId);
+        reject(new Error("In-app Browser surface request timed out"));
+      }, requestTimeoutMs);
+      pending.set(requestId, {
+        reject,
+        resolve,
+        senderId: ownerWindow.webContents.id,
+        timeout
+      });
+      ownerWindow.webContents.send(
+        desktopIpcChannels.browser.automationRequest,
+        { ...request, requestId } satisfies DesktopBrowserAutomationRequest
+      );
+    });
+  };
+
+  return {
+    async closeTarget(target) {
+      await send({
+        action: "close",
+        agentSessionId: target.agentSessionId ?? null,
+        nodeId: target.nodeId,
+        surfaceRole: target.surfaceRole,
+        url: null,
+        workspaceId: target.workspaceId
+      });
+    },
+    dispose() {
+      ipcMain.off(
+        desktopIpcChannels.browser.automationResponse,
+        handleResponse
+      );
+      for (const request of pending.values()) {
+        clearTimeout(request.timeout);
+        request.reject(new Error("In-app Browser automation stopped"));
+      }
+      pending.clear();
+    },
+    requestTarget(input) {
+      return send({
+        action: "create",
+        agentSessionId: input.agentSessionId,
+        nodeId: input.requestedPageId ?? null,
+        surfaceRole: input.agentSessionId ? "agent" : "user",
+        url: input.url ?? null,
+        workspaceId: input.workspaceId
+      });
+    },
+    async selectTarget(target) {
+      await send({
+        action: "select",
+        agentSessionId: target.agentSessionId ?? null,
+        nodeId: target.nodeId,
+        surfaceRole: target.surfaceRole,
+        url: null,
+        workspaceId: target.workspaceId
+      });
+    }
+  };
+}
+
+function resolveOwnerWindow(
+  request: Pick<DesktopBrowserAutomationRequest, "surfaceRole" | "workspaceId">
+): BrowserWindow | null {
+  return findWorkspaceWindow(
+    request.workspaceId,
+    request.surfaceRole === "agent" ? "agent" : "workspace"
+  );
+}

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -52,13 +52,15 @@ export interface IpcRegistrationDependencies {
   >;
 }
 
-export function registerIpcHandlers(deps: IpcRegistrationDependencies): void {
+export async function registerIpcHandlers(
+  deps: IpcRegistrationDependencies
+): Promise<readonly { dispose(): void }[]> {
   registerWorkspaceAppContextIpc(deps.daemonEndpoint, deps.preferences, {
     logger: deps.logger,
     sessionID: getDesktopLogSessionID(),
     stateRootDir: resolveDesktopDefaultsFromEnv().state.rootDir
   });
-  registerBrowserIpc(deps.preferences);
+  const browserAutomation = await registerBrowserIpc(deps.preferences);
   registerComputerUseIpc();
   registerDockPreviewCacheIpc();
   registerDeveloperIpc(deps.preferences, deps.tuttidClient);
@@ -71,4 +73,5 @@ export function registerIpcHandlers(deps: IpcRegistrationDependencies): void {
     workspaceFileIconCache: deps.workspaceFileIconCache,
     workspaceLaunch: deps.workspaceLaunch
   });
+  return [browserAutomation];
 }

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -45,6 +45,7 @@ export interface IpcRegistrationDependencies {
   updateService: AppUpdateService;
   workspaceLaunch: Pick<
     WorkspaceLaunch,
+    | "ensureAgentBrowserHost"
     | "openStartupWindow"
     | "replaceWorkspaceWindow"
     | "showAgentWindow"
@@ -60,7 +61,13 @@ export async function registerIpcHandlers(
     sessionID: getDesktopLogSessionID(),
     stateRootDir: resolveDesktopDefaultsFromEnv().state.rootDir
   });
-  const browserAutomation = await registerBrowserIpc(deps.preferences);
+  const browserAutomation = await registerBrowserIpc(deps.preferences, {
+    ensureAgentBrowserHost: ({ agentSessionId, workspaceId }) =>
+      deps.workspaceLaunch.ensureAgentBrowserHost({
+        agentSessionID: agentSessionId,
+        workspaceID: workspaceId
+      })
+  });
   registerComputerUseIpc();
   registerDockPreviewCacheIpc();
   registerDeveloperIpc(deps.preferences, deps.tuttidClient);

--- a/apps/desktop/src/main/transport/paths.ts
+++ b/apps/desktop/src/main/transport/paths.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import { join } from "node:path";
 import { resolveDesktopDefaultsFromEnv } from "../defaults.ts";
 
 export interface DesktopDaemonEndpoint {
@@ -60,6 +61,13 @@ export function resolveDesktopBusinessEventStreamUrl(
 
 export function resolveDesktopLogsDir(): string {
   return resolveDesktopDefaultsFromEnv().state.logsDir;
+}
+
+export function resolveBrowserNodeAutomationListenerInfoPath(): string {
+  return join(
+    resolveDesktopDefaultsFromEnv().state.runDir,
+    "browser-node-automation.json"
+  );
 }
 
 function toBaseUrl(addr: string): string {

--- a/apps/desktop/src/main/windows/workspaceWindow.ts
+++ b/apps/desktop/src/main/windows/workspaceWindow.ts
@@ -300,6 +300,12 @@ export function getWorkspaceWindowKind(
   return workspaceWindows.getKind(workspaceWindow);
 }
 
+export function getWorkspaceWindowWorkspaceID(
+  workspaceWindow: BrowserWindow
+): string | null {
+  return workspaceWindows.getWorkspaceID(workspaceWindow);
+}
+
 export function findWorkspaceWindow(
   workspaceID: string,
   kind: "agent" | "workspace"

--- a/apps/desktop/src/main/windows/workspaceWindowRegistry.ts
+++ b/apps/desktop/src/main/windows/workspaceWindowRegistry.ts
@@ -48,6 +48,10 @@ export class WorkspaceWindowRegistry<
     return this.registrations.get(window)?.kind ?? null;
   }
 
+  getWorkspaceID(window: TWindow): string | null {
+    return this.registrations.get(window)?.workspaceID ?? null;
+  }
+
   register(window: TWindow, registration: WorkspaceWindowRegistration): void {
     if (registration.kind === "workspace") {
       this.assertDurableWorkspaceAvailable(registration.workspaceID);

--- a/apps/desktop/src/preload/api/browser.ts
+++ b/apps/desktop/src/preload/api/browser.ts
@@ -10,6 +10,7 @@ import { invokeDesktopApi } from "./invoke";
 
 type BrowserInvokeChannel = Exclude<
   (typeof desktopIpcChannels.browser)[keyof typeof desktopIpcChannels.browser],
+  | typeof desktopIpcChannels.browser.automationHostReady
   | typeof desktopIpcChannels.browser.automationRequest
   | typeof desktopIpcChannels.browser.automationResponse
   | typeof desktopIpcChannels.browser.event
@@ -40,6 +41,9 @@ export function createBrowserDesktopApi(): DesktopBrowserApi {
   });
   return {
     ...browserApi,
+    announceAutomationHostReady(input) {
+      ipcRenderer.send(desktopIpcChannels.browser.automationHostReady, input);
+    },
     onAutomationRequest(listener) {
       const handleRequest = (
         _event: Electron.IpcRendererEvent,

--- a/apps/desktop/src/preload/api/browser.ts
+++ b/apps/desktop/src/preload/api/browser.ts
@@ -10,12 +10,14 @@ import { invokeDesktopApi } from "./invoke";
 
 type BrowserInvokeChannel = Exclude<
   (typeof desktopIpcChannels.browser)[keyof typeof desktopIpcChannels.browser],
-  typeof desktopIpcChannels.browser.event
+  | typeof desktopIpcChannels.browser.automationRequest
+  | typeof desktopIpcChannels.browser.automationResponse
+  | typeof desktopIpcChannels.browser.event
 > &
   DesktopInvokeChannel;
 
 export function createBrowserDesktopApi(): DesktopBrowserApi {
-  return createBrowserNodeElectronRendererApi({
+  const browserApi = createBrowserNodeElectronRendererApi({
     channels: {
       ...desktopIpcChannels.browser,
       openDevTools: isBrowserDevToolsEnabled()
@@ -36,6 +38,29 @@ export function createBrowserDesktopApi(): DesktopBrowserApi {
         ipcRenderer.removeListener(channel, listener)
     }
   });
+  return {
+    ...browserApi,
+    onAutomationRequest(listener) {
+      const handleRequest = (
+        _event: Electron.IpcRendererEvent,
+        request: unknown
+      ) => {
+        listener(request as Parameters<typeof listener>[0]);
+      };
+      ipcRenderer.on(
+        desktopIpcChannels.browser.automationRequest,
+        handleRequest
+      );
+      return () =>
+        ipcRenderer.removeListener(
+          desktopIpcChannels.browser.automationRequest,
+          handleRequest
+        );
+    },
+    respondAutomationRequest(response) {
+      ipcRenderer.send(desktopIpcChannels.browser.automationResponse, response);
+    }
+  };
 }
 
 function isBrowserDevToolsEnabled(): boolean {

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -249,6 +249,7 @@ export type DesktopBrowserApi = Pick<
   | "showDevToolsContextMenu"
   | "stopFindInPage"
   | "unregisterGuest"
+  | "updateAutomationTarget"
 >;
 
 export interface DesktopUpdateApi {

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -47,6 +47,7 @@ import type {
   DesktopArchiveAgentPromptFileInput,
   DesktopArchiveAgentPromptFileResult,
   DesktopBrowserAutomationRequest,
+  DesktopBrowserAutomationHostReady,
   DesktopBrowserAutomationResponse
 } from "../shared/contracts/ipc";
 import type { BrowserNodeHostApi } from "@tutti-os/browser-node";
@@ -253,6 +254,7 @@ export type DesktopBrowserApi = Pick<
   | "unregisterGuest"
   | "updateAutomationTarget"
 > & {
+  announceAutomationHostReady?(input: DesktopBrowserAutomationHostReady): void;
   onAutomationRequest(
     listener: (request: DesktopBrowserAutomationRequest) => void
   ): () => void;

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -45,7 +45,9 @@ import type {
   DesktopWorkspaceAppOpenFileResolvedPayload,
   DesktopWorkspaceOpenFeatureRequest,
   DesktopArchiveAgentPromptFileInput,
-  DesktopArchiveAgentPromptFileResult
+  DesktopArchiveAgentPromptFileResult,
+  DesktopBrowserAutomationRequest,
+  DesktopBrowserAutomationResponse
 } from "../shared/contracts/ipc";
 import type { BrowserNodeHostApi } from "@tutti-os/browser-node";
 
@@ -250,7 +252,12 @@ export type DesktopBrowserApi = Pick<
   | "stopFindInPage"
   | "unregisterGuest"
   | "updateAutomationTarget"
->;
+> & {
+  onAutomationRequest(
+    listener: (request: DesktopBrowserAutomationRequest) => void
+  ): () => void;
+  respondAutomationRequest(response: DesktopBrowserAutomationResponse): void;
+};
 
 export interface DesktopUpdateApi {
   checkForUpdates(): Promise<AppUpdateState>;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/appCenterWorkbenchContributionFactory.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/appCenterWorkbenchContributionFactory.test.ts
@@ -342,11 +342,13 @@ function createBrowserApi(
     goBack: async () => undefined,
     goForward: async () => undefined,
     navigate: async () => undefined,
+    onAutomationRequest: () => () => undefined,
     onEvent: () => () => undefined,
     openExternal: async () => undefined,
     prepareSession: async () => undefined,
     registerGuest: async () => undefined,
     reload: async () => undefined,
+    respondAutomationRequest: () => undefined,
     unregisterGuest: async () => undefined,
     ...overrides
   };

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserContribution.ts
@@ -81,6 +81,10 @@ export function createWorkspaceBrowserContribution(input: {
     }),
     feature,
     node: {
+      automationTarget: {
+        surfaceRole: "user",
+        workspaceId: input.workspaceId
+      },
       renderTrafficLights: input.renderTrafficLights
     },
     typeId: workspaceBrowserNodeID

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserContribution.ts
@@ -63,6 +63,10 @@ export function createWorkspaceBrowserContribution(input: {
     resolveSearchUrl: resolveWorkspaceBrowserSearchUrl
   });
   input.browserService.ensureFeatureConnected(feature);
+  input.browserService.setUserAutomationSurface({
+    feature,
+    workspaceId: input.workspaceId
+  });
 
   const contribution = createBrowserWorkbenchContribution({
     contributionId: "workspace-browser",

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.test.ts
@@ -5,6 +5,10 @@ import type {
   BrowserNodeEvent,
   BrowserNodeHostApi
 } from "@tutti-os/browser-node";
+import type {
+  DesktopBrowserAutomationRequest,
+  DesktopBrowserAutomationResponse
+} from "@shared/contracts/ipc";
 import {
   registerWorkspaceBrowserLaunchHandler,
   type WorkspaceBrowserLaunchRequest
@@ -189,6 +193,71 @@ test("workspace app Browser features do not inherit Chrome Cookie import", () =>
   assert.equal(workspaceAppApi.discoverChromeCookieProfiles, undefined);
   assert.equal(workspaceAppApi.importChromeCookies, undefined);
   assert.equal(workspaceAppApi.cancelChromeCookieImport, undefined);
+});
+
+test("workspace browser service owns user automation tab lifecycle", () => {
+  let handleRequest = (_request: DesktopBrowserAutomationRequest): void =>
+    undefined;
+  const responses: DesktopBrowserAutomationResponse[] = [];
+  const browserApi = {
+    ...createBrowserNodeHostApi(),
+    onAutomationRequest(listener: typeof handleRequest) {
+      handleRequest = listener;
+      return () => {
+        handleRequest = () => undefined;
+      };
+    },
+    respondAutomationRequest(response: DesktopBrowserAutomationResponse) {
+      responses.push(response);
+    }
+  };
+  const service = createWorkspaceBrowserService({ browserApi });
+  const feature = createBrowserNodeFeature({ hostApi: browserApi });
+  const surfaceNodeId = "workspace-browser:instance-1";
+  const initial = feature.tabsStore.ensureSurface(
+    surfaceNodeId,
+    "https://example.com/"
+  );
+  service.setUserAutomationSurface({
+    feature,
+    workspaceId: "workspace-1"
+  });
+
+  handleRequest({
+    action: "create",
+    agentSessionId: "agent-1",
+    nodeId: initial.tabs[0]!.nodeId,
+    requestId: "create-1",
+    surfaceRole: "user",
+    url: "https://created.example/",
+    workspaceId: "workspace-1"
+  });
+  const createdNodeId = responses[0]?.ok ? responses[0].nodeId : null;
+  assert.ok(createdNodeId);
+  assert.equal(
+    feature.tabsStore
+      .getSurfaceState(surfaceNodeId)
+      ?.tabs.find((tab) => tab.nodeId === createdNodeId)?.defaultUrl,
+    "https://created.example/"
+  );
+
+  handleRequest({
+    action: "close",
+    agentSessionId: "agent-1",
+    nodeId: createdNodeId,
+    requestId: "close-1",
+    surfaceRole: "user",
+    url: null,
+    workspaceId: "workspace-1"
+  });
+  assert.equal(
+    feature.tabsStore.getSurfaceState(surfaceNodeId)?.tabs.length,
+    1
+  );
+  assert.deepEqual(
+    responses.map((response) => response.ok),
+    [true, true]
+  );
 });
 
 function browserNodeOwnsEvent(event: BrowserNodeEvent): boolean {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.ts
@@ -34,7 +34,9 @@ export function createWorkspaceBrowserService(
       Partial<
         Pick<
           DesktopBrowserApi,
-          "onAutomationRequest" | "respondAutomationRequest"
+          | "announceAutomationHostReady"
+          | "onAutomationRequest"
+          | "respondAutomationRequest"
         >
       >;
   } = {}
@@ -190,6 +192,10 @@ export function createWorkspaceBrowserService(
             });
           }
         }) ?? null;
+      input.browserApi?.announceAutomationHostReady?.({
+        surfaceRole: "user",
+        workspaceId
+      });
     }
   };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.ts
@@ -4,6 +4,8 @@ import type {
   BrowserNodeHostApi,
   BrowserNodeOpenUrlEvent
 } from "@tutti-os/browser-node";
+import { closeBrowserNodeTab } from "@tutti-os/browser-node";
+import type { DesktopBrowserApi } from "@preload/types";
 import { requestWorkspaceBrowserLaunch } from "../workspaceBrowserLaunchCoordinator.ts";
 
 export type WorkspaceBrowserEventMatcher = (event: BrowserNodeEvent) => boolean;
@@ -20,16 +22,27 @@ export interface WorkspaceBrowserService {
     input: WorkspaceBrowserFeatureHostApiInput
   ): BrowserNodeHostApi;
   ensureFeatureConnected(feature: BrowserNodeFeature): void;
+  setUserAutomationSurface(input: {
+    feature: BrowserNodeFeature;
+    workspaceId: string;
+  }): void;
 }
 
 export function createWorkspaceBrowserService(
   input: {
-    browserApi?: BrowserNodeHostApi;
+    browserApi?: BrowserNodeHostApi &
+      Partial<
+        Pick<
+          DesktopBrowserApi,
+          "onAutomationRequest" | "respondAutomationRequest"
+        >
+      >;
   } = {}
 ): WorkspaceBrowserService {
   const connectedFeatures = new WeakSet<BrowserNodeFeature>();
   const routes = new Set<WorkspaceBrowserEventRoute>();
   let disconnectBrowserEvents: (() => void) | null = null;
+  let disconnectUserAutomation: (() => void) | null = null;
 
   const ensureBrowserEventsConnected = () => {
     if (disconnectBrowserEvents) {
@@ -116,8 +129,74 @@ export function createWorkspaceBrowserService(
 
       feature.connect();
       connectedFeatures.add(feature);
+    },
+    setUserAutomationSurface({ feature, workspaceId }) {
+      disconnectUserAutomation?.();
+      disconnectUserAutomation =
+        input.browserApi?.onAutomationRequest?.((request) => {
+          if (
+            request.workspaceId !== workspaceId ||
+            request.surfaceRole !== "user"
+          ) {
+            return;
+          }
+          try {
+            const anchorNodeId = request.nodeId?.trim() ?? "";
+            const surfaceNodeId = resolveBrowserSurfaceNodeId(anchorNodeId);
+            const state = surfaceNodeId
+              ? feature.tabsStore.getSurfaceState(surfaceNodeId)
+              : null;
+            if (!surfaceNodeId || !state) {
+              throw new Error("No user Browser surface is available");
+            }
+            if (request.action === "create") {
+              const tab = feature.tabsStore.addTab(
+                surfaceNodeId,
+                request.url?.trim() || "about:blank"
+              );
+              input.browserApi?.respondAutomationRequest?.({
+                nodeId: tab.nodeId,
+                ok: true,
+                requestId: request.requestId
+              });
+              return;
+            }
+            const tab = state.tabs.find(
+              (candidate) => candidate.nodeId === anchorNodeId
+            );
+            if (!tab) {
+              throw new Error(
+                `User Browser page is unavailable: ${anchorNodeId}`
+              );
+            }
+            if (request.action === "select") {
+              feature.tabsStore.selectTab(surfaceNodeId, tab.id);
+            } else {
+              if (state.tabs.length === 1) {
+                throw new Error("The final user Browser page cannot be closed");
+              }
+              closeBrowserNodeTab(feature, surfaceNodeId, tab.id);
+            }
+            input.browserApi?.respondAutomationRequest?.({
+              nodeId: anchorNodeId,
+              ok: true,
+              requestId: request.requestId
+            });
+          } catch (error) {
+            input.browserApi?.respondAutomationRequest?.({
+              error: error instanceof Error ? error.message : String(error),
+              ok: false,
+              requestId: request.requestId
+            });
+          }
+        }) ?? null;
     }
   };
+}
+
+function resolveBrowserSurfaceNodeId(nodeId: string): string | null {
+  const separatorIndex = nodeId.lastIndexOf(":tab:");
+  return separatorIndex > 0 ? nodeId.slice(0, separatorIndex) : null;
 }
 
 interface WorkspaceBrowserEventRoute {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentBrowserSession.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentBrowserSession.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveStandaloneAgentBrowserSessionId } from "./standaloneAgentBrowserSession.ts";
+
+test("automation-managed Browser tabs stay bound to their resource session", () => {
+  assert.equal(
+    resolveStandaloneAgentBrowserSessionId({
+      currentAgentSessionId: "session-b",
+      resourceAgentSessionId: "session-a"
+    }),
+    "session-a"
+  );
+});
+
+test("user-created Browser tabs follow the current Agent session", () => {
+  assert.equal(
+    resolveStandaloneAgentBrowserSessionId({
+      currentAgentSessionId: "session-b"
+    }),
+    "session-b"
+  );
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentBrowserSession.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentBrowserSession.ts
@@ -1,0 +1,6 @@
+export function resolveStandaloneAgentBrowserSessionId(input: {
+  currentAgentSessionId: string | null;
+  resourceAgentSessionId?: string | null;
+}): string | null {
+  return input.resourceAgentSessionId ?? input.currentAgentSessionId;
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentBrowserToolPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentBrowserToolPanel.tsx
@@ -7,6 +7,7 @@ import { getDesktopChromeCookieImportPromptAdapter } from "../services/chromeCoo
 import { StandaloneAgentToolLoadingState } from "./StandaloneAgentToolLoadingState.tsx";
 
 export function StandaloneAgentBrowserToolPanel({
+  agentSessionId,
   appI18n,
   browserApi,
   elementContextCopy,
@@ -16,6 +17,7 @@ export function StandaloneAgentBrowserToolPanel({
   onBrowserElementError,
   workspaceId
 }: {
+  agentSessionId: string | null;
   appI18n: I18nRuntime<string>;
   browserApi: DesktopBrowserApi;
   elementContextCopy: {
@@ -35,6 +37,11 @@ export function StandaloneAgentBrowserToolPanel({
       data-standalone-agent-browser-surface="true"
     >
       <AgentToolBrowserPanel
+        automationTarget={{
+          agentSessionId,
+          surfaceRole: "agent",
+          workspaceId
+        }}
         browserApi={browserApi}
         chromeCookieImportPrompt={getDesktopChromeCookieImportPromptAdapter()}
         hidden={hidden}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentBrowserToolPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentBrowserToolPanel.tsx
@@ -1,5 +1,8 @@
-import type { ReactNode } from "react";
-import { AgentToolBrowserPanel } from "@tutti-os/agent-gui/workbench/tool-sidebar";
+import { useCallback, useState, type ReactNode } from "react";
+import {
+  AgentToolBrowserPanel,
+  type AgentToolBrowserController
+} from "@tutti-os/agent-gui/workbench/tool-sidebar";
 import { BrowserElementContextAction } from "@tutti-os/agent-gui/workbench/browser-element-context";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import type { DesktopBrowserApi } from "@preload/types";
@@ -9,16 +12,20 @@ import { StandaloneAgentToolLoadingState } from "./StandaloneAgentToolLoadingSta
 export function StandaloneAgentBrowserToolPanel({
   agentSessionId,
   appI18n,
+  automationManaged,
   browserApi,
   elementContextCopy,
   hidden,
   loadingLabel,
   onAppendBrowserElementMention,
   onBrowserElementError,
+  onControllerReady,
+  tabId,
   workspaceId
 }: {
   agentSessionId: string | null;
   appI18n: I18nRuntime<string>;
+  automationManaged: boolean;
   browserApi: DesktopBrowserApi;
   elementContextCopy: {
     cancel: string;
@@ -29,8 +36,20 @@ export function StandaloneAgentBrowserToolPanel({
   loadingLabel: string;
   onAppendBrowserElementMention: (mention: string) => void;
   onBrowserElementError: (message: string) => void;
+  onControllerReady?: (
+    tabId: string,
+    agentSessionId: string | null,
+    controller: AgentToolBrowserController | null
+  ) => void;
+  tabId: string;
   workspaceId: string;
 }): ReactNode {
+  const [stableAgentSessionId] = useState(agentSessionId);
+  const handleControllerReady = useCallback(
+    (controller: AgentToolBrowserController | null) =>
+      onControllerReady?.(tabId, stableAgentSessionId, controller),
+    [onControllerReady, stableAgentSessionId, tabId]
+  );
   return (
     <div
       className="relative h-full min-h-0 overflow-hidden"
@@ -38,18 +57,20 @@ export function StandaloneAgentBrowserToolPanel({
     >
       <AgentToolBrowserPanel
         automationTarget={{
-          agentSessionId,
+          agentSessionId: stableAgentSessionId,
           surfaceRole: "agent",
           workspaceId
         }}
         browserApi={browserApi}
         chromeCookieImportPrompt={getDesktopChromeCookieImportPromptAdapter()}
+        defaultUrl={automationManaged ? "about:blank" : undefined}
         hidden={hidden}
         i18n={appI18n}
         loadingFallback={
           <StandaloneAgentToolLoadingState label={loadingLabel} />
         }
         nodeIdPrefix="browser:standalone-agent-tool"
+        onControllerReady={handleControllerReady}
         navigationActions={
           <BrowserElementContextAction
             copy={elementContextCopy}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx
@@ -42,6 +42,7 @@ export type { StandaloneAgentFileOpenRequest } from "./StandaloneAgentToolSideba
 
 interface StandaloneAgentToolSidebarProps {
   activityService: WorkspaceAgentActivityService;
+  agentSessionId: string | null;
   appOpenId?: string | null;
   appI18n: I18nRuntime<string>;
   browserApi?: DesktopBrowserApi;
@@ -68,6 +69,7 @@ interface StandaloneAgentToolSidebarProps {
 
 export function StandaloneAgentToolSidebar({
   activityService,
+  agentSessionId,
   appOpenId = null,
   appI18n,
   browserApi,
@@ -288,6 +290,7 @@ export function StandaloneAgentToolSidebar({
         renderPanel={({ active, closeSidebar, tab }) => (
           <StandaloneAgentToolSidebarPanel
             active={active}
+            agentSessionId={agentSessionId}
             appI18n={appI18n}
             activityService={activityService}
             browserApi={browserApi}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx
@@ -283,6 +283,10 @@ export function StandaloneAgentToolSidebar({
         }
       })();
     });
+    browserApi.announceAutomationHostReady?.({
+      surfaceRole: "agent",
+      workspaceId
+    });
     return () => {
       disconnectAutomation();
       onToolHostReady(null);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx
@@ -10,6 +10,7 @@ import { selectWorkspaceAgentConsumerCounts } from "@tutti-os/agent-activity-cor
 import {
   AgentToolPanelIcon,
   AgentToolSidebar,
+  type AgentToolBrowserController,
   type AgentToolPanelDefinition,
   type AgentToolPanelId,
   type AgentToolSidebarCopy,
@@ -39,6 +40,8 @@ import { createStandaloneAgentToolHostGroup } from "./standaloneAgentToolWorkben
 import { useExternalStoreValue } from "./useExternalStoreValue.ts";
 
 export type { StandaloneAgentFileOpenRequest } from "./StandaloneAgentToolSidebarPanel.tsx";
+
+const browserControllerReadyTimeoutMs = 8_000;
 
 interface StandaloneAgentToolSidebarProps {
   activityService: WorkspaceAgentActivityService;
@@ -100,6 +103,20 @@ export function StandaloneAgentToolSidebar({
   const lastHandledIssueManagerOpenRequestRef = useRef<string | null>(null);
   const issueManagerOpenRequestTabIdRef = useRef<string | null>(null);
   const toolHostGroup = useMemo(createStandaloneAgentToolHostGroup, []);
+  const browserControllersRef = useRef(
+    new Map<string, { controller: AgentToolBrowserController; tabId: string }>()
+  );
+  const browserControllerWaitersRef = useRef(
+    new Map<
+      string,
+      Set<
+        (entry: {
+          controller: AgentToolBrowserController;
+          tabId: string;
+        }) => void
+      >
+    >()
+  );
 
   const sessionEngine = useMemo(
     () => activityService.getSessionEngine(workspaceId),
@@ -112,6 +129,9 @@ export function StandaloneAgentToolSidebar({
     () =>
       selectWorkspaceAgentConsumerCounts(sessionEngine.getSnapshot()).working
   );
+  const automationBrowserCount = mountedTabs.filter(
+    (tab) => tab.panel === "browser" && Boolean(tab.resourceId)
+  ).length;
   const panels = useMemo<readonly AgentToolPanelDefinition[]>(
     () => [
       { id: "files", label: i18n.t("workspace.agentGui.toolSidebar.files") },
@@ -151,10 +171,123 @@ export function StandaloneAgentToolSidebar({
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
   }, []);
+  const handleBrowserControllerReady = useCallback(
+    (
+      tabId: string,
+      browserAgentSessionId: string | null,
+      controller: AgentToolBrowserController | null
+    ) => {
+      const sessionId = browserAgentSessionId?.trim() ?? "";
+      if (!sessionId) return;
+      const existing = browserControllersRef.current.get(sessionId);
+      if (!controller) {
+        if (existing?.tabId === tabId) {
+          browserControllersRef.current.delete(sessionId);
+        }
+        return;
+      }
+      const entry = { controller, tabId };
+      browserControllersRef.current.set(sessionId, entry);
+      const waiters = browserControllerWaitersRef.current.get(sessionId);
+      if (!waiters) return;
+      browserControllerWaitersRef.current.delete(sessionId);
+      for (const resolve of waiters) resolve(entry);
+    },
+    []
+  );
+
   useEffect(() => {
     onToolHostReady(toolHostGroup.host);
-    return () => onToolHostReady(null);
-  }, [onToolHostReady, toolHostGroup]);
+    if (!browserApi) return () => onToolHostReady(null);
+    const waitForController = (
+      sessionId: string
+    ): Promise<{
+      controller: AgentToolBrowserController;
+      tabId: string;
+    }> => {
+      const existing = browserControllersRef.current.get(sessionId);
+      if (existing) return Promise.resolve(existing);
+      return new Promise((resolve, reject) => {
+        const waiters =
+          browserControllerWaitersRef.current.get(sessionId) ?? new Set();
+        const handleReady = (entry: {
+          controller: AgentToolBrowserController;
+          tabId: string;
+        }) => {
+          clearTimeout(timeout);
+          resolve(entry);
+        };
+        const timeout = setTimeout(() => {
+          waiters.delete(handleReady);
+          if (waiters.size === 0) {
+            browserControllerWaitersRef.current.delete(sessionId);
+          }
+          reject(new Error("Agent Browser surface did not become ready"));
+        }, browserControllerReadyTimeoutMs);
+        waiters.add(handleReady);
+        browserControllerWaitersRef.current.set(sessionId, waiters);
+      });
+    };
+    const disconnectAutomation = browserApi.onAutomationRequest((request) => {
+      if (
+        request.workspaceId !== workspaceId ||
+        request.surfaceRole !== "agent"
+      ) {
+        return;
+      }
+      void (async () => {
+        try {
+          const sessionId = request.agentSessionId?.trim() ?? "";
+          if (!sessionId) {
+            throw new Error("Agent Browser request requires an agent session");
+          }
+          if (request.action === "create") {
+            sidebarRef.current?.ensurePanel("browser", sessionId);
+          }
+          const entry = await waitForController(sessionId);
+          if (request.action === "create") {
+            const nodeId = entry.controller.createPage(request.url);
+            browserApi.respondAutomationRequest({
+              nodeId,
+              ok: true,
+              requestId: request.requestId
+            });
+            return;
+          }
+          const nodeId = request.nodeId?.trim() ?? "";
+          if (!nodeId) throw new Error("Browser page id is required");
+          if (request.action === "select") {
+            if (!entry.controller.selectPage(nodeId)) {
+              throw new Error(`Agent Browser page is unavailable: ${nodeId}`);
+            }
+          } else {
+            const result = entry.controller.closePage(nodeId);
+            if (result === "not-found") {
+              throw new Error(`Agent Browser page is unavailable: ${nodeId}`);
+            }
+            if (result === "last-page") {
+              sidebarRef.current?.closeTab(entry.tabId);
+            }
+          }
+          browserApi.respondAutomationRequest({
+            nodeId,
+            ok: true,
+            requestId: request.requestId
+          });
+        } catch (error) {
+          browserApi.respondAutomationRequest({
+            error: error instanceof Error ? error.message : String(error),
+            ok: false,
+            requestId: request.requestId
+          });
+        }
+      })();
+    });
+    return () => {
+      disconnectAutomation();
+      onToolHostReady(null);
+    };
+  }, [browserApi, onToolHostReady, toolHostGroup, workspaceId]);
 
   useEffect(() => {
     const appId = appOpenId?.trim() || null;
@@ -281,8 +414,16 @@ export function StandaloneAgentToolSidebar({
         copy={copy}
         mainContentMinWidthPx={mainContentMinWidthPx}
         panels={panels}
-        quickActionPanels={["tasks", "apps", "messages"]}
-        reminders={{ messages: messageCenterWorkingCount }}
+        quickActionPanels={[
+          ...(automationBrowserCount > 0 ? (["browser"] as const) : []),
+          "tasks",
+          "apps",
+          "messages"
+        ]}
+        reminders={{
+          browser: automationBrowserCount,
+          messages: messageCenterWorkingCount
+        }}
         renderHeader={renderHeader}
         renderLoading={() => (
           <StandaloneAgentToolLoadingState label={i18n.t("common.loading")} />
@@ -314,6 +455,7 @@ export function StandaloneAgentToolSidebar({
             workspaceId={workspaceId}
             onAppendBrowserElementMention={onAppendBrowserElementMention}
             onBrowserElementError={onBrowserElementError}
+            onBrowserControllerReady={handleBrowserControllerReady}
             onCloseMessageCenter={closeSidebar}
             onOpenMessageCenterChat={onOpenMessageCenterChat}
           />

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebarPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebarPanel.tsx
@@ -61,6 +61,7 @@ export interface StandaloneAgentFileOpenRequest {
 
 export function StandaloneAgentToolSidebarPanel({
   active,
+  agentSessionId,
   appI18n,
   activityService,
   browserApi,
@@ -80,6 +81,7 @@ export function StandaloneAgentToolSidebarPanel({
   workspaceId
 }: {
   active: boolean;
+  agentSessionId: string | null;
   appI18n: I18nRuntime<string>;
   activityService: WorkspaceAgentActivityService;
   browserApi?: DesktopBrowserApi;
@@ -192,6 +194,7 @@ export function StandaloneAgentToolSidebarPanel({
   if (panel === "browser") {
     return browserApi ? (
       <StandaloneAgentBrowserToolPanel
+        agentSessionId={agentSessionId}
         appI18n={appI18n}
         browserApi={browserApi}
         elementContextCopy={{

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebarPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebarPanel.tsx
@@ -10,6 +10,7 @@ import type { WorkspaceAgentActivityService } from "@renderer/features/workspace
 import type { DesktopBrowserApi } from "@preload/types";
 import type { useTranslation } from "@renderer/i18n";
 import type { StandaloneAgentIssueManagerOpenRequest } from "../services/standaloneAgentIssueManagerLaunch.ts";
+import { resolveStandaloneAgentBrowserSessionId } from "../services/standaloneAgentBrowserSession.ts";
 import { StandaloneAgentBrowserToolPanel } from "./StandaloneAgentBrowserToolPanel.tsx";
 import { StandaloneAgentToolLoadingState } from "./StandaloneAgentToolLoadingState.tsx";
 
@@ -201,7 +202,10 @@ export function StandaloneAgentToolSidebarPanel({
   if (panel === "browser") {
     return browserApi ? (
       <StandaloneAgentBrowserToolPanel
-        agentSessionId={agentSessionId}
+        agentSessionId={resolveStandaloneAgentBrowserSessionId({
+          currentAgentSessionId: agentSessionId,
+          resourceAgentSessionId: tab.resourceId
+        })}
         appI18n={appI18n}
         automationManaged={Boolean(tab.resourceId)}
         browserApi={browserApi}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebarPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebarPanel.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, type ReactNode } from "react";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import type { AgentToolTab } from "@tutti-os/agent-gui/workbench/tool-sidebar";
+import type { AgentToolBrowserController } from "@tutti-os/agent-gui/workbench/tool-sidebar";
 import type {
   WorkbenchContribution,
   WorkbenchHostHandle
@@ -74,6 +75,7 @@ export function StandaloneAgentToolSidebarPanel({
   messageCenterOpen,
   onAppendBrowserElementMention,
   onBrowserElementError,
+  onBrowserControllerReady,
   onCloseMessageCenter,
   onOpenMessageCenterChat,
   tab,
@@ -94,6 +96,11 @@ export function StandaloneAgentToolSidebarPanel({
   messageCenterOpen: boolean;
   onAppendBrowserElementMention: (mention: string) => void;
   onBrowserElementError: (message: string) => void;
+  onBrowserControllerReady?: (
+    tabId: string,
+    agentSessionId: string | null,
+    controller: AgentToolBrowserController | null
+  ) => void;
   onCloseMessageCenter: () => void;
   onOpenMessageCenterChat: (input: {
     agentSessionId: string;
@@ -196,6 +203,7 @@ export function StandaloneAgentToolSidebarPanel({
       <StandaloneAgentBrowserToolPanel
         agentSessionId={agentSessionId}
         appI18n={appI18n}
+        automationManaged={Boolean(tab.resourceId)}
         browserApi={browserApi}
         elementContextCopy={{
           cancel: i18n.t("workspace.agentGui.browserElementContext.cancel"),
@@ -207,6 +215,8 @@ export function StandaloneAgentToolSidebarPanel({
         workspaceId={workspaceId}
         onAppendBrowserElementMention={onAppendBrowserElementMention}
         onBrowserElementError={onBrowserElementError}
+        onControllerReady={onBrowserControllerReady}
+        tabId={tab.id}
       />
     ) : null;
   }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -689,6 +689,7 @@ export function StandaloneAgentWindow({
       >
         <StandaloneAgentToolSidebar
           activityService={workspaceAgentActivityService}
+          agentSessionId={nodeState.lastActiveAgentSessionId}
           appOpenId={openAppId}
           appI18n={toolWorkbench.appI18n}
           browserApi={desktopApi.browser}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.test.ts
@@ -140,6 +140,25 @@ test("standalone Agent tools load their OS node UI on demand", () => {
   );
 });
 
+test("standalone Agent automation keeps a session-owned background Browser surface", () => {
+  assert.match(
+    standaloneAgentToolSidebarAdapterSource,
+    /onAutomationRequest[\s\S]*?ensurePanel\("browser", sessionId\)/
+  );
+  assert.match(
+    standaloneAgentBrowserToolPanelSource,
+    /useState\(agentSessionId\)/
+  );
+  assert.match(
+    standaloneAgentBrowserToolPanelSource,
+    /defaultUrl=\{automationManaged \? "about:blank" : undefined\}/
+  );
+  assert.match(
+    standaloneAgentToolSidebarAdapterSource,
+    /browser: automationBrowserCount/
+  );
+});
+
 test("standalone Agent opens an empty right sidebar with the core tool picker", () => {
   assert.match(
     standaloneAgentToolSidebarSource,
@@ -163,7 +182,7 @@ test("standalone Agent opens an empty right sidebar with the core tool picker", 
 test("standalone Agent quick actions open the apps and messages panel tabs", () => {
   assert.match(
     standaloneAgentToolSidebarAdapterSource,
-    /quickActionPanels=\{\["tasks", "apps", "messages"\]\}/
+    /quickActionPanels=\{\[[\s\S]*?"tasks"[\s\S]*?"apps"[\s\S]*?"messages"/
   );
   assert.match(
     standaloneAgentToolSidebarToolbarSource,
@@ -265,7 +284,7 @@ test("standalone Agent restores the resize baseline after closing the empty pick
 test("standalone Agent toolbar exposes task management in the unified panel", () => {
   assert.match(
     standaloneAgentToolSidebarAdapterSource,
-    /quickActionPanels=\{\["tasks", "apps", "messages"\]\}/
+    /quickActionPanels=\{\[[\s\S]*?"tasks"[\s\S]*?"apps"[\s\S]*?"messages"/
   );
   assert.match(
     standaloneAgentToolSidebarToolbarSource,

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -152,6 +152,7 @@ export const desktopIpcChannels = {
   },
   browser: {
     activate: "browser:activate",
+    automationHostReady: "browser:automation-host-ready",
     automationRequest: "browser:automation-request",
     automationResponse: "browser:automation-response",
     capturePreview: "browser:capturePreview",
@@ -866,6 +867,11 @@ export interface DesktopBrowserAutomationRequest {
   requestId: string;
   surfaceRole: "agent" | "user";
   url: string | null;
+  workspaceId: string;
+}
+
+export interface DesktopBrowserAutomationHostReady {
+  surfaceRole: "agent" | "user";
   workspaceId: string;
 }
 

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -41,7 +41,8 @@ import type {
   BrowserNodeSetZoomFactorInput,
   BrowserNodeShowDevToolsContextMenuInput,
   BrowserNodeStopFindInPageInput,
-  BrowserNodeUnregisterGuestInput
+  BrowserNodeUnregisterGuestInput,
+  BrowserNodeUpdateAutomationTargetInput
 } from "@tutti-os/browser-node";
 import type {
   TuttiExternalAtQueryInput,
@@ -178,7 +179,8 @@ export const desktopIpcChannels = {
     setZoomFactor: "browser:setZoomFactor",
     showDevToolsContextMenu: "browser:showDevToolsContextMenu",
     stopFindInPage: "browser:stopFindInPage",
-    unregisterGuest: "browser:unregisterGuest"
+    unregisterGuest: "browser:unregisterGuest",
+    updateAutomationTarget: "browser:updateAutomationTarget"
   },
   dockPreviewCache: {
     read: "dock-preview-cache:read",
@@ -945,6 +947,8 @@ export interface DesktopInvokePayloadByChannel {
     .showDevToolsContextMenu]: BrowserNodeShowDevToolsContextMenuInput;
   [desktopIpcChannels.browser.stopFindInPage]: BrowserNodeStopFindInPageInput;
   [desktopIpcChannels.browser.unregisterGuest]: BrowserNodeUnregisterGuestInput;
+  [desktopIpcChannels.browser
+    .updateAutomationTarget]: BrowserNodeUpdateAutomationTargetInput;
   [desktopIpcChannels.dockPreviewCache.read]: DesktopReadDockPreviewInput;
   [desktopIpcChannels.dockPreviewCache.write]: DesktopWriteDockPreviewInput;
   [desktopIpcChannels.developer.clearLogs]: undefined;
@@ -1118,6 +1122,7 @@ export interface DesktopInvokeResultByChannel {
   [desktopIpcChannels.browser.showDevToolsContextMenu]: void;
   [desktopIpcChannels.browser.stopFindInPage]: void;
   [desktopIpcChannels.browser.unregisterGuest]: void;
+  [desktopIpcChannels.browser.updateAutomationTarget]: void;
   [desktopIpcChannels.dockPreviewCache.read]: string | null;
   [desktopIpcChannels.dockPreviewCache.write]: void;
   [desktopIpcChannels.developer.clearLogs]: ClearDeveloperLogsResult;

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -152,6 +152,8 @@ export const desktopIpcChannels = {
   },
   browser: {
     activate: "browser:activate",
+    automationRequest: "browser:automation-request",
+    automationResponse: "browser:automation-response",
     capturePreview: "browser:capturePreview",
     chooseDownloadDirectory: "browser:chooseDownloadDirectory",
     clearBrowsingData: "browser:clearBrowsingData",
@@ -856,6 +858,28 @@ export interface DesktopComputerUseRestartDriverResult {
   result: DesktopComputerUseActionResult;
   status: DesktopComputerUseStatus;
 }
+
+export interface DesktopBrowserAutomationRequest {
+  action: "create" | "select" | "close";
+  agentSessionId: string | null;
+  nodeId: string | null;
+  requestId: string;
+  surfaceRole: "agent" | "user";
+  url: string | null;
+  workspaceId: string;
+}
+
+export type DesktopBrowserAutomationResponse =
+  | {
+      nodeId: string | null;
+      ok: true;
+      requestId: string;
+    }
+  | {
+      error: string;
+      ok: false;
+      requestId: string;
+    };
 
 export interface DesktopInvokePayloadByChannel {
   [desktopIpcChannels.computerUse.checkStatus]: undefined;

--- a/docs/architecture/browser-node-package.md
+++ b/docs/architecture/browser-node-package.md
@@ -141,6 +141,14 @@ The Browser Node package owns:
 - the reusable macOS Chrome Stable Profile, SQLite snapshot, Keychain, and
   Cookie decryption adapter
 - default package i18n resources for generic browser behavior
+- an optional host-rendered Browser Home slot for empty tabs; the host owns
+  service discovery and product-specific shortcuts while the package owns
+  navigation back into the guest
+- Electron BrowserNode automation target registration, CDP-backed snapshot,
+  interaction, evaluation, navigation, and screenshot mechanics
+- per-Agent stable page selection and per-tab automation leases
+- an authenticated loopback automation endpoint that a daemon can select
+  explicitly instead of launching a second browser backend
 
 The host owns:
 
@@ -159,6 +167,42 @@ The host owns:
 - product authorization and host allowlist policy
 - daemon or server clients
 - any business mutation triggered by a guest page
+- which BrowserNode surfaces are visible to automation, how Agent Browser tabs
+  are created/selected/closed, and when an Agent lease is released
+- automation network authorization; listing may expose a restricted page's
+  title and URL, but inspect/control calls must fail closed
+
+## Browser automation projection
+
+BrowserNode is the desktop browser authority. A host opts individual tabs into
+automation by attaching metadata with the workspace, surface role (`user` or
+`agent`), optional Agent session, selected state, and focus state. Website App
+guests do not attach this metadata and therefore never enter the automation
+registry.
+
+The registry exposes User Browser tabs in the current workspace plus Agent
+Browser tabs owned by the calling Agent session. The most recently focused
+selected tab is the initial target; an explicit page selection remains stable
+for later calls. A tab has one time-limited Agent automation lease, while user
+input remains available through Electron throughout the lease.
+
+Desktop hosts publish the registry over a versioned HTTP endpoint bound to
+`127.0.0.1` with a random bearer token stored in a mode-`0600` listener-info
+file. The managed daemon receives that file path explicitly. When configured,
+it must fail if the BrowserNode host is unavailable and must not fall back to a
+separate Chrome process. A daemon without the configuration remains the
+explicit headless mode and may own managed Chrome.
+
+Network authorization runs before leasing or operating a tab. The standard
+desktop policy allows public HTTP/HTTPS destinations and loopback sandbox
+previews, while rejecting private, link-local, metadata, multicast, and local
+network targets. `list_pages` remains metadata-only so an Agent can report the
+title and URL of a restricted page without reading its contents.
+
+`BrowserNode` also accepts a `renderHome` slot. The package shows it only for
+an empty/`about:blank` tab and supplies a package-owned navigation callback.
+Hosts can use the slot for live sandbox service-port shortcuts without moving
+runtime discovery or product UI into this package.
 
 Browser data actions are scoped through the registered guest's Electron
 session. Clearing data therefore affects the active Browser Node partition:

--- a/docs/architecture/browser-node-package.md
+++ b/docs/architecture/browser-node-package.md
@@ -186,7 +186,10 @@ The registry exposes User Browser tabs in the current workspace plus Agent
 Browser tabs owned by the calling Agent session. The most recently focused
 selected tab is the initial target; an explicit page selection remains stable
 for later calls. A tab has one time-limited Agent automation lease, while user
-input remains available through Electron throughout the lease.
+input remains available through Electron throughout the lease. Releasing an
+Agent is a barrier: already-queued target work completes before its request
+guard is disabled, retained Agent pages are then closed, and later calls for
+that Agent session are rejected.
 
 Desktop hosts publish the registry over a versioned HTTP endpoint bound to
 `127.0.0.1` with a random bearer token stored in a mode-`0600` listener-info
@@ -195,23 +198,30 @@ it must fail if the BrowserNode host is unavailable and must not fall back to a
 separate Chrome process. A daemon without the configuration remains the
 explicit headless mode and may own managed Chrome.
 
-The Desktop renderer owns page lifecycle. Main sends internal
-create/select/close requests only to the registered workspace or Agent window,
-and accepts a response only from that same renderer. Agent requests ensure a
-session-keyed Browser tool surface without opening the sidebar or taking focus;
-the header exposes that retained surface, and switching the active conversation
-does not rebind it to another session. Deleting an Agent session releases its
-leases and closes its retained Agent Browser surface through the same path.
+The Desktop renderer owns page lifecycle. A renderer announces readiness only
+for its main-verified workspace and surface role. Main records the exact
+renderer that created each page, sends later select/close requests to that
+owner, and accepts a response only from the renderer that received the request.
+If no Agent renderer exists, Desktop starts one hidden without taking focus and
+waits for its readiness before creating the page. Agent Browser tabs are keyed
+by their resource Agent session; switching the window's active conversation
+does not rebind retained tabs to another session. Deleting an Agent session
+releases its leases and closes its retained Agent Browser surface through the
+same path.
 
-Network authorization runs before leasing or creating a tab. While leased,
-CDP request interception applies the same policy to main-frame redirects,
-subresources, and script-initiated requests. The standard policy permits public
-HTTP/HTTPS destinations while rejecting private, link-local, metadata,
-multicast, and local-network targets. Loopback is denied by default; a
-virtualized host may enable it only after its product-owned preview resolver
-maps the URL to the caller's sandbox instead of host localhost. `list_pages`
-remains metadata-only so an Agent can report a restricted page's title and URL
-without reading its contents.
+Network authorization runs before leasing or creating a tab. `new_page`
+creates only `about:blank`, attaches CDP request interception, and then loads
+the requested URL. The same policy therefore covers the initial document,
+main-frame redirects, subresources, and script-initiated requests. For an
+attached target, hostname checks use that target's Chromium Session resolver,
+keeping policy resolution in the browser network context that will make the
+request. The standard policy permits public HTTP/HTTPS destinations while
+rejecting private, link-local, metadata, multicast, and local-network targets.
+Loopback is denied by default; a virtualized host may permit an exact URL only
+through the trusted `isLoopbackUrlRouted` capability after its product-owned
+preview router maps the URL to the caller's sandbox instead of host localhost.
+`list_pages` remains metadata-only so an Agent can report a restricted page's
+title and URL without reading its contents.
 
 `BrowserNode` also accepts a `renderHome` slot. The package shows it only for
 an empty/`about:blank` tab and supplies a package-owned navigation callback.

--- a/docs/architecture/browser-node-package.md
+++ b/docs/architecture/browser-node-package.md
@@ -147,6 +147,8 @@ The Browser Node package owns:
 - Electron BrowserNode automation target registration, CDP-backed snapshot,
   interaction, evaluation, navigation, and screenshot mechanics
 - per-Agent stable page selection and per-tab automation leases
+- per-target command serialization, navigation-time snapshot invalidation, and
+  request interception for redirects and subresources while a lease is active
 - an authenticated loopback automation endpoint that a daemon can select
   explicitly instead of launching a second browser backend
 
@@ -193,11 +195,23 @@ it must fail if the BrowserNode host is unavailable and must not fall back to a
 separate Chrome process. A daemon without the configuration remains the
 explicit headless mode and may own managed Chrome.
 
-Network authorization runs before leasing or operating a tab. The standard
-desktop policy allows public HTTP/HTTPS destinations and loopback sandbox
-previews, while rejecting private, link-local, metadata, multicast, and local
-network targets. `list_pages` remains metadata-only so an Agent can report the
-title and URL of a restricted page without reading its contents.
+The Desktop renderer owns page lifecycle. Main sends internal
+create/select/close requests only to the registered workspace or Agent window,
+and accepts a response only from that same renderer. Agent requests ensure a
+session-keyed Browser tool surface without opening the sidebar or taking focus;
+the header exposes that retained surface, and switching the active conversation
+does not rebind it to another session. Deleting an Agent session releases its
+leases and closes its retained Agent Browser surface through the same path.
+
+Network authorization runs before leasing or creating a tab. While leased,
+CDP request interception applies the same policy to main-frame redirects,
+subresources, and script-initiated requests. The standard policy permits public
+HTTP/HTTPS destinations while rejecting private, link-local, metadata,
+multicast, and local-network targets. Loopback is denied by default; a
+virtualized host may enable it only after its product-owned preview resolver
+maps the URL to the caller's sandbox instead of host localhost. `list_pages`
+remains metadata-only so an Agent can report a restricted page's title and URL
+without reading its contents.
 
 `BrowserNode` also accepts a `renderHome` slot. The package shows it only for
 an empty/`about:blank` tab and supplies a package-owned navigation callback.

--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.tsx
@@ -3,6 +3,7 @@ import {
   createBrowserNodeFeature,
   isBrowserNodeSurfaceEvent,
   type BrowserNodeChromeImportPromptAdapter,
+  type BrowserNodeAutomationTargetMetadata,
   type BrowserNodeFeature,
   type BrowserNodeHostApi,
   type BrowserNodeSessionMode
@@ -18,6 +19,10 @@ const LazyBrowserNode = lazy(() =>
 export const agentToolBrowserDefaultUrl = "https://www.google.com/";
 
 export interface AgentToolBrowserPanelProps {
+  automationTarget?: Omit<
+    BrowserNodeAutomationTargetMetadata,
+    "focused" | "selected" | "surfaceId" | "tabId"
+  > | null;
   browserApi: BrowserNodeHostApi;
   chromeCookieImportPrompt?: BrowserNodeChromeImportPromptAdapter;
   defaultUrl?: string;
@@ -32,6 +37,7 @@ export interface AgentToolBrowserPanelProps {
 }
 
 export function AgentToolBrowserPanel({
+  automationTarget = null,
   browserApi,
   chromeCookieImportPrompt,
   defaultUrl = agentToolBrowserDefaultUrl,
@@ -64,6 +70,9 @@ export function AgentToolBrowserPanel({
     >
       <Suspense fallback={loadingFallback}>
         <LazyBrowserNode
+          automationTarget={
+            automationTarget ? { ...automationTarget, focused: !hidden } : null
+          }
           defaultUrl={defaultUrl}
           feature={feature}
           hidden={hidden}

--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.tsx
@@ -1,5 +1,13 @@
-import { lazy, Suspense, useMemo, useState, type ReactNode } from "react";
 import {
+  lazy,
+  Suspense,
+  useCallback,
+  useMemo,
+  useState,
+  type ReactNode
+} from "react";
+import {
+  closeBrowserNodeTab,
   createBrowserNodeFeature,
   isBrowserNodeSurfaceEvent,
   type BrowserNodeChromeImportPromptAdapter,
@@ -31,9 +39,18 @@ export interface AgentToolBrowserPanelProps {
   loadingFallback?: ReactNode;
   navigationActions?: ReactNode;
   nodeIdPrefix?: string;
+  onControllerReady?: (controller: AgentToolBrowserController | null) => void;
   profileId?: string | null;
   sessionMode?: BrowserNodeSessionMode;
   sessionPartition?: string | null;
+}
+
+export interface AgentToolBrowserController {
+  closePage(nodeId: string): "closed" | "last-page" | "not-found";
+  createPage(url?: string | null): string;
+  ownsPage(nodeId: string): boolean;
+  selectPage(nodeId: string): boolean;
+  surfaceNodeId: string;
 }
 
 export function AgentToolBrowserPanel({
@@ -46,6 +63,7 @@ export function AgentToolBrowserPanel({
   loadingFallback = null,
   navigationActions,
   nodeIdPrefix = "browser:agent-tool",
+  onControllerReady,
   profileId = null,
   sessionMode = "shared",
   sessionPartition = null
@@ -61,12 +79,64 @@ export function AgentToolBrowserPanel({
       }),
     [browserApi, chromeCookieImportPrompt, i18n, nodeId]
   );
+  const controller = useMemo<AgentToolBrowserController>(() => {
+    const getPage = (pageNodeId: string) => {
+      const state = feature.tabsStore.getSurfaceState(nodeId);
+      const tab = state?.tabs.find(
+        (candidate) => candidate.nodeId === pageNodeId
+      );
+      return state && tab ? { state, tab } : null;
+    };
+    return {
+      closePage(pageNodeId) {
+        const page = getPage(pageNodeId);
+        if (!page) return "not-found";
+        if (page.state.tabs.length === 1) return "last-page";
+        closeBrowserNodeTab(feature, nodeId, page.tab.id);
+        return "closed";
+      },
+      createPage(url) {
+        const resolvedUrl = url?.trim() || "about:blank";
+        const state = feature.tabsStore.ensureSurface(nodeId, defaultUrl);
+        const activeTab = state.tabs.find(
+          (tab) => tab.id === state.activeTabId
+        );
+        const activeRuntime = activeTab
+          ? feature.runtimeStore.getNodeState(activeTab.nodeId)
+          : null;
+        if (
+          state.tabs.length === 1 &&
+          activeTab?.defaultUrl === "about:blank" &&
+          !activeRuntime?.url
+        ) {
+          feature.tabsStore.syncDefaultUrl(nodeId, resolvedUrl);
+          return activeTab.nodeId;
+        }
+        return feature.tabsStore.addTab(nodeId, resolvedUrl).nodeId;
+      },
+      ownsPage: (pageNodeId) => getPage(pageNodeId) !== null,
+      selectPage(pageNodeId) {
+        const page = getPage(pageNodeId);
+        if (!page) return false;
+        feature.tabsStore.selectTab(nodeId, page.tab.id);
+        return true;
+      },
+      surfaceNodeId: nodeId
+    };
+  }, [defaultUrl, feature, nodeId]);
+
+  const bindController = useCallback(
+    (node: HTMLDivElement | null) =>
+      onControllerReady?.(node ? controller : null),
+    [controller, onControllerReady]
+  );
 
   return (
     <div
       className="relative h-full min-h-0 overflow-hidden"
       data-agent-tool-browser-surface="true"
       data-agent-tool-browser-surface-id={nodeId}
+      ref={bindController}
     >
       <Suspense fallback={loadingFallback}>
         <LazyBrowserNode

--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolSidebar.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolSidebar.tsx
@@ -26,6 +26,7 @@ export interface AgentToolSidebarHandle {
   addPanel(panel: AgentToolPanelId, resourceId?: string): string | null;
   close(): void;
   closeTab(tabId: string): void;
+  ensurePanel(panel: AgentToolPanelId, resourceId?: string): string | null;
   openPanel(panel: AgentToolPanelId, resourceId?: string): string | null;
 }
 
@@ -115,6 +116,7 @@ export const AgentToolSidebar = forwardRef<
     closePanel,
     closePanelTab,
     contentReadyTabIds,
+    ensurePanel,
     handleSidebarTransitionEnd,
     isEmptySidebar,
     isEmptySidebarClosing,
@@ -146,9 +148,10 @@ export const AgentToolSidebar = forwardRef<
       addPanel,
       close: closePanel,
       closeTab: closePanelTab,
+      ensurePanel,
       openPanel
     }),
-    [addPanel, closePanel, closePanelTab, openPanel]
+    [addPanel, closePanel, closePanelTab, ensurePanel, openPanel]
   );
 
   const isHostHeaderDrag = headerDrag?.mode === "host";

--- a/packages/agent/gui/workbench/tool-sidebar/model.test.ts
+++ b/packages/agent/gui/workbench/tool-sidebar/model.test.ts
@@ -73,6 +73,36 @@ describe("agent tool sidebar model", () => {
     ).toBe(620);
   });
 
+  it("ensures a background panel without changing the active tab", () => {
+    let state = createAgentToolSidebarState({
+      activePanel: "files",
+      activeTabId: "files:first",
+      mountedTabs: [{ id: "files:first", panel: "files" }]
+    });
+    state = reduceAgentToolSidebarState(state, {
+      panel: "browser",
+      resourceId: "agent-1",
+      tabId: "browser:agent-1",
+      type: "ensure-panel"
+    });
+
+    expect(state.activePanel).toBe("files");
+    expect(state.activeTabId).toBe("files:first");
+    expect(state.mountedTabs).toContainEqual({
+      id: "browser:agent-1",
+      panel: "browser",
+      resourceId: "agent-1"
+    });
+
+    const repeated = reduceAgentToolSidebarState(state, {
+      panel: "browser",
+      resourceId: "agent-1",
+      tabId: "browser:duplicate",
+      type: "ensure-panel"
+    });
+    expect(repeated).toBe(state);
+  });
+
   it("transfers expansion while remembering both panel widths", () => {
     expect(
       resolveAgentToolPanelExpansionTransfer({

--- a/packages/agent/gui/workbench/tool-sidebar/model.ts
+++ b/packages/agent/gui/workbench/tool-sidebar/model.ts
@@ -86,7 +86,7 @@ export type AgentToolSidebarAction =
       panel: AgentToolPanelId;
       resourceId?: string;
       tabId: string;
-      type: "open-panel" | "add-panel";
+      type: "open-panel" | "add-panel" | "ensure-panel";
     }
   | { tabId: string; type: "activate-tab" | "close-tab" }
   | { type: "close" };
@@ -148,6 +148,14 @@ export function reduceAgentToolSidebarState(
     }
     case "add-panel":
       return addTab(state, action);
+    case "ensure-panel": {
+      const existing = findLastTab(
+        state.mountedTabs,
+        action.panel,
+        action.resourceId
+      );
+      return existing ? state : addTab(state, action, { activate: false });
+    }
     case "open-panel": {
       const existing = findLastTab(
         state.mountedTabs,
@@ -167,16 +175,18 @@ function addTab(
     panel: AgentToolPanelId;
     resourceId?: string;
     tabId: string;
-  }
+  },
+  options: { activate?: boolean } = {}
 ): AgentToolSidebarState {
   const nextTab: AgentToolTab = {
     id: tab.tabId,
     panel: tab.panel,
     ...(tab.resourceId ? { resourceId: tab.resourceId } : {})
   };
+  const activate = options.activate !== false;
   return {
-    activePanel: nextTab.panel,
-    activeTabId: nextTab.id,
+    activePanel: activate ? nextTab.panel : state.activePanel,
+    activeTabId: activate ? nextTab.id : state.activeTabId,
     mountedTabs: state.mountedTabs.some(
       (candidate) => candidate.id === nextTab.id
     )

--- a/packages/agent/gui/workbench/tool-sidebar/useAgentToolSidebarController.ts
+++ b/packages/agent/gui/workbench/tool-sidebar/useAgentToolSidebarController.ts
@@ -194,6 +194,30 @@ export function useAgentToolSidebarController({
     ]
   );
 
+  const ensurePanel = useCallback(
+    (panel: AgentToolPanelId, resourceId?: string) => {
+      if (!panelIds.has(panel)) return null;
+      const existing = state.mountedTabs.find(
+        (tab) =>
+          tab.panel === panel && (tab.resourceId ?? undefined) === resourceId
+      );
+      if (existing) return existing.id;
+      const tabId = createToolTabId(panel);
+      const action = {
+        panel,
+        resourceId,
+        tabId,
+        type: "ensure-panel"
+      } as const;
+      const nextState = reduceAgentToolSidebarState(state, action);
+      dispatch(action);
+      onTabsChange?.(nextState.mountedTabs);
+      markContentReady(tabId);
+      return tabId;
+    },
+    [markContentReady, onTabsChange, panelIds, state]
+  );
+
   const closePanelTab = useCallback(
     (tabId: string) => {
       const closingIndex = state.mountedTabs.findIndex(
@@ -341,6 +365,7 @@ export function useAgentToolSidebarController({
     closePanel,
     closePanelTab,
     contentReadyTabIds,
+    ensurePanel,
     handleSidebarTransitionEnd,
     isEmptySidebar,
     isEmptySidebarClosing,

--- a/packages/agent/runtimeprep/skill_templates/browser-use.md
+++ b/packages/agent/runtimeprep/skill_templates/browser-use.md
@@ -14,10 +14,13 @@ Drive the browser only through `{{CLI_COMMAND}} browser`. The Tutti daemon owns 
 1. Navigate when needed: `{{CLI_COMMAND}} browser navigate --url <url>`.
 2. Read the current page with `{{CLI_COMMAND}} browser snapshot`; use returned `uid` values for interactions.
 3. Act with `{{CLI_COMMAND}} browser click --uid <uid>` or `{{CLI_COMMAND}} browser fill --uid <uid> --value <text>`.
-4. Use `{{CLI_COMMAND}} browser eval --script '() => document.title'` for page JS, `{{CLI_COMMAND}} browser screenshot` for a PNG path, and `{{CLI_COMMAND}} browser list-pages` to inspect open pages.
-5. Re-run `snapshot` after navigation or UI-changing actions because `uid` values can change.
+4. Use `{{CLI_COMMAND}} browser list-pages` to inspect the User Browser and your Agent Browser tabs. Select a stable target with `{{CLI_COMMAND}} browser select-page --page-id <id>` when needed.
+5. Create an Agent Browser tab with `{{CLI_COMMAND}} browser new-page --url <url>` and close a page you own with `{{CLI_COMMAND}} browser close-page --page-id <id>`.
+6. Use `{{CLI_COMMAND}} browser eval --script '() => document.title'` for page JS and `{{CLI_COMMAND}} browser screenshot` for a PNG path.
+7. Re-run `snapshot` after navigation or UI-changing actions because `uid` values can change.
 
 ## Guardrails
 
-- The browser session is shared per workspace; do not open or close it yourself.
-- If the daemon reports startup failure or missing Chrome, report that error instead of falling back to shell/browser tools.
+- The desktop browser session includes visible in-app BrowserNode tabs for the current workspace. Website App tabs are outside this automation scope.
+- User Browser tabs may contain the user's active work. Read or modify them only when that is required by the request.
+- If the desktop BrowserNode host or the headless managed Chrome backend is unavailable, report that error instead of falling back to shell/browser tools.

--- a/packages/browser/workbench-node/README.md
+++ b/packages/browser/workbench-node/README.md
@@ -93,3 +93,22 @@ dock label, matches Browser nodes back to the dock entry, and restores popup
 title, URL subtitle, and preview capture from the Browser runtime state.
 Hosts that want the package-owned default dock visual can import it explicitly
 from `@tutti-os/browser-node/assets/workspace-dock-website.png`.
+
+## Browser Home and Agent automation
+
+`BrowserNode` accepts an optional `renderHome` function for empty tabs. The
+function receives the tab node id and a `navigate(url)` callback, allowing a
+host to render live sandbox ports or other product-owned shortcuts without
+forking the Browser surface.
+
+Electron hosts may attach `automationTarget` metadata to User Browser and
+Agent Browser surfaces. The package registry then exposes the current
+workspace's User tabs and only the calling Agent session's Agent tabs, with
+stable page selection and per-tab leases. Website Apps remain excluded unless
+a host explicitly opts them in.
+
+`createBrowserNodeAutomationServer` publishes the registry on authenticated
+loopback and writes a private listener-info file for an explicitly configured
+daemon. `createBrowserNodeAutomationNetworkAuthorizer` provides the standard
+public HTTP/HTTPS plus loopback policy and blocks private, link-local, metadata,
+multicast, and local-network pages from inspect/control calls.

--- a/packages/browser/workbench-node/README.md
+++ b/packages/browser/workbench-node/README.md
@@ -105,14 +105,22 @@ Electron hosts may attach `automationTarget` metadata to User Browser and
 Agent Browser surfaces. The package registry then exposes the current
 workspace's User tabs and only the calling Agent session's Agent tabs, with
 stable page selection and per-tab leases. Website Apps remain excluded unless
-a host explicitly opts them in.
+a host explicitly opts them in. `new_page` is created as `about:blank`; the
+package attaches request interception before navigating to the requested URL,
+so the initial document, redirects, and subresources all cross the same guard.
+Agent release is a lifecycle barrier: queued target work drains before guards
+are disabled and retained Agent pages are closed, and later calls fail closed.
 
 `createBrowserNodeAutomationServer` publishes the registry on authenticated
 loopback and writes a private listener-info file for an explicitly configured
 daemon. `createBrowserNodeAutomationNetworkAuthorizer` provides the standard
 public HTTP/HTTPS policy and blocks private, link-local, metadata, multicast,
 and local-network pages from inspect/control calls. Loopback fails closed by
-default; hosts may enable it only after supplying sandbox-owned preview
-routing. Hosts should also install the authorizer as the registry's
-`authorizeRequest` callback so redirects, subresources, and script-initiated
-requests remain guarded for the lifetime of an automation lease.
+default; hosts may permit a loopback URL only through the
+`isLoopbackUrlRouted` capability after sandbox-owned preview routing has
+accepted that exact URL. For registered targets, authorization resolves host
+names through the target's Chromium session rather than an unrelated process
+resolver. Hosts should also install the authorizer as the registry's
+`authorizeRequest` callback so the initial navigation, redirects,
+subresources, and script-initiated requests remain guarded for the lifetime of
+an automation lease.

--- a/packages/browser/workbench-node/README.md
+++ b/packages/browser/workbench-node/README.md
@@ -110,5 +110,9 @@ a host explicitly opts them in.
 `createBrowserNodeAutomationServer` publishes the registry on authenticated
 loopback and writes a private listener-info file for an explicitly configured
 daemon. `createBrowserNodeAutomationNetworkAuthorizer` provides the standard
-public HTTP/HTTPS plus loopback policy and blocks private, link-local, metadata,
-multicast, and local-network pages from inspect/control calls.
+public HTTP/HTTPS policy and blocks private, link-local, metadata, multicast,
+and local-network pages from inspect/control calls. Loopback fails closed by
+default; hosts may enable it only after supplying sandbox-owned preview
+routing. Hosts should also install the authorizer as the registry's
+`authorizeRequest` callback so redirects, subresources, and script-initiated
+requests remain guarded for the lifetime of an automation lease.

--- a/packages/browser/workbench-node/src/core/index.ts
+++ b/packages/browser/workbench-node/src/core/index.ts
@@ -40,6 +40,8 @@ export {
 } from "./session.ts";
 export type {
   BrowserNodeActivationInput,
+  BrowserNodeAutomationSurfaceRole,
+  BrowserNodeAutomationTargetMetadata,
   BrowserNodeClosedEvent,
   BrowserNodeContextMenuPoint,
   BrowserNodeCookieImportResult,
@@ -78,5 +80,6 @@ export type {
   BrowserNodeShowDevToolsContextMenuInput,
   BrowserNodeStateEvent,
   BrowserNodeStopFindInPageInput,
-  BrowserNodeUnregisterGuestInput
+  BrowserNodeUnregisterGuestInput,
+  BrowserNodeUpdateAutomationTargetInput
 } from "./types.ts";

--- a/packages/browser/workbench-node/src/core/tabsStore.test.ts
+++ b/packages/browser/workbench-node/src/core/tabsStore.test.ts
@@ -51,3 +51,10 @@ test("browser tabs isolate surfaces and return all tabs on removal", () => {
   assert.equal(store.getActiveNodeId("browser:one"), "browser:one");
   assert.equal(store.getActiveNodeId("browser:two"), "browser:two:tab:1");
 });
+
+test("browser tabs can create an automation page at a requested URL", () => {
+  const store = createBrowserNodeTabsStore();
+  store.ensureSurface("browser:one", "about:blank");
+  const tab = store.addTab("browser:one", "https://example.com/");
+  assert.equal(tab.defaultUrl, "https://example.com/");
+});

--- a/packages/browser/workbench-node/src/core/tabsStore.ts
+++ b/packages/browser/workbench-node/src/core/tabsStore.ts
@@ -10,7 +10,7 @@ export interface BrowserNodeTabsState {
 }
 
 export interface BrowserNodeTabsStore {
-  addTab(surfaceNodeId: string): BrowserNodeTab;
+  addTab(surfaceNodeId: string, defaultUrl?: string): BrowserNodeTab;
   closeTab(surfaceNodeId: string, tabId: string): BrowserNodeTab | null;
   ensureSurface(
     surfaceNodeId: string,
@@ -36,11 +36,14 @@ export function createBrowserNodeTabsStore(): BrowserNodeTabsStore {
     }
   };
 
-  const createTab = (surfaceNodeId: string): BrowserNodeTab => {
+  const createTab = (
+    surfaceNodeId: string,
+    defaultUrl = defaultUrls.get(surfaceNodeId) ?? "about:blank"
+  ): BrowserNodeTab => {
     const sequence = nextSequences.get(surfaceNodeId) ?? 1;
     nextSequences.set(surfaceNodeId, sequence + 1);
     return {
-      defaultUrl: defaultUrls.get(surfaceNodeId) ?? "about:blank",
+      defaultUrl,
       id: `tab-${sequence}`,
       nodeId: `${surfaceNodeId}:tab:${sequence}`
     };
@@ -66,14 +69,14 @@ export function createBrowserNodeTabsStore(): BrowserNodeTabsStore {
   };
 
   return {
-    addTab(surfaceNodeId) {
+    addTab(surfaceNodeId, defaultUrl) {
       const current = states.get(surfaceNodeId);
       if (!current) {
         throw new Error(
           `Browser tab surface is not initialized: ${surfaceNodeId}`
         );
       }
-      const tab = createTab(surfaceNodeId);
+      const tab = createTab(surfaceNodeId, defaultUrl);
       states.set(surfaceNodeId, {
         activeTabId: tab.id,
         tabs: [...current.tabs, tab]

--- a/packages/browser/workbench-node/src/core/types.ts
+++ b/packages/browser/workbench-node/src/core/types.ts
@@ -139,6 +139,7 @@ export interface BrowserNodePrepareSessionInput {
 }
 
 export interface BrowserNodeRegisterGuestInput {
+  automationTarget?: BrowserNodeAutomationTargetMetadata | null;
   navigationPolicy?: BrowserNodeNavigationPolicy | null;
   nodeId: string;
   profileId: string | null;
@@ -146,6 +147,22 @@ export interface BrowserNodeRegisterGuestInput {
   sessionPartition?: string | null;
   url?: string;
   webContentsId: number;
+}
+
+export type BrowserNodeAutomationSurfaceRole = "agent" | "user";
+
+export interface BrowserNodeAutomationTargetMetadata {
+  agentSessionId?: string | null;
+  focused?: boolean;
+  selected: boolean;
+  surfaceId: string;
+  surfaceRole: BrowserNodeAutomationSurfaceRole;
+  tabId: string | null;
+  workspaceId: string;
+}
+
+export interface BrowserNodeUpdateAutomationTargetInput extends BrowserNodeNodeIdInput {
+  automationTarget: BrowserNodeAutomationTargetMetadata;
 }
 
 export interface BrowserNodeUnregisterGuestInput {
@@ -365,4 +382,7 @@ export interface BrowserNodeHostApi {
   ): Promise<void>;
   stopFindInPage?(payload: BrowserNodeStopFindInPageInput): Promise<void>;
   unregisterGuest(payload: BrowserNodeUnregisterGuestInput): Promise<void>;
+  updateAutomationTarget?(
+    payload: BrowserNodeUpdateAutomationTargetInput
+  ): Promise<void>;
 }

--- a/packages/browser/workbench-node/src/core/webviewController.ts
+++ b/packages/browser/workbench-node/src/core/webviewController.ts
@@ -2,6 +2,7 @@ import type { BrowserNodeFeature } from "./feature.ts";
 import { browserNodeGuestInteractionHostChannel } from "./guestInteraction.ts";
 import { resolveBrowserSessionPartition } from "./session.ts";
 import type {
+  BrowserNodeAutomationTargetMetadata,
   BrowserNodeLifecycle,
   BrowserNodeNavigationPolicy,
   BrowserNodeSessionMode
@@ -36,6 +37,7 @@ export interface BrowserNodeWebviewController {
 }
 
 interface BrowserNodeWebviewControllerContext {
+  automationTarget?: BrowserNodeAutomationTargetMetadata | null;
   feature: BrowserNodeFeature;
   initialUrl: string;
   lifecycle: BrowserNodeLifecycle;
@@ -77,6 +79,7 @@ const pendingUnregisterTimersByNodeId = new Map<
 >();
 
 export function acquireBrowserNodeWebviewController(input: {
+  automationTarget?: BrowserNodeAutomationTargetMetadata | null;
   feature: BrowserNodeFeature;
   initialUrl: string;
   lifecycle: BrowserNodeLifecycle;
@@ -91,6 +94,7 @@ export function acquireBrowserNodeWebviewController(input: {
   const entry =
     existing ??
     createBrowserNodeWebviewControllerEntry({
+      automationTarget: input.automationTarget,
       feature: input.feature,
       initialUrl: input.initialUrl,
       lifecycle: input.lifecycle,
@@ -103,6 +107,7 @@ export function acquireBrowserNodeWebviewController(input: {
     });
 
   entry.context = {
+    automationTarget: input.automationTarget,
     feature: input.feature,
     initialUrl: input.initialUrl,
     lifecycle: input.lifecycle,
@@ -242,6 +247,14 @@ function reconcileBrowserNodeWebviewControllerState(
     entry.state.webviewSrc !== nextState.webviewSrc;
 
   if (options.allowHostEffects) {
+    if (entry.context.automationTarget) {
+      void entry.context.feature.hostApi
+        .updateAutomationTarget?.({
+          automationTarget: entry.context.automationTarget,
+          nodeId: entry.context.nodeId
+        })
+        .catch(() => undefined);
+    }
     if (entry.context.lifecycle === "cold") {
       scheduleBrowserNodeGuestUnregister(entry);
     } else {
@@ -404,6 +417,7 @@ function attachBrowserNodeWebview(
     entry.registeringGuestId = guestId;
     try {
       await entry.context.feature.hostApi.registerGuest({
+        automationTarget: entry.context.automationTarget,
         navigationPolicy: entry.context.navigationPolicy,
         nodeId: entry.context.nodeId,
         profileId: entry.context.profileId,
@@ -428,6 +442,17 @@ function attachBrowserNodeWebview(
   };
   const handleGuestInteraction: EventListener = () => {
     entry.context.onGuestInteraction?.();
+    if (entry.context.automationTarget) {
+      void entry.context.feature.hostApi
+        .updateAutomationTarget?.({
+          automationTarget: {
+            ...entry.context.automationTarget,
+            focused: true
+          },
+          nodeId: entry.context.nodeId
+        })
+        .catch(() => undefined);
+    }
   };
   const handleGuestInteractionIpcMessage: EventListener = (event) => {
     if (

--- a/packages/browser/workbench-node/src/electron-main/automationDebugger.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationDebugger.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { BrowserNodeAutomationDriver } from "./automationDebugger.ts";
+import type { BrowserGuestDebugger, BrowserGuestWebContents } from "./types.ts";
+
+test("automation request guard intercepts redirects and subresources", async () => {
+  const commands: Array<{ method: string; params?: Record<string, unknown> }> =
+    [];
+  let attached = false;
+  let messageListener:
+    | ((event: unknown, method: string, params: unknown) => void)
+    | null = null;
+  const debuggerClient: BrowserGuestDebugger = {
+    attach() {
+      attached = true;
+    },
+    detach() {
+      attached = false;
+    },
+    isAttached: () => attached,
+    off(_event, listener) {
+      if (messageListener === listener) messageListener = null;
+      return this;
+    },
+    on(_event, listener) {
+      messageListener = listener;
+      return this;
+    },
+    async sendCommand(method, params) {
+      commands.push({ method, ...(params ? { params } : {}) });
+      return {};
+    }
+  };
+  const contents = {
+    debugger: debuggerClient,
+    isDestroyed: () => false,
+    off() {
+      return this;
+    },
+    on() {
+      return this;
+    }
+  } as unknown as BrowserGuestWebContents;
+  const driver = new BrowserNodeAutomationDriver(contents);
+  await driver.enableRequestGuard(async (url) =>
+    url.startsWith("https://public.example/")
+      ? { allowed: true }
+      : {
+          allowed: false,
+          code: "private_network_blocked",
+          message: "blocked"
+        }
+  );
+
+  const emitMessage = messageListener as
+    | ((event: unknown, method: string, params: unknown) => void)
+    | null;
+  assert.ok(emitMessage);
+  emitMessage(null, "Fetch.requestPaused", {
+    request: { url: "https://public.example/script.js" },
+    requestId: "public"
+  });
+  emitMessage(null, "Fetch.requestPaused", {
+    request: { url: "http://169.254.169.254/latest/meta-data" },
+    requestId: "private"
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.ok(
+    commands.some(
+      ({ method, params }) =>
+        method === "Fetch.continueRequest" && params?.requestId === "public"
+    )
+  );
+  assert.ok(
+    commands.some(
+      ({ method, params }) =>
+        method === "Fetch.failRequest" && params?.requestId === "private"
+    )
+  );
+  driver.dispose();
+});

--- a/packages/browser/workbench-node/src/electron-main/automationDebugger.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationDebugger.ts
@@ -1,0 +1,311 @@
+import type { BrowserGuestDebugger, BrowserGuestWebContents } from "./types.ts";
+import type { BrowserNodeAutomationToolResult } from "./automationTypes.ts";
+
+const clickedResultPrefix = "Clicked";
+const filledResultPrefix = "Filled";
+
+interface AccessibilityNode {
+  backendDOMNodeId?: number;
+  childIds?: string[];
+  ignored?: boolean;
+  name?: { value?: unknown };
+  nodeId?: string;
+  role?: { value?: unknown };
+}
+
+interface SnapshotElement {
+  backendDOMNodeId: number;
+  uid: string;
+}
+
+export class BrowserNodeAutomationDriver {
+  private attachedByDriver = false;
+  private readonly contents: BrowserGuestWebContents;
+  private readonly elements = new Map<string, SnapshotElement>();
+  private nextSnapshotSequence = 1;
+
+  constructor(contents: BrowserGuestWebContents) {
+    this.contents = contents;
+  }
+
+  async click(uid: string): Promise<BrowserNodeAutomationToolResult> {
+    const element = this.requireElement(uid);
+    const debuggerClient = this.requireDebugger();
+    const model = asRecord(
+      await debuggerClient.sendCommand("DOM.getBoxModel", {
+        backendNodeId: element.backendDOMNodeId
+      })
+    );
+    const quad = readNumberArray(asRecord(model.model)?.content);
+    if (quad.length < 8) {
+      throw new Error(`Browser element ${uid} is not visible`);
+    }
+    const x = (quad[0]! + quad[2]! + quad[4]! + quad[6]!) / 4;
+    const y = (quad[1]! + quad[3]! + quad[5]! + quad[7]!) / 4;
+    await debuggerClient.sendCommand("Input.dispatchMouseEvent", {
+      button: "left",
+      clickCount: 1,
+      type: "mousePressed",
+      x,
+      y
+    });
+    await debuggerClient.sendCommand("Input.dispatchMouseEvent", {
+      button: "left",
+      clickCount: 1,
+      type: "mouseReleased",
+      x,
+      y
+    });
+    const text = `${clickedResultPrefix} ${uid}`;
+    return { text };
+  }
+
+  dispose(): void {
+    const debuggerClient = this.contents.debugger;
+    if (this.attachedByDriver && debuggerClient?.isAttached()) {
+      debuggerClient.detach();
+    }
+    this.attachedByDriver = false;
+    this.elements.clear();
+  }
+
+  async evaluate(script: string): Promise<BrowserNodeAutomationToolResult> {
+    const expression = normalizeEvaluationExpression(script);
+    const response = asRecord(
+      await this.requireDebugger().sendCommand("Runtime.evaluate", {
+        awaitPromise: true,
+        expression,
+        returnByValue: true,
+        userGesture: true
+      })
+    );
+    const exception = recordOrNull(response.exceptionDetails);
+    if (exception) {
+      throw new Error(
+        readString(exception.text) || "Browser script evaluation failed"
+      );
+    }
+    const result = asRecord(response.result);
+    const value = result.value;
+    return { text: formatEvaluationResult(value) };
+  }
+
+  async fill(
+    uid: string,
+    value: string
+  ): Promise<BrowserNodeAutomationToolResult> {
+    const element = this.requireElement(uid);
+    const debuggerClient = this.requireDebugger();
+    const resolved = asRecord(
+      await debuggerClient.sendCommand("DOM.resolveNode", {
+        backendNodeId: element.backendDOMNodeId
+      })
+    );
+    const objectId = readString(asRecord(resolved.object)?.objectId);
+    if (!objectId) {
+      throw new Error(`Browser element ${uid} is unavailable`);
+    }
+    await debuggerClient.sendCommand("Runtime.callFunctionOn", {
+      functionDeclaration:
+        "function(){ if(typeof this.focus==='function'){this.focus();} if('value' in this){this.value=''; this.dispatchEvent(new Event('input',{bubbles:true}));} else if(this.isContentEditable){this.textContent='';} }",
+      objectId,
+      returnByValue: true,
+      userGesture: true
+    });
+    await debuggerClient.sendCommand("Input.insertText", { text: value });
+    await debuggerClient.sendCommand("Runtime.callFunctionOn", {
+      functionDeclaration:
+        "function(){ if('value' in this){this.dispatchEvent(new Event('input',{bubbles:true})); this.dispatchEvent(new Event('change',{bubbles:true}));} }",
+      objectId,
+      returnByValue: true,
+      userGesture: true
+    });
+    const text = `${filledResultPrefix} ${uid}`;
+    return { text };
+  }
+
+  async screenshot(
+    fullPage: boolean
+  ): Promise<BrowserNodeAutomationToolResult> {
+    const response = asRecord(
+      await this.requireDebugger().sendCommand("Page.captureScreenshot", {
+        captureBeyondViewport: fullPage,
+        format: "png",
+        fromSurface: true
+      })
+    );
+    const data = readString(response.data);
+    if (!data) {
+      throw new Error("Browser screenshot capture returned no data");
+    }
+    return {
+      screenshotData: data,
+      text: fullPage
+        ? "Captured full-page browser screenshot"
+        : "Captured browser screenshot"
+    };
+  }
+
+  async snapshot(): Promise<BrowserNodeAutomationToolResult> {
+    const debuggerClient = this.requireDebugger();
+    await debuggerClient.sendCommand("Accessibility.enable");
+    const response = asRecord(
+      await debuggerClient.sendCommand("Accessibility.getFullAXTree")
+    );
+    const nodes = Array.isArray(response.nodes)
+      ? response.nodes.map(readAccessibilityNode).filter(isAccessibilityNode)
+      : [];
+    this.elements.clear();
+    const snapshotSequence = this.nextSnapshotSequence++;
+    let elementSequence = 1;
+    const lines: string[] = [];
+    for (const node of nodes) {
+      if (node.ignored) {
+        continue;
+      }
+      const role = readString(node.role?.value) || "generic";
+      const name = readString(node.name?.value);
+      const actionable =
+        typeof node.backendDOMNodeId === "number" &&
+        isActionableAccessibilityRole(role);
+      let uid = "";
+      if (actionable) {
+        uid = `${snapshotSequence}_${elementSequence++}`;
+        this.elements.set(uid, {
+          backendDOMNodeId: node.backendDOMNodeId!,
+          uid
+        });
+      }
+      if (!name && !actionable && role === "generic") {
+        continue;
+      }
+      lines.push(
+        `${role}${name ? ` "${sanitizeSnapshotText(name)}"` : ""}${uid ? ` uid=${uid}` : ""}`
+      );
+    }
+    if (lines.length === 0) {
+      lines.push("(no accessible page content)");
+    }
+    return { text: lines.join("\n") };
+  }
+
+  private requireDebugger(): BrowserGuestDebugger {
+    if (this.contents.isDestroyed()) {
+      throw new Error("Browser page is closed");
+    }
+    const debuggerClient = this.contents.debugger;
+    if (!debuggerClient) {
+      throw new Error("Browser page debugging is unavailable");
+    }
+    if (!debuggerClient.isAttached()) {
+      debuggerClient.attach("1.3");
+      this.attachedByDriver = true;
+    }
+    return debuggerClient;
+  }
+
+  private requireElement(uid: string): SnapshotElement {
+    const normalized = uid.trim();
+    const element = this.elements.get(normalized);
+    if (!element) {
+      throw new Error(
+        `Unknown browser element uid ${normalized || "(empty)"}; run browser snapshot again`
+      );
+    }
+    return element;
+  }
+}
+
+function normalizeEvaluationExpression(script: string): string {
+  const trimmed = script.trim();
+  if (!trimmed) {
+    throw new Error("Browser evaluation script is required");
+  }
+  return `(${trimmed})()`;
+}
+
+function formatEvaluationResult(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === undefined) {
+    return "undefined";
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function readAccessibilityNode(value: unknown): AccessibilityNode | null {
+  const record = recordOrNull(value);
+  if (!record) {
+    return null;
+  }
+  return {
+    backendDOMNodeId:
+      typeof record.backendDOMNodeId === "number"
+        ? record.backendDOMNodeId
+        : undefined,
+    childIds: Array.isArray(record.childIds)
+      ? record.childIds.filter(
+          (item): item is string => typeof item === "string"
+        )
+      : undefined,
+    ignored: record.ignored === true,
+    name: asRecord(record.name) ?? undefined,
+    nodeId: readString(record.nodeId) || undefined,
+    role: asRecord(record.role) ?? undefined
+  };
+}
+
+function isAccessibilityNode(
+  value: AccessibilityNode | null
+): value is AccessibilityNode {
+  return value !== null;
+}
+
+function isActionableAccessibilityRole(role: string): boolean {
+  return new Set([
+    "button",
+    "checkbox",
+    "combobox",
+    "link",
+    "menuitem",
+    "option",
+    "radio",
+    "searchbox",
+    "slider",
+    "spinbutton",
+    "switch",
+    "tab",
+    "textbox"
+  ]).has(role.toLowerCase());
+}
+
+function sanitizeSnapshotText(value: string): string {
+  return value.replace(/\s+/gu, " ").replaceAll('"', '\\"').trim();
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function recordOrNull(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readNumberArray(value: unknown): number[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is number => typeof item === "number")
+    : [];
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}

--- a/packages/browser/workbench-node/src/electron-main/automationDebugger.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationDebugger.ts
@@ -1,5 +1,8 @@
 import type { BrowserGuestDebugger, BrowserGuestWebContents } from "./types.ts";
-import type { BrowserNodeAutomationToolResult } from "./automationTypes.ts";
+import type {
+  BrowserNodeAutomationAuthorizationResult,
+  BrowserNodeAutomationToolResult
+} from "./automationTypes.ts";
 
 const clickedResultPrefix = "Clicked";
 const filledResultPrefix = "Filled";
@@ -23,9 +26,25 @@ export class BrowserNodeAutomationDriver {
   private readonly contents: BrowserGuestWebContents;
   private readonly elements = new Map<string, SnapshotElement>();
   private nextSnapshotSequence = 1;
+  private requestAuthorizer:
+    | ((url: string) => Promise<BrowserNodeAutomationAuthorizationResult>)
+    | null = null;
+  private requestGuardEnabled = false;
+  private readonly onNavigation = (): void => {
+    this.elements.clear();
+  };
+  private readonly onDebuggerMessage = (
+    _event: unknown,
+    method: string,
+    rawParams: unknown
+  ): void => {
+    if (method !== "Fetch.requestPaused") return;
+    void this.handlePausedRequest(asRecord(rawParams));
+  };
 
   constructor(contents: BrowserGuestWebContents) {
     this.contents = contents;
+    this.contents.on("did-start-navigation", this.onNavigation);
   }
 
   async click(uid: string): Promise<BrowserNodeAutomationToolResult> {
@@ -66,6 +85,52 @@ export class BrowserNodeAutomationDriver {
       debuggerClient.detach();
     }
     this.attachedByDriver = false;
+    this.requestAuthorizer = null;
+    this.requestGuardEnabled = false;
+    this.elements.clear();
+    this.contents.off("did-start-navigation", this.onNavigation);
+    debuggerClient?.off?.("message", this.onDebuggerMessage);
+  }
+
+  async enableRequestGuard(
+    authorizer: (
+      url: string
+    ) => Promise<BrowserNodeAutomationAuthorizationResult>
+  ): Promise<void> {
+    this.requestAuthorizer = authorizer;
+    if (this.requestGuardEnabled) return;
+    const debuggerClient = this.requireDebugger();
+    if (!debuggerClient.on) {
+      throw new Error("Browser request interception is unavailable");
+    }
+    debuggerClient.on("message", this.onDebuggerMessage);
+    try {
+      await debuggerClient.sendCommand("Fetch.enable", {
+        patterns: [
+          { requestStage: "Request", urlPattern: "http://*" },
+          { requestStage: "Request", urlPattern: "https://*" }
+        ]
+      });
+      this.requestGuardEnabled = true;
+    } catch (error) {
+      debuggerClient.off?.("message", this.onDebuggerMessage);
+      this.requestAuthorizer = null;
+      throw error;
+    }
+  }
+
+  async disableRequestGuard(): Promise<void> {
+    this.requestAuthorizer = null;
+    if (!this.requestGuardEnabled) return;
+    this.requestGuardEnabled = false;
+    const debuggerClient = this.contents.debugger;
+    debuggerClient?.off?.("message", this.onDebuggerMessage);
+    if (debuggerClient?.isAttached()) {
+      await debuggerClient.sendCommand("Fetch.disable").catch(() => undefined);
+    }
+  }
+
+  invalidate(): void {
     this.elements.clear();
   }
 
@@ -202,6 +267,27 @@ export class BrowserNodeAutomationDriver {
       this.attachedByDriver = true;
     }
     return debuggerClient;
+  }
+
+  private async handlePausedRequest(
+    params: Record<string, unknown>
+  ): Promise<void> {
+    const debuggerClient = this.contents.debugger;
+    const requestId = readString(params.requestId);
+    const url = readString(asRecord(params.request)?.url);
+    if (!debuggerClient?.isAttached() || !requestId) return;
+    let allowed = false;
+    try {
+      allowed = Boolean(url && (await this.requestAuthorizer?.(url))?.allowed);
+    } catch {
+      allowed = false;
+    }
+    await debuggerClient
+      .sendCommand(
+        allowed ? "Fetch.continueRequest" : "Fetch.failRequest",
+        allowed ? { requestId } : { errorReason: "BlockedByClient", requestId }
+      )
+      .catch(() => undefined);
   }
 
   private requireElement(uid: string): SnapshotElement {

--- a/packages/browser/workbench-node/src/electron-main/automationNetworkPolicy.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationNetworkPolicy.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createBrowserNodeAutomationNetworkAuthorizer } from "./automationNetworkPolicy.ts";
+import type { BrowserNodeAutomationAuthorizationInput } from "./automationTypes.ts";
+
+function authorizationInput(
+  targetUrl: string,
+  navigationUrl?: string
+): BrowserNodeAutomationAuthorizationInput {
+  return {
+    agentSessionId: "agent-1",
+    args: navigationUrl ? { url: navigationUrl } : {},
+    target: {
+      focused: true,
+      nodeId: "browser:tab:1",
+      selected: true,
+      surfaceId: "browser",
+      surfaceRole: "user",
+      tabId: "tab-1",
+      title: "Page",
+      url: targetUrl,
+      workspaceId: "workspace-1"
+    },
+    tool: navigationUrl ? "navigate_page" : "take_snapshot",
+    workspaceId: "workspace-1"
+  };
+}
+
+test("automation network policy permits public pages and sandbox loopback", async () => {
+  const authorize = createBrowserNodeAutomationNetworkAuthorizer({
+    resolveHost: async () => ["93.184.216.34"]
+  });
+  assert.deepEqual(await authorize(authorizationInput("https://example.com")), {
+    allowed: true
+  });
+  assert.deepEqual(
+    await authorize(authorizationInput("http://127.0.0.1:3000")),
+    { allowed: true }
+  );
+});
+
+test("automation network policy blocks private current pages and navigation", async () => {
+  const authorize = createBrowserNodeAutomationNetworkAuthorizer({
+    resolveHost: async () => ["10.0.0.2"]
+  });
+  assert.equal(
+    (await authorize(authorizationInput("https://internal.example"))).allowed,
+    false
+  );
+  assert.equal(
+    (
+      await authorize(
+        authorizationInput("https://example.com", "http://169.254.169.254")
+      )
+    ).allowed,
+    false
+  );
+});

--- a/packages/browser/workbench-node/src/electron-main/automationNetworkPolicy.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationNetworkPolicy.test.ts
@@ -26,9 +26,9 @@ function authorizationInput(
   };
 }
 
-test("automation network policy permits public pages and sandbox loopback", async () => {
+test("automation network policy permits public pages and only routed loopback", async () => {
   const authorize = createBrowserNodeAutomationNetworkAuthorizer({
-    allowLoopback: true,
+    isLoopbackUrlRouted: async (url) => url === "http://127.0.0.1:3000/",
     resolveHost: async () => ["93.184.216.34"]
   });
   assert.deepEqual(await authorize(authorizationInput("https://example.com")), {
@@ -38,6 +38,25 @@ test("automation network policy permits public pages and sandbox loopback", asyn
     await authorize(authorizationInput("http://127.0.0.1:3000")),
     { allowed: true }
   );
+  assert.equal(
+    (await authorize(authorizationInput("http://127.0.0.1:4000"))).allowed,
+    false
+  );
+});
+
+test("automation request policy uses the target Chromium session resolver", async () => {
+  let nodeResolverCalled = false;
+  const authorize = createBrowserNodeAutomationNetworkAuthorizer({
+    resolveHost: async () => {
+      nodeResolverCalled = true;
+      return ["10.0.0.2"];
+    }
+  });
+  const input = authorizationInput("https://example.com");
+  input.resolveHost = async () => ["93.184.216.34"];
+
+  assert.deepEqual(await authorize(input), { allowed: true });
+  assert.equal(nodeResolverCalled, false);
 });
 
 test("automation network policy blocks private current pages and navigation", async () => {

--- a/packages/browser/workbench-node/src/electron-main/automationNetworkPolicy.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationNetworkPolicy.test.ts
@@ -28,6 +28,7 @@ function authorizationInput(
 
 test("automation network policy permits public pages and sandbox loopback", async () => {
   const authorize = createBrowserNodeAutomationNetworkAuthorizer({
+    allowLoopback: true,
     resolveHost: async () => ["93.184.216.34"]
   });
   assert.deepEqual(await authorize(authorizationInput("https://example.com")), {

--- a/packages/browser/workbench-node/src/electron-main/automationNetworkPolicy.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationNetworkPolicy.ts
@@ -6,7 +6,7 @@ import type {
 } from "./automationTypes.ts";
 
 export interface BrowserNodeAutomationNetworkPolicyOptions {
-  allowLoopback?: boolean;
+  isLoopbackUrlRouted?: (url: string) => boolean | Promise<boolean>;
   resolveHost?: (hostname: string) => Promise<readonly string[]>;
 }
 
@@ -15,8 +15,6 @@ export function createBrowserNodeAutomationNetworkAuthorizer(
 ): (
   input: BrowserNodeAutomationAuthorizationInput
 ) => Promise<BrowserNodeAutomationAuthorizationResult> {
-  const allowLoopback = options.allowLoopback === true;
-  const resolveHost = options.resolveHost ?? resolveHostnameAddresses;
   return async (input) => {
     const candidate = resolveAuthorizationUrl(input);
     if (candidate === "about:blank") {
@@ -37,8 +35,9 @@ export function createBrowserNodeAutomationNetworkAuthorizer(
     }
 
     const hostname = normalizeHostname(url.hostname);
-    if (hostname === "localhost") {
-      return allowLoopback
+    if (isLoopbackHostname(hostname)) {
+      const routed = await options.isLoopbackUrlRouted?.(url.toString());
+      return routed === true
         ? { allowed: true }
         : blocked("private_network_blocked", "Loopback pages are not allowed");
     }
@@ -51,6 +50,8 @@ export function createBrowserNodeAutomationNetworkAuthorizer(
 
     let addresses: readonly string[];
     try {
+      const resolveHost =
+        input.resolveHost ?? options.resolveHost ?? resolveHostnameAddresses;
       addresses = isIP(hostname) ? [hostname] : await resolveHost(hostname);
     } catch {
       return blocked(
@@ -60,7 +61,7 @@ export function createBrowserNodeAutomationNetworkAuthorizer(
     }
     if (
       addresses.length === 0 ||
-      addresses.some((address) => !isAllowedAddress(address, allowLoopback))
+      addresses.some((address) => !isAllowedAddress(address))
     ) {
       return blocked(
         "private_network_blocked",
@@ -91,26 +92,31 @@ function normalizeHostname(hostname: string): string {
   return hostname.replace(/^\[|\]$/gu, "").toLowerCase();
 }
 
-function isAllowedAddress(address: string, allowLoopback: boolean): boolean {
-  const normalized = normalizeHostname(address);
-  if (normalized.includes(":")) {
-    return isAllowedIPv6(normalized, allowLoopback);
-  }
-  return isAllowedIPv4(normalized, allowLoopback);
+function isLoopbackHostname(hostname: string): boolean {
+  if (hostname === "localhost" || hostname === "::1") return true;
+  if (!hostname.includes(".")) return false;
+  const octets = hostname.split(".").map(Number);
+  return octets.length === 4 && octets[0] === 127;
 }
 
-function isAllowedIPv4(address: string, allowLoopback: boolean): boolean {
+function isAllowedAddress(address: string): boolean {
+  const normalized = normalizeHostname(address);
+  if (normalized.includes(":")) {
+    return isAllowedIPv6(normalized);
+  }
+  return isAllowedIPv4(normalized);
+}
+
+function isAllowedIPv4(address: string): boolean {
   const octets = address.split(".").map(Number);
   if (octets.length !== 4 || octets.some((value) => !Number.isInteger(value))) {
     return false;
   }
   const a = octets[0]!;
   const b = octets[1]!;
-  if (a === 127) {
-    return allowLoopback;
-  }
   return !(
     a === 0 ||
+    a === 127 ||
     a === 10 ||
     (a === 100 && b >= 64 && b <= 127) ||
     (a === 169 && b === 254) ||
@@ -121,15 +127,12 @@ function isAllowedIPv4(address: string, allowLoopback: boolean): boolean {
   );
 }
 
-function isAllowedIPv6(address: string, allowLoopback: boolean): boolean {
-  if (address === "::1") {
-    return allowLoopback;
-  }
-  if (address === "::" || address.startsWith("ff")) {
+function isAllowedIPv6(address: string): boolean {
+  if (address === "::" || address === "::1" || address.startsWith("ff")) {
     return false;
   }
   if (address.startsWith("::ffff:")) {
-    return isAllowedIPv4(address.slice("::ffff:".length), allowLoopback);
+    return isAllowedIPv4(address.slice("::ffff:".length));
   }
   const first = Number.parseInt(address.split(":", 1)[0] || "0", 16);
   return !((first & 0xfe00) === 0xfc00 || (first & 0xffc0) === 0xfe80);

--- a/packages/browser/workbench-node/src/electron-main/automationNetworkPolicy.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationNetworkPolicy.ts
@@ -1,0 +1,143 @@
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+import type {
+  BrowserNodeAutomationAuthorizationInput,
+  BrowserNodeAutomationAuthorizationResult
+} from "./automationTypes.ts";
+
+export interface BrowserNodeAutomationNetworkPolicyOptions {
+  allowLoopback?: boolean;
+  resolveHost?: (hostname: string) => Promise<readonly string[]>;
+}
+
+export function createBrowserNodeAutomationNetworkAuthorizer(
+  options: BrowserNodeAutomationNetworkPolicyOptions = {}
+): (
+  input: BrowserNodeAutomationAuthorizationInput
+) => Promise<BrowserNodeAutomationAuthorizationResult> {
+  const allowLoopback = options.allowLoopback !== false;
+  const resolveHost = options.resolveHost ?? resolveHostnameAddresses;
+  return async (input) => {
+    const candidate = resolveAuthorizationUrl(input);
+    if (candidate === "about:blank") {
+      return { allowed: true };
+    }
+
+    let url: URL;
+    try {
+      url = new URL(candidate);
+    } catch {
+      return blocked("invalid_url", "The browser URL is invalid");
+    }
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return blocked(
+        "unsupported_protocol",
+        "Browser automation only supports HTTP and HTTPS pages"
+      );
+    }
+
+    const hostname = normalizeHostname(url.hostname);
+    if (hostname === "localhost") {
+      return allowLoopback
+        ? { allowed: true }
+        : blocked("private_network_blocked", "Loopback pages are not allowed");
+    }
+    if (hostname.endsWith(".local")) {
+      return blocked(
+        "private_network_blocked",
+        "Local-network pages are not available to browser automation"
+      );
+    }
+
+    let addresses: readonly string[];
+    try {
+      addresses = isIP(hostname) ? [hostname] : await resolveHost(hostname);
+    } catch {
+      return blocked(
+        "host_resolution_failed",
+        "The browser host could not be resolved safely"
+      );
+    }
+    if (
+      addresses.length === 0 ||
+      addresses.some((address) => !isAllowedAddress(address, allowLoopback))
+    ) {
+      return blocked(
+        "private_network_blocked",
+        "Private, link-local, and metadata-network pages are not available to browser automation"
+      );
+    }
+    return { allowed: true };
+  };
+}
+
+function resolveAuthorizationUrl(
+  input: BrowserNodeAutomationAuthorizationInput
+): string {
+  if (input.tool === "navigate_page") {
+    const candidate = input.args.url;
+    return typeof candidate === "string" ? candidate.trim() : "";
+  }
+  return input.target.url.trim() || "about:blank";
+}
+
+async function resolveHostnameAddresses(hostname: string): Promise<string[]> {
+  return (await lookup(hostname, { all: true, verbatim: true })).map(
+    ({ address }) => address
+  );
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.replace(/^\[|\]$/gu, "").toLowerCase();
+}
+
+function isAllowedAddress(address: string, allowLoopback: boolean): boolean {
+  const normalized = normalizeHostname(address);
+  if (normalized.includes(":")) {
+    return isAllowedIPv6(normalized, allowLoopback);
+  }
+  return isAllowedIPv4(normalized, allowLoopback);
+}
+
+function isAllowedIPv4(address: string, allowLoopback: boolean): boolean {
+  const octets = address.split(".").map(Number);
+  if (octets.length !== 4 || octets.some((value) => !Number.isInteger(value))) {
+    return false;
+  }
+  const a = octets[0]!;
+  const b = octets[1]!;
+  if (a === 127) {
+    return allowLoopback;
+  }
+  return !(
+    a === 0 ||
+    a === 10 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    a >= 224
+  );
+}
+
+function isAllowedIPv6(address: string, allowLoopback: boolean): boolean {
+  if (address === "::1") {
+    return allowLoopback;
+  }
+  if (address === "::" || address.startsWith("ff")) {
+    return false;
+  }
+  if (address.startsWith("::ffff:")) {
+    return isAllowedIPv4(address.slice("::ffff:".length), allowLoopback);
+  }
+  const first = Number.parseInt(address.split(":", 1)[0] || "0", 16);
+  return !((first & 0xfe00) === 0xfc00 || (first & 0xffc0) === 0xfe80);
+}
+
+function blocked(
+  code: string,
+  message: string
+): BrowserNodeAutomationAuthorizationResult {
+  return { allowed: false, code, message };
+}

--- a/packages/browser/workbench-node/src/electron-main/automationNetworkPolicy.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationNetworkPolicy.ts
@@ -15,7 +15,7 @@ export function createBrowserNodeAutomationNetworkAuthorizer(
 ): (
   input: BrowserNodeAutomationAuthorizationInput
 ) => Promise<BrowserNodeAutomationAuthorizationResult> {
-  const allowLoopback = options.allowLoopback !== false;
+  const allowLoopback = options.allowLoopback === true;
   const resolveHost = options.resolveHost ?? resolveHostnameAddresses;
   return async (input) => {
     const candidate = resolveAuthorizationUrl(input);
@@ -74,11 +74,11 @@ export function createBrowserNodeAutomationNetworkAuthorizer(
 function resolveAuthorizationUrl(
   input: BrowserNodeAutomationAuthorizationInput
 ): string {
-  if (input.tool === "navigate_page") {
+  if (input.tool === "navigate_page" || input.tool === "new_page") {
     const candidate = input.args.url;
     return typeof candidate === "string" ? candidate.trim() : "";
   }
-  return input.target.url.trim() || "about:blank";
+  return input.target?.url.trim() || "about:blank";
 }
 
 async function resolveHostnameAddresses(hostname: string): Promise<string[]> {

--- a/packages/browser/workbench-node/src/electron-main/automationRegistry.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationRegistry.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { createBrowserNodeAutomationRegistry } from "./automationRegistry.ts";
-import type { BrowserGuestWebContents } from "./types.ts";
+import type { BrowserGuestDebugger, BrowserGuestWebContents } from "./types.ts";
 
 function fakeContents(title: string, url: string): BrowserGuestWebContents {
   return {
@@ -21,6 +21,63 @@ function fakeContents(title: string, url: string): BrowserGuestWebContents {
       return this;
     },
     reload() {}
+  };
+}
+
+function guardedContents(events: string[]): BrowserGuestWebContents {
+  let attached = false;
+  let currentUrl = "about:blank";
+  let messageListener:
+    | ((event: unknown, method: string, params: unknown) => void)
+    | null = null;
+  const debuggerClient: BrowserGuestDebugger = {
+    attach() {
+      attached = true;
+    },
+    detach() {
+      attached = false;
+    },
+    isAttached: () => attached,
+    off(_event, listener) {
+      if (messageListener === listener) messageListener = null;
+      return this;
+    },
+    on(_event, listener) {
+      messageListener = listener;
+      return this;
+    },
+    async sendCommand(method) {
+      events.push(method);
+      return {};
+    }
+  };
+  return {
+    ...fakeContents("Page", "about:blank"),
+    debugger: debuggerClient,
+    getURL: () => currentUrl,
+    session: {
+      off() {
+        return this;
+      },
+      on() {
+        return this;
+      },
+      async resolveHost() {
+        events.push("session.resolveHost");
+        return { endpoints: [{ address: "93.184.216.34" }] };
+      }
+    },
+    async loadURL(url) {
+      events.push(`loadURL:${url}`);
+      messageListener?.(null, "Fetch.requestPaused", {
+        request: { url },
+        requestId: "navigation"
+      });
+      while (!events.includes("Fetch.continueRequest")) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+      currentUrl = url;
+    }
   };
 }
 
@@ -147,7 +204,8 @@ test("new page authorization runs before requesting a renderer target", async ()
     requestTarget: async () => {
       requested = true;
       return "agent:tab:1";
-    }
+    },
+    closeTarget: async () => undefined
   });
 
   await assert.rejects(
@@ -160,6 +218,48 @@ test("new page authorization runs before requesting a renderer target", async ()
     /blocked_by_policy/u
   );
   assert.equal(requested, false);
+});
+
+test("new page creates about:blank and enables the request guard before navigation", async () => {
+  const events: string[] = [];
+  const contents = guardedContents(events);
+  let registry: ReturnType<typeof createBrowserNodeAutomationRegistry>;
+  registry = createBrowserNodeAutomationRegistry({
+    authorize: async () => ({ allowed: true }),
+    authorizeRequest: async (input) => {
+      assert.ok(input.resolveHost);
+      assert.deepEqual(await input.resolveHost("public.example"), [
+        "93.184.216.34"
+      ]);
+      return { allowed: true };
+    },
+    closeTarget: async () => undefined,
+    requestTarget: async (input) => {
+      assert.equal(input.url, "about:blank");
+      registry.register("agent:tab:1", contents, {
+        agentSessionId: "agent-a",
+        selected: true,
+        surfaceId: "agent",
+        surfaceRole: "agent",
+        tabId: "tab-1",
+        workspaceId: "ws-1"
+      });
+      return "agent:tab:1";
+    }
+  });
+
+  await registry.call({
+    agentSessionId: "agent-a",
+    args: { url: "https://public.example/start" },
+    tool: "new_page",
+    workspaceId: "ws-1"
+  });
+
+  assert.ok(events.indexOf("Fetch.enable") >= 0);
+  assert.ok(
+    events.indexOf("Fetch.enable") <
+      events.indexOf("loadURL:https://public.example/start")
+  );
 });
 
 test("automation target ids are isolated by workspace", () => {
@@ -211,4 +311,100 @@ test("releasing an Agent closes only its retained Browser pages", async () => {
 
   await registry.releaseAgent("agent-a");
   assert.deepEqual(closed, ["agent-a:tab:1"]);
+});
+
+test("releasing an Agent waits for in-flight target work before disabling its guard", async () => {
+  const events: string[] = [];
+  let finishSelection!: () => void;
+  const selectionBlocked = new Promise<void>((resolve) => {
+    finishSelection = resolve;
+  });
+  const registry = createBrowserNodeAutomationRegistry({
+    authorizeRequest: async () => ({ allowed: true }),
+    selectTarget: async () => {
+      events.push("select:start");
+      await selectionBlocked;
+      events.push("select:end");
+    }
+  });
+  registry.register("user:tab:1", guardedContents(events), {
+    selected: true,
+    surfaceId: "user",
+    surfaceRole: "user",
+    tabId: "tab-1",
+    workspaceId: "ws-1"
+  });
+
+  const call = registry.call({
+    agentSessionId: "agent-a",
+    args: { pageId: "user:tab:1" },
+    tool: "select_page",
+    workspaceId: "ws-1"
+  });
+  while (!events.includes("select:start")) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  const release = registry.releaseAgent("agent-a");
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(events.includes("Fetch.disable"), false);
+
+  finishSelection();
+  await Promise.all([call, release]);
+  assert.ok(events.indexOf("select:end") < events.indexOf("Fetch.disable"));
+  await assert.rejects(
+    registry.call({
+      agentSessionId: "agent-a",
+      tool: "list_pages",
+      workspaceId: "ws-1"
+    }),
+    /agent_session_released/u
+  );
+});
+
+test("releasing an Agent closes a new page that finishes creating after release", async () => {
+  const closed: string[] = [];
+  let finishCreation!: () => void;
+  let creationStarted!: () => void;
+  const creationPending = new Promise<void>((resolve) => {
+    finishCreation = resolve;
+  });
+  const started = new Promise<void>((resolve) => {
+    creationStarted = resolve;
+  });
+  let registry!: ReturnType<typeof createBrowserNodeAutomationRegistry>;
+  registry = createBrowserNodeAutomationRegistry({
+    authorize: async () => ({ allowed: true }),
+    closeTarget: async (target) => {
+      closed.push(target.nodeId);
+    },
+    requestTarget: async () => {
+      creationStarted();
+      await creationPending;
+      registry.register(
+        "agent-a:tab:late",
+        fakeContents("Late page", "about:blank"),
+        {
+          agentSessionId: "agent-a",
+          selected: true,
+          surfaceId: "agent-a",
+          surfaceRole: "agent",
+          tabId: "tab-late",
+          workspaceId: "ws-1"
+        }
+      );
+      return "agent-a:tab:late";
+    }
+  });
+
+  const call = registry.call({
+    agentSessionId: "agent-a",
+    tool: "new_page",
+    workspaceId: "ws-1"
+  });
+  await started;
+  await registry.releaseAgent("agent-a");
+  finishCreation();
+
+  await assert.rejects(call, /agent_session_released/u);
+  assert.deepEqual(closed, ["agent-a:tab:late"]);
 });

--- a/packages/browser/workbench-node/src/electron-main/automationRegistry.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationRegistry.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createBrowserNodeAutomationRegistry } from "./automationRegistry.ts";
+import type { BrowserGuestWebContents } from "./types.ts";
+
+function fakeContents(title: string, url: string): BrowserGuestWebContents {
+  return {
+    canGoBack: () => false,
+    canGoForward: () => false,
+    getTitle: () => title,
+    getURL: () => url,
+    goBack() {},
+    goForward() {},
+    isDestroyed: () => false,
+    isLoading: () => false,
+    loadURL: async () => undefined,
+    off() {
+      return this;
+    },
+    on() {
+      return this;
+    },
+    reload() {}
+  };
+}
+
+test("automation targets expose user tabs and only the caller's agent tabs", () => {
+  const registry = createBrowserNodeAutomationRegistry();
+  registry.register("user:tab:1", fakeContents("User", "https://user.test"), {
+    focused: true,
+    selected: true,
+    surfaceId: "user",
+    surfaceRole: "user",
+    tabId: "tab-1",
+    workspaceId: "ws-1"
+  });
+  registry.register(
+    "agent-a:tab:1",
+    fakeContents("Agent A", "https://a.test"),
+    {
+      agentSessionId: "agent-a",
+      selected: true,
+      surfaceId: "agent-a",
+      surfaceRole: "agent",
+      tabId: "tab-1",
+      workspaceId: "ws-1"
+    }
+  );
+  registry.register(
+    "agent-b:tab:1",
+    fakeContents("Agent B", "https://b.test"),
+    {
+      agentSessionId: "agent-b",
+      selected: true,
+      surfaceId: "agent-b",
+      surfaceRole: "agent",
+      tabId: "tab-1",
+      workspaceId: "ws-1"
+    }
+  );
+
+  assert.deepEqual(
+    registry
+      .list({ agentSessionId: "agent-a", workspaceId: "ws-1" })
+      .map((target) => target.nodeId),
+    ["user:tab:1", "agent-a:tab:1"]
+  );
+});
+
+test("automation leases reject a second agent on the same user tab", async () => {
+  let timestamp = 10;
+  const registry = createBrowserNodeAutomationRegistry({
+    leaseTtlMs: 100,
+    now: () => timestamp,
+    selectTarget: async () => undefined
+  });
+  registry.register("user:tab:1", fakeContents("User", "https://user.test"), {
+    focused: true,
+    selected: true,
+    surfaceId: "user",
+    surfaceRole: "user",
+    tabId: "tab-1",
+    workspaceId: "ws-1"
+  });
+
+  await registry.call({
+    agentSessionId: "agent-a",
+    args: { pageId: "user:tab:1" },
+    tool: "select_page",
+    workspaceId: "ws-1"
+  });
+  await assert.rejects(
+    registry.call({
+      agentSessionId: "agent-b",
+      args: { pageId: "user:tab:1" },
+      tool: "select_page",
+      workspaceId: "ws-1"
+    }),
+    /tab_in_use/u
+  );
+
+  timestamp = 111;
+  await registry.call({
+    agentSessionId: "agent-b",
+    args: { pageId: "user:tab:1" },
+    tool: "select_page",
+    workspaceId: "ws-1"
+  });
+});
+
+test("automation authorization runs before a target lease is acquired", async () => {
+  const registry = createBrowserNodeAutomationRegistry({
+    authorize: async () => ({
+      allowed: false,
+      code: "blocked_by_policy",
+      message: "private target"
+    }),
+    selectTarget: async () => undefined
+  });
+  registry.register("user:tab:1", fakeContents("User", "http://10.0.0.1"), {
+    selected: true,
+    surfaceId: "user",
+    surfaceRole: "user",
+    tabId: "tab-1",
+    workspaceId: "ws-1"
+  });
+
+  await assert.rejects(
+    registry.call({
+      agentSessionId: "agent-a",
+      args: { pageId: "user:tab:1" },
+      tool: "select_page",
+      workspaceId: "ws-1"
+    }),
+    /blocked_by_policy/u
+  );
+});

--- a/packages/browser/workbench-node/src/electron-main/automationRegistry.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationRegistry.test.ts
@@ -135,3 +135,80 @@ test("automation authorization runs before a target lease is acquired", async ()
     /blocked_by_policy/u
   );
 });
+
+test("new page authorization runs before requesting a renderer target", async () => {
+  let requested = false;
+  const registry = createBrowserNodeAutomationRegistry({
+    authorize: async () => ({
+      allowed: false,
+      code: "blocked_by_policy",
+      message: "private target"
+    }),
+    requestTarget: async () => {
+      requested = true;
+      return "agent:tab:1";
+    }
+  });
+
+  await assert.rejects(
+    registry.call({
+      agentSessionId: "agent-a",
+      args: { url: "http://169.254.169.254" },
+      tool: "new_page",
+      workspaceId: "ws-1"
+    }),
+    /blocked_by_policy/u
+  );
+  assert.equal(requested, false);
+});
+
+test("automation target ids are isolated by workspace", () => {
+  const registry = createBrowserNodeAutomationRegistry();
+  for (const workspaceId of ["ws-1", "ws-2"]) {
+    registry.register(
+      "browser:tab:1",
+      fakeContents(workspaceId, `https://${workspaceId}.test`),
+      {
+        selected: true,
+        surfaceId: "browser",
+        surfaceRole: "user",
+        tabId: "tab-1",
+        workspaceId
+      }
+    );
+  }
+
+  assert.equal(registry.list({ workspaceId: "ws-1" })[0]?.title, "ws-1");
+  assert.equal(registry.list({ workspaceId: "ws-2" })[0]?.title, "ws-2");
+});
+
+test("releasing an Agent closes only its retained Browser pages", async () => {
+  const closed: string[] = [];
+  const registry = createBrowserNodeAutomationRegistry({
+    closeTarget: async (target) => {
+      closed.push(target.nodeId);
+    }
+  });
+  registry.register("user:tab:1", fakeContents("User", "https://user.test"), {
+    selected: true,
+    surfaceId: "user",
+    surfaceRole: "user",
+    tabId: "tab-1",
+    workspaceId: "ws-1"
+  });
+  registry.register(
+    "agent-a:tab:1",
+    fakeContents("Agent A", "https://agent.test"),
+    {
+      agentSessionId: "agent-a",
+      selected: true,
+      surfaceId: "agent-a",
+      surfaceRole: "agent",
+      tabId: "tab-1",
+      workspaceId: "ws-1"
+    }
+  );
+
+  await registry.releaseAgent("agent-a");
+  assert.deepEqual(closed, ["agent-a:tab:1"]);
+});

--- a/packages/browser/workbench-node/src/electron-main/automationRegistry.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationRegistry.ts
@@ -37,6 +37,7 @@ export function createBrowserNodeAutomationRegistry(
   const targets = new Map<string, RegisteredTarget>();
   const leases = new Map<string, AutomationLease>();
   const selectedTargetByOwner = new Map<string, string>();
+  const releasedAgents = new Set<string>();
   const now = options.now ?? Date.now;
   const leaseTtlMs = Math.max(1, options.leaseTtlMs ?? defaultLeaseTtlMs);
   let focusSequence = 0;
@@ -63,10 +64,13 @@ export function createBrowserNodeAutomationRegistry(
       workspaceId: input.workspaceId
     });
     const ownerKey = resolveOwnerKey(input);
-    const stablePageId = selectedTargetByOwner.get(ownerKey);
+    const stableTargetKey = selectedTargetByOwner.get(ownerKey);
     const selected = pageId
       ? visible.find((target) => target.nodeId === pageId)
-      : (visible.find((target) => target.nodeId === stablePageId) ??
+      : (visible.find(
+          (target) =>
+            targetKey(input.workspaceId, target.nodeId) === stableTargetKey
+        ) ??
         visible.find((target) => target.focused && target.selected) ??
         visible.find((target) => target.selected) ??
         visible[0]);
@@ -75,7 +79,10 @@ export function createBrowserNodeAutomationRegistry(
         targetKey(input.workspaceId, selected.nodeId)
       );
       if (registered) {
-        selectedTargetByOwner.set(ownerKey, registered.nodeId);
+        selectedTargetByOwner.set(
+          ownerKey,
+          targetKey(input.workspaceId, registered.nodeId)
+        );
         return registered;
       }
     }
@@ -101,7 +108,10 @@ export function createBrowserNodeAutomationRegistry(
     ) {
       throw new Error("No in-app Browser page is available");
     }
-    selectedTargetByOwner.set(ownerKey, requested.nodeId);
+    selectedTargetByOwner.set(
+      ownerKey,
+      targetKey(input.workspaceId, requested.nodeId)
+    );
     return requested;
   };
 
@@ -110,9 +120,11 @@ export function createBrowserNodeAutomationRegistry(
     args: Record<string, unknown>,
     target: RegisteredTarget
   ): Promise<void> => {
+    const resolveHost = resolveTargetHost(target);
     const result = await options.authorize?.({
       agentSessionId: normalizeOptional(input.agentSessionId),
       args,
+      ...(resolveHost ? { resolveHost } : {}),
       target: toSummary(target),
       tool: input.tool,
       workspaceId: input.workspaceId
@@ -139,9 +151,11 @@ export function createBrowserNodeAutomationRegistry(
     }
     if (current) clearTimeout(current.timeout);
     const timeout = setTimeout(() => {
-      if (leases.get(key) !== lease) return;
-      leases.delete(key);
-      void targets.get(key)?.driver.disableRequestGuard();
+      void enqueueTarget(target, async () => {
+        if (leases.get(key) !== lease) return;
+        leases.delete(key);
+        await target.driver.disableRequestGuard();
+      });
     }, leaseTtlMs);
     (
       timeout as ReturnType<typeof setTimeout> & { unref?: () => void }
@@ -158,6 +172,8 @@ export function createBrowserNodeAutomationRegistry(
   return {
     async call(input) {
       const workspaceId = normalizeRequired(input.workspaceId, "workspaceId");
+      const agentSessionId = normalizeOptional(input.agentSessionId);
+      assertAgentActive(releasedAgents, agentSessionId);
       const args = input.args ?? {};
       if (input.tool === "list_pages") {
         return {
@@ -168,6 +184,9 @@ export function createBrowserNodeAutomationRegistry(
       }
 
       if (input.tool === "new_page") {
+        if (!options.requestTarget || !options.closeTarget) {
+          throw new Error("Creating in-app Browser pages is unavailable");
+        }
         const ownerKey = resolveOwnerKey(input);
         const visibleTargets = list({
           agentSessionId: input.agentSessionId,
@@ -176,7 +195,7 @@ export function createBrowserNodeAutomationRegistry(
         const requestedPageId =
           readString(args.pageId) ||
           readString(args.page_id) ||
-          selectedTargetByOwner.get(ownerKey) ||
+          selectedNodeId(selectedTargetByOwner.get(ownerKey), workspaceId) ||
           visibleTargets.find((target) => target.focused && target.selected)
             ?.nodeId ||
           visibleTargets.find((target) => target.selected)?.nodeId ||
@@ -193,31 +212,71 @@ export function createBrowserNodeAutomationRegistry(
         if (authorization && !authorization.allowed) {
           throw new Error(`${authorization.code}: ${authorization.message}`);
         }
-        const nodeId = await options.requestTarget?.({
-          agentSessionId: normalizeOptional(input.agentSessionId),
+        const nodeId = await options.requestTarget({
+          agentSessionId,
           requestedPageId,
-          url: rawUrl,
+          url: "about:blank",
           workspaceId
         });
         if (!nodeId) {
           throw new Error("In-app Browser did not create a page");
         }
-        selectedTargetByOwner.set(ownerKey, nodeId);
-        const text = `${createdPageResultPrefix} ${nodeId}`;
-        return { text };
+        const key = targetKey(workspaceId, nodeId);
+        const target = targets.get(key);
+        if (!target || !isTargetVisible(target, workspaceId, agentSessionId)) {
+          if (target) await closeCreatedTarget(options, target);
+          throw new Error("In-app Browser created an unavailable page");
+        }
+        return enqueueTarget(target, async () => {
+          if (agentSessionId && releasedAgents.has(agentSessionId)) {
+            await closeCreatedTarget(options, target);
+            assertAgentActive(releasedAgents, agentSessionId);
+          }
+          const acquired = acquireLease(input, target);
+          try {
+            if (rawUrl !== "about:blank") {
+              if (!options.authorizeRequest) {
+                throw new Error("Browser request authorization is unavailable");
+              }
+              const resolveHost = resolveTargetHost(target);
+              await target.driver.enableRequestGuard(async (url) =>
+                options.authorizeRequest!({
+                  agentSessionId,
+                  args: { url },
+                  ...(resolveHost ? { resolveHost } : {}),
+                  target: toSummary(target),
+                  tool: "navigate_page",
+                  workspaceId
+                })
+              );
+              await loadTargetUrl(target, rawUrl);
+            }
+          } catch (error) {
+            await releaseTargetLease(leases, acquired, target);
+            await closeCreatedTarget(options, target);
+            throw error;
+          }
+          selectedTargetByOwner.set(ownerKey, key);
+          return {
+            text: formatPageResult(createdPageResultPrefix, nodeId)
+          };
+        });
       }
 
       const normalizedInput = { ...input, workspaceId };
       const target = await resolveTarget(normalizedInput, args);
       return enqueueTarget(target, async () => {
+        assertAgentActive(releasedAgents, agentSessionId);
         await authorize(normalizedInput, args, target);
         const acquired = acquireLease(normalizedInput, target);
         try {
           if (options.authorizeRequest) {
+            const resolveHost = resolveTargetHost(target);
             await target.driver.enableRequestGuard(async (url) =>
               options.authorizeRequest!({
                 agentSessionId: normalizeOptional(input.agentSessionId),
                 args: { url },
+                ...(resolveHost ? { resolveHost } : {}),
                 target: toSummary(target),
                 tool: "navigate_page",
                 workspaceId
@@ -240,7 +299,10 @@ export function createBrowserNodeAutomationRegistry(
               throw new Error("Closing in-app Browser pages is unavailable");
             }
             await options.closeTarget(toSummary(target));
-            clearSelectedTarget(selectedTargetByOwner, target.nodeId);
+            clearSelectedTarget(
+              selectedTargetByOwner,
+              targetKey(workspaceId, target.nodeId)
+            );
             return {
               text: formatPageResult(closedPageResultPrefix, target.nodeId)
             };
@@ -256,7 +318,7 @@ export function createBrowserNodeAutomationRegistry(
           case "select_page":
             selectedTargetByOwner.set(
               resolveOwnerKey(normalizedInput),
-              target.nodeId
+              targetKey(workspaceId, target.nodeId)
             );
             await options.selectTarget?.(toSummary(target));
             return {
@@ -304,29 +366,37 @@ export function createBrowserNodeAutomationRegistry(
     },
     async releaseAgent(agentSessionId) {
       const owner = normalizeRequired(agentSessionId, "agentSessionId");
-      for (const [nodeId, lease] of leases) {
-        if (lease.owner === owner) {
-          clearTimeout(lease.timeout);
-          leases.delete(nodeId);
-          void targets.get(nodeId)?.driver.disableRequestGuard();
-        }
-      }
+      releasedAgents.add(owner);
       for (const ownerKey of selectedTargetByOwner.keys()) {
         if (ownerKey.endsWith(`:${owner}`)) {
           selectedTargetByOwner.delete(ownerKey);
         }
       }
-      if (options.closeTarget) {
-        const agentTargets = Array.from(targets.values()).filter(
-          (target) =>
+      const ownedTargets = Array.from(targets.values()).filter((target) => {
+        const key = targetKey(target.metadata.workspaceId, target.nodeId);
+        return (
+          leases.get(key)?.owner === owner ||
+          (target.metadata.surfaceRole === "agent" &&
+            normalizeOptional(target.metadata.agentSessionId) === owner)
+        );
+      });
+      for (const target of ownedTargets) {
+        await enqueueTarget(target, async () => {
+          const key = targetKey(target.metadata.workspaceId, target.nodeId);
+          const lease = leases.get(key);
+          if (lease?.owner === owner) {
+            clearTimeout(lease.timeout);
+            leases.delete(key);
+            await target.driver.disableRequestGuard();
+          }
+          if (
+            options.closeTarget &&
             target.metadata.surfaceRole === "agent" &&
             normalizeOptional(target.metadata.agentSessionId) === owner
-        );
-        for (const target of agentTargets) {
-          await enqueueTarget(target, () =>
-            options.closeTarget!(toSummary(target))
-          );
-        }
+          ) {
+            await options.closeTarget(toSummary(target));
+          }
+        });
       }
     },
     unregister(nodeId, contents) {
@@ -342,7 +412,7 @@ export function createBrowserNodeAutomationRegistry(
         const lease = leases.get(key);
         if (lease) clearTimeout(lease.timeout);
         leases.delete(key);
-        clearSelectedTarget(selectedTargetByOwner, existing.nodeId);
+        clearSelectedTarget(selectedTargetByOwner, key);
       }
     },
     update(nodeId, metadata) {
@@ -379,6 +449,68 @@ function targetKey(workspaceId: string, nodeId: string): string {
   return `${normalizeRequired(workspaceId, "workspaceId")}\u0000${normalizeRequired(nodeId, "nodeId")}`;
 }
 
+function selectedNodeId(
+  selectedKey: string | undefined,
+  workspaceId: string
+): string {
+  const prefix = `${normalizeRequired(workspaceId, "workspaceId")}\u0000`;
+  return selectedKey?.startsWith(prefix)
+    ? selectedKey.slice(prefix.length)
+    : "";
+}
+
+function assertAgentActive(
+  releasedAgents: Set<string>,
+  agentSessionId: string | null
+): void {
+  if (agentSessionId && releasedAgents.has(agentSessionId)) {
+    throw new Error(
+      "agent_session_released: Browser automation session is closed"
+    );
+  }
+}
+
+function resolveTargetHost(
+  target: RegisteredTarget
+): ((hostname: string) => Promise<readonly string[]>) | null {
+  const browserSession = target.contents.session;
+  const resolveHost = browserSession?.resolveHost;
+  if (!browserSession || !resolveHost) return null;
+  return async (hostname) => {
+    const result = await resolveHost.call(browserSession, hostname, {
+      cacheUsage: "allowed"
+    });
+    return result.endpoints.map((endpoint) => endpoint.address);
+  };
+}
+
+async function loadTargetUrl(
+  target: RegisteredTarget,
+  rawUrl: string
+): Promise<void> {
+  const resolved = resolveBrowserNavigationUrl(rawUrl);
+  if (!resolved.url) throw new Error("Invalid browser URL");
+  await target.contents.loadURL(resolved.url);
+}
+
+async function closeCreatedTarget(
+  options: BrowserNodeAutomationRegistryOptions,
+  target: RegisteredTarget
+): Promise<void> {
+  await options.closeTarget?.(toSummary(target));
+}
+
+async function releaseTargetLease(
+  leases: Map<string, AutomationLease>,
+  acquired: { key: string; lease: AutomationLease },
+  target: RegisteredTarget
+): Promise<void> {
+  if (leases.get(acquired.key) !== acquired.lease) return;
+  clearTimeout(acquired.lease.timeout);
+  leases.delete(acquired.key);
+  await target.driver.disableRequestGuard();
+}
+
 function resolveOwnerKey(input: BrowserNodeAutomationCallInput): string {
   return `${normalizeRequired(input.workspaceId, "workspaceId")}:${normalizeOptional(input.agentSessionId) ?? "manual"}`;
 }
@@ -389,10 +521,10 @@ function formatPageResult(prefix: string, nodeId: string): string {
 
 function clearSelectedTarget(
   selections: Map<string, string>,
-  nodeId: string
+  selectedKey: string
 ): void {
-  for (const [owner, selectedNodeId] of selections) {
-    if (selectedNodeId === nodeId) {
+  for (const [owner, ownerSelectedKey] of selections) {
+    if (ownerSelectedKey === selectedKey) {
       selections.delete(owner);
     }
   }
@@ -402,11 +534,7 @@ async function navigateTarget(
   target: RegisteredTarget,
   rawUrl: string
 ): Promise<BrowserNodeAutomationToolResult> {
-  const resolved = resolveBrowserNavigationUrl(rawUrl);
-  if (!resolved.url) {
-    throw new Error("Invalid browser URL");
-  }
-  await target.contents.loadURL(resolved.url);
+  await loadTargetUrl(target, rawUrl);
   return target.driver.snapshot();
 }
 

--- a/packages/browser/workbench-node/src/electron-main/automationRegistry.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationRegistry.ts
@@ -1,0 +1,394 @@
+import type { BrowserNodeAutomationTargetMetadata } from "../core/types.ts";
+import { resolveBrowserNavigationUrl } from "../core/url.ts";
+import { BrowserNodeAutomationDriver } from "./automationDebugger.ts";
+import type {
+  BrowserNodeAutomationCallInput,
+  BrowserNodeAutomationRegistry,
+  BrowserNodeAutomationRegistryOptions,
+  BrowserNodeAutomationTargetSummary,
+  BrowserNodeAutomationTool,
+  BrowserNodeAutomationToolResult
+} from "./automationTypes.ts";
+import type { BrowserGuestWebContents } from "./types.ts";
+
+interface RegisteredTarget {
+  contents: BrowserGuestWebContents;
+  driver: BrowserNodeAutomationDriver;
+  focusedSequence: number;
+  metadata: BrowserNodeAutomationTargetMetadata;
+  nodeId: string;
+}
+
+interface AutomationLease {
+  expiresAt: number;
+  owner: string;
+}
+
+const defaultLeaseTtlMs = 60_000;
+const createdPageResultPrefix = "Created browser page";
+const closedPageResultPrefix = "Closed browser page";
+const selectedPageResultPrefix = "Selected browser page";
+
+export function createBrowserNodeAutomationRegistry(
+  options: BrowserNodeAutomationRegistryOptions = {}
+): BrowserNodeAutomationRegistry {
+  const targets = new Map<string, RegisteredTarget>();
+  const leases = new Map<string, AutomationLease>();
+  const selectedTargetByOwner = new Map<string, string>();
+  const now = options.now ?? Date.now;
+  const leaseTtlMs = Math.max(1, options.leaseTtlMs ?? defaultLeaseTtlMs);
+  let focusSequence = 0;
+
+  const list = (input: {
+    agentSessionId?: string | null;
+    workspaceId: string;
+  }): BrowserNodeAutomationTargetSummary[] => {
+    const workspaceId = normalizeRequired(input.workspaceId, "workspaceId");
+    const agentSessionId = normalizeOptional(input.agentSessionId);
+    return Array.from(targets.values())
+      .filter((target) => isTargetVisible(target, workspaceId, agentSessionId))
+      .sort(compareTargets)
+      .map(toSummary);
+  };
+
+  const resolveTarget = async (
+    input: BrowserNodeAutomationCallInput,
+    args: Record<string, unknown>
+  ): Promise<RegisteredTarget> => {
+    const pageId = readString(args.pageId) || readString(args.page_id);
+    const visible = list({
+      agentSessionId: input.agentSessionId,
+      workspaceId: input.workspaceId
+    });
+    const ownerKey = resolveOwnerKey(input);
+    const stablePageId = selectedTargetByOwner.get(ownerKey);
+    const selected = pageId
+      ? visible.find((target) => target.nodeId === pageId)
+      : (visible.find((target) => target.nodeId === stablePageId) ??
+        visible.find((target) => target.focused && target.selected) ??
+        visible.find((target) => target.selected) ??
+        visible[0]);
+    if (selected) {
+      const registered = targets.get(selected.nodeId);
+      if (registered) {
+        selectedTargetByOwner.set(ownerKey, registered.nodeId);
+        return registered;
+      }
+    }
+
+    if (pageId) {
+      throw new Error(`Browser page is unavailable: ${pageId}`);
+    }
+    const requestedNodeId = await options.requestTarget?.({
+      agentSessionId: normalizeOptional(input.agentSessionId),
+      requestedPageId: null,
+      workspaceId: input.workspaceId
+    });
+    const requested = requestedNodeId ? targets.get(requestedNodeId) : null;
+    if (
+      !requested ||
+      !isTargetVisible(
+        requested,
+        input.workspaceId,
+        normalizeOptional(input.agentSessionId)
+      )
+    ) {
+      throw new Error("No in-app Browser page is available");
+    }
+    return requested;
+  };
+
+  const authorize = async (
+    input: BrowserNodeAutomationCallInput,
+    args: Record<string, unknown>,
+    target: RegisteredTarget
+  ): Promise<void> => {
+    const result = await options.authorize?.({
+      agentSessionId: normalizeOptional(input.agentSessionId),
+      args,
+      target: toSummary(target),
+      tool: input.tool,
+      workspaceId: input.workspaceId
+    });
+    if (result && !result.allowed) {
+      throw new Error(`${result.code}: ${result.message}`);
+    }
+  };
+
+  const acquireLease = (
+    input: BrowserNodeAutomationCallInput,
+    target: RegisteredTarget
+  ): void => {
+    const timestamp = now();
+    const owner =
+      normalizeOptional(input.agentSessionId) ??
+      `manual:${normalizeRequired(input.workspaceId, "workspaceId")}`;
+    const current = leases.get(target.nodeId);
+    if (current && current.owner !== owner && current.expiresAt > timestamp) {
+      throw new Error(
+        `tab_in_use: browser page is controlled by ${current.owner}`
+      );
+    }
+    leases.set(target.nodeId, { expiresAt: timestamp + leaseTtlMs, owner });
+  };
+
+  return {
+    async call(input) {
+      const workspaceId = normalizeRequired(input.workspaceId, "workspaceId");
+      const args = input.args ?? {};
+      if (input.tool === "list_pages") {
+        return {
+          text: formatPageList(
+            list({ agentSessionId: input.agentSessionId, workspaceId })
+          )
+        };
+      }
+
+      if (input.tool === "new_page") {
+        const requestedPageId =
+          readString(args.pageId) || readString(args.page_id) || null;
+        const rawUrl = readString(args.url) || "about:blank";
+        const nodeId = await options.requestTarget?.({
+          agentSessionId: normalizeOptional(input.agentSessionId),
+          requestedPageId,
+          url: rawUrl,
+          workspaceId
+        });
+        if (!nodeId) {
+          throw new Error("In-app Browser did not create a page");
+        }
+        selectedTargetByOwner.set(resolveOwnerKey(input), nodeId);
+        const text = `${createdPageResultPrefix} ${nodeId}`;
+        return { text };
+      }
+
+      const normalizedInput = { ...input, workspaceId };
+      const target = await resolveTarget(normalizedInput, args);
+      await authorize(normalizedInput, args, target);
+      acquireLease(normalizedInput, target);
+
+      switch (input.tool) {
+        case "click":
+          return target.driver.click(requireString(args, "uid"));
+        case "close_page":
+          if (!options.closeTarget) {
+            throw new Error("Closing in-app Browser pages is unavailable");
+          }
+          await options.closeTarget(toSummary(target));
+          clearSelectedTarget(selectedTargetByOwner, target.nodeId);
+          return {
+            text: formatPageResult(closedPageResultPrefix, target.nodeId)
+          };
+        case "evaluate_script":
+          return target.driver.evaluate(requireString(args, "function"));
+        case "fill":
+          return target.driver.fill(
+            requireString(args, "uid"),
+            requireString(args, "value")
+          );
+        case "navigate_page":
+          return navigateTarget(target, requireString(args, "url"));
+        case "select_page":
+          selectedTargetByOwner.set(
+            resolveOwnerKey(normalizedInput),
+            target.nodeId
+          );
+          await options.selectTarget?.(toSummary(target));
+          return {
+            text: formatPageResult(selectedPageResultPrefix, target.nodeId)
+          };
+        case "take_screenshot":
+          return target.driver.screenshot(args.fullPage === true);
+        case "take_snapshot":
+          return target.driver.snapshot();
+      }
+    },
+    list,
+    register(nodeId, contents, metadata) {
+      const normalizedNodeId = normalizeRequired(nodeId, "nodeId");
+      const existing = targets.get(normalizedNodeId);
+      if (existing?.contents === contents) {
+        existing.metadata = normalizeMetadata(metadata);
+        if (metadata.focused) {
+          existing.focusedSequence = ++focusSequence;
+        }
+        return;
+      }
+      existing?.driver.dispose();
+      targets.set(normalizedNodeId, {
+        contents,
+        driver: new BrowserNodeAutomationDriver(contents),
+        focusedSequence: metadata.focused ? ++focusSequence : 0,
+        metadata: normalizeMetadata(metadata),
+        nodeId: normalizedNodeId
+      });
+    },
+    releaseAgent(agentSessionId) {
+      const owner = normalizeRequired(agentSessionId, "agentSessionId");
+      for (const [nodeId, lease] of leases) {
+        if (lease.owner === owner) {
+          leases.delete(nodeId);
+        }
+      }
+    },
+    unregister(nodeId, contents) {
+      const existing = targets.get(nodeId);
+      if (!existing || (contents && existing.contents !== contents)) {
+        return;
+      }
+      existing.driver.dispose();
+      targets.delete(nodeId);
+      leases.delete(nodeId);
+      clearSelectedTarget(selectedTargetByOwner, nodeId);
+    },
+    update(nodeId, metadata) {
+      const target = targets.get(nodeId);
+      if (!target) {
+        return;
+      }
+      target.metadata = normalizeMetadata(metadata);
+      if (metadata.focused) {
+        target.focusedSequence = ++focusSequence;
+      }
+    }
+  };
+}
+
+function resolveOwnerKey(input: BrowserNodeAutomationCallInput): string {
+  return `${normalizeRequired(input.workspaceId, "workspaceId")}:${normalizeOptional(input.agentSessionId) ?? "manual"}`;
+}
+
+function formatPageResult(prefix: string, nodeId: string): string {
+  return `${prefix} ${nodeId}`;
+}
+
+function clearSelectedTarget(
+  selections: Map<string, string>,
+  nodeId: string
+): void {
+  for (const [owner, selectedNodeId] of selections) {
+    if (selectedNodeId === nodeId) {
+      selections.delete(owner);
+    }
+  }
+}
+
+async function navigateTarget(
+  target: RegisteredTarget,
+  rawUrl: string
+): Promise<BrowserNodeAutomationToolResult> {
+  const resolved = resolveBrowserNavigationUrl(rawUrl);
+  if (!resolved.url) {
+    throw new Error("Invalid browser URL");
+  }
+  await target.contents.loadURL(resolved.url);
+  return target.driver.snapshot();
+}
+
+function isTargetVisible(
+  target: RegisteredTarget,
+  workspaceId: string,
+  agentSessionId: string | null
+): boolean {
+  if (
+    target.contents.isDestroyed() ||
+    target.metadata.workspaceId !== workspaceId
+  ) {
+    return false;
+  }
+  return (
+    target.metadata.surfaceRole === "user" ||
+    (target.metadata.surfaceRole === "agent" &&
+      normalizeOptional(target.metadata.agentSessionId) === agentSessionId)
+  );
+}
+
+function compareTargets(
+  left: RegisteredTarget,
+  right: RegisteredTarget
+): number {
+  if (left.focusedSequence !== right.focusedSequence) {
+    return right.focusedSequence - left.focusedSequence;
+  }
+  if (left.metadata.selected !== right.metadata.selected) {
+    return left.metadata.selected ? -1 : 1;
+  }
+  return left.nodeId.localeCompare(right.nodeId);
+}
+
+function toSummary(
+  target: RegisteredTarget
+): BrowserNodeAutomationTargetSummary {
+  return {
+    ...target.metadata,
+    focused: target.focusedSequence > 0,
+    nodeId: target.nodeId,
+    title: target.contents.getTitle(),
+    url: target.contents.getURL()
+  };
+}
+
+function formatPageList(
+  targets: readonly BrowserNodeAutomationTargetSummary[]
+): string {
+  if (targets.length === 0) {
+    return "No in-app Browser pages are available";
+  }
+  return targets
+    .map(
+      (target) =>
+        `${target.nodeId}${target.selected ? " [selected]" : ""} ${target.title || "(untitled)"} ${target.url || "about:blank"} surface=${target.surfaceRole}:${target.surfaceId}`
+    )
+    .join("\n");
+}
+
+function normalizeMetadata(
+  metadata: BrowserNodeAutomationTargetMetadata
+): BrowserNodeAutomationTargetMetadata {
+  return {
+    agentSessionId: normalizeOptional(metadata.agentSessionId),
+    focused: metadata.focused === true,
+    selected: metadata.selected === true,
+    surfaceId: normalizeRequired(metadata.surfaceId, "surfaceId"),
+    surfaceRole: metadata.surfaceRole,
+    tabId: normalizeOptional(metadata.tabId),
+    workspaceId: normalizeRequired(metadata.workspaceId, "workspaceId")
+  };
+}
+
+function normalizeRequired(value: unknown, label: string): string {
+  const normalized = readString(value);
+  if (!normalized) {
+    throw new Error(`Browser automation ${label} is required`);
+  }
+  return normalized;
+}
+
+function normalizeOptional(value: unknown): string | null {
+  return readString(value) || null;
+}
+
+function requireString(args: Record<string, unknown>, key: string): string {
+  return normalizeRequired(args[key], key);
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function isBrowserNodeAutomationTool(
+  value: string
+): value is BrowserNodeAutomationTool {
+  return new Set<string>([
+    "click",
+    "close_page",
+    "evaluate_script",
+    "fill",
+    "list_pages",
+    "navigate_page",
+    "new_page",
+    "select_page",
+    "take_screenshot",
+    "take_snapshot"
+  ]).has(value);
+}

--- a/packages/browser/workbench-node/src/electron-main/automationRegistry.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationRegistry.ts
@@ -17,11 +17,13 @@ interface RegisteredTarget {
   focusedSequence: number;
   metadata: BrowserNodeAutomationTargetMetadata;
   nodeId: string;
+  queue: Promise<void>;
 }
 
 interface AutomationLease {
   expiresAt: number;
   owner: string;
+  timeout: ReturnType<typeof setTimeout>;
 }
 
 const defaultLeaseTtlMs = 60_000;
@@ -69,7 +71,9 @@ export function createBrowserNodeAutomationRegistry(
         visible.find((target) => target.selected) ??
         visible[0]);
     if (selected) {
-      const registered = targets.get(selected.nodeId);
+      const registered = targets.get(
+        targetKey(input.workspaceId, selected.nodeId)
+      );
       if (registered) {
         selectedTargetByOwner.set(ownerKey, registered.nodeId);
         return registered;
@@ -84,7 +88,9 @@ export function createBrowserNodeAutomationRegistry(
       requestedPageId: null,
       workspaceId: input.workspaceId
     });
-    const requested = requestedNodeId ? targets.get(requestedNodeId) : null;
+    const requested = requestedNodeId
+      ? targets.get(targetKey(input.workspaceId, requestedNodeId))
+      : null;
     if (
       !requested ||
       !isTargetVisible(
@@ -95,6 +101,7 @@ export function createBrowserNodeAutomationRegistry(
     ) {
       throw new Error("No in-app Browser page is available");
     }
+    selectedTargetByOwner.set(ownerKey, requested.nodeId);
     return requested;
   };
 
@@ -118,18 +125,34 @@ export function createBrowserNodeAutomationRegistry(
   const acquireLease = (
     input: BrowserNodeAutomationCallInput,
     target: RegisteredTarget
-  ): void => {
+  ): { key: string; lease: AutomationLease } => {
     const timestamp = now();
     const owner =
       normalizeOptional(input.agentSessionId) ??
       `manual:${normalizeRequired(input.workspaceId, "workspaceId")}`;
-    const current = leases.get(target.nodeId);
+    const key = targetKey(target.metadata.workspaceId, target.nodeId);
+    const current = leases.get(key);
     if (current && current.owner !== owner && current.expiresAt > timestamp) {
       throw new Error(
         `tab_in_use: browser page is controlled by ${current.owner}`
       );
     }
-    leases.set(target.nodeId, { expiresAt: timestamp + leaseTtlMs, owner });
+    if (current) clearTimeout(current.timeout);
+    const timeout = setTimeout(() => {
+      if (leases.get(key) !== lease) return;
+      leases.delete(key);
+      void targets.get(key)?.driver.disableRequestGuard();
+    }, leaseTtlMs);
+    (
+      timeout as ReturnType<typeof setTimeout> & { unref?: () => void }
+    ).unref?.();
+    const lease: AutomationLease = {
+      expiresAt: timestamp + leaseTtlMs,
+      owner,
+      timeout
+    };
+    leases.set(key, lease);
+    return { key, lease };
   };
 
   return {
@@ -145,9 +168,31 @@ export function createBrowserNodeAutomationRegistry(
       }
 
       if (input.tool === "new_page") {
+        const ownerKey = resolveOwnerKey(input);
+        const visibleTargets = list({
+          agentSessionId: input.agentSessionId,
+          workspaceId
+        });
         const requestedPageId =
-          readString(args.pageId) || readString(args.page_id) || null;
+          readString(args.pageId) ||
+          readString(args.page_id) ||
+          selectedTargetByOwner.get(ownerKey) ||
+          visibleTargets.find((target) => target.focused && target.selected)
+            ?.nodeId ||
+          visibleTargets.find((target) => target.selected)?.nodeId ||
+          visibleTargets[0]?.nodeId ||
+          null;
         const rawUrl = readString(args.url) || "about:blank";
+        const authorization = await options.authorize?.({
+          agentSessionId: normalizeOptional(input.agentSessionId),
+          args: { ...args, url: rawUrl },
+          target: null,
+          tool: input.tool,
+          workspaceId
+        });
+        if (authorization && !authorization.allowed) {
+          throw new Error(`${authorization.code}: ${authorization.message}`);
+        }
         const nodeId = await options.requestTarget?.({
           agentSessionId: normalizeOptional(input.agentSessionId),
           requestedPageId,
@@ -157,56 +202,79 @@ export function createBrowserNodeAutomationRegistry(
         if (!nodeId) {
           throw new Error("In-app Browser did not create a page");
         }
-        selectedTargetByOwner.set(resolveOwnerKey(input), nodeId);
+        selectedTargetByOwner.set(ownerKey, nodeId);
         const text = `${createdPageResultPrefix} ${nodeId}`;
         return { text };
       }
 
       const normalizedInput = { ...input, workspaceId };
       const target = await resolveTarget(normalizedInput, args);
-      await authorize(normalizedInput, args, target);
-      acquireLease(normalizedInput, target);
-
-      switch (input.tool) {
-        case "click":
-          return target.driver.click(requireString(args, "uid"));
-        case "close_page":
-          if (!options.closeTarget) {
-            throw new Error("Closing in-app Browser pages is unavailable");
+      return enqueueTarget(target, async () => {
+        await authorize(normalizedInput, args, target);
+        const acquired = acquireLease(normalizedInput, target);
+        try {
+          if (options.authorizeRequest) {
+            await target.driver.enableRequestGuard(async (url) =>
+              options.authorizeRequest!({
+                agentSessionId: normalizeOptional(input.agentSessionId),
+                args: { url },
+                target: toSummary(target),
+                tool: "navigate_page",
+                workspaceId
+              })
+            );
           }
-          await options.closeTarget(toSummary(target));
-          clearSelectedTarget(selectedTargetByOwner, target.nodeId);
-          return {
-            text: formatPageResult(closedPageResultPrefix, target.nodeId)
-          };
-        case "evaluate_script":
-          return target.driver.evaluate(requireString(args, "function"));
-        case "fill":
-          return target.driver.fill(
-            requireString(args, "uid"),
-            requireString(args, "value")
-          );
-        case "navigate_page":
-          return navigateTarget(target, requireString(args, "url"));
-        case "select_page":
-          selectedTargetByOwner.set(
-            resolveOwnerKey(normalizedInput),
-            target.nodeId
-          );
-          await options.selectTarget?.(toSummary(target));
-          return {
-            text: formatPageResult(selectedPageResultPrefix, target.nodeId)
-          };
-        case "take_screenshot":
-          return target.driver.screenshot(args.fullPage === true);
-        case "take_snapshot":
-          return target.driver.snapshot();
-      }
+        } catch (error) {
+          if (leases.get(acquired.key) === acquired.lease) {
+            clearTimeout(acquired.lease.timeout);
+            leases.delete(acquired.key);
+          }
+          throw error;
+        }
+
+        switch (input.tool) {
+          case "click":
+            return target.driver.click(requireString(args, "uid"));
+          case "close_page":
+            if (!options.closeTarget) {
+              throw new Error("Closing in-app Browser pages is unavailable");
+            }
+            await options.closeTarget(toSummary(target));
+            clearSelectedTarget(selectedTargetByOwner, target.nodeId);
+            return {
+              text: formatPageResult(closedPageResultPrefix, target.nodeId)
+            };
+          case "evaluate_script":
+            return target.driver.evaluate(requireString(args, "function"));
+          case "fill":
+            return target.driver.fill(
+              requireString(args, "uid"),
+              requireString(args, "value")
+            );
+          case "navigate_page":
+            return navigateTarget(target, requireString(args, "url"));
+          case "select_page":
+            selectedTargetByOwner.set(
+              resolveOwnerKey(normalizedInput),
+              target.nodeId
+            );
+            await options.selectTarget?.(toSummary(target));
+            return {
+              text: formatPageResult(selectedPageResultPrefix, target.nodeId)
+            };
+          case "take_screenshot":
+            return target.driver.screenshot(args.fullPage === true);
+          case "take_snapshot":
+            return target.driver.snapshot();
+        }
+        throw new Error(`Unsupported browser automation tool: ${input.tool}`);
+      });
     },
     list,
     register(nodeId, contents, metadata) {
       const normalizedNodeId = normalizeRequired(nodeId, "nodeId");
-      const existing = targets.get(normalizedNodeId);
+      const key = targetKey(metadata.workspaceId, normalizedNodeId);
+      const existing = targets.get(key);
       if (existing?.contents === contents) {
         existing.metadata = normalizeMetadata(metadata);
         if (metadata.focused) {
@@ -215,34 +283,70 @@ export function createBrowserNodeAutomationRegistry(
         return;
       }
       existing?.driver.dispose();
-      targets.set(normalizedNodeId, {
+      targets.set(key, {
         contents,
         driver: new BrowserNodeAutomationDriver(contents),
         focusedSequence: metadata.focused ? ++focusSequence : 0,
         metadata: normalizeMetadata(metadata),
-        nodeId: normalizedNodeId
+        nodeId: normalizedNodeId,
+        queue: Promise.resolve()
       });
     },
-    releaseAgent(agentSessionId) {
+    invalidate(nodeId, contents) {
+      for (const target of targets.values()) {
+        if (
+          target.nodeId === nodeId &&
+          (!contents || target.contents === contents)
+        ) {
+          target.driver.invalidate();
+        }
+      }
+    },
+    async releaseAgent(agentSessionId) {
       const owner = normalizeRequired(agentSessionId, "agentSessionId");
       for (const [nodeId, lease] of leases) {
         if (lease.owner === owner) {
+          clearTimeout(lease.timeout);
           leases.delete(nodeId);
+          void targets.get(nodeId)?.driver.disableRequestGuard();
+        }
+      }
+      for (const ownerKey of selectedTargetByOwner.keys()) {
+        if (ownerKey.endsWith(`:${owner}`)) {
+          selectedTargetByOwner.delete(ownerKey);
+        }
+      }
+      if (options.closeTarget) {
+        const agentTargets = Array.from(targets.values()).filter(
+          (target) =>
+            target.metadata.surfaceRole === "agent" &&
+            normalizeOptional(target.metadata.agentSessionId) === owner
+        );
+        for (const target of agentTargets) {
+          await enqueueTarget(target, () =>
+            options.closeTarget!(toSummary(target))
+          );
         }
       }
     },
     unregister(nodeId, contents) {
-      const existing = targets.get(nodeId);
-      if (!existing || (contents && existing.contents !== contents)) {
-        return;
+      for (const [key, existing] of targets) {
+        if (
+          existing.nodeId !== nodeId ||
+          (contents && existing.contents !== contents)
+        ) {
+          continue;
+        }
+        existing.driver.dispose();
+        targets.delete(key);
+        const lease = leases.get(key);
+        if (lease) clearTimeout(lease.timeout);
+        leases.delete(key);
+        clearSelectedTarget(selectedTargetByOwner, existing.nodeId);
       }
-      existing.driver.dispose();
-      targets.delete(nodeId);
-      leases.delete(nodeId);
-      clearSelectedTarget(selectedTargetByOwner, nodeId);
     },
     update(nodeId, metadata) {
-      const target = targets.get(nodeId);
+      const target = targets.get(targetKey(metadata.workspaceId, nodeId));
       if (!target) {
         return;
       }
@@ -252,6 +356,27 @@ export function createBrowserNodeAutomationRegistry(
       }
     }
   };
+}
+
+async function enqueueTarget<TResult>(
+  target: RegisteredTarget,
+  operation: () => Promise<TResult>
+): Promise<TResult> {
+  const previous = target.queue;
+  let release!: () => void;
+  target.queue = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
+}
+
+function targetKey(workspaceId: string, nodeId: string): string {
+  return `${normalizeRequired(workspaceId, "workspaceId")}\u0000${normalizeRequired(nodeId, "nodeId")}`;
 }
 
 function resolveOwnerKey(input: BrowserNodeAutomationCallInput): string {

--- a/packages/browser/workbench-node/src/electron-main/automationServer.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationServer.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createBrowserNodeAutomationServer } from "./automationServer.ts";
+import type { BrowserNodeAutomationRegistry } from "./automationTypes.ts";
+
+test("automation server publishes a private authenticated loopback endpoint", async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), "browser-node-server-"));
+  const listenerInfoPath = join(directory, "listener.json");
+  let callCount = 0;
+  const registry: BrowserNodeAutomationRegistry = {
+    async call(input) {
+      callCount += 1;
+      return { text: `${input.workspaceId}:${input.tool}` };
+    },
+    list: () => [],
+    register() {},
+    releaseAgent() {},
+    unregister() {},
+    update() {}
+  };
+  const server = await createBrowserNodeAutomationServer({
+    listenerInfoPath,
+    registry
+  });
+  t.after(() => server.dispose());
+
+  const published = JSON.parse(await readFile(listenerInfoPath, "utf8")) as {
+    address: string;
+    token: string;
+  };
+  assert.equal((await stat(listenerInfoPath)).mode & 0o777, 0o600);
+  assert.match(published.address, /^127\.0\.0\.1:\d+$/u);
+
+  const unauthorized = await fetch(`http://${published.address}/v1/call`, {
+    body: JSON.stringify({
+      tool: "list_pages",
+      workspaceId: "workspace-1"
+    }),
+    method: "POST"
+  });
+  assert.equal(unauthorized.status, 401);
+
+  const response = await fetch(`http://${published.address}/v1/call`, {
+    body: JSON.stringify({
+      tool: "list_pages",
+      workspaceId: "workspace-1"
+    }),
+    headers: { authorization: `Bearer ${published.token}` },
+    method: "POST"
+  });
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    result: { text: "workspace-1:list_pages" }
+  });
+  assert.equal(callCount, 1);
+});

--- a/packages/browser/workbench-node/src/electron-main/automationServer.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationServer.test.ts
@@ -10,14 +10,18 @@ test("automation server publishes a private authenticated loopback endpoint", as
   const directory = await mkdtemp(join(tmpdir(), "browser-node-server-"));
   const listenerInfoPath = join(directory, "listener.json");
   let callCount = 0;
+  const releasedAgents: string[] = [];
   const registry: BrowserNodeAutomationRegistry = {
     async call(input) {
       callCount += 1;
       return { text: `${input.workspaceId}:${input.tool}` };
     },
     list: () => [],
+    invalidate() {},
     register() {},
-    releaseAgent() {},
+    async releaseAgent(agentSessionId) {
+      releasedAgents.push(agentSessionId);
+    },
     unregister() {},
     update() {}
   };
@@ -56,4 +60,12 @@ test("automation server publishes a private authenticated loopback endpoint", as
     result: { text: "workspace-1:list_pages" }
   });
   assert.equal(callCount, 1);
+
+  const released = await fetch(`http://${published.address}/v1/release-agent`, {
+    body: JSON.stringify({ agentSessionId: "agent-1" }),
+    headers: { authorization: `Bearer ${published.token}` },
+    method: "POST"
+  });
+  assert.equal(released.status, 200);
+  assert.deepEqual(releasedAgents, ["agent-1"]);
 });

--- a/packages/browser/workbench-node/src/electron-main/automationServer.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationServer.ts
@@ -1,0 +1,204 @@
+import { randomBytes } from "node:crypto";
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse
+} from "node:http";
+import { dirname } from "node:path";
+import type { AddressInfo } from "node:net";
+import { isBrowserNodeAutomationTool } from "./automationRegistry.ts";
+import type {
+  BrowserNodeAutomationCallInput,
+  BrowserNodeAutomationRegistry,
+  BrowserNodeAutomationToolResult
+} from "./automationTypes.ts";
+import type { BrowserNodeElectronLogger } from "./types.ts";
+
+const maximumRequestBytes = 1024 * 1024;
+const genericRequestFailure = "BrowserNode automation request failed";
+const notFoundMessage = "Not found";
+const unauthorizedMessage = "Unauthorized";
+
+export interface BrowserNodeAutomationListenerInfo {
+  address: string;
+  token: string;
+  version: 1;
+}
+
+export interface BrowserNodeAutomationServer {
+  readonly listenerInfo: BrowserNodeAutomationListenerInfo;
+  dispose(): void;
+}
+
+export async function createBrowserNodeAutomationServer(input: {
+  listenerInfoPath: string;
+  logger?: BrowserNodeElectronLogger;
+  registry: BrowserNodeAutomationRegistry;
+}): Promise<BrowserNodeAutomationServer> {
+  const listenerInfoPath = input.listenerInfoPath.trim();
+  if (!listenerInfoPath) {
+    throw new Error("BrowserNode automation listener info path is required");
+  }
+  const token = randomBytes(32).toString("base64url");
+  const server = createServer((request, response) => {
+    void handleRequest(request, response, token, input.registry).catch(
+      (error) => {
+        input.logger?.warn?.("BrowserNode automation request failed", {
+          error: error instanceof Error ? error.message : String(error)
+        });
+        sendJson(response, 500, {
+          error: { message: genericRequestFailure }
+        });
+      }
+    );
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address() as AddressInfo | null;
+  if (!address) {
+    server.close();
+    throw new Error("BrowserNode automation server did not bind an address");
+  }
+  const listenerInfo: BrowserNodeAutomationListenerInfo = {
+    address: `127.0.0.1:${address.port}`,
+    token,
+    version: 1
+  };
+  await writeListenerInfo(listenerInfoPath, listenerInfo);
+  input.logger?.info?.("BrowserNode automation server listening", {
+    address: listenerInfo.address,
+    listenerInfoPath
+  });
+
+  let disposed = false;
+  return {
+    listenerInfo,
+    dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      server.close();
+      void rm(listenerInfoPath, { force: true }).catch(() => undefined);
+    }
+  };
+}
+
+async function handleRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  token: string,
+  registry: BrowserNodeAutomationRegistry
+): Promise<void> {
+  if (request.method !== "POST" || request.url !== "/v1/call") {
+    sendJson(response, 404, { error: { message: notFoundMessage } });
+    return;
+  }
+  if (request.headers.authorization !== `Bearer ${token}`) {
+    sendJson(response, 401, { error: { message: unauthorizedMessage } });
+    return;
+  }
+
+  let call: BrowserNodeAutomationCallInput;
+  try {
+    call = parseCall(await readRequestBody(request));
+  } catch (error) {
+    sendJson(response, 400, {
+      error: {
+        message: error instanceof Error ? error.message : String(error)
+      }
+    });
+    return;
+  }
+
+  try {
+    const result = await registry.call(call);
+    sendJson(response, 200, { result });
+  } catch (error) {
+    sendJson(response, 409, {
+      error: {
+        message: error instanceof Error ? error.message : String(error)
+      }
+    });
+  }
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.length;
+    if (size > maximumRequestBytes) {
+      throw new Error("BrowserNode automation request is too large");
+    }
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function parseCall(raw: string): BrowserNodeAutomationCallInput {
+  const value = JSON.parse(raw) as Partial<BrowserNodeAutomationCallInput>;
+  if (
+    !value ||
+    typeof value !== "object" ||
+    typeof value.workspaceId !== "string" ||
+    typeof value.tool !== "string" ||
+    !isBrowserNodeAutomationTool(value.tool) ||
+    (value.args !== undefined &&
+      (!value.args ||
+        typeof value.args !== "object" ||
+        Array.isArray(value.args)))
+  ) {
+    throw new Error("Invalid BrowserNode automation call");
+  }
+  return {
+    agentSessionId:
+      typeof value.agentSessionId === "string" ? value.agentSessionId : null,
+    args: value.args ?? {},
+    tool: value.tool,
+    workspaceId: value.workspaceId
+  };
+}
+
+function sendJson(
+  response: ServerResponse,
+  statusCode: number,
+  value:
+    | { error: { message: string } }
+    | { result: BrowserNodeAutomationToolResult }
+): void {
+  if (response.headersSent) {
+    response.end();
+    return;
+  }
+  response.writeHead(statusCode, {
+    "cache-control": "no-store",
+    "content-type": "application/json; charset=utf-8"
+  });
+  response.end(JSON.stringify(value));
+}
+
+async function writeListenerInfo(
+  path: string,
+  listenerInfo: BrowserNodeAutomationListenerInfo
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const temporaryPath = `${path}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
+  await writeFile(temporaryPath, `${JSON.stringify(listenerInfo)}\n`, {
+    mode: 0o600
+  });
+  try {
+    await rename(temporaryPath, path);
+  } catch (error) {
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}

--- a/packages/browser/workbench-node/src/electron-main/automationServer.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationServer.ts
@@ -19,6 +19,8 @@ const maximumRequestBytes = 1024 * 1024;
 const genericRequestFailure = "BrowserNode automation request failed";
 const notFoundMessage = "Not found";
 const unauthorizedMessage = "Unauthorized";
+const callPath = "/v1/call";
+const releaseAgentPath = "/v1/release-agent";
 
 export interface BrowserNodeAutomationListenerInfo {
   address: string;
@@ -97,7 +99,10 @@ async function handleRequest(
   token: string,
   registry: BrowserNodeAutomationRegistry
 ): Promise<void> {
-  if (request.method !== "POST" || request.url !== "/v1/call") {
+  if (
+    request.method !== "POST" ||
+    (request.url !== callPath && request.url !== releaseAgentPath)
+  ) {
     sendJson(response, 404, { error: { message: notFoundMessage } });
     return;
   }
@@ -106,9 +111,25 @@ async function handleRequest(
     return;
   }
 
+  const body = await readRequestBody(request);
+  if (request.url === releaseAgentPath) {
+    try {
+      const agentSessionId = parseReleaseAgent(body);
+      await registry.releaseAgent(agentSessionId);
+      sendJson(response, 200, { result: { text: "" } });
+    } catch (error) {
+      sendJson(response, 400, {
+        error: {
+          message: error instanceof Error ? error.message : String(error)
+        }
+      });
+    }
+    return;
+  }
+
   let call: BrowserNodeAutomationCallInput;
   try {
-    call = parseCall(await readRequestBody(request));
+    call = parseCall(body);
   } catch (error) {
     sendJson(response, 400, {
       error: {
@@ -128,6 +149,18 @@ async function handleRequest(
       }
     });
   }
+}
+
+function parseReleaseAgent(raw: string): string {
+  const value = JSON.parse(raw) as { agentSessionId?: unknown };
+  const agentSessionId =
+    typeof value?.agentSessionId === "string"
+      ? value.agentSessionId.trim()
+      : "";
+  if (!agentSessionId) {
+    throw new Error("Invalid BrowserNode Agent release request");
+  }
+  return agentSessionId;
 }
 
 async function readRequestBody(request: IncomingMessage): Promise<string> {

--- a/packages/browser/workbench-node/src/electron-main/automationTypes.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationTypes.ts
@@ -1,0 +1,87 @@
+import type { BrowserNodeAutomationTargetMetadata } from "../core/types.ts";
+import type { BrowserGuestWebContents } from "./types.ts";
+
+export type BrowserNodeAutomationTool =
+  | "click"
+  | "close_page"
+  | "evaluate_script"
+  | "fill"
+  | "list_pages"
+  | "navigate_page"
+  | "new_page"
+  | "select_page"
+  | "take_screenshot"
+  | "take_snapshot";
+
+export interface BrowserNodeAutomationCallInput {
+  agentSessionId?: string | null;
+  args?: Record<string, unknown>;
+  tool: BrowserNodeAutomationTool;
+  workspaceId: string;
+}
+
+export interface BrowserNodeAutomationToolResult {
+  screenshotData?: string;
+  text: string;
+}
+
+export interface BrowserNodeAutomationTargetSummary extends BrowserNodeAutomationTargetMetadata {
+  nodeId: string;
+  title: string;
+  url: string;
+}
+
+export interface BrowserNodeAutomationAuthorizationInput {
+  agentSessionId: string | null;
+  args: Record<string, unknown>;
+  target: BrowserNodeAutomationTargetSummary;
+  tool: BrowserNodeAutomationTool;
+  workspaceId: string;
+}
+
+export type BrowserNodeAutomationAuthorizationResult =
+  | { allowed: true }
+  | { allowed: false; code: string; message: string };
+
+export interface BrowserNodeAutomationTargetRequest {
+  agentSessionId: string | null;
+  requestedPageId?: string | null;
+  url?: string | null;
+  workspaceId: string;
+}
+
+export interface BrowserNodeAutomationRegistryOptions {
+  authorize?: (
+    input: BrowserNodeAutomationAuthorizationInput
+  ) =>
+    | BrowserNodeAutomationAuthorizationResult
+    | Promise<BrowserNodeAutomationAuthorizationResult>;
+  closeTarget?: (target: BrowserNodeAutomationTargetSummary) => Promise<void>;
+  leaseTtlMs?: number;
+  now?: () => number;
+  requestTarget?: (
+    input: BrowserNodeAutomationTargetRequest
+  ) => Promise<string | null>;
+  selectTarget?: (target: BrowserNodeAutomationTargetSummary) => Promise<void>;
+}
+
+export interface BrowserNodeAutomationTargetRegistry {
+  register(
+    nodeId: string,
+    contents: BrowserGuestWebContents,
+    metadata: BrowserNodeAutomationTargetMetadata
+  ): void;
+  unregister(nodeId: string, contents?: BrowserGuestWebContents | null): void;
+  update(nodeId: string, metadata: BrowserNodeAutomationTargetMetadata): void;
+}
+
+export interface BrowserNodeAutomationRegistry extends BrowserNodeAutomationTargetRegistry {
+  call(
+    input: BrowserNodeAutomationCallInput
+  ): Promise<BrowserNodeAutomationToolResult>;
+  list(input: {
+    agentSessionId?: string | null;
+    workspaceId: string;
+  }): readonly BrowserNodeAutomationTargetSummary[];
+  releaseAgent(agentSessionId: string): void;
+}

--- a/packages/browser/workbench-node/src/electron-main/automationTypes.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationTypes.ts
@@ -34,6 +34,7 @@ export interface BrowserNodeAutomationTargetSummary extends BrowserNodeAutomatio
 export interface BrowserNodeAutomationAuthorizationInput {
   agentSessionId: string | null;
   args: Record<string, unknown>;
+  resolveHost?: (hostname: string) => Promise<readonly string[]>;
   target: BrowserNodeAutomationTargetSummary | null;
   tool: BrowserNodeAutomationTool;
   workspaceId: string;

--- a/packages/browser/workbench-node/src/electron-main/automationTypes.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationTypes.ts
@@ -34,7 +34,7 @@ export interface BrowserNodeAutomationTargetSummary extends BrowserNodeAutomatio
 export interface BrowserNodeAutomationAuthorizationInput {
   agentSessionId: string | null;
   args: Record<string, unknown>;
-  target: BrowserNodeAutomationTargetSummary;
+  target: BrowserNodeAutomationTargetSummary | null;
   tool: BrowserNodeAutomationTool;
   workspaceId: string;
 }
@@ -56,6 +56,11 @@ export interface BrowserNodeAutomationRegistryOptions {
   ) =>
     | BrowserNodeAutomationAuthorizationResult
     | Promise<BrowserNodeAutomationAuthorizationResult>;
+  authorizeRequest?: (
+    input: BrowserNodeAutomationAuthorizationInput
+  ) =>
+    | BrowserNodeAutomationAuthorizationResult
+    | Promise<BrowserNodeAutomationAuthorizationResult>;
   closeTarget?: (target: BrowserNodeAutomationTargetSummary) => Promise<void>;
   leaseTtlMs?: number;
   now?: () => number;
@@ -66,6 +71,7 @@ export interface BrowserNodeAutomationRegistryOptions {
 }
 
 export interface BrowserNodeAutomationTargetRegistry {
+  invalidate(nodeId: string, contents?: BrowserGuestWebContents | null): void;
   register(
     nodeId: string,
     contents: BrowserGuestWebContents,
@@ -83,5 +89,5 @@ export interface BrowserNodeAutomationRegistry extends BrowserNodeAutomationTarg
     agentSessionId?: string | null;
     workspaceId: string;
   }): readonly BrowserNodeAutomationTargetSummary[];
-  releaseAgent(agentSessionId: string): void;
+  releaseAgent(agentSessionId: string): Promise<void>;
 }

--- a/packages/browser/workbench-node/src/electron-main/guestManager.ts
+++ b/packages/browser/workbench-node/src/electron-main/guestManager.ts
@@ -1,4 +1,5 @@
 import type {
+  BrowserNodeAutomationTargetMetadata,
   BrowserNodeLifecycle,
   BrowserNodeNavigationPolicy,
   BrowserNodeSessionMode
@@ -49,6 +50,7 @@ import {
 
 interface BrowserGuestSession {
   appliedColorScheme: BrowserPreferredColorScheme | null;
+  automationTarget: BrowserNodeAutomationTargetMetadata | null;
   contents: BrowserGuestWebContents | null;
   desiredUrl: string;
   findQuery: string;
@@ -98,6 +100,7 @@ async function applyPreferredColorSchemeToGuest(
 }
 
 export function createBrowserGuestManager({
+  automationRegistry,
   chooseDownloadDirectory,
   emit,
   getPreferredColorScheme,
@@ -127,6 +130,7 @@ export function createBrowserGuestManager({
   const getSession = (
     nodeId: string,
     input?: {
+      automationTarget?: BrowserNodeAutomationTargetMetadata | null;
       navigationPolicy?: BrowserNodeNavigationPolicy | null;
       profileId?: string | null;
       sessionMode?: BrowserNodeSessionMode;
@@ -136,6 +140,9 @@ export function createBrowserGuestManager({
   ): BrowserGuestSession => {
     const existing = sessions.get(nodeId);
     if (existing) {
+      if (input?.automationTarget !== undefined) {
+        existing.automationTarget = input.automationTarget;
+      }
       if (input?.profileId !== undefined) {
         existing.profileId = input.profileId;
       }
@@ -156,6 +163,7 @@ export function createBrowserGuestManager({
 
     const session: BrowserGuestSession = {
       appliedColorScheme: null,
+      automationTarget: input?.automationTarget ?? null,
       contents: null,
       desiredUrl: input?.url ?? "about:blank",
       findQuery: "",
@@ -204,6 +212,7 @@ export function createBrowserGuestManager({
       }
     }
     session.listeners = [];
+    automationRegistry?.unregister(session.nodeId, contents);
     session.contents = null;
     session.appliedColorScheme = null;
     session.webContentsId = null;
@@ -693,6 +702,7 @@ export function createBrowserGuestManager({
       }
 
       const session = getSession(input.nodeId, {
+        automationTarget: input.automationTarget,
         navigationPolicy: input.navigationPolicy,
         profileId: input.profileId,
         sessionMode: input.sessionMode,
@@ -703,6 +713,15 @@ export function createBrowserGuestManager({
         session.webContentsId === input.webContentsId &&
         session.contents === contents
       ) {
+        if (session.automationTarget) {
+          automationRegistry?.register(
+            session.nodeId,
+            contents,
+            session.automationTarget
+          );
+        } else {
+          automationRegistry?.unregister(session.nodeId, contents);
+        }
         publishState(session);
         return;
       }
@@ -716,6 +735,13 @@ export function createBrowserGuestManager({
         downloadController.attach(contents.session);
       }
       session.lifecycle = "active";
+      if (session.automationTarget) {
+        automationRegistry?.register(
+          session.nodeId,
+          contents,
+          session.automationTarget
+        );
+      }
       contents.setWindowOpenHandler?.(({ url }) => {
         if (isGoogleGisOAuthPopupUrl(url)) {
           logger?.info?.("Browser Node allowing Google GIS OAuth popup", {
@@ -791,7 +817,23 @@ export function createBrowserGuestManager({
       detachGuest(session);
       return Promise.resolve();
     },
+    updateAutomationTarget(nodeId, metadata) {
+      const session = sessions.get(nodeId);
+      if (!session) {
+        return;
+      }
+      session.automationTarget = metadata;
+      if (metadata && session.contents && !session.contents.isDestroyed()) {
+        automationRegistry?.register(nodeId, session.contents, metadata);
+      } else {
+        automationRegistry?.unregister(nodeId, session.contents);
+      }
+    },
     dispose() {
+      for (const session of sessions.values()) {
+        detachGuest(session);
+      }
+      sessions.clear();
       unsubscribePreferredColorScheme?.();
       downloadController.dispose();
     }

--- a/packages/browser/workbench-node/src/electron-main/guestManager.ts
+++ b/packages/browser/workbench-node/src/electron-main/guestManager.ts
@@ -250,6 +250,10 @@ export function createBrowserGuestManager({
     }
 
     const onStateChange = () => publishState(session);
+    const onDidStartNavigation = () => {
+      automationRegistry?.invalidate(session.nodeId, contents);
+      publishState(session);
+    };
     const onDidNavigate = (...args: unknown[]) => {
       const url = typeof args[1] === "string" ? args[1] : undefined;
       const statusCode = typeof args[2] === "number" ? args[2] : undefined;
@@ -344,6 +348,7 @@ export function createBrowserGuestManager({
 
     const records: BrowserGuestSession["listeners"] = [
       { event: "did-start-loading", listener: onStateChange },
+      { event: "did-start-navigation", listener: onDidStartNavigation },
       { event: "did-stop-loading", listener: onStateChange },
       { event: "did-navigate", listener: onDidNavigate },
       { event: "did-navigate-in-page", listener: onStateChange },

--- a/packages/browser/workbench-node/src/electron-main/index.ts
+++ b/packages/browser/workbench-node/src/electron-main/index.ts
@@ -15,6 +15,31 @@ export type {
   BrowserNodeElectronLogger
 } from "./types.ts";
 export {
+  createBrowserNodeAutomationRegistry,
+  isBrowserNodeAutomationTool
+} from "./automationRegistry.ts";
+export {
+  createBrowserNodeAutomationServer,
+  type BrowserNodeAutomationListenerInfo,
+  type BrowserNodeAutomationServer
+} from "./automationServer.ts";
+export {
+  createBrowserNodeAutomationNetworkAuthorizer,
+  type BrowserNodeAutomationNetworkPolicyOptions
+} from "./automationNetworkPolicy.ts";
+export type {
+  BrowserNodeAutomationAuthorizationInput,
+  BrowserNodeAutomationAuthorizationResult,
+  BrowserNodeAutomationCallInput,
+  BrowserNodeAutomationRegistry,
+  BrowserNodeAutomationRegistryOptions,
+  BrowserNodeAutomationTargetRegistry,
+  BrowserNodeAutomationTargetRequest,
+  BrowserNodeAutomationTargetSummary,
+  BrowserNodeAutomationTool,
+  BrowserNodeAutomationToolResult
+} from "./automationTypes.ts";
+export {
   applyBrowserGuestUserAgent,
   sanitizeBrowserGuestUserAgent
 } from "./userAgent.ts";

--- a/packages/browser/workbench-node/src/electron-main/registerElectronMain.ts
+++ b/packages/browser/workbench-node/src/electron-main/registerElectronMain.ts
@@ -21,8 +21,10 @@ import type {
   BrowserNodeSetZoomFactorInput,
   BrowserNodeShowDevToolsContextMenuInput,
   BrowserNodeStopFindInPageInput,
-  BrowserNodeUnregisterGuestInput
+  BrowserNodeUnregisterGuestInput,
+  BrowserNodeUpdateAutomationTargetInput
 } from "../core/types.ts";
+import type { BrowserNodeAutomationTargetRegistry } from "./automationTypes.ts";
 import { createBrowserGuestManager } from "./guestManager.ts";
 import type {
   BrowserGuestManager,
@@ -62,6 +64,7 @@ export interface BrowserNodeElectronMainChannels {
   readonly showDevToolsContextMenu?: string;
   readonly stopFindInPage?: string;
   readonly unregisterGuest: string;
+  readonly updateAutomationTarget?: string;
 }
 
 export interface BrowserNodeElectronDevToolsContextMenuInput {
@@ -76,6 +79,7 @@ export interface BrowserNodeElectronScreenshotSaveInput extends BrowserNodeScree
 }
 
 export interface RegisterBrowserNodeElectronMainInput {
+  readonly automationRegistry?: BrowserNodeAutomationTargetRegistry;
   readonly channels: BrowserNodeElectronMainChannels;
   readonly chooseDownloadDirectory?: (
     ownerWindow: BrowserWindow
@@ -172,6 +176,7 @@ export function registerBrowserNodeElectronMain(
     }
 
     const manager = createBrowserGuestManager({
+      automationRegistry: input.automationRegistry,
       chooseDownloadDirectory: input.chooseDownloadDirectory
         ? () =>
             input.chooseDownloadDirectory?.(ownerWindow) ??
@@ -371,6 +376,18 @@ export function registerBrowserNodeElectronMain(
       payload as BrowserNodeUnregisterGuestInput
     )
   );
+  if (input.channels.updateAutomationTarget) {
+    input.registerHandler(
+      input.channels.updateAutomationTarget,
+      (event, payload) => {
+        const normalized = payload as BrowserNodeUpdateAutomationTargetInput;
+        resolveOwnedManager(event).manager.updateAutomationTarget(
+          normalized.nodeId,
+          normalized.automationTarget
+        );
+      }
+    );
+  }
   input.registerHandler(input.channels.navigate, (event, payload) =>
     resolveOwnedManager(event).manager.navigate(
       payload as BrowserNodeNavigateInput

--- a/packages/browser/workbench-node/src/electron-main/types.ts
+++ b/packages/browser/workbench-node/src/electron-main/types.ts
@@ -1,5 +1,6 @@
 import type {
   BrowserNodeActivationInput,
+  BrowserNodeAutomationTargetMetadata,
   BrowserNodeChromeCookieImportInput,
   BrowserNodeChromeProfileId,
   BrowserNodeCookieImportResult,
@@ -22,6 +23,7 @@ import type {
   BrowserNodeStopFindInPageInput,
   BrowserNodeUnregisterGuestInput
 } from "../core/types.ts";
+import type { BrowserNodeAutomationTargetRegistry } from "./automationTypes.ts";
 
 export interface BrowserGuestManager {
   activate(input: BrowserNodeActivationInput): Promise<void>;
@@ -66,6 +68,10 @@ export interface BrowserGuestManager {
   setZoomFactor(input: BrowserNodeSetZoomFactorInput): Promise<void>;
   stopFindInPage(input: BrowserNodeStopFindInPageInput): Promise<void>;
   unregisterGuest(input: BrowserNodeUnregisterGuestInput): Promise<void>;
+  updateAutomationTarget(
+    nodeId: string,
+    metadata: BrowserNodeAutomationTargetMetadata
+  ): void;
 }
 
 export type BrowserNodeShowDevToolsContextMenuPayload =
@@ -74,6 +80,7 @@ export type BrowserNodeShowDevToolsContextMenuPayload =
 export type BrowserPreferredColorScheme = "dark" | "light";
 
 export interface BrowserGuestManagerInput {
+  automationRegistry?: BrowserNodeAutomationTargetRegistry;
   emit: (event: BrowserNodeEvent) => void;
   getPreferredColorScheme?: () => BrowserPreferredColorScheme;
   chooseDownloadDirectory?: () => Promise<string | null>;

--- a/packages/browser/workbench-node/src/electron-main/types.ts
+++ b/packages/browser/workbench-node/src/electron-main/types.ts
@@ -177,6 +177,10 @@ export interface BrowserGuestElectronSession {
   cookies?: BrowserGuestCookieStore;
   off(event: "will-download", listener: BrowserGuestWillDownloadListener): this;
   on(event: "will-download", listener: BrowserGuestWillDownloadListener): this;
+  resolveHost?(
+    hostname: string,
+    options?: { cacheUsage?: "allowed" | "disallowed" | "staleAllowed" }
+  ): Promise<{ endpoints: readonly { address: string }[] }>;
   setDownloadPath?(path: string): void;
 }
 

--- a/packages/browser/workbench-node/src/electron-main/types.ts
+++ b/packages/browser/workbench-node/src/electron-main/types.ts
@@ -216,6 +216,14 @@ export interface BrowserGuestDebugger {
   attach(protocolVersion?: string): void;
   detach(): void;
   isAttached(): boolean;
+  off?(
+    event: "message",
+    listener: (event: unknown, method: string, params: unknown) => void
+  ): this;
+  on?(
+    event: "message",
+    listener: (event: unknown, method: string, params: unknown) => void
+  ): this;
   sendCommand(
     method: string,
     commandParams?: Record<string, unknown>

--- a/packages/browser/workbench-node/src/electron-preload/rendererApi.ts
+++ b/packages/browser/workbench-node/src/electron-preload/rendererApi.ts
@@ -136,6 +136,12 @@ export function createBrowserNodeElectronRendererApi(input: {
         }
       : {}),
     unregisterGuest: (payload) =>
-      invoke<void>(channels.unregisterGuest, payload)
+      invoke<void>(channels.unregisterGuest, payload),
+    ...(channels.updateAutomationTarget
+      ? {
+          updateAutomationTarget: (payload) =>
+            invoke<void>(channels.updateAutomationTarget!, payload)
+        }
+      : {})
   };
 }

--- a/packages/browser/workbench-node/src/index.ts
+++ b/packages/browser/workbench-node/src/index.ts
@@ -29,6 +29,8 @@ export {
 } from "./core/tabsLifecycle.ts";
 export type {
   BrowserNodeActivationInput,
+  BrowserNodeAutomationSurfaceRole,
+  BrowserNodeAutomationTargetMetadata,
   BrowserNodeClosedEvent,
   BrowserNodeContextMenuPoint,
   BrowserNodeCookieImportResult,
@@ -74,7 +76,8 @@ export type {
   BrowserNodeShowDevToolsContextMenuInput,
   BrowserNodeStateEvent,
   BrowserNodeStopFindInPageInput,
-  BrowserNodeUnregisterGuestInput
+  BrowserNodeUnregisterGuestInput,
+  BrowserNodeUpdateAutomationTargetInput
 } from "./core/types.ts";
 export type {
   BrowserAddressInputResolution,

--- a/packages/browser/workbench-node/src/react/BrowserNode.tsx
+++ b/packages/browser/workbench-node/src/react/BrowserNode.tsx
@@ -16,6 +16,7 @@ import {
 import type { JSX, ReactNode } from "react";
 import type { BrowserNodeFeature } from "../core/feature.ts";
 import type {
+  BrowserNodeAutomationTargetMetadata,
   BrowserNodeNavigationPolicy,
   BrowserNodeRuntimeError,
   BrowserNodeSessionMode
@@ -40,6 +41,7 @@ import {
   isBrowserNodeHostOverlayOpen,
   subscribeBrowserNodeHostOverlay
 } from "./browserNodeHostOverlayStore.ts";
+import { isBrowserNodeHomeUrl } from "./browserNodeHome.ts";
 
 // Electron needs the serialized string attribute for dynamically created webviews.
 const browserNodeAllowPopupsAttribute = "true" as unknown as boolean;
@@ -73,9 +75,14 @@ function useHostWindowMinimizing(): boolean {
 }
 
 export interface BrowserNodeProps {
+  automationTarget?: Omit<
+    BrowserNodeAutomationTargetMetadata,
+    "selected" | "surfaceId" | "tabId"
+  > | null;
   defaultUrl: string;
   feature: BrowserNodeFeature;
   hidden?: boolean;
+  renderHome?: (context: BrowserNodeHomeRenderContext) => ReactNode;
   navigationPolicy?: BrowserNodeNavigationPolicy | null;
   navigationActions?: ReactNode;
   nodeId: string;
@@ -89,10 +96,17 @@ export interface BrowserNodeProps {
   tabs?: boolean;
 }
 
+export interface BrowserNodeHomeRenderContext {
+  navigate(url: string): Promise<void>;
+  nodeId: string;
+}
+
 export function BrowserNode({
+  automationTarget = null,
   defaultUrl,
   feature,
   hidden = false,
+  renderHome,
   navigationPolicy = null,
   navigationActions,
   nodeId,
@@ -108,9 +122,11 @@ export function BrowserNode({
   if (tabs) {
     return (
       <TabbedBrowserNode
+        automationTarget={automationTarget}
         defaultUrl={defaultUrl}
         feature={feature}
         hidden={hidden}
+        renderHome={renderHome}
         navigationPolicy={navigationPolicy}
         navigationActions={navigationActions}
         nodeId={nodeId}
@@ -127,9 +143,20 @@ export function BrowserNode({
 
   return (
     <BrowserNodeContent
+      automationTarget={
+        automationTarget
+          ? {
+              ...automationTarget,
+              selected: true,
+              surfaceId: nodeId,
+              tabId: null
+            }
+          : null
+      }
       defaultUrl={defaultUrl}
       feature={feature}
       hidden={hidden}
+      renderHome={renderHome}
       navigationPolicy={navigationPolicy}
       navigationActions={navigationActions}
       nodeId={nodeId}
@@ -145,9 +172,11 @@ export function BrowserNode({
 }
 
 function TabbedBrowserNode({
+  automationTarget,
   defaultUrl,
   feature,
   hidden,
+  renderHome,
   navigationPolicy,
   navigationActions,
   nodeId,
@@ -213,9 +242,20 @@ function TabbedBrowserNode({
                 key={tab.id}
               >
                 <BrowserNodeContent
+                  automationTarget={
+                    automationTarget
+                      ? {
+                          ...automationTarget,
+                          selected: active,
+                          surfaceId: nodeId,
+                          tabId: tab.id
+                        }
+                      : null
+                  }
                   defaultUrl={tab.defaultUrl}
                   feature={feature}
                   hidden={hidden || !active}
+                  renderHome={renderHome}
                   navigationPolicy={navigationPolicy}
                   nodeId={tab.nodeId}
                   onFocusRequest={onFocusRequest}
@@ -239,9 +279,11 @@ function TabbedBrowserNode({
 }
 
 function BrowserNodeContent({
+  automationTarget = null,
   defaultUrl,
   feature,
   hidden = false,
+  renderHome,
   navigationPolicy = null,
   navigationActions,
   nodeId,
@@ -253,7 +295,8 @@ function BrowserNodeContent({
   sessionPartition = null,
   showHeader = false,
   syncDefaultUrl = false
-}: Omit<BrowserNodeProps, "tabs"> & {
+}: Omit<BrowserNodeProps, "automationTarget" | "tabs"> & {
+  automationTarget?: BrowserNodeAutomationTargetMetadata | null;
   onWebviewChange?: (webview: BrowserNodeWebviewTag | null) => void;
 }): JSX.Element {
   const { state } = useBrowserNodeController({
@@ -279,6 +322,11 @@ function BrowserNodeContent({
     ? formatBrowserNodeErrorStatus(feature, runtime.error)
     : null;
   const isShowingLoadError = errorMessage !== null;
+  const isShowingHome =
+    renderHome !== undefined &&
+    !isShowingLoadError &&
+    !runtime.isLoading &&
+    isBrowserNodeHomeUrl(runtime.url ?? state.displayUrl);
   const openExternalUrl = resolveBrowserNodeOpenExternalUrl(feature, state);
   const {
     devToolsContextMenu,
@@ -290,6 +338,7 @@ function BrowserNodeContent({
     webviewPartition,
     webviewSrc
   } = useBrowserNodeWebview({
+    automationTarget,
     feature,
     initialUrl: state.displayUrl,
     lifecycle: runtime.lifecycle,
@@ -362,6 +411,7 @@ function BrowserNodeContent({
               className={cn(
                 "absolute inset-0 h-full w-full border-0 bg-[var(--background-panel)]",
                 isShowingLoadError ? "hidden pointer-events-none" : "visible",
+                isShowingHome && "invisible pointer-events-none",
                 shouldHideBrowserNodeWebview({
                   hidden,
                   isHostMinimizing,
@@ -373,6 +423,24 @@ function BrowserNodeContent({
               partition={webviewPartition}
               src={webviewSrc}
             />
+          ) : null}
+          {isShowingHome ? (
+            <div className="absolute inset-0 z-10 overflow-auto bg-[var(--background-panel)]">
+              {renderHome({
+                navigate: async (url) => {
+                  const resolved = feature.resolveAddressInput(url);
+                  if (!resolved.url) {
+                    return;
+                  }
+                  await feature.hostApi.navigate({
+                    navigationPolicy,
+                    nodeId,
+                    url: resolved.url
+                  });
+                },
+                nodeId
+              })}
+            </div>
           ) : null}
           {errorMessage ? (
             <div className="absolute inset-0 z-10 flex items-center justify-center bg-[var(--background-panel)] px-8 py-10 text-center">

--- a/packages/browser/workbench-node/src/react/browserNodeHome.test.ts
+++ b/packages/browser/workbench-node/src/react/browserNodeHome.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isBrowserNodeHomeUrl } from "./browserNodeHome.ts";
+
+test("browser home is limited to an empty browser URL", () => {
+  assert.equal(isBrowserNodeHomeUrl(null), true);
+  assert.equal(isBrowserNodeHomeUrl(""), true);
+  assert.equal(isBrowserNodeHomeUrl(" ABOUT:BLANK "), true);
+  assert.equal(isBrowserNodeHomeUrl("https://example.com/"), false);
+  assert.equal(isBrowserNodeHomeUrl("file:///workspace/index.html"), false);
+});

--- a/packages/browser/workbench-node/src/react/browserNodeHome.ts
+++ b/packages/browser/workbench-node/src/react/browserNodeHome.ts
@@ -1,0 +1,4 @@
+export function isBrowserNodeHomeUrl(url: string | null | undefined): boolean {
+  const normalized = url?.trim().toLowerCase() ?? "";
+  return normalized.length === 0 || normalized === "about:blank";
+}

--- a/packages/browser/workbench-node/src/react/index.ts
+++ b/packages/browser/workbench-node/src/react/index.ts
@@ -1,4 +1,9 @@
-export { BrowserNode, type BrowserNodeProps } from "./BrowserNode.tsx";
+export {
+  BrowserNode,
+  type BrowserNodeHomeRenderContext,
+  type BrowserNodeProps
+} from "./BrowserNode.tsx";
+export { isBrowserNodeHomeUrl } from "./browserNodeHome.ts";
 export {
   BrowserNodeChrome,
   BrowserNodeHeader,

--- a/packages/browser/workbench-node/src/react/useBrowserNodeWebview.ts
+++ b/packages/browser/workbench-node/src/react/useBrowserNodeWebview.ts
@@ -7,6 +7,7 @@ import {
 } from "../core/webviewController.ts";
 import type { BrowserNodeFeature } from "../core/feature.ts";
 import type {
+  BrowserNodeAutomationTargetMetadata,
   BrowserNodeLifecycle,
   BrowserNodeNavigationPolicy,
   BrowserNodeSessionMode
@@ -14,6 +15,7 @@ import type {
 import type { BrowserNodeWebviewTag } from "./webviewTag.ts";
 
 export function useBrowserNodeWebview({
+  automationTarget,
   feature,
   initialUrl,
   lifecycle,
@@ -24,6 +26,7 @@ export function useBrowserNodeWebview({
   sessionMode,
   sessionPartition
 }: {
+  automationTarget?: BrowserNodeAutomationTargetMetadata | null;
   feature: BrowserNodeFeature;
   initialUrl: string;
   lifecycle: BrowserNodeLifecycle;
@@ -46,6 +49,7 @@ export function useBrowserNodeWebview({
   const controller = useMemo(
     () =>
       acquireBrowserNodeWebviewController({
+        automationTarget,
         feature,
         initialUrl,
         lifecycle,
@@ -58,6 +62,7 @@ export function useBrowserNodeWebview({
       }),
     [
       feature,
+      automationTarget,
       initialUrl,
       lifecycle,
       navigationPolicy,
@@ -80,6 +85,7 @@ export function useBrowserNodeWebview({
     controller.sync();
   }, [
     controller,
+    automationTarget,
     initialUrl,
     lifecycle,
     navigationPolicy,

--- a/packages/browser/workbench-node/src/workbench/index.ts
+++ b/packages/browser/workbench-node/src/workbench/index.ts
@@ -11,6 +11,7 @@ import type {
   WorkbenchHostNodeDefinition
 } from "@tutti-os/workbench-surface";
 import type { BrowserNodeFeature } from "../core/feature.ts";
+import type { BrowserNodeAutomationTargetMetadata } from "../core/types.ts";
 import { BrowserNode } from "../react/BrowserNode.tsx";
 import { BrowserNodeWorkbenchHeader } from "../react/BrowserNodeChrome.tsx";
 
@@ -25,6 +26,10 @@ export interface BrowserNodeExternalState {
 }
 
 export interface CreateBrowserNodeDefinitionInput {
+  automationTarget?: Omit<
+    BrowserNodeAutomationTargetMetadata,
+    "focused" | "selected" | "surfaceId" | "tabId"
+  > | null;
   defaultUrl: string;
   dockIcon?: ReactNode;
   feature: BrowserNodeFeature;
@@ -74,6 +79,7 @@ const defaultBrowserNodeFrame: WorkbenchFrame = {
 export const defaultBrowserNodeTypeId = "browser";
 
 export function createBrowserNodeDefinition({
+  automationTarget = null,
   defaultUrl,
   feature,
   frame = defaultBrowserNodeFrame,
@@ -88,6 +94,12 @@ export function createBrowserNodeDefinition({
     },
     renderBody: (context) =>
       createElement(BrowserNode, {
+        automationTarget: automationTarget
+          ? {
+              ...automationTarget,
+              focused: context.isFocused
+            }
+          : null,
         defaultUrl: resolveBrowserNodeInitialUrl({
           activation: context.activation,
           defaultUrl,

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -523,6 +524,9 @@ func (s *Service) Delete(ctx context.Context, workspaceID string, agentSessionID
 	result, err := s.ApplicationHost().DeleteSession(ctx, agenthost.SessionRef{
 		WorkspaceID: workspaceID, AgentSessionID: agentSessionID,
 	})
+	if err == nil && result.Deleted {
+		s.releaseAgentResources(ctx, agentSessionID)
+	}
 	return result.Deleted, err
 }
 
@@ -546,7 +550,27 @@ func (s *Service) Clear(ctx context.Context, workspaceID string) (ClearSessionsR
 	if !ok {
 		return ClearSessionsResult{}, ErrSessionNotFound
 	}
-	return clearer.ClearSessions(ctx, workspaceID)
+	result, err := clearer.ClearSessions(ctx, workspaceID)
+	if err != nil {
+		return ClearSessionsResult{}, err
+	}
+	for _, agentSessionID := range result.RemovedSessionIDs {
+		s.releaseAgentResources(ctx, agentSessionID)
+	}
+	return result, nil
+}
+
+func (s *Service) releaseAgentResources(ctx context.Context, agentSessionID string) {
+	if s.AgentSessionResourceReleaser == nil {
+		return
+	}
+	if err := s.AgentSessionResourceReleaser.ReleaseAgent(ctx, agentSessionID); err != nil {
+		slog.WarnContext(ctx, "release Agent session resources failed",
+			"agentSessionId", strings.TrimSpace(agentSessionID),
+			"error", err,
+			"event", "agent.session.resource_release_failed",
+		)
+	}
 }
 
 func (s *Service) UpdatePin(ctx context.Context, workspaceID string, agentSessionID string, pinned bool) (Session, error) {

--- a/services/tuttid/service/agent/service_session_sections.go
+++ b/services/tuttid/service/agent/service_session_sections.go
@@ -371,6 +371,7 @@ func (s *Service) DeleteSessionsBatch(
 			if err := s.cleanupRuntime(ctx, workspaceID, sessionID); err != nil {
 				return DeleteSessionsBatchResult{}, err
 			}
+			s.releaseAgentResources(ctx, sessionID)
 		}
 	}
 	return DeleteSessionsBatchResult{

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -5352,6 +5352,8 @@ func TestServiceListsActivePeersFromCanonicalSessionStatus(t *testing.T) {
 
 func TestServiceDeletesPersistedSession(t *testing.T) {
 	service := newIsolatedAgentService(newFakeRuntime())
+	releaser := &fakeAgentSessionResourceReleaser{}
+	service.AgentSessionResourceReleaser = releaser
 	service.SessionReader = fakeSessionReader{
 		sessions: map[string]PersistedSession{
 			"ws-1:session-1": {
@@ -5371,6 +5373,9 @@ func TestServiceDeletesPersistedSession(t *testing.T) {
 	}
 	if _, err := service.Get(context.Background(), "ws-1", "session-1"); err != ErrSessionNotFound {
 		t.Fatalf("Get after delete error = %v, want %v", err, ErrSessionNotFound)
+	}
+	if !slices.Equal(releaser.released, []string{"session-1"}) {
+		t.Fatalf("released Agent resources = %#v", releaser.released)
 	}
 }
 
@@ -7236,6 +7241,15 @@ func (f fakeSessionInitializer) InitializeRuntimeSession(
 		CreatedAtUnixMS:        session.CreatedAtUnixMS,
 		UpdatedAtUnixMS:        session.UpdatedAtUnixMS,
 	}, nil
+}
+
+type fakeAgentSessionResourceReleaser struct {
+	released []string
+}
+
+func (f *fakeAgentSessionResourceReleaser) ReleaseAgent(_ context.Context, agentSessionID string) error {
+	f.released = append(f.released, agentSessionID)
+	return nil
 }
 
 type fakeSectionReader struct {

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -27,6 +27,7 @@ type Service struct {
 	SessionInitializer             SessionInitializer
 	SessionReader                  SessionReader
 	SessionPurgeStore              agenthost.SessionPurgeStore
+	AgentSessionResourceReleaser   AgentSessionResourceReleaser
 	UserProjectReader              UserProjectReader
 	MessageReader                  MessageReader
 	ExternalImportStore            agentactivitybiz.Repository
@@ -386,6 +387,10 @@ type ClearSessionsResult struct {
 
 type SessionClearer interface {
 	ClearSessions(context.Context, string) (ClearSessionsResult, error)
+}
+
+type AgentSessionResourceReleaser interface {
+	ReleaseAgent(context.Context, string) error
 }
 
 type SessionDeleter interface {

--- a/services/tuttid/service/browser/browsernode.go
+++ b/services/tuttid/service/browser/browsernode.go
@@ -1,0 +1,140 @@
+package browser
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
+)
+
+const browserNodeResponseLimit = 64 * 1024 * 1024
+
+type browserNodeBackend interface {
+	Call(context.Context, string, string, string, map[string]any) (ToolResult, error)
+}
+
+type browserNodeHTTPBackend struct {
+	listenerInfoPath string
+	client           *http.Client
+}
+
+type browserNodeListenerInfo struct {
+	Address string `json:"address"`
+	Token   string `json:"token"`
+	Version int    `json:"version"`
+}
+
+type browserNodeCallResponse struct {
+	Result *struct {
+		ScreenshotData string `json:"screenshotData,omitempty"`
+		Text           string `json:"text"`
+	} `json:"result,omitempty"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+func newBrowserNodeHTTPBackend(listenerInfoPath string) browserNodeBackend {
+	return &browserNodeHTTPBackend{
+		listenerInfoPath: strings.TrimSpace(listenerInfoPath),
+		client:           httpx.Default(),
+	}
+}
+
+func (b *browserNodeHTTPBackend) Call(ctx context.Context, workspaceID, agentSessionID, tool string, args map[string]any) (ToolResult, error) {
+	info, err := b.readListenerInfo()
+	if err != nil {
+		return ToolResult{}, err
+	}
+	payload, err := json.Marshal(map[string]any{
+		"agentSessionId": strings.TrimSpace(agentSessionID),
+		"args":           args,
+		"tool":           tool,
+		"workspaceId":    strings.TrimSpace(workspaceID),
+	})
+	if err != nil {
+		return ToolResult{}, fmt.Errorf("encode BrowserNode automation call: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+info.Address+"/v1/call", bytes.NewReader(payload))
+	if err != nil {
+		return ToolResult{}, fmt.Errorf("create BrowserNode automation request: %w", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+info.Token)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := b.client.Do(request)
+	if err != nil {
+		return ToolResult{}, fmt.Errorf("BrowserNode desktop host is unavailable: %w", err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, browserNodeResponseLimit+1))
+	if err != nil {
+		return ToolResult{}, fmt.Errorf("read BrowserNode automation response: %w", err)
+	}
+	if len(body) > browserNodeResponseLimit {
+		return ToolResult{}, errors.New("BrowserNode automation response is too large")
+	}
+	var decoded browserNodeCallResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return ToolResult{}, fmt.Errorf("decode BrowserNode automation response: %w", err)
+	}
+	if response.StatusCode != http.StatusOK || decoded.Error != nil {
+		message := "BrowserNode automation request failed"
+		if decoded.Error != nil && strings.TrimSpace(decoded.Error.Message) != "" {
+			message = decoded.Error.Message
+		}
+		return ToolResult{}, errors.New(message)
+	}
+	if decoded.Result == nil {
+		return ToolResult{}, errors.New("BrowserNode automation response is missing a result")
+	}
+
+	result := ToolResult{Text: decoded.Result.Text}
+	if decoded.Result.ScreenshotData == "" {
+		return result, nil
+	}
+	if filePath, _ := args["filePath"].(string); strings.TrimSpace(filePath) != "" {
+		image, err := base64.StdEncoding.DecodeString(decoded.Result.ScreenshotData)
+		if err != nil {
+			return ToolResult{}, fmt.Errorf("decode BrowserNode screenshot: %w", err)
+		}
+		if err := os.WriteFile(filePath, image, 0o600); err != nil {
+			return ToolResult{}, fmt.Errorf("write BrowserNode screenshot: %w", err)
+		}
+		return result, nil
+	}
+	result.Images = []ToolImage{{Data: decoded.Result.ScreenshotData, MimeType: "image/png"}}
+	return result, nil
+}
+
+func (b *browserNodeHTTPBackend) readListenerInfo() (browserNodeListenerInfo, error) {
+	body, err := os.ReadFile(b.listenerInfoPath)
+	if err != nil {
+		return browserNodeListenerInfo{}, fmt.Errorf("BrowserNode desktop host is unavailable: %w", err)
+	}
+	var info browserNodeListenerInfo
+	if err := json.Unmarshal(body, &info); err != nil {
+		return browserNodeListenerInfo{}, fmt.Errorf("decode BrowserNode listener info: %w", err)
+	}
+	if info.Version != 1 || strings.TrimSpace(info.Token) == "" {
+		return browserNodeListenerInfo{}, errors.New("BrowserNode listener info is invalid")
+	}
+	host, _, err := net.SplitHostPort(info.Address)
+	if err != nil {
+		return browserNodeListenerInfo{}, errors.New("BrowserNode listener address is invalid")
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		return browserNodeListenerInfo{}, errors.New("BrowserNode listener must use a loopback address")
+	}
+	return info, nil
+}

--- a/services/tuttid/service/browser/browsernode.go
+++ b/services/tuttid/service/browser/browsernode.go
@@ -20,6 +20,49 @@ const browserNodeResponseLimit = 64 * 1024 * 1024
 
 type browserNodeBackend interface {
 	Call(context.Context, string, string, string, map[string]any) (ToolResult, error)
+	ReleaseAgent(context.Context, string) error
+}
+
+func (b *browserNodeHTTPBackend) ReleaseAgent(ctx context.Context, agentSessionID string) error {
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	if agentSessionID == "" {
+		return errors.New("BrowserNode Agent session ID is required")
+	}
+	info, err := b.readListenerInfo()
+	if err != nil {
+		return err
+	}
+	payload, err := json.Marshal(map[string]string{"agentSessionId": agentSessionID})
+	if err != nil {
+		return fmt.Errorf("encode BrowserNode Agent release: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+info.Address+"/v1/release-agent", bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create BrowserNode Agent release request: %w", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+info.Token)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := b.client.Do(request)
+	if err != nil {
+		return fmt.Errorf("BrowserNode desktop host is unavailable: %w", err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, browserNodeResponseLimit+1))
+	if err != nil {
+		return fmt.Errorf("read BrowserNode Agent release response: %w", err)
+	}
+	if len(body) > browserNodeResponseLimit {
+		return errors.New("BrowserNode Agent release response is too large")
+	}
+	if response.StatusCode != http.StatusOK {
+		var decoded browserNodeCallResponse
+		_ = json.Unmarshal(body, &decoded)
+		if decoded.Error != nil && strings.TrimSpace(decoded.Error.Message) != "" {
+			return errors.New(decoded.Error.Message)
+		}
+		return errors.New("BrowserNode Agent release failed")
+	}
+	return nil
 }
 
 type browserNodeHTTPBackend struct {

--- a/services/tuttid/service/browser/browsernode_test.go
+++ b/services/tuttid/service/browser/browsernode_test.go
@@ -1,0 +1,81 @@
+package browser
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBrowserNodeBackendCallsAuthenticatedDesktopHost(t *testing.T) {
+	var gotAuthorization string
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		gotAuthorization = request.Header.Get("Authorization")
+		_ = json.NewEncoder(response).Encode(map[string]any{
+			"result": map[string]any{"text": "pages"},
+		})
+	}))
+	defer server.Close()
+
+	listenerInfoPath := writeBrowserNodeListenerInfo(t, strings.TrimPrefix(server.URL, "http://"), "secret")
+	backend := newBrowserNodeHTTPBackend(listenerInfoPath)
+	result, err := backend.Call(context.Background(), "workspace-1", "agent-1", "list_pages", map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "pages" || gotAuthorization != "Bearer secret" {
+		t.Fatalf("result = %#v, authorization = %q", result, gotAuthorization)
+	}
+}
+
+func TestBrowserNodeBackendWritesScreenshotToRequestedPath(t *testing.T) {
+	png := []byte("png-data")
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(response).Encode(map[string]any{
+			"result": map[string]any{
+				"screenshotData": base64.StdEncoding.EncodeToString(png),
+				"text":           "captured",
+			},
+		})
+	}))
+	defer server.Close()
+
+	backend := newBrowserNodeHTTPBackend(writeBrowserNodeListenerInfo(t, strings.TrimPrefix(server.URL, "http://"), "secret"))
+	screenshotPath := filepath.Join(t.TempDir(), "screenshot.png")
+	if _, err := backend.Call(context.Background(), "workspace-1", "agent-1", "take_screenshot", map[string]any{"filePath": screenshotPath}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(screenshotPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(png) {
+		t.Fatalf("screenshot = %q, want %q", got, png)
+	}
+}
+
+func TestBrowserNodeBackendRejectsNonLoopbackListener(t *testing.T) {
+	backend := newBrowserNodeHTTPBackend(writeBrowserNodeListenerInfo(t, "10.0.0.1:1234", "secret"))
+	_, err := backend.Call(context.Background(), "workspace-1", "agent-1", "list_pages", nil)
+	if err == nil || !strings.Contains(err.Error(), "loopback") {
+		t.Fatalf("err = %v, want loopback rejection", err)
+	}
+}
+
+func writeBrowserNodeListenerInfo(t *testing.T, address, token string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "listener.json")
+	body, err := json.Marshal(browserNodeListenerInfo{Address: address, Token: token, Version: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/services/tuttid/service/browser/browsernode_test.go
+++ b/services/tuttid/service/browser/browsernode_test.go
@@ -59,6 +59,31 @@ func TestBrowserNodeBackendWritesScreenshotToRequestedPath(t *testing.T) {
 	}
 }
 
+func TestBrowserNodeBackendReleasesAgentLease(t *testing.T) {
+	var gotPath string
+	var gotAgentSessionID string
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		gotPath = request.URL.Path
+		var payload struct {
+			AgentSessionID string `json:"agentSessionId"`
+		}
+		_ = json.NewDecoder(request.Body).Decode(&payload)
+		gotAgentSessionID = payload.AgentSessionID
+		_ = json.NewEncoder(response).Encode(map[string]any{
+			"result": map[string]any{"text": "released"},
+		})
+	}))
+	defer server.Close()
+
+	backend := newBrowserNodeHTTPBackend(writeBrowserNodeListenerInfo(t, strings.TrimPrefix(server.URL, "http://"), "secret"))
+	if err := backend.ReleaseAgent(context.Background(), "agent-1"); err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/v1/release-agent" || gotAgentSessionID != "agent-1" {
+		t.Fatalf("path = %q, agentSessionId = %q", gotPath, gotAgentSessionID)
+	}
+}
+
 func TestBrowserNodeBackendRejectsNonLoopbackListener(t *testing.T) {
 	backend := newBrowserNodeHTTPBackend(writeBrowserNodeListenerInfo(t, "10.0.0.1:1234", "secret"))
 	_, err := backend.Call(context.Background(), "workspace-1", "agent-1", "list_pages", nil)

--- a/services/tuttid/service/browser/service.go
+++ b/services/tuttid/service/browser/service.go
@@ -2,6 +2,7 @@ package browser
 
 import (
 	"context"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -24,6 +25,7 @@ type Service struct {
 	managedRuntime       managedruntime.ProfileResolver
 	idleTTL              time.Duration
 	autoConnectPreflight func() error
+	browserNode          browserNodeBackend
 
 	mu       sync.Mutex
 	sessions map[string]*browserSession
@@ -40,7 +42,7 @@ func NewService(preferences ...PreferencesReader) *Service {
 	if len(preferences) > 0 {
 		reader = preferences[0]
 	}
-	return &Service{
+	service := &Service{
 		transport:            agentruntime.NewLocalProcessTransport(),
 		preferences:          reader,
 		managedRuntime:       managedruntime.DefaultResolver{},
@@ -48,12 +50,26 @@ func NewService(preferences ...PreferencesReader) *Service {
 		autoConnectPreflight: validateAutoConnectChromeReady,
 		sessions:             make(map[string]*browserSession),
 	}
+	if listenerInfoPath := strings.TrimSpace(os.Getenv("TUTTI_BROWSER_NODE_LISTENER_INFO")); listenerInfoPath != "" {
+		service.browserNode = newBrowserNodeHTTPBackend(listenerInfoPath)
+	}
+	return service
 }
 
 // CallTool invokes a chrome-devtools-mcp tool against the workspace's browser
 // session, lazily starting it on first use.
 func (s *Service) CallTool(ctx context.Context, workspaceID, cwd, tool string, args map[string]any) (ToolResult, error) {
+	return s.CallToolForAgent(ctx, workspaceID, cwd, "", tool, args)
+}
+
+// CallToolForAgent routes desktop-owned browser calls to the in-app
+// BrowserNode host. A daemon without that explicit host configuration keeps
+// the managed Chrome backend for headless use.
+func (s *Service) CallToolForAgent(ctx context.Context, workspaceID, cwd, agentSessionID, tool string, args map[string]any) (ToolResult, error) {
 	workspaceID = strings.TrimSpace(workspaceID)
+	if s.browserNode != nil {
+		return s.browserNode.Call(ctx, workspaceID, strings.TrimSpace(agentSessionID), tool, args)
+	}
 	currentMode := resolveBrowserUseConnectionMode(ctx, s.preferences)
 
 	s.mu.Lock()

--- a/services/tuttid/service/browser/service.go
+++ b/services/tuttid/service/browser/service.go
@@ -121,6 +121,16 @@ func (s *Service) CallToolForAgent(ctx context.Context, workspaceID, cwd, agentS
 	return result, err
 }
 
+// ReleaseAgent closes BrowserNode pages and relinquishes their leases when a
+// durable Agent session is deleted. Managed Chrome sessions are
+// workspace-scoped and do not have per-Agent resources.
+func (s *Service) ReleaseAgent(ctx context.Context, agentSessionID string) error {
+	if s.browserNode == nil {
+		return nil
+	}
+	return s.browserNode.ReleaseAgent(ctx, strings.TrimSpace(agentSessionID))
+}
+
 // isBrowserPageGoneError reports whether err is chrome-devtools-mcp's error for
 // a page-scoped tool call made after the selected page (or all pages) closed
 // out from under the browser, e.g. because the user manually closed the

--- a/services/tuttid/service/cli/providers/browser/commands.go
+++ b/services/tuttid/service/cli/providers/browser/commands.go
@@ -30,6 +30,14 @@ type evalInput struct {
 	Script string `cli:"script" validate:"required"`
 }
 
+type pageInput struct {
+	PageID string `cli:"page-id" validate:"required"`
+}
+
+type newPageInput struct {
+	URL string `cli:"url"`
+}
+
 func plainOutputSpec() framework.OutputSpec {
 	return framework.OutputSpec{
 		DefaultMode: cliservice.OutputModePlain,
@@ -51,7 +59,7 @@ func (p Provider) newNavigateCommand() cliservice.Command {
 		Inputs:      framework.FromStruct[navigateInput](),
 		Output:      plainOutputSpec(),
 		Run: func(ctx context.Context, invoke framework.InvokeContext, input navigateInput) (any, error) {
-			return p.call(ctx, invoke.WorkspaceID, "navigate_page", map[string]any{"url": input.URL})
+			return p.call(ctx, invoke, "navigate_page", map[string]any{"url": input.URL})
 		},
 	})
 }
@@ -68,7 +76,7 @@ func (p Provider) newSnapshotCommand() cliservice.Command {
 		Inputs:      framework.FromStruct[struct{}](),
 		Output:      plainOutputSpec(),
 		Run: func(ctx context.Context, invoke framework.InvokeContext, _ struct{}) (any, error) {
-			return p.call(ctx, invoke.WorkspaceID, "take_snapshot", map[string]any{})
+			return p.call(ctx, invoke, "take_snapshot", map[string]any{})
 		},
 	})
 }
@@ -99,7 +107,7 @@ func (p Provider) runScreenshot(ctx context.Context, invoke framework.InvokeCont
 	if input.FullPage {
 		args["fullPage"] = true
 	}
-	text, err := p.call(ctx, invoke.WorkspaceID, "take_screenshot", args)
+	text, err := p.call(ctx, invoke, "take_screenshot", args)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +126,7 @@ func (p Provider) newClickCommand() cliservice.Command {
 		Inputs:      framework.FromStruct[uidInput](),
 		Output:      plainOutputSpec(),
 		Run: func(ctx context.Context, invoke framework.InvokeContext, input uidInput) (any, error) {
-			return p.call(ctx, invoke.WorkspaceID, "click", map[string]any{"uid": input.UID})
+			return p.call(ctx, invoke, "click", map[string]any{"uid": input.UID})
 		},
 	})
 }
@@ -135,7 +143,7 @@ func (p Provider) newFillCommand() cliservice.Command {
 		Inputs:      framework.FromStruct[fillInput](),
 		Output:      plainOutputSpec(),
 		Run: func(ctx context.Context, invoke framework.InvokeContext, input fillInput) (any, error) {
-			return p.call(ctx, invoke.WorkspaceID, "fill", map[string]any{"uid": input.UID, "value": input.Value})
+			return p.call(ctx, invoke, "fill", map[string]any{"uid": input.UID, "value": input.Value})
 		},
 	})
 }
@@ -152,7 +160,7 @@ func (p Provider) newEvalCommand() cliservice.Command {
 		Inputs:      framework.FromStruct[evalInput](),
 		Output:      plainOutputSpec(),
 		Run: func(ctx context.Context, invoke framework.InvokeContext, input evalInput) (any, error) {
-			return p.call(ctx, invoke.WorkspaceID, "evaluate_script", map[string]any{"function": input.Script})
+			return p.call(ctx, invoke, "evaluate_script", map[string]any{"function": input.Script})
 		},
 	})
 }
@@ -173,7 +181,62 @@ func (p Provider) newListPagesCommand() cliservice.Command {
 			ListCompact: true,
 		},
 		Run: func(ctx context.Context, invoke framework.InvokeContext, _ struct{}) (any, error) {
-			return p.call(ctx, invoke.WorkspaceID, "list_pages", map[string]any{})
+			return p.call(ctx, invoke, "list_pages", map[string]any{})
+		},
+	})
+}
+
+func (p Provider) newPageCommand() cliservice.Command {
+	return framework.Register(framework.CommandSpec[newPageInput]{
+		ID:          "browser.new-page",
+		Path:        []string{"browser", "new-page"},
+		Summary:     "Create a browser page",
+		Description: "Create a background page in the Agent Browser and select it for later commands.",
+		Kind:        framework.KindAction,
+		Workspace:   framework.WorkspaceRequired,
+		Workspaces:  p.workspaces,
+		Inputs:      framework.FromStruct[newPageInput](),
+		Output:      plainOutputSpec(),
+		Run: func(ctx context.Context, invoke framework.InvokeContext, input newPageInput) (any, error) {
+			args := map[string]any{}
+			if input.URL != "" {
+				args["url"] = input.URL
+			}
+			return p.call(ctx, invoke, "new_page", args)
+		},
+	})
+}
+
+func (p Provider) newSelectPageCommand() cliservice.Command {
+	return framework.Register(framework.CommandSpec[pageInput]{
+		ID:          "browser.select-page",
+		Path:        []string{"browser", "select-page"},
+		Summary:     "Select a browser page",
+		Description: "Select a page id from `tutti browser list-pages` for later commands.",
+		Kind:        framework.KindAction,
+		Workspace:   framework.WorkspaceRequired,
+		Workspaces:  p.workspaces,
+		Inputs:      framework.FromStruct[pageInput](),
+		Output:      plainOutputSpec(),
+		Run: func(ctx context.Context, invoke framework.InvokeContext, input pageInput) (any, error) {
+			return p.call(ctx, invoke, "select_page", map[string]any{"pageId": input.PageID})
+		},
+	})
+}
+
+func (p Provider) newClosePageCommand() cliservice.Command {
+	return framework.Register(framework.CommandSpec[pageInput]{
+		ID:          "browser.close-page",
+		Path:        []string{"browser", "close-page"},
+		Summary:     "Close a browser page",
+		Description: "Close a page by id from `tutti browser list-pages`.",
+		Kind:        framework.KindAction,
+		Workspace:   framework.WorkspaceRequired,
+		Workspaces:  p.workspaces,
+		Inputs:      framework.FromStruct[pageInput](),
+		Output:      plainOutputSpec(),
+		Run: func(ctx context.Context, invoke framework.InvokeContext, input pageInput) (any, error) {
+			return p.call(ctx, invoke, "close_page", map[string]any{"pageId": input.PageID})
 		},
 	})
 }

--- a/services/tuttid/service/cli/providers/browser/provider.go
+++ b/services/tuttid/service/cli/providers/browser/provider.go
@@ -9,6 +9,7 @@ import (
 
 	browsersvc "github.com/tutti-os/tutti/services/tuttid/service/browser"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
+	"github.com/tutti-os/tutti/services/tuttid/service/cli/framework"
 )
 
 const appID = "browser"
@@ -17,7 +18,7 @@ var errBrowserUnavailable = errors.New("browser service is unavailable")
 
 // BrowserService is the subset of the daemon browser service the CLI needs.
 type BrowserService interface {
-	CallTool(ctx context.Context, workspaceID, cwd, tool string, args map[string]any) (browsersvc.ToolResult, error)
+	CallToolForAgent(ctx context.Context, workspaceID, cwd, agentSessionID, tool string, args map[string]any) (browsersvc.ToolResult, error)
 }
 
 type Provider struct {
@@ -40,6 +41,9 @@ func (p Provider) Commands() []cliservice.Command {
 		p.newFillCommand(),
 		p.newEvalCommand(),
 		p.newListPagesCommand(),
+		p.newPageCommand(),
+		p.newSelectPageCommand(),
+		p.newClosePageCommand(),
 	}
 }
 
@@ -47,11 +51,18 @@ func (p Provider) Commands() []cliservice.Command {
 // browser service surfaces
 // tool errors (e.g. "Chrome not installed", "browser MCP failed to start") as
 // Go errors, which the CLI renders to the agent.
-func (p Provider) call(ctx context.Context, workspaceID string, tool string, args map[string]any) (string, error) {
+func (p Provider) call(ctx context.Context, invoke framework.InvokeContext, tool string, args map[string]any) (string, error) {
 	if p.browser == nil {
 		return "", errBrowserUnavailable
 	}
-	result, err := p.browser.CallTool(ctx, workspaceID, "", tool, args)
+	result, err := p.browser.CallToolForAgent(
+		ctx,
+		invoke.WorkspaceID,
+		"",
+		invoke.Request.Context.AgentSessionID,
+		tool,
+		args,
+	)
 	if err != nil {
 		return "", err
 	}

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -364,6 +364,9 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 	}
 	agentRuntimeController := newAgentRuntimeAdapter(agentRuntime.Controller())
 	agentSessionService := agentservice.NewService(agentRuntimeController)
+	if browserService != nil {
+		agentSessionService.AgentSessionResourceReleaser = browserService
+	}
 	agentActivityProjection.SetRootTurnObserver(agentRuntimeController)
 	agentSessionService.AnalyticsReporter = analyticsReporter
 	agentModelCapabilities := agentservice.NewModelCapabilitiesService()


### PR DESCRIPTION
## What changed

- add a host-rendered Browser Home slot to `@tutti-os/browser-node`
- register User Browser and Agent Browser tabs as workspace-scoped automation targets while excluding Website Apps
- add complete page lifecycle routing for create, select, close, background Agent surfaces, and session deletion cleanup
- keep Agent Browser ownership pinned to the exact `agentSessionId`; Agents can also inspect User Browser tabs in the same workspace
- start a hidden Agent Browser host when no Agent window exists, wait for renderer readiness, and route later operations to the exact renderer that created the page
- add CDP-backed snapshot, click, fill, eval, navigation, screenshot, stable page selection, and per-target serialized leases
- create `new_page` as `about:blank`, attach interception first, and only then navigate to the requested URL
- resolve request-policy hostnames through the target Chromium Session; deny loopback unless a trusted host capability confirms that the exact URL is sandbox-routed
- make Agent release a lifecycle barrier that drains target work before disabling guards and closes pages that finish creating after release
- route desktop `tutti browser` calls through an authenticated loopback BrowserNode endpoint with no managed-Chrome fallback
- key targets and stable selection by workspace plus node identity and fail closed when the owning renderer surface is unavailable
- retain managed Chrome only for explicitly headless daemon use

## Why

Desktop browser behavior previously had two authorities: Electron BrowserNode for user-visible browsing and a separate Chrome/MCP process for Agent browser-use. This establishes BrowserNode as the desktop authority so hosts can share login state, tabs, Browser Home behavior, and Agent automation without copying product-specific implementations.

The reusable lifecycle, network guard, and automation contracts live in BrowserNode and Agent GUI packages. Desktop keeps Electron/window IPC adapters, including session-aware background hosting. TSH can consume the same contract in its downstream host integration.

## Validation

- `pnpm --filter @tutti-os/browser-node typecheck`
- `pnpm --filter @tutti-os/browser-node test` (157 passed)
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/agent-gui test` (2013 passed)
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop test` (1500 passed, 2 skipped)
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:electron-runtime-boundaries`
- `pnpm check:renderer-boundaries`
- focused Go tests for `services/tuttid/service/browser` and `services/tuttid/service/agent`
- `go build ./...` in `services/tuttid`
- `pnpm check:changed -- --push-ready` (21 lanes passed)
