### PR TITLE
fix(agent-gui): suppress empty handoff tooltip

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/quickPrompts/AgentQuickPromptRow.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/quickPrompts/AgentQuickPromptRow.tsx
@@ -72,6 +72,7 @@ export function AgentQuickPromptRow({
                   aria-label={labels.dragHandle(prompt.title)}
                   className="cursor-grab text-[var(--text-tertiary)] hover:text-[var(--text-primary)] focus-visible:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:text-[var(--text-disabled)] disabled:opacity-100"
                   size="md"
+                  title=""
                 >
                   <GripVerticalIcon />
                 </BareIconButton>
@@ -115,6 +116,7 @@ export function AgentQuickPromptRow({
                 className={`mt-1.5 ${actionRevealClass}`}
                 disabled={pending}
                 size="md"
+                title=""
               >
                 <EditIcon />
               </BareIconButton>
@@ -129,6 +131,7 @@ export function AgentQuickPromptRow({
                 className={`mt-1.5 ${actionRevealClass}`}
                 disabled={pending}
                 size="md"
+                title=""
               >
                 <DeleteIcon />
               </BareIconButton>

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailSectionHeader.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailSectionHeader.tsx
@@ -162,6 +162,7 @@ const CreateAction = memo(function CreateAction({
       className={styles.conversationSectionMoreButton}
       aria-label={createConversationLabel}
       size="sm"
+      title=""
       disabled={createConversationDisabled}
       onClick={onCreateConversation}
     >
@@ -222,6 +223,7 @@ const ProjectMenuButton = forwardRef<HTMLButtonElement, ProjectMenuButtonProps>(
         className={styles.conversationSectionMoreButton}
         aria-label={accessibleName}
         size="sm"
+        title=""
         disabled={projectActionLocked || disabled}
       >
         <MoreHorizontalIcon aria-hidden="true" />
@@ -385,6 +387,7 @@ function ConversationMenuTrigger({
             className={styles.conversationSectionMoreButton}
             aria-label={accessibleName}
             size="sm"
+            title=""
           >
             <MoreHorizontalIcon aria-hidden="true" />
           </BareIconButton>
@@ -402,6 +405,7 @@ function ConversationMenuTrigger({
               className={styles.conversationSectionMoreButton}
               aria-label={accessibleName}
               size="sm"
+              title=""
             >
               <MoreHorizontalIcon aria-hidden="true" />
             </BareIconButton>

--- a/packages/ui/system/src/components/bare-icon-button/bare-icon-button.spec.tsx
+++ b/packages/ui/system/src/components/bare-icon-button/bare-icon-button.spec.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BareIconButton } from "./bare-icon-button";
+
+describe("BareIconButton", () => {
+  it("uses its accessible name as the default hover title", () => {
+    render(
+      <BareIconButton aria-label="Edit password">
+        <span aria-hidden="true">E</span>
+      </BareIconButton>
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Edit password" })
+    ).toHaveAttribute("title", "Edit password");
+  });
+
+  it("keeps an explicitly supplied hover title", () => {
+    render(
+      <BareIconButton aria-label="Remove member" title="Remove Ada">
+        <span aria-hidden="true">R</span>
+      </BareIconButton>
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Remove member" })
+    ).toHaveAttribute("title", "Remove Ada");
+  });
+});

--- a/packages/ui/system/src/components/bare-icon-button/bare-icon-button.spec.tsx
+++ b/packages/ui/system/src/components/bare-icon-button/bare-icon-button.spec.tsx
@@ -27,4 +27,17 @@ describe("BareIconButton", () => {
       screen.getByRole("button", { name: "Remove member" })
     ).toHaveAttribute("title", "Remove Ada");
   });
+
+  it("suppresses native hover title when title is empty", () => {
+    render(
+      <BareIconButton aria-label="Edit prompt" title="">
+        <span aria-hidden="true">E</span>
+      </BareIconButton>
+    );
+
+    expect(screen.getByRole("button", { name: "Edit prompt" })).toHaveAttribute(
+      "title",
+      ""
+    );
+  });
 });

--- a/packages/ui/system/src/components/bare-icon-button/bare-icon-button.tsx
+++ b/packages/ui/system/src/components/bare-icon-button/bare-icon-button.tsx
@@ -35,7 +35,15 @@ type BareIconButtonProps = Omit<
 
 const BareIconButton = React.forwardRef<HTMLButtonElement, BareIconButtonProps>(
   (
-    { className, size = "md", asChild = false, type = "button", ...props },
+    {
+      className,
+      size = "md",
+      asChild = false,
+      type = "button",
+      title,
+      "aria-label": ariaLabel,
+      ...props
+    },
     ref
   ) => {
     const Comp = asChild ? Slot.Root : "button";
@@ -46,6 +54,8 @@ const BareIconButton = React.forwardRef<HTMLButtonElement, BareIconButtonProps>(
         data-slot="bare-icon-button"
         data-size={size}
         type={type}
+        aria-label={ariaLabel}
+        title={title ?? ariaLabel}
         className={cn(bareIconButtonVariants({ size, className }))}
         {...props}
       />


### PR DESCRIPTION
## Summary
- Refactor AgentHandoffMenu so handoff actions no longer render empty hover tooltips
- Default BareIconButton hover `title` from `aria-label` when no explicit title is supplied, with regression tests

## Test plan
- [x] `pnpm check:changed -- --push-ready`
- [x] BareIconButton unit tests for default and explicit title behavior
- [ ] Manual: hover agent handoff icon buttons and confirm tooltips show accessible names


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->