### PR TITLE
fix(agent): allow cold VM registry probes

### DIFF
--- a/packages/agent/daemon/managednpm/registry.go
+++ b/packages/agent/daemon/managednpm/registry.go
@@ -13,7 +13,10 @@ const (
 	OfficialRegistryURL = "https://registry.npmjs.org"
 	HuaweiRegistryURL   = "https://repo.huaweicloud.com/repository/npm/"
 	TencentRegistryURL  = "https://mirrors.cloud.tencent.com/npm/"
-	DefaultProbeTimeout = 5 * time.Second
+	// Registry probes can perform two cold npm metadata requests (the root
+	// package and its platform package) inside a newly started VM. Keep the
+	// candidates concurrent, but allow enough time for first DNS/TLS/cache use.
+	DefaultProbeTimeout = 20 * time.Second
 	MinimumRankDelta    = 25 * time.Millisecond
 )
 


### PR DESCRIPTION
## What changed
- increase the shared managed npm registry probe budget from 5s to 20s
- keep all registry candidates concurrent, so healthy-path selection still completes when the fastest complete source responds

## Why
A real TSH Linux VM cold-start validation showed that each candidate can require two npm metadata requests after first DNS/TLS/cache initialization. The previous 5s shared context canceled all candidates before completeness could be verified, leaving no eligible registry.

## Risk
When every registry is unavailable, failure can now take up to 20s instead of 5s. Candidates remain concurrent and no host command/path/credential responsibility moves into the package.

## Verification
- `go test ./packages/agent/daemon/managednpm -count=1`
- `git diff --check`
- pre-push `pnpm check:changed -- --push-ready` (8 lanes)

## Documentation impact
No durable documentation change: this corrects an internal default timeout without changing the public contract or ownership boundary.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->