### PR TITLE
feat(agent-host): expose canonical message queries

### DIFF
--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -37,9 +37,10 @@ without its runtime or inbox consumer fails recovery with
 `ErrGoalConsumerUnavailable` instead of silently accumulating work.
 
 `GetSession` reads canonical session truth plus an optional live runtime
-observation without starting a provider. `GetTurn`,
+observation without starting a provider. `GetTurn`, `ListSessionMessages`,
 `FindTurnByClientSubmitID`, and `GetSessionInteractionSnapshot` expose
-canonical queries without leaking an adapter's concrete store. The interaction
+canonical queries without leaking an adapter's concrete store. Message pages
+use per-session version cursors and may be narrowed to one turn. The interaction
 snapshot contains every interaction on the latest turn and derives its pending
 subset from that same read; older-turn pending rows can never become current
 actionable state. `CreateSessionInput.ClientSubmitID` and

--- a/packages/agent/host/canonical_queries.go
+++ b/packages/agent/host/canonical_queries.go
@@ -31,6 +31,26 @@ func (h *Host) FindTurnByClientSubmitID(ctx context.Context, ref SessionRef, cli
 	return h.store.FindTurnByClientSubmitID(ctx, ref.WorkspaceID, ref.AgentSessionID, clientSubmitID)
 }
 
+// ListSessionMessages reads one version-cursor page of canonical message
+// snapshots without starting or resuming a provider runtime. Session identity
+// is carried only by SessionRef; the query owns filters and pagination.
+func (h *Host) ListSessionMessages(ctx context.Context, ref SessionRef, query SessionMessageQuery) (storesqlite.MessagePage, bool, error) {
+	ref = normalizedSessionRef(ref)
+	if h == nil || h.store == nil || ref.WorkspaceID == "" || ref.AgentSessionID == "" {
+		return storesqlite.MessagePage{}, false, ErrInvalidArgument
+	}
+	return h.store.ListSessionMessages(ctx, storesqlite.ListSessionMessagesInput{
+		WorkspaceID:    ref.WorkspaceID,
+		AgentSessionID: ref.AgentSessionID,
+		MessageID:      strings.TrimSpace(query.MessageID),
+		TurnID:         strings.TrimSpace(query.TurnID),
+		AfterVersion:   query.AfterVersion,
+		BeforeVersion:  query.BeforeVersion,
+		Limit:          query.Limit,
+		Order:          query.Order,
+	})
+}
+
 // GetSessionInteractionSnapshot returns every interaction from the canonical
 // latest turn and derives the actionable subset from that same read. It does
 // not start or resume a provider runtime.

--- a/packages/agent/host/canonical_queries_sqlite_test.go
+++ b/packages/agent/host/canonical_queries_sqlite_test.go
@@ -87,3 +87,60 @@ func TestSessionInteractionSnapshotReadsOnlyLatestTurnFromSQLite(t *testing.T) {
 		t.Fatalf("PendingInteractions = %#v, want latest-pending only", snapshot.PendingInteractions)
 	}
 }
