### PR TITLE
fix(agent-gui): suppress empty handoff tooltip

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentHandoffMenu.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentHandoffMenu.spec.tsx
@@ -30,6 +30,22 @@ describe("AgentHandoffMenu", () => {
     );
   });
 
+  it("does not create an empty tooltip when its tooltip label is blank", async () => {
+    render(
+      <AgentHandoffMenu
+        labels={{ ...labels, tooltip: "   " }}
+        targets={targets}
+        onSelect={vi.fn()}
+      />
+    );
+
+    const trigger = screen.getByRole("combobox", { name: "Handoff" });
+    fireEvent.pointerMove(trigger.parentElement!, { pointerType: "mouse" });
+
+    await new Promise((resolve) => setTimeout(resolve, 160));
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
   it("renders self and shared ownership and selects the exact target", async () => {
     const onSelect = vi.fn();
     render(

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentHandoffMenu.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentHandoffMenu.tsx
@@ -61,6 +61,67 @@ export function AgentHandoffMenu({
 }: AgentHandoffMenuProps): JSX.Element {
   const [isIconPlaying, setIsIconPlaying] = useState(false);
   const menuDisabled = disabled || targets.length === 0;
+  const tooltip = labels.tooltip.trim();
+
+  const trigger = (
+    <span className="inline-flex">
+      <SelectTrigger
+        size="sm"
+        aria-label={labels.action}
+        data-testid={testId}
+        onClick={
+          isolateTriggerEvents
+            ? (event) => {
+                event.stopPropagation();
+              }
+            : undefined
+        }
+        onKeyDown={
+          isolateTriggerEvents
+            ? (event) => {
+                event.stopPropagation();
+              }
+            : undefined
+        }
+        onPointerDown={
+          isolateTriggerEvents
+            ? (event) => {
+                event.stopPropagation();
+              }
+            : undefined
+        }
+        onBlur={() => {
+          setIsIconPlaying(false);
+        }}
+        onFocus={() => {
+          setIsIconPlaying(true);
+        }}
+        onMouseEnter={() => {
+          setIsIconPlaying(true);
+        }}
+        onMouseLeave={() => {
+          setIsIconPlaying(false);
+        }}
+        className={cn(
+          styles.composerMenuTrigger,
+          styles.composerProviderSelect,
+          styles.composerHandoffTrigger,
+          "w-auto max-w-[180px] [&>svg:last-child]:hidden",
+          triggerClassName
+        )}
+      >
+        <span className="flex min-w-0 items-center gap-1.5">
+          <AgentComposerHandoffIcon
+            disabled={menuDisabled}
+            isPlaying={isIconPlaying}
+          />
+          {!iconOnly ? (
+            <span className="min-w-0 truncate">{triggerLabel}</span>
+          ) : null}
+        </span>
+      </SelectTrigger>
+    </span>
+  );
 
   return (
     <span
@@ -100,70 +161,16 @@ export function AgentHandoffMenu({
           onSelect(target);
         }}
       >
-        <TooltipProvider delayDuration={120}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex">
-                <SelectTrigger
-                  size="sm"
-                  aria-label={labels.action}
-                  data-testid={testId}
-                  onClick={
-                    isolateTriggerEvents
-                      ? (event) => {
-                          event.stopPropagation();
-                        }
-                      : undefined
-                  }
-                  onKeyDown={
-                    isolateTriggerEvents
-                      ? (event) => {
-                          event.stopPropagation();
-                        }
-                      : undefined
-                  }
-                  onPointerDown={
-                    isolateTriggerEvents
-                      ? (event) => {
-                          event.stopPropagation();
-                        }
-                      : undefined
-                  }
-                  onBlur={() => {
-                    setIsIconPlaying(false);
-                  }}
-                  onFocus={() => {
-                    setIsIconPlaying(true);
-                  }}
-                  onMouseEnter={() => {
-                    setIsIconPlaying(true);
-                  }}
-                  onMouseLeave={() => {
-                    setIsIconPlaying(false);
-                  }}
-                  className={cn(
-                    styles.composerMenuTrigger,
-                    styles.composerProviderSelect,
-                    styles.composerHandoffTrigger,
-                    "w-auto max-w-[180px] [&>svg:last-child]:hidden",
-                    triggerClassName
-                  )}
-                >
-                  <span className="flex min-w-0 items-center gap-1.5">
-                    <AgentComposerHandoffIcon
-                      disabled={menuDisabled}
-                      isPlaying={isIconPlaying}
-                    />
-                    {!iconOnly ? (
-                      <span className="min-w-0 truncate">{triggerLabel}</span>
-                    ) : null}
-                  </span>
-                </SelectTrigger>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="top">{labels.tooltip}</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        {tooltip ? (
+          <TooltipProvider delayDuration={120}>
+            <Tooltip>
+              <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+              <TooltipContent side="top">{tooltip}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          trigger
+        )}
         <SelectContent
           align={align}
           className={cn(

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.composition.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.composition.spec.ts
@@ -25,7 +25,10 @@ describe("ComposerFooter trigger composition", () => {
       /<TooltipTrigger asChild>\s*<span className="inline-flex">\s*<SelectTrigger/u
     );
     expect(handoffMenuSource).toMatch(
-      /<TooltipTrigger asChild>\s*<span className="inline-flex">\s*<SelectTrigger/u
+      /const trigger = \(\s*<span className="inline-flex">\s*<SelectTrigger/u
+    );
+    expect(handoffMenuSource).toContain(
+      "<TooltipTrigger asChild>{trigger}</TooltipTrigger>"
     );
   });
 
@@ -36,7 +39,10 @@ describe("ComposerFooter trigger composition", () => {
     );
     expect(handoffMenuSource).not.toContain("title={labels.tooltip}");
     expect(handoffMenuSource).toContain(
-      '<TooltipContent side="top">{labels.tooltip}</TooltipContent>'
+      "const tooltip = labels.tooltip.trim();"
+    );
+    expect(handoffMenuSource).toContain(
+      '<TooltipContent side="top">{tooltip}</TooltipContent>'
     );
   });
 


### PR DESCRIPTION
## What changed
- Skip rendering the handoff tooltip when its label is blank or whitespace-only.
- Add a regression test for hovering an empty-tooltip handoff trigger.

## Why
Host surfaces can intentionally suppress duplicate tooltip copy. Rendering an empty TooltipContent still opens a visible blank overlay.

## Risk
Presentation-only shared AgentGUI behavior. Non-empty tooltips and handoff selection behavior remain covered by the component tests.

## Verification
- pnpm exec vitest run --environment jsdom agent-gui/agentGuiNode/composer/AgentHandoffMenu.spec.tsx --reporter=verbose
- pnpm check:changed
- pre-push: pnpm check:changed -- --push-ready
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->