### PR TITLE
fix(workbench): stabilize headers during transforms

### DIFF
--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -1695,6 +1695,33 @@ describe("agent GUI workbench contribution copy", () => {
     expect(screen.queryByTestId("agent-gui-window-detail-title")).toBeNull();
   });
 
+  it("keys direct-manipulation header renders by visible rail layout", () => {
+    const definition = createTestAgentGuiWorkbenchContribution({
+      renderBody: () => null,
+      workspaceId: "workspace-1"
+    }).nodes?.[0];
+    const getKey = definition?.getHeaderFrameRenderKey;
+    const createContext = (input: { isDragging?: boolean; width: number }) =>
+      ({
+        externalNodeState: {
+          conversationRailCollapsed: false,
+          conversationRailWidthPx: 520
+        },
+        isDragging: input.isDragging === true,
+        node: {
+          data: { runtimeNodeState: null },
+          frame: { height: 560, width: input.width, x: 0, y: 0 }
+        }
+      }) as never;
+
+    expect(getKey?.(createContext({ isDragging: true, width: 700 }))).toBe(
+      "dragging"
+    );
+    expect(getKey?.(createContext({ width: 600 }))).toBe("collapsed");
+    expect(getKey?.(createContext({ width: 650 }))).toBe("expanded:420");
+    expect(getKey?.(createContext({ width: 700 }))).toBe("expanded:470");
+  });
+
   it("renders the expanded workbench header as a rail titlebar plus detail title", () => {
     const openDetachedWindow = vi.fn();
     const contribution = createTestAgentGuiWorkbenchContribution({

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -181,6 +181,32 @@ export function createAgentGuiWorkbenchContribution(
     nodes: [
       {
         frame,
+        getHeaderFrameRenderKey: (context) => {
+          if (context.isDragging) {
+            return "dragging";
+          }
+          const rawWorkbenchState = (context.externalNodeState ??
+            context.node.data.runtimeNodeState) as
+            | Partial<AgentGuiWorkbenchNodeState>
+            | null
+            | undefined;
+          const workbenchState = normalizeAgentGuiWorkbenchState(
+            migrateLegacyAgentGuiWorkbenchState(rawWorkbenchState)
+          );
+          const isAutoCollapsed = shouldAutoCollapseAgentGUIConversationRail(
+            context.node.frame.width
+          );
+          if (
+            workbenchState.conversationRailCollapsed === true ||
+            isAutoCollapsed
+          ) {
+            return "collapsed";
+          }
+          return `expanded:${clampAgentGUIConversationRailWidthPx(
+            workbenchState.conversationRailWidthPx,
+            context.node.frame.width
+          )}`;
+        },
         instance: { mode: "multi" },
         onBodyRenderErrorChange: ({ hasError, node }) => {
           setAgentGuiWorkbenchBodyRenderError(node.id, hasError);
@@ -368,19 +394,20 @@ export function createAgentGuiWorkbenchContribution(
                 nextCollapsed === false &&
                 node.displayMode !== "fullscreen"
               ) {
+                const currentFrame = windowActions.getFrame();
                 const expandedFrame = resolveAgentGUIExpandedWindowFrame({
                   conversationRailWidthPx: nodeState.conversationRailWidthPx,
                   desktopSize: surfaceSize,
-                  height: node.frame.height,
+                  height: currentFrame.height,
                   position: {
-                    x: node.frame.x,
-                    y: node.frame.y
+                    x: currentFrame.x,
+                    y: currentFrame.y
                   },
-                  width: node.frame.width
+                  width: currentFrame.width
                 });
 
                 windowActions.resize({
-                  ...node.frame,
+                  ...currentFrame,
                   height: expandedFrame.size.height,
                   width: expandedFrame.size.width,
                   x: expandedFrame.position.x,

--- a/packages/workbench/surface/README.md
+++ b/packages/workbench/surface/README.md
@@ -43,11 +43,19 @@ When a node body or header needs host-owned business state, pass an
 `externalNodeState` and `externalWorkspaceState`. If the source exposes
 `subscribe(...)`, the host re-renders when that subscription notifies.
 
-Node body context also exposes `isDragging` and `isResizing`. The Workbench
+Node body and header contexts expose `isDragging` and `isResizing`. The Workbench
 shell continues applying live frame geometry during direct manipulation, while
 an expensive body adapter may use these flags to suppress frame-only renders
 until the interaction settles. The adapter must still observe both interaction
 transitions so the final committed frame reaches responsive body layout.
+
+Headers keep live frame renders by default. A definition may provide
+`getHeaderFrameRenderKey(context)` when several intermediate frames produce the
+same visible header layout. During drag or resize, equal primitive keys skip
+`renderHeader`; changes to node data, external state, focus, or interaction
+state still render. Call `context.windowActions.getFrame()` inside actions that
+need execution-time geometry instead of closing over a frame omitted from the
+key.
 
 Host-owned business instances are represented with `projectedNodes`. A
 projected node tells the workbench that a shell should currently exist for a

--- a/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
@@ -2,13 +2,41 @@ import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { describe, expect, it, vi } from "vitest";
 import type { WorkbenchSnapshot } from "@tutti-os/workbench-snapshot";
+import type { WorkbenchNode } from "../core/types.ts";
+import { WorkbenchProvider } from "../react/WorkbenchProvider.tsx";
+import { WorkbenchWindowFrame } from "../react/WorkbenchWindowFrame.tsx";
+import {
+  useWorkbenchGenieAnimation,
+  type WorkbenchGenieController
+} from "../react/useWorkbenchGenieAnimation.tsx";
+import { createWorkbenchController } from "../store/createWorkbenchController.ts";
+import type {
+  WorkbenchController,
+  WorkbenchDebugDiagnostics
+} from "../store/types.ts";
 import { WorkbenchHost } from "./WorkbenchHost.tsx";
 import type {
   WorkbenchContribution,
   WorkbenchHostDockEntryPresentationOverrides,
   WorkbenchHostHandle,
+  WorkbenchHostNodeDefinition,
+  WorkbenchHostRuntimeHandle,
   WorkbenchHostSnapshotRepository
 } from "./types.ts";
+
+function WorkbenchGenieIdentityProbe({
+  controller,
+  debugDiagnostics,
+  onRender
+}: {
+  controller: WorkbenchController;
+  debugDiagnostics?: WorkbenchDebugDiagnostics;
+  onRender: (genie: WorkbenchGenieController) => void;
+}) {
+  const genie = useWorkbenchGenieAnimation({ controller, debugDiagnostics });
+  onRender(genie);
+  return <>{genie.genieLayer}</>;
+}
 
 describe("WorkbenchHost", () => {
   it("keeps the host session when Dock presentation overrides change identity", async () => {
@@ -171,6 +199,339 @@ describe("WorkbenchHost", () => {
 
       expect(renderA).toHaveBeenCalledTimes(rendersBeforeNodeBChange);
       expect(renderB).toHaveBeenLastCalledWith({ value: "B2" });
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+  });
+
+  it("uses explicit frame keys while isolating inactive headers", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const renderHeader = vi.fn((context) => (
+      <div
+        data-header-frame={`${context.node.frame.x}:${context.node.frame.width}`}
+      />
+    ));
+    const renderSiblingHeader = vi.fn(() => <div data-sibling-header />);
+    const onHandleReady = vi.fn<(handle: WorkbenchHostHandle | null) => void>();
+    const nodes: readonly WorkbenchHostNodeDefinition[] = [
+      {
+        frame: { x: 0, y: 0, width: 320, height: 240 },
+        getHeaderFrameRenderKey: ({ isDragging, node }) =>
+          isDragging ? "dragging" : node.frame.width >= 380,
+        renderBody: () => null,
+        renderHeader,
+        title: "Deferred header",
+        typeId: "deferred-header",
+        window: { defaultOpen: true }
+      },
+      {
+        frame: { x: 360, y: 0, width: 320, height: 240 },
+        renderBody: () => null,
+        renderHeader: renderSiblingHeader,
+        title: "Live sibling header",
+        typeId: "live-sibling-header",
+        window: { defaultOpen: true }
+      }
+    ];
+    const snapshotRepository = createSnapshotRepository();
+    const renderWorkbench = () => (
+      <WorkbenchHost
+        nodes={nodes}
+        onHandleReady={onHandleReady}
+        snapshotRepository={snapshotRepository}
+        workspaceId="workspace-1"
+      />
+    );
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(renderWorkbench());
+      });
+
+      const host = onHandleReady.mock
+        .calls[0]?.[0] as WorkbenchHostRuntimeHandle | null;
+      const nodeId = host
+        ?.getSnapshot()
+        .nodes.find((node) => node.data.typeId === "deferred-header")?.id;
+      const siblingNodeId = host
+        ?.getSnapshot()
+        .nodes.find((node) => node.data.typeId === "live-sibling-header")?.id;
+      expect(nodeId).toBeTruthy();
+      expect(siblingNodeId).toBeTruthy();
+
+      await act(async () => {
+        host?.controller.commands.setSurfaceSize({ width: 1200, height: 800 });
+        host?.controller.commands.focusNode(nodeId ?? "");
+        host?.controller.commands.setActiveDragNode(nodeId ?? null);
+      });
+      const rendersAtDragStart = renderHeader.mock.calls.length;
+      const siblingRendersAtDragStart = renderSiblingHeader.mock.calls.length;
+
+      await act(async () => {
+        host?.controller.commands.dragNode(nodeId ?? "", {
+          x: 20,
+          y: 10,
+          width: 320,
+          height: 240
+        });
+      });
+      await act(async () => {
+        host?.controller.commands.dragNode(nodeId ?? "", {
+          x: 40,
+          y: 20,
+          width: 320,
+          height: 240
+        });
+      });
+
+      expect(renderHeader).toHaveBeenCalledTimes(rendersAtDragStart);
+      expect(renderSiblingHeader).toHaveBeenCalledTimes(
+        siblingRendersAtDragStart
+      );
+
+      await act(async () => {
+        host?.controller.commands.setActiveDragNode(null);
+      });
+      expect(renderHeader).toHaveBeenCalledTimes(rendersAtDragStart + 1);
+      const frameAfterDrag = host?.getSnapshot().nodes[0]?.frame;
+      expect(renderHeader.mock.lastCall?.[0].node.frame).toEqual(
+        frameAfterDrag
+      );
+      expect(
+        container.querySelector(
+          `[data-header-frame='${frameAfterDrag?.x}:${frameAfterDrag?.width}']`
+        )
+      ).not.toBeNull();
+
+      await act(async () => {
+        host?.controller.commands.setActiveResizeNode(nodeId ?? null);
+      });
+      const rendersAtResizeStart = renderHeader.mock.calls.length;
+
+      await act(async () => {
+        host?.controller.commands.resizeNode(nodeId ?? "", {
+          x: 40,
+          y: 20,
+          width: 360,
+          height: 240
+        });
+      });
+      await act(async () => {
+        host?.controller.commands.resizeNode(nodeId ?? "", {
+          x: 40,
+          y: 20,
+          width: 400,
+          height: 240
+        });
+      });
+
+      expect(renderHeader).toHaveBeenCalledTimes(rendersAtResizeStart + 1);
+      expect(renderSiblingHeader).toHaveBeenCalledTimes(
+        siblingRendersAtDragStart
+      );
+
+      await act(async () => {
+        host?.controller.commands.setActiveResizeNode(null);
+      });
+      expect(renderHeader).toHaveBeenCalledTimes(rendersAtResizeStart + 2);
+      const frameAfterResize = host?.getSnapshot().nodes[0]?.frame;
+      expect(renderHeader.mock.lastCall?.[0].node.frame).toEqual(
+        frameAfterResize
+      );
+      expect(
+        container.querySelector(
+          `[data-header-frame='${frameAfterResize?.x}:${frameAfterResize?.width}']`
+        )
+      ).not.toBeNull();
+
+      await act(async () => {
+        host?.controller.commands.setActiveDragNode(siblingNodeId ?? null);
+      });
+      const siblingRendersAtOwnDragStart =
+        renderSiblingHeader.mock.calls.length;
+      await act(async () => {
+        host?.controller.commands.dragNode(siblingNodeId ?? "", {
+          x: 400,
+          y: 20,
+          width: 320,
+          height: 240
+        });
+      });
+      expect(renderSiblingHeader).toHaveBeenCalledTimes(
+        siblingRendersAtOwnDragStart + 1
+      );
+      await act(async () => {
+        host?.controller.commands.setActiveDragNode(null);
+      });
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+  });
+
+  it("keeps header infrastructure stable across genie implementation changes", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const node: WorkbenchNode = {
+      data: null,
+      displayMode: "floating",
+      frame: { x: 0, y: 0, width: 320, height: 240 },
+      id: "node-1",
+      isMinimized: false,
+      kind: "test",
+      restoreFrame: null,
+      title: "Test"
+    };
+    const controller = createWorkbenchController({
+      nodes: [node],
+      nodeStack: [node.id]
+    });
+    const revisions: object[] = [];
+    const headerControls: {
+      minimizeNodeToAnchor:
+        | ((nodeID: string, minimize?: () => void) => void)
+        | null;
+    } = { minimizeNodeToAnchor: null };
+    const renderHeader = vi.fn((context) => {
+      revisions.push(context.renderRevision);
+      headerControls.minimizeNodeToAnchor = context.genie.minimizeNodeToAnchor;
+      return <div data-window-header />;
+    });
+    const createGenie = (
+      minimizeNodeToAnchor: WorkbenchGenieController["minimizeNodeToAnchor"]
+    ): WorkbenchGenieController => ({
+      genieLayer: null,
+      isNodeGenieHidden: () => false,
+      isPendingMinimizedDockNode: () => false,
+      launchNodeFromAnchor: () => {},
+      minimizeNodeToAnchor,
+      pendingMinimizedNode: null,
+      registerDockAnchor: () => {},
+      shouldAnimateMinimizedDockEnter: () => false
+    });
+    const firstMinimize = vi.fn();
+    const secondMinimize = vi.fn();
+    const renderFrame = (
+      minimizeNodeToAnchor: WorkbenchGenieController["minimizeNodeToAnchor"]
+    ) => (
+      <WorkbenchProvider controller={controller}>
+        <WorkbenchWindowFrame
+          genie={createGenie(minimizeNodeToAnchor)}
+          node={node}
+          renderHeader={renderHeader}
+          windowChromeMode="custom-header"
+        >
+          <div />
+        </WorkbenchWindowFrame>
+      </WorkbenchProvider>
+    );
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(renderFrame(firstMinimize));
+      });
+      await act(async () => {
+        root.render(renderFrame(secondMinimize));
+      });
+
+      expect(revisions).toHaveLength(2);
+      expect(revisions[1]).toBe(revisions[0]);
+      headerControls.minimizeNodeToAnchor?.(node.id);
+      expect(firstMinimize).not.toHaveBeenCalled();
+      expect(secondMinimize).toHaveBeenCalledWith(node.id, undefined);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+  });
+
+  it("keeps the genie controller stable while forwarding to current internals", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const controller = createWorkbenchController();
+    const firstLog = vi.fn();
+    const secondLog = vi.fn();
+    const firstDiagnostics: WorkbenchDebugDiagnostics = {
+      isEnabled: () => true,
+      log: firstLog
+    };
+    const secondDiagnostics: WorkbenchDebugDiagnostics = {
+      isEnabled: () => true,
+      log: secondLog
+    };
+    const renders: WorkbenchGenieController[] = [];
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchGenieIdentityProbe
+            controller={controller}
+            debugDiagnostics={firstDiagnostics}
+            onRender={(genie) => renders.push(genie)}
+          />
+        );
+      });
+      await act(async () => {
+        root.render(
+          <WorkbenchGenieIdentityProbe
+            controller={controller}
+            debugDiagnostics={secondDiagnostics}
+            onRender={(genie) => renders.push(genie)}
+          />
+        );
+      });
+
+      expect(renders).toHaveLength(2);
+      expect(renders[1]).toBe(renders[0]);
+      renders[1]?.minimizeNodeToAnchor("missing-node");
+      expect(firstLog).not.toHaveBeenCalled();
+      expect(secondLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details: expect.objectContaining({
+            nodeId: "missing-node",
+            reason: "target_missing"
+          }),
+          event: "workbench.genie.minimize.skipped"
+        })
+      );
     } finally {
       await act(async () => {
         root.unmount();

--- a/packages/workbench/surface/src/host/hostNodeContext.ts
+++ b/packages/workbench/surface/src/host/hostNodeContext.ts
@@ -114,8 +114,9 @@ export function createWorkbenchHostNodeHeaderContext<
       resolvedExternalState.externalWorkspaceState as TExternalWorkspaceState,
     instanceId: context.node.data.instanceId,
     instanceKey: context.node.data.instanceKey ?? null,
-    isFocused:
-      selectFocusedWorkbenchNode(host.getSnapshot())?.id === context.node.id,
+    isDragging: context.isDragging,
+    isFocused: context.isFocused,
+    isResizing: context.isResizing,
     node: context.node,
     surfaceSize: context.surfaceSize,
     windowActions: createWorkbenchHostNodeHeaderWindowActions(context, {

--- a/packages/workbench/surface/src/host/types.ts
+++ b/packages/workbench/surface/src/host/types.ts
@@ -432,6 +432,7 @@ export interface WorkbenchHostNodeHeaderWindowActions {
   applyQuickLayout(target: WorkbenchQuickLayoutTarget): void;
   close(): void;
   focus(): void;
+  getFrame(): WorkbenchFrame;
   minimize(): void;
   resize(frame: WorkbenchFrame): void;
   toggleDisplayMode(): void;
@@ -449,7 +450,9 @@ export interface WorkbenchHostNodeHeaderContext<
   externalWorkspaceState: TExternalWorkspaceState;
   instanceId: string;
   instanceKey?: string | null;
+  isDragging: boolean;
   isFocused: boolean;
+  isResizing: boolean;
   node: WorkbenchNode<WorkbenchHostNodeData>;
   surfaceSize: WorkbenchSize;
   windowActions: WorkbenchHostNodeHeaderWindowActions;
@@ -481,6 +484,24 @@ type WorkbenchHostHeaderRenderer<
   ): ReactNode;
 }["bivarianceHack"];
 
+export type WorkbenchHostNodeHeaderFrameRenderKey =
+  | boolean
+  | number
+  | string
+  | null;
+
+type WorkbenchHostHeaderFrameRenderKeyResolver<
+  TExternalNodeState = unknown,
+  TExternalWorkspaceState = unknown
+> = {
+  bivarianceHack(
+    context: WorkbenchHostNodeHeaderContext<
+      TExternalNodeState,
+      TExternalWorkspaceState
+    >
+  ): WorkbenchHostNodeHeaderFrameRenderKey;
+}["bivarianceHack"];
+
 type WorkbenchHostWindowCloseEffectResolver<
   TExternalNodeState = unknown,
   TExternalWorkspaceState = unknown
@@ -507,6 +528,14 @@ export interface WorkbenchHostNodeDefinition<
   description?: string;
   frame: WorkbenchFrame;
   getWindowCloseEffect?: WorkbenchHostWindowCloseEffectResolver<
+    TExternalNodeState,
+    TExternalWorkspaceState
+  >;
+  /**
+   * Projects frame-derived header presentation during direct manipulation.
+   * Equal keys skip renderHeader; omitted definitions keep live frame renders.
+   */
+  getHeaderFrameRenderKey?: WorkbenchHostHeaderFrameRenderKeyResolver<
     TExternalNodeState,
     TExternalWorkspaceState
   >;

--- a/packages/workbench/surface/src/host/useWorkbenchHostSurfaceRenderers.tsx
+++ b/packages/workbench/surface/src/host/useWorkbenchHostSurfaceRenderers.tsx
@@ -1,4 +1,4 @@
-import { Component, useCallback, useMemo } from "react";
+import { Component, memo, useCallback, useMemo } from "react";
 import type { ErrorInfo, ReactNode } from "react";
 import type { WorkbenchNode } from "../core/types.ts";
 import type {
@@ -38,6 +38,8 @@ import type {
   WorkbenchHostNodeBodyContext,
   WorkbenchHostNodeData,
   WorkbenchHostNodeDefinition,
+  WorkbenchHostNodeHeaderContext,
+  WorkbenchHostNodeHeaderFrameRenderKey,
   WorkbenchHostProps,
   WorkbenchHostRuntimeHandle
 } from "./types.ts";
@@ -259,7 +261,7 @@ export function useWorkbenchHostSurfaceRenderers(input: {
       }
 
       return (
-        <WorkbenchHostNodeHeaderRenderer
+        <MemoizedWorkbenchHostNodeHeaderStateBridge
           context={context}
           definition={definition}
           externalStateSource={input.externalStateSource}
@@ -509,29 +511,147 @@ function WorkbenchHostNodeRenderer(input: {
   );
 }
 
-function WorkbenchHostNodeHeaderRenderer(input: {
+interface WorkbenchHostNodeHeaderStateBridgeProps {
   context: Parameters<WorkbenchRenderWindowHeader<WorkbenchHostNodeData>>[0];
   definition: WorkbenchHostNodeDefinition;
   externalStateSource?: WorkbenchHostExternalStateSource;
   host: WorkbenchHostRuntimeHandle;
   workspaceId: string;
-}): ReactNode {
+}
+
+function WorkbenchHostNodeHeaderStateBridge(
+  input: WorkbenchHostNodeHeaderStateBridgeProps
+): ReactNode {
   const externalState = useWorkbenchHostExternalState({
     externalStateSource: input.externalStateSource,
     node: input.context.node,
     workspaceId: input.workspaceId
   });
-  return input.definition.renderHeader?.(
-    createWorkbenchHostNodeHeaderContext({
-      context: input.context,
-      definition: input.definition,
-      externalState,
-      externalStateSource: input.externalStateSource,
-      host: input.host,
-      workspaceId: input.workspaceId
-    })
+  const context = createWorkbenchHostNodeHeaderContext({
+    context: input.context,
+    definition: input.definition,
+    externalState,
+    externalStateSource: input.externalStateSource,
+    host: input.host,
+    workspaceId: input.workspaceId
+  });
+  const getFrameRenderKey = input.definition.getHeaderFrameRenderKey;
+
+  return (
+    <MemoizedWorkbenchHostNodeHeaderRenderer
+      context={context}
+      definition={input.definition}
+      frameRenderKey={getFrameRenderKey?.(context) ?? null}
+      hasFrameRenderKey={getFrameRenderKey !== undefined}
+      host={input.host}
+      renderRevision={input.context.renderRevision}
+    />
   );
 }
+
+function areWorkbenchHostNodeHeaderStateBridgePropsEqual(
+  previous: WorkbenchHostNodeHeaderStateBridgeProps,
+  next: WorkbenchHostNodeHeaderStateBridgeProps
+): boolean {
+  return (
+    previous.definition === next.definition &&
+    previous.externalStateSource === next.externalStateSource &&
+    previous.host === next.host &&
+    previous.workspaceId === next.workspaceId &&
+    previous.context.controller === next.context.controller &&
+    previous.context.isDragging === next.context.isDragging &&
+    previous.context.isFocused === next.context.isFocused &&
+    previous.context.isResizing === next.context.isResizing &&
+    previous.context.node === next.context.node &&
+    previous.context.renderRevision === next.context.renderRevision &&
+    previous.context.surfaceSize.width === next.context.surfaceSize.width &&
+    previous.context.surfaceSize.height === next.context.surfaceSize.height
+  );
+}
+
+const MemoizedWorkbenchHostNodeHeaderStateBridge = memo(
+  WorkbenchHostNodeHeaderStateBridge,
+  areWorkbenchHostNodeHeaderStateBridgePropsEqual
+);
+
+interface WorkbenchHostNodeHeaderRendererProps {
+  context: WorkbenchHostNodeHeaderContext;
+  definition: WorkbenchHostNodeDefinition;
+  frameRenderKey: WorkbenchHostNodeHeaderFrameRenderKey;
+  hasFrameRenderKey: boolean;
+  host: WorkbenchHostRuntimeHandle;
+  renderRevision: object;
+}
+
+function WorkbenchHostNodeHeaderRenderer(
+  input: WorkbenchHostNodeHeaderRendererProps
+): ReactNode {
+  return input.definition.renderHeader?.(input.context);
+}
+
+function areWorkbenchHostNodeHeaderRendererPropsEqual(
+  previous: WorkbenchHostNodeHeaderRendererProps,
+  next: WorkbenchHostNodeHeaderRendererProps
+): boolean {
+  if (
+    previous.definition !== next.definition ||
+    previous.host !== next.host ||
+    previous.renderRevision !== next.renderRevision ||
+    previous.context.activation !== next.context.activation ||
+    previous.context.externalNodeState !== next.context.externalNodeState ||
+    previous.context.externalWorkspaceState !==
+      next.context.externalWorkspaceState ||
+    previous.context.isDragging !== next.context.isDragging ||
+    previous.context.isFocused !== next.context.isFocused ||
+    previous.context.isResizing !== next.context.isResizing
+  ) {
+    return false;
+  }
+
+  const previousNode = previous.context.node;
+  const nextNode = next.context.node;
+  const nonFrameInputsEqual =
+    previous.context.surfaceSize.width === next.context.surfaceSize.width &&
+    previous.context.surfaceSize.height === next.context.surfaceSize.height &&
+    previousNode.id === nextNode.id &&
+    previousNode.kind === nextNode.kind &&
+    previousNode.title === nextNode.title &&
+    previousNode.displayMode === nextNode.displayMode &&
+    previousNode.restoreFrame === nextNode.restoreFrame &&
+    previousNode.isMinimized === nextNode.isMinimized &&
+    previousNode.minimizedAtUnixMs === nextNode.minimizedAtUnixMs &&
+    previousNode.sizeConstraints === nextNode.sizeConstraints &&
+    previousNode.data === nextNode.data;
+  if (!nonFrameInputsEqual) {
+    return false;
+  }
+
+  if (
+    (next.context.isDragging || next.context.isResizing) &&
+    next.hasFrameRenderKey
+  ) {
+    return Object.is(previous.frameRenderKey, next.frameRenderKey);
+  }
+
+  return areWorkbenchFramesEqual(previousNode.frame, nextNode.frame);
+}
+
+function areWorkbenchFramesEqual(
+  previous: WorkbenchNode["frame"],
+  next: WorkbenchNode["frame"]
+): boolean {
+  return (
+    previous.x === next.x &&
+    previous.y === next.y &&
+    previous.width === next.width &&
+    previous.height === next.height
+  );
+}
+
+const MemoizedWorkbenchHostNodeHeaderRenderer = memo(
+  WorkbenchHostNodeHeaderRenderer,
+  areWorkbenchHostNodeHeaderRendererPropsEqual
+);
 
 interface WorkbenchHostSurfaceRenderErrorBoundaryProps {
   children: ReactNode;

--- a/packages/workbench/surface/src/host/windowActions.test.ts
+++ b/packages/workbench/surface/src/host/windowActions.test.ts
@@ -29,7 +29,11 @@ test("host header window actions expose quick layout and resize", () => {
       onPointerDown: () => {}
     },
     genie: { minimizeNodeToAnchor: (_nodeID, minimize) => minimize?.() },
+    isDragging: false,
+    isFocused: false,
+    isResizing: false,
     node,
+    renderRevision: {},
     surfaceSize: controller.getSnapshot().surfaceSize
   });
 
@@ -43,6 +47,12 @@ test("host header window actions expose quick layout and resize", () => {
 
   actions.resize({ x: 360, y: 80, width: 640, height: 420 });
   assert.deepEqual(controller.getSnapshot().nodes[0]?.frame, {
+    x: 360,
+    y: 80,
+    width: 640,
+    height: 420
+  });
+  assert.deepEqual(actions.getFrame(), {
     x: 360,
     y: 80,
     width: 640,

--- a/packages/workbench/surface/src/host/windowActions.ts
+++ b/packages/workbench/surface/src/host/windowActions.ts
@@ -24,6 +24,14 @@ export function createWorkbenchHostNodeHeaderWindowActions(
     focus() {
       context.controller.commands.focusNode(context.node.id);
     },
+    getFrame() {
+      return (
+        context.controller
+          .getSnapshot()
+          .nodes.find((node) => node.id === context.node.id)?.frame ??
+        context.node.frame
+      );
+    },
     minimize() {
       context.genie.minimizeNodeToAnchor(context.node.id, () =>
         context.controller.commands.minimizeNode(context.node.id)

--- a/packages/workbench/surface/src/index.ts
+++ b/packages/workbench/surface/src/index.ts
@@ -74,6 +74,7 @@ export type {
   WorkbenchHostNodeBodyContext,
   WorkbenchHostNodeData,
   WorkbenchHostNodeDefinition,
+  WorkbenchHostNodeHeaderFrameRenderKey,
   WorkbenchHostNodeHeaderContext,
   WorkbenchHostNodeHeaderWindowActions,
   WorkbenchHostNodeInstanceStrategy,

--- a/packages/workbench/surface/src/react/WorkbenchWindowFrame.tsx
+++ b/packages/workbench/surface/src/react/WorkbenchWindowFrame.tsx
@@ -1,4 +1,10 @@
-import { type ReactNode } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef
+} from "react";
 import { createI18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import { Checkbox } from "@tutti-os/ui-system";
 import {
@@ -126,11 +132,31 @@ export function WorkbenchWindowFrame<TData>({
     controller.commands.focusNode(node.id);
     controller.commands.applySnapTarget(node.id, "top");
   };
-  const genieControls = {
-    minimizeNodeToAnchor: (nodeID: string, minimize?: () => void) => {
-      genie.minimizeNodeToAnchor(nodeID, minimize);
-    }
-  } as const;
+  const minimizeNodeToAnchorRef = useRef(genie.minimizeNodeToAnchor);
+  useLayoutEffect(() => {
+    minimizeNodeToAnchorRef.current = genie.minimizeNodeToAnchor;
+  }, [genie.minimizeNodeToAnchor]);
+  const minimizeNodeToAnchor = useCallback(
+    (nodeID: string, minimize?: () => void) => {
+      minimizeNodeToAnchorRef.current(nodeID, minimize);
+    },
+    []
+  );
+  const genieControls = useMemo(
+    () => ({ minimizeNodeToAnchor }),
+    [minimizeNodeToAnchor]
+  );
+  const headerRenderRevision = useMemo(
+    () => ({}),
+    [
+      controller,
+      edgeSnapEnabled,
+      interactive,
+      renderActions,
+      renderHeader,
+      windowChromeI18n
+    ]
+  );
   const defaultActions = interactive ? (
     <div
       className="workbench-window__traffic-light-actions"
@@ -159,10 +185,14 @@ export function WorkbenchWindowFrame<TData>({
     controller,
     defaultActions,
     genie: genieControls,
+    isDragging,
+    isFocused,
+    isResizing,
     node,
     onDoubleClick: onHeaderDoubleClick,
     onDragStart,
     renderHeader: interactive ? renderHeader : undefined,
+    renderRevision: headerRenderRevision,
     windowChromeMode
   });
   const shouldRenderCustomHeader =

--- a/packages/workbench/surface/src/react/types.ts
+++ b/packages/workbench/surface/src/react/types.ts
@@ -114,11 +114,16 @@ export interface WorkbenchWindowHeaderContext<TData = unknown> {
   node: WorkbenchNode<TData>;
   controller: WorkbenchController<TData>;
   surfaceSize: WorkbenchSize;
+  isDragging: boolean;
+  isFocused: boolean;
+  isResizing: boolean;
   genie: {
     minimizeNodeToAnchor(nodeID: string, minimize?: () => void): void;
   };
   defaultActions: ReactNode;
   dragHandleProps: WorkbenchWindowHeaderDragHandleProps;
+  /** Stable while the non-node inputs used to build header chrome are unchanged. */
+  renderRevision: object;
 }
 
 export type WorkbenchRenderNode<TData = unknown> = (

--- a/packages/workbench/surface/src/react/useWorkbenchGenieAnimation.tsx
+++ b/packages/workbench/surface/src/react/useWorkbenchGenieAnimation.tsx
@@ -1,6 +1,8 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type ReactNode
@@ -1930,8 +1932,18 @@ export function useWorkbenchGenieAnimation<TData>({
     []
   );
 
-  return {
-    genieLayer:
+  const minimizeNodeToAnchorRef = useRef(minimizeNodeToAnchor);
+  useLayoutEffect(() => {
+    minimizeNodeToAnchorRef.current = minimizeNodeToAnchor;
+  }, [minimizeNodeToAnchor]);
+  const stableMinimizeNodeToAnchor = useCallback(
+    (nodeID: string, minimize?: () => void) => {
+      minimizeNodeToAnchorRef.current(nodeID, minimize);
+    },
+    []
+  );
+  const genieLayer = useMemo(
+    () =>
       typeof document === "undefined"
         ? null
         : createPortal(
@@ -1971,18 +1983,37 @@ export function useWorkbenchGenieAnimation<TData>({
             </>,
             document.body
           ),
-    isNodeGenieHidden: useCallback(
-      (nodeID: string) => genieHiddenNodeIDs.has(nodeID),
-      [genieHiddenNodeIDs]
-    ),
-    isPendingMinimizedDockNode: useCallback(
-      (nodeID: string) => pendingMinimizedNode?.id === nodeID,
-      [pendingMinimizedNode]
-    ),
-    launchNodeFromAnchor,
-    minimizeNodeToAnchor,
-    pendingMinimizedNode,
-    registerDockAnchor,
-    shouldAnimateMinimizedDockEnter
-  };
+    [isCanvasActive, pendingRenderedPreviewCapture]
+  );
+  const isNodeGenieHidden = useCallback(
+    (nodeID: string) => genieHiddenNodeIDs.has(nodeID),
+    [genieHiddenNodeIDs]
+  );
+  const isPendingMinimizedDockNode = useCallback(
+    (nodeID: string) => pendingMinimizedNode?.id === nodeID,
+    [pendingMinimizedNode]
+  );
+
+  return useMemo(
+    () => ({
+      genieLayer,
+      isNodeGenieHidden,
+      isPendingMinimizedDockNode,
+      launchNodeFromAnchor,
+      minimizeNodeToAnchor: stableMinimizeNodeToAnchor,
+      pendingMinimizedNode,
+      registerDockAnchor,
+      shouldAnimateMinimizedDockEnter
+    }),
+    [
+      genieLayer,
+      isNodeGenieHidden,
+      isPendingMinimizedDockNode,
+      launchNodeFromAnchor,
+      pendingMinimizedNode,
+      registerDockAnchor,
+      shouldAnimateMinimizedDockEnter,
+      stableMinimizeNodeToAnchor
+    ]
+  );
 }

--- a/packages/workbench/surface/src/react/windowHeader.test.ts
+++ b/packages/workbench/surface/src/react/windowHeader.test.ts
@@ -24,9 +24,13 @@ test("defaults to the built-in system chrome mode", () => {
     controller,
     defaultActions: "default-actions",
     genie: { minimizeNodeToAnchor: () => {} },
+    isDragging: false,
+    isFocused: false,
+    isResizing: false,
     node,
     onDoubleClick: () => {},
     onDragStart: () => {},
+    renderRevision: {},
     windowChromeMode: "system"
   });
 
@@ -49,6 +53,9 @@ test("custom-header mode uses the host header and replaces the shared default he
     controller,
     defaultActions: "default-actions",
     genie: { minimizeNodeToAnchor: () => {} },
+    isDragging: true,
+    isFocused: true,
+    isResizing: false,
     node,
     onDoubleClick: () => {},
     onDragStart: () => {},
@@ -56,6 +63,7 @@ test("custom-header mode uses the host header and replaces the shared default he
       receivedDragHandleProps = dragHandleProps;
       return "custom-header";
     },
+    renderRevision: {},
     windowChromeMode: resolvedMode
   });
 
@@ -66,6 +74,9 @@ test("custom-header mode uses the host header and replaces the shared default he
     onDoubleClick: resolvedHeader.context.dragHandleProps.onDoubleClick,
     onPointerDown: resolvedHeader.context.dragHandleProps.onPointerDown
   });
+  assert.equal(resolvedHeader.context.isDragging, true);
+  assert.equal(resolvedHeader.context.isFocused, true);
+  assert.equal(resolvedHeader.context.isResizing, false);
 });
 
 test("custom headers can reuse the shared default actions bundle", () => {
@@ -79,6 +90,9 @@ test("custom headers can reuse the shared default actions bundle", () => {
     controller,
     defaultActions,
     genie: { minimizeNodeToAnchor: () => {} },
+    isDragging: false,
+    isFocused: false,
+    isResizing: false,
     node,
     onDoubleClick: () => {},
     onDragStart: () => {},
@@ -87,6 +101,7 @@ test("custom headers can reuse the shared default actions bundle", () => {
       receivedDragHandleProps = dragHandleProps;
       return "custom-header";
     },
+    renderRevision: {},
     windowChromeMode: "custom-header"
   });
 
@@ -110,6 +125,9 @@ test("custom headers receive the current surface size", () => {
     controller,
     defaultActions: "default-actions",
     genie: { minimizeNodeToAnchor: () => {} },
+    isDragging: false,
+    isFocused: false,
+    isResizing: true,
     node,
     onDoubleClick: () => {},
     onDragStart: () => {},
@@ -117,6 +135,7 @@ test("custom headers receive the current surface size", () => {
       receivedSurfaceSize = surfaceSize;
       return "custom-header";
     },
+    renderRevision: {},
     windowChromeMode: "custom-header"
   });
 

--- a/packages/workbench/surface/src/react/windowHeader.ts
+++ b/packages/workbench/surface/src/react/windowHeader.ts
@@ -17,10 +17,14 @@ export interface ResolveWorkbenchWindowHeaderInput<TData = unknown> {
   controller: WorkbenchController<TData>;
   defaultActions: ReactNode;
   genie: WorkbenchHeaderGenieControls;
+  isDragging: boolean;
+  isFocused: boolean;
+  isResizing: boolean;
   node: WorkbenchNode<TData>;
   onDoubleClick: WorkbenchWindowHeaderDragHandleProps["onDoubleClick"];
   onDragStart: WorkbenchWindowHeaderDragHandleProps["onPointerDown"];
   renderHeader?: WorkbenchRenderWindowHeader<TData>;
+  renderRevision: object;
   windowChromeMode?: WorkbenchWindowChromeMode;
 }
 
@@ -52,10 +56,14 @@ export function resolveWorkbenchWindowHeader<TData>({
   controller,
   defaultActions,
   genie,
+  isDragging,
+  isFocused,
+  isResizing,
   node,
   onDoubleClick,
   onDragStart,
   renderHeader,
+  renderRevision,
   windowChromeMode = "system"
 }: ResolveWorkbenchWindowHeaderInput<TData>): ResolvedWorkbenchWindowHeader<TData> {
   const context: WorkbenchWindowHeaderContext<TData> = {
@@ -67,7 +75,11 @@ export function resolveWorkbenchWindowHeader<TData>({
       onPointerDown: onDragStart
     },
     genie,
+    isDragging,
+    isFocused,
+    isResizing,
     node,
+    renderRevision,
     surfaceSize: controller.getSnapshot().surfaceSize
   };
 

--- a/packages/workspace/issue-manager/src/workbench/index.ts
+++ b/packages/workspace/issue-manager/src/workbench/index.ts
@@ -123,6 +123,10 @@ export function createIssueManagerWorkbenchNodeDefinition<
     instance: {
       mode: "single"
     },
+    getHeaderFrameRenderKey: ({ isDragging, node }) =>
+      isDragging
+        ? "dragging"
+        : shouldAutoCollapseIssueManagerSidebar(node.frame.width),
     renderBody: (context) =>
       createElement(IssueManagerNode, {
         emptyIllustration,
@@ -222,8 +226,9 @@ export function createIssueManagerWorkbenchNodeDefinition<
             nextCollapsed === false &&
             node.displayMode !== "fullscreen"
           ) {
+            const currentFrame = windowActions.getFrame();
             windowActions.resize(
-              resolveIssueManagerExpandedFrame(node.frame, surfaceSize.width)
+              resolveIssueManagerExpandedFrame(currentFrame, surfaceSize.width)
             );
             applyTaskListCollapsed(false);
             return;


### PR DESCRIPTION
## Summary

- Keep window shell position/size live during drag and resize, while skipping header renders when a contribution's frame-derived presentation key is unchanged.
- Expose current frame data through header context/actions so threshold-based headers can read the latest geometry without forcing per-pixel rendering.
- Apply the contract to AgentGUI and Issue Manager; stabilize related renderer inputs and document/test the public behavior.

## Verification

- `pnpm check:changed`
- `go test ./service/agentextension -run '^TestManagedBinaryActivationRecoversAfterCrashAtBothRenameBoundaries$/after_backup_rename$' -count=3 -v`
- `pnpm push:checked` (`check:full`: 22 tasks passed)

## Fix Scope Justification

- Root cause: every direct-manipulation frame update changed the header context and re-ran `renderHeader`, even when the header only cared about a width threshold or collapse state.
- Why can this not be fixed at a lower layer? The window shell must keep consuming every frame update for live movement and sizing. Only each header contribution knows which frame changes affect its presentation. Most added lines are focused renderer contract tests.

## Fallback Three Questions

- Source: high-frequency pointer-move frame updates invalidate React header rendering.
- Why can it not be fixed at that source? Those updates are required for live window transforms; suppressing them would make movement and resizing stale.
- Removal condition: remove the memoized projection once the workbench exposes equivalent selector-based header subscriptions that avoid per-pixel invalidation.

## Checklist

- [x] N/A: this PR does not change agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] N/A: no translated README/CONTRIBUTING source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.