### PR TITLE
fix(tooling): harden local validation workflow

### DIFF
--- a/docs/conventions/local-git-hooks.md
+++ b/docs/conventions/local-git-hooks.md
@@ -153,8 +153,15 @@ Failure output prints an 80-line tail by default. Use
 `pnpm check:changed -- --tail-lines <n>` when a larger or smaller tail is more
 useful; full logs remain in `.tmp/check-runs`.
 
+The runner rejects unknown options, missing option values, and invalid positive
+integer values. A misspelled `--push-ready` or malformed concurrency value must
+fail instead of silently selecting a weaker or empty validation plan.
+
 After failures, prefer `pnpm check:changed -- --failed-only` to rerun failed
-lanes instead of repeating successful lanes.
+lanes instead of repeating successful lanes. Failed-lane state is bound to the
+validated base ref, HEAD, index, working tree, and untracked file contents. If
+any of those change, `--failed-only` refuses the stale result and requires a
+normal `pnpm check:changed` run.
 
 When the changed set includes deleted package test files, `check:changed` should
 not pass those missing paths to Vitest as explicit targets. Deleting source files

--- a/packages/agent/gui/vitest.setup.ts
+++ b/packages/agent/gui/vitest.setup.ts
@@ -85,6 +85,32 @@ if (typeof Range !== "undefined") {
   });
 }
 
+const testLocalStorageValues = new Map<string, string>();
+const testLocalStorage: Storage = {
+  get length() {
+    return testLocalStorageValues.size;
+  },
+  clear() {
+    testLocalStorageValues.clear();
+  },
+  getItem(key) {
+    return testLocalStorageValues.get(key) ?? null;
+  },
+  key(index) {
+    return Array.from(testLocalStorageValues.keys())[index] ?? null;
+  },
+  removeItem(key) {
+    testLocalStorageValues.delete(key);
+  },
+  setItem(key, value) {
+    testLocalStorageValues.set(key, String(value));
+  }
+};
+Object.defineProperty(window, "localStorage", {
+  configurable: true,
+  value: testLocalStorage
+});
+
 let restoreReactRenderLoopConsoleTrap: (() => void) | null = null;
 
 beforeEach(() => {
@@ -94,7 +120,7 @@ beforeEach(() => {
   });
   resetAgentHostApiForTests();
   resetMentionSearchBrowseCacheForTests();
-  installTestLocalStorage();
+  testLocalStorage.clear();
   installTestAgentHostApi();
 });
 
@@ -115,28 +141,6 @@ function resetMentionSearchBrowseCacheForTests(): void {
       __tuttiResetAgentMentionSearchBrowseCacheForTests?: () => void;
     }
   ).__tuttiResetAgentMentionSearchBrowseCacheForTests?.();
