### PR TITLE
feat(agent): persist turn-scoped reply resources

### DIFF
--- a/packages/agent/claude-sdk-sidecar/package.json
+++ b/packages/agent/claude-sdk-sidecar/package.json
@@ -14,6 +14,7 @@
     "src/interactive.ts",
     "src/interactiveTurnResolver.ts",
     "src/main.ts",
+    "src/managedMCP.ts",
     "src/messageProjection.ts",
     "src/messageRouter.ts",
     "src/normalizer.ts",

--- a/packages/agent/claude-sdk-sidecar/src/managedMCP.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/managedMCP.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { managedMCPServersFromEnv } from "./managedMCP.ts";
+
+test("managedMCPServersFromEnv projects trusted stdio servers", () => {
+  const raw = Buffer.from(
+    JSON.stringify({
+      servers: [
+        {
+          name: "tsh_reply_resources",
+          stdio: {
+            command: "/opt/tsh/product/bin/tsh-bundle-services",
+            args: ["reply-resource-mcp"],
+            env: [{ name: "TSH_REPLY_RESOURCE_SCOPE_TOKEN", value: "scoped" }]
+          }
+        }
+      ]
+    })
+  ).toString("base64");
+  assert.deepEqual(
+    managedMCPServersFromEnv({
+      TSH_MANAGED_AGENT_MCP_ATTACHMENT_B64: raw
+    }),
+    {
+      tsh_reply_resources: {
+        type: "stdio",
+        command: "/opt/tsh/product/bin/tsh-bundle-services",
+        args: ["reply-resource-mcp"],
+        env: { TSH_REPLY_RESOURCE_SCOPE_TOKEN: "scoped" }
+      }
+    }
+  );
+});
+
+test("managedMCPServersFromEnv fails closed for malformed attachments", () => {
+  assert.deepEqual(
+    managedMCPServersFromEnv({
+      TSH_MANAGED_AGENT_MCP_ATTACHMENT_B64: "not-base64-json"
+    }),
+    {}
+  );
+});

