### PR TITLE
fix(agent-extension): preserve signed release payload

### DIFF
--- a/services/tuttid/service/agentextension/release_fetch.go
+++ b/services/tuttid/service/agentextension/release_fetch.go
@@ -54,12 +54,30 @@ type Release struct {
 	PublishedAt       string           `json:"publishedAt"`
 	GitSHA            string           `json:"gitSha"`
 	Signature         ReleaseSignature `json:"signature"`
+	signedPayload     []byte
 }
 
 type ReleaseSignature struct {
 	Algorithm string `json:"algorithm"`
 	KeyID     string `json:"keyId"`
 	Value     string `json:"value"`
+}
+
+func (release *Release) UnmarshalJSON(data []byte) error {
+	type releaseWire Release
+	var wire releaseWire
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&wire); err != nil {
+		return err
+	}
+	payload, err := releasePayloadFromJSON(data)
+	if err != nil {
+		return err
+	}
+	*release = Release(wire)
+	release.signedPayload = payload
+	return nil
 }
 
 func (m *Manager) getJSON(ctx context.Context, rawURL string, limit int64, target any) error {
@@ -169,16 +187,7 @@ func verifyRelease(release Release, source tuttitypes.AgentExtensionSource) erro
 	if !ok {
 		return errors.New("extension signing key must be Ed25519")
 	}
-	raw, err := json.Marshal(release)
-	if err != nil {
-		return err
-	}
-	var unsigned map[string]any
-	if err := json.Unmarshal(raw, &unsigned); err != nil {
-		return err
-	}
-	delete(unsigned, "signature")
-	payload, err := json.Marshal(unsigned)
+	payload, err := releasePayload(release)
 	if err != nil {
 		return err
 	}
@@ -187,4 +196,24 @@ func verifyRelease(release Release, source tuttitypes.AgentExtensionSource) erro
 		return errors.New("agent extension release signature is invalid")
 	}
 	return nil
+}
+
+func releasePayload(release Release) ([]byte, error) {
+	if len(release.signedPayload) > 0 {
+		return release.signedPayload, nil
+	}
+	raw, err := json.Marshal(release)
+	if err != nil {
+		return nil, err
+	}
+	return releasePayloadFromJSON(raw)
+}
+
+func releasePayloadFromJSON(raw []byte) ([]byte, error) {
+	var unsigned map[string]any
+	if err := json.Unmarshal(raw, &unsigned); err != nil {
+		return nil, err
+	}
+	delete(unsigned, "signature")
+	return json.Marshal(unsigned)
 }

--- a/services/tuttid/service/agentextension/release_fetch_test.go
+++ b/services/tuttid/service/agentextension/release_fetch_test.go
@@ -2,11 +2,17 @@ package agentextension
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
 )
 
 func TestReleaseDownloadsRejectIntermediateHTTPSDowngradeRedirect(t *testing.T) {
@@ -107,5 +113,56 @@ func TestReleaseDownloadsRejectConfiguredRedirectPolicyHTTPSDowngrade(t *testing
 	}
 	if insecureRequests != 0 {
 		t.Fatalf("insecure redirect target received %d requests", insecureRequests)
+	}
+}
+
+func TestVerifyReleasePreservesSignedOptionalManifestFields(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	document := map[string]any{
+		"schemaVersion":     releaseSchema,
+		"agentKey":          "grok",
+		"version":           "0.1.2",
+		"artifactUrl":       "https://example.test/grok-0.1.2.zip",
+		"artifactSha256":    "abc",
+		"artifactSizeBytes": 1,
+		"publishedAt":       "2026-07-21T00:00:00Z",
+		"gitSha":            "test",
+		"manifest": map[string]any{
+			"schemaVersion": "tutti.agent.manifest.v2",
+			"agentKey":      "grok",
+			"version":       "0.1.2",
+			"name":          "Grok Build",
+			"icon":          map[string]any{"type": "asset", "src": "assets/icon.svg"},
+			"runtime": map[string]any{
+				"kind":    "standard-acp",
+				"install": map[string]any{"runner": "binary"},
+				"launch":  map[string]any{"executable": "grok", "args": []string{"agent", "stdio"}},
+			},
+			"profiles": map[string]any{"discovery": "profiles/discovery.json"},
+		},
+		"signature": map[string]any{
+			"algorithm": "ed25519",
+			"keyId":     "test-grok-key",
+			"value":     "",
+		},
+	}
+	payload, err := releasePayloadFromJSON(mustJSON(t, document))
+	if err != nil {
+		t.Fatal(err)
+	}
+	document["signature"].(map[string]any)["value"] = base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, payload))
+
+	var release Release
+	if err := json.Unmarshal(mustJSON(t, document), &release); err != nil {
+		t.Fatal(err)
+	}
+	source := tuttitypes.AgentExtensionSource{
+		Key: "grok", SigningKeyID: "test-grok-key", SigningPublicKey: publicKeyPEM(t, publicKey),
+	}
+	if err := verifyRelease(release, source); err != nil {
+		t.Fatalf("verifyRelease() error = %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- preserve the unsigned JSON payload captured when an extension release is decoded
- verify against that payload instead of rebuilding optional manifest fields from Go structs
- cover signed manifests that omit optional image fields

## Validation
- `pnpm check:changed -- --push-ready`

No documentation impact: this is an internal signature-verification correction with no public contract change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->