### PR TITLE
fix(tooling): reuse unchanged validation lanes

### DIFF
--- a/docs/conventions/local-git-hooks.md
+++ b/docs/conventions/local-git-hooks.md
@@ -166,8 +166,10 @@ lane command and its relevant files across the base diff, index, working tree,
 and untracked contents. A previous result is reused only when that lane passed
 and its input fingerprint is unchanged. Failed lanes, new lanes, and lanes with
 changed inputs run again; lanes no longer selected by the current plan are
-dropped. Summaries created before per-lane fingerprints are rejected and
-require one normal `pnpm check:changed` run.
+dropped. A failed-only retry inherits the previous run's push-ready mode so
+failed build and pack lanes cannot disappear from the retry plan. Summaries
+created before per-lane fingerprints are rejected and require one normal
+`pnpm check:changed` run.
 
 When the changed set includes deleted package test files, `check:changed` should
 not pass those missing paths to Vitest as explicit targets. Deleting source files

--- a/docs/conventions/local-git-hooks.md
+++ b/docs/conventions/local-git-hooks.md
@@ -160,10 +160,14 @@ integer values. A misspelled `--push-ready` or malformed concurrency value must
 fail instead of silently selecting a weaker or empty validation plan.
 
 After failures, prefer `pnpm check:changed -- --failed-only` to rerun failed
-lanes instead of repeating successful lanes. Failed-lane state is bound to the
-validated base ref, HEAD, index, working tree, and untracked file contents. If
-any of those change, `--failed-only` refuses the stale result and requires a
-normal `pnpm check:changed` run.
+lanes after editing the failure. The runner rebuilds the current lane plan and
+stores a separate input fingerprint for every lane. The fingerprint covers the
+lane command and its relevant files across the base diff, index, working tree,
+and untracked contents. A previous result is reused only when that lane passed
+and its input fingerprint is unchanged. Failed lanes, new lanes, and lanes with
+changed inputs run again; lanes no longer selected by the current plan are
+dropped. Summaries created before per-lane fingerprints are rejected and
+require one normal `pnpm check:changed` run.
 
 When the changed set includes deleted package test files, `check:changed` should
 not pass those missing paths to Vitest as explicit targets. Deleting source files

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -22,10 +22,11 @@ Direct package or boundary commands are iteration tools for a failing or
 uncertain surface. After a failed changed-aware run, use
 `pnpm check:changed -- --failed-only` after fixing the failure. The runner
 rebuilds the current plan, reruns failed, new, and input-changed lanes, and
-reuses only lanes that previously passed with the same lane inputs. A focused
-command run before subsequent edits is evidence for that iteration, not for the
-final worktree; some narrow coverage may therefore run again in the final
-changed-aware gate.
+reuses only lanes that previously passed with the same lane inputs. Retries
+inherit the previous run's push-ready mode so failed build or pack lanes remain
+in the plan. A focused command run before subsequent edits is evidence for that
+iteration, not for the final worktree; some narrow coverage may therefore run
+again in the final changed-aware gate.
 
 Add a standalone final check only when the dry-run plan omits a capability the
 changed surface requires:

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -20,10 +20,12 @@ same commands as a separate final preflight or follow-up.
 
 Direct package or boundary commands are iteration tools for a failing or
 uncertain surface. After a failed changed-aware run, use
-`pnpm check:changed -- --failed-only` when only failed lanes need another pass.
-A focused command run before subsequent edits is evidence for that iteration,
-not for the final worktree; some narrow coverage may therefore run again in the
-final changed-aware gate.
+`pnpm check:changed -- --failed-only` after fixing the failure. The runner
+rebuilds the current plan, reruns failed, new, and input-changed lanes, and
+reuses only lanes that previously passed with the same lane inputs. A focused
+command run before subsequent edits is evidence for that iteration, not for the
+final worktree; some narrow coverage may therefore run again in the final
+changed-aware gate.
 
 Add a standalone final check only when the dry-run plan omits a capability the
 changed surface requires:

--- a/tools/scripts/repository-checks.mjs
+++ b/tools/scripts/repository-checks.mjs
@@ -139,10 +139,13 @@ export function selectRepositoryChecks(changedFiles, { group } = {}) {
   return repositoryCheckDefinitions.filter(
     (definition) =>
       (!group || definition.group === group) &&
-      changedFiles.some(
-        (file) =>
-          isCheckInfrastructure(file) || definition.matches(normalize(file))
-      )
+      selectRepositoryCheckInputs(definition, changedFiles).length > 0
+  );
+}
+
+export function selectRepositoryCheckInputs(definition, changedFiles) {
+  return changedFiles.filter(
+    (file) => isCheckInfrastructure(file) || definition.matches(normalize(file))
   );
 }
 

