### PR TITLE
feat(agent-gui): add participant avatar presentation

### DIFF
--- a/.changeset/agent-conversation-participant-presentation.md
+++ b/.changeset/agent-conversation-participant-presentation.md
@@ -1,0 +1,9 @@
+---
+"@tutti-os/agent-gui": minor
+---
+
+Add an opt-in participant presentation contract to the standalone Agent
+conversation renderers. Hosts can explicitly disable avatars, show stable
+loading slots while identity data resolves, or provide user and Agent names and
+avatar URLs while Agent GUI owns the shared Avatar rendering and message-side
+layout.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -420,6 +420,16 @@ text, but they are not an additional transcript text block when the canonical
 structured content already renders the same image. Explicit display prompts
 remain transcript content and continue to replace expanded rich prompt text.
 
+Standalone hosts may opt a transcript into participant avatars through the
+`agent-conversation` entrypoint's explicit presentation contract. Omitted or
+disabled presentation preserves the existing transcript DOM. Enabled
+presentation has distinct `loading` and `ready` states, so the renderer never
+infers identity readiness from a missing image URL. The host supplies user and
+Agent names and optional avatar URLs; AgentGUI owns the UI System Avatar,
+fixed-size loading slot, fallback initial, and user-right/Agent-left layout.
+This presentation input is view data only and must not enter canonical Session,
+Turn, Message, activity-runtime, or workspace-engine state.
+
 ## 5. Agent identity and provider architecture
 
 ### 5.1 `agentTargetId` is UI identity

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -90,6 +90,36 @@ accepted for host capabilities that are not agent activity data:
 AgentGUI has no host-API activity fallback. A host must inject the runtime and
 the grouped `AgentGUINodeProps` responsibility objects.
 
+## Standalone Conversation Participant Presentation
+
+The `@tutti-os/agent-gui/agent-conversation` entrypoint exposes one optional,
+host-owned participant presentation contract on `WorkspaceAgentSessionDetail`,
+`AgentConversationFlow`, and `AgentTranscriptView`:
+
+```tsx
+<WorkspaceAgentSessionDetail
+  participantPresentation={{
+    enabled: true,
+    status: "ready",
+    user: { name: "Alice", avatarUrl: userAvatarUrl },
+    agent: { name: "Codex", avatarUrl: agentAvatarUrl }
+  }}
+  {...props}
+/>
+```
+
+Omitting the property or passing `{ enabled: false }` preserves the existing
+transcript DOM and spacing. Pass `{ enabled: true, status: "loading" }` while
+the host is resolving identities; existing messages stay visible and the
+package renders fixed-size circular loading slots. In the `ready` state, each
+participant requires a non-empty `name`; `avatarUrl` is optional and the shared
+UI System `Avatar` falls back to the name's initial.
+
+The host owns identity lookup and lifecycle. Agent GUI owns placement, sizing,
+loading treatment, image fallback, and left/right message alignment. The
+contract is presentation-only and must not be copied into canonical Session,
+Turn, Message, or workspace-engine state.
+
 ## Session Handoff Drafts
 
 External AgentGUI hosts can use `createAgentSessionHandoffPrompt` to prefill a

--- a/packages/agent/gui/agent-conversation/agentConversation.publicContract.spec.ts
+++ b/packages/agent/gui/agent-conversation/agentConversation.publicContract.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AgentConversationFlowProps,
+  AgentConversationParticipantPresentation,
+  AgentTranscriptViewProps,
+  WorkspaceAgentSessionDetailProps
+} from "./index";
+
+const presentation: AgentConversationParticipantPresentation = {
+  enabled: true,
+  status: "ready",
+  user: {
+    name: "Alice",
+    avatarUrl: "https://example.test/alice.png"
+  },
+  agent: {
+    name: "Codex",
+    avatarUrl: "https://example.test/codex.png"
+  }
+};
+
+const detailPresentation: WorkspaceAgentSessionDetailProps["participantPresentation"] =
+  presentation;
+const flowPresentation: AgentConversationFlowProps["participantPresentation"] =
+  presentation;
+const transcriptPresentation: AgentTranscriptViewProps["participantPresentation"] =
+  presentation;
+
+describe("agent-conversation public contract", () => {
+  it("shares one participant presentation contract across public transcript entrypoints", () => {
+    expect(detailPresentation).toBe(presentation);
+    expect(flowPresentation).toBe(presentation);
+    expect(transcriptPresentation).toBe(presentation);
+  });
+});

--- a/packages/agent/gui/agent-conversation/index.ts
+++ b/packages/agent/gui/agent-conversation/index.ts
@@ -32,6 +32,13 @@ export type {
 } from "../shared/workspaceAgentSessionDetailViewModel";
 
 export type { AgentConversationVM } from "../shared/agentConversation/contracts/agentConversationVM";
