### PR TITLE
fix(agent-gui): float provider rail selected stroke 1px outside icon container

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -9493,6 +9493,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   color: var(--text-tertiary);
   transition:
     border-color 140ms ease,
+    outline-color 140ms ease,
     background-color 140ms ease,
     color 140ms ease,
     opacity 140ms ease,
@@ -9504,11 +9505,12 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   opacity: 0.38;
 }
 
-/* "Beta" tag straddling the selected icon's bottom border: its centerline sits
-   on the selected-state stroke, horizontally centered on the icon. */
+/* "Beta" tag straddling the selected icon's stroke: its centerline sits on
+   the avatar's outer edge (the stroke is centered there with a -1px
+   outline offset), horizontally centered on the icon. */
 .agent-gui-node__provider-rail-beta-badge {
   position: absolute;
-  top: calc(100% - 1px);
+  top: 100%;
   left: 50%;
   transform: translate(-50%, -50%);
   z-index: 2;
@@ -9527,11 +9529,15 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   color: var(--text-primary);
 }
 
+/* Selected stroke floats 1px outside the 28px icon container: a 2px outline
+   centered on the avatar's outer edge (-1px offset) leaves exactly 1px of
+   transparent gap between the container and the stroke's inner edge. */
 .agent-gui-node__provider-rail-tile[data-selected="true"]
   .agent-gui-node__provider-rail-avatar {
-  border-color: var(--brand-primary, var(--tutti-purple));
+  border-color: transparent;
   background: color-mix(in srgb, var(--background-fronted) 80%, white);
-  box-shadow: 0 0 0 1px color-mix(in srgb, white 45%, transparent);
+  outline: 2px solid var(--brand-primary, var(--tutti-purple));
+  outline-offset: -1px;
   color: var(--brand-primary, var(--tutti-purple));
 }
 


### PR DESCRIPTION
## Motivation

In the AgentGUI provider rail, the selected tile drew its stroke as the avatar's own border, so the stroke sat flush against the 28px icon container. Design calls for a 1px transparent gap between the selected stroke and the icon container.

## Changes

(`packages/agent/gui/app/renderer/agentactivity.css` only)

- Selected state now renders the stroke as `outline: 2px solid` with `outline-offset: -1px`, centering it on the avatar's outer edge — exactly 1px of transparent gap between the icon container and the stroke's inner edge
- `outline-color` added to the avatar transition so selection changes fade smoothly
- The 1px white outer halo (box-shadow) was removed: it overlapped the new stroke position
- Beta badge centerline moved from `calc(100% - 1px)` to `100%` to match the relocated stroke; comment updated

The stroke extends 1px beyond the 32px avatar box; the 52px tile leaves 10px of slack on each side, so layout is unaffected.

## Validation

- UI-only presentation change; no logic or behavior impact
- `pre-commit` staged checks (prettier, UI/renderer boundary, agent-gui degradation): passed
- `pnpm check:changed -- --push-ready`: 8 lanes passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->