### PR TITLE
fix(agent-gui): preserve message history boundary

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
@@ -1,12 +1,12 @@
 import {
-  type AgentActivityMessagePage,
   type AgentActivitySession,
   type AgentActivitySnapshot
 } from "@tutti-os/agent-activity-core";
 import {
   createAgentActivitySnapshotProjector,
   parseInlineActivityMessages,
-  selectEngineSession
+  selectEngineSession,
+  selectSessionHasOlderMessages
 } from "@tutti-os/agent-activity-core";
 import type { WorkspaceAgentActivityEnsureSessionSynchronizedInput } from "../workspaceAgentActivityService.interface.ts";
 import type { WorkspaceAgentSessionEngineHost } from "./workspaceAgentSessionEngineHost.ts";
@@ -608,14 +608,16 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
     if (this.isSessionTombstoned(workspaceId, agentSessionId)) {
       return;
     }
-    const reconcileMessages = async (
-      sessions: AgentActivitySession[]
-    ): Promise<AgentActivityMessagePage[]> =>
+    const reconcileMessages = async (sessions: AgentActivitySession[]) =>
       Promise.all(
         sessions.map(async (session) => {
           const sessionId = session.agentSessionId;
           const cached =
             this.activitySnapshot(workspaceId).sessionMessagesById[sessionId];
+          const historyBoundary = selectSessionHasOlderMessages(
+            entry.engine.getSnapshot(),
+            sessionId
+          );
           const afterVersion = reconcileAfterVersion(cached ?? []);
           this.reportReconcileTrace({
             agentSessionId: sessionId,
@@ -623,10 +625,11 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
             workspaceId,
             fields: { afterVersion, requestedSessionId: agentSessionId }
           });
-          const page = await reconcileAgentSessionMessagePages({
+          const result = await reconcileAgentSessionMessagePages({
             adapter: entry.adapter,
             agentSessionId: sessionId,
             cached: cached ?? [],
+            historyBoundary,
             shouldAbort: () => this.isSessionTombstoned(workspaceId, sessionId),
             workspaceId
           });
@@ -636,12 +639,12 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
             workspaceId,
             fields: {
               afterVersion,
-              latestVersion: page.latestVersion,
-              messageCount: page.messages.length,
+              latestVersion: result.page.latestVersion,
+              messageCount: result.page.messages.length,
               requestedSessionId: agentSessionId
             }
           });
-          return page;
+          return { agentSessionId: sessionId, ...result };
         })
       );
     const discoveredSessions = [
@@ -675,11 +678,22 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
       "reconcile.combined.state_upsert",
       { live }
     );
