### PR TITLE
feat(agent-gui): add canonical session rail placement

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -217,6 +217,9 @@ export function createDesktopAgentActivityAdapter({
           model: input.model ?? null,
           noProject:
             input.noProject ?? (normalizeText(input.cwd) ? null : true),
+          ...(input.railPlacement
+            ? { railPlacement: { ...input.railPlacement } }
+            : {}),
           planMode: input.planMode ?? null,
           permissionModeId: input.permissionModeId ?? null,
           reasoningEffort: input.reasoningEffort ?? null,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -508,6 +508,9 @@ export class WorkspaceAgentActivityService
         permissionModeId: resolveComposerPermissionMode(input.settings),
         reasoningEffort: input.settings?.reasoningEffort ?? null,
         ...(resolvedCwd?.noProject ? { noProject: true } : {}),
+        ...(input.railPlacement
+          ? { railPlacement: { ...input.railPlacement } }
+          : {}),
         speed: input.settings?.speed ?? null,
         title: input.title ?? null,
         visible: input.visible ?? true,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
@@ -307,6 +307,9 @@ function activationInput(
           }
         }
       : {}),
+    ...(command.railPlacement
+      ? { railPlacement: { ...command.railPlacement } }
+      : {}),
     ...(command.submitDiagnostics
       ? { submitDiagnostics: { ...command.submitDiagnostics } }
       : {}),

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -696,6 +696,10 @@ The pending activation carries the same resolved project section key as the
 create command. Exact rail projection therefore shows the conversation as soon
 as the intent is accepted; it does not wait for provider startup or invent a
 temporary catch-all section.
+For delegated/shared execution, the initiating caller remains the placement
+authority: the adapter forwards that caller-selected `RailPlacement` through
+the binding to the owner Host. The owner persists the same section key and does
+not recompute it from the owner's user-project list.
 
 ### 7.2 Existing conversation submit
 

