### PR TITLE
fix(agent-gui): fail closed Tutti Mode without host opt-in

### DIFF
--- a/.changeset/agent-gui-tutti-mode-fail-closed.md
+++ b/.changeset/agent-gui-tutti-mode-fail-closed.md
@@ -1,0 +1,8 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Fail closed on Tutti Mode UI unless the host sets
+`capabilityMenuState.tuttiMode.enabled` to true, so shared AgentGUI hosts do not
+leak the hero toggle, badge activation, or `/tutti` when the lab capability is
+omitted or disabled.

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -223,7 +223,10 @@
   `initialTuttiModeActivation` or its Tutti `capabilityRefs` even when the
   upstream type carries them. Reading mutable draft state after submit can also
   lose the exact composer selection. Separately, allowing `/tutti` while the lab
-  flag is disabled produces renderer state that the daemon must reject.
+  flag is disabled produces renderer state that the daemon must reject. AgentGUI
+  must therefore treat `capabilityMenuState.tuttiMode.enabled === true` as the
+  sole opt-in for the hero toggle, badge activation, and `/tutti` (omit or
+  `enabled: false` fails closed).
 - **Fix:** Snapshot active/inactive state and orchestration intensity atomically
   with the composer submit. Preserve both activation and capability provenance
   through every create projection, and gate slash actions with the same host

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -180,6 +180,29 @@ The supported stable IDs are `meet-tutti`, `task-breakdown`, `quality-review`,
 `agent-interaction`, and `import-session`. Omitting `disabled` (or passing an
 empty array) renders all five entries.
 
+## Tutti Mode capability
+
+Tutti Mode UI (empty-hero toggle, composer badge activation, `/tutti`) is a
+host-gated product capability under
+`hostCapabilities.capabilityMenuState.tuttiMode.enabled`.
+
+Hosts must set `enabled: true` to show those controls. Omitting `tuttiMode` or
+setting `enabled: false` fails closed — the same rule as other unsupported host
+capabilities. External hosts that share AgentGUI for Codex/Claude/VM sessions
+should keep Tutti Mode disabled unless they intentionally productize it, and
+should also hide Tutti branding home chips via `disabled` (for example
+`meet-tutti`).
+
+```tsx
+<AgentGUI
+  disabled={["meet-tutti", "import-session"]}
+  hostCapabilities={{
+    capabilityMenuState: { tuttiMode: { enabled: false } }
+  }}
+  {...props}
+/>
+```
+
 ## Agent Directory
 
 `AgentGUI` requires the host's `/agents` projection through its `agents` prop.

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -405,7 +405,10 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     promptImagesSupported: canUploadAttachment && promptImagesSupported,
     availableSkills,
     composerSettings,
