### PR TITLE
fix(agent): stabilize goal control rendering and delivery

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -216,7 +216,7 @@ A child Interaction may appear in the root conversation, but submission carries 
 
 Goal is a Session-level durable entity, not a Turn command. It owns desired/observed state, revision, and an independent operation.
 
-A Goal operation may produce zero or more provider Turns, but it cannot reserve or fabricate Turn IDs. Goal control bypasses the prompt pipeline and does not create a user transcript message.
+A Goal operation may produce zero or more provider Turns, but it cannot reserve or fabricate Turn IDs. Goal control bypasses the prompt pipeline and does not create a user transcript Turn message. AgentGUI may project its durable session audit as a dedicated `goal-control` timeline row; that row has no Turn ID and does not participate in Turn counts, processing ownership, cancellation, or settlement.
 
 Host owns recovery for runtime operations, Goal operations, and the reconcile inbox. An adapter must not start a second worker or state machine.
 
@@ -544,7 +544,9 @@ and runtime adapter preserve the structured `{action, objective}` command, the
 host integration creates a non-provisional Session without initial content,
 and Goal control completes without manufacturing a Turn. The structured field
 is authoritative; integrations must not reparse the display prompt to recover
-Goal semantics.
+Goal semantics. AgentGUI represents the pending control and its durable audit
+with the same client-submit presentation identity, so canonical replacement
+does not remove and recreate the visible `goal-control` row.
 The pending activation carries the same resolved project section key as the
 create command. Exact rail projection therefore shows the conversation as soon
 as the intent is accepted; it does not wait for provider startup or invent a

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -218,6 +218,11 @@ Goal is a Session-level durable entity, not a Turn command. It owns desired/obse
 
 A Goal operation may produce zero or more provider Turns, but it cannot reserve or fabricate Turn IDs. Goal control bypasses the prompt pipeline and does not create a user transcript Turn message. AgentGUI may project its durable session audit as a dedicated `goal-control` timeline row; that row has no Turn ID and does not participate in Turn counts, processing ownership, cancellation, or settlement.
 
+When a session-level timeline row occurs chronologically between two rows from
+the same Turn, transcript presentation keeps one Turn group and renders the
+session-level row as an interstitial item. This presentation grouping does not
+assign the row a Turn ID or make it lifecycle-owned by that Turn.
+
 Host owns recovery for runtime operations, Goal operations, and the reconcile inbox. An adapter must not start a second worker or state machine.
 
 On daemon restart, Host recovery first restores durable operations, then settles unrecoverable active Turns as `settled/interrupted` and supersedes pending Interactions.

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -551,10 +551,10 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
 
 - Symptom:
   Clearing a goal while its current turn is still running leaves the composer
-  on a non-clickable send spinner. The transcript shows `/goal clear` followed
-  by a new processing row even though no new user turn started. Claude Code may
-  instead append a native `Goal cleared: …` assistant message at the bottom of
-  the transcript after the interrupted turn.
+  on a non-clickable send spinner. The transcript treats `/goal clear` as a
+  user Turn followed by a new processing row even though no new user work
+  started. Claude Code may instead append a native `Goal cleared: …` assistant
+  message at the bottom of the transcript after the interrupted turn.
 - Quick checks:
   Inspect the AgentGUI clear handler and the engine pending-submit records. If
   clear calls `executePrompt` with an immediate `/goal clear`, the control has
@@ -573,7 +573,10 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   row at the bottom.
 - Fix:
   Route every goal action, including clear, through the dedicated runtime
-  goal-control API. Do not create a user message, pending submit, or pseudo turn.
+  goal-control API. Do not create a user Turn message, pending submit, or pseudo
+  turn. A surface may project the durable session audit as a dedicated
+  `goal-control` row, but that row must carry no Turn ID and must not affect
+  processing ownership or Turn counts.
   If the provider needs an internal clear-command turn, register its generated
   turn ID and suppress only that turn's assistant/thinking acknowledgement at
   the runtime-adapter boundary before persistence. Do not filter by localized
@@ -588,11 +591,12 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   active light or dark theme instead of using the inverted neutral toast style.
 - Validation:
   Clear a goal while a turn is running and verify the goal-control API is called
-  without an engine submit dispatch. The clear command must not appear in the
-  transcript, the original processing row must remain in place, and Stop must
-  remain clickable until the active turn settles or is interrupted. For Claude
-  Code, verify the native acknowledgement is absent both live and after reload,
-  while identical text from an ordinary assistant turn remains visible.
+  without an engine submit dispatch. If the clear control is visible, it must
+  be a `goal-control` row with no Turn ID; the original processing row must
+  remain in place, and Stop must remain clickable until the active turn settles
+  or is interrupted. For Claude Code, verify the native acknowledgement is
+  absent both live and after reload, while identical text from an ordinary
+  assistant turn remains visible.
 - References:
   [useAgentGUISubmitInteractionActions.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts)
   [claude_sdk_goal.go](../../../packages/agent/daemon/runtime/claude_sdk_goal.go)
@@ -2181,3 +2185,37 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [Agent Goal Control Design](../../specs/2026-07-15-agent-goal-control-design.md)
   [controller_exec.go](../../../packages/agent/daemon/runtime/controller_exec.go)
   [goal_state.go](../../../packages/agent/store-sqlite/goal_state.go)
+
+### Initial Goal prompt disappears when the Agent starts responding
+
+- Symptom:
+  A new conversation opened with `/goal <objective>` first shows the submitted
+  command, then removes it as soon as the durable session or the first provider
+  response arrives. The response and processing state remain visible.
+- Quick checks:
+  Compare the optimistic activation message with the durable
+  `session_audit`. Verify both carry the same `clientSubmitId` and inspect the
+  transcript projection after the overlay removes the optimistic twin. If the
+  durable Goal audit is filtered from all presentation output, the replacement
+  leaves no visible row.
+- Root cause:
+  The optimistic activation was projected as an ordinary user message while
+  the canonical Goal control was correctly persisted as a session-level audit.
+  Overlay reconciliation removed the optimistic message by `clientSubmitId`,
+  then the message projector discarded the durable audit, so two individually
+  correct policies composed into a disappearing row.
+- Fix:
+  Mark the optimistic activation as Goal control when
+  `initialGoalControl` is present. Project both optimistic and durable forms as
+  a dedicated `goal-control` row outside the Turn model. Derive the row identity
+  from the audit payload's client-submit message identity before falling back
+  to the durable operation ID, so replacement preserves the renderer key.
+- Validation:
+  Project the optimistic-only state and the durable-after-overlay state. Both
+  must contain one `goal-control` row with the same ID and zero Turns. Also
+  verify the dedicated row renders, the first real provider Turn remains the
+  sole Turn, and reload produces the same control row.
+- References:
+  [workspaceAgentMessageOverlay.ts](../../../packages/agent/gui/shared/workspaceAgentMessageOverlay.ts)
+  [workspaceAgentMessageProjection.ts](../../../packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts)
+  [workspaceAgentTimelineCanonical.ts](../../../packages/agent/gui/shared/workspaceAgentTimelineCanonical.ts)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -2186,6 +2186,41 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [controller_exec.go](../../../packages/agent/daemon/runtime/controller_exec.go)
   [goal_state.go](../../../packages/agent/store-sqlite/goal_state.go)
 
