### PR TITLE
fix(workbench): share component dock preview contract

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -1,4 +1,4 @@
-import { createElement, type CSSProperties, type ReactNode } from "react";
+import { createElement, type ReactNode } from "react";
 import type {
   AgentGUIProvider,
   AgentGUIAllAgentsPresentation,
@@ -23,6 +23,7 @@ import type {
   WorkbenchContribution,
   WorkbenchDockPreviewCache
 } from "@tutti-os/workbench-surface";
+import { WorkbenchDockComponentPreviewFrame } from "@tutti-os/workbench-surface";
 import type {
   DesktopComputerUseApi,
   DesktopHostFilesApi,
@@ -236,21 +237,29 @@ export function createWorkspaceAgentGuiContribution(input: {
     ),
     renderBody: (context, helpers) =>
       renderAgentGuiWorkbenchBody(context, helpers),
-    renderPreview: (context, helpers) =>
-      createElement(
-        DesktopAgentGUIWorkbenchDockPreviewFrame,
-        { height: context.node.frame.height, width: context.node.frame.width },
-        renderAgentGuiWorkbenchBody(context, helpers, { previewMode: true })
-      ),
+    renderPreview: (context, helpers) => {
+      const body = renderAgentGuiWorkbenchBody(context, helpers, {
+        previewMode: true
+      });
+      return context.previewViewport
+        ? createElement(
+            WorkbenchDockComponentPreviewFrame,
+            {
+              sourceSize: context.node.frame,
+              viewport: context.previewViewport
+            },
+            body
+          )
+        : body;
+    },
     renderMinimizedPreview: (context, helpers) => {
       const previewViewport =
         context.previewViewport ?? minimizedDockPreviewViewport;
       return createElement(
-        DesktopAgentGUIWorkbenchDockPreviewFrame,
+        WorkbenchDockComponentPreviewFrame,
         {
-          height: context.node.frame.height,
-          viewport: previewViewport,
-          width: context.node.frame.width
+          sourceSize: context.node.frame,
+          viewport: previewViewport
         },
         renderAgentGuiWorkbenchBody(context, helpers, { previewMode: true })
       );
@@ -363,61 +372,7 @@ function resolveWorkspaceAgentGuiDockPopupIdentity(
   });
 }
 
-const dockPopupPreviewViewport = {
-  height: 95,
-  width: 157
-};
-
 const minimizedDockPreviewViewport = {
   height: 34.2,
   width: 46.8
 };
-
-function DesktopAgentGUIWorkbenchDockPreviewFrame({
-  children,
-  height,
-  viewport = dockPopupPreviewViewport,
-  width
-}: {
-  children?: ReactNode;
-  height: number;
-  viewport?: { height: number; width: number };
-  width: number;
-}): ReactNode {
-  const safeWidth = Math.max(1, width);
-  const safeHeight = Math.max(1, height);
-  const scale = Math.min(
-    viewport.width / safeWidth,
-    viewport.height / safeHeight
-  );
-  const bodyStyle = {
-    height: `${safeHeight}px`,
-    left: "50%",
-    position: "absolute",
-    top: "50%",
-    transform: `translate(-50%, -50%) scale(${scale})`,
-    transformOrigin: "center",
-    width: `${safeWidth}px`
-  } satisfies CSSProperties;
-
-  return createElement(
-    "span",
-    {
-      "aria-hidden": "true",
-      className:
-        "relative block h-full w-full overflow-hidden rounded-md bg-transparent",
-      style: {
-        height: `${viewport.height}px`,
-        width: `${viewport.width}px`
-      } satisfies CSSProperties
-    },
-    createElement(
-      "span",
-      {
-        className: "pointer-events-none block overflow-hidden",
-        style: bodyStyle
-      },
-      children
-    )
-  );
-}

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -129,6 +129,12 @@ pnpm check:agent-activity-runtime-boundaries
 `hostCapabilities`, `hostActions`, and `renderSlots`. Extend the owning object;
 do not restore flat compatibility props.
 
+Workbench hosts with custom Dock entry projections can import
+`createAgentGuiWorkbenchPreviewContent` from
+`@tutti-os/agent-gui/workbench`. The helper owns AgentGUI preview identity,
+revision, and render-context construction; hosts continue to own their Agent
+directory, product-specific Dock grouping, and preview body renderer.
+
 ## Reference Provenance Filtering
 
 Reference provenance filtering is disabled by default. Collaboration hosts can

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -681,6 +681,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
               }
               inlineNoticeChrome={inlineNoticeChrome}
               isRespondingApproval={viewModel.interaction.isRespondingApproval}
+              previewMode={previewMode}
               onSubmitApprovalOption={submitApprovalOption}
               onRetryActivation={retryActivation}
               onAuthLogin={authLogin}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyHeroCarouselStage.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyHeroCarouselStage.spec.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentGUIAgentAvatarPresentation } from "../model/agentGuiAgentAvatarPresentation";
