### PR TITLE
feat(workspace-file-preview): normalize package to shared contract

### DIFF
--- a/.changeset/workspace-file-preview-contract.md
+++ b/.changeset/workspace-file-preview-contract.md
@@ -1,0 +1,7 @@
+---
+"@tutti-os/workspace-file-preview": minor
+"@tutti-os/workspace-file-manager": minor
+"@tutti-os/workspace-file-reference": minor
+---
+
+Normalize workspace file preview to the shared contract: flat `previewKind`, preview-oriented target naming, host renderer hooks, `toSurfaceState`, and move open-with advisories to file-manager.

--- a/apps/desktop/src/main/host/openWithApplications.ts
+++ b/apps/desktop/src/main/host/openWithApplications.ts
@@ -1,4 +1,4 @@
-import { shouldFilterVideoPlayersForOpenWith } from "@tutti-os/workspace-file-preview";
+import { shouldFilterVideoPlayersForOpenWith } from "@tutti-os/workspace-file-manager/services";
 import { execFile } from "node:child_process";
 import { accessSync, constants, readdirSync } from "node:fs";
 import { mkdtemp, writeFile } from "node:fs/promises";

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
@@ -280,7 +280,9 @@ test("desktop agent GUI workbench host input opens workspace references through 
     workspaceAgentActivityService: createWorkspaceAgentActivityService([]),
     workspaceFilePreviewSurfaceHost: {
       async present(workspaceId, target) {
-        calls.push(`preview:${workspaceId}:${target.path}:${target.fileKind}`);
+        calls.push(
+          `preview:${workspaceId}:${target.path}:${target.previewKind}`
+        );
         return {
           presented: true,
           unsupportedFallbackNotification: "show"

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/resolveWorkbenchDockFileMentionItems.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/resolveWorkbenchDockFileMentionItems.test.ts
@@ -70,7 +70,7 @@ test("resolveWorkbenchDockFileMentionItems returns open file preview nodes in st
           data: {
             activation: {
               payload: {
-                fileKind: "text",
+                previewKind: "text",
                 mtimeMs: null,
                 name: "alpha.ts",
                 path: "/workspace/alpha.ts",
@@ -89,7 +89,7 @@ test("resolveWorkbenchDockFileMentionItems returns open file preview nodes in st
           data: {
             activation: {
               payload: {
-                fileKind: "text",
+                previewKind: "text",
                 mtimeMs: null,
                 name: "beta.ts",
                 path: "/workspace/beta.ts",
@@ -156,7 +156,7 @@ test("resolveWorkbenchDockFileMentionItems includes image previews restored from
             instanceId: "path:img",
             snapshotNodeState: {
               file: {
-                fileKind: "image",
+                previewKind: "image",
                 mtimeMs: null,
                 name: "diagram.png",
                 path: "/workspace/assets/diagram.png",
@@ -200,7 +200,7 @@ test("resolveWorkbenchDockFileMentionItems reads preview targets from runtime no
             instanceId: "path:txt",
             runtimeNodeState: {
               file: {
-                fileKind: "text",
+                previewKind: "text",
                 mtimeMs: null,
                 name: "notes.md",
                 path: "/workspace/notes.md",

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/resolveWorkbenchDockFileMentionItems.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/resolveWorkbenchDockFileMentionItems.ts
@@ -1,6 +1,6 @@
-import type { WorkspaceFilePreviewActivationTarget } from "@tutti-os/workspace-file-preview";
+import type { WorkspaceFilePreviewTarget } from "@tutti-os/workspace-file-preview";
 import {
-  isWorkspaceFilePreviewActivationTarget,
+  coerceWorkspaceFilePreviewTarget,
   isWorkspaceFilePreviewNodeTypeID,
   workspaceFilePreviewActivationType
 } from "../../../workspace-workbench/services/workspaceFilePreviewLaunch.ts";
@@ -77,24 +77,22 @@ export function resolveWorkbenchDockFileMentionItems(input: {
 
 function resolveWorkbenchDockFileTarget(
   nodeData: WorkbenchHostNodeData
-): WorkspaceFilePreviewActivationTarget | null {
+): WorkspaceFilePreviewTarget | null {
   for (const value of [nodeData.runtimeNodeState, nodeData.snapshotNodeState]) {
     if (!value || typeof value !== "object") {
       continue;
     }
 
     const candidate = value as { file?: unknown };
-    if (isWorkspaceFilePreviewActivationTarget(candidate.file)) {
-      return candidate.file;
+    const file = coerceWorkspaceFilePreviewTarget(candidate.file);
+    if (file) {
+      return file;
     }
   }
 
   const activation = nodeData.activation;
-  if (
-    activation?.type === workspaceFilePreviewActivationType &&
-    isWorkspaceFilePreviewActivationTarget(activation.payload)
-  ) {
-    return activation.payload;
+  if (activation?.type === workspaceFilePreviewActivationType) {
+    return coerceWorkspaceFilePreviewTarget(activation.payload);
   }
 
   return null;

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/createDesktopWorkspaceFileReferenceAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/createDesktopWorkspaceFileReferenceAdapter.test.ts
@@ -209,7 +209,7 @@ test("desktop workspace file reference adapter opens previewable files with the 
       }
     } as unknown as DesktopHostFilesApi,
     presentFilePreview(target, workspaceId) {
-      calls.push(`preview:${workspaceId}:${target.path}:${target.fileKind}`);
+      calls.push(`preview:${workspaceId}:${target.path}:${target.previewKind}`);
       return true;
     },
     tuttidClient: {} as TuttidClient,
@@ -233,7 +233,7 @@ test("desktop workspace file reference adapter falls back to system open when th
       }
     } as unknown as DesktopHostFilesApi,
     presentFilePreview(target, workspaceId) {
-      calls.push(`preview:${workspaceId}:${target.path}:${target.fileKind}`);
+      calls.push(`preview:${workspaceId}:${target.path}:${target.previewKind}`);
       return false;
     },
     tuttidClient: {} as TuttidClient,
@@ -333,4 +333,28 @@ test("desktop workspace file reference adapter reads video previews", async () =
     kind: "video"
   });
   assert.deepEqual(previewReads, [["workspace-2", "/workspace/demo.mp4"]]);
+});
+
+test("desktop workspace file reference adapter classifies preview reads from displayName", async () => {
+  const adapter = createDesktopWorkspaceFileReferenceAdapter({
+    hostFilesApi: {
+      async readPreviewFile() {
+        return new Uint8Array([0x23, 0x20]);
+      }
+    } as unknown as DesktopHostFilesApi,
+    tuttidClient: {} as TuttidClient,
+    workspaceId: "workspace-1"
+  });
+
+  const preview = await adapter.readReferencePreview?.({
+    reference: {
+      displayName: "notes.md",
+      kind: "file",
+      path: "/workspace/objects/abc123"
+    },
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(preview?.kind, "markdown");
+  assert.equal(preview?.contentType, "text/plain;charset=utf-8");
 });

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/createDesktopWorkspaceFileReferenceAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/createDesktopWorkspaceFileReferenceAdapter.ts
@@ -9,18 +9,19 @@ import type {
 } from "@tutti-os/workspace-file-reference/contracts";
 import {
   classifyWorkspaceFilePreviewKind,
-  resolveWorkspaceFileActivationTarget,
+  resolveWorkspaceFileBuiltinRenderKind,
   resolveWorkspaceFilePreviewName,
+  resolveWorkspaceFilePreviewTarget,
   resolveWorkspaceImageMimeType,
   resolveWorkspaceVideoMimeType,
-  type WorkspaceFilePreviewActivationTarget
+  type WorkspaceFilePreviewTarget
 } from "@tutti-os/workspace-file-preview";
 import type { DesktopHostFilesApi } from "@preload/types";
 
 export function createDesktopWorkspaceFileReferenceAdapter(input: {
   hostFilesApi: DesktopHostFilesApi;
   presentFilePreview?: (
-    target: WorkspaceFilePreviewActivationTarget,
+    target: WorkspaceFilePreviewTarget,
     workspaceId: string
   ) => Promise<boolean> | boolean;
   tuttidClient: TuttidClient;
@@ -84,9 +85,7 @@ export function createDesktopWorkspaceFileReferenceAdapter(input: {
         path: trimmedPath
       });
       const target =
-        entry.kind === "file"
-          ? resolveWorkspaceFileActivationTarget(entry)
-          : null;
+        entry.kind === "file" ? resolveWorkspaceFilePreviewTarget(entry) : null;
       if (
         target &&
         (await presentFilePreview?.(target, workspaceId)) === true
@@ -125,11 +124,23 @@ export function createDesktopWorkspaceFileReferenceAdapter(input: {
       );
     },
     async readReferencePreview({ reference, workspaceId }) {
-      const previewKind = classifyWorkspaceFilePreviewKind(reference);
-      if (!previewKind || isTerminalReferencePath(reference.path)) {
+      // References use displayName; map to preview entry.name so classification
+      // matches openReference → referenceToWorkspaceFileEntry.
+      const name = resolveWorkspaceFilePreviewName({
+        name: reference.displayName,
+        path: reference.path
+      });
+      const previewKind = classifyWorkspaceFilePreviewKind({
+        kind: reference.kind === "folder" ? "directory" : reference.kind,
+        name,
+        path: reference.path
+      });
+      if (
+        resolveWorkspaceFileBuiltinRenderKind(previewKind) === null ||
+        isTerminalReferencePath(reference.path)
+      ) {
         return null;
       }
-      const name = resolveWorkspaceFilePreviewName(reference);
       const path = reference.path.trim();
       return {
         bytes: await hostFilesApi.readPreviewFile(workspaceId, path),

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/desktopWorkspaceFileManagerAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/desktopWorkspaceFileManagerAdapter.ts
@@ -7,7 +7,7 @@ import type {
   WorkspaceFileManagerHostFileActivationResult,
   WorkspaceFileSearchResult
 } from "@tutti-os/workspace-file-manager/services";
-import type { WorkspaceFilePreviewActivationTarget } from "@tutti-os/workspace-file-preview";
+import type { WorkspaceFilePreviewTarget } from "@tutti-os/workspace-file-preview";
 import { requestWorkspaceBrowserHostFileLaunch } from "../../../workspace-workbench/services/workspaceBrowserLaunchCoordinator.ts";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
 import { resolveDesktopErrorMessage } from "../../../../lib/desktopErrors.ts";
@@ -31,7 +31,7 @@ export function createDesktopWorkspaceFileManagerAdapter(
       workspaceID: string
     ): WorkspaceFilePreviewPresentationResult["unsupportedFallbackNotification"];
     openCanvasPreview(
-      target: WorkspaceFilePreviewActivationTarget,
+      target: WorkspaceFilePreviewTarget,
       workspaceID: string
     ): Promise<WorkspaceFilePreviewPresentationResult>;
   }

--- a/apps/desktop/src/renderer/src/features/workspace-file-preview/services/internal/workspaceFilePreviewSurfaceHost.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-preview/services/internal/workspaceFilePreviewSurfaceHost.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { WorkspaceFilePreviewActivationTarget } from "@tutti-os/workspace-file-preview";
+import type { WorkspaceFilePreviewTarget } from "@tutti-os/workspace-file-preview";
 import { WorkspaceFilePreviewSurfaceHost } from "./workspaceFilePreviewSurfaceHost.ts";
 
-const target: WorkspaceFilePreviewActivationTarget = {
-  fileKind: "text",
+const target: WorkspaceFilePreviewTarget = {
+  previewKind: "text",
   mtimeMs: null,
   name: "notes.txt",
   path: "/workspace/notes.txt",

--- a/apps/desktop/src/renderer/src/features/workspace-file-preview/services/workspaceFilePreviewSurfaceHost.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-preview/services/workspaceFilePreviewSurfaceHost.interface.ts
@@ -1,11 +1,9 @@
 import { createDecorator } from "@tutti-os/infra/di";
-import type { WorkspaceFilePreviewActivationTarget } from "@tutti-os/workspace-file-preview";
+import type { WorkspaceFilePreviewTarget } from "@tutti-os/workspace-file-preview";
 
 export interface WorkspaceFilePreviewSurfacePresenter {
   readonly unsupportedFallbackNotification: "show" | "suppress";
-  present(
-    target: WorkspaceFilePreviewActivationTarget
-  ): Promise<boolean> | boolean;
+  present(target: WorkspaceFilePreviewTarget): Promise<boolean> | boolean;
 }
 
 export interface WorkspaceFilePreviewPresentationResult {
@@ -20,7 +18,7 @@ export interface IWorkspaceFilePreviewSurfaceHost {
   ): WorkspaceFilePreviewPresentationResult["unsupportedFallbackNotification"];
   present(
     workspaceID: string,
-    target: WorkspaceFilePreviewActivationTarget
+    target: WorkspaceFilePreviewTarget
   ): Promise<WorkspaceFilePreviewPresentationResult>;
   registerPresenter(
     workspaceID: string,

--- a/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/adapters/desktopIssueManagerFileAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/adapters/desktopIssueManagerFileAdapter.test.ts
@@ -345,7 +345,7 @@ test("desktop issue-manager file adapter reads image and text previews", async (
   assert.deepEqual(textPreview, {
     bytes: new TextEncoder().encode("hello"),
     contentType: "text/plain;charset=utf-8",
-    kind: "text"
+    kind: "markdown"
   });
   assert.equal(unsupportedPreview, null);
   assert.equal(terminalPreview, null);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilePreviewContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilePreviewContribution.ts
@@ -17,7 +17,7 @@ import { WorkspaceFilePreviewNodeBody } from "../../ui/WorkspaceFilePreviewNodeB
 import { WorkspaceFilePreviewNodeHeader } from "../../ui/WorkspaceFilePreviewNodeHeader.tsx";
 import {
   createWorkspaceFilePreviewInstanceID,
-  isWorkspaceFilePreviewActivationTarget,
+  coerceWorkspaceFilePreviewTarget,
   isWorkspaceFilePreviewNodeTypeID,
   resolveWorkspaceFilePreviewNodeTypeID,
   workspaceFilePreviewActivationType,
@@ -56,17 +56,14 @@ export function createWorkspaceFilePreviewContribution(input: {
       })
     ],
     onLaunchRequest: (request) => {
-      if (
-        !isWorkspaceFilePreviewNodeTypeID(request.typeId) ||
-        !isWorkspaceFilePreviewActivationTarget(request.payload)
-      ) {
+      const target = coerceWorkspaceFilePreviewTarget(request.payload);
+      if (!isWorkspaceFilePreviewNodeTypeID(request.typeId) || !target) {
         return null;
       }
 
-      const target = request.payload;
       if (
         request.typeId !==
-        resolveWorkspaceFilePreviewNodeTypeID(target.fileKind)
+        resolveWorkspaceFilePreviewNodeTypeID(target.previewKind)
       ) {
         return null;
       }
@@ -155,11 +152,12 @@ function createWorkspaceFilePreviewNodeDefinition(input: {
 }
 
 function resolvePreviewFileExtension(payload: unknown): string | null {
-  if (!isWorkspaceFilePreviewActivationTarget(payload)) {
+  const target = coerceWorkspaceFilePreviewTarget(payload);
+  if (!target) {
     return null;
   }
 
-  const source = payload.name || payload.path;
+  const source = target.name || target.path;
   const slashIndex = Math.max(
     source.lastIndexOf("/"),
     source.lastIndexOf("\\")

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilePreviewNodeController.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilePreviewNodeController.ts
@@ -1,10 +1,11 @@
 import {
   createWorkspaceFilePreviewController,
   formatWorkspacePreviewByteLimit,
+  isTextDegradablePreviewKind,
   workspaceFilePreviewMaxBytes,
   type WorkspaceFilePreviewController,
   type WorkspaceFilePreviewControllerState,
-  type WorkspaceFilePreviewActivationTarget,
+  type WorkspaceFilePreviewTarget,
   type WorkspaceFilePreviewReadonlyReason
 } from "@tutti-os/workspace-file-preview";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
@@ -28,37 +29,37 @@ export type WorkspaceFilePreviewTextSaveStatus =
 
 export type WorkspaceFilePreviewNodeControllerState =
   | { status: "empty" }
-  | { entry: WorkspaceFilePreviewActivationTarget; status: "loading" }
+  | { entry: WorkspaceFilePreviewTarget; status: "loading" }
   | {
       content: string;
       draft: string;
-      entry: WorkspaceFilePreviewActivationTarget;
+      entry: WorkspaceFilePreviewTarget;
       message?: string;
       saveStatus: WorkspaceFilePreviewTextSaveStatus;
       status: "text";
     }
   | {
-      entry: WorkspaceFilePreviewActivationTarget;
+      entry: WorkspaceFilePreviewTarget;
       objectUrl: string;
       status: "image";
     }
   | {
-      entry: WorkspaceFilePreviewActivationTarget;
+      entry: WorkspaceFilePreviewTarget;
       objectUrl: string;
       status: "video";
     }
   | {
-      entry: WorkspaceFilePreviewActivationTarget;
+      entry: WorkspaceFilePreviewTarget;
       message: string;
       status: "error";
     }
   | {
-      entry: WorkspaceFilePreviewActivationTarget;
+      entry: WorkspaceFilePreviewTarget;
       message: string;
       status: "readonly";
     }
   | {
-      entry: WorkspaceFilePreviewActivationTarget;
+      entry: WorkspaceFilePreviewTarget;
       message: string;
       status: "unsupported";
     };
@@ -68,7 +69,7 @@ export interface WorkspaceFilePreviewNodeController {
   dispose(): void;
   getSnapshot(): WorkspaceFilePreviewNodeControllerState;
   saveTextFile(): Promise<void>;
-  setActiveFile(file: WorkspaceFilePreviewActivationTarget | null): void;
+  setActiveFile(file: WorkspaceFilePreviewTarget | null): void;
   subscribe(listener: () => void): () => void;
 }
 
@@ -76,7 +77,7 @@ export function createWorkspaceFilePreviewNodeController(input: {
   appI18n: I18nRuntime<string>;
   hostFilesApi: Pick<DesktopHostFilesApi, "readLocalPreviewFile">;
   i18n: WorkspaceWorkbenchDesktopI18nRuntime;
-  initialFile: WorkspaceFilePreviewActivationTarget | null;
+  initialFile: WorkspaceFilePreviewTarget | null;
   tuttidClient: Pick<
     TuttidClient,
     "readWorkspaceFilePreview" | "writeWorkspaceFileText"
@@ -95,7 +96,7 @@ class WorkspaceFilePreviewNodeControllerImpl implements WorkspaceFilePreviewNode
     appI18n: I18nRuntime<string>;
     hostFilesApi: Pick<DesktopHostFilesApi, "readLocalPreviewFile">;
     i18n: WorkspaceWorkbenchDesktopI18nRuntime;
-    initialFile: WorkspaceFilePreviewActivationTarget | null;
+    initialFile: WorkspaceFilePreviewTarget | null;
     tuttidClient: Pick<
       TuttidClient,
       "readWorkspaceFilePreview" | "writeWorkspaceFileText"
@@ -104,7 +105,7 @@ class WorkspaceFilePreviewNodeControllerImpl implements WorkspaceFilePreviewNode
     onSnapshotStateChange(state: unknown): void;
     workspaceID: string;
   };
-  private readonly previewController: WorkspaceFilePreviewController<WorkspaceFilePreviewActivationTarget>;
+  private readonly previewController: WorkspaceFilePreviewController<WorkspaceFilePreviewTarget>;
   private readonly unsubscribePreview: () => void;
   private runtimeStateKey: string | null = null;
   private snapshotStateKey: string | null = null;
@@ -114,7 +115,7 @@ class WorkspaceFilePreviewNodeControllerImpl implements WorkspaceFilePreviewNode
     appI18n: I18nRuntime<string>;
     hostFilesApi: Pick<DesktopHostFilesApi, "readLocalPreviewFile">;
     i18n: WorkspaceWorkbenchDesktopI18nRuntime;
-    initialFile: WorkspaceFilePreviewActivationTarget | null;
+    initialFile: WorkspaceFilePreviewTarget | null;
     tuttidClient: Pick<
       TuttidClient,
       "readWorkspaceFilePreview" | "writeWorkspaceFileText"
@@ -141,9 +142,9 @@ class WorkspaceFilePreviewNodeControllerImpl implements WorkspaceFilePreviewNode
                 )
               ).bytesBase64
             ),
-        kind: entry.fileKind
+        kind: entry.previewKind
       }),
-      toPreviewEntry: (entry: WorkspaceFilePreviewActivationTarget) => ({
+      toPreviewEntry: (entry: WorkspaceFilePreviewTarget) => ({
         ...entry,
         kind: "file"
       })
@@ -228,7 +229,7 @@ class WorkspaceFilePreviewNodeControllerImpl implements WorkspaceFilePreviewNode
     }
   }
 
-  setActiveFile(file: WorkspaceFilePreviewActivationTarget | null): void {
+  setActiveFile(file: WorkspaceFilePreviewTarget | null): void {
     if (this.disposed) {
       return;
     }
@@ -243,7 +244,7 @@ class WorkspaceFilePreviewNodeControllerImpl implements WorkspaceFilePreviewNode
   }
 
   private applyPreviewState(
-    state: WorkspaceFilePreviewControllerState<WorkspaceFilePreviewActivationTarget>
+    state: WorkspaceFilePreviewControllerState<WorkspaceFilePreviewTarget>
   ): void {
     switch (state.status) {
       case "empty":
@@ -267,6 +268,17 @@ class WorkspaceFilePreviewNodeControllerImpl implements WorkspaceFilePreviewNode
           entry: state.entry,
           objectUrl: state.objectUrl,
           status: state.status
+        }));
+        return;
+      case "bytes":
+        // Desktop workbench does not register host renderers yet; hook-only
+        // payloads are treated as unsupported in this surface.
+        this.updateState(() => ({
+          entry: state.entry,
+          message: this.input.appI18n.t(
+            "workspaceFileManager.previewUnsupported"
+          ),
+          status: "unsupported"
         }));
         return;
       case "readonly":
@@ -355,10 +367,9 @@ function resolveRuntimeStateFromPreviewState(
 
   return createWorkspaceFilePreviewNodeRuntimeState({
     file: state.entry,
-    textHeader:
-      state.entry.fileKind === "text"
-        ? resolveTextHeaderStateFromPreviewState(state)
-        : undefined
+    textHeader: isTextDegradablePreviewKind(state.entry.previewKind)
+      ? resolveTextHeaderStateFromPreviewState(state)
+      : undefined
   });
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentWorkspaceFilePreviewPresenter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentWorkspaceFilePreviewPresenter.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { WorkspaceFilePreviewActivationTarget } from "@tutti-os/workspace-file-preview";
+import type { WorkspaceFilePreviewTarget } from "@tutti-os/workspace-file-preview";
 import { createStandaloneAgentWorkspaceFilePreviewPresenter } from "./standaloneAgentWorkspaceFilePreviewPresenter.ts";
 
 test("standalone Agent file preview presenter opens the file with the system host", async () => {
@@ -13,8 +13,8 @@ test("standalone Agent file preview presenter opens the file with the system hos
     },
     workspaceId: "workspace-1"
   });
-  const target: WorkspaceFilePreviewActivationTarget = {
-    fileKind: "text",
+  const target: WorkspaceFilePreviewTarget = {
+    previewKind: "text",
     mtimeMs: null,
     name: "notes.txt",
     path: "/workspace/notes.txt",

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchWorkspaceFilePreviewPresenter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchWorkspaceFilePreviewPresenter.test.ts
@@ -1,12 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { WorkbenchHostHandle } from "@tutti-os/workbench-surface";
-import type { WorkspaceFilePreviewActivationTarget } from "@tutti-os/workspace-file-preview";
+import type { WorkspaceFilePreviewTarget } from "@tutti-os/workspace-file-preview";
 import { createWorkspaceFilePreviewLaunchRequest } from "./workspaceFilePreviewLaunch.ts";
 import { createWorkbenchWorkspaceFilePreviewPresenter } from "./workbenchWorkspaceFilePreviewPresenter.ts";
 
-const target: WorkspaceFilePreviewActivationTarget = {
-  fileKind: "image",
+const target: WorkspaceFilePreviewTarget = {
+  previewKind: "image",
   mtimeMs: 1,
   name: "cover.png",
   path: "/workspace/cover.png",

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilePreviewLaunch.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilePreviewLaunch.test.ts
@@ -1,16 +1,17 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { WorkspaceFilePreviewActivationTarget } from "@tutti-os/workspace-file-preview";
+import type { WorkspaceFilePreviewTarget } from "@tutti-os/workspace-file-preview";
 import {
+  coerceWorkspaceFilePreviewTarget,
   createWorkspaceFilePreviewInstanceID,
   createWorkspaceFilePreviewLaunchRequest,
-  isWorkspaceFilePreviewActivationTarget,
+  isWorkspaceFilePreviewTarget,
   workspaceTextFileNodeTypeID
 } from "./workspaceFilePreviewLaunch.ts";
 
-function textTarget(path: string): WorkspaceFilePreviewActivationTarget {
+function textTarget(path: string): WorkspaceFilePreviewTarget {
   return {
-    fileKind: "text",
+    previewKind: "text",
     mtimeMs: null,
     name: path.split("/").pop() ?? "file.txt",
     path,
@@ -46,8 +47,8 @@ test("workspace file preview launch requests preserve the original file target",
 
 test("workspace file preview activation accepts video targets", () => {
   assert.equal(
-    isWorkspaceFilePreviewActivationTarget({
-      fileKind: "video",
+    isWorkspaceFilePreviewTarget({
+      previewKind: "video",
       mtimeMs: null,
       name: "demo.mp4",
       path: "/workspace/demo.mp4",
@@ -59,11 +60,49 @@ test("workspace file preview activation accepts video targets", () => {
 
 test("workspace file preview activation accepts shared targets without optional metadata", () => {
   assert.equal(
-    isWorkspaceFilePreviewActivationTarget({
-      fileKind: "image",
+    isWorkspaceFilePreviewTarget({
+      previewKind: "image",
       name: "cover.png",
       path: "/workspace/cover.png"
     }),
     true
+  );
+});
+
+test("workspace file preview activation coerces legacy fileKind snapshots", () => {
+  const legacy = {
+    fileKind: "text",
+    mtimeMs: null,
+    name: "notes.md",
+    path: "/workspace/notes.md",
+    sizeBytes: 12
+  };
+
+  assert.equal(isWorkspaceFilePreviewTarget(legacy), false);
+  assert.deepEqual(coerceWorkspaceFilePreviewTarget(legacy), {
+    previewKind: "text",
+    mtimeMs: null,
+    name: "notes.md",
+    path: "/workspace/notes.md",
+    sizeBytes: 12
+  });
+});
+
+test("workspace file preview activation coerces legacy video fileKind snapshots", () => {
+  assert.deepEqual(
+    coerceWorkspaceFilePreviewTarget({
+      fileKind: "video",
+      mtimeMs: null,
+      name: "demo.mp4",
+      path: "/workspace/demo.mp4",
+      sizeBytes: null
+    }),
+    {
+      previewKind: "video",
+      mtimeMs: null,
+      name: "demo.mp4",
+      path: "/workspace/demo.mp4",
+      sizeBytes: null
+    }
   );
 });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilePreviewLaunch.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilePreviewLaunch.ts
@@ -1,4 +1,8 @@
-import type { WorkspaceFilePreviewActivationTarget } from "@tutti-os/workspace-file-preview";
+import {
+  resolveWorkspaceFileBuiltinRenderKind,
+  type WorkspaceFilePreviewKind,
+  type WorkspaceFilePreviewTarget
+} from "@tutti-os/workspace-file-preview";
 import type { WorkbenchHostLaunchInput } from "@tutti-os/workbench-surface";
 
 export const workspaceImageFileNodeTypeID = "workspace-image-file";
@@ -6,26 +10,26 @@ export const workspaceTextFileNodeTypeID = "workspace-text-file";
 export const workspaceFilePreviewActivationType = "workspace-file-preview";
 
 export function createWorkspaceFilePreviewLaunchRequest(
-  target: WorkspaceFilePreviewActivationTarget
+  target: WorkspaceFilePreviewTarget
 ): WorkbenchHostLaunchInput {
   return {
     launchSource: "file_manager",
     payload: target,
     reason: "host",
-    typeId: resolveWorkspaceFilePreviewNodeTypeID(target.fileKind)
+    typeId: resolveWorkspaceFilePreviewNodeTypeID(target.previewKind)
   };
 }
 
 export function createWorkspaceFilePreviewInstanceID(
-  target: WorkspaceFilePreviewActivationTarget
+  target: WorkspaceFilePreviewTarget
 ): string {
   return `path:${hashWorkspaceFilePreviewPath(target.path)}`;
 }
 
 export function resolveWorkspaceFilePreviewNodeTypeID(
-  fileKind: WorkspaceFilePreviewActivationTarget["fileKind"]
+  previewKind: WorkspaceFilePreviewKind
 ): string {
-  return fileKind === "image"
+  return resolveWorkspaceFileBuiltinRenderKind(previewKind) === "image"
     ? workspaceImageFileNodeTypeID
     : workspaceTextFileNodeTypeID;
 }
@@ -37,29 +41,84 @@ export function isWorkspaceFilePreviewNodeTypeID(typeID: string): boolean {
   );
 }
 
-export function isWorkspaceFilePreviewActivationTarget(
+/**
+ * Coerce unknown activation/snapshot payloads into a canonical preview target.
+ * Accepts legacy `fileKind` (`image` | `text` | `video`) from pre-rename
+ * snapshots and normalizes it to `previewKind`.
+ */
+export function coerceWorkspaceFilePreviewTarget(
   value: unknown
-): value is WorkspaceFilePreviewActivationTarget {
+): WorkspaceFilePreviewTarget | null {
   if (!value || typeof value !== "object") {
-    return false;
+    return null;
   }
 
-  const candidate = value as Partial<WorkspaceFilePreviewActivationTarget>;
+  const candidate = value as Partial<WorkspaceFilePreviewTarget> & {
+    fileKind?: unknown;
+  };
+  const previewKind = resolveCoercedPreviewKind(candidate);
+  if (
+    previewKind === null ||
+    typeof candidate.name !== "string" ||
+    candidate.name.trim().length === 0 ||
+    typeof candidate.path !== "string" ||
+    candidate.path.trim().length === 0 ||
+    (candidate.mtimeMs !== undefined &&
+      candidate.mtimeMs !== null &&
+      typeof candidate.mtimeMs !== "number") ||
+    (candidate.sizeBytes !== undefined &&
+      candidate.sizeBytes !== null &&
+      typeof candidate.sizeBytes !== "number")
+  ) {
+    return null;
+  }
+
+  return {
+    previewKind,
+    name: candidate.name,
+    path: candidate.path,
+    ...(candidate.mtimeMs === undefined ? {} : { mtimeMs: candidate.mtimeMs }),
+    ...(candidate.sizeBytes === undefined
+      ? {}
+      : { sizeBytes: candidate.sizeBytes })
+  };
+}
+
+/**
+ * Type guard for canonical preview targets (`previewKind` present).
+ * Prefer {@link coerceWorkspaceFilePreviewTarget} when reading unknown
+ * activation/snapshot payloads that may still use legacy `fileKind`.
+ */
+export function isWorkspaceFilePreviewTarget(
+  value: unknown
+): value is WorkspaceFilePreviewTarget {
   return (
-    (candidate.fileKind === "image" ||
-      candidate.fileKind === "text" ||
-      candidate.fileKind === "video") &&
-    typeof candidate.name === "string" &&
-    candidate.name.trim().length > 0 &&
-    typeof candidate.path === "string" &&
-    candidate.path.trim().length > 0 &&
-    (candidate.mtimeMs === undefined ||
-      candidate.mtimeMs === null ||
-      typeof candidate.mtimeMs === "number") &&
-    (candidate.sizeBytes === undefined ||
-      candidate.sizeBytes === null ||
-      typeof candidate.sizeBytes === "number")
+    !!value &&
+    typeof value === "object" &&
+    "previewKind" in value &&
+    coerceWorkspaceFilePreviewTarget(value) !== null
   );
+}
+
+function resolveCoercedPreviewKind(
+  candidate: Partial<WorkspaceFilePreviewTarget> & { fileKind?: unknown }
+): WorkspaceFilePreviewKind | null {
+  if (candidate.previewKind !== undefined) {
+    return resolveWorkspaceFileBuiltinRenderKind(candidate.previewKind) === null
+      ? null
+      : candidate.previewKind;
+  }
+
+  // Legacy activation / snapshot field before previewKind rename.
+  if (
+    candidate.fileKind === "image" ||
+    candidate.fileKind === "text" ||
+    candidate.fileKind === "video"
+  ) {
+    return candidate.fileKind;
+  }
+
+  return null;
 }
 
 function hashWorkspaceFilePreviewPath(path: string): string {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceFilePreviewNodeBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceFilePreviewNodeBody.tsx
@@ -12,15 +12,18 @@ import {
   LoadingIcon,
   VideoFileIcon
 } from "@tutti-os/ui-system";
-import type { WorkspaceFilePreviewActivationTarget } from "@tutti-os/workspace-file-preview";
-import { WorkspaceFilePreviewSurface } from "@tutti-os/workspace-file-preview/react";
+import type { WorkspaceFilePreviewTarget } from "@tutti-os/workspace-file-preview";
+import {
+  WorkspaceFilePreviewSurface,
+  type WorkspaceFilePreviewSurfaceState
+} from "@tutti-os/workspace-file-preview/react";
 import type { WorkbenchHostNodeBodyContext } from "@tutti-os/workbench-surface";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import type { DesktopHostFilesApi } from "@preload/types";
 import type { WorkspaceWorkbenchDesktopI18nRuntime } from "@shared/i18n";
 import {
-  isWorkspaceFilePreviewActivationTarget,
+  coerceWorkspaceFilePreviewTarget,
   workspaceFilePreviewActivationType
 } from "../services/workspaceFilePreviewLaunch";
 import type { WorkspaceFilePreviewSaveRequestSource } from "../services/workspaceFilePreviewSaveRequests";
@@ -163,18 +166,77 @@ export function WorkspaceFilePreviewNodeBody({
       }
       loadingMessage={appI18n.t("workspaceFileManager.previewLoadingLabel")}
       renderIcon={(entry) =>
-        entry.fileKind === "image" ? (
+        entry.previewKind === "image" ? (
           <ImageFileIcon className="h-8 w-8" aria-hidden />
-        ) : entry.fileKind === "video" ? (
+        ) : entry.previewKind === "video" ? (
           <VideoFileIcon className="h-8 w-8" aria-hidden />
         ) : (
           <FileTextIcon className="h-8 w-8" aria-hidden />
         )
       }
-      state={state}
+      state={toWorkspaceFilePreviewSurfaceState(state)}
       variant="canvas"
     />
   );
+}
+
+function toWorkspaceFilePreviewSurfaceState(
+  state: WorkspaceFilePreviewNodeControllerState
+): WorkspaceFilePreviewSurfaceState<WorkspaceFilePreviewTarget> {
+  switch (state.status) {
+    case "empty":
+      return { status: "empty" };
+    case "loading":
+      return {
+        entry: state.entry,
+        previewKind: state.entry.previewKind,
+        status: "loading"
+      };
+    case "image":
+      return {
+        entry: state.entry,
+        objectUrl: state.objectUrl,
+        previewKind: "image",
+        status: "image"
+      };
+    case "video":
+      return {
+        entry: state.entry,
+        objectUrl: state.objectUrl,
+        previewKind: "video",
+        status: "video"
+      };
+    case "readonly":
+      return {
+        entry: state.entry,
+        message: state.message,
+        previewKind: state.entry.previewKind,
+        status: "readonly"
+      };
+    case "unsupported":
+      return {
+        entry: state.entry,
+        message: state.message,
+        previewKind: state.entry.previewKind,
+        status: "unsupported"
+      };
+    case "error":
+      return {
+        entry: state.entry,
+        message: state.message,
+        previewKind: state.entry.previewKind,
+        status: "error"
+      };
+    case "text":
+      // Text editing uses WorkspaceTextFileEditor; this branch is unreachable
+      // for the shared surface path above.
+      return {
+        content: state.content,
+        entry: state.entry,
+        previewKind: state.entry.previewKind,
+        status: "text"
+      };
+  }
 }
 
 function WorkspaceTextFileEditor({
@@ -209,12 +271,9 @@ function WorkspaceTextFileEditor({
 
 function resolveActivationTarget(
   context: WorkbenchHostNodeBodyContext
-): WorkspaceFilePreviewActivationTarget | null {
-  if (
-    context.activation?.type !== workspaceFilePreviewActivationType ||
-    !isWorkspaceFilePreviewActivationTarget(context.activation.payload)
-  ) {
+): WorkspaceFilePreviewTarget | null {
+  if (context.activation?.type !== workspaceFilePreviewActivationType) {
     return null;
   }
-  return context.activation.payload;
+  return coerceWorkspaceFilePreviewTarget(context.activation.payload);
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceFilePreviewNodeHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceFilePreviewNodeHeader.tsx
@@ -1,4 +1,5 @@
 import type { PointerEvent } from "react";
+import { isTextDegradablePreviewKind } from "@tutti-os/workspace-file-preview";
 import { Button, LoadingIcon, StatusDot } from "@tutti-os/ui-system";
 import type { WorkbenchHostNodeHeaderContext } from "@tutti-os/workbench-surface";
 import type { WorkspaceWorkbenchDesktopI18nRuntime } from "@shared/i18n";
@@ -23,9 +24,12 @@ export function WorkspaceFilePreviewNodeHeader({
   const textHeaderState = resolveWorkspaceFilePreviewTextHeaderState(
     context.node.data
   );
+  // Video shares the text workbench node typeId; only text-degradable kinds
+  // publish textHeader / save chrome.
   const shouldShowTextAccessory =
     context.node.data.typeId === workspaceTextFileNodeTypeID &&
-    file?.fileKind === "text";
+    file !== null &&
+    isTextDegradablePreviewKind(file.previewKind);
 
   const onDragPointerDown = (event: PointerEvent<HTMLElement>): void => {
     context.dragHandleProps.onPointerDown?.(event);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
@@ -44,7 +44,10 @@ import type {
 import type { DesktopThemeAppearance } from "@shared/theme";
 import { createWorkspaceFilePreviewLaunchRequest } from "../services/workspaceFilePreviewLaunch";
 import { requestWorkspaceFilesLaunch } from "../services/workspaceFilesLaunchCoordinator";
-import { classifyWorkspaceFilePreviewKind } from "@tutti-os/workspace-file-preview";
+import {
+  classifyWorkspaceFilePreviewKind,
+  resolveWorkspaceFileBuiltinRenderKind
+} from "@tutti-os/workspace-file-preview";
 import type { WorkbenchSurfaceWallpaperFit } from "@tutti-os/workbench-surface";
 import type { DesktopWorkbenchWindowSnapping } from "@shared/preferences";
 import type {
@@ -280,12 +283,15 @@ export function useWorkspaceWorkbenchShellRuntime({
         return;
       }
 
-      const fileKind = classifyWorkspaceFilePreviewKind({
+      const previewKind = classifyWorkspaceFilePreviewKind({
         kind: "file",
         name: request.name,
         path: request.absolutePath
       });
-      if (!fileKind || request.mode === "auto") {
+      if (
+        resolveWorkspaceFileBuiltinRenderKind(previewKind) === null ||
+        request.mode === "auto"
+      ) {
         void requestWorkspaceFilesLaunch({
           homeDirectory: workbenchHostService.getHomeDirectory(),
           path: request.absolutePath,
@@ -296,7 +302,7 @@ export function useWorkspaceWorkbenchShellRuntime({
 
       void host.launchNode(
         createWorkspaceFilePreviewLaunchRequest({
-          fileKind,
+          previewKind,
           mtimeMs: request.mtimeMs,
           name: request.name,
           path: request.absolutePath,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/workspaceFilePreviewNodeState.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/workspaceFilePreviewNodeState.ts
@@ -1,6 +1,6 @@
-import type { WorkspaceFilePreviewActivationTarget } from "@tutti-os/workspace-file-preview";
+import type { WorkspaceFilePreviewTarget } from "@tutti-os/workspace-file-preview";
 import type { WorkbenchHostNodeData } from "@tutti-os/workbench-surface";
-import { isWorkspaceFilePreviewActivationTarget } from "../services/workspaceFilePreviewLaunch";
+import { coerceWorkspaceFilePreviewTarget } from "../services/workspaceFilePreviewLaunch";
 
 export type WorkspaceFilePreviewTextHeaderStatus =
   | "error"
@@ -17,16 +17,16 @@ export interface WorkspaceFilePreviewTextHeaderState {
 }
 
 export interface WorkspaceFilePreviewNodeRuntimeState {
-  file: WorkspaceFilePreviewActivationTarget;
+  file: WorkspaceFilePreviewTarget;
   textHeader?: WorkspaceFilePreviewTextHeaderState;
 }
 
 export interface WorkspaceFilePreviewNodeSnapshotState {
-  file: WorkspaceFilePreviewActivationTarget;
+  file: WorkspaceFilePreviewTarget;
 }
 
 export function createWorkspaceFilePreviewNodeRuntimeState(input: {
-  file: WorkspaceFilePreviewActivationTarget;
+  file: WorkspaceFilePreviewTarget;
   textHeader?: WorkspaceFilePreviewTextHeaderState;
 }): WorkspaceFilePreviewNodeRuntimeState {
   return input.textHeader
@@ -35,22 +35,23 @@ export function createWorkspaceFilePreviewNodeRuntimeState(input: {
 }
 
 export function createWorkspaceFilePreviewNodeSnapshotState(input: {
-  file: WorkspaceFilePreviewActivationTarget;
+  file: WorkspaceFilePreviewTarget;
 }): WorkspaceFilePreviewNodeSnapshotState {
   return { file: input.file };
 }
 
 export function resolveWorkspaceFilePreviewNodeFile(
   data: Pick<WorkbenchHostNodeData, "runtimeNodeState" | "snapshotNodeState">
-): WorkspaceFilePreviewActivationTarget | null {
+): WorkspaceFilePreviewTarget | null {
   for (const value of [data.runtimeNodeState, data.snapshotNodeState]) {
     if (!value || typeof value !== "object") {
       continue;
     }
 
     const candidate = value as Partial<WorkspaceFilePreviewNodeSnapshotState>;
-    if (isWorkspaceFilePreviewActivationTarget(candidate.file)) {
-      return candidate.file;
+    const file = coerceWorkspaceFilePreviewTarget(candidate.file);
+    if (file) {
+      return file;
     }
   }
 
@@ -66,7 +67,7 @@ export function resolveWorkspaceFilePreviewTextHeaderState(
 
   const candidate =
     data.runtimeNodeState as Partial<WorkspaceFilePreviewNodeRuntimeState>;
-  if (!isWorkspaceFilePreviewActivationTarget(candidate.file)) {
+  if (!coerceWorkspaceFilePreviewTarget(candidate.file)) {
     return null;
   }
 
@@ -96,10 +97,10 @@ export function resolveWorkspaceFilePreviewTextHeaderState(
 }
 
 export function workspaceFilePreviewNodeFileKey(
-  file: WorkspaceFilePreviewActivationTarget
+  file: WorkspaceFilePreviewTarget
 ): string {
   return [
-    file.fileKind,
+    file.previewKind,
     file.path,
     file.name,
     file.sizeBytes ?? "",

--- a/packages/workspace/file-manager/src/services/index.ts
+++ b/packages/workspace/file-manager/src/services/index.ts
@@ -33,6 +33,11 @@ export {
   WorkspaceFileOpenWithApplicationsCache
 } from "./internal/model/openWithApplicationsCache.ts";
 export {
+  isWorkspaceFileBrowserOpenable,
+  shouldFilterVideoPlayersForOpenWith,
+  workspaceFileVideoHandlerCollisionExtensions
+} from "./internal/model/openWithPolicy.ts";
+export {
   isWorkspaceApplicationBundle,
   resolveWorkspaceFileDefaultApplicationIconExtension,
   resolveWorkspaceFileEntryIconCacheKey,

--- a/packages/workspace/file-manager/src/services/internal/model/fileKinds.ts
+++ b/packages/workspace/file-manager/src/services/internal/model/fileKinds.ts
@@ -1,19 +1,23 @@
-import { resolveWorkspaceFileActivationTarget as resolveSharedWorkspaceFileActivationTarget } from "@tutti-os/workspace-file-preview";
+import { resolveWorkspaceFilePreviewTarget } from "@tutti-os/workspace-file-preview";
 import type {
   WorkspaceFileActivationTarget,
   WorkspaceFileEntry
 } from "../../workspaceFileManagerTypes.ts";
 
+/**
+ * Host activation adapter over the shared preview target vocabulary.
+ * Open / reveal / open-with remain file-manager / desktop concerns.
+ */
 export function resolveWorkspaceFileActivationTarget(
   entry: WorkspaceFileEntry
 ): WorkspaceFileActivationTarget | null {
-  const target = resolveSharedWorkspaceFileActivationTarget(entry);
+  const target = resolveWorkspaceFilePreviewTarget(entry);
   if (!target) {
     return null;
   }
 
   return {
-    fileKind: target.fileKind,
+    previewKind: target.previewKind,
     mtimeMs: target.mtimeMs ?? null,
     name: target.name,
     path: target.path,

--- a/packages/workspace/file-manager/src/services/internal/model/openWithPolicy.test.ts
+++ b/packages/workspace/file-manager/src/services/internal/model/openWithPolicy.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isWorkspaceFileBrowserOpenable,
+  shouldFilterVideoPlayersForOpenWith
+} from "./openWithPolicy.ts";
+
+test("open-with policy filters video players for code and text targets", () => {
+  assert.equal(
+    shouldFilterVideoPlayersForOpenWith({
+      kind: "file",
+      path: "/workspace/src/App.tsx"
+    }),
+    true
+  );
+  assert.equal(
+    shouldFilterVideoPlayersForOpenWith({
+      kind: "file",
+      path: "/workspace/config.json"
+    }),
+    true
+  );
+  assert.equal(
+    shouldFilterVideoPlayersForOpenWith({
+      kind: "file",
+      path: "/workspace/transport.ts"
+    }),
+    true
+  );
+  assert.equal(
+    shouldFilterVideoPlayersForOpenWith({
+      kind: "file",
+      path: "/workspace/README.md"
+    }),
+    true
+  );
+  assert.equal(
+    shouldFilterVideoPlayersForOpenWith({
+      kind: "file",
+      path: "/workspace/clip.mp4"
+    }),
+    false
+  );
+  assert.equal(
+    shouldFilterVideoPlayersForOpenWith({
+      kind: "file",
+      path: "/workspace/clip.mts"
+    }),
+    false
+  );
+  assert.equal(
+    shouldFilterVideoPlayersForOpenWith({
+      kind: "file",
+      path: "/workspace/archive.zip"
+    }),
+    false
+  );
+});
+
+test("open-with policy identifies browser-openable files", () => {
+  assert.equal(
+    isWorkspaceFileBrowserOpenable({
+      kind: "file",
+      path: "/workspace/index.html"
+    }),
+    true
+  );
+  assert.equal(
+    isWorkspaceFileBrowserOpenable({
+      kind: "file",
+      path: "/workspace/report.pdf"
+    }),
+    true
+  );
+  assert.equal(
+    isWorkspaceFileBrowserOpenable({
+      kind: "file",
+      path: "/workspace/logo.png"
+    }),
+    true
+  );
+  assert.equal(
+    isWorkspaceFileBrowserOpenable({
+      kind: "file",
+      path: "/workspace/demo.mp4"
+    }),
+    true
+  );
+  assert.equal(
+    isWorkspaceFileBrowserOpenable({
+      kind: "file",
+      path: "/workspace/config.json"
+    }),
+    true
+  );
+  assert.equal(
+    isWorkspaceFileBrowserOpenable({
+      kind: "file",
+      path: "/workspace/README"
+    }),
+    true
+  );
+  assert.equal(
+    isWorkspaceFileBrowserOpenable({
+      kind: "directory",
+      path: "/workspace/docs"
+    }),
+    false
+  );
+  assert.equal(
+    isWorkspaceFileBrowserOpenable({
+      kind: "file",
+      path: "/workspace/archive.zip"
+    }),
+    false
+  );
+});

--- a/packages/workspace/file-manager/src/services/internal/model/openWithPolicy.ts
+++ b/packages/workspace/file-manager/src/services/internal/model/openWithPolicy.ts
@@ -1,0 +1,76 @@
+/**
+ * Open / open-with / browser-activation advisories.
+ *
+ * These helpers live on the file-manager host edge, not in
+ * `@tutti-os/workspace-file-preview` (see that package CONTRACT.md).
+ */
+
+import {
+  classifyWorkspaceFilePreviewKind,
+  isTextDegradablePreviewKind,
+  isWorkspaceFileBrowserHtmlExtension,
+  isWorkspaceFileImageExtension,
+  resolveWorkspaceFileExtension,
+  resolveWorkspaceFileVisualKind,
+  workspaceFileBrowserVideoExtensions
+} from "@tutti-os/workspace-file-preview";
+
+export interface WorkspaceFileOpenWithEntry {
+  kind: string;
+  name?: string;
+  path: string;
+}
+
+/**
+ * Extensions where macOS Launch Services may register video handlers even when
+ * the workspace file is source code (UTI / uniform type collisions).
+ */
+export const workspaceFileVideoHandlerCollisionExtensions = new Set(["ts"]);
+
+export function isWorkspaceFileBrowserOpenable(
+  entry: WorkspaceFileOpenWithEntry
+): boolean {
+  if (entry.kind !== "file") {
+    return false;
+  }
+
+  const extension = resolveWorkspaceFileExtension(
+    entry.path || entry.name || ""
+  );
+  if (
+    extension === "pdf" ||
+    isWorkspaceFileBrowserHtmlExtension(extension) ||
+    isWorkspaceFileImageExtension(extension) ||
+    workspaceFileBrowserVideoExtensions.has(extension)
+  ) {
+    return true;
+  }
+
+  return isTextDegradablePreviewKind(classifyWorkspaceFilePreviewKind(entry));
+}
+
+export function shouldFilterVideoPlayersForOpenWith(
+  entry: WorkspaceFileOpenWithEntry
+): boolean {
+  if (entry.kind !== "file") {
+    return false;
+  }
+
+  const visualKind = resolveWorkspaceFileVisualKind(entry);
+  if (visualKind === "video") {
+    return false;
+  }
+
+  const extension = resolveWorkspaceFileExtension(
+    entry.path || entry.name || ""
+  );
+  if (workspaceFileVideoHandlerCollisionExtensions.has(extension)) {
+    return true;
+  }
+
+  if (visualKind === "code" || visualKind === "markdown") {
+    return true;
+  }
+
+  return isTextDegradablePreviewKind(classifyWorkspaceFilePreviewKind(entry));
+}

--- a/packages/workspace/file-manager/src/services/internal/workspaceFileManagerPreviewController.ts
+++ b/packages/workspace/file-manager/src/services/internal/workspaceFileManagerPreviewController.ts
@@ -41,8 +41,13 @@ export class WorkspaceFileManagerPreviewController {
     this.store = input.store;
     this.previewController = createWorkspaceFilePreviewController({
       read: input.host.readPreviewFile
-        ? ({ entry }) =>
-            input.host.readPreviewFile!(input.store.workspaceID, entry.path)
+        ? async ({ entry }) => {
+            const bytes = await input.host.readPreviewFile!(
+              input.store.workspaceID,
+              entry.path
+            );
+            return bytes == null ? null : { bytes };
+          }
         : undefined,
       toPreviewEntry: (entry: WorkspaceFileEntry) => entry
     });
@@ -90,18 +95,47 @@ export class WorkspaceFileManagerPreviewController {
           };
           return;
         }
-        this.store.previewState =
-          state.status === "loading"
-            ? { entry: target, status: "loading" }
-            : state.status === "text"
-              ? { content: state.content, entry: target, status: "text" }
-              : {
-                  entry: target,
-                  objectUrl: state.objectUrl,
-                  status: state.status
-                };
+        if (state.status === "loading") {
+          this.store.previewState = {
+            entry: target,
+            previewKind: state.previewKind,
+            status: "loading"
+          };
+          return;
+        }
+        if (state.status === "text") {
+          this.store.previewState = {
+            content: state.content,
+            entry: target,
+            previewKind: state.previewKind,
+            status: "text"
+          };
+          return;
+        }
+        if (state.status === "image") {
+          this.store.previewState = {
+            entry: target,
+            objectUrl: state.objectUrl,
+            previewKind: "image",
+            status: "image"
+          };
+          return;
+        }
+        this.store.previewState = {
+          entry: target,
+          objectUrl: state.objectUrl,
+          previewKind: "video",
+          status: "video"
+        };
         return;
       }
+      case "bytes":
+        this.store.previewState = {
+          entry: state.entry,
+          message: copy.t("previewUnsupported"),
+          status: "unsupported"
+        };
+        return;
       case "readonly":
         this.store.previewState = {
           entry: state.entry,

--- a/packages/workspace/file-manager/src/services/internal/workspaceFileManagerViewModel.test.ts
+++ b/packages/workspace/file-manager/src/services/internal/workspaceFileManagerViewModel.test.ts
@@ -90,12 +90,13 @@ test("splits panels and dialog view state from the shared store", () => {
   store.previewState = {
     content: "export {};",
     entry: {
-      fileKind: "text",
+      previewKind: "code",
       mtimeMs: null,
       name: fileEntry.name,
       path: fileEntry.path,
       sizeBytes: fileEntry.sizeBytes
     },
+    previewKind: "code",
     status: "text"
   };
   store.dragDepth = 1;

--- a/packages/workspace/file-manager/src/services/workspaceFileEntryIconPolicy.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileEntryIconPolicy.ts
@@ -1,5 +1,6 @@
 import {
   classifyWorkspaceFilePreviewKind,
+  isTextDegradablePreviewKind,
   resolveWorkspaceFileExtension,
   resolveWorkspaceFileVisualKind
 } from "@tutti-os/workspace-file-preview";
@@ -71,7 +72,7 @@ export function shouldUseWorkspaceFileExtensionDocumentIcon(
     visualKind === "code" ||
     visualKind === "markdown" ||
     extensionDocumentIconExtensions.has(extension) ||
-    classifyWorkspaceFilePreviewKind(entry) === "text"
+    isTextDegradablePreviewKind(classifyWorkspaceFilePreviewKind(entry))
   );
 }
 

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerModel.test.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerModel.test.ts
@@ -145,7 +145,7 @@ test("resolves previewable files into activation targets", () => {
   markdownEntry.sizeBytes = 128;
 
   assert.deepEqual(resolveWorkspaceFileActivationTarget(markdownEntry), {
-    fileKind: "text",
+    previewKind: "markdown",
     mtimeMs: null,
     name: "README.md",
     path: "/Users/demo/project/README.md",

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerSession.test.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerSession.test.ts
@@ -164,6 +164,9 @@ test("preview mode transitions follow selection changes", async () => {
   await flushMicrotasks();
   assert.equal(previewStatus(session), "loading");
   deferred.resolve(new TextEncoder().encode("hello"));
+  // Host returns bare bytes; preview controller wraps them in `{ bytes }`,
+  // which adds one extra async turn after the deferred resolves.
+  await flushMicrotasks();
   await flushMicrotasks();
   assert.equal(previewStatus(session), "text");
 
@@ -195,12 +198,13 @@ test("html files are previewed as source text", async () => {
   assert.deepEqual(session.store.previewState, {
     content,
     entry: {
-      fileKind: "text",
+      previewKind: "html",
       mtimeMs: null,
       name: "login.html",
       path: "/Users/demo/project/login.html",
       sizeBytes: content.length
     },
+    previewKind: "html",
     status: "text"
   });
 

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerTypes.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerTypes.ts
@@ -3,8 +3,8 @@ import type {
   WorkspaceFileManagerHostImportConflict
 } from "./workspaceFileManagerHostTypes.ts";
 import type {
-  WorkspaceFilePreviewActivationTarget,
-  WorkspaceFilePreviewKind as SharedWorkspaceFilePreviewKind
+  WorkspaceFilePreviewKind as SharedWorkspaceFilePreviewKind,
+  WorkspaceFilePreviewTarget
 } from "@tutti-os/workspace-file-preview";
 
 export const workspaceFileManagerLogicalRoot = "/" as const;
@@ -34,7 +34,12 @@ export interface WorkspaceFileEntry {
   sizeBytes: number | null;
 }
 
-export interface WorkspaceFileActivationTarget extends WorkspaceFilePreviewActivationTarget {
+/**
+ * File-manager activation payload. Reuses the shared preview target shape
+ * (`previewKind`) so hosts can decide whether to open an in-app preview, while
+ * open / reveal / open-with stay outside `@tutti-os/workspace-file-preview`.
+ */
+export interface WorkspaceFileActivationTarget extends WorkspaceFilePreviewTarget {
   mtimeMs: number | null;
   sizeBytes: number | null;
 }
@@ -42,10 +47,29 @@ export interface WorkspaceFileActivationTarget extends WorkspaceFilePreviewActiv
 export type WorkspaceFilePreviewState =
   | { status: "empty" }
   | { entry: WorkspaceFileEntry; status: "directory" }
-  | { entry: WorkspaceFileActivationTarget; status: "loading" }
-  | { content: string; entry: WorkspaceFileActivationTarget; status: "text" }
-  | { entry: WorkspaceFileActivationTarget; objectUrl: string; status: "image" }
-  | { entry: WorkspaceFileActivationTarget; objectUrl: string; status: "video" }
+  | {
+      entry: WorkspaceFileActivationTarget;
+      previewKind: WorkspaceFilePreviewKind;
+      status: "loading";
+    }
+  | {
+      content: string;
+      entry: WorkspaceFileActivationTarget;
+      previewKind: WorkspaceFilePreviewKind;
+      status: "text";
+    }
+  | {
+      entry: WorkspaceFileActivationTarget;
+      objectUrl: string;
+      previewKind: "image";
+      status: "image";
+    }
+  | {
+      entry: WorkspaceFileActivationTarget;
+      objectUrl: string;
+      previewKind: "video";
+      status: "video";
+    }
   | { entry: WorkspaceFileEntry; message: string; status: "unsupported" }
   | { entry: WorkspaceFileEntry; message: string; status: "readonly" }
   | { entry: WorkspaceFileEntry; message: string; status: "error" };

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenuContainer.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenuContainer.tsx
@@ -6,7 +6,7 @@ import {
   type WorkspaceFileManagerI18nRuntime
 } from "../i18n/workspaceFileManagerI18n.ts";
 import type { WorkspaceFileOpenWithApplication } from "../services/workspaceFileManagerTypes.ts";
-import { isWorkspaceFileBrowserOpenable } from "@tutti-os/workspace-file-preview";
+import { isWorkspaceFileBrowserOpenable } from "../services/internal/model/openWithPolicy.ts";
 import { WorkspaceFileManagerContextMenu } from "./WorkspaceFileManagerContextMenu.tsx";
 import { useWorkspaceFileManagerContextMenuView } from "./useWorkspaceFileManagerService.ts";
 

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx
@@ -1628,9 +1628,9 @@ function resolveWorkspaceFilePreviewIconKind(
   if ("kind" in entry) {
     return resolveWorkspaceFileVisualKind(entry);
   }
-  return entry.fileKind === "image"
+  return entry.previewKind === "image"
     ? "image"
-    : entry.fileKind === "video"
+    : entry.previewKind === "video"
       ? "video"
       : "document";
 }

--- a/packages/workspace/file-preview/CONTRACT.md
+++ b/packages/workspace/file-preview/CONTRACT.md
@@ -1,0 +1,274 @@
+# @tutti-os/workspace-file-preview contract
+
+Status: agreed package boundary (direction). Open questions are listed under
+[Open questions](#open-questions) when any remain.
+
+This document is the authoritative ownership contract for
+`packages/workspace/file-preview`. Prefer it over chat history when planning
+or reviewing changes. The package `README.md` remains a short usage overview
+and must stay consistent with this contract.
+
+## Purpose
+
+This package owns **host-neutral workspace file preview**:
+
+1. Recognize high-frequency file kinds for preview routing.
+2. Run a shared preview loading lifecycle after a focused entry is chosen.
+3. Render with built-in preview capabilities, optional host renderer hooks, and
+   a fallback path.
+
+It does **not** own:
+
+- open / reveal / open-with / browser-activation flows
+- full-content reading/editing experiences (complete PDF workbench, rich
+  markdown authoring, spreadsheet editing, dirty/save flows, and similar)
+
+## Preview vs open vs full content
+
+| Concern                                              | Owner                           |
+| ---------------------------------------------------- | ------------------------------- |
+| Side-pane / picker / compact or detail **preview**   | This package (+ host hooks)     |
+| Open / reveal / open-with / system or browser launch | Host activation flows           |
+| Full-content viewer / editor / save / dirty guard    | Host or another product surface |
+| How bytes or URLs are fetched from disk/VM/daemon    | Host transport ports            |
+| Localized copy, icons, product chrome                | Host                            |
+
+**Decided route:** this package does **not** own the open scenario.
+
+Kind / classification helpers from this package are a **shared vocabulary**.
+Hosts may reuse them when deciding activation policy (for example whether an
+entry is previewable in-app), but that reuse does not transfer open ownership
+into this package. After a user double-click / Open starts a host activation
+flow, open actions remain host-owned.
+
+HTML **source** may appear in preview as text. Opening or executing HTML as a
+document belongs to a separate browser/activation flow, not to ordinary preview
+rendering.
+
+Tutti activation paths may call preview helpers such as
+`resolveWorkspaceFilePreviewTarget` and present an in-app preview surface for
+builtin-presentable kinds (`image` / `video` / text-degradable). That is host
+policy reusing preview capabilities, not package ownership of Open.
+
+## Ownership layers
+
+### 1. Classification
+
+The package must recognize preview kinds for high-frequency workspace files.
+Classification produces a flat `previewKind` (no `textSubtype` dimension).
+
+**Classification inputs (decided):** stay aligned with the current Tutti/package
+model:
+
+- entry kind (file vs directory)
+- path / file-name **extension** (plus a small special-filename set such as
+  `Dockerfile` / `README`)
+
+Do **not** take MIME type or MIME-source reliability (`magic` /
+`content-heuristic` / `extension` / `unknown`) into the shared classification
+contract for now. Hosts that historically used richer signals (for example TSH)
+should simplify toward this package model rather than pushing that complexity
+into the shared boundary prematurely. If stronger classification is needed
+later, this package owns the expansion.
+
+**`visualKind` vs `previewKind` (decided):** keep both tracks.
+
+- `visualKind`: coarser signal for icons / glyphs
+- `previewKind`: preview routing (built-in renderer, host hook, or unsupported
+  preview state)
+
+They must not be collapsed together unless a later contract revision explicitly
+merges them. Icon policy must not dictate preview routing, and preview routing
+must not dictate icon taxonomy.
+
+### 2. Loading lifecycle
+
+`createWorkspaceFilePreviewController` (or its successor) owns readiness checks,
+cancellation, stale-request fencing, decoding where applicable, canonical
+language-neutral preview state, and media object-URL cleanup when object URLs
+are used.
+
+Hosts inject read/projection capabilities. Product controllers keep selection,
+editing, persistence, transport wiring, and localized error presentation.
+
+**Loading contract (decided for now):** keep the current package protocol.
+
+- Host always supplies the focused `entry` (identity + metadata) via `setEntry`.
+- Host injects `read({ entry, signal, target })` that returns preview **bytes**.
+- The package decides whether to call `read` from readiness (directory /
+  unsupported / over-budget readonly vs ready).
+- Bytes are **not** a streaming/range “first N bytes” contract today. Within the
+  preview size budget the host reads the file contents used for preview (for
+  Tutti: whole file when under budget); over budget, preview does not read and
+  becomes readonly/fallback instead.
+- Image/video preview materializes browser object URLs from those bytes; text
+  preview decodes to a string.
+
+Do **not** expand the shared loading ports to content URL / range / streaming in
+this phase. How TSH adapts onto this bytes protocol (or whether a later contract
+revision adds richer ports) is deferred; simplify or bridge on the host side
+until then.
+
+### 3. Rendering resolve chain
+
+For a classified `previewKind`, resolve renderers in this order:
+
+1. **Host renderer hook** for that kind, if registered.
+2. Else if the kind is **text-degradable** (`markdown`, `json`, `csv`, `html`,
+   `code`, and plain `text`) → **built-in text** preview.
+3. Else → **fallback**: package reports an unsupported/fallback preview state
+   only.
+
+**Fallback ownership (decided):** the package only emits preview state (for
+example `unsupported` / readonly messaging inputs). It does **not** own open /
+reveal / open-with / browser-activation actions, and it does not require an
+`openExternally` (or equivalent) port.
+
+If a host chooses to open a file in the system default app after an unsupported
+preview, that is host product behavior outside this package. Mentioning “open”
+in host docs is only to clarify that such actions stay out of preview scope.
+
+This chain is what keeps Tutti stable when it does not inject rich hooks, while
+allowing TSH (or others) to deepen preview via hooks.
+
+### 4. Built-in preview surface
+
+Built-in preview UI in this package is intentionally thin and currently limited
+to:
+
+- `image`
+- `video`
+- `text` (including the text-degradation path for `markdown` / `json` / `csv` /
+  `html` / `code` when no host hook is registered)
+
+`audio`, `pdf`, `markdown` (rich), Office kinds (`docx` / `xlsx` / `pptx`), and
+other rich viewers are **hook-only** unless a later contract revision promotes a
+kind into the built-in set.
+
+Layout variants such as `compact` / `detail` / `canvas` remain shell concerns.
+Built-in rendering stays lightweight; rich viewers arrive through host hooks.
+
+### 5. Host renderer registry
+
+Hosts register preview renderers **by `previewKind`**.
+
+`variant` (`compact` | `detail` | `canvas`) is passed into the renderer as
+context/props. Optional `(kind, variant)` overrides may exist later as a
+specificity layer (`(kind, variant)` > `kind` > built-in/fallback), but the
+default contract is kind-keyed registration.
+
+## Target high-frequency `previewKind` set
+
+Pursue high-frequency coverage, not exhaustive format support.
+
+Agreed candidates for first-class kinds:
+
+- `directory`
+- `image`
+- `video`
+- `audio`
+- `text`
+- `code`
+- `markdown`
+- `json`
+- `csv`
+- `html`
+- `pdf`
+- `docx`
+- `xlsx`
+- `pptx`
+- `unsupported` (terminal fallback kind/state)
+
+Office kinds (`docx` / `xlsx` / `pptx`) are valid first-class preview kinds even
+when only host hooks implement them.
+
+Kinds intentionally left out of the first-class set stay `unsupported` (for
+example archives, fonts, CAD, PSD), while icons may still use coarse
+`visualKind` values.
+
+## Host responsibilities
+
+Hosts own:
+
+- Transport: local/VM/daemon reads, content URLs, range/streaming, auth.
+- Renderer hooks for rich preview kinds they support.
+- Any open / reveal / open-with / browser-activation flows (not preview).
+- Product chrome: toolbars, share/download/copy, workbench framing.
+- Full-content experiences outside this package.
+- User-visible copy and icon rendering injected into shared shells.
+
+Hosts must not reimplement a second preview kind taxonomy for the same product
+job when they already consume this package; extend this contract instead.
+
+## Non-goals
+
+- Opening, revealing, or launching files/apps (system open, open-with, browser
+  activation, reveal in folder, and similar). Those are host activation flows.
+- Full-content editing, save, dirty guards, close confirmation.
+- Becoming a general document platform (only high-frequency preview kinds).
+- Embedding host transport or product globals (`__tutti`, `__tsh`, preload).
+- Requiring every host to implement every rich renderer.
+
+## API cleanup decisions
+
+These are decided hygiene items for the package-normalization pass (alongside
+kinds / hooks work). Update consumers in the same effort when the public shape
+changes.
+
+### Naming (done)
+
+- `WorkspaceFilePreviewTarget` / `resolveWorkspaceFilePreviewTarget`
+- Target field is `previewKind` (flat taxonomy)
+
+### Entry / directory / read / state shapes (done)
+
+- `WorkspaceFilePreviewEntry` keeps a single `name` field (no `displayName`).
+- Canonical directory kind is `directory`; adapt `folder` at host edges.
+- `read` returns only `{ bytes, contentType?, kind? }` (no bare byte buffers).
+- `toSurfaceState(controllerState, copy)` projects controller → surface state.
+
+### Open-with advisories (done)
+
+Removed from this package. Tutti hosts them in
+`@tutti-os/workspace-file-manager/services`:
+
+- `isWorkspaceFileBrowserOpenable`
+- `shouldFilterVideoPlayersForOpenWith`
+- `workspaceFileVideoHandlerCollisionExtensions`
+
+### Keep as-is
+
+- Generic `TEntry` + `toPreviewEntry` (lets File Manager / Reference picker /
+  Workbench reuse one controller).
+- Built-in surface staying thin (`image` / `text` / `video`) with host-injected
+  copy/icons.
+- Byte-budget constants and readiness gates.
+
+## Current shipped shape vs this contract
+
+The package implementation is aligned with the sections above for the Tutti
+normalization pass:
+
+- Flat `previewKind` taxonomy (including text-family and hook-only kinds).
+- Built-in React surface covers image / text / video shells; text-degradable
+  kinds fall back to built-in text when no host hook is registered.
+- Host renderer registry is kind-keyed (`renderers` on the surface; optional
+  `hasHostRenderer` on the controller for readiness / bytes planning).
+- Open-with / browser-openable advisories live outside this package (Tutti:
+  `@tutti-os/workspace-file-manager/services`).
+
+Hosts that previously kept a parallel richer classifier (for example TSH)
+should adapt onto this contract rather than inventing a second taxonomy.
+
+## Open questions
+
+None right now. New questions should be added here when they appear, then moved
+into the main sections once decided.
+
+## Change policy
+
+- Contract changes that alter lifecycle, kind taxonomy, resolve-chain order, or
+  host hook obligations require updating this file in the same change.
+- Prefer extending kinds/hooks over inventing parallel preview stacks in hosts.
+- When an open question is decided, move the decision into the main sections and
+  remove it from [Open questions](#open-questions).

--- a/packages/workspace/file-preview/README.md
+++ b/packages/workspace/file-preview/README.md
@@ -1,26 +1,36 @@
 # @tutti-os/workspace-file-preview
 
-Shared, host-neutral file preview helpers for workspace features.
+Shared, host-neutral workspace file preview helpers.
 
-This package owns file preview classification, safe byte handling, text
-decoding, image mime resolution, and byte-limit helpers. Host adapters remain
-responsible for reading bytes from the local workspace.
+**Authority for ownership and boundary decisions:**
+[CONTRACT.md](./CONTRACT.md). Read that file before changing classification,
+loading lifecycle, renderer hooks, or fallback behavior.
 
-It also exposes a small React preview surface for consumers that want the shared
-image, text, loading, and readonly rendering shell while keeping host-specific
-icons and localized copy outside this package.
+## Package surface
 
-`createWorkspaceFilePreviewController` owns the shared frontend loading
-lifecycle. Consumers inject a byte reader and entry projection; the controller
-owns readiness checks, stale-request fencing, cancellation, decoding, canonical
-language-neutral state, and media object-URL cleanup. Product controllers keep
-selection, editing, persistence, transport, and localized error presentation.
+This package ships:
+
+- Flat `previewKind` classification (`directory` / media / text-family /
+  Office / `unsupported`), plus a separate coarser `visualKind` for icons
+- `createWorkspaceFilePreviewController` for shared frontend loading lifecycle
+  (readiness, cancellation, stale-request fencing, decoding, object-URL cleanup)
+- Built-in React preview shells for `image` / `video` / `text`
+- Host renderer registry (by `previewKind`) and a resolve chain:
+  host hook → text degradation → unsupported state
+- `toSurfaceState(controllerState, copy)` to project controller state into the
+  React surface
+
+Hosts inject read/projection capabilities. Product controllers keep selection,
+editing, persistence, transport wiring, and localized error presentation.
+
+Open / reveal / open-with / browser activation are **not** owned here. Those
+helpers live on the host edge (for Tutti:
+`@tutti-os/workspace-file-manager/services`).
 
 Sources may provide `canReadEntry` as a capability gate. Returning `false`
 blocks reads for every non-directory entry, while returning `true` also allows
 the injected reader to classify file types that local extension detection does
 not recognize. Omitting the callback keeps the default local classification.
 
-HTML files are shown as source text. Opening or executing an HTML document
-belongs to a separate browser activation flow rather than the ordinary file
-preview surface.
+HTML files degrade to source text in the built-in surface. Opening or executing
+an HTML document belongs to a separate browser activation flow.

--- a/packages/workspace/file-preview/src/core/workspaceFilePreview.test.ts
+++ b/packages/workspace/file-preview/src/core/workspaceFilePreview.test.ts
@@ -6,15 +6,14 @@ import {
   decodeWorkspaceTextFile,
   formatWorkspacePreviewByteLimit,
   looksLikeBinaryText,
-  isWorkspaceFileBrowserOpenable,
-  shouldFilterVideoPlayersForOpenWith,
-  resolveWorkspaceFileActivationTarget,
+  resolveWorkspaceFileBuiltinRenderKind,
+  resolveWorkspaceFilePreviewTarget,
   resolveWorkspaceFilePreviewReadiness,
   resolveWorkspaceFileVisualKind,
   resolveWorkspaceImageMimeType
 } from "./workspaceFilePreview.ts";
 
-test("workspace file preview classifies previewable files", () => {
+test("workspace file preview classifies the flat previewKind taxonomy", () => {
   assert.equal(
     classifyWorkspaceFilePreviewKind({
       kind: "file",
@@ -40,29 +39,71 @@ test("workspace file preview classifies previewable files", () => {
   assert.equal(
     classifyWorkspaceFilePreviewKind({
       kind: "file",
-      path: "/workspace/demo.webm"
+      path: "/workspace/guide.md"
     }),
-    "video"
+    "markdown"
+  );
+  assert.equal(
+    classifyWorkspaceFilePreviewKind({
+      kind: "file",
+      path: "/workspace/app.ts"
+    }),
+    "code"
+  );
+  assert.equal(
+    classifyWorkspaceFilePreviewKind({
+      kind: "file",
+      path: "/workspace/data.json"
+    }),
+    "json"
+  );
+  assert.equal(
+    classifyWorkspaceFilePreviewKind({
+      kind: "file",
+      path: "/workspace/index.html"
+    }),
+    "html"
+  );
+  assert.equal(
+    classifyWorkspaceFilePreviewKind({
+      kind: "file",
+      path: "/workspace/track.mp3"
+    }),
+    "audio"
+  );
+  assert.equal(
+    classifyWorkspaceFilePreviewKind({
+      kind: "file",
+      path: "/workspace/report.pdf"
+    }),
+    "pdf"
+  );
+  assert.equal(
+    classifyWorkspaceFilePreviewKind({
+      kind: "directory",
+      path: "/workspace/docs"
+    }),
+    "directory"
   );
   assert.equal(
     classifyWorkspaceFilePreviewKind({
       kind: "folder",
       path: "/workspace/docs"
     }),
-    null
+    "directory"
   );
   assert.equal(
     classifyWorkspaceFilePreviewKind({
       kind: "file",
       path: "/workspace/archive.zip"
     }),
-    null
+    "unsupported"
   );
 });
 
-test("workspace file preview resolves activation targets and display kinds", () => {
+test("workspace file preview resolves builtin-presentable targets", () => {
   assert.deepEqual(
-    resolveWorkspaceFileActivationTarget({
+    resolveWorkspaceFilePreviewTarget({
       kind: "file",
       mtimeMs: 1,
       name: "guide.md",
@@ -70,13 +111,22 @@ test("workspace file preview resolves activation targets and display kinds", () 
       sizeBytes: 32
     }),
     {
-      fileKind: "text",
+      previewKind: "markdown",
       mtimeMs: 1,
       name: "guide.md",
       path: "/workspace/guide.md",
       sizeBytes: 32
     }
   );
+  assert.equal(
+    resolveWorkspaceFilePreviewTarget({
+      kind: "file",
+      path: "/workspace/report.pdf"
+    }),
+    null
+  );
+  assert.equal(resolveWorkspaceFileBuiltinRenderKind("markdown"), "text");
+  assert.equal(resolveWorkspaceFileBuiltinRenderKind("pdf"), null);
   assert.equal(
     resolveWorkspaceFileVisualKind({
       kind: "directory",
@@ -109,7 +159,7 @@ test("workspace file preview creates loaded image, video, text, and readonly sta
       bytes: new Uint8Array([0x89, 0x50]),
       entry: { kind: "file", path: "/workspace/image.png" },
       target: {
-        fileKind: "image",
+        previewKind: "image",
         name: "image.png",
         path: "/workspace/image.png"
       }
@@ -118,10 +168,11 @@ test("workspace file preview creates loaded image, video, text, and readonly sta
       bytes: new Uint8Array([0x89, 0x50]),
       contentType: "image/png",
       entry: {
-        fileKind: "image",
+        previewKind: "image",
         name: "image.png",
         path: "/workspace/image.png"
       },
+      previewKind: "image",
       status: "image"
     }
   );
@@ -132,7 +183,7 @@ test("workspace file preview creates loaded image, video, text, and readonly sta
       contentType: "video/mp4",
       entry: { kind: "file", path: "/workspace/demo.mp4" },
       target: {
-        fileKind: "video",
+        previewKind: "video",
         name: "demo.mp4",
         path: "/workspace/demo.mp4"
       }
@@ -141,10 +192,11 @@ test("workspace file preview creates loaded image, video, text, and readonly sta
       bytes: new Uint8Array([0x00, 0x00, 0x00, 0x18]),
       contentType: "video/mp4",
       entry: {
-        fileKind: "video",
+        previewKind: "video",
         name: "demo.mp4",
         path: "/workspace/demo.mp4"
       },
+      previewKind: "video",
       status: "video"
     }
   );
@@ -154,7 +206,7 @@ test("workspace file preview creates loaded image, video, text, and readonly sta
       bytes: new TextEncoder().encode("hello"),
       entry: { kind: "file", path: "/workspace/readme.md" },
       target: {
-        fileKind: "text",
+        previewKind: "markdown",
         name: "readme.md",
         path: "/workspace/readme.md"
       }
@@ -162,10 +214,11 @@ test("workspace file preview creates loaded image, video, text, and readonly sta
     {
       content: "hello",
       entry: {
-        fileKind: "text",
+        previewKind: "markdown",
         name: "readme.md",
         path: "/workspace/readme.md"
       },
+      previewKind: "markdown",
       status: "text"
     }
   );
@@ -174,7 +227,7 @@ test("workspace file preview creates loaded image, video, text, and readonly sta
       bytes: new Uint8Array([0xff]),
       entry: { kind: "file", path: "/workspace/readme.md" },
       target: {
-        fileKind: "text",
+        previewKind: "markdown",
         name: "readme.md",
         path: "/workspace/readme.md"
       }
@@ -185,15 +238,39 @@ test("workspace file preview creates loaded image, video, text, and readonly sta
       status: "readonly"
     }
   );
+  assert.deepEqual(
+    createWorkspaceFilePreviewLoadedState({
+      bytes: new Uint8Array([1, 2, 3]),
+      contentType: "application/pdf",
+      preferHostBytes: true,
+      entry: { kind: "file", path: "/workspace/report.pdf" },
+      target: {
+        previewKind: "pdf",
+        name: "report.pdf",
+        path: "/workspace/report.pdf"
+      }
+    }),
+    {
+      bytes: new Uint8Array([1, 2, 3]),
+      contentType: "application/pdf",
+      entry: {
+        previewKind: "pdf",
+        name: "report.pdf",
+        path: "/workspace/report.pdf"
+      },
+      previewKind: "pdf",
+      status: "bytes"
+    }
+  );
 });
 
-test("workspace file preview treats html as source text", () => {
+test("workspace file preview treats html as source text by default", () => {
   assert.deepEqual(
     createWorkspaceFilePreviewLoadedState({
       bytes: new TextEncoder().encode("<!doctype html><h1>Hello</h1>"),
       entry: { kind: "file", path: "/workspace/index.html" },
       target: {
-        fileKind: "text",
+        previewKind: "html",
         name: "index.html",
         path: "/workspace/index.html"
       }
@@ -201,10 +278,11 @@ test("workspace file preview treats html as source text", () => {
     {
       content: "<!doctype html><h1>Hello</h1>",
       entry: {
-        fileKind: "text",
+        previewKind: "html",
         name: "index.html",
         path: "/workspace/index.html"
       },
+      previewKind: "html",
       status: "text"
     }
   );
@@ -234,7 +312,43 @@ test("workspace file preview resolves readiness before reading bytes", () => {
         kind: "file",
         path: "/workspace/archive.zip"
       },
+      previewKind: "unsupported",
       status: "unsupported"
+    }
+  );
+  assert.deepEqual(
+    resolveWorkspaceFilePreviewReadiness({
+      kind: "file",
+      path: "/workspace/report.pdf"
+    }),
+    {
+      entry: {
+        kind: "file",
+        path: "/workspace/report.pdf"
+      },
+      previewKind: "pdf",
+      status: "unsupported"
+    }
+  );
+  assert.deepEqual(
+    resolveWorkspaceFilePreviewReadiness(
+      {
+        kind: "file",
+        path: "/workspace/report.pdf"
+      },
+      { hasHostRenderer: (kind) => kind === "pdf" }
+    ),
+    {
+      entry: {
+        kind: "file",
+        path: "/workspace/report.pdf"
+      },
+      status: "ready",
+      target: {
+        previewKind: "pdf",
+        name: "report.pdf",
+        path: "/workspace/report.pdf"
+      }
     }
   );
   assert.deepEqual(
@@ -268,122 +382,11 @@ test("workspace file preview resolves readiness before reading bytes", () => {
       },
       status: "ready",
       target: {
-        fileKind: "image",
+        previewKind: "image",
         name: "image.png",
         path: "/workspace/image.png",
         sizeBytes: 12
       }
     }
-  );
-});
-
-test("workspace file preview filters video players for code and text open-with targets", () => {
-  assert.equal(
-    shouldFilterVideoPlayersForOpenWith({
-      kind: "file",
-      path: "/workspace/src/App.tsx"
-    }),
-    true
-  );
-  assert.equal(
-    shouldFilterVideoPlayersForOpenWith({
-      kind: "file",
-      path: "/workspace/config.json"
-    }),
-    true
-  );
-  assert.equal(
-    shouldFilterVideoPlayersForOpenWith({
-      kind: "file",
-      path: "/workspace/transport.ts"
-    }),
-    true
-  );
-  assert.equal(
-    shouldFilterVideoPlayersForOpenWith({
-      kind: "file",
-      path: "/workspace/README.md"
-    }),
-    true
-  );
-  assert.equal(
-    shouldFilterVideoPlayersForOpenWith({
-      kind: "file",
-      path: "/workspace/clip.mp4"
-    }),
-    false
-  );
-  assert.equal(
-    shouldFilterVideoPlayersForOpenWith({
-      kind: "file",
-      path: "/workspace/clip.mts"
-    }),
-    false
-  );
-  assert.equal(
-    shouldFilterVideoPlayersForOpenWith({
-      kind: "file",
-      path: "/workspace/archive.zip"
-    }),
-    false
-  );
-});
-
-test("workspace file preview identifies browser-openable files", () => {
-  assert.equal(
-    isWorkspaceFileBrowserOpenable({
-      kind: "file",
-      path: "/workspace/index.html"
-    }),
-    true
-  );
-  assert.equal(
-    isWorkspaceFileBrowserOpenable({
-      kind: "file",
-      path: "/workspace/report.pdf"
-    }),
-    true
-  );
-  assert.equal(
-    isWorkspaceFileBrowserOpenable({
-      kind: "file",
-      path: "/workspace/logo.png"
-    }),
-    true
-  );
-  assert.equal(
-    isWorkspaceFileBrowserOpenable({
-      kind: "file",
-      path: "/workspace/demo.mp4"
-    }),
-    true
-  );
-  assert.equal(
-    isWorkspaceFileBrowserOpenable({
-      kind: "file",
-      path: "/workspace/config.json"
-    }),
-    true
-  );
-  assert.equal(
-    isWorkspaceFileBrowserOpenable({
-      kind: "file",
-      path: "/workspace/README"
-    }),
-    true
-  );
-  assert.equal(
-    isWorkspaceFileBrowserOpenable({
-      kind: "directory",
-      path: "/workspace/docs"
-    }),
-    false
-  );
-  assert.equal(
-    isWorkspaceFileBrowserOpenable({
-      kind: "file",
-      path: "/workspace/archive.zip"
-    }),
-    false
   );
 });

--- a/packages/workspace/file-preview/src/core/workspaceFilePreview.ts
+++ b/packages/workspace/file-preview/src/core/workspaceFilePreview.ts
@@ -1,37 +1,23 @@
-export type WorkspaceFilePreviewEntryKind =
-  | "file"
-  | "directory"
-  | "folder"
-  | "unknown"
-  | (string & {});
+/**
+ * Preview readiness, byte decoding, and loaded-state construction.
+ *
+ * Ownership rules: packages/workspace/file-preview/CONTRACT.md
+ */
 
-export type WorkspaceFilePreviewKind = "image" | "text" | "video";
+import {
+  classifyWorkspaceFilePreviewKind,
+  isTextDegradablePreviewKind,
+  resolveWorkspaceFileBuiltinRenderKind,
+  resolveWorkspaceFilePreviewName,
+  resolveWorkspaceFilePreviewTarget,
+  resolveWorkspaceImageMimeType,
+  resolveWorkspaceVideoMimeType,
+  type WorkspaceFilePreviewEntry,
+  type WorkspaceFilePreviewKind,
+  type WorkspaceFilePreviewTarget
+} from "./workspaceFilePreviewKinds.ts";
 
-export type WorkspaceFileVisualKind =
-  | "binary"
-  | "code"
-  | "directory"
-  | "document"
-  | "image"
-  | "markdown"
-  | "video";
-
-export interface WorkspaceFilePreviewEntry {
-  displayName?: string;
-  kind: WorkspaceFilePreviewEntryKind;
-  mtimeMs?: number | null;
-  name?: string;
-  path: string;
-  sizeBytes?: number | null;
-}
-
-export interface WorkspaceFilePreviewActivationTarget {
-  fileKind: WorkspaceFilePreviewKind;
-  mtimeMs?: number | null;
-  name: string;
-  path: string;
-  sizeBytes?: number | null;
-}
+export * from "./workspaceFilePreviewKinds.ts";
 
 export type WorkspaceFilePreviewReadonlyReason =
   | "binary"
@@ -41,8 +27,7 @@ export type WorkspaceFilePreviewReadonlyReason =
 
 export type WorkspaceFilePreviewReadiness<
   TEntry extends WorkspaceFilePreviewEntry,
-  TTarget extends WorkspaceFilePreviewActivationTarget =
-    WorkspaceFilePreviewActivationTarget
+  TTarget extends WorkspaceFilePreviewTarget = WorkspaceFilePreviewTarget
 > =
   | { entry: TEntry; status: "directory" }
   | {
@@ -54,25 +39,43 @@ export type WorkspaceFilePreviewReadiness<
       >;
       status: "readonly";
     }
-  | { entry: TEntry; status: "unsupported" }
+  | {
+      entry: TEntry;
+      previewKind: WorkspaceFilePreviewKind;
+      status: "unsupported";
+    }
   | { entry: TEntry; status: "ready"; target: TTarget };
 
 export type WorkspaceFilePreviewLoadedState<
   TEntry extends WorkspaceFilePreviewEntry,
-  TTarget extends WorkspaceFilePreviewActivationTarget
+  TTarget extends WorkspaceFilePreviewTarget
 > =
-  | { content: string; entry: TTarget; status: "text" }
+  | {
+      content: string;
+      entry: TTarget;
+      previewKind: WorkspaceFilePreviewKind;
+      status: "text";
+    }
   | {
       bytes: Uint8Array<ArrayBuffer>;
       contentType: string;
       entry: TTarget;
+      previewKind: "image";
       status: "image";
     }
   | {
       bytes: Uint8Array<ArrayBuffer>;
       contentType: string;
       entry: TTarget;
+      previewKind: "video";
       status: "video";
+    }
+  | {
+      bytes: Uint8Array<ArrayBuffer>;
+      contentType: string | null;
+      entry: TTarget;
+      previewKind: WorkspaceFilePreviewKind;
+      status: "bytes";
     }
   | {
       entry: TEntry;
@@ -81,329 +84,51 @@ export type WorkspaceFilePreviewLoadedState<
       status: "readonly";
     };
 
-const imageExtensions = new Set([
-  "avif",
-  "gif",
-  "jpeg",
-  "jpg",
-  "png",
-  "svg",
-  "webp"
-]);
-const browserOpenableHtmlExtensions = new Set([
-  "htm",
-  "html",
-  "shtml",
-  "xhtml"
-]);
-const browserOpenableVideoExtensions = new Set(["mp4", "webm"]);
-
-const videoExtensions = new Set([
-  "avi",
-  "m2ts",
-  "mkv",
-  "mov",
-  "mp4",
-  "mpeg",
-  "mpg",
-  "mts",
-  "webm",
-  "wmv"
-]);
-/**
- * Extensions where macOS Launch Services may register video handlers even when
- * the workspace file is source code (UTI / uniform type collisions).
- */
-export const workspaceFileVideoHandlerCollisionExtensions = new Set(["ts"]);
-const markdownExtensions = new Set(["md", "mdx"]);
-const codeExtensions = new Set([
-  "bash",
-  "c",
-  "cc",
-  "conf",
-  "cpp",
-  "cs",
-  "css",
-  "go",
-  "h",
-  "hpp",
-  "html",
-  "java",
-  "js",
-  "jsx",
-  "json",
-  "lua",
-  "m",
-  "mm",
-  "php",
-  "plist",
-  "proto",
-  "py",
-  "rb",
-  "rs",
-  "sh",
-  "sql",
-  "swift",
-  "toml",
-  "ts",
-  "tsx",
-  "xml",
-  "yaml",
-  "yml",
-  "zsh"
-]);
-const documentExtensions = new Set([
-  "csv",
-  "doc",
-  "docx",
-  "log",
-  "pdf",
-  "rtf",
-  "txt",
-  "xls",
-  "xlsx"
-]);
-const textExtensions = new Set([
-  "bash",
-  "c",
-  "cc",
-  "conf",
-  "cpp",
-  "cs",
-  "css",
-  "csv",
-  "env",
-  "go",
-  "h",
-  "hpp",
-  "html",
-  "ini",
-  "java",
-  "js",
-  "json",
-  "jsx",
-  "log",
-  "lua",
-  "m",
-  "md",
-  "mdx",
-  "mm",
-  "php",
-  "plist",
-  "proto",
-  "py",
-  "rb",
-  "rs",
-  "sh",
-  "sql",
-  "swift",
-  "toml",
-  "ts",
-  "tsx",
-  "txt",
-  "xml",
-  "yaml",
-  "yml",
-  "zsh"
-]);
-const textFileNames = new Set([
-  ".gitignore",
-  ".npmrc",
-  ".nvmrc",
-  "dockerfile",
-  "makefile",
-  "readme"
-]);
+export interface ResolveWorkspaceFilePreviewReadinessOptions {
+  /**
+   * When true for a classified kind, readiness treats the entry as presentable
+   * even if it is hook-only (pdf / audio / Office). Built-in presentable kinds
+   * do not require this callback.
+   */
+  hasHostRenderer?: (kind: WorkspaceFilePreviewKind) => boolean;
+}
 
 export const workspaceFileTextMaxBytes = 1024 * 1024;
 export const workspaceFilePreviewMaxBytes = 20 * 1024 * 1024;
 
-export function resolveWorkspaceFileVisualKind(
-  entry: Pick<WorkspaceFilePreviewEntry, "kind" | "name" | "path">
-): WorkspaceFileVisualKind {
-  if (entry.kind === "directory" || entry.kind === "folder") {
-    return "directory";
-  }
-
-  const extension = resolveWorkspaceFileExtension(
-    entry.path || entry.name || ""
-  );
-  if (imageExtensions.has(extension)) {
-    return "image";
-  }
-  if (videoExtensions.has(extension)) {
-    return "video";
-  }
-  if (markdownExtensions.has(extension)) {
-    return "markdown";
-  }
-  if (codeExtensions.has(extension)) {
-    return "code";
-  }
-  if (documentExtensions.has(extension)) {
-    return "document";
-  }
-  return "binary";
-}
-
-export function resolveWorkspaceFileExtension(pathOrName: string): string {
-  const name = pathOrName.split("/").pop()?.trim().toLowerCase() ?? "";
-  const dotIndex = name.lastIndexOf(".");
-  return dotIndex > 0 ? name.slice(dotIndex + 1) : "";
-}
-
-export function isWorkspaceFileBrowserOpenable(
-  entry: Pick<WorkspaceFilePreviewEntry, "kind" | "name" | "path">
-): boolean {
-  if (entry.kind !== "file") {
-    return false;
-  }
-
-  const extension = resolveWorkspaceFileExtension(
-    entry.path || entry.name || ""
-  );
-  if (
-    extension === "pdf" ||
-    browserOpenableHtmlExtensions.has(extension) ||
-    imageExtensions.has(extension) ||
-    browserOpenableVideoExtensions.has(extension)
-  ) {
-    return true;
-  }
-
-  return classifyWorkspaceFilePreviewKind(entry) === "text";
-}
-
-export function shouldFilterVideoPlayersForOpenWith(
-  entry: Pick<WorkspaceFilePreviewEntry, "kind" | "name" | "path">
-): boolean {
-  if (entry.kind !== "file") {
-    return false;
-  }
-
-  const visualKind = resolveWorkspaceFileVisualKind(entry);
-  if (visualKind === "video") {
-    return false;
-  }
-
-  const extension = resolveWorkspaceFileExtension(
-    entry.path || entry.name || ""
-  );
-  if (workspaceFileVideoHandlerCollisionExtensions.has(extension)) {
-    return true;
-  }
-
-  if (visualKind === "code" || visualKind === "markdown") {
-    return true;
-  }
-
-  return classifyWorkspaceFilePreviewKind(entry) === "text";
-}
-
-export function resolveWorkspaceImageMimeType(
-  pathOrName: string
-): string | null {
-  switch (resolveWorkspaceFileExtension(pathOrName)) {
-    case "avif":
-      return "image/avif";
-    case "gif":
-      return "image/gif";
-    case "jpeg":
-    case "jpg":
-      return "image/jpeg";
-    case "png":
-      return "image/png";
-    case "svg":
-      return "image/svg+xml";
-    case "webp":
-      return "image/webp";
-    default:
-      return null;
-  }
-}
-
-export function resolveWorkspaceVideoMimeType(
-  pathOrName: string
-): string | null {
-  switch (resolveWorkspaceFileExtension(pathOrName)) {
-    case "mp4":
-      return "video/mp4";
-    case "webm":
-      return "video/webm";
-    default:
-      return null;
-  }
-}
-
-export function classifyWorkspaceFilePreviewKind(
-  entry: Pick<
-    WorkspaceFilePreviewEntry,
-    "displayName" | "kind" | "name" | "path"
-  >
-): WorkspaceFilePreviewKind | null {
-  if (entry.kind !== "file") {
-    return null;
-  }
-
-  const name = resolveWorkspaceFilePreviewName(entry);
-  if (resolveWorkspaceImageMimeType(name) !== null) {
-    return "image";
-  }
-  if (resolveWorkspaceVideoMimeType(name) !== null) {
-    return "video";
-  }
-
-  const normalizedName = name.trim().toLowerCase();
-  const extension = resolveWorkspaceFileExtension(name);
-  if (textExtensions.has(extension) || textFileNames.has(normalizedName)) {
-    return "text";
-  }
-
-  return null;
-}
-
-export function resolveWorkspaceFileActivationTarget(
-  entry: WorkspaceFilePreviewEntry
-): WorkspaceFilePreviewActivationTarget | null {
-  const fileKind = classifyWorkspaceFilePreviewKind(entry);
-  if (!fileKind) {
-    return null;
-  }
-
-  const target: WorkspaceFilePreviewActivationTarget = {
-    fileKind,
-    name: resolveWorkspaceFilePreviewName(entry),
-    path: entry.path
-  };
-  if (entry.mtimeMs !== undefined) {
-    target.mtimeMs = entry.mtimeMs;
-  }
-  if (entry.sizeBytes !== undefined) {
-    target.sizeBytes = entry.sizeBytes;
-  }
-  return target;
-}
-
 export function resolveWorkspaceFilePreviewReadiness<
   TEntry extends WorkspaceFilePreviewEntry
->(entry: TEntry): WorkspaceFilePreviewReadiness<TEntry> {
-  if (entry.kind === "directory" || entry.kind === "folder") {
+>(
+  entry: TEntry,
+  options?: ResolveWorkspaceFilePreviewReadinessOptions
+): WorkspaceFilePreviewReadiness<TEntry> {
+  const previewKind = classifyWorkspaceFilePreviewKind(entry);
+  if (previewKind === "directory") {
     return {
       entry,
       status: "directory"
     };
   }
 
-  const target = resolveWorkspaceFileActivationTarget(entry);
-  if (!target) {
+  const builtin = resolveWorkspaceFileBuiltinRenderKind(previewKind);
+  const hostRenderable =
+    options?.hasHostRenderer?.(previewKind) === true &&
+    previewKind !== "unsupported";
+
+  if (!builtin && !hostRenderable) {
     return {
       entry,
+      previewKind,
       status: "unsupported"
     };
   }
 
+  const target =
+    resolveWorkspaceFilePreviewTarget(entry) ??
+    createWorkspaceFilePreviewTarget(entry, previewKind);
+
   if (
-    target.fileKind === "text" &&
+    (builtin === "text" || isTextDegradablePreviewKind(previewKind)) &&
     isWorkspaceTextFileTooLarge(entry.sizeBytes)
   ) {
     return {
@@ -432,14 +157,22 @@ export function resolveWorkspaceFilePreviewReadiness<
 
 export function createWorkspaceFilePreviewLoadedState<
   TEntry extends WorkspaceFilePreviewEntry,
-  TTarget extends WorkspaceFilePreviewActivationTarget
+  TTarget extends WorkspaceFilePreviewTarget
 >(input: {
   bytes: Uint8Array | ArrayBuffer;
   contentType?: string | null;
   entry: TEntry;
+  /**
+   * When true, skip built-in text degradation and keep raw bytes for a host
+   * renderer (hook-only kinds, or text-degradable kinds with a host hook).
+   */
+  preferHostBytes?: boolean;
   target: TTarget;
 }): WorkspaceFilePreviewLoadedState<TEntry, TTarget> {
-  if (input.target.fileKind === "image") {
+  const previewKind = input.target.previewKind;
+  const builtin = resolveWorkspaceFileBuiltinRenderKind(previewKind);
+
+  if (builtin === "image") {
     return {
       bytes: copyWorkspaceFilePreviewBytes(input.bytes),
       contentType:
@@ -447,10 +180,11 @@ export function createWorkspaceFilePreviewLoadedState<
         resolveWorkspaceImageMimeType(input.target.name) ??
         "application/octet-stream",
       entry: input.target,
+      previewKind: "image",
       status: "image"
     };
   }
-  if (input.target.fileKind === "video") {
+  if (builtin === "video") {
     return {
       bytes: copyWorkspaceFilePreviewBytes(input.bytes),
       contentType:
@@ -458,7 +192,18 @@ export function createWorkspaceFilePreviewLoadedState<
         resolveWorkspaceVideoMimeType(input.target.name) ??
         "application/octet-stream",
       entry: input.target,
+      previewKind: "video",
       status: "video"
+    };
+  }
+
+  if (input.preferHostBytes || builtin === null) {
+    return {
+      bytes: copyWorkspaceFilePreviewBytes(input.bytes),
+      contentType: input.contentType ?? null,
+      entry: input.target,
+      previewKind,
+      status: "bytes"
     };
   }
 
@@ -474,6 +219,7 @@ export function createWorkspaceFilePreviewLoadedState<
     return {
       content,
       entry: input.target,
+      previewKind,
       status: "text"
     };
   } catch {
@@ -483,17 +229,6 @@ export function createWorkspaceFilePreviewLoadedState<
       status: "readonly"
     };
   }
-}
-
-export function resolveWorkspaceFilePreviewName(
-  entry: Pick<WorkspaceFilePreviewEntry, "displayName" | "name" | "path">
-): string {
-  return (
-    entry.name?.trim() ||
-    entry.displayName?.trim() ||
-    entry.path.split("/").pop()?.trim() ||
-    entry.path
-  );
 }
 
 export function isWorkspaceTextFileTooLarge(
@@ -576,4 +311,22 @@ export function formatWorkspacePreviewByteLimit(sizeBytes: number): string {
     return `${mebibytes} MiB`;
   }
   return `${mebibytes.toFixed(1)} MiB`;
+}
+
+function createWorkspaceFilePreviewTarget(
+  entry: WorkspaceFilePreviewEntry,
+  previewKind: WorkspaceFilePreviewKind
+): WorkspaceFilePreviewTarget {
+  const target: WorkspaceFilePreviewTarget = {
+    previewKind,
+    name: resolveWorkspaceFilePreviewName(entry),
+    path: entry.path
+  };
+  if (entry.mtimeMs !== undefined) {
+    target.mtimeMs = entry.mtimeMs;
+  }
+  if (entry.sizeBytes !== undefined) {
+    target.sizeBytes = entry.sizeBytes;
+  }
+  return target;
 }

--- a/packages/workspace/file-preview/src/core/workspaceFilePreviewController.test.ts
+++ b/packages/workspace/file-preview/src/core/workspaceFilePreviewController.test.ts
@@ -50,6 +50,7 @@ function createDeferredRead() {
 }
 
 function createController(input?: {
+  hasHostRenderer?: (kind: string) => boolean;
   objectUrls?: WorkspaceFilePreviewObjectUrlFactory;
   read?: (input: {
     entry: TestEntry;
@@ -57,6 +58,7 @@ function createController(input?: {
   }) => Promise<WorkspaceFilePreviewReadResult | null>;
 }) {
   return createWorkspaceFilePreviewController<TestEntry>({
+    hasHostRenderer: input?.hasHostRenderer,
     objectUrls: input?.objectUrls,
     read: input?.read,
     toPreviewEntry: (entry) => entry
@@ -77,6 +79,7 @@ test("preview controller resolves empty, directory, unsupported, and readonly en
   controller.setEntry({ kind: "file", path: "/workspace/archive.zip" });
   assert.deepEqual(controller.getSnapshot(), {
     entry: { kind: "file", path: "/workspace/archive.zip" },
+    previewKind: "unsupported",
     reason: "file_type",
     status: "unsupported"
   });
@@ -103,11 +106,16 @@ test("preview controller loads text and reports reader errors without localizing
   });
 
   controller.setEntry({ kind: "file", path: "/workspace/readme.md" });
-  assert.equal(controller.getSnapshot().status, "loading");
+  assert.deepEqual(controller.getSnapshot(), {
+    entry: { kind: "file", path: "/workspace/readme.md" },
+    previewKind: "markdown",
+    status: "loading"
+  });
   await flush();
   assert.deepEqual(controller.getSnapshot(), {
     content: "hello",
     entry: { kind: "file", path: "/workspace/readme.md" },
+    previewKind: "markdown",
     previewSizeBytes: 5,
     status: "text"
   });
@@ -117,7 +125,29 @@ test("preview controller loads text and reports reader errors without localizing
   assert.deepEqual(controller.getSnapshot(), {
     entry: { kind: "file", path: "/workspace/fail.md" },
     error: failure,
+    previewKind: "markdown",
     status: "error"
+  });
+});
+
+test("preview controller loads hook-only kinds as bytes when a host renderer exists", async () => {
+  const controller = createController({
+    hasHostRenderer: (kind) => kind === "pdf",
+    read: async () => ({
+      bytes: new Uint8Array([1, 2, 3]),
+      contentType: "application/pdf"
+    })
+  });
+
+  controller.setEntry({ kind: "file", path: "/workspace/report.pdf" });
+  await flush();
+  assert.deepEqual(controller.getSnapshot(), {
+    bytes: new Uint8Array([1, 2, 3]),
+    contentType: "application/pdf",
+    entry: { kind: "file", path: "/workspace/report.pdf" },
+    previewKind: "pdf",
+    previewSizeBytes: 3,
+    status: "bytes"
   });
 });
 
@@ -199,6 +229,7 @@ test("preview controller reports an unavailable reader explicitly", () => {
   controller.setEntry({ kind: "file", path: "/workspace/readme.md" });
   assert.deepEqual(controller.getSnapshot(), {
     entry: { kind: "file", path: "/workspace/readme.md" },
+    previewKind: "markdown",
     reason: "reader_unavailable",
     status: "unsupported"
   });
@@ -215,7 +246,6 @@ test("preview controller skips reading when canReadEntry explicitly returns fals
     toPreviewEntry: (entry) => entry
   });
 
-  // .md is a recognized text file, but canReadEntry=false should skip reading
   controller.setEntry({ kind: "file", path: "/workspace/readme.md" });
   const snapshot = controller.getSnapshot();
   assert.equal(snapshot.status, "unsupported");
@@ -225,7 +255,6 @@ test("preview controller skips reading when canReadEntry explicitly returns fals
   );
   assert.equal(reads, 0);
 
-  // .json is also recognized text, same behavior
   controller.setEntry({ kind: "file", path: "/workspace/data.json" });
   assert.equal(controller.getSnapshot().status, "unsupported");
   assert.equal(reads, 0);
@@ -262,7 +291,6 @@ test("preview controller attempts reading for unknown extension when canReadEntr
     canReadEntry: () => true,
     read: async () => {
       reads += 1;
-      // Source provides kind from server response
       return {
         bytes: new TextEncoder().encode("server content"),
         kind: "text"
@@ -271,12 +299,10 @@ test("preview controller attempts reading for unknown extension when canReadEntr
     toPreviewEntry: (entry) => entry
   });
 
-  // .xyz is not a recognized extension locally
   controller.setEntry({ kind: "file", path: "/workspace/file.xyz" });
   assert.equal(controller.getSnapshot().status, "loading");
   await flush();
 
-  // Should have attempted to read because canReadEntry=true
   assert.equal(reads, 1);
   assert.equal(controller.getSnapshot().status, "text");
 
@@ -297,6 +323,7 @@ test("preview controller reports an unavailable reader for an explicitly readabl
 
   assert.deepEqual(controller.getSnapshot(), {
     entry,
+    previewKind: "unsupported",
     reason: "reader_unavailable",
     status: "unsupported"
   });
@@ -309,7 +336,6 @@ test("preview controller allows source-provided kind to override local classific
     canReadEntry: () => true,
     read: async () => {
       reads += 1;
-      // Source says this unknown file is actually an image
       return {
         bytes: new Uint8Array([0, 1, 2, 3]),
         contentType: "image/png",
@@ -319,7 +345,6 @@ test("preview controller allows source-provided kind to override local classific
     toPreviewEntry: (entry) => entry
   });
 
-  // .data is unrecognized, but source provides kind="image"
   controller.setEntry({ kind: "file", path: "/workspace/unknown.data" });
   await flush();
 

--- a/packages/workspace/file-preview/src/core/workspaceFilePreviewController.ts
+++ b/packages/workspace/file-preview/src/core/workspaceFilePreviewController.ts
@@ -1,10 +1,17 @@
+/**
+ * Shared preview loading lifecycle.
+ *
+ * Ownership rules: packages/workspace/file-preview/CONTRACT.md
+ */
+
 import {
   createWorkspaceFilePreviewLoadedState,
+  resolveWorkspaceFileBuiltinRenderKind,
   resolveWorkspaceFilePreviewReadiness,
-  type WorkspaceFilePreviewActivationTarget,
   type WorkspaceFilePreviewEntry,
   type WorkspaceFilePreviewKind,
-  type WorkspaceFilePreviewReadonlyReason
+  type WorkspaceFilePreviewReadonlyReason,
+  type WorkspaceFilePreviewTarget
 } from "./workspaceFilePreview.ts";
 
 export type WorkspaceFilePreviewUnsupportedReason =
@@ -14,55 +21,77 @@ export type WorkspaceFilePreviewUnsupportedReason =
 export type WorkspaceFilePreviewControllerState<TEntry> =
   | { status: "empty" }
   | { entry: TEntry; status: "directory" }
-  | { entry: TEntry; status: "loading" }
+  | {
+      entry: TEntry;
+      previewKind: WorkspaceFilePreviewKind;
+      status: "loading";
+    }
   | {
       content: string;
       entry: TEntry;
+      previewKind: WorkspaceFilePreviewKind;
       previewSizeBytes: number;
       status: "text";
     }
   | {
       entry: TEntry;
       objectUrl: string;
+      previewKind: "image";
       previewSizeBytes: number;
       status: "image";
     }
   | {
       entry: TEntry;
       objectUrl: string;
+      previewKind: "video";
       previewSizeBytes: number;
       status: "video";
     }
   | {
+      bytes: Uint8Array<ArrayBuffer>;
+      contentType: string | null;
+      entry: TEntry;
+      previewKind: WorkspaceFilePreviewKind;
+      previewSizeBytes: number;
+      status: "bytes";
+    }
+  | {
       entry: TEntry;
       maxSizeBytes?: number;
+      previewKind?: WorkspaceFilePreviewKind;
       previewSizeBytes?: number;
       reason: WorkspaceFilePreviewReadonlyReason;
       status: "readonly";
     }
   | {
       entry: TEntry;
+      previewKind?: WorkspaceFilePreviewKind;
       reason: WorkspaceFilePreviewUnsupportedReason;
       status: "unsupported";
     }
-  | { entry: TEntry; error: unknown; status: "error" };
+  | {
+      entry: TEntry;
+      error: unknown;
+      previewKind?: WorkspaceFilePreviewKind;
+      status: "error";
+    };
 
 export interface WorkspaceFilePreviewReadInput<TEntry> {
   entry: TEntry;
   signal: AbortSignal;
-  target: WorkspaceFilePreviewActivationTarget;
+  target: WorkspaceFilePreviewTarget;
 }
 
+/**
+ * Host read result. Bare Uint8Array / ArrayBuffer are intentionally not
+ * accepted; wrap bytes in this object shape.
+ */
 export interface WorkspaceFilePreviewReadResult {
   bytes: Uint8Array | ArrayBuffer;
   contentType?: string | null;
+  /** Optional host override of the classified preview kind. */
   kind?: WorkspaceFilePreviewKind;
 }
-
-export type WorkspaceFilePreviewReadOutput =
-  | WorkspaceFilePreviewReadResult
-  | Uint8Array
-  | ArrayBuffer;
 
 export interface WorkspaceFilePreviewObjectUrlFactory {
   create(bytes: Uint8Array<ArrayBuffer>, contentType: string): string;
@@ -77,10 +106,16 @@ export interface CreateWorkspaceFilePreviewControllerInput<TEntry> {
    */
   canReadEntry?: (entry: TEntry) => boolean;
   getEntryKey?: (entry: TEntry) => string;
+  /**
+   * Host renderer registry probe used by readiness / load planning. Returning
+   * true for a kind keeps hook-only kinds presentable and can prefer raw bytes
+   * for text-degradable kinds that the host wants to render itself.
+   */
+  hasHostRenderer?: (kind: WorkspaceFilePreviewKind) => boolean;
   objectUrls?: WorkspaceFilePreviewObjectUrlFactory;
   read?: (
     input: WorkspaceFilePreviewReadInput<TEntry>
-  ) => Promise<WorkspaceFilePreviewReadOutput | null>;
+  ) => Promise<WorkspaceFilePreviewReadResult | null>;
   toPreviewEntry: (entry: TEntry) => WorkspaceFilePreviewEntry;
 }
 
@@ -186,7 +221,7 @@ class WorkspaceFilePreviewControllerImpl<
   private async load(
     entry: TEntry,
     previewEntry: WorkspaceFilePreviewEntry,
-    target: WorkspaceFilePreviewActivationTarget,
+    target: WorkspaceFilePreviewTarget,
     generation: number,
     abortController: AbortController
   ): Promise<void> {
@@ -202,32 +237,35 @@ class WorkspaceFilePreviewControllerImpl<
       if (!result) {
         this.updateState({
           entry,
+          previewKind: target.previewKind,
           reason: "file_type",
           status: "unsupported"
         });
         return;
       }
 
+      const resolvedKind = result.kind ?? target.previewKind;
+      const resolvedTarget: WorkspaceFilePreviewTarget = {
+        ...target,
+        previewKind: resolvedKind
+      };
+      // Hook-only kinds keep raw bytes for the host renderer. Text-degradable
+      // kinds still decode to text; the surface may then prefer a host hook.
+      const preferHostBytes =
+        resolveWorkspaceFileBuiltinRenderKind(resolvedKind) === null;
+
       const loaded = createWorkspaceFilePreviewLoadedState({
-        bytes:
-          result instanceof Uint8Array || result instanceof ArrayBuffer
-            ? result
-            : result.bytes,
-        contentType:
-          result instanceof Uint8Array || result instanceof ArrayBuffer
-            ? undefined
-            : result.contentType,
+        bytes: result.bytes,
+        contentType: result.contentType,
         entry: previewEntry,
-        target:
-          result instanceof Uint8Array || result instanceof ArrayBuffer
-            ? target
-            : { ...target, fileKind: result.kind ?? target.fileKind }
+        preferHostBytes,
+        target: resolvedTarget
       });
       if (this.isStale(generation)) {
         return;
       }
 
-      if (loaded.status === "image" || loaded.status === "video") {
+      if (loaded.status === "image") {
         const previewSizeBytes = loaded.bytes.byteLength;
         const objectUrl = this.objectUrls.create(
           loaded.bytes,
@@ -241,8 +279,29 @@ class WorkspaceFilePreviewControllerImpl<
         this.updateState({
           entry,
           objectUrl,
+          previewKind: "image",
           previewSizeBytes,
-          status: loaded.status
+          status: "image"
+        });
+        return;
+      }
+      if (loaded.status === "video") {
+        const previewSizeBytes = loaded.bytes.byteLength;
+        const objectUrl = this.objectUrls.create(
+          loaded.bytes,
+          loaded.contentType
+        );
+        if (this.isStale(generation)) {
+          this.objectUrls.revoke(objectUrl);
+          return;
+        }
+        this.objectUrl = objectUrl;
+        this.updateState({
+          entry,
+          objectUrl,
+          previewKind: "video",
+          previewSizeBytes,
+          status: "video"
         });
         return;
       }
@@ -250,14 +309,27 @@ class WorkspaceFilePreviewControllerImpl<
         this.updateState({
           content: loaded.content,
           entry,
-          previewSizeBytes: byteLengthOfPreviewReadResult(result),
+          previewKind: loaded.previewKind,
+          previewSizeBytes: result.bytes.byteLength,
           status: "text"
+        });
+        return;
+      }
+      if (loaded.status === "bytes") {
+        this.updateState({
+          bytes: loaded.bytes,
+          contentType: loaded.contentType,
+          entry,
+          previewKind: loaded.previewKind,
+          previewSizeBytes: loaded.bytes.byteLength,
+          status: "bytes"
         });
         return;
       }
       this.updateState({
         entry,
-        previewSizeBytes: byteLengthOfPreviewReadResult(result),
+        previewKind: target.previewKind,
+        previewSizeBytes: result.bytes.byteLength,
         reason: loaded.reason,
         ...(loaded.maxSizeBytes === undefined
           ? {}
@@ -268,7 +340,12 @@ class WorkspaceFilePreviewControllerImpl<
       if (this.isStale(generation)) {
         return;
       }
-      this.updateState({ entry, error, status: "error" });
+      this.updateState({
+        entry,
+        error,
+        previewKind: target.previewKind,
+        status: "error"
+      });
     } finally {
       if (!this.isStale(generation)) {
         this.abortController = null;
@@ -285,7 +362,6 @@ class WorkspaceFilePreviewControllerImpl<
       previewEntry.kind,
       previewEntry.path,
       previewEntry.name ?? "",
-      previewEntry.displayName ?? "",
       previewEntry.sizeBytes ?? "",
       previewEntry.mtimeMs ?? ""
     ].join("\0");
@@ -304,7 +380,9 @@ class WorkspaceFilePreviewControllerImpl<
     this.revokeObjectUrl();
 
     const previewEntry = this.input.toPreviewEntry(entry);
-    const readiness = resolveWorkspaceFilePreviewReadiness(previewEntry);
+    const readiness = resolveWorkspaceFilePreviewReadiness(previewEntry, {
+      hasHostRenderer: this.input.hasHostRenderer
+    });
 
     if (readiness.status === "directory") {
       this.updateState({ entry, status: "directory" });
@@ -327,6 +405,7 @@ class WorkspaceFilePreviewControllerImpl<
       if (canRead !== true) {
         this.updateState({
           entry,
+          previewKind: readiness.previewKind,
           reason: "file_type",
           status: "unsupported"
         });
@@ -336,17 +415,18 @@ class WorkspaceFilePreviewControllerImpl<
       if (!this.input.read) {
         this.updateState({
           entry,
+          previewKind: readiness.previewKind,
           reason: "reader_unavailable",
           status: "unsupported"
         });
         this.loadPromise = Promise.resolve();
         return this.loadPromise;
       }
-      const target: WorkspaceFilePreviewActivationTarget = {
-        fileKind: "text",
+      // Source claimed it can classify/read locally unsupported files as text.
+      const target: WorkspaceFilePreviewTarget = {
+        previewKind: "text",
         name:
           previewEntry.name ??
-          previewEntry.displayName ??
           previewEntry.path.split("/").pop() ??
           previewEntry.path,
         path: previewEntry.path,
@@ -357,18 +437,7 @@ class WorkspaceFilePreviewControllerImpl<
           ? {}
           : { sizeBytes: previewEntry.sizeBytes })
       };
-      const abortController = new AbortController();
-      this.abortController = abortController;
-      const generation = this.generation;
-      this.updateState({ entry, status: "loading" });
-      this.loadPromise = this.load(
-        entry,
-        previewEntry,
-        target,
-        generation,
-        abortController
-      );
-      return this.loadPromise;
+      return this.beginLoad(entry, previewEntry, target);
     }
 
     if (readiness.status === "readonly") {
@@ -385,6 +454,7 @@ class WorkspaceFilePreviewControllerImpl<
     if (!this.input.read) {
       this.updateState({
         entry,
+        previewKind: readiness.target.previewKind,
         reason: "reader_unavailable",
         status: "unsupported"
       });
@@ -392,14 +462,26 @@ class WorkspaceFilePreviewControllerImpl<
       return this.loadPromise;
     }
 
+    return this.beginLoad(entry, previewEntry, readiness.target);
+  }
+
+  private beginLoad(
+    entry: TEntry,
+    previewEntry: WorkspaceFilePreviewEntry,
+    target: WorkspaceFilePreviewTarget
+  ): Promise<void> {
     const abortController = new AbortController();
     this.abortController = abortController;
     const generation = this.generation;
-    this.updateState({ entry, status: "loading" });
+    this.updateState({
+      entry,
+      previewKind: target.previewKind,
+      status: "loading"
+    });
     this.loadPromise = this.load(
       entry,
       previewEntry,
-      readiness.target,
+      target,
       generation,
       abortController
     );
@@ -428,13 +510,3 @@ const browserWorkspaceFilePreviewObjectUrls: WorkspaceFilePreviewObjectUrlFactor
       URL.revokeObjectURL(objectUrl);
     }
   };
-
-function byteLengthOfPreviewReadResult(
-  result: WorkspaceFilePreviewReadOutput
-): number {
-  const bytes =
-    result instanceof Uint8Array || result instanceof ArrayBuffer
-      ? result
-      : result.bytes;
-  return bytes.byteLength;
-}

--- a/packages/workspace/file-preview/src/core/workspaceFilePreviewKinds.ts
+++ b/packages/workspace/file-preview/src/core/workspaceFilePreviewKinds.ts
@@ -1,0 +1,386 @@
+/**
+ * Preview kind taxonomy and classification.
+ *
+ * Ownership rules: packages/workspace/file-preview/CONTRACT.md
+ */
+
+export type WorkspaceFilePreviewEntryKind =
+  | "file"
+  | "directory"
+  | "folder"
+  | "unknown"
+  | (string & {});
+
+/**
+ * Flat preview routing kind. Built-in surface covers image / video / text;
+ * text-degradable kinds fall back to built-in text when no host hook is
+ * registered. Hook-only kinds (audio / pdf / Office) stay unsupported until a
+ * host registers a renderer.
+ */
+export type WorkspaceFilePreviewKind =
+  | "directory"
+  | "image"
+  | "video"
+  | "audio"
+  | "text"
+  | "code"
+  | "markdown"
+  | "json"
+  | "csv"
+  | "html"
+  | "pdf"
+  | "docx"
+  | "xlsx"
+  | "pptx"
+  | "unsupported";
+
+/** Coarse glyph / icon signal; must not be collapsed into previewKind. */
+export type WorkspaceFileVisualKind =
+  | "binary"
+  | "code"
+  | "directory"
+  | "document"
+  | "image"
+  | "markdown"
+  | "video";
+
+/** Built-in render modes the package surface can paint without host hooks. */
+export type WorkspaceFileBuiltinRenderKind = "image" | "text" | "video";
+
+export interface WorkspaceFilePreviewEntry {
+  kind: WorkspaceFilePreviewEntryKind;
+  mtimeMs?: number | null;
+  name?: string;
+  path: string;
+  sizeBytes?: number | null;
+}
+
+export interface WorkspaceFilePreviewTarget {
+  previewKind: WorkspaceFilePreviewKind;
+  mtimeMs?: number | null;
+  name: string;
+  path: string;
+  sizeBytes?: number | null;
+}
+
+const imageExtensions = new Set([
+  "avif",
+  "gif",
+  "jpeg",
+  "jpg",
+  "png",
+  "svg",
+  "webp"
+]);
+
+const videoExtensions = new Set([
+  "avi",
+  "m2ts",
+  "mkv",
+  "mov",
+  "mp4",
+  "mpeg",
+  "mpg",
+  "mts",
+  "webm",
+  "wmv"
+]);
+
+/** Browser-decodable video subset used for mime hints and open-with hosts. */
+export const workspaceFileBrowserVideoExtensions = new Set(["mp4", "webm"]);
+
+const audioExtensions = new Set([
+  "aac",
+  "flac",
+  "m4a",
+  "mp3",
+  "oga",
+  "ogg",
+  "opus",
+  "wav"
+]);
+
+const markdownExtensions = new Set(["md", "mdx"]);
+const jsonExtensions = new Set(["json", "jsonc"]);
+const csvExtensions = new Set(["csv", "tsv"]);
+const htmlExtensions = new Set(["htm", "html", "shtml", "xhtml"]);
+const pdfExtensions = new Set(["pdf"]);
+const docxExtensions = new Set(["docx"]);
+const xlsxExtensions = new Set(["xlsx"]);
+const pptxExtensions = new Set(["pptx"]);
+
+const codeExtensions = new Set([
+  "bash",
+  "c",
+  "cc",
+  "conf",
+  "cpp",
+  "cs",
+  "css",
+  "go",
+  "h",
+  "hpp",
+  "ini",
+  "java",
+  "js",
+  "jsx",
+  "lua",
+  "m",
+  "mm",
+  "php",
+  "plist",
+  "proto",
+  "py",
+  "rb",
+  "rs",
+  "sh",
+  "sql",
+  "swift",
+  "toml",
+  "ts",
+  "tsx",
+  "xml",
+  "yaml",
+  "yml",
+  "zsh"
+]);
+
+const plainTextExtensions = new Set(["env", "log", "txt"]);
+
+const textFileNames = new Set([
+  ".gitignore",
+  ".npmrc",
+  ".nvmrc",
+  "dockerfile",
+  "makefile",
+  "readme"
+]);
+
+/** Document-like icons that are not themselves first-class preview kinds. */
+const documentVisualExtensions = new Set([
+  "csv",
+  "doc",
+  "docx",
+  "log",
+  "pdf",
+  "rtf",
+  "txt",
+  "xls",
+  "xlsx"
+]);
+
+const textDegradablePreviewKinds = new Set<WorkspaceFilePreviewKind>([
+  "text",
+  "code",
+  "markdown",
+  "json",
+  "csv",
+  "html"
+]);
+
+export function resolveWorkspaceFileExtension(pathOrName: string): string {
+  const name = pathOrName.split("/").pop()?.trim().toLowerCase() ?? "";
+  const dotIndex = name.lastIndexOf(".");
+  return dotIndex > 0 ? name.slice(dotIndex + 1) : "";
+}
+
+export function resolveWorkspaceFilePreviewName(
+  entry: Pick<WorkspaceFilePreviewEntry, "name" | "path">
+): string {
+  return (
+    entry.name?.trim() || entry.path.split("/").pop()?.trim() || entry.path
+  );
+}
+
+export function isWorkspaceFileDirectoryKind(
+  kind: WorkspaceFilePreviewEntryKind
+): boolean {
+  return kind === "directory" || kind === "folder";
+}
+
+export function isTextDegradablePreviewKind(
+  kind: WorkspaceFilePreviewKind
+): boolean {
+  return textDegradablePreviewKinds.has(kind);
+}
+
+/**
+ * Maps a classified preview kind onto the built-in surface renderer, if any.
+ * Text-degradable kinds resolve to built-in `text`.
+ */
+export function resolveWorkspaceFileBuiltinRenderKind(
+  kind: WorkspaceFilePreviewKind
+): WorkspaceFileBuiltinRenderKind | null {
+  if (kind === "image" || kind === "video") {
+    return kind;
+  }
+  if (isTextDegradablePreviewKind(kind)) {
+    return "text";
+  }
+  return null;
+}
+
+export function resolveWorkspaceFileVisualKind(
+  entry: Pick<WorkspaceFilePreviewEntry, "kind" | "name" | "path">
+): WorkspaceFileVisualKind {
+  if (isWorkspaceFileDirectoryKind(entry.kind)) {
+    return "directory";
+  }
+
+  const extension = resolveWorkspaceFileExtension(
+    entry.path || entry.name || ""
+  );
+  if (imageExtensions.has(extension)) {
+    return "image";
+  }
+  if (videoExtensions.has(extension)) {
+    return "video";
+  }
+  if (markdownExtensions.has(extension)) {
+    return "markdown";
+  }
+  if (codeExtensions.has(extension) || jsonExtensions.has(extension)) {
+    return "code";
+  }
+  if (
+    documentVisualExtensions.has(extension) ||
+    htmlExtensions.has(extension) ||
+    pptxExtensions.has(extension)
+  ) {
+    return "document";
+  }
+  return "binary";
+}
+
+/**
+ * Classifies the flat previewKind for an entry.
+ * Directory synonyms (`folder`) are normalized to `directory`.
+ */
+export function classifyWorkspaceFilePreviewKind(
+  entry: Pick<WorkspaceFilePreviewEntry, "kind" | "name" | "path">
+): WorkspaceFilePreviewKind {
+  if (isWorkspaceFileDirectoryKind(entry.kind)) {
+    return "directory";
+  }
+  if (entry.kind !== "file") {
+    return "unsupported";
+  }
+
+  const name = resolveWorkspaceFilePreviewName(entry);
+  const extension = resolveWorkspaceFileExtension(name);
+  const normalizedName = name.trim().toLowerCase();
+
+  if (imageExtensions.has(extension)) {
+    return "image";
+  }
+  if (videoExtensions.has(extension)) {
+    return "video";
+  }
+  if (audioExtensions.has(extension)) {
+    return "audio";
+  }
+  if (markdownExtensions.has(extension)) {
+    return "markdown";
+  }
+  if (jsonExtensions.has(extension)) {
+    return "json";
+  }
+  if (csvExtensions.has(extension)) {
+    return "csv";
+  }
+  if (htmlExtensions.has(extension)) {
+    return "html";
+  }
+  if (pdfExtensions.has(extension)) {
+    return "pdf";
+  }
+  if (docxExtensions.has(extension)) {
+    return "docx";
+  }
+  if (xlsxExtensions.has(extension)) {
+    return "xlsx";
+  }
+  if (pptxExtensions.has(extension)) {
+    return "pptx";
+  }
+  if (codeExtensions.has(extension)) {
+    return "code";
+  }
+  if (plainTextExtensions.has(extension) || textFileNames.has(normalizedName)) {
+    return "text";
+  }
+
+  return "unsupported";
+}
+
+/**
+ * Returns a preview target when the entry can be presented with the built-in
+ * resolve chain (host hook omitted). Hook-only kinds return null here; hosts
+ * with renderers should call classify + hasHostRenderer themselves.
+ */
+export function resolveWorkspaceFilePreviewTarget(
+  entry: WorkspaceFilePreviewEntry
+): WorkspaceFilePreviewTarget | null {
+  const previewKind = classifyWorkspaceFilePreviewKind(entry);
+  if (resolveWorkspaceFileBuiltinRenderKind(previewKind) === null) {
+    return null;
+  }
+
+  const target: WorkspaceFilePreviewTarget = {
+    previewKind,
+    name: resolveWorkspaceFilePreviewName(entry),
+    path: entry.path
+  };
+  if (entry.mtimeMs !== undefined) {
+    target.mtimeMs = entry.mtimeMs;
+  }
+  if (entry.sizeBytes !== undefined) {
+    target.sizeBytes = entry.sizeBytes;
+  }
+  return target;
+}
+
+export function resolveWorkspaceImageMimeType(
+  pathOrName: string
+): string | null {
+  switch (resolveWorkspaceFileExtension(pathOrName)) {
+    case "avif":
+      return "image/avif";
+    case "gif":
+      return "image/gif";
+    case "jpeg":
+    case "jpg":
+      return "image/jpeg";
+    case "png":
+      return "image/png";
+    case "svg":
+      return "image/svg+xml";
+    case "webp":
+      return "image/webp";
+    default:
+      return null;
+  }
+}
+
+export function resolveWorkspaceVideoMimeType(
+  pathOrName: string
+): string | null {
+  switch (resolveWorkspaceFileExtension(pathOrName)) {
+    case "mp4":
+      return "video/mp4";
+    case "webm":
+      return "video/webm";
+    default:
+      return null;
+  }
+}
+
+export function isWorkspaceFileBrowserHtmlExtension(
+  extension: string
+): boolean {
+  return htmlExtensions.has(extension);
+}
+
+export function isWorkspaceFileImageExtension(extension: string): boolean {
+  return imageExtensions.has(extension);
+}

--- a/packages/workspace/file-preview/src/react/index.ts
+++ b/packages/workspace/file-preview/src/react/index.ts
@@ -1,5 +1,12 @@
 export {
+  toSurfaceState,
+  type WorkspaceFilePreviewSurfaceCopy
+} from "./toSurfaceState.ts";
+export {
   WorkspaceFilePreviewSurface,
+  type WorkspaceFilePreviewHostRenderer,
+  type WorkspaceFilePreviewHostRendererProps,
+  type WorkspaceFilePreviewHostRenderers,
   type WorkspaceFilePreviewSurfaceProps,
   type WorkspaceFilePreviewSurfaceState,
   type WorkspaceFilePreviewSurfaceVariant

--- a/packages/workspace/file-preview/src/react/toSurfaceState.ts
+++ b/packages/workspace/file-preview/src/react/toSurfaceState.ts
@@ -1,0 +1,97 @@
+/**
+ * Projects controller state into surface state with host-provided copy.
+ *
+ * Ownership rules: packages/workspace/file-preview/CONTRACT.md
+ */
+
+import type {
+  WorkspaceFilePreviewControllerState,
+  WorkspaceFilePreviewUnsupportedReason
+} from "../core/workspaceFilePreviewController.ts";
+import type { WorkspaceFilePreviewReadonlyReason } from "../core/workspaceFilePreview.ts";
+import type { WorkspaceFilePreviewKind } from "../core/workspaceFilePreviewKinds.ts";
+import type { WorkspaceFilePreviewSurfaceState } from "./workspaceFilePreviewSurface.tsx";
+
+export interface WorkspaceFilePreviewSurfaceCopy {
+  errorMessage: (error: unknown) => string;
+  readonlyMessage: (
+    reason: WorkspaceFilePreviewReadonlyReason,
+    maxSizeBytes?: number
+  ) => string;
+  unsupportedMessage: (
+    reason: WorkspaceFilePreviewUnsupportedReason,
+    previewKind?: WorkspaceFilePreviewKind
+  ) => string;
+}
+
+/**
+ * Shared projection from machine-readable controller state to the React
+ * surface state. Controllers remain the source of truth; hosts inject copy.
+ */
+export function toSurfaceState<TEntry>(
+  state: WorkspaceFilePreviewControllerState<TEntry>,
+  copy: WorkspaceFilePreviewSurfaceCopy
+): WorkspaceFilePreviewSurfaceState<TEntry> {
+  switch (state.status) {
+    case "empty":
+      return { status: "empty" };
+    case "directory":
+      return { entry: state.entry, status: "directory" };
+    case "loading":
+      return {
+        entry: state.entry,
+        previewKind: state.previewKind,
+        status: "loading"
+      };
+    case "text":
+      return {
+        content: state.content,
+        entry: state.entry,
+        previewKind: state.previewKind,
+        status: "text"
+      };
+    case "image":
+      return {
+        entry: state.entry,
+        objectUrl: state.objectUrl,
+        previewKind: "image",
+        status: "image"
+      };
+    case "video":
+      return {
+        entry: state.entry,
+        objectUrl: state.objectUrl,
+        previewKind: "video",
+        status: "video"
+      };
+    case "bytes":
+      return {
+        bytes: state.bytes,
+        contentType: state.contentType,
+        entry: state.entry,
+        previewKind: state.previewKind,
+        status: "bytes"
+      };
+    case "readonly":
+      return {
+        entry: state.entry,
+        message: copy.readonlyMessage(state.reason, state.maxSizeBytes),
+        previewKind: state.previewKind,
+        status: "readonly"
+      };
+    case "unsupported":
+      return {
+        entry: state.entry,
+        message: copy.unsupportedMessage(state.reason, state.previewKind),
+        previewKind: state.previewKind,
+        status: "unsupported"
+      };
+    case "error":
+      return {
+        entry: state.entry,
+        message: copy.errorMessage(state.error),
+        previewKind: state.previewKind,
+        status: "error"
+      };
+  }
+}

--- a/packages/workspace/file-preview/src/react/workspaceFilePreviewSurface.tsx
+++ b/packages/workspace/file-preview/src/react/workspaceFilePreviewSurface.tsx
@@ -1,20 +1,96 @@
+/**
+ * Thin built-in preview surface (image / video / text) plus host renderer hooks.
+ *
+ * Resolve order: host renderer for previewKind → built-in text degradation →
+ * unsupported/fallback messaging already present in state.
+ *
+ * Ownership rules: packages/workspace/file-preview/CONTRACT.md
+ */
+
 import type { ReactElement, ReactNode } from "react";
+import type { WorkspaceFilePreviewKind } from "../core/workspaceFilePreviewKinds.ts";
 
 export type WorkspaceFilePreviewSurfaceState<TEntry> =
   | { status: "empty" }
   | { entry: TEntry; status: "directory" }
-  | { entry: TEntry; status: "loading" }
-  | { content: string; entry: TEntry; status: "text" }
-  | { entry: TEntry; objectUrl: string; status: "image" }
-  | { entry: TEntry; objectUrl: string; status: "video" }
-  | { entry: TEntry; message: string; status: "readonly" }
-  | { entry: TEntry; message: string; status: "unsupported" }
-  | { entry: TEntry; message: string; status: "error" };
+  | {
+      entry: TEntry;
+      previewKind?: WorkspaceFilePreviewKind;
+      status: "loading";
+    }
+  | {
+      content: string;
+      entry: TEntry;
+      previewKind: WorkspaceFilePreviewKind;
+      status: "text";
+    }
+  | {
+      entry: TEntry;
+      objectUrl: string;
+      previewKind: "image";
+      status: "image";
+    }
+  | {
+      entry: TEntry;
+      objectUrl: string;
+      previewKind: "video";
+      status: "video";
+    }
+  | {
+      bytes: Uint8Array<ArrayBuffer>;
+      contentType: string | null;
+      entry: TEntry;
+      previewKind: WorkspaceFilePreviewKind;
+      status: "bytes";
+    }
+  | {
+      entry: TEntry;
+      message: string;
+      previewKind?: WorkspaceFilePreviewKind;
+      status: "readonly";
+    }
+  | {
+      entry: TEntry;
+      message: string;
+      previewKind?: WorkspaceFilePreviewKind;
+      status: "unsupported";
+    }
+  | {
+      entry: TEntry;
+      message: string;
+      previewKind?: WorkspaceFilePreviewKind;
+      status: "error";
+    };
 
 export type WorkspaceFilePreviewSurfaceVariant =
   | "canvas"
   | "compact"
   | "detail";
+
+export interface WorkspaceFilePreviewHostRendererProps<TEntry> {
+  entry: TEntry;
+  previewKind: WorkspaceFilePreviewKind;
+  variant: WorkspaceFilePreviewSurfaceVariant;
+  /** Present when the controller decoded text (including text-degradable kinds). */
+  content?: string;
+  /** Present for hook-only kinds loaded as raw bytes. */
+  bytes?: Uint8Array<ArrayBuffer>;
+  contentType?: string | null;
+  /** Present for built-in media kinds when a host still overrides rendering. */
+  objectUrl?: string;
+}
+
+export type WorkspaceFilePreviewHostRenderer<TEntry> = (
+  props: WorkspaceFilePreviewHostRendererProps<TEntry>
+) => ReactNode;
+
+/**
+ * Host renderer registry keyed by previewKind. `variant` is passed as props;
+ * optional (kind, variant) specificity may be added later.
+ */
+export type WorkspaceFilePreviewHostRenderers<TEntry> = Partial<
+  Record<WorkspaceFilePreviewKind, WorkspaceFilePreviewHostRenderer<TEntry>>
+>;
 
 export interface WorkspaceFilePreviewSurfaceProps<TEntry> {
   directoryMessage: string;
@@ -22,6 +98,11 @@ export interface WorkspaceFilePreviewSurfaceProps<TEntry> {
   imageAlt: (entry: TEntry) => string;
   loadingIndicator: ReactNode;
   loadingMessage: string;
+  /**
+   * Optional host renderers registered by previewKind. When present for the
+   * current kind, they win over built-in image / video / text shells.
+   */
+  renderers?: WorkspaceFilePreviewHostRenderers<TEntry>;
   renderIcon: (entry: TEntry) => ReactNode;
   state: WorkspaceFilePreviewSurfaceState<TEntry>;
   variant: WorkspaceFilePreviewSurfaceVariant;
@@ -33,11 +114,25 @@ export function WorkspaceFilePreviewSurface<TEntry>({
   imageAlt,
   loadingIndicator,
   loadingMessage,
+  renderers,
   renderIcon,
   state,
   variant
 }: WorkspaceFilePreviewSurfaceProps<TEntry>): ReactElement {
   const styles = workspaceFilePreviewSurfaceStyles[variant];
+  const hostRendered = renderHostPreview({
+    renderers,
+    state,
+    variant
+  });
+  if (hostRendered !== null) {
+    return (
+      <WorkspaceFilePreviewFrame className={styles.frame}>
+        {hostRendered}
+      </WorkspaceFilePreviewFrame>
+    );
+  }
+
   switch (state.status) {
     case "directory":
       return (
@@ -98,6 +193,18 @@ export function WorkspaceFilePreviewSurface<TEntry>({
           />
         </WorkspaceFilePreviewFrame>
       );
+    case "bytes":
+      // Hook-only kinds without a registered renderer fall through to the
+      // unsupported messaging path via host-projected state; if bytes somehow
+      // arrive without a hook, show the generic unsupported shell.
+      return (
+        <WorkspaceFilePreviewFrame className={styles.frame}>
+          <div className="flex flex-col items-center justify-center gap-3 px-4 text-center text-[13px] text-[var(--text-tertiary)]">
+            {renderIcon(state.entry)}
+            <span className={styles.message}>{emptyMessage}</span>
+          </div>
+        </WorkspaceFilePreviewFrame>
+      );
     case "readonly":
     case "unsupported":
     case "error":
@@ -115,6 +222,57 @@ export function WorkspaceFilePreviewSurface<TEntry>({
           <span className={styles.message}>{emptyMessage}</span>
         </WorkspaceFilePreviewFrame>
       );
+  }
+}
+
+function renderHostPreview<TEntry>(input: {
+  renderers: WorkspaceFilePreviewHostRenderers<TEntry> | undefined;
+  state: WorkspaceFilePreviewSurfaceState<TEntry>;
+  variant: WorkspaceFilePreviewSurfaceVariant;
+}): ReactNode | null {
+  const { renderers, state, variant } = input;
+  if (!renderers) {
+    return null;
+  }
+
+  switch (state.status) {
+    case "text": {
+      const renderer = renderers[state.previewKind];
+      return renderer
+        ? renderer({
+            content: state.content,
+            entry: state.entry,
+            previewKind: state.previewKind,
+            variant
+          })
+        : null;
+    }
+    case "image":
+    case "video": {
+      const renderer = renderers[state.previewKind];
+      return renderer
+        ? renderer({
+            entry: state.entry,
+            objectUrl: state.objectUrl,
+            previewKind: state.previewKind,
+            variant
+          })
+        : null;
+    }
+    case "bytes": {
+      const renderer = renderers[state.previewKind];
+      return renderer
+        ? renderer({
+            bytes: state.bytes,
+            contentType: state.contentType,
+            entry: state.entry,
+            previewKind: state.previewKind,
+            variant
+          })
+        : null;
+    }
+    default:
+      return null;
   }
 }
 

--- a/packages/workspace/file-reference/src/contracts/index.ts
+++ b/packages/workspace/file-reference/src/contracts/index.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceFileOpenWithApplication } from "@tutti-os/workspace-file-manager/services";
+import type { WorkspaceFilePreviewKind } from "@tutti-os/workspace-file-preview";
 
 export interface WorkspaceFileReference {
   createdTimeMs?: number | null;
@@ -52,12 +53,13 @@ export interface WorkspaceFileReferenceTreeSnapshot {
   rootPath: string;
 }
 
-export type WorkspaceFileReferencePreviewKind = "image" | "text" | "video";
+/** Optional host override of classified preview kind for a preview read. */
+export type WorkspaceFileReferencePreviewKind = WorkspaceFilePreviewKind;
 
 export interface WorkspaceFileReferencePreview {
   bytes: Uint8Array | ArrayBuffer;
   contentType?: string | null;
-  kind: WorkspaceFileReferencePreviewKind;
+  kind?: WorkspaceFileReferencePreviewKind;
 }
 
 export interface WorkspaceFileReferenceScope {

--- a/packages/workspace/file-reference/src/react/internal/reference/WorkspaceFileReferencePickerController.test.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/WorkspaceFileReferencePickerController.test.ts
@@ -265,6 +265,7 @@ test("workspace file reference picker controller ignores stale preview results",
 
   assert.deepEqual(controller.getSnapshot().previewState, {
     content: "fresh",
+    previewKind: "text",
     reference: {
       kind: "file",
       path: "/workspace/fresh.txt"
@@ -335,6 +336,7 @@ test("workspace file reference picker controller shows html source as text", asy
 
   assert.deepEqual(controller.getSnapshot().previewState, {
     content,
+    previewKind: "text",
     reference: {
       kind: "file",
       path: "/workspace/login.html"

--- a/packages/workspace/file-reference/src/react/internal/reference/WorkspaceFileReferencePickerController.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/WorkspaceFileReferencePickerController.ts
@@ -2,6 +2,7 @@ import { proxy } from "valtio/vanilla";
 import {
   createWorkspaceFilePreviewController,
   type WorkspaceFilePreviewControllerState,
+  type WorkspaceFilePreviewKind,
   type WorkspaceFilePreviewReadonlyReason
 } from "@tutti-os/workspace-file-preview";
 import type {
@@ -21,16 +22,35 @@ export type WorkspaceFileReferencePreviewState =
   | { status: "directory"; reference: WorkspaceFileReference }
   | { status: "empty" }
   | { status: "error"; reference: WorkspaceFileReference }
-  | { status: "image"; objectUrl: string; reference: WorkspaceFileReference }
-  | { status: "loading"; reference: WorkspaceFileReference }
-  | { status: "video"; objectUrl: string; reference: WorkspaceFileReference }
+  | {
+      status: "image";
+      objectUrl: string;
+      previewKind: "image";
+      reference: WorkspaceFileReference;
+    }
+  | {
+      previewKind?: WorkspaceFilePreviewKind;
+      reference: WorkspaceFileReference;
+      status: "loading";
+    }
+  | {
+      status: "video";
+      objectUrl: string;
+      previewKind: "video";
+      reference: WorkspaceFileReference;
+    }
   | {
       maxSizeBytes?: number;
       reason: WorkspaceFilePreviewReadonlyReason;
       reference: WorkspaceFileReference;
       status: "readonly";
     }
-  | { status: "text"; content: string; reference: WorkspaceFileReference }
+  | {
+      status: "text";
+      content: string;
+      previewKind: WorkspaceFilePreviewKind;
+      reference: WorkspaceFileReference;
+    }
   | { status: "unsupported"; reference: WorkspaceFileReference }
   | { status: "unavailable"; reference: WorkspaceFileReference };
 
@@ -139,7 +159,8 @@ export function createWorkspaceFileReferencePickerController(
           return preview
             ? {
                 bytes: preview.bytes,
-                contentType: preview.contentType
+                contentType: preview.contentType,
+                kind: preview.kind
               }
             : null;
         }
@@ -614,20 +635,34 @@ function projectReferencePreviewState(
     case "directory":
       return { reference: state.entry, status: "directory" };
     case "loading":
-      return { reference: state.entry, status: "loading" };
+      return {
+        previewKind: state.previewKind,
+        reference: state.entry,
+        status: "loading"
+      };
     case "text":
       return {
         content: state.content,
+        previewKind: state.previewKind,
         reference: state.entry,
         status: "text"
       };
     case "image":
+      return {
+        objectUrl: state.objectUrl,
+        previewKind: "image",
+        reference: state.entry,
+        status: "image"
+      };
     case "video":
       return {
         objectUrl: state.objectUrl,
+        previewKind: "video",
         reference: state.entry,
-        status: state.status
+        status: "video"
       };
+    case "bytes":
+      return { reference: state.entry, status: "unsupported" };
     case "readonly":
       return {
         maxSizeBytes: state.maxSizeBytes,

--- a/packages/workspace/file-reference/src/react/internal/reference/useReferenceSourcePickerView.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/useReferenceSourcePickerView.ts
@@ -25,6 +25,7 @@ import {
 import {
   createWorkspaceFilePreviewController,
   type WorkspaceFilePreviewControllerState,
+  type WorkspaceFilePreviewKind,
   type WorkspaceFilePreviewReadonlyReason
 } from "@tutti-os/workspace-file-preview";
 import {
@@ -56,22 +57,29 @@ function referenceNodeToOpenWithCacheEntry(
 export type ReferenceNodePreviewState =
   | { status: "empty" }
   | { node: ReferenceNode; status: "directory" }
-  | { node: ReferenceNode; status: "loading" }
+  | {
+      node: ReferenceNode;
+      previewKind?: WorkspaceFilePreviewKind;
+      status: "loading";
+    }
   | {
       content: string;
       node: ReferenceNode;
+      previewKind: WorkspaceFilePreviewKind;
       previewSizeBytes?: number;
       status: "text";
     }
   | {
       node: ReferenceNode;
       objectUrl: string;
+      previewKind: "image";
       previewSizeBytes?: number;
       status: "image";
     }
   | {
       node: ReferenceNode;
       objectUrl: string;
+      previewKind: "video";
       previewSizeBytes?: number;
       status: "video";
     }
@@ -983,22 +991,37 @@ function projectReferenceNodePreviewState(
     case "directory":
       return { node: state.entry, status: "directory" };
     case "loading":
-      return { node: state.entry, status: "loading" };
+      return {
+        node: state.entry,
+        previewKind: state.previewKind,
+        status: "loading"
+      };
     case "text":
       return {
         content: state.content,
         node: state.entry,
+        previewKind: state.previewKind,
         previewSizeBytes: state.previewSizeBytes,
         status: "text"
       };
     case "image":
+      return {
+        node: state.entry,
+        objectUrl: state.objectUrl,
+        previewKind: "image",
+        previewSizeBytes: state.previewSizeBytes,
+        status: "image"
+      };
     case "video":
       return {
         node: state.entry,
         objectUrl: state.objectUrl,
+        previewKind: "video",
         previewSizeBytes: state.previewSizeBytes,
-        status: state.status
+        status: "video"
       };
+    case "bytes":
+      return { node: state.entry, status: "unsupported" };
     case "readonly":
       return {
         maxSizeBytes: state.maxSizeBytes,

--- a/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.tsx
+++ b/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.tsx
@@ -1614,21 +1614,32 @@ function toPreviewSurfaceState(
     case "directory":
       return { entry: node, status: "directory" };
     case "loading":
-      return { entry: node, status: "loading" };
+      return {
+        entry: node,
+        previewKind: previewState.previewKind,
+        status: "loading"
+      };
     case "image":
       return {
         entry: node,
         objectUrl: previewState.objectUrl,
+        previewKind: "image",
         status: "image"
       };
     case "video":
       return {
         entry: node,
         objectUrl: previewState.objectUrl,
+        previewKind: "video",
         status: "video"
       };
     case "text":
-      return { content: previewState.content, entry: node, status: "text" };
+      return {
+        content: previewState.content,
+        entry: node,
+        previewKind: previewState.previewKind,
+        status: "text"
+      };
     case "readonly":
       return {
         entry: node,


### PR DESCRIPTION
## Summary
- Normalize `@tutti-os/workspace-file-preview` to the agreed contract: flat `previewKind`, preview-oriented target naming, host renderer hooks + resolve chain, `toSurfaceState`, and bytes-only `read` shape.
- Move open-with / browser-openable advisories out of preview into `@tutti-os/workspace-file-manager/services`.
- Update Tutti consumers (file-manager, file-reference, desktop workbench/adapters) and document the boundary in `CONTRACT.md`.

## Why merge Tutti first
TSH adaptation should land against this stable published boundary. Landing Tutti first avoids adapting TSH onto a moving API, then rebasing twice.

## Test plan
- [x] `pnpm check:changed` passed on this change set
- [x] Manual Tutti smoke: File Manager preview, Reference picker preview, Workbench open for md/json/html/image/video
- [ ] CI green
- [ ] Reviewer follow-ups already applied locally are reflected in this PR

## Follow-up
After merge + package release/consume path is ready, adapt TSH onto this contract via local link / published version.


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->