### PR TITLE
feat(agent): share tutti-agent managed runtime contracts

### DIFF
--- a/.changeset/tutti-agent-managed-runtime-contracts.md
+++ b/.changeset/tutti-agent-managed-runtime-contracts.md
@@ -1,0 +1,8 @@
+---
+"@tutti-os/desktop": patch
+---
+
+Make Tutti Agent managed installation reproducible with an exact tested npm
+version and complete platform-package registry ranking, expose host-neutral
+authentication reconciliation, and allow VM-backed hosts to inject a canonical
+auth source into session runtime preparation.

--- a/docs/architecture/tutti-agent-readiness-bootstrap.md
+++ b/docs/architecture/tutti-agent-readiness-bootstrap.md
@@ -24,6 +24,7 @@ with:
 - binary: `tutti-agent`;
 - adapter command: `tutti-agent app-server`;
 - minimum CLI version: the registry's `TuttiAgentMinVersion`;
+- tested install version: the registry's `TuttiAgentRecommendedVersion`;
 - auth marker: `~/.tutti-agent/auth.json`;
 - installer: registry kind `InstallerKindManagedNPM` (mapped to agentstatus
   `InstallerKindManagedNPMPackage`) for
@@ -39,13 +40,15 @@ The managed installer places the package in a global prefix searched by the
 daemon binary resolver. It also repairs an existing npm-owned installation in
 place when the launcher or a platform package is broken.
 
-New installs and minimum-version repairs install the current published package;
-the minimum is a compatibility floor, not an exact-version pin. The effective
-command has this shape:
+New installs and minimum-version repairs install the descriptor's exact tested
+`RecommendedVersion`. `MinVersion` remains the compatibility floor: an existing
+runtime at or above it is reused without contacting npm. Keeping these values
+separate makes installation reproducible and permits an explicit downgrade
+during rollback. The effective command has this shape:
 
 ```text
 npm install -g --prefix <managed-or-existing-prefix> \
-  @tutti-os/tutti-agent --include=optional
+  @tutti-os/tutti-agent@<recommended-version> --include=optional
 ```
 
 `--include=optional` is required because the CLI depends on platform-specific
@@ -58,9 +61,12 @@ Registry selection follows the shared agent npm registry policy:
 2. otherwise the installer ranks and retries the configured official and mirror
    registries for the exact package being installed.
 
-The mirrors must contain both the aggregate package and its matching platform
-dependencies. A partially synchronized mirror can otherwise produce an npm
-success followed by an unusable launcher.
+The shared `packages/agent/daemon/managednpm` policy ranks registries in the
+runtime's own network. A registry is eligible only when it contains the exact
+aggregate version and the matching optional platform package. A fast but
+partially synchronized mirror is ranked behind complete sources. Installation
+still verifies the binary, native payload, and app-server rather than trusting
+metadata or npm's exit status.
 
 ## Desktop Proactive Install
 
