### PR TITLE
fix(agent-gui): preserve image-only queue presentation

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -290,6 +290,8 @@ The busy-session prompt queue is ephemeral durable-intent coordination in the wo
 - a provider with native guidance capability may guide the active Turn
 - otherwise send-now performs exact cancel-then-send
 - user Stop pauses the queue; cancellation must not leak the next prompt
+- a visible failed queue entry continues to own its submitted content for retry;
+  draft settlement must not duplicate that content back into the composer
 - uncertain delivery reconciles by `clientSubmitId` and exact `turnId`; it never resends merely because the Session appears idle
 - the delivery barrier serializes new-Turn sends only; a guidance head steering the running barrier Turn is exempt and may steer it repeatedly, while in-flight, uncertain-delivery, suspension, and failed-head blockers still gate guidance sends
 - drain readiness is one pure decision over the queue record and canonical availability; a new blocker joins that single decision with an explicit priority against every existing blocker, never as another independent pre-check in the drain path
@@ -337,6 +339,11 @@ High-frequency transcript updates must not pair DOM mutation with unconditional 
 A virtualized transcript derives message-locator selection from the virtualizer's measured turn positions and explicit transcript identity. The currently mounted DOM window is rendering output, not a selection source; range changes must not make the locator temporarily select a neighboring message.
 
 Historical rich text renders from the canonical Tiptap document through a static schema renderer. Only interactive composer surfaces own a Tiptap Editor/ProseMirror EditorView; read-only transcript and title surfaces reuse the same mention/token presentation without mounting editor lifecycle.
