### PR TITLE
feat(agent): make goal controls durable and restart-idempotent

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -532,6 +532,12 @@ home composer submit
 ```
 
 Initial-content create is one transaction. Failure compensates the provisional runtime/canonical shell; it must not leave a Turn-less Session.
+An activation may instead carry `initialGoalControl`. In that branch the engine
+and runtime adapter preserve the structured `{action, objective}` command, the
+host integration creates a non-provisional Session without initial content,
+and Goal control completes without manufacturing a Turn. The structured field
+is authoritative; integrations must not reparse the display prompt to recover
+Goal semantics.
 The pending activation carries the same resolved project section key as the
 create command. Exact rail projection therefore shows the conversation as soon
 as the intent is accepted; it does not wait for provider startup or invent a

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
@@ -243,6 +243,7 @@ test("control activation can carry content without expecting a Turn", () => {
   const intent = {
     ...activation(),
     content: [{ type: "text" as const, text: "/goal ship it" }],
+    initialGoalControl: { action: "set" as const, objective: "ship it" },
     initialTurnExpected: false,
     runtimeContent: [{ type: "text" as const, text: "/goal ship it" }]
   };
@@ -260,6 +261,7 @@ test("control activation can carry content without expecting a Turn", () => {
       cwd: "/workspace",
       initialContent: [{ type: "text", text: "/goal ship it" }],
       initialDisplayPrompt: "/browser",
+      initialGoalControl: { action: "set", objective: "ship it" },
       submitDiagnostics: { submittedAtUnixMs: 1 },
       mode: "new",
       settings: { model: "model-1" },

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.ts
@@ -223,6 +223,9 @@ function requestActivation(
     expiresAtUnixMs: intent.expiresAtUnixMs,
     initialTurnExpected:
       intent.initialTurnExpected ?? runtimeContent.length > 0,
+    ...(intent.initialGoalControl
+      ? { initialGoalControl: { ...intent.initialGoalControl } }
+      : {}),
     ...(intent.railSectionKey?.trim()
       ? { railSectionKey: intent.railSectionKey.trim() }
       : {}),
@@ -274,6 +277,9 @@ function requestActivation(
               ? { initialContent: runtimeContent }
               : {}),
             ...(displayPrompt ? { initialDisplayPrompt: displayPrompt } : {}),
+            ...(intent.initialGoalControl
+              ? { initialGoalControl: { ...intent.initialGoalControl } }
+              : {}),
             ...(intent.submitDiagnostics
               ? { submitDiagnostics: { ...intent.submitDiagnostics } }
               : {}),

--- a/packages/agent/activity-core/src/engine/pendingIntents.types.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.types.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentActivityInitialGoalControl,
   AgentActivityMessage,
   AgentActivitySessionSettings,
   AgentActivitySubmitDiagnostics,
@@ -34,6 +35,7 @@ interface PendingActivationIntentRecordBase {
   errorMessage: string | null;
   expiresAtUnixMs: number;
   initialTurnExpected: boolean;
+  initialGoalControl?: Readonly<AgentActivityInitialGoalControl>;
   railSectionKey?: string;
   submitDiagnostics?: Readonly<AgentActivitySubmitDiagnostics>;
   pendingSettingsPatch?: Readonly<Record<string, unknown>>;
@@ -98,6 +100,7 @@ interface SessionActivationRequestedIntentBase {
   cwd?: string;
   expiresAtUnixMs: number;
   initialTurnExpected?: boolean;
+  initialGoalControl?: Readonly<AgentActivityInitialGoalControl>;
   railSectionKey?: string;
   initialDisplayPrompt?: string;
   runtimeContent?: readonly AgentPromptContentBlock[];
@@ -165,6 +168,7 @@ interface SessionActivateCommandBase {
   cwd?: string;
   initialContent?: readonly AgentPromptContentBlock[];
   initialDisplayPrompt?: string;
+  initialGoalControl?: Readonly<AgentActivityInitialGoalControl>;
   submitDiagnostics?: Readonly<AgentActivitySubmitDiagnostics>;
   settings?: AgentActivitySessionSettings;
   timeoutMs?: number;

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -250,6 +250,7 @@ export type {
   AgentActivityDisplayStatus,
   AgentActivityCancelTurnInput,
   AgentActivityGoalControlAction,
+  AgentActivityInitialGoalControl,
   AgentActivityGoalControlInput,
   AgentActivityGoalControlResult,
   AgentActivityComposerCapabilityOption,

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -528,10 +528,16 @@ export type AgentActivityGoalControlAction =
   | "clear"
   | "set";
 
+export interface AgentActivityInitialGoalControl {
+  action: AgentActivityGoalControlAction;
+  objective?: string;
+}
+
 export interface AgentActivityGoalControlInput {
   workspaceId: string;
   agentSessionId: string;
   action: AgentActivityGoalControlAction;
+  clientSubmitId?: string;
   objective?: string;
   signal?: AbortSignal;
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActivation.ts
@@ -1,6 +1,7 @@
 import {
   selectSessionActivationPresentations,
   sessionActivationPresentationMapsEqual,
+  type AgentActivityInitialGoalControl,
   type AgentActivitySubmitDiagnostics,
   type PendingActivationIntentRecord,
   type AgentSessionEngine
@@ -20,6 +21,7 @@ interface AgentGUIActivateInputBase {
   cwd?: string;
   initialContent?: AgentPromptContentBlock[];
   initialTurnExpected?: boolean;
+  initialGoalControl?: AgentActivityInitialGoalControl;
   railSectionKey?: string;
   initialDisplayPrompt?: string;
   runtimeContent?: AgentPromptContentBlock[];
@@ -122,6 +124,9 @@ export function useAgentGUIActivation({
         expiresAtUnixMs: requestedAtUnixMs + ACTIVATION_EXPIRY_MS,
         ...(input.initialTurnExpected !== undefined
           ? { initialTurnExpected: input.initialTurnExpected }
+          : {}),
+        ...(input.initialGoalControl
+          ? { initialGoalControl: { ...input.initialGoalControl } }
           : {}),
         ...(input.railSectionKey?.trim()
           ? { railSectionKey: input.railSectionKey.trim() }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIGoalControlActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIGoalControlActions.ts
@@ -121,6 +121,7 @@ export function useAgentGUIGoalControlActions(
           workspaceId: input.workspaceId,
           agentSessionId,
           action,
+          clientSubmitId: optimisticRequestId,
           ...(objective !== undefined ? { objective } : {})
         })
         .then(() => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
@@ -1,4 +1,5 @@
 import {
+  type AgentActivityInitialGoalControl,
   isPendingActivationViable,
   selectLatestActivationForSession
 } from "@tutti-os/agent-activity-core";
@@ -79,7 +80,8 @@ export function useAgentGUINewConversationActivation(
       initialContentInput?: unknown,
       displayPrompt?: string,
       submitOptions?: AgentComposerSubmitOptions,
-      initialTurnExpected?: boolean
+      initialTurnExpected?: boolean,
+      initialGoalControl?: AgentActivityInitialGoalControl
     ): AgentGUINewConversationActivationResult | null => {
       const target = selectedAgentTargetRef.current;
       const targetData = selectedComposerTargetDataRef.current;
@@ -185,6 +187,7 @@ export function useAgentGUINewConversationActivation(
         ...(railSectionKey ? { railSectionKey } : {}),
         initialContent: normalizedInitialContent,
         ...(initialTurnExpected !== undefined ? { initialTurnExpected } : {}),
+        ...(initialGoalControl ? { initialGoalControl } : {}),
         initialDisplayPrompt,
         runtimeContent: toRuntimeSendContent(normalizedInitialContent),
         submitDiagnostics: agentSubmitTraceDiagnostics(submitTrace),

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts
@@ -234,7 +234,8 @@ describe("goal controls", () => {
       [{ type: "text", text: "/goal count to ten" }],
       undefined,
       undefined,
-      false
+      false,
+      { action: "set", objective: "count to ten" }
     );
     expect(optimisticGoalControlRef.current).toEqual({
       agentSessionId: "session-new",
@@ -359,6 +360,7 @@ describe("goal controls", () => {
     expect(goalControl).toHaveBeenCalledWith({
       action: "clear",
       agentSessionId: "session-1",
+      clientSubmitId: expect.stringMatching(/^goal-control:/),
       workspaceId: "workspace-1"
     });
     expect(setGoalClearNoticeSequence).toHaveBeenCalledTimes(1);

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
@@ -118,7 +118,11 @@ interface UseAgentGUISubmitInteractionActionsInput {
     content: AgentPromptContentBlock[],
     displayPrompt?: string,
     options?: AgentComposerSubmitOptions,
-    initialTurnExpected?: boolean
+    initialTurnExpected?: boolean,
+    initialGoalControl?: {
+      action: AgentActivityGoalControlAction;
+      objective?: string;
+    }
   ): AgentGUINewConversationActivationResult | null;
   submitPromptRef: RefObject<
     (
@@ -528,7 +532,8 @@ export function useAgentGUISubmitInteractionActions(
           normalizedContent,
           displayPromptText,
           options,
-          typedGoal ? false : undefined
+          typedGoal ? false : undefined,
+          typedGoal ?? undefined
         );
         if (activationResult) {
           if (typedGoal) {

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -9,6 +9,7 @@ import type {
   AgentActivityActivateSessionResult,
   AgentActivityGoalControlInput,
   AgentActivityGoalControlResult,
+  AgentActivityInitialGoalControl,
   AgentActivityCreateSessionInput,
   AgentActivityDeleteSessionInput,
   AgentActivityDeleteSessionResult,
@@ -212,11 +213,13 @@ export type AgentActivityRuntimeActivateSessionInput =
   | (AgentActivityRuntimeActivateSessionInputBase & {
       agentTargetId: string;
       clientSubmitId: string;
+      initialGoalControl?: AgentActivityInitialGoalControl;
       mode: "new";
     })
   | (AgentActivityRuntimeActivateSessionInputBase & {
       agentTargetId?: string | null;
       clientSubmitId?: never;
+      initialGoalControl?: never;
       mode: "existing";
     });
 

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -29,7 +29,11 @@ empty; only an explicit title or the first eligible prompt establishes one.
 Cancellation exposes durable intent acceptance, provider confirmation, and
 canonical settlement as separate facts. `GoalControl`, `GetGoalState`, and
 `ReconcileGoal` are provider-neutral Host APIs; typed `/goal` commands enter the
-same durable saga without opening a turn. `Recover` first requeues and recovers
+same durable saga without opening a turn. A caller-stable `ClientSubmitID`
+makes one goal mutation idempotent across retries and Host restarts (and takes
+precedence over the legacy metadata field). `GetGoalState` is a pure canonical
+read: only `GoalControl`, `ReconcileGoal`, and recovery workers may create or
+change the durable goal projection. `Recover` first requeues and recovers
 durable runtime operations, then goal operations and the goal reconcile inbox,
 then settles unrecoverable stale turns, and finally invokes the adapter's
 worktree-isolation sweep. Configuring a goal store

--- a/packages/agent/host/canonical_queries_sqlite_test.go
+++ b/packages/agent/host/canonical_queries_sqlite_test.go
@@ -88,6 +88,44 @@ func TestSessionInteractionSnapshotReadsOnlyLatestTurnFromSQLite(t *testing.T) {
 	}
 }
 
+func TestGetGoalStateDoesNotBootstrapMissingProjection(t *testing.T) {
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "agent-host-goal-read.db"))
+	if err != nil {
+		t.Fatalf("open SQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	store := storesqlite.New(db, storesqlite.Options{})
+	if err := store.Migrate(t.Context()); err != nil {
+		t.Fatalf("migrate SQLite: %v", err)
+	}
+	if _, err := store.ReportSessionState(t.Context(), storesqlite.SessionStateReport{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-goal-read", Provider: "codex", OccurredAtUnixMS: 1,
+	}); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	if _, found, err := store.GetSessionGoalState(t.Context(), "workspace-1", "session-goal-read"); err != nil || found {
+		t.Fatalf("goal before read: found=%v err=%v", found, err)
+	}
+
+	host := agenthost.New(agenthost.Config{
+		CanonicalStore: sqliteCanonicalStore{Store: store},
+		GoalStore:      store,
+	})
+	result, err := host.GetGoalState(t.Context(), agenthost.SessionRef{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-goal-read",
+	})
+	if err != nil {
+		t.Fatalf("GetGoalState() error = %v", err)
+	}
+	if result.State.Revision != 0 || result.State.WorkspaceID != "" {
+		t.Fatalf("GetGoalState() state = %#v, want zero value", result.State)
+	}
+	if _, found, err := store.GetSessionGoalState(t.Context(), "workspace-1", "session-goal-read"); err != nil || found {
+		t.Fatalf("goal after read: found=%v err=%v", found, err)
+	}
+}
+
 func TestListSessionMessagesReadsOneCanonicalTurnPageFromSQLite(t *testing.T) {
 	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "agent-host-messages.db"))
 	if err != nil {

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -18,7 +18,7 @@ func TestPublishedScenarioCatalogsHaveUniqueNames(t *testing.T) {
 		{name: "submission fence", scenarios: SubmissionFenceScenarios(), wantCount: 1},
 		{name: "title policy", scenarios: TitlePolicyScenarios(), wantCount: 1},
 		{name: "coordinator", scenarios: CoordinatorScenarios(), wantCount: 7},
-		{name: "goal", scenarios: GoalScenarios(), wantCount: 5},
+		{name: "goal", scenarios: GoalScenarios(), wantCount: 6},
 		{name: "commit observer", scenarios: CommitObserverScenarios(), wantCount: 2},
 	}
 	for _, catalog := range catalogs {

--- a/packages/agent/host/conformance/goal_scenarios.go
+++ b/packages/agent/host/conformance/goal_scenarios.go
@@ -76,6 +76,29 @@ func runGoalActionLifecycle(ctx context.Context, driver Driver) error {
 	return nil
 }
 
+func runDuplicateGoalClientSubmitID(ctx context.Context, driver Driver) error {
+	if err := driver.Reset(ctx, liveSessionFixture("session-goal-idempotent", "")); err != nil {
+		return err
+	}
+	input := agenthost.GoalControlInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-goal-idempotent",
+		Action: "set", Objective: "ship exactly once", ClientSubmitID: "goal-idempotent-1",
+		SubmissionMetadata: map[string]any{"clientSubmitId": "ignored-legacy-id"},
+	}
+	first, err := driver.GoalControl(ctx, input)
+	if err != nil {
+		return fmt.Errorf("first goal control: %w", err)
+	}
+	second, err := driver.GoalControl(ctx, input)
+	if err != nil {
+		return fmt.Errorf("duplicate goal control: %w", err)
+	}
+	if first.Revision != 1 || second.Revision != first.Revision || driver.Metrics().GoalControlCalls != 1 {
+		return fmt.Errorf("duplicate goal control was not idempotent: first=%#v second=%#v metrics=%#v", first, second, driver.Metrics())
+	}
+	return nil
+}
+
 func runGoalReconcileObservation(ctx context.Context, driver Driver) error {
 	if err := driver.Reset(ctx, liveSessionFixture("session-goal-reconcile", "")); err != nil {
 		return err

--- a/packages/agent/host/conformance/scenarios.go
+++ b/packages/agent/host/conformance/scenarios.go
@@ -84,6 +84,7 @@ func GoalScenarios() []Scenario {
 	return []Scenario{
 		{Name: "direct and typed goal equivalence", run: runDirectAndTypedGoalEquivalence},
 		{Name: "goal action lifecycle", run: runGoalActionLifecycle},
+		{Name: "duplicate goal client submit id", run: runDuplicateGoalClientSubmitID},
 		{Name: "goal reconcile observation", run: runGoalReconcileObservation},
 		{Name: "goal revision actor fence", run: runGoalRevisionActorFence},
 		{Name: "goal inbox consumer preflight", run: runGoalInboxConsumerPreflight},

--- a/packages/agent/host/goal_control.go
+++ b/packages/agent/host/goal_control.go
@@ -3,6 +3,7 @@ package agenthost
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"unicode"
@@ -43,6 +44,24 @@ func durableGoalForResponse(state storesqlite.SessionGoalState) map[string]any {
 		return nil
 	}
 	return clonePayload(state.Desired)
+}
+
+func goalControlOperationID(workspaceID, agentSessionID, clientSubmitID string) string {
+	clientSubmitID = strings.TrimSpace(clientSubmitID)
+	if clientSubmitID == "" {
+		return uuid.NewString()
+	}
+	name := strings.Join([]string{
+		strings.TrimSpace(workspaceID), strings.TrimSpace(agentSessionID), clientSubmitID,
+	}, "\x00")
+	return uuid.NewSHA1(uuid.NameSpaceURL, []byte(name)).String()
+}
+
+func goalControlClientSubmitID(input GoalControlInput, submissionMetadata map[string]any) string {
+	if clientSubmitID := strings.TrimSpace(input.ClientSubmitID); clientSubmitID != "" {
+		return clientSubmitID
+	}
+	return metadataString(submissionMetadata, "clientSubmitId")
 }
 
 // ParseTypedGoalControl recognizes the text-only slash surface at the Host
@@ -130,24 +149,16 @@ func (h *Host) goalControlSerialized(
 		"agentSessionId", agentSessionID,
 		"action", action,
 	)
-	if _, err := h.EnsureRuntimeSession(ctx, SessionRef{WorkspaceID: workspaceID, AgentSessionID: agentSessionID}); err != nil {
-		slog.Warn("workspace agent session goal control prepare failed",
-			"event", "workspace_agent_session.goal_control.prepare_failed",
-			"workspaceId", workspaceID,
-			"agentSessionId", agentSessionID,
-			"error", err.Error(),
-		)
-		return GoalControlResult{}, err
-	}
 	operationID := ""
 	goalRevision := int64(0)
-	clientSubmitID := metadataString(submissionMetadata, "clientSubmitId")
+	clientSubmitID := goalControlClientSubmitID(input, submissionMetadata)
 	var persistedState *storesqlite.SessionGoalState
+	replayed := false
 	if h.goals != nil {
-		operationID = uuid.NewString()
+		operationID = goalControlOperationID(workspaceID, agentSessionID, clientSubmitID)
 		err := h.withGoalActor(ctx, workspaceID, agentSessionID, func(actorCtx context.Context) error {
 			now := h.goalOperationNow()
-			op, state, _, err := h.goals.PrepareGoalControlOperation(actorCtx, storesqlite.GoalControlOperationPrepare{
+			op, state, created, err := h.goals.PrepareGoalControlOperation(actorCtx, storesqlite.GoalControlOperationPrepare{
 				OperationID: operationID, WorkspaceID: workspaceID, AgentSessionID: agentSessionID,
 				Action: strings.TrimSpace(action), Objective: strings.TrimSpace(objective), ClientSubmitID: clientSubmitID,
 				OccurredAtUnixMS: now.UnixMilli(),
@@ -157,6 +168,48 @@ func (h *Host) goalControlSerialized(
 			}
 			goalRevision = op.GoalRevision
 			persistedState = &state
+			if !created {
+				switch op.Status {
+				case storesqlite.GoalOperationStatusCompleted, storesqlite.GoalOperationStatusSuperseded:
+					replayed = true
+					return nil
+				case storesqlite.GoalOperationStatusFailed:
+					return fmt.Errorf("%w: %s", ErrRuntimeOperationFailed, strings.TrimSpace(op.LastError))
+				default:
+					return ErrRuntimeOperationInProgress
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return GoalControlResult{}, err
+		}
+	}
+	if replayed {
+		canonical, found, err := h.store.GetSession(ctx, workspaceID, agentSessionID)
+		if err != nil {
+			return GoalControlResult{}, err
+		}
+		if !found {
+			return GoalControlResult{}, ErrSessionNotFound
+		}
+		return GoalControlResult{
+			Canonical: canonical, Goal: durableGoalForResponse(*persistedState),
+			OperationID: operationID, GoalState: persistedState,
+		}, nil
+	}
+	if _, err := h.EnsureRuntimeSession(ctx, SessionRef{WorkspaceID: workspaceID, AgentSessionID: agentSessionID}); err != nil {
+		slog.Warn("workspace agent session goal control prepare failed",
+			"event", "workspace_agent_session.goal_control.prepare_failed",
+			"workspaceId", workspaceID,
+			"agentSessionId", agentSessionID,
+			"error", err.Error(),
+		)
+		return GoalControlResult{}, err
+	}
+	if h.goals != nil {
+		err := h.withGoalActor(ctx, workspaceID, agentSessionID, func(actorCtx context.Context) error {
+			now := h.goalOperationNow()
 			owner := h.goalOperationOwner()
 			if _, claimed, err := h.goals.ClaimGoalControlOperation(actorCtx, storesqlite.ClaimGoalControlOperationInput{
 				WorkspaceID: workspaceID, OperationID: operationID, LeaseOwner: owner,

--- a/packages/agent/host/goal_control_idempotency_test.go
+++ b/packages/agent/host/goal_control_idempotency_test.go
@@ -1,0 +1,21 @@
+package agenthost
+
+import "testing"
+
+func TestGoalControlOperationIDUsesCallerStableIdentity(t *testing.T) {
+	first := goalControlOperationID("workspace-1", "session-1", "submit-1")
+	second := goalControlOperationID(" workspace-1 ", " session-1 ", " submit-1 ")
+	if first != second {
+		t.Fatalf("stable operation IDs differ: %q != %q", first, second)
+	}
+	if other := goalControlOperationID("workspace-1", "session-1", "submit-2"); other == first {
+		t.Fatalf("different client submit IDs produced %q", first)
+	}
+}
+
+func TestGoalControlClientSubmitIDPrefersTypedField(t *testing.T) {
+	input := GoalControlInput{ClientSubmitID: " typed-id "}
+	if got := goalControlClientSubmitID(input, map[string]any{"clientSubmitId": "legacy-id"}); got != "typed-id" {
+		t.Fatalf("client submit ID = %q, want typed-id", got)
+	}
+}

--- a/packages/agent/host/goal_control_restart_test.go
+++ b/packages/agent/host/goal_control_restart_test.go
@@ -1,0 +1,89 @@
+package agenthost_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	_ "modernc.org/sqlite"
+)
+
+type liveGoalRuntime struct {
+	agenthost.RuntimeController
+	session agenthost.ProviderRuntimeSession
+}
+
+func (r liveGoalRuntime) Session(workspaceID, agentSessionID string) (agenthost.ProviderRuntimeSession, bool) {
+	return r.session, workspaceID == r.session.WorkspaceID && agentSessionID == r.session.ID
+}
+
+type countingGoalRuntime struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (r *countingGoalRuntime) GoalControl(_ context.Context, input agenthost.RuntimeGoalControlInput) (agenthost.RuntimeGoalControlResult, error) {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
+	return agenthost.RuntimeGoalControlResult{
+		Goal: map[string]any{"objective": input.Objective, "status": "active"},
+	}, nil
+}
+
+func (r *countingGoalRuntime) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+func TestGoalControlRetryAfterHostRestartDoesNotReplayProviderMutation(t *testing.T) {
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "agent-host-goal-restart.db"))
+	if err != nil {
+		t.Fatalf("open SQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	store := storesqlite.New(db, storesqlite.Options{})
+	if err := store.Migrate(t.Context()); err != nil {
+		t.Fatalf("migrate SQLite: %v", err)
+	}
+	if _, err := store.ReportSessionState(t.Context(), storesqlite.SessionStateReport{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", Provider: "codex", OccurredAtUnixMS: 1,
+	}); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	runtimeSession := agenthost.ProviderRuntimeSession{
+		ID: "session-1", WorkspaceID: "workspace-1", Provider: "codex",
+	}
+	runtime := liveGoalRuntime{session: runtimeSession}
+	goalRuntime := &countingGoalRuntime{}
+	newHost := func() *agenthost.Host {
+		return agenthost.New(agenthost.Config{
+			CanonicalStore: sqliteCanonicalStore{Store: store}, Runtime: runtime,
+			GoalStore: store, GoalRuntime: goalRuntime,
+		})
+	}
+	input := agenthost.GoalControlInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", Action: "set",
+		Objective: "ship exactly once", ClientSubmitID: "stable-submit-1",
+	}
+	first, err := newHost().GoalControl(t.Context(), input)
+	if err != nil {
+		t.Fatalf("first GoalControl(): %v", err)
+	}
+	second, err := newHost().GoalControl(t.Context(), input)
+	if err != nil {
+		t.Fatalf("GoalControl() after restart: %v", err)
+	}
+	if goalRuntime.callCount() != 1 {
+		t.Fatalf("provider GoalControl calls = %d, want 1", goalRuntime.callCount())
+	}
+	if first.OperationID == "" || second.OperationID != first.OperationID || second.GoalState == nil || second.GoalState.Revision != 1 {
+		t.Fatalf("first=%#v second=%#v", first, second)
+	}
+}

--- a/packages/agent/host/goal_reconcile.go
+++ b/packages/agent/host/goal_reconcile.go
@@ -28,24 +28,7 @@ func (h *Host) GetGoalState(ctx context.Context, ref SessionRef) (GoalStateResul
 		return GoalStateResult{}, err
 	}
 	if !found {
-		// Observation reconciliation bootstraps the projection without changing
-		// desired revision. An absent provider observation remains unknown.
-		state, err = h.goals.ReconcileSessionGoalObservation(ctx, storesqlite.GoalObservationReconcile{
-			WorkspaceID: workspaceID, AgentSessionID: agentSessionID,
-			Evidence:         map[string]any{"source": "upper_read_bootstrap", "confidence": "unknown"},
-			OccurredAtUnixMS: h.goalOperationNow().UnixMilli(),
-			Expected:         &storesqlite.GoalObservationFence{Exists: false},
-			ForceSyncUnknown: true,
-		})
-		if errors.Is(err, storesqlite.ErrGoalReconcileConflict) {
-			state, found, err = h.goals.GetSessionGoalState(ctx, workspaceID, agentSessionID)
-			if err == nil && !found {
-				err = storesqlite.ErrGoalReconcileConflict
-			}
-		}
-		if err != nil {
-			return GoalStateResult{}, err
-		}
+		return GoalStateResult{Canonical: canonical}, nil
 	}
 	return GoalStateResult{Canonical: canonical, State: state}, nil
 }

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -475,10 +475,14 @@ type RuntimeGoalRecoveryPolicy struct {
 }
 
 type GoalControlInput struct {
-	WorkspaceID        string
-	AgentSessionID     string
-	Action             string
-	Objective          string
+	WorkspaceID    string
+	AgentSessionID string
+	Action         string
+	Objective      string
+	// ClientSubmitID is the caller-stable identity for one semantic mutation.
+	// It overrides the legacy SubmissionMetadata["clientSubmitId"] value and
+	// makes retries idempotent across Host process restarts.
+	ClientSubmitID     string
 	SubmissionMetadata map[string]any
 }
 


### PR DESCRIPTION
## What changed

- Carry structured initial Goal control through AgentActivity and AgentGUI activation without manufacturing a Turn.
- Propagate a caller-stable `ClientSubmitID` for direct and typed Goal mutations.
- Derive durable Goal operation identity from workspace, session, and client submission identity.
- Coalesce completed/superseded retries and reject conflicting or in-flight replays without calling the provider again.
- Make `GetGoalState` a pure canonical read; only mutation, reconcile, and recovery paths may create Goal state.
- Add conformance, pure-read, deterministic identity, and Host-restart regression coverage.

## Why

Goal operations persisted `clientSubmitId` but generated a random operation ID for every call. A retry after Host restart could therefore execute the same provider mutation twice. Goal reads also bootstrapped missing projection state, turning a query into a write.

This change makes retries safe across process restarts and restores the read/mutation boundary.

## Impact

Shared Agent integrations can use the same structured Goal activation path for new sessions and stable submission identity for subsequent controls. Existing metadata-based `clientSubmitId` callers remain supported; the typed field takes precedence.

## Verification

- `go test ./packages/agent/host/... ./packages/agent/store-sqlite/... ./services/tuttid/service/agent`
- `pnpm --filter @tutti-os/agent-activity-core test`
- `pnpm --filter @tutti-os/agent-activity-core typecheck`
- `pnpm --filter @tutti-os/agent-gui test` — 242 files / 2072 tests passed
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `git diff --check`

E2E was not run.
