### PR TITLE
feat(agent-gui): allow host session menu actions

### DIFF
--- a/packages/agent/gui/workbench/AgentGuiWorkbenchSessionMenu.spec.tsx
+++ b/packages/agent/gui/workbench/AgentGuiWorkbenchSessionMenu.spec.tsx
@@ -74,6 +74,39 @@ describe("AgentGuiWorkbenchSessionMenu", () => {
     expect(screen.queryByRole("separator")).toBeNull();
   });
 
+  it("renders host-defined actions before the built-in session actions", async () => {
+    const onOpenSession = vi.fn();
+    render(
+      <AgentGuiWorkbenchSessionMenu
+        actions={["copy-markdown", "copy-reference"]}
+        additionalActions={[
+          {
+            id: "open-session",
+            label: "Open session",
+            onSelect: onOpenSession
+          }
+        ]}
+        copy={copy}
+        onAction={vi.fn()}
+      />
+    );
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: copy.moreSessionActions }),
+      { button: 0, ctrlKey: false }
+    );
+
+    const menuItems = await screen.findAllByRole("menuitem");
+    expect(menuItems[0]).toHaveTextContent("Open session");
+    expect(screen.getByRole("separator")).toBeTruthy();
+
+    const openSession = screen.getByRole("menuitem", { name: "Open session" });
+    fireEvent.pointerDown(openSession, { button: 0 });
+    fireEvent.pointerUp(openSession, { button: 0 });
+    fireEvent.click(openSession);
+    await waitFor(() => expect(onOpenSession).toHaveBeenCalledOnce());
+  });
+
   it("lets the complete header constrain its session menu actions", async () => {
     render(
       <AgentGuiWorkbenchHeader

--- a/packages/agent/gui/workbench/AgentGuiWorkbenchSessionMenu.tsx
+++ b/packages/agent/gui/workbench/AgentGuiWorkbenchSessionMenu.tsx
@@ -22,14 +22,23 @@ import type {
 const menuContentClassName =
   "w-max min-w-44 nodrag [-webkit-app-region:no-drag]";
 
+export interface AgentGuiWorkbenchSessionMenuAdditionalAction {
+  id: string;
+  label: string;
+  icon?: ReactNode;
+  onSelect: () => void;
+}
+
 export interface AgentGuiWorkbenchSessionMenuProps {
   actions?: readonly AgentGuiWorkbenchSessionAction[];
+  additionalActions?: readonly AgentGuiWorkbenchSessionMenuAdditionalAction[];
   copy: AgentGuiWorkbenchSessionMenuCopy;
   onAction: (action: AgentGuiWorkbenchSessionAction) => void;
 }
 
 export function AgentGuiWorkbenchSessionMenu({
   actions = ["rename", "copy-markdown", "copy-reference"],
+  additionalActions = [],
   copy,
   onAction
 }: AgentGuiWorkbenchSessionMenuProps): ReactNode {
@@ -37,33 +46,31 @@ export function AgentGuiWorkbenchSessionMenu({
   const showCopyMarkdown = actions.includes("copy-markdown");
   const showCopyReference = actions.includes("copy-reference");
   const showCopyActions = showCopyMarkdown || showCopyReference;
+  const showBuiltInActions = showRename || showCopyActions;
   const pendingActionRef = useRef(false);
-  const select = useCallback(
-    (action: AgentGuiWorkbenchSessionAction) => {
-      if (pendingActionRef.current) {
-        return;
-      }
-      pendingActionRef.current = true;
-      // Radix renders the menu through a React portal. Portal events still
-      // bubble through the React tree, so dispatching synchronously from
-      // pointerup can update/unmount header chrome while its draggable region
-      // is handling the same gesture. Let the menu gesture finish first.
-      window.requestAnimationFrame(() => {
-        pendingActionRef.current = false;
-        onAction(action);
-      });
-    },
-    [onAction]
-  );
+  const select = useCallback((onSelect: () => void) => {
+    if (pendingActionRef.current) {
+      return;
+    }
+    pendingActionRef.current = true;
+    // Radix renders the menu through a React portal. Portal events still
+    // bubble through the React tree, so dispatching synchronously from
+    // pointerup can update/unmount header chrome while its draggable region
+    // is handling the same gesture. Let the menu gesture finish first.
+    window.requestAnimationFrame(() => {
+      pendingActionRef.current = false;
+      onSelect();
+    });
+  }, []);
   const actionProps = useCallback(
-    (action: AgentGuiWorkbenchSessionAction) => ({
-      onClick: () => select(action),
+    (onSelect: () => void) => ({
+      onClick: () => select(onSelect),
       onPointerUp: (event: PointerEvent) => {
         if (event.button === 0) {
-          select(action);
+          select(onSelect);
         }
       },
-      onSelect: () => select(action)
+      onSelect: () => select(onSelect)
     }),
     [select]
   );
@@ -103,21 +110,30 @@ export function AgentGuiWorkbenchSessionMenu({
         onPointerUp={stopPointerPropagation}
         sideOffset={6}
       >
+        {additionalActions.map((action) => (
+          <DropdownMenuItem key={action.id} {...actionProps(action.onSelect)}>
+            {action.icon}
+            <span>{action.label}</span>
+          </DropdownMenuItem>
+        ))}
+        {additionalActions.length > 0 && showBuiltInActions ? (
+          <DropdownMenuSeparator />
+        ) : null}
         {showRename ? (
-          <DropdownMenuItem {...actionProps("rename")}>
+          <DropdownMenuItem {...actionProps(() => onAction("rename"))}>
             <Pencil aria-hidden="true" />
             <span>{copy.renameSession}</span>
           </DropdownMenuItem>
         ) : null}
         {showRename && showCopyActions ? <DropdownMenuSeparator /> : null}
         {showCopyMarkdown ? (
-          <DropdownMenuItem {...actionProps("copy-markdown")}>
+          <DropdownMenuItem {...actionProps(() => onAction("copy-markdown"))}>
             <FileText aria-hidden="true" />
             <span>{copy.copyAsMarkdown}</span>
           </DropdownMenuItem>
         ) : null}
         {showCopyReference ? (
-          <DropdownMenuItem {...actionProps("copy-reference")}>
+          <DropdownMenuItem {...actionProps(() => onAction("copy-reference"))}>
             <AtSign aria-hidden="true" />
             <span>{copy.copyAsReference}</span>
           </DropdownMenuItem>

--- a/packages/agent/gui/workbench/header.ts
+++ b/packages/agent/gui/workbench/header.ts
@@ -28,6 +28,7 @@ import type {
   AgentGuiWorkbenchSessionAction,
   AgentGuiWorkbenchSessionMenuCopy
 } from "./sessionActions.ts";
+import type { AgentGuiWorkbenchSessionMenuAdditionalAction } from "./AgentGuiWorkbenchSessionMenu.tsx";
 
 const LazyAgentRichTextReadonly = lazy(() =>
   import("../shared/AgentRichTextReadonly.tsx").then((module) => ({
@@ -74,6 +75,7 @@ export interface AgentGuiWorkbenchHeaderProps extends HTMLAttributes<HTMLElement
   providerRailWidthPx?: number | null;
   primaryAccessory?: ReactNode;
   secondaryAccessory?: ReactNode;
+  sessionMenuAdditionalActions?: readonly AgentGuiWorkbenchSessionMenuAdditionalAction[];
   sessionMenuActions?: readonly AgentGuiWorkbenchSessionAction[];
   conversationTitle?: string | null;
   conversationTitleDisplayPrompt?: string | null;
@@ -107,6 +109,7 @@ export function AgentGuiWorkbenchHeader({
   providerRailWidthPx,
   primaryAccessory,
   secondaryAccessory,
+  sessionMenuAdditionalActions,
   sessionMenuActions,
   conversationTitle,
   conversationTitleDisplayPrompt,
@@ -145,6 +148,7 @@ export function AgentGuiWorkbenchHeader({
     onSessionAction && copy.sessionMenu && sessionTitle && !hasBodyRenderError
       ? createElement(AgentGuiWorkbenchSessionMenu, {
           actions: sessionMenuActions,
+          additionalActions: sessionMenuAdditionalActions,
           copy: copy.sessionMenu,
           onAction: onSessionAction
         })

--- a/packages/agent/gui/workbench/index.ts
+++ b/packages/agent/gui/workbench/index.ts
@@ -78,6 +78,7 @@ export {
   type AgentGuiWorkbenchHeaderCopy,
   type AgentGuiWorkbenchHeaderProps
 } from "./header.ts";
+export type { AgentGuiWorkbenchSessionMenuAdditionalAction } from "./AgentGuiWorkbenchSessionMenu.tsx";
 export {
   resolveAgentGuiWorkbenchHeaderTitle,
   resolveAgentGuiWorkbenchSessionTitle


### PR DESCRIPTION
## Summary
- add a host-defined action slot before built-in Agent GUI session-menu actions
- preserve shared menu gesture handling for injected actions
- cover ordering and one-time callback delivery

## Validation
- agent-gui typecheck passed
- agent-gui package build passed
- TypeScript lint passed
- UI-boundary check passed

The AgentGuiWorkbenchSessionMenu Vitest run did not complete in this new worktree after dependency installation; an existing sessionActions test stalled at the same startup point. Repository-wide formatting also reports two pre-existing unrelated files.