### PR TITLE
fix(agent): preserve extension permission mode ids

### DIFF
--- a/apps/cli/internal/app/run_test.go
+++ b/apps/cli/internal/app/run_test.go
@@ -967,6 +967,40 @@ func TestRunDynamicJSONMapsDaemonInvalidInputToExitCodeTwo(t *testing.T) {
 	}
 }
 
+func TestRunDynamicJSONPreservesUnsupportedPermissionReasonAndOmitsFalseRetryable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/cli/capabilities":
+			_, _ = w.Write([]byte(`{"commands":[{"id":"agent-context.agent.start","path":["agent","start"],"summary":"Start agent","output":{"defaultMode":"json","json":true}}]}`))
+		case "/v1/cli/commands/agent-context.agent.start/invoke":
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"code":"invalid_request","reason":"unsupported_permission_mode_id","developerMessage":"refresh Composer Options and use an advertised permission id","retryable":false}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	writeEndpoint(t, server.URL, "token-1")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := runDefaultProgram(t, []string{"--json", "agent", "start"}, &stdout, &stderr); code != 2 {
+		t.Fatalf("code = %d, want 2; stderr = %s", code, stderr.String())
+	}
+	assertCLIJSONError(t, stdout.Bytes(), "unsupported_permission_mode_id", "refresh Composer Options")
+	var envelope map[string]map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode CLI error: %v", err)
+	}
+	if _, present := envelope["error"]["retryable"]; present {
+		t.Fatalf("stdout = %s, want false retryable omitted by JSON contract", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestRunDynamicJSONUnknownCommandIsStructured(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -945,6 +945,39 @@ file or directory`. If the CLI path exists but `codex app-server` cannot
   proving bypass mode allows an ordinary Bash request without
   `approval_requested`, while `AskUserQuestion` still surfaces user input.
 
+### Extension session create rejects a semantic permission id
+
+- Symptom:
+  An extension exposes a full-access option whose id is provider-specific, such
+  as `bypassPermissions`, but session creation fails after a caller sends
+  `full-access`. The Tutti CLI reports
+  `reasonCode=unsupported_permission_mode_id` and lists the currently accepted
+  ids.
+- Quick checks:
+  Query Composer Options for the exact Agent target. Compare
+  `permissionConfig.modes[].id` with `permissionConfig.modes[].semantic` and
+  inspect the submitted `permissionModeId`. Multiple ids may legitimately have
+  the same semantic.
+- Root cause:
+  `semantic` is provider-neutral classification metadata. It is only a launch
+  id for extensions whose signed Composer profile declares semantic launch
+  permission mapping. Runtime-id extensions require the exact provider-owned
+  id returned by Composer Options.
+- Fix:
+  Refresh Composer Options and round-trip the selected `id` verbatim. Do not
+  hard-code a provider permission alias or collapse modes by semantic. Extension
+  implementations keep the signed Composer profile as the launch contract;
+  runtime config options may enrich current state and labels but cannot rewrite
+  ids.
+- Validation:
+  Confirm Composer Options preserves every declared runtime id in profile order,
+  including multiple ids with the same semantic, and that the exact selected id
+  reaches the runtime start input. An invalid semantic alias must fail before
+  hidden discovery or visible session creation.
+- References:
+  [extension_composer_options.go](../../../services/tuttid/service/agent/extension_composer_options.go)
+  [composer_runtime_context.go](../../../services/tuttid/service/agent/composer_runtime_context.go)
+
 ### Claude Code logs out after sending a message (invalid_grant, credentials wiped)
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -968,12 +968,17 @@ file or directory`. If the CLI path exists but `codex app-server` cannot
   hard-code a provider permission alias or collapse modes by semantic. Extension
   implementations keep the signed Composer profile as the launch contract;
   runtime config options may enrich current state and labels but cannot rewrite
-  ids.
+  ids. Composer Options ignores a persisted default that is no longer in the
+  signed profile and falls back to live runtime state, then the profile default;
+  an explicit obsolete id still fails. Exact runtime ids also take precedence
+  over semantic and historical aliases in the Standard ACP lookup.
 - Validation:
   Confirm Composer Options preserves every declared runtime id in profile order,
   including multiple ids with the same semantic, and that the exact selected id
-  reaches the runtime start input. An invalid semantic alias must fail before
-  hidden discovery or visible session creation.
+  reaches the runtime start input and final Standard ACP mapping. Test an exact
+  runtime id that collides with another mode's semantic alias, plus an obsolete
+  persisted default. An invalid explicitly supplied semantic alias must fail
+  before hidden discovery or visible session creation.
 - References:
   [extension_composer_options.go](../../../services/tuttid/service/agent/extension_composer_options.go)
   [composer_runtime_context.go](../../../services/tuttid/service/agent/composer_runtime_context.go)

--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -29,6 +29,12 @@ the daemon error `code` when no narrower reason exists. Optional daemon
 daemon invocation use stable CLI-owned reason codes such as `invalid_input`,
 `command_not_found`, and `daemon_unavailable`.
 
+Domain validation keeps its narrower daemon reason when one exists. For
+example, `unsupported_permission_mode_id` means a caller supplied a permission
+identifier that is not advertised for the selected Agent target. Automation
+must refresh Composer Options and pass one of its `modes[].id` values verbatim;
+it must not retry the same value or substitute `modes[].semantic`.
+
 Exit codes stay intentionally small and stable: `0` means success, `2` means
 the command invocation or input was invalid, and `1` means authentication,
 transport, domain, or runtime failure. A daemon HTTP 400 response is invalid

--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -29,11 +29,20 @@ the daemon error `code` when no narrower reason exists. Optional daemon
 daemon invocation use stable CLI-owned reason codes such as `invalid_input`,
 `command_not_found`, and `daemon_unavailable`.
 
+Because `retryable` is omitted when false, consumers must not treat a missing
+field as permission to retry an arbitrary structured failure. CLI-owned
+transient reasons such as `daemon_unavailable` and `daemon_request_failed`
+remain retryable by reason; daemon errors are retryable only when the envelope
+explicitly says so.
+
 Domain validation keeps its narrower daemon reason when one exists. For
 example, `unsupported_permission_mode_id` means a caller supplied a permission
 identifier that is not advertised for the selected Agent target. Automation
 must refresh Composer Options and pass one of its `modes[].id` values verbatim;
 it must not retry the same value or substitute `modes[].semantic`.
+An obsolete persisted default is ignored while reading Composer Options so the
+caller can recover by selecting a current advertised id. The same obsolete id,
+when explicitly supplied in the current invocation, remains invalid input.
 
 Exit codes stay intentionally small and stable: `0` means success, `2` means
 the command invocation or input was invalid, and `1` means authentication,

--- a/docs/specs/2026-07-14-agent-extension-package-design.md
+++ b/docs/specs/2026-07-14-agent-extension-package-design.md
@@ -781,15 +781,25 @@ Manifest 声明不能覆盖实际 ACP handshake，也不能开启当前 host 不
 
 `configOptions` is the canonical profile shape. During compatibility migration,
 the loader also accepts the earlier top-level `model` and `permission` source
-objects. These declarations identify or constrain ACP fields; they do not
-manufacture models, modes, values, labels, or commands absent from the current
-runtime catalog.
+objects. These declarations identify or constrain ACP fields. Model, reasoning,
+and command catalogs still require runtime facts; the signed `permissionModes`
+list is the independent launch-permission contract and does not depend on model
+catalog discovery.
 
 Known permission semantics are `ask-before-write`, `accept-edits`, `auto`,
 `locked-down`, `full-access`, and the plan-only `read-only` mapping. The composer
-projects a supported runtime value as its Tutti semantic tier, while the generic
-adapter retains and writes the signed `runtimeId`. Runtime values absent from
-the signed mapping are not admitted. Reasoning option ids
+returns each signed `runtimeId` as `permissionConfig.modes[].id` by default and
+retains every distinct runtime id even when several modes share one semantic.
+Only a profile with `launchSettings.permission` exposes the closed Tutti
+semantic as its public id, because that launch contract explicitly maps the
+semantic back to a runtime value. Clients must round-trip the advertised `id`
+verbatim; `semantic` is classification metadata and is never a portable
+provider permission id.
+
+Runtime permission config options may enrich the current selection, label, and
+description for a signed runtime id. They cannot collapse modes by semantic,
+rewrite public ids, admit unsigned values, or make permission availability
+depend on model discovery. Reasoning option ids
 `thought_level`, `effort`, and `model_reasoning_effort` project as
 `reasoning_effort`, with deterministic alias precedence and the original id
 retained for ACP writes. Unrelated runtime options such as `sandbox` remain

--- a/docs/specs/2026-07-14-agent-extension-package-design.md
+++ b/docs/specs/2026-07-14-agent-extension-package-design.md
@@ -796,6 +796,11 @@ semantic back to a runtime value. Clients must round-trip the advertised `id`
 verbatim; `semantic` is classification metadata and is never a portable
 provider permission id.
 
+Runtime ids are compared case-insensitively at the Standard ACP command
+boundary and therefore must be unique ignoring case. Exact declared runtime ids
+are registered before semantic and historical aliases; an alias can never
+redirect an advertised id to another permission tier.
+
 Runtime permission config options may enrich the current selection, label, and
 description for a signed runtime id. They cannot collapse modes by semantic,
 rewrite public ids, admit unsigned values, or make permission availability

--- a/services/tuttid/agent_extension_composer_profile_resolver.go
+++ b/services/tuttid/agent_extension_composer_profile_resolver.go
@@ -25,12 +25,13 @@ func (r agentExtensionComposerProfileResolver) ResolveExtensionComposerProfile(
 		return agentservice.ExtensionComposerProfile{}, err
 	}
 	result := agentservice.ExtensionComposerProfile{
-		Capabilities: capabilities,
+		Capabilities:           capabilities,
+		PermissionModeIDPolicy: agentservice.ExtensionPermissionModeIDPolicyRuntime,
 	}
 	result.ModelConfigOptionID, result.PermissionConfigOptionID, result.ReasoningConfigOptionID = profile.ACPConfigOptionIDs()
 	if launchPermission := profile.LaunchPermissionSetting(); launchPermission != nil {
 		result.DefaultPermissionModeID = launchPermission.DefaultSemantic
-		result.PermissionModeIDsAreSemantic = true
+		result.PermissionModeIDPolicy = agentservice.ExtensionPermissionModeIDPolicySemantic
 		if result.DefaultPermissionModeID == "" {
 			result.DefaultPermissionModeID = "ask-before-write"
 		}

--- a/services/tuttid/apierrors/apierrors.go
+++ b/services/tuttid/apierrors/apierrors.go
@@ -88,6 +88,7 @@ const (
 	ReasonWorkspaceAgentSessionNotFound                  = "workspace_agent_session_not_found"
 	ReasonWorkspaceAgentSessionTitleTooLong              = "workspace_agent_session_title_too_long"
 	ReasonWorkspaceAgentSessionUnavailable               = "workspace_agent_session_service_unavailable"
+	ReasonUnsupportedPermissionModeID                    = "unsupported_permission_mode_id"
 	ReasonAgentProviderUnavailable                       = "agent_provider_unavailable"
 	ReasonAgentRuntimeOperationReconciling               = "agent_runtime_operation_reconciling"
 	ReasonAgentRuntimeOperationFailed                    = "agent_runtime_operation_failed"
@@ -351,6 +352,21 @@ func Classify(err error) *ProtocolError {
 			params["availableModels"] = invalidModelErr.AvailableModels
 		}
 		return InvalidRequest("agent.invalid_model", WithCause(err), WithParams(params))
+	}
+	var unsupportedPermissionErr *agentservice.UnsupportedPermissionModeIDError
+	if errors.As(err, &unsupportedPermissionErr) {
+		params := map[string]any{
+			"agentTargetId":    strings.TrimSpace(unsupportedPermissionErr.AgentTargetID),
+			"permissionModeId": strings.TrimSpace(unsupportedPermissionErr.PermissionModeID),
+		}
+		if len(unsupportedPermissionErr.AvailablePermissionModeIDs) > 0 {
+			params["availablePermissionModeIds"] = unsupportedPermissionErr.AvailablePermissionModeIDs
+		}
+		return InvalidRequest(
+			ReasonUnsupportedPermissionModeID,
+			WithCause(err),
+			WithParams(params),
+		)
 	}
 	switch {
 	case errors.Is(err, agentservice.ErrNotAGitRepo):

--- a/services/tuttid/apierrors/apierrors_test.go
+++ b/services/tuttid/apierrors/apierrors_test.go
@@ -52,3 +52,23 @@ func TestClassifySessionTitleTooLongHasStableReasonAndLimit(t *testing.T) {
 		t.Fatalf("params = %#v, want maxCharacters = %d", classified.Params, agentservice.MaxSessionTitleRunes)
 	}
 }
+
+func TestClassifyUnsupportedPermissionModeHasStableReasonAndOptions(t *testing.T) {
+	err := &agentservice.UnsupportedPermissionModeIDError{
+		AgentTargetID:              "extension:codebuddy",
+		PermissionModeID:           "full-access",
+		AvailablePermissionModeIDs: []string{"default", "bypassPermissions", "fullAccess"},
+	}
+	classified := Classify(err)
+	if classified.Reason != ReasonUnsupportedPermissionModeID || !errors.Is(classified, agentservice.ErrInvalidArgument) {
+		t.Fatalf("classified = %#v, want stable unsupported permission reason", classified)
+	}
+	if classified.Params["agentTargetId"] != "extension:codebuddy" ||
+		classified.Params["permissionModeId"] != "full-access" {
+		t.Fatalf("params = %#v, want target and rejected id", classified.Params)
+	}
+	available, ok := classified.Params["availablePermissionModeIds"].([]string)
+	if !ok || len(available) != 3 || available[1] != "bypassPermissions" {
+		t.Fatalf("availablePermissionModeIds = %#v", classified.Params["availablePermissionModeIds"])
+	}
+}

--- a/services/tuttid/service/agent/composer_defaults_validation.go
+++ b/services/tuttid/service/agent/composer_defaults_validation.go
@@ -139,7 +139,15 @@ func (s *Service) validateExtensionComposerSettingsForCreate(
 	if settings.PermissionModeID != "" &&
 		(!options.PermissionConfig.Configurable ||
 			!permissionModeConfigHasModeID(options.PermissionConfig, settings.PermissionModeID)) {
-		return fmt.Errorf("%w: permission mode is not supported by agent target", ErrInvalidArgument)
+		available := make([]string, 0, len(options.PermissionConfig.Modes))
+		for _, mode := range options.PermissionConfig.Modes {
+			available = append(available, strings.TrimSpace(mode.ID))
+		}
+		return &UnsupportedPermissionModeIDError{
+			AgentTargetID:              strings.TrimSpace(input.AgentTargetID),
+			PermissionModeID:           settings.PermissionModeID,
+			AvailablePermissionModeIDs: available,
+		}
 	}
 	reasoningConfig := composerReasoningConfigForSelectedModel(options)
 	if err := validateExtensionComposerOption(

--- a/services/tuttid/service/agent/composer_defaults_validation.go
+++ b/services/tuttid/service/agent/composer_defaults_validation.go
@@ -107,9 +107,10 @@ func (s *Service) validateExtensionComposerSettingsForCreate(
 	ctx context.Context,
 	workspaceID string,
 	cwd string,
-	input CreateSessionInput,
+	input *CreateSessionInput,
+	permissionModeExplicit bool,
 ) error {
-	if providerTargetRefKind(input.ProviderTargetRef) != "agent_extension" {
+	if input == nil || providerTargetRefKind(input.ProviderTargetRef) != "agent_extension" {
 		return nil
 	}
 	settings := ComposerSettings{
@@ -117,6 +118,12 @@ func (s *Service) validateExtensionComposerSettingsForCreate(
 		PermissionModeID: strings.TrimSpace(value(input.PermissionModeID)),
 		ReasoningEffort:  strings.TrimSpace(value(input.ReasoningEffort)),
 		Speed:            strings.TrimSpace(value(input.Speed)),
+	}
+	if !permissionModeExplicit {
+		// Persisted defaults are fallback preferences, not caller selections.
+		// Let Composer Options ignore a stale default and resolve runtime/profile
+		// state instead of treating old data as an explicit invalid request.
+		settings.PermissionModeID = ""
 	}
 	options, err := s.GetComposerOptions(ctx, ComposerOptionsInput{
 		AgentTargetID:            input.AgentTargetID,
@@ -129,6 +136,14 @@ func (s *Service) validateExtensionComposerSettingsForCreate(
 	if err != nil {
 		return err
 	}
+	if !permissionModeExplicit {
+		resolved := strings.TrimSpace(options.EffectiveSettings.PermissionModeID)
+		if resolved == "" {
+			input.PermissionModeID = nil
+		} else {
+			input.PermissionModeID = stringPointer(resolved)
+		}
+	}
 	if err := validateExtensionComposerOption(
 		preferencesbiz.AgentComposerDefaultsFieldModel,
 		settings.Model,
@@ -136,7 +151,7 @@ func (s *Service) validateExtensionComposerSettingsForCreate(
 	); err != nil {
 		return err
 	}
-	if settings.PermissionModeID != "" &&
+	if permissionModeExplicit && settings.PermissionModeID != "" &&
 		(!options.PermissionConfig.Configurable ||
 			!permissionModeConfigHasModeID(options.PermissionConfig, settings.PermissionModeID)) {
 		available := make([]string, 0, len(options.PermissionConfig.Modes))

--- a/services/tuttid/service/agent/composer_extension_scope_test.go
+++ b/services/tuttid/service/agent/composer_extension_scope_test.go
@@ -144,24 +144,21 @@ func TestExtensionCapabilitiesRemainUnknownWithoutLiveRuntimeFacts(t *testing.T)
 }
 
 func TestExtensionSpawnPermissionUsesSemanticComposerIDs(t *testing.T) {
-	service := newIsolatedAgentService(newFakeRuntime())
-	service.ExtensionComposerProfiles = extensionComposerProfileResolverStub{
-		profile: ExtensionComposerProfile{
-			DefaultPermissionModeID:      "ask-before-write",
-			PermissionModeIDsAreSemantic: true,
+	projection, err := projectExtensionPermissionConfig(extensionPermissionProjectionInput{
+		Profile: ExtensionComposerProfile{
+			DefaultPermissionModeID: "ask-before-write",
+			PermissionModeIDPolicy:  ExtensionPermissionModeIDPolicySemantic,
 			PermissionModes: []ExtensionComposerPermissionMode{
 				{RuntimeID: "ask", Semantic: PermissionModeSemanticAskBeforeWrite},
 				{RuntimeID: "auto", Semantic: PermissionModeSemanticAuto},
 				{RuntimeID: "always-approve", Semantic: PermissionModeSemanticFullAccess},
 			},
 		},
-	}
-	config, err := service.extensionComposerPermissionConfig(context.Background(), map[string]any{
-		"extensionInstallationId": "spawn@1.0.0",
-	}, "")
+	})
 	if err != nil {
-		t.Fatalf("extensionComposerPermissionConfig: %v", err)
+		t.Fatalf("projectExtensionPermissionConfig: %v", err)
 	}
+	config := projection.Config
 	if config.DefaultValue != "ask-before-write" || len(config.Modes) != 3 {
 		t.Fatalf("permission config = %#v", config)
 	}

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -201,18 +201,18 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 	locale := normalizeComposerLocale(input.Locale)
 	permissionConfig := composerPermissionConfig(provider, effectiveSettings.PermissionModeID, locale)
 	if providerTargetRefKind(input.providerTargetRef) == "agent_extension" {
-		var err error
-		permissionConfig, err = s.extensionComposerPermissionConfig(
-			ctx,
-			input.providerTargetRef,
-			effectiveSettings.PermissionModeID,
-		)
+		permissionProjection, err := projectExtensionPermissionConfig(extensionPermissionProjectionInput{
+			AgentTargetID: input.AgentTargetID,
+			Locale:        locale,
+			Profile:       extensionProfile,
+			Provider:      provider,
+			SelectedID:    effectiveSettings.PermissionModeID,
+		})
 		if err != nil {
 			return ComposerOptions{}, err
 		}
-		if effectiveSettings.PermissionModeID == "" {
-			effectiveSettings.PermissionModeID = permissionConfig.DefaultValue
-		}
+		permissionConfig = permissionProjection.Config
+		effectiveSettings.PermissionModeID = permissionProjection.CurrentID
 	}
 	modelOptions := s.enrichModelCapabilityOptions(ctx, provider, composerSelectedModelOptions(effectiveSettings.Model))
 	if composerProfileFor(provider).Behavior.ModelOptionsAuthoritative {
@@ -312,7 +312,11 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 		}
 	}
 	if providerTargetRefKind(input.providerTargetRef) == "agent_extension" {
-		options = s.mergeRuntimeComposerContextForComposerOptions(input, effectiveSettings, locale, extensionProfile, options)
+		var err error
+		options, err = s.mergeRuntimeComposerContextForComposerOptions(input, effectiveSettings, locale, extensionProfile, options)
+		if err != nil {
+			return ComposerOptions{}, err
+		}
 		options = applyExtensionComposerCapabilities(options, extensionProfile)
 	}
 	return options, nil

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -123,6 +123,7 @@ type ComposerOptions struct {
 }
 
 func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsInput) (ComposerOptions, error) {
+	requestedPermissionModeID := strings.TrimSpace(input.Settings.PermissionModeID)
 	provider := agentprovider.Normalize(input.Provider)
 	agentTargetID := strings.TrimSpace(input.AgentTargetID)
 	if agentTargetID != "" {
@@ -203,14 +204,16 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 	if providerTargetRefKind(input.providerTargetRef) == "agent_extension" {
 		permissionProjection, err := projectExtensionPermissionConfig(extensionPermissionProjectionInput{
 			AgentTargetID: input.AgentTargetID,
+			FallbackID:    effectiveSettings.PermissionModeID,
 			Locale:        locale,
 			Profile:       extensionProfile,
 			Provider:      provider,
-			SelectedID:    effectiveSettings.PermissionModeID,
+			SelectedID:    requestedPermissionModeID,
 		})
 		if err != nil {
 			return ComposerOptions{}, err
 		}
+		logExtensionPermissionProjectionDiagnostics(permissionProjection, input.AgentTargetID, provider)
 		permissionConfig = permissionProjection.Config
 		effectiveSettings.PermissionModeID = permissionProjection.CurrentID
 	}
@@ -313,7 +316,14 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 	}
 	if providerTargetRefKind(input.providerTargetRef) == "agent_extension" {
 		var err error
-		options, err = s.mergeRuntimeComposerContextForComposerOptions(input, effectiveSettings, locale, extensionProfile, options)
+		options, err = s.mergeRuntimeComposerContextForComposerOptions(
+			input,
+			effectiveSettings,
+			locale,
+			extensionProfile,
+			requestedPermissionModeID,
+			options,
+		)
 		if err != nil {
 			return ComposerOptions{}, err
 		}

--- a/services/tuttid/service/agent/composer_runtime_context.go
+++ b/services/tuttid/service/agent/composer_runtime_context.go
@@ -14,6 +14,7 @@ func (s *Service) mergeRuntimeComposerContextForComposerOptions(
 	requestSettings ComposerSettings,
 	locale string,
 	extensionProfile ExtensionComposerProfile,
+	requestedPermissionModeID string,
 	options ComposerOptions,
 ) (ComposerOptions, error) {
 	// The discovery cache signature belongs to the request that created the
@@ -53,6 +54,7 @@ func (s *Service) mergeRuntimeComposerContextForComposerOptions(
 	if permissionOption, ok := runtimeConfigOptionByID(configOptions, extensionProfile.PermissionConfigOptionID); ok {
 		projection, err := projectExtensionPermissionConfig(extensionPermissionProjectionInput{
 			AgentTargetID: input.AgentTargetID,
+			FallbackID:    requestSettings.PermissionModeID,
 			Locale:        locale,
 			Profile:       extensionProfile,
 			Provider:      input.Provider,
@@ -60,18 +62,12 @@ func (s *Service) mergeRuntimeComposerContextForComposerOptions(
 				CurrentRuntimeID: runtimeConfigOptionCurrentValue(permissionOption, configValues),
 				Options:          composerConfigOptionValuesFromAny(permissionOption["options"]),
 			},
-			SelectedID: options.EffectiveSettings.PermissionModeID,
+			SelectedID: requestedPermissionModeID,
 		})
 		if err != nil {
 			return ComposerOptions{}, err
 		}
-		for _, diagnostic := range projection.Diagnostics {
-			logAgentExtensionComposerDebug(diagnostic.Reason, map[string]any{
-				"agentTargetId": input.AgentTargetID,
-				"provider":      input.Provider,
-				"runtimeId":     diagnostic.RuntimeID,
-			})
-		}
+		logExtensionPermissionProjectionDiagnostics(projection, input.AgentTargetID, input.Provider)
 		options.PermissionConfig = projection.Config
 		options.EffectiveSettings.PermissionModeID = projection.CurrentID
 		options.RuntimeContext["permissionModeId"] = nullableString(projection.CurrentID)

--- a/services/tuttid/service/agent/composer_runtime_context.go
+++ b/services/tuttid/service/agent/composer_runtime_context.go
@@ -15,7 +15,7 @@ func (s *Service) mergeRuntimeComposerContextForComposerOptions(
 	locale string,
 	extensionProfile ExtensionComposerProfile,
 	options ComposerOptions,
-) ComposerOptions {
+) (ComposerOptions, error) {
 	// The discovery cache signature belongs to the request that created the
 	// hidden session. Runtime projection may already have selected a model or
 	// mode, so deriving the key from options.EffectiveSettings here would turn
@@ -23,7 +23,7 @@ func (s *Service) mergeRuntimeComposerContextForComposerOptions(
 	scope := newComposerLiveModelScopeForInput(input, requestSettings)
 	runtimeContext := s.composerRuntimeContextFromSession(scope)
 	if len(runtimeContext) == 0 {
-		return options
+		return options, nil
 	}
 	if options.RuntimeContext == nil {
 		options.RuntimeContext = map[string]any{}
@@ -43,7 +43,7 @@ func (s *Service) mergeRuntimeComposerContextForComposerOptions(
 	}
 	configOptions := runtimeConfigOptionsAsMapSlice(runtimeContext["configOptions"])
 	if len(configOptions) == 0 {
-		return options
+		return options, nil
 	}
 	options.RuntimeContext["configOptions"] = mergeRuntimeConfigOptions(
 		runtimeConfigOptionsAsMapSlice(options.RuntimeContext["configOptions"]),
@@ -51,17 +51,30 @@ func (s *Service) mergeRuntimeComposerContextForComposerOptions(
 	)
 	configValues, _ := runtimeContext["config"].(map[string]any)
 	if permissionOption, ok := runtimeConfigOptionByID(configOptions, extensionProfile.PermissionConfigOptionID); ok {
-		if config, current := composerPermissionConfigFromRuntimeOption(
-			input.Provider,
-			permissionOption,
-			configValues,
-			locale,
-			extensionProfile.PermissionModes,
-		); len(config.Modes) > 0 {
-			options.PermissionConfig = config
-			options.EffectiveSettings.PermissionModeID = current
-			options.RuntimeContext["permissionModeId"] = nullableString(current)
+		projection, err := projectExtensionPermissionConfig(extensionPermissionProjectionInput{
+			AgentTargetID: input.AgentTargetID,
+			Locale:        locale,
+			Profile:       extensionProfile,
+			Provider:      input.Provider,
+			Runtime: &extensionPermissionRuntimeState{
+				CurrentRuntimeID: runtimeConfigOptionCurrentValue(permissionOption, configValues),
+				Options:          composerConfigOptionValuesFromAny(permissionOption["options"]),
+			},
+			SelectedID: options.EffectiveSettings.PermissionModeID,
+		})
+		if err != nil {
+			return ComposerOptions{}, err
 		}
+		for _, diagnostic := range projection.Diagnostics {
+			logAgentExtensionComposerDebug(diagnostic.Reason, map[string]any{
+				"agentTargetId": input.AgentTargetID,
+				"provider":      input.Provider,
+				"runtimeId":     diagnostic.RuntimeID,
+			})
+		}
+		options.PermissionConfig = projection.Config
+		options.EffectiveSettings.PermissionModeID = projection.CurrentID
+		options.RuntimeContext["permissionModeId"] = nullableString(projection.CurrentID)
 	}
 	if reasoningOption, ok := runtimeConfigOptionByID(configOptions, extensionProfile.ReasoningConfigOptionID); ok {
 		if config, current := composerReasoningConfigFromRuntimeOption(
@@ -74,7 +87,7 @@ func (s *Service) mergeRuntimeComposerContextForComposerOptions(
 			options.RuntimeContext["reasoningEffort"] = nullableString(current)
 		}
 	}
-	return options
+	return options, nil
 }
 
 func (s *Service) composerRuntimeContextFromSession(
@@ -211,83 +224,6 @@ func runtimeConfigOptionMatchesID(option map[string]any, id string) bool {
 	}
 	return strings.TrimSpace(stringFromAny(option["id"])) == id ||
 		strings.TrimSpace(stringFromAny(option["runtimeId"])) == id
-}
-
-func composerPermissionConfigFromRuntimeOption(
-	provider string,
-	option map[string]any,
-	configValues map[string]any,
-	locale string,
-	declaredModes []ExtensionComposerPermissionMode,
-) (PermissionConfig, string) {
-	values := composerConfigOptionValuesFromAny(option["options"])
-	runtimeCurrent := runtimeConfigOptionCurrentValue(option, configValues)
-	modeByRuntimeID := make(map[string]ExtensionComposerPermissionMode, len(declaredModes))
-	for _, mode := range declaredModes {
-		runtimeID := strings.TrimSpace(mode.RuntimeID)
-		if runtimeID != "" {
-			modeByRuntimeID[runtimeID] = mode
-		}
-	}
-	config := PermissionConfig{
-		Configurable: false,
-		Modes:        make([]PermissionModeOption, 0, len(values)),
-	}
-	representativeBySemantic := map[PermissionModeSemantic]string{}
-	for _, value := range values {
-		runtimeID := strings.TrimSpace(value.Value)
-		declared, ok := modeByRuntimeID[runtimeID]
-		if !ok {
-			continue
-		}
-		semantic, ok := supportedExtensionPermissionSemantic(declared.Semantic)
-		if !ok {
-			continue
-		}
-		if _, exists := representativeBySemantic[semantic]; exists {
-			continue
-		}
-		modeID := string(semantic)
-		representativeBySemantic[semantic] = modeID
-		label, description := permissionModeDisplay(provider, modeID, semantic, locale)
-		if text := strings.TrimSpace(value.Label); text != "" {
-			label = text
-		}
-		if text := strings.TrimSpace(value.Description); text != "" {
-			description = text
-		}
-		config.Modes = append(config.Modes, PermissionModeOption{
-			Description: description,
-			ID:          modeID,
-			Semantic:    semantic,
-			Label:       label,
-		})
-	}
-	current := ""
-	if declared, ok := modeByRuntimeID[runtimeCurrent]; ok {
-		if semantic, supported := supportedExtensionPermissionSemantic(declared.Semantic); supported {
-			current = representativeBySemantic[semantic]
-		}
-	}
-	if current == "" && len(config.Modes) > 0 {
-		current = config.Modes[0].ID
-	}
-	config.DefaultValue = current
-	config.Configurable = len(config.Modes) > 1
-	return config, current
-}
-
-func supportedExtensionPermissionSemantic(value PermissionModeSemantic) (PermissionModeSemantic, bool) {
-	switch value {
-	case PermissionModeSemanticAskBeforeWrite,
-		PermissionModeSemanticAcceptEdits,
-		PermissionModeSemanticLockedDown,
-		PermissionModeSemanticAuto,
-		PermissionModeSemanticFullAccess:
-		return value, true
-	default:
-		return "", false
-	}
 }
 
 func applyExtensionComposerCapabilities(options ComposerOptions, profile ExtensionComposerProfile) ComposerOptions {

--- a/services/tuttid/service/agent/extension_composer_create_validation_test.go
+++ b/services/tuttid/service/agent/extension_composer_create_validation_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
@@ -33,6 +34,114 @@ func TestServiceCreateValidatesExtensionDefaultsAndExplicitOverrides(t *testing.
 	}
 	if visibleStarts[0].Model != "gemini-fast" || visibleStarts[0].PermissionModeID != "yolo" {
 		t.Fatalf("visible settings = %#v", visibleStarts[0])
+	}
+}
+
+func TestServiceCreateRoundTripsCodeBuddyLikeRuntimePermissionID(t *testing.T) {
+	runtime := newFakeRuntime()
+	runtime.startHook = func(input RuntimeStartInput, session ProviderRuntimeSession) ProviderRuntimeSession {
+		if input.Visible != nil && !*input.Visible {
+			session.RuntimeContext = map[string]any{
+				"configOptions": []any{
+					map[string]any{
+						"id":           "model",
+						"currentValue": "glm-5.2",
+						"options": []any{
+							map[string]any{"value": "glm-5.2", "name": "GLM-5.2"},
+						},
+					},
+					map[string]any{
+						"id":           "approval-mode",
+						"currentValue": "default",
+						"options": []any{
+							map[string]any{"value": "default", "name": "Default"},
+							map[string]any{"value": "bypassPermissions", "name": "Full access"},
+							map[string]any{"value": "fullAccess", "name": "Full access"},
+						},
+					},
+				},
+			}
+		}
+		return session
+	}
+	service := newIsolatedAgentService(runtime)
+	service.AgentTargetStore = fakeAgentTargetStore{targets: map[string]agenttargetbiz.Target{
+		"extension:codebuddy": {
+			ID:            "extension:codebuddy",
+			Provider:      "acp:codebuddy",
+			LaunchRefJSON: `{"type":"agent_extension","extensionInstallationId":"codebuddy@2.0.3"}`,
+			Name:          "CodeBuddy",
+			Enabled:       true,
+			Source:        agenttargetbiz.SourceSystem,
+		},
+	}}
+	service.ExtensionComposerProfiles = extensionComposerProfileResolverStub{
+		profile: ExtensionComposerProfile{
+			ModelConfigOptionID:      "model",
+			PermissionConfigOptionID: "approval-mode",
+			PermissionModeIDPolicy:   ExtensionPermissionModeIDPolicyRuntime,
+			PermissionModes: []ExtensionComposerPermissionMode{
+				{RuntimeID: "default", Semantic: PermissionModeSemanticAskBeforeWrite},
+				{RuntimeID: "bypassPermissions", Semantic: PermissionModeSemanticFullAccess},
+				{RuntimeID: "fullAccess", Semantic: PermissionModeSemanticFullAccess},
+			},
+		},
+	}
+	cwd := t.TempDir()
+	settings := ComposerSettings{Model: "glm-5.2", PermissionModeID: "bypassPermissions"}
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		AgentTargetID: "extension:codebuddy",
+		WorkspaceID:   "workspace-codebuddy",
+		Cwd:           cwd,
+		Settings:      settings,
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions() error = %v", err)
+	}
+	if options.EffectiveSettings.PermissionModeID != "bypassPermissions" {
+		t.Fatalf("effective permission = %q, want explicit runtime id", options.EffectiveSettings.PermissionModeID)
+	}
+	if got := permissionModeIDs(options.PermissionConfig); !slices.Equal(got, []string{"default", "bypassPermissions", "fullAccess"}) {
+		t.Fatalf("permission ids = %#v", got)
+	}
+
+	model := settings.Model
+	permission := settings.PermissionModeID
+	if _, err := service.Create(context.Background(), "workspace-codebuddy", CreateSessionInput{
+		AgentTargetID:    "extension:codebuddy",
+		Cwd:              &cwd,
+		Model:            &model,
+		PermissionModeID: &permission,
+	}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	visibleStarts := visibleRuntimeStarts(runtime.startCalls)
+	if len(visibleStarts) != 1 || visibleStarts[0].PermissionModeID != "bypassPermissions" {
+		t.Fatalf("visible starts = %#v, want exact runtime permission id", visibleStarts)
+	}
+	for _, start := range runtime.startCalls {
+		if start.PermissionModeID != "bypassPermissions" {
+			t.Fatalf("runtime start permission = %q, want exact selected id", start.PermissionModeID)
+		}
+	}
+}
+
+func TestServiceGetComposerOptionsRejectsSemanticAliasBeforeRuntimeDiscovery(t *testing.T) {
+	runtime, service := newExtensionComposerValidationService(t)
+	_, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		AgentTargetID: extensionComposerValidationTargetID,
+		WorkspaceID:   "workspace-extension",
+		Cwd:           t.TempDir(),
+		Settings: ComposerSettings{
+			PermissionModeID: "full-access",
+		},
+	})
+	var unsupported *UnsupportedPermissionModeIDError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("GetComposerOptions() error = %v, want UnsupportedPermissionModeIDError", err)
+	}
+	if len(runtime.startCalls) != 0 {
+		t.Fatalf("runtime starts = %#v, want invalid id rejected before discovery", runtime.startCalls)
 	}
 }
 

--- a/services/tuttid/service/agent/extension_composer_create_validation_test.go
+++ b/services/tuttid/service/agent/extension_composer_create_validation_test.go
@@ -145,6 +145,88 @@ func TestServiceGetComposerOptionsRejectsSemanticAliasBeforeRuntimeDiscovery(t *
 	}
 }
 
+func TestServiceGetComposerOptionsIgnoresStalePersistedPermissionDefault(t *testing.T) {
+	runtime, service := newExtensionComposerValidationService(t)
+	cwd := t.TempDir()
+	service.AgentComposerDefaultsReader = fakeAgentComposerDefaultsReader{
+		extensionComposerValidationTargetID: {PermissionModeID: "full-access"},
+	}
+	service.ExtensionComposerProfiles = extensionComposerProfileResolverStub{
+		profile: ExtensionComposerProfile{
+			DefaultPermissionModeID: "default",
+			PermissionModeIDPolicy:  ExtensionPermissionModeIDPolicyRuntime,
+			PermissionModes: []ExtensionComposerPermissionMode{
+				{RuntimeID: "default", Semantic: PermissionModeSemanticAskBeforeWrite},
+				{RuntimeID: "bypassPermissions", Semantic: PermissionModeSemanticFullAccess},
+				{RuntimeID: "fullAccess", Semantic: PermissionModeSemanticFullAccess},
+			},
+		},
+	}
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		AgentTargetID: extensionComposerValidationTargetID,
+		WorkspaceID:   "workspace-extension",
+		Cwd:           cwd,
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions() error = %v", err)
+	}
+	if options.EffectiveSettings.PermissionModeID != "default" ||
+		!slices.Equal(permissionModeIDs(options.PermissionConfig), []string{"default", "bypassPermissions", "fullAccess"}) {
+		t.Fatalf("options = %#v, want stale default ignored and current contract advertised", options)
+	}
+	if len(runtime.startCalls) == 0 {
+		t.Fatal("runtime discovery did not run")
+	}
+	if _, err := service.Create(context.Background(), "workspace-extension", CreateSessionInput{
+		AgentTargetID: extensionComposerValidationTargetID,
+		Cwd:           &cwd,
+	}); err != nil {
+		t.Fatalf("Create() with stale persisted default error = %v", err)
+	}
+	visibleStarts := visibleRuntimeStarts(runtime.startCalls)
+	if len(visibleStarts) != 1 || visibleStarts[0].PermissionModeID != "default" {
+		t.Fatalf("visible starts = %#v, want recovered profile default", visibleStarts)
+	}
+}
+
+func TestServiceGetComposerOptionsUsesRuntimeCurrentBeforeSemanticProfileDefault(t *testing.T) {
+	runtime, service := newExtensionComposerValidationService(t)
+	runtime.startHook = func(input RuntimeStartInput, session ProviderRuntimeSession) ProviderRuntimeSession {
+		if input.Visible != nil && !*input.Visible {
+			session.RuntimeContext = map[string]any{"configOptions": []any{map[string]any{
+				"id": "approval-mode", "currentValue": "all", "options": []any{
+					map[string]any{"value": "ask", "name": "Ask"},
+					map[string]any{"value": "all", "name": "Full access"},
+				},
+			}}}
+		}
+		return session
+	}
+	service.ExtensionComposerProfiles = extensionComposerProfileResolverStub{
+		profile: ExtensionComposerProfile{
+			DefaultPermissionModeID:  "ask-before-write",
+			PermissionConfigOptionID: "approval-mode",
+			PermissionModeIDPolicy:   ExtensionPermissionModeIDPolicySemantic,
+			PermissionModes: []ExtensionComposerPermissionMode{
+				{RuntimeID: "ask", Semantic: PermissionModeSemanticAskBeforeWrite},
+				{RuntimeID: "all", Semantic: PermissionModeSemanticFullAccess},
+			},
+		},
+	}
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		AgentTargetID: extensionComposerValidationTargetID,
+		WorkspaceID:   "workspace-extension",
+		Cwd:           t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions() error = %v", err)
+	}
+	if options.EffectiveSettings.PermissionModeID != "full-access" {
+		t.Fatalf("effective permission = %q, want runtime current", options.EffectiveSettings.PermissionModeID)
+	}
+}
+
 func TestServiceCreateRejectsExtensionSettingsOutsideDescriptor(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/services/tuttid/service/agent/extension_composer_options.go
+++ b/services/tuttid/service/agent/extension_composer_options.go
@@ -47,6 +47,7 @@ type extensionPermissionRuntimeState struct {
 
 type extensionPermissionProjectionInput struct {
 	AgentTargetID string
+	FallbackID    string
 	Locale        string
 	Profile       ExtensionComposerProfile
 	Provider      string
@@ -88,15 +89,22 @@ func projectExtensionPermissionConfig(input extensionPermissionProjectionInput) 
 
 	declarations := make([]extensionPermissionDeclaration, 0, len(input.Profile.PermissionModes))
 	byRuntimeID := make(map[string]extensionPermissionDeclaration, len(input.Profile.PermissionModes))
+	seenRuntimeIDs := make(map[string]string, len(input.Profile.PermissionModes))
 	publicIDs := make(map[string]struct{}, len(input.Profile.PermissionModes))
 	for _, mode := range input.Profile.PermissionModes {
 		runtimeID := strings.TrimSpace(mode.RuntimeID)
 		if runtimeID == "" {
 			return extensionPermissionProjection{}, fmt.Errorf("extension composer permission runtime id is required")
 		}
-		if _, duplicate := byRuntimeID[runtimeID]; duplicate {
-			return extensionPermissionProjection{}, fmt.Errorf("extension composer permission runtime id %q must be unique", runtimeID)
+		normalizedRuntimeID := strings.ToLower(runtimeID)
+		if existing, duplicate := seenRuntimeIDs[normalizedRuntimeID]; duplicate {
+			return extensionPermissionProjection{}, fmt.Errorf(
+				"extension composer permission runtime id %q conflicts with %q; runtime ids must be unique ignoring case",
+				runtimeID,
+				existing,
+			)
 		}
+		seenRuntimeIDs[normalizedRuntimeID] = runtimeID
 		semantic, supported := normalizeExtensionPermissionModeSemantic(mode.Semantic)
 		if !supported {
 			return extensionPermissionProjection{}, fmt.Errorf(
@@ -192,6 +200,17 @@ func projectExtensionPermissionConfig(input extensionPermissionProjectionInput) 
 		}
 	}
 	if currentID == "" {
+		fallbackID := strings.TrimSpace(input.FallbackID)
+		if _, supported := publicIDs[fallbackID]; fallbackID != "" && supported {
+			currentID = fallbackID
+		} else if fallbackID != "" {
+			diagnostics = append(diagnostics, extensionPermissionProjectionDiagnostic{
+				Reason:    "permission_configured_default_unsupported",
+				RuntimeID: fallbackID,
+			})
+		}
+	}
+	if currentID == "" {
 		defaultID := strings.TrimSpace(input.Profile.DefaultPermissionModeID)
 		if defaultID != "" {
 			if _, supported := publicIDs[defaultID]; !supported {
@@ -246,5 +265,19 @@ func disambiguateExtensionPermissionLabels(
 			continue
 		}
 		modes[index].Label = fmt.Sprintf("%s (%s)", modes[index].Label, declarations[index].RuntimeID)
+	}
+}
+
+func logExtensionPermissionProjectionDiagnostics(
+	projection extensionPermissionProjection,
+	agentTargetID string,
+	provider string,
+) {
+	for _, diagnostic := range projection.Diagnostics {
+		logAgentExtensionComposerDebug(diagnostic.Reason, map[string]any{
+			"agentTargetId": strings.TrimSpace(agentTargetID),
+			"provider":      strings.TrimSpace(provider),
+			"runtimeId":     diagnostic.RuntimeID,
+		})
 	}
 }

--- a/services/tuttid/service/agent/extension_composer_options.go
+++ b/services/tuttid/service/agent/extension_composer_options.go
@@ -1,63 +1,250 @@
 package agent
 
 import (
-	"context"
+	"fmt"
+	"slices"
 	"strings"
 )
 
-func (s *Service) extensionComposerPermissionConfig(
-	ctx context.Context,
-	providerTargetRef map[string]any,
-	selected string,
-) (PermissionConfig, error) {
-	resolver := s.ExtensionComposerProfiles
-	installationID := strings.TrimSpace(stringFromAny(providerTargetRef["extensionInstallationId"]))
-	if resolver == nil || installationID == "" {
-		return PermissionConfig{}, nil
+// UnsupportedPermissionModeIDError reports a caller-provided permission ID
+// that is not part of the current Composer Options contract. Callers must
+// refresh Composer Options and round-trip an advertised ID verbatim; semantic
+// labels are not substitutes for runtime-owned IDs.
+type UnsupportedPermissionModeIDError struct {
+	AgentTargetID              string
+	PermissionModeID           string
+	AvailablePermissionModeIDs []string
+}
+
+func (e *UnsupportedPermissionModeIDError) Error() string {
+	if e == nil {
+		return "unsupported permission mode id"
 	}
-	profile, err := resolver.ResolveExtensionComposerProfile(ctx, installationID)
-	if err != nil {
-		return PermissionConfig{}, err
+	target := strings.TrimSpace(e.AgentTargetID)
+	if target == "" {
+		target = "agent target"
 	}
-	modes := make([]PermissionModeOption, 0, len(profile.PermissionModes))
-	for _, declaration := range profile.PermissionModes {
-		runtimeID := strings.TrimSpace(declaration.RuntimeID)
+	available := strings.Join(e.AvailablePermissionModeIDs, ", ")
+	if available == "" {
+		available = "none"
+	}
+	return fmt.Sprintf(
+		"permission mode %q is not supported by %s; refresh Composer Options and use one of its IDs: %s",
+		strings.TrimSpace(e.PermissionModeID),
+		target,
+		available,
+	)
+}
+
+func (*UnsupportedPermissionModeIDError) Unwrap() error {
+	return ErrInvalidArgument
+}
+
+type extensionPermissionRuntimeState struct {
+	CurrentRuntimeID string
+	Options          []ComposerConfigOptionValue
+}
+
+type extensionPermissionProjectionInput struct {
+	AgentTargetID string
+	Locale        string
+	Profile       ExtensionComposerProfile
+	Provider      string
+	Runtime       *extensionPermissionRuntimeState
+	SelectedID    string
+}
+
+type extensionPermissionProjectionDiagnostic struct {
+	Reason    string
+	RuntimeID string
+}
+
+type extensionPermissionProjection struct {
+	Config      PermissionConfig
+	CurrentID   string
+	Diagnostics []extensionPermissionProjectionDiagnostic
+}
+
+type extensionPermissionDeclaration struct {
+	PublicID  string
+	RuntimeID string
+	Semantic  PermissionModeSemantic
+}
+
+// projectExtensionPermissionConfig is the single extension permission
+// projection boundary. The signed Composer profile owns the launchable mode
+// set and ID policy. Runtime config options may enrich current state and
+// presentation, but never redefine or collapse the launch contract.
+func projectExtensionPermissionConfig(input extensionPermissionProjectionInput) (extensionPermissionProjection, error) {
+	policy := input.Profile.PermissionModeIDPolicy
+	if policy == "" {
+		// Profiles created before the explicit policy field used provider-owned
+		// runtime IDs unless launchSettings.permission opted into semantic IDs.
+		policy = ExtensionPermissionModeIDPolicyRuntime
+	}
+	if policy != ExtensionPermissionModeIDPolicyRuntime && policy != ExtensionPermissionModeIDPolicySemantic {
+		return extensionPermissionProjection{}, fmt.Errorf("extension composer permission id policy %q is unsupported", policy)
+	}
+
+	declarations := make([]extensionPermissionDeclaration, 0, len(input.Profile.PermissionModes))
+	byRuntimeID := make(map[string]extensionPermissionDeclaration, len(input.Profile.PermissionModes))
+	publicIDs := make(map[string]struct{}, len(input.Profile.PermissionModes))
+	for _, mode := range input.Profile.PermissionModes {
+		runtimeID := strings.TrimSpace(mode.RuntimeID)
 		if runtimeID == "" {
-			continue
+			return extensionPermissionProjection{}, fmt.Errorf("extension composer permission runtime id is required")
 		}
-		semantic := normalizeExtensionPermissionModeSemantic(declaration.Semantic)
-		modeID := runtimeID
-		if profile.PermissionModeIDsAreSemantic {
-			modeID = string(semantic)
+		if _, duplicate := byRuntimeID[runtimeID]; duplicate {
+			return extensionPermissionProjection{}, fmt.Errorf("extension composer permission runtime id %q must be unique", runtimeID)
+		}
+		semantic, supported := normalizeExtensionPermissionModeSemantic(mode.Semantic)
+		if !supported {
+			return extensionPermissionProjection{}, fmt.Errorf(
+				"extension composer permission runtime id %q has unsupported semantic %q",
+				runtimeID,
+				strings.TrimSpace(string(mode.Semantic)),
+			)
+		}
+		publicID := runtimeID
+		if policy == ExtensionPermissionModeIDPolicySemantic {
+			publicID = string(semantic)
+		}
+		if _, duplicate := publicIDs[publicID]; duplicate {
+			return extensionPermissionProjection{}, fmt.Errorf("extension composer permission id %q must be unique", publicID)
+		}
+		declaration := extensionPermissionDeclaration{
+			PublicID:  publicID,
+			RuntimeID: runtimeID,
+			Semantic:  semantic,
+		}
+		declarations = append(declarations, declaration)
+		byRuntimeID[runtimeID] = declaration
+		publicIDs[publicID] = struct{}{}
+	}
+
+	runtimePresentation := map[string]ComposerConfigOptionValue{}
+	diagnostics := make([]extensionPermissionProjectionDiagnostic, 0)
+	if input.Runtime != nil {
+		for _, option := range input.Runtime.Options {
+			runtimeID := strings.TrimSpace(option.Value)
+			if runtimeID == "" {
+				continue
+			}
+			if _, declared := byRuntimeID[runtimeID]; !declared {
+				diagnostics = append(diagnostics, extensionPermissionProjectionDiagnostic{
+					Reason:    "permission_runtime_option_undeclared",
+					RuntimeID: runtimeID,
+				})
+				continue
+			}
+			if _, duplicate := runtimePresentation[runtimeID]; duplicate {
+				diagnostics = append(diagnostics, extensionPermissionProjectionDiagnostic{
+					Reason:    "permission_runtime_option_duplicate",
+					RuntimeID: runtimeID,
+				})
+				continue
+			}
+			runtimePresentation[runtimeID] = option
+		}
+	}
+
+	modes := make([]PermissionModeOption, 0, len(declarations))
+	for _, declaration := range declarations {
+		label, description := permissionModeDisplay(
+			input.Provider,
+			declaration.PublicID,
+			declaration.Semantic,
+			input.Locale,
+		)
+		if runtimeOption, ok := runtimePresentation[declaration.RuntimeID]; ok {
+			if text := strings.TrimSpace(runtimeOption.Label); text != "" {
+				label = text
+			}
+			if text := strings.TrimSpace(runtimeOption.Description); text != "" {
+				description = text
+			}
 		}
 		modes = append(modes, PermissionModeOption{
-			ID:       modeID,
-			Label:    modeID,
-			Semantic: semantic,
+			Description: description,
+			ID:          declaration.PublicID,
+			Label:       label,
+			Semantic:    declaration.Semantic,
 		})
 	}
-	selected = strings.TrimSpace(selected)
-	if selected == "" {
-		selected = strings.TrimSpace(profile.DefaultPermissionModeID)
+	disambiguateExtensionPermissionLabels(modes, declarations)
+
+	availableIDs := make([]string, 0, len(modes))
+	for _, mode := range modes {
+		availableIDs = append(availableIDs, mode.ID)
 	}
-	return PermissionConfig{
-		Configurable: len(modes) > 0,
-		DefaultValue: selected,
-		Modes:        modes,
+	currentID := strings.TrimSpace(input.SelectedID)
+	if currentID != "" {
+		if _, supported := publicIDs[currentID]; !supported {
+			return extensionPermissionProjection{}, &UnsupportedPermissionModeIDError{
+				AgentTargetID:              strings.TrimSpace(input.AgentTargetID),
+				PermissionModeID:           currentID,
+				AvailablePermissionModeIDs: slices.Clone(availableIDs),
+			}
+		}
+	} else if input.Runtime != nil {
+		if declaration, ok := byRuntimeID[strings.TrimSpace(input.Runtime.CurrentRuntimeID)]; ok {
+			currentID = declaration.PublicID
+		}
+	}
+	if currentID == "" {
+		defaultID := strings.TrimSpace(input.Profile.DefaultPermissionModeID)
+		if defaultID != "" {
+			if _, supported := publicIDs[defaultID]; !supported {
+				return extensionPermissionProjection{}, fmt.Errorf(
+					"extension composer default permission id %q is not declared",
+					defaultID,
+				)
+			}
+			currentID = defaultID
+		}
+	}
+
+	return extensionPermissionProjection{
+		Config: PermissionConfig{
+			Configurable: len(modes) > 0,
+			DefaultValue: currentID,
+			Modes:        modes,
+		},
+		CurrentID:   currentID,
+		Diagnostics: diagnostics,
 	}, nil
 }
 
-func normalizeExtensionPermissionModeSemantic(semantic PermissionModeSemantic) PermissionModeSemantic {
-	switch PermissionModeSemantic(strings.TrimSpace(string(semantic))) {
+func normalizeExtensionPermissionModeSemantic(value PermissionModeSemantic) (PermissionModeSemantic, bool) {
+	switch PermissionModeSemantic(strings.TrimSpace(string(value))) {
 	case PermissionModeSemanticAskBeforeWrite:
-		return PermissionModeSemanticAskBeforeWrite
+		return PermissionModeSemanticAskBeforeWrite, true
 	case PermissionModeSemanticAcceptEdits:
-		return PermissionModeSemanticAcceptEdits
+		return PermissionModeSemanticAcceptEdits, true
 	case PermissionModeSemanticFullAccess:
-		return PermissionModeSemanticFullAccess
+		return PermissionModeSemanticFullAccess, true
 	case PermissionModeSemanticLockedDown, "read-only":
-		return PermissionModeSemanticLockedDown
+		return PermissionModeSemanticLockedDown, true
+	case PermissionModeSemanticAuto:
+		return PermissionModeSemanticAuto, true
 	default:
-		return PermissionModeSemanticAuto
+		return "", false
+	}
+}
+
+func disambiguateExtensionPermissionLabels(
+	modes []PermissionModeOption,
+	declarations []extensionPermissionDeclaration,
+) {
+	labelCounts := make(map[string]int, len(modes))
+	for _, mode := range modes {
+		labelCounts[strings.ToLower(strings.TrimSpace(mode.Label))]++
+	}
+	for index := range modes {
+		key := strings.ToLower(strings.TrimSpace(modes[index].Label))
+		if key == "" || labelCounts[key] < 2 {
+			continue
+		}
+		modes[index].Label = fmt.Sprintf("%s (%s)", modes[index].Label, declarations[index].RuntimeID)
 	}
 }

--- a/services/tuttid/service/agent/extension_composer_options_test.go
+++ b/services/tuttid/service/agent/extension_composer_options_test.go
@@ -95,6 +95,39 @@ func TestProjectExtensionPermissionConfigExplicitSelectionWinsOverRuntimeCurrent
 	}
 }
 
+func TestProjectExtensionPermissionConfigUsesRuntimeBeforeConfiguredAndProfileDefaults(t *testing.T) {
+	profile := ExtensionComposerProfile{
+		DefaultPermissionModeID: "default",
+		PermissionModes: []ExtensionComposerPermissionMode{
+			{RuntimeID: "default", Semantic: PermissionModeSemanticAskBeforeWrite},
+			{RuntimeID: "bypassPermissions", Semantic: PermissionModeSemanticFullAccess},
+		},
+	}
+	projection, err := projectExtensionPermissionConfig(extensionPermissionProjectionInput{
+		FallbackID: "default",
+		Profile:    profile,
+		Runtime:    &extensionPermissionRuntimeState{CurrentRuntimeID: "bypassPermissions"},
+	})
+	if err != nil {
+		t.Fatalf("projectExtensionPermissionConfig() error = %v", err)
+	}
+	if projection.CurrentID != "bypassPermissions" {
+		t.Fatalf("current id = %q, want runtime current before configured default", projection.CurrentID)
+	}
+
+	projection, err = projectExtensionPermissionConfig(extensionPermissionProjectionInput{
+		FallbackID: "stale-semantic-id",
+		Profile:    profile,
+	})
+	if err != nil {
+		t.Fatalf("projectExtensionPermissionConfig() stale fallback error = %v", err)
+	}
+	if projection.CurrentID != "default" || len(projection.Diagnostics) != 1 ||
+		projection.Diagnostics[0].Reason != "permission_configured_default_unsupported" {
+		t.Fatalf("projection = %#v, want stale fallback ignored before profile default", projection)
+	}
+}
+
 func TestProjectExtensionPermissionConfigRejectsUnsupportedExplicitID(t *testing.T) {
 	_, err := projectExtensionPermissionConfig(extensionPermissionProjectionInput{
 		AgentTargetID: "extension:codebuddy",
@@ -140,6 +173,13 @@ func TestProjectExtensionPermissionConfigRejectsInvalidProfileModes(t *testing.T
 			modes: []ExtensionComposerPermissionMode{
 				{RuntimeID: "same", Semantic: PermissionModeSemanticAskBeforeWrite},
 				{RuntimeID: "same", Semantic: PermissionModeSemanticFullAccess},
+			},
+		},
+		{
+			name: "case-insensitive duplicate runtime id",
+			modes: []ExtensionComposerPermissionMode{
+				{RuntimeID: "Auto", Semantic: PermissionModeSemanticAskBeforeWrite},
+				{RuntimeID: "auto", Semantic: PermissionModeSemanticFullAccess},
 			},
 		},
 		{

--- a/services/tuttid/service/agent/extension_composer_options_test.go
+++ b/services/tuttid/service/agent/extension_composer_options_test.go
@@ -1,0 +1,172 @@
+package agent
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestProjectExtensionPermissionConfigPreservesRuntimeIDsWithSharedSemantic(t *testing.T) {
+	projection, err := projectExtensionPermissionConfig(extensionPermissionProjectionInput{
+		AgentTargetID: "extension:codebuddy",
+		Profile: ExtensionComposerProfile{
+			PermissionModeIDPolicy: ExtensionPermissionModeIDPolicyRuntime,
+			PermissionModes: []ExtensionComposerPermissionMode{
+				{RuntimeID: "default", Semantic: PermissionModeSemanticAskBeforeWrite},
+				{RuntimeID: "bypassPermissions", Semantic: PermissionModeSemanticFullAccess},
+				{RuntimeID: "fullAccess", Semantic: PermissionModeSemanticFullAccess},
+			},
+		},
+		Runtime: &extensionPermissionRuntimeState{
+			CurrentRuntimeID: "default",
+			Options: []ComposerConfigOptionValue{
+				{Value: "default", Label: "Default"},
+				{Value: "bypassPermissions", Label: "Full access"},
+				{Value: "bypassPermissions", Label: "Duplicate should not win"},
+				{Value: "fullAccess", Label: "Full access"},
+				{Value: "providerExperimental", Label: "Experimental"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("projectExtensionPermissionConfig() error = %v", err)
+	}
+	if projection.CurrentID != "default" || !projection.Config.Configurable {
+		t.Fatalf("projection = %#v", projection)
+	}
+	ids := permissionModeIDs(projection.Config)
+	if !slices.Equal(ids, []string{"default", "bypassPermissions", "fullAccess"}) {
+		t.Fatalf("permission ids = %#v, want exact profile order", ids)
+	}
+	if projection.Config.Modes[1].Semantic != PermissionModeSemanticFullAccess ||
+		projection.Config.Modes[2].Semantic != PermissionModeSemanticFullAccess {
+		t.Fatalf("full access modes = %#v", projection.Config.Modes[1:])
+	}
+	if projection.Config.Modes[1].Label != "Full access (bypassPermissions)" ||
+		projection.Config.Modes[2].Label != "Full access (fullAccess)" {
+		t.Fatalf("disambiguated labels = %#v", projection.Config.Modes[1:])
+	}
+	if len(projection.Diagnostics) != 2 ||
+		projection.Diagnostics[0].Reason != "permission_runtime_option_duplicate" ||
+		projection.Diagnostics[1].Reason != "permission_runtime_option_undeclared" {
+		t.Fatalf("diagnostics = %#v, want duplicate and undeclared runtime options", projection.Diagnostics)
+	}
+}
+
+func TestProjectExtensionPermissionConfigUsesSemanticIDsOnlyForSemanticPolicy(t *testing.T) {
+	projection, err := projectExtensionPermissionConfig(extensionPermissionProjectionInput{
+		Profile: ExtensionComposerProfile{
+			DefaultPermissionModeID: "ask-before-write",
+			PermissionModeIDPolicy:  ExtensionPermissionModeIDPolicySemantic,
+			PermissionModes: []ExtensionComposerPermissionMode{
+				{RuntimeID: "ask", Semantic: PermissionModeSemanticAskBeforeWrite},
+				{RuntimeID: "auto", Semantic: PermissionModeSemanticAuto},
+				{RuntimeID: "all", Semantic: PermissionModeSemanticFullAccess},
+			},
+		},
+		Runtime: &extensionPermissionRuntimeState{CurrentRuntimeID: "all"},
+	})
+	if err != nil {
+		t.Fatalf("projectExtensionPermissionConfig() error = %v", err)
+	}
+	if projection.CurrentID != "full-access" {
+		t.Fatalf("current id = %q, want runtime current mapped to semantic id", projection.CurrentID)
+	}
+	if got := permissionModeIDs(projection.Config); !slices.Equal(got, []string{"ask-before-write", "auto", "full-access"}) {
+		t.Fatalf("permission ids = %#v, want semantic ids", got)
+	}
+}
+
+func TestProjectExtensionPermissionConfigExplicitSelectionWinsOverRuntimeCurrent(t *testing.T) {
+	projection, err := projectExtensionPermissionConfig(extensionPermissionProjectionInput{
+		SelectedID: "bypassPermissions",
+		Profile: ExtensionComposerProfile{PermissionModes: []ExtensionComposerPermissionMode{
+			{RuntimeID: "default", Semantic: PermissionModeSemanticAskBeforeWrite},
+			{RuntimeID: "bypassPermissions", Semantic: PermissionModeSemanticFullAccess},
+		}},
+		Runtime: &extensionPermissionRuntimeState{CurrentRuntimeID: "default"},
+	})
+	if err != nil {
+		t.Fatalf("projectExtensionPermissionConfig() error = %v", err)
+	}
+	if projection.CurrentID != "bypassPermissions" || projection.Config.DefaultValue != "bypassPermissions" {
+		t.Fatalf("projection = %#v, want explicit selection preserved", projection)
+	}
+}
+
+func TestProjectExtensionPermissionConfigRejectsUnsupportedExplicitID(t *testing.T) {
+	_, err := projectExtensionPermissionConfig(extensionPermissionProjectionInput{
+		AgentTargetID: "extension:codebuddy",
+		SelectedID:    "full-access",
+		Profile: ExtensionComposerProfile{PermissionModes: []ExtensionComposerPermissionMode{
+			{RuntimeID: "default", Semantic: PermissionModeSemanticAskBeforeWrite},
+			{RuntimeID: "bypassPermissions", Semantic: PermissionModeSemanticFullAccess},
+			{RuntimeID: "fullAccess", Semantic: PermissionModeSemanticFullAccess},
+		}},
+	})
+	var unsupported *UnsupportedPermissionModeIDError
+	if !errors.As(err, &unsupported) || !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("error = %v, want UnsupportedPermissionModeIDError", err)
+	}
+	if unsupported.PermissionModeID != "full-access" ||
+		!slices.Equal(unsupported.AvailablePermissionModeIDs, []string{"default", "bypassPermissions", "fullAccess"}) ||
+		!strings.Contains(err.Error(), "refresh Composer Options") {
+		t.Fatalf("unsupported error = %#v (%v)", unsupported, err)
+	}
+}
+
+func TestProjectExtensionPermissionConfigSingleModeIsConfigurableWithoutInventingCurrent(t *testing.T) {
+	projection, err := projectExtensionPermissionConfig(extensionPermissionProjectionInput{
+		Profile: ExtensionComposerProfile{PermissionModes: []ExtensionComposerPermissionMode{
+			{RuntimeID: "default", Semantic: PermissionModeSemanticAskBeforeWrite},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("projectExtensionPermissionConfig() error = %v", err)
+	}
+	if !projection.Config.Configurable || projection.CurrentID != "" || projection.Config.DefaultValue != "" {
+		t.Fatalf("projection = %#v, want supported field without invented selection", projection)
+	}
+}
+
+func TestProjectExtensionPermissionConfigRejectsInvalidProfileModes(t *testing.T) {
+	tests := []struct {
+		name  string
+		modes []ExtensionComposerPermissionMode
+	}{
+		{
+			name: "duplicate runtime id",
+			modes: []ExtensionComposerPermissionMode{
+				{RuntimeID: "same", Semantic: PermissionModeSemanticAskBeforeWrite},
+				{RuntimeID: "same", Semantic: PermissionModeSemanticFullAccess},
+			},
+		},
+		{
+			name:  "unknown semantic",
+			modes: []ExtensionComposerPermissionMode{{RuntimeID: "mystery", Semantic: "whatever"}},
+		},
+		{
+			name:  "missing runtime id",
+			modes: []ExtensionComposerPermissionMode{{Semantic: PermissionModeSemanticAuto}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := projectExtensionPermissionConfig(extensionPermissionProjectionInput{
+				Profile: ExtensionComposerProfile{PermissionModes: test.modes},
+			})
+			if err == nil {
+				t.Fatal("projectExtensionPermissionConfig() error = nil")
+			}
+		})
+	}
+}
+
+func permissionModeIDs(config PermissionConfig) []string {
+	result := make([]string, 0, len(config.Modes))
+	for _, mode := range config.Modes {
+		result = append(result, mode.ID)
+	}
+	return result
+}

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -69,6 +69,7 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 	}
 	input.Provider = provider
 	input.ProviderTargetRef = launch.ProviderTargetRef
+	permissionModeExplicit := strings.TrimSpace(value(input.PermissionModeID)) != ""
 	if err := s.applyCreateSessionComposerDefaults(ctx, &input); err != nil {
 		return CreateSessionResult{}, err
 	}
@@ -154,7 +155,13 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 	}
 	if providerTargetRefKind(input.ProviderTargetRef) == "agent_extension" {
 		nodeStartedAt = time.Now()
-		if err := s.validateExtensionComposerSettingsForCreate(ctx, workspaceID, cwd, input); err != nil {
+		if err := s.validateExtensionComposerSettingsForCreate(
+			ctx,
+			workspaceID,
+			cwd,
+			&input,
+			permissionModeExplicit,
+		); err != nil {
 			s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "settings_validated", provider, nodeStartedAt, err)
 			return CreateSessionResult{}, err
 		}

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -2912,7 +2912,7 @@ func TestServiceGetComposerOptionsPreservesGenericExtensionTargetAndProjectsSign
 		WorkspaceID:   "workspace-1",
 		Cwd:           t.TempDir(),
 		Settings: ComposerSettings{
-			PermissionModeID: "ask-before-write",
+			PermissionModeID: "default",
 			ReasoningEffort:  "deep",
 		},
 	})
@@ -2929,18 +2929,19 @@ func TestServiceGetComposerOptionsPreservesGenericExtensionTargetAndProjectsSign
 		t.Fatalf("modelConfig = %#v, want live extension model options", options.ModelConfig)
 	}
 	if !options.PermissionConfig.Configurable ||
-		options.PermissionConfig.DefaultValue != "ask-before-write" ||
-		len(options.PermissionConfig.Modes) != 5 ||
+		options.PermissionConfig.DefaultValue != "default" ||
+		len(options.PermissionConfig.Modes) != 6 ||
 		options.PermissionConfig.Modes[1].Semantic != PermissionModeSemanticAcceptEdits ||
-		options.PermissionConfig.Modes[4].Semantic != PermissionModeSemanticFullAccess {
+		options.PermissionConfig.Modes[4].Semantic != PermissionModeSemanticFullAccess ||
+		options.PermissionConfig.Modes[5].Semantic != PermissionModeSemanticFullAccess {
 		t.Fatalf("permissionConfig = %#v, want runtime extension permission modes", options.PermissionConfig)
 	}
 	permissionModeIDs := make([]string, 0, len(options.PermissionConfig.Modes))
 	for _, mode := range options.PermissionConfig.Modes {
 		permissionModeIDs = append(permissionModeIDs, mode.ID)
 	}
-	if !slices.Equal(permissionModeIDs, []string{"ask-before-write", "accept-edits", "auto", "locked-down", "full-access"}) {
-		t.Fatalf("permission mode ids = %#v, want semantic representatives", permissionModeIDs)
+	if !slices.Equal(permissionModeIDs, []string{"default", "acceptEdits", "auto", "dontAsk", "bypassPermissions", "fullAccess"}) {
+		t.Fatalf("permission mode ids = %#v, want exact runtime ids", permissionModeIDs)
 	}
 	if !options.ReasoningConfig.Configurable ||
 		options.ReasoningConfig.CurrentValue != "enabled" ||
@@ -2975,8 +2976,8 @@ func TestServiceGetComposerOptionsPreservesGenericExtensionTargetAndProjectsSign
 	if len(runtime.startCalls) != 1 || runtime.startCalls[0].ProviderTargetRef["kind"] != "agent_extension" {
 		t.Fatalf("runtime start calls = %#v, want one target-scoped extension discovery", runtime.startCalls)
 	}
-	if runtime.startCalls[0].PermissionModeID != "ask-before-write" || runtime.startCalls[0].ReasoningEffort != "deep" {
-		t.Fatalf("runtime start settings = %#v, want signed semantic permission and requested reasoning", runtime.startCalls[0])
+	if runtime.startCalls[0].PermissionModeID != "default" || runtime.startCalls[0].ReasoningEffort != "deep" {
+		t.Fatalf("runtime start settings = %#v, want exact runtime permission and requested reasoning", runtime.startCalls[0])
 	}
 	if len(runtime.closeCalls) != 1 || len(runtime.sessions) != 0 {
 		t.Fatalf("runtime cleanup = calls %#v sessions %#v, want hidden discovery closed immediately", runtime.closeCalls, runtime.sessions)

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -132,12 +132,24 @@ type ExtensionComposerProfileResolver interface {
 	ResolveExtensionComposerProfile(context.Context, string) (ExtensionComposerProfile, error)
 }
 
+// ExtensionPermissionModeIDPolicy defines the identifier contract exposed by
+// Composer Options for an extension permission mode. Runtime IDs are exact
+// provider-owned values. Semantic IDs are Tutti's closed permission vocabulary
+// and are only valid when the extension's launch contract explicitly consumes
+// that vocabulary.
+type ExtensionPermissionModeIDPolicy string
+
+const (
+	ExtensionPermissionModeIDPolicyRuntime  ExtensionPermissionModeIDPolicy = "runtime-id"
+	ExtensionPermissionModeIDPolicySemantic ExtensionPermissionModeIDPolicy = "semantic-id"
+)
+
 type ExtensionComposerProfile struct {
 	Capabilities                     []string
 	ModelConfigOptionID              string
 	PermissionConfigOptionID         string
 	DefaultPermissionModeID          string
-	PermissionModeIDsAreSemantic     bool
+	PermissionModeIDPolicy           ExtensionPermissionModeIDPolicy
 	PermissionModes                  []ExtensionComposerPermissionMode
 	ReasoningConfigOptionID          string
 	Skills                           *ExtensionComposerSkillProfile

--- a/services/tuttid/service/agentextension/manager_test.go
+++ b/services/tuttid/service/agentextension/manager_test.go
@@ -613,6 +613,31 @@ func TestLoadComposerModesKeepsDistinctGenericRuntimeModes(t *testing.T) {
 	}
 }
 
+func TestLoadComposerModesExactRuntimeIDWinsOverSemanticAlias(t *testing.T) {
+	packageDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(packageDir, "profiles"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, "profiles", "composer.json"), []byte(`{
+		"schemaVersion":"tutti.agent.composer.v1",
+		"permissionModes":[
+			{"runtimeId":"auto","semantic":"ask-before-write"},
+			{"runtimeId":"danger","semantic":"auto"}
+		]
+	}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manifest := Manifest{}
+	manifest.Profiles.Composer = "profiles/composer.json"
+	modes, _, err := loadComposerModes(Installation{PackageDir: packageDir, Manifest: manifest})
+	if err != nil {
+		t.Fatalf("loadComposerModes() error = %v", err)
+	}
+	if modes["auto"] != "auto" || modes["danger"] != "danger" {
+		t.Fatalf("composer modes = %#v, want exact runtime ids to win over aliases", modes)
+	}
+}
+
 func TestValidateComposerProfileRejectsInvalidSignedCommandDeclarations(t *testing.T) {
 	tests := []struct {
 		name string
@@ -683,6 +708,41 @@ func TestValidateComposerProfileRejectsInvalidSignedCommandDeclarations(t *testi
 			}
 			if err := validateComposerProfile(profile); err == nil {
 				t.Fatal("validateComposerProfile() error = nil, want signed profile rejection")
+			}
+		})
+	}
+}
+
+func TestValidateComposerPermissionModeErrorsIdentifyConflictingDeclaration(t *testing.T) {
+	tests := []struct {
+		name  string
+		modes []ComposerPermissionMode
+		want  []string
+	}{
+		{
+			name: "case-insensitive runtime id conflict",
+			modes: []ComposerPermissionMode{
+				{RuntimeID: "Auto", Semantic: "ask-before-write"},
+				{RuntimeID: "auto", Semantic: "full-access"},
+			},
+			want: []string{`"Auto"`, `"auto"`, "ignoring case"},
+		},
+		{
+			name:  "unsupported semantic",
+			modes: []ComposerPermissionMode{{RuntimeID: "danger", Semantic: "root"}},
+			want:  []string{`"danger"`, `"root"`},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateComposerPermissionModes(test.modes)
+			if err == nil {
+				t.Fatal("validateComposerPermissionModes() error = nil")
+			}
+			for _, want := range test.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %q, want substring %q", err, want)
+				}
 			}
 		})
 	}

--- a/services/tuttid/service/agentextension/manager_test.go
+++ b/services/tuttid/service/agentextension/manager_test.go
@@ -643,6 +643,14 @@ func TestValidateComposerProfileRejectsInvalidSignedCommandDeclarations(t *testi
 			raw:  `{"schemaVersion":"tutti.agent.composer.v1","launchSettings":{"permission":{"placeholder":"${permissionMode}"}},"permissionModes":[{"runtimeId":"ask","semantic":"ask-before-write"},{"runtimeId":"auto","semantic":"auto"},{"runtimeId":"all","semantic":"full-access"},{"runtimeId":"maybe","semantic":"maybe"}]}`,
 		},
 		{
+			name: "unknown runtime semantic",
+			raw:  `{"schemaVersion":"tutti.agent.composer.v1","permissionModes":[{"runtimeId":"maybe","semantic":"maybe"}]}`,
+		},
+		{
+			name: "duplicate runtime permission id",
+			raw:  `{"schemaVersion":"tutti.agent.composer.v1","permissionModes":[{"runtimeId":"same","semantic":"ask-before-write"},{"runtimeId":"same","semantic":"full-access"}]}`,
+		},
+		{
 			name: "duplicate launch runtime value",
 			raw:  `{"schemaVersion":"tutti.agent.composer.v1","launchSettings":{"permission":{"placeholder":"${permissionMode}"}},"permissionModes":[{"runtimeId":"ask","semantic":"ask-before-write"},{"runtimeId":"ask","semantic":"auto"},{"runtimeId":"all","semantic":"full-access"}]}`,
 		},

--- a/services/tuttid/service/agentextension/profiles.go
+++ b/services/tuttid/service/agentextension/profiles.go
@@ -190,13 +190,19 @@ func loadComposerModes(installation Installation) (map[string]string, string, er
 	}
 	modes := map[string]string{}
 	planMode := ""
+	// Runtime IDs are the exact public launch contract. Register every exact
+	// ID before compatibility aliases so an alias can never redirect an
+	// advertised ID to a different permission tier.
+	for _, mode := range profile.PermissionModes {
+		runtimeID := strings.TrimSpace(mode.RuntimeID)
+		modes[strings.ToLower(runtimeID)] = runtimeID
+	}
 	for _, mode := range profile.PermissionModes {
 		runtimeID := strings.TrimSpace(mode.RuntimeID)
 		if runtimeID == "" {
 			return nil, "", errors.New("composer permission runtimeId is required")
 		}
 		semantic := strings.TrimSpace(mode.Semantic)
-		modes[strings.ToLower(runtimeID)] = runtimeID
 		setComposerModeAlias(modes, semantic, runtimeID)
 		switch semantic {
 		case "ask-before-write":
@@ -205,7 +211,7 @@ func loadComposerModes(installation Installation) (map[string]string, string, er
 			setComposerModeAlias(modes, "accept-edits", runtimeID)
 			setComposerModeAlias(modes, "auto", runtimeID)
 		case "auto":
-			modes["auto"] = runtimeID
+			setComposerModeAlias(modes, "auto", runtimeID)
 			setComposerModeAlias(modes, "agent", runtimeID)
 		case "locked-down":
 			setComposerModeAlias(modes, "locked-down", runtimeID)
@@ -213,7 +219,7 @@ func loadComposerModes(installation Installation) (map[string]string, string, er
 		case "full-access":
 			setComposerModeAlias(modes, "full-access", runtimeID)
 		case "read-only":
-			modes["plan"] = runtimeID
+			setComposerModeAlias(modes, "plan", runtimeID)
 			planMode = runtimeID
 		default:
 			return nil, "", errors.New("composer permission semantic is unsupported")
@@ -362,20 +368,30 @@ func validateComposerProfile(profile ComposerProfile) error {
 }
 
 func validateComposerPermissionModes(modes []ComposerPermissionMode) error {
-	seenRuntimeIDs := make(map[string]struct{}, len(modes))
+	seenRuntimeIDs := make(map[string]string, len(modes))
 	for _, mode := range modes {
 		runtimeID := strings.TrimSpace(mode.RuntimeID)
 		if runtimeID == "" {
 			return errors.New("composer permission runtimeId is required")
 		}
-		if _, duplicate := seenRuntimeIDs[runtimeID]; duplicate {
-			return errors.New("composer permission runtimeId must be unique")
+		normalizedRuntimeID := strings.ToLower(runtimeID)
+		if existing, duplicate := seenRuntimeIDs[normalizedRuntimeID]; duplicate {
+			return fmt.Errorf(
+				"composer permission runtimeId %q conflicts with %q; runtime IDs must be unique ignoring case",
+				runtimeID,
+				existing,
+			)
 		}
-		seenRuntimeIDs[runtimeID] = struct{}{}
-		switch strings.TrimSpace(mode.Semantic) {
+		seenRuntimeIDs[normalizedRuntimeID] = runtimeID
+		semantic := strings.TrimSpace(mode.Semantic)
+		switch semantic {
 		case "ask-before-write", "accept-edits", "auto", "locked-down", "full-access", "read-only":
 		default:
-			return errors.New("composer permission semantic is unsupported")
+			return fmt.Errorf(
+				"composer permission runtimeId %q has unsupported semantic %q",
+				runtimeID,
+				semantic,
+			)
 		}
 	}
 	return nil

--- a/services/tuttid/service/agentextension/profiles.go
+++ b/services/tuttid/service/agentextension/profiles.go
@@ -21,12 +21,8 @@ type ComposerProfile struct {
 		Permission ComposerConfigOptionReference `json:"permission"`
 		Reasoning  ComposerConfigOptionReference `json:"reasoning"`
 	} `json:"configOptions,omitempty"`
-	PermissionModes []struct {
-		RuntimeID         string `json:"runtimeId"`
-		Semantic          string `json:"semantic"`
-		AutomaticDecision string `json:"automaticDecision,omitempty"`
-	} `json:"permissionModes"`
-	LaunchSettings *struct {
+	PermissionModes []ComposerPermissionMode `json:"permissionModes"`
+	LaunchSettings  *struct {
 		Permission *struct {
 			Placeholder     string `json:"placeholder"`
 			DefaultSemantic string `json:"defaultSemantic"`
@@ -57,6 +53,12 @@ type ComposerProfile struct {
 			Path  string `json:"path"`
 		} `json:"roots"`
 	} `json:"skills,omitempty"`
+}
+
+type ComposerPermissionMode struct {
+	RuntimeID         string `json:"runtimeId"`
+	Semantic          string `json:"semantic"`
+	AutomaticDecision string `json:"automaticDecision,omitempty"`
 }
 
 const composerPermissionLaunchPlaceholder = "${permissionMode}"
@@ -279,6 +281,9 @@ func validateComposerProfile(profile ComposerProfile) error {
 	if profile.SchemaVersion != "tutti.agent.composer.v1" {
 		return errors.New("unsupported composer profile schema")
 	}
+	if err := validateComposerPermissionModes(profile.PermissionModes); err != nil {
+		return err
+	}
 	if profile.SlashCommands != nil {
 		if len(profile.SlashCommands.Commands) == 0 {
 			return errors.New("composer slashCommands requires at least one command")
@@ -351,6 +356,26 @@ func validateComposerProfile(profile ComposerProfile) error {
 		cleaned := filepath.Clean(strings.TrimSpace(root.Path))
 		if cleaned == "." || filepath.IsAbs(cleaned) || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
 			return errors.New("composer skill root path must be a safe relative path")
+		}
+	}
+	return nil
+}
+
+func validateComposerPermissionModes(modes []ComposerPermissionMode) error {
+	seenRuntimeIDs := make(map[string]struct{}, len(modes))
+	for _, mode := range modes {
+		runtimeID := strings.TrimSpace(mode.RuntimeID)
+		if runtimeID == "" {
+			return errors.New("composer permission runtimeId is required")
+		}
+		if _, duplicate := seenRuntimeIDs[runtimeID]; duplicate {
+			return errors.New("composer permission runtimeId must be unique")
+		}
+		seenRuntimeIDs[runtimeID] = struct{}{}
+		switch strings.TrimSpace(mode.Semantic) {
+		case "ask-before-write", "accept-edits", "auto", "locked-down", "full-access", "read-only":
+		default:
+			return errors.New("composer permission semantic is unsupported")
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

- make the signed extension Composer profile the single launch-permission contract
- preserve provider runtime IDs in Composer Options unless launch settings explicitly use semantic IDs
- keep duplicate semantic classifications as distinct modes and preserve an explicit selected ID over runtime current state
- return `unsupported_permission_mode_id` with the accepted IDs for stale or semantic aliases
- validate malformed permission declarations early and document the round-trip contract

## Why

The static extension Composer path respected runtime IDs, while the live runtime-context merge collapsed modes by semantic and rewrote IDs. A caller could select `bypassPermissions` from Composer Options, then Create would re-fetch options, observe `full-access`, and reject the original launchable ID before a visible session started.

## Compatibility

This intentionally does not migrate invalid persisted semantic aliases for runtime-ID extensions. Callers must refresh Composer Options and submit one of the advertised IDs verbatim. Built-in providers and non-extension session behavior are unchanged.

## Architecture boundary

This is Tutti daemon Composer projection and validation policy, not session or Turn lifecycle behavior. tsh and other Host consumers do not need this product-specific Composer Options projection, so no Agent Host lifecycle API changes are included.

## Validation

- `go test ./service/agent ./service/agentextension ./apierrors`
- `pnpm check:changed` (6 lanes)
- pre-push `pnpm check:changed -- --push-ready` (7 lanes)
- `cd services/tuttid && go build ./...`

Tests use an in-process CodeBuddy-like runtime fixture with `bypassPermissions` and `fullAccess`. They exercise profile parsing, Composer Options, Create validation, and the runtime start boundary without contacting a real provider or consuming Agent tokens.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->