### PR TITLE
fix(agent): recover stalled Codex turn starts

### DIFF
--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -75,6 +75,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [AgentGUI freezes when session history is large](./agent-session-lifecycle.md#agentgui-freezes-when-session-history-is-large)
 - [AgentGUI @ Sessions tab is empty](./agent-session-lifecycle.md#agentgui--sessions-tab-is-empty)
 - [Agent diagnostics flood while a turn is streaming](./agent-session-lifecycle.md#agent-diagnostics-flood-while-a-turn-is-streaming)
+- [Codex turn stays working before any reply or tool activity](./agent-session-lifecycle.md#codex-turn-stays-working-before-any-reply-or-tool-activity)
 - [Codex WebSocket reconnect rejects a long prompt metadata header](./agent-session-lifecycle.md#codex-websocket-reconnect-rejects-a-long-prompt-metadata-header)
 - [Imported sessions trigger fresh-completion indicators](./agent-session-lifecycle.md#imported-sessions-trigger-fresh-completion-indicators)
 - [Realtime agent completion does not show unread attention](./agent-session-lifecycle.md#realtime-agent-completion-does-not-show-unread-attention)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -407,6 +407,43 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [codex_appserver_adapter_test.go](../../../packages/agent/daemon/runtime/codex_appserver_adapter_test.go)
   [agent-gui-node.md](../../architecture/agent-gui-node.md)
 
+### Codex turn stays working before any reply or tool activity
+
+- Symptom:
+  A submitted Codex turn stays working without assistant text, reasoning, or
+  tool activity. Stop may return quickly, but the next prompt on the same
+  conversation can stall in the same way.
+- Quick checks:
+  Correlate `agent.submit.trace` records by `client_submit_id`, `turn_id`, and
+  `agent_session_id`. A `turn.start.requested` without
+  `turn.start.succeeded` means the immediate app-server acknowledgement did
+  not arrive. After the bounded failure, confirm
+  `agent_session.app_server.turn_start.client_invalidated` appears and the next
+  submit starts a new local process with `thread/resume`.
+- Root cause:
+  Codex `turn/start` should acknowledge immediately and stream the actual work
+  through notifications, but the adapter previously called it with no client
+  deadline. A graceful Stop could acknowledge `turn/interrupt` without proving
+  that the unacknowledged `turn/start` connection was healthy, so the adapter
+  retained and reused the same bad process.
+- Fix:
+  Bound only the `turn/start` acknowledgement to 30 seconds; do not bound the
+  subsequent running turn. Treat deadline, cancellation before acknowledgement,
+  or transport disconnect as an unhealthy client, remove exactly that client
+  from the live-session registry, and close it. Do not automatically replay the
+  prompt because delivery is unknown. The next explicit submit uses the
+  existing session recovery path to start a process and resume the provider
+  thread. Bound `turn/steer` acknowledgement separately to 10 seconds.
+- Validation:
+  Run
+  `go test ./packages/agent/daemon/runtime -run 'TestCodexAppServerAdapter(Turn(StartAckTimeoutInvalidatesClient|StartCancelBeforeAckInvalidatesClient|StartAckTimeoutDoesNotBoundRunningTurn|SteerTimesOut)|CanResumeAfterTurnStartAckTimeout)$'`.
+  Cover timeout, pre-ack cancellation, a long post-ack turn, bounded guidance,
+  and successful `thread/resume` followed by a completed turn.
+- References:
+  [codex_appserver_turn.go](../../../packages/agent/daemon/runtime/codex_appserver_turn.go)
+  [codex_appserver_registry.go](../../../packages/agent/daemon/runtime/codex_appserver_registry.go)
+  [codex_appserver_turn_timeout_test.go](../../../packages/agent/daemon/runtime/codex_appserver_turn_timeout_test.go)
+
 ### AgentGUI turn actions return plain-text route 404s
 
 - Symptom:

--- a/packages/agent/daemon/runtime/acp_client.go
+++ b/packages/agent/daemon/runtime/acp_client.go
@@ -75,6 +75,22 @@ type acpCallError struct {
 	Err    acpError
 }
 
+type acpCallTimeoutError struct {
+	Method  string
+	Timeout time.Duration
+}
+
+func (e *acpCallTimeoutError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("acp %s timed out after %s", e.Method, e.Timeout)
+}
+
+func (*acpCallTimeoutError) Unwrap() error {
+	return context.DeadlineExceeded
+}
+
 func (e *acpCallError) Error() string {
 	if e == nil {
 		return ""
@@ -222,7 +238,7 @@ func (c *acpClient) CallWithTimeout(
 	defer cancel()
 	result, err := c.callLocked(callCtx, method, params, handler)
 	if errors.Is(err, context.DeadlineExceeded) {
-		return nil, fmt.Errorf("acp %s timed out after %s", method, timeout)
+		return nil, &acpCallTimeoutError{Method: method, Timeout: timeout}
 	}
 	return result, err
 }
@@ -352,7 +368,7 @@ func (c *acpClient) CallNoHandlerWithTimeout(
 	defer cancel()
 	result, err := c.CallNoHandler(callCtx, method, params)
 	if errors.Is(err, context.DeadlineExceeded) {
-		return nil, fmt.Errorf("acp %s timed out after %s", method, timeout)
+		return nil, &acpCallTimeoutError{Method: method, Timeout: timeout}
 	}
 	return result, err
 }

--- a/packages/agent/daemon/runtime/acp_client.go
+++ b/packages/agent/daemon/runtime/acp_client.go
@@ -75,22 +75,6 @@ type acpCallError struct {
 	Err    acpError
 }
 
-type acpCallTimeoutError struct {
-	Method  string
-	Timeout time.Duration
-}
-
-func (e *acpCallTimeoutError) Error() string {
-	if e == nil {
-		return ""
-	}
-	return fmt.Sprintf("acp %s timed out after %s", e.Method, e.Timeout)
-}
-
-func (*acpCallTimeoutError) Unwrap() error {
-	return context.DeadlineExceeded
-}
-
 func (e *acpCallError) Error() string {
 	if e == nil {
 		return ""

--- a/packages/agent/daemon/runtime/acp_client_timeout_error.go
+++ b/packages/agent/daemon/runtime/acp_client_timeout_error.go
@@ -1,0 +1,23 @@
+package agentruntime
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type acpCallTimeoutError struct {
+	Method  string
+	Timeout time.Duration
+}
+
+func (e *acpCallTimeoutError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("acp %s timed out after %s", e.Method, e.Timeout)
+}
+
+func (*acpCallTimeoutError) Unwrap() error {
+	return context.DeadlineExceeded
+}

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -110,6 +110,15 @@ type CodexAppServerAdapterOptions struct {
 // honor turn/interrupt gracefully before force-closing the app-server process.
 const defaultCodexAppServerCancelGraceWindow = 3 * time.Second
 
+// defaultCodexAppServerTurnStartAckTimeout only bounds the immediate
+// turn/start acknowledgement. Turn output continues through notifications
+// without this deadline after the acknowledgement arrives.
+const defaultCodexAppServerTurnStartAckTimeout = acpStartCallTimeout
+
+// defaultCodexAppServerTurnSteerTimeout bounds guidance delivery to a running
+// turn so a missing app-server response cannot block the caller forever.
+const defaultCodexAppServerTurnSteerTimeout = 10 * time.Second
+
 // startupModelSteadyRetryCount is how many 30s-spaced model/list retries follow
 // the initial fast ramp before the background refresh gives up (~18 minutes
 // total), bounding the goroutine while covering realistic transient outages.
@@ -151,6 +160,12 @@ type CodexAppServerAdapter struct {
 	// cancelGraceWindow bounds the graceful-interrupt wait in Cancel before the
 	// process is force-closed. Zero falls back to the default.
 	cancelGraceWindow time.Duration
+	// turnStartAckTimeout bounds only the immediate turn/start RPC response.
+	// Zero falls back to the default.
+	turnStartAckTimeout time.Duration
+	// turnSteerTimeout bounds turn/steer guidance delivery. Zero falls back to
+	// the default.
+	turnSteerTimeout time.Duration
 	// cliVersionMu/cliVersionCached memoize the served CLI's --version result
 	// per adapter instance (each instance owns one command).
 	cliVersionMu     sync.Mutex
@@ -395,13 +410,15 @@ func newAppServerAdapter(
 	commandResolver ProviderCommandResolver,
 ) *CodexAppServerAdapter {
 	return &CodexAppServerAdapter{
-		transport:         transport,
-		host:              host,
-		config:            config,
-		commandResolver:   commandResolver,
-		sessions:          make(map[string]*codexAppServerSession),
-		lifecycleLocks:    make(map[string]*codexAppServerSessionLock),
-		cancelGraceWindow: defaultCodexAppServerCancelGraceWindow,
+		transport:           transport,
+		host:                host,
+		config:              config,
+		commandResolver:     commandResolver,
+		sessions:            make(map[string]*codexAppServerSession),
+		lifecycleLocks:      make(map[string]*codexAppServerSessionLock),
+		cancelGraceWindow:   defaultCodexAppServerCancelGraceWindow,
+		turnStartAckTimeout: defaultCodexAppServerTurnStartAckTimeout,
+		turnSteerTimeout:    defaultCodexAppServerTurnSteerTimeout,
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -122,6 +122,25 @@ func (c *scriptedAppServerConnection) sendJSON(value map[string]any) {
 	c.sendJSONWithWaitSignal(value, nil)
 }
 
+// sendJSONBatch mirrors stdio coalescing adjacent JSON-RPC lines into one
+// frame, so response/request ordering cannot depend on goroutine scheduling.
+func (c *scriptedAppServerConnection) sendJSONBatch(values ...map[string]any) {
+	var raw []byte
+	for _, value := range values {
+		line, err := json.Marshal(value)
+		if err != nil {
+			return
+		}
+		raw = append(raw, line...)
+		raw = append(raw, '\n')
+	}
+	select {
+	case <-c.closed:
+		return
+	case c.recv <- ProcessFrame{Stdout: raw}:
+	}
+}
+
 func (c *scriptedAppServerConnection) sendJSONWithWaitSignal(value map[string]any, waitEntered chan<- struct{}) {
 	raw, err := json.Marshal(value)
 	if err != nil {
@@ -461,18 +480,62 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 				})
 				continue
 			}
-			// Mirror the real app-server: the RPC responds immediately with
-			// the inProgress turn; output streams as notifications.
-			c.sendJSON(map[string]any{
+			turnStartResponse := map[string]any{
 				"id": message.ID,
 				"result": map[string]any{
 					"turn": map[string]any{"id": "turn-1", "status": "inProgress", "items": []any{}},
 				},
-			})
-			c.notify(appServerNotifyTurnStarted, map[string]any{
-				"threadId": "codex-thread-1",
-				"turn":     map[string]any{"id": "turn-1", "status": "inProgress", "items": []any{}},
-			})
+			}
+			turnStartedNotification := map[string]any{
+				"method": appServerNotifyTurnStarted,
+				"params": map[string]any{
+					"threadId": "codex-thread-1",
+					"turn":     map[string]any{"id": "turn-1", "status": "inProgress", "items": []any{}},
+				},
+			}
+			if approval {
+				c.sendJSONBatch(
+					turnStartResponse,
+					turnStartedNotification,
+					map[string]any{
+						"id":     "approval-1",
+						"method": appServerMethodCommandApproval,
+						"params": map[string]any{
+							"threadId":    "codex-thread-1",
+							"turnId":      "turn-1",
+							"itemId":      "item-cmd",
+							"command":     "rm -rf build",
+							"cwd":         "/workspace",
+							"reason":      "cleanup",
+							"startedAtMs": 1750000000000,
+						},
+					},
+				)
+				continue
+			}
+			if userInput {
+				c.sendJSONBatch(
+					turnStartResponse,
+					turnStartedNotification,
+					map[string]any{
+						"id":     "question-1",
+						"method": appServerMethodRequestUserInput,
+						"params": map[string]any{
+							"threadId": "codex-thread-1",
+							"turnId":   "turn-1",
+							"itemId":   "item-question",
+							"questions": []any{
+								map[string]any{"id": "q1", "question": "Which database?"},
+							},
+						},
+					},
+				)
+				continue
+			}
+			// Mirror the real app-server: the RPC responds immediately with
+			// the inProgress turn; output streams as notifications.
+			c.sendJSON(turnStartResponse)
+			c.sendJSON(turnStartedNotification)
 			if foreignThreadNoise {
 				c.notify(appServerNotifyAgentMessageDelta, map[string]any{
 					"threadId": "foreign-thread-1", "turnId": "foreign-turn-1", "itemId": "foreign-msg",
@@ -494,37 +557,6 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 						},
 					},
 				})
-			}
-			if approval {
-				c.sendJSON(map[string]any{
-					"id":     "approval-1",
-					"method": appServerMethodCommandApproval,
-					"params": map[string]any{
-						"threadId":    "codex-thread-1",
-						"turnId":      "turn-1",
-						"itemId":      "item-cmd",
-						"command":     "rm -rf build",
-						"cwd":         "/workspace",
-						"reason":      "cleanup",
-						"startedAtMs": 1750000000000,
-					},
-				})
-				continue
-			}
-			if userInput {
-				c.sendJSON(map[string]any{
-					"id":     "question-1",
-					"method": appServerMethodRequestUserInput,
-					"params": map[string]any{
-						"threadId": "codex-thread-1",
-						"turnId":   "turn-1",
-						"itemId":   "item-question",
-						"questions": []any{
-							map[string]any{"id": "q1", "question": "Which database?"},
-						},
-					},
-				})
-				continue
 			}
 			if emitPlan {
 				c.notify(appServerNotifyItemCompleted, map[string]any{

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -472,12 +472,32 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 				// turn/started ever fires for the stub id and the only
 				// terminal notification is the running turn's turn/completed
 				// (sent by the test via completePendingTurn).
-				c.sendJSON(map[string]any{
+				turnStartResponse := map[string]any{
 					"id": message.ID,
 					"result": map[string]any{
 						"turn": map[string]any{"id": "turn-steer-stub", "status": "inProgress", "items": []any{}},
 					},
-				})
+				}
+				if approval {
+					c.sendJSONBatch(
+						turnStartResponse,
+						map[string]any{
+							"id":     "approval-1",
+							"method": appServerMethodCommandApproval,
+							"params": map[string]any{
+								"threadId":    "codex-thread-1",
+								"turnId":      "turn-1",
+								"itemId":      "item-cmd",
+								"command":     "rm -rf build",
+								"cwd":         "/workspace",
+								"reason":      "cleanup",
+								"startedAtMs": 1750000000000,
+							},
+						},
+					)
+					continue
+				}
+				c.sendJSON(turnStartResponse)
 				continue
 			}
 			turnStartResponse := map[string]any{
@@ -2202,6 +2222,54 @@ func TestCodexAppServerAdapterExecSteeredTurnSettlesOnRunningTurnCompletion(t *t
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatalf("Exec never settled: turn/completed for the running turn was dropped by the provider-turn-id guard")
+	}
+}
+
+func TestCodexAppServerAdapterQueuedSteerKeepsApprovalAlive(t *testing.T) {
+	t.Parallel()
+
+	adapter, transport, session := startedAppServerAdapter(t)
+	transport.conn.steeredTurnStart = true
+	transport.conn.commandApproval = true
+
+	execDone := make(chan []activityshared.Event, 1)
+	go func() {
+		events, _ := adapter.Exec(
+			context.Background(),
+			session,
+			textPrompt("change direction"),
+			"",
+			"turn-local-2",
+			func([]activityshared.Event) {},
+			nil,
+		)
+		execDone <- events
+	}()
+
+	waitForCondition(t, func() bool {
+		return adapter.getPendingRequest(session.AgentSessionID, "turn-local-2", "approval-1") != nil
+	})
+	result, err := adapter.SubmitInteractive(context.Background(), session, SubmitInteractiveInput{
+		TurnID:    "turn-local-2",
+		RequestID: "approval-1",
+		OptionID:  "approve",
+	})
+	if err != nil {
+		t.Fatalf("SubmitInteractive: %v", err)
+	}
+	if !result.Accepted || result.Disposition != InteractiveDispositionAnswered {
+		t.Fatalf("submit result = %#v, want answered approval", result)
+	}
+
+	select {
+	case events := <-execDone:
+		completed := eventsOfType(events, activityshared.EventRootProviderTurnCompleted)
+		if len(completed) != 1 ||
+			completed[0].Payload.TurnOutcome != string(activityshared.TurnOutcomeCompleted) {
+			t.Fatalf("queued steer terminal events = %#v, want one completed outcome", events)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("queued steer did not settle after its approval response")
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -90,6 +90,8 @@ type scriptedAppServerConnection struct {
 	childNicknames                  map[string]string // thread/read agentNickname responses by threadId
 	turnStartEntered                chan struct{}
 	turnStartRelease                chan struct{}
+	hangTurnStart                   bool
+	hangSteer                       bool
 	threadName                      string
 	commandApproval                 bool
 	userInputRequest                bool
@@ -431,12 +433,16 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 			foreignThreadNoise := c.foreignThreadNoise
 			turnStartEntered := c.turnStartEntered
 			turnStartRelease := c.turnStartRelease
+			hangTurnStart := c.hangTurnStart
 			c.mu.Unlock()
 			if turnStartEntered != nil {
 				close(turnStartEntered)
 			}
 			if turnStartRelease != nil {
 				<-turnStartRelease
+			}
+			if hangTurnStart {
+				continue
 			}
 			if steered {
 				// Mirror real codex steering (live-verified against codex
@@ -643,6 +649,12 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 				c.completePendingTurn()
 			}
 		case appServerMethodTurnSteer:
+			c.mu.Lock()
+			hang := c.hangSteer
+			c.mu.Unlock()
+			if hang {
+				continue
+			}
 			c.sendJSON(map[string]any{"id": message.ID, "result": map[string]any{"turnId": "turn-1"}})
 		case appServerMethodThreadCompact:
 			c.sendJSON(map[string]any{"id": message.ID, "result": map[string]any{}})

--- a/packages/agent/daemon/runtime/codex_appserver_client.go
+++ b/packages/agent/daemon/runtime/codex_appserver_client.go
@@ -360,6 +360,7 @@ func (c *codexAppServerClient) ThreadResume(
 
 func (c *codexAppServerClient) TurnStart(
 	ctx context.Context,
+	timeout time.Duration,
 	params map[string]any,
 	handler acpMessageHandler,
 ) (json.RawMessage, error) {
@@ -367,7 +368,7 @@ func (c *codexAppServerClient) TurnStart(
 	if err != nil {
 		return nil, err
 	}
-	client, caller := c.typed(0, handler, false)
+	client, caller := c.typed(timeout, handler, false)
 	_, err = client.TurnStart(ctx, typedParams)
 	if err != nil {
 		return nil, err
@@ -375,12 +376,16 @@ func (c *codexAppServerClient) TurnStart(
 	return caller.rawResult, nil
 }
 
-func (c *codexAppServerClient) TurnSteerNoHandler(ctx context.Context, params map[string]any) (json.RawMessage, error) {
+func (c *codexAppServerClient) TurnSteerNoHandler(
+	ctx context.Context,
+	timeout time.Duration,
+	params map[string]any,
+) (json.RawMessage, error) {
 	typedParams, err := codexProtoParams[codexproto.TurnSteerParams](params)
 	if err != nil {
 		return nil, err
 	}
-	client, caller := c.typed(0, nil, true)
+	client, caller := c.typed(timeout, nil, true)
 	_, err = client.TurnSteer(ctx, typedParams)
 	if err != nil {
 		return nil, err

--- a/packages/agent/daemon/runtime/codex_appserver_client.go
+++ b/packages/agent/daemon/runtime/codex_appserver_client.go
@@ -362,13 +362,12 @@ func (c *codexAppServerClient) TurnStart(
 	ctx context.Context,
 	timeout time.Duration,
 	params map[string]any,
-	handler acpMessageHandler,
 ) (json.RawMessage, error) {
 	typedParams, err := codexProtoParams[codexproto.TurnStartParams](params)
 	if err != nil {
 		return nil, err
 	}
-	client, caller := c.typed(timeout, handler, false)
+	client, caller := c.typed(timeout, nil, false)
 	_, err = client.TurnStart(ctx, typedParams)
 	if err != nil {
 		return nil, err

--- a/packages/agent/daemon/runtime/codex_appserver_goal.go
+++ b/packages/agent/daemon/runtime/codex_appserver_goal.go
@@ -12,7 +12,7 @@ import (
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
-func (*CodexAppServerAdapter) steerActiveTurn(
+func (a *CodexAppServerAdapter) steerActiveTurn(
 	ctx context.Context,
 	appSession *codexAppServerSession,
 	session Session,
@@ -24,7 +24,11 @@ func (*CodexAppServerAdapter) steerActiveTurn(
 	activeTurnID string,
 	emit EventSink,
 ) ([]activityshared.Event, error) {
-	_, err := appSession.client.TurnSteerNoHandler(ctx, map[string]any{
+	timeout := a.turnSteerTimeout
+	if timeout <= 0 {
+		timeout = defaultCodexAppServerTurnSteerTimeout
+	}
+	_, err := appSession.client.TurnSteerNoHandler(ctx, timeout, map[string]any{
 		"threadId":       appSession.threadID,
 		"expectedTurnId": activeTurnID,
 		"input":          appServerUserInput(providerContent),

--- a/packages/agent/daemon/runtime/codex_appserver_registry.go
+++ b/packages/agent/daemon/runtime/codex_appserver_registry.go
@@ -69,7 +69,7 @@ func (a *CodexAppServerAdapter) removeSession(agentSessionID string) {
 	}
 	a.mu.Unlock()
 	for _, request := range pending {
-		request.finish(pendingInteractiveRequestStateSuperseded)
+		request.supersede(errPermissionRequestCanceled)
 	}
 	a.mu.Lock()
 	delete(a.sessions, strings.TrimSpace(agentSessionID))
@@ -101,7 +101,7 @@ func (a *CodexAppServerAdapter) invalidateSessionClient(
 	a.mu.Unlock()
 
 	for _, request := range pending {
-		request.finish(pendingInteractiveRequestStateSuperseded)
+		request.supersede(errPermissionRequestCanceled)
 	}
 	_ = expectedClient.Close()
 	return true

--- a/packages/agent/daemon/runtime/codex_appserver_registry.go
+++ b/packages/agent/daemon/runtime/codex_appserver_registry.go
@@ -76,6 +76,37 @@ func (a *CodexAppServerAdapter) removeSession(agentSessionID string) {
 	a.mu.Unlock()
 }
 
+// invalidateSessionClient removes and closes only the client that failed its
+// turn/start acknowledgement. The identity check prevents a late failure from
+// closing a replacement process that another lifecycle operation installed.
+func (a *CodexAppServerAdapter) invalidateSessionClient(
+	agentSessionID string,
+	expectedClient *codexAppServerClient,
+) bool {
+	if a == nil || expectedClient == nil {
+		return false
+	}
+	key := strings.TrimSpace(agentSessionID)
+	a.mu.Lock()
+	appSession := a.sessions[key]
+	if appSession == nil || appSession.client != expectedClient {
+		a.mu.Unlock()
+		return false
+	}
+	pending := make([]*pendingInteractiveRequest, 0, len(appSession.pendingRequests))
+	for _, request := range appSession.pendingRequests {
+		pending = append(pending, request)
+	}
+	delete(a.sessions, key)
+	a.mu.Unlock()
+
+	for _, request := range pending {
+		request.finish(pendingInteractiveRequestStateSuperseded)
+	}
+	_ = expectedClient.Close()
+	return true
+}
+
 func (a *CodexAppServerAdapter) getSession(agentSessionID string) *codexAppServerSession {
 	if a == nil {
 		return nil

--- a/packages/agent/daemon/runtime/codex_appserver_turn.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn.go
@@ -355,7 +355,8 @@ func (a *CodexAppServerAdapter) execBlocking(
 	// production; the blocking shell below only waits and returns.
 	a.markTurnSettleEmits(appTurn)
 
-	trace := newCodexAppServerTurnTrace(session, turnID, execMetadataFromContext(ctx))
+	execMetadata := execMetadataFromContext(ctx)
+	trace := newCodexAppServerTurnTrace(session, turnID, execMetadata)
 	turnParams := appServerTurnStartParams(
 		session,
 		appSession.threadID,
@@ -367,8 +368,15 @@ func (a *CodexAppServerAdapter) execBlocking(
 		a.config.commandNetworkAccess,
 	)
 	trace.Log("turn.start.params", codexAppServerTraceTurnStartParams(session, turnParams, providerContent))
+	turnStartAckTimeout := a.turnStartAckTimeout
+	if turnStartAckTimeout <= 0 {
+		turnStartAckTimeout = defaultCodexAppServerTurnStartAckTimeout
+	}
+	logAgentSubmitTrace("turn.start.requested", session, turnID, execMetadata, map[string]any{
+		"timeout_ms": turnStartAckTimeout.Milliseconds(),
+	})
 	turnStartedAt := time.Now()
-	result, err := appSession.client.TurnStart(ctx, turnParams,
+	result, err := appSession.client.TurnStart(ctx, turnStartAckTimeout, turnParams,
 		func(ctx context.Context, message acpMessage) error {
 			trace.LogMessage(message.Method, len(message.ID) > 0, len(message.Params))
 			next, err := a.handleAppServerMessage(ctx, appSession.client, session, turnID, message, normalizer, emitEvents, emitCommands)
@@ -376,10 +384,16 @@ func (a *CodexAppServerAdapter) execBlocking(
 			return err
 		})
 	if err != nil {
+		durationMS := time.Since(turnStartedAt).Milliseconds()
 		trace.Log("turn.start.failed", map[string]any{
-			"duration_ms": time.Since(turnStartedAt).Milliseconds(),
+			"duration_ms": durationMS,
 			"error":       err.Error(),
 		})
+		logAgentSubmitTrace("turn.start.failed", session, turnID, execMetadata, map[string]any{
+			"duration_ms": durationMS,
+			"error":       err.Error(),
+		})
+		invalidateClient := codexTurnStartClientUnhealthy(err, appSession.client)
 		a.endActiveTurn(session.AgentSessionID, appTurn)
 		if errors.Is(err, context.Canceled) || errors.Is(err, errPermissionRequestCanceled) {
 			terminalEvents := a.pendingRequestFailureEvents(session, turnID, errPermissionRequestCanceled)
@@ -393,10 +407,25 @@ func (a *CodexAppServerAdapter) execBlocking(
 			terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", acpFailureMetadata(err)))
 			emitTerminal(terminalEvents)
 		}
+		if invalidateClient && a.invalidateSessionClient(session.AgentSessionID, appSession.client) {
+			slog.Warn(
+				"agent session app-server client invalidated after turn/start failed",
+				"event", "agent_session.app_server.turn_start.client_invalidated",
+				"agent_session_id", session.AgentSessionID,
+				"provider_session_id", appSession.threadID,
+				"turn_id", turnID,
+				"error", err.Error(),
+			)
+		}
 		return snapshotEvents(), nil
 	}
+	durationMS := time.Since(turnStartedAt).Milliseconds()
 	trace.Log("turn.start.succeeded", map[string]any{
-		"duration_ms": time.Since(turnStartedAt).Milliseconds(),
+		"duration_ms": durationMS,
+		"result_size": len(result),
+	})
+	logAgentSubmitTrace("turn.start.succeeded", session, turnID, execMetadata, map[string]any{
+		"duration_ms": durationMS,
 		"result_size": len(result),
 	})
 
@@ -445,6 +474,23 @@ func (a *CodexAppServerAdapter) execBlocking(
 	normalizer.ApplyAssistantFinalText(appServerTurnFinalAssistantText(finalTurn))
 	emitTerminal(appServerTurnTerminalEvents(session, turnID, finalTurn, normalizer))
 	return snapshotEvents(), nil
+}
+
+func codexTurnStartClientUnhealthy(err error, client *codexAppServerClient) bool {
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, ErrSessionDisconnected) {
+		return true
+	}
+	if client == nil {
+		return true
+	}
+	select {
+	case <-client.Done():
+		return true
+	default:
+		return false
+	}
 }
 
 // pendingRequestFailureEvents resolves any still-pending approval or

--- a/packages/agent/daemon/runtime/codex_appserver_turn.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn.go
@@ -376,13 +376,7 @@ func (a *CodexAppServerAdapter) execBlocking(
 		"timeout_ms": turnStartAckTimeout.Milliseconds(),
 	})
 	turnStartedAt := time.Now()
-	result, err := appSession.client.TurnStart(ctx, turnStartAckTimeout, turnParams,
-		func(ctx context.Context, message acpMessage) error {
-			trace.LogMessage(message.Method, len(message.ID) > 0, len(message.Params))
-			next, err := a.handleAppServerMessage(ctx, appSession.client, session, turnID, message, normalizer, emitEvents, emitCommands)
-			emitEvents(next)
-			return err
-		})
+	result, err := appSession.client.TurnStart(ctx, turnStartAckTimeout, turnParams)
 	if err != nil {
 		durationMS := time.Since(turnStartedAt).Milliseconds()
 		trace.Log("turn.start.failed", map[string]any{

--- a/packages/agent/daemon/runtime/codex_appserver_turn.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn.go
@@ -511,7 +511,7 @@ func (a *CodexAppServerAdapter) pendingRequestFailureEvents(
 	a.mu.Unlock()
 	var events []activityshared.Event
 	for _, pending := range pendings {
-		if !pending.finish(pendingInteractiveRequestStateSuperseded) {
+		if !pending.supersede(cause) {
 			continue
 		}
 		events = append(events, normalizedPermissionResolvedEvents(session, turnID, pending, pendingInteractiveResponse{}, cause)...)

--- a/packages/agent/daemon/runtime/codex_appserver_turn_timeout_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn_timeout_test.go
@@ -1,0 +1,225 @@
+package agentruntime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+type sequentialAppServerTransport struct {
+	mu          sync.Mutex
+	connections []*scriptedAppServerConnection
+	starts      int
+}
+
+func (t *sequentialAppServerTransport) Start(_ context.Context, _ ProcessSpec) (ProcessConnection, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.starts >= len(t.connections) {
+		return nil, fmt.Errorf("unexpected process start %d", t.starts+1)
+	}
+	connection := t.connections[t.starts]
+	t.starts++
+	return connection, nil
+}
+
+func TestCodexAppServerAdapterTurnStartAckTimeoutInvalidatesClient(t *testing.T) {
+	adapter, transport, session := startedAppServerAdapter(t)
+	t.Cleanup(func() { _ = adapter.Close(context.Background(), session) })
+	adapter.turnStartAckTimeout = 25 * time.Millisecond
+	transport.conn.hangTurnStart = true
+
+	startedAt := time.Now()
+	events, err := adapter.Exec(context.Background(), session, []PromptContentBlock{{
+		Type: "text", Text: "hang before acknowledgement",
+	}}, "", "turn-timeout", nil, nil)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("Exec elapsed = %s, want bounded turn/start acknowledgement", elapsed)
+	}
+
+	failed := eventsOfType(events, activityshared.EventTurnFailed)
+	if len(failed) != 1 {
+		t.Fatalf("turn.failed events = %d, want 1; events = %#v", len(failed), events)
+	}
+	message, _ := failed[0].Payload.Metadata["error"].(string)
+	if !strings.Contains(message, "turn/start timed out after 25ms") {
+		t.Fatalf("turn.failed metadata = %#v, want turn/start timeout", failed[0].Payload.Metadata)
+	}
+	if adapter.HasLiveSession(session) {
+		t.Fatalf("timed-out turn/start client remained live")
+	}
+	transport.conn.mu.Lock()
+	closeCount := transport.conn.closeCount
+	transport.conn.mu.Unlock()
+	if closeCount == 0 {
+		t.Fatalf("timed-out turn/start client was not closed")
+	}
+}
+
+func TestCodexAppServerAdapterTurnStartCancelBeforeAckInvalidatesClient(t *testing.T) {
+	adapter, transport, session := startedAppServerAdapter(t)
+	t.Cleanup(func() { _ = adapter.Close(context.Background(), session) })
+	adapter.turnStartAckTimeout = time.Second
+	transport.conn.hangTurnStart = true
+	transport.conn.turnStartEntered = make(chan struct{})
+
+	execCtx, cancelExec := context.WithCancel(context.Background())
+	execDone := make(chan []activityshared.Event, 1)
+	go func() {
+		events, _ := adapter.Exec(execCtx, session, []PromptContentBlock{{
+			Type: "text", Text: "cancel before acknowledgement",
+		}}, "", "turn-canceled", nil, nil)
+		execDone <- events
+	}()
+
+	select {
+	case <-transport.conn.turnStartEntered:
+	case <-time.After(time.Second):
+		t.Fatalf("turn/start was not sent")
+	}
+	cancelExec()
+
+	select {
+	case events := <-execDone:
+		completed := eventsOfType(events, activityshared.EventTurnCompleted)
+		if len(completed) != 1 ||
+			completed[0].Payload.TurnOutcome != string(activityshared.TurnOutcomeInterrupted) {
+			t.Fatalf("expected interrupted turn outcome, got %#v", events)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("Exec did not finish after cancellation")
+	}
+	if adapter.HasLiveSession(session) {
+		t.Fatalf("canceled unacknowledged turn/start client remained live")
+	}
+}
+
+func TestCodexAppServerAdapterCanResumeAfterTurnStartAckTimeout(t *testing.T) {
+	firstConnection := newScriptedAppServerConnection()
+	firstConnection.hangTurnStart = true
+	secondConnection := newScriptedAppServerConnection()
+	transport := &sequentialAppServerTransport{
+		connections: []*scriptedAppServerConnection{firstConnection, secondConnection},
+	}
+	adapter := NewCodexAppServerAdapter(transport)
+	adapter.turnStartAckTimeout = 25 * time.Millisecond
+	session := testAppServerSession()
+	t.Cleanup(func() { _ = adapter.Close(context.Background(), session) })
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session.ProviderSessionID = "codex-thread-1"
+
+	if _, err := adapter.Exec(context.Background(), session, []PromptContentBlock{{
+		Type: "text", Text: "first attempt",
+	}}, "", "turn-timeout", nil, nil); err != nil {
+		t.Fatalf("first Exec: %v", err)
+	}
+	if adapter.HasLiveSession(session) {
+		t.Fatalf("timed-out client remained live")
+	}
+
+	if err := adapter.Resume(context.Background(), session); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if !adapter.HasLiveSession(session) {
+		t.Fatalf("resumed client is not live")
+	}
+	if requests := appServerRequestParamsList(t, secondConnection, appServerMethodThreadResume); len(requests) != 1 {
+		t.Fatalf("thread/resume calls = %d, want 1", len(requests))
+	}
+	events, err := adapter.Exec(context.Background(), session, []PromptContentBlock{{
+		Type: "text", Text: "second attempt",
+	}}, "", "turn-recovered", nil, nil)
+	if err != nil {
+		t.Fatalf("second Exec: %v", err)
+	}
+	completed := eventsOfType(events, activityshared.EventRootProviderTurnCompleted)
+	if len(completed) != 1 ||
+		completed[0].Payload.TurnOutcome != string(activityshared.TurnOutcomeCompleted) {
+		t.Fatalf("expected recovered provider turn to complete, got %#v", events)
+	}
+}
+
+func TestCodexAppServerAdapterTurnStartAckTimeoutDoesNotBoundRunningTurn(t *testing.T) {
+	adapter, transport, session := startedAppServerAdapter(t)
+	t.Cleanup(func() { _ = adapter.Close(context.Background(), session) })
+	adapter.turnStartAckTimeout = 25 * time.Millisecond
+	transport.conn.holdTurn = true
+
+	execDone := make(chan []activityshared.Event, 1)
+	go func() {
+		events, _ := adapter.Exec(context.Background(), session, []PromptContentBlock{{
+			Type: "text", Text: "long running turn",
+		}}, "", "turn-running", nil, nil)
+		execDone <- events
+	}()
+
+	waitForCondition(t, func() bool {
+		return adapter.sessionActiveTurnID(session.AgentSessionID) == "turn-1"
+	})
+	time.Sleep(75 * time.Millisecond)
+	if !adapter.HasLiveSession(session) {
+		t.Fatalf("acknowledged running turn was closed by acknowledgement timeout")
+	}
+	transport.conn.completePendingTurn()
+
+	select {
+	case events := <-execDone:
+		completed := eventsOfType(events, activityshared.EventRootProviderTurnCompleted)
+		if len(completed) != 1 ||
+			completed[0].Payload.TurnOutcome != string(activityshared.TurnOutcomeCompleted) {
+			t.Fatalf("expected completed provider turn outcome, got %#v", events)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("acknowledged running turn did not complete")
+	}
+}
+
+func TestCodexAppServerAdapterTurnSteerTimesOut(t *testing.T) {
+	adapter, transport, session := startedAppServerAdapter(t)
+	t.Cleanup(func() { _ = adapter.Close(context.Background(), session) })
+	adapter.turnSteerTimeout = 25 * time.Millisecond
+	transport.conn.holdTurn = true
+
+	execDone := make(chan struct{}, 1)
+	go func() {
+		_, _ = adapter.Exec(context.Background(), session, []PromptContentBlock{{
+			Type: "text", Text: "running turn",
+		}}, "", "turn-running", nil, nil)
+		execDone <- struct{}{}
+	}()
+	waitForCondition(t, func() bool {
+		return adapter.sessionActiveTurnID(session.AgentSessionID) == "turn-1"
+	})
+	transport.conn.mu.Lock()
+	transport.conn.hangSteer = true
+	transport.conn.mu.Unlock()
+
+	startedAt := time.Now()
+	_, err := adapter.GuideActiveTurn(context.Background(), session, []PromptContentBlock{{
+		Type: "text", Text: "new guidance",
+	}}, "", "turn-guidance", nil, nil)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("GuideActiveTurn error = %v, want deadline exceeded", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("GuideActiveTurn elapsed = %s, want bounded turn/steer", elapsed)
+	}
+
+	transport.conn.completePendingTurn()
+	select {
+	case <-execDone:
+	case <-time.After(time.Second):
+		t.Fatalf("running turn did not finish during cleanup")
+	}
+}

--- a/packages/agent/daemon/runtime/interactive_projection_test.go
+++ b/packages/agent/daemon/runtime/interactive_projection_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 )
 
 func TestPendingInteractionTransitionProjectsSelfDescribingActions(t *testing.T) {
@@ -203,6 +204,30 @@ func TestPendingInteractiveRequestReleaseResolvingDoesNotOverwriteTerminal(t *te
 	}
 	if pending.disposition() != pendingInteractiveRequestStateSuperseded {
 		t.Fatalf("terminal disposition = %q, want superseded", pending.disposition())
+	}
+}
+
+func TestPendingInteractiveRequestSupersedeUnblocksProviderWaiter(t *testing.T) {
+	t.Parallel()
+	pending := &pendingInteractiveRequest{
+		requestID: "request-1",
+		response:  make(chan pendingInteractiveResponse, 1),
+	}
+	result := make(chan error, 1)
+	go func() {
+		_, err := pending.wait(context.Background())
+		result <- err
+	}()
+
+	pending.supersede(errPermissionRequestCanceled)
+
+	select {
+	case err := <-result:
+		if !errors.Is(err, errPermissionRequestCanceled) {
+			t.Fatalf("wait error = %v, want permission request canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("terminal request left provider waiter blocked")
 	}
 }
 

--- a/packages/agent/daemon/runtime/interactive_request_state.go
+++ b/packages/agent/daemon/runtime/interactive_request_state.go
@@ -253,6 +253,23 @@ func (p *pendingInteractiveRequest) wait(ctx context.Context) (pendingInteractiv
 	}
 }
 
+func (p *pendingInteractiveRequest) supersede(err error) bool {
+	if p == nil {
+		return false
+	}
+	if err == nil {
+		err = errPermissionRequestCanceled
+	}
+	if !p.finish(pendingInteractiveRequestStateSuperseded) {
+		return false
+	}
+	select {
+	case p.response <- pendingInteractiveResponse{err: err}:
+	default:
+	}
+	return true
+}
+
 func (p *pendingInteractiveRequest) reject(err error) {
 	if p == nil {
 		return


### PR DESCRIPTION
## Summary
- bound the immediate Codex `turn/start` acknowledgement to 30 seconds without limiting the running turn
- invalidate only the stalled app-server client after a pre-ack timeout, cancellation, or disconnect so the next submit resumes the same provider thread with a fresh process
- keep turn notifications, approvals, and user-input requests on the session handler after the acknowledgement returns
- wake provider responders when local timeout/recovery supersedes a pending interaction
- bound `turn/steer` to 10 seconds and add correlated diagnostics, regression coverage, and troubleshooting guidance

## Verification
- coalesced `turn/start` response + approval/user-input frame: reproduced the old race before the handler fix
- focused interaction/timeout/recovery suite: 30 consecutive passes
- focused race suite: 10 consecutive passes
- `pnpm test:go:agent-daemon`
- `pnpm check:changed -- --push-ready`

## Fix Scope Justification
- Root cause: a missing Codex `turn/start` response left the caller waiting forever; adding the acknowledgement deadline initially exposed a second source bug because the deadline-owned RPC handler also owned adjacent approval/user-input messages and canceled them as soon as the response returned
- Why not a lower layer: the lower layer already separates JSON-RPC responses from session messages; the Codex app-server adapter must choose the correct lifetime owner, invalidate only the exact unhealthy client, preserve the provider thread for resume, and settle adapter-owned interaction state. Moving those provider-specific rules lower would change standard ACP semantics and couple the generic transport to Codex lifecycle policy

## Fallback Three Questions
- Source: Codex app-server can accept a `turn/start` or `turn/steer` write without returning the matching JSON-RPC response
- Why not fixed at source: Codex is an external process and the client cannot prove whether a prompt was accepted when the acknowledgement is missing
- Removal condition: remove the timeout recovery only when the app-server protocol provides a durable, queryable request identity that proves delivery and allows safe replay

## Notes
- the 30-second deadline is a Tutti client-side acknowledgement bound, not an ACP protocol timeout
- timed-out prompts are not replayed automatically because provider delivery is unknown
- this is Codex adapter transport/recovery policy; it does not change Host-owned session or turn lifecycle semantics
