### PR TITLE
feat(workspace-file-manager): add toolbar trailing actions slot

### DIFF
--- a/.changeset/workspace-file-manager-toolbar-trailing-actions.md
+++ b/.changeset/workspace-file-manager-toolbar-trailing-actions.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/workspace-file-manager": minor
+---
+
+Add optional `renderToolbarTrailingActions` so hosts can inject product-owned toolbar actions after Refresh.

--- a/packages/workspace/file-manager/CONTRACT.md
+++ b/packages/workspace/file-manager/CONTRACT.md
@@ -45,7 +45,7 @@ It does **not** own:
 | Side-pane preview loading + built-in preview shells            | `@tutti-os/workspace-file-preview`       |
 | File-manager preview projection into session `previewState`    | This package                             |
 | Open / reveal / open-with / browser / system activation        | This package orchestrates; host executes |
-| Import / export / upload / download / drag-to-import UX        | Host                                     |
+| Import / export / upload / download / drag-to-import UX        | Host (toolbar slot / menus / overlays)   |
 | Multi-step upload UX, transfer progress, gitignore pickers     | Host                                     |
 | Share / link / exposure / room collaboration                   | Host                                     |
 | Context-menu action lists for blank / directory / file targets | Host via `resolveContextMenu`            |
@@ -225,10 +225,17 @@ Public entrypoints:
 
 UI injection points that remain host-owned presentation hooks include, among
 others: `resolveContextMenu`, `renderExternalLocationContent`,
-`resolveEntryIconUrl`, `showPreviewPanel`, `showLocationSidebar`,
-`showInternalOpenWithActions`, open-with icon overrides, and analytics
-callbacks. These do **not** become a general product-action plugin system in
-this phase.
+`renderToolbarTrailingActions`, `resolveEntryIconUrl`, `showPreviewPanel`,
+`showLocationSidebar`, `showInternalOpenWithActions`, open-with icon
+overrides, and analytics callbacks. These do **not** become a general
+product-action plugin system in this phase.
+
+**Toolbar trailing actions (decided):** hosts may inject a narrow React node
+cluster through `renderToolbarTrailingActions`. The package places it in the
+toolbar trailing cluster after Refresh and before Search, and passes the
+current directory path plus busy/loading/mutating flags. Product primary
+affordances such as upload belong here (or in host chrome outside the shared
+surface); multi-step transfer UX stays host-owned.
 
 **Published UI assets (decided):** folder/archive fallback glyphs ship as
 inlined `data:` URLs in the published `dist` (tsup `loader: { ".png": "dataurl" }`).
@@ -277,9 +284,9 @@ Hosts own:
 - Requiring every host to implement Tutti’s full capability set
 - Inventing a parallel preview taxonomy or open-with advisory stack in hosts
   that already consume the workspace file packages
-- Promising a host menu/action contribution API for arbitrary product commands
-  in this phase (hosts wrap or add product entry points outside the shared
-  menu when needed)
+- Promising a general host menu/action contribution API for arbitrary product
+  commands in this phase (hosts use `resolveContextMenu`,
+  `renderToolbarTrailingActions`, or wrappers outside the shared surface)
 
 ## Relationship to other workspace packages
 

--- a/packages/workspace/file-manager/README.md
+++ b/packages/workspace/file-manager/README.md
@@ -73,7 +73,9 @@ When another host wants to reuse this package:
    `createWorkspaceFileManagerI18nRuntime(...)`.
 5. Provide `resolveContextMenu` when using the React surface so blank,
    directory, and file menus stay host-owned.
-6. Override wording in the host runtime when the host intentionally owns the
+6. Optionally provide `renderToolbarTrailingActions` for product-owned primary
+   toolbar actions (for example upload) after Refresh.
+7. Override wording in the host runtime when the host intentionally owns the
    product phrasing; otherwise fall back to the package defaults.
 
 This keeps the package reusable across different hosts without pushing host

