### PR TITLE
fix(release): freeze desktop release summaries

### DIFF
--- a/.github/workflows/desktop-release-promote.yml
+++ b/.github/workflows/desktop-release-promote.yml
@@ -32,8 +32,6 @@ on:
         description: Promoted GitHub release URL
         value: ${{ jobs.promote.outputs.release_url }}
     secrets:
-      AGNES_API_KEY:
-        required: false
       FEISHU_RELEASE_WEBHOOK_URL:
         required: false
   workflow_dispatch:
@@ -212,6 +210,7 @@ jobs:
       - name: Verify staged release assets
         run: |
           test -f release-assets/SHA256SUMS.txt
+          test -f release-assets/release-summary.json
           if ! grep -Eq "  .+\.(dmg|zip|exe|AppImage)$" release-assets/SHA256SUMS.txt; then
             echo "SHA256SUMS.txt does not contain an installable desktop artifact." >&2
             exit 1
@@ -220,6 +219,13 @@ jobs:
             cd release-assets
             sha256sum --check SHA256SUMS.txt
           )
+
+      - name: Validate staged release summary
+        env:
+          RELEASE_CHANNEL: ${{ env.TUTTI_DESKTOP_RELEASE_CHANNEL }}
+          RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
+          RELEASE_TARGET: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
+        run: node apps/desktop/scripts/validate-release-summary.mjs release-assets/release-summary.json
 
       - name: Install AWS CLI
         run: |
@@ -306,19 +312,11 @@ jobs:
             --size-only \
             --cache-control "public, max-age=31536000, immutable"
 
