### PR TITLE
fix(agent-gui): lock shared capability controls

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -454,6 +454,12 @@ Workspace picker results and internal workspace-reference drags remain live refe
 | `renderSlots`      | narrow product-neutral presentation slots |
 
 Do not restore flat compatibility props or hide workflow inside a render slot.
+Hosts that render capabilities owned by another device set
+`hostCapabilities.capabilityControlsReadOnly`; AgentGUI keeps owner-supported
+Browser/Computer entries visible but disables their mutation and setup actions.
+Unsupported capabilities remain absent according to the authoritative composer
+capability descriptor. A caller host must not open its local device settings as
+a fallback for a remote owner.
 Host chrome that aligns to AgentGUI's internal layout must consume explicit
 package signals such as `hostActions.onConversationRailLayoutChange`; it must
 not observe package DOM, CSS variables, or class names with

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -125,6 +125,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     onDraftContentChange,
     onSettingsChange,
     capabilityMenuState,
+    capabilityControlsReadOnly = false,
     onSubmit,
     onSubmitGuidance,
     onInterruptCurrentTurn,
@@ -240,6 +241,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     compactSupported,
     composerSettings,
     capabilityMenuState,
+    capabilityControlsReadOnly,
     labels,
     uiLanguage,
     editorHandleRef
@@ -363,6 +365,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     promptImagesSupported: canUploadAttachment && promptImagesSupported,
     availableSkills,
     composerSettings,
