### PR TITLE
fix(agent-activity): fence projection rebaselines

### DIFF
--- a/packages/agent/activity-replication/README.md
+++ b/packages/agent/activity-replication/README.md
@@ -40,4 +40,11 @@ or daemon to a consumer's module graph.
 Consumers should validate an ordered batch with `ValidateBatch`, preserve the
 original durable cursor for duplicate acknowledgements, count duplicate and
 stale mutations in `acceptedCount`, and use `SummarizeAcknowledgements` to
-produce the batch result.
+produce the batch result. `ProjectionEpoch` is an explicit rebaseline fence:
+when a cloud projection is destructively reset, its paired consumer release
+must increment the epoch. Clients then treat acknowledgement rows from an
+older epoch as untrusted and replay the canonical projection in dependency
+order before relying on cloud-derived features. The cloud sink must be deployed
+before clients that emit the new field; it rejects a different epoch rather
+than applying a partially compatible projection. This is an intentional
+fail-closed release fence, not a compatibility mode.

--- a/packages/agent/activity-replication/conformance/fixtures.go
+++ b/packages/agent/activity-replication/conformance/fixtures.go
@@ -225,7 +225,7 @@ func appliedAcknowledgements(mutations []activityreplication.Mutation, firstCurs
 }
 
 func batch(mutations ...activityreplication.Mutation) activityreplication.ChangeBatch {
-	return activityreplication.ChangeBatch{SchemaVersion: activityreplication.SchemaVersion, Mutations: mutations}
+	return activityreplication.ChangeBatch{SchemaVersion: activityreplication.SchemaVersion, ProjectionEpoch: activityreplication.ProjectionEpoch, Mutations: mutations}
 }
 
 func targetMutation(mutationID, transactionID string, updatedAt int64) activityreplication.Mutation {

--- a/packages/agent/activity-replication/types.go
+++ b/packages/agent/activity-replication/types.go
@@ -9,7 +9,11 @@ package activityreplication
 import "encoding/json"
 
 const (
-	SchemaVersion     = 1
+	SchemaVersion = 1
+	// ProjectionEpoch fences local acknowledgement state from a cloud
+	// projection that has been intentionally rebaselined. Increment it in the
+	// same release as any destructive cloud projection reset.
+	ProjectionEpoch   = 1
 	MaxBatchMutations = 500
 )
 
@@ -192,14 +196,16 @@ type Mutation struct {
 }
 
 type ChangeBatch struct {
-	SchemaVersion int        `json:"schemaVersion"`
-	Mutations     []Mutation `json:"mutations"`
+	SchemaVersion   int        `json:"schemaVersion"`
+	ProjectionEpoch int        `json:"projectionEpoch"`
+	Mutations       []Mutation `json:"mutations"`
 }
 
 // ApplyResult is the HTTP acknowledgement returned after a whole ordered
 // batch is accepted. Cursor is the greatest durable cursor observed while
 // applying the batch; stale no-ops do not create one.
 type ApplyResult struct {
-	AcceptedCount int    `json:"acceptedCount"`
-	Cursor        uint64 `json:"cursor"`
+	AcceptedCount   int    `json:"acceptedCount"`
+	Cursor          uint64 `json:"cursor"`
+	ProjectionEpoch int    `json:"projectionEpoch"`
 }


### PR DESCRIPTION
## Summary
- add an explicit projection epoch to the activity replication batch and acknowledgement contract
- define a fail-closed rebaseline fence for destructive cloud projection resets
- document the required cloud-sink-before-client release order

## Why
A reset cloud projection can lose agent targets and scopes while a desktop still trusts its local acknowledgements. The epoch makes those acknowledgements untrusted after a rebaseline so canonical targets are replayed before dependent sessions.

## Risks and rollout
This is intentionally a first-release, fail-closed contract. Deploy tsh-server with the matching epoch before desktop clients. After this package is released, tsh-server and TSH must upgrade the complete Tutti cohort atomically.

## Verification
GOTOOLCHAIN=go1.25.12 go test -count=1 ./packages/agent/activity-replication/...

## Follow-up
Downstream tsh-server and TSH PRs will follow the published Tutti release.