-      - name: Generate desktop release summary
-        env:
-          AGNES_API_KEY: ${{ secrets.AGNES_API_KEY }}
-          RELEASE_CHANNEL: ${{ env.TUTTI_DESKTOP_RELEASE_CHANNEL }}
-          RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
-          RELEASE_TARGET: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
-        run: node apps/desktop/scripts/generate-release-summary.mjs --output release-summary.json
-
       - name: Upload desktop release summary artifact
         uses: actions/upload-artifact@v7
         with:
           name: promoted-desktop-release-summary-${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
-          path: release-summary.json
+          path: release-assets/release-summary.json
 
       - name: Update release notes with summary and direct downloads
         env:
@@ -329,7 +327,7 @@ jobs:
           gh release view "${RELEASE_TAG}" --json body --jq .body > release-body.md
           node apps/desktop/scripts/upsert-release-summary.mjs \
             release-body.md \
-            release-summary.json \
+            release-assets/release-summary.json \
             release-body-with-summary.md
           node apps/desktop/scripts/upsert-release-download-links.mjs \
             release-body-with-summary.md \
@@ -362,7 +360,7 @@ jobs:
           fi
           node apps/desktop/scripts/upsert-release-changelog.mjs \
             existing-changelog.json \
-            release-summary.json \
+            release-assets/release-summary.json \
             changelog.json
           aws s3 cp changelog.json "${s3_root}/changelog.json" \
             --content-type "application/json" \

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -480,6 +480,23 @@ jobs:
             release-assets-input \
             release-assets
 
+      - name: Generate desktop release summary
+        env:
+          AGNES_API_KEY: ${{ secrets.AGNES_API_KEY }}
+          RELEASE_CHANNEL: ${{ needs.resolve.outputs.release_channel }}
+          RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
+          RELEASE_TARGET: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
+        run: |
+          node apps/desktop/scripts/generate-release-summary.mjs \
+            --output release-assets/release-summary.json
+
+      - name: Validate desktop release summary
+        env:
+          RELEASE_CHANNEL: ${{ needs.resolve.outputs.release_channel }}
+          RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
+          RELEASE_TARGET: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
+        run: node apps/desktop/scripts/validate-release-summary.mjs release-assets/release-summary.json
+
       - name: Generate checksums
         run: node apps/desktop/scripts/generate-checksums.mjs release-assets
 
@@ -556,21 +573,11 @@ jobs:
             --recursive \
             --cache-control "public, max-age=31536000, immutable"
 
-      - name: Generate desktop release summary
-        env:
-          AGNES_API_KEY: ${{ secrets.AGNES_API_KEY }}
-          RELEASE_CHANNEL: ${{ needs.resolve.outputs.release_channel }}
-          RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
-          RELEASE_TARGET: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
-        run: |
-          node apps/desktop/scripts/generate-release-summary.mjs \
-            --output release-summary.json
-
       - name: Upload desktop release summary artifact
         uses: actions/upload-artifact@v7
         with:
           name: tutti-desktop-release-summary
-          path: release-summary.json
+          path: release-assets/release-summary.json
 
       - name: Update release notes with summary
         env:
@@ -579,7 +586,7 @@ jobs:
           gh release view "${TUTTI_DESKTOP_RELEASE_TAG}" --json body --jq .body > release-body.md
           node apps/desktop/scripts/upsert-release-summary.mjs \
             release-body.md \
-            release-summary.json \
+            release-assets/release-summary.json \
             updated-release-body.md
           gh release edit "${TUTTI_DESKTOP_RELEASE_TAG}" --notes-file updated-release-body.md
 
@@ -594,7 +601,8 @@ jobs:
       expected_channel: ${{ needs.resolve.outputs.release_channel }}
       source_ref: ${{ github.ref_name }}
       notify_feishu: ${{ needs.resolve.outputs.notify_feishu == 'true' }}
-    secrets: inherit
+    secrets:
+      FEISHU_RELEASE_WEBHOOK_URL: ${{ secrets.FEISHU_RELEASE_WEBHOOK_URL }}
 
   notify-draft-feishu:
     name: Notify Draft Release

--- a/apps/desktop/scripts/validate-release-summary.mjs
+++ b/apps/desktop/scripts/validate-release-summary.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const schemaVersion = "tutti.desktop.release.summary.v1";
+const releaseTagPattern =
+  /^v(?<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?<channel>rc|beta)\.(?:0|[1-9]\d*))?)$/u;
+
+function requireNonEmptyString(value, label) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+}
+
+function validateLocale(locale, label) {
+  if (!locale || typeof locale !== "object" || Array.isArray(locale)) {
+    throw new Error(`${label} must be an object`);
+  }
+  requireNonEmptyString(locale.headline, `${label}.headline`);
+  if (!Array.isArray(locale.sections) || locale.sections.length === 0) {
+    throw new Error(`${label}.sections must be a non-empty array`);
+  }
+  for (const [sectionIndex, section] of locale.sections.entries()) {
+    requireNonEmptyString(
+      section?.title,
+      `${label}.sections[${sectionIndex}].title`
+    );
+    if (!Array.isArray(section?.items) || section.items.length === 0) {
+      throw new Error(
+        `${label}.sections[${sectionIndex}].items must be a non-empty array`
+      );
+    }
+    for (const [itemIndex, item] of section.items.entries()) {
+      requireNonEmptyString(
+        item,
+        `${label}.sections[${sectionIndex}].items[${itemIndex}]`
+      );
+    }
+  }
+  if (!Array.isArray(locale.qaFocus)) {
+    throw new Error(`${label}.qaFocus must be an array`);
+  }
+  for (const [itemIndex, item] of locale.qaFocus.entries()) {
+    requireNonEmptyString(item, `${label}.qaFocus[${itemIndex}]`);
+  }
+}
+
+function validateReleaseSummary(summary, expected = {}) {
+  if (!summary || typeof summary !== "object" || Array.isArray(summary)) {
+    throw new Error("release summary must be an object");
+  }
+  if (summary.schemaVersion !== schemaVersion) {
+    throw new Error(
+      `Unexpected release summary schema: ${summary.schemaVersion}`
+    );
+  }
+
+  const tagMatch = releaseTagPattern.exec(summary.tag);
+  if (!tagMatch?.groups) {
+    throw new Error(`Unsupported release summary tag: ${summary.tag}`);
+  }
+  const derivedChannel = tagMatch.groups.channel ?? "stable";
+  const derivedPrerelease = derivedChannel !== "stable";
+  if (summary.version !== tagMatch.groups.version) {
+    throw new Error("release summary version does not match its tag");
+  }
+  if (summary.channel !== derivedChannel) {
+    throw new Error("release summary channel does not match its tag");
+  }
+  if (summary.prerelease !== derivedPrerelease) {
+    throw new Error(
+      "release summary prerelease flag does not match its channel"
+    );
+  }
+
+  requireNonEmptyString(summary.targetCommit, "release summary targetCommit");
+  requireNonEmptyString(summary.generatedAt, "release summary generatedAt");
+  if (Number.isNaN(Date.parse(summary.generatedAt))) {
+    throw new Error("release summary generatedAt must be an ISO date-time");
+  }
+  if (
+    summary.summarySource !== "agnes" &&
+    summary.summarySource !== "fallback"
+  ) {
+    throw new Error("release summary summarySource must be agnes or fallback");
+  }
+  if (
+    !summary.compare ||
+    typeof summary.compare !== "object" ||
+    Array.isArray(summary.compare)
+  ) {
+    throw new Error("release summary compare must be an object");
+  }
+  if (
+    summary.compare.from !== null &&
+    typeof summary.compare.from !== "string"
+  ) {
+    throw new Error("release summary compare.from must be a string or null");
+  }
+  requireNonEmptyString(summary.compare.range, "release summary compare.range");
+  requireNonEmptyString(summary.compare.to, "release summary compare.to");
+  validateLocale(summary.zh, "release summary zh");
+  validateLocale(summary.en, "release summary en");
+
+  for (const [field, expectedValue] of Object.entries(expected)) {
+    if (expectedValue && summary[field] !== expectedValue) {
+      throw new Error(
+        `release summary ${field} does not match the staged release`
+      );
+    }
+  }
+  return summary;
+}
+
+async function main() {
+  const [summaryPath] = process.argv.slice(2);
+  if (!summaryPath) {
+    throw new Error("Usage: validate-release-summary.mjs <summary-json-path>");
+  }
+  const summary = JSON.parse(await readFile(summaryPath, "utf8"));
+  validateReleaseSummary(summary, {
+    tag: process.env.RELEASE_TAG,
+    channel: process.env.RELEASE_CHANNEL,
+    targetCommit: process.env.RELEASE_TARGET
+  });
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main().catch((error) => {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`
+    );
+    process.exit(1);
+  });
+}
+
+export { schemaVersion, validateReleaseSummary };

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -299,7 +299,7 @@ Promotion performs these checks before changing public state:
 - `SHA256SUMS.txt` exists and the downloaded draft assets match it
 - the target version does not move the selected public channel backwards
 
-It then repairs or uploads the immutable AWS objects, updates release notes, publishes a stable GitHub Release when applicable, writes the selected stable/RC/beta pointer, refreshes the stable alias, verifies the public CloudFront pointer, and sends the promoted release notification. Promotion is serialized with the `desktop-release-promotion` concurrency group because stable and prerelease pointers are mutable shared state.
+It then consumes the checksummed `release-summary.json` staged with the Draft Release, repairs or uploads the immutable AWS objects, updates release notes, publishes a stable GitHub Release when applicable, writes the selected stable/RC/beta pointer, refreshes the stable alias, verifies the public CloudFront pointer, and sends the promoted release notification. Promotion never regenerates the summary or calls the summary model. GitHub Draft assets remain mutable until promotion, so any restage or asset replacement invalidates the prior human approval and requires another review of the current `SHA256SUMS.txt`; cryptographic binding to an external approval record or immutable candidate ID is not implemented. Promotion is serialized with the `desktop-release-promotion` concurrency group because stable and prerelease pointers are mutable shared state.
 
 RC and beta promotions preserve the existing GitHub policy: their GitHub Releases remain drafts while their AWS channel pointers become available. Stable promotion changes the GitHub Release from draft to public and marks it Latest.
 
@@ -312,7 +312,11 @@ Summary generation is best-effort:
 - if `AGNES_API_KEY` is configured, the workflow asks Agnes to summarize commits and diff stats
 - if the key is missing, the API fails, or the response is invalid, the workflow falls back to a deterministic commit-based summary
 
-The summary is used to:
+The Stage job adds the summary to the Draft Release assets before generating
+`SHA256SUMS.txt`. The summary and installable archives are therefore in the
+same checksummed candidate set. Electron updater `.yml` and `.blockmap` files
+remain outside `SHA256SUMS.txt` under the existing checksum policy. The summary
+is used to:
 
 - upsert a managed English `Release Summary` section into the GitHub Release body
 - enrich the Feishu release card with the Chinese summary when Feishu notification is enabled

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -392,6 +392,37 @@ test("desktop release workflow generates summaries and stable changelog metadata
   );
 });
 
+test("desktop promotion consumes the checksummed summary staged with the draft", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+  const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
+
+  const summaryIndex = workflow.indexOf(
+    "name: Generate desktop release summary"
+  );
+  const validationIndex = workflow.indexOf(
+    "name: Validate desktop release summary"
+  );
+  const checksumIndex = workflow.indexOf("name: Generate checksums");
+  const draftIndex = workflow.indexOf("name: Stage GitHub release assets");
+  assert.notEqual(summaryIndex, -1);
+  assert.notEqual(validationIndex, -1);
+  assert.notEqual(checksumIndex, -1);
+  assert.notEqual(draftIndex, -1);
+  assert.ok(summaryIndex < validationIndex);
+  assert.ok(validationIndex < checksumIndex);
+  assert.ok(checksumIndex < draftIndex);
+  assert.match(workflow, /--output release-assets\/release-summary\.json/);
+  assert.match(
+    workflow,
+    /validate-release-summary\.mjs release-assets\/release-summary\.json/
+  );
+  assert.match(promoteWorkflow, /release-assets\/release-summary\.json/);
+  assert.doesNotMatch(
+    promoteWorkflow,
+    /Generate desktop release summary|secrets\.AGNES_API_KEY/
+  );
+});
+
 test("desktop release workflow keeps prereleases as drafts and reserves the public list for stable", async () => {
   const workflow = await readFile(workflowPath, "utf8");
   const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");

--- a/tools/scripts/desktop-release-summary.test.mjs
+++ b/tools/scripts/desktop-release-summary.test.mjs
@@ -18,6 +18,34 @@ import {
   SECTION_START,
   buildUpdatedReleaseBody
 } from "../../apps/desktop/scripts/upsert-release-summary.mjs";
+import { validateReleaseSummary } from "../../apps/desktop/scripts/validate-release-summary.mjs";
+
+function validReleaseSummary(overrides = {}) {
+  return {
+    schemaVersion: "tutti.desktop.release.summary.v1",
+    tag: "v1.2.4-rc.1",
+    version: "1.2.4-rc.1",
+    channel: "rc",
+    prerelease: true,
+    targetCommit: "0123456789abcdef",
+    compare: { from: "v1.2.4-rc.0", range: "v1.2.4-rc.0..HEAD", to: "HEAD" },
+    generatedAt: "2026-07-21T00:00:00.000Z",
+    summarySource: "fallback",
+    zh: {
+      headline: "本次版本优化发布流程。",
+      sections: [{ title: "发布与更新", items: ["验证候选版本。"] }],
+      qaFocus: ["验证更新。"]
+    },
+    en: {
+      headline: "This release improves the release flow.",
+      sections: [
+        { title: "Release and Updates", items: ["Validate the candidate."] }
+      ],
+      qaFocus: ["Verify updates."]
+    },
+    ...overrides
+  };
+}
 
 test("desktop release summary classifies commit messages for human sections", () => {
   assert.equal(
@@ -156,4 +184,27 @@ test("desktop release summary trims only generated notes at GitHub's body limit"
   assert.match(nextBody, /generated note 0:/);
   assert.doesNotMatch(nextBody, /generated note 1999:/);
   assert.ok(nextBody.includes(RELEASE_NOTES_TRUNCATION_NOTICE));
+});
+
+test("desktop release summary validator accepts a complete staged summary", () => {
+  const summary = validReleaseSummary();
+  assert.equal(
+    validateReleaseSummary(summary, {
+      tag: summary.tag,
+      channel: summary.channel,
+      targetCommit: summary.targetCommit
+    }),
+    summary
+  );
+});
+
+test("desktop release summary validator rejects inconsistent or incomplete summaries", () => {
+  assert.throws(
+    () => validateReleaseSummary(validReleaseSummary({ prerelease: false })),
+    /prerelease flag/
+  );
+  assert.throws(
+    () => validateReleaseSummary(validReleaseSummary({ en: { headline: "" } })),
+    /en.headline/
+  );
 });


### PR DESCRIPTION
## Summary
- generate the Tutti desktop release summary during Stage before checksums
- validate and freeze the summary with the GitHub Draft assets
- make Promotion consume the staged summary without calling Agnes again
- narrow reusable workflow secrets and document the mutable GitHub Draft boundary

## Validation
- desktop release protocol tests: 42 passed
- pnpm check:changed passed all 7 lanes after rebase
- workflow YAML parsing passed
- independent release review completed and findings fixed