### PR TITLE
fix(workspace-files): render fallback icons without assets

### DIFF
--- a/docs/conventions/troubleshooting/toolchain-browser-terminal.md
+++ b/docs/conventions/troubleshooting/toolchain-browser-terminal.md
@@ -540,22 +540,22 @@ emitted before this method can be called`, especially after HMR, navigation,
   Let the business consumer import that asset only when it needs the default
   visual, and keep the package build rule that copies the asset into the packed
   `dist/assets` directory.
-  When the package runtime intentionally owns the default visual, import the
-  explicit public asset subpath from that runtime and keep the asset import
-  external in the package build. This lets the consumer bundler observe and
-  rewrite the asset dependency instead of inferring it from `import.meta.url`.
-  If Node-based consumers also evaluate the runtime, give the same public asset
-  subpath conditional exports: a browser condition that targets the image and
-  a Node condition that targets a sibling JavaScript module returning the
-  module-relative file URL. Do not require every consumer to add a test alias
-  for the published package.
+  When the package runtime owns an always-available default icon, prefer a
+  code-owned UI-system SVG component so the runtime does not import an image at
+  all. Conditional asset exports are not sufficient for this case: a
+  browser-conditioned test environment can select the image target and then
+  externalize the package for Node execution, which still fails on `.png`.
+  Keep explicit public asset subpaths only for browser consumers that knowingly
+  opt into the artwork. Do not require every consumer to add a test alias for
+  the published package.
   Apply the same rule to every public runtime subpath in the package, not just
   the first failing icon.
 - Validation:
   Build the affected package, inspect the built runtime entrypoint for the
   absence of the old asset dependency, and rerun `pnpm release:pack:check`.
-  Import the packed public asset subpath with Node and run a real Vite
-  dependency-prebundle fixture; both paths must succeed.
+  Import any intentionally supported packed asset subpath with Node and run a
+  real Vite dependency-prebundle fixture. The optimized root runtime must
+  contain the code-owned fallback icon and no fallback image dependency.
   If the package is consumed by desktop renderer code in this repo, also run
   the relevant desktop build to confirm the consumer bundler copies or emits
   the asset only when the business import is present.

--- a/packages/ui/system/src/icons/system-icons.tsx
+++ b/packages/ui/system/src/icons/system-icons.tsx
@@ -670,6 +670,37 @@ export function FileCodeIcon(props: IconProps) {
   );
 }
 
+export function FileArchiveIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path
+        d="M6 2H14L19 7V20C19 21.1046 18.1046 22 17 22H6C4.89543 22 4 21.1046 4 20V4C4 2.89543 4.89543 2 6 2Z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="2"
+      />
+      <path
+        d="M14 2V7H19"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="2"
+      />
+      <path
+        d="M10 3V5H12V7H10V9H12V11H10V13"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="2"
+      />
+      <path
+        d="M9 13H13V17H9V13Z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="2"
+      />
+    </SvgIcon>
+  );
+}
+
 export function TerminalLinedIcon(props: IconProps) {
   return (
     <FilledPathIcon {...props}>

--- a/packages/ui/system/src/metadata/components.json
+++ b/packages/ui/system/src/metadata/components.json
@@ -2460,6 +2460,20 @@
       "iconVariant": "filled"
     },
     {
+      "id": "file-archive-lined-icon",
+      "layer": "base",
+      "name": "FileArchiveIcon",
+      "export": "FileArchiveIcon",
+      "from": "@tutti-os/ui-system/icons",
+      "category": "icon",
+      "status": "stable",
+      "source": "src/icons/system-icons.tsx",
+      "description": "System icon for archive and compressed files.",
+      "useCases": ["Archive file items", "Compressed file previews"],
+      "migrationHints": [],
+      "iconVariant": "lined"
+    },
+    {
       "id": "terminal-lined-icon",
       "layer": "base",
       "name": "TerminalLinedIcon",

--- a/packages/workspace/file-manager/README.md
+++ b/packages/workspace/file-manager/README.md
@@ -43,14 +43,14 @@ drag movement.
 Hosts now provide one app-level i18n runtime and scope it into the file-manager
 namespace, rather than hand-assembling package-local message objects.
 
-The React surface owns its archive and folder fallback artwork. Runtime code
-loads the artwork through the stable
-`@tutti-os/workspace-file-manager/assets/workspace-*-fallback.png` subpaths.
-The published export maps each subpath to the PNG in browser conditions and to
-a JavaScript URL module in Node conditions. Browser bundlers therefore
-preserve asset handling during dependency prebundling, while Node-based test
-runners evaluate JavaScript instead of importing a `.png` file. Keep the root
-entry free of relative `new URL("./assets/...", import.meta.url)` references.
+The React surface renders its default archive and folder fallbacks with
+code-owned `@tutti-os/ui-system` SVG icon components. Keep the package root free
+of fallback image imports: browser-conditioned test environments may select a
+raw image export and then externalize the package for Node execution, which
+cannot evaluate `.png` modules. The legacy
+`@tutti-os/workspace-file-manager/assets/workspace-*-fallback.png` subpaths
+remain available to browser consumers that explicitly need the artwork, but
+the shared runtime does not depend on them.
 
 What stays outside this package is concrete host integration: desktop preload
 calls, tuttid transport wiring, host absolute paths, import/export/upload

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileEntryIcon.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileEntryIcon.tsx
@@ -1,6 +1,8 @@
 import {
+  FileArchiveIcon,
   FileCodeIcon,
   FileTextIcon,
+  FolderFilledIcon,
   ImageFileIcon,
   LoadingIcon,
   VideoFileIcon,
@@ -13,10 +15,6 @@ import {
   resolveWorkspaceFileVisualKind
 } from "@tutti-os/workspace-file-preview";
 import type { WorkspaceFileEntry } from "../services/workspaceFileManagerTypes.ts";
-import {
-  workspaceArchiveFallbackIconUrl,
-  workspaceFolderFallbackIconUrl
-} from "../workspaceFileFallbackAssets.ts";
 import {
   resolveWorkspaceFileEntryIconCacheKey,
   isWorkspaceApplicationBundle,
@@ -237,14 +235,7 @@ export function WorkspaceFolderFallbackIcon({
   className: string;
 }): ReactElement {
   return (
-    <img
-      alt=""
-      aria-hidden="true"
-      className={cn("object-contain", className)}
-      decoding="async"
-      draggable={false}
-      src={workspaceFolderFallbackIconUrl}
-    />
+    <FolderFilledIcon className={vectorFallbackIconClassName(className)} />
   );
 }
 
@@ -253,16 +244,7 @@ export function WorkspaceArchiveFallbackIcon({
 }: {
   className: string;
 }): ReactElement {
-  return (
-    <img
-      alt=""
-      aria-hidden="true"
-      className={cn("object-contain", className)}
-      decoding="async"
-      draggable={false}
-      src={workspaceArchiveFallbackIconUrl}
-    />
-  );
+  return <FileArchiveIcon className={vectorFallbackIconClassName(className)} />;
 }
 
 export function WorkspaceImageFallbackIcon({

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.render.test.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.render.test.tsx
@@ -7,9 +7,48 @@ import {
   workspaceFileManagerI18nResources
 } from "../i18n/workspaceFileManagerI18n.ts";
 import type { WorkspaceFileEntry } from "../services/workspaceFileManagerTypes.ts";
+import {
+  WorkspaceArchiveFallbackIcon,
+  WorkspaceFolderFallbackIcon
+} from "./WorkspaceFileEntryIcon.tsx";
 import { WorkspaceFileManagerPanels } from "./WorkspaceFileManagerPanels.tsx";
 
 describe("WorkspaceFileManagerPanels", () => {
+  it.each([
+    ["archive", WorkspaceArchiveFallbackIcon],
+    ["folder", WorkspaceFolderFallbackIcon]
+  ] as const)(
+    "renders the %s fallback as a code-owned SVG without an image request",
+    async (_kind, FallbackIcon) => {
+      const container = document.createElement("div");
+      document.body.append(container);
+      const root = createRoot(container);
+      const previousActEnvironment = (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT;
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = true;
+
+      try {
+        await act(async () => {
+          root.render(<FallbackIcon className="size-4" />);
+        });
+
+        expect(container.querySelector("svg")).not.toBeNull();
+        expect(container.querySelector("img")).toBeNull();
+      } finally {
+        await act(async () => {
+          root.unmount();
+        });
+        container.remove();
+        (
+          globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+        ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+      }
+    }
+  );
+
   it("keeps row activation and directory disclosure as sibling buttons", async () => {
     const entry: WorkspaceFileEntry = {
       hasChildren: true,

--- a/packages/workspace/file-manager/src/workspaceFileFallbackAssets.ts
+++ b/packages/workspace/file-manager/src/workspaceFileFallbackAssets.ts
@@ -1,4 +1,0 @@
-import workspaceArchiveFallbackIconUrl from "@tutti-os/workspace-file-manager/assets/workspace-archive-fallback.png";
-import workspaceFolderFallbackIconUrl from "@tutti-os/workspace-file-manager/assets/workspace-folder-fallback.png";
-
-export { workspaceArchiveFallbackIconUrl, workspaceFolderFallbackIconUrl };

--- a/tools/fixtures/workspace-file-manager-external-vite/vite-dev-assets.test.mjs
+++ b/tools/fixtures/workspace-file-manager-external-vite/vite-dev-assets.test.mjs
@@ -32,30 +32,10 @@ try {
   );
   assert.doesNotMatch(
     optimizedSource,
-    /\.vite\/deps\/assets\/workspace-(?:archive|folder)-fallback\.png/u
+    /workspace-(?:archive|folder)-fallback\.png/u
   );
-
-  for (const fallbackKind of ["archive", "folder"]) {
-    const assetModulePath = matchFirst(
-      optimizedSource,
-      new RegExp(
-        `["']([^"']*workspace-${fallbackKind}-fallback\\.png\\?[^"']*)["']`,
-        "u"
-      ),
-      `${fallbackKind} fallback asset module`
-    );
-    const assetModuleSource = await fetchText(
-      new URL(assetModulePath, origin).href
-    );
-    const assetPath = matchFirst(
-      assetModuleSource,
-      /export default\s+["']([^"']+)["']/u,
-      `${fallbackKind} fallback asset URL`
-    );
-    const assetResponse = await fetch(new URL(assetPath, origin));
-    assert.equal(assetResponse.status, 200);
-    assert.equal(assetResponse.headers.get("content-type"), "image/png");
-  }
+  assert.match(optimizedSource, /FileArchiveIcon/u);
+  assert.match(optimizedSource, /FolderFilledIcon/u);
 } finally {
   await server.close();
 }

