### PR TITLE
fix(agent-gui): prevent rail first-page refresh race

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -364,6 +364,12 @@ candidate lookup and the batch mutation. AgentGUI fails that paired capability
 closed when either method is absent, so the view cannot expose an action that
 will resolve to an empty optional-method path.
 
+The full first-page query is the only Rail read that resolves a navigation
+scope and clears its pending state. Targeted section refresh and pagination may
+update only an already-resolved matching scope. A subordinate result must not
+cancel the full query, publish partial membership for an unresolved scope, or
+unlock Rail interactions.
+
 Presentation-invisible Sessions remain canonical engine entities and stay
 available through exact Session selectors for trusted open, reconcile, and
 command flows. Plural consumer selectors exclude them before Rail and Message

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
@@ -107,6 +107,98 @@ describe("AgentGUIConversationRailQueryController", () => {
     engine.dispose();
   });
 
+  it("does not start a targeted page refresh while the rail scope is pending", async () => {
+    const engine = createTestAgentSessionEngine();
+    const session = normalizeAgentActivitySession({
+      activeTurnId: null,
+      agentSessionId: "session-during-first-pages",
+      agentTargetId: "local:codex",
+      cwd: "/workspace",
+      latestTurnInteractions: [],
+      pendingInteractions: [],
+      provider: "codex",
+      railSectionKey: "conversations",
+      title: "Session during first pages",
+      updatedAtUnixMs: 1,
+      workspaceId: "test-workspace"
+    });
+    let resolveFirstPages!: () => void;
+    const listSessionSections = vi.fn<
+      NonNullable<ConversationRailQueryRuntime["listSessionSections"]>
+    >((input) =>
+      new Promise<void>((resolve) => {
+        resolveFirstPages = resolve;
+      }).then(() => ({
+        sections: [
+          {
+            hasMore: false,
+            kind: "conversations" as const,
+            sectionKey: "conversations",
+            sessions: [session],
+            totalCount: 1
+          }
+        ],
+        workspaceId: input.workspaceId
+      }))
+    );
+    const listSessionSectionPage = vi.fn(async (input) => ({
+      hasMore: false,
+      kind: "conversations" as const,
+      sectionKey: input.sectionKey,
+      sessions: [session],
+      totalCount: 1
+    }));
+    const controller = new AgentGUIConversationRailQueryController({
+      engine,
+      getActiveConversationId: () => null,
+      runtime: { listSessionSections, listSessionSectionPage },
+      workspaceId: "test-workspace"
+    });
+    const scope: ConversationRailQueryScope = {
+      conversationFilter: { kind: "all" },
+      previewMode: false,
+      sectionAgentTargetFallbackId: null,
+      userProjects: []
+    };
+    const scopeKey = resolveConversationRailQueryScope(
+      "test-workspace",
+      scope
+    ).scopeKey;
+    controller.configure(scope);
+
+    const detach = controller.attach();
+    await vi.waitFor(() =>
+      expect(engine.getSnapshot().engineRuntime.workspaceReconcile.status).toBe(
+        "ready"
+      )
+    );
+    engine.dispatch({ session, type: "session/upserted" });
+    expect(listSessionSectionPage).not.toHaveBeenCalled();
+
+    expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(true);
+    expect(controller.getSnapshot().runtimeRailResolvedScopeKey).not.toBe(
+      scopeKey
+    );
+    expect(controller.getSnapshot().runtimeRailMemberships).toBeNull();
+    expect(controller.isInteractionLocked()).toBe(true);
+
+    resolveFirstPages();
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
+    expect(controller.getSnapshot().runtimeRailResolvedScopeKey).toBe(scopeKey);
+    expect(controller.getSnapshot().runtimeRailMemberships).toEqual([
+      expect.objectContaining({
+        id: "conversations",
+        sessionIds: [session.agentSessionId]
+      })
+    ]);
+    expect(controller.isInteractionLocked()).toBe(false);
+
+    detach();
+    engine.dispose();
+  });
+
   it("debounces conversation searches and immediately clears an active query", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -397,7 +397,9 @@ export class AgentGUIConversationRailQueryController {
     }
     if (
       !this.runtimeSectionsEnabled() ||
-      state.engineRuntime.workspaceReconcile.status === "loading"
+      state.engineRuntime.workspaceReconcile.status === "loading" ||
+      this.queryState.pending ||
+      this.queryState.resolvedScopeKey !== this.railSectionQueryKey
     ) {
       this.previousMembershipRecords = next;
       this.publishIfReady(state);
@@ -708,7 +710,6 @@ export class AgentGUIConversationRailQueryController {
       this.runtime.listSessionSectionPage
     );
   }
-
   private searchEnabled(): boolean {
     return Boolean(!this.scope?.previewMode && this.runtime.listSessionsPage);
   }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryCache.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryCache.ts
@@ -142,7 +142,6 @@ export function replaceConversationRailFirstPages(input: {
   }
   return {
     ...input.queryState,
-    pending: false,
     reconcilingSessionIds: [],
     sectionPageStates,
     sections


### PR DESCRIPTION
## Summary
- prevent targeted Rail section refreshes until the first-page scope is resolved
- keep global pending state owned by the full first-page query so partial results cannot publish an empty Rail or lock pagination
- add race regression coverage and document the Rail query ownership invariant

## Tests
- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=1 agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts` (13 passed)
- `pnpm check:agent-gui-degradation`
- `pnpm check:changed -- --push-ready` (12 lanes passed)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->