### PR TITLE
fix(agent): persist root provider failure codes

### DIFF
--- a/packages/agent/daemon/runtime/activity_projection_test.go
+++ b/packages/agent/daemon/runtime/activity_projection_test.go
@@ -145,6 +145,38 @@ func TestReportableActivityEventsIncludesRootProviderTurnLifecycle(t *testing.T)
 	if completed == nil || completed.RootTurnID != "root-turn-1" || completed.ProviderTurnID != "provider-turn-1" || completed.Phase != agentsessionstore.RootProviderTurnPhaseCompleted || completed.Outcome != string(activityshared.TurnOutcomeCompleted) {
 		t.Fatalf("completed root provider turn = %#v, want completed transition", completed)
 	}
+	if completed.ErrorCode != "" {
+		t.Fatalf("completed root provider turn error code = %q, want empty", completed.ErrorCode)
+	}
+}
+
+func TestRootProviderTurnFailurePersistsVisibleErrorCode(t *testing.T) {
+	t.Parallel()
+
+	session := reportTestSession()
+	session.Provider = ProviderTuttiAgent
+	ctx, ok := activityEventContext(session, "root-provider-turn-failed", "root-turn-1")
+	if !ok {
+		t.Fatal("activityEventContext() returned !ok")
+	}
+	const errorMessage = "You've hit your usage limit. Insufficient credits. View Tutti plans at https://tutti.sh/profile/plan, or try again later."
+	failed := activityshared.NewRootProviderTurnCompleted(ctx, "root-turn-1", "provider-turn-1", activityshared.TurnOutcomeFailed)
+	failed.Payload.Metadata = map[string]any{"error": errorMessage}
+
+	report := reportActivityInput(session, []activityshared.Event{failed})
+	if len(report.StatePatches) != 1 {
+		t.Fatalf("state patches = %#v, want one root provider failure", report.StatePatches)
+	}
+	completed := report.StatePatches[0].RootProviderTurn
+	if completed == nil {
+		t.Fatal("root provider turn transition is nil")
+	}
+	if completed.ErrorMessage != errorMessage {
+		t.Fatalf("root provider turn error message = %q, want %q", completed.ErrorMessage, errorMessage)
+	}
+	if completed.ErrorCode != "insufficient_credits" {
+		t.Fatalf("root provider turn error code = %q, want insufficient_credits", completed.ErrorCode)
+	}
 }
 
 func TestSessionStatusFromActivityPreservesWaiting(t *testing.T) {

--- a/packages/agent/daemon/runtime/reporter_state.go
+++ b/packages/agent/daemon/runtime/reporter_state.go
@@ -137,12 +137,20 @@ func statePatchFromSessionEvent(source canonical.EventSource, event activityshar
 		if event.Type == activityshared.EventRootProviderTurnCompleted {
 			phase = agentsessionstore.RootProviderTurnPhaseCompleted
 		}
+		errorMessage := activityshared.BestEffortErrorMessage(event.Payload)
+		errorCode := ""
+		if event.Type == activityshared.EventRootProviderTurnCompleted &&
+			strings.TrimSpace(event.Payload.TurnOutcome) == string(activityshared.TurnOutcomeFailed) &&
+			strings.TrimSpace(errorMessage) != "" {
+			errorCode = visibleFailureCode(errorMessage)
+		}
 		patch.RootProviderTurn = &canonical.WorkspaceAgentRootProviderTurnTransition{
 			RootTurnID:     strings.TrimSpace(event.Payload.TurnID),
 			ProviderTurnID: strings.TrimSpace(event.Payload.ProviderTurnID),
 			Phase:          phase,
 			Outcome:        strings.TrimSpace(event.Payload.TurnOutcome),
-			ErrorMessage:   activityshared.BestEffortErrorMessage(event.Payload),
+			ErrorMessage:   errorMessage,
+			ErrorCode:      errorCode,
 		}
 		if event.Type == activityshared.EventRootProviderTurnStarted {
 			applyProviderCreatedGoalTurnToPatch(&patch, event, timestamp)


### PR DESCRIPTION
## Summary

- classify failed root provider turn error messages with the existing visible failure taxonomy
- persist the resulting error code on the root provider turn transition
- cover the Tutti insufficient-credits message and keep successful completions free of error codes

## Why

New root provider turn failures persisted the raw error message but left `errorCode` empty. The Agent GUI therefore could not map Tutti insufficient-credit failures to its existing plans CTA.

## Validation

- `go test ./packages/agent/daemon/runtime -run 'Test(RootProviderTurnFailurePersistsVisibleErrorCode|ReportableActivityEventsIncludesRootProviderTurnLifecycle|VisibleFailureCodeClassifiesTuttiInsufficientCredits)$' -count=1`
- `pnpm test:go:agent-daemon`
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready` (8 lanes)

## Scope

- affects newly reported failed root provider turns only
- no historical event backfill
- no Tutti Agent, TSH, or UI changes
- no documentation impact

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->