### PR TITLE
fix(claude-sdk): resolve runtime metadata in sidecar

### DIFF
--- a/docs/architecture/claude-code-sdk-runtime.md
+++ b/docs/architecture/claude-code-sdk-runtime.md
@@ -49,6 +49,11 @@ process/session lifecycle and normalization behind that selection. They must not
 raw SDK envelopes to services or GUI packages. Service-layer provider catalogs,
 composer profiles, targets, status probes, and identity projections consume the
 same `ProviderDescriptor` instead of re-registering Claude Code locally.
+Provider preparation may inject system-prompt and plugin paths that exist only
+in the sidecar runtime filesystem. The Go adapter treats those environment
+values as opaque and forwards them unchanged; `options.ts` reads and validates
+the referenced files after the sidecar starts. Daemon code must not inspect
+those paths because remote transports do not share its filesystem.
 Claude modules do not call ACP _protocol_ helpers (session-update decoding,
 standard ACP tool-call envelopes, and similar). Open tool-call bookkeeping and
 turn `Finish*` settlement reuse the shared adapter turn lifecycle

--- a/packages/agent/claude-sdk-sidecar/src/options.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/options.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import {
   claudeQueryOptionOverrides,
@@ -66,4 +69,59 @@ test("sidecarClaudeOptionsFromPayload defaults to Claude Code tool preset", () =
   assert.equal(overrides.disallowedTools, undefined);
   assert.equal(overrides.plugins, undefined);
   assert.equal(overrides.extraArgs, undefined);
+});
+
+test("sidecarClaudeOptionsFromPayload resolves prepared metadata in the sidecar filesystem", (t) => {
+  const runtimeRoot = mkdtempSync(join(tmpdir(), "tutti-claude-meta-"));
+  t.after(() => rmSync(runtimeRoot, { recursive: true, force: true }));
+  const systemPromptPath = join(runtimeRoot, "claude-system-prompt.md");
+  const pluginDir = join(runtimeRoot, "claude-plugin", "tutti-cli");
+  writeFileSync(systemPromptPath, "Use Tutti CLI for issue context.\n", "utf8");
+  mkdirSync(pluginDir, { recursive: true });
+
+  const options = sidecarClaudeOptionsFromPayload({
+    env: {
+      TUTTI_CLAUDE_SYSTEM_PROMPT_FILE: systemPromptPath,
+      TUTTI_CLAUDE_PLUGIN_DIR: pluginDir
+    },
+    extraArgs: { model: "MiniMax-M2.7" }
+  });
+  const overrides = claudeQueryOptionOverrides(options);
+
+  assert.deepEqual(overrides.systemPrompt, {
+    type: "preset",
+    preset: "claude_code",
+    append: "Use Tutti CLI for issue context."
+  });
+  assert.deepEqual(overrides.plugins, [{ type: "local", path: pluginDir }]);
+  assert.deepEqual(overrides.extraArgs, {
+    model: "MiniMax-M2.7",
+    "plugin-dir": pluginDir
+  });
+});
+
+test("sidecarClaudeOptionsFromPayload reports missing prepared metadata", () => {
+  const missingRoot = join(
+    tmpdir(),
+    `tutti-claude-missing-${crypto.randomUUID()}`
+  );
+
+  assert.throws(
+    () =>
+      sidecarClaudeOptionsFromPayload({
+        env: {
+          TUTTI_CLAUDE_SYSTEM_PROMPT_FILE: join(missingRoot, "prompt.md")
+        }
+      }),
+    /read claude system prompt:.*ENOENT/u
+  );
+  assert.throws(
+    () =>
+      sidecarClaudeOptionsFromPayload({
+        env: {
+          TUTTI_CLAUDE_PLUGIN_DIR: join(missingRoot, "plugin")
+        }
+      }),
+    /stat claude plugin dir:.*ENOENT/u
+  );
 });

--- a/packages/agent/claude-sdk-sidecar/src/options.ts
+++ b/packages/agent/claude-sdk-sidecar/src/options.ts
@@ -1,7 +1,11 @@
+import { readFileSync, statSync } from "node:fs";
 import type {
   Options as ClaudeQueryOptions,
   SdkPluginConfig
 } from "@anthropic-ai/claude-agent-sdk";
