### PR TITLE
feat: migrate Tutti assets to Cloudflare Asset Delivery

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAccountMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAccountMenu.tsx
@@ -4,6 +4,7 @@ import {
   AgentGUIAccountMenu,
   AgentGUIAccountRewardToast,
   agentGUIAccountInitials,
+  buildAssetUrl,
   type AgentGUIAccountMenuLabels,
   type AgentGUIAccountMenuState
 } from "@tutti-os/agent-gui";
@@ -122,7 +123,7 @@ function useWorkspaceAccountMenuState(): WorkspaceAccountMenuState {
             userId: user.user_id,
             name: user.name,
             email: user.email,
-            avatar: user.avatar
+            assetUrl: user.assetUrl
           }
         : null,
       membershipLabel,
@@ -312,11 +313,15 @@ const WorkspaceAccountMenuView = memo(function WorkspaceAccountMenuView({
                 className="grid size-7 place-items-center overflow-hidden rounded-full bg-[color-mix(in_srgb,var(--workbench-chrome-foreground)_16%,transparent)] text-[12px] font-semibold"
                 data-testid="workspace-account-avatar"
               >
-                {accountMenuState.user.avatar ? (
+                {accountMenuState.user.assetUrl ? (
                   <img
                     alt=""
                     className="size-full object-cover"
-                    src={accountMenuState.user.avatar}
+                    src={buildAssetUrl(accountMenuState.user.assetUrl, {
+                      kind: "avatar",
+                      size: 48,
+                      format: "webp"
+                    })}
                   />
                 ) : (
                   <span aria-hidden="true">{initials}</span>

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -7,6 +7,7 @@ import {
   useSyncExternalStore
 } from "react";
 import { createPortal } from "react-dom";
+import { buildAssetUrl } from "@tutti-os/agent-gui";
 import { useService } from "@tutti-os/infra/di";
 import type { WorkspaceSummary } from "@tutti-os/client-tuttid-ts";
 import { INotificationService } from "@tutti-os/ui-notifications";
@@ -2800,12 +2801,16 @@ function WorkspaceAccountSettingsSection() {
     <div className="flex flex-col gap-6 pb-[22px] pt-5">
       <div className="flex min-w-0 items-center justify-between gap-4 max-[560px]:flex-col max-[560px]:items-stretch">
         <div className="flex min-w-0 flex-1 items-center gap-3">
-          {user?.avatar ? (
+          {user?.assetUrl ? (
             <img
               alt=""
               className="size-12 shrink-0 rounded-full object-cover"
               draggable={false}
-              src={user.avatar}
+              src={buildAssetUrl(user.assetUrl, {
+                kind: "avatar",
+                size: 48,
+                format: "webp"
+              })}
             />
           ) : (
             <div className="grid size-12 shrink-0 place-items-center rounded-full bg-[var(--transparency-block)] text-[18px] font-semibold text-[var(--text-primary)]">

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
@@ -364,7 +364,7 @@ function createTestSessionProvider(
             agentTargetId: session.agentTargetId,
             agentName: testProviderLabel(session.provider),
             id: session.agentSessionId,
-            initiatorAvatarUrl: profile?.avatar ?? "",
+            initiatorAvatarUrl: profile?.assetUrl ?? "",
             initiatorName: profile?.name || userId,
             provider: session.provider,
             scope:
@@ -2288,12 +2288,14 @@ describe("AgentMentionSearchController", () => {
           {
             userId: "user-1",
             name: "Wang",
-            avatar: "https://cdn.example.com/wang.png"
+            assetUrl:
+              "https://assets.tutti.sh/v1/assets/member-wang/account_avatar/wang.png"
           },
           {
             userId: "user-2",
             name: "Alice",
-            avatar: "https://cdn.example.com/alice.png"
+            assetUrl:
+              "https://assets.tutti.sh/v1/assets/member-alice/account_avatar/alice.png"
           }
         ]
       }),

--- a/packages/agent/gui/agent-gui/agentGuiNode/accountMenuState.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/accountMenuState.ts
@@ -9,7 +9,7 @@ export interface AgentGUIAccountMenuState {
     userId: string;
     name?: string | null;
     email?: string | null;
-    avatar?: string | null;
+    assetUrl?: string | null;
   } | null;
   membershipLabel: string;
   /**

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentMentionSearchHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentMentionSearchHelpers.ts
@@ -1,4 +1,5 @@
 import type { AgentHostUserInfo } from "../../shared/contracts/dto";
+import { buildAssetUrl } from "../../shared/assetUrl";
 import { translate } from "../../i18n/index";
 import { agentMentionEmptyGroupLabel } from "./AgentMentionLabels";
 import {
@@ -32,7 +33,7 @@ export function buildSessionMentionItem(input: {
   currentUserId: string;
   session: AgentActivitySession;
   summary: WorkspaceAgentActivitySessionSummary | null;
-  userProfiles: Record<string, Pick<AgentHostUserInfo, "name" | "avatar">>;
+  userProfiles: Record<string, Pick<AgentHostUserInfo, "name" | "assetUrl">>;
   fallbackTitle?: string | null;
 }): AgentMentionSessionItem | null {
   const sessionUserId = input.session.userId?.trim() ?? "";
@@ -93,7 +94,15 @@ export function buildSessionMentionItem(input: {
     title: mentionTitle,
     scope,
     initiatorName,
-    ...(userProfile?.avatar ? { initiatorAvatarUrl: userProfile.avatar } : {}),
+    ...(userProfile?.assetUrl
+      ? {
+          initiatorAvatarUrl: buildAssetUrl(userProfile.assetUrl, {
+            kind: "avatar",
+            size: 32,
+            format: "webp"
+          })
+        }
+      : {}),
     agentName,
     status,
     inputPreview,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useState } from "react";
 import { Gauge, Gift, Wrench, X } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@tutti-os/ui-system";
+import { buildAssetUrl } from "../../../shared/assetUrl";
 import { AgentProbeUsageFreshness } from "../AgentProbeUsageFreshness";
 import { AgentUsageMeter } from "../AgentUsageMeter";
 import { AccountMembershipBadge } from "../AccountMembershipBadge";
@@ -162,11 +163,15 @@ export const AgentGUIAccountRailMenu = memo(function AgentGUIAccountRailMenu({
                 className="grid h-8 w-8 shrink-0 place-items-center overflow-hidden rounded-full bg-[var(--background-fronted)] text-[13px] font-semibold"
                 data-testid="agent-gui-account-avatar"
               >
-                {accountMenuState.user?.avatar ? (
+                {accountMenuState.user?.assetUrl ? (
                   <img
                     alt=""
                     className="h-full w-full object-cover"
-                    src={accountMenuState.user.avatar}
+                    src={buildAssetUrl(accountMenuState.user.assetUrl, {
+                      kind: "avatar",
+                      size: 48,
+                      format: "webp"
+                    })}
                   />
                 ) : (
                   <span aria-hidden="true">{initials}</span>

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountMenu.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountMenu.tsx
@@ -17,6 +17,7 @@ import {
   PopoverContent,
   PopoverTrigger
 } from "@tutti-os/ui-system";
+import { buildAssetUrl } from "../../../shared/assetUrl";
 import { AccountMembershipBadge } from "../AccountMembershipBadge";
 import type { AgentGUIAccountMenuState } from "../accountMenuState";
 
@@ -93,11 +94,15 @@ export function AgentGUIAccountMenu({
           <div className="flex min-w-0 items-center gap-2 px-2 py-2">
             <AgentGUIAccountAvatar state={state} label={labels.copyUserId}>
               <span className="grid size-8 shrink-0 place-items-center overflow-hidden rounded-full bg-[var(--background-fronted)] text-[13px] font-semibold text-[var(--text-primary)]">
-                {state.user?.avatar ? (
+                {state.user?.assetUrl ? (
                   <img
                     alt=""
                     className="size-full object-cover"
-                    src={state.user.avatar}
+                    src={buildAssetUrl(state.user.assetUrl, {
+                      kind: "avatar",
+                      size: 48,
+                      format: "webp"
+                    })}
                   />
                 ) : (
                   initials

--- a/packages/agent/gui/host/agentHostAccountStore.ts
+++ b/packages/agent/gui/host/agentHostAccountStore.ts
@@ -167,10 +167,8 @@ function mergeProfilesIntoSnapshot(
     profilesByUserId[userId] = {
       userId,
       ...(user.email?.trim() ? { email: user.email.trim() } : {}),
-      ...(user.avatar?.trim() ? { avatar: user.avatar.trim() } : {}),
-      ...(user.avatarObjectKey?.trim()
-        ? { avatarObjectKey: user.avatarObjectKey.trim() }
-        : {}),
+      ...(user.assetUrl?.trim() ? { assetUrl: user.assetUrl.trim() } : {}),
+      ...(user.assetRef?.trim() ? { assetRef: user.assetRef.trim() } : {}),
       ...(user.name?.trim() ? { name: user.name.trim() } : {})
     };
   }

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -1,4 +1,12 @@
 export {
+  buildAssetUrl,
+  type AssetOutputFormat,
+  type AssetVariant,
+  type AvatarAssetSize,
+  type ContentAssetWidth,
+  type EmojiAssetSize
+} from "./shared/assetUrl";
+export {
   getAgentCustomMentionKind,
   registerAgentCustomMentionKind,
   resetAgentCustomMentionKindsForTests,

--- a/packages/agent/gui/shared/assetUrl.spec.ts
+++ b/packages/agent/gui/shared/assetUrl.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { buildAssetUrl } from "./assetUrl";
+
+describe("buildAssetUrl", () => {
+  it("preserves delivery authorization while appending a frozen variant", () => {
+    const result = buildAssetUrl(
+      "https://assets.tutti.sh/v1/assets/u/room_snapshot/a.png?expires=10&keyId=k&policy=private&signature=s",
+      { kind: "image", width: 1280, format: "webp" }
+    );
+
+    expect(Object.fromEntries(new URL(result).searchParams)).toEqual({
+      expires: "10",
+      keyId: "k",
+      policy: "private",
+      signature: "s",
+      width: "1280",
+      fit: "scale-down",
+      format: "webp"
+    });
+  });
+});

--- a/packages/agent/gui/shared/assetUrl.ts
+++ b/packages/agent/gui/shared/assetUrl.ts
@@ -1,0 +1,49 @@
+export type AvatarAssetSize = 32 | 48 | 64 | 96 | 128 | 256 | 512;
+export type EmojiAssetSize = 32 | 48 | 64 | 96 | 128 | 256;
+export type ContentAssetWidth = 320 | 640 | 1280 | 1920;
+export type AssetOutputFormat = "webp";
+
+export type AssetVariant =
+  | { kind: "avatar"; size: AvatarAssetSize; format?: AssetOutputFormat }
+  | { kind: "emoji"; size: EmojiAssetSize; format?: AssetOutputFormat }
+  | { kind: "image"; width: ContentAssetWidth; format?: AssetOutputFormat };
+
+const IMAGE_QUERY_NAMES = ["width", "height", "fit", "format"] as const;
+
+export function buildAssetUrl(baseUrl: string, variant?: AssetVariant): string {
+  const trimmed = baseUrl.trim();
+  if (!trimmed || !variant) {
+    return trimmed;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return trimmed;
+  }
+  if (
+    url.origin !== "https://assets.tutti.sh" ||
+    !url.pathname.startsWith("/v1/assets/")
+  ) {
+    return trimmed;
+  }
+  for (const name of IMAGE_QUERY_NAMES) {
+    url.searchParams.delete(name);
+  }
+  if (variant.kind === "image") {
+    url.searchParams.set("width", String(variant.width));
+    url.searchParams.set("fit", "scale-down");
+  } else {
+    url.searchParams.set("width", String(variant.size));
+    url.searchParams.set("height", String(variant.size));
+    url.searchParams.set(
+      "fit",
+      variant.kind === "avatar" ? "cover" : "contain"
+    );
+  }
+  if (variant.format) {
+    url.searchParams.set("format", variant.format);
+  }
+  return url.toString();
+}

--- a/packages/agent/gui/shared/contracts/dto/agentHostAccount.ts
+++ b/packages/agent/gui/shared/contracts/dto/agentHostAccount.ts
@@ -2,7 +2,8 @@ export interface AgentHostMockSession {
   name: string;
   userId: string;
   email?: string;
-  avatar?: string;
+  assetUrl?: string;
+  assetRef?: string;
 }
 
 export const UNAUTHENTICATED_AGENT_HOST_MOCK_SESSION: AgentHostMockSession = {
@@ -58,8 +59,8 @@ export interface AgentHostConsumeBetaInviteCodeResult {
 export interface AgentHostUserInfo {
   userId: string;
   email?: string;
-  avatar?: string;
-  avatarObjectKey?: string;
+  assetUrl?: string;
+  assetRef?: string;
   name?: string;
 }
 
@@ -73,8 +74,8 @@ export interface AgentHostBatchUserInfoResult {
 
 export interface AgentHostUpdateUserProfileInput {
   name?: string;
-  avatar?: string;
-  avatarObjectKey?: string;
+  assetUrl?: string;
+  assetRef?: string;
 }
 
 export const TSH_DESKTOP_MAX_USER_DISPLAY_NAME_LENGTH = 32;

--- a/packages/agent/gui/shared/contracts/dto/agentHostWorkspace.ts
+++ b/packages/agent/gui/shared/contracts/dto/agentHostWorkspace.ts
@@ -84,13 +84,14 @@ export interface AgentHostRoomStatus {
 }
 
 export interface AgentHostRoomUserSnapshot {
-  imageUrl: string;
+  assetRef: string;
+  assetUrl: string;
   capturedAtUnixMs: string;
 }
 
 export interface AgentHostCreateObjectUploadResult {
   uploadId: string;
-  objectKey?: string;
+  assetRef?: string;
   uploadUrl: string;
   headers?: Record<string, string>;
   expiresAt?: string;
@@ -98,7 +99,7 @@ export interface AgentHostCreateObjectUploadResult {
 
 export interface AgentHostCompleteObjectUploadResult {
   uploadId: string;
-  objectKey?: string;
+  assetRef?: string;
   status: string;
 }
 
@@ -117,7 +118,8 @@ export interface AgentHostLeaveRoomMembershipInput {
 
 export interface AgentHostCaptureRoomSnapshotResult {
   captured: boolean;
-  imageUrl?: string;
+  assetRef?: string;
+  assetUrl?: string;
   capturedAtUnixMs?: number;
 }
 

--- a/packages/agent/gui/shared/workspaceAgentActivityListProjection.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListProjection.ts
@@ -4,6 +4,7 @@ import type {
   AgentActivitySession
 } from "@tutti-os/agent-activity-core";
 import { selectRootAgentActivitySessions } from "@tutti-os/agent-activity-core";
+import { buildAssetUrl } from "./assetUrl";
 import { resolveWorkspaceAgentSessionSortTimeUnixMs } from "./workspaceAgentSessionSortTime";
 import { workspaceAgentProviderLabel } from "./workspaceAgentProviderLabel";
 import {
@@ -192,13 +193,21 @@ function resolveUserFromId(
   const userId = rawUserId.trim();
   const profile = options.userProfilesById?.[userId];
   const profileName = compactText(profile?.name ?? "");
-  const profileAvatar = profile?.avatar?.trim();
+  const profileAvatar = profile?.assetUrl?.trim();
   const rawName = profileName || userId || "Unknown member";
 
   return {
     userId,
     userName: stripTrailingParentheticalEmailFromLabel(rawName) || rawName,
-    ...(profileAvatar ? { userAvatarUrl: profileAvatar } : {})
+    ...(profileAvatar
+      ? {
+          userAvatarUrl: buildAssetUrl(profileAvatar, {
+            kind: "avatar",
+            size: 32,
+            format: "webp"
+          })
+        }
+      : {})
   };
 }
 

--- a/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
@@ -400,7 +400,8 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
       "user-a": {
         userId: "user-a",
         name: "Jessica",
-        avatar: "https://cdn.example.com/jessica.png",
+        assetUrl:
+          "https://assets.tutti.sh/v1/assets/user-a/account_avatar/jessica.png",
         email: "jessica@example.com"
       }
     };
@@ -425,7 +426,8 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
       sessionId: "session-10",
       userId: "user-a",
       userName: "Jessica",
-      userAvatarUrl: "https://cdn.example.com/jessica.png",
+      userAvatarUrl:
+        "https://assets.tutti.sh/v1/assets/user-a/account_avatar/jessica.png?width=32&height=32&fit=cover&format=webp",
       agentProvider: "codex",
       agentName: "Codex",
       title: "帮我根据目前工作区的 Landing 页面信息出交互原型",
@@ -2407,7 +2409,8 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
       "member-2": {
         userId: "member-2",
         name: "Mina",
-        avatar: "https://cdn.example.com/mina.png"
+        assetUrl:
+          "https://assets.tutti.sh/v1/assets/member-2/account_avatar/mina.png"
       }
     };
 
@@ -2418,7 +2421,8 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
     expect(view.activities[0]).toMatchObject({
       userId: "member-2",
       userName: "Mina",
-      userAvatarUrl: "https://cdn.example.com/mina.png"
+      userAvatarUrl:
+        "https://assets.tutti.sh/v1/assets/member-2/account_avatar/mina.png?width=32&height=32&fit=cover&format=webp"
     });
   });
 

--- a/packages/auth/bridge-go/authbridge.go
+++ b/packages/auth/bridge-go/authbridge.go
@@ -71,10 +71,11 @@ type Client struct {
 }
 
 type UserInfo struct {
-	UserID string `json:"user_id"`
-	Name   string `json:"name,omitempty"`
-	Email  string `json:"email,omitempty"`
-	Avatar string `json:"avatar,omitempty"`
+	UserID   string `json:"user_id"`
+	Name     string `json:"name,omitempty"`
+	Email    string `json:"email,omitempty"`
+	AssetURL string `json:"assetUrl,omitempty"`
+	AssetRef string `json:"assetRef,omitempty"`
 }
 
 type Session struct {
@@ -82,7 +83,8 @@ type Session struct {
 	Cookie    string `json:"cookie"`
 	UserID    string `json:"user_id"`
 	Name      string `json:"name"`
-	Avatar    string `json:"avatar"`
+	AssetURL  string `json:"assetUrl"`
+	AssetRef  string `json:"assetRef"`
 	Email     string `json:"email"`
 	UpdatedAt int64  `json:"updatedAt"`
 }
@@ -296,7 +298,8 @@ func (c *Client) ReadSession() (*Session, error) {
 		Cookie    string `json:"cookie"`
 		UserID    string `json:"user_id"`
 		Name      string `json:"name"`
-		Avatar    string `json:"avatar"`
+		AssetURL  string `json:"assetUrl"`
+		AssetRef  string `json:"assetRef"`
 		Email     string `json:"email"`
 		UpdatedAt int64  `json:"updatedAt"`
 	}
@@ -307,10 +310,11 @@ func (c *Client) ReadSession() (*Session, error) {
 		return nil, nil
 	}
 	session := sessionFromUser(payload.SessionID, UserInfo{
-		UserID: payload.UserID,
-		Name:   payload.Name,
-		Email:  payload.Email,
-		Avatar: payload.Avatar,
+		UserID:   payload.UserID,
+		Name:     payload.Name,
+		Email:    payload.Email,
+		AssetURL: payload.AssetURL,
+		AssetRef: payload.AssetRef,
 	})
 	if payload.Cookie != "" {
 		session.Cookie = payload.Cookie
@@ -779,44 +783,6 @@ func isAllowedAppCallbackScheme(scheme string) bool {
 	default:
 		return false
 	}
-}
-
-func buildAccountURL(baseURL string, path string) string {
-	return strings.TrimRight(baseURL, "/") + "/" + strings.TrimLeft(path, "/")
-}
-
-func buildSessionCookie(sessionID string) string {
-	return "session_id=" + strings.TrimSpace(sessionID)
-}
-
-func sessionFromUser(sessionID string, user UserInfo) Session {
-	return Session{
-		SessionID: strings.TrimSpace(sessionID),
-		Cookie:    buildSessionCookie(sessionID),
-		UserID:    user.UserID,
-		Name:      user.Name,
-		Avatar:    user.Avatar,
-		Email:     user.Email,
-		UpdatedAt: time.Now().UnixMilli(),
-	}
-}
-
-func mapUserInfo(data map[string]any) UserInfo {
-	return UserInfo{
-		UserID: stringField(data, "userId", "user_id"),
-		Name:   stringField(data, "name"),
-		Email:  stringField(data, "email", "userEmail", "emailAddress"),
-		Avatar: stringField(data, "avatar", "picture", "avatarUrl", "headImg"),
-	}
-}
-
-func stringField(data map[string]any, keys ...string) string {
-	for _, key := range keys {
-		if value, ok := data[key].(string); ok && strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
 }
 
 func readJSON(reader io.Reader, out any) error {

--- a/packages/auth/bridge-go/authbridge_test.go
+++ b/packages/auth/bridge-go/authbridge_test.go
@@ -481,10 +481,11 @@ func newAccountServer(t *testing.T) *httptest.Server {
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"code": 0,
 				"data": map[string]string{
-					"user_id": "user-1",
-					"name":    "Tutti User",
-					"email":   "user@example.com",
-					"avatar":  "https://example.com/avatar.png",
+					"user_id":  "user-1",
+					"name":     "Tutti User",
+					"email":    "user@example.com",
+					"assetUrl": "https://assets.tutti.sh/v1/assets/user-1/account_avatar/avatar.png",
+					"assetRef": "user-1/account_avatar/avatar.png",
 				},
 			})
 		case "/auth/v1/logout-web-session":

--- a/packages/auth/bridge-go/user_info.go
+++ b/packages/auth/bridge-go/user_info.go
@@ -1,0 +1,46 @@
+package authbridge
+
+import (
+	"strings"
+	"time"
+)
+
+func buildAccountURL(baseURL string, path string) string {
+	return strings.TrimRight(baseURL, "/") + "/" + strings.TrimLeft(path, "/")
+}
+
+func buildSessionCookie(sessionID string) string {
+	return "session_id=" + strings.TrimSpace(sessionID)
+}
+
+func sessionFromUser(sessionID string, user UserInfo) Session {
+	return Session{
+		SessionID: strings.TrimSpace(sessionID),
+		Cookie:    buildSessionCookie(sessionID),
+		UserID:    user.UserID,
+		Name:      user.Name,
+		AssetURL:  user.AssetURL,
+		AssetRef:  user.AssetRef,
+		Email:     user.Email,
+		UpdatedAt: time.Now().UnixMilli(),
+	}
+}
+
+func mapUserInfo(data map[string]any) UserInfo {
+	return UserInfo{
+		UserID:   stringField(data, "userId", "user_id"),
+		Name:     stringField(data, "name"),
+		Email:    stringField(data, "email", "userEmail", "emailAddress"),
+		AssetURL: stringField(data, "assetUrl"),
+		AssetRef: stringField(data, "assetRef"),
+	}
+}
+
+func stringField(data map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := data[key].(string); ok && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/packages/auth/bridge/src/browser.test.ts
+++ b/packages/auth/bridge/src/browser.test.ts
@@ -55,7 +55,8 @@ test("browser getUserInfo returns user and nulls unauthorized sessions", async (
       userId: "user-1",
       name: "Alice",
       email: undefined,
-      avatar: undefined
+      assetUrl: undefined,
+      assetRef: undefined
     });
     assert.equal(await auth.getUserInfo(), null);
   } finally {

--- a/packages/auth/bridge/src/node.test.ts
+++ b/packages/auth/bridge/src/node.test.ts
@@ -186,7 +186,8 @@ test("node login preserves a typed cancellation without reopening the app", asyn
       cookie: "session_id=existing-session",
       userId: "existing-user",
       name: "Existing User",
-      avatar: "",
+      assetUrl: "",
+      assetRef: "",
       email: "",
       updatedAt: 123
     });

--- a/packages/auth/bridge/src/node.test.ts
+++ b/packages/auth/bridge/src/node.test.ts
@@ -27,7 +27,8 @@ test("auth json read/write keeps desktop-compatible shape", async () => {
       cookie: "session_id=session-1",
       userId: "user-1",
       name: "Alice",
-      avatar: "https://example.com/a.png",
+      assetUrl: "https://assets.tutti.sh/v1/assets/user-1/account_avatar/a.png",
+      assetRef: "user-1/account_avatar/a.png",
       email: "alice@example.com",
       updatedAt: 123
     });
@@ -36,7 +37,8 @@ test("auth json read/write keeps desktop-compatible shape", async () => {
       cookie: "session_id=session-1",
       user_id: "user-1",
       name: "Alice",
-      avatar: "https://example.com/a.png",
+      assetUrl: "https://assets.tutti.sh/v1/assets/user-1/account_avatar/a.png",
+      assetRef: "user-1/account_avatar/a.png",
       email: "alice@example.com",
       updatedAt: 123
     });
@@ -96,7 +98,8 @@ test("node login completes bridge, redeems transfer code, writes auth json", asy
       userId: "user-1",
       name: "Alice",
       email: "alice@example.com",
-      avatar: undefined
+      assetUrl: undefined,
+      assetRef: undefined
     });
     assert.equal(
       (await readAuthJson(file))?.cookie,
@@ -401,7 +404,8 @@ test("node getUserInfo refreshes auth json and logout clears it", async () => {
       cookie: "session_id=desktop-session-1",
       userId: "old-user",
       name: "",
-      avatar: "",
+      assetUrl: "",
+      assetRef: "",
       email: "",
       updatedAt: 1
     });
@@ -420,7 +424,8 @@ test("node getUserInfo refreshes auth json and logout clears it", async () => {
       userId: "user-1",
       name: "Alice",
       email: "alice@example.com",
-      avatar: undefined
+      assetUrl: undefined,
+      assetRef: undefined
     });
     assert.equal((await readAuthJson(file))?.userId, "user-1");
     await auth.logout();

--- a/packages/auth/bridge/src/node.ts
+++ b/packages/auth/bridge/src/node.ts
@@ -244,7 +244,8 @@ export async function readAuthJson(
       cookie: trimString(parsed.cookie) || buildSessionCookie(sessionId),
       userId: trimString(parsed.userId) || trimString(parsed.user_id),
       name: trimString(parsed.name),
-      avatar: trimString(parsed.avatar),
+      assetUrl: trimString(parsed.assetUrl),
+      assetRef: trimString(parsed.assetRef),
       email: trimString(parsed.email),
       updatedAt:
         typeof parsed.updatedAt === "number" &&
@@ -267,7 +268,8 @@ export async function writeAuthJson(
     cookie: session.cookie,
     user_id: session.userId,
     name: session.name,
-    avatar: session.avatar,
+    assetUrl: session.assetUrl,
+    assetRef: session.assetRef,
     email: session.email,
     updatedAt: session.updatedAt
   };
@@ -682,7 +684,8 @@ function sessionFromUser(
     cookie: buildSessionCookie(sessionId),
     userId: user.userId,
     name: user.name ?? "",
-    avatar: user.avatar ?? "",
+    assetUrl: user.assetUrl ?? "",
+    assetRef: user.assetRef ?? "",
     email: user.email ?? "",
     updatedAt: Date.now()
   };

--- a/packages/auth/bridge/src/shared.ts
+++ b/packages/auth/bridge/src/shared.ts
@@ -11,7 +11,8 @@ export interface TuttiUserInfo {
   userId: string;
   name?: string;
   email?: string;
-  avatar?: string;
+  assetUrl?: string;
+  assetRef?: string;
 }
 
 export interface TuttiAuthSession {
@@ -19,7 +20,8 @@ export interface TuttiAuthSession {
   cookie: string;
   userId: string;
   name: string;
-  avatar: string;
+  assetUrl: string;
+  assetRef: string;
   email: string;
   updatedAt: number;
 }
@@ -76,11 +78,7 @@ export function mapUserInfo(
       trimString(data.userEmail) ||
       trimString(data.emailAddress) ||
       undefined,
-    avatar:
-      trimString(data.avatar) ||
-      trimString(data.picture) ||
-      trimString(data.avatarUrl) ||
-      trimString(data.headImg) ||
-      undefined
+    assetUrl: trimString(data.assetUrl) || undefined,
+    assetRef: trimString(data.assetRef) || undefined
   };
 }

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -25,7 +25,8 @@ export type AccountUserInfo = {
   user_id: string;
   name?: string | null;
   email?: string | null;
-  avatar?: string | null;
+  assetUrl?: string | null;
+  assetRef?: string | null;
 };
 
 export type AccountUserInfoResponse = {

--- a/services/tuttid/api/daemon_account.go
+++ b/services/tuttid/api/daemon_account.go
@@ -176,10 +176,11 @@ func generatedAccountUser(user *authbridge.UserInfo) *tuttigenerated.AccountUser
 		return nil
 	}
 	return &tuttigenerated.AccountUserInfo{
-		Avatar: stringPointer(user.Avatar),
-		Email:  stringPointer(user.Email),
-		Name:   stringPointer(user.Name),
-		UserId: user.UserID,
+		AssetUrl: stringPointer(user.AssetURL),
+		AssetRef: stringPointer(user.AssetRef),
+		Email:    stringPointer(user.Email),
+		Name:     stringPointer(user.Name),
+		UserId:   user.UserID,
 	}
 }
 

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -3272,10 +3272,11 @@ type AccountRegistrationCreditsReward struct {
 
 // AccountUserInfo defines model for AccountUserInfo.
 type AccountUserInfo struct {
-	Avatar *string `json:"avatar,omitempty"`
-	Email  *string `json:"email,omitempty"`
-	Name   *string `json:"name,omitempty"`
-	UserId string  `json:"user_id"`
+	AssetRef *string `json:"assetRef,omitempty"`
+	AssetUrl *string `json:"assetUrl,omitempty"`
+	Email    *string `json:"email,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	UserId   string  `json:"user_id"`
 }
 
 // AccountUserInfoResponse defines model for AccountUserInfoResponse.

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -5914,7 +5914,10 @@ components:
         email:
           type: string
           nullable: true
-        avatar:
+        assetUrl:
+          type: string
+          nullable: true
+        assetRef:
           type: string
           nullable: true
     AccountUserInfoResponse:

--- a/services/tuttid/service/account/service_test.go
+++ b/services/tuttid/service/account/service_test.go
@@ -131,7 +131,7 @@ func TestGetProductSummaryFetchesCommerceWithSessionCookie(t *testing.T) {
 			if got := r.Header.Get("Cookie"); got != "session_id=session-1" {
 				t.Fatalf("account user info Cookie = %q, want session cookie", got)
 			}
-			_, _ = w.Write([]byte(`{"code":0,"data":{"userId":"user-1","name":"Jane","email":"jane@example.com","avatar":"https://example.com/avatar.png"}}`))
+			_, _ = w.Write([]byte(`{"code":0,"data":{"userId":"user-1","name":"Jane","email":"jane@example.com","assetUrl":"https://assets.tutti.sh/v1/assets/user-1/account_avatar/avatar.png","assetRef":"user-1/account_avatar/avatar.png"}}`))
 		case "/v1/user-info":
 			commerceUserInfoCookie = r.Header.Get("Cookie")
 			_, _ = w.Write([]byte(`{


### PR DESCRIPTION
## Summary\n- migrate auth bridge and Agent GUI user assets to assetRef and assetUrl\n- add the shared fixed-preset Asset Delivery helper\n- update account menu, mention, and host mapping flows\n\n## Validation\n- pnpm check:changed -- --push-ready passed 26 lanes\n- GOWORK=off go test ./... passed in packages/auth/bridge-go\n\n## Dependencies\nRequires the coordinated account protocol release.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->