### PR TITLE
fix(agent-gui): hide sidebar display settings entry

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.tsx
@@ -7,13 +7,11 @@ import {
   Gift,
   LogIn,
   LogOut,
-  ListTree,
   Settings,
   Wrench,
   X
 } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@tutti-os/ui-system";
-import { openWorkspaceSettingsPanel } from "../../../shared/workspaceSettingsPanel/workspaceSettingsPanelStore";
 import { AccountMembershipBadge } from "../AccountMembershipBadge";
 import { AgentProbeUsageFreshness } from "../AgentProbeUsageFreshness";
 import { AgentUsageMeter } from "../AgentUsageMeter";
@@ -487,27 +485,6 @@ export function AgentGUIConfigMenu({
             </>
           ) : null}
           <div className="flex min-w-0 flex-col gap-1">
-            <button
-              type="button"
-              data-testid="agent-gui-config-manage-agents"
-              className="nodrag flex h-7 w-full items-center gap-2 rounded-[6px] px-2 text-[13px] text-[var(--text-primary)] transition-colors hover:bg-[var(--transparency-hover)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-focus)] disabled:text-[var(--text-tertiary)] [-webkit-app-region:no-drag]"
-              disabled={previewMode}
-              onClick={() => {
-                setOpen(false);
-                // Single management surface: the old sidebar-display dialog is
-                // superseded by the Agents settings tab (single source of truth
-                // for sidebar visibility + provider status). Carry the current
-                // provider so its row scrolls into view and highlights.
-                openWorkspaceSettingsPanel({
-                  section: "agent",
-                  pane: "agents",
-                  provider: provider ?? undefined
-                });
-              }}
-            >
-              <ListTree aria-hidden="true" size={16} strokeWidth={1.8} />
-              <span>{labels.manageAgents}</span>
-            </button>
             {providerScopedActionsVisible && environmentSetupVisible ? (
               <button
                 type="button"


### PR DESCRIPTION
## What changed

Removes the Agent GUI configuration-menu entry that opens the sidebar display settings.

## Why

The sidebar display settings should no longer be exposed from the Agent GUI menu.

## Impact

The underlying Agents settings page and sidebar display preference implementation remain unchanged; this only hides the menu entry.

## Validation

- `git diff --check`
- UI-only presentation change; no automated check required by repository policy.