### PR TITLE
fix(ui-rich-text): bundle internal Tiptap extensions

### DIFF
--- a/docs/conventions/npm-package-release.md
+++ b/docs/conventions/npm-package-release.md
@@ -193,9 +193,11 @@ Published packages should not include:
 
 Packages that expose Tiptap runtime objects or types must declare their shared
 Tiptap runtime packages as peer dependencies, with the same ranges repeated as
-development dependencies for workspace builds. Component-internal extensions
-can remain regular dependencies. A package-private copy of the shared runtime
-can make structurally identical extensions type-incompatible in consumers.
+development dependencies for workspace builds. Tiptap packages require exact
+peer versions, so component-internal extensions must be bundled from development
+dependencies rather than resolved independently in the consumer. A
+package-private copy of the shared runtime can make structurally identical
+extensions type-incompatible in consumers.
 
 Runtime assets that are rendered or referenced by public entrypoints must also
 survive the packed package shape. When a public runtime entrypoint such as

--- a/packages/ui/rich-text/package.json
+++ b/packages/ui/rich-text/package.json
@@ -30,15 +30,15 @@
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },
   "dependencies": {
-    "@tiptap/extension-document": "^3.23.6",
-    "@tiptap/extension-hard-break": "^3.23.6",
-    "@tiptap/extension-paragraph": "^3.23.6",
-    "@tiptap/extension-text": "^3.23.6",
     "@tutti-os/ui-i18n-runtime": "workspace:*",
     "@tutti-os/ui-system": "workspace:*"
   },
   "devDependencies": {
     "@tiptap/core": "^3.23.6",
+    "@tiptap/extension-document": "^3.23.6",
+    "@tiptap/extension-hard-break": "^3.23.6",
+    "@tiptap/extension-paragraph": "^3.23.6",
+    "@tiptap/extension-text": "^3.23.6",
     "@tiptap/react": "^3.23.6",
     "@tutti-os/config-tsconfig": "workspace:*",
     "@types/node": "^24.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -556,6 +556,16 @@ importers:
 
   packages/ui/rich-text:
     dependencies:
+      "@tutti-os/ui-i18n-runtime":
+        specifier: workspace:*
+        version: link:../i18n-runtime
+      "@tutti-os/ui-system":
+        specifier: workspace:*
+        version: link:../system
+    devDependencies:
+      "@tiptap/core":
+        specifier: ^3.23.6
+        version: 3.23.6(@tiptap/pm@3.23.6)
       "@tiptap/extension-document":
         specifier: ^3.23.6
         version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
@@ -568,16 +578,6 @@ importers:
       "@tiptap/extension-text":
         specifier: ^3.23.6
         version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
-      "@tutti-os/ui-i18n-runtime":
-        specifier: workspace:*
-        version: link:../i18n-runtime
-      "@tutti-os/ui-system":
-        specifier: workspace:*
-        version: link:../system
-    devDependencies:
-      "@tiptap/core":
-        specifier: ^3.23.6
-        version: 3.23.6(@tiptap/pm@3.23.6)
       "@tiptap/react":
         specifier: ^3.23.6
         version: 3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)

--- a/tools/scripts/check-package-packs.mjs
+++ b/tools/scripts/check-package-packs.mjs
@@ -15,7 +15,10 @@ import {
   packedFilesWithRawSvgDataUrls,
   packedFilesWithRelativeSvgUrls
 } from "./package-pack-svg-data-urls.mjs";