+
+const claudeSystemPromptFileEnv = "TUTTI_CLAUDE_SYSTEM_PROMPT_FILE";
+const claudePluginDirEnv = "TUTTI_CLAUDE_PLUGIN_DIR";
 
 export type ClaudeToolsOption = NonNullable<ClaudeQueryOptions["tools"]>;
 
@@ -18,18 +22,61 @@ export type SidecarClaudeOptions = {
 export function sidecarClaudeOptionsFromPayload(
   payload: Record<string, unknown>
 ): SidecarClaudeOptions {
+  const env = stringRecordValue(payload.env);
+  const explicitSystemPrompt = stringValue(payload.systemPromptAppend);
+  const explicitPlugins = pluginListValue(payload.plugins);
+  const extraArgs = stringRecordValue(payload.extraArgs);
+  const pluginDir = explicitPlugins.length > 0 ? "" : env[claudePluginDirEnv];
+
+  if (pluginDir) {
+    let info;
+    try {
+      info = statSync(pluginDir);
+    } catch (error) {
+      throw new Error(`stat claude plugin dir: ${errorMessage(error)}`);
+    }
+    if (!info.isDirectory()) {
+      throw new Error(`claude plugin dir is not a directory: ${pluginDir}`);
+    }
+    if (!("plugin-dir" in extraArgs)) {
+      extraArgs["plugin-dir"] = pluginDir;
+    }
+  }
+
   return {
-    systemPromptAppend: stringValue(payload.systemPromptAppend),
+    systemPromptAppend:
+      explicitSystemPrompt ||
+      claudeSystemPromptAppend(env[claudeSystemPromptFileEnv]),
     planModeInstructions: stringValue(payload.planModeInstructions),
     allowedTools: stringArrayValue(payload.allowedTools),
     disallowedTools: stringArrayValue(payload.disallowedTools),
-    plugins: pluginListValue(payload.plugins),
-    extraArgs: stringRecordValue(payload.extraArgs),
+    plugins:
+      explicitPlugins.length > 0
+        ? explicitPlugins
+        : pluginDir
+          ? [{ type: "local", path: pluginDir }]
+          : [],
+    extraArgs,
     tools: toolsValue(payload.tools) ?? {
       type: "preset",
       preset: "claude_code"
     }
   };
+}
+
+function claudeSystemPromptAppend(path: string | null | undefined): string {
+  if (!path) {
+    return "";
+  }
+  try {
+    return readFileSync(path, "utf8").trim();
+  } catch (error) {
+    throw new Error(`read claude system prompt: ${errorMessage(error)}`);
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 export function claudeQueryOptionOverrides(

--- a/packages/agent/daemon/runtime/claude_provider_meta.go
+++ b/packages/agent/daemon/runtime/claude_provider_meta.go
@@ -1,13 +1,8 @@
 package agentruntime
 
 import (
-	"fmt"
-	"os"
 	"strings"
 )
-
-const claudeSystemPromptFileEnv = "TUTTI_CLAUDE_SYSTEM_PROMPT_FILE"
-const claudePluginDirEnv = "TUTTI_CLAUDE_PLUGIN_DIR"
 
 const claudePlanModeInstructions = "You are in plan mode. Inspect files and gather context as needed, but do not edit files, run mutation commands, or make external changes. Produce a concrete implementation plan first. If the user gives feedback, refine the plan. Only after the user approves leaving plan mode may you implement changes."
 
@@ -26,33 +21,6 @@ var claudeCodeBuiltInModelAliases = map[string]bool{
 	"sonnet[1m]": true,
 }
 
-func claudeSystemPromptAppend(env []string) (string, error) {
-	path := sessionEnvValue(env, claudeSystemPromptFileEnv)
-	if strings.TrimSpace(path) == "" {
-		return "", nil
-	}
-	content, err := os.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("read claude system prompt: %w", err)
-	}
-	return string(content), nil
-}
-
-func claudePluginDir(env []string) (string, error) {
-	path := sessionEnvValue(env, claudePluginDirEnv)
-	if strings.TrimSpace(path) == "" {
-		return "", nil
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		return "", fmt.Errorf("stat claude plugin dir: %w", err)
-	}
-	if !info.IsDir() {
-		return "", fmt.Errorf("claude plugin dir is not a directory: %s", path)
-	}
-	return path, nil
-}
-
 func claudeCodeCustomModel(session Session) string {
 	model := strings.TrimSpace(session.SettingsValue().Model)
 	if model == "" || claudeCodeBuiltInModelAliases[model] {
@@ -61,49 +29,8 @@ func claudeCodeCustomModel(session Session) string {
 	return model
 }
 
-type claudeProviderMetaError struct {
-	phase string
-	err   error
-}
-
-func (e claudeProviderMetaError) Error() string {
-	if e.err == nil {
-		return e.phase
-	}
-	return e.err.Error()
-}
-
-func (e claudeProviderMetaError) Unwrap() error {
-	return e.err
-}
-
-type claudeCodeSessionMeta struct {
-	systemPromptPath   string
-	systemPromptAppend string
-	pluginDirPath      string
-	pluginDir          string
-	options            map[string]any
-}
-
-func buildClaudeCodeSessionMeta(session Session) (claudeCodeSessionMeta, error) {
-	meta := claudeCodeSessionMeta{
-		systemPromptPath: sessionEnvValue(session.Env, claudeSystemPromptFileEnv),
-		pluginDirPath:    sessionEnvValue(session.Env, claudePluginDirEnv),
-	}
-	systemPrompt, err := claudeSystemPromptAppend(session.Env)
-	if err != nil {
-		return meta, claudeProviderMetaError{phase: "system_prompt", err: err}
-	}
-	if !promptHasAgentConversationDetailMode(systemPrompt) {
-		systemPrompt = joinPromptSections(systemPrompt, agentConversationDetailModePromptAppend(session.SettingsValue()))
-	}
-	meta.systemPromptAppend = systemPrompt
-	pluginDir, err := claudePluginDir(session.Env)
-	if err != nil {
-		return meta, claudeProviderMetaError{phase: "plugin_dir", err: err}
-	}
-	meta.pluginDir = pluginDir
-	meta.options = map[string]any{
+func claudeCodeSDKStartOptions(session Session) map[string]any {
+	options := map[string]any{
 		"planModeInstructions": claudePlanModeInstructions,
 		"allowedTools":         []string{"Grep", "Glob"},
 		"disallowedTools":      []string{"Monitor"},
@@ -113,30 +40,11 @@ func buildClaudeCodeSessionMeta(session Session) (claudeCodeSessionMeta, error) 
 		},
 	}
 	extraArgs := map[string]string{}
-	if pluginDir != "" {
-		extraArgs["plugin-dir"] = pluginDir
-		meta.options["plugins"] = []map[string]string{
-			{"type": "local", "path": pluginDir},
-		}
-	}
 	if model := claudeCodeCustomModel(session); model != "" {
 		extraArgs["model"] = model
 	}
 	if len(extraArgs) > 0 {
-		meta.options["extraArgs"] = extraArgs
+		options["extraArgs"] = extraArgs
 	}
-	return meta, nil
-}
-
-func (m claudeCodeSessionMeta) sdkPayload() map[string]any {
-	payload := map[string]any{}
-	if strings.TrimSpace(m.systemPromptAppend) != "" {
-		payload["systemPromptAppend"] = m.systemPromptAppend
-	}
-	for _, key := range []string{"planModeInstructions", "allowedTools", "disallowedTools", "plugins", "extraArgs", "tools"} {
-		if value, ok := m.options[key]; ok {
-			payload[key] = value
-		}
-	}
-	return payload
+	return options
 }

--- a/packages/agent/daemon/runtime/claude_sdk_lifecycle.go
+++ b/packages/agent/daemon/runtime/claude_sdk_lifecycle.go
@@ -33,11 +33,6 @@ func (a *ClaudeCodeSDKAdapter) Start(ctx context.Context, session Session) ([]ac
 	launchSession := session
 	launchSession.CWD = spec.CWD
 	launchSession.Env = append([]string(nil), spec.Env...)
-	claudeMeta, err := buildClaudeCodeSessionMeta(launchSession)
-	if err != nil {
-		cleanupPreparedLaunch(cleanup)
-		return nil, err
-	}
 	conn, err := a.transport.Start(ctx, spec)
 	if err != nil {
 		cleanupPreparedLaunch(cleanup)
@@ -70,7 +65,7 @@ func (a *ClaudeCodeSDKAdapter) Start(ctx context.Context, session Session) ([]ac
 		"settings":          claudeSDKSessionSettingsPayload(session),
 		"resumeCursor":      claudeSDKResumeCursorFromSession(session),
 	}
-	for key, value := range claudeMeta.sdkPayload() {
+	for key, value := range claudeCodeSDKStartOptions(session) {
 		startPayload[key] = value
 	}
 	if err := adapterSession.send(claudeSDKSidecarRequest{

--- a/packages/agent/daemon/runtime/claude_sdk_session_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_session_test.go
@@ -295,15 +295,9 @@ func TestClaudeCodeSDKAdapterStartEnablesSandboxBypassEnv(t *testing.T) {
 	}
 }
 
-func TestClaudeCodeSDKAdapterStartSendsClaudeProviderMeta(t *testing.T) {
-	systemPromptPath := filepath.Join(t.TempDir(), "claude-system-prompt.md")
-	if err := os.WriteFile(systemPromptPath, []byte("Use Tutti CLI for issue context."), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	pluginDir := filepath.Join(t.TempDir(), "tutti-cli-plugin")
-	if err := os.MkdirAll(pluginDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
+func TestClaudeCodeSDKAdapterStartPassesPreparedClaudeMetaPathsToSidecar(t *testing.T) {
+	systemPromptPath := "/run/tsh/managed-agent/session/claude-system-prompt.md"
+	pluginDir := "/run/tsh/managed-agent/session/claude-plugin/tutti-cli"
 	conn := &scriptedClaudeSDKConnection{
 		frames: []ProcessFrame{{
 			Stdout: []byte(`{"type":"session_started","payload":{"providerSessionId":"provider-session-meta"}}` + "\n"),
@@ -314,8 +308,8 @@ func TestClaudeCodeSDKAdapterStartSendsClaudeProviderMeta(t *testing.T) {
 		return ProviderLaunchPrepareResult{
 			Command: input.Command,
 			Env: append(append([]string(nil), input.Env...),
-				claudeSystemPromptFileEnv+"="+systemPromptPath,
-				claudePluginDirEnv+"="+pluginDir,
+				"TUTTI_CLAUDE_SYSTEM_PROMPT_FILE="+systemPromptPath,
+				"TUTTI_CLAUDE_PLUGIN_DIR="+pluginDir,
 			),
 			CWD: input.CWD,
 		}, nil
@@ -336,8 +330,12 @@ func TestClaudeCodeSDKAdapterStartSendsClaudeProviderMeta(t *testing.T) {
 		t.Fatalf("sent requests = %#v, want start", sent)
 	}
 	payload := sent[0].Payload
-	if got, _ := payload["systemPromptAppend"].(string); got != "Use Tutti CLI for issue context." {
-		t.Fatalf("systemPromptAppend = %q, want prompt file content", got)
+	if _, ok := payload["systemPromptAppend"]; ok {
+		t.Fatalf("systemPromptAppend = %#v, want sidecar to read the prepared file", payload["systemPromptAppend"])
+	}
+	env := payloadMap(payload, "env")
+	if env["TUTTI_CLAUDE_SYSTEM_PROMPT_FILE"] != systemPromptPath || env["TUTTI_CLAUDE_PLUGIN_DIR"] != pluginDir {
+		t.Fatalf("env = %#v, want prepared Claude metadata paths", env)
 	}
 	if got, _ := payload["planModeInstructions"].(string); !strings.Contains(got, "do not edit files") || !strings.Contains(got, "implementation plan") {
 		t.Fatalf("planModeInstructions = %#v, want Tutti plan workflow instructions", payload["planModeInstructions"])
@@ -364,58 +362,15 @@ func TestClaudeCodeSDKAdapterStartSendsClaudeProviderMeta(t *testing.T) {
 	if !ok || tools["type"] != "preset" || tools["preset"] != "claude_code" {
 		t.Fatalf("tools = %#v, want claude_code preset", payload["tools"])
 	}
-	plugins, ok := payload["plugins"].([]any)
-	if !ok || len(plugins) != 1 {
-		t.Fatalf("plugins = %#v, want local plugin dir", payload["plugins"])
-	}
-	plugin, _ := plugins[0].(map[string]any)
-	if plugin["type"] != "local" || plugin["path"] != pluginDir {
-		t.Fatalf("plugins = %#v, want local plugin dir", payload["plugins"])
+	if _, ok := payload["plugins"]; ok {
+		t.Fatalf("plugins = %#v, want sidecar to resolve the prepared plugin dir", payload["plugins"])
 	}
 	extraArgs, ok := payload["extraArgs"].(map[string]any)
-	if !ok || extraArgs["plugin-dir"] != pluginDir || extraArgs["model"] != "MiniMax-M2.7" {
-		t.Fatalf("extraArgs = %#v, want plugin-dir and custom model", payload["extraArgs"])
+	if !ok || extraArgs["model"] != "MiniMax-M2.7" {
+		t.Fatalf("extraArgs = %#v, want custom model", payload["extraArgs"])
 	}
-}
-
-func TestClaudeCodeSDKAdapterStartFailsBeforeProcessForMissingClaudeMetaFiles(t *testing.T) {
-	transport := &recordingClaudeSDKTransport{conn: &scriptedClaudeSDKConnection{}}
-	adapter := NewClaudeCodeSDKAdapter(transport)
-	missingSystemPromptPath := filepath.Join(t.TempDir(), "missing.md")
-	cleanupCalls := 0
-	adapter.SetProviderLaunchPreparer(func(_ context.Context, input ProviderLaunchPrepareInput) (ProviderLaunchPrepareResult, error) {
-		return ProviderLaunchPrepareResult{
-			Command: input.Command,
-			Env:     append(append([]string(nil), input.Env...), claudeSystemPromptFileEnv+"="+missingSystemPromptPath),
-			CWD:     input.CWD,
-			Cleanup: func(context.Context) error {
-				cleanupCalls++
-				return nil
-			},
-		}, nil
-	})
-	session := standardTestSession(ProviderClaudeCode)
-
-	if _, err := adapter.Start(context.Background(), session); err == nil {
-		t.Fatal("Start error = nil, want missing system prompt error")
-	}
-	if transport.spec.Command != nil {
-		t.Fatalf("process spec = %#v, want no sidecar process start on invalid meta", transport.spec)
-	}
-	if cleanupCalls != 1 {
-		t.Fatalf("cleanup calls = %d, want 1 after prepared metadata validation fails", cleanupCalls)
-	}
-
-	pluginTransport := &recordingClaudeSDKTransport{conn: &scriptedClaudeSDKConnection{}}
-	pluginAdapter := NewClaudeCodeSDKAdapter(pluginTransport)
-	pluginSession := standardTestSession(ProviderClaudeCode)
-	pluginSession.Env = []string{claudePluginDirEnv + "=" + filepath.Join(t.TempDir(), "missing-plugin")}
-
-	if _, err := pluginAdapter.Start(context.Background(), pluginSession); err == nil {
-		t.Fatal("Start error = nil, want missing plugin dir error")
-	}
-	if pluginTransport.spec.Command != nil {
-		t.Fatalf("process spec = %#v, want no sidecar process start on invalid plugin dir", pluginTransport.spec)
+	if _, ok := extraArgs["plugin-dir"]; ok {
+		t.Fatalf("extraArgs = %#v, want sidecar to resolve plugin-dir", extraArgs)
 	}
 }
 

--- a/packages/agent/daemon/runtime/conversation_detail_mode.go
+++ b/packages/agent/daemon/runtime/conversation_detail_mode.go
@@ -15,31 +15,3 @@ func normalizeAgentConversationDetailMode(value string) string {
 		return AgentConversationDetailModeCoding
 	}
 }
-
-func agentConversationDetailModeDeveloperInstructions(conversationDetailMode string) string {
-	switch normalizeAgentConversationDetailMode(conversationDetailMode) {
-	case AgentConversationDetailModeGeneral:
-		return nonTechnicalUIConversationDetailModeDeveloperInstructions
-	default:
-		return ""
-	}
-}
-
-func agentConversationDetailModePromptAppend(settings SessionSettings) string {
-	instructions := agentConversationDetailModeDeveloperInstructions(settings.ConversationDetailMode)
-	if strings.TrimSpace(instructions) == "" {
-		return ""
-	}
-	return instructions
-}
-
-func promptHasAgentConversationDetailMode(content string) bool {
-	return strings.Contains(content, "### Non-technical UI")
-}
-
-const nonTechnicalUIConversationDetailModeDeveloperInstructions = `### Non-technical UI
-- The user has requested a non-technical UI.
-- The app will take care of aspects of this, such as hiding bash tool outputs and similar.
-- Prefer non-technical language when conversing with the user. For example, don't name bash commands you're running. Instead, describe what they do.
-- When writing code to perform non-coding tasks--such as writing and running python to build slide artifacts--avoid mentioning or citing these intermediate code items. Just focus on outputs.
-- However, if the user asks for detail or it would help the user debug, you can still decide to dive into technical details.`

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -220,16 +220,6 @@ func mergeACPParamsMeta(params map[string]any, meta map[string]any) {
 	}
 }
 
-func joinPromptSections(sections ...string) string {
-	nonEmpty := make([]string, 0, len(sections))
-	for _, section := range sections {
-		if trimmed := strings.TrimSpace(section); trimmed != "" {
-			nonEmpty = append(nonEmpty, trimmed)
-		}
-	}
-	return strings.Join(nonEmpty, "\n\n")
-}
-
 func sessionEnvValue(env []string, key string) string {
 	prefix := key + "="
 	for _, item := range env {

--- a/packages/agent/daemon/runtime/visible_error.go
+++ b/packages/agent/daemon/runtime/visible_error.go
@@ -310,18 +310,10 @@ func detailIsMcpToolServerAuth(detail string) bool {
 // binary that could not be located/executed (as opposed to a binary that ran and
 // exited non-zero).
 func codexErrorLooksLikeMissingBinary(lower string) bool {
-	for _, marker := range []string{
-		"no such file or directory",
-		"fork/exec",
-		"command not found",
-		"executable file not found",
-		"enoent",
-	} {
-		if strings.Contains(lower, marker) {
-			return true
-		}
-	}
-	return false
+	return strings.Contains(lower, "command not found") ||
+		strings.Contains(lower, "executable file not found") ||
+		strings.Contains(lower, "fork/exec") && strings.Contains(lower, "no such file or directory") ||
+		strings.Contains(lower, "spawn ") && strings.Contains(lower, "enoent")
 }
 
 // codexExitCodeFromDetail extracts the numeric process exit code from a

--- a/packages/agent/daemon/runtime/visible_error_test.go
+++ b/packages/agent/daemon/runtime/visible_error_test.go
@@ -204,6 +204,13 @@ func TestVisibleFailureCodeClassifiesMissingBinaryAsCliNotFound(t *testing.T) {
 	}
 }
 
+func TestVisibleFailureCodeDoesNotClassifyMetadataReadAsMissingCLI(t *testing.T) {
+	detail := `read claude system prompt: open /run/tsh/managed-agent/session/claude-system-prompt.md: no such file or directory`
+	if got := visibleFailureCode(detail); got != "provider_error" {
+		t.Fatalf("visibleFailureCode(%q) = %q, want provider_error", detail, got)
+	}
+}
+
 func TestVisibleFailureCodeClassifiesGenuineExitAsProcessExited(t *testing.T) {
 	// A non-zero exit that is NOT a missing binary stays process_exited.
 	if got := visibleFailureCode("codex process exited with code 1"); got != "process_exited" {


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Verification

<!-- Commands run, manual checks, or why verification is not applicable. -->

## Fix Scope Justification

<!--
Required when a fix-titled PR changes more than 300 lines; delete otherwise.

- Root cause: which event or state is the actual source of the bug?
- Why can this not be fixed at a lower layer?
-->

## Fallback Three Questions

<!--
Required when this change adds a timer, retry, cache, or defensive branch;
delete otherwise.

- Source: which event or state does this fallback compensate for?
- Why can it not be fixed at that source?
- Removal condition: when can this fallback be deleted?
-->

## Checklist

- [ ] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [ ] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [ ] I ran the lowest meaningful local checks for the changed surface.
- [ ] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->