### PR TITLE
fix(desktop): preserve recent unstructured logs

### DIFF
--- a/apps/desktop/src/main/developerLogs.test.ts
+++ b/apps/desktop/src/main/developerLogs.test.ts
@@ -195,7 +195,10 @@ test("developer logs service exports only log content from the last ten minutes"
       "time=2026-07-20T12:00:00.001Z level=info msg=future"
     ].join("\n") + "\n"
   );
-  await writeFile(runtimeLogPath, "recent unstructured app output\n");
+  await writeFile(
+    runtimeLogPath,
+    "recent app output referencing 2020-01-01T00:00:00Z snapshot\n"
+  );
   await writeFile(oldRotatedLogPath, "old unstructured daemon output\n");
   await utimes(
     runtimeLogPath,
@@ -265,7 +268,7 @@ test("developer logs service exports only log content from the last ten minutes"
         `app-logs/app.alpha/${workspaceAppScopeSegment("workspace-1", "app.alpha")}/runtime.log`
       )
       ?.toString("utf8"),
-    "recent unstructured app output\n"
+    "recent app output referencing 2020-01-01T00:00:00Z snapshot\n"
   );
   assert.equal(entries.has("logs/tuttid.2026-07-20.log"), false);
   assert.equal(

--- a/apps/desktop/src/main/developerLogsRecentWindow.ts
+++ b/apps/desktop/src/main/developerLogsRecentWindow.ts
@@ -28,13 +28,11 @@ export async function prepareDeveloperLogFilesForExport(
     artifacts.map(
       async (artifact): Promise<PreparedDeveloperLogFile | null> => {
         const originalContent = await readFile(artifact.path);
-        const content = timeWindow
-          ? filterDeveloperLogContentByTime({
-              content: originalContent,
-              modifiedAtUnixMs: artifact.modifiedAtUnixMs,
-              timeWindow
-            })
-          : originalContent;
+        const content = selectDeveloperLogContent({
+          artifact,
+          originalContent,
+          timeWindow
+        });
 
         if (content === null || (timeWindow && content.byteLength === 0)) {
           return null;
@@ -52,6 +50,30 @@ export async function prepareDeveloperLogFilesForExport(
   return prepared.filter(
     (artifact): artifact is PreparedDeveloperLogFile => artifact !== null
   );
+}
+
+function selectDeveloperLogContent(input: {
+  artifact: DeveloperLogFileArtifact;
+  originalContent: Buffer;
+  timeWindow: DeveloperLogsTimeWindow | null;
+}): Buffer | null {
+  if (!input.timeWindow) {
+    return input.originalContent;
+  }
+  if (input.artifact.category !== "managed-log") {
+    return isInDeveloperLogsTimeWindow(
+      input.artifact.modifiedAtUnixMs,
+      input.timeWindow
+    )
+      ? input.originalContent
+      : null;
+  }
+
+  return filterDeveloperLogContentByTime({
+    content: input.originalContent,
+    modifiedAtUnixMs: input.artifact.modifiedAtUnixMs,
+    timeWindow: input.timeWindow
+  });
 }
 
 function filterDeveloperLogContentByTime(input: {
@@ -75,9 +97,10 @@ function filterDeveloperLogContentByTime(input: {
     const timestamp = parseDeveloperLogTimestamp(segment);
     if (timestamp !== null) {
       foundTimestamp = true;
-      includeContinuation =
-        timestamp >= input.timeWindow.startTimeUnixMs &&
-        timestamp <= input.timeWindow.endTimeUnixMs;
+      includeContinuation = isInDeveloperLogsTimeWindow(
+        timestamp,
+        input.timeWindow
+      );
     }
 
     if (includeContinuation) {
@@ -89,10 +112,21 @@ function filterDeveloperLogContentByTime(input: {
     return Buffer.from(selectedSegments.join(""), "utf8");
   }
 
-  const fileWasUpdatedInWindow =
-    input.modifiedAtUnixMs >= input.timeWindow.startTimeUnixMs &&
-    input.modifiedAtUnixMs <= input.timeWindow.endTimeUnixMs;
+  const fileWasUpdatedInWindow = isInDeveloperLogsTimeWindow(
+    input.modifiedAtUnixMs,
+    input.timeWindow
+  );
   return fileWasUpdatedInWindow ? input.content : null;
+}
+
+function isInDeveloperLogsTimeWindow(
+  timestampUnixMs: number,
+  timeWindow: DeveloperLogsTimeWindow
+): boolean {
+  return (
+    timestampUnixMs >= timeWindow.startTimeUnixMs &&
+    timestampUnixMs <= timeWindow.endTimeUnixMs
+  );
 }
 
 function parseDeveloperLogTimestamp(line: string): number | null {


### PR DESCRIPTION
## Summary

- limit line-level timestamp filtering to managed desktop and daemon logs
- keep recent workspace app and app factory stdout/stderr based on file modification time
- add regression coverage for unstructured output that mentions an older ISO timestamp

## Root cause

The recent-window export treated any parseable ISO timestamp in a file as proof that the file was structured. Unstructured app output could therefore be excluded when its message text merely referenced an older date.

## Validation

- `pnpm --filter @tutti-os/desktop typecheck`
- targeted Desktop tests: 79 passed
- `pnpm check:changed -- --push-ready`: 10 lanes passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->