### PR TITLE
perf(agent-gui): reduce session switch layout work

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerProjectMenu.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerProjectMenu.spec.tsx
@@ -1,9 +1,18 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { createDefaultWorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-project/i18n";
+import { WorkspaceUserProjectSelect } from "@tutti-os/workspace-user-project/ui";
 import { AgentActivityHostProvider } from "../../agentActivityHost";
 import type { AgentHostInputApi } from "../../host/agentHostApi";
 import { AgentProjectDropdown } from "./AgentComposerProjectMenu";
+
+beforeAll(() => {
+  Object.defineProperties(HTMLElement.prototype, {
+    hasPointerCapture: { configurable: true, value: () => false },
+    releasePointerCapture: { configurable: true, value: () => undefined },
+    setPointerCapture: { configurable: true, value: () => undefined }
+  });
+});
 
 describe("AgentProjectDropdown project selection intent", () => {
   it("keeps an explicitly unscoped home composer instead of restoring the default project", async () => {
@@ -44,6 +53,59 @@ describe("AgentProjectDropdown project selection intent", () => {
     await waitFor(() => expect(getDefaultSelection).toHaveBeenCalledTimes(1));
     expect(onProjectPathChange).not.toHaveBeenCalled();
     expect(screen.getByRole("combobox")).toHaveTextContent("No project");
+  });
+});
+
+describe("WorkspaceUserProjectSelect render budget", () => {
+  it("does not construct project action content while closed", async () => {
+    const renderAddProjectIcon = vi.fn(() => <span aria-hidden />);
+    const alphaProject = {
+      id: "project-alpha",
+      label: "Alpha",
+      path: "/workspace/alpha",
+      pinnedAtUnixMs: 0
+    };
+    const betaProject = {
+      id: "project-beta",
+      label: "Beta",
+      path: "/workspace/beta",
+      pinnedAtUnixMs: 0
+    };
+    const onProjectPathChange = vi.fn();
+
+    render(
+      <WorkspaceUserProjectSelect
+        api={{
+          create: async () => alphaProject,
+          list: async () => ({ projects: [alphaProject, betaProject] })
+        }}
+        renderAddProjectIcon={renderAddProjectIcon}
+        selectedProjectPath={alphaProject.path}
+        shouldApplyPreparedSelection={false}
+        onProjectPathChange={onProjectPathChange}
+      />
+    );
+
+    const trigger = await screen.findByRole("combobox", { name: "Project" });
+    expect(renderAddProjectIcon).not.toHaveBeenCalled();
+
+    fireEvent.pointerDown(trigger, {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse"
+    });
+
+    const betaOption = await screen.findByRole("option", { name: "Beta" });
+    expect(renderAddProjectIcon).toHaveBeenCalledTimes(1);
+    fireEvent.pointerDown(betaOption, { button: 0, ctrlKey: false });
+    fireEvent.click(betaOption);
+
+    expect(onProjectPathChange).toHaveBeenCalledWith(betaProject.path, {
+      action: "select_existing"
+    });
+    await waitFor(() =>
+      expect(screen.queryByRole("option", { name: "Beta" })).toBeNull()
+    );
   });
 });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -236,7 +236,7 @@ export function AgentGUINodeView({
   const requestComposerFocus = useCallback(() => {
     setLocalComposerFocusRequestSequence((current) => current + 1);
   }, []);
-  const requestCreateConversation = useCallback(
+  const requestCreateConversation = useStableEventCallback(
     (options?: { projectPath?: string | null; source?: string }) => {
       if (previewMode) {
         return;
@@ -253,13 +253,7 @@ export function AgentGUINodeView({
         createConversationAction({ source: source ?? "rail_toolbar" });
       }
       requestComposerFocus();
-    },
-    [
-      createConversationAction,
-      previewMode,
-      requestComposerFocus,
-      viewModel.composer.composerSettings.selectedProjectPath
-    ]
+    }
   );
   const effectiveWorkspaceAppIcons = useMemo(
     () =>

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx
@@ -35,6 +35,33 @@ describe("useAgentGUIDetailScroll", () => {
     expect(harness.timeline.scrollTop).toBe(7_900);
   });
 
+  it("reads timeline geometry once for a semantic conversation switch", () => {
+    const harness = createHarness({ scrollHeight: 5_000 });
+    const { rerender } = renderHook(
+      ({ activeConversationId }) =>
+        useAgentGUIDetailScroll(
+          harness.input({ activeConversationId, showTimelineSkeleton: false })
+        ),
+      { initialProps: { activeConversationId: "conversation-a" } }
+    );
+
+    expect(harness.geometryReadCounts()).toEqual({
+      clientHeight: 1,
+      scrollHeight: 1,
+      scrollTop: 0
+    });
+
+    harness.resetGeometryReadCounts();
+    harness.setScrollHeight(8_000);
+    rerender({ activeConversationId: "conversation-b" });
+
+    expect(harness.geometryReadCounts()).toEqual({
+      clientHeight: 1,
+      scrollHeight: 1,
+      scrollTop: 0
+    });
+  });
+
   it("does not scroll the retained previous timeline when selection changes", () => {
     const harness = createHarness({ scrollHeight: 5_000 });
     const { rerender } = renderHook(
@@ -135,8 +162,14 @@ describe("useAgentGUIDetailScroll", () => {
     });
     expect(harness.timeline.scrollTop).toBe(4_900);
 
+    harness.resetGeometryReadCounts();
     act(() => animationFrames[0]?.(0));
 
+    expect(harness.geometryReadCounts()).toEqual({
+      clientHeight: 1,
+      scrollHeight: 1,
+      scrollTop: 0
+    });
     expect(harness.timeline.scrollTop).toBe(4_900);
   });
 
@@ -215,6 +248,87 @@ describe("useAgentGUIDetailScroll", () => {
       scrollHeight: 0,
       scrollTop: 0
     });
+  });
+
+  it("prefetches older messages from the initialized anchor without rereading scrollTop", () => {
+    const harness = createHarness({ scrollHeight: 100 });
+
+    renderHook(() =>
+      useAgentGUIDetailScroll(
+        harness.input({
+          activeConversationId: "conversation-prefetch",
+          hasOlderMessages: true,
+          showTimelineSkeleton: false
+        })
+      )
+    );
+
+    expect(harness.loadOlderConversationMessages).toHaveBeenCalledOnce();
+    expect(harness.geometryReadCounts()).toEqual({
+      clientHeight: 1,
+      scrollHeight: 1,
+      scrollTop: 0
+    });
+  });
+
+  it("restores a prepend anchor from one timeline geometry snapshot", () => {
+    const harness = createHarness({ scrollHeight: 5_000 });
+    const { rerender } = renderHook(
+      ({ isLoadingOlderMessages }) =>
+        useAgentGUIDetailScroll(
+          harness.input({
+            activeConversationId: "conversation-prepend",
+            isLoadingOlderMessages,
+            showTimelineSkeleton: false
+          })
+        ),
+      { initialProps: { isLoadingOlderMessages: false } }
+    );
+
+    act(() => {
+      harness.timeline.dispatchEvent(new WheelEvent("wheel", { deltaY: -100 }));
+      harness.timeline.scrollTop = 200;
+      harness.timeline.dispatchEvent(new Event("scroll"));
+    });
+    harness.pendingPrependScrollAnchorRef.current = {
+      conversationId: "conversation-prepend",
+      scrollHeight: 5_000,
+      scrollTop: 200
+    };
+    harness.setScrollHeight(6_000);
+    harness.resetGeometryReadCounts();
+
+    rerender({ isLoadingOlderMessages: true });
+
+    expect(harness.geometryReadCounts()).toEqual({
+      clientHeight: 1,
+      scrollHeight: 1,
+      scrollTop: 0
+    });
+    expect(harness.timeline.scrollTop).toBe(1_200);
+  });
+
+  it("reads timeline geometry once for an explicit scroll to bottom", () => {
+    const harness = createHarness({ scrollHeight: 5_000 });
+    const { result } = renderHook(() =>
+      useAgentGUIDetailScroll(
+        harness.input({
+          activeConversationId: "conversation-scroll-bottom",
+          showTimelineSkeleton: false
+        })
+      )
+    );
+    harness.timeline.scrollTop = 2_000;
+    harness.resetGeometryReadCounts();
+
+    act(() => result.current.scrollTimelineToBottom());
+
+    expect(harness.geometryReadCounts()).toEqual({
+      clientHeight: 1,
+      scrollHeight: 1,
+      scrollTop: 0
+    });
+    expect(harness.timeline.scrollTop).toBe(4_900);
   });
 
   it("keeps the bottom lock through observed streaming content growth", () => {
@@ -368,6 +482,9 @@ function createHarness(input: { scrollHeight: number }) {
       }
     }
   });
+  timeline.scrollTo = ((options: ScrollToOptions) => {
+    scrollTop = options.top ?? scrollTop;
+  }) as typeof timeline.scrollTo;
 
   const timelineScrollAnchorRef = mutableRef<{
     conversationId: string;
@@ -381,12 +498,15 @@ function createHarness(input: { scrollHeight: number }) {
     scrollTop: number;
   } | null>(null);
   const submittedPromptScrollConversationRef = mutableRef<string | null>(null);
+  const loadOlderConversationMessages = vi.fn();
   const actions = {
-    loadOlderConversationMessages: vi.fn()
+    loadOlderConversationMessages
   } as unknown as AgentGUINodeViewProps["actions"];
 
   return {
     bottomDock,
+    loadOlderConversationMessages,
+    pendingPrependScrollAnchorRef,
     timeline,
     timelineContent,
     resetGeometryReadCounts() {
@@ -407,6 +527,8 @@ function createHarness(input: { scrollHeight: number }) {
     input(options: {
       activeConversationId: string;
       conversation?: AgentConversationVM;
+      hasOlderMessages?: boolean;
+      isLoadingOlderMessages?: boolean;
       showTimelineSkeleton: boolean;
       timelineConversationId?: string;
     }) {
@@ -423,7 +545,11 @@ function createHarness(input: { scrollHeight: number }) {
         timelineContentRef: ref(timelineContent),
         timelineRef: ref(timeline),
         timelineScrollAnchorRef,
-        viewModel: viewModel(options.activeConversationId)
+        viewModel: viewModel(
+          options.activeConversationId,
+          options.hasOlderMessages,
+          options.isLoadingOlderMessages
+        )
       };
     }
   };
@@ -463,12 +589,16 @@ function installResizeObserverMock(): ResizeObserverMock[] {
   return observers;
 }
 
-function viewModel(activeConversationId: string): AgentGUINodeViewModel {
+function viewModel(
+  activeConversationId: string,
+  hasOlderMessages = false,
+  isLoadingOlderMessages = false
+): AgentGUINodeViewModel {
   return {
     rail: { activeConversationId },
     detail: {
-      hasOlderMessages: false,
-      isLoadingOlderMessages: false
+      hasOlderMessages,
+      isLoadingOlderMessages
     }
   } as unknown as AgentGUINodeViewModel;
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.ts
@@ -44,6 +44,22 @@ interface Input {
   viewModel: AgentGUINodeViewModel;
 }
 
+interface TimelineGeometry {
+  clientHeight: number;
+  maxScrollTop: number;
+  scrollHeight: number;
+}
+
+function readTimelineGeometry(timeline: HTMLElement): TimelineGeometry {
+  const scrollHeight = timeline.scrollHeight;
+  const clientHeight = timeline.clientHeight;
+  return {
+    clientHeight,
+    maxScrollTop: Math.max(0, scrollHeight - clientHeight),
+    scrollHeight
+  };
+}
+
 export function useAgentGUIDetailScroll(input: Input) {
   const {
     actions,
@@ -101,10 +117,8 @@ export function useAgentGUIDetailScroll(input: Input) {
     ) {
       return;
     }
-    const maxScrollTop = Math.max(
-      0,
-      timeline.scrollHeight - timeline.clientHeight
-    );
+    const geometry = readTimelineGeometry(timeline);
+    const maxScrollTop = geometry.maxScrollTop;
     let nextScrollTop: number;
     if (conversationChanged || shouldScrollSubmittedPromptToBottom) {
       bottomLockOwnerRef.current = activeConversationId;
@@ -125,7 +139,7 @@ export function useAgentGUIDetailScroll(input: Input) {
         pendingPrependScrollAnchorRef.current = null;
       }
     } else if (shouldRestorePrependAnchor && prependAnchor) {
-      const nextScrollHeight = timeline.scrollHeight;
+      const nextScrollHeight = geometry.scrollHeight;
       const delta = nextScrollHeight - prependAnchor.scrollHeight;
       nextScrollTop = Math.max(0, prependAnchor.scrollTop + delta);
       timeline.scrollTop = nextScrollTop;
@@ -152,9 +166,9 @@ export function useAgentGUIDetailScroll(input: Input) {
 
     timelineScrollAnchorRef.current = {
       conversationId: activeConversationId,
-      scrollHeight: timeline.scrollHeight,
+      scrollHeight: geometry.scrollHeight,
       scrollTop: nextScrollTop,
-      clientHeight: timeline.clientHeight
+      clientHeight: geometry.clientHeight
     };
     setIsTimelineScrolledToTop(
       nextScrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
@@ -271,16 +285,14 @@ export function useAgentGUIDetailScroll(input: Input) {
         ) {
           return;
         }
-        const maxScrollTop = Math.max(
-          0,
-          timeline.scrollHeight - timeline.clientHeight
-        );
+        const geometry = readTimelineGeometry(timeline);
+        const maxScrollTop = geometry.maxScrollTop;
         timeline.scrollTop = maxScrollTop;
         timelineScrollAnchorRef.current = {
           conversationId: activeConversationId,
-          scrollHeight: timeline.scrollHeight,
+          scrollHeight: geometry.scrollHeight,
           scrollTop: maxScrollTop,
-          clientHeight: timeline.clientHeight
+          clientHeight: geometry.clientHeight
         };
         setIsTimelineScrolledToTop(
           maxScrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
@@ -334,6 +346,25 @@ export function useAgentGUIDetailScroll(input: Input) {
       return;
     }
 
+    const loadOlderMessagesNearTop = (
+      scrollTop: number,
+      scrollHeight: number
+    ): void => {
+      if (
+        activeConversationId === viewModel.rail.activeConversationId &&
+        viewModel.detail.hasOlderMessages &&
+        !viewModel.detail.isLoadingOlderMessages &&
+        scrollTop <= AGENT_GUI_TOP_HISTORY_PREFETCH_THRESHOLD_PX
+      ) {
+        pendingPrependScrollAnchorRef.current = {
+          conversationId: activeConversationId,
+          scrollHeight,
+          scrollTop
+        };
+        actions.loadOlderConversationMessages();
+      }
+    };
+
     const captureScrollAnchor = (): void => {
       const previousAnchor = timelineScrollAnchorRef.current;
       if (
@@ -368,19 +399,7 @@ export function useAgentGUIDetailScroll(input: Input) {
         scrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
       );
       setIsTimelineScrolledToBottom(effectiveAtBottom);
-      if (
-        activeConversationId === viewModel.rail.activeConversationId &&
-        viewModel.detail.hasOlderMessages &&
-        !viewModel.detail.isLoadingOlderMessages &&
-        scrollTop <= AGENT_GUI_TOP_HISTORY_PREFETCH_THRESHOLD_PX
-      ) {
-        pendingPrependScrollAnchorRef.current = {
-          conversationId: activeConversationId,
-          scrollHeight: previousAnchor.scrollHeight,
-          scrollTop
-        };
-        actions.loadOlderConversationMessages();
-      }
+      loadOlderMessagesNearTop(scrollTop, previousAnchor.scrollHeight);
     };
 
     const syncObservedTimelineGeometry = (): void => {
@@ -389,9 +408,8 @@ export function useAgentGUIDetailScroll(input: Input) {
         return;
       }
 
-      const scrollHeight = timeline.scrollHeight;
-      const clientHeight = timeline.clientHeight;
-      const maxScrollTop = Math.max(0, scrollHeight - clientHeight);
+      const geometry = readTimelineGeometry(timeline);
+      const { clientHeight, maxScrollTop, scrollHeight } = geometry;
       const bottomLocked = bottomLockOwnerRef.current === activeConversationId;
       let scrollTop = Math.min(maxScrollTop, timeline.scrollTop);
       if (bottomLocked) {
@@ -430,7 +448,13 @@ export function useAgentGUIDetailScroll(input: Input) {
       }
     };
 
-    captureScrollAnchor();
+    const initialAnchor = timelineScrollAnchorRef.current;
+    if (initialAnchor?.conversationId === activeConversationId) {
+      loadOlderMessagesNearTop(
+        initialAnchor.scrollTop,
+        initialAnchor.scrollHeight
+      );
+    }
     timeline.addEventListener("scroll", captureScrollAnchor, { passive: true });
     timeline.addEventListener("wheel", captureWheelIntent, { passive: true });
     timeline.addEventListener("keydown", captureKeyboardIntent);
@@ -466,18 +490,16 @@ export function useAgentGUIDetailScroll(input: Input) {
       return;
     }
 
-    const maxScrollTop = Math.max(
-      0,
-      timeline.scrollHeight - timeline.clientHeight
-    );
+    const geometry = readTimelineGeometry(timeline);
+    const maxScrollTop = geometry.maxScrollTop;
     bottomLockOwnerRef.current = activeConversationId;
     userScrollAwayIntentConversationRef.current = null;
     setTimelineScrollTopWithUserTransition(timeline, maxScrollTop);
     timelineScrollAnchorRef.current = {
       conversationId: activeConversationId,
-      scrollHeight: timeline.scrollHeight,
+      scrollHeight: geometry.scrollHeight,
       scrollTop: maxScrollTop,
-      clientHeight: timeline.clientHeight
+      clientHeight: geometry.clientHeight
     };
     setIsTimelineScrolledToTop(
       maxScrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX

--- a/packages/workspace/user-project/src/ui/internal/project/WorkspaceUserProjectSelect.tsx
+++ b/packages/workspace/user-project/src/ui/internal/project/WorkspaceUserProjectSelect.tsx
@@ -596,91 +596,95 @@ export function WorkspaceUserProjectSelect({
             <WorkspaceUserProjectOverflowLabel label={triggerLabel} />
           </span>
         </SelectTrigger>
-        <SelectContent
-          align={contentAlign}
-          className={classNames?.content}
-          collisionPadding={16}
-          side={contentSide}
-          sideOffset={contentSideOffset}
-          onCloseAutoFocus={onDismissAutoFocus}
-        >
-          {visibleProjects.map((project) => {
-            const projectLabel =
-              resolveWorkspaceUserProjectDisplayLabel(project);
-            return (
-              <SelectItem
-                className={classNames?.item}
-                key={project.id || project.path}
-                value={project.path}
-              >
-                <span className="flex min-w-0 flex-1 items-center gap-2 pr-1">
-                  <FolderIcon aria-hidden size={15} />
-                  <WorkspaceUserProjectOverflowLabel label={projectLabel} />
-                </span>
-              </SelectItem>
-            );
-          })}
-          {showProjectActionDivider ? (
-            <SelectSeparator
-              className="mx-[12px] my-1 shrink-0 bg-[var(--line-2)]"
-              data-workspace-user-project-action-separator="true"
-            />
-          ) : null}
-          {hasProjectActions ? (
-            <SelectGroup
-              className="gap-0.5 p-0"
-              data-workspace-user-project-action-group="true"
-            >
-              {effectiveApi?.selectDirectory ? (
+        {isSelectOpen ? (
+          <SelectContent
+            align={contentAlign}
+            className={classNames?.content}
+            collisionPadding={16}
+            side={contentSide}
+            sideOffset={contentSideOffset}
+            onCloseAutoFocus={onDismissAutoFocus}
+          >
+            {visibleProjects.map((project) => {
+              const projectLabel =
+                resolveWorkspaceUserProjectDisplayLabel(project);
+              return (
                 <SelectItem
                   className={classNames?.item}
-                  value={linkExistingProjectOptionValue}
+                  key={project.id || project.path}
+                  value={project.path}
                 >
                   <span className="flex min-w-0 flex-1 items-center gap-2 pr-1">
-                    <LinkIcon aria-hidden size={15} />
-                    <span className="truncate">
-                      {resolvedLabels.linkExistingProject}
-                    </span>
+                    <FolderIcon aria-hidden size={15} />
+                    <WorkspaceUserProjectOverflowLabel label={projectLabel} />
                   </span>
                 </SelectItem>
-              ) : null}
-              {showCreateProjectAction ? (
-                <SelectItem
-                  className={classNames?.item}
-                  value={addProjectOptionValue}
-                >
-                  <span className="flex min-w-0 flex-1 items-center gap-2 pr-1">
-                    {renderAddProjectIcon?.() ?? (
-                      <NewWorkspaceLinedIcon
+              );
+            })}
+            {showProjectActionDivider ? (
+              <SelectSeparator
+                className="mx-[12px] my-1 shrink-0 bg-[var(--line-2)]"
+                data-workspace-user-project-action-separator="true"
+              />
+            ) : null}
+            {hasProjectActions ? (
+              <SelectGroup
+                className="gap-0.5 p-0"
+                data-workspace-user-project-action-group="true"
+              >
+                {effectiveApi?.selectDirectory ? (
+                  <SelectItem
+                    className={classNames?.item}
+                    value={linkExistingProjectOptionValue}
+                  >
+                    <span className="flex min-w-0 flex-1 items-center gap-2 pr-1">
+                      <LinkIcon aria-hidden size={15} />
+                      <span className="truncate">
+                        {resolvedLabels.linkExistingProject}
+                      </span>
+                    </span>
+                  </SelectItem>
+                ) : null}
+                {showCreateProjectAction ? (
+                  <SelectItem
+                    className={classNames?.item}
+                    value={addProjectOptionValue}
+                  >
+                    <span className="flex min-w-0 flex-1 items-center gap-2 pr-1">
+                      {renderAddProjectIcon?.() ?? (
+                        <NewWorkspaceLinedIcon
+                          aria-hidden
+                          data-workspace-user-project-add-icon="true"
+                          size={15}
+                        />
+                      )}
+                      <span className="truncate">
+                        {resolvedLabels.addProject}
+                      </span>
+                    </span>
+                  </SelectItem>
+                ) : null}
+                {showNoProjectAction ? (
+                  <SelectItem
+                    className={classNames?.item}
+                    value={noProjectOptionValue}
+                  >
+                    <span className="flex min-w-0 flex-1 items-center gap-2 pr-1">
+                      <NoWorkspaceLinedIcon
                         aria-hidden
-                        data-workspace-user-project-add-icon="true"
+                        data-agent-project-no-workspace-icon="true"
                         size={15}
                       />
-                    )}
-                    <span className="truncate">
-                      {resolvedLabels.addProject}
+                      <span className="truncate">
+                        {resolvedLabels.noProject}
+                      </span>
                     </span>
-                  </span>
-                </SelectItem>
-              ) : null}
-              {showNoProjectAction ? (
-                <SelectItem
-                  className={classNames?.item}
-                  value={noProjectOptionValue}
-                >
-                  <span className="flex min-w-0 flex-1 items-center gap-2 pr-1">
-                    <NoWorkspaceLinedIcon
-                      aria-hidden
-                      data-agent-project-no-workspace-icon="true"
-                      size={15}
-                    />
-                    <span className="truncate">{resolvedLabels.noProject}</span>
-                  </span>
-                </SelectItem>
-              ) : null}
-            </SelectGroup>
-          ) : null}
-        </SelectContent>
+                  </SelectItem>
+                ) : null}
+              </SelectGroup>
+            ) : null}
+          </SelectContent>
+        ) : null}
       </Select>
       {isProjectDialogOpen ? (
         <Dialog

--- a/tools/degradation-baseline/agent-gui.json
+++ b/tools/degradation-baseline/agent-gui.json
@@ -9,7 +9,7 @@
   "metrics": {
     "componentMemoOverages": {
       "packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx": 13,
-      "packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx": 10,
+      "packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx": 9,
       "packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx": 6,
       "packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerChrome.tsx": 8,
       "packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx": 6,


### PR DESCRIPTION
## Summary
- stabilize the new-conversation action and defer project menu content construction until the menu opens, reducing session-switch render fanout
- consolidate timeline geometry reads so each scroll synchronization phase reuses one layout snapshot
- add regression coverage for the closed project menu and timeline scroll, prepend, and observer behavior; tighten the AgentGUI degradation baseline

## Tests
- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=1 agent-gui/agentGuiNode/AgentComposerProjectMenu.spec.tsx agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx` (16 passed)
- `pnpm check:agent-gui-degradation`
- `pnpm check:changed -- --push-ready` (14 lanes passed)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->