### PR TITLE
fix(packages): share Tiptap peer runtime

### DIFF
--- a/docs/conventions/npm-package-release.md
+++ b/docs/conventions/npm-package-release.md
@@ -191,6 +191,12 @@ Published packages should not include:
 - package-local build config
 - generated junk files
 
+Packages that expose Tiptap runtime objects or types must declare their shared
+Tiptap runtime packages as peer dependencies, with the same ranges repeated as
+development dependencies for workspace builds. Component-internal extensions
+can remain regular dependencies. A package-private copy of the shared runtime
+can make structurally identical extensions type-incompatible in consumers.
+
 Runtime assets that are rendered or referenced by public entrypoints must also
 survive the packed package shape. When a public runtime entrypoint such as
 `./workbench` or `./ui` renders a package-local image, icon bitmap, schema, or

--- a/packages/agent/gui/package.json
+++ b/packages/agent/gui/package.json
@@ -57,11 +57,6 @@
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-virtual": "^3.13.12",
-    "@tiptap/core": "^3.11.1",
-    "@tiptap/pm": "^3.23.6",
-    "@tiptap/react": "^3.11.1",
-    "@tiptap/starter-kit": "^3.11.1",
-    "@tiptap/suggestion": "^3.11.1",
     "@tutti-os/agent-activity-core": "workspace:*",
     "@tutti-os/browser-node": "workspace:*",
     "@tutti-os/ui-i18n-runtime": "workspace:*",
@@ -90,6 +85,11 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
+    "@tiptap/core": "^3.11.1",
+    "@tiptap/pm": "^3.23.6",
+    "@tiptap/react": "^3.11.1",
+    "@tiptap/starter-kit": "^3.11.1",
+    "@tiptap/suggestion": "^3.11.1",
     "@tutti-os/client-tuttid-ts": "workspace:*",
     "@tutti-os/config-tsconfig": "workspace:*",
     "@types/lodash": "^4.17.24",
