### PR TITLE
feat(ui-system): add --background-board-card token for task board surfaces

### DIFF
--- a/apps/ui-storyboard/src/foundation/colors.json
+++ b/apps/ui-storyboard/src/foundation/colors.json
@@ -40,6 +40,12 @@
           "usage": "菜单、select、右键菜单等前置浮层"
         },
         {
+          "label": "--background-board-card",
+          "dark": "rgba(255, 255, 255, 0.08)",
+          "light": "rgb(255, 255, 255)",
+          "usage": "任务中心 board 卡片及分段控件选中滑块等板卡实底"
+        },
+        {
           "label": "--transparency-block",
           "dark": "rgba(255, 255, 255, 0.05)",
           "light": "rgba(60, 60, 60, 0.04)",

--- a/packages/ui/system/src/styles/semantic.css
+++ b/packages/ui/system/src/styles/semantic.css
@@ -7,6 +7,7 @@
   --color-background-session-flow: var(--background-session-flow);
   --color-background-session-sidepanel: var(--background-session-sidepanel);
   --color-background-fronted: var(--background-fronted);
+  --color-background-board-card: var(--background-board-card);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
   --color-card-foreground: var(--card-foreground);

--- a/packages/ui/system/src/styles/theme.css
+++ b/packages/ui/system/src/styles/theme.css
@@ -23,6 +23,7 @@
   --background-session-sidepanel: rgb(244 245 247);
   --background-fronted: rgb(255 255 255 / 1);
   --background-soft: oklch(0.968 0.006 84);
+  --background-board-card: rgb(255 255 255 / 1);
   --foreground: oklch(0.248 0.016 258);
   --text-primary: rgb(60 60 60);
   --text-primary-hover: rgb(60 60 60 / 90%);
@@ -211,6 +212,7 @@
   --background-session-sidepanel: rgb(42 42 43);
   --background-fronted: rgb(51 51 51 / 1);
   --background-soft: oklch(0.224 0.01 255);
+  --background-board-card: rgb(255 255 255 / 8%);
   --foreground: oklch(0.955 0.004 84);
   --text-primary: rgb(255 255 255);
   --text-primary-hover: rgb(255 255 255 / 90%);
@@ -389,6 +391,7 @@
     --background-session-sidepanel: rgb(42 42 43);
     --background-fronted: rgb(51 51 51 / 1);
     --background-soft: oklch(0.224 0.01 255);
+    --background-board-card: rgb(255 255 255 / 8%);
     --foreground: oklch(0.955 0.004 84);
     --text-primary: rgb(255 255 255);
     --text-primary-hover: rgb(255 255 255 / 90%);

--- a/packages/workspace/issue-manager/src/ui/internal/issue/IssueManagerIssueSections.tsx
+++ b/packages/workspace/issue-manager/src/ui/internal/issue/IssueManagerIssueSections.tsx
@@ -394,7 +394,7 @@ function IssueManagerSubtaskViewModeSwitch({
       <span
         aria-hidden="true"
         className={cn(
-          "absolute top-0.5 bottom-0.5 left-0.5 w-[calc((100%-4px)/2)] rounded-[5px] bg-[var(--background-fronted)] transition-transform duration-150 ease-out",
+          "absolute top-0.5 bottom-0.5 left-0.5 w-[calc((100%-4px)/2)] rounded-[5px] bg-[var(--background-board-card)] transition-transform duration-150 ease-out",
           value === "board" && "translate-x-full"
         )}
       />

--- a/packages/workspace/issue-manager/src/ui/internal/issue/IssueManagerSubtaskBoard.tsx
+++ b/packages/workspace/issue-manager/src/ui/internal/issue/IssueManagerSubtaskBoard.tsx
@@ -710,7 +710,7 @@ function IssueManagerSubtaskBoardColumn({
             >
               <button
                 className={cn(
-                  "rounded-[8px] bg-[var(--background-fronted)] px-3 py-2.5 text-left transition-shadow duration-150 motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/25",
+                  "rounded-[8px] bg-[var(--background-board-card)] px-3 py-2.5 text-left transition-shadow duration-150 motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/25",
                   "cursor-grab active:cursor-grabbing",
                   isDraggingTask && issueManagerSubtaskDragShadowClassName
                 )}


### PR DESCRIPTION
## What

- Add shared UI-system token `--background-board-card` (light: `rgb(255 255 255 / 1)`, dark: `rgb(255 255 255 / 8%)`) in `packages/ui-system` theme styles, with the Tailwind-facing semantic mapping `--color-background-board-card`
- Apply the token to the task center board/list segment control slider (`IssueManagerIssueSections.tsx`) and board cards (`IssueManagerSubtaskBoard.tsx`), replacing direct `--background-fronted` usage
- Register the token in the storyboard foundation colors data

## Why

Board card backgrounds should be themable through a single UI-system token instead of reusing the generic fronted-overlay token.

## Validation

- `pnpm check:ui-boundaries` ✅
- `pnpm typecheck` (27 packages) ✅
- `pnpm --filter @tutti-os/ui-storyboard typecheck` ✅
- pre-commit / pre-push changed-aware checks ✅
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->