### PR TITLE
fix(browser): tolerate destroyed automation guests

### DIFF
--- a/packages/browser/workbench-node/src/electron-main/automationDebugger.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationDebugger.test.ts
@@ -80,3 +80,54 @@ test("automation request guard intercepts redirects and subresources", async () 
   );
   driver.dispose();
 });
+
+test("automation driver disposal does not access a destroyed WebContents debugger", async () => {
+  let destroyed = false;
+  let messageListener:
+    | ((event: unknown, method: string, params: unknown) => void)
+    | null = null;
+  const debuggerClient: BrowserGuestDebugger = {
+    attach() {},
+    detach() {},
+    isAttached: () => true,
+    off(_event, listener) {
+      if (messageListener === listener) messageListener = null;
+      return this;
+    },
+    on(_event, listener) {
+      messageListener = listener;
+      return this;
+    },
+    async sendCommand() {
+      return {};
+    }
+  };
+  const contents = {
+    get debugger() {
+      if (destroyed) throw new TypeError("Object has been destroyed");
+      return debuggerClient;
+    },
+    isDestroyed: () => destroyed,
+    off() {
+      return this;
+    },
+    on() {
+      return this;
+    }
+  } as unknown as BrowserGuestWebContents;
+  const driver = new BrowserNodeAutomationDriver(contents);
+  await driver.enableRequestGuard(async () => ({ allowed: true }));
+  const emitMessage = messageListener as
+    | ((event: unknown, method: string, params: unknown) => void)
+    | null;
+
+  destroyed = true;
+  emitMessage?.(null, "Fetch.requestPaused", {
+    request: { url: "https://public.example/late.js" },
+    requestId: "late"
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  await assert.doesNotReject(driver.disableRequestGuard());
+  assert.doesNotThrow(() => driver.dispose());
+  assert.doesNotThrow(() => driver.dispose());
+});

--- a/packages/browser/workbench-node/src/electron-main/automationDebugger.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationDebugger.ts
@@ -24,6 +24,7 @@ interface SnapshotElement {
 export class BrowserNodeAutomationDriver {
   private attachedByDriver = false;
   private readonly contents: BrowserGuestWebContents;
+  private disposed = false;
   private readonly elements = new Map<string, SnapshotElement>();
   private nextSnapshotSequence = 1;
   private requestAuthorizer:
@@ -80,16 +81,20 @@ export class BrowserNodeAutomationDriver {
   }
 
   dispose(): void {
-    const debuggerClient = this.contents.debugger;
-    if (this.attachedByDriver && debuggerClient?.isAttached()) {
-      debuggerClient.detach();
-    }
+    if (this.disposed) return;
+    this.disposed = true;
+    const shouldDetach = this.attachedByDriver;
     this.attachedByDriver = false;
     this.requestAuthorizer = null;
     this.requestGuardEnabled = false;
     this.elements.clear();
+    if (this.contents.isDestroyed()) return;
+    const debuggerClient = this.contents.debugger;
     this.contents.off("did-start-navigation", this.onNavigation);
     debuggerClient?.off?.("message", this.onDebuggerMessage);
+    if (shouldDetach && debuggerClient?.isAttached()) {
+      debuggerClient.detach();
+    }
   }
 
   async enableRequestGuard(
@@ -123,6 +128,7 @@ export class BrowserNodeAutomationDriver {
     this.requestAuthorizer = null;
     if (!this.requestGuardEnabled) return;
     this.requestGuardEnabled = false;
+    if (this.disposed || this.contents.isDestroyed()) return;
     const debuggerClient = this.contents.debugger;
     debuggerClient?.off?.("message", this.onDebuggerMessage);
     if (debuggerClient?.isAttached()) {
@@ -255,7 +261,7 @@ export class BrowserNodeAutomationDriver {
   }
 
   private requireDebugger(): BrowserGuestDebugger {
-    if (this.contents.isDestroyed()) {
+    if (this.disposed || this.contents.isDestroyed()) {
       throw new Error("Browser page is closed");
     }
     const debuggerClient = this.contents.debugger;
@@ -272,6 +278,7 @@ export class BrowserNodeAutomationDriver {
   private async handlePausedRequest(
     params: Record<string, unknown>
   ): Promise<void> {
+    if (this.disposed || this.contents.isDestroyed()) return;
     const debuggerClient = this.contents.debugger;
     const requestId = readString(params.requestId);
     const url = readString(asRecord(params.request)?.url);


### PR DESCRIPTION
## Summary

- make BrowserNode automation-driver disposal idempotent
- avoid reading debugger state after Electron has destroyed the guest WebContents
- make request-guard teardown and paused-request handling no-op after disposal
- add regression coverage for destroyed guest cleanup and repeated disposal

## Verification

- `pnpm --filter @tutti-os/browser-node test -- --run` (158 tests passed)
- `pnpm --filter @tutti-os/browser-node typecheck`
- pre-push `pnpm check:changed -- --push-ready` (9 lanes passed)

## Fallback Three Questions

- Source: Electron emits the guest `destroyed` lifecycle event before BrowserNode registry cleanup calls the automation driver disposer.
- Why can it not be fixed at that source? Guest destruction is the authoritative and expected lifecycle event; cleanup must be safe when the underlying Electron object is already invalid.
- Removal condition: this guard is a lifecycle invariant and can only be removed if Electron guarantees all WebContents debugger/listener access remains safe after destruction.

## Checklist

- [x] This PR does not change agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] No documentation update is needed; public behavior and setup are unchanged.
- [x] No README/CONTRIBUTING source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->