### PR TITLE
fix(agent-gui): avoid synchronous composer measurement

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -378,6 +378,13 @@ A controller may compose flows but cannot become a second lifecycle state machin
 
 Activation and existing-Session submit share a canonical prompt envelope. Submit eligibility includes text and renderable structured content; an individual composer does not redefine it.
 
+Composer text transactions may publish the current draft, but the draft value
+must not drive synchronous pre-paint geometry reads. The dock observes the
+actual editor, input area, and attachment containers; its initial and
+subsequent `ResizeObserver` deliveries own height measurement after layout.
+Viewport resizing is covered by those element observations and must not add a
+duplicate global resize measurement source.
+
 External OS file paste and drop enter one host-injected classification boundary before draft attachment creation. The synchronous `resolveExternalPromptEntries` port classifies each source index as a live `WorkspaceFileReference` or a snapshot requiring preparation. AgentGUI owns ordered mention insertion and draft reconciliation: references become ordinary file/folder mentions and never consume prompt-asset slots, while only `prepare` entries create pending attachment state and enter `prepareExternalPromptFiles`. A host without the resolver prepares every external entry. The preparer owns native-path or byte lookup, size enforcement, persistence, and remote transport; each prepared input has one `sourceIndex` result, one failure must not fail siblings, successful results include a provider-readable `path` or `url`, and failures carry typed error codes. Hosts that classify path-backed entries as references must reject any such entry that unexpectedly reaches preparation, so classification failure cannot silently create a duplicate snapshot.
 
 Workspace picker results and internal workspace-reference drags remain live references. They enter the rich-text document as mentions and never pass through external-file preparation. Removing an inline external-file mention removes its draft intent; a later async result must not revive it or lose its error reason when the draft is in another scope.

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -108,9 +108,9 @@ declaration when static symbol matching succeeds. Those links identify source
 ownership, not a runtime call stack or proof of causation.
 
 The capture runner ships `provider-switch`, `session-switch`,
-`provider-session-cycle`, `virtualized-streaming`, `rail-scope-reveal`,
-`virtualized-scroll-locator`, `composer-overflow-resize`,
-`workbench-window-lifecycle`, and
+`provider-session-cycle`, `virtualized-streaming`,
+`virtualized-scroll-locator`, `rail-scope-reveal`, `composer-input`,
+`composer-overflow-resize`, `workbench-window-lifecycle`, and
 `desktop-window-state`. List them with `--list-scenarios`; select one with
 `--scenario <id>`. Scenario modules own preparation, completion conditions,
 semantic assertions, milestones, and metadata; runtime startup, trace capture,
@@ -139,6 +139,10 @@ Neither scenario launches or sends input to a developer's installed Agent provid
 renderer viewport, asserts the hero prompt-tip's native `scrollWidth` and
 `clientWidth` getters were read after resize, then restores the original
 viewport metrics.
