### PR TITLE
fix(workspace-file-manager): avoid nested row buttons

### DIFF
--- a/packages/workspace/file-manager/package.json
+++ b/packages/workspace/file-manager/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts && node ../../../tools/scripts/copy-package-assets.mjs src/assets dist/assets",
-    "test": "node --test --experimental-strip-types \"./src/**/*.test.ts\"",
+    "test": "node --test --experimental-strip-types \"./src/**/*.test.ts\" && vitest run ./src/ui/WorkspaceFileManagerPanels.render.test.tsx --environment jsdom",
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },
   "dependencies": {
@@ -33,10 +33,12 @@
     "@types/node": "^24.0.1",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",
+    "jsdom": "^27.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "typescript": "^5.8.3",
-    "valtio": "^2.3.2"
+    "valtio": "^2.3.2",
+    "vitest": "^4.0.13"
   },
   "peerDependencies": {
     "react": "^19.1.0",

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.render.test.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.render.test.tsx
@@ -20,6 +20,7 @@ describe("WorkspaceFileManagerPanels", () => {
       sizeBytes: null
     };
     const onSelect = vi.fn();
+    const onEntryDragStart = vi.fn();
     const onToggleDirectoryExpanded = vi.fn();
     const container = document.createElement("div");
     document.body.append(container);
@@ -80,6 +81,7 @@ describe("WorkspaceFileManagerPanels", () => {
             onClearInlineRenameValidation={() => {}}
             onConfirmInlineRename={async () => true}
             onEntryContextMenu={() => {}}
+            onEntryDragStart={onEntryDragStart}
             onMoveEntry={() => {}}
             onOpenEntry={() => {}}
             onSelect={onSelect}
@@ -100,8 +102,23 @@ describe("WorkspaceFileManagerPanels", () => {
 
       expect(row).not.toBeNull();
       expect(row?.querySelector("button button")).toBeNull();
+      expect(row?.draggable).toBe(true);
       expect(rowButton).not.toBeNull();
+      expect(rowButton?.draggable).toBe(false);
       expect(disclosureButton).not.toBeNull();
+
+      const dataTransfer = {} as DataTransfer;
+      const dragStartEvent = new Event("dragstart", {
+        bubbles: true,
+        cancelable: true
+      });
+      Object.defineProperty(dragStartEvent, "dataTransfer", {
+        value: dataTransfer
+      });
+      await act(async () => {
+        row?.dispatchEvent(dragStartEvent);
+      });
+      expect(onEntryDragStart).toHaveBeenCalledWith(entry, dataTransfer);
 
       await act(async () => {
         rowButton?.click();

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.render.test.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.render.test.tsx
@@ -1,0 +1,126 @@
+import { createI18nRuntime } from "@tutti-os/ui-i18n-runtime";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createWorkspaceFileManagerI18nRuntime,
+  workspaceFileManagerI18nResources
+} from "../i18n/workspaceFileManagerI18n.ts";
+import type { WorkspaceFileEntry } from "../services/workspaceFileManagerTypes.ts";
+import { WorkspaceFileManagerPanels } from "./WorkspaceFileManagerPanels.tsx";
+
+describe("WorkspaceFileManagerPanels", () => {
+  it("keeps row activation and directory disclosure as sibling buttons", async () => {
+    const entry: WorkspaceFileEntry = {
+      hasChildren: true,
+      kind: "directory",
+      mtimeMs: null,
+      name: "Applications",
+      path: "/Users/demo/Applications",
+      sizeBytes: null
+    };
+    const onSelect = vi.fn();
+    const onToggleDirectoryExpanded = vi.fn();
+    const container = document.createElement("div");
+    document.body.append(container);
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: () => null,
+        setItem: () => {}
+      }
+    });
+    const root = createRoot(container);
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkspaceFileManagerPanels
+            arrangeMode="none"
+            canMove={false}
+            contextMenuEntryPath={null}
+            copy={createWorkspaceFileManagerI18nRuntime(
+              createI18nRuntime({
+                dictionaries: [workspaceFileManagerI18nResources.en]
+              })
+            )}
+            inlineRenameEntryPath={null}
+            inlineRenameValidation={null}
+            isRenaming={false}
+            layoutMode="list"
+            pendingDirectoryPath={null}
+            previewState={{ status: "empty" }}
+            selectedEntry={null}
+            selectedPath={null}
+            showPreviewPanel={false}
+            state={{
+              entries: [entry],
+              error: null,
+              isLoading: false,
+              isSearchMode: false
+            }}
+            treeRows={[
+              {
+                depth: 0,
+                entry,
+                expanded: false,
+                expandable: true,
+                kind: "entry",
+                loadingChildren: false
+              }
+            ]}
+            onBlankContextMenu={() => {}}
+            onCancelInlineRename={() => {}}
+            onClearInlineRenameValidation={() => {}}
+            onConfirmInlineRename={async () => true}
+            onEntryContextMenu={() => {}}
+            onMoveEntry={() => {}}
+            onOpenEntry={() => {}}
+            onSelect={onSelect}
+            onToggleDirectoryExpanded={onToggleDirectoryExpanded}
+          />
+        );
+      });
+
+      const row = container.querySelector<HTMLElement>(
+        '[data-workspace-file-entry-path="/Users/demo/Applications"]'
+      );
+      const rowButton = row?.querySelector<HTMLButtonElement>(
+        'button[aria-label="Applications"]'
+      );
+      const disclosureButton = row?.querySelector<HTMLButtonElement>(
+        'button[aria-label="Expand folder"]'
+      );
+
+      expect(row).not.toBeNull();
+      expect(row?.querySelector("button button")).toBeNull();
+      expect(rowButton).not.toBeNull();
+      expect(disclosureButton).not.toBeNull();
+
+      await act(async () => {
+        rowButton?.click();
+      });
+      expect(onSelect).toHaveBeenCalledOnce();
+
+      await act(async () => {
+        disclosureButton?.click();
+      });
+      expect(onToggleDirectoryExpanded).toHaveBeenCalledWith(entry, false);
+      expect(onSelect).toHaveBeenCalledOnce();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+  });
+});

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx
@@ -944,7 +944,7 @@ function EntryRow({
   }, [selected]);
 
   const rowClassName = cn(
-    "grid min-h-10 w-full items-center gap-x-6 border-b border-[var(--border-1)] px-0 text-left transition-colors",
+    "relative grid min-h-10 w-full items-center gap-x-6 border-b border-[var(--border-1)] px-0 text-left transition-colors",
     gridClassName,
     isInlineRenaming
       ? "cursor-default"
@@ -959,17 +959,21 @@ function EntryRow({
     moveDragActive && !moveDragSource && !moveDragTarget && "opacity-90"
   );
   const rowProps = {
-    "aria-label": entry.name,
     className: rowClassName,
     "data-workspace-file-entry-path": entry.path,
-    draggable: isInlineRenaming ? false : draggable,
     style: gridStyle,
     onContextMenu: (event: ReactMouseEvent<HTMLElement>) => {
       onContextMenu(event, entry);
     }
   };
   const nameCell = (
-    <span className={cn("min-w-0 overflow-hidden", tableCellPaddingClassName)}>
+    <span
+      className={cn(
+        "min-w-0 overflow-hidden",
+        !isInlineRenaming && "pointer-events-none relative z-[1]",
+        tableCellPaddingClassName
+      )}
+    >
       <EntryNameCell
         copy={copy}
         contextLabel={contextLabel}
@@ -996,6 +1000,7 @@ function EntryRow({
     <span
       className={cn(
         "truncate text-xs text-[var(--text-secondary)]",
+        !isInlineRenaming && "pointer-events-none relative z-[1]",
         tableCellPaddingClassName
       )}
     >
@@ -1009,6 +1014,7 @@ function EntryRow({
     <span
       className={cn(
         "truncate text-xs text-[var(--text-secondary)]",
+        !isInlineRenaming && "pointer-events-none relative z-[1]",
         tableCellPaddingClassName
       )}
     >
@@ -1020,7 +1026,12 @@ function EntryRow({
 
   if (isInlineRenaming) {
     return (
-      <div {...rowProps} ref={divRowRef}>
+      <div
+        {...rowProps}
+        aria-label={entry.name}
+        draggable={false}
+        ref={divRowRef}
+      >
         {nameCell}
         {modifiedCell}
         {sizeCell}
@@ -1029,28 +1040,31 @@ function EntryRow({
   }
 
   return (
-    <button
-      {...rowProps}
-      ref={buttonRowRef}
-      type="button"
-      onDragStart={(event: ReactDragEvent<HTMLElement>) => {
-        if (!draggable) {
-          event.preventDefault();
-          return;
-        }
-        onDragStart?.(entry, event.dataTransfer);
-      }}
-      onPointerDown={(event) => {
-        onPointerDown(entry, event);
-      }}
-      onClick={() => {
-        onClick(entry);
-      }}
-    >
+    <div {...rowProps} ref={divRowRef}>
+      <button
+        aria-label={entry.name}
+        className="absolute inset-0 z-0"
+        draggable={draggable}
+        ref={buttonRowRef}
+        type="button"
+        onDragStart={(event: ReactDragEvent<HTMLElement>) => {
+          if (!draggable) {
+            event.preventDefault();
+            return;
+          }
+          onDragStart?.(entry, event.dataTransfer);
+        }}
+        onPointerDown={(event) => {
+          onPointerDown(entry, event);
+        }}
+        onClick={() => {
+          onClick(entry);
+        }}
+      />
       {nameCell}
       {modifiedCell}
       {sizeCell}
-    </button>
+    </div>
   );
 }
 
@@ -1260,7 +1274,7 @@ function DirectoryDisclosureButton({
         expanded ? "collapseFolderLabel" : "expandFolderLabel"
       )}
       aria-expanded={expanded}
-      className="grid size-5 shrink-0 place-items-center rounded text-[var(--text-tertiary)] transition-colors hover:bg-transparency-block hover:text-[var(--text-primary)]"
+      className="pointer-events-auto grid size-5 shrink-0 place-items-center rounded text-[var(--text-tertiary)] transition-colors hover:bg-transparency-block hover:text-[var(--text-primary)]"
       disabled={isLoading}
       type="button"
       onClick={(event) => {

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx
@@ -1040,20 +1040,23 @@ function EntryRow({
   }
 
   return (
-    <div {...rowProps} ref={divRowRef}>
+    <div
+      {...rowProps}
+      draggable={draggable}
+      ref={divRowRef}
+      onDragStart={(event: ReactDragEvent<HTMLElement>) => {
+        if (!draggable) {
+          event.preventDefault();
+          return;
+        }
+        onDragStart?.(entry, event.dataTransfer);
+      }}
+    >
       <button
         aria-label={entry.name}
         className="absolute inset-0 z-0"
-        draggable={draggable}
         ref={buttonRowRef}
         type="button"
-        onDragStart={(event: ReactDragEvent<HTMLElement>) => {
-          if (!draggable) {
-            event.preventDefault();
-            return;
-          }
-          onDragStart?.(entry, event.dataTransfer);
-        }}
         onPointerDown={(event) => {
           onPointerDown(entry, event);
         }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -887,6 +887,9 @@ importers:
       "@types/react-dom":
         specifier: ^19.1.5
         version: 19.2.3(@types/react@19.2.15)
+      jsdom:
+        specifier: ^27.2.0
+        version: 27.4.0
       react:
         specifier: ^19.1.0
         version: 19.2.6
@@ -899,6 +902,9 @@ importers:
       valtio:
         specifier: ^2.3.2
         version: 2.3.2(@types/react@19.2.15)(react@19.2.6)
+      vitest:
+        specifier: ^4.0.13
+        version: 4.1.7(@types/node@24.12.4)(jsdom@27.4.0)(vite@6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/workspace/file-preview:
     devDependencies:


### PR DESCRIPTION
## Summary

- replace the invalid nested row/disclosure button structure with sibling native buttons
- preserve row selection, directory expansion, context menu, and drag handling
- add a jsdom render regression test for DOM structure and click isolation

## Verification

- pnpm --filter @tutti-os/workspace-file-manager test
- pnpm --filter @tutti-os/workspace-file-manager typecheck
- pnpm exec oxlint packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.render.test.tsx --deny-warnings
- pnpm check:full

## Checklist

- [x] Agent lifecycle semantics are not changed
- [x] I kept the change focused on one concern
- [x] No durable documentation change is required; behavior is preserved and the package test command is unchanged for callers
- [x] No README/CONTRIBUTING language variants are affected
- [x] I ran the lowest meaningful local checks for the changed surface
- [x] The commit is signed off with DCO
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->