### PR TITLE
fix(workspace-file-manager): preserve fallback asset URLs

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -9,6 +9,14 @@ const aliases = {
   "@app/renderer": resolve("../../packages/agent/gui/app/renderer"),
   "@contexts": resolve("../../packages/agent/gui/contexts"),
   "@main": resolve("src/main"),
+  "@tutti-os/workspace-file-manager/assets/workspace-archive-fallback.png":
+    resolve(
+      "../../packages/workspace/file-manager/src/assets/workspace-archive-fallback.png"
+    ),
+  "@tutti-os/workspace-file-manager/assets/workspace-folder-fallback.png":
+    resolve(
+      "../../packages/workspace/file-manager/src/assets/workspace-folder-fallback.png"
+    ),
   "@tutti-os/workspace-file-manager/services": resolve(
     "../../packages/workspace/file-manager/src/services/index.ts"
   ),

--- a/apps/desktop/vite.web.config.mjs
+++ b/apps/desktop/vite.web.config.mjs
@@ -9,6 +9,14 @@ const aliases = {
   "@app/renderer": resolve("../../packages/agent/gui/app/renderer"),
   "@contexts": resolve("../../packages/agent/gui/contexts"),
   "@main": resolve("src/main"),
+  "@tutti-os/workspace-file-manager/assets/workspace-archive-fallback.png":
+    resolve(
+      "../../packages/workspace/file-manager/src/assets/workspace-archive-fallback.png"
+    ),
+  "@tutti-os/workspace-file-manager/assets/workspace-folder-fallback.png":
+    resolve(
+      "../../packages/workspace/file-manager/src/assets/workspace-folder-fallback.png"
+    ),
   "@tutti-os/workspace-file-manager/services": resolve(
     "../../packages/workspace/file-manager/src/services/index.ts"
   ),

--- a/docs/conventions/npm-package-release.md
+++ b/docs/conventions/npm-package-release.md
@@ -229,6 +229,11 @@ following:
   CSS-safe data URL or an absolute URL constructed relative to the module
 - every asset referenced through `new URL(relativePath, import.meta.url)` exists
   at that exact module-relative location inside the packed tarball
+- published code that may be dependency-prebundled must import fallback images
+  through explicit public asset subpaths; do not leave
+  `new URL("./assets/...", import.meta.url)` in a bundled runtime entrypoint,
+  because a consumer optimizer may relocate the JavaScript without relocating
+  the adjacent asset
 
 Emitting an SVG next to a bundled JavaScript file is not sufficient when the
 bundle only exports a string such as `./icon-HASH.svg`. CSS resolves that value
@@ -285,6 +290,8 @@ The stable package entrypoints are:
 @tutti-os/workspace-file-preview/core
 @tutti-os/workspace-file-preview/react
 @tutti-os/workspace-file-manager
+@tutti-os/workspace-file-manager/assets/workspace-archive-fallback.png
+@tutti-os/workspace-file-manager/assets/workspace-folder-fallback.png
 @tutti-os/workspace-file-manager/services
 @tutti-os/workspace-file-reference
 @tutti-os/workspace-file-reference/contracts

--- a/docs/conventions/troubleshooting/toolchain-browser-terminal.md
+++ b/docs/conventions/troubleshooting/toolchain-browser-terminal.md
@@ -507,6 +507,10 @@ emitted before this method can be called`, especially after HMR, navigation,
   `dist/assets/...`. The same feature often works inside this monorepo because
   workspace source resolution or local build layout hides the packaging
   problem.
+  In Vite development mode the failing URL may instead point at
+  `node_modules/.vite/deps/assets/...`: dependency prebundling moved the
+  JavaScript module, then a preserved `new URL("./assets/...", import.meta.url)`
+  resolved relative to the optimizer cache.
 - Quick checks:
   If the failing package entrypoint renders a package-local image or icon,
   inspect whether the main runtime entrypoint still imports that asset directly
@@ -521,6 +525,9 @@ emitted before this method can be called`, especially after HMR, navigation,
   exposing that asset as an explicit public subpath. The packed npm artifact
   either did not ship the matching file layout or forced every consumer to pay
   the asset cost even when the feature was unused.
+  A related failure occurs when a published bundle preserves a module-relative
+  `new URL(...)`: consumer dependency optimization can relocate that bundle
+  independently from its adjacent asset.
 - Fix:
   Move the image or icon out of the main runtime entrypoint and export it
   through an explicit package asset subpath such as
@@ -528,6 +535,10 @@ emitted before this method can be called`, especially after HMR, navigation,
   Let the business consumer import that asset only when it needs the default
   visual, and keep the package build rule that copies the asset into the packed
   `dist/assets` directory.
+  When the package runtime intentionally owns the default visual, import the
+  explicit public asset subpath from that runtime and keep the asset import
+  external in the package build. This lets the consumer bundler observe and
+  rewrite the asset dependency instead of inferring it from `import.meta.url`.
   Apply the same rule to every public runtime subpath in the package, not just
   the first failing icon.
 - Validation:

--- a/packages/agent/gui/vitest.config.ts
+++ b/packages/agent/gui/vitest.config.ts
@@ -6,6 +6,8 @@ const rootDir = fileURLToPath(new URL(".", import.meta.url));
 export default defineConfig({
   resolve: {
     alias: {
+      "@tutti-os/workspace-file-manager/assets/workspace-archive-fallback.png": `${rootDir}../../workspace/file-manager/src/assets/workspace-archive-fallback.png`,
+      "@tutti-os/workspace-file-manager/assets/workspace-folder-fallback.png": `${rootDir}../../workspace/file-manager/src/assets/workspace-folder-fallback.png`,
       "@tutti-os/workspace-file-manager/services": `${rootDir}../../workspace/file-manager/src/services/index.ts`,
       "@tutti-os/workspace-file-manager": `${rootDir}../../workspace/file-manager/src/index.ts`
     }

--- a/packages/workspace/file-manager/README.md
+++ b/packages/workspace/file-manager/README.md
@@ -43,6 +43,13 @@ drag movement.
 Hosts now provide one app-level i18n runtime and scope it into the file-manager
 namespace, rather than hand-assembling package-local message objects.
 
+The React surface owns its archive and folder fallback artwork. Those files are
+published through the stable
+`@tutti-os/workspace-file-manager/assets/workspace-*-fallback.png` subpaths so
+consumer bundlers can resolve them during dependency prebundling. Keep runtime
+imports on those public subpaths; relative `new URL("./assets/...", import.meta.url)`
+references from the built entry are not a supported asset contract.
+
 What stays outside this package is concrete host integration: desktop preload
 calls, tuttid transport wiring, host absolute paths, import/export/upload
 flows, share/exposure flows, and other product-specific integration details

--- a/packages/workspace/file-manager/package.json
+++ b/packages/workspace/file-manager/package.json
@@ -6,6 +6,14 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./assets/workspace-archive-fallback.png": {
+      "types": "./src/assets/workspace-archive-fallback.png.d.ts",
+      "default": "./src/assets/workspace-archive-fallback.png"
+    },
+    "./assets/workspace-folder-fallback.png": {
+      "types": "./src/assets/workspace-folder-fallback.png.d.ts",
+      "default": "./src/assets/workspace-folder-fallback.png"
+    },
     "./i18n": "./src/i18n/index.ts",
     "./services": "./src/services/index.ts"
   },
@@ -54,6 +62,14 @@
       ".": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
+      },
+      "./assets/workspace-archive-fallback.png": {
+        "types": "./dist/assets/workspace-archive-fallback.png.d.ts",
+        "default": "./dist/assets/workspace-archive-fallback.png"
+      },
+      "./assets/workspace-folder-fallback.png": {
+        "types": "./dist/assets/workspace-folder-fallback.png.d.ts",
+        "default": "./dist/assets/workspace-folder-fallback.png"
       },
       "./i18n": {
         "types": "./dist/i18n/index.d.ts",

--- a/packages/workspace/file-manager/src/assets/workspace-archive-fallback.png.d.ts
+++ b/packages/workspace/file-manager/src/assets/workspace-archive-fallback.png.d.ts
@@ -1,0 +1,3 @@
+declare const workspaceArchiveFallbackIconUrl: string;
+
+export default workspaceArchiveFallbackIconUrl;

--- a/packages/workspace/file-manager/src/assets/workspace-folder-fallback.png.d.ts
+++ b/packages/workspace/file-manager/src/assets/workspace-folder-fallback.png.d.ts
@@ -1,0 +1,3 @@
+declare const workspaceFolderFallbackIconUrl: string;
+
+export default workspaceFolderFallbackIconUrl;

--- a/packages/workspace/file-manager/src/workspaceFileFallbackAssets.ts
+++ b/packages/workspace/file-manager/src/workspaceFileFallbackAssets.ts
@@ -1,9 +1,4 @@
-export const workspaceArchiveFallbackIconUrl = new URL(
-  "./assets/workspace-archive-fallback.png",
-  import.meta.url
-).toString();
+import workspaceArchiveFallbackIconUrl from "@tutti-os/workspace-file-manager/assets/workspace-archive-fallback.png";
+import workspaceFolderFallbackIconUrl from "@tutti-os/workspace-file-manager/assets/workspace-folder-fallback.png";
 
-export const workspaceFolderFallbackIconUrl = new URL(
-  "./assets/workspace-folder-fallback.png",
-  import.meta.url
-).toString();
+export { workspaceArchiveFallbackIconUrl, workspaceFolderFallbackIconUrl };

--- a/packages/workspace/file-manager/tsup.config.ts
+++ b/packages/workspace/file-manager/tsup.config.ts
@@ -8,7 +8,13 @@ export default defineConfig({
     "i18n/index": "src/i18n/index.ts",
     "services/index": "src/services/index.ts"
   },
-  external: ["react", "react-dom", "valtio"],
+  external: [
+    "@tutti-os/workspace-file-manager/assets/workspace-archive-fallback.png",
+    "@tutti-os/workspace-file-manager/assets/workspace-folder-fallback.png",
+    "react",
+    "react-dom",
+    "valtio"
+  ],
   format: ["esm"],
   sourcemap: true
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1209,6 +1209,25 @@ importers:
         specifier: ^6.3.5
         version: 6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
 
+  tools/fixtures/workspace-file-manager-external-vite:
+    dependencies:
+      "@tutti-os/workspace-file-manager":
+        specifier: workspace:*
+        version: link:../../../packages/workspace/file-manager
+      react:
+        specifier: ^19.1.0
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.6(react@19.2.6)
+      valtio:
+        specifier: ^2.3.2
+        version: 2.3.2(@types/react@19.2.15)(react@19.2.6)
+    devDependencies:
+      vite:
+        specifier: ^6.3.5
+        version: 6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
+
 packages:
   7zip-bin@5.2.0:
     resolution:

--- a/tools/fixtures/workspace-file-manager-external-vite/index.html
+++ b/tools/fixtures/workspace-file-manager-external-vite/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Workspace File Manager Vite Asset Fixture</title>
+  </head>
+  <body>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/tools/fixtures/workspace-file-manager-external-vite/package.json
+++ b/tools/fixtures/workspace-file-manager-external-vite/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@tutti-os/fixture-workspace-file-manager-external-vite",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "test": "pnpm --filter @tutti-os/workspace-file-manager build && node ./vite-dev-assets.test.mjs"
+  },
+  "dependencies": {
+    "@tutti-os/workspace-file-manager": "workspace:*",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "valtio": "^2.3.2"
+  },
+  "devDependencies": {
+    "vite": "^6.3.5"
+  }
+}

--- a/tools/fixtures/workspace-file-manager-external-vite/src/main.ts
+++ b/tools/fixtures/workspace-file-manager-external-vite/src/main.ts
@@ -1,0 +1,3 @@
+import { WorkspaceFileEntryIcon } from "@tutti-os/workspace-file-manager";
+
+globalThis.__workspaceFileManagerFixture = WorkspaceFileEntryIcon;

--- a/tools/fixtures/workspace-file-manager-external-vite/vite-dev-assets.test.mjs
+++ b/tools/fixtures/workspace-file-manager-external-vite/vite-dev-assets.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createServer } from "vite";
+
+const fixtureRoot = dirname(fileURLToPath(import.meta.url));
+const server = await createServer({
+  configFile: fileURLToPath(new URL("./vite.config.ts", import.meta.url)),
+  logLevel: "error",
+  root: fixtureRoot,
+  server: {
+    host: "127.0.0.1",
+    port: 0
+  }
+});
+
+try {
+  await server.listen();
+  const address = server.httpServer?.address();
+  assert.ok(address && typeof address !== "string");
+  const origin = `http://127.0.0.1:${address.port}`;
+
+  const entrySource = await fetchText(`${origin}/src/main.ts`);
+  const optimizedModulePath = matchFirst(
+    entrySource,
+    /from\s+["']([^"']*@tutti-os_workspace-file-manager[^"']*)["']/u,
+    "optimized workspace-file-manager module"
+  );
+  const optimizedSource = await fetchText(
+    new URL(optimizedModulePath, origin).href
+  );
+  assert.doesNotMatch(
+    optimizedSource,
+    /\.vite\/deps\/assets\/workspace-(?:archive|folder)-fallback\.png/u
+  );
+
+  for (const fallbackKind of ["archive", "folder"]) {
+    const assetModulePath = matchFirst(
+      optimizedSource,
+      new RegExp(
+        `["']([^"']*workspace-${fallbackKind}-fallback\\.png\\?[^"']*)["']`,
+        "u"
+      ),
+      `${fallbackKind} fallback asset module`
+    );
+    const assetModuleSource = await fetchText(
+      new URL(assetModulePath, origin).href
+    );
+    const assetPath = matchFirst(
+      assetModuleSource,
+      /export default\s+["']([^"']+)["']/u,
+      `${fallbackKind} fallback asset URL`
+    );
+    const assetResponse = await fetch(new URL(assetPath, origin));
+    assert.equal(assetResponse.status, 200);
+    assert.equal(assetResponse.headers.get("content-type"), "image/png");
+  }
+} finally {
+  await server.close();
+}
+
+async function fetchText(url) {
+  const response = await fetch(url);
+  assert.equal(response.status, 200, `${url} should be served`);
+  return response.text();
+}
+
+function matchFirst(source, pattern, label) {
+  const match = source.match(pattern);
+  assert.ok(match?.[1], `expected ${label}`);
+  return match[1];
+}

--- a/tools/fixtures/workspace-file-manager-external-vite/vite.config.ts
+++ b/tools/fixtures/workspace-file-manager-external-vite/vite.config.ts
@@ -1,0 +1,31 @@
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vite";
+
+const packageRoot = new URL(
+  "../../../packages/workspace/file-manager/dist/",
+  import.meta.url
+);
+
+export default defineConfig({
+  optimizeDeps: {
+    include: ["@tutti-os/workspace-file-manager"]
+  },
+  resolve: {
+    alias: [
+      {
+        find: /^@tutti-os\/workspace-file-manager$/u,
+        replacement: fileURLToPath(new URL("index.js", packageRoot))
+      },
+      ...["archive", "folder"].map((fallbackKind) => ({
+        find: new RegExp(
+          `^@tutti-os/workspace-file-manager/assets/workspace-${fallbackKind}-fallback\\.png$`,
+          "u"
+        ),
+        replacement: fileURLToPath(
+          new URL(`assets/workspace-${fallbackKind}-fallback.png`, packageRoot)
+        )
+      }))
+    ]
+  }
+});

--- a/tools/scripts/check-package-packs.mjs
+++ b/tools/scripts/check-package-packs.mjs
@@ -143,6 +143,24 @@ async function checkPackage(packageConfig, destination) {
     if (/data:image\/png(?:;|,)/i.test(mainEntrySource)) {
       violations.push("PNG data URL embedded in dist/index.js");
     }
+    if (
+      /new URL\(\s*["']\.\/assets\/workspace-(?:archive|folder)-fallback\.png["']/u.test(
+        mainEntrySource
+      )
+    ) {
+      violations.push(
+        "fallback asset URL is relative to the bundled module location"
+      );
+    }
+    for (const assetName of [
+      "workspace-archive-fallback.png",
+      "workspace-folder-fallback.png"
+    ]) {
+      const publicAssetSpecifier = `@tutti-os/workspace-file-manager/assets/${assetName}`;
+      if (!mainEntrySource.includes(publicAssetSpecifier)) {
+        violations.push(`missing public asset import ${publicAssetSpecifier}`);
+      }
+    }
   }
 
   if (violations.length > 0) {


### PR DESCRIPTION
## Summary

- expose archive and folder fallback images through stable package asset subpaths
- preserve those asset imports in the published ESM entry so Vite can resolve them after dependency prebundling
- add pack-contract checks and a real built-package Vite dev regression fixture

## Validation

- `pnpm check:changed`
- `pnpm release:pack:check`
- `pnpm --filter @tutti-os/fixture-workspace-file-manager-external-vite test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->