### PR TITLE
fix(agent-gui): stabilize composer auto-resize

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -568,11 +568,33 @@ alignment first activates. Later React updates coalesce alignment into the next
 animation frame; ResizeObserver and MutationObserver keep layout roots current.
 
 Composer text transactions may publish the current draft, but the draft value
-must not drive synchronous pre-paint geometry reads. The dock observes the
-actual editor, input area, and attachment containers; its initial and
-subsequent `ResizeObserver` deliveries own height measurement after layout.
-Viewport resizing is covered by those element observations and must not add a
-duplicate global resize measurement source.
+must not drive synchronous pre-paint geometry reads or an urgent AgentGUI tree
+render. The rich-text editor DOM owns the urgent input transaction. The latest
+prompt ref updates synchronously for submit and attachment reconciliation,
+while palette and controlled-draft projections publish in a React transition.
+The editor recognizes stale controlled echoes from that transition so an older
+projection cannot overwrite newer local input; a value not emitted locally
+remains an authoritative external replacement.
+
+The dock observes geometry through one coalesced animation-frame measurement
+entry point. Editor document updates, attachment membership or intrinsic
+attachment size changes, and changes to the stable input-shell width may
+invalidate that entry point.
+`ResizeObserver` must not observe the animated input area or editor block size:
+their height transition is an output of measurement and must never feed back
+into another measurement cycle. Width observations compare inline size before
+invalidating, while attachment observers cover asynchronous chip and preview
+sizes without a duplicate global resize listener.
+
+The measurement pass is read-only. It derives natural text height from the
+editor document blocks, reads attachment heights, and publishes one atomic
+composer-metrics snapshot only when the snapshot changes. It must not
+temporarily collapse or restyle either the editor or transitioned input
+container. The dock input area establishes a local layout-containment boundary
+so a composer read cannot invalidate the conversation root. Composer paragraphs
+and the viewport calculation share the same line-height token so the 3.5-line
+cap remains exact. Regression coverage must expand across explicit newline
+rows, delete back to one row, and verify stable action-button placement.
 
 External OS file paste and drop enter one host-injected classification boundary before draft attachment creation. The synchronous `resolveExternalPromptEntries` port classifies each source index as a live `WorkspaceFileReference` or a snapshot requiring preparation. AgentGUI owns ordered mention insertion and draft reconciliation: references become ordinary file/folder mentions and never consume prompt-asset slots, while only `prepare` entries create pending attachment state and enter `prepareExternalPromptFiles`. A host without the resolver prepares every external entry. The preparer owns native-path or byte lookup, size enforcement, persistence, and remote transport; each prepared input has one `sourceIndex` result, one failure must not fail siblings, successful results include a provider-readable `path` or `url`, and failures carry typed error codes. Hosts that classify path-backed entries as references must reject any such entry that unexpectedly reaches preparation, so classification failure cannot silently create a duplicate snapshot.
 

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -144,9 +144,12 @@ renderer viewport, asserts the hero prompt-tip's native `scrollWidth` and
 `clientWidth` getters were read after resize, then restores the original
 viewport metrics.
 `composer-input` restores a settled Session so the dock composer is active,
-injects text one character at a time, drives a real CDP IME composition
-lifecycle, then opens the `@` panel and verifies ArrowDown, Tab, and Escape
-navigation without submitting the draft.
+inserts four explicit newline rows, waits for the 3.5-line viewport to finish
+expanding, deletes back to one row, and verifies that the action button remains
+bottom-aligned across both transitions. It then injects ordinary text one
+character at a time, drives a real CDP IME composition lifecycle, opens the `@`
+panel, and verifies ArrowDown, Tab, and Escape navigation without submitting
+the draft.
 
 `workbench-window-lifecycle` measures the internal AgentGUI Workbench node's
 minimize, restore, maximize, unmaximize, close, and reopen mechanics.

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -17,7 +17,10 @@ import { formatSlashStatusTokenCount } from "./AgentSlashStatusPanel";
 import { useOptionalAgentActivityRuntime } from "../../agentActivityRuntime";
 import { useComposerDraftAttachments } from "./composer/useComposerDraftAttachments";
 import { goalDraftObjectiveFromPrompt } from "./composer/composerDraftUtils";
-import { useComposerLayout } from "./composer/useComposerLayout";
+import {
+  INITIAL_DOCK_COMPOSER_METRICS,
+  useComposerLayout
+} from "./composer/useComposerLayout";
 import { useComposerPaletteCatalog } from "./composer/useComposerPaletteCatalog";
 import { useMentionPaletteFrame } from "./composer/useMentionPaletteFrame";
 import { useComposerSlashActions } from "./composer/useComposerSlashActions";
