### PR TITLE
chore(test): remove low-value text-matching tests (batch 4)

### DIFF
--- a/packages/workbench/surface/src/host/dockMagnification.test.ts
+++ b/packages/workbench/surface/src/host/dockMagnification.test.ts
@@ -1,6 +1,4 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import test from "node:test";
 import {
   advanceDockMagnificationSpring,
@@ -20,8 +18,6 @@ import {
   resolveDockMagnificationVisibleHitBounds,
   resolveDockMagnificationVisibleSlotRects
 } from "./dockMagnification.ts";
-
-const source = readFileSync(resolve("src/host/dockMagnification.ts"), "utf8");
 
 function assertBoundsEqual(
   actual: ReturnType<typeof resolveDockMagnificationHitBounds>,
@@ -387,20 +383,6 @@ test("dock magnification spring settles on the target size", () => {
   assert.ok(Math.abs(spring.value - target) < 0.5);
 });
 
-test("dock magnification keeps active styles until leave animation settles", () => {
-  const handlePointerLeaveSource =
-    source.match(
-      /const handlePointerLeave = useCallback\([\s\S]*?\n {2}\}, \[scheduleAnimation\]\);/
-    )?.[0] ?? "";
-
-  assert.notEqual(handlePointerLeaveSource, "");
-  assert.match(
-    source,
-    /if \(pointerAxis === null && allSettled\) \{[\s\S]*?setMagnifyActive\(false\);/
-  );
-  assert.doesNotMatch(handlePointerLeaveSource, /setMagnifyActive\(false\);/);
-});
-
 test("dock magnification global pointer tracker forwards gap moves and cleans up", () => {
   const pointerTarget = new FakePointerTrackingTarget();
   const blurTarget = new FakePointerTrackingTarget();
@@ -449,68 +431,6 @@ test("dock magnification global pointer tracker forwards gap moves and cleans up
   assert.equal(blurTarget.listenerCount("blur"), 0);
 });
 
-test("dock magnification starts global tracking on active pointers and stops on bounds exit or reset", () => {
-  assert.match(
-    source,
-    /createDockMagnificationGlobalPointerTracker\(\{[\s\S]*?pointerTarget: document/
-  );
-  assert.match(
-    source,
-    /startGlobalPointerTracking\(\);[\s\S]*?scheduleAnimation\(\);/
-  );
-  assert.match(
-    source,
-    /const isPointerInsideDockMagnificationTarget = useCallback\([\s\S]*?isDockMagnificationPointInsideHitBounds\([\s\S]*?\) \|\| isPointerInsideAnyVisibleDockSlot\(clientX, clientY\)/
-  );
-  assert.match(
-    source,
-    /if \(!isPointerInsideDockMagnificationTarget\(clientX, clientY\)\) \{[\s\S]*?stopGlobalPointerTracking\(\);[\s\S]*?clearTrackedPointer\(\);/
-  );
-  assert.match(
-    source,
-    /const resetMagnification = useCallback\([\s\S]*?stopGlobalPointerTracking\(\);/
-  );
-  assert.match(
-    source,
-    /useEffect\(\s*\(\) => \(\) => \{[\s\S]*?resetMagnification\(\);/
-  );
-});
-
-test("dock magnification samples ambient pointer moves without taking dock pointer events", () => {
-  assert.match(
-    source,
-    /document\.addEventListener\(\s*"pointermove",\s*handleAmbientPointerMove/
-  );
-  assert.match(source, /isPointNearDockScreenEdge\(/);
-  assert.match(source, /isPointNearDockViewport\(/);
-  assert.match(
-    source,
-    /const handleAmbientPointerMove = \(event: PointerEvent\) => \{[\s\S]*?!isPointNearDockScreenEdge\([\s\S]*?return;[\s\S]*?latestPoint =/
-  );
-  assert.match(
-    source,
-    /const clearAmbientPointerSample = \(\) => \{[\s\S]*?latestPoint = null;[\s\S]*?cancelAnimationFrame\(animationFrame\);/
-  );
-  assert.match(
-    source,
-    /!isPointNearDockScreenEdge\([\s\S]*?\) \{[\s\S]*?clearAmbientPointerSample\(\);[\s\S]*?return;/
-  );
-  assert.match(
-    source,
-    /isPointerInsideDockMagnificationTarget\(point\.clientX, point\.clientY\)[\s\S]*?handlePointerMove\(point\.clientX, point\.clientY\);/
-  );
-});
-
-test("dock magnification caches slot shell lookups during animation", () => {
-  assert.match(source, /const dockMagnificationShellBySlot = new WeakMap/);
-  assert.match(source, /dockMagnificationShellBySlot\.get\(slotElement\)/);
-  assert.match(source, /slotElement\.contains\(cachedShell\)/);
-  assert.match(
-    source,
-    /dockMagnificationShellBySlot\.set\(slotElement, shell\)/
-  );
-});
-
 test("dock magnification skips layout-locked dock slots", () => {
   assert.equal(
     isDockMagnificationSlotLayoutLocked({
@@ -535,23 +455,5 @@ test("dock magnification skips layout-locked dock slots", () => {
       dataset: { presence: "present" }
     } as unknown as HTMLElement),
     false
-  );
-  assert.match(source, /isDockMagnificationSlotLayoutLocked\(slotElement\)/);
-});
-
-test("dock magnification refreshes slot centers while the pointer is active", () => {
-  const runAnimationFrameSource =
-    source.match(
-      /const runAnimationFrame = useCallback\([\s\S]*?\n {4}\},\n {4}\[captureRestCenters, setMagnifyActive, slotRefs\]\n {2}\);/
-    )?.[0] ?? "";
-
-  assert.notEqual(runAnimationFrameSource, "");
-  assert.match(
-    runAnimationFrameSource,
-    /if \(pointerAxis !== null\) \{[\s\S]*?captureRestCenters\(\);/
-  );
-  assert.match(
-    source,
-    /const ensureDockMagnificationGeometry = useCallback\([\s\S]*?restCentersRef\.current === null[\s\S]*?hitBoundsRef\.current === null[\s\S]*?visibleSlotRectsRef\.current === null[\s\S]*?captureRestCenters\(\);/
   );
 });

--- a/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerTaskDrawerState.test.ts
+++ b/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerTaskDrawerState.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import test from "node:test";
 import type {
   IssueManagerIssueSummary,
@@ -11,23 +10,6 @@ import {
   isIssueManagerRunControlDisabled,
   resolveIssueManagerTaskDrawerViewState
 } from "./IssueManagerTaskDrawerState.ts";
-
-const taskDrawerSectionsSource = readFileSync(
-  new URL("./IssueManagerTaskDrawerSections.tsx", import.meta.url),
-  "utf8"
-);
-const issueManagerBottomBarSource = readFileSync(
-  new URL("./IssueManagerBottomBar.tsx", import.meta.url),
-  "utf8"
-);
-const issueManagerRunSectionsSource = readFileSync(
-  new URL("../task/IssueManagerRunSections.tsx", import.meta.url),
-  "utf8"
-);
-const issueManagerPanelsSource = readFileSync(
-  new URL("./IssueManagerPanels.tsx", import.meta.url),
-  "utf8"
-);
 
 test("task drawer view state prefers create labels in create mode", () => {
   const view = resolveIssueManagerTaskDrawerViewState({
@@ -137,37 +119,6 @@ test("run controls stay enabled for a not started task while another task is run
     }),
     true
   );
-});
-
-test("task drawer run controls do not use the global running task lock", () => {
-  assert.doesNotMatch(
-    taskDrawerSectionsSource,
-    /disabled=\{controller\.isRunningTask\}/
-  );
-  assert.doesNotMatch(
-    issueManagerBottomBarSource,
-    /disabled=\{controller\.isRunningTask\}/
-  );
-  assert.doesNotMatch(
-    issueManagerRunSectionsSource,
-    /controller\.isRunningTask/
-  );
-});
-
-test("issue pane keeps issue-level run content behind the task drawer", () => {
-  assert.match(issueManagerPanelsSource, /latestRun=\{issueLatestRun\}/);
-  assert.match(issueManagerPanelsSource, /outputs=\{issueLatestOutputs\}/);
-  assert.match(issueManagerPanelsSource, /title=\{selectedIssue\.title\}/);
-  assert.match(issueManagerPanelsSource, /selectedTaskId=\{selectedTaskId\}/);
-  assert.doesNotMatch(
-    issueManagerPanelsSource,
-    /controller\.taskDetail\.value\?\.latestRun/
-  );
-  assert.doesNotMatch(
-    issueManagerPanelsSource,
-    /controller\.taskDetail\.value\?\.latestOutputs/
-  );
-  assert.doesNotMatch(issueManagerPanelsSource, /selectedTask\?\.title/);
 });
 
 function createController(

--- a/packages/workspace/terminal/src/react/TerminalSurface.test.ts
+++ b/packages/workspace/terminal/src/react/TerminalSurface.test.ts
@@ -1,29 +1,8 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import test from "node:test";
 import type { ILink, Terminal } from "@xterm/xterm";
 import type { TerminalNodeFeature } from "../core/feature.ts";
 import { createTerminalFileLinkProvider } from "./terminalFileLinkProvider.ts";
-
-const terminalSurfaceSource = readFileSync(
-  new URL("./TerminalSurface.tsx", import.meta.url),
-  "utf8"
-);
-const terminalStyles = readFileSync(
-  new URL("../styles/terminal.css", import.meta.url),
-  "utf8"
-);
-
-test("terminal viewport follows the resolved theme background", () => {
-  assert.match(
-    terminalSurfaceSource,
-    /"--workspace-terminal-background": theme\.background/
-  );
-  assert.match(
-    terminalStyles,
-    /\.workspace-terminal__xterm \.xterm-viewport \{[\s\S]*?background-color: var\([\s\S]*?--workspace-terminal-background,[\s\S]*?var\(--tutti-surface, #111\)[\s\S]*?\);/
-  );
-});
 
 test("terminal file link provider resolves cwd from the latest getter value", async () => {
   let currentCwd = "/workspace/first";

--- a/packages/workspace/terminal/src/workbench/index.test.ts
+++ b/packages/workspace/terminal/src/workbench/index.test.ts
@@ -1,6 +1,4 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import test from "node:test";
 import type {
   WorkbenchHostNodeBodyContext,
@@ -10,10 +8,6 @@ import type { TerminalNodeExternalState } from "../contracts/index.ts";
 import type { TerminalNodeFeature } from "../core/feature.ts";
 import { resolveTerminalWorkbenchBodyProps } from "./bodyProps.ts";
 import { resolveTerminalWindowCloseEffect } from "./windowCloseEffect.ts";
-
-const workbenchIndexSource = readFileSync(resolve("src/workbench/index.ts"), {
-  encoding: "utf8"
-});
 
 test("terminal workbench body lets the mounted surface retain its session", () => {
   const props = resolveTerminalWorkbenchBodyProps({
@@ -52,15 +46,6 @@ test("terminal workbench body forwards preview changes to the host", () => {
   });
 
   assert.equal(props.onPreviewChange, onPreviewChange);
-});
-
-test("terminal minimized dock preview is component-provided, not snapshot", () => {
-  assert.doesNotMatch(workbenchIndexSource, /kind:\s*"snapshot"/);
-  assert.match(workbenchIndexSource, /provideMinimizedPreview/);
-  assert.match(
-    workbenchIndexSource,
-    /kind:\s*"component",\s*providePreview:\s*provideMinimizedPreview/s
-  );
 });
 
 function createTerminalWorkbenchBodyTestContext({


### PR DESCRIPTION
## Summary

删除低价值单测（第四批）- 共183行

### 精简文件（4个）：

| 文件 | 删除行数 | 保留内容 |
|------|---------|----------|
| `dockMagnification.test.ts` | 98行 | 17个有价值的单元测试 |
| `IssueManagerTaskDrawerState.test.ts` | 49行 | 5个有价值的单元测试 |
| `TerminalSurface.test.ts` | 21行 | 1个有价值的单元测试 |
| `workbench/index.test.ts` | 15行 | 4个有价值的单元测试 |

### 删除原因：

这些测试使用 `readFileSync` + `assert.match` 文本匹配模式，只检查代码是否包含特定字符串，不验证实际行为是否正确。

### 保留的测试（验证真实函数行为）：

**dockMagnification:**
- hit bounds 计算（边界坐标）
- spring 弹簧物理模拟
- pointer tracker 生命周期
- slot layout locked 状态判断

**issue-manager:**
- task drawer view state 状态机
- save task 前置条件
- run control disabled 逻辑

**terminal:**
- file link provider 路径解析
- workbench body props
- window close effect

### 测试验证

- ✅ 所有相关测试通过
- ✅ CI检查全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->