### PR TITLE
refactor(workspace-files): remove preview manager proxy

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
@@ -16,7 +16,6 @@ import type { WorkspaceUserProject } from "@tutti-os/workspace-user-project/cont
 import type { ReporterEventInput } from "@renderer/features/analytics/services/reporterService.interface.ts";
 import type { IDesktopRichTextAtService } from "@renderer/features/rich-text-at";
 import type { IWorkspaceUserProjectService } from "@renderer/features/workspace-user-project";
-import type { IWorkspaceFileManagerService } from "@renderer/features/workspace-file-manager";
 import {
   USER_PROJECT_REFERENCE_SOURCE_ID,
   WORKSPACE_FILE_SOURCE_ID
@@ -265,7 +264,7 @@ test("desktop agent GUI workbench host input creates the default agent host api"
   );
 });
 
-test("desktop agent GUI workbench host input opens workspace references through the file manager canvas preview first", async () => {
+test("desktop agent GUI workbench host input opens workspace references through the preview surface host first", async () => {
   const calls: string[] = [];
   const hostInput = createDesktopAgentGUIWorkbenchHostInput({
     hostFilesApi: {
@@ -279,12 +278,15 @@ test("desktop agent GUI workbench host input opens workspace references through 
     richTextAtService: createRichTextAtService(),
     runtimeApi: createRuntimeApi(),
     workspaceAgentActivityService: createWorkspaceAgentActivityService([]),
-    workspaceFileManagerService: createWorkspaceFileManagerService({
-      async openCanvasFilePreview(workspaceId, target) {
+    workspaceFilePreviewSurfaceHost: {
+      async present(workspaceId, target) {
         calls.push(`preview:${workspaceId}:${target.path}:${target.fileKind}`);
-        return true;
+        return {
+          presented: true,
+          unsupportedFallbackNotification: "show"
+        };
       }
-    }),
+    },
     workspaceId
   });
 
@@ -296,7 +298,7 @@ test("desktop agent GUI workbench host input opens workspace references through 
   assert.deepEqual(calls, ["preview:workspace-1:/workspace/image.png:image"]);
 });
 
-test("desktop agent GUI workbench host input opens references in the system default application when configured", async () => {
+test("desktop agent GUI workbench host input opens references in the system default application without a preview presenter", async () => {
   const calls: string[] = [];
   const hostInput = createDesktopAgentGUIWorkbenchHostInput({
     hostFilesApi: {
@@ -310,13 +312,6 @@ test("desktop agent GUI workbench host input opens references in the system defa
     richTextAtService: createRichTextAtService(),
     runtimeApi: createRuntimeApi(),
     workspaceAgentActivityService: createWorkspaceAgentActivityService([]),
-    workspaceFileManagerService: createWorkspaceFileManagerService({
-      async openCanvasFilePreview() {
-        calls.push("preview");
-        return true;
-      }
-    }),
-    workspaceFilePreviewMode: "system-default",
     workspaceId
   });
 
@@ -1448,18 +1443,6 @@ function createPlatformApi(
       return [];
     },
     ...overrides
-  };
-}
-
-function createWorkspaceFileManagerService(input: {
-  openCanvasFilePreview: IWorkspaceFileManagerService["openCanvasFilePreview"];
-}): Pick<
-  IWorkspaceFileManagerService,
-  "openCanvasFilePreview" | "resolveEntryIconUrl"
-> {
-  return {
-    openCanvasFilePreview: input.openCanvasFilePreview,
-    resolveEntryIconUrl: async () => null
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts
@@ -15,6 +15,7 @@ import type { WorkspaceFileEntry } from "@tutti-os/workspace-file-manager/servic
 import type { IDesktopRichTextAtService } from "@renderer/features/rich-text-at";
 import type { IReporterService } from "@renderer/features/analytics";
 import type { IWorkspaceFileManagerService } from "@renderer/features/workspace-file-manager";
+import type { IWorkspaceFilePreviewSurfaceHost } from "@renderer/features/workspace-file-preview";
 import type { WorkspaceFileReference } from "@tutti-os/workspace-file-reference/contracts";
 import {
   createReferenceSourceAggregator,
@@ -103,9 +104,12 @@ export interface CreateDesktopAgentGUIWorkbenchHostInputInput {
   workspaceAgentActivityService: IWorkspaceAgentActivityService;
   workspaceFileManagerService?: Pick<
     IWorkspaceFileManagerService,
-    "openCanvasFilePreview" | "resolveEntryIconUrl"
+    "resolveEntryIconUrl"
   >;
-  workspaceFilePreviewMode?: "canvas" | "system-default";
+  workspaceFilePreviewSurfaceHost?: Pick<
+    IWorkspaceFilePreviewSurfaceHost,
+    "present"
+  >;
   workspaceUserProjectService?: IWorkspaceUserProjectService;
   workspaceId: string;
 }
@@ -122,7 +126,7 @@ export function createDesktopAgentGUIWorkbenchHostInput({
   runtimeApi,
   workspaceAgentActivityService,
   workspaceFileManagerService,
-  workspaceFilePreviewMode = "canvas",
+  workspaceFilePreviewSurfaceHost,
   workspaceUserProjectService,
   workspaceId
 }: CreateDesktopAgentGUIWorkbenchHostInputInput): DesktopAgentGUIWorkbenchHostInput {
@@ -159,14 +163,11 @@ export function createDesktopAgentGUIWorkbenchHostInput({
   const workspaceFileReferenceAdapter =
     createDesktopWorkspaceFileReferenceAdapter({
       hostFilesApi,
-      openCanvasFilePreview:
-        workspaceFilePreviewMode === "canvas" && workspaceFileManagerService
-          ? (target, workspaceId) =>
-              workspaceFileManagerService.openCanvasFilePreview(
-                workspaceId,
-                target
-              )
-          : undefined,
+      presentFilePreview: workspaceFilePreviewSurfaceHost
+        ? async (target, workspaceId) =>
+            (await workspaceFilePreviewSurfaceHost.present(workspaceId, target))
+              .presented
+        : undefined,
       tuttidClient,
       workspaceId
     });

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/createDesktopWorkspaceFileReferenceAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/createDesktopWorkspaceFileReferenceAdapter.test.ts
@@ -200,7 +200,7 @@ test("desktop workspace file reference adapter preserves file creation times fro
   assert.equal(refs?.[0]?.createdTimeMs, 1_800_000_000_000);
 });
 
-test("desktop workspace file reference adapter opens previewable files with the canvas preview first", async () => {
+test("desktop workspace file reference adapter opens previewable files with the preview presenter first", async () => {
   const calls: string[] = [];
   const adapter = createDesktopWorkspaceFileReferenceAdapter({
     hostFilesApi: {
@@ -208,7 +208,7 @@ test("desktop workspace file reference adapter opens previewable files with the 
         calls.push("open-file");
       }
     } as unknown as DesktopHostFilesApi,
-    openCanvasFilePreview(target, workspaceId) {
+    presentFilePreview(target, workspaceId) {
       calls.push(`preview:${workspaceId}:${target.path}:${target.fileKind}`);
       return true;
     },
@@ -224,7 +224,7 @@ test("desktop workspace file reference adapter opens previewable files with the 
   assert.deepEqual(calls, ["preview:workspace-1:/workspace/image.png:image"]);
 });
 
-test("desktop workspace file reference adapter falls back to system open when canvas preview cannot handle the file", async () => {
+test("desktop workspace file reference adapter falls back to system open when the preview presenter cannot handle the file", async () => {
   const calls: string[] = [];
   const adapter = createDesktopWorkspaceFileReferenceAdapter({
     hostFilesApi: {
@@ -232,7 +232,7 @@ test("desktop workspace file reference adapter falls back to system open when ca
         calls.push(`open-file:${workspaceId}:${path}`);
       }
     } as unknown as DesktopHostFilesApi,
-    openCanvasFilePreview(target, workspaceId) {
+    presentFilePreview(target, workspaceId) {
       calls.push(`preview:${workspaceId}:${target.path}:${target.fileKind}`);
       return false;
     },
@@ -259,7 +259,7 @@ test("desktop workspace file reference adapter opens unsupported preview formats
         calls.push(`open-file:${workspaceId}:${path}`);
       }
     } as unknown as DesktopHostFilesApi,
-    openCanvasFilePreview() {
+    presentFilePreview() {
       calls.push("preview");
       return true;
     },

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/createDesktopWorkspaceFileReferenceAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/createDesktopWorkspaceFileReferenceAdapter.ts
@@ -19,15 +19,14 @@ import type { DesktopHostFilesApi } from "@preload/types";
 
 export function createDesktopWorkspaceFileReferenceAdapter(input: {
   hostFilesApi: DesktopHostFilesApi;
-  openCanvasFilePreview?: (
+  presentFilePreview?: (
     target: WorkspaceFilePreviewActivationTarget,
     workspaceId: string
   ) => Promise<boolean> | boolean;
   tuttidClient: TuttidClient;
   workspaceId: string;
 }): WorkspaceFileReferenceAdapter {
-  const { hostFilesApi, openCanvasFilePreview, tuttidClient, workspaceId } =
-    input;
+  const { hostFilesApi, presentFilePreview, tuttidClient, workspaceId } = input;
 
   return {
     async loadReferenceTree({
@@ -90,7 +89,7 @@ export function createDesktopWorkspaceFileReferenceAdapter(input: {
           : null;
       if (
         target &&
-        (await openCanvasFilePreview?.(target, workspaceId)) === true
+        (await presentFilePreview?.(target, workspaceId)) === true
       ) {
         return;
       }

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.ts
@@ -133,8 +133,9 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
     const workspaceFileReferenceAdapter =
       createDesktopWorkspaceFileReferenceAdapter({
         hostFilesApi: this.dependencies.hostFilesApi,
-        openCanvasFilePreview: (target, workspaceId) =>
-          this.openCanvasFilePreview(workspaceId, target),
+        presentFilePreview: async (target, workspaceId) =>
+          (await this.filePreviewSurfaceHost.present(workspaceId, target))
+            .presented,
         tuttidClient: this.dependencies.tuttidClient,
         workspaceId: workspaceID
       });
@@ -295,14 +296,6 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
       name: entry.name,
       path: entry.path
     });
-  }
-
-  async openCanvasFilePreview(
-    workspaceID: string,
-    target: Parameters<WorkspaceFilePreviewSurfaceHost["present"]>[1]
-  ): Promise<boolean> {
-    return (await this.filePreviewSurfaceHost.present(workspaceID, target))
-      .presented;
   }
 
   subscribe(workspaceID: string, listener: () => void): () => void {

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/workspaceFileManagerService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/workspaceFileManagerService.interface.ts
@@ -7,7 +7,6 @@ import type {
   WorkspaceFileManagerPersistedState,
   WorkspaceFileManagerSession as SharedWorkspaceFileManagerSession
 } from "@tutti-os/workspace-file-manager/services";
-import type { WorkspaceFilePreviewActivationTarget } from "@tutti-os/workspace-file-preview";
 export type WorkspaceFileManagerSession = SharedWorkspaceFileManagerSession;
 
 export interface IWorkspaceFileManagerService {
@@ -27,10 +26,6 @@ export interface IWorkspaceFileManagerService {
   getSnapshotState(
     workspaceID: string
   ): WorkspaceFileManagerPersistedState | null;
-  openCanvasFilePreview(
-    workspaceID: string,
-    target: WorkspaceFilePreviewActivationTarget
-  ): Promise<boolean>;
   resolveEntryIconUrl(
     workspaceID: string,
     entry: WorkspaceFileEntry

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/agentGuiWorkbenchContributionFactory.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/agentGuiWorkbenchContributionFactory.ts
@@ -27,6 +27,7 @@ type AgentGuiWorkbenchContributionContext = Pick<
   | "tuttidClient"
   | "workspaceAgentActivityService"
   | "workspaceFileManagerService"
+  | "workspaceFilePreviewSurfaceHost"
   | "workspaceId"
   | "workspaceUserProjectService"
 >;
@@ -59,6 +60,8 @@ export const agentGuiWorkbenchContributionFactory: DesktopWorkbenchContributionF
         runtimeApi: context.runtimeApi,
         workspaceAgentActivityService: context.workspaceAgentActivityService,
         workspaceFileManagerService: context.workspaceFileManagerService,
+        workspaceFilePreviewSurfaceHost:
+          context.workspaceFilePreviewSurfaceHost,
         workspaceUserProjectService: context.workspaceUserProjectService,
         workspaceId: context.workspaceId
       });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/tuttiWorkbenchProductProfile.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/tuttiWorkbenchProductProfile.ts
@@ -90,6 +90,7 @@ export function createTuttiWorkbenchProductProfile(
           "tuttidClient",
           "workspaceAgentActivityService",
           "workspaceFileManagerService",
+          "workspaceFilePreviewSurfaceHost",
           "workspaceId",
           "workspaceUserProjectService"
         ])

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -38,6 +38,7 @@ import type {
 } from "@renderer/features/workspace-agent";
 import type { IWorkspaceUserProjectService } from "@renderer/features/workspace-user-project";
 import type { IWorkspaceFileManagerService } from "@renderer/features/workspace-file-manager";
+import type { IWorkspaceFilePreviewSurfaceHost } from "@renderer/features/workspace-file-preview";
 import type { IReporterService } from "@renderer/features/analytics";
 import { createDesktopAgentGUIWorkbenchHostInput } from "@renderer/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts";
 import { requestWorkspaceAgentGuiLaunch } from "@renderer/features/workspace-agent/services/workspaceAgentGuiLaunchCoordinator.ts";
@@ -88,6 +89,7 @@ export function createWorkspaceAgentGuiContribution(input: {
   runtimeApi: DesktopRuntimeApi;
   workspaceAgentActivityService: IWorkspaceAgentActivityService;
   workspaceFileManagerService: IWorkspaceFileManagerService;
+  workspaceFilePreviewSurfaceHost: IWorkspaceFilePreviewSurfaceHost;
   workspaceUserProjectService: IWorkspaceUserProjectService;
   workspaceId: string;
 }): WorkbenchContribution {
@@ -108,6 +110,7 @@ export function createWorkspaceAgentGuiContribution(input: {
     runtimeApi: input.runtimeApi,
     workspaceAgentActivityService: input.workspaceAgentActivityService,
     workspaceFileManagerService: input.workspaceFileManagerService,
+    workspaceFilePreviewSurfaceHost: input.workspaceFilePreviewSurfaceHost,
     workspaceUserProjectService: input.workspaceUserProjectService,
     workspaceId: input.workspaceId
   });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.test.ts
@@ -290,9 +290,6 @@ function createFileManagerServiceStub(
         navigationForwardStack: [...snapshotState.navigationForwardStack]
       };
     },
-    async openCanvasFilePreview() {
-      return false;
-    },
     async resolveEntryIconUrl() {
       return null;
     },

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchContributionFactory.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchContributionFactory.ts
@@ -31,6 +31,7 @@ import type {
 } from "@renderer/features/workspace-agent";
 import type { IWorkspaceAppCenterService } from "@renderer/features/workspace-app-center";
 import type { IWorkspaceFileManagerService } from "@renderer/features/workspace-file-manager";
+import type { IWorkspaceFilePreviewSurfaceHost } from "@renderer/features/workspace-file-preview";
 import type { IWorkspaceUserProjectService } from "@renderer/features/workspace-user-project";
 import type { IReporterService } from "@renderer/features/analytics";
 import type {
@@ -77,6 +78,7 @@ export interface DesktopWorkbenchContributionContext {
   comingSoonAgentProviders?: readonly AgentGUIProvider[];
   agentProviderStatusService: AgentProviderStatusService;
   workspaceFileManagerService: IWorkspaceFileManagerService;
+  workspaceFilePreviewSurfaceHost: IWorkspaceFilePreviewSurfaceHost;
   workspaceUserProjectService: IWorkspaceUserProjectService;
   workspaceAgentActivityService: IWorkspaceAgentActivityService;
   workspaceAgentPromptSessionService: WorkspaceAgentPromptSessionService;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostInputResolver.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostInputResolver.ts
@@ -39,6 +39,7 @@ import type { IWorkspaceAppCenterService } from "@renderer/features/workspace-ap
 import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
 import type { IDesktopRichTextAtService } from "../../../rich-text-at/services/richTextAtService.interface.ts";
 import type { IWorkspaceFileManagerService } from "../../../workspace-file-manager/services/workspaceFileManagerService.interface.ts";
+import type { IWorkspaceFilePreviewSurfaceHost } from "../../../workspace-file-preview/services/workspaceFilePreviewSurfaceHost.interface.ts";
 import type { IWorkspaceUserProjectService } from "../../../workspace-user-project/services/workspaceUserProjectService.interface.ts";
 import type { IAgentProviderStatusService as AgentProviderStatusService } from "../../../workspace-agent/services/agentProviderStatusService.interface.ts";
 import type { IAgentQuickPromptService as AgentQuickPromptService } from "../../../workspace-agent/services/agentQuickPromptService.interface.ts";
@@ -82,6 +83,7 @@ export interface WorkspaceWorkbenchHostInputResolverDependencies {
   hostFilesApi: DesktopHostFilesApi;
   hostWindowApi: DesktopHostWindowApi;
   workspaceFileManagerService: IWorkspaceFileManagerService;
+  workspaceFilePreviewSurfaceHost: IWorkspaceFilePreviewSurfaceHost;
   workspaceUserProjectService: IWorkspaceUserProjectService;
   workspaceAgentActivityService: WorkspaceAgentActivityService;
   workspaceAgentPromptSessionService: WorkspaceAgentPromptSessionService;
@@ -185,6 +187,8 @@ export class WorkspaceWorkbenchHostInputResolver {
         eventStreamClient: this.dependencies.eventStreamClient,
         workspaceFileManagerService:
           this.dependencies.workspaceFileManagerService,
+        workspaceFilePreviewSurfaceHost:
+          this.dependencies.workspaceFilePreviewSurfaceHost,
         workspaceUserProjectService:
           this.dependencies.workspaceUserProjectService,
         workspaceAgentActivityService:

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -47,6 +47,7 @@ import {
 import { IWorkspaceAppCenterService } from "@renderer/features/workspace-app-center/services/workspaceAppCenterService.interface.ts";
 import { createDesktopAgentGeneratedFileMentionProvider } from "@renderer/features/workspace-agent/services/createDesktopAgentGeneratedFileMentionProvider.ts";
 import { IWorkspaceFileManagerService } from "../../../workspace-file-manager/services/workspaceFileManagerService.interface.ts";
+import { IWorkspaceFilePreviewSurfaceHost } from "../../../workspace-file-preview/services/workspaceFilePreviewSurfaceHost.interface.ts";
 import { createDesktopWorkspaceFileReferenceAdapter } from "../../../workspace-file-manager/services/createDesktopWorkspaceFileReferenceAdapter.ts";
 import { IWorkspaceUserProjectService } from "../../../workspace-user-project/services/workspaceUserProjectService.interface.ts";
 import { confirmWorkspaceWindowClose } from "./workspaceWindowCloseCoordinator.ts";
@@ -184,6 +185,7 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
     workspaceAgentPromptSessionService: WorkspaceAgentPromptSessionService,
     appCenterService: IWorkspaceAppCenterService,
     workspaceFileManagerService: IWorkspaceFileManagerService,
+    workspaceFilePreviewSurfaceHost: IWorkspaceFilePreviewSurfaceHost,
     workspaceUserProjectService: IWorkspaceUserProjectService
   ) {
     const repository = externalDependencies.snapshotRepository;
@@ -205,6 +207,7 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
       hostWindowApi: externalDependencies.hostWindowApi,
       hostWorkspaceApi: externalDependencies.hostWorkspaceApi,
       workspaceFileManagerService,
+      workspaceFilePreviewSurfaceHost,
       workspaceUserProjectService,
       workspaceAgentActivityService,
       workspaceAgentPromptSessionService,
@@ -773,7 +776,8 @@ IWorkspaceAgentPromptSessionService(
 );
 IWorkspaceAppCenterService(WorkspaceWorkbenchHostService, undefined, 7);
 IWorkspaceFileManagerService(WorkspaceWorkbenchHostService, undefined, 8);
-IWorkspaceUserProjectService(WorkspaceWorkbenchHostService, undefined, 9);
+IWorkspaceFilePreviewSurfaceHost(WorkspaceWorkbenchHostService, undefined, 9);
+IWorkspaceUserProjectService(WorkspaceWorkbenchHostService, undefined, 10);
 
 function createWorkspaceWorkbenchPartition(
   workspaceId: string

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -473,7 +473,7 @@ export function StandaloneAgentWindow({
         runtimeApi: desktopApi.runtime,
         workspaceAgentActivityService,
         workspaceFileManagerService,
-        workspaceFilePreviewMode: "canvas",
+        workspaceFilePreviewSurfaceHost,
         workspaceUserProjectService,
         workspaceId
       }),
@@ -487,6 +487,7 @@ export function StandaloneAgentWindow({
       tuttidClient,
       workspaceAgentActivityService,
       workspaceFileManagerService,
+      workspaceFilePreviewSurfaceHost,
       workspaceId,
       workspaceUserProjectService
     ]

--- a/docs/conventions/desktop-layering.md
+++ b/docs/conventions/desktop-layering.md
@@ -105,7 +105,7 @@ Reading rules:
 - `renderer/src/app/windows/*` are renderer window composition shells such as `dashboard` and `workspace`
 - `renderer/src/features/*` are reusable renderer feature modules
 - `renderer/src/features/*/services/internal/**` is private implementation for the owning feature
-- `renderer/src/features/workspace-file-preview` owns the workspace-scoped preview presenter registry and fallback policy; file-manager, Workbench, and Agent surfaces consume its public service contract instead of owning parallel routing
+- `renderer/src/features/workspace-file-preview` owns the workspace-scoped preview presenter registry and fallback policy; file-manager, Workbench, and Agent surfaces consume its public service contract directly instead of owning parallel routing or adding preview-open proxy methods to another feature service
 - desktop business-facing capabilities should usually surface through `ipc/*` and `preload/api/*`
 - `shared/contracts/*` is for stable desktop-local bridge contracts, not a general utility bucket
 - `shared/errors/*` owns desktop-local error codes and non-Electron error classification shared across desktop layers


### PR DESCRIPTION
## Summary

- route AgentGUI workspace reference previews directly through the workspace file preview surface host
- remove `openCanvasFilePreview` from the file-manager service and rename the adapter callback to the surface-neutral `presentFilePreview`
- remove the obsolete `workspaceFilePreviewMode` switch; absence of a presenter now naturally falls back to the system application
- document that preview consumers must use the preview owner contract directly instead of adding cross-feature proxy methods

## Why

After #1508 moved preview routing into `workspace-file-preview`, AgentGUI still reached it through an `IWorkspaceFileManagerService` proxy. That kept preview ownership exposed on the file-manager API and left a redundant mode switch. This change completes that ownership cutover and deletes the compatibility path.

## Impact

Workspace and standalone Agent file references keep the same behavior: previewable files open in the registered surface, while unsupported files or surfaces without a presenter use the system application.

## Validation

- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop test` (1469 passed, 2 skipped)
- `pnpm check:changed` (11 lanes)
- pre-push `pnpm check:changed -- --push-ready` (12 lanes)
- `pnpm --filter @tutti-os/desktop build`
