### PR TITLE
fix(auth): bound desktop bridge shutdown

### DIFF
--- a/packages/auth/bridge/src/node.test.ts
+++ b/packages/auth/bridge/src/node.test.ts
@@ -6,7 +6,7 @@ import {
   type Server,
   type ServerResponse
 } from "node:http";
-import type { AddressInfo } from "node:net";
+import { createConnection, type AddressInfo, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -163,6 +163,79 @@ test("node login callback redirects to web result after writing auth json", asyn
       device_id: accountServer.requests.redeem?.device_id
     });
   } finally {
+    await accountServer.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("node login completes when another bridge connection is stalled", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tutti-auth-bridge-"));
+  const file = join(dir, "auth.json");
+  const accountServer = await startAccountStub();
+  let stalledSocket: Socket | undefined;
+  let stalledSocketClosed: Promise<void> | undefined;
+  try {
+    const authBase = `http://127.0.0.1:${accountServer.port}`;
+    const auth = createTuttiNodeAuthClient({
+      authJsonPath: file,
+      appCallbackUrl: "tutti://auth/login",
+      accountBaseUrl: authBase,
+      authLoginUrl: `${authBase}/auth/login`,
+      openUrl: async (loginUrl) => {
+        const state = new URL(loginUrl).searchParams.get("state") ?? "";
+        const bridgeUrl = new URL(decodeState(state).localServerOrigin ?? "");
+        stalledSocket = createConnection({
+          host: bridgeUrl.hostname,
+          port: Number(bridgeUrl.port)
+        });
+        stalledSocketClosed = new Promise<void>((resolve) => {
+          stalledSocket?.once("close", resolve);
+        });
+        await new Promise<void>((resolve, reject) => {
+          stalledSocket?.once("connect", resolve);
+          stalledSocket?.once("error", reject);
+        });
+        stalledSocket.write(
+          `GET /oauth/health HTTP/1.1\r\nHost: ${bridgeUrl.host}\r\n`
+        );
+
+        const callbackUrl = new URL("/oauth/callback", bridgeUrl);
+        callbackUrl.searchParams.set("state", state);
+        callbackUrl.searchParams.set("transfer_code", "transfer-1");
+        const callbackResponse = await fetch(callbackUrl, {
+          redirect: "manual"
+        });
+        assert.equal(callbackResponse.status, 302);
+        assert.equal(callbackResponse.headers.get("connection"), "close");
+      }
+    });
+
+    let timeout: NodeJS.Timeout | undefined;
+    const result = await Promise.race([
+      auth.login(),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error("login did not close the bridge in time")),
+          2_500
+        );
+      })
+    ]).finally(() => clearTimeout(timeout));
+    assert.equal(result.session.sessionId, "desktop-session-1");
+    let socketCloseTimeout: NodeJS.Timeout | undefined;
+    await Promise.race([
+      stalledSocketClosed,
+      new Promise<never>((_, reject) => {
+        socketCloseTimeout = setTimeout(
+          () =>
+            reject(
+              new Error("stalled bridge connection did not close in time")
+            ),
+          2_500
+        );
+      })
+    ]).finally(() => clearTimeout(socketCloseTimeout));
+  } finally {
+    stalledSocket?.destroy();
     await accountServer.close();
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/auth/bridge/src/node.ts
+++ b/packages/auth/bridge/src/node.ts
@@ -29,6 +29,8 @@ import {
   trimString
 } from "./shared";
 
+const BRIDGE_SERVER_FORCE_CLOSE_TIMEOUT_MS = 1_000;
+
 export interface TuttiNodeAuthClientOptions {
   authJsonPath: string;
   appCallbackUrl: string;
@@ -694,7 +696,8 @@ function sendCors(res: ServerResponse, status: number): void {
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type",
-    "Access-Control-Allow-Private-Network": "true"
+    "Access-Control-Allow-Private-Network": "true",
+    Connection: "close"
   });
   res.end();
 }
@@ -718,13 +721,14 @@ function sendJson(res: ServerResponse, status: number, payload: unknown): void {
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type",
     "Access-Control-Allow-Private-Network": "true",
-    "Content-Type": "application/json; charset=utf-8"
+    "Content-Type": "application/json; charset=utf-8",
+    Connection: "close"
   });
   res.end(JSON.stringify(payload));
 }
 
 function sendRedirect(res: ServerResponse, location: string): void {
-  res.writeHead(302, { Location: location });
+  res.writeHead(302, { Location: location, Connection: "close" });
   res.end();
 }
 
@@ -784,7 +788,19 @@ function isAllowedAppCallbackProtocol(protocol: string): boolean {
 }
 
 function closeServer(server: Server): Promise<void> {
-  return new Promise((resolve) => server.close(() => resolve()));
+  return new Promise((resolve) => {
+    const forceCloseTimer = setTimeout(() => {
+      server.closeAllConnections();
+      resolve();
+    }, BRIDGE_SERVER_FORCE_CLOSE_TIMEOUT_MS);
+    forceCloseTimer.unref();
+
+    server.close(() => {
+      clearTimeout(forceCloseTimer);
+      resolve();
+    });
+    server.closeIdleConnections();
+  });
 }
 
 function openUrlWithDefaultBrowser(url: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Make OAuth callback responses request connection close.
- Stop new connections, close idle connections, and force-close remaining bridge connections after a one-second bound.
- Add a real partial HTTP request regression test that verifies login completion, callback headers, and socket closure.

This fixes desktop web login hanging after auth.json is written when a bridge connection remains open, which prevented the caller from restarting desktopd.

## Verification

- pnpm --filter @tutti-os/auth-bridge test: 9/9 passed; stalled connection completed in about 1.0 seconds.
- pnpm --filter @tutti-os/auth-bridge type-check: passed.
- pnpm check:changed: passed 8 lanes locally.
- pre-push pnpm check:changed --push-ready: passed 9 lanes.
- git diff --check: passed.
- Independent subagent review: no blocking findings after the bounded socket-close test was hardened against errors and hangs.

## Fallback Three Questions

- Source: an accepted keep-alive or incomplete HTTP connection can keep Node server.close waiting after the OAuth callback already completed.
- Why can it not be fixed at that source: the connection belongs to a browser or local client outside the bridge and cannot be trusted to finish; the short-lived bridge owns its shutdown deadline.
- Removal condition: remove the forced-close fallback if the bridge no longer shares a listening HTTP server across requests or its lifecycle API guarantees bounded closure.

## Checklist

- [x] This does not change agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] Documentation is not required because the public API and setup are unchanged.
- [x] README and CONTRIBUTING variants are unaffected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] Commits are signed off with DCO.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->