### PR TITLE
fix(auth): align desktop session bridge contract

### DIFF
--- a/packages/auth/bridge-go/authbridge_test.go
+++ b/packages/auth/bridge-go/authbridge_test.go
@@ -53,7 +53,7 @@ func TestCallbackCompletesWritesAuthJSONAndRedirectsToWebResult(t *testing.T) {
 	if got := resultURL.Query().Get("desktopBridgeStatus"); got != "success" {
 		t.Fatalf("desktopBridgeStatus = %q", got)
 	}
-	if strings.Contains(location, "transfer-1") || strings.Contains(location, "session-1") {
+	if strings.Contains(location, "transfer-1") || strings.Contains(location, "desktop-session-1") {
 		t.Fatalf("redirect leaked sensitive value: %s", location)
 	}
 	openAppURL := resultURL.Query().Get("openAppUrl")
@@ -73,7 +73,7 @@ func TestCallbackCompletesWritesAuthJSONAndRedirectsToWebResult(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if session == nil || session.SessionID != "session-1" || session.UserID != "user-1" {
+	if session == nil || session.SessionID != "desktop-session-1" || session.UserID != "user-1" {
 		t.Fatalf("session = %#v", session)
 	}
 }
@@ -125,7 +125,7 @@ func TestStartLoginCompletesAndWritesAuthJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if session == nil || session.SessionID != "session-1" || session.UserID != "user-1" {
+	if session == nil || session.SessionID != "desktop-session-1" || session.UserID != "user-1" {
 		t.Fatalf("session = %#v", session)
 	}
 }
@@ -273,7 +273,7 @@ func TestGetUserInfoAndLogout(t *testing.T) {
 	defer account.Close()
 
 	client := newTestClient(t, account.URL)
-	err := client.writeAuthJSON(sessionFromUser("session-1", UserInfo{UserID: "old"}))
+	err := client.writeAuthJSON(sessionFromUser("desktop-session-1", UserInfo{UserID: "old"}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,9 +321,12 @@ func newAccountServer(t *testing.T) *httptest.Server {
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"code": 0,
-				"data": map[string]string{"sessionId": "session-1"},
+				"data": map[string]string{"sessionId": "desktop-session-1"},
 			})
 		case "/user/v1/user_info":
+			if got := r.Header.Get("Cookie"); got != "session_id=desktop-session-1" {
+				t.Errorf("user_info cookie = %q, want redeemed desktop session", got)
+			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"code": 0,
 				"data": map[string]string{
@@ -334,6 +337,16 @@ func newAccountServer(t *testing.T) *httptest.Server {
 				},
 			})
 		case "/auth/v1/logout-web-session":
+			if got := r.Header.Get("Cookie"); got != "session_id=desktop-session-1" {
+				t.Errorf("logout cookie = %q, want redeemed desktop session", got)
+			}
+			var body map[string]string
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode logout body: %v", err)
+			}
+			if strings.TrimSpace(body["app_id"]) == "" {
+				t.Errorf("logout app_id is empty in body %#v", body)
+			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"code": 0, "data": map[string]any{}})
 		default:
 			t.Fatalf("unexpected account path %s", r.URL.Path)

--- a/packages/auth/bridge/README.md
+++ b/packages/auth/bridge/README.md
@@ -21,11 +21,16 @@ import { createTuttiNodeAuthClient } from "@tutti-os/auth-bridge/node";
 
 const auth = createTuttiNodeAuthClient({
   authJsonPath,
-  appCallbackUrl
+  appCallbackUrl,
+  accountHeaders: { "x-environment-lane": "example" }
 });
 
 const { session, user } = await auth.login();
 ```
+
+`accountHeaders` adds host-owned headers to Account API requests. The bridge
+always owns and overwrites its JSON content negotiation and Desktop session
+cookie headers.
 
 ## Local Desktop Callback
 

--- a/packages/auth/bridge/src/node.test.ts
+++ b/packages/auth/bridge/src/node.test.ts
@@ -51,6 +51,12 @@ test("node login completes bridge, redeems transfer code, writes auth json", asy
       authJsonPath: file,
       appCallbackUrl: "tutti://auth/login",
       accountBaseUrl: authBase,
+      accountHeaders: {
+        "x-zk-ppe-lane": "lane-1",
+        accept: "text/plain",
+        "Content-TYPE": "text/plain",
+        cookie: "session_id=attacker"
+      },
       authLoginUrl: `${authBase}/auth/login`,
       openUrl: async (loginUrl) => {
         const state = new URL(loginUrl).searchParams.get("state") ?? "";
@@ -80,14 +86,17 @@ test("node login completes bridge, redeems transfer code, writes auth json", asy
     });
 
     const result = await auth.login();
-    assert.equal(result.session.sessionId, "session-1");
+    assert.equal(result.session.sessionId, "desktop-session-1");
     assert.deepEqual(result.user, {
       userId: "user-1",
       name: "Alice",
       email: "alice@example.com",
       avatar: undefined
     });
-    assert.equal((await readAuthJson(file))?.cookie, "session_id=session-1");
+    assert.equal(
+      (await readAuthJson(file))?.cookie,
+      "session_id=desktop-session-1"
+    );
     assert.deepEqual(accountServer.requests.redeem, {
       transfer_code: "transfer-1",
       attempt_id: accountServer.requests.redeem?.attempt_id,
@@ -95,6 +104,8 @@ test("node login completes bridge, redeems transfer code, writes auth json", asy
       app_id: DEFAULT_APP_ID,
       device_id: accountServer.requests.redeem?.device_id
     });
+    assert.equal(accountServer.requests.headers.redeem, "lane-1");
+    assert.equal(accountServer.requests.headers.userInfo, "lane-1");
   } finally {
     await accountServer.close();
     await rm(dir, { recursive: true, force: true });
@@ -139,8 +150,11 @@ test("node login callback redirects to web result after writing auth json", asyn
     });
 
     const result = await auth.login();
-    assert.equal(result.session.sessionId, "session-1");
-    assert.equal((await readAuthJson(file))?.cookie, "session_id=session-1");
+    assert.equal(result.session.sessionId, "desktop-session-1");
+    assert.equal(
+      (await readAuthJson(file))?.cookie,
+      "session_id=desktop-session-1"
+    );
     assert.deepEqual(accountServer.requests.redeem, {
       transfer_code: "transfer-1",
       attempt_id: accountServer.requests.redeem?.attempt_id,
@@ -200,8 +214,8 @@ test("node getUserInfo refreshes auth json and logout clears it", async () => {
   const accountServer = await startAccountStub();
   try {
     await writeAuthJson(file, {
-      sessionId: "session-1",
-      cookie: "session_id=session-1",
+      sessionId: "desktop-session-1",
+      cookie: "session_id=desktop-session-1",
       userId: "old-user",
       name: "",
       avatar: "",
@@ -211,7 +225,13 @@ test("node getUserInfo refreshes auth json and logout clears it", async () => {
     const auth = createTuttiNodeAuthClient({
       authJsonPath: file,
       appCallbackUrl: "tutti://auth/login",
-      accountBaseUrl: `http://127.0.0.1:${accountServer.port}`
+      accountBaseUrl: `http://127.0.0.1:${accountServer.port}`,
+      accountHeaders: {
+        "x-zk-ppe-lane": "lane-1",
+        accept: "text/plain",
+        "Content-TYPE": "text/plain",
+        cookie: "session_id=attacker"
+      }
     });
     assert.deepEqual(await auth.getUserInfo(), {
       userId: "user-1",
@@ -222,7 +242,9 @@ test("node getUserInfo refreshes auth json and logout clears it", async () => {
     assert.equal((await readAuthJson(file))?.userId, "user-1");
     await auth.logout();
     assert.equal(await readAuthJson(file), null);
-    assert.equal(accountServer.requests.logout?.appId, DEFAULT_APP_ID);
+    assert.equal(accountServer.requests.logout?.app_id, DEFAULT_APP_ID);
+    assert.equal(accountServer.requests.headers.userInfo, "lane-1");
+    assert.equal(accountServer.requests.headers.logout, "lane-1");
   } finally {
     await accountServer.close();
     await rm(dir, { recursive: true, force: true });
@@ -247,21 +269,42 @@ async function startAccountStub(): Promise<{
   requests: {
     redeem?: Record<string, string>;
     logout?: Record<string, string>;
+    headers: {
+      redeem?: string;
+      userInfo?: string;
+      logout?: string;
+    };
   };
   close: () => Promise<void>;
 }> {
   const requests: {
     redeem?: Record<string, string>;
     logout?: Record<string, string>;
-  } = {};
+    headers: {
+      redeem?: string;
+      userInfo?: string;
+      logout?: string;
+    };
+  } = { headers: {} };
   const server = createServer(async (req, res) => {
     if (req.url === "/auth/v1/redeem_desktop_transfer_code") {
+      assert.equal(req.headers.accept, "application/json");
+      assert.equal(req.headers["content-type"], "application/json");
+      assert.equal(req.headers.cookie, undefined);
+      requests.headers.redeem = req.headers["x-zk-ppe-lane"] as
+        | string
+        | undefined;
       requests.redeem = (await readBody(req)) as Record<string, string>;
-      sendJson(res, { code: 0, data: { session_id: "session-1" } });
+      sendJson(res, { code: 0, data: { session_id: "desktop-session-1" } });
       return;
     }
     if (req.url === "/user/v1/user_info") {
-      assert.equal(req.headers.cookie, "session_id=session-1");
+      assert.equal(req.headers.accept, "application/json");
+      assert.equal(req.headers["content-type"], "application/json");
+      requests.headers.userInfo = req.headers["x-zk-ppe-lane"] as
+        | string
+        | undefined;
+      assert.equal(req.headers.cookie, "session_id=desktop-session-1");
       sendJson(res, {
         code: 0,
         data: { user_id: "user-1", name: "Alice", email: "alice@example.com" }
@@ -269,8 +312,13 @@ async function startAccountStub(): Promise<{
       return;
     }
     if (req.url === "/auth/v1/logout-web-session") {
+      assert.equal(req.headers.accept, "application/json");
+      assert.equal(req.headers["content-type"], "application/json");
+      requests.headers.logout = req.headers["x-zk-ppe-lane"] as
+        | string
+        | undefined;
       requests.logout = (await readBody(req)) as Record<string, string>;
-      assert.equal(req.headers.cookie, "session_id=session-1");
+      assert.equal(req.headers.cookie, "session_id=desktop-session-1");
       sendJson(res, { code: 0 });
       return;
     }

--- a/packages/auth/bridge/src/node.ts
+++ b/packages/auth/bridge/src/node.ts
@@ -42,6 +42,7 @@ export interface TuttiNodeAuthClientOptions {
   hostname?: string;
   loginIdleTimeoutMs?: number;
   loginMaxTimeoutMs?: number;
+  accountHeaders?: Readonly<Record<string, string>>;
 }
 
 export interface TuttiNodeAuthClient {
@@ -69,6 +70,7 @@ type BridgeState = {
 };
 
 type PendingLogin = {
+  accountHeaders: Readonly<Record<string, string>>;
   accountBaseUrl: string;
   appId: string;
   appCallbackUrl: string;
@@ -117,6 +119,7 @@ export function createTuttiNodeAuthClient(
     idleTimeoutMs,
     positiveMs(options.loginMaxTimeoutMs, DEFAULT_LOGIN_MAX_TIMEOUT_MS)
   );
+  const accountHeaders = { ...options.accountHeaders };
 
   async function readSession(): Promise<TuttiAuthSession | null> {
     return await readAuthJson(authJsonPath);
@@ -131,7 +134,11 @@ export function createTuttiNodeAuthClient(
     if (!session) {
       return null;
     }
-    const user = await fetchUserInfo(accountBaseUrl, session.cookie);
+    const user = await fetchUserInfo(
+      accountBaseUrl,
+      session.cookie,
+      accountHeaders
+    );
     if (!user) {
       return null;
     }
@@ -161,6 +168,7 @@ export function createTuttiNodeAuthClient(
         hostname: options.hostname?.trim() || hostname()
       });
       const pending: PendingLogin = {
+        accountHeaders,
         accountBaseUrl,
         appId,
         appCallbackUrl,
@@ -196,7 +204,12 @@ export function createTuttiNodeAuthClient(
     logout: async (): Promise<void> => {
       const session = await readSession();
       if (session) {
-        await logoutSession(accountBaseUrl, appId, session.cookie);
+        await logoutSession(
+          accountBaseUrl,
+          appId,
+          session.cookie,
+          accountHeaders
+        );
       }
       await clearSession();
     },
@@ -496,7 +509,8 @@ async function completePendingLogin(
   const sessionId = await redeemDesktopTransferCode(input, transferCode);
   const user = await fetchUserInfo(
     input.accountBaseUrl,
-    buildSessionCookie(sessionId)
+    buildSessionCookie(sessionId),
+    input.accountHeaders
   );
   if (!user) {
     throw new Error("Failed to load user info after login");
@@ -528,17 +542,14 @@ async function waitForCompletion(
 
 async function fetchUserInfo(
   accountBaseUrl: string,
-  cookie: string
+  cookie: string,
+  accountHeaders: Readonly<Record<string, string>>
 ): Promise<TuttiUserInfo | null> {
   const response = await fetch(
     buildAccountUrl(accountBaseUrl, "/user/v1/user_info"),
     {
       method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-        Cookie: cookie
-      },
+      headers: buildAccountHeaders(accountHeaders, cookie),
       body: JSON.stringify({})
     }
   );
@@ -565,10 +576,7 @@ async function redeemDesktopTransferCode(
     ),
     {
       method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json"
-      },
+      headers: buildAccountHeaders(input.accountHeaders),
       body: JSON.stringify({
         transfer_code: transferCode,
         attempt_id: input.attemptId,
@@ -594,18 +602,15 @@ async function redeemDesktopTransferCode(
 async function logoutSession(
   accountBaseUrl: string,
   appId: string,
-  cookie: string
+  cookie: string,
+  accountHeaders: Readonly<Record<string, string>>
 ): Promise<void> {
   const response = await fetch(
     buildAccountUrl(accountBaseUrl, "/auth/v1/logout-web-session"),
     {
       method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-        Cookie: cookie
-      },
-      body: JSON.stringify({ appId })
+      headers: buildAccountHeaders(accountHeaders, cookie),
+      body: JSON.stringify({ app_id: appId })
     }
   );
   const payload = (await response.json().catch(() => null)) as AccountEnvelope<
@@ -614,6 +619,21 @@ async function logoutSession(
   if (!response.ok || (payload?.code ?? 0) !== 0) {
     throw readEnvelopeError(response, payload);
   }
+}
+
+function buildAccountHeaders(
+  accountHeaders: Readonly<Record<string, string>>,
+  cookie?: string
+): Headers {
+  const headers = new Headers(accountHeaders);
+  headers.set("Accept", "application/json");
+  headers.set("Content-Type", "application/json");
+  if (cookie) {
+    headers.set("Cookie", cookie);
+  } else {
+    headers.delete("Cookie");
+  }
+  return headers;
 }
 
 async function findAvailablePort(): Promise<number> {


### PR DESCRIPTION
## Summary
- expose host-owned Account request headers from the Node auth bridge for environment routing
- protect bridge-owned JSON and Desktop Cookie headers against case-insensitive collisions
- align logout payloads on app_id and prove Node/Go use the redeemed Desktop session

## Verification
- auth bridge Node tests: 8 passed
- auth bridge TypeScript type-check and package build
- auth bridge Go tests passed
- format, oxlint and git diff --check
- independent security re-review passed

## Follow-up
After merge, publish the complete Tutti package cohort. TSH must upgrade the released cohort atomically before consuming accountHeaders.

## Known baseline
The repository push-ready changed-package check also reports two pre-existing findings in unchanged packages/auth/bridge-go/authbridge.go: forbidden http.DefaultClient usage and the file exceeding 800 lines.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->