### PR TITLE
fix(agent-gui): count turn time from client submission

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -396,6 +396,11 @@ A focused controller may own detail paging/loading/error. Canonical messages, Tu
 
 Timeline projection is pure, deterministic, and provider-neutral. React views render rows/cards and dispatch actions.
 
+Turn elapsed-time presentation starts at the client submission timestamp carried
+by the canonical user-message payload, not at provider runtime start. Historical
+activity without that timestamp falls back to the leading user-message
+timestamp.
+
 High-frequency transcript updates must not pair DOM mutation with unconditional synchronous reads of the timeline's full scroll geometry. Conversation switches, explicit submit-to-bottom requests, skeleton transitions, and older-page prepend restoration may perform pre-paint scroll correction; ordinary content growth preserves bottom lock and user scroll-away state from observed content and viewport geometry after layout.
 
 A virtualized transcript derives message-locator selection from the virtualizer's measured turn positions and explicit transcript identity. The currently mounted DOM window is rendering output, not a selection source; range changes must not make the locator temporarily select a neighboring message.

--- a/packages/agent/daemon/runtime/prompt_content.go
+++ b/packages/agent/daemon/runtime/prompt_content.go
@@ -211,6 +211,9 @@ func userPromptActivityPayloadExtraFromMetadata(metadata map[string]any, extra m
 		payload = map[string]any{}
 	}
 	payload["clientSubmitId"] = clientSubmitID
+	if submittedAtUnixMS := metadataInt64(metadata, "clientSubmittedAtUnixMs"); submittedAtUnixMS > 0 {
+		payload["clientSubmittedAtUnixMs"] = submittedAtUnixMS
+	}
 	if strings.TrimSpace(payloadString(payload, "messageId")) == "" {
 		payload["messageId"] = userPromptActivityMessageIDFromClientSubmitID(clientSubmitID)
 	}