+
+vi.mock("../AgentGUIHeroAgentCarousel", () => ({
+  AgentGUIHeroAgentCarousel: () => <div data-testid="carousel" />
+}));
+
+import { AgentGUIEmptyHeroCarouselStage } from "./AgentGUIEmptyHeroCarouselStage";
+
+const items: readonly AgentGUIAgentAvatarPresentation[] = [
+  {
+    agentTargetId: "codex",
+    iconUrl: "codex.png",
+    label: "Codex",
+    provider: "codex",
+    targetId: "codex"
+  },
+  {
+    agentTargetId: "claude",
+    iconUrl: "claude.png",
+    label: "Claude",
+    provider: "claude",
+    targetId: "claude"
+  }
+];
+
+afterEach(cleanup);
+
+describe("AgentGUIEmptyHeroCarouselStage", () => {
+  it("keeps CSS fallback alignment in preview mode", () => {
+    const { container } = render(
+      <AgentGUIEmptyHeroCarouselStage
+        items={items}
+        previewMode
+        providerSelectLabel="Select provider"
+      >
+        <div data-carousel-placeholder />
+      </AgentGUIEmptyHeroCarouselStage>
+    );
+
+    const layer = container.querySelector<HTMLElement>(
+      ".agent-gui-node__empty-hero-carousel-layer"
+    );
+    expect(
+      layer?.style.getPropertyValue("--agent-gui-hero-carousel-slot-top")
+    ).toBe("");
+    expect(
+      layer?.style.getPropertyValue("--agent-gui-hero-carousel-slot-left")
+    ).toBe("");
+  });
+
+  it("measures live carousel alignment outside preview mode", () => {
+    const { container } = render(
+      <AgentGUIEmptyHeroCarouselStage
+        items={items}
+        previewMode={false}
+        providerSelectLabel="Select provider"
+      >
+        <div data-carousel-placeholder />
+      </AgentGUIEmptyHeroCarouselStage>
+    );
+
+    const layer = container.querySelector<HTMLElement>(
+      ".agent-gui-node__empty-hero-carousel-layer"
+    );
+    expect(
+      layer?.style.getPropertyValue("--agent-gui-hero-carousel-slot-top")
+    ).toBe("0px");
+    expect(
+      layer?.style.getPropertyValue("--agent-gui-hero-carousel-slot-left")
+    ).toBe("0px");
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyHeroCarouselStage.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyHeroCarouselStage.tsx
@@ -9,6 +9,7 @@ interface AgentGUIEmptyHeroCarouselStageProps {
   children: ReactNode;
   items: readonly AgentGUIAgentAvatarPresentation[];
   onProviderSelect?: AgentGUINodeViewProps["actions"]["selectHomeComposerAgentTarget"];
+  previewMode: boolean;
   providerSelectLabel: string;
 }
 
@@ -65,7 +66,12 @@ export class AgentGUIEmptyHeroCarouselStage extends Component<AgentGUIEmptyHeroC
   // while measuring the slot preserves alignment across host padding and
   // ready/gated subtree changes. The CSS fallback covers the pre-measure paint.
   private startAlignment(): void {
-    if (this.props.items.length <= 1 || !this.stage || !this.layer) {
+    if (
+      this.props.previewMode ||
+      this.props.items.length <= 1 ||
+      !this.stage ||
+      !this.layer
+    ) {
       this.stopAlignment();
       return;
     }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
@@ -98,6 +98,7 @@ interface AgentGUIEmptyHomePaneProps {
   onProviderSelect?: AgentGUINodeViewProps["actions"]["selectHomeComposerAgentTarget"];
   inlineNoticeChrome: AgentGUISessionChrome | null;
   isRespondingApproval: boolean;
+  previewMode: boolean;
   onSubmitApprovalOption: AgentGUINodeViewProps["actions"]["submitApprovalOption"];
   onAuthLogin?: (provider?: string | null) => void;
   onRetryActivation: AgentGUINodeViewProps["actions"]["retryActivation"];
@@ -118,6 +119,7 @@ export const AgentGUIEmptyHomePane = memo(function AgentGUIEmptyHomePane({
   agentTargets,
   selectedAgentTarget,
   onProviderSelect,
+  previewMode,
   labels,
   ...heroProps
 }: AgentGUIEmptyHomePaneProps): React.JSX.Element {
@@ -158,6 +160,7 @@ export const AgentGUIEmptyHomePane = memo(function AgentGUIEmptyHomePane({
       }
       items={avatarPresentations}
       onProviderSelect={onProviderSelect}
+      previewMode={previewMode}
       providerSelectLabel={labels.providerSwitchLabel}
     >
       <AgentTargetSetupGate

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -599,6 +599,7 @@ export {
   agentGuiWorkbenchNewWindowCascadeOffset,
   agentGuiWorkbenchProviderRailWidthPx,
   buildAgentGuiDockEntries,
+  createAgentGuiWorkbenchPreviewContent,
   resolveAgentGuiUnifiedDockLaunchPayload,
   resolveAgentGuiWorkbenchContributionCopy,
   resolveAgentGuiWorkbenchDefaultLaunchFrame

--- a/packages/agent/gui/workbench/index.ts
+++ b/packages/agent/gui/workbench/index.ts
@@ -5,6 +5,7 @@ export {
   agentGuiWorkbenchDefaultNodeFrame,
   buildAgentGuiDockEntries,
   createAgentGuiWorkbenchContribution,
+  createAgentGuiWorkbenchPreviewContent,
   resolveAgentGuiUnifiedDockLaunchPayload,
   resolveAgentGuiWorkbenchContributionCopy
 } from "./contribution.ts";

--- a/packages/agent/gui/workbench/publicExports.test.ts
+++ b/packages/agent/gui/workbench/publicExports.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { createAgentGuiWorkbenchPreviewContent } from "./index.ts";
+
+describe("AgentGUI workbench public exports", () => {
+  it("exports the shared preview content builder for host dock adapters", () => {
+    expect(createAgentGuiWorkbenchPreviewContent).toBeTypeOf("function");
+  });
+});

--- a/packages/workbench/surface/README.md
+++ b/packages/workbench/surface/README.md
@@ -61,6 +61,15 @@ Entries may also provide host-owned popup metadata through
 `resolvePopupItem(...)` and `capturePopupItemPreview(...)`, plus custom badge
 content when the default count or status shapes are not enough.
 
+Component-based dock previews should render their host-owned body through
+`WorkbenchDockComponentPreviewFrame`. The frame owns source-to-viewport
+scaling, clipping, centering, and the non-interactive preview boundary. Preview
+children are decorative and never participate in pointer hit testing; the Dock
+button remains the only interaction owner even if frozen preview markup is
+replaced between pointer events. Popup preview providers receive the canonical
+target size through `item.previewViewport`; use that value instead of duplicating
+Dock card dimensions in a consuming host.
+
 Presentation-only changes to merged Dock entries belong in
 `dockEntryPresentationOverrides`. `WorkbenchHost` applies these overrides by
 entry id after contributions and explicit entries are merged, preserving Dock

--- a/packages/workbench/surface/package.json
+++ b/packages/workbench/surface/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts && node ../../../tools/scripts/copy-package-assets.mjs src/styles dist/styles",
-    "test": "node --test --experimental-strip-types ./src/**/*.test.ts && vitest run ./src/host/WorkbenchHostDock.render.test.tsx ./src/host/WorkbenchHost.render.test.tsx --environment jsdom",
+    "test": "node --test --experimental-strip-types ./src/**/*.test.ts && vitest run ./src/host/WorkbenchHostDock.render.test.tsx ./src/host/WorkbenchHost.render.test.tsx ./src/react/WorkbenchDockComponentPreviewFrame.test.tsx --environment jsdom",
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },
   "devDependencies": {

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.render.test.tsx
@@ -1,11 +1,15 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { describe, expect, it } from "vitest";
-import type { WorkbenchState } from "../core/types.ts";
+import { describe, expect, it, vi } from "vitest";
+import type { WorkbenchNode, WorkbenchState } from "../core/types.ts";
 import type { WorkbenchDockContext } from "../react/types.ts";
 import type { WorkbenchController } from "../store/types.ts";
 import { WorkbenchHostDock } from "./WorkbenchHostDock.tsx";
-import type { WorkbenchHostHandle, WorkbenchHostNodeData } from "./types.ts";
+import type {
+  WorkbenchHostDockPopupPreviewProvider,
+  WorkbenchHostHandle,
+  WorkbenchHostNodeData
+} from "./types.ts";
 import { createWorkbenchHostI18nRuntime } from "./workbenchHostI18n.ts";
 
 describe("WorkbenchHostDock", () => {
@@ -53,9 +57,96 @@ describe("WorkbenchHostDock", () => {
       ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
     }
   });
+
+  it("provides the dock popup preview viewport to component preview providers", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        disconnect() {}
+        observe() {}
+        unobserve() {}
+      }
+    );
+    const node = createNode();
+    const props = createDockProps([node]);
+    const providePopupItemPreview =
+      vi.fn<WorkbenchHostDockPopupPreviewProvider>(() => ({
+        element: null,
+        kind: "component"
+      }));
+    const dockEntry = {
+      icon: null,
+      id: "agent-gui",
+      instanceMode: "multi" as const,
+      label: "Agent",
+      providePopupItemPreview,
+      typeId: "agent-gui",
+      visibility: "always" as const
+    };
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(<WorkbenchHostDock {...props} dockEntries={[dockEntry]} />);
+      });
+      const button = container.querySelector<HTMLButtonElement>(
+        'button[aria-haspopup="dialog"]'
+      );
+      expect(button).not.toBeNull();
+
+      await act(async () => {
+        button?.click();
+      });
+
+      expect(providePopupItemPreview).toHaveBeenCalledOnce();
+      expect(
+        providePopupItemPreview.mock.calls[0]?.[0].previewViewport
+      ).toEqual({
+        height: 95,
+        width: 157
+      });
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+      vi.unstubAllGlobals();
+    }
+  });
 });
 
-function createDockProps() {
+function createNode(): WorkbenchNode<WorkbenchHostNodeData> {
+  return {
+    data: {
+      dockEntryId: "agent-gui",
+      instanceId: "agent-gui-1",
+      instanceKey: null,
+      typeId: "agent-gui"
+    },
+    displayMode: "floating",
+    frame: { height: 560, width: 1040, x: 20, y: 20 },
+    id: "agent-gui:agent-gui-1",
+    isMinimized: false,
+    kind: "agent-gui",
+    restoreFrame: null,
+    title: "Agent"
+  };
+}
+
+function createDockProps(
+  nodes: readonly WorkbenchNode<WorkbenchHostNodeData>[] = []
+) {
   const state: WorkbenchState<WorkbenchHostNodeData> = {
     activeDragNodeId: null,
     activeResizeNodeId: null,
@@ -67,7 +158,7 @@ function createDockProps() {
       surfacePadding: 0
     },
     lockedLayout: null,
-    nodes: [],
+    nodes: [...nodes],
     nodeStack: [],
     surfaceSize: { height: 800, width: 1200 }
   };
@@ -89,7 +180,7 @@ function createDockProps() {
       shouldAnimateMinimizedDockEnter: () => false
     },
     minimizedNodes: [],
-    nodes: []
+    nodes: [...nodes]
   };
   const host: WorkbenchHostHandle = {
     activateNode() {},

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -60,6 +60,7 @@ import {
 } from "./minimizedDockRestoreIntent.ts";
 import {
   WorkbenchHostDockPopup,
+  workbenchHostDockPopupPreviewViewport,
   type WorkbenchHostDockPopupAnchorRect,
   type WorkbenchHostDockPopupState
 } from "./WorkbenchHostDockPopup.tsx";
@@ -2252,7 +2253,8 @@ export function WorkbenchHostDock({
                 host,
                 isFocused: context.focusedNodeId === node.id,
                 isMinimized: minimizedNodeIDs.has(node.id),
-                node
+                node,
+                previewViewport: workbenchHostDockPopupPreviewViewport
               };
               const descriptor =
                 popupEntry.entry.resolvePopupItem?.(item) ?? {};

--- a/packages/workbench/surface/src/host/WorkbenchHostDockPopup.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDockPopup.tsx
@@ -53,6 +53,12 @@ import type {
 } from "../react/dockPreviewCache.ts";
 
 const dockPopupCardWidthPx = 165;
+const dockPopupCardHeightPx = 103;
+const dockPopupPreviewInsetPx = 4;
+export const workbenchHostDockPopupPreviewViewport = Object.freeze({
+  height: dockPopupCardHeightPx - dockPopupPreviewInsetPx * 2,
+  width: dockPopupCardWidthPx - dockPopupPreviewInsetPx * 2
+});
 const dockPopupGridGapPx = 8;
 const dockPopupPanelPaddingInlinePx = 12;
 const dockPopupPanelBorderInlinePx = 2;

--- a/packages/workbench/surface/src/index.ts
+++ b/packages/workbench/surface/src/index.ts
@@ -93,6 +93,10 @@ export {
   type WorkbenchSurfaceWallpaperFit,
   type WorkbenchWindowManagementConfig
 } from "./react/WorkbenchSurface.tsx";
+export {
+  WorkbenchDockComponentPreviewFrame,
+  type WorkbenchDockComponentPreviewFrameProps
+} from "./react/WorkbenchDockComponentPreviewFrame.tsx";
 export { useWorkbenchSelector } from "./react/hooks/useWorkbenchSelector.ts";
 export { getWorkbenchLayoutFrame } from "./core/geometry.ts";
 export { selectFocusedWorkbenchNode } from "./core/selectors.ts";

--- a/packages/workbench/surface/src/react/WorkbenchDockComponentPreviewFrame.test.tsx
+++ b/packages/workbench/surface/src/react/WorkbenchDockComponentPreviewFrame.test.tsx
@@ -1,0 +1,56 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it } from "vitest";
+import { WorkbenchDockComponentPreviewFrame } from "./WorkbenchDockComponentPreviewFrame.tsx";
+
+describe("WorkbenchDockComponentPreviewFrame", () => {
+  it("owns preview geometry and keeps decorative content out of hit testing", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchDockComponentPreviewFrame
+            sourceSize={{ height: 560, width: 1040 }}
+            viewport={{ height: 95, width: 157 }}
+          >
+            <span data-preview-content="true" />
+          </WorkbenchDockComponentPreviewFrame>
+        );
+      });
+
+      const frame = container.querySelector<HTMLElement>(
+        "[data-workbench-dock-component-preview-frame]"
+      );
+      const content = container.querySelector<HTMLElement>(
+        "[data-workbench-dock-component-preview-content]"
+      );
+
+      expect(frame?.getAttribute("aria-hidden")).toBe("true");
+      expect(frame?.style.height).toBe("95px");
+      expect(frame?.style.pointerEvents).toBe("none");
+      expect(frame?.style.width).toBe("157px");
+      expect(content?.style.height).toBe("560px");
+      expect(content?.style.transform).toBe(
+        "translate(-50%, -50%) scale(0.15096153846153845)"
+      );
+      expect(content?.style.width).toBe("1040px");
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+  });
+});

--- a/packages/workbench/surface/src/react/WorkbenchDockComponentPreviewFrame.tsx
+++ b/packages/workbench/surface/src/react/WorkbenchDockComponentPreviewFrame.tsx
@@ -1,0 +1,60 @@
+import type { CSSProperties, ReactNode } from "react";
+import type { WorkbenchSize } from "../core/types.ts";
+
+export interface WorkbenchDockComponentPreviewFrameProps {
+  children?: ReactNode;
+  sourceSize: WorkbenchSize;
+  viewport: WorkbenchSize;
+}
+
+export function WorkbenchDockComponentPreviewFrame({
+  children,
+  sourceSize,
+  viewport
+}: WorkbenchDockComponentPreviewFrameProps): ReactNode {
+  const sourceHeight = Math.max(1, sourceSize.height);
+  const sourceWidth = Math.max(1, sourceSize.width);
+  const viewportHeight = Math.max(1, viewport.height);
+  const viewportWidth = Math.max(1, viewport.width);
+  const scale = Math.min(
+    viewportWidth / sourceWidth,
+    viewportHeight / sourceHeight
+  );
+  const frameStyle = {
+    background: "transparent",
+    borderRadius: "0.375rem",
+    display: "block",
+    height: `${viewportHeight}px`,
+    overflow: "hidden",
+    pointerEvents: "none",
+    position: "relative",
+    width: `${viewportWidth}px`
+  } satisfies CSSProperties;
+  const contentStyle = {
+    display: "block",
+    height: `${sourceHeight}px`,
+    left: "50%",
+    overflow: "hidden",
+    pointerEvents: "none",
+    position: "absolute",
+    top: "50%",
+    transform: `translate(-50%, -50%) scale(${scale})`,
+    transformOrigin: "center",
+    width: `${sourceWidth}px`
+  } satisfies CSSProperties;
+
+  return (
+    <span
+      aria-hidden="true"
+      data-workbench-dock-component-preview-frame="true"
+      style={frameStyle}
+    >
+      <span
+        data-workbench-dock-component-preview-content="true"
+        style={contentStyle}
+      >
+        {children}
+      </span>
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a shared `WorkbenchDockComponentPreviewFrame` contract for component previews.
- Pass the canonical popup viewport from Workbench Dock to preview providers.
- Keep AgentGUI preview rendering read-only and skip carousel layout measurement in preview mode.
- Reuse the same contract in Tutti Desktop and external hosts such as TSH.

## Verification

- `pnpm check:changed -- --push-ready` — passed 17 lanes.
- `packages/workbench/surface/node_modules/.bin/vitest run src/host/WorkbenchHostDock.render.test.tsx --environment jsdom` — 2 tests passed.
- Manual TSH GUI validation: minimize/restore works, Dock popup no longer stays loading, preview styling/position matches the live node, and popup content scales into the card.

## Fix Scope Justification

- Root cause: component preview lifecycle and viewport ownership were split between host-specific implementations; popup providers did not receive the Dock card viewport, while preview-only AgentGUI layout measurement mutated presentation geometry.
- Why can this not be fixed at a lower layer? Workbench Surface owns Dock card dimensions and the shared component-preview boundary; AgentGUI owns whether its layout measurement runs in preview mode. Both owners need the matching contract.

## Fallback Three Questions

- Source: `renderPreview` can also be called by contexts that do not provide a bounded preview viewport.
- Why can it not be fixed at that source? Only bounded Dock preview callers have a canonical viewport; other preview consumers may intentionally render the raw body.
- Removal condition: remove the raw-body branch if the public `renderPreview` contract makes `previewViewport` mandatory for every caller.

## Checklist

- [x] This PR does not change agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation for the shared preview contract.
- [x] No root README or CONTRIBUTING language variants changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] Commits are signed off with DCO.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->