### PR TITLE
fix(desktop): forward Tutti orchestration intensity

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -582,6 +582,7 @@ test("desktop agent activity adapter creates, projects, and revision-updates the
   const updated = await adapter.updateTuttiModeActivation({
     agentSessionId: "agent-session-1",
     expectedRevision: 1,
+    orchestrationIntensity: 25,
     signal: controller.signal,
     source: "badge_remove",
     status: "inactive",
@@ -591,6 +592,7 @@ test("desktop agent activity adapter creates, projects, and revision-updates the
     agentSessionId: "agent-session-1",
     request: {
       expectedRevision: 1,
+      orchestrationIntensity: 25,
       source: "badge_remove",
       status: "inactive"
     },

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -359,6 +359,9 @@ export function createDesktopAgentActivityAdapter({
             ...(input.expectedRevision === undefined
               ? {}
               : { expectedRevision: input.expectedRevision }),
+            ...(input.orchestrationIntensity === undefined
+              ? {}
+              : { orchestrationIntensity: input.orchestrationIntensity }),
             source: input.source,
             status: input.status
           },

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.test.ts
@@ -57,7 +57,7 @@ test("prompt command does not send when its required settings fail", async () =>
   assert.equal(sent, false);
 });
 
-test("Tutti mode update command preserves the canonical CAS revision", async () => {
+test("Tutti mode update command preserves CAS revision and zero intensity", async () => {
   const controller = new AbortController();
   let received: unknown;
   await executeWorkspaceAgentTuttiModeUpdateCommand(
@@ -71,8 +71,9 @@ test("Tutti mode update command preserves the canonical CAS revision", async () 
       agentSessionId: "session-1",
       commandId: "tutti-1",
       expectedRevision: 3,
-      source: "badge_remove",
-      status: "inactive",
+      orchestrationIntensity: 0,
+      source: "slash_command",
+      status: "active",
       type: "tuttiMode/update",
       workspaceId: "workspace-1"
     } satisfies TuttiModeActivationUpdateCommand,
@@ -82,9 +83,10 @@ test("Tutti mode update command preserves the canonical CAS revision", async () 
   assert.deepEqual(received, {
     agentSessionId: "session-1",
     expectedRevision: 3,
+    orchestrationIntensity: 0,
     signal: controller.signal,
-    source: "badge_remove",
-    status: "inactive",
+    source: "slash_command",
+    status: "active",
     workspaceId: "workspace-1"
   });
 });

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
@@ -101,6 +101,9 @@ export function executeWorkspaceAgentTuttiModeUpdateCommand(
     ...(command.expectedRevision === undefined
       ? {}
       : { expectedRevision: command.expectedRevision }),
+    ...(command.orchestrationIntensity === undefined
+      ? {}
+      : { orchestrationIntensity: command.orchestrationIntensity }),
     signal,
     source: command.source,
     status: command.status,

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -472,6 +472,9 @@ from the engine-projected orchestration intensity. Cancel discards the draft;
 Confirm sends the selected intensity through the existing Tutti Mode activation
 command. Turning Tutti Mode off remains a separate adjacent action, and both
 controls stay disabled while an activation update is unresolved.
+The Desktop command host and HTTP adapter must preserve both the optimistic
+CAS revision and the optional orchestration intensity; dropping either field
+turns a valid UI intent into a stale or semantically mismatched response.
 
 The intensity popup uses one interactive Cost-to-Balance-to-Powerful gradient
 slider and projects its local draft into equal tendency bands while it moves.


### PR DESCRIPTION
## What

- forward `orchestrationIntensity` from the AgentSessionEngine command through the Desktop command host
- include the intensity in the generated tuttid update request
- cover both adapter forwarding and the `0` intensity boundary with regression tests
- document that Desktop must preserve both the CAS revision and orchestration intensity

## Root cause

The Tutti intensity popup dispatched the requested value correctly, but two Desktop integration boundaries dropped `orchestrationIntensity`. The daemon therefore received only the unchanged `active` status and returned the previous activation revision. The frontend engine correctly rejected that semantically mismatched response and surfaced “Tutti mode couldn't be updated.”

The exported log bundle supports this chain: the session was created with Tutti active at intensity 100, no later activation revision was persisted after the slider change, and the exported session still reported revision 1 / intensity 100.

## Impact

Existing-session intensity changes now reach tuttid and produce the expected durable activation revision. Status-only activation/deactivation behavior and the HTTP contract are unchanged.

## Validation

- targeted Desktop tests: 35 passed
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop build`
- renderer CSS contracts
- `pnpm check:changed --tail-lines 120` (16 lanes)
- pre-push `pnpm check:changed -- --push-ready` (17 lanes)
- staged formatting, lint, UI, renderer, and Agent GUI degradation gates

## Stack

This PR targets `codex/restore-tutti-badge-intensity-20260723` because the affected intensity UI is currently introduced by PR #1539. Retarget to `main` after #1539 merges.