### PR TITLE
perf(agent-gui): trace layout regressions

### DIFF
--- a/.codex/skills/analyze-performance-traces/SKILL.md
+++ b/.codex/skills/analyze-performance-traces/SKILL.md
@@ -1,33 +1,28 @@
 ---
 name: analyze-performance-traces
-description: Analyze large Chrome, Chromium, Electron, React DevTools, or Perfetto-compatible JSON performance traces without loading the whole file into context; locate concrete source-level bottlenecks, explain trigger-to-layout/render chains, classify behavior-preserving versus user-observable optimizations, implement safe fixes when requested, and verify semantic equivalence. Use for trace files, dropped frames, long tasks, resize jank, render storms, layout thrashing, selector hot paths, interaction latency, or requests to identify exact code choke points from profiling evidence.
+description: Analyze Chrome, Chromium, Electron, React DevTools, or Perfetto-compatible JSON traces and audit user-reported profiling findings without loading large artifacts into context; prove trigger-to-render/layout chains, separate measured facts from source inference, find exact code choke points, classify forced layout and render fanout, implement semantically safe fixes, and verify behavior plus repository budgets. Use for trace files, reported profiling durations or call chains, dropped frames, long tasks, resize or scroll jank, render storms, layout thrashing, selector hot paths, interaction latency, or requests to locate exact source-level bottlenecks.
 ---
 
 # Analyze Performance Traces
 
-Turn a large trace into an evidence chain ending at concrete files, symbols, and lines. Optimize root causes only. Keep measured facts separate from inference.
+End with an evidence chain from trigger to exact source. Fix the earliest proven cause. Never turn an API name or an inclusive duration into a causal claim without checking execution context.
+
+## Choose the evidence mode
+
+State which mode applies before making findings:
+
+1. **Trace-backed**: a trace is supplied or discoverable. Durations, processes, threads, and event ordering may be reported from it.
+2. **Reported-finding audit**: the user supplies durations or a chain but not the artifact. Treat those details as leads. Confirm current source paths and trigger conditions; label the durations, thread, and invalidation scope unverified.
+3. **Source-only**: no trace-derived lead exists. Report hypotheses, not measured bottlenecks.
+
+Do not block a reported-finding audit merely because the original trace file is absent. If the user asks for safe implementation after the source chain is proven, proceed within authorization; require a comparable post-change trace before claiming millisecond or frame-rate improvement.
+
+If neither a trace nor a concrete lead exists, ask for the smallest reproducible capture unless the user explicitly wants source-only analysis.
 
 ## Start safely
 
-1. Read repository instructions and relevant architecture docs before interpreting ownership or editing.
-2. If no trace is supplied or discoverable, ask the user to capture the smallest reproducible desktop window. For this repository, have them launch Tutti with tracing enabled:
-
-   ```sh
-   TUTTI_ELECTRON_REMOTE_DEBUGGING_PORT=9223 \
-   TUTTI_ELECTRON_JS_FLAGS=--max-old-space-size=8192 \
-   VITE_TUTTI_WHY_DID_YOU_RENDER=0 \
-   make dev-gui
-   ```
-
-   Then have them reproduce the issue while recording from another terminal:
-
-   ```sh
-   pnpm trace:desktop -- --duration 15
-   ```
-
-   Ask for the generated `TuttiTrace-<timestamp>.json` path before trace-backed analysis. Do not invent trace findings while waiting. If the user explicitly wants source-only analysis, proceed but label conclusions as hypotheses without trace evidence.
-
-3. Inspect file size and envelope; never print or load a huge trace into model context:
+1. Read repository instructions, nearest area instructions, relevant architecture docs, current diff, and validation policy. Record Git baseline before editing.
+2. Discover trace artifacts without printing them wholesale. For each candidate:
 
    ```sh
    ls -lh TRACE.json
@@ -35,91 +30,163 @@ Turn a large trace into an evidence chain ending at concrete files, symbols, and
    tail -c 512 TRACE.json
    ```
 
-4. Run the bundled bounded-memory summarizer:
+3. Run the bundled bounded-memory summarizer:
 
    ```sh
    node <skill-dir>/scripts/summarize-trace TRACE.json --top 40 --min-ms 16
    ```
 
-5. Record whether the trace includes development-only profiling, React component tracks, source maps, screenshots, or multiple renderer processes. Treat profiler startup and instrumentation cost separately from product cost.
+4. Record trace revision/build, production versus development mode, profiling hooks, source maps, screenshots, React tracks, renderer count, and capture window. Separate profiler startup and instrumentation overhead from product work.
+5. Prefer a repository-owned performance runner when it reproduces the same interaction. List scenarios first; a convenient but different scenario is not proof. In this repository, inspect `docs/conventions/testing.md` and use `pnpm perf:agent-gui -- --list-scenarios` when relevant.
 
-## Build the evidence chain
+### Tutti manual capture
+
+When a new Desktop trace is required:
+
+```sh
+TUTTI_ELECTRON_REMOTE_DEBUGGING_PORT=9223 \
+TUTTI_ELECTRON_JS_FLAGS=--max-old-space-size=8192 \
+VITE_TUTTI_WHY_DID_YOU_RENDER=0 \
+make dev-gui
+```
+
+Then capture from another terminal:
+
+```sh
+pnpm trace:desktop -- --duration 15
+```
+
+## Build one evidence chain
 
 Work in this order:
 
-1. **Select process/thread**: use metadata to identify browser main, renderer main, compositor, workers, and GPU threads. Do not combine their durations.
-2. **Find symptoms**: quantify long tasks, worst interactions, dropped/begin frames, layout/style duration, scripting duration, and burst windows.
-3. **Correlate timestamps**: connect input/resize/timer events to state updates, React renders, style recalculation, layout, paint, and frame loss within the same window.
-4. **Measure fanout**: count repeated component events or DOM/layout objects. Express multiplicative patterns such as `34 sections × 67 parent updates = 2,278 renders`.
-5. **Map to source**: extract stack URLs/function names, then use `rg` to follow symbols through current source. If trace points to a bundle, use source maps, named component tracks, event handler names, or unique class names. Verify that current code matches the traced revision.
-6. **Inspect data cardinality**: use read-only DB/query inspection only when needed. Explain why an algorithm becomes hot using actual session/turn/item counts; remove local paths and personal data from durable output.
-7. **State one causal chain**: `trigger → state write → reference churn/computation → render fanout → DOM/style/layout → missed frame`.
+1. **Select process/thread**: identify browser main, renderer main, compositor, workers, and GPU threads. Never sum unrelated threads.
+2. **Select the window**: locate the interaction or burst containing the symptom. Quantify long tasks, layout/style, scripting, paint, frame signals, and repeated events only inside that window.
+3. **Correlate timestamps**: connect input, timer, stream, resize, or observer delivery to state updates, React commits, DOM mutation, style/layout, paint, and missed frames.
+4. **Measure fanout**: count repeated components, selectors, entities, DOM nodes, or geometry reads. Express multiplicative patterns such as `34 sections × 67 updates = 2,278 renders`.
+5. **Map to source**: use stack URLs, source maps, named React tracks, event handlers, class names, and unique strings. Follow symbols with `rg`. Verify current source still matches the traced revision.
+6. **Inspect cardinality**: use read-only DB/query inspection when scale explains the cost. Remove local paths, secrets, and personal data from durable output.
+7. **State the chain**:
 
-Do not rank functions only by inclusive time: nested trace events overlap and double-count. Report self time when available; otherwise label inclusive duration explicitly.
+   ```text
+   trigger → state/DOM write → churn or invalidation → render/layout fanout → paint/frame impact
+   ```
 
-## Recognize common root causes
+Keep measured facts, source-confirmed facts, and inference visibly separate. Do not rank nested events only by inclusive time; use self time when available or label duration inclusive.
 
-- Reducer recreates every entity during resize even when derived values are exactly equal.
-- Memoized child receives inline callbacks or objects, defeating referential equality.
-- Context provider publishes a fresh projection with unchanged rendered fields.
-- Selector scans/sorts all entities once per session, producing `O(S × (T + I))` work.
-- Layout read follows DOM mutation or repeats across a large subtree.
-- Development profiling or extension hooks create apparent long frames not present in production.
+## Audit forced layout precisely
 
-Prefer fixing the earliest proven cause. Do not hide upstream churn with broad leaf memoization when stable ownership/projection can be fixed at the producer.
+For every suspected geometry hotspot, record:
 
-## Classify optimization visibility
+| Field          | Question                                                                                          |
+| -------------- | ------------------------------------------------------------------------------------------------- |
+| Trigger        | What invokes it, and how often?                                                                   |
+| Invalidation   | Which DOM/style write may have dirtied layout first?                                              |
+| Read/operation | `scrollHeight`, `client*`, `offset*`, rect/style read, `scrollIntoView`, virtualizer measurement? |
+| Phase          | render, ref commit, layout effect, effect, observer, event, or animation frame?                   |
+| Scope          | Which scroll/layout subtree must become current?                                                  |
+| Semantics      | Why is the read needed: selection, bottom lock, prepend anchor, tooltip, placement?               |
+| Evidence       | Trace-backed, source-confirmed path, or inference?                                                |
 
-Treat an optimization as strictly behavior-preserving only when rendered values, ordering, event timing, focus, lock scope, mounted state, and side effects remain equivalent.
+Apply these rules:
+
+- A geometry API can force layout only when relevant layout is dirty. Its presence alone is not proof.
+- A layout effect after a DOM-heavy commit is high risk because the read occurs before paint while invalidation is pending.
+- `ResizeObserver` runs after layout calculation; a read-first callback usually consumes current geometry. Writes earlier in the same observer delivery can dirty layout again, so keep observer callbacks read-first, then write.
+- `requestAnimationFrame`, scroll events, and ordinary effects are not automatically layout-clean.
+- `scrollIntoView` performs synchronous visibility/scroll calculation. An explicit low-frequency reveal may still be correct and cheaper than changing interaction timing.
+- Replacing `scrollIntoView` with `offsetTop`, rect reads, or computed style does not inherently remove forced layout.
+- Distinguish **natural layout work** from **synchronously forced scheduling**. Observer-driven code may coalesce layout without eliminating the layout itself.
+- Do not claim “whole page/tree layout” without trace scope, layout-object evidence, or containment analysis.
+
+## Recognize root-cause families
+
+- Reducer recreates every entity when derived values are unchanged.
+- Memoized child receives fresh callbacks, arrays, objects, or context projections.
+- Selector scans/sorts all entities once per consumer, producing `O(S × (T + I))` work.
+- Streaming or resize commits trigger unconditional scroll-container geometry reads.
+- A measurement effect reads, writes state/style, then causes another render/layout pass.
+- The same resize is covered by both `ResizeObserver` and a global resize listener.
+- Virtualizer DOM writes are followed by parent scroll geometry reads in the same commit.
+- Development profiling, extensions, or source-map instrumentation dominate the apparent frame.
+
+Fix the earliest owner. Do not hide producer churn with broad leaf memoization or replace a proven geometry problem with timing heuristics.
+
+## Choose a fix without semantic drift
+
+### Data and render churn
+
+- Reuse references when every rendered/derived value is exactly equal.
+- Stabilize event-time callbacks without freezing stale reads.
+- Replace repeated scans with one-pass grouping while preserving filters, orphan rules, stable ordering, and tie-breakers.
+- Keep exact comparators in named helpers.
+- Avoid persistent indexes unless evidence proves ephemeral grouping insufficient.
+
+### DOM geometry and scrolling
+
+- Separate **semantic pre-paint commands** from **high-frequency content growth**. Conversation switches, explicit submit-to-bottom, focus, and prepend restoration may require layout-phase correction; ordinary streaming growth should not automatically share that path.
+- Before reading geometry, gate on the semantic branches that genuinely need it. A hot update that requires no scroll side effect should return before any geometry read.
+- For continuing content/viewport growth, prefer observing the actual content box and viewport. Consume geometry after layout while preserving bottom lock, user scroll-away, prepend anchors, and explicit reveal identity.
+- Expose a narrow content ref through the owning primitive when needed; avoid brittle queries into private DOM structure.
+- Remove a global resize listener only when element/parent observation covers the same geometry changes.
+- Preserve initial observer delivery and text/content-change remeasurement; observing a fixed outer box alone may miss intrinsic overflow changes unless observation is re-established or the measured node resizes.
+- Avoid CSS containment, `content-visibility`, or size containment around virtualized/dynamic-height content unless measurement, sticky, focus, overlay, and clipping behavior are proven equivalent.
+- Reuse an existing lifecycle effect/observer owner when repository budgets constrain effect count. Do not raise an architecture baseline to land an optimization.
+
+### Visibility classification
+
+Treat a change as strictly behavior-preserving only when rendered values, ordering, scroll/focus timing, lock ownership, mounted state, and side effects remain equivalent.
 
 Usually safe after exact tests:
 