+
+func TestListSessionMessagesReadsOneCanonicalTurnPageFromSQLite(t *testing.T) {
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "agent-host-messages.db"))
+	if err != nil {
+		t.Fatalf("open SQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	store := storesqlite.New(db, storesqlite.Options{})
+	if err := store.Migrate(t.Context()); err != nil {
+		t.Fatalf("migrate SQLite: %v", err)
+	}
+	if _, err := store.ReportSessionState(t.Context(), storesqlite.SessionStateReport{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", Provider: "codex", OccurredAtUnixMS: 1,
+	}); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	if _, accepted, err := store.RecordTurnTransition(t.Context(), storesqlite.TurnTransition{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", TurnID: "turn-old",
+		Phase: storesqlite.TurnPhaseRunning, OccurredAtUnixMS: 2,
+	}); err != nil || !accepted {
+		t.Fatalf("seed old turn: accepted=%v err=%v", accepted, err)
+	}
+	if _, accepted, err := store.RecordTurnTransition(t.Context(), storesqlite.TurnTransition{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", TurnID: "turn-old",
+		Phase: storesqlite.TurnPhaseSettled, Outcome: storesqlite.TurnOutcomeCompleted, OccurredAtUnixMS: 3,
+	}); err != nil || !accepted {
+		t.Fatalf("settle old turn: accepted=%v err=%v", accepted, err)
+	}
+	if _, accepted, err := store.RecordTurnTransition(t.Context(), storesqlite.TurnTransition{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", TurnID: "turn-current",
+		Phase: storesqlite.TurnPhaseRunning, OccurredAtUnixMS: 4,
+	}); err != nil || !accepted {
+		t.Fatalf("seed current turn: accepted=%v err=%v", accepted, err)
+	}
+	for index, turnID := range []string{"turn-old", "turn-current", "turn-current"} {
+		messageID := []string{"old", "first", "second"}[index]
+		if _, err := store.ReportSessionMessages(t.Context(), storesqlite.SessionMessageReport{
+			WorkspaceID: "workspace-1", AgentSessionID: "session-1", Messages: []storesqlite.MessageUpdate{{
+				MessageID: messageID, TurnID: turnID, Role: "assistant", Kind: "tool", OccurredAtUnixMS: int64(index + 10),
+			}},
+		}); err != nil {
+			t.Fatalf("seed message %s: %v", messageID, err)
+		}
+	}
+
+	host := agenthost.New(agenthost.Config{CanonicalStore: sqliteCanonicalStore{Store: store}})
+	page, found, err := host.ListSessionMessages(t.Context(), agenthost.SessionRef{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1",
+	}, agenthost.SessionMessageQuery{TurnID: "turn-current", Limit: 1, Order: storesqlite.MessageOrderAsc})
+	if err != nil || !found {
+		t.Fatalf("ListSessionMessages() found=%v error=%v", found, err)
+	}
+	if len(page.Messages) != 1 || page.Messages[0].MessageID != "first" || !page.HasMore || page.LatestVersion == 0 {
+		t.Fatalf("ListSessionMessages() page = %#v, want first current-turn message with cursor", page)
+	}
+}

--- a/packages/agent/host/canonical_queries_test.go
+++ b/packages/agent/host/canonical_queries_test.go
@@ -11,12 +11,15 @@ import (
 
 type canonicalQueryStore struct {
 	CanonicalStore
-	wantWorkspaceID string
-	wantSessionID   string
-	wantTurnID      string
-	turn            storesqlite.Turn
-	err             error
-	interactions    map[string][]storesqlite.Interaction
+	wantWorkspaceID  string
+	wantSessionID    string
+	wantTurnID       string
+	wantMessageQuery storesqlite.ListSessionMessagesInput
+	turn             storesqlite.Turn
+	messagePage      storesqlite.MessagePage
+	messageFound     bool
+	err              error
+	interactions     map[string][]storesqlite.Interaction
 }
 
 func (s canonicalQueryStore) GetTurn(_ context.Context, workspaceID, sessionID, turnID string) (storesqlite.Turn, bool, error) {
@@ -45,6 +48,13 @@ func (s canonicalQueryStore) ListLatestTurnInteractions(_ context.Context, works
 		return nil, errors.New("unexpected latest-turn interaction key")
 	}
 	return s.interactions, s.err
+}
+
+func (s canonicalQueryStore) ListSessionMessages(_ context.Context, input storesqlite.ListSessionMessagesInput) (storesqlite.MessagePage, bool, error) {
+	if !reflect.DeepEqual(input, s.wantMessageQuery) {
+		return storesqlite.MessagePage{}, false, errors.New("unexpected canonical message query")
+	}
+	return s.messagePage, s.messageFound, s.err
 }
 
 func TestGetTurnDelegatesCanonicalQueryWithNormalizedIdentity(t *testing.T) {
@@ -80,6 +90,41 @@ func TestGetTurnRejectsIncompleteIdentity(t *testing.T) {
 				t.Fatalf("GetTurn() error = %v, want %v", err, ErrInvalidArgument)
 			}
 		})
+	}
+}
+
+func TestListSessionMessagesDelegatesCanonicalQueryWithNormalizedIdentity(t *testing.T) {
+	wantQuery := storesqlite.ListSessionMessagesInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", MessageID: "message-1", TurnID: "turn-1",
+		AfterVersion: 7, BeforeVersion: 20, Limit: 25, Order: storesqlite.MessageOrderAsc,
+	}
+	wantPage := storesqlite.MessagePage{
+		AgentSessionID: "session-1", LatestVersion: 9,
+		Messages: []storesqlite.Message{{AgentSessionID: "session-1", MessageID: "message-1", TurnID: "turn-1", Version: 9}},
+	}
+	host := New(Config{CanonicalStore: canonicalQueryStore{
+		wantMessageQuery: wantQuery,
+		messagePage:      wantPage,
+		messageFound:     true,
+	}})
+
+	got, found, err := host.ListSessionMessages(t.Context(), SessionRef{
+		WorkspaceID: " workspace-1 ", AgentSessionID: " session-1 ",
+	}, SessionMessageQuery{
+		MessageID: " message-1 ", TurnID: " turn-1 ", AfterVersion: 7, BeforeVersion: 20,
+		Limit: 25, Order: storesqlite.MessageOrderAsc,
+	})
+	if err != nil || !found || !reflect.DeepEqual(got, wantPage) {
+		t.Fatalf("ListSessionMessages() = (%#v, %v, %v), want (%#v, true, nil)", got, found, err, wantPage)
+	}
+}
+
+func TestListSessionMessagesRejectsIncompleteIdentity(t *testing.T) {
+	host := New(Config{CanonicalStore: canonicalQueryStore{}})
+	for _, ref := range []SessionRef{{WorkspaceID: "workspace-1"}, {AgentSessionID: "session-1"}, {}} {
+		if _, _, err := host.ListSessionMessages(t.Context(), ref, SessionMessageQuery{}); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("ListSessionMessages(%#v) error = %v, want %v", ref, err, ErrInvalidArgument)
+		}
 	}
 }
 

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -23,6 +23,10 @@ type CanonicalTurnStore interface {
 	ListSessionInteractions(context.Context, storesqlite.ListSessionInteractionsInput) ([]storesqlite.Interaction, error)
 }
 
