### PR TITLE
feat(agent-gui): show participant header above conversation messages

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIConversation.styles.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIConversation.styles.ts
@@ -37,6 +37,9 @@ const styles = {
   assistantMessageFlow: "agent-gui-conversation__assistant-message-flow",
   participantMessageLayout:
     "agent-gui-conversation__participant-message-layout",
+  participantMessageHeader:
+    "agent-gui-conversation__participant-message-header",
+  participantName: "agent-gui-conversation__participant-name",
   participantMessageContent:
     "agent-gui-conversation__participant-message-content",
   participantAvatar: "agent-gui-conversation__participant-avatar",

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -3774,16 +3774,78 @@ aside.workspace-agents-status-panel
   display: grid;
   width: 100%;
   min-width: 0;
-  column-gap: 10px;
-  align-items: start;
 }
 
-.agent-gui-conversation__participant-message-layout[data-agent-message-speaker="assistant"] {
-  grid-template-columns: 32px minmax(0, 1fr);
+.agent-gui-conversation__participant-message-header {
+  display: flex;
+  max-width: 100%;
+  min-width: 0;
+  align-items: center;
+  column-gap: 8px;
 }
 
-.agent-gui-conversation__participant-message-layout[data-agent-message-speaker="user"] {
-  grid-template-columns: minmax(0, 1fr) 32px;
+/* The participant header sits directly above the thinking/tool-call info and
+   the message content, so it uses a tighter gap than the default 24px flow
+   spacing. */
+.agent-gui-conversation__assistant-message-flow
+  > .agent-gui-conversation__participant-message-header
+  + * {
+  margin-top: 8px;
+}
+
+/* Content below the header aligns with the participant name: assistant
+   content insets to the name's left edge, user content to the name's right
+   edge (28px avatar + 8px gap). The header is pulled back over the padding so
+   it stays flush with the flow edge. */
+.agent-gui-conversation__assistant-message-flow[data-agent-message-flow-participant="true"] {
+  padding-left: 36px;
+}
+
+.agent-gui-conversation__assistant-message-flow[data-agent-message-flow-participant="true"]
+  > .agent-gui-conversation__participant-message-header {
+  margin-left: -36px;
+}
+
+.agent-gui-conversation__user-message-flow[data-agent-message-flow-participant="true"] {
+  padding-right: 36px;
+}
+
+.agent-gui-conversation__user-message-flow[data-agent-message-flow-participant="true"]
+  > .agent-gui-conversation__participant-message-header {
+  margin-right: -36px;
+}
+
+.agent-gui-conversation__participant-name {
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 18px;
+  color: var(--text-secondary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Hairline ring + crisp circular edge for participant avatars. The ring is
+   painted on the avatar root (paint, anti-aliased on composited layers); the
+   radial-gradient mask on the surface keeps the clipped image edge smooth in
+   virtualized/composited lists where border-radius clipping is not
+   anti-aliased. */
+.agent-gui-conversation__participant-avatar {
+  border-radius: 50%;
+  box-shadow: 0 0 0 0.5px var(--line-2);
+}
+
+.agent-gui-conversation__participant-avatar [data-slot="avatar-surface"] {
+  -webkit-mask-image: radial-gradient(
+    circle closest-side,
+    #000 calc(100% - 1px),
+    transparent
+  );
+  mask-image: radial-gradient(
+    circle closest-side,
+    #000 calc(100% - 1px),
+    transparent
+  );
 }
 
 .agent-gui-conversation__participant-message-content {
@@ -3796,10 +3858,6 @@ aside.workspace-agents-status-panel
   > .agent-gui-conversation__participant-message-content {
   row-gap: 14px;
   justify-items: end;
-}
-
-.agent-gui-conversation__participant-avatar {
-  margin-top: 2px;
 }
 
 .agent-gui-conversation__message-group {

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -30,6 +30,7 @@ import type {
   AgentConversationParticipantPresentation
 } from "../contracts/agentConversationParticipantPresentation";
 import { AgentMessageDetailsDisclosure } from "./AgentMessageDetailsDisclosure";
+import { AgentToolGroupRow } from "./AgentToolGroupRow";
 import {
   AgentVisibleErrorMessage,
   recoverVisibleErrorFromMessage
@@ -42,6 +43,8 @@ import { CanvasNodeGhostIconButton } from "../../../contexts/workspace/presentat
 import { AgentUserImageGrid } from "./AgentMessageImages";
 
 const MESSAGE_COPY_FEEDBACK_MS = 1400;
+const DEFAULT_TOOL_CALLS_LABEL = (count: number): string =>
+  `${count} tool calls`;
 const TRANSPORT_RETRY_PROGRESS_PATTERN =
   /\b(reconnect(?:ing)?(?:\s*(?:\.\.\.|…|[.。]+|:|-))?\s*\(?\d+\s*\/\s*\d+\)?)/i;
 // All system-notice banners use the light-red danger surface. Yellow/warning
@@ -56,6 +59,7 @@ interface AgentMessageBlockProps {
   row: AgentMessageRowVM;
   onLinkAction?: (action: WorkspaceLinkAction) => void;
   thinkingLabel: string;
+  toolCallsLabel?: (count: number) => string;
   onAuthLogin?: (provider?: string | null) => void;
   // The conversation's provider, so a failed message recovered as an env error
   // routes its wizard CTA to the right provider.
@@ -74,6 +78,7 @@ export function AgentMessageBlock({
   row,
   onLinkAction,
   thinkingLabel,
+  toolCallsLabel = DEFAULT_TOOL_CALLS_LABEL,
   onAuthLogin,
   provider,
   availableSkills,
@@ -139,6 +144,22 @@ export function AgentMessageBlock({
         />
       ))
     : null;
+
+  const leadingToolContent =
+    !isUser && row.leadingToolRows && row.leadingToolRows.length > 0
+      ? row.leadingToolRows.map((toolRow) => (
+          <AgentToolGroupRow
+            key={toolRow.id}
+            row={toolRow}
+            label={toolCallsLabel}
+            thinkingLabel={thinkingLabel}
+            onLinkClick={handleLinkClick}
+            previewMode={previewMode}
+            showRawTimelineJson={showRawTimelineJson}
+            rawTimelineJsonLabel={rawTimelineJsonLabel}
+          />
+        ))
+      : null;
 
   const messageContent = row.messages.map((message) => {
     const rawTimelineJson =
@@ -268,31 +289,74 @@ export function AgentMessageBlock({
           ? "true"
           : undefined
       }
+      data-agent-message-flow-participant={
+        showParticipant ? "true" : undefined
+      }
     >
+      {showParticipant ? (
+        <AgentConversationParticipantHeader
+          presentation={enabledParticipantPresentation}
+          speaker={row.speaker}
+        />
+      ) : null}
       {thinkingContent}
+      {leadingToolContent}
       {showParticipant ? (
         <div
           className={styles.participantMessageLayout}
           data-agent-message-speaker={row.speaker}
         >
-          {!isUser ? (
-            <AgentConversationParticipantAvatar
-              presentation={enabledParticipantPresentation}
-              speaker="assistant"
-            />
-          ) : null}
           <div className={styles.participantMessageContent}>
             {messageContent}
           </div>
-          {isUser ? (
-            <AgentConversationParticipantAvatar
-              presentation={enabledParticipantPresentation}
-              speaker="user"
-            />
-          ) : null}
         </div>
       ) : (
         messageContent
+      )}
+    </div>
+  );
+}
+
+function AgentConversationParticipantHeader({
+  presentation,
+  speaker
+}: {
+  presentation: Extract<
+    AgentConversationParticipantPresentation,
+    { enabled: true }
+  >;
+  speaker: AgentMessageRowVM["speaker"];
+}): JSX.Element {
+  const participant: AgentConversationParticipantIdentity | null =
+    presentation.status === "loading"
+      ? null
+      : speaker === "user"
+        ? presentation.user
+        : presentation.agent;
+  const nameContent = participant ? (
+    <span className={styles.participantName}>{participant.name}</span>
+  ) : null;
+  const avatarContent = (
+    <AgentConversationParticipantAvatar
+      presentation={presentation}
+      speaker={speaker}
+    />
+  );
+  return (
+    <div
+      className={styles.participantMessageHeader}
+      data-agent-conversation-participant-header={speaker}
+    >
+      {speaker === "user" ? (
+        <>
+          {nameContent}
+          {avatarContent}
+        </>
+      ) : (
+        <>
+          {avatarContent}
+          {nameContent}
+        </>
       )}
     </div>
   );
@@ -316,7 +380,7 @@ function AgentConversationParticipantAvatar({
         data-agent-conversation-participant-avatar={speaker}
         label=""
         loading
-        size="md"
+        size={28}
       />
     );
   }
@@ -329,7 +393,7 @@ function AgentConversationParticipantAvatar({
       className={styles.participantAvatar}
       data-agent-conversation-participant-avatar={speaker}
       label={participant.name}
-      size="md"
+      size={28}
       src={participant.avatarUrl}
     />
   );

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -368,7 +368,7 @@ describe("AgentTranscriptItemView render stability", () => {
     expect(screen.getByText("User asks for a fix")).toBeInTheDocument();
   });
 
-  it("places the agent avatar left and the user avatar right from external identity data", () => {
+  it("renders the avatar and sender name in a header row above the message", () => {
     const participantPresentation = {
       enabled: true,
       status: "ready",
@@ -400,17 +400,82 @@ describe("AgentTranscriptItemView render stability", () => {
     const userLayout = container.querySelector(
       '.agent-gui-conversation__participant-message-layout[data-agent-message-speaker="user"]'
     );
-    expect(assistantLayout?.firstElementChild).toHaveAttribute(
-      "aria-label",
-      "Codex"
+    const assistantHeader = container.querySelector(
+      '[data-agent-conversation-participant-header="assistant"]'
     );
-    expect(assistantLayout?.lastElementChild).toHaveClass(
-      "agent-gui-conversation__participant-message-content"
+    expect(assistantHeader).toHaveClass(
+      "agent-gui-conversation__participant-message-header"
     );
-    expect(userLayout?.firstElementChild).toHaveClass(
-      "agent-gui-conversation__participant-message-content"
+    expect(
+      assistantHeader?.querySelector(
+        '[data-agent-conversation-participant-avatar="assistant"]'
+      )
+    ).toHaveAttribute("aria-label", "Codex");
+    expect(assistantHeader).toHaveTextContent("Codex");
+    // The header row renders above the thinking/tool-call info and the
+    // message content.
+    expect(
+      assistantHeader?.compareDocumentPosition(assistantLayout as Element)
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    const userHeader = container.querySelector(
+      '[data-agent-conversation-participant-header="user"]'
     );
-    expect(userLayout?.lastElementChild).toHaveAttribute("aria-label", "Alice");
+    expect(userHeader).toHaveClass(
+      "agent-gui-conversation__participant-message-header"
+    );
+    expect(
+      userHeader?.querySelector(
+        '[data-agent-conversation-participant-avatar="user"]'
+      )
+    ).toHaveAttribute("aria-label", "Alice");
+    expect(userHeader).toHaveTextContent("Alice");
+    expect(
+      userHeader?.compareDocumentPosition(userLayout as Element)
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it("renders leading tool rows under the participant header above the message", () => {
+    const participantPresentation = {
+      enabled: true,
+      status: "ready",
+      agent: { name: "Codex" },
+      user: { name: "Alice" }
+    } as const;
+    const leadingToolGroup: AgentToolGroupRowVM = {
+      kind: "tool-group",
+      id: "leading-tools-1",
+      turnId: "turn-1",
+      grouped: true,
+      calls: [toolCall(), toolCall()],
+      entries: [],
+      occurredAtUnixMs: 1
+    };
+    const row: AgentMessageRowVM = {
+      ...assistantMessageRow(),
+      leadingToolRows: [leadingToolGroup]
+    };
+    const { container, getByText } = render(
+      <AgentMessageBlock
+        workspaceRoot="/workspace/demo"
+        basePath="/workspace/demo"
+        row={row}
+        thinkingLabel="Thought process"
+        participantPresentation={participantPresentation}
+      />
+    );
+
+    const header = container.querySelector(
+      '[data-agent-conversation-participant-header="assistant"]'
+    );
+    const toolContent = getByText("Tool group");
+    const messageContent = getByText(/Assistant answer/);
+    expect(header).not.toBeNull();
+    expect(header?.compareDocumentPosition(toolContent)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
+    expect(toolContent.compareDocumentPosition(messageContent)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
   });
 
   it("copies user message text through the agent host clipboard", async () => {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.tsx
@@ -93,6 +93,7 @@ export const AgentTranscriptItemView = memo(function AgentTranscriptItemView({
           workspaceAppIcons={workspaceAppIcons}
           previewMode={previewMode}
           thinkingLabel={labels.thinkingLabel}
+          toolCallsLabel={labels.toolCallsLabel}
           showRawTimelineJson={showRawTimelineJson}
           rawTimelineJsonLabel={labels.rawTimelineJson}
           participantPresentation={participantPresentation}

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
@@ -235,18 +235,17 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
   const participantHeadersEnabled = participantPresentation?.enabled === true;
   // Participant-header presentation (Agent board session detail): tool-group
   // rows attach to the assistant message that follows them instead of sitting
-  // after the previous message, and turn dividers key off user messages.
-  const displayRows = useMemo(
-    () =>
-      participantHeadersEnabled
-        ? attachLeadingToolRowsToFollowingMessages(conversation.rows)
-        : conversation.rows,
-    [conversation.rows, participantHeadersEnabled]
-  );
-  const rowKeys = useMemo(
-    () => displayRows.map(transcriptRowKey),
-    [displayRows]
-  );
+  // after the previous message, and turn dividers key off user messages. Rows
+  // and their keys share a single projection so this component stays within
+  // the degradation-check memo budget.
+  const transcriptRowSet = useMemo(() => {
+    const rows = participantHeadersEnabled
+      ? attachLeadingToolRowsToFollowingMessages(conversation.rows)
+      : conversation.rows;
+    return { rows, rowKeys: rows.map(transcriptRowKey) };
+  }, [conversation.rows, participantHeadersEnabled]);
+  const displayRows = transcriptRowSet.rows;
+  const rowKeys = transcriptRowSet.rowKeys;
   const turnGroups = useMemo(
     () => buildAgentTranscriptTurnGroups(displayRows, rowKeys),
     [displayRows, rowKeys]

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
@@ -27,10 +27,12 @@ import {
   scrollTranscriptRowIntoView
 } from "./AgentMessageLocatorRail";
 import {
+  attachLeadingToolRowsToFollowingMessages,
   buildAgentTranscriptTurnGroups,
   buildTurnGroupIndexByRowIndex,
   buildUserMessageLocatorItems,
   escapeCssString,
+  findParticipantTurnDividerRowIndexes,
   findTurnDividerRowIndexes,
   transcriptRowKey,
   useEnteringTranscriptRows,
@@ -230,13 +232,24 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
   const virtualizerHostRef = useRef<HTMLDivElement | null>(null);
   const [virtualScrollElement, setVirtualScrollElement] =
     useState<HTMLElement | null>(null);
+  const participantHeadersEnabled = participantPresentation?.enabled === true;
+  // Participant-header presentation (Agent board session detail): tool-group
+  // rows attach to the assistant message that follows them instead of sitting
+  // after the previous message, and turn dividers key off user messages.
+  const displayRows = useMemo(
+    () =>
+      participantHeadersEnabled
+        ? attachLeadingToolRowsToFollowingMessages(conversation.rows)
+        : conversation.rows,
+    [conversation.rows, participantHeadersEnabled]
+  );
   const rowKeys = useMemo(
-    () => conversation.rows.map(transcriptRowKey),
-    [conversation.rows]
+    () => displayRows.map(transcriptRowKey),
+    [displayRows]
   );
   const turnGroups = useMemo(
-    () => buildAgentTranscriptTurnGroups(conversation.rows, rowKeys),
-    [conversation.rows, rowKeys]
+    () => buildAgentTranscriptTurnGroups(displayRows, rowKeys),
+    [displayRows, rowKeys]
   );
   const turnGroupIndexByRowIndex = useMemo(
     () => buildTurnGroupIndexByRowIndex(turnGroups),
@@ -245,11 +258,11 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
   const userMessageLocatorItems = useMemo(
     () =>
       buildUserMessageLocatorItems(
-        conversation.rows,
+        displayRows,
         rowKeys,
         turnGroupIndexByRowIndex
       ),
-    [conversation.rows, rowKeys, turnGroupIndexByRowIndex]
+    [displayRows, rowKeys, turnGroupIndexByRowIndex]
   );
   const enteringRowKeys = useEnteringTranscriptRows(rowKeys);
   const handleToolGroupExpandedChange = useCallback(
@@ -274,8 +287,11 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
     [conversation.sourceDetail.turns]
   );
   const dividerRowIndexes = useMemo(
-    () => findTurnDividerRowIndexes(turnIndexById, conversation.rows),
-    [conversation.rows, turnIndexById]
+    () =>
+      participantHeadersEnabled
+        ? findParticipantTurnDividerRowIndexes(displayRows)
+        : findTurnDividerRowIndexes(turnIndexById, displayRows),
+    [displayRows, turnIndexById, participantHeadersEnabled]
   );
   const canonicalTurnById = new Map(
     (conversation.sourceDetail.sessionTurns ?? []).map((turn) => [
@@ -383,7 +399,7 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
   ): JSX.Element => {
     const rowKey =
       renderKey ??
-      (conversation.rows[rowIndex] === row
+      (displayRows[rowIndex] === row
         ? (rowKeys[rowIndex] ?? transcriptRowKey(row))
         : transcriptRowKey(row));
     const shouldAnimateEnter =

--- a/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.spec.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import type { AgentTranscriptPresentationKind } from "../contracts/agentTranscriptPresentation";
 import type { AgentTranscriptRowVM } from "../contracts/agentTranscriptRowVM";
 import {
+  attachLeadingToolRowsToFollowingMessages,
   buildAgentTranscriptTurnGroups,
+  findParticipantTurnDividerRowIndexes,
   findTurnDividerRowIndexes,
   transcriptRowKey
 } from "./agentTranscriptModel";
@@ -114,3 +116,102 @@ function goalControlRow(): AgentTranscriptRowVM {
     occurredAtUnixMs: 2
   };
 }
+
+function userRow(turnId: string): AgentTranscriptRowVM {
+  return {
+    kind: "message",
+    id: `row:user:${turnId}`,
+    turnId,
+    speaker: "user",
+    messages: [
+      {
+        kind: "message-content",
+        id: `message:user:${turnId}`,
+        turnId,
+        body: "user question",
+        presentationKind: "content",
+        occurredAtUnixMs: 1
+      }
+    ],
+    thinking: [],
+    occurredAtUnixMs: 1
+  };
+}
+
+function toolGroupRow(id: string, turnId: string): AgentTranscriptRowVM {
+  return {
+    kind: "tool-group",
+    id: `tool-group:${id}`,
+    turnId,
+    grouped: true,
+    calls: [],
+    entries: [],
+    occurredAtUnixMs: 1
+  };
+}
+
+describe("findParticipantTurnDividerRowIndexes", () => {
+  it("marks every user message after the first row as a turn divider", () => {
+    expect([
+      ...findParticipantTurnDividerRowIndexes([
+        userRow("turn-1"),
+        row("turn-1"),
+        userRow("turn-2"),
+        row("turn-2")
+      ])
+    ]).toEqual([2]);
+  });
+
+  it("marks a user message that follows another user message", () => {
+    expect([
+      ...findParticipantTurnDividerRowIndexes([
+        userRow("turn-1"),
+        userRow("turn-2")
+      ])
+    ]).toEqual([1]);
+  });
+
+  it("never marks the first row", () => {
+    expect([
+      ...findParticipantTurnDividerRowIndexes([userRow("turn-1")])
+    ]).toEqual([]);
+  });
+});
+
+describe("attachLeadingToolRowsToFollowingMessages", () => {
+  it("moves tool-group rows into the assistant message that follows them", () => {
+    const rows = [
+      row("turn-1"),
+      toolGroupRow("a", "turn-1"),
+      toolGroupRow("b", "turn-1"),
+      row("turn-1")
+    ];
+    const result = attachLeadingToolRowsToFollowingMessages(rows);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.kind).toBe("message");
+    const merged = result[1];
+    expect(merged?.kind).toBe("message");
+    if (merged?.kind !== "message") {
+      throw new Error("Expected a message row");
+    }
+    expect(merged.leadingToolRows?.map((toolRow) => toolRow.id)).toEqual([
+      "tool-group:a",
+      "tool-group:b"
+    ]);
+  });
+
+  it("does not attach tool-group rows to user messages", () => {
+    const rows = [toolGroupRow("a", "turn-1"), userRow("turn-1")];
+    const result = attachLeadingToolRowsToFollowingMessages(rows);
+
+    expect(result.map((item) => item.kind)).toEqual(["tool-group", "message"]);
+  });
+
+  it("keeps trailing tool-group rows standalone", () => {
+    const rows = [row("turn-1"), toolGroupRow("a", "turn-1")];
+    const result = attachLeadingToolRowsToFollowingMessages(rows);
+
+    expect(result.map((item) => item.kind)).toEqual(["message", "tool-group"]);
+  });
+});

--- a/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.ts
@@ -217,3 +217,65 @@ export function findTurnDividerRowIndexes(
 
   return dividerRowIndexes;
 }
+
+/**
+ * Participant-header presentation (Agent board session detail): a new user
+ * message always starts the next turn, so the divider goes between the
+ * previous turn's last row and every user message row — regardless of whether
+ * the rebuilt session carries canonical turn ids.
+ */
+export function findParticipantTurnDividerRowIndexes(
+  rows: ReadonlyArray<AgentConversationVM["rows"][number]>
+): ReadonlySet<number> {
+  const dividerRowIndexes = new Set<number>();
+  rows.forEach((row, rowIndex) => {
+    if (rowIndex > 0 && row.kind === "message" && row.speaker === "user") {
+      dividerRowIndexes.add(rowIndex);
+    }
+  });
+  return dividerRowIndexes;
+}
+
+/**
+ * Participant-header presentation: standalone tool-group rows belong to the
+ * work that produced the NEXT assistant message, so they attach to that
+ * message (rendered inside its block) instead of sitting after the previous
+ * one. Trailing tool rows with no following assistant message stay standalone.
+ */
+export function attachLeadingToolRowsToFollowingMessages(
+  rows: ReadonlyArray<AgentConversationVM["rows"][number]>
+): AgentConversationVM["rows"] {
+  const result: AgentConversationVM["rows"] = [];
+  let pendingToolRows: Extract<
+    AgentConversationVM["rows"][number],
+    { kind: "tool-group" }
+  >[] = [];
+  for (const row of rows) {
+    if (row.kind === "tool-group") {
+      pendingToolRows.push(row);
+      continue;
+    }
+    if (row.kind === "message" && row.speaker === "assistant") {
+      if (pendingToolRows.length > 0) {
+        result.push({
+          ...row,
+          leadingToolRows: [
+            ...(row.leadingToolRows ?? []),
+            ...pendingToolRows
+          ]
+        });
+        pendingToolRows = [];
+        continue;
+      }
+      result.push(row);
+      continue;
+    }
+    if (pendingToolRows.length > 0) {
+      result.push(...pendingToolRows);
+      pendingToolRows = [];
+    }
+    result.push(row);
+  }
+  result.push(...pendingToolRows);
+  return result;
+}

--- a/packages/agent/gui/shared/agentConversation/contracts/agentMessageRowVM.ts
+++ b/packages/agent/gui/shared/agentConversation/contracts/agentMessageRowVM.ts
@@ -3,6 +3,7 @@ import type { ToolCallStatusKind } from "../../workspaceAgentToolCallDisplay";
 import type { WorkspaceAgentActivityTimelineItem } from "../../workspaceAgentTimelineTypes";
 import type { AgentTranscriptPresentationKind } from "./agentTranscriptPresentation";
 import type { AgentCollaborationVM } from "./agentCollaborationVM";
+import type { AgentToolGroupRowVM } from "./agentToolGroupRowVM";
 
 export interface AgentMessageContentVM {
   kind: "message-content";
@@ -67,5 +68,12 @@ export interface AgentMessageRowVM {
   speaker: "user" | "assistant";
   messages: AgentMessageContentVM[];
   thinking: AgentThinkingContentVM[];
+  /**
+   * Tool-group rows that happened right before this message and are rendered
+   * inside this message's block (under the participant header, above the
+   * content) instead of as standalone transcript rows. Populated only for the
+   * participant-header presentation (e.g. the Agent board session detail).
+   */
+  leadingToolRows?: AgentToolGroupRowVM[];
   occurredAtUnixMs: number | null;
 }


### PR DESCRIPTION
## What changed

In the participant presentation (used by the Agent board session detail), the conversation message layout moves the participant avatar out of the message row into a dedicated header row above the message:

- **Header row**: 28px avatar + sender display name (13px). User messages render `[name][avatar]` right-aligned; assistant messages render `[avatar][name]` left-aligned.
- **Alignment**: content below the header aligns with the name — assistant thinking/tool-call/message content insets 36px to the name's left edge; user bubbles inset 36px to the name's right edge (container padding + negative header margin, no horizontal overflow).
- **Tool-call rows attach forward**: standalone `tool-group` transcript rows now merge into the assistant message that follows them (new optional `AgentMessageRowVM.leadingToolRows`) and render inside that message's block under the header, instead of sitting after the previous message. Applied at the view layer (`attachLeadingToolRowsToFollowingMessages`) only when participant presentation is enabled.
- **Turn dividers**: in participant mode, dividers key off user-message rows (`findParticipantTurnDividerRowIndexes`) instead of canonical turn ids, so they also appear for sessions rebuilt from cloud messages without turn structure.
- **Avatar rendering**: participant avatars get a 0.5px `var(--line-2)` ring on the root and a radial-gradient mask on the avatar surface (same anti-aliasing approach as tsh's `crispCircleMaskClassName`) to fix jagged circular edges on composited/virtualized layers.

## Why

Agent board session detail redesign: sender identity (avatar + name) should sit above each message; tool calls belong with the message they produced; turns need visible separation; shared/regular avatars need crisp edges.

## Risks / affected surfaces

- All new behavior is gated on `participantPresentation.enabled === true`; the default AgentGUI canvas timeline (no participant presentation) is untouched — the projection layer (`agentTurnRowProjection`) is not modified.
- `AgentMessageRowVM.leadingToolRows` is an optional additive field.
- Nested tool groups use `AgentToolGroupRow`'s built-in uncontrolled expansion state.
- After merge, this needs a Tutti package release and a tsh dependency bump before it ships in tsh production builds.

## Verification

- `pnpm --dir packages/agent/gui test` — 267 tests passed in shared/agentConversation/components (6 new: participant divider x3, leading-tool attach x3, leading-tool render x1), plus the participant public-contract spec
- `pnpm --dir packages/agent/gui typecheck` and `pnpm --dir packages/agent/gui build` pass
- Verified live in the tsh desktop app (Agent board session detail) via a locally linked build
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->