@@ -105,6 +105,11 @@
     "vitest": "^4.0.13"
   },
   "peerDependencies": {
+    "@tiptap/core": "^3.11.1",
+    "@tiptap/pm": "^3.23.6",
+    "@tiptap/react": "^3.11.1",
+    "@tiptap/starter-kit": "^3.11.1",
+    "@tiptap/suggestion": "^3.11.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/packages/ui/rich-text/package.json
+++ b/packages/ui/rich-text/package.json
@@ -30,16 +30,16 @@
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },
   "dependencies": {
-    "@tutti-os/ui-i18n-runtime": "workspace:*",
-    "@tutti-os/ui-system": "workspace:*",
-    "@tiptap/core": "^3.23.6",
     "@tiptap/extension-document": "^3.23.6",
     "@tiptap/extension-hard-break": "^3.23.6",
     "@tiptap/extension-paragraph": "^3.23.6",
     "@tiptap/extension-text": "^3.23.6",
-    "@tiptap/react": "^3.23.6"
+    "@tutti-os/ui-i18n-runtime": "workspace:*",
+    "@tutti-os/ui-system": "workspace:*"
   },
   "devDependencies": {
+    "@tiptap/core": "^3.23.6",
+    "@tiptap/react": "^3.23.6",
     "@tutti-os/config-tsconfig": "workspace:*",
     "@types/node": "^24.0.1",
     "@types/react": "^19.1.6",
@@ -49,6 +49,8 @@
     "typescript": "^5.8.3"
   },
   "peerDependencies": {
+    "@tiptap/core": "^3.23.6",
+    "@tiptap/react": "^3.23.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,21 +272,6 @@ importers:
       "@tanstack/react-virtual":
         specifier: ^3.13.12
         version: 3.13.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@tiptap/core":
-        specifier: ^3.11.1
-        version: 3.23.6(@tiptap/pm@3.23.6)
-      "@tiptap/pm":
-        specifier: ^3.23.6
-        version: 3.23.6
-      "@tiptap/react":
-        specifier: ^3.11.1
-        version: 3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@tiptap/starter-kit":
-        specifier: ^3.11.1
-        version: 3.23.6
-      "@tiptap/suggestion":
-        specifier: ^3.11.1
-        version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
       "@tutti-os/agent-activity-core":
         specifier: workspace:*
         version: link:../activity-core
@@ -372,6 +357,21 @@ importers:
       "@testing-library/react":
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@tiptap/core":
+        specifier: ^3.11.1
+        version: 3.23.6(@tiptap/pm@3.23.6)
+      "@tiptap/pm":
+        specifier: ^3.23.6
+        version: 3.23.6
+      "@tiptap/react":
+        specifier: ^3.11.1
+        version: 3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@tiptap/starter-kit":
+        specifier: ^3.11.1
+        version: 3.23.6
+      "@tiptap/suggestion":
+        specifier: ^3.11.1
+        version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
       "@tutti-os/client-tuttid-ts":
         specifier: workspace:*
         version: link:../../clients/tuttid-ts
@@ -556,9 +556,6 @@ importers:
 
   packages/ui/rich-text:
     dependencies:
-      "@tiptap/core":
-        specifier: ^3.23.6
-        version: 3.23.6(@tiptap/pm@3.23.6)
       "@tiptap/extension-document":
         specifier: ^3.23.6
         version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
@@ -571,9 +568,6 @@ importers:
       "@tiptap/extension-text":
         specifier: ^3.23.6
         version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
-      "@tiptap/react":
-        specifier: ^3.23.6
-        version: 3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@tutti-os/ui-i18n-runtime":
         specifier: workspace:*
         version: link:../i18n-runtime
@@ -581,6 +575,12 @@ importers:
         specifier: workspace:*
         version: link:../system
     devDependencies:
+      "@tiptap/core":
+        specifier: ^3.23.6
+        version: 3.23.6(@tiptap/pm@3.23.6)
+      "@tiptap/react":
+        specifier: ^3.23.6
+        version: 3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@tutti-os/config-tsconfig":
         specifier: workspace:*
         version: link:../../configs/tsconfig

--- a/tools/scripts/check-package-packs.mjs
+++ b/tools/scripts/check-package-packs.mjs
@@ -15,6 +15,7 @@ import {
   packedFilesWithRawSvgDataUrls,
   packedFilesWithRelativeSvgUrls
 } from "./package-pack-svg-data-urls.mjs";
+import { packagePeerContractViolations } from "./package-pack-peer-contracts.mjs";
 
 const forbiddenPrefixes = [
   "package/src/",
@@ -54,6 +55,9 @@ async function checkPackage(packageConfig, destination) {
   const entries = listTarballEntries(tarballPath);
   const entrySet = new Set(entries);
   const violations = [];
+  violations.push(
+    ...packagePeerContractViolations(packageConfig.name, packageConfig.manifest)
+  );
   const requiredFiles = getRequiredFiles(packageConfig.manifest);
   const packageForbiddenPrefixes = sourcePublishingPackages.has(
     packageConfig.name

--- a/tools/scripts/package-pack-peer-contracts.mjs
+++ b/tools/scripts/package-pack-peer-contracts.mjs
@@ -1,0 +1,36 @@
+const requiredTiptapPeers = new Map([
+  [
+    "@tutti-os/agent-gui",
+    [
+      "@tiptap/core",
+      "@tiptap/pm",
+      "@tiptap/react",
+      "@tiptap/starter-kit",
+      "@tiptap/suggestion"
+    ]
+  ],
+  ["@tutti-os/ui-rich-text", ["@tiptap/core", "@tiptap/react"]]
+]);
+
+export function packagePeerContractViolations(packageName, manifest) {
+  const requiredPeers = requiredTiptapPeers.get(packageName);
+  if (!requiredPeers) return [];
+
+  const dependencies = manifest.dependencies ?? {};
+  const devDependencies = manifest.devDependencies ?? {};
+  const peerDependencies = manifest.peerDependencies ?? {};
+  const violations = [];
+
+  for (const name of requiredPeers) {
+    if (Object.hasOwn(dependencies, name)) {
+      violations.push(`${name} must be a peer dependency`);
+    }
+    if (!Object.hasOwn(peerDependencies, name)) {
+      violations.push(`${name} is missing from peerDependencies`);
+    } else if (devDependencies[name] !== peerDependencies[name]) {
+      violations.push(`${name} must use the same peer and dev range`);
+    }
+  }
+
+  return violations;
+}

--- a/tools/scripts/package-pack-peer-contracts.test.mjs
+++ b/tools/scripts/package-pack-peer-contracts.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { packagePeerContractViolations } from "./package-pack-peer-contracts.mjs";
+
+test("accepts matching Tiptap peer and development dependencies", () => {
+  assert.deepEqual(
+    packagePeerContractViolations("@tutti-os/ui-rich-text", {
+      dependencies: { "@tiptap/extension-document": "^3.23.6" },
+      devDependencies: { "@tiptap/core": "^3.23.6" },
+      peerDependencies: { "@tiptap/core": "^3.23.6" }
+    }),
+    ["@tiptap/react is missing from peerDependencies"]
+  );
+  assert.deepEqual(
+    packagePeerContractViolations("@tutti-os/ui-rich-text", {
+      dependencies: { "@tiptap/extension-document": "^3.23.6" },
+      devDependencies: {
+        "@tiptap/core": "^3.23.6",
+        "@tiptap/react": "^3.23.6"
+      },
+      peerDependencies: {
+        "@tiptap/core": "^3.23.6",
+        "@tiptap/react": "^3.23.6"
+      }
+    }),
+    []
+  );
+});
+
+test("rejects package-private or mismatched Tiptap dependencies", () => {
+  assert.deepEqual(
+    packagePeerContractViolations("@tutti-os/ui-rich-text", {
+      devDependencies: {
+        "@tiptap/core": "^3.23.6",
+        "@tiptap/react": "^3.23.6"
+      },
+      peerDependencies: { "@tiptap/react": "^3.23.6" }
+    }),
+    ["@tiptap/core is missing from peerDependencies"]
+  );
+  assert.deepEqual(
+    packagePeerContractViolations("@tutti-os/agent-gui", {
+      dependencies: { "@tiptap/core": "^3.11.1" },
+      devDependencies: { "@tiptap/core": "^3.23.6" }
+    }),
+    [
+      "@tiptap/core must be a peer dependency",
+      "@tiptap/core is missing from peerDependencies",
+      "@tiptap/pm is missing from peerDependencies",
+      "@tiptap/react is missing from peerDependencies",
+      "@tiptap/starter-kit is missing from peerDependencies",
+      "@tiptap/suggestion is missing from peerDependencies"
+    ]
+  );
+  assert.deepEqual(
+    packagePeerContractViolations("@tutti-os/agent-gui", {
+      devDependencies: { "@tiptap/core": "^3.11.1" },
+      peerDependencies: { "@tiptap/core": "^3.23.6" }
+    }),
+    [
+      "@tiptap/core must use the same peer and dev range",
+      "@tiptap/pm is missing from peerDependencies",
+      "@tiptap/react is missing from peerDependencies",
+      "@tiptap/starter-kit is missing from peerDependencies",
+      "@tiptap/suggestion is missing from peerDependencies"
+    ]
+  );
+});


### PR DESCRIPTION
## Why

The 0.0.163 cohort installs package-private Tiptap runtimes in consumers. TSH fresh installs then resolve Tutti and TSH against different Tiptap instances, causing nominal `Extension` type incompatibilities. Upgrading TSH to the newest Tiptap instead regresses first-frame workspace app mentions.

## What

- expose the shared Tiptap runtime as peer dependencies from `agent-gui` and `ui-rich-text`
- keep component-internal rich-text extensions as regular dependencies
- enforce the peer/dev dependency contract in the package pack gate
- document the published-package contract

## Validation

- `pnpm test:tools`
- `pnpm lint:ts`
- `pnpm typecheck`
- `pnpm release:pack:check`
- `pnpm check:changed -- --push-ready` (pre-push)
- TSH local packed consumer: desktop check passed; `RoomChatRichTextInput.spec.tsx` 41/41 passed

Follow-up for tutti-lab/tsh#1800.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->