### PR TITLE
fix(app-center): fence stale factory snapshots

### DIFF
--- a/.changeset/app-center-factory-snapshot-fence.md
+++ b/.changeset/app-center-factory-snapshot-fence.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/workspace-app-center": patch
+---
+
+Prevent older App Factory reads from replacing newer job snapshots, and treat agent target identity changes as authoritative factory state updates.

--- a/packages/workspace/app-center/src/core/appCenterController.test.ts
+++ b/packages/workspace/app-center/src/core/appCenterController.test.ts
@@ -255,6 +255,64 @@ test("WorkspaceAppCenterController sorts factory jobs and reports snapshot appli
   );
 });
 
+test("WorkspaceAppCenterController discards an older factory refresh after an authoritative snapshot", async () => {
+  let resolveFactoryRefresh: (
+    snapshot: WorkspaceAppFactorySnapshot
+  ) => void = () => {};
+  const factoryRefresh = new Promise<WorkspaceAppFactorySnapshot>((resolve) => {
+    resolveFactoryRefresh = resolve;
+  });
+  const discarded: string[] = [];
+  const controller = createWorkspaceAppCenterController({
+    formatError,
+    gateway: createGateway({
+      async listWorkspaceAppFactoryJobs() {
+        return factoryRefresh;
+      }
+    }),
+    hooks: {
+      onRefreshDiscard(input) {
+        discarded.push(input.snapshotKind);
+      }
+    }
+  });
+
+  const refresh = controller.refresh("workspace-1");
+  controller.applyFactorySnapshot(
+    "workspace-1",
+    createFactorySnapshot({
+      jobs: [createFactoryJob({ status: "generating", updatedAtUnixMs: 2 })]
+    })
+  );
+  resolveFactoryRefresh(createFactorySnapshot());
+  await refresh;
+
+  assert.equal(controller.store.factoryJobs[0]?.status, "generating");
+  assert.deepEqual(discarded, ["factory_jobs"]);
+});
+
+test("WorkspaceAppCenterController treats agent target changes as factory state changes", () => {
+  const controller = createWorkspaceAppCenterController({
+    formatError,
+    gateway: createGateway()
+  });
+  controller.applyFactorySnapshot(
+    "workspace-1",
+    createFactorySnapshot({
+      jobs: [createFactoryJob({ agentTargetId: "target-1" })]
+    })
+  );
+
+  controller.applyFactorySnapshot(
+    "workspace-1",
+    createFactorySnapshot({
+      jobs: [createFactoryJob({ agentTargetId: "target-2" })]
+    })
+  );
+
+  assert.equal(controller.store.factoryJobs[0]?.agentTargetId, "target-2");
+});
+
 test("WorkspaceAppCenterController keeps a factory job visible while publish is pending", async () => {
   const readyJob = createFactoryJob({ status: "ready" });
   let resolvePublish: (

--- a/packages/workspace/app-center/src/core/appCenterControllerHelpers.ts
+++ b/packages/workspace/app-center/src/core/appCenterControllerHelpers.ts
@@ -238,6 +238,7 @@ export function areWorkspaceAppFactoryJobsEqual(
     const rightJob = right[index];
     return (
       rightJob !== undefined &&
+      leftJob.agentTargetId === rightJob.agentTargetId &&
       leftJob.agentSessionId === rightJob.agentSessionId &&
       leftJob.appId === rightJob.appId &&
       leftJob.createdAtUnixMs === rightJob.createdAtUnixMs &&

--- a/packages/workspace/app-center/src/core/appCenterControllerState.ts
+++ b/packages/workspace/app-center/src/core/appCenterControllerState.ts
@@ -89,6 +89,9 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
     workspaceId: string,
     snapshot: WorkspaceAppFactorySnapshot
   ): void {
+    // Any authoritative factory snapshot supersedes reads that started before
+    // it, including the factory half of an in-flight full refresh.
+    this.factoryLoadSequence += 1;
     this.clearOperationCursorsOnWorkspaceChange(workspaceId);
     if (this.store.workspaceId !== workspaceId) {
       this.store.workspaceId = workspaceId;


### PR DESCRIPTION
## Summary

- fence in-flight factory list reads whenever an authoritative factory snapshot is applied
- treat `agentTargetId` changes as meaningful factory-job state changes
- add regression coverage for stale initial reads and target-only updates
- add a patch changeset for `@tutti-os/workspace-app-center`

## Root cause

The shared controller sequenced only list requests against other list requests. A newer host-pushed snapshot did not advance that sequence, so an older initial GET could complete later and replace the authoritative snapshot with an empty result. Factory-job equality also omitted `agentTargetId`, which could suppress a navigation-target update.

## Validation

- `pnpm --filter @tutti-os/workspace-app-center test` — 117 passed
- `pnpm --filter @tutti-os/workspace-app-center typecheck` — passed
- `pnpm check:changed` — 8 lanes passed after rebase
- pre-push `pnpm check:changed -- --push-ready` — 9 lanes passed

## Compatibility and rollback

No public API or persisted-data shape changes. The changeset is patch-level. Rollback is a single commit revert; consumers that retain their own host-side stale-read fence remain safe during a staggered rollout.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->