+
+Attachment-only fallback labels such as `[Image]` may provide title or summary
+text, but they are not an additional transcript text block when the canonical
+structured content already renders the same image. Explicit display prompts
+remain transcript content and continue to replace expanded rich prompt text.
 
 ## 5. Agent identity and provider architecture
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIHomeDraftSettlementController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIHomeDraftSettlementController.spec.ts
@@ -1,4 +1,8 @@
-import { normalizeAgentActivitySession } from "@tutti-os/agent-activity-core";
+import {
+  normalizeAgentActivitySession,
+  selectEngineHasVisibleQueuedSubmit,
+  selectPendingSubmitsForSession
+} from "@tutti-os/agent-activity-core";
 import { describe, expect, it, vi } from "vitest";
 import { createTestAgentSessionEngine } from "../../../shared/testing/createTestAgentSessionEngine";
 import {
@@ -96,7 +100,7 @@ describe("AgentGUIHomeDraftSettlementController", () => {
     engine.dispose();
   });
 
-  it("restores a failed existing-session submit while its draft is empty", async () => {
+  it("restores the original image preview after a non-visible send fails", async () => {
     const engine = createTestAgentSessionEngine("test-workspace", {
       execute(command) {
         return command.type === "queue/sendPrompt"
@@ -119,9 +123,20 @@ describe("AgentGUIHomeDraftSettlementController", () => {
       })
     });
     const sourceScopeKey = "session:session-1";
+    const submittedDraft: AgentComposerDraft = [
+      { type: "text", text: "" },
+      {
+        type: "image",
+        id: "draft-image-1",
+        mimeType: "image/png",
+        name: "screen.png",
+        path: "/workspace/screen.png",
+        previewUrl: "data:image/png;base64,aWFnZQ=="
+      }
+    ];
     const snapshots: Record<string, SubmittedDraftSnapshot> = {
       "submit-1": {
-        content: [{ type: "text", text: "follow up" }],
+        content: submittedDraft,
         sourceScopeKey
       }
     };
@@ -141,18 +156,139 @@ describe("AgentGUIHomeDraftSettlementController", () => {
       type: "submit/requested",
       agentSessionId: "session-1",
       clientSubmitId: "submit-1",
-      content: [{ type: "text", text: "follow up" }],
+      content: [
+        {
+          type: "image",
+          mimeType: "image/png",
+          name: "screen.png",
+          path: "/workspace/screen.png"
+        }
+      ],
       expiresAtUnixMs: Date.now() + 60_000,
       requestedAtUnixMs: Date.now(),
       workspaceId: "test-workspace"
     });
 
     await vi.waitFor(() => {
-      expect(agentComposerDraftPrompt(drafts[sourceScopeKey]!)).toBe(
-        "follow up"
-      );
+      expect(drafts[sourceScopeKey]).toEqual(submittedDraft);
     });
     expect(snapshots).toEqual({});
+    detach();
+    engine.dispose();
+  });
+
+  it("does not duplicate a failed visible queued submit into the composer", async () => {
+    const engine = createTestAgentSessionEngine("test-workspace", {
+      execute(command) {
+        return command.type === "queue/sendPrompt"
+          ? Promise.reject(new Error("send failed"))
+          : Promise.resolve({ ok: true });
+      }
+    });
+    engine.dispatch({
+      type: "session/upserted",
+      session: normalizeAgentActivitySession({
+        activeTurnId: "turn-1",
+        agentSessionId: "session-1",
+        createdAtUnixMs: Date.now(),
+        cwd: "/workspace/app",
+        latestTurnInteractions: [],
+        pendingInteractions: [],
+        provider: "codex",
+        title: "session",
+        workspaceId: "test-workspace"
+      })
+    });
+    engine.dispatch({
+      type: "turn/upserted",
+      turn: {
+        agentSessionId: "session-1",
+        origin: "user_prompt",
+        phase: "running",
+        startedAtUnixMs: Date.now(),
+        turnId: "turn-1",
+        updatedAtUnixMs: Date.now()
+      }
+    });
+    const sourceScopeKey = "session:session-1";
+    const submittedDraft: AgentComposerDraft = [
+      { type: "text", text: "" },
+      {
+        type: "image",
+        id: "draft-image-1",
+        mimeType: "image/png",
+        name: "screen.png",
+        path: "/workspace/screen.png",
+        previewUrl: "data:image/png;base64,aWFnZQ=="
+      }
+    ];
+    const snapshots: Record<string, SubmittedDraftSnapshot> = {
+      "submit-1": { content: submittedDraft, sourceScopeKey }
+    };
+    let drafts: Record<string, AgentComposerDraft> = {
+      [sourceScopeKey]: emptyAgentComposerDraft()
+    };
+    const controller = new AgentGUIHomeDraftSettlementController({
+      applyDraftUpdate: (update) => {
+        drafts = update(drafts);
+      },
+      engine,
+      snapshots
+    });
+    const detach = controller.attach();
+
+    engine.dispatch({
+      type: "submit/requested",
+      agentSessionId: "session-1",
+      clientSubmitId: "submit-1",
+      content: [
+        {
+          type: "image",
+          mimeType: "image/png",
+          name: "screen.png",
+          path: "/workspace/screen.png"
+        }
+      ],
+      expiresAtUnixMs: Date.now() + 60_000,
+      requestedAtUnixMs: Date.now(),
+      workspaceId: "test-workspace"
+    });
+    expect(
+      selectEngineHasVisibleQueuedSubmit(
+        engine.getSnapshot(),
+        "session-1",
+        "submit-1"
+      )
+    ).toBe(true);
+    engine.dispatch({
+      type: "turn/upserted",
+      turn: {
+        agentSessionId: "session-1",
+        origin: "user_prompt",
+        outcome: "completed",
+        phase: "settled",
+        startedAtUnixMs: Date.now() - 1,
+        turnId: "turn-1",
+        updatedAtUnixMs: Date.now()
+      }
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        selectPendingSubmitsForSession(engine.getSnapshot(), "session-1").find(
+          (submit) => submit.clientSubmitId === "submit-1"
+        )?.status
+      ).toBe("failed");
+    });
+    expect(
+      selectEngineHasVisibleQueuedSubmit(
+        engine.getSnapshot(),
+        "session-1",
+        "submit-1"
+      )
+    ).toBe(true);
+    expect(drafts[sourceScopeKey]).toEqual(emptyAgentComposerDraft());
+    expect(snapshots["submit-1"]?.content).toEqual(submittedDraft);
     detach();
     engine.dispose();
   });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIHomeDraftSettlementController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIHomeDraftSettlementController.ts
@@ -1,4 +1,5 @@
 import {
+  selectEngineHasVisibleQueuedSubmit,
   selectPendingActivations,
   selectPendingSubmitsForSession,
   type AgentSessionEngine,
@@ -64,10 +65,9 @@ export class AgentGUIHomeDraftSettlementController {
           activation.status === "confirmed"
             ? clearSubmittedDraftIfUnchanged({ drafts, snapshot })
             : restoreFailedAgentGUIHomeDraft({
-                agentSessionId: activation.agentSessionId,
-                content: activation.content,
                 draftKey: snapshot.sourceScopeKey,
-                drafts
+                drafts,
+                submittedDraft: snapshot.content
               })
         );
         delete this.snapshots[clientSubmitId];
@@ -91,13 +91,22 @@ export class AgentGUIHomeDraftSettlementController {
       ) {
         continue;
       }
+      if (
+        submit.status === "failed" &&
+        selectEngineHasVisibleQueuedSubmit(
+          state,
+          submit.agentSessionId,
+          clientSubmitId
+        )
+      ) {
+        continue;
+      }
       this.applyDraftUpdate((drafts) =>
         submit.status === "failed"
           ? restoreFailedAgentGUIHomeDraft({
-              agentSessionId: submit.agentSessionId,
-              content: submit.content,
               draftKey: snapshot.sourceScopeKey,
-              drafts
+              drafts,
+              submittedDraft: snapshot.content
             })
           : clearSubmittedDraftIfUnchanged({ drafts, snapshot })
       );

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.homeDraftHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.homeDraftHelpers.ts
@@ -1,8 +1,7 @@
-import type { AgentPromptContentBlock } from "../../../shared/contracts/dto";
 import {
   agentComposerDraftHasContent,
-  agentPromptContentToComposerDraft,
-  emptyAgentComposerDraft
+  emptyAgentComposerDraft,
+  snapshotAgentComposerDraft
 } from "../model/agentComposerDraft";
 import type { AgentComposerDraft } from "../model/agentGuiNodeTypes";
 import { shouldClearSubmittedDraft } from "./agentGuiController.draftMessageHelpers";
@@ -27,10 +26,9 @@ export function clearSubmittedAgentGUIHomeDraft(input: {
 }
 
 export function restoreFailedAgentGUIHomeDraft(input: {
-  agentSessionId: string;
-  content: readonly AgentPromptContentBlock[];
   draftKey: string;
   drafts: Record<string, AgentComposerDraft>;
+  submittedDraft: AgentComposerDraft;
 }): Record<string, AgentComposerDraft> {
   const currentDraft = input.drafts[input.draftKey];
   if (currentDraft && agentComposerDraftHasContent(currentDraft)) {
@@ -38,9 +36,6 @@ export function restoreFailedAgentGUIHomeDraft(input: {
   }
   return {
     ...input.drafts,
-    [input.draftKey]: agentPromptContentToComposerDraft(
-      input.content,
-      `activation-failure:${input.agentSessionId}`
-    )
+    [input.draftKey]: snapshotAgentComposerDraft(input.submittedDraft)
   };
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts
@@ -145,9 +145,8 @@ describe("new-conversation home draft lifecycle", () => {
     const empty = { [draftKey]: draft("") };
     const changed = { [draftKey]: draft("second") };
     const failure = {
-      agentSessionId: "session-1",
-      content: [{ type: "text" as const, text: "first" }],
-      draftKey
+      draftKey,
+      submittedDraft: draft("first")
     };
 
     expect(

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
@@ -2079,6 +2079,73 @@ describe("projectAgentConversationVM", () => {
     );
   });
 
+  it("does not render a synthetic image-only displayPrompt below the image", () => {
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        session: {
+          ...detailViewModel().session,
+          workspaceId: "room-1"
+        },
+        turns: [
+          {
+            id: "turn-1",
+            userMessage: null,
+            userMessages: [
+              {
+                id: "user-1",
+                body: "[Image]",
+                sourceTimelineItems: [
+                  {
+                    id: 1,
+                    agentSessionId: "session-1",
+                    eventId: "event-1",
+                    actorType: "user",
+                    actorId: "user",
+                    itemType: "message",
+                    role: "user",
+                    payload: {
+                      displayPrompt: "[Image]",
+                      content: [
+                        {
+                          type: "image",
+                          mimeType: "image/png",
+                          attachmentId: "attachment-1",
+                          name: "screen.png"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            agentMessages: [],
+            toolCalls: [],
+            toolCallCount: 0,
+            hasFailedToolCall: false,
+            agentItems: []
+          }
+        ],
+        showProcessingIndicator: false
+      })
+    );
+
+    const userRow = conversation.rows.find(
+      (
+        row
+      ): row is Extract<
+        (typeof conversation.rows)[number],
+        { kind: "message" }
+      > => row.kind === "message" && row.speaker === "user"
+    );
+
+    expect(userRow?.messages.map((message) => message.contentKind)).toEqual([
+      "image-grid"
+    ]);
+    expect(userRow?.messages.map((message) => message.body)).not.toContain(
+      "[Image]"
+    );
+  });
+
   it("reuses unchanged transcript row references across incremental updates", () => {
     const firstTurn = detailViewModel().turns[0]!;
     const secondTurn = {

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationUserProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationUserProjection.ts
@@ -127,6 +127,12 @@ function userPromptContentBlocks(
         : ""
     ) ?? []
   );
+  const visibleDisplayPrompt = isSyntheticImageOnlyDisplayPrompt(
+    displayPrompt,
+    content
+  )
+    ? ""
+    : displayPrompt;
   const blocks = content.flatMap((raw): UserPromptContentBlock[] => {
     const block =
       raw && typeof raw === "object" && !Array.isArray(raw)
@@ -134,7 +140,7 @@ function userPromptContentBlocks(
         : null;
     if (!block) return [];
     if (block.type === "text" && typeof block.text === "string") {
-      return displayPrompt
+      return visibleDisplayPrompt
         ? []
         : [{ type: "text", text: linkifyPastedTextReferences(block.text) }];
     }
@@ -156,9 +162,37 @@ function userPromptContentBlocks(
       }
     ];
   });
-  return displayPrompt
-    ? [{ type: "text", text: displayPrompt }, ...blocks]
+  return visibleDisplayPrompt
+    ? [{ type: "text", text: visibleDisplayPrompt }, ...blocks]
     : blocks;
+}
+
+function isSyntheticImageOnlyDisplayPrompt(
+  displayPrompt: string,
+  content: readonly unknown[]
+): boolean {
+  if (displayPrompt !== "[Image]" && displayPrompt !== "[Images]") {
+    return false;
+  }
+  let imageCount = 0;
+  for (const raw of content) {
+    const block =
+      raw && typeof raw === "object" && !Array.isArray(raw)
+        ? (raw as Record<string, unknown>)
+        : null;
+    if (!block) continue;
+    if (
+      block.type === "text" &&
+      typeof block.text === "string" &&
+      block.text.trim()
+    ) {
+      return false;
+    }
+    if (block.type === "image") {
+      imageCount += 1;
+    }
+  }
+  return displayPrompt === "[Image]" ? imageCount === 1 : imageCount > 1;
 }
 
 function optionalString(value: unknown): string | null {


### PR DESCRIPTION
## Summary
- suppress synthetic image-only fallback labels when structured images already render in the transcript
- keep failed visible queued prompts owned by the queue instead of duplicating them into the composer
- restore the original submitted draft snapshot for genuine send failures so image previews remain renderer-safe
- document the queue and transcript presentation ownership rules

## Root cause
TSH projects an attachment-only fallback such as [Image] through displayPrompt, while Agent GUI treated every displayPrompt as explicit transcript text. Separately, failed queued sends remained in the retryable queue but the generic draft settlement controller also rebuilt them from path-backed transport content, producing a duplicate draft with an unreadable VM path preview.

## Validation
- pnpm check:changed
- pnpm check:changed -- --push-ready
- pnpm release:pack:check
- focused Agent GUI tests: 58 passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->