+export type {
+  AgentConversationParticipantIdentity,
+  AgentConversationParticipantPresentation
+} from "../shared/agentConversation/contracts/agentConversationParticipantPresentation";
+export type { AgentConversationFlowProps } from "../shared/agentConversation/components/AgentConversationFlow";
+export type { AgentTranscriptViewProps } from "../shared/agentConversation/components/AgentTranscriptView";
+export type { WorkspaceAgentSessionDetailProps } from "../shared/WorkspaceAgentSessionDetail";
 export type { WorkspaceAgentActivityTimelineItem } from "../shared/workspaceAgentTimelineTypes";
 export type { WorkspaceAgentActivityCard } from "../shared/workspaceAgentActivityListViewModel";
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIConversation.styles.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIConversation.styles.ts
@@ -35,6 +35,11 @@ const styles = {
     "agent-gui-conversation__interactive-prompt-actions",
   userMessageFlow: "agent-gui-conversation__user-message-flow",
   assistantMessageFlow: "agent-gui-conversation__assistant-message-flow",
+  participantMessageLayout:
+    "agent-gui-conversation__participant-message-layout",
+  participantMessageContent:
+    "agent-gui-conversation__participant-message-content",
+  participantAvatar: "agent-gui-conversation__participant-avatar",
   messageGroup: "agent-gui-conversation__message-group",
   messageFooter: "agent-gui-conversation__message-footer",
   messageTimestamp: "agent-gui-conversation__message-timestamp",

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -3731,6 +3731,38 @@ aside.workspace-agents-status-panel
   justify-items: end;
 }
 