--- a/tools/scripts/run-check-changed-cache.mjs
+++ b/tools/scripts/run-check-changed-cache.mjs
@@ -1,0 +1,134 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const laneFingerprintVersion = 1;
+
+export class LaneCacheError extends Error {}
+
+export function buildLaneInputFingerprint(input) {
+  const root = input.workspaceRoot;
+  const inputFiles = Array.from(new Set(input.lane.inputFiles)).sort();
+  const hash = createHash("sha256");
+  const addGitOutput = (label, args) => {
+    const result = spawnSync("git", args, {
+      cwd: root,
+      encoding: null
+    });
+    if (result.status !== 0) {
+      throw new Error(
+        `check:changed failed to fingerprint git ${args.join(" ")}`
+      );
+    }
+    hash.update(label);
+    hash.update(result.stdout);
+  };
+
+  hash.update(`version:${laneFingerprintVersion}\n`);
+  hash.update(`base-ref:${input.baseRef}\n`);
+  hash.update(`key:${input.lane.key}\n`);
+  hash.update(`label:${input.lane.label}\n`);
+  hash.update(`command:${JSON.stringify(input.lane.command)}\n`);
+  hash.update(`input-files:${JSON.stringify(inputFiles)}\n`);
+
+  if (inputFiles.length === 0) {
+    return hash.digest("hex");
+  }
+
+  const pathspec = ["--", ...inputFiles];
+  addGitOutput("base-diff", [
+    "diff",
+    "--binary",
+    `${input.baseRef}...HEAD`,
+    ...pathspec
+  ]);
+  addGitOutput("staged-diff", [
+    "diff",
+    "--cached",
+    "--binary",
+    "HEAD",
+    ...pathspec
+  ]);
+  addGitOutput("working-diff", ["diff", "--binary", ...pathspec]);
+
+  const untrackedResult = spawnSync(
+    "git",
+    ["ls-files", "--others", "--exclude-standard", "-z", "--", ...inputFiles],
+    { cwd: root, encoding: "utf8" }
+  );
+  if (untrackedResult.status !== 0) {
+    throw new Error("check:changed failed to fingerprint untracked files");
+  }
+  for (const file of untrackedResult.stdout
+    .split("\0")
+    .filter(Boolean)
+    .sort()) {
+    hash.update(`untracked:${file}\n`);
+    hash.update(readFileSync(join(root, file)));
+  }
+
+  return hash.digest("hex");
+}
+
+export function selectFailedOnlyLanes(currentLanes, summary) {
+  if (summary.laneFingerprintVersion !== laneFingerprintVersion) {
+    throw new LaneCacheError(
+      "cannot reuse legacy failed-lane state; run pnpm check:changed"
+    );
+  }
+
+  const previousByKey = new Map(
+    (summary.results ?? []).map((result) => [result.key, result])
+  );
+  const lanesToRun = [];
+  const reusedResults = [];
+
+  for (const lane of currentLanes) {
+    const previous = previousByKey.get(lane.key);
+    if (
+      previous?.exitCode === 0 &&
+      previous.inputFingerprint === lane.inputFingerprint
+    ) {
+      reusedResults.push({
+        ...previous,
+        command: lane.command,
+        inputFiles: lane.inputFiles,
+        inputFingerprint: lane.inputFingerprint,
+        key: lane.key,
+        label: lane.label,
+        reused: true
+      });
+    } else {
+      lanesToRun.push(lane);
+    }
+  }
+
+  return { lanesToRun, reusedResults };
+}
+
+export function mergeLaneResults(currentLanes, executedResults, reusedResults) {
+  const executedByKey = new Map(
+    executedResults.map((result) => [result.key, result])
+  );
+  const reusedByKey = new Map(
+    reusedResults.map((result) => [result.key, result])
+  );
+
+  return currentLanes.map((lane, index) => {
+    const result = executedByKey.get(lane.key) ?? reusedByKey.get(lane.key);
+    if (!result) {
+      throw new Error(`check:changed missing lane result for ${lane.key}`);
+    }
+    return {
+      ...result,
+      command: lane.command,
+      index,
+      inputFiles: lane.inputFiles,
+      inputFingerprint: lane.inputFingerprint,
+      key: lane.key,
+      label: lane.label,
+      reused: reusedByKey.has(lane.key)
+    };
+  });
+}

--- a/tools/scripts/run-check-changed-cache.mjs
+++ b/tools/scripts/run-check-changed-cache.mjs
@@ -7,6 +7,10 @@ export const laneFingerprintVersion = 1;
 
 export class LaneCacheError extends Error {}
 
