### PR TITLE
fix(agent-extension): restore Grok runtime setup

### DIFF
--- a/docs/architecture/agent-extensions.md
+++ b/docs/architecture/agent-extensions.md
@@ -240,9 +240,10 @@ installation that the user confirmed. Every install action recomputes the plan
 and compares its digest before creating files or processes.
 
 The signed release is authoritative for runtime commands. Tutti persists both
-the complete signed release record and the exact signed ZIP beside the extracted
-package. Every remote-package load reverifies the Ed25519 signature against the
-configured source key, checks the ZIP's signed SHA-256 and size, derives a
+the complete signed release record (preserving its signed JSON shape) and the
+exact signed ZIP beside the extracted package. Every remote-package load
+reverifies the Ed25519 signature against the configured source key, checks the
+ZIP's signed SHA-256 and size, derives a
 canonical content identity directly from those signed ZIP bytes, and compares
 that identity and complete manifest with the active package. The copied manifest
 and digest in `installation.json` are metadata and cannot redefine authority. A

--- a/packages/agent/daemon/runtime/process_executable_darwin_test.go
+++ b/packages/agent/daemon/runtime/process_executable_darwin_test.go
@@ -3,9 +3,13 @@
 package agentruntime
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -41,5 +45,42 @@ func TestPrepareProcessExecutableCreatesImmutablePrivateSnapshot(t *testing.T) {
 	}
 	if _, err := os.Lstat(filepath.Dir(snapshotPath)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("verified snapshot directory remains after close: %v", err)
+	}
+}
+
+func TestLocalProcessTransportKeepsVerifiedSnapshotUntilProcessExit(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "runtime")
+	contents := []byte("#!/bin/sh\nsleep 0.1\nif [ -f \"$0\" ]; then printf available; else printf missing; fi\n")
+	if err := os.WriteFile(script, contents, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(contents)
+	conn, err := NewLocalProcessTransport().Start(context.Background(), ProcessSpec{
+		Command: []string{script},
+		ExecutableIdentity: &ExecutableIdentity{
+			SHA256: hex.EncodeToString(digest[:]), SizeBytes: int64(len(contents)),
+		},
+	})
+	if err != nil {
+		t.Fatalf("start verified process: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	var output strings.Builder
+	for {
+		frame, err := conn.Recv()
+		if err != nil {
+			t.Fatalf("receive process frame: %v", err)
+		}
+		output.Write(frame.Stdout)
+		if frame.ExitCode != nil {
+			if *frame.ExitCode != 0 {
+				t.Fatalf("verified process exit code = %d", *frame.ExitCode)
+			}
+			break
+		}
+	}
+	if got := output.String(); got != "available" {
+		t.Fatalf("verified process snapshot state = %q, want available", got)
 	}
 }

--- a/packages/agent/daemon/runtime/process_transport.go
+++ b/packages/agent/daemon/runtime/process_transport.go
@@ -39,12 +39,13 @@ func RunVerifiedExecutable(ctx context.Context, path string, args []string, iden
 }
 
 type localProcessConnection struct {
-	cancel  context.CancelFunc
-	cmd     *exec.Cmd
-	done    chan struct{}
-	closing chan struct{}
-	frames  chan ProcessFrame
-	stdin   io.WriteCloser
+	cancel             context.CancelFunc
+	cmd                *exec.Cmd
+	preparedExecutable *preparedProcessExecutable
+	done               chan struct{}
+	closing            chan struct{}
+	frames             chan ProcessFrame
+	stdin              io.WriteCloser
 
 	closeOnce sync.Once
 	sendMu    sync.Mutex
@@ -75,7 +76,12 @@ func (localProcessTransport) Start(ctx context.Context, spec ProcessSpec) (Proce
 		cancel()
 		return nil, err
 	}
-	defer func() { _ = preparedExecutable.Close() }()
+	started := false
+	defer func() {
+		if !started {
+			_ = preparedExecutable.Close()
+		}
+	}()
 	cmd := exec.CommandContext(processCtx, preparedExecutable.path, spec.Command[1:]...)
 	if preparedExecutable.file != nil {
 		cmd.ExtraFiles = []*os.File{preparedExecutable.file}
@@ -110,6 +116,8 @@ func (localProcessTransport) Start(ctx context.Context, spec ProcessSpec) (Proce
 		cancel()
 		return nil, err
 	}
+	conn.preparedExecutable = &preparedExecutable
+	started = true
 
 	go conn.wait()
 	return conn, nil
@@ -389,6 +397,10 @@ func (w processFrameWriter) Write(data []byte) (int, error) {
 
 func (c *localProcessConnection) wait() {
 	err := c.cmd.Wait()
+	if c.preparedExecutable != nil {
+		_ = c.preparedExecutable.Close()
+		c.preparedExecutable = nil
+	}
 	exitCode := 0
 	if err != nil {
 		exitCode = 1

--- a/services/tuttid/service/agentextension/release_fetch.go
+++ b/services/tuttid/service/agentextension/release_fetch.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -55,6 +56,7 @@ type Release struct {
 	GitSHA            string           `json:"gitSha"`
 	Signature         ReleaseSignature `json:"signature"`
 	signedPayload     []byte
+	signedDocument    []byte
 }
 
 type ReleaseSignature struct {
@@ -77,7 +79,37 @@ func (release *Release) UnmarshalJSON(data []byte) error {
 	}
 	*release = Release(wire)
 	release.signedPayload = payload
+	release.signedDocument = append([]byte(nil), data...)
 	return nil
+}
+
+// MarshalJSON preserves the wire shape that was covered by the release
+// signature. In particular, optional zero-value manifest structs cannot be
+// reintroduced when a release record is written to local state and later
+// reverified.
+func (release Release) MarshalJSON() ([]byte, error) {
+	if len(release.signedDocument) > 0 {
+		var original Release
+		if err := json.Unmarshal(release.signedDocument, &original); err == nil &&
+			sameReleaseWire(release, original) {
+			return append([]byte(nil), release.signedDocument...), nil
+		}
+	}
+	type releaseWire Release
+	return json.Marshal(releaseWire(release))
+}
+
+func sameReleaseWire(left, right Release) bool {
+	return left.SchemaVersion == right.SchemaVersion &&
+		left.AgentKey == right.AgentKey &&
+		left.Version == right.Version &&
+		reflect.DeepEqual(left.Manifest, right.Manifest) &&
+		left.ArtifactURL == right.ArtifactURL &&
+		left.ArtifactSHA256 == right.ArtifactSHA256 &&
+		left.ArtifactSizeBytes == right.ArtifactSizeBytes &&
+		left.PublishedAt == right.PublishedAt &&
+		left.GitSHA == right.GitSHA &&
+		left.Signature == right.Signature
 }
 
 func (m *Manager) getJSON(ctx context.Context, rawURL string, limit int64, target any) error {

--- a/services/tuttid/service/agentextension/release_fetch_test.go
+++ b/services/tuttid/service/agentextension/release_fetch_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -164,5 +165,17 @@ func TestVerifyReleasePreservesSignedOptionalManifestFields(t *testing.T) {
 	}
 	if err := verifyRelease(release, source); err != nil {
 		t.Fatalf("verifyRelease() error = %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "release.json")
+	if err := writeJSONAtomic(path, release); err != nil {
+		t.Fatal(err)
+	}
+	var persisted Release
+	if err := readJSON(path, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyRelease(persisted, source); err != nil {
+		t.Fatalf("verifyRelease() after persistence error = %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- preserve the exact signed release JSON when persisting extension metadata, so optional manifest fields cannot invalidate Ed25519 verification after reload
- keep macOS verified runtime snapshots alive until the spawned ACP process exits
- add persistence and Darwin process-lifetime regressions

## Root cause

The Grok extension release record changed wire shape when it was written to local state, invalidating its signature on the next reconciliation. After that was fixed, the macOS process transport deleted the verified executable snapshot immediately after starting Grok; the runtime could not complete its ACP initialization.

## Impact

Grok can now install successfully in the desktop development environment and proceeds to the expected sign-in state.

## Validation

- `go test ./services/tuttid/service/agentextension`
- `go test ./packages/agent/daemon/runtime`
- `pnpm check:changed`
- rebuilt and restarted the development daemon; completed a real Grok install through the setup API, reaching `auth_required` with runtime version `0.2.103`