### PR TITLE
revert(agent): restore provider model catalogs

### DIFF
--- a/packages/agent/daemon/runtime/acp_scripted_transport_test.go
+++ b/packages/agent/daemon/runtime/acp_scripted_transport_test.go
@@ -403,9 +403,6 @@ func (c *scriptedACPConnection) handleAppServerMessage(line string, id json.RawM
 	case appServerMethodModelList:
 		c.sendJSON(map[string]any{"id": id, "result": map[string]any{"data": []any{}}})
 		return true
-	case appServerMethodConfigRead:
-		c.sendJSON(map[string]any{"id": id, "result": map[string]any{"config": map[string]any{}}})
-		return true
 	case appServerMethodCollaborationModeList:
 		c.sendJSON(map[string]any{"id": id, "result": map[string]any{"data": []any{}}})
 		return true

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -22,7 +22,6 @@ const (
 	appServerMethodAccountRead    = "account/read"
 	appServerMethodRateLimitsRead = "account/rateLimits/read"
 	appServerMethodModelList      = "model/list"
-	appServerMethodConfigRead     = "config/read"
 	// Experimental: collaboration mode presets (plan/pair/execute). Absence of
 	// the method on older binaries downgrades planMode capability gracefully.
 	appServerMethodCollaborationModeList = "collaborationMode/list"
@@ -234,7 +233,6 @@ type codexAppServerSession struct {
 	// direct control, reconcile and delayed continuation nudges for this thread.
 	goalMutationMu         sync.Mutex
 	models                 []map[string]any
-	modelProvider          string
 	startupModelsReady     bool
 	startupRateLimitsReady bool
 	// lifecycleSeq numbers the adapter's TurnLifecycle snapshots (ADR 0008):

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -75,7 +75,6 @@ type scriptedAppServerConnection struct {
 	closed chan struct{}
 
 	modelList                       []any
-	config                          map[string]any
 	requiresAuth                    bool
 	collaborationModeUnsupported    bool
 	emitPlanItem                    bool
@@ -394,16 +393,6 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 					"data": models,
 				},
 			})
-		case appServerMethodConfigRead:
-			c.mu.Lock()
-			config := clonePayloadDeep(c.config)
-			c.mu.Unlock()
-			c.sendJSON(map[string]any{
-				"id": message.ID,
-				"result": map[string]any{
-					"config": config,
-				},
-			})
 		case appServerMethodRateLimitsRead:
 			c.sendJSON(map[string]any{
 				"id": message.ID,
@@ -441,12 +430,11 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 					},
 				})
 			}
