### PR TITLE
fix(agent): restore custom agent resolution and model auth

### DIFF
--- a/apps/desktop/src/main/developerLogs.test.ts
+++ b/apps/desktop/src/main/developerLogs.test.ts
@@ -6,7 +6,27 @@ import test from "node:test";
 import { inflateRawSync } from "node:zlib";
 import { createDeveloperLogsService } from "./developerLogs.ts";
 import type { DeveloperLogsAgentSessionRecord } from "./developerLogsAgentSessions.ts";
+import { sanitizeDeveloperLogsTransportSnapshot } from "./developerLogsRuntimeContext.ts";
 import { workspaceAppScopeSegment } from "./host/workspaceAppFolderPaths.ts";
+
+test("developer logs runtime context allowlists transport diagnostics", () => {
+  const snapshot = sanitizeDeveloperLogsTransportSnapshot({
+    accessToken: "must-not-export",
+    boundAddr: "127.0.0.1:4545",
+    listenerInfoPath: "/tmp/tuttid.listener.json",
+    pidPath: "/tmp/tuttid.pid",
+    requestedAddr: "127.0.0.1:0",
+    unknownField: "must-not-export-either"
+  });
+
+  assert.deepEqual(snapshot, {
+    boundAddr: "127.0.0.1:4545",
+    listenerInfoPath: "/tmp/tuttid.listener.json",
+    pidPath: "/tmp/tuttid.pid",
+    requestedAddr: "127.0.0.1:0"
+  });
+  assert.equal(JSON.stringify(snapshot).includes("must-not-export"), false);
+});
 
 test("developer logs service summarizes managed desktop and daemon logs", async () => {
   const root = join(tmpdir(), `tutti-developer-logs-${Date.now()}`);

--- a/apps/desktop/src/main/developerLogsRuntimeContext.ts
+++ b/apps/desktop/src/main/developerLogsRuntimeContext.ts
@@ -54,8 +54,37 @@ export function buildDeveloperLogsRuntimeContext(
       release: process.release.name,
       sessionId: process.env.TUTTI_SESSION_ID
     },
-    transport: input.transportSnapshot
+    transport: sanitizeDeveloperLogsTransportSnapshot(input.transportSnapshot)
   };
+}
+
+const developerLogsTransportFields = [
+  "boundAddr",
+  "listenerInfoPath",
+  "pidPath",
+  "requestedAddr"
+] as const;
+
+export function sanitizeDeveloperLogsTransportSnapshot(
+  snapshot: unknown
+): Record<string, string | null> | null {
+  if (
+    snapshot === null ||
+    typeof snapshot !== "object" ||
+    Array.isArray(snapshot)
+  ) {
+    return null;
+  }
+
+  const source = snapshot as Record<string, unknown>;
+  const safeSnapshot: Record<string, string | null> = {};
+  for (const field of developerLogsTransportFields) {
+    const value = source[field];
+    if (typeof value === "string" || value === null) {
+      safeSnapshot[field] = value;
+    }
+  }
+  return safeSnapshot;
 }
 
 function collectRuntimeOverrides(): Record<string, string> {

--- a/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
@@ -34,6 +34,8 @@ import {
   userAvatarPlaceholderUrl,
   workspaceAgentActivityStatusLabel
 } from "@tutti-os/agent-gui/agent-message-center";
+import { resolveAgentGUIProviderCatalogIdentity } from "@tutti-os/agent-gui/provider-catalog";
+import { resolveProviderIconAsset } from "@tutti-os/agent-gui/provider-icons";
 import { normalizeAgentActivityDisplayStatus } from "@tutti-os/agent-activity-core";
 import { translate } from "../../../i18n";
 import { getActiveLocale } from "../../../i18n/runtime";
@@ -215,6 +217,7 @@ export function createWorkspaceWindowContainer(): WorkspaceWindowContainerResult
     tuttidClient,
     notifications: notificationService,
     reporterService,
+    resolveAgentTargetIconUrl: resolveWorkspaceAgentTargetIconUrl,
     runtimeApi: desktopApi.runtime,
     terminalCommandRunner: createAgentProviderTerminalCommandRunner(
       desktopApi.runtime
@@ -448,4 +451,18 @@ function logWorkspaceWindowRuntimeDiagnostic(
 
 function resolveWorkspaceRichTextAgentIconUrl(provider: string | undefined) {
   return managedAgentRoundedIconUrl(provider);
+}
+
+function resolveWorkspaceAgentTargetIconUrl(identity: {
+  iconKey: string | null;
+  provider: string;
+}): string {
+  const catalogIconKey =
+    identity.iconKey ||
+    resolveAgentGUIProviderCatalogIdentity(identity.provider)?.iconKey;
+  return (
+    resolveProviderIconAsset(catalogIconKey, "rounded") ??
+    resolveProviderIconAsset(catalogIconKey, "manage") ??
+    managedAgentRoundedIconUrl(identity.provider)
+  );
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { AgentTarget } from "@tutti-os/client-tuttid-ts";
+import type { AgentTarget, WorkspaceAgent } from "@tutti-os/client-tuttid-ts";
+import {
+  normalizeAgentGUIAgents,
+  projectAgentGUIAgentsToTargets
+} from "@tutti-os/agent-gui/agents";
 import {
   DesktopAgentsService,
   mapAgentTargetsToPresentations,
@@ -187,6 +191,74 @@ test("desktop agents service maps enabled daemon targets into the AgentGUI agent
   ]);
 });
 
+test("desktop agents service lists a custom Agent with its Harness target catalog icon", async () => {
+  let listedWorkspaceId = "";
+  const service = new DesktopAgentsService({
+    resolveAgentTargetIconUrl: ({ iconKey, provider }) =>
+      iconKey ? `catalog://${iconKey}` : `catalog://provider/${provider}`,
+    tuttidClient: {
+      async listAgentTargets() {
+        return {
+          targets: [
+            createAgentTarget({
+              iconKey: "codex-target",
+              iconUrl: null,
+              id: "local:codex",
+              name: "Codex",
+              provider: "codex",
+              sortOrder: 10
+            })
+          ]
+        };
+      },
+      async listWorkspaceAgents(workspaceId) {
+        listedWorkspaceId = workspaceId;
+        return {
+          agents: [
+            createWorkspaceAgent({
+              harness: {
+                agentTargetId: "local:codex",
+                available: true,
+                enabled: true,
+                iconKey: null,
+                name: "Codex",
+                provider: "codex"
+              }
+            })
+          ]
+        };
+      }
+    },
+    workspaceId: "workspace-1"
+  });
+
+  const snapshot = await service.load();
+  const customAgent = snapshot.agents.find(
+    (agent) => agent.agentTargetId === "workspace-agent:reviewer"
+  );
+  const normalizedAgents = normalizeAgentGUIAgents(snapshot.agents);
+  const customTarget = projectAgentGUIAgentsToTargets(normalizedAgents).find(
+    (target) => target.agentTargetId === "workspace-agent:reviewer"
+  );
+
+  assert.equal(listedWorkspaceId, "workspace-1");
+  assert.equal(customAgent?.iconUrl, "catalog://codex-target");
+  assert.deepEqual(customTarget, {
+    agentTargetId: "workspace-agent:reviewer",
+    availability: { status: "ready" },
+    description: "Reviews workspace changes",
+    iconUrl: "catalog://codex-target",
+    label: "Reviewer",
+    provider: "codex",
+    ref: {
+      agentTargetId: "workspace-agent:reviewer",
+      kind: "agent-directory",
+      provider: "codex"
+    },
+    targetId: "workspace-agent:reviewer"
+  });
+});
+
 test("desktop agents service preserves Extension primary and mask icons", () => {
   const presentations = mapAgentTargetsToPresentations([
     {
@@ -297,7 +369,10 @@ function createAgentTarget(input: {
     createdAtUnixMs: 1780272000000,
     enabled: input.enabled ?? true,
     iconKey: input.iconKey ?? null,
-    iconUrl: input.iconUrl ?? `tutti-asset://agent/${input.provider}.png`,
+    iconUrl:
+      "iconUrl" in input
+        ? (input.iconUrl ?? null)
+        : `tutti-asset://agent/${input.provider}.png`,
     heroImageUrl: input.heroImageUrl ?? null,
     maskIconUrl: input.maskIconUrl ?? null,
     id: input.id,
@@ -310,6 +385,39 @@ function createAgentTarget(input: {
     sortOrder: input.sortOrder,
     source: "system",
     updatedAtUnixMs: 1780272000000
+  };
+}
+
+function createWorkspaceAgent(
+  overrides: Partial<WorkspaceAgent> = {}
+): WorkspaceAgent {
+  return {
+    agentTargetId: "workspace-agent:reviewer",
+    capabilitiesExplicit: false,
+    callConditions: ["Use for workspace reviews"],
+    createdAt: "2026-07-23T00:00:00Z",
+    defaultModel: null,
+    description: "Reviews workspace changes",
+    harness: {
+      agentTargetId: "local:codex",
+      available: true,
+      enabled: true,
+      iconKey: "codex",
+      name: "Codex",
+      provider: "codex"
+    },
+    id: "workspace-agent:reviewer",
+    instructions: "Review carefully",
+    modelFallbacks: [],
+    modelPlanId: null,
+    name: "Reviewer",
+    revision: 1,
+    skills: [],
+    source: "user",
+    tools: [],
+    updatedAt: "2026-07-23T00:00:00Z",
+    workspaceId: "workspace-1",
+    ...overrides
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.ts
@@ -172,6 +172,12 @@ export class DesktopAgentsService implements IAgentsService {
           resolveAgentTargetIconUrl: this.dependencies.resolveAgentTargetIconUrl
         }
       );
+      const daemonAgentTargetIconUrls = new Map(
+        daemonAgentTargets.map((target) => [
+          target.agentTargetId,
+          target.iconUrl
+        ])
+      );
       const agentTargets = daemonAgentTargets;
       // Built-in Harness targets and explicit workspace Agents coexist in the
       // AgentGUI directory: built-ins keep their placement and workspace
@@ -185,7 +191,13 @@ export class DesktopAgentsService implements IAgentsService {
         {
           isAgentTargetProviderGated:
             this.dependencies.isAgentTargetProviderGated,
-          resolveAgentTargetIconUrl: this.dependencies.resolveAgentTargetIconUrl
+          resolveAgentTargetIconUrl: ({ agentTargetId, iconKey, provider }) =>
+            daemonAgentTargetIconUrls.get(agentTargetId)?.trim() ||
+            this.dependencies.resolveAgentTargetIconUrl?.({
+              iconKey,
+              provider
+            }) ||
+            ""
         }
       );
       const agents = dedupeAgentsByAgentTargetId([
@@ -350,6 +362,7 @@ export function mapWorkspaceAgentsToAgents(
   options: {
     isAgentTargetProviderGated?: (provider: string) => boolean;
     resolveAgentTargetIconUrl?: (identity: {
+      agentTargetId: string;
       iconKey: string | null;
       provider: string;
     }) => string;
@@ -373,6 +386,7 @@ export function mapWorkspaceAgentsToAgents(
         description: agent.description || null,
         iconUrl:
           options.resolveAgentTargetIconUrl?.({
+            agentTargetId: agent.harness.agentTargetId,
             iconKey: agent.harness.iconKey?.trim() || null,
             provider
           }) ?? "",

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
@@ -125,6 +125,7 @@ export function registerWorkspaceAgentServices(
       preferencesStore.featureFlags,
       EARLY_ACCESS_AGENT_INTEGRATIONS_FLAG
     ),
+    resolveAgentTargetIconUrl: input.resolveAgentTargetIconUrl,
     tuttidClient: input.tuttidClient,
     workspaceId: input.workspaceId
   });

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -468,10 +468,14 @@ idle | loading | ready | error
 `ready` may contain an authoritative empty list. `error` may retain the last successful snapshot. Components must not infer loading from `agents.length`.
 
 The directory owns Agent presentation. `agents[].iconUrl` is the primary
-identity used by conversation identity, Message Center, mentions, and the
-empty-home carousel and Provider Rail. `maskIconUrl` may supply the monochrome
-conversation-row glyph. Host projections preserve these roles independently
-and do not create provider-specific renderer catalogs.
+presentation asset used by conversation identity, Message Center, mentions,
+and the empty-home carousel and Provider Rail. It is decorative metadata:
+an Agent with an exact `agentTargetId` and name remains selectable when the
+icon is absent. `maskIconUrl` may supply the monochrome conversation-row glyph.
+Desktop Workspace Agent projections first inherit the resolved icon of their
+Harness target by exact target ID, then use the provider/icon catalog fallback.
+Host projections preserve these roles independently and do not create
+provider-specific renderer catalogs.
 
 When the Desktop host projects built-in Agent mentions into a workspace app,
 it replaces host-local file URLs with bounded 64px WebP data URLs. The external

--- a/docs/architecture/model-access-plans.md
+++ b/docs/architecture/model-access-plans.md
@@ -132,6 +132,14 @@ Rules:
   `openai` plans, `claude-code` consumes `anthropic` plans. Cursor keeps
   provider-native credentials (no endpoint injection) — no fake UI entry
   points.
+- Anthropic-protocol credential injection follows the endpoint's Claude Code
+  contract, not a blanket “official versus relay” rule. `api.anthropic.com`
+  and Kimi Coding (`api.kimi.com`) require `ANTHROPIC_API_KEY`/`x-api-key`;
+  other relay-style endpoints keep the bearer `ANTHROPIC_AUTH_TOKEN` default.
+  Runtime preparation explicitly blanks the opposite credential variable so
+  inherited shell or Claude settings cannot override the Plan's auth shape.
+  Detection and the launched Agent must use equivalent authentication shapes,
+  or a plan can pass inference detection while every real Agent turn gets 401.
 - Model addressing is a second registry strategy
   (`ModelPlanModelAddressing`): OpenCode declares `provider_prefixed`, so its
   composer/settings values carry the injected `tutti-model-plan/<model>`

--- a/docs/architecture/workspace-agents-and-automation.md
+++ b/docs/architecture/workspace-agents-and-automation.md
@@ -115,6 +115,14 @@ They do not look for a legacy binding whose key happens to equal the new Agent
 id. Plan and Agent mutations publish target-scoped configuration invalidation
 for the affected WorkspaceAgent ids.
 
+The daemon composition root must wire both sides of this workspace-scoped
+identity: `AgentSessionService.WorkspaceAgentResolver` resolves composer and
+launch requests through the WorkspaceAgent service, while
+`ActivityProjection.SetWorkspaceAgentTargetResolver` validates persisted
+session targets through the workspace store. Omitting the former turns valid
+composer/create requests into invalid requests; omitting the latter drops a
+successfully created WorkspaceAgent target from the projected session.
+
 Fallback resolution applies only while creating a new session. It does not
 mutate the Agent, and the actual selected Plan/model/revision is persisted in
 the immutable session snapshot. Editing fallback order affects later sessions

--- a/docs/conventions/logging.md
+++ b/docs/conventions/logging.md
@@ -83,6 +83,10 @@ Choosing logs only must not query or write Agent Session records. Runtime contex
 the export summary, and other non-Session diagnostic snapshots remain part of the
 log bundle so exported evidence stays interpretable.
 
+Runtime-context transport diagnostics are allowlisted. Exports may include the
+bound/requested address and listener/PID paths, but must never serialize the
+transport access token or newly added transport snapshot fields by default.
+
 ## Error Codes
 
 Startup, transport, and supervision failures should carry a stable `error_code` in addition to the human-readable message.

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -1138,6 +1138,43 @@ invalid_grant`. Search `tuttid.log` for
   [agentErrorPresentation.ts](../../../packages/agent/gui/shared/agentEnv/agentErrorPresentation.ts)
   [AgentMessageBlock.tsx](../../../packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx)
 
+### Model Plan check succeeds but Kimi Claude Code turns wait and then return 401
+
+- Symptom:
+  An Anthropic-protocol Model Plan using
+  `https://api.kimi.com/coding/` passes model discovery/inference checks, but a
+  custom Agent backed by Claude Code stays `running` for roughly three minutes
+  and then appends `Failed to authenticate. API Error: 401`.
+- Quick checks:
+  Confirm the submit claim is `accepted`, the user message exists, and the
+  runtime reached `runtime.turn_goroutine_started`. Inspect only environment
+  variable names and whether each is non-empty, never credential values. If
+  the child has a non-empty `ANTHROPIC_AUTH_TOKEN` but no non-empty
+  `ANTHROPIC_API_KEY`, the plan credential was injected with the wrong auth
+  shape.
+- Root cause:
+  Model Plan detection sends Anthropic requests with `x-api-key`. Runtime
+  preparation previously treated every non-`api.anthropic.com` endpoint as a
+  bearer-token relay and launched Claude Code with `ANTHROPIC_AUTH_TOKEN`.
+  Kimi Coding's Claude Code contract requires `ANTHROPIC_API_KEY`, so the same
+  valid credential passed detection and failed only in the real Agent process.
+- Fix:
+  Keep the existing bearer default for relay endpoints, but classify
+  `api.kimi.com` alongside the official Anthropic endpoint for
+  `ANTHROPIC_API_KEY` injection. Also preserve Claude SDK `assistant.error` and
+  `result.is_error` as failed message/turn state; a result subtype of `success`
+  is not authoritative when either error signal is present.
+- Validation:
+  Run `go test ./packages/agent/runtimeprep ./packages/agent/daemon/runtime`
+  and `pnpm --dir packages/agent/claude-sdk-sidecar test`. Verify a newly
+  created Kimi-backed session has a non-empty `ANTHROPIC_API_KEY`, an empty
+  `ANTHROPIC_AUTH_TOKEN`, and no 401. Existing running sessions retain their
+  launch environment and must be recreated.
+- References:
+  [Kimi Claude Code setup](https://www.kimi.com/code/docs/en/third-party-tools/claude-code.html)
+  [model_endpoint.go](../../../packages/agent/runtimeprep/model_endpoint.go)
+  [messageRouter.ts](../../../packages/agent/claude-sdk-sidecar/src/messageRouter.ts)
+
 ### Claude Code sessions fail with `effectiveSource: "none"` when CC-Switch or similar proxy tools are used
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -35,6 +35,7 @@ Provider discovery, installation, authentication, models, configuration, and run
 - [Claude SDK rejects live bypassPermissions mode](./agent-provider-setup.md#claude-sdk-rejects-live-bypasspermissions-mode)
 - [Claude Code logs out after sending a message (invalid_grant, credentials wiped)](./agent-provider-setup.md#claude-code-logs-out-after-sending-a-message-invalidgrant-credentials-wiped)
 - [Claude Code `Not logged in` renders as a file link instead of sign-in guidance](./agent-provider-setup.md#claude-code-not-logged-in-renders-as-a-file-link-instead-of-sign-in-guidance)
+- [Model Plan check succeeds but Kimi Claude Code turns wait and then return 401](./agent-provider-setup.md#model-plan-check-succeeds-but-kimi-claude-code-turns-wait-and-then-return-401)
 - [Claude Code sessions fail with `effectiveSource: "none"` when CC-Switch or similar proxy tools are used](./agent-provider-setup.md#claude-code-sessions-fail-with-effectivesource-none-when-cc-switch-or-similar-proxy-tools-are-used)
 - [Tutti Agent retries a 402 and shows generic provider setup](./agent-provider-setup.md#tutti-agent-retries-a-402-and-shows-generic-provider-setup)
 - [OpenCode effort changes fail with `effort not found`](./agent-provider-setup.md#opencode-effort-changes-fail-with-effort-not-found)

--- a/packages/agent/claude-sdk-sidecar/src/assistantStream.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/assistantStream.test.ts
@@ -50,6 +50,27 @@ test("assistant fallback reuses a streamed prefix", () => {
   );
 });
 
+test("assistant SDK error replaces completion with a failed message", () => {
+  const events: Array<Omit<ClaudeSDKSidecarEvent, "version">> = [];
+  const projector = new AssistantStreamProjector(
+    () => "turn-1",
+    (event) => events.push(event)
+  );
+
+  projector.setMessageBase("message-1");
+  projector.failContent(
+    "assistant",
+    "message-1",
+    "Failed to authenticate",
+    new Set<string>()
+  );
+
+  assert.deepEqual(
+    events.map((event) => [event.type, event.payload?.content]),
+    [["assistant_failed", "Failed to authenticate"]]
+  );
+});
+
 test("assistant stream reset drops stale indexes", () => {
   const events: Array<Omit<ClaudeSDKSidecarEvent, "version">> = [];
   const projector = new AssistantStreamProjector(

--- a/packages/agent/claude-sdk-sidecar/src/assistantStream.ts
+++ b/packages/agent/claude-sdk-sidecar/src/assistantStream.ts
@@ -85,6 +85,28 @@ export class AssistantStreamProjector {
     usedSegmentIds.add(segment.messageId);
   }
 
+  failContent(
+    kind: AssistantSegmentKind,
+    messageBase: string,
+    content: string,
+    usedSegmentIds: Set<string>
+  ): void {
+    if (!content) {
+      return;
+    }
+    const existing = this.segmentWithContent(
+      kind,
+      messageBase,
+      content,
+      usedSegmentIds
+    );
+    const segment =
+      existing ??
+      this.createSegment(kind, "fallback", messageBase || this.activeTurnId());
+    this.completeSegment(undefined, segment, content, true);
+    usedSegmentIds.add(segment.messageId);
+  }
+
   private emitDelta(segment: AssistantSegmentState, delta: string): void {
     if (!delta) {
       return;
@@ -156,12 +178,13 @@ export class AssistantStreamProjector {
   private completeSegment(
     index: number | undefined,
     segment: AssistantSegmentState,
-    fallbackText = ""
+    fallbackText = "",
+    failed = false
   ): void {
     if (typeof index === "number") {
       this.segmentKeyByIndex.delete(indexKey(segment.kind, index));
     }
-    if (segment.completed) {
+    if (segment.completed && !failed) {
       return;
     }
     const tail =
@@ -180,7 +203,9 @@ export class AssistantStreamProjector {
     this.emit({
       type:
         segment.kind === "assistant"
-          ? "assistant_completed"
+          ? failed
+            ? "assistant_failed"
+            : "assistant_completed"
           : "thinking_completed",
       payload: {
         turnId: this.activeTurnId(),

--- a/packages/agent/claude-sdk-sidecar/src/messageProjection.ts
+++ b/packages/agent/claude-sdk-sidecar/src/messageProjection.ts
@@ -123,7 +123,8 @@ export class MessageProjection {
     block: Record<string, unknown>,
     parentToolUseID = "",
     messageId = "",
-    usedSegmentIds = new Set<string>()
+    usedSegmentIds = new Set<string>(),
+    failed = false
   ): void {
     if (isThinkingBlock(block)) {
       if (!parentToolUseID) {
@@ -138,12 +139,22 @@ export class MessageProjection {
     }
     if (block.type === "text") {
       if (!parentToolUseID) {
-        this.assistant.completeContent(
-          "assistant",
-          messageId,
-          stringValue(block.text),
-          usedSegmentIds
-        );
+        const content = stringValue(block.text);
+        if (failed) {
+          this.assistant.failContent(
+            "assistant",
+            messageId,
+            content,
+            usedSegmentIds
+          );
+        } else {
+          this.assistant.completeContent(
+            "assistant",
+            messageId,
+            content,
+            usedSegmentIds
+          );
+        }
       }
       return;
     }

--- a/packages/agent/claude-sdk-sidecar/src/messageRouter.ts
+++ b/packages/agent/claude-sdk-sidecar/src/messageRouter.ts
@@ -37,6 +37,7 @@ export class SDKMessageRouter {
   private readonly compaction: CompactionTracker;
   private readonly emit: ClaudeSDKSidecarEventEmitter;
   private contextUsageGeneration = 0;
+  private activeRootAssistantError = "";
 
   constructor(options: {
     getProviderSessionId: () => string;
@@ -184,7 +185,11 @@ export class SDKMessageRouter {
         ...(stringValue(raw.tool_use_id)
           ? { toolUseId: stringValue(raw.tool_use_id) }
           : {}),
-        ...(stringValue(raw.status) ? { status: stringValue(raw.status) } : {})
+        ...(stringValue(raw.status) ? { status: stringValue(raw.status) } : {}),
+        ...(raw.is_error === true ? { sdkResultIsError: true } : {}),
+        ...(typeof raw.api_error_status === "number"
+          ? { sdkApiErrorStatus: raw.api_error_status }
+          : {})
       }
     });
   }
@@ -264,6 +269,12 @@ export class SDKMessageRouter {
     if (!this.turns.ensureActive("assistant")) {
       return;
     }
+    const assistantError = stringValue(
+      (message as unknown as Record<string, unknown>).error
+    );
+    if (assistantError) {
+      this.activeRootAssistantError = assistantError;
+    }
     const messageId = readSDKAssistantMessageID(message);
     const blocks = contentBlocksFromMessage(message);
     const usedAssistantSegmentIds = new Set<string>();
@@ -272,7 +283,8 @@ export class SDKMessageRouter {
         block,
         parentToolUseID,
         messageId,
-        usedAssistantSegmentIds
+        usedAssistantSegmentIds,
+        Boolean(assistantError)
       );
     }
     this.projection.emitGoalStatusFromBlocks(blocks);
@@ -320,6 +332,7 @@ export class SDKMessageRouter {
       this.turns.activeId !== activeTurnIdBefore
     ) {
       this.contextUsageGeneration += 1;
+      this.activeRootAssistantError = "";
     }
     const blocks = contentBlocksFromMessage(message);
     if (
@@ -348,6 +361,9 @@ export class SDKMessageRouter {
     const result = message as {
       subtype?: string;
       errors?: string[];
+      is_error?: boolean;
+      result?: string;
+      api_error_status?: number | null;
       usage?: unknown;
       modelUsage?: unknown;
       total_cost_usd?: unknown;
@@ -364,14 +380,28 @@ export class SDKMessageRouter {
     }
     const turnId = this.turns.activeId;
     const contextUsageGeneration = this.contextUsageGeneration;
+    const assistantError = this.activeRootAssistantError;
+    this.activeRootAssistantError = "";
     if (this.turns.cancelled) {
       this.turns.settleActive("turn_canceled");
       this.turns.clearCancelled();
-    } else if (result.subtype === "success") {
+    } else if (
+      result.subtype === "success" &&
+      result.is_error !== true &&
+      !assistantError
+    ) {
       this.turns.settleActive("turn_completed", { stopReason: "end_turn" });
     } else {
       this.turns.settleActive("turn_failed", {
-        error: result.errors?.[0] ?? "Claude SDK turn failed"
+        error:
+          result.errors?.[0] ||
+          (result.is_error ? result.result : "") ||
+          assistantError ||
+          "Claude SDK turn failed",
+        ...(assistantError ? { code: assistantError } : {}),
+        ...(typeof result.api_error_status === "number"
+          ? { apiErrorStatus: result.api_error_status }
+          : {})
       });
     }
     void this.emitResultUsage(turnId, contextUsageGeneration, result);

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.session.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.session.test.ts
@@ -106,6 +106,84 @@ test("tutti host context shares one SDK prompt with unchanged user input", async
   }
 });
 
+test("SDK assistant authentication error fails the message and turn", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  const failure =
+    "Failed to authenticate. API Error: 401 The API Key appears to be invalid.";
+  try {
+    const session = new SessionRuntime(
+      "provider-session-auth",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "k3",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => ({
+        async *[Symbol.asyncIterator]() {
+          const iterator = prompt[Symbol.asyncIterator]();
+          const message = (await iterator.next()).value!;
+          yield {
+            ...message,
+            type: "user",
+            parent_tool_use_id: null,
+            session_id: "provider-session-auth"
+          } as never;
+          yield {
+            type: "assistant",
+            error: "authentication_failed",
+            message: {
+              id: "assistant-auth-error",
+              role: "assistant",
+              content: [{ type: "text", text: failure }]
+            },
+            parent_tool_use_id: null,
+            session_id: "provider-session-auth"
+          } as never;
+          yield {
+            type: "result",
+            subtype: "success",
+            is_error: true,
+            api_error_status: 401,
+            result: failure,
+            session_id: "provider-session-auth"
+          } as never;
+        },
+        close() {}
+      })
+    );
+
+    await session.start();
+    session.exec("turn-auth", "hello");
+    await waitForEvent(events, "turn_failed");
+
+    const failedMessage = events.find(
+      (event) => event.type === "assistant_failed"
+    );
+    assert.equal(failedMessage?.payload?.content, failure);
+    const failedTurn = events.find((event) => event.type === "turn_failed");
+    assert.equal(failedTurn?.payload?.turnId, "turn-auth");
+    assert.equal(failedTurn?.payload?.code, "authentication_failed");
+    assert.equal(failedTurn?.payload?.apiErrorStatus, 401);
+    assert.equal(
+      events.some((event) => event.type === "turn_completed"),
+      false
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
 test("guidance prompt stays on the active SDK turn", async () => {
   const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
   const prompts: string[] = [];

--- a/packages/agent/daemon/runtime/acp_turn_normalizer.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer.go
@@ -258,6 +258,29 @@ func (n *acpTurnNormalizer) AppendAssistantSnapshot(
 	return n.Finish(session, turnID, messageStreamStateCompleted)
 }
 
+func (n *acpTurnNormalizer) FailAssistantSnapshot(
+	session Session,
+	turnID string,
+	text string,
+	messageID string,
+) []activityshared.Event {
+	if n == nil || n.suppressAssistantOutput {
+		return nil
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+	messageID = strings.TrimSpace(messageID)
+	if n.assistantMessageID == "" || (messageID != "" && n.assistantMessageID != messageID) {
+		n.assistantMessageID = firstNonEmpty(messageID, newID())
+	}
+	n.assistantContent.Reset()
+	_, _ = n.assistantContent.WriteString(text)
+	n.assistantSegmentCompleted = false
+	return n.Finish(session, turnID, messageStreamStateFailed)
+}
+
 func (n *acpTurnNormalizer) mergeAssistantText(next string) {
 	if n == nil || next == "" {
 		return

--- a/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
@@ -76,6 +76,32 @@ func TestClaudeCodeSDKAdapterUsesSidecarAssistantMessageID(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeSDKAdapterMapsAssistantSDKErrorToFailedMessage(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{liveState: newClaudeSDKLiveState()}
+
+	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-auth", claudeSDKSidecarEvent{
+		Type: "assistant_failed",
+		Payload: map[string]any{
+			"turnId":    "turn-auth",
+			"messageId": "claude-sdk:assistant:auth-error:fallback:0",
+			"content":   "Failed to authenticate. API Error: 401",
+		},
+	})
+	if err != nil || terminal {
+		t.Fatalf("assistant_failed err=%v terminal=%v", err, terminal)
+	}
+	if len(events) != 1 ||
+		events[0].Type != activityshared.EventMessageAppended ||
+		events[0].EventID != "claude-sdk:assistant:auth-error:fallback:0" ||
+		events[0].Payload.Role != activityshared.MessageRoleAssistant ||
+		events[0].Payload.Metadata["streamState"] != messageStreamStateFailed ||
+		events[0].Payload.Content != "Failed to authenticate. API Error: 401" {
+		t.Fatalf("assistant failed events = %#v", events)
+	}
+}
+
 func TestClaudeCodeSDKAdapterApprovalDoesNotMergeWithApprovedToolCall(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)

--- a/packages/agent/daemon/runtime/claude_sdk_events.go
+++ b/packages/agent/daemon/runtime/claude_sdk_events.go
@@ -170,6 +170,15 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 			payloadString(event.Payload, "content"),
 			true,
 		), false, nil
+	case "assistant_failed":
+		messageID := firstNonEmptyString(payloadString(event.Payload, "messageId"), adapterSession.assistantMessageID(providerTurnID))
+		return a.claudeSDKAssistantFailedEvents(
+			adapterSession,
+			session,
+			rootTurnID,
+			messageID,
+			payloadString(event.Payload, "content"),
+		), false, nil
 	case "thinking_delta":
 		messageID := firstNonEmptyString(payloadString(event.Payload, "messageId"), adapterSession.thinkingMessageID(providerTurnID))
 		content := firstNonEmpty(payloadString(event.Payload, "snapshot"), payloadString(event.Payload, "content"))
@@ -268,7 +277,7 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 
 func isClaudeSDKGoalClearHiddenEvent(eventType string) bool {
 	switch eventType {
-	case "turn_started", "assistant_delta", "assistant_completed", "thinking_delta", "thinking_completed":
+	case "turn_started", "assistant_delta", "assistant_completed", "assistant_failed", "thinking_delta", "thinking_completed":
 		return true
 	default:
 		return false
@@ -567,6 +576,12 @@ func (a *ClaudeCodeSDKAdapter) logClaudeSDKLifecycleEvent(agentSessionID string,
 	}
 	if payloadBoolValue(payload, "rootContinuationCandidate") {
 		args = append(args, "root_continuation_candidate", true)
+	}
+	if payloadBoolValue(payload, "sdkResultIsError") {
+		args = append(args, "sdk_result_is_error", true)
+	}
+	if apiErrorStatus := payloadInt64(payload, "sdkApiErrorStatus"); apiErrorStatus > 0 {
+		args = append(args, "sdk_api_error_status", apiErrorStatus)
 	}
 	if payloadBoolValue(payload, "syntheticTimeout") {
 		args = append(args, "synthetic_timeout", true)

--- a/packages/agent/daemon/runtime/claude_sdk_turn.go
+++ b/packages/agent/daemon/runtime/claude_sdk_turn.go
@@ -131,6 +131,31 @@ func (a *ClaudeCodeSDKAdapter) claudeSDKAssistantEvents(
 	return stampClaudeSDKAdapterMetadata(events)
 }
 
+func (a *ClaudeCodeSDKAdapter) claudeSDKAssistantFailedEvents(
+	adapterSession *claudeSDKAdapterSession,
+	session Session,
+	turnID string,
+	messageID string,
+	content string,
+) []activityshared.Event {
+	if a == nil || adapterSession == nil {
+		return nil
+	}
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	normalizer := adapterSession.ensureClaudeSDKTurnNormalizerLocked(turnID)
+	if normalizer == nil {
+		return nil
+	}
+	return stampClaudeSDKAdapterMetadata(
+		normalizer.FailAssistantSnapshot(session, turnID, content, messageID),
+	)
+}
+
 func stampClaudeSDKAdapterMetadata(events []activityshared.Event) []activityshared.Event {
 	if len(events) == 0 {
 		return events

--- a/packages/agent/gui/agents.test.ts
+++ b/packages/agent/gui/agents.test.ts
@@ -34,7 +34,7 @@ describe("normalizeAgentGUIAgents", () => {
     expect(agents.map((agent) => agent.provider)).toEqual(["codex", "codex"]);
   });
 
-  it("drops invalid and duplicate identities while normalizing presentation", () => {
+  it("drops invalid and duplicate identities while retaining iconless Agents", () => {
     const agents = normalizeAgentGUIAgents([
       createAgent(" alice ", {
         name: " Alice ",
@@ -50,7 +50,13 @@ describe("normalizeAgentGUIAgents", () => {
       createAgent("alice"),
       createAgent("", { name: "Missing identity" }),
       createAgent("missing-name", { name: " " }),
-      createAgent("missing-icon", { iconUrl: " " })
+      {
+        agentTargetId: "missing-icon",
+        name: "missing-icon",
+        iconUrl: "",
+        availability: { status: "ready" },
+        provider: "codex"
+      }
     ]);
 
     expect(agents).toEqual([
@@ -65,6 +71,13 @@ describe("normalizeAgentGUIAgents", () => {
         owner: { name: "Owner", avatarUrl: "app://owner.png" },
         ownership: "shared",
         availability: { status: "unavailable", reason: "Offline" },
+        provider: "codex"
+      },
+      {
+        agentTargetId: "missing-icon",
+        name: "missing-icon",
+        iconUrl: "",
+        availability: { status: "ready" },
         provider: "codex"
       }
     ]);
@@ -100,6 +113,21 @@ describe("projectAgentGUIAgentsToTargets", () => {
       iconUrl: "app://agents/agent-a.png",
       maskIconUrl: "app://agents/agent-a-mask.png"
     });
+  });
+
+  it("keeps an Agent without decorative icon metadata selectable", () => {
+    const agents = normalizeAgentGUIAgents([
+      createAgent("workspace-agent:reviewer", { iconUrl: " " })
+    ]);
+
+    const [target] = projectAgentGUIAgentsToTargets(agents);
+
+    expect(target).toMatchObject({
+      agentTargetId: "workspace-agent:reviewer",
+      iconUrl: "",
+      targetId: "workspace-agent:reviewer"
+    });
+    expect(target?.disabled).toBeUndefined();
   });
 
   it("preserves availability separately from disabled interaction state", () => {

--- a/packages/agent/gui/agents.ts
+++ b/packages/agent/gui/agents.ts
@@ -16,12 +16,7 @@ export function normalizeAgentGUIAgents(
     const maskIconUrl = agent.maskIconUrl?.trim() ?? "";
     const heroImageUrl = agent.heroImageUrl?.trim() ?? "";
     const ownerDeviceLabel = agent.ownerDeviceLabel?.trim() ?? "";
-    if (
-      !agentTargetId ||
-      !name ||
-      !iconUrl ||
-      seenAgentTargetIds.has(agentTargetId)
-    ) {
+    if (!agentTargetId || !name || seenAgentTargetIds.has(agentTargetId)) {
       continue;
     }
     seenAgentTargetIds.add(agentTargetId);

--- a/packages/agent/runtimeprep/model_endpoint.go
+++ b/packages/agent/runtimeprep/model_endpoint.go
@@ -83,29 +83,42 @@ func OpenCodePlanModelID(value string) string {
 }
 
 // modelEndpointClaudeEnv maps an anthropic-protocol plan endpoint onto the
-// Claude Code environment contract. Official API endpoints authenticate with
-// ANTHROPIC_API_KEY (x-api-key); relays and coding-plan gateways generally
-// expect the bearer ANTHROPIC_AUTH_TOKEN form.
+// Claude Code environment contract. Anthropic's official endpoint and Kimi
+// Coding authenticate with ANTHROPIC_API_KEY (x-api-key); relays and other
+// coding-plan gateways generally expect the bearer ANTHROPIC_AUTH_TOKEN form.
 func modelEndpointClaudeEnv(endpoint *ModelEndpointConfig) []string {
 	if !endpoint.supportsClaudeCode() {
 		return nil
 	}
 	baseURL := strings.TrimSpace(endpoint.BaseURL)
 	env := []string{"ANTHROPIC_BASE_URL=" + strings.TrimSuffix(baseURL, "/v1")}
-	if modelEndpointIsOfficialAnthropic(baseURL) {
-		env = append(env, "ANTHROPIC_API_KEY="+endpoint.APIKey)
+	if modelEndpointUsesAnthropicAPIKey(baseURL) {
+		env = append(
+			env,
+			"ANTHROPIC_API_KEY="+endpoint.APIKey,
+			"ANTHROPIC_AUTH_TOKEN=",
+		)
 	} else {
-		env = append(env, "ANTHROPIC_AUTH_TOKEN="+endpoint.APIKey)
+		env = append(
+			env,
+			"ANTHROPIC_AUTH_TOKEN="+endpoint.APIKey,
+			"ANTHROPIC_API_KEY=",
+		)
 	}
 	return env
 }
 
-func modelEndpointIsOfficialAnthropic(baseURL string) bool {
+func modelEndpointUsesAnthropicAPIKey(baseURL string) bool {
 	parsed, err := url.Parse(baseURL)
 	if err != nil {
 		return false
 	}
-	return strings.EqualFold(parsed.Hostname(), "api.anthropic.com")
+	switch strings.ToLower(parsed.Hostname()) {
+	case "api.anthropic.com", "api.kimi.com":
+		return true
+	default:
+		return false
+	}
 }
 
 // codexConfigWithModelPlanEndpoint rewrites the session-scoped Codex

--- a/packages/agent/runtimeprep/model_endpoint_test.go
+++ b/packages/agent/runtimeprep/model_endpoint_test.go
@@ -58,7 +58,7 @@ func TestModelEndpointClaudeEnvSelectsAuthShape(t *testing.T) {
 	if !strings.Contains(joined, "ANTHROPIC_BASE_URL=https://relay.example/api/anthropic") {
 		t.Fatalf("relay env = %v", relay)
 	}
-	if !strings.Contains(joined, "ANTHROPIC_AUTH_TOKEN=sk-relay") || strings.Contains(joined, "ANTHROPIC_API_KEY=") {
+	if !strings.Contains(joined, "ANTHROPIC_AUTH_TOKEN=sk-relay") || !strings.HasSuffix(joined, "ANTHROPIC_API_KEY=") {
 		t.Fatalf("relay should use bearer auth token: %v", relay)
 	}
 
@@ -68,11 +68,24 @@ func TestModelEndpointClaudeEnvSelectsAuthShape(t *testing.T) {
 		APIKey:   "sk-ant",
 	})
 	joined = strings.Join(official, "\n")
-	if !strings.Contains(joined, "ANTHROPIC_API_KEY=sk-ant") || strings.Contains(joined, "ANTHROPIC_AUTH_TOKEN=") {
+	if !strings.Contains(joined, "ANTHROPIC_API_KEY=sk-ant") || !strings.HasSuffix(joined, "ANTHROPIC_AUTH_TOKEN=") {
 		t.Fatalf("official endpoint should use api key: %v", official)
 	}
 	if !strings.Contains(joined, "ANTHROPIC_BASE_URL=https://api.anthropic.com") {
 		t.Fatalf("official base url should drop /v1 suffix: %v", official)
+	}
+
+	kimiCoding := modelEndpointClaudeEnv(&ModelEndpointConfig{
+		Protocol: "anthropic",
+		BaseURL:  "https://api.kimi.com/coding/",
+		APIKey:   "sk-kimi",
+	})
+	joined = strings.Join(kimiCoding, "\n")
+	if !strings.Contains(joined, "ANTHROPIC_API_KEY=sk-kimi") || !strings.HasSuffix(joined, "ANTHROPIC_AUTH_TOKEN=") {
+		t.Fatalf("Kimi Coding should use api key auth: %v", kimiCoding)
+	}
+	if !strings.Contains(joined, "ANTHROPIC_BASE_URL=https://api.kimi.com/coding/") {
+		t.Fatalf("Kimi Coding base url should be preserved: %v", kimiCoding)
 	}
 
 	if env := modelEndpointClaudeEnv(&ModelEndpointConfig{Protocol: "openai", BaseURL: "https://x", APIKey: "k"}); env != nil {

--- a/services/tuttid/service/agent/workspace_agent_resolution_test.go
+++ b/services/tuttid/service/agent/workspace_agent_resolution_test.go
@@ -82,6 +82,67 @@ func TestResolveCreateSessionLaunchHydratesWorkspaceAgentRuntimeConfiguration(t 
 	}
 }
 
+func TestGetComposerOptionsResolvesWorkspaceAgentModelPlan(t *testing.T) {
+	plan := modelplanbiz.Plan{
+		ID:           "mp-kimi",
+		WorkspaceID:  "ws",
+		Revision:     6,
+		Name:         "Kimi",
+		Protocol:     modelplanbiz.ProtocolAnthropic,
+		APIKey:       "secret",
+		BaseURL:      "https://api.kimi.example/coding/",
+		Models:       []modelplanbiz.Model{{ID: "k3", Name: "K3"}},
+		DefaultModel: "k3",
+		Enabled:      true,
+	}
+	service := NewService(newFakeRuntime())
+	service.WorkspaceAgentResolver = staticWorkspaceAgentResolver{resolved: workspaceagentbiz.Resolved{
+		Agent: workspaceagentbiz.Agent{
+			ID:                   "workspace-agent:kimi",
+			WorkspaceID:          "ws",
+			Name:                 "Kimi Agent",
+			HarnessAgentTargetID: "local:claude-code",
+			DefaultModel:         "k3",
+			Revision:             1,
+		},
+		HarnessTarget: agenttargetbiz.Target{
+			ID:            "local:claude-code",
+			Provider:      "claude-code",
+			LaunchRefJSON: agenttargetbiz.MustLocalCLILaunchRefJSON("claude-code"),
+			Name:          "Claude Code",
+			Source:        agenttargetbiz.SourceSystem,
+			Enabled:       true,
+		},
+		ModelPlan:      &plan,
+		EffectiveModel: "k3",
+	}}
+	includeCapabilityCatalog := false
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		WorkspaceID:              "ws",
+		AgentTargetID:            "workspace-agent:kimi",
+		Provider:                 "claude-code",
+		IncludeCapabilityCatalog: &includeCapabilityCatalog,
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions() error = %v", err)
+	}
+	if options.EffectiveSettings.Model != "k3" ||
+		len(options.ModelConfig.Options) != 1 ||
+		options.ModelConfig.Options[0].ID != "k3" {
+		t.Fatalf("GetComposerOptions() model config = %#v", options.ModelConfig)
+	}
+	configuration, ok := options.RuntimeContext["modelConfiguration"].(map[string]any)
+	if !ok ||
+		configuration["agentTargetId"] != "workspace-agent:kimi" ||
+		configuration["modelPlanId"] != "mp-kimi" {
+		t.Fatalf(
+			"GetComposerOptions() model configuration = %#v",
+			options.RuntimeContext["modelConfiguration"],
+		)
+	}
+}
+
 func TestResolveCreateSessionLaunchPreservesExplicitWorkspaceAgentModel(t *testing.T) {
 	plan := modelplanbiz.Plan{ID: "mp-one", Revision: 2, Enabled: true}
 	service := &Service{

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -60,6 +60,22 @@ import (
 	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
 )
 
+type workspaceAgentTargetResolverSetter interface {
+	SetWorkspaceAgentTargetResolver(agentservice.WorkspaceAgentTargetResolver)
+}
+
+func configureWorkspaceAgentResolution(
+	agentSessions *agentservice.Service,
+	activityProjection workspaceAgentTargetResolverSetter,
+	workspaceAgents *workspaceagentservice.Service,
+	workspaceAgentTargets agentservice.WorkspaceAgentTargetResolver,
+) {
+	agentSessions.WorkspaceAgentResolver = workspaceAgents
+	if workspaceAgentTargets != nil {
+		activityProjection.SetWorkspaceAgentTargetResolver(workspaceAgentTargets)
+	}
+}
+
 func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analyticsReporter reporterservice.Reporter, browserService *browsersvc.Service, computerService *computersvc.Service) (tuttiapi.DaemonAPI, *workspaceservice.AppCenterService, *agentdaemon.Runtime, *agentservice.ProviderAuthWatcher, error) {
 	workspaceStore, _ := store.(workspacedata.WorkbenchStore)
 	issueStore, _ := store.(workspaceissues.Store)
@@ -281,6 +297,12 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 	agentSessionService.ConfigureModelPlanBinding(modelBindingsStore, modelPlansStore)
 	agentSessionService.ModelCapabilities = agentModelCapabilities
 	agentSessionService.AgentTargetStore = agentTargetStore
+	configureWorkspaceAgentResolution(
+		agentSessionService,
+		agentActivityProjection,
+		workspaceAgents,
+		workspaceAgentsStore,
+	)
 	agentSessionService.AgentComposerDefaultsReader = preferences
 	preferences.AgentComposerDefaultsValidator = agentSessionService
 	agentSessionService.ExtensionComposerProfiles = agentExtensionComposerProfileResolver{

--- a/services/tuttid/wiring_test.go
+++ b/services/tuttid/wiring_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"testing"
 
+	workspaceagentbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceagent"
+	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
+	workspaceagentservice "github.com/tutti-os/tutti/services/tuttid/service/workspaceagent"
 	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
 )
 
@@ -36,6 +39,53 @@ func TestResolveAnalyticsDebugPublisherSkipsDisabledAnalytics(t *testing.T) {
 
 	if got != nil {
 		t.Fatalf("debug publisher = %T, want nil", got)
+	}
+}
+
+type recordingWorkspaceAgentTargetResolverSetter struct {
+	resolver agentservice.WorkspaceAgentTargetResolver
+}
+
+func (r *recordingWorkspaceAgentTargetResolverSetter) SetWorkspaceAgentTargetResolver(
+	resolver agentservice.WorkspaceAgentTargetResolver,
+) {
+	r.resolver = resolver
+}
+
+type fakeWorkspaceAgentTargetResolver struct{}
+
+func (fakeWorkspaceAgentTargetResolver) GetWorkspaceAgent(
+	context.Context,
+	string,
+	string,
+) (workspaceagentbiz.Agent, error) {
+	return workspaceagentbiz.Agent{}, nil
+}
+
+func TestConfigureWorkspaceAgentResolutionWiresLaunchAndProjection(t *testing.T) {
+	agentSessions := &agentservice.Service{}
+	activityProjection := &recordingWorkspaceAgentTargetResolverSetter{}
+	workspaceAgents := &workspaceagentservice.Service{}
+	workspaceAgentTargets := fakeWorkspaceAgentTargetResolver{}
+
+	configureWorkspaceAgentResolution(
+		agentSessions,
+		activityProjection,
+		workspaceAgents,
+		workspaceAgentTargets,
+	)
+
+	if agentSessions.WorkspaceAgentResolver != workspaceAgents {
+		t.Fatalf(
+			"agent session WorkspaceAgentResolver = %T, want workspace agent service",
+			agentSessions.WorkspaceAgentResolver,
+		)
+	}
+	if activityProjection.resolver != workspaceAgentTargets {
+		t.Fatalf(
+			"activity projection WorkspaceAgentTargetResolver = %T, want workspace agent service",
+			activityProjection.resolver,
+		)
 	}
 }
 


### PR DESCRIPTION
## Summary

- restore workspace custom-Agent directory projection and daemon resolver wiring so configured Agents remain visible and their model / reasoning options can load
- preserve workspace Agents without icons and bind the desktop workspace window to the workspace-Agent service expected by the composer
- prepare Kimi Coding Model Plan credentials with `ANTHROPIC_API_KEY` (while clearing the conflicting auth-token variable) instead of applying the generic non-Anthropic Bearer-token rule
- surface Claude SDK `assistant.error` and `result.is_error` events as failed messages / turns instead of leaving a sent message waiting indefinitely
- redact transport authorization values from exported runtime context and document the troubleshooting path

## Root cause

This restores the custom-Agent resolution path expected by #1536 while retaining the model binding introduced around #1412. The relevant logic had become split across UI projection, workspace service registration, and daemon wiring:

1. Workspace Agents could be filtered out during desktop projection when no icon existed, and the workspace container did not expose the service needed to resolve the selected custom Agent.
2. The daemon API wiring did not install the workspace-Agent resolver, so an ID visible in the composer could not reliably resolve to its stored runtime/model configuration.
3. Runtime preparation classified every non-Anthropic endpoint as an `ANTHROPIC_AUTH_TOKEN` Bearer endpoint. Kimi Coding Model Plan uses the Claude SDK compatibility path but requires `ANTHROPIC_API_KEY`, so model validation could succeed while the actual Agent request failed authorization.
4. Claude SDK error events were not promoted to terminal turn failures, making the UI look as though messages were swallowed or perpetually loading.

## Validation

- `pnpm check:changed -- --push-ready` — passed 26 lanes
- `pnpm --dir packages/agent/claude-sdk-sidecar test` — 91 tests passed
- `pnpm --dir packages/agent/claude-sdk-sidecar typecheck` — passed
- `go test ./packages/agent/runtimeprep ./packages/agent/daemon/runtime` — passed
- commit hooks: formatting, Oxlint, Electron/UI/renderer/Agent GUI boundary checks — passed
- `git diff --check origin/main...HEAD` — passed

## Documentation

Updated Agent GUI/workspace-Agent/model-access architecture notes plus logging and Agent provider/runtime troubleshooting guidance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication env injection, daemon session wiring, and Claude turn lifecycle; changes are well-tested but affect credential handling and session projection.
> 
> **Overview**
> Restores **workspace custom Agents** end-to-end: the desktop directory keeps iconless Agents selectable, resolves icons from the Harness target ID then provider catalog, and wires `resolveAgentTargetIconUrl` through the workspace window. The daemon composition root now connects **session launch** (`WorkspaceAgentResolver`) and **activity projection** (`SetWorkspaceAgentTargetResolver`) so composer options and projected sessions match configured Agents.
> 
> Fixes **Kimi Coding Model Plans** for Claude Code by treating `api.kimi.com` like the official Anthropic endpoint (`ANTHROPIC_API_KEY`, clearing `ANTHROPIC_AUTH_TOKEN`) so detection and runtime auth align.
> 
> **Claude SDK** paths now surface `assistant.error` / `result.is_error` as failed assistant messages and terminal turns instead of hanging on `subtype: success`.
> 
> **Developer log exports** allowlist transport diagnostics and drop access tokens and extra snapshot fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76b5f5bc51c280fa7f23b1bd5bba3389685cd9f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->