--- a/packages/agent/daemon/runtime/prompt_content_test.go
+++ b/packages/agent/daemon/runtime/prompt_content_test.go
@@ -162,13 +162,15 @@ func TestUserPromptActivityPayloadExtraFromExecMetadataAddsClientSubmitIdentity(
 	t.Parallel()
 
 	ctx := context.WithValue(context.Background(), execMetadataContextKey{}, map[string]any{
-		"clientSubmitId": "submit-1",
+		"clientSubmitId":          "submit-1",
+		"clientSubmittedAtUnixMs": int64(1234),
 	})
 	extra := userPromptActivityPayloadExtraFromExecMetadata(ctx, map[string]any{
 		"steered": true,
 	})
 
 	if extra["clientSubmitId"] != "submit-1" ||
+		extra["clientSubmittedAtUnixMs"] != int64(1234) ||
 		extra["messageId"] != "client-submit:user:submit-1" ||
 		extra["steered"] != true {
 		t.Fatalf("extra = %#v, want client submit identity and existing fields", extra)

--- a/packages/agent/gui/shared/agentConversation/components/agentTurnWorkSectionModel.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTurnWorkSectionModel.spec.ts
@@ -53,6 +53,41 @@ describe("agentTurnWorkSectionModel", () => {
     ).toBeNull();
   });
 
+  it("counts settled turn time from client submission", () => {
+    const prompt = {
+      ...message("Please fix it", null),
+      occurredAtUnixMs: 2_000,
+      sourceTimelineItems: [
+        {
+          id: 1,
+          agentSessionId: "session-1",
+          eventId: "user-1",
+          actorType: "user",
+          actorId: "user",
+          itemType: "message",
+          payload: { clientSubmittedAtUnixMs: 1_000 },
+          occurredAtUnixMs: 2_000
+        }
+      ]
+    };
+    const reply = message("Final answer", "Final answer", true);
+
+    const model = buildAgentTurnWorkSectionModel(
+      turnGroup([
+        userRow({ occurredAtUnixMs: 2_000, messages: [prompt] }),
+        assistantRow({ occurredAtUnixMs: 10_000, messages: [reply] })
+      ]),
+      canonicalTurn({
+        phase: "settled",
+        outcome: "completed",
+        startedAtUnixMs: 6_000,
+        settledAtUnixMs: 13_000
+      })
+    );
+
+    expect(model.timing).toEqual({ kind: "settled", elapsedSeconds: 12 });
+  });
+
   it("formats seconds and minute boundaries without a zero-second suffix", () => {
     expect(formatAgentTurnDuration(45)).toEqual({
       kind: "seconds",

--- a/packages/agent/gui/shared/agentConversation/components/agentTurnWorkSectionModel.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTurnWorkSectionModel.ts
@@ -37,22 +37,28 @@ interface AgentTurnWorkSectionOptions {
 
 export function resolveAgentTurnTiming(
   turn: AgentActivityTurn | null | undefined,
-  isActiveTurn: boolean
+  isActiveTurn: boolean,
+  submittedAtUnixMs?: number | null
 ): AgentTurnTiming | null {
   if (!turn || !Number.isFinite(turn.startedAtUnixMs)) {
     return null;
   }
+  const timingStartedAtUnixMs =
+    Number.isFinite(submittedAtUnixMs) &&
+    (submittedAtUnixMs as number) <= turn.startedAtUnixMs
+      ? (submittedAtUnixMs as number)
+      : turn.startedAtUnixMs;
 
   if (turn.phase !== "settled") {
     return isActiveTurn
-      ? { kind: "live", startedAtUnixMs: turn.startedAtUnixMs }
+      ? { kind: "live", startedAtUnixMs: timingStartedAtUnixMs }
       : null;
   }
 
   const endUnixMs = turn.settledAtUnixMs;
   if (
     !Number.isFinite(endUnixMs) ||
-    (endUnixMs as number) < turn.startedAtUnixMs
+    (endUnixMs as number) < timingStartedAtUnixMs
   ) {
     return null;
   }
@@ -61,7 +67,7 @@ export function resolveAgentTurnTiming(
     kind: "settled",
     elapsedSeconds: Math.max(
       0,
-      Math.floor(((endUnixMs as number) - turn.startedAtUnixMs) / 1_000)
+      Math.floor(((endUnixMs as number) - timingStartedAtUnixMs) / 1_000)
     )
   };
 }
@@ -88,13 +94,17 @@ export function buildAgentTurnWorkSectionModel(
   isActiveTurn = false,
   options: AgentTurnWorkSectionOptions = {}
 ): AgentTurnWorkSectionModel | null {
-  const timing = resolveAgentTurnTiming(turn, isActiveTurn);
+  const leadingRowCount = countLeadingUserRows(group.rows);
+  const leadingRows = group.rows.slice(0, leadingRowCount);
+  const submittedAtUnixMs = resolveTurnSubmittedAtUnixMs(
+    leadingRows,
+    turn?.startedAtUnixMs
+  );
+  const timing = resolveAgentTurnTiming(turn, isActiveTurn, submittedAtUnixMs);
   if (!timing) {
     return null;
   }
 
-  const leadingRowCount = countLeadingUserRows(group.rows);
-  const leadingRows = group.rows.slice(0, leadingRowCount);
   const finalTarget = findFinalAssistantTextTarget(group.rows);
   const sections = buildOrderedSections(
     group.rows,
@@ -119,6 +129,50 @@ export function buildAgentTurnWorkSectionModel(
     sections,
     collapseEligible
   };
+}
+
+function resolveTurnSubmittedAtUnixMs(
+  leadingRows: readonly AgentTurnWorkSectionRow[],
+  fallbackUnixMs: number | null | undefined
+): number | null {
+  const exactTimestamps = leadingRows.flatMap(({ row }) => {
+    if (row.kind !== "message" || row.speaker !== "user") {
+      return [];
+    }
+    return row.messages.flatMap((message) =>
+      (message.sourceTimelineItems ?? []).flatMap((item) => {
+        const value = item.payload?.clientSubmittedAtUnixMs;
+        return validUnixMs(value) ? [value] : [];
+      })
+    );
+  });
+  const exact = minimumTimestamp(exactTimestamps);
+  if (exact !== null) {
+    return exact;
+  }
+
+  const projected = minimumTimestamp(
+    leadingRows.flatMap(({ row }) =>
+      row.kind === "message" && row.speaker === "user"
+        ? [
+            row.occurredAtUnixMs,
+            ...row.messages.map((message) => message.occurredAtUnixMs)
+          ]
+        : []
+    )
+  );
+  return projected ?? (validUnixMs(fallbackUnixMs) ? fallbackUnixMs : null);
+}
+
+function minimumTimestamp(
+  values: readonly (number | null | undefined)[]
+): number | null {
+  const valid = values.filter(validUnixMs);
+  return valid.length > 0 ? Math.min(...valid) : null;
+}
+
+function validUnixMs(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
 }
 
 function countLeadingUserRows(


### PR DESCRIPTION
## Summary

- Preserve the client submission timestamp in canonical user-message activity.
- Count the existing AgentGUI total duration from client submission instead of provider runtime start.
- Keep the current total-duration UI and wording unchanged.

## Why

The previous total omitted the delay between user submission and provider runtime start.

## Risks

- Affects only the start point used by the existing live and settled total-duration calculation.
- Historical activity without the exact submission timestamp falls back to the leading user-message timestamp.

## Tests

- `go test ./packages/agent/daemon/runtime -run TestUserPromptActivityPayloadExtraFromExecMetadataAddsClientSubmitIdentity`
- `corepack pnpm --dir packages/agent/gui exec vitest run --environment jsdom --maxWorkers=3 shared/agentConversation/components/agentTurnWorkSectionModel.spec.ts` (12 tests passed)
- `pnpm check:changed -- --push-ready` (16 lanes passed)

## Notes

- No stage breakdown, UI layout, or localization changes are included.
- Publishing the updated Tutti package cohort and upgrading TSH remain follow-up work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->