### PR TITLE
fix(agent-gui): publish commercial toast assets

### DIFF
--- a/.changeset/fuzzy-taxis-smile.md
+++ b/.changeset/fuzzy-taxis-smile.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Include the registration credits reward background asset in the published package.

--- a/packages/agent/gui/package.json
+++ b/packages/agent/gui/package.json
@@ -51,7 +51,7 @@
     "directory": "packages/agent/gui"
   },
   "scripts": {
-    "build": "tsup --config tsup.config.ts && tsup --config tsup.dts.config.ts && node ../../../tools/scripts/copy-package-assets.mjs app/renderer/agentactivity.css dist/app/renderer/agentactivity.css app/renderer/assets/icons dist/app/renderer/assets/icons",
+    "build": "tsup --config tsup.config.ts && tsup --config tsup.dts.config.ts && node ../../../tools/scripts/copy-package-assets.mjs app/renderer/agentactivity.css dist/app/renderer/agentactivity.css app/renderer/assets/icons dist/app/renderer/assets/icons app/renderer/assets/commercial dist/app/renderer/assets/commercial",
     "test": "vitest run --environment jsdom --maxWorkers=3",
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },


### PR DESCRIPTION
## Summary

- include AgentGUI commercial assets in the published package
- add a patch changeset for `@tutti-os/agent-gui`
- keep the resource owned upstream so TSH does not duplicate it

## Evidence

- `pnpm check:changed -- --push-ready` (9 lanes passed)
- `pnpm --filter @tutti-os/agent-gui build`
- packed tarball contains `dist/app/renderer/assets/commercial/registration-credits-bg.png`
- independent review: no Blocker/High/Medium

## Why

The published stylesheet references `./assets/commercial/registration-credits-bg.png`, but the npm package previously copied only icon assets, so downstream Vite builds could not resolve the registration reward toast background.

## Documentation impact

No durable documentation impact: package ownership and public API are unchanged; this only repairs an existing release artifact.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->