--- a/packages/agent/claude-sdk-sidecar/src/managedMCP.ts
+++ b/packages/agent/claude-sdk-sidecar/src/managedMCP.ts
@@ -1,0 +1,57 @@
+const attachmentEnvKey = "TSH_MANAGED_AGENT_MCP_ATTACHMENT_B64";
+
+type PrepareAttachment = {
+  servers?: Array<{
+    name?: unknown;
+    stdio?: {
+      command?: unknown;
+      args?: unknown;
+      env?: unknown;
+    };
+  }>;
+};
+
+export function managedMCPServersFromEnv(
+  env: Record<string, string | undefined>
+): Record<string, unknown> {
+  const encoded = env[attachmentEnvKey]?.trim();
+  if (!encoded) return {};
+  try {
+    const attachment = JSON.parse(
+      Buffer.from(encoded, "base64").toString("utf8")
+    ) as PrepareAttachment;
+    const result: Record<string, unknown> = {};
+    for (const server of attachment.servers ?? []) {
+      const name = typeof server.name === "string" ? server.name.trim() : "";
+      const command =
+        typeof server.stdio?.command === "string"
+          ? server.stdio.command.trim()
+          : "";
+      if (!name || !command || Object.hasOwn(result, name)) continue;
+      const args = Array.isArray(server.stdio?.args)
+        ? server.stdio.args.filter(
+            (value): value is string => typeof value === "string"
+          )
+        : [];
+      const variables: Record<string, string> = {};
+      if (Array.isArray(server.stdio?.env)) {
+        for (const entry of server.stdio.env) {
+          if (!entry || typeof entry !== "object") continue;
+          const item = entry as { name?: unknown; value?: unknown };
+          if (typeof item.name === "string" && typeof item.value === "string") {
+            variables[item.name] = item.value;
+          }
+        }
+      }
+      result[name] = {
+        type: "stdio",
+        command,
+        ...(args.length > 0 ? { args } : {}),
+        ...(Object.keys(variables).length > 0 ? { env: variables } : {})
+      };
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
@@ -45,6 +45,7 @@ import { CompactionTracker } from "./compaction.ts";
 import { MessageProjection } from "./messageProjection.ts";
 import { SDKMessageRouter } from "./messageRouter.ts";
 import { emit } from "./eventSink.ts";
+import { managedMCPServersFromEnv } from "./managedMCP.ts";
 import {
   canBypassPermissions,
   effectivePermissionMode,
@@ -594,6 +595,7 @@ export class SessionRuntime {
     const querySettings = querySettingsFromSessionSettings(
       this.configuration.settings
     );
+    const mcpServers = managedMCPServersFromEnv(this.env);
     // One settings snapshot feeds both the executable resolution and the SDK
     // env, so the two can never disagree (and the settings hierarchy is read
     // once per query creation).
@@ -636,6 +638,7 @@ export class SessionRuntime {
       ...(Object.keys(querySettings).length > 0
         ? { settings: querySettings }
         : {}),
+      ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
       ...claudeQueryOptionOverrides(this.claudeOptions),
       hooks: queryGenerationHooks({
         generation,

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -46,6 +46,13 @@ subset from that same read; older-turn pending rows can never become current
 actionable state. `CreateSessionInput.ClientSubmitID` and
 `SendInput.ClientSubmitID` are the typed idempotency identities and override
 the legacy metadata value when both are present.
+`AttachReplyResource` is the canonical declaration boundary for reply files
+and artifacts. The store atomically binds each declaration to the session's
+currently active turn and deduplicates it within that exact
+`(workspaceId, agentSessionId, turnId)` scope; declarations arriving after
+settlement fail with `ErrNoActiveTurn`. Host stores immutable reference
+metadata only. Byte snapshotting, upload, Markdown mention composition, and
+chat delivery remain adapter responsibilities.
 Runtime adapters preserve explicit downstream failures as `ProviderError` so
 Host consumers can distinguish provider-owned rejection from preparation,
 canonical-store, timeout, and other local failures with `errors.As`. The

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 )
 
 type SessionSeed struct {
@@ -150,6 +151,15 @@ type Driver interface {
 	Metrics() Metrics
 }
 
+// ReplyResourceDriver is the focused Host contract for turn-scoped reply
+// declarations. Reset remains test-only seeding; scenario actions use only
+// public Host commands and queries.
+type ReplyResourceDriver interface {
+	Reset(context.Context, Fixture) error
+	AttachReplyResource(context.Context, agenthost.SessionRef, agenthost.AttachReplyResourceInput) (agenthost.AttachReplyResourceResult, error)
+	ListTurnReplyResources(context.Context, agenthost.SessionRef, string) ([]storesqlite.ReplyResource, error)
+}
+
 type Scenario struct {
 	Name string
 	run  func(context.Context, Driver) error
@@ -161,6 +171,21 @@ func Run(ctx context.Context, driver Driver, scenario Scenario) error {
 	}
 	if scenario.run == nil {
 		return fmt.Errorf("agent host conformance scenario %q has no runner", scenario.Name)
+	}
+	return scenario.run(ctx, driver)
+}
+
+type ReplyResourceScenario struct {
+	Name string
+	run  func(context.Context, ReplyResourceDriver) error
+}
+
+func RunReplyResource(ctx context.Context, driver ReplyResourceDriver, scenario ReplyResourceScenario) error {
+	if driver == nil {
+		return fmt.Errorf("agent host reply resource conformance driver is required")
+	}
+	if scenario.run == nil {
+		return fmt.Errorf("agent host reply resource conformance scenario %q has no runner", scenario.Name)
 	}
 	return scenario.run(ctx, driver)
 }

--- a/packages/agent/host/conformance/reply_resource_scenarios.go
+++ b/packages/agent/host/conformance/reply_resource_scenarios.go
@@ -1,0 +1,63 @@
+package conformance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+var attachReplyResourceScenario = ReplyResourceScenario{
+	Name: "reply resource binds once to active turn and rejects after settlement",
+	run:  runAttachReplyResource,
+}
+
+func ReplyResourceScenarios() []ReplyResourceScenario {
+	return []ReplyResourceScenario{attachReplyResourceScenario}
+}
+
+func runAttachReplyResource(ctx context.Context, driver ReplyResourceDriver) error {
+	fixture := Fixture{
+		Session: &SessionSeed{WorkspaceID: "workspace-1", AgentSessionID: "session-1", ActiveTurnID: "turn-1"},
+		Turn:    &TurnSeed{TurnID: "turn-1", Phase: storesqlite.TurnPhaseRunning},
+	}
+	if err := driver.Reset(ctx, fixture); err != nil {
+		return err
+	}
+	ref := agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"}
+	input := agenthost.AttachReplyResourceInput{
+		TurnID:     "turn-1",
+		ResourceID: "resource-1", DedupeKey: "sha256:abc", Kind: storesqlite.ReplyResourceKindLocalFile,
+		SourceRef: "sha256_abc", ContentHash: "abc", DisplayName: "chart.png", MediaType: "image/png", SizeBytes: 42,
+	}
+	first, err := driver.AttachReplyResource(ctx, ref, input)
+	if err != nil || !first.Created || first.Resource.TurnID != "turn-1" {
+		return fmt.Errorf("first reply resource attach result=%#v error=%v", first, err)
+	}
+	input.ResourceID = "resource-duplicate"
+	duplicate, err := driver.AttachReplyResource(ctx, ref, input)
+	if err != nil || duplicate.Created || duplicate.Resource.ResourceID != "resource-1" {
+		return fmt.Errorf("deduplicated reply resource result=%#v error=%v", duplicate, err)
+	}
+	resources, err := driver.ListTurnReplyResources(ctx, ref, "turn-1")
+	if err != nil || len(resources) != 1 || resources[0].ResourceID != "resource-1" {
+		return fmt.Errorf("turn reply resources=%#v error=%v", resources, err)
+	}
+
+	fixture.Session.ActiveTurnID = ""
+	fixture.Turn.Phase = storesqlite.TurnPhaseSettled
+	fixture.Turn.Outcome = storesqlite.TurnOutcomeCompleted
+	if err := driver.Reset(ctx, fixture); err != nil {
+		return err
+	}
+	input.ResourceID = "late"
+	input.DedupeKey = "sha256:late"
+	input.SourceRef = "sha256_late"
+	_, err = driver.AttachReplyResource(ctx, ref, input)
+	if !errors.Is(err, agenthost.ErrNoActiveTurn) {
+		return fmt.Errorf("late reply resource error=%v, want %v", err, agenthost.ErrNoActiveTurn)
+	}
+	return nil
+}

--- a/packages/agent/host/errors.go
+++ b/packages/agent/host/errors.go
@@ -16,6 +16,7 @@ var (
 	ErrRuntimeOperationFailed           = errors.New("agent runtime operation failed")
 	ErrRuntimeOperationIdentityMismatch = errors.New("agent runtime operation identity is inconsistent")
 	ErrGoalConsumerUnavailable          = errors.New("agent goal reconcile consumer is unavailable")
+	ErrNoActiveTurn                     = errors.New("agent session has no active turn")
 )
 
 // ProviderError preserves a provider-owned failure across the runtime adapter

--- a/packages/agent/host/host.go
+++ b/packages/agent/host/host.go
@@ -34,6 +34,7 @@ type Config struct {
 	GoalMaxAttempts      int
 	GoalDispatchDeadline time.Duration
 	GoalActor            *GoalActor
+	ReplyResources       ReplyResourceStore
 }
 
 type Host struct {
@@ -65,6 +66,7 @@ type Host struct {
 	goalMaxAttempts      int
 	goalDispatchDeadline time.Duration
 	goalActor            *GoalActor
+	replyResources       ReplyResourceStore
 }
 
 func New(config Config) *Host {
@@ -84,7 +86,8 @@ func New(config Config) *Host {
 		goalOwner: config.GoalOwner, goalClock: config.GoalClock,
 		goalAttemptTimeout: config.GoalAttemptTimeout, goalRecoveryBudget: config.GoalRecoveryBudget,
 		goalMaxAttempts: config.GoalMaxAttempts, goalDispatchDeadline: config.GoalDispatchDeadline,
-		goalActor: goalActor,
+		goalActor:      goalActor,
+		replyResources: config.ReplyResources,
 	}
 	if host.operations != nil && host.commitObserver != nil {
 		host.operations = &observedRuntimeOperationStore{RuntimeOperationStore: host.operations, host: host}

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -27,6 +27,14 @@ type CanonicalMessageStore interface {
 	ListSessionMessages(context.Context, storesqlite.ListSessionMessagesInput) (storesqlite.MessagePage, bool, error)
 }
 
+// ReplyResourceStore owns the atomic active-turn fence for reply-resource
+// declarations. Byte materialization and product delivery stay in adapters;
+// the Host owns only which canonical turn may accept a declaration.
+type ReplyResourceStore interface {
+	AttachReplyResourceToActiveTurn(context.Context, storesqlite.AttachReplyResourceInput) (storesqlite.ReplyResource, bool, error)
+	ListTurnReplyResources(context.Context, string, string, string) ([]storesqlite.ReplyResource, error)
+}
+
 type CanonicalSubmitClaimStore interface {
 	PrepareSubmitClaim(context.Context, storesqlite.SubmitClaimPrepare) (storesqlite.SubmitClaim, bool, error)
 	AcceptSubmitClaim(context.Context, string, string, string, string, int64) (storesqlite.SubmitClaim, bool, error)

--- a/packages/agent/host/reply_resources.go
+++ b/packages/agent/host/reply_resources.go
@@ -1,0 +1,60 @@
+package agenthost
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+// AttachReplyResource binds an already-immutable resource reference to the
+// canonical active turn. The store performs the active-turn check and insert
+// atomically, so a late tool call cannot leak into the next turn.
+func (h *Host) AttachReplyResource(ctx context.Context, ref SessionRef, input AttachReplyResourceInput) (AttachReplyResourceResult, error) {
+	ref = normalizedSessionRef(ref)
+	input = normalizeAttachReplyResourceInput(input)
+	if h == nil || h.replyResources == nil || ref.WorkspaceID == "" || ref.AgentSessionID == "" ||
+		input.TurnID == "" || input.ResourceID == "" || input.DedupeKey == "" || input.SourceRef == "" || input.DisplayName == "" ||
+		input.SizeBytes < 0 || (input.Kind != storesqlite.ReplyResourceKindLocalFile && input.Kind != storesqlite.ReplyResourceKindExternalArtifact) {
+		return AttachReplyResourceResult{}, ErrInvalidArgument
+	}
+	if input.CreatedAtUnixMS <= 0 {
+		input.CreatedAtUnixMS = time.Now().UnixMilli()
+	}
+	resource, created, err := h.replyResources.AttachReplyResourceToActiveTurn(ctx, storesqlite.AttachReplyResourceInput{
+		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, TurnID: input.TurnID,
+		ResourceID: input.ResourceID, DedupeKey: input.DedupeKey, Kind: input.Kind,
+		SourceRef: input.SourceRef, ContentHash: input.ContentHash, DisplayName: input.DisplayName,
+		MediaType: input.MediaType, SizeBytes: input.SizeBytes, CreatedAtUnixMS: input.CreatedAtUnixMS,
+	})
+	if errors.Is(err, storesqlite.ErrNoActiveTurn) {
+		return AttachReplyResourceResult{}, ErrNoActiveTurn
+	}
+	if err != nil {
+		return AttachReplyResourceResult{}, err
+	}
+	return AttachReplyResourceResult{Resource: resource, Created: created}, nil
+}
+
+func (h *Host) ListTurnReplyResources(ctx context.Context, ref SessionRef, turnID string) ([]storesqlite.ReplyResource, error) {
+	ref = normalizedSessionRef(ref)
+	turnID = strings.TrimSpace(turnID)
+	if h == nil || h.replyResources == nil || ref.WorkspaceID == "" || ref.AgentSessionID == "" || turnID == "" {
+		return nil, ErrInvalidArgument
+	}
+	return h.replyResources.ListTurnReplyResources(ctx, ref.WorkspaceID, ref.AgentSessionID, turnID)
+}
+
+func normalizeAttachReplyResourceInput(input AttachReplyResourceInput) AttachReplyResourceInput {
+	input.TurnID = strings.TrimSpace(input.TurnID)
+	input.ResourceID = strings.TrimSpace(input.ResourceID)
+	input.DedupeKey = strings.TrimSpace(input.DedupeKey)
+	input.Kind = strings.TrimSpace(input.Kind)
+	input.SourceRef = strings.TrimSpace(input.SourceRef)
+	input.ContentHash = strings.TrimSpace(input.ContentHash)
+	input.DisplayName = strings.TrimSpace(input.DisplayName)
+	input.MediaType = strings.TrimSpace(input.MediaType)
+	return input
+}

--- a/packages/agent/host/reply_resources_conformance_test.go
+++ b/packages/agent/host/reply_resources_conformance_test.go
@@ -1,0 +1,78 @@
+package agenthost_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	"github.com/tutti-os/tutti/packages/agent/host/conformance"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+type replyResourceConformanceDriver struct {
+	host  *agenthost.Host
+	store *replyResourceConformanceStore
+}
+
+type replyResourceConformanceStore struct {
+	activeTurnID string
+	phase        string
+	resources    []storesqlite.ReplyResource
+}
+
+func (d *replyResourceConformanceDriver) Reset(_ context.Context, fixture conformance.Fixture) error {
+	d.store = &replyResourceConformanceStore{}
+	if fixture.Session != nil {
+		d.store.activeTurnID = fixture.Session.ActiveTurnID
+	}
+	if fixture.Turn != nil {
+		d.store.phase = fixture.Turn.Phase
+	}
+	d.host = agenthost.New(agenthost.Config{ReplyResources: d.store})
+	return nil
+}
+
+func (d *replyResourceConformanceDriver) AttachReplyResource(ctx context.Context, ref agenthost.SessionRef, input agenthost.AttachReplyResourceInput) (agenthost.AttachReplyResourceResult, error) {
+	return d.host.AttachReplyResource(ctx, ref, input)
+}
+
+func (d *replyResourceConformanceDriver) ListTurnReplyResources(ctx context.Context, ref agenthost.SessionRef, turnID string) ([]storesqlite.ReplyResource, error) {
+	return d.host.ListTurnReplyResources(ctx, ref, turnID)
+}
+
+func (s *replyResourceConformanceStore) AttachReplyResourceToActiveTurn(_ context.Context, input storesqlite.AttachReplyResourceInput) (storesqlite.ReplyResource, bool, error) {
+	if s.activeTurnID == "" || s.activeTurnID != input.TurnID || s.phase == storesqlite.TurnPhaseSettled {
+		return storesqlite.ReplyResource{}, false, storesqlite.ErrNoActiveTurn
+	}
+	for _, resource := range s.resources {
+		if resource.DedupeKey == input.DedupeKey {
+			return resource, false, nil
+		}
+	}
+	resource := storesqlite.ReplyResource{
+		WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID, TurnID: s.activeTurnID,
+		ResourceID: input.ResourceID, DedupeKey: input.DedupeKey, Kind: input.Kind, SourceRef: input.SourceRef,
+		ContentHash: input.ContentHash, DisplayName: input.DisplayName, MediaType: input.MediaType,
+		SizeBytes: input.SizeBytes, CreatedAtUnixMS: input.CreatedAtUnixMS,
+	}
+	s.resources = append(s.resources, resource)
+	return resource, true, nil
+}
+
+func (s *replyResourceConformanceStore) ListTurnReplyResources(_ context.Context, workspaceID, sessionID, turnID string) ([]storesqlite.ReplyResource, error) {
+	if workspaceID == "" || sessionID == "" || turnID == "" {
+		return nil, errors.New("invalid query")
+	}
+	return append([]storesqlite.ReplyResource(nil), s.resources...), nil
+}
+
+func TestReplyResourceConformance(t *testing.T) {
+	for _, scenario := range conformance.ReplyResourceScenarios() {
+		t.Run(scenario.Name, func(t *testing.T) {
+			if err := conformance.RunReplyResource(t.Context(), &replyResourceConformanceDriver{}, scenario); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/packages/agent/host/reply_resources_sqlite_test.go
+++ b/packages/agent/host/reply_resources_sqlite_test.go
@@ -1,0 +1,63 @@
+package agenthost_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	_ "modernc.org/sqlite"
+)
+
+func TestAttachReplyResourceUsesCanonicalActiveTurnFence(t *testing.T) {
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "reply-resources.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	store := storesqlite.New(db, storesqlite.Options{})
+	if err := store.Migrate(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ReportSessionState(t.Context(), storesqlite.SessionStateReport{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1", Provider: "codex", OccurredAtUnixMS: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, accepted, err := store.RecordTurnTransition(t.Context(), storesqlite.TurnTransition{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1",
+		Phase: storesqlite.TurnPhaseRunning, OccurredAtUnixMS: 2,
+	}); err != nil || !accepted {
+		t.Fatalf("record turn accepted=%v error=%v", accepted, err)
+	}
+
+	host := agenthost.New(agenthost.Config{ReplyResources: store})
+	ref := agenthost.SessionRef{WorkspaceID: "ws-1", AgentSessionID: "session-1"}
+	result, err := host.AttachReplyResource(t.Context(), ref, agenthost.AttachReplyResourceInput{
+		TurnID:     "turn-1",
+		ResourceID: "resource-1", DedupeKey: "sha256:abc", Kind: storesqlite.ReplyResourceKindLocalFile,
+		SourceRef: "sha256_abc", ContentHash: "abc", DisplayName: "chart.png", MediaType: "image/png", SizeBytes: 42,
+	})
+	if err != nil || !result.Created || result.Resource.TurnID != "turn-1" {
+		t.Fatalf("attach result=%#v error=%v", result, err)
+	}
+
+	if _, accepted, err := store.RecordTurnTransition(context.Background(), storesqlite.TurnTransition{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1",
+		Phase: storesqlite.TurnPhaseSettled, Outcome: storesqlite.TurnOutcomeCompleted, OccurredAtUnixMS: 3,
+	}); err != nil || !accepted {
+		t.Fatalf("settle turn accepted=%v error=%v", accepted, err)
+	}
+	_, err = host.AttachReplyResource(t.Context(), ref, agenthost.AttachReplyResourceInput{
+		TurnID:     "turn-1",
+		ResourceID: "late", DedupeKey: "sha256:late", Kind: storesqlite.ReplyResourceKindLocalFile,
+		SourceRef: "sha256_late", DisplayName: "late.txt",
+	})
+	if !errors.Is(err, agenthost.ErrNoActiveTurn) {
+		t.Fatalf("late attach error = %v, want %v", err, agenthost.ErrNoActiveTurn)
+	}
+}

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -9,6 +9,26 @@ type SessionRef struct {
 	AgentSessionID string
 }
 
+// AttachReplyResourceInput registers an immutable resource reference against
+// the session's current canonical turn. It never uploads or sends a message.
+type AttachReplyResourceInput struct {
+	TurnID          string
+	ResourceID      string
+	DedupeKey       string
+	Kind            string
+	SourceRef       string
+	ContentHash     string
+	DisplayName     string
+	MediaType       string
+	SizeBytes       int64
+	CreatedAtUnixMS int64
+}
+
+type AttachReplyResourceResult struct {
+	Resource storesqlite.ReplyResource
+	Created  bool
+}
+
 // InteractionRef identifies one canonical interaction. Provider request IDs
 // are transport-local correlation values and are only unique within the Turn
 // that owns them.

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -67,6 +67,7 @@ const schemaMigrationWorkspaceAgentGoalProvenanceLedgerV1 = "workspace_agent_goa
 const schemaMigrationWorkspaceAgentMessageSemanticsV1 = "workspace_agent_message_semantics_v1"
 const schemaMigrationWorkspaceAgentDeletedPurgeIndexV1 = "workspace_agent_deleted_purge_index_v1"
 const schemaMigrationWorkspaceAgentSessionTurnPageIndexV1 = "workspace_agent_session_turn_page_index_v1"
+const schemaMigrationWorkspaceAgentTurnReplyResourcesV1 = "workspace_agent_turn_reply_resources_v1"
 
 // claimableMigrationIDs are the migration IDs that may already be recorded
 // in the legacy tuttid ledger; the claim copies exactly these.
@@ -240,7 +241,10 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 	if err := s.applyWorkspaceAgentDeletedPurgeIndexV1(ctx); err != nil {
 		return err
 	}
-	return s.applyWorkspaceAgentSessionTurnPageIndexV1(ctx)
+	if err := s.applyWorkspaceAgentSessionTurnPageIndexV1(ctx); err != nil {
+		return err
+	}
+	return s.applyWorkspaceAgentTurnReplyResourcesV1(ctx)
 }
 
 // claimLegacyMigrations copies agent-store migration records that were

--- a/packages/agent/store-sqlite/migrations_reply_resources.go
+++ b/packages/agent/store-sqlite/migrations_reply_resources.go
@@ -1,0 +1,61 @@
+package storesqlite
+
+import (
+	"context"
+	"fmt"
+)
+
+func (s *Store) applyWorkspaceAgentTurnReplyResourcesV1(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentTurnReplyResourcesV1)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin workspace agent turn reply resources migration: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, err := tx.ExecContext(ctx, `
+CREATE TABLE workspace_agent_turn_reply_resources (
+  workspace_id TEXT NOT NULL,
+  agent_session_id TEXT NOT NULL,
+  turn_id TEXT NOT NULL,
+  resource_id TEXT NOT NULL,
+  dedupe_key TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('local_file', 'external_artifact')),
+  source_ref TEXT NOT NULL,
+  content_hash TEXT NOT NULL DEFAULT '',
+  display_name TEXT NOT NULL,
+  media_type TEXT NOT NULL DEFAULT '',
+  size_bytes INTEGER NOT NULL DEFAULT 0 CHECK (size_bytes >= 0),
+  created_at_unix_ms INTEGER NOT NULL,
+  PRIMARY KEY (workspace_id, agent_session_id, turn_id, resource_id),
+  UNIQUE (workspace_id, agent_session_id, turn_id, dedupe_key),
+  FOREIGN KEY (workspace_id, agent_session_id, turn_id)
+    REFERENCES workspace_agent_turns(workspace_id, agent_session_id, turn_id)
+    ON DELETE CASCADE
+);
+CREATE INDEX idx_workspace_agent_turn_reply_resources_turn
+  ON workspace_agent_turn_reply_resources(workspace_id, agent_session_id, turn_id, created_at_unix_ms, resource_id);
+`); err != nil {
+		return fmt.Errorf("apply workspace agent turn reply resources schema: %w", err)
+	}
+	if err := recordMigrationTx(ctx, tx, schemaMigrationWorkspaceAgentTurnReplyResourcesV1); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit workspace agent turn reply resources migration: %w", err)
+	}
+	committed = true
+	return nil
+}

--- a/packages/agent/store-sqlite/reply_resources.go
+++ b/packages/agent/store-sqlite/reply_resources.go
@@ -1,0 +1,138 @@
+package storesqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// AttachReplyResourceToActiveTurn atomically binds a resource to the session's
+// canonical active turn. A concurrent settlement cannot admit a late resource:
+// both the active-turn read and insert run in this transaction.
+func (s *Store) AttachReplyResourceToActiveTurn(ctx context.Context, input AttachReplyResourceInput) (ReplyResource, bool, error) {
+	if s == nil || s.db == nil {
+		return ReplyResource{}, false, errors.New("workspace database is not initialized")
+	}
+	input = normalizeAttachReplyResourceInput(input)
+	if input.WorkspaceID == "" || input.AgentSessionID == "" || input.TurnID == "" || input.ResourceID == "" || input.DedupeKey == "" ||
+		input.SourceRef == "" || input.DisplayName == "" || input.CreatedAtUnixMS <= 0 || input.SizeBytes < 0 ||
+		(input.Kind != ReplyResourceKindLocalFile && input.Kind != ReplyResourceKindExternalArtifact) {
+		return ReplyResource{}, false, fmt.Errorf("invalid workspace agent reply resource")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return ReplyResource{}, false, fmt.Errorf("begin workspace agent reply resource attach: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var turnID, phase string
+	err = tx.QueryRowContext(ctx, `
+SELECT session.active_turn_id, turn.phase
+FROM workspace_agent_sessions AS session
+JOIN workspace_agent_turns AS turn
+  ON turn.workspace_id = session.workspace_id
+ AND turn.agent_session_id = session.agent_session_id
+ AND turn.turn_id = session.active_turn_id
+WHERE session.workspace_id = ? AND session.agent_session_id = ? AND session.active_turn_id = ?
+  AND session.deleted_at_unix_ms = 0 AND session.active_turn_id <> ''
+`, input.WorkspaceID, input.AgentSessionID, input.TurnID).Scan(&turnID, &phase)
+	if errors.Is(err, sql.ErrNoRows) || strings.TrimSpace(phase) == TurnPhaseSettled {
+		return ReplyResource{}, false, ErrNoActiveTurn
+	}
+	if err != nil {
+		return ReplyResource{}, false, fmt.Errorf("read active turn for reply resource: %w", err)
+	}
+
+	result, err := tx.ExecContext(ctx, `
+INSERT OR IGNORE INTO workspace_agent_turn_reply_resources (
+  workspace_id, agent_session_id, turn_id, resource_id, dedupe_key, kind,
+  source_ref, content_hash, display_name, media_type, size_bytes, created_at_unix_ms
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`, input.WorkspaceID, input.AgentSessionID, turnID, input.ResourceID, input.DedupeKey, input.Kind,
+		input.SourceRef, input.ContentHash, input.DisplayName, input.MediaType, input.SizeBytes, input.CreatedAtUnixMS)
+	if err != nil {
+		return ReplyResource{}, false, fmt.Errorf("attach workspace agent reply resource: %w", err)
+	}
+	created, err := rowsWereAffected(result, "attach workspace agent reply resource")
+	if err != nil {
+		return ReplyResource{}, false, err
+	}
+	resource, err := readReplyResource(ctx, tx.QueryRowContext(ctx, `
+SELECT workspace_id, agent_session_id, turn_id, resource_id, dedupe_key, kind,
+       source_ref, content_hash, display_name, media_type, size_bytes, created_at_unix_ms
+FROM workspace_agent_turn_reply_resources
+WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ? AND dedupe_key = ?
+`, input.WorkspaceID, input.AgentSessionID, turnID, input.DedupeKey))
+	if err != nil {
+		return ReplyResource{}, false, fmt.Errorf("read attached workspace agent reply resource: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return ReplyResource{}, false, fmt.Errorf("commit workspace agent reply resource attach: %w", err)
+	}
+	committed = true
+	return resource, created, nil
+}
+
+func (s *Store) ListTurnReplyResources(ctx context.Context, workspaceID, agentSessionID, turnID string) ([]ReplyResource, error) {
+	workspaceID, agentSessionID, turnID = strings.TrimSpace(workspaceID), strings.TrimSpace(agentSessionID), strings.TrimSpace(turnID)
+	if s == nil || s.db == nil || workspaceID == "" || agentSessionID == "" || turnID == "" {
+		return nil, fmt.Errorf("invalid workspace agent reply resource query")
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT workspace_id, agent_session_id, turn_id, resource_id, dedupe_key, kind,
+       source_ref, content_hash, display_name, media_type, size_bytes, created_at_unix_ms
+FROM workspace_agent_turn_reply_resources
+WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ?
+ORDER BY created_at_unix_ms, resource_id
+`, workspaceID, agentSessionID, turnID)
+	if err != nil {
+		return nil, fmt.Errorf("list workspace agent turn reply resources: %w", err)
+	}
+	defer rows.Close()
+	resources := make([]ReplyResource, 0)
+	for rows.Next() {
+		resource, err := readReplyResource(ctx, rows)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate workspace agent turn reply resources: %w", err)
+	}
+	return resources, nil
+}
+
+type replyResourceScanner interface{ Scan(...any) error }
+
+func readReplyResource(_ context.Context, scanner replyResourceScanner) (ReplyResource, error) {
+	var resource ReplyResource
+	if err := scanner.Scan(&resource.WorkspaceID, &resource.AgentSessionID, &resource.TurnID, &resource.ResourceID,
+		&resource.DedupeKey, &resource.Kind, &resource.SourceRef, &resource.ContentHash, &resource.DisplayName,
+		&resource.MediaType, &resource.SizeBytes, &resource.CreatedAtUnixMS); err != nil {
+		return ReplyResource{}, err
+	}
+	return resource, nil
+}
+
+func normalizeAttachReplyResourceInput(input AttachReplyResourceInput) AttachReplyResourceInput {
+	input.WorkspaceID = strings.TrimSpace(input.WorkspaceID)
+	input.AgentSessionID = strings.TrimSpace(input.AgentSessionID)
+	input.TurnID = strings.TrimSpace(input.TurnID)
+	input.ResourceID = strings.TrimSpace(input.ResourceID)
+	input.DedupeKey = strings.TrimSpace(input.DedupeKey)
+	input.Kind = strings.TrimSpace(input.Kind)
+	input.SourceRef = strings.TrimSpace(input.SourceRef)
+	input.ContentHash = strings.TrimSpace(input.ContentHash)
+	input.DisplayName = strings.TrimSpace(input.DisplayName)
+	input.MediaType = strings.TrimSpace(input.MediaType)
+	return input
+}

--- a/packages/agent/store-sqlite/reply_resources_test.go
+++ b/packages/agent/store-sqlite/reply_resources_test.go
@@ -1,0 +1,89 @@
+package storesqlite
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestReplyResourceBindsToActiveTurnAndDeduplicates(t *testing.T) {
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	seedTurnTestSession(t, store, "ws-1", "session-1")
+	if _, accepted, err := store.RecordTurnTransition(ctx, TurnTransition{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1",
+		Phase: TurnPhaseRunning, OccurredAtUnixMS: 1,
+	}); err != nil || !accepted {
+		t.Fatalf("record running turn accepted=%v error=%v", accepted, err)
+	}
+
+	input := AttachReplyResourceInput{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1", ResourceID: "resource-1",
+		DedupeKey: "sha256:abc", Kind: ReplyResourceKindLocalFile, SourceRef: "sha256_abc",
+		ContentHash: "abc", DisplayName: "chart.png", MediaType: "image/png", SizeBytes: 42, CreatedAtUnixMS: 2,
+	}
+	first, created, err := store.AttachReplyResourceToActiveTurn(ctx, input)
+	if err != nil || !created {
+		t.Fatalf("first attach resource=%#v created=%v error=%v", first, created, err)
+	}
+	input.ResourceID = "resource-duplicate"
+	duplicate, created, err := store.AttachReplyResourceToActiveTurn(ctx, input)
+	if err != nil || created {
+		t.Fatalf("duplicate attach resource=%#v created=%v error=%v", duplicate, created, err)
+	}
+	if duplicate.ResourceID != "resource-1" || duplicate.TurnID != "turn-1" {
+		t.Fatalf("deduplicated resource = %#v", duplicate)
+	}
+
+	resources, err := store.ListTurnReplyResources(ctx, "ws-1", "session-1", "turn-1")
+	if err != nil || len(resources) != 1 || resources[0].ResourceID != "resource-1" {
+		t.Fatalf("turn resources = %#v, error=%v", resources, err)
+	}
+}
+
+func TestReplyResourceRejectsAfterTurnSettlement(t *testing.T) {
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	seedTurnTestSession(t, store, "ws-1", "session-1")
+	for _, transition := range []TurnTransition{
+		{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1", Phase: TurnPhaseRunning, OccurredAtUnixMS: 1},
+		{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1", Phase: TurnPhaseSettled, Outcome: TurnOutcomeCompleted, OccurredAtUnixMS: 2},
+	} {
+		if _, accepted, err := store.RecordTurnTransition(ctx, transition); err != nil || !accepted {
+			t.Fatalf("record transition %#v accepted=%v error=%v", transition, accepted, err)
+		}
+	}
+
+	_, _, err := store.AttachReplyResourceToActiveTurn(ctx, AttachReplyResourceInput{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1", ResourceID: "late",
+		DedupeKey: "sha256:late", Kind: ReplyResourceKindLocalFile, SourceRef: "sha256_late",
+		DisplayName: "late.txt", CreatedAtUnixMS: 3,
+	})
+	if !errors.Is(err, ErrNoActiveTurn) {
+		t.Fatalf("late attach error = %v, want %v", err, ErrNoActiveTurn)
+	}
+}
+
+func TestReplyResourceRejectsStaleTurnAfterNextTurnStarts(t *testing.T) {
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	seedTurnTestSession(t, store, "ws-1", "session-1")
+	for _, transition := range []TurnTransition{
+		{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1", Phase: TurnPhaseRunning, OccurredAtUnixMS: 1},
+		{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1", Phase: TurnPhaseSettled, Outcome: TurnOutcomeCompleted, OccurredAtUnixMS: 2},
+		{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-2", Phase: TurnPhaseRunning, OccurredAtUnixMS: 3},
+	} {
+		if _, accepted, err := store.RecordTurnTransition(ctx, transition); err != nil || !accepted {
+			t.Fatalf("record transition %#v accepted=%v error=%v", transition, accepted, err)
+		}
+	}
+
+	_, _, err := store.AttachReplyResourceToActiveTurn(ctx, AttachReplyResourceInput{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1", ResourceID: "stale",
+		DedupeKey: "sha256:stale", Kind: ReplyResourceKindLocalFile, SourceRef: "sha256_stale",
+		DisplayName: "stale.txt", CreatedAtUnixMS: 4,
+	})
+	if !errors.Is(err, ErrNoActiveTurn) {
+		t.Fatalf("stale turn attach error = %v, want %v", err, ErrNoActiveTurn)
+	}
+}

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -8,9 +8,12 @@ package storesqlite
 
 import (
 	"context"
+	"errors"
 
 	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 )
+
+var ErrNoActiveTurn = errors.New("workspace agent session has no active turn")
 
 // Repository is the public persistence contract for agent activity.
 // All methods are scoped by a host-defined workspace ID.
@@ -53,6 +56,13 @@ type Repository interface {
 	UpdateSessionPinned(context.Context, string, string, bool) (Session, bool, error)
 	UpdateSessionSettings(context.Context, string, string, string, map[string]any) (Session, bool, error)
 	UpdateSessionTitle(context.Context, string, string, string) (Session, bool, error)
+}
+
+// ReplyResourceRepository is kept narrow so read-only/custom activity
+// repositories are not forced to implement reply composition durability.
+type ReplyResourceRepository interface {
+	AttachReplyResourceToActiveTurn(context.Context, AttachReplyResourceInput) (ReplyResource, bool, error)
+	ListTurnReplyResources(context.Context, string, string, string) ([]ReplyResource, error)
 }
 
 // SessionTurnSummaryReader is a narrow optional read seam for consumers that
@@ -366,6 +376,46 @@ type Turn struct {
 	RootProviderTurnCompletedCommandKind   string
 	RootProviderTurnCompletedCommandStatus string
 	RootProviderTurnUpdatedAtUnixMS        int64
+}
+
+const (
+	ReplyResourceKindLocalFile        = "local_file"
+	ReplyResourceKindExternalArtifact = "external_artifact"
+)
+
+// AttachReplyResourceInput contains only an immutable resource reference. The
+// host adapter snapshots mutable file bytes before entering this canonical
+// transaction; the absolute source path never becomes canonical state.
+type AttachReplyResourceInput struct {
+	WorkspaceID     string
+	AgentSessionID  string
+	TurnID          string
+	ResourceID      string
+	DedupeKey       string
+	Kind            string
+	SourceRef       string
+	ContentHash     string
+	DisplayName     string
+	MediaType       string
+	SizeBytes       int64
+	CreatedAtUnixMS int64
+}
+
+// ReplyResource is a turn-scoped declaration of an immutable resource that
+// may be selected by the final assistant reply. Registration never sends it.
+type ReplyResource struct {
+	WorkspaceID     string
+	AgentSessionID  string
+	TurnID          string
+	ResourceID      string
+	DedupeKey       string
+	Kind            string
+	SourceRef       string
+	ContentHash     string
+	DisplayName     string
+	MediaType       string
+	SizeBytes       int64
+	CreatedAtUnixMS int64
 }
 
 // SessionTurnCursor is the stable position immediately before a descending

--- a/services/tuttid/data/workspace/agent_store.go
+++ b/services/tuttid/data/workspace/agent_store.go
@@ -223,6 +223,14 @@ func (s *SQLiteStore) GetTurn(ctx context.Context, workspaceID string, agentSess
 	return s.agentReadStore().GetTurn(ctx, workspaceID, agentSessionID, turnID)
 }
 
+func (s *SQLiteStore) AttachReplyResourceToActiveTurn(ctx context.Context, input agentstore.AttachReplyResourceInput) (agentstore.ReplyResource, bool, error) {
+	return s.agentStore().AttachReplyResourceToActiveTurn(ctx, input)
+}
+
+func (s *SQLiteStore) ListTurnReplyResources(ctx context.Context, workspaceID string, agentSessionID string, turnID string) ([]agentstore.ReplyResource, error) {
+	return s.agentReadStore().ListTurnReplyResources(ctx, workspaceID, agentSessionID, turnID)
+}
+
 func (s *SQLiteStore) GetLatestTurn(ctx context.Context, workspaceID string, agentSessionID string) (agentactivitybiz.Turn, bool, error) {
 	return s.agentReadStore().GetLatestTurn(ctx, workspaceID, agentSessionID)
 }

--- a/services/tuttid/service/agent/host_adapters.go
+++ b/services/tuttid/service/agent/host_adapters.go
@@ -475,7 +475,8 @@ func newApplicationHost(s *Service, worktreeGC agenthost.WorktreeGarbageCollecto
 		GoalOwner: s.GoalOperationOwner, GoalClock: serviceHostGoalClock{service: s},
 		GoalAttemptTimeout: s.GoalOperationAttemptTimeout, GoalRecoveryBudget: s.GoalOperationRecoveryBudget,
 		GoalMaxAttempts: s.GoalOperationMaxAttempts, GoalDispatchDeadline: s.GoalOperationDispatchDeadline,
-		GoalActor: agenthost.NewGoalActor(),
+		GoalActor:      agenthost.NewGoalActor(),
+		ReplyResources: s.ReplyResourceStore,
 	})
 }
 

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -27,6 +27,7 @@ type Service struct {
 	SessionInitializer             SessionInitializer
 	SessionReader                  SessionReader
 	SessionPurgeStore              agenthost.SessionPurgeStore
+	ReplyResourceStore             agenthost.ReplyResourceStore
 	AgentSessionResourceReleaser   AgentSessionResourceReleaser
 	UserProjectReader              UserProjectReader
 	MessageReader                  MessageReader

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -439,6 +439,11 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 		return tuttiapi.DaemonAPI{}, nil, nil, nil, fmt.Errorf("agent session purge store is unavailable")
 	}
 	agentSessionService.SessionPurgeStore = agentSessionPurgeStore
+	replyResourceStore, ok := agentActivityRepo.(agenthost.ReplyResourceStore)
+	if !ok {
+		return tuttiapi.DaemonAPI{}, nil, nil, nil, fmt.Errorf("agent reply resource store is unavailable")
+	}
+	agentSessionService.ReplyResourceStore = replyResourceStore
 	agentSessionService.UserProjectReader = userProjectService
 	agentSessionService.MessageReader = agentActivityProjection
 	agentSessionService.ExternalImportStore = agentActivityRepo


### PR DESCRIPTION
## Summary

Agent-generated or discovered files need a durable declaration tied to the exact canonical turn. Without that fence, a slow file snapshot can be registered after settlement or leak into a later turn, and provider-specific runtimes have no standard way to expose the registration tool.

This change adds a narrow reply-resource capability to Agent Host and `store-sqlite`:

- persist immutable local/external resource declarations under `workspace + session + turn`;
- atomically require the requested turn to still be the session's active turn;
- deduplicate registrations by a turn-scoped key and list them for final reply composition;
- expose Host APIs and a conformance scenario for active-turn attach, dedupe, settled-turn rejection, and stale-turn rejection;
- wire the production tuttid SQLite adapter;
- project the managed MCP attachment into Claude SDK `mcpServers` (Codex already consumes the same managed attachment contract).

Related rollout PRs:

- tutti-lab/tsh#1865
- tutti-lab/tsh-server#458

## Verification

- `packages/agent/store-sqlite/reply_resources_test.go` proves active-turn binding, dedupe, post-settlement rejection, and rejection when a newer turn has started.
- `packages/agent/host/conformance/reply_resource_scenarios.go` exercises the lifecycle contract through the public Host API.
- `packages/agent/claude-sdk-sidecar/src/managedMCP.test.ts` proves trusted stdio MCP projection and malformed-input fail-closed behavior.
- The push-ready changed check passed all 19 selected lanes.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source (not applicable; no translated counterpart exists for the edited Host README section).
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