-			responseModel := firstNonEmpty(asString(message.Params["model"]), "gpt-5.1-codex")
 			c.sendJSON(map[string]any{
 				"id": message.ID,
 				"result": map[string]any{
 					"thread":          map[string]any{"id": "codex-thread-1"},
-					"model":           responseModel,
+					"model":           "gpt-5.1-codex",
 					"reasoningEffort": "medium",
 					"cwd":             "/workspace",
 					"approvalPolicy":  "on-request",
@@ -1088,92 +1076,6 @@ func TestCodexAppServerAdapterStartClampsProviderDefaultReasoning(t *testing.T) 
 	}
 }
 
-func TestCodexAppServerAdapterStartUsesEffectiveConfigModelOverStaleCatalogDefault(t *testing.T) {
-	t.Parallel()
-
-	transport := newScriptedAppServerTransport()
-	transport.conn.config = map[string]any{
-		"model":                  "glm-5",
-		"model_provider":         "custom",
-		"model_reasoning_effort": "high",
-	}
-	adapter := NewCodexAppServerAdapter(transport)
-	session := testAppServerSession()
-	if _, err := adapter.Start(context.Background(), session); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-
-	configRead := appServerRequestParams(t, transport.conn, appServerMethodConfigRead)
-	if got := asString(configRead["cwd"]); got != "/workspace" {
-		t.Fatalf("config/read cwd = %q, want /workspace", got)
-	}
-	threadStart := appServerRequestParams(t, transport.conn, appServerMethodThreadStart)
-	if got := asString(threadStart["model"]); got != "glm-5" {
-		t.Fatalf("thread/start model = %q, want effective config model glm-5", got)
-	}
-	threadConfig, _ := threadStart["config"].(map[string]any)
-	if got := asString(threadConfig["model_reasoning_effort"]); got != "high" {
-		t.Fatalf("thread/start reasoning effort = %q, want effective config effort high", got)
-	}
-
-	state := adapter.SessionState(session)
-	if state.Settings == nil || state.Settings.Model != "glm-5" {
-		t.Fatalf("session settings = %#v, want effective config model glm-5", state.Settings)
-	}
-	options, _ := state.RuntimeContext["configOptions"].([]map[string]any)
-	modelOption := configOptionByID(options, "model")
-	if got := asString(modelOption["currentValue"]); got != "glm-5" {
-		t.Fatalf("model option = %#v, want effective config model glm-5", modelOption)
-	}
-	modelOptions, _ := modelOption["options"].([]any)
-	if len(modelOptions) != 1 || asString(modelOptions[0].(map[string]any)["value"]) != "glm-5" {
-		t.Fatalf("model options = %#v, want only effective custom-provider model glm-5", modelOptions)
-	}
-
-	if !adapter.applyStartupModels(
-		session.AgentSessionID,
-		session,
-		nil,
-		[]map[string]any{{
-			"id":        "gpt-5.6-sol",
-			"model":     "gpt-5.6-sol",
-			"isDefault": true,
-		}},
-	) {
-		t.Fatal("applyStartupModels = false, want stale catalog refresh applied")
-	}
-	refreshed := adapter.SessionState(session)
-	if refreshed.Settings == nil || refreshed.Settings.Model != "glm-5" {
-		t.Fatalf("settings after catalog refresh = %#v, want config model glm-5", refreshed.Settings)
-	}
-	refreshedOptions, _ := refreshed.RuntimeContext["configOptions"].([]map[string]any)
-	refreshedModelOption := configOptionByID(refreshedOptions, "model")
-	refreshedModelOptions, _ := refreshedModelOption["options"].([]any)
-	if len(refreshedModelOptions) != 1 || asString(refreshedModelOptions[0].(map[string]any)["value"]) != "glm-5" {
-		t.Fatalf("model options after catalog refresh = %#v, want only glm-5", refreshedModelOptions)
-	}
-}
-
-func TestCodexAppServerAdapterStartExplicitModelOverridesEffectiveConfig(t *testing.T) {
-	t.Parallel()
-
-	transport := newScriptedAppServerTransport()
-	transport.conn.config = map[string]any{
-		"model":          "glm-5",
-		"model_provider": "custom",
-	}
-	adapter := NewCodexAppServerAdapter(transport)
-	session := testAppServerSession()
-	session.Settings = &SessionSettings{Model: "requested-model"}
-	if _, err := adapter.Start(context.Background(), session); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	threadStart := appServerRequestParams(t, transport.conn, appServerMethodThreadStart)
-	if got := asString(threadStart["model"]); got != "requested-model" {
-		t.Fatalf("thread/start model = %q, want explicit requested-model", got)
-	}
-}
-
 func TestCodexAppServerAdapterStartClampsPersistedReasoningForExplicitModel(t *testing.T) {
 	t.Parallel()
 
@@ -1755,37 +1657,6 @@ func TestCodexAppServerAdapterResume(t *testing.T) {
 	}
 	if !adapter.CanResume(session) {
 		t.Fatalf("CanResume = false, want true")
-	}
-}
-
-func TestCodexAppServerAdapterResumeUsesEffectiveCustomProviderConfig(t *testing.T) {
-	t.Parallel()
-
-	transport := newScriptedAppServerTransport()
-	transport.conn.config = map[string]any{
-		"model":          "glm-5",
-		"model_provider": "custom",
-	}
-	adapter := NewCodexAppServerAdapter(transport)
-	session := testAppServerSession()
-	session.ProviderSessionID = "codex-thread-1"
-
-	if err := adapter.Resume(context.Background(), session); err != nil {
-		t.Fatalf("Resume: %v", err)
-	}
-	resume := appServerRequestParams(t, transport.conn, appServerMethodThreadResume)
-	if got := asString(resume["model"]); got != "glm-5" {
-		t.Fatalf("thread/resume model = %q, want effective config model glm-5", got)
-	}
-	state := adapter.SessionState(session)
-	if state.Settings == nil || state.Settings.Model != "glm-5" {
-		t.Fatalf("resumed settings = %#v, want effective config model glm-5", state.Settings)
-	}
-	options, _ := state.RuntimeContext["configOptions"].([]map[string]any)
-	modelOption := configOptionByID(options, "model")
-	modelOptions, _ := modelOption["options"].([]any)
-	if len(modelOptions) != 1 || asString(modelOptions[0].(map[string]any)["value"]) != "glm-5" {
-		t.Fatalf("resumed model options = %#v, want only glm-5", modelOptions)
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_client.go
+++ b/packages/agent/daemon/runtime/codex_appserver_client.go
@@ -284,24 +284,6 @@ func (c *codexAppServerClient) ModelListNoHandler(
 	return caller.rawResult, nil
 }
 
-func (c *codexAppServerClient) ConfigRead(
-	ctx context.Context,
-	timeout time.Duration,
-	params map[string]any,
-	handler acpMessageHandler,
-) (json.RawMessage, error) {
-	typedParams, err := codexProtoParams[codexproto.ConfigReadParams](params)
-	if err != nil {
-		return nil, err
-	}
-	client, caller := c.typed(timeout, handler, false)
-	_, err = client.ConfigRead(ctx, typedParams)
-	if err != nil {
-		return nil, err
-	}
-	return caller.rawResult, nil
-}
-
 func (c *codexAppServerClient) AccountRateLimitsRead(
 	ctx context.Context,
 	timeout time.Duration,

--- a/packages/agent/daemon/runtime/codex_appserver_metadata.go
+++ b/packages/agent/daemon/runtime/codex_appserver_metadata.go
@@ -97,57 +97,6 @@ func (*CodexAppServerAdapter) fetchModelsNoHandler(
 	return payload.Data
 }
 
-type codexAppServerEffectiveConfig struct {
-	settings      map[string]any
-	modelProvider string
-}
-
-func (a *CodexAppServerAdapter) fetchEffectiveConfig(
-	ctx context.Context,
-	client *codexAppServerClient,
-	session Session,
-	trace *codexAppServerStartupTrace,
-) codexAppServerEffectiveConfig {
-	cwd := a.sessionCWD(session)
-	includeLayers := false
-	result, err := trace.TypedCall(acpStartCallTimeout, appServerMethodConfigRead, func() (json.RawMessage, error) {
-		return client.ConfigRead(ctx, acpStartCallTimeout, map[string]any{
-			"cwd":           cwd,
-			"includeLayers": includeLayers,
-		}, func(ctx context.Context, message acpMessage) error {
-			trace.LogMessage(message.Method, len(message.ID) > 0, len(message.Params))
-			_, err := a.handleAppServerMessage(ctx, client, session, "", message, nil, nil, nil)
-			return err
-		})
-	})
-	if err != nil {
-		return codexAppServerEffectiveConfig{}
-	}
-	var payload struct {
-		Config map[string]any `json:"config"`
-	}
-	if err := json.Unmarshal(result, &payload); err != nil {
-		return codexAppServerEffectiveConfig{}
-	}
-	config := make(map[string]any, 3)
-	copyConfigValue := func(targetKey, sourceKey string) {
-		if value, exists := payload.Config[sourceKey]; exists {
-			config[targetKey] = strings.TrimSpace(asString(value))
-		}
-	}
-	copyConfigValue("model", "model")
-	copyConfigValue("reasoning_effort", "model_reasoning_effort")
-	copyConfigValue("service_tier", "service_tier")
-	trace.Log("config.parsed", map[string]any{
-		"model":          asString(config["model"]),
-		"model_provider": asString(payload.Config["model_provider"]),
-	})
-	return codexAppServerEffectiveConfig{
-		settings:      config,
-		modelProvider: strings.TrimSpace(asString(payload.Config["model_provider"])),
-	}
-}
-
 func (*CodexAppServerAdapter) fetchRateLimitsNoHandler(
 	ctx context.Context,
 	client *codexAppServerClient,

--- a/packages/agent/daemon/runtime/codex_appserver_model_settings.go
+++ b/packages/agent/daemon/runtime/codex_appserver_model_settings.go
@@ -73,42 +73,6 @@ func cloneCodexAppServerModels(models []map[string]any) []map[string]any {
 	return cloned
 }
 
-func codexAppServerModelsForEffectiveConfig(
-	models []map[string]any,
-	config codexAppServerEffectiveConfig,
-) []map[string]any {
-	effectiveModel := strings.TrimSpace(asString(config.settings["model"]))
-	if effectiveModel == "" {
-		return models
-	}
-	if provider := strings.ToLower(strings.TrimSpace(config.modelProvider)); provider != "" && provider != "openai" {
-		return []map[string]any{{
-			"id":          effectiveModel,
-			"model":       effectiveModel,
-			"displayName": effectiveModel,
-			"isDefault":   true,
-			"hidden":      false,
-		}}
-	}
-	reconciled := cloneCodexAppServerModels(models)
-	found := false
-	for _, model := range reconciled {
-		isEffective := codexAppServerModelValue(model) == effectiveModel
-		model["isDefault"] = isEffective
-		found = found || isEffective
-	}
-	if found {
-		return reconciled
-	}
-	return append([]map[string]any{{
-		"id":          effectiveModel,
-		"model":       effectiveModel,
-		"displayName": effectiveModel,
-		"isDefault":   true,
-		"hidden":      false,
-	}}, reconciled...)
-}
-
 // codexAppServerSessionWithConfig applies every present live config key,
 // including empty-string tombstones. Presence matters while model/list is
 // loading: an explicit clear must override the stale startup session value.
@@ -149,43 +113,19 @@ func codexAppServerExecSessionWithConfig(session Session, config map[string]any)
 	return session
 }
 
-func codexAppServerConfigWithEffectiveSettings(
-	config map[string]any,
-	settings SessionSettings,
-) map[string]any {
-	effective := clonePayloadDeep(config)
-	if effective == nil {
-		effective = map[string]any{}
-	}
-	if model := strings.TrimSpace(settings.Model); model != "" {
-		effective["model"] = model
-	}
-	if reasoning := strings.TrimSpace(settings.ReasoningEffort); reasoning != "" {
-		effective["reasoning_effort"] = reasoning
-	}
-	if speed := strings.TrimSpace(settings.Speed); speed != "" {
-		effective["service_tier"] = speed
-	}
-	return effective
-}
-
 func (a *CodexAppServerAdapter) applyStartupModels(
 	agentSessionID string,
 	session Session,
 	threadResult json.RawMessage,
 	models []map[string]any,
 ) bool {
+	if len(models) == 0 {
+		return false
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	appSession := a.sessions[strings.TrimSpace(agentSessionID)]
 	if appSession == nil {
-		return false
-	}
-	models = codexAppServerModelsForEffectiveConfig(models, codexAppServerEffectiveConfig{
-		settings:      appSession.configOptions,
-		modelProvider: appSession.modelProvider,
-	})
-	if len(models) == 0 {
 		return false
 	}
 	effectiveSession := codexAppServerSessionWithConfig(session, appSession.configOptions)

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -67,14 +67,9 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 			"authMessage":      a.config.authRequiredMessage,
 		})}, nil
 	}
-	effectiveConfig := a.fetchEffectiveConfig(ctx, client, session, trace)
-	configOptions := effectiveConfig.settings
-	session = codexAppServerExecSessionWithConfig(session, configOptions)
-	effectiveConfig.settings = codexAppServerConfigWithEffectiveSettings(configOptions, session.SettingsValue())
 	models := []map[string]any(nil)
 	if codexAppServerNeedsSynchronousModels(session) {
 		models = a.fetchModels(ctx, client, session, trace)
-		models = codexAppServerModelsForEffectiveConfig(models, effectiveConfig)
 	}
 	if len(models) > 0 {
 		effectiveSettings := codexAppServerEffectiveSettings(models, session, nil)
@@ -135,8 +130,6 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 	liveState.currentMode = codexACPEffectiveModeID(session)
 	liveState.availableCommands = codexAppServerCommands()
 	liveState.commandsKnown = true
-	configOptions = codexAppServerConfigWithEffectiveSettings(effectiveConfig.settings, session.SettingsValue())
-	liveState.configOptions = clonePayloadDeep(configOptions)
 	applyACPConfigOptionDescriptors(&liveState, codexAppServerConfigOptionDescriptors(models, session, threadResult))
 
 	started = true
@@ -147,7 +140,6 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 		serverInfo:             serverInfo,
 		account:                account,
 		models:                 cloneCodexAppServerModels(models),
-		modelProvider:          effectiveConfig.modelProvider,
 		startupModelsReady:     len(models) > 0,
 		startupRateLimitsReady: false,
 		planModeMask:           planModeMask,
@@ -222,14 +214,9 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) (er
 		keepSession = true
 		return nil
 	}
-	effectiveConfig := a.fetchEffectiveConfig(ctx, client, session, trace)
-	configOptions := effectiveConfig.settings
-	session = codexAppServerExecSessionWithConfig(session, configOptions)
-	effectiveConfig.settings = codexAppServerConfigWithEffectiveSettings(configOptions, session.SettingsValue())
 	models := []map[string]any(nil)
 	if codexAppServerNeedsSynchronousModels(session) {
 		models = a.fetchModels(ctx, client, session, trace)
-		models = codexAppServerModelsForEffectiveConfig(models, effectiveConfig)
 	}
 	if len(models) > 0 && strings.TrimSpace(session.SettingsValue().ReasoningEffort) != "" {
 		hasExplicitModel := strings.TrimSpace(session.SettingsValue().Model) != ""
@@ -282,8 +269,6 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) (er
 	liveState.currentMode = codexACPEffectiveModeID(session)
 	liveState.availableCommands = codexAppServerCommands()
 	liveState.commandsKnown = true
-	configOptions = codexAppServerConfigWithEffectiveSettings(effectiveConfig.settings, session.SettingsValue())
-	liveState.configOptions = clonePayloadDeep(configOptions)
 	applyACPConfigOptionDescriptors(&liveState, codexAppServerConfigOptionDescriptors(models, session, threadResult))
 	if replayedUsageKnown {
 		liveState.usage = mergeACPUsageState(liveState.usage, replayedUsage)
@@ -297,7 +282,6 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) (er
 		serverInfo:             serverInfo,
 		account:                account,
 		models:                 cloneCodexAppServerModels(models),
-		modelProvider:          effectiveConfig.modelProvider,
 		startupModelsReady:     len(models) > 0,
 		startupRateLimitsReady: false,
 		planModeMask:           planModeMask,


### PR DESCRIPTION
## Summary

Reverts `cbd406f72 fix(agent): honor effective Codex provider model`.

That change collapsed every non-OpenAI provider catalog to its effective model. Tutti Agent reports `model_provider=tutti-llm` and owns an authoritative `/models` catalog, so the behavior reduced its valid model picker to one model.

## Validation

- `go test ./runtime`
- `go test ./...` in `packages/agent/daemon`
- `git diff --check origin/main...HEAD`

## Notes

This is intentionally a full revert. The separate runtime-loading/UI-refresh issue remains tracked independently and is not changed by this PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->