### PR TITLE
fix(browser-node): harden Cookie import and same-origin sync

### DIFF
--- a/packages/browser/workbench-node/src/chrome-cookie-import/macos/chromeCookieImport.ts
+++ b/packages/browser/workbench-node/src/chrome-cookie-import/macos/chromeCookieImport.ts
@@ -12,7 +12,7 @@ import { DatabaseSync, backup } from "node:sqlite";
 import { readChromeProfileAvatarDataUrl } from "./chromeProfileMetadata.ts";
 
 const CHROME_KEYCHAIN_SERVICE = "Chrome Safe Storage";
-const CHROME_KEYCHAIN_TIMEOUT_MS = 10_000;
+const CHROME_KEYCHAIN_TIMEOUT_MS = 60_000;
 const CHROME_COOKIE_EPOCH_OFFSET_SECONDS = 11_644_473_600;
 const CHROME_V10_PREFIX = Buffer.from("v10");
 const MACOS_CHROME_IV = Buffer.alloc(16, 0x20);

--- a/packages/browser/workbench-node/src/core/nodeController.test.ts
+++ b/packages/browser/workbench-node/src/core/nodeController.test.ts
@@ -295,6 +295,97 @@ test("Browser Node controller preserves same-origin in-app navigation after atta
   controller.release();
 });
 
