### PR TITLE
fix(desktop): copy user ID directly from account avatar

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAccountMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAccountMenu.tsx
@@ -1,6 +1,5 @@
 import { memo, useEffect, useMemo, useState } from "react";
 import {
-  AgentGUIAccountAvatar,
   AgentGUIAccountMenu,
   AgentGUIAccountRewardToast,
   agentGUIAccountInitials,
@@ -303,26 +302,26 @@ const WorkspaceAccountMenuView = memo(function WorkspaceAccountMenuView({
             aria-label={userLabel}
             className="relative grid size-8 cursor-pointer place-items-center rounded-full border border-transparent bg-transparent p-0 text-[var(--workbench-chrome-foreground)] shadow-none hover:bg-transparent [-webkit-app-region:no-drag]"
             data-account-menu-trigger="true"
+            onContextMenu={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              void accountMenuState.onCopyUserId?.();
+            }}
           >
-            <AgentGUIAccountAvatar
-              state={accountMenuState}
-              label={labels.copyUserId}
+            <span
+              className="grid size-7 place-items-center overflow-hidden rounded-full bg-[color-mix(in_srgb,var(--workbench-chrome-foreground)_16%,transparent)] text-[12px] font-semibold"
+              data-testid="workspace-account-avatar"
             >
-              <span
-                className="grid size-7 place-items-center overflow-hidden rounded-full bg-[color-mix(in_srgb,var(--workbench-chrome-foreground)_16%,transparent)] text-[12px] font-semibold"
-                data-testid="workspace-account-avatar"
-              >
-                {accountMenuState.user.avatar ? (
-                  <img
-                    alt=""
-                    className="size-full object-cover"
-                    src={accountMenuState.user.avatar}
-                  />
-                ) : (
-                  <span aria-hidden="true">{initials}</span>
-                )}
-              </span>
-            </AgentGUIAccountAvatar>
+              {accountMenuState.user.avatar ? (
+                <img
+                  alt=""
+                  className="size-full object-cover"
+                  src={accountMenuState.user.avatar}
+                />
+              ) : (
+                <span aria-hidden="true">{initials}</span>
+              )}
+            </span>
             <img
               alt=""
               aria-hidden="true"


### PR DESCRIPTION
## Summary
- make right-clicking the desktop account avatar copy the current User ID immediately
- suppress the nested context menu for the titlebar avatar
- retain the existing localized success/failure notifications

## Verification
- `pnpm --dir apps/desktop typecheck`
- `pnpm --dir apps/desktop build`
- push-ready changed checks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->