-}
-
-function installTestLocalStorage(): void {
-  if (typeof window.localStorage?.clear === "function") {
-    return;
-  }
-  const values = new Map<string, string>();
-  Object.defineProperty(window, "localStorage", {
-    configurable: true,
-    value: {
-      get length() {
-        return values.size;
-      },
-      clear: () => values.clear(),
-      getItem: (key: string) => values.get(key) ?? null,
-      key: (index: number) => Array.from(values.keys())[index] ?? null,
-      removeItem: (key: string) => values.delete(key),
-      setItem: (key: string, value: string) => {
-        values.set(key, String(value));
-      }
-    }
-  });
 }
 
 function installTestAgentHostApi(): void {

--- a/tools/scripts/check-agent-gui-degradation.mjs
+++ b/tools/scripts/check-agent-gui-degradation.mjs
@@ -905,7 +905,8 @@ function readMergeHead(workspaceRoot) {
   try {
     return execFileSync("git", ["rev-parse", "--verify", "MERGE_HEAD"], {
       cwd: workspaceRoot,
-      encoding: "utf8"
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
     }).trim();
   } catch {
     return null;

--- a/tools/scripts/check-agent-gui-degradation.test.mjs
+++ b/tools/scripts/check-agent-gui-degradation.test.mjs
@@ -499,6 +499,7 @@ test("staged mode flags violations on staged added lines end to end", async () =
   runFixtureGit(workspaceRoot, ["add", "."]);
   const pass = runScript(workspaceRoot, baselinePath, ["--staged"]);
   assert.equal(pass.status, 0, pass.stderr || pass.stdout);
+  assert.doesNotMatch(pass.stderr, /fatal:/u);
 });
 
 test("full mode fails with instructions when the baseline is missing", async () => {

--- a/tools/scripts/push-checked.test.mjs
+++ b/tools/scripts/push-checked.test.mjs
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  writeFile
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const sourceScriptPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "push-checked.mjs"
+);
+
+test("push-checked validates and pushes with the fetched remote lease", async () => {
+  const fixture = await createFixture();
+  await commitLocalChange(fixture.workspaceRoot, "local change");
+
+  const result = runPushChecked(fixture);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(
+    remoteHead(fixture.remoteRoot),
+    localHead(fixture.workspaceRoot)
+  );
+  assert.equal(await readFile(fixture.pnpmLogPath, "utf8"), "run check:full\n");
+  assert.match(result.stdout, /push:checked pushed/u);
+});
+
+test("push-checked rejects a dirty worktree before validation", async () => {
+  const fixture = await createFixture();
+  await writeFile(join(fixture.workspaceRoot, "source.txt"), "dirty\n");
+
+  const result = runPushChecked(fixture);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /commit or stash local changes/u);
+});
+
+test("push-checked lease rejects a concurrent remote update", async () => {
+  const fixture = await createFixture();
+  const peerRoot = await mkdtemp(join(tmpdir(), "push-checked-peer-"));
+  runGit(tmpdir(), [
+    "clone",
+    "--quiet",
+    "--branch",
+    "main",
+    fixture.remoteRoot,
+    peerRoot
+  ]);
+  await commitLocalChange(fixture.workspaceRoot, "local change");
+
+  const result = runPushChecked(fixture, {
+    TUTTI_PUSH_CHECKED_TEST_PEER: peerRoot
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(remoteHead(fixture.remoteRoot), localHead(peerRoot));
+  assert.notEqual(
+    remoteHead(fixture.remoteRoot),
+    localHead(fixture.workspaceRoot)
+  );
+  assert.match(result.stderr, /stale info/u);
+});
+
+async function createFixture() {
+  const workspaceRoot = await mkdtemp(
+    join(tmpdir(), "push-checked-workspace-")
+  );
+  const remoteRoot = await mkdtemp(join(tmpdir(), "push-checked-remote-"));
+  const binRoot = await mkdtemp(join(tmpdir(), "push-checked-bin-"));
+  const copiedScriptPath = join(
+    workspaceRoot,
+    "tools/scripts/push-checked.mjs"
+  );
+  const pnpmPath = join(binRoot, "pnpm");
+  const pnpmLogPath = join(binRoot, "pnpm.log");
+
+  await mkdir(dirname(copiedScriptPath), { recursive: true });
+  await copyFile(sourceScriptPath, copiedScriptPath);
+  await writeFile(
+    pnpmPath,
+    [
+      "#!/usr/bin/env node",
+      'import { appendFileSync } from "node:fs";',
+      'import { spawnSync } from "node:child_process";',
+      "",
+      'appendFileSync(process.env.TUTTI_PUSH_CHECKED_TEST_LOG, `${process.argv.slice(2).join(" ")}\\n`);',
+      "const peer = process.env.TUTTI_PUSH_CHECKED_TEST_PEER;",
+      "if (peer) {",
+      '  const commit = spawnSync("git", ["-C", peer, "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "--quiet", "--allow-empty", "-m", "concurrent"], { encoding: "utf8" });',
+      "  if (commit.status !== 0) process.exit(commit.status ?? 1);",
+      '  const push = spawnSync("git", ["-C", peer, "push", "--quiet", "origin", "HEAD:main"], { encoding: "utf8" });',
+      "  if (push.status !== 0) process.exit(push.status ?? 1);",
+      "}",
+      ""
+    ].join("\n")
+  );
+  await chmod(pnpmPath, 0o755);
+
+  runGit(remoteRoot, ["init", "--bare", "--quiet"]);
+  runGit(workspaceRoot, ["init", "--quiet", "--initial-branch=main"]);
+  await writeFile(join(workspaceRoot, "source.txt"), "initial\n");
+  runGit(workspaceRoot, ["add", "."]);
+  commit(workspaceRoot, "initial");
+  runGit(workspaceRoot, ["remote", "add", "origin", remoteRoot]);
+  runGit(workspaceRoot, [
+    "push",
+    "--quiet",
+    "--set-upstream",
+    "origin",
+    "main"
+  ]);
+  runGit(remoteRoot, ["symbolic-ref", "HEAD", "refs/heads/main"]);
+
+  return {
+    binRoot,
+    copiedScriptPath,
+    pnpmLogPath,
+    remoteRoot,
+    workspaceRoot
+  };
+}
+
+async function commitLocalChange(workspaceRoot, message) {
+  await writeFile(join(workspaceRoot, "source.txt"), `${message}\n`);
+  runGit(workspaceRoot, ["add", "source.txt"]);
+  commit(workspaceRoot, message);
+}
+
+function commit(workspaceRoot, message) {
+  runGit(workspaceRoot, [
+    "-c",
+    "user.email=test@example.com",
+    "-c",
+    "user.name=Test",
+    "commit",
+    "--quiet",
+    "-m",
+    message
+  ]);
+}
+
+function runPushChecked(fixture, extraEnv = {}) {
+  return spawnSync(process.execPath, [fixture.copiedScriptPath], {
+    cwd: fixture.workspaceRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...extraEnv,
+      PATH: `${fixture.binRoot}:${process.env.PATH ?? ""}`,
+      TUTTI_PUSH_CHECKED_TEST_LOG: fixture.pnpmLogPath
+    }
+  });
+}
+
+function localHead(workspaceRoot) {
+  return runGit(workspaceRoot, ["rev-parse", "HEAD"]).stdout.trim();
+}
+
+function remoteHead(remoteRoot) {
+  return runGit(remoteRoot, ["rev-parse", "refs/heads/main"]).stdout.trim();
+}
+
+function runGit(cwd, args) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result;
+}

--- a/tools/scripts/run-check-changed.mjs
+++ b/tools/scripts/run-check-changed.mjs
@@ -1,4 +1,5 @@
 import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   createWriteStream,
   existsSync,
@@ -25,13 +26,13 @@ const workspaceRoot = join(scriptDirectory, "..", "..");
 const golangciLintBinary = resolveGolangciLintBinary({ cwd: workspaceRoot });
 const pnpmCommand = resolvePnpmCommand();
 const pnpmShellCommand = formatCommand(pnpmCommand);
-const maxParallel = Number.parseInt(readOption("--max-parallel") ?? "4", 10);
-const tailLines = readPositiveIntegerOption("--tail-lines", 80);
-const dryRun = process.argv.includes("--dry-run");
-const failedOnly = process.argv.includes("--failed-only");
-const pushReady = process.argv.includes("--push-ready");
-const verbose = process.argv.includes("--verbose");
-const baseRef = readOption("--base") ?? resolveDefaultBaseRef();
+let maxParallel = 4;
+let tailLines = 80;
+let dryRun = false;
+let failedOnly = false;
+let pushReady = false;
+let verbose = false;
+let baseRef = resolveDefaultBaseRef();
 const tmpRoot = join(workspaceRoot, ".tmp", "check-runs");
 const latestSummaryPath = join(tmpRoot, "latest.json");
 
@@ -54,6 +55,11 @@ export async function main() {
     return;
   }
 
+  const validationFingerprint = buildValidationFingerprint({
+    baseRef,
+    workspaceRoot
+  });
+
   const runId = new Date().toISOString().replace(/[:.]/g, "-");
   const runDirectory = join(tmpRoot, runId);
   mkdirSync(runDirectory, { recursive: true });
@@ -74,6 +80,7 @@ export async function main() {
     runDirectory,
     startedAt: new Date(startedAt).toISOString(),
     tailLines,
+    validationFingerprint,
     results
   };
   writeFileSync(
@@ -255,6 +262,14 @@ function readFailedLanes() {
     return [];
   }
   const summary = JSON.parse(readFileSync(latestSummaryPath, "utf8"));
+  if (!summary.baseRef || !summary.validationFingerprint) {
+    validateFailedRunSummary(summary, null);
+  }
+  const currentFingerprint = buildValidationFingerprint({
+    baseRef,
+    workspaceRoot
+  });
+  validateFailedRunSummary(summary, currentFingerprint);
   return (summary.results ?? [])
     .filter((result) => result.exitCode !== 0)
     .map((result) => ({
@@ -262,6 +277,19 @@ function readFailedLanes() {
       label: result.label,
       command: result.command
     }));
+}
+
+export function validateFailedRunSummary(summary, currentFingerprint) {
+  if (!summary.baseRef || !summary.validationFingerprint) {
+    throw new UserFacingError(
+      "cannot reuse legacy failed-lane state; run pnpm check:changed"
+    );
+  }
+  if (currentFingerprint !== summary.validationFingerprint) {
+    throw new UserFacingError(
+      "workspace or base changed since the failed run; run pnpm check:changed"
+    );
+  }
 }
 
 export async function runLanes(inputLanes, runDirectory) {
@@ -450,21 +478,116 @@ function resolvePnpmCommand() {
   }
 }
 
-function readOption(name) {
-  const index = process.argv.indexOf(name);
-  if (index === -1) {
-    return null;
+export function parseCliArgs(inputArgs) {
+  const options = {
+    baseRef: null,
+    dryRun: false,
+    failedOnly: false,
+    maxParallel: 4,
+    pushReady: false,
+    tailLines: 80,
+    verbose: false
+  };
+  const args = inputArgs.filter((arg) => arg !== "--");
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--dry-run":
+        options.dryRun = true;
+        break;
+      case "--failed-only":
+        options.failedOnly = true;
+        break;
+      case "--push-ready":
+        options.pushReady = true;
+        break;
+      case "--verbose":
+        options.verbose = true;
+        break;
+      case "--base":
+        options.baseRef = readCliValue(args, ++index, arg);
+        break;
+      case "--max-parallel":
+        options.maxParallel = readPositiveIntegerCliValue(args, ++index, arg);
+        break;
+      case "--tail-lines":
+        options.tailLines = readPositiveIntegerCliValue(args, ++index, arg);
+        break;
+      default:
+        throw new UserFacingError(`unknown option: ${arg}`);
+    }
   }
-  return process.argv[index + 1] ?? null;
+
+  return options;
 }
 
-function readPositiveIntegerOption(name, defaultValue) {
-  const value = readOption(name);
-  if (value === null) {
-    return defaultValue;
+function readCliValue(args, index, option) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    throw new UserFacingError(`${option} requires a value`);
   }
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+  return value;
+}
+
+function readPositiveIntegerCliValue(args, index, option) {
+  const value = readCliValue(args, index, option);
+  if (!/^[1-9]\d*$/u.test(value)) {
+    throw new UserFacingError(`${option} requires a positive integer`);
+  }
+  return Number.parseInt(value, 10);
+}
+
+function applyCliOptions(options) {
+  maxParallel = options.maxParallel;
+  tailLines = options.tailLines;
+  dryRun = options.dryRun;
+  failedOnly = options.failedOnly;
+  pushReady = options.pushReady;
+  verbose = options.verbose;
+  baseRef = options.baseRef ?? resolveDefaultBaseRef();
+}
+
+export function buildValidationFingerprint(input) {
+  const root = input.workspaceRoot;
+  const hash = createHash("sha256");
+  const addGitOutput = (label, args) => {
+    const result = spawnSync("git", args, {
+      cwd: root,
+      encoding: null
+    });
+    if (result.status !== 0) {
+      throw new Error(
+        `check:changed failed to fingerprint git ${args.join(" ")}`
+      );
+    }
+    hash.update(label);
+    hash.update(result.stdout);
+  };
+
+  hash.update(`base-ref:${input.baseRef}\n`);
+  addGitOutput("base-oid", ["rev-parse", "--verify", input.baseRef]);
+  addGitOutput("head-oid", ["rev-parse", "--verify", "HEAD"]);
+  addGitOutput("working-diff", ["diff", "--binary", "HEAD"]);
+  addGitOutput("staged-diff", ["diff", "--cached", "--binary", "HEAD"]);
+
+  const untrackedResult = spawnSync(
+    "git",
+    ["ls-files", "--others", "--exclude-standard", "-z"],
+    { cwd: root, encoding: "utf8" }
+  );
+  if (untrackedResult.status !== 0) {
+    throw new Error("check:changed failed to fingerprint untracked files");
+  }
+  for (const file of untrackedResult.stdout
+    .split("\0")
+    .filter(Boolean)
+    .sort()) {
+    hash.update(`untracked:${file}\n`);
+    hash.update(readFileSync(join(root, file)));
+  }
+
+  return hash.digest("hex");
 }
 
 function isLintableCodeFile(file) {
@@ -548,12 +671,21 @@ function failureExcerpt(path, lineCount) {
   };
 }
 
+class UserFacingError extends Error {}
+
 const currentPath = fileURLToPath(import.meta.url);
 if (process.argv[1] && resolve(process.argv[1]) === currentPath) {
-  main().catch((error) => {
-    console.error(
-      error instanceof Error ? (error.stack ?? error.message) : error
-    );
-    process.exitCode = 1;
-  });
+  Promise.resolve()
+    .then(() => applyCliOptions(parseCliArgs(process.argv.slice(2))))
+    .then(() => main())
+    .catch((error) => {
+      console.error(
+        error instanceof UserFacingError
+          ? `check:changed: ${error.message}`
+          : error instanceof Error
+            ? (error.stack ?? error.message)
+            : error
+      );
+      process.exitCode = 1;
+    });
 }

--- a/tools/scripts/run-check-changed.test.mjs
+++ b/tools/scripts/run-check-changed.test.mjs
@@ -1,17 +1,120 @@
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 import {
+  buildValidationFingerprint,
+  parseCliArgs,
   printSummary,
   runLanes,
-  selectExistingLintFiles
+  selectExistingLintFiles,
+  validateFailedRunSummary
 } from "./run-check-changed.mjs";
 import {
   isAgentActivityRuntimeBoundaryRelevant,
   isRendererBoundaryRelevant
 } from "./repository-checks.mjs";
+
+test("parseCliArgs rejects unknown and invalid options", () => {
+  assert.throws(() => parseCliArgs(["--push-reddy"]), /unknown option/u);
+  assert.throws(
+    () => parseCliArgs(["--max-parallel", "nope"]),
+    /positive integer/u
+  );
+  assert.throws(() => parseCliArgs(["--base"]), /requires a value/u);
+});
+
+test("parseCliArgs accepts pnpm separators and explicit values", () => {
+  assert.deepEqual(
+    parseCliArgs([
+      "--",
+      "--dry-run",
+      "--push-ready",
+      "--base",
+      "origin/trunk",
+      "--max-parallel",
+      "2",
+      "--tail-lines",
+      "40"
+    ]),
+    {
+      baseRef: "origin/trunk",
+      dryRun: true,
+      failedOnly: false,
+      maxParallel: 2,
+      pushReady: true,
+      tailLines: 40,
+      verbose: false
+    }
+  );
+});
+
+test("validation fingerprint changes with working and staged state", () => {
+  const workspaceRoot = mkdtempSync(join(tmpdir(), "check-fingerprint-"));
+  runFixtureGit(workspaceRoot, ["init", "--quiet"]);
+  const sourcePath = join(workspaceRoot, "source.ts");
+  writeFileSync(sourcePath, "export const value = 1;\n");
+  runFixtureGit(workspaceRoot, ["add", "source.ts"]);
+  runFixtureGit(workspaceRoot, [
+    "-c",
+    "user.email=test@example.com",
+    "-c",
+    "user.name=Test",
+    "commit",
+    "--quiet",
+    "-m",
+    "init"
+  ]);
+  const initial = buildValidationFingerprint({
+    baseRef: "HEAD",
+    workspaceRoot
+  });
+  const differentBase = buildValidationFingerprint({
+    baseRef: "HEAD^{commit}",
+    workspaceRoot
+  });
+  assert.notEqual(differentBase, initial);
+
+  writeFileSync(sourcePath, "export const value = 2;\n");
+  const working = buildValidationFingerprint({
+    baseRef: "HEAD",
+    workspaceRoot
+  });
+  assert.notEqual(working, initial);
+
+  runFixtureGit(workspaceRoot, ["add", "source.ts"]);
+  writeFileSync(sourcePath, "export const value = 3;\n");
+  const staged = buildValidationFingerprint({ baseRef: "HEAD", workspaceRoot });
+  runFixtureGit(workspaceRoot, ["reset", "--quiet"]);
+  const unstaged = buildValidationFingerprint({
+    baseRef: "HEAD",
+    workspaceRoot
+  });
+  assert.notEqual(staged, unstaged);
+});
+
+test("failed-only state must match the validated workspace", () => {
+  assert.throws(
+    () => validateFailedRunSummary({ baseRef: "HEAD" }, null),
+    /legacy failed-lane state/u
+  );
+  assert.throws(
+    () =>
+      validateFailedRunSummary(
+        { baseRef: "HEAD", validationFingerprint: "before" },
+        "after"
+      ),
+    /workspace or base changed/u
+  );
+  assert.doesNotThrow(() =>
+    validateFailedRunSummary(
+      { baseRef: "HEAD", validationFingerprint: "same" },
+      "same"
+    )
+  );
+});
 
 test("renderer boundary lane covers renderer and checker changes", () => {
   for (const file of [
@@ -144,3 +247,11 @@ test("printSummary includes rerun hint for failures", () => {
     /Rerun failed lanes with: pnpm check:changed -- --failed-only/u
   );
 });
+
+function runFixtureGit(workspaceRoot, args) {
+  const result = spawnSync("git", args, {
+    cwd: workspaceRoot,
+    encoding: "utf8"
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+}


### PR DESCRIPTION
## Summary
- reject unknown or malformed `check:changed` options
- bind `--failed-only` reuse to base, HEAD, index, worktree, and untracked contents
- add black-box coverage for `push:checked` validation and explicit leases
- silence expected MERGE_HEAD lookup noise and install deterministic Agent GUI test storage

## Tests
- `node --test tools/scripts/run-check-changed.test.mjs tools/scripts/check-agent-gui-degradation.test.mjs tools/scripts/push-checked.test.mjs`
- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=1 agent-message-center/messageCenterFilterPreferences.spec.ts agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx`
- pre-push: `pnpm check:changed -- --push-ready` (12 lanes)

## Risks
- failed-only summaries created before validation fingerprints are intentionally rejected; run a normal `pnpm check:changed` once
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->