### PR TITLE
fix(agent-gui): stabilize empty composer identity and layout

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -308,6 +308,8 @@ When runtime sections are enabled, projection unions IDs from the current sectio
 
 Scroll, section collapse, visible limits, and search query belong to mounted view scope. Non-search state is isolated by `workspaceId + agentTargetId/all`; search creates a temporary navigation scope. `activeConversationId` expresses selection only. Scrolling requires an explicit reveal intent.
 
+Rail scroll memory is captured by scroll events and explicit navigation. Effect cleanup must not synchronously read `scrollTop`: React may already have dirtied the document, turning that read into a full layout inside the interaction task.
+
 Contain selection and presentation identity at the Rail boundary. Each section receives the active ID only when it owns the canonical or overlay row; unrelated sections receive `null` so their memoized props remain equal. Rail pane, section, and row receive a dedicated Rail-label projection whose identity changes for locale changes, not provider-specific detail copy. Event handlers shared by every section keep stable identities and read the current scope and lock state when invoked.
 
 Keep section header/action chrome independent from changing item collections. A memoized header receives scalar presentation fields and stable event-time actions; it must not receive the section object or rebuild project/session semantics. Split the header into narrow render islands. Frequently changing derived booleans such as project drag disabled, project action locked, and batch deletion disabled may cross the Section presentation boundary through separate primitive Context projections. The Rail pane owns those providers outside the memoized Section so a projection-only update does not execute item projection; only the frame, forwarded-ref button leaf, or open menu content that renders the value may consume it. Do not combine those values into one Context object or copy them into persistent state. Menu disclosure is view-local state: keep each Radix root and trigger mounted for focus and keyboard behavior, but instantiate portaled content only while that menu is open. A closed menu has no availability-state consumer. The project header remains the native drag source, each project section updates the insertion position across its full area, and the Rail scroll viewport owns the final drop so section gaps cannot discard an already visible insertion target. This is a presentation boundary, not a second Rail or lifecycle store; stable event-time guards remain authoritative for action delivery.
@@ -427,6 +429,10 @@ durable default only while that intent is unresolved. Entering the unscoped
 conversation section resolves the intent to no project, so remounting the hero
 composer or refreshing the project list cannot restore a previous project.
 
+The empty-home carousel may measure its placeholder synchronously when live
+alignment first activates. Later React updates coalesce alignment into the next
+animation frame; ResizeObserver and MutationObserver keep layout roots current.
+
 Composer text transactions may publish the current draft, but the draft value
 must not drive synchronous pre-paint geometry reads. The dock observes the
 actual editor, input area, and attachment containers; its initial and
@@ -490,6 +496,10 @@ client-local until the user explicitly saves them through the CRUD capability.
 AgentGUI, Message Center, dock/header, workspace window, and standalone Agent window consume the same workspace engine.
 
 Opening a panel/window creates presentation state only. It does not clone a Session, copy engine entities, or start another event stream. Standalone tools are Desktop chrome, not AgentGUI lifecycle.