+test("Browser Node controller does not fight same-origin auth redirects when default URL follows runtime", async () => {
+  const activateCalls: string[] = [];
+  const runtimeStore = createBrowserNodeRuntimeStore();
+  const feature = createBrowserNodeFeature({
+    hostApi: createBrowserNodeHostApi({
+      activate(payload) {
+        activateCalls.push(payload.url);
+        return Promise.resolve();
+      }
+    }),
+    runtimeStore
+  });
+  runtimeStore.applyEvent({
+    canGoBack: false,
+    canGoForward: false,
+    isAttachedToWindow: true,
+    isLoading: false,
+    isOccluded: false,
+    lifecycle: "active",
+    nodeId: "auth-redirect",
+    title: null,
+    type: "state",
+    url: "https://app.example/"
+  });
+
+  const controller = acquireBrowserNodeController({
+    defaultUrl: "https://app.example/",
+    feature,
+    nodeId: "auth-redirect",
+    syncDefaultUrl: true
+  });
+  controller.retain();
+  await Promise.resolve();
+  assert.deepEqual(activateCalls, []);
+
+  // Guest redirected to /dashboard; host defaultUrl catches up to the runtime page.
+  runtimeStore.applyEvent({
+    canGoBack: true,
+    canGoForward: false,
+    isAttachedToWindow: true,
+    isLoading: false,
+    isOccluded: false,
+    lifecycle: "active",
+    nodeId: "auth-redirect",
+    title: "Dashboard",
+    type: "state",
+    url: "https://app.example/dashboard"
+  });
+  acquireBrowserNodeController({
+    defaultUrl: "https://app.example/dashboard",
+    feature,
+    nodeId: "auth-redirect",
+    syncDefaultUrl: true
+  }).sync();
+  await Promise.resolve();
+  assert.deepEqual(activateCalls, []);
+
+  // Redirect chain still in flight: committed /dashboard while guest is briefly on /.
+  runtimeStore.applyEvent({
+    canGoBack: false,
+    canGoForward: false,
+    isAttachedToWindow: true,
+    isLoading: false,
+    isOccluded: false,
+    lifecycle: "active",
+    nodeId: "auth-redirect",
+    title: null,
+    type: "state",
+    url: "https://app.example/"
+  });
+  acquireBrowserNodeController({
+    defaultUrl: "https://app.example/dashboard",
+    feature,
+    nodeId: "auth-redirect",
+    syncDefaultUrl: true
+  }).sync();
+  await Promise.resolve();
+  assert.deepEqual(activateCalls, []);
+
+  // Cross-origin host URL changes must still force navigation.
+  acquireBrowserNodeController({
+    defaultUrl: "https://example.com/",
+    feature,
+    nodeId: "auth-redirect",
+    syncDefaultUrl: true
+  }).sync();
+  await Promise.resolve();
+  assert.deepEqual(activateCalls, ["https://example.com/"]);
+  controller.release();
+});
+
 test("Browser Node controller shares retain lifecycle across consumers of the same node", () => {
   let connectCount = 0;
   let disconnectCount = 0;

--- a/packages/browser/workbench-node/src/core/nodeController.ts
+++ b/packages/browser/workbench-node/src/core/nodeController.ts
@@ -306,6 +306,20 @@ function reconcileBrowserNodeControllerState(
   }
 }
 
+function isSameOriginComparableBrowserUrl(
+  left: string | null,
+  right: string | null
+): boolean {
+  if (!left || !right) {
+    return false;
+  }
+  try {
+    return new URL(left).origin === new URL(right).origin;
+  } catch {
+    return false;
+  }
+}
+
 async function maybeActivateBrowserNodeDefaultUrl(
   entry: BrowserNodeControllerEntry
 ): Promise<void> {
@@ -325,10 +339,22 @@ async function maybeActivateBrowserNodeDefaultUrl(
     ? normalizeHostBrowserComparableUrl(entry.state.runtime.url)
     : null;
   const shouldActivateColdNode = entry.state.runtime.lifecycle === "cold";
+  // Host-driven sync must not fight same-origin guest redirects
+  // (e.g. example.com → example.com/dashboard after Cookie import).
+  // Runtime URL follows guest navigation; only cross-origin / missing
+  // runtime URLs (or hard errors) should force activate().
+  const runtimeNeedsHostNavigation =
+    entry.state.runtime.error !== null ||
+    comparableRuntimeUrl === null ||
+    !isSameOriginComparableBrowserUrl(
+      comparableRuntimeUrl,
+      comparableDefaultUrl
+    );
   const shouldSyncDefaultUrl =
     syncDefaultUrl &&
     entry.state.runtime.lifecycle !== "cold" &&
     comparableDefaultUrl !== null &&
+    runtimeNeedsHostNavigation &&
     (comparableRuntimeUrl !== comparableDefaultUrl ||
       entry.state.runtime.error !== null) &&
     entry.lastColdActivationUrl !== trimmedUrl;

--- a/packages/browser/workbench-node/src/electron-main/chromeCookieImportTarget.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/chromeCookieImportTarget.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  importChromeCookiesIntoBrowserGuest,
+  reloadBrowserGuestsForCookieSession
+} from "./chromeCookieImportTarget.ts";
+import type {
+  BrowserGuestCookieDetails,
+  BrowserGuestCookieStore,
+  BrowserGuestElectronSession,
+  BrowserGuestWebContents
+} from "./types.ts";
+
+test("cookie session reload skips blank guests and refreshes real pages", () => {
+  const sharedSession = {
+    id: "shared"
+  } as unknown as BrowserGuestElectronSession;
+  const blank = {
+    getURL: () => "about:blank",
+    isDestroyed: () => false,
+    reloadCalls: 0,
+    reload() {
+      this.reloadCalls += 1;
+    },
+    session: sharedSession
+  };
+  const page = {
+    getURL: () => "https://example.test/app",
+    isDestroyed: () => false,
+    reloadCalls: 0,
+    reload() {
+      this.reloadCalls += 1;
+    },
+    session: sharedSession
+  };
+
+  reloadBrowserGuestsForCookieSession(
+    [
+      {
+        contents: blank as unknown as BrowserGuestWebContents,
+        sessionMode: "shared",
+        sessionPartition: null
+      },
+      {
+        contents: page as unknown as BrowserGuestWebContents,
+        sessionMode: "shared",
+        sessionPartition: null
+      }
+    ],
+    sharedSession
+  );
+
+  assert.equal(blank.reloadCalls, 0);
+  assert.equal(page.reloadCalls, 1);
+});
+
+test("Chrome Cookie import can target an ordinary Cookie store without a live guest", async () => {
+  const cookies: BrowserGuestCookieDetails[] = [];
+  const cookieStore = {
+    async set(cookie: BrowserGuestCookieDetails) {
+      cookies.push(cookie);
+    }
+  } as BrowserGuestCookieStore;
+
+  const result = await importChromeCookiesIntoBrowserGuest({
+    contents: null,
+    cookieStore,
+    importInput: {
+      nodeId: "home-browser",
+      operationId: "operation-home",
+      profileId: "opaque" as never
+    },
+    prepareChromeCookieImport: async () => ({
+      cookies: [
+        {
+          name: "session",
+          url: "https://example.test/",
+          value: "one"
+        }
+      ],
+      skipped: 0,
+      status: "ready"
+    }),
+    signal: new AbortController().signal,
+    sessionMode: "shared",
+    sessionPartition: null
+  });
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.imported, 1);
+  assert.equal(cookies.length, 1);
+});

--- a/packages/browser/workbench-node/src/electron-main/chromeCookieImportTarget.ts
+++ b/packages/browser/workbench-node/src/electron-main/chromeCookieImportTarget.ts
@@ -5,6 +5,7 @@ import type {
 } from "../core/types.ts";
 import { importPreparedBrowserGuestCookies } from "./cookieImport.ts";
 import type {
+  BrowserGuestCookieStore,
   BrowserGuestElectronSession,
   BrowserGuestWebContents,
   BrowserNodeChromeCookiePreparationResult
@@ -16,6 +17,21 @@ export function getBrowserGuestCookieImportSession(
   return contents && !contents.isDestroyed()
     ? (contents.session ?? null)
     : null;
+}
+
+function isBrowserGuestCookieReloadUrl(
+  url: string | null | undefined
+): boolean {
+  const trimmed = url?.trim() ?? "";
+  if (trimmed.length === 0 || trimmed === "about:blank") {
+    return false;
+  }
+  try {
+    const protocol = new URL(trimmed).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 export function reloadBrowserGuestsForCookieSession(
@@ -33,7 +49,8 @@ export function reloadBrowserGuestsForCookieSession(
       browserSession.sessionPartition === null &&
       contents &&
       !contents.isDestroyed() &&
-      contents.session === target
+      contents.session === target &&
+      isBrowserGuestCookieReloadUrl(contents.getURL?.() ?? null)
     ) {
       contents.reload();
     }
@@ -42,6 +59,7 @@ export function reloadBrowserGuestsForCookieSession(
 
 export async function importChromeCookiesIntoBrowserGuest(input: {
   contents: BrowserGuestWebContents | null | undefined;
+  cookieStore?: BrowserGuestCookieStore | null;
   importInput: BrowserNodeChromeCookieImportInput;
   prepareChromeCookieImport?: (
     profileId: BrowserNodeChromeCookieImportInput["profileId"],
@@ -51,10 +69,13 @@ export async function importChromeCookiesIntoBrowserGuest(input: {
   sessionMode: BrowserNodeSessionMode;
   sessionPartition: string | null;
 }): Promise<BrowserNodeCookieImportResult> {
-  const store = input.contents?.session?.cookies;
+  const store =
+    input.cookieStore ??
+    (input.contents && !input.contents.isDestroyed()
+      ? (input.contents.session?.cookies ?? null)
+      : null);
   if (
     !store ||
-    input.contents?.isDestroyed() ||
     input.sessionMode === "incognito" ||
     input.sessionPartition !== null ||
     !input.prepareChromeCookieImport

--- a/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
@@ -581,6 +581,11 @@ test("reloads only ordinary Browser nodes sharing the imported Electron Session"
     sessionMode: "profile",
     webContentsId: isolated.id
   });
+  sharedOne.currentUrl = "https://example.test/one";
+  sharedTwo.currentUrl = "https://example.test/two";
+  isolated.currentUrl = "https://example.test/isolated";
+  incognito.currentUrl = "https://example.test/incognito";
+  workspaceApp.currentUrl = "https://example.test/app";
 
   manager.reloadCookieImportSession(sharedSession);
   assert.equal(sharedOne.reloadCalls, 1);
@@ -681,6 +686,10 @@ test("Cookie imports refresh ordinary nodes across windows and exclude custom Se
     sessionMode: "profile",
     webContentsId: isolated.id
   });
+  first.currentUrl = "https://example.test/first";
+  second.currentUrl = "https://example.test/second";
+  custom.currentUrl = "https://example.test/custom";
+  isolated.currentUrl = "https://example.test/isolated";
 
   await handlers.get("browser:importCookies")?.(firstEvent, {
     nodeId: "first"

--- a/packages/browser/workbench-node/src/electron-main/guestManager.ts
+++ b/packages/browser/workbench-node/src/electron-main/guestManager.ts
@@ -10,6 +10,7 @@ import {
   resolveHostBrowserNavigationUrl
 } from "../core/url.ts";
 import type {
+  BrowserGuestCookieStore,
   BrowserGuestManager,
   BrowserGuestManagerInput,
   BrowserPreferredColorScheme,
@@ -109,6 +110,8 @@ export function createBrowserGuestManager({
   openExternal,
   prepareSession,
   prepareChromeCookieImport,
+  resolveOrdinaryCookieStore,
+  resolveOrdinaryCookieSession,
   resolveWebContents,
   saveScreenshot,
   selectCookieImport,
@@ -598,18 +601,71 @@ export function createBrowserGuestManager({
     },
     async importChromeCookies(input, signal) {
       const browserSession = sessions.get(input.nodeId);
+      const sessionMode = browserSession?.sessionMode ?? "shared";
+      const sessionPartition = browserSession?.sessionPartition ?? null;
+      const profileId = browserSession?.profileId ?? null;
+      const contents = browserSession?.contents ?? null;
+      let cookieStore: BrowserGuestCookieStore | null =
+        contents && !contents.isDestroyed()
+          ? (contents.session?.cookies ?? null)
+          : null;
+      if (
+        !cookieStore &&
+        sessionMode !== "incognito" &&
+        sessionPartition === null &&
+        resolveOrdinaryCookieStore
+      ) {
+        await prepareSession?.({
+          nodeId: input.nodeId,
+          profileId,
+          sessionMode,
+          sessionPartition,
+          url: undefined
+        });
+        cookieStore =
+          (await resolveOrdinaryCookieStore({
+            profileId,
+            sessionMode,
+            sessionPartition
+          })) ?? null;
+      }
       return importChromeCookiesIntoBrowserGuest({
-        contents: browserSession?.contents,
+        contents,
+        cookieStore,
         importInput: input,
         prepareChromeCookieImport,
         signal,
-        sessionMode: browserSession?.sessionMode ?? "incognito",
-        sessionPartition: browserSession?.sessionPartition ?? null
+        sessionMode,
+        sessionPartition
       });
     },
     getCookieImportSession(input) {
-      return getBrowserGuestCookieImportSession(
+      const browserSession = sessions.get(input.nodeId);
+      return getBrowserGuestCookieImportSession(browserSession?.contents);
+    },
+    async resolveCookieImportSession(input) {
+      const fromGuest = getBrowserGuestCookieImportSession(
         sessions.get(input.nodeId)?.contents
+      );
+      if (fromGuest) {
+        return fromGuest;
+      }
+      const browserSession = sessions.get(input.nodeId);
+      const sessionMode = browserSession?.sessionMode ?? "shared";
+      const sessionPartition = browserSession?.sessionPartition ?? null;
+      if (
+        sessionMode === "incognito" ||
+        sessionPartition !== null ||
+        !resolveOrdinaryCookieSession
+      ) {
+        return null;
+      }
+      return (
+        (await resolveOrdinaryCookieSession({
+          profileId: browserSession?.profileId ?? null,
+          sessionMode,
+          sessionPartition
+        })) ?? null
       );
     },
     reloadCookieImportSession(target) {

--- a/packages/browser/workbench-node/src/electron-main/registerElectronMain.ts
+++ b/packages/browser/workbench-node/src/electron-main/registerElectronMain.ts
@@ -199,6 +199,42 @@ export function registerBrowserNodeElectronMain(
             }
           : undefined,
       prepareChromeCookieImport: input.prepareChromeCookieImport,
+      async resolveOrdinaryCookieSession({
+        profileId,
+        sessionMode,
+        sessionPartition
+      }) {
+        if (sessionMode === "incognito" || sessionPartition !== null) {
+          return null;
+        }
+        const { session } = await import("electron");
+        return session.fromPartition(
+          resolveBrowserSessionPartition({
+            profileId,
+            sessionMode,
+            sessionPartition
+          })
+        );
+      },
+      async resolveOrdinaryCookieStore({
+        profileId,
+        sessionMode,
+        sessionPartition
+      }) {
+        if (sessionMode === "incognito" || sessionPartition !== null) {
+          return null;
+        }
+        const { session } = await import("electron");
+        return (
+          session.fromPartition(
+            resolveBrowserSessionPartition({
+              profileId,
+              sessionMode,
+              sessionPartition
+            })
+          ).cookies ?? null
+        );
+      },
       resolveWebContents: (webContentsId) =>
         input.resolveWebContents({
           event,
@@ -245,6 +281,9 @@ export function registerBrowserNodeElectronMain(
     target: import("./types.ts").BrowserGuestElectronSession | null,
     result: import("../core/types.ts").BrowserNodeCookieImportResult
   ): void => {
+    // Refresh only real navigable pages. Reloading blank/home guests (or doing a
+    // broad session refresh while the home UI is visible) races with URL sync and
+    // produces a visible flash / workspace update storm.
     if (!target || result.imported === 0) {
       return;
     }
@@ -304,8 +343,8 @@ export function registerBrowserNodeElectronMain(
       async (event, payload) => {
         const { manager, ownerWindow } = resolveOwnedManager(event);
         const nodeInput = payload as BrowserNodeNodeIdInput;
-        const target = manager.getCookieImportSession(nodeInput);
         const result = await manager.importCookies(nodeInput);
+        const target = await manager.resolveCookieImportSession(nodeInput);
         refreshCookieImportSession(target, result);
         input.notifyCookieImportResult?.({
           ownerWindow,
@@ -341,7 +380,6 @@ export function registerBrowserNodeElectronMain(
         }
         const controller = new AbortController();
         imports.set(chromeInput.operationId, controller);
-        const target = manager.getCookieImportSession(chromeInput);
         let result;
         try {
           result = await manager.importChromeCookies(
@@ -351,6 +389,7 @@ export function registerBrowserNodeElectronMain(
         } finally {
           imports.delete(chromeInput.operationId);
         }
+        const target = await manager.resolveCookieImportSession(chromeInput);
         refreshCookieImportSession(target, result);
         input.notifyCookieImportResult?.({
           ownerWindow,

--- a/packages/browser/workbench-node/src/electron-main/types.ts
+++ b/packages/browser/workbench-node/src/electron-main/types.ts
@@ -17,6 +17,7 @@ import type {
   BrowserNodeRegisterGuestInput,
   BrowserNodeScreenshotSaveResult,
   BrowserNodeSaveScreenshotInput,
+  BrowserNodeSessionMode,
   BrowserNodeSetDeviceEmulationInput,
   BrowserNodeSetZoomFactorInput,
   BrowserNodeShowDevToolsContextMenuInput,
@@ -48,6 +49,9 @@ export interface BrowserGuestManager {
   getCookieImportSession(
     input: BrowserNodeNodeIdInput
   ): BrowserGuestElectronSession | null;
+  resolveCookieImportSession(
+    input: BrowserNodeNodeIdInput
+  ): Promise<BrowserGuestElectronSession | null>;
   reloadCookieImportSession(target: BrowserGuestElectronSession): void;
   handleGuestOpenUrl(
     webContentsId: number,
@@ -95,6 +99,22 @@ export interface BrowserGuestManagerInput {
   prepareSession?: (
     input: BrowserNodePrepareSessionInput
   ) => Promise<void> | void;
+  resolveOrdinaryCookieStore?: (input: {
+    profileId: string | null;
+    sessionMode: BrowserNodeSessionMode;
+    sessionPartition: string | null;
+  }) =>
+    | Promise<BrowserGuestCookieStore | null>
+    | BrowserGuestCookieStore
+    | null;
+  resolveOrdinaryCookieSession?: (input: {
+    profileId: string | null;
+    sessionMode: BrowserNodeSessionMode;
+    sessionPartition: string | null;
+  }) =>
+    | Promise<BrowserGuestElectronSession | null>
+    | BrowserGuestElectronSession
+    | null;
   resolveWebContents: (webContentsId: number) => BrowserGuestWebContents | null;
   saveScreenshot?: (
     input: BrowserNodeScreenshotCapture

--- a/packages/browser/workbench-node/src/react/BrowserNode.tsx
+++ b/packages/browser/workbench-node/src/react/BrowserNode.tsx
@@ -322,10 +322,12 @@ function BrowserNodeContent({
     ? formatBrowserNodeErrorStatus(feature, runtime.error)
     : null;
   const isShowingLoadError = errorMessage !== null;
+  // Keep home mounted across about:blank loading flickers. Hiding home while the
+  // bootstrap webview reports isLoading makes the empty state flash on every
+  // guest reload/attach (including Cookie-import session refreshes).
   const isShowingHome =
     renderHome !== undefined &&
     !isShowingLoadError &&
-    !runtime.isLoading &&
     isBrowserNodeHomeUrl(runtime.url ?? state.displayUrl);
   const openExternalUrl = resolveBrowserNodeOpenExternalUrl(feature, state);
   const {

--- a/packages/browser/workbench-node/src/react/useBrowserNodeWebview.ts
+++ b/packages/browser/workbench-node/src/react/useBrowserNodeWebview.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useExternalStoreSnapshot } from "@tutti-os/ui-react-hooks";
 import {
   acquireBrowserNodeWebviewController,
@@ -46,6 +46,12 @@ export function useBrowserNodeWebview({
   webviewPartition: string;
   webviewSrc: string;
 } {
+  const onGuestInteractionRef = useRef(onGuestInteraction);
+  onGuestInteractionRef.current = onGuestInteraction;
+  const stableOnGuestInteraction = useCallback(() => {
+    onGuestInteractionRef.current?.();
+  }, []);
+
   const controller = useMemo(
     () =>
       acquireBrowserNodeWebviewController({
@@ -55,7 +61,7 @@ export function useBrowserNodeWebview({
         lifecycle,
         navigationPolicy,
         nodeId,
-        onGuestInteraction,
+        onGuestInteraction: stableOnGuestInteraction,
         profileId,
         sessionMode,
         sessionPartition
@@ -67,7 +73,7 @@ export function useBrowserNodeWebview({
       lifecycle,
       navigationPolicy,
       nodeId,
-      onGuestInteraction,
+      stableOnGuestInteraction,
       profileId,
       sessionMode,
       sessionPartition
@@ -90,7 +96,6 @@ export function useBrowserNodeWebview({
     lifecycle,
     navigationPolicy,
     nodeId,
-    onGuestInteraction,
     profileId,
     sessionMode,
     sessionPartition


### PR DESCRIPTION
## Summary
- Allow Chrome Cookie import into an ordinary Cookie store without a live guest (home/blank browser).
- Skip Cookie-import reloads for blank/non-HTTP guests; raise Keychain timeout for large imports.
- Stop `syncDefaultUrl` from calling `activate` for same-origin path-only changes so post-import auth redirects are not fought.

## Test plan
- [x] `pnpm --dir packages/browser/workbench-node test`
- [ ] After merge: run **npm Package Release** on `main` (cohort bump for TSH)
- [ ] Manual: home Cookie import → open an authenticated site → settle on redirected path without bounce


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->