### PR TITLE
refactor(agent): centralize lifecycle and composer contracts

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
@@ -459,6 +459,7 @@ function createWorkspaceAgentActivityService(): IWorkspaceAgentActivityService {
       workspaceId: input.workspaceId
     }),
     deleteSessionsBatch: async () => ({
+      cleanupFailedSessionIds: [],
       removedMessages: 0,
       removedSessionIds: [],
       removedSessions: 0

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
@@ -1671,7 +1671,7 @@ function createWorkspaceAgentActivityService(
       };
     },
     async deleteSession() {
-      return { removed: true };
+      return { cleanupFailed: false, removed: true };
     },
     async renameSession(input) {
       return {
@@ -1747,6 +1747,7 @@ function createWorkspaceAgentActivityService(
     },
     async deleteSessionsBatch() {
       return {
+        cleanupFailedSessionIds: [],
         removedMessages: 0,
         removedSessionIds: [],
         removedSessions: 0

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -1575,7 +1575,7 @@ test("desktop agent activity adapter loads Claude options without mutating draft
       },
       async deleteWorkspaceAgentSession(_workspaceId, agentSessionId) {
         calls.push(`delete:${agentSessionId}`);
-        return { removed: true };
+        return { cleanupFailed: false, removed: true };
       }
     }),
     runtimeApi: createRuntimeApi()

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -371,6 +371,7 @@ export function createDesktopAgentActivityAdapter({
         { signal: input.signal }
       );
       return {
+        cleanupFailedSessionIds: response.cleanupFailedSessionIds,
         removedMessages: response.removedMessages,
         removedSessionIds: response.removedSessionIds,
         removedSessions: response.removedSessions

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -2205,6 +2205,7 @@ test("WorkspaceAgentActivityService deletes one exact session batch", async () =
       ) => {
         calls.push({ request, workspaceId });
         return {
+          cleanupFailedSessionIds: [],
           removedMessages: 3,
           removedSessionIds: ["session-1", "child-1"],
           removedSessions: 2
@@ -2232,6 +2233,7 @@ test("WorkspaceAgentActivityService deletes one exact session batch", async () =
     }
   ]);
   assert.deepEqual(result, {
+    cleanupFailedSessionIds: [],
     removedMessages: 3,
     removedSessionIds: ["session-1", "child-1"],
     removedSessions: 2
@@ -2305,6 +2307,7 @@ test("WorkspaceAgentActivityService single delete uses the authoritative batch r
       ) => {
         calls.push({ request, workspaceId });
         return {
+          cleanupFailedSessionIds: [],
           removedMessages: 2,
           removedSessionIds: ["session-1", "child-1"],
           removedSessions: 2
@@ -2325,7 +2328,7 @@ test("WorkspaceAgentActivityService single delete uses the authoritative batch r
     workspaceId: "ws-1"
   });
 
-  assert.deepEqual(result, { removed: true });
+  assert.deepEqual(result, { cleanupFailed: false, removed: true });
   assert.deepEqual(calls, [
     {
       request: { sessionIds: ["session-1"] },

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -314,6 +314,9 @@ export class WorkspaceAgentActivityService
       throw new Error("workspace_agent_delete_result_missing");
     }
     return {
+      cleanupFailedSessionIds: [
+        ...mutation.deleteResult.cleanupFailedSessionIds
+      ],
       removedMessages: mutation.deleteResult.removedMessages,
       removedSessionIds: [...mutation.deleteResult.removedSessionIds],
       removedSessions: mutation.deleteResult.removedSessions
@@ -634,7 +637,10 @@ export class WorkspaceAgentActivityService
       signal: input.signal,
       workspaceId
     });
-    return { removed: result.removedSessionIds.includes(agentSessionId) };
+    return {
+      cleanupFailed: result.cleanupFailedSessionIds.includes(agentSessionId),
+      removed: result.removedSessionIds.includes(agentSessionId)
+    };
   }
 
   async renameSession(

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -73,6 +73,15 @@ runtime mutation; provider normalization stays in an adapter policy. Pin and
 canonical delete are Host commands, while authorization, transport DTOs,
 shared bindings, and local view cleanup remain adapter-owned.
 
+Single and batch canonical delete are the same Host command shape. The store
+plans the complete descendant closure, Host quiesces that exact closure under
+the shared session-mutation lane, and the write transaction rejects a stale
+plan. Renderer-side request loops are not an atomic batch-delete
+implementation. `daemon/hostadapter` is the official daemon-runtime-to-Host
+adapter, `host.SQLiteWorkspaceStore` is the workspace-routed canonical store,
+and `daemon/modelcatalog` owns provider model/reasoning/speed normalization;
+product daemons compose these modules instead of copying their mappings.
+
 Permanent deletion is intentionally distinct from the normal canonical delete
 command. `Host.PurgeDeletedSessions` accepts a cutoff and bounded batch limits,
 while `store-sqlite` selects tombstones globally by deletion time, fences every

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -488,6 +488,7 @@ The reusable standalone-tool sidebar contract lives in `packages/agent/gui/workb
 ```text
 home composer submit
   -> engine pending activation + optimistic Session/message
+     (including the resolved immutable railSectionKey)
   -> Host CreateSession(initial content, clientSubmitId)
   -> provisional runtime + canonical transaction
   -> first Turn accepted
@@ -495,6 +496,10 @@ home composer submit
 ```
 
 Initial-content create is one transaction. Failure compensates the provisional runtime/canonical shell; it must not leave a Turn-less Session.
+The pending activation carries the same resolved project section key as the
+create command. Exact rail projection therefore shows the conversation as soon
+as the intent is accepted; it does not wait for provider startup or invent a
+temporary catch-all section.
 
 ### 7.2 Existing conversation submit
 

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -238,6 +238,12 @@ and in the PR `go-lint` job. The boundary rationale and adapter rules live in
 the root `AGENTS.md` `Agent Host Boundary` section and
 `services/tuttid/service/agent/AGENTS.md`.
 
+The same check also verifies production reachability: `services/tuttid/wiring.go`
+must compose Host with `daemon/hostadapter.RuntimeController`,
+`host.SQLiteWorkspaceStore`, and `NewApplicationHostWithPorts`. This prevents
+shared lifecycle adapters from existing only in tests while production keeps a
+parallel service implementation.
+
 ## Agent GUI Degradation Ratchet
 
 The agent GUI refactor

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -242,7 +242,10 @@ The same check also verifies production reachability: `services/tuttid/wiring.go
 must compose Host with `daemon/hostadapter.RuntimeController`,
 `host.SQLiteWorkspaceStore`, and `NewApplicationHostWithPorts`. This prevents
 shared lifecycle adapters from existing only in tests while production keeps a
-parallel service implementation.
+parallel service implementation. Production agent service files also reject
+service-local `serviceHostStore` / `serviceHostRuntime` composition and lazy
+`NewApplicationHost` factories; isolated in-memory adapters may exist only in
+`_test.go` fixtures.
 
 ## Agent GUI Degradation Ratchet
 

--- a/packages/agent/activity-core/src/capabilities.test.ts
+++ b/packages/agent/activity-core/src/capabilities.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   AGENT_CAPABILITY_KEYS,
+  agentActivitySessionCapabilitiesFromIds,
   hasAgentCapability,
   resolveAgentActivityCapability
 } from "./capabilities.ts";
@@ -75,6 +76,19 @@ test("vocabulary matches the Go side", () => {
     "skills",
     "tokenUsage"
   ]);
+});
+
+test("canonical capability ids project to the closed activity record", () => {
+  const capabilities = agentActivitySessionCapabilitiesFromIds([
+    "tokenUsage",
+    "goalPause",
+    "unknown"
+  ]);
+
+  assert.equal(capabilities.tokenUsage, true);
+  assert.equal(capabilities.goalPause, true);
+  assert.equal(capabilities.interrupt, false);
+  assert.deepEqual(Object.keys(capabilities), [...AGENT_CAPABILITY_KEYS]);
 });
 
 function composerOptions(input: {

--- a/packages/agent/activity-core/src/capabilities.ts
+++ b/packages/agent/activity-core/src/capabilities.ts
@@ -1,9 +1,15 @@
-import type { AgentActivityComposerOptions } from "./types.ts";
+import type {
+  AgentActivityComposerOptions,
+  AgentActivitySessionCapabilities
+} from "./types.ts";
 export {
   AGENT_CAPABILITY_KEYS,
   type AgentCapabilityKey
 } from "./generated/agentCapabilityKeys.ts";
-import type { AgentCapabilityKey } from "./generated/agentCapabilityKeys.ts";
+import {
+  AGENT_CAPABILITY_KEYS,
+  type AgentCapabilityKey
+} from "./generated/agentCapabilityKeys.ts";
 
 export interface AgentActivityCapabilityInput {
   composerOptions?: AgentActivityComposerOptions | null;
@@ -25,4 +31,20 @@ export function hasAgentCapability(
   key: AgentCapabilityKey
 ): boolean {
   return capabilities?.[key] === true;
+}
+
+/**
+ * Projects the canonical capability id list carried by session metadata into
+ * the closed AgentActivity capability record consumed by AgentGUI.
+ */
+export function agentActivitySessionCapabilitiesFromIds(
+  capabilities: readonly string[]
+): AgentActivitySessionCapabilities {
+  const capabilitySet = new Set(capabilities);
+  return Object.fromEntries(
+    AGENT_CAPABILITY_KEYS.map((capability) => [
+      capability,
+      capabilitySet.has(capability)
+    ])
+  ) as unknown as AgentActivitySessionCapabilities;
 }

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
@@ -209,6 +209,7 @@ test("activation intent owns the transport command and confirmation deadline", (
   assert.equal(pendingActivation?.status, "requested");
   assert.equal(pendingActivation?.displayPrompt, "/browser");
   assert.equal(pendingActivation?.optimisticTitle, "Review browser flow");
+  assert.equal(pendingActivation?.railSectionKey, "project:/workspace");
   assert.deepEqual(pendingActivation?.content, [
     { type: "text", text: "hello" }
   ]);
@@ -636,6 +637,7 @@ function activation() {
     expiresAtUnixMs: 120_000,
     initialDisplayPrompt: "/browser",
     optimisticTitle: "Review browser flow",
+    railSectionKey: "project:/workspace",
     runtimeContent: [{ type: "text" as const, text: "runtime instructions" }],
     submitDiagnostics: { submittedAtUnixMs: 1 },
     mode: "new" as const,

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.ts
@@ -223,6 +223,9 @@ function requestActivation(
     expiresAtUnixMs: intent.expiresAtUnixMs,
     initialTurnExpected:
       intent.initialTurnExpected ?? runtimeContent.length > 0,
+    ...(intent.railSectionKey?.trim()
+      ? { railSectionKey: intent.railSectionKey.trim() }
+      : {}),
     ...(intent.submitDiagnostics
       ? { submitDiagnostics: { ...intent.submitDiagnostics } }
       : {}),

--- a/packages/agent/activity-core/src/engine/pendingIntents.types.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.types.ts
@@ -34,6 +34,7 @@ interface PendingActivationIntentRecordBase {
   errorMessage: string | null;
   expiresAtUnixMs: number;
   initialTurnExpected: boolean;
+  railSectionKey?: string;
   submitDiagnostics?: Readonly<AgentActivitySubmitDiagnostics>;
   pendingSettingsPatch?: Readonly<Record<string, unknown>>;
   settingsUpdateStatus?: "failed" | "inFlight" | "unknown";
@@ -97,6 +98,7 @@ interface SessionActivationRequestedIntentBase {
   cwd?: string;
   expiresAtUnixMs: number;
   initialTurnExpected?: boolean;
+  railSectionKey?: string;
   initialDisplayPrompt?: string;
   runtimeContent?: readonly AgentPromptContentBlock[];
   submitDiagnostics?: Readonly<AgentActivitySubmitDiagnostics>;

--- a/packages/agent/activity-core/src/engine/sessionMutations.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionMutations.reducer.test.ts
@@ -134,6 +134,7 @@ test("delete result emits removals for requested and cascaded sessions", () => {
       outcome: "succeeded",
       type: "engine/commandResult",
       value: {
+        cleanupFailedSessionIds: [],
         removedMessages: 2,
         removedSessionIds: ["session-1", "child-1"],
         removedSessions: 2
@@ -172,6 +173,7 @@ test("settled mutation history stays bounded across unique sessions", () => {
         outcome: "succeeded",
         type: "engine/commandResult",
         value: {
+          cleanupFailedSessionIds: [],
           removedMessages: 0,
           removedSessionIds: [agentSessionId],
           removedSessions: 1

--- a/packages/agent/activity-core/src/engine/sessionMutations.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionMutations.reducer.ts
@@ -194,6 +194,7 @@ function requestDelete(
     return replaceRecord(state, {
       ...record,
       deleteResult: {
+        cleanupFailedSessionIds: [],
         removedMessages: 0,
         removedSessionIds: [],
         removedSessions: 0
@@ -251,12 +252,17 @@ function validDeleteResult(value: unknown): SessionDeleteMutationResult | null {
   if (
     typeof result.removedMessages !== "number" ||
     typeof result.removedSessions !== "number" ||
+    !Array.isArray(result.cleanupFailedSessionIds) ||
+    !result.cleanupFailedSessionIds.every((id) => typeof id === "string") ||
     !Array.isArray(result.removedSessionIds) ||
     !result.removedSessionIds.every((id) => typeof id === "string")
   ) {
     return null;
   }
   return {
+    cleanupFailedSessionIds: result.cleanupFailedSessionIds.map((id) =>
+      id.trim()
+    ),
     removedMessages: result.removedMessages,
     removedSessionIds: result.removedSessionIds.map((id) => id.trim()),
     removedSessions: result.removedSessions

--- a/packages/agent/activity-core/src/engine/sessionMutations.types.ts
+++ b/packages/agent/activity-core/src/engine/sessionMutations.types.ts
@@ -7,6 +7,7 @@ export type SessionMutationStatus =
   | "unknown";
 
 export interface SessionDeleteMutationResult {
+  cleanupFailedSessionIds: readonly string[];
   removedMessages: number;
   removedSessionIds: readonly string[];
   removedSessions: number;

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -5,6 +5,7 @@ export {
 } from "./sessionNormalization.ts";
 export {
   AGENT_CAPABILITY_KEYS,
+  agentActivitySessionCapabilitiesFromIds,
   hasAgentCapability,
   resolveAgentActivityCapability,
   type AgentActivityCapabilityInput,
@@ -284,6 +285,7 @@ export type {
   AgentActivitySessionCapabilities,
   AgentActivitySessionGoal,
   AgentActivitySessionPermissionConfig,
+  AgentActivitySessionUsage,
   AgentActivitySessionSettings,
   AgentActivitySessionKind,
   AgentActivitySessionEventEnvelope,

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -563,6 +563,7 @@ export interface AgentActivityDeleteSessionInput {
 }
 
 export interface AgentActivityDeleteSessionResult {
+  cleanupFailed: boolean;
   removed: boolean;
 }
 
@@ -573,6 +574,7 @@ export interface AgentActivityDeleteSessionsInput {
 }
 
 export interface AgentActivityDeleteSessionsResult {
+  cleanupFailedSessionIds: string[];
   removedMessages: number;
   removedSessionIds: string[];
   removedSessions: number;

--- a/packages/agent/daemon/activity/events/activity_types.go
+++ b/packages/agent/daemon/activity/events/activity_types.go
@@ -284,7 +284,7 @@ func NewSessionAudit(ctx EventContext, role MessageRole, content string, metadat
 }
 
 // NewGoalReconcileRequired carries internal, session-scoped evidence from a
-// provider adapter to the durable GoalActor. It is neither transcript content
+// provider adapter to the durable Host goal mutation lane. It is neither transcript content
 // nor a Turn lifecycle event.
 func NewGoalReconcileRequired(ctx EventContext, metadata map[string]any) Event {
 	event := eventFromContext(ctx, EventGoalReconcileRequired, EventPayload{Metadata: cloneMap(metadata)})

--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -1,0 +1,373 @@
+// Package hostadapter adapts the daemon runtime contract to Agent Host.
+//
+// Both sides of this boundary are owned by Tutti. Product services should
+// provide only the concrete runtime backend and current-user identity instead
+// of maintaining their own lifecycle and error mappings.
+package hostadapter
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+	host "github.com/tutti-os/tutti/packages/agent/host"
+)
+
+// RuntimeBackend is the daemon controller surface required by Agent Host.
+// *runtime.Controller implements this interface.
+type RuntimeBackend interface {
+	Start(context.Context, agentruntime.StartInput) (agentruntime.StartResult, error)
+	Resume(context.Context, agentruntime.ResumeInput) (agentruntime.Session, error)
+	Session(string, string) (agentruntime.Session, bool)
+	CanResume(agentruntime.ResumeInput) bool
+	Exec(context.Context, agentruntime.ExecInput) (agentruntime.ExecResult, error)
+	ValidatePromptContent(context.Context, agentruntime.ExecInput) error
+	Cancel(context.Context, agentruntime.CancelInput) (agentruntime.CancelResult, error)
+	SubmitInteractive(context.Context, agentruntime.SubmitInteractiveInput) (agentruntime.SubmitInteractiveResult, error)
+	InteractiveDisposition(string, string, string, string, string) agentruntime.InteractiveDisposition
+	UpdateSettings(context.Context, agentruntime.UpdateSettingsInput) (agentruntime.UpdateSettingsResult, error)
+	SetTitle(context.Context, string, string, string) (agentruntime.Session, error)
+	SetVisible(context.Context, string, string, bool) (agentruntime.Session, error)
+	Close(context.Context, agentruntime.CloseInput) (agentruntime.CloseResult, error)
+	GoalControl(context.Context, agentruntime.GoalControlInput) (agentruntime.GoalControlResult, error)
+	ReconcileGoal(context.Context, agentruntime.GoalReconcileInput) (agentruntime.GoalReconcileResult, error)
+	GoalCapabilities(context.Context, agentruntime.GoalReconcileInput) (agentruntime.GoalAdapterCapabilities, error)
+}
+
+// RuntimeController implements Agent Host runtime ports with a daemon backend.
+type RuntimeController struct {
+	Backend       RuntimeBackend
+	CurrentUserID func() string
+}
+
+var (
+	_ host.RuntimeController                 = (*RuntimeController)(nil)
+	_ host.GoalRuntimeController             = (*RuntimeController)(nil)
+	_ host.GoalRuntimeReconciler             = (*RuntimeController)(nil)
+	_ host.GoalRuntimeRecoveryPolicyResolver = (*RuntimeController)(nil)
+)
+
+func (a *RuntimeController) Start(ctx context.Context, input host.RuntimeStartInput) (host.ProviderRuntimeSession, error) {
+	if err := a.requireBackend(); err != nil {
+		return host.ProviderRuntimeSession{}, err
+	}
+	result, err := a.Backend.Start(ctx, agentruntime.StartInput{
+		RoomID:                  input.WorkspaceID,
+		AgentSessionID:          input.AgentSessionID,
+		AgentTargetID:           input.AgentTargetID,
+		Provider:                input.Provider,
+		CWD:                     input.Cwd,
+		Env:                     append([]string(nil), input.Env...),
+		Title:                   input.Title,
+		InitialTitleEstablished: input.InitialTitleEstablished,
+		Visible:                 input.Visible,
+		RuntimeContext:          cloneMap(input.RuntimeContext),
+		ProviderTargetRef:       cloneMap(input.ProviderTargetRef),
+		PermissionModeID:        input.PermissionModeID,
+		Settings: runtimeSettings(host.ComposerSettings{
+			Model:                  input.Model,
+			PermissionModeID:       input.PermissionModeID,
+			PlanMode:               input.PlanMode,
+			BrowserUse:             input.BrowserUse,
+			ComputerUse:            input.ComputerUse,
+			ReasoningEffort:        input.ReasoningEffort,
+			Speed:                  input.Speed,
+			ConversationDetailMode: input.ConversationDetailMode,
+		}),
+		Provisional: input.Provisional,
+	})
+	if err != nil {
+		return host.ProviderRuntimeSession{}, mapRuntimeError(err)
+	}
+	session := a.fromSession(result.Session)
+	session.Provisional = input.Provisional
+	return session, nil
+}
+
+func (a *RuntimeController) Resume(ctx context.Context, input host.RuntimeResumeInput) (host.ProviderRuntimeSession, error) {
+	if err := a.requireBackend(); err != nil {
+		return host.ProviderRuntimeSession{}, err
+	}
+	session, err := a.Backend.Resume(ctx, runtimeResumeInput(input))
+	return a.fromSession(session), mapRuntimeError(err)
+}
+
+func (a *RuntimeController) Session(workspaceID, sessionID string) (host.ProviderRuntimeSession, bool) {
+	if a == nil || a.Backend == nil {
+		return host.ProviderRuntimeSession{}, false
+	}
+	session, found := a.Backend.Session(workspaceID, sessionID)
+	return a.fromSession(session), found
+}
+
+func (a *RuntimeController) CanResume(input host.RuntimeResumeInput) bool {
+	return a != nil && a.Backend != nil && a.Backend.CanResume(runtimeResumeInput(input))
+}
+
+func (a *RuntimeController) Exec(ctx context.Context, input host.RuntimeExecInput) (host.RuntimeExecResult, error) {
+	if err := a.requireBackend(); err != nil {
+		return host.RuntimeExecResult{}, err
+	}
+	result, err := a.Backend.Exec(ctx, runtimeExecInput(input))
+	return host.RuntimeExecResult{
+		AgentSessionID: result.AgentSessionID,
+		Status:         result.Status,
+		TurnID:         result.TurnID,
+		Accepted:       result.Accepted,
+		SessionStatus:  result.SessionStatus,
+		TurnLifecycle:  hostTurnLifecycle(result.TurnLifecycle),
+		SubmitAvailability: host.SubmitAvailability{
+			State: result.SubmitAvailability.State, Reason: result.SubmitAvailability.Reason,
+		},
+	}, mapRuntimeError(err)
+}
+
+func (a *RuntimeController) ValidatePromptContent(ctx context.Context, input host.RuntimeExecInput) error {
+	if err := a.requireBackend(); err != nil {
+		return err
+	}
+	return mapRuntimeError(a.Backend.ValidatePromptContent(ctx, runtimeExecInput(input)))
+}
+
+func (a *RuntimeController) Cancel(ctx context.Context, input host.RuntimeCancelInput) (host.RuntimeCancelResult, error) {
+	if err := a.requireBackend(); err != nil {
+		return host.RuntimeCancelResult{}, err
+	}
+	targets := make([]agentruntime.CancelTarget, 0, len(input.Targets))
+	for _, target := range input.Targets {
+		targets = append(targets, agentruntime.CancelTarget{AgentSessionID: target.AgentSessionID, TurnID: target.TurnID})
+	}
+	result, err := a.Backend.Cancel(ctx, agentruntime.CancelInput{
+		RoomID: input.WorkspaceID, RootAgentSessionID: input.RootAgentSessionID, Targets: targets, Reason: input.Reason,
+	})
+	confirmed := make([]host.RuntimeCancelTarget, 0, len(result.ConfirmedTargets))
+	for _, target := range result.ConfirmedTargets {
+		confirmed = append(confirmed, host.RuntimeCancelTarget{AgentSessionID: target.AgentSessionID, TurnID: target.TurnID})
+	}
+	return host.RuntimeCancelResult{
+		AgentSessionID:   result.AgentSessionID,
+		Canceled:         result.Canceled,
+		TargetAbsent:     result.TargetAbsent,
+		ConfirmedTargets: confirmed,
+	}, mapRuntimeError(err)
+}
+
+func (a *RuntimeController) SubmitInteractive(ctx context.Context, input host.RuntimeSubmitInteractiveInput) (host.RuntimeSubmitInteractiveResult, error) {
+	if err := a.requireBackend(); err != nil {
+		return host.RuntimeSubmitInteractiveResult{}, err
+	}
+	result, err := a.Backend.SubmitInteractive(ctx, agentruntime.SubmitInteractiveInput{
+		RoomID: input.WorkspaceID, RootAgentSessionID: input.RootAgentSessionID,
+		AgentSessionID: input.AgentSessionID, TurnID: input.TurnID, RequestID: input.RequestID,
+		Action: input.Action, OptionID: input.OptionID, Payload: cloneMap(input.Payload),
+	})
+	return host.RuntimeSubmitInteractiveResult{Disposition: host.RuntimeInteractiveDisposition(result.Disposition)}, mapRuntimeError(err)
+}
+
+func (a *RuntimeController) InteractiveDisposition(workspaceID, rootSessionID, sessionID, turnID, requestID string) host.RuntimeInteractiveDisposition {
+	if a == nil || a.Backend == nil {
+		return host.RuntimeInteractiveDispositionUnknown
+	}
+	return host.RuntimeInteractiveDisposition(a.Backend.InteractiveDisposition(workspaceID, rootSessionID, sessionID, turnID, requestID))
+}
+
+func (a *RuntimeController) UpdateSettings(ctx context.Context, input host.RuntimeUpdateSettingsInput) error {
+	if err := a.requireBackend(); err != nil {
+		return err
+	}
+	_, err := a.Backend.UpdateSettings(ctx, agentruntime.UpdateSettingsInput{
+		RoomID: input.WorkspaceID, AgentSessionID: input.AgentSessionID,
+		Settings: agentruntime.SessionSettingsPatch{
+			Model: input.Settings.Model, ReasoningEffort: input.Settings.ReasoningEffort, Speed: input.Settings.Speed,
+			PlanMode: input.Settings.PlanMode, BrowserUse: input.Settings.BrowserUse,
+			ComputerUse: input.Settings.ComputerUse, PermissionModeID: input.Settings.PermissionModeID,
+		},
+	})
+	return mapRuntimeError(err)
+}
+
+func (a *RuntimeController) SetTitle(ctx context.Context, input host.RuntimeSetTitleInput) (host.ProviderRuntimeSession, error) {
+	if err := a.requireBackend(); err != nil {
+		return host.ProviderRuntimeSession{}, err
+	}
+	session, err := a.Backend.SetTitle(ctx, input.WorkspaceID, input.AgentSessionID, input.Title)
+	return a.fromSession(session), mapRuntimeError(err)
+}
+
+func (a *RuntimeController) SetVisible(ctx context.Context, input host.RuntimeSetVisibleInput) (host.ProviderRuntimeSession, error) {
+	if err := a.requireBackend(); err != nil {
+		return host.ProviderRuntimeSession{}, err
+	}
+	session, err := a.Backend.SetVisible(ctx, input.WorkspaceID, input.AgentSessionID, input.Visible)
+	return a.fromSession(session), mapRuntimeError(err)
+}
+
+func (a *RuntimeController) Close(ctx context.Context, input host.RuntimeCloseInput) error {
+	if err := a.requireBackend(); err != nil {
+		return err
+	}
+	_, err := a.Backend.Close(ctx, agentruntime.CloseInput{RoomID: input.WorkspaceID, AgentSessionID: input.AgentSessionID})
+	return mapRuntimeError(err)
+}
+
+func (a *RuntimeController) GoalControl(ctx context.Context, input host.RuntimeGoalControlInput) (host.RuntimeGoalControlResult, error) {
+	if err := a.requireBackend(); err != nil {
+		return host.RuntimeGoalControlResult{}, err
+	}
+	result, err := a.Backend.GoalControl(ctx, agentruntime.GoalControlInput{
+		RoomID: input.WorkspaceID, AgentSessionID: input.AgentSessionID,
+		Action: agentruntime.GoalControlAction(input.Action), Objective: input.Objective,
+		OperationID: input.OperationID, GoalRevision: input.GoalRevision, RepairEpoch: input.RepairEpoch,
+		SubmissionMetadata: cloneMap(input.SubmissionMetadata),
+	})
+	return host.RuntimeGoalControlResult{
+		AgentSessionID: result.AgentSessionID, Goal: cloneMap(result.Goal), Evidence: cloneMap(result.Evidence),
+		ProviderPhase: result.ProviderPhase,
+	}, mapRuntimeError(err)
+}
+
+func (a *RuntimeController) ReconcileGoal(ctx context.Context, input host.RuntimeGoalControlInput) (host.RuntimeGoalReconcileResult, error) {
+	if err := a.requireBackend(); err != nil {
+		return host.RuntimeGoalReconcileResult{}, err
+	}
+	result, err := a.Backend.ReconcileGoal(ctx, agentruntime.GoalReconcileInput{RoomID: input.WorkspaceID, AgentSessionID: input.AgentSessionID})
+	return host.RuntimeGoalReconcileResult{
+		AgentSessionID: result.AgentSessionID, Goal: cloneMap(result.Goal), Evidence: cloneMap(result.Evidence),
+	}, mapRuntimeError(err)
+}
+
+func (a *RuntimeController) GoalRecoveryPolicy(ctx context.Context, input host.RuntimeGoalControlInput) (host.RuntimeGoalRecoveryPolicy, error) {
+	if err := a.requireBackend(); err != nil {
+		return host.RuntimeGoalRecoveryPolicy{}, err
+	}
+	capabilities, err := a.Backend.GoalCapabilities(ctx, agentruntime.GoalReconcileInput{RoomID: input.WorkspaceID, AgentSessionID: input.AgentSessionID})
+	return host.RuntimeGoalRecoveryPolicy{
+		QuerySupported: capabilities.QuerySupported, ReplaySetAfterRestart: capabilities.ReplaySetAfterRestart,
+	}, mapRuntimeError(err)
+}
+
+func (a *RuntimeController) requireBackend() error {
+	if a == nil || a.Backend == nil {
+		return errors.New("agent runtime controller is unavailable")
+	}
+	return nil
+}
+
+func mapRuntimeError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var appErr *agentruntime.AppError
+	if errors.As(err, &appErr) && appErr != nil {
+		if errors.Is(appErr, context.Canceled) || errors.Is(appErr, context.DeadlineExceeded) {
+			return err
+		}
+		return host.NewProviderError(appErr.Code, appErr.Message, appErr.DebugMessage, appErr)
+	}
+	return err
+}
+
+func (a *RuntimeController) fromSession(session agentruntime.Session) host.ProviderRuntimeSession {
+	var settings *host.ComposerSettings
+	if session.Settings != nil {
+		value := hostSettings(*session.Settings)
+		settings = &value
+	}
+	return host.ProviderRuntimeSession{
+		ID: session.AgentSessionID, WorkspaceID: session.RoomID, UserID: a.currentUserID(),
+		AgentTargetID: session.AgentTargetID, Provider: session.Provider, ProviderSessionID: session.ProviderSessionID,
+		Cwd: session.CWD, Env: append([]string(nil), session.Env...), Settings: settings,
+		RuntimeContext: cloneMap(session.RuntimeContext), Status: session.Status,
+		TurnLifecycle: hostTurnLifecyclePointer(session.TurnLifecycle), SubmitAvailability: hostSubmitAvailability(session.SubmitAvailability),
+		Visible: session.Visible, Title: session.Title, InitialTitleEstablished: session.InitialTitleEstablished,
+		LastError: session.LastError, CreatedAtUnixMS: session.CreatedAtUnixMS, UpdatedAtUnixMS: session.UpdatedAtUnixMS,
+	}
+}
+
+func (a *RuntimeController) currentUserID() string {
+	if a != nil && a.CurrentUserID != nil {
+		return strings.TrimSpace(a.CurrentUserID())
+	}
+	return ""
+}
+
+func runtimeResumeInput(input host.RuntimeResumeInput) agentruntime.ResumeInput {
+	return agentruntime.ResumeInput{
+		RoomID: input.WorkspaceID, AgentSessionID: input.AgentSessionID, AgentTargetID: input.AgentTargetID,
+		Provider: input.Provider, ProviderSessionID: input.ProviderSessionID, CWD: input.Cwd,
+		Env: append([]string(nil), input.Env...), Title: input.Title, Status: input.Status, Visible: input.Visible,
+		RuntimeContext: cloneMap(input.RuntimeContext), ProviderTargetRef: cloneMap(input.ProviderTargetRef),
+		PermissionModeID: input.Settings.PermissionModeID, Settings: runtimeSettings(input.Settings),
+		CreatedAtUnixMS: input.CreatedAtUnixMS, UpdatedAtUnixMS: input.UpdatedAtUnixMS,
+		RecreateIfMissing: input.RecreateIfMissing,
+	}
+}
+
+func runtimeExecInput(input host.RuntimeExecInput) agentruntime.ExecInput {
+	content := make([]agentruntime.PromptContentBlock, 0, len(input.Content))
+	for _, block := range input.Content {
+		content = append(content, agentruntime.PromptContentBlock{
+			Type: block.Type, Text: block.Text, MimeType: block.MimeType, Data: block.Data, URL: block.URL,
+			AttachmentID: block.AttachmentID, Name: block.Name, Path: block.Path,
+		})
+	}
+	return agentruntime.ExecInput{
+		RoomID: input.WorkspaceID, AgentSessionID: input.AgentSessionID, Content: content,
+		DisplayPrompt: input.DisplayPrompt, InitialTitle: input.InitialTitle, InitialTitleBase: input.InitialTitleBase,
+		Metadata: cloneMap(input.Metadata), Guidance: input.Guidance,
+	}
+}
+
+func runtimeSettings(settings host.ComposerSettings) *agentruntime.SessionSettings {
+	return &agentruntime.SessionSettings{
+		Model: settings.Model, ReasoningEffort: settings.ReasoningEffort, Speed: settings.Speed,
+		PlanMode: settings.PlanMode, BrowserUse: settings.BrowserUse, ComputerUse: settings.ComputerUse,
+		PermissionModeID: settings.PermissionModeID, ConversationDetailMode: settings.ConversationDetailMode,
+	}
+}
+
+func hostSettings(settings agentruntime.SessionSettings) host.ComposerSettings {
+	return host.ComposerSettings{
+		Model: settings.Model, ReasoningEffort: settings.ReasoningEffort, Speed: settings.Speed,
+		PlanMode: settings.PlanMode, BrowserUse: settings.BrowserUse, ComputerUse: settings.ComputerUse,
+		PermissionModeID: settings.PermissionModeID, ConversationDetailMode: settings.ConversationDetailMode,
+	}
+}
+
+func hostTurnLifecyclePointer(input *agentruntime.TurnLifecycle) *host.TurnLifecycle {
+	if input == nil {
+		return nil
+	}
+	value := hostTurnLifecycle(*input)
+	return &value
+}
+
+func hostTurnLifecycle(input agentruntime.TurnLifecycle) host.TurnLifecycle {
+	var completed *host.CompletedCommand
+	if input.CompletedCommand != nil {
+		completed = &host.CompletedCommand{Kind: input.CompletedCommand.Kind, Status: input.CompletedCommand.Status}
+	}
+	return host.TurnLifecycle{
+		ActiveTurnID: input.ActiveTurnID, Phase: input.Phase, Settling: input.Settling,
+		Outcome: input.Outcome, CompletedCommand: completed,
+	}
+}
+
+func hostSubmitAvailability(input *agentruntime.SubmitAvailability) *host.SubmitAvailability {
+	if input == nil {
+		return nil
+	}
+	return &host.SubmitAvailability{State: input.State, Reason: input.Reason}
+}
+
+func cloneMap(input map[string]any) map[string]any {
+	if input == nil {
+		return nil
+	}
+	out := make(map[string]any, len(input))
+	for key, value := range input {
+		out[key] = value
+	}
+	return out
+}

--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -20,6 +20,7 @@ type RuntimeBackend interface {
 	Start(context.Context, agentruntime.StartInput) (agentruntime.StartResult, error)
 	Resume(context.Context, agentruntime.ResumeInput) (agentruntime.Session, error)
 	Session(string, string) (agentruntime.Session, bool)
+	State(string, string) (agentruntime.SessionStateSnapshot, error)
 	CanResume(agentruntime.ResumeInput) bool
 	Exec(context.Context, agentruntime.ExecInput) (agentruntime.ExecResult, error)
 	ValidatePromptContent(context.Context, agentruntime.ExecInput) error
@@ -80,7 +81,7 @@ func (a *RuntimeController) Start(ctx context.Context, input host.RuntimeStartIn
 	if err != nil {
 		return host.ProviderRuntimeSession{}, mapRuntimeError(err)
 	}
-	session := a.fromSession(result.Session)
+	session := a.sessionWithState(result.Session)
 	session.Provisional = input.Provisional
 	return session, nil
 }
@@ -90,7 +91,10 @@ func (a *RuntimeController) Resume(ctx context.Context, input host.RuntimeResume
 		return host.ProviderRuntimeSession{}, err
 	}
 	session, err := a.Backend.Resume(ctx, runtimeResumeInput(input))
-	return a.fromSession(session), mapRuntimeError(err)
+	if err != nil {
+		return host.ProviderRuntimeSession{}, mapRuntimeError(err)
+	}
+	return a.sessionWithState(session), nil
 }
 
 func (a *RuntimeController) Session(workspaceID, sessionID string) (host.ProviderRuntimeSession, bool) {
@@ -98,7 +102,10 @@ func (a *RuntimeController) Session(workspaceID, sessionID string) (host.Provide
 		return host.ProviderRuntimeSession{}, false
 	}
 	session, found := a.Backend.Session(workspaceID, sessionID)
-	return a.fromSession(session), found
+	if !found {
+		return host.ProviderRuntimeSession{}, false
+	}
+	return a.sessionWithState(session), true
 }
 
 func (a *RuntimeController) CanResume(input host.RuntimeResumeInput) bool {
@@ -192,7 +199,10 @@ func (a *RuntimeController) SetTitle(ctx context.Context, input host.RuntimeSetT
 		return host.ProviderRuntimeSession{}, err
 	}
 	session, err := a.Backend.SetTitle(ctx, input.WorkspaceID, input.AgentSessionID, input.Title)
-	return a.fromSession(session), mapRuntimeError(err)
+	if err != nil {
+		return host.ProviderRuntimeSession{}, mapRuntimeError(err)
+	}
+	return a.sessionWithState(session), nil
 }
 
 func (a *RuntimeController) SetVisible(ctx context.Context, input host.RuntimeSetVisibleInput) (host.ProviderRuntimeSession, error) {
@@ -200,7 +210,10 @@ func (a *RuntimeController) SetVisible(ctx context.Context, input host.RuntimeSe
 		return host.ProviderRuntimeSession{}, err
 	}
 	session, err := a.Backend.SetVisible(ctx, input.WorkspaceID, input.AgentSessionID, input.Visible)
-	return a.fromSession(session), mapRuntimeError(err)
+	if err != nil {
+		return host.ProviderRuntimeSession{}, mapRuntimeError(err)
+	}
+	return a.sessionWithState(session), nil
 }
 
 func (a *RuntimeController) Close(ctx context.Context, input host.RuntimeCloseInput) error {
@@ -283,6 +296,42 @@ func (a *RuntimeController) fromSession(session agentruntime.Session) host.Provi
 		Visible: session.Visible, Title: session.Title, InitialTitleEstablished: session.InitialTitleEstablished,
 		LastError: session.LastError, CreatedAtUnixMS: session.CreatedAtUnixMS, UpdatedAtUnixMS: session.UpdatedAtUnixMS,
 	}
+}
+
+// sessionWithState preserves the daemon runtime's provider-enriched live
+// observation. The base Session owns process identity and lifecycle fields;
+// State overlays provider-computed settings and runtime context such as model
+// catalogs, usage, rate limits, account details, and commands.
+func (a *RuntimeController) sessionWithState(session agentruntime.Session) host.ProviderRuntimeSession {
+	result := a.fromSession(session)
+	if a == nil || a.Backend == nil {
+		return result
+	}
+	state, err := a.Backend.State(session.RoomID, session.AgentSessionID)
+	if err != nil {
+		return result
+	}
+	if state.ProviderSessionID != "" {
+		result.ProviderSessionID = state.ProviderSessionID
+	}
+	if state.Status != "" {
+		result.Status = state.Status
+	}
+	if state.TurnLifecycle != nil {
+		result.TurnLifecycle = hostTurnLifecyclePointer(state.TurnLifecycle)
+	}
+	if state.SubmitAvailability != nil {
+		result.SubmitAvailability = hostSubmitAvailability(state.SubmitAvailability)
+	}
+	if state.Settings != nil {
+		settings := hostSettings(*state.Settings)
+		result.Settings = &settings
+	}
+	result.RuntimeContext = cloneMap(state.RuntimeContext)
+	if state.UpdatedAtUnixMS > 0 {
+		result.UpdatedAtUnixMS = state.UpdatedAtUnixMS
+	}
+	return result
 }
 
 func (a *RuntimeController) currentUserID() string {

--- a/packages/agent/daemon/hostadapter/runtime_test.go
+++ b/packages/agent/daemon/hostadapter/runtime_test.go
@@ -1,0 +1,83 @@
+package hostadapter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+	host "github.com/tutti-os/tutti/packages/agent/host"
+)
+
+func TestMapRuntimeErrorPreservesProviderDiagnostics(t *testing.T) {
+	cause := errors.New("provider process rejected request")
+	runtimeErr := &agentruntime.AppError{
+		Code:         "provider_auth_required",
+		Message:      "Agent provider needs authentication",
+		DebugMessage: "provider exited with status 1",
+		Cause:        cause,
+	}
+
+	mapped := mapRuntimeError(fmt.Errorf("daemon runtime: %w", runtimeErr))
+	var providerErr *host.ProviderError
+	if !errors.As(mapped, &providerErr) {
+		t.Fatalf("mapped error = %v, want ProviderError", mapped)
+	}
+	if providerErr.Code != runtimeErr.Code || providerErr.Message != runtimeErr.Message || providerErr.DebugMessage != runtimeErr.DebugMessage {
+		t.Fatalf("ProviderError = %#v, want diagnostics from %#v", providerErr, runtimeErr)
+	}
+	if !errors.Is(mapped, runtimeErr) || !errors.Is(mapped, cause) {
+		t.Fatalf("mapped error did not preserve source chain: %v", mapped)
+	}
+}
+
+func TestMapRuntimeErrorKeepsTransportOutcomeUnknown(t *testing.T) {
+	for _, target := range []error{context.Canceled, context.DeadlineExceeded} {
+		t.Run(target.Error(), func(t *testing.T) {
+			runtimeErr := &agentruntime.AppError{
+				Code:  "request_failed",
+				Cause: fmt.Errorf("provider response: %w", target),
+			}
+			mapped := mapRuntimeError(runtimeErr)
+			var providerErr *host.ProviderError
+			if errors.As(mapped, &providerErr) {
+				t.Fatalf("mapped error = %#v, want transport outcome to remain unknown", providerErr)
+			}
+			if !errors.Is(mapped, target) {
+				t.Fatalf("mapped error = %v, want %v in chain", mapped, target)
+			}
+		})
+	}
+}
+
+func TestRuntimeControllerProjectsSessionWithoutAliasingMutableInputs(t *testing.T) {
+	runtimeContext := map[string]any{"mode": "plan"}
+	env := []string{"A=1"}
+	controller := &RuntimeController{CurrentUserID: func() string { return " user-1 " }}
+
+	projected := controller.fromSession(agentruntime.Session{
+		RoomID: "workspace-1", AgentSessionID: "session-1", AgentTargetID: "target-1",
+		Provider: "codex", Env: env, RuntimeContext: runtimeContext,
+		Settings: &agentruntime.SessionSettings{Model: "gpt-5.6", ReasoningEffort: "max", Speed: "standard"},
+	})
+	env[0] = "A=2"
+	runtimeContext["mode"] = "changed"
+
+	if projected.UserID != "user-1" || projected.Env[0] != "A=1" || projected.RuntimeContext["mode"] != "plan" {
+		t.Fatalf("projected session retained mutable input or identity whitespace: %#v", projected)
+	}
+	if projected.Settings == nil || projected.Settings.Model != "gpt-5.6" || projected.Settings.ReasoningEffort != "max" || projected.Settings.Speed != "standard" {
+		t.Fatalf("projected settings = %#v", projected.Settings)
+	}
+}
+
+func TestRuntimeControllerFailsClosedWithoutBackend(t *testing.T) {
+	controller := &RuntimeController{}
+	if _, err := controller.Start(t.Context(), host.RuntimeStartInput{}); err == nil {
+		t.Fatal("Start succeeded without a runtime backend")
+	}
+	if controller.CanResume(host.RuntimeResumeInput{}) {
+		t.Fatal("CanResume reported support without a runtime backend")
+	}
+}

--- a/packages/agent/daemon/hostadapter/runtime_test.go
+++ b/packages/agent/daemon/hostadapter/runtime_test.go
@@ -10,6 +10,21 @@ import (
 	host "github.com/tutti-os/tutti/packages/agent/host"
 )
 
+type stateRuntimeBackend struct {
+	RuntimeBackend
+	session  agentruntime.Session
+	state    agentruntime.SessionStateSnapshot
+	stateErr error
+}
+
+func (b *stateRuntimeBackend) Session(_, _ string) (agentruntime.Session, bool) {
+	return b.session, true
+}
+
+func (b *stateRuntimeBackend) State(_, _ string) (agentruntime.SessionStateSnapshot, error) {
+	return b.state, b.stateErr
+}
+
 func TestMapRuntimeErrorPreservesProviderDiagnostics(t *testing.T) {
 	cause := errors.New("provider process rejected request")
 	runtimeErr := &agentruntime.AppError{
@@ -69,6 +84,63 @@ func TestRuntimeControllerProjectsSessionWithoutAliasingMutableInputs(t *testing
 	}
 	if projected.Settings == nil || projected.Settings.Model != "gpt-5.6" || projected.Settings.ReasoningEffort != "max" || projected.Settings.Speed != "standard" {
 		t.Fatalf("projected settings = %#v", projected.Settings)
+	}
+}
+
+func TestRuntimeControllerProjectsProviderEnrichedLiveState(t *testing.T) {
+	backend := &stateRuntimeBackend{
+		session: agentruntime.Session{
+			RoomID: "workspace-1", AgentSessionID: "session-1", Provider: "codex",
+			ProviderSessionID: "base-provider-session", Status: "starting",
+			RuntimeContext:  map[string]any{"base": true},
+			Settings:        &agentruntime.SessionSettings{Model: "base-model"},
+			UpdatedAtUnixMS: 10,
+		},
+		state: agentruntime.SessionStateSnapshot{
+			ProviderSessionID: "live-provider-session",
+			Status:            "ready",
+			Settings: &agentruntime.SessionSettings{
+				Model: "gpt-5.6", ReasoningEffort: "max", Speed: "fast",
+			},
+			RuntimeContext: map[string]any{
+				"account":    map[string]any{"email": "agent@example.com"},
+				"rateLimits": map[string]any{"primary": 42},
+				"usage":      map[string]any{"usedTokens": 1200},
+				"commands":   []string{"compact", "status"},
+			},
+			UpdatedAtUnixMS: 20,
+		},
+	}
+	controller := &RuntimeController{Backend: backend}
+
+	projected, found := controller.Session("workspace-1", "session-1")
+	if !found {
+		t.Fatal("Session() found = false")
+	}
+	if projected.ProviderSessionID != "live-provider-session" || projected.Status != "ready" || projected.UpdatedAtUnixMS != 20 {
+		t.Fatalf("projected live identity/status = %#v", projected)
+	}
+	if projected.Settings == nil || projected.Settings.Model != "gpt-5.6" || projected.Settings.ReasoningEffort != "max" || projected.Settings.Speed != "fast" {
+		t.Fatalf("projected live settings = %#v", projected.Settings)
+	}
+	if projected.RuntimeContext["account"] == nil || projected.RuntimeContext["rateLimits"] == nil || projected.RuntimeContext["usage"] == nil || projected.RuntimeContext["commands"] == nil {
+		t.Fatalf("projected live runtime context = %#v", projected.RuntimeContext)
+	}
+}
+
+func TestRuntimeControllerFallsBackToBaseSessionWhenLiveStateFails(t *testing.T) {
+	backend := &stateRuntimeBackend{
+		session: agentruntime.Session{
+			RoomID: "workspace-1", AgentSessionID: "session-1", Provider: "codex",
+			Status: "starting", RuntimeContext: map[string]any{"base": true},
+		},
+		stateErr: errors.New("state unavailable"),
+	}
+	controller := &RuntimeController{Backend: backend}
+
+	projected, found := controller.Session("workspace-1", "session-1")
+	if !found || projected.Status != "starting" || projected.RuntimeContext["base"] != true {
+		t.Fatalf("Session() = %#v found=%v, want base observation", projected, found)
 	}
 }
 

--- a/packages/agent/daemon/modelcatalog/codex.go
+++ b/packages/agent/daemon/modelcatalog/codex.go
@@ -1,0 +1,214 @@
+package modelcatalog
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ParseCodexModelListLine parses one JSON-RPC stdout line. handled is false
+// for notifications, logs, and responses to other request ids.
+func ParseCodexModelListLine(line []byte, requestID string) ([]ModelOption, bool, error) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(line, &payload); err != nil {
+		return nil, false, nil
+	}
+	if !codexRPCIDMatches(payload["id"], requestID) {
+		return nil, false, nil
+	}
+	if rawError, ok := payload["error"]; ok && string(rawError) != "null" {
+		return nil, true, errors.New(extractCodexRPCError(rawError))
+	}
+	var result struct {
+		Data []json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(payload["result"], &result); err != nil {
+		return nil, true, fmt.Errorf("parse codex model/list result: %w", err)
+	}
+	models := make([]ModelOption, 0, len(result.Data))
+	for _, rawModel := range result.Data {
+		if model, ok := NormalizeCodexModel(rawModel); ok {
+			models = append(models, model)
+		}
+	}
+	return models, true, nil
+}
+
+func NormalizeCodexModel(raw json.RawMessage) (ModelOption, bool) {
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return ModelOption{}, false
+	}
+	id := firstNonBlank(stringMapValue(object, "model"), stringMapValue(object, "id"))
+	if id == "" {
+		return ModelOption{}, false
+	}
+	displayName := firstNonBlank(stringMapValue(object, "displayName"), stringMapValue(object, "display_name"), id)
+	reasoningValue, reasoningAdvertised := advertisedValue(object, "supportedReasoningEfforts", "supported_reasoning_efforts")
+	speedValue, speedAdvertised := advertisedValue(object, "serviceTiers", "service_tiers")
+	legacySpeedValue, legacySpeedAdvertised := advertisedValue(object, "additionalSpeedTiers", "additional_speed_tiers")
+	speeds := normalizeCodexSpeeds(speedValue, legacySpeedValue)
+	defaultSpeed := canonicalCodexSpeed(firstNonBlank(stringMapValue(object, "defaultServiceTier"), stringMapValue(object, "default_service_tier")))
+	defaultSpeed = validSpeedDefault(speeds, defaultSpeed)
+	return ModelOption{
+		ID:                         id,
+		DisplayName:                displayName,
+		Description:                stringMapValue(object, "description"),
+		DefaultReasoningEffort:     firstNonBlank(stringMapValue(object, "defaultReasoningEffort"), stringMapValue(object, "default_reasoning_effort")),
+		DefaultSpeed:               defaultSpeed,
+		IsDefault:                  boolMapValue(object, "isDefault") || boolMapValue(object, "is_default"),
+		ReasoningEffortsAdvertised: reasoningAdvertised,
+		SupportedReasoningEfforts:  normalizeCodexReasoningEfforts(reasoningValue),
+		SpeedsAdvertised:           speedAdvertised || legacySpeedAdvertised,
+		SupportedSpeeds:            speeds,
+		SupportsImageInput:         codexImageInputSupport(object),
+	}, true
+}
+
+func normalizeCodexReasoningEfforts(value any) []ReasoningEffortOption {
+	rawOptions, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	options := make([]ReasoningEffortOption, 0, len(rawOptions))
+	seen := make(map[string]struct{}, len(rawOptions))
+	for _, rawOption := range rawOptions {
+		var option ReasoningEffortOption
+		switch typed := rawOption.(type) {
+		case string:
+			option.Value = strings.TrimSpace(typed)
+		case map[string]any:
+			option.Value = firstNonBlank(stringMapValue(typed, "reasoningEffort"), stringMapValue(typed, "effort"), stringMapValue(typed, "value"))
+			option.Label = firstNonBlank(stringMapValue(typed, "label"), stringMapValue(typed, "name"))
+			option.Description = stringMapValue(typed, "description")
+		}
+		if option.Value == "" {
+			continue
+		}
+		if _, exists := seen[option.Value]; exists {
+			continue
+		}
+		seen[option.Value] = struct{}{}
+		options = append(options, option)
+	}
+	return options
+}
+
+func normalizeCodexSpeeds(values ...any) []SpeedOption {
+	options := []SpeedOption{{Value: "standard", Label: "Standard"}}
+	seen := map[string]struct{}{"standard": {}}
+	for _, rawValue := range values {
+		rawOptions, ok := rawValue.([]any)
+		if !ok {
+			continue
+		}
+		for _, rawOption := range rawOptions {
+			var option SpeedOption
+			switch typed := rawOption.(type) {
+			case string:
+				option.Value = canonicalCodexSpeed(typed)
+			case map[string]any:
+				option.Value = canonicalCodexSpeed(stringMapValue(typed, "id"))
+				option.Label = stringMapValue(typed, "name")
+				option.Description = stringMapValue(typed, "description")
+			}
+			if option.Value == "" {
+				continue
+			}
+			if _, exists := seen[option.Value]; exists {
+				continue
+			}
+			seen[option.Value] = struct{}{}
+			options = append(options, option)
+		}
+	}
+	return options
+}
+
+func canonicalCodexSpeed(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "default", "standard":
+		return "standard"
+	case "priority", "fast":
+		return "fast"
+	default:
+		return strings.TrimSpace(value)
+	}
+}
+
+func codexImageInputSupport(object map[string]any) *bool {
+	raw, advertised := object["inputModalities"]
+	if !advertised {
+		raw, advertised = object["input_modalities"]
+	}
+	if !advertised {
+		return nil
+	}
+	modalities, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	supported := false
+	for _, modality := range modalities {
+		if value, ok := modality.(string); ok && strings.EqualFold(strings.TrimSpace(value), "image") {
+			supported = true
+			break
+		}
+	}
+	return &supported
+}
+
+func advertisedValue(object map[string]any, keys ...string) (any, bool) {
+	for _, key := range keys {
+		if value, ok := object[key]; ok {
+			return value, true
+		}
+	}
+	return nil, false
+}
+
+func codexRPCIDMatches(raw json.RawMessage, want string) bool {
+	var stringID string
+	if err := json.Unmarshal(raw, &stringID); err == nil {
+		return stringID == want
+	}
+	var numberID int
+	if err := json.Unmarshal(raw, &numberID); err == nil {
+		return fmt.Sprintf("%d", numberID) == want
+	}
+	return false
+}
+
+func extractCodexRPCError(raw json.RawMessage) string {
+	var message string
+	if err := json.Unmarshal(raw, &message); err == nil && strings.TrimSpace(message) != "" {
+		return strings.TrimSpace(message)
+	}
+	var object struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(raw, &object); err == nil && strings.TrimSpace(object.Message) != "" {
+		return strings.TrimSpace(object.Message)
+	}
+	return "unknown codex app-server RPC error"
+}
+
+func stringMapValue(object map[string]any, key string) string {
+	value, _ := object[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func boolMapValue(object map[string]any, key string) bool {
+	value, ok := object[key].(bool)
+	return ok && value
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/packages/agent/daemon/modelcatalog/codex_test.go
+++ b/packages/agent/daemon/modelcatalog/codex_test.go
@@ -1,0 +1,91 @@
+package modelcatalog
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseCodexModelListLinePreservesPerModelCapabilities(t *testing.T) {
+	models, handled, err := ParseCodexModelListLine([]byte(`{
+  "id":"2",
+  "result":{"data":[{
+    "id":"gpt-5.6-sol",
+    "model":"gpt-5.6-sol",
+    "displayName":"GPT-5.6-Sol",
+    "description":"Latest frontier agentic coding model.",
+    "supportedReasoningEfforts":[
+      {"reasoningEffort":"low","description":"Fast responses"},
+      {"reasoningEffort":"medium","description":"Balanced"},
+      {"reasoningEffort":"high","description":"Greater depth"},
+      {"reasoningEffort":"xhigh","description":"Extra high"},
+      {"reasoningEffort":"max","description":"Maximum"},
+      {"reasoningEffort":"ultra","description":"Automatic delegation"}
+    ],
+    "defaultReasoningEffort":"low",
+    "additionalSpeedTiers":["fast"],
+    "defaultServiceTier":null,
+    "inputModalities":["text","image"],
+    "isDefault":true
+  }]}
+}`), "2")
+	if err != nil || !handled || len(models) != 1 {
+		t.Fatalf("ParseCodexModelListLine() = (%#v, %v, %v)", models, handled, err)
+	}
+	model := models[0]
+	efforts := make([]string, 0, len(model.SupportedReasoningEfforts))
+	for _, option := range model.SupportedReasoningEfforts {
+		efforts = append(efforts, option.Value)
+	}
+	if !reflect.DeepEqual(efforts, []string{"low", "medium", "high", "xhigh", "max", "ultra"}) {
+		t.Fatalf("reasoning efforts = %#v", efforts)
+	}
+	if model.DefaultReasoningEffort != "low" || !model.ReasoningEffortsAdvertised {
+		t.Fatalf("reasoning defaults = %#v", model)
+	}
+	speeds := make([]string, 0, len(model.SupportedSpeeds))
+	for _, option := range model.SupportedSpeeds {
+		speeds = append(speeds, option.Value)
+	}
+	if !reflect.DeepEqual(speeds, []string{"standard", "fast"}) || model.DefaultSpeed != "standard" {
+		t.Fatalf("speed profile = %#v", model)
+	}
+	if model.SupportsImageInput == nil || !*model.SupportsImageInput {
+		t.Fatalf("image input support = %#v", model.SupportsImageInput)
+	}
+}
+
+func TestNormalizeCodexModelDistinguishesMissingAndEmptyReasoningCatalog(t *testing.T) {
+	missing, ok := NormalizeCodexModel([]byte(`{"id":"missing"}`))
+	if !ok || missing.ReasoningEffortsAdvertised {
+		t.Fatalf("missing reasoning catalog = %#v, %v", missing, ok)
+	}
+	empty, ok := NormalizeCodexModel([]byte(`{"id":"empty","supportedReasoningEfforts":[]}`))
+	if !ok || !empty.ReasoningEffortsAdvertised || len(empty.SupportedReasoningEfforts) != 0 {
+		t.Fatalf("empty reasoning catalog = %#v, %v", empty, ok)
+	}
+}
+
+func TestNormalizeCodexModelUsesServiceTierCatalog(t *testing.T) {
+	model, ok := NormalizeCodexModel([]byte(`{
+  "id":"gpt-5.6-sol",
+  "serviceTiers":[{"id":"priority","name":"Fast","description":"Lower latency"}],
+  "defaultServiceTier":"priority"
+}`))
+	if !ok || !model.SpeedsAdvertised || model.DefaultSpeed != "fast" {
+		t.Fatalf("model = %#v, ok = %v", model, ok)
+	}
+	speeds := make([]string, 0, len(model.SupportedSpeeds))
+	for _, option := range model.SupportedSpeeds {
+		speeds = append(speeds, option.Value)
+	}
+	if !reflect.DeepEqual(speeds, []string{"standard", "fast"}) {
+		t.Fatalf("speeds = %#v", speeds)
+	}
+}
+
+func TestParseCodexModelListLineIgnoresOtherResponses(t *testing.T) {
+	models, handled, err := ParseCodexModelListLine([]byte(`{"id":"1","result":{}}`), "2")
+	if err != nil || handled || models != nil {
+		t.Fatalf("other response = (%#v, %v, %v)", models, handled, err)
+	}
+}

--- a/packages/agent/daemon/modelcatalog/composer_projection.go
+++ b/packages/agent/daemon/modelcatalog/composer_projection.go
@@ -1,0 +1,39 @@
+package modelcatalog
+
+import "strings"
+
+// ComposerCatalogProjection is the provider-neutral projection of a model
+// catalog into the model, reasoning, and speed dimensions exposed by a
+// composer. Product services remain responsible only for localization and
+// transport DTOs.
+type ComposerCatalogProjection struct {
+	Selection               ModelSelection
+	ReasoningOptionsByModel map[string]ReasoningProfile
+}
+
+type ReasoningProfile struct {
+	DefaultValue string
+	Options      []ReasoningEffortOption
+}
+
+// ProjectComposerCatalog preserves every model's advertised capabilities and
+// resolves the effective model in one shared owner. Callers must not replace an
+// advertised empty capability set with provider-wide static options.
+func ProjectComposerCatalog(models []ModelOption, requestedModel string) ComposerCatalogProjection {
+	projection := ComposerCatalogProjection{
+		Selection:               SelectModel(models, requestedModel),
+		ReasoningOptionsByModel: make(map[string]ReasoningProfile),
+	}
+	for _, model := range models {
+		modelID := strings.TrimSpace(model.ID)
+		if modelID == "" || !model.ReasoningEffortsAdvertised {
+			continue
+		}
+		options := append([]ReasoningEffortOption(nil), model.SupportedReasoningEfforts...)
+		projection.ReasoningOptionsByModel[modelID] = ReasoningProfile{
+			DefaultValue: validReasoningDefault(options, model.DefaultReasoningEffort),
+			Options:      options,
+		}
+	}
+	return projection
+}

--- a/packages/agent/daemon/modelcatalog/composer_projection_test.go
+++ b/packages/agent/daemon/modelcatalog/composer_projection_test.go
@@ -1,0 +1,59 @@
+package modelcatalog
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestProjectComposerCatalogPreservesSelectedModelCapabilities(t *testing.T) {
+	models := []ModelOption{
+		{
+			ID:                         "gpt-5.6",
+			IsDefault:                  true,
+			ReasoningEffortsAdvertised: true,
+			DefaultReasoningEffort:     "high",
+			SupportedReasoningEfforts: []ReasoningEffortOption{
+				{Value: "low"}, {Value: "medium"}, {Value: "high"},
+				{Value: "xhigh"}, {Value: "max"}, {Value: "ultra"},
+			},
+			SpeedsAdvertised: true,
+			DefaultSpeed:     "standard",
+			SupportedSpeeds:  []SpeedOption{{Value: "standard"}, {Value: "fast"}},
+		},
+	}
+
+	projection := ProjectComposerCatalog(models, "")
+	if !projection.Selection.Found || projection.Selection.Model.ID != "gpt-5.6" {
+		t.Fatalf("selection = %#v", projection.Selection)
+	}
+	if projection.Selection.DefaultSpeed != "standard" {
+		t.Fatalf("default speed = %q, want standard", projection.Selection.DefaultSpeed)
+	}
+	wantReasoning := []string{"low", "medium", "high", "xhigh", "max", "ultra"}
+	gotReasoning := make([]string, 0, len(projection.Selection.ReasoningEfforts))
+	for _, option := range projection.Selection.ReasoningEfforts {
+		gotReasoning = append(gotReasoning, option.Value)
+	}
+	if !reflect.DeepEqual(gotReasoning, wantReasoning) {
+		t.Fatalf("reasoning = %#v, want %#v", gotReasoning, wantReasoning)
+	}
+	profile := projection.ReasoningOptionsByModel["gpt-5.6"]
+	if profile.DefaultValue != "high" || len(profile.Options) != len(wantReasoning) {
+		t.Fatalf("reasoning profile = %#v", profile)
+	}
+}
+
+func TestProjectComposerCatalogPreservesAdvertisedEmptyCapabilities(t *testing.T) {
+	projection := ProjectComposerCatalog([]ModelOption{{
+		ID:                         "catalog-owned",
+		ReasoningEffortsAdvertised: true,
+	}}, "catalog-owned")
+
+	profile, found := projection.ReasoningOptionsByModel["catalog-owned"]
+	if !found || len(profile.Options) != 0 || profile.DefaultValue != "" {
+		t.Fatalf("profile = %#v, found=%v", profile, found)
+	}
+	if !projection.Selection.ReasoningEffortsAdvertised || len(projection.Selection.ReasoningEfforts) != 0 {
+		t.Fatalf("selection = %#v", projection.Selection)
+	}
+}

--- a/packages/agent/daemon/modelcatalog/selection.go
+++ b/packages/agent/daemon/modelcatalog/selection.go
@@ -1,0 +1,90 @@
+package modelcatalog
+
+import "strings"
+
+// SelectModel resolves one effective model and projects only that model's
+// reasoning and speed capabilities. A non-empty requested value remains the
+// effective model even when a provider omits it from a partial catalog; in
+// that case its capabilities are intentionally unadvertised. Without a
+// request, the catalog default, then the first model, wins.
+func SelectModel(models []ModelOption, requested string) ModelSelection {
+	selected, found := effectiveModel(models, requested)
+	if !found {
+		return ModelSelection{}
+	}
+	selection := ModelSelection{
+		Model:                      cloneModelOption(selected),
+		Found:                      true,
+		ReasoningEffortsAdvertised: selected.ReasoningEffortsAdvertised,
+		ReasoningEfforts:           append([]ReasoningEffortOption(nil), selected.SupportedReasoningEfforts...),
+		SpeedsAdvertised:           selected.SpeedsAdvertised,
+		Speeds:                     append([]SpeedOption(nil), selected.SupportedSpeeds...),
+	}
+	selection.DefaultReasoningEffort = validReasoningDefault(selection.ReasoningEfforts, selected.DefaultReasoningEffort)
+	selection.DefaultSpeed = validSpeedDefault(selection.Speeds, selected.DefaultSpeed)
+	return selection
+}
+
+func effectiveModel(models []ModelOption, requested string) (ModelOption, bool) {
+	requested = strings.TrimSpace(requested)
+	if requested != "" {
+		for _, model := range models {
+			if strings.TrimSpace(model.ID) == requested {
+				return model, true
+			}
+		}
+		return ModelOption{ID: requested, DisplayName: requested}, true
+	}
+	for _, model := range models {
+		if model.IsDefault && strings.TrimSpace(model.ID) != "" {
+			return model, true
+		}
+	}
+	for _, model := range models {
+		if strings.TrimSpace(model.ID) != "" {
+			return model, true
+		}
+	}
+	return ModelOption{}, false
+}
+
+func validReasoningDefault(options []ReasoningEffortOption, requested string) string {
+	requested = strings.TrimSpace(requested)
+	for _, option := range options {
+		if strings.TrimSpace(option.Value) == requested && requested != "" {
+			return requested
+		}
+	}
+	for _, option := range options {
+		if option.Default && strings.TrimSpace(option.Value) != "" {
+			return strings.TrimSpace(option.Value)
+		}
+	}
+	if len(options) > 0 {
+		return strings.TrimSpace(options[0].Value)
+	}
+	return ""
+}
+
+func validSpeedDefault(options []SpeedOption, requested string) string {
+	requested = strings.TrimSpace(requested)
+	for _, option := range options {
+		if strings.TrimSpace(option.Value) == requested && requested != "" {
+			return requested
+		}
+	}
+	if len(options) > 0 {
+		return strings.TrimSpace(options[0].Value)
+	}
+	return ""
+}
+
+func cloneModelOption(model ModelOption) ModelOption {
+	model.SupportedReasoningEfforts = append([]ReasoningEffortOption(nil), model.SupportedReasoningEfforts...)
+	model.SupportedSpeeds = append([]SpeedOption(nil), model.SupportedSpeeds...)
+	if model.SupportsImageInput != nil {
+		value := *model.SupportsImageInput
+		model.SupportsImageInput = &value
+	}
+	return model
+}

--- a/packages/agent/daemon/modelcatalog/selection_test.go
+++ b/packages/agent/daemon/modelcatalog/selection_test.go
@@ -1,0 +1,46 @@
+package modelcatalog
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSelectModelProjectsOnlyEffectiveModelCapabilities(t *testing.T) {
+	models := []ModelOption{
+		{ID: "default", IsDefault: true, ReasoningEffortsAdvertised: true, SupportedReasoningEfforts: []ReasoningEffortOption{{Value: "medium"}}, DefaultReasoningEffort: "medium"},
+		{
+			ID: "gpt-5.6-sol", ReasoningEffortsAdvertised: true,
+			SupportedReasoningEfforts: []ReasoningEffortOption{{Value: "low"}, {Value: "medium"}, {Value: "high"}, {Value: "xhigh"}, {Value: "max"}, {Value: "ultra"}},
+			DefaultReasoningEffort:    "low", SpeedsAdvertised: true,
+			SupportedSpeeds: []SpeedOption{{Value: "standard"}, {Value: "fast"}}, DefaultSpeed: "standard",
+		},
+	}
+	selection := SelectModel(models, "gpt-5.6-sol")
+	if !selection.Found || selection.Model.ID != "gpt-5.6-sol" {
+		t.Fatalf("selection = %#v", selection)
+	}
+	efforts := make([]string, 0, len(selection.ReasoningEfforts))
+	for _, option := range selection.ReasoningEfforts {
+		efforts = append(efforts, option.Value)
+	}
+	if !reflect.DeepEqual(efforts, []string{"low", "medium", "high", "xhigh", "max", "ultra"}) {
+		t.Fatalf("efforts = %#v", efforts)
+	}
+	if selection.DefaultReasoningEffort != "low" || selection.DefaultSpeed != "standard" {
+		t.Fatalf("defaults = %#v", selection)
+	}
+}
+
+func TestSelectModelPreservesAdvertisedEmptyReasoning(t *testing.T) {
+	selection := SelectModel([]ModelOption{{ID: "plain", IsDefault: true, ReasoningEffortsAdvertised: true}}, "")
+	if !selection.Found || !selection.ReasoningEffortsAdvertised || selection.ReasoningEfforts != nil || selection.DefaultReasoningEffort != "" {
+		t.Fatalf("selection = %#v", selection)
+	}
+}
+
+func TestSelectModelPreservesRequestedModelMissingFromPartialCatalog(t *testing.T) {
+	selection := SelectModel([]ModelOption{{ID: "default", IsDefault: true}}, "custom")
+	if !selection.Found || selection.Model.ID != "custom" || selection.ReasoningEffortsAdvertised || selection.SpeedsAdvertised {
+		t.Fatalf("selection = %#v", selection)
+	}
+}

--- a/packages/agent/daemon/modelcatalog/types.go
+++ b/packages/agent/daemon/modelcatalog/types.go
@@ -1,0 +1,44 @@
+// Package modelcatalog owns provider-neutral model capability descriptors and
+// provider protocol parsers. Process launch and caching remain host adapters.
+package modelcatalog
+
+type ReasoningEffortOption struct {
+	Default     bool
+	Description string
+	Label       string
+	Value       string
+}
+
+type SpeedOption struct {
+	Description string
+	Label       string
+	Value       string
+}
+
+type ModelOption struct {
+	ID                         string
+	DisplayName                string
+	Description                string
+	DefaultReasoningEffort     string
+	DefaultSpeed               string
+	IsDefault                  bool
+	ReasoningEffortsAdvertised bool
+	SupportedReasoningEfforts  []ReasoningEffortOption
+	SpeedsAdvertised           bool
+	SupportedSpeeds            []SpeedOption
+	SupportsImageInput         *bool
+}
+
+// ModelSelection is the capability projection for the effective model. Field
+// presence is preserved so callers can distinguish an explicitly empty
+// provider catalog from a provider that did not advertise that capability.
+type ModelSelection struct {
+	Model                      ModelOption
+	Found                      bool
+	ReasoningEffortsAdvertised bool
+	ReasoningEfforts           []ReasoningEffortOption
+	DefaultReasoningEffort     string
+	SpeedsAdvertised           bool
+	Speeds                     []SpeedOption
+	DefaultSpeed               string
+}

--- a/packages/agent/daemon/providerregistry/claude_code.go
+++ b/packages/agent/daemon/providerregistry/claude_code.go
@@ -78,6 +78,8 @@ func claudeCodeDescriptor() ProviderDescriptor {
 			ReasoningEffortOptions: ReasoningEffortOptionsStatic,
 			DefaultReasoningEffort: "high",
 			Speed:                  true,
+			SpeedValues:            []string{"standard", "fast"},
+			DefaultSpeed:           "standard",
 			Capabilities: []string{
 				"imageInput",
 				"skills",

--- a/packages/agent/daemon/providerregistry/codex.go
+++ b/packages/agent/daemon/providerregistry/codex.go
@@ -92,6 +92,7 @@ func codexDescriptor() ProviderDescriptor {
 				CapabilityPlanMode,
 				CapabilityInterrupt,
 				CapabilityActiveTurnGuidance,
+				CapabilityGoalPause,
 				CapabilityModelPlanBinding,
 				CapabilityPlanImplementation,
 				CapabilityPermissionModeChangeDuringTurn,

--- a/packages/agent/daemon/providerregistry/codex.go
+++ b/packages/agent/daemon/providerregistry/codex.go
@@ -83,6 +83,8 @@ func codexDescriptor() ProviderDescriptor {
 			DefaultReasoningEffort:  "high",
 			ConfiguredModelOverride: ConfiguredModelOverrideCodexCustomProvider,
 			Speed:                   true,
+			SpeedValues:             []string{"standard", "fast"},
+			DefaultSpeed:            "standard",
 			Capabilities: []string{
 				CapabilityImageInput,
 				CapabilitySkills,

--- a/packages/agent/daemon/providerregistry/providers.go
+++ b/packages/agent/daemon/providerregistry/providers.go
@@ -70,6 +70,7 @@ func tuttiAgentDescriptor() ProviderDescriptor {
 		},
 		ComposerProfile: ComposerProfileDescriptor{
 			ModelSelection: true, ModelCatalog: ModelCatalogKindTuttiCLI, ReasoningEffort: true, ReasoningEffortOptions: ReasoningEffortOptionsModelCatalog, DefaultReasoningEffort: "high", Speed: true,
+			SpeedValues: []string{"standard", "fast"}, DefaultSpeed: "standard",
 			Capabilities: []string{CapabilityImageInput, CapabilitySkills, CapabilityCompact, CapabilityTokenUsage, CapabilityRateLimits, CapabilityPlanMode, CapabilityInterrupt, CapabilityActiveTurnGuidance, CapabilityModelPlanBinding}, PermissionConfigurable: true, DefaultPermissionModeID: "auto",
 			PermissionModes: []PermissionModeDescriptor{{ID: "read-only", Semantic: "ask-before-write"}, {ID: "auto", Semantic: "auto"}, {ID: "full-access", Semantic: "full-access"}}, ConfigOptionIDs: ComposerConfigOptionIDs{Model: "model", Reasoning: "reasoning_effort", Speed: "service_tier", Permission: "mode"},
 		},

--- a/packages/agent/daemon/providerregistry/registry.go
+++ b/packages/agent/daemon/providerregistry/registry.go
@@ -457,6 +457,20 @@ func Validate(descriptor ProviderDescriptor) error {
 	} else if descriptor.ComposerProfile.ReasoningEffortOptions != "" {
 		return fmt.Errorf("provider %q reasoning option source requires reasoning support", providerID)
 	}
+	if descriptor.ComposerProfile.Speed {
+		if err := validateUniqueNonBlankStrings(descriptor.ComposerProfile.SpeedValues); err != nil {
+			return fmt.Errorf("provider %q speed values: %w", providerID, err)
+		}
+		if len(descriptor.ComposerProfile.SpeedValues) == 0 {
+			return fmt.Errorf("provider %q speed support requires values", providerID)
+		}
+		defaultSpeed := strings.TrimSpace(descriptor.ComposerProfile.DefaultSpeed)
+		if !containsNormalized(descriptor.ComposerProfile.SpeedValues, defaultSpeed) {
+			return fmt.Errorf("provider %q default speed %q is not declared", providerID, defaultSpeed)
+		}
+	} else if len(descriptor.ComposerProfile.SpeedValues) != 0 || strings.TrimSpace(descriptor.ComposerProfile.DefaultSpeed) != "" {
+		return fmt.Errorf("provider %q speed values require speed support", providerID)
+	}
 	if err := validateUniqueNonBlankStrings(descriptor.ComposerProfile.Capabilities); err != nil {
 		return fmt.Errorf("provider %q capabilities: %w", providerID, err)
 	}

--- a/packages/agent/daemon/providerregistry/registry_clone.go
+++ b/packages/agent/daemon/providerregistry/registry_clone.go
@@ -20,6 +20,7 @@ func cloneDescriptor(value ProviderDescriptor) ProviderDescriptor {
 	value.Status.Install.FailureReasonMarkers = cloneStringSliceMap(value.Status.Install.FailureReasonMarkers)
 	value.Status.AuthWatch.Sources = cloneAuthWatchSources(value.Status.AuthWatch.Sources)
 	value.ComposerProfile.ReasoningEffortValues = append([]string(nil), value.ComposerProfile.ReasoningEffortValues...)
+	value.ComposerProfile.SpeedValues = append([]string(nil), value.ComposerProfile.SpeedValues...)
 	value.ComposerProfile.Capabilities = append([]string(nil), value.ComposerProfile.Capabilities...)
 	value.ComposerProfile.PermissionModes = append([]PermissionModeDescriptor(nil), value.ComposerProfile.PermissionModes...)
 	value.ComposerProfile.SlashCommandPolicy.FallbackCommands = append([]string(nil), value.ComposerProfile.SlashCommandPolicy.FallbackCommands...)

--- a/packages/agent/daemon/providerregistry/registry_test.go
+++ b/packages/agent/daemon/providerregistry/registry_test.go
@@ -126,6 +126,9 @@ func TestMigratedCodexDescriptorIsComplete(t *testing.T) {
 	if descriptor.ComposerProfile.CapabilityCatalog.Kind != CapabilityCatalogKindCodexAppServer {
 		t.Fatalf("CapabilityCatalog = %#v", descriptor.ComposerProfile.CapabilityCatalog)
 	}
+	if !slices.Contains(descriptor.ComposerProfile.Capabilities, CapabilityGoalPause) {
+		t.Fatalf("Composer capabilities missing Codex goal pause: %#v", descriptor.ComposerProfile.Capabilities)
+	}
 	effects := descriptor.ComposerProfile.SlashCommandPolicy.CommandEffects
 	if len(effects) != 7 {
 		t.Fatalf("SlashCommandPolicy = %#v", descriptor.ComposerProfile.SlashCommandPolicy)

--- a/packages/agent/daemon/providerregistry/registry_test.go
+++ b/packages/agent/daemon/providerregistry/registry_test.go
@@ -115,6 +115,9 @@ func TestMigratedCodexDescriptorIsComplete(t *testing.T) {
 	if descriptor.ComposerProfile.ConfigOptionIDs.Speed != "service_tier" {
 		t.Fatalf("Speed config option = %q", descriptor.ComposerProfile.ConfigOptionIDs.Speed)
 	}
+	if !slices.Equal(descriptor.ComposerProfile.SpeedValues, []string{"standard", "fast"}) || descriptor.ComposerProfile.DefaultSpeed != "standard" {
+		t.Fatalf("Speed profile = %#v, default %q", descriptor.ComposerProfile.SpeedValues, descriptor.ComposerProfile.DefaultSpeed)
+	}
 	if descriptor.Status.MinVersion != CodexMinVersion {
 		t.Fatalf("Status.MinVersion = %q", descriptor.Status.MinVersion)
 	}

--- a/packages/agent/daemon/providerregistry/types.go
+++ b/packages/agent/daemon/providerregistry/types.go
@@ -444,6 +444,8 @@ type ComposerProfileDescriptor struct {
 	DefaultReasoningEffort  string
 	ConfiguredModelOverride ConfiguredModelOverrideKind
 	Speed                   bool
+	SpeedValues             []string
+	DefaultSpeed            string
 	Capabilities            []string
 	PermissionConfigurable  bool
 	DefaultPermissionModeID string

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -214,7 +214,7 @@ type codexAppServerSession struct {
 	// session. Once bounded evidence can no longer preserve ambiguity, no later
 	// notification may rebuild a partial cache and become adoptable.
 	provenanceDegraded bool
-	// goalMutationMu is the provider-side half of GoalActor. It serializes
+	// goalMutationMu is the provider-side half of the Host goal mutation lane. It serializes
 	// direct control, reconcile and delayed continuation nudges for this thread.
 	goalMutationMu         sync.Mutex
 	models                 []map[string]any

--- a/packages/agent/daemon/runtime/codex_appserver_goal_provenance.go
+++ b/packages/agent/daemon/runtime/codex_appserver_goal_provenance.go
@@ -759,7 +759,7 @@ func (a *CodexAppServerAdapter) quiesceUnprovenGoalTurn(session Session, provide
 			)
 			_ = client.Close()
 		}
-		// The durable GoalActor is notified only after exact quiesce has
+		// The durable Host goal mutation lane is notified only after exact quiesce has
 		// completed. Failed quiesce is explicit evidence: the service attaches
 		// repair work and must not mark the observation converged.
 		if finalizeErr := a.reportGoalReconcileRequired(session, requestID, providerTurnID, reason, fenceMode, current, "finalized", quiesceErr); finalizeErr != nil {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.interactiveHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.interactiveHelpers.spec.ts
@@ -131,6 +131,34 @@ describe("AgentGUI user-project snapshot projection", () => {
     ).toBe(false);
   });
 
+  it.each(["createdAtUnixMs", "updatedAtUnixMs", "lastUsedAtUnixMs"] as const)(
+    "treats a %s-only change as a new AgentGUI snapshot",
+    (field) => {
+      expect(
+        areAgentGUIUserProjectsEqual(
+          [
+            {
+              id: "alpha",
+              label: "Alpha",
+              path: "/alpha",
+              pinnedAtUnixMs: 0,
+              [field]: 10
+            }
+          ],
+          [
+            {
+              id: "alpha",
+              label: "Alpha",
+              path: "/alpha",
+              pinnedAtUnixMs: 0,
+              [field]: 20
+            }
+          ]
+        )
+      ).toBe(false);
+    }
+  );
+
   it("keeps sectionKey when a use result is upserted", () => {
     expect(
       upsertAgentGUIUserProject([], {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.interactiveHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.interactiveHelpers.ts
@@ -146,7 +146,10 @@ export function areAgentGUIUserProjectsEqual(
         project.path === candidate.path &&
         project.label === candidate.label &&
         project.sectionKey === candidate.sectionKey &&
-        project.pinnedAtUnixMs === candidate.pinnedAtUnixMs
+        project.pinnedAtUnixMs === candidate.pinnedAtUnixMs &&
+        project.createdAtUnixMs === candidate.createdAtUnixMs &&
+        project.updatedAtUnixMs === candidate.updatedAtUnixMs &&
+        project.lastUsedAtUnixMs === candidate.lastUsedAtUnixMs
       );
     })
   );

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationActivation.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationActivation.types.ts
@@ -31,6 +31,9 @@ export interface UseAgentGUINewConversationActivationInput {
     (updater: (current: AgentGUINodeData) => AgentGUINodeData) => void
   >;
   selectedProjectPathRef: RefObject<string | null>;
+  userProjectsRef: RefObject<
+    import("../../../host/agentHostApi").AgentHostUserProject[]
+  >;
   draftByScopeKeyRef: RefObject<Record<string, AgentComposerDraft>>;
   submittedDraftSnapshotsRef: RefObject<Record<string, SubmittedDraftSnapshot>>;
   draftSettingsBySessionIdRef: RefObject<

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActivation.ts
@@ -20,6 +20,7 @@ interface AgentGUIActivateInputBase {
   cwd?: string;
   initialContent?: AgentPromptContentBlock[];
   initialTurnExpected?: boolean;
+  railSectionKey?: string;
   initialDisplayPrompt?: string;
   runtimeContent?: AgentPromptContentBlock[];
   submitDiagnostics?: AgentActivitySubmitDiagnostics;
@@ -121,6 +122,9 @@ export function useAgentGUIActivation({
         expiresAtUnixMs: requestedAtUnixMs + ACTIVATION_EXPIRY_MS,
         ...(input.initialTurnExpected !== undefined
           ? { initialTurnExpected: input.initialTurnExpected }
+          : {}),
+        ...(input.railSectionKey?.trim()
+          ? { railSectionKey: input.railSectionKey.trim() }
           : {}),
         ...(input.initialDisplayPrompt
           ? { initialDisplayPrompt: input.initialDisplayPrompt }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationBatchDeletion.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationBatchDeletion.spec.tsx
@@ -56,6 +56,7 @@ describe("useAgentGUIConversationBatchDeletion", () => {
       workspaceId: "workspace-1"
     }));
     const deleteSessionsBatch = vi.fn(async () => ({
+      cleanupFailedSessionIds: [],
       removedMessages: 1,
       removedSessionIds: ["loaded-session", "unloaded-session"],
       removedSessions: 2
@@ -140,6 +141,7 @@ describe("useAgentGUIConversationBatchDeletion", () => {
     const deleteSessionsBatch = vi.fn(async () => {
       activeConversationIdObservedByDelete = committedActiveConversationId;
       return {
+        cleanupFailedSessionIds: [],
         removedMessages: 0,
         removedSessionIds: ["loaded-session"],
         removedSessions: 1

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationBatchDeletion.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationBatchDeletion.ts
@@ -206,6 +206,37 @@ export function useAgentGUIConversationBatchDeletion(
         workspaceId
       })
         .then((result) => {
+          if (result.cleanupFailedSessionIds.length > 0) {
+            try {
+              void Promise.resolve(
+                agentActivityRuntime.reportDiagnostic?.({
+                  details: {
+                    cleanupFailedSessionIds: result.cleanupFailedSessionIds
+                  },
+                  event: "agent.gui.conversation_delete.cleanup_failed",
+                  level: "warn",
+                  source: "agent-gui",
+                  workspaceId
+                })
+              ).catch((error) => {
+                console.error(
+                  "[agent-gui-cleanup-diagnostic]",
+                  JSON.stringify({
+                    error: getAgentGUIErrorMessage(error),
+                    workspaceId
+                  })
+                );
+              });
+            } catch (error) {
+              console.error(
+                "[agent-gui-cleanup-diagnostic]",
+                JSON.stringify({
+                  error: getAgentGUIErrorMessage(error),
+                  workspaceId
+                })
+              );
+            }
+          }
           const removedIds = new Set([
             ...targetIds,
             ...result.removedSessionIds

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDeletion.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDeletion.spec.tsx
@@ -65,6 +65,7 @@ describe("useAgentGUIConversationDeletion", () => {
     const deleteSession = vi.fn(async () => {
       activeConversationIdObservedByDelete = committedActiveConversationId;
       return {
+        cleanupFailed: false,
         removed: true,
         removedMessages: 0
       };

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.spec.tsx
@@ -57,7 +57,18 @@ describe("useAgentGUINewConversationActivation", () => {
         setDetailError: vi.fn(),
         isCreatingConversationRef: { current: false },
         onDataChangeRef: { current: vi.fn() },
-        selectedProjectPathRef: { current: null },
+        selectedProjectPathRef: { current: "/workspace" },
+        userProjectsRef: {
+          current: [
+            {
+              id: "project-1",
+              label: "Workspace",
+              path: "/workspace",
+              pinnedAtUnixMs: 0,
+              sectionKey: "project:/workspace"
+            }
+          ]
+        },
         draftByScopeKeyRef: { current: {} },
         submittedDraftSnapshotsRef: { current: {} },
         draftSettingsBySessionIdRef: { current: {} },
@@ -121,7 +132,8 @@ describe("useAgentGUINewConversationActivation", () => {
     expect(activate.mock.calls[0]?.[0]).toMatchObject({
       initialContent: [{ type: "text", text: "$review-code inspect this" }],
       initialDisplayPrompt: "/review-code inspect this",
-      optimisticTitle: "/review-code inspect this"
+      optimisticTitle: "/review-code inspect this",
+      railSectionKey: "project:/workspace"
     });
     expect(activate.mock.calls[0]?.[0].settings).toMatchObject({
       computerUse: true

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
@@ -30,6 +30,7 @@ import {
   type UseAgentGUINewConversationActivationInput
 } from "./agentGuiNewConversationActivation.types";
 import { resolveAgentComposerDraftScopeKey } from "../model/agentComposerDraftScope";
+import { resolveAgentGUIConversationProject } from "../model/agentGuiConversationProjectResolver";
 import type { AgentComposerSubmitOptions } from "../composer/AgentComposer.types";
 
 export function useAgentGUINewConversationActivation(
@@ -45,6 +46,7 @@ export function useAgentGUINewConversationActivation(
     isCreatingConversationRef,
     onDataChangeRef,
     selectedProjectPathRef,
+    userProjectsRef,
     draftByScopeKeyRef,
     submittedDraftSnapshotsRef,
     draftSettingsBySessionIdRef,
@@ -118,6 +120,13 @@ export function useAgentGUINewConversationActivation(
             }
       );
       const selectedProjectPath = selectedProjectPathRef.current;
+      const selectedProject = resolveAgentGUIConversationProject(
+        selectedProjectPath,
+        userProjectsRef.current
+      );
+      const railSectionKey = !selectedProjectPath?.trim()
+        ? "conversations"
+        : selectedProject?.sectionKey?.trim() || undefined;
       const initialNodeSettings = readNodeDefaultDraftSettings({
         data: targetData.data,
         defaultReasoningEffort,
@@ -173,6 +182,7 @@ export function useAgentGUINewConversationActivation(
         agentTargetId,
         clientSubmitId: submitTrace.clientSubmitId,
         cwd: selectedProjectPath ?? "",
+        ...(railSectionKey ? { railSectionKey } : {}),
         initialContent: normalizedInitialContent,
         ...(initialTurnExpected !== undefined ? { initialTurnExpected } : {}),
         initialDisplayPrompt,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailMembershipRecords.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailMembershipRecords.ts
@@ -32,7 +32,7 @@ export function projectConversationRailMembershipRecords(
         id: record.agentSessionId,
         pinnedAtUnixMs: null,
         projectionSource: "pending_activation" as const,
-        railSectionKey: null,
+        railSectionKey: record.railSectionKey?.trim() || null,
         title: record.title ?? ""
       }))
   ];

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -305,6 +305,7 @@ export interface AgentActivityRuntimeDeleteSessionsBatchInput {
 }
 
 export interface AgentActivityRuntimeDeleteSessionsBatchResult {
+  cleanupFailedSessionIds: string[];
   removedMessages: number;
   removedSessionIds: string[];
   removedSessions: number;

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.spec.tsx
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.spec.tsx
@@ -126,6 +126,7 @@ describe("useAgentGuiConversationList", () => {
         initialDisplayPrompt: displayPrompt,
         mode: "new",
         optimisticTitle: "@Task 看看",
+        railSectionKey: "project:/workspace",
         requestedAtUnixMs: 1,
         requestId: "activation-1",
         workspaceId: "workspace-1"
@@ -134,6 +135,7 @@ describe("useAgentGuiConversationList", () => {
 
     expect(result.current?.conversations[0]).toEqual(
       expect.objectContaining({
+        railSectionKey: "project:/workspace",
         title: "@Task 看看",
         titleLeadingMentionKind: "task"
       })

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.ts
@@ -185,6 +185,7 @@ export function useAgentGuiConversationList(
           sortTimeUnixMs: activation.requestedAtUnixMs,
           status: "working",
           projectionSource: "pending_activation",
+          railSectionKey: activation.railSectionKey,
           title,
           titleLeadingMentionKind,
           titleFallback,

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -59,9 +59,16 @@ historical sessions persist settings only, while live sessions update the
 runtime first and persist the resulting settings only after the runtime
 accepts the change. Provider-specific model, reasoning, and speed normalization
 stays behind `SettingsPolicy`. `UpdatePin` mutates canonical metadata only.
-`DeleteSession` closes a live runtime before writing the canonical tombstone;
-authorization, shared bindings, transport DTOs, and local view cleanup remain
-adapter responsibilities.
+`DeleteSession` and `DeleteSessions` enter one deletion coordinator. The
+canonical store first resolves the complete root/child closure; Host acquires
+the shared session-mutation actor and session locks in stable order, closes
+every live runtime in that closure, and commits only if the store resolves the
+same closure inside the write transaction. A changed child tree is replanned
+before any tombstone is written. Goal provider mutations use the same outer
+session-mutation actor, so clear/set/reconcile work cannot race session
+deletion. Post-commit runtime cleanup failures are reported separately from
+the committed delete result. Authorization, shared bindings, transport DTOs,
+and local view cleanup remain adapter responsibilities.
 
 `PurgeDeletedSessions` is the separate permanent-removal command for bounded
 batches of canonical tombstones. Host owns the command boundary and delegates

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -64,10 +64,13 @@ canonical store first resolves the complete root/child closure; Host acquires
 the shared session-mutation actor and session locks in stable order, closes
 every live runtime in that closure, and commits only if the store resolves the
 same closure inside the write transaction. A changed child tree is replanned
-before any tombstone is written. Goal provider mutations use the same outer
-session-mutation actor, so clear/set/reconcile work cannot race session
-deletion. Post-commit runtime cleanup failures are reported separately from
-the committed delete result. Authorization, shared bindings, transport DTOs,
+before any tombstone is written. A requested runtime that is live before its
+first canonical report is still closed and cleaned up by the same coordinator;
+the empty canonical plan simply skips the tombstone transaction. Goal provider
+mutations use the same outer session-mutation actor, so clear/set/reconcile work
+cannot race session deletion. Post-commit runtime cleanup failures are reported
+separately from the committed delete result. Authorization, shared bindings,
+transport DTOs,
 and local view cleanup remain adapter responsibilities.
 
 `PurgeDeletedSessions` is the separate permanent-removal command for bounded

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -44,6 +44,7 @@ type InteractionSeed struct {
 
 type Fixture struct {
 	Session                *SessionSeed
+	LiveOnlySession        *SessionSeed
 	AdditionalSessions     []SessionSeed
 	Turn                   *TurnSeed
 	AdditionalTurns        []TurnSeed

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -12,8 +12,8 @@ func TestPublishedScenarioCatalogsHaveUniqueNames(t *testing.T) {
 		scenarios []Scenario
 		wantCount int
 	}{
-		{name: "adapter lifecycle", scenarios: Scenarios(), wantCount: 16},
-		{name: "application core", scenarios: ApplicationCoreScenarios(), wantCount: 11},
+		{name: "adapter lifecycle", scenarios: Scenarios(), wantCount: 17},
+		{name: "application core", scenarios: ApplicationCoreScenarios(), wantCount: 12},
 		{name: "resume policy", scenarios: ResumePolicyScenarios(), wantCount: 4},
 		{name: "submission fence", scenarios: SubmissionFenceScenarios(), wantCount: 1},
 		{name: "title policy", scenarios: TitlePolicyScenarios(), wantCount: 1},
@@ -55,6 +55,7 @@ func TestScenarioOwnershipIsExplicit(t *testing.T) {
 		"historical and live settings",
 		"pin session",
 		"delete session",
+		"delete live session before canonical report",
 		"purge deleted sessions",
 	}
 	wantCoordinator := []string{

--- a/packages/agent/host/conformance/scenarios.go
+++ b/packages/agent/host/conformance/scenarios.go
@@ -17,8 +17,12 @@ var (
 		Name: "historical and live settings",
 		run:  runHistoricalAndLiveSettings,
 	}
-	pinSessionScenario           = Scenario{Name: "pin session", run: runPinSession}
-	deleteSessionScenario        = Scenario{Name: "delete session", run: runDeleteSession}
+	pinSessionScenario            = Scenario{Name: "pin session", run: runPinSession}
+	deleteSessionScenario         = Scenario{Name: "delete session", run: runDeleteSession}
+	deleteLiveOnlySessionScenario = Scenario{
+		Name: "delete live session before canonical report",
+		run:  runDeleteLiveSessionBeforeCanonicalReport,
+	}
 	purgeDeletedSessionsScenario = Scenario{Name: "purge deleted sessions", run: runPurgeDeletedSessions}
 )
 
@@ -40,6 +44,7 @@ func Scenarios() []Scenario {
 		historicalAndLiveSettingsScenario,
 		pinSessionScenario,
 		deleteSessionScenario,
+		deleteLiveOnlySessionScenario,
 		purgeDeletedSessionsScenario,
 	}
 }
@@ -109,6 +114,7 @@ func ApplicationCoreScenarios() []Scenario {
 		historicalAndLiveSettingsScenario,
 		pinSessionScenario,
 		deleteSessionScenario,
+		deleteLiveOnlySessionScenario,
 		purgeDeletedSessionsScenario,
 	}
 }

--- a/packages/agent/host/conformance/session_management_scenarios.go
+++ b/packages/agent/host/conformance/session_management_scenarios.go
@@ -173,3 +173,24 @@ func runDeleteSession(ctx context.Context, driver Driver) error {
 	}
 	return nil
 }
+
+func runDeleteLiveSessionBeforeCanonicalReport(ctx context.Context, driver Driver) error {
+	if err := driver.Reset(ctx, Fixture{LiveOnlySession: &SessionSeed{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-delete-live-only", Provider: "codex",
+		ProviderSessionID: "provider-session-delete-live-only", Cwd: "/workspace", Live: true,
+	}}); err != nil {
+		return err
+	}
+	ref := agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-delete-live-only"}
+	result, err := driver.DeleteSession(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("delete live-only session: %w", err)
+	}
+	if !result.Deleted || !result.RuntimeClosed || result.CanonicalRemoved || driver.Metrics().CloseCalls != 1 {
+		return fmt.Errorf("delete live-only result=%#v metrics=%#v", result, driver.Metrics())
+	}
+	if _, err := driver.GetSession(ctx, ref); !errors.Is(err, agenthost.ErrSessionNotFound) {
+		return fmt.Errorf("get deleted live-only session error=%v", err)
+	}
+	return nil
+}

--- a/packages/agent/host/goal_actor.go
+++ b/packages/agent/host/goal_actor.go
@@ -2,74 +2,11 @@ package agenthost
 
 import (
 	"context"
-	"strings"
-	"sync"
 	"time"
 )
 
-type goalActorEntry struct {
-	gate chan struct{}
-	refs int
-}
-
-// GoalActor serializes one session's goal revision transitions. An adapter
-// that constructs short-lived Host values must share one GoalActor instance.
-type GoalActor struct {
-	mu      sync.Mutex
-	entries map[string]*goalActorEntry
-}
-
-func NewGoalActor() *GoalActor {
-	return &GoalActor{entries: make(map[string]*goalActorEntry)}
-}
-
-func (a *GoalActor) Do(ctx context.Context, ref SessionRef, fn func(context.Context) error) error {
-	if a == nil || strings.TrimSpace(ref.WorkspaceID) == "" || strings.TrimSpace(ref.AgentSessionID) == "" || fn == nil {
-		return ErrInvalidArgument
-	}
-	return a.do(ctx, ref.WorkspaceID, ref.AgentSessionID, fn)
-}
-
 func (h *Host) withGoalActor(ctx context.Context, workspaceID, agentSessionID string, fn func(context.Context) error) error {
 	return h.goalActor.Do(ctx, SessionRef{WorkspaceID: workspaceID, AgentSessionID: agentSessionID}, fn)
-}
-
-func (a *GoalActor) do(ctx context.Context, workspaceID, agentSessionID string, fn func(context.Context) error) error {
-	key := strings.TrimSpace(workspaceID) + "\x00" + strings.TrimSpace(agentSessionID)
-	a.mu.Lock()
-	entry := a.entries[key]
-	if entry == nil {
-		entry = &goalActorEntry{gate: make(chan struct{}, 1)}
-		entry.gate <- struct{}{}
-		a.entries[key] = entry
-	}
-	entry.refs++
-	a.mu.Unlock()
-
-	select {
-	case <-ctx.Done():
-		a.releaseReference(key, entry)
-		return ctx.Err()
-	case <-entry.gate:
-	}
-	if err := ctx.Err(); err != nil {
-		entry.gate <- struct{}{}
-		a.releaseReference(key, entry)
-		return err
-	}
-	err := fn(ctx)
-	entry.gate <- struct{}{}
-	a.releaseReference(key, entry)
-	return err
-}
-
-func (a *GoalActor) releaseReference(key string, entry *goalActorEntry) {
-	a.mu.Lock()
-	entry.refs--
-	if entry.refs == 0 && a.entries[key] == entry {
-		delete(a.entries, key)
-	}
-	a.mu.Unlock()
 }
 
 func (h *Host) goalOperationNow() time.Time {

--- a/packages/agent/host/goal_control.go
+++ b/packages/agent/host/goal_control.go
@@ -91,6 +91,31 @@ func (h *Host) goalControl(
 	ctx context.Context,
 	input GoalControlInput,
 ) (GoalControlResult, error) {
+	if h == nil {
+		return GoalControlResult{}, ErrInvalidArgument
+	}
+	workspaceID := strings.TrimSpace(input.WorkspaceID)
+	agentSessionID := strings.TrimSpace(input.AgentSessionID)
+	if workspaceID == "" || agentSessionID == "" {
+		return GoalControlResult{}, ErrInvalidArgument
+	}
+	var result GoalControlResult
+	err := h.withSessionMutationActor(ctx, workspaceID, agentSessionID, func(actorCtx context.Context) error {
+		var commandErr error
+		result, commandErr = h.goalControlSerialized(actorCtx, input)
+		return commandErr
+	})
+	return result, err
+}
+
+// goalControlSerialized keeps the provider mutation and its durable revision
+// transition in one per-session command lane. A clear submitted immediately
+// after set must reach the provider after set; revision repair alone cannot
+// prevent the older provider call from temporarily resurrecting a goal.
+func (h *Host) goalControlSerialized(
+	ctx context.Context,
+	input GoalControlInput,
+) (GoalControlResult, error) {
 	workspaceID := strings.TrimSpace(input.WorkspaceID)
 	agentSessionID := strings.TrimSpace(input.AgentSessionID)
 	action := strings.TrimSpace(input.Action)

--- a/packages/agent/host/goal_operation_worker.go
+++ b/packages/agent/host/goal_operation_worker.go
@@ -42,8 +42,10 @@ func (h *Host) StepGoalOperationWorker(ctx context.Context, recovering bool) err
 		}
 		op := operation
 		opCtx, cancel := context.WithTimeout(ctx, h.goalOperationAttemptTimeout())
-		err := h.withGoalActor(opCtx, op.WorkspaceID, op.AgentSessionID, func(actorCtx context.Context) error {
-			return h.recoverGoalOperation(actorCtx, op, recovering)
+		err := h.withSessionMutationActor(opCtx, op.WorkspaceID, op.AgentSessionID, func(commandCtx context.Context) error {
+			return h.withGoalActor(commandCtx, op.WorkspaceID, op.AgentSessionID, func(actorCtx context.Context) error {
+				return h.recoverGoalOperation(actorCtx, op, recovering)
+			})
 		})
 		cancel()
 		if err != nil && !errors.Is(err, ErrRuntimeOperationInProgress) {

--- a/packages/agent/host/goal_operation_worker_test.go
+++ b/packages/agent/host/goal_operation_worker_test.go
@@ -2,38 +2,108 @@ package agenthost
 
 import (
 	"context"
-	"errors"
+	"reflect"
+	"sync"
 	"testing"
 	"time"
 
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 )
 
-func TestGoalActorWaitObservesContextCancellation(t *testing.T) {
-	actor := NewGoalActor()
-	entered := make(chan struct{})
-	release := make(chan struct{})
-	done := make(chan error, 1)
-	ref := SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"}
-	go func() {
-		done <- actor.Do(context.Background(), ref, func(context.Context) error {
-			close(entered)
-			<-release
-			return nil
-		})
-	}()
-	<-entered
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancel()
-	if err := actor.Do(ctx, ref, func(context.Context) error {
-		t.Fatal("canceled waiter entered GoalActor")
-		return nil
-	}); !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("GoalActor.Do() error = %v", err)
+type goalCommandCanonicalStore struct {
+	CanonicalStore
+	session storesqlite.Session
+}
+
+func (s goalCommandCanonicalStore) SessionDeleted(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+
+func (s goalCommandCanonicalStore) GetSession(context.Context, string, string) (storesqlite.Session, bool, error) {
+	return s.session, true, nil
+}
+
+type goalCommandRuntime struct {
+	RuntimeController
+	session ProviderRuntimeSession
+}
+
+func (r goalCommandRuntime) Session(workspaceID string, agentSessionID string) (ProviderRuntimeSession, bool) {
+	return r.session, workspaceID == r.session.WorkspaceID && agentSessionID == r.session.ID
+}
+
+type blockingGoalRuntime struct {
+	mu         sync.Mutex
+	actions    []string
+	setEntered chan struct{}
+	releaseSet chan struct{}
+}
+
+func (r *blockingGoalRuntime) GoalControl(ctx context.Context, input RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
+	r.mu.Lock()
+	r.actions = append(r.actions, input.Action)
+	r.mu.Unlock()
+	if input.Action == "set" {
+		close(r.setEntered)
+		select {
+		case <-ctx.Done():
+			return RuntimeGoalControlResult{}, ctx.Err()
+		case <-r.releaseSet:
+		}
+		return RuntimeGoalControlResult{Goal: map[string]any{"objective": input.Objective, "status": "active"}}, nil
 	}
-	close(release)
-	if err := <-done; err != nil {
-		t.Fatal(err)
+	return RuntimeGoalControlResult{}, nil
+}
+
+func (r *blockingGoalRuntime) recordedActions() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.actions...)
+}
+
+func TestGoalCommandsSerializeProviderMutations(t *testing.T) {
+	canonical := storesqlite.Session{
+		ID: "session-1", WorkspaceID: "workspace-1", Kind: storesqlite.SessionKindRoot,
+		Provider: "codex", ProviderSessionID: "provider-session-1",
+	}
+	runtimeSession := ProviderRuntimeSession{
+		ID: "session-1", WorkspaceID: "workspace-1", Provider: "codex",
+		ProviderSessionID: "provider-session-1",
+	}
+	goalRuntime := &blockingGoalRuntime{setEntered: make(chan struct{}), releaseSet: make(chan struct{})}
+	host := New(Config{
+		CanonicalStore: goalCommandCanonicalStore{session: canonical},
+		Runtime:        goalCommandRuntime{session: runtimeSession},
+		GoalRuntime:    goalRuntime,
+	})
+	setDone := make(chan error, 1)
+	go func() {
+		_, err := host.GoalControl(context.Background(), GoalControlInput{
+			WorkspaceID: "workspace-1", AgentSessionID: "session-1", Action: "set", Objective: "ship it",
+		})
+		setDone <- err
+	}()
+	<-goalRuntime.setEntered
+	clearDone := make(chan error, 1)
+	go func() {
+		_, err := host.GoalControl(context.Background(), GoalControlInput{
+			WorkspaceID: "workspace-1", AgentSessionID: "session-1", Action: "clear",
+		})
+		clearDone <- err
+	}()
+	time.Sleep(20 * time.Millisecond)
+	if got := goalRuntime.recordedActions(); !reflect.DeepEqual(got, []string{"set"}) {
+		t.Fatalf("provider actions before set completion = %#v", got)
+	}
+	close(goalRuntime.releaseSet)
+	if err := <-setDone; err != nil {
+		t.Fatalf("set goal: %v", err)
+	}
+	if err := <-clearDone; err != nil {
+		t.Fatalf("clear goal: %v", err)
+	}
+	if got := goalRuntime.recordedActions(); !reflect.DeepEqual(got, []string{"set", "clear"}) {
+		t.Fatalf("provider actions = %#v", got)
 	}
 }
 

--- a/packages/agent/host/goal_operation_worker_test.go
+++ b/packages/agent/host/goal_operation_worker_test.go
@@ -15,7 +15,7 @@ type goalCommandCanonicalStore struct {
 	session storesqlite.Session
 }
 
-func (s goalCommandCanonicalStore) SessionDeleted(context.Context, string, string) (bool, error) {
+func (goalCommandCanonicalStore) SessionDeleted(context.Context, string, string) (bool, error) {
 	return false, nil
 }
 

--- a/packages/agent/host/goal_reconcile.go
+++ b/packages/agent/host/goal_reconcile.go
@@ -56,10 +56,12 @@ func (h *Host) ReconcileGoal(ctx context.Context, ref SessionRef) (GoalStateResu
 		return GoalStateResult{}, ErrInvalidArgument
 	}
 	var result GoalStateResult
-	err := h.withGoalActor(ctx, workspaceID, agentSessionID, func(actorCtx context.Context) error {
-		var reconcileErr error
-		result, reconcileErr = h.reconcileGoalLocked(actorCtx, workspaceID, agentSessionID)
-		return reconcileErr
+	err := h.withSessionMutationActor(ctx, workspaceID, agentSessionID, func(commandCtx context.Context) error {
+		return h.withGoalActor(commandCtx, workspaceID, agentSessionID, func(actorCtx context.Context) error {
+			var reconcileErr error
+			result, reconcileErr = h.reconcileGoalLocked(actorCtx, workspaceID, agentSessionID)
+			return reconcileErr
+		})
 	})
 	return result, err
 }

--- a/packages/agent/host/goal_reconcile_evidence.go
+++ b/packages/agent/host/goal_reconcile_evidence.go
@@ -19,6 +19,12 @@ func (h *Host) ReconcileGoalFromEvidence(ctx context.Context, input GoalReconcil
 	if h == nil || strings.TrimSpace(input.WorkspaceID) == "" || strings.TrimSpace(input.AgentSessionID) == "" {
 		return ErrInvalidArgument
 	}
+	return h.withSessionMutationActor(ctx, input.WorkspaceID, input.AgentSessionID, func(actorCtx context.Context) error {
+		return h.reconcileGoalFromEvidenceSerialized(actorCtx, input)
+	})
+}
+
+func (h *Host) reconcileGoalFromEvidenceSerialized(ctx context.Context, input GoalReconcileRequiredInput) error {
 	timeout := 2 * h.goalOperationAttemptTimeout()
 	if timeout < 30*time.Second {
 		timeout = 30 * time.Second

--- a/packages/agent/host/goal_reconcile_inbox.go
+++ b/packages/agent/host/goal_reconcile_inbox.go
@@ -98,6 +98,12 @@ func (h *Host) escalateGoalReconcileInboxTerminal(ctx context.Context, item stor
 	if h.goals == nil {
 		return errors.New("goal reconcile inbox terminal escalation store is unavailable")
 	}
+	return h.withSessionMutationActor(ctx, item.WorkspaceID, item.AgentSessionID, func(actorCtx context.Context) error {
+		return h.escalateGoalReconcileInboxTerminalSerialized(actorCtx, item, cause)
+	})
+}
+
+func (h *Host) escalateGoalReconcileInboxTerminalSerialized(ctx context.Context, item storesqlite.GoalReconcileInboxItem, cause error) error {
 	return h.withGoalActor(ctx, item.WorkspaceID, item.AgentSessionID, func(actorCtx context.Context) error {
 		for attempt := 0; attempt < 3; attempt++ {
 			state, found, err := h.goals.GetSessionGoalState(actorCtx, item.WorkspaceID, item.AgentSessionID)

--- a/packages/agent/host/host.go
+++ b/packages/agent/host/host.go
@@ -6,74 +6,82 @@ import (
 )
 
 type Config struct {
-	CanonicalStore       CanonicalStore
-	SessionManagement    SessionManagementStore
-	SessionPurge         SessionPurgeStore
-	Runtime              RuntimeController
-	RuntimePreparation   RuntimePreparationPort
-	SettingsPolicy       SettingsPolicy
-	Attachments          AttachmentMaterializer
-	Clock                Clock
-	SessionLocker        SessionLocker
-	RuntimeStartGate     RuntimeStartGate
-	LifecycleObserver    LifecycleObserver
-	CommitObserver       CommitObserver
-	RuntimeOperations    RuntimeOperationStore
-	OperationEvents      RuntimeOperationEventPublisher
-	OperationOwner       string
-	Scheduler            Scheduler
-	StaleTurnSettler     StaleTurnSettler
-	WorktreeGC           WorktreeGarbageCollector
-	GoalStore            GoalStateStore
-	GoalRuntime          GoalRuntimeController
-	GoalInbox            GoalReconcileInboxStore
-	GoalOwner            string
-	GoalClock            Clock
-	GoalAttemptTimeout   time.Duration
-	GoalRecoveryBudget   time.Duration
-	GoalMaxAttempts      int
-	GoalDispatchDeadline time.Duration
-	GoalActor            *GoalActor
+	CanonicalStore         CanonicalStore
+	SessionManagement      SessionManagementStore
+	SessionBatchManagement SessionBatchManagementStore
+	SessionPurge           SessionPurgeStore
+	Runtime                RuntimeController
+	RuntimePreparation     RuntimePreparationPort
+	SettingsPolicy         SettingsPolicy
+	Attachments            AttachmentMaterializer
+	Clock                  Clock
+	SessionLocker          SessionLocker
+	RuntimeStartGate       RuntimeStartGate
+	LifecycleObserver      LifecycleObserver
+	CommitObserver         CommitObserver
+	RuntimeOperations      RuntimeOperationStore
+	OperationEvents        RuntimeOperationEventPublisher
+	OperationOwner         string
+	Scheduler              Scheduler
+	StaleTurnSettler       StaleTurnSettler
+	WorktreeGC             WorktreeGarbageCollector
+	GoalStore              GoalStateStore
+	GoalRuntime            GoalRuntimeController
+	GoalInbox              GoalReconcileInboxStore
+	GoalOwner              string
+	GoalClock              Clock
+	GoalAttemptTimeout     time.Duration
+	GoalRecoveryBudget     time.Duration
+	GoalMaxAttempts        int
+	GoalDispatchDeadline   time.Duration
+	GoalActor              *SessionActor
+	SessionMutationActor   *SessionActor
 }
 
 type Host struct {
-	store                CanonicalStore
-	sessionManagement    SessionManagementStore
-	sessionPurge         SessionPurgeStore
-	runtime              RuntimeController
-	preparation          RuntimePreparationPort
-	settingsPolicy       SettingsPolicy
-	attachments          AttachmentMaterializer
-	clock                Clock
-	locker               SessionLocker
-	startupGate          RuntimeStartGate
-	observer             LifecycleObserver
-	commitObserver       CommitObserver
-	operations           RuntimeOperationStore
-	events               RuntimeOperationEventPublisher
-	owner                string
-	scheduler            Scheduler
-	staleTurns           StaleTurnSettler
-	worktreeGC           WorktreeGarbageCollector
-	goals                GoalStateStore
-	goalRuntime          GoalRuntimeController
-	goalInbox            GoalReconcileInboxStore
-	goalOwner            string
-	goalClock            Clock
-	goalAttemptTimeout   time.Duration
-	goalRecoveryBudget   time.Duration
-	goalMaxAttempts      int
-	goalDispatchDeadline time.Duration
-	goalActor            *GoalActor
+	store                  CanonicalStore
+	sessionManagement      SessionManagementStore
+	sessionBatchManagement SessionBatchManagementStore
+	sessionPurge           SessionPurgeStore
+	runtime                RuntimeController
+	preparation            RuntimePreparationPort
+	settingsPolicy         SettingsPolicy
+	attachments            AttachmentMaterializer
+	clock                  Clock
+	locker                 SessionLocker
+	startupGate            RuntimeStartGate
+	observer               LifecycleObserver
+	commitObserver         CommitObserver
+	operations             RuntimeOperationStore
+	events                 RuntimeOperationEventPublisher
+	owner                  string
+	scheduler              Scheduler
+	staleTurns             StaleTurnSettler
+	worktreeGC             WorktreeGarbageCollector
+	goals                  GoalStateStore
+	goalRuntime            GoalRuntimeController
+	goalInbox              GoalReconcileInboxStore
+	goalOwner              string
+	goalClock              Clock
+	goalAttemptTimeout     time.Duration
+	goalRecoveryBudget     time.Duration
+	goalMaxAttempts        int
+	goalDispatchDeadline   time.Duration
+	goalActor              *SessionActor
+	sessionMutationActor   *SessionActor
 }
 
 func New(config Config) *Host {
 	goalActor := config.GoalActor
 	if goalActor == nil {
-		goalActor = NewGoalActor()
+		goalActor = NewSessionActor()
+	}
+	sessionMutationActor := config.SessionMutationActor
+	if sessionMutationActor == nil {
+		sessionMutationActor = NewSessionActor()
 	}
 	host := &Host{
-		store: config.CanonicalStore, sessionManagement: config.SessionManagement, sessionPurge: config.SessionPurge, runtime: config.Runtime,
+		store: config.CanonicalStore, sessionManagement: config.SessionManagement, sessionBatchManagement: config.SessionBatchManagement, sessionPurge: config.SessionPurge, runtime: config.Runtime,
 		preparation: config.RuntimePreparation, settingsPolicy: config.SettingsPolicy, attachments: config.Attachments,
 		clock: config.Clock, locker: config.SessionLocker, startupGate: config.RuntimeStartGate,
 		observer: config.LifecycleObserver, commitObserver: config.CommitObserver,
@@ -84,7 +92,7 @@ func New(config Config) *Host {
 		goalOwner: config.GoalOwner, goalClock: config.GoalClock,
 		goalAttemptTimeout: config.GoalAttemptTimeout, goalRecoveryBudget: config.GoalRecoveryBudget,
 		goalMaxAttempts: config.GoalMaxAttempts, goalDispatchDeadline: config.GoalDispatchDeadline,
-		goalActor: goalActor,
+		goalActor: goalActor, sessionMutationActor: sessionMutationActor,
 	}
 	if host.operations != nil && host.commitObserver != nil {
 		host.operations = &observedRuntimeOperationStore{RuntimeOperationStore: host.operations, host: host}

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -49,7 +49,15 @@ type CanonicalStore interface {
 type SessionManagementStore interface {
 	UpdateSessionSettings(context.Context, string, string, ComposerSettings) (storesqlite.Session, bool, error)
 	UpdateSessionPinned(context.Context, string, string, bool) (storesqlite.Session, bool, error)
-	DeleteSession(context.Context, string, string) (bool, error)
+}
+
+// SessionBatchManagementStore is the atomic canonical mutation boundary for
+// project/section deletion. It is separate from single-session management so
+// runtimes can advertise batch support only when the backing store implements
+// one transaction rather than a renderer-side request loop.
+type SessionBatchManagementStore interface {
+	PlanDeleteSessions(context.Context, storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsPlan, error)
+	DeleteSessionsBatch(context.Context, storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsBatchResult, error)
 }
 
 // SessionPurgeStore is the narrow permanent-removal boundary. Retention and

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -56,6 +56,7 @@ type SessionManagementStore interface {
 // runtimes can advertise batch support only when the backing store implements
 // one transaction rather than a renderer-side request loop.
 type SessionBatchManagementStore interface {
+	PlanClearSessions(context.Context, string) (storesqlite.DeleteSessionsPlan, error)
 	PlanDeleteSessions(context.Context, storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsPlan, error)
 	DeleteSessionsBatch(context.Context, storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsBatchResult, error)
 }

--- a/packages/agent/host/session_actor.go
+++ b/packages/agent/host/session_actor.go
@@ -1,0 +1,81 @@
+package agenthost
+
+import (
+	"context"
+	"strings"
+	"sync"
+)
+
+type sessionActorEntry struct {
+	gate chan struct{}
+	refs int
+}
+
+// SessionActor serializes mutations for one canonical session. An adapter
+// that constructs short-lived Host values must share actor instances across
+// those Host values for every mutation lane it configures.
+type SessionActor struct {
+	mu      sync.Mutex
+	entries map[string]*sessionActorEntry
+}
+
+func NewSessionActor() *SessionActor {
+	return &SessionActor{entries: make(map[string]*sessionActorEntry)}
+}
+
+func (a *SessionActor) Do(ctx context.Context, ref SessionRef, fn func(context.Context) error) error {
+	if a == nil || strings.TrimSpace(ref.WorkspaceID) == "" || strings.TrimSpace(ref.AgentSessionID) == "" || fn == nil {
+		return ErrInvalidArgument
+	}
+	key := strings.TrimSpace(ref.WorkspaceID) + "\x00" + strings.TrimSpace(ref.AgentSessionID)
+	a.mu.Lock()
+	entry := a.entries[key]
+	if entry == nil {
+		entry = &sessionActorEntry{gate: make(chan struct{}, 1)}
+		entry.gate <- struct{}{}
+		a.entries[key] = entry
+	}
+	entry.refs++
+	a.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		a.releaseReference(key, entry)
+		return ctx.Err()
+	case <-entry.gate:
+	}
+	if err := ctx.Err(); err != nil {
+		entry.gate <- struct{}{}
+		a.releaseReference(key, entry)
+		return err
+	}
+	err := fn(ctx)
+	entry.gate <- struct{}{}
+	a.releaseReference(key, entry)
+	return err
+}
+
+func (a *SessionActor) releaseReference(key string, entry *sessionActorEntry) {
+	a.mu.Lock()
+	entry.refs--
+	if entry.refs == 0 && a.entries[key] == entry {
+		delete(a.entries, key)
+	}
+	a.mu.Unlock()
+}
+
+func (h *Host) withSessionMutationActor(ctx context.Context, workspaceID, agentSessionID string, fn func(context.Context) error) error {
+	if h == nil || h.sessionMutationActor == nil {
+		return ErrInvalidArgument
+	}
+	return h.sessionMutationActor.Do(ctx, SessionRef{WorkspaceID: workspaceID, AgentSessionID: agentSessionID}, fn)
+}
+
+func (h *Host) withSessionMutationActors(ctx context.Context, workspaceID string, agentSessionIDs []string, fn func(context.Context) error) error {
+	if len(agentSessionIDs) == 0 {
+		return fn(ctx)
+	}
+	return h.withSessionMutationActor(ctx, workspaceID, agentSessionIDs[0], func(actorCtx context.Context) error {
+		return h.withSessionMutationActors(actorCtx, workspaceID, agentSessionIDs[1:], fn)
+	})
+}

--- a/packages/agent/host/session_actor_test.go
+++ b/packages/agent/host/session_actor_test.go
@@ -1,0 +1,36 @@
+package agenthost
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestSessionActorWaitObservesContextCancellation(t *testing.T) {
+	actor := NewSessionActor()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	ref := SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"}
+	go func() {
+		done <- actor.Do(context.Background(), ref, func(context.Context) error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := actor.Do(ctx, ref, func(context.Context) error {
+		t.Fatal("canceled waiter entered SessionActor")
+		return nil
+	}); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("SessionActor.Do() error = %v", err)
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}

--- a/packages/agent/host/session_batch_management_test.go
+++ b/packages/agent/host/session_batch_management_test.go
@@ -38,6 +38,10 @@ type batchCleanup struct {
 	calls           []string
 }
 
+func (s *batchManagementStore) PlanClearSessions(_ context.Context, workspaceID string) (storesqlite.DeleteSessionsPlan, error) {
+	return storesqlite.DeleteSessionsPlan{WorkspaceID: workspaceID, SessionIDs: append([]string(nil), s.plan...)}, nil
+}
+
 func (*batchCleanup) Prepare(context.Context, RuntimePreparationInput) (PreparedRuntime, error) {
 	return PreparedRuntime{}, nil
 }
@@ -96,6 +100,23 @@ func TestDeleteSessionsUsesOneCanonicalBatchAfterClosingRuntimes(t *testing.T) {
 	}
 	if result.RemovedSessions != 2 || result.RemovedMessages != 3 || !reflect.DeepEqual(result.RemovedSessionIDs, wantIDs) || !reflect.DeepEqual(result.RuntimeClosedIDs, wantIDs) {
 		t.Fatalf("DeleteSessions() result = %#v", result)
+	}
+}
+
+func TestClearSessionsUsesCanonicalPlanAndSharedDeletionCoordinator(t *testing.T) {
+	runtime := &batchRuntime{live: map[string]bool{"session-a": true, "session-b": true}}
+	store := &batchManagementStore{runtime: runtime, plan: []string{"session-a", "session-b"}}
+	host := New(Config{Runtime: runtime, SessionBatchManagement: store})
+
+	result, err := host.ClearSessions(t.Context(), " workspace-1 ")
+	if err != nil {
+		t.Fatalf("ClearSessions() error = %v", err)
+	}
+	if !reflect.DeepEqual(result.RemovedSessionIDs, []string{"session-a", "session-b"}) {
+		t.Fatalf("ClearSessions() result = %#v", result)
+	}
+	if !reflect.DeepEqual(runtime.closeOrder, []string{"session-a", "session-b"}) || store.calls != 1 {
+		t.Fatalf("clear coordinator closeOrder=%#v calls=%d", runtime.closeOrder, store.calls)
 	}
 }
 

--- a/packages/agent/host/session_batch_management_test.go
+++ b/packages/agent/host/session_batch_management_test.go
@@ -1,0 +1,203 @@
+package agenthost
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+type batchRuntime struct {
+	RuntimeController
+	live       map[string]bool
+	closeOrder []string
+}
+
+func (r *batchRuntime) Session(_, sessionID string) (ProviderRuntimeSession, bool) {
+	return ProviderRuntimeSession{ID: sessionID}, r.live[sessionID]
+}
+
+func (r *batchRuntime) Close(_ context.Context, input RuntimeCloseInput) error {
+	r.closeOrder = append(r.closeOrder, input.AgentSessionID)
+	delete(r.live, input.AgentSessionID)
+	return nil
+}
+
+type batchManagementStore struct {
+	runtime *batchRuntime
+	plan    []string
+	input   storesqlite.DeleteSessionsBatchInput
+	changes int
+	calls   int
+}
+
+type batchCleanup struct {
+	failedSessionID string
+	calls           []string
+}
+
+func (*batchCleanup) Prepare(context.Context, RuntimePreparationInput) (PreparedRuntime, error) {
+	return PreparedRuntime{}, nil
+}
+
+func (c *batchCleanup) Cleanup(_ context.Context, input RuntimeCleanupInput) error {
+	c.calls = append(c.calls, input.AgentSessionID)
+	if input.AgentSessionID == c.failedSessionID {
+		return errors.New("cleanup failed")
+	}
+	return nil
+}
+
+func (s *batchManagementStore) PlanDeleteSessions(_ context.Context, input storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsPlan, error) {
+	plan := s.plan
+	if len(plan) == 0 {
+		plan = input.SessionIDs
+	}
+	return storesqlite.DeleteSessionsPlan{WorkspaceID: input.WorkspaceID, SessionIDs: append([]string(nil), plan...)}, nil
+}
+
+func (s *batchManagementStore) DeleteSessionsBatch(_ context.Context, input storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsBatchResult, error) {
+	s.calls++
+	if s.changes > 0 {
+		s.changes--
+		return storesqlite.DeleteSessionsBatchResult{}, storesqlite.ErrDeleteSessionsPlanChanged
+	}
+	if len(s.runtime.live) != 0 {
+		panic("canonical batch delete ran before all live runtimes closed")
+	}
+	s.input = input
+	return storesqlite.DeleteSessionsBatchResult{
+		RemovedSessionIDs: append([]string(nil), input.SessionIDs...),
+		RemovedSessions:   len(input.SessionIDs),
+		RemovedMessages:   3,
+	}, nil
+}
+
+func TestDeleteSessionsUsesOneCanonicalBatchAfterClosingRuntimes(t *testing.T) {
+	runtime := &batchRuntime{live: map[string]bool{"session-a": true, "session-b": true}}
+	store := &batchManagementStore{runtime: runtime}
+	host := New(Config{Runtime: runtime, SessionBatchManagement: store})
+
+	result, err := host.DeleteSessions(t.Context(), DeleteSessionsInput{
+		WorkspaceID: " workspace-1 ",
+		SessionIDs:  []string{"session-b", "session-a", "session-b", " "},
+	})
+	if err != nil {
+		t.Fatalf("DeleteSessions() error = %v", err)
+	}
+	wantIDs := []string{"session-a", "session-b"}
+	if !reflect.DeepEqual(runtime.closeOrder, wantIDs) {
+		t.Fatalf("runtime close order = %#v, want %#v", runtime.closeOrder, wantIDs)
+	}
+	if store.input.WorkspaceID != "workspace-1" || !reflect.DeepEqual(store.input.SessionIDs, wantIDs) || !reflect.DeepEqual(store.input.ExpectedSessionIDs, wantIDs) {
+		t.Fatalf("canonical batch input = %#v", store.input)
+	}
+	if result.RemovedSessions != 2 || result.RemovedMessages != 3 || !reflect.DeepEqual(result.RemovedSessionIDs, wantIDs) || !reflect.DeepEqual(result.RuntimeClosedIDs, wantIDs) {
+		t.Fatalf("DeleteSessions() result = %#v", result)
+	}
+}
+
+func TestDeleteSessionsClosesLiveChildFromCanonicalDeletionPlan(t *testing.T) {
+	runtime := &batchRuntime{live: map[string]bool{"child": true}}
+	store := &batchManagementStore{runtime: runtime, plan: []string{"child", "root"}}
+	host := New(Config{Runtime: runtime, SessionBatchManagement: store})
+
+	result, err := host.DeleteSessions(t.Context(), DeleteSessionsInput{
+		WorkspaceID: "workspace-1",
+		SessionIDs:  []string{"root"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteSessions() error = %v", err)
+	}
+	if !reflect.DeepEqual(runtime.closeOrder, []string{"child"}) {
+		t.Fatalf("runtime close order = %#v", runtime.closeOrder)
+	}
+	if !reflect.DeepEqual(store.input.ExpectedSessionIDs, []string{"child", "root"}) {
+		t.Fatalf("expected canonical closure = %#v", store.input.ExpectedSessionIDs)
+	}
+	if !reflect.DeepEqual(result.RuntimeClosedIDs, []string{"child"}) {
+		t.Fatalf("runtime closed ids = %#v", result.RuntimeClosedIDs)
+	}
+}
+
+func TestDeleteSessionsReportsPostCommitCleanupFailuresWithoutSkippingOtherSessions(t *testing.T) {
+	runtime := &batchRuntime{live: map[string]bool{}}
+	store := &batchManagementStore{runtime: runtime}
+	cleanup := &batchCleanup{failedSessionID: "session-a"}
+	host := New(Config{Runtime: runtime, SessionBatchManagement: store, RuntimePreparation: cleanup})
+
+	result, err := host.DeleteSessions(t.Context(), DeleteSessionsInput{
+		WorkspaceID: "workspace-1",
+		SessionIDs:  []string{"session-a", "session-b"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteSessions() error = %v", err)
+	}
+	if !reflect.DeepEqual(cleanup.calls, []string{"session-a", "session-b"}) {
+		t.Fatalf("cleanup calls = %#v", cleanup.calls)
+	}
+	if !reflect.DeepEqual(result.CleanupFailedIDs, []string{"session-a"}) {
+		t.Fatalf("cleanup failed ids = %#v", result.CleanupFailedIDs)
+	}
+}
+
+func TestDeleteSessionsReplansWhenChildClosureChangesBeforeCommit(t *testing.T) {
+	runtime := &batchRuntime{live: map[string]bool{"root": true}}
+	store := &batchManagementStore{runtime: runtime, plan: []string{"root"}, changes: 1}
+	host := New(Config{Runtime: runtime, SessionBatchManagement: store})
+
+	result, err := host.DeleteSessions(t.Context(), DeleteSessionsInput{
+		WorkspaceID: "workspace-1",
+		SessionIDs:  []string{"root"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteSessions() error = %v", err)
+	}
+	if store.calls != 2 {
+		t.Fatalf("canonical delete calls = %d, want replan then commit", store.calls)
+	}
+	if !reflect.DeepEqual(result.RuntimeClosedIDs, []string{"root"}) {
+		t.Fatalf("runtime closed ids = %#v", result.RuntimeClosedIDs)
+	}
+}
+
+func TestDeleteSessionsWaitsForSharedSessionMutationActor(t *testing.T) {
+	runtime := &batchRuntime{live: map[string]bool{"root": true}}
+	store := &batchManagementStore{runtime: runtime, plan: []string{"root"}}
+	actor := NewSessionActor()
+	host := New(Config{Runtime: runtime, SessionBatchManagement: store, SessionMutationActor: actor})
+	held := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		_ = actor.Do(t.Context(), SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "root"}, func(context.Context) error {
+			close(held)
+			<-release
+			return nil
+		})
+	}()
+	<-held
+	done := make(chan error, 1)
+	go func() {
+		_, err := host.DeleteSessions(t.Context(), DeleteSessionsInput{WorkspaceID: "workspace-1", SessionIDs: []string{"root"}})
+		done <- err
+	}()
+	if len(runtime.closeOrder) != 0 {
+		t.Fatalf("runtime closed before mutation actor released: %#v", runtime.closeOrder)
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("DeleteSessions() error = %v", err)
+	}
+	if !reflect.DeepEqual(runtime.closeOrder, []string{"root"}) {
+		t.Fatalf("runtime close order = %#v", runtime.closeOrder)
+	}
+}
+
+func TestDeleteSessionsFailsClosedWithoutBatchStore(t *testing.T) {
+	host := New(Config{Runtime: &batchRuntime{live: map[string]bool{}}})
+	if _, err := host.DeleteSessions(t.Context(), DeleteSessionsInput{WorkspaceID: "workspace-1", SessionIDs: []string{"session-1"}}); err == nil {
+		t.Fatal("DeleteSessions succeeded without atomic batch storage")
+	}
+}

--- a/packages/agent/host/session_batch_management_test.go
+++ b/packages/agent/host/session_batch_management_test.go
@@ -26,11 +26,12 @@ func (r *batchRuntime) Close(_ context.Context, input RuntimeCloseInput) error {
 }
 
 type batchManagementStore struct {
-	runtime *batchRuntime
-	plan    []string
-	input   storesqlite.DeleteSessionsBatchInput
-	changes int
-	calls   int
+	runtime      *batchRuntime
+	plan         []string
+	input        storesqlite.DeleteSessionsBatchInput
+	changes      int
+	calls        int
+	useExactPlan bool
 }
 
 type batchCleanup struct {
@@ -56,10 +57,32 @@ func (c *batchCleanup) Cleanup(_ context.Context, input RuntimeCleanupInput) err
 
 func (s *batchManagementStore) PlanDeleteSessions(_ context.Context, input storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsPlan, error) {
 	plan := s.plan
-	if len(plan) == 0 {
+	if len(plan) == 0 && !s.useExactPlan {
 		plan = input.SessionIDs
 	}
 	return storesqlite.DeleteSessionsPlan{WorkspaceID: input.WorkspaceID, SessionIDs: append([]string(nil), plan...)}, nil
+}
+
+func TestDeleteSessionClosesLiveRuntimeBeforeFirstCanonicalReport(t *testing.T) {
+	runtime := &batchRuntime{live: map[string]bool{"session-live-only": true}}
+	store := &batchManagementStore{runtime: runtime, useExactPlan: true}
+	host := New(Config{Runtime: runtime, SessionBatchManagement: store})
+
+	result, err := host.DeleteSession(t.Context(), SessionRef{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-live-only",
+	})
+	if err != nil {
+		t.Fatalf("DeleteSession() error = %v", err)
+	}
+	if !result.Deleted || !result.RuntimeClosed || result.CanonicalRemoved {
+		t.Fatalf("DeleteSession() result = %#v", result)
+	}
+	if !reflect.DeepEqual(runtime.closeOrder, []string{"session-live-only"}) {
+		t.Fatalf("runtime close order = %#v", runtime.closeOrder)
+	}
+	if store.calls != 0 {
+		t.Fatalf("canonical delete calls = %d, want none without a canonical row", store.calls)
+	}
 }
 
 func (s *batchManagementStore) DeleteSessionsBatch(_ context.Context, input storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsBatchResult, error) {

--- a/packages/agent/host/session_management.go
+++ b/packages/agent/host/session_management.go
@@ -2,8 +2,12 @@ package agenthost
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 )
 
 // GetSession reads canonical truth and, when present, the current provider
@@ -127,37 +131,147 @@ func (h *Host) UpdatePin(ctx context.Context, input UpdatePinInput) (UpdatePinRe
 	return UpdatePinResult{Session: live, Canonical: canonical, Live: ok}, nil
 }
 
-// DeleteSession closes a live runtime before writing the canonical tombstone.
-// Authorization, binding deletion, and local view cleanup remain adapter work.
+// DeleteSession and DeleteSessions share one deletion coordinator so child
+// expansion, runtime shutdown, canonical tombstones, and goal mutation
+// serialization cannot diverge between entry points.
 func (h *Host) DeleteSession(ctx context.Context, ref SessionRef) (DeleteSessionResult, error) {
 	ref = normalizedSessionRef(ref)
-	if h == nil || h.sessionManagement == nil || h.runtime == nil || ref.WorkspaceID == "" || ref.AgentSessionID == "" {
+	if h == nil || h.sessionBatchManagement == nil || h.runtime == nil || ref.WorkspaceID == "" || ref.AgentSessionID == "" {
 		return DeleteSessionResult{}, ErrInvalidArgument
 	}
-	result := DeleteSessionResult{}
-	if _, live := h.runtime.Session(ref.WorkspaceID, ref.AgentSessionID); live {
-		if err := h.runtime.Close(ctx, RuntimeCloseInput(ref)); err != nil {
-			return DeleteSessionResult{}, err
-		}
-		result.RuntimeClosed = true
-	}
-	removed, err := h.sessionManagement.DeleteSession(ctx, ref.WorkspaceID, ref.AgentSessionID)
+	batch, err := h.DeleteSessions(ctx, DeleteSessionsInput{
+		WorkspaceID: ref.WorkspaceID,
+		SessionIDs:  []string{ref.AgentSessionID},
+	})
 	if err != nil {
 		return DeleteSessionResult{}, err
 	}
-	result.CanonicalRemoved = removed
-	result.Deleted = removed || result.RuntimeClosed
+	result := DeleteSessionResult{
+		Deleted:          len(batch.RemovedSessionIDs) > 0 || len(batch.RuntimeClosedIDs) > 0,
+		RuntimeClosed:    containsSessionID(batch.RuntimeClosedIDs, ref.AgentSessionID),
+		CanonicalRemoved: containsSessionID(batch.RemovedSessionIDs, ref.AgentSessionID),
+		CleanupFailed:    len(batch.CleanupFailedIDs) > 0,
+	}
 	if !result.Deleted {
 		return DeleteSessionResult{}, ErrSessionNotFound
 	}
-	if h.preparation != nil {
-		if err := h.preparation.Cleanup(ctx, RuntimeCleanupInput{
-			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
-		}); err != nil {
-			return DeleteSessionResult{}, err
+	return result, nil
+}
+
+// DeleteSessions closes every selected live runtime before committing one
+// canonical batch tombstone transaction. A missing batch store is reported as
+// unsupported; Host never degrades this command into sequential deletes.
+func (h *Host) DeleteSessions(ctx context.Context, input DeleteSessionsInput) (DeleteSessionsResult, error) {
+	workspaceID := strings.TrimSpace(input.WorkspaceID)
+	sessionIDs := normalizedUniqueSessionIDs(input.SessionIDs)
+	if h == nil || h.sessionBatchManagement == nil || h.runtime == nil || workspaceID == "" || len(sessionIDs) == 0 {
+		return DeleteSessionsResult{}, ErrInvalidArgument
+	}
+	runtimeClosedIDs := make([]string, 0, len(sessionIDs))
+	var deleted storesqlite.DeleteSessionsBatchResult
+	for {
+		plan, err := h.sessionBatchManagement.PlanDeleteSessions(ctx, storesqlite.DeleteSessionsBatchInput{
+			WorkspaceID: workspaceID,
+			SessionIDs:  sessionIDs,
+		})
+		if err != nil {
+			return DeleteSessionsResult{}, err
+		}
+		if len(plan.SessionIDs) == 0 {
+			break
+		}
+		err = h.withSessionMutationActors(ctx, workspaceID, plan.SessionIDs, func(commandCtx context.Context) error {
+			releases := make([]func(), 0, len(plan.SessionIDs))
+			for _, sessionID := range plan.SessionIDs {
+				release, acquireErr := h.acquireSession(commandCtx, SessionRef{WorkspaceID: workspaceID, AgentSessionID: sessionID})
+				if acquireErr != nil {
+					releaseSessionLocks(releases)
+					return acquireErr
+				}
+				releases = append(releases, release)
+			}
+			defer releaseSessionLocks(releases)
+			for _, sessionID := range plan.SessionIDs {
+				if _, live := h.runtime.Session(workspaceID, sessionID); !live {
+					continue
+				}
+				if closeErr := h.runtime.Close(commandCtx, RuntimeCloseInput{WorkspaceID: workspaceID, AgentSessionID: sessionID}); closeErr != nil {
+					return closeErr
+				}
+				runtimeClosedIDs = append(runtimeClosedIDs, sessionID)
+			}
+			var deleteErr error
+			deleted, deleteErr = h.sessionBatchManagement.DeleteSessionsBatch(commandCtx, storesqlite.DeleteSessionsBatchInput{
+				WorkspaceID:        workspaceID,
+				SessionIDs:         sessionIDs,
+				ExpectedSessionIDs: plan.SessionIDs,
+			})
+			return deleteErr
+		})
+		if errors.Is(err, storesqlite.ErrDeleteSessionsPlanChanged) {
+			if ctx.Err() != nil {
+				return DeleteSessionsResult{}, ctx.Err()
+			}
+			continue
+		}
+		if err != nil {
+			return DeleteSessionsResult{}, err
+		}
+		break
+	}
+	runtimeClosedIDs = normalizedUniqueSessionIDs(runtimeClosedIDs)
+	cleanupSessionIDs := normalizedUniqueSessionIDs(append(append([]string(nil), deleted.RemovedSessionIDs...), runtimeClosedIDs...))
+	cleanupFailedIDs := make([]string, 0)
+	for _, sessionID := range cleanupSessionIDs {
+		if h.preparation == nil {
+			continue
+		}
+		if err := h.preparation.Cleanup(ctx, RuntimeCleanupInput{WorkspaceID: workspaceID, AgentSessionID: sessionID}); err != nil {
+			cleanupFailedIDs = append(cleanupFailedIDs, sessionID)
 		}
 	}
-	return result, nil
+	return DeleteSessionsResult{
+		RemovedSessionIDs: append([]string(nil), deleted.RemovedSessionIDs...),
+		RemovedSessions:   deleted.RemovedSessions,
+		RemovedMessages:   deleted.RemovedMessages,
+		RuntimeClosedIDs:  runtimeClosedIDs,
+		CleanupFailedIDs:  cleanupFailedIDs,
+	}, nil
+}
+
+func containsSessionID(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizedUniqueSessionIDs(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func releaseSessionLocks(releases []func()) {
+	for index := len(releases) - 1; index >= 0; index-- {
+		if releases[index] != nil {
+			releases[index]()
+		}
+	}
 }
 
 func normalizedSessionRef(ref SessionRef) SessionRef {

--- a/packages/agent/host/session_management.go
+++ b/packages/agent/host/session_management.go
@@ -239,6 +239,28 @@ func (h *Host) DeleteSessions(ctx context.Context, input DeleteSessionsInput) (D
 	}, nil
 }
 
+// ClearSessions routes workspace-wide removal through the same runtime-close,
+// mutation-actor, atomic canonical delete, and post-commit cleanup coordinator
+// as scoped deletion. Service layers must not enumerate or clear sessions on
+// their own because doing so creates a second lifecycle authority.
+func (h *Host) ClearSessions(ctx context.Context, workspaceID string) (ClearSessionsResult, error) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if h == nil || h.sessionBatchManagement == nil || h.runtime == nil || workspaceID == "" {
+		return ClearSessionsResult{}, ErrInvalidArgument
+	}
+	plan, err := h.sessionBatchManagement.PlanClearSessions(ctx, workspaceID)
+	if err != nil {
+		return ClearSessionsResult{}, err
+	}
+	if len(plan.SessionIDs) == 0 {
+		return ClearSessionsResult{}, nil
+	}
+	return h.DeleteSessions(ctx, DeleteSessionsInput{
+		WorkspaceID: workspaceID,
+		SessionIDs:  plan.SessionIDs,
+	})
+}
+
 func containsSessionID(values []string, expected string) bool {
 	for _, value := range values {
 		if value == expected {

--- a/packages/agent/host/session_management.go
+++ b/packages/agent/host/session_management.go
@@ -177,12 +177,15 @@ func (h *Host) DeleteSessions(ctx context.Context, input DeleteSessionsInput) (D
 		if err != nil {
 			return DeleteSessionsResult{}, err
 		}
-		if len(plan.SessionIDs) == 0 {
-			break
-		}
-		err = h.withSessionMutationActors(ctx, workspaceID, plan.SessionIDs, func(commandCtx context.Context) error {
-			releases := make([]func(), 0, len(plan.SessionIDs))
-			for _, sessionID := range plan.SessionIDs {
+		// Requested sessions can be live before their first canonical report is
+		// committed (for example, short-lived hidden discovery sessions). Keep
+		// those runtimes inside the same deletion coordinator even when the
+		// canonical plan is empty; the canonical plan remains the exact fence for
+		// rows that do exist.
+		mutationSessionIDs := normalizedUniqueSessionIDs(append(append([]string(nil), plan.SessionIDs...), sessionIDs...))
+		err = h.withSessionMutationActors(ctx, workspaceID, mutationSessionIDs, func(commandCtx context.Context) error {
+			releases := make([]func(), 0, len(mutationSessionIDs))
+			for _, sessionID := range mutationSessionIDs {
 				release, acquireErr := h.acquireSession(commandCtx, SessionRef{WorkspaceID: workspaceID, AgentSessionID: sessionID})
 				if acquireErr != nil {
 					releaseSessionLocks(releases)
@@ -191,7 +194,7 @@ func (h *Host) DeleteSessions(ctx context.Context, input DeleteSessionsInput) (D
 				releases = append(releases, release)
 			}
 			defer releaseSessionLocks(releases)
-			for _, sessionID := range plan.SessionIDs {
+			for _, sessionID := range mutationSessionIDs {
 				if _, live := h.runtime.Session(workspaceID, sessionID); !live {
 					continue
 				}
@@ -199,6 +202,9 @@ func (h *Host) DeleteSessions(ctx context.Context, input DeleteSessionsInput) (D
 					return closeErr
 				}
 				runtimeClosedIDs = append(runtimeClosedIDs, sessionID)
+			}
+			if len(plan.SessionIDs) == 0 {
+				return nil
 			}
 			var deleteErr error
 			deleted, deleteErr = h.sessionBatchManagement.DeleteSessionsBatch(commandCtx, storesqlite.DeleteSessionsBatchInput{

--- a/packages/agent/host/sqlite_workspace_store.go
+++ b/packages/agent/host/sqlite_workspace_store.go
@@ -1,0 +1,355 @@
+package agenthost
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+const canonicalRuntimeSessionOrigin = "WORKSPACE_AGENT_SESSION_ORIGIN_RUNTIME"
+
+// SQLiteWorkspaceStore is the official workspace-routed store composition for
+// Agent Host. It owns canonical runtime-session initialization and post-commit
+// notifications so product services cannot drift on lifecycle projection.
+//
+// Product-owned sidecar projections should wrap this type and observe the
+// persisted result; they must not reimplement canonical initialization.
+type SQLiteWorkspaceStore struct {
+	StoreForWorkspace      func(string) *storesqlite.Store
+	CurrentUserID          func() string
+	Clock                  Clock
+	Observer               CommitObserver
+	InitializationObserver RuntimeSessionInitializationObserver
+}
+
+// RuntimeSessionInitializationObserver projects product-owned, repairable
+// sidecars after canonical initialization succeeds. It cannot reject or alter
+// the canonical commit; implementations own their own diagnostics and repair.
+type RuntimeSessionInitializationObserver interface {
+	ObserveRuntimeSessionInitialized(context.Context, ProviderRuntimeSession, storesqlite.Session)
+}
+
+var _ CanonicalStore = (*SQLiteWorkspaceStore)(nil)
+var _ SessionManagementStore = (*SQLiteWorkspaceStore)(nil)
+var _ SessionBatchManagementStore = (*SQLiteWorkspaceStore)(nil)
+
+func (s *SQLiteWorkspaceStore) GetSession(ctx context.Context, workspaceID, sessionID string) (storesqlite.Session, bool, error) {
+	store, err := s.store(workspaceID)
+	if err != nil {
+		return storesqlite.Session{}, false, err
+	}
+	return store.GetSession(ctx, workspaceID, sessionID)
+}
+
+func (s *SQLiteWorkspaceStore) SessionDeleted(ctx context.Context, workspaceID, sessionID string) (bool, error) {
+	store, err := s.store(workspaceID)
+	if err != nil {
+		return false, err
+	}
+	return store.SessionDeleted(ctx, workspaceID, sessionID)
+}
+
+func (s *SQLiteWorkspaceStore) RollbackRuntimeSessionInitialization(ctx context.Context, workspaceID, sessionID string) (bool, error) {
+	store, err := s.store(workspaceID)
+	if err != nil {
+		return false, err
+	}
+	changed, err := store.RollbackRuntimeSessionInitialization(ctx, workspaceID, sessionID)
+	if err == nil && changed {
+		NotifyCommitted(ctx, s.Observer, CommittedDelta{
+			ProjectionDirty: []CanonicalProjectionDirty{{
+				WorkspaceID: workspaceID, AgentSessionID: sessionID,
+				EntityKind: storesqlite.MutationEntitySession, EntityID: sessionID, Operation: "delete",
+			}},
+			ViewsInvalidated: []CanonicalViewInvalidated{{WorkspaceID: workspaceID, AgentSessionID: sessionID}},
+		})
+	}
+	return changed, err
+}
+
+func (s *SQLiteWorkspaceStore) InitializeRuntimeSession(ctx context.Context, session ProviderRuntimeSession) (storesqlite.Session, error) {
+	workspaceID := strings.TrimSpace(session.WorkspaceID)
+	sessionID := strings.TrimSpace(session.ID)
+	if workspaceID == "" || sessionID == "" {
+		return storesqlite.Session{}, ErrInvalidArgument
+	}
+	store, err := s.store(workspaceID)
+	if err != nil {
+		return storesqlite.Session{}, err
+	}
+	occurredAt := session.UpdatedAtUnixMS
+	if occurredAt <= 0 {
+		occurredAt = session.CreatedAtUnixMS
+	}
+	if occurredAt <= 0 {
+		occurredAt = s.now().UnixMilli()
+	}
+	runtimeContext := cloneStringAnyMap(session.RuntimeContext)
+	if runtimeContext == nil {
+		runtimeContext = map[string]any{}
+	}
+	runtimeContext["visible"] = session.Visible && !session.Provisional
+	userID := firstNonBlank(session.UserID, s.currentUserID())
+	result, err := store.ReportActivityState(ctx, storesqlite.ActivityStateReport{
+		Session: storesqlite.SessionStateReport{
+			WorkspaceID:       workspaceID,
+			AgentSessionID:    sessionID,
+			Kind:              storesqlite.SessionKindRoot,
+			Origin:            canonicalRuntimeSessionOrigin,
+			UserID:            userID,
+			AgentTargetID:     strings.TrimSpace(session.AgentTargetID),
+			Provider:          strings.TrimSpace(session.Provider),
+			ProviderSessionID: strings.TrimSpace(session.ProviderSessionID),
+			Model:             composerSettingsModel(session.Settings),
+			Settings:          composerSettingsPayload(session.Settings),
+			RuntimeContext:    runtimeContext,
+			Cwd:               strings.TrimSpace(session.Cwd),
+			Title:             strings.TrimSpace(session.Title),
+			Status:            runtimeLifecycleStatus(session.Status),
+			CurrentPhase:      runtimeLifecyclePhase(session.Status),
+			LastError:         strings.TrimSpace(session.LastError),
+			OccurredAtUnixMS:  occurredAt,
+			StartedAtUnixMS:   session.CreatedAtUnixMS,
+			CreatedAtUnixMS:   session.CreatedAtUnixMS,
+		},
+	})
+	if err != nil {
+		return storesqlite.Session{}, err
+	}
+	persisted := result.State.Session
+	if strings.TrimSpace(persisted.ID) == "" {
+		return storesqlite.Session{}, errors.New("initialized agent session was not persisted")
+	}
+	if s.InitializationObserver != nil {
+		s.InitializationObserver.ObserveRuntimeSessionInitialized(ctx, session, persisted)
+	}
+	NotifyCommitted(ctx, s.Observer, CanonicalDelta(result.CommitDelta))
+	persisted, found, err := store.GetSession(ctx, workspaceID, sessionID)
+	if err != nil {
+		return storesqlite.Session{}, err
+	}
+	if !found || strings.TrimSpace(persisted.ID) == "" {
+		return storesqlite.Session{}, errors.New("initialized agent session was not persisted")
+	}
+	return persisted, nil
+}
+
+func (s *SQLiteWorkspaceStore) UpdateSessionTitle(ctx context.Context, workspaceID, sessionID, title string) (storesqlite.Session, bool, error) {
+	store, err := s.store(workspaceID)
+	if err != nil {
+		return storesqlite.Session{}, false, err
+	}
+	session, changed, err := store.UpdateSessionTitle(ctx, workspaceID, sessionID, title)
+	if err == nil && changed {
+		NotifyCommitted(ctx, s.Observer, CanonicalDelta(session.CommitDelta))
+	}
+	return session, changed, err
+}
+
+func (s *SQLiteWorkspaceStore) UpdateSessionSettings(ctx context.Context, workspaceID, sessionID string, settings ComposerSettings) (storesqlite.Session, bool, error) {
+	store, err := s.store(workspaceID)
+	if err != nil {
+		return storesqlite.Session{}, false, err
+	}
+	session, changed, err := store.UpdateSessionSettings(ctx, workspaceID, sessionID, settings.Model, composerSettingsPayload(&settings))
+	if err == nil && changed {
+		NotifyCommitted(ctx, s.Observer, CanonicalDelta(session.CommitDelta))
+	}
+	return session, changed, err
+}
+
+func (s *SQLiteWorkspaceStore) UpdateSessionPinned(ctx context.Context, workspaceID, sessionID string, pinned bool) (storesqlite.Session, bool, error) {
+	store, err := s.store(workspaceID)
+	if err != nil {
+		return storesqlite.Session{}, false, err
+	}
+	session, changed, err := store.UpdateSessionPinned(ctx, workspaceID, sessionID, pinned)
+	if err == nil && changed {
+		NotifyCommitted(ctx, s.Observer, CanonicalDelta(session.CommitDelta))
+	}
+	return session, changed, err
+}
+
+func (s *SQLiteWorkspaceStore) PlanDeleteSessions(ctx context.Context, input storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsPlan, error) {
+	store, err := s.store(input.WorkspaceID)
+	if err != nil {
+		return storesqlite.DeleteSessionsPlan{}, err
+	}
+	return store.PlanDeleteSessions(ctx, input)
+}
+
+func (s *SQLiteWorkspaceStore) DeleteSessionsBatch(ctx context.Context, input storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsBatchResult, error) {
+	store, err := s.store(input.WorkspaceID)
+	if err != nil {
+		return storesqlite.DeleteSessionsBatchResult{}, err
+	}
+	result, err := store.DeleteSessionsBatch(ctx, input)
+	if err == nil && result.RemovedSessions > 0 {
+		NotifyCommitted(ctx, s.Observer, CanonicalDelta(result.CommitDelta))
+	}
+	return result, err
+}
+
+func (s *SQLiteWorkspaceStore) ListChildSessions(ctx context.Context, workspaceID, sessionID string) ([]storesqlite.Session, error) {
+	store, err := s.store(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	return store.ListChildSessions(ctx, workspaceID, sessionID)
+}
+
+func (s *SQLiteWorkspaceStore) GetTurn(ctx context.Context, workspaceID, sessionID, turnID string) (storesqlite.Turn, bool, error) {
+	store, err := s.store(workspaceID)
+	if err != nil {
+		return storesqlite.Turn{}, false, err
+	}
+	return store.GetTurn(ctx, workspaceID, sessionID, turnID)
+}
+
+func (s *SQLiteWorkspaceStore) FindTurnByClientSubmitID(ctx context.Context, workspaceID, sessionID, clientSubmitID string) (string, bool, error) {
+	store, err := s.store(workspaceID)
+	if err != nil {
+		return "", false, err
+	}
+	return store.FindTurnByClientSubmitID(ctx, workspaceID, sessionID, clientSubmitID)
+}
+
+func (s *SQLiteWorkspaceStore) ListLatestTurnInteractions(ctx context.Context, workspaceID string, sessionIDs []string) (map[string][]storesqlite.Interaction, error) {
+	store, err := s.store(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	return store.ListLatestTurnInteractions(ctx, workspaceID, sessionIDs)
+}
+
+func (s *SQLiteWorkspaceStore) ListSessionInteractions(ctx context.Context, input storesqlite.ListSessionInteractionsInput) ([]storesqlite.Interaction, error) {
+	store, err := s.store(input.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+	return store.ListSessionInteractions(ctx, input)
+}
+
+func (s *SQLiteWorkspaceStore) ListSessionMessages(ctx context.Context, input storesqlite.ListSessionMessagesInput) (storesqlite.MessagePage, bool, error) {
+	store, err := s.store(input.WorkspaceID)
+	if err != nil {
+		return storesqlite.MessagePage{}, false, err
+	}
+	return store.ListSessionMessages(ctx, input)
+}
+
+func (s *SQLiteWorkspaceStore) PrepareSubmitClaim(ctx context.Context, input storesqlite.SubmitClaimPrepare) (storesqlite.SubmitClaim, bool, error) {
+	store, err := s.store(input.WorkspaceID)
+	if err != nil {
+		return storesqlite.SubmitClaim{}, false, err
+	}
+	return store.PrepareSubmitClaim(ctx, input)
+}
+
+func (s *SQLiteWorkspaceStore) AcceptSubmitClaim(ctx context.Context, workspaceID, sessionID, clientSubmitID, turnID string, now int64) (storesqlite.SubmitClaim, bool, error) {
+	store, err := s.store(workspaceID)
+	if err != nil {
+		return storesqlite.SubmitClaim{}, false, err
+	}
+	return store.AcceptSubmitClaim(ctx, workspaceID, sessionID, clientSubmitID, turnID, now)
+}
+
+func (s *SQLiteWorkspaceStore) DeleteSubmitClaim(ctx context.Context, workspaceID, sessionID, clientSubmitID string) (bool, error) {
+	store, err := s.store(workspaceID)
+	if err != nil {
+		return false, err
+	}
+	return store.DeleteSubmitClaim(ctx, workspaceID, sessionID, clientSubmitID)
+}
+
+func (s *SQLiteWorkspaceStore) store(workspaceID string) (*storesqlite.Store, error) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if s == nil || s.StoreForWorkspace == nil || workspaceID == "" {
+		return nil, errors.New("workspace-scoped canonical agent store is unavailable")
+	}
+	store := s.StoreForWorkspace(workspaceID)
+	if store == nil {
+		return nil, errors.New("workspace-scoped canonical agent store is unavailable")
+	}
+	return store, nil
+}
+
+func (s *SQLiteWorkspaceStore) currentUserID() string {
+	if s != nil && s.CurrentUserID != nil {
+		return strings.TrimSpace(s.CurrentUserID())
+	}
+	return ""
+}
+
+func (s *SQLiteWorkspaceStore) now() time.Time {
+	if s != nil && s.Clock != nil {
+		return s.Clock.Now()
+	}
+	return time.Now().UTC()
+}
+
+func composerSettingsPayload(settings *ComposerSettings) map[string]any {
+	if settings == nil {
+		return nil
+	}
+	return map[string]any{
+		"model": settings.Model, "permissionModeId": settings.PermissionModeID, "planMode": settings.PlanMode,
+		"browserUse": settings.BrowserUse, "computerUse": settings.ComputerUse,
+		"reasoningEffort": settings.ReasoningEffort, "speed": settings.Speed,
+		"conversationDetailMode": settings.ConversationDetailMode,
+	}
+}
+
+func composerSettingsModel(settings *ComposerSettings) string {
+	if settings == nil {
+		return ""
+	}
+	return strings.TrimSpace(settings.Model)
+}
+
+func runtimeLifecycleStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "failed":
+		return "failed"
+	case "completed", "canceled":
+		return "ended"
+	default:
+		return "active"
+	}
+}
+
+func runtimeLifecyclePhase(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "working":
+		return "working"
+	case "waiting":
+		return "waiting"
+	case "failed":
+		return "failed"
+	default:
+		return "idle"
+	}
+}
+
+func cloneStringAnyMap(input map[string]any) map[string]any {
+	if input == nil {
+		return nil
+	}
+	result := make(map[string]any, len(input))
+	for key, value := range input {
+		result[key] = value
+	}
+	return result
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/packages/agent/host/sqlite_workspace_store.go
+++ b/packages/agent/host/sqlite_workspace_store.go
@@ -22,7 +22,15 @@ type SQLiteWorkspaceStore struct {
 	CurrentUserID          func() string
 	Clock                  Clock
 	Observer               CommitObserver
+	InitializationPolicy   RuntimeSessionInitializationPolicy
 	InitializationObserver RuntimeSessionInitializationObserver
+}
+
+// RuntimeSessionInitializationPolicy normalizes product-owned identity fields
+// before the shared store commits the canonical session shell. It cannot write
+// canonical state itself.
+type RuntimeSessionInitializationPolicy interface {
+	NormalizeRuntimeSessionInitialization(context.Context, ProviderRuntimeSession) (ProviderRuntimeSession, error)
 }
 
 // RuntimeSessionInitializationObserver projects product-owned, repairable
@@ -71,6 +79,13 @@ func (s *SQLiteWorkspaceStore) RollbackRuntimeSessionInitialization(ctx context.
 }
 
 func (s *SQLiteWorkspaceStore) InitializeRuntimeSession(ctx context.Context, session ProviderRuntimeSession) (storesqlite.Session, error) {
+	if s != nil && s.InitializationPolicy != nil {
+		var err error
+		session, err = s.InitializationPolicy.NormalizeRuntimeSessionInitialization(ctx, session)
+		if err != nil {
+			return storesqlite.Session{}, err
+		}
+	}
 	workspaceID := strings.TrimSpace(session.WorkspaceID)
 	sessionID := strings.TrimSpace(session.ID)
 	if workspaceID == "" || sessionID == "" {
@@ -179,6 +194,14 @@ func (s *SQLiteWorkspaceStore) PlanDeleteSessions(ctx context.Context, input sto
 		return storesqlite.DeleteSessionsPlan{}, err
 	}
 	return store.PlanDeleteSessions(ctx, input)
+}
+
+func (s *SQLiteWorkspaceStore) PlanClearSessions(ctx context.Context, workspaceID string) (storesqlite.DeleteSessionsPlan, error) {
+	store, err := s.store(strings.TrimSpace(workspaceID))
+	if err != nil {
+		return storesqlite.DeleteSessionsPlan{}, err
+	}
+	return store.PlanClearSessions(ctx, workspaceID)
 }
 
 func (s *SQLiteWorkspaceStore) DeleteSessionsBatch(ctx context.Context, input storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsBatchResult, error) {

--- a/packages/agent/host/sqlite_workspace_store_test.go
+++ b/packages/agent/host/sqlite_workspace_store_test.go
@@ -28,6 +28,17 @@ type runtimeSessionInitializationObserver struct {
 	persisted storesqlite.Session
 }
 
+type runtimeSessionInitializationPolicy struct{ calls int }
+
+func (p *runtimeSessionInitializationPolicy) NormalizeRuntimeSessionInitialization(
+	_ context.Context,
+	session agenthost.ProviderRuntimeSession,
+) (agenthost.ProviderRuntimeSession, error) {
+	p.calls++
+	session.AgentTargetID = "canonical-target"
+	return session, nil
+}
+
 func (o *runtimeSessionInitializationObserver) ObserveRuntimeSessionInitialized(
 	_ context.Context,
 	runtime agenthost.ProviderRuntimeSession,
@@ -50,6 +61,7 @@ func TestSQLiteWorkspaceStoreInitializesCanonicalRuntimeSession(t *testing.T) {
 	}
 	observer := &workspaceStoreObserver{}
 	initializationObserver := &runtimeSessionInitializationObserver{}
+	initializationPolicy := &runtimeSessionInitializationPolicy{}
 	store := &agenthost.SQLiteWorkspaceStore{
 		StoreForWorkspace: func(workspaceID string) *storesqlite.Store {
 			if workspaceID != "workspace-1" {
@@ -60,6 +72,7 @@ func TestSQLiteWorkspaceStoreInitializesCanonicalRuntimeSession(t *testing.T) {
 		CurrentUserID:          func() string { return " user-1 " },
 		Clock:                  workspaceStoreClock{value: time.UnixMilli(1234)},
 		Observer:               observer,
+		InitializationPolicy:   initializationPolicy,
 		InitializationObserver: initializationObserver,
 	}
 
@@ -71,7 +84,7 @@ func TestSQLiteWorkspaceStoreInitializesCanonicalRuntimeSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InitializeRuntimeSession() error = %v", err)
 	}
-	if persisted.ID != "session-1" || persisted.UserID != "user-1" || persisted.Provider != "codex" {
+	if persisted.ID != "session-1" || persisted.UserID != "user-1" || persisted.Provider != "codex" || persisted.AgentTargetID != "canonical-target" {
 		t.Fatalf("persisted session = %#v", persisted)
 	}
 	if persisted.LastEventUnixMS != 1234 || persisted.Settings["reasoningEffort"] != "ultra" || persisted.Settings["speed"] != "standard" {
@@ -85,6 +98,9 @@ func TestSQLiteWorkspaceStoreInitializesCanonicalRuntimeSession(t *testing.T) {
 	}
 	if initializationObserver.runtime.ID != "session-1" || initializationObserver.persisted.ID != "session-1" {
 		t.Fatalf("initialization projection = %#v", initializationObserver)
+	}
+	if initializationPolicy.calls != 1 {
+		t.Fatalf("initialization policy calls = %d, want 1", initializationPolicy.calls)
 	}
 }
 

--- a/packages/agent/host/sqlite_workspace_store_test.go
+++ b/packages/agent/host/sqlite_workspace_store_test.go
@@ -1,0 +1,96 @@
+package agenthost_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	_ "modernc.org/sqlite"
+)
+
+type workspaceStoreClock struct{ value time.Time }
+
+func (c workspaceStoreClock) Now() time.Time { return c.value }
+
+type workspaceStoreObserver struct{ deltas []agenthost.CommittedDelta }
+
+func (o *workspaceStoreObserver) ObserveCommitted(_ context.Context, delta agenthost.CommittedDelta) error {
+	o.deltas = append(o.deltas, delta)
+	return nil
+}
+
+type runtimeSessionInitializationObserver struct {
+	runtime   agenthost.ProviderRuntimeSession
+	persisted storesqlite.Session
+}
+
+func (o *runtimeSessionInitializationObserver) ObserveRuntimeSessionInitialized(
+	_ context.Context,
+	runtime agenthost.ProviderRuntimeSession,
+	persisted storesqlite.Session,
+) {
+	o.runtime = runtime
+	o.persisted = persisted
+}
+
+func TestSQLiteWorkspaceStoreInitializesCanonicalRuntimeSession(t *testing.T) {
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "agent-host-store.db"))
+	if err != nil {
+		t.Fatalf("open SQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	canonical := storesqlite.New(db, storesqlite.Options{})
+	if err := canonical.Migrate(t.Context()); err != nil {
+		t.Fatalf("migrate SQLite: %v", err)
+	}
+	observer := &workspaceStoreObserver{}
+	initializationObserver := &runtimeSessionInitializationObserver{}
+	store := &agenthost.SQLiteWorkspaceStore{
+		StoreForWorkspace: func(workspaceID string) *storesqlite.Store {
+			if workspaceID != "workspace-1" {
+				return nil
+			}
+			return canonical
+		},
+		CurrentUserID:          func() string { return " user-1 " },
+		Clock:                  workspaceStoreClock{value: time.UnixMilli(1234)},
+		Observer:               observer,
+		InitializationObserver: initializationObserver,
+	}
+
+	persisted, err := store.InitializeRuntimeSession(t.Context(), agenthost.ProviderRuntimeSession{
+		ID: "session-1", WorkspaceID: "workspace-1", AgentTargetID: "target-1", Provider: "codex",
+		Visible: true, Provisional: true, RuntimeContext: map[string]any{"source": "create"},
+		Settings: &agenthost.ComposerSettings{Model: "gpt-5.6", ReasoningEffort: "ultra", Speed: "standard"},
+	})
+	if err != nil {
+		t.Fatalf("InitializeRuntimeSession() error = %v", err)
+	}
+	if persisted.ID != "session-1" || persisted.UserID != "user-1" || persisted.Provider != "codex" {
+		t.Fatalf("persisted session = %#v", persisted)
+	}
+	if persisted.LastEventUnixMS != 1234 || persisted.Settings["reasoningEffort"] != "ultra" || persisted.Settings["speed"] != "standard" {
+		t.Fatalf("persisted canonical fields = %#v", persisted)
+	}
+	if persisted.Metadata.Visible {
+		t.Fatalf("provisional session visibility = true, want false")
+	}
+	if len(observer.deltas) != 1 || len(observer.deltas[0].ProjectionDirty) == 0 || len(observer.deltas[0].ViewsInvalidated) != 1 {
+		t.Fatalf("commit deltas = %#v", observer.deltas)
+	}
+	if initializationObserver.runtime.ID != "session-1" || initializationObserver.persisted.ID != "session-1" {
+		t.Fatalf("initialization projection = %#v", initializationObserver)
+	}
+}
+
+func TestSQLiteWorkspaceStoreRejectsUnknownWorkspace(t *testing.T) {
+	store := &agenthost.SQLiteWorkspaceStore{StoreForWorkspace: func(string) *storesqlite.Store { return nil }}
+	if _, _, err := store.GetSession(t.Context(), "workspace-1", "session-1"); err == nil {
+		t.Fatal("GetSession succeeded without a workspace store")
+	}
+}

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -430,6 +430,8 @@ type DeleteSessionsResult struct {
 	CleanupFailedIDs  []string
 }
 
+type ClearSessionsResult = DeleteSessionsResult
+
 type PurgeDeletedSessionsInput struct {
 	CutoffUnixMS    int64
 	MaxSessions     int

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -414,6 +414,20 @@ type DeleteSessionResult struct {
 	Deleted          bool
 	RuntimeClosed    bool
 	CanonicalRemoved bool
+	CleanupFailed    bool
+}
+
+type DeleteSessionsInput struct {
+	WorkspaceID string
+	SessionIDs  []string
+}
+
+type DeleteSessionsResult struct {
+	RemovedSessionIDs []string
+	RemovedSessions   int
+	RemovedMessages   int
+	RuntimeClosedIDs  []string
+	CleanupFailedIDs  []string
 }
 
 type PurgeDeletedSessionsInput struct {

--- a/packages/agent/store-sqlite/activity_delete.go
+++ b/packages/agent/store-sqlite/activity_delete.go
@@ -5,9 +5,36 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
+
+var ErrDeleteSessionsPlanChanged = errors.New("workspace agent session deletion plan changed")
+
+func (s *Store) PlanDeleteSessions(
+	ctx context.Context,
+	input DeleteSessionsBatchInput,
+) (DeleteSessionsPlan, error) {
+	if s == nil || s.db == nil {
+		return DeleteSessionsPlan{}, errors.New("workspace database is not initialized")
+	}
+	workspaceID := strings.TrimSpace(input.WorkspaceID)
+	sessionIDs := normalizedSessionIDs(input.SessionIDs)
+	if workspaceID == "" || len(sessionIDs) == 0 {
+		return DeleteSessionsPlan{}, nil
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return DeleteSessionsPlan{}, fmt.Errorf("begin plan workspace agent sessions delete: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	resolved, err := expandSessionTreeIDsTx(ctx, tx, workspaceID, sessionIDs)
+	if err != nil {
+		return DeleteSessionsPlan{}, err
+	}
+	return DeleteSessionsPlan{WorkspaceID: workspaceID, SessionIDs: normalizedSessionIDs(resolved)}, nil
+}
 
 func (s *Store) DeleteSession(
 	ctx context.Context,
@@ -85,19 +112,7 @@ func (s *Store) DeleteSessionsBatch(
 		return DeleteSessionsBatchResult{}, errors.New("workspace database is not initialized")
 	}
 	workspaceID := strings.TrimSpace(input.WorkspaceID)
-	sessionIDs := make([]string, 0, len(input.SessionIDs))
-	seenSessionIDs := make(map[string]struct{}, len(input.SessionIDs))
-	for _, value := range input.SessionIDs {
-		sessionID := strings.TrimSpace(value)
-		if sessionID == "" {
-			continue
-		}
-		if _, exists := seenSessionIDs[sessionID]; exists {
-			continue
-		}
-		seenSessionIDs[sessionID] = struct{}{}
-		sessionIDs = append(sessionIDs, sessionID)
-	}
+	sessionIDs := normalizedSessionIDs(input.SessionIDs)
 	if workspaceID == "" || len(sessionIDs) == 0 {
 		return DeleteSessionsBatchResult{}, nil
 	}
@@ -116,6 +131,9 @@ func (s *Store) DeleteSessionsBatch(
 	removedSessionIDs, err := expandSessionTreeIDsTx(ctx, tx, workspaceID, sessionIDs)
 	if err != nil {
 		return DeleteSessionsBatchResult{}, err
+	}
+	if expected := normalizedSessionIDs(input.ExpectedSessionIDs); len(expected) > 0 && !equalStrings(expected, normalizedSessionIDs(removedSessionIDs)) {
+		return DeleteSessionsBatchResult{}, ErrDeleteSessionsPlanChanged
 	}
 	now := unixMs(time.Now().UTC())
 	for _, agentSessionID := range sessionIDs {
@@ -147,6 +165,36 @@ func (s *Store) DeleteSessionsBatch(
 		RemovedSessions:   removedSessions,
 		RemovedSessionIDs: removedSessionIDs,
 	}, nil
+}
+
+func normalizedSessionIDs(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
 }
 
 func deleteGoalRecordsForSessionTx(ctx context.Context, tx *sql.Tx, workspaceID string, agentSessionID string) error {

--- a/packages/agent/store-sqlite/activity_delete.go
+++ b/packages/agent/store-sqlite/activity_delete.go
@@ -12,6 +12,35 @@ import (
 
 var ErrDeleteSessionsPlanChanged = errors.New("workspace agent session deletion plan changed")
 
+// PlanClearSessions resolves the exact canonical session set owned by one
+// workspace. Host uses this snapshot to close live runtimes before issuing the
+// same atomic batch deletion command used by scoped deletes.
+func (s *Store) PlanClearSessions(
+	ctx context.Context,
+	workspaceID string,
+) (DeleteSessionsPlan, error) {
+	if s == nil || s.db == nil {
+		return DeleteSessionsPlan{}, errors.New("workspace database is not initialized")
+	}
+	workspaceID = strings.TrimSpace(workspaceID)
+	if workspaceID == "" {
+		return DeleteSessionsPlan{}, nil
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return DeleteSessionsPlan{}, fmt.Errorf("begin plan workspace agent sessions clear: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	sessionIDs, err := listAgentSessionIDsTx(ctx, tx, workspaceID)
+	if err != nil {
+		return DeleteSessionsPlan{}, err
+	}
+	return DeleteSessionsPlan{
+		WorkspaceID: workspaceID,
+		SessionIDs:  normalizedSessionIDs(sessionIDs),
+	}, nil
+}
+
 func (s *Store) PlanDeleteSessions(
 	ctx context.Context,
 	input DeleteSessionsBatchInput,

--- a/packages/agent/store-sqlite/child_sessions_test.go
+++ b/packages/agent/store-sqlite/child_sessions_test.go
@@ -2,6 +2,7 @@ package storesqlite
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -131,6 +132,26 @@ func TestDeleteSessionsBatchExpandsChildSessionTree(t *testing.T) {
 	for _, sessionID := range []string{"root", "child-1", "child-2"} {
 		if !containsString(result.RemovedSessionIDs, sessionID) {
 			t.Fatalf("removed session ids=%#v, want %s", result.RemovedSessionIDs, sessionID)
+		}
+	}
+}
+
+func TestDeleteSessionsBatchRejectsChangedDeletionPlan(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	seedChildSessionTree(t, store)
+
+	_, err := store.DeleteSessionsBatch(context.Background(), DeleteSessionsBatchInput{
+		WorkspaceID:        "ws-1",
+		SessionIDs:         []string{"root"},
+		ExpectedSessionIDs: []string{"root"},
+	})
+	if !errors.Is(err, ErrDeleteSessionsPlanChanged) {
+		t.Fatalf("DeleteSessionsBatch() error = %v, want plan changed", err)
+	}
+	for _, sessionID := range []string{"root", "child-1", "child-2"} {
+		if deleted, lookupErr := store.SessionDeleted(context.Background(), "ws-1", sessionID); lookupErr != nil || deleted {
+			t.Fatalf("SessionDeleted(%s)=%v err=%v after rejected plan", sessionID, deleted, lookupErr)
 		}
 	}
 }

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -16,6 +16,7 @@ import (
 // All methods are scoped by a host-defined workspace ID.
 type Repository interface {
 	ClearSessions(context.Context, string) (ClearSessionsResult, error)
+	PlanClearSessions(context.Context, string) (DeleteSessionsPlan, error)
 	PlanDeleteSessions(context.Context, DeleteSessionsBatchInput) (DeleteSessionsPlan, error)
 	DeleteSessionsBatch(context.Context, DeleteSessionsBatchInput) (DeleteSessionsBatchResult, error)
 	GetSession(context.Context, string, string) (Session, bool, error)

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -16,7 +16,7 @@ import (
 // All methods are scoped by a host-defined workspace ID.
 type Repository interface {
 	ClearSessions(context.Context, string) (ClearSessionsResult, error)
-	DeleteSessionWithCommit(context.Context, string, string) (DeleteSessionResult, error)
+	PlanDeleteSessions(context.Context, DeleteSessionsBatchInput) (DeleteSessionsPlan, error)
 	DeleteSessionsBatch(context.Context, DeleteSessionsBatchInput) (DeleteSessionsBatchResult, error)
 	GetSession(context.Context, string, string) (Session, bool, error)
 	ListChildSessions(context.Context, string, string) ([]Session, error)
@@ -212,6 +212,12 @@ type SessionSectionDeletionCandidates struct {
 }
 
 type DeleteSessionsBatchInput struct {
+	WorkspaceID        string
+	SessionIDs         []string
+	ExpectedSessionIDs []string
+}
+
+type DeleteSessionsPlan struct {
 	WorkspaceID string
 	SessionIDs  []string
 }

--- a/packages/agent/store-sqlite/session_metadata.go
+++ b/packages/agent/store-sqlite/session_metadata.go
@@ -41,6 +41,22 @@ type SessionGoal struct {
 	Tokens     int64  `json:"tokens,omitempty"`
 }
 
+// DecodeSessionGoal validates and decodes the canonical goal payload shared by
+// goal state and session metadata into the public typed session contract.
+func DecodeSessionGoal(raw any) (*SessionGoal, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	var value SessionGoal
+	if err := remarshalJSON(raw, &value); err != nil {
+		return nil, err
+	}
+	if err := validateSessionGoal(value); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
 var sessionMetadataRuntimeContextKeys = []string{"visible", "imported", "capabilities", "usage", "goal"}
 
 func splitSessionRuntimeContext(runtimeContext map[string]any) (SessionMetadata, map[string]any, error) {
@@ -76,14 +92,11 @@ func splitSessionRuntimeContext(runtimeContext map[string]any) (SessionMetadata,
 		metadata.Usage = &value
 	}
 	if raw := runtimeContext["goal"]; raw != nil {
-		var value SessionGoal
-		if err := remarshalJSON(raw, &value); err != nil {
+		value, err := DecodeSessionGoal(raw)
+		if err != nil {
 			return SessionMetadata{}, nil, err
 		}
-		if err := validateSessionGoal(value); err != nil {
-			return SessionMetadata{}, nil, err
-		}
-		metadata.Goal = &value
+		metadata.Goal = value
 	}
 	internal := cloneJSONMap(runtimeContext)
 	for _, key := range sessionMetadataRuntimeContextKeys {

--- a/packages/agent/store-sqlite/session_metadata_test.go
+++ b/packages/agent/store-sqlite/session_metadata_test.go
@@ -50,3 +50,18 @@ func TestSplitSessionRuntimeContextUsesClosedMetadataVocabularies(t *testing.T) 
 		t.Fatalf("internal context = %#v, want empty", internal)
 	}
 }
+
+func TestDecodeSessionGoalUsesCanonicalValidation(t *testing.T) {
+	goal, err := DecodeSessionGoal(map[string]any{
+		"objective": "ship", "status": "paused", "iterations": 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if goal.Objective != "ship" || goal.Status != "paused" || goal.Iterations != 2 {
+		t.Fatalf("goal=%#v", goal)
+	}
+	if _, err := DecodeSessionGoal(map[string]any{"objective": "ship", "status": "unknown"}); err == nil {
+		t.Fatal("DecodeSessionGoal() error=nil, want closed status validation")
+	}
+}

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -2137,6 +2137,7 @@ export type ExternalAgentImportResultResponse = {
 
 export type DeleteWorkspaceAgentSessionResponse = {
   removed: boolean;
+  cleanupFailed: boolean;
 };
 
 export type WorkspaceAgentSessionSectionDeletionCandidatesResponse = {
@@ -2155,6 +2156,7 @@ export type DeleteWorkspaceAgentSessionsBatchResponse = {
   removedMessages: number;
   removedSessions: number;
   removedSessionIds: Array<string>;
+  cleanupFailedSessionIds: Array<string>;
 };
 
 export type ClearWorkspaceAgentSessionsResponse = {

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -2162,6 +2162,7 @@ export type DeleteWorkspaceAgentSessionsBatchResponse = {
 export type ClearWorkspaceAgentSessionsResponse = {
   removedMessages: number;
   removedSessions: number;
+  cleanupFailedSessionIds: Array<string>;
 };
 
 export type UpdateWorkspaceAgentSessionPinRequest = {

--- a/services/tuttid/api/daemon_agent_session_list.go
+++ b/services/tuttid/api/daemon_agent_session_list.go
@@ -173,9 +173,10 @@ func (api DaemonAPI) DeleteWorkspaceAgentSessionsBatch(ctx context.Context, requ
 		return writeDeleteWorkspaceAgentSessionsBatchError(err), nil
 	}
 	return tuttigenerated.DeleteWorkspaceAgentSessionsBatch200JSONResponse{
-		RemovedMessages:   result.RemovedMessages,
-		RemovedSessionIds: result.RemovedSessionIDs,
-		RemovedSessions:   result.RemovedSessions,
+		RemovedMessages:         result.RemovedMessages,
+		RemovedSessionIds:       result.RemovedSessionIDs,
+		RemovedSessions:         result.RemovedSessions,
+		CleanupFailedSessionIds: result.CleanupFailedSessionIDs,
 	}, nil
 }
 

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -63,8 +63,9 @@ func (api DaemonAPI) ClearWorkspaceAgentSessions(ctx context.Context, request tu
 		return writeClearWorkspaceAgentSessionsError(err), nil
 	}
 	return tuttigenerated.ClearWorkspaceAgentSessions200JSONResponse{
-		RemovedMessages: result.RemovedMessages,
-		RemovedSessions: result.RemovedSessions,
+		RemovedMessages:         result.RemovedMessages,
+		RemovedSessions:         result.RemovedSessions,
+		CleanupFailedSessionIds: append([]string(nil), result.CleanupFailedSessionIDs...),
 	}, nil
 }
 

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -39,7 +39,7 @@ type AgentSessionService interface {
 	ResolveGitPatchSupportForPath(context.Context, string, string) (agentservice.GitPatchSupport, error)
 	ApplyGitPatchForPath(context.Context, string, agentservice.ApplyGitPatchInput) (agentservice.ApplyGitPatchResult, error)
 	Clear(context.Context, string) (agentservice.ClearSessionsResult, error)
-	Delete(context.Context, string, string) (bool, error)
+	Delete(context.Context, string, string) (agentservice.DeleteSessionResult, error)
 	CancelTurn(context.Context, string, string, string) (agentservice.CancelTurnResult, error)
 	GoalControl(ctx context.Context, workspaceID string, agentSessionID string, action string, objective string) (agentservice.GoalControlSessionResult, error)
 	GetGoalState(context.Context, string, string) (agentservice.GoalStateSessionResult, error)
@@ -130,12 +130,12 @@ func (api DaemonAPI) DeleteWorkspaceAgentSession(ctx context.Context, request tu
 			ServiceUnavailableErrorJSONResponse: agentSessionServiceUnavailableError(),
 		}, nil
 	}
-	removed, err := api.AgentSessionService.Delete(ctx, string(request.WorkspaceID), string(request.AgentSessionID))
+	result, err := api.AgentSessionService.Delete(ctx, string(request.WorkspaceID), string(request.AgentSessionID))
 	if err != nil {
 		return writeDeleteWorkspaceAgentSessionError(err), nil
 	}
 	return tuttigenerated.DeleteWorkspaceAgentSession200JSONResponse{
-		Removed: removed,
+		Removed: result.Removed, CleanupFailed: result.CleanupFailed,
 	}, nil
 }
 

--- a/services/tuttid/api/daemon_test.go
+++ b/services/tuttid/api/daemon_test.go
@@ -93,7 +93,7 @@ type stubAgentSessionService struct {
 	clearFn                         func(context.Context, string) (agentservice.ClearSessionsResult, error)
 	composerOptionsFn               func(context.Context, agentservice.ComposerOptionsInput) (agentservice.ComposerOptions, error)
 	createFn                        func(context.Context, string, agentservice.CreateSessionInput) (agentservice.Session, error)
-	deleteFn                        func(context.Context, string, string) (bool, error)
+	deleteFn                        func(context.Context, string, string) (agentservice.DeleteSessionResult, error)
 	listSectionDeletionCandidatesFn func(context.Context, string, agentservice.ListSessionSectionDeletionCandidatesInput) (agentservice.SessionSectionDeletionCandidates, error)
 	deleteSessionsBatchFn           func(context.Context, string, agentservice.DeleteSessionsBatchInput) (agentservice.DeleteSessionsBatchResult, error)
 	importExternalFn                func(context.Context, string, agentservice.ExternalImportInput) (agentservice.ExternalImportResult, error)
@@ -388,9 +388,9 @@ func (s stubAgentSessionService) ApplyGitPatchForPath(ctx context.Context, works
 	return agentservice.ApplyGitPatchResult{}, nil
 }
 
-func (s stubAgentSessionService) Delete(ctx context.Context, workspaceID string, agentSessionID string) (bool, error) {
+func (s stubAgentSessionService) Delete(ctx context.Context, workspaceID string, agentSessionID string) (agentservice.DeleteSessionResult, error) {
 	if s.deleteFn == nil {
-		return true, nil
+		return agentservice.DeleteSessionResult{Removed: true}, nil
 	}
 	return s.deleteFn(ctx, workspaceID, agentSessionID)
 }
@@ -1124,9 +1124,10 @@ func TestDaemonAPIGeneratedRoutesDeleteAgentSessionsBatchForwardsExactIDs(t *tes
 					t.Fatalf("delete input = %#v, want exact session IDs", input)
 				}
 				return agentservice.DeleteSessionsBatchResult{
-					RemovedMessages:   5,
-					RemovedSessions:   2,
-					RemovedSessionIDs: []string{"session-1", "session-2"},
+					RemovedMessages:         5,
+					RemovedSessions:         2,
+					RemovedSessionIDs:       []string{"session-1", "session-2"},
+					CleanupFailedSessionIDs: []string{"session-2"},
 				}, nil
 			},
 		},
@@ -1145,6 +1146,11 @@ func TestDaemonAPIGeneratedRoutesDeleteAgentSessionsBatchForwardsExactIDs(t *tes
 	var response tuttigenerated.DeleteWorkspaceAgentSessionsBatchResponse
 	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
 		t.Fatalf("decode response error = %v", err)
+	}
+	if response.RemovedMessages != 5 || response.RemovedSessions != 2 ||
+		!slices.Equal(response.RemovedSessionIds, []string{"session-1", "session-2"}) ||
+		!slices.Equal(response.CleanupFailedSessionIds, []string{"session-2"}) {
+		t.Fatalf("response = %#v", response)
 	}
 	if response.RemovedSessions != 2 || !slices.Equal(response.RemovedSessionIds, []string{"session-1", "session-2"}) {
 		t.Fatalf("response = %#v", response)
@@ -1973,14 +1979,14 @@ func TestDaemonAPIGeneratedRoutesDeleteAgentSession(t *testing.T) {
 	mux := http.NewServeMux()
 	RegisterRoutes(mux, NewRoutes(DaemonAPI{
 		AgentSessionService: stubAgentSessionService{
-			deleteFn: func(_ context.Context, workspaceID string, agentSessionID string) (bool, error) {
+			deleteFn: func(_ context.Context, workspaceID string, agentSessionID string) (agentservice.DeleteSessionResult, error) {
 				if workspaceID != "ws-1" {
 					t.Fatalf("workspaceID = %q, want ws-1", workspaceID)
 				}
 				if agentSessionID != "agent-session-1" {
 					t.Fatalf("agentSessionID = %q, want agent-session-1", agentSessionID)
 				}
-				return true, nil
+				return agentservice.DeleteSessionResult{Removed: true, CleanupFailed: true}, nil
 			},
 		},
 	}))
@@ -2000,6 +2006,9 @@ func TestDaemonAPIGeneratedRoutesDeleteAgentSession(t *testing.T) {
 	decodeGeneratedRouteResponse(t, recorder, &response)
 	if !response.Removed {
 		t.Fatal("removed = false, want true")
+	}
+	if !response.CleanupFailed {
+		t.Fatal("cleanupFailed = false, want true")
 	}
 }
 

--- a/services/tuttid/api/daemon_test.go
+++ b/services/tuttid/api/daemon_test.go
@@ -2020,7 +2020,10 @@ func TestDaemonAPIGeneratedRoutesClearAgentSessions(t *testing.T) {
 				if workspaceID != "ws-1" {
 					t.Fatalf("workspaceID = %q, want ws-1", workspaceID)
 				}
-				return agentservice.ClearSessionsResult{RemovedMessages: 5, RemovedSessions: 2}, nil
+				return agentservice.ClearSessionsResult{
+					RemovedMessages: 5, RemovedSessions: 2,
+					CleanupFailedSessionIDs: []string{"session-2"},
+				}, nil
 			},
 		},
 	}))
@@ -2040,6 +2043,9 @@ func TestDaemonAPIGeneratedRoutesClearAgentSessions(t *testing.T) {
 	decodeGeneratedRouteResponse(t, recorder, &response)
 	if response.RemovedSessions != 2 || response.RemovedMessages != 5 {
 		t.Fatalf("response = %#v, want 2 sessions and 5 messages", response)
+	}
+	if !slices.Equal(response.CleanupFailedSessionIds, []string{"session-2"}) {
+		t.Fatalf("cleanupFailedSessionIds = %#v, want session-2", response.CleanupFailedSessionIds)
 	}
 }
 

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -3232,8 +3232,9 @@ type CheckUserProjectPathRequest struct {
 
 // ClearWorkspaceAgentSessionsResponse defines model for ClearWorkspaceAgentSessionsResponse.
 type ClearWorkspaceAgentSessionsResponse struct {
-	RemovedMessages int `json:"removedMessages"`
-	RemovedSessions int `json:"removedSessions"`
+	CleanupFailedSessionIds []string `json:"cleanupFailedSessionIds"`
+	RemovedMessages         int      `json:"removedMessages"`
+	RemovedSessions         int      `json:"removedSessions"`
 }
 
 // CliCapabilitiesResponse defines model for CliCapabilitiesResponse.

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -3551,7 +3551,8 @@ type DeleteUserProjectRequest struct {
 
 // DeleteWorkspaceAgentSessionResponse defines model for DeleteWorkspaceAgentSessionResponse.
 type DeleteWorkspaceAgentSessionResponse struct {
-	Removed bool `json:"removed"`
+	CleanupFailed bool `json:"cleanupFailed"`
+	Removed       bool `json:"removed"`
 }
 
 // DeleteWorkspaceAgentSessionsBatchRequest defines model for DeleteWorkspaceAgentSessionsBatchRequest.
@@ -3561,9 +3562,10 @@ type DeleteWorkspaceAgentSessionsBatchRequest struct {
 
 // DeleteWorkspaceAgentSessionsBatchResponse defines model for DeleteWorkspaceAgentSessionsBatchResponse.
 type DeleteWorkspaceAgentSessionsBatchResponse struct {
-	RemovedMessages   int      `json:"removedMessages"`
-	RemovedSessionIds []string `json:"removedSessionIds"`
-	RemovedSessions   int      `json:"removedSessions"`
+	CleanupFailedSessionIds []string `json:"cleanupFailedSessionIds"`
+	RemovedMessages         int      `json:"removedMessages"`
+	RemovedSessionIds       []string `json:"removedSessionIds"`
+	RemovedSessions         int      `json:"removedSessions"`
 }
 
 // DeleteWorkspaceAppResponse defines model for DeleteWorkspaceAppResponse.

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -9823,8 +9823,11 @@ components:
       additionalProperties: false
       required:
         - removed
+        - cleanupFailed
       properties:
         removed:
+          type: boolean
+        cleanupFailed:
           type: boolean
     WorkspaceAgentSessionSectionDeletionCandidatesResponse:
       type: object
@@ -9872,6 +9875,7 @@ components:
         - removedMessages
         - removedSessions
         - removedSessionIds
+        - cleanupFailedSessionIds
       properties:
         removedMessages:
           type: integer
@@ -9880,6 +9884,11 @@ components:
           type: integer
           minimum: 0
         removedSessionIds:
+          type: array
+          items:
+            type: string
+            minLength: 1
+        cleanupFailedSessionIds:
           type: array
           items:
             type: string

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -9899,6 +9899,7 @@ components:
       required:
         - removedMessages
         - removedSessions
+        - cleanupFailedSessionIds
       properties:
         removedMessages:
           type: integer
@@ -9906,6 +9907,11 @@ components:
         removedSessions:
           type: integer
           minimum: 0
+        cleanupFailedSessionIds:
+          type: array
+          items:
+            type: string
+            minLength: 1
     UpdateWorkspaceAgentSessionPinRequest:
       type: object
       additionalProperties: false

--- a/services/tuttid/biz/agentactivity/activity.go
+++ b/services/tuttid/biz/agentactivity/activity.go
@@ -11,13 +11,13 @@ type Repository = agentstore.Repository
 type SessionTurnSummaryReader = agentstore.SessionTurnSummaryReader
 
 type ClearSessionsResult = agentstore.ClearSessionsResult
-type DeleteSessionResult = agentstore.DeleteSessionResult
 type PurgeDeletedSessionsInput = agentstore.PurgeDeletedSessionsInput
 type PurgedSession = agentstore.PurgedSession
 type PurgeDeletedSessionsResult = agentstore.PurgeDeletedSessionsResult
 type ListSessionSectionDeletionCandidatesInput = agentstore.ListSessionSectionDeletionCandidatesInput
 type SessionSectionDeletionCandidates = agentstore.SessionSectionDeletionCandidates
 type DeleteSessionsBatchInput = agentstore.DeleteSessionsBatchInput
+type DeleteSessionsPlan = agentstore.DeleteSessionsPlan
 type DeleteSessionsBatchResult = agentstore.DeleteSessionsBatchResult
 type TransactionDelta = agentstore.TransactionDelta
 type TransactionMutation = agentstore.TransactionMutation

--- a/services/tuttid/data/workspace/agent_store.go
+++ b/services/tuttid/data/workspace/agent_store.go
@@ -59,6 +59,12 @@ func (s *SQLiteStore) agentStore() *agentstore.Store {
 	return s.agentWriter
 }
 
+// AgentCanonicalStore exposes the official canonical agent store for Host
+// composition. Product services must not wrap its lifecycle mutations.
+func (s *SQLiteStore) AgentCanonicalStore() *agentstore.Store {
+	return s.agentStore()
+}
+
 func (s *SQLiteStore) agentReadStore() *agentstore.Store {
 	if s == nil {
 		return nil
@@ -187,16 +193,16 @@ func (s *SQLiteStore) ListWorkspaceGeneratedFileTurns(ctx context.Context, input
 	return s.agentReadStore().ListWorkspaceGeneratedFileTurns(ctx, input)
 }
 
-func (s *SQLiteStore) DeleteSession(ctx context.Context, workspaceID string, agentSessionID string) (bool, error) {
-	return s.agentStore().DeleteSession(ctx, workspaceID, agentSessionID)
-}
-
 func (s *SQLiteStore) DeleteSessionsBatch(ctx context.Context, input agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsBatchResult, error) {
 	return s.agentStore().DeleteSessionsBatch(ctx, input)
 }
 
 func (s *SQLiteStore) PlanDeleteSessions(ctx context.Context, input agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsPlan, error) {
 	return s.agentReadStore().PlanDeleteSessions(ctx, input)
+}
+
+func (s *SQLiteStore) PlanClearSessions(ctx context.Context, workspaceID string) (agentactivitybiz.DeleteSessionsPlan, error) {
+	return s.agentReadStore().PlanClearSessions(ctx, workspaceID)
 }
 
 func (s *SQLiteStore) ClearSessions(ctx context.Context, workspaceID string) (agentactivitybiz.ClearSessionsResult, error) {

--- a/services/tuttid/data/workspace/agent_store.go
+++ b/services/tuttid/data/workspace/agent_store.go
@@ -191,12 +191,12 @@ func (s *SQLiteStore) DeleteSession(ctx context.Context, workspaceID string, age
 	return s.agentStore().DeleteSession(ctx, workspaceID, agentSessionID)
 }
 
-func (s *SQLiteStore) DeleteSessionWithCommit(ctx context.Context, workspaceID string, agentSessionID string) (agentactivitybiz.DeleteSessionResult, error) {
-	return s.agentStore().DeleteSessionWithCommit(ctx, workspaceID, agentSessionID)
-}
-
 func (s *SQLiteStore) DeleteSessionsBatch(ctx context.Context, input agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsBatchResult, error) {
 	return s.agentStore().DeleteSessionsBatch(ctx, input)
+}
+
+func (s *SQLiteStore) PlanDeleteSessions(ctx context.Context, input agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsPlan, error) {
+	return s.agentReadStore().PlanDeleteSessions(ctx, input)
 }
 
 func (s *SQLiteStore) ClearSessions(ctx context.Context, workspaceID string) (agentactivitybiz.ClearSessionsResult, error) {

--- a/services/tuttid/data/workspace/sqlite_store_test.go
+++ b/services/tuttid/data/workspace/sqlite_store_test.go
@@ -2170,12 +2170,14 @@ func TestSQLiteStoreDeleteAgentActivitySessionSoftDeletesMessages(t *testing.T) 
 		t.Fatalf("ReportSessionMessages() error = %v", err)
 	}
 
-	removed, err := store.DeleteSession(ctx, "ws-agent-delete", "session-1")
+	deleteResult, err := store.DeleteSessionsBatch(ctx, agentactivitybiz.DeleteSessionsBatchInput{
+		WorkspaceID: "ws-agent-delete", SessionIDs: []string{"session-1"},
+	})
 	if err != nil {
-		t.Fatalf("DeleteSession() error = %v", err)
+		t.Fatalf("DeleteSessionsBatch() error = %v", err)
 	}
-	if !removed {
-		t.Fatal("DeleteSession() removed = false, want true")
+	if deleteResult.RemovedSessions != 1 {
+		t.Fatalf("DeleteSessionsBatch() = %#v, want one removed session", deleteResult)
 	}
 	if _, ok, err := store.GetSession(ctx, "ws-agent-delete", "session-1"); err != nil || ok {
 		t.Fatalf("GetSession() after delete ok=%v error=%v, want ok=false", ok, err)
@@ -2251,8 +2253,8 @@ func TestSQLiteStoreClearAgentActivitySessionsHardDeletesTombstones(t *testing.T
 			t.Fatalf("ReportSessionMessages(%s) error = %v", sessionID, err)
 		}
 	}
-	if removed, err := store.DeleteSession(ctx, workspaceID, "session-1"); err != nil || !removed {
-		t.Fatalf("DeleteSession() removed=%v error=%v, want removed=true", removed, err)
+	if removed, err := store.DeleteSessionsBatch(ctx, agentactivitybiz.DeleteSessionsBatchInput{WorkspaceID: workspaceID, SessionIDs: []string{"session-1"}}); err != nil || removed.RemovedSessions != 1 {
+		t.Fatalf("DeleteSessionsBatch() result=%#v error=%v, want one removed session", removed, err)
 	}
 
 	result, err := store.ClearSessions(ctx, workspaceID)
@@ -2363,8 +2365,8 @@ func TestSQLiteStoreUpdateAgentActivitySessionPinned(t *testing.T) {
 		t.Fatalf("pinnedAtUnixMS after unpin = %d, want 0", unpinned.PinnedAtUnixMS)
 	}
 
-	if removed, err := store.DeleteSession(ctx, "ws-agent-pin", "session-1"); err != nil || !removed {
-		t.Fatalf("DeleteSession() removed=%v error=%v, want removed=true", removed, err)
+	if removed, err := store.DeleteSessionsBatch(ctx, agentactivitybiz.DeleteSessionsBatchInput{WorkspaceID: "ws-agent-pin", SessionIDs: []string{"session-1"}}); err != nil || removed.RemovedSessions != 1 {
+		t.Fatalf("DeleteSessionsBatch() result=%#v error=%v, want one removed session", removed, err)
 	}
 	if _, ok, err := store.UpdateSessionPinned(ctx, "ws-agent-pin", "session-1", true); err != nil || ok {
 		t.Fatalf("UpdateSessionPinned(deleted) ok=%v error=%v, want ok=false", ok, err)
@@ -2438,8 +2440,8 @@ func TestSQLiteStoreDeleteAgentActivitySessionIgnoresLateReports(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("ReportSessionState() error = %v", err)
 	}
-	if removed, err := store.DeleteSession(ctx, "ws-agent-delete-late", "session-1"); err != nil || !removed {
-		t.Fatalf("DeleteSession() removed=%v error=%v, want removed=true", removed, err)
+	if removed, err := store.DeleteSessionsBatch(ctx, agentactivitybiz.DeleteSessionsBatchInput{WorkspaceID: "ws-agent-delete-late", SessionIDs: []string{"session-1"}}); err != nil || removed.RemovedSessions != 1 {
+		t.Fatalf("DeleteSessionsBatch() result=%#v error=%v, want one removed session", removed, err)
 	}
 
 	lateState, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -604,23 +604,11 @@ func (p *ActivityProjection) PlanDeleteSessions(
 	return p.repo.PlanDeleteSessions(ctx, input)
 }
 
-func (p *ActivityProjection) ClearSessions(ctx context.Context, workspaceID string) (ClearSessionsResult, error) {
+func (p *ActivityProjection) PlanClearSessions(ctx context.Context, workspaceID string) (agentactivitybiz.DeleteSessionsPlan, error) {
 	if p == nil || p.repo == nil {
-		return ClearSessionsResult{}, nil
+		return agentactivitybiz.DeleteSessionsPlan{}, nil
 	}
-	workspaceID = strings.TrimSpace(workspaceID)
-	result, err := p.repo.ClearSessions(ctx, workspaceID)
-	if err != nil {
-		return ClearSessionsResult{}, err
-	}
-	if result.RemovedSessions > 0 {
-		agenthost.NotifyCommitted(ctx, p, agenthost.CanonicalDelta(result.CommitDelta))
-	}
-	return ClearSessionsResult{
-		RemovedMessages:   result.RemovedMessages,
-		RemovedSessions:   result.RemovedSessions,
-		RemovedSessionIDs: result.RemovedSessionIDs,
-	}, nil
+	return p.repo.PlanClearSessions(ctx, strings.TrimSpace(workspaceID))
 }
 
 func (p *ActivityProjection) UpdateSessionPinned(ctx context.Context, workspaceID string, agentSessionID string, pinned bool) (PersistedSession, bool, error) {

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -539,22 +539,6 @@ func (p *ActivityProjection) ListSessionSections(
 	return p.repo.ListSessionSections(ctx, input)
 }
 
-func (p *ActivityProjection) DeleteSession(ctx context.Context, workspaceID string, agentSessionID string) (bool, error) {
-	if p == nil || p.repo == nil {
-		return false, nil
-	}
-	workspaceID = strings.TrimSpace(workspaceID)
-	agentSessionID = strings.TrimSpace(agentSessionID)
-	result, err := p.repo.DeleteSessionWithCommit(ctx, workspaceID, agentSessionID)
-	if err != nil {
-		return false, err
-	}
-	if result.RemovedSessions > 0 {
-		agenthost.NotifyCommitted(ctx, p, agenthost.CanonicalDelta(result.CommitDelta))
-	}
-	return result.RemovedSessions > 0, nil
-}
-
 func (p *ActivityProjection) RollbackRuntimeSessionInitialization(ctx context.Context, workspaceID string, agentSessionID string) (bool, error) {
 	if p == nil || p.repo == nil {
 		return false, nil
@@ -608,6 +592,16 @@ func (p *ActivityProjection) DeleteSessionsBatch(
 		agenthost.NotifyCommitted(ctx, p, agenthost.CanonicalDelta(result.CommitDelta))
 	}
 	return result, nil
+}
+
+func (p *ActivityProjection) PlanDeleteSessions(
+	ctx context.Context,
+	input agentactivitybiz.DeleteSessionsBatchInput,
+) (agentactivitybiz.DeleteSessionsPlan, error) {
+	if p == nil || p.repo == nil {
+		return agentactivitybiz.DeleteSessionsPlan{}, nil
+	}
+	return p.repo.PlanDeleteSessions(ctx, input)
 }
 
 func (p *ActivityProjection) ClearSessions(ctx context.Context, workspaceID string) (ClearSessionsResult, error) {

--- a/services/tuttid/service/agent/activity_projection_session_initialize.go
+++ b/services/tuttid/service/agent/activity_projection_session_initialize.go
@@ -7,9 +7,27 @@ import (
 	"time"
 
 	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 )
+
+func (p *ActivityProjection) NormalizeRuntimeSessionInitialization(
+	ctx context.Context,
+	session agenthost.ProviderRuntimeSession,
+) (agenthost.ProviderRuntimeSession, error) {
+	if p == nil {
+		return agenthost.ProviderRuntimeSession{}, fmt.Errorf("agent activity projection is unavailable")
+	}
+	canonicalTargetID, runtimeContext := p.canonicalizeAgentTargetID(
+		ctx,
+		session.AgentTargetID,
+		session.RuntimeContext,
+	)
+	session.AgentTargetID = canonicalTargetID
+	session.RuntimeContext = runtimeContext
+	return session, nil
+}
 
 // InitializeRuntimeSession is the synchronous Create boundary. Runtime
 // reporting remains asynchronous for subsequent observations, but a successful

--- a/services/tuttid/service/agent/codex_model_catalog.go
+++ b/services/tuttid/service/agent/codex_model_catalog.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tutti-os/tutti/packages/agent/daemon/modelcatalog"
 	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 )
 
@@ -225,29 +226,7 @@ func readCodexModelListResponse(scanner *bufio.Scanner) ([]AgentModelOption, err
 }
 
 func parseCodexModelListLine(line []byte) ([]AgentModelOption, bool, error) {
-	var payload map[string]json.RawMessage
-	if err := json.Unmarshal(line, &payload); err != nil {
-		return nil, false, nil
-	}
-	if !codexRPCIDMatches(payload["id"], "2") {
-		return nil, false, nil
-	}
-	if rawError, ok := payload["error"]; ok && string(rawError) != "null" {
-		return nil, true, errors.New(extractCodexRPCError(rawError))
-	}
-	var result struct {
-		Data []json.RawMessage `json:"data"`
-	}
-	if err := json.Unmarshal(payload["result"], &result); err != nil {
-		return nil, true, fmt.Errorf("parse codex model/list result: %w", err)
-	}
-	models := make([]AgentModelOption, 0, len(result.Data))
-	for _, rawModel := range result.Data {
-		if model, ok := normalizeCodexModel(rawModel); ok {
-			models = append(models, model)
-		}
-	}
-	return models, true, nil
+	return modelcatalog.ParseCodexModelListLine(line, "2")
 }
 
 func codexRPCIDMatches(raw json.RawMessage, want string) bool {
@@ -274,83 +253,4 @@ func extractCodexRPCError(raw json.RawMessage) string {
 		return strings.TrimSpace(object.Message)
 	}
 	return "unknown codex app-server RPC error"
-}
-
-func normalizeCodexModel(raw json.RawMessage) (AgentModelOption, bool) {
-	var object map[string]any
-	if err := json.Unmarshal(raw, &object); err != nil {
-		return AgentModelOption{}, false
-	}
-	id := stringMapValue(object, "model")
-	if id == "" {
-		id = stringMapValue(object, "id")
-	}
-	if id == "" {
-		return AgentModelOption{}, false
-	}
-	displayName := stringMapValue(object, "displayName")
-	if displayName == "" {
-		displayName = stringMapValue(object, "display_name")
-	}
-	if displayName == "" {
-		displayName = id
-	}
-	reasoningEffortsValue, reasoningEffortsAdvertised := object["supportedReasoningEfforts"]
-	if !reasoningEffortsAdvertised {
-		reasoningEffortsValue, reasoningEffortsAdvertised = object["supported_reasoning_efforts"]
-	}
-	return AgentModelOption{
-		ID:                         id,
-		DisplayName:                displayName,
-		Description:                stringMapValue(object, "description"),
-		DefaultReasoningEffort:     firstNonEmptyString(stringMapValue(object, "defaultReasoningEffort"), stringMapValue(object, "default_reasoning_effort")),
-		IsDefault:                  boolMapValue(object, "isDefault") || boolMapValue(object, "is_default"),
-		ReasoningEffortsAdvertised: reasoningEffortsAdvertised,
-		SupportedReasoningEfforts:  normalizeCodexReasoningEfforts(reasoningEffortsValue),
-	}, true
-}
-
-func normalizeCodexReasoningEfforts(value any) []AgentModelReasoningEffortOption {
-	rawOptions, ok := value.([]any)
-	if !ok {
-		return nil
-	}
-	options := make([]AgentModelReasoningEffortOption, 0, len(rawOptions))
-	seen := make(map[string]struct{}, len(rawOptions))
-	for _, rawOption := range rawOptions {
-		var option AgentModelReasoningEffortOption
-		switch typed := rawOption.(type) {
-		case string:
-			option.Value = strings.TrimSpace(typed)
-		case map[string]any:
-			option.Value = firstNonEmptyString(
-				stringMapValue(typed, "reasoningEffort"),
-				stringMapValue(typed, "effort"),
-				stringMapValue(typed, "value"),
-			)
-			option.Description = stringMapValue(typed, "description")
-		}
-		if option.Value == "" {
-			continue
-		}
-		if _, exists := seen[option.Value]; exists {
-			continue
-		}
-		seen[option.Value] = struct{}{}
-		options = append(options, option)
-	}
-	return options
-}
-
-func stringMapValue(object map[string]any, key string) string {
-	value, ok := object[key].(string)
-	if !ok {
-		return ""
-	}
-	return strings.TrimSpace(value)
-}
-
-func boolMapValue(object map[string]any, key string) bool {
-	value, ok := object[key].(bool)
-	return ok && value
 }

--- a/services/tuttid/service/agent/codex_model_catalog_test.go
+++ b/services/tuttid/service/agent/codex_model_catalog_test.go
@@ -153,19 +153,6 @@ func (t *strictCodexHandshakeTransport) Read(p []byte) (int, error) {
 	return copy(p, response), nil
 }
 
-func TestNormalizeCodexModelPreservesAdvertisedEmptyReasoningEfforts(t *testing.T) {
-	model, ok := normalizeCodexModel([]byte(`{"id":"no-reasoning","supportedReasoningEfforts":[]}`))
-	if !ok {
-		t.Fatal("normalizeCodexModel ok = false")
-	}
-	if !model.ReasoningEffortsAdvertised {
-		t.Fatal("ReasoningEffortsAdvertised = false, want true")
-	}
-	if model.SupportedReasoningEfforts == nil || len(model.SupportedReasoningEfforts) != 0 {
-		t.Fatalf("SupportedReasoningEfforts = %#v, want advertised empty list", model.SupportedReasoningEfforts)
-	}
-}
-
 func TestCodexCLIModelListerResolvesCodexFromKnownUserBin(t *testing.T) {
 	home := t.TempDir()
 	binDir := filepath.Join(home, ".local", "bin")

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -294,11 +294,8 @@ func (s *Service) discoverLiveComposerModelsUncachedForScope(
 			s.setComposerRuntimeContextForScope(scope, time.Now().UTC(), runtimeContext)
 		}
 		cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), liveModelDiscoveryLifecycleTimeout)
-		_, cleanupErr := s.Delete(cleanupCtx, scope.workspaceID, session.ID)
+		cleanupErr := s.cleanupLiveModelDiscoveryRuntime(cleanupCtx, scope.workspaceID, session.ID)
 		cancelCleanup()
-		if errors.Is(cleanupErr, ErrSessionNotFound) {
-			cleanupErr = nil
-		}
 		if cleanupErr == nil {
 			s.untrackLiveModelDiscoverySession(scope.workspaceID, session.ID)
 		} else {
@@ -338,10 +335,22 @@ func (s *Service) scheduleLiveModelDiscoveryDelete(workspaceID string, agentSess
 	time.AfterFunc(delay, func() {
 		cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), liveModelDiscoveryLifecycleTimeout)
 		defer cancelCleanup()
-		if _, err := s.Delete(cleanupCtx, workspaceID, agentSessionID); err == nil || errors.Is(err, ErrSessionNotFound) {
+		if err := s.cleanupLiveModelDiscoveryRuntime(cleanupCtx, workspaceID, agentSessionID); err == nil {
 			s.untrackLiveModelDiscoverySession(workspaceID, agentSessionID)
 		}
 	})
+}
+
+func (s *Service) cleanupLiveModelDiscoveryRuntime(ctx context.Context, workspaceID, agentSessionID string) error {
+	if _, live := s.controller().Session(workspaceID, agentSessionID); live {
+		err := normalizeRuntimeError(s.controller().Close(ctx, RuntimeCloseInput{
+			WorkspaceID: workspaceID, AgentSessionID: agentSessionID,
+		}))
+		if err != nil && !errors.Is(err, ErrSessionNotFound) {
+			return err
+		}
+	}
+	return s.cleanupRuntime(ctx, workspaceID, agentSessionID)
 }
 
 func (s *Service) liveModelDiscoveryDeleteDelay() time.Duration {

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -294,8 +294,11 @@ func (s *Service) discoverLiveComposerModelsUncachedForScope(
 			s.setComposerRuntimeContextForScope(scope, time.Now().UTC(), runtimeContext)
 		}
 		cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), liveModelDiscoveryLifecycleTimeout)
-		cleanupErr := s.cleanupLiveModelDiscoveryRuntime(cleanupCtx, scope.workspaceID, session.ID)
+		_, cleanupErr := s.Delete(cleanupCtx, scope.workspaceID, session.ID)
 		cancelCleanup()
+		if errors.Is(cleanupErr, ErrSessionNotFound) {
+			cleanupErr = nil
+		}
 		if cleanupErr == nil {
 			s.untrackLiveModelDiscoverySession(scope.workspaceID, session.ID)
 		} else {
@@ -335,22 +338,10 @@ func (s *Service) scheduleLiveModelDiscoveryDelete(workspaceID string, agentSess
 	time.AfterFunc(delay, func() {
 		cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), liveModelDiscoveryLifecycleTimeout)
 		defer cancelCleanup()
-		if err := s.cleanupLiveModelDiscoveryRuntime(cleanupCtx, workspaceID, agentSessionID); err == nil {
+		if _, err := s.Delete(cleanupCtx, workspaceID, agentSessionID); err == nil || errors.Is(err, ErrSessionNotFound) {
 			s.untrackLiveModelDiscoverySession(workspaceID, agentSessionID)
 		}
 	})
-}
-
-func (s *Service) cleanupLiveModelDiscoveryRuntime(ctx context.Context, workspaceID, agentSessionID string) error {
-	if _, live := s.controller().Session(workspaceID, agentSessionID); live {
-		err := normalizeRuntimeError(s.controller().Close(ctx, RuntimeCloseInput{
-			WorkspaceID: workspaceID, AgentSessionID: agentSessionID,
-		}))
-		if err != nil && !errors.Is(err, ErrSessionNotFound) {
-			return err
-		}
-	}
-	return s.cleanupRuntime(ctx, workspaceID, agentSessionID)
 }
 
 func (s *Service) liveModelDiscoveryDeleteDelay() time.Duration {

--- a/services/tuttid/service/agent/composer_model_catalog.go
+++ b/services/tuttid/service/agent/composer_model_catalog.go
@@ -4,16 +4,15 @@ import (
 	"context"
 	"log/slog"
 	"strings"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/modelcatalog"
 )
 
 type composerModelCatalogProjection struct {
-	DefaultModel               string
-	ModelOptions               []ComposerConfigOptionValue
-	ReasoningProfiles          map[string]composerModelReasoningProfile
-	DefaultReasoningEffort     string
-	ReasoningEfforts           []AgentModelReasoningEffortOption
-	ReasoningEffortsAdvertised bool
-	Source                     string
+	Selection         modelcatalog.ModelSelection
+	ModelOptions      []ComposerConfigOptionValue
+	ReasoningProfiles map[string]composerModelReasoningProfile
+	Source            string
 }
 
 func composerModelOptionsFromCatalog(ctx context.Context, catalog AgentModelCatalog, provider string, cwd string, selectedModel string) (composerModelCatalogProjection, bool) {
@@ -33,14 +32,10 @@ func composerModelOptionsFromCatalog(ctx context.Context, catalog AgentModelCata
 	}
 	options := make([]ComposerConfigOptionValue, 0, len(result.Models)+1)
 	reasoningProfiles := make(map[string]composerModelReasoningProfile)
-	defaultModel := ""
 	for _, model := range result.Models {
 		id := strings.TrimSpace(model.ID)
 		if id == "" {
 			continue
-		}
-		if defaultModel == "" && model.IsDefault {
-			defaultModel = id
 		}
 		if containsModelOption(options, id) {
 			continue
@@ -66,22 +61,18 @@ func composerModelOptionsFromCatalog(ctx context.Context, catalog AgentModelCata
 			}
 		}
 	}
-	selected := strings.TrimSpace(selectedModel)
-	if selected != "" && !containsModelOption(options, selected) {
-		options = append(options, ComposerConfigOptionValue{ID: selected, Label: selected, Value: selected})
+	selection := modelcatalog.SelectModel(result.Models, selectedModel)
+	if selection.Found && !containsModelOption(options, selection.Model.ID) {
+		options = append(options, ComposerConfigOptionValue{
+			ID: selection.Model.ID, Label: selection.Model.DisplayName, Value: selection.Model.ID,
+		})
 	}
-	projection := composerModelCatalogProjection{
-		DefaultModel:      defaultModel,
+	return composerModelCatalogProjection{
+		Selection:         selection,
 		ModelOptions:      options,
 		ReasoningProfiles: reasoningProfiles,
 		Source:            strings.TrimSpace(result.Source),
-	}
-	if profile, ok := reasoningProfiles[selected]; ok {
-		projection.DefaultReasoningEffort = profile.DefaultReasoningEffort
-		projection.ReasoningEfforts = append([]AgentModelReasoningEffortOption(nil), profile.ReasoningEfforts...)
-		projection.ReasoningEffortsAdvertised = true
-	}
-	return projection, true
+	}, true
 }
 
 func containsModelOption(options []ComposerConfigOptionValue, value string) bool {

--- a/services/tuttid/service/agent/composer_model_catalog.go
+++ b/services/tuttid/service/agent/composer_model_catalog.go
@@ -11,7 +11,7 @@ import (
 type composerModelCatalogProjection struct {
 	Selection         modelcatalog.ModelSelection
 	ModelOptions      []ComposerConfigOptionValue
-	ReasoningProfiles map[string]composerModelReasoningProfile
+	ReasoningProfiles map[string]modelcatalog.ReasoningProfile
 	Source            string
 }
 
@@ -31,7 +31,7 @@ func composerModelOptionsFromCatalog(ctx context.Context, catalog AgentModelCata
 		return composerModelCatalogProjection{}, false
 	}
 	options := make([]ComposerConfigOptionValue, 0, len(result.Models)+1)
-	reasoningProfiles := make(map[string]composerModelReasoningProfile)
+	catalogProjection := modelcatalog.ProjectComposerCatalog(result.Models, selectedModel)
 	for _, model := range result.Models {
 		id := strings.TrimSpace(model.ID)
 		if id == "" {
@@ -51,17 +51,8 @@ func composerModelOptionsFromCatalog(ctx context.Context, catalog AgentModelCata
 			Description:        strings.TrimSpace(model.Description),
 			SupportsImageInput: model.SupportsImageInput,
 		})
-		if model.ReasoningEffortsAdvertised {
-			reasoningProfiles[id] = composerModelReasoningProfile{
-				DefaultReasoningEffort: strings.TrimSpace(model.DefaultReasoningEffort),
-				ReasoningEfforts: append(
-					[]AgentModelReasoningEffortOption(nil),
-					model.SupportedReasoningEfforts...,
-				),
-			}
-		}
 	}
-	selection := modelcatalog.SelectModel(result.Models, selectedModel)
+	selection := catalogProjection.Selection
 	if selection.Found && !containsModelOption(options, selection.Model.ID) {
 		options = append(options, ComposerConfigOptionValue{
 			ID: selection.Model.ID, Label: selection.Model.DisplayName, Value: selection.Model.ID,
@@ -70,7 +61,7 @@ func composerModelOptionsFromCatalog(ctx context.Context, catalog AgentModelCata
 	return composerModelCatalogProjection{
 		Selection:         selection,
 		ModelOptions:      options,
-		ReasoningProfiles: reasoningProfiles,
+		ReasoningProfiles: catalogProjection.ReasoningOptionsByModel,
 		Source:            strings.TrimSpace(result.Source),
 	}, true
 }

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -191,8 +191,9 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 		)
 	}
 	defaultModel := composerConfiguredDefaultModel(provider)
-	if catalogProjectionOK && catalogProjection.DefaultModel != "" {
-		defaultModel = catalogProjection.DefaultModel
+	if catalogProjectionOK && catalogProjection.Selection.Found {
+		settings.Model = strings.TrimSpace(catalogProjection.Selection.Model.ID)
+		defaultModel = settings.Model
 	}
 	effectiveSettings := resolveComposerEffectiveSettings(
 		provider,
@@ -222,13 +223,14 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 		modelOptions = []ComposerConfigOptionValue{}
 	}
 	reasoningOptions := composerReasoningOptionValues(provider, effectiveSettings.ReasoningEffort, locale)
+	speedOptions := composerSpeedOptionValues(provider, locale)
 	capabilities := composerProviderCapabilities(provider, s.computerUseAvailable())
 	if providerTargetRefKind(input.providerTargetRef) == "agent_extension" {
 		capabilities = nil
 	}
 	runtimeContext := map[string]any{
 		"capabilities":     capabilities,
-		"configOptions":    composerConfigOptions(provider, effectiveSettings, modelOptions, reasoningOptions),
+		"configOptions":    composerConfigOptions(provider, effectiveSettings, modelOptions, reasoningOptions, speedOptions),
 		"model":            nullableString(effectiveSettings.Model),
 		"permissionModeId": nullableString(effectiveSettings.PermissionModeID),
 		"reasoningEffort":  nullableString(effectiveSettings.ReasoningEffort),
@@ -273,22 +275,32 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 				catalogProjection.ReasoningProfiles,
 			)
 		}
-		if profile, advertised := catalogProjection.ReasoningProfiles[effectiveSettings.Model]; advertised {
+		selection := catalogProjection.Selection
+		if selection.ReasoningEffortsAdvertised {
 			effectiveSettings.ReasoningEffort = resolveAdvertisedReasoningEffort(
 				provider,
-				effectiveSettings.ReasoningEffort,
-				profile.DefaultReasoningEffort,
-				profile.ReasoningEfforts,
+				settings.ReasoningEffort,
+				selection.DefaultReasoningEffort,
+				selection.ReasoningEfforts,
 			)
 			reasoningOptions = composerAdvertisedReasoningOptionValues(
 				provider,
 				effectiveSettings.ReasoningEffort,
 				locale,
-				profile.ReasoningEfforts,
+				selection.ReasoningEfforts,
 			)
 			runtimeContext["reasoningEffort"] = nullableString(effectiveSettings.ReasoningEffort)
 		}
-		runtimeContext["configOptions"] = composerConfigOptions(provider, effectiveSettings, modelOptions, reasoningOptions)
+		if selection.SpeedsAdvertised {
+			effectiveSettings.Speed = resolveAdvertisedSpeed(
+				settings.Speed,
+				selection.DefaultSpeed,
+				selection.Speeds,
+			)
+			speedOptions = composerAdvertisedSpeedOptionValues(locale, selection.Speeds)
+			runtimeContext["speed"] = nullableString(effectiveSettings.Speed)
+		}
+		runtimeContext["configOptions"] = composerConfigOptions(provider, effectiveSettings, modelOptions, reasoningOptions, speedOptions)
 	}
 	options := ComposerOptions{
 		Provider:                provider,
@@ -298,7 +310,7 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 		PermissionConfig:        permissionConfig,
 		ReasoningConfig:         composerReasoningConfigFromOptions(provider, effectiveSettings.ReasoningEffort, reasoningOptions),
 		ReasoningOptionsByModel: reasoningOptionsByModel,
-		SpeedConfig:             composerSpeedConfig(provider, effectiveSettings.Speed, locale),
+		SpeedConfig:             composerSpeedConfigFromOptions(provider, effectiveSettings.Speed, speedOptions),
 		EffectiveSettings:       effectiveSettings,
 		RuntimeContext:          runtimeContext,
 		Skills:                  skills,
@@ -456,6 +468,7 @@ func composerConfigOptions(
 	settings ComposerSettings,
 	modelOptions []ComposerConfigOptionValue,
 	reasoningOptions []ComposerConfigOptionValue,
+	speedOptions []ComposerConfigOptionValue,
 ) []map[string]any {
 	profile := composerProfileFor(provider)
 	if !profile.ModelSelection && !profile.ReasoningEffort && !profile.Speed {
@@ -481,7 +494,7 @@ func composerConfigOptions(
 			options = append(options, map[string]any{
 				"currentValue": nullableString(settings.ReasoningEffort),
 				"id":           reasoningConfigOptionID(provider),
-				"options":      composerReasoningOptionValuesToRuntimeOptions(reasoningOptions),
+				"options":      composerConfigOptionValuesToRuntimeOptions(reasoningOptions),
 			})
 		}
 	}
@@ -489,7 +502,7 @@ func composerConfigOptions(
 		options = append(options, map[string]any{
 			"currentValue": nullableString(settings.Speed),
 			"id":           speedConfigOptionID(provider),
-			"options":      speedTierOptions(provider),
+			"options":      composerConfigOptionValuesToRuntimeOptions(speedOptions),
 		})
 	}
 	return options
@@ -722,19 +735,7 @@ func normalizeSpeedForProvider(provider string, value string) string {
 	return speedTierStandard
 }
 
-func speedTierOptions(provider string) []map[string]string {
-	values := speedTierValuesForProvider(provider)
-	options := make([]map[string]string, 0, len(values))
-	for _, value := range values {
-		options = append(options, map[string]string{
-			"name":  speedLabel(value, preferencesbiz.DefaultDesktopLocale),
-			"value": value,
-		})
-	}
-	return options
-}
-
-func composerSpeedConfig(provider string, selected string, locale string) ComposerConfigOption {
+func composerSpeedOptionValues(provider string, locale string) []ComposerConfigOptionValue {
 	values := speedTierValuesForProvider(provider)
 	options := make([]ComposerConfigOptionValue, 0, len(values))
 	for _, value := range values {
@@ -746,11 +747,62 @@ func composerSpeedConfig(provider string, selected string, locale string) Compos
 			Description: description,
 		})
 	}
-	selected = normalizeSpeedForProvider(provider, selected)
+	return options
+}
+
+func composerSpeedConfigFromOptions(provider string, selected string, options []ComposerConfigOptionValue) ComposerConfigOption {
+	selected = strings.TrimSpace(selected)
 	return ComposerConfigOption{
-		Configurable: speedProviderSupportsSpeed(provider),
+		Configurable: speedProviderSupportsSpeed(provider) && len(options) > 0,
 		CurrentValue: selected,
 		DefaultValue: selected,
-		Options:      options,
+		Options:      cloneComposerConfigOptionValues(options),
 	}
+}
+
+func composerAdvertisedSpeedOptionValues(locale string, advertised []AgentModelSpeedOption) []ComposerConfigOptionValue {
+	options := make([]ComposerConfigOptionValue, 0, len(advertised))
+	for _, advertisedOption := range advertised {
+		value := strings.TrimSpace(advertisedOption.Value)
+		if value == "" {
+			continue
+		}
+		label, description := speedDisplay(value, locale)
+		if advertisedLabel := strings.TrimSpace(advertisedOption.Label); advertisedLabel != "" {
+			label = advertisedLabel
+		}
+		if advertisedDescription := strings.TrimSpace(advertisedOption.Description); advertisedDescription != "" {
+			description = advertisedDescription
+		}
+		options = append(options, ComposerConfigOptionValue{
+			ID: value, Label: label, Value: value, Description: description,
+		})
+	}
+	return options
+}
+
+func resolveAdvertisedSpeed(selected string, advertisedDefault string, advertised []AgentModelSpeedOption) string {
+	selected = strings.TrimSpace(selected)
+	advertisedDefault = strings.TrimSpace(advertisedDefault)
+	firstValue := ""
+	defaultSupported := false
+	for _, option := range advertised {
+		value := strings.TrimSpace(option.Value)
+		if value == "" {
+			continue
+		}
+		if firstValue == "" {
+			firstValue = value
+		}
+		if value == selected {
+			return selected
+		}
+		if value == advertisedDefault {
+			defaultSupported = true
+		}
+	}
+	if defaultSupported {
+		return advertisedDefault
+	}
+	return firstValue
 }

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -408,10 +408,7 @@ func resolveComposerEffectiveSettings(
 // composerDefaultSpeed returns the default speed tier for providers that expose
 // the speed dimension; an empty string for providers that do not.
 func composerDefaultSpeed(provider string) string {
-	if speedProviderSupportsSpeed(provider) {
-		return speedTierStandard
-	}
-	return ""
+	return strings.TrimSpace(composerProfileFor(provider).DefaultSpeed)
 }
 
 func composerDefaultReasoningEffort(provider string) string {
@@ -693,11 +690,6 @@ func reasoningConfigOptionID(provider string) string {
 	return strings.TrimSpace(composerProfileFor(provider).ReasoningConfigOptionID)
 }
 
-const (
-	speedTierStandard = "standard"
-	speedTierFast     = "fast"
-)
-
 // speedProviderSupportsSpeed reports whether the provider exposes the speed
 // dimension. Speed combines orthogonally with model and reasoning effort.
 //
@@ -716,10 +708,7 @@ func speedConfigOptionID(provider string) string {
 }
 
 func speedTierValuesForProvider(provider string) []string {
-	if speedProviderSupportsSpeed(provider) {
-		return []string{speedTierStandard, speedTierFast}
-	}
-	return nil
+	return append([]string(nil), composerProfileFor(provider).SpeedValues...)
 }
 
 func normalizeSpeedForProvider(provider string, value string) string {
@@ -732,7 +721,7 @@ func normalizeSpeedForProvider(provider string, value string) string {
 			return normalized
 		}
 	}
-	return speedTierStandard
+	return strings.TrimSpace(composerProfileFor(provider).DefaultSpeed)
 }
 
 func composerSpeedOptionValues(provider string, locale string) []ComposerConfigOptionValue {

--- a/services/tuttid/service/agent/composer_options_locale.go
+++ b/services/tuttid/service/agent/composer_options_locale.go
@@ -58,11 +58,6 @@ func speedDisplay(value string, locale string) (string, string) {
 	return value, ""
 }
 
-func speedLabel(value string, locale string) string {
-	label, _ := speedDisplay(value, locale)
-	return label
-}
-
 func permissionModeDisplay(provider string, id string, semantic PermissionModeSemantic, locale string) (string, string) {
 	provider = agentprovider.Normalize(provider)
 	id = strings.TrimSpace(id)

--- a/services/tuttid/service/agent/composer_options_test.go
+++ b/services/tuttid/service/agent/composer_options_test.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/tutti-os/tutti/packages/agent/daemon/modelcatalog"
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 )
@@ -331,10 +332,10 @@ func TestComposerModelReasoningOptionsByModelPreservesCatalogOptions(t *testing.
 			profiles := composerModelReasoningOptionsByModel(
 				provider,
 				"en",
-				map[string]composerModelReasoningProfile{
+				map[string]modelcatalog.ReasoningProfile{
 					"model-1": {
-						DefaultReasoningEffort: "ultra",
-						ReasoningEfforts: []AgentModelReasoningEffortOption{
+						DefaultValue: "ultra",
+						Options: []AgentModelReasoningEffortOption{
 							{Value: "high"},
 							{Value: "ultra"},
 						},

--- a/services/tuttid/service/agent/composer_profiles.go
+++ b/services/tuttid/service/agent/composer_profiles.go
@@ -56,6 +56,10 @@ type composerProfile struct {
 	ReasoningEffortValues []string
 	// Speed: the provider exposes the orthogonal speed tier (standard/fast).
 	Speed bool
+	// SpeedValues and DefaultSpeed are registry-owned so all Host consumers
+	// project the same ordered options and initial selection.
+	SpeedValues  []string
+	DefaultSpeed string
 	// Capabilities is the conservative static capability list used to render
 	// the composer before a session exists. Once a session is live the
 	// adapter-reported typed session capabilities take precedence. Keys mirror
@@ -122,6 +126,8 @@ func composerProfileFromDescriptor(provider providerregistry.ProviderDescriptor)
 		ReasoningEffortValues:    append([]string(nil), descriptor.ReasoningEffortValues...),
 		DefaultReasoningEffort:   strings.TrimSpace(descriptor.DefaultReasoningEffort),
 		Speed:                    descriptor.Speed,
+		SpeedValues:              append([]string(nil), descriptor.SpeedValues...),
+		DefaultSpeed:             strings.TrimSpace(descriptor.DefaultSpeed),
 		Capabilities:             append([]string(nil), descriptor.Capabilities...),
 		PermissionConfigurable:   descriptor.PermissionConfigurable,
 		DefaultPermissionModeID:  strings.TrimSpace(descriptor.DefaultPermissionModeID),

--- a/services/tuttid/service/agent/composer_reasoning_options.go
+++ b/services/tuttid/service/agent/composer_reasoning_options.go
@@ -172,7 +172,7 @@ func resolveAdvertisedReasoningEffort(
 	return firstValue
 }
 
-func composerReasoningOptionValuesToRuntimeOptions(
+func composerConfigOptionValuesToRuntimeOptions(
 	options []ComposerConfigOptionValue,
 ) []map[string]string {
 	result := make([]map[string]string, 0, len(options))

--- a/services/tuttid/service/agent/composer_reasoning_options.go
+++ b/services/tuttid/service/agent/composer_reasoning_options.go
@@ -3,19 +3,15 @@ package agent
 import (
 	"strings"
 
+	"github.com/tutti-os/tutti/packages/agent/daemon/modelcatalog"
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
 
-type composerModelReasoningProfile struct {
-	DefaultReasoningEffort string
-	ReasoningEfforts       []AgentModelReasoningEffortOption
-}
-
 func composerModelReasoningOptionsByModel(
 	provider string,
 	locale string,
-	profiles map[string]composerModelReasoningProfile,
+	profiles map[string]modelcatalog.ReasoningProfile,
 ) map[string]ComposerReasoningProfile {
 	result := make(map[string]ComposerReasoningProfile, len(profiles))
 	for model, profile := range profiles {
@@ -23,17 +19,12 @@ func composerModelReasoningOptionsByModel(
 		if model == "" {
 			continue
 		}
-		defaultValue := resolveAdvertisedReasoningEffort(
-			provider,
-			"",
-			profile.DefaultReasoningEffort,
-			profile.ReasoningEfforts,
-		)
+		defaultValue := profile.DefaultValue
 		options := composerAdvertisedReasoningOptionValues(
 			provider,
 			"",
 			locale,
-			profile.ReasoningEfforts,
+			profile.Options,
 		)
 		result[model] = ComposerReasoningProfile{
 			DefaultValue: defaultValue,

--- a/services/tuttid/service/agent/external_import_claude_export_test.go
+++ b/services/tuttid/service/agent/external_import_claude_export_test.go
@@ -167,6 +167,7 @@ func TestClaudeExportArchiveImportIsIdempotentNoProjectAndNonResumable(t *testin
 		),
 	})
 	service := NewService(newFakeRuntime())
+	configureTestApplicationHost(service)
 	projection := NewActivityProjection(store)
 	service.SessionReader = projection
 	service.MessageReader = projection
@@ -287,6 +288,7 @@ func TestClaudeExportArchiveKeepsChangedRetryBranchesInSeparateSessions(t *testi
 		),
 	})
 	service := NewService(newFakeRuntime())
+	configureTestApplicationHost(service)
 	projection := NewActivityProjection(store)
 	service.SessionReader = projection
 	service.MessageReader = projection

--- a/services/tuttid/service/agent/host_adapters.go
+++ b/services/tuttid/service/agent/host_adapters.go
@@ -31,23 +31,6 @@ func (a serviceHostStore) GetSession(ctx context.Context, workspaceID, sessionID
 			return session, ok, err
 		}
 	}
-	// Service configurations without the legacy SessionReader have always
-	// allowed a live provider session to supply the session observation. A
-	// TurnStore may still be present for turn lifecycle operations, so its
-	// absence must not suppress that established fallback.
-	if a.service.SessionReader == nil {
-		if session, ok := a.service.controller().Session(workspaceID, sessionID); ok {
-			activeTurnID := ""
-			if session.TurnLifecycle != nil && session.TurnLifecycle.ActiveTurnID != nil {
-				activeTurnID = strings.TrimSpace(*session.TurnLifecycle.ActiveTurnID)
-			}
-			return storesqlite.Session{
-				ID: session.ID, WorkspaceID: session.WorkspaceID, Provider: session.Provider,
-				ProviderSessionID: session.ProviderSessionID, Cwd: session.Cwd, Title: session.Title,
-				Kind: storesqlite.SessionKindRoot, ActiveTurnID: activeTurnID,
-			}, true, nil
-		}
-	}
 	return storesqlite.Session{}, false, nil
 }
 
@@ -120,6 +103,14 @@ func (a serviceHostStore) PlanDeleteSessions(ctx context.Context, input storesql
 		return storesqlite.DeleteSessionsPlan{}, agenthost.ErrInvalidArgument
 	}
 	return deleter.PlanDeleteSessions(ctx, input)
+}
+
+func (a serviceHostStore) PlanClearSessions(ctx context.Context, workspaceID string) (storesqlite.DeleteSessionsPlan, error) {
+	deleter, ok := a.service.SessionReader.(SessionBatchDeleter)
+	if !ok {
+		return storesqlite.DeleteSessionsPlan{}, agenthost.ErrInvalidArgument
+	}
+	return deleter.PlanClearSessions(ctx, workspaceID)
 }
 
 func (a serviceHostStore) ListChildSessions(ctx context.Context, workspaceID, sessionID string) ([]storesqlite.Session, error) {
@@ -463,14 +454,63 @@ func NewApplicationHost(s *Service) *agenthost.Host {
 	return newApplicationHost(s, s)
 }
 
+type ApplicationHostRuntime interface {
+	agenthost.RuntimeController
+	agenthost.GoalRuntimeController
+}
+
+// ApplicationHostCanonicalPorts groups the shared canonical store roles that
+// must advance together in production.
+type ApplicationHostCanonicalPorts interface {
+	agenthost.CanonicalStore
+	agenthost.SessionManagementStore
+	agenthost.SessionBatchManagementStore
+}
+
+func NewApplicationHostWithPorts(
+	s *Service,
+	canonical ApplicationHostCanonicalPorts,
+	runtime ApplicationHostRuntime,
+) *agenthost.Host {
+	if s == nil || canonical == nil || runtime == nil {
+		return nil
+	}
+	return composeApplicationHost(s, s, canonical, canonical, canonical, runtime, runtime)
+}
+
 func newApplicationHost(s *Service, worktreeGC agenthost.WorktreeGarbageCollector) *agenthost.Host {
 	if s == nil {
 		return nil
 	}
+	return newApplicationHostWithPorts(s, worktreeGC, serviceHostRuntime{service: s}, serviceHostGoalRuntime{service: s})
+}
+
+func newApplicationHostWithPorts(
+	s *Service,
+	worktreeGC agenthost.WorktreeGarbageCollector,
+	runtime agenthost.RuntimeController,
+	goalRuntime agenthost.GoalRuntimeController,
+) *agenthost.Host {
+	if s == nil {
+		return nil
+	}
+	store := serviceHostStore{service: s}
+	return composeApplicationHost(s, worktreeGC, store, store, store, runtime, goalRuntime)
+}
+
+func composeApplicationHost(
+	s *Service,
+	worktreeGC agenthost.WorktreeGarbageCollector,
+	canonical agenthost.CanonicalStore,
+	sessionManagement agenthost.SessionManagementStore,
+	sessionBatchManagement agenthost.SessionBatchManagementStore,
+	runtime agenthost.RuntimeController,
+	goalRuntime agenthost.GoalRuntimeController,
+) *agenthost.Host {
 	return agenthost.New(agenthost.Config{
-		CanonicalStore: serviceHostStore{service: s}, SessionManagement: serviceHostStore{service: s},
-		SessionBatchManagement: serviceHostStore{service: s}, SessionPurge: s.SessionPurgeStore,
-		Runtime:            serviceHostRuntime{service: s},
+		CanonicalStore: canonical, SessionManagement: sessionManagement,
+		SessionBatchManagement: sessionBatchManagement, SessionPurge: s.SessionPurgeStore,
+		Runtime:            runtime,
 		RuntimePreparation: serviceHostPreparation{service: s}, Attachments: s.PromptAttachmentStore,
 		SettingsPolicy: serviceHostSettingsPolicy{service: s},
 		Clock:          serviceHostClock{service: s}, SessionLocker: serviceHostLocker{service: s},
@@ -480,7 +520,7 @@ func newApplicationHost(s *Service, worktreeGC agenthost.WorktreeGarbageCollecto
 		RuntimeOperations: s.RuntimeOperationStore, OperationEvents: serviceHostRuntimeOperationEventPublisher{service: s},
 		OperationOwner: s.RuntimeOperationOwner, StaleTurnSettler: s.StaleTurnSettler,
 		WorktreeGC: worktreeGC,
-		GoalStore:  s.GoalStateStore, GoalRuntime: serviceHostGoalRuntime{service: s}, GoalInbox: s.GoalReconcileInboxStore,
+		GoalStore:  s.GoalStateStore, GoalRuntime: goalRuntime, GoalInbox: s.GoalReconcileInboxStore,
 		GoalOwner: s.GoalOperationOwner, GoalClock: serviceHostGoalClock{service: s},
 		GoalAttemptTimeout: s.GoalOperationAttemptTimeout, GoalRecoveryBudget: s.GoalOperationRecoveryBudget,
 		GoalMaxAttempts: s.GoalOperationMaxAttempts, GoalDispatchDeadline: s.GoalOperationDispatchDeadline,

--- a/services/tuttid/service/agent/host_adapters.go
+++ b/services/tuttid/service/agent/host_adapters.go
@@ -106,12 +106,20 @@ func (a serviceHostStore) UpdateSessionPinned(ctx context.Context, workspaceID, 
 	return activitySessionFromPersisted(persisted), updated, err
 }
 
-func (a serviceHostStore) DeleteSession(ctx context.Context, workspaceID, sessionID string) (bool, error) {
-	deleter, ok := a.service.SessionReader.(SessionDeleter)
+func (a serviceHostStore) DeleteSessionsBatch(ctx context.Context, input storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsBatchResult, error) {
+	deleter, ok := a.service.SessionReader.(SessionBatchDeleter)
 	if !ok {
-		return false, nil
+		return storesqlite.DeleteSessionsBatchResult{}, agenthost.ErrInvalidArgument
 	}
-	return deleter.DeleteSession(ctx, workspaceID, sessionID)
+	return deleter.DeleteSessionsBatch(ctx, input)
+}
+
+func (a serviceHostStore) PlanDeleteSessions(ctx context.Context, input storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsPlan, error) {
+	deleter, ok := a.service.SessionReader.(SessionBatchDeleter)
+	if !ok {
+		return storesqlite.DeleteSessionsPlan{}, agenthost.ErrInvalidArgument
+	}
+	return deleter.PlanDeleteSessions(ctx, input)
 }
 
 func (a serviceHostStore) ListChildSessions(ctx context.Context, workspaceID, sessionID string) ([]storesqlite.Session, error) {
@@ -300,7 +308,7 @@ func (a serviceHostPreparation) Prepare(ctx context.Context, input agenthost.Run
 }
 
 func (a serviceHostPreparation) Cleanup(ctx context.Context, input agenthost.RuntimeCleanupInput) error {
-	return a.service.cleanupRuntime(ctx, input.WorkspaceID, input.AgentSessionID)
+	return a.service.cleanupSessionResources(ctx, input.WorkspaceID, input.AgentSessionID)
 }
 
 type serviceHostLocker struct{ service *Service }
@@ -460,7 +468,8 @@ func newApplicationHost(s *Service, worktreeGC agenthost.WorktreeGarbageCollecto
 		return nil
 	}
 	return agenthost.New(agenthost.Config{
-		CanonicalStore: serviceHostStore{service: s}, SessionManagement: serviceHostStore{service: s}, SessionPurge: s.SessionPurgeStore,
+		CanonicalStore: serviceHostStore{service: s}, SessionManagement: serviceHostStore{service: s},
+		SessionBatchManagement: serviceHostStore{service: s}, SessionPurge: s.SessionPurgeStore,
 		Runtime:            serviceHostRuntime{service: s},
 		RuntimePreparation: serviceHostPreparation{service: s}, Attachments: s.PromptAttachmentStore,
 		SettingsPolicy: serviceHostSettingsPolicy{service: s},
@@ -475,7 +484,7 @@ func newApplicationHost(s *Service, worktreeGC agenthost.WorktreeGarbageCollecto
 		GoalOwner: s.GoalOperationOwner, GoalClock: serviceHostGoalClock{service: s},
 		GoalAttemptTimeout: s.GoalOperationAttemptTimeout, GoalRecoveryBudget: s.GoalOperationRecoveryBudget,
 		GoalMaxAttempts: s.GoalOperationMaxAttempts, GoalDispatchDeadline: s.GoalOperationDispatchDeadline,
-		GoalActor: agenthost.NewGoalActor(),
+		GoalActor: agenthost.NewSessionActor(),
 	})
 }
 

--- a/services/tuttid/service/agent/host_adapters.go
+++ b/services/tuttid/service/agent/host_adapters.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"time"
 
@@ -10,184 +9,6 @@ import (
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
-
-type serviceHostStore struct{ service *Service }
-
-type canonicalSessionMessageReader interface {
-	ListSessionMessages(context.Context, storesqlite.ListSessionMessagesInput) (storesqlite.MessagePage, bool, error)
-}
-
-func (a serviceHostStore) GetSession(ctx context.Context, workspaceID, sessionID string) (storesqlite.Session, bool, error) {
-	if a.service == nil {
-		return storesqlite.Session{}, false, nil
-	}
-	if a.service.SessionReader != nil {
-		if session, ok := a.service.SessionReader.GetSession(workspaceID, sessionID); ok {
-			return activitySessionFromPersisted(session), true, nil
-		}
-	}
-	if a.service.TurnStore != nil {
-		if session, ok, err := a.service.TurnStore.GetSession(ctx, workspaceID, sessionID); err != nil || ok {
-			return session, ok, err
-		}
-	}
-	return storesqlite.Session{}, false, nil
-}
-
-func (a serviceHostStore) SessionDeleted(ctx context.Context, workspaceID, sessionID string) (bool, error) {
-	if a.service == nil || a.service.SessionReader == nil {
-		return false, nil
-	}
-	return a.service.SessionReader.SessionDeleted(ctx, workspaceID, sessionID)
-}
-
-func (a serviceHostStore) RollbackRuntimeSessionInitialization(ctx context.Context, workspaceID, sessionID string) (bool, error) {
-	if a.service == nil {
-		return false, nil
-	}
-	rollbacker, ok := a.service.SessionReader.(interface {
-		RollbackRuntimeSessionInitialization(context.Context, string, string) (bool, error)
-	})
-	if !ok {
-		return false, nil
-	}
-	return rollbacker.RollbackRuntimeSessionInitialization(ctx, workspaceID, sessionID)
-}
-
-func (a serviceHostStore) InitializeRuntimeSession(ctx context.Context, session ProviderRuntimeSession) (storesqlite.Session, error) {
-	persisted, err := a.service.initializeRuntimeSession(ctx, session)
-	if err != nil {
-		return storesqlite.Session{}, err
-	}
-	return activitySessionFromPersisted(persisted), nil
-}
-
-func (a serviceHostStore) UpdateSessionTitle(ctx context.Context, workspaceID, sessionID, title string) (storesqlite.Session, bool, error) {
-	updater, ok := a.service.SessionReader.(SessionTitleUpdater)
-	if !ok {
-		return storesqlite.Session{}, false, nil
-	}
-	persisted, updated, err := updater.UpdateSessionTitle(ctx, workspaceID, sessionID, title)
-	return activitySessionFromPersisted(persisted), updated, err
-}
-
-func (a serviceHostStore) UpdateSessionSettings(ctx context.Context, workspaceID, sessionID string, settings agenthost.ComposerSettings) (storesqlite.Session, bool, error) {
-	updater, ok := a.service.SessionReader.(SessionSettingsUpdater)
-	if !ok {
-		return storesqlite.Session{}, false, nil
-	}
-	persisted, updated, err := updater.UpdateSessionSettings(ctx, workspaceID, sessionID, settings)
-	return activitySessionFromPersisted(persisted), updated, err
-}
-
-func (a serviceHostStore) UpdateSessionPinned(ctx context.Context, workspaceID, sessionID string, pinned bool) (storesqlite.Session, bool, error) {
-	updater, ok := a.service.SessionReader.(SessionPinUpdater)
-	if !ok {
-		return storesqlite.Session{}, false, nil
-	}
-	persisted, updated, err := updater.UpdateSessionPinned(ctx, workspaceID, sessionID, pinned)
-	return activitySessionFromPersisted(persisted), updated, err
-}
-
-func (a serviceHostStore) DeleteSessionsBatch(ctx context.Context, input storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsBatchResult, error) {
-	deleter, ok := a.service.SessionReader.(SessionBatchDeleter)
-	if !ok {
-		return storesqlite.DeleteSessionsBatchResult{}, agenthost.ErrInvalidArgument
-	}
-	return deleter.DeleteSessionsBatch(ctx, input)
-}
-
-func (a serviceHostStore) PlanDeleteSessions(ctx context.Context, input storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsPlan, error) {
-	deleter, ok := a.service.SessionReader.(SessionBatchDeleter)
-	if !ok {
-		return storesqlite.DeleteSessionsPlan{}, agenthost.ErrInvalidArgument
-	}
-	return deleter.PlanDeleteSessions(ctx, input)
-}
-
-func (a serviceHostStore) PlanClearSessions(ctx context.Context, workspaceID string) (storesqlite.DeleteSessionsPlan, error) {
-	deleter, ok := a.service.SessionReader.(SessionBatchDeleter)
-	if !ok {
-		return storesqlite.DeleteSessionsPlan{}, agenthost.ErrInvalidArgument
-	}
-	return deleter.PlanClearSessions(ctx, workspaceID)
-}
-
-func (a serviceHostStore) ListChildSessions(ctx context.Context, workspaceID, sessionID string) ([]storesqlite.Session, error) {
-	reader, ok := a.service.SessionReader.(ChildSessionReader)
-	if !ok {
-		return nil, nil
-	}
-	children, err := reader.ListChildSessions(ctx, workspaceID, sessionID)
-	if err != nil {
-		return nil, err
-	}
-	result := make([]storesqlite.Session, 0, len(children))
-	for _, child := range children {
-		result = append(result, activitySessionFromPersisted(child))
-	}
-	return result, nil
-}
-
-func (a serviceHostStore) GetTurn(ctx context.Context, workspaceID, sessionID, turnID string) (storesqlite.Turn, bool, error) {
-	if a.service.TurnStore == nil {
-		return storesqlite.Turn{}, false, nil
-	}
-	return a.service.TurnStore.GetTurn(ctx, workspaceID, sessionID, turnID)
-}
-
-func (a serviceHostStore) FindTurnByClientSubmitID(ctx context.Context, workspaceID, sessionID, clientSubmitID string) (string, bool, error) {
-	if a.service.RuntimeOperationStore == nil {
-		return "", false, nil
-	}
-	return a.service.RuntimeOperationStore.FindTurnByClientSubmitID(ctx, workspaceID, sessionID, clientSubmitID)
-}
-
-func (a serviceHostStore) ListSessionInteractions(ctx context.Context, input storesqlite.ListSessionInteractionsInput) ([]storesqlite.Interaction, error) {
-	if a.service.TurnStore == nil {
-		return nil, nil
-	}
-	return a.service.TurnStore.ListSessionInteractions(ctx, input)
-}
-
-func (a serviceHostStore) ListLatestTurnInteractions(ctx context.Context, workspaceID string, sessionIDs []string) (map[string][]storesqlite.Interaction, error) {
-	if a.service.TurnStore == nil {
-		return nil, nil
-	}
-	return a.service.TurnStore.ListLatestTurnInteractions(ctx, workspaceID, sessionIDs)
-}
-
-func (a serviceHostStore) ListSessionMessages(ctx context.Context, input storesqlite.ListSessionMessagesInput) (storesqlite.MessagePage, bool, error) {
-	if a.service == nil {
-		return storesqlite.MessagePage{}, false, nil
-	}
-	reader, ok := a.service.TurnStore.(canonicalSessionMessageReader)
-	if !ok {
-		return storesqlite.MessagePage{}, false, nil
-	}
-	return reader.ListSessionMessages(ctx, input)
-}
-
-func (a serviceHostStore) PrepareSubmitClaim(ctx context.Context, input storesqlite.SubmitClaimPrepare) (storesqlite.SubmitClaim, bool, error) {
-	if a.service.SubmitClaimStore == nil {
-		return storesqlite.SubmitClaim{}, false, nil
-	}
-	return a.service.SubmitClaimStore.PrepareSubmitClaim(ctx, input)
-}
-
-func (a serviceHostStore) AcceptSubmitClaim(ctx context.Context, workspaceID, sessionID, clientSubmitID, turnID string, now int64) (storesqlite.SubmitClaim, bool, error) {
-	if a.service.SubmitClaimStore == nil {
-		return storesqlite.SubmitClaim{}, false, nil
-	}
-	return a.service.SubmitClaimStore.AcceptSubmitClaim(ctx, workspaceID, sessionID, clientSubmitID, turnID, now)
-}
-
-func (a serviceHostStore) DeleteSubmitClaim(ctx context.Context, workspaceID, sessionID, clientSubmitID string) (bool, error) {
-	if a.service.SubmitClaimStore == nil {
-		return false, nil
-	}
-	return a.service.SubmitClaimStore.DeleteSubmitClaim(ctx, workspaceID, sessionID, clientSubmitID)
-}
 
 type serviceHostPreparation struct {
 	service *Service
@@ -328,79 +149,6 @@ func (a serviceHostStartupGate) Acquire(ctx context.Context, provider string) (f
 	return a.service.awaitClaudeStartupSlot(ctx, provider)
 }
 
-type serviceHostRuntime struct{ service *Service }
-
-func (a serviceHostRuntime) Start(ctx context.Context, input RuntimeStartInput) (ProviderRuntimeSession, error) {
-	session, err := a.service.controller().Start(ctx, input)
-	session.Provisional = input.Provisional
-	if err != nil {
-		a.service.invalidateProviderAvailability(input.Provider)
-	}
-	return session, normalizeRuntimeError(err)
-}
-func (a serviceHostRuntime) Resume(ctx context.Context, input RuntimeResumeInput) (ProviderRuntimeSession, error) {
-	session, err := a.service.controller().Resume(ctx, input)
-	return session, normalizeRuntimeError(err)
-}
-func (a serviceHostRuntime) Session(workspaceID, sessionID string) (ProviderRuntimeSession, bool) {
-	return a.service.controller().Session(workspaceID, sessionID)
-}
-func (a serviceHostRuntime) CanResume(input RuntimeResumeInput) bool {
-	return a.service.controller().CanResume(input)
-}
-func (a serviceHostRuntime) Exec(ctx context.Context, input RuntimeExecInput) (RuntimeExecResult, error) {
-	result, err := a.service.controller().Exec(ctx, input)
-	return result, normalizeRuntimeError(err)
-}
-func (a serviceHostRuntime) ValidatePromptContent(ctx context.Context, input RuntimeExecInput) error {
-	return normalizeRuntimeError(a.service.controller().ValidatePromptContent(ctx, input))
-}
-func (a serviceHostRuntime) Cancel(ctx context.Context, input RuntimeCancelInput) (RuntimeCancelResult, error) {
-	return a.service.controller().Cancel(ctx, input)
-}
-func (a serviceHostRuntime) SubmitInteractive(ctx context.Context, input RuntimeSubmitInteractiveInput) (RuntimeSubmitInteractiveResult, error) {
-	return a.service.controller().SubmitInteractive(ctx, input)
-}
-func (a serviceHostRuntime) InteractiveDisposition(workspaceID, rootAgentSessionID, agentSessionID, turnID, requestID string) RuntimeInteractiveDisposition {
-	return a.service.controller().InteractiveDisposition(workspaceID, rootAgentSessionID, agentSessionID, turnID, requestID)
-}
-func (a serviceHostRuntime) UpdateSettings(ctx context.Context, input RuntimeUpdateSettingsInput) error {
-	return normalizeRuntimeError(a.service.controller().UpdateSettings(ctx, input))
-}
-func (a serviceHostRuntime) SetTitle(ctx context.Context, input RuntimeSetTitleInput) (ProviderRuntimeSession, error) {
-	return a.service.controller().SetTitle(ctx, input)
-}
-func (a serviceHostRuntime) SetVisible(ctx context.Context, input RuntimeSetVisibleInput) (ProviderRuntimeSession, error) {
-	return a.service.controller().SetVisible(ctx, input)
-}
-func (a serviceHostRuntime) Close(ctx context.Context, input RuntimeCloseInput) error {
-	return normalizeRuntimeError(a.service.controller().Close(ctx, input))
-}
-
-type serviceHostGoalRuntime struct{ service *Service }
-
-func (a serviceHostGoalRuntime) GoalControl(ctx context.Context, input agenthost.RuntimeGoalControlInput) (agenthost.RuntimeGoalControlResult, error) {
-	result, err := a.service.controller().GoalControl(ctx, input)
-	return result, normalizeRuntimeError(err)
-}
-
-func (a serviceHostGoalRuntime) ReconcileGoal(ctx context.Context, input agenthost.RuntimeGoalControlInput) (agenthost.RuntimeGoalReconcileResult, error) {
-	reconciler, ok := a.service.controller().(RuntimeGoalReconciler)
-	if !ok {
-		return agenthost.RuntimeGoalReconcileResult{}, errors.New("agent runtime goal reconciliation is unavailable")
-	}
-	result, err := reconciler.ReconcileGoal(ctx, input)
-	return result, normalizeRuntimeError(err)
-}
-
-func (a serviceHostGoalRuntime) GoalRecoveryPolicy(ctx context.Context, input agenthost.RuntimeGoalControlInput) (agenthost.RuntimeGoalRecoveryPolicy, error) {
-	resolver, ok := a.service.controller().(RuntimeGoalRecoveryPolicyResolver)
-	if !ok {
-		return agenthost.RuntimeGoalRecoveryPolicy{}, nil
-	}
-	return resolver.GoalRecoveryPolicy(ctx, input)
-}
-
 type serviceHostClock struct{ service *Service }
 
 func (c serviceHostClock) Now() time.Time {
@@ -447,13 +195,6 @@ func (p serviceHostRuntimeOperationEventPublisher) PublishRuntimeOperationEvent(
 	return p.service.RuntimeOperationEventPublisher.PublishRuntimeOperationEvent(ctx, event)
 }
 
-// NewApplicationHost composes the provider-neutral Host with tuttid-owned
-// adapters. Production wiring constructs exactly one Host and installs it on
-// Service; isolated package consumers may use ApplicationHost for lazy setup.
-func NewApplicationHost(s *Service) *agenthost.Host {
-	return newApplicationHost(s, s)
-}
-
 type ApplicationHostRuntime interface {
 	agenthost.RuntimeController
 	agenthost.GoalRuntimeController
@@ -476,26 +217,6 @@ func NewApplicationHostWithPorts(
 		return nil
 	}
 	return composeApplicationHost(s, s, canonical, canonical, canonical, runtime, runtime)
-}
-
-func newApplicationHost(s *Service, worktreeGC agenthost.WorktreeGarbageCollector) *agenthost.Host {
-	if s == nil {
-		return nil
-	}
-	return newApplicationHostWithPorts(s, worktreeGC, serviceHostRuntime{service: s}, serviceHostGoalRuntime{service: s})
-}
-
-func newApplicationHostWithPorts(
-	s *Service,
-	worktreeGC agenthost.WorktreeGarbageCollector,
-	runtime agenthost.RuntimeController,
-	goalRuntime agenthost.GoalRuntimeController,
-) *agenthost.Host {
-	if s == nil {
-		return nil
-	}
-	store := serviceHostStore{service: s}
-	return composeApplicationHost(s, worktreeGC, store, store, store, runtime, goalRuntime)
 }
 
 func composeApplicationHost(
@@ -535,40 +256,34 @@ func (s *Service) SetApplicationHost(host *agenthost.Host) {
 	}
 	s.applicationHostMu.Lock()
 	defer s.applicationHostMu.Unlock()
-	if s.applicationHost != nil && s.applicationHost != host {
+	if s.applicationHostProvider != nil {
+		if s.applicationHost == host {
+			return
+		}
 		panic("agent service application host is already configured")
 	}
 	s.applicationHost = host
+	s.applicationHostProvider = func() *agenthost.Host { return host }
 }
 
-// ApplicationHost returns the configured Host. Lazy construction keeps
-// isolated service consumers and tests hermetic; production wiring always
-// installs its explicitly composed singleton before recovery or API serving.
+// ApplicationHost returns the Host installed by the process composition root.
+// Missing wiring is a startup invariant violation; this adapter never creates
+// a second lifecycle stack from service-local store/runtime copies.
 func (s *Service) ApplicationHost() *agenthost.Host {
 	if s == nil {
 		return nil
 	}
 	s.applicationHostMu.Lock()
-	defer s.applicationHostMu.Unlock()
-	if s.applicationHost == nil {
-		s.applicationHost = NewApplicationHost(s)
+	provider := s.applicationHostProvider
+	s.applicationHostMu.Unlock()
+	if provider == nil {
+		panic("agent service application host is not configured")
 	}
-	return s.applicationHost
-}
-
-func activitySessionFromPersisted(session PersistedSession) storesqlite.Session {
-	return storesqlite.Session{
-		ID: session.ID, WorkspaceID: session.WorkspaceID, Kind: session.Kind,
-		RootAgentSessionID: session.RootAgentSessionID, RootTurnID: session.RootTurnID,
-		ParentAgentSessionID: session.ParentAgentSessionID, ParentTurnID: session.ParentTurnID,
-		ParentToolCallID: session.ParentToolCallID, Origin: session.Origin, UserID: session.UserID,
-		AgentTargetID: session.AgentTargetID, Provider: session.Provider, ProviderSessionID: session.ProviderSessionID,
-		Cwd: session.Cwd, RailSectionKey: session.RailSectionKey, Settings: ComposerSettingsToMap(session.Settings),
-		Metadata: session.Metadata, InternalRuntimeContext: clonePayload(session.InternalRuntimeContext), Title: session.Title,
-		PinnedAtUnixMS: session.PinnedAtUnixMS, LastEventUnixMS: session.LastEventUnixMS,
-		StartedAtUnixMS: session.StartedAtUnixMS, EndedAtUnixMS: session.EndedAtUnixMS,
-		CreatedAtUnixMS: session.CreatedAtUnixMS, UpdatedAtUnixMS: session.UpdatedAtUnixMS, ActiveTurnID: session.ActiveTurnID,
+	host := provider()
+	if host == nil {
+		panic("agent service application host provider returned nil")
 	}
+	return host
 }
 
 func persistedSessionFromHost(session storesqlite.Session) PersistedSession {

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -680,7 +680,7 @@ func (d *legacyHostConformanceDriver) DeleteSession(ctx context.Context, ref age
 	_, persisted := d.sessions.GetSession(ref.WorkspaceID, ref.AgentSessionID)
 	deleted, err := d.service.Delete(ctx, ref.WorkspaceID, ref.AgentSessionID)
 	return agenthost.DeleteSessionResult{
-		Deleted: deleted, RuntimeClosed: live && deleted, CanonicalRemoved: persisted && deleted,
+		Deleted: deleted.Removed, RuntimeClosed: live && deleted.Removed, CanonicalRemoved: persisted && deleted.Removed,
 	}, err
 }
 

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -222,7 +222,8 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 	steps := make([]string, 0)
 	d.recoverySteps = &steps
 	d.operationPort = &conformanceRuntimeOperationStore{runtimeOperationMemoryStore: d.operations, steps: &steps}
-	d.service = newTestService(d.runtime)
+	d.service = newUnconfiguredIsolatedAgentService(d.runtime)
+	d.service.AgentTargetStore = fakeAgentTargetStore{targets: defaultTestAgentTargets()}
 	d.commitObserver = &conformanceCommitObserver{fail: fixture.FailCommitObserver}
 	d.service.CommitObserver = d.commitObserver
 	d.service.SessionReader = d.sessions

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -279,6 +279,16 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 			Evidence: map[string]any{"confidence": "authoritative"},
 		}, nil
 	}
+	if fixture.LiveOnlySession != nil {
+		seed := *fixture.LiveOnlySession
+		settings := seed.Settings
+		d.runtime.sessions[seed.WorkspaceID+":"+seed.AgentSessionID] = ProviderRuntimeSession{
+			ID: seed.AgentSessionID, WorkspaceID: seed.WorkspaceID, Provider: seed.Provider,
+			ProviderSessionID: seed.ProviderSessionID, Cwd: seed.Cwd, Status: "ready",
+			Settings: &settings, Title: seed.Title, InitialTitleEstablished: seed.InitialTitleEstablished,
+			Visible: true, PinnedAtUnixMS: boolUnixMS(seed.Pinned), CreatedAtUnixMS: 1, UpdatedAtUnixMS: 2,
+		}
+	}
 
 	if fixture.Session == nil {
 		return nil

--- a/services/tuttid/service/agent/host_test_adapters_test.go
+++ b/services/tuttid/service/agent/host_test_adapters_test.go
@@ -95,7 +95,7 @@ func (a serviceHostStore) DeleteSessionsBatch(ctx context.Context, input storesq
 func (a serviceHostStore) PlanDeleteSessions(ctx context.Context, input storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsPlan, error) {
 	deleter, ok := a.service.SessionReader.(SessionBatchDeleter)
 	if !ok {
-		return storesqlite.DeleteSessionsPlan{}, agenthost.ErrInvalidArgument
+		return storesqlite.DeleteSessionsPlan{WorkspaceID: input.WorkspaceID}, nil
 	}
 	return deleter.PlanDeleteSessions(ctx, input)
 }

--- a/services/tuttid/service/agent/host_test_adapters_test.go
+++ b/services/tuttid/service/agent/host_test_adapters_test.go
@@ -1,0 +1,291 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+// serviceHostStore is deliberately test-only. Production wiring consumes
+// agenthost.SQLiteWorkspaceStore; package tests retain this adapter for their
+// narrow in-memory service fakes.
+type serviceHostStore struct{ service *Service }
+
+type canonicalSessionMessageReader interface {
+	ListSessionMessages(context.Context, storesqlite.ListSessionMessagesInput) (storesqlite.MessagePage, bool, error)
+}
+
+func (a serviceHostStore) GetSession(ctx context.Context, workspaceID, sessionID string) (storesqlite.Session, bool, error) {
+	if a.service == nil {
+		return storesqlite.Session{}, false, nil
+	}
+	if a.service.SessionReader != nil {
+		if session, ok := a.service.SessionReader.GetSession(workspaceID, sessionID); ok {
+			return activitySessionFromPersisted(session), true, nil
+		}
+	}
+	if a.service.TurnStore != nil {
+		if session, ok, err := a.service.TurnStore.GetSession(ctx, workspaceID, sessionID); err != nil || ok {
+			return session, ok, err
+		}
+	}
+	return storesqlite.Session{}, false, nil
+}
+
+func (a serviceHostStore) SessionDeleted(ctx context.Context, workspaceID, sessionID string) (bool, error) {
+	if a.service == nil || a.service.SessionReader == nil {
+		return false, nil
+	}
+	return a.service.SessionReader.SessionDeleted(ctx, workspaceID, sessionID)
+}
+
+func (a serviceHostStore) RollbackRuntimeSessionInitialization(ctx context.Context, workspaceID, sessionID string) (bool, error) {
+	rollbacker, ok := a.service.SessionReader.(interface {
+		RollbackRuntimeSessionInitialization(context.Context, string, string) (bool, error)
+	})
+	if !ok {
+		return false, nil
+	}
+	return rollbacker.RollbackRuntimeSessionInitialization(ctx, workspaceID, sessionID)
+}
+
+func (a serviceHostStore) InitializeRuntimeSession(ctx context.Context, session ProviderRuntimeSession) (storesqlite.Session, error) {
+	persisted, err := a.service.initializeRuntimeSession(ctx, session)
+	return activitySessionFromPersisted(persisted), err
+}
+
+func (a serviceHostStore) UpdateSessionTitle(ctx context.Context, workspaceID, sessionID, title string) (storesqlite.Session, bool, error) {
+	updater, ok := a.service.SessionReader.(SessionTitleUpdater)
+	if !ok {
+		return storesqlite.Session{}, false, nil
+	}
+	persisted, updated, err := updater.UpdateSessionTitle(ctx, workspaceID, sessionID, title)
+	return activitySessionFromPersisted(persisted), updated, err
+}
+
+func (a serviceHostStore) UpdateSessionSettings(ctx context.Context, workspaceID, sessionID string, settings agenthost.ComposerSettings) (storesqlite.Session, bool, error) {
+	updater, ok := a.service.SessionReader.(SessionSettingsUpdater)
+	if !ok {
+		return storesqlite.Session{}, false, nil
+	}
+	persisted, updated, err := updater.UpdateSessionSettings(ctx, workspaceID, sessionID, settings)
+	return activitySessionFromPersisted(persisted), updated, err
+}
+
+func (a serviceHostStore) UpdateSessionPinned(ctx context.Context, workspaceID, sessionID string, pinned bool) (storesqlite.Session, bool, error) {
+	updater, ok := a.service.SessionReader.(SessionPinUpdater)
+	if !ok {
+		return storesqlite.Session{}, false, nil
+	}
+	persisted, updated, err := updater.UpdateSessionPinned(ctx, workspaceID, sessionID, pinned)
+	return activitySessionFromPersisted(persisted), updated, err
+}
+
+func (a serviceHostStore) DeleteSessionsBatch(ctx context.Context, input storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsBatchResult, error) {
+	deleter, ok := a.service.SessionReader.(SessionBatchDeleter)
+	if !ok {
+		return storesqlite.DeleteSessionsBatchResult{}, agenthost.ErrInvalidArgument
+	}
+	return deleter.DeleteSessionsBatch(ctx, input)
+}
+
+func (a serviceHostStore) PlanDeleteSessions(ctx context.Context, input storesqlite.DeleteSessionsBatchInput) (storesqlite.DeleteSessionsPlan, error) {
+	deleter, ok := a.service.SessionReader.(SessionBatchDeleter)
+	if !ok {
+		return storesqlite.DeleteSessionsPlan{}, agenthost.ErrInvalidArgument
+	}
+	return deleter.PlanDeleteSessions(ctx, input)
+}
+
+func (a serviceHostStore) PlanClearSessions(ctx context.Context, workspaceID string) (storesqlite.DeleteSessionsPlan, error) {
+	deleter, ok := a.service.SessionReader.(SessionBatchDeleter)
+	if !ok {
+		return storesqlite.DeleteSessionsPlan{}, agenthost.ErrInvalidArgument
+	}
+	return deleter.PlanClearSessions(ctx, workspaceID)
+}
+
+func (a serviceHostStore) ListChildSessions(ctx context.Context, workspaceID, sessionID string) ([]storesqlite.Session, error) {
+	reader, ok := a.service.SessionReader.(ChildSessionReader)
+	if !ok {
+		return nil, nil
+	}
+	children, err := reader.ListChildSessions(ctx, workspaceID, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]storesqlite.Session, 0, len(children))
+	for _, child := range children {
+		result = append(result, activitySessionFromPersisted(child))
+	}
+	return result, nil
+}
+
+func (a serviceHostStore) GetTurn(ctx context.Context, workspaceID, sessionID, turnID string) (storesqlite.Turn, bool, error) {
+	if a.service.TurnStore == nil {
+		return storesqlite.Turn{}, false, nil
+	}
+	return a.service.TurnStore.GetTurn(ctx, workspaceID, sessionID, turnID)
+}
+
+func (a serviceHostStore) FindTurnByClientSubmitID(ctx context.Context, workspaceID, sessionID, clientSubmitID string) (string, bool, error) {
+	if a.service.RuntimeOperationStore == nil {
+		return "", false, nil
+	}
+	return a.service.RuntimeOperationStore.FindTurnByClientSubmitID(ctx, workspaceID, sessionID, clientSubmitID)
+}
+
+func (a serviceHostStore) ListSessionInteractions(ctx context.Context, input storesqlite.ListSessionInteractionsInput) ([]storesqlite.Interaction, error) {
+	if a.service.TurnStore == nil {
+		return nil, nil
+	}
+	return a.service.TurnStore.ListSessionInteractions(ctx, input)
+}
+
+func (a serviceHostStore) ListLatestTurnInteractions(ctx context.Context, workspaceID string, sessionIDs []string) (map[string][]storesqlite.Interaction, error) {
+	if a.service.TurnStore == nil {
+		return nil, nil
+	}
+	return a.service.TurnStore.ListLatestTurnInteractions(ctx, workspaceID, sessionIDs)
+}
+
+func (a serviceHostStore) ListSessionMessages(ctx context.Context, input storesqlite.ListSessionMessagesInput) (storesqlite.MessagePage, bool, error) {
+	reader, ok := a.service.TurnStore.(canonicalSessionMessageReader)
+	if !ok {
+		return storesqlite.MessagePage{}, false, nil
+	}
+	return reader.ListSessionMessages(ctx, input)
+}
+
+func (a serviceHostStore) PrepareSubmitClaim(ctx context.Context, input storesqlite.SubmitClaimPrepare) (storesqlite.SubmitClaim, bool, error) {
+	if a.service.SubmitClaimStore == nil {
+		return storesqlite.SubmitClaim{}, false, nil
+	}
+	return a.service.SubmitClaimStore.PrepareSubmitClaim(ctx, input)
+}
+
+func (a serviceHostStore) AcceptSubmitClaim(ctx context.Context, workspaceID, sessionID, clientSubmitID, turnID string, now int64) (storesqlite.SubmitClaim, bool, error) {
+	if a.service.SubmitClaimStore == nil {
+		return storesqlite.SubmitClaim{}, false, nil
+	}
+	return a.service.SubmitClaimStore.AcceptSubmitClaim(ctx, workspaceID, sessionID, clientSubmitID, turnID, now)
+}
+
+func (a serviceHostStore) DeleteSubmitClaim(ctx context.Context, workspaceID, sessionID, clientSubmitID string) (bool, error) {
+	if a.service.SubmitClaimStore == nil {
+		return false, nil
+	}
+	return a.service.SubmitClaimStore.DeleteSubmitClaim(ctx, workspaceID, sessionID, clientSubmitID)
+}
+
+type serviceHostRuntime struct{ service *Service }
+
+func (a serviceHostRuntime) Start(ctx context.Context, input RuntimeStartInput) (ProviderRuntimeSession, error) {
+	session, err := a.service.controller().Start(ctx, input)
+	session.Provisional = input.Provisional
+	if err != nil {
+		a.service.invalidateProviderAvailability(input.Provider)
+	}
+	return session, normalizeRuntimeError(err)
+}
+func (a serviceHostRuntime) Resume(ctx context.Context, input RuntimeResumeInput) (ProviderRuntimeSession, error) {
+	session, err := a.service.controller().Resume(ctx, input)
+	return session, normalizeRuntimeError(err)
+}
+func (a serviceHostRuntime) Session(workspaceID, sessionID string) (ProviderRuntimeSession, bool) {
+	return a.service.controller().Session(workspaceID, sessionID)
+}
+func (a serviceHostRuntime) CanResume(input RuntimeResumeInput) bool {
+	return a.service.controller().CanResume(input)
+}
+func (a serviceHostRuntime) Exec(ctx context.Context, input RuntimeExecInput) (RuntimeExecResult, error) {
+	result, err := a.service.controller().Exec(ctx, input)
+	return result, normalizeRuntimeError(err)
+}
+func (a serviceHostRuntime) ValidatePromptContent(ctx context.Context, input RuntimeExecInput) error {
+	return normalizeRuntimeError(a.service.controller().ValidatePromptContent(ctx, input))
+}
+func (a serviceHostRuntime) Cancel(ctx context.Context, input RuntimeCancelInput) (RuntimeCancelResult, error) {
+	return a.service.controller().Cancel(ctx, input)
+}
+func (a serviceHostRuntime) SubmitInteractive(ctx context.Context, input RuntimeSubmitInteractiveInput) (RuntimeSubmitInteractiveResult, error) {
+	return a.service.controller().SubmitInteractive(ctx, input)
+}
+func (a serviceHostRuntime) InteractiveDisposition(workspaceID, rootAgentSessionID, agentSessionID, turnID, requestID string) RuntimeInteractiveDisposition {
+	return a.service.controller().InteractiveDisposition(workspaceID, rootAgentSessionID, agentSessionID, turnID, requestID)
+}
+func (a serviceHostRuntime) UpdateSettings(ctx context.Context, input RuntimeUpdateSettingsInput) error {
+	return normalizeRuntimeError(a.service.controller().UpdateSettings(ctx, input))
+}
+func (a serviceHostRuntime) SetTitle(ctx context.Context, input RuntimeSetTitleInput) (ProviderRuntimeSession, error) {
+	return a.service.controller().SetTitle(ctx, input)
+}
+func (a serviceHostRuntime) SetVisible(ctx context.Context, input RuntimeSetVisibleInput) (ProviderRuntimeSession, error) {
+	return a.service.controller().SetVisible(ctx, input)
+}
+func (a serviceHostRuntime) Close(ctx context.Context, input RuntimeCloseInput) error {
+	return normalizeRuntimeError(a.service.controller().Close(ctx, input))
+}
+
+type serviceHostGoalRuntime struct{ service *Service }
+
+func (a serviceHostGoalRuntime) GoalControl(ctx context.Context, input agenthost.RuntimeGoalControlInput) (agenthost.RuntimeGoalControlResult, error) {
+	result, err := a.service.controller().GoalControl(ctx, input)
+	return result, normalizeRuntimeError(err)
+}
+
+func (a serviceHostGoalRuntime) ReconcileGoal(ctx context.Context, input agenthost.RuntimeGoalControlInput) (agenthost.RuntimeGoalReconcileResult, error) {
+	reconciler, ok := a.service.controller().(RuntimeGoalReconciler)
+	if !ok {
+		return agenthost.RuntimeGoalReconcileResult{}, errors.New("agent runtime goal reconciliation is unavailable")
+	}
+	result, err := reconciler.ReconcileGoal(ctx, input)
+	return result, normalizeRuntimeError(err)
+}
+
+func (a serviceHostGoalRuntime) GoalRecoveryPolicy(ctx context.Context, input agenthost.RuntimeGoalControlInput) (agenthost.RuntimeGoalRecoveryPolicy, error) {
+	resolver, ok := a.service.controller().(RuntimeGoalRecoveryPolicyResolver)
+	if !ok {
+		return agenthost.RuntimeGoalRecoveryPolicy{}, nil
+	}
+	return resolver.GoalRecoveryPolicy(ctx, input)
+}
+
+func newApplicationHost(s *Service, worktreeGC agenthost.WorktreeGarbageCollector) *agenthost.Host {
+	store := serviceHostStore{service: s}
+	return composeApplicationHost(s, worktreeGC, store, store, store, serviceHostRuntime{service: s}, serviceHostGoalRuntime{service: s})
+}
+
+func configureTestApplicationHost(s *Service) {
+	var once sync.Once
+	var host *agenthost.Host
+	s.applicationHostMu.Lock()
+	defer s.applicationHostMu.Unlock()
+	if s.applicationHostProvider != nil {
+		panic("test application host is already configured")
+	}
+	s.applicationHostProvider = func() *agenthost.Host {
+		once.Do(func() {
+			host = newApplicationHost(s, s)
+		})
+		return host
+	}
+}
+
+func activitySessionFromPersisted(session PersistedSession) storesqlite.Session {
+	return storesqlite.Session{
+		ID: session.ID, WorkspaceID: session.WorkspaceID, Kind: session.Kind,
+		RootAgentSessionID: session.RootAgentSessionID, RootTurnID: session.RootTurnID,
+		ParentAgentSessionID: session.ParentAgentSessionID, ParentTurnID: session.ParentTurnID,
+		ParentToolCallID: session.ParentToolCallID, Origin: session.Origin, UserID: session.UserID,
+		AgentTargetID: session.AgentTargetID, Provider: session.Provider, ProviderSessionID: session.ProviderSessionID,
+		Cwd: session.Cwd, RailSectionKey: session.RailSectionKey, Settings: ComposerSettingsToMap(session.Settings),
+		Metadata: session.Metadata, InternalRuntimeContext: clonePayload(session.InternalRuntimeContext), Title: session.Title,
+		PinnedAtUnixMS: session.PinnedAtUnixMS, LastEventUnixMS: session.LastEventUnixMS,
+		StartedAtUnixMS: session.StartedAtUnixMS, EndedAtUnixMS: session.EndedAtUnixMS,
+		CreatedAtUnixMS: session.CreatedAtUnixMS, UpdatedAtUnixMS: session.UpdatedAtUnixMS, ActiveTurnID: session.ActiveTurnID,
+	}
+}

--- a/services/tuttid/service/agent/model_catalog.go
+++ b/services/tuttid/service/agent/model_catalog.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tutti-os/tutti/packages/agent/daemon/modelcatalog"
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 	tuttiagentservice "github.com/tutti-os/tutti/services/tuttid/service/tuttiagent"
@@ -19,23 +20,11 @@ const (
 	codexModelErrorCacheTTL = 5 * time.Second
 )
 
-type AgentModelOption struct {
-	ID                         string
-	DisplayName                string
-	Description                string
-	DefaultReasoningEffort     string
-	IsDefault                  bool
-	ReasoningEffortsAdvertised bool
-	SupportedReasoningEfforts  []AgentModelReasoningEffortOption
-	SupportsImageInput         *bool
-}
+type AgentModelOption = modelcatalog.ModelOption
 
-type AgentModelReasoningEffortOption struct {
-	Default     bool
-	Description string
-	Label       string
-	Value       string
-}
+type AgentModelReasoningEffortOption = modelcatalog.ReasoningEffortOption
+
+type AgentModelSpeedOption = modelcatalog.SpeedOption
 
 type AgentModelCatalogResult struct {
 	Provider  string

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"strings"
 	"time"
 
@@ -533,14 +532,11 @@ func (s *Service) get(ctx context.Context, workspaceID string, agentSessionID st
 	return s.projectHostSessionResult(ctx, result.Canonical, result.Session, result.Live, true)
 }
 
-func (s *Service) Delete(ctx context.Context, workspaceID string, agentSessionID string) (bool, error) {
+func (s *Service) Delete(ctx context.Context, workspaceID string, agentSessionID string) (DeleteSessionResult, error) {
 	result, err := s.ApplicationHost().DeleteSession(ctx, agenthost.SessionRef{
 		WorkspaceID: workspaceID, AgentSessionID: agentSessionID,
 	})
-	if err == nil && result.Deleted {
-		s.releaseAgentResources(ctx, agentSessionID)
-	}
-	return result.Deleted, err
+	return DeleteSessionResult{Removed: result.Deleted, CleanupFailed: result.CleanupFailed}, err
 }
 
 func (s *Service) Clear(ctx context.Context, workspaceID string) (ClearSessionsResult, error) {
@@ -555,7 +551,7 @@ func (s *Service) Clear(ctx context.Context, workspaceID string) (ClearSessionsR
 		}); err != nil {
 			return ClearSessionsResult{}, normalizeRuntimeError(err)
 		}
-		if err := s.cleanupRuntime(ctx, workspaceID, session.ID); err != nil {
+		if err := s.cleanupSessionResources(ctx, workspaceID, session.ID); err != nil {
 			return ClearSessionsResult{}, err
 		}
 	}
@@ -567,23 +563,7 @@ func (s *Service) Clear(ctx context.Context, workspaceID string) (ClearSessionsR
 	if err != nil {
 		return ClearSessionsResult{}, err
 	}
-	for _, agentSessionID := range result.RemovedSessionIDs {
-		s.releaseAgentResources(ctx, agentSessionID)
-	}
 	return result, nil
-}
-
-func (s *Service) releaseAgentResources(ctx context.Context, agentSessionID string) {
-	if s.AgentSessionResourceReleaser == nil {
-		return
-	}
-	if err := s.AgentSessionResourceReleaser.ReleaseAgent(ctx, agentSessionID); err != nil {
-		slog.WarnContext(ctx, "release Agent session resources failed",
-			"agentSessionId", strings.TrimSpace(agentSessionID),
-			"error", err,
-			"event", "agent.session.resource_release_failed",
-		)
-	}
 }
 
 func (s *Service) UpdatePin(ctx context.Context, workspaceID string, agentSessionID string, pinned bool) (Session, error) {
@@ -621,6 +601,18 @@ func (s *Service) cleanupRuntime(ctx context.Context, workspaceID string, agentS
 		WorkspaceID:    workspaceID,
 		AgentSessionID: agentSessionID,
 	})
+}
+
+func (s *Service) cleanupSessionResources(ctx context.Context, workspaceID string, agentSessionID string) error {
+	var runtimeErr error
+	if s.RuntimePreparer != nil {
+		runtimeErr = s.cleanupRuntime(ctx, workspaceID, agentSessionID)
+	}
+	var agentResourceErr error
+	if s.AgentSessionResourceReleaser != nil {
+		agentResourceErr = s.AgentSessionResourceReleaser.ReleaseAgent(ctx, strings.TrimSpace(agentSessionID))
+	}
+	return errors.Join(runtimeErr, agentResourceErr)
 }
 
 func (s *Service) SubmitInteractive(ctx context.Context, ref agenthost.InteractionRef, input agenthost.SubmitInteractiveInput) (Session, error) {

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -544,26 +544,16 @@ func (s *Service) Clear(ctx context.Context, workspaceID string) (ClearSessionsR
 	if workspaceID == "" {
 		return ClearSessionsResult{}, ErrInvalidArgument
 	}
-	for _, session := range s.controller().Sessions(workspaceID) {
-		if err := s.controller().Close(ctx, RuntimeCloseInput{
-			WorkspaceID:    workspaceID,
-			AgentSessionID: session.ID,
-		}); err != nil {
-			return ClearSessionsResult{}, normalizeRuntimeError(err)
-		}
-		if err := s.cleanupSessionResources(ctx, workspaceID, session.ID); err != nil {
-			return ClearSessionsResult{}, err
-		}
-	}
-	clearer, ok := s.SessionReader.(SessionClearer)
-	if !ok {
-		return ClearSessionsResult{}, ErrSessionNotFound
-	}
-	result, err := clearer.ClearSessions(ctx, workspaceID)
+	result, err := s.ApplicationHost().ClearSessions(ctx, workspaceID)
 	if err != nil {
 		return ClearSessionsResult{}, err
 	}
-	return result, nil
+	return ClearSessionsResult{
+		RemovedMessages:         result.RemovedMessages,
+		RemovedSessions:         result.RemovedSessions,
+		RemovedSessionIDs:       result.RemovedSessionIDs,
+		CleanupFailedSessionIDs: result.CleanupFailedIDs,
+	}, nil
 }
 
 func (s *Service) UpdatePin(ctx context.Context, workspaceID string, agentSessionID string, pinned bool) (Session, error) {

--- a/services/tuttid/service/agent/service_session_sections.go
+++ b/services/tuttid/service/agent/service_session_sections.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	userprojectbiz "github.com/tutti-os/tutti/services/tuttid/biz/userproject"
 )
@@ -337,47 +338,17 @@ func (s *Service) DeleteSessionsBatch(
 	if workspaceID == "" || err != nil {
 		return DeleteSessionsBatchResult{}, ErrInvalidArgument
 	}
-	deleter, ok := s.SessionReader.(SessionBatchDeleter)
-	if !ok {
-		return DeleteSessionsBatchResult{}, fmt.Errorf("%w: session batch deleter is unavailable", ErrInvalidArgument)
-	}
-	runtimeClosed := make(map[string]struct{})
-	for _, agentSessionID := range sessionIDs {
-		if _, ok := s.controller().Session(workspaceID, agentSessionID); ok {
-			if err := s.controller().Close(ctx, RuntimeCloseInput{
-				WorkspaceID:    workspaceID,
-				AgentSessionID: agentSessionID,
-			}); err != nil {
-				return DeleteSessionsBatchResult{}, normalizeRuntimeError(err)
-			}
-			runtimeClosed[agentSessionID] = struct{}{}
-		}
-	}
-	result, err := deleter.DeleteSessionsBatch(ctx, agentactivitybiz.DeleteSessionsBatchInput{
-		WorkspaceID: workspaceID,
-		SessionIDs:  sessionIDs,
+	result, err := s.ApplicationHost().DeleteSessions(ctx, agenthost.DeleteSessionsInput{
+		WorkspaceID: workspaceID, SessionIDs: sessionIDs,
 	})
 	if err != nil {
 		return DeleteSessionsBatchResult{}, err
 	}
-	removed := make(map[string]struct{}, len(result.RemovedSessionIDs))
-	for _, sessionID := range result.RemovedSessionIDs {
-		removed[sessionID] = struct{}{}
-	}
-	for _, sessionID := range sessionIDs {
-		_, wasRemoved := removed[sessionID]
-		_, wasClosed := runtimeClosed[sessionID]
-		if wasRemoved || wasClosed {
-			if err := s.cleanupRuntime(ctx, workspaceID, sessionID); err != nil {
-				return DeleteSessionsBatchResult{}, err
-			}
-			s.releaseAgentResources(ctx, sessionID)
-		}
-	}
 	return DeleteSessionsBatchResult{
-		RemovedMessages:   result.RemovedMessages,
-		RemovedSessions:   result.RemovedSessions,
-		RemovedSessionIDs: result.RemovedSessionIDs,
+		RemovedMessages:         result.RemovedMessages,
+		RemovedSessions:         result.RemovedSessions,
+		RemovedSessionIDs:       result.RemovedSessionIDs,
+		CleanupFailedSessionIDs: result.CleanupFailedIDs,
 	}, nil
 }
 

--- a/services/tuttid/service/agent/service_settings.go
+++ b/services/tuttid/service/agent/service_settings.go
@@ -25,14 +25,14 @@ func (s *Service) clampReasoningEffortForModel(
 		model = composerDefaultModel(ctx, provider, "", s.ModelCatalog)
 	}
 	catalogOptions, ok := composerModelOptionsFromCatalog(ctx, s.ModelCatalog, provider, "", model)
-	if !ok || !catalogOptions.ReasoningEffortsAdvertised {
+	if !ok || !catalogOptions.Selection.ReasoningEffortsAdvertised {
 		return normalizeReasoningEffortForProvider(provider, selected)
 	}
 	return resolveAdvertisedReasoningEffort(
 		provider,
 		selected,
-		catalogOptions.DefaultReasoningEffort,
-		catalogOptions.ReasoningEfforts,
+		catalogOptions.Selection.DefaultReasoningEffort,
+		catalogOptions.Selection.ReasoningEfforts,
 	)
 }
 

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -4564,49 +4564,6 @@ func TestActivityProjectionPreservesMixedMessageAuditOrder(t *testing.T) {
 	}
 }
 
-func TestActivityProjectionPublishesDeletedEventsForClearedSessions(t *testing.T) {
-	repo := &activityProjectionRepoStub{
-		clearResult: agentactivitybiz.ClearSessionsResult{
-			TransactionID: "tx-clear",
-			CommitDelta: agentactivitybiz.TransactionDelta{
-				TransactionID: "tx-clear",
-				Mutations: []agentactivitybiz.TransactionMutation{
-					{WorkspaceID: "ws-1", AgentSessionID: "session-1", EntityKind: agentactivitybiz.MutationEntitySession, EntityID: "session-1", Operation: "delete"},
-					{WorkspaceID: "ws-1", AgentSessionID: "session-2", EntityKind: agentactivitybiz.MutationEntitySession, EntityID: "session-2", Operation: "delete"},
-				},
-			},
-			RemovedMessages:   5,
-			RemovedSessions:   2,
-			RemovedSessionIDs: []string{"session-1", "session-2"},
-		},
-	}
-	publisher := &activityUpdatePublisherStub{}
-	projection := NewActivityProjection(repo)
-	projection.SetPublisher(publisher)
-
-	result, err := projection.ClearSessions(context.Background(), " ws-1 ")
-	if err != nil {
-		t.Fatalf("ClearSessions() error = %v", err)
-	}
-	if result.RemovedSessions != 2 || result.RemovedMessages != 5 {
-		t.Fatalf("ClearSessions() = %#v, want clear result", result)
-	}
-	if len(publisher.events) != 2 {
-		t.Fatalf("published events = %d, want 2", len(publisher.events))
-	}
-	for _, event := range publisher.events {
-		if event.workspaceID != "ws-1" || event.eventType != "session_deleted" {
-			t.Fatalf("published event = %#v, want workspace session_deleted", event)
-		}
-		if !slices.Contains([]string{"session-1", "session-2"}, event.agentSessionID) {
-			t.Fatalf("published agentSessionID = %q, want cleared session id", event.agentSessionID)
-		}
-		if event.payload["agentSessionId"] != event.agentSessionID {
-			t.Fatalf("payload agentSessionId = %#v, want %q", event.payload["agentSessionId"], event.agentSessionID)
-		}
-	}
-}
-
 func TestServiceListsSessionMessages(t *testing.T) {
 	service := newIsolatedAgentService(newFakeRuntime())
 	lastLimit := 0
@@ -7170,7 +7127,21 @@ func (isolatedComposerCapabilityLister) ListComposerCapabilityOptions(
 func newIsolatedAgentService(runtime RuntimeController) *Service {
 	service := NewService(runtime)
 	service.CapabilityLister = isolatedComposerCapabilityLister{}
-	service.SessionInitializer = fakeSessionInitializer{}
+	installFakeCanonicalSessionStore(service)
+	if fake, ok := runtime.(*fakeRuntime); ok {
+		reader := service.SessionReader.(*fakeSessionReader)
+		for key, session := range fake.sessions {
+			settings := ComposerSettings{}
+			if session.Settings != nil {
+				settings = *session.Settings
+			}
+			reader.sessions[key] = PersistedSession{
+				ID: session.ID, WorkspaceID: session.WorkspaceID, Provider: session.Provider,
+				ProviderSessionID: session.ProviderSessionID, AgentTargetID: session.AgentTargetID,
+				Cwd: session.Cwd, Title: session.Title, Settings: settings,
+			}
+		}
+	}
 	return service
 }
 
@@ -7187,6 +7158,7 @@ func installFakeCanonicalSessionStore(service *Service) {
 		deletedAt:   map[string]int64{},
 		parentByKey: map[string]string{},
 		children:    map[string][]PersistedSession{},
+		runtime:     service.Runtime,
 	}
 	service.SessionInitializer = fakeSessionInitializer{reader: reader}
 	service.SessionReader = reader
@@ -7248,6 +7220,7 @@ type fakeSessionReader struct {
 	deletedAt   map[string]int64
 	parentByKey map[string]string
 	children    map[string][]PersistedSession
+	runtime     RuntimeController
 }
 
 type fakeSessionInitializer struct {
@@ -7380,6 +7353,10 @@ func (f *fakeSectionReader) DeleteSessionsBatch(_ context.Context, input agentac
 
 func (f *fakeSectionReader) PlanDeleteSessions(_ context.Context, input agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsPlan, error) {
 	return agentactivitybiz.DeleteSessionsPlan{WorkspaceID: input.WorkspaceID, SessionIDs: input.SessionIDs}, nil
+}
+
+func (f *fakeSectionReader) PlanClearSessions(_ context.Context, workspaceID string) (agentactivitybiz.DeleteSessionsPlan, error) {
+	return agentactivitybiz.DeleteSessionsPlan{WorkspaceID: workspaceID}, nil
 }
 
 type fakeUserProjectReader struct {
@@ -7635,11 +7612,42 @@ func (f *fakeRuntime) Sessions(workspaceID string) []ProviderRuntimeSession {
 }
 
 func (f fakeSessionReader) GetSession(workspaceID string, agentSessionID string) (PersistedSession, bool) {
-	session, ok := f.sessions[workspaceID+":"+agentSessionID]
+	key := workspaceID + ":" + agentSessionID
+	session, ok := f.sessions[key]
+	if !ok && f.runtime != nil {
+		if runtimeSession, found := f.runtime.Session(workspaceID, agentSessionID); found {
+			session = persistedSessionFromTestRuntime(runtimeSession)
+			if canonicalReader, supported := f.runtime.(interface {
+				GetSession(context.Context, string, string) (agentactivitybiz.Session, bool, error)
+			}); supported {
+				canonicalSession, canonicalFound, err := canonicalReader.GetSession(context.Background(), workspaceID, agentSessionID)
+				if err == nil && canonicalFound {
+					session.Kind = canonicalSession.Kind
+					session.RootAgentSessionID = canonicalSession.RootAgentSessionID
+				}
+			}
+			f.sessions[key] = session
+			ok = true
+		}
+	}
 	if ok && strings.TrimSpace(session.RailSectionKey) == "" {
 		session.RailSectionKey = "conversations"
 	}
 	return session, ok
+}
+
+func persistedSessionFromTestRuntime(session ProviderRuntimeSession) PersistedSession {
+	settings := ComposerSettings{}
+	if session.Settings != nil {
+		settings = *session.Settings
+	}
+	return PersistedSession{
+		ID: session.ID, WorkspaceID: session.WorkspaceID, Kind: agentactivitybiz.SessionKindRoot,
+		Provider: session.Provider, ProviderSessionID: session.ProviderSessionID,
+		AgentTargetID: session.AgentTargetID, Cwd: session.Cwd, RailSectionKey: "conversations",
+		Title: session.Title, Settings: settings, CreatedAtUnixMS: session.CreatedAtUnixMS,
+		UpdatedAtUnixMS: session.UpdatedAtUnixMS, LastEventUnixMS: session.UpdatedAtUnixMS,
+	}
 }
 
 func (f fakeSessionReader) SessionDeleted(_ context.Context, workspaceID string, agentSessionID string) (bool, error) {
@@ -7713,6 +7721,17 @@ func (f fakeSessionReader) PlanDeleteSessions(_ context.Context, input agentacti
 	return agentactivitybiz.DeleteSessionsPlan{WorkspaceID: input.WorkspaceID, SessionIDs: ids}, nil
 }
 
+func (f fakeSessionReader) PlanClearSessions(_ context.Context, workspaceID string) (agentactivitybiz.DeleteSessionsPlan, error) {
+	ids := make([]string, 0)
+	for _, session := range f.sessions {
+		if session.WorkspaceID == workspaceID {
+			ids = append(ids, session.ID)
+		}
+	}
+	slices.Sort(ids)
+	return agentactivitybiz.DeleteSessionsPlan{WorkspaceID: workspaceID, SessionIDs: ids}, nil
+}
+
 func (f fakeSessionReader) DeleteSessionsBatch(_ context.Context, input agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsBatchResult, error) {
 	removed := make([]string, 0, len(input.ExpectedSessionIDs))
 	for _, sessionID := range input.ExpectedSessionIDs {
@@ -7724,19 +7743,6 @@ func (f fakeSessionReader) DeleteSessionsBatch(_ context.Context, input agentact
 		removed = append(removed, sessionID)
 	}
 	return agentactivitybiz.DeleteSessionsBatchResult{RemovedSessions: len(removed), RemovedSessionIDs: removed}, nil
-}
-
-func (f fakeSessionReader) ClearSessions(_ context.Context, workspaceID string) (ClearSessionsResult, error) {
-	removed := 0
-	removedIDs := make([]string, 0)
-	for key, session := range f.sessions {
-		if session.WorkspaceID == workspaceID {
-			delete(f.sessions, key)
-			removed++
-			removedIDs = append(removedIDs, session.ID)
-		}
-	}
-	return ClearSessionsResult{RemovedSessions: removed, RemovedSessionIDs: removedIDs}, nil
 }
 
 func (f fakeSessionReader) PurgeDeletedSessions(_ context.Context, input agentactivitybiz.PurgeDeletedSessionsInput) (agentactivitybiz.PurgeDeletedSessionsResult, error) {
@@ -7943,6 +7949,10 @@ func (*activityProjectionRepoStub) DeleteSessionsBatch(context.Context, agentact
 
 func (*activityProjectionRepoStub) PlanDeleteSessions(_ context.Context, input agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsPlan, error) {
 	return agentactivitybiz.DeleteSessionsPlan{WorkspaceID: input.WorkspaceID, SessionIDs: input.SessionIDs}, nil
+}
+
+func (*activityProjectionRepoStub) PlanClearSessions(_ context.Context, workspaceID string) (agentactivitybiz.DeleteSessionsPlan, error) {
+	return agentactivitybiz.DeleteSessionsPlan{WorkspaceID: workspaceID}, nil
 }
 
 func (r *activityProjectionRepoStub) ListSessionMessages(context.Context, agentactivitybiz.ListSessionMessagesInput) (agentactivitybiz.MessagePage, bool, error) {

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -2694,6 +2694,7 @@ func TestServiceGetSkillBundleRequiresRenderer(t *testing.T) {
 func TestServiceDeleteCleansPreparedRuntime(t *testing.T) {
 	runtime := newFakeRuntime()
 	service := newTestService(runtime)
+	installFakeCanonicalSessionStore(service)
 	cleanupCalls := make([]runtimeprep.CleanupInput, 0)
 	service.RuntimePreparer = fakeRuntimePreparer{
 		result:       runtimeprep.PreparedRuntime{Cwd: "/prepared/workdir"},
@@ -2715,7 +2716,7 @@ func TestServiceDeleteCleansPreparedRuntime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Delete returned error: %v", err)
 	}
-	if !removed {
+	if !removed.Removed {
 		t.Fatal("Delete removed = false, want true")
 	}
 	if len(cleanupCalls) != 1 {
@@ -5259,6 +5260,7 @@ func TestServiceDeleteSessionsBatchClosesAllRuntimesBeforePersistence(t *testing
 	}}
 	service := newIsolatedAgentService(runtime)
 	service.SessionReader = reader
+	service.AgentSessionResourceReleaser = &fakeAgentSessionResourceReleaser{err: errors.New("release browser resources")}
 
 	result, err := service.DeleteSessionsBatch(context.Background(), "ws-1", DeleteSessionsBatchInput{
 		SessionIDs: []string{" session-1 ", "session-2"},
@@ -5269,7 +5271,7 @@ func TestServiceDeleteSessionsBatchClosesAllRuntimesBeforePersistence(t *testing
 	if len(runtime.closeCalls) != 2 || reader.batchDeleteCalls != 1 || !slices.Equal(reader.lastBatchDeleteInput.SessionIDs, []string{"session-1", "session-2"}) {
 		t.Fatalf("close calls=%#v batch input=%#v calls=%d", runtime.closeCalls, reader.lastBatchDeleteInput, reader.batchDeleteCalls)
 	}
-	if result.RemovedSessions != 2 {
+	if result.RemovedSessions != 2 || !slices.Equal(result.CleanupFailedSessionIDs, []string{"session-1", "session-2"}) {
 		t.Fatalf("result = %#v", result)
 	}
 }
@@ -5373,11 +5375,31 @@ func TestServiceDeletesPersistedSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Delete returned error: %v", err)
 	}
-	if !removed {
+	if !removed.Removed {
 		t.Fatal("Delete removed = false, want true")
 	}
 	if _, err := service.Get(context.Background(), "ws-1", "session-1"); err != ErrSessionNotFound {
 		t.Fatalf("Get after delete error = %v, want %v", err, ErrSessionNotFound)
+	}
+	if !slices.Equal(releaser.released, []string{"session-1"}) {
+		t.Fatalf("released Agent resources = %#v", releaser.released)
+	}
+}
+
+func TestServiceDeleteReportsPostCommitCleanupFailure(t *testing.T) {
+	service := newIsolatedAgentService(newFakeRuntime())
+	releaser := &fakeAgentSessionResourceReleaser{err: errors.New("release browser resources")}
+	service.AgentSessionResourceReleaser = releaser
+	service.SessionReader = fakeSessionReader{sessions: map[string]PersistedSession{
+		"ws-1:session-1": {ID: "session-1", WorkspaceID: "ws-1", Provider: "codex"},
+	}}
+
+	result, err := service.Delete(context.Background(), "ws-1", "session-1")
+	if err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+	if !result.Removed || !result.CleanupFailed {
+		t.Fatalf("Delete result = %#v, want committed delete with cleanup failure", result)
 	}
 	if !slices.Equal(releaser.released, []string{"session-1"}) {
 		t.Fatalf("released Agent resources = %#v", releaser.released)
@@ -5406,6 +5428,9 @@ func TestServiceDeleteNormalizesWrappedRuntimeSessionNotFound(t *testing.T) {
 	runtime.sessions["ws-1:session-1"] = ProviderRuntimeSession{ID: "session-1", WorkspaceID: "ws-1"}
 	runtime.closeErr = fmt.Errorf("runtime close: %w", ErrSessionNotFound)
 	service := newIsolatedAgentService(runtime)
+	service.SessionReader = &fakeSessionReader{sessions: map[string]PersistedSession{
+		"ws-1:session-1": {ID: "session-1", WorkspaceID: "ws-1"},
+	}}
 
 	_, err := service.Delete(context.Background(), "ws-1", "session-1")
 	if err != ErrSessionNotFound {
@@ -5416,6 +5441,7 @@ func TestServiceDeleteNormalizesWrappedRuntimeSessionNotFound(t *testing.T) {
 func TestServiceDeleteClosesRuntimeSession(t *testing.T) {
 	runtime := newFakeRuntime()
 	service := newTestService(runtime)
+	installFakeCanonicalSessionStore(service)
 	session, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
 		AgentTargetID:  agenttargetbiz.IDLocalCodex,
 		Provider:       "codex",
@@ -5429,7 +5455,7 @@ func TestServiceDeleteClosesRuntimeSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Delete returned error: %v", err)
 	}
-	if !removed {
+	if !removed.Removed {
 		t.Fatal("Delete removed = false, want true")
 	}
 	if len(runtime.closeCalls) != 1 || runtime.closeCalls[0].AgentSessionID != session.ID {
@@ -5687,7 +5713,7 @@ func TestServiceTypedGoalUsesDurableSagaBeforeTurnSubmit(t *testing.T) {
 	}
 }
 
-func TestGoalActorSlowRevisionOneResultCannotOverwriteRevisionTwoClear(t *testing.T) {
+func TestGoalSessionMutationLaneOrdersSlowSetBeforeClear(t *testing.T) {
 	ctx := context.Background()
 	store := openAgentServiceSQLiteStore(t)
 	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-goal-actor", Name: "Goal Actor"}); err != nil {
@@ -5732,48 +5758,40 @@ func TestGoalActorSlowRevisionOneResultCannotOverwriteRevisionTwoClear(t *testin
 		setDone <- goalCallResult{result: result, err: err}
 	}()
 	<-setStarted
-	clearResult, err := service.GoalControl(ctx, "ws-goal-actor", "session-goal-actor", "clear", "")
-	if err != nil {
-		t.Fatalf("clear while set RPC is slow: %v", err)
-	}
+	clearDone := make(chan goalCallResult, 1)
+	go func() {
+		result, err := service.GoalControl(ctx, "ws-goal-actor", "session-goal-actor", "clear", "")
+		clearDone <- goalCallResult{result: result, err: err}
+	}()
 	close(releaseSet)
 	setCall := <-setDone
 	if setCall.err != nil {
 		t.Fatalf("slow set completion: %v", setCall.err)
 	}
+	clearCall := <-clearDone
+	if clearCall.err != nil {
+		t.Fatalf("ordered clear: %v", clearCall.err)
+	}
 	state, found, err := store.GetSessionGoalState(ctx, "ws-goal-actor", "session-goal-actor")
 	if err != nil || !found || state.Revision != 2 || !state.Tombstoned || len(state.Desired) != 0 ||
-		state.SyncStatus != agentactivitybiz.GoalSyncStatusPending || state.PendingOperationID == "" {
+		state.SyncStatus != agentactivitybiz.GoalSyncStatusSynced || state.PendingOperationID != "" {
 		t.Fatalf("current state=%#v found=%v error=%v", state, found, err)
 	}
-	if setCall.result.Goal != nil || setCall.result.GoalState == nil || setCall.result.GoalState.Revision != 2 {
-		t.Fatalf("stale response leaked revision one: %#v", setCall.result)
+	if setCall.result.GoalState == nil || setCall.result.GoalState.Revision != 1 {
+		t.Fatalf("set result=%#v, want revision one", setCall.result)
 	}
-	if clearResult.OperationID == "" {
+	if clearCall.result.OperationID == "" {
 		t.Fatal("clear operation id is empty")
 	}
 	runtime.mu.Lock()
 	calls := append([]RuntimeGoalControlInput(nil), runtime.goalControlCalls...)
 	runtime.mu.Unlock()
 	if len(calls) != 2 || calls[0].Action != "set" || calls[1].Action != "clear" {
-		t.Fatalf("provider calls before worker=%#v, want no synchronous compensation", calls)
-	}
-	if err := service.ApplicationHost().StepGoalOperationWorker(ctx, false); err != nil {
-		t.Fatalf("run durable repair: %v", err)
-	}
-	state, found, err = store.GetSessionGoalState(ctx, "ws-goal-actor", "session-goal-actor")
-	if err != nil || !found || state.SyncStatus != agentactivitybiz.GoalSyncStatusSynced || state.PendingOperationID != "" {
-		t.Fatalf("repaired state=%#v found=%v error=%v", state, found, err)
-	}
-	runtime.mu.Lock()
-	calls = append([]RuntimeGoalControlInput(nil), runtime.goalControlCalls...)
-	runtime.mu.Unlock()
-	if len(calls) != 3 || calls[2].Action != "clear" {
-		t.Fatalf("provider calls after worker=%#v, want durable clear repair", calls)
+		t.Fatalf("provider calls=%#v, want ordered set then clear", calls)
 	}
 }
 
-func TestGoalActorAmbiguousOldErrorSchedulesDurableRepairOfNewerRevision(t *testing.T) {
+func TestGoalSessionMutationLaneRunsClearAfterAmbiguousSetFailure(t *testing.T) {
 	ctx := context.Background()
 	store := openAgentServiceSQLiteStore(t)
 	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-goal-error", Name: "Goal Error"}); err != nil {
@@ -5808,29 +5826,22 @@ func TestGoalActorAmbiguousOldErrorSchedulesDurableRepairOfNewerRevision(t *test
 		setDone <- err
 	}()
 	<-setStarted
-	if _, err := service.GoalControl(ctx, "ws-goal-error", "session-goal-error", "clear", ""); err != nil {
-		t.Fatalf("newer clear: %v", err)
-	}
 	close(releaseSet)
 	if err := <-setDone; err == nil {
 		t.Fatal("ambiguous old provider result unexpectedly succeeded")
 	}
+	if _, err := service.GoalControl(ctx, "ws-goal-error", "session-goal-error", "clear", ""); err != nil {
+		t.Fatalf("clear after failed set: %v", err)
+	}
 	state, found, err := store.GetSessionGoalState(ctx, "ws-goal-error", "session-goal-error")
-	if err != nil || !found || state.Revision != 2 || state.PendingOperationID == "" || state.SyncStatus != agentactivitybiz.GoalSyncStatusPending {
-		t.Fatalf("durable repair state=%#v found=%v err=%v", state, found, err)
-	}
-	if err := service.ApplicationHost().StepGoalOperationWorker(ctx, false); err != nil {
-		t.Fatalf("repair ambiguous old result: %v", err)
-	}
-	state, found, err = store.GetSessionGoalState(ctx, "ws-goal-error", "session-goal-error")
-	if err != nil || !found || state.PendingOperationID != "" || state.SyncStatus != agentactivitybiz.GoalSyncStatusSynced {
-		t.Fatalf("repaired state=%#v found=%v err=%v", state, found, err)
+	if err != nil || !found || state.Revision != 2 || state.PendingOperationID != "" || state.SyncStatus != agentactivitybiz.GoalSyncStatusSynced || !state.Tombstoned {
+		t.Fatalf("cleared state=%#v found=%v err=%v", state, found, err)
 	}
 	runtime.mu.Lock()
 	calls := append([]RuntimeGoalControlInput(nil), runtime.goalControlCalls...)
 	runtime.mu.Unlock()
-	if len(calls) != 3 || calls[0].Action != "set" || calls[1].Action != "clear" || calls[2].Action != "clear" {
-		t.Fatalf("provider calls=%#v, want set, clear, durable clear repair", calls)
+	if len(calls) != 2 || calls[0].Action != "set" || calls[1].Action != "clear" {
+		t.Fatalf("provider calls=%#v, want set then clear", calls)
 	}
 }
 
@@ -7169,6 +7180,18 @@ func newTestService(runtime RuntimeController) *Service {
 	return service
 }
 
+func installFakeCanonicalSessionStore(service *Service) {
+	reader := &fakeSessionReader{
+		sessions:    map[string]PersistedSession{},
+		tombstoned:  map[string]bool{},
+		deletedAt:   map[string]int64{},
+		parentByKey: map[string]string{},
+		children:    map[string][]PersistedSession{},
+	}
+	service.SessionInitializer = fakeSessionInitializer{reader: reader}
+	service.SessionReader = reader
+}
+
 func seedPersistedLiveSettingsSession(service *Service, session ProviderRuntimeSession) {
 	settings := ComposerSettings{}
 	if session.Settings != nil {
@@ -7228,7 +7251,8 @@ type fakeSessionReader struct {
 }
 
 type fakeSessionInitializer struct {
-	err error
+	err    error
+	reader *fakeSessionReader
 }
 
 func (f fakeSessionInitializer) InitializeRuntimeSession(
@@ -7239,7 +7263,7 @@ func (f fakeSessionInitializer) InitializeRuntimeSession(
 		return PersistedSession{}, f.err
 	}
 	settings := cloneComposerSettingsPointerValue(session.Settings)
-	return PersistedSession{
+	persisted := PersistedSession{
 		ID:                     strings.TrimSpace(session.ID),
 		WorkspaceID:            strings.TrimSpace(session.WorkspaceID),
 		Kind:                   agentactivitybiz.SessionKindRoot,
@@ -7258,16 +7282,21 @@ func (f fakeSessionInitializer) InitializeRuntimeSession(
 		StartedAtUnixMS:        session.CreatedAtUnixMS,
 		CreatedAtUnixMS:        session.CreatedAtUnixMS,
 		UpdatedAtUnixMS:        session.UpdatedAtUnixMS,
-	}, nil
+	}
+	if f.reader != nil {
+		f.reader.sessions[persisted.WorkspaceID+":"+persisted.ID] = persisted
+	}
+	return persisted, nil
 }
 
 type fakeAgentSessionResourceReleaser struct {
 	released []string
+	err      error
 }
 
 func (f *fakeAgentSessionResourceReleaser) ReleaseAgent(_ context.Context, agentSessionID string) error {
 	f.released = append(f.released, agentSessionID)
-	return nil
+	return f.err
 }
 
 type fakeSectionReader struct {
@@ -7347,6 +7376,10 @@ func (f *fakeSectionReader) DeleteSessionsBatch(_ context.Context, input agentac
 	f.batchDeleteCalls++
 	f.lastBatchDeleteInput = input
 	return f.batchDeleteResult, f.batchDeleteErr
+}
+
+func (f *fakeSectionReader) PlanDeleteSessions(_ context.Context, input agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsPlan, error) {
+	return agentactivitybiz.DeleteSessionsPlan{WorkspaceID: input.WorkspaceID, SessionIDs: input.SessionIDs}, nil
 }
 
 type fakeUserProjectReader struct {
@@ -7669,13 +7702,28 @@ func (f *fakeSessionReader) UpdateSessionPinned(_ context.Context, workspaceID s
 	return session, true, nil
 }
 
-func (f fakeSessionReader) DeleteSession(_ context.Context, workspaceID string, agentSessionID string) (bool, error) {
-	key := workspaceID + ":" + agentSessionID
-	if _, ok := f.sessions[key]; !ok {
-		return false, nil
+func (f fakeSessionReader) PlanDeleteSessions(_ context.Context, input agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsPlan, error) {
+	ids := make([]string, 0, len(input.SessionIDs))
+	for _, sessionID := range input.SessionIDs {
+		if _, ok := f.sessions[input.WorkspaceID+":"+sessionID]; ok {
+			ids = append(ids, sessionID)
+		}
 	}
-	delete(f.sessions, key)
-	return true, nil
+	slices.Sort(ids)
+	return agentactivitybiz.DeleteSessionsPlan{WorkspaceID: input.WorkspaceID, SessionIDs: ids}, nil
+}
+
+func (f fakeSessionReader) DeleteSessionsBatch(_ context.Context, input agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsBatchResult, error) {
+	removed := make([]string, 0, len(input.ExpectedSessionIDs))
+	for _, sessionID := range input.ExpectedSessionIDs {
+		key := input.WorkspaceID + ":" + sessionID
+		if _, ok := f.sessions[key]; !ok {
+			continue
+		}
+		delete(f.sessions, key)
+		removed = append(removed, sessionID)
+	}
+	return agentactivitybiz.DeleteSessionsBatchResult{RemovedSessions: len(removed), RemovedSessionIDs: removed}, nil
 }
 
 func (f fakeSessionReader) ClearSessions(_ context.Context, workspaceID string) (ClearSessionsResult, error) {
@@ -7861,10 +7909,6 @@ func (r *activityProjectionRepoStub) ClearSessions(context.Context, string) (age
 	return r.clearResult, nil
 }
 
-func (*activityProjectionRepoStub) DeleteSessionWithCommit(context.Context, string, string) (agentactivitybiz.DeleteSessionResult, error) {
-	return agentactivitybiz.DeleteSessionResult{}, nil
-}
-
 func (*activityProjectionRepoStub) GetSession(context.Context, string, string) (agentactivitybiz.Session, bool, error) {
 	return agentactivitybiz.Session{}, false, nil
 }
@@ -7895,6 +7939,10 @@ func (*activityProjectionRepoStub) ListSessionSectionDeletionCandidates(context.
 
 func (*activityProjectionRepoStub) DeleteSessionsBatch(context.Context, agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsBatchResult, error) {
 	return agentactivitybiz.DeleteSessionsBatchResult{}, nil
+}
+
+func (*activityProjectionRepoStub) PlanDeleteSessions(_ context.Context, input agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsPlan, error) {
+	return agentactivitybiz.DeleteSessionsPlan{WorkspaceID: input.WorkspaceID, SessionIDs: input.SessionIDs}, nil
 }
 
 func (r *activityProjectionRepoStub) ListSessionMessages(context.Context, agentactivitybiz.ListSessionMessagesInput) (agentactivitybiz.MessagePage, bool, error) {

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -99,8 +99,7 @@ func TestServiceCreateInheritsTargetComposerDefaultsAndExplicitOverridesWin(t *t
 
 func TestServiceApplicationHostUsesConfiguredSingleton(t *testing.T) {
 	service := newTestService(newFakeRuntime())
-	host := NewApplicationHost(service)
-	service.SetApplicationHost(host)
+	host := service.ApplicationHost()
 
 	if got := service.ApplicationHost(); got != host {
 		t.Fatalf("ApplicationHost() = %p, want configured host %p", got, host)
@@ -4163,6 +4162,7 @@ func TestServiceUpdateSettingsPreservesAdvertisedReasoningEffort(t *testing.T) {
 				},
 			}
 
+			configureTestApplicationHost(service)
 			session, err := service.UpdateSettings(context.Background(), "ws-1", "session-1", ComposerSettingsPatch{
 				ReasoningEffort: stringRef(effort),
 			})
@@ -4216,6 +4216,7 @@ func TestServiceUpdateSettingsDefersModelChangeReasoningClampToLiveRuntime(t *te
 			},
 		},
 	}
+	configureTestApplicationHost(service)
 	model := "gpt-5.6-luna"
 
 	session, err := service.UpdateSettings(context.Background(), "ws-1", "session-1", ComposerSettingsPatch{
@@ -6901,6 +6902,7 @@ func TestServiceResumeClampsPersistedReasoningToSelectedModelCatalog(t *testing.
 		},
 	}
 
+	configureTestApplicationHost(service)
 	if _, err := service.SendInput(
 		context.Background(),
 		"ws-1",
@@ -7124,7 +7126,7 @@ func (isolatedComposerCapabilityLister) ListComposerCapabilityOptions(
 
 // newIsolatedAgentService keeps package tests hermetic. Tests that exercise
 // capability discovery replace CapabilityLister with an explicit fixture.
-func newIsolatedAgentService(runtime RuntimeController) *Service {
+func newUnconfiguredIsolatedAgentService(runtime RuntimeController) *Service {
 	service := NewService(runtime)
 	service.CapabilityLister = isolatedComposerCapabilityLister{}
 	installFakeCanonicalSessionStore(service)
@@ -7142,6 +7144,12 @@ func newIsolatedAgentService(runtime RuntimeController) *Service {
 			}
 		}
 	}
+	return service
+}
+
+func newIsolatedAgentService(runtime RuntimeController) *Service {
+	service := newUnconfiguredIsolatedAgentService(runtime)
+	configureTestApplicationHost(service)
 	return service
 }
 

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -4000,6 +4000,18 @@ func TestGetComposerOptionsClaudeCodeStartsHiddenDiscoveryOnceAcrossWorkspacesAn
 		runtime.startCalls[0].ProviderTargetRef["targetId"] != agenttargetbiz.IDLocalClaudeCode {
 		t.Fatalf("discovery target = %q / %#v", runtime.startCalls[0].AgentTargetID, runtime.startCalls[0].ProviderTargetRef)
 	}
+	discoverySessionID := runtime.startCalls[0].AgentSessionID
+	persisted := &fakeSessionReader{sessions: map[string]PersistedSession{
+		"ws-1:" + discoverySessionID: {
+			ID: discoverySessionID, WorkspaceID: "ws-1", Provider: "claude-code",
+			Metadata:               agentactivitybiz.SessionMetadata{Visible: false},
+			InternalRuntimeContext: map[string]any{"hiddenLiveModelDiscovery": true},
+		},
+	}}
+	// Model discovery sessions are reported asynchronously in production. Seed
+	// the canonical observation after startup so the delayed cleanup must close
+	// the runtime and remove the canonical row through Host.
+	service.SessionReader = persisted
 	select {
 	case input := <-closed:
 		t.Fatalf("unexpected immediate hidden discovery cleanup: %#v", input)
@@ -4035,6 +4047,16 @@ func TestGetComposerOptionsClaudeCodeStartsHiddenDiscoveryOnceAcrossWorkspacesAn
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for delayed hidden discovery cleanup")
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		if _, exists := persisted.sessions["ws-1:"+discoverySessionID]; !exists {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("hidden discovery session still persisted after delayed cleanup")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -7359,11 +7359,11 @@ func (f *fakeSectionReader) DeleteSessionsBatch(_ context.Context, input agentac
 	return f.batchDeleteResult, f.batchDeleteErr
 }
 
-func (f *fakeSectionReader) PlanDeleteSessions(_ context.Context, input agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsPlan, error) {
+func (*fakeSectionReader) PlanDeleteSessions(_ context.Context, input agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsPlan, error) {
 	return agentactivitybiz.DeleteSessionsPlan{WorkspaceID: input.WorkspaceID, SessionIDs: input.SessionIDs}, nil
 }
 
-func (f *fakeSectionReader) PlanClearSessions(_ context.Context, workspaceID string) (agentactivitybiz.DeleteSessionsPlan, error) {
+func (*fakeSectionReader) PlanClearSessions(_ context.Context, workspaceID string) (agentactivitybiz.DeleteSessionsPlan, error) {
 	return agentactivitybiz.DeleteSessionsPlan{WorkspaceID: workspaceID}, nil
 }
 

--- a/services/tuttid/service/agent/service_turns_error_test.go
+++ b/services/tuttid/service/agent/service_turns_error_test.go
@@ -13,6 +13,7 @@ func TestCancelTurnPropagatesPersistedTurnReadFailure(t *testing.T) {
 	t.Parallel()
 	want := errors.New("turn store unavailable")
 	service := &Service{TurnStore: failingTurnStore{getTurnErr: want}}
+	configureTestApplicationHost(service)
 
 	_, err := service.CancelTurn(context.Background(), "workspace-1", "session-1", "turn-1")
 	if !errors.Is(err, want) {
@@ -112,6 +113,7 @@ func TestGetTurnReadsCanonicalTurnThroughHost(t *testing.T) {
 	t.Parallel()
 	want := agentactivitybiz.Turn{WorkspaceID: "workspace-1", AgentSessionID: "session-1", TurnID: "turn-1"}
 	service := &Service{TurnStore: failingTurnStore{turn: want}}
+	configureTestApplicationHost(service)
 
 	got, found, err := service.GetTurn(context.Background(), "workspace-1", "session-1", "turn-1")
 	if err != nil || !found || got.TurnID != want.TurnID {

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -271,10 +271,16 @@ type DeleteSessionsBatchInput struct {
 	SessionIDs []string
 }
 
+type DeleteSessionResult struct {
+	Removed       bool
+	CleanupFailed bool
+}
+
 type DeleteSessionsBatchResult struct {
-	RemovedMessages   int
-	RemovedSessions   int
-	RemovedSessionIDs []string
+	RemovedMessages         int
+	RemovedSessions         int
+	RemovedSessionIDs       []string
+	CleanupFailedSessionIDs []string
 }
 
 type ListPinnedSessionPageInput struct {
@@ -389,6 +395,7 @@ type SessionSectionDeletionCandidateReader interface {
 }
 
 type SessionBatchDeleter interface {
+	PlanDeleteSessions(context.Context, agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsPlan, error)
 	DeleteSessionsBatch(context.Context, agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsBatchResult, error)
 }
 
@@ -408,10 +415,6 @@ type SessionClearer interface {
 
 type AgentSessionResourceReleaser interface {
 	ReleaseAgent(context.Context, string) error
-}
-
-type SessionDeleter interface {
-	DeleteSession(context.Context, string, string) (bool, error)
 }
 
 type SessionPinUpdater interface {

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -395,6 +395,7 @@ type SessionSectionDeletionCandidateReader interface {
 }
 
 type SessionBatchDeleter interface {
+	PlanClearSessions(context.Context, string) (agentactivitybiz.DeleteSessionsPlan, error)
 	PlanDeleteSessions(context.Context, agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsPlan, error)
 	DeleteSessionsBatch(context.Context, agentactivitybiz.DeleteSessionsBatchInput) (agentactivitybiz.DeleteSessionsBatchResult, error)
 }
@@ -404,13 +405,10 @@ type UserProjectReader interface {
 }
 
 type ClearSessionsResult struct {
-	RemovedMessages   int
-	RemovedSessions   int
-	RemovedSessionIDs []string
-}
-
-type SessionClearer interface {
-	ClearSessions(context.Context, string) (ClearSessionsResult, error)
+	RemovedMessages         int
+	RemovedSessions         int
+	RemovedSessionIDs       []string
+	CleanupFailedSessionIDs []string
 }
 
 type AgentSessionResourceReleaser interface {

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -76,6 +76,7 @@ type Service struct {
 	sessionSettingsLocks           map[string]*serviceSessionSettingsLock
 	applicationHostMu              sync.Mutex
 	applicationHost                *agenthost.Host
+	applicationHostProvider        func() *agenthost.Host
 	worktreeIsolationMu            sync.RWMutex
 	generatedFilesCacheMu          sync.Mutex
 	generatedFilesCache            map[string]generatedFilesCacheEntry

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -13,8 +13,10 @@ import (
 
 	"github.com/google/uuid"
 	agentdaemon "github.com/tutti-os/tutti/packages/agent/daemon"
+	agenthostadapter "github.com/tutti-os/tutti/packages/agent/daemon/hostadapter"
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	runtimeprep "github.com/tutti-os/tutti/packages/agent/runtimeprep"
+	agentstoresqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	workspaceissues "github.com/tutti-os/tutti/packages/workspace/issues"
 	tuttiapi "github.com/tutti-os/tutti/services/tuttid/api"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
@@ -493,7 +495,22 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 	agentSessionService.AvailabilityChecker = agentservice.AgentStatusProviderAvailabilityChecker{
 		Service: &agentStatusService,
 	}
-	agentHost := agentservice.NewApplicationHost(agentSessionService)
+	canonicalStoreProvider, ok := store.(interface {
+		AgentCanonicalStore() *agentstoresqlite.Store
+	})
+	if !ok || canonicalStoreProvider.AgentCanonicalStore() == nil {
+		return tuttiapi.DaemonAPI{}, nil, nil, nil, fmt.Errorf("canonical agent store is unavailable")
+	}
+	canonicalHostStore := &agenthost.SQLiteWorkspaceStore{
+		StoreForWorkspace: func(string) *agentstoresqlite.Store {
+			return canonicalStoreProvider.AgentCanonicalStore()
+		},
+		Observer:             agentActivityProjection,
+		InitializationPolicy: agentActivityProjection,
+	}
+	agentHost := agentservice.NewApplicationHostWithPorts(agentSessionService, canonicalHostStore, &agenthostadapter.RuntimeController{
+		Backend: agentRuntime.Controller(),
+	})
 	agentSessionService.SetApplicationHost(agentHost)
 	// Host fixes startup order: durable runtime operations first, then goal
 	// operations and reconcile inbox work, and only then stale turns.

--- a/tools/scripts/check-agent-host-boundary.mjs
+++ b/tools/scripts/check-agent-host-boundary.mjs
@@ -134,6 +134,26 @@ export function findStaleAllowlistEntries(fileExists = existsSync) {
   return stale;
 }
 
+export function findProductionCompositionViolations(source) {
+  const required = [
+    [
+      "agenthostadapter.RuntimeController",
+      "production wiring must consume the shared daemon-to-Host runtime adapter"
+    ],
+    [
+      "agenthost.SQLiteWorkspaceStore",
+      "production wiring must consume the shared Host canonical SQLite store"
+    ],
+    [
+      "agentservice.NewApplicationHostWithPorts",
+      "production wiring must compose Host from the shared runtime and canonical ports"
+    ]
+  ];
+  return required.flatMap(([token, message]) =>
+    source.includes(token) ? [] : [`services/tuttid/wiring.go: ${message}`]
+  );
+}
+
 function scanWorkspace() {
   const violations = [];
   for (const file of goFiles(join(workspaceRoot, scanRoot))) {
@@ -174,6 +194,11 @@ if (isMainModule()) {
   }
 
   const violations = scanWorkspace();
+  violations.push(
+    ...findProductionCompositionViolations(
+      readFileSync(join(workspaceRoot, "services/tuttid/wiring.go"), "utf8")
+    )
+  );
   if (violations.length > 0) {
     console.error(
       "Agent application lifecycle semantics must live in packages/agent/host, " +

--- a/tools/scripts/check-agent-host-boundary.mjs
+++ b/tools/scripts/check-agent-host-boundary.mjs
@@ -59,6 +59,18 @@ export function findBoundaryViolations(path, source) {
 
   const violations = [];
 
+  for (const forbidden of [
+    "type serviceHostStore struct",
+    "type serviceHostRuntime struct",
+    "func NewApplicationHost("
+  ]) {
+    if (source.includes(forbidden)) {
+      violations.push(
+        `${path}: production adapter must not reintroduce ${forbidden}; use shared Host composition ports`
+      );
+    }
+  }
+
   if (ORCHESTRATION_FILENAME.test(path)) {
     violations.push(
       `${path}: filename declares an agent application-core orchestration surface ` +

--- a/tools/scripts/check-agent-host-boundary.test.mjs
+++ b/tools/scripts/check-agent-host-boundary.test.mjs
@@ -2,10 +2,21 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   findBoundaryViolations,
+  findProductionCompositionViolations,
   findStaleAllowlistEntries,
   isAllowlisted,
   isTestSource
 } from "./check-agent-host-boundary.mjs";
+
+test("requires production wiring to consume shared Host adapters", () => {
+  const source = [
+    "agenthostadapter.RuntimeController{}",
+    "agenthost.SQLiteWorkspaceStore{}",
+    "agentservice.NewApplicationHostWithPorts(service, store, runtime)"
+  ].join("\n");
+  assert.deepEqual(findProductionCompositionViolations(source), []);
+  assert.equal(findProductionCompositionViolations("legacy wiring").length, 3);
+});
 
 test("flags a new *Coordinator production type declaration", () => {
   const source = [

--- a/tools/scripts/check-agent-host-boundary.test.mjs
+++ b/tools/scripts/check-agent-host-boundary.test.mjs
@@ -18,6 +18,21 @@ test("requires production wiring to consume shared Host adapters", () => {
   assert.equal(findProductionCompositionViolations("legacy wiring").length, 3);
 });
 
+test("rejects service-local Host store/runtime composition in production", () => {
+  const source = [
+    "type serviceHostStore struct {}",
+    "type serviceHostRuntime struct {}",
+    "func NewApplicationHost() {}"
+  ].join("\n");
+  assert.equal(
+    findBoundaryViolations(
+      "services/tuttid/service/agent/host_adapters.go",
+      source
+    ).length,
+    3
+  );
+});
+
 test("flags a new *Coordinator production type declaration", () => {
   const source = [
     "package agent",


### PR DESCRIPTION
## Summary

- make `packages/agent/host` the production owner of session, goal, clear, and batch-deletion lifecycle coordination, with shared runtime and SQLite workspace adapters consumed by `tuttid`
- centralize Codex model parsing, model-level reasoning/speed projection, and provider defaults in the reusable model catalog and provider registry
- expose canonical activity capability and session metadata projections so desktop consumers do not reconstruct provider or lifecycle truth
- remove duplicated service-local production adapters and add architecture gates and documentation that prevent the lifecycle boundary from diverging again

## Verification

- `go test ./packages/agent/daemon/providerregistry ./packages/agent/daemon/modelcatalog ./packages/agent/store-sqlite ./services/tuttid/service/agent -count=1`
- `pnpm --dir packages/agent/activity-core test`
- `node tools/scripts/check-agent-host-boundary.mjs`
- `node --test tools/scripts/check-agent-host-boundary.test.mjs`
- staged formatting, Electron/UI/renderer boundary checks from the repository pre-commit hook

## Checklist

- [x] No new adapter-owned lifecycle semantics were introduced; production lifecycle coordination delegates to `packages/agent/host`.
- [x] I kept the change focused on canonical Agent lifecycle and composer contract ownership.
- [x] I updated architecture and static-analysis documentation for the changed ownership and enforcement.
- [x] README/CONTRIBUTING language variants were not changed.
- [x] I ran the lowest meaningful local checks for the changed surfaces.
- [x] All commits include DCO sign-off.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
