### PR TITLE
ci(mobile): add manual Android internal build

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,110 @@
+name: Android Internal Build
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: android-internal-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build internal Android APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.5"
+          cache-dependency-path: |
+            go.work
+            go.work.sum
+            packages/device-link/go.mod
+            packages/device-link/go.sum
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android build dependencies
+        shell: bash
+        run: |
+          sdkmanager --install \
+            "platform-tools" \
+            "platforms;android-36" \
+            "build-tools;36.0.0" \
+            "ndk;27.3.13750724"
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Android release APK
+        run: |
+          pnpm --filter @tutti-os/mobile android:aar
+          cd apps/mobile/android
+          ./gradlew app:assembleRelease
+
+      - name: Sign internal APK
+        shell: bash
+        run: |
+          signing_dir="${RUNNER_TEMP}/tutti-android-signing"
+          unsigned_apk="apps/mobile/android/app/build/outputs/apk/release/app-release-unsigned.apk"
+          aligned_apk="${signing_dir}/app-release-aligned.apk"
+          signed_apk="apps/mobile/android/app/build/outputs/apk/release/tutti-mobile-internal.apk"
+          build_tools="${ANDROID_HOME}/build-tools/36.0.0"
+
+          test -f "${unsigned_apk}"
+          mkdir -p "${signing_dir}"
+          keytool -genkeypair \
+            -keystore "${signing_dir}/internal.keystore" \
+            -storepass android \
+            -keypass android \
+            -alias tutti-internal \
+            -dname "CN=Tutti Internal,O=Tutti,C=US" \
+            -keyalg RSA \
+            -validity 7300 \
+            >/dev/null 2>&1
+          "${build_tools}/zipalign" -p -f 4 "${unsigned_apk}" "${aligned_apk}"
+          "${build_tools}/apksigner" sign \
+            --ks "${signing_dir}/internal.keystore" \
+            --ks-pass pass:android \
+            --key-pass pass:android \
+            --out "${signed_apk}" \
+            "${aligned_apk}"
+          "${build_tools}/apksigner" verify --verbose "${signed_apk}"
+
+      - name: Generate APK checksum
+        working-directory: apps/mobile/android/app/build/outputs/apk/release
+        run: sha256sum tutti-mobile-internal.apk > SHA256SUMS
+
+      - name: Upload internal Android artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tutti-mobile-internal-${{ github.sha }}
+          path: |
+            apps/mobile/android/app/build/outputs/apk/release/tutti-mobile-internal.apk
+            apps/mobile/android/app/build/outputs/apk/release/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -423,8 +423,10 @@ Every change under `packages/device-link/**`, including Makefiles, Java probe
 sources, and Android manifests, also selects
 `pnpm check:device-link-android`. That contract runs the Go suite, Android
 arm64 cross-compile, and Java gomobile binding generation. AAR assembly remains
-an explicit Android-SDK validation until the release workflow publishes this
-currently provisional module.
+an explicit Android-SDK validation locally. The manually dispatched Android
+Internal Build workflow installs the pinned SDK/NDK versions, assembles the AAR
+and the internal mobile APK, and uploads a private validation artifact; it does
+not publish this currently provisional module.
 
 Local runs resolve `golangci-lint` from `$(go env GOPATH)/bin` first and fall
 back to `PATH`. This matches the repository install command without requiring a

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -168,6 +168,12 @@ pnpm mobile:test
 `pnpm mobile:start` 启动 Metro，`pnpm mobile:check` 运行移动端 TypeScript 和
 Jest 检查。
 
+需要在没有本机开发环境的真机上测试时，可从 GitHub Actions 手动运行
+`Android Internal Build`。它只上传保留 14 天的内部 artifact
+`tutti-mobile-internal-<commit>`，其中的 `tutti-mobile-internal.apk` 已嵌入
+JavaScript bundle，可直接侧载；不会创建 GitHub Release 或公开下载链接。每次
+运行使用新的临时签名 key，安装新构建前可能需要先卸载手机上的旧内部构建。
+
 ## 6. 调试时先判断问题属于哪一层
 
 | 现象                           | 首先检查                                                   |


### PR DESCRIPTION
## Summary

- add a manual-only Android workflow that builds the full React Native mobile release APK
- sign the internal artifact with an ephemeral CI keystore and upload it with a SHA-256 checksum for 14 days
- document internal sideloading and the validation-artifact boundary

## Validation

- `pnpm --filter @tutti-os/mobile typecheck`
- Prettier check, YAML parse, and manual-trigger assertion
- staged repository hooks

The workflow does not publish a GitHub Release or expose a public download link.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->