### PR TITLE
perf(agent-gui): reduce session switch parsing and reconcile work

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -403,8 +403,16 @@ Relative time uses one renderer-realm minute clock. Timestamp leaves subscribe d
 Rail selection, detail hydration, older-page loading, and transcript projection are separate states.
 
 A focused controller may own detail paging/loading/error. Canonical messages, Turns, Interactions, and optimistic prompts still come from the engine. An empty message list means neither hydrated nor not-found.
+Selecting an already hydrated Session must not start another detail reconcile;
+the selection controller alone decides whether hydration is missing. Composer
+option synchronization does not own Session detail reloads.
 
 Timeline projection is pure, deterministic, and provider-neutral. React views render rows/cards and dispatch actions.
+Canonical reducers preserve entity and collection references when an accepted
+Session snapshot is semantically unchanged, while still merging changed Turns
+and Interactions at the same Session version. The legacy activity snapshot
+projector preserves each unchanged domain-slice projection so reconcile
+bookkeeping or composer-option updates do not rebuild transcript inputs.
 
 Turn elapsed-time presentation starts at the client submission timestamp carried
 by the canonical user-message payload, not at provider runtime start. Historical
@@ -427,7 +435,7 @@ replacement may rebuild the document.
 
 A virtualized transcript derives message-locator selection from the virtualizer's measured turn positions and explicit transcript identity. The currently mounted DOM window is rendering output, not a selection source; range changes must not make the locator temporarily select a neighboring message.
 
-Historical rich text renders from the canonical Tiptap document through a static schema renderer. Only interactive composer surfaces own a Tiptap Editor/ProseMirror EditorView; read-only transcript surfaces reuse the same mention/token presentation without mounting editor lifecycle. Conversation titles are a separate plain-text projection: Markdown mention links are normalized to their `@label` text and never render mention SVGs or interactive rich-text tokens.
+Historical rich text renders from the canonical Tiptap document through a static schema renderer. Only interactive composer surfaces own a Tiptap Editor/ProseMirror EditorView; read-only transcript surfaces reuse the same mention/token presentation without mounting editor lifecycle. Settled transcript messages reuse a bounded cache of pure Markdown ASTs and Tiptap JSON documents keyed by message identity and exact parser input; rendered React elements are never cached, and streaming Markdown bypasses this cache. Conversation titles are a separate plain-text projection: Markdown mention links are normalized to their `@label` text and never render mention SVGs or interactive rich-text tokens.
 
 Attachment-only fallback labels such as `[Image]` may provide title or summary
 text, but they are not an additional transcript text block when the canonical
@@ -457,6 +465,10 @@ Use `agentTargetId` for:
 - Agent mentions and handoff targets
 
 `provider` is execution metadata, not UI identity. Multiple Agents may share a provider; UI must not group, deduplicate, cache, or fall back by provider.
+Ordinary Session selection reads composer options through the existing
+target/cwd/settings request cache. It does not force a refresh; force is
+reserved for explicit invalidation, completed Session creation, and documented
+provider prewarm behavior.
 
 Trusted host/daemon code resolves a target-backed request through `agent_targets`, then derives provider and runtime reference. If a client supplies both target and provider, daemon rejects a mismatch.
 
@@ -604,8 +616,9 @@ composer or refreshing the project list cannot restore a previous project.
 
 A locked Session cwd existence check is UI-local observation, not Session
 truth. AgentGUI starts it only after pending creation has resolved, scopes its
-result to the exact Session composer identity, and discards callbacks from a
-previous selection. A host probe failure leaves existence unknown; only a
+result to the normalized selected path, and discards callbacks from a previous
+path. Switching between Sessions that share the same cwd must not repeat the
+same mounted probe. A host probe failure leaves existence unknown; only a
 successful check that confirms absence may render missing-project chrome.
 
 The empty-home carousel may measure its placeholder synchronously when live

--- a/packages/agent/activity-core/src/engine/agentActivitySnapshot.projector.test.ts
+++ b/packages/agent/activity-core/src/engine/agentActivitySnapshot.projector.test.ts
@@ -26,6 +26,40 @@ test("projects canonical engine state and preserves the snapshot reference", () 
   assert.equal(populated.sessions[0]?.pendingInteractions.length, 1);
 });
 