+### Accepted Goal clear is sent repeatedly until convergence times out
+
+- Symptom:
+  One `/goal clear` produces repeated provider control requests at the Goal
+  worker interval. Each request is accepted, but the durable operation remains
+  `dispatched` with provider phase `accepted`, its attempt count keeps rising,
+  and it eventually fails with `accepted goal operation exceeded its
+convergence deadline`.
+- Quick checks:
+  Correlate logs by `agent_session_id`, operation ID, and Goal revision. Verify
+  there is one user control audit but multiple provider `action=clear` calls.
+  Inspect `workspace_agent_goal_control_operations`: an accepted operation with
+  increasing attempts and unchanged accepted evidence identifies Host replay,
+  not repeated user input.
+- Root cause:
+  The steady-state Goal worker treated clear's provider idempotence as
+  permission to resubmit an already accepted command. Acceptance had already
+  crossed the delivery boundary, so every later worker claim queued another
+  native clear command while the Host was supposed to wait for applied
+  lifecycle evidence.
+- Fix:
+  For every accepted Goal mutation, make the steady-state worker defer without
+  calling the provider again. Keep the convergence deadline so missing applied
+  evidence still terminates. Reserve replay for startup crash recovery and
+  gate it with the adapter recovery policy; query-incapable adapters may replay
+  an idempotent clear once, while unsafe set replay remains rejected.
+- Validation:
+  Return `accepted` from a clear, advance the worker clock past its next claim,
+  and step the steady-state worker. The provider call count must remain one,
+  while the operation stays pending and `applying`. Existing deadline coverage
+  must still fail a lost-evidence operation without another provider call.
+- References:
+  [goal_operation_worker.go](../../../packages/agent/host/goal_operation_worker.go)
+  [goal_scenarios.go](../../../packages/agent/host/conformance/goal_scenarios.go)
+
 ### Initial Goal prompt disappears when the Agent starts responding
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -2219,3 +2219,32 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [workspaceAgentMessageOverlay.ts](../../../packages/agent/gui/shared/workspaceAgentMessageOverlay.ts)
   [workspaceAgentMessageProjection.ts](../../../packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts)
   [workspaceAgentTimelineCanonical.ts](../../../packages/agent/gui/shared/workspaceAgentTimelineCanonical.ts)
+
+### Goal clear duplicates the live Agent work section
+
+- Symptom:
+  While a Goal Turn is still streaming, clicking clear inserts `/goal clear`
+  between two identical Agent work sections. Both sections continue updating
+  together even though the daemon executed only one Turn.
+- Quick checks:
+  Inspect canonical Turns and message ownership. If Agent messages on both
+  sides of the turnless Goal audit carry the same Turn ID, compare transcript
+  group keys before inspecting provider retries or duplicate persistence.
+- Root cause:
+  Chronological insertion produced `Turn T -> goal-control -> Turn T`. A
+  grouping pass treated the turnless row as a hard boundary and created two
+  groups with key `T`; the work-section map retained the later model for that
+  shared key, so both Turn positions rendered the same rows.
+- Fix:
+  Keep a turnless session row inside the current presentation group only when
+  the next lifecycle-owned row proves that the surrounding Turn ID is
+  unchanged. Preserve the session row's null Turn ID; presentation continuity
+  must not manufacture lifecycle ownership.
+- Validation:
+  Cover `T -> goal-control -> T` and assert one Turn group, one processed-time
+  section, one Goal control row, and one copy of each Agent row. Also cover
+  `T1 -> goal-control -> T2` and verify the Goal control remains an independent
+  orphan between different Turns.
+- References:
+  [agentTranscriptModel.ts](../../../packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.ts)
+  [AgentTranscriptView.tsx](../../../packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx)

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.promptHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.promptHelpers.spec.ts
@@ -3,7 +3,10 @@ import {
   mergeAgentActivityMessages,
   type AgentActivityMessage
 } from "@tutti-os/agent-activity-core";
-import { createOptimisticPromptMessage } from "./agentGuiController.promptHelpers";
+import {
+  createOptimisticGoalControlMessage,
+  createOptimisticPromptMessage
+} from "./agentGuiController.promptHelpers";
 
 // Step 9 (ADR 0004 desktop-half): optimistic echoes must not carry
 // daemon-domain version numbers. Durable rows use the store's small monotonic