-    tuttiModeSupported: capabilityMenuState?.tuttiMode?.enabled !== false,
+    // Host-gated product capability: omit or enabled:false must hide Tutti Mode
+    // entries (hero toggle, badge activation, /tutti). Fail closed like other
+    // unsupported host capabilities — do not treat a missing flag as enabled.
+    tuttiModeSupported: capabilityMenuState?.tuttiMode?.enabled === true,
     capabilityControlsReadOnly,
     onDraftContentChange,
     onSettingsChange,

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.composition.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.composition.spec.ts
@@ -99,7 +99,7 @@ describe("ComposerFooter trigger composition", () => {
 
   it("uses the host Tutti feature gate for typed slash-command submits", () => {
     expect(composerSource).toContain(
-      "tuttiModeSupported: capabilityMenuState?.tuttiMode?.enabled !== false"
+      "tuttiModeSupported: capabilityMenuState?.tuttiMode?.enabled === true"
     );
     expect(slashActionsSource).toContain("tuttiSupported: tuttiModeSupported");
     expect(slashActionsSource).not.toContain("tuttiSupported: true");

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.ts
@@ -94,7 +94,7 @@ export function useComposerPaletteCatalog({
         planSupported: composerSettings.supportsPlanMode,
         browserSupported: Boolean(composerSettings.supportsBrowser),
         computerSupported: Boolean(composerSettings.supportsComputerUse),
-        tuttiSupported: capabilityMenuState?.tuttiMode?.enabled !== false
+        tuttiSupported: capabilityMenuState?.tuttiMode?.enabled === true
       }).filter(
         (command) =>
           goalSupported || command.name.trim().toLowerCase() !== "goal"

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -468,9 +468,17 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       onProjectPathChange: updateSelectedProjectPath,
       onSettingsChange: updateComposerSettings,
       onRetryComposerOptions: retryComposerOptions,
-      onTuttiModeChange: tuttiPlan.setTuttiModeActiveAndSettleReview,
+      // Only wire Tutti Mode callbacks when the host explicitly enables the
+      // capability. Empty hero toggle keys off callback presence; slash/badge
+      // use capabilityMenuState.tuttiMode.enabled === true (fail closed).
+      onTuttiModeChange:
+        capabilityMenuState?.tuttiMode?.enabled === true
+          ? tuttiPlan.setTuttiModeActiveAndSettleReview
+          : undefined,
       onTuttiModeOrchestrationIntensityChange:
-        setTuttiModeOrchestrationIntensity,
+        capabilityMenuState?.tuttiMode?.enabled === true
+          ? setTuttiModeOrchestrationIntensity
+          : undefined,
       onPlanIssueBudgetPresetChange: updatePlanIssueBudgetPreset,
       onSubmit: tuttiPlan.submitPromptOrDecidePlan,
       onSubmitEmpty: tuttiPlan.planReviewSendActive

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
@@ -344,7 +344,11 @@ export function AgentGUIEmptyHeroTuttiToggle({
 }): React.JSX.Element | null {
   const switchId = useId();
   const onTuttiModeChange = composerProps.onTuttiModeChange;
-  if (!onTuttiModeChange) {
+  // Same host gate as /tutti and the composer badge: omit or enabled:false
+  // must not show Tutti Mode chrome on Codex/VM or other shared AgentGUI hosts.
+  const tuttiModeEnabled =
+    composerProps.capabilityMenuState?.tuttiMode?.enabled === true;
+  if (!onTuttiModeChange || !tuttiModeEnabled) {
     return null;
   }
   const active = composerProps.tuttiModeActive === true;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tuttiToggle.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tuttiToggle.spec.tsx
@@ -11,6 +11,7 @@ function composerProps(
     tuttiModeActive: false,
     tuttiModeUpdating: false,
     onTuttiModeChange: vi.fn(),
+    capabilityMenuState: { tuttiMode: { enabled: true } },
     labels: {
       tuttiModeLabel: "Tutti mode",
       tuttiModeDescription: "Plan first, then orchestrate agents"
@@ -59,6 +60,30 @@ describe("AgentGUIEmptyHeroTuttiToggle", () => {
     render(
       <AgentGUIEmptyHeroTuttiToggle
         composerProps={composerProps({ onTuttiModeChange: undefined })}
+      />
+    );
+    expect(
+      screen.queryByTestId("agent-gui-hero-tutti-toggle")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the host Tutti Mode capability is disabled", () => {
+    render(
+      <AgentGUIEmptyHeroTuttiToggle
+        composerProps={composerProps({
+          capabilityMenuState: { tuttiMode: { enabled: false } }
+        })}
+      />
+    );
+    expect(
+      screen.queryByTestId("agent-gui-hero-tutti-toggle")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the host omits the Tutti Mode capability", () => {
+    render(
+      <AgentGUIEmptyHeroTuttiToggle
+        composerProps={composerProps({ capabilityMenuState: undefined })}
       />
     );
     expect(


### PR DESCRIPTION
## Summary
- Treat `capabilityMenuState.tuttiMode.enabled === true` as the only opt-in for Tutti Mode UI (hero toggle, badge activation, `/tutti`), matching other unsupported host capabilities that fail closed.
- Stop wiring `onTuttiModeChange` from `AgentGUIDetailPane` when the host omits or disables the capability, so Codex/VM and other shared AgentGUI hosts no longer leak Tutti Mode chrome.
- Document the host contract in `@tutti-os/agent-gui` README and add a patch changeset.

## Test plan
- [x] `pnpm test` in `packages/agent/gui` covering `AgentGUIEmptyState.tuttiToggle.spec.tsx` and `ComposerFooter.composition.spec.ts`
- [x] Pre-push `check:changed` passed
- [ ] With Tutti desktop `lab.tuttiMode` off: empty Codex session shows no Tutti Mode toggle / `/tutti`
- [ ] With `lab.tuttiMode` on: hero toggle and `/tutti` still work
- [ ] TSH (or any host with `tuttiMode.enabled: false`) no longer shows the Tutti Mode hero row after upgrading this cohort


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->