### PR TITLE
fix(tooling): isolate temporary git fixtures

### DIFF
--- a/docs/conventions/troubleshooting/toolchain-browser-terminal.md
+++ b/docs/conventions/troubleshooting/toolchain-browser-terminal.md
@@ -54,13 +54,16 @@
   after initialization, and pass fixture author identity through commit-local
   `-c` arguments instead of `git config`.
 - Validation:
-  Run the fixture tests with poisoned `GIT_DIR`, `GIT_WORK_TREE`, and
-  `GIT_CONFIG_*` inputs that point only at disposable paths. Confirm the fixture
-  initializes its own `.git`, then verify the caller's config, index, branch,
-  and worktree remain unchanged.
+  Run `git-environment.test.mjs`, which launches the temporary-repository test
+  suites with a poisoned linked-worktree `GIT_DIR` that points only at a
+  disposable repository. Confirm each fixture initializes its own `.git`, then
+  verify the caller's config and branch remain unchanged. Keep the lower-level
+  environment test coverage for `GIT_WORK_TREE` and `GIT_CONFIG_*` inputs.
 - References:
   [git-environment.mjs](../../../tools/scripts/git-environment.mjs)
   [check-agent-gui-degradation.test.mjs](../../../tools/scripts/check-agent-gui-degradation.test.mjs)
+  [push-checked.test.mjs](../../../tools/scripts/push-checked.test.mjs)
+  [run-check-changed.test.mjs](../../../tools/scripts/run-check-changed.test.mjs)
   [static-analysis.md](../static-analysis.md)
 
 ### Dynamic CLI input rejects plausible flags

--- a/tools/scripts/git-environment.test.mjs
+++ b/tools/scripts/git-environment.test.mjs
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 
 import { createIsolatedGitEnvironment } from "./git-environment.mjs";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 
 test("isolates Git repository selectors case-insensitively", () => {
   const fixtureRoot = "/tmp/tutti-git-fixture";
@@ -23,3 +30,78 @@ test("isolates Git repository selectors case-insensitively", () => {
     PRESERVED_FIXTURE_VALUE: "preserved"
   });
 });
+
+test("temporary Git fixture tests preserve an inherited linked worktree", () => {
+  for (const testFile of [
+    "push-checked.test.mjs",
+    "run-check-changed.test.mjs"
+  ]) {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "tutti-git-isolation-"));
+    const primaryRoot = join(fixtureRoot, "primary");
+    const linkedRoot = join(fixtureRoot, "linked");
+    mkdirSync(primaryRoot);
+    runGit(fixtureRoot, [
+      "init",
+      "--quiet",
+      "--initial-branch=main",
+      primaryRoot
+    ]);
+    runGit(primaryRoot, [
+      "-c",
+      "user.email=test@example.com",
+      "-c",
+      "user.name=Test",
+      "commit",
+      "--quiet",
+      "--allow-empty",
+      "-m",
+      "initial"
+    ]);
+    runGit(primaryRoot, [
+      "worktree",
+      "add",
+      "--quiet",
+      "-b",
+      "fixture",
+      linkedRoot
+    ]);
+
+    const linkedGitDirectory = gitOutput(linkedRoot, [
+      "rev-parse",
+      "--absolute-git-dir"
+    ]);
+    const configPath = join(primaryRoot, ".git", "config");
+    const configBefore = readFileSync(configPath, "utf8");
+    const headBefore = gitOutput(linkedRoot, ["rev-parse", "HEAD"]);
+    const childEnvironment = createIsolatedGitEnvironment(linkedRoot);
+    delete childEnvironment.NODE_TEST_CONTEXT;
+    childEnvironment.GIT_DIR = linkedGitDirectory;
+    const result = spawnSync(
+      process.execPath,
+      ["--test", join(scriptDirectory, testFile)],
+      {
+        cwd: scriptDirectory,
+        encoding: "utf8",
+        env: childEnvironment
+      }
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(readFileSync(configPath, "utf8"), configBefore, testFile);
+    assert.equal(gitOutput(linkedRoot, ["rev-parse", "HEAD"]), headBefore);
+  }
+});
+
+function runGit(cwd, args) {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: createIsolatedGitEnvironment(cwd)
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result;
+}
+
+function gitOutput(cwd, args) {
+  return runGit(cwd, args).stdout.trim();
+}

--- a/tools/scripts/push-checked.test.mjs
+++ b/tools/scripts/push-checked.test.mjs
@@ -13,6 +13,8 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
+import { createIsolatedGitEnvironment } from "./git-environment.mjs";
+
 const sourceScriptPath = resolve(
   dirname(fileURLToPath(import.meta.url)),
   "push-checked.mjs"
@@ -151,12 +153,12 @@ function runPushChecked(fixture, extraEnv = {}) {
   return spawnSync(process.execPath, [fixture.copiedScriptPath], {
     cwd: fixture.workspaceRoot,
     encoding: "utf8",
-    env: {
+    env: createIsolatedGitEnvironment(fixture.workspaceRoot, {
       ...process.env,
       ...extraEnv,
       PATH: `${fixture.binRoot}:${process.env.PATH ?? ""}`,
       TUTTI_PUSH_CHECKED_TEST_LOG: fixture.pnpmLogPath
-    }
+    })
   });
 }
 
@@ -169,7 +171,11 @@ function remoteHead(remoteRoot) {
 }
 
 function runGit(cwd, args) {
-  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: createIsolatedGitEnvironment(cwd)
+  });
   assert.equal(result.status, 0, result.stderr || result.stdout);
   return result;
 }

--- a/tools/scripts/run-check-changed.test.mjs
+++ b/tools/scripts/run-check-changed.test.mjs
@@ -16,6 +16,9 @@ import {
   isAgentActivityRuntimeBoundaryRelevant,
   isRendererBoundaryRelevant
 } from "./repository-checks.mjs";
+import { createIsolatedGitEnvironment } from "./git-environment.mjs";
+
+isolateProcessGitEnvironment(createIsolatedGitEnvironment(tmpdir()));
 
 test("parseCliArgs rejects unknown and invalid options", () => {
   assert.throws(() => parseCliArgs(["--push-reddy"]), /unknown option/u);
@@ -251,7 +254,17 @@ test("printSummary includes rerun hint for failures", () => {
 function runFixtureGit(workspaceRoot, args) {
   const result = spawnSync("git", args, {
     cwd: workspaceRoot,
-    encoding: "utf8"
+    encoding: "utf8",
+    env: createIsolatedGitEnvironment(workspaceRoot)
   });
   assert.equal(result.status, 0, result.stderr || result.stdout);
+}
+
+function isolateProcessGitEnvironment(nextEnvironment) {
+  for (const name of Object.keys(process.env)) {
+    if (!Object.hasOwn(nextEnvironment, name)) {
+      delete process.env[name];
+    }
+  }
+  Object.assign(process.env, nextEnvironment);
 }


### PR DESCRIPTION
## Summary
- isolate temporary Git commands in push-checked and changed-check tests from inherited repository selectors
- sanitize the changed-check test process before direct fingerprint calls
- add a linked-worktree regression that proves shared config and HEAD remain unchanged
- improve the existing troubleshooting guidance

## Tests
- `node --test tools/scripts/push-checked.test.mjs tools/scripts/run-check-changed.test.mjs tools/scripts/git-environment.test.mjs`
- `pnpm check:changed -- --push-ready`

## Notes
- the regression failed against the previous helpers under a poisoned linked-worktree `GIT_DIR` and passes with the isolated environments
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->