+
+The shared Workbench Header owns conversation-identity visibility. When no
+Conversation exists, it ignores conversation titles, Agent titles, primary
+icons, and fallback icons even if a host supplies them.
 
 The reusable standalone-tool sidebar contract lives in `packages/agent/gui/workbench/tool-sidebar`. Hosts provide the supported panel catalog and render adapters; the shared component owns tab selection, picker, sizing, toolbar mechanics, and the boundary between draggable header space and interactive controls. Native Electron hosts keep the default native-window drag mode, while embedded Workbench hosts select host drag mode and provide their pointer and double-click handlers. The shared component disables native app-region handling in host mode so one header never has two competing drag owners.
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyHeroCarouselStage.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyHeroCarouselStage.spec.tsx
@@ -25,7 +25,11 @@ const items: readonly AgentGUIAgentAvatarPresentation[] = [
   }
 ];
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe("AgentGUIEmptyHeroCarouselStage", () => {
   it("keeps CSS fallback alignment in preview mode", () => {
@@ -70,5 +74,39 @@ describe("AgentGUIEmptyHeroCarouselStage", () => {
     expect(
       layer?.style.getPropertyValue("--agent-gui-hero-carousel-slot-left")
     ).toBe("0px");
+  });
+
+  it("defers alignment measurement after the selected provider updates", () => {
+    const requestFrame = vi.fn(() => 1);
+    vi.stubGlobal("requestAnimationFrame", requestFrame);
+    const getBoundingClientRect = vi.spyOn(
+      HTMLElement.prototype,
+      "getBoundingClientRect"
+    );
+    const view = render(
+      <AgentGUIEmptyHeroCarouselStage
+        activeAgentTargetId="codex"
+        items={items}
+        previewMode={false}
+        providerSelectLabel="Select provider"
+      >
+        <div data-carousel-placeholder />
+      </AgentGUIEmptyHeroCarouselStage>
+    );
+    getBoundingClientRect.mockClear();
+
+    view.rerender(
+      <AgentGUIEmptyHeroCarouselStage
+        activeAgentTargetId="claude"
+        items={items}
+        previewMode={false}
+        providerSelectLabel="Select provider"
+      >
+        <div data-carousel-placeholder />
+      </AgentGUIEmptyHeroCarouselStage>
+    );
+
+    expect(getBoundingClientRect).not.toHaveBeenCalled();
+    expect(requestFrame).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyHeroCarouselStage.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyHeroCarouselStage.tsx
@@ -16,6 +16,7 @@ interface AgentGUIEmptyHeroCarouselStageProps {
 // Keep the carousel outside the ready/readiness-gate branch. Runtime
 // readiness changes must not replace the WebGL canvas or reset its position.
 export class AgentGUIEmptyHeroCarouselStage extends Component<AgentGUIEmptyHeroCarouselStageProps> {
+  private alignmentActive = false;
   private animationFrame: number | null = null;
   private layer: HTMLDivElement | null = null;
   private mutationObserver: MutationObserver | null = null;
@@ -27,7 +28,15 @@ export class AgentGUIEmptyHeroCarouselStage extends Component<AgentGUIEmptyHeroC
   }
 
   componentDidUpdate(): void {
-    this.startAlignment();
+    if (!this.canAlign()) {
+      this.stopAlignment();
+      return;
+    }
+    if (!this.alignmentActive) {
+      this.startAlignment();
+      return;
+    }
+    this.scheduleAlignment();
   }
 
   componentWillUnmount(): void {
@@ -66,16 +75,13 @@ export class AgentGUIEmptyHeroCarouselStage extends Component<AgentGUIEmptyHeroC
   // while measuring the slot preserves alignment across host padding and
   // ready/gated subtree changes. The CSS fallback covers the pre-measure paint.
   private startAlignment(): void {
-    if (
-      this.props.previewMode ||
-      this.props.items.length <= 1 ||
-      !this.stage ||
-      !this.layer
-    ) {
+    const stage = this.stage;
+    if (!this.canAlign() || !stage) {
       this.stopAlignment();
       return;
     }
 
+    this.alignmentActive = true;
     if (!this.resizeObserver && typeof ResizeObserver === "function") {
       this.resizeObserver = new ResizeObserver(this.scheduleAlignment);
     }
@@ -84,7 +90,7 @@ export class AgentGUIEmptyHeroCarouselStage extends Component<AgentGUIEmptyHeroC
         this.observeLayoutRoots();
         this.scheduleAlignment();
       });
-      this.mutationObserver.observe(this.stage, {
+      this.mutationObserver.observe(stage, {
         childList: true,
         subtree: true
       });
@@ -93,7 +99,17 @@ export class AgentGUIEmptyHeroCarouselStage extends Component<AgentGUIEmptyHeroC
     this.syncAlignment();
   }
 
+  private canAlign(): boolean {
+    return Boolean(
+      !this.props.previewMode &&
+      this.props.items.length > 1 &&
+      this.stage &&
+      this.layer
+    );
+  }
+
   private stopAlignment(): void {
+    this.alignmentActive = false;
     if (this.animationFrame !== null) {
       cancelAnimationFrame(this.animationFrame);
       this.animationFrame = null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIConversationRailViewState.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIConversationRailViewState.spec.tsx
@@ -165,6 +165,44 @@ describe("useAgentGUIConversationRailViewState", () => {
     expect(scrollIntoView).not.toHaveBeenCalled();
   });
 
+  it("does not read scroll geometry while replacing a settled navigation effect", () => {
+    const view = render(
+      <Harness
+        activeConversationId={null}
+        contentReady
+        identity="list-1"
+        itemIds={[]}
+        scopeKey="codex"
+      />
+    );
+    const viewport = screen.getByTestId("viewport");
+    let scrollTop = 240;
+    const readScrollTop = vi.fn(() => scrollTop);
+    Object.defineProperty(viewport, "scrollTop", {
+      configurable: true,
+      get: readScrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      }
+    });
+
+    fireEvent.scroll(viewport);
+    expect(readScrollTop).toHaveBeenCalledTimes(1);
+    readScrollTop.mockClear();
+
+    view.rerender(
+      <Harness
+        activeConversationId="session-1"
+        contentReady
+        identity="list-1"
+        itemIds={["session-1"]}
+        scopeKey="codex"
+      />
+    );
+
+    expect(readScrollTop).not.toHaveBeenCalled();
+  });
+
   it("reveals only an explicit navigation request within a settled target", () => {
     const view = render(
       <Harness

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIConversationRailViewState.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIConversationRailViewState.ts
@@ -142,7 +142,6 @@ export function useAgentGUIConversationRailViewState(
       recordScrollTop();
     }
     return () => {
-      recordScrollTop();
       viewport.removeEventListener("scroll", recordScrollTop);
     };
   }, [

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -294,15 +294,10 @@ export function createAgentGuiWorkbenchContribution(
             : (conversationIdentity?.title ??
               input.resolveDockPopupTitle?.(workbenchState) ??
               null);
-          // The empty new-conversation home has no session identity, so it
-          // must not inherit the provider icon from the workbench instance.
-          // Once a local session id exists, keep the provider icon available
-          // while the canonical conversation title is still being persisted.
           const hasConversation = Boolean(
             workbenchState.lastActiveAgentSessionId?.trim()
           );
-          const conversationIconFallbackUrl =
-            hasConversation && selectedAgent ? selectedAgent.iconUrl : null;
+          const conversationIconFallbackUrl = selectedAgent?.iconUrl ?? null;
           const conversationIconUrl =
             conversationIdentity?.iconUrl ?? conversationIconFallbackUrl;
           const persistConversationRailCollapsed = (collapsed: boolean) => {

--- a/packages/agent/gui/workbench/header.spec.tsx
+++ b/packages/agent/gui/workbench/header.spec.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentGuiWorkbenchHeader } from "./header";
+
+afterEach(cleanup);
+
+describe("AgentGuiWorkbenchHeader conversation identity", () => {
+  it.each([false, true])(
+    "hides conversation identity without a conversation when collapsed is %s",
+    (isConversationRailCollapsed) => {
+      render(
+        <AgentGuiWorkbenchHeader
+          agentTitle="Leaked agent"
+          conversationIconFallbackUrl="fallback-agent.png"
+          conversationIconUrl="conversation-agent.png"
+          conversationTitle="Leaked conversation"
+          conversationTitleDisplayPrompt="Leaked rich conversation"
+          copy={{
+            collapseConversationRail: "Collapse",
+            expandConversationRail: "Expand",
+            fallbackAgentLabel: "Agent",
+            newConversation: "New conversation",
+            untitledConversation: "Untitled conversation"
+          }}
+          hasConversation={false}
+          isConversationRailAutoCollapsed={false}
+          isConversationRailCollapsed={isConversationRailCollapsed}
+          nodeId="empty-agent-gui"
+          secondaryAccessory={<span>Session-independent accessory</span>}
+          showConversationRailToggle={false}
+          showWindowControls={false}
+          onToggleConversationRail={vi.fn()}
+        />
+      );
+
+      expect(screen.queryByText("Leaked agent")).toBeNull();
+      expect(screen.queryByText("Leaked conversation")).toBeNull();
+      expect(screen.queryByText("Leaked rich conversation")).toBeNull();
+      expect(screen.queryByTestId("agent-gui-window-detail-title")).toBeNull();
+      expect(
+        document.querySelector(
+          '[data-testid^="agent-gui-window-detail-title-icon"]'
+        )
+      ).toBeNull();
+      expect(
+        document.querySelector('[data-testid^="agent-gui-window-session-icon"]')
+      ).toBeNull();
+      expect(screen.getByText("Session-independent accessory")).toBeTruthy();
+    }
+  );
+});

--- a/packages/agent/gui/workbench/header.ts
+++ b/packages/agent/gui/workbench/header.ts
@@ -130,17 +130,26 @@ export function AgentGuiWorkbenchHeader({
     ? copy.expandConversationRail
     : copy.collapseConversationRail;
   const appTitle = _title?.trim() || copy.fallbackAgentLabel;
-  const sessionTitle = hasBodyRenderError
-    ? ""
-    : conversationTitle?.trim() ||
-      (hasConversation ? copy.untitledConversation?.trim() : "") ||
-      "";
-  const sessionTitleDisplayPrompt = hasBodyRenderError
-    ? ""
-    : conversationTitleDisplayPrompt?.trim() || "";
-  const collapsedTitle = sessionTitle || agentTitle?.trim() || "";
-  const sessionIconUrl = conversationIconUrl?.trim() || "";
-  const sessionIconFallbackUrl = conversationIconFallbackUrl?.trim() || "";
+  // Conversation identity belongs to an actual or pending Session. Keep this
+  // invariant at the shared Header boundary so hosts may pass fallback
+  // presentation without recreating the empty-home visibility rule.
+  const sessionTitle =
+    !hasConversation || hasBodyRenderError
+      ? ""
+      : conversationTitle?.trim() || copy.untitledConversation?.trim() || "";
+  const sessionTitleDisplayPrompt =
+    !hasConversation || hasBodyRenderError
+      ? ""
+      : conversationTitleDisplayPrompt?.trim() || "";
+  const collapsedTitle = hasConversation
+    ? sessionTitle || agentTitle?.trim() || ""
+    : "";
+  const sessionIconUrl = hasConversation
+    ? conversationIconUrl?.trim() || ""
+    : "";
+  const sessionIconFallbackUrl = hasConversation
+    ? conversationIconFallbackUrl?.trim() || ""
+    : "";
   const hasExpandedIdentity = Boolean(
     collapsedTitle || sessionIconUrl || sessionIconFallbackUrl
   );


### PR DESCRIPTION
## Summary
- make the shared Workbench Header hide all conversation identity when no Conversation exists
- remove the Rail layout read from effect cleanup and defer repeated empty-home carousel alignment to the next frame
- add regression coverage and document the shared identity and layout ownership rules

## Tests
- `pnpm check:changed -- --push-ready` — passed 12 lanes
- `pnpm perf:agent-gui -- --scenario provider-switch` — scenario passed; report-only and ungraded

## Notes
- Manual Electron traces confirmed the removed `recordScrollTop` hotspot no longer receives CPU samples.
- The trace comparison was not a controlled benchmark because the interaction mixes differed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->