### PR TITLE
fix(browser): keep cold lifecycle status internal

### DIFF
--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -2,12 +2,13 @@
 
 [Back to troubleshooting index](./README.md)
 
-### Tabbed standalone Browser remains in `Sleeping` state
+### Tabbed standalone Browser remains blank with a cold lifecycle
 
 - Symptom:
   A standalone Browser shows its default URL and tab title, but the guest area
-  stays blank and the navigation bar keeps showing `Sleeping` after multi-tab
-  support is enabled. The same Browser may work in an OS-mode Workbench window.
+  stays blank after multi-tab support is enabled. Renderer diagnostics keep the
+  active tab in the internal `cold` lifecycle even though activation was
+  requested. The same Browser may work in an OS-mode Workbench window.
 - Quick checks:
   Compare the surface node ID with the node ID in Browser runtime events. A
   tabbed surface owns a parent such as `browser:surface` while its controller

--- a/packages/browser/workbench-node/src/react/BrowserNodeChrome.tsx
+++ b/packages/browser/workbench-node/src/react/BrowserNodeChrome.tsx
@@ -2,7 +2,6 @@ import {
   AddIcon,
   ArrowLeftIcon,
   ArrowRightIcon,
-  Badge,
   Button,
   CloseIcon,
   Input,
@@ -329,14 +328,6 @@ export function BrowserNodeHeader({
         }
         runtime={runtime}
       />
-      {runtime.lifecycle === "cold" ? (
-        <Badge
-          className="nodrag h-[26px] min-w-7 shrink-0 rounded-md text-[10px] font-semibold lowercase tracking-[0.08em]"
-          aria-label={feature.i18n.t("coldStatus")}
-        >
-          {feature.i18n.t("coldStatus")}
-        </Badge>
-      ) : null}
     </div>
   );
 }

--- a/packages/browser/workbench-node/src/react/browserNodeActionsMenu.test.ts
+++ b/packages/browser/workbench-node/src/react/browserNodeActionsMenu.test.ts
@@ -120,3 +120,8 @@ test("Browser Node address-bar icon actions use shared hover tooltips", () => {
     /<TooltipTrigger asChild>[\s\S]*?<Button[\s\S]*?<TooltipContent side="bottom">[\s\S]*?actions\.more/
   );
 });
+
+test("Browser Node keeps cold lifecycle state internal", () => {
+  assert.doesNotMatch(browserNodeChromeSource, /runtime\.lifecycle === "cold"/);
+  assert.doesNotMatch(browserNodeChromeSource, /coldStatus/);
+});


### PR DESCRIPTION
## Summary

- Remove the visible `Sleeping` badge from BrowserNode chrome.
- Keep the underlying `cold` lifecycle and lazy guest activation behavior unchanged.
- Add a regression assertion that lifecycle state is not rendered as user-facing browser chrome.
- Update the renderer troubleshooting guide to use diagnostics for internal cold-state investigation.

## Why

`cold` is an implementation lifecycle state, not a user action or actionable browser status. Showing `Sleeping` beside normal browser controls is confusing, especially for an empty `about:blank` tab, and leaks internal runtime terminology into product UI.

## Verification

- `pnpm --filter @tutti-os/browser-node test` — 159 tests passed
- `pnpm --filter @tutti-os/browser-node typecheck`
- pre-push `pnpm check:changed -- --push-ready` — 9 lanes passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->