--- a/packages/workspace/file-manager/src/index.ts
+++ b/packages/workspace/file-manager/src/index.ts
@@ -47,6 +47,10 @@ export {
   WorkspaceFileManager,
   type WorkspaceFileManagerProps
 } from "./ui/WorkspaceFileManager.tsx";
+export type {
+  RenderWorkspaceFileManagerToolbarTrailingActions,
+  WorkspaceFileManagerToolbarTrailingActionsContext
+} from "./ui/workspaceFileManagerToolbarTypes.ts";
 export {
   WorkspaceFileManagerContextMenu,
   type WorkspaceFileManagerContextMenuProps

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManager.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManager.tsx
@@ -33,6 +33,7 @@ import {
 } from "./WorkspaceFileManagerPanels.tsx";
 import type { ResolveWorkspaceFileManagerContextMenu } from "./workspaceFileManagerContextMenuTypes.ts";
 import { WorkspaceFileManagerToolbar } from "./WorkspaceFileManagerToolbar.tsx";
+import type { RenderWorkspaceFileManagerToolbarTrailingActions } from "./workspaceFileManagerToolbarTypes.ts";
 import { WorkspaceFileManagerSidebar } from "./WorkspaceFileManagerSidebar.tsx";
 import {
   clampWorkspaceFileManagerSidebarWidth,
@@ -75,6 +76,11 @@ import {
 
 const workspaceFileManagerSearchDebounceMs = 180;
 
+export type {
+  RenderWorkspaceFileManagerToolbarTrailingActions,
+  WorkspaceFileManagerToolbarTrailingActionsContext
+} from "./workspaceFileManagerToolbarTypes.ts";
+
 export interface WorkspaceFileManagerProps {
   className?: string;
   dateLocale?: TuttiDateLocale;
@@ -92,6 +98,12 @@ export interface WorkspaceFileManagerProps {
   renderExternalLocationContent?: (
     location: Extract<WorkspaceFileLocation, { kind: "external" }>
   ) => ReactElement | null;
+  /**
+   * Optional host actions rendered in the toolbar trailing cluster, after
+   * Refresh and before Search. Use for product-owned primary affordances such
+   * as upload; keep multi-step transfer UX outside this package.
+   */
+  renderToolbarTrailingActions?: RenderWorkspaceFileManagerToolbarTrailingActions;
   i18n: WorkspaceFileManagerI18nRuntime;
   session: WorkspaceFileManagerSession;
   /**
@@ -115,6 +127,7 @@ export function WorkspaceFileManager({
   resolveContextMenu,
   resolveEntryIconUrl,
   renderExternalLocationContent,
+  renderToolbarTrailingActions,
   session,
   showLocationSidebar = true,
   showPreviewPanel = true,
@@ -482,6 +495,7 @@ export function WorkspaceFileManager({
               onArrangeModeChange={setArrangeMode}
               onDirectoryExpanded={onDirectoryExpanded}
               onLayoutModeChange={setLayoutMode}
+              renderToolbarTrailingActions={renderToolbarTrailingActions}
               session={session}
             />
             <div className="@max-[600px]/workspace-file-manager:flex-col @max-[600px]/workspace-file-manager:gap-3 flex min-h-0 min-w-0 flex-1 overflow-hidden">
@@ -522,6 +536,7 @@ function WorkspaceFileManagerToolbarContainer({
   onArrangeModeChange,
   onDirectoryExpanded,
   onLayoutModeChange,
+  renderToolbarTrailingActions,
   session
 }: {
   arrangeMode: WorkspaceFileManagerArrangeMode;
@@ -530,6 +545,7 @@ function WorkspaceFileManagerToolbarContainer({
   onArrangeModeChange: (arrangeMode: WorkspaceFileManagerArrangeMode) => void;
   onDirectoryExpanded?: (path: string) => void;
   onLayoutModeChange: (layoutMode: WorkspaceFileManagerLayoutMode) => void;
+  renderToolbarTrailingActions?: RenderWorkspaceFileManagerToolbarTrailingActions;
   session: WorkspaceFileManagerSession;
 }): ReactElement {
   const { view } = useWorkspaceFileManagerToolbarView(session, i18n);
@@ -582,6 +598,7 @@ function WorkspaceFileManagerToolbarContainer({
       isSearching={view.isSearching}
       arrangeMode={arrangeMode}
       layoutMode={layoutMode}
+      renderToolbarTrailingActions={renderToolbarTrailingActions}
       searchQuery={searchQuery}
       onArrangeModeChange={onArrangeModeChange}
       onGoBack={() => {

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerToolbar.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerToolbar.tsx
@@ -26,6 +26,7 @@ import { useEffect, useRef, useState, type ReactElement } from "react";
 import type { WorkspaceFileManagerI18nRuntime } from "../i18n/workspaceFileManagerI18n.ts";
 import type { WorkspaceFileManagerArrangeMode } from "./workspaceFileManagerArrangeMode.ts";
 import type { WorkspaceFileManagerLayoutMode } from "./workspaceFileManagerLayoutMode.ts";
+import type { RenderWorkspaceFileManagerToolbarTrailingActions } from "./workspaceFileManagerToolbarTypes.ts";
 
 export function WorkspaceFileManagerToolbar({
   breadcrumbs,
@@ -40,6 +41,7 @@ export function WorkspaceFileManagerToolbar({
   isSearching,
   arrangeMode,
   layoutMode,
+  renderToolbarTrailingActions,
   searchQuery,
   onGoBack,
   onGoForward,
@@ -62,6 +64,7 @@ export function WorkspaceFileManagerToolbar({
   isSearching: boolean;
   arrangeMode: WorkspaceFileManagerArrangeMode;
   layoutMode: WorkspaceFileManagerLayoutMode;
+  renderToolbarTrailingActions?: RenderWorkspaceFileManagerToolbarTrailingActions;
   searchQuery: string;
   onGoBack: () => void;
   onGoForward: () => void;
@@ -144,6 +147,12 @@ export function WorkspaceFileManagerToolbar({
             {copy.t("refreshLabel")}
           </span>
         </ToolbarActionButton>
+        {renderToolbarTrailingActions?.({
+          currentDirectoryPath,
+          isBusy,
+          isLoading,
+          isMutating
+        }) ?? null}
         <WorkspaceFileManagerToolbarSearch
           canSearch={canSearch}
           copy={copy}

--- a/packages/workspace/file-manager/src/ui/workspaceFileManagerToolbarTypes.ts
+++ b/packages/workspace/file-manager/src/ui/workspaceFileManagerToolbarTypes.ts
@@ -1,0 +1,12 @@
+import type { ReactElement } from "react";
+
+export interface WorkspaceFileManagerToolbarTrailingActionsContext {
+  currentDirectoryPath: string;
+  isBusy: boolean;
+  isLoading: boolean;
+  isMutating: boolean;
+}
+
+export type RenderWorkspaceFileManagerToolbarTrailingActions = (
+  context: WorkspaceFileManagerToolbarTrailingActionsContext
+) => ReactElement | null;


### PR DESCRIPTION
## Summary
- Add optional `renderToolbarTrailingActions` on the shared file-manager React surface.
- Render the host slot in the toolbar trailing cluster after Refresh and before Search, with current directory and busy/loading/mutating context.
- Document the injection point in `CONTRACT.md` / `README.md` so product upload/share actions stay host-owned.

## Verification
- Locally linked into TSH via `dev-local-tutti` and verified Upload restores next to Refresh.
- `pnpm --dir packages/workspace/file-manager build` succeeded.
- Node unit tests under the package passed (`133` tests).

## Checklist
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I ran the lowest meaningful local checks for the changed surface.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->