+`composer-input` restores a settled Session so the dock composer is active,
+injects text one character at a time, drives a real CDP IME composition
+lifecycle, then opens the `@` panel and verifies ArrowDown, Tab, and Escape
+navigation without submitting the draft.
 
 `workbench-window-lifecycle` measures the internal AgentGUI Workbench node's
 minimize, restore, maximize, unmaximize, close, and reopen mechanics.

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -543,7 +543,6 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   const layout = useComposerLayout({
     isHeroLayout,
     inputDisabled,
-    paletteDraftPrompt,
     showFileMentionPalette,
     showFloatingCommandMenu,
     previewMode,

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.spec.tsx
@@ -32,52 +32,14 @@ describe("useComposerLayout", () => {
     const setIsPromptTipOverflowing = vi.fn();
 
     renderHook(() =>
-      useComposerLayout({
-        isHeroLayout: true,
-        inputDisabled: false,
-        paletteDraftPrompt: "",
-        showFileMentionPalette: false,
-        showFloatingCommandMenu: false,
-        previewMode: false,
-        promptTips: [{ id: "tip-1", label: "Label", prompt: "Prompt" }],
-        promptTipsPrefix: "Tip: ",
-        composerSettings: {
-          sessionSettings: null,
-          draftSettings: {
-            model: null,
-            reasoningEffort: null,
-            speed: null,
-            planMode: false
-          },
-          supportsModel: false,
-          supportsReasoningEffort: false,
-          supportsSpeed: false,
-          supportsPlanMode: false,
-          isSettingsLoading: false,
-          modelUnavailable: false,
-          reasoningUnavailable: false,
-          speedUnavailable: false,
-          availableModels: [],
-          availableReasoningEfforts: [],
-          availableSpeeds: [],
-          projectLocked: false,
-          projectPathIsRemote: false
-        },
-        selectedProjectPath: "",
-        promptTipRef: { current: promptTip },
-        promptInputAreaRef: { current: null },
-        setIsPromptTipOverflowing,
-        dockComposerInputHeight: 56,
-        setDockComposerInputHeight: vi.fn(),
-        dockComposerInputMaxHeight: 110,
-        setDockComposerInputMaxHeight: vi.fn(),
-        dockComposerAttachmentHeight: 0,
-        setDockComposerAttachmentHeight: vi.fn(),
-        dockComposerTextHeight: 56,
-        setDockComposerTextHeight: vi.fn(),
-        draftImages: [],
-        draftLargeTexts: []
-      })
+      useComposerLayout(
+        createComposerLayoutInput({
+          isHeroLayout: true,
+          promptTips: [{ id: "tip-1", label: "Label", prompt: "Prompt" }],
+          promptTipRef: { current: promptTip },
+          setIsPromptTipOverflowing
+        })
+      )
     );
 
     expect(scrollWidth).not.toHaveBeenCalled();
@@ -92,4 +54,156 @@ describe("useComposerLayout", () => {
     expect(clientWidth).toHaveBeenCalledTimes(1);
     expect(setIsPromptTipOverflowing).toHaveBeenLastCalledWith(true);
   });
+
+  it("measures dock content only after ResizeObserver delivers layout", () => {
+    const resizeObservers: ResizeObserverMock[] = [];
+    class ResizeObserverMock implements ResizeObserver {
+      readonly observed = new Set<Element>();
+
+      constructor(readonly callback: ResizeObserverCallback) {
+        resizeObservers.push(this);
+      }
+
+      observe(target: Element): void {
+        this.observed.add(target);
+      }
+
+      unobserve(target: Element): void {
+        this.observed.delete(target);
+      }
+
+      disconnect(): void {
+        this.observed.clear();
+      }
+    }
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    const inputArea = document.createElement("div");
+    const editor = document.createElement("div");
+    editor.className = "agent-gui-node__composer-textarea";
+    inputArea.appendChild(editor);
+    const editorScrollHeight = vi
+      .spyOn(editor, "scrollHeight", "get")
+      .mockReturnValue(48);
+    const inputAreaScrollHeight = vi
+      .spyOn(inputArea, "scrollHeight", "get")
+      .mockReturnValue(74);
+    const setDockComposerInputHeight = vi.fn();
+    const setDockComposerInputMaxHeight = vi.fn();
+    const setDockComposerAttachmentHeight = vi.fn();
+    const setDockComposerTextHeight = vi.fn();
+
+    const input = createComposerLayoutInput({
+      promptInputAreaRef: { current: inputArea },
+      setDockComposerInputHeight,
+      setDockComposerInputMaxHeight,
+      setDockComposerAttachmentHeight,
+      setDockComposerTextHeight
+    });
+
+    const rendered = renderHook(
+      ({ paletteOpen }) =>
+        useComposerLayout({
+          ...input,
+          showFileMentionPalette: paletteOpen
+        }),
+      { initialProps: { paletteOpen: false } }
+    );
+
+    expect(editorScrollHeight).not.toHaveBeenCalled();
+    expect(inputAreaScrollHeight).not.toHaveBeenCalled();
+    expect(resizeObservers).toHaveLength(1);
+    expect(resizeObservers[0]?.observed).toEqual(new Set([inputArea, editor]));
+
+    act(() => {
+      resizeObservers[0]?.callback([], resizeObservers[0]);
+    });
+
+    expect(editorScrollHeight).toHaveBeenCalledTimes(1);
+    expect(inputAreaScrollHeight).toHaveBeenCalledTimes(1);
+    expect(applyLastNumericStateUpdate(setDockComposerInputHeight, 56)).toBe(
+      76
+    );
+    expect(
+      applyLastNumericStateUpdate(setDockComposerInputMaxHeight, 110)
+    ).toBe(110);
+    expect(
+      applyLastNumericStateUpdate(setDockComposerAttachmentHeight, 0)
+    ).toBe(0);
+    expect(applyLastNumericStateUpdate(setDockComposerTextHeight, 56)).toBe(62);
+
+    editorScrollHeight.mockClear();
+    inputAreaScrollHeight.mockClear();
+    rendered.rerender({ paletteOpen: true });
+
+    expect(editorScrollHeight).not.toHaveBeenCalled();
+    expect(inputAreaScrollHeight).not.toHaveBeenCalled();
+    expect(resizeObservers).toHaveLength(1);
+  });
 });
+
+function applyLastNumericStateUpdate(
+  setter: ReturnType<typeof vi.fn>,
+  value: number
+) {
+  const update = setter.mock.calls.at(-1)?.[0] as
+    | number
+    | ((current: number) => number)
+    | undefined;
+  if (typeof update === "function") {
+    return update(value);
+  }
+  return update;
+}
+
+type ComposerLayoutInput = Parameters<typeof useComposerLayout>[0];
+
+function createComposerLayoutInput(
+  overrides: Partial<ComposerLayoutInput>
+): ComposerLayoutInput {
+  return {
+    isHeroLayout: false,
+    inputDisabled: false,
+    showFileMentionPalette: false,
+    showFloatingCommandMenu: false,
+    previewMode: false,
+    promptTips: [],
+    promptTipsPrefix: "Tip: ",
+    composerSettings: {
+      sessionSettings: null,
+      draftSettings: {
+        model: null,
+        reasoningEffort: null,
+        speed: null,
+        planMode: false
+      },
+      supportsModel: false,
+      supportsReasoningEffort: false,
+      supportsSpeed: false,
+      supportsPlanMode: false,
+      isSettingsLoading: false,
+      modelUnavailable: false,
+      reasoningUnavailable: false,
+      speedUnavailable: false,
+      availableModels: [],
+      availableReasoningEfforts: [],
+      availableSpeeds: [],
+      projectLocked: false,
+      projectPathIsRemote: false
+    },
+    selectedProjectPath: "",
+    promptTipRef: { current: null },
+    promptInputAreaRef: { current: null },
+    setIsPromptTipOverflowing: vi.fn(),
+    dockComposerInputHeight: 56,
+    setDockComposerInputHeight: vi.fn(),
+    dockComposerInputMaxHeight: 110,
+    setDockComposerInputMaxHeight: vi.fn(),
+    dockComposerAttachmentHeight: 0,
+    setDockComposerAttachmentHeight: vi.fn(),
+    dockComposerTextHeight: 56,
+    setDockComposerTextHeight: vi.fn(),
+    draftImages: [],
+    draftLargeTexts: [],
+    ...overrides
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.ts
@@ -37,7 +37,6 @@ function hasInlineOverflow(element: HTMLElement | null): boolean {
 interface UseComposerLayoutInput {
   isHeroLayout: boolean;
   inputDisabled: boolean;
-  paletteDraftPrompt: string;
   showFileMentionPalette: boolean;
   showFloatingCommandMenu: boolean;
   previewMode: boolean;
@@ -63,7 +62,6 @@ interface UseComposerLayoutInput {
 export function useComposerLayout({
   isHeroLayout,
   inputDisabled,
-  paletteDraftPrompt,
   showFileMentionPalette,
   showFloatingCommandMenu,
   previewMode,
@@ -267,27 +265,23 @@ export function useComposerLayout({
       );
     };
 
-    measure();
     const resizeObserver =
       typeof ResizeObserver === "undefined"
         ? null
         : new ResizeObserver(measure);
     resizeObserver?.observe(inputArea);
     resizeObserver?.observe(editor);
-    for (const child of Array.from(inputArea.querySelectorAll("*"))) {
-      resizeObserver?.observe(child);
+    for (const attachmentArea of Array.from(
+      inputArea.querySelectorAll(
+        '[data-testid="agent-gui-composer-image-drafts"], [data-testid="agent-gui-composer-file-drafts"]'
+      )
+    )) {
+      resizeObserver?.observe(attachmentArea);
     }
-    window.addEventListener("resize", measure);
     return () => {
       resizeObserver?.disconnect();
-      window.removeEventListener("resize", measure);
     };
-  }, [
-    draftImages.length,
-    draftLargeTexts.length,
-    isHeroLayout,
-    paletteDraftPrompt
-  ]);
+  }, [draftImages.length, draftLargeTexts.length, isHeroLayout]);
   const composerStyle = useMemo<CSSProperties | undefined>(
     () =>
       isHeroLayout

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -81,6 +81,7 @@ pnpm perf:agent-gui
 pnpm perf:agent-gui -- --list-scenarios
 pnpm perf:agent-gui -- --scenario session-switch
 pnpm perf:agent-gui -- --scenario virtualized-streaming
+pnpm perf:agent-gui -- --scenario composer-input
 ```
 
 The command reads `~/.tutti-dev/tuttid.db` by default and uses SQLite online
@@ -100,11 +101,13 @@ Outputs are stored under
 only infrastructure, scenario, trace, or analysis failures return a non-zero
 exit code. Available scenarios also cover deterministic streaming into an
 already virtualized transcript, fresh-scope Rail reveal, hero composer
-prompt-tip layout measurement during resize, internal Workbench window lifecycle, and
-native Electron window state changes. The streaming scenario rewrites only the
-isolated snapshot and shadows `cursor-agent` only inside the isolated Desktop
-process, so it cannot send input to an installed Agent provider. The native
-window scenarios are currently macOS-only. Use `--source-db`,
+prompt-tip layout measurement during resize, per-character composer input,
+IME composition, `@` panel keyboard navigation in a restored dock composer,
+internal Workbench window lifecycle, and native Electron window state changes.
+The streaming scenario rewrites only the isolated snapshot and shadows
+`cursor-agent` only inside the isolated Desktop process, so it cannot send input
+to an installed Agent provider. The native window scenarios are currently
+macOS-only. Use `--source-db`,
 `--from-target-id`, or `--to-target-id` to override the defaults.
 
 The Markdown report contains scenario assertions, observed milestone phases,

--- a/tools/scripts/agent-gui-composer-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-composer-performance-scenarios.mjs
@@ -1,0 +1,389 @@
+import {
+  requiredScenarioData,
+  scenarioSummary as summary,
+  sqlString,
+  startupWorkspaceID,
+  updateAgentGUISnapshot
+} from "./agent-gui-performance-snapshot-helpers.mjs";
+import {
+  evaluate,
+  finishRendererScenario,
+  markRenderer,
+  startRendererScenario,
+  waitForEvaluation
+} from "./agent-gui-performance-helpers.mjs";
+
+const editorSelector =
+  '#agent-gui-detail [contenteditable="true"][role="textbox"]';
+const paletteSelector = '[data-testid="agent-gui-mention-palette-surface"]';
+const ordinaryText =
+  "Measure AgentGUI composer input one character at a time. ";
+const imeCandidates = ["x", "xing", "性能"];
+const imeCommittedText = "性能";
+
+const composerInputMarkers = {
+  start: "tutti-perf:composer-input:start",
+  textEntered: "tutti-perf:composer-input:text-entered-observed",
+  imeComposing: "tutti-perf:composer-input:ime-composing-observed",
+  imeCommitted: "tutti-perf:composer-input:ime-committed-observed",
+  mentionOpened: "tutti-perf:composer-input:mention-opened-observed",
+  mentionNavigated: "tutti-perf:composer-input:mention-navigated-observed",
+  mentionClosed: "tutti-perf:composer-input:mention-closed-observed",
+  end: "tutti-perf:composer-input:end"
+};
+
+export const composerInputScenario = {
+  id: "composer-input",
+  markers: composerInputMarkers,
+  milestones: [
+    {
+      key: "textEntered",
+      label: "per-character text entered",
+      marker: composerInputMarkers.textEntered
+    },
+    {
+      key: "imeComposing",
+      label: "IME composition updated",
+      marker: composerInputMarkers.imeComposing
+    },
+    {
+      key: "imeCommitted",
+      label: "IME composition committed",
+      marker: composerInputMarkers.imeCommitted
+    },
+    {
+      key: "mentionOpened",
+      label: "@ mention panel opened",
+      marker: composerInputMarkers.mentionOpened
+    },
+    {
+      key: "mentionNavigated",
+      label: "mention highlight and category changed",
+      marker: composerInputMarkers.mentionNavigated
+    },
+    {
+      key: "mentionClosed",
+      label: "mention panel closed",
+      marker: composerInputMarkers.mentionClosed
+    }
+  ],
+  prepareSnapshot: prepareComposerInputSnapshot,
+  prepare: prepareComposerInput,
+  execute: executeComposerInput,
+  describe(prepared) {
+    return `${prepared.sessionID}; ${Array.from(ordinaryText).length} text inserts + ${imeCandidates.length} IME updates + @ keyboard navigation`;
+  },
+  summarize(prepared, result) {
+    return summary(
+      [
+        { name: "dock composer active", passed: prepared.dockComposer },
+        {
+          name: "per-character text input observed",
+          passed: result.inputEvents >= Array.from(ordinaryText).length
+        },
+        {
+          name: "IME composition lifecycle observed",
+          passed:
+            result.compositionStarts > 0 &&
+            result.compositionUpdates >= imeCandidates.length &&
+            result.compositionEnds > 0
+        },
+        { name: "IME text committed once", passed: result.imeCommitted },
+        { name: "@ mention panel opened", passed: result.mentionOpened },
+        {
+          name: "mention selection moved",
+          passed: result.highlightChanged
+        },
+        { name: "mention category cycled", passed: result.categoryChanged },
+        {
+          name: "mention keyboard events observed",
+          passed: result.mentionKeys.join(",") === "ArrowDown,Tab,Escape"
+        },
+        { name: "mention panel closed", passed: result.mentionClosed }
+      ],
+      [
+        { label: "Session", value: prepared.sessionID },
+        {
+          label: "Text inserts",
+          value: String(Array.from(ordinaryText).length)
+        },
+        { label: "Input events", value: String(result.inputEvents) },
+        {
+          label: "IME events",
+          value: `${result.compositionStarts} start / ${result.compositionUpdates} update / ${result.compositionEnds} end`
+        },
+        {
+          label: "Mention keys",
+          value: result.mentionKeys.join(" -> ")
+        }
+      ],
+      "CDP injects each text character separately, drives one real IME composition lifecycle, then opens the @ panel and verifies ArrowDown, Tab, and Escape through DOM state and captured keyboard events"
+    );
+  }
+};
+
+async function prepareComposerInputSnapshot(context) {
+  const workspaceID = await startupWorkspaceID(context);
+  const candidates = await context.sqliteJSON(
+    context.databasePath,
+    `
+SELECT s.agent_session_id AS sessionID,
+       s.agent_target_id AS targetID
+FROM workspace_agent_sessions s
+JOIN agent_targets t ON t.id = s.agent_target_id
+WHERE s.workspace_id = '${sqlString(workspaceID)}'
+  AND s.deleted_at_unix_ms = 0
+  AND s.session_kind = 'root'
+  AND s.active_turn_id IS NULL
+  AND t.enabled = 1
+ORDER BY s.updated_at_unix_ms DESC, s.agent_session_id ASC
+LIMIT 1;
+`
+  );
+  const candidate = candidates[0];
+  if (!candidate?.sessionID || !candidate.targetID) {
+    throw new Error(
+      "composer-input requires one settled root session for an enabled Agent target"
+    );
+  }
+  await updateAgentGUISnapshot(context, (state) => ({
+    ...state,
+    agentTargetId: candidate.targetID,
+    conversationRailCollapsed: false,
+    lastActiveAgentSessionId: candidate.sessionID,
+    lastActiveAgentSessionIdByAgentTargetId: {
+      ...(state.lastActiveAgentSessionIdByAgentTargetId ?? {}),
+      [candidate.targetID]: candidate.sessionID
+    }
+  }));
+  return {
+    data: {
+      sessionID: candidate.sessionID,
+      targetID: candidate.targetID,
+      workspaceID
+    }
+  };
+}
+
+async function prepareComposerInput(context, options) {
+  const fixture = requiredScenarioData(context, "composer-input");
+  const ready = await waitForEvaluation(
+    context.pageClient,
+    `(() => {
+      const editor = document.querySelector(${JSON.stringify(editorSelector)});
+      const activeSession = document.querySelector(${JSON.stringify(`[data-testid="agent-gui-conversation-item-${fixture.sessionID}"]`)});
+      const dockComposer = Boolean(editor?.closest('.agent-gui-node__composer-prompt-input-area'));
+      return {
+        ready: editor instanceof HTMLElement && editor.getAttribute('contenteditable') === 'true' && activeSession?.dataset.active === 'true' && dockComposer,
+        dockComposer,
+        editorReady: editor instanceof HTMLElement
+      };
+    })()`,
+    options.timeoutMs,
+    "enabled AgentGUI composer editor"
+  );
+  await evaluate(
+    context.pageClient,
+    `(() => {
+      const editor = document.querySelector(${JSON.stringify(editorSelector)});
+      if (!(editor instanceof HTMLElement)) throw new Error('composer editor is unavailable');
+      editor.focus();
+      document.execCommand('selectAll', false);
+      document.execCommand('delete', false);
+      return true;
+    })()`
+  );
+  await waitForEditorText(context.pageClient, "", options.timeoutMs);
+  return {
+    dockComposer: ready.dockComposer,
+    editorReady: ready.editorReady,
+    sessionID: fixture.sessionID,
+    targetID: fixture.targetID
+  };
+}
+
+async function executeComposerInput(context, _prepared, options) {
+  const { pageClient } = context;
+  await installComposerInputCounters(pageClient);
+  await startRendererScenario(pageClient, composerInputMarkers.start);
+
+  for (const character of Array.from(ordinaryText)) {
+    await pageClient.send("Input.insertText", { text: character });
+  }
+  await waitForEditorText(pageClient, ordinaryText, options.timeoutMs);
+  await markRenderer(pageClient, composerInputMarkers.textEntered);
+
+  for (const candidate of imeCandidates) {
+    await pageClient.send("Input.imeSetComposition", {
+      text: candidate,
+      selectionStart: candidate.length,
+      selectionEnd: candidate.length
+    });
+  }
+  await waitForEditorText(
+    pageClient,
+    `${ordinaryText}${imeCommittedText}`,
+    options.timeoutMs
+  );
+  await markRenderer(pageClient, composerInputMarkers.imeComposing);
+  await pageClient.send("Input.insertText", { text: imeCommittedText });
+  const committed = await waitForEditorText(
+    pageClient,
+    `${ordinaryText}${imeCommittedText}`,
+    options.timeoutMs
+  );
+  await markRenderer(pageClient, composerInputMarkers.imeCommitted);
+
+  await pageClient.send("Input.insertText", { text: " @" });
+  const opened = await waitForMentionState(
+    pageClient,
+    "Boolean(palette)",
+    options.timeoutMs,
+    "open @ mention panel"
+  );
+  await markRenderer(pageClient, composerInputMarkers.mentionOpened);
+
+  const initialHighlight = opened.highlightedIndex;
+  const initialCategory = opened.activeCategoryIndex;
+  await dispatchKey(pageClient, "ArrowDown", "ArrowDown", 40);
+  const highlighted = await waitForMentionState(
+    pageClient,
+    `Boolean(palette) && highlightedIndex !== ${JSON.stringify(initialHighlight)}`,
+    options.timeoutMs,
+    "changed mention highlight"
+  );
+  await dispatchKey(pageClient, "Tab", "Tab", 9);
+  const navigated = await waitForMentionState(
+    pageClient,
+    `Boolean(palette) && activeCategoryIndex !== ${JSON.stringify(initialCategory)}`,
+    options.timeoutMs,
+    "changed mention category"
+  );
+  await markRenderer(pageClient, composerInputMarkers.mentionNavigated);
+
+  await dispatchKey(pageClient, "Escape", "Escape", 27);
+  const closed = await waitForMentionState(
+    pageClient,
+    "!palette",
+    options.timeoutMs,
+    "closed mention panel"
+  );
+  await markRenderer(pageClient, composerInputMarkers.mentionClosed);
+  const counters = await readAndRemoveComposerInputCounters(pageClient);
+  await finishRendererScenario(pageClient, composerInputMarkers.end);
+
+  return {
+    ...counters,
+    categoryChanged: navigated.activeCategoryIndex !== initialCategory,
+    highlightChanged: highlighted.highlightedIndex !== initialHighlight,
+    imeCommitted:
+      committed.text === `${ordinaryText}${imeCommittedText}` &&
+      countOccurrences(committed.text, imeCommittedText) === 1,
+    mentionClosed: closed.palettePresent === false,
+    mentionOpened: opened.palettePresent === true
+  };
+}
+
+async function installComposerInputCounters(client) {
+  await evaluate(
+    client,
+    `(() => {
+      const editor = document.querySelector(${JSON.stringify(editorSelector)});
+      if (!(editor instanceof HTMLElement)) throw new Error('composer editor is unavailable');
+      const state = {
+        compositionStarts: 0,
+        compositionUpdates: 0,
+        compositionEnds: 0,
+        inputEvents: 0,
+        mentionKeys: []
+      };
+      const handlers = {
+        compositionstart: () => { state.compositionStarts += 1; },
+        compositionupdate: () => { state.compositionUpdates += 1; },
+        compositionend: () => { state.compositionEnds += 1; },
+        input: () => { state.inputEvents += 1; }
+      };
+      for (const [type, handler] of Object.entries(handlers)) editor.addEventListener(type, handler, true);
+      const keydown = (event) => {
+        if (event.target === editor && ['ArrowDown', 'Tab', 'Escape'].includes(event.key)) state.mentionKeys.push(event.key);
+      };
+      document.addEventListener('keydown', keydown, true);
+      window.__tuttiPerfComposerInput = { editor, handlers, keydown, state };
+      editor.focus();
+      return true;
+    })()`
+  );
+}
+
+async function readAndRemoveComposerInputCounters(client) {
+  return evaluate(
+    client,
+    `(() => {
+      const owner = window.__tuttiPerfComposerInput;
+      if (!owner) throw new Error('composer input counters are unavailable');
+      for (const [type, handler] of Object.entries(owner.handlers)) owner.editor.removeEventListener(type, handler, true);
+      document.removeEventListener('keydown', owner.keydown, true);
+      delete window.__tuttiPerfComposerInput;
+      return owner.state;
+    })()`
+  );
+}
+
+async function waitForEditorText(client, expected, timeoutMs) {
+  return waitForEvaluation(
+    client,
+    `(() => {
+      const editor = document.querySelector(${JSON.stringify(editorSelector)});
+      const text = editor?.textContent ?? '';
+      return { ready: text === ${JSON.stringify(expected)}, text };
+    })()`,
+    timeoutMs,
+    `composer text ${JSON.stringify(expected)}`,
+    25
+  );
+}
+
+async function waitForMentionState(client, predicate, timeoutMs, label) {
+  return waitForEvaluation(
+    client,
+    `(() => {
+      const palette = document.querySelector(${JSON.stringify(paletteSelector)});
+      const highlighted = palette?.querySelector('[data-highlighted]') ?? null;
+      const highlightable = palette ? [...palette.querySelectorAll('[role="option"], button[data-highlighted]')] : [];
+      const activeCategory = palette?.querySelector('[role="tab"][aria-selected="true"]') ?? null;
+      const categories = palette ? [...palette.querySelectorAll('[role="tab"]')] : [];
+      const activeCategoryIndex = activeCategory ? categories.indexOf(activeCategory) : -1;
+      const highlightedIndex = highlighted ? highlightable.indexOf(highlighted) : -1;
+      return {
+        ready: ${predicate},
+        activeCategoryIndex,
+        highlightedIndex,
+        palettePresent: Boolean(palette)
+      };
+    })()`,
+    timeoutMs,
+    label,
+    25
+  );
+}
+
+async function dispatchKey(client, key, code, virtualKeyCode) {
+  await client.send("Input.dispatchKeyEvent", {
+    type: "rawKeyDown",
+    key,
+    code,
+    windowsVirtualKeyCode: virtualKeyCode,
+    nativeVirtualKeyCode: virtualKeyCode
+  });
+  await client.send("Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key,
+    code,
+    windowsVirtualKeyCode: virtualKeyCode,
+    nativeVirtualKeyCode: virtualKeyCode
+  });
+}
+
+function countOccurrences(value, needle) {
+  return value.split(needle).length - 1;
+}

--- a/tools/scripts/agent-gui-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-performance-scenarios.mjs
@@ -12,6 +12,7 @@ import {
   railScopeRevealScenario,
   virtualizedStreamingScenario
 } from "./agent-gui-layout-performance-scenarios.mjs";
+import { composerInputScenario } from "./agent-gui-composer-performance-scenarios.mjs";
 import { virtualizedScrollLocatorScenario } from "./agent-gui-scroll-performance-scenario.mjs";
 
 export const agentGuiPerformanceScenarios = [
@@ -21,6 +22,7 @@ export const agentGuiPerformanceScenarios = [
   virtualizedStreamingScenario,
   virtualizedScrollLocatorScenario,
   railScopeRevealScenario,
+  composerInputScenario,
   composerOverflowResizeScenario,
   workbenchWindowLifecycleScenario,
   desktopWindowStateScenario

--- a/tools/scripts/run-agent-gui-performance.test.mjs
+++ b/tools/scripts/run-agent-gui-performance.test.mjs
@@ -9,6 +9,7 @@ import {
   agentGuiPerformanceScenarios,
   resolveAgentGuiPerformanceScenario
 } from "./agent-gui-performance-scenarios.mjs";
+import { composerInputScenario } from "./agent-gui-composer-performance-scenarios.mjs";
 import {
   applyScenarioAssessment,
   findUnknownAgentTargetMigrationIDs,
@@ -165,6 +166,7 @@ test("performance scenario registry exposes renderer and window scenarios", () =
       "virtualized-streaming",
       "virtualized-scroll-locator",
       "rail-scope-reveal",
+      "composer-input",
       "composer-overflow-resize",
       "workbench-window-lifecycle",
       "desktop-window-state"
@@ -177,5 +179,39 @@ test("performance scenario registry exposes renderer and window scenarios", () =
   assert.throws(
     () => resolveAgentGuiPerformanceScenario("missing"),
     /unknown scenario: missing/
+  );
+});
+
+test("composer input summary requires text, IME, and mention keyboard semantics", () => {
+  const report = composerInputScenario.summarize(
+    { dockComposer: true, editorReady: true, sessionID: "session-1" },
+    {
+      categoryChanged: true,
+      compositionEnds: 1,
+      compositionStarts: 1,
+      compositionUpdates: 3,
+      highlightChanged: true,
+      imeCommitted: true,
+      inputEvents: 58,
+      mentionClosed: true,
+      mentionKeys: ["ArrowDown", "Tab", "Escape"],
+      mentionOpened: true
+    }
+  );
+
+  assert.equal(report.outcome, "passed");
+  assert.deepEqual(
+    report.assertions.map((assertion) => assertion.name),
+    [
+      "dock composer active",
+      "per-character text input observed",
+      "IME composition lifecycle observed",
+      "IME text committed once",
+      "@ mention panel opened",
+      "mention selection moved",
+      "mention category cycled",
+      "mention keyboard events observed",
+      "mention panel closed"
+    ]
   );
 });


### PR DESCRIPTION
## Summary

- stop draft text transactions from synchronously measuring dock-composer geometry and recreating its `ResizeObserver`
- observe the editor, input area, and attachment containers so initial and subsequent size changes retain the existing dock-height behavior
- add a dock-composer performance scenario covering per-character input, IME composition, and `@` panel keyboard navigation

## Performance

Single-run A/B on the same isolated DB snapshot and Session using:

```text
pnpm perf:agent-gui -- --scenario composer-input
```

Baseline used the pre-fix composer layout implementation from `2e75cc9af`; fixed used `a37343cea`. In the marker-bounded 57-input window:

- duration: 582.09 ms -> 499.30 ms (-14.2%)
- Layout events: 208 -> 61 (-70.7%)
- Layout inclusive time: 72.79 ms -> 46.71 ms (-35.8%)
- UpdateLayoutTree events: 244 -> 92 (-62.3%)
- AgentComposer markers: 68 -> 9 (-86.8%)
- long tasks: 4 -> 2

## Tests

- `pnpm check:changed -- --push-ready` (12 lanes passed)
- `pnpm push:checked` (`check:full`: 22 tasks passed)
- `pnpm perf:agent-gui -- --scenario composer-input` (9 semantic assertions passed for both baseline and fixed runs)

## Notes

- benchmark values are one run per variant, not a statistical latency distribution
- maximum individual long-task duration did not improve in the single input-window sample, so this PR does not claim tail-latency improvement
- no debounce, throttle, event dropping, or input/IME/mention timing changes are introduced

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->