+export function resolveRetryPushReady(requestedPushReady, previousSummary) {
+  return requestedPushReady || previousSummary?.pushReady === true;
+}
+
 export function buildLaneInputFingerprint(input) {
   const root = input.workspaceRoot;
   const inputFiles = Array.from(new Set(input.lane.inputFiles)).sort();

--- a/tools/scripts/run-check-changed.mjs
+++ b/tools/scripts/run-check-changed.mjs
@@ -13,6 +13,7 @@ import {
   laneFingerprintVersion,
   LaneCacheError,
   mergeLaneResults,
+  resolveRetryPushReady,
   selectFailedOnlyLanes
 } from "./run-check-changed-cache.mjs";
 import {
@@ -49,6 +50,13 @@ const latestSummaryPath = join(tmpRoot, "latest.json");
 const packageInfos = loadPackageInfos();
 
 export async function main() {
+  const previousSummary = failedOnly ? readLatestSummary() : null;
+  if (failedOnly && !previousSummary) {
+    console.log("check:changed found no previous run to reuse");
+    return;
+  }
+  pushReady = resolveRetryPushReady(pushReady, previousSummary);
+
   const plannedLanes = buildChangedLanes();
 
   if (plannedLanes.length === 0) {
@@ -70,13 +78,9 @@ export async function main() {
     })
   }));
 
-  const failedOnlySelection = failedOnly
-    ? readFailedOnlySelection(currentLanes)
+  const failedOnlySelection = previousSummary
+    ? selectFailedOnlyLanes(currentLanes, previousSummary)
     : null;
-  if (failedOnlySelection && !failedOnlySelection.hasSummary) {
-    console.log("check:changed found no previous run to reuse");
-    return;
-  }
   const lanesToRun = failedOnlySelection?.lanesToRun ?? currentLanes;
   const reusedResults = failedOnlySelection?.reusedResults ?? [];
 
@@ -331,19 +335,11 @@ function buildChangedLanes() {
   return Array.from(lanesByKey.values());
 }
 
