### PR TITLE
feat(ui-system): add shared avatar primitive

### DIFF
--- a/apps/ui-storyboard/src/App.tsx
+++ b/apps/ui-storyboard/src/App.tsx
@@ -1,4 +1,5 @@
 import {
+  Avatar,
   Badge,
   BareIconButton,
   Button,
@@ -127,6 +128,11 @@ const storyboardDarkThemeOverrideCss = `
   border-color: var(--border-1) !important;
 }
 `;
+
+const avatarSampleImageUrl = new URL(
+  "../../../docs/assets/tutti-logo.png",
+  import.meta.url
+).href;
 
 const {
   CheckIcon,
@@ -304,6 +310,7 @@ const buttonComponent = uiSystemMetadata.components.find(
 
 const sections = [
   ...foundationNavigationSections,
+  ...componentSection("avatar", "Avatar", "身份图片、字母与加载回退"),
   ...componentSection("badge", "Badge", "状态标签与紧凑元信息"),
   ...componentSection("button", "Button", "按钮层级、尺寸与状态"),
   {
@@ -1560,6 +1567,104 @@ function BadgeStoryboard() {
           </div>
         </ExampleCard>
       </div>
+    </DocsSection>
+  );
+}
+
+function AvatarStoryboard() {
+  if (!hasStoryboard("Avatar")) {
+    return null;
+  }
+
+  const states = [
+    {
+      description: "Local raster image",
+      label: "Image",
+      node: (
+        <Avatar label="Tutti" size="lg" src={avatarSampleImageUrl}>
+          <StatusDot
+            className="absolute right-0 bottom-0 ring-2 ring-background"
+            tone="green"
+          />
+        </Avatar>
+      )
+    },
+    {
+      description: "Label-derived fallback",
+      label: "Initial",
+      node: <Avatar label="Tutti" size="lg" />
+    },
+    {
+      description: "Intentionally blank",
+      label: "Empty",
+      node: <Avatar fallback="empty" label="Private identity" size="lg" />
+    },
+    {
+      description: "Busy placeholder",
+      label: "Loading",
+      node: <Avatar label="Loading identity" loading size="lg" />
+    },
+    {
+      description: "Broken image to initial",
+      label: "Error",
+      node: (
+        <Avatar
+          initial="B"
+          label="Broken image"
+          size="lg"
+          src="/__missing-avatar-image__.png"
+        />
+      )
+    }
+  ];
+  const sizes = [
+    { label: "xs", size: "xs" as const },
+    { label: "sm", size: "sm" as const },
+    { label: "md", size: "md" as const },
+    { label: "lg", size: "lg" as const },
+    { label: "28px", size: 28 }
+  ];
+
+  return (
+    <DocsSection
+      id="avatar"
+      title="Avatar"
+      description="统一身份图片、字母、空白、加载和坏图回退"
+      componentId={metadataFor("Avatar")?.id}
+    >
+      <ExampleCard
+        title="Identity States"
+        description="真实图片和所有公开回退状态"
+      >
+        <div className="flex flex-wrap gap-5">
+          {states.map((state) => (
+            <div
+              className="grid min-w-20 justify-items-center gap-2 text-center"
+              key={state.label}
+            >
+              {state.node}
+              <div className="grid gap-0.5">
+                <span className="text-[13px] font-medium text-[var(--text-primary)]">
+                  {state.label}
+                </span>
+                <span className="text-[11px] text-[var(--text-secondary)]">
+                  {state.description}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-5 flex flex-wrap items-end gap-4 border-t border-[var(--border-1)] pt-5">
+          {sizes.map(({ label, size }) => (
+            <div className="grid justify-items-center gap-2" key={label}>
+              <Avatar label={label} size={size} />
+              <code className="font-mono text-[11px] text-[var(--text-secondary)]">
+                {label}
+              </code>
+            </div>
+          ))}
+        </div>
+      </ExampleCard>
     </DocsSection>
   );
 }
@@ -3953,6 +4058,7 @@ export function App() {
               description={copy.baseLayerDescription}
             />
           ) : null}
+          <AvatarStoryboard />
           <BadgeStoryboard />
           <ButtonStoryboard />
           <CheckboxStoryboard />

--- a/packages/ui/system/src/components/avatar/avatar.spec.tsx
+++ b/packages/ui/system/src/components/avatar/avatar.spec.tsx
@@ -1,0 +1,264 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Avatar } from "./avatar";
+
+class MockImage extends EventTarget {
+  complete = false;
+  naturalWidth = 0;
+  private source = "";
+
+  get src(): string {
+    return this.source;
+  }
+
+  set src(value: string) {
+    if (value !== this.source) {
+      this.complete = false;
+      this.naturalWidth = 0;
+      this.source = value;
+    }
+  }
+}
+
+let preloadedImages: MockImage[] = [];
+
+function finishPreload(status: "error" | "loaded"): void {
+  const image = preloadedImages.at(-1);
+  if (!image) {
+    throw new Error("Expected Radix Avatar to create an image preloader");
+  }
+
+  if (status === "loaded") {
+    image.complete = true;
+    image.naturalWidth = 40;
+  }
+
+  act(() => {
+    image.dispatchEvent(new Event(status === "loaded" ? "load" : "error"));
+  });
+}
+
+describe("Avatar", () => {
+  beforeEach(() => {
+    preloadedImages = [];
+    vi.stubGlobal(
+      "Image",
+      class extends MockImage {
+        constructor() {
+          super();
+          preloadedImages.push(this);
+        }
+      }
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders a decorative image and forwards root and image props", () => {
+    const onLoad = vi.fn();
+
+    render(
+      <Avatar
+        aria-label="Jun Sun"
+        data-testid="avatar"
+        imageClassName="object-contain"
+        imageProps={{ "data-testid": "avatar-image", onLoad }}
+        label="Jun Sun"
+        src="https://example.test/avatar.png"
+        surfaceClassName="bg-muted"
+      />
+    );
+
+    expect(screen.getByTestId("avatar")).toHaveAttribute(
+      "data-avatar-state",
+      "loading"
+    );
+    expect(screen.queryByTestId("avatar-image")).not.toBeInTheDocument();
+
+    finishPreload("loaded");
+    const image = screen.getByTestId("avatar-image");
+    fireEvent.load(image);
+
+    expect(screen.getByTestId("avatar")).toHaveAttribute(
+      "data-avatar-state",
+      "image"
+    );
+    expect(screen.getByTestId("avatar")).toHaveAttribute(
+      "aria-label",
+      "Jun Sun"
+    );
+    expect(image).toHaveAttribute("alt", "");
+    expect(image).toHaveClass("object-contain");
+    expect(onLoad).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to the requested initial when an image fails", () => {
+    render(
+      <Avatar
+        data-testid="avatar"
+        fallbackColor="rgb(10, 20, 30)"
+        imageProps={{ "data-testid": "avatar-image" }}
+        initial="j"
+        label="Jun Sun"
+        size="sm"
+        src="https://example.test/avatar.png"
+      />
+    );
+
+    finishPreload("error");
+
+    expect(screen.getByTestId("avatar")).toHaveAttribute(
+      "data-avatar-state",
+      "initial"
+    );
+    expect(screen.getByTestId("avatar")).toHaveTextContent("J");
+    expect(
+      screen.getByTestId("avatar").querySelector('[data-slot="avatar-surface"]')
+    ).toHaveStyle({ backgroundColor: "rgb(10, 20, 30)" });
+  });
+
+  it("does not show the initial while an image is loading", () => {
+    render(
+      <Avatar
+        data-testid="avatar"
+        label="Jun Sun"
+        src="https://example.test/avatar.png"
+      />
+    );
+
+    expect(screen.getByTestId("avatar")).toHaveAttribute(
+      "data-avatar-state",
+      "loading"
+    );
+    expect(screen.getByTestId("avatar")).not.toHaveTextContent("J");
+    expect(
+      screen.getByTestId("avatar").querySelector('[data-slot="avatar-surface"]')
+    ).toHaveClass("bg-transparent");
+
+    finishPreload("error");
+    expect(screen.getByTestId("avatar")).toHaveTextContent("J");
+  });
+
+  it("falls back when the rendered image fails after preloading", () => {
+    const onError = vi.fn();
+
+    render(
+      <Avatar
+        data-testid="avatar"
+        imageProps={{ "data-testid": "avatar-image", onError }}
+        label="Jun Sun"
+        src="https://example.test/avatar.png"
+      />
+    );
+
+    finishPreload("loaded");
+    fireEvent.error(screen.getByTestId("avatar-image"));
+
+    expect(screen.getByTestId("avatar")).toHaveAttribute(
+      "data-avatar-state",
+      "initial"
+    );
+    expect(screen.getByTestId("avatar")).toHaveTextContent("J");
+    expect(screen.queryByTestId("avatar-image")).not.toBeInTheDocument();
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
+  it("supports an intentionally empty fallback and numeric sizing", () => {
+    render(
+      <Avatar
+        data-testid="avatar"
+        fallback="empty"
+        fallbackColor="red"
+        label="Private profile"
+        size={18}
+      />
+    );
+
+    expect(screen.getByTestId("avatar")).toHaveAttribute(
+      "data-avatar-state",
+      "empty"
+    );
+    expect(screen.getByTestId("avatar")).toHaveStyle({
+      height: "18px",
+      width: "18px"
+    });
+    expect(screen.getByTestId("avatar")).toHaveTextContent("");
+  });
+
+  it("renders a loading surface without an image or initial", () => {
+    render(
+      <Avatar
+        data-testid="avatar"
+        label="Jun Sun"
+        loading
+        src="https://example.test/avatar.png"
+      />
+    );
+
+    expect(screen.getByTestId("avatar")).toHaveAttribute(
+      "data-avatar-state",
+      "loading"
+    );
+    expect(screen.getByTestId("avatar")).toHaveTextContent("");
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("avatar").querySelector('[data-slot="avatar-surface"]')
+    ).toHaveClass("animate-pulse", "motion-reduce:animate-none");
+  });
+
+  it("retries a failed URL after the source changes away and back", () => {
+    const { rerender } = render(
+      <Avatar
+        imageProps={{ "data-testid": "avatar-image" }}
+        label="Jun Sun"
+        src="https://example.test/a.png"
+      />
+    );
+
+    finishPreload("error");
+    rerender(
+      <Avatar
+        imageProps={{ "data-testid": "avatar-image" }}
+        label="Jun Sun"
+        src="https://example.test/b.png"
+      />
+    );
+    finishPreload("loaded");
+    rerender(
+      <Avatar
+        imageProps={{ "data-testid": "avatar-image" }}
+        label="Jun Sun"
+        src="https://example.test/a.png"
+      />
+    );
+    finishPreload("loaded");
+
+    expect(screen.getByTestId("avatar-image")).toHaveAttribute(
+      "src",
+      "https://example.test/a.png"
+    );
+  });
+
+  it("renders overlays outside the clipped image surface", () => {
+    render(
+      <Avatar data-testid="avatar" label="Alice">
+        <span data-testid="badge">online</span>
+      </Avatar>
+    );
+
+    expect(screen.getByTestId("avatar")).toContainElement(
+      screen.getByTestId("badge")
+    );
+  });
+
+  it("uses the first Unicode character and a question mark for blank labels", () => {
+    const { rerender } = render(<Avatar data-testid="avatar" label="阿丽塔" />);
+    expect(screen.getByTestId("avatar")).toHaveTextContent("阿");
+
+    rerender(<Avatar data-testid="avatar" label="" />);
+    expect(screen.getByTestId("avatar")).toHaveTextContent("?");
+  });
+});

--- a/packages/ui/system/src/components/avatar/avatar.tsx
+++ b/packages/ui/system/src/components/avatar/avatar.tsx
@@ -1,0 +1,168 @@
+import { Avatar as AvatarPrimitive } from "radix-ui";
+import {
+  useState,
+  type ComponentProps,
+  type ComponentPropsWithoutRef,
+  type ReactNode
+} from "react";
+
+import { cn } from "#lib/utils";
+
+type AvatarFallback = "initial" | "empty";
+type AvatarSize = "xs" | "sm" | "md" | "lg" | number;
+type AvatarImageStatus = Parameters<
+  NonNullable<
+    ComponentPropsWithoutRef<
+      typeof AvatarPrimitive.Image
+    >["onLoadingStatusChange"]
+  >
+>[0];
+type DataAttributes = {
+  [key: `data-${string}`]: boolean | number | string | undefined;
+};
+
+interface AvatarProps extends Omit<
+  ComponentProps<typeof AvatarPrimitive.Root>,
+  "asChild" | "children"
+> {
+  children?: ReactNode;
+  fallback?: AvatarFallback;
+  fallbackColor?: string;
+  imageClassName?: string;
+  imageProps?: Omit<
+    ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>,
+    "alt" | "className" | "src"
+  > &
+    DataAttributes;
+  initial?: string;
+  label: string;
+  loading?: boolean;
+  size?: AvatarSize;
+  src?: string | null;
+  surfaceClassName?: string;
+}
+
+const sizeClassNames: Record<Exclude<AvatarSize, number>, string> = {
+  xs: "size-4",
+  sm: "size-6",
+  md: "size-8",
+  lg: "size-10"
+};
+
+function avatarInitial(label: string, initial?: string): string {
+  const value = initial?.trim() || label.trim();
+  return Array.from(value)[0]?.toLocaleUpperCase() || "?";
+}
+
+function Avatar({
+  children,
+  className,
+  fallback = "initial",
+  fallbackColor,
+  imageClassName,
+  imageProps,
+  initial,
+  label,
+  loading = false,
+  size = "md",
+  src,
+  style,
+  surfaceClassName,
+  ...rootProps
+}: AvatarProps): React.JSX.Element {
+  const normalizedSrc = src?.trim() ?? "";
+  const effectiveImageSrc = loading ? "" : normalizedSrc;
+  const [imageState, setImageState] = useState<{
+    src: string;
+    status: AvatarImageStatus;
+  }>({ src: "", status: "idle" });
+  const imageStatus =
+    imageState.src === effectiveImageSrc
+      ? imageState.status
+      : effectiveImageSrc
+        ? "loading"
+        : "error";
+  const showImage = imageStatus === "loaded" && effectiveImageSrc.length > 0;
+  const imagePending =
+    effectiveImageSrc.length > 0 &&
+    (imageStatus === "loading" || imageStatus === "idle");
+  const imageSrcForPrimitive =
+    imageStatus === "error" ? undefined : effectiveImageSrc || undefined;
+  const avatarState = loading
+    ? "loading"
+    : effectiveImageSrc.length === 0
+      ? fallback
+      : imageStatus === "loading" || imageStatus === "idle"
+        ? "loading"
+        : showImage
+          ? "image"
+          : fallback;
+  const numericSizeStyle =
+    typeof size === "number"
+      ? { height: `${size}px`, width: `${size}px`, ...style }
+      : style;
+
+  return (
+    <AvatarPrimitive.Root
+      {...rootProps}
+      className={cn(
+        "relative inline-grid shrink-0 place-items-center rounded-full align-middle",
+        typeof size === "number" ? undefined : sizeClassNames[size],
+        className
+      )}
+      data-avatar-state={avatarState}
+      data-slot="avatar"
+      style={numericSizeStyle}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "grid size-full place-items-center overflow-hidden rounded-[inherit]",
+          loading
+            ? "animate-pulse bg-[var(--transparency-block)] motion-reduce:animate-none"
+            : fallback === "empty" || imagePending
+              ? "bg-transparent"
+              : "bg-[var(--text-primary)] font-semibold leading-none text-[var(--text-inverted)]",
+          surfaceClassName
+        )}
+        data-slot="avatar-surface"
+        style={
+          fallback === "initial" &&
+          fallbackColor &&
+          !showImage &&
+          !loading &&
+          !imagePending
+            ? { backgroundColor: fallbackColor }
+            : undefined
+        }
+      >
+        <AvatarPrimitive.Image
+          {...imageProps}
+          alt=""
+          className={cn(
+            "block size-full max-w-none object-cover",
+            imageClassName
+          )}
+          src={imageSrcForPrimitive}
+          onError={(event) => {
+            setImageState({ src: effectiveImageSrc, status: "error" });
+            imageProps?.onError?.(event);
+          }}
+          onLoadingStatusChange={(status) => {
+            setImageState({ src: effectiveImageSrc, status });
+            imageProps?.onLoadingStatusChange?.(status);
+          }}
+        />
+        <AvatarPrimitive.Fallback>
+          {loading || fallback === "empty" || imagePending
+            ? null
+            : avatarInitial(label, initial)}
+        </AvatarPrimitive.Fallback>
+      </span>
+      {children}
+    </AvatarPrimitive.Root>
+  );
+}
+
+export { Avatar };
+export type { AvatarProps };

--- a/packages/ui/system/src/components/avatar/index.tsx
+++ b/packages/ui/system/src/components/avatar/index.tsx
@@ -1,0 +1,1 @@
+export * from "./avatar";

--- a/packages/ui/system/src/components/index.ts
+++ b/packages/ui/system/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from "./avatar";
 export * from "./badge";
 export * from "./bare-icon-button";
 export * from "./button";

--- a/packages/ui/system/src/metadata/components.json
+++ b/packages/ui/system/src/metadata/components.json
@@ -95,6 +95,28 @@
       "migrationHints": []
     },
     {
+      "id": "avatar",
+      "layer": "base",
+      "name": "Avatar",
+      "export": "Avatar",
+      "from": "@tutti-os/ui-system/components",
+      "category": "primitive",
+      "status": "stable",
+      "source": "src/components/avatar/index.tsx",
+      "description": "High-level identity image primitive with initial, empty, loading, and broken-image fallback states.",
+      "propsType": "AvatarProps",
+      "useCases": [
+        "People and account identity",
+        "Agent identity",
+        "Compact image surfaces with caller-owned overlays"
+      ],
+      "migrationHints": [
+        "Pass a stable label even when src is available so broken images have a meaningful fallback.",
+        "Use children for caller-owned presence badges and other overlays."
+      ],
+      "storyboard": true
+    },
+    {
       "id": "badge",
       "layer": "base",
       "name": "Badge",

--- a/packages/ui/system/ui-system.md
+++ b/packages/ui/system/ui-system.md
@@ -49,6 +49,18 @@ recorded in the package `NOTICE`. Update that provenance whenever registry
 source is refreshed. Storyboard coverage is the visual inventory for enabled,
 disabled, keyboard-focus, and overlay states.
 
+## Avatar foundation
+
+`Avatar` is the single high-level identity-image primitive. It owns decorative
+image loading, broken-image fallback, initial or empty fallback modes, loading
+presentation, named or numeric sizing, and a caller-owned overlay slot through
+`children`. Consumers own identity resolution, image URLs, labels, fallback
+colors, presence semantics, and overlay content. The underlying Radix/shadcn
+parts are intentionally not public. `fallbackColor` is the narrow exception for
+caller-owned dynamic identity data; component defaults still use semantic
+tokens. Initial fallback content appears only when the image URL is absent or
+the image fails, never while a valid image URL is still loading.
+
 ## Current Package Role
 
 `@tutti-os/ui-system` is the single source of truth for:


### PR DESCRIPTION
## What changed

- Add one shared Avatar primitive for image, loading, failed-image, and letter fallback states.
- Add component metadata, storyboard coverage, docs, and focused tests.
- Keep fallback colors caller-owned so products can preserve deterministic identity colors.

## Why

TSH had multiple incompatible avatar implementations. The shared primitive gives all consumers one image and white-letter fallback behavior without product-specific compatibility code.

## Risks

- New public UI-system component and export.
- Image loading and error transitions are the main behavior risk.

## Verification

- `corepack pnpm@10.11.0 check:changed`
- pre-push `corepack pnpm@10.11.0 check:changed -- --push-ready`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->