-- Reuse entity/array references when every derived value is exactly equal.
-- Stabilize callbacks while preserving event-time reads and dependency semantics.
-- Replace repeated scans with one-pass grouping while preserving filtering, orphan rules, stable ordering, and tie-breakers.
-- Memoize a presentation projection using every field that affects its output.
-- Replace full sort for latest-item selection with the identical comparator and a one-pass maximum.
+- return before an unused geometry read;
+- consume observer-delivered geometry while preserving the same lock and anchor transitions;
+- remove a redundant event source with equivalent observation coverage;
+- reuse references or replace equivalent scans.
 
-Potentially user-observable; exclude or request approval:
+Potentially user-observable; exclude or request direction unless explicitly authorized:
 
-- Debounce, throttle, or move work to `requestAnimationFrame`.
-- Reduce animation/carousel frame rate.
-- Pause work using visibility/intersection heuristics.
-- Remove global interaction locks, focus behavior, autofocus, or layout reads.
-- Virtualize/unmount content, drop events, delay updates, or return stale cached values.
+- debounce, throttle, or move behavior to a later animation frame/effect;
+- IntersectionObserver visibility gating;
+- delayed reveal or autofocus;
+- always showing a tooltip instead of measuring overflow;
+- virtualization/unmounting, stale caching, event dropping, or reduced animation rate.
 
-When unsure, classify as observable.
+## Implement with direct performance tests
 
-## Implement without semantic drift
-
-1. Preserve existing architecture and module ownership.
-2. Add identity tests for structural sharing and output tests for selector ordering/filtering.
-3. Keep exact comparators in named helpers so old and optimized paths cannot diverge.
-4. Avoid new persistent indexes unless evidence shows ephemeral one-pass grouping is insufficient; persistent indexes expand reducer/state migration surface.
-5. Do not add compatibility, fallback, cache, or timing layers without evidence.
-6. Run formatter, targeted tests, typecheck/lint, architecture budgets, then changed-aware checks required by the repository.
-
-If asked only to analyze, stop before editing. If asked to optimize, implement only the authorized visibility class.
+1. Preserve architecture and local ownership. Do not add compatibility, fallback, or timing layers without evidence.
+2. Add tests that expose both semantics and the expensive operation:
+   - spy on geometry getters; after stable mount, a hot streaming rerender should perform zero synchronous reads when no semantic scroll command exists;
+   - mock `ResizeObserver`, deliver it explicitly, and verify bottom lock plus user scroll-away;
+   - verify prepend, selection, focus, reveal revision, tooltip overflow, and native/custom primitive variants affected by the change;
+   - add structural-sharing identity tests for render-churn fixes.
+3. Scan sibling callsites by mechanism, not API string alone. Classify each as confirmed same trigger, structurally similar but different frequency/semantics, or unverified.
+4. Run formatter and focused tests while iterating. Inspect the repository's changed-aware dry-run before the final gate.
+5. Run architecture budgets/boundaries. If a metric increases, redesign or merge ownership; never raise the baseline merely to pass.
+6. Run the repository-selected final validation once the diff settles. Perform the documentation-impact and durable-lesson check.
 
 ## Validate and report
 
 Validate at three levels:
 
-- **Semantic**: same values, sort order, filters, lock transitions, focus, and event behavior.
-- **Structural**: unchanged values retain references; changed entities still receive new references.
-- **Performance**: complexity reduction or rerender containment is proven; recapture a comparable trace when practical.
+- **Semantic**: identical values, ordering, filtering, focus, scroll lock, reveal, prepend, and event behavior.
+- **Structural**: stable references, bounded render fanout, and no new duplicate effect/observer owner.
+- **Performance**: prevented hot-path reads/renders proven by tests; comparable trace when practical.
 
 Report:
 
-1. Trace facts with counts/durations and process/thread.
-2. Concrete source locations and causal chain.
-3. Fixes grouped by strictly invisible versus potentially observable.
-4. Validation commands/results.
-5. What remains unverified, especially when no post-fix trace was captured.
-6. Any implementation-plan changes and documentation impact required by repository rules.
+1. evidence mode and process/thread/window facts;
+2. exact source chain and trigger frequency;
+3. measured facts versus source inference;
+4. fixes grouped by behavior-preserving versus timing-sensitive;
+5. implementation-plan changes caused by gates or counter-evidence;
+6. tests, typechecks, boundaries, and changed-aware result;
+7. same-mechanism sweep: included, excluded, and why;
+8. documentation impact and line-count distribution when code changed;
+9. anything unverified, especially missing post-change trace.
 
-Never claim millisecond or frame-rate improvement without a comparable post-change measurement. Complexity reduction and prevented rerenders may be stated as such.
+Never claim millisecond, frame-rate, or layout-scope improvement without a comparable post-change capture. It is valid to claim a proven reduction such as “ordinary streaming rerender performs zero synchronous `scrollHeight` reads.”
 
 ## Bundled script
 
-`scripts/summarize-trace` streams `traceEvents`, keeps bounded top-event state, and outputs JSON containing thread metadata, event totals, long tasks, frame signals, and source hints. Use it for the first pass; write narrow follow-up scripts only after a specific hypothesis exists.
+`scripts/summarize-trace` streams `traceEvents`, keeps bounded top-event state, and outputs JSON with thread metadata, event totals, long tasks, frame signals, and source hints. Use it first for large traces; write narrow follow-up scripts only after a specific hypothesis exists.

--- a/.codex/skills/analyze-performance-traces/agents/openai.yaml
+++ b/.codex/skills/analyze-performance-traces/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Analyze Performance Traces"
-  short_description: "Find code hotspots in large Chromium traces"
-  default_prompt: "Use $analyze-performance-traces to locate concrete code hotspots in this performance trace and propose behavior-preserving optimizations."
+  short_description: "Trace renderer jank to exact source paths"
+  default_prompt: "Use $analyze-performance-traces to audit this trace or reported performance chain, locate exact source bottlenecks, and propose semantically safe fixes."

--- a/apps/desktop/src/main/defaults.test.ts
+++ b/apps/desktop/src/main/defaults.test.ts
@@ -7,6 +7,7 @@ import {
   resolveDesktopLoginCallbackUrl,
   resolveDesktopLoginProtocolClientRegistration,
   resolveDesktopLoginProtocolScheme,
+  resolveDesktopPerformanceHeadless,
   resolveDesktopUserDataPath,
   resolveTuttiEnv
 } from "./defaults.ts";