-import { packagePeerContractViolations } from "./package-pack-peer-contracts.mjs";
+import {
+  externalBundledTiptapImports,
+  packagePeerContractViolations
+} from "./package-pack-peer-contracts.mjs";
 
 const forbiddenPrefixes = [
   "package/src/",
@@ -105,6 +108,22 @@ async function checkPackage(packageConfig, destination) {
     );
     for (const file of relativeSvgUrlFiles) {
       violations.push(`consumer-unresolvable relative SVG URL in ${file}`);
+    }
+  }
+
+  if (packageConfig.name === "@tutti-os/ui-rich-text") {
+    const unpackedDirectory = join(destination, `${tarball}.unpacked`);
+    await mkdir(unpackedDirectory, { recursive: true });
+    execFileSync("tar", ["-xzf", tarballPath, "-C", unpackedDirectory]);
+    const editorSource = await readFile(
+      join(unpackedDirectory, "package/dist/editor/index.js"),
+      "utf8"
+    );
+    for (const specifier of externalBundledTiptapImports(
+      packageConfig.name,
+      editorSource
+    )) {
+      violations.push(`unbundled internal Tiptap extension ${specifier}`);
     }
   }
 

--- a/tools/scripts/package-pack-peer-contracts.mjs
+++ b/tools/scripts/package-pack-peer-contracts.mjs
@@ -11,17 +11,29 @@ const requiredTiptapPeers = new Map([
   ],
   ["@tutti-os/ui-rich-text", ["@tiptap/core", "@tiptap/react"]]
 ]);
