### PR TITLE
fix(agent): avoid repeated provider status scans

### DIFF
--- a/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
@@ -234,8 +234,9 @@ export function createWorkspaceWindowContainer(): WorkspaceWindowContainerResult
     ? startDesktopAgentAvailabilitySnapshotAnalytics({
         dependencies: { reporterService },
         lifecycle: windowLifecycle,
-        refreshStatuses:
-          workspaceAgentServices.refreshManagedAgentProviderStatuses
+        readStatuses: workspaceAgentServices.readManagedAgentProviderStatuses,
+        subscribeStatuses:
+          workspaceAgentServices.subscribeManagedAgentProviderStatuses
       })
     : null;
   windowLifecycle.start();

--- a/apps/desktop/src/renderer/src/app/windows/workspace/workspaceWindowLifecycleAnalytics.test.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/workspaceWindowLifecycleAnalytics.test.ts
@@ -29,7 +29,7 @@ test("workspace lifecycle gives pageview and availability the same activation op
   startDesktopAgentAvailabilitySnapshotAnalytics({
     dependencies: { reporterService, storage: null },
     lifecycle,
-    async refreshStatuses() {
+    readStatuses() {
       return [
         {
           actions: [],
@@ -50,7 +50,8 @@ test("workspace lifecycle gives pageview and availability the same activation op
           }
         }
       ];
-    }
+    },
+    subscribeStatuses: () => () => {}
   });
 
   lifecycle.start();
@@ -62,13 +63,16 @@ test("workspace lifecycle gives pageview and availability the same activation op
   await flushAsyncWork();
 
   assert.deepEqual(
-    events.map((event) => [event.name, event.clientTS]),
-    [
-      ["app.pageview", 1_000],
-      ["agent.availability_snapshot", 1_000],
-      ["app.pageview", 2_000],
-      ["agent.availability_snapshot", 2_000]
-    ]
+    events
+      .filter((event) => event.name === "app.pageview")
+      .map((event) => event.clientTS),
+    [1_000, 2_000]
+  );
+  assert.deepEqual(
+    events
+      .filter((event) => event.name === "agent.availability_snapshot")
+      .map((event) => event.clientTS),
+    [1_000, 2_000]
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/analytics/reporters/agent-availability-snapshot/types.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/agent-availability-snapshot/types.ts
@@ -2,6 +2,7 @@ import type { AnalyticsReporterParams } from "../baseReporter.ts";
 
 export type AgentAvailabilitySnapshotTrigger =
   | "config_change"
+  | "conversation_start_failed"
   | "daily_rollover"
   | "env_detected"
   | "resume";

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/agentProviderStatusService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/agentProviderStatusService.interface.ts
@@ -76,6 +76,14 @@ export interface IAgentProviderStatusService {
      */
     includeUpdates?: boolean;
   }): Promise<AgentProviderStatusListResponse | null>;
+  /**
+   * Reconciles the renderer snapshot with tuttid without bypassing tuttid's
+   * provider-status cache. Stale visibility checks use this path; analytics
+   * reuses ensureLoaded, and explicit user actions use refresh instead.
+   */
+  reconcileStatuses(
+    providers?: WorkspaceAgentProvider[]
+  ): Promise<AgentProviderStatusListResponse | null>;
   runAction(
     provider: WorkspaceAgentProvider,
     actionId: string,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/agentAvailabilitySnapshotTelemetry.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/agentAvailabilitySnapshotTelemetry.test.ts
@@ -116,6 +116,46 @@ test("availability requires installed CLI, authentication, and ready provider", 
   assert.equal(params.unavailableReason, "provider_error");
 });
 
+test("availability reports an explicit conversation failure trigger", async () => {
+  const events: ReporterEventInput[] = [];
+  const telemetry = new AgentAvailabilitySnapshotTelemetry({
+    now: () => 1_749_124_800_000,
+    reporterService: {
+      async trackEvents(input) {
+        events.push(...input);
+      }
+    },
+    storage: createMemoryStorage()
+  });
+
+  telemetry.reportStatus(
+    status({
+      authenticated: false,
+      availability: "auth_required",
+      cliInstalled: true,
+      provider: "cursor"
+    }),
+    "conversation_start_failed"
+  );
+  await flushAsyncWork();
+
+  assert.deepEqual(
+    events.map((event) => event.params),
+    [
+      {
+        authenticated: false,
+        cli_installed: true,
+        error_code: "agent_error_none",
+        error_message: "",
+        is_available: false,
+        provider: "cursor",
+        trigger: "conversation_start_failed",
+        unavailable_reason: "not_authenticated"
+      }
+    ]
+  );
+});
+
 test("availability rollover uses the activation time supplied by its lifecycle", async () => {
   const events: ReporterEventInput[] = [];
   const telemetry = new AgentAvailabilitySnapshotTelemetry({

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/agentAvailabilitySnapshotTelemetry.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/agentAvailabilitySnapshotTelemetry.ts
@@ -58,11 +58,23 @@ export class AgentAvailabilitySnapshotTelemetry {
         currentSignature: signature,
         previous
       });
-      // State classifies the next snapshot; it does not suppress a pageview
-      // opportunity when the provider state is unchanged.
-      this.writeState(status.provider, { date, signature });
-      void this.report({ ...params, trigger }, now);
+      this.reportStatus(status, trigger, now);
     }
+  }
+
+  reportStatus(
+    status: AgentProviderStatus,
+    trigger: AgentAvailabilitySnapshotTrigger,
+    occurredAt: number = this.now()
+  ): void {
+    const params = buildAvailabilitySnapshotParams(status, trigger);
+    // State classifies the next snapshot; it does not suppress a pageview or
+    // failure-diagnostic opportunity when the provider state is unchanged.
+    this.writeState(status.provider, {
+      date: localDateKey(occurredAt),
+      signature: snapshotSignature(params)
+    });
+    void this.report(params, occurredAt);
   }
 
   private async report(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/agentEnvService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/agentEnvService.test.ts
@@ -74,6 +74,9 @@ class FakeProviderStatusService implements IAgentProviderStatusService {
     this.ensureLoadedInputs[0] = input;
     return null;
   }
+  async reconcileStatuses(): Promise<null> {
+    return null;
+  }
   async runAction(
     provider: WorkspaceAgentProvider,
     actionId: string,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentAvailabilitySnapshotAnalytics.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentAvailabilitySnapshotAnalytics.test.ts
@@ -8,21 +8,21 @@ import type {
 import type { ReporterEventInput } from "../../../analytics/services/reporterService.interface.ts";
 import { startDesktopAgentAvailabilitySnapshotAnalytics } from "./desktopAgentAvailabilitySnapshotAnalytics.ts";
 
-test("availability analytics waits for refreshed provider information", async () => {
+test("availability analytics waits for current provider information", async () => {
   const events: ReporterEventInput[] = [];
   const lifecycle = createLifecycleHarness();
-  const refresh = deferred<readonly AgentProviderStatus[] | null>();
+  const statuses = createStatusSource();
   startDesktopAgentAvailabilitySnapshotAnalytics({
     dependencies: createDependencies(events),
     lifecycle,
-    refreshStatuses: () => refresh.promise
+    readStatuses: statuses.read,
+    subscribeStatuses: statuses.subscribe
   });
 
   lifecycle.emit({ kind: "opened", occurredAt: 1_000 });
-  await Promise.resolve();
   assert.equal(events.length, 0);
 
-  refresh.resolve([createReadyStatus("codex")]);
+  statuses.set([createReadyStatus("codex")]);
   await flushAsyncWork();
 
   const event = events.at(0);
@@ -34,38 +34,30 @@ test("availability analytics waits for refreshed provider information", async ()
   assert.equal(events.length, 1);
 });
 
-test("availability analytics coalesces activations while a refresh is running", async () => {
+test("availability analytics preserves activations while waiting for a snapshot", async () => {
   const events: ReporterEventInput[] = [];
   const lifecycle = createLifecycleHarness();
-  const refreshes = [
-    deferred<readonly AgentProviderStatus[] | null>(),
-    deferred<readonly AgentProviderStatus[] | null>()
-  ];
-  let refreshCount = 0;
+  const statuses = createStatusSource();
   startDesktopAgentAvailabilitySnapshotAnalytics({
     dependencies: createDependencies(events),
     lifecycle,
-    refreshStatuses: () => refreshes[refreshCount++]!.promise
+    readStatuses: statuses.read,
+    subscribeStatuses: statuses.subscribe
   });
 
   lifecycle.emit({ kind: "opened", occurredAt: 1_000 });
   lifecycle.emit({ kind: "focused", occurredAt: 2_000 });
   lifecycle.emit({ kind: "focused", occurredAt: 3_000 });
-  assert.equal(refreshCount, 1);
 
-  refreshes[0]!.resolve([createReadyStatus("codex")]);
-  await flushAsyncWork();
-  assert.equal(refreshCount, 2);
-
-  refreshes[1]!.resolve([createUnavailableStatus("codex")]);
+  statuses.set([createUnavailableStatus("codex")]);
   await flushAsyncWork();
 
-  assert.equal(refreshCount, 2);
   assert.deepEqual(
     events.map((event) => [event.clientTS, event.params?.trigger]),
     [
       [1_000, "env_detected"],
-      [3_000, "config_change"]
+      [2_000, "env_detected"],
+      [3_000, "env_detected"]
     ]
   );
 });
@@ -76,9 +68,10 @@ test("availability analytics reports unchanged status for every pageview opportu
   startDesktopAgentAvailabilitySnapshotAnalytics({
     dependencies: createDependencies(events),
     lifecycle,
-    async refreshStatuses() {
+    readStatuses() {
       return [createReadyStatus("codex")];
-    }
+    },
+    subscribeStatuses: () => () => {}
   });
 
   lifecycle.emit({ kind: "opened", occurredAt: 1_000 });
@@ -98,16 +91,17 @@ test("availability analytics reports unchanged status for every pageview opportu
 test("availability analytics does not report after disposal", async () => {
   const events: ReporterEventInput[] = [];
   const lifecycle = createLifecycleHarness();
-  const refresh = deferred<readonly AgentProviderStatus[] | null>();
+  const statuses = createStatusSource();
   const controller = startDesktopAgentAvailabilitySnapshotAnalytics({
     dependencies: createDependencies(events),
     lifecycle,
-    refreshStatuses: () => refresh.promise
+    readStatuses: statuses.read,
+    subscribeStatuses: statuses.subscribe
   });
 
   lifecycle.emit({ kind: "opened", occurredAt: 1_000 });
   controller.dispose();
-  refresh.resolve([createReadyStatus("codex")]);
+  statuses.set([createReadyStatus("codex")]);
   await flushAsyncWork();
 
   assert.deepEqual(events, []);
@@ -142,12 +136,22 @@ function createLifecycleHarness(): WorkspaceWindowLifecycle & {
   };
 }
 
-function deferred<T>() {
-  let resolve = (_value: T) => {};
-  const promise = new Promise<T>((nextResolve) => {
-    resolve = nextResolve;
-  });
-  return { promise, resolve };
+function createStatusSource() {
+  const listeners = new Set<() => void>();
+  let value: readonly AgentProviderStatus[] | null = null;
+  return {
+    read: () => value,
+    set(nextValue: readonly AgentProviderStatus[]) {
+      value = nextValue;
+      for (const listener of [...listeners]) {
+        listener();
+      }
+    },
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    }
+  };
 }
 
 function createReadyStatus(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentAvailabilitySnapshotAnalytics.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentAvailabilitySnapshotAnalytics.ts
@@ -21,38 +21,33 @@ export interface DesktopAgentAvailabilitySnapshotAnalyticsController {
 export function startDesktopAgentAvailabilitySnapshotAnalytics(input: {
   dependencies?: DesktopAgentAvailabilitySnapshotAnalyticsDependencies;
   lifecycle: WorkspaceWindowLifecycle;
-  refreshStatuses(): Promise<readonly AgentProviderStatus[] | null>;
+  readStatuses(): readonly AgentProviderStatus[] | null;
+  subscribeStatuses(listener: () => void): () => void;
 }): DesktopAgentAvailabilitySnapshotAnalyticsController {
   const telemetry = new AgentAvailabilitySnapshotTelemetry(input.dependencies);
   let disposed = false;
-  let pendingActivation: WorkspaceWindowLifecycleEvent | null = null;
-  let running = false;
+  const pendingActivations: WorkspaceWindowLifecycleEvent[] = [];
 
-  const drain = async (): Promise<void> => {
-    running = true;
-    while (!disposed && pendingActivation) {
-      const activation = pendingActivation;
-      pendingActivation = null;
-      try {
-        const statuses = await input.refreshStatuses();
-        if (!disposed && statuses) {
-          telemetry.reportStatuses(statuses, activation.occurredAt);
-        }
-      } catch {
-        // Status refresh and analytics are best effort on window activation.
-      }
+  const reportPendingActivations = (): void => {
+    if (disposed || pendingActivations.length === 0) {
+      return;
     }
-    running = false;
+    const statuses = input.readStatuses();
+    if (!statuses) {
+      return;
+    }
+    for (const activation of pendingActivations.splice(0)) {
+      telemetry.reportStatuses(statuses, activation.occurredAt);
+    }
   };
 
+  const unsubscribeStatuses = input.subscribeStatuses(reportPendingActivations);
   const unsubscribeLifecycle = input.lifecycle.subscribe((event) => {
     if (event.kind !== "opened" && event.kind !== "focused") {
       return;
     }
-    pendingActivation = event;
-    if (!running) {
-      void drain();
-    }
+    pendingActivations.push(event);
+    reportPendingActivations();
   });
 
   return {
@@ -61,7 +56,8 @@ export function startDesktopAgentAvailabilitySnapshotAnalytics(input: {
         return;
       }
       disposed = true;
-      pendingActivation = null;
+      pendingActivations.length = 0;
+      unsubscribeStatuses();
       unsubscribeLifecycle();
     }
   };

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.test.ts
@@ -2018,6 +2018,52 @@ test("a targeted ensure resolves before an older full scan and keeps its newer s
   assert.equal(service.getStatus("cursor")?.availability.status, "ready");
 });
 
+test("reconcileStatuses reuses an in-flight read without forcing daemon detection", async () => {
+  const requests: Array<{
+    providers: readonly WorkspaceAgentProvider[] | undefined;
+    refresh: boolean | undefined;
+  }> = [];
+  const firstStatusRequest = createDeferred<AgentProviderStatusListResponse>();
+  const service = new DesktopAgentProviderStatusService({
+    tuttidClient: {
+      async getAgentProviderStatuses(request) {
+        requests.push({
+          providers: request?.providers,
+          refresh: request?.refresh
+        });
+        return firstStatusRequest.promise;
+      }
+    } as Partial<TuttidClient> as TuttidClient,
+    terminalCommandRunner: {
+      async runTerminalCommand() {}
+    }
+  });
+
+  const firstRead = service.reconcileStatuses(["codex"]);
+  const secondRead = service.reconcileStatuses(["codex"]);
+
+  assert.deepEqual(requests, [{ providers: ["codex"], refresh: undefined }]);
+
+  firstStatusRequest.resolve(
+    createStatusResponse([
+      createProviderStatus({
+        actions: [],
+        availability: "ready",
+        provider: "codex"
+      })
+    ])
+  );
+  await Promise.all([firstRead, secondRead]);
+
+  await service.reconcileStatuses(["codex"]);
+
+  assert.equal(service.getStatus("codex")?.availability.status, "ready");
+  assert.deepEqual(requests, [
+    { providers: ["codex"], refresh: undefined },
+    { providers: ["codex"], refresh: undefined }
+  ]);
+});
+
 test("refresh waits for an in-flight load and then requests a fresh status", async () => {
   const calls: Array<readonly WorkspaceAgentProvider[] | undefined> = [];
   const firstStatusRequest = createDeferred<AgentProviderStatusListResponse>();

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts
@@ -213,6 +213,12 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
     return this.requestStatuses(input);
   }
 
+  async reconcileStatuses(
+    providers?: WorkspaceAgentProvider[]
+  ): Promise<AgentProviderStatusListResponse | null> {
+    return this.requestStatuses({ providers });
+  }
+
   private async requestStatuses(
     input: {
       providers?: WorkspaceAgentProvider[];

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderVisibilityRefresh.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderVisibilityRefresh.test.ts
@@ -8,13 +8,14 @@ import type {
 import { desktopManagedAgentProviders } from "./desktopManagedAgentProviders.ts";
 import { bindDesktopManagedAgentProviderVisibilityRefresh } from "./desktopAgentProviderVisibilityRefresh.ts";
 
-test("managed provider refresh follows visible window activations", () => {
-  const refreshCalls: unknown[] = [];
+test("managed provider reconciliation serializes providers for visible window activations", async () => {
+  const reconcileCalls: unknown[] = [];
   const lifecycle = createLifecycleHarness();
   const dispose = bindDesktopManagedAgentProviderVisibilityRefresh(
     {
-      async refresh(providers) {
-        refreshCalls.push(providers);
+      async reconcileStatuses(providers) {
+        reconcileCalls.push(providers);
+        return null;
       }
     },
     lifecycle,
@@ -23,6 +24,7 @@ test("managed provider refresh follows visible window activations", () => {
 
   lifecycle.emit({ kind: "opened", occurredAt: 1_000 });
   lifecycle.emit({ kind: "focused", occurredAt: 2_000 });
+  await flushAsyncWork();
   lifecycle.setSnapshot({ focused: false, visibility: "hidden" });
   lifecycle.emit({ kind: "focused", occurredAt: 3_000 });
   lifecycle.setSnapshot({ focused: false, visibility: "visible" });
@@ -31,17 +33,20 @@ test("managed provider refresh follows visible window activations", () => {
     occurredAt: 4_000,
     visibility: "visible"
   });
+  await flushAsyncWork();
   dispose();
   lifecycle.emit({ kind: "focused", occurredAt: 5_000 });
 
-  assert.deepEqual(refreshCalls, [
-    [...desktopManagedAgentProviders],
-    [...desktopManagedAgentProviders]
-  ]);
+  assert.deepEqual(
+    reconcileCalls,
+    [...desktopManagedAgentProviders, ...desktopManagedAgentProviders].map(
+      (provider) => [provider]
+    )
+  );
 });
 
-test("managed provider refresh preserves a fresh application snapshot", () => {
-  const refreshCalls: unknown[] = [];
+test("managed provider reconciliation preserves a fresh application snapshot", async () => {
+  const reconcileCalls: unknown[] = [];
   const lifecycle = createLifecycleHarness();
   bindDesktopManagedAgentProviderVisibilityRefresh(
     {
@@ -55,8 +60,9 @@ test("managed provider refresh preserves a fresh application snapshot", () => {
           statuses: []
         };
       },
-      async refresh(providers) {
-        refreshCalls.push(providers);
+      async reconcileStatuses(providers) {
+        reconcileCalls.push(providers);
+        return null;
       }
     },
     lifecycle,
@@ -67,8 +73,36 @@ test("managed provider refresh preserves a fresh application snapshot", () => {
     kind: "focused",
     occurredAt: Date.parse("2026-07-16T06:00:00Z")
   });
+  await flushAsyncWork();
 
-  assert.deepEqual(refreshCalls, []);
+  assert.deepEqual(reconcileCalls, []);
+});
+
+test("managed provider reconciliation stops scheduling when the window hides", async () => {
+  const lifecycle = createLifecycleHarness();
+  const reconcileCalls: unknown[] = [];
+  const firstProvider = deferred<void>();
+  bindDesktopManagedAgentProviderVisibilityRefresh(
+    {
+      async reconcileStatuses(providers) {
+        reconcileCalls.push(providers);
+        if (reconcileCalls.length === 1) {
+          await firstProvider.promise;
+        }
+        return null;
+      }
+    },
+    lifecycle,
+    { minIntervalMs: 0 }
+  );
+
+  lifecycle.emit({ kind: "focused", occurredAt: 1_000 });
+  await Promise.resolve();
+  lifecycle.setSnapshot({ focused: false, visibility: "hidden" });
+  firstProvider.resolve();
+  await flushAsyncWork();
+
+  assert.deepEqual(reconcileCalls, [[desktopManagedAgentProviders[0]]]);
 });
 
 function createLifecycleHarness(): WorkspaceWindowLifecycle & {
@@ -95,4 +129,16 @@ function createLifecycleHarness(): WorkspaceWindowLifecycle & {
       return () => listeners.delete(listener);
     }
   };
+}
+
+function deferred<T>() {
+  let resolve = (_value: T | PromiseLike<T>) => {};
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderVisibilityRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderVisibilityRefresh.ts
@@ -8,7 +8,7 @@ export interface DesktopAgentProviderVisibilityRefreshOptions {
 }
 
 export function bindDesktopManagedAgentProviderVisibilityRefresh(
-  service: Pick<IAgentProviderStatusService, "refresh"> &
+  service: Pick<IAgentProviderStatusService, "reconcileStatuses"> &
     Partial<Pick<IAgentProviderStatusService, "getSnapshot">>,
   lifecycle: WorkspaceWindowLifecycle,
   options: DesktopAgentProviderVisibilityRefreshOptions = {}
@@ -17,12 +17,32 @@ export function bindDesktopManagedAgentProviderVisibilityRefresh(
   const freshnessMs = options.freshnessMs ?? 30 * 60 * 1_000;
   const providers = [...desktopManagedAgentProviders];
   let lastRefreshAt = Number.NEGATIVE_INFINITY;
+  let disposed = false;
+  let running = false;
 
-  return lifecycle.subscribe((event) => {
+  const reconcileProviders = async (): Promise<void> => {
+    running = true;
+    try {
+      for (const provider of providers) {
+        if (disposed || lifecycle.getSnapshot().visibility !== "visible") {
+          return;
+        }
+        await service.reconcileStatuses([provider]).catch(() => null);
+      }
+    } finally {
+      running = false;
+    }
+  };
+
+  const unsubscribe = lifecycle.subscribe((event) => {
     const activated =
       event.kind === "focused" ||
       (event.kind === "visibility_changed" && event.visibility === "visible");
-    if (!activated || lifecycle.getSnapshot().visibility !== "visible") {
+    if (
+      !activated ||
+      running ||
+      lifecycle.getSnapshot().visibility !== "visible"
+    ) {
       return;
     }
     if (event.occurredAt - lastRefreshAt < minIntervalMs) {
@@ -37,6 +57,11 @@ export function bindDesktopManagedAgentProviderVisibilityRefresh(
       return;
     }
     lastRefreshAt = event.occurredAt;
-    void service.refresh(providers).catch(() => {});
+    void reconcileProviders();
   });
+
+  return () => {
+    disposed = true;
+    unsubscribe();
+  };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/tuttiAgentInstallBootstrap.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/tuttiAgentInstallBootstrap.test.ts
@@ -161,6 +161,7 @@ function createService(
         providers: [status]
       };
     },
+    reconcileStatuses: async () => null,
     getDiagnosticsConsent: () => false,
     getRevision: () => 0,
     getSnapshot: () => ({

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityAnalytics.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityAnalytics.ts
@@ -1,4 +1,8 @@
 import type { AgentActivityRuntime } from "@tutti-os/agent-gui";
+import type {
+  AgentProviderStatusListResponse,
+  WorkspaceAgentProvider
+} from "@tutti-os/client-tuttid-ts";
 import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
 import type { IWorkspaceUserProjectService } from "../../../workspace-user-project/index.ts";
 import type { IWorkspaceAgentActivityService } from "../workspaceAgentActivityService.interface.ts";
@@ -9,10 +13,17 @@ import {
   resolveAgentSessionSource
 } from "./agentSessionStartedAnalytics.ts";
 import { resolveComposerPermissionMode } from "./desktopAgentHostProjection.ts";
+import { AgentAvailabilitySnapshotTelemetry } from "./agentAvailabilitySnapshotTelemetry.ts";
 
 interface WorkspaceAgentActivityAnalyticsDependencies {
+  forceRefreshAgentProviderStatuses?: (
+    providers: WorkspaceAgentProvider[]
+  ) => Promise<AgentProviderStatusListResponse | null>;
   reporterNow?: () => number;
   reporterService?: Pick<IReporterService, "trackEvents">;
+  resolveAgentTargetProvider?: (
+    agentTargetId: string
+  ) => WorkspaceAgentProvider | null;
   workspaceUserProjectService?: Pick<
     IWorkspaceUserProjectService,
     "isNoProjectPath"
@@ -20,6 +31,7 @@ interface WorkspaceAgentActivityAnalyticsDependencies {
 }
 
 export class WorkspaceAgentActivityAnalytics {
+  private readonly availabilitySnapshotTelemetry: AgentAvailabilitySnapshotTelemetry;
   private readonly dependencies: WorkspaceAgentActivityAnalyticsDependencies;
   private readonly messageSentTracker: ReturnType<
     typeof createAgentMessageSentTracker
@@ -30,8 +42,37 @@ export class WorkspaceAgentActivityAnalytics {
 
   constructor(dependencies: WorkspaceAgentActivityAnalyticsDependencies) {
     this.dependencies = dependencies;
+    this.availabilitySnapshotTelemetry = new AgentAvailabilitySnapshotTelemetry(
+      {
+        now: dependencies.reporterNow,
+        reporterService: dependencies.reporterService
+      }
+    );
     this.messageSentTracker = createAgentMessageSentTracker(dependencies);
     this.sessionStartedTracker = createAgentSessionStartedTracker(dependencies);
+  }
+
+  trackSessionCreateFailure(input: { agentTargetId?: string | null }): void {
+    const agentTargetId = input.agentTargetId?.trim() ?? "";
+    const provider = agentTargetId
+      ? this.dependencies.resolveAgentTargetProvider?.(agentTargetId)
+      : null;
+    const forceRefresh = this.dependencies.forceRefreshAgentProviderStatuses;
+    if (!provider || !forceRefresh) {
+      return;
+    }
+    runBestEffortAnalytics(async () => {
+      const response = await forceRefresh([provider]);
+      const freshStatus = response?.providers.find(
+        (status) => status.provider === provider
+      );
+      if (freshStatus) {
+        this.availabilitySnapshotTelemetry.reportStatus(
+          freshStatus,
+          "conversation_start_failed"
+        );
+      }
+    });
   }
 
   trackEngineActivation(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -200,6 +200,119 @@ test("WorkspaceAgentActivityService.activateSession creates target-backed sessio
   });
 });
 
+test("WorkspaceAgentActivityService force-refreshes only the failed conversation provider before reporting availability", async () => {
+  const refreshCalls: string[][] = [];
+  const reporterEvents: ReporterEventInput[] = [];
+  const service = new WorkspaceAgentActivityService({
+    forceRefreshAgentProviderStatuses: async (providers) => {
+      refreshCalls.push(providers);
+      return {
+        capturedAt: "2026-07-22T12:00:00.000Z",
+        defaultProvider: "cursor",
+        providers: [
+          {
+            actions: [],
+            adapter: { command: [], installed: true },
+            auth: { status: "required" },
+            availability: { status: "auth_required" },
+            cli: { installed: true },
+            provider: "cursor",
+            update: {
+              capability: "unsupported",
+              currentVersion: null,
+              lastCheckedAt: null,
+              latestVersion: null,
+              reasonCode: null,
+              source: null,
+              unsupportedReason: "update_strategy_unsupported",
+              updateAvailable: null
+            }
+          }
+        ]
+      };
+    },
+    reporterNow: () => 1_749_124_800_000,
+    reporterService: {
+      async trackEvents(events) {
+        reporterEvents.push(...events);
+      }
+    },
+    resolveAgentTargetProvider: (agentTargetId) =>
+      agentTargetId === "target-cursor" ? "cursor" : null,
+    tuttidClient: {
+      createWorkspaceAgentSession: async () => {
+        throw new Error("provider launch failed");
+      }
+    } as unknown as TuttidClient,
+    runtimeApi: { logTerminalDiagnostic: async () => {} }
+  });
+
+  await assert.rejects(
+    service.createSession({
+      agentSessionId: "session-failed",
+      agentTargetId: "target-cursor",
+      clientSubmitId: "submit-failed",
+      initialContent: [{ type: "text", text: "hello" }],
+      workspaceId: "ws-1"
+    }),
+    /provider launch failed/
+  );
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(refreshCalls, [["cursor"]]);
+  const snapshot = reporterEvents.find(
+    (event) => event.name === "agent.availability_snapshot"
+  );
+  assert.deepEqual(snapshot?.params, {
+    authenticated: false,
+    cli_installed: true,
+    error_code: "agent_error_none",
+    error_message: "",
+    is_available: false,
+    provider: "cursor",
+    trigger: "conversation_start_failed",
+    unavailable_reason: "not_authenticated"
+  });
+});
+
+test("WorkspaceAgentActivityService does not report a cached availability snapshot when the forced refresh fails", async () => {
+  const reporterEvents: ReporterEventInput[] = [];
+  const service = new WorkspaceAgentActivityService({
+    forceRefreshAgentProviderStatuses: async () => null,
+    reporterService: {
+      async trackEvents(events) {
+        reporterEvents.push(...events);
+      }
+    },
+    resolveAgentTargetProvider: () => "cursor",
+    tuttidClient: {
+      createWorkspaceAgentSession: async () => {
+        throw new Error("provider launch failed");
+      }
+    } as unknown as TuttidClient,
+    runtimeApi: { logTerminalDiagnostic: async () => {} }
+  });
+
+  await assert.rejects(
+    service.createSession({
+      agentSessionId: "session-failed",
+      agentTargetId: "target-cursor",
+      clientSubmitId: "submit-failed",
+      initialContent: [{ type: "text", text: "hello" }],
+      workspaceId: "ws-1"
+    }),
+    /provider launch failed/
+  );
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(
+    reporterEvents.some(
+      (event) => event.name === "agent.availability_snapshot"
+    ),
+    false
+  );
+});
+
 test("WorkspaceAgentActivityService confirms engine activation from the realtime session upsert", async () => {
   const createRequests: unknown[] = [];
   const service = new WorkspaceAgentActivityService({

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -9,10 +9,12 @@ import {
 } from "@tutti-os/agent-activity-core";
 import type { AgentActivityRuntime } from "@tutti-os/agent-gui";
 import type {
+  AgentProviderStatusListResponse,
   Client,
   CollaborationRun,
   TuttidClient,
-  TuttidEventStreamClient
+  TuttidEventStreamClient,
+  WorkspaceAgentProvider
 } from "@tutti-os/client-tuttid-ts";
 import {
   createClient,
@@ -30,7 +32,6 @@ import type {
   IWorkspaceAgentActivityService,
   WorkspaceAgentActivityListMessagesInput
 } from "../workspaceAgentActivityService.interface.ts";
-import type { IAgentProviderStatusService } from "../agentProviderStatusService.interface.ts";
 import type { IWorkspaceUserProjectService } from "../../../workspace-user-project/index.ts";
 import {
   createWorkspaceAgentSessionEngineHost,
@@ -87,7 +88,12 @@ export interface WorkspaceAgentActivityServiceDependencies {
   reporterService?: Pick<IReporterService, "trackEvents">;
   runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic"> &
     Partial<Pick<DesktopRuntimeApi, "getBackendConfig">>;
-  agentProviderStatusService?: Pick<IAgentProviderStatusService, "refresh">;
+  forceRefreshAgentProviderStatuses?: (
+    providers: WorkspaceAgentProvider[]
+  ) => Promise<AgentProviderStatusListResponse | null>;
+  resolveAgentTargetProvider?: (
+    agentTargetId: string
+  ) => WorkspaceAgentProvider | null;
   workspaceUserProjectService?: IWorkspaceUserProjectService;
 }
 
@@ -123,8 +129,11 @@ export class WorkspaceAgentActivityService
     super(dependencies);
     this.dependencies = dependencies;
     this.analytics = new WorkspaceAgentActivityAnalytics({
+      forceRefreshAgentProviderStatuses:
+        dependencies.forceRefreshAgentProviderStatuses,
       reporterNow: dependencies.reporterNow,
       reporterService: dependencies.reporterService,
+      resolveAgentTargetProvider: dependencies.resolveAgentTargetProvider,
       workspaceUserProjectService: dependencies.workspaceUserProjectService
     });
     this.queryOperations = new WorkspaceAgentActivityQueryOperations(
@@ -405,7 +414,14 @@ export class WorkspaceAgentActivityService
   async createSession(
     input: Parameters<AgentActivityAdapter["createSession"]>[0]
   ): Promise<AgentActivitySession> {
-    return this.mutationOperations.createSession(input);
+    try {
+      return await this.mutationOperations.createSession(input);
+    } catch (error) {
+      this.analytics.trackSessionCreateFailure({
+        agentTargetId: input.agentTargetId
+      });
+      throw error;
+    }
   }
 
   async activateSession(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
@@ -70,9 +70,8 @@ export interface WorkspaceAgentServiceRegistrationResult {
   agentEnvService: IAgentEnvService;
   agentsService: IAgentsService;
   agentProviderStatusService: IAgentProviderStatusService;
-  refreshManagedAgentProviderStatuses(): Promise<
-    readonly AgentProviderStatus[] | null
-  >;
+  readManagedAgentProviderStatuses(): readonly AgentProviderStatus[] | null;
+  subscribeManagedAgentProviderStatuses(listener: () => void): () => void;
   agentQuickPromptService: AgentQuickPromptService;
   workspaceAgentActivityService: IWorkspaceAgentActivityService;
   dispose(): void;
@@ -110,14 +109,13 @@ export function registerWorkspaceAgentServices(
   const managedProviderSet = new Set<WorkspaceAgentProvider>(
     desktopManagedAgentProviders
   );
-  const refreshManagedAgentProviderStatuses = async () => {
-    const response = await agentProviderStatusService.refreshStatuses([
-      ...desktopManagedAgentProviders
-    ]);
-    return (
-      response?.providers.filter((status) =>
-        managedProviderSet.has(status.provider)
-      ) ?? null
+  const readManagedAgentProviderStatuses = () => {
+    const snapshot = agentProviderStatusService.getSnapshot();
+    if (!snapshot.capturedAt) {
+      return null;
+    }
+    return snapshot.statuses.filter((status) =>
+      managedProviderSet.has(status.provider)
     );
   };
   startManagedAgentInstallBootstraps(agentProviderStatusService);
@@ -143,7 +141,10 @@ export function registerWorkspaceAgentServices(
   registry.registerInstance(IAgentQuickPromptService, agentQuickPromptService);
   const workspaceAgentActivityService = new WorkspaceAgentActivityService({
     ...input,
-    agentProviderStatusService
+    forceRefreshAgentProviderStatuses: (providers) =>
+      agentProviderStatusService.refreshStatuses(providers),
+    resolveAgentTargetProvider: (agentTargetId) =>
+      agentsService.getAgentTarget({ agentTargetId })?.provider ?? null
   });
   registry.registerInstance(
     IWorkspaceAgentActivityService,
@@ -161,7 +162,9 @@ export function registerWorkspaceAgentServices(
     agentEnvService,
     agentsService,
     agentProviderStatusService,
-    refreshManagedAgentProviderStatuses,
+    readManagedAgentProviderStatuses,
+    subscribeManagedAgentProviderStatuses: (listener) =>
+      agentProviderStatusService.subscribe(listener),
     agentQuickPromptService,
     workspaceAgentActivityService,
     dispose() {

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -169,6 +169,34 @@ without a frame is a failed refresh: a retained value may remain visible, but
 the UI must show the refresh failure rather than treating the old value as a
 new success.
 
+Desktop availability analytics reads the renderer's loaded managed-provider
+snapshot and must not turn a pageview or focus event into a daemon request. A
+stale visibility snapshot may reconcile through a non-forced tuttid status
+read; tuttid owns cache validity, credential-fingerprint checks, and
+single-flight probing. Forced detection is reserved for explicit provider
+refresh and the provider-scoped confirmation after an install, login, or
+update action. A confirmed new-conversation creation failure is the only
+analytics exception: Desktop force-refreshes only the exact target's provider,
+then reports the fresh availability snapshot with a failure-specific trigger.
+
+Cold workspace initialization may request all managed providers together so the
+first useful snapshot arrives quickly. tuttid may detect different providers in
+parallel, but it applies one process-wide limit to auth, version, and adapter
+probe subprocesses because a single provider can otherwise fan out into several
+CLI processes. Later visible-window stale reconciliation is best-effort
+background work and checks providers serially; another focus cannot overlap the
+same reconciliation run.
+
+Provider detection separates volatile readiness from stable executable facts.
+An ordinary read may reuse the full provider snapshot. A forced read bypasses
+that snapshot and rechecks current authentication/readiness, including the
+provider credential marker, but may reuse a successful CLI version or adapter
+launch result while the resolved executable fingerprint is unchanged. Failed
+version reads and failed adapter launches are never cached. OpenCode and
+Tutti Agent use their validated local credential files as the primary auth
+signal; malformed files may fall back to one CLI check. Cursor's single
+`about --format json` result supplies both auth and version when available.
+
 ## 3. Domain model
 
 ### 3.1 Session

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -111,7 +111,8 @@ The capture runner ships `provider-switch`, `session-switch`,
 `provider-session-cycle`, `virtualized-streaming`,
 `virtualized-scroll-locator`, `rail-scope-reveal`, `composer-input`,
 `composer-overflow-resize`, `workbench-window-lifecycle`, and
-`desktop-window-state`. List them with `--list-scenarios`; select one with
+`desktop-window-state`, and `provider-status-focus-refresh`. List them with
+`--list-scenarios`; select one with
 `--scenario <id>`. Scenario modules own preparation, completion conditions,
 semantic assertions, milestones, and metadata; runtime startup, trace capture,
 renderer analysis, and report rendering stay scenario-neutral.
@@ -153,6 +154,14 @@ close/reopen is not part of that renderer-marked scenario because closing the
 owning native window destroys the renderer that owns the trace boundary
 markers. Every declared milestone is required in the captured trace; a missing
 marker fails capture instead of silently producing an incomplete phase table.
+
+`provider-status-focus-refresh` dispatches a second workspace focus while the
+first focus is being observed, then watches the page for one second. It asserts
+that neither focus starts a provider-status request. This guards against window
+focus regressing into provider CLI scans without starting an Agent turn. On
+macOS, pass `--all-process-time-profile` to also write `time-profile.trace`,
+covering Electron, `tuttid`, and short-lived provider CLI child processes that
+Chromium CDP tracing cannot see.
 
 Daemon migrations remain forward-only. If the personal dev database was last
 opened by a newer checkout with incompatible Agent target migrations, the

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -16,6 +16,7 @@ Use the focused runtime index or open one area directly:
 
 - [Agent Providers And Setup](./agent-provider-setup.md): Provider discovery, installation, authentication, models, configuration, and runtime reachability.
   Includes extension command/Skill palette hydration failures.
+  Also covers focus-driven provider CLI scans and CPU spikes.
 - [Agent Sessions And Lifecycle](./agent-session-lifecycle.md): Turn state, activation, planning-mode classification, Tutti workflow response contracts, loading, cancel, goal controls, restore, file-change undo, rail projection, realtime completion provenance, event updates, imports, and performance.
   Includes shared-device recovery that looks terminal while the host is still retrying.
 - [Agent Approvals And Child Sessions](./agent-approvals-subagents.md): Approval gates, plan exits, root/parent/child event attribution, child sessions, and Message Center.

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -4,6 +4,49 @@
 
 Provider discovery, installation, authentication, models, configuration, and runtime reachability.
 
+### Focusing a workspace repeatedly starts provider CLIs and raises CPU usage
+
+- Symptom:
+  Focusing or reopening a workspace makes the fan ramp up even when no Agent
+  turn starts. The effect grows when more managed provider CLIs are installed.
+- Quick checks:
+  Inspect GET requests to `/v1/agent-providers/status`. A focus-driven request
+  with `refresh=true` bypasses the daemon status cache. Correlate the same time
+  range with short-lived `codex`, `opencode`, `cursor`, `node`, `git`, and
+  credential-helper processes. Use `pnpm perf:agent-gui -- --scenario
+provider-status-focus-refresh --all-process-time-profile` on macOS when a
+  Chromium trace cannot see daemon child processes.
+- Root cause:
+  Window lifecycle analytics requested a fresh availability snapshot by using
+  the explicit-refresh path. Every pageview opportunity therefore bypassed the
+  daemon cache and launched provider detection work; a focus arriving during a
+  scan queued another forced scan.
+- Fix:
+  Let availability analytics reuse the renderer's loaded status snapshot, and
+  route only stale visibility reconciliation through a non-forced tuttid read.
+  Let tuttid own cache expiry, credential fingerprints, and per-provider
+  single-flight. Initialize providers in parallel for first-paint latency, but
+  serialize later background stale reconciliation and cap the aggregate
+  auth/version/adapter subprocess count. Keep `refresh=true` only for explicit
+  user refreshes and provider-scoped confirmation after state-changing actions.
+  A forced read must recheck auth/readiness, but can reuse successful
+  executable-scoped facts while the binary fingerprint is unchanged; never
+  cache failed version or adapter probes. Prefer validated credential files for
+  OpenCode and Tutti Agent and allow at most one CLI fallback for malformed
+  files. Reuse fields from a provider command instead of launching duplicate
+  probes: Cursor `about --format json` returns both authentication details and
+  `cliVersion`, so its status detection must not also launch `cursor-agent
+--version` unless the `about` output omitted the version.
+- Validation:
+  Dispatch two focus events and assert they start no provider-status request,
+  availability pageviews are unchanged, and an explicit refresh still sends
+  exactly one forced request. The all-process trace should contain no
+  focus-driven provider-detection child process burst.
+- References:
+  [agent-gui-node.md](../../architecture/agent-gui-node.md)
+  [desktopAgentProviderStatusService.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts)
+  [agent-provider-status-performance-scenario.mjs](../../../tools/scripts/agent-provider-status-performance-scenario.mjs)
+
 ### An extension Agent is installed in the terminal but Tutti cannot detect it
 
 - Symptom:

--- a/packages/agent/daemon/providerregistry/opencode.go
+++ b/packages/agent/daemon/providerregistry/opencode.go
@@ -35,7 +35,7 @@ func openCodeDescriptor() ProviderDescriptor {
 		Status: StatusDescriptor{
 			Kind:                   StatusKindOpenCodeCLI,
 			AuthOutputParserKind:   AuthOutputParserKindOpenCode,
-			AuthMarkerParserKind:   AuthMarkerParserKindFileExists,
+			AuthMarkerParserKind:   AuthMarkerParserKindOpenCode,
 			AuthCommandRunnerKind:  AuthCommandRunnerKindGeneric,
 			StaticSpecResolverKind: StaticSpecResolverKindGeneric,
 			BinaryNames:            []string{"opencode"},

--- a/packages/agent/daemon/providerregistry/registry.go
+++ b/packages/agent/daemon/providerregistry/registry.go
@@ -321,7 +321,7 @@ func Validate(descriptor ProviderDescriptor) error {
 		return fmt.Errorf("provider %q auth output parser kind %q is unsupported", providerID, descriptor.Status.AuthOutputParserKind)
 	}
 	switch descriptor.Status.AuthMarkerParserKind {
-	case AuthMarkerParserKindFileExists, AuthMarkerParserKindClaude, AuthMarkerParserKindTuttiToken:
+	case AuthMarkerParserKindFileExists, AuthMarkerParserKindClaude, AuthMarkerParserKindOpenCode, AuthMarkerParserKindTuttiToken:
 	default:
 		return fmt.Errorf("provider %q auth marker parser kind %q is unsupported", providerID, descriptor.Status.AuthMarkerParserKind)
 	}

--- a/packages/agent/daemon/providerregistry/types.go
+++ b/packages/agent/daemon/providerregistry/types.go
@@ -110,6 +110,7 @@ type AuthMarkerParserKind string
 const (
 	AuthMarkerParserKindFileExists AuthMarkerParserKind = "file_exists"
 	AuthMarkerParserKindClaude     AuthMarkerParserKind = "claude"
+	AuthMarkerParserKindOpenCode   AuthMarkerParserKind = "opencode"
 	AuthMarkerParserKindTuttiToken AuthMarkerParserKind = "tutti_token"
 )
 

--- a/services/tuttid/service/agentstatus/auth_marker_strategy_test.go
+++ b/services/tuttid/service/agentstatus/auth_marker_strategy_test.go
@@ -1,0 +1,82 @@
+package agentstatus
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
+)
+
+func TestOpenCodeAuthUsesXDGMarkerWithoutStartingCLI(t *testing.T) {
+	dataHome := t.TempDir()
+	authPath := filepath.Join(dataHome, "opencode", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(authPath), 0o700); err != nil {
+		t.Fatalf("mkdir auth dir: %v", err)
+	}
+	if err := os.WriteFile(authPath, []byte(`{"openai":{"type":"oauth"}}`), 0o600); err != nil {
+		t.Fatalf("write auth marker: %v", err)
+	}
+	service := Service{
+		Environ: func() []string {
+			return []string{"XDG_DATA_HOME=" + dataHome}
+		},
+		HomeDir: func() (string, error) {
+			return t.TempDir(), nil
+		},
+	}
+	auth := service.resolveAuth(context.Background(), ProviderSpec{
+		Provider:             providerregistry.OpenCodeProviderID,
+		AuthMarkerParserKind: providerregistry.AuthMarkerParserKindOpenCode,
+		AuthStatusCommand:    []string{"auth", "list"},
+		AuthMarkerPaths:      []string{"~/.local/share/opencode/auth.json"},
+	}, true, "/definitely/not/an/opencode-binary")
+
+	if auth.Status != AuthAuthenticated {
+		t.Fatalf("Status = %q, want %q", auth.Status, AuthAuthenticated)
+	}
+}
+
+func TestOpenCodeAuthMarkerEmptyObjectRequiresLogin(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(path, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write auth marker: %v", err)
+	}
+	auth, ok := parseOpenCodeAuthMarkerFile(path)
+	if !ok || auth.Status != AuthRequired {
+		t.Fatalf("parseOpenCodeAuthMarkerFile() = %#v, %v", auth, ok)
+	}
+}
+
+func TestTuttiAuthUsesValidatedMarkerWithoutStartingCLI(t *testing.T) {
+	home := t.TempDir()
+	authPath := filepath.Join(home, ".tutti-agent", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(authPath), 0o700); err != nil {
+		t.Fatalf("mkdir auth dir: %v", err)
+	}
+	if err := os.WriteFile(authPath, []byte(`{
+		"tutti_llm":{
+			"app_id":"app",
+			"access_token":"access",
+			"refresh_token":"refresh"
+		}
+	}`), 0o600); err != nil {
+		t.Fatalf("write auth marker: %v", err)
+	}
+	service := Service{
+		HomeDir: func() (string, error) {
+			return home, nil
+		},
+	}
+	auth := service.resolveAuth(context.Background(), ProviderSpec{
+		Provider:             providerregistry.TuttiAgentProviderID,
+		AuthMarkerParserKind: providerregistry.AuthMarkerParserKindTuttiToken,
+		AuthStatusCommand:    []string{"login", "status"},
+		AuthMarkerPaths:      []string{"~/.tutti-agent/auth.json"},
+	}, true, "/definitely/not/a/tutti-agent-binary")
+
+	if auth.Status != AuthAuthenticated || auth.AccountLabel != "app" {
+		t.Fatalf("Auth = %#v, want authenticated app", auth)
+	}
+}

--- a/services/tuttid/service/agentstatus/auth_markers.go
+++ b/services/tuttid/service/agentstatus/auth_markers.go
@@ -1,0 +1,180 @@
+package agentstatus
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
+)
+
+// authCredentialsRefreshedAfter reports whether any of the provider's credential
+// marker files was modified after the given time — i.e. a login rewrote the
+// credentials since the recorded auth failure.
+func (s Service) authCredentialsRefreshedAfter(spec ProviderSpec, since time.Time) bool {
+	paths, _ := s.resolvedAuthMarkerPaths(spec)
+	for _, path := range paths {
+		if mod, ok := s.fileModTime(path); ok && mod.After(since) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s Service) resolveAuthFromMarkers(spec ProviderSpec) AuthInfo {
+	auth, definitive := s.resolveAuthFromMarkersWithValidity(spec)
+	if definitive {
+		return auth
+	}
+	return AuthInfo{Status: AuthUnknown}
+}
+
+func (s Service) resolveAuthFromMarkersWithValidity(spec ProviderSpec) (AuthInfo, bool) {
+	if len(spec.AuthMarkerPaths) == 0 {
+		return AuthInfo{Status: AuthUnknown}, true
+	}
+
+	paths, complete := s.resolvedAuthMarkerPaths(spec)
+	invalidMarker := false
+	for _, path := range paths {
+		if !s.fileExists(path) {
+			continue
+		}
+		if auth, ok := s.authFromMarkerFile(spec, path); ok {
+			return auth, true
+		}
+		invalidMarker = true
+	}
+	if invalidMarker || !complete {
+		return AuthInfo{Status: AuthUnknown}, false
+	}
+	return AuthInfo{Status: AuthRequired}, true
+}
+
+func (s Service) resolvedAuthMarkerPaths(spec ProviderSpec) ([]string, bool) {
+	markers := append([]string(nil), spec.AuthMarkerPaths...)
+	if authMarkerParserKind(spec) == providerregistry.AuthMarkerParserKindOpenCode {
+		if dataHome := strings.TrimSpace(s.lookupEnv("XDG_DATA_HOME")); dataHome != "" {
+			markers = append([]string{filepath.Join(dataHome, "opencode", "auth.json")}, markers...)
+		}
+	}
+	if len(markers) == 0 {
+		return nil, true
+	}
+
+	home, err := s.homeDir()
+	homeAvailable := err == nil && strings.TrimSpace(home) != ""
+	complete := true
+	paths := make([]string, 0, len(markers))
+	seen := make(map[string]struct{}, len(markers))
+	for _, marker := range markers {
+		marker = strings.TrimSpace(marker)
+		if marker == "" {
+			continue
+		}
+		if (marker == "~" || strings.HasPrefix(marker, "~/")) && !homeAvailable {
+			complete = false
+			continue
+		}
+		path := filepath.Clean(expandHomePath(marker, home))
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	return paths, complete
+}
+
+func (s Service) authFromMarkerFile(spec ProviderSpec, path string) (AuthInfo, bool) {
+	if !s.fileExists(path) {
+		return AuthInfo{}, false
+	}
+	switch authMarkerParserKind(spec) {
+	case providerregistry.AuthMarkerParserKindClaude:
+		if auth, ok := parseClaudeAuthMarkerFile(path); ok {
+			return auth, true
+		}
+		return AuthInfo{}, false
+	case providerregistry.AuthMarkerParserKindOpenCode:
+		if auth, ok := parseOpenCodeAuthMarkerFile(path); ok {
+			return auth, true
+		}
+		return AuthInfo{}, false
+	case providerregistry.AuthMarkerParserKindTuttiToken:
+		if auth, ok := parseTuttiAgentAuthMarkerFile(path); ok {
+			return auth, true
+		}
+		return AuthInfo{}, false
+	case providerregistry.AuthMarkerParserKindFileExists:
+		return AuthInfo{Status: AuthAuthenticated}, true
+	default:
+		return AuthInfo{}, false
+	}
+}
+
+func authMarkerParserKind(spec ProviderSpec) providerregistry.AuthMarkerParserKind {
+	if spec.AuthMarkerParserKind != "" {
+		return spec.AuthMarkerParserKind
+	}
+	if status, ok := migratedProviderStatus(spec.Provider); ok {
+		return status.AuthMarkerParserKind
+	}
+	return ""
+}
+
+func authMarkerIsAuthoritative(spec ProviderSpec) bool {
+	switch authMarkerParserKind(spec) {
+	case providerregistry.AuthMarkerParserKindOpenCode, providerregistry.AuthMarkerParserKindTuttiToken:
+		return true
+	default:
+		return false
+	}
+}
+
+func parseOpenCodeAuthMarkerFile(path string) (AuthInfo, bool) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return AuthInfo{}, false
+	}
+	var credentials map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &credentials); err != nil {
+		return AuthInfo{}, false
+	}
+	if len(credentials) == 0 {
+		return AuthInfo{Status: AuthRequired}, true
+	}
+	return AuthInfo{Status: AuthAuthenticated}, true
+}
+
+// parseTuttiAgentAuthMarkerFile validates that the Tutti Agent auth.json holds
+// a usable `tutti_llm` token bundle instead of treating file existence as
+// authenticated.
+func parseTuttiAgentAuthMarkerFile(path string) (AuthInfo, bool) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return AuthInfo{}, false
+	}
+	var payload struct {
+		TuttiLLM *struct {
+			AppID        string `json:"app_id"`
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+		} `json:"tutti_llm"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return AuthInfo{}, false
+	}
+	if payload.TuttiLLM == nil ||
+		strings.TrimSpace(payload.TuttiLLM.AccessToken) == "" ||
+		strings.TrimSpace(payload.TuttiLLM.RefreshToken) == "" {
+		return AuthInfo{Status: AuthRequired}, true
+	}
+	return AuthInfo{
+		AccountLabel: payload.TuttiLLM.AppID,
+		AuthMethod:   "tutti_llm",
+		Status:       AuthAuthenticated,
+	}, true
+}

--- a/services/tuttid/service/agentstatus/cursor_auth.go
+++ b/services/tuttid/service/agentstatus/cursor_auth.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 )
 
-func runCursorAuthStatusCommand(ctx context.Context, binaryPath string, env []string) (AuthInfo, bool) {
+func runCursorAuthStatusCommand(ctx context.Context, binaryPath string, env []string) (AuthInfo, string, bool) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -20,7 +20,7 @@ func runCursorAuthStatusCommand(ctx context.Context, binaryPath string, env []st
 	defer cancel()
 	output, ok := runCursorCLICommand(commandCtx, binaryPath, []string{"about", "--format", "json"}, proxyEnv)
 	if !ok {
-		return AuthInfo{}, false
+		return AuthInfo{}, "", false
 	}
 	return parseCursorAboutOutput(output)
 }
@@ -75,28 +75,34 @@ func parseCursorAuthStatusOutput(output []byte) (AuthInfo, bool) {
 	return AuthInfo{}, false
 }
 
-func parseCursorAboutOutput(output []byte) (AuthInfo, bool) {
+func parseCursorAboutOutput(output []byte) (AuthInfo, string, bool) {
 	trimmed := bytes.TrimSpace(output)
 	if len(trimmed) == 0 {
-		return AuthInfo{}, false
+		return AuthInfo{}, "", false
 	}
 	if trimmed[0] == '{' {
-		return parseCursorAboutJSON(trimmed)
+		return parseCursorAboutJSONWithVersion(trimmed)
 	}
-	return parseCursorAboutText(trimmed)
+	return parseCursorAboutTextWithVersion(trimmed)
 }
 
 func parseCursorAboutJSON(output []byte) (AuthInfo, bool) {
+	auth, _, ok := parseCursorAboutJSONWithVersion(output)
+	return auth, ok
+}
+
+func parseCursorAboutJSONWithVersion(output []byte) (AuthInfo, string, bool) {
 	var payload struct {
 		CLIVersion       string          `json:"cliVersion"`
 		SubscriptionTier *string         `json:"subscriptionTier"`
 		UserEmail        json.RawMessage `json:"userEmail"`
 	}
 	if err := json.Unmarshal(output, &payload); err != nil {
-		return AuthInfo{}, false
+		return AuthInfo{}, "", false
 	}
+	cliVersion := strings.TrimSpace(payload.CLIVersion)
 	if len(payload.UserEmail) > 0 && string(payload.UserEmail) == "null" {
-		return AuthInfo{Status: AuthRequired}, true
+		return AuthInfo{Status: AuthRequired}, cliVersion, true
 	}
 	userEmail := ""
 	if len(payload.UserEmail) > 0 && string(payload.UserEmail) != "null" {
@@ -110,37 +116,37 @@ func parseCursorAboutJSON(output []byte) (AuthInfo, bool) {
 		subscriptionTier = strings.TrimSpace(*payload.SubscriptionTier)
 	}
 	if isCursorUnauthenticatedEmail(userEmail) {
-		return AuthInfo{Status: AuthRequired}, true
+		return AuthInfo{Status: AuthRequired}, cliVersion, true
 	}
 	if userEmail == "" && subscriptionTier == "" {
-		return AuthInfo{}, false
+		return AuthInfo{}, cliVersion, false
 	}
 	return AuthInfo{
 		Status:       AuthAuthenticated,
 		AccountLabel: formatCursorAccountLabel(subscriptionTier, userEmail),
 		AuthMethod:   "cursor_login",
-	}, true
+	}, cliVersion, true
 }
 
-func parseCursorAboutText(output []byte) (AuthInfo, bool) {
+func parseCursorAboutTextWithVersion(output []byte) (AuthInfo, string, bool) {
 	plain := stripANSIEscapeSequences(string(output))
 	version := extractCursorAboutField(plain, "CLI Version")
 	userEmail := extractCursorAboutField(plain, "User Email")
 	subscriptionTier := extractCursorAboutField(plain, "Subscription Tier")
 	if userEmail == "" && subscriptionTier == "" && version == "" {
-		return AuthInfo{}, false
+		return AuthInfo{}, "", false
 	}
 	if isCursorUnauthenticatedEmail(userEmail) {
-		return AuthInfo{Status: AuthRequired}, true
+		return AuthInfo{Status: AuthRequired}, version, true
 	}
 	if userEmail == "" && subscriptionTier == "" {
-		return AuthInfo{Status: AuthAuthenticated}, true
+		return AuthInfo{Status: AuthAuthenticated}, version, true
 	}
 	return AuthInfo{
 		Status:       AuthAuthenticated,
 		AccountLabel: formatCursorAccountLabel(subscriptionTier, userEmail),
 		AuthMethod:   "cursor_login",
-	}, true
+	}, version, true
 }
 
 func formatCursorAccountLabel(subscriptionTier, userEmail string) string {

--- a/services/tuttid/service/agentstatus/cursor_auth_test.go
+++ b/services/tuttid/service/agentstatus/cursor_auth_test.go
@@ -2,10 +2,42 @@ package agentstatus
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 )
+
+func TestCursorStatusReusesAboutCLIVersion(t *testing.T) {
+	binaryPath := "/test/cursor-agent"
+	service := testService(func(name string) (string, error) {
+		if name == "cursor-agent" || name == "agent" {
+			return binaryPath, nil
+		}
+		return "", errors.New("not found")
+	}, map[string]bool{})
+	aboutCalls := 0
+	service.runCursorAuthStatusCommand = func(context.Context, string, []string) (AuthInfo, string, bool) {
+		aboutCalls++
+		return AuthInfo{
+			Status:       AuthAuthenticated,
+			AccountLabel: "Cursor Pro · user@example.com",
+			AuthMethod:   "cursor_login",
+		}, "2026.07.22-test", true
+	}
+
+	snapshot, err := service.List(t.Context(), ListInput{Providers: []string{"cursor"}, ForceRefresh: true})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	status := onlyStatus(t, snapshot)
+	if status.CLI.Version != "2026.07.22-test" {
+		t.Fatalf("CLI.Version = %q, want about cliVersion", status.CLI.Version)
+	}
+	if aboutCalls != 1 {
+		t.Fatalf("Cursor about calls = %d, want 1", aboutCalls)
+	}
+}
 
 func TestCursorAuthCommandUsesSingleOuterAttempt(t *testing.T) {
 	spec := ProviderSpec{

--- a/services/tuttid/service/agentstatus/detection_cache.go
+++ b/services/tuttid/service/agentstatus/detection_cache.go
@@ -1,0 +1,179 @@
+package agentstatus
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+)
+
+type executableFingerprint struct {
+	info         os.FileInfo
+	resolvedPath string
+}
+
+func readExecutableFingerprint(path string) (executableFingerprint, bool) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return executableFingerprint{}, false
+	}
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		resolvedPath = filepath.Clean(path)
+	}
+	info, err := os.Stat(resolvedPath)
+	if err != nil {
+		return executableFingerprint{}, false
+	}
+	return executableFingerprint{
+		info:         info,
+		resolvedPath: filepath.Clean(resolvedPath),
+	}, true
+}
+
+func sameExecutableFingerprint(left executableFingerprint, right executableFingerprint) bool {
+	return left.resolvedPath == right.resolvedPath &&
+		left.info.Size() == right.info.Size() &&
+		left.info.ModTime().Equal(right.info.ModTime()) &&
+		os.SameFile(left.info, right.info)
+}
+
+type cliVersionCacheEntry struct {
+	fingerprint executableFingerprint
+	output      string
+}
+
+// CLIVersionCache reuses successful `--version` output until the resolved
+// executable changes. A forced auth/readiness refresh does not need to restart
+// an unchanged binary just to rediscover the same version.
+type CLIVersionCache struct {
+	mu      sync.RWMutex
+	entries map[string]cliVersionCacheEntry
+	group   singleflight.Group
+}
+
+func NewCLIVersionCache() *CLIVersionCache {
+	return &CLIVersionCache{entries: make(map[string]cliVersionCacheEntry)}
+}
+
+func (c *CLIVersionCache) load(binaryPath string, loader func() string) string {
+	if c == nil {
+		return loader()
+	}
+	key := filepath.Clean(strings.TrimSpace(binaryPath))
+	if output, ok := c.get(key); ok {
+		return output
+	}
+	value, _, _ := c.group.Do(key, func() (any, error) {
+		if output, ok := c.get(key); ok {
+			return output, nil
+		}
+		output := loader()
+		if output != "" {
+			c.set(key, output)
+		}
+		return output, nil
+	})
+	return value.(string)
+}
+
+func (c *CLIVersionCache) get(binaryPath string) (string, bool) {
+	fingerprint, ok := readExecutableFingerprint(binaryPath)
+	if !ok {
+		return "", false
+	}
+	c.mu.RLock()
+	entry, found := c.entries[binaryPath]
+	c.mu.RUnlock()
+	if !found || !sameExecutableFingerprint(entry.fingerprint, fingerprint) {
+		return "", false
+	}
+	return entry.output, true
+}
+
+func (c *CLIVersionCache) set(binaryPath string, output string) {
+	fingerprint, ok := readExecutableFingerprint(binaryPath)
+	if !ok {
+		return
+	}
+	c.mu.Lock()
+	c.entries[binaryPath] = cliVersionCacheEntry{
+		fingerprint: fingerprint,
+		output:      output,
+	}
+	c.mu.Unlock()
+}
+
+type adapterProbeCacheEntry struct {
+	fingerprint executableFingerprint
+}
+
+// AdapterProbeCache stores only successful launch probes. Failures are always
+// retried, and explicit refresh/probe paths bypass this cache.
+type AdapterProbeCache struct {
+	mu      sync.RWMutex
+	entries map[string]adapterProbeCacheEntry
+}
+
+func NewAdapterProbeCache() *AdapterProbeCache {
+	return &AdapterProbeCache{entries: make(map[string]adapterProbeCacheEntry)}
+}
+
+func (c *AdapterProbeCache) ready(key string, binaryPath string) bool {
+	if c == nil {
+		return false
+	}
+	fingerprint, ok := readExecutableFingerprint(binaryPath)
+	if !ok {
+		return false
+	}
+	c.mu.RLock()
+	entry, found := c.entries[key]
+	c.mu.RUnlock()
+	return found && sameExecutableFingerprint(entry.fingerprint, fingerprint)
+}
+
+func (c *AdapterProbeCache) markReady(key string, binaryPath string) {
+	if c == nil {
+		return
+	}
+	fingerprint, ok := readExecutableFingerprint(binaryPath)
+	if !ok {
+		return
+	}
+	c.mu.Lock()
+	c.entries[key] = adapterProbeCacheEntry{fingerprint: fingerprint}
+	c.mu.Unlock()
+}
+
+// DetectionCommandLimiter bounds actual auth/version/adapter subprocesses
+// across concurrent List requests. Provider-level concurrency alone does not
+// cover the multiple commands started inside each provider.
+type DetectionCommandLimiter struct {
+	slots chan struct{}
+}
+
+func NewDetectionCommandLimiter(limit int) *DetectionCommandLimiter {
+	if limit < 1 {
+		limit = 1
+	}
+	return &DetectionCommandLimiter{slots: make(chan struct{}, limit)}
+}
+
+func (l *DetectionCommandLimiter) acquire(ctx context.Context) (func(), bool) {
+	if l == nil {
+		return func() {}, true
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case l.slots <- struct{}{}:
+		return func() { <-l.slots }, true
+	case <-ctx.Done():
+		return nil, false
+	}
+}

--- a/services/tuttid/service/agentstatus/detection_cache_test.go
+++ b/services/tuttid/service/agentstatus/detection_cache_test.go
@@ -1,0 +1,119 @@
+package agentstatus
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCLIVersionCacheReusesVersionUntilExecutableChanges(t *testing.T) {
+	binaryPath := filepath.Join(t.TempDir(), "agent-cli")
+	if err := os.WriteFile(binaryPath, []byte("first"), 0o700); err != nil {
+		t.Fatalf("write first binary: %v", err)
+	}
+	cache := NewCLIVersionCache()
+	loads := 0
+	load := func() string {
+		loads++
+		return "1.0.0"
+	}
+
+	if got := cache.load(binaryPath, load); got != "1.0.0" {
+		t.Fatalf("first version = %q, want 1.0.0", got)
+	}
+	if got := cache.load(binaryPath, load); got != "1.0.0" {
+		t.Fatalf("cached version = %q, want 1.0.0", got)
+	}
+	if loads != 1 {
+		t.Fatalf("loads = %d, want 1 before binary change", loads)
+	}
+
+	replacementPath := filepath.Join(filepath.Dir(binaryPath), "replacement")
+	if err := os.WriteFile(replacementPath, []byte("second binary"), 0o700); err != nil {
+		t.Fatalf("write replacement binary: %v", err)
+	}
+	if err := os.Rename(replacementPath, binaryPath); err != nil {
+		t.Fatalf("replace binary: %v", err)
+	}
+	if got := cache.load(binaryPath, load); got != "1.0.0" {
+		t.Fatalf("version after replacement = %q, want 1.0.0", got)
+	}
+	if loads != 2 {
+		t.Fatalf("loads = %d, want 2 after binary replacement", loads)
+	}
+}
+
+func TestCLIVersionCacheDoesNotStoreFailedReads(t *testing.T) {
+	binaryPath := filepath.Join(t.TempDir(), "agent-cli")
+	if err := os.WriteFile(binaryPath, []byte("binary"), 0o700); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+	cache := NewCLIVersionCache()
+	loads := 0
+	load := func() string {
+		loads++
+		if loads == 1 {
+			return ""
+		}
+		return "1.0.0"
+	}
+
+	if got := cache.load(binaryPath, load); got != "" {
+		t.Fatalf("failed read = %q, want empty", got)
+	}
+	if got := cache.load(binaryPath, load); got != "1.0.0" {
+		t.Fatalf("retry read = %q, want 1.0.0", got)
+	}
+	if loads != 2 {
+		t.Fatalf("loads = %d, want failed read retried", loads)
+	}
+}
+
+func TestAdapterProbeCacheStoresOnlyMatchingExecutable(t *testing.T) {
+	binaryPath := filepath.Join(t.TempDir(), "adapter")
+	if err := os.WriteFile(binaryPath, []byte("first"), 0o700); err != nil {
+		t.Fatalf("write first adapter: %v", err)
+	}
+	cache := NewAdapterProbeCache()
+	cache.markReady("codex", binaryPath)
+	if !cache.ready("codex", binaryPath) {
+		t.Fatal("ready = false after successful probe")
+	}
+
+	replacementPath := filepath.Join(filepath.Dir(binaryPath), "replacement")
+	if err := os.WriteFile(replacementPath, []byte("second adapter"), 0o700); err != nil {
+		t.Fatalf("write replacement adapter: %v", err)
+	}
+	if err := os.Rename(replacementPath, binaryPath); err != nil {
+		t.Fatalf("replace adapter: %v", err)
+	}
+	if cache.ready("codex", binaryPath) {
+		t.Fatal("ready = true after adapter replacement")
+	}
+}
+
+func TestDetectionCommandLimiterBoundsConcurrentCommands(t *testing.T) {
+	limiter := NewDetectionCommandLimiter(1)
+	release, acquired := limiter.acquire(context.Background())
+	if !acquired {
+		t.Fatal("first command did not acquire limiter")
+	}
+
+	blockedContext, cancel := context.WithTimeout(
+		context.Background(),
+		20*time.Millisecond,
+	)
+	defer cancel()
+	if _, acquired := limiter.acquire(blockedContext); acquired {
+		t.Fatal("second command acquired a full limiter")
+	}
+
+	release()
+	nextRelease, acquired := limiter.acquire(context.Background())
+	if !acquired {
+		t.Fatal("next command did not acquire released limiter")
+	}
+	nextRelease()
+}

--- a/services/tuttid/service/agentstatus/installer_codex_cli.go
+++ b/services/tuttid/service/agentstatus/installer_codex_cli.go
@@ -203,7 +203,7 @@ func (s Service) runManagedNPMPackageAction(
 	return result, err
 }
 
-func (Service) repairManagedNPMBinEEXIST(
+func (s Service) repairManagedNPMBinEEXIST(
 	ctx context.Context,
 	result InstallCommandResult,
 	installPrefix string,
@@ -215,7 +215,7 @@ func (Service) repairManagedNPMBinEEXIST(
 	if !ok || !managedNPMBinConflictMatchesInstallTarget(conflictPath, installPrefix, binaryName) {
 		return false
 	}
-	installedVersion, _ := managednpm.ExtractVersion(cliVersionOutput(ctx, conflictPath, env))
+	installedVersion, _ := managednpm.ExtractVersion(s.cliVersionOutput(ctx, conflictPath, env))
 	if required := strings.TrimSpace(requiredVersion); required != "" && installedVersion == required {
 		return false
 	}

--- a/services/tuttid/service/agentstatus/provider_descriptor_test.go
+++ b/services/tuttid/service/agentstatus/provider_descriptor_test.go
@@ -110,6 +110,9 @@ func TestOpenCodeStatusSpecComesFromProviderDescriptor(t *testing.T) {
 		!reflect.DeepEqual(spec.AuthStatusCommand, []string{"auth", "list"}) {
 		t.Fatalf("status commands = %#v %#v", spec.AdapterCommand, spec.AuthStatusCommand)
 	}
+	if spec.AuthMarkerParserKind != providerregistry.AuthMarkerParserKindOpenCode {
+		t.Fatalf("AuthMarkerParserKind = %q, want opencode", spec.AuthMarkerParserKind)
+	}
 	if spec.Install.Kind != InstallerKindOfficialScript ||
 		spec.Install.ScriptURL != "https://opencode.ai/install" ||
 		spec.Install.ScriptShell != "bash" {
@@ -158,6 +161,7 @@ func TestAuthStrategiesProjectFromProviderDescriptor(t *testing.T) {
 		providerregistry.CodexProviderID,
 		providerregistry.ClaudeCodeProviderID,
 		providerregistry.CursorProviderID,
+		providerregistry.OpenCodeProviderID,
 		providerregistry.TuttiAgentProviderID,
 	} {
 		descriptor, ok := providerregistry.Find(provider)

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -250,6 +250,7 @@ type Service struct {
 	InstallCommand              func(context.Context, InstallCommandInput) (InstallCommandResult, error)
 	InstallTimeout              time.Duration
 	RunAuthStatusCommand        func(context.Context, ProviderSpec, string) (AuthInfo, bool)
+	runCursorAuthStatusCommand  func(context.Context, string, []string) (AuthInfo, string, bool)
 	AuthStatusCommandRetryDelay time.Duration
 	IsExecutableFile            func(string) bool
 	Now                         func() time.Time
@@ -272,6 +273,12 @@ type Service struct {
 	// readiness probes run once per provider instead of once per caller/window.
 	StatusCache    *ProviderStatusCache
 	StatusCacheTTL time.Duration
+	// CLIVersionCache and AdapterProbeCache keep stable executable facts across
+	// forced auth refreshes. DetectionCommands bounds actual subprocess fan-out
+	// across concurrent requests.
+	CLIVersionCache   *CLIVersionCache
+	AdapterProbeCache *AdapterProbeCache
+	DetectionCommands *DetectionCommandLimiter
 	// UpdateCache is separate from readiness caching because remote release
 	// discovery is opt-in and must never make ordinary local status reads touch
 	// the network.
@@ -423,7 +430,7 @@ func (s Service) List(ctx context.Context, input ListInput) (snapshot Snapshot, 
 func (s Service) cachedStatusForSpec(ctx context.Context, spec ProviderSpec, forceRefresh bool) ProviderStatus {
 	cache := s.StatusCache
 	if cache == nil {
-		return s.detectStatusForSpec(ctx, spec)
+		return s.detectStatusForSpec(ctx, spec, forceRefresh)
 	}
 	if !forceRefresh {
 		if cached, cachedAt, credentialFingerprint, ok := cache.get(spec.Provider, s.now(), s.providerStatusCacheTTL()); ok &&
@@ -439,7 +446,7 @@ func (s Service) cachedStatusForSpec(ctx context.Context, spec ProviderSpec, for
 				return cached, nil
 			}
 		}
-		status := s.detectStatusForSpec(ctx, spec)
+		status := s.detectStatusForSpec(ctx, spec, forceRefresh)
 		completedAt := s.now()
 		status.Availability.CheckedAt = &completedAt
 		cache.set(spec.Provider, completedAt, s.providerCredentialFingerprint(spec), status)
@@ -448,8 +455,10 @@ func (s Service) cachedStatusForSpec(ctx context.Context, spec ProviderSpec, for
 	return cloneProviderStatus(value.(ProviderStatus))
 }
 
-func (s Service) detectStatusForSpec(ctx context.Context, spec ProviderSpec) ProviderStatus {
-	status := s.statusForSpec(ctx, spec, s.now())
+func (s Service) detectStatusForSpec(ctx context.Context, spec ProviderSpec, forceRefresh bool) ProviderStatus {
+	status := s.statusForSpec(ctx, spec, s.now(), statusDetectionOptions{
+		forceRefresh: forceRefresh,
+	})
 	completedAt := s.now()
 	status.Availability.CheckedAt = &completedAt
 	return status
@@ -491,7 +500,10 @@ func (s Service) Probe(ctx context.Context, input ProbeInput) (ProbeResult, erro
 		return result, nil
 	}
 	runtimeResolution := s.resolveProviderRuntime(ctx, spec)
-	status := s.statusForSpec(ctx, spec, now)
+	status := s.statusForSpec(ctx, spec, now, statusDetectionOptions{
+		forceRefresh:     true,
+		skipAdapterProbe: true,
+	})
 	result := ProbeResult{
 		Provider:   spec.Provider,
 		CheckedAt:  now,
@@ -562,7 +574,21 @@ func (s Service) probeAdapterRuntimeCommand(
 	} else {
 		result.BinaryPath = command[0]
 	}
+	release, acquired := s.DetectionCommands.acquire(ctx)
+	if !acquired {
+		result.Status = ProbeFailed
+		result.ReasonCode = "probe_canceled"
+		result.Message = context.Cause(ctx).Error()
+		return result
+	}
+	defer release()
 	result = s.probeCommandWithReadyAfter(ctx, result, command, env, s.probeReadyAfterForSpec(spec))
+	if result.Status == ProbeReady {
+		s.AdapterProbeCache.markReady(
+			adapterProbeCacheKey(spec, runtimeResolution),
+			result.BinaryPath,
+		)
+	}
 	if isCodexStatusSpec(spec) && result.Status == ProbeFailed {
 		if code, ok := classifyCodexRuntimeError(result.Message); ok {
 			result.LastError = &ProviderLastError{Code: string(code), Message: result.Message}
@@ -570,6 +596,14 @@ func (s Service) probeAdapterRuntimeCommand(
 		}
 	}
 	return result
+}
+
+func adapterProbeCacheKey(spec ProviderSpec, runtimeResolution providerRuntimeResolution) string {
+	command := runtimeResolution.AdapterCommand
+	if len(command) == 0 {
+		command = spec.AdapterCommand
+	}
+	return spec.Provider + "\x00" + strings.Join(command, "\x00")
 }
 
 func (s Service) RunAction(ctx context.Context, input RunActionInput) (RunActionResult, error) {
@@ -640,7 +674,9 @@ func (s Service) runInstallAction(ctx context.Context, spec ProviderSpec, result
 		}
 		result.Probe = &probe
 		if probe.Status == ProbeFailed {
-			repairStatus := s.statusForSpec(ctx, spec, s.now())
+			repairStatus := s.statusForSpec(ctx, spec, s.now(), statusDetectionOptions{
+				forceRefresh: true,
+			})
 			if repairStatus.Availability.ReasonCode == "acp_adapter_launch_failed" {
 				runtimeResolution.ReasonCode = "acp_adapter_launch_failed"
 				summary, updatedRuntime, err = s.installMissingProviderRuntime(installCtx, spec, runtimeResolution)

--- a/services/tuttid/service/agentstatus/service_helpers.go
+++ b/services/tuttid/service/agentstatus/service_helpers.go
@@ -197,11 +197,21 @@ func resolveInstallerShell() string {
 }
 
 func (s Service) resolveAuth(ctx context.Context, spec ProviderSpec, installed bool, binaryPath string) AuthInfo {
+	auth, _ := s.resolveAuthAndCLIVersion(ctx, spec, installed, binaryPath)
+	return auth
+}
+
+func (s Service) resolveAuthAndCLIVersion(
+	ctx context.Context,
+	spec ProviderSpec,
+	installed bool,
+	binaryPath string,
+) (AuthInfo, string) {
 	if !installed {
-		return AuthInfo{Status: AuthUnknown}
+		return AuthInfo{Status: AuthUnknown}, ""
 	}
 	if isClaudeStatusSpec(spec) && strings.TrimSpace(os.Getenv("TUTTI_MOCK_AGENT_UNBOUND")) == "1" {
-		return AuthInfo{Status: AuthRequired}
+		return AuthInfo{Status: AuthRequired}, ""
 	}
 	// A runtime authentication failure (e.g. a 401 sending a message) invalidates
 	// the stale "logged in" marker/command result until the user re-authenticates
@@ -211,114 +221,59 @@ func (s Service) resolveAuth(ctx context.Context, spec ProviderSpec, installed b
 	// next message succeeds, leaving the dock/wizard stuck on "needs login".
 	if failedAt, ok := s.RunOutcomes.AuthInvalidatedSince(spec.Provider); ok {
 		if !s.authCredentialsRefreshedAfter(spec, failedAt) {
-			return AuthInfo{Status: AuthRequired}
+			return AuthInfo{Status: AuthRequired}, ""
 		}
 		s.RunOutcomes.ClearAuthInvalidated(spec.Provider)
 	}
-	if len(spec.AuthStatusCommand) > 0 && strings.TrimSpace(binaryPath) != "" {
+	// RunAuthStatusCommand is an explicit test seam. Keep it authoritative so
+	// status-cache tests can observe detection without depending on a real home
+	// directory or provider credential file.
+	if s.RunAuthStatusCommand != nil && len(spec.AuthStatusCommand) > 0 &&
+		strings.TrimSpace(binaryPath) != "" {
 		if auth, ok := s.resolveAuthFromCommand(ctx, spec, binaryPath); ok {
-			return auth
+			return auth, ""
 		}
-		return s.resolveAuthFromMarkers(spec)
+		return s.resolveAuthFromMarkers(spec), ""
 	}
-	return s.resolveAuthFromMarkers(spec)
+	if authMarkerIsAuthoritative(spec) {
+		if auth, definitive := s.resolveAuthFromMarkersWithValidity(spec); definitive {
+			return auth, ""
+		}
+	}
+	if len(spec.AuthStatusCommand) > 0 && strings.TrimSpace(binaryPath) != "" {
+		if isCursorAuthCommandSpec(spec) && s.RunAuthStatusCommand == nil {
+			release, acquired := s.DetectionCommands.acquire(ctx)
+			if !acquired {
+				return s.resolveAuthFromMarkers(spec), ""
+			}
+			defer release()
+			auth, cliVersion, ok := s.cursorAuthStatus(
+				ctx,
+				binaryPath,
+				s.commandResolver().Env(spec.AdapterEnv),
+			)
+			if ok {
+				return auth, cliVersion
+			}
+			return s.resolveAuthFromMarkers(spec), cliVersion
+		}
+		if auth, ok := s.resolveAuthFromCommand(ctx, spec, binaryPath); ok {
+			return auth, ""
+		}
+		return s.resolveAuthFromMarkers(spec), ""
+	}
+	return s.resolveAuthFromMarkers(spec), ""
 }
 
-// authCredentialsRefreshedAfter reports whether any of the provider's credential
-// marker files was modified after the given time — i.e. a login rewrote the
-// credentials since the recorded auth failure.
-func (s Service) authCredentialsRefreshedAfter(spec ProviderSpec, since time.Time) bool {
-	if len(spec.AuthMarkerPaths) == 0 {
-		return false
+func (s Service) cursorAuthStatus(
+	ctx context.Context,
+	binaryPath string,
+	env []string,
+) (AuthInfo, string, bool) {
+	if s.runCursorAuthStatusCommand != nil {
+		return s.runCursorAuthStatusCommand(ctx, binaryPath, env)
 	}
-	home, err := s.homeDir()
-	if err != nil || strings.TrimSpace(home) == "" {
-		return false
-	}
-	for _, marker := range spec.AuthMarkerPaths {
-		path := expandHomePath(marker, home)
-		if mod, ok := s.fileModTime(path); ok && mod.After(since) {
-			return true
-		}
-	}
-	return false
-}
-
-func (s Service) resolveAuthFromMarkers(spec ProviderSpec) AuthInfo {
-	if len(spec.AuthMarkerPaths) == 0 {
-		return AuthInfo{Status: AuthUnknown}
-	}
-
-	home, err := s.homeDir()
-	if err != nil || strings.TrimSpace(home) == "" {
-		return AuthInfo{Status: AuthUnknown}
-	}
-
-	for _, marker := range spec.AuthMarkerPaths {
-		path := expandHomePath(marker, home)
-		if auth, ok := s.authFromMarkerFile(spec, path); ok {
-			return auth
-		}
-	}
-	return AuthInfo{Status: AuthRequired}
-}
-
-func (s Service) authFromMarkerFile(spec ProviderSpec, path string) (AuthInfo, bool) {
-	if !s.fileExists(path) {
-		return AuthInfo{}, false
-	}
-	markerParserKind := spec.AuthMarkerParserKind
-	if markerParserKind == "" {
-		if status, ok := migratedProviderStatus(spec.Provider); ok {
-			markerParserKind = status.AuthMarkerParserKind
-		}
-	}
-	switch markerParserKind {
-	case providerregistry.AuthMarkerParserKindClaude:
-		if auth, ok := parseClaudeAuthMarkerFile(path); ok {
-			return auth, true
-		}
-		return AuthInfo{}, false
-	case providerregistry.AuthMarkerParserKindTuttiToken:
-		if auth, ok := parseTuttiAgentAuthMarkerFile(path); ok {
-			return auth, true
-		}
-		return AuthInfo{}, false
-	case providerregistry.AuthMarkerParserKindFileExists:
-		return AuthInfo{Status: AuthAuthenticated}, true
-	default:
-		return AuthInfo{}, false
-	}
-}
-
-// parseTuttiAgentAuthMarkerFile validates that the Tutti Agent auth.json holds
-// a usable `tutti_llm` token bundle instead of treating file existence as
-// authenticated.
-func parseTuttiAgentAuthMarkerFile(path string) (AuthInfo, bool) {
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		return AuthInfo{}, false
-	}
-	var payload struct {
-		TuttiLLM *struct {
-			AppID        string `json:"app_id"`
-			AccessToken  string `json:"access_token"`
-			RefreshToken string `json:"refresh_token"`
-		} `json:"tutti_llm"`
-	}
-	if err := json.Unmarshal(raw, &payload); err != nil {
-		return AuthInfo{}, false
-	}
-	if payload.TuttiLLM == nil ||
-		strings.TrimSpace(payload.TuttiLLM.AccessToken) == "" ||
-		strings.TrimSpace(payload.TuttiLLM.RefreshToken) == "" {
-		return AuthInfo{Status: AuthRequired}, true
-	}
-	return AuthInfo{
-		AccountLabel: payload.TuttiLLM.AppID,
-		AuthMethod:   "tutti_llm",
-		Status:       AuthAuthenticated,
-	}, true
+	return runCursorAuthStatusCommand(ctx, binaryPath, env)
 }
 
 func (s Service) resolveAuthFromCommand(ctx context.Context, spec ProviderSpec, binaryPath string) (AuthInfo, bool) {
@@ -326,7 +281,8 @@ func (s Service) resolveAuthFromCommand(ctx context.Context, spec ProviderSpec, 
 		ctx = context.Background()
 	}
 	attempts := authStatusCommandAttempts
-	if isCursorAuthCommandSpec(spec) {
+	if isCursorAuthCommandSpec(spec) ||
+		authMarkerIsAuthoritative(spec) {
 		attempts = 1
 	}
 	for attempt := 0; attempt < attempts; attempt++ {
@@ -354,6 +310,11 @@ func (s Service) runAuthStatusCommand(ctx context.Context, spec ProviderSpec, bi
 	if s.RunAuthStatusCommand != nil {
 		return s.RunAuthStatusCommand(ctx, spec, binaryPath)
 	}
+	release, acquired := s.DetectionCommands.acquire(ctx)
+	if !acquired {
+		return AuthInfo{}, false
+	}
+	defer release()
 	return runAuthStatusCommand(ctx, spec, binaryPath, s.commandResolver().Env(spec.AdapterEnv))
 }
 
@@ -373,15 +334,15 @@ func parseCLIVersion(output string) string {
 // "" when the binary is absent, errors, or prints nothing version-like. Used for
 // every supported provider (not just codex) so the config panel can show the
 // installed CLI version.
-func (Service) cliVersion(ctx context.Context, binaryPath string, env []string) string {
-	return parseCLIVersion(cliVersionOutput(ctx, binaryPath, env))
+func (s Service) cliVersion(ctx context.Context, binaryPath string, env []string) string {
+	return parseCLIVersion(s.cliVersionOutput(ctx, binaryPath, env))
 }
 
 // providerCLIVersion applies the public managed-npm version contract to
 // managed package providers. Other providers retain their historical
 // semver-ish output compatibility.
-func (Service) providerCLIVersion(ctx context.Context, spec ProviderSpec, binaryPath string, env []string) string {
-	output := cliVersionOutput(ctx, binaryPath, env)
+func (s Service) providerCLIVersion(ctx context.Context, spec ProviderSpec, binaryPath string, env []string) string {
+	output := s.cliVersionOutput(ctx, binaryPath, env)
 	if providerUsesManagedNPMVersionContract(spec) {
 		version, _ := managednpm.ExtractVersion(output)
 		return version
@@ -389,7 +350,7 @@ func (Service) providerCLIVersion(ctx context.Context, spec ProviderSpec, binary
 	return parseCLIVersion(output)
 }
 
-func cliVersionOutput(ctx context.Context, binaryPath string, env []string) string {
+func (s Service) cliVersionOutput(ctx context.Context, binaryPath string, env []string) string {
 	binaryPath = strings.TrimSpace(binaryPath)
 	if binaryPath == "" {
 		return ""
@@ -397,17 +358,24 @@ func cliVersionOutput(ctx context.Context, binaryPath string, env []string) stri
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	commandCtx, cancel := context.WithTimeout(ctx, authStatusCommandTimeout)
-	defer cancel()
-	command := exec.CommandContext(commandCtx, binaryPath, "--version")
-	if env != nil {
-		command.Env = env
-	}
-	output, err := command.CombinedOutput()
-	if err != nil {
-		return ""
-	}
-	return string(output)
+	return s.CLIVersionCache.load(binaryPath, func() string {
+		release, acquired := s.DetectionCommands.acquire(ctx)
+		if !acquired {
+			return ""
+		}
+		defer release()
+		commandCtx, cancel := context.WithTimeout(ctx, authStatusCommandTimeout)
+		defer cancel()
+		command := exec.CommandContext(commandCtx, binaryPath, "--version")
+		if env != nil {
+			command.Env = env
+		}
+		output, err := command.CombinedOutput()
+		if err != nil {
+			return ""
+		}
+		return string(output)
+	})
 }
 
 func cloneProviderChecks(input []ProviderCheck) []ProviderCheck {
@@ -449,7 +417,8 @@ func runAuthStatusCommand(ctx context.Context, spec ProviderSpec, binaryPath str
 		}
 	}
 	if runnerKind == providerregistry.AuthCommandRunnerKindCursor {
-		return runCursorAuthStatusCommand(ctx, binaryPath, env)
+		auth, _, ok := runCursorAuthStatusCommand(ctx, binaryPath, env)
+		return auth, ok
 	}
 	commandCtx, cancel := context.WithTimeout(ctx, authStatusTimeout(spec))
 	defer cancel()
@@ -562,6 +531,12 @@ func parseOpenCodeAuthStatusOutput(output []byte) (AuthInfo, bool) {
 	if normalized == "" {
 		return AuthInfo{}, false
 	}
+	if match := openCodeCredentialCountPattern.FindStringSubmatch(normalized); len(match) == 2 {
+		if strings.TrimLeft(match[1], "0") == "" {
+			return AuthInfo{Status: AuthRequired}, true
+		}
+		return AuthInfo{Status: AuthAuthenticated}, true
+	}
 	if strings.Contains(normalized, "not logged in") ||
 		strings.Contains(normalized, "not authenticated") ||
 		strings.Contains(normalized, "no authenticated") ||
@@ -575,6 +550,8 @@ func parseOpenCodeAuthStatusOutput(output []byte) (AuthInfo, bool) {
 	}
 	return AuthInfo{}, false
 }
+
+var openCodeCredentialCountPattern = regexp.MustCompile(`([0-9]+)\s+credentials?\b`)
 
 func parseClaudeAuthStatusOutput(output []byte) (AuthInfo, bool) {
 	output = bytes.TrimSpace(output)

--- a/services/tuttid/service/agentstatus/service_status.go
+++ b/services/tuttid/service/agentstatus/service_status.go
@@ -13,7 +13,17 @@ import (
 // concurrently for different specs: it only reads Service configuration, and
 // the shared stores it touches (RunOutcomes, the active-action table) are
 // internally synchronized.
-func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.Time) (status ProviderStatus) {
+type statusDetectionOptions struct {
+	forceRefresh     bool
+	skipAdapterProbe bool
+}
+
+func (s Service) statusForSpec(
+	ctx context.Context,
+	spec ProviderSpec,
+	now time.Time,
+	options statusDetectionOptions,
+) (status ProviderStatus) {
 	startedAt := time.Now()
 	var runtimeResolutionDuration time.Duration
 	var adapterProbeDuration time.Duration
@@ -21,6 +31,7 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 	var cliVersionDuration time.Duration
 	var postChecksDuration time.Duration
 	adapterProbeRan := false
+	adapterProbeCacheHit := false
 	cliVersionRan := false
 	unsupported := false
 	defer func() {
@@ -33,6 +44,7 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 			"durationMs", time.Since(startedAt).Milliseconds(),
 			"runtimeResolutionMs", runtimeResolutionDuration.Milliseconds(),
 			"adapterProbeRan", adapterProbeRan,
+			"adapterProbeCacheHit", adapterProbeCacheHit,
 			"adapterProbeMs", adapterProbeDuration.Milliseconds(),
 			"authMs", authDuration.Milliseconds(),
 			"cliVersionRan", cliVersionRan,
@@ -59,27 +71,36 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 	// concurrently: the per-provider cost becomes the slowest step instead of
 	// the sum. Each goroutine writes distinct variables read only after Wait.
 	var auth AuthInfo
+	authCLIVersion := ""
 	cliVersion := ""
+	reuseCursorAboutVersion := installed && isCursorAuthCommandSpec(spec) && s.RunAuthStatusCommand == nil
 	var checks errgroup.Group
-	if installed && adapterReady && s.shouldProbeAdapterCommandForStatus(spec, runtimeResolution) {
-		adapterProbeRan = true
-		checks.Go(func() error {
-			probeStartedAt := time.Now()
-			if probe := s.probeAdapterRuntimeCommand(ctx, spec, runtimeResolution, now); probe.Status == ProbeFailed {
-				adapterReady = false
-				adapterLaunchFailed = true
-			}
-			adapterProbeDuration = time.Since(probeStartedAt)
-			return nil
-		})
+	if installed && adapterReady && !options.skipAdapterProbe &&
+		s.shouldProbeAdapterCommandForStatus(spec, runtimeResolution) {
+		probeCacheKey := adapterProbeCacheKey(spec, runtimeResolution)
+		if !options.forceRefresh &&
+			s.AdapterProbeCache.ready(probeCacheKey, runtimeResolution.AdapterPath) {
+			adapterProbeCacheHit = true
+		} else {
+			adapterProbeRan = true
+			checks.Go(func() error {
+				probeStartedAt := time.Now()
+				if probe := s.probeAdapterRuntimeCommand(ctx, spec, runtimeResolution, now); probe.Status == ProbeFailed {
+					adapterReady = false
+					adapterLaunchFailed = true
+				}
+				adapterProbeDuration = time.Since(probeStartedAt)
+				return nil
+			})
+		}
 	}
 	checks.Go(func() error {
 		authStartedAt := time.Now()
-		auth = s.resolveAuth(ctx, spec, installed, runtimeResolution.CLIPath)
+		auth, authCLIVersion = s.resolveAuthAndCLIVersion(ctx, spec, installed, runtimeResolution.CLIPath)
 		authDuration = time.Since(authStartedAt)
 		return nil
 	})
-	if installed {
+	if installed && !reuseCursorAboutVersion {
 		cliVersionRan = true
 		checks.Go(func() error {
 			cliVersionStartedAt := time.Now()
@@ -89,6 +110,15 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 		})
 	}
 	_ = checks.Wait()
+	if reuseCursorAboutVersion {
+		cliVersion = authCLIVersion
+		if cliVersion == "" {
+			cliVersionRan = true
+			cliVersionStartedAt := time.Now()
+			cliVersion = s.cliVersion(ctx, runtimeResolution.CLIPath, runtimeResolution.Env)
+			cliVersionDuration = time.Since(cliVersionStartedAt)
+		}
+	}
 	postChecksStartedAt := time.Now()
 
 	codexPlatformOK := true

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -221,13 +221,17 @@ func TestParseCursorAuthStatusOutput(t *testing.T) {
 }
 
 func TestParseCursorAboutJSON(t *testing.T) {
-	auth, ok := parseCursorAboutJSON([]byte(`{
+	output := []byte(`{
 		"cliVersion": "2026.07.01-41b2de7",
 		"subscriptionTier": "Ultra",
 		"userEmail": "user@example.com"
-	}`))
+	}`)
+	auth, cliVersion, ok := parseCursorAboutJSONWithVersion(output)
 	if !ok {
-		t.Fatal("parseCursorAboutJSON() ok = false, want true")
+		t.Fatal("parseCursorAboutJSONWithVersion() ok = false, want true")
+	}
+	if cliVersion != "2026.07.01-41b2de7" {
+		t.Fatalf("cliVersion = %q, want 2026.07.01-41b2de7", cliVersion)
 	}
 	if auth.Status != AuthAuthenticated {
 		t.Fatalf("status = %q, want authenticated", auth.Status)
@@ -246,14 +250,17 @@ func TestParseCursorAboutJSON(t *testing.T) {
 }
 
 func TestParseCursorAboutText(t *testing.T) {
-	auth, ok := parseCursorAboutText([]byte(`About Cursor CLI
+	auth, cliVersion, ok := parseCursorAboutTextWithVersion([]byte(`About Cursor CLI
 
 CLI Version         2026.07.01-41b2de7
 Subscription Tier   Ultra
 User Email          user@example.com
 `))
 	if !ok {
-		t.Fatal("parseCursorAboutText() ok = false, want true")
+		t.Fatal("parseCursorAboutTextWithVersion() ok = false, want true")
+	}
+	if cliVersion != "2026.07.01-41b2de7" {
+		t.Fatalf("cliVersion = %q, want 2026.07.01-41b2de7", cliVersion)
 	}
 	if auth.AccountLabel != "Cursor Ultra · user@example.com" {
 		t.Fatalf("accountLabel = %q, want Cursor Ultra · user@example.com", auth.AccountLabel)
@@ -270,6 +277,8 @@ func TestParseOpenCodeAuthStatusOutput(t *testing.T) {
 		{output: "Status: authenticated", status: AuthAuthenticated, ok: true},
 		{output: "Not authenticated. Run opencode auth login.", status: AuthRequired, ok: true},
 		{output: "No providers are authenticated", status: AuthRequired, ok: true},
+		{output: "\x1b[0m\n└  0 credentials", status: AuthRequired, ok: true},
+		{output: "\x1b[0m\n└  2 credentials", status: AuthAuthenticated, ok: true},
 		{output: "", ok: false},
 		{output: "unexpected opencode error", ok: false},
 	} {

--- a/services/tuttid/service/agentstatus/service_update_test.go
+++ b/services/tuttid/service/agentstatus/service_update_test.go
@@ -156,7 +156,12 @@ func TestTuttiAgentVersionFloorPrecedesAdapterFailure(t *testing.T) {
 	spec := specs[0]
 	spec.AdapterBinaryNames = []string{"missing-adapter"}
 
-	status := service.statusForSpec(context.Background(), spec, service.now())
+	status := service.statusForSpec(
+		context.Background(),
+		spec,
+		service.now(),
+		statusDetectionOptions{},
+	)
 	if status.Availability.ReasonCode != "cli_version_unsupported" {
 		t.Fatalf("Availability = %#v, want CLI floor before adapter failure", status.Availability)
 	}

--- a/services/tuttid/service/agentstatus/status_cache.go
+++ b/services/tuttid/service/agentstatus/status_cache.go
@@ -65,16 +65,18 @@ func (c *ProviderStatusCache) invalidate(provider string) {
 }
 
 func (s Service) providerCredentialFingerprint(spec ProviderSpec) string {
-	if len(spec.AuthMarkerPaths) == 0 {
+	paths, complete := s.resolvedAuthMarkerPaths(spec)
+	if len(paths) == 0 {
+		if !complete {
+			return "markers:unavailable"
+		}
 		return ""
 	}
-	home, err := s.homeDir()
-	if err != nil || strings.TrimSpace(home) == "" {
-		return "home:unavailable"
+	parts := make([]string, 0, len(paths)+1)
+	if !complete {
+		parts = append(parts, "markers:incomplete")
 	}
-	parts := make([]string, 0, len(spec.AuthMarkerPaths))
-	for _, marker := range spec.AuthMarkerPaths {
-		path := expandHomePath(marker, home)
+	for _, path := range paths {
 		if modifiedAt, ok := s.fileModTime(path); ok {
 			parts = append(parts, path+"="+modifiedAt.UTC().Format(time.RFC3339Nano))
 			continue

--- a/services/tuttid/service/agentstatus/status_cache_test.go
+++ b/services/tuttid/service/agentstatus/status_cache_test.go
@@ -3,6 +3,9 @@ package agentstatus
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -39,6 +42,50 @@ func TestProviderStatusCacheReusesProviderAcrossRequestShapes(t *testing.T) {
 	}
 	if got := authCalls.Load(); got <= probesAfterFirst {
 		t.Fatalf("auth probes after force refresh = %d, want > %d", got, probesAfterFirst)
+	}
+}
+
+func TestForcedProviderStatusRefreshRechecksAuthButReusesStableCLIVersion(t *testing.T) {
+	tempDir := t.TempDir()
+	binaryPath := filepath.Join(tempDir, "cursor-agent")
+	versionCallsPath := filepath.Join(tempDir, "version-calls")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then\n" +
+		"  echo call >> " + versionCallsPath + "\n" +
+		"  echo 'cursor-agent 1.2.3'\n" +
+		"fi\n"
+	if err := os.WriteFile(binaryPath, []byte(script), 0o700); err != nil {
+		t.Fatalf("write cursor test CLI: %v", err)
+	}
+
+	var authCalls atomic.Int32
+	service := testService(func(string) (string, error) {
+		return binaryPath, nil
+	}, map[string]bool{})
+	service.StatusCache = NewProviderStatusCache()
+	service.CLIVersionCache = NewCLIVersionCache()
+	service.RunAuthStatusCommand = func(context.Context, ProviderSpec, string) (AuthInfo, bool) {
+		authCalls.Add(1)
+		return AuthInfo{Status: AuthAuthenticated}, true
+	}
+
+	for range 2 {
+		if _, err := service.List(context.Background(), ListInput{
+			Providers:    []string{"cursor"},
+			ForceRefresh: true,
+		}); err != nil {
+			t.Fatalf("forced List() error = %v", err)
+		}
+	}
+	if got := authCalls.Load(); got != 2 {
+		t.Fatalf("auth checks = %d, want every forced refresh", got)
+	}
+	versionCalls, err := os.ReadFile(versionCallsPath)
+	if err != nil {
+		t.Fatalf("read version calls: %v", err)
+	}
+	if got := len(strings.Fields(string(versionCalls))); got != 1 {
+		t.Fatalf("version checks = %d, want stable binary checked once", got)
 	}
 }
 

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -213,6 +213,9 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 		ClaudeCodeRuntimeDir: filepath.Join(agentRuntimeDir, "claude-code"),
 		RunOutcomes:          runOutcomes,
 		StatusCache:          agentstatusservice.NewProviderStatusCache(),
+		CLIVersionCache:      agentstatusservice.NewCLIVersionCache(),
+		AdapterProbeCache:    agentstatusservice.NewAdapterProbeCache(),
+		DetectionCommands:    agentstatusservice.NewDetectionCommandLimiter(4),
 		UpdateCache:          agentstatusservice.NewProviderUpdateCache(),
 	}
 	accountService := accountservice.NewService("")

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -82,6 +82,7 @@ pnpm perf:agent-gui -- --list-scenarios
 pnpm perf:agent-gui -- --scenario session-switch
 pnpm perf:agent-gui -- --scenario virtualized-streaming
 pnpm perf:agent-gui -- --scenario composer-input
+pnpm perf:agent-gui -- --scenario provider-status-focus-refresh --all-process-time-profile
 ```
 
 The command reads `~/.tutti-dev/tuttid.db` by default and uses SQLite online
@@ -109,6 +110,13 @@ The streaming scenario rewrites only the isolated snapshot and shadows
 to an installed Agent provider. The native window scenarios are currently
 macOS-only. Use `--source-db`,
 `--from-target-id`, or `--to-target-id` to override the defaults.
+
+The `provider-status-focus-refresh` scenario dispatches a second synthetic
+workspace focus and observes the page for one second, then proves neither focus
+starts a provider-status request. On macOS,
+`--all-process-time-profile` additionally writes `time-profile.trace` for all
+processes, including `tuttid` and short-lived provider CLIs that are outside the
+Chromium trace.
 
 The Markdown report contains scenario assertions, observed milestone phases,
 renderer-main `RunTask`/layout/paint metrics, React component fanout, and static

--- a/tools/scripts/agent-gui-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-performance-scenarios.mjs
@@ -14,6 +14,7 @@ import {
 } from "./agent-gui-layout-performance-scenarios.mjs";
 import { composerInputScenario } from "./agent-gui-composer-performance-scenarios.mjs";
 import { virtualizedScrollLocatorScenario } from "./agent-gui-scroll-performance-scenario.mjs";
+import { providerStatusFocusRefreshScenario } from "./agent-provider-status-performance-scenario.mjs";
 
 export const agentGuiPerformanceScenarios = [
   providerSwitchScenario,
@@ -25,7 +26,8 @@ export const agentGuiPerformanceScenarios = [
   composerInputScenario,
   composerOverflowResizeScenario,
   workbenchWindowLifecycleScenario,
-  desktopWindowStateScenario
+  desktopWindowStateScenario,
+  providerStatusFocusRefreshScenario
 ];
 
 export function resolveAgentGuiPerformanceScenario(id) {

--- a/tools/scripts/agent-provider-status-performance-scenario.mjs
+++ b/tools/scripts/agent-provider-status-performance-scenario.mjs
@@ -1,0 +1,256 @@
+import {
+  evaluate,
+  finishRendererScenario,
+  markRenderer,
+  startRendererScenario,
+  waitForProviderTiles
+} from "./agent-gui-performance-helpers.mjs";
+import { setTimeout as delay } from "node:timers/promises";
+
+const markers = {
+  start: "tutti-perf:provider-status-focus-refresh:start",
+  firstFocusDispatched:
+    "tutti-perf:provider-status-focus-refresh:first-focus-dispatched",
+  secondFocusDispatched:
+    "tutti-perf:provider-status-focus-refresh:second-focus-dispatched",
+  observationCompleted:
+    "tutti-perf:provider-status-focus-refresh:observation-completed",
+  end: "tutti-perf:provider-status-focus-refresh:end"
+};
+
+export const providerStatusFocusRefreshScenario = {
+  id: "provider-status-focus-refresh",
+  markers,
+  milestones: [
+    {
+      key: "firstFocusDispatched",
+      label: "first focus dispatched",
+      marker: markers.firstFocusDispatched
+    },
+    {
+      key: "secondFocusDispatched",
+      label: "second focus dispatched",
+      marker: markers.secondFocusDispatched
+    },
+    {
+      key: "observationCompleted",
+      label: "focus observation completed",
+      marker: markers.observationCompleted
+    }
+  ],
+  prepare: prepareProviderStatusFocusRefresh,
+  execute: executeProviderStatusFocusRefresh,
+  describe(prepared) {
+    return `${prepared.providerCount} visible providers; focus twice without requesting provider status`;
+  },
+  summarize(prepared, result) {
+    return summarizeProviderStatusFocusRefresh(prepared, result);
+  }
+};
+
+async function prepareProviderStatusFocusRefresh(context, options) {
+  const { pageClient } = context;
+  await pageClient.send("Page.enable");
+  await pageClient.send("Network.enable");
+  const networkRecorder = createProviderStatusNetworkRecorder(pageClient);
+  const ownership = await evaluate(
+    pageClient,
+    `new URLSearchParams(location.search).get('reportPredefinePageview')`
+  );
+  if (ownership !== "1") {
+    const loaded = pageClient.waitForEvent("Page.loadEventFired");
+    await evaluate(
+      pageClient,
+      `(() => {
+        const url = new URL(location.href);
+        url.searchParams.set('reportPredefinePageview', '1');
+        history.replaceState(null, '', url);
+        return true;
+      })()`
+    );
+    await pageClient.send("Page.reload");
+    await loaded;
+  }
+  const providers = await waitForProviderTiles(pageClient, options.timeoutMs);
+  await waitForRecordedRequests(
+    networkRecorder,
+    (requests) =>
+      requests.length > 0 &&
+      requests.every((request) => request.endedAt !== null),
+    options.timeoutMs,
+    "completed startup provider-status request"
+  );
+  await waitForNetworkQuiescence(networkRecorder, 2_500, options.timeoutMs);
+  const startupRequestCount = networkRecorder.requests.length;
+  networkRecorder.reset();
+  return {
+    networkRecorder,
+    providerCount: providers.tiles.length,
+    startupRequestCount
+  };
+}
+
+async function executeProviderStatusFocusRefresh(context, prepared) {
+  const { pageClient } = context;
+  const recorder = prepared.networkRecorder;
+  try {
+    await startRendererScenario(pageClient, markers.start);
+    await evaluate(
+      pageClient,
+      `(() => {
+        window.dispatchEvent(new Event('focus'));
+        console.timeStamp(${JSON.stringify(markers.firstFocusDispatched)});
+        return true;
+      })()`
+    );
+    await delay(100);
+    await evaluate(
+      pageClient,
+      `(() => {
+        window.dispatchEvent(new Event('focus'));
+        console.timeStamp(${JSON.stringify(markers.secondFocusDispatched)});
+        return true;
+      })()`
+    );
+    await delay(1_000);
+    await markRenderer(pageClient, markers.observationCompleted);
+    await finishRendererScenario(pageClient, markers.end);
+    return { requests: recorder.requests.map((request) => ({ ...request })) };
+  } finally {
+    recorder.dispose();
+    await pageClient.send("Network.disable").catch(() => {});
+  }
+}
+
+function createProviderStatusNetworkRecorder(pageClient) {
+  const requests = [];
+  const requestsByID = new Map();
+  let lastActivityAt = Date.now();
+  const markActivity = () => {
+    lastActivityAt = Date.now();
+  };
+  const disposables = [
+    pageClient.subscribe("Network.requestWillBeSent", (event) => {
+      const url = new URL(event.params.request.url);
+      if (
+        url.pathname !== "/v1/agent-providers/status" ||
+        event.params.request.method !== "GET"
+      ) {
+        return;
+      }
+      markActivity();
+      const record = {
+        endedAt: null,
+        error: null,
+        ok: null,
+        refresh: url.searchParams.get("refresh"),
+        requestID: event.params.requestId,
+        startedAt: event.params.timestamp * 1000,
+        status: null,
+        url: url.toString()
+      };
+      requests.push(record);
+      requestsByID.set(record.requestID, record);
+    }),
+    pageClient.subscribe("Network.responseReceived", (event) => {
+      const record = requestsByID.get(event.params.requestId);
+      if (!record) return;
+      markActivity();
+      record.status = event.params.response.status;
+      record.ok = record.status >= 200 && record.status < 300;
+    }),
+    pageClient.subscribe("Network.loadingFinished", (event) => {
+      const record = requestsByID.get(event.params.requestId);
+      if (record) {
+        markActivity();
+        record.endedAt = event.params.timestamp * 1000;
+      }
+    }),
+    pageClient.subscribe("Network.loadingFailed", (event) => {
+      const record = requestsByID.get(event.params.requestId);
+      if (!record) return;
+      markActivity();
+      record.endedAt = event.params.timestamp * 1000;
+      record.error = event.params.errorText;
+      record.ok = false;
+    })
+  ];
+  return {
+    requests,
+    getLastActivityAt: () => lastActivityAt,
+    dispose() {
+      for (const dispose of disposables) dispose();
+    },
+    reset() {
+      requests.length = 0;
+      requestsByID.clear();
+      markActivity();
+    }
+  };
+}
+
+async function waitForRecordedRequests(recorder, predicate, timeoutMs, label) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate(recorder.requests)) return;
+    await delay(50);
+  }
+  throw new Error(
+    `timed out waiting for ${label}: ${JSON.stringify(recorder.requests)}`
+  );
+}
+
+async function waitForNetworkQuiescence(recorder, quietPeriodMs, timeoutMs) {
+  await waitForRecordedRequests(
+    recorder,
+    (requests) =>
+      requests.length > 0 &&
+      requests.every((request) => request.endedAt !== null) &&
+      Date.now() - recorder.getLastActivityAt() >= quietPeriodMs,
+    timeoutMs,
+    `${quietPeriodMs} ms of provider-status startup quiescence`
+  );
+}
+
+export function summarizeProviderStatusFocusRefresh(prepared, result) {
+  const requests = result.requests ?? [];
+  const durations = requests.map((request) =>
+    request.endedAt === null
+      ? "incomplete"
+      : `${Math.round(request.endedAt - request.startedAt)} ms`
+  );
+  const assertions = [
+    {
+      name: "startup provider snapshot loaded before capture",
+      passed: prepared.startupRequestCount > 0
+    },
+    {
+      name: "focus uses the loaded renderer snapshot",
+      passed: requests.length === 0
+    },
+    {
+      name: "focus never forces provider detection",
+      passed: requests.every((request) => request.refresh !== "true")
+    }
+  ];
+  return {
+    outcome: assertions.every((assertion) => assertion.passed)
+      ? "passed"
+      : "failed",
+    assertions,
+    details: [
+      { label: "Visible providers", value: String(prepared.providerCount) },
+      {
+        label: "Startup requests drained before capture",
+        value: String(prepared.startupRequestCount)
+      },
+      { label: "Focus-driven status requests", value: String(requests.length) },
+      {
+        label: "Unexpected request durations",
+        value: durations.length > 0 ? durations.join(" → ") : "none"
+      }
+    ],
+    stabilityCriterion:
+      "two focus events observed for one second with no provider-status request"
+  };
+}

--- a/tools/scripts/all-process-time-profile.mjs
+++ b/tools/scripts/all-process-time-profile.mjs
@@ -1,0 +1,86 @@
+import { spawn } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
+
+const readyPattern = /Ctrl-C to stop the recording/iu;
+
+export function buildAllProcessTimeProfileArgs(outputPath) {
+  return [
+    "xctrace",
+    "record",
+    "--template",
+    "Time Profiler",
+    "--all-processes",
+    "--no-prompt",
+    "--output",
+    outputPath
+  ];
+}
+
+export async function startAllProcessTimeProfile(input) {
+  if (process.platform !== "darwin") {
+    throw new Error("all-process Time Profiler capture requires macOS");
+  }
+  const child = spawn(
+    "xcrun",
+    buildAllProcessTimeProfileArgs(input.outputPath),
+    {
+      cwd: input.cwd,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"]
+    }
+  );
+  let output = "";
+  const append = (chunk) => {
+    output = (output + chunk.toString()).slice(-20_000);
+  };
+  child.stdout.on("data", append);
+  child.stderr.on("data", append);
+  let exitResult = null;
+  const exit = new Promise((resolveExit) => {
+    child.once("error", (error) => {
+      exitResult = { error };
+      resolveExit(exitResult);
+    });
+    child.once("exit", (code, signal) => {
+      exitResult = { code, signal };
+      resolveExit(exitResult);
+    });
+  });
+  const deadline = Date.now() + (input.timeoutMs ?? 30_000);
+  while (!readyPattern.test(output)) {
+    if (exitResult) {
+      throw new Error(
+        `xctrace exited before recording (${exitResult.error?.message ?? exitResult.code ?? exitResult.signal ?? "unknown"})${output.trim() ? `: ${output.trim()}` : ""}`
+      );
+    }
+    if (Date.now() >= deadline) {
+      child.kill("SIGKILL");
+      await exit;
+      throw new Error(
+        `timed out waiting for xctrace Time Profiler${output.trim() ? `: ${output.trim()}` : ""}`
+      );
+    }
+    await delay(100);
+  }
+
+  let stopped = false;
+  return {
+    outputPath: input.outputPath,
+    async stop() {
+      if (stopped) return;
+      stopped = true;
+      child.kill("SIGINT");
+      const result = await Promise.race([exit, delay(45_000).then(() => null)]);
+      if (!result) {
+        child.kill("SIGKILL");
+        await exit;
+        throw new Error("timed out saving xctrace Time Profiler capture");
+      }
+      if (result.code !== 0) {
+        throw new Error(
+          `xctrace failed (${result.error?.message ?? result.code ?? result.signal ?? "unknown"})${output.trim() ? `: ${output.trim()}` : ""}`
+        );
+      }
+    }
+  };
+}

--- a/tools/scripts/capture-electron-trace.mjs
+++ b/tools/scripts/capture-electron-trace.mjs
@@ -188,6 +188,7 @@ export class CdpClient {
     this.nextId = 1;
     this.pending = new Map();
     this.eventWaiters = new Map();
+    this.eventListeners = new Map();
 
     socket.addEventListener("message", (event) => {
       this.handleMessage(event.data);
@@ -217,6 +218,15 @@ export class CdpClient {
       waiters.push(resolveEvent);
       this.eventWaiters.set(method, waiters);
     });
+  }
+
+  subscribe(method, listener) {
+    const listeners = this.eventListeners.get(method) ?? new Set();
+    listeners.add(listener);
+    this.eventListeners.set(method, listeners);
+    return () => {
+      listeners.delete(listener);
+    };
   }
 
   close() {
@@ -249,6 +259,10 @@ export class CdpClient {
     }
 
     if (message.method) {
+      const listeners = this.eventListeners.get(message.method);
+      for (const listener of listeners ?? []) {
+        listener(message);
+      }
       const waiters = this.eventWaiters.get(message.method);
       if (!waiters?.length) {
         return;

--- a/tools/scripts/run-agent-gui-performance.mjs
+++ b/tools/scripts/run-agent-gui-performance.mjs
@@ -29,6 +29,7 @@ import {
   agentGuiPerformanceScenarios,
   resolveAgentGuiPerformanceScenario
 } from "./agent-gui-performance-scenarios.mjs";
+import { startAllProcessTimeProfile } from "./all-process-time-profile.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = resolve(scriptDirectory, "..", "..");
@@ -79,9 +80,11 @@ export async function main(argv) {
   const reportJSONPath = join(outputDirectory, "report.json");
   const reportMarkdownPath = join(outputDirectory, "report.md");
   const desktopLogPath = join(outputDirectory, "desktop.log");
+  const timeProfilePath = join(outputDirectory, "time-profile.trace");
   let desktopProcess = null;
   let pageClient = null;
   let browserClient = null;
+  let timeProfileCapture = null;
   let primaryError = null;
 
   log(`source snapshot: ${basename(options.sourceDatabase)}`);
@@ -137,6 +140,15 @@ export async function main(argv) {
     });
     log(`scenario ${scenario.id}: ${scenario.describe(prepared)}`);
 
+    if (options.allProcessTimeProfile) {
+      log("starting all-process Time Profiler");
+      timeProfileCapture = await startAllProcessTimeProfile({
+        cwd: workspaceRoot,
+        outputPath: timeProfilePath,
+        timeoutMs: 30_000
+      });
+    }
+
     await browserClient.send("Tracing.start", {
       categories: defaultTraceCategories,
       options: "sampling-frequency=10000",
@@ -144,13 +156,30 @@ export async function main(argv) {
     });
 
     let scenarioResult;
+    let scenarioError = null;
+    let captureError = null;
     try {
       scenarioResult = await scenario.execute(context, prepared, {
         timeoutMs: scenarioReadyTimeoutMs
       });
+    } catch (error) {
+      scenarioError = error;
     } finally {
-      await stopTrace(browserClient, tracePath);
+      try {
+        await stopTrace(browserClient, tracePath);
+      } catch (error) {
+        captureError = error;
+      }
+      if (timeProfileCapture) {
+        try {
+          await timeProfileCapture.stop();
+        } catch (error) {
+          captureError ??= error;
+        }
+      }
     }
+    if (scenarioError) throw scenarioError;
+    if (captureError) throw captureError;
 
     const summary = await analyzeElectronTrace({
       tracePath,
@@ -169,6 +198,12 @@ export async function main(argv) {
       sourceProjectCount: snapshotInfo.projectCount,
       clearedRecoveryRows: snapshotInfo.clearedRecoveryRows
     };
+    if (timeProfileCapture) {
+      summary.run.details.push({
+        label: "All-process Time Profiler",
+        value: basename(timeProfilePath)
+      });
+    }
     applyScenarioAssessment(summary, scenario.assessTrace?.(summary));
     await writeFile(reportJSONPath, `${JSON.stringify(summary, null, 2)}\n`);
     await writeFile(
@@ -184,12 +219,11 @@ export async function main(argv) {
     );
     log(`report: ${reportMarkdownPath}`);
     log(`trace: ${tracePath}`);
-    if (summary.verdict.status === "failed") {
+    if (timeProfileCapture) log(`time profile: ${timeProfilePath}`);
+    const failureReasons = performanceRunFailureReasons(summary);
+    if (failureReasons.length > 0) {
       throw new Error(
-        `${scenario.id} performance gate failed: ${summary.run.assertions
-          .filter((assertion) => !assertion.passed)
-          .map((assertion) => assertion.name)
-          .join(", ")}`
+        `${scenario.id} performance gate failed: ${failureReasons.join(", ")}`
       );
     }
   } catch (error) {
@@ -198,6 +232,14 @@ export async function main(argv) {
   } finally {
     pageClient?.close();
     browserClient?.close();
+    if (timeProfileCapture) {
+      try {
+        await timeProfileCapture.stop();
+      } catch (error) {
+        if (!primaryError) process.exitCode = 1;
+        log(`Time Profiler cleanup warning: ${error.message}`);
+      }
+    }
     if (desktopProcess) {
       await stopProcessTree(desktopProcess);
     }
@@ -404,6 +446,19 @@ export function applyScenarioAssessment(summary, assessment) {
           reason: `${failedAssertions.length} of ${summary.run.assertions.length} scenario assertions failed`
         };
   return summary;
+}
+
+export function performanceRunFailureReasons(summary) {
+  const failedAssertions = (summary.run?.assertions ?? [])
+    .filter((assertion) => !assertion.passed)
+    .map((assertion) => assertion.name);
+  if (failedAssertions.length > 0) {
+    return failedAssertions;
+  }
+  if (summary.verdict?.status === "failed") {
+    return [summary.verdict.reason ?? "trace assessment failed"];
+  }
+  return [];
 }
 
 async function buildDaemon(outputPath) {
@@ -648,6 +703,8 @@ function parseArgs(argv) {
       );
     } else if (arg === "--keep-runtime") {
       options.keepRuntime = true;
+    } else if (arg === "--all-process-time-profile") {
+      options.allProcessTimeProfile = true;
     } else {
       throw new Error(`unknown option: ${arg}`);
     }
@@ -692,7 +749,7 @@ function log(message) {
 
 function printUsage() {
   process.stdout.write(
-    `Run an isolated, report-only AgentGUI performance scenario.\n\nUsage:\n  pnpm perf:agent-gui\n  pnpm perf:agent-gui -- --scenario session-switch\n  pnpm perf:agent-gui -- --list-scenarios\n\nOptions:\n  --scenario <id>          Scenario. Default: provider-switch\n  --list-scenarios         Print available scenario ids\n  --source-db <path>       Source dev DB. Default: ~/.tutti-dev/tuttid.db\n  --output <directory>     Report/trace output directory under .tmp by default\n  --from-target-id <id>    Source Agent target for provider scenarios\n  --to-target-id <id>      Target Agent target for provider scenarios\n  --min-ms <milliseconds>  Long-event threshold. Default: 16\n  --keep-runtime           Keep isolated DB and Electron userData for debugging\n`
+    `Run an isolated, report-only AgentGUI performance scenario.\n\nUsage:\n  pnpm perf:agent-gui\n  pnpm perf:agent-gui -- --scenario session-switch\n  pnpm perf:agent-gui -- --list-scenarios\n\nOptions:\n  --scenario <id>          Scenario. Default: provider-switch\n  --list-scenarios         Print available scenario ids\n  --source-db <path>       Source dev DB. Default: ~/.tutti-dev/tuttid.db\n  --output <directory>     Report/trace output directory under .tmp by default\n  --from-target-id <id>    Source Agent target for provider scenarios\n  --to-target-id <id>      Target Agent target for provider scenarios\n  --min-ms <milliseconds>  Long-event threshold. Default: 16\n  --all-process-time-profile\n                           Also record macOS Time Profiler for all processes\n  --keep-runtime           Keep isolated DB and Electron userData for debugging\n`
   );
   process.stdout.write(
     "\n--min-ms applies to renderer-main RunTask duration, not all trace events.\n"

--- a/tools/scripts/run-agent-gui-performance.test.mjs
+++ b/tools/scripts/run-agent-gui-performance.test.mjs
@@ -10,9 +10,12 @@ import {
   resolveAgentGuiPerformanceScenario
 } from "./agent-gui-performance-scenarios.mjs";
 import { composerInputScenario } from "./agent-gui-composer-performance-scenarios.mjs";
+import { summarizeProviderStatusFocusRefresh } from "./agent-provider-status-performance-scenario.mjs";
+import { buildAllProcessTimeProfileArgs } from "./all-process-time-profile.mjs";
 import {
   applyScenarioAssessment,
   findUnknownAgentTargetMigrationIDs,
+  performanceRunFailureReasons,
   prepareWorkbenchSnapshotForPerformance
 } from "./run-agent-gui-performance.mjs";
 
@@ -42,6 +45,22 @@ test("scenario trace assessment turns report metrics into a gate", () => {
   });
   assert.equal(summary.run.outcome, "failed");
   assert.deepEqual(summary.run.details, [{ label: "Scroll", value: "4 ms" }]);
+});
+
+test("failed scenario contract fails even when trace metrics are ungraded", () => {
+  assert.deepEqual(
+    performanceRunFailureReasons({
+      run: {
+        assertions: [
+          { name: "semantic contract", passed: false },
+          { name: "non-forced request", passed: true }
+        ],
+        outcome: "failed"
+      },
+      verdict: { status: "ungraded", reason: "report only" }
+    }),
+    ["semantic contract"]
+  );
 });
 
 test("performance snapshot rejects newer Agent target migrations", () => {
@@ -169,7 +188,8 @@ test("performance scenario registry exposes renderer and window scenarios", () =
       "composer-input",
       "composer-overflow-resize",
       "workbench-window-lifecycle",
-      "desktop-window-state"
+      "desktop-window-state",
+      "provider-status-focus-refresh"
     ]
   );
   assert.equal(
@@ -214,4 +234,38 @@ test("composer input summary requires text, IME, and mention keyboard semantics"
       "mention panel closed"
     ]
   );
+});
+
+test("provider status focus summary proves focus reuses the renderer snapshot", () => {
+  const report = summarizeProviderStatusFocusRefresh(
+    { providerCount: 6, startupRequestCount: 1 },
+    { requests: [] }
+  );
+
+  assert.equal(report.outcome, "passed");
+  assert.deepEqual(
+    report.assertions.map((assertion) => assertion.name),
+    [
+      "startup provider snapshot loaded before capture",
+      "focus uses the loaded renderer snapshot",
+      "focus never forces provider detection"
+    ]
+  );
+  assert.deepEqual(report.details.at(-1), {
+    label: "Unexpected request durations",
+    value: "none"
+  });
+});
+
+test("all-process Time Profiler records every process without a time limit", () => {
+  assert.deepEqual(buildAllProcessTimeProfileArgs("/tmp/profile.trace"), [
+    "xctrace",
+    "record",
+    "--template",
+    "Time Profiler",
+    "--all-processes",
+    "--no-prompt",
+    "--output",
+    "/tmp/profile.trace"
+  ]);
 });


### PR DESCRIPTION
## Summary

- Stop focus/open analytics from requesting fresh provider status; it now reports the loaded renderer snapshot.
- Keep failed session creation accurate by force-refreshing only the target provider before reporting.
- Reduce each provider scan with local auth markers, Cursor `about` version reuse, executable-fingerprint caches, and a process-wide CLI concurrency limit of 4.
- Add an 8-provider focus performance scenario and optional all-process Time Profiler capture.

## Verification

- `pnpm check:changed` — passed 19 lanes.
- Pre-push `pnpm check:changed -- --push-ready` — passed 21 lanes.
- `pnpm perf:agent-gui -- --scenario provider-status-focus-refresh --all-process-time-profile --output .tmp/provider-status-focus-refresh-pr-20260723` — 1 run, passed:
  - 8 visible providers.
  - 2 focus events.
  - 0 focus-driven provider-status requests.
  - 0 renderer `RunTask` events at or above 16 ms; max 2.96 ms.

Performance comparison:

- Baseline commit: `82daad4ea`; supplied production logs recorded 69 full six-provider scans over 133 minutes. Scan latency: median 3,256 ms, average 3,896 ms, p95 9,992 ms, max 11,927 ms.
- PR commit: `39e4e066613c06c8295cb293b2bfcb9e5a05d2f0`; the exact command above recorded 0 provider-status requests for two focus events.
- Run count: 1 final trace run. This is an event-elimination comparison, not a controlled CPU A/B, because the baseline came from production logs.

## Fix Scope Justification

- Root cause: focus/open analytics treated a telemetry snapshot as a freshness request, causing all visible providers to launch CLI detection. Individual scans also repeated stable version/adapter work.
- Why it cannot be fixed at a lower layer: stopping telemetry-triggered scans belongs in the renderer, while preventing repeated CLI work across startup, manual refresh, and failure checks belongs in the daemon provider-status service. A fix in only one layer leaves the other trigger path intact. The large diff is mainly regression tests, the performance scenario/trace tooling, and durable docs.

## Fallback Three Questions

- Source: provider CLIs do not emit change events for executable version, adapter launchability, or every auth-state transition.
- Why it cannot be fixed at that source: Tutti controls the caller, not the provider CLI implementations. Successful stable facts are cached by executable fingerprint; auth failures still bypass readiness caches and force-refresh the exact provider.
- Removal condition: remove these caches when all supported providers expose cheap change notifications or an equivalent durable status stream.

## Checklist

- [x] N/A: this does not change session/turn/goal/runtime-operation lifecycle semantics.
- [x] I kept the change focused on provider-status scan CPU cost.
- [x] I updated architecture, testing, performance-tool, and troubleshooting documentation.
- [x] N/A: no README/CONTRIBUTING language source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.