@@ -106,6 +112,19 @@ account logout completed
   -> revoke the removed LLM refresh token in the background
 ```
 
+The host-neutral ordering and compensation rules live in
+`packages/agent/daemon/tuttiagentauth`; the Tutti daemon supplies the Account,
+credential-file, and local CLI adapters. Another host may supply VM-backed
+adapters without importing Tutti product paths or account-session storage. One
+reconciler instance serializes mutations of one canonical credential file.
+Hosts must run local cleanup on logout/account switch before reconciling the
+next account; this does not require a user ID in the credential path.
+
+Reconciliation only establishes usable credential material. It does not prove
+that the provider accepts the credential and must not be treated as an
+authenticated or ready product state. Every host must run a provider probe
+after reconciliation and publish readiness from that authoritative probe.
+
 The same auth bootstrap runs once when the daemon starts and before each Tutti
 Agent runtime preparation. These fallback entry points cover a login completed
 before callback wiring, a transient token failure, or a stale provider auth
@@ -133,6 +152,10 @@ refresh so setup UI can move between `not_installed`, `auth_required`, and
 - Rendering an AgentGUI item never installs a provider.
 - Only `tutti-agent` uses proactive installation.
 - Installation completion is determined by a fresh provider probe.
+- Missing, unknown, or below-floor versions install the exact recommended
+  version; compatible versions do not contact a registry.
+- Registry ranking happens where npm will run and rejects incomplete platform
+  packages before comparing speed.
 - A Tutti Agent below `TuttiAgentMinVersion` is not ready and is repaired by
   the same proactive install path as a missing CLI.
 - Desktop account credentials and Tutti LLM tokens never pass through renderer

--- a/packages/agent/daemon/managednpm/descriptor.go
+++ b/packages/agent/daemon/managednpm/descriptor.go
@@ -1,0 +1,46 @@
+// Package managednpm defines the reusable policy for provider runtimes that
+// are distributed as npm packages. Hosts retain ownership of command
+// execution, filesystem paths, credentials, and VM transport.
+package managednpm
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	packageNamePattern = regexp.MustCompile(`^(?:@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$`)
+	binaryNamePattern  = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+)
+
+// Descriptor is data, not an executable install plan. In particular it does
+// not accept shell commands, arbitrary environment variables, or paths.
+type Descriptor struct {
+	PackageName        string
+	BinaryName         string
+	MinimumVersion     string
+	RecommendedVersion string
+	IncludeOptional    bool
+}
+
+func (d Descriptor) Validate() error {
+	if d.PackageName != strings.TrimSpace(d.PackageName) || !packageNamePattern.MatchString(d.PackageName) {
+		return fmt.Errorf("managed npm package name is invalid")
+	}
+	if d.BinaryName != strings.TrimSpace(d.BinaryName) || !binaryNamePattern.MatchString(d.BinaryName) {
+		return fmt.Errorf("managed npm binary name is invalid")
+	}
+	minimum, ok := parseStableVersion(d.MinimumVersion)
+	if !ok {
+		return fmt.Errorf("managed npm minimum version must be a stable x.y.z version")
+	}
+	recommended, ok := parseStableVersion(d.RecommendedVersion)
+	if !ok {
+		return fmt.Errorf("managed npm recommended version must be a stable x.y.z version")
+	}
+	if compareVersions(recommended, minimum) < 0 {
+		return fmt.Errorf("managed npm recommended version is below the minimum version")
+	}
+	return nil
+}

--- a/packages/agent/daemon/managednpm/managednpm_test.go
+++ b/packages/agent/daemon/managednpm/managednpm_test.go
@@ -1,0 +1,120 @@
+package managednpm
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDescriptorValidationAndVersionDecision(t *testing.T) {
+	descriptor := Descriptor{PackageName: "@tutti-os/tutti-agent", BinaryName: "tutti-agent", MinimumVersion: "0.0.4", RecommendedVersion: "0.0.4", IncludeOptional: true}
+	if err := descriptor.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	want := map[string]VersionDecision{
+		"":                  VersionDecisionInstallMissing,
+		"unknown":           VersionDecisionInstallUnknown,
+		"tutti-agent 0.0.3": VersionDecisionInstallBelowFloor,
+		"tutti-agent 0.0.4": VersionDecisionReady,
+		"tutti-agent 1.0.0": VersionDecisionReady,
+	}
+	for output, expected := range want {
+		if got := DecideVersion(output, descriptor.MinimumVersion); got != expected {
+			t.Fatalf("DecideVersion(%q) = %q, want %q", output, got, expected)
+		}
+	}
+	for _, output := range []string{"tutti-agent 0.0.4-beta.1", "tutti-agent 0.0.4.1"} {
+		if got := DecideVersion(output, descriptor.MinimumVersion); got != VersionDecisionInstallUnknown {
+			t.Fatalf("DecideVersion(%q) = %q, want %q", output, got, VersionDecisionInstallUnknown)
+		}
+	}
+	descriptor.PackageName = " @tutti-os/tutti-agent"
+	if err := descriptor.Validate(); err == nil {
+		t.Fatal("Validate() error = nil, want non-canonical package rejection")
+	}
+	descriptor.PackageName = "@tutti-os/tutti-agent"
+	descriptor.RecommendedVersion = "0.0.3"
+	if err := descriptor.Validate(); err == nil {
+		t.Fatal("Validate() error = nil, want recommended-below-floor rejection")
+	}
+}
+
+func TestRankRegistriesRequiresCompletenessAndAvoidsTimingNoise(t *testing.T) {
+	descriptor := Descriptor{PackageName: "@tutti-os/tutti-agent", BinaryName: "tutti-agent", MinimumVersion: "0.0.4", RecommendedVersion: "0.0.4", IncludeOptional: true}
+	prober := fakeExecutor{registryProbes: map[string]RegistryProbeResult{
+		"official": {Reachable: true, Complete: true, Duration: 90 * time.Millisecond},
+		"fast-bad": {Reachable: true, Complete: false, Duration: 5 * time.Millisecond},
+		"mirror":   {Reachable: true, Complete: true, Duration: 20 * time.Millisecond},
+	}}
+	registries := []Registry{{ID: "official"}, {ID: "fast-bad"}, {ID: "mirror"}}
+	ranked := RankRegistries(context.Background(), descriptor, registries, "linux", "arm64", &prober)
+	got := []string{ranked[0].Registry.ID, ranked[1].Registry.ID, ranked[2].Registry.ID}
+	if want := []string{"mirror", "official", "fast-bad"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("RankRegistries() = %#v, want %#v", got, want)
+	}
+}
+
+func TestRankRegistriesUsesTransitiveFastBand(t *testing.T) {
+	descriptor := testDescriptor()
+	prober := fakeExecutor{registryProbes: map[string]RegistryProbeResult{
+		"slow": {Reachable: true, Complete: true, Duration: 40 * time.Millisecond},
+		"near": {Reachable: true, Complete: true, Duration: 20 * time.Millisecond},
+		"fast": {Reachable: true, Complete: true, Duration: 1 * time.Millisecond},
+	}}
+	ranked := RankRegistries(context.Background(), descriptor, []Registry{{ID: "slow"}, {ID: "near"}, {ID: "fast"}}, "linux", "arm64", &prober)
+	got := []string{ranked[0].Registry.ID, ranked[1].Registry.ID, ranked[2].Registry.ID}
+	if want := []string{"near", "fast", "slow"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("RankRegistries() = %#v, want %#v", got, want)
+	}
+}
+
+func TestResolveOptionalPlatformPackageSupportsNPMAlias(t *testing.T) {
+	targets := []struct {
+		goOS, goArch   string
+		npmOS, npmArch string
+	}{
+		{goOS: "linux", goArch: "amd64", npmOS: "linux", npmArch: "x64"},
+		{goOS: "linux", goArch: "arm64", npmOS: "linux", npmArch: "arm64"},
+		{goOS: "darwin", goArch: "amd64", npmOS: "darwin", npmArch: "x64"},
+		{goOS: "darwin", goArch: "arm64", npmOS: "darwin", npmArch: "arm64"},
+		{goOS: "windows", goArch: "amd64", npmOS: "win32", npmArch: "x64"},
+		{goOS: "windows", goArch: "arm64", npmOS: "win32", npmArch: "arm64"},
+	}
+	for _, target := range targets {
+		t.Run(target.goOS+"-"+target.goArch, func(t *testing.T) {
+			alias := "@tutti-os/tutti-agent-" + target.npmOS + "-" + target.npmArch
+			version := "0.0.5-" + target.npmOS + "-" + target.npmArch
+			name, gotVersion, ok := ResolveOptionalPlatformPackage(
+				"@tutti-os/tutti-agent",
+				map[string]string{alias: "npm:@tutti-os/tutti-agent@" + version},
+				target.goOS,
+				target.goArch,
+			)
+			if !ok || name != "@tutti-os/tutti-agent" || gotVersion != version {
+				t.Fatalf("ResolveOptionalPlatformPackage() = %q, %q, %v", name, gotVersion, ok)
+			}
+		})
+	}
+	if _, _, ok := ResolveOptionalPlatformPackage("@tutti-os/tutti-agent", nil, "freebsd", "amd64"); ok {
+		t.Fatal("ResolveOptionalPlatformPackage() accepted unsupported target")
+	}
+}
+
+func testDescriptor() Descriptor {
+	return Descriptor{PackageName: "@tutti-os/tutti-agent", BinaryName: "tutti-agent", MinimumVersion: "0.0.4", RecommendedVersion: "0.0.4", IncludeOptional: true}
+}
+
+type fakeExecutor struct {
+	registryProbes     map[string]RegistryProbeResult
+	registryProbeMu    sync.Mutex
+	registryProbeCalls int
+}
+
+func (f *fakeExecutor) ProbeRegistry(_ context.Context, request RegistryProbeRequest) RegistryProbeResult {
+	f.registryProbeMu.Lock()
+	f.registryProbeCalls++
+	f.registryProbeMu.Unlock()
+	return f.registryProbes[request.Registry.ID]
+}

--- a/packages/agent/daemon/managednpm/registry.go
+++ b/packages/agent/daemon/managednpm/registry.go
@@ -1,0 +1,197 @@
+package managednpm
+
+import (
+	"context"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	RegistryOverrideEnv = "TUTTI_AGENT_NPM_REGISTRY"
+	OfficialRegistryURL = "https://registry.npmjs.org"
+	HuaweiRegistryURL   = "https://repo.huaweicloud.com/repository/npm/"
+	TencentRegistryURL  = "https://mirrors.cloud.tencent.com/npm/"
+	DefaultProbeTimeout = 5 * time.Second
+	MinimumRankDelta    = 25 * time.Millisecond
+)
+
+type Registry struct {
+	ID     string
+	URL    string
+	Pinned bool
+}
+
+func ResolveOptionalPlatformPackage(packageName string, optionalDependencies map[string]string, platformOS string, platformArch string) (string, string, bool) {
+	packageName = strings.TrimSpace(packageName)
+	platformOS, platformArch, platformOK := NPMPlatform(platformOS, platformArch)
+	if packageName == "" || !platformOK {
+		return "", "", false
+	}
+	separator := strings.LastIndex(packageName, "/")
+	prefix, name := "", packageName
+	if separator >= 0 {
+		prefix, name = packageName[:separator+1], packageName[separator+1:]
+	}
+	dependencyName := prefix + name + "-" + platformOS + "-" + platformArch
+	spec := strings.TrimSpace(optionalDependencies[dependencyName])
+	if spec == "" {
+		return "", "", false
+	}
+	if !strings.HasPrefix(spec, "npm:") {
+		return dependencyName, spec, true
+	}
+	aliased := strings.TrimPrefix(spec, "npm:")
+	versionSeparator := strings.LastIndex(aliased, "@")
+	if versionSeparator <= 0 || versionSeparator == len(aliased)-1 {
+		return "", "", false
+	}
+	return aliased[:versionSeparator], aliased[versionSeparator+1:], true
+}
+
+// NPMPlatform maps Go target names to the operating-system and architecture
+// suffixes used by npm platform packages. It also accepts already-canonical
+// npm names so hosts do not need their own platform mapping tables.
+func NPMPlatform(platformOS string, platformArch string) (string, string, bool) {
+	switch strings.TrimSpace(platformOS) {
+	case "linux":
+		platformOS = "linux"
+	case "darwin":
+		platformOS = "darwin"
+	case "windows", "win32":
+		platformOS = "win32"
+	default:
+		return "", "", false
+	}
+	switch strings.TrimSpace(platformArch) {
+	case "amd64", "x64":
+		platformArch = "x64"
+	case "arm64":
+		platformArch = "arm64"
+	default:
+		return "", "", false
+	}
+	return platformOS, platformArch, true
+}
+
+type RegistryProbeRequest struct {
+	Registry        Registry
+	PackageName     string
+	Version         string
+	IncludeOptional bool
+	OperatingSystem string
+	Architecture    string
+}
+
+type RegistryProbeResult struct {
+	Reachable bool
+	Complete  bool
+	Duration  time.Duration
+}
+
+type RegistryProber interface {
+	ProbeRegistry(context.Context, RegistryProbeRequest) RegistryProbeResult
+}
+
+type RankedRegistry struct {
+	Registry Registry
+	Probe    RegistryProbeResult
+}
+
+func DefaultRegistries(override string) []Registry {
+	if value := strings.TrimSpace(override); value != "" {
+		return []Registry{{ID: "override", URL: value, Pinned: true}}
+	}
+	return []Registry{
+		{ID: "npm", URL: OfficialRegistryURL},
+		{ID: "huawei", URL: HuaweiRegistryURL},
+		{ID: "tencent", URL: TencentRegistryURL},
+	}
+}
+
+func RankRegistries(ctx context.Context, descriptor Descriptor, registries []Registry, platformOS string, platformArch string, prober RegistryProber) []RankedRegistry {
+	if len(registries) == 0 || prober == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	type indexedResult struct {
+		index int
+		RankedRegistry
+	}
+	results := make(chan indexedResult, len(registries))
+	for index, registry := range registries {
+		go func(index int, registry Registry) {
+			probeCtx, cancel := context.WithTimeout(ctx, DefaultProbeTimeout)
+			defer cancel()
+			startedAt := time.Now()
+			probe := prober.ProbeRegistry(probeCtx, RegistryProbeRequest{
+				Registry: registry, PackageName: descriptor.PackageName,
+				Version: descriptor.RecommendedVersion, IncludeOptional: descriptor.IncludeOptional,
+				OperatingSystem: platformOS, Architecture: platformArch,
+			})
+			if probe.Duration <= 0 {
+				probe.Duration = time.Since(startedAt)
+			}
+			results <- indexedResult{index: index, RankedRegistry: RankedRegistry{Registry: registry, Probe: probe}}
+		}(index, registry)
+	}
+	probed := make([]indexedResult, 0, len(registries))
+	for range registries {
+		probed = append(probed, <-results)
+	}
+	fastestEligible := time.Duration(1<<63 - 1)
+	for _, candidate := range probed {
+		if candidate.Probe.Reachable && candidate.Probe.Complete && candidate.Probe.Duration < fastestEligible {
+			fastestEligible = candidate.Probe.Duration
+		}
+	}
+	sort.SliceStable(probed, func(i, j int) bool {
+		left, right := probed[i], probed[j]
+		leftEligible := left.Probe.Reachable && left.Probe.Complete
+		rightEligible := right.Probe.Reachable && right.Probe.Complete
+		if leftEligible != rightEligible {
+			return leftEligible
+		}
+		if leftEligible {
+			leftInFastBand := left.Probe.Duration <= fastestEligible+MinimumRankDelta
+			rightInFastBand := right.Probe.Duration <= fastestEligible+MinimumRankDelta
+			if leftInFastBand != rightInFastBand {
+				return leftInFastBand
+			}
+			if !leftInFastBand && left.Probe.Duration != right.Probe.Duration {
+				return left.Probe.Duration < right.Probe.Duration
+			}
+		}
+		return left.index < right.index
+	})
+	ranked := make([]RankedRegistry, len(probed))
+	for index := range probed {
+		ranked[index] = probed[index].RankedRegistry
+	}
+	return ranked
+}
+
+func PackageEndpoint(registryURL string, packageName string, version string) string {
+	registryURL = strings.TrimRight(strings.TrimSpace(registryURL), "/")
+	packageName = strings.TrimSpace(packageName)
+	if registryURL == "" || packageName == "" {
+		return registryURL
+	}
+	escapedPackage := strings.ReplaceAll(packageName, "/", "%2f")
+	endpoint := registryURL + "/" + escapedPackage
+	if value := strings.TrimSpace(version); value != "" {
+		endpoint += "/" + url.PathEscape(value)
+	}
+	return endpoint
+}
+
+func DisplayRegistryHost(registryURL string) string {
+	parsed, err := url.Parse(strings.TrimSpace(registryURL))
+	if err != nil || parsed.Hostname() == "" {
+		return "invalid-registry"
+	}
+	return parsed.Hostname()
+}

--- a/packages/agent/daemon/managednpm/version.go
+++ b/packages/agent/daemon/managednpm/version.go
@@ -1,0 +1,81 @@
+package managednpm
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var stableVersionPattern = regexp.MustCompile(`^(?:v)?([0-9]+)\.([0-9]+)\.([0-9]+)$`)
+var embeddedVersionPattern = regexp.MustCompile(`(?:^|[^0-9A-Za-z.-])(?:v)?([0-9]+)\.([0-9]+)\.([0-9]+)(?:$|[^0-9A-Za-z.-])`)
+
+type stableVersion [3]uint64
+
+type VersionDecision string
+
+const (
+	VersionDecisionReady             VersionDecision = "ready"
+	VersionDecisionInstallMissing    VersionDecision = "install_missing"
+	VersionDecisionInstallUnknown    VersionDecision = "install_unknown"
+	VersionDecisionInstallBelowFloor VersionDecision = "install_below_floor"
+)
+
+func DecideVersion(installedOutput string, minimumVersion string) VersionDecision {
+	if strings.TrimSpace(installedOutput) == "" {
+		return VersionDecisionInstallMissing
+	}
+	installed, ok := extractStableVersion(installedOutput)
+	if !ok {
+		return VersionDecisionInstallUnknown
+	}
+	minimum, ok := parseStableVersion(minimumVersion)
+	if !ok || compareVersions(installed, minimum) < 0 {
+		return VersionDecisionInstallBelowFloor
+	}
+	return VersionDecisionReady
+}
+
+func ExtractVersion(output string) (string, bool) {
+	version, ok := extractStableVersion(output)
+	if !ok {
+		return "", false
+	}
+	return strconv.FormatUint(version[0], 10) + "." + strconv.FormatUint(version[1], 10) + "." + strconv.FormatUint(version[2], 10), true
+}
+
+func parseStableVersion(value string) (stableVersion, bool) {
+	matches := stableVersionPattern.FindStringSubmatch(strings.TrimSpace(value))
+	return versionFromMatches(matches)
+}
+
+func extractStableVersion(value string) (stableVersion, bool) {
+	matches := embeddedVersionPattern.FindStringSubmatch(strings.TrimSpace(value))
+	return versionFromMatches(matches)
+}
+
+func versionFromMatches(matches []string) (stableVersion, bool) {
+	if len(matches) != 4 {
+		return stableVersion{}, false
+	}
+	var result stableVersion
+	for index := range result {
+		part, err := strconv.ParseUint(matches[index+1], 10, 64)
+		if err != nil {
+			return stableVersion{}, false
+		}
+		result[index] = part
+	}
+	return result, true
+}
+
+func compareVersions(left stableVersion, right stableVersion) int {
+	for index := range left {
+		if left[index] < right[index] {
+			return -1
+		}
+		if left[index] > right[index] {
+			return 1
+		}
+	}
+	return 0
+}

--- a/packages/agent/daemon/providerregistry/providers.go
+++ b/packages/agent/daemon/providerregistry/providers.go
@@ -5,15 +5,16 @@ import canonical "github.com/tutti-os/tutti/packages/agent/store-sqlite/canonica
 // This file owns the descriptors shared by the remaining provider families.
 
 const (
-	CursorProviderID     = canonical.CursorProviderID
-	CursorTargetID       = "local:cursor"
-	TuttiAgentProviderID = canonical.TuttiAgentProviderID
-	TuttiAgentTargetID   = "local:tutti-agent"
-	TuttiAgentMinVersion = "0.0.4"
-	NexightProviderID    = canonical.NexightProviderID
-	NexightTargetID      = "local:nexight"
-	OpenClawProviderID   = canonical.OpenClawProviderID
-	OpenClawTargetID     = "local:openclaw"
+	CursorProviderID             = canonical.CursorProviderID
+	CursorTargetID               = "local:cursor"
+	TuttiAgentProviderID         = canonical.TuttiAgentProviderID
+	TuttiAgentTargetID           = "local:tutti-agent"
+	TuttiAgentMinVersion         = "0.0.5"
+	TuttiAgentRecommendedVersion = "0.0.5"
+	NexightProviderID            = canonical.NexightProviderID
+	NexightTargetID              = "local:nexight"
+	OpenClawProviderID           = canonical.OpenClawProviderID
+	OpenClawTargetID             = "local:openclaw"
 )
 
 const temporarilyUnsupportedReason = "provider_temporarily_unsupported"
@@ -66,7 +67,7 @@ func tuttiAgentDescriptor() ProviderDescriptor {
 		Runtime:  RuntimeDescriptor{Kind: RuntimeKindCodexAppServer, Name: "tutti-agent-app-server", Command: []string{"tutti-agent", "app-server"}, ClientInfoName: "tutti_agent", AuthRequiredMessage: "Tutti Agent requires authentication. Sign in to Tutti on this device (or run `tutti-agent login`), then retry this session.", Endpoint: RuntimeEndpointDescriptor{ModelPlanProtocol: ModelPlanProtocolOpenAI}},
 		Status: StatusDescriptor{
 			Kind: StatusKindGenericCLI, AuthOutputParserKind: AuthOutputParserKindCodex, AuthMarkerParserKind: AuthMarkerParserKindTuttiToken, AuthCommandRunnerKind: AuthCommandRunnerKindGeneric, StaticSpecResolverKind: StaticSpecResolverKindGeneric, MinVersion: TuttiAgentMinVersion, BinaryNames: []string{"tutti-agent"}, AdapterBinaryNames: []string{"tutti-agent"}, AuthStatusCommand: []string{"login", "status"}, AuthMarkerPaths: []string{"~/.tutti-agent/auth.json"}, LoginArgs: []string{"login"}, LoginActionKind: StatusActionKindDaemon,
-			Install: InstallerDescriptor{Kind: InstallerKindManagedNPM, DisplayCommand: "npm install -g @tutti-os/tutti-agent --include=optional", PackageName: "@tutti-os/tutti-agent", BinaryName: "tutti-agent", IncludeOptional: true},
+			Install: InstallerDescriptor{Kind: InstallerKindManagedNPM, DisplayCommand: "npm install -g @tutti-os/tutti-agent@" + TuttiAgentRecommendedVersion + " --include=optional", PackageName: "@tutti-os/tutti-agent", BinaryName: "tutti-agent", RecommendedVersion: TuttiAgentRecommendedVersion, IncludeOptional: true},
 			Update:  UpdateDescriptor{Capability: UpdateCapabilitySupported, Source: UpdateSourceNPM, Strategy: UpdateStrategyManagedNPM, PackageName: "@tutti-os/tutti-agent", BinaryName: "tutti-agent", IncludeOptional: true},
 		},
 		ComposerProfile: ComposerProfileDescriptor{

--- a/packages/agent/daemon/providerregistry/registry.go
+++ b/packages/agent/daemon/providerregistry/registry.go
@@ -410,6 +410,10 @@ func Validate(descriptor ProviderDescriptor) error {
 		if strings.TrimSpace(descriptor.Status.Install.PackageName) == "" || strings.TrimSpace(descriptor.Status.Install.BinaryName) == "" {
 			return fmt.Errorf("provider %q managed npm installer package and binary are required", providerID)
 		}
+		managedDescriptor, _ := descriptor.ManagedNPMDescriptor()
+		if err := managedDescriptor.Validate(); err != nil {
+			return fmt.Errorf("provider %q managed npm installer: %w", providerID, err)
+		}
 	case InstallerKindShellCommand:
 		if strings.TrimSpace(descriptor.Status.Install.ShellCommand) == "" {
 			return fmt.Errorf("provider %q shell installer command is required", providerID)

--- a/packages/agent/daemon/providerregistry/registry_test.go
+++ b/packages/agent/daemon/providerregistry/registry_test.go
@@ -56,6 +56,7 @@ func TestMigratedTuttiAgentDescriptorRequiresRefreshCapableVersion(t *testing.T)
 	}
 	if descriptor.Status.Install.PackageName != "@tutti-os/tutti-agent" ||
 		descriptor.Status.Install.BinaryName != "tutti-agent" ||
+		descriptor.Status.Install.RecommendedVersion != TuttiAgentRecommendedVersion ||
 		!descriptor.Status.Install.IncludeOptional {
 		t.Fatalf("Status.Install = %#v", descriptor.Status.Install)
 	}
@@ -74,6 +75,13 @@ func TestValidateRejectsInvalidMinimumVersionFloor(t *testing.T) {
 	t.Run("missing repair installer", func(t *testing.T) {
 		descriptor := tuttiAgentDescriptor()
 		descriptor.Status.Install = InstallerDescriptor{}
+		if err := Validate(descriptor); err == nil {
+			t.Fatal("Validate() error = nil")
+		}
+	})
+	t.Run("missing recommended version", func(t *testing.T) {
+		descriptor := tuttiAgentDescriptor()
+		descriptor.Status.Install.RecommendedVersion = ""
 		if err := Validate(descriptor); err == nil {
 			t.Fatal("Validate() error = nil")
 		}

--- a/packages/agent/daemon/providerregistry/types.go
+++ b/packages/agent/daemon/providerregistry/types.go
@@ -1,6 +1,9 @@
 package providerregistry
 
-import canonical "github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
+import (
+	"github.com/tutti-os/tutti/packages/agent/daemon/managednpm"
+	canonical "github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
+)
 
 // RuntimeKind identifies the adapter family used to execute a provider. The
 // runtime package maps each kind to an adapter constructor; provider identity
@@ -181,11 +184,25 @@ type InstallerDescriptor struct {
 	DisplayCommand       string
 	PackageName          string
 	BinaryName           string
+	RecommendedVersion   string
 	IncludeOptional      bool
 	ScriptURL            string
 	ScriptShell          string
 	ShellCommand         string
 	FailureReasonMarkers map[string][]string
+}
+
+func (d ProviderDescriptor) ManagedNPMDescriptor() (managednpm.Descriptor, bool) {
+	if d.Status.Install.Kind != InstallerKindManagedNPM {
+		return managednpm.Descriptor{}, false
+	}
+	return managednpm.Descriptor{
+		PackageName:        d.Status.Install.PackageName,
+		BinaryName:         d.Status.Install.BinaryName,
+		MinimumVersion:     d.Status.MinVersion,
+		RecommendedVersion: d.Status.Install.RecommendedVersion,
+		IncludeOptional:    d.Status.Install.IncludeOptional,
+	}, true
 }
 
 // UpdateCapability declares whether tuttid may safely discover and apply CLI

--- a/packages/agent/daemon/tuttiagentauth/auth.go
+++ b/packages/agent/daemon/tuttiagentauth/auth.go
@@ -1,0 +1,182 @@
+// Package tuttiagentauth owns the host-neutral Tutti Agent credential
+// reconciliation order. Account sessions, credential paths, process execution,
+// and VM transport remain host adapters.
+package tuttiagentauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	ScopeModels = "llm:models"
+	ScopeChat   = "llm:chat"
+)
+
+type TokenBundle struct {
+	AppID                 string   `json:"app_id"`
+	AccountBaseURL        string   `json:"account_base_url"`
+	AccessToken           string   `json:"access_token"`
+	AccessTokenExpiresAt  int64    `json:"access_token_expires_at"`
+	RefreshToken          string   `json:"refresh_token"`
+	RefreshTokenExpiresAt int64    `json:"refresh_token_expires_at"`
+	TokenType             string   `json:"token_type"`
+	Scopes                []string `json:"scopes"`
+}
+
+func (b TokenBundle) Validate(now time.Time) error {
+	if strings.TrimSpace(b.AppID) == "" || strings.TrimSpace(b.AccountBaseURL) == "" {
+		return fmt.Errorf("token bundle identity is incomplete")
+	}
+	if strings.TrimSpace(b.AccessToken) == "" || strings.TrimSpace(b.RefreshToken) == "" {
+		return fmt.Errorf("token bundle credentials are incomplete")
+	}
+	if b.AccessTokenExpiresAt <= now.Unix() || b.RefreshTokenExpiresAt <= now.Unix() {
+		return fmt.Errorf("token bundle is already expired")
+	}
+	if !slices.Contains(b.Scopes, ScopeModels) || !slices.Contains(b.Scopes, ScopeChat) {
+		return fmt.Errorf("token bundle is missing required scopes")
+	}
+	return nil
+}
+
+type RevokeTarget struct {
+	AccountBaseURL string
+	RefreshToken   string
+}
+
+func (t RevokeTarget) Valid() bool {
+	return strings.TrimSpace(t.RefreshToken) != ""
+}
+
+type CredentialState struct {
+	// MaterialReady only means the canonical credential material exists and is
+	// locally usable for a provider probe. It does not prove that the provider
+	// accepted the credential, and must not be projected as product readiness.
+	MaterialReady bool
+	RevokeTarget  RevokeTarget
+}
+
+// Reconciler serializes all mutations of one canonical credential authority.
+// A host must use the same instance for reconcile and logout, and must call
+// RemoveLocal during an account switch before reconciling the next account.
+type Reconciler struct {
+	mu sync.Mutex
+}
+
+type SessionAuthorizer interface {
+	Issue(context.Context) (TokenBundle, error)
+	Revoke(context.Context, RevokeTarget, string) error
+}
+
+type CredentialStore interface {
+	Inspect(context.Context) (CredentialState, error)
+	Remove(context.Context) error
+}
+
+type LoginRunner interface {
+	Login(context.Context, TokenBundle) error
+}
+
+type ReconcileResult struct {
+	Changed bool
+}
+
+type StageError struct {
+	Stage string
+	Err   error
+}
+
+func (e StageError) Error() string {
+	return "tutti-agent auth " + strings.TrimSpace(e.Stage) + " failed"
+}
+
+func (e StageError) Unwrap() error { return e.Err }
+
+func (r *Reconciler) Reconcile(ctx context.Context, authorizer SessionAuthorizer, store CredentialStore, runner LoginRunner, now time.Time) (ReconcileResult, error) {
+	if r == nil {
+		return ReconcileResult{}, fmt.Errorf("tutti-agent auth reconciler is required")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if authorizer == nil || store == nil || runner == nil {
+		return ReconcileResult{}, fmt.Errorf("tutti-agent auth adapters are required")
+	}
+	state, err := store.Inspect(ctx)
+	if err != nil {
+		return ReconcileResult{}, StageError{Stage: "inspect", Err: err}
+	}
+	if state.MaterialReady {
+		return ReconcileResult{}, nil
+	}
+	bundle, err := authorizer.Issue(ctx)
+	if err != nil {
+		return ReconcileResult{}, StageError{Stage: "issue", Err: err}
+	}
+	if err := bundle.Validate(now); err != nil {
+		return ReconcileResult{}, compensate(ctx, authorizer, store, bundle.RevokeTarget(), "invalid_bundle", StageError{Stage: "validate", Err: err})
+	}
+	if err := runner.Login(ctx, bundle); err != nil {
+		return ReconcileResult{}, compensate(ctx, authorizer, store, bundle.RevokeTarget(), "login_failed", StageError{Stage: "login", Err: err})
+	}
+	state, err = store.Inspect(ctx)
+	if err != nil || !state.MaterialReady {
+		if err == nil {
+			err = errors.New("credential material did not become usable")
+		}
+		return ReconcileResult{}, compensate(ctx, authorizer, store, bundle.RevokeTarget(), "not_ready", StageError{Stage: "verify", Err: err})
+	}
+	return ReconcileResult{Changed: true}, nil
+}
+
+func (b TokenBundle) RevokeTarget() RevokeTarget {
+	return RevokeTarget{AccountBaseURL: b.AccountBaseURL, RefreshToken: b.RefreshToken}
+}
+
+func (r *Reconciler) RemoveLocal(ctx context.Context, store CredentialStore) (RevokeTarget, error) {
+	if r == nil {
+		return RevokeTarget{}, fmt.Errorf("tutti-agent auth reconciler is required")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if store == nil {
+		return RevokeTarget{}, fmt.Errorf("tutti-agent credential store is required")
+	}
+	state, inspectErr := store.Inspect(ctx)
+	removeErr := store.Remove(ctx)
+	if removeErr != nil {
+		return RevokeTarget{}, StageError{Stage: "remove", Err: removeErr}
+	}
+	if inspectErr != nil {
+		return RevokeTarget{}, StageError{Stage: "inspect", Err: inspectErr}
+	}
+	return state.RevokeTarget, nil
+}
+
+func compensate(ctx context.Context, authorizer SessionAuthorizer, store CredentialStore, target RevokeTarget, reason string, primary error) error {
+	compensationCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	removeErr := store.Remove(compensationCtx)
+	var revokeErr error
+	if target.Valid() {
+		revokeErr = authorizer.Revoke(compensationCtx, target, reason)
+	}
+	if removeErr != nil {
+		removeErr = StageError{Stage: "compensating_remove", Err: removeErr}
+	}
+	if revokeErr != nil {
+		revokeErr = StageError{Stage: "compensating_revoke", Err: revokeErr}
+	}
+	return errors.Join(primary, removeErr, revokeErr)
+}

--- a/packages/agent/daemon/tuttiagentauth/auth_test.go
+++ b/packages/agent/daemon/tuttiagentauth/auth_test.go
@@ -1,0 +1,204 @@
+package tuttiagentauth
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestReconcileIsIdempotentWhenCredentialMaterialReady(t *testing.T) {
+	authorizer := &fakeAuthorizer{}
+	store := &fakeStore{state: CredentialState{MaterialReady: true}}
+	runner := &fakeRunner{}
+	result, err := (&Reconciler{}).Reconcile(context.Background(), authorizer, store, runner, time.Now())
+	if err != nil || result.Changed || authorizer.issueCalls != 0 || runner.calls != 0 {
+		t.Fatalf("Reconcile() = %#v, %v; authorizer=%#v runner=%#v", result, err, authorizer, runner)
+	}
+}
+
+func TestReconcileCompensatesFailedLoginWithoutLeakingTokens(t *testing.T) {
+	now := time.Now().UTC()
+	authorizer := &fakeAuthorizer{bundle: validBundle(now)}
+	store := &fakeStore{}
+	runner := &fakeRunner{err: errors.New("runner output contained lat_secret lrt_secret")}
+	_, err := (&Reconciler{}).Reconcile(context.Background(), authorizer, store, runner, now)
+	if err == nil {
+		t.Fatal("Reconcile() error = nil")
+	}
+	if strings.Contains(err.Error(), "lat_secret") || strings.Contains(err.Error(), "lrt_secret") {
+		t.Fatalf("Reconcile() leaked credential in error: %v", err)
+	}
+	if store.removeCalls != 1 || authorizer.revokeCalls != 1 || authorizer.lastReason != "login_failed" {
+		t.Fatalf("compensation calls: store=%#v authorizer=%#v", store, authorizer)
+	}
+}
+
+func TestReconcileVerifiesCredentialMaterialAfterLogin(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeStore{}
+	runner := &fakeRunner{afterLogin: store.setReady}
+	result, err := (&Reconciler{}).Reconcile(context.Background(), &fakeAuthorizer{bundle: validBundle(now)}, store, runner, now)
+	if err != nil || !result.Changed {
+		t.Fatalf("Reconcile() = %#v, %v", result, err)
+	}
+}
+
+func TestRemoveLocalDeletesBeforeReturningRevokeTarget(t *testing.T) {
+	target := RevokeTarget{RefreshToken: "lrt_secret"}
+	store := &fakeStore{state: CredentialState{MaterialReady: true, RevokeTarget: target}}
+	got, err := (&Reconciler{}).RemoveLocal(context.Background(), store)
+	if err != nil || got != target || store.removeCalls != 1 {
+		t.Fatalf("RemoveLocal() = %#v, %v; store=%#v", got, err, store)
+	}
+}
+
+func TestReconcilerSerializesConcurrentCredentialMutation(t *testing.T) {
+	now := time.Now().UTC()
+	reconciler := &Reconciler{}
+	authorizer := &fakeAuthorizer{bundle: validBundle(now)}
+	store := &fakeStore{}
+	runner := &fakeRunner{afterLogin: store.setReady}
+	start := make(chan struct{})
+	errorsByCall := make(chan error, 2)
+	for range 2 {
+		go func() {
+			<-start
+			_, err := reconciler.Reconcile(context.Background(), authorizer, store, runner, now)
+			errorsByCall <- err
+		}()
+	}
+	close(start)
+	for range 2 {
+		if err := <-errorsByCall; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if authorizer.issueCount() != 1 || runner.callCount() != 1 {
+		t.Fatalf("concurrent reconcile issued %d token(s) and ran %d login(s)", authorizer.issueCount(), runner.callCount())
+	}
+}
+
+func TestReconcileCompensationSurvivesCallerCancellation(t *testing.T) {
+	now := time.Now().UTC()
+	ctx, cancel := context.WithCancel(context.Background())
+	authorizer := &fakeAuthorizer{bundle: validBundle(now)}
+	store := &fakeStore{}
+	runner := &fakeRunner{
+		err:        errors.New("login failed"),
+		afterLogin: cancel,
+	}
+	_, err := (&Reconciler{}).Reconcile(ctx, authorizer, store, runner, now)
+	if err == nil {
+		t.Fatal("Reconcile() error = nil")
+	}
+	if store.removeContextError() != nil || authorizer.revokeContextError() != nil {
+		t.Fatalf("compensation inherited cancellation: remove=%v revoke=%v", store.removeContextError(), authorizer.revokeContextError())
+	}
+}
+
+func validBundle(now time.Time) TokenBundle {
+	return TokenBundle{
+		AppID: "233749", AccountBaseURL: "https://account.example", AccessToken: "lat_secret",
+		AccessTokenExpiresAt: now.Add(time.Hour).Unix(), RefreshToken: "lrt_secret",
+		RefreshTokenExpiresAt: now.Add(24 * time.Hour).Unix(), TokenType: "Bearer",
+		Scopes: []string{ScopeModels, ScopeChat},
+	}
+}
+
+type fakeAuthorizer struct {
+	mu           sync.Mutex
+	bundle       TokenBundle
+	issueErr     error
+	issueCalls   int
+	revokeCalls  int
+	lastReason   string
+	revokeCtxErr error
+}
+
+func (f *fakeAuthorizer) Issue(context.Context) (TokenBundle, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.issueCalls++
+	return f.bundle, f.issueErr
+}
+
+func (f *fakeAuthorizer) Revoke(ctx context.Context, _ RevokeTarget, reason string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.revokeCalls++
+	f.lastReason = reason
+	f.revokeCtxErr = ctx.Err()
+	return nil
+}
+
+func (f *fakeAuthorizer) issueCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.issueCalls
+}
+
+func (f *fakeAuthorizer) revokeContextError() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.revokeCtxErr
+}
+
+type fakeStore struct {
+	mu           sync.Mutex
+	state        CredentialState
+	inspectErr   error
+	removeErr    error
+	removeCalls  int
+	removeCtxErr error
+}
+
+func (f *fakeStore) Inspect(context.Context) (CredentialState, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.state, f.inspectErr
+}
+func (f *fakeStore) Remove(ctx context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.removeCalls++
+	f.removeCtxErr = ctx.Err()
+	return f.removeErr
+}
+
+func (f *fakeStore) setReady() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.state.MaterialReady = true
+}
+
+func (f *fakeStore) removeContextError() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.removeCtxErr
+}
+
+type fakeRunner struct {
+	mu         sync.Mutex
+	err        error
+	calls      int
+	afterLogin func()
+}
+
+func (f *fakeRunner) Login(context.Context, TokenBundle) error {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+	if f.afterLogin != nil {
+		f.afterLogin()
+	}
+	return f.err
+}
+
+func (f *fakeRunner) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}

--- a/packages/agent/runtimeprep/README.md
+++ b/packages/agent/runtimeprep/README.md
@@ -42,6 +42,16 @@ and later sessions reuse it. Hosts must therefore run preparation with `HOME`
 set to the provider user's stable local Home, never a session runtime directory
 or a remote filesystem projection.
 
+`TuttiAgentPreparer.ResolveAuthSource` lets a host expose one explicit absolute
+credential authority into the session-scoped `TUTTI_AGENT_HOME`. When omitted,
+the Tutti desktop keeps its existing `~/.tutti-agent/auth.json` behavior. An
+explicit source may be a dangling symlink target so a host-controlled login can
+materialize it atomically later; runtimeprep never follows or deletes that
+target during session cleanup. If a configured resolver returns no path,
+runtimeprep leaves auth unprojected and does not fall back to the VM user's
+`~/.tutti-agent`. Tutti Agent preparation also materializes the same resolved
+native Skills used by the other supported providers.
+
 ## Capability Packs
 
 A deployment capability resolves once into its policy, skills, and environment
@@ -115,8 +125,10 @@ the skill-bundle API cannot drift.
 
 The module must not import `services/tuttid/*`. Product adapters translate
 their command catalog and readiness types into the narrow interfaces here.
-Tutti account token issue/revoke remains in `services/tuttid/service/tuttiagent`;
-only the provider home/config preparation is shared.
+Tutti Account HTTP and local credential paths remain in
+`services/tuttid/service/tuttiagent`. The host-neutral issue/login/verify and
+cleanup ordering lives in `packages/agent/daemon/tuttiagentauth`; only provider
+home/config/Skills preparation lives in this module.
 
 Provider-specific runtime protocol and session control belong to
 `packages/agent/daemon`, not this module.

--- a/packages/agent/runtimeprep/tutti_agent.go
+++ b/packages/agent/runtimeprep/tutti_agent.go
@@ -19,7 +19,8 @@ const (
 // tutti-agent provider. Account-token bootstrap remains a host responsibility
 // and can be injected through BeforePrepare.
 type TuttiAgentPreparer struct {
-	BeforePrepare func(context.Context, PrepareInput)
+	BeforePrepare     func(context.Context, PrepareInput)
+	ResolveAuthSource func(context.Context, PrepareInput) (string, error)
 }
 
 func (TuttiAgentPreparer) Provider() string {
@@ -32,7 +33,16 @@ func (p TuttiAgentPreparer) Prepare(ctx context.Context, input ProviderPrepareIn
 	if p.BeforePrepare != nil {
 		p.BeforePrepare(ctx, input.PrepareInput)
 	}
-	if err := PrepareTuttiAgentHome(home, input.PrepareInput); err != nil {
+	authSource := ""
+	authSourceConfigured := p.ResolveAuthSource != nil
+	if authSourceConfigured {
+		resolved, err := p.ResolveAuthSource(ctx, input.PrepareInput)
+		if err != nil {
+			return ProviderPrepareResult{}, fmt.Errorf("resolve tutti-agent auth source: %w", err)
+		}
+		authSource = strings.TrimSpace(resolved)
+	}
+	if err := prepareTuttiAgentHome(home, input.PrepareInput, authSource, authSourceConfigured); err != nil {
 		return ProviderPrepareResult{}, err
 	}
 	logRuntimePrepareTrace("runtime_prepare.tutti_agent.home_prepared", input.PrepareInput, nil)
@@ -59,29 +69,43 @@ func (p TuttiAgentPreparer) Prepare(ctx context.Context, input ProviderPrepareIn
 // PrepareTuttiAgentHome materializes a TUTTI_AGENT_HOME with the user's auth
 // exposed and a session-safe config pinned to the Tutti LLM gateway.
 func PrepareTuttiAgentHome(home string, input PrepareInput) error {
+	return prepareTuttiAgentHome(home, input, "", false)
+}
+
+func prepareTuttiAgentHome(home string, input PrepareInput, authSource string, authSourceConfigured bool) error {
 	if err := os.MkdirAll(home, 0o700); err != nil {
 		return fmt.Errorf("create tutti-agent home: %w", err)
 	}
-	if err := exposeUserTuttiAgentFiles(home); err != nil {
+	if err := exposeUserTuttiAgentFiles(home, authSource, authSourceConfigured); err != nil {
 		return err
 	}
-	return ensureTuttiAgentSessionConfig(filepath.Join(home, "config.toml"), input)
+	if err := ensureTuttiAgentSessionConfig(filepath.Join(home, "config.toml"), input); err != nil {
+		return err
+	}
+	if _, err := installProviderNativeSkills(filepath.Join(home, "skills"), input); err != nil {
+		return fmt.Errorf("install tutti-agent native skills: %w", err)
+	}
+	return nil
 }
 
-func exposeUserTuttiAgentFiles(home string) error {
+func exposeUserTuttiAgentFiles(home string, explicitAuthSource string, explicitAuthSourceConfigured bool) error {
+	if explicitAuthSourceConfigured {
+		if explicitAuthSource == "" {
+			return nil
+		}
+		if !filepath.IsAbs(explicitAuthSource) {
+			return fmt.Errorf("tutti-agent auth source must be absolute")
+		}
+		return exposeTuttiAgentAuth(home, filepath.Clean(explicitAuthSource), true)
+	}
 	userHome, err := os.UserHomeDir()
 	if err != nil || strings.TrimSpace(userHome) == "" {
 		return nil
 	}
 	userAgentHome := filepath.Join(userHome, ".tutti-agent")
 	source := filepath.Join(userAgentHome, "auth.json")
-	if _, err := os.Stat(source); err == nil {
-		target := filepath.Join(home, "auth.json")
-		if _, err := os.Lstat(target); os.IsNotExist(err) {
-			if err := os.Symlink(source, target); err != nil {
-				return fmt.Errorf("expose tutti-agent auth.json: %w", err)
-			}
-		}
+	if err := exposeTuttiAgentAuth(home, source, false); err != nil {
+		return err
 	}
 	target := filepath.Join(home, "config.toml")
 	if _, err := os.Lstat(target); os.IsNotExist(err) {
@@ -91,6 +115,30 @@ func exposeUserTuttiAgentFiles(home string) error {
 				return fmt.Errorf("copy tutti-agent config: %w", err)
 			}
 		}
+	}
+	return nil
+}
+
+func exposeTuttiAgentAuth(home string, source string, allowMissingSource bool) error {
+	if !allowMissingSource {
+		if _, err := os.Stat(source); err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("stat tutti-agent auth source: %w", err)
+		}
+	}
+	target := filepath.Join(home, "auth.json")
+	if current, err := os.Readlink(target); err == nil {
+		if current == source {
+			return nil
+		}
+		return fmt.Errorf("tutti-agent auth target already links to a different source")
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect tutti-agent auth target: %w", err)
+	}
+	if err := os.Symlink(source, target); err != nil {
+		return fmt.Errorf("expose tutti-agent auth.json: %w", err)
 	}
 	return nil
 }

--- a/packages/agent/runtimeprep/tutti_agent_test.go
+++ b/packages/agent/runtimeprep/tutti_agent_test.go
@@ -1,0 +1,118 @@
+package runtimeprep
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTuttiAgentPreparerUsesExplicitAuthSourceAndInstallsSkills(t *testing.T) {
+	userHome := t.TempDir()
+	t.Setenv("HOME", userHome)
+	defaultAuthDir := filepath.Join(userHome, ".tutti-agent")
+	if err := os.MkdirAll(defaultAuthDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(defaultAuthDir, "config.toml"), []byte("model = \"must-not-be-copied\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	runtimeRoot := t.TempDir()
+	authSource := filepath.Join(t.TempDir(), "auth.json")
+	preparer := TuttiAgentPreparer{
+		ResolveAuthSource: func(context.Context, PrepareInput) (string, error) {
+			return authSource, nil
+		},
+	}
+	store := LocalStore{StateDir: t.TempDir()}
+	result, err := preparer.Prepare(context.Background(), ProviderPrepareInput{
+		PrepareInput: PrepareInput{
+			AgentSessionID: "session-1",
+			AgentTargetID:  "local:tutti-agent",
+			Provider:       "tutti-agent",
+			CLICommand:     "tutti",
+		},
+		RuntimeRoot: runtimeRoot,
+		Store:       store,
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+
+	home := filepath.Join(runtimeRoot, "tutti-agent-home")
+	linked, err := os.Readlink(filepath.Join(home, "auth.json"))
+	if err != nil {
+		t.Fatalf("read auth symlink: %v", err)
+	}
+	if linked != authSource {
+		t.Fatalf("auth symlink = %q, want %q", linked, authSource)
+	}
+	if _, err := os.Stat(filepath.Join(home, "skills", "tutti-cli", "SKILL.md")); err != nil {
+		t.Fatalf("native tutti-cli skill missing: %v", err)
+	}
+	config, err := os.ReadFile(filepath.Join(home, "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(config), "must-not-be-copied") {
+		t.Fatal("explicit auth source unexpectedly imported the VM user's config")
+	}
+	if len(result.Env) == 0 || result.Env[0] != "TUTTI_AGENT_HOME="+home {
+		t.Fatalf("Prepare() env = %#v", result.Env)
+	}
+}
+
+func TestTuttiAgentPreparerRejectsRelativeAuthSource(t *testing.T) {
+	preparer := TuttiAgentPreparer{
+		ResolveAuthSource: func(context.Context, PrepareInput) (string, error) {
+			return "relative/auth.json", nil
+		},
+	}
+	_, err := preparer.Prepare(context.Background(), ProviderPrepareInput{
+		PrepareInput: PrepareInput{Provider: "tutti-agent"},
+		RuntimeRoot:  t.TempDir(),
+		Store:        LocalStore{StateDir: t.TempDir()},
+	})
+	if err == nil {
+		t.Fatal("Prepare() error = nil, want relative auth source rejection")
+	}
+}
+
+func TestTuttiAgentPreparerDoesNotFallbackWhenExplicitAuthSourceIsEmpty(t *testing.T) {
+	userHome := t.TempDir()
+	t.Setenv("HOME", userHome)
+	defaultHome := filepath.Join(userHome, ".tutti-agent")
+	if err := os.MkdirAll(defaultHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(defaultHome, "auth.json"), []byte(`{"old":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(defaultHome, "config.toml"), []byte("model = \"old\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	runtimeRoot := t.TempDir()
+	preparer := TuttiAgentPreparer{ResolveAuthSource: func(context.Context, PrepareInput) (string, error) { return "", nil }}
+	_, err := preparer.Prepare(context.Background(), ProviderPrepareInput{
+		PrepareInput: PrepareInput{Provider: "tutti-agent"},
+		RuntimeRoot:  runtimeRoot,
+		Store:        LocalStore{StateDir: t.TempDir()},
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	home := filepath.Join(runtimeRoot, "tutti-agent-home")
+	if _, err := os.Lstat(filepath.Join(home, "auth.json")); !os.IsNotExist(err) {
+		t.Fatalf("auth fallback exists, error = %v", err)
+	}
+	config, err := os.ReadFile(filepath.Join(home, "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(config), `model = "old"`) {
+		t.Fatal("explicit empty auth source imported the VM user's config")
+	}
+}

--- a/services/tuttid/service/agentstatus/codex_version.go
+++ b/services/tuttid/service/agentstatus/codex_version.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/tutti-os/tutti/packages/agent/daemon/managednpm"
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 )
 
@@ -83,11 +84,18 @@ func providerCLIVersionMeetsMinimum(spec ProviderSpec, version string) bool {
 	if minimum == "" {
 		return true
 	}
+	if providerUsesManagedNPMVersionContract(spec) {
+		return managednpm.DecideVersion(version, minimum) == managednpm.VersionDecisionReady
+	}
 	cmp, ok := compareCLIVersions(version, minimum)
 	if !ok {
 		return isCodexStatusSpec(spec)
 	}
 	return cmp >= 0
+}
+
+func providerUsesManagedNPMVersionContract(spec ProviderSpec) bool {
+	return !isCodexStatusSpec(spec) && spec.Install.Kind == InstallerKindManagedNPMPackage
 }
 
 // parseCLIVersionForComparison returns the [major, minor, patch] core, whether a

--- a/services/tuttid/service/agentstatus/installer.go
+++ b/services/tuttid/service/agentstatus/installer.go
@@ -349,7 +349,7 @@ func (s Service) providerCLIRequiresInstall(spec ProviderSpec, runtime providerR
 	if strings.TrimSpace(spec.MinVersion) == "" {
 		return false
 	}
-	return !providerCLIVersionMeetsMinimum(spec, s.cliVersion(context.Background(), runtime.CLIPath, runtime.Env))
+	return !providerCLIVersionMeetsMinimum(spec, s.providerCLIVersion(context.Background(), spec, runtime.CLIPath, runtime.Env))
 }
 
 func adapterPackageRequirementSatisfied(requirement AdapterPackageRequirement, version string) bool {

--- a/services/tuttid/service/agentstatus/installer_codex_cli.go
+++ b/services/tuttid/service/agentstatus/installer_codex_cli.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/tutti-os/tutti/packages/agent/daemon/managednpm"
 	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )
@@ -125,7 +126,7 @@ func (s Service) runManagedNPMPackageAction(
 	// which on some machines holds root-owned files that make every user-mode npm
 	// install fail with EACCES before any registry is hit.
 	baseEnv = withAgentNPMCache(baseEnv, filepath.Join(installPrefix, agentNPMCacheDirName))
-	registries := s.rankedAgentNPMRegistries(ctx, packageName)
+	registries := s.rankedManagedNPMRegistries(ctx, spec)
 	var result InstallCommandResult
 	binConflictRepaired := false
 	for i, registry := range registries {
@@ -202,7 +203,7 @@ func (s Service) runManagedNPMPackageAction(
 	return result, err
 }
 
-func (s Service) repairManagedNPMBinEEXIST(
+func (Service) repairManagedNPMBinEEXIST(
 	ctx context.Context,
 	result InstallCommandResult,
 	installPrefix string,
@@ -214,7 +215,7 @@ func (s Service) repairManagedNPMBinEEXIST(
 	if !ok || !managedNPMBinConflictMatchesInstallTarget(conflictPath, installPrefix, binaryName) {
 		return false
 	}
-	installedVersion := s.cliVersion(ctx, conflictPath, env)
+	installedVersion, _ := managednpm.ExtractVersion(cliVersionOutput(ctx, conflictPath, env))
 	if required := strings.TrimSpace(requiredVersion); required != "" && installedVersion == required {
 		return false
 	}

--- a/services/tuttid/service/agentstatus/installer_codex_cli_test.go
+++ b/services/tuttid/service/agentstatus/installer_codex_cli_test.go
@@ -279,7 +279,7 @@ func TestRunManagedNPMPackageInstallerRepairsManagedBinEEXIST(t *testing.T) {
 	managedNode := filepath.Join(runtimeRoot, "node", "bin", nodeBinaryNameForTest())
 	managedNodeBinDir := filepath.Dir(managedNode)
 	conflictPath := filepath.Join(home, ".local", "bin", "tutti-agent")
-	writeExecutable(t, conflictPath, "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'tutti-agent 0.0.1'; exit 0; fi\nexit 0\n")
+	writeExecutable(t, conflictPath, "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'tutti-agent 0.0.5.1'; exit 0; fi\nexit 0\n")
 
 	service := probeTestService(home)
 	service.HTTPClient = agentNPMRegistryProbeHTTPClient(nil)
@@ -319,7 +319,7 @@ func TestRunManagedNPMPackageInstallerRepairsManagedBinEEXIST(t *testing.T) {
 
 	if _, err := service.runManagedNPMPackageInstaller(context.Background(), "tutti-agent", ManagedNPMPackageInstallerSpec{
 		PackageName:     "@tutti-os/tutti-agent",
-		PackageVersion:  "0.0.2",
+		PackageVersion:  "0.0.5",
 		BinaryName:      "tutti-agent",
 		IncludeOptional: true,
 	}, conflictPath); err != nil {

--- a/services/tuttid/service/agentstatus/npm_registry.go
+++ b/services/tuttid/service/agentstatus/npm_registry.go
@@ -2,32 +2,35 @@ package agentstatus
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
 	"os"
-	"sort"
+	"runtime"
 	"strings"
 	"time"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/managednpm"
 )
 
 const (
 	// agentNPMRegistryEnv pins a single npm registry for agent-adapter installs
 	// (an enterprise proxy, or one specific mirror). When set, no fallback chain
 	// is used — the operator's choice is trusted as-is.
-	agentNPMRegistryEnv = "TUTTI_AGENT_NPM_REGISTRY"
+	agentNPMRegistryEnv = managednpm.RegistryOverrideEnv
 
 	// officialNPMRegistry is the authoritative default source. Installers may
 	// rank it behind a mirror when the user's current network makes a mirror
 	// measurably faster.
-	officialNPMRegistry = "https://registry.npmjs.org"
+	officialNPMRegistry = managednpm.OfficialRegistryURL
 
 	// CN-available fallback mirrors, used when public npm is slow or blocked.
 	// These mirrors were verified to host large platform optional-dependency
 	// packages end-to-end. They serve identical tarballs, so npm integrity
 	// verification is unaffected.
-	huaweiNPMRegistry  = "https://repo.huaweicloud.com/repository/npm/" // Huawei Cloud
-	tencentNPMRegistry = "https://mirrors.cloud.tencent.com/npm/"       // Tencent Cloud
+	huaweiNPMRegistry  = managednpm.HuaweiRegistryURL  // Huawei Cloud
+	tencentNPMRegistry = managednpm.TencentRegistryURL // Tencent Cloud
 
 	// agentNPMCacheDirName is the dedicated npm cache directory agent installs use
 	// instead of npm's global ~/.npm. It lives inside the install prefix so it is
@@ -42,17 +45,6 @@ const (
 	// otherwise-succeeding installs, so it is set comfortably above the proxied
 	// case while staying below the overall install timeout.
 	perRegistryInstallTimeout = 150 * time.Second
-
-	// agentNPMRegistryRankTimeout bounds the lightweight package metadata probe
-	// used to order registries before a large npm install. It is intentionally
-	// much shorter than an install attempt: a registry that cannot return metadata
-	// quickly should not get the first shot at a 100MB+ optional platform binary.
-	agentNPMRegistryRankTimeout = 5 * time.Second
-
-	// Avoid reshuffling registries on tiny timing noise from goroutine scheduling,
-	// DNS cache warmth, or localhost test transports. Meaningful network
-	// differences are much larger than this.
-	agentNPMRegistryRankMinDifference = 25 * time.Millisecond
 )
 
 // agentNPMRegistries returns the ordered list of npm registries to try for
@@ -61,14 +53,12 @@ const (
 // access. An explicit TUTTI_AGENT_NPM_REGISTRY pins a single registry with no
 // fallback.
 func (s Service) agentNPMRegistries() []string {
-	if override := strings.TrimSpace(s.lookupEnv(agentNPMRegistryEnv)); override != "" {
-		return []string{override}
+	registries := managednpm.DefaultRegistries(s.lookupEnv(agentNPMRegistryEnv))
+	result := make([]string, len(registries))
+	for index := range registries {
+		result[index] = registries[index].URL
 	}
-	return []string{
-		officialNPMRegistry,
-		huaweiNPMRegistry,
-		tencentNPMRegistry,
-	}
+	return result
 }
 
 // primaryAgentNPMRegistry is the first registry to try (the override, or
@@ -87,70 +77,102 @@ func (s Service) preferredAgentNPMRegistry(ctx context.Context, packageName stri
 }
 
 func (s Service) rankedAgentNPMRegistries(ctx context.Context, packageName string) []string {
+	return s.rankAgentNPMRegistries(ctx, managednpm.Descriptor{PackageName: packageName})
+}
+
+func (s Service) rankedManagedNPMRegistries(ctx context.Context, spec ManagedNPMPackageInstallerSpec) []string {
+	return s.rankAgentNPMRegistries(ctx, managednpm.Descriptor{
+		PackageName:        spec.PackageName,
+		BinaryName:         spec.BinaryName,
+		RecommendedVersion: spec.PackageVersion,
+		IncludeOptional:    spec.IncludeOptional,
+	})
+}
+
+func (s Service) rankAgentNPMRegistries(ctx context.Context, descriptor managednpm.Descriptor) []string {
 	registries := s.agentNPMRegistries()
 	if len(registries) <= 1 {
 		return registries
 	}
-	if ctx == nil {
-		ctx = context.Background()
+	candidates := make([]managednpm.Registry, len(registries))
+	for index := range registries {
+		candidates[index] = managednpm.Registry{ID: displayNPMRegistry(registries[index]), URL: registries[index]}
 	}
-
-	type probeResult struct {
-		index     int
-		registry  string
-		reachable bool
-		duration  time.Duration
-	}
-	results := make(chan probeResult, len(registries))
-	for index, registry := range registries {
-		go func(index int, registry string) {
-			startedAt := time.Now()
-			probeCtx, cancel := context.WithTimeout(ctx, agentNPMRegistryRankTimeout)
-			defer cancel()
-			reachable := s.probeNPMRegistryPackage(probeCtx, registry, packageName)
-			results <- probeResult{
-				index:     index,
-				registry:  registry,
-				reachable: reachable,
-				duration:  time.Since(startedAt),
-			}
-		}(index, registry)
-	}
-
-	probed := make([]probeResult, 0, len(registries))
-	for range registries {
-		probed = append(probed, <-results)
-	}
-	sort.SliceStable(probed, func(i, j int) bool {
-		left := probed[i]
-		right := probed[j]
-		if left.reachable != right.reachable {
-			return left.reachable
-		}
-		if left.reachable && right.reachable {
-			diff := left.duration - right.duration
-			if diff < 0 {
-				diff = -diff
-			}
-			if diff > agentNPMRegistryRankMinDifference {
-				return left.duration < right.duration
-			}
-		}
-		return left.index < right.index
-	})
-
-	ranked := make([]string, 0, len(probed))
-	displayRanked := make([]string, 0, len(probed))
-	for _, result := range probed {
-		ranked = append(ranked, result.registry)
-		displayRanked = append(displayRanked, displayNPMRegistry(result.registry))
+	probed := managednpm.RankRegistries(ctx, descriptor, candidates, runtime.GOOS, runtime.GOARCH, agentNPMRegistryProber{service: s})
+	ranked := make([]string, len(probed))
+	displayRanked := make([]string, len(probed))
+	for index := range probed {
+		ranked[index] = probed[index].Registry.URL
+		displayRanked[index] = displayNPMRegistry(probed[index].Registry.URL)
 	}
 	slog.Info(
 		"agent npm registries ranked",
-		"package", strings.TrimSpace(packageName),
+		"package", strings.TrimSpace(descriptor.PackageName),
+		"version", strings.TrimSpace(descriptor.RecommendedVersion),
 		"registries", displayRanked,
 	)
 	return ranked
+}
+
+type agentNPMRegistryProber struct {
+	service Service
+}
+
+func (p agentNPMRegistryProber) ProbeRegistry(ctx context.Context, request managednpm.RegistryProbeRequest) managednpm.RegistryProbeResult {
+	if strings.TrimSpace(request.Version) != "" {
+		return p.service.probeNPMRegistryPackageVersion(ctx, request)
+	}
+	reachable := p.service.probeNPMRegistryPackage(ctx, request.Registry.URL, request.PackageName)
+	return managednpm.RegistryProbeResult{Reachable: reachable, Complete: reachable}
+}
+
+func (s Service) probeNPMRegistryPackageVersion(ctx context.Context, request managednpm.RegistryProbeRequest) managednpm.RegistryProbeResult {
+	metadata, ok := s.readNPMRegistryPackageVersion(ctx, request.Registry.URL, request.PackageName, request.Version)
+	if !ok {
+		return managednpm.RegistryProbeResult{}
+	}
+	if !request.IncludeOptional {
+		return managednpm.RegistryProbeResult{Reachable: true, Complete: true}
+	}
+	platformPackage, platformVersion, ok := managednpm.ResolveOptionalPlatformPackage(
+		request.PackageName,
+		metadata.OptionalDependencies,
+		request.OperatingSystem,
+		request.Architecture,
+	)
+	if !ok {
+		return managednpm.RegistryProbeResult{Reachable: true}
+	}
+	_, platformReady := s.readNPMRegistryPackageVersion(ctx, request.Registry.URL, platformPackage, platformVersion)
+	return managednpm.RegistryProbeResult{Reachable: true, Complete: platformReady}
+}
+
+type npmPackageVersionMetadata struct {
+	Version              string            `json:"version"`
+	OptionalDependencies map[string]string `json:"optionalDependencies"`
+}
+
+func (s Service) readNPMRegistryPackageVersion(ctx context.Context, registry string, packageName string, version string) (npmPackageVersionMetadata, bool) {
+	endpoint := managednpm.PackageEndpoint(registry, packageName, version)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return npmPackageVersionMetadata{}, false
+	}
+	response, err := s.httpClient().Do(request)
+	if err != nil {
+		return npmPackageVersionMetadata{}, false
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64*1024))
+		return npmPackageVersionMetadata{}, false
+	}
+	var metadata npmPackageVersionMetadata
+	decoder := json.NewDecoder(io.LimitReader(response.Body, 512*1024))
+	if err := decoder.Decode(&metadata); err != nil || strings.TrimSpace(metadata.Version) != strings.TrimSpace(version) {
+		return npmPackageVersionMetadata{}, false
+	}
+	return metadata, true
 }
 
 func (s Service) probeNPMRegistryPackage(ctx context.Context, registry string, packageName string) bool {
@@ -169,13 +191,7 @@ func (s Service) probeNPMRegistryPackage(ctx context.Context, registry string, p
 }
 
 func npmRegistryPackageEndpoint(registry string, packageName string) string {
-	registry = strings.TrimRight(strings.TrimSpace(registry), "/")
-	packageName = strings.TrimSpace(packageName)
-	if registry == "" || packageName == "" {
-		return registry
-	}
-	escapedPackage := strings.ReplaceAll(packageName, "/", "%2f")
-	return registry + "/" + escapedPackage
+	return managednpm.PackageEndpoint(registry, packageName, "")
 }
 
 // withAgentNPMRegistry returns env with exactly one npm_config_registry entry.

--- a/services/tuttid/service/agentstatus/npm_registry_test.go
+++ b/services/tuttid/service/agentstatus/npm_registry_test.go
@@ -3,14 +3,17 @@ package agentstatus
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
 
+	"github.com/tutti-os/tutti/packages/agent/daemon/managednpm"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )
 
@@ -279,6 +282,36 @@ func TestRankedAgentNPMRegistriesMovesHTTPErrorBehindSuccessfulMirror(t *testing
 	got := service.rankedAgentNPMRegistries(context.Background(), "@openai/codex")
 	if len(got) == 0 || got[0] != "https://repo.huaweicloud.com/repository/npm/" {
 		t.Fatalf("rankedAgentNPMRegistries()[0] = %q, want first successful mirror; full order=%#v", got[0], got)
+	}
+}
+
+func TestRankedManagedNPMRegistriesRejectsMirrorMissingPlatformPackage(t *testing.T) {
+	npmOS, npmArch, ok := managednpm.NPMPlatform(runtime.GOOS, runtime.GOARCH)
+	if !ok {
+		t.Fatalf("NPMPlatform(%q, %q) unsupported", runtime.GOOS, runtime.GOARCH)
+	}
+	platformDependency := fmt.Sprintf("@tutti-os/tutti-agent-%s-%s", npmOS, npmArch)
+	platformVersion := fmt.Sprintf("0.0.4-%s-%s", npmOS, npmArch)
+	service := Service{
+		Environ: func() []string { return []string{"PATH=/usr/bin"} },
+		HTTPClient: &http.Client{Transport: networkRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+			body := `{"version":"` + platformVersion + `"}`
+			if !strings.Contains(request.URL.Path, platformVersion) {
+				optional := ""
+				if request.URL.Host != "registry.npmjs.org" {
+					optional = fmt.Sprintf(`,"optionalDependencies":{"%s":"npm:@tutti-os/tutti-agent@%s"}`, platformDependency, platformVersion)
+				}
+				body = `{"version":"0.0.4"` + optional + `}`
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+		})},
+	}
+
+	got := service.rankedManagedNPMRegistries(context.Background(), ManagedNPMPackageInstallerSpec{
+		PackageName: "@tutti-os/tutti-agent", PackageVersion: "0.0.4", BinaryName: "tutti-agent", IncludeOptional: true,
+	})
+	if len(got) == 0 || got[0] != "https://repo.huaweicloud.com/repository/npm/" {
+		t.Fatalf("rankedManagedNPMRegistries()[0] = %q, want complete mirror; full order=%#v", got[0], got)
 	}
 }
 

--- a/services/tuttid/service/agentstatus/registry.go
+++ b/services/tuttid/service/agentstatus/registry.go
@@ -232,7 +232,7 @@ func installerSpecFromProviderDescriptor(descriptor providerregistry.InstallerDe
 			DisplayCommand:       descriptor.DisplayCommand,
 			FailureReasonMarkers: failureReasonMarkers,
 			ManagedNPM: &ManagedNPMPackageInstallerSpec{
-				PackageName: descriptor.PackageName, BinaryName: descriptor.BinaryName, IncludeOptional: descriptor.IncludeOptional,
+				PackageName: descriptor.PackageName, PackageVersion: descriptor.RecommendedVersion, BinaryName: descriptor.BinaryName, IncludeOptional: descriptor.IncludeOptional,
 			},
 		}, nil
 	case providerregistry.InstallerKindShellCommand:

--- a/services/tuttid/service/agentstatus/service_helpers.go
+++ b/services/tuttid/service/agentstatus/service_helpers.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tutti-os/tutti/packages/agent/daemon/managednpm"
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 	claudecodeservice "github.com/tutti-os/tutti/services/tuttid/service/claudecode"
@@ -373,6 +374,22 @@ func parseCLIVersion(output string) string {
 // every supported provider (not just codex) so the config panel can show the
 // installed CLI version.
 func (Service) cliVersion(ctx context.Context, binaryPath string, env []string) string {
+	return parseCLIVersion(cliVersionOutput(ctx, binaryPath, env))
+}
+
+// providerCLIVersion applies the public managed-npm version contract to
+// managed package providers. Other providers retain their historical
+// semver-ish output compatibility.
+func (Service) providerCLIVersion(ctx context.Context, spec ProviderSpec, binaryPath string, env []string) string {
+	output := cliVersionOutput(ctx, binaryPath, env)
+	if providerUsesManagedNPMVersionContract(spec) {
+		version, _ := managednpm.ExtractVersion(output)
+		return version
+	}
+	return parseCLIVersion(output)
+}
+
+func cliVersionOutput(ctx context.Context, binaryPath string, env []string) string {
 	binaryPath = strings.TrimSpace(binaryPath)
 	if binaryPath == "" {
 		return ""
@@ -390,7 +407,7 @@ func (Service) cliVersion(ctx context.Context, binaryPath string, env []string) 
 	if err != nil {
 		return ""
 	}
-	return parseCLIVersion(string(output))
+	return string(output)
 }
 
 func cloneProviderChecks(input []ProviderCheck) []ProviderCheck {

--- a/services/tuttid/service/agentstatus/service_status.go
+++ b/services/tuttid/service/agentstatus/service_status.go
@@ -83,7 +83,7 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 		cliVersionRan = true
 		checks.Go(func() error {
 			cliVersionStartedAt := time.Now()
-			cliVersion = s.cliVersion(ctx, runtimeResolution.CLIPath, runtimeResolution.Env)
+			cliVersion = s.providerCLIVersion(ctx, spec, runtimeResolution.CLIPath, runtimeResolution.Env)
 			cliVersionDuration = time.Since(cliVersionStartedAt)
 			return nil
 		})

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 	externalagentregistry "github.com/tutti-os/tutti/services/tuttid/service/externalagentregistry"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )
@@ -142,6 +143,9 @@ func TestDefaultRegistryUsesTuttiAgentManagedNPMInstaller(t *testing.T) {
 	if install.ManagedNPM.BinaryName != "tutti-agent" {
 		t.Fatalf("BinaryName = %q, want tutti-agent", install.ManagedNPM.BinaryName)
 	}
+	if install.ManagedNPM.PackageVersion != providerregistry.TuttiAgentRecommendedVersion {
+		t.Fatalf("PackageVersion = %q, want %q", install.ManagedNPM.PackageVersion, providerregistry.TuttiAgentRecommendedVersion)
+	}
 	if !install.ManagedNPM.IncludeOptional {
 		t.Fatalf("IncludeOptional = false, want true")
 	}
@@ -151,7 +155,7 @@ func TestDefaultRegistryUsesTuttiAgentManagedNPMInstaller(t *testing.T) {
 }
 
 func TestServiceListUsesDescriptorOwnedDaemonLoginAction(t *testing.T) {
-	service, _ := updateTestService(t, "0.0.4")
+	service, _ := updateTestService(t, "0.0.5")
 
 	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"tutti-agent"}})
 	if err != nil {

--- a/services/tuttid/service/agentstatus/service_update.go
+++ b/services/tuttid/service/agentstatus/service_update.go
@@ -127,7 +127,7 @@ func (s Service) DiscoverManagedProviderUpdates(ctx context.Context) error {
 		runtimeResolution := s.resolveProviderRuntime(ctx, spec)
 		currentVersion := ""
 		if strings.TrimSpace(runtimeResolution.CLIPath) != "" {
-			currentVersion = s.cliVersion(ctx, runtimeResolution.CLIPath, runtimeResolution.Env)
+			currentVersion = s.providerCLIVersion(ctx, spec, runtimeResolution.CLIPath, runtimeResolution.Env)
 		}
 		status := baseProviderUpdateStatus(spec, currentVersion, runtimeResolution.CLIPath)
 		if status.Capability != UpdateCapabilitySupported || status.CurrentVersion == "" {
@@ -274,7 +274,7 @@ func (s Service) runUpdateAction(ctx context.Context, spec ProviderSpec, result 
 		result.Message = "Provider CLI installation source is not managed npm"
 		return result, nil
 	}
-	currentVersion := s.cliVersion(ctx, runtimeResolution.CLIPath, runtimeResolution.Env)
+	currentVersion := s.providerCLIVersion(ctx, spec, runtimeResolution.CLIPath, runtimeResolution.Env)
 	update := s.updateStatusForSpec(ctx, spec, currentVersion, runtimeResolution.CLIPath, true)
 	if update.ReasonCode != "" {
 		result.Status = RunActionFailed

--- a/services/tuttid/service/agentstatus/service_update_test.go
+++ b/services/tuttid/service/agentstatus/service_update_test.go
@@ -69,8 +69,8 @@ func TestTuttiAgentBelowMinimumRequiresManagedInstall(t *testing.T) {
 	if status.Availability.Status != AvailabilityNotInstalled || status.Availability.ReasonCode != "cli_version_unsupported" {
 		t.Fatalf("Availability = %#v, want minimum-version repair", status.Availability)
 	}
-	if status.CLI.Version != "0.0.2" || status.CLI.MinVersion != "0.0.4" {
-		t.Fatalf("CLI = %#v, want current 0.0.2 and minimum 0.0.4", status.CLI)
+	if status.CLI.Version != "0.0.2" || status.CLI.MinVersion != "0.0.5" {
+		t.Fatalf("CLI = %#v, want current 0.0.2 and minimum 0.0.5", status.CLI)
 	}
 	if !hasProviderAction(status.Actions, ActionInstall) {
 		t.Fatalf("Actions = %#v, want install", status.Actions)
@@ -116,7 +116,7 @@ func TestTuttiAgentUnknownVersionFailsClosed(t *testing.T) {
 			if status.Availability.Status != AvailabilityNotInstalled || status.Availability.ReasonCode != "cli_version_unsupported" {
 				t.Fatalf("Availability = %#v, want unknown-version repair", status.Availability)
 			}
-			if status.CLI.Version != "" || status.CLI.MinVersion != "0.0.4" || !hasProviderAction(status.Actions, ActionInstall) {
+			if status.CLI.Version != "" || status.CLI.MinVersion != "0.0.5" || !hasProviderAction(status.Actions, ActionInstall) {
 				t.Fatalf("CLI/actions = %#v/%#v, want unknown current version and managed install", status.CLI, status.Actions)
 			}
 
@@ -128,6 +128,22 @@ func TestTuttiAgentUnknownVersionFailsClosed(t *testing.T) {
 				t.Fatalf("Probe = %#v, want unknown-version failure", probe)
 			}
 		})
+	}
+}
+
+func TestTuttiAgentNonCanonicalVersionUsesManagedNPMContract(t *testing.T) {
+	service, _ := updateTestService(t, "0.0.5.1")
+
+	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"tutti-agent"}})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	status := onlyStatus(t, snapshot)
+	if status.CLI.Version != "" || status.Availability.Status != AvailabilityNotInstalled || status.Availability.ReasonCode != "cli_version_unsupported" {
+		t.Fatalf("status = %#v, want non-canonical managed-npm version to fail closed", status)
+	}
+	if !hasProviderAction(status.Actions, ActionInstall) {
+		t.Fatalf("Actions = %#v, want repair install", status.Actions)
 	}
 }
 
@@ -144,13 +160,13 @@ func TestTuttiAgentVersionFloorPrecedesAdapterFailure(t *testing.T) {
 	if status.Availability.ReasonCode != "cli_version_unsupported" {
 		t.Fatalf("Availability = %#v, want CLI floor before adapter failure", status.Availability)
 	}
-	if status.CLI.Version != "0.0.2" || status.CLI.MinVersion != "0.0.4" {
+	if status.CLI.Version != "0.0.2" || status.CLI.MinVersion != "0.0.5" {
 		t.Fatalf("CLI = %#v, want version evidence retained", status.CLI)
 	}
 }
 
 func TestCompatibleTuttiAgentDoesNotRequireManagedInstall(t *testing.T) {
-	for _, version := range []string{"0.0.4", "0.0.5"} {
+	for _, version := range []string{"0.0.5", "0.0.6"} {
 		t.Run(version, func(t *testing.T) {
 			service, _ := updateTestService(t, version)
 			snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"tutti-agent"}})
@@ -196,10 +212,10 @@ func TestRunInstallActionUpgradesTuttiAgentBelowMinimumAndReprobes(t *testing.T)
 	var commands atomic.Int32
 	service.InstallCommand = func(_ context.Context, input InstallCommandInput) (InstallCommandResult, error) {
 		commands.Add(1)
-		if !strings.Contains(input.Command, "@tutti-os/tutti-agent") {
-			t.Fatalf("install command = %q, want managed Tutti Agent package", input.Command)
+		if !strings.Contains(input.Command, "@tutti-os/tutti-agent@0.0.5") {
+			t.Fatalf("install command = %q, want exact managed Tutti Agent 0.0.5 package", input.Command)
 		}
-		writeUpdateTestCLI(t, binaryPath, "0.0.4")
+		writeUpdateTestCLI(t, binaryPath, "0.0.5")
 		return InstallCommandResult{ExitCode: 0, Stdout: "updated"}, nil
 	}
 
@@ -216,7 +232,7 @@ func TestRunInstallActionUpgradesTuttiAgentBelowMinimumAndReprobes(t *testing.T)
 		t.Fatalf("post-install List() error = %v", err)
 	}
 	status := onlyStatus(t, snapshot)
-	if status.Availability.Status != AvailabilityReady || status.CLI.Version != "0.0.4" {
+	if status.Availability.Status != AvailabilityReady || status.CLI.Version != "0.0.5" {
 		t.Fatalf("post-install status = %#v", status)
 	}
 }

--- a/services/tuttid/service/tuttiagent/service.go
+++ b/services/tuttid/service/tuttiagent/service.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
+	"github.com/tutti-os/tutti/packages/agent/daemon/tuttiagentauth"
 	runtimeprep "github.com/tutti-os/tutti/packages/agent/runtimeprep"
 	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
 )
@@ -26,7 +27,10 @@ const (
 	tuttiAgentLLMTokenIssueRoute = "/auth/v1/llm-token"
 )
 
-var tuttiAgentDefaultLLMAppID = "nex" + "top"
+var (
+	tuttiAgentDefaultLLMAppID = "nex" + "top"
+	tuttiAgentAuthReconciler  tuttiagentauth.Reconciler
+)
 
 // NewPreparer returns the shared runtime preparer with Tutti account bootstrap
 // injected at the product boundary.
@@ -71,27 +75,14 @@ func LogoutTuttiAgentUserAuth(ctx context.Context) {
 }
 
 func logoutTuttiAgentUserAuth(ctx context.Context) error {
-	authPath, ok := userTuttiAgentAuthPath()
-	if !ok {
-		return nil
+	target, err := tuttiAgentAuthReconciler.RemoveLocal(ctx, tuttiAgentUserCredentialStore{})
+	if err != nil {
+		return err
 	}
-	if _, err := os.Stat(authPath); errors.Is(err, os.ErrNotExist) {
-		return nil
-	} else if err != nil {
-		return fmt.Errorf("stat tutti-agent auth.json: %w", err)
-	}
-	raw, readErr := os.ReadFile(authPath)
-	if readErr != nil {
-		slog.Warn("read tutti-agent auth before cleanup failed", "error", readErr)
-	}
-	removeErr := os.Remove(authPath)
-	if removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-		return fmt.Errorf("remove tutti-agent auth.json: %w", removeErr)
-	}
-	if refreshToken, accountBaseURL, ok := parseTuttiAgentLLMRevokeTarget(raw); ok {
+	if target.Valid() {
 		revokeCtx := context.WithoutCancel(ctx)
 		go func() {
-			if err := revokeTuttiAgentLLMToken(revokeCtx, accountBaseURL, refreshToken); err != nil {
+			if err := (tuttiAgentSessionAuthorizer{}).Revoke(revokeCtx, target, "logout"); err != nil {
 				slog.Warn("tutti-agent llm token revoke failed", "error", err)
 			}
 		}()
@@ -110,12 +101,18 @@ func bootstrapTuttiAgentUserAuth(ctx context.Context, input runtimeprep.PrepareI
 		slog.Debug("tutti-agent auth bootstrap skipped", "reason", "no_host_account_session", "agent_session_id", input.AgentSessionID)
 		return
 	}
-	if tuttiAgentUserAuthReady() {
+	if tuttiAgentUserAuthMaterialReady() {
 		return
 	}
-	bundle, err := issueTuttiAgentLLMToken(ctx, cookie)
+	_, err := tuttiAgentAuthReconciler.Reconcile(
+		ctx,
+		tuttiAgentSessionAuthorizer{cookie: cookie},
+		tuttiAgentUserCredentialStore{},
+		tuttiAgentLoginRunner{},
+		time.Now().UTC(),
+	)
 	if err != nil {
-		slog.Warn("tutti-agent llm token issue failed", "error", err)
+		slog.Warn("tutti-agent auth reconcile failed", "error", err)
 		if tuttiAgentLLMTokenIssueRejectedWithCode(err, http.StatusUnauthorized) {
 			if cleanupErr := logoutTuttiAgentUserAuth(ctx); cleanupErr != nil {
 				slog.Warn("tutti-agent auth cleanup after token rejection failed", "error", cleanupErr)
@@ -123,42 +120,44 @@ func bootstrapTuttiAgentUserAuth(ctx context.Context, input runtimeprep.PrepareI
 		}
 		return
 	}
-	if err := runTuttiAgentTokenLogin(ctx, bundle); err != nil {
-		slog.Warn("tutti-agent token login failed", "error", err)
-		return
-	}
 	slog.Debug("tutti-agent auth bootstrap resolved", "agent_session_id", input.AgentSessionID)
 }
 
-func tuttiAgentUserAuthReady() bool {
-	authPath, ok := userTuttiAgentAuthPath()
-	if !ok {
-		return false
-	}
-	raw, err := os.ReadFile(authPath)
-	if err != nil {
-		return false
-	}
+func tuttiAgentUserAuthMaterialReady() bool {
+	state, err := (tuttiAgentUserCredentialStore{}).Inspect(context.Background())
+	return err == nil && state.MaterialReady
+}
+
+func inspectTuttiAgentCredential(raw []byte) tuttiagentauth.CredentialState {
 	var payload struct {
 		TuttiLLM *struct {
+			AccountBaseURL       string          `json:"account_base_url"`
 			AccessToken          string          `json:"access_token"`
 			AccessTokenExpiresAt json.RawMessage `json:"access_token_expires_at"`
 			RefreshToken         string          `json:"refresh_token"`
 		} `json:"tutti_llm"`
 	}
 	if err := json.Unmarshal(raw, &payload); err != nil {
-		return false
+		return tuttiagentauth.CredentialState{}
 	}
 	if payload.TuttiLLM == nil ||
 		strings.TrimSpace(payload.TuttiLLM.AccessToken) == "" ||
 		strings.TrimSpace(payload.TuttiLLM.RefreshToken) == "" {
-		return false
+		return tuttiagentauth.CredentialState{}
+	}
+	state := tuttiagentauth.CredentialState{RevokeTarget: tuttiagentauth.RevokeTarget{
+		AccountBaseURL: payload.TuttiLLM.AccountBaseURL,
+		RefreshToken:   payload.TuttiLLM.RefreshToken,
+	}}
+	if strings.TrimSpace(state.RevokeTarget.AccountBaseURL) == "" {
+		state.RevokeTarget.AccountBaseURL = tuttiAgentAccountBase()
 	}
 	expiresAt, ok := parseTuttiAgentTokenExpiresAt(payload.TuttiLLM.AccessTokenExpiresAt)
 	if !ok {
-		return false
+		return state
 	}
-	return time.Now().UTC().Before(expiresAt)
+	state.MaterialReady = time.Now().UTC().Before(expiresAt)
+	return state
 }
 
 func parseTuttiAgentTokenExpiresAt(raw json.RawMessage) (time.Time, bool) {
@@ -216,15 +215,52 @@ func tuttiAgentAccountSessionCookie() (string, bool) {
 	return "", false
 }
 
-type tuttiAgentLLMTokenBundle struct {
-	AppID                 string   `json:"app_id"`
-	AccountBaseURL        string   `json:"account_base_url"`
-	AccessToken           string   `json:"access_token"`
-	AccessTokenExpiresAt  int64    `json:"access_token_expires_at"`
-	RefreshToken          string   `json:"refresh_token"`
-	RefreshTokenExpiresAt int64    `json:"refresh_token_expires_at"`
-	TokenType             string   `json:"token_type"`
-	Scopes                []string `json:"scopes"`
+type tuttiAgentLLMTokenBundle = tuttiagentauth.TokenBundle
+
+type tuttiAgentSessionAuthorizer struct {
+	cookie string
+}
+
+func (a tuttiAgentSessionAuthorizer) Issue(ctx context.Context) (tuttiagentauth.TokenBundle, error) {
+	return issueTuttiAgentLLMToken(ctx, a.cookie)
+}
+
+func (tuttiAgentSessionAuthorizer) Revoke(ctx context.Context, target tuttiagentauth.RevokeTarget, reason string) error {
+	return revokeTuttiAgentLLMToken(ctx, target.AccountBaseURL, target.RefreshToken, reason)
+}
+
+type tuttiAgentUserCredentialStore struct{}
+
+func (tuttiAgentUserCredentialStore) Inspect(context.Context) (tuttiagentauth.CredentialState, error) {
+	authPath, ok := userTuttiAgentAuthPath()
+	if !ok {
+		return tuttiagentauth.CredentialState{}, nil
+	}
+	raw, err := os.ReadFile(authPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return tuttiagentauth.CredentialState{}, nil
+	}
+	if err != nil {
+		return tuttiagentauth.CredentialState{}, fmt.Errorf("read tutti-agent auth state: %w", err)
+	}
+	return inspectTuttiAgentCredential(raw), nil
+}
+
+func (tuttiAgentUserCredentialStore) Remove(context.Context) error {
+	authPath, ok := userTuttiAgentAuthPath()
+	if !ok {
+		return nil
+	}
+	if err := os.Remove(authPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove tutti-agent auth state: %w", err)
+	}
+	return nil
+}
+
+type tuttiAgentLoginRunner struct{}
+
+func (tuttiAgentLoginRunner) Login(ctx context.Context, bundle tuttiagentauth.TokenBundle) error {
+	return runTuttiAgentTokenLogin(ctx, bundle)
 }
 
 type tuttiAgentLLMTokenIssueRejectedError struct {
@@ -302,31 +338,10 @@ func issueTuttiAgentLLMToken(ctx context.Context, cookie string) (tuttiAgentLLMT
 	}, nil
 }
 
-func parseTuttiAgentLLMRevokeTarget(raw []byte) (string, string, bool) {
-	var payload struct {
-		TuttiLLM *struct {
-			AccountBaseURL string `json:"account_base_url"`
-			RefreshToken   string `json:"refresh_token"`
-		} `json:"tutti_llm"`
-	}
-	if err := json.Unmarshal(raw, &payload); err != nil || payload.TuttiLLM == nil {
-		return "", "", false
-	}
-	refreshToken := strings.TrimSpace(payload.TuttiLLM.RefreshToken)
-	if refreshToken == "" {
-		return "", "", false
-	}
-	accountBaseURL := strings.TrimSpace(payload.TuttiLLM.AccountBaseURL)
-	if accountBaseURL == "" {
-		accountBaseURL = tuttiAgentAccountBase()
-	}
-	return refreshToken, accountBaseURL, true
-}
-
-func revokeTuttiAgentLLMToken(ctx context.Context, accountBaseURL string, refreshToken string) error {
+func revokeTuttiAgentLLMToken(ctx context.Context, accountBaseURL string, refreshToken string, reason string) error {
 	requestBody, err := json.Marshal(map[string]string{
 		"refresh_token": refreshToken,
-		"reason":        "logout",
+		"reason":        strings.TrimSpace(reason),
 	})
 	if err != nil {
 		return err

--- a/services/tuttid/service/tuttiagent/service_test.go
+++ b/services/tuttid/service/tuttiagent/service_test.go
@@ -79,8 +79,8 @@ func TestTuttiAgentUserAuthReadyRejectsExpiredAccessToken(t *testing.T) {
 	expiresAt := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
 	writeTuttiAgentUserAuth(t, t.TempDir(), `{"tutti_llm":{"access_token":"lat_test","access_token_expires_at":`+strconv.Quote(expiresAt)+`,"refresh_token":"lrt_test"}}`)
 
-	if tuttiAgentUserAuthReady() {
-		t.Fatal("tuttiAgentUserAuthReady() = true, want false for expired access token")
+	if tuttiAgentUserAuthMaterialReady() {
+		t.Fatal("tuttiAgentUserAuthMaterialReady() = true, want false for expired access token")
 	}
 }
 
@@ -88,8 +88,8 @@ func TestTuttiAgentUserAuthReadyAcceptsFutureAccessTokenExpiry(t *testing.T) {
 	expiresAt := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
 	writeTuttiAgentUserAuth(t, t.TempDir(), `{"tutti_llm":{"access_token":"lat_test","access_token_expires_at":`+strconv.Quote(expiresAt)+`,"refresh_token":"lrt_test"}}`)
 
-	if !tuttiAgentUserAuthReady() {
-		t.Fatal("tuttiAgentUserAuthReady() = false, want true for unexpired access token")
+	if !tuttiAgentUserAuthMaterialReady() {
+		t.Fatal("tuttiAgentUserAuthMaterialReady() = false, want true for unexpired access token")
 	}
 }
 
@@ -97,16 +97,16 @@ func TestTuttiAgentUserAuthReadyAcceptsUnixAccessTokenExpiry(t *testing.T) {
 	expiresAt := strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10)
 	writeTuttiAgentUserAuth(t, t.TempDir(), `{"tutti_llm":{"access_token":"lat_test","access_token_expires_at":`+expiresAt+`,"refresh_token":"lrt_test"}}`)
 
-	if !tuttiAgentUserAuthReady() {
-		t.Fatal("tuttiAgentUserAuthReady() = false, want true for numeric access token expiry")
+	if !tuttiAgentUserAuthMaterialReady() {
+		t.Fatal("tuttiAgentUserAuthMaterialReady() = false, want true for numeric access token expiry")
 	}
 }
 
 func TestTuttiAgentUserAuthReadyRejectsMissingAccessTokenExpiry(t *testing.T) {
 	writeTuttiAgentUserAuth(t, t.TempDir(), `{"tutti_llm":{"access_token":"lat_test","refresh_token":"lrt_test"}}`)
 
-	if tuttiAgentUserAuthReady() {
-		t.Fatal("tuttiAgentUserAuthReady() = true, want false without access token expiry")
+	if tuttiAgentUserAuthMaterialReady() {
+		t.Fatal("tuttiAgentUserAuthMaterialReady() = true, want false without access token expiry")
 	}
 }
 
@@ -160,6 +160,9 @@ func TestBootstrapTuttiAgentUserAuthIssuesTokenWhenExistingAccessTokenExpired(t 
 	}
 	if !strings.Contains(string(loginJSON), `"access_token":"lat_new"`) {
 		t.Fatalf("login payload = %s, want issued access token", string(loginJSON))
+	}
+	if !tuttiAgentUserAuthMaterialReady() {
+		t.Fatal("tutti-agent credential material is not usable after successful reconcile")
 	}
 }
 
@@ -298,7 +301,9 @@ func installFakeTuttiAgentBinary(t *testing.T) {
 		"  echo unexpected arguments: \"$@\" >&2\n" +
 		"  exit 2\n" +
 		"fi\n" +
-		"cat > \"$TUTTI_AGENT_LOGIN_CAPTURE\"\n"
+		"cat > \"$TUTTI_AGENT_LOGIN_CAPTURE\"\n" +
+		"mkdir -p \"$HOME/.tutti-agent\"\n" +
+		"printf '%s' '{\"tutti_llm\":{\"access_token\":\"lat_new\",\"access_token_expires_at\":4102444800,\"refresh_token\":\"lrt_new\"}}' > \"$HOME/.tutti-agent/auth.json\"\n"
 	if err := os.WriteFile(binaryPath, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- publish host-neutral managed npm descriptor, strict version policy, six-target Go-to-npm platform mapping, and complete-registry ranking
- publish host-neutral Tutti Agent credential reconciliation and VM-backed auth-source runtime preparation
- make Tutti consume the same managed npm version/registry policy and pin minimum/recommended Tutti Agent to 0.0.5

## Dependency gate
Do not merge or deploy until @tutti-os/tutti-agent@0.0.5 is published to the real npm registry and an isolated registry install verifies:
- tutti-agent --version returns exactly 0.0.5
- tutti-agent app-server starts/probes successfully
- the required platform optional package is resolvable

Dependency release fix: https://github.com/tutti-os/tutti-agent/pull/32
Full-target dry-run: https://github.com/tutti-os/tutti-agent/actions/runs/29949281320

## Validation
- pnpm check:changed: 12/12 passed
- push-ready hook: 13/13 passed
- go test -race for managednpm, providerregistry, tuttiagentauth, runtimeprep, agentstatus, tuttiagent
- staged Linux x64 JS launcher smoke passed in CI
- staged darwin-arm64 main plus platform tarballs executed locally as tutti-agent 0.0.5
- independent subagent final review: no Blocker or High after fixes

## Architecture constraints
- public managednpm is policy only; Host owns VM execution, lifecycle, singleflight, paths, and transport
- credential MaterialReady is not product authentication/readiness; Host must run provider probe
- no user-id credential directory is introduced
- Codex keeps its existing permissive version compatibility path; managed npm providers fail closed on non-canonical versions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->