### PR TITLE
fix(workspace-file-manager): context menu loop, sidebar toggle, nav fixes

### DIFF
--- a/packages/workspace/file-manager/CONTRACT.md
+++ b/packages/workspace/file-manager/CONTRACT.md
@@ -225,9 +225,18 @@ Public entrypoints:
 
 UI injection points that remain host-owned presentation hooks include, among
 others: `resolveContextMenu`, `renderExternalLocationContent`,
-`resolveEntryIconUrl`, `showPreviewPanel`, `showInternalOpenWithActions`,
-open-with icon overrides, and analytics callbacks. These do **not** become a
-general product-action plugin system in this phase.
+`resolveEntryIconUrl`, `showPreviewPanel`, `showLocationSidebar`,
+`showInternalOpenWithActions`, open-with icon overrides, and analytics
+callbacks. These do **not** become a general product-action plugin system in
+this phase.
+
+**Published UI assets (decided):** folder/archive fallback glyphs ship as
+inlined `data:` URLs in the published `dist` (tsup `loader: { ".png": "dataurl" }`).
+Do not rely on `new URL(..., import.meta.url)` against loose files next to
+`dist` — Electron hosts with strict `img-src` (no `file:`) will show broken
+images. Hosts that alias this package to source for local development still
+get Vite-rewritten asset URLs; published consumers must keep working without
+that alias.
 
 ### 9. i18n
 

