### PR TITLE
fix(workspace-file-manager): support Node asset imports

### DIFF
--- a/docs/conventions/troubleshooting/toolchain-browser-terminal.md
+++ b/docs/conventions/troubleshooting/toolchain-browser-terminal.md
@@ -511,6 +511,9 @@ emitted before this method can be called`, especially after HMR, navigation,
   `node_modules/.vite/deps/assets/...`: dependency prebundling moved the
   JavaScript module, then a preserved `new URL("./assets/...", import.meta.url)`
   resolved relative to the optimizer cache.
+  A browser-only correction can surface as `Unknown file extension ".png"` in
+  Vitest when the test runner externalizes the published dependency and Node
+  evaluates its asset import directly.
 - Quick checks:
   If the failing package entrypoint renders a package-local image or icon,
   inspect whether the main runtime entrypoint still imports that asset directly
@@ -519,7 +522,9 @@ emitted before this method can be called`, especially after HMR, navigation,
   Run `pnpm release:pack:check` and confirm the packed tarball includes the
   exported asset file under `dist/assets/...`.
   Inspect the built `dist` entrypoint and confirm the main runtime code no
-  longer hard-depends on the asset unless the consumer imported it explicitly.
+  longer uses a module-relative asset URL. If the runtime intentionally imports
+  the asset, verify the public export has both a browser asset target and a
+  Node-executable target.
 - Root cause:
   The public runtime entrypoint owned a default asset dependency instead of
   exposing that asset as an explicit public subpath. The packed npm artifact