-    const reconciledMessages = pages.flatMap((page) => page.messages);
+    const reconciledMessages = pages.flatMap((result) => result.page.messages);
+    const historyBoundaries = pages.flatMap((result) =>
+      result.historyBoundary === undefined
+        ? []
+        : [
+            {
+              agentSessionId: result.agentSessionId,
+              hasOlderMessages: result.historyBoundary
+            }
+          ]
+    );
     for (const message of reconciledMessages) {
       this.emitSessionEvent(workspaceId, hostMessageEventFromCore(message));
     }
     entry.engine.dispatch({
+      ...(historyBoundaries.length > 0 ? { historyBoundaries } : {}),
       messages: reconciledMessages,
       type: "message/snapshotReceived",
       workspaceId
@@ -744,6 +758,10 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
     const entry = this.entry(workspaceId);
     const messages =
       this.activitySnapshot(workspaceId).sessionMessagesById[agentSessionId];
+    const historyBoundary = selectSessionHasOlderMessages(
+      entry.engine.getSnapshot(),
+      agentSessionId
+    );
     const afterVersion = reconcileAfterVersion(messages ?? []);
     this.reportReconcileTrace({
       agentSessionId,
@@ -751,10 +769,11 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
       workspaceId,
       fields: { afterVersion }
     });
-    const page = await reconcileAgentSessionMessagePages({
+    const result = await reconcileAgentSessionMessagePages({
       adapter: entry.adapter,
       agentSessionId,
       cached: messages ?? [],
+      historyBoundary,
       shouldAbort: () => this.isSessionTombstoned(workspaceId, agentSessionId),
       workspaceId
     });
@@ -767,15 +786,25 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
       workspaceId,
       fields: {
         afterVersion,
-        latestVersion: page.latestVersion,
-        messageCount: page.messages.length
+        latestVersion: result.page.latestVersion,
+        messageCount: result.page.messages.length
       }
     });
-    for (const message of page.messages) {
+    for (const message of result.page.messages) {
       this.emitSessionEvent(workspaceId, hostMessageEventFromCore(message));
     }
     entry.engine.dispatch({
-      messages: page.messages,
+      ...(result.historyBoundary === undefined
+        ? {}
+        : {
+            historyBoundaries: [
+              {
+                agentSessionId,
+                hasOlderMessages: result.historyBoundary
+              }
+            ]
+          }),
+      messages: result.page.messages,
       type: "message/snapshotReceived",
       workspaceId
     });

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { AgentActivityMessage } from "@tutti-os/agent-activity-core";
-import { analyzeInlineMessageVersionContinuity } from "./workspaceAgentActivityReconcileMessages.ts";
+import type {
+  AgentActivityAdapter,
+  AgentActivityMessage
+} from "@tutti-os/agent-activity-core";
+import {
+  analyzeInlineMessageVersionContinuity,
+  reconcileAgentSessionMessagePages
+} from "./workspaceAgentActivityReconcileMessages.ts";
 
 test("inline message continuity accepts snapshot cursor gaps already present in the cache", () => {
   const result = analyzeInlineMessageVersionContinuity(
@@ -40,6 +46,89 @@ test("inline message continuity accepts duplicate or stale delivery", () => {
     true
   );
 });
+
+test("initial descending reconcile exposes the exact older-history boundary", async () => {
+  const result = await reconcileAgentSessionMessagePages({
+    adapter: adapter({
+      hasMore: false,
+      latestVersion: 4,
+      messages: [message(2), message(4)]
+    }),
+    agentSessionId: "session-1",
+    cached: [],
+    historyBoundary: undefined,
+    shouldAbort: () => false,
+    workspaceId: "ws-1"
+  });
+
+  assert.equal(result.historyBoundary, false);
+  assert.deepEqual(
+    result.page.messages.map((item) => item.version),
+    [2, 4]
+  );
+});
+
+test("cached realtime messages without a history boundary still reconcile from the newest page", async () => {
+  const requests: unknown[] = [];
+  const result = await reconcileAgentSessionMessagePages({
+    adapter: {
+      listSessionMessages: async (
+        request: Parameters<AgentActivityAdapter["listSessionMessages"]>[0]
+      ) => {
+        requests.push(request);
+        return {
+          hasMore: false,
+          latestVersion: 4,
+          messages: [message(2), message(4)]
+        };
+      }
+    } as unknown as AgentActivityAdapter,
+    agentSessionId: "session-1",
+    cached: [message(4)],
+    historyBoundary: undefined,
+    shouldAbort: () => false,
+    workspaceId: "ws-1"
+  });
+
+  assert.deepEqual(requests, [
+    {
+      agentSessionId: "session-1",
+      limit: 100,
+      order: "desc",
+      workspaceId: "ws-1"
+    }
+  ]);
+  assert.equal(result.historyBoundary, false);
+});
+
+test("incremental ascending reconcile does not claim an older-history boundary", async () => {
+  const result = await reconcileAgentSessionMessagePages({
+    adapter: adapter({
+      hasMore: false,
+      latestVersion: 5,
+      messages: [message(5)]
+    }),
+    agentSessionId: "session-1",
+    cached: [message(4)],
+    historyBoundary: true,
+    shouldAbort: () => false,
+    workspaceId: "ws-1"
+  });
+
+  assert.equal(result.historyBoundary, undefined);
+  assert.deepEqual(
+    result.page.messages.map((item) => item.version),
+    [5]
+  );
+});
+
+function adapter(
+  page: Awaited<ReturnType<AgentActivityAdapter["listSessionMessages"]>>
+): AgentActivityAdapter {
+  return {
+    listSessionMessages: async () => page
+  } as unknown as AgentActivityAdapter;
+}
 
 function message(version: number): AgentActivityMessage {
   return {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.ts
@@ -10,8 +10,14 @@ interface ReconcileAgentSessionMessagePagesInput {
   adapter: AgentActivityAdapter;
   agentSessionId: string;
   cached: AgentActivityMessage[];
+  historyBoundary: boolean | undefined;
   shouldAbort: () => boolean;
   workspaceId: string;
+}
+
+export interface ReconciledAgentSessionMessagePage {
+  historyBoundary?: boolean;
+  page: AgentActivityMessagePage;
 }
 
 export interface InlineMessageVersionContinuity {
@@ -57,14 +63,15 @@ export function analyzeInlineMessageVersionContinuity(
 
 export async function reconcileAgentSessionMessagePages(
   input: ReconcileAgentSessionMessagePagesInput
-): Promise<AgentActivityMessagePage> {
-  if (input.cached.length === 0) {
-    return input.adapter.listSessionMessages({
+): Promise<ReconciledAgentSessionMessagePage> {
+  if (input.historyBoundary === undefined) {
+    const page = await input.adapter.listSessionMessages({
       workspaceId: input.workspaceId,
       agentSessionId: input.agentSessionId,
       limit: 100,
       order: "desc"
     });
+    return { historyBoundary: page.hasMore, page };
   }
 
   const afterVersion = reconcileAfterVersion(input.cached);
@@ -80,12 +87,14 @@ export async function reconcileAgentSessionMessagePages(
     shouldAbort: input.shouldAbort
   });
   return {
-    hasMore: false,
-    latestVersion: result.messages.reduce(
-      (latest, message) => Math.max(latest, message.version),
-      afterVersion
-    ),
-    messages: result.messages
+    page: {
+      hasMore: false,
+      latestVersion: result.messages.reduce(
+        (latest, message) => Math.max(latest, message.version),
+        afterVersion
+      ),
+      messages: result.messages
+    }
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -8,6 +8,7 @@ import {
   selectEngineTurnsForSession,
   selectSessionActivationPresentations,
   selectSessionAttention,
+  selectSessionHasOlderMessages,
   selectSessionMutations
 } from "@tutti-os/agent-activity-core";
 import type { ReporterEventInput } from "../../../analytics/services/reporterService.interface.ts";
@@ -1173,6 +1174,7 @@ test("WorkspaceAgentActivityService reconciles a realtime message version gap be
   await service.load("ws-1");
   await service.listSessionMessages({
     agentSessionId: "session-1",
+    order: "desc",
     workspaceId: "ws-1"
   });
   assert.equal(
@@ -1325,6 +1327,7 @@ test("WorkspaceAgentActivityService reconciles cached messages after reconnect w
   await service.load("ws-1");
   await service.listSessionMessages({
     agentSessionId: "session-1",
+    order: "desc",
     workspaceId: "ws-1"
   });
   assert.ok(connectionListener);
@@ -1846,7 +1849,7 @@ test("WorkspaceAgentActivityService reconciles child sessions and their messages
       ) => {
         messageRequests.push(agentSessionId);
         return {
-          hasMore: false,
+          hasMore: agentSessionId === "child-1",
           latestVersion: 1,
           messages: [
             {
@@ -1897,11 +1900,11 @@ test("WorkspaceAgentActivityService reconciles child sessions and their messages
     snapshot.sessionMessagesById["child-1"]?.[0]?.turnId,
     "child-turn-1"
   );
+  const engineState = service.getSessionEngine("ws-1").getSnapshot();
+  assert.equal(selectSessionHasOlderMessages(engineState, "session-1"), false);
+  assert.equal(selectSessionHasOlderMessages(engineState, "child-1"), true);
   assert.deepEqual(
-    selectEngineTurnsForSession(
-      service.getSessionEngine("ws-1").getSnapshot(),
-      "session-1"
-    ).map((turn) => ({
+    selectEngineTurnsForSession(engineState, "session-1").map((turn) => ({
       turnId: turn.turnId,
       phase: turn.phase,
       updatedAtUnixMs: turn.updatedAtUnixMs,
@@ -1957,6 +1960,60 @@ test("WorkspaceAgentActivityService loads the newest history page first", async 
   assert.deepEqual(requests, [
     { afterVersion: 0, beforeVersion: undefined, limit: 100, order: "desc" }
   ]);
+  assert.equal(
+    selectSessionHasOlderMessages(
+      service.getSessionEngine("ws-1").getSnapshot(),
+      "session-1"
+    ),
+    true
+  );
+});
+
+test("WorkspaceAgentActivityService caches a boundary only for the unbounded newest page", async () => {
+  let hasMore = true;
+  const service = new WorkspaceAgentActivityService({
+    tuttidClient: {
+      listWorkspaceAgentSessionMessages: async () => ({
+        hasMore,
+        latestVersion: 4,
+        messages: []
+      }),
+      listWorkspaceAgentSessions: async () => ({
+        hasMore: false,
+        sessions: [],
+        workspaceId: "ws-1"
+      })
+    } as unknown as TuttidClient,
+    runtimeApi: { logTerminalDiagnostic: async () => {} }
+  });
+
+  await service.listSessionMessages({
+    agentSessionId: "session-1",
+    order: "desc",
+    workspaceId: "ws-1"
+  });
+  assert.equal(
+    selectSessionHasOlderMessages(
+      service.getSessionEngine("ws-1").getSnapshot(),
+      "session-1"
+    ),
+    true
+  );
+
+  hasMore = false;
+  await service.listSessionMessages({
+    afterVersion: 4,
+    agentSessionId: "session-1",
+    order: "asc",
+    workspaceId: "ws-1"
+  });
+  assert.equal(
+    selectSessionHasOlderMessages(
+      service.getSessionEngine("ws-1").getSnapshot(),
+      "session-1"
+    ),
+    true
+  );
 });
 
 test("WorkspaceAgentActivityService drains every incremental history page", async () => {
@@ -2031,6 +2088,14 @@ test("WorkspaceAgentActivityService drains every incremental history page", asyn
       .sessionMessagesById["session-1"]?.map((item) => item.version),
     [100]
   );
+  service.getSessionEngine("ws-1").dispatch({
+    historyBoundaries: [
+      { agentSessionId: "session-1", hasOlderMessages: true }
+    ],
+    messages: [],
+    type: "message/snapshotReceived",
+    workspaceId: "ws-1"
+  });
   mode = "incremental";
   requests.length = 0;
   await (
@@ -2051,6 +2116,13 @@ test("WorkspaceAgentActivityService drains every incremental history page", asyn
       .getSnapshot("ws-1")
       .sessionMessagesById["session-1"]?.map((item) => item.version),
     [100, 200, 300]
+  );
+  assert.equal(
+    selectSessionHasOlderMessages(
+      service.getSessionEngine("ws-1").getSnapshot(),
+      "session-1"
+    ),
+    true
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -283,6 +283,18 @@ export class WorkspaceAgentActivityService
       .then((page) => {
         if (input.cache !== false) {
           entry.engine.dispatch({
+            ...(input.order === "desc" &&
+            input.afterVersion === undefined &&
+            input.beforeVersion === undefined
+              ? {
+                  historyBoundaries: [
+                    {
+                      agentSessionId: input.agentSessionId,
+                      hasOlderMessages: page.hasMore
+                    }
+                  ]
+                }
+              : {}),
             messages: page.messages,
             type: "message/snapshotReceived",
             workspaceId

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -165,6 +165,8 @@ It owns:
 - the host adapter interface
 - canonical session, turn, interaction, message, composer-option, prompt-queue,
   and attention state inside one workspace engine
+- the exact server-confirmed older-history boundary for each canonical
+  per-session message window
 - memoized projection from engine state to the `AgentActivitySnapshot` runtime
   contract
 - message merge, immutable presentation-sequence ordering, mutable version
@@ -812,8 +814,14 @@ the normalized event is applied:
   `session/upserted`, and message buckets are canonicalized as soon as either
   shape reveals a provider-session alias
 - when a session is removed, use its pre-removal identity to delete both the
-  canonical message bucket and any provider-session alias bucket
+  canonical message bucket and any provider-session alias bucket, including
+  their older-history boundaries
 - deduplicate messages by stable message identity and version
+- retain `hasMore` from the initial descending message page as the canonical
+  older-history boundary; incremental ascending and realtime snapshots omit the
+  boundary so their page-continuation result cannot overwrite it
+- never infer older-history availability from message `version`; `version` is
+  the mutable incremental cursor
 - treat transcript `message_update` messages as normalized input: each message
   must have `messageId`, positive `version`/`seq`, nullable `turnId`, and
   `occurredAtUnixMs` before core merges it

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -273,6 +273,8 @@ One `(workspaceId, runtime origin)` maps to one `AgentSessionEngine`. Panel unmo
 The engine owns:
 
 - canonical Session, Turn, Interaction, and Message indexes
+- the exact server-confirmed older-history boundary for each canonical
+  per-Session message window
 - pending activation/submit intents and optimistic projections
 - prompt queue, send-now, and cancel-then-send coordination
 - session mutation, settings, composer options, and operation state
@@ -328,6 +330,11 @@ notice does not offer a manual retry because transport recovery is host-owned.
 - realtime authoritative entities use upsert intents
 - message updates fold inline only when unseen versions are continuous
 - version gaps and reconnects trigger incremental message reconciliation for hydrated Sessions
+- the initial descending message page carries its exact `hasMore` boundary into
+  the engine; realtime and incremental ascending updates omit that boundary and
+  must not overwrite it
+- `version` remains a mutable update cursor and must not be used to infer
+  whether older pages exist
 - Turn, Interaction, and legacy state invalidation trigger authoritative Session reconciliation
 - realtime provenance survives until the authoritative result reaches the engine; fetch failure must not downgrade it to historical
 
@@ -392,7 +399,12 @@ Relative time uses one renderer-realm minute clock. Timestamp leaves subscribe d
 
 Rail selection, detail hydration, older-page loading, and transcript projection are separate states.
 
-A focused controller may own detail paging/loading/error. Canonical messages, Turns, Interactions, and optimistic prompts still come from the engine. An empty message list means neither hydrated nor not-found.
+A focused controller owns older-page requests, loading/error state, and
+UI-local prepended pages. It reads the engine's exact older-history boundary
+for the canonical window and replaces that boundary only with an explicit
+older-page response. Canonical messages, Turns, Interactions, and optimistic
+prompts still come from the engine. An empty message list means neither hydrated
+nor not-found.
 
 Timeline projection is pure, deterministic, and provider-neutral. React views render rows/cards and dispatch actions.
 

--- a/packages/agent/activity-core/src/engine/pendingIntents.types.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.types.ts
@@ -246,7 +246,18 @@ export interface SubmitCanceledIntent {
 export interface ActivityMessagesReceivedIntent {
   type: "message/snapshotReceived";
   messages: readonly AgentActivityMessage[];
+  /**
+   * Exact server-confirmed history boundaries for the canonical message
+   * windows in this snapshot. Omission means this snapshot carries no history
+   * boundary information, as with realtime or incremental-ascending updates.
+   */
+  historyBoundaries?: readonly AgentActivityMessageHistoryBoundary[];
   workspaceId?: string;
+}
+
+export interface AgentActivityMessageHistoryBoundary {
+  agentSessionId: string;
+  hasOlderMessages: boolean;
 }
 
 export type PendingIntentsIntent =

--- a/packages/agent/activity-core/src/engine/sessionMessages.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionMessages.reducer.test.ts
@@ -51,6 +51,46 @@ test("merges messages into the canonical session bucket", () => {
   );
 });
 
+test("records an exact older-history boundary even when the page is empty", () => {
+  const state = sessionMessagesReducer(
+    createInitialSessionMessagesState(),
+    {
+      type: "message/snapshotReceived",
+      messages: [],
+      historyBoundaries: [
+        { agentSessionId: "session-1", hasOlderMessages: false }
+      ]
+    },
+    context
+  ).state;
+
+  assert.equal(state.hasOlderMessagesBySessionId["session-1"], false);
+});
+
+test("an incremental message snapshot does not overwrite the older-history boundary", () => {
+  let state = sessionMessagesReducer(
+    createInitialSessionMessagesState(),
+    {
+      type: "message/snapshotReceived",
+      messages: [],
+      historyBoundaries: [
+        { agentSessionId: "session-1", hasOlderMessages: true }
+      ]
+    },
+    context
+  ).state;
+  state = sessionMessagesReducer(
+    state,
+    {
+      type: "message/snapshotReceived",
+      messages: [message({ messageId: "m2", agentSessionId: "session-1" })]
+    },
+    context
+  ).state;
+
+  assert.equal(state.hasOlderMessagesBySessionId["session-1"], true);
+});
+
 test("a higher version replaces the existing message; a lower version is dropped", () => {
   let state = sessionMessagesReducer(
     createInitialSessionMessagesState(),
@@ -136,6 +176,41 @@ test("session identity arrival folds an existing provider alias bucket", () => {
   );
 });
 
+test("session identity arrival folds an existing history boundary alias", () => {
+  let state = sessionMessagesReducer(
+    createInitialSessionMessagesState(),
+    {
+      type: "message/snapshotReceived",
+      historyBoundaries: [
+        { agentSessionId: "provider-1", hasOlderMessages: false }
+      ],
+      messages: []
+    },
+    { sessionsById: {} }
+  ).state;
+  state = sessionMessagesReducer(
+    state,
+    {
+      type: "session/upserted",
+      session: {
+        activeTurnId: null,
+        agentSessionId: "session-1",
+        cwd: "/workspace",
+        latestTurnInteractions: [],
+        pendingInteractions: [],
+        provider: "codex",
+        providerSessionId: "provider-1",
+        title: "Session",
+        workspaceId: "workspace-1"
+      }
+    },
+    context
+  ).state;
+
+  assert.equal(state.hasOlderMessagesBySessionId["provider-1"], undefined);
+  assert.equal(state.hasOlderMessagesBySessionId["session-1"], false);
+});
+
 test("session/removed drops the session bucket", () => {
   let state = sessionMessagesReducer(
     createInitialSessionMessagesState(),
@@ -170,4 +245,30 @@ test("session/removed drops a provider alias bucket using previous identity", ()
     { previousSessionsById: context.sessionsById, sessionsById: {} }
   ).state;
   assert.equal(state.messagesBySessionId["provider-1"], undefined);
+});
+
+test("session/removed drops canonical and provider history boundaries", () => {
+  let state = sessionMessagesReducer(
+    createInitialSessionMessagesState(),
+    {
+      type: "message/snapshotReceived",
+      historyBoundaries: [
+        { agentSessionId: "session-1", hasOlderMessages: true },
+        { agentSessionId: "provider-1", hasOlderMessages: false }
+      ],
+      messages: []
+    },
+    { sessionsById: {} }
+  ).state;
+  state = sessionMessagesReducer(
+    state,
+    {
+      type: "session/removed",
+      agentSessionId: "session-1"
+    },
+    { previousSessionsById: context.sessionsById, sessionsById: {} }
+  ).state;
+
+  assert.equal(state.hasOlderMessagesBySessionId["session-1"], undefined);
+  assert.equal(state.hasOlderMessagesBySessionId["provider-1"], undefined);
 });

--- a/packages/agent/activity-core/src/engine/sessionMessages.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionMessages.reducer.ts
@@ -4,6 +4,7 @@ import {
   mergeAgentActivityMessages
 } from "../merge.ts";
 import type { EngineIntent, EngineReducerResult } from "./types.ts";
+import type { AgentActivityMessageHistoryBoundary } from "./pendingIntents.types.ts";
 import type { SessionMessagesState } from "./sessionMessages.types.ts";
 
 const NO_COMMANDS = [] as const;
@@ -28,7 +29,7 @@ export interface SessionMessagesReducerContext {
 }
 
 export function createInitialSessionMessagesState(): SessionMessagesState {
-  return { messagesBySessionId: {} };
+  return { hasOlderMessagesBySessionId: {}, messagesBySessionId: {} };
 }
 
 export function sessionMessagesReducer(
@@ -38,10 +39,15 @@ export function sessionMessagesReducer(
 ): EngineReducerResult<SessionMessagesState> {
   switch (intent.type) {
     case "message/snapshotReceived":
-      return mergeIncomingMessages(state, context, intent.messages);
+      return mergeIncomingSnapshot(
+        state,
+        context,
+        intent.messages,
+        intent.historyBoundaries
+      );
     case "session/snapshotReceived":
     case "session/upserted":
-      return canonicalizeMessageBuckets(state, context.sessionsById);
+      return canonicalizeSessionMessageState(state, context.sessionsById);
     case "session/removed":
       return dropSessionBuckets(
         state,
@@ -53,12 +59,12 @@ export function sessionMessagesReducer(
   }
 }
 
-function mergeIncomingMessages(
+function mergeIncomingSnapshot(
   state: SessionMessagesState,
   context: SessionMessagesReducerContext,
-  messages: readonly AgentActivityMessage[]
+  messages: readonly AgentActivityMessage[],
+  historyBoundaries: readonly AgentActivityMessageHistoryBoundary[] | undefined
 ): EngineReducerResult<SessionMessagesState> {
-  if (messages.length === 0) return unchanged(state);
   const bySessionId = new Map<string, AgentActivityMessage[]>();
   for (const message of messages) {
     const rawId = message.agentSessionId.trim();
@@ -71,9 +77,52 @@ function mergeIncomingMessages(
   for (const [rawId, sessionMessages] of bySessionId) {
     next = mergeSessionMessages(next, context, rawId, sessionMessages);
   }
-  return next === state.messagesBySessionId
+  const hasOlderMessagesBySessionId = mergeHistoryBoundaries(
+    state.hasOlderMessagesBySessionId,
+    context,
+    historyBoundaries
+  );
+  return next === state.messagesBySessionId &&
+    hasOlderMessagesBySessionId === state.hasOlderMessagesBySessionId
     ? unchanged(state)
-    : changed({ messagesBySessionId: next });
+    : changed({
+        ...state,
+        hasOlderMessagesBySessionId,
+        messagesBySessionId: next
+      });
+}
+
+function mergeHistoryBoundaries(
+  current: Readonly<Record<string, boolean>>,
+  context: SessionMessagesReducerContext,
+  boundaries: readonly AgentActivityMessageHistoryBoundary[] | undefined
+): Readonly<Record<string, boolean>> {
+  let next = current;
+  for (const boundary of boundaries ?? []) {
+    const rawId = boundary.agentSessionId.trim();
+    const agentSessionId = resolveCanonicalAgentSessionId(
+      context.sessionsById,
+      rawId
+    );
+    if (!agentSessionId) {
+      continue;
+    }
+    const hasAlias =
+      rawId !== agentSessionId &&
+      Object.prototype.hasOwnProperty.call(next, rawId);
+    if (next[agentSessionId] === boundary.hasOlderMessages && !hasAlias) {
+      continue;
+    }
+    if (next[agentSessionId] !== boundary.hasOlderMessages) {
+      next = { ...next, [agentSessionId]: boundary.hasOlderMessages };
+    }
+    if (hasAlias) {
+      const withoutAlias = { ...next };
+      delete withoutAlias[rawId];
+      next = withoutAlias;
+    }
+  }
+  return next;
 }
 
 /**
@@ -134,11 +183,11 @@ function mergeSessionMessages(
   return next;
 }
 
-function canonicalizeMessageBuckets(
+function canonicalizeSessionMessageState(
   state: SessionMessagesState,
   sessionsById: Readonly<Record<string, SessionMessagesSessionIdentity>>
 ): EngineReducerResult<SessionMessagesState> {
-  let next = state.messagesBySessionId;
+  let messagesBySessionId = state.messagesBySessionId;
   for (const [rawAgentSessionId, messages] of Object.entries(
     state.messagesBySessionId
   )) {
@@ -153,20 +202,54 @@ function canonicalizeMessageBuckets(
       continue;
     }
     const merged = mergeAgentActivityMessages(
-      next[canonicalAgentSessionId] ?? [],
+      messagesBySessionId[canonicalAgentSessionId] ?? [],
       canonicalizeMessages(messages, canonicalAgentSessionId)
     );
-    next = deleteBucket(
+    messagesBySessionId = deleteBucket(
       {
-        ...next,
+        ...messagesBySessionId,
         [canonicalAgentSessionId]: merged
       },
       rawAgentSessionId
     );
   }
-  return next === state.messagesBySessionId
+  const hasOlderMessagesBySessionId = canonicalizeHistoryBoundaries(
+    state.hasOlderMessagesBySessionId,
+    sessionsById
+  );
+  return messagesBySessionId === state.messagesBySessionId &&
+    hasOlderMessagesBySessionId === state.hasOlderMessagesBySessionId
     ? unchanged(state)
-    : changed({ messagesBySessionId: next });
+    : changed({
+        ...state,
+        hasOlderMessagesBySessionId,
+        messagesBySessionId
+      });
+}
+
+function canonicalizeHistoryBoundaries(
+  current: Readonly<Record<string, boolean>>,
+  sessionsById: Readonly<Record<string, SessionMessagesSessionIdentity>>
+): Readonly<Record<string, boolean>> {
+  let next = current;
+  for (const [rawAgentSessionId, hasOlderMessages] of Object.entries(current)) {
+    const canonicalAgentSessionId = resolveCanonicalAgentSessionId(
+      sessionsById,
+      rawAgentSessionId
+    );
+    if (
+      !canonicalAgentSessionId ||
+      canonicalAgentSessionId === rawAgentSessionId
+    ) {
+      continue;
+    }
+    const canonicalValue = next[canonicalAgentSessionId];
+    next = deleteBoundary(next, rawAgentSessionId);
+    if (canonicalValue === undefined) {
+      next = { ...next, [canonicalAgentSessionId]: hasOlderMessages };
+    }
+  }
+  return next;
 }
 
 function dropSessionBuckets(
@@ -191,15 +274,34 @@ function dropSessionBuckets(
   ) {
     removableIds.add(providerSessionId);
   }
-  let next = state.messagesBySessionId;
+  let messagesBySessionId = state.messagesBySessionId;
+  let hasOlderMessagesBySessionId = state.hasOlderMessagesBySessionId;
   for (const removableId of removableIds) {
-    if (Object.prototype.hasOwnProperty.call(next, removableId)) {
-      next = deleteBucket(next, removableId);
+    if (
+      Object.prototype.hasOwnProperty.call(messagesBySessionId, removableId)
+    ) {
+      messagesBySessionId = deleteBucket(messagesBySessionId, removableId);
+    }
+    if (
+      Object.prototype.hasOwnProperty.call(
+        hasOlderMessagesBySessionId,
+        removableId
+      )
+    ) {
+      hasOlderMessagesBySessionId = deleteBoundary(
+        hasOlderMessagesBySessionId,
+        removableId
+      );
     }
   }
-  return next === state.messagesBySessionId
+  return messagesBySessionId === state.messagesBySessionId &&
+    hasOlderMessagesBySessionId === state.hasOlderMessagesBySessionId
     ? unchanged(state)
-    : changed({ messagesBySessionId: next });
+    : changed({
+        ...state,
+        hasOlderMessagesBySessionId,
+        messagesBySessionId
+      });
 }
 
 /**
@@ -249,6 +351,15 @@ function deleteBucket(
   agentSessionId: string
 ): Record<string, readonly AgentActivityMessage[]> {
   const next = { ...messagesBySessionId };
+  delete next[agentSessionId];
+  return next;
+}
+
+function deleteBoundary(
+  boundariesBySessionId: Readonly<Record<string, boolean>>,
+  agentSessionId: string
+): Readonly<Record<string, boolean>> {
+  const next = { ...boundariesBySessionId };
   delete next[agentSessionId];
   return next;
 }

--- a/packages/agent/activity-core/src/engine/sessionMessages.selectors.ts
+++ b/packages/agent/activity-core/src/engine/sessionMessages.selectors.ts
@@ -17,3 +17,11 @@ export function selectSessionMessages(
   if (!id) return EMPTY_MESSAGES;
   return state.sessionMessages.messagesBySessionId[id] ?? EMPTY_MESSAGES;
 }
+
+export function selectSessionHasOlderMessages(
+  state: AgentSessionEngineState,
+  agentSessionId: string | null | undefined
+): boolean | undefined {
+  const id = agentSessionId?.trim() ?? "";
+  return id ? state.sessionMessages.hasOlderMessagesBySessionId[id] : undefined;
+}

--- a/packages/agent/activity-core/src/engine/sessionMessages.types.ts
+++ b/packages/agent/activity-core/src/engine/sessionMessages.types.ts
@@ -1,6 +1,7 @@
 import type { AgentActivityMessage } from "../types.ts";
 
 export interface SessionMessagesState {
+  hasOlderMessagesBySessionId: Readonly<Record<string, boolean>>;
   messagesBySessionId: Readonly<
     Record<string, readonly AgentActivityMessage[]>
   >;

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -108,6 +108,7 @@ export {
   selectSessionAttention
 } from "./engine/attentionReadState.selectors.ts";
 export {
+  selectSessionHasOlderMessages,
   selectSessionMessages,
   selectSessionMessagesById
 } from "./engine/sessionMessages.selectors.ts";
@@ -217,6 +218,7 @@ export type {
 } from "./engine/promptQueue.types.ts";
 export type {
   ActivityMessagesReceivedIntent,
+  AgentActivityMessageHistoryBoundary,
   PendingActivationIntentRecord,
   PendingActivationStatus,
   PendingIntentsIntent,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.conversationHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.conversationHelpers.ts
@@ -53,7 +53,6 @@ export {
   maxFiniteMessageVersion,
   minFiniteMessageVersion,
   sessionHasRenderableMessages,
-  sessionViewHasUnhydratedOlderDetailMessages,
   windowHasTurnMissingUserPrompt
 } from "./useAgentConversationMessagePaging";
 export function buildContinueInNewConversationPrompt(input: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.ts
@@ -72,7 +72,6 @@ export {
   maxFiniteMessageVersion,
   minFiniteMessageVersion,
   sessionHasRenderableMessages,
-  sessionViewHasUnhydratedOlderDetailMessages,
   windowHasTurnMissingUserPrompt
 } from "./useAgentConversationMessagePaging";
 export interface AgentGUIOpenSessionRequest {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.reporting.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.reporting.ts
@@ -65,7 +65,6 @@ export {
   maxFiniteMessageVersion,
   minFiniteMessageVersion,
   sessionHasRenderableMessages,
-  sessionViewHasUnhydratedOlderDetailMessages,
   windowHasTurnMissingUserPrompt
 } from "./useAgentConversationMessagePaging";
 export type AgentGUIRuntimeErrorPhase =

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.stableHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.stableHelpers.ts
@@ -58,7 +58,6 @@ export {
   maxFiniteMessageVersion,
   minFiniteMessageVersion,
   sessionHasRenderableMessages,
-  sessionViewHasUnhydratedOlderDetailMessages,
   windowHasTurnMissingUserPrompt
 } from "./useAgentConversationMessagePaging";
 export function stableConversationSummaryList(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationMessagePaging.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationMessagePaging.spec.tsx
@@ -45,6 +45,46 @@ describe("useAgentConversationMessagePaging", () => {
     expect(reconcileDetail).toHaveBeenCalledWith("historical-session");
   });
 
+  it("does not infer an older page from a non-contiguous mutable version cursor", async () => {
+    const listSessionMessages = vi.fn();
+    const { result } = renderHook(() =>
+      useAgentConversationMessagePaging({
+        diagnostics: { error: vi.fn(), page: vi.fn() },
+        getActiveSessionId: () => "historical-session",
+        getCanonicalMessages: () => [],
+        isMounted: () => true,
+        projection: {
+          maxVersion: () => 4,
+          minVersion: () => 2,
+          windowHasTurnMissingUserPrompt: () => false
+        },
+        reload: {
+          getActivationStatus: () => null,
+          reconcileDetail: vi.fn(),
+          syncConversationList: vi.fn()
+        },
+        runtime: { listSessionMessages } as unknown as AgentActivityRuntime,
+        sessionViewRef: (agentSessionId) => ({
+          agentSessionId,
+          origin: "test",
+          workspaceId: "workspace-1"
+        }),
+        view: {
+          get: () => null,
+          mergeOlder: vi.fn(),
+          setOlderMessagesLoading: vi.fn()
+        },
+        workspaceId: "workspace-1"
+      })
+    );
+
+    await act(async () => {
+      await result.current.loadOlderMessages("historical-session");
+    });
+
+    expect(listSessionMessages).not.toHaveBeenCalled();
+  });
+
   it("clears older-message loading after a successful page", async () => {
     const mergeOlder = vi.fn();
     const setOlderMessagesLoading = vi.fn();

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationMessagePaging.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationMessagePaging.ts
@@ -148,29 +148,6 @@ export function filterMessagesForDetailWindowOverlay(input: {
   );
 }
 
-export function sessionViewHasUnhydratedOlderDetailMessages(input: {
-  agentSessionId: string;
-  detailMessages: readonly AgentActivityMessage[];
-  hasLoadedInitialMessages: boolean;
-  hasOlderMessages: boolean;
-  oldestLoadedVersion: number | null;
-  snapshotMessagesById: Record<string, AgentActivityMessage[]>;
-}): boolean {
-  if (
-    input.hasLoadedInitialMessages ||
-    input.hasOlderMessages ||
-    input.detailMessages.length === 0
-  )
-    return false;
-  const oldest =
-    input.oldestLoadedVersion ?? minFiniteMessageVersion(input.detailMessages);
-  if (oldest === null) return false;
-  const snapshotOldest = minFiniteMessageVersion(
-    input.snapshotMessagesById[input.agentSessionId] ?? []
-  );
-  return oldest > 1 || (snapshotOldest !== null && snapshotOldest < oldest);
-}
-
 export function sessionHasRenderableMessages(input: {
   agentSessionId: string;
   snapshotMessagesById: Record<string, AgentActivityMessage[]>;
@@ -276,11 +253,7 @@ export function useAgentConversationMessagePaging(
       );
       const oldestLoadedVersion =
         view?.oldestLoadedVersion ?? canonicalOldestVersion;
-      const hasOlderMessages =
-        view?.hasOlderMessages === true ||
-        (view?.oldestLoadedVersion == null &&
-          canonicalOldestVersion !== null &&
-          canonicalOldestVersion > 1);
+      const hasOlderMessages = view?.hasOlderMessages === true;
       if (
         !hasOlderMessages ||
         view?.isLoadingOlderMessages === true ||

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -95,7 +95,6 @@ export {
   maxFiniteMessageVersion,
   minFiniteMessageVersion,
   sessionHasRenderableMessages,
-  sessionViewHasUnhydratedOlderDetailMessages,
   windowHasTurnMissingUserPrompt
 } from "./useAgentConversationMessagePaging";
 export { resolveConversationSummaryById } from "./useAgentConversationSelection";

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionDetailTransport.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionDetailTransport.ts
@@ -1,5 +1,6 @@
 import {
   selectLatestActivationForSession,
+  selectSessionHasOlderMessages,
   type SessionReconcileScope,
   type AgentActivitySnapshot,
   type AgentSessionEngine
@@ -21,6 +22,7 @@ import {
   useAgentConversationMessagePaging,
   windowHasTurnMissingUserPrompt
 } from "./useAgentConversationMessagePaging";
+import { useEngineSelector } from "../../../shared/engine/useEngineSelector";
 
 export function useAgentGUISessionDetailTransport(input: {
   activeConversationId: string | null;
@@ -65,11 +67,17 @@ export function useAgentGUISessionDetailTransport(input: {
     }),
     [agentActivityRuntimeOrigin, workspaceId]
   );
+  const canonicalHasOlderMessages = useEngineSelector(
+    sessionEngine,
+    (engineState) =>
+      selectSessionHasOlderMessages(engineState, activeConversationId)
+  );
   const state = useAgentSessionControllerState(
     sessionViewRef(activeConversationId),
     activeConversationId
       ? (agentActivitySnapshot.sessionMessagesById[activeConversationId] ?? [])
-      : []
+      : [],
+    canonicalHasOlderMessages
   );
   const resolveSessionMessages = useCallback(
     (agentSessionId: string | null | undefined) => {
@@ -160,7 +168,10 @@ export function useAgentGUISessionDetailTransport(input: {
     runtime: agentActivityRuntime,
     sessionViewRef,
     view: {
-      get: state.getAgentSessionView,
+      get: (ref) =>
+        ref.agentSessionId?.trim() === activeConversationId
+          ? state.activeSessionView
+          : state.getAgentSessionView(ref),
       mergeOlder: state.mergeAgentSessionViewOlderMessages,
       setOlderMessagesLoading: state.setAgentSessionViewOlderMessagesLoading
     },

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/useAgentSessionControllerState.spec.tsx
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/useAgentSessionControllerState.spec.tsx
@@ -23,9 +23,24 @@ function message(version: number): AgentActivityMessage {
 }
 
 describe("useAgentSessionControllerState", () => {
+  it("uses the exact engine boundary instead of inferring history from message versions", () => {
+    const { result } = renderHook(() =>
+      useAgentSessionControllerState(
+        ACTIVE_REF,
+        [message(2), message(4)],
+        false
+      )
+    );
+
+    expect(result.current.activeSessionView).toMatchObject({
+      hasOlderMessages: false,
+      oldestLoadedVersion: 2
+    });
+  });
+
   it("keeps a terminal older page authoritative over the bounded canonical window", () => {
     const { result } = renderHook(() =>
-      useAgentSessionControllerState(ACTIVE_REF, [message(446)])
+      useAgentSessionControllerState(ACTIVE_REF, [message(446)], true)
     );
 
     expect(result.current.activeSessionView?.hasOlderMessages).toBe(true);

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/useAgentSessionControllerState.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/useAgentSessionControllerState.ts
@@ -8,7 +8,8 @@ import {
 
 export function useAgentSessionControllerState(
   activeRef: AgentSessionViewRef,
-  canonicalMessages: readonly AgentActivityMessage[] = []
+  canonicalMessages: readonly AgentActivityMessage[] = [],
+  canonicalHasOlderMessages?: boolean
 ) {
   const transport = useAgentSessionTransport();
   const paging = useAgentSessionPagingState();
@@ -20,14 +21,15 @@ export function useAgentSessionControllerState(
         ? {
             ...(transportEntry ?? {
               olderMessages: [],
-              hasOlderMessages: false,
+              hasOlderMessages: null,
               oldestLoadedVersion: null
             }),
             ...(pagingEntry ?? {
               error: null,
               isLoadingMessages: false,
               isLoadingOlderMessages: false
-            })
+            }),
+            hasOlderMessages: transportEntry?.hasOlderMessages ?? false
           }
         : null;
     },
@@ -52,36 +54,37 @@ export function useAgentSessionControllerState(
   );
   void transport.entries;
   void paging.entries;
-  const storedActiveView = getAgentSessionView(activeRef);
+  const storedActiveTransport = transport.get(activeRef);
+  const storedActivePaging = paging.get(activeRef);
   const canonicalOldestVersion = oldestVersion(canonicalMessages);
-  const activeSessionView = storedActiveView
+  const hasActiveView =
+    storedActiveTransport !== null ||
+    storedActivePaging !== null ||
+    canonicalOldestVersion !== null ||
+    canonicalHasOlderMessages !== undefined;
+  const activeSessionView = hasActiveView
     ? {
-        ...storedActiveView,
+        error: storedActivePaging?.error ?? null,
         hasOlderMessages:
-          storedActiveView.hasOlderMessages ||
-          (storedActiveView.oldestLoadedVersion === null &&
-            canonicalOldestVersion !== null &&
-            canonicalOldestVersion > 1),
+          storedActiveTransport?.hasOlderMessages ??
+          canonicalHasOlderMessages ??
+          false,
+        isLoadingMessages: storedActivePaging?.isLoadingMessages ?? false,
+        isLoadingOlderMessages:
+          storedActivePaging?.isLoadingOlderMessages ?? false,
+        olderMessages: storedActiveTransport?.olderMessages ?? [],
         oldestLoadedVersion:
-          storedActiveView.oldestLoadedVersion === null
+          storedActiveTransport?.oldestLoadedVersion === null ||
+          storedActiveTransport === null
             ? canonicalOldestVersion
             : canonicalOldestVersion === null
-              ? storedActiveView.oldestLoadedVersion
+              ? storedActiveTransport.oldestLoadedVersion
               : Math.min(
-                  storedActiveView.oldestLoadedVersion,
+                  storedActiveTransport.oldestLoadedVersion,
                   canonicalOldestVersion
                 )
       }
-    : canonicalOldestVersion === null
-      ? null
-      : {
-          error: null,
-          hasOlderMessages: canonicalOldestVersion > 1,
-          isLoadingMessages: false,
-          isLoadingOlderMessages: false,
-          olderMessages: [],
-          oldestLoadedVersion: canonicalOldestVersion
-        };
+    : null;
   return {
     activeSessionView,
     deleteAgentSessionView,

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/useAgentSessionTransport.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/useAgentSessionTransport.ts
@@ -10,13 +10,13 @@ export interface AgentSessionViewRef {
 
 export interface AgentSessionTransportEntry {
   olderMessages: AgentActivityMessage[];
-  hasOlderMessages: boolean;
+  hasOlderMessages: boolean | null;
   oldestLoadedVersion: number | null;
 }
 
 const EMPTY_ENTRY: AgentSessionTransportEntry = {
   olderMessages: [],
-  hasOlderMessages: false,
+  hasOlderMessages: null,
   oldestLoadedVersion: null
 };
 
@@ -86,7 +86,7 @@ export function useAgentSessionTransport() {
       update(ref, (entry) => ({
         ...entry,
         olderMessages: [],
-        hasOlderMessages: false,
+        hasOlderMessages: null,
         oldestLoadedVersion: null
       })),
     [update]


### PR DESCRIPTION
## Summary

- preserve the initial descending message page's exact `hasMore` boundary in the workspace engine
- stop inferring older-message availability from mutable message versions
- keep realtime and incremental reconciliation from overwriting the per-session history boundary

## Tests

- `pnpm check:changed -- --push-ready`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm perf:agent-gui -- --scenario session-switch`

## Notes

- the performance scenario passed in report-only mode; render-churn optimization remains out of scope

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->