+test("reuses expensive projections when unrelated engine slices change", () => {
+  const project = createAgentActivitySnapshotProjector("workspace-1");
+  const populatedState = rootEngineReducer(
+    createInitialAgentSessionEngineState(),
+    {
+      type: "session/snapshotReceived",
+      sessions: [session()]
+    }
+  ).state;
+  const populated = project(populatedState);
+  const reconcileOnlyState = {
+    ...populatedState,
+    sessionReconcile: { ...populatedState.sessionReconcile }
+  };
+
+  const reconciled = project(reconcileOnlyState);
+
+  assert.notEqual(reconciled, populated);
+  assert.equal(reconciled.sessions, populated.sessions);
+  assert.equal(reconciled.sessionMessagesById, populated.sessionMessagesById);
+  assert.equal(
+    reconciled.sessionMessageWindowsById,
+    populated.sessionMessageWindowsById
+  );
+  assert.equal(
+    reconciled.composerOptionsByTargetKey,
+    populated.composerOptionsByTargetKey
+  );
+  assert.equal(
+    reconciled.composerOptionsLoadStatusByTargetKey,
+    populated.composerOptionsLoadStatusByTargetKey
+  );
+});
+
 function session(): AgentActivitySession {
   const turn = {
     agentSessionId: "session-1",

--- a/packages/agent/activity-core/src/engine/agentActivitySnapshot.projector.ts
+++ b/packages/agent/activity-core/src/engine/agentActivitySnapshot.projector.ts
@@ -9,6 +9,8 @@ import {
 } from "./sessionLifecycle.selectors.ts";
 import type { AgentSessionEngineState } from "./types.ts";
 
+const EMPTY_PRESENCES: AgentActivitySnapshot["presences"] = [];
+
 /**
  * Builds the legacy runtime snapshot shape as a memoized projection of the
  * canonical workspace engine. The projector must be retained per engine so
@@ -22,39 +24,69 @@ export function createAgentActivitySnapshotProjector(
   let previousSnapshot: AgentActivitySnapshot | null = null;
   return (state) => {
     if (state === previousState && previousSnapshot) return previousSnapshot;
+    const sessions =
+      previousState &&
+      previousSnapshot &&
+      state.sessionLifecycle === previousState.sessionLifecycle
+        ? previousSnapshot.sessions
+        : selectAllWorkspaceAgentConsumerSessions(state).map((item) =>
+            projectSession(
+              item.session,
+              item.activeTurn,
+              item.latestTurn,
+              selectEngineInteractionsForSession(
+                state,
+                item.session.agentSessionId
+              ),
+              item.pendingInteractions
+            )
+          );
+    const sessionMessagesById =
+      previousState &&
+      previousSnapshot &&
+      state.sessionMessages.messagesBySessionId ===
+        previousState.sessionMessages.messagesBySessionId
+        ? previousSnapshot.sessionMessagesById
+        : Object.fromEntries(
+            Object.entries(state.sessionMessages.messagesBySessionId).map(
+              ([agentSessionId, messages]) => [agentSessionId, [...messages]]
+            )
+          );
+    const sessionMessageWindowsById =
+      previousState &&
+      previousSnapshot &&
+      state.sessionMessages.windowsBySessionId ===
+        previousState.sessionMessages.windowsBySessionId
+        ? previousSnapshot.sessionMessageWindowsById
+        : { ...state.sessionMessages.windowsBySessionId };
+    const composerOptionsByTargetKey =
+      previousState &&
+      previousSnapshot &&
+      state.composerOptions.optionsByTargetKey ===
+        previousState.composerOptions.optionsByTargetKey
+        ? previousSnapshot.composerOptionsByTargetKey
+        : { ...state.composerOptions.optionsByTargetKey };
+    const composerOptionsLoadStatusByTargetKey =
+      previousState &&
+      previousSnapshot &&
+      state.composerOptions.entriesByTargetKey ===
+        previousState.composerOptions.entriesByTargetKey
+        ? previousSnapshot.composerOptionsLoadStatusByTargetKey
+        : Object.fromEntries(
+            Object.entries(state.composerOptions.entriesByTargetKey).map(
+              ([targetKey, entry]) => [targetKey, entry.status]
+            )
+          );
     const snapshot: AgentActivitySnapshot = {
       workspaceId,
-      sessions: selectAllWorkspaceAgentConsumerSessions(state).map((item) =>
-        projectSession(
-          item.session,
-          item.activeTurn,
-          item.latestTurn,
-          selectEngineInteractionsForSession(
-            state,
-            item.session.agentSessionId
-          ),
-          item.pendingInteractions
-        )
-      ),
+      sessions,
       // Presence is no longer canonical activity state. Keep the legacy
       // snapshot field empty until the runtime contract drops it.
-      presences: [],
-      sessionMessagesById: Object.fromEntries(
-        Object.entries(state.sessionMessages.messagesBySessionId).map(
-          ([agentSessionId, messages]) => [agentSessionId, [...messages]]
-        )
-      ),
-      sessionMessageWindowsById: {
-        ...state.sessionMessages.windowsBySessionId
-      },
-      composerOptionsByTargetKey: {
-        ...state.composerOptions.optionsByTargetKey
-      },
-      composerOptionsLoadStatusByTargetKey: Object.fromEntries(
-        Object.entries(state.composerOptions.entriesByTargetKey).map(
-          ([targetKey, entry]) => [targetKey, entry.status]
-        )
-      )
+      presences: EMPTY_PRESENCES,
+      sessionMessagesById,
+      sessionMessageWindowsById,
+      composerOptionsByTargetKey,
+      composerOptionsLoadStatusByTargetKey
     };
     previousState = state;
     previousSnapshot = snapshot;

--- a/packages/agent/activity-core/src/engine/sessionEntities.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionEntities.reducer.ts
@@ -1,5 +1,6 @@
 import type { AgentActivityInteraction, AgentActivityTurn } from "../types.ts";
 import { shouldUseIncomingInteraction } from "../interactionMonotonicity.ts";
+import { areJsonLikeValuesEqual } from "../merge.ts";
 import { normalizeAgentActivitySession } from "../sessionNormalization.ts";
 import type { AgentActivitySessionInput } from "../sessionNormalization.ts";
 import type {
@@ -30,9 +31,13 @@ export function replaceCanonicalSessionSnapshot(
     const current = state.sessionsById[id];
     const incomingSession = canonicalSession(source);
     const useIncoming = shouldUseIncomingSession(current, incomingSession);
-    sessionsById[id] = useIncoming
+    const candidateSession = useIncoming
       ? preserveLiveTurnOnTimestampTie(current, incomingSession)
       : current!;
+    sessionsById[id] =
+      current && areJsonLikeValuesEqual(current, candidateSession)
+        ? current
+        : candidateSession;
     operationBySessionId[id] =
       state.operationBySessionId[id] ?? createOperation();
     if (useIncoming) {
@@ -50,7 +55,11 @@ export function replaceCanonicalSessionSnapshot(
       ...source.pendingInteractions
     ]) {
       if (interaction.agentSessionId === id) {
-        mergeInteractionInto(interactionsById, interaction);
+        mergeInteractionInto(
+          interactionsById,
+          state.interactionsById,
+          interaction
+        );
       }
     }
   }
@@ -101,12 +110,33 @@ export function replaceCanonicalSessionSnapshot(
       interactionsById[key] = interaction;
     }
   }
+  const nextInteractionsById = reuseRecordIfShallowEqual(
+    state.interactionsById,
+    interactionsById
+  );
+  const nextOperationBySessionId = reuseRecordIfShallowEqual(
+    state.operationBySessionId,
+    operationBySessionId
+  );
+  const nextSessionsById = reuseRecordIfShallowEqual(
+    state.sessionsById,
+    sessionsById
+  );
+  const nextTurnsById = reuseRecordIfShallowEqual(state.turnsById, turnsById);
+  if (
+    nextInteractionsById === state.interactionsById &&
+    nextOperationBySessionId === state.operationBySessionId &&
+    nextSessionsById === state.sessionsById &&
+    nextTurnsById === state.turnsById
+  ) {
+    return state;
+  }
   return {
     ...state,
-    interactionsById,
-    operationBySessionId,
-    sessionsById,
-    turnsById
+    interactionsById: nextInteractionsById,
+    operationBySessionId: nextOperationBySessionId,
+    sessionsById: nextSessionsById,
+    turnsById: nextTurnsById
   };
 }
 
@@ -120,18 +150,28 @@ export function upsertCanonicalSession(
   const current = state.sessionsById[id];
   const incoming = canonicalSession(source);
   const useIncoming = shouldUseIncomingSession(current, incoming);
-  let next: SessionLifecycleState = {
-    ...state,
-    operationBySessionId: state.operationBySessionId[id]
-      ? state.operationBySessionId
-      : { ...state.operationBySessionId, [id]: createOperation() },
-    sessionsById: {
-      ...state.sessionsById,
-      [id]: useIncoming
-        ? preserveLiveTurnOnTimestampTie(current, incoming)
-        : current!
-    }
-  };
+  const candidateSession = useIncoming
+    ? preserveLiveTurnOnTimestampTie(current, incoming)
+    : current!;
+  const nextSession =
+    current && areJsonLikeValuesEqual(current, candidateSession)
+      ? current
+      : candidateSession;
+  const operationBySessionId = state.operationBySessionId[id]
+    ? state.operationBySessionId
+    : { ...state.operationBySessionId, [id]: createOperation() };
+  let next: SessionLifecycleState =
+    operationBySessionId === state.operationBySessionId &&
+    nextSession === current
+      ? state
+      : {
+          ...state,
+          operationBySessionId,
+          sessionsById:
+            nextSession === current
+              ? state.sessionsById
+              : { ...state.sessionsById, [id]: nextSession }
+        };
   if (useIncoming && source.activeTurn?.agentSessionId === id) {
     next = upsertCanonicalTurn(next, source.activeTurn);
   }
@@ -202,6 +242,7 @@ export function upsertCanonicalTurn(
   const current = state.turnsById[key];
   if (current && !shouldUseIncomingTurn(current, turn)) return state;
   const nextTurn = current ? preserveTurnProvenance(current, turn) : turn;
+  if (current && areJsonLikeValuesEqual(current, nextTurn)) return state;
   return {
     ...state,
     turnsById: { ...state.turnsById, [key]: { ...nextTurn } }
@@ -227,6 +268,7 @@ export function upsertCanonicalInteraction(
   );
   const current = state.interactionsById[key];
   if (!shouldUseIncomingInteraction(current, interaction)) return state;
+  if (current && areJsonLikeValuesEqual(current, interaction)) return state;
   return {
     ...state,
     interactionsById: {
@@ -238,6 +280,7 @@ export function upsertCanonicalInteraction(
 
 function mergeInteractionInto(
   target: Record<string, AgentActivityInteraction>,
+  existing: Readonly<Record<string, AgentActivityInteraction>>,
   interaction: AgentActivityInteraction
 ): void {
   const key = canonicalInteractionKey(
@@ -245,8 +288,12 @@ function mergeInteractionInto(
     interaction.turnId,
     interaction.requestId
   );
-  if (shouldUseIncomingInteraction(target[key], interaction)) {
-    target[key] = { ...interaction };
+  const current = target[key] ?? existing[key];
+  if (shouldUseIncomingInteraction(current, interaction)) {
+    target[key] =
+      current && areJsonLikeValuesEqual(current, interaction)
+        ? current
+        : { ...interaction };
   }
 }
 
@@ -327,10 +374,27 @@ function mergeTurnInto(
   const key = canonicalTurnKey(turn.agentSessionId, turn.turnId);
   const current = target[key] ?? existing[key];
   if (!current || shouldUseIncomingTurn(current, turn)) {
-    target[key] = {
-      ...(current ? preserveTurnProvenance(current, turn) : turn)
-    };
+    const candidate = current ? preserveTurnProvenance(current, turn) : turn;
+    target[key] =
+      current && areJsonLikeValuesEqual(current, candidate)
+        ? current
+        : { ...candidate };
   }
+}
+
+function reuseRecordIfShallowEqual<T>(
+  current: Readonly<Record<string, T>>,
+  next: Record<string, T>
+): Record<string, T> {
+  const currentKeys = Object.keys(current);
+  const nextKeys = Object.keys(next);
+  if (
+    currentKeys.length === nextKeys.length &&
+    nextKeys.every((key) => current[key] === next[key])
+  ) {
+    return current as Record<string, T>;
+  }
+  return next;
 }
 
 /**

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
@@ -45,6 +45,64 @@ test("snapshot decomposes protocol v2 session and turn entities", () => {
   );
 });
 
+test("identical session upserts preserve canonical state references", () => {
+  const source = session(activeTurn(2), 2);
+  const first = reduce(createInitialSessionLifecycleState(), {
+    type: "session/upserted",
+    session: source
+  }).state;
+  const second = reduce(first, {
+    type: "session/upserted",
+    session: source
+  }).state;
+
+  assert.equal(second, first);
+  assert.equal(second.sessionsById, first.sessionsById);
+  assert.equal(second.turnsById, first.turnsById);
+});
+
+test("identical session snapshots preserve canonical state references", () => {
+  const source = session(activeTurn(2), 2);
+  const first = reduce(createInitialSessionLifecycleState(), {
+    type: "session/snapshotReceived",
+    sessions: [source]
+  }).state;
+  const second = reduce(first, {
+    type: "session/snapshotReceived",
+    sessions: [source]
+  }).state;
+
+  assert.equal(second, first);
+});
+
+test("equal-version sessions still merge changed pending interactions", () => {
+  const source = session(activeTurn(2), 2);
+  source.latestTurnInteractions = [interaction("pending", 2)];
+  source.pendingInteractions = source.latestTurnInteractions;
+  const first = reduce(createInitialSessionLifecycleState(), {
+    type: "session/upserted",
+    session: source
+  }).state;
+  const changed = {
+    ...source,
+    latestTurnInteractions: [interaction("pending", 3)],
+    pendingInteractions: [interaction("pending", 3)]
+  };
+  const second = reduce(first, {
+    type: "session/upserted",
+    session: changed
+  }).state;
+
+  assert.equal(second.sessionsById, first.sessionsById);
+  assert.notEqual(second.interactionsById, first.interactionsById);
+  assert.equal(
+    second.interactionsById[
+      canonicalInteractionKey("session-1", "turn-1", "request-1")
+    ]?.updatedAtUnixMs,
+    3
+  );
+});
+
 test("snapshot restores a settled latest turn without an active turn", () => {
   const latestTurn: AgentActivityTurn = {
     ...activeTurn(7),

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -220,15 +220,15 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   );
   const [fileMentionSuggestion, setFileMentionSuggestion] =
     useState<AgentFileMentionSuggestionState | null>(null);
+  const selectedProjectPath =
+    composerSettings.selectedProjectPath?.trim() ?? "";
   const [isSelectedProjectMissing, setIsSelectedProjectMissing] =
-    useScopedProjectMissingState(draftScopeKey);
+    useScopedProjectMissingState(selectedProjectPath);
   const [isSlashStatusPanelOpen, setIsSlashStatusPanelOpen] = useState(false);
   const slashStatusAgentSessionId = slashStatus?.agentSessionId ?? null;
   const previousSlashStatusAgentSessionIdRef = useRef<string | null>(
     slashStatusAgentSessionId
   );
-  const selectedProjectPath =
-    composerSettings.selectedProjectPath?.trim() ?? "";
   const selectedProjectSectionKey =
     composerSettings.selectedProjectSectionKey?.trim() ?? "";
   const previousSelectedProjectPathRef = useRef(selectedProjectPath);

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useScopedProjectMissingState.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useScopedProjectMissingState.spec.tsx
@@ -3,26 +3,30 @@ import { describe, expect, it } from "vitest";
 import { useScopedProjectMissingState } from "./useScopedProjectMissingState";
 
 describe("useScopedProjectMissingState", () => {
-  it("does not carry missing results across session scopes", () => {
+  it("keeps results for the same path and rejects stale results after a path change", () => {
     const rendered = renderHook(
       ({ scopeKey }) => useScopedProjectMissingState(scopeKey),
-      { initialProps: { scopeKey: "session:one" } }
+      { initialProps: { scopeKey: "/workspace/one" } }
     );
 
     act(() => rendered.result.current[1](true));
     expect(rendered.result.current[0]).toBe(true);
+    const reportForFirstPath = rendered.result.current[1];
 
-    const reportForFirstSession = rendered.result.current[1];
-    rendered.rerender({ scopeKey: "session:two" });
+    rendered.rerender({ scopeKey: "/workspace/one" });
+    expect(rendered.result.current[0]).toBe(true);
+    expect(rendered.result.current[1]).toBe(reportForFirstPath);
+
+    rendered.rerender({ scopeKey: "/workspace/two" });
     expect(rendered.result.current[0]).toBe(false);
 
-    act(() => reportForFirstSession(true));
+    act(() => reportForFirstPath(true));
     expect(rendered.result.current[0]).toBe(false);
 
     act(() => rendered.result.current[1](true));
     expect(rendered.result.current[0]).toBe(true);
 
-    rendered.rerender({ scopeKey: "session:one" });
+    rendered.rerender({ scopeKey: "/workspace/one" });
     expect(rendered.result.current[0]).toBe(false);
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useScopedProjectMissingState.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useScopedProjectMissingState.ts
@@ -34,7 +34,11 @@ export function useScopedProjectMissingState(
       if (identityRef.current !== identity) {
         return;
       }
-      setResult({ identity, isMissing });
+      setResult((current) =>
+        current.identity === identity && current.isMissing === isMissing
+          ? current
+          : { identity, isMissing }
+      );
     },
     [identity]
   );

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.spec.tsx
@@ -1,8 +1,4 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import {
-  createAgentSessionEngine,
-  type AgentSessionEngine
-} from "@tutti-os/agent-activity-core";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import type { AgentGUIProvider, AgentGUINodeData } from "../../../types";
@@ -52,13 +48,9 @@ describe("useAgentGUIComposerOptionsSync", () => {
           onComposerDefaultsAuthorityReloadedRef: authorityReconcilerRef,
           previewMode: false,
           providerComposerOptions: null,
-          reloadSelectedConversation: vi.fn(),
           selectedComposerTargetDataRef: selectedTargetRef,
           selectedProjectPath: "/workspace/project",
           selectedProjectPathRef,
-          sessionEngine: {
-            getSnapshot: () => ({})
-          } as unknown as AgentSessionEngine,
           syncConversationListProjection: vi.fn(async () => {}),
           workspaceId: "workspace-1",
           workspacePath: "/workspace"
@@ -153,13 +145,9 @@ describe("useAgentGUIComposerOptionsSync", () => {
             createComposerDefaultsAuthorityReconcilerRef(),
           previewMode: false,
           providerComposerOptions: null,
-          reloadSelectedConversation: vi.fn(),
           selectedComposerTargetDataRef: selectedTargetRef,
           selectedProjectPath: "/workspace/project",
           selectedProjectPathRef,
-          sessionEngine: {
-            getSnapshot: () => ({})
-          } as unknown as AgentSessionEngine,
           syncConversationListProjection: vi.fn(async () => {}),
           workspaceId: "workspace-1",
           workspacePath: "/workspace"
@@ -182,6 +170,60 @@ describe("useAgentGUIComposerOptionsSync", () => {
         })
       );
     });
+  });
+
+  it("does not force composer options when switching hydrated sessions", async () => {
+    const getComposerOptions = vi.fn(async () => ({}));
+    const data = targetData("codex");
+    const target = composerTarget("codex");
+    const activeConversationIdRef = { current: "session-1" };
+
+    const { rerender } = renderHook(
+      ({ activeConversationId }) => {
+        activeConversationIdRef.current = activeConversationId;
+        return useAgentGUIComposerOptionsSync({
+          activeConversationId,
+          activeConversationIdRef,
+          agentActivityRuntime: {
+            getComposerOptions,
+            getSnapshot: () => ({})
+          } as unknown as AgentActivityRuntime,
+          composerTargetData: target,
+          conversationFilter: null,
+          currentUserId: "user-1",
+          data,
+          dataRef: { current: data },
+          defaultReasoningEffort: null,
+          draftSettingsBySessionIdRef: { current: {} },
+          isComposerHome: false,
+          isComposerHomeRef: { current: false },
+          isCreatingConversation: false,
+          loadDraftComposerOptionsRef: { current: () => {} },
+          loadSessionState: vi.fn(),
+          onComposerDefaultsAuthorityReloadedRef:
+            createComposerDefaultsAuthorityReconcilerRef(),
+          previewMode: false,
+          providerComposerOptions: null,
+          selectedComposerTargetDataRef: { current: target },
+          selectedProjectPath: "/workspace/project",
+          selectedProjectPathRef: { current: "/workspace/project" },
+          syncConversationListProjection: vi.fn(async () => {}),
+          workspaceId: "workspace-1",
+          workspacePath: "/workspace"
+        });
+      },
+      { initialProps: { activeConversationId: "session-1" } }
+    );
+
+    await waitFor(() => expect(getComposerOptions).toHaveBeenCalledTimes(1));
+    getComposerOptions.mockClear();
+
+    rerender({ activeConversationId: "session-2" });
+
+    await waitFor(() => expect(getComposerOptions).toHaveBeenCalledTimes(1));
+    expect(getComposerOptions).toHaveBeenLastCalledWith(
+      expect.objectContaining({ force: undefined })
+    );
   });
 
   it("rereads target authority on invalidation without sending local persistent intent", async () => {
@@ -233,13 +275,9 @@ describe("useAgentGUIComposerOptionsSync", () => {
         onComposerDefaultsAuthorityReloadedRef: authorityReconcilerRef,
         previewMode: false,
         providerComposerOptions: null,
-        reloadSelectedConversation: vi.fn(),
         selectedComposerTargetDataRef: { current: target },
         selectedProjectPath: "/workspace/project",
         selectedProjectPathRef: { current: "/workspace/project" },
-        sessionEngine: {
-          getSnapshot: () => ({})
-        } as unknown as AgentSessionEngine,
         syncConversationListProjection: vi.fn(async () => {}),
         workspaceId: "workspace-1",
         workspacePath: "/workspace"
@@ -359,13 +397,9 @@ describe("useAgentGUIComposerOptionsSync", () => {
         onComposerDefaultsAuthorityReloadedRef: authorityReconcilerRef,
         previewMode: false,
         providerComposerOptions: null,
-        reloadSelectedConversation: vi.fn(),
         selectedComposerTargetDataRef: { current: target },
         selectedProjectPath: "/workspace/project",
         selectedProjectPathRef: { current: "/workspace/project" },
-        sessionEngine: {
-          getSnapshot: () => ({})
-        } as unknown as AgentSessionEngine,
         syncConversationListProjection: vi.fn(async () => {}),
         workspaceId: "workspace-1",
         workspacePath: "/workspace"
@@ -394,13 +428,6 @@ describe("useAgentGUIComposerOptionsSync", () => {
     const target = composerTarget("opencode");
     const authorityReconcilerRef =
       createComposerDefaultsAuthorityReconcilerRef();
-    const sessionEngine = createAgentSessionEngine({
-      clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: vi.fn() },
-      identity: { origin: "test", workspaceId: "workspace-1" },
-      scheduler: { schedule: () => ({ cancel() {} }) }
-    });
-
     renderHook(() =>
       useAgentGUIComposerOptionsSync({
         activeConversationId: "session-1",
@@ -424,11 +451,9 @@ describe("useAgentGUIComposerOptionsSync", () => {
         onComposerDefaultsAuthorityReloadedRef: authorityReconcilerRef,
         previewMode: false,
         providerComposerOptions: null,
-        reloadSelectedConversation: vi.fn(),
         selectedComposerTargetDataRef: { current: target },
         selectedProjectPath: "/workspace/project",
         selectedProjectPathRef: { current: "/workspace/project" },
-        sessionEngine,
         syncConversationListProjection: vi.fn(async () => {}),
         workspaceId: "workspace-1",
         workspacePath: "/workspace"

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.ts
@@ -1,7 +1,3 @@
-import {
-  selectLatestActivationForSession,
-  type AgentSessionEngine
-} from "@tutti-os/agent-activity-core";
 import type { RefObject } from "react";
 import { useCallback, useEffect, useRef } from "react";
 import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
@@ -48,19 +44,13 @@ export function useAgentGUIComposerOptionsSync(input: {
     | { behavior?: { prewarmDraftSession?: boolean } | null }
     | null
     | undefined;
-  reloadSelectedConversation(
-    agentSessionId: string,
-    options: { reloadConversations: boolean; reloadDetail: boolean }
-  ): void;
   selectedComposerTargetDataRef: RefObject<AgentGUIComposerTargetData>;
   selectedProjectPath: string | null;
   selectedProjectPathRef: RefObject<string | null>;
-  sessionEngine: AgentSessionEngine;
   syncConversationListProjection(agentSessionId?: string | null): Promise<void>;
   workspaceId: string;
   workspacePath: string;
 }) {
-  const previousActiveConversationIdRef = useRef(input.activeConversationId);
   const previousIsCreatingConversationRef = useRef(
     input.isCreatingConversation
   );
@@ -254,20 +244,15 @@ export function useAgentGUIComposerOptionsSync(input: {
   useEffect(() => {
     if (input.previewMode) return;
     // Session creation can finish after an earlier request cached the
-    // provider's selected-model-only fallback. Once activation or creation
-    // settles, bypass request-signature deduplication so runtime-discovered
+    // provider's selected-model-only fallback. Once creation settles, bypass
+    // request-signature deduplication so runtime-discovered
     // model options replace that bootstrap snapshot.
-    const conversationActivated =
-      input.activeConversationId !== null &&
-      previousActiveConversationIdRef.current !== input.activeConversationId;
     const conversationCreationSettled =
       previousIsCreatingConversationRef.current &&
       !input.isCreatingConversation;
-    previousActiveConversationIdRef.current = input.activeConversationId;
     previousIsCreatingConversationRef.current = input.isCreatingConversation;
     loadDraftComposerOptions(
-      conversationActivated ||
-        conversationCreationSettled ||
+      conversationCreationSettled ||
         (input.providerComposerOptions?.behavior?.prewarmDraftSession ===
           true &&
           input.isComposerHome)
@@ -298,31 +283,6 @@ export function useAgentGUIComposerOptionsSync(input: {
     input.data.provider,
     input.previewMode,
     input.syncConversationListProjection
-  ]);
-
-  useEffect(() => {
-    if (input.previewMode || !input.activeConversationId) return;
-    const activation = selectLatestActivationForSession(
-      input.sessionEngine.getSnapshot(),
-      input.activeConversationId
-    );
-    if (
-      activation?.status === "failed" ||
-      activation?.status === "canceled" ||
-      activation?.status === "requested" ||
-      activation?.status === "uncertain"
-    ) {
-      return;
-    }
-    input.reloadSelectedConversation(input.activeConversationId, {
-      reloadConversations: false,
-      reloadDetail: true
-    });
-  }, [
-    input.activeConversationId,
-    input.previewMode,
-    input.reloadSelectedConversation,
-    input.sessionEngine
   ]);
 
   return { loadDraftComposerOptions, reloadComposerOptionsForTarget };

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -364,7 +364,6 @@ export function useAgentGUINodeController({
   const {
     loadSessionState,
     markSelectedConversationDetailPending,
-    reloadSelectedConversation,
     resolveSessionMessages
   } = sessionDetailTransport;
   const storedActiveMessages = activeConversationId
@@ -627,11 +626,9 @@ export function useAgentGUINodeController({
       onComposerDefaultsAuthorityReloadedRef,
       previewMode,
       providerComposerOptions,
-      reloadSelectedConversation,
       selectedComposerTargetDataRef,
       selectedProjectPath,
       selectedProjectPathRef,
-      sessionEngine,
       syncConversationListProjection,
       workspaceId,
       workspacePath

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -17,6 +17,10 @@ import {
   managedAgentRoundedIconUrl
 } from "./managedAgentIcons";
 import { RichTextMentionReadonly } from "@tutti-os/ui-rich-text/editor";
+import {
+  parsedDocumentCacheStatsForTests,
+  resetParsedDocumentCacheForTests
+} from "./parsedDocumentCache";
 
 describe("RichTextMentionReadonly compatibility", () => {
   it("uses the resolved label without adding the persisted trigger", () => {
@@ -41,6 +45,31 @@ describe("AgentMessageMarkdown", () => {
   afterEach(() => {
     vi.useRealTimers();
     resetCachedMarkdownImagesForTests();
+    resetParsedDocumentCacheForTests();
+  });
+
+  it("reuses the parsed document after a settled message remounts", () => {
+    resetParsedDocumentCacheForTests();
+    const first = render(
+      <AgentMessageMarkdown
+        content="A **settled** historical message"
+        documentCacheKey="message-1:version-1"
+      />
+    );
+    first.unmount();
+
+    render(
+      <AgentMessageMarkdown
+        content="A **settled** historical message"
+        documentCacheKey="message-1:version-1"
+      />
+    );
+
+    expect(parsedDocumentCacheStatsForTests()).toMatchObject({
+      entries: 1,
+      hits: 1,
+      misses: 1
+    });
   });
 
   it("renders a workspace-reference mention as one chip without a file-count badge", () => {

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -65,6 +65,7 @@ import {
 } from "./AgentMessageMarkdownRenderers";
 import { MarkdownMedia } from "./AgentMessageMarkdownMedia";
 import { remarkLiteralAutolinkBoundary } from "./remarkLiteralAutolinkBoundary";
+import { cachedMarkdownParser } from "./cachedMarkdownParser";
 export { resetCachedMarkdownImagesForTests } from "./AgentMessageMarkdownMedia";
 export type { StreamingMarkdownBlock } from "./agentMessageMarkdownRuntime";
 export { splitStreamingMarkdownBlocks } from "./agentMessageMarkdownRuntime";
@@ -107,6 +108,7 @@ export interface AgentMessageMarkdownWorkspaceLinkContext {
 
 interface AgentMessageMarkdownProps {
   content: string;
+  documentCacheKey?: string;
   onLinkClick?: (href: string) => void;
   onLinkAction?: (action: WorkspaceLinkAction) => void;
   workspaceLinkContext?: AgentMessageMarkdownWorkspaceLinkContext | null;
@@ -140,9 +142,13 @@ export type MarkdownDomProps<Tag extends keyof JSX.IntrinsicElements> =
 type ReactMarkdownComponents = ComponentPropsWithoutRef<
   typeof ReactMarkdown
 >["components"];
+type ReactMarkdownRemarkPlugins = NonNullable<
+  ComponentPropsWithoutRef<typeof ReactMarkdown>["remarkPlugins"]
+>;
 
 export function AgentMessageMarkdown({
   content,
+  documentCacheKey,
   onLinkClick,
   onLinkAction,
   workspaceLinkContext = null,
@@ -196,6 +202,20 @@ export function AgentMessageMarkdown({
         )
       ),
     [normalizePlainIssueMentionTitle, stabilizedContent]
+  );
+  const settledRemarkPlugins = useMemo<ReactMarkdownRemarkPlugins>(
+    () => [
+      remarkGfm,
+      remarkLiteralAutolinkBoundary,
+      [
+        cachedMarkdownParser,
+        {
+          cacheKey: documentCacheKey?.trim() || "content",
+          content: normalizedContent
+        }
+      ]
+    ],
+    [documentCacheKey, normalizedContent]
   );
   const isMentionOnly = isMentionOnlyMarkdownContent(normalizedContent);
   const handleLinkClick = useCallback(
@@ -306,7 +326,7 @@ export function AgentMessageMarkdown({
           />
         ) : (
           <ReactMarkdown
-            remarkPlugins={[remarkGfm, remarkLiteralAutolinkBoundary]}
+            remarkPlugins={settledRemarkPlugins}
             rehypePlugins={[[rehypeSanitize, MARKDOWN_SANITIZE_SCHEMA]]}
             urlTransform={markdownUrlTransform}
             components={markdownComponents}

--- a/packages/agent/gui/shared/AgentRichTextReadonly.spec.tsx
+++ b/packages/agent/gui/shared/AgentRichTextReadonly.spec.tsx
@@ -6,9 +6,14 @@ import {
   registerAgentCustomMentionKind,
   resetAgentCustomMentionKindsForTests
 } from "./agentCustomMentionKinds";
+import {
+  parsedDocumentCacheStatsForTests,
+  resetParsedDocumentCacheForTests
+} from "./parsedDocumentCache";
 
 afterEach(() => {
   resetAgentCustomMentionKindsForTests();
+  resetParsedDocumentCacheForTests();
   vi.restoreAllMocks();
 });
 
@@ -20,6 +25,30 @@ describe("AgentRichTextReadonly", () => {
 
     expect(container).toHaveTextContent("First-frame user message");
     expect(container.querySelector(".ProseMirror")).not.toBeNull();
+  });
+
+  it("reuses the parsed document after a historical message remounts", () => {
+    resetParsedDocumentCacheForTests();
+    const first = render(
+      <AgentRichTextReadonly
+        value="Historical user message"
+        documentCacheKey="message-1:version-1"
+      />
+    );
+    first.unmount();
+
+    render(
+      <AgentRichTextReadonly
+        value="Historical user message"
+        documentCacheKey="message-1:version-1"
+      />
+    );
+
+    expect(parsedDocumentCacheStatsForTests()).toMatchObject({
+      entries: 1,
+      hits: 1,
+      misses: 1
+    });
   });
 
   it("mounts a transcript window without creating editable views or reading DOM selection", () => {

--- a/packages/agent/gui/shared/AgentRichTextReadonly.tsx
+++ b/packages/agent/gui/shared/AgentRichTextReadonly.tsx
@@ -13,6 +13,7 @@ import {
   useAgentTargetPresentations,
   type AgentMessageMarkdownAgentTarget
 } from "./AgentTargetPresentationContext";
+import { readParsedDocumentCache } from "./parsedDocumentCache";
 
 const EMPTY_WORKSPACE_APP_ICONS: readonly AgentMessageMarkdownWorkspaceAppIcon[] =
   [];
@@ -20,6 +21,7 @@ const EMPTY_SKILLS: readonly AgentGUIProviderSkillOption[] = [];
 
 interface AgentRichTextReadonlyProps {
   value: string;
+  documentCacheKey?: string;
   className?: string;
   editorClassName?: string;
   onLinkClick?: (href: string) => void;
@@ -30,6 +32,7 @@ interface AgentRichTextReadonlyProps {
 
 export function AgentRichTextReadonly({
   value,
+  documentCacheKey,
   className,
   editorClassName,
   onLinkClick,
@@ -40,15 +43,29 @@ export function AgentRichTextReadonly({
   "use memo";
   const contextAgentTargets = useAgentTargetPresentations();
   const effectiveAgentTargets = agentTargets ?? contextAgentTargets;
+  const skillsCacheSource = useMemo(
+    () => JSON.stringify(availableSkills),
+    [availableSkills]
+  );
+  const parsedDoc = useMemo(
+    () =>
+      readParsedDocumentCache({
+        namespace: "rich-text",
+        identity: documentCacheKey?.trim() || "content",
+        source: `${value}\u0000${skillsCacheSource}`,
+        create: () =>
+          plainTextToAgentRichTextDoc(value, { skills: availableSkills })
+      }),
+    [availableSkills, documentCacheKey, skillsCacheSource, value]
+  );
   const contentDoc = useMemo(
     () =>
-      plainTextToAgentRichTextDocWithMentionPresentations(
-        value,
-        availableSkills,
+      hydrateAgentRichTextMentionPresentations(
+        parsedDoc,
         workspaceAppIcons,
         effectiveAgentTargets
       ),
-    [availableSkills, effectiveAgentTargets, value, workspaceAppIcons]
+    [effectiveAgentTargets, parsedDoc, workspaceAppIcons]
   );
   const isMentionOnly = isMentionOnlyRichTextDoc(contentDoc);
   const extensions = useMemo(
@@ -135,13 +152,12 @@ function isMentionOnlyRichTextDoc(doc: JSONContent): boolean {
   );
 }
 
-function plainTextToAgentRichTextDocWithMentionPresentations(
-  value: string,
-  availableSkills: readonly AgentGUIProviderSkillOption[],
+function hydrateAgentRichTextMentionPresentations(
+  parsedDoc: JSONContent,
   workspaceAppIcons: readonly AgentMessageMarkdownWorkspaceAppIcon[],
   agentTargets: readonly AgentMessageMarkdownAgentTarget[]
 ): JSONContent {
-  let doc = plainTextToAgentRichTextDoc(value, { skills: availableSkills });
+  let doc = parsedDoc;
   if (workspaceAppIcons.length > 0) {
     doc = hydrateWorkspaceAppMentionIcons(doc, workspaceAppIcons);
   }

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -163,6 +163,7 @@ export function AgentMessageBlock({
       ) : isUser ? (
         <AgentRichTextReadonly
           value={message.body}
+          documentCacheKey={message.id}
           className={`workspace-agents-status-panel__detail-user-message ${styles.userMessageBubble}`}
           editorClassName="text-[inherit]"
           onLinkClick={handleLinkClick}
@@ -204,6 +205,7 @@ export function AgentMessageBlock({
       ) : (
         <AgentMessageMarkdown
           content={message.body}
+          documentCacheKey={message.id}
           className={styles.assistantMarkdown}
           onLinkAction={onLinkAction}
           workspaceLinkContext={{

--- a/packages/agent/gui/shared/cachedMarkdownParser.ts
+++ b/packages/agent/gui/shared/cachedMarkdownParser.ts
@@ -1,0 +1,31 @@
+import { readParsedDocumentCache } from "./parsedDocumentCache";
+
+type MarkdownParser = (...args: unknown[]) => unknown;
+
+interface MarkdownProcessor {
+  parser?: unknown;
+}
+
+interface CachedMarkdownParserOptions {
+  cacheKey: string;
+  content: string;
+}
+
+export function cachedMarkdownParser(
+  this: MarkdownProcessor,
+  options: CachedMarkdownParserOptions
+): void {
+  if (typeof this.parser !== "function") {
+    return;
+  }
+  const parse = this.parser as MarkdownParser;
+  this.parser = (...args: unknown[]) =>
+    structuredClone(
+      readParsedDocumentCache({
+        namespace: "markdown",
+        identity: options.cacheKey,
+        source: options.content,
+        create: () => parse.apply(this, args)
+      })
+    );
+}

--- a/packages/agent/gui/shared/parsedDocumentCache.spec.ts
+++ b/packages/agent/gui/shared/parsedDocumentCache.spec.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  parsedDocumentCacheStatsForTests,
+  readParsedDocumentCache,
+  resetParsedDocumentCacheForTests
+} from "./parsedDocumentCache";
+
+describe("parsedDocumentCache", () => {
+  afterEach(() => {
+    resetParsedDocumentCacheForTests();
+  });
+
+  it("is bounded and keeps recently used documents", () => {
+    const first = { type: "doc" };
+    readParsedDocumentCache({
+      namespace: "test",
+      identity: "first",
+      source: "first",
+      create: () => first
+    });
+    expect(
+      readParsedDocumentCache({
+        namespace: "test",
+        identity: "first",
+        source: "first",
+        create: () => ({ type: "unexpected" })
+      })
+    ).toBe(first);
+
+    for (let index = 0; index < 300; index += 1) {
+      readParsedDocumentCache({
+        namespace: "test",
+        identity: `message-${index}`,
+        source: `message-${index}`,
+        create: () => ({ index })
+      });
+    }
+
+    expect(parsedDocumentCacheStatsForTests()).toMatchObject({
+      entries: 256,
+      hits: 1,
+      misses: 301
+    });
+  });
+});

--- a/packages/agent/gui/shared/parsedDocumentCache.ts
+++ b/packages/agent/gui/shared/parsedDocumentCache.ts
@@ -1,0 +1,96 @@
+const MAX_CACHE_ENTRIES = 256;
+const MAX_CACHE_SOURCE_CHARS = 2_000_000;
+
+interface ParsedDocumentCacheEntry {
+  source: string;
+  value: unknown;
+  weight: number;
+}
+
+const parsedDocumentCache = new Map<string, ParsedDocumentCacheEntry>();
+const parsedDocumentCacheStats = {
+  hits: 0,
+  misses: 0,
+  sourceChars: 0
+};
+
+export function readParsedDocumentCache<T>(input: {
+  namespace: string;
+  identity: string;
+  source: string;
+  create: () => T;
+}): T {
+  const key = `${input.namespace}:${input.identity}:${hashCacheSource(input.source)}`;
+  const cached = parsedDocumentCache.get(key);
+  if (cached?.source === input.source) {
+    parsedDocumentCache.delete(key);
+    parsedDocumentCache.set(key, cached);
+    parsedDocumentCacheStats.hits += 1;
+    return cached.value as T;
+  }
+
+  parsedDocumentCacheStats.misses += 1;
+  const value = input.create();
+  if (input.source.length > MAX_CACHE_SOURCE_CHARS) {
+    return value;
+  }
+  if (cached) {
+    parsedDocumentCache.delete(key);
+    parsedDocumentCacheStats.sourceChars -= cached.weight;
+  }
+  const entry = {
+    source: input.source,
+    value,
+    weight: input.source.length
+  };
+  parsedDocumentCache.set(key, entry);
+  parsedDocumentCacheStats.sourceChars += entry.weight;
+  trimParsedDocumentCache();
+  return value;
+}
+
+export function resetParsedDocumentCacheForTests(): void {
+  parsedDocumentCache.clear();
+  parsedDocumentCacheStats.hits = 0;
+  parsedDocumentCacheStats.misses = 0;
+  parsedDocumentCacheStats.sourceChars = 0;
+}
+
+export function parsedDocumentCacheStatsForTests(): {
+  entries: number;
+  hits: number;
+  misses: number;
+  sourceChars: number;
+} {
+  return {
+    entries: parsedDocumentCache.size,
+    hits: parsedDocumentCacheStats.hits,
+    misses: parsedDocumentCacheStats.misses,
+    sourceChars: parsedDocumentCacheStats.sourceChars
+  };
+}
+
+function trimParsedDocumentCache(): void {
+  while (
+    parsedDocumentCache.size > MAX_CACHE_ENTRIES ||
+    parsedDocumentCacheStats.sourceChars > MAX_CACHE_SOURCE_CHARS
+  ) {
+    const oldest = parsedDocumentCache.entries().next().value as
+      | [string, ParsedDocumentCacheEntry]
+      | undefined;
+    if (!oldest) {
+      return;
+    }
+    parsedDocumentCache.delete(oldest[0]);
+    parsedDocumentCacheStats.sourceChars -= oldest[1].weight;
+  }
+}
+
+function hashCacheSource(source: string): string {
+  let hash = 2_166_136_261;
+  for (let index = 0; index < source.length; index += 1) {
+    hash ^= source.charCodeAt(index);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return `${source.length}:${hash >>> 0}`;
+}

--- a/tools/degradation-baseline/agent-gui.json
+++ b/tools/degradation-baseline/agent-gui.json
@@ -19,7 +19,7 @@
       "packages/agent/gui/shared/AgentMessageMarkdown.tsx": 7,
       "packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx": 10
     },
-    "effectCount": 139,
+    "effectCount": 138,
     "fileLines": {
       "packages/agent/gui/app/renderer/i18n/locales/en.ts": 1893,
       "packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts": 1773


### PR DESCRIPTION
## Summary

- cache bounded pure Markdown ASTs and rich-text documents for settled transcript messages
- preserve canonical entity and snapshot-slice references when reconciliation returns semantically unchanged data
- stop composer synchronization from forcing Session detail reloads or composer-option refreshes on ordinary Session selection
- scope the mounted project-existence probe by normalized project path

## Tests

- `pnpm check:changed -- --push-ready` — passed 14 lanes

## Notes

- A post-change 15-second Electron trace showed zero composer-options requests across five Session selections, project checks only when the selected path changed, and one `Session -> Messages -> Session` hydration chain per selection
- The separate one-frame virtualized transcript overlap found during follow-up testing is intentionally excluded from this PR
- This changes frontend reconciliation and presentation work only; Agent Host lifecycle semantics are unchanged