@@ -199,6 +200,24 @@ test("resolveDesktopDevelopmentAppName isolates development single-instance iden
 
     process.env.TUTTI_ENV = "production";
     assert.equal(resolveDesktopDevelopmentAppName("Tutti"), null);
+  } finally {
+    restoreEnv(previousEnv);
+  }
+});
+
+test("resolveDesktopPerformanceHeadless is limited to explicit development diagnostics", () => {
+  const previousEnv = { ...process.env };
+
+  try {
+    process.env.TUTTI_ENV = "development";
+    delete process.env.TUTTI_DESKTOP_PERFORMANCE_HEADLESS;
+    assert.equal(resolveDesktopPerformanceHeadless(), false);
+
+    process.env.TUTTI_DESKTOP_PERFORMANCE_HEADLESS = "1";
+    assert.equal(resolveDesktopPerformanceHeadless(), true);
+
+    process.env.TUTTI_ENV = "production";
+    assert.equal(resolveDesktopPerformanceHeadless(), false);
   } finally {
     restoreEnv(previousEnv);
   }

--- a/apps/desktop/src/main/defaults.ts
+++ b/apps/desktop/src/main/defaults.ts
@@ -75,6 +75,13 @@ export function resolveDesktopDevelopmentAppName(
   return `${safeAppName} Dev`;
 }
 
+export function resolveDesktopPerformanceHeadless(): boolean {
+  return (
+    resolveTuttiEnv() === "development" &&
+    process.env.TUTTI_DESKTOP_PERFORMANCE_HEADLESS?.trim() === "1"
+  );
+}
+
 export function resolveDesktopLoginProtocolScheme(): "tutti" | "tutti-dev" {
   return resolveTuttiEnv() === "development" ? "tutti-dev" : "tutti";
 }

--- a/apps/desktop/src/main/host/workspaceLaunchDesktopAdapters.test.ts
+++ b/apps/desktop/src/main/host/workspaceLaunchDesktopAdapters.test.ts
@@ -15,6 +15,7 @@ test("workspace window readiness handles ready-to-show emitted during load start
 
   assert.equal(target.maximizeCount, 1);
   assert.equal(target.showCount, 1);
+  assert.equal(target.showInactiveCount, 0);
 });
 
 test("workspace window readiness rejects failed loads emitted during load start", async () => {
@@ -71,11 +72,28 @@ test("workspace window readiness can keep a background Browser host hidden", asy
   assert.equal(target.showCount, 0);
 });
 
+test("workspace window readiness can render without activating a visible window", async () => {
+  const target = createWorkspaceWindowReadyTarget();
+
+  await awaitWorkspaceWindowReady(
+    target.window,
+    () => {
+      target.emit("ready-to-show");
+    },
+    { showInactive: true }
+  );
+
+  assert.equal(target.maximizeCount, 1);
+  assert.equal(target.showCount, 0);
+  assert.equal(target.showInactiveCount, 1);
+});
+
 interface WorkspaceWindowReadyTargetFixture {
   closeCount: number;
   emit: (event: string, ...args: unknown[]) => void;
   maximizeCount: number;
   showCount: number;
+  showInactiveCount: number;
   window: WorkspaceWindowReadyTarget;
 }
 
@@ -86,6 +104,7 @@ function createWorkspaceWindowReadyTarget(): WorkspaceWindowReadyTargetFixture {
     closeCount: 0,
     maximizeCount: 0,
     showCount: 0,
+    showInactiveCount: 0,
     window: {
       close() {
         fixture.closeCount += 1;
@@ -109,6 +128,9 @@ function createWorkspaceWindowReadyTarget(): WorkspaceWindowReadyTargetFixture {
       },
       show() {
         fixture.showCount += 1;
+      },
+      showInactive() {
+        fixture.showInactiveCount += 1;
       },
       webContents: {
         isDestroyed() {

--- a/apps/desktop/src/main/host/workspaceLaunchDesktopAdapters.ts
+++ b/apps/desktop/src/main/host/workspaceLaunchDesktopAdapters.ts
@@ -19,6 +19,7 @@ import {
 import { awaitWorkspaceWindowReady } from "./workspaceWindowReady.ts";
 import type { WorkspaceLaunchWindowKind } from "./workspaceLaunchMode.ts";
 import { createDurableWorkspaceWindowCoordinator } from "./durableWorkspaceWindowCoordinator.ts";
+import { resolveDesktopPerformanceHeadless } from "../defaults.ts";
 
 export interface WorkspaceLaunchDesktopAdapterOptions {
   browserNodeGuestPreloadPath?: string;
@@ -36,8 +37,10 @@ export function createWorkspaceLaunchDesktopAdapters(
   options: WorkspaceLaunchDesktopAdapterOptions
 ): WorkspaceLaunchAdapters {
   const pendingAgentBrowserHosts = new Map<string, Promise<void>>();
+  const performanceHeadless = resolveDesktopPerformanceHeadless();
   const durableWorkspaceWindows = createDurableWorkspaceWindowCoordinator({
-    activate: activateWorkspaceWindow,
+    activate: (workspaceWindow) =>
+      activateWorkspaceWindow(workspaceWindow, performanceHeadless),
     find: (workspaceID: string) =>
       findWorkspaceWindow(workspaceID, "workspace"),
     open: (workspaceID: string) =>
@@ -97,28 +100,39 @@ async function createAndShowWorkspaceWindow(
     workspaceAppPreloadPath: options.workspaceAppPreloadPath,
     workspaceID
   });
-  await awaitWorkspaceWindowReady(workspaceWindow, () => {
-    loadWorkspaceWindowContent(workspaceWindow, {
-      dockPlacement: options.getDockPlacement(),
-      locale: options.getLocale(),
-      rendererUrl: options.rendererUrl,
-      theme: options.getTheme(),
-      workspaceID
-    });
-  });
+  await awaitWorkspaceWindowReady(
+    workspaceWindow,
+    () => {
+      loadWorkspaceWindowContent(workspaceWindow, {
+        dockPlacement: options.getDockPlacement(),
+        locale: options.getLocale(),
+        rendererUrl: options.rendererUrl,
+        theme: options.getTheme(),
+        workspaceID
+      });
+    },
+    { showInactive: resolveDesktopPerformanceHeadless() }
+  );
   return workspaceWindow;
 }
 
 function activateWorkspaceWindow(
-  workspaceWindow: Electron.BrowserWindow
+  workspaceWindow: Electron.BrowserWindow,
+  performanceHeadless: boolean
 ): void {
   if (workspaceWindow.isMinimized()) {
     workspaceWindow.restore();
   }
   if (!workspaceWindow.isVisible()) {
-    workspaceWindow.show();
+    if (performanceHeadless) {
+      workspaceWindow.showInactive();
+    } else {
+      workspaceWindow.show();
+    }
   }
-  workspaceWindow.focus();
+  if (!performanceHeadless) {
+    workspaceWindow.focus();
+  }
 }
 
 async function showStandaloneAgentWindow(
@@ -160,7 +174,11 @@ async function showStandaloneAgentWindow(
         workspaceID: input.workspaceID
       });
     },
-    { maximizeOnShow: false, showOnReady: readyOptions.showOnReady }
+    {
+      maximizeOnShow: false,
+      showOnReady: readyOptions.showOnReady,
+      showInactive: resolveDesktopPerformanceHeadless()
+    }
   );
   return agentWindow;
 }

--- a/apps/desktop/src/main/host/workspaceWindowReady.ts
+++ b/apps/desktop/src/main/host/workspaceWindowReady.ts
@@ -11,6 +11,7 @@ export interface WorkspaceWindowReadyTarget {
     listener: WorkspaceWindowReadyListener
   ): unknown;
   show(): void;
+  showInactive(): void;
   webContents: {
     isDestroyed(): boolean;
     once(event: string, listener: WorkspaceWindowReadyListener): unknown;
@@ -24,6 +25,7 @@ export interface WorkspaceWindowReadyTarget {
 export interface AwaitWorkspaceWindowReadyOptions {
   maximizeOnShow?: boolean;
   showOnReady?: boolean;
+  showInactive?: boolean;
 }
 
 export async function awaitWorkspaceWindowReady(
@@ -65,7 +67,11 @@ export async function awaitWorkspaceWindowReady(
           if (options.maximizeOnShow !== false) {
             window.maximize();
           }
-          window.show();
+          if (options.showInactive) {
+            window.showInactive();
+          } else {
+            window.show();
+          }
         }
         resolve();
       });
@@ -77,7 +83,11 @@ export async function awaitWorkspaceWindowReady(
           if (options.maximizeOnShow !== false) {
             window.maximize();
           }
-          window.show();
+          if (options.showInactive) {
+            window.showInactive();
+          } else {
+            window.show();
+          }
         }
         resolve();
       });

--- a/apps/desktop/src/main/windows/workspaceWindow.ts
+++ b/apps/desktop/src/main/windows/workspaceWindow.ts
@@ -9,6 +9,7 @@ import { registerBrowserGuestWebContents } from "../browser/browserGuestRegistry
 import { registerTuttiAssetProtocolForSession } from "../host/tuttiAssetProtocol.ts";
 import { registerWorkspaceAppGuestWebContents } from "../ipc/workspaceAppContext";
 import { resolveDesktopWindowBackgroundColor } from "../desktopTheme";
+import { resolveDesktopPerformanceHeadless } from "../defaults.ts";
 import { getDesktopLogger } from "../logging";
 import type { DesktopLocale } from "../../shared/i18n";
 import type { DesktopDockPlacement } from "../../shared/preferences/index.ts";
@@ -86,6 +87,7 @@ export function createWorkspaceWindow(
   options: CreateWorkspaceWindowOptions
 ): BrowserWindow {
   const logger = getDesktopLogger();
+  const performanceHeadless = resolveDesktopPerformanceHeadless();
   const windowKind = options.windowKind ?? "workspace";
   if (windowKind === "workspace") {
     workspaceWindows.assertDurableWorkspaceAvailable(options.workspaceID);
@@ -133,6 +135,7 @@ export function createWorkspaceWindow(
     height: agentWindowBounds?.height ?? 840,
     minWidth: windowKind === "agent" ? agentWindowMinWidthPx : 960,
     minHeight: windowKind === "agent" ? agentWindowMinHeightPx : 640,
+    ...(performanceHeadless ? { opacity: 0, skipTaskbar: true } : {}),
     ...(agentWindowBounds
       ? {
           x: agentWindowBounds.x,
@@ -150,6 +153,7 @@ export function createWorkspaceWindow(
         }
       : {}),
     webPreferences: {
+      backgroundThrottling: !performanceHeadless,
       contextIsolation: true,
       nodeIntegration: false,
       preload: options.preloadPath,
@@ -157,6 +161,10 @@ export function createWorkspaceWindow(
       webviewTag: true
     }
   });
+  if (performanceHeadless) {
+    workspaceWindow.setFocusable(false);
+    workspaceWindow.setIgnoreMouseEvents(true);
+  }
   reportPredefinePageviewByWindow.set(
     workspaceWindow,
     primaryWindowAnalyticsClaim.claim()

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -272,6 +272,8 @@ A focused controller may own detail paging/loading/error. Canonical messages, Tu
 
 Timeline projection is pure, deterministic, and provider-neutral. React views render rows/cards and dispatch actions.
 
+High-frequency transcript updates must not pair DOM mutation with unconditional synchronous reads of the timeline's full scroll geometry. Conversation switches, explicit submit-to-bottom requests, skeleton transitions, and older-page prepend restoration may perform pre-paint scroll correction; ordinary content growth preserves bottom lock and user scroll-away state from observed content and viewport geometry after layout.
+
 ## 5. Agent identity and provider architecture
 
 ### 5.1 `agentTargetId` is UI identity

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -83,7 +83,14 @@ without requiring a manually started Desktop or manually exported trace. It
 makes a transactionally consistent SQLite backup of
 `~/.tutti-dev/tuttid.db`, clears recoverable operation queues and active AgentGUI
 session selection only in that copy, then starts an isolated daemon and
-Electron `userData` directory. The source database is never opened for writes.
+Electron `userData` directory. The source database is never written; the
+SQLite source connection enables `query_only` before online backup.
+The runner also sets `TUTTI_DESKTOP_PERFORMANCE_HEADLESS=1`; workspace and
+standalone Agent windows remain fully rendered for CDP tracing but use zero
+opacity, stay out of the taskbar, disable background throttling, and never
+activate over the developer's current app. They are also non-focusable and
+ignore native mouse events, so pointer input passes through to the underlying
+application; CDP-injected scenario input remains available.
 
 Reports and traces are written under
 `.tmp/perf/agent-gui/<scenario>/<timestamp>/`. Metric values are
@@ -100,11 +107,24 @@ declaration when static symbol matching succeeds. Those links identify source
 ownership, not a runtime call stack or proof of causation.
 
 The capture runner ships `provider-switch`, `session-switch`,
-`provider-session-cycle`, `workbench-window-lifecycle`, and
+`provider-session-cycle`, `virtualized-streaming`, `rail-scope-reveal`,
+`composer-overflow-resize`, `workbench-window-lifecycle`, and
 `desktop-window-state`. List them with `--list-scenarios`; select one with
 `--scenario <id>`. Scenario modules own preparation, completion conditions,
 semantic assertions, milestones, and metadata; runtime startup, trace capture,
 renderer analysis, and report rendering stay scenario-neutral.
+
+`virtualized-streaming` requires one root Session with at least thirty settled
+Turns in the source snapshot. It changes only the isolated copy to route that
+Session through the repository's deterministic fake Cursor ACP executable,
+then asserts that the transcript is virtualized while real daemon events drive
+repeated React DOM mutations. It never launches or sends input to a developer's
+installed Agent provider. `rail-scope-reveal` asserts the exact active-row
+`scrollIntoView` call during a fresh Agent scope restore.
+`composer-overflow-resize` maximizes the AgentGUI Workbench node, narrows the
+renderer viewport, asserts the hero prompt-tip's native `scrollWidth` and
+`clientWidth` getters were read after resize, then restores the original
+viewport metrics.
 
 `workbench-window-lifecycle` measures the internal AgentGUI Workbench node's
 minimize, restore, maximize, unmaximize, close, and reopen mechanics.

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.spec.tsx
@@ -1,0 +1,95 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useComposerLayout } from "./useComposerLayout";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("useComposerLayout", () => {
+  it("measures prompt-tip overflow only after ResizeObserver delivers layout", () => {
+    const resizeObservers: ResizeObserverMock[] = [];
+    class ResizeObserverMock implements ResizeObserver {
+      constructor(readonly callback: ResizeObserverCallback) {
+        resizeObservers.push(this);
+      }
+
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    }
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    const promptTip = document.createElement("span");
+    const promptTipParent = document.createElement("div");
+    promptTipParent.appendChild(promptTip);
+    const scrollWidth = vi
+      .spyOn(promptTip, "scrollWidth", "get")
+      .mockReturnValue(160);
+    const clientWidth = vi
+      .spyOn(promptTip, "clientWidth", "get")
+      .mockReturnValue(120);
+    const setIsPromptTipOverflowing = vi.fn();
+
+    renderHook(() =>
+      useComposerLayout({
+        isHeroLayout: true,
+        inputDisabled: false,
+        paletteDraftPrompt: "",
+        showFileMentionPalette: false,
+        showFloatingCommandMenu: false,
+        previewMode: false,
+        promptTips: [{ id: "tip-1", label: "Label", prompt: "Prompt" }],
+        promptTipsPrefix: "Tip: ",
+        composerSettings: {
+          sessionSettings: null,
+          draftSettings: {
+            model: null,
+            reasoningEffort: null,
+            speed: null,
+            planMode: false
+          },
+          supportsModel: false,
+          supportsReasoningEffort: false,
+          supportsSpeed: false,
+          supportsPlanMode: false,
+          isSettingsLoading: false,
+          modelUnavailable: false,
+          reasoningUnavailable: false,
+          speedUnavailable: false,
+          availableModels: [],
+          availableReasoningEfforts: [],
+          availableSpeeds: [],
+          projectLocked: false,
+          projectPathIsRemote: false
+        },
+        selectedProjectPath: "",
+        promptTipRef: { current: promptTip },
+        promptInputAreaRef: { current: null },
+        setIsPromptTipOverflowing,
+        dockComposerInputHeight: 56,
+        setDockComposerInputHeight: vi.fn(),
+        dockComposerInputMaxHeight: 110,
+        setDockComposerInputMaxHeight: vi.fn(),
+        dockComposerAttachmentHeight: 0,
+        setDockComposerAttachmentHeight: vi.fn(),
+        dockComposerTextHeight: 56,
+        setDockComposerTextHeight: vi.fn(),
+        draftImages: [],
+        draftLargeTexts: []
+      })
+    );
+
+    expect(scrollWidth).not.toHaveBeenCalled();
+    expect(clientWidth).not.toHaveBeenCalled();
+    expect(resizeObservers).toHaveLength(1);
+
+    act(() => {
+      resizeObservers[0]?.callback([], resizeObservers[0]);
+    });
+
+    expect(scrollWidth).toHaveBeenCalledTimes(1);
+    expect(clientWidth).toHaveBeenCalledTimes(1);
+    expect(setIsPromptTipOverflowing).toHaveBeenLastCalledWith(true);
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.ts
@@ -137,7 +137,6 @@ export function useComposerLayout({
       setIsPromptTipOverflowing(hasInlineOverflow(element));
     };
 
-    measure();
     const resizeObserver =
       typeof ResizeObserver === "undefined"
         ? null
@@ -146,10 +145,8 @@ export function useComposerLayout({
     if (element.parentElement) {
       resizeObserver?.observe(element.parentElement);
     }
-    window.addEventListener("resize", measure);
     return () => {
       resizeObserver?.disconnect();
-      window.removeEventListener("resize", measure);
     };
   }, [activePromptTipId, activePromptTipText, previewMode]);
   useLayoutEffect(() => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -184,6 +184,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
 }: AgentGUIDetailPaneProps): React.JSX.Element {
   "use memo";
   const timelineRef = useRef<HTMLDivElement | null>(null);
+  const timelineContentRef = useRef<HTMLDivElement | null>(null);
   const bottomDockRef = useRef<HTMLDivElement | null>(null);
   const timelineScrollAnchorRef = useRef<{
     conversationId: string;
@@ -616,6 +617,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     showTimelineSkeleton,
     submittedPromptScrollConversationRef,
     timelineConversationId,
+    timelineContentRef,
     timelineRef,
     timelineScrollAnchorRef,
     viewModel
@@ -638,6 +640,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
         scrollbarMode="native"
         className="flex h-full min-h-0 flex-1 flex-col [&_[data-orientation=vertical][data-slot=scroll-area-scrollbar]]:opacity-100"
         viewportRef={timelineRef}
+        viewportContentRef={timelineContentRef}
         viewportTestId="agent-gui-timeline"
         viewportClassName={`${styles.timeline} ${
           hasActiveConversation

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx
@@ -1,12 +1,14 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MutableRefObject, RefObject } from "react";
+import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
 import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
 import type { AgentGUINodeViewProps } from "../AgentGUINodeView";
 import { useAgentGUIDetailScroll } from "./useAgentGUIDetailScroll";
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("useAgentGUIDetailScroll", () => {
@@ -159,6 +161,85 @@ describe("useAgentGUIDetailScroll", () => {
     expect(harness.timeline.scrollTop).toBe(4_000);
   });
 
+  it("does not synchronously read timeline geometry for a streaming update", () => {
+    const harness = createHarness({ scrollHeight: 5_000 });
+    const { rerender } = renderHook(
+      ({ conversation }) =>
+        useAgentGUIDetailScroll(
+          harness.input({
+            activeConversationId: "conversation-streaming",
+            conversation,
+            showTimelineSkeleton: false
+          })
+        ),
+      { initialProps: { conversation: conversationVM("first") } }
+    );
+    harness.resetGeometryReadCounts();
+
+    rerender({ conversation: conversationVM("second") });
+
+    expect(harness.geometryReadCounts()).toEqual({
+      clientHeight: 0,
+      scrollHeight: 0,
+      scrollTop: 0
+    });
+  });
+
+  it("keeps the bottom lock through observed streaming content growth", () => {
+    const resizeObservers = installResizeObserverMock();
+    const harness = createHarness({ scrollHeight: 5_000 });
+
+    renderHook(() =>
+      useAgentGUIDetailScroll(
+        harness.input({
+          activeConversationId: "conversation-observed",
+          showTimelineSkeleton: false
+        })
+      )
+    );
+    const timelineObserver = resizeObservers.find((observer) =>
+      observer.observed.has(harness.timelineContent)
+    );
+    expect(timelineObserver).toBeDefined();
+
+    harness.setScrollHeight(6_000);
+    act(() => {
+      timelineObserver?.callback([], timelineObserver);
+    });
+
+    expect(harness.timeline.scrollTop).toBe(5_900);
+  });
+
+  it("preserves user scroll-away through observed streaming content growth", () => {
+    const resizeObservers = installResizeObserverMock();
+    const harness = createHarness({ scrollHeight: 5_000 });
+
+    renderHook(() =>
+      useAgentGUIDetailScroll(
+        harness.input({
+          activeConversationId: "conversation-observed-away",
+          showTimelineSkeleton: false
+        })
+      )
+    );
+    const timelineObserver = resizeObservers.find((observer) =>
+      observer.observed.has(harness.timelineContent)
+    );
+    expect(timelineObserver).toBeDefined();
+    act(() => {
+      harness.timeline.dispatchEvent(new WheelEvent("wheel", { deltaY: -100 }));
+      harness.timeline.scrollTop = 4_000;
+      harness.timeline.dispatchEvent(new Event("scroll"));
+    });
+
+    harness.setScrollHeight(6_000);
+    act(() => {
+      timelineObserver?.callback([], timelineObserver);
+    });
+
+    expect(harness.timeline.scrollTop).toBe(4_000);
+  });
+
   it("moves floating dock controls above a growing composer without reserving timeline space", () => {
     const harness = createHarness({ scrollHeight: 5_000 });
     const composerInputShell = document.createElement("div");
@@ -222,16 +303,37 @@ function mockRect(input: {
 
 function createHarness(input: { scrollHeight: number }) {
   const timeline = document.createElement("div");
+  const timelineContent = document.createElement("div");
   const bottomDock = document.createElement("div");
+  let scrollTop = 0;
   let scrollHeight = input.scrollHeight;
+  let clientHeightReadCount = 0;
+  let scrollHeightReadCount = 0;
+  let scrollTopReadCount = 0;
   Object.defineProperties(timeline, {
     clientHeight: {
       configurable: true,
-      get: () => 100
+      get: () => {
+        clientHeightReadCount += 1;
+        return 100;
+      }
     },
     scrollHeight: {
       configurable: true,
-      get: () => scrollHeight
+      get: () => {
+        scrollHeightReadCount += 1;
+        return scrollHeight;
+      }
+    },
+    scrollTop: {
+      configurable: true,
+      get: () => {
+        scrollTopReadCount += 1;
+        return scrollTop;
+      },
+      set: (value: number) => {
+        scrollTop = value;
+      }
     }
   });
 
@@ -247,36 +349,86 @@ function createHarness(input: { scrollHeight: number }) {
     scrollTop: number;
   } | null>(null);
   const submittedPromptScrollConversationRef = mutableRef<string | null>(null);
+  const actions = {
+    loadOlderConversationMessages: vi.fn()
+  } as unknown as AgentGUINodeViewProps["actions"];
 
   return {
     bottomDock,
     timeline,
+    timelineContent,
+    resetGeometryReadCounts() {
+      clientHeightReadCount = 0;
+      scrollHeightReadCount = 0;
+      scrollTopReadCount = 0;
+    },
+    geometryReadCounts() {
+      return {
+        clientHeight: clientHeightReadCount,
+        scrollHeight: scrollHeightReadCount,
+        scrollTop: scrollTopReadCount
+      };
+    },
     setScrollHeight(value: number) {
       scrollHeight = value;
     },
     input(options: {
       activeConversationId: string;
+      conversation?: AgentConversationVM;
       showTimelineSkeleton: boolean;
       timelineConversationId?: string;
     }) {
       return {
-        actions: {
-          loadOlderConversationMessages: vi.fn()
-        } as unknown as AgentGUINodeViewProps["actions"],
+        actions,
         bottomDockRef: ref(bottomDock),
         bottomDockStoreRevision: "stable",
-        conversation: null,
+        conversation: options.conversation ?? null,
         pendingPrependScrollAnchorRef,
         showTimelineSkeleton: options.showTimelineSkeleton,
         submittedPromptScrollConversationRef,
         timelineConversationId:
           options.timelineConversationId ?? options.activeConversationId,
+        timelineContentRef: ref(timelineContent),
         timelineRef: ref(timeline),
         timelineScrollAnchorRef,
         viewModel: viewModel(options.activeConversationId)
       };
     }
   };
+}
+
+function conversationVM(id: string): AgentConversationVM {
+  return { id } as unknown as AgentConversationVM;
+}
+
+interface ResizeObserverMock extends ResizeObserver {
+  readonly callback: ResizeObserverCallback;
+  readonly observed: Set<Element>;
+}
+
+function installResizeObserverMock(): ResizeObserverMock[] {
+  const observers: ResizeObserverMock[] = [];
+  class TestResizeObserver implements ResizeObserverMock {
+    readonly observed = new Set<Element>();
+
+    constructor(readonly callback: ResizeObserverCallback) {
+      observers.push(this);
+    }
+
+    observe(target: Element): void {
+      this.observed.add(target);
+    }
+
+    unobserve(target: Element): void {
+      this.observed.delete(target);
+    }
+
+    disconnect(): void {
+      this.observed.clear();
+    }
+  }
+  vi.stubGlobal("ResizeObserver", TestResizeObserver);
+  return observers;
 }
 
 function viewModel(activeConversationId: string): AgentGUINodeViewModel {

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.ts
@@ -33,6 +33,7 @@ interface Input {
   showTimelineSkeleton: boolean;
   submittedPromptScrollConversationRef: MutableRefObject<string | null>;
   timelineConversationId: string | null;
+  timelineContentRef: RefObject<HTMLDivElement | null>;
   timelineRef: RefObject<HTMLDivElement | null>;
   timelineScrollAnchorRef: MutableRefObject<{
     conversationId: string;
@@ -53,6 +54,7 @@ export function useAgentGUIDetailScroll(input: Input) {
     showTimelineSkeleton,
     submittedPromptScrollConversationRef,
     timelineConversationId,
+    timelineContentRef,
     timelineRef,
     timelineScrollAnchorRef,
     viewModel
@@ -62,7 +64,11 @@ export function useAgentGUIDetailScroll(input: Input) {
     useState(true);
   const bottomLockOwnerRef = useRef<string | null>(null);
   const userScrollAwayIntentConversationRef = useRef<string | null>(null);
+  const lastShowTimelineSkeletonRef = useRef(showTimelineSkeleton);
   useLayoutEffect(() => {
+    const timelineSkeletonChanged =
+      lastShowTimelineSkeletonRef.current !== showTimelineSkeleton;
+    lastShowTimelineSkeletonRef.current = showTimelineSkeleton;
     const timeline = timelineRef.current;
     if (!timeline) {
       return;
@@ -79,17 +85,27 @@ export function useAgentGUIDetailScroll(input: Input) {
       return;
     }
 
-    const maxScrollTop = Math.max(
-      0,
-      timeline.scrollHeight - timeline.clientHeight
-    );
     const anchor = timelineScrollAnchorRef.current;
     const prependAnchor = pendingPrependScrollAnchorRef.current;
     const shouldScrollSubmittedPromptToBottom =
       submittedPromptScrollConversationRef.current === activeConversationId;
-    let nextScrollTop = timeline.scrollTop;
     const conversationChanged =
       !anchor || anchor.conversationId !== activeConversationId;
+    const shouldRestorePrependAnchor =
+      prependAnchor?.conversationId === activeConversationId;
+    if (
+      !conversationChanged &&
+      !shouldScrollSubmittedPromptToBottom &&
+      !shouldRestorePrependAnchor &&
+      !timelineSkeletonChanged
+    ) {
+      return;
+    }
+    const maxScrollTop = Math.max(
+      0,
+      timeline.scrollHeight - timeline.clientHeight
+    );
+    let nextScrollTop: number;
     if (conversationChanged || shouldScrollSubmittedPromptToBottom) {
       bottomLockOwnerRef.current = activeConversationId;
       userScrollAwayIntentConversationRef.current = null;
@@ -108,7 +124,7 @@ export function useAgentGUIDetailScroll(input: Input) {
       if (shouldScrollSubmittedPromptToBottom) {
         pendingPrependScrollAnchorRef.current = null;
       }
-    } else if (prependAnchor?.conversationId === activeConversationId) {
+    } else if (shouldRestorePrependAnchor && prependAnchor) {
       const nextScrollHeight = timeline.scrollHeight;
       const delta = nextScrollHeight - prependAnchor.scrollHeight;
       nextScrollTop = Math.max(0, prependAnchor.scrollTop + delta);
@@ -312,6 +328,7 @@ export function useAgentGUIDetailScroll(input: Input) {
 
   useEffect(() => {
     const timeline = timelineRef.current;
+    const timelineContent = timelineContentRef.current;
     const activeConversationId = timelineConversationId;
     if (!timeline || !activeConversationId) {
       return;
@@ -380,6 +397,38 @@ export function useAgentGUIDetailScroll(input: Input) {
       }
     };
 
+    const syncObservedTimelineGeometry = (): void => {
+      const anchor = timelineScrollAnchorRef.current;
+      if (!anchor || anchor.conversationId !== activeConversationId) {
+        return;
+      }
+
+      const scrollHeight = timeline.scrollHeight;
+      const clientHeight = timeline.clientHeight;
+      const maxScrollTop = Math.max(0, scrollHeight - clientHeight);
+      const bottomLocked = bottomLockOwnerRef.current === activeConversationId;
+      let scrollTop = Math.min(maxScrollTop, timeline.scrollTop);
+      if (bottomLocked) {
+        setTimelineScrollTopInstantly(timeline, maxScrollTop);
+        scrollTop = maxScrollTop;
+      }
+      timelineScrollAnchorRef.current = {
+        conversationId: activeConversationId,
+        scrollHeight,
+        scrollTop,
+        clientHeight
+      };
+      const atBottom =
+        maxScrollTop - scrollTop <= AGENT_GUI_STICK_TO_BOTTOM_THRESHOLD_PX;
+      if (atBottom) {
+        bottomLockOwnerRef.current = activeConversationId;
+      }
+      setIsTimelineScrolledToTop(
+        scrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
+      );
+      setIsTimelineScrolledToBottom(bottomLocked || atBottom);
+    };
+
     const captureWheelIntent = (event: WheelEvent): void => {
       if (event.deltaY < 0) {
         userScrollAwayIntentConversationRef.current = activeConversationId;
@@ -399,7 +448,16 @@ export function useAgentGUIDetailScroll(input: Input) {
     timeline.addEventListener("scroll", captureScrollAnchor, { passive: true });
     timeline.addEventListener("wheel", captureWheelIntent, { passive: true });
     timeline.addEventListener("keydown", captureKeyboardIntent);
+    const geometryObserver =
+      timelineContent && typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(syncObservedTimelineGeometry)
+        : null;
+    geometryObserver?.observe(timeline);
+    if (timelineContent) {
+      geometryObserver?.observe(timelineContent);
+    }
     return () => {
+      geometryObserver?.disconnect();
       timeline.removeEventListener("scroll", captureScrollAnchor);
       timeline.removeEventListener("wheel", captureWheelIntent);
       timeline.removeEventListener("keydown", captureKeyboardIntent);

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageLocatorRail.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageLocatorRail.tsx
@@ -218,9 +218,10 @@ export function AgentMessageLocatorRail({
     const railHeight =
       (items.length - 1) * AGENT_MESSAGE_LOCATOR_ITEM_SPACING_PX +
       AGENT_MESSAGE_LOCATOR_HIT_SIZE_PX;
-    const viewportHeight =
-      viewport.clientHeight ||
-      Math.min(railHeight, visibleFrame?.heightPx ?? railHeight);
+    const viewportHeight = Math.min(
+      railHeight,
+      visibleFrame?.heightPx ?? railHeight
+    );
     scrollMessageLocatorViewportToIndex(
       viewport,
       selectedIndex,

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -787,7 +787,7 @@ describe("AgentTranscriptView", () => {
     }
   });
 
-  it("keeps the selected user message locator tick inside the locator viewport", async () => {
+  it("keeps the selected locator tick visible through resize without reading viewport geometry", async () => {
     const turns = Array.from({ length: 16 }, (_, index) => ({
       id: `turn-${index + 1}`,
       userMessage: {
@@ -821,23 +821,37 @@ describe("AgentTranscriptView", () => {
     }));
 
     render(
-      <AgentTranscriptView
-        conversation={projectAgentConversationVM(detailViewModel({ turns }))}
-        labels={{
-          thinkingLabel: "Thought process",
-          toolCallsLabel: (count) => `Tool calls (${count})`,
-          processing: "Planning next moves",
-          turnSummary: "Changed files",
-          userMessageLocator: "User messages"
-        }}
-      />
+      <div data-testid="agent-gui-timeline">
+        <AgentTranscriptView
+          conversation={projectAgentConversationVM(detailViewModel({ turns }))}
+          labels={{
+            thinkingLabel: "Thought process",
+            toolCallsLabel: (count) => `Tool calls (${count})`,
+            processing: "Planning next moves",
+            turnSummary: "Changed files",
+            userMessageLocator: "User messages"
+          }}
+        />
+      </div>
     );
 
+    const timeline = screen.getByTestId("agent-gui-timeline");
     const locator = screen.getByTestId("agent-message-locator");
     const viewport = screen.getByTestId("agent-message-locator-viewport");
+    let timelineClientHeight = 96;
+    Object.defineProperty(timeline, "clientHeight", {
+      configurable: true,
+      get: () => timelineClientHeight
+    });
+    await flushAnimationFrame();
+
+    let viewportClientHeightReadCount = 0;
     Object.defineProperty(viewport, "clientHeight", {
       configurable: true,
-      value: 96
+      get: () => {
+        viewportClientHeightReadCount += 1;
+        return timelineClientHeight;
+      }
     });
 
     fireEvent.click(
@@ -847,9 +861,18 @@ describe("AgentTranscriptView", () => {
     await waitFor(() => {
       expect(viewport.scrollTop).toBeGreaterThan(0);
     });
+    expect(viewportClientHeightReadCount).toBe(0);
     expect(
       locator.querySelectorAll(".agent-gui-message-locator__tick")[14]
     ).toHaveAttribute("data-selected", "true");
+
+    const scrollTopBeforeResize = viewport.scrollTop;
+    timelineClientHeight = 120;
+    fireEvent(window, new Event("resize"));
+    await flushAnimationFrame();
+
+    expect(viewport.scrollTop).toBeLessThan(scrollTopBeforeResize);
+    expect(viewportClientHeightReadCount).toBe(0);
   });
 
   it("keeps a compact locator safety inset above composer scroll padding", async () => {

--- a/packages/ui/system/src/components/scroll-area/scroll-area.spec.tsx
+++ b/packages/ui/system/src/components/scroll-area/scroll-area.spec.tsx
@@ -1,0 +1,27 @@
+import { createRef } from "react";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ScrollArea } from "./scroll-area";
+
+describe("ScrollArea", () => {
+  it.each(["native", "custom"] as const)(
+    "exposes the %s viewport content element",
+    (scrollbarMode) => {
+      const viewportContentRef = createRef<HTMLDivElement>();
+
+      render(
+        <ScrollArea
+          scrollbarMode={scrollbarMode}
+          viewportContentRef={viewportContentRef}
+        >
+          content
+        </ScrollArea>
+      );
+
+      expect(viewportContentRef.current).toHaveAttribute(
+        "data-slot",
+        "scroll-area-content"
+      );
+    }
+  );
+});

--- a/packages/ui/system/src/components/scroll-area/scroll-area.tsx
+++ b/packages/ui/system/src/components/scroll-area/scroll-area.tsx
@@ -12,6 +12,8 @@ type ScrollAreaProps = React.HTMLAttributes<HTMLDivElement> & {
   scrollHideDelay?: number;
   type?: ScrollAreaType;
   viewportClassName?: string;
+  /** Receives the element that directly wraps children inside the viewport. */
+  viewportContentRef?: React.Ref<HTMLDivElement>;
   viewportContentStyle?: React.CSSProperties;
   viewportProps?: Omit<
     React.ComponentPropsWithoutRef<"div">,
@@ -51,6 +53,7 @@ function ScrollArea({
   scrollHideDelay: _scrollHideDelay,
   type,
   viewportClassName,
+  viewportContentRef,
   viewportContentStyle,
   viewportProps,
   viewportRef,
@@ -66,6 +69,7 @@ function ScrollArea({
     scrollbarMode,
     type,
     viewportClassName,
+    viewportContentRef,
     viewportContentStyle,
     viewportProps,
     viewportRef,
@@ -94,6 +98,7 @@ function NativeScrollArea({
   scrollbarMode,
   type,
   viewportClassName,
+  viewportContentRef,
   viewportContentStyle,
   viewportProps,
   viewportRef,
@@ -115,6 +120,7 @@ function NativeScrollArea({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       alwaysVisible={false}
+      contentRef={viewportContentRef}
       viewportClassName={cn(
         nativeScrollbarClassName(alwaysVisible),
         viewportClassName
@@ -139,6 +145,7 @@ function CustomScrollArea({
   scrollbarMode,
   type,
   viewportClassName,
+  viewportContentRef,
   viewportContentStyle,
   viewportProps,
   viewportRef,
@@ -158,7 +165,7 @@ function CustomScrollArea({
     <ScrollAreaFrame
       {...props}
       className={className}
-      contentRef={contentRef}
+      contentRef={setRefs(contentRef, viewportContentRef)}
       data-scrollbar-mode={scrollbarMode}
       onBlur={(event) => {
         onBlur?.(event);

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -80,6 +80,7 @@ Automated AgentGUI performance reports:
 pnpm perf:agent-gui
 pnpm perf:agent-gui -- --list-scenarios
 pnpm perf:agent-gui -- --scenario session-switch
+pnpm perf:agent-gui -- --scenario virtualized-streaming
 ```
 
 The command reads `~/.tutti-dev/tuttid.db` by default and uses SQLite online
@@ -88,17 +89,23 @@ copy keeps projects, sessions, and rail data, but clears recoverable operation
 queues and the selected AgentGUI session before starting an isolated daemon and
 Electron `userData` directory. This prevents the diagnostic run from resuming a
 real provider session while avoiding a schema-sensitive fixture.
+All scenarios run with invisible, non-activating Electron windows while keeping
+the real renderer, compositor, and CDP trace pipeline active. Native pointer
+events pass through those windows; scenario interaction is injected through
+CDP.
 
 Outputs are stored under
 `.tmp/perf/agent-gui/<scenario>/<timestamp>/`: `trace.json`,
 `report.json`, `report.md`, and `desktop.log`. Metric values are report-only;
 only infrastructure, scenario, trace, or analysis failures return a non-zero
-exit code. Available scenarios cover one Provider switch, one Session switch,
-two Provider/Session switching rounds, internal Workbench window lifecycle, and
-native Electron window state changes. The native window scenario is currently
-macOS-only because its minimize completion signal comes from the typed macOS
-host event. Use `--source-db`, `--from-target-id`, or `--to-target-id` to
-override the defaults.
+exit code. Available scenarios also cover deterministic streaming into an
+already virtualized transcript, fresh-scope Rail reveal, hero composer
+prompt-tip layout measurement during resize, internal Workbench window lifecycle, and
+native Electron window state changes. The streaming scenario rewrites only the
+isolated snapshot and shadows `cursor-agent` only inside the isolated Desktop
+process, so it cannot send input to an installed Agent provider. The native
+window scenarios are currently macOS-only. Use `--source-db`,
+`--from-target-id`, or `--to-target-id` to override the defaults.
 
 The Markdown report contains scenario assertions, observed milestone phases,
 renderer-main `RunTask`/layout/paint metrics, React component fanout, and static

--- a/tools/scripts/agent-gui-layout-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-layout-performance-scenarios.mjs
@@ -1,0 +1,751 @@
+import { chmod, copyFile, mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  clickAgentWindowControl,
+  clickProviderTarget,
+  clickSession,
+  evaluate,
+  finishRendererScenario,
+  markRenderer,
+  selectProvider,
+  startRendererScenario,
+  waitForActiveSession,
+  waitForAgentWorkbenchWindow,
+  waitForEvaluation,
+  waitForProviderTiles,
+  waitForSelectedTarget,
+  waitForStableAgentWorkbenchWindow,
+  waitForStableRail,
+  waitForStableViewport
+} from "./agent-gui-performance-helpers.mjs";
+import {
+  requiredScenarioData,
+  scenarioSummary as summary,
+  sqlString,
+  startupWorkspaceID,
+  updateAgentGUISnapshot
+} from "./agent-gui-performance-snapshot-helpers.mjs";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const cursorFixtureDirectory = join(
+  scriptDirectory,
+  "fixtures",
+  "agent-gui-performance"
+);
+const conversationItemPrefix = "agent-gui-conversation-item-";
+
+const virtualizedStreamingMarkers = {
+  start: "tutti-perf:virtualized-streaming:start",
+  submitted: "tutti-perf:virtualized-streaming:submitted-observed",
+  firstMutation: "tutti-perf:virtualized-streaming:first-mutation-observed",
+  settled: "tutti-perf:virtualized-streaming:settled-observed",
+  end: "tutti-perf:virtualized-streaming:end"
+};
+
+export const virtualizedStreamingScenario = {
+  id: "virtualized-streaming",
+  markers: virtualizedStreamingMarkers,
+  milestones: [
+    {
+      key: "submitted",
+      label: "fixture prompt submitted",
+      marker: virtualizedStreamingMarkers.submitted
+    },
+    {
+      key: "firstMutation",
+      label: "first virtualized transcript mutation",
+      marker: virtualizedStreamingMarkers.firstMutation
+    },
+    {
+      key: "settled",
+      label: "streaming fixture settled",
+      marker: virtualizedStreamingMarkers.settled
+    }
+  ],
+  prepareSnapshot: prepareVirtualizedStreamingSnapshot,
+  prepare: prepareVirtualizedStreaming,
+  execute: executeVirtualizedStreaming,
+  describe(prepared) {
+    return `${prepared.sessionID}; ${prepared.turnCount} persisted turns + deterministic ACP stream`;
+  },
+  summarize(prepared, result) {
+    return summary(
+      [
+        {
+          name: "transcript virtualized before stream",
+          passed: prepared.virtualized
+        },
+        {
+          name: "stream entered working state",
+          passed: result.started
+        },
+        {
+          name: "virtualizer DOM mutated repeatedly",
+          passed: result.mutationBatches >= 8
+        },
+        {
+          name: "transcript remained virtualized",
+          passed: result.virtualizedAfter
+        },
+        { name: "stream settled", passed: result.settled }
+      ],
+      [
+        { label: "Session", value: prepared.sessionID },
+        { label: "Persisted turns", value: String(prepared.turnCount) },
+        { label: "Mutation batches", value: String(result.mutationBatches) },
+        { label: "DOM mutations", value: String(result.mutations) },
+        { label: "Provider", value: "isolated fake Cursor ACP" }
+      ],
+      "virtualized DOM is observed before submit; deterministic local ACP chunks produce at least eight MutationObserver batches; working state settles before the trace tail"
+    );
+  }
+};
+
+async function prepareVirtualizedStreamingSnapshot(context) {
+  const fixtureBinDirectory = join(context.runtimeDirectory, "state", "bin");
+  await mkdir(fixtureBinDirectory, { recursive: true });
+  const fixtureBinaryPath = join(fixtureBinDirectory, "cursor-agent");
+  await copyFile(
+    join(cursorFixtureDirectory, "cursor-agent"),
+    fixtureBinaryPath
+  );
+  await chmod(fixtureBinaryPath, 0o755);
+  const workspaceID = await startupWorkspaceID(context);
+  const candidates = await context.sqliteJSON(
+    context.databasePath,
+    `
+SELECT s.agent_session_id AS sessionID,
+       COUNT(t.turn_id) AS turnCount
+FROM workspace_agent_sessions s
+JOIN workspace_agent_turns t
+  ON t.workspace_id = s.workspace_id
+ AND t.agent_session_id = s.agent_session_id
+WHERE s.workspace_id = '${sqlString(workspaceID)}'
+  AND s.deleted_at_unix_ms = 0
+  AND s.session_kind = 'root'
+  AND s.active_turn_id IS NULL
+GROUP BY s.agent_session_id
+HAVING COUNT(t.turn_id) >= 30
+ORDER BY COUNT(t.turn_id) ASC, s.agent_session_id ASC
+LIMIT 1;
+`
+  );
+  const candidate = candidates[0];
+  if (!candidate?.sessionID) {
+    throw new Error(
+      "virtualized-streaming requires one root session with at least 30 settled turns in the source snapshot"
+    );
+  }
+  const now = Date.now();
+  await context.sqliteExec(
+    context.databasePath,
+    `
+PRAGMA foreign_keys = ON;
+UPDATE agent_targets
+SET enabled = 1, updated_at_ms = ${now}
+WHERE id = 'local:cursor';
+UPDATE workspace_agent_sessions
+SET agent_target_id = 'local:cursor',
+    provider = 'cursor',
+    provider_session_id = 'tutti-perf-cursor-session',
+    model = '',
+    settings_json = '{}',
+    cwd = '${sqlString(context.workspaceRoot)}',
+    rail_section_kind = 'project',
+    rail_project_path = '${sqlString(context.workspaceRoot)}',
+    rail_section_key = 'project:${sqlString(context.workspaceRoot)}',
+    session_metadata_json = json_set(
+      session_metadata_json,
+      '$.visible', json('true'),
+      '$.imported', json('false')
+    ),
+    internal_runtime_context_json = '{}',
+    updated_at_unix_ms = ${now}
+WHERE workspace_id = '${sqlString(workspaceID)}'
+  AND agent_session_id = '${sqlString(candidate.sessionID)}';
+`
+  );
+  return {
+    data: {
+      sessionID: candidate.sessionID,
+      turnCount: Number(candidate.turnCount),
+      workspaceID
+    },
+    environment: {
+      PATH: `${fixtureBinDirectory}:${process.env.PATH ?? ""}`,
+      SHELL: fixtureBinaryPath
+    }
+  };
+}
+
+async function prepareVirtualizedStreaming(context, options) {
+  const fixture = requiredScenarioData(context, "virtualized-streaming");
+  const providers = await waitForProviderTiles(
+    context.pageClient,
+    options.timeoutMs
+  );
+  if (
+    !providers.tiles.some(
+      (tile) => tile.targetID === "local:cursor" && !tile.disabled
+    )
+  ) {
+    throw new Error(
+      `enabled local:cursor target is unavailable; visible targets: ${providers.tiles.map((tile) => `${tile.targetID}${tile.disabled ? " (disabled)" : ""}`).join(", ")}`
+    );
+  }
+  await selectProvider(context.pageClient, "local:cursor", options.timeoutMs);
+  await clickSession(context.pageClient, fixture.sessionID);
+  await waitForActiveSession(
+    context.pageClient,
+    fixture.sessionID,
+    options.timeoutMs
+  );
+  const transcript = await waitForEvaluation(
+    context.pageClient,
+    `(() => {
+      const timeline = document.querySelector('[data-testid="agent-gui-timeline"]');
+      const virtualized = timeline?.querySelector('[data-agent-transcript-virtualized="true"]');
+      const editor = document.querySelector('#agent-gui-detail [contenteditable="true"][role="textbox"]');
+      return {
+        ready: Boolean(timeline && virtualized && editor && editor.getAttribute('aria-disabled') !== 'true'),
+        virtualized: Boolean(virtualized)
+      };
+    })()`,
+    options.timeoutMs,
+    "virtualized transcript and enabled composer"
+  );
+  return { ...fixture, virtualized: transcript.virtualized };
+}
+
+async function executeVirtualizedStreaming(context, _prepared, options) {
+  const { pageClient } = context;
+  await evaluate(
+    pageClient,
+    `(() => {
+      const root = document.querySelector('[data-agent-transcript-virtualized="true"]');
+      if (!(root instanceof HTMLElement)) throw new Error('virtualized transcript is unavailable');
+      const state = window.__tuttiPerfVirtualizedStreaming = {
+        firstMutationMarked: false,
+        mutationBatches: 0,
+        mutations: 0
+      };
+      state.observer = new MutationObserver((records) => {
+        state.mutationBatches += 1;
+        state.mutations += records.length;
+        if (!state.firstMutationMarked) {
+          state.firstMutationMarked = true;
+          console.timeStamp(${JSON.stringify(virtualizedStreamingMarkers.firstMutation)});
+        }
+      });
+      state.observer.observe(root, {
+        attributes: true,
+        characterData: true,
+        childList: true,
+        subtree: true
+      });
+      return true;
+    })()`
+  );
+  await startRendererScenario(pageClient, virtualizedStreamingMarkers.start);
+  await enterAndSubmitComposerPrompt(
+    pageClient,
+    "Render deterministic virtualized streaming performance fixture",
+    options.timeoutMs
+  );
+  const started = await waitForEvaluation(
+    pageClient,
+    `({ ready: Boolean(document.querySelector('[data-testid="agent-gui-composer-stop-symbol"]')) })`,
+    options.timeoutMs,
+    "streaming fixture working state"
+  );
+  await markRenderer(pageClient, virtualizedStreamingMarkers.submitted);
+  const settled = await waitForEvaluation(
+    pageClient,
+    `(() => {
+      const state = window.__tuttiPerfVirtualizedStreaming;
+      return {
+        ready: Boolean(state?.firstMutationMarked && state.mutationBatches >= 8 && !document.querySelector('[data-testid="agent-gui-composer-stop-symbol"]')),
+        mutationBatches: state?.mutationBatches ?? 0,
+        mutations: state?.mutations ?? 0,
+        virtualizedAfter: Boolean(document.querySelector('[data-agent-transcript-virtualized="true"]'))
+      };
+    })()`,
+    options.timeoutMs,
+    "settled virtualized streaming fixture",
+    50
+  );
+  await markRenderer(pageClient, virtualizedStreamingMarkers.settled);
+  await evaluate(
+    pageClient,
+    `(() => {
+      window.__tuttiPerfVirtualizedStreaming?.observer?.disconnect();
+      return true;
+    })()`
+  );
+  await finishRendererScenario(pageClient, virtualizedStreamingMarkers.end);
+  return {
+    mutationBatches: settled.mutationBatches,
+    mutations: settled.mutations,
+    settled: settled.ready,
+    started: started.ready,
+    virtualizedAfter: settled.virtualizedAfter
+  };
+}
+
+const railRevealMarkers = {
+  start: "tutti-perf:rail-scope-reveal:start",
+  selected: "tutti-perf:rail-scope-reveal:selected-observed",
+  revealed: "tutti-perf:rail-scope-reveal:scroll-into-view-observed",
+  stable: "tutti-perf:rail-scope-reveal:stable-observed",
+  end: "tutti-perf:rail-scope-reveal:end"
+};
+
+export const railScopeRevealScenario = {
+  id: "rail-scope-reveal",
+  markers: railRevealMarkers,
+  milestones: [
+    {
+      key: "selected",
+      label: "target Agent scope selected",
+      marker: railRevealMarkers.selected
+    },
+    {
+      key: "revealed",
+      label: "active session scrollIntoView",
+      marker: railRevealMarkers.revealed
+    },
+    {
+      key: "stable",
+      label: "target rail stable",
+      marker: railRevealMarkers.stable
+    }
+  ],
+  prepareSnapshot: prepareRailScopeRevealSnapshot,
+  prepare: prepareRailScopeReveal,
+  execute: executeRailScopeReveal,
+  describe(prepared) {
+    return `${prepared.sourceTargetID} -> ${prepared.targetTargetID}; reveal ${prepared.sessionID}`;
+  },
+  summarize(prepared, result) {
+    return summary(
+      [
+        { name: "target Agent selected", passed: result.selected },
+        { name: "target session active", passed: result.active },
+        {
+          name: "target session received scrollIntoView",
+          passed: result.revealCalls > 0
+        },
+        { name: "rail stable", passed: result.stable }
+      ],
+      [
+        {
+          label: "Agent scope",
+          value: `${prepared.sourceTargetID} → ${prepared.targetTargetID}`
+        },
+        { label: "Session", value: prepared.sessionID },
+        { label: "scrollIntoView calls", value: String(result.revealCalls) }
+      ],
+      "a fresh Agent scope restores its mapped active session; the scenario records the exact target row scrollIntoView call before waiting for five stable rail snapshots"
+    );
+  }
+};
+
+async function prepareRailScopeRevealSnapshot(context) {
+  const workspaceID = await startupWorkspaceID(context);
+  const targets = await context.sqliteJSON(
+    context.databasePath,
+    `
+SELECT agent_target_id AS targetID, COUNT(*) AS sessionCount
+FROM workspace_agent_sessions
+WHERE workspace_id = '${sqlString(workspaceID)}'
+  AND deleted_at_unix_ms = 0
+  AND agent_target_id IS NOT NULL
+GROUP BY agent_target_id
+HAVING COUNT(*) >= 2
+ORDER BY COUNT(*) DESC, agent_target_id ASC
+LIMIT 2;
+`
+  );
+  if (targets.length < 2) {
+    throw new Error(
+      "rail-scope-reveal requires sessions for at least two Agent targets"
+    );
+  }
+  const targetTargetID = targets[0].targetID;
+  const sourceTargetID = targets[1].targetID;
+  const sessions = await context.sqliteJSON(
+    context.databasePath,
+    `
+SELECT agent_session_id AS sessionID
+FROM workspace_agent_sessions
+WHERE workspace_id = '${sqlString(workspaceID)}'
+  AND agent_target_id = '${sqlString(targetTargetID)}'
+  AND deleted_at_unix_ms = 0
+ORDER BY updated_at_unix_ms DESC, agent_session_id ASC
+LIMIT 1 OFFSET 4;
+`
+  );
+  const sessionID = sessions[0]?.sessionID;
+  if (!sessionID) {
+    throw new Error(
+      "rail-scope-reveal could not select a fifth target session"
+    );
+  }
+  await updateAgentGUISnapshot(context, (state) => ({
+    ...state,
+    agentTargetId: sourceTargetID,
+    lastActiveAgentSessionId: null,
+    lastActiveAgentSessionIdByAgentTargetId: {
+      ...(state.lastActiveAgentSessionIdByAgentTargetId ?? {}),
+      [targetTargetID]: sessionID
+    }
+  }));
+  return {
+    data: { sessionID, sourceTargetID, targetTargetID, workspaceID }
+  };
+}
+
+async function prepareRailScopeReveal(context, options) {
+  const fixture = requiredScenarioData(context, "rail-scope-reveal");
+  const providers = await waitForProviderTiles(
+    context.pageClient,
+    options.timeoutMs
+  );
+  const available = new Set(
+    providers.tiles
+      .filter((tile) => tile.disabled !== true)
+      .map((tile) => tile.targetID)
+  );
+  if (
+    !available.has(fixture.sourceTargetID) ||
+    !available.has(fixture.targetTargetID)
+  ) {
+    throw new Error(
+      `rail-scope-reveal requires enabled targets ${fixture.sourceTargetID} and ${fixture.targetTargetID}`
+    );
+  }
+  if (providers.selectedTargetID !== fixture.sourceTargetID) {
+    await selectProvider(
+      context.pageClient,
+      fixture.sourceTargetID,
+      options.timeoutMs
+    );
+  } else {
+    await waitForStableRail(
+      context.pageClient,
+      fixture.sourceTargetID,
+      options.timeoutMs
+    );
+  }
+  return fixture;
+}
+
+async function executeRailScopeReveal(context, prepared, options) {
+  const { pageClient } = context;
+  await evaluate(
+    pageClient,
+    `(() => {
+      const original = Element.prototype.scrollIntoView;
+      window.__tuttiPerfRailReveal = { calls: [], original };
+      Element.prototype.scrollIntoView = function(options) {
+        const testID = this instanceof HTMLElement ? (this.dataset.testid ?? '') : '';
+        window.__tuttiPerfRailReveal.calls.push({ options, testID });
+        return original.call(this, options);
+      };
+      return true;
+    })()`
+  );
+  await startRendererScenario(pageClient, railRevealMarkers.start);
+  await clickProviderTarget(pageClient, prepared.targetTargetID);
+  const selected = await waitForSelectedTarget(
+    pageClient,
+    prepared.targetTargetID,
+    options.timeoutMs
+  );
+  await markRenderer(pageClient, railRevealMarkers.selected);
+  const active = await waitForActiveSession(
+    pageClient,
+    prepared.sessionID,
+    options.timeoutMs
+  );
+  const revealed = await waitForEvaluation(
+    pageClient,
+    `(() => {
+      const testID = ${JSON.stringify(conversationItemPrefix)} + ${JSON.stringify(prepared.sessionID)};
+      const calls = window.__tuttiPerfRailReveal?.calls ?? [];
+      return { ready: calls.some((call) => call.testID === testID), revealCalls: calls.filter((call) => call.testID === testID).length };
+    })()`,
+    options.timeoutMs,
+    `scrollIntoView for ${prepared.sessionID}`,
+    50
+  );
+  await markRenderer(pageClient, railRevealMarkers.revealed);
+  const stable = await waitForStableRail(
+    pageClient,
+    prepared.targetTargetID,
+    options.timeoutMs
+  );
+  await markRenderer(pageClient, railRevealMarkers.stable);
+  await evaluate(
+    pageClient,
+    `(() => {
+      const state = window.__tuttiPerfRailReveal;
+      if (state?.original) Element.prototype.scrollIntoView = state.original;
+      return true;
+    })()`
+  );
+  await finishRendererScenario(pageClient, railRevealMarkers.end);
+  return {
+    active: active.ready,
+    revealCalls: revealed.revealCalls,
+    selected: selected.ready,
+    stable: stable.sectionCount > 0
+  };
+}
+
+const composerResizeMarkers = {
+  start: "tutti-perf:composer-overflow-resize:start",
+  narrowed: "tutti-perf:composer-overflow-resize:narrowed-observed",
+  overflowing: "tutti-perf:composer-overflow-resize:overflow-observed",
+  restored: "tutti-perf:composer-overflow-resize:restored-observed",
+  end: "tutti-perf:composer-overflow-resize:end"
+};
+
+export const composerOverflowResizeScenario = {
+  id: "composer-overflow-resize",
+  markers: composerResizeMarkers,
+  milestones: [
+    {
+      key: "narrowed",
+      label: "renderer viewport narrowed",
+      marker: composerResizeMarkers.narrowed
+    },
+    {
+      key: "overflowing",
+      label: "prompt tip layout measurement observed",
+      marker: composerResizeMarkers.overflowing
+    },
+    {
+      key: "restored",
+      label: "renderer viewport restored",
+      marker: composerResizeMarkers.restored
+    }
+  ],
+  prepare: prepareComposerOverflowResize,
+  execute: executeComposerOverflowResize,
+  describe(prepared) {
+    return `${prepared.originalWidth}px -> narrow -> ${prepared.originalWidth}px`;
+  },
+  summarize(prepared, result) {
+    return summary(
+      [
+        { name: "hero prompt tip present", passed: prepared.promptTipPresent },
+        { name: "viewport narrowed", passed: result.narrowed },
+        {
+          name: "prompt tip layout measured after resize",
+          passed: result.measurementReads > 0
+        },
+        { name: "viewport restored", passed: result.restored }
+      ],
+      [
+        { label: "Original viewport", value: `${prepared.originalWidth}px` },
+        { label: "Narrow viewport", value: `${result.narrowWidth}px` },
+        { label: "Prompt tip", value: "hero composer" },
+        {
+          label: "Layout getter reads",
+          value: String(result.measurementReads)
+        }
+      ],
+      "AgentGUI Workbench is fullscreen; native scrollWidth/clientWidth getters are transparently counted while renderer resizes drive the prompt-tip ResizeObserver, then viewport metrics are restored"
+    );
+  }
+};
+
+async function prepareComposerOverflowResize(context, options) {
+  const { pageClient } = context;
+  const providers = await waitForProviderTiles(pageClient, options.timeoutMs);
+  const targetIDValue =
+    providers.selectedTargetID ?? providers.tiles[0]?.targetID;
+  if (!targetIDValue) {
+    throw new Error("composer-overflow-resize has no Agent target");
+  }
+  if (providers.selectedTargetID !== targetIDValue) {
+    await clickProviderTarget(pageClient, targetIDValue);
+    await waitForSelectedTarget(pageClient, targetIDValue, options.timeoutMs);
+  }
+  const windowState = await waitForStableAgentWorkbenchWindow(
+    pageClient,
+    options.timeoutMs
+  );
+  if (windowState.displayMode !== "fullscreen") {
+    await clickAgentWindowControl(
+      pageClient,
+      windowState.id,
+      "agent-gui-window-toggle-display-mode"
+    );
+    await waitForAgentWorkbenchWindow(
+      pageClient,
+      options.timeoutMs,
+      "windowState?.displayMode === 'fullscreen'",
+      "fullscreen AgentGUI Workbench window",
+      windowState.id
+    );
+  }
+  const promptTip = await waitForEvaluation(
+    pageClient,
+    `(() => {
+      const tip = document.querySelector('[data-testid="agent-gui-prompt-tip"]');
+      return { ready: Boolean(tip), promptTipPresent: Boolean(tip) };
+    })()`,
+    options.timeoutMs,
+    "hero composer prompt tip"
+  );
+  const viewport = await waitForStableViewport(pageClient, options.timeoutMs);
+  return {
+    nodeID: windowState.id,
+    originalHeight: viewport.height,
+    originalWidth: viewport.width,
+    promptTipPresent: promptTip.promptTipPresent
+  };
+}
+
+async function executeComposerOverflowResize(context, prepared, options) {
+  const widths = [760, 680, 600, 520];
+  let measurement = null;
+  await evaluate(
+    context.pageClient,
+    `(() => {
+      const scrollDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollWidth');
+      const clientDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, 'clientWidth');
+      if (!scrollDescriptor?.get || !clientDescriptor?.get) {
+        throw new Error('native inline layout getters are unavailable');
+      }
+      const state = window.__tuttiPerfComposerResize = {
+        clientWidthReads: 0,
+        scrollWidthReads: 0,
+        scrollDescriptor,
+        clientDescriptor
+      };
+      Object.defineProperty(Element.prototype, 'scrollWidth', {
+        ...scrollDescriptor,
+        get() {
+          const value = scrollDescriptor.get.call(this);
+          if (this instanceof HTMLElement && this.matches('[data-testid="agent-gui-prompt-tip"]')) {
+            state.scrollWidthReads += 1;
+          }
+          return value;
+        }
+      });
+      Object.defineProperty(Element.prototype, 'clientWidth', {
+        ...clientDescriptor,
+        get() {
+          const value = clientDescriptor.get.call(this);
+          if (this instanceof HTMLElement && this.matches('[data-testid="agent-gui-prompt-tip"]')) {
+            state.clientWidthReads += 1;
+          }
+          return value;
+        }
+      });
+      return true;
+    })()`
+  );
+  await startRendererScenario(context.pageClient, composerResizeMarkers.start);
+  for (const width of widths) {
+    await context.pageClient.send("Emulation.setDeviceMetricsOverride", {
+      deviceScaleFactor: 1,
+      height: prepared.originalHeight,
+      mobile: false,
+      width
+    });
+    const viewport = await waitForStableViewport(
+      context.pageClient,
+      options.timeoutMs
+    );
+    await markRenderer(context.pageClient, composerResizeMarkers.narrowed);
+    measurement = await evaluate(
+      context.pageClient,
+      `(() => {
+        const state = window.__tuttiPerfComposerResize;
+        return {
+          measurementReads: Math.min(
+            state?.scrollWidthReads ?? 0,
+            state?.clientWidthReads ?? 0
+          ),
+          viewportWidth: window.innerWidth
+        };
+      })()`
+    );
+    if (measurement?.measurementReads > 0) {
+      measurement.viewportWidth = viewport.width;
+      break;
+    }
+  }
+  if (!measurement?.measurementReads) {
+    throw new Error(
+      "prompt tip layout getters were not read after viewport resize"
+    );
+  }
+  await markRenderer(context.pageClient, composerResizeMarkers.overflowing);
+  await context.pageClient.send("Emulation.clearDeviceMetricsOverride");
+  const restored = await waitForStableViewport(
+    context.pageClient,
+    options.timeoutMs
+  );
+  await evaluate(
+    context.pageClient,
+    `(() => {
+      const state = window.__tuttiPerfComposerResize;
+      if (!state) return false;
+      Object.defineProperty(Element.prototype, 'scrollWidth', state.scrollDescriptor);
+      Object.defineProperty(Element.prototype, 'clientWidth', state.clientDescriptor);
+      return true;
+    })()`
+  );
+  await markRenderer(context.pageClient, composerResizeMarkers.restored);
+  await finishRendererScenario(context.pageClient, composerResizeMarkers.end);
+  return {
+    narrowWidth: measurement.viewportWidth,
+    narrowed: measurement.viewportWidth < prepared.originalWidth,
+    measurementReads: measurement.measurementReads,
+    restored: Math.abs(restored.width - prepared.originalWidth) <= 2
+  };
+}
+
+async function enterAndSubmitComposerPrompt(client, prompt, timeoutMs) {
+  await evaluate(
+    client,
+    `(() => {
+      const editor = document.querySelector('#agent-gui-detail [contenteditable="true"][role="textbox"]');
+      if (!(editor instanceof HTMLElement)) throw new Error('composer editor is unavailable');
+      editor.focus();
+      document.execCommand('selectAll', false);
+      if (!document.execCommand('insertText', false, ${JSON.stringify(prompt)})) {
+        throw new Error('could not enter composer prompt');
+      }
+      return true;
+    })()`
+  );
+  await waitForEvaluation(
+    client,
+    `(() => {
+      const editor = document.querySelector('#agent-gui-detail [contenteditable="true"][role="textbox"]');
+      const form = editor?.closest('form');
+      const submit = form?.querySelector('button[type="submit"]');
+      return { ready: submit instanceof HTMLButtonElement && !submit.disabled };
+    })()`,
+    timeoutMs,
+    "enabled composer submit button",
+    25
+  );
+  await evaluate(
+    client,
+    `(() => {
+      const editor = document.querySelector('#agent-gui-detail [contenteditable="true"][role="textbox"]');
+      const form = editor.closest('form');
+      if (!(form instanceof HTMLFormElement)) throw new Error('composer form is unavailable');
+      form.requestSubmit();
+      return true;
+    })()`
+  );
+}

--- a/tools/scripts/agent-gui-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-performance-scenarios.mjs
@@ -7,11 +7,19 @@ import {
   desktopWindowStateScenario,
   workbenchWindowLifecycleScenario
 } from "./agent-gui-window-performance-scenarios.mjs";
+import {
+  composerOverflowResizeScenario,
+  railScopeRevealScenario,
+  virtualizedStreamingScenario
+} from "./agent-gui-layout-performance-scenarios.mjs";
 
 export const agentGuiPerformanceScenarios = [
   providerSwitchScenario,
   sessionSwitchScenario,
   providerSessionCycleScenario,
+  virtualizedStreamingScenario,
+  railScopeRevealScenario,
+  composerOverflowResizeScenario,
   workbenchWindowLifecycleScenario,
   desktopWindowStateScenario
 ];

--- a/tools/scripts/agent-gui-performance-snapshot-helpers.mjs
+++ b/tools/scripts/agent-gui-performance-snapshot-helpers.mjs
@@ -1,0 +1,69 @@
+export async function startupWorkspaceID(context) {
+  const rows = await context.sqliteJSON(
+    context.databasePath,
+    `
+SELECT id AS workspaceID
+FROM workspaces
+ORDER BY COALESCE(last_opened_at_unix_ms, 0) DESC,
+         updated_at_unix_ms DESC,
+         id ASC
+LIMIT 1;
+`
+  );
+  const workspaceID = rows[0]?.workspaceID;
+  if (!workspaceID) {
+    throw new Error("performance snapshot has no startup workspace");
+  }
+  return workspaceID;
+}
+
+export async function updateAgentGUISnapshot(context, updateState) {
+  const rows = await context.sqliteJSON(
+    context.databasePath,
+    `
+SELECT workspace_id AS workspaceID, snapshot_json AS snapshotJSON
+FROM workspace_workbench_snapshots
+WHERE workspace_id = '${sqlString(await startupWorkspaceID(context))}'
+LIMIT 1;
+`
+  );
+  const row = rows[0];
+  const snapshot = JSON.parse(row?.snapshotJSON ?? "null");
+  const node = snapshot?.nodes?.find(
+    (candidate) => candidate?.data?.typeId === "agent-gui"
+  );
+  if (!row?.workspaceID || !node) {
+    throw new Error("performance snapshot has no AgentGUI node state");
+  }
+  node.data.snapshotNodeState = updateState(node.data.snapshotNodeState ?? {});
+  await context.sqliteExec(
+    context.databasePath,
+    `
+UPDATE workspace_workbench_snapshots
+SET snapshot_json = '${sqlString(JSON.stringify(snapshot))}'
+WHERE workspace_id = '${sqlString(row.workspaceID)}';
+`
+  );
+}
+
+export function requiredScenarioData(context, scenarioID) {
+  if (!context.scenarioData) {
+    throw new Error(`${scenarioID} snapshot preparation did not return data`);
+  }
+  return context.scenarioData;
+}
+
+export function sqlString(value) {
+  return String(value).replaceAll("'", "''");
+}
+
+export function scenarioSummary(assertions, details, stabilityCriterion) {
+  return {
+    outcome: assertions.every((assertion) => assertion.passed)
+      ? "passed"
+      : "failed",
+    assertions,
+    details,
+    stabilityCriterion
+  };
+}

--- a/tools/scripts/agent-gui-window-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-window-performance-scenarios.mjs
@@ -267,7 +267,7 @@ async function prepareDesktopWindow(context, options) {
       return {
         ready: Boolean(workspaceID && hostWindow?.minimize && hostWindow?.toggleMaximize && hostWorkspace?.showWorkspace && document.querySelector('[data-app-header="true"]')),
         workspaceID,
-        maximized: document.documentElement.dataset.tuttiWindowMaximized === 'true'
+        maximized: document.documentElement?.dataset.tuttiWindowMaximized === 'true'
       };
     })()`,
     options.timeoutMs,
@@ -281,7 +281,7 @@ async function prepareDesktopWindow(context, options) {
     );
     await waitForEvaluation(
       pageClient,
-      "({ ready: document.documentElement.dataset.tuttiWindowMaximized !== 'true' })",
+      "({ ready: document.documentElement?.dataset.tuttiWindowMaximized !== 'true' })",
       options.timeoutMs,
       "normal native window before scenario"
     );

--- a/tools/scripts/fixtures/agent-gui-performance/cursor-agent
+++ b/tools/scripts/fixtures/agent-gui-performance/cursor-agent
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+import process from "node:process";
+import readline from "node:readline";
+
+const args = process.argv.slice(2);
+
+if (args.includes("about")) {
+  process.stdout.write(
+    `${JSON.stringify({
+      cliVersion: "tutti-perf-fixture",
+      subscriptionTier: "Fixture",
+      userEmail: "performance-fixture@localhost"
+    })}\n`
+  );
+} else if (args.includes("--version") || args.includes("version")) {
+  process.stdout.write("cursor-agent tutti-perf-fixture\n");
+} else if (args.includes("acp")) {
+  runACPFixture();
+} else {
+  process.stdout.write("Logged in as performance-fixture@localhost\n");
+}
+
+function runACPFixture() {
+  const input = readline.createInterface({ input: process.stdin });
+  let canceled = false;
+  input.on("line", (line) => {
+    void handleMessage(line).catch((error) => {
+      process.stderr.write(`${error.stack ?? error.message}\n`);
+      process.exitCode = 1;
+    });
+  });
+
+  async function handleMessage(line) {
+    const message = JSON.parse(line);
+    switch (message.method) {
+      case "initialize":
+        respond(message.id, {
+          protocolVersion: 1,
+          agentInfo: { name: "tutti-perf-cursor", title: "Tutti Perf Cursor" },
+          agentCapabilities: { loadSession: true }
+        });
+        return;
+      case "session/new":
+        respond(message.id, {
+          configOptions: [],
+          sessionId: "tutti-perf-cursor-session"
+        });
+        return;
+      case "session/load":
+      case "session/resume":
+      case "session/set_mode":
+      case "session/set_config_option":
+        respond(message.id, { configOptions: [] });
+        return;
+      case "session/cancel":
+        canceled = true;
+        return;
+      case "session/prompt":
+        canceled = false;
+        await streamPrompt(message.id);
+        return;
+      default:
+        if (message.id !== undefined) {
+          write({
+            jsonrpc: "2.0",
+            id: message.id,
+            error: {
+              code: -32601,
+              message: `method not found: ${message.method}`
+            }
+          });
+        }
+    }
+  }
+
+  async function streamPrompt(promptID) {
+    for (let index = 0; index < 48 && !canceled; index += 1) {
+      notify("session/update", {
+        sessionId: "tutti-perf-cursor-session",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            type: "text",
+            text: `Virtualized streaming fixture chunk ${String(index + 1).padStart(2, "0")}: ${"layout-safe-content ".repeat(8)}\n\n`
+          }
+        }
+      });
+      await new Promise((resolve) => setTimeout(resolve, 30));
+    }
+    respond(promptID, { stopReason: canceled ? "canceled" : "end_turn" });
+  }
+}
+
+function respond(id, result) {
+  write({ jsonrpc: "2.0", id, result });
+}
+
+function notify(method, params) {
+  write({ jsonrpc: "2.0", method, params });
+}
+
+function write(value) {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}

--- a/tools/scripts/run-agent-gui-performance.mjs
+++ b/tools/scripts/run-agent-gui-performance.mjs
@@ -91,6 +91,15 @@ export async function main(argv) {
     await mkdir(stateDirectory, { recursive: true });
     await snapshotSQLiteDatabase(options.sourceDatabase, databasePath);
     const snapshotInfo = await prepareDatabaseSnapshot(databasePath);
+    const scenarioSnapshot = scenario.prepareSnapshot
+      ? await scenario.prepareSnapshot({
+          databasePath,
+          runtimeDirectory,
+          sqliteExec,
+          sqliteJSON,
+          workspaceRoot
+        })
+      : null;
     log(
       `snapshot ready: ${snapshotInfo.sessionCount} sessions, ${snapshotInfo.projectCount} projects`
     );
@@ -101,6 +110,7 @@ export async function main(argv) {
       cdpPort,
       daemonPath,
       desktopLogPath,
+      environment: scenarioSnapshot?.environment,
       stateDirectory,
       userDataDirectory
     });
@@ -117,6 +127,7 @@ export async function main(argv) {
     const context = {
       browserClient,
       pageClient,
+      scenarioData: scenarioSnapshot?.data ?? null,
       targetID: targetIDFromWebSocket(pageWebSocket)
     };
     const prepared = await scenario.prepare(context, {
@@ -201,8 +212,8 @@ export async function main(argv) {
 async function snapshotSQLiteDatabase(sourcePath, destinationPath) {
   const escapedDestination = destinationPath.replaceAll("'", "''");
   await runCommand("sqlite3", [
-    "-readonly",
     sourcePath,
+    "PRAGMA query_only=ON;",
     ".timeout 10000",
     `.backup '${escapedDestination}'`
   ]);
@@ -373,15 +384,17 @@ async function buildDaemon(outputPath) {
 }
 
 function startDesktop(input) {
-  log(`starting isolated Desktop on CDP ${input.cdpPort}`);
+  log(`starting headless isolated Desktop on CDP ${input.cdpPort}`);
   const logStream = createWriteStream(input.desktopLogPath, { flags: "w" });
   const child = spawn("pnpm", ["dev:desktop"], {
     cwd: workspaceRoot,
     detached: process.platform !== "win32",
     env: {
       ...process.env,
+      ...input.environment,
       TUTTI_ANALYTICS_DISABLED: "1",
       TUTTI_DESKTOP_LOG_OUTPUT: "tee",
+      TUTTI_DESKTOP_PERFORMANCE_HEADLESS: "1",
       TUTTI_DESKTOP_USER_DATA_DIR: input.userDataDirectory,
       TUTTI_ELECTRON_JS_FLAGS: "--max-old-space-size=8192",
       TUTTI_ELECTRON_REMOTE_DEBUGGING_PORT: String(input.cdpPort),

--- a/tools/scripts/run-agent-gui-performance.test.mjs
+++ b/tools/scripts/run-agent-gui-performance.test.mjs
@@ -133,6 +133,9 @@ test("performance scenario registry exposes renderer and window scenarios", () =
       "provider-switch",
       "session-switch",
       "provider-session-cycle",
+      "virtualized-streaming",
+      "rail-scope-reveal",
+      "composer-overflow-resize",
       "workbench-window-lifecycle",
       "desktop-window-state"
     ]


### PR DESCRIPTION
## Summary
- avoid synchronous timeline and composer layout reads during streaming updates
- add non-activating desktop performance windows plus deterministic AgentGUI layout scenarios
- document performance-trace workflow and validation selection

## Tests
- `pnpm check:changed -- --push-ready`
- `pnpm --filter @tutti-os/desktop test -- src/main/defaults.test.ts src/main/host/workspaceLaunchDesktopAdapters.test.ts`
- `pnpm --filter @tutti-os/agent-gui test -- agentGuiNode/composer/useComposerLayout.spec.tsx agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx`
- `pnpm --filter @tutti-os/ui-system test -- src/components/scroll-area/scroll-area.spec.tsx`
- `node --test tools/scripts/run-agent-gui-performance.test.mjs`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/ui-system typecheck`
- `pnpm check:electron-runtime-boundaries`
- `pnpm check:ui-boundaries`

## Notes
- End-to-end performance scenarios require a local snapshot and were not run.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->