### PR TITLE
fix(agent-gui): preserve queued mention icons

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.composition.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.composition.spec.ts
@@ -18,6 +18,29 @@ const queuedMentionStyles = css.slice(
 );
 
 describe("AgentQueuedPromptPanel CSS composition", () => {
+  it("keeps mention pill icons visible while hiding standalone media", () => {
+    const mediaSelector =
+      ':is(img, video, table, hr, br, input):not([data-slot="mention-pill"] *)';
+    expect(queuedMentionStyles).toMatch(
+      /:is\(img, video, table, hr, br, input\):not\(\[data-slot="mention-pill"\] \*\)\s*\{[^}]*display:\s*none;/s
+    );
+    expect(queuedMentionStyles).not.toMatch(
+      /:is\(img, video, table, hr, br, input\)\s*\{[^}]*display:\s*none;/s
+    );
+
+    const mentionPill = document.createElement("span");
+    mentionPill.dataset.slot = "mention-pill";
+    const mentionIcon = document.createElement("img");
+    const standaloneImage = document.createElement("img");
+    mentionPill.append(mentionIcon);
+    document.body.append(mentionPill, standaloneImage);
+
+    expect(mentionIcon.matches(mediaSelector)).toBe(false);
+    expect(standaloneImage.matches(mediaSelector)).toBe(true);
+    mentionPill.remove();
+    standaloneImage.remove();
+  });
+
   it("keeps the entity link layout-only around the shared mention pill", () => {
     expect(queuedMentionStyles).toMatch(
       /\[data-agent-file-mention="true"\]\.tsh-agent-object-token--entity\s*\{[^}]*top:\s*0;[^}]*gap:\s*0;[^}]*min-height:\s*0;[^}]*padding:\s*0;[^}]*border:\s*0;[^}]*line-height:\s*inherit;/s

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -8430,11 +8430,12 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   white-space: nowrap;
 }
 
-/* Media, tables, rules, and explicit line breaks cannot collapse into one
-   text line — drop them from the preview entirely. */
+/* Standalone media, tables, rules, and explicit line breaks cannot collapse
+   into one text line — drop them from the preview entirely. MentionPill owns
+   its nested image icon, which remains part of the inline mention preview. */
 .agent-gui-node__composer-queued-prompt-text
   .agent-gui-node__composer-queued-prompt-markdown
-  :is(img, video, table, hr, br, input) {
+  :is(img, video, table, hr, br, input):not([data-slot="mention-pill"] *) {
   display: none;
 }
 


### PR DESCRIPTION
## Summary

- keep resolved workspace-app icons visible inside queued prompt mention pills
- continue hiding standalone markdown media from the single-line queue preview
- add a regression test for the selector behavior

Root cause: the queued prompt preview applied a broad media selector to every nested `img`, including the image owned by the shared `MentionPill`. Mention resolution and the Ship icon URL were already correct; the first incorrect state was CSS setting the resolved icon to `display: none`.

Impact: all queued mentions backed by image icons were affected, not only Ship.

Documentation impact: none. This corrects selector scope without changing module ownership, data flow, public contracts, or interaction semantics.

## Verification

- `pnpm exec vitest run agent-gui/agentGuiNode/AgentQueuedPromptPanel.composition.spec.ts --environment jsdom --maxWorkers=1` (3 tests passed)
- `pnpm check:changed` (11 lanes passed)
- `pnpm check:changed -- --push-ready` (12 lanes passed)
- `pnpm release:pack:check` (package pack check passed)
- `git diff --check`

## Checklist

- [x] If this PR changes agent lifecycle semantics: not applicable; no lifecycle semantics changed.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed: not applicable; no documentation impact.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source: not applicable.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->