### PR TITLE
fix(agent): scope interactive responses to turns

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -421,7 +421,10 @@ canonical Interaction(pending)
   -> answered or superseded projection
 ```
 
-Every surface shares request identity and submitting state.
+Every surface shares the exact interaction identity
+`(workspaceId, agentSessionId, turnId, requestId)` and submitting state.
+Provider request ids remain unchanged and may repeat across Turns; no adapter
+may recover a missing Turn by scanning for a session-wide request-id match.
 
 A synthesized plan decision uses a durable `plan_decision` operation. A provider-native plan Interaction continues through `interactive_response`. Similar UI does not justify merging their write paths.
 

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -796,6 +796,47 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [desktopPreferencesService.ts](../../../apps/desktop/src/renderer/src/features/desktop-preferences/services/internal/desktopPreferencesService.ts)
   [useAgentGUIComposerSettingsActions.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.ts)
 
+### Agent interaction remains waiting after the user already responded
+
+- Symptom:
+  An approval or question remains at an ask-user stop point after the user
+  submitted a response. The session may continue after Cancel or an app
+  restart, while retrying by request id alone can target an older Turn or be
+  rejected as ambiguous.
+- Quick checks:
+  Inspect the canonical Interaction identity without logging its prompt or
+  response payload. Compare `workspace_id`, `agent_session_id`, `turn_id`, and
+  `request_id` across the UI/CLI command, Interaction row, and durable runtime
+  operation. A provider request id reused by two Turns is valid. An operation
+  id whose stored tuple differs from the command tuple is an invariant failure.
+- Root cause:
+  Provider request ids are transport-local and are not session-wide durable
+  identities. Selecting an Interaction or deduplicating a runtime operation by
+  request id alone can bind a response to historical Turn state, leaving the
+  live Turn waiting.
+- Fix:
+  Carry the typed exact tuple
+  `(workspaceId, agentSessionId, turnId, requestId)` into Host and select the
+  Interaction atomically by that tuple. Scope runtime-operation idempotency to
+  the same tuple. Keep the provider request id unchanged. Do not scan, guess,
+  auto-deduplicate, or rewrite historical rows. The V4 runtime-operation
+  migration removes the lossy `subject_id`, creates partial unique indexes for
+  each operation kind, verifies copied row distributions and foreign keys, and
+  rolls the whole transaction back when a conflicting durable identity exists.
+- Recovery:
+  Existing affected sessions may be canceled and retried; restart settlement
+  may also interrupt a stale Turn. This forward fix deliberately does not
+  mutate historical Interaction rows.
+- Validation:
+  Cover the same provider request id in two Turns, exact CLI response routing,
+  same-answer idempotency, different-answer supersession, operation identity
+  mismatch failure, lossless V1-to-V4 migration, and V4 preflight rollback.
+- References:
+  [host README](../../../packages/agent/host/README.md)
+  [runtime_operations.go](../../../packages/agent/host/runtime_operations.go)
+  [migrations_runtime_operations_v4.go](../../../packages/agent/store-sqlite/migrations_runtime_operations_v4.go)
+  [tutti-cli-contract.md](../tutti-cli-contract.md)
+
 ### Historical AgentGUI permission changes time out or stop responding
 
 - Symptom:

--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -235,11 +235,13 @@ blocks for the new stop point instead of immediately replaying the previous
 session stop state.
 
 `agent respond --json` answers one pending interaction selected by
-`--session-id` and `--request-id`. `--action`, `--option`, and object-valued
+`--session-id`, `--turn-id`, and `--request-id`. Provider request ids are
+transport-local and may repeat across Turns, so callers must pass the exact
+Turn returned by `agent wait`. `--action`, `--option`, and object-valued
 `--payload` map directly to the Host interactive input. `--semantic` is a thin
 shortcut that resolves exactly one matching `actions[].semantic` from the
 stored interaction; the CLI must not keep a provider-to-semantic mapping.
-Unknown requests and missing or ambiguous semantics are invalid input errors.
+Unknown exact interaction tuples and missing or ambiguous semantics are invalid input errors.
 The first responder atomically claims the pending interaction. Later responses
 with the same action/option/payload return `answered`; different responses
 return `superseded`. The result exposes the request and turn ids plus that Host

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -74,6 +74,12 @@ in-progress errors to the responder. The Interaction's pre-delivery `answered`
 state is a durable claim marker, not the runtime's terminal result; completed
 operation and responder dispositions follow an authoritative runtime
 `superseded` result instead of being overwritten by that marker.
+Interactive identity is always the typed `InteractionRef` tuple
+`(workspaceId, agentSessionId, turnId, requestId)`. Provider request ids remain
+unchanged and are only unique within their owning Turn. The response payload
+contains no identity fields. Durable operation idempotency uses the same tuple;
+an operation id that disagrees with its structured identity is an invariant
+failure and must fail closed rather than guessing or rewriting stored data.
 
 Adapters retain authorization and identity, transport, runtime process or VM
 selection, desktop APIs, attachment ingress, and cloud inbox/outbox behavior.

--- a/packages/agent/host/conformance/commit_observer_scenarios.go
+++ b/packages/agent/host/conformance/commit_observer_scenarios.go
@@ -22,8 +22,11 @@ func runRuntimeCommitObserverFailure(ctx context.Context, driver Driver) error {
 	}
 	optionID := "approve"
 	if _, err := driver.SubmitInteractive(ctx,
-		agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-observer-runtime"},
-		"request-observer-runtime", agenthost.SubmitInteractiveInput{TurnID: "turn-observer-runtime", OptionID: &optionID},
+		agenthost.InteractionRef{
+			WorkspaceID: "workspace-1", AgentSessionID: "session-observer-runtime",
+			TurnID: "turn-observer-runtime", RequestID: "request-observer-runtime",
+		},
+		agenthost.SubmitInteractiveInput{OptionID: &optionID},
 	); err != nil {
 		return fmt.Errorf("observer failure escaped committed runtime command: %w", err)
 	}

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -43,15 +43,17 @@ type InteractionSeed struct {
 }
 
 type Fixture struct {
-	Session            *SessionSeed
-	AdditionalSessions []SessionSeed
-	Turn               *TurnSeed
-	Interaction        *InteractionSeed
-	PreparedSubmitID   string
-	RecoverInteractive bool
-	DisableGoalInbox   bool
-	FailCommitObserver bool
-	WorktreeGCSweepErr error
+	Session                *SessionSeed
+	AdditionalSessions     []SessionSeed
+	Turn                   *TurnSeed
+	AdditionalTurns        []TurnSeed
+	Interaction            *InteractionSeed
+	AdditionalInteractions []InteractionSeed
+	PreparedSubmitID       string
+	RecoverInteractive     bool
+	DisableGoalInbox       bool
+	FailCommitObserver     bool
+	WorktreeGCSweepErr     error
 }
 
 type SessionObservation struct {
@@ -95,6 +97,9 @@ type OperationObservation struct {
 
 type InteractiveObservation struct {
 	Session     SessionObservation
+	OperationID string
+	TurnID      string
+	RequestID   string
 	Disposition agenthost.RuntimeInteractiveDisposition
 }
 
@@ -128,7 +133,8 @@ type Driver interface {
 	EnsureSession(context.Context, agenthost.SessionRef) (SessionObservation, error)
 	SendInput(context.Context, agenthost.SessionRef, agenthost.SendInput) (SendObservation, error)
 	CancelTurn(context.Context, agenthost.CancelTurnInput) (CancelObservation, error)
-	SubmitInteractive(context.Context, agenthost.SessionRef, string, agenthost.SubmitInteractiveInput) (InteractiveObservation, error)
+	SubmitInteractive(context.Context, agenthost.InteractionRef, agenthost.SubmitInteractiveInput) (InteractiveObservation, error)
+	GetInteractionStatus(context.Context, agenthost.InteractionRef) (string, bool, error)
 	SubmitPlanDecision(context.Context, agenthost.SessionRef, string, string, agenthost.SubmitPlanDecisionInput) (OperationObservation, error)
 	UpdateTitle(context.Context, agenthost.UpdateTitleInput) (SessionObservation, error)
 	GetSession(context.Context, agenthost.SessionRef) (SessionObservation, error)

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -12,12 +12,12 @@ func TestPublishedScenarioCatalogsHaveUniqueNames(t *testing.T) {
 		scenarios []Scenario
 		wantCount int
 	}{
-		{name: "adapter lifecycle", scenarios: Scenarios(), wantCount: 15},
+		{name: "adapter lifecycle", scenarios: Scenarios(), wantCount: 16},
 		{name: "application core", scenarios: ApplicationCoreScenarios(), wantCount: 11},
 		{name: "resume policy", scenarios: ResumePolicyScenarios(), wantCount: 4},
 		{name: "submission fence", scenarios: SubmissionFenceScenarios(), wantCount: 1},
 		{name: "title policy", scenarios: TitlePolicyScenarios(), wantCount: 1},
-		{name: "coordinator", scenarios: CoordinatorScenarios(), wantCount: 6},
+		{name: "coordinator", scenarios: CoordinatorScenarios(), wantCount: 7},
 		{name: "goal", scenarios: GoalScenarios(), wantCount: 5},
 		{name: "commit observer", scenarios: CommitObserverScenarios(), wantCount: 2},
 	}
@@ -60,6 +60,7 @@ func TestScenarioOwnershipIsExplicit(t *testing.T) {
 	wantCoordinator := []string{
 		"exact turn cancel",
 		"interactive response",
+		"interactive response reuses provider request id across turns",
 		"interactive response race",
 		"plan decision",
 		"recover operations before stale turns and worktree sweep",

--- a/packages/agent/host/conformance/interactive_response.go
+++ b/packages/agent/host/conformance/interactive_response.go
@@ -20,8 +20,11 @@ func runInteractiveResponse(ctx context.Context, driver Driver) error {
 	}
 	optionID := "approve"
 	result, err := driver.SubmitInteractive(ctx,
-		agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-interactive"},
-		"request-1", agenthost.SubmitInteractiveInput{TurnID: "turn-interactive", OptionID: &optionID},
+		agenthost.InteractionRef{
+			WorkspaceID: "workspace-1", AgentSessionID: "session-interactive",
+			TurnID: "turn-interactive", RequestID: "request-1",
+		},
+		agenthost.SubmitInteractiveInput{OptionID: &optionID},
 	)
 	if err != nil {
 		return fmt.Errorf("submit interactive: %w", err)
@@ -32,6 +35,63 @@ func runInteractiveResponse(ctx context.Context, driver Driver) error {
 	metrics := driver.Metrics()
 	if metrics.InteractiveCalls != 1 || metrics.LastInteractiveTurnID != "turn-interactive" || metrics.LastInteractiveRequestID != "request-1" {
 		return fmt.Errorf("interactive metrics=%#v", metrics)
+	}
+	return nil
+}
+
+func runInteractiveResponseReusedRequestID(ctx context.Context, driver Driver) error {
+	fixture := liveSessionFixture("session-interactive-reused", "turn-current")
+	fixture.Turn = &TurnSeed{TurnID: "turn-current", Phase: canonical.TurnPhaseWaiting}
+	fixture.AdditionalTurns = []TurnSeed{{
+		TurnID: "turn-previous", Phase: canonical.TurnPhaseWaiting,
+	}}
+	fixture.Interaction = &InteractionSeed{
+		RequestID: "provider-request", TurnID: "turn-current",
+		Kind: canonical.InteractionKindApproval, Status: canonical.InteractionStatusPending,
+	}
+	fixture.AdditionalInteractions = []InteractionSeed{{
+		RequestID: "provider-request", TurnID: "turn-previous",
+		Kind: canonical.InteractionKindApproval, Status: canonical.InteractionStatusPending,
+	}}
+	if err := driver.Reset(ctx, fixture); err != nil {
+		return err
+	}
+	previousRef := agenthost.InteractionRef{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-interactive-reused",
+		TurnID: "turn-previous", RequestID: "provider-request",
+	}
+	currentRef := previousRef
+	currentRef.TurnID = "turn-current"
+	previousOption := "deny"
+	previous, err := driver.SubmitInteractive(ctx, previousRef, agenthost.SubmitInteractiveInput{OptionID: &previousOption})
+	if err != nil {
+		return fmt.Errorf("submit previous reused provider request id: %w", err)
+	}
+	if previous.Disposition != agenthost.RuntimeInteractiveDispositionAnswered || previous.TurnID != previousRef.TurnID || previous.RequestID != previousRef.RequestID {
+		return fmt.Errorf("previous reused provider request result=%#v, want exact answered operation", previous)
+	}
+	if status, found, statusErr := driver.GetInteractionStatus(ctx, currentRef); statusErr != nil || !found || status != canonical.InteractionStatusPending {
+		return fmt.Errorf("current interaction before response status=%q found=%v error=%v, want pending", status, found, statusErr)
+	}
+	currentOption := "approve"
+	current, err := driver.SubmitInteractive(ctx, currentRef, agenthost.SubmitInteractiveInput{OptionID: &currentOption})
+	if err != nil {
+		return fmt.Errorf("submit current reused provider request id: %w", err)
+	}
+	if current.Disposition != agenthost.RuntimeInteractiveDispositionAnswered || current.TurnID != currentRef.TurnID || current.RequestID != currentRef.RequestID {
+		return fmt.Errorf("current reused provider request result=%#v, want exact answered operation", current)
+	}
+	if previous.OperationID == "" || current.OperationID == "" || previous.OperationID == current.OperationID {
+		return fmt.Errorf("reused provider request operation ids previous=%q current=%q, want distinct", previous.OperationID, current.OperationID)
+	}
+	for _, ref := range []agenthost.InteractionRef{previousRef, currentRef} {
+		if status, found, statusErr := driver.GetInteractionStatus(ctx, ref); statusErr != nil || !found || status != canonical.InteractionStatusAnswered {
+			return fmt.Errorf("interaction %q status=%q found=%v error=%v, want answered", ref.TurnID, status, found, statusErr)
+		}
+	}
+	metrics := driver.Metrics()
+	if metrics.InteractiveCalls != 2 || metrics.LastInteractiveTurnID != "turn-current" || metrics.LastInteractiveRequestID != "provider-request" {
+		return fmt.Errorf("reused provider request metrics=%#v", metrics)
 	}
 	return nil
 }
@@ -65,8 +125,11 @@ func runInteractiveResponseRace(ctx context.Context, driver Driver) error {
 				defer group.Done()
 				<-start
 				result, err := driver.SubmitInteractive(ctx,
-					agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-interactive-race"},
-					"request-race", agenthost.SubmitInteractiveInput{TurnID: "turn-interactive-race", OptionID: &option},
+					agenthost.InteractionRef{
+						WorkspaceID: "workspace-1", AgentSessionID: "session-interactive-race",
+						TurnID: "turn-interactive-race", RequestID: "request-race",
+					},
+					agenthost.SubmitInteractiveInput{OptionID: &option},
 				)
 				if err != nil {
 					errorsByCall <- err

--- a/packages/agent/host/conformance/scenarios.go
+++ b/packages/agent/host/conformance/scenarios.go
@@ -1,18 +1,19 @@
 package conformance
 
 var (
-	createEmptySessionScenario        = Scenario{Name: "create empty session", run: runCreateEmptySession}
-	createWithInitialContentScenario  = Scenario{Name: "create with initial content", run: runCreateWithInitialContent}
-	resumePersistedSessionScenario    = Scenario{Name: "resume persisted session", run: runResumePersistedSession}
-	sendInputScenario                 = Scenario{Name: "send input", run: runSendInput}
-	duplicateClientSubmitIDScenario   = Scenario{Name: "duplicate client submit id", run: runDuplicateClientSubmitID}
-	exactTurnCancelScenario           = Scenario{Name: "exact turn cancel", run: runExactTurnCancel}
-	interactiveResponseScenario       = Scenario{Name: "interactive response", run: runInteractiveResponse}
-	interactiveResponseRaceScenario   = Scenario{Name: "interactive response race", run: runInteractiveResponseRace}
-	planDecisionScenario              = Scenario{Name: "plan decision", run: runPlanDecision}
-	initialTitleCASScenario           = Scenario{Name: "initial title cas", run: runInitialTitleCAS}
-	getSessionScenario                = Scenario{Name: "get session", run: runGetSession}
-	historicalAndLiveSettingsScenario = Scenario{
+	createEmptySessionScenario          = Scenario{Name: "create empty session", run: runCreateEmptySession}
+	createWithInitialContentScenario    = Scenario{Name: "create with initial content", run: runCreateWithInitialContent}
+	resumePersistedSessionScenario      = Scenario{Name: "resume persisted session", run: runResumePersistedSession}
+	sendInputScenario                   = Scenario{Name: "send input", run: runSendInput}
+	duplicateClientSubmitIDScenario     = Scenario{Name: "duplicate client submit id", run: runDuplicateClientSubmitID}
+	exactTurnCancelScenario             = Scenario{Name: "exact turn cancel", run: runExactTurnCancel}
+	interactiveResponseScenario         = Scenario{Name: "interactive response", run: runInteractiveResponse}
+	interactiveResponseReusedIDScenario = Scenario{Name: "interactive response reuses provider request id across turns", run: runInteractiveResponseReusedRequestID}
+	interactiveResponseRaceScenario     = Scenario{Name: "interactive response race", run: runInteractiveResponseRace}
+	planDecisionScenario                = Scenario{Name: "plan decision", run: runPlanDecision}
+	initialTitleCASScenario             = Scenario{Name: "initial title cas", run: runInitialTitleCAS}
+	getSessionScenario                  = Scenario{Name: "get session", run: runGetSession}
+	historicalAndLiveSettingsScenario   = Scenario{
 		Name: "historical and live settings",
 		run:  runHistoricalAndLiveSettings,
 	}
@@ -31,6 +32,7 @@ func Scenarios() []Scenario {
 		duplicateClientSubmitIDScenario,
 		exactTurnCancelScenario,
 		interactiveResponseScenario,
+		interactiveResponseReusedIDScenario,
 		interactiveResponseRaceScenario,
 		planDecisionScenario,
 		initialTitleCASScenario,
@@ -65,6 +67,7 @@ func CoordinatorScenarios() []Scenario {
 	return []Scenario{
 		exactTurnCancelScenario,
 		interactiveResponseScenario,
+		interactiveResponseReusedIDScenario,
 		interactiveResponseRaceScenario,
 		planDecisionScenario,
 		{Name: "recover operations before stale turns and worktree sweep", run: runRecoveryOrder},

--- a/packages/agent/host/contracts_test.go
+++ b/packages/agent/host/contracts_test.go
@@ -34,6 +34,7 @@ func TestPublicCommandTypesContainNoAdapterIdentityOrTransportFields(t *testing.
 	t.Parallel()
 	types := []reflect.Type{
 		reflect.TypeOf(SessionRef{}),
+		reflect.TypeOf(InteractionRef{}),
 		reflect.TypeOf(CreateSessionInput{}),
 		reflect.TypeOf(SendInput{}),
 		reflect.TypeOf(SubmitInteractiveInput{}),
@@ -66,5 +67,22 @@ func TestPublicCommandTypesContainNoAdapterIdentityOrTransportFields(t *testing.
 				}
 			}
 		}
+	}
+}
+
+func TestInteractiveCommandSeparatesIdentityFromResponse(t *testing.T) {
+	t.Parallel()
+	ref := reflect.TypeOf(InteractionRef{})
+	wantRefFields := []string{"WorkspaceID", "AgentSessionID", "TurnID", "RequestID"}
+	if ref.NumField() != len(wantRefFields) {
+		t.Fatalf("InteractionRef fields=%d, want %d", ref.NumField(), len(wantRefFields))
+	}
+	for index, want := range wantRefFields {
+		if got := ref.Field(index).Name; got != want {
+			t.Fatalf("InteractionRef field[%d]=%q, want %q", index, got, want)
+		}
+	}
+	if _, found := reflect.TypeOf(SubmitInteractiveInput{}).FieldByName("TurnID"); found {
+		t.Fatal("SubmitInteractiveInput must not own interaction identity")
 	}
 }

--- a/packages/agent/host/errors.go
+++ b/packages/agent/host/errors.go
@@ -3,12 +3,14 @@ package agenthost
 import "errors"
 
 var (
-	ErrInvalidArgument            = errors.New("invalid agent session request")
-	ErrSessionNotFound            = errors.New("workspace agent session not found")
-	ErrSubmitDeliveryUnknown      = errors.New("agent submit delivery is still being confirmed")
-	ErrSessionTitleTooLong        = errors.New("agent session title is too long")
-	ErrRuntimeSessionDisconnected = errors.New("agent runtime session is disconnected")
-	ErrRuntimeOperationInProgress = errors.New("agent runtime operation is already in progress")
-	ErrRuntimeOperationFailed     = errors.New("agent runtime operation failed")
-	ErrGoalConsumerUnavailable    = errors.New("agent goal reconcile consumer is unavailable")
+	ErrInvalidArgument                  = errors.New("invalid agent session request")
+	ErrSessionNotFound                  = errors.New("workspace agent session not found")
+	ErrSubmitDeliveryUnknown            = errors.New("agent submit delivery is still being confirmed")
+	ErrSessionTitleTooLong              = errors.New("agent session title is too long")
+	ErrRuntimeSessionDisconnected       = errors.New("agent runtime session is disconnected")
+	ErrInteractionNotFound              = errors.New("agent interaction was not found")
+	ErrRuntimeOperationInProgress       = errors.New("agent runtime operation is already in progress")
+	ErrRuntimeOperationFailed           = errors.New("agent runtime operation failed")
+	ErrRuntimeOperationIdentityMismatch = errors.New("agent runtime operation identity is inconsistent")
+	ErrGoalConsumerUnavailable          = errors.New("agent goal reconcile consumer is unavailable")
 )

--- a/packages/agent/host/runtime_commands.go
+++ b/packages/agent/host/runtime_commands.go
@@ -79,18 +79,19 @@ func (h *Host) CancelTurn(ctx context.Context, input CancelTurnInput) (CancelTur
 	return result, nil
 }
 
-func (h *Host) SubmitInteractive(ctx context.Context, ref SessionRef, requestID string, input SubmitInteractiveInput) (SubmitInteractiveResult, error) {
+func (h *Host) SubmitInteractive(ctx context.Context, ref InteractionRef, input SubmitInteractiveInput) (SubmitInteractiveResult, error) {
 	ref.WorkspaceID = strings.TrimSpace(ref.WorkspaceID)
 	ref.AgentSessionID = strings.TrimSpace(ref.AgentSessionID)
-	requestID = strings.TrimSpace(requestID)
-	if h == nil || h.store == nil || h.runtime == nil || ref.WorkspaceID == "" || ref.AgentSessionID == "" || requestID == "" {
+	ref.TurnID = strings.TrimSpace(ref.TurnID)
+	ref.RequestID = strings.TrimSpace(ref.RequestID)
+	if h == nil || h.store == nil || h.runtime == nil || ref.WorkspaceID == "" || ref.AgentSessionID == "" || ref.TurnID == "" || ref.RequestID == "" {
 		return SubmitInteractiveResult{}, ErrInvalidArgument
 	}
 	route, err := h.resolveRuntimeControlRoute(ctx, ref.WorkspaceID, ref.AgentSessionID)
 	if err != nil {
 		return SubmitInteractiveResult{}, err
 	}
-	operation, claimDisposition, claimed, err := h.prepareInteractiveRuntimeOperation(ctx, ref, requestID, input, route.RootAgentSessionID)
+	operation, claimDisposition, claimed, err := h.prepareInteractiveRuntimeOperation(ctx, ref, input, route.RootAgentSessionID)
 	if err != nil {
 		return SubmitInteractiveResult{}, err
 	}

--- a/packages/agent/host/runtime_operations.go
+++ b/packages/agent/host/runtime_operations.go
@@ -37,19 +37,16 @@ func runtimeOperationPayloadText(payload map[string]any, key string) string {
 
 func (h *Host) prepareInteractiveRuntimeOperation(
 	ctx context.Context,
-	ref SessionRef,
-	requestID string,
+	ref InteractionRef,
 	input SubmitInteractiveInput,
 	rootAgentSessionID string,
 ) (storesqlite.RuntimeOperation, RuntimeInteractiveDisposition, bool, error) {
 	if h.operations == nil || h.store == nil {
 		return storesqlite.RuntimeOperation{}, RuntimeInteractiveDispositionUnknown, false, errors.New("agent runtime operation store is unavailable")
 	}
-	expectedTurnID := strings.TrimSpace(input.TurnID)
-	operationSubjectID := requestID
-	if expectedTurnID != "" {
-		operationSubjectID = expectedTurnID + "\x00" + requestID
-	}
+	expectedTurnID := strings.TrimSpace(ref.TurnID)
+	requestID := strings.TrimSpace(ref.RequestID)
+	operationSubjectID := expectedTurnID + "\x00" + requestID
 	operationID := runtimeOperationID(ref.WorkspaceID, ref.AgentSessionID, storesqlite.RuntimeOperationKindInteractiveResponse, operationSubjectID)
 	payload := map[string]any{
 		"rootAgentSessionId": strings.TrimSpace(rootAgentSessionID),
@@ -61,8 +58,8 @@ func (h *Host) prepareInteractiveRuntimeOperation(
 	} else if found {
 		if existing.WorkspaceID != ref.WorkspaceID || existing.AgentSessionID != ref.AgentSessionID ||
 			existing.Kind != storesqlite.RuntimeOperationKindInteractiveResponse || existing.RequestID != requestID ||
-			(expectedTurnID != "" && existing.TurnID != expectedTurnID) {
-			return storesqlite.RuntimeOperation{}, RuntimeInteractiveDispositionUnknown, false, storesqlite.ErrRuntimeOperationConflict
+			existing.TurnID != expectedTurnID {
+			return storesqlite.RuntimeOperation{}, RuntimeInteractiveDispositionUnknown, false, interactiveIdentityMismatch(ref, operationID)
 		}
 		switch existing.Status {
 		case storesqlite.RuntimeOperationStatusCompleted:
@@ -78,29 +75,18 @@ func (h *Host) prepareInteractiveRuntimeOperation(
 			return existing, RuntimeInteractiveDispositionUnknown, true, nil
 		}
 	}
-	interactions, err := h.store.ListSessionInteractions(ctx, storesqlite.ListSessionInteractionsInput{
-		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
-	})
-	if err != nil {
-		return storesqlite.RuntimeOperation{}, RuntimeInteractiveDispositionUnknown, false, err
-	}
-	var target storesqlite.Interaction
-	for _, interaction := range interactions {
-		if strings.TrimSpace(interaction.RequestID) == requestID && (expectedTurnID == "" || strings.TrimSpace(interaction.TurnID) == expectedTurnID) {
-			target = interaction
-			break
-		}
-	}
-	turnID := strings.TrimSpace(target.TurnID)
-	if turnID == "" {
-		return storesqlite.RuntimeOperation{}, RuntimeInteractiveDispositionUnknown, false, fmt.Errorf("%w: interaction %q was not found", ErrInvalidArgument, requestID)
-	}
 	operation, interaction, transition, err := h.operations.PrepareInteractiveRuntimeOperation(ctx, storesqlite.RuntimeOperationPrepare{
 		OperationID: operationID, WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
-		Kind: storesqlite.RuntimeOperationKindInteractiveResponse, TurnID: turnID, RequestID: requestID,
+		Kind: storesqlite.RuntimeOperationKindInteractiveResponse, TurnID: expectedTurnID, RequestID: requestID,
 		Payload: payload, OccurredAtMS: h.now().UnixMilli(),
 	})
 	if err != nil {
+		if errors.Is(err, storesqlite.ErrRuntimeOperationIdentityMismatch) {
+			return storesqlite.RuntimeOperation{}, RuntimeInteractiveDispositionUnknown, false, interactiveIdentityMismatch(ref, operationID)
+		}
+		if errors.Is(err, storesqlite.ErrRuntimeOperationSubjectState) {
+			return storesqlite.RuntimeOperation{}, RuntimeInteractiveDispositionUnknown, false, ErrInteractionNotFound
+		}
 		return storesqlite.RuntimeOperation{}, RuntimeInteractiveDispositionUnknown, false, err
 	}
 	disposition := RuntimeInteractiveDispositionSuperseded
@@ -108,6 +94,17 @@ func (h *Host) prepareInteractiveRuntimeOperation(
 		disposition = RuntimeInteractiveDispositionAnswered
 	}
 	return operation, disposition, transition == storesqlite.InteractionTransitionApplied && disposition == RuntimeInteractiveDispositionAnswered, nil
+}
+
+func interactiveIdentityMismatch(ref InteractionRef, operationID string) error {
+	slog.Error(runtimeOperationLogPrefix+" interactive identity mismatch",
+		"workspace_id", ref.WorkspaceID,
+		"agent_session_id", ref.AgentSessionID,
+		"turn_id", ref.TurnID,
+		"request_id", ref.RequestID,
+		"operation_id", operationID,
+	)
+	return ErrRuntimeOperationIdentityMismatch
 }
 
 func interactiveClaimOutput(input SubmitInteractiveInput) map[string]any {

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -9,6 +9,16 @@ type SessionRef struct {
 	AgentSessionID string
 }
 
+// InteractionRef identifies one canonical interaction. Provider request IDs
+// are transport-local correlation values and are only unique within the Turn
+// that owns them.
+type InteractionRef struct {
+	WorkspaceID    string
+	AgentSessionID string
+	TurnID         string
+	RequestID      string
+}
+
 type ComposerSettings struct {
 	Model            string
 	PermissionModeID string
@@ -270,7 +280,6 @@ type SendInput struct {
 }
 
 type SubmitInteractiveInput struct {
-	TurnID   string
 	Action   *string
 	OptionID *string
 	Payload  map[string]any

--- a/packages/agent/store-sqlite/activity_turns.go
+++ b/packages/agent/store-sqlite/activity_turns.go
@@ -663,6 +663,15 @@ func (s *Store) ListSessionInteractions(ctx context.Context, input ListSessionIn
 	query := agentInteractionSelectSQL + `
 WHERE workspace_id = ? AND agent_session_id = ?`
 	args := []any{workspaceID, agentSessionID}
+	turnID := strings.TrimSpace(input.TurnID)
+	requestID := strings.TrimSpace(input.RequestID)
+	if turnID != "" || requestID != "" {
+		if turnID == "" || requestID == "" {
+			return nil, errors.New("workspace agent interaction turn and request ids must be provided together")
+		}
+		query += ` AND turn_id = ? AND request_id = ?`
+		args = append(args, turnID, requestID)
+	}
 	if status := strings.TrimSpace(input.Status); status != "" {
 		query += ` AND status = ?`
 		args = append(args, status)

--- a/packages/agent/store-sqlite/activity_turns_test.go
+++ b/packages/agent/store-sqlite/activity_turns_test.go
@@ -849,6 +849,17 @@ func TestInteractionsAllowSameRequestIDInDifferentTurns(t *testing.T) {
 	if err != nil || len(interactions) != 2 || interactions[0].TurnID == interactions[1].TurnID {
 		t.Fatalf("interactions=%#v error=%v, want independently owned rows", interactions, err)
 	}
+	exact, err := store.ListSessionInteractions(ctx, ListSessionInteractionsInput{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-2", RequestID: "same-request",
+	})
+	if err != nil || len(exact) != 1 || exact[0].TurnID != "turn-2" || exact[0].RequestID != "same-request" {
+		t.Fatalf("exact interactions=%#v error=%v", exact, err)
+	}
+	if _, err := store.ListSessionInteractions(ctx, ListSessionInteractionsInput{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-2",
+	}); err == nil {
+		t.Fatal("partial exact interaction identity error = nil")
+	}
 }
 
 func TestSessionActiveTurnReferenceRejectsOrphanAndCrossSessionTurns(t *testing.T) {

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -43,6 +43,7 @@ const schemaMigrationWorkspaceAgentEntityInvariantsV1 = "workspace_agent_entity_
 const schemaMigrationWorkspaceAgentRuntimeOperationsV1 = "workspace_agent_runtime_operations_v1"
 const schemaMigrationWorkspaceAgentRuntimeOperationsV2 = "workspace_agent_runtime_operations_v2"
 const schemaMigrationWorkspaceAgentRuntimeOperationsV3 = "workspace_agent_runtime_operations_v3"
+const schemaMigrationWorkspaceAgentRuntimeOperationsV4 = "workspace_agent_runtime_operations_v4"
 const schemaMigrationWorkspaceAgentSubmitClaimsV1 = "workspace_agent_submit_claims_v1"
 const schemaMigrationAgentTargetsV1 = "agent_targets_v1"
 const schemaMigrationAgentTargetsV2 = "agent_targets_v2"
@@ -182,6 +183,9 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 		return err
 	}
 	if err := s.applyWorkspaceAgentRuntimeOperationsV3(ctx); err != nil {
+		return err
+	}
+	if err := s.applyWorkspaceAgentRuntimeOperationsV4(ctx); err != nil {
 		return err
 	}
 	if err := s.applyWorkspaceAgentSubmitClaimsV1(ctx); err != nil {

--- a/packages/agent/store-sqlite/migrations_runtime_operations_v2_test.go
+++ b/packages/agent/store-sqlite/migrations_runtime_operations_v2_test.go
@@ -12,7 +12,7 @@ func TestRuntimeOperationsV2UpgradesV1DataAndConstraints(t *testing.T) {
 DROP TABLE workspace_agent_runtime_operation_events;
 DROP TABLE workspace_agent_runtime_operations;
 DELETE FROM agent_store_schema_migrations
-WHERE id IN ('workspace_agent_runtime_operations_v1', 'workspace_agent_runtime_operations_v2', 'workspace_agent_runtime_operations_v3');
+WHERE id IN ('workspace_agent_runtime_operations_v1', 'workspace_agent_runtime_operations_v2', 'workspace_agent_runtime_operations_v3', 'workspace_agent_runtime_operations_v4');
 `); err != nil {
 		t.Fatal(err)
 	}
