### PR TITLE
feat(workspace-files): add reference picker error recovery

### DIFF
--- a/.changeset/reference-picker-content-error-retry.md
+++ b/.changeset/reference-picker-content-error-retry.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/workspace-file-reference": minor
+---
+
+Allow hosts to expose a centered retry action for selected reference-picker content errors.

--- a/packages/workspace/file-reference/README.md
+++ b/packages/workspace/file-reference/README.md
@@ -18,3 +18,19 @@ apply active constraints before pagination. The package does not fetch a
 catalog or infer product-specific membership itself. Disabled catalog options
 remain available to host logic but are hidden by the controlled filter view by
 default; a host can opt into rendering them with `showDisabledOptions`.
+
+## Content error recovery
+
+`ReferenceSourcePicker` accepts `resolveContentErrorAction` when a host can
+offer recovery for selected content errors. Return an action label for errors
+that should be retryable, or `null` to keep the default message-only state.
+Selecting the action reruns the failed browse, search, or filtered-tree request.
+
+```tsx
+<ReferenceSourcePicker
+  resolveContentErrorAction={(error) =>
+    isRecoverable(error) ? { label: copy.t("actions.retry") } : null
+  }
+  {...props}
+/>
+```

--- a/packages/workspace/file-reference/src/react/internal/reference/useReferenceSourcePickerView.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/useReferenceSourcePickerView.ts
@@ -184,6 +184,7 @@ export function useReferenceSourcePickerView({
       loading: false
     }
   );
+  const [filteredTreeRetrySequence, setFilteredTreeRetrySequence] = useState(0);
   const openWithApplicationsCache = useRef(
     new WorkspaceFileOpenWithApplicationsCache()
   );
