### PR TITLE
fix(device-link): avoid gomobile read crashes

### DIFF
--- a/apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt
+++ b/apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt
@@ -317,9 +317,12 @@ class DeviceLinkModule(
         val output = ByteArrayOutputStream(size)
         while (output.size() < size) {
             val remaining = size - output.size()
-            val chunk = stream.read(minOf(remaining, MAX_READ_CHUNK).toLong())
-            require(chunk.isNotEmpty()) { "DeviceLink stream closed before the response completed" }
-            output.write(chunk)
+            val chunk = ByteArray(minOf(remaining, MAX_READ_CHUNK))
+            val count = stream.readInto(chunk).toInt()
+            require(count > 0 && count <= chunk.size) {
+                "DeviceLink stream closed before the response completed"
+            }
+            output.write(chunk, 0, count)
         }
         return output.toByteArray()
     }

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -109,6 +109,7 @@ CLI behavior, CI, package assets, skills, Browser Node, and terminal input.
 Android app login, native bridge, secure identity, and mobile transport diagnostics.
 
 - [Browser login returns to the App but remains signed out](./mobile.md#browser-login-returns-to-the-app-but-remains-signed-out)
+- [Android DeviceLink opens a session and then repeatedly restarts](./mobile.md#android-devicelink-opens-a-session-and-then-repeatedly-restarts)
 
 ## [Computer Use](./computer-use.md)
 

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -21,3 +21,35 @@
   authorizes device-list requests.
 - **References:** `apps/mobile/src/services/accountClient.ts`,
   `apps/mobile/android/app/src/main/java/dev/tutti/mobile/MobileSecurityModule.kt`
+
+## Android DeviceLink opens a session and then repeatedly restarts
+
+- **Symptom:** Pairing and the secure link succeed, and the App may briefly load
+  a workspace or session before returning to the launcher. Android process exit
+  history reports `EXIT_SELF` with status `2`; logcat contains
+  `fatal error: bulkBarrierPreWrite: unaligned arguments` instead of a Java or
+  React Native exception.
+- **Quick checks:** Run `adb shell dumpsys activity exit-info
+dev.tutti.mobile` and inspect a narrow logcat window for the Go fatal message.
+  This distinguishes a Go runtime abort from an Android lifecycle transition or
+  a React Native development reload.
+- **Root cause:** A gomobile-exported Go method returned `([]byte, error)`.
+  Generated cgo code moves the pointer-bearing return values through a packed
+  result structure; its address is not guaranteed to satisfy the Go runtime
+  write barrier's pointer alignment. The first successful response-body read
+  therefore exposed the upstream cgo alignment defect. Returning final data
+  together with `io.EOF` also cannot be represented by the generated Java API,
+  which chooses either a byte array or an exception.
+- **Fix:** Keep bulk stream data in a Java-owned byte array passed into Go and
+  return only a scalar byte count from the gomobile method. A positive count
+  takes precedence when the underlying Go reader returns data together with
+  `io.EOF`; zero or a negative count is a failed incomplete frame. Do not change
+  this boundary back to a Go slice-plus-error return while the repository uses a
+  Go toolchain affected by
+  [golang/go#46893](https://github.com/golang/go/issues/46893).
+- **Validation:** Generate the Java binding and confirm the stream method is
+  `readInto(byte[])` with a scalar return, run the mobile DeviceLink tests, build
+  and install the AAR consumer, load a real session on an ARM64 Android device,
+  and observe beyond the previous crash window with no new Go fatal message.
+- **References:** `packages/device-link/mobile/link.go`,
+  `apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt`

--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -33,6 +33,13 @@ link facade:
 - authenticated bidirectional stream open/accept/read/write/deadline/close;
 - the loopback integration probe used by the Android build gate.
 
+The Android read boundary intentionally fills a caller-owned byte buffer and
+returns only a scalar count. Do not replace it with a Go `[]byte` plus `error`
+return while the pinned Go/cgo toolchain is affected by packed-result alignment
+failures: gomobile cannot preserve final bytes returned together with `io.EOF`,
+and the generated pointer-bearing result may abort the Android process before
+Java receives it.
+
 Account identity signatures, DeviceLink attempts, pairing scope, Agent HTTP
 framing, and foreground/background policy remain in the Android and tuttid
 product adapters. The mobile facade never accepts account cookies or Agent

--- a/packages/device-link/mobile/link.go
+++ b/packages/device-link/mobile/link.go
@@ -165,16 +165,24 @@ type Stream struct {
 	once sync.Once
 }
 
-func (s *Stream) Read(maxBytes int) ([]byte, error) {
+func (s *Stream) ReadInto(buffer []byte) int {
 	if s == nil || s.conn == nil {
-		return nil, errors.New("device-link mobile stream is closed")
+		return -1
 	}
-	if maxBytes <= 0 || maxBytes > maxMobileStreamRead {
-		return nil, fmt.Errorf("device-link mobile stream read must be between 1 and %d bytes", maxMobileStreamRead)
+	if len(buffer) == 0 || len(buffer) > maxMobileStreamRead {
+		return -1
 	}
-	buffer := make([]byte, maxBytes)
 	count, err := s.conn.Read(buffer)
-	return buffer[:count], err
+	if count > 0 {
+		// Go readers may return final bytes together with io.EOF. The gomobile
+		// boundary cannot return both data and an error without losing the data,
+		// so the positive byte count always wins for this call.
+		return count
+	}
+	if err != nil {
+		return -1
+	}
+	return 0
 }
 
 func (s *Stream) Write(data []byte) (int, error) {

--- a/packages/device-link/mobile/link_test.go
+++ b/packages/device-link/mobile/link_test.go
@@ -2,8 +2,27 @@ package mobile
 
 import (
 	"io"
+	"net"
 	"testing"
 )
+
+func TestStreamReadPreservesFinalBytesReturnedWithEOF(t *testing.T) {
+	t.Parallel()
+	stream := &Stream{conn: &finalBytesConn{remaining: []byte("final response frame")}}
+	buffer := make([]byte, 1024)
+
+	count := stream.ReadInto(buffer)
+	if count != len("final response frame") {
+		t.Fatalf("read final bytes count = %d, want %d", count, len("final response frame"))
+	}
+	if string(buffer[:count]) != "final response frame" {
+		t.Fatalf("read = %q, want final response frame", buffer[:count])
+	}
+
+	if count := stream.ReadInto(buffer); count != -1 {
+		t.Fatalf("read after final bytes count = %d, want -1", count)
+	}
+}
 
 func TestLoopbackLinksExchangeDescriptionsAndStreams(t *testing.T) {
 	t.Parallel()
@@ -46,16 +65,15 @@ func TestLoopbackLinksExchangeDescriptionsAndStreams(t *testing.T) {
 			return
 		}
 		defer stream.Close()
+		buffer := make([]byte, 1024)
 		for {
-			value, readErr := stream.Read(1024)
-			if len(value) > 0 {
-				if _, writeErr := stream.Write(value); writeErr != nil {
-					serveDone <- writeErr
-					return
-				}
+			count := stream.ReadInto(buffer)
+			if count <= 0 {
+				serveDone <- io.EOF
+				return
 			}
-			if readErr != nil {
-				serveDone <- readErr
+			if _, writeErr := stream.Write(buffer[:count]); writeErr != nil {
+				serveDone <- writeErr
 				return
 			}
 		}
@@ -71,10 +89,12 @@ func TestLoopbackLinksExchangeDescriptionsAndStreams(t *testing.T) {
 	if _, err := stream.Write(payload); err != nil {
 		t.Fatal(err)
 	}
-	got, err := stream.Read(len(payload))
-	if err != nil {
-		t.Fatal(err)
+	buffer := make([]byte, len(payload))
+	count := stream.ReadInto(buffer)
+	if count != len(payload) {
+		t.Fatalf("read count = %d, want %d", count, len(payload))
 	}
+	got := buffer[:count]
 	if string(got) != string(payload) {
 		t.Fatalf("echo = %q, want %q", got, payload)
 	}
@@ -90,4 +110,18 @@ func TestProtocolEpochMatchesApplicationPrelude(t *testing.T) {
 	if ProtocolEpoch() != ApplicationProtocolEpoch {
 		t.Fatalf("ProtocolEpoch() = %d, want %d", ProtocolEpoch(), ApplicationProtocolEpoch)
 	}
+}
+
+type finalBytesConn struct {
+	net.Conn
+	remaining []byte
+}
+
+func (c *finalBytesConn) Read(buffer []byte) (int, error) {
+	if len(c.remaining) == 0 {
+		return 0, io.EOF
+	}
+	count := copy(buffer, c.remaining)
+	c.remaining = c.remaining[count:]
+	return count, io.EOF
 }


### PR DESCRIPTION
## Summary

- replace the gomobile `Stream.Read() ([]byte, error)` boundary with a caller-owned byte buffer and scalar byte count
- preserve final response bytes when Go returns data together with `io.EOF`
- update the Android bridge and add regression coverage for the final-bytes-plus-EOF case
- document the Go/cgo packed-return alignment failure and the safe mobile boundary

## Root cause

The Android client previously lost the final response body because gomobile can expose either a byte array or an exception, but not Go's valid `(data, io.EOF)` result. Returning the body successfully then exposed Go issue #46893: the generated cgo callback moves pointer-bearing `([]byte, error)` results through a packed structure and can abort ARM64 Android with `fatal error: bulkBarrierPreWrite: unaligned arguments`.

The new API fills a Java-owned byte array and returns only a scalar count, avoiding both failure modes without changing the DeviceLink or Agent HTTP protocols.

## Validation

- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`
- generated binding exposes `long readInto(byte[])`
- Android AAR and debug APK built and installed successfully
- physical vivo ARM64 device paired and loaded a real workspace/session stream
- process remained alive beyond the previous crash window with no new Go fatal log