### PR TITLE
fix(tuttid): register lab.previewAgents in daemon Lab registry

### DIFF
--- a/packages/agent/store-sqlite/activity_replication_conformance_test.go
+++ b/packages/agent/store-sqlite/activity_replication_conformance_test.go
@@ -126,7 +126,11 @@ func (b *sqliteProjectionBuilder) Build(ctx context.Context) (activityreplicatio
 		mutation.TransactionID = "sqlite-projection"
 		mutations = append(mutations, mutation)
 	}
-	return activityreplication.ChangeBatch{SchemaVersion: activityreplication.SchemaVersion, Mutations: mutations}, nil
+	return activityreplication.ChangeBatch{
+		SchemaVersion:   activityreplication.SchemaVersion,
+		ProjectionEpoch: activityreplication.ProjectionEpoch,
+		Mutations:       mutations,
+	}, nil
 }
 
 func (b *sqliteProjectionBuilder) seedMutation(ctx context.Context, mutation activityreplication.Mutation) error {

--- a/services/tuttid/biz/preferences/lab_flags.go
+++ b/services/tuttid/biz/preferences/lab_flags.go
@@ -10,6 +10,8 @@ const (
 	LabFlagModelPlans      = "lab.modelPlans"
 	LabFlagWorkspaceAgents = "lab.workspaceAgents"
 	LabFlagAutomationRules = "lab.automationRules"
+	// Durable key for Early Access agent-integration visibility (Agents directory).
+	LabFlagPreviewAgents = "lab.previewAgents"
 )
 
 // labFlagDefaults is fail-closed: every Lab flag defaults to off.
@@ -18,6 +20,7 @@ var labFlagDefaults = map[string]bool{
 	LabFlagModelPlans:      false,
 	LabFlagWorkspaceAgents: false,
 	LabFlagAutomationRules: false,
+	LabFlagPreviewAgents:   false,
 }
 
 // IsLabFlag reports whether key is a registered Lab flag.

--- a/services/tuttid/biz/preferences/lab_flags_test.go
+++ b/services/tuttid/biz/preferences/lab_flags_test.go
@@ -8,6 +8,7 @@ func TestLabFlagRegistryKeysAndDefaults(t *testing.T) {
 		LabFlagModelPlans,
 		LabFlagWorkspaceAgents,
 		LabFlagAutomationRules,
+		LabFlagPreviewAgents,
 	}
 	if len(labFlagDefaults) != len(keys) {
 		t.Fatalf("registry has %d entries, want %d", len(labFlagDefaults), len(keys))
@@ -40,6 +41,7 @@ func TestIsLabFlagEnabledFailsClosed(t *testing.T) {
 		LabFlagModelPlans,
 		LabFlagWorkspaceAgents,
 		LabFlagAutomationRules,
+		LabFlagPreviewAgents,
 	} {
 		if IsLabFlagEnabled(nil, key) {
 			t.Fatalf("IsLabFlagEnabled(nil, %q) = true, want false", key)


### PR DESCRIPTION
## Summary
- Register `lab.previewAgents` in the daemon Lab flag registry (`lab_flags.go`) with fail-closed default `false`, matching the existing renderer catalog entry from #1401.
- Keep the durable key unchanged so existing profiles are unaffected; presentation copy stays in the renderer (`Early access agent integrations` / 抢先体验 Agent 集成).
- No daemon write-route guard: this flag only controls Agents-directory / Early Access integration visibility. Ownership stays in the renderer sync path (`desktopAgentsEarlyAccessSync`), consistent with the “flag infra distributes config; feature owns semantics” pattern from #1436.

## Flag classification
| Item | Decision |
|---|---|
| Kind | UI-preference (entry visibility), not a capability flag |
| Daemon write guard | Not needed — no write API should be rejected when off |
| Key | `lab.previewAgents` (durable; unchanged) |
| Default | `false` (fail-closed) |
| Terminology | Lab section + Early Access display name (same exception as `lab.workspaceAgents` → Custom Agents) |

## Context
`feat/hermes-acp-integration` feature work already landed via #1297 / #1401; this PR only closes the remaining Go↔TS key-contract gap called out after #1436.

## Test plan
- [x] `go test ./services/tuttid/biz/preferences/...`
- [ ] Confirm Lab settings still toggles `lab.previewAgents` and Agents directory visibility follows the existing Early Access sync
- [ ] Confirm profiles that already store `lab.previewAgents: true` keep working after pull


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->