--- a/packages/workspace/file-manager/src/services/internal/model/paths.ts
+++ b/packages/workspace/file-manager/src/services/internal/model/paths.ts
@@ -138,6 +138,17 @@ export function buildWorkspaceFileBreadcrumbs(
 ): Array<{ label: string; path: string }> {
   const root = normalizeWorkspaceFilePath(rootPath);
   const current = normalizeWorkspaceFilePath(path, root);
+
+  // Package placeholder root is "/". Hosts like TSH keep logical paths under
+  // "/workspace" before listing.root arrives. Splitting "/workspace" under
+  // "/" yields a duplicate crumb: "workspace" / "workspace".
+  if (
+    root === workspaceFileManagerLogicalRoot &&
+    current !== workspaceFileManagerLogicalRoot
+  ) {
+    return [{ label: rootLabel, path: current }];
+  }
+
   const relative =
     current === root ? "" : current.slice(root.length).replace(/^\//, "");
   const breadcrumbs: Array<{ label: string; path: string }> = [

--- a/packages/workspace/file-manager/src/services/internal/workspaceFileManagerNavigationController.test.ts
+++ b/packages/workspace/file-manager/src/services/internal/workspaceFileManagerNavigationController.test.ts
@@ -8,6 +8,48 @@ import type {
 } from "../workspaceFileManagerTypes.ts";
 import type { WorkspaceFileManagerHost } from "../workspaceFileManagerHost.interface.ts";
 
+test("same-path concurrent loads share one host request and keep non-empty entries", async () => {
+  const store = createTestStore();
+  store.root = "/workspace";
+  store.currentDirectoryPath = "/workspace";
+  let calls = 0;
+  const slow =
+    createDeferred<
+      ReturnType<WorkspaceFileManagerHost["listDirectory"]> extends Promise<
+        infer T
+      >
+        ? T
+        : never
+    >();
+
+  const controller = new WorkspaceFileManagerNavigationController({
+    host: {
+      async listDirectory() {
+        calls += 1;
+        return slow.promise;
+      }
+    },
+    resolveErrorMessage: defaultResolveErrorMessage,
+    store
+  });
+
+  const first = controller.loadDirectory("/workspace");
+  const second = controller.loadDirectory("/workspace");
+  assert.equal(calls, 1);
+
+  slow.resolve({
+    directoryPath: "/workspace",
+    entries: [createFileEntry("/workspace/.tsh")],
+    root: "/workspace",
+    workspaceID: "workspace-1"
+  });
+  await Promise.all([first, second]);
+
+  assert.equal(calls, 1);
+  assert.equal(store.entries[0]?.name, ".tsh");
+  assert.equal(store.isLoading, false);
+});
+
 test("latest directory load wins over stale earlier requests", async () => {
   const store = createTestStore();
   store.root = "/Users/demo/project";
@@ -254,6 +296,61 @@ test("revealPath includes hidden entries when target file is hidden", async () =
 
   assert.equal(store.currentDirectoryPath, "/Users/demo/project");
   assert.equal(store.selectedPath, "/Users/demo/project/.env");
+});
+
+test("superseded directory load still clears isLoading when no loads remain", async () => {
+  const store = createTestStore();
+  store.root = "/Users/demo/project";
+  store.currentDirectoryPath = "/Users/demo/project";
+
+  let releaseFirst!: () => void;
+  let releaseSecond!: () => void;
+  const firstGate = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  const secondGate = new Promise<void>((resolve) => {
+    releaseSecond = resolve;
+  });
+
+  const controller = new WorkspaceFileManagerNavigationController({
+    host: {
+      async listDirectory(input) {
+        if (input.path === "/Users/demo/project") {
+          await firstGate;
+          return {
+            directoryPath: input.path,
+            entries: [createFileEntry("/Users/demo/project/a.txt")],
+            root: "/Users/demo/project",
+            workspaceID: input.workspaceID
+          };
+        }
+        await secondGate;
+        return {
+          directoryPath: input.path,
+          entries: [createFileEntry("/Users/demo/project/docs/b.txt")],
+          root: "/Users/demo/project",
+          workspaceID: input.workspaceID
+        };
+      }
+    },
+    resolveErrorMessage: defaultResolveErrorMessage,
+    store
+  });
+
+  const first = controller.loadDirectory("/Users/demo/project");
+  const second = controller.loadDirectory("/Users/demo/project/docs");
+  await Promise.resolve();
+  assert.equal(store.isLoading, true);
+
+  // Winner finishes first; superseded request must not leave isLoading latched.
+  releaseSecond();
+  await second;
+  assert.equal(store.isLoading, false);
+  assert.equal(store.currentDirectoryPath, "/Users/demo/project/docs");
+
+  releaseFirst();
+  await first;
+  assert.equal(store.isLoading, false);
 });
 
 test("loadDirectory failure leaves existing selection in place and surfaces an error", async () => {

--- a/packages/workspace/file-manager/src/services/internal/workspaceFileManagerNavigationController.ts
+++ b/packages/workspace/file-manager/src/services/internal/workspaceFileManagerNavigationController.ts
@@ -18,11 +18,34 @@ export class WorkspaceFileManagerNavigationController {
   private readonly resolveErrorMessage: (error: unknown) => string;
   private readonly store: WorkspaceFileManagerState;
   private requestSeq = 0;
+  /** Counts performLoad/reveal/replace calls so superseded requests cannot leave isLoading latched. */
+  private activeLoadCount = 0;
+  /**
+   * Same-path loads share one in-flight promise. Concurrent initialize/reveal/
+   * remount callers used to bump requestSeq and let a faster empty response
+   * discard a slower successful listing.
+   */
+  private readonly inFlightLoadByPath = new Map<string, Promise<void>>();
 
   constructor(input: WorkspaceFileManagerNavigationControllerInput) {
     this.host = input.host;
     this.resolveErrorMessage = input.resolveErrorMessage;
     this.store = input.store;
+  }
+
+  private beginLoad(): number {
+    const requestID = ++this.requestSeq;
+    this.activeLoadCount += 1;
+    this.store.isLoading = true;
+    this.store.error = null;
+    return requestID;
+  }
+
+  private endLoad(requestID: number): void {
+    this.activeLoadCount = Math.max(0, this.activeLoadCount - 1);
+    if (requestID === this.requestSeq || this.activeLoadCount === 0) {
+      this.store.isLoading = false;
+    }
   }
 
   async goBack(): Promise<void> {
@@ -45,9 +68,29 @@ export class WorkspaceFileManagerNavigationController {
 
   async loadDirectory(path = this.store.currentDirectoryPath): Promise<void> {
     const normalizedPath = normalizeWorkspaceFilePath(path, this.store.root);
-    const requestID = ++this.requestSeq;
-    this.store.isLoading = true;
-    this.store.error = null;
+    const existing = this.inFlightLoadByPath.get(normalizedPath);
+    if (existing) {
+      await existing;
+      return;
+    }
+
+    const run = this.performLoadDirectory(normalizedPath);
+    this.inFlightLoadByPath.set(normalizedPath, run);
+    try {
+      await run;
+    } finally {
+      if (this.inFlightLoadByPath.get(normalizedPath) === run) {
+        this.inFlightLoadByPath.delete(normalizedPath);
+      }
+    }
+  }
+
+  async refresh(): Promise<void> {
+    await this.loadDirectory(this.store.currentDirectoryPath);
+  }
+
+  private async performLoadDirectory(normalizedPath: string): Promise<void> {
+    const requestID = this.beginLoad();
 
     try {
       const listing = await this.host.listDirectory({
@@ -56,6 +99,25 @@ export class WorkspaceFileManagerNavigationController {
         workspaceID: this.store.workspaceID
       });
       if (requestID !== this.requestSeq) {
+        // Same-path coalescing covers the common remount race. Still recover
+        // when a superseded response has entries and the store is empty for
+        // that directory (e.g. empty prefetch won, then network returned data).
+        if (
+          listing.entries.length > 0 &&
+          this.store.entries.length === 0 &&
+          this.store.error === null &&
+          normalizeWorkspaceFilePath(listing.directoryPath, listing.root) ===
+            normalizeWorkspaceFilePath(
+              this.store.currentDirectoryPath,
+              this.store.root
+            )
+        ) {
+          this.store.root = normalizeWorkspaceFilePath(listing.root);
+          this.store.currentDirectoryPath = listing.directoryPath;
+          this.store.entries = sortWorkspaceEntries(listing.entries);
+          this.store.directoryExpansionByPath = {};
+          this.store.expandedDirectoryPaths = {};
+        }
         return;
       }
 
@@ -78,14 +140,8 @@ export class WorkspaceFileManagerNavigationController {
         this.store.error = this.resolveErrorMessage(error);
       }
     } finally {
-      if (requestID === this.requestSeq) {
-        this.store.isLoading = false;
-      }
+      this.endLoad(requestID);
     }
-  }
-
-  async refresh(): Promise<void> {
-    await this.loadDirectory(this.store.currentDirectoryPath);
   }
 
   async revealPath(path: string): Promise<void> {
@@ -94,9 +150,7 @@ export class WorkspaceFileManagerNavigationController {
       normalizedPath,
       this.store.root
     );
-    const requestID = ++this.requestSeq;
-    this.store.isLoading = true;
-    this.store.error = null;
+    const requestID = this.beginLoad();
 
     try {
       const listing = await this.host.listDirectory({
@@ -127,17 +181,13 @@ export class WorkspaceFileManagerNavigationController {
         this.store.error = this.resolveErrorMessage(error);
       }
     } finally {
-      if (requestID === this.requestSeq) {
-        this.store.isLoading = false;
-      }
+      this.endLoad(requestID);
     }
   }
 
   private async replaceDirectory(path: string): Promise<void> {
     const normalizedPath = normalizeWorkspaceFilePath(path, this.store.root);
-    const requestID = ++this.requestSeq;
-    this.store.isLoading = true;
-    this.store.error = null;
+    const requestID = this.beginLoad();
     try {
       const listing = await this.host.listDirectory({
         includeHidden: workspaceFilePathHasHiddenSegment(normalizedPath),
@@ -158,9 +208,7 @@ export class WorkspaceFileManagerNavigationController {
         this.store.error = this.resolveErrorMessage(error);
       }
     } finally {
-      if (requestID === this.requestSeq) {
-        this.store.isLoading = false;
-      }
+      this.endLoad(requestID);
     }
   }
 

--- a/packages/workspace/file-manager/src/services/internal/workspaceFileManagerSession.ts
+++ b/packages/workspace/file-manager/src/services/internal/workspaceFileManagerSession.ts
@@ -57,6 +57,11 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
   readonly store: WorkspaceFileManagerState;
   private readonly host: WorkspaceFileManagerHost;
   private hasInitialized = false;
+  /**
+   * True after a directory listing attempt finished without leaving the session
+   * mid-flight. Empty folders set this too — "no entries" is not "not loaded".
+   */
+  private hasSettledDirectoryListing = false;
   private initializePromise: Promise<void> | null = null;
   private isActive = false;
   private isDisposed = false;
@@ -310,6 +315,7 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
   dispose(): void {
     this.isDisposed = true;
     this.hasInitialized = false;
+    this.hasSettledDirectoryListing = false;
     this.initializePromise = null;
     this.isActive = false;
     this.searchRequestSeq += 1;
@@ -351,6 +357,8 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
     this.initializePromise = (async () => {
       this.observeStore();
       if (!this.hasLoadedDirectoryState()) {
+        // loadDirectory owns isLoading true→false. Do not latch isLoading here:
+        // a host that primes loading and then aborts initialize would stick.
         await this.loadSelectedLocationOrDirectory();
       }
       await this.previewController.syncPreviewState();
@@ -360,12 +368,20 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
       await this.initializePromise;
     } finally {
       this.initializePromise = null;
+      // If init aborted/failed before a listing settled, never leave the UI
+      // spinning on a stale loading latch.
+      if (!this.hasSettledDirectoryListing && this.store.isLoading) {
+        this.store.isLoading = false;
+      }
     }
   }
 
   async loadDirectory(path = this.store.currentDirectoryPath): Promise<void> {
     this.clearSearchState();
     await this.navigationController.loadDirectory(path);
+    if (!this.store.isLoading) {
+      this.hasSettledDirectoryListing = true;
+    }
     this.syncSelectedDirectoryLocation();
   }
 
@@ -661,7 +677,7 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
       await this.loadRecentLocation(location);
       return;
     }
-    await this.navigationController.loadDirectory(location.path);
+    await this.loadDirectory(location.path);
   }
 
   setActive(active: boolean): void {
@@ -670,6 +686,15 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
     }
     this.isActive = active;
     if (active) {
+      // Recover only when initialize finished without ever settling a listing
+      // (superseded/remount race). A settled empty folder must not reload.
+      if (
+        this.hasInitialized &&
+        !this.hasSettledDirectoryListing &&
+        !this.store.isLoading
+      ) {
+        void this.loadSelectedLocationOrDirectory();
+      }
       return;
     }
     this.store.contextMenu = null;
@@ -740,23 +765,27 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
   }
 
   private hasLoadedDirectoryState(): boolean {
+    // selectedPath alone is not a listing — persistence can restore a selection
+    // before any directory.list runs. Skipping load left the panel empty/stuck.
     return (
+      this.hasSettledDirectoryListing ||
       this.store.error !== null ||
-      this.store.entries.length > 0 ||
-      this.store.selectedPath !== null
+      this.store.entries.length > 0
     );
   }
 
   private async loadSelectedLocationOrDirectory(): Promise<void> {
     const selectedLocation = this.selectedLocation();
     if (isWorkspaceFileExternalLocation(selectedLocation)) {
+      this.hasSettledDirectoryListing = true;
+      this.store.isLoading = false;
       return;
     }
     if (selectedLocation?.kind === "recent") {
       await this.loadRecentLocation(selectedLocation);
       return;
     }
-    await this.navigationController.loadDirectory(
+    await this.loadDirectory(
       this.resolveInitialDirectoryPath(selectedLocation)
     );
   }
@@ -786,6 +815,7 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
       this.store.error = this.resolveErrorMessage(error);
     } finally {
       this.store.isLoading = false;
+      this.hasSettledDirectoryListing = true;
     }
   }
 

--- a/packages/workspace/file-manager/src/services/internal/workspaceFileManagerStore.ts
+++ b/packages/workspace/file-manager/src/services/internal/workspaceFileManagerStore.ts
@@ -1,4 +1,7 @@
-import { proxy } from "valtio";
+// Must share the same valtio module instance as subscribe() in the session.
+// Mixing "valtio" with "valtio/vanilla" under Vite can create two proxyStateMaps
+// and crash subscribe with: Cannot read properties of undefined (reading '2').
+import { proxy } from "valtio/vanilla";
 import {
   workspaceFileManagerPersistedStateSchemaVersion,
   workspaceFileManagerLogicalRoot,

--- a/packages/workspace/file-manager/src/services/internal/workspaceFileManagerViewModel.test.ts
+++ b/packages/workspace/file-manager/src/services/internal/workspaceFileManagerViewModel.test.ts
@@ -187,6 +187,21 @@ test("maps context-menu state without depending on unrelated fields", () => {
   assert.equal(contextMenuView.isLoading, true);
 });
 
+test("avoids duplicate breadcrumb when placeholder root is / and path is /workspace", () => {
+  const store = createStore();
+  store.root = "/";
+  store.currentDirectoryPath = "/workspace";
+
+  const toolbarView = resolveWorkspaceFileManagerToolbarViewState({
+    copy: createCopy(),
+    state: store
+  });
+  assert.deepEqual(
+    toolbarView.breadcrumbs.map((crumb) => crumb.path),
+    ["/workspace"]
+  );
+});
+
 function createCopy() {
   return createWorkspaceFileManagerI18nRuntime(
     createI18nRuntime({

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerSession.test.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerSession.test.ts
@@ -1467,6 +1467,49 @@ test("initialize preserves directory state already loaded by a reveal intent", a
   session.dispose();
 });
 
+test("initialize still lists when only selectedPath is restored", async () => {
+  const listedPaths: string[] = [];
+  const session = createWorkspaceFileManagerService().createSession({
+    host: {
+      async listDirectory(input) {
+        listedPaths.push(input.path);
+        return {
+          directoryPath: "/Users/demo/project",
+          entries: [
+            {
+              hasChildren: false,
+              kind: "file",
+              mtimeMs: null,
+              name: "README.md",
+              path: "/Users/demo/project/README.md",
+              sizeBytes: 12
+            }
+          ],
+          root: "/Users/demo/project",
+          workspaceID: input.workspaceID
+        };
+      }
+    },
+    i18n: createTestI18nRuntime(),
+    initialDirectoryPath: "/Users/demo/project",
+    workspaceID: "workspace-1"
+  });
+  session.store.root = "/Users/demo/project";
+  session.store.currentDirectoryPath = "/Users/demo/project";
+  session.store.selectedPath = "/Users/demo/project/README.md";
+  session.store.entries = [];
+  session.store.isLoading = true;
+
+  await session.initialize();
+
+  assert.deepEqual(listedPaths, ["/Users/demo/project"]);
+  assert.equal(session.store.isLoading, false);
+  assert.equal(session.store.entries.length, 1);
+  assert.equal(session.store.entries[0]?.name, "README.md");
+
+  session.dispose();
+});
+
 test("invalid persisted state is ignored", () => {
   const session = createWorkspaceFileManagerService().createSession({
     host: {

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManager.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManager.tsx
@@ -94,6 +94,12 @@ export interface WorkspaceFileManagerProps {
   ) => ReactElement | null;
   i18n: WorkspaceFileManagerI18nRuntime;
   session: WorkspaceFileManagerSession;
+  /**
+   * When false, hide the locations sidebar even if the session has location
+   * sections. Hosts with a single workspace root (for example TSH embedded
+   * Files) can turn this off. Defaults to true.
+   */
+  showLocationSidebar?: boolean;
   showPreviewPanel?: boolean;
   surface?: "card" | "embedded";
 }
@@ -110,6 +116,7 @@ export function WorkspaceFileManager({
   resolveEntryIconUrl,
   renderExternalLocationContent,
   session,
+  showLocationSidebar = true,
   showPreviewPanel = true,
   surface = "card"
 }: WorkspaceFileManagerProps): ReactElement {
@@ -136,9 +143,9 @@ export function WorkspaceFileManager({
     );
     return location?.kind === "external" ? location : null;
   }, [rootView.locationSections, rootView.selectedLocationId]);
-  const hasLocationSidebar = rootView.locationSections.some(
-    (section) => section.locations.length > 0
-  );
+  const hasLocationSidebar =
+    showLocationSidebar &&
+    rootView.locationSections.some((section) => section.locations.length > 0);
   const sidebarContentMinWidth = showPreviewPanel
     ? workspaceFileManagerContentMinWidth
     : workspaceFileManagerContentWithoutPreviewMinWidth;
@@ -388,21 +395,19 @@ export function WorkspaceFileManager({
     event.preventDefault();
     event.stopPropagation();
 
-    const rootBounds = rootRef.current?.getBoundingClientRect();
-    if (!rootBounds) {
-      return;
-    }
-
+    // Store viewport (client) coordinates. The menu renders with
+    // positionMode="viewport" / fixed so overflow:hidden ancestors in host
+    // shells (e.g. TSH workbench nodes) cannot clip or mis-stack it.
     const menuWidth = 220;
     const menuHeight = 280;
     const x = clampContextMenuCoordinate(
-      event.clientX - rootBounds.left,
-      rootBounds.width,
+      event.clientX,
+      window.innerWidth,
       menuWidth
     );
     const y = clampContextMenuCoordinate(
-      event.clientY - rootBounds.top,
-      rootBounds.height,
+      event.clientY,
+      window.innerHeight,
       menuHeight
     );
 
@@ -425,19 +430,29 @@ export function WorkspaceFileManager({
       data-slot="viewport-menu-boundary"
       data-workspace-file-manager=""
       ref={rootRef}
+      style={
+        {
+          // Owned by the root so context menus (siblings of the panels pane)
+          // can resolve overlay stacking instead of falling back to invalid
+          // `calc(var(--undefined) - 1)`.
+          "--workspace-file-manager-dialog-overlay-z-index": "20"
+        } as CSSProperties
+      }
     >
-      <WorkspaceFileManagerSidebar
-        disabled={rootView.isBusy || panelsState.isLoading}
-        locationSections={rootView.locationSections}
-        selectedLocationId={rootView.selectedLocationId}
-        width={sidebarWidth}
-        onSelectLocation={(location) => {
-          if (location.kind === "directory") {
-            onDirectoryExpanded?.(location.path);
-          }
-          void session.selectLocation(location.id);
-        }}
-      />
+      {hasLocationSidebar ? (
+        <WorkspaceFileManagerSidebar
+          disabled={rootView.isBusy || panelsState.isLoading}
+          locationSections={rootView.locationSections}
+          selectedLocationId={rootView.selectedLocationId}
+          width={sidebarWidth}
+          onSelectLocation={(location) => {
+            if (location.kind === "directory") {
+              onDirectoryExpanded?.(location.path);
+            }
+            void session.selectLocation(location.id);
+          }}
+        />
+      ) : null}
       {hasLocationSidebar ? (
         <div
           aria-label={i18n.t("resizeLocationsSidebar")}
@@ -469,14 +484,7 @@ export function WorkspaceFileManager({
               onLayoutModeChange={setLayoutMode}
               session={session}
             />
-            <div
-              className="@max-[600px]/workspace-file-manager:flex-col @max-[600px]/workspace-file-manager:gap-3 flex min-h-0 min-w-0 flex-1 overflow-hidden"
-              style={
-                {
-                  "--workspace-file-manager-dialog-overlay-z-index": "20"
-                } as CSSProperties
-              }
-            >
+            <div className="@max-[600px]/workspace-file-manager:flex-col @max-[600px]/workspace-file-manager:gap-3 flex min-h-0 min-w-0 flex-1 overflow-hidden">
               <WorkspaceFileManagerPanelsContainer
                 dateLocale={dateLocale}
                 entryDragMode={entryDragMode}

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenu.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenu.tsx
@@ -15,6 +15,7 @@ import {
   type ReactElement,
   type RefObject
 } from "react";
+import { createPortal } from "react-dom";
 import {
   OPEN_WITH_SUBMENU_WIDTH_PX,
   clampContextMenuPosition,
@@ -54,7 +55,11 @@ export function WorkspaceFileManagerContextMenu({
     if (!contextMenu) {
       return;
     }
-    setPosition({ x: contextMenu.x, y: contextMenu.y });
+    setPosition((current) =>
+      current.x === contextMenu.x && current.y === contextMenu.y
+        ? current
+        : { x: contextMenu.x, y: contextMenu.y }
+    );
   }, [contextMenu?.x, contextMenu?.y]);
 
   useLayoutEffect(() => {
@@ -76,35 +81,46 @@ export function WorkspaceFileManagerContextMenu({
       return;
     }
     const boundaryRect = boundary?.getBoundingClientRect();
-    setPosition(
-      clampContextMenuPosition({
-        boundaryHeight: boundaryRect?.height ?? window.innerHeight,
-        boundaryWidth: boundaryRect?.width ?? window.innerWidth,
-        menuHeight: menuRect.height,
-        menuWidth: menuRect.width,
-        x: contextMenu.x,
-        y: contextMenu.y
-      })
+    const next = clampContextMenuPosition({
+      boundaryHeight: boundaryRect?.height ?? window.innerHeight,
+      boundaryWidth: boundaryRect?.width ?? window.innerWidth,
+      menuHeight: menuRect.height,
+      menuWidth: menuRect.width,
+      x: contextMenu.x,
+      y: contextMenu.y
+    });
+    // Bail out on identical coordinates — a fresh object every layout pass
+    // retriggers render and can exceed React's maximum update depth.
+    setPosition((current) =>
+      current.x === next.x && current.y === next.y ? current : next
     );
-  }, [contextMenu, contextMenuRef, items, positionMode]);
+  }, [contextMenu?.x, contextMenu?.y, contextMenuRef, items, positionMode]);
 
   if (!contextMenu || items.length === 0) {
     return null;
   }
 
-  return (
+  const menu = (
     <MenuSurface
       ref={contextMenuRef}
       data-workspace-file-manager-context-menu=""
       className={cn(
-        "w-[220px] overflow-visible p-1",
+        // `is-open` keeps host CSS that keys off the class (not only data-state)
+        // from leaving the surface at opacity:0.
+        "is-open w-[220px] overflow-visible p-1",
         positionMode === "viewport" ? "fixed" : "absolute"
       )}
       role="menu"
       style={{
         left: `${position.x}px`,
         top: `${position.y}px`,
-        zIndex: "calc(var(--workspace-file-manager-dialog-overlay-z-index) - 1)"
+        // Prefer the host CSS var when present; fall back to a stable stacking
+        // value so an unset var cannot invalidate the entire z-index declaration.
+        // Viewport menus need to clear typical workbench chrome (≈ z-10..50).
+        zIndex:
+          positionMode === "viewport"
+            ? "var(--workspace-file-manager-dialog-overlay-z-index, 10050)"
+            : "var(--workspace-file-manager-dialog-overlay-z-index, 20)"
       }}
       onContextMenu={(event) => {
         event.preventDefault();
@@ -115,6 +131,14 @@ export function WorkspaceFileManagerContextMenu({
       ))}
     </MenuSurface>
   );
+
+  // Viewport menus must leave overflow/contain ancestors (e.g. Agent tool
+  // sidebar `[contain:layout_paint]`) or fixed coords are clipped off-screen.
+  if (positionMode === "viewport" && typeof document !== "undefined") {
+    return createPortal(menu, document.body);
+  }
+
+  return menu;
 }
 
 function ContextMenuItemRenderer({

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenuContainer.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenuContainer.tsx
@@ -28,9 +28,13 @@ export function WorkspaceFileManagerContextMenuContainer({
     readonly WorkspaceFileManagerContextMenuItem[]
   >([]);
 
+  const contextMenuX = view.contextMenu?.x;
+  const contextMenuY = view.contextMenu?.y;
+  const contextMenuEntryPath = view.contextMenu?.entry?.path ?? null;
+
   useLayoutEffect(() => {
-    if (!view.contextMenu) {
-      setItems([]);
+    if (contextMenuX === undefined || contextMenuY === undefined) {
+      setItems((current) => (current.length === 0 ? current : []));
       return;
     }
 
@@ -40,24 +44,34 @@ export function WorkspaceFileManagerContextMenuContainer({
     });
     const resolved = resolveContextMenu(request);
     if (!isPromiseLike(resolved)) {
-      setItems(resolved);
+      setItems((current) =>
+        areContextMenuItemsEquivalent(current, resolved) ? current : resolved
+      );
       return;
     }
 
     let cancelled = false;
-    setItems([]);
+    setItems((current) => (current.length === 0 ? current : []));
     void resolved.then((nextItems) => {
       if (!cancelled) {
-        setItems(nextItems);
+        setItems((current) =>
+          areContextMenuItemsEquivalent(current, nextItems)
+            ? current
+            : nextItems
+        );
       }
     });
     return () => {
       cancelled = true;
     };
+    // Depend on stable primitives from the view — `view.contextMenu` is a new
+    // object every render and would retrigger setItems forever.
   }, [
+    contextMenuEntryPath,
+    contextMenuX,
+    contextMenuY,
     resolveContextMenu,
     session,
-    view.contextMenu,
     view.currentDirectoryPath,
     view.isBusy,
     view.isLoading,
@@ -79,6 +93,7 @@ export function WorkspaceFileManagerContextMenuContainer({
       contextMenu={{ x: view.contextMenu.x, y: view.contextMenu.y }}
       contextMenuRef={contextMenuRef}
       items={items}
+      positionMode="viewport"
       onClose={() => {
         session.closeContextMenu();
       }}
@@ -128,6 +143,47 @@ function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
     "then" in value &&
     typeof value.then === "function"
   );
+}
+
+function areContextMenuItemsEquivalent(
+  left: readonly WorkspaceFileManagerContextMenuItem[],
+  right: readonly WorkspaceFileManagerContextMenuItem[]
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let index = 0; index < left.length; index += 1) {
+    const leftItem = left[index];
+    const rightItem = right[index];
+    if (!leftItem || !rightItem || leftItem.id !== rightItem.id) {
+      return false;
+    }
+    if (leftItem.type !== rightItem.type) {
+      return false;
+    }
+    if (leftItem.type === "item" && rightItem.type === "item") {
+      if (
+        leftItem.label !== rightItem.label ||
+        leftItem.disabled !== rightItem.disabled ||
+        leftItem.danger !== rightItem.danger
+      ) {
+        return false;
+      }
+    }
+    if (leftItem.type === "submenu" && rightItem.type === "submenu") {
+      if (
+        leftItem.label !== rightItem.label ||
+        leftItem.disabled !== rightItem.disabled ||
+        leftItem.loading !== rightItem.loading
+      ) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 function useCloseContextMenuOnOutsideInteraction(input: {


### PR DESCRIPTION
## Summary
- Stop `Maximum update depth exceeded` in context menu (`setPosition` / `setItems` fresh-object loops).
- Restore `showLocationSidebar` so single-root hosts (TSH embedded Files) can hide the locations sidebar.
- Include navigation/session/path hardening and CONTRACT updates prepared with this package work.
- Explicitly **out of scope**: `useSnapshot` → `valtio/react` (separate follow-up).

## Release
After merge to `main`, run **npm Package Release** (next `packages-v0.0.x`, tip was `0.0.210` → expect `0.0.211`). Then bump TSH Desktop Tutti cohort and pass `showLocationSidebar={false}` for embedded Files.

## Test plan
- [ ] TSH Files opens without package-shell render-failed
- [ ] Right-click file/empty area: menu opens/closes; no max update depth
- [ ] With `showLocationSidebar={false}`, locations sidebar is hidden
- [ ] file-manager package tests pass