### PR TITLE
refactor(workspace-files): remove preview compatibility exports

### DIFF
--- a/apps/desktop/src/main/host/workspaceFileEntryIcon.ts
+++ b/apps/desktop/src/main/host/workspaceFileEntryIcon.ts
@@ -1,9 +1,7 @@
 import { stat } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
-import {
-  resolveWorkspaceFileDefaultApplicationIconExtension,
-  resolveWorkspaceFileVisualKind
-} from "@tutti-os/workspace-file-manager/services";
+import { resolveWorkspaceFileDefaultApplicationIconExtension } from "@tutti-os/workspace-file-manager/services";
+import { resolveWorkspaceFileVisualKind } from "@tutti-os/workspace-file-preview";
 import { requestWorkerIconPngBytes } from "./iconWorker/iconWorkerClient.ts";
 import {
   readApplicationIconDataUrl,

--- a/apps/desktop/src/main/host/workspaceFileHostAccess.test.ts
+++ b/apps/desktop/src/main/host/workspaceFileHostAccess.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { pathToFileURL } from "node:url";
-import { workspaceFilePreviewMaxBytes } from "@tutti-os/workspace-file-manager/services";
+import { workspaceFilePreviewMaxBytes } from "@tutti-os/workspace-file-preview";
 import { desktopErrorCodes } from "../../shared/errors/desktopErrors.ts";
 import { createWorkspaceFileHostAccess } from "./workspaceFileHostAccess.ts";
 

--- a/apps/desktop/src/main/host/workspaceFileHostAccess.ts
+++ b/apps/desktop/src/main/host/workspaceFileHostAccess.ts
@@ -3,7 +3,7 @@ import { mkdir, readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import path, { basename } from "node:path";
 import { pathToFileURL } from "node:url";
-import { workspaceFilePreviewMaxBytes } from "@tutti-os/workspace-file-manager/services";
+import { workspaceFilePreviewMaxBytes } from "@tutti-os/workspace-file-preview";
 import { desktopErrorCodes } from "../../shared/errors/desktopErrors.ts";
 import type {
   DesktopCreateUserDocumentsProjectDirectoryInput,

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.ts
@@ -1,6 +1,5 @@
 import {
   createWorkspaceFileManagerService,
-  resolveWorkspaceFileExtension,
   type WorkspaceFileExternalLocation,
   type WorkspaceFileEntry,
   type WorkspaceFileLocationSection,
@@ -9,6 +8,7 @@ import {
   type WorkspaceFileManagerMutationErrorMessage,
   type WorkspaceFileManagerPersistedState
 } from "@tutti-os/workspace-file-manager/services";
+import { resolveWorkspaceFileExtension } from "@tutti-os/workspace-file-preview";
 import {
   createReferenceSourceAggregator,
   createStaticReferenceSourceRegistry,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationActionsMenu.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationActionsMenu.tsx
@@ -27,7 +27,7 @@ import {
   DropdownMenuTrigger
 } from "@tutti-os/ui-system";
 import { BareIconButton } from "@tutti-os/ui-system/components";
-import { resolveWorkspaceImageMimeType } from "@tutti-os/workspace-file-manager/services";
+import { resolveWorkspaceImageMimeType } from "@tutti-os/workspace-file-preview";
 import { useOptionalAgentHostApi } from "../../../agentActivityHost";
 import { useOptionalAgentActivityRuntime } from "../../../agentActivityRuntime";
 import type { UiLanguage } from "../../../contexts/settings/domain/agentSettings";

--- a/packages/agent/gui/package.json
+++ b/packages/agent/gui/package.json
@@ -67,6 +67,7 @@
     "@tutti-os/workbench-surface": "workspace:*",
     "@tutti-os/workspace-external-core": "workspace:*",
     "@tutti-os/workspace-file-manager": "workspace:*",
+    "@tutti-os/workspace-file-preview": "workspace:*",
     "@tutti-os/workspace-file-reference": "workspace:*",
     "@tutti-os/workspace-issue-manager": "workspace:*",
     "@tutti-os/workspace-user-project": "workspace:*",

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -16,10 +16,8 @@ import rehypeSanitize, {
   type Options as RehypeSanitizeOptions
 } from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
-import {
-  resolveWorkspaceFileExtension,
-  workspaceFileName as basenameWorkspacePath
-} from "@tutti-os/workspace-file-manager/services";
+import { workspaceFileName as basenameWorkspacePath } from "@tutti-os/workspace-file-manager/services";
+import { resolveWorkspaceFileExtension } from "@tutti-os/workspace-file-preview";
 import { MentionPill } from "@tutti-os/ui-system/components";
 import { useResolvedRichTextMention } from "@tutti-os/ui-rich-text/editor";
 import {

--- a/packages/agent/gui/shared/agentConversation/components/AgentGeneratedImagePreview.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentGeneratedImagePreview.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type JSX } from "react";
-import { resolveWorkspaceImageMimeType } from "@tutti-os/workspace-file-manager/services";
+import { resolveWorkspaceImageMimeType } from "@tutti-os/workspace-file-preview";
 import { useOptionalAgentHostApi } from "../../../agentActivityHost";
 import { ZoomableImage } from "../../../app/renderer/components/ZoomableImage";
 import {

--- a/packages/agent/gui/shared/agentMessageMarkdownLinks.ts
+++ b/packages/agent/gui/shared/agentMessageMarkdownLinks.ts
@@ -2,7 +2,7 @@ import { defaultUrlTransform } from "react-markdown";
 import {
   resolveWorkspaceImageMimeType,
   resolveWorkspaceVideoMimeType
-} from "@tutti-os/workspace-file-manager/services";
+} from "@tutti-os/workspace-file-preview";
 import {
   isRichTextMentionHref,
   parseRichTextMentionHref

--- a/packages/agent/gui/shared/workspaceFileVisualKind.ts
+++ b/packages/agent/gui/shared/workspaceFileVisualKind.ts
@@ -1,10 +1,10 @@
 import {
-  resolveWorkspaceFileVisualKind as resolveWorkspaceFileManagerVisualKind,
-  type WorkspaceFileVisualKind as WorkspaceFileManagerVisualKind
-} from "@tutti-os/workspace-file-manager/services";
+  resolveWorkspaceFileVisualKind,
+  type WorkspaceFileVisualKind
+} from "@tutti-os/workspace-file-preview";
 
 export type AgentWorkspaceFileVisualKind =
-  | Exclude<WorkspaceFileManagerVisualKind, "directory">
+  | Exclude<WorkspaceFileVisualKind, "directory">
   | "folder";
 
 export function resolveAgentWorkspaceFileVisualKind(
@@ -12,7 +12,7 @@ export function resolveAgentWorkspaceFileVisualKind(
   options: { refType?: string } = {}
 ): AgentWorkspaceFileVisualKind {
   const refType = options.refType;
-  const kind = resolveWorkspaceFileManagerVisualKind({
+  const kind = resolveWorkspaceFileVisualKind({
     kind:
       refType === "folder" || refType === "directory" ? "directory" : "file",
     name: pathOrName,

--- a/packages/workspace/file-manager/README.md
+++ b/packages/workspace/file-manager/README.md
@@ -18,11 +18,12 @@ only a transport-agnostic data kernel. Shared session orchestration, preview
 flow, upload flow, activation flow, and React-facing interaction state may live
 here when they are part of the reusable file-manager experience across hosts.
 
-The shared surface owns host-neutral file preview classification,
-activation-target shaping, shared view-model derivation, and the host contract
-needed to drive those flows so different hosts can integrate primarily by
-implementing `WorkspaceFileManagerHost` instead of rebuilding workflow around
-the shared UI.
+The shared surface consumes host-neutral classification and loading lifecycle
+from `@tutti-os/workspace-file-preview`. This package owns file-manager-specific
+activation-target shaping, localized state projection, shared view-model
+derivation, and the host contract needed to drive those flows so different
+hosts can integrate primarily by implementing `WorkspaceFileManagerHost`
+instead of rebuilding workflow around the shared UI.
 
 The optional React surface persists the adjustable locations-sidebar and
 details-panel widths on the current device. Restored widths are clamped to the

--- a/packages/workspace/file-manager/src/index.ts
+++ b/packages/workspace/file-manager/src/index.ts
@@ -16,18 +16,7 @@ export type {
   WorkspaceFileManagerHost,
   WorkspaceFileManagerMutationErrorMessage
 } from "./services/workspaceFileManagerHost.interface.ts";
-export {
-  classifyWorkspaceFilePreviewKind,
-  decodeWorkspaceTextFile,
-  isWorkspaceTextFileTooLarge,
-  looksLikeBinaryText,
-  resolveWorkspaceFileActivationTarget,
-  resolveWorkspaceFileExtension,
-  resolveWorkspaceImageMimeType,
-  resolveWorkspaceVideoMimeType,
-  workspaceFilePreviewMaxBytes,
-  workspaceFileTextMaxBytes
-} from "./services/workspaceFileManagerModel.ts";
+export { resolveWorkspaceFileActivationTarget } from "./services/workspaceFileManagerModel.ts";
 export {
   findWorkspaceFileLocationById,
   flattenWorkspaceFileLocations,

--- a/packages/workspace/file-manager/src/services/index.ts
+++ b/packages/workspace/file-manager/src/services/index.ts
@@ -40,21 +40,7 @@ export {
   shouldUseWorkspaceFileArchiveIcon,
   shouldUseWorkspaceFileExtensionDocumentIcon
 } from "./workspaceFileEntryIconPolicy.ts";
-export {
-  classifyWorkspaceFilePreviewKind,
-  decodeWorkspaceTextFile,
-  isWorkspaceFileBrowserOpenable,
-  isWorkspaceTextFileTooLarge,
-  looksLikeBinaryText,
-  resolveWorkspaceFileActivationTarget,
-  resolveWorkspaceFileExtension,
-  resolveWorkspaceFileVisualKind,
-  resolveWorkspaceImageMimeType,
-  resolveWorkspaceVideoMimeType,
-  workspaceFilePreviewMaxBytes,
-  workspaceFileTextMaxBytes,
-  type WorkspaceFileVisualKind
-} from "./workspaceFileManagerModel.ts";
+export { resolveWorkspaceFileActivationTarget } from "./workspaceFileManagerModel.ts";
 export {
   findWorkspaceFileLocationById,
   flattenWorkspaceFileLocations,

--- a/packages/workspace/file-manager/src/services/internal/model/fileKinds.ts
+++ b/packages/workspace/file-manager/src/services/internal/model/fileKinds.ts
@@ -1,39 +1,8 @@
-import {
-  classifyWorkspaceFilePreviewKind as classifySharedWorkspaceFilePreviewKind,
-  resolveWorkspaceFileActivationTarget as resolveSharedWorkspaceFileActivationTarget,
-  resolveWorkspaceFilePreviewReadiness as resolveSharedWorkspaceFilePreviewReadiness
-} from "@tutti-os/workspace-file-preview";
-import type {
-  WorkspaceFilePreviewLoadedState,
-  WorkspaceFilePreviewReadonlyReason
-} from "@tutti-os/workspace-file-preview";
+import { resolveWorkspaceFileActivationTarget as resolveSharedWorkspaceFileActivationTarget } from "@tutti-os/workspace-file-preview";
 import type {
   WorkspaceFileActivationTarget,
-  WorkspaceFileEntry,
-  WorkspaceFilePreviewKind
+  WorkspaceFileEntry
 } from "../../workspaceFileManagerTypes.ts";
-
-export {
-  decodeWorkspaceTextFile,
-  formatWorkspacePreviewByteLimit,
-  isWorkspaceFileBrowserOpenable,
-  isWorkspacePreviewFileTooLarge,
-  isWorkspaceTextFileTooLarge,
-  looksLikeBinaryText,
-  resolveWorkspaceFileExtension,
-  resolveWorkspaceFileVisualKind,
-  resolveWorkspaceImageMimeType,
-  resolveWorkspaceVideoMimeType,
-  workspaceFilePreviewMaxBytes,
-  workspaceFileTextMaxBytes
-} from "@tutti-os/workspace-file-preview";
-export type { WorkspaceFileVisualKind } from "@tutti-os/workspace-file-preview";
-
-export function classifyWorkspaceFilePreviewKind(
-  entry: WorkspaceFileEntry
-): WorkspaceFilePreviewKind | null {
-  return classifySharedWorkspaceFilePreviewKind(entry);
-}
 
 export function resolveWorkspaceFileActivationTarget(
   entry: WorkspaceFileEntry
@@ -51,47 +20,3 @@ export function resolveWorkspaceFileActivationTarget(
     sizeBytes: target.sizeBytes ?? null
   };
 }
-
-export type WorkspaceFilePreviewReadiness =
-  | { entry: WorkspaceFileEntry; status: "directory" }
-  | {
-      entry: WorkspaceFileEntry;
-      maxSizeBytes: number;
-      reason: Extract<
-        WorkspaceFilePreviewReadonlyReason,
-        "file_too_large" | "text_too_large"
-      >;
-      status: "readonly";
-    }
-  | { entry: WorkspaceFileEntry; status: "unsupported" }
-  | {
-      entry: WorkspaceFileEntry;
-      status: "ready";
-      target: WorkspaceFileActivationTarget;
-    };
-
-export function resolveWorkspaceFilePreviewReadiness(
-  entry: WorkspaceFileEntry
-): WorkspaceFilePreviewReadiness {
-  const readiness = resolveSharedWorkspaceFilePreviewReadiness(entry);
-  if (readiness.status !== "ready") {
-    return readiness;
-  }
-
-  return {
-    entry,
-    status: "ready",
-    target: {
-      fileKind: readiness.target.fileKind,
-      mtimeMs: readiness.target.mtimeMs ?? null,
-      name: readiness.target.name,
-      path: readiness.target.path,
-      sizeBytes: readiness.target.sizeBytes ?? null
-    }
-  };
-}
-
-export type WorkspaceFilePreviewLoadedResult = WorkspaceFilePreviewLoadedState<
-  WorkspaceFileEntry,
-  WorkspaceFileActivationTarget
->;

--- a/packages/workspace/file-manager/src/services/internal/workspaceFileManagerPreviewController.ts
+++ b/packages/workspace/file-manager/src/services/internal/workspaceFileManagerPreviewController.ts
@@ -1,14 +1,12 @@
 import {
   createWorkspaceFilePreviewController,
+  formatWorkspacePreviewByteLimit,
+  workspaceFilePreviewMaxBytes,
   type WorkspaceFilePreviewController,
   type WorkspaceFilePreviewControllerState,
   type WorkspaceFilePreviewReadonlyReason
 } from "@tutti-os/workspace-file-preview";
-import {
-  formatWorkspacePreviewByteLimit,
-  resolveWorkspaceFileActivationTarget,
-  workspaceFilePreviewMaxBytes
-} from "../workspaceFileManagerModel.ts";
+import { resolveWorkspaceFileActivationTarget } from "../workspaceFileManagerModel.ts";
 import type { WorkspaceFileManagerI18nRuntime } from "../../i18n/workspaceFileManagerI18n.ts";
 import type { WorkspaceFileManagerHost } from "../workspaceFileManagerHost.interface.ts";
 import type {

--- a/packages/workspace/file-manager/src/services/workspaceFileEntryIconPolicy.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileEntryIconPolicy.ts
@@ -2,7 +2,7 @@ import {
   classifyWorkspaceFilePreviewKind,
   resolveWorkspaceFileExtension,
   resolveWorkspaceFileVisualKind
-} from "./workspaceFileManagerModel.ts";
+} from "@tutti-os/workspace-file-preview";
 import type { WorkspaceFileEntry } from "./workspaceFileManagerTypes.ts";
 
 const defaultApplicationIconExtensions = new Set([

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerModel.test.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerModel.test.ts
@@ -1,20 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  classifyWorkspaceFilePreviewKind,
-  decodeWorkspaceTextFile,
   filterVisibleWorkspaceEntries,
   formatWorkspaceFileModifiedTime,
-  isWorkspaceTextFileTooLarge,
-  looksLikeBinaryText,
   normalizeWorkspaceFilePath,
   resolveWorkspaceFileActivationTarget,
-  resolveWorkspaceImageMimeType,
   sortWorkspaceEntries,
   validateWorkspaceFileEntryName,
   workspaceFileDirectory,
-  workspaceFilePathHasHiddenSegment,
-  workspaceFileTextMaxBytes
+  workspaceFilePathHasHiddenSegment
 } from "./workspaceFileManagerModel.ts";
 import type { WorkspaceFileEntry } from "./workspaceFileManagerTypes.ts";
 
@@ -150,7 +144,6 @@ test("resolves previewable files into activation targets", () => {
   const markdownEntry = entry("README.md", "file");
   markdownEntry.sizeBytes = 128;
 
-  assert.equal(classifyWorkspaceFilePreviewKind(markdownEntry), "text");
   assert.deepEqual(resolveWorkspaceFileActivationTarget(markdownEntry), {
     fileKind: "text",
     mtimeMs: null,
@@ -159,24 +152,8 @@ test("resolves previewable files into activation targets", () => {
     sizeBytes: 128
   });
 
-  const imageEntry = entry("hero.png", "file");
-  assert.equal(classifyWorkspaceFilePreviewKind(imageEntry), "image");
-  assert.equal(resolveWorkspaceImageMimeType(imageEntry.name), "image/png");
-
   const archiveEntry = entry("archive.zip", "file");
-  assert.equal(classifyWorkspaceFilePreviewKind(archiveEntry), null);
   assert.equal(resolveWorkspaceFileActivationTarget(archiveEntry), null);
-});
-
-test("exposes conservative text preview safety helpers", () => {
-  assert.equal(isWorkspaceTextFileTooLarge(workspaceFileTextMaxBytes), false);
-  assert.equal(
-    isWorkspaceTextFileTooLarge(workspaceFileTextMaxBytes + 1),
-    true
-  );
-  assert.equal(decodeWorkspaceTextFile(new Uint8Array([0x68, 0x69])), "hi");
-  assert.equal(looksLikeBinaryText("plain text"), false);
-  assert.equal(looksLikeBinaryText("a\u0000b"), true);
 });
 
 function entry(

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerModel.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerModel.ts
@@ -1,23 +1,4 @@
-export {
-  classifyWorkspaceFilePreviewKind,
-  decodeWorkspaceTextFile,
-  formatWorkspacePreviewByteLimit,
-  isWorkspaceFileBrowserOpenable,
-  isWorkspacePreviewFileTooLarge,
-  isWorkspaceTextFileTooLarge,
-  looksLikeBinaryText,
-  resolveWorkspaceFileActivationTarget,
-  resolveWorkspaceFileExtension,
-  resolveWorkspaceFilePreviewReadiness,
-  resolveWorkspaceFileVisualKind,
-  resolveWorkspaceImageMimeType,
-  resolveWorkspaceVideoMimeType,
-  type WorkspaceFilePreviewLoadedResult,
-  type WorkspaceFilePreviewReadiness,
-  type WorkspaceFileVisualKind,
-  workspaceFilePreviewMaxBytes,
-  workspaceFileTextMaxBytes
-} from "./internal/model/fileKinds.ts";
+export { resolveWorkspaceFileActivationTarget } from "./internal/model/fileKinds.ts";
 export {
   formatWorkspaceFileBytes,
   formatWorkspaceFileModifiedTime,

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileEntryIcon.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileEntryIcon.tsx
@@ -10,7 +10,7 @@ import { useEffect, useRef } from "react";
 import {
   resolveWorkspaceFileExtension,
   resolveWorkspaceFileVisualKind
-} from "../services/workspaceFileManagerModel.ts";
+} from "@tutti-os/workspace-file-preview";
 import type { WorkspaceFileEntry } from "../services/workspaceFileManagerTypes.ts";
 import {
   workspaceArchiveFallbackIconUrl,

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenuContainer.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenuContainer.tsx
@@ -6,7 +6,7 @@ import {
   type WorkspaceFileManagerI18nRuntime
 } from "../i18n/workspaceFileManagerI18n.ts";
 import type { WorkspaceFileOpenWithApplication } from "../services/workspaceFileManagerTypes.ts";
-import { isWorkspaceFileBrowserOpenable } from "../services/index.ts";
+import { isWorkspaceFileBrowserOpenable } from "@tutti-os/workspace-file-preview";
 import { WorkspaceFileManagerContextMenu } from "./WorkspaceFileManagerContextMenu.tsx";
 import { useWorkspaceFileManagerContextMenuView } from "./useWorkspaceFileManagerService.ts";
 

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx
@@ -8,6 +8,7 @@ import {
   cn
 } from "@tutti-os/ui-system";
 import type { TuttiDateLocale } from "@tutti-os/ui-system/date-format";
+import { resolveWorkspaceFileVisualKind } from "@tutti-os/workspace-file-preview";
 import { WorkspaceFilePreviewSurface as SharedWorkspaceFilePreviewSurface } from "@tutti-os/workspace-file-preview/react";
 import type { WorkspaceFileManagerI18nRuntime } from "../i18n/workspaceFileManagerI18n.ts";
 import type {
@@ -30,7 +31,6 @@ import {
 import {
   formatWorkspaceFileBytes,
   formatWorkspaceFileModifiedTime,
-  resolveWorkspaceFileVisualKind,
   splitWorkspaceFileName
 } from "../services/workspaceFileManagerModel.ts";
 import type {

--- a/packages/workspace/file-manager/src/ui/workspaceFileManagerArrangeMode.ts
+++ b/packages/workspace/file-manager/src/ui/workspaceFileManagerArrangeMode.ts
@@ -1,7 +1,7 @@
 import {
   resolveWorkspaceFileExtension,
   resolveWorkspaceFileVisualKind
-} from "../services/workspaceFileManagerModel.ts";
+} from "@tutti-os/workspace-file-preview";
 import type { WorkspaceFileEntry } from "../services/workspaceFileManagerTypes.ts";
 
 export type WorkspaceFileManagerArrangeMode =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,9 @@ importers:
       "@tutti-os/workspace-file-manager":
         specifier: workspace:*
         version: link:../../workspace/file-manager
+      "@tutti-os/workspace-file-preview":
+        specifier: workspace:*
+        version: link:../../workspace/file-preview
       "@tutti-os/workspace-file-reference":
         specifier: workspace:*
         version: link:../../workspace/file-reference


### PR DESCRIPTION
## Summary

- migrate AgentGUI, Desktop, and workspace file-manager consumers to import preview classification, MIME, visual-kind, extension, and size helpers directly from `@tutti-os/workspace-file-preview`
- remove the deprecated forwarding exports and wrapper types from `@tutti-os/workspace-file-manager`
- delete duplicate file-manager tests now owned by the shared preview package
- document the file-manager/preview ownership boundary and add the direct AgentGUI workspace dependency

## Why

The unified preview package introduced in #1505 is now the single owner of generic file preview semantics. Keeping compatibility exports in the file-manager package preserved multiple public entry points and allowed new consumers to continue depending on the wrong owner.

This follow-up narrows the file-manager API to its manager-specific activation-target adapter while preserving current behavior.

## Impact

No user-visible behavior changes are intended. This is API cleanup inside the monorepo and reduces duplicate ownership before further preview work.

## Dependency

This PR is stacked on #1505 because GitHub still reports that PR as open. Once #1505 is merged, this PR can be retargeted to `main`.

## Validation

- `pnpm --filter @tutti-os/workspace-file-manager typecheck`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/workspace-file-manager test` (141 passed)
- `pnpm --filter @tutti-os/agent-gui test` (2086 passed)
- `pnpm --filter @tutti-os/desktop test` (1469 passed, 2 skipped)
- `pnpm --filter @tutti-os/workspace-file-manager build`
- `pnpm --filter @tutti-os/agent-gui build`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:changed` (17 lanes)
- pre-push `pnpm check:changed -- --push-ready` (18 lanes)