### PR TITLE
fix(agent): cache extension version probes

### DIFF
--- a/docs/architecture/agent-extensions.md
+++ b/docs/architecture/agent-extensions.md
@@ -463,6 +463,15 @@ active installation remains available. If no verified installation exists,
 the source is not registered and `tuttid` logs one
 `agent_extension.reconcile_failed` record with a JSON payload.
 
+Agent Target catalog reads continue to verify the installed extension package
+and managed runtime integrity before reporting availability. Successful runtime
+version probes are reused only while the resolved executable fingerprint,
+version arguments, and constraint are unchanged. Concurrent reads share the
+same in-flight probe. Failed probes are not cached, so repairing or installing a
+runtime is visible on the next read. Runtime launch and setup keep their
+authoritative integrity checks and do not trust catalog availability as launch
+authorization.
+
 Composite session-pinned adapter cache keys, richer tool/event profiles, and
 removal of remaining built-in catalogs remain migration work. Composer
 discovery is not setup state and does not infer

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -16,7 +16,8 @@ Use the focused runtime index or open one area directly:
 
 - [Agent Providers And Setup](./agent-provider-setup.md): Provider discovery, installation, authentication, models, configuration, and runtime reachability.
   Includes extension command/Skill palette hydration failures.
-  Also covers focus-driven provider CLI scans and CPU spikes.
+  Also covers focus-driven provider CLI scans, repeated Extension Target version
+  probes, and CPU spikes.
 - [Agent Sessions And Lifecycle](./agent-session-lifecycle.md): Turn state, activation, planning-mode classification, Tutti workflow response contracts, loading, cancel, goal controls, restore, file-change undo, rail projection, realtime completion provenance, event updates, imports, and performance.
   Includes shared-device recovery that looks terminal while the host is still retrying.
 - [Agent Approvals And Child Sessions](./agent-approvals-subagents.md): Approval gates, plan exits, root/parent/child event attribution, child sessions, and Message Center.

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -47,6 +47,38 @@ provider-status-focus-refresh --all-process-time-profile` on macOS when a
   [desktopAgentProviderStatusService.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts)
   [agent-provider-status-performance-scenario.mjs](../../../tools/scripts/agent-provider-status-performance-scenario.mjs)
 
+### Loading Agent Targets repeatedly starts Extension CLIs
+
+- Symptom:
+  Opening a workspace, standalone Agent window, or Agent settings takes longer
+  as more Agent Extensions are enabled. Repeated `GET /v1/agent-targets`
+  requests start the same Extension CLI `--version` commands even though the
+  executables did not change.
+- Quick checks:
+  Time several authenticated `GET /v1/agent-targets` requests and correlate them
+  with short-lived Extension CLI processes. Compare the total request duration
+  with each configured discovery candidate's version command.
+- Root cause:
+  Extension Target availability resolved every runtime from scratch. Package
+  and executable validation are required, but the stable successful version
+  result was discarded after every request. Concurrent catalog consumers could
+  also run the same version command independently.
+- Fix:
+  Cache only successful version results by resolved executable fingerprint,
+  arguments, and version constraint, and coalesce concurrent probes. Keep failed
+  probes uncached. Continue package authority and managed-runtime integrity
+  checks on every resolution; catalog availability is not runtime launch
+  authorization.
+- Validation:
+  Resolve the same Extension runtime twice and assert one version subprocess.
+  Cover concurrent callers, a failed probe followed by recovery, and executable
+  replacement invalidation. Repeated `/v1/agent-targets` requests should retain
+  the same availability while no longer starting unchanged Extension CLIs.
+- References:
+  [agent-extensions.md](../../architecture/agent-extensions.md)
+  [manager.go](../../../services/tuttid/service/agentextension/manager.go)
+  [runtime_version_cache.go](../../../services/tuttid/service/agentextension/runtime_version_cache.go)
+
 ### An extension Agent is installed in the terminal but Tutti cannot detect it
 
 - Symptom:

--- a/services/tuttid/service/agentextension/managed_runtime.go
+++ b/services/tuttid/service/agentextension/managed_runtime.go
@@ -141,7 +141,7 @@ func (m *Manager) resolveInstalledManagedRuntime(
 		if artifact != nil {
 			identity = executableIdentity(fingerprint)
 		}
-		version, err := runtimeVersionWithIdentity(ctx, executable, candidate.Version.Args, candidate.Version.Constraint, identity)
+		version, err := m.runtimeVersionWithIdentity(ctx, executable, candidate.Version.Args, candidate.Version.Constraint, identity)
 		if err != nil {
 			if artifact != nil {
 				return RuntimeBinding{}, fmt.Errorf("%w: verified version probe failed: %v", ErrManagedRuntimeIntegrity, err)

--- a/services/tuttid/service/agentextension/managed_runtime_binary_test.go
+++ b/services/tuttid/service/agentextension/managed_runtime_binary_test.go
@@ -53,6 +53,34 @@ func TestResolveInstalledBinaryRejectsReplacementDuringVersionProbe(t *testing.T
 	}
 }
 
+func TestManagerRuntimeVersionWithIdentityReusesSuccessfulProbe(t *testing.T) {
+	manager, _, profile, sourceRoot, fingerprint := managedBinaryResolutionFixture(t, nil)
+	versionProbeLog := filepath.Join(t.TempDir(), "version-probes.log")
+	t.Setenv("TUTTI_TEST_MANAGED_BINARY_VERSION_LOG", versionProbeLog)
+	executable := filepath.Join(sourceRoot, "grok")
+	candidate := profile.Candidates[0]
+
+	for range 2 {
+		version, err := manager.runtimeVersionWithIdentity(
+			context.Background(),
+			executable,
+			candidate.Version.Args,
+			candidate.Version.Constraint,
+			executableIdentity(fingerprint),
+		)
+		if err != nil || version != "0.2.103" {
+			t.Fatalf("managed runtime version = %q, %v", version, err)
+		}
+	}
+	probes, err := os.ReadFile(versionProbeLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(probes), "probe\n"); got != 1 {
+		t.Fatalf("managed runtime version probes = %d, want 1", got)
+	}
+}
+
 func TestResolveInstalledBinaryRejectsSymlinkedActiveRoot(t *testing.T) {
 	manager, installation, profile, activeRoot, fingerprint := managedBinaryResolutionFixture(t, nil)
 	realRoot := activeRoot + ".real"

--- a/services/tuttid/service/agentextension/manager.go
+++ b/services/tuttid/service/agentextension/manager.go
@@ -40,6 +40,8 @@ type Manager struct {
 	Client            *http.Client
 	RuntimeResolver   runtimecmd.Resolver
 	reconcileMu       sync.Mutex
+	versionCacheOnce  sync.Once
+	runtimeVersions   *runtimeVersionCache
 }
 
 type Installation = agentextensionbiz.Installation
@@ -189,7 +191,7 @@ func (m *Manager) resolveRuntime(ctx context.Context, installationID, cwd string
 			if m.isManagedRuntimeExecutable(path) {
 				continue
 			}
-			version, err := runtimeVersionWithEnv(ctx, path, candidate.Version.Args, candidate.Version.Constraint, env)
+			version, err := m.runtimeVersionWithEnv(ctx, path, candidate.Version.Args, candidate.Version.Constraint, env)
 			if err != nil {
 				continue
 			}
@@ -668,6 +670,37 @@ func runtimeVersionWithEnv(ctx context.Context, executable string, args []string
 		return "", errors.New("runtime version is incompatible")
 	}
 	return version, nil
+}
+
+func (m *Manager) runtimeVersionWithEnv(
+	ctx context.Context,
+	executable string,
+	args []string,
+	constraint string,
+	env []string,
+) (string, error) {
+	return m.runtimeVersionCache().load(executable, args, constraint, func() (string, error) {
+		return runtimeVersionWithEnv(ctx, executable, args, constraint, env)
+	})
+}
+
+func (m *Manager) runtimeVersionWithIdentity(
+	ctx context.Context,
+	executable string,
+	args []string,
+	constraint string,
+	identity *agentruntime.ExecutableIdentity,
+) (string, error) {
+	return m.runtimeVersionCache().load(executable, args, constraint, func() (string, error) {
+		return runtimeVersionWithIdentity(ctx, executable, args, constraint, identity)
+	})
+}
+
+func (m *Manager) runtimeVersionCache() *runtimeVersionCache {
+	m.versionCacheOnce.Do(func() {
+		m.runtimeVersions = newRuntimeVersionCache()
+	})
+	return m.runtimeVersions
 }
 
 func runtimeVersionWithIdentity(

--- a/services/tuttid/service/agentextension/manager_test.go
+++ b/services/tuttid/service/agentextension/manager_test.go
@@ -251,7 +251,8 @@ func TestManagerResolveRuntimeUsesSignedUserSearchPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	executable := filepath.Join(binDir, "kimi")
-	if err := os.WriteFile(executable, []byte("#!/bin/sh\nprintf '0.28.0\\n'\n"), 0o700); err != nil {
+	versionProbeLog := filepath.Join(homeDir, "version-probes.log")
+	if err := os.WriteFile(executable, []byte("#!/bin/sh\nprintf 'probe\\n' >> \"$VERSION_PROBE_LOG\"\nprintf '0.28.0\\n'\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -262,7 +263,12 @@ func TestManagerResolveRuntimeUsesSignedUserSearchPath(t *testing.T) {
 	manager := Manager{
 		Installations: agentextensiondata.NewFileInstallationStore(t.TempDir()),
 		RuntimeResolver: runtimecmd.Resolver{
-			Environ: func() []string { return []string{"PATH=/usr/bin:/bin"} },
+			Environ: func() []string {
+				return []string{
+					"PATH=/usr/bin:/bin",
+					"VERSION_PROBE_LOG=" + versionProbeLog,
+				}
+			},
 			HomeDir: func() (string, error) { return homeDir, nil },
 		},
 	}
@@ -282,6 +288,16 @@ func TestManagerResolveRuntimeUsesSignedUserSearchPath(t *testing.T) {
 	}
 	if binding.Source != "local" || binding.Version != "0.28.0" || len(binding.Command) != 2 || binding.Command[0] != executable || binding.Command[1] != "acp" {
 		t.Fatalf("ResolveRuntimeForCWD() = %#v", binding)
+	}
+	if _, err := manager.ResolveRuntimeForCWD(context.Background(), installation.ID, t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	probes, err := os.ReadFile(versionProbeLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(probes), "probe\n"); got != 1 {
+		t.Fatalf("version probes = %d, want 1 across repeated runtime resolution", got)
 	}
 }
 

--- a/services/tuttid/service/agentextension/runtime_version_cache.go
+++ b/services/tuttid/service/agentextension/runtime_version_cache.go
@@ -1,0 +1,140 @@
+package agentextension
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+)
+
+type runtimeVersionExecutableFingerprint struct {
+	info         os.FileInfo
+	resolvedPath string
+}
+
+func readRuntimeVersionExecutableFingerprint(path string) (runtimeVersionExecutableFingerprint, bool) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return runtimeVersionExecutableFingerprint{}, false
+	}
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		resolvedPath = filepath.Clean(path)
+	}
+	info, err := os.Stat(resolvedPath)
+	if err != nil {
+		return runtimeVersionExecutableFingerprint{}, false
+	}
+	return runtimeVersionExecutableFingerprint{
+		info:         info,
+		resolvedPath: filepath.Clean(resolvedPath),
+	}, true
+}
+
+func sameRuntimeVersionExecutableFingerprint(
+	left runtimeVersionExecutableFingerprint,
+	right runtimeVersionExecutableFingerprint,
+) bool {
+	return left.resolvedPath == right.resolvedPath &&
+		left.info.Size() == right.info.Size() &&
+		left.info.ModTime().Equal(right.info.ModTime()) &&
+		os.SameFile(left.info, right.info)
+}
+
+type runtimeVersionCacheEntry struct {
+	fingerprint runtimeVersionExecutableFingerprint
+	version     string
+}
+
+type runtimeVersionCache struct {
+	mu      sync.RWMutex
+	entries map[string]runtimeVersionCacheEntry
+	group   singleflight.Group
+}
+
+func newRuntimeVersionCache() *runtimeVersionCache {
+	return &runtimeVersionCache{entries: make(map[string]runtimeVersionCacheEntry)}
+}
+
+func (c *runtimeVersionCache) load(
+	executable string,
+	args []string,
+	constraint string,
+	loader func() (string, error),
+) (string, error) {
+	if c == nil {
+		return loader()
+	}
+	key := runtimeVersionCacheKey(executable, args, constraint)
+	fingerprint, ok := readRuntimeVersionExecutableFingerprint(executable)
+	if !ok {
+		return loader()
+	}
+	if version, ok := c.get(key, fingerprint); ok {
+		return version, nil
+	}
+	flightKey := fmt.Sprintf(
+		"%s\x00%s\x00%d\x00%d",
+		key,
+		fingerprint.resolvedPath,
+		fingerprint.info.Size(),
+		fingerprint.info.ModTime().UnixNano(),
+	)
+	value, err, _ := c.group.Do(flightKey, func() (any, error) {
+		current, ok := readRuntimeVersionExecutableFingerprint(executable)
+		if !ok {
+			return loader()
+		}
+		if version, ok := c.get(key, current); ok {
+			return version, nil
+		}
+		version, err := loader()
+		if err != nil {
+			return "", err
+		}
+		after, ok := readRuntimeVersionExecutableFingerprint(executable)
+		if ok && sameRuntimeVersionExecutableFingerprint(current, after) {
+			c.set(key, after, version)
+		}
+		return version, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return value.(string), nil
+}
+
+func runtimeVersionCacheKey(executable string, args []string, constraint string) string {
+	return filepath.Clean(strings.TrimSpace(executable)) +
+		"\x00" + strings.Join(args, "\x00") +
+		"\x00" + strings.TrimSpace(constraint)
+}
+
+func (c *runtimeVersionCache) get(
+	key string,
+	fingerprint runtimeVersionExecutableFingerprint,
+) (string, bool) {
+	c.mu.RLock()
+	entry, found := c.entries[key]
+	c.mu.RUnlock()
+	if !found || !sameRuntimeVersionExecutableFingerprint(entry.fingerprint, fingerprint) {
+		return "", false
+	}
+	return entry.version, true
+}
+
+func (c *runtimeVersionCache) set(
+	key string,
+	fingerprint runtimeVersionExecutableFingerprint,
+	version string,
+) {
+	c.mu.Lock()
+	c.entries[key] = runtimeVersionCacheEntry{
+		fingerprint: fingerprint,
+		version:     version,
+	}
+	c.mu.Unlock()
+}

--- a/services/tuttid/service/agentextension/runtime_version_cache_test.go
+++ b/services/tuttid/service/agentextension/runtime_version_cache_test.go
@@ -1,0 +1,101 @@
+package agentextension
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestRuntimeVersionCacheCoalescesConcurrentSuccessfulLoads(t *testing.T) {
+	executable := filepath.Join(t.TempDir(), "agent-cli")
+	if err := os.WriteFile(executable, []byte("binary"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cache := newRuntimeVersionCache()
+	var loads atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	loader := func() (string, error) {
+		if loads.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return "1.2.3", nil
+	}
+
+	const callers = 20
+	var wait sync.WaitGroup
+	errs := make(chan error, callers)
+	wait.Add(callers)
+	for range callers {
+		go func() {
+			defer wait.Done()
+			version, err := cache.load(executable, []string{"--version"}, ">=1.0.0 <2.0.0", loader)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if version != "1.2.3" {
+				errs <- errors.New("unexpected cached version")
+			}
+		}()
+	}
+	<-started
+	close(release)
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+	if got := loads.Load(); got != 1 {
+		t.Fatalf("version loads = %d, want 1", got)
+	}
+}
+
+func TestRuntimeVersionCacheRetriesFailuresAndInvalidatesExecutableReplacement(t *testing.T) {
+	root := t.TempDir()
+	executable := filepath.Join(root, "agent-cli")
+	if err := os.WriteFile(executable, []byte("first"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cache := newRuntimeVersionCache()
+	loads := 0
+	loader := func() (string, error) {
+		loads++
+		if loads == 1 {
+			return "", errors.New("version probe failed")
+		}
+		return "1.2.3", nil
+	}
+
+	if _, err := cache.load(executable, []string{"--version"}, ">=1.0.0 <2.0.0", loader); err == nil {
+		t.Fatal("first load error = nil")
+	}
+	for range 2 {
+		version, err := cache.load(executable, []string{"--version"}, ">=1.0.0 <2.0.0", loader)
+		if err != nil || version != "1.2.3" {
+			t.Fatalf("cached load = %q, %v", version, err)
+		}
+	}
+	if loads != 2 {
+		t.Fatalf("version loads = %d, want 2 after failure recovery", loads)
+	}
+
+	replacement := filepath.Join(root, "replacement")
+	if err := os.WriteFile(replacement, []byte("replacement binary"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(replacement, executable); err != nil {
+		t.Fatal(err)
+	}
+	version, err := cache.load(executable, []string{"--version"}, ">=1.0.0 <2.0.0", loader)
+	if err != nil || version != "1.2.3" {
+		t.Fatalf("load after replacement = %q, %v", version, err)
+	}
+	if loads != 3 {
+		t.Fatalf("version loads = %d, want 3 after executable replacement", loads)
+	}
+}

--- a/services/tuttid/service/agentextension/setup_test.go
+++ b/services/tuttid/service/agentextension/setup_test.go
@@ -103,6 +103,19 @@ func TestManagedBinaryVersionFixture(_ *testing.T) {
 	if os.Getenv("TUTTI_TEST_MANAGED_BINARY_VERSION") != "1" {
 		return
 	}
+	if logPath := os.Getenv("TUTTI_TEST_MANAGED_BINARY_VERSION_LOG"); logPath != "" {
+		file, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := file.WriteString("probe\n"); err != nil {
+			_ = file.Close()
+			panic(err)
+		}
+		if err := file.Close(); err != nil {
+			panic(err)
+		}
+	}
 	fmt.Println("0.2.103")
 	if os.Getenv("TUTTI_TEST_MANAGED_BINARY_REPLACE") == "1" {
 		path, err := os.Executable()


### PR DESCRIPTION
## Summary

- Cache successful local and managed Agent Extension version probes while the executable is unchanged
- Coalesce concurrent identical probes, retry failures, and invalidate the cache after binary replacement
- Document the runtime semantics and the repeated Agent Targets loading symptom

## Tests

- `go test ./service/agentextension`
- focused cache and runtime tests with `-count=10`
- `pnpm check:changed -- --push-ready` (6 lanes passed)

## Notes

- No Extension repository changes are required
- Availability failures remain uncached
- Managed runtime integrity checks remain authoritative

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->