@@ -51,15 +54,6 @@ import {
 
 export { formatSlashStatusTokenCount };
 
-const DOCK_COMPOSER_INPUT_MIN_HEIGHT = 56;
-const DOCK_COMPOSER_TEXT_LINE_HEIGHT = 24;
-const DOCK_COMPOSER_MAX_VISIBLE_TEXT_LINES = 3.5;
-const DOCK_COMPOSER_INPUT_TEXT_CHROME_HEIGHT = 26;
-const DOCK_COMPOSER_TEXT_VIEWPORT_MAX_HEIGHT =
-  DOCK_COMPOSER_TEXT_LINE_HEIGHT * DOCK_COMPOSER_MAX_VISIBLE_TEXT_LINES;
-const DOCK_COMPOSER_INPUT_MAX_HEIGHT =
-  DOCK_COMPOSER_INPUT_TEXT_CHROME_HEIGHT +
-  DOCK_COMPOSER_TEXT_VIEWPORT_MAX_HEIGHT;
 /**
  * 引用 picker 的确认结果:松散文件按 file mention 插入;mentionItems(如文件夹 bundle)
  * 作为整体节点插入。两者各走各的插入路径,composer 不需要理解 bundle 内部结构。
@@ -259,16 +253,8 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   const lastComposerFocusRequestRef = useRef<number | null>(null);
   const autoMentionHighlightedKeyRef = useRef<string | null>(null);
   const [isPromptTipOverflowing, setIsPromptTipOverflowing] = useState(false);
-  const [dockComposerInputHeight, setDockComposerInputHeight] = useState(
-    DOCK_COMPOSER_INPUT_MIN_HEIGHT
-  );
-  const [dockComposerInputMaxHeight, setDockComposerInputMaxHeight] = useState(
-    DOCK_COMPOSER_INPUT_MAX_HEIGHT
-  );
-  const [dockComposerAttachmentHeight, setDockComposerAttachmentHeight] =
-    useState(0);
-  const [dockComposerTextHeight, setDockComposerTextHeight] = useState(
-    DOCK_COMPOSER_INPUT_MIN_HEIGHT
+  const [dockComposerMetrics, setDockComposerMetrics] = useState(
+    INITIAL_DOCK_COMPOSER_METRICS
   );
   const paletteCatalog = useComposerPaletteCatalog({
     provider,
@@ -603,14 +589,8 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     promptTipRef,
     promptInputAreaRef,
     setIsPromptTipOverflowing,
-    dockComposerInputHeight,
-    setDockComposerInputHeight,
-    dockComposerInputMaxHeight,
-    setDockComposerInputMaxHeight,
-    dockComposerAttachmentHeight,
-    setDockComposerAttachmentHeight,
-    dockComposerTextHeight,
-    setDockComposerTextHeight,
+    dockComposerMetrics,
+    setDockComposerMetrics,
     draftImages,
     draftLargeTexts
   });

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
@@ -102,9 +102,85 @@ describe("AgentRichTextEditor file paste", () => {
 });
 
 describe("AgentRichTextEditor prompt insertion", () => {
+  it("ignores stale controlled echoes while a transition catches up", async () => {
+    const ref = createRef<AgentRichTextEditorHandle>();
+    const props = {
+      disabled: false,
+      onChange: vi.fn(),
+      onSubmit: vi.fn(),
+      placeholder: "Prompt"
+    };
+    const rendered = render(
+      <AgentRichTextEditor ref={ref} value="a" {...props} />
+    );
+    await waitFor(() => expect(ref.current).not.toBeNull());
+
+    act(() => {
+      ref.current?.focusAtEnd();
+      ref.current?.insertPlainTextAtSelection("b");
+      ref.current?.insertPlainTextAtSelection("c");
+    });
+    expect(
+      rendered.container.querySelector('[contenteditable="true"]')
+    ).toHaveTextContent("abc");
+
+    rendered.rerender(<AgentRichTextEditor ref={ref} value="ab" {...props} />);
+    await waitFor(() =>
+      expect(
+        rendered.container.querySelector('[contenteditable="true"]')
+      ).toHaveTextContent("abc")
+    );
+
+    rendered.rerender(<AgentRichTextEditor ref={ref} value="abc" {...props} />);
+    rendered.rerender(
+      <AgentRichTextEditor ref={ref} value="replacement" {...props} />
+    );
+    await waitFor(() =>
+      expect(
+        rendered.container.querySelector('[contenteditable="true"]')
+      ).toHaveTextContent("replacement")
+    );
+  });
+
+  it("invalidates layout after a programmatic document update", async () => {
+    const onContentLayoutInvalidated = vi.fn();
+    const rendered = render(
+      <AgentRichTextEditor
+        value="hello"
+        disabled={false}
+        placeholder="Prompt"
+        onChange={vi.fn()}
+        onContentLayoutInvalidated={onContentLayoutInvalidated}
+        onSubmit={vi.fn()}
+      />
+    );
+    await waitFor(() =>
+      expect(
+        rendered.container.querySelector('[contenteditable="true"]')
+      ).not.toBeNull()
+    );
+    onContentLayoutInvalidated.mockClear();
+
+    rendered.rerender(
+      <AgentRichTextEditor
+        value={"hello\nworld"}
+        disabled={false}
+        placeholder="Prompt"
+        onChange={vi.fn()}
+        onContentLayoutInvalidated={onContentLayoutInvalidated}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    await waitFor(() =>
+      expect(onContentLayoutInvalidated).toHaveBeenCalledTimes(1)
+    );
+  });
+
   it("inserts multiline plain text at the current selection without submitting", async () => {
     const ref = createRef<AgentRichTextEditorHandle>();
     const onChange = vi.fn();
+    const onContentLayoutInvalidated = vi.fn();
     const onSubmit = vi.fn();
     render(
       <AgentRichTextEditor
@@ -113,6 +189,7 @@ describe("AgentRichTextEditor prompt insertion", () => {
         disabled={false}
         placeholder="Prompt"
         onChange={onChange}
+        onContentLayoutInvalidated={onContentLayoutInvalidated}
         onSubmit={onSubmit}
       />
     );
@@ -127,6 +204,7 @@ describe("AgentRichTextEditor prompt insertion", () => {
 
     expect(nextPrompt).toBe("hello\nworld 👋");
     expect(onChange).toHaveBeenLastCalledWith("hello\nworld 👋");
+    expect(onContentLayoutInvalidated).toHaveBeenCalled();
     expect(onSubmit).not.toHaveBeenCalled();
   });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
@@ -75,6 +75,7 @@ export const AgentRichTextEditor = forwardRef<
     removeMentionLabel,
     className,
     onChange,
+    onContentLayoutInvalidated,
     onFocus,
     onUserContentChange,
     onSubmit,
@@ -99,8 +100,10 @@ export const AgentRichTextEditor = forwardRef<
   "use memo";
   const { t } = useTranslation();
   const lastEmittedPromptRef = useRef<string | null>(value);
+  const pendingLocalPromptEchoesRef = useRef(new Set<string>());
   const editorRef = useRef<Editor | null>(null);
   const onChangeRef = useRef(onChange);
+  const onContentLayoutInvalidatedRef = useRef(onContentLayoutInvalidated);
   const onFocusRef = useRef(onFocus);
   const onUserContentChangeRef = useRef(onUserContentChange);
   const pendingFocusMethodRef = useRef<"pointer" | "programmatic" | null>(null);
@@ -263,6 +266,7 @@ export const AgentRichTextEditor = forwardRef<
   );
 
   onChangeRef.current = onChange;
+  onContentLayoutInvalidatedRef.current = onContentLayoutInvalidated;
   onFocusRef.current = onFocus;
   onUserContentChangeRef.current = onUserContentChange;
   onSubmitRef.current = onSubmit;
@@ -624,11 +628,13 @@ export const AgentRichTextEditor = forwardRef<
     onUpdate: ({ editor: nextEditor, transaction }) => {
       editorRef.current = nextEditor;
       scheduleSelectionScroll(nextEditor);
+      onContentLayoutInvalidatedRef.current?.();
       const nextPrompt = editorToPromptText(nextEditor);
       if (nextPrompt === lastEmittedPromptRef.current) {
         return;
       }
       lastEmittedPromptRef.current = nextPrompt;
+      pendingLocalPromptEchoesRef.current.add(nextPrompt);
       if (isAgentRichTextUserContentInsertion(transaction)) {
         onUserContentChangeRef.current?.(nextPrompt);
       }
@@ -724,9 +730,16 @@ export const AgentRichTextEditor = forwardRef<
     if (!editor || editor.isDestroyed) {
       return;
     }
+    if (pendingLocalPromptEchoesRef.current.has(value)) {
+      if (value === lastEmittedPromptRef.current) {
+        pendingLocalPromptEchoesRef.current.clear();
+      }
+      return;
+    }
     if (value === lastEmittedPromptRef.current) {
       return;
     }
+    pendingLocalPromptEchoesRef.current.clear();
     const nextDoc = plainTextToAgentRichTextDoc(value, {
       capabilities: availableCapabilities,
       skills: availableSkills
@@ -738,6 +751,7 @@ export const AgentRichTextEditor = forwardRef<
     editor.commands.setContent(nextDoc, { emitUpdate: false });
     editor.commands.setTextSelection(editor.state.doc.content.size);
     lastEmittedPromptRef.current = value;
+    onContentLayoutInvalidatedRef.current?.();
   }, [availableCapabilities, availableSkills, editor, value]);
 
   return (

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.types.ts
@@ -16,6 +16,7 @@ export interface AgentRichTextEditorProps {
   removeMentionLabel?: string;
   className?: string;
   onChange: (value: string) => void;
+  onContentLayoutInvalidated?: () => void;
   onFocus?: (method: AgentGUIComposerFocusMethod) => void;
   onUserContentChange?: (value: string) => void;
   onSubmit: () => void;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
@@ -388,6 +388,9 @@ export function AgentComposerView(input: Props): React.JSX.Element {
                     disabled={inputDisabled}
                     className={styles.composerTextarea}
                     onChange={handleDraftChange}
+                    onContentLayoutInvalidated={
+                      input.layout.invalidateComposerMeasurement
+                    }
                     onFocus={(method) => engagement?.focused(method)}
                     onUserContentChange={(nextPrompt) => {
                       if (

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftAttachments.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftAttachments.ts
@@ -1,5 +1,6 @@
 import { flushSync } from "react-dom";
 import {
+  startTransition,
   useCallback,
   useRef,
   type Dispatch,
@@ -67,7 +68,6 @@ function useStableEventCallback<Args extends unknown[], Result>(
   callbackRef.current = callback;
   return useCallback((...args: Args) => callbackRef.current(...args), []);
 }
-
 interface UseComposerDraftAttachmentsInput {
   workspaceId: string;
   workspacePath?: string | null;
@@ -175,30 +175,36 @@ export function useComposerDraftAttachments({
       if (isGoalModeActive) {
         const nextGoalPrompt = buildGoalModePrompt(nextDraft);
         draftPromptRef.current = nextGoalPrompt;
-        setPaletteDraftPrompt(nextDraft);
-        setIsPaletteOpen(true);
-        updateScopedDraft(draftScopeKey, (currentDraft) =>
-          updateDraftPromptAndReconcileFiles(currentDraft, nextGoalPrompt)
-        );
+        startTransition(() => {
+          setPaletteDraftPrompt(nextDraft);
+          setIsPaletteOpen(true);
+          updateScopedDraft(draftScopeKey, (currentDraft) =>
+            updateDraftPromptAndReconcileFiles(currentDraft, nextGoalPrompt)
+          );
+        });
         return;
       }
       const nextGoalObjective = goalDraftObjectiveFromPrompt(nextDraft);
       if (nextGoalObjective !== null) {
         const nextGoalPrompt = buildGoalModePrompt(nextGoalObjective);
         draftPromptRef.current = nextGoalPrompt;
-        setPaletteDraftPrompt(nextGoalObjective);
-        setIsPaletteOpen(true);
-        updateScopedDraft(draftScopeKey, (currentDraft) =>
-          updateDraftPromptAndReconcileFiles(currentDraft, nextGoalPrompt)
-        );
+        startTransition(() => {
+          setPaletteDraftPrompt(nextGoalObjective);
+          setIsPaletteOpen(true);
+          updateScopedDraft(draftScopeKey, (currentDraft) =>
+            updateDraftPromptAndReconcileFiles(currentDraft, nextGoalPrompt)
+          );
+        });
         return;
       }
       draftPromptRef.current = nextDraft;
-      setPaletteDraftPrompt(nextDraft);
-      setIsPaletteOpen(true);
-      updateScopedDraft(draftScopeKey, (currentDraft) =>
-        updateDraftPromptAndReconcileFiles(currentDraft, nextDraft)
-      );
+      startTransition(() => {
+        setPaletteDraftPrompt(nextDraft);
+        setIsPaletteOpen(true);
+        updateScopedDraft(draftScopeKey, (currentDraft) =>
+          updateDraftPromptAndReconcileFiles(currentDraft, nextDraft)
+        );
+      });
     }
   );
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.spec.tsx
@@ -72,8 +72,9 @@ describe("useComposerLayout", () => {
     expect(setIsPromptTipOverflowing).toHaveBeenLastCalledWith(true);
   });
 
-  it("measures dock content only after ResizeObserver delivers layout", () => {
+  it("coalesces content invalidations and does not observe animated heights", () => {
     const resizeObservers: ResizeObserverMock[] = [];
+    const animationFrames: FrameRequestCallback[] = [];
     class ResizeObserverMock implements ResizeObserver {
       readonly observed = new Set<Element>();
 
@@ -94,82 +95,210 @@ describe("useComposerLayout", () => {
       }
     }
     vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      animationFrames.push(callback);
+      return animationFrames.length;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+    const inputShell = document.createElement("div");
     const inputArea = document.createElement("div");
     const editor = document.createElement("div");
     editor.className = "agent-gui-node__composer-textarea";
+    editor.style.paddingTop = "12px";
+    const firstParagraph = document.createElement("p");
+    const lastParagraph = document.createElement("p");
+    editor.append(firstParagraph, lastParagraph);
     inputArea.appendChild(editor);
-    const editorScrollHeight = vi
-      .spyOn(editor, "scrollHeight", "get")
-      .mockReturnValue(48);
-    const inputAreaScrollHeight = vi
-      .spyOn(inputArea, "scrollHeight", "get")
-      .mockReturnValue(74);
-    const setDockComposerInputHeight = vi.fn();
-    const setDockComposerInputMaxHeight = vi.fn();
-    const setDockComposerAttachmentHeight = vi.fn();
-    const setDockComposerTextHeight = vi.fn();
+    inputShell.appendChild(inputArea);
+    let contentHeight = 24;
+    vi.spyOn(firstParagraph, "getBoundingClientRect").mockImplementation(() =>
+      createRect({ bottom: 24, top: 0 })
+    );
+    vi.spyOn(lastParagraph, "getBoundingClientRect").mockImplementation(() =>
+      createRect({ bottom: contentHeight, top: contentHeight - 24 })
+    );
+    const editorScrollHeight = vi.spyOn(editor, "scrollHeight", "get");
+    const setDockComposerMetrics = vi.fn();
 
     const input = createComposerLayoutInput({
       promptInputAreaRef: { current: inputArea },
-      setDockComposerInputHeight,
-      setDockComposerInputMaxHeight,
-      setDockComposerAttachmentHeight,
-      setDockComposerTextHeight
+      setDockComposerMetrics
     });
 
-    const rendered = renderHook(
-      ({ paletteOpen }) =>
-        useComposerLayout({
-          ...input,
-          showFileMentionPalette: paletteOpen
-        }),
-      { initialProps: { paletteOpen: false } }
-    );
+    const rendered = renderHook(() => useComposerLayout(input));
 
     expect(editorScrollHeight).not.toHaveBeenCalled();
-    expect(inputAreaScrollHeight).not.toHaveBeenCalled();
     expect(resizeObservers).toHaveLength(1);
-    expect(resizeObservers[0]?.observed).toEqual(new Set([inputArea, editor]));
+    expect(resizeObservers[0]?.observed).toEqual(new Set([inputShell]));
+    expect(animationFrames).toHaveLength(1);
 
     act(() => {
-      resizeObservers[0]?.callback([], resizeObservers[0]);
+      animationFrames[0]?.(0);
     });
 
-    expect(editorScrollHeight).toHaveBeenCalledTimes(1);
-    expect(inputAreaScrollHeight).toHaveBeenCalledTimes(1);
-    expect(applyLastNumericStateUpdate(setDockComposerInputHeight, 56)).toBe(
-      76
-    );
-    expect(
-      applyLastNumericStateUpdate(setDockComposerInputMaxHeight, 110)
-    ).toBe(110);
-    expect(
-      applyLastNumericStateUpdate(setDockComposerAttachmentHeight, 0)
-    ).toBe(0);
-    expect(applyLastNumericStateUpdate(setDockComposerTextHeight, 56)).toBe(62);
-
-    editorScrollHeight.mockClear();
-    inputAreaScrollHeight.mockClear();
-    rendered.rerender({ paletteOpen: true });
-
     expect(editorScrollHeight).not.toHaveBeenCalled();
-    expect(inputAreaScrollHeight).not.toHaveBeenCalled();
-    expect(resizeObservers).toHaveLength(1);
+    expect(
+      applyLastMetricsStateUpdate(setDockComposerMetrics, {
+        attachmentHeight: 0,
+        inputHeight: 56,
+        inputMaxHeight: 110,
+        textHeight: 56
+      })
+    ).toEqual({
+      attachmentHeight: 0,
+      inputHeight: 56,
+      inputMaxHeight: 110,
+      textHeight: 56
+    });
+
+    contentHeight = 72;
+    act(() => {
+      rendered.result.current.invalidateComposerMeasurement();
+      rendered.result.current.invalidateComposerMeasurement();
+    });
+
+    expect(animationFrames).toHaveLength(2);
+
+    act(() => {
+      animationFrames[1]?.(16);
+    });
+
+    expect(
+      applyLastMetricsStateUpdate(setDockComposerMetrics, {
+        attachmentHeight: 0,
+        inputHeight: 56,
+        inputMaxHeight: 110,
+        textHeight: 56
+      }).inputHeight
+    ).toBe(98);
+
+    contentHeight = 24;
+    act(() => {
+      rendered.result.current.invalidateComposerMeasurement();
+    });
+    expect(animationFrames).toHaveLength(3);
+
+    act(() => {
+      animationFrames[2]?.(32);
+    });
+
+    expect(
+      applyLastMetricsStateUpdate(setDockComposerMetrics, {
+        attachmentHeight: 0,
+        inputHeight: 98,
+        inputMaxHeight: 110,
+        textHeight: 98
+      }).inputHeight
+    ).toBe(56);
+  });
+
+  it("remeasures only when the stable host width changes", () => {
+    const resizeObservers: ResizeObserverMock[] = [];
+    const animationFrames: FrameRequestCallback[] = [];
+    class ResizeObserverMock implements ResizeObserver {
+      constructor(readonly callback: ResizeObserverCallback) {
+        resizeObservers.push(this);
+      }
+
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    }
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      animationFrames.push(callback);
+      return animationFrames.length;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+    const inputShell = document.createElement("div");
+    const inputArea = document.createElement("div");
+    inputShell.appendChild(inputArea);
+
+    renderHook(() =>
+      useComposerLayout(
+        createComposerLayoutInput({
+          promptInputAreaRef: { current: inputArea }
+        })
+      )
+    );
+    act(() => {
+      animationFrames[0]?.(0);
+    });
+
+    act(() => {
+      resizeObservers[0]?.callback(
+        [createResizeObserverEntry(inputShell, 600)],
+        resizeObservers[0]
+      );
+    });
+    expect(animationFrames).toHaveLength(2);
+    act(() => {
+      animationFrames[1]?.(16);
+    });
+
+    act(() => {
+      resizeObservers[0]?.callback(
+        [createResizeObserverEntry(inputShell, 600)],
+        resizeObservers[0]
+      );
+    });
+    expect(animationFrames).toHaveLength(2);
+
+    act(() => {
+      resizeObservers[0]?.callback(
+        [createResizeObserverEntry(inputShell, 540)],
+        resizeObservers[0]
+      );
+    });
+    expect(animationFrames).toHaveLength(3);
   });
 });
 
-function applyLastNumericStateUpdate(
+function applyLastMetricsStateUpdate(
   setter: ReturnType<typeof vi.fn>,
-  value: number
+  value: ComposerLayoutInput["dockComposerMetrics"]
 ) {
   const update = setter.mock.calls.at(-1)?.[0] as
-    | number
-    | ((current: number) => number)
+    | ComposerLayoutInput["dockComposerMetrics"]
+    | ((
+        current: ComposerLayoutInput["dockComposerMetrics"]
+      ) => ComposerLayoutInput["dockComposerMetrics"])
     | undefined;
   if (typeof update === "function") {
     return update(value);
   }
-  return update;
+  return update ?? value;
+}
+
+function createRect({ bottom, top }: { bottom: number; top: number }): DOMRect {
+  return {
+    bottom,
+    height: bottom - top,
+    left: 0,
+    right: 100,
+    top,
+    width: 100,
+    x: 0,
+    y: top,
+    toJSON: () => ({})
+  };
+}
+
+function createResizeObserverEntry(
+  target: Element,
+  width: number
+): ResizeObserverEntry {
+  return {
+    borderBoxSize: [],
+    contentBoxSize: [],
+    contentRect: {
+      ...createRect({ bottom: 0, top: 0 }),
+      right: width,
+      width
+    },
+    devicePixelContentBoxSize: [],
+    target
+  };
 }
 
 type ComposerLayoutInput = Parameters<typeof useComposerLayout>[0];
@@ -212,14 +341,13 @@ function createComposerLayoutInput(
     promptTipRef: { current: null },
     promptInputAreaRef: { current: null },
     setIsPromptTipOverflowing: vi.fn(),
-    dockComposerInputHeight: 56,
-    setDockComposerInputHeight: vi.fn(),
-    dockComposerInputMaxHeight: 110,
-    setDockComposerInputMaxHeight: vi.fn(),
-    dockComposerAttachmentHeight: 0,
-    setDockComposerAttachmentHeight: vi.fn(),
-    dockComposerTextHeight: 56,
-    setDockComposerTextHeight: vi.fn(),
+    dockComposerMetrics: {
+      attachmentHeight: 0,
+      inputHeight: 56,
+      inputMaxHeight: 110,
+      textHeight: 56
+    },
+    setDockComposerMetrics: vi.fn(),
     draftImages: [],
     draftLargeTexts: [],
     ...overrides

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.ts
@@ -1,6 +1,8 @@
 import {
+  useCallback,
   useLayoutEffect,
   useMemo,
+  useRef,
   type CSSProperties,
   type Dispatch,
   type RefObject,
@@ -25,10 +27,25 @@ const DOCK_COMPOSER_TEXT_VIEWPORT_MAX_HEIGHT =
 const DOCK_COMPOSER_INPUT_MAX_HEIGHT =
   DOCK_COMPOSER_INPUT_TEXT_MAX_HEIGHT_CHROME +
   DOCK_COMPOSER_TEXT_VIEWPORT_MAX_HEIGHT;
-const DOCK_COMPOSER_INPUT_BORDER_HEIGHT = 2;
 const DOCK_COMPOSER_INPUT_PADDING_BLOCK_HEIGHT = 24;
 const PROMPT_TIP_CYCLE_STEP_MS = 5_200;
 const COMPOSER_PALETTE_Z_INDEX = "var(--z-popover)";
+const COMPOSER_ATTACHMENT_SELECTOR =
+  '[data-testid="agent-gui-composer-image-drafts"], [data-testid="agent-gui-composer-file-drafts"]';
+
+export interface DockComposerMetrics {
+  attachmentHeight: number;
+  inputHeight: number;
+  inputMaxHeight: number;
+  textHeight: number;
+}
+
+export const INITIAL_DOCK_COMPOSER_METRICS: DockComposerMetrics = {
+  attachmentHeight: 0,
+  inputHeight: DOCK_COMPOSER_INPUT_MIN_HEIGHT,
+  inputMaxHeight: DOCK_COMPOSER_INPUT_MAX_HEIGHT,
+  textHeight: DOCK_COMPOSER_INPUT_MIN_HEIGHT
+};
 
 function hasInlineOverflow(element: HTMLElement | null): boolean {
   return Boolean(element && element.scrollWidth > element.clientWidth);
@@ -48,14 +65,8 @@ interface UseComposerLayoutInput {
   promptTipRef: RefObject<HTMLSpanElement | null>;
   promptInputAreaRef: RefObject<HTMLDivElement | null>;
   setIsPromptTipOverflowing: Dispatch<SetStateAction<boolean>>;
-  dockComposerInputHeight: number;
-  setDockComposerInputHeight: Dispatch<SetStateAction<number>>;
-  dockComposerInputMaxHeight: number;
-  setDockComposerInputMaxHeight: Dispatch<SetStateAction<number>>;
-  dockComposerAttachmentHeight: number;
-  setDockComposerAttachmentHeight: Dispatch<SetStateAction<number>>;
-  dockComposerTextHeight: number;
-  setDockComposerTextHeight: Dispatch<SetStateAction<number>>;
+  dockComposerMetrics: DockComposerMetrics;
+  setDockComposerMetrics: Dispatch<SetStateAction<DockComposerMetrics>>;
   draftImages: AgentComposerDraftImage[];
   draftLargeTexts: AgentComposerDraftLargeText[];
 }
@@ -74,17 +85,12 @@ export function useComposerLayout({
   promptTipRef,
   promptInputAreaRef,
   setIsPromptTipOverflowing,
-  dockComposerInputHeight,
-  setDockComposerInputHeight,
-  dockComposerInputMaxHeight,
-  setDockComposerInputMaxHeight,
-  dockComposerAttachmentHeight,
-  setDockComposerAttachmentHeight,
-  dockComposerTextHeight,
-  setDockComposerTextHeight,
+  dockComposerMetrics,
+  setDockComposerMetrics,
   draftImages,
   draftLargeTexts
 }: UseComposerLayoutInput) {
+  const composerMeasurementFrameRef = useRef<number | null>(null);
   const labels = { promptTipsPrefix };
   const showEdgeGlow = isHeroLayout && !inputDisabled;
   const showPromptTips = isHeroLayout && promptTips.length > 0;
@@ -150,141 +156,148 @@ export function useComposerLayout({
       resizeObserver?.disconnect();
     };
   }, [activePromptTipId, activePromptTipText, previewMode]);
-  useLayoutEffect(() => {
+  const measureDockComposer = useCallback((): void => {
+    composerMeasurementFrameRef.current = null;
     if (isHeroLayout) {
-      setDockComposerInputHeight(DOCK_COMPOSER_INPUT_MIN_HEIGHT);
-      setDockComposerInputMaxHeight(DOCK_COMPOSER_INPUT_MAX_HEIGHT);
-      setDockComposerAttachmentHeight(0);
-      setDockComposerTextHeight(DOCK_COMPOSER_INPUT_MIN_HEIGHT);
+      setDockComposerMetrics((currentMetrics) =>
+        areDockComposerMetricsEqual(
+          currentMetrics,
+          INITIAL_DOCK_COMPOSER_METRICS
+        )
+          ? currentMetrics
+          : INITIAL_DOCK_COMPOSER_METRICS
+      );
       return;
     }
-
     const inputArea = promptInputAreaRef.current;
     const editor = inputArea?.querySelector(
       ".agent-gui-node__composer-textarea"
     );
     if (!inputArea || !(editor instanceof HTMLElement)) {
-      setDockComposerInputHeight(DOCK_COMPOSER_INPUT_MIN_HEIGHT);
+      setDockComposerMetrics((currentMetrics) =>
+        currentMetrics.inputHeight === DOCK_COMPOSER_INPUT_MIN_HEIGHT
+          ? currentMetrics
+          : {
+              ...currentMetrics,
+              inputHeight: DOCK_COMPOSER_INPUT_MIN_HEIGHT
+            }
+      );
       return;
     }
 
-    const measure = (): void => {
-      // Both attachment rows contribute to the composer height: images live in
-      // one container and files/pasted-text chips in another. Measuring only the
-      // image row clipped the taller pasted-text chip ("展示不全").
-      const attachmentAreas = inputArea.querySelectorAll(
-        '[data-testid="agent-gui-composer-image-drafts"], [data-testid="agent-gui-composer-file-drafts"]'
-      );
-      let attachmentHeight = 0;
-      attachmentAreas.forEach((area) => {
-        if (area instanceof HTMLElement) {
-          attachmentHeight += area.scrollHeight;
-        }
-      });
-      const textHeight = Math.min(
-        DOCK_COMPOSER_INPUT_MAX_HEIGHT,
-        Math.max(
-          DOCK_COMPOSER_INPUT_MIN_HEIGHT,
-          editor.scrollHeight +
-            DOCK_COMPOSER_INPUT_TEXT_MEASUREMENT_CHROME_HEIGHT
-        )
-      );
-      const attachmentChromeHeight =
-        attachmentHeight > 0 ? DOCK_COMPOSER_INPUT_PADDING_BLOCK_HEIGHT : 0;
-      const maxHeight =
-        DOCK_COMPOSER_INPUT_MAX_HEIGHT +
-        Math.max(0, attachmentHeight) +
-        attachmentChromeHeight;
-      const previousHeight = inputArea.style.height;
-      const previousInputHeight = inputArea.style.getPropertyValue(
-        "--agent-gui-composer-input-height"
-      );
-      const previousInputMaxHeight = inputArea.style.getPropertyValue(
-        "--agent-gui-composer-input-max-height"
-      );
-      const previousAttachmentHeight = inputArea.style.getPropertyValue(
-        "--agent-gui-composer-attachment-height"
-      );
-      inputArea.style.height = "auto";
-      inputArea.style.setProperty(
-        "--agent-gui-composer-input-height",
-        `${DOCK_COMPOSER_INPUT_MIN_HEIGHT}px`
-      );
-      inputArea.style.setProperty(
-        "--agent-gui-composer-input-max-height",
-        `${maxHeight}px`
-      );
-      inputArea.style.setProperty(
-        "--agent-gui-composer-attachment-height",
-        `${attachmentHeight}px`
-      );
-      const contentHeight = inputArea.scrollHeight;
-      inputArea.style.height = previousHeight;
-      if (previousInputHeight) {
-        inputArea.style.setProperty(
-          "--agent-gui-composer-input-height",
-          previousInputHeight
-        );
-      } else {
-        inputArea.style.removeProperty("--agent-gui-composer-input-height");
+    // Both attachment rows contribute to the composer height: images live in
+    // one container and files/pasted-text chips in another. Measuring only the
+    // image row clipped the taller pasted-text chip ("展示不全").
+    const attachmentAreas = inputArea.querySelectorAll(
+      COMPOSER_ATTACHMENT_SELECTOR
+    );
+    let attachmentHeight = 0;
+    attachmentAreas.forEach((area) => {
+      if (area instanceof HTMLElement) {
+        attachmentHeight += area.scrollHeight;
       }
-      if (previousInputMaxHeight) {
-        inputArea.style.setProperty(
-          "--agent-gui-composer-input-max-height",
-          previousInputMaxHeight
-        );
-      } else {
-        inputArea.style.removeProperty("--agent-gui-composer-input-max-height");
-      }
-      if (previousAttachmentHeight) {
-        inputArea.style.setProperty(
-          "--agent-gui-composer-attachment-height",
-          previousAttachmentHeight
-        );
-      } else {
-        inputArea.style.removeProperty(
-          "--agent-gui-composer-attachment-height"
-        );
-      }
-      const measuredHeight = Math.max(
-        contentHeight + DOCK_COMPOSER_INPUT_BORDER_HEIGHT,
-        attachmentHeight + textHeight + attachmentChromeHeight
-      );
-      const nextHeight = Math.min(
-        maxHeight,
-        Math.max(DOCK_COMPOSER_INPUT_MIN_HEIGHT, measuredHeight)
-      );
-      setDockComposerInputHeight((currentHeight) =>
-        currentHeight === nextHeight ? currentHeight : nextHeight
-      );
-      setDockComposerInputMaxHeight((currentHeight) =>
-        currentHeight === maxHeight ? currentHeight : maxHeight
-      );
-      setDockComposerAttachmentHeight((currentHeight) =>
-        currentHeight === attachmentHeight ? currentHeight : attachmentHeight
-      );
-      setDockComposerTextHeight((currentHeight) =>
-        currentHeight === textHeight ? currentHeight : textHeight
-      );
+    });
+    const editorContentHeight = readEditorIntrinsicContentHeight(editor);
+    const textHeight = Math.min(
+      DOCK_COMPOSER_INPUT_MAX_HEIGHT,
+      Math.max(
+        DOCK_COMPOSER_INPUT_MIN_HEIGHT,
+        editorContentHeight + DOCK_COMPOSER_INPUT_TEXT_MEASUREMENT_CHROME_HEIGHT
+      )
+    );
+    const attachmentChromeHeight =
+      attachmentHeight > 0 ? DOCK_COMPOSER_INPUT_PADDING_BLOCK_HEIGHT : 0;
+    const inputMaxHeight =
+      DOCK_COMPOSER_INPUT_MAX_HEIGHT +
+      Math.max(0, attachmentHeight) +
+      attachmentChromeHeight;
+    const measuredHeight =
+      attachmentHeight + textHeight + attachmentChromeHeight;
+    const inputHeight = Math.min(
+      inputMaxHeight,
+      Math.max(DOCK_COMPOSER_INPUT_MIN_HEIGHT, measuredHeight)
+    );
+    const nextMetrics: DockComposerMetrics = {
+      attachmentHeight,
+      inputHeight,
+      inputMaxHeight,
+      textHeight
     };
+    setDockComposerMetrics((currentMetrics) =>
+      areDockComposerMetricsEqual(currentMetrics, nextMetrics)
+        ? currentMetrics
+        : nextMetrics
+    );
+  }, [isHeroLayout, promptInputAreaRef, setDockComposerMetrics]);
 
+  const invalidateComposerMeasurement = useCallback((): void => {
+    if (composerMeasurementFrameRef.current !== null) {
+      return;
+    }
+    if (typeof window.requestAnimationFrame !== "function") {
+      measureDockComposer();
+      return;
+    }
+    composerMeasurementFrameRef.current =
+      window.requestAnimationFrame(measureDockComposer);
+  }, [measureDockComposer]);
+
+  useLayoutEffect(() => {
+    if (isHeroLayout) {
+      invalidateComposerMeasurement();
+      return () => {
+        if (composerMeasurementFrameRef.current !== null) {
+          window.cancelAnimationFrame(composerMeasurementFrameRef.current);
+          composerMeasurementFrameRef.current = null;
+        }
+      };
+    }
+    const inputArea = promptInputAreaRef.current;
+    const widthHost = inputArea?.parentElement ?? null;
+    let observedWidth: number | null = null;
     const resizeObserver =
       typeof ResizeObserver === "undefined"
         ? null
-        : new ResizeObserver(measure);
-    resizeObserver?.observe(inputArea);
-    resizeObserver?.observe(editor);
+        : new ResizeObserver((entries) => {
+            let shouldInvalidate = false;
+            for (const entry of entries) {
+              if (entry.target === widthHost) {
+                const nextWidth = entry.contentRect.width;
+                if (nextWidth !== observedWidth) {
+                  observedWidth = nextWidth;
+                  shouldInvalidate = true;
+                }
+              } else {
+                shouldInvalidate = true;
+              }
+            }
+            if (shouldInvalidate) {
+              invalidateComposerMeasurement();
+            }
+          });
+    if (widthHost) {
+      resizeObserver?.observe(widthHost);
+    }
     for (const attachmentArea of Array.from(
-      inputArea.querySelectorAll(
-        '[data-testid="agent-gui-composer-image-drafts"], [data-testid="agent-gui-composer-file-drafts"]'
-      )
+      inputArea?.querySelectorAll(COMPOSER_ATTACHMENT_SELECTOR) ?? []
     )) {
       resizeObserver?.observe(attachmentArea);
     }
+    invalidateComposerMeasurement();
     return () => {
+      if (composerMeasurementFrameRef.current !== null) {
+        window.cancelAnimationFrame(composerMeasurementFrameRef.current);
+        composerMeasurementFrameRef.current = null;
+      }
       resizeObserver?.disconnect();
     };
-  }, [draftImages.length, draftLargeTexts.length, isHeroLayout]);
+  }, [
+    draftImages.length,
+    draftLargeTexts.length,
+    invalidateComposerMeasurement,
+    isHeroLayout,
+    promptInputAreaRef
+  ]);
   const composerStyle = useMemo<CSSProperties | undefined>(
     () =>
       isHeroLayout
@@ -297,10 +310,10 @@ export function useComposerLayout({
             // instead of being covered by it.
             "--agent-gui-composer-input-overflow": `${Math.max(
               0,
-              dockComposerInputHeight - DOCK_COMPOSER_INPUT_MIN_HEIGHT
+              dockComposerMetrics.inputHeight - DOCK_COMPOSER_INPUT_MIN_HEIGHT
             )}px`
           } as CSSProperties),
-    [dockComposerInputHeight, isHeroLayout]
+    [dockComposerMetrics.inputHeight, isHeroLayout]
   );
   const inputShellStyle = useMemo<CSSProperties | undefined>(
     () =>
@@ -314,21 +327,15 @@ export function useComposerLayout({
       isHeroLayout
         ? undefined
         : ({
-            "--agent-gui-composer-attachment-height": `${dockComposerAttachmentHeight}px`,
-            "--agent-gui-composer-input-height": `${dockComposerInputHeight}px`,
-            "--agent-gui-composer-input-max-height": `${dockComposerInputMaxHeight}px`,
-            "--agent-gui-composer-text-height": `${dockComposerTextHeight}px`,
+            "--agent-gui-composer-attachment-height": `${dockComposerMetrics.attachmentHeight}px`,
+            "--agent-gui-composer-input-height": `${dockComposerMetrics.inputHeight}px`,
+            "--agent-gui-composer-input-max-height": `${dockComposerMetrics.inputMaxHeight}px`,
+            "--agent-gui-composer-text-height": `${dockComposerMetrics.textHeight}px`,
             "--agent-gui-composer-text-line-height": `${DOCK_COMPOSER_TEXT_LINE_HEIGHT}px`,
             "--agent-gui-composer-text-max-visible-lines": `${DOCK_COMPOSER_MAX_VISIBLE_TEXT_LINES}`,
             "--agent-gui-composer-text-viewport-height": `${DOCK_COMPOSER_TEXT_VIEWPORT_MAX_HEIGHT}px`
           } as CSSProperties),
-    [
-      dockComposerAttachmentHeight,
-      dockComposerInputHeight,
-      dockComposerInputMaxHeight,
-      dockComposerTextHeight,
-      isHeroLayout
-    ]
+    [dockComposerMetrics, isHeroLayout]
   );
 
   return {
@@ -339,9 +346,46 @@ export function useComposerLayout({
     promptInputAreaStyle,
     promptTipStyle,
     rotatingPromptTips,
+    invalidateComposerMeasurement,
     showEdgeGlow,
     showHeroProjectSelector,
     showProjectMissingProbe,
     showProjectRow
   };
+}
+
+function readEditorIntrinsicContentHeight(editor: HTMLElement): number {
+  const firstBlock = editor.firstElementChild;
+  const lastBlock = editor.lastElementChild;
+  if (firstBlock instanceof HTMLElement && lastBlock instanceof HTMLElement) {
+    const firstRect = firstBlock.getBoundingClientRect();
+    const lastRect = lastBlock.getBoundingClientRect();
+    const contentHeight = lastRect.bottom - firstRect.top;
+    if (contentHeight > 0) {
+      const style = window.getComputedStyle(editor);
+      return (
+        contentHeight +
+        parseCssPixelValue(style.paddingTop) +
+        parseCssPixelValue(style.paddingBottom)
+      );
+    }
+  }
+  return editor.scrollHeight;
+}
+
+function parseCssPixelValue(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function areDockComposerMetricsEqual(
+  left: DockComposerMetrics,
+  right: DockComposerMetrics
+): boolean {
+  return (
+    left.attachmentHeight === right.attachmentHeight &&
+    left.inputHeight === right.inputHeight &&
+    left.inputMaxHeight === right.inputMaxHeight &&
+    left.textHeight === right.textHeight
+  );
 }

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -7847,6 +7847,7 @@ button.agent-gui-node__conversation-section-toggle:hover
   max-height: var(--agent-gui-composer-input-max-height, 110px);
   align-items: end;
   align-self: end;
+  contain: layout;
   overflow: hidden;
   padding: 0 12px;
   border: 1px solid var(--line-2);
@@ -8770,7 +8771,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   p:not(.agent-rich-text-placeholder-node):not(:empty) {
   position: relative;
   top: 0;
-  line-height: 20px;
+  line-height: var(--agent-gui-composer-text-line-height);
 }
 
 .agent-gui-node__composer-textarea

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -2046,7 +2046,7 @@ describe("agent GUI workbench contribution copy", () => {
       /\.agent-gui-node__composer\[data-layout="dock"\]\s+\.agent-gui-node__composer-prompt-input-area\s+textarea,\s*\.agent-gui-node__composer\[data-layout="dock"\]\s+\.agent-gui-node__composer-textarea\s*{[^}]*padding-top:\s*12px;/s
     );
     expect(css).toMatch(
-      /\.agent-gui-node__composer-textarea\s+p:not\(\.agent-rich-text-placeholder-node\):not\(:empty\)\s*{[^}]*top:\s*0;/s
+      /\.agent-gui-node__composer-textarea\s+p:not\(\.agent-rich-text-placeholder-node\):not\(:empty\)\s*{[^}]*top:\s*0;[^}]*line-height:\s*var\(--agent-gui-composer-text-line-height\);/s
     );
     expect(css).toMatch(
       /\.agent-gui-node__composer-textarea\s+p:not\(\.agent-rich-text-placeholder-node\):not\(:empty\)\s+\.agent-rich-text-mention-node\s*{[^}]*transform:\s*translateY\(-2px\);/s

--- a/tools/scripts/agent-gui-composer-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-composer-performance-scenarios.mjs
@@ -18,11 +18,14 @@ const editorSelector =
 const paletteSelector = '[data-testid="agent-gui-mention-palette-surface"]';
 const ordinaryText =
   "Measure AgentGUI composer input one character at a time. ";
+const multilineText = "2\n3\n4\n5";
 const imeCandidates = ["x", "xing", "性能"];
 const imeCommittedText = "性能";
 
 const composerInputMarkers = {
   start: "tutti-perf:composer-input:start",
+  multilineExpanded: "tutti-perf:composer-input:multiline-expanded-observed",
+  multilineShrunk: "tutti-perf:composer-input:multiline-shrunk-observed",
   textEntered: "tutti-perf:composer-input:text-entered-observed",
   imeComposing: "tutti-perf:composer-input:ime-composing-observed",
   imeCommitted: "tutti-perf:composer-input:ime-committed-observed",
@@ -36,6 +39,16 @@ export const composerInputScenario = {
   id: "composer-input",
   markers: composerInputMarkers,
   milestones: [
+    {
+      key: "multilineExpanded",
+      label: "four-line composer expanded",
+      marker: composerInputMarkers.multilineExpanded
+    },
+    {
+      key: "multilineShrunk",
+      label: "composer shrunk to one line",
+      marker: composerInputMarkers.multilineShrunk
+    },
     {
       key: "textEntered",
       label: "per-character text entered",
@@ -71,12 +84,36 @@ export const composerInputScenario = {
   prepare: prepareComposerInput,
   execute: executeComposerInput,
   describe(prepared) {
-    return `${prepared.sessionID}; ${Array.from(ordinaryText).length} text inserts + ${imeCandidates.length} IME updates + @ keyboard navigation`;
+    return `${prepared.sessionID}; ${Array.from(multilineText).length} multiline inserts + shrink + ${Array.from(ordinaryText).length} text inserts + ${imeCandidates.length} IME updates + @ keyboard navigation`;
   },
   summarize(prepared, result) {
     return summary(
       [
         { name: "dock composer active", passed: prepared.dockComposer },
+        {
+          name: "four-line composer expanded",
+          passed:
+            result.expandedGeometry.height > result.collapsedGeometry.height + 1
+        },
+        {
+          name: "composer shrank to one line",
+          passed:
+            Math.abs(
+              result.shrunkGeometry.height - result.collapsedGeometry.height
+            ) <= 1
+        },
+        {
+          name: "action button stayed bottom-aligned",
+          passed:
+            Math.abs(
+              result.expandedGeometry.buttonBottomOffset -
+                result.collapsedGeometry.buttonBottomOffset
+            ) <= 1 &&
+            Math.abs(
+              result.shrunkGeometry.buttonBottomOffset -
+                result.collapsedGeometry.buttonBottomOffset
+            ) <= 1
+        },
         {
           name: "per-character text input observed",
           passed: result.inputEvents >= Array.from(ordinaryText).length
@@ -104,8 +141,14 @@ export const composerInputScenario = {
       [
         { label: "Session", value: prepared.sessionID },
         {
+          label: "Composer heights",
+          value: `${result.collapsedGeometry.height.toFixed(1)} -> ${result.expandedGeometry.height.toFixed(1)} -> ${result.shrunkGeometry.height.toFixed(1)} px`
+        },
+        {
           label: "Text inserts",
-          value: String(Array.from(ordinaryText).length)
+          value: String(
+            Array.from(multilineText).length + Array.from(ordinaryText).length
+          )
         },
         { label: "Input events", value: String(result.inputEvents) },
         {
@@ -117,7 +160,7 @@ export const composerInputScenario = {
           value: result.mentionKeys.join(" -> ")
         }
       ],
-      "CDP injects each text character separately, drives one real IME composition lifecycle, then opens the @ panel and verifies ArrowDown, Tab, and Escape through DOM state and captured keyboard events"
+      "CDP expands the composer through explicit newline transactions, deletes back to one line, injects ordinary text character by character, drives one real IME composition lifecycle, then verifies @ keyboard navigation"
     );
   }
 };
@@ -207,6 +250,29 @@ async function executeComposerInput(context, _prepared, options) {
   await installComposerInputCounters(pageClient);
   await startRendererScenario(pageClient, composerInputMarkers.start);
 
+  const collapsedGeometry = await readComposerGeometry(pageClient);
+  for (const character of Array.from(multilineText)) {
+    await pageClient.send("Input.insertText", { text: character });
+  }
+  await waitForEditorText(pageClient, multilineText, options.timeoutMs);
+  const expandedGeometry = await waitForComposerGeometry(
+    pageClient,
+    `height > ${JSON.stringify(collapsedGeometry.height + 1)} && Math.abs(height - targetHeight) <= 1`,
+    options.timeoutMs,
+    "four-line composer expansion"
+  );
+  await markRenderer(pageClient, composerInputMarkers.multilineExpanded);
+
+  await clearComposerEditor(pageClient);
+  await waitForEditorText(pageClient, "", options.timeoutMs);
+  const shrunkGeometry = await waitForComposerGeometry(
+    pageClient,
+    `Math.abs(height - ${JSON.stringify(collapsedGeometry.height)}) <= 1`,
+    options.timeoutMs,
+    "composer shrink to one line"
+  );
+  await markRenderer(pageClient, composerInputMarkers.multilineShrunk);
+
   for (const character of Array.from(ordinaryText)) {
     await pageClient.send("Input.insertText", { text: character });
   }
@@ -274,6 +340,9 @@ async function executeComposerInput(context, _prepared, options) {
 
   return {
     ...counters,
+    collapsedGeometry,
+    expandedGeometry,
+    shrunkGeometry,
     categoryChanged: navigated.activeCategoryIndex !== initialCategory,
     highlightChanged: highlighted.highlightedIndex !== initialHighlight,
     imeCommitted:
@@ -282,6 +351,58 @@ async function executeComposerInput(context, _prepared, options) {
     mentionClosed: closed.palettePresent === false,
     mentionOpened: opened.palettePresent === true
   };
+}
+
+async function clearComposerEditor(client) {
+  await evaluate(
+    client,
+    `(() => {
+      const editor = document.querySelector(${JSON.stringify(editorSelector)});
+      if (!(editor instanceof HTMLElement)) throw new Error('composer editor is unavailable');
+      editor.focus();
+      document.execCommand('selectAll', false);
+      document.execCommand('delete', false);
+      return true;
+    })()`
+  );
+}
+
+async function readComposerGeometry(client) {
+  return evaluate(client, composerGeometryExpression("true"));
+}
+
+async function waitForComposerGeometry(client, predicate, timeoutMs, label) {
+  return waitForEvaluation(
+    client,
+    composerGeometryExpression(predicate),
+    timeoutMs,
+    label,
+    25
+  );
+}
+
+function composerGeometryExpression(predicate) {
+  return `(() => {
+    const editor = document.querySelector(${JSON.stringify(editorSelector)});
+    const inputArea = editor?.closest('.agent-gui-node__composer-prompt-input-area');
+    const actionButton = inputArea?.querySelector('.agent-gui-node__composer-send-button, .agent-gui-node__composer-stop-button');
+    if (!(inputArea instanceof HTMLElement) || !(actionButton instanceof HTMLElement)) {
+      return { ready: false, buttonBottomOffset: -1, height: -1, targetHeight: -1 };
+    }
+    const inputRect = inputArea.getBoundingClientRect();
+    const buttonRect = actionButton.getBoundingClientRect();
+    const height = inputRect.height;
+    const targetHeight = Number.parseFloat(
+      inputArea.style.getPropertyValue('--agent-gui-composer-input-height')
+    );
+    const buttonBottomOffset = inputRect.bottom - buttonRect.bottom;
+    return {
+      ready: ${predicate},
+      buttonBottomOffset,
+      height,
+      targetHeight
+    };
+  })()`;
 }
 
 async function installComposerInputCounters(client) {
@@ -334,7 +455,9 @@ async function waitForEditorText(client, expected, timeoutMs) {
     client,
     `(() => {
       const editor = document.querySelector(${JSON.stringify(editorSelector)});
-      const text = editor?.textContent ?? '';
+      const text = editor
+        ? [...editor.children].map((block) => block.textContent ?? '').join('\\n')
+        : '';
       return { ready: text === ${JSON.stringify(expected)}, text };
     })()`,
     timeoutMs,

--- a/tools/scripts/run-agent-gui-performance.test.mjs
+++ b/tools/scripts/run-agent-gui-performance.test.mjs
@@ -207,15 +207,18 @@ test("composer input summary requires text, IME, and mention keyboard semantics"
     { dockComposer: true, editorReady: true, sessionID: "session-1" },
     {
       categoryChanged: true,
+      collapsedGeometry: { buttonBottomOffset: 13, height: 56 },
       compositionEnds: 1,
       compositionStarts: 1,
       compositionUpdates: 3,
+      expandedGeometry: { buttonBottomOffset: 13, height: 110 },
       highlightChanged: true,
       imeCommitted: true,
       inputEvents: 58,
       mentionClosed: true,
       mentionKeys: ["ArrowDown", "Tab", "Escape"],
-      mentionOpened: true
+      mentionOpened: true,
+      shrunkGeometry: { buttonBottomOffset: 13, height: 56 }
     }
   );
 
@@ -224,6 +227,9 @@ test("composer input summary requires text, IME, and mention keyboard semantics"
     report.assertions.map((assertion) => assertion.name),
     [
       "dock composer active",
+      "four-line composer expanded",
+      "composer shrank to one line",
+      "action button stayed bottom-aligned",
       "per-character text input observed",
       "IME composition lifecycle observed",
       "IME text committed once",


### PR DESCRIPTION
## Summary
- coalesce dock composer measurement into one read-only animation-frame pass without observing animated heights
- restore exact 3.5-line expansion, one-line shrink, and stable action-button alignment
- defer controlled draft projections while protecting newer local editor input from stale echoes
- extend unit and isolated composer scenario coverage plus durable architecture/testing docs

## Fix Scope Justification
- Root cause: the dock `ResizeObserver` watched the animated input/editor heights that its own synchronous measurement and temporary style writes changed. This created a geometry feedback loop. Urgent React draft projection could also replay an older controlled value over newer local editor input.
- Lower layer: ProseMirror and the browser do not own dock chrome, attachment height, the 3.5-line product cap, or React draft publication. The rich-text editor now only reports content-layout invalidation; measurement ownership, coalescing, and controlled-draft scheduling remain at the AgentGUI composer boundary that owns those facts.

## Tests
- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx agent-gui/agentGuiNode/composer/useComposerLayout.spec.tsx workbench/contribution.test.ts`
- `pnpm check:changed -- --push-ready`

## Notes
- Manual Electron trace verification confirms the old composer measurement loop is gone
- Existing ProseMirror-triggered full-window layout tail latency remains outside this focused fix
