### PR TITLE
fix(agent-gui): reduce composer input layout work

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,6 @@
 pnpm exec lint-staged
 pnpm check:backdrop-filter-authoring:staged
+pnpm check:css-has-performance:staged
 pnpm check:electron-runtime-boundaries:staged
 pnpm check:ui-boundaries:staged
 pnpm check:renderer-boundaries:staged

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -403,6 +403,14 @@ timestamp.
 
 High-frequency transcript updates must not pair DOM mutation with unconditional synchronous reads of the timeline's full scroll geometry. Conversation switches, explicit submit-to-bottom requests, skeleton transitions, and older-page prepend restoration may perform pre-paint scroll correction; ordinary content growth preserves bottom lock and user scroll-away state from observed content and viewport geometry after layout.
 
+Composer draft updates cross the view boundary through the stable `shell`,
+`rail`, `detail`, `composer`, `interaction`, `readiness`, and `operations`
+projections rather than one aggregate Detail prop. The active Timeline
+`ScrollArea` is a memoized render island and does not consume draft state.
+TipTap treats a controlled value as a local acknowledgement only when its
+draft scope and local edit revision match; a scope change or other external
+replacement may rebuild the document.
+
 A virtualized transcript derives message-locator selection from the virtualizer's measured turn positions and explicit transcript identity. The currently mounted DOM window is rendering output, not a selection source; range changes must not make the locator temporarily select a neighboring message.
 
 Historical rich text renders from the canonical Tiptap document through a static schema renderer. Only interactive composer surfaces own a Tiptap Editor/ProseMirror EditorView; read-only transcript and title surfaces reuse the same mention/token presentation without mounting editor lifecycle.
@@ -595,6 +603,15 @@ so a composer read cannot invalidate the conversation root. Composer paragraphs
 and the viewport calculation share the same line-height token so the 3.5-line
 cap remains exact. Regression coverage must expand across explicit newline
 rows, delete back to one row, and verify stable action-button placement.
+
+Dynamic Agent surfaces must not use `:has()` on `.workbench-window`, the
+timeline, or transcript rows. Composer and streaming DOM mutations would make
+those relational subjects candidates for subtree style invalidation. Window
+header layout and render-error state are projected onto the owning window or
+header; message footer, speaker, thinking-edge, and row-kind state are projected
+onto the owning message flow or transcript row. Small, self-contained controls
+may still use local relational selectors when their subject and mutation scope
+are bounded.
 
 External OS file paste and drop enter one host-injected classification boundary before draft attachment creation. The synchronous `resolveExternalPromptEntries` port classifies each source index as a live `WorkspaceFileReference` or a snapshot requiring preparation. AgentGUI owns ordered mention insertion and draft reconciliation: references become ordinary file/folder mentions and never consume prompt-asset slots, while only `prepare` entries create pending attachment state and enter `prepareExternalPromptFiles`. A host without the resolver prepares every external entry. The preparer owns native-path or byte lookup, size enforcement, persistence, and remote transport; each prepared input has one `sourceIndex` result, one failure must not fail siblings, successful results include a provider-readable `path` or `url`, and failures carry typed error codes. Hosts that classify path-backed entries as references must reject any such entry that unexpectedly reaches preparation, so classification failure cannot silently create a duplicate snapshot.
 

--- a/docs/architecture/browser-node-package.md
+++ b/docs/architecture/browser-node-package.md
@@ -56,15 +56,15 @@ The ordinary Browser surface and the Workbench Browser node render the same
 strip above a navigation row, so the broad top-row blank area is the window
 drag target while the address bar remains fully interactive below it. The
 Workbench adapter does not recreate either row: it renders the same component
-and opts its custom header into the Browser-owned 76-pixel layout through
-`data-workbench-custom-header-layout="browser-tabs"`.
+and declares the Browser-owned header presentation through the node definition:
+`window.header: { heightPx: 76, overflow: "visible" }`. Workbench projects the
+height to `--workbench-header-height` on the owning window.
 
 The menu stays inline so its Electron guest-overlay coordination is identical
-in both shells. The shared Browser header also marks itself with
-`data-workbench-custom-header-overflow="visible"`; Workbench honors that opt-in
-on its otherwise clipping custom-header row, allowing the menu to extend over
-the node body while the outer Workbench window still clips content to the
-window bounds.
+in both shells. Workbench projects the declared overflow policy to
+`data-window-header-overflow="visible"` on `.workbench-window` and allows the
+otherwise clipping custom-header row to extend over the node body. The outer
+Workbench window still clips content to the window bounds.
 
 Tabbed Browser surfaces keep a feature-owned tab store keyed by the Workbench
 surface node ID. Each tab receives a stable child Browser Node ID and owns its

--- a/docs/architecture/workbench-contributions.md
+++ b/docs/architecture/workbench-contributions.md
@@ -129,6 +129,8 @@ Those packages may own:
 - capability-local external state shaping
 - capability-local launch helpers
 - capability-local close-policy hooks
+- custom-header presentation declared through
+  `WorkbenchHostNodeWindowCapabilities.header`
 
 They must not own:
 
@@ -136,6 +138,20 @@ They must not own:
 - preload surface assumptions
 - app-specific daemon client creation
 - product-specific enablement or routing policy
+
+### Window header presentation
+
+A node definition declares structural custom-header state through
+`window.header`: `heightPx`, `layout: "overlay"`, `overflow: "visible"`, or
+`border: "none"`. `WorkbenchHost` projects that state onto the
+`.workbench-window` subject as data attributes and, for height, a CSS custom
+property.
+
+Do not discover these states with `.workbench-window:has(...)` or by inspecting
+rendered header descendants. A descendant mutation inside an editor, browser,
+or other live node can otherwise make the full window subtree a style
+invalidation candidate. Component-local relational selectors remain acceptable
+only when both the subject and mutation scope are small and bounded.
 
 ### External State Subscription
 

--- a/docs/conventions/local-git-hooks.md
+++ b/docs/conventions/local-git-hooks.md
@@ -32,6 +32,7 @@ Current behavior:
 
 - `pnpm exec lint-staged`
 - `pnpm check:backdrop-filter-authoring:staged`
+- `pnpm check:css-has-performance:staged`
 - `pnpm check:electron-runtime-boundaries:staged`
 - `pnpm check:ui-boundaries:staged`
 - `pnpm check:renderer-boundaries:staged`
@@ -82,6 +83,7 @@ machine-readable task results and log paths are recorded in
 That full validation currently includes:
 
 - `pnpm check:backdrop-filter-authoring`
+- `pnpm check:css-has-performance`
 - `pnpm check:defaults-generated`
 - `pnpm check:agent-gui-provider-catalog-generated`
 - `pnpm check:api-generated`

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -22,6 +22,7 @@ Repository entrypoints:
 
 - `pnpm setup:dev`
 - `pnpm check:backdrop-filter-authoring`
+- `pnpm check:css-has-performance`
 - `pnpm check:golangci-version`
 - `pnpm lint`
 - `pnpm lint:ts`
@@ -167,6 +168,27 @@ followed by the standard property; it rejects prefix-only output, reversed
 ordering, and a launchpad dismiss layer without a non-`none` standard filter.
 The React `WebkitBackdropFilter` inline-style property is outside this stylesheet
 optimization boundary and is not rejected by the authoring check.
+
+## CSS Relational Selector Performance
+
+`pnpm check:css-has-performance` scans production CSS under `apps/`,
+`packages/`, and `services/`. It rejects `:has()` when the selector subject is
+the document root, a Workbench window/surface, an AgentGUI root layout,
+timeline, transcript row, or another listed large dynamic surface.
+
+Those subjects contain editors, streamed transcript content, dock animation, or
+other frequently mutating descendants. Relational matching there can make the
+entire subject subtree a style-invalidation candidate. Project the semantic
+state onto the subject with a class or data attribute instead.
+
+The check intentionally permits bounded local subjects such as buttons, icons,
+dialogs, and individual conversation rows. Add a subject to the policy only
+when its descendant scope or mutation frequency makes relational invalidation
+structurally unsafe; do not turn this into a blanket ban on `:has()`.
+
+The staged form runs in `pre-commit`. The full form is selected by
+`check:changed` for production CSS or policy implementation changes and is part
+of `check:full`.
 
 Renderer feature implementation boundaries are checked by `pnpm check:renderer-boundaries`.
 That check also enforces the Workbench-specific rule that

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -139,6 +139,9 @@ at least one CPU sample so missing profiler data cannot pass as zero.
 Neither scenario launches or sends input to a developer's installed Agent provider.
 `rail-scope-reveal` asserts the exact active-row
 `scrollIntoView` call during a fresh Agent scope restore.
+`session-switch` also reports inclusive CPU samples for
+`readTimelineGeometry`; sample counts are diagnostic stack samples, not
+function-call counts.
 `composer-overflow-resize` maximizes the AgentGUI Workbench node, narrows the
 renderer viewport, asserts the hero prompt-tip's native `scrollWidth` and
 `clientWidth` getters were read after resize, then restores the original

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -50,11 +50,13 @@
   clips descendants before stacking order can place the menu over the node
   body. Raising the menu z-index cannot escape ancestor overflow clipping.
 - Fix:
-  Keep the shared inline menu and mark only headers that own intentional inline
-  overlays with `data-workbench-custom-header-overflow="visible"`. Workbench
-  uses that semantic opt-in to allow overflow on the custom-header row; do not
-  copy the menu into the OS shell or globally disable clipping for every custom
-  header. The outer `.workbench-window` remains the window-bounds clip.
+  Keep the shared inline menu and declare the owning node's header presentation
+  as `window.header: { overflow: "visible" }` (plus its explicit `heightPx`
+  when it owns a non-default header height). Workbench projects that contract
+  to `data-window-header-overflow="visible"` on `.workbench-window` and allows
+  overflow only for that custom-header row. Do not copy the menu into the OS
+  shell or globally disable clipping for every custom header. The outer
+  `.workbench-window` remains the window-bounds clip.
 - Validation:
   Run the Browser Node and Workbench Surface package tests, typecheck the
   affected packages, and build the desktop renderer. In both Agent-only and OS

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "check:api-generated": "node ./tools/scripts/generate-openapi.mjs --check && node ./tools/scripts/check-agent-protocol-enums.mjs",
     "check:backdrop-filter-authoring": "node ./tools/scripts/check-backdrop-filter-authoring.mjs",
     "check:backdrop-filter-authoring:staged": "node ./tools/scripts/check-backdrop-filter-authoring.mjs --staged",