--- a/tools/fixtures/workspace-file-manager-external-vite/vite.config.ts
+++ b/tools/fixtures/workspace-file-manager-external-vite/vite.config.ts
@@ -16,16 +16,7 @@ export default defineConfig({
       {
         find: /^@tutti-os\/workspace-file-manager$/u,
         replacement: fileURLToPath(new URL("index.js", packageRoot))
-      },
-      ...["archive", "folder"].map((fallbackKind) => ({
-        find: new RegExp(
-          `^@tutti-os/workspace-file-manager/assets/workspace-${fallbackKind}-fallback\\.png$`,
-          "u"
-        ),
-        replacement: fileURLToPath(
-          new URL(`assets/workspace-${fallbackKind}-fallback.png`, packageRoot)
-        )
-      }))
+      }
     ]
   }
 });

--- a/tools/scripts/check-package-packs.mjs
+++ b/tools/scripts/check-package-packs.mjs
@@ -152,14 +152,14 @@ async function checkPackage(packageConfig, destination) {
         "fallback asset URL is relative to the bundled module location"
       );
     }
-    for (const assetName of [
-      "workspace-archive-fallback.png",
-      "workspace-folder-fallback.png"
-    ]) {
-      const publicAssetSpecifier = `@tutti-os/workspace-file-manager/assets/${assetName}`;
-      if (!mainEntrySource.includes(publicAssetSpecifier)) {
-        violations.push(`missing public asset import ${publicAssetSpecifier}`);
-      }
+    if (
+      /@tutti-os\/workspace-file-manager\/assets\/workspace-(?:archive|folder)-fallback\.png/u.test(
+        mainEntrySource
+      )
+    ) {
+      violations.push(
+        "main runtime imports a fallback image instead of a code-owned UI icon"
+      );
     }
     try {
       execFileSync(


### PR DESCRIPTION
## Summary

- render archive and folder fallbacks with code-owned UI System SVG icons
- remove fallback image imports from the workspace file manager root runtime
- keep explicit legacy asset subpaths available for browser consumers
- strengthen packed-package and real Vite prebundle regression coverage
- document the browser-conditioned Vitest externalization trap

## Root cause

The published workspace file manager root statically imported its fallback PNGs. Vite dependency optimization could relocate the runtime away from those assets, while browser-conditioned Vitest runs could select the PNG export and then externalize the package for Node execution. Conditional exports therefore did not eliminate the runtime asset dependency across consumers.

## Validation

- `pnpm --filter @tutti-os/workspace-file-manager test`
- `pnpm --filter @tutti-os/ui-system test`
- `pnpm --filter @tutti-os/ui-system typecheck`
- `pnpm --filter @tutti-os/workspace-file-manager typecheck`
- `pnpm --filter @tutti-os/ui-storyboard typecheck`
- `node tools/scripts/check-ui-metadata.mjs`
- `pnpm check:ui-boundaries`
- `pnpm --filter @tutti-os/fixture-workspace-file-manager-external-vite test`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm release:pack:check`
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->