@@ -80,5 +83,25 @@ describe("createOptimisticPromptMessage", () => {
     const merged = mergeAgentActivityMessages([echo], [durableTwin]);
     expect(merged).toHaveLength(1);
     expect(merged[0]).toMatchObject({ version: 3, turnId: "turn-2" });
+  });
+
+  it("marks an initial goal as a control event instead of a prompt turn", () => {
+    const echo = createOptimisticGoalControlMessage({
+      ...echoInput,
+      displayPrompt: "/goal ship it",
+      goalControl: { action: "set", objective: "ship it" }
+    });
+
+    expect(echo).toMatchObject({
+      kind: "session_audit",
+      payload: {
+        __agentGuiOptimisticPrompt: true,
+        action: "set",
+        goalControl: true,
+        messageId: "client-submit:user:submit-1",
+        objective: "ship it",
+        text: "/goal ship it"
+      }
+    });
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.promptHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.promptHelpers.ts
@@ -1,7 +1,10 @@
 // Agent GUI controller — prompt content normalization and optimistic messages.
 
 import type { AgentPromptContentBlock } from "../../../shared/contracts/dto";
-import type { AgentActivityMessage } from "@tutti-os/agent-activity-core";
+import type {
+  AgentActivityInitialGoalControl,
+  AgentActivityMessage
+} from "@tutti-os/agent-activity-core";
 import { mergeAgentGUITimelineItems } from "../model/agentGuiConversationModel";
 import { projectWorkspaceAgentMessagesToTimelineItems } from "../../../shared/agentConversation/projection/workspaceAgentMessageProjection";
 import { createWorkspaceAgentActivityUserMessageIdFromClientSubmitId } from "../../../shared/workspaceAgentMessageOverlay";
@@ -62,6 +65,27 @@ export function createOptimisticPromptMessage(input: {
     },
     occurredAtUnixMs: input.occurredAtUnixMs,
     startedAtUnixMs: input.occurredAtUnixMs
+  };
+}
+
+export function createOptimisticGoalControlMessage(
+  input: Parameters<typeof createOptimisticPromptMessage>[0] & {
+    goalControl: Readonly<AgentActivityInitialGoalControl>;
+  }
+): AgentActivityMessage {
+  const message = createOptimisticPromptMessage(input);
+  return {
+    ...message,
+    kind: "session_audit",
+    payload: {
+      ...message.payload,
+      action: input.goalControl.action,
+      goalControl: true,
+      ...(input.goalControl.objective !== undefined
+        ? { objective: input.goalControl.objective }
+        : {}),
+      messageId: message.messageId
+    }
   };
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.stableHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.stableHelpers.ts
@@ -121,6 +121,7 @@ export function stabilizeConversationDetail(
     previous.cwd === next.cwd &&
     previous.workspaceRoot === next.workspaceRoot &&
     previous.showProcessingIndicator === next.showProcessingIndicator &&
+    previous.goalControls === next.goalControls &&
     previous.turns === next.turns &&
     previous.sessionTurns === next.sessionTurns &&
     previous.session === session &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActiveMessages.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActiveMessages.ts
@@ -9,6 +9,7 @@ import { useMemo } from "react";
 import { mergeWorkspaceAgentMessages } from "../../../host/workspaceAgentSessionMessages";
 import { createPendingOptimisticTurnId } from "./agentGuiController.draftMessageHelpers";
 import {
+  createOptimisticGoalControlMessage,
   createOptimisticPromptMessage,
   projectAgentGUIMessagesToTimelineItems
 } from "./agentGuiController.promptHelpers";
@@ -66,18 +67,32 @@ export function useAgentGUIActiveMessages(input: {
       isPendingActivationViable(activePendingActivation) &&
       activePendingActivation.clientSubmitId &&
       activePendingActivation.content.length > 0
-        ? createOptimisticPromptMessage({
-            agentSessionId: activePendingActivation.agentSessionId,
-            clientSubmitId: activePendingActivation.clientSubmitId,
-            content: [...activePendingActivation.content],
-            displayPrompt: activePendingActivation.displayPrompt,
-            occurredAtUnixMs: activePendingActivation.requestedAtUnixMs,
-            turnId: createPendingOptimisticTurnId(
-              activePendingActivation.clientSubmitId
-            ),
-            userId: currentUserId?.trim() || "user",
-            workspaceId
-          })
+        ? activePendingActivation.initialGoalControl
+          ? createOptimisticGoalControlMessage({
+              agentSessionId: activePendingActivation.agentSessionId,
+              clientSubmitId: activePendingActivation.clientSubmitId,
+              content: [...activePendingActivation.content],
+              displayPrompt: activePendingActivation.displayPrompt,
+              goalControl: activePendingActivation.initialGoalControl,
+              occurredAtUnixMs: activePendingActivation.requestedAtUnixMs,
+              turnId: createPendingOptimisticTurnId(
+                activePendingActivation.clientSubmitId
+              ),
+              userId: currentUserId?.trim() || "user",
+              workspaceId
+            })
+          : createOptimisticPromptMessage({
+              agentSessionId: activePendingActivation.agentSessionId,
+              clientSubmitId: activePendingActivation.clientSubmitId,
+              content: [...activePendingActivation.content],
+              displayPrompt: activePendingActivation.displayPrompt,
+              occurredAtUnixMs: activePendingActivation.requestedAtUnixMs,
+              turnId: createPendingOptimisticTurnId(
+                activePendingActivation.clientSubmitId
+              ),
+              userId: currentUserId?.trim() || "user",
+              workspaceId
+            })
         : null;
     const optimisticMessages = pendingActivationMessage
       ? [...pendingMessages, pendingActivationMessage]

--- a/packages/agent/gui/shared/agentConversation/components/AgentGoalControlRow.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentGoalControlRow.tsx
@@ -1,0 +1,34 @@
+import type { JSX } from "react";
+import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../AgentMessageMarkdown";
+import { AgentRichTextReadonly } from "../../AgentRichTextReadonly";
+import type { AgentGUIProviderSkillOption } from "../../../agent-gui/agentGuiNode/model/agentGuiNodeTypes";
+import styles from "../../../agent-gui/agentGuiNode/AgentGUIConversation.styles";
+import type { AgentGoalControlRowVM } from "../contracts/agentGoalControlRowVM";
+
+interface AgentGoalControlRowProps {
+  row: AgentGoalControlRowVM;
+  availableSkills?: readonly AgentGUIProviderSkillOption[];
+  workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
+}
+
+export function AgentGoalControlRow({
+  row,
+  availableSkills,
+  workspaceAppIcons
+}: AgentGoalControlRowProps): JSX.Element {
+  "use memo";
+  return (
+    <div
+      className={styles.userMessageFlow}
+      data-agent-goal-control-action={row.action}
+    >
+      <AgentRichTextReadonly
+        value={row.body}
+        className={`workspace-agents-status-panel__detail-user-message ${styles.userMessageBubble}`}
+        editorClassName="text-[inherit]"
+        availableSkills={availableSkills}
+        workspaceAppIcons={workspaceAppIcons}
+      />
+    </div>
+  );
+}

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -5,12 +5,13 @@ import {
   screen,
   waitFor
 } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentEnvPanelActionProvider } from "../../agentEnv";
 import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import { AgentMessageBlock } from "./AgentMessageBlock";
 import { AgentTranscriptItemView } from "./AgentTranscriptItemView";
 import type { AgentGeneratedImageRowVM } from "../contracts/agentGeneratedImageRowVM";
+import type { AgentGoalControlRowVM } from "../contracts/agentGoalControlRowVM";
 import type { AgentMessageContentVM } from "../contracts/agentMessageRowVM";
 import type { AgentMessageRowVM } from "../contracts/agentMessageRowVM";
 import type { AgentToolCallVM } from "../contracts/agentToolCallVM";
@@ -72,7 +73,38 @@ vi.mock("./AgentToolGroupRow", () => ({
   }
 }));
 
+beforeEach(() => {
+  mockState.markdownOnLinkClicks.length = 0;
+  mockState.markdownStreamingFlags.length = 0;
+  mockState.toolGroupOnLinkClicks.length = 0;
+});
+
 describe("AgentTranscriptItemView render stability", () => {
+  it("renders a goal control as a dedicated transcript row", () => {
+    const row: AgentGoalControlRowVM = {
+      kind: "goal-control",
+      id: "goal-control:client-submit:user:submit-goal-1",
+      turnId: null,
+      action: "set",
+      body: "/goal ship it",
+      occurredAtUnixMs: 1
+    };
+
+    const { container } = render(
+      <AgentTranscriptItemView
+        workspaceRoot="/workspace/demo"
+        basePath="/workspace/demo"
+        row={row}
+        labels={transcriptLabels()}
+      />
+    );
+
+    expect(screen.getByText("/goal ship it")).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-agent-goal-control-action="set"]')
+    ).toBeInTheDocument();
+  });
+
   it("renders a generated image artifact independently from tool-call expansion", () => {
     const row: AgentGeneratedImageRowVM = {
       kind: "generated-image",

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.tsx
@@ -5,6 +5,7 @@ import type { AgentGUIProviderSkillOption } from "../../../agent-gui/agentGuiNod
 import { resolveAgentConversationLinkAction } from "../actions/agentConversationLinkActions";
 import type { AgentTranscriptRowVM } from "../contracts/agentTranscriptRowVM";
 import { AgentGeneratedImageRow } from "./AgentGeneratedImageRow";
+import { AgentGoalControlRow } from "./AgentGoalControlRow";
 import { AgentMessageBlock } from "./AgentMessageBlock";
 import { AgentProcessingRow } from "./AgentProcessingRow";
 import { AgentToolGroupRow } from "./AgentToolGroupRow";
@@ -68,6 +69,14 @@ export const AgentTranscriptItemView = memo(function AgentTranscriptItemView({
   switch (row.kind) {
     case "generated-image":
       return <AgentGeneratedImageRow row={row} />;
+    case "goal-control":
+      return (
+        <AgentGoalControlRow
+          row={row}
+          availableSkills={availableSkills}
+          workspaceAppIcons={workspaceAppIcons}
+        />
+      );
     case "message":
       return (
         <AgentMessageBlock

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -202,6 +202,107 @@ describe("AgentTranscriptView", () => {
     }
   });
 
+  it("renders one live Turn work section when Goal clear occurs between its rows", () => {
+    const baseDetail = detailViewModel();
+    const sourceTurn = baseDetail.turns[0]!;
+    const activeTurn = canonicalTurn();
+    const timedToolCall = {
+      ...sourceTurn.toolCalls[0]!,
+      turnId: "turn-1",
+      occurredAtUnixMs: 500
+    };
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        session: {
+          ...baseDetail.session,
+          activeTurnId: activeTurn.turnId,
+          activeTurn
+        },
+        sessionTurns: [activeTurn],
+        goalControls: [
+          {
+            id: "goal-control:clear",
+            action: "clear",
+            body: "/goal clear",
+            occurredAtUnixMs: 400
+          }
+        ],
+        turns: [
+          {
+            ...sourceTurn,
+            userMessage: {
+              id: "user-1",
+              body: "Start the goal",
+              turnId: "turn-1",
+              occurredAtUnixMs: 100
+            },
+            userMessages: [
+              {
+                id: "user-1",
+                body: "Start the goal",
+                turnId: "turn-1",
+                occurredAtUnixMs: 100
+              }
+            ],
+            agentMessages: [
+              {
+                id: "assistant-before-clear",
+                body: "Working before clear",
+                turnId: "turn-1",
+                occurredAtUnixMs: 200
+              }
+            ],
+            toolCalls: [timedToolCall],
+            agentItems: [
+              {
+                kind: "message",
+                message: {
+                  id: "assistant-before-clear",
+                  body: "Working before clear",
+                  turnId: "turn-1",
+                  occurredAtUnixMs: 200
+                }
+              },
+              {
+                kind: "tool-calls",
+                id: "tools-after-clear",
+                toolCalls: [timedToolCall],
+                toolCallCount: 1,
+                hasFailedToolCall: false
+              }
+            ]
+          }
+        ]
+      })
+    );
+    const goalControlIndex = conversation.rows.findIndex(
+      (row) => row.kind === "goal-control"
+    );
+
+    expect(goalControlIndex).toBeGreaterThan(0);
+    expect(conversation.rows[goalControlIndex]?.turnId).toBeNull();
+    expect(conversation.rows[goalControlIndex - 1]?.turnId).toBe("turn-1");
+    expect(conversation.rows[goalControlIndex + 1]?.turnId).toBe("turn-1");
+
+    const { container } = render(
+      <AgentTranscriptView
+        conversation={conversation}
+        labels={{
+          thinkingLabel: "Thought process",
+          toolCallsLabel: (count) => `Tool calls (${count})`,
+          processing: "Planning next moves",
+          turnSummary: "Changed files"
+        }}
+      />
+    );
+
+    expect(
+      container.querySelectorAll("[data-agent-turn-work-section]")
+    ).toHaveLength(1);
+    expect(screen.getAllByText("/goal clear")).toHaveLength(1);
+    expect(screen.getAllByText("Working before clear")).toHaveLength(1);
+  });
+
   it("freezes settled duration, auto-collapses work, and keeps manual expansion", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(500_000);

--- a/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.spec.ts
@@ -1,7 +1,46 @@
 import { describe, expect, it } from "vitest";
 import type { AgentTranscriptPresentationKind } from "../contracts/agentTranscriptPresentation";
 import type { AgentTranscriptRowVM } from "../contracts/agentTranscriptRowVM";
-import { findTurnDividerRowIndexes } from "./agentTranscriptModel";
+import {
+  buildAgentTranscriptTurnGroups,
+  findTurnDividerRowIndexes,
+  transcriptRowKey
+} from "./agentTranscriptModel";
+
+describe("buildAgentTranscriptTurnGroups", () => {
+  it("keeps a turnless Goal control inside one surrounding Turn presentation group", () => {
+    const rows = [row("turn-1"), goalControlRow(), row("turn-1")];
+    const groups = buildAgentTranscriptTurnGroups(
+      rows,
+      rows.map(transcriptRowKey)
+    );
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.key).toBe("turn-1");
+    expect(groups[0]?.turnId).toBe("turn-1");
+    expect(groups[0]?.rows.map(({ row: item }) => item.kind)).toEqual([
+      "message",
+      "goal-control",
+      "message"
+    ]);
+    expect(groups[0]?.rows[1]?.row.turnId).toBeNull();
+  });
+
+  it("keeps a Goal control between different Turns independent", () => {
+    const rows = [row("turn-1"), goalControlRow(), row("turn-2")];
+    const groups = buildAgentTranscriptTurnGroups(
+      rows,
+      rows.map(transcriptRowKey)
+    );
+
+    expect(groups.map((group) => group.key)).toEqual([
+      "turn-1",
+      "orphan:goal-control:clear",
+      "turn-2"
+    ]);
+    expect(groups[1]?.turnId).toBeNull();
+  });
+});
 
 describe("findTurnDividerRowIndexes", () => {
   const turnIndexes = new Map([
@@ -62,5 +101,16 @@ function row(
     ],
     thinking: [],
     occurredAtUnixMs: 1
+  };
+}
+
+function goalControlRow(): AgentTranscriptRowVM {
+  return {
+    kind: "goal-control",
+    id: "goal-control:clear",
+    turnId: null,
+    action: "clear",
+    body: "/goal clear",
+    occurredAtUnixMs: 2
   };
 }

--- a/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.ts
@@ -60,7 +60,11 @@ export function buildAgentTranscriptTurnGroups(
   let currentGroup: AgentTranscriptTurnGroup | null = null;
 
   rows.forEach((row, rowIndex) => {
-    const turnId = row.turnId ?? null;
+    const turnId = transcriptPresentationTurnId(
+      rows,
+      rowIndex,
+      currentGroup?.turnId ?? null
+    );
     if (!currentGroup || currentGroup.turnId !== turnId) {
       currentGroup = {
         key: turnId ?? `orphan:${rowKeys[rowIndex] ?? transcriptRowKey(row)}`,
@@ -74,6 +78,24 @@ export function buildAgentTranscriptTurnGroups(
   });
 
   return groups;
+}
+
+function transcriptPresentationTurnId(
+  rows: ReadonlyArray<AgentConversationVM["rows"][number]>,
+  rowIndex: number,
+  currentTurnId: string | null
+): string | null {
+  const rowTurnId = rows[rowIndex]?.turnId ?? null;
+  if (rowTurnId || !currentTurnId) {
+    return rowTurnId;
+  }
+  const nextTurnId =
+    rows.slice(rowIndex + 1).find((candidate) => candidate.turnId !== null)
+      ?.turnId ?? null;
+  // A session-level row can occur chronologically inside a live Turn. Keep it
+  // in that Turn's presentation group only when the next lifecycle-owned row
+  // proves the surrounding Turn is unchanged; the row itself stays turnless.
+  return nextTurnId === currentTurnId ? currentTurnId : null;
 }
 
 export function buildTurnGroupIndexByRowIndex(

--- a/packages/agent/gui/shared/agentConversation/contracts/agentGoalControlRowVM.ts
+++ b/packages/agent/gui/shared/agentConversation/contracts/agentGoalControlRowVM.ts
@@ -1,0 +1,12 @@
+import type { AgentActivityGoalControlAction } from "@tutti-os/agent-activity-core";
+import type { WorkspaceAgentActivityTimelineItem } from "../../workspaceAgentTimelineTypes";
+
+export interface AgentGoalControlRowVM {
+  kind: "goal-control";
+  id: string;
+  turnId: null;
+  action: AgentActivityGoalControlAction;
+  body: string;
+  occurredAtUnixMs: number | null;
+  sourceTimelineItems?: WorkspaceAgentActivityTimelineItem[];
+}

--- a/packages/agent/gui/shared/agentConversation/contracts/agentTranscriptRowVM.ts
+++ b/packages/agent/gui/shared/agentConversation/contracts/agentTranscriptRowVM.ts
@@ -1,4 +1,5 @@
 import type { AgentGeneratedImageRowVM } from "./agentGeneratedImageRowVM";
+import type { AgentGoalControlRowVM } from "./agentGoalControlRowVM";
 import type { AgentMessageRowVM } from "./agentMessageRowVM";
 import type { AgentProcessingRowVM } from "./agentProcessingRowVM";
 import type { AgentToolGroupRowVM } from "./agentToolGroupRowVM";
@@ -6,6 +7,7 @@ import type { AgentTurnSummaryRowVM } from "./agentTurnSummaryRowVM";
 
 export type AgentTranscriptRowVM =
   | AgentGeneratedImageRowVM
+  | AgentGoalControlRowVM
   | AgentMessageRowVM
   | AgentToolGroupRowVM
   | AgentTurnSummaryRowVM

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
@@ -5,6 +5,7 @@ import type {
 import { extractImageGenerationPreview } from "../../imageGenerationTool";
 import type { AgentConversationVM } from "../contracts/agentConversationVM";
 import type { AgentGeneratedImageRowVM } from "../contracts/agentGeneratedImageRowVM";
+import type { AgentGoalControlRowVM } from "../contracts/agentGoalControlRowVM";
 import type {
   AgentMessageContentVM,
   AgentMessageRowVM
@@ -63,9 +64,10 @@ export function projectAgentConversationVM(
       )
     )
   );
-  const processing = projectAgentProcessingRow(detail, normalizedRows);
+  const timelineRows = insertGoalControlRows(normalizedRows, detail);
+  const processing = projectAgentProcessingRow(detail, timelineRows);
   const projectedRows = projectAgentMessageFinalText(
-    processing ? [...normalizedRows, processing] : normalizedRows,
+    processing ? [...timelineRows, processing] : timelineRows,
     detail
   );
 
@@ -75,6 +77,40 @@ export function projectAgentConversationVM(
     sourceDetail: detail,
     rows: projectedRows
   };
+}
+
+function insertGoalControlRows(
+  rows: readonly AgentTranscriptRowVM[],
+  detail: WorkspaceAgentSessionDetailViewModel
+): AgentTranscriptRowVM[] {
+  const controls = detail.goalControls ?? [];
+  if (controls.length === 0) {
+    return [...rows];
+  }
+  const merged = [...rows];
+  for (const control of controls) {
+    const row: AgentGoalControlRowVM = {
+      kind: "goal-control",
+      id: `goal-control:${control.id}`,
+      turnId: null,
+      action: control.action,
+      body: control.body,
+      occurredAtUnixMs: control.occurredAtUnixMs ?? null,
+      sourceTimelineItems: control.sourceTimelineItems
+    };
+    const insertionIndex = merged.findIndex(
+      (candidate) =>
+        row.occurredAtUnixMs !== null &&
+        candidate.occurredAtUnixMs !== null &&
+        candidate.occurredAtUnixMs > row.occurredAtUnixMs
+    );
+    if (insertionIndex < 0) {
+      merged.push(row);
+    } else {
+      merged.splice(insertionIndex, 0, row);
+    }
+  }
+  return merged;
 }
 
 function dropRedundantCompactFailureEchoRows(

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
@@ -5,6 +5,7 @@ import {
   type AgentActivitySession
 } from "@tutti-os/agent-activity-core";
 import type { WorkspaceAgentActivityCard } from "../../workspaceAgentActivityListViewModel";
+import { mergeWorkspaceAgentActivityDurableAndOverlayMessages } from "../../workspaceAgentMessageOverlay";
 import { projectWorkspaceAgentMessagesToConversationVM } from "./workspaceAgentMessageProjection";
 
 describe("projectWorkspaceAgentMessagesToConversationVM", () => {
@@ -417,7 +418,7 @@ describe("projectWorkspaceAgentMessagesToConversationVM", () => {
     ]);
   });
 
-  it("keeps goal control audits out of the user conversation", () => {
+  it("projects goal control audits as dedicated non-turn rows", () => {
     const conversation = projectWorkspaceAgentMessagesToConversationVM({
       activity: activity(),
       session: session({
@@ -449,11 +450,84 @@ describe("projectWorkspaceAgentMessagesToConversationVM", () => {
       ]
     });
 
+    expect(conversation.rows.map((row) => row.kind)).toEqual([
+      "message",
+      "goal-control"
+    ]);
     expect(
-      conversation.rows
-        .filter((row) => row.kind === "message")
-        .flatMap((row) => row.messages.map((item) => item.body))
-    ).toEqual(["Pause the goal"]);
+      conversation.rows.find((row) => row.kind === "goal-control")
+    ).toMatchObject({
+      action: "pause",
+      body: "/goal pause",
+      turnId: null
+    });
+    expect(conversation.sourceDetail.turns).toHaveLength(1);
+  });
+
+  it("keeps the goal control row identity stable when the durable audit replaces its optimistic echo", () => {
+    const optimistic = message({
+      messageId: "client-submit:user:submit-goal-1",
+      version: 0,
+      turnId: "pending:submit-goal-1",
+      role: "user",
+      kind: "session_audit",
+      payload: {
+        __agentGuiOptimisticPrompt: true,
+        action: "set",
+        clientSubmitId: "submit-goal-1",
+        goalControl: true,
+        messageId: "client-submit:user:submit-goal-1",
+        text: "/goal ship it"
+      },
+      occurredAtUnixMs: 100
+    });
+    const durable = message({
+      messageId: "goal-control:operation-1",
+      version: 1,
+      turnId: undefined,
+      role: "user",
+      kind: "session_audit",
+      payload: {
+        action: "set",
+        clientSubmitId: "submit-goal-1",
+        goalControl: true,
+        messageId: "client-submit:user:submit-goal-1",
+        operationId: "operation-1",
+        text: "/goal ship it"
+      },
+      occurredAtUnixMs: 100
+    });
+    const optimisticConversation =
+      projectWorkspaceAgentMessagesToConversationVM({
+        activity: activity(),
+        session: session({ effectiveStatus: "completed" }),
+        messages: [optimistic]
+      });
+    const mergedMessages = mergeWorkspaceAgentActivityDurableAndOverlayMessages(
+      {
+        durableMessages: [durable],
+        localMessages: [optimistic]
+      }
+    );
+    const durableConversation = projectWorkspaceAgentMessagesToConversationVM({
+      activity: activity(),
+      session: session({ effectiveStatus: "completed" }),
+      messages: mergedMessages
+    });
+    const optimisticRow = optimisticConversation.rows.find(
+      (row) => row.kind === "goal-control"
+    );
+    const durableRow = durableConversation.rows.find(
+      (row) => row.kind === "goal-control"
+    );
+
+    expect(mergedMessages).toEqual([durable]);
+    expect(optimisticRow?.id).toBe(
+      "goal-control:client-submit:user:submit-goal-1"
+    );
+    expect(durableRow?.id).toBe(optimisticRow?.id);
+    expect(optimisticConversation.sourceDetail.turns).toHaveLength(0);
+    expect(durableConversation.sourceDetail.turns).toHaveLength(0);
   });
 
   it("projects only the latest text snapshot for a stable message id", () => {

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts
@@ -35,20 +35,41 @@ export function projectWorkspaceAgentMessagesToConversationVM(
 export function projectWorkspaceAgentMessagesToTimelineItems(
   messages: readonly AgentActivityMessage[]
 ): WorkspaceAgentActivityTimelineItem[] {
-  const sortedMessages = latestMessageSnapshots(messages)
-    .filter((message) => !isGoalControlAudit(message))
-    .sort(compareMessagesByDisplayOrder);
+  const sortedMessages = latestMessageSnapshots(messages).sort(
+    compareMessagesByDisplayOrder
+  );
   const mergedToolPayloadByKey = new Map<string, Record<string, unknown>>();
 
   return sortedMessages.map((message, index) => {
     const kind = normalizeToken(message.kind);
     const role = normalizeToken(message.role);
     const payload = normalizedPayload(message.payload);
+    const goalControlAudit = isGoalControlAudit(message);
     const id = normalizedMessageId(message.version, index);
     const seq = index + 1;
-    const eventId = message.messageId.trim() || `message:${id}`;
+    const eventId = goalControlAudit
+      ? firstNonEmptyString(
+          stringValue(payload.messageId),
+          message.messageId,
+          `message:${id}`
+        )
+      : message.messageId.trim() || `message:${id}`;
     const turnId = message.turnId?.trim() || undefined;
     const occurredAtUnixMs = messageDisplayOrderTime(message);
+
+    if (goalControlAudit) {
+      return messageTimelineItem({
+        message,
+        id,
+        seq,
+        eventId,
+        actorType: "user",
+        itemType: "goal.control",
+        role: "user",
+        content: messageText(message),
+        occurredAtUnixMs
+      });
+    }
 
     if (kind === "tool_call") {
       const callId = firstNonEmptyString(

--- a/packages/agent/gui/shared/workspaceAgentGoalControlProjection.ts
+++ b/packages/agent/gui/shared/workspaceAgentGoalControlProjection.ts
@@ -1,0 +1,35 @@
+import type { WorkspaceAgentSessionDetailGoalControl } from "./workspaceAgentSessionDetailViewModel";
+import type { WorkspaceAgentActivityTimelineItem } from "./workspaceAgentTimelineTypes";
+import { normalizedPayload } from "./workspaceAgentTimelineProjectionHelpers";
+
+export function appendWorkspaceAgentGoalControl(
+  target: WorkspaceAgentSessionDetailGoalControl[],
+  item: WorkspaceAgentActivityTimelineItem,
+  id: string,
+  body: string
+): boolean {
+  if (item.itemType !== "goal.control") {
+    return false;
+  }
+  const action = normalizedPayload(item.payload)?.action;
+  if (
+    action !== "pause" &&
+    action !== "resume" &&
+    action !== "clear" &&
+    action !== "set"
+  ) {
+    return true;
+  }
+  const normalizedBody = body.trim();
+  if (!normalizedBody) {
+    return true;
+  }
+  target.push({
+    id,
+    action,
+    body: normalizedBody,
+    occurredAtUnixMs: item.occurredAtUnixMs ?? item.createdAtUnixMs ?? null,
+    sourceTimelineItems: [item]
+  });
+  return true;
+}

--- a/packages/agent/gui/shared/workspaceAgentSessionDetailViewModel.ts
+++ b/packages/agent/gui/shared/workspaceAgentSessionDetailViewModel.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentActivityGoalControlAction,
   AgentActivityMessageSemantics,
   AgentActivitySession,
   AgentActivityTurn
@@ -40,6 +41,14 @@ export interface WorkspaceAgentSessionDetailThinking {
   body: string;
   statusKind?: ToolCallStatusKind | null;
   turnId?: string;
+  occurredAtUnixMs?: number | null;
+  sourceTimelineItems?: WorkspaceAgentActivityTimelineItem[];
+}
+
+export interface WorkspaceAgentSessionDetailGoalControl {
+  id: string;
+  action: AgentActivityGoalControlAction;
+  body: string;
   occurredAtUnixMs?: number | null;
   sourceTimelineItems?: WorkspaceAgentActivityTimelineItem[];
 }
@@ -105,6 +114,7 @@ export interface WorkspaceAgentSessionDetailViewModel {
   session: AgentActivitySession;
   cwd: string;
   workspaceRoot: string | null;
+  goalControls?: WorkspaceAgentSessionDetailGoalControl[];
   turns: WorkspaceAgentSessionDetailTurn[];
   sessionTurns?: readonly AgentActivityTurn[];
   showProcessingIndicator?: boolean;

--- a/packages/agent/gui/shared/workspaceAgentTimelineCanonical.ts
+++ b/packages/agent/gui/shared/workspaceAgentTimelineCanonical.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceAgentActivityTimelineItem } from "./workspaceAgentTimelineTypes";
+import { appendWorkspaceAgentGoalControl } from "./workspaceAgentGoalControlProjection";
 import {
   isWorkspaceAgentToolCallItem,
   resolveWorkspaceAgentToolName
@@ -6,6 +7,7 @@ import {
 import type {
   BuildWorkspaceAgentSessionDetailInput,
   WorkspaceAgentSessionDetailAgentItem,
+  WorkspaceAgentSessionDetailGoalControl,
   WorkspaceAgentSessionDetailToolCall,
   WorkspaceAgentSessionDetailToolGroupEntry,
   WorkspaceAgentSessionDetailTurn,
@@ -48,6 +50,7 @@ export function buildCanonicalWorkspaceAgentDetailView({
   workspaceRoot = null
 }: BuildWorkspaceAgentSessionDetailInput): WorkspaceAgentSessionDetailViewModel {
   const turns = new Map<string, WorkspaceAgentSessionDetailTurn>();
+  const goalControls: WorkspaceAgentSessionDetailGoalControl[] = [];
   const recentUserMessages = new Map<
     string,
     WorkspaceAgentActivityTimelineItem
@@ -64,6 +67,12 @@ export function buildCanonicalWorkspaceAgentDetailView({
     const role = messageRole(item);
     const body = messageBody(item);
     const explicitTurnId = item.turnId?.trim();
+
+    if (
+      appendWorkspaceAgentGoalControl(goalControls, item, itemId(item), body)
+    ) {
+      continue;
+    }
 
     if (role === "user") {
       const turnId = explicitTurnId || `seq:${item.seq || item.id}`;
@@ -213,6 +222,7 @@ export function buildCanonicalWorkspaceAgentDetailView({
     sessionTurns,
     cwd: session.cwd.trim(),
     workspaceRoot: workspaceRoot?.trim() || null,
+    goalControls,
     turns: visibleTurns,
     showProcessingIndicator: shouldShowProcessingIndicator(
       session,

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -40,6 +40,14 @@ worktree-isolation sweep. Configuring a goal store
 without its runtime or inbox consumer fails recovery with
 `ErrGoalConsumerUnavailable` instead of silently accumulating work.
 
+A provider-accepted Goal operation has crossed the delivery boundary. The
+steady-state worker waits for applied evidence and never resubmits that
+mutation; the accepted convergence deadline terminates a lost-evidence case.
+Startup recovery may replay an accepted mutation only according to the
+adapter's recovery policy. In particular, a query-incapable adapter may replay
+an idempotent clear once to resolve a crash window, while unsafe set replay
+remains rejected.
+
 `GetSession` reads canonical session truth plus an optional live runtime
 observation without starting a provider. `GetTurn`, `ListSessionMessages`,
 `FindTurnByClientSubmitID`, and `GetSessionInteractionSnapshot` expose

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -53,6 +53,7 @@ type Fixture struct {
 	PreparedSubmitID       string
 	RecoverInteractive     bool
 	DisableGoalInbox       bool
+	AcceptGoalControlsOnly bool
 	FailCommitObserver     bool
 	WorktreeGCSweepErr     error
 }
@@ -147,6 +148,7 @@ type Driver interface {
 	GoalControl(context.Context, agenthost.GoalControlInput) (GoalObservation, error)
 	GetGoalState(context.Context, agenthost.SessionRef) (GoalObservation, error)
 	ReconcileGoal(context.Context, agenthost.SessionRef) (GoalObservation, error)
+	StepGoalOperations(context.Context, int64) error
 	Recover(context.Context) error
 	Metrics() Metrics
 }

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -18,7 +18,7 @@ func TestPublishedScenarioCatalogsHaveUniqueNames(t *testing.T) {
 		{name: "submission fence", scenarios: SubmissionFenceScenarios(), wantCount: 1},
 		{name: "title policy", scenarios: TitlePolicyScenarios(), wantCount: 1},
 		{name: "coordinator", scenarios: CoordinatorScenarios(), wantCount: 7},
-		{name: "goal", scenarios: GoalScenarios(), wantCount: 6},
+		{name: "goal", scenarios: GoalScenarios(), wantCount: 7},
 		{name: "commit observer", scenarios: CommitObserverScenarios(), wantCount: 2},
 	}
 	for _, catalog := range catalogs {

--- a/packages/agent/host/conformance/goal_scenarios.go
+++ b/packages/agent/host/conformance/goal_scenarios.go
@@ -144,6 +144,41 @@ func runGoalRevisionActorFence(ctx context.Context, driver Driver) error {
 	return nil
 }
 
+func runAcceptedGoalControlWaitsWithoutReplay(ctx context.Context, driver Driver) error {
+	fixture := liveSessionFixture("session-goal-accepted", "")
+	fixture.AcceptGoalControlsOnly = true
+	if err := driver.Reset(ctx, fixture); err != nil {
+		return err
+	}
+	result, err := driver.GoalControl(ctx, agenthost.GoalControlInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-goal-accepted",
+		Action: "clear", ClientSubmitID: "goal-clear-accepted",
+	})
+	if err != nil {
+		return fmt.Errorf("accepted goal clear: %w", err)
+	}
+	if result.PendingOperationID == "" || result.SyncStatus != storesqlite.GoalSyncStatusApplying {
+		return fmt.Errorf("accepted goal clear state=%#v", result)
+	}
+	if calls := driver.Metrics().GoalControlCalls; calls != 1 {
+		return fmt.Errorf("initial goal control calls=%d", calls)
+	}
+	if err := driver.StepGoalOperations(ctx, 7_000); err != nil {
+		return fmt.Errorf("step accepted goal worker: %w", err)
+	}
+	if calls := driver.Metrics().GoalControlCalls; calls != 1 {
+		return fmt.Errorf("accepted goal control replayed: calls=%d", calls)
+	}
+	state, err := driver.GetGoalState(ctx, agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-goal-accepted"})
+	if err != nil {
+		return err
+	}
+	if state.PendingOperationID != result.PendingOperationID || state.SyncStatus != storesqlite.GoalSyncStatusApplying {
+		return fmt.Errorf("accepted goal state after worker=%#v", state)
+	}
+	return nil
+}
+
 func runGoalInboxConsumerPreflight(ctx context.Context, driver Driver) error {
 	fixture := liveSessionFixture("session-goal-no-consumer", "")
 	fixture.DisableGoalInbox = true

--- a/packages/agent/host/conformance/scenarios.go
+++ b/packages/agent/host/conformance/scenarios.go
@@ -87,6 +87,7 @@ func GoalScenarios() []Scenario {
 		{Name: "duplicate goal client submit id", run: runDuplicateGoalClientSubmitID},
 		{Name: "goal reconcile observation", run: runGoalReconcileObservation},
 		{Name: "goal revision actor fence", run: runGoalRevisionActorFence},
+		{Name: "accepted goal control waits without replay", run: runAcceptedGoalControlWaitsWithoutReplay},
 		{Name: "goal inbox consumer preflight", run: runGoalInboxConsumerPreflight},
 	}
 }

--- a/packages/agent/host/goal_operation_worker.go
+++ b/packages/agent/host/goal_operation_worker.go
@@ -162,14 +162,22 @@ func (h *Host) recoverGoalOperation(ctx context.Context, operation storesqlite.G
 		}
 	}
 
-	// An adapter may report that replaying set after restart can create duplicate
-	// long-running work. In that policy only a fresh dispatch is safe; clear is
-	// idempotent and remains repairable.
+	// Provider acceptance proves delivery, so the steady-state worker must wait
+	// for applied evidence instead of submitting the same mutation again. The
+	// accepted deadline above still bounds a lost lifecycle event. Startup
+	// recovery is different: a query-incapable adapter may need one replay to
+	// resolve the crash window, subject to its recovery policy below.
 	if leased.ProviderPhase == storesqlite.GoalProviderPhaseAccepted && leased.AcceptedAtUnixMS > 0 &&
 		(h.goalOperationNow().UnixMilli()-leased.AcceptedAtUnixMS >= goalAcceptedWaitDeadline.Milliseconds() ||
 			leased.Attempt-leased.AcceptedAttempt >= goalAcceptedMaxAttempts) {
 		return h.failRecoveredGoalOperation(ctx, leased, "accepted goal operation exceeded its convergence deadline")
 	}
+	if leased.ProviderPhase == storesqlite.GoalProviderPhaseAccepted && !freshDispatch && !recovering {
+		return h.deferGoalOperation(ctx, leased, 5*time.Second)
+	}
+	// An adapter may report that replaying set after restart can create duplicate
+	// long-running work. In that policy only a fresh dispatch is safe; clear is
+	// idempotent and remains repairable during startup recovery.
 	if !policy.ReplaySetAfterRestart && leased.Action != "clear" &&
 		leased.ProviderPhase != storesqlite.GoalProviderPhasePrepared && !freshDispatch {
 		if !recovering {

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -204,6 +204,7 @@ type legacyHostConformanceDriver struct {
 	recoverySteps  *[]string
 	createdTurns   map[string]string
 	directHost     bool
+	goalNowUnixMS  int64
 }
 
 func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconformance.Fixture) error {
@@ -240,7 +241,8 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 	d.service.GoalStateStore = d.goalStore
 	d.service.GoalReconcileInboxStore = d.goalInbox
 	d.service.GoalOperationOwner = "host-goal-conformance-worker"
-	d.service.GoalOperationClock = func() time.Time { return time.UnixMilli(1_000) }
+	d.goalNowUnixMS = 1_000
+	d.service.GoalOperationClock = func() time.Time { return time.UnixMilli(d.goalNowUnixMS) }
 	if fixture.DisableGoalInbox {
 		d.service.GoalReconcileInboxStore = nil
 	}
@@ -266,10 +268,21 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 		case "clear":
 			providerGoal = nil
 		}
+		providerPhase := "applied"
+		evidence := map[string]any{"confidence": "authoritative"}
+		if fixture.AcceptGoalControlsOnly {
+			providerPhase = "accepted"
+			evidence = map[string]any{"confidence": "accepted_only", "phase": "accepted"}
+		}
 		return RuntimeGoalControlResult{
-			AgentSessionID: input.AgentSessionID, Goal: clonePayload(providerGoal), ProviderPhase: "applied",
-			Evidence: map[string]any{"confidence": "authoritative"},
+			AgentSessionID: input.AgentSessionID, Goal: clonePayload(providerGoal),
+			Evidence: evidence, ProviderPhase: providerPhase,
 		}, nil
+	}
+	if fixture.AcceptGoalControlsOnly {
+		d.runtime.goalRecoveryPolicyHook = func(context.Context, RuntimeGoalControlInput) (RuntimeGoalRecoveryPolicy, error) {
+			return RuntimeGoalRecoveryPolicy{QuerySupported: false, ReplaySetAfterRestart: false}, nil
+		}
 	}
 	d.runtime.goalReconcileHook = func(_ context.Context, input RuntimeGoalControlInput) (RuntimeGoalReconcileResult, error) {
 		goalMu.Lock()
@@ -739,6 +752,11 @@ func (d *legacyHostConformanceDriver) ReconcileGoal(ctx context.Context, ref age
 		return hostconformance.GoalObservation{}, err
 	}
 	return hostGoalStateObservation(agenthost.GoalStateResult{State: result.State}), nil
+}
+
+func (d *legacyHostConformanceDriver) StepGoalOperations(ctx context.Context, nowUnixMS int64) error {
+	d.goalNowUnixMS = nowUnixMS
+	return d.service.ApplicationHost().StepGoalOperationWorker(ctx, false)
 }
 
 func hostGoalControlObservation(result agenthost.GoalControlResult) hostconformance.GoalObservation {


### PR DESCRIPTION
## Summary

- preserve optimistic `/goal` control rows when durable audit replaces them
- keep a turnless `/goal clear` row inside one ongoing turn group to avoid duplicate live work sections
- stop steady-state Goal workers from replaying provider-accepted controls while retaining bounded convergence and startup recovery policy

## Fix Scope Justification

- **Root cause:** the durable goal-control audit was not projected as the same visible user control as its optimistic row, a turnless clear audit was allowed to split an active turn group, and the Host steady-state worker treated provider-accepted controls as dispatchable work. Together those ownership errors caused disappearing prompts, duplicated work sections, and repeated `/goal clear` delivery.
- **Lower layer:** this cannot be fixed at a lower layer because provider adapters and SDK transports neither own the shared AgentGUI transcript grouping nor the provider-neutral operation lifecycle. The fixes therefore sit at the two actual owners: `packages/agent/gui` for canonical presentation and `packages/agent/host` for accepted-operation lifecycle semantics; provider adapters remain unchanged.

## Validation

- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready` (19 lanes)
- `go test ./service/agent/... -count=1 -v -timeout=2m`

## Architecture

The accepted-operation replay rule is provider-neutral lifecycle behavior needed by every Host consumer, so it lives in `packages/agent/host`. AgentGUI presentation fixes remain in the shared GUI package.

## Documentation

Updated the AgentGUI architecture guide, Agent Host README, and agent session lifecycle troubleshooting guide.