@@ -20,15 +20,17 @@ WHERE id IN ('workspace_agent_runtime_operations_v1', 'workspace_agent_runtime_o
 		t.Fatal(err)
 	}
 	seedRuntimeInteractiveSubject(t, store, "session-1", "turn-1", "request-1")
-	prepareRuntimeInteractive(t, store, "interactive-1", "session-1", "turn-1", "request-1")
-	if _, created, err := store.PrepareRuntimeOperation(ctx, RuntimeOperationPrepare{
-		OperationID: "cancel-1", WorkspaceID: "ws-1", AgentSessionID: "session-1",
-		Kind: RuntimeOperationKindCancelTurn, TurnID: "turn-1", OccurredAtMS: 10,
-		Payload: map[string]any{"rootAgentSessionId": "session-1", "targets": []any{
-			map[string]any{"agentSessionId": "session-1", "turnId": "turn-1"},
-		}},
-	}); err != nil || !created {
-		t.Fatalf("prepare v1 cancel created=%v err=%v", created, err)
+	if _, err := store.db.Exec(`
+INSERT INTO workspace_agent_runtime_operations (
+  operation_id, workspace_id, agent_session_id, kind, status, subject_id, turn_id,
+  request_id, payload_json, next_attempt_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
+) VALUES
+  ('interactive-1', 'ws-1', 'session-1', 'interactive_response', 'prepared', 'request-1', 'turn-1',
+   'request-1', '{"answer":"yes"}', 10, 10, 10),
+  ('cancel-1', 'ws-1', 'session-1', 'cancel_turn', 'prepared', 'turn-1', 'turn-1',
+   NULL, '{"rootAgentSessionId":"session-1","targets":[{"agentSessionId":"session-1","turnId":"turn-1"}]}', 10, 10, 10)
+`); err != nil {
+		t.Fatalf("seed v1 operations: %v", err)
 	}
 	if _, err := store.db.Exec(`
 INSERT INTO workspace_agent_runtime_operation_events (
@@ -63,16 +65,14 @@ INSERT INTO workspace_agent_runtime_operation_events (
 		t.Fatalf("claimable index count=%d err=%v", indexCount, err)
 	}
 	seedPlanDecisionSubject(t, store, "session-2", "plan-turn")
-	valid := RuntimeOperationPrepare{
-		OperationID: "plan-op", WorkspaceID: "ws-1", AgentSessionID: "session-2",
-		Kind: RuntimeOperationKindPlanDecision, TurnID: "plan-turn", RequestID: "plan-turn", OccurredAtMS: 20,
-		Payload: map[string]any{
-			"promptKind": "plan-implementation", "action": "implement", "idempotencyKey": "decision-1",
-			"clientSubmitId": "plan-decision:plan-op", "step": "prepared",
-		},
-	}
-	if _, created, err := store.PrepareRuntimeOperation(ctx, valid); err != nil || !created {
-		t.Fatalf("valid plan created=%v err=%v", created, err)
+	if _, err := store.db.Exec(`
+INSERT INTO workspace_agent_runtime_operations (
+ operation_id, workspace_id, agent_session_id, kind, status, subject_id, turn_id,
+ request_id, payload_json, next_attempt_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
+) VALUES ('plan-op', 'ws-1', 'session-2', 'plan_decision', 'prepared', 'plan-turn',
+ 'plan-turn', 'plan-turn', '{"promptKind":"plan-implementation","action":"implement","idempotencyKey":"decision-1","clientSubmitId":"plan-decision:plan-op","step":"prepared"}', 20, 20, 20)
+`); err != nil {
+		t.Fatalf("seed valid v2 plan operation: %v", err)
 	}
 	if _, err := store.db.Exec(`
 INSERT INTO workspace_agent_runtime_operations (
@@ -110,5 +110,35 @@ INSERT INTO workspace_agent_runtime_operation_events (
 	var v3Count int
 	if err := store.db.QueryRow(`SELECT COUNT(*) FROM agent_store_schema_migrations WHERE id = ?`, schemaMigrationWorkspaceAgentRuntimeOperationsV3).Scan(&v3Count); err != nil || v3Count != 1 {
 		t.Fatalf("v3 migration count=%d err=%v", v3Count, err)
+	}
+	if _, err := store.db.Exec(`UPDATE workspace_agent_runtime_operations SET attempt = 3, version = 4, last_error = 'retry me', updated_at_unix_ms = 25 WHERE operation_id = 'interactive-1'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`UPDATE workspace_agent_runtime_operation_events SET published_at_unix_ms = 23 WHERE operation_id = 'interactive-1'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.applyWorkspaceAgentRuntimeOperationsV4(ctx); err != nil {
+		t.Fatal(err)
+	}
+	var subjectColumnCount int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('workspace_agent_runtime_operations') WHERE name = 'subject_id'`).Scan(&subjectColumnCount); err != nil || subjectColumnCount != 0 {
+		t.Fatalf("subject_id column count=%d err=%v", subjectColumnCount, err)
+	}
+	var operationCount, eventCount int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM workspace_agent_runtime_operations`).Scan(&operationCount); err != nil || operationCount != 3 {
+		t.Fatalf("operation count=%d err=%v", operationCount, err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM workspace_agent_runtime_operation_events`).Scan(&eventCount); err != nil || eventCount != 4 {
+		t.Fatalf("event count=%d err=%v", eventCount, err)
+	}
+	var attempt, version int
+	var lastError string
+	var updatedAt int64
+	if err := store.db.QueryRow(`SELECT attempt, version, last_error, updated_at_unix_ms FROM workspace_agent_runtime_operations WHERE operation_id = 'interactive-1'`).Scan(&attempt, &version, &lastError, &updatedAt); err != nil || attempt != 3 || version != 4 || lastError != "retry me" || updatedAt != 25 {
+		t.Fatalf("preserved operation fields attempt=%d version=%d lastError=%q updatedAt=%d err=%v", attempt, version, lastError, updatedAt, err)
+	}
+	var publishedAt int64
+	if err := store.db.QueryRow(`SELECT published_at_unix_ms FROM workspace_agent_runtime_operation_events WHERE operation_id = 'interactive-1'`).Scan(&publishedAt); err != nil || publishedAt != 23 {
+		t.Fatalf("preserved event publishedAt=%d err=%v", publishedAt, err)
 	}
 }

--- a/packages/agent/store-sqlite/migrations_runtime_operations_v4.go
+++ b/packages/agent/store-sqlite/migrations_runtime_operations_v4.go
@@ -1,0 +1,277 @@
+package storesqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"maps"
+)
+
+func (s *Store) applyWorkspaceAgentRuntimeOperationsV4(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentRuntimeOperationsV4)
+	if err != nil || applied {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin workspace agent runtime operations v4: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := preflightRuntimeOperationIdentitiesV4(ctx, tx); err != nil {
+		return err
+	}
+	before, err := runtimeOperationMigrationCounts(ctx, tx, "workspace_agent_runtime_operations", "workspace_agent_runtime_operation_events")
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+ALTER TABLE workspace_agent_runtime_operation_events RENAME TO workspace_agent_runtime_operation_events_v3;
+ALTER TABLE workspace_agent_runtime_operations RENAME TO workspace_agent_runtime_operations_v3;
+DROP INDEX IF EXISTS idx_workspace_agent_runtime_operations_claimable;
+DROP INDEX IF EXISTS idx_workspace_agent_runtime_operations_session;
+DROP INDEX IF EXISTS idx_workspace_agent_runtime_operation_events_workspace;
+
+CREATE TABLE workspace_agent_runtime_operations (
+  operation_id TEXT PRIMARY KEY CHECK (length(operation_id) > 0),
+  workspace_id TEXT NOT NULL,
+  agent_session_id TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('interactive_response','cancel_turn','plan_decision')),
+  status TEXT NOT NULL CHECK (status IN ('prepared','leased','completed','failed')),
+  result TEXT CHECK (result IS NULL OR result IN ('answered','superseded','canceled','already_settled','applied','failed')),
+  turn_id TEXT NOT NULL CHECK (length(turn_id) > 0),
+  request_id TEXT,
+  payload_json TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(payload_json)),
+  lease_owner TEXT,
+  lease_expires_at_unix_ms INTEGER,
+  next_attempt_at_unix_ms INTEGER,
+  attempt INTEGER NOT NULL DEFAULT 0 CHECK (attempt >= 0),
+  version INTEGER NOT NULL DEFAULT 1 CHECK (version > 0),
+  last_error TEXT NOT NULL DEFAULT '',
+  created_at_unix_ms INTEGER NOT NULL,
+  updated_at_unix_ms INTEGER NOT NULL,
+  completed_at_unix_ms INTEGER,
+  CHECK ((kind = 'interactive_response' AND request_id IS NOT NULL)
+      OR (kind = 'cancel_turn' AND request_id IS NULL)
+      OR (kind = 'plan_decision' AND request_id IS NOT NULL
+          AND request_id = turn_id
+          AND json_extract(payload_json, '$.promptKind') = 'plan-implementation'
+          AND json_extract(payload_json, '$.action') = 'implement'
+          AND length(json_extract(payload_json, '$.idempotencyKey')) > 0
+          AND json_extract(payload_json, '$.clientSubmitId') = 'plan-decision:' || operation_id
+          AND json_extract(payload_json, '$.step') IN ('prepared','settings_applied','send_dispatched','send_confirmed')
+          AND ((json_extract(payload_json, '$.step') = 'send_confirmed'
+                AND length(json_extract(payload_json, '$.confirmedTurnId')) > 0
+                AND json_extract(payload_json, '$.confirmedTurnId') != turn_id)
+               OR (json_extract(payload_json, '$.step') != 'send_confirmed'
+                   AND json_extract(payload_json, '$.confirmedTurnId') IS NULL)))),
+  CHECK ((status = 'leased' AND lease_owner IS NOT NULL AND length(lease_owner) > 0 AND lease_expires_at_unix_ms > 0)
+      OR (status != 'leased' AND lease_owner IS NULL AND lease_expires_at_unix_ms IS NULL)),
+  CHECK ((status = 'prepared' AND next_attempt_at_unix_ms IS NOT NULL)
+      OR (status != 'prepared' AND next_attempt_at_unix_ms IS NULL)),
+  CHECK ((status = 'completed' AND result IS NOT NULL AND completed_at_unix_ms IS NOT NULL)
+      OR (status != 'completed' AND completed_at_unix_ms IS NULL)),
+  FOREIGN KEY (workspace_id, agent_session_id)
+    REFERENCES workspace_agent_sessions(workspace_id, agent_session_id) ON DELETE CASCADE,
+  FOREIGN KEY (workspace_id, agent_session_id, turn_id)
+    REFERENCES workspace_agent_turns(workspace_id, agent_session_id, turn_id) ON DELETE CASCADE
+);
+
+INSERT INTO workspace_agent_runtime_operations (
+  operation_id, workspace_id, agent_session_id, kind, status, result, turn_id,
+  request_id, payload_json, lease_owner, lease_expires_at_unix_ms,
+  next_attempt_at_unix_ms, attempt, version, last_error, created_at_unix_ms,
+  updated_at_unix_ms, completed_at_unix_ms
+)
+SELECT
+  operation_id, workspace_id, agent_session_id, kind, status, result, turn_id,
+  request_id, payload_json, lease_owner, lease_expires_at_unix_ms,
+  next_attempt_at_unix_ms, attempt, version, last_error, created_at_unix_ms,
+  updated_at_unix_ms, completed_at_unix_ms
+FROM workspace_agent_runtime_operations_v3;
+
+CREATE UNIQUE INDEX idx_workspace_agent_runtime_operations_interactive_identity
+  ON workspace_agent_runtime_operations(workspace_id, agent_session_id, turn_id, request_id)
+  WHERE kind = 'interactive_response';
+CREATE UNIQUE INDEX idx_workspace_agent_runtime_operations_cancel_identity
+  ON workspace_agent_runtime_operations(workspace_id, agent_session_id, turn_id)
+  WHERE kind = 'cancel_turn';
+CREATE UNIQUE INDEX idx_workspace_agent_runtime_operations_plan_identity
+  ON workspace_agent_runtime_operations(workspace_id, agent_session_id, turn_id)
+  WHERE kind = 'plan_decision';
+CREATE INDEX idx_workspace_agent_runtime_operations_claimable
+  ON workspace_agent_runtime_operations(status, next_attempt_at_unix_ms, lease_expires_at_unix_ms, created_at_unix_ms, operation_id);
+CREATE INDEX idx_workspace_agent_runtime_operations_session
+  ON workspace_agent_runtime_operations(workspace_id, agent_session_id, updated_at_unix_ms);
+
+CREATE TABLE workspace_agent_runtime_operation_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  operation_id TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
+  agent_session_id TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('interactive_completed','turn_canceled','plan_decision_pending_confirmation','plan_decision_completed')),
+  payload_json TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(payload_json)),
+  created_at_unix_ms INTEGER NOT NULL,
+  published_at_unix_ms INTEGER,
+  FOREIGN KEY (operation_id) REFERENCES workspace_agent_runtime_operations(operation_id) ON DELETE CASCADE,
+  FOREIGN KEY (workspace_id, agent_session_id)
+    REFERENCES workspace_agent_sessions(workspace_id, agent_session_id) ON DELETE CASCADE,
+  UNIQUE (operation_id, kind)
+);
+
+INSERT INTO workspace_agent_runtime_operation_events (
+  id, operation_id, workspace_id, agent_session_id, kind, payload_json,
+  created_at_unix_ms, published_at_unix_ms
+)
+SELECT
+  id, operation_id, workspace_id, agent_session_id, kind, payload_json,
+  created_at_unix_ms, published_at_unix_ms
+FROM workspace_agent_runtime_operation_events_v3;
+
+CREATE INDEX idx_workspace_agent_runtime_operation_events_workspace
+  ON workspace_agent_runtime_operation_events(workspace_id, published_at_unix_ms, id);
+`); err != nil {
+		return fmt.Errorf("migrate workspace agent runtime operations v4: %w", err)
+	}
+
+	after, err := runtimeOperationMigrationCounts(ctx, tx, "workspace_agent_runtime_operations", "workspace_agent_runtime_operation_events")
+	if err != nil {
+		return err
+	}
+	if !maps.Equal(before, after) {
+		return fmt.Errorf("migrate workspace agent runtime operations v4: copied row distribution changed: before=%v after=%v", before, after)
+	}
+	if err := requireRuntimeOperationRowsPreservedV4(ctx, tx); err != nil {
+		return err
+	}
+	if err := requireNoForeignKeyViolations(ctx, tx, "workspace_agent_runtime_operations"); err != nil {
+		return err
+	}
+	if err := requireNoForeignKeyViolations(ctx, tx, "workspace_agent_runtime_operation_events"); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+DROP TABLE workspace_agent_runtime_operation_events_v3;
+DROP TABLE workspace_agent_runtime_operations_v3;
+`); err != nil {
+		return fmt.Errorf("drop workspace agent runtime operations v3 tables: %w", err)
+	}
+	if err := recordMigrationTx(ctx, tx, schemaMigrationWorkspaceAgentRuntimeOperationsV4); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit workspace agent runtime operations v4: %w", err)
+	}
+	return nil
+}
+
+func requireRuntimeOperationRowsPreservedV4(ctx context.Context, tx *sql.Tx) error {
+	operationColumns := `operation_id, workspace_id, agent_session_id, kind, status, result, turn_id,
+request_id, payload_json, lease_owner, lease_expires_at_unix_ms, next_attempt_at_unix_ms,
+attempt, version, last_error, created_at_unix_ms, updated_at_unix_ms, completed_at_unix_ms`
+	eventColumns := `id, operation_id, workspace_id, agent_session_id, kind, payload_json,
+created_at_unix_ms, published_at_unix_ms`
+	for _, comparison := range []struct {
+		label      string
+		oldTable   string
+		newTable   string
+		columnList string
+	}{
+		{
+			label: "operations", oldTable: "workspace_agent_runtime_operations_v3",
+			newTable: "workspace_agent_runtime_operations", columnList: operationColumns,
+		},
+		{
+			label: "events", oldTable: "workspace_agent_runtime_operation_events_v3",
+			newTable: "workspace_agent_runtime_operation_events", columnList: eventColumns,
+		},
+	} {
+		for _, direction := range [][2]string{{comparison.oldTable, comparison.newTable}, {comparison.newTable, comparison.oldTable}} {
+			query := `SELECT COUNT(*) FROM (SELECT ` + comparison.columnList + ` FROM ` + direction[0] +
+				` EXCEPT SELECT ` + comparison.columnList + ` FROM ` + direction[1] + `)`
+			var differences int64
+			if err := tx.QueryRowContext(ctx, query).Scan(&differences); err != nil {
+				return fmt.Errorf("verify workspace agent runtime operation v4 %s: %w", comparison.label, err)
+			}
+			if differences != 0 {
+				return fmt.Errorf("verify workspace agent runtime operation v4 %s: found %d changed rows", comparison.label, differences)
+			}
+		}
+	}
+	return nil
+}
+
+func preflightRuntimeOperationIdentitiesV4(ctx context.Context, tx *sql.Tx) error {
+	var conflicts int
+	err := tx.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM (
+  SELECT 1
+  FROM workspace_agent_runtime_operations
+  WHERE kind = 'interactive_response'
+  GROUP BY workspace_id, agent_session_id, turn_id, request_id
+  HAVING COUNT(*) > 1
+  UNION ALL
+  SELECT 1
+  FROM workspace_agent_runtime_operations
+  WHERE kind = 'cancel_turn'
+  GROUP BY workspace_id, agent_session_id, turn_id
+  HAVING COUNT(*) > 1
+  UNION ALL
+  SELECT 1
+  FROM workspace_agent_runtime_operations
+  WHERE kind = 'plan_decision'
+  GROUP BY workspace_id, agent_session_id, turn_id
+  HAVING COUNT(*) > 1
+)
+`).Scan(&conflicts)
+	if err != nil {
+		return fmt.Errorf("preflight workspace agent runtime operation identities v4: %w", err)
+	}
+	if conflicts != 0 {
+		return fmt.Errorf("preflight workspace agent runtime operation identities v4: found %d conflicting durable identities", conflicts)
+	}
+	return nil
+}
+
+func runtimeOperationMigrationCounts(ctx context.Context, tx *sql.Tx, operationsTable, eventsTable string) (map[string]int64, error) {
+	counts := make(map[string]int64)
+	for _, query := range []struct {
+		prefix string
+		sql    string
+	}{
+		{prefix: "operation", sql: `SELECT kind, status, COUNT(*) FROM ` + operationsTable + ` GROUP BY kind, status`},
+		{prefix: "event", sql: `SELECT kind, '', COUNT(*) FROM ` + eventsTable + ` GROUP BY kind`},
+	} {
+		rows, err := tx.QueryContext(ctx, query.sql)
+		if err != nil {
+			return nil, fmt.Errorf("count workspace agent runtime operation migration rows: %w", err)
+		}
+		for rows.Next() {
+			var kind, status string
+			var count int64
+			if err := rows.Scan(&kind, &status, &count); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("scan workspace agent runtime operation migration counts: %w", err)
+			}
+			counts[query.prefix+"\x00"+kind+"\x00"+status] = count
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("iterate workspace agent runtime operation migration counts: %w", err)
+		}
+		rows.Close()
+	}
+	return counts, nil
+}
+
+func requireNoForeignKeyViolations(ctx context.Context, tx *sql.Tx, table string) error {
+	rows, err := tx.QueryContext(ctx, `PRAGMA foreign_key_check(`+table+`)`)
+	if err != nil {
+		return fmt.Errorf("check %s foreign keys: %w", table, err)
+	}
+	defer rows.Close()
+	if rows.Next() {
+		return fmt.Errorf("check %s foreign keys: migration produced a foreign key violation", table)
+	}
+	return rows.Err()
+}

--- a/packages/agent/store-sqlite/migrations_runtime_operations_v4_test.go
+++ b/packages/agent/store-sqlite/migrations_runtime_operations_v4_test.go
@@ -1,0 +1,74 @@
+package storesqlite
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeOperationsV4RejectsDuplicateStructuredIdentityWithoutMutation(t *testing.T) {
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	if _, err := store.db.Exec(`
+DROP TABLE workspace_agent_runtime_operation_events;
+DROP TABLE workspace_agent_runtime_operations;
+DELETE FROM agent_store_schema_migrations WHERE id = 'workspace_agent_runtime_operations_v4';
+CREATE TABLE workspace_agent_runtime_operations (
+  operation_id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  agent_session_id TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  status TEXT NOT NULL,
+  subject_id TEXT NOT NULL,
+  turn_id TEXT NOT NULL,
+  request_id TEXT,
+  payload_json TEXT NOT NULL DEFAULT '{}',
+  result TEXT,
+  lease_owner TEXT,
+  lease_expires_at_unix_ms INTEGER,
+  next_attempt_at_unix_ms INTEGER,
+  attempt INTEGER NOT NULL DEFAULT 0,
+  version INTEGER NOT NULL DEFAULT 1,
+  last_error TEXT NOT NULL DEFAULT '',
+  created_at_unix_ms INTEGER NOT NULL,
+  updated_at_unix_ms INTEGER NOT NULL,
+  completed_at_unix_ms INTEGER
+);
+CREATE TABLE workspace_agent_runtime_operation_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  operation_id TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
+  agent_session_id TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  payload_json TEXT NOT NULL DEFAULT '{}',
+  created_at_unix_ms INTEGER NOT NULL,
+  published_at_unix_ms INTEGER
+);
+INSERT INTO workspace_agent_runtime_operations (
+  operation_id, workspace_id, agent_session_id, kind, status, subject_id,
+  turn_id, request_id, next_attempt_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
+) VALUES
+  ('operation-a', 'ws-1', 'session-1', 'interactive_response', 'prepared', 'legacy-a', 'turn-1', 'request-reused', 10, 10, 10),
+  ('operation-b', 'ws-1', 'session-1', 'interactive_response', 'prepared', 'legacy-b', 'turn-1', 'request-reused', 11, 11, 11);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	err := store.applyWorkspaceAgentRuntimeOperationsV4(ctx)
+	if err == nil || !strings.Contains(err.Error(), "conflicting durable identities") {
+		t.Fatalf("migration error = %v", err)
+	}
+	var rows, subjectColumns, migrationRows, renamedTables int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM workspace_agent_runtime_operations`).Scan(&rows); err != nil || rows != 2 {
+		t.Fatalf("operation rows=%d err=%v", rows, err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('workspace_agent_runtime_operations') WHERE name = 'subject_id'`).Scan(&subjectColumns); err != nil || subjectColumns != 1 {
+		t.Fatalf("subject columns=%d err=%v", subjectColumns, err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM agent_store_schema_migrations WHERE id = ?`, schemaMigrationWorkspaceAgentRuntimeOperationsV4).Scan(&migrationRows); err != nil || migrationRows != 0 {
+		t.Fatalf("migration rows=%d err=%v", migrationRows, err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name LIKE 'workspace_agent_runtime_operation%_v3'`).Scan(&renamedTables); err != nil || renamedTables != 0 {
+		t.Fatalf("renamed tables=%d err=%v", renamedTables, err)
+	}
+}

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -439,6 +439,9 @@ const (
 type ListSessionInteractionsInput struct {
 	WorkspaceID    string
 	AgentSessionID string
+	// TurnID and RequestID select one exact canonical Interaction when both are set.
+	TurnID    string
+	RequestID string
 	// Status filters by interaction status when non-empty.
 	Status string
 }

--- a/packages/agent/store-sqlite/runtime_operation_plan_decision_test.go
+++ b/packages/agent/store-sqlite/runtime_operation_plan_decision_test.go
@@ -39,8 +39,13 @@ func TestPlanDecisionIdentityRejectsCrossScopeAndPayloadMismatch(t *testing.T) {
 	input.OperationID = "operation-retry"
 	input.Payload["clientSubmitId"] = "plan-decision:operation-retry"
 	input.Payload["idempotencyKey"] = "decision-other"
-	if _, _, err := store.PrepareRuntimeOperation(context.Background(), input); !errors.Is(err, ErrRuntimeOperationConflict) {
+	if _, _, err := store.PrepareRuntimeOperation(context.Background(), input); !errors.Is(err, ErrRuntimeOperationIdentityMismatch) {
 		t.Fatalf("same turn different key error = %v", err)
+	}
+	input.OperationID = "operation-1"
+	input.Payload["clientSubmitId"] = "plan-decision:operation-1"
+	if _, _, err := store.PrepareRuntimeOperation(context.Background(), input); !errors.Is(err, ErrRuntimeOperationConflict) {
+		t.Fatalf("same operation different payload error = %v", err)
 	}
 	input.RequestID = "request-other"
 	if _, _, err := store.PrepareRuntimeOperation(context.Background(), input); err == nil {

--- a/packages/agent/store-sqlite/runtime_operation_types.go
+++ b/packages/agent/store-sqlite/runtime_operation_types.go
@@ -26,10 +26,11 @@ const (
 )
 
 var (
-	ErrRuntimeOperationConflict     = errors.New("runtime operation identity conflicts with an existing operation")
-	ErrRuntimeOperationNotClaimable = errors.New("runtime operation is not claimable")
-	ErrRuntimeOperationLeaseLost    = errors.New("runtime operation lease is not owned by the caller")
-	ErrRuntimeOperationSubjectState = errors.New("runtime operation subject is not in the required state")
+	ErrRuntimeOperationConflict         = errors.New("runtime operation identity conflicts with an existing operation")
+	ErrRuntimeOperationIdentityMismatch = errors.New("runtime operation durable identity does not match its subject")
+	ErrRuntimeOperationNotClaimable     = errors.New("runtime operation is not claimable")
+	ErrRuntimeOperationLeaseLost        = errors.New("runtime operation lease is not owned by the caller")
+	ErrRuntimeOperationSubjectState     = errors.New("runtime operation subject is not in the required state")
 )
 
 type RuntimeOperation struct {

--- a/packages/agent/store-sqlite/runtime_operations.go
+++ b/packages/agent/store-sqlite/runtime_operations.go
@@ -37,14 +37,11 @@ func (s *Store) PrepareRuntimeOperation(ctx context.Context, input RuntimeOperat
 	if now <= 0 {
 		return RuntimeOperation{}, false, errors.New("runtime operation occurred time is required")
 	}
-	subjectID := input.TurnID
 	requestID := any(nil)
 	switch input.Kind {
 	case RuntimeOperationKindInteractiveResponse:
-		subjectID = input.RequestID
 		requestID = input.RequestID
 	case RuntimeOperationKindPlanDecision:
-		subjectID = input.TurnID
 		requestID = input.RequestID
 	}
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -57,12 +54,15 @@ func (s *Store) PrepareRuntimeOperation(ctx context.Context, input RuntimeOperat
 			_ = tx.Rollback()
 		}
 	}()
-	existing, found, err := getRuntimeOperationBySubjectTx(ctx, tx, input.WorkspaceID, input.AgentSessionID, input.Kind, subjectID)
+	existing, found, err := getRuntimeOperationByIdentityTx(ctx, tx, input)
 	if err != nil {
 		return RuntimeOperation{}, false, err
 	}
 	if found {
-		if existing.TurnID != input.TurnID || existing.RequestID != input.RequestID || !jsonMapsEqual(existing.Payload, input.Payload) {
+		if existing.OperationID != input.OperationID {
+			return RuntimeOperation{}, false, ErrRuntimeOperationIdentityMismatch
+		}
+		if !jsonMapsEqual(existing.Payload, input.Payload) {
 			return RuntimeOperation{}, false, ErrRuntimeOperationConflict
 		}
 		if _, err := s.commitTransaction(ctx, tx, input.WorkspaceID, nil); err != nil {
@@ -74,7 +74,9 @@ func (s *Store) PrepareRuntimeOperation(ctx context.Context, input RuntimeOperat
 	if byID, idFound, err := getRuntimeOperationTx(ctx, tx, input.WorkspaceID, input.OperationID); err != nil {
 		return RuntimeOperation{}, false, err
 	} else if idFound {
-		_ = byID
+		if !runtimeOperationIdentityMatches(byID, input) {
+			return RuntimeOperation{}, false, ErrRuntimeOperationIdentityMismatch
+		}
 		return RuntimeOperation{}, false, ErrRuntimeOperationConflict
 	}
 	if err := validateRuntimeOperationSubjectTx(ctx, tx, input); err != nil {
@@ -82,11 +84,11 @@ func (s *Store) PrepareRuntimeOperation(ctx context.Context, input RuntimeOperat
 	}
 	_, err = tx.ExecContext(ctx, `
 INSERT INTO workspace_agent_runtime_operations (
-  operation_id, workspace_id, agent_session_id, kind, status, subject_id, turn_id,
-  request_id, payload_json, next_attempt_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	operation_id, workspace_id, agent_session_id, kind, status, turn_id,
+	request_id, payload_json, next_attempt_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `, input.OperationID, input.WorkspaceID, input.AgentSessionID, input.Kind,
-		RuntimeOperationStatusPrepared, subjectID, input.TurnID, requestID, payloadJSON, now, now, now)
+		RuntimeOperationStatusPrepared, input.TurnID, requestID, payloadJSON, now, now, now)
 	if err != nil {
 		return RuntimeOperation{}, false, fmt.Errorf("insert runtime operation: %w", err)
 	}
@@ -151,11 +153,12 @@ func (s *Store) PrepareInteractiveRuntimeOperation(
 	if !found {
 		return RuntimeOperation{}, Interaction{}, InteractionTransitionConflict, ErrRuntimeOperationSubjectState
 	}
-	existingOperation, operationFound, err := getRuntimeOperationBySubjectTx(
-		ctx, tx, input.WorkspaceID, input.AgentSessionID, input.Kind, input.RequestID,
-	)
+	existingOperation, operationFound, err := getRuntimeOperationByIdentityTx(ctx, tx, input)
 	if err != nil {
 		return RuntimeOperation{}, Interaction{}, InteractionTransitionConflict, err
+	}
+	if operationFound && existingOperation.OperationID != input.OperationID {
+		return RuntimeOperation{}, Interaction{}, InteractionTransitionConflict, ErrRuntimeOperationIdentityMismatch
 	}
 	claimPayload := input.Payload
 	if operationFound {
@@ -207,16 +210,18 @@ func (s *Store) PrepareInteractiveRuntimeOperation(
 	if byID, idFound, err := getRuntimeOperationTx(ctx, tx, input.WorkspaceID, input.OperationID); err != nil {
 		return RuntimeOperation{}, Interaction{}, InteractionTransitionConflict, err
 	} else if idFound {
-		_ = byID
+		if !runtimeOperationIdentityMatches(byID, input) {
+			return RuntimeOperation{}, Interaction{}, InteractionTransitionConflict, ErrRuntimeOperationIdentityMismatch
+		}
 		return RuntimeOperation{}, Interaction{}, InteractionTransitionConflict, ErrRuntimeOperationConflict
 	}
 	if _, err := tx.ExecContext(ctx, `
 INSERT INTO workspace_agent_runtime_operations (
-  operation_id, workspace_id, agent_session_id, kind, status, subject_id, turn_id,
-  request_id, payload_json, next_attempt_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	operation_id, workspace_id, agent_session_id, kind, status, turn_id,
+	request_id, payload_json, next_attempt_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `, input.OperationID, input.WorkspaceID, input.AgentSessionID, input.Kind,
-		RuntimeOperationStatusPrepared, input.RequestID, input.TurnID, input.RequestID,
+		RuntimeOperationStatusPrepared, input.TurnID, input.RequestID,
 		payloadJSON, now, now, now); err != nil {
 		return RuntimeOperation{}, Interaction{}, InteractionTransitionConflict, fmt.Errorf("insert interactive runtime operation: %w", err)
 	}
@@ -777,8 +782,22 @@ func getRuntimeOperationTx(ctx context.Context, tx *sql.Tx, workspaceID string, 
 	return getRuntimeOperation(ctx, tx, workspaceID, operationID)
 }
 
-func getRuntimeOperationBySubjectTx(ctx context.Context, tx *sql.Tx, workspaceID string, sessionID string, kind string, subjectID string) (RuntimeOperation, bool, error) {
-	return scanRuntimeOperationRow(tx.QueryRowContext(ctx, runtimeOperationSelectSQL+` WHERE workspace_id = ? AND agent_session_id = ? AND kind = ? AND subject_id = ?`, workspaceID, sessionID, kind, subjectID))
+func getRuntimeOperationByIdentityTx(ctx context.Context, tx *sql.Tx, input RuntimeOperationPrepare) (RuntimeOperation, bool, error) {
+	query := runtimeOperationSelectSQL + ` WHERE workspace_id = ? AND agent_session_id = ? AND kind = ? AND turn_id = ? AND request_id = ?`
+	args := []any{input.WorkspaceID, input.AgentSessionID, input.Kind, input.TurnID, input.RequestID}
+	if input.Kind == RuntimeOperationKindCancelTurn {
+		query = runtimeOperationSelectSQL + ` WHERE workspace_id = ? AND agent_session_id = ? AND kind = ? AND turn_id = ? AND request_id IS NULL`
+		args = []any{input.WorkspaceID, input.AgentSessionID, input.Kind, input.TurnID}
+	}
+	return scanRuntimeOperationRow(tx.QueryRowContext(ctx, query, args...))
+}
+
+func runtimeOperationIdentityMatches(operation RuntimeOperation, input RuntimeOperationPrepare) bool {
+	return operation.WorkspaceID == input.WorkspaceID &&
+		operation.AgentSessionID == input.AgentSessionID &&
+		operation.Kind == input.Kind &&
+		operation.TurnID == input.TurnID &&
+		operation.RequestID == input.RequestID
 }
 
 func scanRuntimeOperationRow(row *sql.Row) (RuntimeOperation, bool, error) {

--- a/packages/agent/store-sqlite/runtime_operations_test.go
+++ b/packages/agent/store-sqlite/runtime_operations_test.go
@@ -19,7 +19,6 @@ func TestRuntimeOperationPrepareIsSubjectIdempotentAndCrashRecoverable(t *testin
 	if err != nil || !created || first.Status != RuntimeOperationStatusPrepared {
 		t.Fatalf("prepare = %#v created=%v err=%v", first, created, err)
 	}
-	input.OperationID = "operation-retry"
 	duplicate, created, err := store.PrepareRuntimeOperation(context.Background(), input)
 	if err != nil || created || duplicate.OperationID != "operation-1" {
 		t.Fatalf("duplicate = %#v created=%v err=%v", duplicate, created, err)
@@ -48,7 +47,7 @@ func TestPrepareInteractiveRuntimeOperationClaimsInteractionAtomically(t *testin
 			defer group.Done()
 			<-start
 			_, interaction, transition, err := store.PrepareInteractiveRuntimeOperation(context.Background(), RuntimeOperationPrepare{
-				OperationID: fmt.Sprintf("operation-%d", index), WorkspaceID: "ws-1", AgentSessionID: "session-claim",
+				OperationID: "operation-claim", WorkspaceID: "ws-1", AgentSessionID: "session-claim",
 				Kind: RuntimeOperationKindInteractiveResponse, TurnID: "turn-claim", RequestID: "request-claim",
 				Payload: map[string]any{"action": "", "optionId": option, "payload": (map[string]any)(nil)}, OccurredAtMS: int64(10 + index),
 			})

--- a/packages/agent/store-sqlite/store_test.go
+++ b/packages/agent/store-sqlite/store_test.go
@@ -701,11 +701,11 @@ func seedRuntimeDeletionSaga(t *testing.T, store *Store, workspaceID string, ses
 		{operationID: "old-runtime-completed", status: RuntimeOperationStatusCompleted, turnID: "turn-completed", result: RuntimeOperationResultCanceled, completedAt: int64(30)},
 	} {
 		query := `INSERT INTO workspace_agent_runtime_operations (
-operation_id, workspace_id, agent_session_id, kind, status, result, subject_id, turn_id,
+operation_id, workspace_id, agent_session_id, kind, status, result, turn_id,
 payload_json, lease_owner, lease_expires_at_unix_ms, next_attempt_at_unix_ms,
 created_at_unix_ms, updated_at_unix_ms, completed_at_unix_ms
-) VALUES (?, ?, ?, 'cancel_turn', ?, ?, ?, ?, '{}', ?, ?, ?, 20, 20, ?)`
-		if _, err := store.db.Exec(query, row.operationID, workspaceID, sessionID, row.status, row.result, row.turnID, row.turnID,
+) VALUES (?, ?, ?, 'cancel_turn', ?, ?, ?, '{}', ?, ?, ?, 20, 20, ?)`
+		if _, err := store.db.Exec(query, row.operationID, workspaceID, sessionID, row.status, row.result, row.turnID,
 			row.leaseOwner, row.leaseExpiry, row.nextAttempt, row.completedAt); err != nil {
 			t.Fatalf("seed runtime operation %s: %v", row.status, err)
 		}
@@ -716,10 +716,10 @@ operation_id, workspace_id, agent_session_id, kind, payload_json, created_at_uni
 		t.Fatalf("seed runtime operation event: %v", err)
 	}
 	if _, err := store.db.Exec(`INSERT INTO workspace_agent_runtime_operations (
-operation_id, workspace_id, agent_session_id, kind, status, result, subject_id, turn_id,
+operation_id, workspace_id, agent_session_id, kind, status, result, turn_id,
 request_id, payload_json, created_at_unix_ms, updated_at_unix_ms, completed_at_unix_ms
 ) VALUES ('old-runtime-interactive', ?, ?, 'interactive_response', 'completed', 'answered',
-  'request-reused', 'turn-prepared', 'request-reused', '{}', 31, 31, 31)`, workspaceID, sessionID); err != nil {
+  'turn-prepared', 'request-reused', '{}', 31, 31, 31)`, workspaceID, sessionID); err != nil {
 		t.Fatalf("seed reused interactive runtime operation: %v", err)
 	}
 	if _, err := store.db.Exec(`INSERT INTO workspace_agent_runtime_operation_events (

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
 	"github.com/tutti-os/tutti/services/tuttid/apierrors"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
@@ -48,7 +49,7 @@ type AgentSessionService interface {
 	UpdateTitle(context.Context, string, string, string) (agentservice.Session, error)
 	UpdateVisible(context.Context, string, string, bool) (agentservice.Session, error)
 	UpdateSettings(context.Context, string, string, agentservice.ComposerSettingsPatch) (agentservice.Session, error)
-	SubmitInteractive(context.Context, string, string, string, agentservice.SubmitInteractiveInput) (agentservice.Session, error)
+	SubmitInteractive(context.Context, agenthost.InteractionRef, agenthost.SubmitInteractiveInput) (agentservice.Session, error)
 }
 
 func (api DaemonAPI) ClearWorkspaceAgentSessions(ctx context.Context, request tuttigenerated.ClearWorkspaceAgentSessionsRequestObject) (tuttigenerated.ClearWorkspaceAgentSessionsResponseObject, error) {
@@ -370,8 +371,10 @@ func (api DaemonAPI) SubmitWorkspaceAgentInteractive(ctx context.Context, reques
 			InvalidRequestErrorJSONResponse: invalidRequestError(apierrors.EmptyBody(apierrors.WithDeveloperMessage("empty body"))),
 		}, nil
 	}
-	session, err := api.AgentSessionService.SubmitInteractive(ctx, string(request.WorkspaceID), string(request.AgentSessionID), string(request.RequestID), agentservice.SubmitInteractiveInput{
-		TurnID:   request.Body.TurnId,
+	session, err := api.AgentSessionService.SubmitInteractive(ctx, agenthost.InteractionRef{
+		WorkspaceID: string(request.WorkspaceID), AgentSessionID: string(request.AgentSessionID),
+		TurnID: request.Body.TurnId, RequestID: string(request.RequestID),
+	}, agenthost.SubmitInteractiveInput{
 		Action:   request.Body.Action,
 		OptionID: request.Body.OptionId,
 		Payload:  optionalPayloadMap(request.Body.Payload),

--- a/services/tuttid/api/daemon_agent_sessions_interactive_test.go
+++ b/services/tuttid/api/daemon_agent_sessions_interactive_test.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
+	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
+)
+
+func TestSubmitWorkspaceAgentInteractiveBuildsTypedHostCommand(t *testing.T) {
+	var gotRef agenthost.InteractionRef
+	var gotInput agenthost.SubmitInteractiveInput
+	action, option := "approve", "allow-once"
+	payload := map[string]any{"answer": "yes"}
+	api := DaemonAPI{AgentSessionService: stubAgentSessionService{
+		submitInteractiveFn: func(_ context.Context, ref agenthost.InteractionRef, input agenthost.SubmitInteractiveInput) (agentservice.Session, error) {
+			gotRef, gotInput = ref, input
+			return agentservice.Session{ID: ref.AgentSessionID}, nil
+		},
+	}}
+
+	response, err := api.SubmitWorkspaceAgentInteractive(context.Background(), tuttigenerated.SubmitWorkspaceAgentInteractiveRequestObject{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", RequestID: "request-1",
+		Body: &tuttigenerated.SubmitWorkspaceAgentInteractiveJSONRequestBody{
+			TurnId: "turn-1", Action: &action, OptionId: &option, Payload: &payload,
+		},
+	})
+	if err != nil {
+		t.Fatalf("SubmitWorkspaceAgentInteractive() error = %v", err)
+	}
+	if _, ok := response.(tuttigenerated.SubmitWorkspaceAgentInteractive200JSONResponse); !ok {
+		t.Fatalf("response = %T, want 200", response)
+	}
+	if gotRef != (agenthost.InteractionRef{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", TurnID: "turn-1", RequestID: "request-1",
+	}) {
+		t.Fatalf("interaction ref = %#v", gotRef)
+	}
+	if gotInput.Action == nil || *gotInput.Action != action || gotInput.OptionID == nil || *gotInput.OptionID != option || gotInput.Payload["answer"] != "yes" {
+		t.Fatalf("interactive input = %#v", gotInput)
+	}
+}

--- a/services/tuttid/api/daemon_test.go
+++ b/services/tuttid/api/daemon_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	workspacefiles "github.com/tutti-os/tutti/packages/workspace/files"
 	workspaceissues "github.com/tutti-os/tutti/packages/workspace/issues"
 	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
@@ -115,6 +116,7 @@ type stubAgentSessionService struct {
 	updateTitleFn                   func(context.Context, string, string, string) (agentservice.Session, error)
 	updateVisibleFn                 func(context.Context, string, string, bool) (agentservice.Session, error)
 	updateSettingsFn                func(context.Context, string, string, agentservice.ComposerSettingsPatch) (agentservice.Session, error)
+	submitInteractiveFn             func(context.Context, agenthost.InteractionRef, agenthost.SubmitInteractiveInput) (agentservice.Session, error)
 	planDecisionFn                  func(context.Context, string, string, string, string, agentservice.SubmitPlanDecisionInput) (agentactivitybiz.RuntimeOperation, error)
 }
 
@@ -447,8 +449,11 @@ func (s stubAgentSessionService) UpdateSettings(ctx context.Context, workspaceID
 	return s.updateSettingsFn(ctx, workspaceID, agentSessionID, settings)
 }
 
-func (stubAgentSessionService) SubmitInteractive(context.Context, string, string, string, agentservice.SubmitInteractiveInput) (agentservice.Session, error) {
-	return agentservice.Session{}, nil
+func (s stubAgentSessionService) SubmitInteractive(ctx context.Context, ref agenthost.InteractionRef, input agenthost.SubmitInteractiveInput) (agentservice.Session, error) {
+	if s.submitInteractiveFn == nil {
+		return agentservice.Session{}, nil
+	}
+	return s.submitInteractiveFn(ctx, ref, input)
 }
 
 func (s rejectingWorkbenchStore) GetWorkbenchSnapshot(context.Context, string) (workspacebiz.WorkbenchSnapshot, error) {

--- a/services/tuttid/biz/agentactivity/activity.go
+++ b/services/tuttid/biz/agentactivity/activity.go
@@ -130,13 +130,14 @@ type SubmitClaim = agentstore.SubmitClaim
 type SubmitClaimPrepare = agentstore.SubmitClaimPrepare
 
 var (
-	ErrRuntimeOperationConflict     = agentstore.ErrRuntimeOperationConflict
-	ErrRuntimeOperationNotClaimable = agentstore.ErrRuntimeOperationNotClaimable
-	ErrRuntimeOperationLeaseLost    = agentstore.ErrRuntimeOperationLeaseLost
-	ErrRuntimeOperationSubjectState = agentstore.ErrRuntimeOperationSubjectState
-	ErrGoalOperationConflict        = agentstore.ErrGoalOperationConflict
-	ErrGoalStateAbsent              = agentstore.ErrGoalStateAbsent
-	ErrGoalReconcileConflict        = agentstore.ErrGoalReconcileConflict
+	ErrRuntimeOperationConflict         = agentstore.ErrRuntimeOperationConflict
+	ErrRuntimeOperationIdentityMismatch = agentstore.ErrRuntimeOperationIdentityMismatch
+	ErrRuntimeOperationNotClaimable     = agentstore.ErrRuntimeOperationNotClaimable
+	ErrRuntimeOperationLeaseLost        = agentstore.ErrRuntimeOperationLeaseLost
+	ErrRuntimeOperationSubjectState     = agentstore.ErrRuntimeOperationSubjectState
+	ErrGoalOperationConflict            = agentstore.ErrGoalOperationConflict
+	ErrGoalStateAbsent                  = agentstore.ErrGoalStateAbsent
+	ErrGoalReconcileConflict            = agentstore.ErrGoalReconcileConflict
 )
 
 const (

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -217,7 +217,7 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 		turns:        map[string]agentactivitybiz.Turn{},
 		interactions: map[string][]agentactivitybiz.Interaction{},
 	}
-	d.operations = &runtimeOperationMemoryStore{}
+	d.operations = &runtimeOperationMemoryStore{interactionStore: d.turns}
 	d.createdTurns = make(map[string]string)
 	steps := make([]string, 0)
 	d.recoverySteps = &steps
@@ -382,6 +382,13 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 		}
 		d.service.TurnStore = d.turns
 	}
+	for _, turn := range fixture.AdditionalTurns {
+		d.turns.turns[seed.AgentSessionID+":"+turn.TurnID] = agentactivitybiz.Turn{
+			WorkspaceID: seed.WorkspaceID, AgentSessionID: seed.AgentSessionID,
+			TurnID: turn.TurnID, Phase: turn.Phase, Outcome: turn.Outcome,
+		}
+		d.service.TurnStore = d.turns
+	}
 	if fixture.Interaction != nil {
 		interaction := *fixture.Interaction
 		d.turns.interactions[seed.AgentSessionID] = []agentactivitybiz.Interaction{{
@@ -389,6 +396,14 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 			TurnID: interaction.TurnID, RequestID: interaction.RequestID,
 			Kind: interaction.Kind, Status: interaction.Status,
 		}}
+		d.service.TurnStore = d.turns
+	}
+	for _, interaction := range fixture.AdditionalInteractions {
+		d.turns.interactions[seed.AgentSessionID] = append(d.turns.interactions[seed.AgentSessionID], agentactivitybiz.Interaction{
+			WorkspaceID: seed.WorkspaceID, AgentSessionID: seed.AgentSessionID,
+			TurnID: interaction.TurnID, RequestID: interaction.RequestID,
+			Kind: interaction.Kind, Status: interaction.Status,
+		})
 		d.service.TurnStore = d.turns
 	}
 	if fixture.RecoverInteractive {
@@ -548,17 +563,28 @@ func (d *legacyHostConformanceDriver) CancelTurn(ctx context.Context, input agen
 
 func (d *legacyHostConformanceDriver) SubmitInteractive(
 	ctx context.Context,
-	ref agenthost.SessionRef,
-	requestID string,
+	ref agenthost.InteractionRef,
 	input agenthost.SubmitInteractiveInput,
 ) (hostconformance.InteractiveObservation, error) {
-	result, err := d.service.ApplicationHost().SubmitInteractive(ctx, ref, requestID, input)
+	result, err := d.service.ApplicationHost().SubmitInteractive(ctx, ref, input)
 	if err != nil {
-		return hostconformance.InteractiveObservation{Disposition: result.Disposition}, err
+		return hostconformance.InteractiveObservation{
+			OperationID: result.Operation.OperationID, TurnID: result.Operation.TurnID,
+			RequestID: result.Operation.RequestID, Disposition: result.Disposition,
+		}, err
 	}
 	return hostconformance.InteractiveObservation{
-		Disposition: result.Disposition,
+		OperationID: result.Operation.OperationID, TurnID: result.Operation.TurnID,
+		RequestID: result.Operation.RequestID, Disposition: result.Disposition,
 	}, nil
+}
+
+func (d *legacyHostConformanceDriver) GetInteractionStatus(
+	_ context.Context,
+	ref agenthost.InteractionRef,
+) (string, bool, error) {
+	interaction, found := d.turns.interaction(ref.AgentSessionID, ref.TurnID, ref.RequestID)
+	return interaction.Status, found && interaction.WorkspaceID == ref.WorkspaceID, nil
 }
 
 func (d *legacyHostConformanceDriver) SubmitPlanDecision(
@@ -894,7 +920,38 @@ func (s *legacyHostConformanceTurnStore) ListSessionTurns(_ context.Context, _ s
 }
 
 func (s *legacyHostConformanceTurnStore) ListSessionInteractions(_ context.Context, input agentactivitybiz.ListSessionInteractionsInput) ([]agentactivitybiz.Interaction, error) {
-	return append([]agentactivitybiz.Interaction(nil), s.interactions[input.AgentSessionID]...), nil
+	result := make([]agentactivitybiz.Interaction, 0, len(s.interactions[input.AgentSessionID]))
+	for _, interaction := range s.interactions[input.AgentSessionID] {
+		if input.TurnID != "" && interaction.TurnID != input.TurnID {
+			continue
+		}
+		if input.RequestID != "" && interaction.RequestID != input.RequestID {
+			continue
+		}
+		result = append(result, interaction)
+	}
+	return result, nil
+}
+
+func (s *legacyHostConformanceTurnStore) interaction(sessionID, turnID, requestID string) (agentactivitybiz.Interaction, bool) {
+	for _, interaction := range s.interactions[sessionID] {
+		if interaction.TurnID == turnID && interaction.RequestID == requestID {
+			return interaction, true
+		}
+	}
+	return agentactivitybiz.Interaction{}, false
+}
+
+func (s *legacyHostConformanceTurnStore) storeInteraction(updated agentactivitybiz.Interaction) {
+	interactions := s.interactions[updated.AgentSessionID]
+	for index, interaction := range interactions {
+		if interaction.TurnID == updated.TurnID && interaction.RequestID == updated.RequestID {
+			interactions[index] = updated
+			s.interactions[updated.AgentSessionID] = interactions
+			return
+		}
+	}
+	s.interactions[updated.AgentSessionID] = append(interactions, updated)
 }
 
 func (s *legacyHostConformanceTurnStore) ListLatestTurns(_ context.Context, _ string, sessionIDs []string) (map[string]agentactivitybiz.Turn, error) {

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -26,9 +26,7 @@ var (
 	ErrRuntimeSessionDisconnected       = agenthost.ErrRuntimeSessionDisconnected
 	ErrInteractiveRequestNotLive        = errors.New("interactive request is no longer live")
 	ErrInteractiveAlreadyAnswered       = errors.New("interactive request has already been answered")
-	ErrInteractionRequestNotFound       = errors.New("agent interaction request was not found")
-	ErrInteractionRequestNotPending     = errors.New("agent interaction request is not pending")
-	ErrInteractionRequestAmbiguous      = errors.New("agent interaction request is ambiguous")
+	ErrInteractionRequestNotFound       = agenthost.ErrInteractionNotFound
 	ErrInteractionSemanticNotFound      = errors.New("agent interaction semantic was not found")
 	ErrInteractionSemanticAmbiguous     = errors.New("agent interaction semantic is ambiguous")
 	ErrSkillBundleUnavailable           = errors.New("agent skill bundle renderer is unavailable")
@@ -586,17 +584,13 @@ func (s *Service) cleanupRuntime(ctx context.Context, workspaceID string, agentS
 	})
 }
 
-func (s *Service) SubmitInteractive(ctx context.Context, workspaceID string, agentSessionID string, requestID string, input SubmitInteractiveInput) (Session, error) {
-	_, err := s.ApplicationHost().SubmitInteractive(
-		ctx,
-		agenthost.SessionRef{WorkspaceID: workspaceID, AgentSessionID: agentSessionID},
-		requestID,
-		input,
-	)
+func (s *Service) SubmitInteractive(ctx context.Context, ref agenthost.InteractionRef, input agenthost.SubmitInteractiveInput) (Session, error) {
+	input.Payload = clonePayload(input.Payload)
+	_, err := s.ApplicationHost().SubmitInteractive(ctx, ref, input)
 	if err != nil {
 		return Session{}, normalizeRuntimeError(err)
 	}
-	return s.Get(ctx, workspaceID, agentSessionID)
+	return s.Get(ctx, ref.WorkspaceID, ref.AgentSessionID)
 }
 
 func (s *Service) Subscribe(ctx context.Context, input StreamInput) (EventStream, error) {

--- a/services/tuttid/service/agent/service_post_runtime_persistence_failure_test.go
+++ b/services/tuttid/service/agent/service_post_runtime_persistence_failure_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -28,7 +29,9 @@ func TestSubmitInteractiveCompletionFailureIsRecoveredFromLeasedOperation(t *tes
 	service.RuntimeOperationClock = func() time.Time { return now }
 	service.TurnStore = runtimeOperationTurnStore("turn-1", "request-1")
 
-	_, err := service.SubmitInteractive(context.Background(), "ws-1", "session-1", "request-1", SubmitInteractiveInput{OptionID: stringRef("approve")})
+	_, err := service.SubmitInteractive(context.Background(),
+		agenthost.InteractionRef{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1", RequestID: "request-1"},
+		agenthost.SubmitInteractiveInput{OptionID: stringRef("approve")})
 	if !errors.Is(err, want) {
 		t.Fatalf("SubmitInteractive() error = %v, want %v", err, want)
 	}
@@ -184,9 +187,9 @@ func TestChildInteractionRoutesThroughRootRuntimeWithCanonicalChildTuple(t *test
 		"ws-1:child": {WorkspaceID: "ws-1", ID: "child", Kind: agentactivitybiz.SessionKindChild, Provider: "claude-code", RootAgentSessionID: "root", RootTurnID: "root-turn", ActiveTurnID: "child-turn"},
 	}}
 
-	if _, err := service.SubmitInteractive(context.Background(), "ws-1", "child", "child-request", SubmitInteractiveInput{
-		TurnID: "child-turn", OptionID: stringRef("allow"),
-	}); err != nil {
+	if _, err := service.SubmitInteractive(context.Background(),
+		agenthost.InteractionRef{WorkspaceID: "ws-1", AgentSessionID: "child", TurnID: "child-turn", RequestID: "child-request"},
+		agenthost.SubmitInteractiveInput{OptionID: stringRef("allow")}); err != nil {
 		t.Fatalf("SubmitInteractive() error = %v", err)
 	}
 	if len(runtime.submitInteractiveCalls) != 1 {
@@ -225,13 +228,14 @@ func TestCompletedInteractiveRetryUsesDeterministicOperationWithoutPendingIntera
 	service.RuntimeOperationOwner = "worker-a"
 	service.RuntimeOperationClock = func() time.Time { return now }
 	service.TurnStore = runtimeOperationTurnStore("turn-1", "request-1")
-	input := SubmitInteractiveInput{OptionID: stringRef("approve")}
+	ref := agenthost.InteractionRef{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1", RequestID: "request-1"}
+	input := agenthost.SubmitInteractiveInput{OptionID: stringRef("approve")}
 
-	if _, err := service.SubmitInteractive(context.Background(), "ws-1", "session-1", "request-1", input); err != nil {
+	if _, err := service.SubmitInteractive(context.Background(), ref, input); err != nil {
 		t.Fatalf("first SubmitInteractive() error = %v", err)
 	}
 	service.TurnStore = runtimeOperationTurnStore("turn-1", "")
-	if _, err := service.SubmitInteractive(context.Background(), "ws-1", "session-1", "request-1", input); err != nil {
+	if _, err := service.SubmitInteractive(context.Background(), ref, input); err != nil {
 		t.Fatalf("duplicate SubmitInteractive() error = %v operation=%#v", err, store.operation)
 	}
 	if len(runtime.submitInteractiveCalls) != 1 {
@@ -252,7 +256,9 @@ func TestInlineOutboxPublishFailureDoesNotTurnCompletedAPIIntoFailure(t *testing
 	service.RuntimeOperationClock = func() time.Time { return now }
 	service.TurnStore = runtimeOperationTurnStore("turn-1", "request-1")
 
-	if _, err := service.SubmitInteractive(context.Background(), "ws-1", "session-1", "request-1", SubmitInteractiveInput{OptionID: stringRef("approve")}); err != nil {
+	if _, err := service.SubmitInteractive(context.Background(),
+		agenthost.InteractionRef{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1", RequestID: "request-1"},
+		agenthost.SubmitInteractiveInput{OptionID: stringRef("approve")}); err != nil {
 		t.Fatalf("SubmitInteractive() error = %v, want completed API success", err)
 	}
 	if len(store.events) != 1 || store.events[0].PublishedAtUnixMS != 0 {
@@ -276,7 +282,9 @@ func TestRetryableRuntimeFailureReturnsReconciliationState(t *testing.T) {
 	service.RuntimeOperationClock = func() time.Time { return now }
 	service.TurnStore = runtimeOperationTurnStore("turn-1", "request-1")
 
-	_, err := service.SubmitInteractive(context.Background(), "ws-1", "session-1", "request-1", SubmitInteractiveInput{OptionID: stringRef("approve")})
+	_, err := service.SubmitInteractive(context.Background(),
+		agenthost.InteractionRef{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1", RequestID: "request-1"},
+		agenthost.SubmitInteractiveInput{OptionID: stringRef("approve")})
 	if !errors.Is(err, ErrRuntimeOperationInProgress) {
 		t.Fatalf("SubmitInteractive() error = %v, want ErrRuntimeOperationInProgress", err)
 	}
@@ -331,8 +339,8 @@ func TestTerminalRuntimeDispositionCompletesInteractiveOperationAsSuperseded(t *
 			service.RuntimeOperationClock = func() time.Time { return time.UnixMilli(1000) }
 
 			result, err := service.ApplicationHost().SubmitInteractive(ctx,
-				agenthost.SessionRef{WorkspaceID: "ws-1", AgentSessionID: "session-1"},
-				"request-1", agenthost.SubmitInteractiveInput{TurnID: "turn-1", OptionID: stringRef("approve")},
+				agenthost.InteractionRef{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1", RequestID: "request-1"},
+				agenthost.SubmitInteractiveInput{OptionID: stringRef("approve")},
 			)
 			if err != nil {
 				t.Fatalf("Host.SubmitInteractive() error = %v", err)
@@ -362,7 +370,9 @@ func TestUnknownRuntimeDispositionFailsInteractiveOperation(t *testing.T) {
 	service.RuntimeOperationClock = func() time.Time { return time.UnixMilli(1000) }
 	service.TurnStore = runtimeOperationTurnStore("turn-1", "request-1")
 
-	if _, err := service.SubmitInteractive(context.Background(), "ws-1", "session-1", "request-1", SubmitInteractiveInput{OptionID: stringRef("approve")}); err == nil {
+	if _, err := service.SubmitInteractive(context.Background(),
+		agenthost.InteractionRef{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1", RequestID: "request-1"},
+		agenthost.SubmitInteractiveInput{OptionID: stringRef("approve")}); err == nil {
 		t.Fatal("SubmitInteractive() error = nil, want unknown disposition error")
 	}
 	if store.operation.Status != agentactivitybiz.RuntimeOperationStatusFailed {
@@ -372,13 +382,13 @@ func TestUnknownRuntimeDispositionFailsInteractiveOperation(t *testing.T) {
 
 func TestDuplicateTerminalFailedOperationReturnsTerminalFailure(t *testing.T) {
 	store := &runtimeOperationMemoryStore{operation: agentactivitybiz.RuntimeOperation{
-		OperationID: runtimeOperationID("ws-1", "session-1", agentactivitybiz.RuntimeOperationKindInteractiveResponse, "request-1"),
+		OperationID: runtimeOperationID("ws-1", "session-1", agentactivitybiz.RuntimeOperationKindInteractiveResponse, "turn-1\x00request-1"),
 		WorkspaceID: "ws-1", AgentSessionID: "session-1", Kind: agentactivitybiz.RuntimeOperationKindInteractiveResponse,
 		Status: agentactivitybiz.RuntimeOperationStatusFailed, Result: agentactivitybiz.RuntimeOperationResultFailed,
 		TurnID: "turn-1", RequestID: "request-1", LastError: "invalid provider option",
 		Payload: map[string]any{
 			"rootAgentSessionId": "session-1", "action": "", "optionId": "approve",
-			"payload": (map[string]any)(nil), "turnId": "",
+			"payload": (map[string]any)(nil), "turnId": "turn-1",
 		},
 	}}
 	runtime := newFakeRuntime()
@@ -387,7 +397,9 @@ func TestDuplicateTerminalFailedOperationReturnsTerminalFailure(t *testing.T) {
 	service.RuntimeOperationStore = store
 	service.TurnStore = runtimeOperationTurnStore("turn-1", "")
 
-	_, err := service.SubmitInteractive(context.Background(), "ws-1", "session-1", "request-1", SubmitInteractiveInput{OptionID: stringRef("approve")})
+	_, err := service.SubmitInteractive(context.Background(),
+		agenthost.InteractionRef{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1", RequestID: "request-1"},
+		agenthost.SubmitInteractiveInput{OptionID: stringRef("approve")})
 	if !errors.Is(err, ErrRuntimeOperationFailed) || errors.Is(err, ErrRuntimeOperationInProgress) {
 		t.Fatalf("SubmitInteractive() error = %v, want terminal ErrRuntimeOperationFailed", err)
 	}
@@ -440,6 +452,8 @@ func runtimeOperationTurnStore(turnID string, requestID string) failingTurnStore
 type runtimeOperationMemoryStore struct {
 	mu                sync.Mutex
 	operation         agentactivitybiz.RuntimeOperation
+	operations        map[string]agentactivitybiz.RuntimeOperation
+	interactionStore  runtimeOperationInteractionStore
 	completeErr       error
 	events            []agentactivitybiz.RuntimeOperationEvent
 	confirmedTurnID   string
@@ -448,31 +462,68 @@ type runtimeOperationMemoryStore struct {
 	cancelCompletions []agentactivitybiz.CompleteCancelRuntimeOperationInput
 }
 
+type runtimeOperationInteractionStore interface {
+	interaction(sessionID, turnID, requestID string) (agentactivitybiz.Interaction, bool)
+	storeInteraction(agentactivitybiz.Interaction)
+}
+
+func (s *runtimeOperationMemoryStore) operationsLocked() map[string]agentactivitybiz.RuntimeOperation {
+	if s.operations == nil {
+		s.operations = make(map[string]agentactivitybiz.RuntimeOperation)
+		if s.operation.OperationID != "" {
+			s.operations[s.operation.OperationID] = s.operation
+		}
+	}
+	return s.operations
+}
+
+func (s *runtimeOperationMemoryStore) operationLocked(operationID string) (agentactivitybiz.RuntimeOperation, bool) {
+	operation, found := s.operationsLocked()[operationID]
+	return operation, found
+}
+
+func (s *runtimeOperationMemoryStore) storeOperationLocked(operation agentactivitybiz.RuntimeOperation) {
+	s.operationsLocked()[operation.OperationID] = operation
+	s.operation = operation
+}
+
+func runtimeOperationPrepareIdentityMatches(operation agentactivitybiz.RuntimeOperation, input agentactivitybiz.RuntimeOperationPrepare) bool {
+	return operation.WorkspaceID == input.WorkspaceID && operation.AgentSessionID == input.AgentSessionID &&
+		operation.Kind == input.Kind && operation.TurnID == input.TurnID && operation.RequestID == input.RequestID
+}
+
 func (s *runtimeOperationMemoryStore) CheckpointRuntimeOperation(_ context.Context, input agentactivitybiz.CheckpointRuntimeOperationInput) (agentactivitybiz.RuntimeOperation, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	operation, found := s.operationLocked(input.OperationID)
+	if !found {
+		return agentactivitybiz.RuntimeOperation{}, false, agentactivitybiz.ErrRuntimeOperationLeaseLost
+	}
 	if s.checkpointErr != nil {
 		err := s.checkpointErr
 		s.checkpointErr = nil
-		return s.operation, false, err
+		return operation, false, err
 	}
-	if s.operation.Status != agentactivitybiz.RuntimeOperationStatusLeased || s.operation.LeaseOwner != input.LeaseOwner {
-		return s.operation, false, agentactivitybiz.ErrRuntimeOperationLeaseLost
+	if operation.Status != agentactivitybiz.RuntimeOperationStatusLeased || operation.LeaseOwner != input.LeaseOwner {
+		return operation, false, agentactivitybiz.ErrRuntimeOperationLeaseLost
 	}
-	s.operation.Payload = input.Payload
+	operation.Payload = input.Payload
+	s.storeOperationLocked(operation)
 	hasPendingEvent := false
 	for _, existing := range s.events {
 		hasPendingEvent = hasPendingEvent || existing.Kind == agentactivitybiz.RuntimeOperationEventPlanDecisionPending
 	}
 	if !hasPendingEvent && payloadText(input.Payload, "step") == "send_dispatched" {
 		event := agentactivitybiz.RuntimeOperationEvent{
-			ID: int64(len(s.events) + 1), OperationID: s.operation.OperationID,
-			WorkspaceID: s.operation.WorkspaceID, AgentSessionID: s.operation.AgentSessionID,
+			ID: int64(len(s.events) + 1), OperationID: operation.OperationID,
+			WorkspaceID: operation.WorkspaceID, AgentSessionID: operation.AgentSessionID,
 			Kind:    agentactivitybiz.RuntimeOperationEventPlanDecisionPending,
-			Payload: map[string]any{"noticeMessageId": "plan-decision:" + s.operation.OperationID + ":status"},
+			Payload: map[string]any{"noticeMessageId": "plan-decision:" + operation.OperationID + ":status"},
 		}
 		s.events = append(s.events, event)
 	}
 	s.checkpointSteps = append(s.checkpointSteps, payloadText(input.Payload, "step"))
-	return s.operation, true, nil
+	return operation, true, nil
 }
 
 func (s *runtimeOperationMemoryStore) FindTurnByClientSubmitID(_ context.Context, _, _, _ string) (string, bool, error) {
@@ -486,77 +537,137 @@ func (p runtimeOperationFailingPublisher) PublishRuntimeOperationEvent(context.C
 }
 
 func (s *runtimeOperationMemoryStore) PrepareRuntimeOperation(_ context.Context, input agentactivitybiz.RuntimeOperationPrepare) (agentactivitybiz.RuntimeOperation, bool, error) {
-	if s.operation.OperationID != "" {
-		return s.operation, false, nil
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, found := s.operationLocked(input.OperationID); found {
+		return existing, false, nil
 	}
-	s.operation = agentactivitybiz.RuntimeOperation{OperationID: input.OperationID, WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID, Kind: input.Kind, Status: agentactivitybiz.RuntimeOperationStatusPrepared, TurnID: input.TurnID, RequestID: input.RequestID, Payload: input.Payload, CreatedAtUnixMS: input.OccurredAtMS, UpdatedAtUnixMS: input.OccurredAtMS}
-	return s.operation, true, nil
+	for _, existing := range s.operationsLocked() {
+		if runtimeOperationPrepareIdentityMatches(existing, input) {
+			return agentactivitybiz.RuntimeOperation{}, false, agentactivitybiz.ErrRuntimeOperationIdentityMismatch
+		}
+	}
+	operation := agentactivitybiz.RuntimeOperation{OperationID: input.OperationID, WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID, Kind: input.Kind, Status: agentactivitybiz.RuntimeOperationStatusPrepared, TurnID: input.TurnID, RequestID: input.RequestID, Payload: input.Payload, CreatedAtUnixMS: input.OccurredAtMS, UpdatedAtUnixMS: input.OccurredAtMS}
+	s.storeOperationLocked(operation)
+	return operation, true, nil
 }
 
 func (s *runtimeOperationMemoryStore) PrepareInteractiveRuntimeOperation(_ context.Context, input agentactivitybiz.RuntimeOperationPrepare) (agentactivitybiz.RuntimeOperation, agentactivitybiz.Interaction, agentactivitybiz.InteractionTransitionResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	transition := agentactivitybiz.InteractionTransitionAlreadyApplied
-	if s.operation.OperationID == "" {
-		s.operation = agentactivitybiz.RuntimeOperation{OperationID: input.OperationID, WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID, Kind: input.Kind, Status: agentactivitybiz.RuntimeOperationStatusPrepared, TurnID: input.TurnID, RequestID: input.RequestID, Payload: input.Payload, CreatedAtUnixMS: input.OccurredAtMS, UpdatedAtUnixMS: input.OccurredAtMS}
-		transition = agentactivitybiz.InteractionTransitionApplied
+	existingOperation, operationFound := s.operationLocked(input.OperationID)
+	if !operationFound {
+		for _, existing := range s.operationsLocked() {
+			if runtimeOperationPrepareIdentityMatches(existing, input) {
+				return agentactivitybiz.RuntimeOperation{}, agentactivitybiz.Interaction{}, agentactivitybiz.InteractionTransitionConflict, agentactivitybiz.ErrRuntimeOperationIdentityMismatch
+			}
+		}
 	}
 	interaction := agentactivitybiz.Interaction{
 		WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID,
-		TurnID: input.TurnID, RequestID: input.RequestID,
-		Status: agentactivitybiz.InteractionStatusAnswered,
-		Output: map[string]any{
-			"action":   payloadText(s.operation.Payload, "action"),
-			"optionId": payloadText(s.operation.Payload, "optionId"),
-			"payload":  s.operation.Payload["payload"],
-		},
+		TurnID: input.TurnID, RequestID: input.RequestID, Status: agentactivitybiz.InteractionStatusPending,
 	}
-	return s.operation, interaction, transition, nil
+	interactionFound := true
+	if s.interactionStore != nil {
+		interaction, interactionFound = s.interactionStore.interaction(input.AgentSessionID, input.TurnID, input.RequestID)
+	}
+	if !interactionFound {
+		return agentactivitybiz.RuntimeOperation{}, agentactivitybiz.Interaction{}, agentactivitybiz.InteractionTransitionConflict, agentactivitybiz.ErrRuntimeOperationSubjectState
+	}
+	transition := agentactivitybiz.InteractionTransitionAlreadyApplied
+	operation := existingOperation
+	if !operationFound && interaction.Status == agentactivitybiz.InteractionStatusPending {
+		operation = agentactivitybiz.RuntimeOperation{OperationID: input.OperationID, WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID, Kind: input.Kind, Status: agentactivitybiz.RuntimeOperationStatusPrepared, TurnID: input.TurnID, RequestID: input.RequestID, Payload: input.Payload, CreatedAtUnixMS: input.OccurredAtMS, UpdatedAtUnixMS: input.OccurredAtMS}
+		s.storeOperationLocked(operation)
+	}
+	claimPayload := input.Payload
+	if operationFound {
+		claimPayload = operation.Payload
+	}
+	if interaction.Status == agentactivitybiz.InteractionStatusPending {
+		transition = agentactivitybiz.InteractionTransitionApplied
+		interaction.Status = agentactivitybiz.InteractionStatusAnswered
+		interaction.Output = map[string]any{
+			"action": payloadText(claimPayload, "action"), "optionId": payloadText(claimPayload, "optionId"),
+			"payload": claimPayload["payload"],
+		}
+		if s.interactionStore != nil {
+			s.interactionStore.storeInteraction(interaction)
+		}
+	}
+	return operation, interaction, transition, nil
 }
 
 func (s *runtimeOperationMemoryStore) GetRuntimeOperation(_ context.Context, workspaceID string, operationID string) (agentactivitybiz.RuntimeOperation, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.operation, s.operation.WorkspaceID == workspaceID && s.operation.OperationID == operationID, nil
+	operation, found := s.operationLocked(operationID)
+	return operation, found && operation.WorkspaceID == workspaceID, nil
 }
 
 func (s *runtimeOperationMemoryStore) ListClaimableRuntimeOperations(_ context.Context, input agentactivitybiz.ListClaimableRuntimeOperationsInput) ([]agentactivitybiz.RuntimeOperation, error) {
-	if (s.operation.Status == agentactivitybiz.RuntimeOperationStatusPrepared && s.operation.NextAttemptAtMS <= input.NowUnixMS) || (s.operation.Status == agentactivitybiz.RuntimeOperationStatusLeased && s.operation.LeaseExpiresAtMS <= input.NowUnixMS) {
-		return []agentactivitybiz.RuntimeOperation{s.operation}, nil
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make([]agentactivitybiz.RuntimeOperation, 0)
+	for _, operation := range s.operationsLocked() {
+		if (operation.Status == agentactivitybiz.RuntimeOperationStatusPrepared && operation.NextAttemptAtMS <= input.NowUnixMS) || (operation.Status == agentactivitybiz.RuntimeOperationStatusLeased && operation.LeaseExpiresAtMS <= input.NowUnixMS) {
+			result = append(result, operation)
+		}
 	}
-	return nil, nil
+	sort.Slice(result, func(left, right int) bool { return result[left].OperationID < result[right].OperationID })
+	return result, nil
 }
 
 func (s *runtimeOperationMemoryStore) ClaimRuntimeOperationLease(_ context.Context, input agentactivitybiz.ClaimRuntimeOperationLeaseInput) (agentactivitybiz.RuntimeOperation, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	claimable := (s.operation.Status == agentactivitybiz.RuntimeOperationStatusPrepared && s.operation.NextAttemptAtMS <= input.NowUnixMS) || (s.operation.Status == agentactivitybiz.RuntimeOperationStatusLeased && s.operation.LeaseExpiresAtMS <= input.NowUnixMS)
-	if !claimable {
-		return s.operation, false, nil
+	operation, found := s.operationLocked(input.OperationID)
+	if !found {
+		return agentactivitybiz.RuntimeOperation{}, false, nil
 	}
-	s.operation.Status, s.operation.LeaseOwner, s.operation.LeaseExpiresAtMS = agentactivitybiz.RuntimeOperationStatusLeased, input.LeaseOwner, input.LeaseExpiresAtMS
-	s.operation.Attempt++
-	return s.operation, true, nil
+	claimable := (operation.Status == agentactivitybiz.RuntimeOperationStatusPrepared && operation.NextAttemptAtMS <= input.NowUnixMS) || (operation.Status == agentactivitybiz.RuntimeOperationStatusLeased && operation.LeaseExpiresAtMS <= input.NowUnixMS)
+	if !claimable {
+		return operation, false, nil
+	}
+	operation.Status, operation.LeaseOwner, operation.LeaseExpiresAtMS = agentactivitybiz.RuntimeOperationStatusLeased, input.LeaseOwner, input.LeaseExpiresAtMS
+	operation.Attempt++
+	s.storeOperationLocked(operation)
+	return operation, true, nil
 }
 
 func (s *runtimeOperationMemoryStore) ReleaseOrFailRuntimeOperation(_ context.Context, input agentactivitybiz.ReleaseOrFailRuntimeOperationInput) (agentactivitybiz.RuntimeOperation, bool, error) {
-	if input.Fail {
-		s.operation.Status, s.operation.Result = agentactivitybiz.RuntimeOperationStatusFailed, agentactivitybiz.RuntimeOperationResultFailed
-	} else {
-		s.operation.Status = agentactivitybiz.RuntimeOperationStatusPrepared
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	operation, found := s.operationLocked(input.OperationID)
+	if !found {
+		return agentactivitybiz.RuntimeOperation{}, false, nil
 	}
-	s.operation.LeaseOwner, s.operation.LeaseExpiresAtMS, s.operation.LastError = "", 0, input.LastError
-	s.operation.NextAttemptAtMS = input.NextAttemptAtMS
-	return s.operation, true, nil
+	if input.Fail {
+		operation.Status, operation.Result = agentactivitybiz.RuntimeOperationStatusFailed, agentactivitybiz.RuntimeOperationResultFailed
+	} else {
+		operation.Status = agentactivitybiz.RuntimeOperationStatusPrepared
+	}
+	operation.LeaseOwner, operation.LeaseExpiresAtMS, operation.LastError = "", 0, input.LastError
+	operation.NextAttemptAtMS = input.NextAttemptAtMS
+	s.storeOperationLocked(operation)
+	return operation, true, nil
 }
 
 func (s *runtimeOperationMemoryStore) RequeueLeasedRuntimeOperationsOnStartup(_ context.Context, now int64) (int64, error) {
-	if s.operation.Status != agentactivitybiz.RuntimeOperationStatusLeased {
-		return 0, nil
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var requeued int64
+	for operationID, operation := range s.operationsLocked() {
+		if operation.Status != agentactivitybiz.RuntimeOperationStatusLeased {
+			continue
+		}
+		operation.Status, operation.LeaseOwner, operation.LeaseExpiresAtMS = agentactivitybiz.RuntimeOperationStatusPrepared, "", 0
+		operation.NextAttemptAtMS = now
+		s.operations[operationID] = operation
+		s.operation = operation
+		requeued++
 	}
-	s.operation.Status, s.operation.LeaseOwner, s.operation.LeaseExpiresAtMS = agentactivitybiz.RuntimeOperationStatusPrepared, "", 0
-	s.operation.NextAttemptAtMS = now
-	return 1, nil
+	return requeued, nil
 }
 
 func (s *runtimeOperationMemoryStore) CompleteInteractiveRuntimeOperation(_ context.Context, input agentactivitybiz.CompleteInteractiveRuntimeOperationInput) (agentactivitybiz.RuntimeOperationCompletion, bool, error) {
@@ -565,34 +676,53 @@ func (s *runtimeOperationMemoryStore) CompleteInteractiveRuntimeOperation(_ cont
 	if s.completeErr != nil {
 		return agentactivitybiz.RuntimeOperationCompletion{}, false, s.completeErr
 	}
-	s.operation.Status, s.operation.Result = agentactivitybiz.RuntimeOperationStatusCompleted, input.Disposition
-	s.operation.LeaseOwner, s.operation.LeaseExpiresAtMS = "", 0
-	event := agentactivitybiz.RuntimeOperationEvent{ID: int64(len(s.events) + 1), OperationID: s.operation.OperationID, WorkspaceID: s.operation.WorkspaceID, AgentSessionID: s.operation.AgentSessionID, Kind: agentactivitybiz.RuntimeOperationEventInteractiveCompleted}
+	operation, found := s.operationLocked(input.OperationID)
+	if !found {
+		return agentactivitybiz.RuntimeOperationCompletion{}, false, nil
+	}
+	operation.Status, operation.Result = agentactivitybiz.RuntimeOperationStatusCompleted, input.Disposition
+	operation.LeaseOwner, operation.LeaseExpiresAtMS = "", 0
+	s.storeOperationLocked(operation)
+	event := agentactivitybiz.RuntimeOperationEvent{ID: int64(len(s.events) + 1), OperationID: operation.OperationID, WorkspaceID: operation.WorkspaceID, AgentSessionID: operation.AgentSessionID, Kind: agentactivitybiz.RuntimeOperationEventInteractiveCompleted}
 	s.events = append(s.events, event)
-	return agentactivitybiz.RuntimeOperationCompletion{Operation: s.operation, Event: event}, true, nil
+	return agentactivitybiz.RuntimeOperationCompletion{Operation: operation, Event: event}, true, nil
 }
 
 func (s *runtimeOperationMemoryStore) CompleteCancelRuntimeOperation(_ context.Context, input agentactivitybiz.CompleteCancelRuntimeOperationInput) (agentactivitybiz.RuntimeOperationCompletion, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.completeErr != nil {
 		return agentactivitybiz.RuntimeOperationCompletion{}, false, s.completeErr
+	}
+	operation, found := s.operationLocked(input.OperationID)
+	if !found {
+		return agentactivitybiz.RuntimeOperationCompletion{}, false, nil
 	}
 	s.cancelCompletions = append(s.cancelCompletions, input)
-	s.operation.Status, s.operation.Result = agentactivitybiz.RuntimeOperationStatusCompleted, agentactivitybiz.RuntimeOperationResultCanceled
-	s.operation.LeaseOwner, s.operation.LeaseExpiresAtMS = "", 0
-	event := agentactivitybiz.RuntimeOperationEvent{ID: int64(len(s.events) + 1), OperationID: s.operation.OperationID, WorkspaceID: s.operation.WorkspaceID, AgentSessionID: s.operation.AgentSessionID, Kind: agentactivitybiz.RuntimeOperationEventTurnCanceled}
+	operation.Status, operation.Result = agentactivitybiz.RuntimeOperationStatusCompleted, agentactivitybiz.RuntimeOperationResultCanceled
+	operation.LeaseOwner, operation.LeaseExpiresAtMS = "", 0
+	s.storeOperationLocked(operation)
+	event := agentactivitybiz.RuntimeOperationEvent{ID: int64(len(s.events) + 1), OperationID: operation.OperationID, WorkspaceID: operation.WorkspaceID, AgentSessionID: operation.AgentSessionID, Kind: agentactivitybiz.RuntimeOperationEventTurnCanceled}
 	s.events = append(s.events, event)
-	return agentactivitybiz.RuntimeOperationCompletion{Operation: s.operation, Event: event}, true, nil
+	return agentactivitybiz.RuntimeOperationCompletion{Operation: operation, Event: event}, true, nil
 }
 
-func (s *runtimeOperationMemoryStore) CompletePlanDecisionRuntimeOperation(_ context.Context, _ agentactivitybiz.CompletePlanDecisionRuntimeOperationInput) (agentactivitybiz.RuntimeOperationCompletion, bool, error) {
+func (s *runtimeOperationMemoryStore) CompletePlanDecisionRuntimeOperation(_ context.Context, input agentactivitybiz.CompletePlanDecisionRuntimeOperationInput) (agentactivitybiz.RuntimeOperationCompletion, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.completeErr != nil {
 		return agentactivitybiz.RuntimeOperationCompletion{}, false, s.completeErr
 	}
-	s.operation.Status, s.operation.Result = agentactivitybiz.RuntimeOperationStatusCompleted, agentactivitybiz.RuntimeOperationResultApplied
-	s.operation.LeaseOwner, s.operation.LeaseExpiresAtMS = "", 0
-	event := agentactivitybiz.RuntimeOperationEvent{ID: int64(len(s.events) + 1), OperationID: s.operation.OperationID, WorkspaceID: s.operation.WorkspaceID, AgentSessionID: s.operation.AgentSessionID, Kind: agentactivitybiz.RuntimeOperationEventPlanDecisionCompleted}
+	operation, found := s.operationLocked(input.OperationID)
+	if !found {
+		return agentactivitybiz.RuntimeOperationCompletion{}, false, nil
+	}
+	operation.Status, operation.Result = agentactivitybiz.RuntimeOperationStatusCompleted, agentactivitybiz.RuntimeOperationResultApplied
+	operation.LeaseOwner, operation.LeaseExpiresAtMS = "", 0
+	s.storeOperationLocked(operation)
+	event := agentactivitybiz.RuntimeOperationEvent{ID: int64(len(s.events) + 1), OperationID: operation.OperationID, WorkspaceID: operation.WorkspaceID, AgentSessionID: operation.AgentSessionID, Kind: agentactivitybiz.RuntimeOperationEventPlanDecisionCompleted}
 	s.events = append(s.events, event)
-	return agentactivitybiz.RuntimeOperationCompletion{Operation: s.operation, Event: event}, true, nil
+	return agentactivitybiz.RuntimeOperationCompletion{Operation: operation, Event: event}, true, nil
 }
 
 func (s *runtimeOperationMemoryStore) ListPendingRuntimeOperationEvents(_ context.Context, _ string, _ int) ([]agentactivitybiz.RuntimeOperationEvent, error) {

--- a/services/tuttid/service/agent/service_respond.go
+++ b/services/tuttid/service/agent/service_respond.go
@@ -12,40 +12,32 @@ import (
 func (s *Service) Respond(ctx context.Context, input RespondInput) (RespondResult, error) {
 	workspaceID := strings.TrimSpace(input.WorkspaceID)
 	agentSessionID := strings.TrimSpace(input.AgentSessionID)
+	turnID := strings.TrimSpace(input.TurnID)
 	requestID := strings.TrimSpace(input.RequestID)
 	semantic := strings.ToLower(strings.TrimSpace(input.Semantic))
-	if workspaceID == "" || agentSessionID == "" || requestID == "" || s.TurnStore == nil {
+	if workspaceID == "" || agentSessionID == "" || turnID == "" || requestID == "" {
 		return RespondResult{}, ErrInvalidArgument
 	}
 	if semantic != "" && strings.TrimSpace(value(input.Action)) != "" {
 		return RespondResult{}, fmt.Errorf("%w: action and semantic are mutually exclusive", ErrInvalidArgument)
 	}
 
-	interactions, err := s.TurnStore.ListSessionInteractions(ctx, agentactivitybiz.ListSessionInteractionsInput{
-		WorkspaceID: workspaceID, AgentSessionID: agentSessionID,
-	})
-	if err != nil {
-		return RespondResult{}, err
-	}
-	matches := make([]agentactivitybiz.Interaction, 0, 1)
-	for _, interaction := range interactions {
-		if strings.TrimSpace(interaction.RequestID) != requestID {
-			continue
-		}
-		matches = append(matches, interaction)
-	}
-	if len(matches) == 0 {
-		return RespondResult{}, fmt.Errorf("%w: %q", ErrInteractionRequestNotFound, requestID)
-	}
-	if len(matches) != 1 {
-		return RespondResult{}, fmt.Errorf("%w: %q matched %d interactions", ErrInteractionRequestAmbiguous, requestID, len(matches))
-	}
-
-	interaction := matches[0]
 	action := input.Action
 	if semantic != "" {
+		if s.TurnStore == nil {
+			return RespondResult{}, ErrInvalidArgument
+		}
+		interactions, err := s.TurnStore.ListSessionInteractions(ctx, agentactivitybiz.ListSessionInteractionsInput{
+			WorkspaceID: workspaceID, AgentSessionID: agentSessionID, TurnID: turnID, RequestID: requestID,
+		})
+		if err != nil {
+			return RespondResult{}, err
+		}
+		if len(interactions) != 1 || strings.TrimSpace(interactions[0].TurnID) != turnID || strings.TrimSpace(interactions[0].RequestID) != requestID {
+			return RespondResult{}, fmt.Errorf("%w: %q", ErrInteractionRequestNotFound, requestID)
+		}
 		matchingActions := make([]InteractionAction, 0, 1)
-		for _, candidate := range interactionActions(interaction) {
+		for _, candidate := range interactionActions(interactions[0]) {
 			if strings.EqualFold(strings.TrimSpace(candidate.Semantic), semantic) {
 				matchingActions = append(matchingActions, candidate)
 			}
@@ -63,18 +55,19 @@ func (s *Service) Respond(ctx context.Context, input RespondInput) (RespondResul
 
 	result, err := s.ApplicationHost().SubmitInteractive(
 		ctx,
-		agenthost.SessionRef{WorkspaceID: workspaceID, AgentSessionID: agentSessionID},
-		requestID,
+		agenthost.InteractionRef{
+			WorkspaceID: workspaceID, AgentSessionID: agentSessionID,
+			TurnID: turnID, RequestID: requestID,
+		},
 		agenthost.SubmitInteractiveInput{
-			TurnID: strings.TrimSpace(interaction.TurnID), Action: action,
-			OptionID: input.OptionID, Payload: clonePayload(input.Payload),
+			Action: action, OptionID: input.OptionID, Payload: clonePayload(input.Payload),
 		},
 	)
 	if err != nil {
 		return RespondResult{}, normalizeRuntimeError(err)
 	}
 	return RespondResult{
-		RequestID: requestID, TurnID: strings.TrimSpace(interaction.TurnID), Disposition: result.Disposition,
+		RequestID: requestID, TurnID: turnID, Disposition: result.Disposition,
 	}, nil
 }
 

--- a/services/tuttid/service/agent/service_respond_test.go
+++ b/services/tuttid/service/agent/service_respond_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 )
 
-func TestRespondRejectsInvalidInteractionSelectionsBeforeHostSubmission(t *testing.T) {
+func TestRespondRejectsInvalidSemanticSelectionsBeforeHostSubmission(t *testing.T) {
 	base := agentactivitybiz.Interaction{
 		WorkspaceID: "ws-1", AgentSessionID: "session-1", RequestID: "request-1", TurnID: "turn-1",
 		Kind: agentactivitybiz.InteractionKindApproval, Status: agentactivitybiz.InteractionStatusPending,
@@ -38,11 +39,84 @@ func TestRespondRejectsInvalidInteractionSelectionsBeforeHostSubmission(t *testi
 			service := newIsolatedAgentService(newFakeRuntime())
 			service.TurnStore = failingTurnStore{interactions: test.interactions}
 			_, err := service.Respond(context.Background(), RespondInput{
-				WorkspaceID: "ws-1", AgentSessionID: "session-1", RequestID: test.requestID, Semantic: test.semantic,
+				WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1", RequestID: test.requestID, Semantic: test.semantic,
 			})
 			if !errors.Is(err, test.want) {
 				t.Fatalf("Respond() error = %v, want %v", err, test.want)
 			}
 		})
+	}
+}
+
+func TestRespondSelectsExactTurnWhenProviderRequestIDIsReused(t *testing.T) {
+	runtime := newFakeRuntime()
+	activeTurnID := "turn-current"
+	runtime.sessions["ws-1:session-1"] = ProviderRuntimeSession{
+		ID: "session-1", WorkspaceID: "ws-1", Provider: "codex", Status: "working",
+		TurnLifecycle: &TurnLifecycle{ActiveTurnID: &activeTurnID, Phase: agentactivitybiz.TurnPhaseWaiting},
+	}
+	service := newIsolatedAgentService(runtime)
+	service.RuntimeOperationStore = &runtimeOperationMemoryStore{}
+	service.RuntimeOperationOwner = "worker-a"
+	service.RuntimeOperationClock = func() time.Time { return time.UnixMilli(1_000) }
+	service.TurnStore = failingTurnStore{
+		listInteractionsErr: errors.New("explicit response must not query interactions in the adapter"),
+		session:             agentactivitybiz.Session{WorkspaceID: "ws-1", ID: "session-1", ActiveTurnID: activeTurnID},
+		turn: agentactivitybiz.Turn{
+			WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: activeTurnID,
+			Phase: agentactivitybiz.TurnPhaseWaiting,
+		},
+		interactions: []agentactivitybiz.Interaction{
+			{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-previous", RequestID: "request-reused", Status: agentactivitybiz.InteractionStatusAnswered},
+			{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: activeTurnID, RequestID: "request-reused", Status: agentactivitybiz.InteractionStatusPending},
+		},
+	}
+
+	result, err := service.Respond(context.Background(), RespondInput{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: activeTurnID,
+		RequestID: "request-reused", Action: stringRef("approve"),
+	})
+	if err != nil {
+		t.Fatalf("Respond() error = %v", err)
+	}
+	if result.TurnID != activeTurnID || result.Disposition != RuntimeInteractiveDispositionAnswered {
+		t.Fatalf("Respond() result = %#v", result)
+	}
+	if len(runtime.submitInteractiveCalls) != 1 || runtime.submitInteractiveCalls[0].TurnID != activeTurnID || runtime.submitInteractiveCalls[0].RequestID != "request-reused" {
+		t.Fatalf("runtime interactive calls = %#v", runtime.submitInteractiveCalls)
+	}
+}
+
+func TestRespondMapsHostOwnedMissingInteractionWithoutAdapterPrevalidation(t *testing.T) {
+	runtime := newFakeRuntime()
+	activeTurnID := "turn-current"
+	runtime.sessions["ws-1:session-1"] = ProviderRuntimeSession{
+		ID: "session-1", WorkspaceID: "ws-1", Provider: "codex", Status: "working",
+		TurnLifecycle: &TurnLifecycle{ActiveTurnID: &activeTurnID, Phase: agentactivitybiz.TurnPhaseWaiting},
+	}
+	service := newIsolatedAgentService(runtime)
+	service.RuntimeOperationStore = &runtimeOperationMemoryStore{interactionStore: &legacyHostConformanceTurnStore{
+		interactions: map[string][]agentactivitybiz.Interaction{},
+	}}
+	service.RuntimeOperationOwner = "worker-a"
+	service.RuntimeOperationClock = func() time.Time { return time.UnixMilli(1_000) }
+	service.TurnStore = failingTurnStore{
+		listInteractionsErr: errors.New("explicit response must not query interactions in the adapter"),
+		session:             agentactivitybiz.Session{WorkspaceID: "ws-1", ID: "session-1", ActiveTurnID: activeTurnID},
+		turn: agentactivitybiz.Turn{
+			WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: activeTurnID,
+			Phase: agentactivitybiz.TurnPhaseWaiting,
+		},
+	}
+
+	_, err := service.Respond(context.Background(), RespondInput{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: activeTurnID,
+		RequestID: "missing", Action: stringRef("approve"),
+	})
+	if !errors.Is(err, ErrInteractionRequestNotFound) {
+		t.Fatalf("Respond() error = %v, want Host-owned missing interaction", err)
+	}
+	if len(runtime.submitInteractiveCalls) != 0 {
+		t.Fatalf("runtime interactive calls = %#v, want none", runtime.submitInteractiveCalls)
 	}
 }

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -6643,10 +6643,8 @@ func TestServiceDoesNotReconcileStalePersistedTurnWhenRuntimeSessionIsWorking(t 
 
 	if _, err := service.SubmitInteractive(
 		context.Background(),
-		"ws-1",
-		"session-1",
-		"permission-1",
-		SubmitInteractiveInput{OptionID: stringRef("approve")},
+		agenthost.InteractionRef{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1", RequestID: "permission-1"},
+		agenthost.SubmitInteractiveInput{OptionID: stringRef("approve")},
 	); err != nil {
 		t.Fatalf("SubmitInteractive returned error: %v", err)
 	}

--- a/services/tuttid/service/agent/service_turns_error_test.go
+++ b/services/tuttid/service/agent/service_turns_error_test.go
@@ -224,6 +224,19 @@ func (s failingTurnStore) GetSession(context.Context, string, string) (agentacti
 	return s.session, true, nil
 }
 
-func (s failingTurnStore) ListSessionInteractions(context.Context, agentactivitybiz.ListSessionInteractionsInput) ([]agentactivitybiz.Interaction, error) {
-	return s.interactions, s.listInteractionsErr
+func (s failingTurnStore) ListSessionInteractions(_ context.Context, input agentactivitybiz.ListSessionInteractionsInput) ([]agentactivitybiz.Interaction, error) {
+	if s.listInteractionsErr != nil {
+		return nil, s.listInteractionsErr
+	}
+	result := make([]agentactivitybiz.Interaction, 0, len(s.interactions))
+	for _, interaction := range s.interactions {
+		if input.TurnID != "" && interaction.TurnID != input.TurnID {
+			continue
+		}
+		if input.RequestID != "" && interaction.RequestID != input.RequestID {
+			continue
+		}
+		result = append(result, interaction)
+	}
+	return result, nil
 }

--- a/services/tuttid/service/agent/service_wait_test.go
+++ b/services/tuttid/service/agent/service_wait_test.go
@@ -290,7 +290,7 @@ func TestWaitRespondChildInteractionAndReturnFinalMessage(t *testing.T) {
 	}
 
 	responded, err := service.Respond(context.Background(), RespondInput{
-		WorkspaceID: "ws-1", AgentSessionID: "child-1", RequestID: interaction.RequestID, Semantic: "approve",
+		WorkspaceID: "ws-1", AgentSessionID: "child-1", TurnID: interaction.TurnID, RequestID: interaction.RequestID, Semantic: "approve",
 	})
 	if err != nil {
 		t.Fatalf("Respond() error = %v", err)

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -513,7 +513,6 @@ type SendInputResult struct {
 
 type PromptContentBlock = agenthost.PromptContentBlock
 type PromptAttachment = agenthost.PromptAttachment
-type SubmitInteractiveInput = agenthost.SubmitInteractiveInput
 type SubmitPlanDecisionInput = agenthost.SubmitPlanDecisionInput
 
 type InteractionAction struct {
@@ -525,6 +524,7 @@ type InteractionAction struct {
 type RespondInput struct {
 	WorkspaceID    string
 	AgentSessionID string
+	TurnID         string
 	RequestID      string
 	Action         *string
 	OptionID       *string

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -879,7 +879,7 @@ func TestRespondCommandPassesResponseAndReturnsDisposition(t *testing.T) {
 	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newRespondCommand()
 	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input: map[string]any{
-			"session-id": "SESSION-1", "request-id": "request-1", "action": "approve",
+			"session-id": "SESSION-1", "turn-id": "turn-1", "request-id": "request-1", "action": "approve",
 			"option": "allow-once", "payload": `{"answer":"yes"}`,
 		},
 		OutputMode: cliservice.OutputModeJSON,
@@ -888,7 +888,7 @@ func TestRespondCommandPassesResponseAndReturnsDisposition(t *testing.T) {
 		t.Fatalf("Handler: %v", err)
 	}
 	if sessions.respondInput.WorkspaceID != "workspace-1" || sessions.respondInput.AgentSessionID != "SESSION-1" ||
-		sessions.respondInput.RequestID != "request-1" || optionalTestString(sessions.respondInput.Action) != "approve" ||
+		sessions.respondInput.TurnID != "turn-1" || sessions.respondInput.RequestID != "request-1" || optionalTestString(sessions.respondInput.Action) != "approve" ||
 		optionalTestString(sessions.respondInput.OptionID) != "allow-once" || sessions.respondInput.Payload["answer"] != "yes" {
 		t.Fatalf("respond input = %#v", sessions.respondInput)
 	}
@@ -901,7 +901,7 @@ func TestRespondCommandPassesSemanticWithoutProviderMapping(t *testing.T) {
 	sessions := &fakeAgentSessions{}
 	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newRespondCommand()
 	if _, err := command.Handler(context.Background(), cliservice.InvokeRequest{
-		Input:      map[string]any{"session-id": "SESSION-1", "request-id": "request-1", "semantic": "approve"},
+		Input:      map[string]any{"session-id": "SESSION-1", "turn-id": "turn-1", "request-id": "request-1", "semantic": "approve"},
 		OutputMode: cliservice.OutputModeJSON,
 	}); err != nil {
 		t.Fatalf("Handler: %v", err)
@@ -917,13 +917,13 @@ func TestRespondCommandReturnsStructuredInputErrors(t *testing.T) {
 		input    map[string]any
 		sessions *fakeAgentSessions
 	}{
-		{name: "missing response", input: map[string]any{"session-id": "SESSION-1", "request-id": "request-1"}, sessions: &fakeAgentSessions{}},
-		{name: "invalid payload", input: map[string]any{"session-id": "SESSION-1", "request-id": "request-1", "payload": `[]`}, sessions: &fakeAgentSessions{}},
-		{name: "action and semantic", input: map[string]any{"session-id": "SESSION-1", "request-id": "request-1", "action": "approve", "semantic": "approve"}, sessions: &fakeAgentSessions{}},
-		{name: "unknown request", input: map[string]any{"session-id": "SESSION-1", "request-id": "missing", "action": "approve"}, sessions: &fakeAgentSessions{respondErr: agentservice.ErrInteractionRequestNotFound}},
-		{name: "non pending", input: map[string]any{"session-id": "SESSION-1", "request-id": "answered", "action": "approve"}, sessions: &fakeAgentSessions{respondErr: agentservice.ErrInteractionRequestNotPending}},
-		{name: "semantic missing", input: map[string]any{"session-id": "SESSION-1", "request-id": "request-1", "semantic": "approve"}, sessions: &fakeAgentSessions{respondErr: agentservice.ErrInteractionSemanticNotFound}},
-		{name: "semantic ambiguous", input: map[string]any{"session-id": "SESSION-1", "request-id": "request-1", "semantic": "approve"}, sessions: &fakeAgentSessions{respondErr: agentservice.ErrInteractionSemanticAmbiguous}},
+		{name: "missing turn", input: map[string]any{"session-id": "SESSION-1", "request-id": "request-1", "action": "approve"}, sessions: &fakeAgentSessions{}},
+		{name: "missing response", input: map[string]any{"session-id": "SESSION-1", "turn-id": "turn-1", "request-id": "request-1"}, sessions: &fakeAgentSessions{}},
+		{name: "invalid payload", input: map[string]any{"session-id": "SESSION-1", "turn-id": "turn-1", "request-id": "request-1", "payload": `[]`}, sessions: &fakeAgentSessions{}},
+		{name: "action and semantic", input: map[string]any{"session-id": "SESSION-1", "turn-id": "turn-1", "request-id": "request-1", "action": "approve", "semantic": "approve"}, sessions: &fakeAgentSessions{}},
+		{name: "unknown request", input: map[string]any{"session-id": "SESSION-1", "turn-id": "turn-1", "request-id": "missing", "action": "approve"}, sessions: &fakeAgentSessions{respondErr: agentservice.ErrInteractionRequestNotFound}},
+		{name: "semantic missing", input: map[string]any{"session-id": "SESSION-1", "turn-id": "turn-1", "request-id": "request-1", "semantic": "approve"}, sessions: &fakeAgentSessions{respondErr: agentservice.ErrInteractionSemanticNotFound}},
+		{name: "semantic ambiguous", input: map[string]any{"session-id": "SESSION-1", "turn-id": "turn-1", "request-id": "request-1", "semantic": "approve"}, sessions: &fakeAgentSessions{respondErr: agentservice.ErrInteractionSemanticAmbiguous}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, test.sessions).newRespondCommand()

--- a/services/tuttid/service/cli/providers/agentcontext/session_commands.go
+++ b/services/tuttid/service/cli/providers/agentcontext/session_commands.go
@@ -60,6 +60,7 @@ type sendInput struct {
 
 type respondInput struct {
 	SessionID string `cli:"session-id" validate:"required" description:"Agent session id containing the pending interaction."`
+	TurnID    string `cli:"turn-id" validate:"required" description:"Exact turn id containing the pending interaction."`
 	RequestID string `cli:"request-id" validate:"required" description:"Pending interaction request id."`
 	Action    string `cli:"action" description:"Provider action id to submit."`
 	Option    string `cli:"option" description:"Provider option id to submit."`
@@ -379,7 +380,7 @@ func (p Provider) runRespond(ctx context.Context, invoke framework.InvokeContext
 		return nil, fmt.Errorf("%w: provide action, option, payload, or semantic", cliservice.ErrInvalidInput)
 	}
 	result, err := p.sessions.Respond(ctx, agentservice.RespondInput{
-		WorkspaceID: invoke.WorkspaceID, AgentSessionID: input.SessionID, RequestID: input.RequestID,
+		WorkspaceID: invoke.WorkspaceID, AgentSessionID: input.SessionID, TurnID: input.TurnID, RequestID: input.RequestID,
 		Action: optionalStringPointer(input.Action), OptionID: optionalStringPointer(input.Option),
 		Payload: payload, Semantic: input.Semantic,
 	})
@@ -395,8 +396,6 @@ func (p Provider) runRespond(ctx context.Context, invoke framework.InvokeContext
 func isRespondInputError(err error) bool {
 	return errors.Is(err, agentservice.ErrInvalidArgument) ||
 		errors.Is(err, agentservice.ErrInteractionRequestNotFound) ||
-		errors.Is(err, agentservice.ErrInteractionRequestNotPending) ||
-		errors.Is(err, agentservice.ErrInteractionRequestAmbiguous) ||
 		errors.Is(err, agentservice.ErrInteractionSemanticNotFound) ||
 		errors.Is(err, agentservice.ErrInteractionSemanticAmbiguous)
 }


### PR DESCRIPTION
## Summary

- make `(workspaceId, agentSessionId, turnId, requestId)` the canonical interaction identity across CLI, tuttid, Host, and durable runtime operations
- move lifecycle validation into `packages/agent/host` and keep tuttid as a typed adapter with semantic-selection policy only
- add a lossless V4 SQLite migration that removes the ambiguous `subject_id`, preserves every existing row, and installs operation-kind-specific unique indexes
- add Host conformance coverage for two turns reusing the same provider request id without cross-turn interference
- document the lifecycle contract, migration behavior, and troubleshooting path

This is a forward fix. It deliberately does not rewrite historical Interaction rows; affected existing sessions can still be canceled and retried.

## Verification

- `pnpm check:changed` — all 10 lanes selected for the clean branch passed
- `pnpm check:agent-host-boundary`
- `go test ./...` in `packages/agent/host`
- `go test ./...` in `packages/agent/store-sqlite`
- targeted and full relevant `services/tuttid` Go tests
- focused architecture review by three sub-agents; all findings addressed

## Fix Scope Justification

- Root cause: provider request ids are transport-local and may repeat across turns, but the old runtime-operation schema and adapter lookup treated them as session-wide durable identity. A response could therefore bind to an older turn and leave the active turn waiting.
- Why can this not be fixed at a lower layer? Correctness spans lifecycle identity, atomic persistence, idempotency, recovery, CLI routing, and every Host consumer. Fixing only the UI or tuttid adapter would preserve the ambiguous durable key and duplicate lifecycle semantics outside Host. The Host contract and SQLite migration must change together, with adapters only carrying the exact typed identity.

## Checklist

- [x] If this PR changes agent lifecycle semantics: the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. No README/CONTRIBUTING source was changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->