### PR TITLE
fix(mobile): include Hermes release compiler

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -36,6 +36,7 @@
     "@types/jest": "29.5.14",
     "@types/react": "19.2.15",
     "@types/react-test-renderer": "19.1.0",
+    "hermes-compiler": "250829098.0.14",
     "jest": "29.7.0",
     "react-test-renderer": "19.2.6",
     "typescript": "5.9.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,6 +262,9 @@ importers:
       "@types/react-test-renderer":
         specifier: 19.1.0
         version: 19.1.0
+      hermes-compiler:
+        specifier: 250829098.0.14
+        version: 250829098.0.14
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@24.12.4)


### PR DESCRIPTION
## Summary

- add the React Native 0.86-compatible Hermes compiler required for release JS bundling
- lock the compiler in the mobile importer so manual internal APK builds can locate `hermesc`

## Validation

- `pnpm --filter @tutti-os/mobile typecheck`
- staged repository hooks

Fixes the failed `:app:createBundleReleaseJsAndAssets` step in Android Internal Build.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->