### PR TITLE
fix(agent-gui): clarify project removal confirmation

### DIFF
--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -437,7 +437,7 @@ export const enAgentGui = {
   projectRailLinkExistingProject: "Link existing project folder",
   removeProject: "Remove",
   removeProjectConfirmDescription:
-    "This only removes “{{project}}” from this list. Local files are not deleted.",
+    "This will remove “{{project}}” and all its sessions from this list. Local files are not deleted. Continue?",
   removeProjectConfirmTitle: "Remove project?",
   batchDeleteProjectSessions: "Batch delete sessions",
   batchDeleteProjectSessionsTitle: "Delete project sessions?",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -457,7 +457,7 @@ export const zhCNAgentGui = {
   projectRailLinkExistingProject: "关联已有项目文件",
   removeProject: "移除",
   removeProjectConfirmDescription:
-    "这只会从列表中移除「{{project}}」，不会删除本地文件。",
+    "将会从列表中移除「{{project}}」及项目下全部会话，不会删除本地文件，是否确认移除？",
   removeProjectConfirmTitle: "移除项目？",
   batchDeleteProjectSessions: "批量删除会话",
   batchDeleteProjectSessionsTitle: "删除项目会话？",


### PR DESCRIPTION
## Summary
- clarify that removing a project also removes its sessions from the conversation list
- state that local files remain untouched
- keep the English and Simplified Chinese copy aligned

## Tests
- Not run (repository policy: UI presentation-only copy change)

## Notes
- No documentation impact; behavior and ownership are unchanged