+.agent-gui-conversation__participant-message-layout {
+  display: grid;
+  width: 100%;
+  min-width: 0;
+  column-gap: 10px;
+  align-items: start;
+}
+
+.agent-gui-conversation__participant-message-layout[data-agent-message-speaker="assistant"] {
+  grid-template-columns: 32px minmax(0, 1fr);
+}
+
+.agent-gui-conversation__participant-message-layout[data-agent-message-speaker="user"] {
+  grid-template-columns: minmax(0, 1fr) 32px;
+}
+
+.agent-gui-conversation__participant-message-content {
+  display: grid;
+  width: 100%;
+  min-width: 0;
+}
+
+.agent-gui-conversation__participant-message-layout[data-agent-message-speaker="user"]
+  > .agent-gui-conversation__participant-message-content {
+  row-gap: 14px;
+  justify-items: end;
+}
+
+.agent-gui-conversation__participant-avatar {
+  margin-top: 2px;
+}
+
 .agent-gui-conversation__message-group {
   position: relative;
   display: grid;

--- a/packages/agent/gui/shared/WorkspaceAgentSessionDetail.tsx
+++ b/packages/agent/gui/shared/WorkspaceAgentSessionDetail.tsx
@@ -2,10 +2,11 @@ import { useMemo, type JSX } from "react";
 import type { WorkspaceLinkAction } from "../contexts/workspace/presentation/renderer/actions/workspaceLinkActions";
 import { translate } from "../i18n/index";
 import { AgentConversationFlow } from "./agentConversation/components/AgentConversationFlow";
+import type { AgentConversationParticipantPresentation } from "./agentConversation/contracts/agentConversationParticipantPresentation";
 import { useProjectedAgentConversation } from "./agentConversation/projection/useProjectedAgentConversation";
 import type { WorkspaceAgentSessionDetailViewModel } from "./workspaceAgentSessionDetailViewModel";
 
-interface WorkspaceAgentSessionDetailProps {
+export interface WorkspaceAgentSessionDetailProps {
   detail: WorkspaceAgentSessionDetailViewModel;
   avoidGroupingEdits?: boolean;
   isLoading: boolean;
@@ -16,6 +17,7 @@ interface WorkspaceAgentSessionDetailProps {
   loadingLabel?: string;
   rawTimelineJsonLabel?: string;
   showRawTimelineJson?: boolean;
+  participantPresentation?: AgentConversationParticipantPresentation;
 }
 
 export function WorkspaceAgentSessionDetail({
@@ -28,7 +30,8 @@ export function WorkspaceAgentSessionDetail({
   thinkingLabel = translate("agentHost.workspaceAgentSessionDetailThinking"),
   loadingLabel = translate("common.loading"),
   rawTimelineJsonLabel,
-  showRawTimelineJson = false
+  showRawTimelineJson = false,
+  participantPresentation
 }: WorkspaceAgentSessionDetailProps): JSX.Element {
   const conversation = useProjectedAgentConversation({
     detail,
@@ -72,6 +75,7 @@ export function WorkspaceAgentSessionDetail({
         empty={emptyState}
         onLinkAction={onLinkAction}
         showRawTimelineJson={showRawTimelineJson}
+        participantPresentation={participantPresentation}
         labels={flowLabels}
       />
     </div>

--- a/packages/agent/gui/shared/agentConversation/components/AgentConversationFlow.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentConversationFlow.tsx
@@ -2,6 +2,7 @@ import { memo, type ReactNode, type JSX, type Ref } from "react";
 import type { WorkspaceLinkAction } from "../../../contexts/workspace/presentation/renderer/actions/workspaceLinkActions";
 import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../AgentMessageMarkdown";
 import type { AgentConversationVM } from "../contracts/agentConversationVM";
+import type { AgentConversationParticipantPresentation } from "../contracts/agentConversationParticipantPresentation";
 import { AgentTranscriptSkeleton } from "./AgentTranscriptSkeleton";
 import {
   AgentTranscriptView,
@@ -11,7 +12,7 @@ import {
 import { AgentTurnDisclosureProvider } from "./AgentTurnDisclosureContext";
 import type { AgentGUIProviderSkillOption } from "../../../agent-gui/agentGuiNode/model/agentGuiNodeTypes";
 
-interface AgentConversationFlowProps {
+export interface AgentConversationFlowProps {
   conversation: AgentConversationVM | null;
   turnAttachments?: readonly AgentTranscriptTurnAttachment[];
   turnAttachmentLocatorRef?: Ref<AgentTranscriptAttachmentLocator>;
@@ -29,6 +30,7 @@ interface AgentConversationFlowProps {
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
   previewMode?: boolean;
   showRawTimelineJson?: boolean;
+  participantPresentation?: AgentConversationParticipantPresentation;
   labels: {
     toolCallsLabel: (count: number) => string;
     thinkingLabel: string;
@@ -54,6 +56,7 @@ export const AgentConversationFlow = memo(function AgentConversationFlow({
   workspaceAppIcons,
   previewMode = false,
   showRawTimelineJson = false,
+  participantPresentation,
   labels
 }: AgentConversationFlowProps): JSX.Element {
   "use memo";
@@ -82,6 +85,7 @@ export const AgentConversationFlow = memo(function AgentConversationFlow({
         previewMode={previewMode}
         labels={labels}
         showRawTimelineJson={showRawTimelineJson}
+        participantPresentation={participantPresentation}
       />
     );
   }

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -6,6 +6,7 @@ import {
   type JSX,
   type ReactNode
 } from "react";
+import { Avatar } from "@tutti-os/ui-system";
 import { CheckIcon, CopyIcon } from "@tutti-os/ui-system/icons";
 import { formatAgentMessageTimestamp } from "../../../app/renderer/shell/utils/format";
 import { AgentPlanCard } from "./AgentPlanCard";
@@ -24,6 +25,10 @@ import type {
   AgentMessageContentVM,
   AgentMessageRowVM
 } from "../contracts/agentMessageRowVM";
+import type {
+  AgentConversationParticipantIdentity,
+  AgentConversationParticipantPresentation
+} from "../contracts/agentConversationParticipantPresentation";
 import { AgentMessageDetailsDisclosure } from "./AgentMessageDetailsDisclosure";
 import {
   AgentVisibleErrorMessage,
@@ -60,6 +65,7 @@ interface AgentMessageBlockProps {
   previewMode?: boolean;
   showRawTimelineJson?: boolean;
   rawTimelineJsonLabel?: string;
+  participantPresentation?: AgentConversationParticipantPresentation;
 }
 
 export function AgentMessageBlock({
@@ -74,7 +80,8 @@ export function AgentMessageBlock({
   workspaceAppIcons,
   previewMode = false,
   showRawTimelineJson = false,
-  rawTimelineJsonLabel = ""
+  rawTimelineJsonLabel = "",
+  participantPresentation
 }: AgentMessageBlockProps): JSX.Element {
   "use memo";
   const agentHostApi = useOptionalAgentHostApi();
@@ -133,6 +140,121 @@ export function AgentMessageBlock({
       ))
     : null;
 
+  const messageContent = row.messages.map((message) => {
+    const rawTimelineJson =
+      showRawTimelineJson &&
+      rawTimelineJsonLabel &&
+      (message.sourceTimelineItems?.length ?? 0) > 0 ? (
+        <RawTimelineJsonDisclosure
+          items={message.sourceTimelineItems}
+          label={rawTimelineJsonLabel}
+        />
+      ) : null;
+    // Recover a structured error card from a terminal message that the
+    // provider reported as plain text, including Claude SDK's completed
+    // standalone login notice.
+    const recoveredError =
+      !isUser && !message.visibleError
+        ? recoverVisibleErrorFromMessage(message, provider)
+        : null;
+    const content =
+      isUser && message.contentKind === "image-grid" ? (
+        <AgentUserImageGrid message={message} />
+      ) : isUser ? (
+        <AgentRichTextReadonly
+          value={message.body}
+          className={`workspace-agents-status-panel__detail-user-message ${styles.userMessageBubble}`}
+          editorClassName="text-[inherit]"
+          onLinkClick={handleLinkClick}
+          availableSkills={availableSkills}
+          workspaceAppIcons={workspaceAppIcons}
+        />
+      ) : message.visibleError ? (
+        <AgentVisibleErrorMessage
+          message={message}
+          onAuthLogin={onAuthLogin}
+          onExternalLink={handleLinkClick}
+        />
+      ) : recoveredError ? (
+        <AgentVisibleErrorMessage
+          message={recoveredError}
+          onAuthLogin={onAuthLogin}
+          onExternalLink={handleLinkClick}
+        />
+      ) : message.systemNotice ? (
+        <AgentSystemNoticeMessage message={message} />
+      ) : message.contentKind === "collaboration" && message.collaboration ? (
+        <AgentCollaborationRow
+          collaboration={message.collaboration}
+          workspaceRoot={workspaceRoot}
+          basePath={basePath}
+          onLinkAction={onLinkAction}
+          workspaceAppIcons={workspaceAppIcons}
+          previewMode={previewMode}
+        />
+      ) : message.contentKind === "plan" ? (
+        <AgentPlanCardMessage
+          message={message}
+          workspaceRoot={workspaceRoot}
+          basePath={basePath}
+          onLinkAction={onLinkAction}
+          workspaceAppIcons={workspaceAppIcons}
+          previewMode={previewMode}
+        />
+      ) : (
+        <AgentMessageMarkdown
+          content={message.body}
+          className={styles.assistantMarkdown}
+          onLinkAction={onLinkAction}
+          workspaceLinkContext={{
+            workspaceRoot,
+            basePath,
+            source: "agent-markdown"
+          }}
+          workspaceAppIcons={workspaceAppIcons}
+          enableImageZoom
+          previewMode={previewMode}
+          streaming={message.statusKind === "working"}
+        />
+      );
+
+    if (rawTimelineJson) {
+      return (
+        <AgentCopyableMessageGroup
+          key={message.id}
+          copyText={message.copyText ?? null}
+          occurredAtUnixMs={message.occurredAtUnixMs}
+          speaker={row.speaker}
+          onCopyMessageText={handleCopyMessageText}
+        >
+          {content}
+          {rawTimelineJson}
+        </AgentCopyableMessageGroup>
+      );
+    }
+
+    const copyText = message.copyText ?? null;
+    if (copyText) {
+      return (
+        <AgentCopyableMessageGroup
+          key={message.id}
+          copyText={copyText}
+          occurredAtUnixMs={message.occurredAtUnixMs}
+          speaker={row.speaker}
+          onCopyMessageText={handleCopyMessageText}
+        >
+          {content}
+        </AgentCopyableMessageGroup>
+      );
+    }
+
+    return <Fragment key={message.id}>{content}</Fragment>;
+  });
+  const enabledParticipantPresentation =
+    participantPresentation?.enabled === true ? participantPresentation : null;
+  const showParticipant =
+    enabledParticipantPresentation !== null && row.messages.length > 0;
+
   return (
     <div
       className={isUser ? styles.userMessageFlow : styles.assistantMessageFlow}
@@ -146,118 +268,68 @@ export function AgentMessageBlock({
       }
     >
       {thinkingContent}
-      {row.messages.map((message) => {
-        const rawTimelineJson =
-          showRawTimelineJson &&
-          rawTimelineJsonLabel &&
-          (message.sourceTimelineItems?.length ?? 0) > 0 ? (
-            <RawTimelineJsonDisclosure
-              items={message.sourceTimelineItems}
-              label={rawTimelineJsonLabel}
+      {showParticipant ? (
+        <div
+          className={styles.participantMessageLayout}
+          data-agent-message-speaker={row.speaker}
+        >
+          {!isUser ? (
+            <AgentConversationParticipantAvatar
+              presentation={enabledParticipantPresentation}
+              speaker="assistant"
             />
-          ) : null;
-        // Recover a structured error card from a terminal message that the
-        // provider reported as plain text, including Claude SDK's completed
-        // standalone login notice.
-        const recoveredError =
-          !isUser && !message.visibleError
-            ? recoverVisibleErrorFromMessage(message, provider)
-            : null;
-        const content =
-          isUser && message.contentKind === "image-grid" ? (
-            <AgentUserImageGrid message={message} />
-          ) : isUser ? (
-            <AgentRichTextReadonly
-              value={message.body}
-              className={`workspace-agents-status-panel__detail-user-message ${styles.userMessageBubble}`}
-              editorClassName="text-[inherit]"
-              onLinkClick={handleLinkClick}
-              availableSkills={availableSkills}
-              workspaceAppIcons={workspaceAppIcons}
+          ) : null}
+          <div className={styles.participantMessageContent}>
+            {messageContent}
+          </div>
+          {isUser ? (
+            <AgentConversationParticipantAvatar
+              presentation={enabledParticipantPresentation}
+              speaker="user"
             />
-          ) : message.visibleError ? (
-            <AgentVisibleErrorMessage
-              message={message}
-              onAuthLogin={onAuthLogin}
-              onExternalLink={handleLinkClick}
-            />
-          ) : recoveredError ? (
-            <AgentVisibleErrorMessage
-              message={recoveredError}
-              onAuthLogin={onAuthLogin}
-              onExternalLink={handleLinkClick}
-            />
-          ) : message.systemNotice ? (
-            <AgentSystemNoticeMessage message={message} />
-          ) : message.contentKind === "collaboration" &&
-            message.collaboration ? (
-            <AgentCollaborationRow
-              collaboration={message.collaboration}
-              workspaceRoot={workspaceRoot}
-              basePath={basePath}
-              onLinkAction={onLinkAction}
-              workspaceAppIcons={workspaceAppIcons}
-              previewMode={previewMode}
-            />
-          ) : message.contentKind === "plan" ? (
-            <AgentPlanCardMessage
-              message={message}
-              workspaceRoot={workspaceRoot}
-              basePath={basePath}
-              onLinkAction={onLinkAction}
-              workspaceAppIcons={workspaceAppIcons}
-              previewMode={previewMode}
-            />
-          ) : (
-            <AgentMessageMarkdown
-              content={message.body}
-              className={styles.assistantMarkdown}
-              onLinkAction={onLinkAction}
-              workspaceLinkContext={{
-                workspaceRoot,
-                basePath,
-                source: "agent-markdown"
-              }}
-              workspaceAppIcons={workspaceAppIcons}
-              enableImageZoom
-              previewMode={previewMode}
-              streaming={message.statusKind === "working"}
-            />
-          );
-
-        if (rawTimelineJson) {
-          return (
-            <AgentCopyableMessageGroup
-              key={message.id}
-              copyText={message.copyText ?? null}
-              occurredAtUnixMs={message.occurredAtUnixMs}
-              speaker={row.speaker}
-              onCopyMessageText={handleCopyMessageText}
-            >
-              {content}
-              {rawTimelineJson}
-            </AgentCopyableMessageGroup>
-          );
-        }
-
-        const copyText = message.copyText ?? null;
-        if (copyText) {
-          return (
-            <AgentCopyableMessageGroup
-              key={message.id}
-              copyText={copyText}
-              occurredAtUnixMs={message.occurredAtUnixMs}
-              speaker={row.speaker}
-              onCopyMessageText={handleCopyMessageText}
-            >
-              {content}
-            </AgentCopyableMessageGroup>
-          );
-        }
-
-        return <Fragment key={message.id}>{content}</Fragment>;
-      })}
+          ) : null}
+        </div>
+      ) : (
+        messageContent
+      )}
     </div>
+  );
+}
+
+function AgentConversationParticipantAvatar({
+  presentation,
+  speaker
+}: {
+  presentation: Extract<
+    AgentConversationParticipantPresentation,
+    { enabled: true }
+  >;
+  speaker: AgentMessageRowVM["speaker"];
+}): JSX.Element {
+  if (presentation.status === "loading") {
+    return (
+      <Avatar
+        aria-hidden="true"
+        className={styles.participantAvatar}
+        data-agent-conversation-participant-avatar={speaker}
+        label=""
+        loading
+        size="md"
+      />
+    );
+  }
+
+  const participant: AgentConversationParticipantIdentity =
+    speaker === "user" ? presentation.user : presentation.agent;
+  return (
+    <Avatar
+      aria-label={participant.name}
+      className={styles.participantAvatar}
+      data-agent-conversation-participant-avatar={speaker}
+      label={participant.name}
+      size="md"
+      src={participant.avatarUrl}
+    />
   );
 }
 

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -260,8 +260,8 @@ describe("AgentTranscriptItemView render stability", () => {
     expect(mockState.markdownStreamingFlags.at(-1)).toBe(false);
   });
 
-  it("renders plain user messages inside a copyable message group", () => {
-    render(
+  it("keeps participant presentation off by default", () => {
+    const { container } = render(
       <AgentMessageBlock
         workspaceRoot="/workspace/demo"
         basePath="/workspace/demo"
@@ -291,6 +291,126 @@ describe("AgentTranscriptItemView render stability", () => {
     expect(
       group.querySelector(".agent-gui-conversation__message-copy-button")
     ).toBeInstanceOf(HTMLButtonElement);
+    expect(
+      container.querySelector("[data-agent-conversation-participant-avatar]")
+    ).toBeNull();
+    expect(
+      container.querySelector(
+        ".agent-gui-conversation__participant-message-layout"
+      )
+    ).toBeNull();
+  });
+
+  it("preserves the existing message DOM when participant presentation is disabled", () => {
+    const { container } = render(
+      <AgentMessageBlock
+        workspaceRoot="/workspace/demo"
+        basePath="/workspace/demo"
+        row={userMessageRow()}
+        thinkingLabel="Thought process"
+        participantPresentation={{ enabled: false }}
+      />
+    );
+
+    expect(
+      container.querySelector(
+        ".agent-gui-conversation__participant-message-layout"
+      )
+    ).toBeNull();
+    expect(
+      container.querySelector("[data-agent-conversation-participant-avatar]")
+    ).toBeNull();
+    expect(
+      container.querySelector(".agent-gui-conversation__user-message-flow")
+        ?.children
+    ).toHaveLength(1);
+  });
+
+  it("renders fixed participant avatar loading slots without hiding messages", () => {
+    const participantPresentation = {
+      enabled: true,
+      status: "loading"
+    } as const;
+    const { container } = render(
+      <>
+        <AgentMessageBlock
+          workspaceRoot="/workspace/demo"
+          basePath="/workspace/demo"
+          row={assistantMessageRow()}
+          thinkingLabel="Thought process"
+          participantPresentation={participantPresentation}
+        />
+        <AgentMessageBlock
+          workspaceRoot="/workspace/demo"
+          basePath="/workspace/demo"
+          row={userMessageRow()}
+          thinkingLabel="Thought process"
+          participantPresentation={participantPresentation}
+        />
+      </>
+    );
+
+    const avatars = container.querySelectorAll(
+      "[data-agent-conversation-participant-avatar]"
+    );
+    expect(avatars).toHaveLength(2);
+    expect(avatars[0]).toHaveAttribute(
+      "data-agent-conversation-participant-avatar",
+      "assistant"
+    );
+    expect(avatars[1]).toHaveAttribute(
+      "data-agent-conversation-participant-avatar",
+      "user"
+    );
+    expect(avatars[0]).toHaveAttribute("data-avatar-state", "loading");
+    expect(avatars[1]).toHaveAttribute("data-avatar-state", "loading");
+    expect(screen.getByText(/Assistant answer/)).toBeInTheDocument();
+    expect(screen.getByText("User asks for a fix")).toBeInTheDocument();
+  });
+
+  it("places the agent avatar left and the user avatar right from external identity data", () => {
+    const participantPresentation = {
+      enabled: true,
+      status: "ready",
+      agent: { name: "Codex" },
+      user: { name: "Alice" }
+    } as const;
+    const { container } = render(
+      <>
+        <AgentMessageBlock
+          workspaceRoot="/workspace/demo"
+          basePath="/workspace/demo"
+          row={assistantMessageRow()}
+          thinkingLabel="Thought process"
+          participantPresentation={participantPresentation}
+        />
+        <AgentMessageBlock
+          workspaceRoot="/workspace/demo"
+          basePath="/workspace/demo"
+          row={userMessageRow()}
+          thinkingLabel="Thought process"
+          participantPresentation={participantPresentation}
+        />
+      </>
+    );
+
+    const assistantLayout = container.querySelector(
+      '.agent-gui-conversation__participant-message-layout[data-agent-message-speaker="assistant"]'
+    );
+    const userLayout = container.querySelector(
+      '.agent-gui-conversation__participant-message-layout[data-agent-message-speaker="user"]'
+    );
+    expect(assistantLayout?.firstElementChild).toHaveAttribute(
+      "aria-label",
+      "Codex"
+    );
+    expect(assistantLayout?.lastElementChild).toHaveClass(
+      "agent-gui-conversation__participant-message-content"
+    );
+    expect(userLayout?.firstElementChild).toHaveClass(
+      "agent-gui-conversation__participant-message-content"
+    );
+    expect(userLayout?.lastElementChild).toHaveAttribute("aria-label", "Alice");
   });
 
   it("copies user message text through the agent host clipboard", async () => {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.tsx
@@ -4,6 +4,7 @@ import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../AgentMessageMar
 import type { AgentGUIProviderSkillOption } from "../../../agent-gui/agentGuiNode/model/agentGuiNodeTypes";
 import { resolveAgentConversationLinkAction } from "../actions/agentConversationLinkActions";
 import type { AgentTranscriptRowVM } from "../contracts/agentTranscriptRowVM";
+import type { AgentConversationParticipantPresentation } from "../contracts/agentConversationParticipantPresentation";
 import { AgentGeneratedImageRow } from "./AgentGeneratedImageRow";
 import { AgentGoalControlRow } from "./AgentGoalControlRow";
 import { AgentMessageBlock } from "./AgentMessageBlock";
@@ -29,6 +30,7 @@ interface AgentTranscriptItemViewProps {
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
   previewMode?: boolean;
   showRawTimelineJson?: boolean;
+  participantPresentation?: AgentConversationParticipantPresentation;
   toolGroupExpanded?: boolean;
   toolGroupExpansionKey?: string;
   onToolGroupExpandedChange?: (key: string, expanded: boolean) => void;
@@ -46,6 +48,7 @@ export const AgentTranscriptItemView = memo(function AgentTranscriptItemView({
   workspaceAppIcons,
   previewMode = false,
   showRawTimelineJson = false,
+  participantPresentation,
   toolGroupExpanded,
   toolGroupExpansionKey,
   onToolGroupExpandedChange
@@ -92,6 +95,7 @@ export const AgentTranscriptItemView = memo(function AgentTranscriptItemView({
           thinkingLabel={labels.thinkingLabel}
           showRawTimelineJson={showRawTimelineJson}
           rawTimelineJsonLabel={labels.rawTimelineJson}
+          participantPresentation={participantPresentation}
         />
       );
     case "tool-group":

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -53,6 +53,70 @@ describe("AgentTranscriptView", () => {
     ).toBe(true);
   });
 
+  it("compares participant presentation by its explicit state and identity data", () => {
+    const labels = {
+      thinkingLabel: "Thought process",
+      toolCallsLabel: (count: number) => `Tool calls (${count})`,
+      processing: "Planning next moves",
+      turnSummary: "Changed files"
+    };
+    const conversation = projectAgentConversationVM(detailViewModel());
+    const baseProps = { conversation, labels };
+
+    expect(
+      areAgentTranscriptViewPropsEqual(baseProps, {
+        ...baseProps,
+        participantPresentation: { enabled: false }
+      })
+    ).toBe(true);
+    expect(
+      areAgentTranscriptViewPropsEqual(
+        {
+          ...baseProps,
+          participantPresentation: { enabled: true, status: "loading" }
+        },
+        {
+          ...baseProps,
+          participantPresentation: { enabled: true, status: "loading" }
+        }
+      )
+    ).toBe(true);
+    expect(
+      areAgentTranscriptViewPropsEqual(
+        {
+          ...baseProps,
+          participantPresentation: { enabled: false }
+        },
+        {
+          ...baseProps,
+          participantPresentation: { enabled: true, status: "loading" }
+        }
+      )
+    ).toBe(false);
+    expect(
+      areAgentTranscriptViewPropsEqual(
+        {
+          ...baseProps,
+          participantPresentation: {
+            enabled: true,
+            status: "ready",
+            user: { name: "Alice", avatarUrl: "user.png" },
+            agent: { name: "Codex", avatarUrl: "agent.png" }
+          }
+        },
+        {
+          ...baseProps,
+          participantPresentation: {
+            enabled: true,
+            status: "ready",
+            user: { name: "Alice", avatarUrl: "user.png" },
+            agent: { name: "Codex", avatarUrl: "agent-v2.png" }
+          }
+        }
+      )
+    ).toBe(false);
+  });
+
   it("rerenders when canonical turn timing changes", () => {
     const labels = {
       thinkingLabel: "Thought process",

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
@@ -14,6 +14,7 @@ import type { WorkspaceLinkAction } from "../../../contexts/workspace/presentati
 import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../AgentMessageMarkdown";
 import type { AgentGUIProviderSkillOption } from "../../../agent-gui/agentGuiNode/model/agentGuiNodeTypes";
 import type { AgentConversationVM } from "../contracts/agentConversationVM";
+import type { AgentConversationParticipantPresentation } from "../contracts/agentConversationParticipantPresentation";
 import { AgentTranscriptItemView } from "./AgentTranscriptItemView";
 import { useAgentTurnDisclosureStore } from "./AgentTurnDisclosureContext";
 import { AgentTurnWorkSection } from "./AgentTurnWorkSection";
@@ -53,7 +54,7 @@ export type {
   AgentTranscriptAttachmentLocator,
   AgentTranscriptTurnAttachment
 } from "./useAgentTranscriptTurnAttachments";
-interface AgentTranscriptViewProps {
+export interface AgentTranscriptViewProps {
   conversation: AgentConversationVM;
   turnAttachments?: readonly AgentTranscriptTurnAttachment[];
   turnAttachmentLocatorRef?: Ref<AgentTranscriptAttachmentLocator>;
@@ -67,6 +68,7 @@ interface AgentTranscriptViewProps {
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
   previewMode?: boolean;
   showRawTimelineJson?: boolean;
+  participantPresentation?: AgentConversationParticipantPresentation;
   labels: {
     toolCallsLabel: (count: number) => string;
     thinkingLabel: string;
@@ -75,6 +77,33 @@ interface AgentTranscriptViewProps {
     rawTimelineJson?: string;
     userMessageLocator?: string;
   };
+}
+
+function participantPresentationEqual(
+  previous: AgentConversationParticipantPresentation | undefined,
+  next: AgentConversationParticipantPresentation | undefined
+): boolean {
+  if (previous === next) {
+    return true;
+  }
+  if ((!previous || !previous.enabled) && (!next || !next.enabled)) {
+    return true;
+  }
+  if (!previous?.enabled || !next?.enabled) {
+    return false;
+  }
+  if (previous.status !== next.status) {
+    return false;
+  }
+  if (previous.status === "loading" || next.status === "loading") {
+    return true;
+  }
+  return (
+    previous.user.name === next.user.name &&
+    previous.user.avatarUrl === next.user.avatarUrl &&
+    previous.agent.name === next.agent.name &&
+    previous.agent.avatarUrl === next.agent.avatarUrl
+  );
 }
 
 function transcriptLabelsEqual(
@@ -169,6 +198,10 @@ export function areAgentTranscriptViewPropsEqual(
       next.onTurnAttachmentVisibilityChange &&
     previous.previewMode === next.previewMode &&
     previous.showRawTimelineJson === next.showRawTimelineJson &&
+    participantPresentationEqual(
+      previous.participantPresentation,
+      next.participantPresentation
+    ) &&
     transcriptLabelsEqual(previous.labels, next.labels)
   );
 }
@@ -184,6 +217,7 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
   workspaceAppIcons,
   previewMode = false,
   showRawTimelineJson = false,
+  participantPresentation,
   labels
 }: AgentTranscriptViewProps): JSX.Element {
   "use memo";
@@ -396,6 +430,7 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
           workspaceAppIcons={workspaceAppIcons}
           previewMode={previewMode}
           showRawTimelineJson={showRawTimelineJson}
+          participantPresentation={participantPresentation}
           toolGroupExpanded={
             row.kind === "tool-group"
               ? expandedToolRows[rowKey] === true

--- a/packages/agent/gui/shared/agentConversation/contracts/agentConversationParticipantPresentation.ts
+++ b/packages/agent/gui/shared/agentConversation/contracts/agentConversationParticipantPresentation.ts
@@ -1,0 +1,19 @@
+export interface AgentConversationParticipantIdentity {
+  name: string;
+  avatarUrl?: string | null;
+}
+
+export type AgentConversationParticipantPresentation =
+  | {
+      enabled: false;
+    }
+  | {
+      enabled: true;
+      status: "loading";
+    }
+  | {
+      enabled: true;
+      status: "ready";
+      user: AgentConversationParticipantIdentity;
+      agent: AgentConversationParticipantIdentity;
+    };


### PR DESCRIPTION
## What changed

- add an opt-in `participantPresentation` contract to the public `@tutti-os/agent-gui/agent-conversation` entrypoint
- keep avatar presentation disabled by default and preserve the existing transcript DOM when omitted or explicitly disabled
- support explicit loading and ready states with host-provided user and Agent identities
- render user-right and Agent-left avatars with the shared UI System `Avatar`
- document the presentation-only ownership boundary and add a minor changeset

## Why

External conversation panels need to provide their own participant identity data while Agent GUI owns consistent avatar layout, loading treatment, and fallback rendering. Some panels do not need avatars, so enablement and loading must be explicit instead of inferred from missing URLs.

## Validation

- `pnpm --filter @tutti-os/agent-gui build`
- `pnpm check:changed`
- push-ready pre-push gate: 13 lanes passed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->