### PR TITLE
fix(css): preserve standard backdrop filters

### DIFF
--- a/.changeset/clean-backdrop-filter-authoring.md
+++ b/.changeset/clean-backdrop-filter-authoring.md
@@ -1,0 +1,9 @@
+---
+"@tutti-os/agent-gui": patch
+"@tutti-os/desktop": patch
+"@tutti-os/workbench-launchpad": patch
+"@tutti-os/workbench-surface": patch
+---
+
+Keep package stylesheet sources on the standard `backdrop-filter` property and
+fail builds when optimized renderer CSS drops the Chromium-supported declaration.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 pnpm exec lint-staged
+pnpm check:backdrop-filter-authoring:staged
 pnpm check:electron-runtime-boundaries:staged
 pnpm check:ui-boundaries:staged
 pnpm check:renderer-boundaries:staged

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -89,33 +89,6 @@ function createPerfMonitorPlugin(): PluginOption {
   });
 }
 
-const webkitBackdropFilterPattern =
-  /^([ \t]*)-webkit-backdrop-filter:\s*([^;]+);(?!\n[ \t]*backdrop-filter:)/gm;
-
-function preserveUnprefixedBackdropFilter(css: string): string {
-  return css.replace(webkitBackdropFilterPattern, "$&\n$1backdrop-filter: $2;");
-}
-
-function preserveUnprefixedBackdropFilterPlugin(): PluginOption {
-  return {
-    name: "preserve-unprefixed-backdrop-filter",
-    enforce: "post",
-    generateBundle(_options, bundle): void {
-      for (const asset of Object.values(bundle)) {
-        if (asset.type !== "asset" || !asset.fileName.endsWith(".css")) {
-          continue;
-        }
-
-        const source =
-          typeof asset.source === "string"
-            ? asset.source
-            : Buffer.from(asset.source).toString("utf8");
-        asset.source = preserveUnprefixedBackdropFilter(source);
-      }
-    }
-  };
-}
-
 const guestPreloadEntryFileNames = new Set([
   "browser-node-guest.cjs",
   "workspace-app.cjs"
@@ -196,7 +169,6 @@ export default defineConfig({
         }
       }),
       tailwindcss(),
-      preserveUnprefixedBackdropFilterPlugin(),
       ...(perfMonitorEnabled ? [createPerfMonitorPlugin()] : [])
     ],
     resolve: {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -76,7 +76,7 @@
     }
   },
   "scripts": {
-    "build": "electron-vite build",
+    "build": "electron-vite build && node ../../tools/scripts/verify-renderer-css-contracts.mjs out/renderer/assets",
     "build:linux": "bash ../../tools/scripts/build-desktop-package.sh linux",
     "build:mac": "bash ../../tools/scripts/build-desktop-package.sh mac-unsigned",
     "build:mac:signed": "bash ../../tools/scripts/build-desktop-package.sh mac-signed",

--- a/docs/conventions/local-git-hooks.md
+++ b/docs/conventions/local-git-hooks.md
@@ -31,6 +31,7 @@ The repository currently uses `husky` with two primary hooks:
 Current behavior:
 
 - `pnpm exec lint-staged`
+- `pnpm check:backdrop-filter-authoring:staged`
 - `pnpm check:electron-runtime-boundaries:staged`
 - `pnpm check:ui-boundaries:staged`
 - `pnpm check:renderer-boundaries:staged`
@@ -80,6 +81,7 @@ machine-readable task results and log paths are recorded in
 
 That full validation currently includes:
 
+- `pnpm check:backdrop-filter-authoring`
 - `pnpm check:defaults-generated`
 - `pnpm check:agent-gui-provider-catalog-generated`
 - `pnpm check:api-generated`

--- a/docs/conventions/npm-package-release.md
+++ b/docs/conventions/npm-package-release.md
@@ -403,6 +403,13 @@ and Tailwind utilities. When package-local CSS is necessary, it must use UI
 system tokens and must not contain app-specific product styling or user-visible
 copy.
 
+Published stylesheet sources use standard CSS properties. In particular,
+author `backdrop-filter` without a handwritten `-webkit-backdrop-filter` pair.
+The consuming application's CSS build owns browser-target prefix generation;
+the packed stylesheet does not promise a second, package-owned legacy-browser
+prefixing pass. Consumer production builds should assert that optimization did
+not leave prefix-only declarations.
+
 Do not add a public `./styles.css` export for a reusable package unless that CSS
 is genuinely part of the package's stable contract. If the same need would help
 multiple packages, add the token, primitive, or utility support to

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -21,6 +21,7 @@ It should not:
 Repository entrypoints:
 
 - `pnpm setup:dev`
+- `pnpm check:backdrop-filter-authoring`
 - `pnpm check:golangci-version`
 - `pnpm lint`
 - `pnpm lint:ts`
@@ -150,6 +151,22 @@ package logs under `.tmp/typecheck-runs`.
 TypeScript package `tsconfig.json` files must not use `baseUrl`; use explicit relative `paths` entries when aliases are needed so the configuration stays compatible with native TypeScript.
 
 The repository-specific UI boundary policy remains in `pnpm check:ui-boundaries`.
+
+## Backdrop Filter Build Contract
+
+Production CSS and Tailwind arbitrary-property authoring under `apps/`,
+`packages/`, and `services/` must use the standard `backdrop-filter` property.
+Do not handwrite `-webkit-backdrop-filter`: Tailwind/Lightning CSS owns
+target-aware prefix generation, and duplicate declarations can be folded into a
+prefix-only result during production optimization.
+
+`pnpm check:backdrop-filter-authoring` enforces the source rule. Desktop builds
+also run `tools/scripts/verify-renderer-css-contracts.mjs` against final renderer
+assets. The artifact gate permits standard-only output or a generated prefix
+followed by the standard property; it rejects prefix-only output, reversed
+ordering, and a launchpad dismiss layer without a non-`none` standard filter.
+The React `WebkitBackdropFilter` inline-style property is outside this stylesheet
+optimization boundary and is not rejected by the authoring check.
 
 Renderer feature implementation boundaries are checked by `pnpm check:renderer-boundaries`.
 That check also enforces the Workbench-specific rule that

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "build:go": "pnpm generate:builtin-apps && cd packages/appcli/core && go build ./... && cd ../../workspace/files && go build ./... && cd ../../workbench/service && go build ./... && cd ../../../services/tuttid && go build ./... && cd ../../apps/cli && go build ./...",
     "build:npm-packages": "node ./tools/scripts/build-npm-packages.mjs",
     "check:api-generated": "node ./tools/scripts/generate-openapi.mjs --check && node ./tools/scripts/check-agent-protocol-enums.mjs",
+    "check:backdrop-filter-authoring": "node ./tools/scripts/check-backdrop-filter-authoring.mjs",
+    "check:backdrop-filter-authoring:staged": "node ./tools/scripts/check-backdrop-filter-authoring.mjs --staged",
     "check:agent-protocol-enums": "node ./tools/scripts/check-agent-protocol-enums.mjs",
     "check:agent-activity-runtime-boundaries": "node ./tools/scripts/check-agent-activity-runtime-boundaries.mjs",
     "check:agent-gui-degradation": "node ./tools/scripts/check-agent-gui-degradation.mjs",

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -325,7 +325,6 @@
   backdrop-filter: none;
   transform-origin: bottom left;
   -webkit-app-region: no-drag;
-  -webkit-backdrop-filter: none;
 }
 
 .workspace-agents-status-panel[data-layer="raised"] {

--- a/packages/workbench/launchpad/src/styles/workbench-launchpad.css
+++ b/packages/workbench/launchpad/src/styles/workbench-launchpad.css
@@ -77,7 +77,6 @@
   animation: workspace-launchpad-backdrop-enter 160ms ease-out both;
   opacity: 1;
   transition: opacity 180ms ease;
-  -webkit-backdrop-filter: blur(24px) saturate(1.18);
 }
 
 .workspace-launchpad-overlay--closing .workspace-launchpad-overlay__dismiss {

--- a/packages/workbench/surface/src/styles/workbench.css
+++ b/packages/workbench/surface/src/styles/workbench.css
@@ -2104,7 +2104,6 @@ body[data-desktop-dock-minimized-stack-open="true"] .desktop-dock {
   overflow: visible;
   border-width: 2px;
   border-radius: 12px;
-  -webkit-backdrop-filter: blur(40px);
   backdrop-filter: blur(40px);
   box-shadow: none;
   pointer-events: auto;

--- a/services/tuttid/builtin-apps/tutti-onboarding/public/styles.css
+++ b/services/tuttid/builtin-apps/tutti-onboarding/public/styles.css
@@ -173,7 +173,6 @@ button {
   background: transparent;
   color: var(--text-primary);
   cursor: pointer;
-  -webkit-backdrop-filter: none;
   backdrop-filter: none;
   box-shadow: none;
   transition:
@@ -237,7 +236,6 @@ button {
   background: var(--background-fronted);
   color: var(--text-primary);
   box-shadow: none;
-  -webkit-backdrop-filter: none;
   backdrop-filter: none;
 }
 .nav.stuck .nav-btn.on::after,

--- a/tools/scripts/backdrop-filter-policy.mjs
+++ b/tools/scripts/backdrop-filter-policy.mjs
@@ -1,0 +1,306 @@
+const prefixedProperty = "-webkit-backdrop-filter";
+const standardProperty = "backdrop-filter";
+const launchpadSelector = ".workspace-launchpad-overlay__dismiss";
+
+export function analyzeBackdropFilterAuthoring({ path, source }) {
+  const diagnostics = [];
+  const pattern = /-webkit-backdrop-filter/giu;
+
+  for (const match of source.matchAll(pattern)) {
+    diagnostics.push(
+      diagnosticAt({
+        index: match.index,
+        kind: "prefixed-authoring",
+        message: `remove ${prefixedProperty}; author ${standardProperty} only`,
+        path,
+        source,
+        token: prefixedProperty
+      })
+    );
+  }
+
+  return diagnostics;
+}
+
+export function analyzeBackdropFilterArtifact({ path, css }) {
+  const diagnostics = [];
+  const launchpadDeclarations = [];
+
+  for (const block of collectCssBlocks(css)) {
+    const declarations = collectBackdropFilterDeclarations(css, block);
+    const prefixed = declarations.filter(
+      (declaration) => declaration.property === prefixedProperty
+    );
+    const standard = declarations.filter(
+      (declaration) => declaration.property === standardProperty
+    );
+
+    if (prefixed.length > 0 && standard.length === 0) {
+      diagnostics.push(
+        artifactDiagnostic({
+          block,
+          css,
+          declaration: prefixed[0],
+          kind: "prefix-only-artifact",
+          message: `${prefixedProperty} must be followed by ${standardProperty} in the same declaration block`,
+          path
+        })
+      );
+    } else if (
+      prefixed.length > 0 &&
+      standard.at(-1).index < prefixed.at(-1).index
+    ) {
+      diagnostics.push(
+        artifactDiagnostic({
+          block,
+          css,
+          declaration: prefixed.at(-1),
+          kind: "artifact-declaration-order",
+          message: `${standardProperty} must appear after ${prefixedProperty} in the final CSS`,
+          path
+        })
+      );
+    }
+
+    if (block.prelude.includes(launchpadSelector)) {
+      launchpadDeclarations.push(
+        ...standard.map((declaration) => ({
+          path,
+          selector: block.prelude,
+          value: declaration.value
+        }))
+      );
+    }
+  }
+
+  return { diagnostics, launchpadDeclarations };
+}
+
+export function analyzeBackdropFilterArtifacts(assets) {
+  const diagnostics = [];
+  const launchpadDeclarations = [];
+
+  for (const asset of assets) {
+    const result = analyzeBackdropFilterArtifact(asset);
+    diagnostics.push(...result.diagnostics);
+    launchpadDeclarations.push(...result.launchpadDeclarations);
+  }
+
+  if (
+    !launchpadDeclarations.some(
+      (declaration) =>
+        !/^none(?:\s*!important)?$/iu.test(declaration.value.trim())
+    )
+  ) {
+    diagnostics.push({
+      column: 1,
+      kind: "missing-launchpad-backdrop-filter",
+      line: 1,
+      message: `${launchpadSelector} must retain a non-none ${standardProperty} declaration`,
+      path: assets[0]?.path ?? "<renderer-css>",
+      selector: launchpadSelector,
+      token: standardProperty
+    });
+  }
+
+  return diagnostics;
+}
+
+export function isBackdropFilterAuthoringPath(path) {
+  const normalized = path.replaceAll("\\", "/");
+  if (!/^(?:apps|packages|services)\//u.test(normalized)) {
+    return false;
+  }
+  if (
+    /(?:^|\/)(?:coverage|dist|node_modules|out|\.tmp)(?:\/|$)/u.test(
+      normalized
+    ) ||
+    /\.(?:spec|test)\.[^.]+$/u.test(normalized)
+  ) {
+    return false;
+  }
+  return /\.(?:cjs|css|cts|html|js|jsx|mjs|mts|ts|tsx)$/u.test(normalized);
+}
+
+function collectCssBlocks(css) {
+  const blocks = [];
+  const stack = [];
+  let quote = null;
+  let inComment = false;
+
+  for (let index = 0; index < css.length; index += 1) {
+    const character = css[index];
+    const next = css[index + 1];
+
+    if (inComment) {
+      if (character === "*" && next === "/") {
+        inComment = false;
+        index += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (character === "\\") {
+        index += 1;
+      } else if (character === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (character === "/" && next === "*") {
+      inComment = true;
+      index += 1;
+      continue;
+    }
+    if (character === "\\") {
+      index += 1;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === "{") {
+      const parent = stack.at(-1)?.blockIndex ?? null;
+      const blockIndex = blocks.length;
+      blocks.push({
+        closeIndex: null,
+        contentStart: index + 1,
+        index,
+        parent,
+        prelude: readPrelude(css, index)
+      });
+      stack.push({ blockIndex });
+      continue;
+    }
+    if (character === "}" && stack.length > 0) {
+      const entry = stack.pop();
+      blocks[entry.blockIndex].closeIndex = index;
+    }
+  }
+
+  return blocks.filter((block) => block.closeIndex !== null);
+}
+
+function readPrelude(css, openIndex) {
+  let start = openIndex - 1;
+  while (start >= 0 && !"{};".includes(css[start])) {
+    start -= 1;
+  }
+  return css
+    .slice(start + 1, openIndex)
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+function collectBackdropFilterDeclarations(css, block) {
+  const content = css.slice(block.contentStart, block.closeIndex);
+  const masked = maskCssNonCode(content);
+  const declarations = [];
+  const pattern =
+    /(^|;)\s*(-webkit-backdrop-filter|backdrop-filter)\s*:\s*([^;{}]*)(?=;|$)/giu;
+
+  for (const match of masked.matchAll(pattern)) {
+    const propertyToken = match[2];
+    const property = propertyToken.toLowerCase();
+    const propertyOffset = match.index + match[0].indexOf(propertyToken);
+    declarations.push({
+      index: block.contentStart + propertyOffset,
+      property,
+      value: match[3].trim()
+    });
+  }
+
+  return declarations;
+}
+
+function maskCssNonCode(source) {
+  const characters = source.split("");
+  let quote = null;
+  let inComment = false;
+  let depth = 0;
+
+  for (let index = 0; index < characters.length; index += 1) {
+    const character = characters[index];
+    const next = characters[index + 1];
+
+    if (inComment) {
+      characters[index] = " ";
+      if (character === "*" && next === "/") {
+        characters[index + 1] = " ";
+        inComment = false;
+        index += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      characters[index] = " ";
+      if (character === "\\") {
+        characters[index + 1] = " ";
+        index += 1;
+      } else if (character === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (character === "/" && next === "*") {
+      characters[index] = " ";
+      characters[index + 1] = " ";
+      inComment = true;
+      index += 1;
+      continue;
+    }
+    if (character === "\\") {
+      characters[index] = " ";
+      characters[index + 1] = " ";
+      index += 1;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      characters[index] = " ";
+      quote = character;
+      continue;
+    }
+    if (character === "{") {
+      depth += 1;
+      characters[index] = " ";
+      continue;
+    }
+    if (character === "}") {
+      depth = Math.max(0, depth - 1);
+      characters[index] = " ";
+      continue;
+    }
+    if (depth > 0) {
+      characters[index] = " ";
+    }
+  }
+
+  return characters.join("");
+}
+
+function artifactDiagnostic({ block, css, declaration, kind, message, path }) {
+  return diagnosticAt({
+    index: declaration.index,
+    kind,
+    message,
+    path,
+    selector: block.prelude || "<anonymous block>",
+    source: css,
+    token: declaration.property
+  });
+}
+
+function diagnosticAt({ index, kind, message, path, selector, source, token }) {
+  const prefix = source.slice(0, index);
+  const lines = prefix.split("\n");
+  return {
+    column: lines.at(-1).length + 1,
+    kind,
+    line: lines.length,
+    message,
+    path,
+    ...(selector ? { selector } : {}),
+    token
+  };
+}

--- a/tools/scripts/backdrop-filter-policy.test.mjs
+++ b/tools/scripts/backdrop-filter-policy.test.mjs
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  analyzeBackdropFilterArtifact,
+  analyzeBackdropFilterArtifacts,
+  analyzeBackdropFilterAuthoring,
+  isBackdropFilterAuthoringPath
+} from "./backdrop-filter-policy.mjs";
+
+test("authoring policy rejects kebab-case prefixed declarations", () => {
+  const source = [
+    ".overlay {",
+    "  backdrop-filter: blur(24px);",
+    "  -webkit-backdrop-filter: blur(24px);",
+    "}"
+  ].join("\n");
+
+  assert.deepEqual(analyzeBackdropFilterAuthoring({ path: "a.css", source }), [
+    {
+      column: 3,
+      kind: "prefixed-authoring",
+      line: 3,
+      message: "remove -webkit-backdrop-filter; author backdrop-filter only",
+      path: "a.css",
+      token: "-webkit-backdrop-filter"
+    }
+  ]);
+});
+
+test("authoring policy rejects case-insensitive prefixed declarations", () => {
+  const diagnostics = analyzeBackdropFilterAuthoring({
+    path: "a.html",
+    source: "<style>.overlay{-Webkit-Backdrop-Filter:blur(2px)}</style>"
+  });
+
+  assert.equal(diagnostics[0]?.kind, "prefixed-authoring");
+  assert.equal(diagnostics[0]?.token, "-webkit-backdrop-filter");
+});
+
+test("authoring policy allows standard and unrelated webkit properties", () => {
+  const source = [
+    ".title { backdrop-filter: blur(1px); -webkit-app-region: drag; }",
+    "const style = { WebkitBackdropFilter: 'none' };"
+  ].join("\n");
+
+  assert.deepEqual(
+    analyzeBackdropFilterAuthoring({ path: "a.ts", source }),
+    []
+  );
+});
+
+test("authoring path scope covers production sources only", () => {
+  assert.equal(
+    isBackdropFilterAuthoringPath(
+      "packages/workbench/launchpad/src/styles/workbench-launchpad.css"
+    ),
+    true
+  );
+  assert.equal(isBackdropFilterAuthoringPath("apps/desktop/index.html"), true);
+  assert.equal(
+    isBackdropFilterAuthoringPath("apps/desktop/src/example.test.ts"),
+    false
+  );
+  assert.equal(
+    isBackdropFilterAuthoringPath("packages/example/dist/styles.css"),
+    false
+  );
+  assert.equal(
+    isBackdropFilterAuthoringPath("tools/fixtures/negative.css"),
+    false
+  );
+});
+
+test("artifact policy accepts standard-only and correct generated ordering", () => {
+  for (const css of [
+    ".overlay{backdrop-filter:blur(2px)}",
+    ".overlay{-webkit-backdrop-filter:blur(2px);backdrop-filter:blur(2px)}"
+  ]) {
+    assert.deepEqual(
+      analyzeBackdropFilterArtifact({ path: "asset.css", css }).diagnostics,
+      []
+    );
+  }
+});
+
+test("artifact policy rejects prefix-only and reversed final ordering", () => {
+  const prefixOnly = analyzeBackdropFilterArtifact({
+    path: "prefix-only.css",
+    css: ".overlay{-webkit-backdrop-filter:blur(2px)}"
+  }).diagnostics;
+  assert.equal(prefixOnly[0]?.kind, "prefix-only-artifact");
+  assert.equal(prefixOnly[0]?.selector, ".overlay");
+
+  const reversed = analyzeBackdropFilterArtifact({
+    path: "reversed.css",
+    css: ".overlay{backdrop-filter:blur(2px);-webkit-backdrop-filter:blur(2px)}"
+  }).diagnostics;
+  assert.equal(reversed[0]?.kind, "artifact-declaration-order");
+
+  const mixedCase = analyzeBackdropFilterArtifact({
+    path: "mixed-case.css",
+    css: ".overlay{-Webkit-Backdrop-Filter:blur(2px)}"
+  }).diagnostics;
+  assert.equal(mixedCase[0]?.kind, "prefix-only-artifact");
+});
+
+test("artifact policy handles nested at-rules, comments, and strings", () => {
+  const css = [
+    "@media (min-width: 1px) {",
+    "  .overlay {",
+    '    content: "{-webkit-backdrop-filter: none}";',
+    "    /* -webkit-backdrop-filter: none; */",
+    "    -webkit-backdrop-filter: blur(2px);",
+    "    backdrop-filter: blur(2px);",
+    "  }",
+    "}"
+  ].join("\n");
+
+  assert.deepEqual(
+    analyzeBackdropFilterArtifact({ path: "nested.css", css }).diagnostics,
+    []
+  );
+});
+
+test("artifact policy handles escaped quotes in generated selectors", () => {
+  const css = [
+    String.raw`.before\:content-\[\'\'\]::before{content:""}`,
+    ".workspace-launchpad-overlay__dismiss{backdrop-filter:blur(24px)}"
+  ].join("\n");
+
+  assert.deepEqual(
+    analyzeBackdropFilterArtifacts([{ path: "generated.css", css }]),
+    []
+  );
+});
+
+test("artifact locations stay correct after astral characters", () => {
+  const diagnostics = analyzeBackdropFilterArtifact({
+    path: "emoji.css",
+    css: '.emoji::before{content:"🧪";-webkit-backdrop-filter:blur(2px)}'
+  }).diagnostics;
+
+  assert.equal(diagnostics[0]?.kind, "prefix-only-artifact");
+  assert.equal(diagnostics[0]?.token, "-webkit-backdrop-filter");
+});
+
+test("launchpad contract requires a non-none standard declaration", () => {
+  const valid = [
+    {
+      path: "valid.css",
+      css: ".workspace-launchpad-overlay__dismiss{-webkit-backdrop-filter:blur(24px);backdrop-filter:blur(24px)}"
+    }
+  ];
+  assert.deepEqual(analyzeBackdropFilterArtifacts(valid), []);
+
+  for (const css of [
+    ".workspace-launchpad-overlay__dismiss{backdrop-filter:none}",
+    ".other{backdrop-filter:blur(24px)}"
+  ]) {
+    const diagnostics = analyzeBackdropFilterArtifacts([
+      { path: "invalid.css", css }
+    ]);
+    assert.equal(
+      diagnostics.some(
+        (diagnostic) => diagnostic.kind === "missing-launchpad-backdrop-filter"
+      ),
+      true
+    );
+  }
+});

--- a/tools/scripts/change-classification.test.mjs
+++ b/tools/scripts/change-classification.test.mjs
@@ -89,3 +89,13 @@ test("provider source changes select catalog and strategy checks", () => {
   assert.ok(keys.includes("generated:agent-provider-catalog"));
   assert.ok(keys.includes("boundary:agent-provider-strategy"));
 });
+
+test("stylesheet changes select the backdrop-filter authoring policy", () => {
+  const checks = selectRepositoryChecks([
+    "packages/workbench/launchpad/src/styles/workbench-launchpad.css"
+  ]);
+
+  assert.ok(
+    checks.some((check) => check.key === "policy:backdrop-filter-authoring")
+  );
+});

--- a/tools/scripts/change-classification.test.mjs
+++ b/tools/scripts/change-classification.test.mjs
@@ -90,12 +90,16 @@ test("provider source changes select catalog and strategy checks", () => {
   assert.ok(keys.includes("boundary:agent-provider-strategy"));
 });
 
-test("stylesheet changes select the backdrop-filter authoring policy", () => {
-  const checks = selectRepositoryChecks([
-    "packages/workbench/launchpad/src/styles/workbench-launchpad.css"
-  ]);
+test("stylesheet and HTML changes select the backdrop-filter authoring policy", () => {
+  for (const file of [
+    "packages/workbench/launchpad/src/styles/workbench-launchpad.css",
+    "apps/desktop/index.html"
+  ]) {
+    const checks = selectRepositoryChecks([file]);
 
-  assert.ok(
-    checks.some((check) => check.key === "policy:backdrop-filter-authoring")
-  );
+    assert.ok(
+      checks.some((check) => check.key === "policy:backdrop-filter-authoring"),
+      `${file} should select the backdrop-filter policy`
+    );
+  }
 });

--- a/tools/scripts/check-backdrop-filter-authoring.mjs
+++ b/tools/scripts/check-backdrop-filter-authoring.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  analyzeBackdropFilterAuthoring,
+  isBackdropFilterAuthoringPath
+} from "./backdrop-filter-policy.mjs";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(scriptDirectory, "../..");
+const staged = process.argv.includes("--staged");
+const files = listFiles();
+const diagnostics = files.flatMap((path) =>
+  analyzeBackdropFilterAuthoring({ path, source: readSource(path) })
+);
+
+if (diagnostics.length > 0) {
+  console.error(
+    "Handwritten -webkit-backdrop-filter is forbidden in production stylesheet authoring."
+  );
+  for (const diagnostic of diagnostics) {
+    console.error(
+      `- ${diagnostic.path}:${diagnostic.line}:${diagnostic.column} ${diagnostic.token}: ${diagnostic.message}`
+    );
+  }
+  process.exitCode = 1;
+} else {
+  console.log(
+    `backdrop-filter authoring policy passed (${files.length} ${staged ? "staged " : ""}files)`
+  );
+}
+
+function listFiles() {
+  const args = staged
+    ? ["diff", "--cached", "--name-only", "--diff-filter=ACMR", "-z"]
+    : ["ls-files", "--cached", "--others", "--exclude-standard", "-z"];
+  return execFileSync("git", args, {
+    cwd: workspaceRoot,
+    encoding: "utf8"
+  })
+    .split("\0")
+    .filter(Boolean)
+    .map((path) => path.replaceAll("\\", "/"))
+    .filter(isBackdropFilterAuthoringPath)
+    .filter((path) => staged || existsSync(join(workspaceRoot, path)));
+}
+
+function readSource(path) {
+  if (staged) {
+    return execFileSync("git", ["show", `:${path}`], {
+      cwd: workspaceRoot,
+      encoding: "utf8",
+      maxBuffer: 20 * 1024 * 1024
+    });
+  }
+  return readFileSync(join(workspaceRoot, path), "utf8");
+}

--- a/tools/scripts/repository-checks.mjs
+++ b/tools/scripts/repository-checks.mjs
@@ -18,6 +18,13 @@ export const repositoryCheckDefinitions = [
     matches: () => true
   },
   {
+    group: "policy",
+    key: "policy:backdrop-filter-authoring",
+    label: "backdrop-filter authoring policy",
+    script: "check:backdrop-filter-authoring",
+    matches: isBackdropFilterAuthoringRelevant
+  },
+  {
     group: "contracts",
     key: "contracts:tool-tests",
     label: "repository tool contracts",
@@ -163,6 +170,13 @@ export function isToolContractRelevant(file) {
     normalized === "docs/conventions/desktop-release.md" ||
     normalized ===
       "services/tuttid/service/workspace/agent_workspace_app_reference/references/github-actions-release.md"
+  );
+}
+
+function isBackdropFilterAuthoringRelevant(file) {
+  return (
+    /^(?:apps|packages|services)\//u.test(file) &&
+    /\.(?:cjs|css|cts|js|jsx|mjs|mts|ts|tsx)$/u.test(file)
   );
 }
 

--- a/tools/scripts/repository-checks.mjs
+++ b/tools/scripts/repository-checks.mjs
@@ -176,7 +176,7 @@ export function isToolContractRelevant(file) {
 function isBackdropFilterAuthoringRelevant(file) {
   return (
     /^(?:apps|packages|services)\//u.test(file) &&
-    /\.(?:cjs|css|cts|js|jsx|mjs|mts|ts|tsx)$/u.test(file)
+    /\.(?:cjs|css|cts|html|js|jsx|mjs|mts|ts|tsx)$/u.test(file)
   );
 }
 

--- a/tools/scripts/verify-renderer-css-contracts.mjs
+++ b/tools/scripts/verify-renderer-css-contracts.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+import { readdir, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { analyzeBackdropFilterArtifacts } from "./backdrop-filter-policy.mjs";
+
+const root = resolve(process.argv[2] ?? "apps/desktop/out/renderer/assets");
+const paths = await listCssFiles(root);
+
+if (paths.length === 0) {
+  throw new Error(`No renderer CSS assets found under ${root}`);
+}
+
+const assets = await Promise.all(
+  paths.map(async (path) => ({ path, css: await readFile(path, "utf8") }))
+);
+const diagnostics = analyzeBackdropFilterArtifacts(assets);
+
+if (diagnostics.length > 0) {
+  console.error("Renderer CSS backdrop-filter contract failed:");
+  for (const diagnostic of diagnostics) {
+    console.error(
+      `- ${diagnostic.path}:${diagnostic.line}:${diagnostic.column} ${diagnostic.selector ?? ""}: ${diagnostic.message}`
+    );
+  }
+  process.exitCode = 1;
+} else {
+  console.log(`renderer CSS contracts passed (${paths.length} assets)`);
+}
+
+async function listCssFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true }).catch(
+    (error) => {
+      if (error?.code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    }
+  );
+  const nested = await Promise.all(
+    entries.map((entry) => {
+      const path = resolve(directory, entry.name);
+      if (entry.isDirectory()) {
+        return listCssFiles(path);
+      }
+      return entry.isFile() && entry.name.endsWith(".css") ? [path] : [];
+    })
+  );
+  return nested.flat().sort();
+}


### PR DESCRIPTION
## Summary

- author backdrop-filter with the standard property only and remove the Electron Vite regex workaround
- add source, built renderer CSS, staged-hook, changed-file, and npm package contract gates
- cover case-insensitive declarations, HTML authoring, nested CSS, Unicode offsets, ordering, and launchpad selector presence

## Fix Scope Justification

- Root cause: source styles manually authored both the standard and prefixed declarations; the CSS optimizer collapsed that pair to prefix-only output, which Electron Chromium ignores.
- Lower layer: the source declarations are the lowest owning layer and have been corrected there. The additional repository, build-output, and packaged-asset checks are necessary because the regression is introduced across package publication and consumer bundling boundaries, so no single lower layer can verify the shipped CSS contract end to end.

## Validation

- node policy/change-selection tests: 18 passed
- backdrop-filter source scan: 2327 files passed
- desktop production build: renderer CSS contracts passed (2 assets)
- check:changed --push-ready: 22 lanes passed
- release:pack:check: all package tarballs passed

## Rollback

Revert this PR. No persisted data or migration is involved.
