### PR TITLE
fix(agent-gui): trace conversation rail scope changes

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -673,6 +673,7 @@ export function AgentGUINodeView({
             <AgentGUIConversationRailController
               {...conversationRailStoreState}
               conversations={viewModel.rail.conversations}
+              nodeId={viewModel.shell.nodeId}
               registerInteractionLockProbe={registerRailInteractionLockProbe}
               userProjects={viewModel.rail.userProjects}
               workspaceId={viewModel.shell.workspaceId}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailController.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailController.tsx
@@ -14,6 +14,7 @@ export const AgentGUIConversationRailController = memo(
       activeConversationId: props.activeConversationId,
       conversationFilter: props.conversationFilter,
       conversationQuery,
+      nodeId: props.nodeId,
       previewMode: props.previewMode,
       registerInteractionLockProbe: props.registerInteractionLockProbe,
       sectionAgentTargetFallbackId: props.sectionAgentTargetFallbackId,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
@@ -1,4 +1,7 @@
-import { normalizeAgentActivitySession } from "@tutti-os/agent-activity-core";
+import {
+  AGENT_SESSION_ENGINE_LOCAL_ORIGIN,
+  normalizeAgentActivitySession
+} from "@tutti-os/agent-activity-core";
 import { describe, expect, it, vi } from "vitest";
 import { createTestAgentSessionEngine } from "../../../shared/testing/createTestAgentSessionEngine";
 import { createWorkspaceQueryCache } from "../../../shared/query/workspaceQueryCache";
@@ -693,10 +696,13 @@ describe("AgentGUIConversationRailQueryController", () => {
         controllerApplyMs: 25,
         durationMs: 325,
         event: "agent_gui.conversation_rail.first_pages_slow",
+        nodeId: null,
         requestId: 2,
         requestMs: 300,
         refreshReason: "attach",
         returnedSessionCount: 0,
+        returnedSessionIds: [],
+        runtimeOrigin: AGENT_SESSION_ENGINE_LOCAL_ORIGIN,
         sectionCount: 2,
         status: "ready",
         workspaceId: "test-workspace"
@@ -762,10 +768,13 @@ describe("AgentGUIConversationRailQueryController", () => {
       durationMs: 20,
       errorKind: "TypeError",
       event: "agent_gui.conversation_rail.first_pages_failed",
+      nodeId: null,
       requestId: 4,
       requestMs: 20,
       refreshReason: "attach",
       returnedSessionCount: 0,
+      returnedSessionIds: [],
+      runtimeOrigin: AGENT_SESSION_ENGINE_LOCAL_ORIGIN,
       sectionCount: 0,
       status: "error",
       workspaceId: "test-workspace"
@@ -935,6 +944,144 @@ describe("AgentGUIConversationRailQueryController", () => {
         status: "ready",
         toAgentTargetId: "local:codex"
       })
+    );
+
+    detach();
+    engine.dispose();
+  });
+
+  it("logs retained sessions when switching from a target filter to all", async () => {
+    const engine = createTestAgentSessionEngine();
+    const diagnosticLogger = vi.fn();
+    const previousSession = normalizeAgentActivitySession({
+      activeTurnId: null,
+      agentSessionId: "session-previous",
+      agentTargetId: "shared:one",
+      cwd: "/workspace",
+      latestTurnInteractions: [],
+      pendingInteractions: [],
+      provider: "codex",
+      railSectionKey: "conversations",
+      title: "Previous conversation",
+      updatedAtUnixMs: 1,
+      workspaceId: "test-workspace"
+    });
+    const allSession = normalizeAgentActivitySession({
+      ...previousSession,
+      agentSessionId: "session-from-all",
+      title: "Conversation returned by all"
+    });
+    let resolveAllSections!: () => void;
+    let requestCount = 0;
+    const listSessionSections = vi.fn<
+      NonNullable<ConversationRailQueryRuntime["listSessionSections"]>
+    >((input) => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        return Promise.resolve({
+          sections: [
+            {
+              hasMore: false,
+              kind: "conversations" as const,
+              sectionKey: "conversations",
+              sessions: [previousSession],
+              totalCount: 1
+            }
+          ],
+          workspaceId: input.workspaceId
+        });
+      }
+      return new Promise<void>((resolve) => {
+        resolveAllSections = resolve;
+      }).then(() => ({
+        sections: [
+          {
+            hasMore: false,
+            kind: "conversations" as const,
+            sectionKey: "conversations",
+            sessions: [previousSession, allSession],
+            totalCount: 2
+          }
+        ],
+        workspaceId: input.workspaceId
+      }));
+    });
+    const controller = new AgentGUIConversationRailQueryController({
+      diagnosticLogger,
+      engine,
+      getActiveConversationId: () => "session-previous",
+      nodeId: "shared-node-1",
+      runtime: {
+        listSessionSections,
+        listSessionSectionPage: async (input) => ({
+          hasMore: false,
+          kind: "conversations",
+          sectionKey: input.sectionKey,
+          sessions: [],
+          totalCount: 0
+        })
+      },
+      workspaceId: "test-workspace"
+    });
+    controller.configure({
+      conversationFilter: {
+        agentTargetId: "shared:one",
+        kind: "agentTarget"
+      },
+      previewMode: false,
+      sectionAgentTargetFallbackId: null,
+      userProjects: []
+    });
+    const detach = controller.attach();
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
+    diagnosticLogger.mockClear();
+
+    controller.configure({
+      conversationFilter: { kind: "all" },
+      previewMode: false,
+      sectionAgentTargetFallbackId: "shared:one",
+      userProjects: []
+    });
+
+    expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(true);
+    expect(controller.getSnapshot().runtimeRailMemberships).toEqual([
+      expect.objectContaining({ sessionIds: ["session-previous"] })
+    ]);
+    expect(diagnosticLogger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activeConversationId: "session-previous",
+        event: "agent_gui.conversation_rail.scope_change.started",
+        fromAgentTargetId: "shared:one",
+        fromFilterKind: "agentTarget",
+        nodeId: "shared-node-1",
+        preservedSectionCount: 1,
+        preservedSessionIds: ["session-previous"],
+        retainedPreviousSections: true,
+        runtimeOrigin: AGENT_SESSION_ENGINE_LOCAL_ORIGIN,
+        status: "pending",
+        toAgentTargetId: "shared:one",
+        toFilterKind: "all"
+      })
+    );
+
+    resolveAllSections();
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
+    expect(diagnosticLogger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cacheStatus: "miss",
+        event: "agent_gui.conversation_rail.scope_change.completed",
+        nodeId: "shared-node-1",
+        returnedSessionCount: 2,
+        returnedSessionIds: ["session-previous", "session-from-all"],
+        status: "ready"
+      })
+    );
+    expect(diagnosticLogger).not.toHaveBeenCalledWith(
+      expect.objectContaining({ event: "agent_gui.provider_switch.completed" })
     );
 
     detach();

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -15,8 +15,8 @@ import {
 } from "../agentGuiScheduler";
 import {
   CONVERSATION_RAIL_SLOW_DIAGNOSTIC_THRESHOLD_MS,
+  conversationRailQuerySessionIds,
   createConversationRailDiagnosticLogger,
-  emitConversationRailFirstPagesDiagnostic,
   ConversationRailProviderSwitchDiagnosticTracker,
   type ConversationRailDiagnosticLogger,
   type ConversationRailRefreshReason
@@ -77,6 +77,7 @@ export class AgentGUIConversationRailQueryController {
   private readonly diagnosticNow: () => number;
   private readonly diagnosticSlowThresholdMs: number;
   private readonly getActiveConversationId: () => string | null;
+  private readonly nodeId: string | null;
   private readonly listeners = new Set<Listener>();
   private readonly runtime: ConversationRailQueryRuntime;
   private readonly scheduler: AgentGuiScheduler;
@@ -119,12 +120,18 @@ export class AgentGUIConversationRailQueryController {
       CONVERSATION_RAIL_SLOW_DIAGNOSTIC_THRESHOLD_MS;
     this.engine = input.engine;
     this.getActiveConversationId = input.getActiveConversationId;
+    this.nodeId = input.nodeId?.trim() || null;
     this.runtime = input.runtime;
     this.providerSwitchDiagnostics =
       new ConversationRailProviderSwitchDiagnosticTracker(
         this.diagnosticLogger,
         this.diagnosticNow,
-        input.workspaceId
+        {
+          nodeId: this.nodeId,
+          runtimeOrigin: input.engine.identity.origin,
+          workspaceId: input.workspaceId
+        },
+        this.diagnosticSlowThresholdMs
       );
     this.sessionSectionsQueryCache =
       input.sessionSectionsQueryCache ??
@@ -179,15 +186,27 @@ export class AgentGUIConversationRailQueryController {
   configure(scope: ConversationRailQueryScope): void {
     const previousScopeKey = this.railSectionQueryKey;
     const previousAgentTargetId = this.sectionAgentTargetId;
+    const previousFilterKind = this.scope?.conversationFilter.kind ?? null;
+    const preservedSessionIds = conversationRailQuerySessionIds(
+      this.queryState
+    );
     const { agentTargetId: sectionAgentTargetId, scopeKey: nextScopeKey } =
       resolveConversationRailQueryScope(this.workspaceId, scope);
     const scopeChanged = nextScopeKey !== this.railSectionQueryKey;
     this.providerSwitchDiagnostics.configure({
+      activeConversationId: this.getActiveConversationId(),
       attached: this.attached,
+      nextFilterKind: scope.conversationFilter.kind,
       nextAgentTargetId: sectionAgentTargetId,
       nextScopeKey,
+      preservedSectionCount: this.queryState.sections?.length ?? 0,
+      preservedSessionIds,
+      previousFilterKind,
       previousAgentTargetId,
-      previousScopeKey
+      previousScopeKey,
+      retainedPreviousSections:
+        this.queryState.sections !== null &&
+        this.queryState.resolvedScopeKey === previousScopeKey
     });
     this.scope = scope;
     this.sectionAgentTargetId = sectionAgentTargetId;
@@ -446,16 +465,12 @@ export class AgentGUIConversationRailQueryController {
       !cached.stale &&
       this.cacheNow() - cached.resolvedAtUnixMs <= this.cacheFreshMs
     ) {
-      this.providerSwitchDiagnostics.complete(scopeKey, {
-        cacheStatus: "fresh",
+      this.providerSwitchDiagnostics.completeCachedFirstPages(scopeKey, {
         controllerApplyMs:
           cacheApplyStartedAt === null
             ? 0
             : Math.max(0, this.diagnosticNow() - cacheApplyStartedAt),
-        requestMs: 0,
-        returnedSessionCount: cached.value.returnedSessionCount,
-        sectionCount: cached.value.sectionCount,
-        status: "ready"
+        query: cached.value
       });
       this.sectionPublicationState = "idle";
       this.publishIfReady(undefined, true);
@@ -500,27 +515,15 @@ export class AgentGUIConversationRailQueryController {
         this.sectionPublicationState = "idle";
         this.publishIfReady(undefined, true);
         const completedAt = this.diagnosticNow();
-        this.providerSwitchDiagnostics.complete(scopeKey, {
-          cacheStatus,
-          controllerApplyMs: Math.max(0, completedAt - requestResolvedAt),
-          requestMs: Math.max(0, requestResolvedAt - requestStartedAt),
-          returnedSessionCount: entry.value.returnedSessionCount,
-          sectionCount: entry.value.sectionCount,
-          status: "ready"
-        });
-        emitConversationRailFirstPagesDiagnostic({
+        this.providerSwitchDiagnostics.completeFirstPages(scopeKey, {
           agentTargetId: this.sectionAgentTargetId || null,
-          controllerApplyMs: Math.max(0, completedAt - requestResolvedAt),
-          diagnosticLogger: this.diagnosticLogger,
-          diagnosticSlowThresholdMs: this.diagnosticSlowThresholdMs,
-          durationMs: Math.max(0, completedAt - requestStartedAt),
-          requestId: requestSequence,
-          requestMs: Math.max(0, requestResolvedAt - requestStartedAt),
+          cacheStatus,
+          completedAt,
+          query: entry.value,
           refreshReason,
-          returnedSessionCount: entry.value.returnedSessionCount,
-          sectionCount: entry.value.sectionCount,
-          status: "ready",
-          workspaceId: this.workspaceId
+          requestId: requestSequence,
+          requestResolvedAt,
+          requestStartedAt
         });
       })
       .catch((error: unknown) => {
@@ -531,29 +534,14 @@ export class AgentGUIConversationRailQueryController {
           return;
         }
         const failedAt = this.diagnosticNow();
-        this.providerSwitchDiagnostics.complete(scopeKey, {
-          cacheStatus,
-          controllerApplyMs: 0,
-          error,
-          requestMs: Math.max(0, failedAt - requestStartedAt),
-          returnedSessionCount: 0,
-          sectionCount: 0,
-          status: "error"
-        });
-        emitConversationRailFirstPagesDiagnostic({
+        this.providerSwitchDiagnostics.failFirstPages(scopeKey, {
           agentTargetId: this.sectionAgentTargetId || null,
-          controllerApplyMs: 0,
-          diagnosticLogger: this.diagnosticLogger,
-          diagnosticSlowThresholdMs: this.diagnosticSlowThresholdMs,
-          durationMs: Math.max(0, failedAt - requestStartedAt),
+          cacheStatus,
           error,
-          requestId: requestSequence,
-          requestMs: Math.max(0, failedAt - requestStartedAt),
+          failedAt,
           refreshReason,
-          returnedSessionCount: 0,
-          sectionCount: 0,
-          status: "error",
-          workspaceId: this.workspaceId
+          requestId: requestSequence,
+          requestStartedAt
         });
         this.queryState = wasResolvedForScope
           ? {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailDiagnostics.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailDiagnostics.ts
@@ -1,4 +1,6 @@
 import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
+import type { ConversationRailQueryState } from "../model/agentGuiConversationRail";
+import type { CachedConversationRailQuery } from "./agentGuiConversationRailQueryCache";
 
 export const CONVERSATION_RAIL_SLOW_DIAGNOSTIC_THRESHOLD_MS = 250;
 
@@ -6,6 +8,14 @@ export type ConversationRailRefreshReason =
   | "attach"
   | "membership_change"
   | "scope_change";
+
+export type ConversationRailFilterKind = "all" | "agentTarget";
+
+export interface ConversationRailDiagnosticContext {
+  nodeId: string | null;
+  runtimeOrigin: string;
+  workspaceId: string;
+}
 
 export interface ConversationRailFirstPagesDiagnostic {
   agentTargetId: string | null;
@@ -18,7 +28,10 @@ export interface ConversationRailFirstPagesDiagnostic {
   requestId: number;
   requestMs: number;
   refreshReason: ConversationRailRefreshReason;
+  returnedSessionIds: readonly string[];
   returnedSessionCount: number;
+  nodeId: string | null;
+  runtimeOrigin: string;
   sectionCount: number;
   status: "ready" | "error";
   workspaceId: string;
@@ -33,11 +46,44 @@ export interface ConversationRailProviderSwitchDiagnostic {
     | "agent_gui.provider_switch.completed"
     | "agent_gui.provider_switch.failed";
   fromAgentTargetId: string | null;
+  nodeId: string | null;
+  requestId: number | null;
   requestMs: number;
+  returnedSessionIds: readonly string[];
   returnedSessionCount: number;
+  runtimeOrigin: string;
   sectionCount: number;
   status: "ready" | "error";
   toAgentTargetId: string | null;
+  workspaceId: string;
+}
+
+export interface ConversationRailScopeChangeDiagnostic {
+  activeConversationId: string | null;
+  cacheStatus: "fresh" | "miss" | "stale" | "unknown";
+  controllerApplyMs: number;
+  durationMs: number;
+  errorKind?: string;
+  event:
+    | "agent_gui.conversation_rail.scope_change.started"
+    | "agent_gui.conversation_rail.scope_change.completed"
+    | "agent_gui.conversation_rail.scope_change.failed"
+    | "agent_gui.conversation_rail.scope_change.superseded";
+  fromAgentTargetId: string | null;
+  fromFilterKind: ConversationRailFilterKind | null;
+  nodeId: string | null;
+  preservedSectionCount: number;
+  preservedSessionIds: readonly string[];
+  requestId: number | null;
+  requestMs: number;
+  retainedPreviousSections: boolean;
+  returnedSessionIds: readonly string[];
+  returnedSessionCount: number;
+  runtimeOrigin: string;
+  sectionCount: number;
+  status: "pending" | "ready" | "error" | "superseded";
+  toAgentTargetId: string | null;
+  toFilterKind: ConversationRailFilterKind;
   workspaceId: string;
 }
 
@@ -45,14 +91,21 @@ export type ConversationRailDiagnosticLogger = (
   payload:
     | ConversationRailFirstPagesDiagnostic
     | ConversationRailProviderSwitchDiagnostic
+    | ConversationRailScopeChangeDiagnostic
 ) => void;
 
 interface PendingProviderSwitchDiagnostic {
-  cacheStatus: "fresh" | "miss" | "stale";
+  activeConversationId: string | null;
+  cacheStatus: "fresh" | "miss" | "stale" | "unknown";
   fromAgentTargetId: string | null;
+  fromFilterKind: ConversationRailFilterKind | null;
+  preservedSectionCount: number;
+  preservedSessionIds: readonly string[];
+  retainedPreviousSections: boolean;
   scopeKey: string;
   startedAtMs: number;
   toAgentTargetId: string | null;
+  toFilterKind: ConversationRailFilterKind;
 }
 
 export class ConversationRailProviderSwitchDiagnosticTracker {
@@ -61,35 +114,75 @@ export class ConversationRailProviderSwitchDiagnosticTracker {
   constructor(
     private readonly diagnosticLogger: ConversationRailDiagnosticLogger,
     private readonly now: () => number,
-    private readonly workspaceId: string
+    private readonly context: ConversationRailDiagnosticContext,
+    private readonly slowThresholdMs: number
   ) {}
 
   configure(input: {
+    activeConversationId: string | null;
     attached: boolean;
+    nextFilterKind: ConversationRailFilterKind;
     nextAgentTargetId: string;
     nextScopeKey: string;
+    preservedSectionCount: number;
+    preservedSessionIds: readonly string[];
+    previousFilterKind: ConversationRailFilterKind | null;
     previousAgentTargetId: string;
     previousScopeKey: string | null;
+    retainedPreviousSections: boolean;
   }): void {
     if (
       input.nextScopeKey !== input.previousScopeKey &&
       this.pending?.scopeKey !== input.nextScopeKey
     ) {
+      if (this.pending) {
+        emitConversationRailScopeChangeDiagnostic({
+          ...this.pending,
+          ...this.context,
+          controllerApplyMs: 0,
+          diagnosticLogger: this.diagnosticLogger,
+          durationMs: Math.max(0, this.now() - this.pending.startedAtMs),
+          requestId: null,
+          requestMs: 0,
+          returnedSessionCount: 0,
+          returnedSessionIds: [],
+          sectionCount: 0,
+          status: "superseded"
+        });
+      }
       this.pending = null;
     }
     if (
       input.attached &&
       input.nextScopeKey !== input.previousScopeKey &&
-      input.previousScopeKey !== null &&
-      input.previousAgentTargetId !== input.nextAgentTargetId
+      input.previousScopeKey !== null
     ) {
       this.pending = {
-        cacheStatus: "miss",
+        activeConversationId: input.activeConversationId,
+        cacheStatus: "unknown",
         fromAgentTargetId: input.previousAgentTargetId || null,
+        fromFilterKind: input.previousFilterKind,
+        preservedSectionCount: input.preservedSectionCount,
+        preservedSessionIds: input.preservedSessionIds,
+        retainedPreviousSections: input.retainedPreviousSections,
         scopeKey: input.nextScopeKey,
         startedAtMs: this.now(),
-        toAgentTargetId: input.nextAgentTargetId || null
+        toAgentTargetId: input.nextAgentTargetId || null,
+        toFilterKind: input.nextFilterKind
       };
+      emitConversationRailScopeChangeDiagnostic({
+        ...this.pending,
+        ...this.context,
+        controllerApplyMs: 0,
+        diagnosticLogger: this.diagnosticLogger,
+        durationMs: 0,
+        requestId: null,
+        requestMs: 0,
+        returnedSessionCount: 0,
+        returnedSessionIds: [],
+        sectionCount: 0,
+        status: "pending"
+      });
     }
   }
 
@@ -113,6 +206,8 @@ export class ConversationRailProviderSwitchDiagnosticTracker {
       | "diagnosticLogger"
       | "durationMs"
       | "fromAgentTargetId"
+      | "nodeId"
+      | "runtimeOrigin"
       | "toAgentTargetId"
       | "workspaceId"
     >
@@ -120,14 +215,203 @@ export class ConversationRailProviderSwitchDiagnosticTracker {
     const pending = this.pending;
     if (!pending || pending.scopeKey !== scopeKey) return;
     this.pending = null;
-    emitConversationRailProviderSwitchDiagnostic({
+    emitConversationRailScopeChangeDiagnostic({
+      ...pending,
       ...result,
+      ...this.context,
       diagnosticLogger: this.diagnosticLogger,
       durationMs: Math.max(0, this.now() - pending.startedAtMs),
-      fromAgentTargetId: pending.fromAgentTargetId,
-      toAgentTargetId: pending.toAgentTargetId,
-      workspaceId: this.workspaceId
+      status: result.status
     });
+    if (pending.fromAgentTargetId !== pending.toAgentTargetId) {
+      emitConversationRailProviderSwitchDiagnostic({
+        ...result,
+        ...this.context,
+        diagnosticLogger: this.diagnosticLogger,
+        durationMs: Math.max(0, this.now() - pending.startedAtMs),
+        fromAgentTargetId: pending.fromAgentTargetId,
+        toAgentTargetId: pending.toAgentTargetId
+      });
+    }
+  }
+
+  completeFirstPages(
+    scopeKey: string,
+    input: {
+      agentTargetId: string | null;
+      cacheStatus: "miss" | "stale";
+      completedAt: number;
+      query: CachedConversationRailQuery;
+      refreshReason: ConversationRailRefreshReason;
+      requestId: number;
+      requestResolvedAt: number;
+      requestStartedAt: number;
+    }
+  ): void {
+    const controllerApplyMs = Math.max(
+      0,
+      input.completedAt - input.requestResolvedAt
+    );
+    const requestMs = Math.max(
+      0,
+      input.requestResolvedAt - input.requestStartedAt
+    );
+    const returnedSessionIds = conversationRailQuerySessionIds(
+      input.query.queryState
+    );
+    this.complete(scopeKey, {
+      cacheStatus: input.cacheStatus,
+      controllerApplyMs,
+      requestId: input.requestId,
+      requestMs,
+      returnedSessionIds,
+      returnedSessionCount: input.query.returnedSessionCount,
+      sectionCount: input.query.sectionCount,
+      status: "ready"
+    });
+    emitConversationRailFirstPagesDiagnostic({
+      agentTargetId: input.agentTargetId,
+      controllerApplyMs,
+      diagnosticLogger: this.diagnosticLogger,
+      diagnosticSlowThresholdMs: this.slowThresholdMs,
+      durationMs: Math.max(0, input.completedAt - input.requestStartedAt),
+      requestId: input.requestId,
+      requestMs,
+      refreshReason: input.refreshReason,
+      returnedSessionIds,
+      returnedSessionCount: input.query.returnedSessionCount,
+      ...this.context,
+      sectionCount: input.query.sectionCount,
+      status: "ready"
+    });
+  }
+
+  completeCachedFirstPages(
+    scopeKey: string,
+    input: {
+      controllerApplyMs: number;
+      query: CachedConversationRailQuery;
+    }
+  ): void {
+    this.complete(scopeKey, {
+      cacheStatus: "fresh",
+      controllerApplyMs: input.controllerApplyMs,
+      requestId: null,
+      requestMs: 0,
+      returnedSessionIds: conversationRailQuerySessionIds(
+        input.query.queryState
+      ),
+      returnedSessionCount: input.query.returnedSessionCount,
+      sectionCount: input.query.sectionCount,
+      status: "ready"
+    });
+  }
+
+  failFirstPages(
+    scopeKey: string,
+    input: {
+      agentTargetId: string | null;
+      cacheStatus: "miss" | "stale";
+      error: unknown;
+      failedAt: number;
+      refreshReason: ConversationRailRefreshReason;
+      requestId: number;
+      requestStartedAt: number;
+    }
+  ): void {
+    const requestMs = Math.max(0, input.failedAt - input.requestStartedAt);
+    this.complete(scopeKey, {
+      cacheStatus: input.cacheStatus,
+      controllerApplyMs: 0,
+      error: input.error,
+      requestId: input.requestId,
+      requestMs,
+      returnedSessionIds: [],
+      returnedSessionCount: 0,
+      sectionCount: 0,
+      status: "error"
+    });
+    emitConversationRailFirstPagesDiagnostic({
+      agentTargetId: input.agentTargetId,
+      controllerApplyMs: 0,
+      diagnosticLogger: this.diagnosticLogger,
+      diagnosticSlowThresholdMs: this.slowThresholdMs,
+      durationMs: requestMs,
+      error: input.error,
+      requestId: input.requestId,
+      requestMs,
+      refreshReason: input.refreshReason,
+      returnedSessionIds: [],
+      returnedSessionCount: 0,
+      ...this.context,
+      sectionCount: 0,
+      status: "error"
+    });
+  }
+}
+
+export function emitConversationRailScopeChangeDiagnostic(input: {
+  activeConversationId: string | null;
+  cacheStatus: ConversationRailScopeChangeDiagnostic["cacheStatus"];
+  controllerApplyMs: number;
+  diagnosticLogger: ConversationRailDiagnosticLogger;
+  durationMs: number;
+  error?: unknown;
+  fromAgentTargetId: string | null;
+  fromFilterKind: ConversationRailFilterKind | null;
+  nodeId: string | null;
+  preservedSectionCount: number;
+  preservedSessionIds: readonly string[];
+  requestId: number | null;
+  requestMs: number;
+  retainedPreviousSections: boolean;
+  returnedSessionIds: readonly string[];
+  returnedSessionCount: number;
+  runtimeOrigin: string;
+  sectionCount: number;
+  status: ConversationRailScopeChangeDiagnostic["status"];
+  toAgentTargetId: string | null;
+  toFilterKind: ConversationRailFilterKind;
+  workspaceId: string;
+}): void {
+  const event: ConversationRailScopeChangeDiagnostic["event"] =
+    input.status === "pending"
+      ? "agent_gui.conversation_rail.scope_change.started"
+      : input.status === "error"
+        ? "agent_gui.conversation_rail.scope_change.failed"
+        : input.status === "superseded"
+          ? "agent_gui.conversation_rail.scope_change.superseded"
+          : "agent_gui.conversation_rail.scope_change.completed";
+  const payload: ConversationRailScopeChangeDiagnostic = {
+    activeConversationId: input.activeConversationId,
+    cacheStatus: input.cacheStatus,
+    controllerApplyMs: input.controllerApplyMs,
+    durationMs: input.durationMs,
+    ...(input.status === "error"
+      ? { errorKind: conversationRailErrorKind(input.error) }
+      : {}),
+    event,
+    fromAgentTargetId: input.fromAgentTargetId,
+    fromFilterKind: input.fromFilterKind,
+    nodeId: input.nodeId,
+    preservedSectionCount: input.preservedSectionCount,
+    preservedSessionIds: input.preservedSessionIds,
+    requestId: input.requestId,
+    requestMs: input.requestMs,
+    retainedPreviousSections: input.retainedPreviousSections,
+    returnedSessionIds: input.returnedSessionIds,
+    returnedSessionCount: input.returnedSessionCount,
+    runtimeOrigin: input.runtimeOrigin,
+    sectionCount: input.sectionCount,
+    status: input.status,
+    toAgentTargetId: input.toAgentTargetId,
+    toFilterKind: input.toFilterKind,
+    workspaceId: input.workspaceId
+  };
+  try {
+    input.diagnosticLogger(payload);
+  } catch (error) {
+    ignoreConversationRailDiagnosticFailure(error);
   }
 }
 
@@ -138,8 +422,12 @@ export function emitConversationRailProviderSwitchDiagnostic(input: {
   durationMs: number;
   error?: unknown;
   fromAgentTargetId: string | null;
+  nodeId: string | null;
+  requestId: number | null;
   requestMs: number;
+  returnedSessionIds: readonly string[];
   returnedSessionCount: number;
+  runtimeOrigin: string;
   sectionCount: number;
   status: "ready" | "error";
   toAgentTargetId: string | null;
@@ -157,8 +445,12 @@ export function emitConversationRailProviderSwitchDiagnostic(input: {
         ? "agent_gui.provider_switch.failed"
         : "agent_gui.provider_switch.completed",
     fromAgentTargetId: input.fromAgentTargetId,
+    nodeId: input.nodeId,
+    requestId: input.requestId,
     requestMs: input.requestMs,
+    returnedSessionIds: input.returnedSessionIds,
     returnedSessionCount: input.returnedSessionCount,
+    runtimeOrigin: input.runtimeOrigin,
     sectionCount: input.sectionCount,
     status: input.status,
     toAgentTargetId: input.toAgentTargetId,
@@ -181,7 +473,10 @@ export function emitConversationRailFirstPagesDiagnostic(input: {
   requestId: number;
   requestMs: number;
   refreshReason: ConversationRailRefreshReason;
+  returnedSessionIds: readonly string[];
   returnedSessionCount: number;
+  nodeId: string | null;
+  runtimeOrigin: string;
   sectionCount: number;
   status: "ready" | "error";
   workspaceId: string;
@@ -206,7 +501,10 @@ export function emitConversationRailFirstPagesDiagnostic(input: {
     requestId: input.requestId,
     requestMs: input.requestMs,
     refreshReason: input.refreshReason,
+    returnedSessionIds: input.returnedSessionIds,
     returnedSessionCount: input.returnedSessionCount,
+    nodeId: input.nodeId,
+    runtimeOrigin: input.runtimeOrigin,
     sectionCount: input.sectionCount,
     status: input.status,
     workspaceId: input.workspaceId
@@ -254,4 +552,14 @@ function conversationRailErrorKind(error: unknown): string {
     return "string";
   }
   return error === null ? "null" : typeof error;
+}
+
+export function conversationRailQuerySessionIds(
+  queryState: ConversationRailQueryState
+): string[] {
+  return [
+    ...new Set(
+      (queryState.sections ?? []).flatMap((section) => section.sessionIds)
+    )
+  ];
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryTypes.ts
@@ -32,6 +32,7 @@ export interface ConversationRailQueryControllerInput {
   diagnosticSlowThresholdMs?: number;
   engine: AgentSessionEngine;
   getActiveConversationId(): string | null;
+  nodeId?: string | null;
   runtime: ConversationRailQueryRuntime;
   sessionSectionsQueryCache?: WorkspaceQueryCache<CachedConversationRailQuery>;
   scheduler?: AgentGuiScheduler;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
@@ -14,6 +14,7 @@ export interface AgentGUIConversationRailInput {
   activeConversationId: string | null;
   conversationFilter: AgentGUINodeViewModel["rail"]["conversationFilter"];
   conversationQuery: string;
+  nodeId?: string | null;
   previewMode: boolean;
   /**
    * Lets the host subtree observe this controller's interaction lock (e.g.
@@ -29,6 +30,7 @@ export function useAgentGUIConversationRailQuery({
   activeConversationId,
   conversationFilter,
   conversationQuery,
+  nodeId,
   previewMode,
   registerInteractionLockProbe,
   sectionAgentTargetFallbackId,
@@ -51,10 +53,11 @@ export function useAgentGUIConversationRailQuery({
       new AgentGUIConversationRailQueryController({
         engine,
         getActiveConversationId: () => activeConversationIdRef.current,
+        nodeId,
         runtime,
         workspaceId
       }),
-    [engine, runtime, workspaceId]
+    [engine, nodeId, runtime, workspaceId]
   );
 
   useEffect(() => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -152,6 +152,7 @@ export type {
 } from "./agentGuiController.providerHelpers";
 
 export function useAgentGUINodeController({
+  nodeId,
   workspaceId,
   currentUserId,
   workspacePath,
@@ -762,6 +763,7 @@ export function useAgentGUINodeController({
     isLoadingConversations,
     isLoadingMessages,
     normalizedComingSoonProviders,
+    nodeId,
     operationActions,
     persistActiveConversation,
     planImplementationTurnIdRef,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
@@ -59,6 +59,7 @@ type UseAgentGUIViewAssemblyInput = ConversationPresentationInput &
   ComposerCapabilities &
   SessionDetailTransport &
   OperationActions & {
+    nodeId?: string | null;
     operationActions: OperationActions;
     detailAvailability: AgentGUIDetailViewModel["availability"];
     updateSelectedProjectPath: Parameters<
@@ -131,6 +132,7 @@ export function useAgentGUIViewAssembly(input: UseAgentGUIViewAssemblyInput) {
   });
   const viewModel = useAgentGUIViewModel({
     shell: {
+      nodeId: input.nodeId?.trim() || null,
       workspaceId: input.workspaceId,
       workspacePath: input.workspacePath,
       currentUserId: input.currentUserId,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -318,6 +318,7 @@ export interface AgentGUIQueuedPromptVM {
 export type AgentGUIQueueStatus = "active" | "paused_by_user";
 
 export interface AgentGUIShellViewModel {
+  nodeId?: string | null;
   workspaceId: string;
   workspacePath?: string | null;
   currentUserId?: string | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/useAgentGUIViewModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/useAgentGUIViewModel.ts
@@ -9,6 +9,7 @@ export function useAgentGUIViewModel(
     [
       candidate.shell.currentUserId,
       candidate.shell.data,
+      candidate.shell.nodeId,
       candidate.shell.workspaceId,
       candidate.shell.workspacePath
     ]

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
@@ -61,6 +61,7 @@ function useDelayedBoolean(value: boolean, delayMs: number): boolean {
 
 export interface AgentGUIConversationRailControllerProps {
   conversations: AgentGUINodeViewModel["rail"]["conversations"];
+  nodeId?: string | null;
   footer?: React.ReactNode;
   workspaceId: string;
   userProjects: AgentGUINodeViewModel["rail"]["userProjects"];


### PR DESCRIPTION
## What changed

- add started, completed, failed, and superseded diagnostics for conversation rail scope changes
- attach AgentGUI node identity, runtime origin, request/cache state, preserved session ids, and returned session ids
- keep existing slow/failure and provider-switch diagnostics while making them attributable to a concrete rail instance
- cover the target-filter to All transition where prior sections remain visible during the pending request

## Why

Shared AgentGUI users can switch the filter control to All while the conversation rail still displays the previous target-scoped sessions. Existing diagnostics cannot distinguish multiple AgentGUI nodes or prove whether the old list was retained, returned again, failed, or superseded.

## Risk and scope

Diagnostic-only change. It does not change filter selection, query behavior, loading presentation, or session membership. No durable documentation impact because ownership, public APIs, runtime configuration, and user-visible behavior are unchanged.

## Verification

- corepack pnpm check:changed: 11/11 lanes passed on latest origin/main
- pre-push check:changed -- --push-ready: 12/12 lanes passed
- AgentGUI package suite: 242 files and 2073 tests passed
- focused conversation rail controller test: 12/12 passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->