### PR TITLE
perf(agent-gui): reduce conversation switch layout work

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -413,6 +413,10 @@ timestamp.
 
 High-frequency transcript updates must not pair DOM mutation with unconditional synchronous reads of the timeline's full scroll geometry. Conversation switches, explicit submit-to-bottom requests, skeleton transitions, and older-page prepend restoration may perform pre-paint scroll correction; ordinary content growth preserves bottom lock and user scroll-away state from observed content and viewport geometry after layout.
 
+Virtualizer- or layout-driven scroll events do not release the bottom lock or
+trigger older-page loading without explicit user scroll-away intent. A settled
+timeline that is too short to fill its viewport may still request older pages.
+
 Composer draft updates cross the view boundary through the stable `shell`,
 `rail`, `detail`, `composer`, `interaction`, `readiness`, and `operations`
 projections rather than one aggregate Detail prop. The active Timeline

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx
@@ -24,6 +24,7 @@ describe("useAgentGUIDetailScroll", () => {
 
     expect(harness.timeline.scrollTop).toBe(4_900);
     act(() => {
+      harness.timeline.dispatchEvent(new WheelEvent("wheel", { deltaY: -100 }));
       harness.timeline.scrollTop = 2_000;
       harness.timeline.dispatchEvent(new Event("scroll"));
     });
@@ -82,6 +83,7 @@ describe("useAgentGUIDetailScroll", () => {
     );
 
     act(() => {
+      harness.timeline.dispatchEvent(new WheelEvent("wheel", { deltaY: -100 }));
       harness.timeline.scrollTop = 2_000;
       harness.timeline.dispatchEvent(new Event("scroll"));
     });
@@ -125,6 +127,7 @@ describe("useAgentGUIDetailScroll", () => {
     expect(harness.timeline.scrollTop).toBe(4_900);
 
     act(() => {
+      harness.timeline.dispatchEvent(new WheelEvent("wheel", { deltaY: -100 }));
       harness.timeline.scrollTop = 4_000;
       harness.timeline.dispatchEvent(new Event("scroll"));
     });
@@ -173,6 +176,41 @@ describe("useAgentGUIDetailScroll", () => {
     expect(harness.timeline.scrollTop).toBe(4_900);
   });
 
+  it("keeps the bottom lock through virtualizer-driven scroll changes", () => {
+    const resizeObservers = installResizeObserverMock();
+    const harness = createHarness({ scrollHeight: 5_000 });
+
+    const { result } = renderHook(() =>
+      useAgentGUIDetailScroll(
+        harness.input({
+          activeConversationId: "conversation-virtualized",
+          hasOlderMessages: true,
+          showTimelineSkeleton: false
+        })
+      )
+    );
+    const timelineObserver = resizeObservers.find((observer) =>
+      observer.observed.has(harness.timelineContent)
+    );
+    expect(timelineObserver).toBeDefined();
+
+    act(() => {
+      harness.timeline.scrollTop = 100;
+      harness.timeline.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(harness.timeline.scrollTop).toBe(4_900);
+    expect(result.current.isTimelineScrolledToBottom).toBe(true);
+    expect(harness.loadOlderConversationMessages).not.toHaveBeenCalled();
+
+    harness.setScrollHeight(6_000);
+    act(() => {
+      timelineObserver?.callback([], timelineObserver);
+    });
+
+    expect(harness.timeline.scrollTop).toBe(5_900);
+  });
+
   it("releases the bottom lock after the user scrolls upward", () => {
     const harness = createHarness({ scrollHeight: 5_000 });
 
@@ -198,6 +236,72 @@ describe("useAgentGUIDetailScroll", () => {
     });
 
     expect(harness.timeline.scrollTop).toBe(4_000);
+  });
+
+  it("releases the bottom lock during pointer-driven scrolling", () => {
+    const resizeObservers = installResizeObserverMock();
+    const harness = createHarness({ scrollHeight: 5_000 });
+
+    renderHook(() =>
+      useAgentGUIDetailScroll(
+        harness.input({
+          activeConversationId: "conversation-pointer-scroll",
+          showTimelineSkeleton: false
+        })
+      )
+    );
+    const timelineObserver = resizeObservers.find((observer) =>
+      observer.observed.has(harness.timelineContent)
+    );
+    expect(timelineObserver).toBeDefined();
+
+    act(() => {
+      harness.timeline.dispatchEvent(new Event("pointerdown"));
+      harness.timeline.scrollTop = 4_000;
+      harness.timeline.dispatchEvent(new Event("scroll"));
+      window.dispatchEvent(new Event("pointerup"));
+    });
+
+    harness.setScrollHeight(6_000);
+    act(() => {
+      timelineObserver?.callback([], timelineObserver);
+    });
+
+    expect(harness.timeline.scrollTop).toBe(4_000);
+  });
+
+  it("releases the bottom lock when a locator initiates scrolling", () => {
+    const resizeObservers = installResizeObserverMock();
+    const harness = createHarness({ scrollHeight: 5_000 });
+    const locator = document.createElement("button");
+    locator.setAttribute("data-agent-transcript-scroll-away-intent", "");
+    harness.timeline.appendChild(locator);
+
+    renderHook(() =>
+      useAgentGUIDetailScroll(
+        harness.input({
+          activeConversationId: "conversation-locator-scroll",
+          showTimelineSkeleton: false
+        })
+      )
+    );
+    const timelineObserver = resizeObservers.find((observer) =>
+      observer.observed.has(harness.timelineContent)
+    );
+    expect(timelineObserver).toBeDefined();
+
+    act(() => {
+      locator.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      harness.timeline.scrollTop = 2_000;
+      harness.timeline.dispatchEvent(new Event("scroll"));
+    });
+
+    harness.setScrollHeight(6_000);
+    act(() => {
+      timelineObserver?.callback([], timelineObserver);
+    });
+
+    expect(harness.timeline.scrollTop).toBe(2_000);
   });
 
   it("does not synchronously read full timeline geometry during scrolling", () => {
@@ -269,6 +373,27 @@ describe("useAgentGUIDetailScroll", () => {
       scrollHeight: 1,
       scrollTop: 0
     });
+  });
+
+  it("waits for the timeline skeleton to resolve before filling the viewport", () => {
+    const harness = createHarness({ scrollHeight: 100 });
+    const { rerender } = renderHook(
+      ({ showTimelineSkeleton }) =>
+        useAgentGUIDetailScroll(
+          harness.input({
+            activeConversationId: "conversation-skeleton-prefetch",
+            hasOlderMessages: true,
+            showTimelineSkeleton
+          })
+        ),
+      { initialProps: { showTimelineSkeleton: true } }
+    );
+
+    expect(harness.loadOlderConversationMessages).not.toHaveBeenCalled();
+
+    rerender({ showTimelineSkeleton: false });
+
+    expect(harness.loadOlderConversationMessages).toHaveBeenCalledOnce();
   });
 
   it("restores a prepend anchor from one timeline geometry snapshot", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx
@@ -101,31 +101,126 @@ describe("useAgentGUIDetailScroll", () => {
     expect(harness.timeline.scrollTop).toBe(7_900);
   });
 
-  it("does not let a skeleton-era bottom frame override newer user scroll", () => {
-    const harness = createHarness({ scrollHeight: 100 });
+  it("restores bottom lock when a retained conversation is reselected", () => {
+    const resizeObservers = installResizeObserverMock();
+    const harness = createHarness({ scrollHeight: 5_000 });
+    const { rerender } = renderHook(
+      ({ activeConversationId }) =>
+        useAgentGUIDetailScroll(
+          harness.input({
+            activeConversationId,
+            showTimelineSkeleton: false,
+            timelineConversationId: "conversation-a"
+          })
+        ),
+      { initialProps: { activeConversationId: "conversation-a" } }
+    );
+    expect(harness.timeline.scrollTop).toBe(4_900);
+
+    rerender({ activeConversationId: "conversation-b" });
+    rerender({ activeConversationId: "conversation-a" });
+    harness.setScrollHeight(6_000);
+    const timelineObserver = resizeObservers.find((observer) =>
+      observer.observed.has(harness.timelineContent)
+    );
+    expect(timelineObserver).toBeDefined();
+    act(() => {
+      timelineObserver?.callback([], timelineObserver);
+    });
+
+    expect(harness.timeline.scrollTop).toBe(5_900);
+  });
+
+  it("defers conversation-switch geometry until the timeline skeleton resolves", () => {
+    const harness = createHarness({ scrollHeight: 5_000 });
+    const { rerender, result } = renderHook(
+      ({ activeConversationId, showTimelineSkeleton }) =>
+        useAgentGUIDetailScroll(
+          harness.input({
+            activeConversationId,
+            showTimelineSkeleton
+          })
+        ),
+      {
+        initialProps: {
+          activeConversationId: "conversation-a",
+          showTimelineSkeleton: false
+        }
+      }
+    );
+
+    expect(harness.timeline.scrollTop).toBe(4_900);
+    act(() => {
+      harness.timeline.dispatchEvent(new WheelEvent("wheel", { deltaY: -100 }));
+      harness.timeline.scrollTop = 2_000;
+      harness.timeline.dispatchEvent(new Event("scroll"));
+    });
+    expect(result.current.isTimelineScrolledToTop).toBe(false);
+    expect(result.current.isTimelineScrolledToBottom).toBe(false);
+    harness.resetGeometryReadCounts();
+
+    harness.setScrollHeight(100);
+    rerender({
+      activeConversationId: "conversation-b",
+      showTimelineSkeleton: true
+    });
+
+    expect(harness.geometryReadCounts()).toEqual({
+      clientHeight: 0,
+      scrollHeight: 0,
+      scrollTop: 0
+    });
+    expect(result.current.isTimelineScrolledToTop).toBe(true);
+    expect(result.current.isTimelineScrolledToBottom).toBe(true);
+    expect(harness.timeline.scrollTop).toBe(2_000);
+
+    harness.setScrollHeight(8_000);
+    rerender({
+      activeConversationId: "conversation-b",
+      showTimelineSkeleton: false
+    });
+
+    expect(harness.geometryReadCounts()).toEqual({
+      clientHeight: 1,
+      scrollHeight: 1,
+      scrollTop: 1
+    });
+    expect(harness.timeline.scrollTop).toBe(7_900);
+  });
+
+  it("does not let a previous conversation bottom frame override newer user scroll", () => {
+    const harness = createHarness({ scrollHeight: 5_000 });
     const animationFrames: FrameRequestCallback[] = [];
     vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
       animationFrames.push(callback);
       return animationFrames.length;
     });
-
     const { rerender } = renderHook(
-      ({ showTimelineSkeleton }) =>
+      ({ activeConversationId, showTimelineSkeleton }) =>
         useAgentGUIDetailScroll(
           harness.input({
-            activeConversationId: "conversation-long",
+            activeConversationId,
             showTimelineSkeleton
           })
         ),
-      { initialProps: { showTimelineSkeleton: true } }
+      {
+        initialProps: {
+          activeConversationId: "conversation-a",
+          showTimelineSkeleton: false
+        }
+      }
     );
-
     expect(animationFrames).toHaveLength(1);
 
+    rerender({
+      activeConversationId: "conversation-b",
+      showTimelineSkeleton: true
+    });
     harness.setScrollHeight(5_000);
-    rerender({ showTimelineSkeleton: false });
-    expect(harness.timeline.scrollTop).toBe(4_900);
-
+    rerender({
+      activeConversationId: "conversation-b",
+      showTimelineSkeleton: false
+    });
     act(() => {
       harness.timeline.dispatchEvent(new WheelEvent("wheel", { deltaY: -100 }));
       harness.timeline.scrollTop = 4_000;
@@ -136,44 +231,59 @@ describe("useAgentGUIDetailScroll", () => {
     expect(harness.timeline.scrollTop).toBe(4_000);
   });
 
-  it("keeps a newly selected conversation bottom-locked while layout grows", () => {
+  it("starts observing content growth after the timeline skeleton resolves", () => {
     const resizeObservers = installResizeObserverMock();
     const harness = createHarness({ scrollHeight: 100 });
-    const animationFrames: FrameRequestCallback[] = [];
-    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
-      animationFrames.push(callback);
-      return animationFrames.length;
-    });
 
-    renderHook(() =>
-      useAgentGUIDetailScroll(
-        harness.input({
-          activeConversationId: "conversation-growing",
-          showTimelineSkeleton: true
-        })
-      )
+    const { rerender } = renderHook(
+      ({ showTimelineSkeleton }) =>
+        useAgentGUIDetailScroll(
+          harness.input({
+            activeConversationId: "conversation-growing",
+            showTimelineSkeleton
+          })
+        ),
+      { initialProps: { showTimelineSkeleton: true } }
     );
 
-    const timelineObserver = resizeObservers.find((observer) =>
+    let timelineObserver = resizeObservers.find((observer) =>
       observer.observed.has(harness.timelineContent)
     );
     expect(timelineObserver).toBeDefined();
+    expect(harness.geometryReadCounts()).toEqual({
+      clientHeight: 0,
+      scrollHeight: 0,
+      scrollTop: 0
+    });
 
     harness.setScrollHeight(5_000);
     act(() => {
       timelineObserver?.callback([], timelineObserver);
     });
-    expect(harness.timeline.scrollTop).toBe(4_900);
+    expect(harness.geometryReadCounts()).toEqual({
+      clientHeight: 0,
+      scrollHeight: 0,
+      scrollTop: 0
+    });
+    expect(harness.timeline.scrollTop).toBe(0);
 
-    harness.resetGeometryReadCounts();
-    act(() => animationFrames[0]?.(0));
+    rerender({ showTimelineSkeleton: false });
 
     expect(harness.geometryReadCounts()).toEqual({
       clientHeight: 1,
       scrollHeight: 1,
-      scrollTop: 0
+      scrollTop: 1
     });
     expect(harness.timeline.scrollTop).toBe(4_900);
+
+    timelineObserver = resizeObservers.find((observer) =>
+      observer.observed.has(harness.timelineContent)
+    );
+    harness.setScrollHeight(6_000);
+    act(() => {
+      timelineObserver?.callback([], timelineObserver);
+    });
+    expect(harness.timeline.scrollTop).toBe(5_900);
   });
 
   it("keeps the bottom lock through virtualizer-driven scroll changes", () => {
@@ -554,6 +664,165 @@ describe("useAgentGUIDetailScroll", () => {
       )
     ).toBe("80px");
   });
+
+  it("reuses dock safe-area geometry across a conversation switch", () => {
+    const resizeObservers = installResizeObserverMock();
+    const harness = createHarness({ scrollHeight: 5_000 });
+    const animationFrames: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      animationFrames.push(callback);
+      return animationFrames.length;
+    });
+    const dockRect = vi
+      .spyOn(harness.bottomDock, "getBoundingClientRect")
+      .mockReturnValue(
+        mockRect({ top: 400, bottom: 500, width: 600, height: 100 })
+      );
+    const { rerender } = renderHook(
+      ({ activeConversationId }) =>
+        useAgentGUIDetailScroll(
+          harness.input({
+            activeConversationId,
+            showTimelineSkeleton: false
+          })
+        ),
+      { initialProps: { activeConversationId: "conversation-a" } }
+    );
+    expect(dockRect).toHaveBeenCalledOnce();
+    const dockObserver = resizeObservers.find((observer) =>
+      observer.observed.has(harness.bottomDock)
+    );
+    expect(dockObserver).toBeDefined();
+    act(() => {
+      dockObserver?.callback([], dockObserver);
+    });
+    expect(dockRect).toHaveBeenCalledTimes(2);
+    dockRect.mockClear();
+
+    harness.setScrollHeight(8_000);
+    rerender({ activeConversationId: "conversation-b" });
+
+    expect(dockRect).not.toHaveBeenCalled();
+    expect(
+      resizeObservers.filter((observer) =>
+        observer.observed.has(harness.bottomDock)
+      )
+    ).toEqual([dockObserver]);
+    expect(harness.timeline.scrollTop).toBe(7_900);
+    act(() => animationFrames.at(-1)?.(0));
+    expect(harness.timeline.scrollTop).toBe(7_900);
+
+    harness.setScrollHeight(9_000);
+    const timelineObserver = resizeObservers.find((observer) =>
+      observer.observed.has(harness.timelineContent)
+    );
+    expect(timelineObserver).toBeDefined();
+    act(() => {
+      timelineObserver?.callback([], timelineObserver);
+    });
+
+    expect(harness.timeline.scrollTop).toBe(8_900);
+    expect(dockRect).not.toHaveBeenCalled();
+  });
+
+  it("disconnects dock observation when the timeline conversation clears", () => {
+    const resizeObservers = installResizeObserverMock();
+    const harness = createHarness({ scrollHeight: 5_000 });
+    const { rerender } = renderHook(
+      ({ timelineConversationId }: { timelineConversationId: string | null }) =>
+        useAgentGUIDetailScroll(
+          harness.input({
+            activeConversationId: "conversation-cleared",
+            showTimelineSkeleton: false,
+            timelineConversationId
+          })
+        ),
+      {
+        initialProps: {
+          timelineConversationId: "conversation-cleared" as string | null
+        }
+      }
+    );
+    const dockObserver = resizeObservers.find((observer) =>
+      observer.observed.has(harness.bottomDock)
+    );
+    expect(dockObserver).toBeDefined();
+
+    rerender({ timelineConversationId: null });
+
+    expect(dockObserver?.observed.size).toBe(0);
+    expect(
+      resizeObservers.some((observer) =>
+        observer.observed.has(harness.bottomDock)
+      )
+    ).toBe(false);
+  });
+
+  it("remeasures dock safe-area after store and ResizeObserver invalidation", () => {
+    const resizeObservers = installResizeObserverMock();
+    const harness = createHarness({ scrollHeight: 5_000 });
+    const liftedChrome = document.createElement("div");
+    harness.bottomDock.appendChild(liftedChrome);
+    let liftedTop = 350;
+    harness.bottomDock.getBoundingClientRect = vi.fn(() =>
+      mockRect({ top: 400, bottom: 500, width: 600, height: 100 })
+    );
+    const liftedRect = vi
+      .spyOn(liftedChrome, "getBoundingClientRect")
+      .mockImplementation(() =>
+        mockRect({
+          top: liftedTop,
+          bottom: liftedTop + 40,
+          width: 600,
+          height: 40
+        })
+      );
+    const { rerender } = renderHook(
+      ({ bottomDockStoreRevision }) =>
+        useAgentGUIDetailScroll(
+          harness.input({
+            activeConversationId: "conversation-dock-invalidation",
+            bottomDockStoreRevision,
+            showTimelineSkeleton: false
+          })
+        ),
+      { initialProps: { bottomDockStoreRevision: "first" } }
+    );
+
+    expect(
+      harness.timeline.style.getPropertyValue(
+        "--agent-gui-bottom-dock-safe-area"
+      )
+    ).toBe("50px");
+    liftedRect.mockClear();
+    liftedTop = 320;
+
+    rerender({ bottomDockStoreRevision: "second" });
+
+    expect(liftedRect).toHaveBeenCalledOnce();
+    expect(
+      harness.timeline.style.getPropertyValue(
+        "--agent-gui-bottom-dock-safe-area"
+      )
+    ).toBe("80px");
+
+    liftedRect.mockClear();
+    liftedTop = 300;
+    const dockObserver = resizeObservers.find((observer) =>
+      observer.observed.has(harness.bottomDock)
+    );
+    expect(dockObserver).toBeDefined();
+    act(() => {
+      dockObserver?.callback([], dockObserver);
+    });
+
+    expect(liftedRect).toHaveBeenCalledOnce();
+    expect(
+      harness.timeline.style.getPropertyValue(
+        "--agent-gui-bottom-dock-safe-area"
+      )
+    ).toBe("100px");
+  });
 });
 
 function mockRect(input: {
@@ -651,22 +920,25 @@ function createHarness(input: { scrollHeight: number }) {
     },
     input(options: {
       activeConversationId: string;
+      bottomDockStoreRevision?: string;
       conversation?: AgentConversationVM;
       hasOlderMessages?: boolean;
       isLoadingOlderMessages?: boolean;
       showTimelineSkeleton: boolean;
-      timelineConversationId?: string;
+      timelineConversationId?: string | null;
     }) {
       return {
         actions,
         bottomDockRef: ref(bottomDock),
-        bottomDockStoreRevision: "stable",
+        bottomDockStoreRevision: options.bottomDockStoreRevision ?? "stable",
         conversation: options.conversation ?? null,
         pendingPrependScrollAnchorRef,
         showTimelineSkeleton: options.showTimelineSkeleton,
         submittedPromptScrollConversationRef,
         timelineConversationId:
-          options.timelineConversationId ?? options.activeConversationId,
+          options.timelineConversationId === undefined
+            ? options.activeConversationId
+            : options.timelineConversationId,
         timelineContentRef: ref(timelineContent),
         timelineRef: ref(timeline),
         timelineScrollAnchorRef,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.ts
@@ -50,6 +50,13 @@ interface TimelineGeometry {
   scrollHeight: number;
 }
 
+interface BottomDockSafeArea {
+  bottomDock: HTMLDivElement;
+  floatingOverflowHeight: number;
+  revision: string;
+  timelineOverflowHeight: number;
+}
+
 function readTimelineGeometry(timeline: HTMLElement): TimelineGeometry {
   const scrollHeight = timeline.scrollHeight;
   const clientHeight = timeline.clientHeight;
@@ -58,6 +65,75 @@ function readTimelineGeometry(timeline: HTMLElement): TimelineGeometry {
     maxScrollTop: Math.max(0, scrollHeight - clientHeight),
     scrollHeight
   };
+}
+
+function readBottomDockSafeArea(bottomDock: HTMLDivElement): {
+  floatingOverflowHeight: number;
+  timelineOverflowHeight: number;
+} {
+  const bottomDockRect = bottomDock.getBoundingClientRect();
+  let timelineVisualTop = bottomDockRect.top;
+  let floatingVisualTop = bottomDockRect.top;
+  bottomDock.querySelectorAll("*").forEach((element) => {
+    if (element.closest(`.${styles.bottomDockScrollToBottom}`)) {
+      return;
+    }
+    const rect = element.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+      return;
+    }
+    // The prompt input box expands upward past the dock top while the
+    // user drafts a long prompt. That transient overhang must not grow
+    // the timeline's reserved bottom space: reserving for it re-pins the
+    // scroll position and visibly pushes the message stream up. Only the
+    // input area's own box contributes to the floating controls' offset;
+    // clipped editor descendants can have layout positions above that box
+    // and would otherwise create an oversized gap.
+    if (element.closest(`.${styles.composerInputShell}`)) {
+      if (element.matches(".agent-gui-node__composer-prompt-input-area")) {
+        floatingVisualTop = Math.min(floatingVisualTop, rect.top);
+      }
+      return;
+    }
+    // Composer disclosure panels (e.g. Tutti mode plan review) are
+    // absolutely-positioned overlays that expand upward from their banner.
+    // They must not inflate the timeline's bottom safe-area — doing so
+    // would push the conversation stream up — but they do affect where
+    // floating controls (scroll-to-bottom) should anchor.
+    if (element.closest(`.${styles.composerDisclosurePanel}`)) {
+      floatingVisualTop = Math.min(floatingVisualTop, rect.top);
+      return;
+    }
+    floatingVisualTop = Math.min(floatingVisualTop, rect.top);
+    timelineVisualTop = Math.min(timelineVisualTop, rect.top);
+  });
+  return {
+    timelineOverflowHeight: Math.max(
+      0,
+      Math.ceil(bottomDockRect.top - timelineVisualTop)
+    ),
+    floatingOverflowHeight: Math.max(
+      0,
+      Math.ceil(bottomDockRect.top - floatingVisualTop)
+    )
+  };
+}
+
+function writeBottomDockSafeArea(
+  timeline: HTMLDivElement,
+  safeArea: Pick<
+    BottomDockSafeArea,
+    "bottomDock" | "floatingOverflowHeight" | "timelineOverflowHeight"
+  >
+): void {
+  timeline.style.setProperty(
+    "--agent-gui-bottom-dock-safe-area",
+    `${safeArea.timelineOverflowHeight}px`
+  );
+  safeArea.bottomDock.style.setProperty(
+    "--agent-gui-bottom-dock-floating-safe-area",
+    `${safeArea.floatingOverflowHeight}px`
+  );
 }
 
 export function useAgentGUIDetailScroll(input: Input) {
@@ -82,6 +158,7 @@ export function useAgentGUIDetailScroll(input: Input) {
   const pointerScrollConversationRef = useRef<string | null>(null);
   const userScrollAwayIntentConversationRef = useRef<string | null>(null);
   const lastShowTimelineSkeletonRef = useRef(showTimelineSkeleton);
+  const bottomDockSafeAreaRef = useRef<BottomDockSafeArea | null>(null);
   useLayoutEffect(() => {
     const timelineSkeletonChanged =
       lastShowTimelineSkeletonRef.current !== showTimelineSkeleton;
@@ -102,6 +179,10 @@ export function useAgentGUIDetailScroll(input: Input) {
       setIsTimelineScrolledToBottom(true);
       return;
     }
+    if (activeConversationId !== viewModel.rail.activeConversationId) {
+      bottomLockOwnerRef.current = null;
+      return;
+    }
 
     const anchor = timelineScrollAnchorRef.current;
     const prependAnchor = pendingPrependScrollAnchorRef.current;
@@ -111,6 +192,22 @@ export function useAgentGUIDetailScroll(input: Input) {
       !anchor || anchor.conversationId !== activeConversationId;
     const shouldRestorePrependAnchor =
       prependAnchor?.conversationId === activeConversationId;
+    if (
+      !conversationChanged &&
+      bottomLockOwnerRef.current === null &&
+      anchor.scrollHeight - anchor.scrollTop - anchor.clientHeight <=
+        AGENT_GUI_STICK_TO_BOTTOM_THRESHOLD_PX
+    ) {
+      bottomLockOwnerRef.current = activeConversationId;
+    }
+    if (conversationChanged && showTimelineSkeleton) {
+      bottomLockOwnerRef.current = activeConversationId;
+      pointerScrollConversationRef.current = null;
+      userScrollAwayIntentConversationRef.current = null;
+      setIsTimelineScrolledToTop(true);
+      setIsTimelineScrolledToBottom(true);
+      return;
+    }
     if (
       !conversationChanged &&
       !shouldScrollSubmittedPromptToBottom &&
@@ -159,6 +256,7 @@ export function useAgentGUIDetailScroll(input: Input) {
       const distanceFromBottom =
         anchor.scrollHeight - anchor.scrollTop - anchor.clientHeight;
       if (distanceFromBottom <= AGENT_GUI_STICK_TO_BOTTOM_THRESHOLD_PX) {
+        bottomLockOwnerRef.current = activeConversationId;
         setTimelineScrollTopInstantly(timeline, maxScrollTop);
         nextScrollTop = maxScrollTop;
       } else {
@@ -183,93 +281,54 @@ export function useAgentGUIDetailScroll(input: Input) {
     conversation,
     showTimelineSkeleton,
     timelineConversationId,
+    viewModel.rail.activeConversationId,
     viewModel.detail.isLoadingOlderMessages
   ]);
 
+  const hasTimelineConversation = timelineConversationId !== null;
   useLayoutEffect(() => {
     const timeline = timelineRef.current;
     const bottomDock = bottomDockRef.current;
-    const activeConversationId = timelineConversationId;
-    if (!timeline || !bottomDock || !activeConversationId) {
+    if (!hasTimelineConversation || !timeline || !bottomDock) {
       return;
     }
 
     let animationFrameId: number | null = null;
-
-    const syncBottomDockSafeArea = (): void => {
-      const bottomDockRect = bottomDock.getBoundingClientRect();
-      let timelineVisualTop = bottomDockRect.top;
-      let floatingVisualTop = bottomDockRect.top;
-      bottomDock.querySelectorAll("*").forEach((element) => {
-        if (element.closest(`.${styles.bottomDockScrollToBottom}`)) {
-          return;
-        }
-        const rect = element.getBoundingClientRect();
-        if (rect.width <= 0 || rect.height <= 0) {
-          return;
-        }
-        // The prompt input box expands upward past the dock top while the
-        // user drafts a long prompt. That transient overhang must not grow
-        // the timeline's reserved bottom space: reserving for it re-pins the
-        // scroll position and visibly pushes the message stream up. Only the
-        // input area's own box contributes to the floating controls' offset;
-        // clipped editor descendants can have layout positions above that box
-        // and would otherwise create an oversized gap.
-        if (element.closest(`.${styles.composerInputShell}`)) {
-          if (element.matches(".agent-gui-node__composer-prompt-input-area")) {
-            floatingVisualTop = Math.min(floatingVisualTop, rect.top);
-          }
-          return;
-        }
-        // Composer disclosure panels (e.g. Tutti mode plan review) are
-        // absolutely-positioned overlays that expand upward from their banner.
-        // They must not inflate the timeline's bottom safe-area — doing so
-        // would push the conversation stream up — but they do affect where
-        // floating controls (scroll-to-bottom) should anchor.
-        if (element.closest(`.${styles.composerDisclosurePanel}`)) {
-          floatingVisualTop = Math.min(floatingVisualTop, rect.top);
-          return;
-        }
-        floatingVisualTop = Math.min(floatingVisualTop, rect.top);
-        timelineVisualTop = Math.min(timelineVisualTop, rect.top);
-      });
-      const timelineOverflowHeight = Math.max(
-        0,
-        Math.ceil(bottomDockRect.top - timelineVisualTop)
-      );
-      const floatingOverflowHeight = Math.max(
-        0,
-        Math.ceil(bottomDockRect.top - floatingVisualTop)
-      );
-      timeline.style.setProperty(
-        "--agent-gui-bottom-dock-safe-area",
-        `${timelineOverflowHeight}px`
-      );
-      bottomDock.style.setProperty(
-        "--agent-gui-bottom-dock-floating-safe-area",
-        `${floatingOverflowHeight}px`
-      );
+    const resolveBottomLockConversation = (): string | null => {
+      const activeConversationId = bottomLockOwnerRef.current;
+      if (!activeConversationId) {
+        return null;
+      }
+      const anchor = timelineScrollAnchorRef.current;
+      if (!anchor || anchor.conversationId !== activeConversationId) {
+        return null;
+      }
+      return activeConversationId;
     };
 
-    const syncBottomDockSpace = (): void => {
-      syncBottomDockSafeArea();
-
-      if (activeConversationId !== viewModel.rail.activeConversationId) {
-        return;
-      }
-
-      const anchor = timelineScrollAnchorRef.current;
-      const bottomLocked = bottomLockOwnerRef.current === activeConversationId;
-      if (!anchor || anchor.conversationId !== activeConversationId) {
-        return;
-      }
-
-      const distanceFromBottom =
-        anchor.scrollHeight - anchor.scrollTop - anchor.clientHeight;
+    const syncBottomDockSafeArea = (forceMeasurement: boolean): void => {
+      const cachedSafeArea = bottomDockSafeAreaRef.current;
       if (
-        !bottomLocked &&
-        distanceFromBottom > AGENT_GUI_STICK_TO_BOTTOM_THRESHOLD_PX
+        !forceMeasurement &&
+        cachedSafeArea?.bottomDock === bottomDock &&
+        cachedSafeArea.revision === bottomDockStoreRevision
       ) {
+        writeBottomDockSafeArea(timeline, cachedSafeArea);
+        return;
+      }
+      const measuredSafeArea = readBottomDockSafeArea(bottomDock);
+      const nextSafeArea: BottomDockSafeArea = {
+        bottomDock,
+        revision: bottomDockStoreRevision,
+        ...measuredSafeArea
+      };
+      bottomDockSafeAreaRef.current = nextSafeArea;
+      writeBottomDockSafeArea(timeline, nextSafeArea);
+    };
+
+    const syncConversationBottomLock = (): void => {
+      const scheduledConversationId = resolveBottomLockConversation();
+      if (!scheduledConversationId) {
         return;
       }
 
@@ -278,22 +337,9 @@ export function useAgentGUIDetailScroll(input: Input) {
       }
       animationFrameId = window.requestAnimationFrame(() => {
         animationFrameId = null;
-        const latestAnchor = timelineScrollAnchorRef.current;
         if (
-          !latestAnchor ||
-          latestAnchor.conversationId !== activeConversationId
-        ) {
-          return;
-        }
-        const latestDistanceFromBottom =
-          latestAnchor.scrollHeight -
-          latestAnchor.scrollTop -
-          latestAnchor.clientHeight;
-        const latestBottomLocked =
-          bottomLockOwnerRef.current === activeConversationId;
-        if (
-          !latestBottomLocked &&
-          latestDistanceFromBottom > AGENT_GUI_STICK_TO_BOTTOM_THRESHOLD_PX
+          resolveBottomLockConversation() !== scheduledConversationId ||
+          timelineRef.current !== timeline
         ) {
           return;
         }
@@ -301,7 +347,7 @@ export function useAgentGUIDetailScroll(input: Input) {
         const maxScrollTop = geometry.maxScrollTop;
         timeline.scrollTop = maxScrollTop;
         timelineScrollAnchorRef.current = {
-          conversationId: activeConversationId,
+          conversationId: scheduledConversationId,
           scrollHeight: geometry.scrollHeight,
           scrollTop: maxScrollTop,
           clientHeight: geometry.clientHeight
@@ -313,7 +359,8 @@ export function useAgentGUIDetailScroll(input: Input) {
       });
     };
 
-    syncBottomDockSpace();
+    syncBottomDockSafeArea(false);
+    syncConversationBottomLock();
     if (typeof ResizeObserver === "undefined") {
       return () => {
         timeline.style.removeProperty("--agent-gui-bottom-dock-safe-area");
@@ -326,7 +373,10 @@ export function useAgentGUIDetailScroll(input: Input) {
       };
     }
 
-    const observer = new ResizeObserver(syncBottomDockSpace);
+    const observer = new ResizeObserver(() => {
+      syncBottomDockSafeArea(true);
+      syncConversationBottomLock();
+    });
     observer.observe(bottomDock);
     const promptInputArea = bottomDock.querySelector(
       ".agent-gui-node__composer-prompt-input-area"
@@ -344,11 +394,7 @@ export function useAgentGUIDetailScroll(input: Input) {
       }
       observer.disconnect();
     };
-  }, [
-    bottomDockStoreRevision,
-    timelineConversationId,
-    viewModel.rail.activeConversationId
-  ]);
+  }, [bottomDockStoreRevision, hasTimelineConversation]);
 
   useEffect(() => {
     const timeline = timelineRef.current;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.ts
@@ -79,6 +79,7 @@ export function useAgentGUIDetailScroll(input: Input) {
   const [isTimelineScrolledToBottom, setIsTimelineScrolledToBottom] =
     useState(true);
   const bottomLockOwnerRef = useRef<string | null>(null);
+  const pointerScrollConversationRef = useRef<string | null>(null);
   const userScrollAwayIntentConversationRef = useRef<string | null>(null);
   const lastShowTimelineSkeletonRef = useRef(showTimelineSkeleton);
   useLayoutEffect(() => {
@@ -94,6 +95,7 @@ export function useAgentGUIDetailScroll(input: Input) {
       timelineScrollAnchorRef.current = null;
       bottomLockOwnerRef.current = null;
       pendingPrependScrollAnchorRef.current = null;
+      pointerScrollConversationRef.current = null;
       submittedPromptScrollConversationRef.current = null;
       userScrollAwayIntentConversationRef.current = null;
       setIsTimelineScrolledToTop(true);
@@ -122,6 +124,7 @@ export function useAgentGUIDetailScroll(input: Input) {
     let nextScrollTop: number;
     if (conversationChanged || shouldScrollSubmittedPromptToBottom) {
       bottomLockOwnerRef.current = activeConversationId;
+      pointerScrollConversationRef.current = null;
       userScrollAwayIntentConversationRef.current = null;
     }
     const shouldKeepBottomLocked =
@@ -357,12 +360,17 @@ export function useAgentGUIDetailScroll(input: Input) {
 
     const loadOlderMessagesNearTop = (
       scrollTop: number,
-      scrollHeight: number
+      scrollHeight: number,
+      clientHeight: number
     ): void => {
+      const bottomLocked = bottomLockOwnerRef.current === activeConversationId;
+      const needsMoreContentToFillViewport = scrollHeight <= clientHeight;
       if (
         activeConversationId === viewModel.rail.activeConversationId &&
         viewModel.detail.hasOlderMessages &&
         !viewModel.detail.isLoadingOlderMessages &&
+        !showTimelineSkeleton &&
+        (!bottomLocked || needsMoreContentToFillViewport) &&
         scrollTop <= AGENT_GUI_TOP_HISTORY_PREFETCH_THRESHOLD_PX
       ) {
         pendingPrependScrollAnchorRef.current = {
@@ -382,13 +390,28 @@ export function useAgentGUIDetailScroll(input: Input) {
       ) {
         return;
       }
-      const scrollTop = timeline.scrollTop;
-      const inferredUserScrollAway = scrollTop < previousAnchor.scrollTop - 1;
+      let scrollTop = timeline.scrollTop;
+      const pointerDrivenScrollAway =
+        pointerScrollConversationRef.current === activeConversationId &&
+        scrollTop < previousAnchor.scrollTop - 1;
       const explicitUserScrollAway =
         userScrollAwayIntentConversationRef.current === activeConversationId;
-      if (explicitUserScrollAway || inferredUserScrollAway) {
+      if (explicitUserScrollAway || pointerDrivenScrollAway) {
         bottomLockOwnerRef.current = null;
         userScrollAwayIntentConversationRef.current = null;
+      }
+      const bottomLocked = bottomLockOwnerRef.current === activeConversationId;
+      const anchoredMaxScrollTop = Math.max(
+        0,
+        previousAnchor.scrollHeight - previousAnchor.clientHeight
+      );
+      if (
+        bottomLocked &&
+        anchoredMaxScrollTop - scrollTop >
+          AGENT_GUI_STICK_TO_BOTTOM_THRESHOLD_PX
+      ) {
+        setTimelineScrollTopInstantly(timeline, anchoredMaxScrollTop);
+        scrollTop = anchoredMaxScrollTop;
       }
       timelineScrollAnchorRef.current = {
         conversationId: activeConversationId,
@@ -408,7 +431,11 @@ export function useAgentGUIDetailScroll(input: Input) {
         scrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
       );
       setIsTimelineScrolledToBottom(effectiveAtBottom);
-      loadOlderMessagesNearTop(scrollTop, previousAnchor.scrollHeight);
+      loadOlderMessagesNearTop(
+        scrollTop,
+        previousAnchor.scrollHeight,
+        previousAnchor.clientHeight
+      );
     };
 
     const syncObservedTimelineGeometry = (): void => {
@@ -456,17 +483,42 @@ export function useAgentGUIDetailScroll(input: Input) {
         userScrollAwayIntentConversationRef.current = activeConversationId;
       }
     };
+    const captureSemanticScrollAwayIntent = (event: MouseEvent): void => {
+      if (
+        event.target instanceof Element &&
+        event.target.closest("[data-agent-transcript-scroll-away-intent]")
+      ) {
+        userScrollAwayIntentConversationRef.current = activeConversationId;
+      }
+    };
+    const capturePointerIntent = (): void => {
+      pointerScrollConversationRef.current = activeConversationId;
+    };
+    const clearPointerIntent = (): void => {
+      if (pointerScrollConversationRef.current === activeConversationId) {
+        pointerScrollConversationRef.current = null;
+      }
+    };
 
     const initialAnchor = timelineScrollAnchorRef.current;
     if (initialAnchor?.conversationId === activeConversationId) {
       loadOlderMessagesNearTop(
         initialAnchor.scrollTop,
-        initialAnchor.scrollHeight
+        initialAnchor.scrollHeight,
+        initialAnchor.clientHeight
       );
     }
     timeline.addEventListener("scroll", captureScrollAnchor, { passive: true });
     timeline.addEventListener("wheel", captureWheelIntent, { passive: true });
     timeline.addEventListener("keydown", captureKeyboardIntent);
+    timeline.addEventListener("click", captureSemanticScrollAwayIntent);
+    timeline.addEventListener("pointerdown", capturePointerIntent, {
+      passive: true
+    });
+    window.addEventListener("pointerup", clearPointerIntent, { passive: true });
+    window.addEventListener("pointercancel", clearPointerIntent, {
+      passive: true
+    });
     const geometryObserver =
       timelineContent && typeof ResizeObserver !== "undefined"
         ? new ResizeObserver(syncObservedTimelineGeometry)
@@ -480,10 +532,15 @@ export function useAgentGUIDetailScroll(input: Input) {
       timeline.removeEventListener("scroll", captureScrollAnchor);
       timeline.removeEventListener("wheel", captureWheelIntent);
       timeline.removeEventListener("keydown", captureKeyboardIntent);
+      timeline.removeEventListener("click", captureSemanticScrollAwayIntent);
+      timeline.removeEventListener("pointerdown", capturePointerIntent);
+      window.removeEventListener("pointerup", clearPointerIntent);
+      window.removeEventListener("pointercancel", clearPointerIntent);
     };
   }, [
     actions,
     timelineConversationId,
+    showTimelineSkeleton,
     viewModel.rail.activeConversationId,
     viewModel.detail.hasOlderMessages,
     viewModel.detail.isLoadingOlderMessages

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageLocatorRail.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageLocatorRail.tsx
@@ -363,6 +363,7 @@ export function AgentMessageLocatorRail({
       ref={locatorRef}
       className="agent-gui-message-locator"
       aria-label={label ?? items[0]?.summary}
+      data-agent-transcript-scroll-away-intent
       data-testid="agent-message-locator"
       onBlurCapture={handleBlurCapture}
       onFocusCapture={openPanel}


### PR DESCRIPTION
## Summary

- preserve virtualized timeline scroll intent and fence stale bottom-lock frames across conversation switches
- defer timeline geometry reads while the replacement conversation is still showing its skeleton
- cache bottom-dock safe-area measurements across conversation switches while preserving ResizeObserver and store-revision invalidation

## Tests

- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx`
- `pnpm check:changed -- --push-ready`

## Notes

- a follow-up development trace confirmed that per-switch dock synchronization was removed and typical switch-window layout work decreased; the captures were observational rather than a controlled benchmark
- the existing message-history PR remains unchanged because current `main` already contains the newer authoritative message-window implementation

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->