### PR TITLE
fix(agent): restore custom Agent selection and session launches

### DIFF
--- a/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
@@ -35,6 +35,8 @@ import {
   userAvatarPlaceholderUrl,
   workspaceAgentActivityStatusLabel
 } from "@tutti-os/agent-gui/agent-message-center";
+import { resolveAgentGUIProviderCatalogIdentity } from "@tutti-os/agent-gui/provider-catalog";
+import { resolveProviderIconAsset } from "@tutti-os/agent-gui/provider-icons";
 import { normalizeAgentActivityDisplayStatus } from "@tutti-os/agent-activity-core";
 import { translate } from "../../../i18n";
 import { getActiveLocale } from "../../../i18n/runtime";
@@ -216,6 +218,7 @@ export function createWorkspaceWindowContainer(): WorkspaceWindowContainerResult
     tuttidClient,
     notifications: notificationService,
     reporterService,
+    resolveAgentTargetIconUrl: resolveWorkspaceAgentTargetIconUrl,
     runtimeApi: desktopApi.runtime,
     terminalCommandRunner: createAgentProviderTerminalCommandRunner(
       desktopApi.runtime
@@ -450,4 +453,18 @@ function logWorkspaceWindowRuntimeDiagnostic(
 
 function resolveWorkspaceRichTextAgentIconUrl(provider: string | undefined) {
   return managedAgentRoundedIconUrl(provider);
+}
+
+function resolveWorkspaceAgentTargetIconUrl(identity: {
+  iconKey: string | null;
+  provider: string;
+}): string {
+  const catalogIconKey =
+    identity.iconKey ||
+    resolveAgentGUIProviderCatalogIdentity(identity.provider)?.iconKey;
+  return (
+    resolveProviderIconAsset(catalogIconKey, "rounded") ??
+    resolveProviderIconAsset(catalogIconKey, "manage") ??
+    managedAgentRoundedIconUrl(identity.provider)
+  );
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { AgentTarget } from "@tutti-os/client-tuttid-ts";
+import type { AgentTarget, WorkspaceAgent } from "@tutti-os/client-tuttid-ts";
+import {
+  normalizeAgentGUIAgents,
+  projectAgentGUIAgentsToTargets
+} from "@tutti-os/agent-gui/agents";
 import {
   DesktopAgentsService,
   mapAgentTargetsToPresentations,
@@ -187,6 +191,74 @@ test("desktop agents service maps enabled daemon targets into the AgentGUI agent
   ]);
 });
 
+test("desktop agents service lists a custom Agent with its Harness target catalog icon", async () => {
+  let listedWorkspaceId = "";
+  const service = new DesktopAgentsService({
+    resolveAgentTargetIconUrl: ({ iconKey, provider }) =>
+      iconKey ? `catalog://${iconKey}` : `catalog://provider/${provider}`,
+    tuttidClient: {
+      async listAgentTargets() {
+        return {
+          targets: [
+            createAgentTarget({
+              iconKey: "codex-target",
+              iconUrl: null,
+              id: "local:codex",
+              name: "Codex",
+              provider: "codex",
+              sortOrder: 10
+            })
+          ]
+        };
+      },
+      async listWorkspaceAgents(workspaceId) {
+        listedWorkspaceId = workspaceId;
+        return {
+          agents: [
+            createWorkspaceAgent({
+              harness: {
+                agentTargetId: "local:codex",
+                available: true,
+                enabled: true,
+                iconKey: null,
+                name: "Codex",
+                provider: "codex"
+              }
+            })
+          ]
+        };
+      }
+    },
+    workspaceId: "workspace-1"
+  });
+
+  const snapshot = await service.load();
+  const customAgent = snapshot.agents.find(
+    (agent) => agent.agentTargetId === "workspace-agent:reviewer"
+  );
+  const normalizedAgents = normalizeAgentGUIAgents(snapshot.agents);
+  const customTarget = projectAgentGUIAgentsToTargets(normalizedAgents).find(
+    (target) => target.agentTargetId === "workspace-agent:reviewer"
+  );
+
+  assert.equal(listedWorkspaceId, "workspace-1");
+  assert.equal(customAgent?.iconUrl, "catalog://codex-target");
+  assert.deepEqual(customTarget, {
+    agentTargetId: "workspace-agent:reviewer",
+    availability: { status: "ready" },
+    description: "Reviews workspace changes",
+    iconUrl: "catalog://codex-target",
+    label: "Reviewer",
+    provider: "codex",
+    ref: {
+      agentTargetId: "workspace-agent:reviewer",
+      kind: "agent-directory",
+      provider: "codex"
+    },
+    targetId: "workspace-agent:reviewer"
+  });
+});
+
 test("desktop agents service preserves Extension primary and mask icons", () => {
   const presentations = mapAgentTargetsToPresentations([
     {
@@ -297,7 +369,10 @@ function createAgentTarget(input: {
     createdAtUnixMs: 1780272000000,
     enabled: input.enabled ?? true,
     iconKey: input.iconKey ?? null,
-    iconUrl: input.iconUrl ?? `tutti-asset://agent/${input.provider}.png`,
+    iconUrl:
+      "iconUrl" in input
+        ? (input.iconUrl ?? null)
+        : `tutti-asset://agent/${input.provider}.png`,
     heroImageUrl: input.heroImageUrl ?? null,
     maskIconUrl: input.maskIconUrl ?? null,
     id: input.id,
@@ -310,6 +385,39 @@ function createAgentTarget(input: {
     sortOrder: input.sortOrder,
     source: "system",
     updatedAtUnixMs: 1780272000000
+  };
+}
+
+function createWorkspaceAgent(
+  overrides: Partial<WorkspaceAgent> = {}
+): WorkspaceAgent {
+  return {
+    agentTargetId: "workspace-agent:reviewer",
+    capabilitiesExplicit: false,
+    callConditions: ["Use for workspace reviews"],
+    createdAt: "2026-07-23T00:00:00Z",
+    defaultModel: null,
+    description: "Reviews workspace changes",
+    harness: {
+      agentTargetId: "local:codex",
+      available: true,
+      enabled: true,
+      iconKey: "codex",
+      name: "Codex",
+      provider: "codex"
+    },
+    id: "workspace-agent:reviewer",
+    instructions: "Review carefully",
+    modelFallbacks: [],
+    modelPlanId: null,
+    name: "Reviewer",
+    revision: 1,
+    skills: [],
+    source: "user",
+    tools: [],
+    updatedAt: "2026-07-23T00:00:00Z",
+    workspaceId: "workspace-1",
+    ...overrides
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.test.ts
@@ -342,6 +342,41 @@ test("desktop agents service gates extension agents behind the Early Access togg
   );
 });
 
+test("desktop agents service preserves the canonical Kimi Extension identity", () => {
+  const presentations = mapAgentTargetsToPresentations([
+    {
+      createdAtUnixMs: 1780272000000,
+      enabled: true,
+      heroImageUrl: null,
+      iconKey: "extension:kimi-code",
+      iconUrl: "data:image/svg+xml;base64,kimi",
+      maskIconUrl: null,
+      id: "extension:kimi-code",
+      launchRef: {
+        extensionInstallationId: "kimi-code@1.0.1",
+        type: "agent_extension"
+      },
+      name: "Kimi Code",
+      provider: "acp:kimi-code",
+      sortOrder: 700,
+      source: "system",
+      updatedAtUnixMs: 1780272000000
+    }
+  ]);
+
+  const agents = mapAgentTargetPresentationsToAgents(presentations, {
+    earlyAccessEnabled: true
+  });
+  const targets = projectAgentGUIAgentsToTargets(
+    normalizeAgentGUIAgents(agents)
+  );
+
+  assert.equal(agents[0]?.agentTargetId, "extension:kimi-code");
+  assert.equal(agents[0]?.provider, "acp:kimi-code");
+  assert.equal(targets[0]?.targetId, "extension:kimi-code");
+  assert.equal(targets[0]?.agentTargetId, "extension:kimi-code");
+});
+
 function selectIconPresentation(input: {
   agentTargetId: string;
   iconUrl: string;

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.ts
@@ -172,6 +172,12 @@ export class DesktopAgentsService implements IAgentsService {
           resolveAgentTargetIconUrl: this.dependencies.resolveAgentTargetIconUrl
         }
       );
+      const daemonAgentTargetIconUrls = new Map(
+        daemonAgentTargets.map((target) => [
+          target.agentTargetId,
+          target.iconUrl
+        ])
+      );
       const agentTargets = daemonAgentTargets;
       // Built-in Harness targets and explicit workspace Agents coexist in the
       // AgentGUI directory: built-ins keep their placement and workspace
@@ -185,7 +191,13 @@ export class DesktopAgentsService implements IAgentsService {
         {
           isAgentTargetProviderGated:
             this.dependencies.isAgentTargetProviderGated,
-          resolveAgentTargetIconUrl: this.dependencies.resolveAgentTargetIconUrl
+          resolveAgentTargetIconUrl: ({ agentTargetId, iconKey, provider }) =>
+            daemonAgentTargetIconUrls.get(agentTargetId)?.trim() ||
+            this.dependencies.resolveAgentTargetIconUrl?.({
+              iconKey,
+              provider
+            }) ||
+            ""
         }
       );
       const agents = dedupeAgentsByAgentTargetId([
@@ -350,6 +362,7 @@ export function mapWorkspaceAgentsToAgents(
   options: {
     isAgentTargetProviderGated?: (provider: string) => boolean;
     resolveAgentTargetIconUrl?: (identity: {
+      agentTargetId: string;
       iconKey: string | null;
       provider: string;
     }) => string;
@@ -373,6 +386,7 @@ export function mapWorkspaceAgentsToAgents(
         description: agent.description || null,
         iconUrl:
           options.resolveAgentTargetIconUrl?.({
+            agentTargetId: agent.harness.agentTargetId,
             iconKey: agent.harness.iconKey?.trim() || null,
             provider
           }) ?? "",

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
@@ -125,6 +125,7 @@ export function registerWorkspaceAgentServices(
       preferencesStore.featureFlags,
       EARLY_ACCESS_AGENT_INTEGRATIONS_FLAG
     ),
+    resolveAgentTargetIconUrl: input.resolveAgentTargetIconUrl,
     tuttidClient: input.tuttidClient,
     workspaceId: input.workspaceId
   });

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -445,10 +445,14 @@ idle | loading | ready | error
 `ready` may contain an authoritative empty list. `error` may retain the last successful snapshot. Components must not infer loading from `agents.length`.
 
 The directory owns Agent presentation. `agents[].iconUrl` is the primary
-identity used by conversation identity, Message Center, mentions, and the
-empty-home carousel and Provider Rail. `maskIconUrl` may supply the monochrome
-conversation-row glyph. Host projections preserve these roles independently
-and do not create provider-specific renderer catalogs.
+presentation asset used by conversation identity, Message Center, mentions,
+and the empty-home carousel and Provider Rail. It is decorative metadata:
+an Agent with an exact `agentTargetId` and name remains selectable when the
+icon is absent. `maskIconUrl` may supply the monochrome conversation-row glyph.
+Desktop Workspace Agent projections first inherit the resolved icon of their
+Harness target by exact target ID, then use the provider/icon catalog fallback.
+Host projections preserve these roles independently and do not create
+provider-specific renderer catalogs.
 
 When the Desktop host projects built-in Agent mentions into a workspace app,
 it replaces host-local file URLs with bounded 64px WebP data URLs. The external

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -454,6 +454,15 @@ Harness target by exact target ID, then use the provider/icon catalog fallback.
 Host projections preserve these roles independently and do not create
 provider-specific renderer catalogs.
 
+An Agent directory target ID is launch authority, not a provider-derived
+presentation key. Desktop must preserve daemon-returned extension identities
+such as `extension:<agent>` and must never rebuild them as `local:<provider>`.
+During a released built-in-to-extension migration, tuttid may retain one narrow
+version-skew alias at the target-resolution boundary; successful resolution
+rewrites both the Session target and provider to the installed extension's
+canonical values. The dynamic runtime still requires the exact extension
+installation reference and never accepts a local-target bypass.
+
 When the Desktop host projects built-in Agent mentions into a workspace app,
 it replaces host-local file URLs with bounded 64px WebP data URLs. The external
 bridge is the serialization owner: workspace apps must not read host paths,

--- a/docs/architecture/workspace-agents-and-automation.md
+++ b/docs/architecture/workspace-agents-and-automation.md
@@ -115,6 +115,15 @@ They do not look for a legacy binding whose key happens to equal the new Agent
 id. Plan and Agent mutations publish target-scoped configuration invalidation
 for the affected WorkspaceAgent ids.
 
+The daemon composition root must connect both sides of the WorkspaceAgent
+aggregate: its service resolves session launches, while its registry store
+validates activity-projection target identity. Launch resolution expands the
+opaque `workspace-agent:*` id into its trusted Harness, model route, and
+instructions; projection validation preserves that workspace-scoped id when
+sessions are persisted, listed, or restored. Wiring only one side either makes
+creation fail with an unavailable resolver or makes an otherwise valid Agent
+disappear from restored session state.
+
 Fallback resolution applies only while creating a new session. It does not
 mutate the Agent, and the actual selected Plan/model/revision is persisted in
 the immutable session snapshot. Editing fallback order affects later sessions

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -4,6 +4,40 @@
 
 Provider discovery, installation, authentication, models, configuration, and runtime reachability.
 
+### Kimi Code session creation reports `requires an agent_extension target`
+
+- Symptom:
+  Selecting an installed Kimi Code Agent immediately fails session creation
+  with `dynamic provider "kimi-code" requires an agent_extension target`.
+- Quick checks:
+  Correlate the renderer's create-session request with the daemon error. If the
+  request carries `agentTargetId = local:kimi-code`, inspect `agent_targets`.
+  An installed externalized Kimi runtime should instead have the canonical
+  target `extension:kimi-code`, provider `acp:kimi-code`, and an
+  `agent_extension` launch reference.
+- Root cause:
+  A released Desktop/daemon version-skew window allowed a renderer that still
+  knew Kimi as a built-in local target to talk to a daemon that already required
+  the externalized Extension identity. The runtime correctly rejected the
+  stale local identity because a dynamic provider must launch through its
+  installed Extension.
+- Fix:
+  Preserve daemon-provided target and provider identities throughout Desktop
+  projection. At the daemon create boundary, resolve only the known released
+  `local:kimi-code` alias, and only when the canonical installed Extension
+  target exists. Rewrite the request to `extension:kimi-code` /
+  `acp:kimi-code` before persistence and launch. Do not weaken the dynamic
+  provider's `agent_extension` requirement or construct a launch reference
+  from the stale request.
+- Validation:
+  Cover Desktop projection of the canonical Kimi Extension identity, alias
+  resolution with and without the installed target, and create-session launch
+  canonicalization including the trusted Extension installation ID.
+- References:
+  [agent-gui-node.md](../../architecture/agent-gui-node.md)
+  [agent_store.go](../../../services/tuttid/data/workspace/agent_store.go)
+  [service.go](../../../services/tuttid/service/agent/service.go)
+
 ### Focusing a workspace repeatedly starts provider CLIs and raises CPU usage
 
 - Symptom:

--- a/packages/agent/gui/agents.test.ts
+++ b/packages/agent/gui/agents.test.ts
@@ -34,7 +34,7 @@ describe("normalizeAgentGUIAgents", () => {
     expect(agents.map((agent) => agent.provider)).toEqual(["codex", "codex"]);
   });
 
-  it("drops invalid and duplicate identities while normalizing presentation", () => {
+  it("drops invalid and duplicate identities while retaining iconless Agents", () => {
     const agents = normalizeAgentGUIAgents([
       createAgent(" alice ", {
         name: " Alice ",
@@ -65,6 +65,13 @@ describe("normalizeAgentGUIAgents", () => {
         owner: { name: "Owner", avatarUrl: "app://owner.png" },
         ownership: "shared",
         availability: { status: "unavailable", reason: "Offline" },
+        provider: "codex"
+      },
+      {
+        agentTargetId: "missing-icon",
+        name: "missing-icon",
+        iconUrl: "",
+        availability: { status: "ready" },
         provider: "codex"
       }
     ]);
@@ -100,6 +107,21 @@ describe("projectAgentGUIAgentsToTargets", () => {
       iconUrl: "app://agents/agent-a.png",
       maskIconUrl: "app://agents/agent-a-mask.png"
     });
+  });
+
+  it("keeps an Agent without decorative icon metadata selectable", () => {
+    const agents = normalizeAgentGUIAgents([
+      createAgent("workspace-agent:reviewer", { iconUrl: " " })
+    ]);
+
+    const [target] = projectAgentGUIAgentsToTargets(agents);
+
+    expect(target).toMatchObject({
+      agentTargetId: "workspace-agent:reviewer",
+      iconUrl: "",
+      targetId: "workspace-agent:reviewer"
+    });
+    expect(target?.disabled).toBeUndefined();
   });
 
   it("preserves availability separately from disabled interaction state", () => {

--- a/packages/agent/gui/agents.ts
+++ b/packages/agent/gui/agents.ts
@@ -16,12 +16,7 @@ export function normalizeAgentGUIAgents(
     const maskIconUrl = agent.maskIconUrl?.trim() ?? "";
     const heroImageUrl = agent.heroImageUrl?.trim() ?? "";
     const ownerDeviceLabel = agent.ownerDeviceLabel?.trim() ?? "";
-    if (
-      !agentTargetId ||
-      !name ||
-      !iconUrl ||
-      seenAgentTargetIds.has(agentTargetId)
-    ) {
+    if (!agentTargetId || !name || seenAgentTargetIds.has(agentTargetId)) {
       continue;
     }
     seenAgentTargetIds.add(agentTargetId);

--- a/services/tuttid/data/workspace/agent_store.go
+++ b/services/tuttid/data/workspace/agent_store.go
@@ -25,6 +25,8 @@ var _ AgentActivityStore = (*SQLiteStore)(nil)
 
 const legacyIDLocalCodex = "local-codex"
 const legacyIDLocalClaudeCode = "local-claude-code"
+const legacyIDLocalKimiCode = "local:kimi-code"
+const extensionIDKimiCode = "extension:kimi-code"
 
 func newAgentStore(db *sql.DB) *agentstore.Store {
 	return agentstore.New(db, agentstore.Options{
@@ -523,13 +525,20 @@ func (s *SQLiteStore) DeleteAgentTarget(ctx context.Context, id string) error {
 // Contract: cross-domain id translation is owned by the host projection layer
 // (tsh/tutti-os rewrites a shared session's owner-domain agentTargetId to the
 // caller-local `shared-agent:{sharedAgentId}` id at its sync boundary), so
-// owner-domain ids are never expected to reach this store and no alias column
-// is planned. This hook exists purely as defense in depth for the ingestion
-// boundary in services/tuttid/service/agent: a hit means an upstream missed
-// its translation. The store-backed implementation therefore resolves
-// nothing.
-func (*SQLiteStore) ResolveAgentTargetAlias(context.Context, string) (string, bool) {
-	return "", false
+// owner-domain ids are never expected to reach this store and no general alias
+// column is planned. The one local alias below bridges a released Desktop /
+// daemon version-skew window from Kimi Code's built-in target to its
+// extension-owned target. It resolves only while the canonical extension
+// target exists, preserving the extension installation as launch authority.
+func (s *SQLiteStore) ResolveAgentTargetAlias(ctx context.Context, id string) (string, bool) {
+	if strings.TrimSpace(id) != legacyIDLocalKimiCode {
+		return "", false
+	}
+	target, err := s.GetAgentTarget(ctx, extensionIDKimiCode)
+	if err != nil || strings.TrimSpace(target.ID) != extensionIDKimiCode {
+		return "", false
+	}
+	return extensionIDKimiCode, true
 }
 
 func agentTargetToStore(target agenttargetbiz.Target) agentstore.Target {

--- a/services/tuttid/data/workspace/sqlite_agent_targets_test.go
+++ b/services/tuttid/data/workspace/sqlite_agent_targets_test.go
@@ -167,6 +167,41 @@ VALUES ('ws-legacy-targets', 'session-1', 'runtime', ?, 'codex', ?, ?);
 	}
 }
 
+func TestSQLiteStoreResolvesExternalizedKimiTargetAlias(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	if canonicalID, ok := store.ResolveAgentTargetAlias(ctx, legacyIDLocalKimiCode); ok || canonicalID != "" {
+		t.Fatalf("ResolveAgentTargetAlias(missing extension) = %q, %v; want empty, false", canonicalID, ok)
+	}
+	launchRef, err := agenttargetbiz.CanonicalLaunchRefJSON("acp:kimi-code", agenttargetbiz.LaunchRef{
+		Type:                    agenttargetbiz.LaunchRefTypeAgentExtension,
+		ExtensionInstallationID: "kimi-code@1.0.1",
+	})
+	if err != nil {
+		t.Fatalf("CanonicalLaunchRefJSON() error = %v", err)
+	}
+	if _, err := store.PutAgentTarget(ctx, agenttargetbiz.Target{
+		ID:            extensionIDKimiCode,
+		Provider:      "acp:kimi-code",
+		LaunchRefJSON: launchRef,
+		Name:          "Kimi Code",
+		Enabled:       true,
+		Source:        agenttargetbiz.SourceSystem,
+	}); err != nil {
+		t.Fatalf("PutAgentTarget() error = %v", err)
+	}
+
+	canonicalID, ok := store.ResolveAgentTargetAlias(ctx, legacyIDLocalKimiCode)
+	if !ok || canonicalID != extensionIDKimiCode {
+		t.Fatalf("ResolveAgentTargetAlias() = %q, %v; want %q, true", canonicalID, ok, extensionIDKimiCode)
+	}
+	if canonicalID, ok := store.ResolveAgentTargetAlias(ctx, "local:unknown"); ok || canonicalID != "" {
+		t.Fatalf("ResolveAgentTargetAlias(unknown) = %q, %v; want empty, false", canonicalID, ok)
+	}
+}
+
 func TestSQLiteStorePutAgentTargetRejectsInvalidLaunchRefs(t *testing.T) {
 	t.Parallel()
 

--- a/services/tuttid/main_test.go
+++ b/services/tuttid/main_test.go
@@ -104,16 +104,7 @@ func TestProcessExists(t *testing.T) {
 }
 
 func TestWiringUsesSupervisedAgentHostRun(t *testing.T) {
-	var source strings.Builder
-	for _, file := range []string{"wiring.go", "wiring_daemon_api.go"} {
-		raw, err := os.ReadFile(file)
-		if err != nil {
-			t.Fatalf("read %s: %v", file, err)
-		}
-		source.Write(raw)
-		source.WriteByte('\n')
-	}
-	combined := source.String()
+	combined := readProductionWiring(t)
 	if !strings.Contains(combined, "agentHost.Run(ctx)") {
 		t.Fatal("production wiring does not start the supervised Agent Host lifecycle")
 	}
@@ -127,6 +118,32 @@ func TestWiringUsesSupervisedAgentHostRun(t *testing.T) {
 			t.Fatalf("production wiring still starts an unsupervised Host worker: %s", legacy)
 		}
 	}
+}
+
+func TestWiringConnectsWorkspaceAgentSessionResolvers(t *testing.T) {
+	combined := readProductionWiring(t)
+	for _, wiring := range []string{
+		"agentActivityProjection.SetWorkspaceAgentTargetResolver(workspaceAgentsStore)",
+		"agentSessionService.WorkspaceAgentResolver = workspaceAgents",
+	} {
+		if !strings.Contains(combined, wiring) {
+			t.Fatalf("production wiring does not connect Workspace Agent session dependency: %s", wiring)
+		}
+	}
+}
+
+func readProductionWiring(t *testing.T) string {
+	t.Helper()
+	var source strings.Builder
+	for _, file := range []string{"wiring.go", "wiring_daemon_api.go"} {
+		raw, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		source.Write(raw)
+		source.WriteByte('\n')
+	}
+	return source.String()
 }
 
 func testLogger() *slog.Logger {

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -381,6 +381,20 @@ func (s *Service) resolveCreateSessionLaunch(ctx context.Context, workspaceID st
 		return resolvedCreateSessionLaunch{}, fmt.Errorf("%w: agent target store is unavailable", ErrInvalidArgument)
 	}
 	target, err := s.AgentTargetStore.GetAgentTarget(ctx, agentTargetID)
+	resolvedFromAlias := false
+	if errors.Is(err, workspacedata.ErrAgentTargetNotFound) {
+		if aliases, ok := s.AgentTargetStore.(AgentTargetResolver); ok {
+			canonicalID, aliasFound := aliases.ResolveAgentTargetAlias(ctx, agentTargetID)
+			canonicalID = strings.TrimSpace(canonicalID)
+			if aliasFound && canonicalID != "" && canonicalID != agentTargetID {
+				target, err = s.AgentTargetStore.GetAgentTarget(ctx, canonicalID)
+				if err == nil {
+					input.AgentTargetID = canonicalID
+					resolvedFromAlias = true
+				}
+			}
+		}
+	}
 	if err != nil {
 		if errors.Is(err, workspacedata.ErrAgentTargetNotFound) {
 			return resolvedCreateSessionLaunch{}, fmt.Errorf("%w: agent target not found", ErrInvalidArgument)
@@ -400,7 +414,9 @@ func (s *Service) resolveCreateSessionLaunch(ctx context.Context, workspaceID st
 	}
 	derivedProvider, _ := derivedRef["provider"].(string)
 	derivedProvider = strings.TrimSpace(derivedProvider)
-	if requestProvider != "" && requestProvider != derivedProvider {
+	if requestProvider != "" &&
+		requestProvider != derivedProvider &&
+		(!resolvedFromAlias || "acp:"+requestProvider != derivedProvider) {
 		return resolvedCreateSessionLaunch{}, fmt.Errorf("%w: provider does not match agent target", ErrInvalidArgument)
 	}
 	input.HarnessAgentTargetID = normalized.ID

--- a/services/tuttid/service/agent/workspace_agent_resolution_test.go
+++ b/services/tuttid/service/agent/workspace_agent_resolution_test.go
@@ -2,11 +2,13 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	modelplanbiz "github.com/tutti-os/tutti/services/tuttid/biz/modelplan"
 	workspaceagentbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceagent"
+	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
 )
 
 type staticWorkspaceAgentResolver struct {
@@ -16,6 +18,77 @@ type staticWorkspaceAgentResolver struct {
 
 func (s staticWorkspaceAgentResolver) Resolve(context.Context, string, string) (workspaceagentbiz.Resolved, error) {
 	return s.resolved, s.err
+}
+
+type aliasingAgentTargetStore struct {
+	targets map[string]agenttargetbiz.Target
+	aliases map[string]string
+}
+
+func (s aliasingAgentTargetStore) GetAgentTarget(_ context.Context, id string) (agenttargetbiz.Target, error) {
+	target, ok := s.targets[id]
+	if !ok {
+		return agenttargetbiz.Target{}, workspacedata.ErrAgentTargetNotFound
+	}
+	return target, nil
+}
+
+func (s aliasingAgentTargetStore) ResolveAgentTargetAlias(_ context.Context, id string) (string, bool) {
+	canonicalID, ok := s.aliases[id]
+	return canonicalID, ok
+}
+
+func TestResolveCreateSessionLaunchCanonicalizesExternalizedAgentTargetAlias(t *testing.T) {
+	const extensionTargetID = "extension:kimi-code"
+	launchRef, err := agenttargetbiz.CanonicalLaunchRefJSON("acp:kimi-code", agenttargetbiz.LaunchRef{
+		Type:                    agenttargetbiz.LaunchRefTypeAgentExtension,
+		ExtensionInstallationID: "kimi-code@1.0.1",
+	})
+	if err != nil {
+		t.Fatalf("CanonicalLaunchRefJSON() error = %v", err)
+	}
+	service := &Service{
+		AgentTargetStore: aliasingAgentTargetStore{
+			targets: map[string]agenttargetbiz.Target{
+				extensionTargetID: {
+					ID:            extensionTargetID,
+					Provider:      "acp:kimi-code",
+					LaunchRefJSON: launchRef,
+					Name:          "Kimi Code",
+					Enabled:       true,
+					Source:        agenttargetbiz.SourceSystem,
+				},
+			},
+			aliases: map[string]string{"local:kimi-code": extensionTargetID},
+		},
+	}
+	input := CreateSessionInput{
+		AgentTargetID: "local:kimi-code",
+		Provider:      "kimi-code",
+	}
+
+	launch, err := service.resolveCreateSessionLaunch(context.Background(), "ws", &input)
+	if err != nil {
+		t.Fatalf("resolveCreateSessionLaunch() error = %v", err)
+	}
+	if input.AgentTargetID != extensionTargetID || input.HarnessAgentTargetID != extensionTargetID {
+		t.Fatalf("canonical target identity = %q / %q, want %q", input.AgentTargetID, input.HarnessAgentTargetID, extensionTargetID)
+	}
+	if launch.Provider != "acp:kimi-code" {
+		t.Fatalf("launch provider = %q, want acp:kimi-code", launch.Provider)
+	}
+	if launch.ProviderTargetRef["kind"] != agenttargetbiz.LaunchRefTypeAgentExtension ||
+		launch.ProviderTargetRef["extensionInstallationId"] != "kimi-code@1.0.1" {
+		t.Fatalf("launch target ref = %#v", launch.ProviderTargetRef)
+	}
+
+	mismatched := CreateSessionInput{
+		AgentTargetID: "local:kimi-code",
+		Provider:      "claude-code",
+	}
+	if _, err := service.resolveCreateSessionLaunch(context.Background(), "ws", &mismatched); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("resolveCreateSessionLaunch(mismatched provider) error = %v, want ErrInvalidArgument", err)
+	}
 }
 
 func TestResolveCreateSessionLaunchHydratesWorkspaceAgentRuntimeConfiguration(t *testing.T) {

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -203,6 +203,7 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 	if agentTargetResolver, ok := store.(agentservice.AgentTargetResolver); ok {
 		agentActivityProjection.SetAgentTargetResolver(agentTargetResolver)
 	}
+	agentActivityProjection.SetWorkspaceAgentTargetResolver(workspaceAgentsStore)
 	managedRuntimeResolver := managedruntime.DefaultResolver{}
 	// Shared so a runtime auth failure (reporter side) surfaces in the status
 	// probe (List side) — see agentRunOutcomeReporter.
@@ -270,6 +271,7 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 	}
 	agentRuntimeController := newAgentRuntimeAdapter(agentRuntime.Controller())
 	agentSessionService := agentservice.NewService(agentRuntimeController)
+	agentSessionService.WorkspaceAgentResolver = workspaceAgents
 	if browserService != nil {
 		agentSessionService.AgentSessionResourceReleaser = browserService
 	}


### PR DESCRIPTION
## Summary

- restore exact Harness target icon inheritance so custom Workspace Agents remain visible and selectable
- wire WorkspaceAgent launch resolution and activity-projection validation into the production daemon composition root
- bridge the released Kimi Code built-in-to-Extension version-skew window by canonicalizing `local:kimi-code` to the installed `extension:kimi-code` target
- preserve the strict `agent_extension` launch requirement and trusted Extension installation reference
- document the target identity, WorkspaceAgent wiring, and troubleshooting contracts

## Root causes

1. Custom Agent directory projection depended on an optional icon resolver that was not wired into `DesktopAgentsService`; entries without a decorative icon were then dropped before the composer menu and provider rail were projected.
2. Production constructed the WorkspaceAgent aggregate but did not attach its resolver to Agent session creation or its registry store to activity projection. Session creation therefore failed with `workspace agent resolver is unavailable`, while restored sessions could lose their `workspace-agent:*` target identity.
3. During Kimi Code externalization, a released/stale renderer could still submit `local:kimi-code` with provider `kimi-code` to a daemon that correctly requires the installed Extension identity `extension:kimi-code` / `acp:kimi-code`.

## Compatibility boundary

The daemon alias is intentionally narrow. It resolves only `local:kimi-code`, only if the canonical installed Extension target exists, then rewrites target/provider identity before persistence and launch. Missing Extensions and unrelated provider mismatches still fail. The dynamic runtime guard requiring an `agent_extension` target is unchanged.

## Validation

- focused Desktop agent-directory tests: 8/8
- full affected Go packages: `service/agent`, `data/workspace`
- production wiring regression tests
- Kimi alias positive, missing-installation, and provider-mismatch regressions
- `pnpm lint:go`
- `pnpm typecheck` (27 packages)
- `pnpm check:agent-host-boundary`
- Desktop production build and renderer CSS contracts
- full Go workspace tests: 14 lanes
- Go workspace build
- `pnpm check:changed`: 18/18 lanes
- pre-push `pnpm check:changed -- --push-ready`: 20/20 lanes (passed twice)