+    "check:css-has-performance": "node ./tools/scripts/check-css-has-performance.mjs",
+    "check:css-has-performance:staged": "node ./tools/scripts/check-css-has-performance.mjs --staged",
     "check:agent-protocol-enums": "node ./tools/scripts/check-agent-protocol-enums.mjs",
     "check:agent-activity-runtime-boundaries": "node ./tools/scripts/check-agent-activity-runtime-boundaries.mjs",
     "check:agent-gui-degradation": "node ./tools/scripts/check-agent-gui-degradation.mjs",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -713,7 +713,13 @@ export function AgentGUINodeView({
           />
           <section id="agent-gui-detail" className={styles.detailPanel}>
             <AgentGUIDetailPane
-              viewModel={viewModel}
+              shell={viewModel.shell}
+              rail={viewModel.rail}
+              detail={viewModel.detail}
+              composer={viewModel.composer}
+              interaction={viewModel.interaction}
+              readiness={viewModel.readiness}
+              operations={viewModel.operations}
               homeTargetProjection={homeTargetProjection}
               referenceProvenanceFilter={referenceProvenanceFilter}
               composerEngagement={composerEngagement}

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
@@ -142,6 +142,49 @@ describe("AgentRichTextEditor prompt insertion", () => {
     );
   });
 
+  it("does not mistake an old local value for an echo after the draft scope changes", async () => {
+    const ref = createRef<AgentRichTextEditorHandle>();
+    const props = {
+      disabled: false,
+      onChange: vi.fn(),
+      onSubmit: vi.fn(),
+      placeholder: "Prompt"
+    };
+    const rendered = render(
+      <AgentRichTextEditor
+        ref={ref}
+        contentScopeKey="session-a"
+        value="a"
+        {...props}
+      />
+    );
+    await waitFor(() => expect(ref.current).not.toBeNull());
+
+    act(() => {
+      ref.current?.focusAtEnd();
+      ref.current?.insertPlainTextAtSelection("b");
+      ref.current?.insertPlainTextAtSelection("c");
+    });
+    expect(
+      rendered.container.querySelector('[contenteditable="true"]')
+    ).toHaveTextContent("abc");
+
+    rendered.rerender(
+      <AgentRichTextEditor
+        ref={ref}
+        contentScopeKey="session-b"
+        value="ab"
+        {...props}
+      />
+    );
+
+    await waitFor(() =>
+      expect(
+        rendered.container.querySelector('[contenteditable="true"]')
+      ).toHaveTextContent("ab")
+    );
+  });
+
   it("invalidates layout after a programmatic document update", async () => {
     const onContentLayoutInvalidated = vi.fn();
     const rendered = render(

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
@@ -58,6 +58,11 @@ import {
   isAgentRichTextUserContentInsertion,
   markAgentRichTextPointerFocus
 } from "./agentRichTextEngagement";
+import {
+  createAgentRichTextControlledValueTracker,
+  recordAgentRichTextLocalEdit,
+  shouldApplyAgentRichTextControlledValue
+} from "./agentRichTextControlledValue";
 
 export type {
   AgentRichTextEditorHandle,
@@ -70,6 +75,7 @@ export const AgentRichTextEditor = forwardRef<
 >(function AgentRichTextEditor(
   {
     value,
+    contentScopeKey = "default",
     disabled,
     placeholder,
     removeMentionLabel,
@@ -100,7 +106,9 @@ export const AgentRichTextEditor = forwardRef<
   "use memo";
   const { t } = useTranslation();
   const lastEmittedPromptRef = useRef<string | null>(value);
-  const pendingLocalPromptEchoesRef = useRef(new Set<string>());
+  const controlledValueTrackerRef = useRef(
+    createAgentRichTextControlledValueTracker(contentScopeKey)
+  );
   const editorRef = useRef<Editor | null>(null);
   const onChangeRef = useRef(onChange);
   const onContentLayoutInvalidatedRef = useRef(onContentLayoutInvalidated);
@@ -634,7 +642,10 @@ export const AgentRichTextEditor = forwardRef<
         return;
       }
       lastEmittedPromptRef.current = nextPrompt;
-      pendingLocalPromptEchoesRef.current.add(nextPrompt);
+      recordAgentRichTextLocalEdit(
+        controlledValueTrackerRef.current,
+        nextPrompt
+      );
       if (isAgentRichTextUserContentInsertion(transaction)) {
         onUserContentChangeRef.current?.(nextPrompt);
       }
@@ -730,16 +741,16 @@ export const AgentRichTextEditor = forwardRef<
     if (!editor || editor.isDestroyed) {
       return;
     }
-    if (pendingLocalPromptEchoesRef.current.has(value)) {
-      if (value === lastEmittedPromptRef.current) {
-        pendingLocalPromptEchoesRef.current.clear();
-      }
+    if (
+      !shouldApplyAgentRichTextControlledValue({
+        lastEmittedValue: lastEmittedPromptRef.current,
+        scopeKey: contentScopeKey,
+        tracker: controlledValueTrackerRef.current,
+        value
+      })
+    ) {
       return;
     }
-    if (value === lastEmittedPromptRef.current) {
-      return;
-    }
-    pendingLocalPromptEchoesRef.current.clear();
     const nextDoc = plainTextToAgentRichTextDoc(value, {
       capabilities: availableCapabilities,
       skills: availableSkills
@@ -752,7 +763,7 @@ export const AgentRichTextEditor = forwardRef<
     editor.commands.setTextSelection(editor.state.doc.content.size);
     lastEmittedPromptRef.current = value;
     onContentLayoutInvalidatedRef.current?.();
-  }, [availableCapabilities, availableSkills, editor, value]);
+  }, [availableCapabilities, availableSkills, contentScopeKey, editor, value]);
 
   return (
     <AgentRichTextEditorSurface

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.types.ts
@@ -11,6 +11,8 @@ import type { AgentGUIComposerFocusMethod } from "../engagement/agentGUIEngageme
 
 export interface AgentRichTextEditorProps {
   value: string;
+  /** Stable owner of the controlled draft, such as a session draft scope. */
+  contentScopeKey?: string;
   disabled: boolean;
   placeholder: string;
   removeMentionLabel?: string;

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextControlledValue.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextControlledValue.ts
@@ -1,0 +1,59 @@
+interface PendingLocalPromptEcho {
+  revision: number;
+  scopeKey: string;
+  value: string;
+}
+
+export interface AgentRichTextControlledValueTracker {
+  nextRevision: number;
+  pendingLocalEchoes: PendingLocalPromptEcho[];
+  scopeKey: string;
+}
+
+export function createAgentRichTextControlledValueTracker(
+  scopeKey: string
+): AgentRichTextControlledValueTracker {
+  return { nextRevision: 0, pendingLocalEchoes: [], scopeKey };
+}
+
+export function recordAgentRichTextLocalEdit(
+  tracker: AgentRichTextControlledValueTracker,
+  value: string
+): void {
+  tracker.nextRevision += 1;
+  tracker.pendingLocalEchoes.push({
+    revision: tracker.nextRevision,
+    scopeKey: tracker.scopeKey,
+    value
+  });
+}
+
+export function shouldApplyAgentRichTextControlledValue(input: {
+  lastEmittedValue: string | null;
+  scopeKey: string;
+  tracker: AgentRichTextControlledValueTracker;
+  value: string;
+}): boolean {
+  const { lastEmittedValue, scopeKey, tracker, value } = input;
+  const scopeChanged = tracker.scopeKey !== scopeKey;
+  if (scopeChanged) {
+    tracker.scopeKey = scopeKey;
+    tracker.pendingLocalEchoes = [];
+  }
+  const localEcho = tracker.pendingLocalEchoes.find(
+    (candidate) => candidate.scopeKey === scopeKey && candidate.value === value
+  );
+  if (!scopeChanged && localEcho) {
+    tracker.pendingLocalEchoes = tracker.pendingLocalEchoes.filter(
+      (candidate) =>
+        candidate.scopeKey !== scopeKey ||
+        candidate.revision > localEcho.revision
+    );
+    return false;
+  }
+  if (!scopeChanged && value === lastEmittedValue) {
+    return false;
+  }
+  tracker.pendingLocalEchoes = [];
+  return true;
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
@@ -384,6 +384,7 @@ export function AgentComposerView(input: Props): React.JSX.Element {
                   <AgentRichTextEditor
                     ref={input.editorHandleRef}
                     value={input.paletteDraftPrompt}
+                    contentScopeKey={input.props.draftScopeKey}
                     placeholder={effectivePlaceholder}
                     disabled={inputDisabled}
                     className={styles.composerTextarea}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.spec.tsx
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import { createEmptyAgentActivitySnapshot } from "@tutti-os/agent-activity-core";
 import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import { createTestAgentSessionEngine } from "../../../shared/testing/createTestAgentSessionEngine";
+import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
+import { buildAgentComposerDraft } from "../model/agentComposerDraft";
 import { useAgentGUIConversationDetail } from "./useAgentGUIConversationDetail";
 
 type ConversationDetailInput = Parameters<
@@ -102,4 +104,38 @@ describe("useAgentGUIConversationDetail", () => {
 
     expect(result.current.isInterrupting).toBe(true);
   });
+
+  it("keeps the conversation projection stable for a draft-only update", () => {
+    const input = conversationDetailInput({
+      activeConversation: conversationSummary()
+    });
+    const rendered = renderHook(
+      ({ draftByScopeKey }) =>
+        useAgentGUIConversationDetail({ ...input, draftByScopeKey }),
+      { initialProps: { draftByScopeKey: {} } }
+    );
+    const previousConversation = rendered.result.current.conversation;
+
+    rendered.rerender({
+      draftByScopeKey: {
+        "session:session-1": buildAgentComposerDraft({ prompt: "a" })
+      }
+    });
+
+    expect(rendered.result.current.conversation).toBe(previousConversation);
+  });
 });
+
+function conversationSummary(): AgentGUIConversationSummary {
+  return {
+    agentTargetId: "local:codex",
+    cwd: "/workspace",
+    id: "session-1",
+    provider: "codex",
+    status: "ready",
+    title: "Conversation",
+    titleFallback: null,
+    updatedAtUnixMs: 1,
+    userId: "user-1"
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.ts
@@ -95,8 +95,10 @@ export function useAgentGUIConversationDetail(
   const activeCanonicalLiveTurn = Boolean(
     input.activeTurn && input.activeTurn.phase !== "settled"
   );
-  const sessionTurns = useEngineSelector(input.sessionEngine, (state) =>
-    selectEngineTurnsForSession(state, input.activeConversationId)
+  const sessionTurns = useEngineSelector(
+    input.sessionEngine,
+    (state) => selectEngineTurnsForSession(state, input.activeConversationId),
+    referenceArrayEqual
   );
   const projectionConversation =
     useMemo<AgentGUIConversationProjectionSource | null>(() => {
@@ -326,4 +328,14 @@ export function useAgentGUIConversationDetail(
       ? null
       : rawPendingInteractivePrompt
   };
+}
+
+function referenceArrayEqual<T>(
+  left: readonly T[],
+  right: readonly T[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -1,13 +1,4 @@
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type CSSProperties
-} from "react";
-import { ScrollArea } from "@tutti-os/ui-system/components";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { WorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-project/i18n";
 import type { WorkspaceLinkAction } from "../../../actions/workspaceLinkActions";
 import type { UiLanguage } from "../../../contexts/settings/domain/agentSettings";
@@ -23,8 +14,14 @@ import type {
 } from "../AgentComposer";
 import type { AgentContextMentionItem } from "../agentRichText/agentFileMentionExtension";
 import type {
+  AgentGUIComposerViewModel,
+  AgentGUIDetailViewModel,
   AgentHomeSuggestionAction,
-  AgentGUINodeViewModel
+  AgentGUIInteractionViewModel,
+  AgentGUIOperationsViewModel,
+  AgentGUIRailViewModel,
+  AgentGUIReadinessViewModel,
+  AgentGUIShellViewModel
 } from "../model/agentGuiNodeTypes";
 import { updateAgentComposerDraft } from "../model/agentComposerDraft";
 import { resolveAgentComposerDraftScopeKey } from "../model/agentComposerDraftScope";
@@ -45,7 +42,7 @@ import {
   resolveAgentGUIHeroIconUrl
 } from "./AgentGUIEmptyState";
 import { AgentGUIContentToast } from "./AgentGUIContentToast";
-import { AgentGUIConversationTimelinePane } from "./AgentGUIConversationTimelinePane";
+import { AgentGUIDetailTimeline } from "./AgentGUIDetailTimeline";
 import {
   useOptionalStableEventCallback,
   useStableEventCallback
@@ -56,17 +53,16 @@ import { useAgentGUIDetailModel } from "./useAgentGUIDetailModel";
 import type { AgentGUIComposerEngagement } from "../engagement/agentGUIEngagement.types";
 import { useAgentGUITuttiWorkflow } from "./useAgentGUITuttiWorkflow";
 
-const AGENT_GUI_TIMELINE_SCROLL_AREA_CONTENT_STYLE: CSSProperties = {
-  width: "100%",
-  minWidth: "100%",
-  display: "grid",
-  gridTemplateColumns: "minmax(0, 1fr)",
-  gap: "24px"
-};
 export const EMPTY_WORKSPACE_APP_ICONS: readonly AgentMessageMarkdownWorkspaceAppIcon[] =
   [];
 export interface AgentGUIDetailPaneProps {
-  viewModel: AgentGUINodeViewModel;
+  shell: AgentGUIShellViewModel;
+  rail: AgentGUIRailViewModel;
+  detail: AgentGUIDetailViewModel;
+  composer: AgentGUIComposerViewModel;
+  interaction: AgentGUIInteractionViewModel;
+  readiness: AgentGUIReadinessViewModel;
+  operations: AgentGUIOperationsViewModel;
   homeTargetProjection: AgentGUIManagedHomeTargetProjection;
   referenceProvenanceFilter?: AgentComposerProps["referenceProvenanceFilter"];
   composerEngagement?: AgentGUIComposerEngagement;
@@ -107,7 +103,13 @@ export interface AgentGUIDetailPaneProps {
 }
 
 export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
-  viewModel,
+  shell,
+  rail,
+  detail,
+  composer,
+  interaction,
+  readiness,
+  operations,
   homeTargetProjection,
   referenceProvenanceFilter = null,
   composerEngagement,
@@ -143,6 +145,15 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
   renderProviderUnavailableState
 }: AgentGUIDetailPaneProps): React.JSX.Element {
   "use memo";
+  const viewModel = {
+    shell,
+    rail,
+    detail,
+    composer,
+    interaction,
+    readiness,
+    operations
+  };
   const timelineRef = useRef<HTMLDivElement | null>(null);
   const timelineContentRef = useRef<HTMLDivElement | null>(null);
   const bottomDockRef = useRef<HTMLDivElement | null>(null);
@@ -660,6 +671,53 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     timelineScrollAnchorRef,
     viewModel
   });
+  const homeContent = !hasActiveConversation ? (
+    shouldRenderProviderUnavailableState && disabledProviderTarget ? (
+      <>
+        {renderProviderUnavailableState?.({
+          provider: disabledProviderTarget.provider,
+          providerLabel:
+            labels.emptyProviderForProvider?.(
+              disabledProviderTarget.provider
+            ) ??
+            resolveAgentGuiWorkbenchProviderLabel(
+              disabledProviderTarget.provider
+            ),
+          target: disabledProviderTarget,
+          iconUrl: resolveAgentGUIHeroIconUrl(disabledProviderTarget.provider),
+          unavailableReason: disabledProviderTarget.unavailableReason ?? null
+        })}
+      </>
+    ) : (
+      <AgentGUIEmptyHomePane
+        provider={emptyHeroProvider}
+        providerReadinessGate={emptyProviderReadinessGate}
+        showAllProviders={viewModel.rail.conversationFilter.kind === "all"}
+        agentTargets={composerProviderTargets}
+        selectedAgentTarget={composerSelectedProviderTarget}
+        onProviderSelect={
+          canSwitchComposerProvider &&
+          viewModel.rail.activeConversationId === null
+            ? selectHomeComposerAgentTargetAndFocus
+            : undefined
+        }
+        noticeChrome={homeNoticeChrome}
+        isRespondingApproval={isInteractionPending}
+        previewMode={previewMode}
+        onSubmitApprovalOption={submitApprovalOption}
+        onRetryActivation={retryActivation}
+        onAuthLogin={authLogin}
+        onContinueInNewConversation={continueInNewConversation}
+        chromeLabels={chromeLabels}
+        composerProps={emptyHeroComposerProps}
+        labels={labels}
+        suggestions={labels.homeSuggestions ?? EMPTY_HOME_SUGGESTIONS}
+        suggestionsCloseLabel={labels.homeSuggestionsClose}
+        onSelectSuggestion={handleSelectHomeSuggestion}
+        onSelectSuggestionAction={handleHomeSuggestionAction}
+      />
+    )
+  ) : null;
 
   return (
     <main
@@ -674,90 +732,25 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
           message={labels.goalRemoved}
         />
       ) : null}
-      <ScrollArea
-        scrollbarMode="native"
-        className="flex h-full min-h-0 flex-1 flex-col [&_[data-orientation=vertical][data-slot=scroll-area-scrollbar]]:opacity-100"
-        viewportRef={timelineRef}
-        viewportContentRef={timelineContentRef}
-        viewportTestId="agent-gui-timeline"
-        viewportClassName={`${styles.timeline} ${
-          hasActiveConversation
-            ? styles.timelineWithComposer
-            : styles.timelineCentered
-        } ${
-          !isTimelineScrolledToTop ? styles.timelineScrolledFromTop : ""
-        } ${showUnavailableChatEmpty ? styles.timelineUnavailableChatEmpty : ""}`.trim()}
-        viewportContentStyle={AGENT_GUI_TIMELINE_SCROLL_AREA_CONTENT_STYLE}
-      >
-        {!hasActiveConversation ? (
-          shouldRenderProviderUnavailableState && disabledProviderTarget ? (
-            <>
-              {renderProviderUnavailableState?.({
-                provider: disabledProviderTarget.provider,
-                providerLabel:
-                  labels.emptyProviderForProvider?.(
-                    disabledProviderTarget.provider
-                  ) ??
-                  resolveAgentGuiWorkbenchProviderLabel(
-                    disabledProviderTarget.provider
-                  ),
-                target: disabledProviderTarget,
-                iconUrl: resolveAgentGUIHeroIconUrl(
-                  disabledProviderTarget.provider
-                ),
-                unavailableReason:
-                  disabledProviderTarget.unavailableReason ?? null
-              })}
-            </>
-          ) : (
-            <AgentGUIEmptyHomePane
-              provider={emptyHeroProvider}
-              providerReadinessGate={emptyProviderReadinessGate}
-              showAllProviders={
-                viewModel.rail.conversationFilter.kind === "all"
-              }
-              agentTargets={composerProviderTargets}
-              selectedAgentTarget={composerSelectedProviderTarget}
-              onProviderSelect={
-                canSwitchComposerProvider &&
-                viewModel.rail.activeConversationId === null
-                  ? selectHomeComposerAgentTargetAndFocus
-                  : undefined
-              }
-              noticeChrome={homeNoticeChrome}
-              isRespondingApproval={isInteractionPending}
-              previewMode={previewMode}
-              onSubmitApprovalOption={submitApprovalOption}
-              onRetryActivation={retryActivation}
-              onAuthLogin={authLogin}
-              onContinueInNewConversation={continueInNewConversation}
-              chromeLabels={chromeLabels}
-              composerProps={emptyHeroComposerProps}
-              labels={labels}
-              suggestions={labels.homeSuggestions ?? EMPTY_HOME_SUGGESTIONS}
-              suggestionsCloseLabel={labels.homeSuggestionsClose}
-              onSelectSuggestion={handleSelectHomeSuggestion}
-              onSelectSuggestionAction={handleHomeSuggestionAction}
-            />
-          )
-        ) : (
-          <>
-            <AgentGUIConversationTimelinePane
-              conversation={conversation}
-              isLoading={showTimelineSkeleton}
-              isLoadingOlderMessages={viewModel.detail.isLoadingOlderMessages}
-              loadingLabel={labels.loadingConversation}
-              empty={conversationFlowEmpty}
-              onLinkAction={stableLinkAction}
-              onAuthLogin={authLogin}
-              availableSkills={viewModel.composer.availableSkills}
-              workspaceAppIcons={workspaceAppIcons}
-              previewMode={previewMode}
-              labels={conversationFlowLabels}
-            />
-          </>
-        )}
-      </ScrollArea>
+      <AgentGUIDetailTimeline
+        availableSkills={viewModel.composer.availableSkills}
+        conversation={conversation}
+        conversationFlowEmpty={conversationFlowEmpty}
+        conversationFlowLabels={conversationFlowLabels}
+        hasActiveConversation={hasActiveConversation}
+        homeContent={homeContent}
+        isLoadingOlderMessages={viewModel.detail.isLoadingOlderMessages}
+        isTimelineScrolledToTop={isTimelineScrolledToTop}
+        labels={labels}
+        onAuthLogin={authLogin}
+        onLinkAction={stableLinkAction}
+        previewMode={previewMode}
+        showTimelineSkeleton={showTimelineSkeleton}
+        showUnavailableChatEmpty={showUnavailableChatEmpty}
+        timelineContentRef={timelineContentRef}
+        timelineRef={timelineRef}
+        workspaceAppIcons={workspaceAppIcons}
+      />
       {hasActiveConversation ? (
         <AgentGUIBottomDockPane
           bottomDockRef={bottomDockRef}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailTimeline.renderBudget.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailTimeline.renderBudget.spec.tsx
@@ -1,0 +1,53 @@
+import { render } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { AgentGUIDetailTimeline } from "./AgentGUIDetailTimeline";
+
+const { timelineRenderSpy } = vi.hoisted(() => ({
+  timelineRenderSpy: vi.fn()
+}));
+
+vi.mock("./AgentGUIConversationTimelinePane", () => ({
+  AgentGUIConversationTimelinePane: (props: unknown) => {
+    timelineRenderSpy(props);
+    return <div data-testid="conversation-timeline" />;
+  }
+}));
+
+describe("AgentGUIDetailTimeline render budget", () => {
+  it("does not rerender the active timeline for a parent-only draft update", () => {
+    const stableProps = {
+      availableSkills: [],
+      conversation: null,
+      conversationFlowEmpty: <div />,
+      conversationFlowLabels: {
+        thinkingLabel: "Thinking",
+        toolCallsLabel: (count: number) => `${count}`,
+        processing: "Processing",
+        turnSummary: "Summary",
+        userMessageLocator: "User"
+      },
+      hasActiveConversation: true,
+      homeContent: null,
+      isLoadingOlderMessages: false,
+      isTimelineScrolledToTop: true,
+      labels: { loadingConversation: "Loading" },
+      previewMode: false,
+      showTimelineSkeleton: false,
+      showUnavailableChatEmpty: false,
+      timelineContentRef: createRef<HTMLDivElement>(),
+      timelineRef: createRef<HTMLDivElement>(),
+      workspaceAppIcons: []
+    };
+    const Parent = ({ draft }: { draft: string }) => {
+      void draft;
+      return <AgentGUIDetailTimeline {...stableProps} />;
+    };
+    const rendered = render(<Parent draft="" />);
+    expect(timelineRenderSpy).toHaveBeenCalledOnce();
+
+    rendered.rerender(<Parent draft="a" />);
+
+    expect(timelineRenderSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailTimeline.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailTimeline.tsx
@@ -1,0 +1,106 @@
+import {
+  memo,
+  type CSSProperties,
+  type ReactNode,
+  type RefObject
+} from "react";
+import { ScrollArea } from "@tutti-os/ui-system/components";
+import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../../shared/AgentMessageMarkdown";
+import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
+import type { AgentGUIProviderSkillOption } from "../model/agentGuiNodeTypes";
+import type { WorkspaceLinkAction } from "../../../actions/workspaceLinkActions";
+import { AgentGUIConversationTimelinePane } from "./AgentGUIConversationTimelinePane";
+import styles from "../AgentGUINode.styles";
+
+const TIMELINE_CONTENT_STYLE: CSSProperties = {
+  width: "100%",
+  minWidth: "100%",
+  display: "grid",
+  gridTemplateColumns: "minmax(0, 1fr)",
+  gap: "24px"
+};
+
+interface AgentGUIDetailTimelineProps {
+  availableSkills: readonly AgentGUIProviderSkillOption[];
+  conversation: AgentConversationVM | null;
+  conversationFlowEmpty: React.JSX.Element;
+  conversationFlowLabels: {
+    thinkingLabel: string;
+    toolCallsLabel: (count: number) => string;
+    processing: string;
+    turnSummary: string;
+    userMessageLocator: string;
+  };
+  hasActiveConversation: boolean;
+  homeContent: ReactNode;
+  isLoadingOlderMessages: boolean;
+  isTimelineScrolledToTop: boolean;
+  labels: {
+    loadingConversation: string;
+  };
+  onAuthLogin?: (provider?: string | null) => void;
+  onLinkAction?: (action: WorkspaceLinkAction) => void;
+  previewMode: boolean;
+  showTimelineSkeleton: boolean;
+  showUnavailableChatEmpty: boolean;
+  timelineContentRef: RefObject<HTMLDivElement | null>;
+  timelineRef: RefObject<HTMLDivElement | null>;
+  workspaceAppIcons: readonly AgentMessageMarkdownWorkspaceAppIcon[];
+}
+
+export const AgentGUIDetailTimeline = memo(function AgentGUIDetailTimeline({
+  availableSkills,
+  conversation,
+  conversationFlowEmpty,
+  conversationFlowLabels,
+  hasActiveConversation,
+  homeContent,
+  isLoadingOlderMessages,
+  isTimelineScrolledToTop,
+  labels,
+  onAuthLogin,
+  onLinkAction,
+  previewMode,
+  showTimelineSkeleton,
+  showUnavailableChatEmpty,
+  timelineContentRef,
+  timelineRef,
+  workspaceAppIcons
+}: AgentGUIDetailTimelineProps): React.JSX.Element {
+  "use memo";
+  return (
+    <ScrollArea
+      scrollbarMode="native"
+      className="flex h-full min-h-0 flex-1 flex-col [&_[data-orientation=vertical][data-slot=scroll-area-scrollbar]]:opacity-100"
+      viewportRef={timelineRef}
+      viewportContentRef={timelineContentRef}
+      viewportTestId="agent-gui-timeline"
+      viewportClassName={`${styles.timeline} ${
+        hasActiveConversation
+          ? styles.timelineWithComposer
+          : styles.timelineCentered
+      } ${
+        !isTimelineScrolledToTop ? styles.timelineScrolledFromTop : ""
+      } ${showUnavailableChatEmpty ? styles.timelineUnavailableChatEmpty : ""}`.trim()}
+      viewportContentStyle={TIMELINE_CONTENT_STYLE}
+    >
+      {hasActiveConversation ? (
+        <AgentGUIConversationTimelinePane
+          conversation={conversation}
+          isLoading={showTimelineSkeleton}
+          isLoadingOlderMessages={isLoadingOlderMessages}
+          loadingLabel={labels.loadingConversation}
+          empty={conversationFlowEmpty}
+          onLinkAction={onLinkAction}
+          onAuthLogin={onAuthLogin}
+          availableSkills={availableSkills}
+          workspaceAppIcons={workspaceAppIcons}
+          previewMode={previewMode}
+          labels={conversationFlowLabels}
+        />
+      ) : (
+        homeContent
+      )}
+    </ScrollArea>
+  );
+});

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -3747,9 +3747,7 @@ aside.workspace-agents-status-panel
   content: "";
 }
 
-.agent-gui-conversation__message-group:has(
-  > .agent-gui-conversation__message-footer
-) {
+.agent-gui-conversation__message-group[data-agent-message-footer="true"] {
   margin-bottom: 26px;
 }
 
@@ -3870,9 +3868,7 @@ aside.workspace-agents-status-panel
 }
 
 .agent-gui-node__timeline
-  > .agent-gui-conversation__assistant-message-flow:has(
-    > .workspace-agents-status-panel__detail-thinking-disclosure:last-child
-  )
+  > .agent-gui-conversation__assistant-message-flow[data-agent-message-flow-thinking-last="true"]
   + :is(
     .workspace-agents-status-panel__detail-tool-section,
     .workspace-agents-status-panel__detail-tool-row
@@ -3882,9 +3878,7 @@ aside.workspace-agents-status-panel
     .workspace-agents-status-panel__detail-tool-section,
     .workspace-agents-status-panel__detail-tool-row
   )
-  + .agent-gui-conversation__assistant-message-flow:has(
-    > .workspace-agents-status-panel__detail-thinking-disclosure:first-child
-  ),
+  + .agent-gui-conversation__assistant-message-flow[data-agent-message-flow-thinking-first="true"],
 .agent-gui-node__timeline
   > :is(
     .workspace-agents-status-panel__detail-tool-section,
@@ -3898,63 +3892,23 @@ aside.workspace-agents-status-panel
 }
 
 .agent-gui-node__timeline
-  > .agent-gui-transcript-row:has(
-    > .agent-gui-conversation__assistant-message-flow
-      > .workspace-agents-status-panel__detail-thinking-disclosure:last-child
-  )
-  + .agent-gui-transcript-row:has(
-    > :is(
-      .workspace-agents-status-panel__detail-tool-section,
-      .workspace-agents-status-panel__detail-tool-row
-    )
-  ),
+  > .agent-gui-transcript-row[data-agent-transcript-row-thinking-last="true"]
+  + .agent-gui-transcript-row[data-agent-transcript-row-kind="tool-group"],
 .agent-gui-node__timeline
-  > .agent-gui-transcript-row:has(
-    > :is(
-      .workspace-agents-status-panel__detail-tool-section,
-      .workspace-agents-status-panel__detail-tool-row
-    )
-  )
-  + .agent-gui-transcript-row:has(
-    > .agent-gui-conversation__assistant-message-flow
-      > .workspace-agents-status-panel__detail-thinking-disclosure:first-child
-  ),
+  > .agent-gui-transcript-row[data-agent-transcript-row-kind="tool-group"]
+  + .agent-gui-transcript-row[data-agent-transcript-row-thinking-first="true"],
 .agent-gui-node__timeline
-  > .agent-gui-transcript-row:has(
-    > :is(
-      .workspace-agents-status-panel__detail-tool-section,
-      .workspace-agents-status-panel__detail-tool-row
-    )
-  )
-  + .agent-gui-transcript-row:has(
-    > :is(
-      .workspace-agents-status-panel__detail-tool-section,
-      .workspace-agents-status-panel__detail-tool-row
-    )
-  ) {
+  > .agent-gui-transcript-row[data-agent-transcript-row-kind="tool-group"]
+  + .agent-gui-transcript-row[data-agent-transcript-row-kind="tool-group"] {
   margin-top: -8px;
 }
 
 .agent-gui-node__timeline
-  > .agent-gui-transcript-row:has(
-    > .agent-gui-conversation__assistant-message-flow
-  )
-  + .agent-gui-transcript-row:has(
-    > :is(
-      .workspace-agents-status-panel__detail-tool-section,
-      .workspace-agents-status-panel__detail-tool-row
-    )
-  ),
+  > .agent-gui-transcript-row[data-agent-transcript-row-speaker="assistant"]
+  + .agent-gui-transcript-row[data-agent-transcript-row-kind="tool-group"],
 .agent-gui-node__timeline
-  > .agent-gui-transcript-row:has(
-    > :is(
-      .workspace-agents-status-panel__detail-tool-section,
-      .workspace-agents-status-panel__detail-tool-row
-    )
-  )
-  + .agent-gui-transcript-row:has(
-    > .agent-gui-conversation__assistant-message-flow
-  ) {
+  > .agent-gui-transcript-row[data-agent-transcript-row-kind="tool-group"]
+  + .agent-gui-transcript-row[data-agent-transcript-row-speaker="assistant"] {
   margin-top: -12px;
 }
 
@@ -4619,17 +4573,16 @@ aside.workspace-agents-status-panel
   transition: none;
 }
 
-.workbench-window:has(
-  > .workbench-window__header [data-agent-gui-workbench-header="true"]
-) {
+.workbench-window[data-window-header-layout="overlay"],
+.workbench-window[data-agent-gui-standalone-window="true"] {
   --agent-gui-workbench-header-height: 44px;
 
   grid-template-rows: minmax(0, 1fr);
 }
 
-.workbench-window:has(
-    > .workbench-window__header [data-agent-gui-workbench-header="true"]
-  )
+.workbench-window[data-window-header-layout="overlay"]
+  .workbench-window__header,
+.workbench-window[data-agent-gui-standalone-window="true"]
   .workbench-window__header {
   position: absolute !important;
   top: 0 !important;
@@ -4648,50 +4601,34 @@ aside.workspace-agents-status-panel
   user-select: auto;
 }
 
-.workbench-window:has(
-    > .workbench-window__header
-      .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
-  )
+.workbench-window[data-agent-gui-standalone-window="true"]
   .workbench-window__header {
   cursor: grab !important;
 }
 
-.workbench-window:has(
-    > .workbench-window__header
-      .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
-  )
+.workbench-window[data-agent-gui-standalone-window="true"]
   .workbench-window__header:active {
   cursor: grabbing !important;
 }
 
-.workbench-window:has(
-    > .workbench-window__header
-      .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
-  )
+.workbench-window[data-agent-gui-standalone-window="true"]
   .workbench-window__header {
   z-index: calc(var(--z-panel) + 1);
 }
 
-.workbench-window:has(
-    > .workbench-window__header
-      .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
-  )
+.workbench-window[data-agent-gui-standalone-window="true"]
   .agent-gui-workbench-header::after {
   display: none;
 }
 
-.workbench-window:has(
-    > .workbench-window__header [data-agent-gui-workbench-header="true"]
-  )
+.workbench-window[data-window-header-layout="overlay"] .workbench-window__body,
+.workbench-window[data-agent-gui-standalone-window="true"]
   .workbench-window__body {
   grid-row: 1;
   overflow: hidden;
 }
 
-.workbench-window:has(
-    > .workbench-window__header
-      .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
-  )
+.workbench-window[data-agent-gui-standalone-window="true"]
   .workbench-window__body {
   display: flex;
   width: 100%;
@@ -4753,9 +4690,9 @@ aside.workspace-agents-status-panel
   overscroll-behavior: contain;
 }
 
-.workbench-window:has(
-    > .workbench-window__header [data-agent-gui-workbench-header="true"]
-  )
+.workbench-window[data-window-header-layout="overlay"]
+  .agent-gui-node__provider-rail-panel,
+.workbench-window[data-agent-gui-standalone-window="true"]
   .agent-gui-node__provider-rail-panel {
   padding-top: var(--agent-gui-workbench-header-height);
 }
@@ -4764,30 +4701,29 @@ aside.workspace-agents-status-panel
    breathing room on the inner rail, so the "All" tile sits at header + 2px. The
    toolbar has no such wrapper, so fold the same 2px into its offset to keep the
    search field top aligned with the provider tiles. */
-.workbench-window:has(
-    > .workbench-window__header [data-agent-gui-workbench-header="true"]
-  )
+.workbench-window[data-window-header-layout="overlay"]
+  .agent-gui-node__rail-toolbar,
+.workbench-window[data-agent-gui-standalone-window="true"]
   .agent-gui-node__rail-toolbar {
   padding-top: calc(var(--agent-gui-workbench-header-height) + 2px);
 }
 
-.workbench-window:has(
-    > .workbench-window__header [data-agent-gui-workbench-header="true"]
-  )
+.workbench-window[data-window-header-layout="overlay"]
+  .agent-gui-node__detail-panel,
+.workbench-window[data-agent-gui-standalone-window="true"]
   .agent-gui-node__detail-panel {
   position: relative;
 }
 
-.workbench-window:has(
-    > .workbench-window__header [data-agent-gui-workbench-header="true"]
-  )
+.workbench-window[data-window-header-layout="overlay"] .agent-gui-node__detail,
+.workbench-window[data-agent-gui-standalone-window="true"]
   .agent-gui-node__detail {
   padding-top: var(--agent-gui-workbench-header-height);
 }
 
-.workbench-window:has(
-    > .workbench-window__header [data-agent-gui-workbench-header="true"]
-  )
+.workbench-window[data-window-header-layout="overlay"]
+  .agent-gui-node__timeline-with-composer,
+.workbench-window[data-agent-gui-standalone-window="true"]
   .agent-gui-node__timeline-with-composer {
   padding-top: 20px;
 }
@@ -5280,15 +5216,9 @@ aside.workspace-agents-status-panel
   pointer-events: auto;
 }
 
-.workbench-window:has(
-    > .workbench-window__header
-      .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
-  )
+.workbench-window[data-agent-gui-standalone-window="true"]
   .agent-gui-workbench-header__session-title,
-.workbench-window:has(
-    > .workbench-window__header
-      .agent-gui-workbench-header[data-agent-gui-standalone-window-header="true"]
-  )
+.workbench-window[data-agent-gui-standalone-window="true"]
   .agent-gui-workbench-header__detail-title {
   box-sizing: border-box;
   width: auto;
@@ -5389,7 +5319,7 @@ aside.workspace-agents-status-panel
   margin-left: -4px;
 }
 
-.workbench-window:has([data-workbench-node-render-error="true"])
+.agent-gui-workbench-header[data-agent-gui-workbench-header-body-error="true"]
   .agent-gui-workbench-header__rail-toggle {
   display: none !important;
 }
@@ -5570,9 +5500,9 @@ aside.workspace-agents-status-panel
   );
 }
 
-.workbench-window:has(
-    > .workbench-window__header [data-agent-gui-workbench-header="true"]
-  )
+.workbench-window[data-window-header-layout="overlay"]
+  .agent-gui-node__provider-rail-panel::after,
+.workbench-window[data-agent-gui-standalone-window="true"]
   .agent-gui-node__provider-rail-panel::after {
   top: var(--agent-gui-workbench-header-height);
 }

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -136,6 +136,14 @@ export function AgentMessageBlock({
   return (
     <div
       className={isUser ? styles.userMessageFlow : styles.assistantMessageFlow}
+      data-agent-message-flow-thinking-first={
+        !isUser && row.thinking.length > 0 ? "true" : undefined
+      }
+      data-agent-message-flow-thinking-last={
+        !isUser && row.thinking.length > 0 && row.messages.length === 0
+          ? "true"
+          : undefined
+      }
     >
       {thinkingContent}
       {row.messages.map((message) => {
@@ -268,11 +276,16 @@ function AgentCopyableMessageGroup({
 }): JSX.Element {
   "use memo";
   const timestamp = formatAgentMessageTimestamp(occurredAtUnixMs);
+  const hasFooter = Boolean(timestamp || copyText);
 
   return (
-    <div className={styles.messageGroup} data-agent-message-speaker={speaker}>
+    <div
+      className={styles.messageGroup}
+      data-agent-message-footer={hasFooter ? "true" : undefined}
+      data-agent-message-speaker={speaker}
+    >
       {children}
-      {timestamp || copyText ? (
+      {hasFooter ? (
         <div className={styles.messageFooter}>
           {timestamp ? (
             <span className={styles.messageTimestamp}>{timestamp}</span>

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -286,6 +286,7 @@ describe("AgentTranscriptItemView render stability", () => {
       throw new Error("Expected user message bubble to render.");
     }
     expect(group).toHaveAttribute("data-agent-message-speaker", "user");
+    expect(group).toHaveAttribute("data-agent-message-footer", "true");
     expect(group).toHaveTextContent("User asks for a fix");
     expect(
       group.querySelector(".agent-gui-conversation__message-copy-button")

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -1386,8 +1386,27 @@ describe("AgentTranscriptView", () => {
     const assistantFlow = document.querySelector(
       ".agent-gui-conversation__assistant-message-flow"
     );
+    const assistantRow = assistantFlow?.closest("[data-agent-transcript-row]");
 
     expect(assistantFlow).toBeTruthy();
+    expect(assistantFlow).toHaveAttribute(
+      "data-agent-message-flow-thinking-first",
+      "true"
+    );
+    expect(assistantFlow).not.toHaveAttribute(
+      "data-agent-message-flow-thinking-last"
+    );
+    expect(assistantRow).toHaveAttribute(
+      "data-agent-transcript-row-speaker",
+      "assistant"
+    );
+    expect(assistantRow).toHaveAttribute(
+      "data-agent-transcript-row-thinking-first",
+      "true"
+    );
+    expect(assistantRow).not.toHaveAttribute(
+      "data-agent-transcript-row-thinking-last"
+    );
     expect(assistantFlow?.firstElementChild?.contains(thinkingButton)).toBe(
       true
     );

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
@@ -361,6 +361,24 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
         className="agent-gui-transcript-row"
         data-agent-transcript-row={rowKey}
         data-agent-transcript-row-kind={row.kind}
+        data-agent-transcript-row-speaker={
+          row.kind === "message" ? row.speaker : undefined
+        }
+        data-agent-transcript-row-thinking-first={
+          row.kind === "message" &&
+          row.speaker === "assistant" &&
+          row.thinking.length > 0
+            ? "true"
+            : undefined
+        }
+        data-agent-transcript-row-thinking-last={
+          row.kind === "message" &&
+          row.speaker === "assistant" &&
+          row.thinking.length > 0 &&
+          row.messages.length === 0
+            ? "true"
+            : undefined
+        }
         data-agent-transcript-row-index={rowIndex}
         data-agent-transcript-row-enter={
           shouldAnimateEnter ? "true" : undefined

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -546,6 +546,9 @@ describe("agent GUI workbench contribution copy", () => {
 
     expect(contribution).toBe(contributionIdentity);
     expect(contribution.nodes?.[0]).toBe(nodeDefinition);
+    expect(nodeDefinition?.window?.header).toEqual({
+      layout: "overlay"
+    });
     expect(renderedAgentTargetIds).toEqual([
       ["local:codex"],
       ["local:claude-code"]
@@ -1548,6 +1551,10 @@ describe("agent GUI workbench contribution copy", () => {
       "data-agent-gui-workbench-header-collapsed",
       "true"
     );
+    expect(header).toHaveAttribute(
+      "data-agent-gui-workbench-header-body-error",
+      "false"
+    );
     expect(primary).not.toHaveTextContent("Agent");
     expect(screen.queryByText("Agent")).toBeNull();
     expect(screen.queryByText("Codex")).toBeNull();
@@ -2005,22 +2012,17 @@ describe("agent GUI workbench contribution copy", () => {
       /\.tsh-zoom-dialog\[data-rmiz-modal\]\s*{[^}]*z-index:\s*var\(--z-dialog\);/s
     );
     expect(css).toMatch(
-      /\.workbench-window:has\(\s*> \.workbench-window__header\s+\.agent-gui-workbench-header\[data-agent-gui-standalone-window-header="true"\]\s*\)\s*\.workbench-window__header\s*{[^}]*z-index:\s*calc\(var\(--z-panel\) \+ 1\);/s
+      /\.workbench-window\[data-agent-gui-standalone-window="true"\]\s*\.workbench-window__header\s*{[^}]*z-index:\s*calc\(var\(--z-panel\) \+ 1\);/s
     );
   });
 
-  it("only applies Agent window chrome when the Header occupies the window header slot", () => {
+  it("uses explicit window presentation state instead of root relational selectors", () => {
     const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
 
     expect(css).toMatch(
-      /\.workbench-window:has\(\s*> \.workbench-window__header \[data-agent-gui-workbench-header="true"\]\s*\)\s*{/s
+      /\.workbench-window\[data-window-header-layout="overlay"\],\s*\.workbench-window\[data-agent-gui-standalone-window="true"\]\s*{/s
     );
-    expect(css).not.toMatch(
-      /\.workbench-window:has\(\s*\[data-agent-gui-workbench-header="true"\]/s
-    );
-    expect(css).not.toMatch(
-      /\.workbench-window:has\(\s*\.agent-gui-workbench-header\[data-agent-gui-standalone-window-header="true"\]/s
-    );
+    expect(css).not.toMatch(/\.workbench-window:has\(/);
   });
 
   it("keeps a lone provider settings footer clear of the window edge", () => {

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -434,6 +434,9 @@ export function createAgentGuiWorkbenchContribution(
         window: {
           closable: true,
           defaultOpen: false,
+          header: {
+            layout: "overlay"
+          },
           minimizedDock: {
             kind: "component",
             providePreview: (item) =>

--- a/packages/agent/gui/workbench/header.ts
+++ b/packages/agent/gui/workbench/header.ts
@@ -194,6 +194,9 @@ export function AgentGuiWorkbenchHeader({
       ...headerProps,
       className: cn("agent-gui-workbench-header", className),
       "data-agent-gui-workbench-header": "true",
+      "data-agent-gui-workbench-header-body-error": hasBodyRenderError
+        ? "true"
+        : "false",
       "data-agent-gui-workbench-header-collapsed": isConversationRailCollapsed
         ? "true"
         : "false",

--- a/packages/browser/workbench-node/src/react/BrowserNodeChrome.tsx
+++ b/packages/browser/workbench-node/src/react/BrowserNodeChrome.tsx
@@ -132,8 +132,6 @@ export function BrowserNodeChrome({
       )}
       data-browser-node-header="true"
       data-browser-node-header-display-mode={displayMode}
-      data-workbench-custom-header-layout="browser-tabs"
-      data-workbench-custom-header-overflow="visible"
     >
       <div
         {...restDragHandleProps}

--- a/packages/browser/workbench-node/src/workbench/index.ts
+++ b/packages/browser/workbench-node/src/workbench/index.ts
@@ -149,6 +149,10 @@ export function createBrowserNodeDefinition({
     window: {
       closable: true,
       defaultOpen: false,
+      header: {
+        heightPx: 76,
+        overflow: "visible"
+      },
       minimizedDock: {
         capturePreview: ({ node }) =>
           feature.hostApi.capturePreview?.({

--- a/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
@@ -230,7 +230,13 @@ describe("WorkbenchHost", () => {
         renderHeader,
         title: "Deferred header",
         typeId: "deferred-header",
-        window: { defaultOpen: true }
+        window: {
+          defaultOpen: true,
+          header: {
+            heightPx: 52,
+            layout: "overlay"
+          }
+        }
       },
       {
         frame: { x: 360, y: 0, width: 320, height: 240 },
@@ -272,6 +278,17 @@ describe("WorkbenchHost", () => {
         .nodes.find((node) => node.data.typeId === "live-sibling-header")?.id;
       expect(nodeId).toBeTruthy();
       expect(siblingNodeId).toBeTruthy();
+      const deferredWindow = container
+        .querySelector("[data-header-frame]")
+        ?.closest(".workbench-window");
+      expect(deferredWindow?.getAttribute("data-window-header-layout")).toBe(
+        "overlay"
+      );
+      expect(
+        (deferredWindow as HTMLElement | null)?.style.getPropertyValue(
+          "--workbench-header-height"
+        )
+      ).toBe("52px");
 
       await act(async () => {
         host?.controller.commands.setSurfaceSize({ width: 1200, height: 800 });
@@ -440,6 +457,12 @@ describe("WorkbenchHost", () => {
           node={node}
           renderHeader={renderHeader}
           windowChromeMode="custom-header"
+          windowHeaderPresentation={{
+            border: "none",
+            heightPx: 76,
+            layout: "overlay",
+            overflow: "visible"
+          }}
         >
           <div />
         </WorkbenchWindowFrame>
@@ -462,6 +485,21 @@ describe("WorkbenchHost", () => {
 
       expect(revisions).toHaveLength(2);
       expect(revisions[1]).toBe(revisions[0]);
+      const windowElement = container.querySelector(".workbench-window");
+      expect(windowElement?.getAttribute("data-window-header-border")).toBe(
+        "none"
+      );
+      expect(windowElement?.getAttribute("data-window-header-layout")).toBe(
+        "overlay"
+      );
+      expect(windowElement?.getAttribute("data-window-header-overflow")).toBe(
+        "visible"
+      );
+      expect(
+        (windowElement as HTMLElement | null)?.style.getPropertyValue(
+          "--workbench-header-height"
+        )
+      ).toBe("76px");
       headerControls.minimizeNodeToAnchor?.(node.id);
       expect(firstMinimize).not.toHaveBeenCalled();
       expect(secondMinimize).toHaveBeenCalledWith(node.id, undefined);

--- a/packages/workbench/surface/src/host/WorkbenchHost.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHost.tsx
@@ -181,6 +181,9 @@ export function WorkbenchHost({
       }
       resolveDockPreviewCacheKey={surfaceRenderers.resolveDockPreviewCacheKey}
       resolveFullscreenHeaderMode={surfaceRenderers.resolveFullscreenHeaderMode}
+      resolveWindowHeaderPresentation={
+        surfaceRenderers.resolveWindowHeaderPresentation
+      }
       resolveWindowSurfaceLayer={surfaceRenderers.resolveWindowSurfaceLayer}
       resolveWindowZIndex={surfaceRenderers.resolveWindowZIndex}
       resolveDockAnchorKey={surfaceRenderers.resolveDockAnchorKey}

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -180,6 +180,7 @@ export function WorkbenchHostDock({
     () => new Set(context.minimizedNodes.map((node) => node.id)),
     [context.minimizedNodes]
   );
+  const dockPlateRef = useRef<HTMLDivElement | null>(null);
   const dockMeasureRef = useRef<HTMLDivElement | null>(null);
   const dockItemsRef = useRef<HTMLDivElement | null>(null);
   const hoverPanelRef = useRef<HTMLDivElement | null>(null);
@@ -456,6 +457,7 @@ export function WorkbenchHostDock({
     pauseMagnification: pauseDockMagnification,
     resetMagnification: resetDockMagnification
   } = useDockMagnification({
+    dockPlateRef,
     dockPlacement,
     dockRootRef: dockMeasureRef,
     dockViewportRef: dockItemsRef,
@@ -1415,7 +1417,9 @@ export function WorkbenchHostDock({
       data-dock-placement={dockPlacement}
     >
       <div
+        ref={dockPlateRef}
         className="desktop-dock-plate"
+        data-dock-placement={dockPlacement}
         style={
           dockFrameSize === null
             ? undefined

--- a/packages/workbench/surface/src/host/dockMagnification.ts
+++ b/packages/workbench/surface/src/host/dockMagnification.ts
@@ -396,11 +396,13 @@ function isPointNearDockViewport({
 }
 
 export function useDockMagnification({
+  dockPlateRef,
   dockPlacement,
   dockRootRef,
   dockViewportRef,
   slotRefs
 }: {
+  dockPlateRef: RefObject<HTMLElement | null>;
   dockPlacement: "bottom" | "left";
   dockRootRef: RefObject<HTMLElement | null>;
   dockViewportRef: RefObject<HTMLElement | null>;
@@ -438,12 +440,14 @@ export function useDockMagnification({
       }
       magnifyActiveRef.current = active;
       if (active) {
+        dockPlateRef.current?.setAttribute("data-dock-pointer-active", "true");
         dockRootRef.current?.setAttribute("data-dock-pointer-active", "true");
       } else {
+        dockPlateRef.current?.removeAttribute("data-dock-pointer-active");
         dockRootRef.current?.removeAttribute("data-dock-pointer-active");
       }
     },
-    [dockRootRef]
+    [dockPlateRef, dockRootRef]
   );
 
   const stopAnimation = useCallback(() => {

--- a/packages/workbench/surface/src/host/types.ts
+++ b/packages/workbench/surface/src/host/types.ts
@@ -27,6 +27,7 @@ import type {
 import type {
   WorkbenchDockPlacement,
   WorkbenchMinimizeAnimation,
+  WorkbenchWindowHeaderPresentation,
   WorkbenchSurfacePresentation,
   WorkbenchWindowSurfaceLayer,
   WorkbenchWindowHeaderDragHandleProps
@@ -351,6 +352,7 @@ export interface WorkbenchHostNodeWindowCapabilities {
   defaultOpen?: boolean;
   fullscreenHeaderMode?: "persistent";
   fullscreenable?: boolean;
+  header?: WorkbenchWindowHeaderPresentation;
   keepMountedWhenMinimized?:
     | boolean
     | ((node: WorkbenchNode<WorkbenchHostNodeData>) => boolean);

--- a/packages/workbench/surface/src/host/useWorkbenchHostSurfaceRenderers.tsx
+++ b/packages/workbench/surface/src/host/useWorkbenchHostSurfaceRenderers.tsx
@@ -425,6 +425,12 @@ export function useWorkbenchHostSurfaceRenderers(input: {
     [input.nodeDefinitionByType]
   );
 
+  const resolveWindowHeaderPresentation = useCallback(
+    ({ node }: { node: WorkbenchNode<WorkbenchHostNodeData> }) =>
+      input.nodeDefinitionByType.get(node.data.typeId)?.window?.header,
+    [input.nodeDefinitionByType]
+  );
+
   return {
     captureNodePreviewImage,
     renderBottomChrome,
@@ -439,6 +445,7 @@ export function useWorkbenchHostSurfaceRenderers(input: {
     resolveDockAnchorKey,
     resolveDockPreviewCacheKey,
     resolveFullscreenHeaderMode,
+    resolveWindowHeaderPresentation,
     resolveWindowSurfaceLayer,
     resolveWindowZIndex,
     windowChromeMode

--- a/packages/workbench/surface/src/index.ts
+++ b/packages/workbench/surface/src/index.ts
@@ -146,9 +146,11 @@ export type {
   WorkbenchResolveFullscreenHeaderMode,
   WorkbenchResolveWindowChromeMode,
   WorkbenchResolveWindowChromeModeContext,
+  WorkbenchResolveWindowHeaderPresentation,
   WorkbenchSurfacePresentation,
   WorkbenchFullscreenHeaderMode,
   WorkbenchWindowActionContext,
   WorkbenchWindowChromeMode,
-  WorkbenchWindowHeaderContext
+  WorkbenchWindowHeaderContext,
+  WorkbenchWindowHeaderPresentation
 } from "./react/types.ts";

--- a/packages/workbench/surface/src/react/WorkbenchNodeLayer.tsx
+++ b/packages/workbench/surface/src/react/WorkbenchNodeLayer.tsx
@@ -16,6 +16,7 @@ import type {
   WorkbenchResolveWindowSurfaceLayer,
   WorkbenchResolveWindowZIndex,
   WorkbenchResolveWindowChromeMode,
+  WorkbenchResolveWindowHeaderPresentation,
   WorkbenchWindowChromeMode
 } from "./types.ts";
 import type { WorkbenchGenieController } from "./useWorkbenchGenieAnimation.tsx";
@@ -36,6 +37,7 @@ export interface WorkbenchNodeLayerProps<TData = unknown> {
   renderWindowActions?: WorkbenchRenderWindowActions<TData>;
   renderWindowHeader?: WorkbenchRenderWindowHeader<TData>;
   resolveFullscreenHeaderMode?: WorkbenchResolveFullscreenHeaderMode<TData>;
+  resolveWindowHeaderPresentation?: WorkbenchResolveWindowHeaderPresentation<TData>;
   resolveWindowSurfaceLayer?: WorkbenchResolveWindowSurfaceLayer<TData>;
   resolveWindowZIndex?: WorkbenchResolveWindowZIndex<TData>;
   windowChromeMode?:
@@ -54,6 +56,7 @@ export function WorkbenchNodeLayer<TData>({
   renderWindowActions,
   renderWindowHeader,
   resolveFullscreenHeaderMode,
+  resolveWindowHeaderPresentation,
   resolveWindowSurfaceLayer,
   resolveWindowZIndex,
   windowChromeMode,
@@ -120,6 +123,7 @@ export function WorkbenchNodeLayer<TData>({
         renderNode={renderNode}
         renderWindowActions={renderWindowActions}
         renderWindowHeader={renderWindowHeader}
+        resolveWindowHeaderPresentation={resolveWindowHeaderPresentation}
         resolveWindowZIndex={resolveWindowZIndex}
         windowChromeI18n={windowChromeI18n}
         windowChromeMode={windowChromeMode}
@@ -140,6 +144,7 @@ export function WorkbenchNodeLayer<TData>({
         renderNode={renderNode}
         renderWindowActions={renderWindowActions}
         renderWindowHeader={renderWindowHeader}
+        resolveWindowHeaderPresentation={resolveWindowHeaderPresentation}
         resolveWindowZIndex={resolveWindowZIndex}
         snapPreviewRect={snapPreviewRect}
         windowChromeI18n={windowChromeI18n}
@@ -166,6 +171,7 @@ interface WorkbenchNodeLayerGroupProps<TData = unknown> {
   renderNode: WorkbenchRenderNode<TData>;
   renderWindowActions?: WorkbenchRenderWindowActions<TData>;
   renderWindowHeader?: WorkbenchRenderWindowHeader<TData>;
+  resolveWindowHeaderPresentation?: WorkbenchResolveWindowHeaderPresentation<TData>;
   resolveWindowZIndex?: WorkbenchResolveWindowZIndex<TData>;
   snapPreviewRect?: ReturnType<typeof selectWorkbenchSnapPreviewRect>;
   windowChromeMode?:
@@ -186,6 +192,7 @@ function WorkbenchNodeLayerGroup<TData>({
   renderNode,
   renderWindowActions,
   renderWindowHeader,
+  resolveWindowHeaderPresentation,
   resolveWindowZIndex,
   snapPreviewRect,
   windowChromeI18n,
@@ -229,6 +236,7 @@ function WorkbenchNodeLayerGroup<TData>({
           renderNode={renderNode}
           renderWindowActions={renderWindowActions}
           renderWindowHeader={renderWindowHeader}
+          resolveWindowHeaderPresentation={resolveWindowHeaderPresentation}
           resolveWindowZIndex={resolveWindowZIndex}
           windowChromeI18n={windowChromeI18n}
           windowChromeMode={windowChromeMode}
@@ -248,6 +256,7 @@ interface WorkbenchNodeLayerItemProps<TData = unknown> {
   renderNode: WorkbenchRenderNode<TData>;
   renderWindowActions?: WorkbenchRenderWindowActions<TData>;
   renderWindowHeader?: WorkbenchRenderWindowHeader<TData>;
+  resolveWindowHeaderPresentation?: WorkbenchResolveWindowHeaderPresentation<TData>;
   resolveWindowZIndex?: WorkbenchResolveWindowZIndex<TData>;
   windowChromeMode?:
     | WorkbenchWindowChromeMode
@@ -265,6 +274,7 @@ function WorkbenchNodeLayerItem<TData>({
   renderNode,
   renderWindowActions,
   renderWindowHeader,
+  resolveWindowHeaderPresentation,
   resolveWindowZIndex,
   windowChromeI18n,
   windowChromeMode
@@ -305,6 +315,10 @@ function WorkbenchNodeLayerItem<TData>({
       })}
       renderActions={renderWindowActions}
       renderHeader={renderWindowHeader}
+      windowHeaderPresentation={resolveWindowHeaderPresentation?.({
+        controller,
+        node
+      })}
       windowChromeI18n={windowChromeI18n}
       windowChromeMode={resolveWorkbenchWindowChromeMode({
         controller,

--- a/packages/workbench/surface/src/react/WorkbenchSurface.tsx
+++ b/packages/workbench/surface/src/react/WorkbenchSurface.tsx
@@ -35,6 +35,7 @@ import type {
   WorkbenchResolveWindowSurfaceLayer,
   WorkbenchResolveWindowZIndex,
   WorkbenchResolveWindowChromeMode,
+  WorkbenchResolveWindowHeaderPresentation,
   WorkbenchWindowChromeMode
 } from "./types.ts";
 import type {
@@ -68,6 +69,7 @@ export interface WorkbenchSurfaceProps<TData = unknown> {
   renderWindowHeader?: WorkbenchRenderWindowHeader<TData>;
   shouldKeepMinimizedNodeMounted?: WorkbenchKeepMinimizedNodeMounted<TData>;
   resolveFullscreenHeaderMode?: WorkbenchResolveFullscreenHeaderMode<TData>;
+  resolveWindowHeaderPresentation?: WorkbenchResolveWindowHeaderPresentation<TData>;
   resolveWindowSurfaceLayer?: WorkbenchResolveWindowSurfaceLayer<TData>;
   resolveWindowZIndex?: WorkbenchResolveWindowZIndex<TData>;
   resolveDockAnchorKey?: (node: WorkbenchNode<TData>) => string;
@@ -123,6 +125,7 @@ export function WorkbenchSurface<TData>({
   renderWindowHeader,
   shouldKeepMinimizedNodeMounted,
   resolveFullscreenHeaderMode,
+  resolveWindowHeaderPresentation,
   resolveWindowSurfaceLayer,
   resolveWindowZIndex,
   resolveDockAnchorKey,
@@ -158,6 +161,7 @@ export function WorkbenchSurface<TData>({
         renderWindowHeader={renderWindowHeader}
         shouldKeepMinimizedNodeMounted={shouldKeepMinimizedNodeMounted}
         resolveFullscreenHeaderMode={resolveFullscreenHeaderMode}
+        resolveWindowHeaderPresentation={resolveWindowHeaderPresentation}
         resolveWindowSurfaceLayer={resolveWindowSurfaceLayer}
         resolveWindowZIndex={resolveWindowZIndex}
         resolveDockAnchorKey={resolveDockAnchorKey}
@@ -195,6 +199,7 @@ function WorkbenchSurfaceInner<TData>({
   renderWindowHeader,
   shouldKeepMinimizedNodeMounted,
   resolveFullscreenHeaderMode,
+  resolveWindowHeaderPresentation,
   resolveWindowSurfaceLayer,
   resolveWindowZIndex,
   resolveDockAnchorKey,
@@ -277,6 +282,7 @@ function WorkbenchSurfaceInner<TData>({
         renderWindowHeader={renderWindowHeader}
         shouldKeepMinimizedNodeMounted={shouldKeepMinimizedNodeMounted}
         resolveFullscreenHeaderMode={resolveFullscreenHeaderMode}
+        resolveWindowHeaderPresentation={resolveWindowHeaderPresentation}
         resolveWindowSurfaceLayer={resolveWindowSurfaceLayer}
         resolveWindowZIndex={resolveWindowZIndex}
         windowChromeMode={windowChromeMode}

--- a/packages/workbench/surface/src/react/WorkbenchWindowFrame.tsx
+++ b/packages/workbench/surface/src/react/WorkbenchWindowFrame.tsx
@@ -1,4 +1,5 @@
 import {
+  type CSSProperties,
   type ReactNode,
   useCallback,
   useLayoutEffect,
@@ -28,7 +29,8 @@ import type {
   WorkbenchRenderWindowHeader,
   WorkbenchResolveWindowZIndex,
   WorkbenchSurfacePresentation,
-  WorkbenchWindowChromeMode
+  WorkbenchWindowChromeMode,
+  WorkbenchWindowHeaderPresentation
 } from "./types.ts";
 import type { WorkbenchGenieController } from "./useWorkbenchGenieAnimation.tsx";
 import { resolveWorkbenchWindowHeader } from "./windowHeader.ts";
@@ -46,6 +48,7 @@ export interface WorkbenchWindowFrameProps<TData = unknown> {
   resolveWindowZIndex?: WorkbenchResolveWindowZIndex<TData>;
   fullscreenHeaderMode?: WorkbenchFullscreenHeaderMode;
   windowChromeMode?: WorkbenchWindowChromeMode;
+  windowHeaderPresentation?: WorkbenchWindowHeaderPresentation;
   windowChromeI18n?: WorkbenchWindowChromeI18nRuntime;
 }
 
@@ -104,6 +107,7 @@ export function WorkbenchWindowFrame<TData>({
   renderHeader,
   resolveWindowZIndex,
   windowChromeMode = "system",
+  windowHeaderPresentation,
   windowChromeI18n
 }: WorkbenchWindowFrameProps<TData>) {
   const controller = useWorkbenchController<TData>();
@@ -195,6 +199,12 @@ export function WorkbenchWindowFrame<TData>({
     renderRevision: headerRenderRevision,
     windowChromeMode
   });
+  const windowHeaderHeightPx =
+    typeof windowHeaderPresentation?.heightPx === "number" &&
+    Number.isFinite(windowHeaderPresentation.heightPx) &&
+    windowHeaderPresentation.heightPx > 0
+      ? windowHeaderPresentation.heightPx
+      : null;
   const shouldRenderCustomHeader =
     resolvedHeader.windowChromeMode === "custom-header";
   const resolvedFullscreenHeaderMode: WorkbenchFullscreenHeaderMode =
@@ -283,9 +293,19 @@ export function WorkbenchWindowFrame<TData>({
           data-display-mode={node.displayMode}
           data-fullscreen-header-mode={resolvedFullscreenHeaderMode}
           data-window-chrome-mode={resolvedHeader.windowChromeMode}
+          data-window-header-border={windowHeaderPresentation?.border}
+          data-window-header-layout={windowHeaderPresentation?.layout}
+          data-window-header-overflow={windowHeaderPresentation?.overflow}
           data-workbench-window-capture="true"
           data-window-drag-state={isDragging ? "dragging" : "idle"}
           data-window-resize-state={isResizing ? "resizing" : "idle"}
+          style={
+            windowHeaderHeightPx !== null
+              ? ({
+                  "--workbench-header-height": `${windowHeaderHeightPx}px`
+                } as CSSProperties)
+              : undefined
+          }
         >
           <div
             className={[

--- a/packages/workbench/surface/src/react/types.ts
+++ b/packages/workbench/surface/src/react/types.ts
@@ -68,6 +68,13 @@ export type WorkbenchWindowChromeMode = "system" | "custom-header";
 
 export type WorkbenchFullscreenHeaderMode = "persistent";
 
+export interface WorkbenchWindowHeaderPresentation {
+  border?: "none";
+  heightPx?: number;
+  layout?: "overlay";
+  overflow?: "visible";
+}
+
 export interface WorkbenchResolveWindowChromeModeContext<TData = unknown> {
   node: WorkbenchNode<TData>;
   controller: WorkbenchController<TData>;
@@ -76,6 +83,10 @@ export interface WorkbenchResolveWindowChromeModeContext<TData = unknown> {
 export type WorkbenchResolveWindowChromeMode<TData = unknown> = (
   context: WorkbenchResolveWindowChromeModeContext<TData>
 ) => WorkbenchWindowChromeMode;
+
+export type WorkbenchResolveWindowHeaderPresentation<TData = unknown> = (
+  context: WorkbenchResolveWindowChromeModeContext<TData>
+) => WorkbenchWindowHeaderPresentation | undefined;
 
 export type WorkbenchWindowSurfaceLayer = "default" | "dialog-popover";
 

--- a/packages/workbench/surface/src/styles/workbench.css
+++ b/packages/workbench/surface/src/styles/workbench.css
@@ -192,10 +192,6 @@
     box-shadow 0.16s ease;
 }
 
-.workbench-window:has([data-workbench-custom-header-layout="browser-tabs"]) {
-  --workbench-header-height: 76px;
-}
-
 .workbench-window[data-display-mode="floating"] {
   background: var(--background-panel);
 }
@@ -229,15 +225,13 @@
   user-select: auto;
 }
 
-.workbench-window__header--custom:has(
-  [data-workbench-custom-header-overflow="visible"]
-) {
+.workbench-window[data-window-header-overflow="visible"]
+  > .workbench-window__header--custom {
   overflow: visible;
 }
 
-.workbench-window__header--custom:has(
-  [data-workbench-custom-header-border="none"]
-) {
+.workbench-window[data-window-header-border="none"]
+  > .workbench-window__header--custom {
   border-bottom-color: transparent;
 }
 
@@ -786,7 +780,7 @@
 }
 
 [data-dock-placement="left"] > .desktop-dock-plate,
-.desktop-dock-plate:has(.desktop-dock[data-dock-placement="left"]) {
+.desktop-dock-plate[data-dock-placement="left"] {
   width: auto;
   height: var(--desktop-dock-frame-size, auto);
   max-width: none;
@@ -841,7 +835,7 @@
   transition: none;
 }
 
-.desktop-dock-plate:has(.desktop-dock[data-dock-pointer-active="true"]) {
+.desktop-dock-plate[data-dock-pointer-active="true"] {
   transition: none;
 }
 

--- a/packages/workbench/surface/src/styles/workbench.test.ts
+++ b/packages/workbench/surface/src/styles/workbench.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const css = readFileSync(new URL("./workbench.css", import.meta.url), "utf8");
+
+test("workbench structural selectors use explicit subject state", () => {
+  assert.doesNotMatch(css, /:has\(/);
+  assert.match(
+    css,
+    /\.workbench-window\[data-window-header-overflow="visible"\]/
+  );
+  assert.match(css, /\.desktop-dock-plate\[data-dock-pointer-active="true"\]/);
+});

--- a/packages/workspace/issue-manager/src/ui/IssueManagerNode.tsx
+++ b/packages/workspace/issue-manager/src/ui/IssueManagerNode.tsx
@@ -312,7 +312,6 @@ export function IssueManagerNodeHeader({
         "relative flex h-full min-h-0 w-full items-center bg-transparent",
         className
       )}
-      data-workbench-custom-header-border="none"
     >
       <div
         {...dragHandleProps}

--- a/packages/workspace/issue-manager/src/workbench/index.ts
+++ b/packages/workspace/issue-manager/src/workbench/index.ts
@@ -243,6 +243,9 @@ export function createIssueManagerWorkbenchNodeDefinition<
     window: {
       closable: true,
       defaultOpen: false,
+      header: {
+        border: "none"
+      },
       minimizedDock: {
         kind: "snapshot"
       },

--- a/tools/scripts/agent-gui-session-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-session-performance-scenarios.mjs
@@ -23,6 +23,7 @@ const sessionMarkers = {
 export const sessionSwitchScenario = {
   id: "session-switch",
   markers: sessionMarkers,
+  profileFunctionNames: ["readTimelineGeometry"],
   milestones: [
     {
       key: "selected",

--- a/tools/scripts/change-classification.test.mjs
+++ b/tools/scripts/change-classification.test.mjs
@@ -103,3 +103,11 @@ test("stylesheet and HTML changes select the backdrop-filter authoring policy", 
     );
   }
 });
+
+test("stylesheet changes select the CSS :has() performance policy", () => {
+  const checks = selectRepositoryChecks([
+    "packages/agent/gui/app/renderer/agentactivity.css"
+  ]);
+
+  assert.ok(checks.some((check) => check.key === "policy:css-has-performance"));
+});

--- a/tools/scripts/check-css-has-performance.mjs
+++ b/tools/scripts/check-css-has-performance.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  analyzeCssHasPerformance,
+  isCssHasPerformancePath
+} from "./css-has-performance-policy.mjs";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(scriptDirectory, "../..");
+const staged = process.argv.includes("--staged");
+const files = listFiles();
+const diagnostics = files.flatMap((path) =>
+  analyzeCssHasPerformance({ path, source: readSource(path) })
+);
+
+if (diagnostics.length > 0) {
+  console.error(
+    ":has() is forbidden on large dynamic CSS subjects because descendant mutations can invalidate the full subject subtree."
+  );
+  for (const diagnostic of diagnostics) {
+    console.error(
+      `- ${diagnostic.path}:${diagnostic.line}:${diagnostic.column} ${diagnostic.selector}: ${diagnostic.message}`
+    );
+  }
+  process.exitCode = 1;
+} else {
+  console.log(
+    `CSS :has() performance policy passed (${files.length} ${staged ? "staged " : ""}files)`
+  );
+}
+
+function listFiles() {
+  const args = staged
+    ? ["diff", "--cached", "--name-only", "--diff-filter=ACMR", "-z"]
+    : ["ls-files", "--cached", "--others", "--exclude-standard", "-z"];
+  return execFileSync("git", args, {
+    cwd: workspaceRoot,
+    encoding: "utf8"
+  })
+    .split("\0")
+    .filter(Boolean)
+    .map((path) => path.replaceAll("\\", "/"))
+    .filter(isCssHasPerformancePath)
+    .filter((path) => staged || existsSync(join(workspaceRoot, path)));
+}
+
+function readSource(path) {
+  if (staged) {
+    return execFileSync("git", ["show", `:${path}`], {
+      cwd: workspaceRoot,
+      encoding: "utf8",
+      maxBuffer: 20 * 1024 * 1024
+    });
+  }
+  return readFileSync(join(workspaceRoot, path), "utf8");
+}

--- a/tools/scripts/css-has-performance-policy.mjs
+++ b/tools/scripts/css-has-performance-policy.mjs
@@ -1,0 +1,238 @@
+const forbiddenClassSubjects = [
+  "agent-gui-conversation__assistant-message-flow",
+  "agent-gui-conversation__user-message-flow",
+  "agent-gui-node__body",
+  "agent-gui-node__conversation-list",
+  "agent-gui-node__detail",
+  "agent-gui-node__detail-panel",
+  "agent-gui-node__layout",
+  "agent-gui-node__provider-rail-panel",
+  "agent-gui-node__rail",
+  "agent-gui-node__shell",
+  "agent-gui-node__timeline",
+  "agent-gui-node__timeline-with-composer",
+  "agent-gui-transcript-row",
+  "desktop-dock",
+  "desktop-dock-plate",
+  "workbench-surface",
+  "workbench-window",
+  "workbench-window-shell",
+  "workspace-node-window",
+  "workspace-node-window__body"
+];
+
+export function analyzeCssHasPerformance({ path, source }) {
+  const diagnostics = [];
+  const maskedSource = maskCssNonCode(source);
+
+  for (const rule of collectCssRulePreludes(maskedSource)) {
+    const hasPattern = /:has\s*\(/giu;
+    for (const match of rule.prelude.matchAll(hasPattern)) {
+      const compound = readSubjectCompound(rule.prelude.slice(0, match.index));
+      const subject = findForbiddenSubject(compound);
+      if (!subject) {
+        continue;
+      }
+
+      diagnostics.push(
+        diagnosticAt({
+          index: rule.startIndex + match.index,
+          message:
+            `do not use :has() on large dynamic subject ${subject}; ` +
+            "project the state onto the subject with a data attribute",
+          path,
+          selector: source
+            .slice(rule.startIndex, rule.endIndex)
+            .replace(/\s+/gu, " ")
+            .trim(),
+          source,
+          subject
+        })
+      );
+    }
+  }
+
+  return diagnostics;
+}
+
+export function isCssHasPerformancePath(path) {
+  const normalized = path.replaceAll("\\", "/");
+  return (
+    /^(?:apps|packages|services)\//u.test(normalized) &&
+    normalized.endsWith(".css") &&
+    !/(?:^|\/)(?:coverage|dist|node_modules|out|\.tmp)(?:\/|$)/u.test(
+      normalized
+    ) &&
+    !/(?:^|\/)[^/]+\.(?:spec|test)\.css$/u.test(normalized)
+  );
+}
+
+function collectCssRulePreludes(maskedSource) {
+  const rules = [];
+  let statementStart = 0;
+
+  for (let index = 0; index < maskedSource.length; index += 1) {
+    const character = maskedSource[index];
+    if (character === "{") {
+      const statement = maskedSource.slice(statementStart, index);
+      const firstCodeOffset = findFirstCodeOffset(statement);
+      if (firstCodeOffset >= 0) {
+        const startIndex = statementStart + firstCodeOffset;
+        const prelude = maskedSource.slice(startIndex, index);
+        if (!prelude.startsWith("@")) {
+          rules.push({ endIndex: index, prelude, startIndex });
+        }
+      }
+      statementStart = index + 1;
+      continue;
+    }
+    if (character === "}" || character === ";") {
+      statementStart = index + 1;
+    }
+  }
+
+  return rules;
+}
+
+function readSubjectCompound(prefix) {
+  let bracketDepth = 0;
+  let parenthesisDepth = 0;
+  let start = 0;
+
+  for (let index = 0; index < prefix.length; index += 1) {
+    const character = prefix[index];
+    if (character === "\u0000") {
+      continue;
+    }
+    if (character === "[") {
+      bracketDepth += 1;
+      continue;
+    }
+    if (character === "]") {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+      continue;
+    }
+    if (character === "(") {
+      parenthesisDepth += 1;
+      continue;
+    }
+    if (character === ")") {
+      parenthesisDepth = Math.max(0, parenthesisDepth - 1);
+      continue;
+    }
+    if (bracketDepth > 0 || parenthesisDepth > 0) {
+      continue;
+    }
+    if (
+      character === "," ||
+      character === ">" ||
+      character === "+" ||
+      character === "~"
+    ) {
+      start = index + 1;
+      continue;
+    }
+    if (/\s/u.test(character)) {
+      start = index + 1;
+    }
+  }
+
+  return prefix.slice(start).trim();
+}
+
+function findForbiddenSubject(compound) {
+  if (/^:root(?=[.#[:]|$)/u.test(compound)) {
+    return ":root";
+  }
+  const typeSubject = /^(?:\*?\|)?(body|html)(?=[.#[:]|$)/u.exec(compound);
+  if (typeSubject) {
+    return typeSubject[1];
+  }
+
+  for (const className of forbiddenClassSubjects) {
+    const pattern = new RegExp(
+      `(?:^|[^a-zA-Z0-9_-])\\.${escapeRegExp(className)}(?![a-zA-Z0-9_-])`,
+      "u"
+    );
+    if (pattern.test(compound)) {
+      return `.${className}`;
+    }
+  }
+
+  return null;
+}
+
+function maskCssNonCode(source) {
+  const characters = source.split("");
+  let inComment = false;
+  let quote = null;
+
+  for (let index = 0; index < characters.length; index += 1) {
+    const character = characters[index];
+    const next = characters[index + 1];
+    if (inComment) {
+      characters[index] = "\u0000";
+      if (character === "*" && next === "/") {
+        characters[index + 1] = "\u0000";
+        inComment = false;
+        index += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (character !== "\n") {
+        characters[index] = " ";
+      }
+      if (character === "\\") {
+        if (next !== "\n") {
+          characters[index + 1] = " ";
+        }
+        index += 1;
+      } else if (character === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (character === "/" && next === "*") {
+      characters[index] = "\u0000";
+      characters[index + 1] = "\u0000";
+      inComment = true;
+      index += 1;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      characters[index] = " ";
+      quote = character;
+    }
+  }
+
+  return characters.join("");
+}
+
+function diagnosticAt({ index, message, path, selector, source, subject }) {
+  const prefix = source.slice(0, index);
+  const lines = prefix.split("\n");
+  return {
+    column: lines.at(-1).length + 1,
+    kind: "large-dynamic-has-subject",
+    line: lines.length,
+    message,
+    path,
+    selector,
+    subject,
+    token: ":has"
+  };
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function findFirstCodeOffset(source) {
+  for (let index = 0; index < source.length; index += 1) {
+    if (source[index] !== "\u0000" && !/\s/u.test(source[index])) {
+      return index;
+    }
+  }
+  return -1;
+}

--- a/tools/scripts/css-has-performance-policy.test.mjs
+++ b/tools/scripts/css-has-performance-policy.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  analyzeCssHasPerformance,
+  isCssHasPerformancePath
+} from "./css-has-performance-policy.mjs";
+
+test("rejects :has() on document and large dynamic component subjects", () => {
+  const source = [
+    "body:has(.modal-open) { overflow: hidden; }",
+    ".workbench-window[data-mode='custom']:has(.editor) { display: grid; }",
+    ".shell .agent-gui-transcript-row:not(:has(.tool-row)) { margin: 0; }"
+  ].join("\n");
+
+  const diagnostics = analyzeCssHasPerformance({
+    path: "packages/example/styles.css",
+    source
+  });
+
+  assert.deepEqual(
+    diagnostics.map(({ line, subject }) => ({ line, subject })),
+    [
+      { line: 1, subject: "body" },
+      { line: 2, subject: ".workbench-window" },
+      { line: 3, subject: ".agent-gui-transcript-row" }
+    ]
+  );
+});
+
+test("allows bounded local subjects and descendant controls inside large surfaces", () => {
+  const source = [
+    ".workbench-window .local-button:has(svg) { color: red; }",
+    ".agent-gui-node__conversation-item:has([data-state='open']) {}",
+    ".dialog:not(:has(.actions)) .controls {}"
+  ].join("\n");
+
+  assert.deepEqual(
+    analyzeCssHasPerformance({
+      path: "packages/example/styles.css",
+      source
+    }),
+    []
+  );
+});
+
+test("handles selector lists, nested at-rules, comments, and strings", () => {
+  const source = [
+    "@media (min-width: 1px) {",
+    "  /* .workbench-window:has(.ignored) {} */",
+    "  .safe,",
+    "  .agent-gui-node__timeline:has(.streaming) {",
+    '    content: ".workbench-window:has(.ignored)";',
+    "  }",
+    "}"
+  ].join("\n");
+
+  const diagnostics = analyzeCssHasPerformance({
+    path: "packages/example/styles.css",
+    source
+  });
+
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0]?.line, 4);
+  assert.equal(diagnostics[0]?.subject, ".agent-gui-node__timeline");
+  assert.match(diagnostics[0]?.selector ?? "", /\.safe,/u);
+});
+
+test("comments cannot hide a forbidden :has() subject", () => {
+  const diagnostics = analyzeCssHasPerformance({
+    path: "packages/example/styles.css",
+    source: ".workbench-window/* comment */:has(.editor) {}"
+  });
+
+  assert.equal(diagnostics[0]?.subject, ".workbench-window");
+});
+
+test("does not confuse similarly prefixed local classes with forbidden roots", () => {
+  const source = [
+    ".workbench-window__title:has(.status) {}",
+    ".agent-gui-node__timeline-label:has(svg) {}",
+    ".desktop-dock-popup:has(.item) {}"
+  ].join("\n");
+
+  assert.deepEqual(
+    analyzeCssHasPerformance({
+      path: "packages/example/styles.css",
+      source
+    }),
+    []
+  );
+});
+
+test("CSS performance path scope covers production stylesheets only", () => {
+  assert.equal(
+    isCssHasPerformancePath(
+      "packages/agent/gui/app/renderer/agentactivity.css"
+    ),
+    true
+  );
+  assert.equal(
+    isCssHasPerformancePath("apps/desktop/src/renderer/styles.css"),
+    true
+  );
+  assert.equal(
+    isCssHasPerformancePath("packages/example/dist/styles.css"),
+    false
+  );
+  assert.equal(isCssHasPerformancePath("tools/fixtures/negative.css"), false);
+  assert.equal(
+    isCssHasPerformancePath("packages/example/styles.test.css"),
+    false
+  );
+});

--- a/tools/scripts/local-git-hooks.test.mjs
+++ b/tools/scripts/local-git-hooks.test.mjs
@@ -7,6 +7,15 @@ import { fileURLToPath } from "node:url";
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = join(scriptDirectory, "..", "..");
 
+test("pre-commit runs the staged CSS :has() performance policy", () => {
+  const hook = readFileSync(
+    join(workspaceRoot, ".husky", "pre-commit"),
+    "utf8"
+  );
+
+  assert.ok(hook.split("\n").includes("pnpm check:css-has-performance:staged"));
+});
+
 test("pre-push uses changed-aware push-ready validation", () => {
   const hook = readFileSync(join(workspaceRoot, ".husky", "pre-push"), "utf8");
 

--- a/tools/scripts/repository-checks.mjs
+++ b/tools/scripts/repository-checks.mjs
@@ -25,6 +25,13 @@ export const repositoryCheckDefinitions = [
     matches: isBackdropFilterAuthoringRelevant
   },
   {
+    group: "policy",
+    key: "policy:css-has-performance",
+    label: "CSS :has() performance policy",
+    script: "check:css-has-performance",
+    matches: isCssHasPerformanceRelevant
+  },
+  {
     group: "contracts",
     key: "contracts:tool-tests",
     label: "repository tool contracts",
@@ -180,6 +187,15 @@ function isBackdropFilterAuthoringRelevant(file) {
   return (
     /^(?:apps|packages|services)\//u.test(file) &&
     /\.(?:cjs|css|cts|html|js|jsx|mjs|mts|ts|tsx)$/u.test(file)
+  );
+}
+
+function isCssHasPerformanceRelevant(file) {
+  return (
+    (/^(?:apps|packages|services)\//u.test(file) && file.endsWith(".css")) ||
+    file === "tools/scripts/check-css-has-performance.mjs" ||
+    file === "tools/scripts/css-has-performance-policy.mjs" ||
+    file === "tools/scripts/css-has-performance-policy.test.mjs"
   );
 }
 

--- a/tools/scripts/run-agent-gui-performance.test.mjs
+++ b/tools/scripts/run-agent-gui-performance.test.mjs
@@ -9,6 +9,7 @@ import {
   agentGuiPerformanceScenarios,
   resolveAgentGuiPerformanceScenario
 } from "./agent-gui-performance-scenarios.mjs";
+import { sessionSwitchScenario } from "./agent-gui-session-performance-scenarios.mjs";
 import { composerInputScenario } from "./agent-gui-composer-performance-scenarios.mjs";
 import { summarizeProviderStatusFocusRefresh } from "./agent-provider-status-performance-scenario.mjs";
 import { buildAllProcessTimeProfileArgs } from "./all-process-time-profile.mjs";
@@ -173,6 +174,12 @@ test("session switch target selection keeps active source and chooses another", 
     ),
     { sourceSessionID: "session-2", targetSessionID: "session-1" }
   );
+});
+
+test("session switch profiles its timeline geometry choke point", () => {
+  assert.deepEqual(sessionSwitchScenario.profileFunctionNames, [
+    "readTimelineGeometry"
+  ]);
 });
 
 test("performance scenario registry exposes renderer and window scenarios", () => {


### PR DESCRIPTION
## Summary
- isolate the active timeline from composer draft renders and stop controlled TipTap echoes from rebuilding the editor DOM
- replace high-cost relational selectors with semantic state attributes and add a repository CSS performance guard

## Fix Scope Justification
- Root cause: composer DOM mutations were coupled to aggregate detail renders, controlled-value writeback, and large dynamic `:has()` subjects. One input could therefore invalidate roughly 3,000 elements and produce a second layout pass.
- Lower layer: no single lower layer owns all three triggers. The fix is placed at each existing owner: the TipTap controlled-value boundary, the AgentGUI render boundary, the shared Workbench window-presentation contract, and the repository CSS policy. Browser, Issue Manager, and AgentGUI all consumed descendant-discovered Workbench header state, so migrating only AgentGUI would leave the same structural invalidation path in the shared surface.

## Tests
- `pnpm check:changed` (25 lanes)

## Notes
- Dock safe-area behavior is unchanged from the PR base. Its optimization was removed from this PR after review because an explicit active-prompt-only ref omitted the queued-prompts panel.
