### PR TITLE
fix(agent-gui): remove workbench header icon button animations

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -5283,6 +5283,13 @@ aside.workspace-agents-status-panel
   background: transparent !important;
   color: var(--agent-gui-workbench-header-muted) !important;
   cursor: pointer;
+  /* Header chrome icon buttons must not animate: no hover fade, no
+     press-down motion inherited from the ui-system Button base. */
+  transition: none !important;
+}
+
+.agent-gui-workbench-header__icon-button:active {
+  transform: none !important;
 }
 
 .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
@@ -5307,12 +5314,6 @@ aside.workspace-agents-status-panel
 
 .agent-gui-workbench-header__rail-toggle {
   margin-left: auto;
-  /* The rail toggle must not animate: no hover fade, no press-down motion. */
-  transition: none !important;
-}
-
-.agent-gui-workbench-header__rail-toggle:active {
-  transform: none !important;
 }
 
 .agent-gui-workbench-header__detached-window {


### PR DESCRIPTION
## Motivation

Follow-up to #1516, which removed the animation from the conversation rail toggle only. All workbench header chrome icon buttons should have no motion effects.

The ui-system `Button` base class gives every header icon button (`new session`, `detached window`, `rail toggle` — all share `.agent-gui-workbench-header__icon-button`):

- `transition-[background-color,border-color,color,box-shadow,transform]` — hover background/color cross-fade
- `active:not-aria-[haspopup]:translate-y-px` — 1px press-down on click

## Changes

CSS-only, scoped to `.agent-gui-workbench-header__icon-button` in `packages/agent/gui/app/renderer/agentactivity.css`:

- `transition: none !important` — removes the hover fade (moved up from the rail-toggle-only rule added in #1516)
- `:active { transform: none !important; }` — removes the press-down movement

Supersedes the rail-toggle-specific rules from #1516; other header elements (traffic lights, title) are unaffected.

## Verification

- `pnpm build` in `packages/agent/gui` passes; rules confirmed in `dist/app/renderer/agentactivity.css`
- Visual-only change; verified locally in the desktop dev build after release + TSH upgrade
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->