### PR TITLE
fix(agent-gui): remove conversation rail toggle button animation

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -5307,6 +5307,12 @@ aside.workspace-agents-status-panel
 
 .agent-gui-workbench-header__rail-toggle {
   margin-left: auto;
+  /* The rail toggle must not animate: no hover fade, no press-down motion. */
+  transition: none !important;
+}
+
+.agent-gui-workbench-header__rail-toggle:active {
+  transform: none !important;
 }
 
 .agent-gui-workbench-header__detached-window {


### PR DESCRIPTION
## Motivation

The expand/collapse icon button for the Agent GUI left conversation rail (workbench header) should have no motion effects. It currently inherits the ui-system `Button` base behavior:

- `transition-[background-color,border-color,color,box-shadow,transform]` — hover background/color cross-fade
- `active:not-aria-[haspopup]:translate-y-px` — 1px press-down on click

## Changes

Scoped CSS-only change in `packages/agent/gui/app/renderer/agentactivity.css`, applied only to `.agent-gui-workbench-header__rail-toggle` (other header icon buttons are unaffected):

- `transition: none !important` — removes the hover fade
- `:active { transform: none !important; }` — removes the press-down movement

## Verification

- `pnpm build` in `packages/agent/gui` passes; the new rules are present in `dist/app/renderer/agentactivity.css`
- Pre-commit staged checks pass (prettier, backdrop-filter, electron-runtime, ui-boundary, renderer-feature, agent-gui degradation)
- Visual-only change; needs a quick visual check in the desktop app after release
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->