+const bundledTiptapDependencies = new Map([
+  [
+    "@tutti-os/ui-rich-text",
+    [
+      "@tiptap/extension-document",
+      "@tiptap/extension-hard-break",
+      "@tiptap/extension-paragraph",
+      "@tiptap/extension-text"
+    ]
+  ]
+]);
 
 export function packagePeerContractViolations(packageName, manifest) {
   const requiredPeers = requiredTiptapPeers.get(packageName);
-  if (!requiredPeers) return [];
+  const bundledDependencies = bundledTiptapDependencies.get(packageName) ?? [];
+  if (!requiredPeers && bundledDependencies.length === 0) return [];
 
   const dependencies = manifest.dependencies ?? {};
   const devDependencies = manifest.devDependencies ?? {};
   const peerDependencies = manifest.peerDependencies ?? {};
   const violations = [];
 
-  for (const name of requiredPeers) {
+  for (const name of requiredPeers ?? []) {
     if (Object.hasOwn(dependencies, name)) {
       violations.push(`${name} must be a peer dependency`);
     }
@@ -32,5 +44,23 @@ export function packagePeerContractViolations(packageName, manifest) {
     }
   }
 
+  for (const name of bundledDependencies) {
+    if (Object.hasOwn(dependencies, name)) {
+      violations.push(`${name} must be bundled from devDependencies`);
+    }
+    if (Object.hasOwn(peerDependencies, name)) {
+      violations.push(`${name} must not be a consumer peer dependency`);
+    }
+    if (!Object.hasOwn(devDependencies, name)) {
+      violations.push(`${name} is missing from devDependencies`);
+    }
+  }
+
   return violations;
+}
+
+export function externalBundledTiptapImports(packageName, source) {
+  return (bundledTiptapDependencies.get(packageName) ?? []).filter(
+    (name) => source.includes(`"${name}"`) || source.includes(`'${name}'`)
+  );
 }

--- a/tools/scripts/package-pack-peer-contracts.test.mjs
+++ b/tools/scripts/package-pack-peer-contracts.test.mjs
@@ -1,22 +1,33 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { packagePeerContractViolations } from "./package-pack-peer-contracts.mjs";
+import {
+  externalBundledTiptapImports,
+  packagePeerContractViolations
+} from "./package-pack-peer-contracts.mjs";
 
 test("accepts matching Tiptap peer and development dependencies", () => {
   assert.deepEqual(
     packagePeerContractViolations("@tutti-os/ui-rich-text", {
-      dependencies: { "@tiptap/extension-document": "^3.23.6" },
-      devDependencies: { "@tiptap/core": "^3.23.6" },
+      devDependencies: {
+        "@tiptap/core": "^3.23.6",
+        "@tiptap/extension-document": "^3.23.6",
+        "@tiptap/extension-hard-break": "^3.23.6",
+        "@tiptap/extension-paragraph": "^3.23.6",
+        "@tiptap/extension-text": "^3.23.6"
+      },
       peerDependencies: { "@tiptap/core": "^3.23.6" }
     }),
     ["@tiptap/react is missing from peerDependencies"]
   );
   assert.deepEqual(
     packagePeerContractViolations("@tutti-os/ui-rich-text", {
-      dependencies: { "@tiptap/extension-document": "^3.23.6" },
       devDependencies: {
         "@tiptap/core": "^3.23.6",
+        "@tiptap/extension-document": "^3.23.6",
+        "@tiptap/extension-hard-break": "^3.23.6",
+        "@tiptap/extension-paragraph": "^3.23.6",
+        "@tiptap/extension-text": "^3.23.6",
         "@tiptap/react": "^3.23.6"
       },
       peerDependencies: {
@@ -33,11 +44,35 @@ test("rejects package-private or mismatched Tiptap dependencies", () => {
     packagePeerContractViolations("@tutti-os/ui-rich-text", {
       devDependencies: {
         "@tiptap/core": "^3.23.6",
+        "@tiptap/extension-document": "^3.23.6",
+        "@tiptap/extension-hard-break": "^3.23.6",
+        "@tiptap/extension-paragraph": "^3.23.6",
+        "@tiptap/extension-text": "^3.23.6",
         "@tiptap/react": "^3.23.6"
       },
       peerDependencies: { "@tiptap/react": "^3.23.6" }
     }),
     ["@tiptap/core is missing from peerDependencies"]
+  );
+  assert.deepEqual(
+    packagePeerContractViolations("@tutti-os/ui-rich-text", {
+      dependencies: { "@tiptap/extension-document": "^3.23.6" },
+      devDependencies: {
+        "@tiptap/core": "^3.23.6",
+        "@tiptap/extension-hard-break": "^3.23.6",
+        "@tiptap/extension-paragraph": "^3.23.6",
+        "@tiptap/extension-text": "^3.23.6",
+        "@tiptap/react": "^3.23.6"
+      },
+      peerDependencies: {
+        "@tiptap/core": "^3.23.6",
+        "@tiptap/react": "^3.23.6"
+      }
+    }),
+    [
+      "@tiptap/extension-document must be bundled from devDependencies",
+      "@tiptap/extension-document is missing from devDependencies"
+    ]
   );
   assert.deepEqual(
     packagePeerContractViolations("@tutti-os/agent-gui", {
@@ -65,5 +100,22 @@ test("rejects package-private or mismatched Tiptap dependencies", () => {
       "@tiptap/starter-kit is missing from peerDependencies",
       "@tiptap/suggestion is missing from peerDependencies"
     ]
+  );
+});
+
+test("finds component-internal Tiptap extensions left external", () => {
+  assert.deepEqual(
+    externalBundledTiptapImports(
+      "@tutti-os/ui-rich-text",
+      'import Document from "@tiptap/extension-document";'
+    ),
+    ["@tiptap/extension-document"]
+  );
+  assert.deepEqual(
+    externalBundledTiptapImports(
+      "@tutti-os/ui-rich-text",
+      'import { Extension } from "@tiptap/core";'
+    ),
+    []
   );
 });


### PR DESCRIPTION
## Why

After the shared-runtime peer fix in #1460, a fresh consumer still resolves `ui-rich-text` internal extension ranges to Tiptap 3.28. Those extensions require exact 3.28 core peers, while TSH intentionally remains on 3.27 because 3.28 regresses first-frame app mentions.

## What

- bundle `ui-rich-text` internal Tiptap extensions from dev dependencies
- keep only the shared core/react runtime as consumer peers
- extend the package gate to reject internal extensions left as dependencies, peers, or emitted external imports
- document the exact-peer constraint

## Validation

- `pnpm test:tools`
- `pnpm lint:ts`
- `pnpm typecheck`
- `pnpm release:pack:check`
- `pnpm check:changed -- --push-ready` (pre-push)
- TSH local packed consumer: TypeScript build/boundary checks passed; `RoomChatRichTextInput.spec.tsx` 41/41 passed

Follow-up for tutti-lab/tsh#1800.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->