### PR TITLE
[Tutloop] 清理低价值单测：移除 workbench-snapshot 中重复的 fixture 校验用例

### DIFF
--- a/packages/workbench/snapshot/src/validate.test.ts
+++ b/packages/workbench/snapshot/src/validate.test.ts
@@ -14,12 +14,6 @@ import {
   workbenchSnapshotSchemaVersion
 } from "./index.ts";
 
-test("validates a fixture snapshot", () => {
-  const result = validateWorkbenchSnapshot(tuttiWorkbenchSnapshotFixture);
-  assert.equal(result.ok, true);
-  assert.deepEqual(result.issues, []);
-});
-
 test("rejects malformed snapshots", () => {
   const result = validateWorkbenchSnapshot({
     schemaVersion: workbenchSnapshotSchemaVersion,


### PR DESCRIPTION
## 候选分类

**A — 重复代码单测**：与同文件中已有用例覆盖同一生产分支、同一输入、同一可观察结果。

## 低价值证据

- **位置**：`packages/workbench/snapshot/src/validate.test.ts:17-21`，用例标题 `"validates a fixture snapshot"`。
- **被覆盖的等价用例**：同文件 `packages/workbench/snapshot/src/validate.test.ts:90-100`，用例标题 `"accepts canonical contract fixtures"`。
- 删除的用例只对 `tuttiWorkbenchSnapshotFixture` 调用 `validateWorkbenchSnapshot(...)`，断言 `result.ok === true` 且 `result.issues` 深度等于 `[]`。
- 等价用例对 `minimalWorkbenchSnapshotFixture`、`tuttiWorkbenchSnapshotFixture`、`workbenchSnapshotWithSpacesFixture` 三个 fixture 循环执行完全相同的调用与断言，其中第二个 fixture 与被删用例输入完全一致。
- 满足高置信准入标准：
  - 标准 1（与另一用例覆盖同一生产分支和可观察结果）：✅
  - 标准 4（具体维护成本证据）：✅ 修改 fixture 或校验 happy-path 时需要同步更新两处。
- 无独特覆盖：无任何独占的边界、错误、平台、并发、兼容性、可访问性、安全或协议分支。
- Git 历史：两条用例均自初始提交 `e2120fb27` 起存在，未见刻意重复的说明。

## 保留的行为覆盖

`"accepts canonical contract fixtures"` 仍然对 `tuttiWorkbenchSnapshotFixture`（以及另两个 fixture）执行相同断言；`"rejects malformed snapshots"` 等其余用例继续覆盖验证器的错误分支。fixture 自身仍由 fixtures 文件维护，无任何引用丢失。

## 改动摘要

- `packages/workbench/snapshot/src/validate.test.ts`：删除 6 行（5 行用例 + 1 行空行）。
- 删除后 `tuttiWorkbenchSnapshotFixture`、`validateWorkbenchSnapshot` 等导入仍被同文件其他用例使用，未触发导入清理。
- 未触碰生产代码、依赖、构建配置、生成文件、fixture/golden 或其他测试。

## 风险

- 风险极低：删除的用例是循环用例的真子集，循环用例继续运行。
- 不影响任何公共 API/CLI/协议契约；不修改被测生产代码。

## 执行过的精确验证命令及结果

| 命令 | 结果 |
| --- | --- |
| `pnpm --filter @tutti-os/workbench-snapshot test` | ✅ 15/15 pass（删除前 16/16） |
| `pnpm check:changed -- --dry-run` | ✅ 8 lanes planned |
| `pnpm check:changed` | ✅ 8 lanes passed in 1.8s |
| `git push`（触发 `pre-push` 的 `pnpm check:changed -- --push-ready`） | ✅ 9 lanes passed in 52.5s |

## 回滚方式

`git revert <merge-commit>` 即可恢复被删除的用例；本 PR 仅删除测试，不触及生产代码或数据格式。

## 备注

- 本 PR 由 Tutloop Loop `81149dd8-2a87-478f-9971-95b8bfc54f1d` 创建，遵循串行门禁：上一次匹配 PR `#1429` 已合并后才启动本轮。
- **本 PR 未自动合并**，等待人工评审与合并。
- 任意时刻没有创建第二个匹配的 open PR。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->