### PR TITLE
fix(agent): forward durable submit provenance in host adapter

### DIFF
--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -23,6 +23,7 @@ type RuntimeBackend interface {
 	State(string, string) (agentruntime.SessionStateSnapshot, error)
 	CanResume(agentruntime.ResumeInput) bool
 	Exec(context.Context, agentruntime.ExecInput) (agentruntime.ExecResult, error)
+	DurablyReportSubmitProvenance(context.Context, agentruntime.SubmitProvenanceInput) error
 	ValidatePromptContent(context.Context, agentruntime.ExecInput) error
 	Cancel(context.Context, agentruntime.CancelInput) (agentruntime.CancelResult, error)
 	SubmitInteractive(context.Context, agentruntime.SubmitInteractiveInput) (agentruntime.SubmitInteractiveResult, error)
@@ -44,6 +45,7 @@ type RuntimeController struct {
 
 var (
 	_ host.RuntimeController                 = (*RuntimeController)(nil)
+	_ host.RuntimeSubmitProvenanceReporter   = (*RuntimeController)(nil)
 	_ host.GoalRuntimeController             = (*RuntimeController)(nil)
 	_ host.GoalRuntimeReconciler             = (*RuntimeController)(nil)
 	_ host.GoalRuntimeRecoveryPolicyResolver = (*RuntimeController)(nil)
@@ -128,6 +130,13 @@ func (a *RuntimeController) Exec(ctx context.Context, input host.RuntimeExecInpu
 			State: result.SubmitAvailability.State, Reason: result.SubmitAvailability.Reason,
 		},
 	}, mapRuntimeError(err)
+}
+
+func (a *RuntimeController) DurablyReportSubmitProvenance(ctx context.Context, input host.RuntimeSubmitProvenanceInput) error {
+	if err := a.requireBackend(); err != nil {
+		return err
+	}
+	return mapRuntimeError(a.Backend.DurablyReportSubmitProvenance(ctx, runtimeSubmitProvenanceInput(input)))
 }
 
 func (a *RuntimeController) ValidatePromptContent(ctx context.Context, input host.RuntimeExecInput) error {
@@ -354,17 +363,55 @@ func runtimeResumeInput(input host.RuntimeResumeInput) agentruntime.ResumeInput 
 }
 
 func runtimeExecInput(input host.RuntimeExecInput) agentruntime.ExecInput {
-	content := make([]agentruntime.PromptContentBlock, 0, len(input.Content))
-	for _, block := range input.Content {
+	return agentruntime.ExecInput{
+		RoomID: input.WorkspaceID, AgentSessionID: input.AgentSessionID,
+		TurnID: input.TurnID, ClientSubmitID: input.ClientSubmitID,
+		CapabilityRefs:    runtimeCapabilityReferences(input.CapabilityRefs),
+		TuttiModeSnapshot: runtimeTuttiModeSnapshot(input.TuttiModeSnapshot),
+		Content:           runtimePromptContent(input.Content),
+		DisplayPrompt:     input.DisplayPrompt, InitialTitle: input.InitialTitle, InitialTitleBase: input.InitialTitleBase,
+		Metadata: cloneMap(input.Metadata), Guidance: input.Guidance,
+	}
+}
+
+func runtimeSubmitProvenanceInput(input host.RuntimeSubmitProvenanceInput) agentruntime.SubmitProvenanceInput {
+	return agentruntime.SubmitProvenanceInput{
+		RoomID: input.WorkspaceID, AgentSessionID: input.AgentSessionID,
+		TurnID: input.TurnID, ClientSubmitID: input.ClientSubmitID,
+		Content: runtimePromptContent(input.Content), DisplayPrompt: input.DisplayPrompt,
+		Guidance: input.Guidance,
+	}
+}
+
+func runtimePromptContent(input []host.PromptContentBlock) []agentruntime.PromptContentBlock {
+	content := make([]agentruntime.PromptContentBlock, 0, len(input))
+	for _, block := range input {
 		content = append(content, agentruntime.PromptContentBlock{
 			Type: block.Type, Text: block.Text, MimeType: block.MimeType, Data: block.Data, URL: block.URL,
 			AttachmentID: block.AttachmentID, Name: block.Name, Path: block.Path,
 		})
 	}
-	return agentruntime.ExecInput{
-		RoomID: input.WorkspaceID, AgentSessionID: input.AgentSessionID, Content: content,
-		DisplayPrompt: input.DisplayPrompt, InitialTitle: input.InitialTitle, InitialTitleBase: input.InitialTitleBase,
-		Metadata: cloneMap(input.Metadata), Guidance: input.Guidance,
+	return content
+}
+
+func runtimeCapabilityReferences(input []host.CapabilityReference) []agentruntime.CapabilityReference {
+	references := make([]agentruntime.CapabilityReference, 0, len(input))
+	for _, reference := range input {
+		references = append(references, agentruntime.CapabilityReference{
+			Capability: reference.Capability,
+			Source:     reference.Source,
+		})
+	}
+	return references
+}
+
+func runtimeTuttiModeSnapshot(input *host.TuttiModeTurnSnapshot) *agentruntime.TuttiModeTurnSnapshot {
+	if input == nil {
+		return nil
+	}
+	return &agentruntime.TuttiModeTurnSnapshot{
+		ActivationID: input.ActivationID, RevisionID: input.RevisionID, Revision: input.Revision,
+		State: input.State, Source: input.Source, OrchestrationIntensity: input.OrchestrationIntensity,
 	}
 }
 

--- a/packages/agent/daemon/hostadapter/runtime_test.go
+++ b/packages/agent/daemon/hostadapter/runtime_test.go
@@ -17,6 +17,17 @@ type stateRuntimeBackend struct {
 	stateErr error
 }
 
+type provenanceRuntimeBackend struct {
+	RuntimeBackend
+	input agentruntime.SubmitProvenanceInput
+	err   error
+}
+
+func (b *provenanceRuntimeBackend) DurablyReportSubmitProvenance(_ context.Context, input agentruntime.SubmitProvenanceInput) error {
+	b.input = input
+	return b.err
+}
+
 func (b *stateRuntimeBackend) Session(_, _ string) (agentruntime.Session, bool) {
 	return b.session, true
 }
@@ -151,5 +162,52 @@ func TestRuntimeControllerFailsClosedWithoutBackend(t *testing.T) {
 	}
 	if controller.CanResume(host.RuntimeResumeInput{}) {
 		t.Fatal("CanResume reported support without a runtime backend")
+	}
+}
+
+func TestRuntimeControllerDelegatesDurableSubmitProvenance(t *testing.T) {
+	backend := &provenanceRuntimeBackend{}
+	controller := &RuntimeController{Backend: backend}
+	input := host.RuntimeSubmitProvenanceInput{
+		WorkspaceID: " workspace-1 ", AgentSessionID: "session-1", TurnID: "turn-1",
+		ClientSubmitID: "submit-1", DisplayPrompt: "display", Guidance: true,
+		Content: []host.PromptContentBlock{{Type: "text", Text: "hello"}},
+	}
+
+	if err := controller.DurablyReportSubmitProvenance(t.Context(), input); err != nil {
+		t.Fatal(err)
+	}
+	if backend.input.RoomID != input.WorkspaceID || backend.input.AgentSessionID != input.AgentSessionID ||
+		backend.input.TurnID != input.TurnID || backend.input.ClientSubmitID != input.ClientSubmitID ||
+		backend.input.DisplayPrompt != input.DisplayPrompt || !backend.input.Guidance {
+		t.Fatalf("delegated provenance = %#v", backend.input)
+	}
+	if len(backend.input.Content) != 1 || backend.input.Content[0].Text != "hello" {
+		t.Fatalf("delegated content = %#v", backend.input.Content)
+	}
+}
+
+func TestRuntimeControllerPreservesTypedExecIdentity(t *testing.T) {
+	input := host.RuntimeExecInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", TurnID: "turn-1", ClientSubmitID: "submit-1",
+		CapabilityRefs: []host.CapabilityReference{{Capability: "browser-use", Source: "composer"}},
+		TuttiModeSnapshot: &host.TuttiModeTurnSnapshot{
+			ActivationID: "activation-1", RevisionID: "revision-1", Revision: 2,
+			State: "active", Source: "workspace", OrchestrationIntensity: 75,
+		},
+	}
+
+	projected := runtimeExecInput(input)
+	if projected.TurnID != input.TurnID || projected.ClientSubmitID != input.ClientSubmitID {
+		t.Fatalf("projected exec identity = %#v", projected)
+	}
+	if len(projected.CapabilityRefs) != 1 || projected.CapabilityRefs[0].Capability != "browser-use" || projected.CapabilityRefs[0].Source != "composer" {
+		t.Fatalf("projected capability refs = %#v", projected.CapabilityRefs)
+	}
+	if projected.TuttiModeSnapshot == nil || projected.TuttiModeSnapshot.ActivationID != "activation-1" ||
+		projected.TuttiModeSnapshot.RevisionID != "revision-1" || projected.TuttiModeSnapshot.Revision != 2 ||
+		projected.TuttiModeSnapshot.State != "active" || projected.TuttiModeSnapshot.Source != "workspace" ||
+		projected.TuttiModeSnapshot.OrchestrationIntensity != 75 {
+		t.Fatalf("projected Tutti Mode snapshot = %#v", projected.TuttiModeSnapshot)
 	}
 }


### PR DESCRIPTION
## What changed

- make `daemon/hostadapter.RuntimeBackend` require durable submit provenance reporting
- have the shared Host adapter implement and forward `host.RuntimeSubmitProvenanceReporter`
- preserve typed turn/submit identity, capability references, and Tutti Mode snapshots when mapping Host exec input to daemon runtime input
- add adapter regression tests for durability delegation and typed exec identity

## Why

The daemon runtime already waits for an atomic canonical client-submit message, but the shared `daemon/hostadapter` did not expose that capability to Agent Host. Host consumers such as TSH therefore skipped the durability barrier after provider acceptance. The adapter also dropped newly added typed exec fields, which could make the runtime return a different Turn identity than the canonical submit claim.

This is adapter translation only; Agent Host lifecycle semantics remain unchanged.

## Risk

The `RuntimeBackend` interface gains a required method. The production `*runtime.Controller` already implements it; custom test or downstream backends now fail at compile time instead of silently skipping the durability contract.

## Verification

- `go test ./packages/agent/daemon/hostadapter ./packages/agent/daemon/runtime ./packages/agent/host/...`
- `pnpm check:changed -- --push-ready` (8 lanes)
- `git diff --check`
- independent subagent review: no blocking findings

## Documentation impact

No documentation update is required: `packages/agent/daemon/README.md` and the existing architecture docs already define the durable provenance contract and the shared host adapter as the owning bridge. This change makes the implementation match that documented contract.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->