--- a/packages/agent/activity-core/src/displayStatus.types.ts
+++ b/packages/agent/activity-core/src/displayStatus.types.ts
@@ -1,0 +1,7 @@
+export type AgentActivityDisplayStatus =
+  | "working"
+  | "waiting"
+  | "idle"
+  | "completed"
+  | "canceled"
+  | "failed";

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
@@ -210,6 +210,12 @@ test("activation intent owns the transport command and confirmation deadline", (
   assert.equal(pendingActivation?.displayPrompt, "/browser");
   assert.equal(pendingActivation?.optimisticTitle, "Review browser flow");
   assert.equal(pendingActivation?.railSectionKey, "project:/workspace");
+  assert.deepEqual(pendingActivation?.railPlacement, {
+    version: 1,
+    kind: "project",
+    projectPath: "/workspace",
+    sectionKey: "project:/workspace"
+  });
   assert.deepEqual(pendingActivation?.content, [
     { type: "text", text: "hello" }
   ]);
@@ -228,6 +234,12 @@ test("activation intent owns the transport command and confirmation deadline", (
       cwd: "/workspace",
       initialContent: [{ type: "text", text: "runtime instructions" }],
       initialDisplayPrompt: "/browser",
+      railPlacement: {
+        version: 1,
+        kind: "project",
+        projectPath: "/workspace",
+        sectionKey: "project:/workspace"
+      },
       submitDiagnostics: { submittedAtUnixMs: 1 },
       mode: "new",
       settings: { model: "model-1" },
@@ -262,6 +274,12 @@ test("control activation can carry content without expecting a Turn", () => {
       initialContent: [{ type: "text", text: "/goal ship it" }],
       initialDisplayPrompt: "/browser",
       initialGoalControl: { action: "set", objective: "ship it" },
+      railPlacement: {
+        version: 1,
+        kind: "project",
+        projectPath: "/workspace",
+        sectionKey: "project:/workspace"
+      },
       submitDiagnostics: { submittedAtUnixMs: 1 },
       mode: "new",
       settings: { model: "model-1" },
@@ -639,6 +657,12 @@ function activation() {
     expiresAtUnixMs: 120_000,
     initialDisplayPrompt: "/browser",
     optimisticTitle: "Review browser flow",
+    railPlacement: {
+      version: 1 as const,
+      kind: "project" as const,
+      projectPath: "/workspace",
+      sectionKey: "project:/workspace"
+    },
     railSectionKey: "project:/workspace",
     runtimeContent: [{ type: "text" as const, text: "runtime instructions" }],
     submitDiagnostics: { submittedAtUnixMs: 1 },

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.ts
@@ -240,6 +240,9 @@ function requestActivation(
       intent.initialTurnExpected ?? runtimeContent.length > 0,
     ...pendingActivationGoalControlFields(intent),
     ...pendingActivationRailSectionKeyFields(intent),
+    ...(intent.railPlacement
+      ? { railPlacement: { ...intent.railPlacement } }
+      : {}),
     ...(intent.submitDiagnostics
       ? { submitDiagnostics: { ...intent.submitDiagnostics } }
       : {}),
@@ -300,6 +303,9 @@ function requestActivation(
               : {}),
             ...(displayPrompt ? { initialDisplayPrompt: displayPrompt } : {}),
             ...pendingActivationGoalControlFields(intent),
+            ...(intent.railPlacement
+              ? { railPlacement: { ...intent.railPlacement } }
+              : {}),
             ...(intent.submitDiagnostics
               ? { submitDiagnostics: { ...intent.submitDiagnostics } }
               : {}),

--- a/packages/agent/activity-core/src/engine/pendingIntents.types.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.types.ts
@@ -8,6 +8,7 @@ import type {
   AgentActivitySubmitSettingsPatch,
   AgentPromptContentBlock
 } from "../types.ts";
+import type { AgentActivityRailPlacement } from "../railPlacement.types.ts";
 
 export type PendingActivationStatus =
   | "requested"
@@ -40,6 +41,7 @@ interface PendingActivationIntentRecordBase {
   initialTurnExpected: boolean;
   initialGoalControl?: Readonly<AgentActivityInitialGoalControl>;
   railSectionKey?: string;
+  railPlacement?: AgentActivityRailPlacement;
   submitDiagnostics?: Readonly<AgentActivitySubmitDiagnostics>;
   pendingSettingsPatch?: Readonly<Record<string, unknown>>;
   settingsUpdateStatus?: "failed" | "inFlight" | "unknown";
@@ -109,6 +111,7 @@ interface SessionActivationRequestedIntentBase {
   initialTurnExpected?: boolean;
   initialGoalControl?: Readonly<AgentActivityInitialGoalControl>;
   railSectionKey?: string;
+  railPlacement?: AgentActivityRailPlacement;
   initialDisplayPrompt?: string;
   runtimeContent?: readonly AgentPromptContentBlock[];
   submitDiagnostics?: Readonly<AgentActivitySubmitDiagnostics>;
@@ -180,6 +183,7 @@ interface SessionActivateCommandBase {
   initialDisplayPrompt?: string;
   initialGoalControl?: Readonly<AgentActivityInitialGoalControl>;
   initialTuttiModeActivation?: AgentActivityInitialTuttiModeActivation;
+  railPlacement?: AgentActivityRailPlacement;
   submitDiagnostics?: Readonly<AgentActivitySubmitDiagnostics>;
   settings?: AgentActivitySessionSettings;
   timeoutMs?: number;

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
@@ -1,8 +1,5 @@
-import type {
-  AgentActivityDisplayStatus,
-  AgentActivityInteraction,
-  AgentActivityTurn
-} from "../types.ts";
+import type { AgentActivityInteraction, AgentActivityTurn } from "../types.ts";
+import type { AgentActivityDisplayStatus } from "../displayStatus.types.ts";
 import type { AgentSessionEngineState } from "./types.ts";
 import type {
   InteractionResponseState,

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -1,5 +1,7 @@
 export type { AgentActivityAdapter } from "./adapter.ts";
 export type { AgentActivityComposerModelConfiguration } from "./composerModelConfiguration.types.ts";
+export type { AgentActivityDisplayStatus } from "./displayStatus.types.ts";
+export type { AgentActivityRailPlacement } from "./railPlacement.types.ts";
 export { normalizeAgentActivityCapabilityReferences } from "./capabilityReferences.ts";
 export {
   normalizeAgentActivitySession,
@@ -262,7 +264,6 @@ export type {
   AgentActivityActivateSessionResult,
   AgentActivityActivationMode,
   AgentActivityActivationStatus,
-  AgentActivityDisplayStatus,
   AgentActivityCancelTurnInput,
   AgentActivityGoalControlAction,
   AgentActivityInitialGoalControl,

--- a/packages/agent/activity-core/src/railPlacement.types.ts
+++ b/packages/agent/activity-core/src/railPlacement.types.ts
@@ -1,0 +1,13 @@
+export type AgentActivityRailPlacement =
+  | {
+      version: 1;
+      kind: "conversations";
+      sectionKey: "conversations";
+      projectPath?: never;
+    }
+  | {
+      version: 1;
+      kind: "project";
+      projectPath: string;
+      sectionKey: string;
+    };

--- a/packages/agent/activity-core/src/selectors.ts
+++ b/packages/agent/activity-core/src/selectors.ts
@@ -1,11 +1,11 @@
 import type {
-  AgentActivityDisplayStatus,
   AgentActivityInteraction,
   AgentActivityNeedsAttentionItem,
   AgentActivityNeedsAttentionKind,
   AgentActivitySession,
   AgentActivitySnapshot
 } from "./types.ts";
+import type { AgentActivityDisplayStatus } from "./displayStatus.types.ts";
 
 export function selectCanonicalAgentActivitySessions(
   snapshot: Pick<AgentActivitySnapshot, "sessions">

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -1,4 +1,5 @@
 import type { AgentActivityComposerModelConfiguration } from "./composerModelConfiguration.types.ts";
+import type { AgentActivityRailPlacement } from "./railPlacement.types.ts";
 import type {
   AgentActivityCapabilityReference,
   AgentActivityInitialTuttiModeActivation,
@@ -15,14 +16,6 @@ export type {
   AgentActivityUpdateTuttiModeActivationInput,
   AgentActivityUpdateTuttiModeActivationResult
 } from "./tuttiMode.types.ts";
-
-export type AgentActivityDisplayStatus =
-  | "working"
-  | "waiting"
-  | "idle"
-  | "completed"
-  | "canceled"
-  | "failed";
 
 export type AgentActivitySessionKind = "root" | "child";
 
@@ -481,6 +474,7 @@ export interface AgentActivityCreateSessionInput {
   noProject?: boolean | null;
   capabilityRefs?: readonly AgentActivityCapabilityReference[] | null;
   initialTuttiModeActivation?: AgentActivityInitialTuttiModeActivation | null;
+  railPlacement?: AgentActivityRailPlacement;
   initialContent?: AgentPromptContentBlock[] | null;
   /** 仅展示用的首轮文本(bundle 折叠成一个 chip);initialContent 仍带展开后的文件。 */
   initialDisplayPrompt?: string | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActivation.ts
@@ -5,6 +5,7 @@ import {
   type AgentActivityInitialGoalControl,
   type AgentActivityInitialTuttiModeActivation,
   type AgentActivitySubmitDiagnostics,
+  type AgentActivityRailPlacement,
   type PendingActivationIntentRecord,
   type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
@@ -26,6 +27,7 @@ interface AgentGUIActivateInputBase {
   initialTurnExpected?: boolean;
   initialGoalControl?: AgentActivityInitialGoalControl;
   railSectionKey?: string;
+  railPlacement?: AgentActivityRailPlacement;
   initialDisplayPrompt?: string;
   runtimeContent?: AgentPromptContentBlock[];
   submitDiagnostics?: AgentActivitySubmitDiagnostics;
@@ -138,6 +140,9 @@ export function useAgentGUIActivation({
           : {}),
         ...(input.railSectionKey?.trim()
           ? { railSectionKey: input.railSectionKey.trim() }
+          : {}),
+        ...(input.railPlacement
+          ? { railPlacement: { ...input.railPlacement } }
           : {}),
         ...(input.initialDisplayPrompt
           ? { initialDisplayPrompt: input.initialDisplayPrompt }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.spec.ts
@@ -1,5 +1,54 @@
 import { describe, expect, it } from "vitest";
-import { resolveInitialTuttiModeActivation } from "./useAgentGUINewConversationActivation";
+import {
+  resolveInitialRailPlacement,
+  resolveInitialTuttiModeActivation
+} from "./useAgentGUINewConversationActivation";
+
+describe("resolveInitialRailPlacement", () => {
+  it("uses the selected caller project section", () => {
+    expect(
+      resolveInitialRailPlacement({
+        selectedProjectPath: "/workspace",
+        userProjects: [
+          {
+            id: "project-1",
+            label: "Workspace",
+            path: "/workspace",
+            pinnedAtUnixMs: 0,
+            sectionKey: "project:/workspace"
+          }
+        ]
+      })
+    ).toEqual({
+      version: 1,
+      kind: "project",
+      projectPath: "/workspace",
+      sectionKey: "project:/workspace"
+    });
+  });
+
+  it("uses conversations only when no project is selected", () => {
+    expect(
+      resolveInitialRailPlacement({
+        selectedProjectPath: null,
+        userProjects: []
+      })
+    ).toEqual({
+      version: 1,
+      kind: "conversations",
+      sectionKey: "conversations"
+    });
+  });
+
+  it("fails closed when the selected project has no canonical section", () => {
+    expect(
+      resolveInitialRailPlacement({
+        selectedProjectPath: "/workspace",
+        userProjects: []
+      })
+    ).toBeNull();
+  });
+});
 
 describe("resolveInitialTuttiModeActivation", () => {
   it("prefers the composer submit snapshot over a stale inactive draft", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
@@ -1,5 +1,6 @@
 import {
   type AgentActivityInitialGoalControl,
+  type AgentActivityRailPlacement,
   isPendingActivationViable,
   selectLatestActivationForSession,
   selectTuttiModeDraftIsActive,
@@ -33,7 +34,10 @@ import {
   type UseAgentGUINewConversationActivationInput
 } from "./agentGuiNewConversationActivation.types";
 import { resolveAgentComposerDraftScopeKey } from "../model/agentComposerDraftScope";
-import { resolveAgentGUIConversationProject } from "../model/agentGuiConversationProjectResolver";
+import {
+  type AgentGUIConversationUserProject,
+  resolveAgentGUIConversationProject
+} from "../model/agentGuiConversationProjectResolver";
 import type { AgentComposerSubmitOptions } from "../composer/AgentComposer.types";
 
 interface ResolvedInitialTuttiModeActivation {
@@ -69,6 +73,34 @@ export function resolveInitialTuttiModeActivation(input: {
 function normalizeOrchestrationIntensity(value: number | null | undefined) {
   if (typeof value !== "number" || !Number.isFinite(value)) return null;
   return Math.min(100, Math.max(0, Math.round(value)));
+}
+
+export function resolveInitialRailPlacement(input: {
+  selectedProjectPath: string | null | undefined;
+  userProjects: readonly AgentGUIConversationUserProject[];
+}): AgentActivityRailPlacement | null {
+  const selectedProjectPath = input.selectedProjectPath?.trim() ?? "";
+  if (!selectedProjectPath) {
+    return {
+      version: 1,
+      kind: "conversations",
+      sectionKey: "conversations"
+    };
+  }
+  const selectedProject = resolveAgentGUIConversationProject(
+    selectedProjectPath,
+    input.userProjects
+  );
+  const sectionKey = selectedProject?.sectionKey?.trim() ?? "";
+  if (!sectionKey) {
+    return null;
+  }
+  return {
+    version: 1,
+    kind: "project",
+    projectPath: selectedProjectPath,
+    sectionKey
+  };
 }
 
 export function useAgentGUINewConversationActivation(
@@ -160,13 +192,14 @@ export function useAgentGUINewConversationActivation(
             }
       );
       const selectedProjectPath = selectedProjectPathRef.current;
-      const selectedProject = resolveAgentGUIConversationProject(
+      const railPlacement = resolveInitialRailPlacement({
         selectedProjectPath,
-        userProjectsRef.current
-      );
-      const railSectionKey = !selectedProjectPath?.trim()
-        ? "conversations"
-        : selectedProject?.sectionKey?.trim() || undefined;
+        userProjects: userProjectsRef.current
+      });
+      if (railPlacement === null) {
+        return null;
+      }
+      const railSectionKey = railPlacement.sectionKey;
       const initialNodeSettings = readNodeDefaultDraftSettings({
         data: targetData.data,
         defaultReasoningEffort,
@@ -241,7 +274,8 @@ export function useAgentGUINewConversationActivation(
           : {}),
         clientSubmitId: submitTrace.clientSubmitId,
         cwd: selectedProjectPath ?? "",
-        ...(railSectionKey ? { railSectionKey } : {}),
+        railPlacement,
+        railSectionKey,
         initialContent: normalizedInitialContent,
         ...(initialTurnExpected !== undefined ? { initialTurnExpected } : {}),
         ...(initialGoalControl ? { initialGoalControl } : {}),

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -15,6 +15,7 @@ import type {
   AgentActivityDeleteSessionResult,
   AgentActivityMessageOrder,
   AgentActivityMessagePage,
+  AgentActivityRailPlacement,
   AgentActivityRenameSessionInput,
   AgentActivitySendInput,
   AgentActivitySendInputResult,
@@ -205,6 +206,7 @@ interface AgentActivityRuntimeActivateSessionInputBase {
   initialContent?: AgentActivitySendInput["content"];
   /** 仅展示用首轮文本(bundle 折叠成一个 chip);initialContent 仍带展开后的文件。 */
   initialDisplayPrompt?: string | null;
+  railPlacement?: AgentActivityRailPlacement;
   submitDiagnostics?: AgentActivitySendInput["submitDiagnostics"];
   settings?: AgentActivitySessionSettings;
   title?: string;

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -26,6 +26,12 @@ eligibility is decided by `ResolveResumePolicy`: root sessions resume normally,
 explicit imports may recreate a missing provider session, and child,
 tombstoned, or non-resumable imports are rejected. Canonical titles may be
 empty; only an explicit title or the first eligible prompt establishes one.
+`CreateSessionInput.RailPlacement` optionally carries the caller-selected,
+versioned canonical rail identity. Host validates it before provider startup
+and persists its opaque `SectionKey` exactly on first creation. An idempotent
+retry that supplies a placement must use the same placement; project deletion
+or another adapter-side view change never reassigns an existing session to
+`conversations`.
 Cancellation exposes durable intent acceptance, provider confirmation, and
 canonical settlement as separate facts. `GoalControl`, `GetGoalState`, and
 `ReconcileGoal` are provider-neutral Host APIs; typed `/goal` commands enter the

--- a/packages/agent/host/canonical_queries_sqlite_test.go
+++ b/packages/agent/host/canonical_queries_sqlite_test.go
@@ -15,7 +15,7 @@ type sqliteCanonicalStore struct {
 	*storesqlite.Store
 }
 
-func (sqliteCanonicalStore) InitializeRuntimeSession(context.Context, agenthost.ProviderRuntimeSession) (storesqlite.Session, error) {
+func (sqliteCanonicalStore) InitializeRuntimeSession(context.Context, agenthost.RuntimeSessionInitialization) (storesqlite.Session, error) {
 	return storesqlite.Session{}, nil
 }
 

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -61,6 +61,7 @@ type Fixture struct {
 type SessionObservation struct {
 	SessionID         string
 	ProviderSessionID string
+	RailSectionKey    string
 	Title             string
 	ActiveTurnID      string
 	Resumable         bool

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -12,8 +12,8 @@ func TestPublishedScenarioCatalogsHaveUniqueNames(t *testing.T) {
 		scenarios []Scenario
 		wantCount int
 	}{
-		{name: "adapter lifecycle", scenarios: Scenarios(), wantCount: 17},
-		{name: "application core", scenarios: ApplicationCoreScenarios(), wantCount: 12},
+		{name: "adapter lifecycle", scenarios: Scenarios(), wantCount: 18},
+		{name: "application core", scenarios: ApplicationCoreScenarios(), wantCount: 13},
 		{name: "resume policy", scenarios: ResumePolicyScenarios(), wantCount: 4},
 		{name: "submission fence", scenarios: SubmissionFenceScenarios(), wantCount: 1},
 		{name: "title policy", scenarios: TitlePolicyScenarios(), wantCount: 1},
@@ -47,6 +47,7 @@ func TestScenarioOwnershipIsExplicit(t *testing.T) {
 	wantApplicationCore := []string{
 		"create empty session",
 		"create with initial content",
+		"create with explicit rail placement",
 		"resume persisted session",
 		"send input",
 		"duplicate client submit id",

--- a/packages/agent/host/conformance/scenarios.go
+++ b/packages/agent/host/conformance/scenarios.go
@@ -3,6 +3,7 @@ package conformance
 var (
 	createEmptySessionScenario          = Scenario{Name: "create empty session", run: runCreateEmptySession}
 	createWithInitialContentScenario    = Scenario{Name: "create with initial content", run: runCreateWithInitialContent}
+	createWithRailPlacementScenario     = Scenario{Name: "create with explicit rail placement", run: runCreateWithRailPlacement}
 	resumePersistedSessionScenario      = Scenario{Name: "resume persisted session", run: runResumePersistedSession}
 	sendInputScenario                   = Scenario{Name: "send input", run: runSendInput}
 	duplicateClientSubmitIDScenario     = Scenario{Name: "duplicate client submit id", run: runDuplicateClientSubmitID}
@@ -31,6 +32,7 @@ func Scenarios() []Scenario {
 	return []Scenario{
 		createEmptySessionScenario,
 		createWithInitialContentScenario,
+		createWithRailPlacementScenario,
 		resumePersistedSessionScenario,
 		sendInputScenario,
 		duplicateClientSubmitIDScenario,
@@ -108,6 +110,7 @@ func ApplicationCoreScenarios() []Scenario {
 	return []Scenario{
 		createEmptySessionScenario,
 		createWithInitialContentScenario,
+		createWithRailPlacementScenario,
 		resumePersistedSessionScenario,
 		sendInputScenario,
 		duplicateClientSubmitIDScenario,

--- a/packages/agent/host/conformance/session_lifecycle_scenarios.go
+++ b/packages/agent/host/conformance/session_lifecycle_scenarios.go
@@ -58,6 +58,53 @@ func runCreateWithInitialContent(ctx context.Context, driver Driver) error {
 	return nil
 }
 
+func runCreateWithRailPlacement(ctx context.Context, driver Driver) error {
+	if err := driver.Reset(ctx, Fixture{}); err != nil {
+		return err
+	}
+	input := agenthost.CreateSessionInput{
+		AgentSessionID: "session-rail-placement",
+		AgentTargetID:  "target-1",
+		Provider:       "codex",
+		InitialContent: []agenthost.PromptContentBlock{{Type: "text", Text: "build in caller project"}},
+		ClientSubmitID: "create-rail-placement-1",
+		RailPlacement: &agenthost.RailPlacement{
+			Version:     1,
+			Kind:        agenthost.RailPlacementKindProject,
+			ProjectPath: "/workspace/project",
+			SectionKey:  "project:workspace-1:/workspace/project",
+		},
+	}
+	session, turnID, err := driver.Create(ctx, "workspace-1", input)
+	if err != nil {
+		return fmt.Errorf("create with explicit rail placement: %w", err)
+	}
+	if turnID == "" {
+		return fmt.Errorf("create with explicit rail placement turn is empty")
+	}
+	if session.RailSectionKey != input.RailPlacement.SectionKey {
+		return fmt.Errorf(
+			"create with explicit rail placement key=%q, want %q",
+			session.RailSectionKey,
+			input.RailPlacement.SectionKey,
+		)
+	}
+	if err := verifyRetriedInitialCreate(ctx, driver, input, session, turnID); err != nil {
+		return err
+	}
+	conflictingRetry := input
+	conflictingPlacement := *input.RailPlacement
+	conflictingPlacement.ProjectPath = "/workspace/other-project"
+	conflictingRetry.RailPlacement = &conflictingPlacement
+	if _, _, err := driver.Create(ctx, "workspace-1", conflictingRetry); !errors.Is(
+		err,
+		agenthost.ErrRailPlacementConflict,
+	) {
+		return fmt.Errorf("retry with conflicting rail placement error=%v", err)
+	}
+	return nil
+}
+
 func runResumePersistedSession(ctx context.Context, driver Driver) error {
 	fixture := Fixture{Session: &SessionSeed{
 		WorkspaceID: "workspace-1", AgentSessionID: "session-resume", Provider: "codex",

--- a/packages/agent/host/errors.go
+++ b/packages/agent/host/errors.go
@@ -7,6 +7,7 @@ import (
 
 var (
 	ErrInvalidArgument                  = errors.New("invalid agent session request")
+	ErrRailPlacementConflict            = errors.New("agent session rail placement conflicts with canonical state")
 	ErrSessionNotFound                  = errors.New("workspace agent session not found")
 	ErrSubmitDeliveryUnknown            = errors.New("agent submit delivery is still being confirmed")
 	ErrSessionTitleTooLong              = errors.New("agent session title is too long")

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -18,6 +18,11 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	if h == nil || h.runtime == nil || h.store == nil || workspaceID == "" || input.AgentSessionID == "" || input.Provider == "" {
 		return CreateSessionResult{}, ErrInvalidArgument
 	}
+	var err error
+	input.RailPlacement, err = normalizeRailPlacement(input.RailPlacement)
+	if err != nil {
+		return CreateSessionResult{}, err
+	}
 	ref := SessionRef{WorkspaceID: workspaceID, AgentSessionID: input.AgentSessionID}
 	normalized, promptText, err := normalizeOptionalPromptContent(input.InitialContent)
 	if err != nil {
@@ -48,6 +53,9 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 		canonicalSession, _, readErr := h.store.GetSession(ctx, workspaceID, input.AgentSessionID)
 		if readErr != nil {
 			return CreateSessionResult{}, readErr
+		}
+		if !railPlacementMatchesSession(input.RailPlacement, canonicalSession) {
+			return CreateSessionResult{}, ErrRailPlacementConflict
 		}
 		runtimeSession, _ := h.runtime.Session(workspaceID, input.AgentSessionID)
 		return CreateSessionResult{Session: runtimeSession, Canonical: canonicalSession, TurnID: claim.TurnID}, nil
@@ -111,7 +119,10 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	}
 	h.observeStep(ctx, "session_create", "runtime_started", session.ID, session.Provider, startedAt, nil)
 	startedAt = h.now()
-	canonicalSession, err := h.store.InitializeRuntimeSession(ctx, session)
+	canonicalSession, err := h.store.InitializeRuntimeSession(ctx, RuntimeSessionInitialization{
+		Session:       session,
+		RailPlacement: input.RailPlacement,
+	})
 	if err != nil {
 		h.observeStep(ctx, "session_create", "session_persisted", session.ID, session.Provider, startedAt, err)
 		return CreateSessionResult{}, cleanup(err, true, false)
@@ -120,6 +131,11 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 		identityErr := fmt.Errorf("initialize workspace agent session: persisted session identity mismatch")
 		h.observeStep(ctx, "session_create", "session_persisted", session.ID, session.Provider, startedAt, identityErr)
 		return CreateSessionResult{}, cleanup(identityErr, true, true)
+	}
+	if !railPlacementMatchesSession(input.RailPlacement, canonicalSession) {
+		placementErr := ErrRailPlacementConflict
+		h.observeStep(ctx, "session_create", "session_persisted", session.ID, session.Provider, startedAt, placementErr)
+		return CreateSessionResult{}, cleanup(placementErr, true, true)
 	}
 	h.observeStep(ctx, "session_create", "session_persisted", session.ID, session.Provider, startedAt, nil)
 	if len(normalized) == 0 && !isTypedGoal {

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -11,9 +11,14 @@ type CanonicalSessionStore interface {
 	GetSession(context.Context, string, string) (storesqlite.Session, bool, error)
 	SessionDeleted(context.Context, string, string) (bool, error)
 	RollbackRuntimeSessionInitialization(context.Context, string, string) (bool, error)
-	InitializeRuntimeSession(context.Context, ProviderRuntimeSession) (storesqlite.Session, error)
+	InitializeRuntimeSession(context.Context, RuntimeSessionInitialization) (storesqlite.Session, error)
 	UpdateSessionTitle(context.Context, string, string, string) (storesqlite.Session, bool, error)
 	ListChildSessions(context.Context, string, string) ([]storesqlite.Session, error)
+}
+
+type RuntimeSessionInitialization struct {
+	Session       ProviderRuntimeSession
+	RailPlacement *RailPlacement
 }
 
 type CanonicalTurnStore interface {

--- a/packages/agent/host/rail_placement.go
+++ b/packages/agent/host/rail_placement.go
@@ -1,0 +1,50 @@
+package agenthost
+
+import (
+	"fmt"
+	"strings"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+const railPlacementVersion = 1
+
+func normalizeRailPlacement(placement *RailPlacement) (*RailPlacement, error) {
+	if placement == nil {
+		return nil, nil
+	}
+	normalized := &RailPlacement{
+		Version:     placement.Version,
+		Kind:        RailPlacementKind(strings.TrimSpace(string(placement.Kind))),
+		ProjectPath: strings.TrimSpace(placement.ProjectPath),
+		SectionKey:  strings.TrimSpace(placement.SectionKey),
+	}
+	if normalized.Version != railPlacementVersion {
+		return nil, fmt.Errorf("%w: unsupported rail placement version", ErrInvalidArgument)
+	}
+	switch normalized.Kind {
+	case RailPlacementKindConversations:
+		if normalized.ProjectPath != "" || normalized.SectionKey != storesqlite.RailSectionKeyConversations {
+			return nil, fmt.Errorf("%w: invalid conversations rail placement", ErrInvalidArgument)
+		}
+	case RailPlacementKindProject:
+		if normalized.ProjectPath == "" ||
+			normalized.SectionKey == "" ||
+			normalized.SectionKey == storesqlite.RailSectionKeyConversations {
+			return nil, fmt.Errorf("%w: invalid project rail placement", ErrInvalidArgument)
+		}
+	default:
+		return nil, fmt.Errorf("%w: invalid rail placement kind", ErrInvalidArgument)
+	}
+	return normalized, nil
+}
+
+func railPlacementMatchesSession(placement *RailPlacement, session storesqlite.Session) bool {
+	if placement == nil {
+		return true
+	}
+	return strings.TrimSpace(session.RailSectionKind) == string(placement.Kind) &&
+		storesqlite.NormalizeProjectPath(session.RailProjectPath) ==
+			storesqlite.NormalizeProjectPath(placement.ProjectPath) &&
+		strings.TrimSpace(session.RailSectionKey) == placement.SectionKey
+}

--- a/packages/agent/host/sqlite_workspace_store.go
+++ b/packages/agent/host/sqlite_workspace_store.go
@@ -3,6 +3,7 @@ package agenthost
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -78,7 +79,8 @@ func (s *SQLiteWorkspaceStore) RollbackRuntimeSessionInitialization(ctx context.
 	return changed, err
 }
 
-func (s *SQLiteWorkspaceStore) InitializeRuntimeSession(ctx context.Context, session ProviderRuntimeSession) (storesqlite.Session, error) {
+func (s *SQLiteWorkspaceStore) InitializeRuntimeSession(ctx context.Context, input RuntimeSessionInitialization) (storesqlite.Session, error) {
+	session := input.Session
 	if s != nil && s.InitializationPolicy != nil {
 		var err error
 		session, err = s.InitializationPolicy.NormalizeRuntimeSessionInitialization(ctx, session)
@@ -108,6 +110,14 @@ func (s *SQLiteWorkspaceStore) InitializeRuntimeSession(ctx context.Context, ses
 	}
 	runtimeContext["visible"] = session.Visible && !session.Provisional
 	userID := firstNonBlank(session.UserID, s.currentUserID())
+	var railPlacement *storesqlite.RailSection
+	if input.RailPlacement != nil {
+		railPlacement = &storesqlite.RailSection{
+			Kind:        string(input.RailPlacement.Kind),
+			ProjectPath: input.RailPlacement.ProjectPath,
+			Key:         input.RailPlacement.SectionKey,
+		}
+	}
 	result, err := store.ReportActivityState(ctx, storesqlite.ActivityStateReport{
 		Session: storesqlite.SessionStateReport{
 			WorkspaceID:       workspaceID,
@@ -122,6 +132,7 @@ func (s *SQLiteWorkspaceStore) InitializeRuntimeSession(ctx context.Context, ses
 			Settings:          composerSettingsPayload(session.Settings),
 			RuntimeContext:    runtimeContext,
 			Cwd:               strings.TrimSpace(session.Cwd),
+			RailPlacement:     railPlacement,
 			Title:             strings.TrimSpace(session.Title),
 			Status:            runtimeLifecycleStatus(session.Status),
 			CurrentPhase:      runtimeLifecyclePhase(session.Status),
@@ -132,6 +143,9 @@ func (s *SQLiteWorkspaceStore) InitializeRuntimeSession(ctx context.Context, ses
 		},
 	})
 	if err != nil {
+		if errors.Is(err, storesqlite.ErrRailSectionConflict) {
+			return storesqlite.Session{}, fmt.Errorf("%w: %v", ErrRailPlacementConflict, err)
+		}
 		return storesqlite.Session{}, err
 	}
 	persisted := result.State.Session

--- a/packages/agent/host/sqlite_workspace_store_test.go
+++ b/packages/agent/host/sqlite_workspace_store_test.go
@@ -3,6 +3,7 @@ package agenthost_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -76,10 +77,18 @@ func TestSQLiteWorkspaceStoreInitializesCanonicalRuntimeSession(t *testing.T) {
 		InitializationObserver: initializationObserver,
 	}
 
-	persisted, err := store.InitializeRuntimeSession(t.Context(), agenthost.ProviderRuntimeSession{
-		ID: "session-1", WorkspaceID: "workspace-1", AgentTargetID: "target-1", Provider: "codex",
-		Visible: true, Provisional: true, RuntimeContext: map[string]any{"source": "create"},
-		Settings: &agenthost.ComposerSettings{Model: "gpt-5.6", ReasoningEffort: "ultra", Speed: "standard"},
+	persisted, err := store.InitializeRuntimeSession(t.Context(), agenthost.RuntimeSessionInitialization{
+		Session: agenthost.ProviderRuntimeSession{
+			ID: "session-1", WorkspaceID: "workspace-1", AgentTargetID: "target-1", Provider: "codex",
+			Visible: true, Provisional: true, RuntimeContext: map[string]any{"source": "create"},
+			Settings: &agenthost.ComposerSettings{Model: "gpt-5.6", ReasoningEffort: "ultra", Speed: "standard"},
+		},
+		RailPlacement: &agenthost.RailPlacement{
+			Version:     1,
+			Kind:        agenthost.RailPlacementKindProject,
+			ProjectPath: "/workspace/app",
+			SectionKey:  "project:workspace-1:/workspace/app",
+		},
 	})
 	if err != nil {
 		t.Fatalf("InitializeRuntimeSession() error = %v", err)
@@ -89,6 +98,9 @@ func TestSQLiteWorkspaceStoreInitializesCanonicalRuntimeSession(t *testing.T) {
 	}
 	if persisted.LastEventUnixMS != 1234 || persisted.Settings["reasoningEffort"] != "ultra" || persisted.Settings["speed"] != "standard" {
 		t.Fatalf("persisted canonical fields = %#v", persisted)
+	}
+	if persisted.RailSectionKey != "project:workspace-1:/workspace/app" {
+		t.Fatalf("persisted rail section key = %q", persisted.RailSectionKey)
 	}
 	if persisted.Metadata.Visible {
 		t.Fatalf("provisional session visibility = true, want false")
@@ -101,6 +113,18 @@ func TestSQLiteWorkspaceStoreInitializesCanonicalRuntimeSession(t *testing.T) {
 	}
 	if initializationPolicy.calls != 1 {
 		t.Fatalf("initialization policy calls = %d, want 1", initializationPolicy.calls)
+	}
+
+	_, err = store.InitializeRuntimeSession(t.Context(), agenthost.RuntimeSessionInitialization{
+		Session: agenthost.ProviderRuntimeSession{
+			ID: "session-1", WorkspaceID: "workspace-1", AgentTargetID: "target-1", Provider: "codex",
+		},
+		RailPlacement: &agenthost.RailPlacement{
+			Version: 1, Kind: agenthost.RailPlacementKindConversations, SectionKey: "conversations",
+		},
+	})
+	if !errors.Is(err, agenthost.ErrRailPlacementConflict) {
+		t.Fatalf("conflicting rail placement error = %v", err)
 	}
 }
 

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -292,6 +292,24 @@ type PromptAttachment struct {
 	Data         string
 }
 
+type RailPlacementKind string
+
+const (
+	RailPlacementKindConversations RailPlacementKind = "conversations"
+	RailPlacementKindProject       RailPlacementKind = "project"
+)
+
+// RailPlacement is the caller-selected canonical conversation-rail identity
+// for a newly created session. SectionKey is opaque to Host and is persisted
+// exactly; ProjectPath is the caller's logical project path, not a prepared
+// runtime or owner-host path.
+type RailPlacement struct {
+	Version     int               `json:"version"`
+	Kind        RailPlacementKind `json:"kind"`
+	ProjectPath string            `json:"projectPath,omitempty"`
+	SectionKey  string            `json:"sectionKey"`
+}
+
 // CreateSessionInput is the provider-neutral create contract. Adapter-only
 // import paths, workspace resolution, identity, and transport state are not
 // part of this type.
@@ -321,6 +339,7 @@ type CreateSessionInput struct {
 	Speed                  *string
 	ConversationDetailMode string
 	Visible                *bool
+	RailPlacement          *RailPlacement
 }
 
 type SendInput struct {

--- a/packages/agent/store-sqlite/activity_session_read.go
+++ b/packages/agent/store-sqlite/activity_session_read.go
@@ -40,6 +40,19 @@ WHERE workspace_id = ? AND agent_session_id = ? AND deleted_at_unix_ms = 0
 		}
 		return Session{}, false, fmt.Errorf("get workspace agent session: %w", err)
 	}
+	railSection, found, err := s.getAgentSessionRailSection(ctx, workspaceID, agentSessionID)
+	if err != nil {
+		return Session{}, false, err
+	}
+	if !found {
+		return Session{}, false, fmt.Errorf(
+			"workspace agent session %q has no rail section",
+			agentSessionID,
+		)
+	}
+	session.RailSectionKind = railSection.Kind
+	session.RailProjectPath = railSection.ProjectPath
+	session.RailSectionKey = railSection.Key
 	return session, true, nil
 }
 

--- a/packages/agent/store-sqlite/activity_transaction.go
+++ b/packages/agent/store-sqlite/activity_transaction.go
@@ -119,6 +119,8 @@ func (s *Store) upsertAgentSessionTx(
 				agentSessionID,
 			)
 		}
+		dto.RailSectionKind = existingRail.Section.Kind
+		dto.RailProjectPath = existingRail.Section.ProjectPath
 		dto.RailSectionKey = existingRail.Section.Key
 		return false, false, projected.LastEventUnixMS, dto, nil
 	}
@@ -147,6 +149,7 @@ func (s *Store) upsertAgentSessionTx(
 		session.CWD,
 		session.RuntimeContext,
 		input.ImportProjectPath,
+		input.RailPlacement,
 	)
 	if err != nil {
 		return false, false, 0, Session{}, err
@@ -205,6 +208,8 @@ WHERE workspace_agent_sessions.deleted_at_unix_ms = 0
 	if err != nil {
 		return false, false, 0, Session{}, err
 	}
+	dto.RailSectionKind = railSection.Kind
+	dto.RailProjectPath = railSection.ProjectPath
 	dto.RailSectionKey = railSection.Key
 	return accepted, sessionStateReportApplied(input, projected.Session), projected.LastEventUnixMS, dto, nil
 }

--- a/packages/agent/store-sqlite/canonical/activity_reports.go
+++ b/packages/agent/store-sqlite/canonical/activity_reports.go
@@ -68,6 +68,7 @@ type WorkspaceAgentSessionStateUpdate struct {
 	SubmitAvailability    *WorkspaceAgentSubmitAvailability         `json:"submitAvailability,omitempty"`
 	InteractionTransition *WorkspaceAgentInteractionTransition      `json:"interactionTransition,omitempty"`
 	CWD                   string                                    `json:"cwd,omitempty"`
+	RailPlacement         *RailPlacement                            `json:"railPlacement,omitempty"`
 	Title                 string                                    `json:"title,omitempty"`
 	LifecycleStatus       string                                    `json:"lifecycleStatus,omitempty"`
 	CurrentPhase          string                                    `json:"currentPhase,omitempty"`
@@ -77,6 +78,12 @@ type WorkspaceAgentSessionStateUpdate struct {
 	EndedAtUnixMS         int64                                     `json:"endedAtUnixMs,omitempty"`
 	Turn                  *WorkspaceAgentTurnStateUpdate            `json:"turn,omitempty"`
 	RootProviderTurn      *WorkspaceAgentRootProviderTurnTransition `json:"rootProviderTurn,omitempty"`
+}
+
+type RailPlacement struct {
+	Kind        string `json:"kind"`
+	ProjectPath string `json:"projectPath,omitempty"`
+	SectionKey  string `json:"sectionKey"`
 }
 
 type WorkspaceAgentRootProviderTurnTransition struct {

--- a/packages/agent/store-sqlite/rail.go
+++ b/packages/agent/store-sqlite/rail.go
@@ -3,12 +3,15 @@ package storesqlite
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 )
+
+var ErrRailSectionConflict = errors.New("workspace agent session rail section conflicts with canonical state")
 
 // Rail section classification buckets sessions in the conversation rail:
 // sessions rooted in a known project path land in that project's section,
@@ -53,8 +56,13 @@ func (s *Store) resolveAgentSessionRailSectionTx(
 	finalCWD string,
 	runtimeContext map[string]any,
 	importProjectPath string,
+	explicitPlacement *RailSection,
 ) (RailSection, error) {
 	existingRail, err := getExistingAgentSessionRailSectionTx(ctx, tx, workspaceID, agentSessionID)
+	if err != nil {
+		return RailSection{}, err
+	}
+	explicitRail, hasExplicitRail, err := explicitAgentSessionRailSection(explicitPlacement)
 	if err != nil {
 		return RailSection{}, err
 	}
@@ -69,15 +77,32 @@ func (s *Store) resolveAgentSessionRailSectionTx(
 	// repair an older ancestor assignment when the same import supplies its
 	// exact selected project path.
 	if existingRail.Found && existingRail.Valid {
+		if hasExplicitRail && existingRail.Section != explicitRail {
+			return RailSection{}, ErrRailSectionConflict
+		}
 		if hasImportRail && shouldRepairImportedAgentSessionRailSection(existingRail.Section, importRail) {
 			return importRail, nil
 		}
 		return existingRail.Section, nil
 	}
+	if hasExplicitRail {
+		return explicitRail, nil
+	}
 	if hasImportRail {
 		return importRail, nil
 	}
 	return s.classifyAgentSessionRailSectionTx(ctx, tx, finalCWD, runtimeContext)
+}
+
+func explicitAgentSessionRailSection(placement *RailSection) (RailSection, bool, error) {
+	if placement == nil {
+		return RailSection{}, false, nil
+	}
+	section := normalizeAgentSessionRailSection(*placement)
+	if !isValidAgentSessionRailSection(section) {
+		return RailSection{}, false, fmt.Errorf("invalid explicit workspace agent rail section")
+	}
+	return section, true, nil
 }
 
 func importedAgentSessionRailSection(
@@ -134,6 +159,33 @@ WHERE workspace_id = ? AND agent_session_id = ?
 		Found:   true,
 		Valid:   isValidAgentSessionRailSection(section),
 	}, nil
+}
+
+func (s *Store) getAgentSessionRailSection(
+	ctx context.Context,
+	workspaceID string,
+	agentSessionID string,
+) (RailSection, bool, error) {
+	row := s.db.QueryRowContext(ctx, `
+SELECT rail_section_kind, rail_project_path, rail_section_key
+FROM workspace_agent_sessions
+WHERE workspace_id = ? AND agent_session_id = ? AND deleted_at_unix_ms = 0
+`, workspaceID, agentSessionID)
+	var section RailSection
+	if err := row.Scan(&section.Kind, &section.ProjectPath, &section.Key); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return RailSection{}, false, nil
+		}
+		return RailSection{}, false, fmt.Errorf("get workspace agent session rail section: %w", err)
+	}
+	section = normalizeAgentSessionRailSection(section)
+	if !isValidAgentSessionRailSection(section) {
+		return RailSection{}, false, fmt.Errorf(
+			"workspace agent session %q has an invalid rail section",
+			agentSessionID,
+		)
+	}
+	return section, true, nil
 }
 
 // ClassifyRailSection classifies a session working directory against the
@@ -324,7 +376,9 @@ func isValidAgentSessionRailSection(section RailSection) bool {
 	case RailSectionKindConversations:
 		return section.ProjectPath == "" && section.Key == RailSectionKeyConversations
 	case RailSectionKindProject:
-		return section.ProjectPath != "" && section.Key == RailSectionKeyForProject(section.ProjectPath)
+		return section.ProjectPath != "" &&
+			section.Key != "" &&
+			section.Key != RailSectionKeyConversations
 	default:
 		return false
 	}

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -291,6 +291,8 @@ type Session struct {
 	Metadata               SessionMetadata
 	InternalRuntimeContext map[string]any
 	Cwd                    string
+	RailSectionKind        string
+	RailProjectPath        string
 	RailSectionKey         string
 	Title                  string
 	// ActiveTurnID is the protocol v2 turn reference: the id of the turn
@@ -579,14 +581,17 @@ type SessionStateReport struct {
 	// ImportProjectPath is the canonical selected project for a historical
 	// import. The store accepts it only for imported, project-backed sessions.
 	ImportProjectPath string
-	Title             string
-	Status            string
-	CurrentPhase      string
-	LastError         string
-	OccurredAtUnixMS  int64
-	StartedAtUnixMS   int64
-	EndedAtUnixMS     int64
-	CreatedAtUnixMS   int64
+	// RailPlacement is an explicit caller-selected placement for a newly
+	// created session. The first accepted value is immutable.
+	RailPlacement    *RailSection
+	Title            string
+	Status           string
+	CurrentPhase     string
+	LastError        string
+	OccurredAtUnixMS int64
+	StartedAtUnixMS  int64
+	EndedAtUnixMS    int64
+	CreatedAtUnixMS  int64
 }
 
 type StateReportResult struct {

--- a/packages/clients/tuttid-ts/src/generated/index.ts
+++ b/packages/clients/tuttid-ts/src/generated/index.ts
@@ -1585,6 +1585,7 @@ export type {
   WorkspaceAgentPlanDecisionOperation,
   WorkspaceAgentPlanDecisionResponse,
   WorkspaceAgentProvider,
+  WorkspaceAgentRailPlacement,
   WorkspaceAgentSession,
   WorkspaceAgentSessionAttachmentResponse,
   WorkspaceAgentSessionDetailResponse,

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -2707,6 +2707,7 @@ export type CreateWorkspaceAgentSessionRequest = {
    * Classifies a session that is intentionally not attached to a workspace project.
    */
   noProject?: boolean | null;
+  railPlacement?: WorkspaceAgentRailPlacement;
   speed?: string | null;
   planMode?: boolean | null;
   browserUse?: boolean | null;
@@ -2719,6 +2720,13 @@ export type CreateWorkspaceAgentSessionRequest = {
    */
   initialTuttiModeActivation?: TuttiModeActivationIntent | null;
   visible?: boolean | null;
+};
+
+export type WorkspaceAgentRailPlacement = {
+  version: 1;
+  kind: "conversations" | "project";
+  projectPath?: string;
+  sectionKey: string;
 };
 
 export type SendWorkspaceAgentSessionInputRequest = {

--- a/services/tuttid/api/daemon_agent_submit_handlers.go
+++ b/services/tuttid/api/daemon_agent_submit_handlers.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
 	"github.com/tutti-os/tutti/services/tuttid/apierrors"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
@@ -69,6 +70,7 @@ func (api DaemonAPI) CreateWorkspaceAgentSession(ctx context.Context, request tu
 		BrowserUse:                 request.Body.BrowserUse,
 		ReasoningEffort:            request.Body.ReasoningEffort,
 		RuntimeContext:             createSessionRuntimeContext(request.Body.NoProject),
+		RailPlacement:              railPlacementFromGenerated(request.Body.RailPlacement),
 		Speed:                      request.Body.Speed,
 		Title:                      request.Body.Title,
 		Visible:                    request.Body.Visible,
@@ -100,6 +102,18 @@ func tuttiModeActivationIntentFromGenerated(input *tuttigenerated.TuttiModeActiv
 		Source:                 string(input.Source),
 		OrchestrationIntensity: input.OrchestrationIntensity,
 	}, nil
+}
+
+func railPlacementFromGenerated(placement *tuttigenerated.WorkspaceAgentRailPlacement) *agenthost.RailPlacement {
+	if placement == nil {
+		return nil
+	}
+	return &agenthost.RailPlacement{
+		Version:     int(placement.Version),
+		Kind:        agenthost.RailPlacementKind(placement.Kind),
+		ProjectPath: stringPtrValue(placement.ProjectPath),
+		SectionKey:  placement.SectionKey,
+	}
 }
 
 func createSessionRuntimeContext(noProject *bool) map[string]any {

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -1998,13 +1998,13 @@ func (e TuttiModePlanTaskPriority) Valid() bool {
 
 // Defines values for WorkbenchSnapshotSchemaVersion.
 const (
-	N1 WorkbenchSnapshotSchemaVersion = 1
+	WorkbenchSnapshotSchemaVersionN1 WorkbenchSnapshotSchemaVersion = 1
 )
 
 // Valid indicates whether the value is a known member of the WorkbenchSnapshotSchemaVersion enum.
 func (e WorkbenchSnapshotSchemaVersion) Valid() bool {
 	switch e {
-	case N1:
+	case WorkbenchSnapshotSchemaVersionN1:
 		return true
 	default:
 		return false
@@ -2170,6 +2170,39 @@ func (e WorkspaceAgentPlanDecisionOperationStatus) Valid() bool {
 	}
 }
 
+// Defines values for WorkspaceAgentRailPlacementKind.
+const (
+	WorkspaceAgentRailPlacementKindConversations WorkspaceAgentRailPlacementKind = "conversations"
+	WorkspaceAgentRailPlacementKindProject       WorkspaceAgentRailPlacementKind = "project"
+)
+
+// Valid indicates whether the value is a known member of the WorkspaceAgentRailPlacementKind enum.
+func (e WorkspaceAgentRailPlacementKind) Valid() bool {
+	switch e {
+	case WorkspaceAgentRailPlacementKindConversations:
+		return true
+	case WorkspaceAgentRailPlacementKindProject:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for WorkspaceAgentRailPlacementVersion.
+const (
+	WorkspaceAgentRailPlacementVersionN1 WorkspaceAgentRailPlacementVersion = 1
+)
+
+// Valid indicates whether the value is a known member of the WorkspaceAgentRailPlacementVersion enum.
+func (e WorkspaceAgentRailPlacementVersion) Valid() bool {
+	switch e {
+	case WorkspaceAgentRailPlacementVersionN1:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for WorkspaceAgentSessionAttachmentResponseMimeType.
 const (
 	WorkspaceAgentSessionAttachmentResponseMimeTypeImagejpeg WorkspaceAgentSessionAttachmentResponseMimeType = "image/jpeg"
@@ -2295,16 +2328,16 @@ func (e WorkspaceAgentSessionKind) Valid() bool {
 
 // Defines values for WorkspaceAgentSessionSectionKind.
 const (
-	Conversations WorkspaceAgentSessionSectionKind = "conversations"
-	Project       WorkspaceAgentSessionSectionKind = "project"
+	WorkspaceAgentSessionSectionKindConversations WorkspaceAgentSessionSectionKind = "conversations"
+	WorkspaceAgentSessionSectionKindProject       WorkspaceAgentSessionSectionKind = "project"
 )
 
 // Valid indicates whether the value is a known member of the WorkspaceAgentSessionSectionKind enum.
 func (e WorkspaceAgentSessionSectionKind) Valid() bool {
 	switch e {
-	case Conversations:
+	case WorkspaceAgentSessionSectionKindConversations:
 		return true
-	case Project:
+	case WorkspaceAgentSessionSectionKindProject:
 		return true
 	default:
 		return false
@@ -4371,14 +4404,15 @@ type CreateWorkspaceAgentSessionRequest struct {
 	Model                      *string                    `json:"model,omitempty"`
 
 	// NoProject Classifies a session that is intentionally not attached to a workspace project.
-	NoProject         *bool                   `json:"noProject,omitempty"`
-	PermissionModeId  *string                 `json:"permissionModeId,omitempty"`
-	PlanMode          *bool                   `json:"planMode,omitempty"`
-	ReasoningEffort   *string                 `json:"reasoningEffort,omitempty"`
-	Speed             *string                 `json:"speed,omitempty"`
-	SubmitDiagnostics *AgentSubmitDiagnostics `json:"submitDiagnostics,omitempty"`
-	Title             *string                 `json:"title,omitempty"`
-	Visible           *bool                   `json:"visible,omitempty"`
+	NoProject         *bool                        `json:"noProject,omitempty"`
+	PermissionModeId  *string                      `json:"permissionModeId,omitempty"`
+	PlanMode          *bool                        `json:"planMode,omitempty"`
+	RailPlacement     *WorkspaceAgentRailPlacement `json:"railPlacement,omitempty"`
+	ReasoningEffort   *string                      `json:"reasoningEffort,omitempty"`
+	Speed             *string                      `json:"speed,omitempty"`
+	SubmitDiagnostics *AgentSubmitDiagnostics      `json:"submitDiagnostics,omitempty"`
+	Title             *string                      `json:"title,omitempty"`
+	Visible           *bool                        `json:"visible,omitempty"`
 }
 
 // CreateWorkspaceAppFactoryJobRequest defines model for CreateWorkspaceAppFactoryJobRequest.
@@ -6154,6 +6188,20 @@ type WorkspaceAgentPlanDecisionResponse struct {
 
 // WorkspaceAgentProvider defines model for WorkspaceAgentProvider.
 type WorkspaceAgentProvider = string
+
+// WorkspaceAgentRailPlacement defines model for WorkspaceAgentRailPlacement.
+type WorkspaceAgentRailPlacement struct {
+	Kind        WorkspaceAgentRailPlacementKind    `json:"kind"`
+	ProjectPath *string                            `json:"projectPath,omitempty"`
+	SectionKey  string                             `json:"sectionKey"`
+	Version     WorkspaceAgentRailPlacementVersion `json:"version"`
+}
+
+// WorkspaceAgentRailPlacementKind defines model for WorkspaceAgentRailPlacement.Kind.
+type WorkspaceAgentRailPlacementKind string
+
+// WorkspaceAgentRailPlacementVersion defines model for WorkspaceAgentRailPlacement.Version.
+type WorkspaceAgentRailPlacementVersion int
 
 // WorkspaceAgentSession defines model for WorkspaceAgentSession.
 type WorkspaceAgentSession struct {

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -12050,6 +12050,8 @@ components:
           type: boolean
           nullable: true
           description: Classifies a session that is intentionally not attached to a workspace project.
+        railPlacement:
+          $ref: "#/components/schemas/WorkspaceAgentRailPlacement"
         speed:
           type: string
           nullable: true
@@ -12073,6 +12075,29 @@ components:
         visible:
           type: boolean
           nullable: true
+    WorkspaceAgentRailPlacement:
+      type: object
+      additionalProperties: false
+      required:
+        - version
+        - kind
+        - sectionKey
+      properties:
+        version:
+          type: integer
+          enum:
+            - 1
+        kind:
+          type: string
+          enum:
+            - conversations
+            - project
+        projectPath:
+          type: string
+          minLength: 1
+        sectionKey:
+          type: string
+          minLength: 1
     SendWorkspaceAgentSessionInputRequest:
       type: object
       additionalProperties: false

--- a/services/tuttid/biz/agentactivity/activity.go
+++ b/services/tuttid/biz/agentactivity/activity.go
@@ -68,6 +68,7 @@ func SplitSessionRuntimeContext(runtimeContext map[string]any) (SessionMetadata,
 }
 
 type SessionStateReport = agentstore.SessionStateReport
+type RailSection = agentstore.RailSection
 
 type StateReportResult = agentstore.StateReportResult
 

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -252,6 +252,7 @@ func (p *ActivityProjection) reportSessionState(
 		Settings:          clonePayload(input.State.Settings),
 		RuntimeContext:    clonePayload(runtimeContext),
 		Cwd:               strings.TrimSpace(input.State.CWD),
+		RailPlacement:     canonicalRailSection(input.State.RailPlacement),
 		Title:             strings.TrimSpace(sessionStateTitle(input.State)),
 		Status:            strings.TrimSpace(input.State.LifecycleStatus),
 		CurrentPhase:      strings.TrimSpace(input.State.CurrentPhase),
@@ -288,6 +289,17 @@ func (p *ActivityProjection) reportSessionState(
 		agenthost.NotifyCommitted(ctx, p, agenthost.ActivityStateDelta(input, reply, activityResult))
 	}
 	return reply, nil
+}
+
+func canonicalRailSection(placement *canonical.RailPlacement) *agentactivitybiz.RailSection {
+	if placement == nil {
+		return nil
+	}
+	return &agentactivitybiz.RailSection{
+		Kind:        strings.TrimSpace(placement.Kind),
+		ProjectPath: strings.TrimSpace(placement.ProjectPath),
+		Key:         strings.TrimSpace(placement.SectionKey),
+	}
 }
 
 func (p *ActivityProjection) reportFailedRuntimeNodeResult(ctx context.Context, input canonical.ReportSessionStateInput) {

--- a/services/tuttid/service/agent/activity_projection_session_initialize.go
+++ b/services/tuttid/service/agent/activity_projection_session_initialize.go
@@ -36,6 +36,7 @@ func (p *ActivityProjection) NormalizeRuntimeSessionInitialization(
 func (p *ActivityProjection) InitializeRuntimeSession(
 	ctx context.Context,
 	session ProviderRuntimeSession,
+	railPlacement *agenthost.RailPlacement,
 ) (PersistedSession, error) {
 	if p == nil || p.repo == nil {
 		return PersistedSession{}, fmt.Errorf("agent activity repository is unavailable")
@@ -86,6 +87,7 @@ func (p *ActivityProjection) InitializeRuntimeSession(
 			Settings:          composerSettingsToStatePayload(settings),
 			RuntimeContext:    runtimeContext,
 			CWD:               strings.TrimSpace(session.Cwd),
+			RailPlacement:     canonicalRailPlacement(railPlacement),
 			Title:             strings.TrimSpace(session.Title),
 			LifecycleStatus:   runtimeSessionLifecycleStatus(session.Status),
 			CurrentPhase:      runtimeSessionCurrentPhase(session.Status),
@@ -109,6 +111,17 @@ func (p *ActivityProjection) InitializeRuntimeSession(
 		return PersistedSession{}, fmt.Errorf("initialized agent session has no rail section key")
 	}
 	return result, nil
+}
+
+func canonicalRailPlacement(placement *agenthost.RailPlacement) *canonical.RailPlacement {
+	if placement == nil {
+		return nil
+	}
+	return &canonical.RailPlacement{
+		Kind:        string(placement.Kind),
+		ProjectPath: placement.ProjectPath,
+		SectionKey:  placement.SectionKey,
+	}
 }
 
 func runtimeSessionLifecycleStatus(status string) string {

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -336,7 +336,8 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 	persisted := PersistedSession{
 		ID: seed.AgentSessionID, WorkspaceID: seed.WorkspaceID, Kind: kind, Origin: seed.Origin,
 		Provider: seed.Provider, ProviderSessionID: seed.ProviderSessionID, Cwd: seed.Cwd,
-		RailSectionKey: "conversations", Settings: settings,
+		RailSectionKind: "conversations",
+		RailSectionKey:  "conversations", Settings: settings,
 		Metadata:               agentactivitybiz.SessionMetadata{Visible: true, Capabilities: []string{}},
 		InternalRuntimeContext: runtimeContext,
 		Title:                  seed.Title, ActiveTurnID: seed.ActiveTurnID,
@@ -356,7 +357,9 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 		additionalKey := additional.WorkspaceID + ":" + additional.AgentSessionID
 		d.sessions.sessions[additionalKey] = PersistedSession{
 			ID: additional.AgentSessionID, WorkspaceID: additional.WorkspaceID, Kind: additionalKind,
-			Provider: additional.Provider, Cwd: additional.Cwd, RailSectionKey: "conversations",
+			Provider: additional.Provider, Cwd: additional.Cwd,
+			RailSectionKind: "conversations",
+			RailSectionKey:  "conversations",
 			Metadata:        agentactivitybiz.SessionMetadata{Visible: true, Capabilities: []string{}},
 			CreatedAtUnixMS: 1, UpdatedAtUnixMS: 2, LastEventUnixMS: 2,
 		}
@@ -482,6 +485,7 @@ func (d *legacyHostConformanceDriver) Create(
 		ProviderTargetRef: input.ProviderTargetRef, ReasoningEffort: input.ReasoningEffort,
 		RuntimeContext: input.RuntimeContext, Speed: input.Speed,
 		ConversationDetailMode: input.ConversationDetailMode, Visible: input.Visible,
+		RailPlacement: input.RailPlacement,
 	})
 	if err != nil {
 		return hostconformance.SessionObservation{}, "", err
@@ -917,8 +921,9 @@ type legacyHostConformanceSessionInitializer struct {
 func (i legacyHostConformanceSessionInitializer) InitializeRuntimeSession(
 	ctx context.Context,
 	session ProviderRuntimeSession,
+	railPlacement *agenthost.RailPlacement,
 ) (PersistedSession, error) {
-	persisted, err := (fakeSessionInitializer{}).InitializeRuntimeSession(ctx, session)
+	persisted, err := (fakeSessionInitializer{}).InitializeRuntimeSession(ctx, session, railPlacement)
 	if err == nil {
 		i.sessions.sessions[persisted.WorkspaceID+":"+persisted.ID] = persisted
 	}
@@ -1042,7 +1047,8 @@ func legacyHostSessionObservationWithLive(session Session, live bool) hostconfor
 	}
 	return hostconformance.SessionObservation{
 		SessionID: session.ID, ProviderSessionID: session.ProviderSessionID,
-		Title: value(session.Title), ActiveTurnID: session.ActiveTurnID, Resumable: session.Resumable,
+		RailSectionKey: session.RailSectionKey,
+		Title:          value(session.Title), ActiveTurnID: session.ActiveTurnID, Resumable: session.Resumable,
 		Settings: settings, Pinned: session.PinnedAtUnixMS > 0, Live: live,
 	}
 }

--- a/services/tuttid/service/agent/host_test_adapters_test.go
+++ b/services/tuttid/service/agent/host_test_adapters_test.go
@@ -52,8 +52,8 @@ func (a serviceHostStore) RollbackRuntimeSessionInitialization(ctx context.Conte
 	return rollbacker.RollbackRuntimeSessionInitialization(ctx, workspaceID, sessionID)
 }
 
-func (a serviceHostStore) InitializeRuntimeSession(ctx context.Context, session ProviderRuntimeSession) (storesqlite.Session, error) {
-	persisted, err := a.service.initializeRuntimeSession(ctx, session)
+func (a serviceHostStore) InitializeRuntimeSession(ctx context.Context, input agenthost.RuntimeSessionInitialization) (storesqlite.Session, error) {
+	persisted, err := a.service.initializeRuntimeSession(ctx, input.Session, input.RailPlacement)
 	return activitySessionFromPersisted(persisted), err
 }
 
@@ -308,7 +308,9 @@ func activitySessionFromPersisted(session PersistedSession) storesqlite.Session 
 		ParentAgentSessionID: session.ParentAgentSessionID, ParentTurnID: session.ParentTurnID,
 		ParentToolCallID: session.ParentToolCallID, Origin: session.Origin, UserID: session.UserID,
 		AgentTargetID: session.AgentTargetID, Provider: session.Provider, ProviderSessionID: session.ProviderSessionID,
-		Cwd: session.Cwd, RailSectionKey: session.RailSectionKey, Settings: ComposerSettingsToMap(session.Settings),
+		Cwd:             session.Cwd,
+		RailSectionKind: session.RailSectionKind, RailProjectPath: session.RailProjectPath,
+		RailSectionKey: session.RailSectionKey, Settings: ComposerSettingsToMap(session.Settings),
 		Metadata: session.Metadata, InternalRuntimeContext: clonePayload(session.InternalRuntimeContext), Title: session.Title,
 		PinnedAtUnixMS: session.PinnedAtUnixMS, LastEventUnixMS: session.LastEventUnixMS,
 		StartedAtUnixMS: session.StartedAtUnixMS, EndedAtUnixMS: session.EndedAtUnixMS,

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -217,6 +217,7 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 		RuntimeContext:         stampAgentExtensionComposerScope(input.RuntimeContext, input.ProviderTargetRef, cwd, runtimeSettings),
 		Speed:                  stringPointer(runtimeSettings.Speed),
 		ConversationDetailMode: input.ConversationDetailMode, Visible: input.Visible,
+		RailPlacement: input.RailPlacement,
 	}
 	if err := s.applyInitialTuttiModeActivation(ctx, workspaceID, input.AgentSessionID, input.InitialTuttiModeActivation); err != nil {
 		return CreateSessionResult{}, err

--- a/services/tuttid/service/agent/service_host_create_rollback_test.go
+++ b/services/tuttid/service/agent/service_host_create_rollback_test.go
@@ -82,7 +82,7 @@ func TestProvisionalRuntimeSessionShellIsHiddenAndUnpublished(t *testing.T) {
 	persisted, err := projection.InitializeRuntimeSession(context.Background(), ProviderRuntimeSession{
 		ID: "session-provisional", WorkspaceID: "ws-1", Provider: "codex",
 		Status: "ready", Visible: true, Provisional: true, CreatedAtUnixMS: 1, UpdatedAtUnixMS: 1,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("InitializeRuntimeSession() error=%v", err)
 	}

--- a/services/tuttid/service/agent/service_session.go
+++ b/services/tuttid/service/agent/service_session.go
@@ -139,11 +139,12 @@ func serviceSession(session ProviderRuntimeSession, resumable bool) Session {
 func (s *Service) initializeRuntimeSession(
 	ctx context.Context,
 	session ProviderRuntimeSession,
+	railPlacement *agenthost.RailPlacement,
 ) (PersistedSession, error) {
 	if s == nil || s.SessionInitializer == nil {
 		return PersistedSession{}, fmt.Errorf("initialize workspace agent session: session initializer is unavailable")
 	}
-	persisted, err := s.SessionInitializer.InitializeRuntimeSession(ctx, session)
+	persisted, err := s.SessionInitializer.InitializeRuntimeSession(ctx, session, railPlacement)
 	if err != nil {
 		return PersistedSession{}, fmt.Errorf("initialize workspace agent session: %w", err)
 	}

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -7225,6 +7225,7 @@ type fakeSessionInitializer struct {
 func (f fakeSessionInitializer) InitializeRuntimeSession(
 	_ context.Context,
 	session ProviderRuntimeSession,
+	railPlacement *agenthost.RailPlacement,
 ) (PersistedSession, error) {
 	if f.err != nil {
 		return PersistedSession{}, f.err
@@ -7239,6 +7240,7 @@ func (f fakeSessionInitializer) InitializeRuntimeSession(
 		Provider:               strings.TrimSpace(session.Provider),
 		ProviderSessionID:      strings.TrimSpace(session.ProviderSessionID),
 		Cwd:                    strings.TrimSpace(session.Cwd),
+		RailSectionKind:        "conversations",
 		RailSectionKey:         "conversations",
 		Settings:               settings,
 		Metadata:               agentactivitybiz.SessionMetadata{Visible: session.Visible, Capabilities: []string{}},
@@ -7249,6 +7251,11 @@ func (f fakeSessionInitializer) InitializeRuntimeSession(
 		StartedAtUnixMS:        session.CreatedAtUnixMS,
 		CreatedAtUnixMS:        session.CreatedAtUnixMS,
 		UpdatedAtUnixMS:        session.UpdatedAtUnixMS,
+	}
+	if railPlacement != nil {
+		persisted.RailSectionKind = strings.TrimSpace(string(railPlacement.Kind))
+		persisted.RailProjectPath = strings.TrimSpace(railPlacement.ProjectPath)
+		persisted.RailSectionKey = strings.TrimSpace(railPlacement.SectionKey)
 	}
 	if f.reader != nil {
 		f.reader.sessions[persisted.WorkspaceID+":"+persisted.ID] = persisted

--- a/services/tuttid/service/agent/service_visibility.go
+++ b/services/tuttid/service/agent/service_visibility.go
@@ -19,7 +19,7 @@ func (s *Service) UpdateVisible(ctx context.Context, workspaceID string, agentSe
 	if err != nil {
 		return Session{}, normalizeRuntimeError(err)
 	}
-	persisted, err := s.initializeRuntimeSession(ctx, session)
+	persisted, err := s.initializeRuntimeSession(ctx, session, nil)
 	if err != nil {
 		return Session{}, err
 	}

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -362,6 +362,8 @@ type PersistedSession struct {
 	Provider               string
 	ProviderSessionID      string
 	Cwd                    string
+	RailSectionKind        string
+	RailProjectPath        string
 	RailSectionKey         string
 	Settings               ComposerSettings
 	Metadata               agentactivitybiz.SessionMetadata
@@ -414,7 +416,7 @@ type SessionPageReader interface {
 // every successful Create response must expose. In particular, it assigns the
 // immutable railSectionKey before the response leaves the daemon.
 type SessionInitializer interface {
-	InitializeRuntimeSession(context.Context, ProviderRuntimeSession) (PersistedSession, error)
+	InitializeRuntimeSession(context.Context, ProviderRuntimeSession, *agenthost.RailPlacement) (PersistedSession, error)
 }
 
 type ChildSessionReader interface {
@@ -604,6 +606,7 @@ type CreateSessionInput struct {
 	Speed                  *string
 	ConversationDetailMode string
 	Visible                *bool
+	RailPlacement          *agenthost.RailPlacement
 	ExtraSkills            []SessionSkillBundle
 	// ExternalRolloutSourcePath is the absolute path to the original provider
 	// CLI rollout/transcript file this session was imported from, when known.

--- a/services/tuttid/service/agent/worktree_test.go
+++ b/services/tuttid/service/agent/worktree_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 )
 
@@ -25,8 +26,9 @@ type recordingWorktreeSessionInitializer struct {
 func (i recordingWorktreeSessionInitializer) InitializeRuntimeSession(
 	ctx context.Context,
 	session ProviderRuntimeSession,
+	railPlacement *agenthost.RailPlacement,
 ) (PersistedSession, error) {
-	persisted, err := (fakeSessionInitializer{}).InitializeRuntimeSession(ctx, session)
+	persisted, err := (fakeSessionInitializer{}).InitializeRuntimeSession(ctx, session, railPlacement)
 	if err == nil {
 		i.sessions.sessions[persisted.WorkspaceID+":"+persisted.ID] = persisted
 	}


### PR DESCRIPTION
## What changed

- add a versioned canonical rail-placement value to AgentGUI session creation and shared-agent Host contracts
- persist the caller-selected `kind`, `projectPath`, and opaque `sectionKey` as immutable session data
- reject idempotent retries whose supplied placement differs from canonical state
- preserve placement across owner hosting and subsequent session reads
- keep placement optional for mixed-version clients; no pre-launch history backfill

## Why

Shared-agent placement belongs to the caller's current `user_project`, not the owner's local project mapping. The persisted rail identity also lets project deletion retain current Tutti deleted-project semantics without relocating old sessions to Conversations.

## Coordinated rollout

- tsh-server: https://github.com/tutti-lab/tsh-server/pull/483
- TSH: https://github.com/tutti-lab/tsh/pull/1973

This PR remains draft. After merge it needs a Tutti release; TSH must then upgrade all aligned Tutti dependencies and generated files atomically.

## Verification

- `pnpm generate:api` (generated output clean)
- `pnpm check:changed -- --push-ready` (32 lanes passed)
- Host/store/service conformance covers same-key/different-project retry conflicts
- pre-commit formatting and repository boundary checks