-function readFailedOnlySelection(currentLanes) {
+function readLatestSummary() {
   if (!existsSync(latestSummaryPath)) {
-    return {
-      hasSummary: false,
-      lanesToRun: [],
-      reusedResults: []
-    };
+    return null;
   }
-  const summary = JSON.parse(readFileSync(latestSummaryPath, "utf8"));
-  return {
-    hasSummary: true,
-    ...selectFailedOnlyLanes(currentLanes, summary)
-  };
+  return JSON.parse(readFileSync(latestSummaryPath, "utf8"));
 }
 
 export async function runLanes(inputLanes, runDirectory) {

--- a/tools/scripts/run-check-changed.mjs
+++ b/tools/scripts/run-check-changed.mjs
@@ -1,5 +1,4 @@
 import { spawn, spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import {
   createWriteStream,
   existsSync,
@@ -10,14 +9,25 @@ import {
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  buildLaneInputFingerprint,
+  laneFingerprintVersion,
+  LaneCacheError,
+  mergeLaneResults,
+  selectFailedOnlyLanes
+} from "./run-check-changed-cache.mjs";
+import {
   buildGoLintLane,
   buildGoTestLane,
   buildPackageTestCommand,
   isBuiltinGenerateRequired,
+  resolveGoModuleRoot,
   resolveGoValidationTargets
 } from "./run-check-changed-targets.mjs";
 import { classifyChangedFiles } from "./change-classification.mjs";
-import { selectRepositoryChecks } from "./repository-checks.mjs";
+import {
+  selectRepositoryCheckInputs,
+  selectRepositoryChecks
+} from "./repository-checks.mjs";
 import { formatFailureExcerpt } from "./run-validation-lanes.mjs";
 import { resolveGolangciLintBinary } from "./golangci-lint-tool.mjs";
 
@@ -39,48 +49,75 @@ const latestSummaryPath = join(tmpRoot, "latest.json");
 const packageInfos = loadPackageInfos();
 
 export async function main() {
-  const lanes = failedOnly ? readFailedLanes() : buildChangedLanes();
+  const currentLanes = buildChangedLanes().map((lane) => ({
+    ...lane,
+    inputFingerprint: buildLaneInputFingerprint({
+      baseRef,
+      lane,
+      workspaceRoot
+    })
+  }));
 
-  if (lanes.length === 0) {
+  if (currentLanes.length === 0) {
+    console.log("check:changed found no changed files to validate");
+    return;
+  }
+
+  const failedOnlySelection = failedOnly
+    ? readFailedOnlySelection(currentLanes)
+    : null;
+  if (failedOnlySelection && !failedOnlySelection.hasSummary) {
+    console.log("check:changed found no previous run to reuse");
+    return;
+  }
+  const lanesToRun = failedOnlySelection?.lanesToRun ?? currentLanes;
+  const reusedResults = failedOnlySelection?.reusedResults ?? [];
+
+  if (dryRun) {
+    printPlan(lanesToRun, reusedResults);
+    return;
+  }
+
+  if (lanesToRun.length === 0) {
     console.log(
-      failedOnly
-        ? "check:changed found no failed lanes in the latest run"
-        : "check:changed found no changed files to validate"
+      `check:changed found no failed or changed lanes; reused ${reusedResults.length} passed lane(s)`
     );
     return;
   }
-
-  if (dryRun) {
-    printPlan(lanes);
-    return;
-  }
-
-  const validationFingerprint = buildValidationFingerprint({
-    baseRef,
-    workspaceRoot
-  });
 
   const runId = new Date().toISOString().replace(/[:.]/g, "-");
   const runDirectory = join(tmpRoot, runId);
   mkdirSync(runDirectory, { recursive: true });
 
   if (verbose) {
-    console.log(`check:changed running ${lanes.length} lane(s)`);
+    console.log(`check:changed running ${lanesToRun.length} lane(s)`);
+    if (reusedResults.length > 0) {
+      console.log(
+        `check:changed reusing ${reusedResults.length} passed lane(s)`
+      );
+    }
     console.log(`logs: ${relative(workspaceRoot, runDirectory)}`);
   }
 
   const startedAt = Date.now();
-  const results = await runLanes(lanes, runDirectory);
+  const executedResults = await runLanes(lanesToRun, runDirectory);
+  const results = mergeLaneResults(
+    currentLanes,
+    executedResults,
+    reusedResults
+  );
   const durationMs = Date.now() - startedAt;
   const summary = {
     baseRef,
     durationMs,
+    executedLaneCount: executedResults.length,
     failedOnly,
+    laneFingerprintVersion,
     pushReady,
+    reusedLaneCount: reusedResults.length,
     runDirectory,
     startedAt: new Date(startedAt).toISOString(),
     tailLines,
-    validationFingerprint,
     results
   };
   writeFileSync(
@@ -103,8 +140,17 @@ function buildChangedLanes() {
   const classification = classifyChangedFiles(changedFiles);
   const lanesByKey = new Map();
   const addLane = (lane) => {
-    if (!lanesByKey.has(lane.key)) {
-      lanesByKey.set(lane.key, lane);
+    const normalizedInputs = Array.from(new Set(lane.inputFiles)).sort();
+    const existing = lanesByKey.get(lane.key);
+    if (existing) {
+      existing.inputFiles = Array.from(
+        new Set([...existing.inputFiles, ...normalizedInputs])
+      ).sort();
+    } else {
+      lanesByKey.set(lane.key, {
+        ...lane,
+        inputFiles: normalizedInputs
+      });
     }
   };
 
@@ -119,7 +165,8 @@ function buildChangedLanes() {
       "bash",
       "-lc",
       `git diff --check ${shellQuote(baseRef)}...HEAD && git diff --check && git diff --cached --check`
-    ]
+    ],
+    inputFiles: changedFiles
   });
 
   const lintFiles = classification.runTs
@@ -135,7 +182,8 @@ function buildChangedLanes() {
         "oxlint",
         "--deny-warnings",
         ...lintFiles
-      ]
+      ],
+      inputFiles: lintFiles
     });
   }
 
@@ -143,7 +191,8 @@ function buildChangedLanes() {
     addLane({
       key: check.key,
       label: check.label,
-      command: [...pnpmCommand, "run", check.script]
+      command: [...pnpmCommand, "run", check.script],
+      inputFiles: selectRepositoryCheckInputs(check, changedFiles)
     });
   }
 
@@ -153,33 +202,46 @@ function buildChangedLanes() {
   const forceBuiltinGenerate = isBuiltinGenerateRequired(changedFiles);
   if (goValidationTargets) {
     for (const [moduleRoot, targets] of goValidationTargets.lintByModule) {
-      addLane(
-        buildGoLintLane({
+      const inputFiles = selectGoLaneInputs(
+        changedFiles,
+        moduleRoot,
+        forceBuiltinGenerate
+      );
+      addLane({
+        ...buildGoLintLane({
           golangciLintBinary,
           moduleRoot,
           targets,
           shellQuote,
           workspaceRoot
-        })
-      );
+        }),
+        inputFiles
+      });
     }
     for (const [moduleRoot, targets] of goValidationTargets.testByModule) {
-      addLane(
-        buildGoTestLane({
+      const inputFiles = selectGoLaneInputs(
+        changedFiles,
+        moduleRoot,
+        forceBuiltinGenerate
+      );
+      addLane({
+        ...buildGoTestLane({
           forceBuiltinGenerate,
           moduleRoot,
           pnpmCommand: pnpmShellCommand,
           shellQuote,
           targets
-        })
-      );
+        }),
+        inputFiles
+      });
     }
 
     if (pushReady) {
       addLane({
         key: "build:go",
         label: "build:go",
-        command: [...pnpmCommand, "run", "build:go"]
+        command: [...pnpmCommand, "run", "build:go"],
+        inputFiles: changedFiles.filter(isGoValidationInput)
       });
     }
   }
@@ -190,7 +252,8 @@ function buildChangedLanes() {
     addLane({
       key: "typecheck:all",
       label: "typecheck:all",
-      command: [process.execPath, "./tools/scripts/run-typecheck.mjs"]
+      command: [process.execPath, "./tools/scripts/run-typecheck.mjs"],
+      inputFiles: changedFiles.filter(isTypeScriptValidationInput)
     });
   }
 
@@ -212,7 +275,8 @@ function buildChangedLanes() {
           "./tools/scripts/run-tsgo-typecheck.mjs",
           "--package-root",
           packageInfo.root
-        ]
+        ],
+        inputFiles: packageFiles
       });
     }
 
