### PR TITLE
fix(agent): rotate Grok extension signing key

### DIFF
--- a/apps/desktop/src/main/generated/defaults.ts
+++ b/apps/desktop/src/main/generated/defaults.ts
@@ -102,9 +102,9 @@ export const generatedDefaults = {
         key: "grok",
         releaseIndexUrl:
           "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/grok/versions.json",
-        signingKeyId: "tutti-grok-release-v1",
+        signingKeyId: "tutti-grok-release-v2",
         signingPublicKey:
-          "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA2ZaE97XclDVCG9MLnQ5z1ZTd8FJPeLqj6KDsY69Iyu8=\n-----END PUBLIC KEY-----\n",
+          "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAwEnBjsJWjJnmmCCmS2MZTMaNJZSkfVhL7rm3lcsutyA=\n-----END PUBLIC KEY-----\n",
         enabled: false
       }
     ]

--- a/config/tutti.defaults.json
+++ b/config/tutti.defaults.json
@@ -87,8 +87,8 @@
       {
         "key": "grok",
         "releaseIndexUrl": "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/grok/versions.json",
-        "signingKeyId": "tutti-grok-release-v1",
-        "signingPublicKey": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA2ZaE97XclDVCG9MLnQ5z1ZTd8FJPeLqj6KDsY69Iyu8=\n-----END PUBLIC KEY-----\n",
+        "signingKeyId": "tutti-grok-release-v2",
+        "signingPublicKey": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAwEnBjsJWjJnmmCCmS2MZTMaNJZSkfVhL7rm3lcsutyA=\n-----END PUBLIC KEY-----\n",
         "enabled": false
       }
     ]

--- a/services/tuttid/types/defaults_generated.go
+++ b/services/tuttid/types/defaults_generated.go
@@ -86,8 +86,8 @@ var generatedDefaults = generatedDefaultsSpec{
 			{
 				Key:              "grok",
 				ReleaseIndexURL:  "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/grok/versions.json",
-				SigningKeyID:     "tutti-grok-release-v1",
-				SigningPublicKey: "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA2ZaE97XclDVCG9MLnQ5z1ZTd8FJPeLqj6KDsY69Iyu8=\n-----END PUBLIC KEY-----\n",
+				SigningKeyID:     "tutti-grok-release-v2",
+				SigningPublicKey: "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAwEnBjsJWjJnmmCCmS2MZTMaNJZSkfVhL7rm3lcsutyA=\n-----END PUBLIC KEY-----\n",
 				Enabled:          false,
 			},
 		},

--- a/services/tuttid/types/defaults_test.go
+++ b/services/tuttid/types/defaults_test.go
@@ -101,7 +101,7 @@ func TestResolveAgentExtensionSourcesAppliesLocalPackageOnlyInDevelopment(t *tes
 
 func TestGrokAgentExtensionSourcePinsApprovedSigningIdentity(t *testing.T) {
 	source := agentExtensionSourceByKey(t, ResolveAgentExtensionSources(), "grok")
-	if source.Enabled || source.SigningKeyID != "tutti-grok-release-v1" ||
+	if source.Enabled || source.SigningKeyID != "tutti-grok-release-v2" ||
 		source.ReleaseIndexURL != "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/grok/versions.json" {
 		t.Fatalf("grok source activation/key identity = %#v", source)
 	}
@@ -113,7 +113,7 @@ func TestGrokAgentExtensionSourcePinsApprovedSigningIdentity(t *testing.T) {
 		t.Fatalf("parse grok signing public key: %v", err)
 	}
 	digest := sha256.Sum256(block.Bytes)
-	if got := hex.EncodeToString(digest[:]); got != "408e1275a69d250897a5889505124ec32e91cfa209d01aa582b370f5d3b255d3" {
+	if got := hex.EncodeToString(digest[:]); got != "1d9c96185b82d9ad0a2102374365a958e6f10d2c9bbdb4a6ab0f7effc503745b" {
 		t.Fatalf("grok signing public key SPKI digest = %s", got)
 	}
 }


### PR DESCRIPTION
## What changed

- rotate the pinned Grok extension signing identity to `tutti-grok-release-v2`
- update the generated daemon and desktop defaults
- update the exact signing-key fingerprint regression test

## Root cause

The Grok `0.1.0` release was signed by a private key that did not match Tutti's pinned public key, so extension reconciliation rejected it and never registered the AgentGUI target.

## Impact

Tutti builds containing this change can verify and install Grok releases signed by the rotated repository secret.

## Validation

- `pnpm generate:defaults`
- `pnpm check:defaults-generated`
- `pnpm check:changed` (all functional lanes passed; `lint:changed` reports no files because the generated TypeScript file is ignored)
- `pnpm exec oxlint --deny-warnings --no-ignore apps/desktop/src/main/generated/defaults.ts`
- pre-commit Electron, UI, renderer, and AgentGUI boundary checks

## Documentation impact

No durable documentation change is needed. This updates a release trust anchor without changing runtime configuration, public APIs, module ownership, or user interaction.
