### PR TITLE
fix(agent-gui): align queued prompt mentions

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.composition.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.composition.spec.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const css = readFileSync(
+  join(process.cwd(), "app/renderer/agentactivity.css"),
+  "utf8"
+);
+const queuedMentionStylesStart = css.indexOf(
+  ".agent-gui-node__composer-queued-prompt-markdown"
+);
+const queuedMentionStyles = css.slice(
+  queuedMentionStylesStart,
+  css.indexOf(
+    '.agent-gui-node__composer-queued-prompt-panel[data-expanded="true"]',
+    queuedMentionStylesStart
+  )
+);
+
+describe("AgentQueuedPromptPanel CSS composition", () => {
+  it("keeps the entity link layout-only around the shared mention pill", () => {
+    expect(queuedMentionStyles).toMatch(
+      /\[data-agent-file-mention="true"\]\.tsh-agent-object-token--entity\s*\{[^}]*top:\s*0;[^}]*gap:\s*0;[^}]*min-height:\s*0;[^}]*padding:\s*0;[^}]*border:\s*0;[^}]*line-height:\s*inherit;/s
+    );
+    expect(queuedMentionStyles).not.toMatch(
+      /\[data-agent-file-mention="true"\]\.tsh-agent-object-token--entity\s*\{[^}]*padding:\s*2px 4px;/s
+    );
+  });
+
+  it("vertically aligns file mentions, entity wrappers, and mention pills", () => {
+    expect(queuedMentionStyles).toMatch(
+      /\.tsh-agent-object-token--file,\s*\.agent-gui-node__composer-queued-prompt-markdown\s+\[data-agent-file-mention="true"\]\.tsh-agent-object-token--entity\s*> \[data-slot="mention-pill"\]\s*\{[^}]*top:\s*0;[^}]*vertical-align:\s*middle;/s
+    );
+  });
+});

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -8436,20 +8436,34 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   width: max-content;
   max-width: min(100%, var(--agent-mention-max-width, 16rem));
   color: inherit;
-  vertical-align: baseline;
+  vertical-align: middle;
 }
 
+/* Entity mentions wrap the shared MentionPill in an interactive link. Keep
+   that link layout-only so the pill remains the single owner of its visual
+   box; otherwise the wrapper's padding and offset create a second pill around
+   it and push adjacent queued mentions apart. */
 .agent-gui-node__composer-queued-prompt-markdown
   [data-agent-file-mention="true"].tsh-agent-object-token--entity {
   color: inherit;
-  top: 3px;
+  top: 0;
+  gap: 0;
   max-width: min(100%, var(--agent-mention-max-width, 16rem));
-  min-height: 24px;
-  padding: 2px 4px;
-  border: 1px solid transparent;
-  border-radius: 4px;
-  line-height: 20px;
+  min-height: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  line-height: inherit;
   transition: none;
+}
+
+.agent-gui-node__composer-queued-prompt-markdown
+  [data-agent-file-mention="true"].tsh-agent-object-token--file,
+.agent-gui-node__composer-queued-prompt-markdown
+  [data-agent-file-mention="true"].tsh-agent-object-token--entity
+  > [data-slot="mention-pill"] {
+  top: 0;
+  vertical-align: middle;
 }
 
 .agent-gui-node__composer-queued-prompt-markdown


### PR DESCRIPTION
## Summary

- keep queued entity mention links as layout-only wrappers around the shared `MentionPill`
- align file mentions, entity wrappers, and mention pills on the same middle baseline
- add a CSS composition regression test

## Root cause

Readonly Markdown mentions now render an interactive outer link around the shared `MentionPill`, while the queued-prompt stylesheet still applied the legacy pill padding, border, height, and vertical offset to that outer link. The nested visual boxes added spacing and produced different vertical offsets for entity and file mentions.

## Lower layer

`MentionPill` already correctly owns reusable mention geometry in `@tutti-os/ui-system`; changing that lower layer would affect unrelated composer and readonly rich-text consumers. The queue-specific wrapper normalization therefore belongs in `@tutti-os/agent-gui`.

## Validation

- pre-commit formatting and staged boundary checks passed
- `@tutti-os/agent-gui` test suite: 246 files, 2088 tests passed
- `pnpm check:changed -- --push-ready`: 12 lanes passed

## Documentation impact

No public API, ownership, or data-flow contract changed. Existing UI-system and AgentGUI ownership documentation already covers the boundary.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->