### PR TITLE
fix(agent): preserve Tutti activation on session create

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -177,12 +177,23 @@ export function createDesktopAgentActivityAdapter({
           event: "renderer_adapter.create.http_requested",
           provider: null,
           submitDiagnostics: input.submitDiagnostics,
-          workspaceId: input.workspaceId
+          workspaceId: input.workspaceId,
+          fields: {
+            hasInitialTuttiModeActivation:
+              input.initialTuttiModeActivation != null
+          }
         });
         const agentTargetId = requiredAgentTargetId(input.agentTargetId);
         const request: CreateWorkspaceAgentSessionRequest = {
           agentSessionId,
           agentTargetId,
+          ...(input.capabilityRefs?.length
+            ? {
+                capabilityRefs: input.capabilityRefs.map(
+                  toTuttidCapabilityReference
+                )
+              }
+            : {}),
           clientSubmitId: input.clientSubmitId,
           cwd: input.cwd ?? null,
           initialContent: toTuttidPromptContentBlocks(
@@ -236,7 +247,11 @@ export function createDesktopAgentActivityAdapter({
           agentSessionId: input.agentSessionId?.trim() ?? null,
           clientSubmitId: input.clientSubmitId,
           event: "renderer_adapter.create.failed",
-          fields: normalizeDesktopAgentDiagnosticError(error),
+          fields: {
+            ...normalizeDesktopAgentDiagnosticError(error),
+            hasInitialTuttiModeActivation:
+              input.initialTuttiModeActivation != null
+          },
           provider: null,
           submitDiagnostics: input.submitDiagnostics,
           workspaceId: input.workspaceId

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
@@ -715,17 +715,12 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
         command.agentSessionId
       );
       if (isWorkspaceAgentSessionNotFoundError(error)) {
-        this.markSessionDeleted({
-          agentSessionId: command.agentSessionId,
-          data: { reason: "workspace_agent_session_not_found" },
-          workspaceId: command.workspaceId
-        });
         void this.reconcileDependencies.runtimeApi.logTerminalDiagnostic({
           details: {
             agentSessionId: command.agentSessionId,
             error: stringifyError(error)
           },
-          event: "agent.activity.reconcile_session_missing",
+          event: "agent.activity.reconcile_session_absent",
           level: "info",
           workspaceId: command.workspaceId
         });

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -4,6 +4,7 @@ import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
 import { TuttidProtocolError } from "@tutti-os/client-tuttid-ts";
 import {
   selectEnginePromptQueue,
+  selectEngineSession,
   selectEngineTurnsForSession,
   selectSessionActivationPresentations,
   selectSessionAttention,
@@ -156,9 +157,15 @@ test("WorkspaceAgentActivityService.activateSession creates target-backed sessio
   await service.activateSession({
     agentSessionId: "11111111-1111-4111-8111-111111111111",
     agentTargetId: "local:codex",
+    capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
     clientSubmitId: "submit-activate-codex",
     cwd: "/workspace",
     initialContent: [{ type: "text", text: "hello" }],
+    initialTuttiModeActivation: {
+      orchestrationIntensity: 73,
+      source: "slash_command",
+      status: "active"
+    },
     mode: "new",
     title: "Shared Codex",
     visible: true,
@@ -171,10 +178,16 @@ test("WorkspaceAgentActivityService.activateSession creates target-backed sessio
     request: {
       agentSessionId: "11111111-1111-4111-8111-111111111111",
       agentTargetId: "local:codex",
+      capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
       clientSubmitId: "submit-activate-codex",
       cwd: "/workspace",
       initialContent: [{ type: "text", text: "hello" }],
       initialDisplayPrompt: null,
+      initialTuttiModeActivation: {
+        orchestrationIntensity: 73,
+        source: "slash_command",
+        status: "active"
+      },
       model: null,
       noProject: null,
       permissionModeId: null,
@@ -188,12 +201,19 @@ test("WorkspaceAgentActivityService.activateSession creates target-backed sessio
 });
 
 test("WorkspaceAgentActivityService confirms engine activation from the realtime session upsert", async () => {
+  const createRequests: unknown[] = [];
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
-      createWorkspaceAgentSession: async () => ({
-        ...workspaceAgentSession({ status: "completed" }),
-        createdAtUnixMs: Date.now()
-      }),
+      createWorkspaceAgentSession: async (
+        _workspaceId: string,
+        request: Parameters<TuttidClient["createWorkspaceAgentSession"]>[1]
+      ) => {
+        createRequests.push(request);
+        return {
+          ...workspaceAgentSession({ status: "completed" }),
+          createdAtUnixMs: Date.now()
+        };
+      },
       listWorkspaceAgentSessions: async () => ({
         hasMore: false,
         sessions: [],
@@ -208,14 +228,43 @@ test("WorkspaceAgentActivityService confirms engine activation from the realtime
     type: "activation/requested",
     agentSessionId: "session-1",
     agentTargetId: "local:codex",
+    capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
     clientSubmitId: "submit-1",
     expiresAtUnixMs: requestedAtUnixMs + 45_000,
     mode: "new",
+    initialTuttiModeActivation: {
+      orchestrationIntensity: 73,
+      source: "slash_command",
+      status: "active"
+    },
     requestedAtUnixMs,
     requestId: "activation-1",
     workspaceId: "ws-1"
   });
   await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(createRequests[0], {
+    agentSessionId: "session-1",
+    agentTargetId: "local:codex",
+    capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
+    clientSubmitId: "submit-1",
+    cwd: null,
+    initialContent: [],
+    initialDisplayPrompt: null,
+    initialTuttiModeActivation: {
+      orchestrationIntensity: 73,
+      source: "slash_command",
+      status: "active"
+    },
+    model: null,
+    noProject: true,
+    permissionModeId: null,
+    planMode: null,
+    reasoningEffort: null,
+    speed: null,
+    title: null,
+    visible: true
+  });
 
   assert.equal(
     selectSessionActivationPresentations(engine.getSnapshot())["session-1"]
@@ -2414,7 +2463,7 @@ test("WorkspaceAgentActivityService.listPinnedSessionsPage forwards cursor to tu
   assert.equal(result.totalCount, 1);
 });
 
-test("WorkspaceAgentActivityService treats missing reconcile sessions as tombstones", async () => {
+test("WorkspaceAgentActivityService does not tombstone a missing reconcile without deletion evidence", async () => {
   const diagnostics: unknown[] = [];
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
@@ -2449,15 +2498,173 @@ test("WorkspaceAgentActivityService treats missing reconcile sessions as tombsto
   });
   await new Promise((resolve) => setImmediate(resolve));
 
+  assert.equal(
+    service.getSessionEngine("ws-1").getSnapshot().sessionLifecycle
+      .deletedSessionIds["ghost-session"],
+    undefined
+  );
   assert.deepEqual(diagnostics.at(-1), {
     details: {
       agentSessionId: "ghost-session",
       error: "workspace agent session not found"
     },
-    event: "agent.activity.reconcile_session_missing",
+    event: "agent.activity.reconcile_session_absent",
     level: "info",
     workspaceId: "ws-1"
   });
+});
+
+test("WorkspaceAgentActivityService preserves a pending new session when the Tutti event races create visibility", async (t) => {
+  const diagnostics: unknown[] = [];
+  const listenersByTopic = new Map<string, (event: unknown) => void>();
+  let resolveCreate!: (value: Record<string, unknown>) => void;
+  let resolveActivation!: () => void;
+  const createResult = new Promise<Record<string, unknown>>((resolve) => {
+    resolveCreate = resolve;
+  });
+  const activationResolved = new Promise<void>((resolve) => {
+    resolveActivation = resolve;
+  });
+  const service = new WorkspaceAgentActivityService({
+    eventStreamClient: {
+      connect: async () => {},
+      dispose: () => {},
+      publishIntent: async () => {},
+      subscribe: (topic: string, listener: (event: unknown) => void) => {
+        listenersByTopic.set(topic, listener);
+        return () => {};
+      },
+      subscribeConnectionState: () => () => {}
+    } as never,
+    tuttidClient: {
+      createWorkspaceAgentSession: async () => createResult,
+      getWorkspaceAgentSession: async () => {
+        throw new TuttidProtocolError({
+          code: "workspace_not_found",
+          developerMessage: "workspace agent session not found",
+          reason: "workspace_agent_session_not_found",
+          statusCode: 404
+        });
+      },
+      listWorkspaceAgentSessions: async () => ({
+        hasMore: false,
+        sessions: [],
+        workspaceId: "ws-1"
+      })
+    } as unknown as TuttidClient,
+    runtimeApi: {
+      logTerminalDiagnostic: async (payload) => {
+        diagnostics.push(payload);
+        if (
+          payload.event === "agent.submit.trace" &&
+          payload.details &&
+          typeof payload.details === "object" &&
+          "traceEvent" in payload.details &&
+          payload.details.traceEvent === "activity_service.activate.resolved"
+        ) {
+          resolveActivation();
+        }
+      }
+    }
+  });
+  t.after(() => service.dispose());
+  const engine = service.getSessionEngine("ws-1");
+  await new Promise((resolve) => setImmediate(resolve));
+  const requestedAtUnixMs = Date.now();
+
+  engine.dispatch({
+    type: "activation/requested",
+    agentSessionId: "session-1",
+    agentTargetId: "local:codex",
+    clientSubmitId: "submit-1",
+    content: [{ type: "text", text: "hello" }],
+    expiresAtUnixMs: requestedAtUnixMs + 45_000,
+    mode: "new",
+    requestedAtUnixMs,
+    requestId: "activation-1",
+    workspaceId: "ws-1"
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const tuttiModeUpdated = listenersByTopic.get("workspace.tuttimode.updated");
+  assert.ok(tuttiModeUpdated);
+  tuttiModeUpdated({
+    payload: {
+      agentSessionId: "session-1",
+      workspaceId: "ws-1"
+    }
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(
+    engine.getSnapshot().sessionLifecycle.deletedSessionIds["session-1"],
+    undefined
+  );
+  assert.deepEqual(diagnostics.at(-1), {
+    details: {
+      agentSessionId: "session-1",
+      error: "workspace agent session not found"
+    },
+    event: "agent.activity.reconcile_session_absent",
+    level: "info",
+    workspaceId: "ws-1"
+  });
+
+  resolveCreate({
+    ...workspaceAgentSession({ status: "working" }),
+    createdAtUnixMs: requestedAtUnixMs
+  });
+  await activationResolved;
+
+  assert.equal(
+    selectEngineSession(engine.getSnapshot(), "session-1")?.provider,
+    "codex"
+  );
+  assert.equal(
+    selectEngineSession(engine.getSnapshot(), "session-1")?.activeTurnId,
+    "turn-1"
+  );
+  assert.equal(
+    selectSessionActivationPresentations(engine.getSnapshot())["session-1"]
+      ?.status,
+    "active"
+  );
+});
+
+test("WorkspaceAgentActivityService tombstones an explicit session deletion event", async () => {
+  const service = new WorkspaceAgentActivityService({
+    tuttidClient: {
+      listWorkspaceAgentSessions: async () => ({
+        hasMore: false,
+        sessions: [],
+        workspaceId: "ws-1"
+      })
+    } as unknown as TuttidClient,
+    runtimeApi: { logTerminalDiagnostic: async () => {} }
+  });
+  const engine = service.getSessionEngine("ws-1");
+
+  await (
+    service as unknown as {
+      reconcileAgentActivityUpdate(input: {
+        agentSessionId: string;
+        data: unknown;
+        eventType: string;
+        workspaceId: string;
+      }): Promise<void>;
+    }
+  ).reconcileAgentActivityUpdate({
+    agentSessionId: "session-1",
+    data: { reason: "deleted" },
+    eventType: "session_deleted",
+    workspaceId: "ws-1"
+  });
+
+  assert.equal(
+    engine.getSnapshot().sessionLifecycle.deletedSessionIds["session-1"],
+    true
+  );
 });
 
 test("WorkspaceAgentActivityService.submitPlanDecision uses one semantic daemon transport", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -420,7 +420,12 @@ export class WorkspaceAgentActivityService
       provider: null,
       submitDiagnostics: input.submitDiagnostics,
       workspaceId,
-      fields: { agentTargetId: input.agentTargetId ?? null, mode: input.mode }
+      fields: {
+        agentTargetId: input.agentTargetId ?? null,
+        hasInitialTuttiModeActivation:
+          input.mode === "new" && input.initialTuttiModeActivation != null,
+        mode: input.mode
+      }
     });
     if (input.mode === "new") {
       reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
@@ -465,16 +470,22 @@ export class WorkspaceAgentActivityService
         provider: null,
         submitDiagnostics: input.submitDiagnostics,
         workspaceId,
-        fields: { agentTargetId: input.agentTargetId ?? null }
+        fields: {
+          agentTargetId: input.agentTargetId ?? null,
+          hasInitialTuttiModeActivation:
+            input.initialTuttiModeActivation != null
+        }
       });
       session = await this.createSession({
         clientSubmitId: input.clientSubmitId,
         workspaceId,
         agentSessionId: requestedAgentSessionId,
         agentTargetId: input.agentTargetId,
+        capabilityRefs: input.capabilityRefs ?? null,
         cwd: resolvedCwd?.cwd ?? null,
         initialContent: input.initialContent ?? [],
         initialDisplayPrompt: input.initialDisplayPrompt ?? null,
+        initialTuttiModeActivation: input.initialTuttiModeActivation ?? null,
         submitDiagnostics: input.submitDiagnostics,
         model: input.settings?.model ?? null,
         planMode: input.settings?.planMode ?? null,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
@@ -287,6 +287,9 @@ function activationInput(
 ): Parameters<AgentActivityRuntime["activateSession"]>[0] {
   const shared = {
     agentSessionId: command.agentSessionId,
+    ...(command.capabilityRefs?.length
+      ? { capabilityRefs: command.capabilityRefs }
+      : {}),
     ...(command.cwd !== undefined ? { cwd: command.cwd } : {}),
     ...(command.initialContent
       ? { initialContent: [...command.initialContent] }

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -545,6 +545,11 @@ home composer submit
 ```
 
 Initial-content create is one transaction. Failure compensates the provisional runtime/canonical shell; it must not leave a Turn-less Session.
+The initiating composer snapshots Tutti activation and orchestration intensity
+with that submit. An explicit active or inactive submit snapshot is authoritative
+over a later read of mutable home-draft state; non-composer callers may fall back
+to the engine draft when no snapshot exists. `capabilityRefs` remain independent
+audit provenance and must never substitute for `initialTuttiModeActivation`.
 An activation may instead carry `initialGoalControl`. In that branch the engine
 and runtime adapter preserve the structured `{action, objective}` command, the
 host integration creates a non-provisional Session without initial content,

--- a/docs/conventions/local-state-storage.md
+++ b/docs/conventions/local-state-storage.md
@@ -148,6 +148,11 @@ keys cascade target deletion and prevent a referenced plan from being deleted.
 `model_plan_first_use_candidates` durably attributes prepared sessions to
 plans until a completed canonical turn settles first-use state; startup
 reconciliation retries candidates left by observer failure or shutdown.
+Its dedicated `model_plan_first_use_candidates_v1` migration repairs databases
+that recorded `model_plans_v1` before this table existed. Migration identifiers
+are immutable once any development or production database can record them;
+later required tables, columns, or indexes must use a new forward migration
+rather than extending the SQL hidden behind an existing marker.
 
 The initial migration copies existing managed model-provider credentials into
 stable `mp-migrated-<provider>` plans without removing the legacy rows, because

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -179,6 +179,64 @@
   order without deadlocking. Unsupported capability/source values must fail at
   HTTP ingress and event publication without changing activation.
 
+### Tutti mode is active in the composer but disappears after the first submit
+
+- **Symptom:** The home composer shows Tutti enabled and the submit trace records
+  `tutti_mode_active=true`, but the created Session has no activation and its
+  first `tutti_mode_turn_snapshots` row is `inactive`.
+- **Quick checks:** Confirm `lab.tuttiMode` is enabled first. Then trace
+  `initialTuttiModeActivation` at the composer submit, controller activation,
+  desktop activity service, renderer HTTP adapter, and daemon create ingress.
+  Log only a presence boolean at each boundary. Compare the Session export with
+  the durable activation and Turn snapshot rows; `capabilityRefs` do not prove
+  current activation.
+- **Root cause:** Session creation crosses several adapters that reconstruct
+  object literals. A manually projected create input can omit
+  `initialTuttiModeActivation` or its Tutti `capabilityRefs` even when the
+  upstream type carries them. Reading mutable draft state after submit can also
+  lose the exact composer selection. Separately, allowing `/tutti` while the lab
+  flag is disabled produces renderer state that the daemon must reject.
+- **Fix:** Snapshot active/inactive state and orchestration intensity atomically
+  with the composer submit. Preserve both activation and capability provenance
+  through every create projection, and gate slash actions with the same host
+  capability flag as the visible control.
+- **Validation:** Keep boundary tests for the service, engine host, and HTTP
+  adapter. In a real development launch, submit once with Tutti enabled and
+  verify the HTTP boundary sees the activation, the activation revision is
+  `active`, and the first Turn snapshot retains its source and intensity.
+
+### A new Tutti conversation becomes unavailable immediately after submit
+
+- **Symptom:** The optimistic conversation appears after the first submit, then
+  immediately changes to `Conversation unavailable` even though the provider
+  starts and the durable Session and Turn complete normally.
+- **Quick checks:** Correlate the Session ID across desktop and daemon submit
+  traces. The characteristic order is
+  `renderer_adapter.create.http_requested`, then
+  `agent.activity.reconcile_session_missing`, then
+  `renderer_adapter.create.resolved` and `api.create.completed`. Confirm the
+  missing reconcile occurs while the engine still has a requested or uncertain
+  new-session activation.
+- **Root cause:** Initial Tutti activation can publish
+  `workspace.tuttimode.updated` before the create transaction is query-visible
+  or its HTTP response returns. The renderer treats the event as a reconcile
+  hint, receives a transient 404, and mistakes it for authoritative deletion.
+  The resulting Session tombstone rejects the later successful create upsert.
+- **Fix:** Treat reconcile not-found as absence, not deletion evidence, and do
+  not create a tombstone from it. Let an authoritative create result or later
+  event upsert the Session. Tombstone only from explicit deletion evidence such
+  as `session_deleted` or a successful delete command, so real deletions remain
+  final.
+- **Validation:** Hold create in flight, publish
+  `workspace.tuttimode.updated`, return not-found from the Session read, and
+  verify the pending Session is not tombstoned. Then resolve create and verify
+  the canonical Session and active activation are present. Also prove an
+  ordinary reconcile 404 remains untombstoned while an explicit
+  `session_deleted` event does tombstone.
+- **References:**
+  [workspaceAgentActivityReconcileBridge.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts)
+  [workspaceAgentActivityEventSubscriptions.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityEventSubscriptions.ts)
+
 ### A Tutti submission remains `delivery is still being confirmed`
 
 - **Symptom:** Retrying the same composer submission keeps returning

--- a/docs/conventions/troubleshooting/desktop-release.md
+++ b/docs/conventions/troubleshooting/desktop-release.md
@@ -116,9 +116,11 @@
   `make dev-gui` exits during startup before the desktop window is usable. The
   early form reports `pnpm <version> installation did not succeed`; the later
   form reaches `start electron app...` and then `make` exits while desktop logs
-  say `secondary tutti instance detected`. Another early form exits while
-  checking prerequisites because a stale `pnpm` shim reports that its bundled
-  `../node/bin/node` no longer exists.
+  say `secondary tutti instance detected`. A database form reports
+  `no such table: model_plan_first_use_candidates`, followed by
+  `tuttid exited before it published its listener info`. Another early form
+  exits while checking prerequisites because a stale `pnpm` shim reports that
+  its bundled `../node/bin/node` no longer exists.
 - Quick checks:
   Run `DEV_GUI_SKIP_START=1 make dev-gui` to isolate prerequisite setup from
   Electron startup. If full startup exits after `start electron app...`, inspect
@@ -134,6 +136,10 @@
   app makes the dev app quit as a secondary instance. Agent shells launched from
   the packaged app may inherit `TUTTI_ENV=production`, so `make dev-gui` must
   force the development environment instead of preserving that inherited value.
+  The missing-table variant comes from a development database that already
+  recorded `model_plans_v1` before the candidate table was added behind that
+  same marker. SQLite correctly skips the recorded migration, so startup
+  reconciliation reaches a physical schema that the marker does not describe.
 - Fix:
   Probe `pnpm --version` without letting a broken shim abort startup, discover
   Corepack from the active or locally installed Node runtime, prefer that
@@ -142,16 +148,23 @@
   single-instance lock. Ensure the dev-gui script exports
   `TUTTI_ENV=development` before resolving pid files, installing the dev CLI, or
   launching Electron.
+  Apply a new, idempotent `model_plan_first_use_candidates_v1` forward migration
+  after `model_plans_v1`; do not require deleting the development database and
+  do not rewrite or reuse the recorded migration identifier.
 - Validation:
   Run `DEV_GUI_SKIP_START=1 make dev-gui`, then run full `make dev-gui` while
   the packaged app is open and confirm the renderer dev server and development
   `tuttid` start. Also run `pnpm --filter @tutti-os/desktop test`,
   `pnpm --filter @tutti-os/desktop typecheck`, and
   `pnpm check:electron-runtime-boundaries`.
+  Retain a migration test that starts with `model_plans_v1` recorded and the
+  candidate table absent, then verifies a full migration pass restores the table
+  and index exactly once.
 - References:
   [dev-gui.sh](../../../tools/scripts/dev-gui.sh)
   [bootstrap.ts](../../../apps/desktop/src/main/bootstrap.ts)
   [defaults.ts](../../../apps/desktop/src/main/defaults.ts)
+  [migrations_model_plans.go](../../../services/tuttid/data/workspace/migrations_model_plans.go)
 
 ### Running a development tuttid breaks the production Agent session
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -15,7 +15,6 @@ import {
 import { type AgentFileMentionSuggestionState } from "./agentRichText/agentFileMentionExtension";
 import { formatSlashStatusTokenCount } from "./AgentSlashStatusPanel";
 import { useOptionalAgentActivityRuntime } from "../../agentActivityRuntime";
-import { normalizeAgentActivityCapabilityReferences } from "@tutti-os/agent-activity-core";
 import { useComposerDraftAttachments } from "./composer/useComposerDraftAttachments";
 import { goalDraftObjectiveFromPrompt } from "./composer/composerDraftUtils";
 import { useComposerLayout } from "./composer/useComposerLayout";
@@ -35,6 +34,7 @@ import { useAgentMentionSearchController } from "./composer/useAgentMentionSearc
 import { useAgentQuickPromptLibrary } from "./composer/quickPrompts/useAgentQuickPromptLibrary";
 import { useScopedProjectMissingState } from "./composer/useScopedProjectMissingState";
 import type { AgentComposerProps } from "./composer/AgentComposer.types";
+import { withAgentComposerTuttiModeSnapshot } from "./composer/agentComposerSubmitOptions";
 import {
   agentComposerDraftAttachmentProjection,
   agentComposerDraftFiles,
@@ -77,6 +77,7 @@ export type {
   AgentComposerSlashStatus,
   AgentComposerSlashStatusLimit,
   AgentComposerSubmitOptions,
+  AgentComposerTuttiModeSubmitSnapshot,
   AgentComposerUsage
 } from "./composer/AgentComposer.types";
 
@@ -100,6 +101,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     submitDisabled,
     tuttiModeActive = false,
     tuttiModeUpdating = false,
+    tuttiModeOrchestrationIntensity = 50,
     placeholder,
     composerSettings,
     selectedAgentTarget = null,
@@ -184,17 +186,15 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     displayPrompt,
     options
   ) => {
-    onSubmit(content, displayPrompt, {
-      ...options,
-      ...(tuttiModeActive
-        ? {
-            capabilityRefs: normalizeAgentActivityCapabilityReferences([
-              ...(options?.capabilityRefs ?? []),
-              { capability: "tutti", source: "slash_command" }
-            ])
-          }
-        : {})
-    });
+    onSubmit(
+      content,
+      displayPrompt,
+      withAgentComposerTuttiModeSnapshot({
+        options,
+        active: tuttiModeActive,
+        orchestrationIntensity: tuttiModeOrchestrationIntensity
+      })
+    );
   };
   const submitGuidanceWithComposerModifiers: NonNullable<
     AgentComposerProps["onSubmitGuidance"]
@@ -403,6 +403,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     promptImagesSupported: canUploadAttachment && promptImagesSupported,
     availableSkills,
     composerSettings,
+    tuttiModeSupported: capabilityMenuState?.tuttiMode?.enabled !== false,
     capabilityControlsReadOnly,
     onDraftContentChange,
     onSettingsChange,

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -38,6 +38,17 @@ export interface AgentComposerReferenceProvenanceFilter {
 export interface AgentComposerSubmitOptions {
   requiredSettingsPatch?: AgentActivitySubmitSettingsPatch;
   capabilityRefs?: readonly AgentComposerCapabilityReference[];
+  /**
+   * Immutable Tutti presentation captured by the composer that initiated the
+   * submit. An explicit inactive snapshot is authoritative over stale draft
+   * state while a new conversation is being created.
+   */
+  tuttiMode?: AgentComposerTuttiModeSubmitSnapshot;
+}
+
+export interface AgentComposerTuttiModeSubmitSnapshot {
+  active: boolean;
+  orchestrationIntensity?: number;
 }
 
 export interface AgentComposerCapabilityReference {
@@ -67,6 +78,8 @@ export interface AgentComposerProps {
   tuttiModeActive?: boolean;
   /** Blocks submission/removal while activation CAS or creation is unresolved. */
   tuttiModeUpdating?: boolean;
+  /** Effective Tutti orchestration intensity (0-100) captured on submit. */
+  tuttiModeOrchestrationIntensity?: number;
   placeholder: string;
   composerSettings: AgentGUIComposerSettingsVM;
   queueStatus?: AgentGUIQueueStatus;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.composition.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.composition.spec.ts
@@ -14,6 +14,13 @@ const composerSource = readFileSync(
   join(process.cwd(), "agent-gui/agentGuiNode/AgentComposer.tsx"),
   "utf8"
 );
+const slashActionsSource = readFileSync(
+  join(
+    process.cwd(),
+    "agent-gui/agentGuiNode/composer/useComposerSlashActions.ts"
+  ),
+  "utf8"
+);
 
 describe("ComposerFooter trigger composition", () => {
   it("keeps tooltip and select triggers on separate elements", () => {
@@ -71,5 +78,13 @@ describe("ComposerFooter trigger composition", () => {
     expect(source).toContain("isPlanModeActive ?");
     expect(source).toContain("isTuttiModeActive ?");
     expect(source).toContain("disabled={isTuttiModeUpdating}");
+  });
+
+  it("uses the host Tutti feature gate for typed slash-command submits", () => {
+    expect(composerSource).toContain(
+      "tuttiModeSupported: capabilityMenuState?.tuttiMode?.enabled !== false"
+    );
+    expect(slashActionsSource).toContain("tuttiSupported: tuttiModeSupported");
+    expect(slashActionsSource).not.toContain("tuttiSupported: true");
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/agentComposerSubmitOptions.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/agentComposerSubmitOptions.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { withAgentComposerTuttiModeSnapshot } from "./agentComposerSubmitOptions";
+
+describe("withAgentComposerTuttiModeSnapshot", () => {
+  it("captures active Tutti state and intensity with its audit reference", () => {
+    expect(
+      withAgentComposerTuttiModeSnapshot({
+        active: true,
+        orchestrationIntensity: 73
+      })
+    ).toEqual({
+      capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
+      tuttiMode: { active: true, orchestrationIntensity: 73 }
+    });
+  });
+
+  it("captures an explicit inactive state without adding an audit reference", () => {
+    expect(
+      withAgentComposerTuttiModeSnapshot({
+        active: false,
+        orchestrationIntensity: 50
+      })
+    ).toEqual({ tuttiMode: { active: false } });
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/agentComposerSubmitOptions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/agentComposerSubmitOptions.ts
@@ -1,0 +1,30 @@
+import { normalizeAgentActivityCapabilityReferences } from "@tutti-os/agent-activity-core";
+import type {
+  AgentComposerSubmitOptions,
+  AgentComposerTuttiModeSubmitSnapshot
+} from "./AgentComposer.types";
+
+export function withAgentComposerTuttiModeSnapshot(input: {
+  options?: AgentComposerSubmitOptions;
+  active: boolean;
+  orchestrationIntensity: number;
+}): AgentComposerSubmitOptions {
+  const tuttiMode: AgentComposerTuttiModeSubmitSnapshot = {
+    active: input.active,
+    ...(input.active
+      ? { orchestrationIntensity: input.orchestrationIntensity }
+      : {})
+  };
+  return {
+    ...input.options,
+    tuttiMode,
+    ...(input.active
+      ? {
+          capabilityRefs: normalizeAgentActivityCapabilityReferences([
+            ...(input.options?.capabilityRefs ?? []),
+            { capability: "tutti", source: "slash_command" }
+          ])
+        }
+      : {})
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashActions.ts
@@ -77,6 +77,7 @@ type Props = Pick<
 
 interface UseComposerSlashActionsInput extends Props {
   onTuttiModeActivate?: () => void;
+  tuttiModeSupported: boolean;
   draftContent: AgentComposerDraft;
   selectedProjectPath: string;
   slashStatusAgentSessionId: string | null;
@@ -124,6 +125,7 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
     promptImagesSupported,
     availableSkills = [],
     composerSettings,
+    tuttiModeSupported,
     capabilityControlsReadOnly = false,
     onDraftContentChange,
     onSettingsChange,
@@ -501,7 +503,7 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
         const slashCommandEffect = resolveSlashCommandSubmitEffect({
           browserSupported: Boolean(composerSettings.supportsBrowser),
           computerSupported: Boolean(composerSettings.supportsComputerUse),
-          tuttiSupported: true,
+          tuttiSupported: tuttiModeSupported,
           commands: resolvedSlashCommands,
           draft: nextPrompt,
           provider,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { resolveInitialTuttiModeActivation } from "./useAgentGUINewConversationActivation";
+
+describe("resolveInitialTuttiModeActivation", () => {
+  it("prefers the composer submit snapshot over a stale inactive draft", () => {
+    expect(
+      resolveInitialTuttiModeActivation({
+        submitOptions: {
+          tuttiMode: { active: true, orchestrationIntensity: 81 }
+        },
+        draftActive: false,
+        draftOrchestrationIntensity: 50
+      })
+    ).toEqual({
+      activation: {
+        source: "slash_command",
+        status: "active",
+        orchestrationIntensity: 81
+      },
+      source: "composer_submit"
+    });
+  });
+
+  it("treats an explicit inactive submit snapshot as authoritative", () => {
+    expect(
+      resolveInitialTuttiModeActivation({
+        submitOptions: { tuttiMode: { active: false } },
+        draftActive: true,
+        draftOrchestrationIntensity: 50
+      })
+    ).toBeNull();
+  });
+
+  it("keeps the engine draft fallback for non-composer callers", () => {
+    expect(
+      resolveInitialTuttiModeActivation({
+        draftActive: true,
+        draftOrchestrationIntensity: 64
+      })
+    ).toEqual({
+      activation: {
+        source: "slash_command",
+        status: "active",
+        orchestrationIntensity: 64
+      },
+      source: "engine_draft"
+    });
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
@@ -2,7 +2,8 @@ import {
   type AgentActivityInitialGoalControl,
   isPendingActivationViable,
   selectLatestActivationForSession,
-  selectTuttiModeDraftIsActive
+  selectTuttiModeDraftIsActive,
+  selectTuttiModeDraftOrchestrationIntensity
 } from "@tutti-os/agent-activity-core";
 import { useCallback } from "react";
 import { translate } from "../../../i18n/index";
@@ -34,6 +35,41 @@ import {
 import { resolveAgentComposerDraftScopeKey } from "../model/agentComposerDraftScope";
 import { resolveAgentGUIConversationProject } from "../model/agentGuiConversationProjectResolver";
 import type { AgentComposerSubmitOptions } from "../composer/AgentComposer.types";
+
+interface ResolvedInitialTuttiModeActivation {
+  activation: {
+    source: "slash_command";
+    status: "active";
+    orchestrationIntensity?: number;
+  };
+  source: "composer_submit" | "engine_draft";
+}
+
+export function resolveInitialTuttiModeActivation(input: {
+  submitOptions?: AgentComposerSubmitOptions;
+  draftActive: boolean;
+  draftOrchestrationIntensity: number | null;
+}): ResolvedInitialTuttiModeActivation | null {
+  const submitSnapshot = input.submitOptions?.tuttiMode;
+  const active = submitSnapshot?.active ?? input.draftActive;
+  if (!active) return null;
+  const orchestrationIntensity = normalizeOrchestrationIntensity(
+    submitSnapshot?.orchestrationIntensity ?? input.draftOrchestrationIntensity
+  );
+  return {
+    activation: {
+      source: "slash_command",
+      status: "active",
+      ...(orchestrationIntensity === null ? {} : { orchestrationIntensity })
+    },
+    source: submitSnapshot ? "composer_submit" : "engine_draft"
+  };
+}
+
+function normalizeOrchestrationIntensity(value: number | null | undefined) {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return Math.min(100, Math.max(0, Math.round(value)));
+}
 
 export function useAgentGUINewConversationActivation(
   input: UseAgentGUINewConversationActivationInput
@@ -173,17 +209,29 @@ export function useAgentGUINewConversationActivation(
         sourceScopeKey,
         content: snapshotAgentComposerDraft(submittedDraft)
       };
+      const engineSnapshot = sessionEngine.getSnapshot();
+      const initialTuttiMode = resolveInitialTuttiModeActivation({
+        submitOptions,
+        draftActive: selectTuttiModeDraftIsActive(
+          engineSnapshot,
+          tuttiModeDraftKey
+        ),
+        draftOrchestrationIntensity: selectTuttiModeDraftOrchestrationIntensity(
+          engineSnapshot,
+          tuttiModeDraftKey
+        )
+      });
       reportAgentSubmitTraceDiagnostic({
         event: "activation.requested",
         runtime: agentActivityRuntime,
         trace: submitTrace,
         workspaceId,
-        fields: { mode: "new" }
+        fields: {
+          mode: "new",
+          tutti_mode_active: initialTuttiMode !== null,
+          tutti_mode_source: initialTuttiMode?.source ?? "inactive"
+        }
       });
-      const initialTuttiModeActive = selectTuttiModeDraftIsActive(
-        sessionEngine.getSnapshot(),
-        tuttiModeDraftKey
-      );
       const requestId = activation.activate({
         mode: "new",
         agentSessionId,
@@ -198,12 +246,9 @@ export function useAgentGUINewConversationActivation(
         ...(initialTurnExpected !== undefined ? { initialTurnExpected } : {}),
         ...(initialGoalControl ? { initialGoalControl } : {}),
         initialDisplayPrompt,
-        ...(initialTuttiModeActive
+        ...(initialTuttiMode
           ? {
-              initialTuttiModeActivation: {
-                source: "slash_command" as const,
-                status: "active" as const
-              },
+              initialTuttiModeActivation: initialTuttiMode.activation,
               tuttiModeDraftKey
             }
           : {}),

--- a/services/tuttid/data/workspace/migrations.go
+++ b/services/tuttid/data/workspace/migrations.go
@@ -58,6 +58,7 @@ const schemaMigrationWorkspaceAppsV2 = "workspace_apps_v2"
 const schemaMigrationWorkspaceAppsV3 = "workspace_apps_v3"
 const schemaMigrationManagedCredentialsV1 = "managed_credentials_v1"
 const schemaMigrationModelPlansV1 = "model_plans_v1"
+const schemaMigrationModelPlanFirstUseCandidatesV1 = "model_plan_first_use_candidates_v1"
 const schemaMigrationAgentModelBindingsV1 = "agent_model_bindings_v1"
 const schemaMigrationAgentModelBindingsV2 = "agent_model_bindings_v2"
 const schemaMigrationAgentModelBindingsV3 = "agent_model_bindings_v3"
@@ -258,6 +259,9 @@ INSERT OR IGNORE INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 		return err
 	}
 	if err := s.applyModelPlansV1(ctx); err != nil {
+		return err
+	}
+	if err := s.applyModelPlanFirstUseCandidatesV1(ctx); err != nil {
 		return err
 	}
 	if err := s.applyModelPlanRevisionsV1(ctx); err != nil {

--- a/services/tuttid/data/workspace/migrations_model_plans.go
+++ b/services/tuttid/data/workspace/migrations_model_plans.go
@@ -82,6 +82,54 @@ VALUES (?, ?)
 	return nil
 }
 
+// applyModelPlanFirstUseCandidatesV1 repairs databases that recorded the
+// original model_plans_v1 migration before the first-use candidate table was
+// added to that migration during feature-branch development. A distinct marker
+// keeps the already-recorded migration immutable for every existing database.
+func (s *SQLiteStore) applyModelPlanFirstUseCandidatesV1(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationModelPlanFirstUseCandidatesV1)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return nil
+	}
+
+	tx, err := s.writeDB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin model plan first-use candidates v1 migration: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+CREATE TABLE IF NOT EXISTS model_plan_first_use_candidates (
+  workspace_id TEXT NOT NULL,
+  agent_session_id TEXT NOT NULL,
+  model_plan_id TEXT NOT NULL,
+  agent_target_id TEXT NOT NULL,
+  model TEXT NOT NULL DEFAULT '',
+  plan_updated_at_unix_ms INTEGER NOT NULL,
+  created_at_unix_ms INTEGER NOT NULL,
+  PRIMARY KEY (workspace_id, agent_session_id),
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+  FOREIGN KEY (workspace_id, model_plan_id)
+    REFERENCES model_plans(workspace_id, plan_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_model_plan_first_use_candidates_plan
+  ON model_plan_first_use_candidates(workspace_id, model_plan_id);
+
+INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
+VALUES (?, ?);
+`, schemaMigrationModelPlanFirstUseCandidatesV1, unixMs(time.Now().UTC())); err != nil {
+		return fmt.Errorf("migrate model plan first-use candidates v1: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit model plan first-use candidates v1 migration: %w", err)
+	}
+	return nil
+}
+
 // applyModelPlanRevisionsV1 adds immutable, secret-bearing plan revisions.
 // Session runtime context stores only the plan id/revision/fingerprint; the
 // encrypted endpoint credential remains in this daemon-owned table.

--- a/services/tuttid/data/workspace/sqlite_model_plans_test.go
+++ b/services/tuttid/data/workspace/sqlite_model_plans_test.go
@@ -274,6 +274,58 @@ WHERE workspace_id = 'ws-retry' AND provider_id = 'openai'
 	}
 }
 
+func TestModelPlanFirstUseCandidatesMigrationRepairsLegacyModelPlansV1Schema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	if _, err := store.writeDB.ExecContext(ctx, `
+DROP TABLE model_plan_first_use_candidates;
+DELETE FROM tuttid_schema_migrations WHERE id = ?;
+`, schemaMigrationModelPlanFirstUseCandidatesV1); err != nil {
+		t.Fatalf("simulate legacy model plans v1 schema: %v", err)
+	}
+
+	legacyMarkerApplied, err := store.hasMigration(ctx, schemaMigrationModelPlansV1)
+	if err != nil {
+		t.Fatalf("inspect legacy model plans marker: %v", err)
+	}
+	if !legacyMarkerApplied {
+		t.Fatal("legacy model_plans_v1 marker missing")
+	}
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate() legacy model plans schema error = %v", err)
+	}
+
+	for kind, name := range map[string]string{
+		"table": "model_plan_first_use_candidates",
+		"index": "idx_model_plan_first_use_candidates_plan",
+	} {
+		var count int
+		if err := store.writeDB.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM sqlite_master WHERE type = ? AND name = ?
+`, kind, name).Scan(&count); err != nil {
+			t.Fatalf("inspect repaired %s %q: %v", kind, name, err)
+		}
+		if count != 1 {
+			t.Fatalf("repaired %s %q count = %d, want 1", kind, name, count)
+		}
+	}
+
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate() idempotent retry error = %v", err)
+	}
+	var markerCount int
+	if err := store.writeDB.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM tuttid_schema_migrations WHERE id = ?
+`, schemaMigrationModelPlanFirstUseCandidatesV1).Scan(&markerCount); err != nil {
+		t.Fatalf("count first-use candidate migration marker: %v", err)
+	}
+	if markerCount != 1 {
+		t.Fatalf("first-use candidate migration marker count = %d, want 1", markerCount)
+	}
+}
+
 func TestListAgentModelBindingsByModelPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -385,8 +437,8 @@ func resetModelPlanMigrations(t *testing.T, store *SQLiteStore) {
 	}
 	if _, err := store.writeDB.ExecContext(ctx, `
 DELETE FROM tuttid_schema_migrations
-WHERE id IN (?, ?)
-`, schemaMigrationModelPlansV1, schemaMigrationAgentModelBindingsV1, schemaMigrationModelPlanRevisionsV1); err != nil {
+WHERE id IN (?, ?, ?, ?)
+`, schemaMigrationModelPlansV1, schemaMigrationModelPlanFirstUseCandidatesV1, schemaMigrationAgentModelBindingsV1, schemaMigrationModelPlanRevisionsV1); err != nil {
 		t.Fatalf("reset model plan migration markers error = %v", err)
 	}
 }


### PR DESCRIPTION
## What

- snapshot Tutti mode activation and orchestration intensity atomically with the initial composer submit
- preserve the initial activation and capability provenance through the Desktop session-create pipeline
- restore #1412's deletion-evidence semantics by treating reconcile `404` as temporary absence instead of a deletion tombstone
- add an idempotent forward migration for `model_plan_first_use_candidates` when a database already recorded `model_plans_v1`
- document submit ownership, local-state migration recovery, and the relevant troubleshooting paths

## Why

The initial Tutti selection crossed several asynchronous projections and could be reread from mutable draft state or omitted while reconstructing the create request. Once activation persistence was restored, `workspace.tuttimode.updated` could race session-create visibility; the renderer interpreted a transient `404` as deletion and rejected the later successful create upsert, leaving the conversation unavailable.

Development databases could also contain the old `model_plans_v1` migration marker without the first-use candidate table, causing `make dev-gui` to fail until local state was deleted. The new forward migration repairs that state without destructive recovery.

## Impact

New Tutti conversations retain the exact submit-time activation, no longer become unavailable during the create/event race, and existing development databases repair the missing candidate table without deleting local data.

## Validation

- `pnpm check:changed --tail-lines 100` — 17 lanes passed during iteration
- pre-commit formatting, lint, Electron/UI/renderer boundaries, and AgentGUI degradation checks passed
- pre-push `pnpm check:changed -- --push-ready` — 19 lanes passed
- targeted workspace activity reconcile regression tests passed
- Desktop typecheck and production build passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session-create and reconcile lifecycle (user-visible agent conversations) and SQLite migrations; behavior is heavily regression-tested but wrong tombstone or activation wiring would affect many submits.
> 
> **Overview**
> Fixes **Tutti mode dropping after the first submit** and **new conversations flipping to unavailable** during create, plus a **dev DB migration** for missing first-use candidate tables.
> 
> The composer now captures an immutable **`tuttiMode` submit snapshot** (active/inactive and orchestration intensity) via `withAgentComposerTuttiModeSnapshot`, and new-session activation uses **`resolveInitialTuttiModeActivation`** so the composer snapshot wins over stale draft state. **`initialTuttiModeActivation`** and **`capabilityRefs`** are threaded through the activity service, engine host, and desktop HTTP create adapter, with trace fields for presence at each step. Typed **`/tutti`** slash submits respect the host Tutti feature gate instead of always enabling Tutti.
> 
> On reconcile, a **404 / session not found** is logged as **`reconcile_session_absent`** and **no longer tombstones** the session; tombstones remain for **`session_deleted`** and successful delete paths. That avoids racing **`workspace.tuttimode.updated`** ahead of create visibility from rejecting the later successful upsert.
> 
> **`tuttid`** adds forward migration **`model_plan_first_use_candidates_v1`** for databases that already recorded **`model_plans_v1`** without the candidate table. Docs cover submit ownership, migration immutability, and troubleshooting for these failure modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae49ac472227ffd4b514707239f20ef5b87e3724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->