+type CanonicalMessageStore interface {
+	ListSessionMessages(context.Context, storesqlite.ListSessionMessagesInput) (storesqlite.MessagePage, bool, error)
+}
+
 type CanonicalSubmitClaimStore interface {
 	PrepareSubmitClaim(context.Context, storesqlite.SubmitClaimPrepare) (storesqlite.SubmitClaim, bool, error)
 	AcceptSubmitClaim(context.Context, string, string, string, string, int64) (storesqlite.SubmitClaim, bool, error)
@@ -35,6 +39,7 @@ type CanonicalSubmitClaimStore interface {
 type CanonicalStore interface {
 	CanonicalSessionStore
 	CanonicalTurnStore
+	CanonicalMessageStore
 	CanonicalSubmitClaimStore
 }
 

--- a/packages/agent/host/testdata/external-consumer/consumer.go
+++ b/packages/agent/host/testdata/external-consumer/consumer.go
@@ -12,6 +12,7 @@ var (
 	_ = (*agenthost.Host).DeleteSession
 	_ = (*agenthost.Host).GetTurn
 	_ = (*agenthost.Host).FindTurnByClientSubmitID
+	_ = (*agenthost.Host).ListSessionMessages
 	_ = (*agenthost.Host).GetSessionInteractionSnapshot
 	_ = (*agenthost.Host).CancelTurn
 	_ = (*agenthost.Host).SubmitInteractive

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -27,6 +27,18 @@ type SessionInteractionSnapshot struct {
 	PendingInteractions []storesqlite.Interaction
 }
 
+// SessionMessageQuery selects one page of canonical message snapshots. Session
+// identity comes from SessionRef so transport adapters cannot accidentally
+// query a different session through duplicated identity fields.
+type SessionMessageQuery struct {
+	MessageID     string
+	TurnID        string
+	AfterVersion  uint64
+	BeforeVersion uint64
+	Limit         int
+	Order         storesqlite.MessageOrder
+}
+
 type ComposerSettings struct {
 	Model            string
 	PermissionModeID string

--- a/services/tuttid/service/agent/host_adapters.go
+++ b/services/tuttid/service/agent/host_adapters.go
@@ -13,6 +13,10 @@ import (
 
 type serviceHostStore struct{ service *Service }
 
+type canonicalSessionMessageReader interface {
+	ListSessionMessages(context.Context, storesqlite.ListSessionMessagesInput) (storesqlite.MessagePage, bool, error)
+}
+
 func (a serviceHostStore) GetSession(ctx context.Context, workspaceID, sessionID string) (storesqlite.Session, bool, error) {
 	if a.service == nil {
 		return storesqlite.Session{}, false, nil
@@ -152,6 +156,17 @@ func (a serviceHostStore) ListLatestTurnInteractions(ctx context.Context, worksp
 		return nil, nil
 	}
 	return a.service.TurnStore.ListLatestTurnInteractions(ctx, workspaceID, sessionIDs)
+}
+
+func (a serviceHostStore) ListSessionMessages(ctx context.Context, input storesqlite.ListSessionMessagesInput) (storesqlite.MessagePage, bool, error) {
+	if a.service == nil {
+		return storesqlite.MessagePage{}, false, nil
+	}
+	reader, ok := a.service.TurnStore.(canonicalSessionMessageReader)
+	if !ok {
+		return storesqlite.MessagePage{}, false, nil
+	}
+	return reader.ListSessionMessages(ctx, input)
 }
 
 func (a serviceHostStore) PrepareSubmitClaim(ctx context.Context, input storesqlite.SubmitClaimPrepare) (storesqlite.SubmitClaim, bool, error) {


### PR DESCRIPTION
## What changed
- add a read-only Host API for paginated canonical session messages
- keep session identity on `SessionRef` and message filters/cursors on `SessionMessageQuery`
- delegate the new Host store port through the tuttid adapter
- document and compile-check the public contract

## Why
TSH shared-agent activity needs a canonical current-turn replay after subscribing to live events so attach and reconnect windows cannot lose tool messages. The query stays Host-owned instead of leaking the concrete SQLite store into downstream adapters.

## Risk
The `CanonicalStore` interface gains a read-only message query method. Production stores already implement it; the tuttid adapter now delegates explicitly. No lifecycle or write semantics change.

## Verification
- `cd packages/agent/host && go test ./...`
- `pnpm test:go:prepared -- --failed-only` (14 Go workspace lanes passed)
- `pnpm check:changed` (10 lanes passed)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->