+    capabilityControlsReadOnly,
     onDraftContentChange,
     onSettingsChange,
     onSubmit,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -106,6 +106,7 @@ export const AgentGUINode = memo(function AgentGUINode({
   } = runtimeRequests;
   const {
     capabilityMenuState,
+    capabilityControlsReadOnly = false,
     accountMenuState = null,
     agentTargets,
     agentTargetsLoading = false,
@@ -493,6 +494,7 @@ export const AgentGUINode = memo(function AgentGUINode({
               onLinkAction={handleLinkAction}
               onHandoffConversation={onHandoffConversation}
               capabilityMenuState={capabilityMenuState}
+              capabilityControlsReadOnly={capabilityControlsReadOnly}
               onCapabilitySettingsRequest={onCapabilitySettingsRequest}
               onAgentProviderLogin={
                 onAgentProviderLogin ? handleAgentProviderLogin : undefined

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
@@ -122,6 +122,11 @@ export interface AgentGUINodeHostCapabilities {
   /** Legacy Tutti Agent-only opt-in. Prefer an explicit catalog in new hosts. */
   referenceProvenanceFilterEnabled?: boolean;
   capabilityMenuState?: AgentComposerCapabilityMenuState;
+  /**
+   * Keeps owner-supported Browser/Computer capability entries visible while
+   * preventing this host from mutating device-owned capability settings.
+   */
+  capabilityControlsReadOnly?: boolean;
   accountMenuState?: AgentGUIAccountMenuState | null;
   agentTargets?: readonly AgentGUIAgentTarget[];
   agentTargetsLoading?: boolean;
@@ -364,6 +369,7 @@ export function areAgentGUINodePropsEqual(
     pr.prefillPrompt === nr.prefillPrompt &&
     pr.agentStatusController === nr.agentStatusController &&
     pc.capabilityMenuState === nc.capabilityMenuState &&
+    pc.capabilityControlsReadOnly === nc.capabilityControlsReadOnly &&
     pc.accountMenuState === nc.accountMenuState &&
     pc.agentTargets === nc.agentTargets &&
     pc.agentTargetsLoading === nc.agentTargetsLoading &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -90,6 +90,7 @@ export function AgentGUINodeView({
   onLinkAction,
   onHandoffConversation,
   capabilityMenuState,
+  capabilityControlsReadOnly = false,
   onCapabilitySettingsRequest,
   isActive = true,
   isVisible = true,
@@ -737,6 +738,7 @@ export function AgentGUINodeView({
               onLinkAction={onLinkAction}
               onHandoffConversation={onHandoffConversation}
               capabilityMenuState={capabilityMenuState}
+              capabilityControlsReadOnly={capabilityControlsReadOnly}
               onCapabilitySettingsRequest={onCapabilitySettingsRequest}
               onAgentProviderLogin={onAgentProviderLogin}
               onRequestWorkspaceReferences={requestWorkspaceReferences}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashCommandPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashCommandPalette.spec.tsx
@@ -356,6 +356,52 @@ describe("AgentSlashCommandPalette", () => {
     });
   });
 
+  it("keeps a read-only capability visible without dispatching mutations", () => {
+    const onSelectCapability = vi.fn();
+    const onSelectCapabilitySettings = vi.fn();
+
+    render(
+      <AgentSlashCommandPalette
+        label="Slash commands"
+        commandsGroupLabel="Commands"
+        capabilitiesGroupLabel="Capabilities"
+        skillsGroupLabel="Skills"
+        pluginsGroupLabel="Plugins"
+        connectorsGroupLabel="Connectors"
+        mcpGroupLabel="MCP"
+        highlightedIndex={0}
+        entries={[
+          {
+            type: "capability",
+            key: "capability:computerUse",
+            label: "Computer",
+            disabled: true,
+            settingsAriaLabel: "Computer use setup",
+            settingsLabel: "Settings",
+            capability: {
+              kind: "capability",
+              capability: "computerUse",
+              name: "computer"
+            }
+          }
+        ]}
+        onHighlightChange={vi.fn()}
+        onSelect={vi.fn()}
+        onSelectCapability={onSelectCapability}
+        onSelectCapabilitySettings={onSelectCapabilitySettings}
+        onSelectSkill={vi.fn()}
+      />
+    );
+
+    const capability = screen.getByRole("option", { name: /computer/i });
+    expect(capability).toHaveAttribute("aria-disabled", "true");
+    capability.click();
+    screen.getByRole("button", { name: "Computer use setup" }).click();
+
+    expect(onSelectCapability).not.toHaveBeenCalled();
+    expect(onSelectCapabilitySettings).not.toHaveBeenCalled();
+  });
+
   it("separates plugin and connector skill entries into source groups", () => {
     render(
       <AgentSlashCommandPalette

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashCommandPalette.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashCommandPalette.tsx
@@ -32,6 +32,7 @@ export type AgentSlashPaletteEntry =
       description?: string;
       settingsAriaLabel?: string;
       settingsLabel?: string;
+      disabled?: boolean;
       selectAction?: "capability" | "settings";
       capability: AgentSlashCommandCapability;
     }
@@ -166,6 +167,8 @@ export function AgentSlashCommandPalette({
     <div className={paletteStyles.palette} role="listbox" aria-label={label}>
       {entries.map((entry, index) => {
         const isHighlighted = index === highlightedIndex;
+        const isDisabled =
+          entry.type === "capability" && entry.disabled === true;
         const groupType = entryGroupType(entry);
         const entryIcon = slashPaletteEntryIcon(entry);
         const groupHeader =
@@ -199,14 +202,20 @@ export function AgentSlashCommandPalette({
               ref={isHighlighted ? highlightedOptionRef : null}
               className={cn(
                 paletteStyles.option,
-                isHighlighted && "bg-[var(--transparency-block)]"
+                isHighlighted && "bg-[var(--transparency-block)]",
+                isDisabled &&
+                  "cursor-not-allowed text-[var(--agent-gui-text-tertiary)] opacity-60 hover:bg-transparent active:bg-transparent"
               )}
               role="option"
               aria-selected={isHighlighted}
+              aria-disabled={isDisabled || undefined}
               data-highlighted={isHighlighted ? "" : undefined}
               onMouseEnter={() => onHighlightChange(index)}
               onMouseDown={(event) => event.preventDefault()}
               onClick={() => {
+                if (isDisabled) {
+                  return;
+                }
                 if (entry.type === "command") {
                   onSelect(entry.command);
                   return;
@@ -252,6 +261,7 @@ export function AgentSlashCommandPalette({
                 <button
                   aria-label={entry.settingsAriaLabel ?? entry.settingsLabel}
                   className={paletteStyles.settingsButton}
+                  disabled={isDisabled}
                   title={entry.settingsAriaLabel ?? entry.settingsLabel}
                   type="button"
                   onClick={(event) => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -289,6 +289,7 @@ export interface AgentComposerProps {
     permissionModeId?: string | null;
   }) => void;
   capabilityMenuState?: AgentComposerCapabilityMenuState;
+  capabilityControlsReadOnly?: boolean;
   onCapabilitySettingsRequest?: (
     capability: AgentComposerCapabilitySettingsTarget
   ) => void;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.ts
@@ -47,6 +47,7 @@ interface UseComposerPaletteCatalogInput {
   compactSupported: boolean | null;
   composerSettings: AgentGUIComposerSettingsVM;
   capabilityMenuState?: AgentComposerCapabilityMenuState;
+  capabilityControlsReadOnly: boolean;
   labels: AgentComposerProps["labels"];
   uiLanguage: UiLanguage;
   editorHandleRef: RefObject<AgentRichTextEditorHandle | null>;
@@ -69,6 +70,7 @@ export function useComposerPaletteCatalog({
   compactSupported,
   composerSettings,
   capabilityMenuState,
+  capabilityControlsReadOnly,
   labels,
   uiLanguage,
   editorHandleRef
@@ -127,6 +129,9 @@ export function useComposerPaletteCatalog({
     [availableSkills, skillQueryMatch]
   );
   const availableCapabilities = useMemo<AgentCapabilityTokenOption[]>(() => {
+    if (capabilityControlsReadOnly) {
+      return [];
+    }
     const entries: AgentCapabilityTokenOption[] = [];
     if (composerSettings.supportsBrowser) {
       entries.push({
@@ -146,6 +151,7 @@ export function useComposerPaletteCatalog({
     }
     return entries;
   }, [
+    capabilityControlsReadOnly,
     composerSettings.supportsBrowser,
     composerSettings.supportsComputerUse,
     labels.browserUseCapabilityLabel,
@@ -190,6 +196,7 @@ export function useComposerPaletteCatalog({
             description: capDescription,
             settingsAriaLabel: capSettingsLabel,
             settingsLabel: labels.capabilityInlineSettingsLabel,
+            disabled: capabilityControlsReadOnly,
             selectAction:
               command.capability === "computerUse" &&
               (computerUseInstalled === false ||
@@ -235,6 +242,7 @@ export function useComposerPaletteCatalog({
     capabilityMenuState?.browserUse?.connectionMode,
     capabilityMenuState?.computerUse?.authorization,
     capabilityMenuState?.computerUse?.installed,
+    capabilityControlsReadOnly,
     filteredCommands,
     filteredSkills,
     labels.browserUseCapabilityDescription,

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashActions.ts
@@ -62,6 +62,7 @@ type Props = Pick<
   | "promptImagesSupported"
   | "availableSkills"
   | "composerSettings"
+  | "capabilityControlsReadOnly"
   | "onDraftContentChange"
   | "onSettingsChange"
   | "onSubmit"
@@ -121,6 +122,7 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
     promptImagesSupported,
     availableSkills = [],
     composerSettings,
+    capabilityControlsReadOnly = false,
     onDraftContentChange,
     onSettingsChange,
     onSubmit,
@@ -368,6 +370,9 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
 
   const selectCapability = useCallback(
     (capability: AgentSlashCommandCapability): void => {
+      if (capabilityControlsReadOnly) {
+        return;
+      }
       const selectionEffect = resolveSlashCommandSelectionEffect({
         provider,
         policy: slashCommandPolicy,
@@ -378,15 +383,23 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
         executeSlashCommandEffect(selectionEffect);
       }
     },
-    [executeSlashCommandEffect, provider, slashCommandPolicy]
+    [
+      capabilityControlsReadOnly,
+      executeSlashCommandEffect,
+      provider,
+      slashCommandPolicy
+    ]
   );
 
   const selectCapabilitySettings = useCallback(
     (capability: AgentSlashCommandCapability): void => {
+      if (capabilityControlsReadOnly) {
+        return;
+      }
       onCapabilitySettingsRequest?.(capability.capability);
       setIsPaletteOpen(false);
     },
-    [onCapabilitySettingsRequest]
+    [capabilityControlsReadOnly, onCapabilitySettingsRequest]
   );
 
   const selectSkill = useCallback(
@@ -476,6 +489,16 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
           policy: slashCommandPolicy
         });
         if (slashCommandEffect) {
+          if (
+            capabilityControlsReadOnly &&
+            slashCommandEffect.kind === "submitPrompt" &&
+            (slashCommandEffect.requiredSettingsPatch?.browserUse !==
+              undefined ||
+              slashCommandEffect.requiredSettingsPatch?.computerUse !==
+                undefined)
+          ) {
+            return;
+          }
           executeSlashCommandEffect(slashCommandEffect);
           return;
         }
@@ -570,6 +593,9 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
       if (event.key === "Tab" || event.key === "Enter") {
         event.preventDefault();
         const activeEntry = slashPaletteEntries[activeHighlight];
+        if (activeEntry?.type === "capability" && activeEntry.disabled) {
+          return true;
+        }
         if (activeEntry?.type === "command") {
           selectCommand(activeEntry.command);
         } else if (activeEntry?.type === "capability") {

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -90,6 +90,7 @@ export interface AgentGUIDetailPaneProps {
   onLinkAction?: (action: WorkspaceLinkAction) => void;
   onHandoffConversation?: AgentGUINodeViewProps["onHandoffConversation"];
   capabilityMenuState?: AgentComposerProps["capabilityMenuState"];
+  capabilityControlsReadOnly?: AgentComposerProps["capabilityControlsReadOnly"];
   onCapabilitySettingsRequest?: AgentComposerProps["onCapabilitySettingsRequest"];
   onAgentProviderLogin?: (provider?: string | null) => void;
   onRequestWorkspaceReferences?:
@@ -176,6 +177,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
   onLinkAction,
   onHandoffConversation,
   capabilityMenuState,
+  capabilityControlsReadOnly = false,
   onCapabilitySettingsRequest,
   onAgentProviderLogin,
   onRequestWorkspaceReferences,
@@ -479,6 +481,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       labels: composerLabels,
       workspaceUserProjectI18n,
       capabilityMenuState,
+      capabilityControlsReadOnly,
       onDraftContentChange: updateDraftContent,
       onProjectPathChange: updateSelectedProjectPath,
       onSettingsChange: updateComposerSettings,
@@ -503,6 +506,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     [
       canQueueWhileBusy,
       capabilityMenuState,
+      capabilityControlsReadOnly,
       canSwitchComposerProvider,
       composerDisabled,
       composerDisabledReason,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -506,6 +506,7 @@ export interface AgentGUINodeViewProps {
     userProjectPath?: string | null;
   }) => void | Promise<void>;
   capabilityMenuState?: AgentComposerProps["capabilityMenuState"];
+  capabilityControlsReadOnly?: AgentComposerProps["capabilityControlsReadOnly"];
   onCapabilitySettingsRequest?: AgentComposerProps["onCapabilitySettingsRequest"];
   isActive?: boolean;
   isVisible?: boolean;


### PR DESCRIPTION
## Summary

- add an opt-in `capabilityControlsReadOnly` AgentGUI host capability
- keep owner-supported Browser and Computer slash entries visible while disabling selection, setup, keyboard, pasted-token, and direct-command mutation paths
- keep unsupported capabilities absent through the authoritative composer capability descriptor
- document that remote-owner hosts must not fall back to caller-local device settings

Shared Agent GUI renders another owner device. Its browser connection and Computer Use installation or authorization cannot be safely configured through caller-local settings. This preserves capability discovery without pretending those device-owned controls can be proxied.

## Risks and affected surfaces

- affects AgentGUI composer capability entries only when a host explicitly opts into read-only controls
- local/default hosts retain the existing behavior
- adds a public package contract that must be released before the TSH consumer change can land

## Verification

- `corepack pnpm --filter @tutti-os/agent-gui test -- AgentSlashCommandPalette.spec.tsx` — 242 files, 2072 tests passed
- `corepack pnpm check:changed` — 11 lanes passed
- `corepack pnpm check:changed -- --failed-only` — npm pack lane passed after the local main checkout finished updating
- pre-push `corepack pnpm check:changed -- --push-ready` — 12 lanes passed
- TSH consumer targeted test — 1 file, 3 tests passed against the locally linked package

## Checklist

- [x] This PR does not change agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated the durable AgentGUI architecture documentation.
- [x] README and CONTRIBUTING language variants are unaffected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->