@@ -227,7 +291,8 @@ function buildChangedLanes() {
         addLane({
           key: `${packageInfo.name}:test`,
           label: `${packageInfo.name}:test`,
-          command
+          command,
+          inputFiles: packageFiles
         });
       }
     }
@@ -241,7 +306,8 @@ function buildChangedLanes() {
       addLane({
         key: `${packageInfo.name}:build`,
         label: `${packageInfo.name}:build`,
-        command: [...pnpmCommand, "--filter", packageInfo.name, "build"]
+        command: [...pnpmCommand, "--filter", packageInfo.name, "build"],
+        inputFiles: packageFiles
       });
     }
   }
@@ -250,46 +316,27 @@ function buildChangedLanes() {
     addLane({
       key: "pack:npm",
       label: "npm package pack",
-      command: [...pnpmCommand, "run", "release:pack:check"]
+      command: [...pnpmCommand, "run", "release:pack:check"],
+      inputFiles: changedFiles
     });
   }
 
   return Array.from(lanesByKey.values());
 }
 
-function readFailedLanes() {
+function readFailedOnlySelection(currentLanes) {
   if (!existsSync(latestSummaryPath)) {
-    return [];
+    return {
+      hasSummary: false,
+      lanesToRun: [],
+      reusedResults: []
+    };
   }
   const summary = JSON.parse(readFileSync(latestSummaryPath, "utf8"));
-  if (!summary.baseRef || !summary.validationFingerprint) {
-    validateFailedRunSummary(summary, null);
-  }
-  const currentFingerprint = buildValidationFingerprint({
-    baseRef,
-    workspaceRoot
-  });
-  validateFailedRunSummary(summary, currentFingerprint);
-  return (summary.results ?? [])
-    .filter((result) => result.exitCode !== 0)
-    .map((result) => ({
-      key: result.key,
-      label: result.label,
-      command: result.command
-    }));
-}
-
-export function validateFailedRunSummary(summary, currentFingerprint) {
-  if (!summary.baseRef || !summary.validationFingerprint) {
-    throw new UserFacingError(
-      "cannot reuse legacy failed-lane state; run pnpm check:changed"
-    );
-  }
-  if (currentFingerprint !== summary.validationFingerprint) {
-    throw new UserFacingError(
-      "workspace or base changed since the failed run; run pnpm check:changed"
-    );
-  }
+  return {
+    hasSummary: true,
+    ...selectFailedOnlyLanes(currentLanes, summary)
+  };
 }
 
 export async function runLanes(inputLanes, runDirectory) {
@@ -357,30 +404,44 @@ function buildLaneResult(lane, index, logPath, startedAt, exitCode) {
     durationMs: Date.now() - startedAt,
     exitCode,
     index,
+    inputFiles: lane.inputFiles,
+    inputFingerprint: lane.inputFingerprint,
     key: lane.key,
     label: lane.label,
     logPath,
-    logPathRelative: relative(workspaceRoot, logPath)
+    logPathRelative: relative(workspaceRoot, logPath),
+    reused: false
   };
 }
 
-function printPlan(inputLanes) {
-  console.log(`check:changed plan (${inputLanes.length} lane(s))`);
+function printPlan(inputLanes, reusedResults = []) {
+  const reusedSuffix =
+    reusedResults.length > 0 ? `, ${reusedResults.length} reused` : "";
+  console.log(
+    `check:changed plan (${inputLanes.length} to run${reusedSuffix})`
+  );
   for (const lane of inputLanes) {
     console.log(`- ${lane.label}: ${formatCommand(lane.command)}`);
+  }
+  for (const result of reusedResults) {
+    console.log(`- ${result.label}: reuse passed result`);
   }
 }
 
 export function printSummary(results, failures, durationMs, runDirectory) {
+  const reusedCount = results.filter((result) => result.reused).length;
+  const runCount = results.length - reusedCount;
+  const reuseSuffix =
+    reusedCount > 0 ? ` (${runCount} run, ${reusedCount} reused)` : "";
   if (failures.length === 0) {
     console.log(
-      `check:changed passed ${results.length} lane(s) in ${formatDuration(durationMs)}`
+      `check:changed passed ${results.length} lane(s) in ${formatDuration(durationMs)}${reuseSuffix}`
     );
     return;
   }
 
   console.error(
-    `check:changed failed ${failures.length}/${results.length} lane(s) in ${formatDuration(durationMs)}`
+    `check:changed failed ${failures.length}/${results.length} lane(s) in ${formatDuration(durationMs)}${reuseSuffix}`
   );
   for (const failure of failures) {
     const output = failureExcerpt(failure.logPath, tailLines);
@@ -548,48 +609,6 @@ function applyCliOptions(options) {
   baseRef = options.baseRef ?? resolveDefaultBaseRef();
 }
 
-export function buildValidationFingerprint(input) {
-  const root = input.workspaceRoot;
-  const hash = createHash("sha256");
-  const addGitOutput = (label, args) => {
-    const result = spawnSync("git", args, {
-      cwd: root,
-      encoding: null
-    });
-    if (result.status !== 0) {
-      throw new Error(
-        `check:changed failed to fingerprint git ${args.join(" ")}`
-      );
-    }
-    hash.update(label);
-    hash.update(result.stdout);
-  };
-
-  hash.update(`base-ref:${input.baseRef}\n`);
-  addGitOutput("base-oid", ["rev-parse", "--verify", input.baseRef]);
-  addGitOutput("head-oid", ["rev-parse", "--verify", "HEAD"]);
-  addGitOutput("working-diff", ["diff", "--binary", "HEAD"]);
-  addGitOutput("staged-diff", ["diff", "--cached", "--binary", "HEAD"]);
-
-  const untrackedResult = spawnSync(
-    "git",
-    ["ls-files", "--others", "--exclude-standard", "-z"],
-    { cwd: root, encoding: "utf8" }
-  );
-  if (untrackedResult.status !== 0) {
-    throw new Error("check:changed failed to fingerprint untracked files");
-  }
-  for (const file of untrackedResult.stdout
-    .split("\0")
-    .filter(Boolean)
-    .sort()) {
-    hash.update(`untracked:${file}\n`);
-    hash.update(readFileSync(join(root, file)));
-  }
-
-  return hash.digest("hex");
-}
-
 function isLintableCodeFile(file) {
   return /\.(?:cjs|cts|js|jsx|mjs|mts|ts|tsx)$/u.test(file);
 }
@@ -632,6 +651,33 @@ function isGlobalTypecheckRelevant(file) {
     "pnpm-workspace.yaml",
     "tsconfig.json"
   ].includes(file);
+}
+
+function isTypeScriptValidationInput(file) {
+  return (
+    isPackageValidationRelevant(file) ||
+    ["pnpm-lock.yaml", "pnpm-workspace.yaml"].includes(file) ||
+    file.startsWith("packages/configs/")
+  );
+}
+
+function isGoValidationInput(file) {
+  return (
+    file.endsWith(".go") ||
+    /(?:^|\/)go\.(?:mod|sum)$/u.test(file) ||
+    ["go.work", "go.work.sum"].includes(file) ||
+    file.startsWith("services/tuttid/.golangci")
+  );
+}
+
+function selectGoLaneInputs(changedFiles, moduleRoot, forceBuiltinGenerate) {
+  return changedFiles.filter(
+    (file) =>
+      (isGoValidationInput(file) && resolveGoModuleRoot(file) === moduleRoot) ||
+      (forceBuiltinGenerate &&
+        moduleRoot === "services/tuttid" &&
+        file.startsWith("services/tuttid/builtin-apps/tutti-onboarding/"))
+  );
 }
 
 function fileExistsWithinWorkspace(file) {
@@ -680,7 +726,7 @@ if (process.argv[1] && resolve(process.argv[1]) === currentPath) {
     .then(() => main())
     .catch((error) => {
       console.error(
-        error instanceof UserFacingError
+        error instanceof UserFacingError || error instanceof LaneCacheError
           ? `check:changed: ${error.message}`
           : error instanceof Error
             ? (error.stack ?? error.message)

--- a/tools/scripts/run-check-changed.mjs
+++ b/tools/scripts/run-check-changed.mjs
@@ -49,7 +49,19 @@ const latestSummaryPath = join(tmpRoot, "latest.json");
 const packageInfos = loadPackageInfos();
 
 export async function main() {
-  const currentLanes = buildChangedLanes().map((lane) => ({
+  const plannedLanes = buildChangedLanes();
+
+  if (plannedLanes.length === 0) {
+    console.log("check:changed found no changed files to validate");
+    return;
+  }
+
+  if (dryRun && !failedOnly) {
+    printPlan(plannedLanes);
+    return;
+  }
+
+  const currentLanes = plannedLanes.map((lane) => ({
     ...lane,
     inputFingerprint: buildLaneInputFingerprint({
       baseRef,
@@ -57,11 +69,6 @@ export async function main() {
       workspaceRoot
     })
   }));
-
-  if (currentLanes.length === 0) {
-    console.log("check:changed found no changed files to validate");
-    return;
-  }
 
   const failedOnlySelection = failedOnly
     ? readFailedOnlySelection(currentLanes)

--- a/tools/scripts/run-check-changed.test.mjs
+++ b/tools/scripts/run-check-changed.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
   buildLaneInputFingerprint,
   mergeLaneResults,
+  resolveRetryPushReady,
   selectFailedOnlyLanes
 } from "./run-check-changed-cache.mjs";
 import {
@@ -162,6 +163,12 @@ test("failed-only rejects summaries without lane fingerprints", () => {
     () => selectFailedOnlyLanes([], { results: [] }),
     /legacy failed-lane state/u
   );
+});
+
+test("failed-only inherits push-ready lanes from the previous run", () => {
+  assert.equal(resolveRetryPushReady(false, { pushReady: true }), true);
+  assert.equal(resolveRetryPushReady(false, { pushReady: false }), false);
+  assert.equal(resolveRetryPushReady(true, { pushReady: false }), true);
 });
 
 test("failed-only keeps reused results available for the next retry", () => {

--- a/tools/scripts/run-check-changed.test.mjs
+++ b/tools/scripts/run-check-changed.test.mjs
@@ -5,12 +5,15 @@ import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 import {
-  buildValidationFingerprint,
+  buildLaneInputFingerprint,
+  mergeLaneResults,
+  selectFailedOnlyLanes
+} from "./run-check-changed-cache.mjs";
+import {
   parseCliArgs,
   printSummary,
   runLanes,
-  selectExistingLintFiles,
-  validateFailedRunSummary
+  selectExistingLintFiles
 } from "./run-check-changed.mjs";
 import {
   isAgentActivityRuntimeBoundaryRelevant,
@@ -54,12 +57,14 @@ test("parseCliArgs accepts pnpm separators and explicit values", () => {
   );
 });
 
-test("validation fingerprint changes with working and staged state", () => {
+test("lane input fingerprints change only with their own inputs", () => {
   const workspaceRoot = mkdtempSync(join(tmpdir(), "check-fingerprint-"));
   runFixtureGit(workspaceRoot, ["init", "--quiet"]);
   const sourcePath = join(workspaceRoot, "source.ts");
+  const helperPath = join(workspaceRoot, "helper.ts");
   writeFileSync(sourcePath, "export const value = 1;\n");
-  runFixtureGit(workspaceRoot, ["add", "source.ts"]);
+  writeFileSync(helperPath, "export const helper = 1;\n");
+  runFixtureGit(workspaceRoot, ["add", "source.ts", "helper.ts"]);
   runFixtureGit(workspaceRoot, [
     "-c",
     "user.email=test@example.com",
@@ -70,52 +75,122 @@ test("validation fingerprint changes with working and staged state", () => {
     "-m",
     "init"
   ]);
-  const initial = buildValidationFingerprint({
+  const sourceLane = {
+    key: "source",
+    label: "source",
+    command: ["check", "source.ts"],
+    inputFiles: ["source.ts"]
+  };
+  const helperLane = {
+    key: "helper",
+    label: "helper",
+    command: ["check", "helper.ts"],
+    inputFiles: ["helper.ts"]
+  };
+  const initialSource = buildLaneInputFingerprint({
     baseRef: "HEAD",
+    lane: sourceLane,
     workspaceRoot
   });
-  const differentBase = buildValidationFingerprint({
-    baseRef: "HEAD^{commit}",
+  const initialHelper = buildLaneInputFingerprint({
+    baseRef: "HEAD",
+    lane: helperLane,
     workspaceRoot
   });
-  assert.notEqual(differentBase, initial);
 
   writeFileSync(sourcePath, "export const value = 2;\n");
-  const working = buildValidationFingerprint({
+  const workingSource = buildLaneInputFingerprint({
     baseRef: "HEAD",
+    lane: sourceLane,
     workspaceRoot
   });
-  assert.notEqual(working, initial);
+  const workingHelper = buildLaneInputFingerprint({
+    baseRef: "HEAD",
+    lane: helperLane,
+    workspaceRoot
+  });
+  assert.notEqual(workingSource, initialSource);
+  assert.equal(workingHelper, initialHelper);
 
   runFixtureGit(workspaceRoot, ["add", "source.ts"]);
   writeFileSync(sourcePath, "export const value = 3;\n");
-  const staged = buildValidationFingerprint({ baseRef: "HEAD", workspaceRoot });
-  runFixtureGit(workspaceRoot, ["reset", "--quiet"]);
-  const unstaged = buildValidationFingerprint({
+  const staged = buildLaneInputFingerprint({
     baseRef: "HEAD",
+    lane: sourceLane,
+    workspaceRoot
+  });
+  runFixtureGit(workspaceRoot, ["reset", "--quiet"]);
+  const unstaged = buildLaneInputFingerprint({
+    baseRef: "HEAD",
+    lane: sourceLane,
     workspaceRoot
   });
   assert.notEqual(staged, unstaged);
 });
 
-test("failed-only state must match the validated workspace", () => {
+test("failed-only reuses only passed lanes with unchanged inputs", () => {
+  const currentLanes = [
+    laneFixture("passed-unchanged", "same"),
+    laneFixture("failed-unchanged", "same"),
+    laneFixture("passed-changed", "after"),
+    laneFixture("new-lane", "new")
+  ];
+  const summary = {
+    laneFingerprintVersion: 1,
+    results: [
+      resultFixture("passed-unchanged", "same", 0),
+      resultFixture("failed-unchanged", "same", 1),
+      resultFixture("passed-changed", "before", 0),
+      resultFixture("removed-lane", "same", 0)
+    ]
+  };
+
+  const selection = selectFailedOnlyLanes(currentLanes, summary);
+
+  assert.deepEqual(
+    selection.lanesToRun.map((lane) => lane.key),
+    ["failed-unchanged", "passed-changed", "new-lane"]
+  );
+  assert.deepEqual(
+    selection.reusedResults.map((result) => result.key),
+    ["passed-unchanged"]
+  );
+});
+
+test("failed-only rejects summaries without lane fingerprints", () => {
   assert.throws(
-    () => validateFailedRunSummary({ baseRef: "HEAD" }, null),
+    () => selectFailedOnlyLanes([], { results: [] }),
     /legacy failed-lane state/u
   );
-  assert.throws(
-    () =>
-      validateFailedRunSummary(
-        { baseRef: "HEAD", validationFingerprint: "before" },
-        "after"
-      ),
-    /workspace or base changed/u
+});
+
+test("failed-only keeps reused results available for the next retry", () => {
+  const currentLanes = [
+    laneFixture("passed", "same"),
+    laneFixture("retried", "fixed")
+  ];
+  const firstSelection = selectFailedOnlyLanes(currentLanes, {
+    laneFingerprintVersion: 1,
+    results: [
+      resultFixture("passed", "same", 0),
+      resultFixture("retried", "broken", 1)
+    ]
+  });
+  const mergedResults = mergeLaneResults(
+    currentLanes,
+    [resultFixture("retried", "fixed", 0)],
+    firstSelection.reusedResults
   );
-  assert.doesNotThrow(() =>
-    validateFailedRunSummary(
-      { baseRef: "HEAD", validationFingerprint: "same" },
-      "same"
-    )
+
+  const nextSelection = selectFailedOnlyLanes(currentLanes, {
+    laneFingerprintVersion: 1,
+    results: mergedResults
+  });
+
+  assert.deepEqual(nextSelection.lanesToRun, []);
+  assert.deepEqual(
+    nextSelection.reusedResults.map((result) => result.key),
+    ["passed", "retried"]
   );
 });
 
@@ -258,6 +333,27 @@ function runFixtureGit(workspaceRoot, args) {
     env: createIsolatedGitEnvironment(workspaceRoot)
   });
   assert.equal(result.status, 0, result.stderr || result.stdout);
+}
+
+function laneFixture(key, inputFingerprint) {
+  return {
+    command: ["check", key],
+    inputFiles: [`${key}.ts`],
+    inputFingerprint,
+    key,
+    label: key
+  };
+}
+
+function resultFixture(key, inputFingerprint, exitCode) {
+  return {
+    ...laneFixture(key, inputFingerprint),
+    durationMs: 10,
+    exitCode,
+    index: 0,
+    logPath: `/tmp/${key}.log`,
+    logPathRelative: `.tmp/${key}.log`
+  };
 }
 
 function isolateProcessGitEnvironment(nextEnvironment) {


### PR DESCRIPTION
## Summary
- rebuild the current changed-aware lane plan for `--failed-only` retries
- fingerprint each lane command and relevant Git inputs, then reuse only unchanged passing lanes
- retain push-ready build/pack lanes across failed-only retries
- keep ordinary `--dry-run` previews free of fingerprint subprocess work
- retain reused results across retries and document the new cache behavior

## Verification
- `node --test tools/scripts/run-check-changed.test.mjs` (13 passed)
- `pnpm check:changed -- --push-ready` (19 lanes passed via pre-push)
- plain `pnpm check:changed -- --dry-run` completed in 0.47s during review verification

## Fix Scope Justification
- Root cause: `--failed-only` bound the whole previous run to one workspace-wide fingerprint, so any post-failure edit invalidated every lane before the runner could select the affected work.
- Lower layer: this cannot be fixed at a lower layer because individual lint, test, build, and boundary commands do not own cross-lane selection or previous results; the changed-aware runner is the owner of lane inputs and result reuse.

## Fallback Three Questions
- Source: the cache stores completed lane results and reuses only successful results whose command and relevant Git inputs are unchanged.
- Why can it not be fixed at that source? Child validation commands cannot coordinate results from sibling lanes; the runner owns orchestration and retry state.
- Removal condition: remove this cache if `--failed-only` is removed or changed-aware validation intentionally returns to executing every selected lane after each edit.

## Notes
- summaries created before per-lane fingerprints require one normal `pnpm check:changed` run

## Checklist
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source (not applicable).
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required.