@@ -539,11 +544,18 @@ emitted before this method can be called`, especially after HMR, navigation,
   explicit public asset subpath from that runtime and keep the asset import
   external in the package build. This lets the consumer bundler observe and
   rewrite the asset dependency instead of inferring it from `import.meta.url`.
+  If Node-based consumers also evaluate the runtime, give the same public asset
+  subpath conditional exports: a browser condition that targets the image and
+  a Node condition that targets a sibling JavaScript module returning the
+  module-relative file URL. Do not require every consumer to add a test alias
+  for the published package.
   Apply the same rule to every public runtime subpath in the package, not just
   the first failing icon.
 - Validation:
   Build the affected package, inspect the built runtime entrypoint for the
   absence of the old asset dependency, and rerun `pnpm release:pack:check`.
+  Import the packed public asset subpath with Node and run a real Vite
+  dependency-prebundle fixture; both paths must succeed.
   If the package is consumed by desktop renderer code in this repo, also run
   the relevant desktop build to confirm the consumer bundler copies or emits
   the asset only when the business import is present.

--- a/packages/agent/gui/vitest.config.ts
+++ b/packages/agent/gui/vitest.config.ts
@@ -6,8 +6,8 @@ const rootDir = fileURLToPath(new URL(".", import.meta.url));
 export default defineConfig({
   resolve: {
     alias: {
-      "@tutti-os/workspace-file-manager/assets/workspace-archive-fallback.png": `${rootDir}../../workspace/file-manager/src/assets/workspace-archive-fallback.png`,
-      "@tutti-os/workspace-file-manager/assets/workspace-folder-fallback.png": `${rootDir}../../workspace/file-manager/src/assets/workspace-folder-fallback.png`,
+      "@tutti-os/workspace-file-manager/assets/workspace-archive-fallback.png": `${rootDir}../../workspace/file-manager/src/runtime-assets/workspace-archive-fallback-url.ts`,
+      "@tutti-os/workspace-file-manager/assets/workspace-folder-fallback.png": `${rootDir}../../workspace/file-manager/src/runtime-assets/workspace-folder-fallback-url.ts`,
       "@tutti-os/workspace-file-manager/services": `${rootDir}../../workspace/file-manager/src/services/index.ts`,
       "@tutti-os/workspace-file-manager": `${rootDir}../../workspace/file-manager/src/index.ts`
     }

--- a/packages/workspace/file-manager/README.md
+++ b/packages/workspace/file-manager/README.md
@@ -43,12 +43,14 @@ drag movement.
 Hosts now provide one app-level i18n runtime and scope it into the file-manager
 namespace, rather than hand-assembling package-local message objects.
 
-The React surface owns its archive and folder fallback artwork. Those files are
-published through the stable
-`@tutti-os/workspace-file-manager/assets/workspace-*-fallback.png` subpaths so
-consumer bundlers can resolve them during dependency prebundling. Keep runtime
-imports on those public subpaths; relative `new URL("./assets/...", import.meta.url)`
-references from the built entry are not a supported asset contract.
+The React surface owns its archive and folder fallback artwork. Runtime code
+loads the artwork through the stable
+`@tutti-os/workspace-file-manager/assets/workspace-*-fallback.png` subpaths.
+The published export maps each subpath to the PNG in browser conditions and to
+a JavaScript URL module in Node conditions. Browser bundlers therefore
+preserve asset handling during dependency prebundling, while Node-based test
+runners evaluate JavaScript instead of importing a `.png` file. Keep the root
+entry free of relative `new URL("./assets/...", import.meta.url)` references.
 
 What stays outside this package is concrete host integration: desktop preload
 calls, tuttid transport wiring, host absolute paths, import/export/upload

--- a/packages/workspace/file-manager/package.json
+++ b/packages/workspace/file-manager/package.json
@@ -8,10 +8,14 @@
     ".": "./src/index.ts",
     "./assets/workspace-archive-fallback.png": {
       "types": "./src/assets/workspace-archive-fallback.png.d.ts",
+      "browser": "./src/assets/workspace-archive-fallback.png",
+      "node": "./src/runtime-assets/workspace-archive-fallback-url.ts",
       "default": "./src/assets/workspace-archive-fallback.png"
     },
     "./assets/workspace-folder-fallback.png": {
       "types": "./src/assets/workspace-folder-fallback.png.d.ts",
+      "browser": "./src/assets/workspace-folder-fallback.png",
+      "node": "./src/runtime-assets/workspace-folder-fallback-url.ts",
       "default": "./src/assets/workspace-folder-fallback.png"
     },
     "./i18n": "./src/i18n/index.ts",
@@ -65,10 +69,14 @@
       },
       "./assets/workspace-archive-fallback.png": {
         "types": "./dist/assets/workspace-archive-fallback.png.d.ts",
+        "browser": "./dist/assets/workspace-archive-fallback.png",
+        "node": "./dist/runtime-assets/workspace-archive-fallback-url.js",
         "default": "./dist/assets/workspace-archive-fallback.png"
       },
       "./assets/workspace-folder-fallback.png": {
         "types": "./dist/assets/workspace-folder-fallback.png.d.ts",
+        "browser": "./dist/assets/workspace-folder-fallback.png",
+        "node": "./dist/runtime-assets/workspace-folder-fallback-url.js",
         "default": "./dist/assets/workspace-folder-fallback.png"
       },
       "./i18n": {

--- a/packages/workspace/file-manager/src/runtime-assets/workspace-archive-fallback-url.ts
+++ b/packages/workspace/file-manager/src/runtime-assets/workspace-archive-fallback-url.ts
@@ -1,0 +1,6 @@
+const workspaceArchiveFallbackIconUrl = new URL(
+  "../assets/workspace-archive-fallback.png",
+  import.meta.url
+).href;
+
+export default workspaceArchiveFallbackIconUrl;

--- a/packages/workspace/file-manager/src/runtime-assets/workspace-folder-fallback-url.ts
+++ b/packages/workspace/file-manager/src/runtime-assets/workspace-folder-fallback-url.ts
@@ -1,0 +1,6 @@
+const workspaceFolderFallbackIconUrl = new URL(
+  "../assets/workspace-folder-fallback.png",
+  import.meta.url
+).href;
+
+export default workspaceFolderFallbackIconUrl;

--- a/packages/workspace/file-manager/tsup.config.ts
+++ b/packages/workspace/file-manager/tsup.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
   dts: true,
   entry: {
     index: "src/index.ts",
+    "runtime-assets/workspace-archive-fallback-url":
+      "src/runtime-assets/workspace-archive-fallback-url.ts",
+    "runtime-assets/workspace-folder-fallback-url":
+      "src/runtime-assets/workspace-folder-fallback-url.ts",
     "i18n/index": "src/i18n/index.ts",
     "services/index": "src/services/index.ts"
   },

--- a/tools/scripts/check-package-packs.mjs
+++ b/tools/scripts/check-package-packs.mjs
@@ -161,6 +161,38 @@ async function checkPackage(packageConfig, destination) {
         violations.push(`missing public asset import ${publicAssetSpecifier}`);
       }
     }
+    try {
+      execFileSync(
+        process.execPath,
+        [
+          "--input-type=module",
+          "--eval",
+          `
+            for (const fallbackKind of ["archive", "folder"]) {
+              const { default: assetUrl } = await import(
+                \`@tutti-os/workspace-file-manager/assets/workspace-\${fallbackKind}-fallback.png\`
+              );
+              if (
+                !assetUrl.startsWith("file:") ||
+                !assetUrl.endsWith(\`workspace-\${fallbackKind}-fallback.png\`)
+              ) {
+                throw new Error(\`unexpected \${fallbackKind} fallback URL: \${assetUrl}\`);
+              }
+            }
+          `
+        ],
+        {
+          cwd: packageRoot,
+          stdio: "pipe"
+        }
+      );
+    } catch (error) {
+      const detail =
+        error instanceof Error && "stderr" in error
+          ? String(error.stderr).trim()
+          : String(error);
+      violations.push(`Node fallback asset import failed: ${detail}`);
+    }
   }
 
   if (violations.length > 0) {


### PR DESCRIPTION
## What changed

- map the stable archive/folder `.png` package subpaths to PNG files for browser conditions and JavaScript URL modules for Node conditions
- emit the two Node URL modules beside the published runtime assets
- make AgentGUI's source-mode Vitest aliases follow the Node side of the same contract
- extend npm pack validation to import both packed asset subpaths in Node
- document the browser-prebundle and externalized-test-runner asset contract

## Why

The `0.0.202` fix correctly stopped Vite dev from resolving fallback icons under `.vite/deps/assets`, but the published root entry still statically imported `.png` subpaths. Vitest externalizes published dependencies, so Node evaluated those imports directly and failed with `Unknown file extension ".png"` during suite collection.

The public specifier now stays asset-shaped for browser bundlers while Node resolves the same specifier to executable JavaScript. Consumers do not need aliases or `node_modules` patches.

## Risk / affected surfaces

- only the workspace-file-manager archive/folder fallback asset resolution contract changes
- browser URL behavior remains the explicit public PNG subpath introduced in `0.0.202`
- Node receives a `file:` URL string instead of attempting to load a PNG module

## Verification

- `pnpm --filter @tutti-os/fixture-workspace-file-manager-external-vite test`
- `pnpm --filter @tutti-os/workspace-file-manager test` (130 tests)
- `pnpm --filter @tutti-os/agent-gui test` (273 files, 2283 tests)
- `pnpm release:pack:check` (24 packages; packed Node import probe passed)
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:changed -- --failed-only` (14/14 lanes; one unrelated async AgentGUI timeout passed on rerun)
- pre-push `pnpm check:changed -- --push-ready` (15/15 lanes)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->