@@ -309,9 +310,17 @@ export function useReferenceSourcePickerView({
       ? JSON.stringify([activeSourceId, recursiveFilters])
       : null;
   const recursiveFilterActive = recursiveFilterKey !== null;
+  const recursiveFilterRequestKey = recursiveFilterKey
+    ? `${recursiveFilterKey}:${filteredTreeRetrySequence}`
+    : null;
 
   useEffect(() => {
-    if (!open || !activeSourceId || !recursiveFilterKey) {
+    if (
+      !open ||
+      !activeSourceId ||
+      !recursiveFilterKey ||
+      !recursiveFilterRequestKey
+    ) {
       setFilteredTreeState({
         childrenByKey: {},
         error: null,
@@ -362,6 +371,7 @@ export function useReferenceSourcePickerView({
     aggregator,
     open,
     recursiveFilterKey,
+    recursiveFilterRequestKey,
     recursiveFilters,
     scope
   ]);
@@ -941,6 +951,20 @@ export function useReferenceSourcePickerView({
     },
     loadMore: () =>
       isQuery ? controller.loadMoreSearch() : controller.loadMore(currentNode),
+    retryContent: () => {
+      if (isQuery) {
+        controller.setSearchQuery(
+          activeTabState?.searchQuery ?? "",
+          searchScopeNodeId
+        );
+        return;
+      }
+      if (recursiveFilterActive) {
+        setFilteredTreeRetrySequence((current) => current + 1);
+        return;
+      }
+      controller.refreshChildren(currentNode);
+    },
     isSelectable,
     isSelected,
     isOpeningReference,

--- a/packages/workspace/file-reference/src/ui/index.ts
+++ b/packages/workspace/file-reference/src/ui/index.ts
@@ -5,6 +5,7 @@ export {
 export {
   ReferenceSourceContentPane,
   ReferenceSourcePicker,
+  type ReferenceSourceContentErrorAction,
   type ReferenceSourceContentPaneProps,
   type ReferenceSourcePickerProps
 } from "./internal/reference/ReferenceSourcePicker.tsx";

--- a/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.render.test.ts
+++ b/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.render.test.ts
@@ -107,6 +107,40 @@ test("reference source picker renders shared folder icons and content errors", a
       "referencePicker.loadError"
     );
 
+    let retryContentCount = 0;
+    (
+      globalThis as { __referenceSourcePickerView?: unknown }
+    ).__referenceSourcePickerView = {
+      ...createFolderOnlyView(folderNode),
+      contentError: new Error("host access denied"),
+      currentEntries: [],
+      retryContent() {
+        retryContentCount += 1;
+      }
+    };
+    await act(async () => {
+      root?.render(
+        createElement(ReferenceSourcePicker, {
+          aggregator: {},
+          copy: createCopy(),
+          onClose() {},
+          onConfirm() {},
+          open: true,
+          resolveContentErrorAction: () => ({ label: "Authorize again" }),
+          workspaceId: "workspace-reference-content-error-action-test"
+        } as unknown as ReferenceSourcePickerProps)
+      );
+    });
+
+    const retryContentButton = Array.from(
+      dom.window.document.querySelectorAll("button")
+    ).find((button) => button.textContent === "Authorize again");
+    assert.ok(retryContentButton);
+    await act(async () => {
+      retryContentButton.click();
+    });
+    assert.equal(retryContentCount, 1);
+
     (
       globalThis as { __referenceSourcePickerView?: unknown }
     ).__referenceSourcePickerView = {

--- a/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.tsx
+++ b/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.tsx
@@ -84,6 +84,9 @@ import {
 export interface ReferenceSourcePickerProps {
   aggregator: ReferenceSourceAggregator;
   copy: WorkspaceFileReferenceCopy;
+  resolveContentErrorAction?: (
+    error: Error
+  ) => ReferenceSourceContentErrorAction | null;
   /** 可选:打开时直达某事项/应用分组(展开并聚焦)。 */
   initialTarget?: ReferenceLocateTarget | null;
   isNodeSelectable?: (node: ReferenceNode) => boolean;
@@ -105,6 +108,10 @@ export interface ReferenceSourcePickerProps {
   open: boolean;
   purpose?: "directory" | "reference";
   workspaceId: string;
+}
+
+export interface ReferenceSourceContentErrorAction {
+  label: string;
 }
 
 /**
@@ -176,6 +183,7 @@ export function ReferenceSourcePicker({
   onConfirmBundles,
   open,
   purpose = "reference",
+  resolveContentErrorAction,
   resolveEntryIconUrl,
   resolveOpenWithApplicationIcon,
   workspaceId
@@ -207,6 +215,9 @@ export function ReferenceSourcePicker({
   const hasVisibleContent = view.isQuery
     ? view.searchResults.length > 0
     : view.currentEntries.length > 0;
+  const contentErrorAction = view.contentError
+    ? (resolveContentErrorAction?.(view.contentError) ?? null)
+    : null;
 
   // 文件类型筛选已下沉为查询参数(view.activeFilters);此处只做切换/清空的转发。
   const activeFilterSet = new Set(view.activeFilters);
@@ -699,7 +710,11 @@ export function ReferenceSourcePicker({
                           <Spinner size={16} />
                         </Feedback>
                       ) : view.contentError && !hasVisibleContent ? (
-                        <ContentError copy={copy} />
+                        <ContentError
+                          action={contentErrorAction}
+                          copy={copy}
+                          onAction={view.retryContent}
+                        />
                       ) : view.isQuery ? (
                         // 查询态(关键词或筛选):扁平结果
                         view.searchResults.length === 0 ? (
@@ -752,7 +767,12 @@ export function ReferenceSourcePicker({
                         ))
                       )}
                       {view.contentError && hasVisibleContent ? (
-                        <ContentError copy={copy} inline />
+                        <ContentError
+                          action={contentErrorAction}
+                          copy={copy}
+                          inline
+                          onAction={view.retryContent}
+                        />
                       ) : null}
                       {view.hasMore && (view.isQuery || hasSelectedGroup) ? (
                         <Button
@@ -1931,19 +1951,33 @@ function Feedback({ children }: { children: ReactNode }): JSX.Element {
 }
 
 function ContentError({
+  action,
   copy,
-  inline = false
+  inline = false,
+  onAction
 }: {
+  action?: ReferenceSourceContentErrorAction | null;
   copy: WorkspaceFileReferenceCopy;
   inline?: boolean;
+  onAction?: () => void;
 }): JSX.Element {
   const content = (
     <div
-      className="flex max-w-sm items-center gap-2 text-[var(--state-danger)]"
+      className={cn(
+        "flex max-w-sm gap-3",
+        inline ? "items-center" : "flex-col items-center"
+      )}
       role="alert"
     >
-      <WarningLinedIcon className="size-5 shrink-0" />
-      <span>{copy.t("referencePicker.loadError")}</span>
+      <div className="flex items-center gap-2 text-[var(--state-danger)]">
+        <WarningLinedIcon className="size-5 shrink-0" />
+        <span>{copy.t("referencePicker.loadError")}</span>
+      </div>
+      {action && onAction ? (
+        <Button size="sm" type="button" variant="secondary" onClick={onAction}>
+          {action.label}
+        </Button>
+      ) : null}
     </div>
   );
   if (inline) {


### PR DESCRIPTION
## Summary

- add an optional host-resolved action to reference-picker content errors
- render the action below centered standalone errors using the shared UI System button
- retry the current browse, search, or filtered-tree request when selected
- document the public API and add render coverage

## Why

Hosts need to distinguish recoverable failures such as denied local-directory access from generic loading failures. The existing picker only rendered a static error message, so users had no way to explicitly retry and reopen the host authorization flow.

## Validation

- `pnpm --filter @tutti-os/workspace-file-reference test` (86 passed)
- `pnpm --filter @tutti-os/workspace-file-reference typecheck`
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready` (10 lanes passed)