### PR TITLE
feat(agent-gui): add intensity-reactive equalizer wave to Tutti budget slider

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/TuttiBudgetPopover.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/TuttiBudgetPopover.tsx
@@ -12,6 +12,7 @@ import {
   projectTuttiIntensityPreview,
   type TuttiIntensityTier
 } from "./tuttiIntensityPreview";
+import { TuttiIntensityWave } from "./TuttiIntensityWave";
 
 export interface TuttiBudgetPopoverLabels {
   title: string;
@@ -136,26 +137,29 @@ export function TuttiBudgetPopover({
             </span>
           </div>
           <div className="mt-3">
-            <Slider
-              aria-label={labels.intensityLabel}
-              className={`-mx-1 w-[calc(100%_+_8px)] [&_[data-slot=slider-range]]:bg-transparent [&_[data-slot=slider-track]]:mx-1 [&_[data-slot=slider-track]]:h-5 [&_[data-slot=slider-track]]:bg-[linear-gradient(90deg,var(--state-success)_0%,var(--accent-codex)_50%,var(--tutti-purple)_100%)] [&_[data-slot=slider-thumb]]:size-10 [&_[data-slot=slider-thumb]]:border-transparent [&_[data-slot=slider-thumb]]:bg-transparent [&_[data-slot=slider-thumb]]:bg-[image:var(--tutti-intensity-handle-url)] [&_[data-slot=slider-thumb]]:bg-contain [&_[data-slot=slider-thumb]]:bg-center [&_[data-slot=slider-thumb]]:bg-no-repeat [&_[data-slot=slider-thumb]]:shadow-none [&_[data-slot=slider-thumb]]:hover:ring-0 [&_[data-slot=slider-thumb]]:focus-visible:ring-0 [&_[data-slot=slider-thumb]]:-translate-y-1 [&_[data-slot=slider-thumb]]:cursor-grab [&_[data-slot=slider-thumb]]:active:cursor-grabbing`}
-              style={
-                {
-                  "--tutti-intensity-handle-url": `url("${previewTone.sliderHandleUrl}")`
-                } as CSSProperties
-              }
-              data-agent-tutti-budget-intensity-slider="true"
-              data-agent-tutti-budget-slider-tone={preview.tier}
-              max={100}
-              min={0}
-              step={1}
-              value={[draftIntensity]}
-              onValueChange={(values) => {
-                const next = values[0] ?? draftIntensity;
-                setDraftIntensity(next);
-                onChange(next);
-              }}
-            />
+            <div className="relative">
+              <Slider
+                aria-label={labels.intensityLabel}
+                className={`-mx-1 w-[calc(100%_+_8px)] [&_[data-slot=slider-range]]:bg-transparent [&_[data-slot=slider-track]]:mx-1 [&_[data-slot=slider-track]]:h-5 [&_[data-slot=slider-track]]:bg-[linear-gradient(90deg,var(--state-success)_0%,var(--accent-codex)_50%,var(--tutti-purple)_100%)] [&_[data-slot=slider-thumb]]:z-[2] [&_[data-slot=slider-thumb]]:size-10 [&_[data-slot=slider-thumb]]:border-transparent [&_[data-slot=slider-thumb]]:bg-transparent [&_[data-slot=slider-thumb]]:bg-[image:var(--tutti-intensity-handle-url)] [&_[data-slot=slider-thumb]]:bg-contain [&_[data-slot=slider-thumb]]:bg-center [&_[data-slot=slider-thumb]]:bg-no-repeat [&_[data-slot=slider-thumb]]:shadow-none [&_[data-slot=slider-thumb]]:hover:ring-0 [&_[data-slot=slider-thumb]]:focus-visible:ring-0 [&_[data-slot=slider-thumb]]:-translate-y-1 [&_[data-slot=slider-thumb]]:cursor-grab [&_[data-slot=slider-thumb]]:active:cursor-grabbing`}
+                style={
+                  {
+                    "--tutti-intensity-handle-url": `url("${previewTone.sliderHandleUrl}")`
+                  } as CSSProperties
+                }
+                data-agent-tutti-budget-intensity-slider="true"
+                data-agent-tutti-budget-slider-tone={preview.tier}
+                max={100}
+                min={0}
+                step={1}
+                value={[draftIntensity]}
+                onValueChange={(values) => {
+                  const next = values[0] ?? draftIntensity;
+                  setDraftIntensity(next);
+                  onChange(next);
+                }}
+              />
+              <TuttiIntensityWave intensity={draftIntensity} />
+            </div>
             <div className="mt-3 flex items-center justify-between gap-2 text-[11px] font-medium">
               <span className="text-[var(--state-success)]">
                 {labels.previewCost}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/TuttiIntensityWave.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/TuttiIntensityWave.tsx
@@ -1,0 +1,188 @@
+import { useCallback, useRef } from "react";
+
+/**
+ * Equalizer-bar music visualizer drawn on the intensity slider track,
+ * behind the mascot thumb. No off-the-shelf visualizer library fits here:
+ * the maintained ones (audioMotion, wavesurfer, ...) all require a real
+ * audio source through the Web Audio API, while this strip is purely
+ * decorative. The bars sample a smooth travelling noise field (three
+ * incommensurate sine components), so neighbouring bars stay coherent and
+ * heights never jump mechanically; a subtle beat envelope keeps the motion
+ * musical.
+ *
+ * Intensity lerps the exposed parameters: even the lowest value renders a
+ * lively mid-energy strip, and the highest pushes tall, fully-spiky bars
+ * dancing fast enough to clip against the track edge. Parameter targets are
+ * assigned during render and the draw loop eases toward them, so drag
+ * updates morph smoothly and repeated assignments from discarded or double
+ * renders are harmless.
+ *
+ * The agent-gui degradation ratchet forbids new effects, so the canvas
+ * lifecycle hangs off the DOM node through a React 19 ref callback with a
+ * cleanup.
+ */
+
+const TRACK_HEIGHT_PX = 20;
+const BAR_WIDTH_PX = 3;
+const BAR_GAP_PX = 2;
+/** Horizontal scale of the noise field per bar; neighbours stay coherent. */
+const BAR_SPATIAL_SCALE = 0.35;
+/** Exponential easing factor (per frame) toward parameter targets. */
+const PARAM_EASE = 0.08;
+/** Subtle loudness pulse, in radians per second at speed 1. */
+const BEAT_RATE = 2.2;
+
+interface WaveParams {
+  /** Peak bar height as a fraction of the track half-height. */
+  amplitude: number;
+  /** Bar-to-bar height variability: low reads flat, high reads spiky. */
+  contrast: number;
+  /** Time multiplier for the noise field and the beat. */
+  speed: number;
+}
+
+function clampIntensity(intensity: number): number {
+  return Number.isFinite(intensity) ? Math.min(100, Math.max(0, intensity)) : 0;
+}
+
+function waveParams(intensity: number): WaveParams {
+  const t = clampIntensity(intensity) / 100;
+  return {
+    // The floor already reads as energetic (roughly the old ~75 intensity);
+    // the top end peaks slightly past the track half-height so the strongest
+    // setting visibly maxes out against the clip.
+    amplitude: 0.8 + t * 0.3,
+    contrast: 0.7 + t * 0.3, // lively variation -> fully spiky heights
+    speed: 2 + t * 1.3 // brisk sway -> fast dance
+  };
+}
+
+/** Deterministic per-bar jitter so heights decorrelate without jumping. */
+function barJitter(index: number): number {
+  const value = Math.sin(index * 127.1) * 43758.5453;
+  return value - Math.floor(value);
+}
+
+/** Smooth 1D noise field in [-1, 1]: three incommensurate travelling sines. */
+function noiseField(x: number, t: number): number {
+  return (
+    0.55 * Math.sin(x * 0.9 + t * 1.1) +
+    0.3 * Math.sin(x * 2.3 - t * 1.7 + 1.3) +
+    0.15 * Math.sin(x * 4.1 + t * 2.9 + 4.2)
+  );
+}
+
+export function TuttiIntensityWave({ intensity }: { intensity: number }) {
+  // The draw loop eases toward these targets every frame, so reassigning
+  // them on every render (including discarded or double renders) is safe.
+  const targetsRef = useRef<WaveParams | null>(null);
+  targetsRef.current = waveParams(intensity);
+
+  // The empty dependency list keeps the attachment stable for the node's
+  // lifetime: the canvas is created once per mount and torn down by the
+  // returned cleanup on unmount.
+  const attachWave = useCallback(
+    (container: HTMLDivElement | null): (() => void) | undefined => {
+      if (container === null) return undefined;
+      // Decorative motion is skipped entirely for reduced-motion users.
+      if (
+        typeof window.matchMedia !== "function" ||
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      ) {
+        return undefined;
+      }
+      const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext("2d");
+      // Environments without a 2D canvas (e.g. jsdom) degrade to the plain
+      // gradient track.
+      if (ctx === null) return undefined;
+
+      const ratio = window.devicePixelRatio || 1;
+      const width = container.clientWidth;
+      canvas.width = width * ratio;
+      canvas.height = TRACK_HEIGHT_PX * ratio;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${TRACK_HEIGHT_PX}px`;
+      container.appendChild(canvas);
+      ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+      ctx.strokeStyle = window.getComputedStyle(container).color;
+      ctx.lineWidth = BAR_WIDTH_PX;
+      ctx.lineCap = "round";
+
+      const barCount = Math.max(
+        1,
+        Math.floor((width + BAR_GAP_PX) / (BAR_WIDTH_PX + BAR_GAP_PX))
+      );
+      const barsWidth = barCount * (BAR_WIDTH_PX + BAR_GAP_PX) - BAR_GAP_PX;
+      const startX = (width - barsWidth) / 2 + BAR_WIDTH_PX / 2;
+      const midY = TRACK_HEIGHT_PX / 2;
+
+      const params = { ...(targetsRef.current ?? waveParams(0)) };
+      let phase = 0;
+      let beatPhase = 0;
+      let lastTime = -1;
+      let animationFrameId = 0;
+
+      const draw = (time: number): void => {
+        animationFrameId = requestAnimationFrame(draw);
+        if (lastTime < 0) lastTime = time;
+        // Clamp the step so a backgrounded tab does not jump on resume.
+        const dt = Math.min(0.05, (time - lastTime) / 1000);
+        lastTime = time;
+
+        const targets = targetsRef.current ?? params;
+        params.amplitude += (targets.amplitude - params.amplitude) * PARAM_EASE;
+        params.contrast += (targets.contrast - params.contrast) * PARAM_EASE;
+        params.speed += (targets.speed - params.speed) * PARAM_EASE;
+
+        phase += dt * params.speed * 2.4;
+        beatPhase += dt * params.speed * BEAT_RATE;
+        const beat = 0.85 + 0.15 * Math.pow(0.5 + 0.5 * Math.sin(beatPhase), 2);
+
+        ctx.clearRect(0, 0, width, TRACK_HEIGHT_PX);
+        ctx.beginPath();
+        for (let i = 0; i < barCount; i += 1) {
+          const fieldX = (i + barJitter(i)) * BAR_SPATIAL_SCALE;
+          const value = (noiseField(fieldX, phase) + 1) / 2;
+          const heightFrac =
+            params.amplitude *
+            (1 - params.contrast + params.contrast * value) *
+            beat;
+          const halfHeight = Math.max(
+            0.8,
+            heightFrac * (TRACK_HEIGHT_PX / 2 - 1)
+          );
+          const x = startX + i * (BAR_WIDTH_PX + BAR_GAP_PX);
+          ctx.moveTo(x, midY - halfHeight);
+          ctx.lineTo(x, midY + halfHeight);
+        }
+        ctx.stroke();
+      };
+      animationFrameId = requestAnimationFrame(draw);
+
+      return () => {
+        cancelAnimationFrame(animationFrameId);
+        canvas.remove();
+      };
+    },
+    []
+  );
+
+  // The mascot PNGs carry a soft semi-transparent halo (~55% alpha), so the
+  // wave would bleed through the thumb. Cut a gap in the wave beneath the
+  // thumb instead; the thumb is 40px wide (`size-10`) and its travel is
+  // inset by half its width on each side, like any Radix slider thumb.
+  const thumbProgress = clampIntensity(intensity) / 100;
+  const thumbCenter = `calc(20px + (100% - 40px) * ${thumbProgress})`;
+  const maskImage = `radial-gradient(circle at ${thumbCenter} 50%, transparent 0, transparent 22px, black 28px)`;
+
+  return (
+    <div
+      aria-hidden="true"
+      ref={attachWave}
+      className="pointer-events-none absolute inset-x-0 top-1/2 z-[1] flex h-5 -translate-y-1/2 items-center justify-center overflow-hidden rounded-full text-[var(--text-primary)] opacity-60"
+      data-agent-tutti-budget-intensity-wave="true"
+      style={{ WebkitMaskImage: maskImage, maskImage }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Adds an animated **equalizer-bar** sound-wave texture to the Tutti intensity slider track in `TuttiBudgetPopover`, rendered behind the mascot thumb.

Off-the-shelf visualizer libraries (audioMotion, wavesurfer, ...) all require a real audio source through the Web Audio API, while this strip is purely decorative. The bars therefore sample a smooth travelling noise field (three incommensurate sine components): neighbouring bars stay coherent, heights never jump mechanically, and a subtle beat envelope keeps the motion musical — the classic music-player equalizer look.

Intensity eases the exposed parameters through per-frame exponential smoothing, so dragging the slider morphs the visual live. The range starts lively — even the weakest setting reads like a mid-energy strip — and tops out at a visibly maxed-out dance:

- `amplitude` 0.8 → 1.1 of the track half-height (the top end peaks slightly past the track and clips against the edge)
- `contrast` 0.7 → 1.0 (lively variation → fully spiky heights)
- `speed` 2.0 → 3.3 (brisk sway → fast dance)

Details:

- **Even motion across the whole track**: each bar animates independently, so both ends move with a similar amplitude — no edge-attenuation dead zones.
- **No bleed-through under the mascot**: the thumb PNGs carry a soft semi-transparent halo (~55% alpha), so a radial mask tracks the thumb position and cuts a gap in the bars beneath it.
- **Graceful degradation**: reduced-motion users and canvas-less environments (jsdom) get the plain gradient track; the container is `aria-hidden` and `pointer-events-none`.
- **Zero new effects**: the agent-gui effect-count ratchet only decreases, so the canvas lifecycle uses a React 19 ref callback with cleanup, and parameter targets sync during render (the draw loop eases toward them; reassigning on discarded or double renders is harmless).
- **Theme-aware**: bar color resolves from `var(--text-primary)` and reads on both dark and light themes.
- No new dependency (an earlier revision used `siriwave`; it has been removed).

## Verification

- `TuttiBudgetPopover` / `TuttiBudgetPopover.presession` / `TuttiWorkflowDock` specs: 12 passed
- `pnpm check:agent-gui-degradation`: passed (effectCount unchanged)
- `@tutti-os/agent-gui` typecheck (tsgo), oxlint, oxfmt, prettier (repo config): passed
- `pnpm check:changed -- --push-ready`: 12/12 lanes passed (run before the later amends; each amend only rewrites `TuttiIntensityWave.tsx`, which is covered by the checks above)
- Visual check: rendered the exact DOM/canvas setup in headless Chrome across intensities 5–100 — confirmed bars span the full track with even motion, stay behind the mascot thumb without bleeding through its halo, and read as a music equalizer that starts lively and maxes out at full intensity

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. — N/A, presentation-only change
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed. — no behavior/setup/workflow change
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. — N/A
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.