### PR TITLE
fix(workbench): make focused node activation idempotent

### DIFF
--- a/packages/workbench/surface/src/core/reducer.test.ts
+++ b/packages/workbench/surface/src/core/reducer.test.ts
@@ -60,6 +60,42 @@ test("selects the focused visible node when the stack top is minimized", () => {
   assert.equal(selectFocusedVisibleWorkbenchNode(state)?.id, "a");
 });
 
+test("keeps an already focused visible node stable", () => {
+  const state = createWorkbenchInitialState({
+    nodes: [makeNode("a"), makeNode("b")],
+    nodeStack: ["a", "b"]
+  });
+
+  const nextState = reduceWorkbenchState(state, {
+    type: "focusNode",
+    nodeID: "b"
+  });
+
+  assert.equal(nextState, state);
+  assert.equal(nextState.nodes, state.nodes);
+  assert.equal(nextState.nodeStack, state.nodeStack);
+});
+
+test("focuses background nodes and restores minimized focused nodes", () => {
+  let state = createWorkbenchInitialState({
+    nodes: [makeNode("a"), makeNode("b")],
+    nodeStack: ["a", "b"]
+  });
+
+  state = reduceWorkbenchState(state, { type: "focusNode", nodeID: "a" });
+  assert.equal(selectFocusedWorkbenchNode(state)?.id, "a");
+
+  state = reduceWorkbenchState(state, { type: "minimizeNode", nodeID: "a" });
+  assert.equal(state.nodes.find((node) => node.id === "a")?.isMinimized, true);
+
+  state = reduceWorkbenchState(state, { type: "focusNode", nodeID: "a" });
+  assert.equal(state.nodes.find((node) => node.id === "a")?.isMinimized, false);
+  assert.equal(
+    state.nodes.find((node) => node.id === "a")?.minimizedAtUnixMs,
+    null
+  );
+});
+
 test("tracks active resize node separately from active drag node", () => {
   let state = createWorkbenchInitialState({ nodes: [makeNode("a")] });
 

--- a/packages/workbench/surface/src/core/reducer.ts
+++ b/packages/workbench/surface/src/core/reducer.ts
@@ -124,8 +124,14 @@ export function reduceWorkbenchState<TData>(
         lockedLayout: pruneLockedLayout(state.lockedLayout, action.nodeID)
       };
 
-    case "focusNode":
-      if (!state.nodes.some((node) => node.id === action.nodeID)) {
+    case "focusNode": {
+      const targetNode = state.nodes.find((node) => node.id === action.nodeID);
+      if (!targetNode) {
+        return state;
+      }
+      const isAlreadyFocused =
+        state.nodeStack[state.nodeStack.length - 1] === action.nodeID;
+      if (isAlreadyFocused && !targetNode.isMinimized) {
         return state;
       }
       return {
@@ -137,6 +143,7 @@ export function reduceWorkbenchState<TData>(
         ),
         nodeStack: focusWorkbenchStack(state.nodeStack, action.nodeID)
       };
+    }
 
     case "minimizeNode":
       return updateNode(state, action.nodeID, (node) =>

--- a/packages/workbench/surface/src/host/missionControlAdapter.test.ts
+++ b/packages/workbench/surface/src/host/missionControlAdapter.test.ts
@@ -40,7 +40,12 @@ test("mission control adapter caches snapshots until controller state changes", 
   controller.commands.focusNode("node-a");
 
   const thirdSnapshot = adapter.getSnapshot();
-  assert.notEqual(thirdSnapshot, firstSnapshot);
+  assert.equal(thirdSnapshot, firstSnapshot);
+
+  controller.commands.minimizeNode("node-a");
+
+  const fourthSnapshot = adapter.getSnapshot();
+  assert.notEqual(fourthSnapshot, firstSnapshot);
 });
 
 function makeNode(id: string): WorkbenchNode<WorkbenchHostNodeData> {

--- a/packages/workbench/surface/src/store/createWorkbenchController.test.ts
+++ b/packages/workbench/surface/src/store/createWorkbenchController.test.ts
@@ -19,6 +19,27 @@ test("notifies subscribers when commands change state", () => {
   assert.equal(notifications, 1);
 });
 
+test("does not notify subscribers when focusing the focused visible node", () => {
+  const controller = createWorkbenchController();
+  controller.commands.openNode(makeNode("a"));
+  const focusedSnapshot = controller.getSnapshot();
+  let notifications = 0;
+  const unsubscribe = controller.subscribe(() => {
+    notifications += 1;
+  });
+
+  controller.commands.focusNode("a");
+
+  assert.equal(controller.getSnapshot(), focusedSnapshot);
+  assert.equal(notifications, 0);
+
+  controller.commands.minimizeNode("a");
+  controller.commands.focusNode("a");
+  assert.equal(controller.getSnapshot().nodes[0]?.isMinimized, false);
+  assert.equal(notifications, 2);
+  unsubscribe();
+});
+
 test("commands match dispatch paths", () => {
   const viaCommand = createWorkbenchController();
   const viaDispatch = createWorkbenchController();


### PR DESCRIPTION
## Summary
- return the existing Workbench state when a visible foreground node is focused again
- preserve focus changes for background nodes and restoration of minimized nodes
- cover reducer, controller notifications, and mission-control snapshot caching

## Root cause
Pointer-down inside an already focused Workbench window still dispatched focusNode. The reducer always allocated a new state, nodes array, and node object even though focus and visibility were unchanged. Consumers treated each redundant allocation as a real layout change and repeatedly persisted/reconciled room windows.

## Validation
- pnpm --filter @tutti-os/workbench-surface test
- pnpm check:changed
- push-ready hook: 10 lanes passed
- pnpm release:pack:check

## Docs
No docs impact: this is an internal idempotence correction with no public API change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->