### PR TITLE
fix(agent-gui): render pasted text mentions in conversation

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
@@ -537,6 +537,20 @@ function agentMentionItemToRowItem(
     };
   }
 
+  if (item.kind === "pasted-text") {
+    return {
+      kind: "file",
+      name: item.name,
+      visualKind: resolveAgentMentionFileVisualKind({
+        path: item.path,
+        entryKind: "file"
+      }),
+      thumbnailUrl: null,
+      childCountLabel: null,
+      entryKind: "file"
+    };
+  }
+
   if (item.kind === "custom") {
     // 自定义 mention 只经 draftPrompt prefill 进入 composer,不出现在 @ 面板候选;
     // 兜底按通用条目展示(label 即注册方给的 name)。

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
@@ -32,6 +32,7 @@ type AgentMentionNodeViewKind =
   | "workspace-reference"
   | "workspace-app-factory"
   | "workspace-issue"
+  | "pasted-text"
   | "custom";
 
 function parseFileCountAttr(value: unknown): number {
@@ -110,6 +111,9 @@ function normalizeKind(value: string): AgentMentionNodeViewKind {
   }
   if (value === "agent-target") {
     return "agent-target";
+  }
+  if (value === "pasted-text") {
+    return "pasted-text";
   }
   if (value === "custom") {
     return "custom";
@@ -210,6 +214,17 @@ function mentionViewModel(
       iconUrl:
         attrString(attrs, "iconUrl").trim() ||
         managedAgentRoundedIconUrl(agentProviderId),
+      kind,
+      label: name
+    };
+  }
+
+  if (kind === "pasted-text") {
+    return {
+      ariaLabel: name,
+      directoryPath: "",
+      entryKind: "file",
+      href,
       kind,
       label: name
     };
@@ -450,7 +465,8 @@ function AgentMentionView({
   if (
     mention.kind === "workspace-app" ||
     mention.kind === "workspace-reference" ||
-    mention.kind === "agent-target"
+    mention.kind === "agent-target" ||
+    mention.kind === "pasted-text"
   ) {
     return (
       <Wrapper
@@ -471,13 +487,23 @@ function AgentMentionView({
           iconUrl={mention.iconUrl}
           iconContainerProps={{
             "data-agent-mention-app-icon":
-              mention.kind === "agent-target" ? undefined : "true",
+              mention.kind === "agent-target" || mention.kind === "pasted-text"
+                ? undefined
+                : "true",
             "data-agent-mention-session-icon":
               mention.kind === "agent-target" ? "true" : undefined,
             "data-workspace-app-icon":
-              mention.kind === "agent-target" ? undefined : "true"
+              mention.kind === "agent-target" || mention.kind === "pasted-text"
+                ? undefined
+                : "true"
           }}
-          kind={mention.kind === "agent-target" ? "session" : "app"}
+          kind={
+            mention.kind === "agent-target"
+              ? "session"
+              : mention.kind === "pasted-text"
+                ? "file"
+                : "app"
+          }
           label={mention.label}
           removable={isEditable}
           removeButtonProps={

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionContracts.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionContracts.ts
@@ -15,6 +15,7 @@ export type AgentMentionKind =
   | "workspace-reference"
   | "workspace-app-factory"
   | "workspace-issue"
+  | "pasted-text"
   | "custom";
 
 export type AgentMentionReferenceSource = "app" | "task";
@@ -122,6 +123,14 @@ export interface AgentMentionWorkspaceAppFactoryItem {
   contextPath?: string;
 }
 
+export interface AgentMentionPastedTextItem {
+  kind: "pasted-text";
+  href: string;
+  targetId: string;
+  name: string;
+  path: string;
+}
+
 // 宿主注册的自定义 mention(见 shared/agentCustomMentionKinds):href 是完整信息源
 // (round-trip 无损),item 只承载通用展示字段;业务细节由宿主在注册的钩子里从 href 还原。
 export interface AgentMentionCustomItem {
@@ -147,6 +156,7 @@ export type AgentContextMentionItem =
   | AgentMentionWorkspaceReferenceItem
   | AgentMentionWorkspaceAppFactoryItem
   | AgentMentionWorkspaceIssueItem
+  | AgentMentionPastedTextItem
   | AgentMentionCustomItem;
 
 export type AgentFileMentionItem = AgentContextMentionItem;

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts
@@ -339,6 +339,26 @@ describe("parseAgentMentionMarkdown", () => {
     });
   });
 
+  it("parses pasted-text mentions as built-in file presentations", () => {
+    const href =
+      "mention://pasted-text/11111111-1111-4111-8111-111111111111?path=%2Fvar%2Fcache%2Ftsh%2Flocal-assets%2Fdeadbeef.txt&size=15083";
+    const parsed = parseAgentMentionMarkdown(`[@first pasted line](${href})`);
+
+    expect(parsed?.item).toEqual({
+      kind: "pasted-text",
+      href,
+      targetId: "11111111-1111-4111-8111-111111111111",
+      name: "first pasted line",
+      path: "/var/cache/tsh/local-assets/deadbeef.txt"
+    });
+    expect(formatAgentMentionMarkdown(parsed!.item)).toBe(
+      `[@first pasted line](${href})`
+    );
+    expect(attrsToMentionItem(mentionItemToAttrs(parsed!.item))).toEqual(
+      parsed!.item
+    );
+  });
+
   it("accepts workspace issue mention hrefs without an @ prefix", () => {
     expect(
       parseAgentMentionMarkdown(

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
@@ -33,6 +33,7 @@ export type {
   AgentMentionFileItem,
   AgentMentionFileNavigationAction,
   AgentMentionKind,
+  AgentMentionPastedTextItem,
   AgentMentionReferenceSource,
   AgentMentionScope,
   AgentMentionSessionItem,
@@ -243,7 +244,7 @@ export function createAgentFileMentionExtension(
         "data-agent-mention-href": href,
         "data-agent-mention-kind": item.kind,
         "aria-label":
-          item.kind === "file"
+          item.kind === "file" || item.kind === "pasted-text"
             ? visual.primary
             : `${visual.kindLabel} ${visual.primary}`.trim()
       };
@@ -268,11 +269,11 @@ export function createAgentFileMentionExtension(
             ? { "data-agent-mention-thumbnail-url": fileThumbnailUrl }
             : {}),
           class:
-            item.kind === "file"
+            item.kind === "file" || item.kind === "pasted-text"
               ? "tsh-agent-object-token tsh-agent-object-token--file"
               : "tsh-agent-object-token tsh-agent-object-token--entity"
         }),
-        ...(item.kind === "file"
+        ...(item.kind === "file" || item.kind === "pasted-text"
           ? [
               fileThumbnailUrl
                 ? [

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionAttrs.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionAttrs.ts
@@ -84,6 +84,15 @@ export function mentionItemToAttrs(
       iconUrl: item.iconUrl ?? ""
     };
   }
+  if (item.kind === "pasted-text") {
+    return {
+      name: item.name,
+      kind: item.kind,
+      href: item.href,
+      targetId: item.targetId,
+      path: item.path
+    };
+  }
   if (item.kind === "workspace-reference") {
     return {
       name: item.name,
@@ -285,6 +294,15 @@ export function attrsToMentionItem(
           : undefined
     };
   }
+  if (kind === "pasted-text") {
+    return {
+      kind,
+      href,
+      targetId: typeof attrs.targetId === "string" ? attrs.targetId.trim() : "",
+      name,
+      path: typeof attrs.path === "string" ? attrs.path.trim() : ""
+    };
+  }
   if (kind === "workspace-reference") {
     const workspaceId = workspaceIdFromMentionAttrs(attrs);
     const targetId =
@@ -436,6 +454,9 @@ function normalizeMentionKind(value: unknown): AgentMentionKind {
   }
   if (value === "workspace-app-factory") {
     return "workspace-app-factory";
+  }
+  if (value === "pasted-text") {
+    return "pasted-text";
   }
   if (value === "custom") {
     return "custom";

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionMarkdown.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionMarkdown.ts
@@ -8,6 +8,7 @@ import {
 } from "@tutti-os/ui-rich-text/core";
 import { getAgentCustomMentionKind } from "../../../shared/agentCustomMentionKinds";
 import { translate } from "../../../i18n/index";
+import { AGENT_PASTED_TEXT_MENTION_KIND } from "../../../shared/pastedTextKinds";
 import type {
   AgentContextMentionItem,
   AgentComposerFileMentionStatus,
@@ -429,6 +430,19 @@ export function parseMentionItemFromHref(input: {
       workspaceId,
       targetId,
       name
+    };
+  }
+  if (resource === AGENT_PASTED_TEXT_MENTION_KIND) {
+    const path = mention.scope?.path?.trim() ?? "";
+    if (!targetId || !path) {
+      return null;
+    }
+    return {
+      kind: "pasted-text",
+      href,
+      targetId,
+      name,
+      path
     };
   }
   if (resource === "workspace-reference") {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionPresentation.ts
@@ -26,7 +26,7 @@ export function mentionVisual(item: AgentContextMentionItem): {
   kindLabel: string;
   primary: string;
 } {
-  if (item.kind === "file") {
+  if (item.kind === "file" || item.kind === "pasted-text") {
     return {
       kindLabel: "File",
       primary: item.name

--- a/packages/agent/gui/shared/AgentRichTextReadonly.spec.tsx
+++ b/packages/agent/gui/shared/AgentRichTextReadonly.spec.tsx
@@ -309,6 +309,28 @@ describe("AgentRichTextReadonly", () => {
     );
   });
 
+  it("renders pasted text references as file pills instead of raw markdown", async () => {
+    const href =
+      "mention://pasted-text/11111111-1111-4111-8111-111111111111?path=%2Fvar%2Fcache%2Ftsh%2Flocal-assets%2Fdeadbeef.txt&size=15083";
+    const { container } = render(
+      <AgentRichTextReadonly value={`[@first pasted line](${href})`} />
+    );
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-agent-mention-kind="pasted-text"]')
+      ).not.toBeNull()
+    );
+
+    const mention = container.querySelector(
+      '[data-agent-mention-kind="pasted-text"]'
+    );
+    expect(mention).toHaveTextContent("first pasted line");
+    expect(mention?.querySelector('[data-slot="mention-pill"]')).not.toBeNull();
+    expect(mention).toHaveAttribute("data-agent-mention-href", href);
+    expect(container).not.toHaveTextContent("mention://pasted-text");
+  });
+
   it("renders known skill triggers as skill tokens", async () => {
     const { container } = render(
       <AgentRichTextReadonly


### PR DESCRIPTION
## Summary

Long pasted text is stored as a canonical `mention://pasted-text/...` reference. The read-only rich-text conversation renderer did not recognize that built-in resource, so it fell back to ordinary text and exposed the complete Markdown URL in consuming applications such as TSH.

This change promotes `pasted-text` to a first-class Agent GUI mention, preserves its href/path through parsing and attribute round-trips, and renders it through the existing file `MentionPill` presentation. It also adds parser and read-only conversation regression coverage to ensure the canonical URL is no longer shown.

## Verification

- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 shared/AgentRichTextReadonly.spec.tsx agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts` — 2 files and 56 tests passed, including the pasted-text conversation regression.
- `pnpm --filter @tutti-os/agent-gui test` — 246 files and 2092 tests passed.
- `pnpm --filter @tutti-os/agent-gui typecheck` — passed.
- `pnpm check:changed --tail-lines 100` — 11 lanes passed; the pre-push push-ready check passed 12 lanes.

## Checklist

- [x] This PR does not change agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I checked documentation impact; the existing large-paste and read-only-rendering architecture documentation already describes the intended behavior.
- [x] No README or CONTRIBUTING language variants are changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.
