### PR TITLE
fix(release): bound desktop release notes

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -483,6 +483,15 @@ jobs:
       - name: Generate checksums
         run: node apps/desktop/scripts/generate-checksums.mjs release-assets
 
+      - id: previous-release-tag
+        name: Resolve previous GitHub release tag
+        env:
+          RELEASE_CHANNEL: ${{ env.TUTTI_DESKTOP_RELEASE_CHANNEL }}
+          RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
+        run: |
+          previous_tag="$(node apps/desktop/scripts/resolve-previous-release-tag.mjs)"
+          echo "tag=${previous_tag}" >> "$GITHUB_OUTPUT"
+
       - id: stage-release
         name: Stage GitHub release assets
         uses: softprops/action-gh-release@v2
@@ -495,6 +504,7 @@ jobs:
           prerelease: ${{ needs.resolve.outputs.release_prerelease == 'true' }}
           make_latest: ${{ needs.resolve.outputs.release_make_latest == 'true' }}
           generate_release_notes: true
+          previous_tag: ${{ steps.previous-release-tag.outputs.tag }}
           files: |
             release-assets/*
 

--- a/apps/desktop/scripts/generate-release-summary.mjs
+++ b/apps/desktop/scripts/generate-release-summary.mjs
@@ -3,7 +3,11 @@
 import { execFileSync } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
-import { parseReleaseTag } from "./lib/releaseConfig.mjs";
+import {
+  isPrereleaseVersion,
+  normalizeVersion,
+  resolvePreviousReleaseTag
+} from "./lib/previousReleaseTag.mjs";
 
 const schemaVersion = "tutti.desktop.release.summary.v1";
 const agnesEndpoint = "https://apihub.agnes-ai.com/v1/chat/completions";
@@ -46,14 +50,6 @@ function requireOption(value, label) {
   return normalized;
 }
 
-function normalizeVersion(tag) {
-  return parseReleaseTag(tag) ?? tag.replace(/^v/u, "");
-}
-
-function isPrereleaseVersion(version) {
-  return /-[0-9A-Za-z.-]+$/u.test(version);
-}
-
 function resolveChannel({ channel = "", version }) {
   if (channel === "stable" || channel === "rc" || channel === "beta") {
     return channel;
@@ -81,37 +77,6 @@ function listReleaseTags() {
     .split("\n")
     .map((tag) => tag.trim())
     .filter(Boolean);
-}
-
-function parseStableCore(version) {
-  const match = /^(?<core>\d+\.\d+\.\d+)(?:-(?:rc|beta)\.\d+)?$/u.exec(version);
-  return match?.groups?.core ?? "";
-}
-
-function resolvePreviousTag({ channel, tag, version }) {
-  const tags = listReleaseTags().filter((candidate) => candidate !== tag);
-  if (channel === "stable") {
-    return (
-      tags.find(
-        (candidate) => !isPrereleaseVersion(normalizeVersion(candidate))
-      ) ?? ""
-    );
-  }
-
-  const stableCore = parseStableCore(version);
-  return (
-    tags.find((candidate) => {
-      const candidateVersion = normalizeVersion(candidate);
-      return (
-        candidateVersion.startsWith(`${stableCore}-${channel}.`) &&
-        isPrereleaseVersion(candidateVersion)
-      );
-    }) ??
-    tags.find(
-      (candidate) => !isPrereleaseVersion(normalizeVersion(candidate))
-    ) ??
-    ""
-  );
 }
 
 function resolveGitSha(target) {
@@ -384,7 +349,13 @@ async function buildReleaseSummary(options) {
   const targetCommit = resolveGitSha(target);
   const requestedCompareFrom = String(options.compareFrom ?? "").trim();
   const compareFrom =
-    requestedCompareFrom || resolvePreviousTag({ channel, tag, version });
+    requestedCompareFrom ||
+    resolvePreviousReleaseTag({
+      channel,
+      tag,
+      tags: listReleaseTags(),
+      version
+    });
   const collected = collectReleaseInput({ compareFrom, target });
   const baseInput = {
     channel,

--- a/apps/desktop/scripts/lib/githubReleaseBody.mjs
+++ b/apps/desktop/scripts/lib/githubReleaseBody.mjs
@@ -1,0 +1,92 @@
+const GITHUB_RELEASE_BODY_MAX_LENGTH = 125_000;
+const RELEASE_NOTES_TRUNCATION_NOTICE =
+  "> Additional generated release-note entries were omitted to stay within GitHub's 125,000-character limit.";
+
+function composeReleaseBody({
+  existingBody,
+  leadingSections,
+  trailingSections,
+  truncated
+}) {
+  const sections = [
+    ...leadingSections,
+    existingBody,
+    ...(truncated ? [RELEASE_NOTES_TRUNCATION_NOTICE] : []),
+    ...trailingSections
+  ]
+    .map((section) => section.trim())
+    .filter(Boolean);
+
+  return `${sections.join("\n\n")}\n`;
+}
+
+function truncateAtLineBoundary(body, maxLength) {
+  if (maxLength <= 0) {
+    return "";
+  }
+
+  const candidate = body.slice(0, maxLength).trimEnd();
+  if (candidate.length === body.trimEnd().length) {
+    return candidate;
+  }
+
+  const lastLineBreak = candidate.lastIndexOf("\n");
+  return lastLineBreak === -1
+    ? ""
+    : candidate.slice(0, lastLineBreak).trimEnd();
+}
+
+function buildLimitedGithubReleaseBody({
+  existingBody,
+  leadingSections = [],
+  maxLength = GITHUB_RELEASE_BODY_MAX_LENGTH,
+  trailingSections = []
+}) {
+  const normalizedExistingBody = existingBody.trim();
+  const fullBody = composeReleaseBody({
+    existingBody: normalizedExistingBody,
+    leadingSections,
+    trailingSections,
+    truncated: false
+  });
+  if (fullBody.length <= maxLength) {
+    return fullBody;
+  }
+
+  const fixedBody = composeReleaseBody({
+    existingBody: "",
+    leadingSections,
+    trailingSections,
+    truncated: true
+  });
+  if (fixedBody.length > maxLength) {
+    throw new Error(
+      `Managed GitHub Release sections exceed the ${maxLength}-character limit`
+    );
+  }
+
+  const retainedExistingBody = truncateAtLineBoundary(
+    normalizedExistingBody,
+    maxLength - fixedBody.length - 2
+  );
+  const limitedBody = composeReleaseBody({
+    existingBody: retainedExistingBody,
+    leadingSections,
+    trailingSections,
+    truncated: true
+  });
+
+  if (limitedBody.length > maxLength) {
+    throw new Error(
+      `GitHub Release body exceeds the ${maxLength}-character limit after truncation`
+    );
+  }
+  return limitedBody;
+}
+
+export {
+  GITHUB_RELEASE_BODY_MAX_LENGTH,
+  RELEASE_NOTES_TRUNCATION_NOTICE,
+  buildLimitedGithubReleaseBody,
+  truncateAtLineBoundary
+};

--- a/apps/desktop/scripts/lib/previousReleaseTag.mjs
+++ b/apps/desktop/scripts/lib/previousReleaseTag.mjs
@@ -1,0 +1,51 @@
+import { parseReleaseTag } from "./releaseConfig.mjs";
+
+function normalizeVersion(tag) {
+  return parseReleaseTag(tag) ?? tag.replace(/^v/u, "");
+}
+
+function isPrereleaseVersion(version) {
+  return /-[0-9A-Za-z.-]+$/u.test(version);
+}
+
+function parseStableCore(version) {
+  const match = /^(?<core>\d+\.\d+\.\d+)(?:-(?:rc|beta)\.\d+)?$/u.exec(version);
+  return match?.groups?.core ?? "";
+}
+
+function resolvePreviousReleaseTag({ channel, tag, tags, version }) {
+  const currentTagIndex = tags.indexOf(tag);
+  const candidates =
+    currentTagIndex === -1
+      ? tags.filter((candidate) => candidate !== tag)
+      : tags.slice(currentTagIndex + 1);
+  if (channel === "stable") {
+    return (
+      candidates.find(
+        (candidate) => !isPrereleaseVersion(normalizeVersion(candidate))
+      ) ?? ""
+    );
+  }
+
+  const stableCore = parseStableCore(version);
+  return (
+    candidates.find((candidate) => {
+      const candidateVersion = normalizeVersion(candidate);
+      return (
+        candidateVersion.startsWith(`${stableCore}-${channel}.`) &&
+        isPrereleaseVersion(candidateVersion)
+      );
+    }) ??
+    candidates.find(
+      (candidate) => !isPrereleaseVersion(normalizeVersion(candidate))
+    ) ??
+    ""
+  );
+}
+
+export {
+  isPrereleaseVersion,
+  normalizeVersion,
+  parseStableCore,
+  resolvePreviousReleaseTag
+};

--- a/apps/desktop/scripts/resolve-previous-release-tag.mjs
+++ b/apps/desktop/scripts/resolve-previous-release-tag.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+import { parseReleaseTag } from "./lib/releaseConfig.mjs";
+import { resolvePreviousReleaseTag } from "./lib/previousReleaseTag.mjs";
+
+function parseArgs(argv) {
+  const args = new Map();
+  for (let index = 2; index < argv.length; index += 1) {
+    const key = argv[index];
+    const next = argv[index + 1];
+    if (!key.startsWith("--") || !next || next.startsWith("--")) {
+      continue;
+    }
+    args.set(key.slice(2), next);
+    index += 1;
+  }
+  return args;
+}
+
+function requireValue(value, label) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) {
+    throw new Error(`${label} is required`);
+  }
+  return normalized;
+}
+
+function listReleaseTags() {
+  return execFileSync(
+    "git",
+    ["tag", "--list", "v*", "--sort=-version:refname"],
+    { encoding: "utf8" }
+  )
+    .split("\n")
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const channel = requireValue(
+    args.get("channel") ?? process.env.RELEASE_CHANNEL,
+    "channel"
+  );
+  const tag = requireValue(args.get("tag") ?? process.env.RELEASE_TAG, "tag");
+  const version = parseReleaseTag(tag);
+  if (!version) {
+    throw new Error(`Unsupported desktop release tag: ${tag}`);
+  }
+
+  process.stdout.write(
+    resolvePreviousReleaseTag({
+      channel,
+      tag,
+      tags: listReleaseTags(),
+      version
+    })
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/apps/desktop/scripts/upsert-release-download-links.mjs
+++ b/apps/desktop/scripts/upsert-release-download-links.mjs
@@ -3,6 +3,7 @@
 import { readdir, readFile, writeFile } from "node:fs/promises";
 import { basename } from "node:path";
 import { pathToFileURL } from "node:url";
+import { buildLimitedGithubReleaseBody } from "./lib/githubReleaseBody.mjs";
 
 const SECTION_START = "<!-- tutti-desktop-download-links:start -->";
 const SECTION_END = "<!-- tutti-desktop-download-links:end -->";
@@ -74,7 +75,7 @@ function buildUpdatedReleaseBody({
   const cleanedBody = removeManagedSection(existingBody);
 
   if (!releaseTag || !releaseAssetBaseUrl) {
-    return `${cleanedBody}\n`;
+    return buildLimitedGithubReleaseBody({ existingBody: cleanedBody });
   }
 
   const directDownloadLinks = resolveDesktopDownloadLinks(
@@ -84,18 +85,19 @@ function buildUpdatedReleaseBody({
   );
 
   if (directDownloadLinks.length === 0) {
-    return `${cleanedBody}\n`;
+    return buildLimitedGithubReleaseBody({ existingBody: cleanedBody });
   }
 
-  return [
-    cleanedBody,
-    "",
+  const downloadSection = [
     SECTION_START,
     "### Direct Downloads",
     ...directDownloadLinks,
-    SECTION_END,
-    ""
+    SECTION_END
   ].join("\n");
+  return buildLimitedGithubReleaseBody({
+    existingBody: cleanedBody,
+    trailingSections: [downloadSection]
+  });
 }
 
 async function main() {

--- a/apps/desktop/scripts/upsert-release-summary.mjs
+++ b/apps/desktop/scripts/upsert-release-summary.mjs
@@ -2,6 +2,7 @@
 
 import { readFile, writeFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
+import { buildLimitedGithubReleaseBody } from "./lib/githubReleaseBody.mjs";
 
 const SECTION_START = "<!-- tutti-desktop-release-summary:start -->";
 const SECTION_END = "<!-- tutti-desktop-release-summary:end -->";
@@ -57,9 +58,10 @@ function renderReleaseSummarySection(summary) {
 
 function buildUpdatedReleaseBody({ existingBody, summary }) {
   const cleanedBody = removeManagedSection(existingBody);
-  return [renderReleaseSummarySection(summary), "", cleanedBody, ""]
-    .join("\n")
-    .trimStart();
+  return buildLimitedGithubReleaseBody({
+    existingBody: cleanedBody,
+    leadingSections: [renderReleaseSummarySection(summary)]
+  });
 }
 
 async function main() {

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -318,6 +318,17 @@ The summary is used to:
 - enrich the Feishu release card with the Chinese summary when Feishu notification is enabled
 - update `changelog.json` for stable releases
 
+Before staging the Draft Release, generate GitHub's detailed release notes with
+an explicit comparison tag. RC and beta notes compare against the newest tag in
+the same version/channel series, falling back to the newest stable tag; stable
+notes compare against the newest stable tag. Do not rely on GitHub's implicit
+previous-release selection because RC and beta GitHub Releases remain drafts
+and therefore are not valid published-release comparison anchors.
+
+Managed summary and direct-download sections must be preserved when release
+notes approach GitHub's 125,000-character body limit. Trim only the generated
+detail entries and leave a visible truncation notice.
+
 Do not commit real model API keys. Configure `AGNES_API_KEY` as a GitHub secret.
 
 ## Required Secrets

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -27,6 +27,7 @@ Electron startup, daemon supervision, macOS packaging, updates, and performance 
 
 - [Packaged Tutti starts but external shells cannot find `tutti`](./desktop-release.md#packaged-tutti-starts-but-external-shells-cannot-find-tutti)
 - [Desktop stable release alias disappears or is not first on Releases](./desktop-release.md#desktop-stable-release-alias-disappears-or-is-not-first-on-releases)
+- [Desktop release notes exceed GitHub's body limit](./desktop-release.md#desktop-release-notes-exceed-githubs-body-limit)
 - [Desktop dev GUI exits before opening](./desktop-release.md#desktop-dev-gui-exits-before-opening)
 - [Running a development tuttid breaks the production Agent session](./desktop-release.md#running-a-development-tuttid-breaks-the-production-agent-session)
 - [macOS updates fail from a mounted DMG](./desktop-release.md#macos-updates-fail-from-a-mounted-dmg)

--- a/docs/conventions/troubleshooting/desktop-release.md
+++ b/docs/conventions/troubleshooting/desktop-release.md
@@ -77,6 +77,39 @@
   [.github/workflows/desktop-release.yml](../../../.github/workflows/desktop-release.yml)
   [desktop-release-config.test.mjs](../../../tools/scripts/desktop-release-config.test.mjs)
 
+### Desktop release notes exceed GitHub's body limit
+
+- Symptom:
+  All architecture builds and asset uploads succeed, but `Stage Release Draft`
+  fails in `Update release notes with summary` with HTTP 422 and
+  `body is too long (maximum is 125000 characters)`. Promotion and notification
+  jobs are then skipped.
+- Quick checks:
+  Inspect the failed step rather than rebuilding the installers. Run
+  `gh release view <tag> --json body --jq '.body | length'` and check whether
+  the generated `What's Changed` section contains repository-wide history.
+- Root cause:
+  GitHub's implicit release-note comparison selects published releases. Tutti
+  intentionally keeps RC and beta GitHub Releases as drafts, so the implicit
+  base can remain far behind and every prerelease accumulates the same old pull
+  requests until the Release body reaches GitHub's limit.
+- Fix:
+  Resolve the previous same-channel tag explicitly and pass it as
+  `softprops/action-gh-release`'s `previous_tag`. Keep the shared Release body
+  limiter as a fallback: it preserves managed summary and direct-download
+  sections and trims only generated detail entries. Re-running an old Actions
+  run still uses its original workflow revision; merge the workflow fix before
+  starting a new release, or repair the existing draft notes before manually
+  promoting that draft.
+- Validation:
+  Generate notes with the failing tag and its resolved previous tag and confirm
+  the body is bounded to that comparison range. Run
+  `node --test tools/scripts/desktop-release-summary.test.mjs tools/scripts/desktop-release-download-links.test.mjs tools/scripts/desktop-release-config.test.mjs`.
+- References:
+  [.github/workflows/desktop-release.yml](../../../.github/workflows/desktop-release.yml)
+  [resolve-previous-release-tag.mjs](../../../apps/desktop/scripts/resolve-previous-release-tag.mjs)
+  [githubReleaseBody.mjs](../../../apps/desktop/scripts/lib/githubReleaseBody.mjs)
+
 ### Desktop dev GUI exits before opening
 
 - Symptom:

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -188,6 +188,33 @@ test("desktop release workflow passes tsh-aligned Feishu card context", async ()
   assert.doesNotMatch(workflow, /RELEASE_ASSET_DIRECTORY:\s+release-assets/);
 });
 
+test("desktop release workflow scopes generated notes to the previous release tag", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+  const previousTagIndex = workflow.indexOf(
+    "name: Resolve previous GitHub release tag"
+  );
+  const stageIndex = workflow.indexOf("name: Stage GitHub release assets");
+
+  assert.notEqual(
+    previousTagIndex,
+    -1,
+    "the previous release tag should be resolved"
+  );
+  assert.ok(
+    previousTagIndex < stageIndex,
+    "the previous release tag should be resolved first"
+  );
+  assert.match(
+    workflow,
+    /node apps\/desktop\/scripts\/resolve-previous-release-tag\.mjs/
+  );
+  assert.match(workflow, /generate_release_notes:\s+true/);
+  assert.match(
+    workflow,
+    /previous_tag:\s+\${{\s*steps\.previous-release-tag\.outputs\.tag\s*}}/
+  );
+});
+
 test("desktop release workflow defaults Feishu notifications on outside manual dispatch", async () => {
   const workflow = await readFile(workflowPath, "utf8");
 

--- a/tools/scripts/desktop-release-download-links.test.mjs
+++ b/tools/scripts/desktop-release-download-links.test.mjs
@@ -2,6 +2,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  GITHUB_RELEASE_BODY_MAX_LENGTH,
+  RELEASE_NOTES_TRUNCATION_NOTICE
+} from "../../apps/desktop/scripts/lib/githubReleaseBody.mjs";
+import {
   SECTION_END,
   SECTION_START,
   buildUpdatedReleaseBody
@@ -92,4 +96,23 @@ test("desktop release notes remove the managed section when no mirrored base URL
   assert.doesNotMatch(nextBody, /Direct Downloads/);
   assert.doesNotMatch(nextBody, /old\.example/);
   assert.match(nextBody, /More text/);
+});
+
+test("desktop release notes preserve direct downloads while trimming oversized generated notes", () => {
+  const nextBody = buildUpdatedReleaseBody({
+    assetNames: ["Tutti-1.0.0-mac-universal.dmg"],
+    existingBody: Array.from(
+      { length: 2_000 },
+      (_, index) => `- generated note ${index}: ${"x".repeat(80)}`
+    ).join("\n"),
+    releaseAssetBaseUrl: "https://downloads.example.com/tutti",
+    releaseTag: "v1.0.0"
+  });
+
+  assert.ok(nextBody.length <= GITHUB_RELEASE_BODY_MAX_LENGTH);
+  assert.match(nextBody, /generated note 0:/);
+  assert.doesNotMatch(nextBody, /generated note 1999:/);
+  assert.match(nextBody, /### Direct Downloads/);
+  assert.match(nextBody, /Tutti-1\.0\.0-mac-universal\.dmg/);
+  assert.ok(nextBody.includes(RELEASE_NOTES_TRUNCATION_NOTICE));
 });

--- a/tools/scripts/desktop-release-summary.test.mjs
+++ b/tools/scripts/desktop-release-summary.test.mjs
@@ -9,6 +9,11 @@ import {
   resolveChannel
 } from "../../apps/desktop/scripts/generate-release-summary.mjs";
 import {
+  GITHUB_RELEASE_BODY_MAX_LENGTH,
+  RELEASE_NOTES_TRUNCATION_NOTICE
+} from "../../apps/desktop/scripts/lib/githubReleaseBody.mjs";
+import { resolvePreviousReleaseTag } from "../../apps/desktop/scripts/lib/previousReleaseTag.mjs";
+import {
   SECTION_END,
   SECTION_START,
   buildUpdatedReleaseBody
@@ -49,6 +54,28 @@ test("desktop release summary resolves channel from version shape", () => {
   assert.equal(resolveChannel({ version: "1.2.4" }), "stable");
   assert.equal(resolveChannel({ version: "1.2.4-rc.1" }), "rc");
   assert.equal(resolveChannel({ version: "1.2.4-beta.1" }), "beta");
+});
+
+test("GitHub release notes compare prereleases against the latest same-channel tag", () => {
+  const previousTag = resolvePreviousReleaseTag({
+    channel: "rc",
+    tag: "v0.2.2-rc.9",
+    tags: ["v0.2.2-rc.9", "v0.2.2-rc.8", "v0.2.2-beta.5", "v0.2.0"],
+    version: "0.2.2-rc.9"
+  });
+
+  assert.equal(previousTag, "v0.2.2-rc.8");
+});
+
+test("GitHub release notes fall back to the latest stable tag", () => {
+  const previousTag = resolvePreviousReleaseTag({
+    channel: "beta",
+    tag: "v0.3.0-beta.0",
+    tags: ["v0.3.0-beta.0", "v0.2.2-rc.8", "v0.2.1", "v0.2.0"],
+    version: "0.3.0-beta.0"
+  });
+
+  assert.equal(previousTag, "v0.2.1");
 });
 
 test("desktop release summary fallback emits zh and en sections", () => {
@@ -104,4 +131,29 @@ test("desktop release summary upserts a managed GitHub release section", () => {
   assert.doesNotMatch(nextBody, /Verify the download entry/);
   assert.match(nextBody, /Raw GitHub note/);
   assert.doesNotMatch(nextBody, /old summary/);
+});
+
+test("desktop release summary trims only generated notes at GitHub's body limit", () => {
+  const oversizedNotes = [
+    "## What's Changed",
+    ...Array.from(
+      { length: 2_000 },
+      (_, index) => `- generated note ${index}: ${"x".repeat(80)}`
+    )
+  ].join("\n");
+  const nextBody = buildUpdatedReleaseBody({
+    existingBody: oversizedNotes,
+    summary: {
+      en: {
+        headline: "A concise release summary.",
+        sections: [{ title: "Bug Fixes", items: ["Kept releases reliable."] }]
+      }
+    }
+  });
+
+  assert.ok(nextBody.length <= GITHUB_RELEASE_BODY_MAX_LENGTH);
+  assert.match(nextBody, /A concise release summary/);
+  assert.match(nextBody, /generated note 0:/);
+  assert.doesNotMatch(nextBody, /generated note 1999:/);
+  assert.ok(nextBody.includes(RELEASE_NOTES_TRUNCATION_NOTICE));
 });


### PR DESCRIPTION
## Summary

- resolve the previous same-channel desktop tag and pass it to `softprops/action-gh-release` through its native `previous_tag` input
- share the previous-tag resolver with release summary generation so detailed notes and summaries use the same comparison range
- bound GitHub Release bodies to 125,000 characters while preserving managed summary and direct-download sections
- document the release convention and the recurring HTTP 422 troubleshooting path

This fixes the failure in https://github.com/tutti-os/tutti/actions/runs/29760661586/job/88417857648, where all macOS builds and uploads succeeded but updating the Release body failed because implicit generated notes had grown beyond GitHub's limit.

For `v0.2.2-rc.9`, the resolver selects `v0.2.2-rc.8`; GitHub generates 1,147 characters for that scoped comparison instead of the existing 124,417-character repository-wide body.

## Verification

- `node --test tools/scripts/desktop-release-summary.test.mjs tools/scripts/desktop-release-download-links.test.mjs tools/scripts/desktop-release-config.test.mjs` — 47 passed
- `pnpm check:changed` — 7 lanes passed
- pre-push `pnpm check:changed -- --push-ready` — 8 lanes passed
- live GitHub generated-notes request for `v0.2.2-rc.8..v0.2.2-rc.9` — 1,147 characters across 13 lines

## Fix Scope Justification

- Root cause: the release workflow delegated comparison-base selection to GitHub, but RC and beta Releases intentionally remain drafts. GitHub therefore could not use them as published-release anchors and accumulated repository-wide pull-request history.
- Why can this not be fixed at a lower layer? The comparison base is release orchestration policy and must be supplied by the workflow. The shared body limiter is used by both managed Release-body upserts so neither the summary nor later direct-download insertion can cross GitHub's external limit.

## Fallback Three Questions

- Source: GitHub enforces a 125,000-character Release body limit, and a legitimately large scoped comparison can still approach it even after the comparison-base fix.
- Why can it not be fixed at that source? Tutti cannot change GitHub's limit or guarantee how much text GitHub's generated-notes API returns.
- Removal condition: remove the limiter if GitHub removes the body limit or its release API/action guarantees bounded generated notes while preserving managed sections.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (Not applicable.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (No README or CONTRIBUTING changes.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->