### PR TITLE
fix(agent): hide presentation-invisible sessions from collections

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -263,6 +263,12 @@ The busy-session prompt queue is ephemeral durable-intent coordination in the wo
 
 The Rail query cache stores section metadata, ordered Session IDs, cursors, and totals only. Session entities always come from the engine.
 
+Presentation-invisible Sessions remain canonical engine entities and stay
+available through exact Session selectors for trusted open, reconcile, and
+command flows. Plural consumer selectors exclude them before Rail and Message
+Center collection projection; a hidden Session must not become a list row just
+because it is resumable or receives later canonical updates.
+
 When runtime sections are enabled, projection unions IDs from the current section, search, and reconciliation, then joins canonical Sessions. Unchanged summaries preserve structural sharing so unrelated engine updates do not rebuild the whole Rail snapshot.
 
 Scroll, section collapse, visible limits, and search query belong to mounted view scope. Non-search state is isolated by `workspaceId + agentTargetId/all`; search creates a temporary navigation scope. `activeConversationId` expresses selection only. Scrolling requires an explicit reveal intent.

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.test.ts
@@ -11,6 +11,7 @@ import {
   selectRootAgentSessionIdsWithPendingInteractions,
   selectWorkspaceAgentConsumerCounts,
   selectWorkspaceAgentConsumerSession,
+  selectWorkspaceAgentConsumerSessions,
   selectWorkspaceAgentRootConversationSessions
 } from "./sessionLifecycle.selectors.ts";
 
@@ -62,6 +63,48 @@ test("deleted session selector normalizes ids and hides tombstone storage", () =
   assert.equal(selectEngineSessionDeleted(state, " session-1 "), true);
   assert.equal(selectEngineSessionDeleted(state, "missing"), false);
   assert.equal(selectEngineSessionDeleted(state, null), false);
+});
+
+test("consumer collections hide presentation-invisible sessions without removing exact lookup", () => {
+  const state = rootEngineReducer(createInitialAgentSessionEngineState(), {
+    sessions: [
+      {
+        activeTurnId: null,
+        agentSessionId: "visible-session",
+        cwd: "/workspace",
+        latestTurnInteractions: [],
+        pendingInteractions: [],
+        provider: "codex",
+        title: "Visible session",
+        visible: true,
+        workspaceId: "workspace-1"
+      },
+      {
+        activeTurnId: null,
+        agentSessionId: "hidden-session",
+        cwd: "/workspace",
+        latestTurnInteractions: [],
+        pendingInteractions: [],
+        provider: "codex",
+        title: "Hidden session",
+        visible: false,
+        workspaceId: "workspace-1"
+      }
+    ],
+    type: "session/snapshotReceived"
+  }).state;
+
+  assert.deepEqual(
+    selectWorkspaceAgentConsumerSessions(state).map(
+      (item) => item.session.agentSessionId
+    ),
+    ["visible-session"]
+  );
+  assert.equal(
+    selectWorkspaceAgentConsumerSession(state, "hidden-session")?.session
+      .agentSessionId,
+    "hidden-session"
+  );
 });
 
 test("consumer status is derived from canonical entities and engine-owned initial activation", () => {

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
@@ -312,7 +312,7 @@ export function selectWorkspaceAgentConsumerSessions(
   state: AgentSessionEngineState
 ): readonly WorkspaceAgentConsumerSession[] {
   return selectAllWorkspaceAgentConsumerSessions(state).filter(
-    (item) => item.session.kind === "root"
+    (item) => item.session.kind === "root" && item.session.visible !== false
   );
 }
 


### PR DESCRIPTION
## Summary
- exclude presentation-invisible root sessions from plural consumer collections
- preserve exact session lookup for trusted open, reconcile, and commands
- document the collection-versus-addressability invariant

## Verification
- pnpm check:changed -- --tail-lines 80
- pnpm lint:ts
- pnpm typecheck
- pnpm check:ui-boundaries
- pnpm release:pack:check
- pnpm --filter @tutti-os/agent-activity-core test
- focused Agent GUI, Message Center, and rail query tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->