### PR TITLE
feat(agent): bridge Codex Responses plans to Chat

### DIFF
--- a/docs/architecture/model-access-plans.md
+++ b/docs/architecture/model-access-plans.md
@@ -23,13 +23,18 @@ configuration.
   mapping. `services/tuttid/service/modelbinding` is a legacy adapter and
   reference source; Desktop no longer calls its write routes.
 - `packages/agent/daemon/providerregistry` declares whether a provider runtime
-  accepts a model-plan endpoint and which protocol it consumes.
+  accepts a model-plan endpoint, which protocol it consumes, and whether it
+  requires the Codex Responses-to-Chat gateway adapter.
 - `packages/agent/runtimeprep` contains the provider-specific endpoint
-  adapters. Codex and Tutti Agent receive a session-scoped Codex provider
-  configuration; Claude Code receives its supported environment contract;
-  OpenCode receives a session-scoped `opencode.json` provider block via
-  `OPENCODE_CONFIG` (credential travels only as `TUTTI_MODEL_PLAN_API_KEY`
-  with an `{env:…}` reference in the file).
+  adapters. Codex receives a session-scoped Responses provider configuration
+  pointed at the daemon's loopback Model Gateway; Claude Code receives its
+  supported environment contract; OpenCode receives a session-scoped
+  `opencode.json` provider block via `OPENCODE_CONFIG` (credential travels only
+  as `TUTTI_MODEL_PLAN_API_KEY` with an `{env:…}` reference in the file).
+- `services/tuttid/service/modelgateway` owns the Codex-only local
+  `Responses API ↔ Chat Completions API` transport adapter. It does not define
+  session lifecycle, expose a public daemon API, or act as a general
+  multi-provider protocol IR.
 - `services/tuttid/service/agent` resolves the WorkspaceAgent and supplies its
   Plan endpoint to runtime preparation. Unsnapshotted historical sessions may
   still use the isolated legacy-binding fallback.
@@ -55,8 +60,10 @@ resolves protocols through the catalog instead of provider-identity switches.
 3. Before a new session starts, tuttid resolves that WorkspaceAgent and
    validates its requested model against the Plan catalog.
 4. Runtime preparation injects the endpoint and credential only into the
-   session-scoped provider environment/configuration. Credentials are never
-   returned by the API or written into generated instructions and manifests.
+   session-scoped provider environment/configuration. Codex receives a
+   temporary gateway token instead of the upstream Plan credential.
+   Credentials are never returned by the API or written into generated
+   instructions and manifests.
 
 Disabling a plan prevents new sessions from using it; existing running
 sessions are not interrupted. Deleting a plan is rejected while any consumer
@@ -79,13 +86,15 @@ gates the Custom Agents tab under Agent.
 
 - Plan credentials are AES-256-GCM encrypted at rest in `model_plans`
   (`api_key_ciphertext`), sharing the managed-credential key derivation.
-- API responses expose only `hasApiKey`. The credential leaves the daemon in
-  exactly two shapes: the session process environment
-  (`TUTTI_MODEL_PLAN_API_KEY`, `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN`) and
-  the legacy workspace-app grant broker.
+- API responses expose only `hasApiKey`. For Codex, the upstream credential
+  remains in daemon memory and only a random 256-bit gateway token enters
+  `TUTTI_MODEL_PLAN_API_KEY`. Other supported runtimes continue to receive
+  their provider-specific session environment, and the legacy workspace-app
+  grant broker remains a separate credential egress.
 - Credentials must never appear in logs, events, timeline payloads, detection
   results, or generated provider instructions. `runtimeprep` writes the Codex
-  provider table with `env_key`, never the key value.
+  provider table with `env_key`, never the key value. The gateway also redacts
+  the exact upstream credential from forwarded error bodies.
 
 ## Staged Detection
 
@@ -120,7 +129,10 @@ path.
 WorkspaceAgent primary Plan/default model
   -> agent.Service.resolveModelPlanEndpoint (Create + prepareRuntime)
   -> runtimeprep.PrepareInput.ModelEndpoint
-  -> CodexPreparer: session config.toml [model_providers.tutti-model-plan] + env_key
+  -> Codex:
+     agent.Service registers workspace/session route in loopback Model Gateway
+     -> CodexPreparer writes local /v1 + temporary env_key + wire_api=responses
+     -> gateway translates POST /v1/responses to upstream /v1/chat/completions
      ClaudeCodePreparer: ANTHROPIC_BASE_URL + ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN
      OpenCodePreparer: session opencode.json provider block via OPENCODE_CONFIG
   -> provider runtime speaks to the plan endpoint for the whole session
@@ -150,6 +162,33 @@ Rules:
   credential source with a structured log, never a broken session.
 - A plan-bound session validates requested models against the plan's model
   list (`validateModelAgainstPlan`), not provider catalogs.
+- Codex routes are in-memory runtime resources keyed by workspace/session.
+  Create failure, deletion, legacy cleanup paths, and resume replacement revoke
+  the previous token. Resume resolves the immutable Model Plan revision from
+  the session runtime snapshot before registering the replacement route.
+- The Codex gateway is bound to `127.0.0.1:0` on its own listener and serves
+  only authenticated `POST /v1/responses`. It is not mounted on the public
+  tuttid HTTP router, so no daemon OpenAPI change is involved.
+- Gateway v1 supports messages, text/image input, function calls and outputs,
+  function tools (including Codex namespace containers, with collision-safe
+  Chat names restored on Responses output), reasoning effort/content
+  extensions, Chat JSON/SSE, usage, cancellation, and bounded timeouts.
+  Responses roles follow the Codex-to-Chat normalization used by cc-switch:
+  `developer` becomes `system`, `latest_reminder` and unknown internal roles
+  become `user`, text-only content-part arrays are joined with newlines, and
+  all textual system instructions are merged in original order into the first
+  Chat message. This preserves instruction precedence while supporting
+  upstreams that only tokenize the portable role set or only allow `system` at
+  message index zero.
+  At the request boundary, the gateway intersects tool registrations with this
+  translatable set: non-translatable hosted or future tool declarations are
+  omitted before forwarding to Chat. If filtering leaves no tools, it also
+  omits `tool_choice` and `parallel_tool_calls`. Explicit selection of a
+  filtered tool, `required` with no remaining tool, and hosted tool call/output
+  history remain hard errors because dropping them would change requested or
+  already-recorded conversation semantics. Background Responses,
+  Conversations, Realtime/WebSocket, `/responses/compact`, and non-empty
+  `previous_response_id` are also rejected instead of dropped.
 - Composer options for a bound target replace provider-native model options
   with the plan's models (`applyModelPlanComposerOverlay`); each option carries
   the source plan name and `runtimeContext.modelPlan = {id, name, protocol}`.
@@ -211,6 +250,9 @@ policy.
 - Do not add a "global current model" or a second AgentTarget binding editor.
   New model selection is owned by explicit WorkspaceAgents.
 - Do not surface plan credentials to the renderer, tests, or snapshots.
+- Do not point Codex directly at a Chat-only Plan while declaring
+  `wire_api = "responses"`; the loopback Model Gateway is the protocol
+  boundary.
 - Do not advertise `modelPlanBinding` for providers without a real injection
   path.
 - Do not let automated review close work; the ladder tops out at

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -15,7 +15,8 @@ recur and the repository now has implementation or debugging evidence for it.
 Use the focused runtime index or open one area directly:
 
 - [Agent Providers And Setup](./agent-provider-setup.md): Provider discovery, installation, authentication, models, configuration, and runtime reachability.
-  Includes extension command/Skill palette hydration failures.
+  Includes Codex Model Plan Responses-to-Chat routing and extension
+  command/Skill palette hydration failures.
   Also covers focus-driven provider CLI scans, repeated Extension Target version
   probes, and CPU spikes.
 - [Agent Sessions And Lifecycle](./agent-session-lifecycle.md): Turn state, activation, planning-mode classification, Tutti workflow response contracts, loading, cancel, goal controls, restore, file-change undo, rail projection, realtime completion provenance, event updates, imports, and performance.

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -1756,3 +1756,60 @@ invalid_grant`. Search `tuttid.log` for
   [composer_commands.go](../../../services/tuttid/service/agent/composer_commands.go)
   [profiles.go](../../../services/tuttid/service/agentextension/profiles.go)
   [agentSlashCommandProviderPolicy.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/model/agentSlashCommandProviderPolicy.ts)
+
+### Codex Model Plan turns fail or stay waiting against a Chat-only endpoint
+
+- Symptom:
+  A Codex session bound to an OpenAI-protocol Model Plan fails immediately,
+  stays working without output, or loses tool-call messages. The Plan's
+  connection check can still pass because detection calls
+  `/v1/chat/completions` directly.
+- Quick checks:
+  Inspect the session-scoped Codex `config.toml`. The
+  `tutti-model-plan` provider must use a loopback `base_url`, a temporary
+  `TUTTI_MODEL_PLAN_API_KEY`, and `wire_api = "responses"`. Verify the upstream
+  server receives `/v1/chat/completions`, not `/v1/responses`. A direct
+  Chat-only Base URL paired with `wire_api = "responses"` is incomplete.
+- Root cause:
+  Current Codex emits Responses-shaped requests and requires terminal
+  Responses SSE events. A Chat-only provider neither owns `/v1/responses` nor
+  emits the `response.output_item.*` and `response.completed` state machine.
+  Renaming Chat deltas or changing only `wire_api` leaves Codex waiting or
+  discarding output. Current Codex can also advertise its built-in hosted
+  `web_search` tool by default, and later versions may advertise other hosted
+  tools that Chat Completions cannot execute. Codex also sends Responses
+  `developer` messages; Chat-compatible providers that only recognize
+  `system`/`user`/`assistant`/`tool` can reject the otherwise valid request
+  during tokenization.
+- Fix:
+  Keep Codex on `wire_api = "responses"` and route the session through
+  tuttid's loopback Model Gateway. The gateway authenticates the temporary
+  session token, converts supported Responses inputs to Chat Completions,
+  forwards with the daemon-held Plan credential, and reconstructs complete
+  Responses JSON/SSE output. The gateway filters non-translatable entries only
+  from the per-request tool registration list and removes orphaned
+  `tool_choice`/`parallel_tool_calls` controls. It still rejects explicit
+  selection of a filtered tool and hosted call/output history. This avoids
+  version-specific Codex config mutations while preserving fail-closed
+  semantics for requested or recorded tool use. Its Codex role normalization
+  matches cc-switch: `developer` becomes `system`, `latest_reminder` and
+  unknown internal roles become `user`, text-only content-part arrays are
+  newline-joined, and textual system messages are merged in order at message
+  index zero. This preserves instruction precedence without requiring newer
+  OpenAI-only roles or mid-conversation system roles from the upstream
+  tokenizer. OpenCode continues to use the Plan endpoint directly.
+- Validation:
+  Cover request/tool conversion, interleaved parallel tool arguments, UTF-8
+  and arbitrary SSE byte boundaries, large arguments, usage, upstream errors,
+  timeout/cancel/disconnect paths, route isolation, token replacement, cleanup,
+  immutable-revision resume, mixed supported/hosted registrations, future
+  unknown registration types, explicit hosted tool choices/history, and
+  internal-role normalization and system-message collapse. A real smoke test
+  must complete two Codex turns and one tool call while the upstream records
+  `/v1/chat/completions` without any upstream `developer` role or `system`
+  message after index zero.
+- References:
+  [model-access-plans.md](../../architecture/model-access-plans.md)
+  [gateway.go](../../../services/tuttid/service/modelgateway/gateway.go)
+  [stream_converter.go](../../../services/tuttid/service/modelgateway/stream_converter.go)
+  [model_endpoint.go](../../../packages/agent/runtimeprep/model_endpoint.go)

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -36,6 +36,7 @@ Provider discovery, installation, authentication, models, configuration, and run
 - [Claude Code logs out after sending a message (invalid_grant, credentials wiped)](./agent-provider-setup.md#claude-code-logs-out-after-sending-a-message-invalidgrant-credentials-wiped)
 - [Claude Code `Not logged in` renders as a file link instead of sign-in guidance](./agent-provider-setup.md#claude-code-not-logged-in-renders-as-a-file-link-instead-of-sign-in-guidance)
 - [Model Plan check succeeds but Kimi Claude Code turns wait and then return 401](./agent-provider-setup.md#model-plan-check-succeeds-but-kimi-claude-code-turns-wait-and-then-return-401)
+- [Codex Model Plan turns fail or stay waiting against a Chat-only endpoint](./agent-provider-setup.md#codex-model-plan-turns-fail-or-stay-waiting-against-a-chat-only-endpoint)
 - [Claude Code sessions fail with `effectiveSource: "none"` when CC-Switch or similar proxy tools are used](./agent-provider-setup.md#claude-code-sessions-fail-with-effectivesource-none-when-cc-switch-or-similar-proxy-tools-are-used)
 - [Tutti Agent retries a 402 and shows generic provider setup](./agent-provider-setup.md#tutti-agent-retries-a-402-and-shows-generic-provider-setup)
 - [OpenCode effort changes fail with `effort not found`](./agent-provider-setup.md#opencode-effort-changes-fail-with-effort-not-found)

--- a/packages/agent/daemon/providerregistry/codex.go
+++ b/packages/agent/daemon/providerregistry/codex.go
@@ -23,9 +23,10 @@ func codexDescriptor() ProviderDescriptor {
 					"OPENAI_API_BASE_URL",
 					"OPENAI_API_BASE",
 				},
-				ConfigKind:         EndpointConfigKindCodexCLI,
-				ModelPlanProtocol:  ModelPlanProtocolOpenAI,
-				NativeSubscription: true,
+				ConfigKind:               EndpointConfigKindCodexCLI,
+				ModelPlanProtocol:        ModelPlanProtocolOpenAI,
+				ModelPlanEndpointAdapter: ModelPlanEndpointAdapterResponsesToChatGateway,
+				NativeSubscription:       true,
 			},
 		},
 		Status: StatusDescriptor{

--- a/packages/agent/daemon/providerregistry/model_plan.go
+++ b/packages/agent/daemon/providerregistry/model_plan.go
@@ -1,0 +1,37 @@
+package providerregistry
+
+// ResolveModelPlanProtocol returns the model API protocol declared by a
+// migrated provider runtime. Providers without endpoint injection support are
+// intentionally unresolved.
+func ResolveModelPlanProtocol(value string) (ModelPlanProtocol, bool) {
+	index, ok := providerDescriptorIndex[normalize(value)]
+	if !ok {
+		return "", false
+	}
+	protocol := migratedDescriptors[index].Runtime.Endpoint.ModelPlanProtocol
+	return protocol, protocol != ""
+}
+
+// ResolveModelPlanModelAddressing returns the composer/settings addressing a
+// migrated provider runtime declares for bound plan models. The empty value
+// (raw plan model ids) resolves as unset.
+func ResolveModelPlanModelAddressing(value string) (ModelPlanModelAddressing, bool) {
+	index, ok := providerDescriptorIndex[normalize(value)]
+	if !ok {
+		return "", false
+	}
+	addressing := migratedDescriptors[index].Runtime.Endpoint.ModelPlanModelAddressing
+	return addressing, addressing != ""
+}
+
+// ResolveModelPlanEndpointAdapter returns the transport adapter declared by a
+// migrated provider runtime. Direct endpoint consumers intentionally resolve
+// as unset.
+func ResolveModelPlanEndpointAdapter(value string) (ModelPlanEndpointAdapter, bool) {
+	index, ok := providerDescriptorIndex[normalize(value)]
+	if !ok {
+		return "", false
+	}
+	adapter := migratedDescriptors[index].Runtime.Endpoint.ModelPlanEndpointAdapter
+	return adapter, adapter != ""
+}

--- a/packages/agent/daemon/providerregistry/registry.go
+++ b/packages/agent/daemon/providerregistry/registry.go
@@ -67,30 +67,6 @@ func ResolveProviderID(value string) (string, bool) {
 	return migratedDescriptors[index].Identity.ID, true
 }
 
-// ResolveModelPlanProtocol returns the model API protocol declared by a
-// migrated provider runtime. Providers without endpoint injection support are
-// intentionally unresolved.
-func ResolveModelPlanProtocol(value string) (ModelPlanProtocol, bool) {
-	index, ok := providerDescriptorIndex[normalize(value)]
-	if !ok {
-		return "", false
-	}
-	protocol := migratedDescriptors[index].Runtime.Endpoint.ModelPlanProtocol
-	return protocol, protocol != ""
-}
-
-// ResolveModelPlanModelAddressing returns the composer/settings addressing a
-// migrated provider runtime declares for bound plan models. The empty value
-// (raw plan model ids) resolves as unset.
-func ResolveModelPlanModelAddressing(value string) (ModelPlanModelAddressing, bool) {
-	index, ok := providerDescriptorIndex[normalize(value)]
-	if !ok {
-		return "", false
-	}
-	addressing := migratedDescriptors[index].Runtime.Endpoint.ModelPlanModelAddressing
-	return addressing, addressing != ""
-}
-
 // EventProvider describes the small immutable event-normalization projection
 // consumed on per-event hot paths.
 type EventProvider struct {
@@ -103,64 +79,6 @@ type EventProvider struct {
 func ResolveEventProvider(value string) (EventProvider, bool) {
 	resolved, ok := eventProviderIndex[normalize(value)]
 	return resolved, ok
-}
-
-func ValidateMigrated() error {
-	if err := validateNativeSubscriptions(Migrated()); err != nil {
-		return err
-	}
-	providerKeys := map[string]string{}
-	eventKeys := map[string]string{}
-	targetIDs := map[string]string{}
-	defaultProviderPriorities := map[int]string{}
-	statusProbePriorities := map[int]string{}
-	managedOrders := map[int]string{}
-	for _, descriptor := range Migrated() {
-		if err := Validate(descriptor); err != nil {
-			return err
-		}
-		providerID := normalize(descriptor.Identity.ID)
-		for _, key := range append([]string{providerID}, descriptor.Identity.Aliases...) {
-			normalizedKey := normalize(key)
-			if owner, exists := providerKeys[normalizedKey]; exists {
-				return fmt.Errorf("provider key %q is shared by %q and %q", normalizedKey, owner, providerID)
-			}
-			providerKeys[normalizedKey] = providerID
-		}
-		if descriptor.Events.Enabled {
-			for _, key := range append([]string{providerID}, descriptor.Events.Aliases...) {
-				normalizedKey := normalize(key)
-				if owner, exists := eventKeys[normalizedKey]; exists {
-					return fmt.Errorf("event provider key %q is shared by %q and %q", normalizedKey, owner, providerID)
-				}
-				eventKeys[normalizedKey] = providerID
-			}
-		}
-		targetID := strings.TrimSpace(descriptor.Target.ID)
-		if owner, exists := targetIDs[targetID]; exists {
-			return fmt.Errorf("target id %q is shared by %q and %q", targetID, owner, providerID)
-		}
-		targetIDs[targetID] = providerID
-		if priority := descriptor.Desktop.DefaultProviderPriority; priority > 0 {
-			if owner, exists := defaultProviderPriorities[priority]; exists {
-				return fmt.Errorf("desktop default provider priority %d is shared by %q and %q", priority, owner, providerID)
-			}
-			defaultProviderPriorities[priority] = providerID
-		}
-		if priority := descriptor.Desktop.StatusProbePriority; priority > 0 {
-			if owner, exists := statusProbePriorities[priority]; exists {
-				return fmt.Errorf("desktop status probe priority %d is shared by %q and %q", priority, owner, providerID)
-			}
-			statusProbePriorities[priority] = providerID
-		}
-		if order := descriptor.Desktop.ManagedOrder; order > 0 {
-			if owner, exists := managedOrders[order]; exists {
-				return fmt.Errorf("desktop managed order %d is shared by %q and %q", order, owner, providerID)
-			}
-			managedOrders[order] = providerID
-		}
-	}
-	return nil
 }
 
 func Validate(descriptor ProviderDescriptor) error {
@@ -298,6 +216,15 @@ func Validate(descriptor ProviderDescriptor) error {
 	}
 	if descriptor.Runtime.Endpoint.ModelPlanModelAddressing != "" && descriptor.Runtime.Endpoint.ModelPlanProtocol == "" {
 		return fmt.Errorf("provider %q model plan model addressing requires a model plan protocol", providerID)
+	}
+	switch descriptor.Runtime.Endpoint.ModelPlanEndpointAdapter {
+	case "", ModelPlanEndpointAdapterResponsesToChatGateway:
+	default:
+		return fmt.Errorf("provider %q model plan endpoint adapter %q is unsupported", providerID, descriptor.Runtime.Endpoint.ModelPlanEndpointAdapter)
+	}
+	if descriptor.Runtime.Endpoint.ModelPlanEndpointAdapter != "" &&
+		descriptor.Runtime.Endpoint.ModelPlanProtocol != ModelPlanProtocolOpenAI {
+		return fmt.Errorf("provider %q model plan endpoint adapter requires the OpenAI protocol", providerID)
 	}
 	hasModelPlanProtocol := descriptor.Runtime.Endpoint.ModelPlanProtocol != ""
 	hasModelPlanCapability := containsNormalized(descriptor.ComposerProfile.Capabilities, normalize(CapabilityModelPlanBinding))

--- a/packages/agent/daemon/providerregistry/registry_catalog_validation.go
+++ b/packages/agent/daemon/providerregistry/registry_catalog_validation.go
@@ -1,0 +1,64 @@
+package providerregistry
+
+import (
+	"fmt"
+	"strings"
+)
+
+func ValidateMigrated() error {
+	if err := validateNativeSubscriptions(Migrated()); err != nil {
+		return err
+	}
+	providerKeys := map[string]string{}
+	eventKeys := map[string]string{}
+	targetIDs := map[string]string{}
+	defaultProviderPriorities := map[int]string{}
+	statusProbePriorities := map[int]string{}
+	managedOrders := map[int]string{}
+	for _, descriptor := range Migrated() {
+		if err := Validate(descriptor); err != nil {
+			return err
+		}
+		providerID := normalize(descriptor.Identity.ID)
+		for _, key := range append([]string{providerID}, descriptor.Identity.Aliases...) {
+			normalizedKey := normalize(key)
+			if owner, exists := providerKeys[normalizedKey]; exists {
+				return fmt.Errorf("provider key %q is shared by %q and %q", normalizedKey, owner, providerID)
+			}
+			providerKeys[normalizedKey] = providerID
+		}
+		if descriptor.Events.Enabled {
+			for _, key := range append([]string{providerID}, descriptor.Events.Aliases...) {
+				normalizedKey := normalize(key)
+				if owner, exists := eventKeys[normalizedKey]; exists {
+					return fmt.Errorf("event provider key %q is shared by %q and %q", normalizedKey, owner, providerID)
+				}
+				eventKeys[normalizedKey] = providerID
+			}
+		}
+		targetID := strings.TrimSpace(descriptor.Target.ID)
+		if owner, exists := targetIDs[targetID]; exists {
+			return fmt.Errorf("target id %q is shared by %q and %q", targetID, owner, providerID)
+		}
+		targetIDs[targetID] = providerID
+		if priority := descriptor.Desktop.DefaultProviderPriority; priority > 0 {
+			if owner, exists := defaultProviderPriorities[priority]; exists {
+				return fmt.Errorf("desktop default provider priority %d is shared by %q and %q", priority, owner, providerID)
+			}
+			defaultProviderPriorities[priority] = providerID
+		}
+		if priority := descriptor.Desktop.StatusProbePriority; priority > 0 {
+			if owner, exists := statusProbePriorities[priority]; exists {
+				return fmt.Errorf("desktop status probe priority %d is shared by %q and %q", priority, owner, providerID)
+			}
+			statusProbePriorities[priority] = providerID
+		}
+		if order := descriptor.Desktop.ManagedOrder; order > 0 {
+			if owner, exists := managedOrders[order]; exists {
+				return fmt.Errorf("desktop managed order %d is shared by %q and %q", order, owner, providerID)
+			}
+			managedOrders[order] = providerID
+		}
+	}
+	return nil
+}

--- a/packages/agent/daemon/providerregistry/registry_test.go
+++ b/packages/agent/daemon/providerregistry/registry_test.go
@@ -449,6 +449,15 @@ func TestResolveModelPlanProtocolOnlyForPreparedProviders(t *testing.T) {
 	if !ok || addressing != ModelPlanModelAddressingProviderPrefixed {
 		t.Fatalf("ResolveModelPlanModelAddressing(opencode) = %q, %v; want provider_prefixed", addressing, ok)
 	}
+	adapter, ok := ResolveModelPlanEndpointAdapter(CodexProviderID)
+	if !ok || adapter != ModelPlanEndpointAdapterResponsesToChatGateway {
+		t.Fatalf("ResolveModelPlanEndpointAdapter(codex) = %q, %v; want responses_to_chat_gateway", adapter, ok)
+	}
+	for _, provider := range []string{ClaudeCodeProviderID, TuttiAgentProviderID, OpenCodeProviderID, "unknown"} {
+		if adapter, ok := ResolveModelPlanEndpointAdapter(provider); ok {
+			t.Fatalf("ResolveModelPlanEndpointAdapter(%q) = %q, true; want direct endpoint", provider, adapter)
+		}
+	}
 }
 
 func TestResolveNativeSubscriptionTargetUsesProviderDescriptor(t *testing.T) {
@@ -482,6 +491,7 @@ func TestValidateRejectsUnsupportedDescriptorStrategies(t *testing.T) {
 		{name: "runtime client info", mutate: func(value *ProviderDescriptor) { value.Runtime.ClientInfoName = " " }},
 		{name: "runtime auth message", mutate: func(value *ProviderDescriptor) { value.Runtime.AuthRequiredMessage = " " }},
 		{name: "model plan protocol", mutate: func(value *ProviderDescriptor) { value.Runtime.Endpoint.ModelPlanProtocol = "poison" }},
+		{name: "model plan endpoint adapter", mutate: func(value *ProviderDescriptor) { value.Runtime.Endpoint.ModelPlanEndpointAdapter = "poison" }},
 		{name: "model plan capability missing", mutate: func(value *ProviderDescriptor) {
 			value.ComposerProfile.Capabilities = slices.DeleteFunc(value.ComposerProfile.Capabilities, func(capability string) bool {
 				return capability == CapabilityModelPlanBinding

--- a/packages/agent/daemon/providerregistry/types.go
+++ b/packages/agent/daemon/providerregistry/types.go
@@ -58,6 +58,15 @@ const (
 	ModelPlanModelAddressingProviderPrefixed ModelPlanModelAddressing = "provider_prefixed"
 )
 
+// ModelPlanEndpointAdapter identifies a provider-owned transport adapter that
+// must wrap a bound plan endpoint before runtime preparation. The empty value
+// means the runtime can consume the plan endpoint directly.
+type ModelPlanEndpointAdapter string
+
+const (
+	ModelPlanEndpointAdapterResponsesToChatGateway ModelPlanEndpointAdapter = "responses_to_chat_gateway"
+)
+
 type RuntimeEndpointDescriptor struct {
 	BaseURLEnvVars    []string
 	ConfigKind        EndpointConfigKind
@@ -65,6 +74,9 @@ type RuntimeEndpointDescriptor struct {
 	// ModelPlanModelAddressing declares the composer/settings addressing for
 	// bound plan models; empty means raw plan model ids.
 	ModelPlanModelAddressing ModelPlanModelAddressing
+	// ModelPlanEndpointAdapter declares an additional provider-owned transport
+	// adapter required before the runtime receives a bound plan endpoint.
+	ModelPlanEndpointAdapter ModelPlanEndpointAdapter
 	// NativeSubscription marks the one local runtime that can validate an
 	// official subscription for this protocol without API credentials.
 	NativeSubscription bool

--- a/packages/agent/runtimeprep/model_endpoint.go
+++ b/packages/agent/runtimeprep/model_endpoint.go
@@ -17,6 +17,10 @@ type ModelEndpointConfig struct {
 	Protocol string
 	BaseURL  string
 	APIKey   string
+	// WireAPI is the provider-facing endpoint shape. Codex accepts "chat" or
+	// "responses"; daemon gateways set "responses" while legacy/direct
+	// callers retain "chat" when this field is empty.
+	WireAPI string
 	// Model is the default model id for the session; providers may still
 	// switch models within the plan on later calls.
 	Model string
@@ -138,7 +142,7 @@ func codexConfigWithModelPlanEndpoint(content string, endpoint *ModelEndpointCon
 		"name = " + strconv.Quote(planProviderDisplayName(endpoint)) + "\n" +
 		"base_url = " + strconv.Quote(strings.TrimSpace(endpoint.BaseURL)) + "\n" +
 		"env_key = " + strconv.Quote(codexModelPlanAPIKeyEnv) + "\n" +
-		"wire_api = \"chat\"\n"
+		"wire_api = " + strconv.Quote(codexModelEndpointWireAPI(endpoint)) + "\n"
 	if !strings.Contains(next, "[model_providers."+codexModelPlanProviderID+"]") {
 		if strings.TrimSpace(next) == "" {
 			next = table
@@ -147,6 +151,13 @@ func codexConfigWithModelPlanEndpoint(content string, endpoint *ModelEndpointCon
 		}
 	}
 	return next, next != content
+}
+
+func codexModelEndpointWireAPI(endpoint *ModelEndpointConfig) string {
+	if endpoint != nil && strings.TrimSpace(endpoint.WireAPI) == "responses" {
+		return "responses"
+	}
+	return "chat"
 }
 
 func planProviderDisplayName(endpoint *ModelEndpointConfig) string {

--- a/packages/agent/runtimeprep/model_endpoint_test.go
+++ b/packages/agent/runtimeprep/model_endpoint_test.go
@@ -14,6 +14,7 @@ func TestCodexConfigWithModelPlanEndpointRewritesProvider(t *testing.T) {
 		Protocol: "openai",
 		BaseURL:  "https://relay.example/v1",
 		APIKey:   "sk-secret",
+		WireAPI:  "responses",
 		Model:    "seed-code",
 	}
 	content := "model = \"gpt-5\"\nmodel_provider = \"openai\"\n\n[tutti]\nconversationDetailMode = \"standard\"\n"
@@ -36,6 +37,9 @@ func TestCodexConfigWithModelPlanEndpointRewritesProvider(t *testing.T) {
 	if !strings.Contains(next, "env_key = \"TUTTI_MODEL_PLAN_API_KEY\"") {
 		t.Fatalf("env_key missing:\n%s", next)
 	}
+	if !strings.Contains(next, "wire_api = \"responses\"") {
+		t.Fatalf("responses wire_api missing:\n%s", next)
+	}
 	if strings.Contains(next, "sk-secret") {
 		t.Fatalf("credential leaked into config:\n%s", next)
 	}
@@ -43,6 +47,24 @@ func TestCodexConfigWithModelPlanEndpointRewritesProvider(t *testing.T) {
 	// Anthropic-protocol plans must not rewrite Codex config.
 	if _, changed := codexConfigWithModelPlanEndpoint(content, &ModelEndpointConfig{Protocol: "anthropic", BaseURL: "https://x", APIKey: "k"}); changed {
 		t.Fatalf("anthropic endpoint should not change codex config")
+	}
+}
+
+func TestCodexConfigWithModelPlanEndpointPreservesWebSearch(t *testing.T) {
+	t.Parallel()
+
+	content := "web_search = \"live\"\n"
+	next, changed := codexConfigWithModelPlanEndpoint(content, &ModelEndpointConfig{
+		Protocol: "openai",
+		BaseURL:  "https://relay.example/v1",
+		APIKey:   "sk-secret",
+		Model:    "seed-code",
+	})
+	if !changed {
+		t.Fatalf("codexConfigWithModelPlanEndpoint() changed = false")
+	}
+	if !strings.Contains(next, "web_search = \"live\"") {
+		t.Fatalf("web_search should be preserved:\n%s", next)
 	}
 }
 

--- a/services/tuttid/biz/agentprovider/provider.go
+++ b/services/tuttid/biz/agentprovider/provider.go
@@ -64,6 +64,13 @@ func ModelPlanModelAddressingProviderPrefixed(provider string) bool {
 	return ok && addressing == providerregistry.ModelPlanModelAddressingProviderPrefixed
 }
 
+// ModelPlanUsesResponsesToChatGateway reports whether the provider runtime
+// strategy requires the daemon's local Responses-to-Chat endpoint adapter.
+func ModelPlanUsesResponsesToChatGateway(provider string) bool {
+	adapter, ok := providerregistry.ResolveModelPlanEndpointAdapter(provider)
+	return ok && adapter == providerregistry.ModelPlanEndpointAdapterResponsesToChatGateway
+}
+
 func IsSupported(provider string) bool {
 	return Normalize(provider) != ""
 }

--- a/services/tuttid/biz/agentprovider/provider_test.go
+++ b/services/tuttid/biz/agentprovider/provider_test.go
@@ -28,3 +28,14 @@ func TestNormalizeUsesMigratedProviderIdentity(t *testing.T) {
 		}
 	}
 }
+
+func TestModelPlanResponsesToChatGatewayUsesRuntimeStrategy(t *testing.T) {
+	if !ModelPlanUsesResponsesToChatGateway(Codex) {
+		t.Fatal("Codex model plans must use the Responses-to-Chat gateway")
+	}
+	for _, provider := range []string{ClaudeCode, OpenCode, TuttiAgent, "unknown"} {
+		if ModelPlanUsesResponsesToChatGateway(provider) {
+			t.Fatalf("%q model plans must use the direct endpoint strategy", provider)
+		}
+	}
+}

--- a/services/tuttid/service/agent/codex_model_gateway_smoke_test.go
+++ b/services/tuttid/service/agent/codex_model_gateway_smoke_test.go
@@ -1,0 +1,353 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	runtimeprep "github.com/tutti-os/tutti/packages/agent/runtimeprep"
+	modelplanbiz "github.com/tutti-os/tutti/services/tuttid/biz/modelplan"
+	modelgatewayservice "github.com/tutti-os/tutti/services/tuttid/service/modelgateway"
+)
+
+// TestCodexModelPlanGatewayCLISmoke is an opt-in real Codex CLI smoke test.
+// It resolves a WorkspaceAgent's immutable Model Plan, registers the gateway
+// through the agent service, prepares the actual session Codex home, drives
+// two persisted turns, and makes the first turn execute exec_command. The
+// Chat-only upstream is deterministic so the test does not consume a
+// developer credential or model quota.
+func TestCodexModelPlanGatewayCLISmoke(t *testing.T) {
+	if os.Getenv("TUTTI_CODEX_MODEL_GATEWAY_SMOKE") != "1" {
+		t.Skip("set TUTTI_CODEX_MODEL_GATEWAY_SMOKE=1 to run the real Codex CLI smoke test")
+	}
+	codexPath, err := exec.LookPath("codex")
+	if err != nil {
+		t.Fatalf("find codex CLI: %v", err)
+	}
+
+	var mu sync.Mutex
+	requestCount := 0
+	sawToolOutput := false
+	sawDeveloperRole := false
+	sawSystemPastHead := false
+	var paths []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		var chat map[string]any
+		if err := json.NewDecoder(request.Body).Decode(&chat); err != nil {
+			http.Error(writer, "invalid Chat request", http.StatusBadRequest)
+			return
+		}
+		messages, _ := chat["messages"].([]any)
+		requestSawToolOutput := false
+		requestSawDeveloperRole := false
+		requestSawSystemPastHead := false
+		for index, encoded := range messages {
+			message, _ := encoded.(map[string]any)
+			if message["role"] == "tool" {
+				requestSawToolOutput = true
+			}
+			if message["role"] == "developer" {
+				requestSawDeveloperRole = true
+			}
+			if index > 0 && message["role"] == "system" {
+				requestSawSystemPastHead = true
+			}
+		}
+		mu.Lock()
+		if requestSawToolOutput {
+			sawToolOutput = true
+		}
+		if requestSawDeveloperRole {
+			sawDeveloperRole = true
+		}
+		if requestSawSystemPastHead {
+			sawSystemPastHead = true
+		}
+		requestCount++
+		current := requestCount
+		paths = append(paths, request.URL.Path)
+		mu.Unlock()
+
+		writer.Header().Set("Content-Type", "text/event-stream")
+		flusher := writer.(http.Flusher)
+		writeChunk := func(payload string) {
+			_, _ = io.WriteString(writer, "data: "+payload+"\n\n")
+			flusher.Flush()
+		}
+		switch current {
+		case 1:
+			writeChunk(`{"id":"chat-smoke-1","model":"smoke-model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_smoke","type":"function","function":{"name":"exec_command","arguments":"{\"cmd\":\"printf codex-gateway-tool-ok\"}"}}]}}]}`)
+			writeChunk(`{"id":"chat-smoke-1","model":"smoke-model","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`)
+		case 2:
+			writeChunk(`{"id":"chat-smoke-2","model":"smoke-model","choices":[{"index":0,"delta":{"content":"FIRST_TURN_OK"},"finish_reason":"stop"}]}`)
+		default:
+			writeChunk(`{"id":"chat-smoke-3","model":"smoke-model","choices":[{"index":0,"delta":{"content":"SECOND_TURN_OK"},"finish_reason":"stop"}]}`)
+		}
+		writeChunk(`{"id":"chat-smoke-usage","model":"smoke-model","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}}`)
+		_, _ = io.WriteString(writer, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	var gatewayLogs bytes.Buffer
+	gateway, err := modelgatewayservice.New(modelgatewayservice.Config{
+		Logger: slog.New(slog.NewJSONHandler(&gatewayLogs, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+	})
+	if err != nil {
+		t.Fatalf("start model gateway: %v", err)
+	}
+	defer func() {
+		if err := gateway.Close(); err != nil {
+			t.Errorf("close model gateway: %v", err)
+		}
+	}()
+	// Keep installed plugins out of the smoke while retaining Codex's default
+	// hosted tool registrations. The gateway must filter those registrations
+	// without a version-specific Codex config override.
+	t.Setenv("HOME", t.TempDir())
+	preparer := runtimeprep.NewDefaultPreparer(t.TempDir())
+	preparer.CommandCatalog = modelGatewaySmokeCommandCatalog{}
+	service := &Service{
+		RuntimePreparer: preparer,
+		ModelGateway:    gateway,
+	}
+	plan := modelplanbiz.Plan{
+		ID:           "model-plan-smoke",
+		WorkspaceID:  "smoke-workspace",
+		Revision:     1,
+		Name:         "Chat-only smoke plan",
+		TemplateKind: modelplanbiz.TemplateCustom,
+		Protocol:     modelplanbiz.ProtocolOpenAI,
+		APIKey:       "smoke-upstream-key",
+		BaseURL:      upstream.URL,
+		Models:       []modelplanbiz.Model{{ID: "smoke-model", Name: "Smoke Model"}},
+		DefaultModel: "smoke-model",
+		Enabled:      true,
+	}
+	resolution, err := resolveProvidedModelPlan(
+		"codex",
+		"workspace-agent:smoke",
+		plan,
+		"smoke-model",
+		"smoke-model",
+	)
+	if err != nil {
+		t.Fatalf("resolve Model Plan: %v", err)
+	}
+	workdir := t.TempDir()
+	prepared, err := service.prepareRuntimeWithModelEndpoint(
+		context.Background(),
+		"smoke-workspace",
+		workdir,
+		CreateSessionInput{
+			AgentSessionID: "smoke-session",
+			AgentTargetID:  "workspace-agent:smoke",
+			Provider:       "codex",
+			Model:          stringPointer("smoke-model"),
+		},
+		resolution.Endpoint,
+	)
+	if err != nil {
+		t.Fatalf("prepare custom Agent runtime: %v", err)
+	}
+	if strings.Contains(strings.Join(prepared.Env, "\n"), plan.APIKey) {
+		t.Fatal("prepared Codex environment contains the upstream Model Plan credential")
+	}
+	gatewayBaseURL, gatewayToken := preparedGatewayEndpoint(t, prepared.Env)
+
+	firstOutput := filepath.Join(t.TempDir(), "first-output.txt")
+	firstStdout := runModelGatewayCodexCommand(
+		t,
+		codexPath,
+		workdir,
+		prepared.Env,
+		"exec", "--json", "--skip-git-repo-check",
+		"--dangerously-bypass-approvals-and-sandbox", "-C", workdir, "-o", firstOutput,
+		"Run the requested tool, then return the upstream final answer exactly.",
+	)
+	threadID := modelGatewaySmokeThreadID(t, firstStdout)
+	firstMessage, err := os.ReadFile(firstOutput)
+	if err != nil {
+		t.Fatalf("read first Codex output: %v", err)
+	}
+	if !strings.Contains(string(firstMessage), "FIRST_TURN_OK") {
+		t.Fatalf("first output = %q\nstdout:\n%s", firstMessage, firstStdout)
+	}
+
+	secondOutput := filepath.Join(t.TempDir(), "second-output.txt")
+	secondStdout := runModelGatewayCodexCommand(
+		t,
+		codexPath,
+		workdir,
+		prepared.Env,
+		"exec", "resume", "--json", "--skip-git-repo-check",
+		"--dangerously-bypass-approvals-and-sandbox", "-o", secondOutput, threadID,
+		"Return the upstream second-turn answer exactly.",
+	)
+	secondMessage, err := os.ReadFile(secondOutput)
+	if err != nil {
+		t.Fatalf("read second Codex output: %v", err)
+	}
+	if !strings.Contains(string(secondMessage), "SECOND_TURN_OK") {
+		t.Fatalf("second output = %q\nstdout:\n%s", secondMessage, secondStdout)
+	}
+
+	mu.Lock()
+	if requestCount < 3 || !sawToolOutput || sawDeveloperRole || sawSystemPastHead {
+		t.Fatalf(
+			"upstream requests = %d, saw tool output = %v, saw developer role = %v, saw system past head = %v",
+			requestCount,
+			sawToolOutput,
+			sawDeveloperRole,
+			sawSystemPastHead,
+		)
+	}
+	for _, path := range paths {
+		if path != "/v1/chat/completions" {
+			t.Fatalf("upstream paths = %#v", paths)
+		}
+	}
+	mu.Unlock()
+	if logs := gatewayLogs.String(); !strings.Contains(logs, `"event":"model_gateway.tools.filtered"`) ||
+		!strings.Contains(logs, "web_search") {
+		t.Fatalf("gateway did not record filtering Codex's hosted web_search registration:\n%s", logs)
+	}
+
+	if err := service.cleanupRuntime(context.Background(), "smoke-workspace", "smoke-session"); err != nil {
+		t.Fatalf("cleanup custom Agent runtime: %v", err)
+	}
+	assertPreparedGatewayTokenRevoked(t, gatewayBaseURL, gatewayToken)
+}
+
+type modelGatewaySmokeCommandCatalog struct{}
+
+func (modelGatewaySmokeCommandCatalog) Capabilities(
+	context.Context,
+	runtimeprep.CommandContext,
+) []runtimeprep.CommandCapability {
+	return nil
+}
+
+func runModelGatewayCodexCommand(
+	t *testing.T,
+	codexPath string,
+	workdir string,
+	runtimeEnv []string,
+	args ...string,
+) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, codexPath, args...)
+	command.Dir = workdir
+	command.Env = mergeModelGatewaySmokeEnv(os.Environ(), runtimeEnv)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		t.Fatalf("codex %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+	return stdout.String()
+}
+
+func mergeModelGatewaySmokeEnv(base []string, overlay []string) []string {
+	overridden := make(map[string]struct{}, len(overlay))
+	for _, entry := range overlay {
+		key, _, found := strings.Cut(entry, "=")
+		if found {
+			overridden[key] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(base)+len(overlay))
+	for _, entry := range base {
+		key, _, found := strings.Cut(entry, "=")
+		if found {
+			if _, exists := overridden[key]; exists {
+				continue
+			}
+		}
+		result = append(result, entry)
+	}
+	return append(result, overlay...)
+}
+
+func modelGatewaySmokeThreadID(t *testing.T, output string) string {
+	t.Helper()
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		var event map[string]any
+		if json.Unmarshal(scanner.Bytes(), &event) != nil {
+			continue
+		}
+		if event["type"] == "thread.started" {
+			threadID, _ := event["thread_id"].(string)
+			if threadID != "" {
+				return threadID
+			}
+		}
+	}
+	t.Fatalf("thread.started missing from Codex output:\n%s", output)
+	return ""
+}
+
+func preparedGatewayEndpoint(t *testing.T, runtimeEnv []string) (string, string) {
+	t.Helper()
+	var baseURL string
+	var token string
+	for _, entry := range runtimeEnv {
+		key, value, found := strings.Cut(entry, "=")
+		if !found {
+			continue
+		}
+		switch key {
+		case "CODEX_HOME":
+			config, err := os.ReadFile(filepath.Join(value, "config.toml"))
+			if err == nil {
+				for _, line := range strings.Split(string(config), "\n") {
+					trimmedLine := strings.TrimSpace(line)
+					if strings.HasPrefix(trimmedLine, "base_url = ") {
+						baseURL = strings.Trim(strings.TrimPrefix(trimmedLine, "base_url = "), `"`)
+					}
+				}
+			}
+		case "TUTTI_MODEL_PLAN_API_KEY":
+			token = value
+		}
+	}
+	if baseURL == "" || token == "" {
+		t.Fatalf("prepared gateway endpoint missing from runtime environment")
+	}
+	return baseURL, token
+}
+
+func assertPreparedGatewayTokenRevoked(t *testing.T, baseURL string, token string) {
+	t.Helper()
+	request, err := http.NewRequest(http.MethodPost, strings.TrimRight(baseURL, "/")+"/responses", strings.NewReader(`{"model":"smoke-model","input":"x"}`))
+	if err != nil {
+		t.Fatalf("create revoked-token request: %v", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("call gateway with revoked token: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("revoked gateway token status = %d, want 401", response.StatusCode)
+	}
+}

--- a/services/tuttid/service/agent/model_gateway.go
+++ b/services/tuttid/service/agent/model_gateway.go
@@ -1,0 +1,14 @@
+package agent
+
+import (
+	"context"
+
+	modelgatewayservice "github.com/tutti-os/tutti/services/tuttid/service/modelgateway"
+)
+
+// ModelGatewayRegistry is the daemon-owned, session-scoped Responses-to-Chat
+// route registry used only by Codex model-plan launches.
+type ModelGatewayRegistry interface {
+	Register(context.Context, modelgatewayservice.Route) (modelgatewayservice.ClientEndpoint, error)
+	Unregister(context.Context, string, string)
+}

--- a/services/tuttid/service/agent/model_gateway_test.go
+++ b/services/tuttid/service/agent/model_gateway_test.go
@@ -1,0 +1,145 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	runtimeprep "github.com/tutti-os/tutti/packages/agent/runtimeprep"
+	modelgatewayservice "github.com/tutti-os/tutti/services/tuttid/service/modelgateway"
+)
+
+type fakeModelGateway struct {
+	endpoint        modelgatewayservice.ClientEndpoint
+	err             error
+	registeredRoute *modelgatewayservice.Route
+	registerCalls   *int
+	unregisterCalls *[][2]string
+}
+
+func (f fakeModelGateway) Register(_ context.Context, route modelgatewayservice.Route) (modelgatewayservice.ClientEndpoint, error) {
+	if f.registerCalls != nil {
+		*f.registerCalls++
+	}
+	if f.registeredRoute != nil {
+		*f.registeredRoute = route
+	}
+	return f.endpoint, f.err
+}
+
+func (f fakeModelGateway) Unregister(_ context.Context, workspaceID string, agentSessionID string) {
+	if f.unregisterCalls != nil {
+		*f.unregisterCalls = append(*f.unregisterCalls, [2]string{workspaceID, agentSessionID})
+	}
+}
+
+func TestPrepareRuntimeCodexGatewayUsesTemporaryCredentialAndRollsBackFailure(t *testing.T) {
+	t.Parallel()
+
+	upstreamKey := "sk-upstream-secret"
+	var preparedInput runtimeprep.PrepareInput
+	var registeredRoute modelgatewayservice.Route
+	var unregisterCalls [][2]string
+	service := &Service{
+		RuntimePreparer: fakeRuntimePreparer{
+			input: &preparedInput,
+			err:   errors.New("prepare failed"),
+		},
+		ModelGateway: fakeModelGateway{
+			endpoint: modelgatewayservice.ClientEndpoint{
+				BaseURL: "http://127.0.0.1:40000/v1",
+				Token:   "temporary-token",
+				WireAPI: "responses",
+			},
+			registeredRoute: &registeredRoute,
+			unregisterCalls: &unregisterCalls,
+		},
+	}
+	_, err := service.prepareRuntimeWithModelEndpoint(
+		context.Background(),
+		"workspace",
+		"/repo",
+		CreateSessionInput{
+			AgentSessionID: "session",
+			Provider:       "codex",
+			Model:          stringPointer("model-a"),
+		},
+		&runtimeprep.ModelEndpointConfig{
+			Protocol: "openai",
+			BaseURL:  "https://upstream.example/v1",
+			APIKey:   upstreamKey,
+			Model:    "model-a",
+			Models:   []runtimeprep.ModelEndpointModel{{ID: "model-a"}},
+		},
+	)
+	if err == nil || err.Error() != "prepare failed" {
+		t.Fatalf("prepareRuntimeWithModelEndpoint() error = %v", err)
+	}
+	if registeredRoute.UpstreamAPIKey != upstreamKey ||
+		registeredRoute.UpstreamURL != "https://upstream.example/v1" {
+		t.Fatalf("registered route = %#v", registeredRoute)
+	}
+	if preparedInput.ModelEndpoint == nil ||
+		preparedInput.ModelEndpoint.APIKey != "temporary-token" ||
+		preparedInput.ModelEndpoint.BaseURL != "http://127.0.0.1:40000/v1" ||
+		preparedInput.ModelEndpoint.WireAPI != "responses" {
+		t.Fatalf("prepared endpoint = %#v", preparedInput.ModelEndpoint)
+	}
+	if len(unregisterCalls) != 2 {
+		t.Fatalf("unregister calls = %#v, want replacement revoke and rollback revoke", unregisterCalls)
+	}
+}
+
+func TestPrepareRuntimeOpenCodeKeepsDirectModelPlanEndpoint(t *testing.T) {
+	t.Parallel()
+
+	var preparedInput runtimeprep.PrepareInput
+	registerCalls := 0
+	service := &Service{
+		RuntimePreparer: fakeRuntimePreparer{input: &preparedInput},
+		ModelGateway: fakeModelGateway{
+			registerCalls: &registerCalls,
+		},
+	}
+	endpoint := &runtimeprep.ModelEndpointConfig{
+		Protocol: "openai",
+		BaseURL:  "https://upstream.example/v1",
+		APIKey:   "sk-direct",
+		Model:    "tutti-model-plan/model-a",
+	}
+	if _, err := service.prepareRuntimeWithModelEndpoint(
+		context.Background(),
+		"workspace",
+		"/repo",
+		CreateSessionInput{
+			AgentSessionID: "session",
+			Provider:       "opencode",
+		},
+		endpoint,
+	); err != nil {
+		t.Fatalf("prepareRuntimeWithModelEndpoint() error = %v", err)
+	}
+	if registerCalls != 0 {
+		t.Fatalf("gateway Register() calls = %d, want 0", registerCalls)
+	}
+	if preparedInput.ModelEndpoint != endpoint ||
+		preparedInput.ModelEndpoint.APIKey != "sk-direct" ||
+		preparedInput.ModelEndpoint.WireAPI != "" {
+		t.Fatalf("OpenCode endpoint = %#v, want direct plan endpoint", preparedInput.ModelEndpoint)
+	}
+}
+
+func TestCleanupRuntimeRevokesGatewayWithoutRuntimePreparer(t *testing.T) {
+	t.Parallel()
+
+	var unregisterCalls [][2]string
+	service := &Service{
+		ModelGateway: fakeModelGateway{unregisterCalls: &unregisterCalls},
+	}
+	if err := service.cleanupRuntime(context.Background(), "workspace", "session"); err != nil {
+		t.Fatalf("cleanupRuntime() error = %v", err)
+	}
+	if len(unregisterCalls) != 1 || unregisterCalls[0] != [2]string{"workspace", "session"} {
+		t.Fatalf("unregister calls = %#v", unregisterCalls)
+	}
+}

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -12,10 +12,12 @@ import (
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	runtimeprep "github.com/tutti-os/tutti/packages/agent/runtimeprep"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
 	claudecodeservice "github.com/tutti-os/tutti/services/tuttid/service/claudecode"
+	modelgatewayservice "github.com/tutti-os/tutti/services/tuttid/service/modelgateway"
 )
 
 var (
@@ -457,13 +459,48 @@ func (s *Service) prepareRuntimeWithModelEndpoint(
 		return preparedRuntime{Cwd: cwd}, nil
 	}
 	provider := strings.TrimSpace(input.Provider)
+	effectiveEndpoint := planEndpoint
+	gatewayRegistered := false
+	if agentprovider.ModelPlanUsesResponsesToChatGateway(provider) && modelEndpointUsesOpenAIProtocol(planEndpoint) {
+		if s.ModelGateway == nil {
+			return preparedRuntime{}, errors.New("codex model-plan gateway is unavailable")
+		}
+		models := make([]string, 0, len(planEndpoint.Models)+1)
+		for _, model := range planEndpoint.Models {
+			if id := strings.TrimSpace(model.ID); id != "" {
+				models = append(models, id)
+			}
+		}
+		if len(models) == 0 && strings.TrimSpace(planEndpoint.Model) != "" {
+			models = append(models, strings.TrimSpace(planEndpoint.Model))
+		}
+		// Revoke before replacement so a failed resume preparation can never
+		// leave the previous process token usable.
+		s.ModelGateway.Unregister(ctx, workspaceID, input.AgentSessionID)
+		clientEndpoint, err := s.ModelGateway.Register(ctx, modelgatewayservice.Route{
+			WorkspaceID:    workspaceID,
+			AgentSessionID: strings.TrimSpace(input.AgentSessionID),
+			UpstreamURL:    planEndpoint.BaseURL,
+			UpstreamAPIKey: planEndpoint.APIKey,
+			Models:         models,
+		})
+		if err != nil {
+			return preparedRuntime{}, fmt.Errorf("register Codex model gateway route: %w", err)
+		}
+		endpointCopy := *planEndpoint
+		endpointCopy.BaseURL = clientEndpoint.BaseURL
+		endpointCopy.APIKey = clientEndpoint.Token
+		endpointCopy.WireAPI = clientEndpoint.WireAPI
+		effectiveEndpoint = &endpointCopy
+		gatewayRegistered = true
+	}
 	prepared, err := s.RuntimePreparer.Prepare(ctx, runtimeprep.PrepareInput{
 		WorkspaceID:               workspaceID,
 		AgentSessionID:            strings.TrimSpace(input.AgentSessionID),
 		AgentTargetID:             strings.TrimSpace(input.AgentTargetID),
 		Provider:                  provider,
 		Cwd:                       cwd,
-		ModelEndpoint:             planEndpoint,
+		ModelEndpoint:             effectiveEndpoint,
 		Title:                     value(input.Title),
 		PermissionModeID:          value(input.PermissionModeID),
 		PlanMode:                  clampComposerPlanModeForLaunch(provider, input.ProviderTargetRef, valueBool(input.PlanMode)),
@@ -484,6 +521,9 @@ func (s *Service) prepareRuntimeWithModelEndpoint(
 		ExternalRolloutSourcePath: input.ExternalRolloutSourcePath,
 	})
 	if err != nil {
+		if gatewayRegistered {
+			s.ModelGateway.Unregister(context.WithoutCancel(ctx), workspaceID, input.AgentSessionID)
+		}
 		return preparedRuntime{}, err
 	}
 	if strings.TrimSpace(prepared.Cwd) == "" {
@@ -493,6 +533,13 @@ func (s *Service) prepareRuntimeWithModelEndpoint(
 		Cwd: prepared.Cwd,
 		Env: append([]string(nil), prepared.Env...),
 	}, nil
+}
+
+func modelEndpointUsesOpenAIProtocol(endpoint *runtimeprep.ModelEndpointConfig) bool {
+	return endpoint != nil &&
+		strings.TrimSpace(endpoint.Protocol) == "openai" &&
+		strings.TrimSpace(endpoint.BaseURL) != "" &&
+		strings.TrimSpace(endpoint.APIKey) != ""
 }
 
 func sessionSkillBundlesToProviderSkillBundles(input []SessionSkillBundle) []runtimeprep.ProviderSkillBundle {
@@ -640,13 +687,17 @@ func (s *Service) UpdatePin(ctx context.Context, workspaceID string, agentSessio
 }
 
 func (s *Service) cleanupRuntime(ctx context.Context, workspaceID string, agentSessionID string) error {
-	if s.RuntimePreparer == nil {
-		return nil
+	var runtimeErr error
+	if s.RuntimePreparer != nil {
+		runtimeErr = s.RuntimePreparer.Cleanup(ctx, runtimeprep.CleanupInput{
+			WorkspaceID:    workspaceID,
+			AgentSessionID: agentSessionID,
+		})
 	}
-	return s.RuntimePreparer.Cleanup(ctx, runtimeprep.CleanupInput{
-		WorkspaceID:    workspaceID,
-		AgentSessionID: agentSessionID,
-	})
+	if s.ModelGateway != nil {
+		s.ModelGateway.Unregister(ctx, workspaceID, agentSessionID)
+	}
+	return runtimeErr
 }
 
 func (s *Service) cleanupSessionResources(ctx context.Context, workspaceID string, agentSessionID string) error {

--- a/services/tuttid/service/agent/session_runtime_snapshot_test.go
+++ b/services/tuttid/service/agent/session_runtime_snapshot_test.go
@@ -11,6 +11,7 @@ import (
 	modelbindingbiz "github.com/tutti-os/tutti/services/tuttid/biz/modelbinding"
 	modelplanbiz "github.com/tutti-os/tutti/services/tuttid/biz/modelplan"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
+	modelgatewayservice "github.com/tutti-os/tutti/services/tuttid/service/modelgateway"
 )
 
 type revisionPlanSource struct {
@@ -173,6 +174,15 @@ func TestPrepareRuntimeForResumeUsesExactModelPlanRevision(t *testing.T) {
 	service.AgentTargetStore = fakeAgentTargetStore{targets: defaultTestAgentTargets()}
 	var preparedInput runtimeprep.PrepareInput
 	service.RuntimePreparer = fakeRuntimePreparer{input: &preparedInput}
+	var registeredRoute modelgatewayservice.Route
+	service.ModelGateway = fakeModelGateway{
+		endpoint: modelgatewayservice.ClientEndpoint{
+			BaseURL: "http://127.0.0.1:43123/v1",
+			Token:   "temporary-gateway-token",
+			WireAPI: "responses",
+		},
+		registeredRoute: &registeredRoute,
+	}
 	service.ConfigureModelPlanBinding(staticBindingSource{binding: modelbindingbiz.Binding{
 		WorkspaceID:   "ws",
 		AgentTargetID: "workspace-agent:writer",
@@ -211,8 +221,14 @@ func TestPrepareRuntimeForResumeUsesExactModelPlanRevision(t *testing.T) {
 	if preparedInput.ModelEndpoint == nil {
 		t.Fatal("prepared model endpoint is nil")
 	}
-	if preparedInput.ModelEndpoint.APIKey != oldPlan.APIKey || preparedInput.ModelEndpoint.BaseURL != oldPlan.BaseURL || preparedInput.ModelEndpoint.Model != resumedModel {
-		t.Fatalf("prepared endpoint = %#v, want exact old revision", preparedInput.ModelEndpoint)
+	if registeredRoute.UpstreamAPIKey != oldPlan.APIKey || registeredRoute.UpstreamURL != oldPlan.BaseURL {
+		t.Fatalf("registered route = %#v, want exact old revision", registeredRoute)
+	}
+	if preparedInput.ModelEndpoint.APIKey != "temporary-gateway-token" ||
+		preparedInput.ModelEndpoint.BaseURL != "http://127.0.0.1:43123/v1" ||
+		preparedInput.ModelEndpoint.WireAPI != "responses" ||
+		preparedInput.ModelEndpoint.Model != resumedModel {
+		t.Fatalf("prepared endpoint = %#v, want temporary gateway endpoint", preparedInput.ModelEndpoint)
 	}
 	if preparedInput.AgentInstructions != "old instructions" || len(preparedInput.AgentSkills) != 1 || preparedInput.AgentSkills[0] != "old-skill" {
 		t.Fatalf("prepared agent definition = %#v", preparedInput)

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -63,6 +63,7 @@ type Service struct {
 	WorkspaceIDs                   func(context.Context) ([]string, error)
 	PromptAttachmentStore          PromptAttachmentStore
 	RuntimePreparer                runtimeprep.Preparer
+	ModelGateway                   ModelGatewayRegistry
 	ComputerUseAvailable           func() bool
 	CapabilityLister               ComposerCapabilityLister
 	ExtensionComposerProfiles      ExtensionComposerProfileResolver

--- a/services/tuttid/service/modelgateway/chat_response.go
+++ b/services/tuttid/service/modelgateway/chat_response.go
@@ -1,0 +1,397 @@
+package modelgateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type chatCompletionResponse struct {
+	ID      string                 `json:"id"`
+	Object  string                 `json:"object"`
+	Created int64                  `json:"created"`
+	Model   string                 `json:"model"`
+	Choices []chatCompletionChoice `json:"choices"`
+	Usage   *chatUsage             `json:"usage"`
+	Error   json.RawMessage        `json:"error"`
+}
+
+type chatCompletionChoice struct {
+	Index        int                 `json:"index"`
+	Message      chatResponseMessage `json:"message"`
+	FinishReason *string             `json:"finish_reason"`
+}
+
+type chatResponseMessage struct {
+	Role             string          `json:"role"`
+	Content          json.RawMessage `json:"content"`
+	ReasoningContent json.RawMessage `json:"reasoning_content"`
+	Reasoning        json.RawMessage `json:"reasoning"`
+	ToolCalls        []chatToolCall  `json:"tool_calls"`
+	FunctionCall     *struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	} `json:"function_call"`
+}
+
+type chatToolCall struct {
+	Index    int    `json:"index"`
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	} `json:"function"`
+}
+
+type chatUsage struct {
+	PromptTokens        int64 `json:"prompt_tokens"`
+	CompletionTokens    int64 `json:"completion_tokens"`
+	TotalTokens         int64 `json:"total_tokens"`
+	PromptTokensDetails *struct {
+		CachedTokens     int64 `json:"cached_tokens"`
+		CacheWriteTokens int64 `json:"cache_write_tokens"`
+	} `json:"prompt_tokens_details"`
+	CompletionTokensDetails *struct {
+		ReasoningTokens int64 `json:"reasoning_tokens"`
+	} `json:"completion_tokens_details"`
+}
+
+func convertChatResponse(
+	request responsesRequest,
+	upstream chatCompletionResponse,
+	toolMap responseToolMap,
+) (map[string]any, error) {
+	if len(bytes.TrimSpace(upstream.Error)) > 0 && !bytes.Equal(bytes.TrimSpace(upstream.Error), []byte("null")) {
+		return nil, fmt.Errorf("upstream returned an error payload")
+	}
+	if len(upstream.Choices) == 0 {
+		return nil, fmt.Errorf("upstream Chat response contained no choices")
+	}
+	choice := upstream.Choices[0]
+	output := make([]any, 0, 2+len(choice.Message.ToolCalls))
+	reasoning, err := chatText(choice.Message.ReasoningContent)
+	if err != nil {
+		return nil, fmt.Errorf("decode upstream reasoning_content: %w", err)
+	}
+	if reasoning == "" {
+		reasoning, err = chatText(choice.Message.Reasoning)
+		if err != nil {
+			return nil, fmt.Errorf("decode upstream reasoning: %w", err)
+		}
+	}
+	if reasoning != "" {
+		output = append(output, completedReasoningItem(reasoning))
+	}
+	text, err := chatText(choice.Message.Content)
+	if err != nil {
+		return nil, fmt.Errorf("decode upstream message content: %w", err)
+	}
+	if text != "" || (len(choice.Message.ToolCalls) == 0 && choice.Message.FunctionCall == nil) {
+		output = append(output, completedMessageItem(text))
+	}
+	toolCalls := append([]chatToolCall(nil), choice.Message.ToolCalls...)
+	if choice.Message.FunctionCall != nil {
+		legacy := chatToolCall{ID: newResponseID("call")}
+		legacy.Type = "function"
+		legacy.Function.Name = choice.Message.FunctionCall.Name
+		legacy.Function.Arguments = choice.Message.FunctionCall.Arguments
+		toolCalls = append(toolCalls, legacy)
+	}
+	for _, toolCall := range toolCalls {
+		output = append(output, completedFunctionCallItem(toolCall, toolMap))
+	}
+	responseID := responseIDFromUpstream(upstream.ID)
+	createdAt := upstream.Created
+	if createdAt <= 0 {
+		createdAt = time.Now().Unix()
+	}
+	status, incompleteDetails, responseError := responseStatus(choice.FinishReason)
+	return responseObject(
+		request,
+		responseID,
+		createdAt,
+		upstream.Model,
+		status,
+		output,
+		responseUsage(upstream.Usage),
+		incompleteDetails,
+		responseError,
+	), nil
+}
+
+func chatText(encoded json.RawMessage) (string, error) {
+	trimmed := bytes.TrimSpace(encoded)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return "", nil
+	}
+	var text string
+	if err := json.Unmarshal(trimmed, &text); err == nil {
+		return text, nil
+	}
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(trimmed, &parts); err != nil {
+		return "", err
+	}
+	var result strings.Builder
+	for _, part := range parts {
+		if part.Type == "" || part.Type == "text" || part.Type == "output_text" || part.Type == "reasoning_text" {
+			result.WriteString(part.Text)
+		}
+	}
+	return result.String(), nil
+}
+
+func completedReasoningItem(text string) map[string]any {
+	return map[string]any{
+		"id":                newResponseID("rs"),
+		"type":              "reasoning",
+		"summary":           []any{},
+		"content":           []any{map[string]any{"type": "reasoning_text", "text": text}},
+		"encrypted_content": nil,
+		"status":            "completed",
+	}
+}
+
+func completedMessageItem(text string) map[string]any {
+	return map[string]any{
+		"id":     newResponseID("msg"),
+		"type":   "message",
+		"role":   "assistant",
+		"status": "completed",
+		"content": []any{map[string]any{
+			"type": "output_text", "text": text, "annotations": []any{},
+		}},
+	}
+}
+
+func completedFunctionCallItem(toolCall chatToolCall, toolMap responseToolMap) map[string]any {
+	callID := strings.TrimSpace(toolCall.ID)
+	if callID == "" {
+		callID = newResponseID("call")
+	}
+	arguments := rawJSONString(toolCall.Function.Arguments)
+	identity := responseIdentityForChatTool(toolCall.Function.Name, toolMap)
+	item := map[string]any{
+		"id":        newResponseID("fc"),
+		"type":      "function_call",
+		"status":    "completed",
+		"call_id":   callID,
+		"name":      identity.Name,
+		"arguments": arguments,
+	}
+	if identity.Namespace != "" {
+		item["namespace"] = identity.Namespace
+	}
+	return item
+}
+
+func responseIdentityForChatTool(name string, toolMap responseToolMap) responseToolIdentity {
+	if identity, exists := toolMap[name]; exists {
+		return identity
+	}
+	return responseToolIdentity{Name: name}
+}
+
+func rawJSONString(encoded json.RawMessage) string {
+	trimmed := bytes.TrimSpace(encoded)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ""
+	}
+	var value string
+	if err := json.Unmarshal(trimmed, &value); err == nil {
+		return value
+	}
+	return string(trimmed)
+}
+
+func responseStatus(finishReason *string) (string, any, any) {
+	if finishReason == nil {
+		return "completed", nil, nil
+	}
+	switch strings.TrimSpace(*finishReason) {
+	case "", "stop", "tool_calls", "function_call":
+		return "completed", nil, nil
+	case "length", "max_tokens":
+		return "incomplete", map[string]any{"reason": "max_output_tokens"}, nil
+	case "content_filter":
+		return "failed", nil, map[string]any{
+			"code": "content_filter", "message": "The upstream model blocked the response",
+		}
+	default:
+		return "incomplete", map[string]any{"reason": "upstream_finish_reason"}, nil
+	}
+}
+
+func responseObject(
+	request responsesRequest,
+	responseID string,
+	createdAt int64,
+	model string,
+	status string,
+	output []any,
+	usage any,
+	incompleteDetails any,
+	responseError any,
+) map[string]any {
+	if strings.TrimSpace(model) == "" {
+		model = request.Model
+	}
+	parallelToolCalls := true
+	if request.ParallelToolCalls != nil {
+		parallelToolCalls = *request.ParallelToolCalls
+	}
+	var reasoning any
+	if request.Reasoning != nil {
+		reasoning = map[string]any{
+			"effort":  nullableStringValue(request.Reasoning.Effort),
+			"summary": nullableStringValue(request.Reasoning.Summary),
+		}
+	}
+	return map[string]any{
+		"id":                   responseID,
+		"object":               "response",
+		"created_at":           createdAt,
+		"completed_at":         completedAt(status),
+		"status":               status,
+		"error":                responseError,
+		"incomplete_details":   incompleteDetails,
+		"instructions":         nil,
+		"max_output_tokens":    request.MaxOutputTokens,
+		"model":                model,
+		"output":               output,
+		"parallel_tool_calls":  parallelToolCalls,
+		"previous_response_id": nil,
+		"reasoning":            reasoning,
+		"store":                valueOrDefault(request.Store, false),
+		"temperature":          request.Temperature,
+		"text":                 responseTextEcho(request.Text),
+		"tool_choice":          rawJSONValue(request.ToolChoice, "auto"),
+		"tools":                rawJSONArray(request.Tools),
+		"top_p":                request.TopP,
+		"truncation":           "disabled",
+		"usage":                usage,
+		"metadata":             mergedMetadata(request),
+	}
+}
+
+func responseUsage(usage *chatUsage) any {
+	if usage == nil {
+		return nil
+	}
+	cachedTokens := int64(0)
+	cacheWriteTokens := int64(0)
+	if usage.PromptTokensDetails != nil {
+		cachedTokens = usage.PromptTokensDetails.CachedTokens
+		cacheWriteTokens = usage.PromptTokensDetails.CacheWriteTokens
+	}
+	reasoningTokens := int64(0)
+	if usage.CompletionTokensDetails != nil {
+		reasoningTokens = usage.CompletionTokensDetails.ReasoningTokens
+	}
+	return map[string]any{
+		"input_tokens": usage.PromptTokens,
+		"input_tokens_details": map[string]any{
+			"cached_tokens":      cachedTokens,
+			"cache_write_tokens": cacheWriteTokens,
+		},
+		"output_tokens": usage.CompletionTokens,
+		"output_tokens_details": map[string]any{
+			"reasoning_tokens": reasoningTokens,
+		},
+		"total_tokens": usage.TotalTokens,
+	}
+}
+
+func responseIDFromUpstream(upstreamID string) string {
+	upstreamID = strings.TrimSpace(upstreamID)
+	if strings.HasPrefix(upstreamID, "resp_") {
+		return upstreamID
+	}
+	return newResponseID("resp")
+}
+
+func newResponseID(prefix string) string {
+	token, err := randomToken()
+	if err != nil {
+		return fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())
+	}
+	if len(token) > 22 {
+		token = token[:22]
+	}
+	return prefix + "_" + token
+}
+
+func completedAt(status string) any {
+	if status == "completed" || status == "failed" || status == "incomplete" {
+		return time.Now().Unix()
+	}
+	return nil
+}
+
+func nullableStringValue(value string) any {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return value
+}
+
+func valueOrDefault(value *bool, fallback bool) bool {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}
+
+func rawJSONValue(encoded json.RawMessage, fallback any) any {
+	trimmed := bytes.TrimSpace(encoded)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return fallback
+	}
+	var value any
+	if json.Unmarshal(trimmed, &value) != nil {
+		return fallback
+	}
+	return value
+}
+
+func rawJSONArray(values []json.RawMessage) []any {
+	result := make([]any, 0, len(values))
+	for _, encoded := range values {
+		var value any
+		if json.Unmarshal(encoded, &value) == nil {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func responseTextEcho(encoded json.RawMessage) any {
+	trimmed := bytes.TrimSpace(encoded)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return map[string]any{"format": map[string]any{"type": "text"}}
+	}
+	var value any
+	if json.Unmarshal(trimmed, &value) != nil {
+		return map[string]any{"format": map[string]any{"type": "text"}}
+	}
+	return value
+}
+
+func mergedMetadata(request responsesRequest) map[string]string {
+	result := make(map[string]string, len(request.Metadata)+len(request.ClientMetadata))
+	for key, value := range request.Metadata {
+		result[key] = value
+	}
+	for key, value := range request.ClientMetadata {
+		if _, exists := result[key]; !exists {
+			result[key] = value
+		}
+	}
+	return result
+}

--- a/services/tuttid/service/modelgateway/errors.go
+++ b/services/tuttid/service/modelgateway/errors.go
@@ -1,0 +1,80 @@
+package modelgateway
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+)
+
+type invalidRequestError struct {
+	Param   string
+	Code    string
+	Message string
+}
+
+func (e *invalidRequestError) Error() string {
+	return e.Message
+}
+
+type responsesErrorEnvelope struct {
+	Error responsesError `json:"error"`
+}
+
+type responsesError struct {
+	Message string  `json:"message"`
+	Type    string  `json:"type"`
+	Param   *string `json:"param"`
+	Code    string  `json:"code"`
+}
+
+func writeResponsesError(
+	writer http.ResponseWriter,
+	status int,
+	errorType string,
+	code string,
+	param string,
+	message string,
+) {
+	writer.Header().Set("Content-Type", "application/json")
+	writer.Header().Set("Cache-Control", "no-store")
+	writer.WriteHeader(status)
+	var encodedParam *string
+	if strings.TrimSpace(param) != "" {
+		value := param
+		encodedParam = &value
+	}
+	_ = json.NewEncoder(writer).Encode(responsesErrorEnvelope{
+		Error: responsesError{
+			Message: message,
+			Type:    errorType,
+			Param:   encodedParam,
+			Code:    code,
+		},
+	})
+}
+
+func sanitizedUpstreamBody(body []byte, secret string) []byte {
+	if strings.TrimSpace(secret) == "" {
+		return body
+	}
+	return []byte(strings.ReplaceAll(string(body), secret, "[REDACTED]"))
+}
+
+func invalidParam(param string, message string) error {
+	return &invalidRequestError{Param: param, Code: "invalid_value", Message: message}
+}
+
+func withParam(err error, prefix string) error {
+	var invalid *invalidRequestError
+	if !errors.As(err, &invalid) {
+		return err
+	}
+	copy := *invalid
+	if copy.Param == "" {
+		copy.Param = prefix
+	} else {
+		copy.Param = prefix + copy.Param
+	}
+	return &copy
+}

--- a/services/tuttid/service/modelgateway/gateway.go
+++ b/services/tuttid/service/modelgateway/gateway.go
@@ -1,0 +1,346 @@
+package modelgateway
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultListenAddress   = "127.0.0.1:0"
+	defaultRequestTimeout  = 10 * time.Minute
+	defaultFirstTokenLimit = 90 * time.Second
+	defaultMaxRequestBytes = 32 << 20
+	defaultMaxErrorBytes   = 1 << 20
+)
+
+// Route is one session-scoped upstream Chat Completions destination. The
+// upstream credential never leaves the gateway process.
+type Route struct {
+	WorkspaceID    string
+	AgentSessionID string
+	UpstreamURL    string
+	UpstreamAPIKey string
+	Models         []string
+}
+
+// ClientEndpoint is the temporary Responses endpoint injected into one Codex
+// runtime. Token is random bearer authentication for this route, not the
+// upstream model-plan credential.
+type ClientEndpoint struct {
+	BaseURL string
+	Token   string
+	WireAPI string
+}
+
+// Config controls the loopback gateway. Zero values select production
+// defaults; tests can replace the client and timeout limits.
+type Config struct {
+	ListenAddress   string
+	HTTPClient      *http.Client
+	RequestTimeout  time.Duration
+	FirstTokenLimit time.Duration
+	MaxRequestBytes int64
+	Logger          *slog.Logger
+}
+
+// Gateway owns the loopback listener and the in-memory session route table.
+type Gateway struct {
+	listener        net.Listener
+	server          *http.Server
+	client          *http.Client
+	baseURL         string
+	requestTimeout  time.Duration
+	firstTokenLimit time.Duration
+	maxRequestBytes int64
+	logger          *slog.Logger
+
+	mu        sync.RWMutex
+	byToken   map[string]Route
+	bySession map[string]string
+
+	serveDone chan struct{}
+	serveErr  error
+	closeOnce sync.Once
+}
+
+// New starts a loopback-only Model Gateway.
+func New(config Config) (*Gateway, error) {
+	address := strings.TrimSpace(config.ListenAddress)
+	if address == "" {
+		address = defaultListenAddress
+	}
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, fmt.Errorf("listen for model gateway: %w", err)
+	}
+	tcpAddress, ok := listener.Addr().(*net.TCPAddr)
+	if !ok || tcpAddress.IP == nil || !tcpAddress.IP.IsLoopback() {
+		_ = listener.Close()
+		return nil, errors.New("model gateway listener must be loopback-only")
+	}
+	requestTimeout := config.RequestTimeout
+	if requestTimeout <= 0 {
+		requestTimeout = defaultRequestTimeout
+	}
+	firstTokenLimit := config.FirstTokenLimit
+	if firstTokenLimit <= 0 {
+		firstTokenLimit = defaultFirstTokenLimit
+	}
+	maxRequestBytes := config.MaxRequestBytes
+	if maxRequestBytes <= 0 {
+		maxRequestBytes = defaultMaxRequestBytes
+	}
+	logger := config.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	gateway := &Gateway{
+		listener:        listener,
+		client:          securedHTTPClient(config.HTTPClient),
+		baseURL:         "http://" + listener.Addr().String(),
+		requestTimeout:  requestTimeout,
+		firstTokenLimit: firstTokenLimit,
+		maxRequestBytes: maxRequestBytes,
+		logger:          logger,
+		byToken:         make(map[string]Route),
+		bySession:       make(map[string]string),
+		serveDone:       make(chan struct{}),
+	}
+	gateway.server = &http.Server{
+		Handler:           gateway,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       2 * time.Minute,
+	}
+	go func() {
+		defer close(gateway.serveDone)
+		err := gateway.server.Serve(listener)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			gateway.serveErr = err
+		}
+	}()
+	return gateway, nil
+}
+
+func securedHTTPClient(input *http.Client) *http.Client {
+	var client http.Client
+	if input != nil {
+		client = *input
+	} else {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.ResponseHeaderTimeout = defaultFirstTokenLimit
+		client.Transport = transport
+	}
+	previousCheck := client.CheckRedirect
+	client.CheckRedirect = func(request *http.Request, via []*http.Request) error {
+		if len(via) == 0 {
+			return http.ErrUseLastResponse
+		}
+		origin := via[0].URL
+		if !sameOrigin(origin, request.URL) {
+			return http.ErrUseLastResponse
+		}
+		if previousCheck != nil {
+			return previousCheck(request, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameOrigin(left *url.URL, right *url.URL) bool {
+	return left != nil && right != nil &&
+		strings.EqualFold(left.Scheme, right.Scheme) &&
+		strings.EqualFold(left.Host, right.Host)
+}
+
+// Register atomically replaces any existing route for the same
+// workspace/session. The old token is invalid before the new endpoint is
+// returned.
+func (g *Gateway) Register(_ context.Context, route Route) (ClientEndpoint, error) {
+	if g == nil {
+		return ClientEndpoint{}, errors.New("model gateway is unavailable")
+	}
+	normalized, err := normalizeRoute(route)
+	if err != nil {
+		return ClientEndpoint{}, err
+	}
+	token, err := randomToken()
+	if err != nil {
+		return ClientEndpoint{}, fmt.Errorf("generate model gateway token: %w", err)
+	}
+	sessionKey := routeSessionKey(normalized.WorkspaceID, normalized.AgentSessionID)
+	g.mu.Lock()
+	if oldToken := g.bySession[sessionKey]; oldToken != "" {
+		delete(g.byToken, oldToken)
+	}
+	g.byToken[token] = normalized
+	g.bySession[sessionKey] = token
+	g.mu.Unlock()
+	return ClientEndpoint{
+		BaseURL: g.baseURL + "/v1",
+		Token:   token,
+		WireAPI: "responses",
+	}, nil
+}
+
+// Unregister revokes the current token for one workspace/session.
+func (g *Gateway) Unregister(_ context.Context, workspaceID string, agentSessionID string) {
+	if g == nil {
+		return
+	}
+	sessionKey := routeSessionKey(workspaceID, agentSessionID)
+	g.mu.Lock()
+	token := g.bySession[sessionKey]
+	delete(g.bySession, sessionKey)
+	if token != "" {
+		delete(g.byToken, token)
+	}
+	g.mu.Unlock()
+}
+
+func normalizeRoute(route Route) (Route, error) {
+	route.WorkspaceID = strings.TrimSpace(route.WorkspaceID)
+	route.AgentSessionID = strings.TrimSpace(route.AgentSessionID)
+	route.UpstreamURL = strings.TrimSpace(route.UpstreamURL)
+	route.UpstreamAPIKey = strings.TrimSpace(route.UpstreamAPIKey)
+	if route.WorkspaceID == "" || route.AgentSessionID == "" ||
+		route.UpstreamURL == "" || route.UpstreamAPIKey == "" {
+		return Route{}, errors.New("model gateway route is incomplete")
+	}
+	parsed, err := url.Parse(route.UpstreamURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return Route{}, errors.New("model gateway upstream URL must be absolute")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return Route{}, errors.New("model gateway upstream URL must use http or https")
+	}
+	if parsed.User != nil {
+		return Route{}, errors.New("model gateway upstream URL must not contain user information")
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	if !endsWithVersionSegment(parsed.Path) {
+		parsed.Path += "/v1"
+	}
+	route.UpstreamURL = parsed.String() + "/chat/completions"
+	seen := make(map[string]struct{}, len(route.Models))
+	models := make([]string, 0, len(route.Models))
+	for _, model := range route.Models {
+		model = strings.TrimSpace(model)
+		if model == "" {
+			continue
+		}
+		if _, exists := seen[model]; exists {
+			continue
+		}
+		seen[model] = struct{}{}
+		models = append(models, model)
+	}
+	route.Models = models
+	return route, nil
+}
+
+func endsWithVersionSegment(path string) bool {
+	segments := strings.Split(strings.Trim(path, "/"), "/")
+	if len(segments) == 0 {
+		return false
+	}
+	last := segments[len(segments)-1]
+	if len(last) < 2 || last[0] != 'v' {
+		return false
+	}
+	for _, character := range last[1:] {
+		if character < '0' || character > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func routeSessionKey(workspaceID string, agentSessionID string) string {
+	return strings.TrimSpace(workspaceID) + "\x00" + strings.TrimSpace(agentSessionID)
+}
+
+func randomToken() (string, error) {
+	value := make([]byte, 32)
+	if _, err := rand.Read(value); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(value), nil
+}
+
+func (g *Gateway) routeForRequest(request *http.Request) (Route, bool) {
+	authorization := strings.TrimSpace(request.Header.Get("Authorization"))
+	const prefix = "Bearer "
+	if !strings.HasPrefix(authorization, prefix) {
+		return Route{}, false
+	}
+	token := strings.TrimSpace(strings.TrimPrefix(authorization, prefix))
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	for candidate, route := range g.byToken {
+		if len(candidate) == len(token) &&
+			subtle.ConstantTimeCompare([]byte(candidate), []byte(token)) == 1 {
+			return route, true
+		}
+	}
+	return Route{}, false
+}
+
+func (g *Gateway) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	if request.URL.Path != "/v1/responses" || request.URL.RawQuery != "" {
+		writeResponsesError(writer, http.StatusNotFound, "invalid_request_error", "not_found", "", "Only POST /v1/responses is supported")
+		return
+	}
+	if request.Method != http.MethodPost {
+		writer.Header().Set("Allow", http.MethodPost)
+		writeResponsesError(writer, http.StatusMethodNotAllowed, "invalid_request_error", "method_not_allowed", "", "Only POST /v1/responses is supported")
+		return
+	}
+	route, ok := g.routeForRequest(request)
+	if !ok {
+		writeResponsesError(writer, http.StatusUnauthorized, "invalid_request_error", "invalid_api_key", "", "Invalid model gateway token")
+		return
+	}
+	g.handleResponses(writer, request, route)
+}
+
+// Close stops the listener and revokes every route.
+func (g *Gateway) Close() error {
+	if g == nil {
+		return nil
+	}
+	var closeErr error
+	g.closeOnce.Do(func() {
+		g.mu.Lock()
+		clear(g.byToken)
+		clear(g.bySession)
+		g.mu.Unlock()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		closeErr = g.server.Shutdown(ctx)
+		if closeErr != nil {
+			_ = g.server.Close()
+		}
+		<-g.serveDone
+		if closeErr == nil {
+			closeErr = g.serveErr
+		}
+	})
+	return closeErr
+}

--- a/services/tuttid/service/modelgateway/gateway_test.go
+++ b/services/tuttid/service/modelgateway/gateway_test.go
@@ -1,0 +1,823 @@
+package modelgateway
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestGatewayConvertsResponsesRequestAndChatJSON(t *testing.T) {
+	t.Parallel()
+
+	var upstreamRequest chatRequest
+	var upstreamAuthorization string
+	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		upstreamAuthorization = request.Header.Get("Authorization")
+		if request.URL.Path != "/v1/chat/completions" {
+			http.Error(writer, "unexpected path", http.StatusNotFound)
+			return
+		}
+		if err := json.NewDecoder(request.Body).Decode(&upstreamRequest); err != nil {
+			http.Error(writer, "invalid request", http.StatusBadRequest)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(writer, `{
+			"id":"chatcmpl-upstream",
+			"object":"chat.completion",
+			"created":123,
+			"model":"model-a",
+			"choices":[{
+				"index":0,
+				"message":{
+					"role":"assistant",
+					"content":"完成",
+					"reasoning_content":"分析",
+					"tool_calls":[{
+						"index":0,
+						"id":"call_one",
+						"type":"function",
+						"function":{"name":"workspace__read_file","arguments":"{\"path\":\"README.md\"}"}
+					}]
+				},
+				"finish_reason":"tool_calls"
+			}],
+			"usage":{
+				"prompt_tokens":10,
+				"completion_tokens":5,
+				"total_tokens":15,
+				"prompt_tokens_details":{"cached_tokens":3},
+				"completion_tokens_details":{"reasoning_tokens":2}
+			}
+		}`)
+	}))
+	defer upstream.Close()
+
+	gateway := newTestGateway(t, Config{})
+	endpoint := registerTestRoute(t, gateway, upstream.URL, "upstream-secret", "model-a", "workspace", "session")
+
+	body := `{
+		"model":"model-a",
+		"instructions":"Follow instructions",
+		"input":[
+			{"type":"message","role":"user","content":[
+				{"type":"input_text","text":"Inspect"},
+				{"type":"input_image","image_url":"data:image/png;base64,AA==","detail":"high"}
+			]},
+			{"type":"reasoning","summary":[{"type":"summary_text","text":"prior reasoning"}],"encrypted_content":null},
+			{"type":"function_call","call_id":"call_old","namespace":"workspace","name":"read_file","arguments":"{}"},
+			{"type":"function_call_output","call_id":"call_old","output":"ok"}
+		],
+		"tools":[{
+			"type":"namespace",
+			"name":"workspace",
+			"description":"Workspace functions",
+			"tools":[{
+				"type":"function",
+				"name":"read_file",
+				"description":"Read one file",
+				"parameters":{"type":"object","properties":{"path":{"type":"string"}}},
+				"strict":true
+			}]
+		},{
+			"type":"namespace",
+			"name":"archive",
+			"description":"Archive functions",
+			"tools":[{
+				"type":"function",
+				"name":"read_file",
+				"description":"Read an archived file",
+				"parameters":{"type":"object"},
+				"strict":false
+			}]
+		}],
+		"tool_choice":{"type":"function","namespace":"workspace","name":"read_file"},
+		"parallel_tool_calls":true,
+		"reasoning":{"effort":"high","summary":"auto"},
+		"max_output_tokens":2048,
+		"temperature":0.2,
+		"top_p":0.9,
+		"stream":false,
+		"store":false,
+		"include":["reasoning.encrypted_content"],
+		"prompt_cache_key":"cache-1",
+		"text":{"verbosity":"low"},
+		"client_metadata":{"trace":"one"}
+	}`
+	response := postResponses(t, endpoint, body, nil)
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.StatusCode, readBody(t, response.Body))
+	}
+	if upstreamAuthorization != "Bearer upstream-secret" {
+		t.Fatalf("upstream authorization = %q", upstreamAuthorization)
+	}
+	if upstreamRequest.Model != "model-a" || upstreamRequest.ReasoningEffort != "high" {
+		t.Fatalf("upstream request = %#v", upstreamRequest)
+	}
+	if upstreamRequest.MaxTokens == nil || *upstreamRequest.MaxTokens != 2048 {
+		t.Fatalf("max_completion_tokens = %#v", upstreamRequest.MaxTokens)
+	}
+	if len(upstreamRequest.Messages) != 4 {
+		t.Fatalf("upstream messages = %#v", upstreamRequest.Messages)
+	}
+	if upstreamRequest.Messages[0]["role"] != "system" || upstreamRequest.Messages[0]["content"] != "Follow instructions" {
+		t.Fatalf("system message = %#v", upstreamRequest.Messages[0])
+	}
+	if upstreamRequest.Messages[2]["reasoning_content"] != "prior reasoning" {
+		t.Fatalf("assistant history = %#v", upstreamRequest.Messages[2])
+	}
+	historyToolCalls := upstreamRequest.Messages[2]["tool_calls"].([]any)
+	historyFunction := historyToolCalls[0].(map[string]any)["function"].(map[string]any)
+	if historyFunction["name"] != "workspace__read_file" {
+		t.Fatalf("namespaced function-call history = %#v", historyFunction)
+	}
+	if upstreamRequest.Messages[3]["role"] != "tool" || upstreamRequest.Messages[3]["tool_call_id"] != "call_old" {
+		t.Fatalf("tool output = %#v", upstreamRequest.Messages[3])
+	}
+	if len(upstreamRequest.Tools) != 2 {
+		t.Fatalf("tools = %#v", upstreamRequest.Tools)
+	}
+	upstreamFunction := upstreamRequest.Tools[0]["function"].(map[string]any)
+	if upstreamFunction["name"] != "workspace__read_file" {
+		t.Fatalf("flattened namespaced function = %#v", upstreamFunction)
+	}
+	archiveFunction := upstreamRequest.Tools[1]["function"].(map[string]any)
+	if archiveFunction["name"] != "archive__read_file" {
+		t.Fatalf("second flattened namespaced function = %#v", archiveFunction)
+	}
+	upstreamChoice := upstreamRequest.ToolChoice.(map[string]any)["function"].(map[string]any)
+	if upstreamChoice["name"] != "workspace__read_file" {
+		t.Fatalf("flattened namespaced tool choice = %#v", upstreamRequest.ToolChoice)
+	}
+
+	var converted map[string]any
+	if err := json.NewDecoder(response.Body).Decode(&converted); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if converted["object"] != "response" || converted["status"] != "completed" {
+		t.Fatalf("converted response = %#v", converted)
+	}
+	output, ok := converted["output"].([]any)
+	if !ok || len(output) != 3 {
+		t.Fatalf("output = %#v", converted["output"])
+	}
+	if output[0].(map[string]any)["type"] != "reasoning" ||
+		output[1].(map[string]any)["type"] != "message" ||
+		output[2].(map[string]any)["type"] != "function_call" {
+		t.Fatalf("output order = %#v", output)
+	}
+	if output[2].(map[string]any)["namespace"] != "workspace" {
+		t.Fatalf("namespaced function call = %#v", output[2])
+	}
+	usage := converted["usage"].(map[string]any)
+	if usage["input_tokens"] != float64(10) || usage["output_tokens"] != float64(5) {
+		t.Fatalf("usage = %#v", usage)
+	}
+}
+
+func TestGatewayFiltersUntranslatableToolRegistrations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		body             string
+		wantToolNames    []string
+		wantToolChoice   any
+		wantParallelTool *bool
+	}{
+		{
+			name: "mixed supported and future hosted tools",
+			body: `{
+				"model":"model-a",
+				"input":"hello",
+				"tools":[
+					{"type":"web_search"},
+					{"type":"future_hosted_tool","preview":true},
+					{"type":"function","name":"read_file","parameters":{"type":"object"}}
+				],
+				"tool_choice":"auto",
+				"parallel_tool_calls":true
+			}`,
+			wantToolNames:    []string{"read_file"},
+			wantToolChoice:   "auto",
+			wantParallelTool: boolPointerForGatewayTest(true),
+		},
+		{
+			name: "required choice preserved when a supported tool remains",
+			body: `{
+				"model":"model-a",
+				"input":"hello",
+				"tools":[
+					{"type":"web_search"},
+					{"type":"function","name":"read_file","parameters":{"type":"object"}}
+				],
+				"tool_choice":"required"
+			}`,
+			wantToolNames:  []string{"read_file"},
+			wantToolChoice: "required",
+		},
+		{
+			name: "all registrations filtered",
+			body: `{
+				"model":"model-a",
+				"input":"hello",
+				"tools":[
+					{"type":"web_search"},
+					{"type":"future_hosted_tool"}
+				],
+				"tool_choice":"auto",
+				"parallel_tool_calls":true
+			}`,
+		},
+		{
+			name: "untranslatable namespace children filtered",
+			body: `{
+				"model":"model-a",
+				"input":"hello",
+				"tools":[{
+					"type":"namespace",
+					"name":"workspace",
+					"tools":[
+						{"type":"future_hosted_tool","name":"preview"},
+						{"type":"function","name":"write_file","parameters":{"type":"object"}}
+					]
+				}]
+			}`,
+			wantToolNames: []string{"workspace__write_file"},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var upstreamRequest chatRequest
+			upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if err := json.NewDecoder(request.Body).Decode(&upstreamRequest); err != nil {
+					http.Error(writer, "invalid request", http.StatusBadRequest)
+					return
+				}
+				writer.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(writer, `{
+					"id":"chat-filtered",
+					"model":"model-a",
+					"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+					"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+				}`)
+			}))
+			defer upstream.Close()
+
+			gateway := newTestGateway(t, Config{})
+			endpoint := registerTestRoute(t, gateway, upstream.URL, "secret", "model-a", "workspace", "session")
+			response := postResponses(t, endpoint, test.body, nil)
+			defer response.Body.Close()
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, body = %s", response.StatusCode, readBody(t, response.Body))
+			}
+
+			gotToolNames := make([]string, 0, len(upstreamRequest.Tools))
+			for _, tool := range upstreamRequest.Tools {
+				function, _ := tool["function"].(map[string]any)
+				name, _ := function["name"].(string)
+				gotToolNames = append(gotToolNames, name)
+			}
+			if fmt.Sprint(gotToolNames) != fmt.Sprint(test.wantToolNames) {
+				t.Fatalf("upstream tool names = %v, want %v", gotToolNames, test.wantToolNames)
+			}
+			if fmt.Sprint(upstreamRequest.ToolChoice) != fmt.Sprint(test.wantToolChoice) {
+				t.Fatalf("upstream tool_choice = %#v, want %#v", upstreamRequest.ToolChoice, test.wantToolChoice)
+			}
+			switch {
+			case test.wantParallelTool == nil && upstreamRequest.ParallelToolCalls != nil:
+				t.Fatalf("parallel_tool_calls = %#v, want nil", upstreamRequest.ParallelToolCalls)
+			case test.wantParallelTool != nil &&
+				(upstreamRequest.ParallelToolCalls == nil ||
+					*upstreamRequest.ParallelToolCalls != *test.wantParallelTool):
+				t.Fatalf("parallel_tool_calls = %#v, want %v", upstreamRequest.ParallelToolCalls, *test.wantParallelTool)
+			}
+		})
+	}
+}
+
+func boolPointerForGatewayTest(value bool) *bool {
+	return &value
+}
+
+func TestGatewayNormalizesCodexInternalRolesAndCollapsesSystemMessages(t *testing.T) {
+	t.Parallel()
+
+	var upstreamRequest chatRequest
+	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if err := json.NewDecoder(request.Body).Decode(&upstreamRequest); err != nil {
+			http.Error(writer, "invalid request", http.StatusBadRequest)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(writer, `{
+			"id":"chat-developer-role",
+			"model":"model-a",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]
+		}`)
+	}))
+	defer upstream.Close()
+
+	gateway := newTestGateway(t, Config{})
+	endpoint := registerTestRoute(t, gateway, upstream.URL, "secret", "model-a", "workspace", "session")
+	response := postResponses(t, endpoint, `{
+		"model":"model-a",
+		"instructions":"instruction",
+		"input":[
+			{"type":"message","role":"developer","content":[{"type":"input_text","text":"context"}]},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]},
+			{"type":"message","role":"developer","content":[
+				{"type":"input_text","text":"late instruction"},
+				{"type":"input_text","text":"continued"}
+			]},
+			{"type":"message","role":"latest_reminder","content":[{"type":"input_text","text":"reminder"}]},
+			{"type":"message","role":"unknown_codex_role","content":[{"type":"input_text","text":"fallback"}]}
+		]
+	}`, nil)
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.StatusCode, readBody(t, response.Body))
+	}
+	if len(upstreamRequest.Messages) != 4 {
+		t.Fatalf("messages = %#v", upstreamRequest.Messages)
+	}
+	for index, wantRole := range []string{"system", "user", "user", "user"} {
+		if upstreamRequest.Messages[index]["role"] != wantRole {
+			t.Fatalf("messages[%d].role = %#v, want %q", index, upstreamRequest.Messages[index]["role"], wantRole)
+		}
+	}
+	if upstreamRequest.Messages[0]["content"] != "instruction\n\ncontext\n\nlate instruction\ncontinued" {
+		t.Fatalf("system content = %#v", upstreamRequest.Messages[0]["content"])
+	}
+	if upstreamRequest.Messages[1]["content"] != "hello" ||
+		upstreamRequest.Messages[2]["content"] != "reminder" ||
+		upstreamRequest.Messages[3]["content"] != "fallback" {
+		t.Fatalf("non-system message order = %#v", upstreamRequest.Messages)
+	}
+}
+
+func TestGatewayStreamsInterleavedToolCallsReasoningAndUTF8WithoutDone(t *testing.T) {
+	t.Parallel()
+
+	largeArguments := `{"value":"` + strings.Repeat("x", 70<<10) + `"}`
+	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "text/event-stream")
+		flusher := writer.(http.Flusher)
+		events := []string{
+			`{"id":"chat-1","model":"model-a","choices":[{"index":0,"delta":{"reasoning_content":"思考"}}]}`,
+			`{"id":"chat-1","model":"model-a","choices":[{"index":0,"delta":{"content":"你"}}]}`,
+			`{"id":"chat-1","model":"model-a","choices":[{"index":0,"delta":{"content":"好"}}]}`,
+			`{"id":"chat-1","model":"model-a","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"alpha","arguments":"{\"a\":"}},{"index":1,"id":"call_b","type":"function","function":{"name":"beta","arguments":"{\"b\":"}}]}}]}`,
+			`{"id":"chat-1","model":"model-a","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"2}"}},{"index":0,"function":{"arguments":"1}"}}]}}]}`,
+			fmt.Sprintf(`{"id":"chat-1","model":"model-a","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":%q}}]}}]}`, largeArguments),
+			`{"id":"chat-1","model":"model-a","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+			`{"id":"chat-1","model":"model-a","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":50,"total_tokens":150,"completion_tokens_details":{"reasoning_tokens":10}}}`,
+		}
+		for _, event := range events {
+			_, _ = io.WriteString(writer, "data: "+event+"\n\n")
+			flusher.Flush()
+		}
+		// Deliberately omit the Chat [DONE] marker. finish_reason is
+		// authoritative and must still complete the Responses stream.
+	}))
+	defer upstream.Close()
+
+	gateway := newTestGateway(t, Config{})
+	endpoint := registerTestRoute(t, gateway, upstream.URL, "secret", "model-a", "workspace", "session")
+	response := postResponses(t, endpoint, `{
+		"model":"model-a",
+		"input":"請處理",
+		"tools":[
+			{"type":"function","name":"alpha","parameters":{"type":"object"}},
+			{"type":"function","name":"beta","parameters":{"type":"object"}}
+		],
+		"tool_choice":"auto",
+		"parallel_tool_calls":true,
+		"stream":true
+	}`, nil)
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.StatusCode, readBody(t, response.Body))
+	}
+	events := readSSEEvents(t, response.Body)
+	types := make([]string, 0, len(events))
+	var completed map[string]any
+	var toolDone []map[string]any
+	for _, event := range events {
+		types = append(types, event.Event)
+		var payload map[string]any
+		if err := json.Unmarshal(event.Data, &payload); err != nil {
+			t.Fatalf("decode %s: %v", event.Event, err)
+		}
+		if event.Event == "response.output_item.done" {
+			item, _ := payload["item"].(map[string]any)
+			if item["type"] == "function_call" {
+				toolDone = append(toolDone, item)
+			}
+		}
+		if event.Event == "response.completed" {
+			completed = payload
+		}
+	}
+	for _, required := range []string{
+		"response.created",
+		"response.in_progress",
+		"response.output_item.added",
+		"response.content_part.added",
+		"response.output_text.delta",
+		"response.function_call_arguments.delta",
+		"response.output_item.done",
+		"response.completed",
+	} {
+		if !containsString(types, required) {
+			t.Fatalf("missing event %q in %v", required, types)
+		}
+	}
+	if len(toolDone) != 2 {
+		t.Fatalf("tool calls = %#v", toolDone)
+	}
+	argumentsByName := map[string]string{}
+	for _, item := range toolDone {
+		argumentsByName[item["name"].(string)] = item["arguments"].(string)
+	}
+	if argumentsByName["beta"] != `{"b":2}` {
+		t.Fatalf("beta arguments = %q", argumentsByName["beta"])
+	}
+	if !strings.Contains(argumentsByName["alpha"], largeArguments) {
+		t.Fatalf("alpha arguments length = %d, want >64KB payload", len(argumentsByName["alpha"]))
+	}
+	if completed == nil {
+		t.Fatal("response.completed missing")
+	}
+	responseObject := completed["response"].(map[string]any)
+	if responseObject["status"] != "completed" {
+		t.Fatalf("completed response = %#v", responseObject)
+	}
+}
+
+func TestGatewayRouteIsolationReplacementAndCleanup(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	upstreamHits := map[string]int{}
+	newUpstream := func(name string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			upstreamHits[name]++
+			mu.Unlock()
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(writer, `{"id":"chat","model":"model-a","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`)
+		}))
+	}
+	upstreamA := newUpstream("a")
+	defer upstreamA.Close()
+	upstreamB := newUpstream("b")
+	defer upstreamB.Close()
+
+	gateway := newTestGateway(t, Config{})
+	first := registerTestRoute(t, gateway, upstreamA.URL, "secret-a", "model-a", "workspace-a", "session")
+	second := registerTestRoute(t, gateway, upstreamB.URL, "secret-b", "model-a", "workspace-b", "session")
+	replacement := registerTestRoute(t, gateway, upstreamB.URL, "secret-c", "model-a", "workspace-a", "session")
+
+	assertGatewayStatus(t, first, http.StatusUnauthorized)
+	assertGatewayStatus(t, second, http.StatusOK)
+	assertGatewayStatus(t, replacement, http.StatusOK)
+	gateway.Unregister(context.Background(), "workspace-a", "session")
+	assertGatewayStatus(t, replacement, http.StatusUnauthorized)
+	assertGatewayStatus(t, second, http.StatusOK)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if upstreamHits["a"] != 0 || upstreamHits["b"] != 3 {
+		t.Fatalf("upstream hits = %#v", upstreamHits)
+	}
+}
+
+func TestGatewayRejectsUnsupportedResponsesInputs(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("upstream must not be called")
+	}))
+	defer upstream.Close()
+	gateway := newTestGateway(t, Config{})
+	endpoint := registerTestRoute(t, gateway, upstream.URL, "secret", "model-a", "workspace", "session")
+
+	tests := []struct {
+		name  string
+		body  string
+		param string
+	}{
+		{
+			name:  "explicit hosted tool choice",
+			body:  `{"model":"model-a","input":"x","tools":[{"type":"web_search"}],"tool_choice":{"type":"web_search"}}`,
+			param: "tool_choice",
+		},
+		{
+			name:  "required choice after all registrations filtered",
+			body:  `{"model":"model-a","input":"x","tools":[{"type":"future_hosted_tool"}],"tool_choice":"required"}`,
+			param: "tool_choice",
+		},
+		{
+			name:  "unregistered named function choice",
+			body:  `{"model":"model-a","input":"x","tools":[{"type":"function","name":"alpha"}],"tool_choice":{"type":"function","name":"beta"}}`,
+			param: "tool_choice",
+		},
+		{
+			name:  "hosted tool call history",
+			body:  `{"model":"model-a","input":[{"type":"web_search_call","id":"search_1"}]}`,
+			param: "input[0].type",
+		},
+		{
+			name:  "previous response",
+			body:  `{"model":"model-a","input":"x","previous_response_id":"resp_old"}`,
+			param: "previous_response_id",
+		},
+		{
+			name:  "background",
+			body:  `{"model":"model-a","input":"x","background":true}`,
+			param: "background",
+		},
+		{
+			name:  "encrypted reasoning history",
+			body:  `{"model":"model-a","input":[{"type":"reasoning","summary":[],"encrypted_content":"cipher"}]}`,
+			param: "input[0].encrypted_content",
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			response := postResponses(t, endpoint, test.body, nil)
+			defer response.Body.Close()
+			if response.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, body = %s", response.StatusCode, readBody(t, response.Body))
+			}
+			var payload responsesErrorEnvelope
+			if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode error: %v", err)
+			}
+			if payload.Error.Param == nil || *payload.Error.Param != test.param {
+				t.Fatalf("error = %#v, want param %q", payload.Error, test.param)
+			}
+		})
+	}
+}
+
+func TestGatewayPreservesUpstreamErrorsAndRedactsCredential(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusTooManyRequests, http.StatusInternalServerError} {
+		status := status
+		t.Run(fmt.Sprintf("status_%d", status), func(t *testing.T) {
+			t.Parallel()
+			upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				writer.WriteHeader(status)
+				_, _ = io.WriteString(writer, `{"error":{"message":"credential upstream-secret rejected","type":"invalid_request_error","code":"upstream"}}`)
+			}))
+			defer upstream.Close()
+			gateway := newTestGateway(t, Config{})
+			endpoint := registerTestRoute(t, gateway, upstream.URL, "upstream-secret", "model-a", "workspace", fmt.Sprintf("session-%d", status))
+			response := postResponses(t, endpoint, `{"model":"model-a","input":"x"}`, nil)
+			defer response.Body.Close()
+			body := readBody(t, response.Body)
+			if response.StatusCode != status {
+				t.Fatalf("status = %d, want %d", response.StatusCode, status)
+			}
+			if strings.Contains(body, "upstream-secret") || !strings.Contains(body, "[REDACTED]") {
+				t.Fatalf("body was not redacted: %s", body)
+			}
+		})
+	}
+}
+
+func TestGatewayFirstTokenTimeoutAndMidStreamDisconnect(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		code    string
+	}{
+		{
+			name: "first token timeout",
+			handler: func(writer http.ResponseWriter, request *http.Request) {
+				writer.Header().Set("Content-Type", "text/event-stream")
+				writer.WriteHeader(http.StatusOK)
+				writer.(http.Flusher).Flush()
+				<-request.Context().Done()
+			},
+			code: "upstream_timeout",
+		},
+		{
+			name: "mid-stream disconnect",
+			handler: func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("Content-Type", "text/event-stream")
+				_, _ = io.WriteString(writer, `data: {"id":"chat","choices":[{"index":0,"delta":{"content":"partial"}}]}`+"\n\n")
+				writer.(http.Flusher).Flush()
+			},
+			code: "upstream_stream_error",
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			upstream := httptest.NewServer(test.handler)
+			defer upstream.Close()
+			gateway := newTestGateway(t, Config{FirstTokenLimit: 30 * time.Millisecond})
+			endpoint := registerTestRoute(t, gateway, upstream.URL, "secret", "model-a", "workspace", test.name)
+			response := postResponses(t, endpoint, `{"model":"model-a","input":"x","stream":true}`, nil)
+			defer response.Body.Close()
+			events := readSSEEvents(t, response.Body)
+			if len(events) < 3 || events[len(events)-1].Event != "response.failed" {
+				t.Fatalf("events = %#v", events)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(events[len(events)-1].Data, &payload); err != nil {
+				t.Fatalf("decode failed event: %v", err)
+			}
+			responseObject := payload["response"].(map[string]any)
+			responseError := responseObject["error"].(map[string]any)
+			if responseError["code"] != test.code {
+				t.Fatalf("error = %#v", responseError)
+			}
+		})
+	}
+}
+
+func TestGatewayPropagatesClientCancellation(t *testing.T) {
+	t.Parallel()
+
+	upstreamCanceled := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		defer close(upstreamCanceled)
+		writer.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(writer, `data: {"id":"chat","choices":[{"index":0,"delta":{"content":"first"}}]}`+"\n\n")
+		writer.(http.Flusher).Flush()
+		<-request.Context().Done()
+	}))
+	defer upstream.Close()
+	gateway := newTestGateway(t, Config{})
+	endpoint := registerTestRoute(t, gateway, upstream.URL, "secret", "model-a", "workspace", "session")
+	ctx, cancel := context.WithCancel(context.Background())
+	response := postResponses(t, endpoint, `{"model":"model-a","input":"x","stream":true}`, ctx)
+	decoder := newSSEDecoder(response.Body)
+	for {
+		event, err := decoder.Next()
+		if err != nil {
+			t.Fatalf("read initial stream: %v", err)
+		}
+		if event.Event == "response.output_text.delta" {
+			break
+		}
+	}
+	cancel()
+	_ = response.Body.Close()
+	select {
+	case <-upstreamCanceled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("upstream request was not canceled")
+	}
+}
+
+func TestSSEDecoderHandlesArbitraryByteBoundariesAndLargeData(t *testing.T) {
+	t.Parallel()
+
+	payload := `{"text":"中文","arguments":"` + strings.Repeat("x", 70<<10) + `"}`
+	source := "event: chunk\r\ndata: " + payload + "\r\n\r\n"
+	decoder := newSSEDecoder(&oneByteReader{data: []byte(source)})
+	event, err := decoder.Next()
+	if err != nil {
+		t.Fatalf("Next() error = %v", err)
+	}
+	if event.Event != "chunk" || string(event.Data) != payload {
+		t.Fatalf("event = %q / %d bytes", event.Event, len(event.Data))
+	}
+	if _, err := decoder.Next(); !errors.Is(err, io.EOF) {
+		t.Fatalf("second Next() error = %v, want EOF", err)
+	}
+}
+
+type oneByteReader struct {
+	data []byte
+}
+
+func (r *oneByteReader) Read(buffer []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, io.EOF
+	}
+	buffer[0] = r.data[0]
+	r.data = r.data[1:]
+	return 1, nil
+}
+
+func newTestGateway(t *testing.T, config Config) *Gateway {
+	t.Helper()
+	gateway, err := New(config)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := gateway.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+	return gateway
+}
+
+func registerTestRoute(
+	t *testing.T,
+	gateway *Gateway,
+	upstreamURL string,
+	upstreamKey string,
+	model string,
+	workspaceID string,
+	sessionID string,
+) ClientEndpoint {
+	t.Helper()
+	endpoint, err := gateway.Register(context.Background(), Route{
+		WorkspaceID: workspaceID, AgentSessionID: sessionID,
+		UpstreamURL: upstreamURL, UpstreamAPIKey: upstreamKey, Models: []string{model},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	if endpoint.WireAPI != "responses" || len(endpoint.Token) < 43 {
+		t.Fatalf("endpoint = %#v", endpoint)
+	}
+	return endpoint
+}
+
+func postResponses(t *testing.T, endpoint ClientEndpoint, body string, ctx context.Context) *http.Response {
+	t.Helper()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.BaseURL+"/responses", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+endpoint.Token)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	return response
+}
+
+func assertGatewayStatus(t *testing.T, endpoint ClientEndpoint, expected int) {
+	t.Helper()
+	response := postResponses(t, endpoint, `{"model":"model-a","input":"x"}`, nil)
+	defer response.Body.Close()
+	if response.StatusCode != expected {
+		t.Fatalf("status = %d, want %d, body = %s", response.StatusCode, expected, readBody(t, response.Body))
+	}
+}
+
+func readSSEEvents(t *testing.T, reader io.Reader) []sseEvent {
+	t.Helper()
+	decoder := newSSEDecoder(reader)
+	var events []sseEvent
+	for {
+		event, err := decoder.Next()
+		if errors.Is(err, io.EOF) {
+			return events
+		}
+		if err != nil {
+			t.Fatalf("read SSE: %v", err)
+		}
+		events = append(events, event)
+	}
+}
+
+func readBody(t *testing.T, reader io.Reader) string {
+	t.Helper()
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	return string(body)
+}
+
+func containsString(values []string, wanted string) bool {
+	for _, value := range values {
+		if value == wanted {
+			return true
+		}
+	}
+	return false
+}

--- a/services/tuttid/service/modelgateway/handler.go
+++ b/services/tuttid/service/modelgateway/handler.go
@@ -94,7 +94,7 @@ func (g *Gateway) handleResponses(writer http.ResponseWriter, request *http.Requ
 		mediaType, _, _ := mime.ParseMediaType(upstreamResponse.Header.Get("Content-Type"))
 		if mediaType == "application/json" {
 			var chatOutput chatCompletionResponse
-			if err := json.NewDecoder(upstreamResponse.Body).Decode(&chatOutput); err != nil {
+			if err := json.NewDecoder(io.LimitReader(upstreamResponse.Body, g.maxRequestBytes+1)).Decode(&chatOutput); err != nil {
 				writeResponsesError(writer, http.StatusBadGateway, "server_error", "upstream_error", "", "Upstream returned invalid Chat JSON")
 				return
 			}

--- a/services/tuttid/service/modelgateway/handler.go
+++ b/services/tuttid/service/modelgateway/handler.go
@@ -1,0 +1,174 @@
+package modelgateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+)
+
+func (g *Gateway) handleResponses(writer http.ResponseWriter, request *http.Request, route Route) {
+	responsesInput, err := decodeResponsesRequest(request.Body, g.maxRequestBytes)
+	if err != nil {
+		writeInvalidRequest(writer, err)
+		return
+	}
+	if !routeAllowsModel(route, responsesInput.Model) {
+		writeResponsesError(
+			writer,
+			http.StatusBadRequest,
+			"invalid_request_error",
+			"model_not_found",
+			"model",
+			fmt.Sprintf("Model %q is not authorized by this Model Plan", responsesInput.Model),
+		)
+		return
+	}
+	chatInput, toolMap, err := convertResponsesRequest(responsesInput)
+	if err != nil {
+		writeInvalidRequest(writer, err)
+		return
+	}
+	if len(chatInput.filteredToolTypes) > 0 {
+		g.logger.DebugContext(
+			request.Context(),
+			"filtered untranslatable Responses tool registrations",
+			"event", "model_gateway.tools.filtered",
+			"workspace_id", route.WorkspaceID,
+			"agent_session_id", route.AgentSessionID,
+			"tool_types", strings.Join(chatInput.filteredToolTypes, ","),
+			"tool_type_count", len(chatInput.filteredToolTypes),
+		)
+	}
+	encoded, err := json.Marshal(chatInput)
+	if err != nil {
+		writeResponsesError(writer, http.StatusInternalServerError, "server_error", "gateway_error", "", "Could not encode upstream request")
+		return
+	}
+	upstreamContext := request.Context()
+	cancel := func() {}
+	if g.requestTimeout > 0 {
+		upstreamContext, cancel = context.WithTimeout(upstreamContext, g.requestTimeout)
+	}
+	defer cancel()
+	upstreamRequest, err := http.NewRequestWithContext(
+		upstreamContext,
+		http.MethodPost,
+		route.UpstreamURL,
+		bytes.NewReader(encoded),
+	)
+	if err != nil {
+		writeResponsesError(writer, http.StatusBadGateway, "server_error", "upstream_error", "", "Could not create upstream request")
+		return
+	}
+	upstreamRequest.Header.Set("Authorization", "Bearer "+route.UpstreamAPIKey)
+	upstreamRequest.Header.Set("Content-Type", "application/json")
+	upstreamRequest.Header.Set("Accept", "application/json")
+	if responsesInput.Stream {
+		upstreamRequest.Header.Set("Accept", "text/event-stream")
+	}
+	upstreamRequest.Header.Set("User-Agent", "tuttid-model-gateway/1")
+	upstreamResponse, err := g.client.Do(upstreamRequest)
+	if err != nil {
+		if errors.Is(upstreamContext.Err(), context.Canceled) {
+			return
+		}
+		if errors.Is(upstreamContext.Err(), context.DeadlineExceeded) {
+			writeResponsesError(writer, http.StatusGatewayTimeout, "server_error", "upstream_timeout", "", "Upstream model request timed out")
+			return
+		}
+		writeResponsesError(writer, http.StatusBadGateway, "server_error", "upstream_error", "", "Upstream model request failed")
+		return
+	}
+	defer upstreamResponse.Body.Close()
+	if upstreamResponse.StatusCode < 200 || upstreamResponse.StatusCode >= 300 {
+		writeUpstreamHTTPError(writer, upstreamResponse, route.UpstreamAPIKey)
+		return
+	}
+	if responsesInput.Stream {
+		mediaType, _, _ := mime.ParseMediaType(upstreamResponse.Header.Get("Content-Type"))
+		if mediaType == "application/json" {
+			var chatOutput chatCompletionResponse
+			if err := json.NewDecoder(upstreamResponse.Body).Decode(&chatOutput); err != nil {
+				writeResponsesError(writer, http.StatusBadGateway, "server_error", "upstream_error", "", "Upstream returned invalid Chat JSON")
+				return
+			}
+			writeSyntheticStream(writer, responsesInput, chatOutput, toolMap)
+			return
+		}
+		g.convertChatStream(writer, request, responsesInput, upstreamResponse, toolMap)
+		return
+	}
+	var chatOutput chatCompletionResponse
+	decoder := json.NewDecoder(io.LimitReader(upstreamResponse.Body, g.maxRequestBytes+1))
+	if err := decoder.Decode(&chatOutput); err != nil {
+		writeResponsesError(writer, http.StatusBadGateway, "server_error", "upstream_error", "", "Upstream returned invalid Chat JSON")
+		return
+	}
+	response, err := convertChatResponse(responsesInput, chatOutput, toolMap)
+	if err != nil {
+		writeResponsesError(writer, http.StatusBadGateway, "server_error", "upstream_error", "", "Upstream Chat response could not be converted")
+		return
+	}
+	writer.Header().Set("Content-Type", "application/json")
+	writer.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(writer).Encode(response)
+}
+
+func routeAllowsModel(route Route, model string) bool {
+	if len(route.Models) == 0 {
+		return true
+	}
+	for _, allowed := range route.Models {
+		if model == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+func writeInvalidRequest(writer http.ResponseWriter, err error) {
+	var invalid *invalidRequestError
+	if errors.As(err, &invalid) {
+		writeResponsesError(
+			writer,
+			http.StatusBadRequest,
+			"invalid_request_error",
+			invalid.Code,
+			invalid.Param,
+			invalid.Message,
+		)
+		return
+	}
+	writeResponsesError(writer, http.StatusBadRequest, "invalid_request_error", "invalid_value", "", err.Error())
+}
+
+func writeUpstreamHTTPError(writer http.ResponseWriter, response *http.Response, secret string) {
+	body, _ := io.ReadAll(io.LimitReader(response.Body, defaultMaxErrorBytes))
+	body = sanitizedUpstreamBody(body, secret)
+	writer.Header().Set("Content-Type", "application/json")
+	writer.Header().Set("Cache-Control", "no-store")
+	if retryAfter := strings.TrimSpace(response.Header.Get("Retry-After")); retryAfter != "" {
+		writer.Header().Set("Retry-After", retryAfter)
+	}
+	writer.WriteHeader(response.StatusCode)
+	var payload map[string]any
+	if json.Unmarshal(body, &payload) == nil {
+		if _, exists := payload["error"]; exists {
+			_ = json.NewEncoder(writer).Encode(payload)
+			return
+		}
+	}
+	_ = json.NewEncoder(writer).Encode(responsesErrorEnvelope{
+		Error: responsesError{
+			Message: fmt.Sprintf("Upstream Chat endpoint returned HTTP %d", response.StatusCode),
+			Type:    "server_error",
+			Code:    "upstream_error",
+		},
+	})
+}

--- a/services/tuttid/service/modelgateway/handler_test.go
+++ b/services/tuttid/service/modelgateway/handler_test.go
@@ -1,0 +1,44 @@
+package modelgateway
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGatewayBoundsJSONFallbackForStreamingResponse(t *testing.T) {
+	t.Parallel()
+
+	const maxResponseBytes = 512
+	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(
+			writer,
+			fmt.Sprintf(
+				`{"id":"chat-oversized","model":"model-a","choices":[{"index":0,"message":{"role":"assistant","content":%q},"finish_reason":"stop"}]}`,
+				strings.Repeat("x", maxResponseBytes),
+			),
+		)
+	}))
+	defer upstream.Close()
+
+	gateway := newTestGateway(t, Config{MaxRequestBytes: maxResponseBytes})
+	endpoint := registerTestRoute(t, gateway, upstream.URL, "secret", "model-a", "workspace", "session")
+	response := postResponses(t, endpoint, `{"model":"model-a","input":"hello","stream":true}`, nil)
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusBadGateway {
+		t.Fatalf(
+			"status = %d, want %d, body = %s",
+			response.StatusCode,
+			http.StatusBadGateway,
+			readBody(t, response.Body),
+		)
+	}
+	if body := readBody(t, response.Body); !strings.Contains(body, `"code":"upstream_error"`) {
+		t.Fatalf("body = %s, want upstream_error", body)
+	}
+}

--- a/services/tuttid/service/modelgateway/response_tool_names.go
+++ b/services/tuttid/service/modelgateway/response_tool_names.go
@@ -1,0 +1,89 @@
+package modelgateway
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+)
+
+func normalizedFilteredToolType(toolType string) string {
+	toolType = strings.TrimSpace(toolType)
+	if toolType == "" {
+		return "<missing>"
+	}
+	if len(toolType) <= 64 {
+		valid := true
+		for index, character := range toolType {
+			if (character >= 'a' && character <= 'z') ||
+				(index > 0 && character >= '0' && character <= '9') ||
+				(index > 0 && character == '_') {
+				continue
+			}
+			valid = false
+			break
+		}
+		if valid {
+			return toolType
+		}
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(toolType)))[:12]
+	return "<invalid:" + hash + ">"
+}
+
+func namespacedToolDescription(namespaceDescription string, toolDescription string) string {
+	namespaceDescription = strings.TrimSpace(namespaceDescription)
+	toolDescription = strings.TrimSpace(toolDescription)
+	switch {
+	case namespaceDescription == "":
+		return toolDescription
+	case toolDescription == "":
+		return namespaceDescription
+	default:
+		return namespaceDescription + "\n\n" + toolDescription
+	}
+}
+
+func flattenedChatToolName(namespace string, name string, used map[string]struct{}) string {
+	base := sanitizeChatToolName(namespace) + "__" + sanitizeChatToolName(name)
+	if len(base) <= 64 {
+		if _, exists := used[base]; !exists {
+			return base
+		}
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(namespace+"\x00"+name)))[:16]
+	suffix := sanitizeChatToolName(name)
+	maxSuffix := 64 - len("tutti_"+hash+"_")
+	if len(suffix) > maxSuffix {
+		suffix = suffix[:maxSuffix]
+	}
+	candidate := "tutti_" + hash + "_" + suffix
+	if _, exists := used[candidate]; !exists {
+		return candidate
+	}
+	for sequence := 2; ; sequence++ {
+		numbered := fmt.Sprintf("tutti_%s_%d", hash, sequence)
+		if _, exists := used[numbered]; !exists {
+			return numbered
+		}
+	}
+}
+
+func sanitizeChatToolName(value string) string {
+	var result strings.Builder
+	for _, character := range strings.TrimSpace(value) {
+		switch {
+		case character >= 'a' && character <= 'z',
+			character >= 'A' && character <= 'Z',
+			character >= '0' && character <= '9',
+			character == '_',
+			character == '-':
+			result.WriteRune(character)
+		default:
+			result.WriteByte('_')
+		}
+	}
+	if result.Len() == 0 {
+		return "tool"
+	}
+	return result.String()
+}

--- a/services/tuttid/service/modelgateway/responses_request.go
+++ b/services/tuttid/service/modelgateway/responses_request.go
@@ -1,0 +1,775 @@
+package modelgateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+type responsesRequest struct {
+	Model              string                     `json:"model"`
+	Instructions       json.RawMessage            `json:"instructions"`
+	Input              json.RawMessage            `json:"input"`
+	Tools              []json.RawMessage          `json:"tools"`
+	ToolChoice         json.RawMessage            `json:"tool_choice"`
+	ParallelToolCalls  *bool                      `json:"parallel_tool_calls"`
+	Reasoning          *responsesReasoningRequest `json:"reasoning"`
+	MaxOutputTokens    *int64                     `json:"max_output_tokens"`
+	Temperature        *float64                   `json:"temperature"`
+	TopP               *float64                   `json:"top_p"`
+	Stream             bool                       `json:"stream"`
+	Store              *bool                      `json:"store"`
+	Include            []string                   `json:"include"`
+	ServiceTier        string                     `json:"service_tier"`
+	PromptCacheKey     string                     `json:"prompt_cache_key"`
+	Text               json.RawMessage            `json:"text"`
+	ClientMetadata     map[string]string          `json:"client_metadata"`
+	Metadata           map[string]string          `json:"metadata"`
+	PreviousResponseID string                     `json:"previous_response_id"`
+	User               string                     `json:"user"`
+}
+
+type responsesReasoningRequest struct {
+	Effort  string `json:"effort"`
+	Summary string `json:"summary"`
+	Context string `json:"context"`
+}
+
+var supportedRequestFields = map[string]struct{}{
+	"model": {}, "instructions": {}, "input": {}, "tools": {},
+	"tool_choice": {}, "parallel_tool_calls": {}, "reasoning": {},
+	"max_output_tokens": {}, "temperature": {}, "top_p": {}, "stream": {},
+	"store": {}, "include": {}, "service_tier": {}, "prompt_cache_key": {},
+	"text": {}, "client_metadata": {}, "metadata": {},
+	"previous_response_id": {}, "user": {},
+}
+
+func decodeResponsesRequest(reader io.Reader, maxBytes int64) (responsesRequest, error) {
+	limited := io.LimitReader(reader, maxBytes+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return responsesRequest{}, &invalidRequestError{
+			Code: "invalid_json", Message: "Could not read request body",
+		}
+	}
+	if int64(len(body)) > maxBytes {
+		return responsesRequest{}, &invalidRequestError{
+			Code: "request_too_large", Message: "Request body exceeds the Model Gateway limit",
+		}
+	}
+	var fields map[string]json.RawMessage
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	if err := decoder.Decode(&fields); err != nil {
+		return responsesRequest{}, &invalidRequestError{
+			Code: "invalid_json", Message: "Request body must be valid JSON",
+		}
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return responsesRequest{}, &invalidRequestError{
+			Code: "invalid_json", Message: "Request body must contain one JSON object",
+		}
+	}
+	var unsupported []string
+	for field := range fields {
+		if _, ok := supportedRequestFields[field]; !ok {
+			unsupported = append(unsupported, field)
+		}
+	}
+	if len(unsupported) > 0 {
+		sort.Strings(unsupported)
+		return responsesRequest{}, &invalidRequestError{
+			Param: unsupported[0],
+			Code:  "unsupported_parameter",
+			Message: fmt.Sprintf(
+				"Unsupported Responses parameter %q", unsupported[0],
+			),
+		}
+	}
+	var request responsesRequest
+	if err := json.Unmarshal(body, &request); err != nil {
+		return responsesRequest{}, &invalidRequestError{
+			Code: "invalid_json", Message: "Request body does not match the Responses request schema",
+		}
+	}
+	request.Model = strings.TrimSpace(request.Model)
+	if request.Model == "" {
+		return responsesRequest{}, &invalidRequestError{
+			Param: "model", Code: "missing_required_parameter", Message: "model is required",
+		}
+	}
+	if strings.TrimSpace(request.PreviousResponseID) != "" {
+		return responsesRequest{}, &invalidRequestError{
+			Param:   "previous_response_id",
+			Code:    "unsupported_parameter",
+			Message: "previous_response_id is not supported by the stateless local Model Gateway",
+		}
+	}
+	for _, include := range request.Include {
+		if include != "reasoning.encrypted_content" {
+			return responsesRequest{}, &invalidRequestError{
+				Param: "include",
+				Code:  "unsupported_value",
+				Message: fmt.Sprintf(
+					"Unsupported Responses include value %q", include,
+				),
+			}
+		}
+	}
+	if request.Reasoning != nil {
+		switch request.Reasoning.Context {
+		case "", "auto", "current_turn", "all_turns":
+		default:
+			return responsesRequest{}, &invalidRequestError{
+				Param: "reasoning.context", Code: "unsupported_value",
+				Message: fmt.Sprintf("Unsupported reasoning.context %q", request.Reasoning.Context),
+			}
+		}
+	}
+	return request, nil
+}
+
+type chatRequest struct {
+	Model             string            `json:"model"`
+	Messages          []map[string]any  `json:"messages"`
+	Tools             []map[string]any  `json:"tools,omitempty"`
+	ToolChoice        any               `json:"tool_choice,omitempty"`
+	ParallelToolCalls *bool             `json:"parallel_tool_calls,omitempty"`
+	ReasoningEffort   string            `json:"reasoning_effort,omitempty"`
+	MaxTokens         *int64            `json:"max_completion_tokens,omitempty"`
+	Temperature       *float64          `json:"temperature,omitempty"`
+	TopP              *float64          `json:"top_p,omitempty"`
+	Stream            bool              `json:"stream"`
+	StreamOptions     map[string]bool   `json:"stream_options,omitempty"`
+	Store             *bool             `json:"store,omitempty"`
+	ServiceTier       string            `json:"service_tier,omitempty"`
+	PromptCacheKey    string            `json:"prompt_cache_key,omitempty"`
+	Verbosity         string            `json:"verbosity,omitempty"`
+	ResponseFormat    map[string]any    `json:"response_format,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+	User              string            `json:"user,omitempty"`
+	filteredToolTypes []string
+}
+
+type responseToolIdentity struct {
+	Name      string
+	Namespace string
+}
+
+type responseToolMap map[string]responseToolIdentity
+
+func convertResponsesRequest(request responsesRequest) (chatRequest, responseToolMap, error) {
+	tools, toolNamespaces, filteredToolTypes, err := convertResponseTools(request.Tools)
+	if err != nil {
+		return chatRequest{}, nil, err
+	}
+	messages, err := convertResponseInput(request.Instructions, request.Input, toolNamespaces)
+	if err != nil {
+		return chatRequest{}, nil, err
+	}
+	messages = collapseSystemMessagesToHead(messages)
+	toolChoice, err := convertResponseToolChoice(request.ToolChoice, toolNamespaces, len(tools))
+	if err != nil {
+		return chatRequest{}, nil, err
+	}
+	verbosity, responseFormat, err := convertResponseTextControls(request.Text)
+	if err != nil {
+		return chatRequest{}, nil, err
+	}
+	metadata := request.Metadata
+	if len(request.ClientMetadata) > 0 {
+		if metadata == nil {
+			metadata = make(map[string]string, len(request.ClientMetadata))
+		}
+		for key, value := range request.ClientMetadata {
+			if _, exists := metadata[key]; !exists {
+				metadata[key] = value
+			}
+		}
+	}
+	result := chatRequest{
+		Model:             request.Model,
+		Messages:          messages,
+		Tools:             tools,
+		ToolChoice:        toolChoice,
+		ParallelToolCalls: request.ParallelToolCalls,
+		MaxTokens:         request.MaxOutputTokens,
+		Temperature:       request.Temperature,
+		TopP:              request.TopP,
+		Stream:            request.Stream,
+		Store:             request.Store,
+		ServiceTier:       strings.TrimSpace(request.ServiceTier),
+		PromptCacheKey:    strings.TrimSpace(request.PromptCacheKey),
+		Verbosity:         verbosity,
+		ResponseFormat:    responseFormat,
+		Metadata:          metadata,
+		User:              strings.TrimSpace(request.User),
+		filteredToolTypes: filteredToolTypes,
+	}
+	if len(tools) == 0 {
+		result.ToolChoice = nil
+		result.ParallelToolCalls = nil
+	}
+	if request.Stream {
+		result.StreamOptions = map[string]bool{"include_usage": true}
+	}
+	if request.Reasoning != nil {
+		result.ReasoningEffort = strings.TrimSpace(request.Reasoning.Effort)
+	}
+	return result, toolNamespaces, nil
+}
+
+type responseInputItem struct {
+	Type      string          `json:"type"`
+	Role      string          `json:"role"`
+	Content   json.RawMessage `json:"content"`
+	Name      string          `json:"name"`
+	Namespace string          `json:"namespace"`
+	Arguments string          `json:"arguments"`
+	CallID    string          `json:"call_id"`
+	Output    json.RawMessage `json:"output"`
+	Summary   []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"summary"`
+	EncryptedContent string `json:"encrypted_content"`
+}
+
+type pendingAssistantMessage struct {
+	content          []map[string]any
+	reasoningContent strings.Builder
+	toolCalls        []map[string]any
+}
+
+func convertResponseInput(
+	instructions json.RawMessage,
+	input json.RawMessage,
+	toolMap responseToolMap,
+) ([]map[string]any, error) {
+	messages := make([]map[string]any, 0)
+	if len(bytes.TrimSpace(instructions)) > 0 && !bytes.Equal(bytes.TrimSpace(instructions), []byte("null")) {
+		instructionMessages, err := convertInstructions(instructions)
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, instructionMessages...)
+	}
+	if len(bytes.TrimSpace(input)) == 0 || bytes.Equal(bytes.TrimSpace(input), []byte("null")) {
+		return messages, nil
+	}
+	var text string
+	if err := json.Unmarshal(input, &text); err == nil {
+		return append(messages, map[string]any{"role": "user", "content": text}), nil
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal(input, &items); err != nil {
+		return nil, invalidParam("input", "input must be a string or an array of Responses input items")
+	}
+	var assistant *pendingAssistantMessage
+	flushAssistant := func() {
+		if assistant == nil {
+			return
+		}
+		message := map[string]any{"role": "assistant"}
+		if len(assistant.content) > 0 {
+			message["content"] = chatContentFromResponseParts(assistant.content)
+		} else {
+			message["content"] = nil
+		}
+		if assistant.reasoningContent.Len() > 0 {
+			message["reasoning_content"] = assistant.reasoningContent.String()
+		}
+		if len(assistant.toolCalls) > 0 {
+			message["tool_calls"] = assistant.toolCalls
+		}
+		messages = append(messages, message)
+		assistant = nil
+	}
+	ensureAssistant := func() *pendingAssistantMessage {
+		if assistant == nil {
+			assistant = &pendingAssistantMessage{}
+		}
+		return assistant
+	}
+	for index, encoded := range items {
+		var item responseInputItem
+		if err := json.Unmarshal(encoded, &item); err != nil {
+			return nil, invalidParam(fmt.Sprintf("input[%d]", index), "invalid Responses input item")
+		}
+		item.Type = strings.TrimSpace(item.Type)
+		if item.Type == "" && strings.TrimSpace(item.Role) != "" {
+			item.Type = "message"
+		}
+		switch item.Type {
+		case "message":
+			role := strings.TrimSpace(item.Role)
+			chatRole := chatRoleForResponseMessage(role)
+			content, err := convertMessageContent(chatRole, item.Content)
+			if err != nil {
+				return nil, withParam(err, fmt.Sprintf("input[%d].content", index))
+			}
+			if chatRole == "assistant" {
+				current := ensureAssistant()
+				current.content = append(current.content, content...)
+				continue
+			}
+			flushAssistant()
+			message := map[string]any{"role": chatRole}
+			message["content"] = chatContentFromResponseParts(content)
+			messages = append(messages, message)
+		case "reasoning":
+			readable := reasoningItemText(item)
+			if readable == "" && strings.TrimSpace(item.EncryptedContent) != "" {
+				return nil, invalidParam(
+					fmt.Sprintf("input[%d].encrypted_content", index),
+					"encrypted reasoning cannot be translated to Chat Completions",
+				)
+			}
+			ensureAssistant().reasoningContent.WriteString(readable)
+		case "function_call":
+			if strings.TrimSpace(item.CallID) == "" || strings.TrimSpace(item.Name) == "" {
+				return nil, invalidParam(fmt.Sprintf("input[%d]", index), "function_call requires call_id and name")
+			}
+			current := ensureAssistant()
+			current.toolCalls = append(current.toolCalls, map[string]any{
+				"id":   item.CallID,
+				"type": "function",
+				"function": map[string]any{
+					"name":      chatNameForResponseTool(item.Namespace, item.Name, toolMap),
+					"arguments": item.Arguments,
+				},
+			})
+		case "function_call_output":
+			if strings.TrimSpace(item.CallID) == "" {
+				return nil, invalidParam(fmt.Sprintf("input[%d].call_id", index), "function_call_output requires call_id")
+			}
+			output, err := functionOutputText(item.Output)
+			if err != nil {
+				return nil, withParam(err, fmt.Sprintf("input[%d].output", index))
+			}
+			flushAssistant()
+			messages = append(messages, map[string]any{
+				"role": "tool", "tool_call_id": item.CallID, "content": output,
+			})
+		case "web_search_call", "computer_call", "file_search_call", "code_interpreter_call",
+			"local_shell_call", "custom_tool_call", "custom_tool_call_output":
+			return nil, invalidParam(
+				fmt.Sprintf("input[%d].type", index),
+				fmt.Sprintf("Responses input item type %q is not supported", item.Type),
+			)
+		default:
+			return nil, invalidParam(
+				fmt.Sprintf("input[%d].type", index),
+				fmt.Sprintf("Responses input item type %q is not supported", item.Type),
+			)
+		}
+	}
+	flushAssistant()
+	return messages, nil
+}
+
+func convertInstructions(encoded json.RawMessage) ([]map[string]any, error) {
+	var text string
+	if err := json.Unmarshal(encoded, &text); err == nil {
+		if text == "" {
+			return nil, nil
+		}
+		return []map[string]any{{"role": "system", "content": text}}, nil
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal(encoded, &items); err != nil {
+		return nil, invalidParam("instructions", "instructions must be a string or message array")
+	}
+	messages := make([]map[string]any, 0, len(items))
+	for index, itemEncoded := range items {
+		var item responseInputItem
+		if err := json.Unmarshal(itemEncoded, &item); err != nil {
+			return nil, invalidParam(fmt.Sprintf("instructions[%d]", index), "invalid instruction message")
+		}
+		if item.Type != "" && item.Type != "message" {
+			return nil, invalidParam(fmt.Sprintf("instructions[%d].type", index), "instructions only support message items")
+		}
+		role := strings.TrimSpace(item.Role)
+		if role != "system" && role != "developer" {
+			return nil, invalidParam(fmt.Sprintf("instructions[%d].role", index), "instruction role must be system or developer")
+		}
+		content, err := convertMessageContent(role, item.Content)
+		if err != nil {
+			return nil, withParam(err, fmt.Sprintf("instructions[%d].content", index))
+		}
+		message := map[string]any{"role": chatRoleForResponseMessage(role)}
+		message["content"] = chatContentFromResponseParts(content)
+		messages = append(messages, message)
+	}
+	return messages, nil
+}
+
+func chatRoleForResponseMessage(role string) string {
+	switch role {
+	case "system", "developer":
+		return "system"
+	case "assistant":
+		return "assistant"
+	case "tool":
+		return "tool"
+	case "user", "latest_reminder":
+		return "user"
+	default:
+		return "user"
+	}
+}
+
+func collapseSystemMessagesToHead(messages []map[string]any) []map[string]any {
+	systemChunks := make([]string, 0)
+	rest := make([]map[string]any, 0, len(messages))
+	for _, message := range messages {
+		if message["role"] == "system" {
+			if content, ok := message["content"].(string); ok {
+				if strings.TrimSpace(content) != "" {
+					systemChunks = append(systemChunks, content)
+				}
+				continue
+			}
+		}
+		rest = append(rest, message)
+	}
+	result := make([]map[string]any, 0, len(rest)+1)
+	if len(systemChunks) > 0 {
+		result = append(result, map[string]any{
+			"role":    "system",
+			"content": strings.Join(systemChunks, "\n\n"),
+		})
+	}
+	return append(result, rest...)
+}
+
+func chatContentFromResponseParts(parts []map[string]any) any {
+	textParts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part["type"] != "text" {
+			return parts
+		}
+		text, _ := part["text"].(string)
+		if text != "" {
+			textParts = append(textParts, text)
+		}
+	}
+	return strings.Join(textParts, "\n")
+}
+
+func convertMessageContent(role string, encoded json.RawMessage) ([]map[string]any, error) {
+	var text string
+	if err := json.Unmarshal(encoded, &text); err == nil {
+		return []map[string]any{{"type": "text", "text": text}}, nil
+	}
+	var parts []struct {
+		Type     string `json:"type"`
+		Text     string `json:"text"`
+		ImageURL string `json:"image_url"`
+		Detail   string `json:"detail"`
+	}
+	if err := json.Unmarshal(encoded, &parts); err != nil {
+		return nil, invalidParam("", "message content must be a string or content-part array")
+	}
+	result := make([]map[string]any, 0, len(parts))
+	for index, part := range parts {
+		switch part.Type {
+		case "input_text":
+			result = append(result, map[string]any{"type": "text", "text": part.Text})
+		case "output_text":
+			if role != "assistant" {
+				return nil, invalidParam(fmt.Sprintf("[%d].type", index), "output_text is only valid for assistant messages")
+			}
+			result = append(result, map[string]any{"type": "text", "text": part.Text})
+		case "input_image":
+			if role != "user" {
+				return nil, invalidParam(fmt.Sprintf("[%d].type", index), "input_image is only valid for user messages")
+			}
+			image := map[string]any{"url": part.ImageURL}
+			if strings.TrimSpace(part.Detail) != "" {
+				image["detail"] = part.Detail
+			}
+			result = append(result, map[string]any{"type": "image_url", "image_url": image})
+		default:
+			return nil, invalidParam(fmt.Sprintf("[%d].type", index), fmt.Sprintf("content part type %q is not supported", part.Type))
+		}
+	}
+	return result, nil
+}
+
+func reasoningItemText(item responseInputItem) string {
+	var result strings.Builder
+	for _, summary := range item.Summary {
+		result.WriteString(summary.Text)
+	}
+	var content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(item.Content, &content) == nil {
+		for _, part := range content {
+			result.WriteString(part.Text)
+		}
+	}
+	return result.String()
+}
+
+func functionOutputText(encoded json.RawMessage) (string, error) {
+	var text string
+	if err := json.Unmarshal(encoded, &text); err == nil {
+		return text, nil
+	}
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(encoded, &parts); err == nil {
+		var result strings.Builder
+		for index, part := range parts {
+			switch part.Type {
+			case "input_text", "output_text":
+				result.WriteString(part.Text)
+			default:
+				return "", invalidParam(fmt.Sprintf("[%d].type", index), fmt.Sprintf("function output content type %q is not supported", part.Type))
+			}
+		}
+		return result.String(), nil
+	}
+	if len(bytes.TrimSpace(encoded)) == 0 || bytes.Equal(bytes.TrimSpace(encoded), []byte("null")) {
+		return "", nil
+	}
+	var value any
+	if err := json.Unmarshal(encoded, &value); err != nil {
+		return "", invalidParam("", "function output must be text or structured text content")
+	}
+	normalized, err := json.Marshal(value)
+	if err != nil {
+		return "", invalidParam("", "function output cannot be encoded")
+	}
+	return string(normalized), nil
+}
+
+func convertResponseTools(tools []json.RawMessage) ([]map[string]any, responseToolMap, []string, error) {
+	if len(tools) == 0 {
+		return nil, nil, nil, nil
+	}
+	result := make([]map[string]any, 0, len(tools))
+	toolMap := make(responseToolMap)
+	filteredTypes := make(map[string]struct{})
+	seenNames := make(map[string]struct{})
+	seenIdentities := make(map[string]struct{})
+	for index, encoded := range tools {
+		var header struct {
+			Type string `json:"type"`
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(encoded, &header); err != nil || header.Type != "function" {
+			continue
+		}
+		name := strings.TrimSpace(header.Name)
+		if name == "" {
+			continue
+		}
+		if _, exists := seenNames[name]; exists {
+			return nil, nil, nil, invalidParam(
+				fmt.Sprintf("tools[%d].name", index),
+				fmt.Sprintf("function tool name %q is duplicated", name),
+			)
+		}
+		seenNames[name] = struct{}{}
+	}
+	for index, encoded := range tools {
+		var tool struct {
+			Type        string            `json:"type"`
+			Name        string            `json:"name"`
+			Description string            `json:"description"`
+			Parameters  json.RawMessage   `json:"parameters"`
+			Strict      *bool             `json:"strict"`
+			Tools       []json.RawMessage `json:"tools"`
+		}
+		if err := json.Unmarshal(encoded, &tool); err != nil {
+			return nil, nil, nil, invalidParam(fmt.Sprintf("tools[%d]", index), "invalid tool")
+		}
+		switch tool.Type {
+		case "function":
+			function, err := convertFunctionTool(
+				tool.Name,
+				tool.Description,
+				tool.Parameters,
+				tool.Strict,
+				fmt.Sprintf("tools[%d]", index),
+			)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			name := function["name"].(string)
+			seenIdentities["\x00"+name] = struct{}{}
+			toolMap[name] = responseToolIdentity{Name: name}
+			result = append(result, map[string]any{"type": "function", "function": function})
+		case "namespace":
+			namespace := strings.TrimSpace(tool.Name)
+			if namespace == "" {
+				return nil, nil, nil, invalidParam(fmt.Sprintf("tools[%d].name", index), "tool namespace name is required")
+			}
+			if len(tool.Tools) == 0 {
+				return nil, nil, nil, invalidParam(fmt.Sprintf("tools[%d].tools", index), "tool namespace must contain at least one function")
+			}
+			for nestedIndex, nestedEncoded := range tool.Tools {
+				var nested struct {
+					Type        string          `json:"type"`
+					Name        string          `json:"name"`
+					Description string          `json:"description"`
+					Parameters  json.RawMessage `json:"parameters"`
+					Strict      *bool           `json:"strict"`
+				}
+				param := fmt.Sprintf("tools[%d].tools[%d]", index, nestedIndex)
+				if err := json.Unmarshal(nestedEncoded, &nested); err != nil {
+					return nil, nil, nil, invalidParam(param, "invalid namespaced tool")
+				}
+				if nested.Type != "function" {
+					filteredTypes[normalizedFilteredToolType(nested.Type)] = struct{}{}
+					continue
+				}
+				function, err := convertFunctionTool(
+					nested.Name,
+					namespacedToolDescription(tool.Description, nested.Description),
+					nested.Parameters,
+					nested.Strict,
+					param,
+				)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				responseName := function["name"].(string)
+				identityKey := namespace + "\x00" + responseName
+				if _, exists := seenIdentities[identityKey]; exists {
+					return nil, nil, nil, invalidParam(
+						param+".name",
+						fmt.Sprintf("function tool name %q is duplicated within namespace %q", responseName, namespace),
+					)
+				}
+				seenIdentities[identityKey] = struct{}{}
+				chatName := flattenedChatToolName(namespace, responseName, seenNames)
+				function["name"] = chatName
+				seenNames[chatName] = struct{}{}
+				toolMap[chatName] = responseToolIdentity{Name: responseName, Namespace: namespace}
+				result = append(result, map[string]any{"type": "function", "function": function})
+			}
+		default:
+			// A Responses tool entry is an availability declaration, not a
+			// call. Intersect declarations with the set this Chat adapter can
+			// represent so newly advertised hosted tools do not break ordinary
+			// turns. Explicit choices and call/output history are validated
+			// separately and remain fail-closed.
+			filteredTypes[normalizedFilteredToolType(tool.Type)] = struct{}{}
+		}
+	}
+	filtered := make([]string, 0, len(filteredTypes))
+	for toolType := range filteredTypes {
+		filtered = append(filtered, toolType)
+	}
+	sort.Strings(filtered)
+	return result, toolMap, filtered, nil
+}
+
+func chatNameForResponseTool(namespace string, name string, toolMap responseToolMap) string {
+	namespace = strings.TrimSpace(namespace)
+	name = strings.TrimSpace(name)
+	for chatName, identity := range toolMap {
+		if identity.Name == name && identity.Namespace == namespace {
+			return chatName
+		}
+	}
+	return name
+}
+
+func convertFunctionTool(
+	name string,
+	description string,
+	encodedParameters json.RawMessage,
+	strict *bool,
+	param string,
+) (map[string]any, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, invalidParam(param+".name", "function tool name is required")
+	}
+	function := map[string]any{"name": name}
+	if description != "" {
+		function["description"] = description
+	}
+	if len(bytes.TrimSpace(encodedParameters)) > 0 &&
+		!bytes.Equal(bytes.TrimSpace(encodedParameters), []byte("null")) {
+		var parameters any
+		if err := json.Unmarshal(encodedParameters, &parameters); err != nil {
+			return nil, invalidParam(param+".parameters", "function parameters must be valid JSON")
+		}
+		function["parameters"] = parameters
+	}
+	if strict != nil {
+		function["strict"] = *strict
+	}
+	return function, nil
+}
+
+func convertResponseToolChoice(encoded json.RawMessage, toolMap responseToolMap, toolCount int) (any, error) {
+	trimmed := bytes.TrimSpace(encoded)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil, nil
+	}
+	var value string
+	if err := json.Unmarshal(trimmed, &value); err == nil {
+		switch value {
+		case "auto", "none":
+			return value, nil
+		case "required":
+			if toolCount == 0 {
+				return nil, invalidParam("tool_choice", "required tool_choice has no translatable tools")
+			}
+			return value, nil
+		default:
+			return nil, invalidParam("tool_choice", fmt.Sprintf("unsupported tool_choice %q", value))
+		}
+	}
+	var choice struct {
+		Type      string `json:"type"`
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	}
+	if err := json.Unmarshal(trimmed, &choice); err != nil {
+		return nil, invalidParam("tool_choice", "named tool_choice must be a valid object")
+	}
+	if choice.Type != "function" {
+		return nil, invalidParam(
+			"tool_choice",
+			fmt.Sprintf("tool_choice type %q cannot be translated to Chat Completions", choice.Type),
+		)
+	}
+	if strings.TrimSpace(choice.Name) == "" {
+		return nil, invalidParam("tool_choice", "named function tool_choice requires a name")
+	}
+	chatName, found := responseToolChatName(choice.Namespace, choice.Name, toolMap)
+	if !found {
+		return nil, invalidParam("tool_choice", fmt.Sprintf("selected function tool %q is not registered", choice.Name))
+	}
+	return map[string]any{
+		"type": "function",
+		"function": map[string]any{
+			"name": chatName,
+		},
+	}, nil
+}
+
+func responseToolChatName(namespace string, name string, toolMap responseToolMap) (string, bool) {
+	namespace = strings.TrimSpace(namespace)
+	name = strings.TrimSpace(name)
+	for chatName, identity := range toolMap {
+		if identity.Name == name && identity.Namespace == namespace {
+			return chatName, true
+		}
+	}
+	return "", false
+}

--- a/services/tuttid/service/modelgateway/responses_text.go
+++ b/services/tuttid/service/modelgateway/responses_text.go
@@ -1,0 +1,49 @@
+package modelgateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func convertResponseTextControls(encoded json.RawMessage) (string, map[string]any, error) {
+	trimmed := bytes.TrimSpace(encoded)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return "", nil, nil
+	}
+	var controls struct {
+		Verbosity string          `json:"verbosity"`
+		Format    json.RawMessage `json:"format"`
+	}
+	if err := json.Unmarshal(trimmed, &controls); err != nil {
+		return "", nil, invalidParam("text", "text controls must be an object")
+	}
+	formatBytes := bytes.TrimSpace(controls.Format)
+	if len(formatBytes) == 0 || bytes.Equal(formatBytes, []byte("null")) {
+		return controls.Verbosity, nil, nil
+	}
+	var format map[string]any
+	if err := json.Unmarshal(formatBytes, &format); err != nil {
+		return "", nil, invalidParam("text.format", "text.format must be an object")
+	}
+	formatType, _ := format["type"].(string)
+	switch formatType {
+	case "", "text":
+		return controls.Verbosity, nil, nil
+	case "json_object":
+		return controls.Verbosity, map[string]any{"type": "json_object"}, nil
+	case "json_schema":
+		jsonSchema := map[string]any{}
+		for _, field := range []string{"name", "description", "schema", "strict"} {
+			if value, ok := format[field]; ok {
+				jsonSchema[field] = value
+			}
+		}
+		return controls.Verbosity, map[string]any{
+			"type":        "json_schema",
+			"json_schema": jsonSchema,
+		}, nil
+	default:
+		return "", nil, invalidParam("text.format.type", fmt.Sprintf("text format %q is not supported", formatType))
+	}
+}

--- a/services/tuttid/service/modelgateway/sse.go
+++ b/services/tuttid/service/modelgateway/sse.go
@@ -1,0 +1,103 @@
+package modelgateway
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type sseEvent struct {
+	Event string
+	Data  []byte
+}
+
+type sseDecoder struct {
+	reader *bufio.Reader
+}
+
+func newSSEDecoder(reader io.Reader) *sseDecoder {
+	return &sseDecoder{reader: bufio.NewReader(reader)}
+}
+
+func (d *sseDecoder) Next() (sseEvent, error) {
+	var event sseEvent
+	var data bytes.Buffer
+	for {
+		line, err := d.reader.ReadString('\n')
+		if err != nil && len(line) == 0 {
+			if errors.Is(err, io.EOF) && (event.Event != "" || data.Len() > 0) {
+				event.Data = bytes.TrimSuffix(data.Bytes(), []byte("\n"))
+				return event, nil
+			}
+			return sseEvent{}, err
+		}
+		line = strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
+		if line == "" {
+			if event.Event == "" && data.Len() == 0 {
+				if err != nil {
+					return sseEvent{}, err
+				}
+				continue
+			}
+			event.Data = bytes.TrimSuffix(data.Bytes(), []byte("\n"))
+			return event, nil
+		}
+		if strings.HasPrefix(line, ":") {
+			if err != nil {
+				return sseEvent{}, err
+			}
+			continue
+		}
+		field, value, found := strings.Cut(line, ":")
+		if found {
+			value = strings.TrimPrefix(value, " ")
+		}
+		switch field {
+		case "event":
+			event.Event = value
+		case "data":
+			data.WriteString(value)
+			data.WriteByte('\n')
+		}
+		if err != nil {
+			event.Data = bytes.TrimSuffix(data.Bytes(), []byte("\n"))
+			return event, nil
+		}
+	}
+}
+
+type responsesSSEWriter struct {
+	writer   http.ResponseWriter
+	flusher  http.Flusher
+	sequence int64
+}
+
+func newResponsesSSEWriter(writer http.ResponseWriter) (*responsesSSEWriter, bool) {
+	flusher, ok := writer.(http.Flusher)
+	return &responsesSSEWriter{writer: writer, flusher: flusher}, ok
+}
+
+func (w *responsesSSEWriter) Event(eventType string, payload map[string]any) error {
+	w.sequence++
+	payload["type"] = eventType
+	payload["sequence_number"] = w.sequence
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if _, err := w.writer.Write([]byte("event: " + eventType + "\ndata: ")); err != nil {
+		return err
+	}
+	if _, err := w.writer.Write(encoded); err != nil {
+		return err
+	}
+	if _, err := w.writer.Write([]byte("\n\n")); err != nil {
+		return err
+	}
+	w.flusher.Flush()
+	return nil
+}

--- a/services/tuttid/service/modelgateway/stream_converter.go
+++ b/services/tuttid/service/modelgateway/stream_converter.go
@@ -1,0 +1,541 @@
+package modelgateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+type chatStreamChunk struct {
+	ID      string             `json:"id"`
+	Object  string             `json:"object"`
+	Created int64              `json:"created"`
+	Model   string             `json:"model"`
+	Choices []chatStreamChoice `json:"choices"`
+	Usage   *chatUsage         `json:"usage"`
+	Error   json.RawMessage    `json:"error"`
+}
+
+type chatStreamChoice struct {
+	Index        int             `json:"index"`
+	Delta        chatStreamDelta `json:"delta"`
+	FinishReason *string         `json:"finish_reason"`
+}
+
+type chatStreamDelta struct {
+	Role             string          `json:"role"`
+	Content          json.RawMessage `json:"content"`
+	ReasoningContent json.RawMessage `json:"reasoning_content"`
+	Reasoning        json.RawMessage `json:"reasoning"`
+	ToolCalls        []chatToolCall  `json:"tool_calls"`
+	FunctionCall     *struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	} `json:"function_call"`
+}
+
+type streamItem interface {
+	outputIndex() int
+	finish(*responsesSSEWriter) (map[string]any, error)
+}
+
+type reasoningStreamItem struct {
+	index int
+	id    string
+	text  strings.Builder
+}
+
+func (i *reasoningStreamItem) outputIndex() int { return i.index }
+
+func (i *reasoningStreamItem) finish(writer *responsesSSEWriter) (map[string]any, error) {
+	part := map[string]any{"type": "reasoning_text", "text": i.text.String()}
+	if err := writer.Event("response.content_part.done", map[string]any{
+		"item_id": i.id, "output_index": i.index, "content_index": 0, "part": part,
+	}); err != nil {
+		return nil, err
+	}
+	item := map[string]any{
+		"id":                i.id,
+		"type":              "reasoning",
+		"summary":           []any{},
+		"content":           []any{part},
+		"encrypted_content": nil,
+		"status":            "completed",
+	}
+	if err := writer.Event("response.output_item.done", map[string]any{
+		"output_index": i.index, "item": item,
+	}); err != nil {
+		return nil, err
+	}
+	return item, nil
+}
+
+type messageStreamItem struct {
+	index int
+	id    string
+	text  strings.Builder
+}
+
+func (i *messageStreamItem) outputIndex() int { return i.index }
+
+func (i *messageStreamItem) finish(writer *responsesSSEWriter) (map[string]any, error) {
+	part := map[string]any{
+		"type": "output_text", "text": i.text.String(), "annotations": []any{},
+	}
+	if err := writer.Event("response.output_text.done", map[string]any{
+		"item_id": i.id, "output_index": i.index, "content_index": 0, "text": i.text.String(),
+	}); err != nil {
+		return nil, err
+	}
+	if err := writer.Event("response.content_part.done", map[string]any{
+		"item_id": i.id, "output_index": i.index, "content_index": 0, "part": part,
+	}); err != nil {
+		return nil, err
+	}
+	item := map[string]any{
+		"id": i.id, "type": "message", "role": "assistant", "status": "completed",
+		"content": []any{part},
+	}
+	if err := writer.Event("response.output_item.done", map[string]any{
+		"output_index": i.index, "item": item,
+	}); err != nil {
+		return nil, err
+	}
+	return item, nil
+}
+
+type toolStreamItem struct {
+	index     int
+	chatIndex int
+	id        string
+	callID    string
+	name      string
+	toolMap   responseToolMap
+	arguments strings.Builder
+}
+
+func (i *toolStreamItem) outputIndex() int { return i.index }
+
+func (i *toolStreamItem) finish(writer *responsesSSEWriter) (map[string]any, error) {
+	identity := responseIdentityForChatTool(i.name, i.toolMap)
+	if err := writer.Event("response.function_call_arguments.done", map[string]any{
+		"item_id": i.id, "output_index": i.index, "name": identity.Name, "arguments": i.arguments.String(),
+	}); err != nil {
+		return nil, err
+	}
+	item := map[string]any{
+		"id": i.id, "type": "function_call", "status": "completed",
+		"call_id": i.callID, "name": identity.Name, "arguments": i.arguments.String(),
+	}
+	if identity.Namespace != "" {
+		item["namespace"] = identity.Namespace
+	}
+	if err := writer.Event("response.output_item.done", map[string]any{
+		"output_index": i.index, "item": item,
+	}); err != nil {
+		return nil, err
+	}
+	return item, nil
+}
+
+type chatStreamState struct {
+	request      responsesRequest
+	writer       *responsesSSEWriter
+	responseID   string
+	createdAt    int64
+	model        string
+	items        []streamItem
+	reasoning    *reasoningStreamItem
+	message      *messageStreamItem
+	tools        map[int]*toolStreamItem
+	usage        *chatUsage
+	finishReason *string
+	sawFinish    bool
+	toolMap      responseToolMap
+}
+
+func newChatStreamState(
+	request responsesRequest,
+	writer *responsesSSEWriter,
+	toolMap responseToolMap,
+) *chatStreamState {
+	return &chatStreamState{
+		request:    request,
+		writer:     writer,
+		responseID: newResponseID("resp"),
+		createdAt:  time.Now().Unix(),
+		model:      request.Model,
+		tools:      make(map[int]*toolStreamItem),
+		toolMap:    toolMap,
+	}
+}
+
+func (s *chatStreamState) start() error {
+	response := responseObject(
+		s.request, s.responseID, s.createdAt, s.model, "in_progress",
+		[]any{}, nil, nil, nil,
+	)
+	if err := s.writer.Event("response.created", map[string]any{"response": response}); err != nil {
+		return err
+	}
+	return s.writer.Event("response.in_progress", map[string]any{"response": response})
+}
+
+func (s *chatStreamState) process(chunk chatStreamChunk) error {
+	if chunk.Created > 0 {
+		s.createdAt = chunk.Created
+	}
+	if strings.TrimSpace(chunk.Model) != "" {
+		s.model = chunk.Model
+	}
+	if chunk.Usage != nil {
+		s.usage = chunk.Usage
+	}
+	if len(bytes.TrimSpace(chunk.Error)) > 0 && !bytes.Equal(bytes.TrimSpace(chunk.Error), []byte("null")) {
+		return errors.New("upstream Chat stream returned an error")
+	}
+	for _, choice := range chunk.Choices {
+		if choice.Index != 0 {
+			continue
+		}
+		if err := s.processDelta(choice.Delta); err != nil {
+			return err
+		}
+		if choice.FinishReason != nil {
+			s.finishReason = choice.FinishReason
+			s.sawFinish = true
+		}
+	}
+	return nil
+}
+
+func (s *chatStreamState) processDelta(delta chatStreamDelta) error {
+	reasoning, err := chatText(delta.ReasoningContent)
+	if err != nil {
+		return fmt.Errorf("decode upstream reasoning_content delta: %w", err)
+	}
+	if reasoning == "" {
+		reasoning, err = chatText(delta.Reasoning)
+		if err != nil {
+			return fmt.Errorf("decode upstream reasoning delta: %w", err)
+		}
+	}
+	if reasoning != "" {
+		if err := s.addReasoning(reasoning); err != nil {
+			return err
+		}
+	}
+	text, err := chatText(delta.Content)
+	if err != nil {
+		return fmt.Errorf("decode upstream content delta: %w", err)
+	}
+	if text != "" {
+		if err := s.addText(text); err != nil {
+			return err
+		}
+	}
+	for _, toolCall := range delta.ToolCalls {
+		if err := s.addToolDelta(toolCall); err != nil {
+			return err
+		}
+	}
+	if delta.FunctionCall != nil {
+		legacy := chatToolCall{Index: 0}
+		legacy.Type = "function"
+		legacy.Function.Name = delta.FunctionCall.Name
+		legacy.Function.Arguments = delta.FunctionCall.Arguments
+		if err := s.addToolDelta(legacy); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *chatStreamState) nextOutputIndex() int {
+	return len(s.items)
+}
+
+func (s *chatStreamState) addReasoning(delta string) error {
+	if s.reasoning == nil {
+		s.reasoning = &reasoningStreamItem{
+			index: s.nextOutputIndex(), id: newResponseID("rs"),
+		}
+		s.items = append(s.items, s.reasoning)
+		item := map[string]any{
+			"id": s.reasoning.id, "type": "reasoning", "summary": []any{},
+			"content": []any{}, "encrypted_content": nil, "status": "in_progress",
+		}
+		if err := s.writer.Event("response.output_item.added", map[string]any{
+			"output_index": s.reasoning.index, "item": item,
+		}); err != nil {
+			return err
+		}
+		if err := s.writer.Event("response.content_part.added", map[string]any{
+			"item_id": s.reasoning.id, "output_index": s.reasoning.index, "content_index": 0,
+			"part": map[string]any{"type": "reasoning_text", "text": ""},
+		}); err != nil {
+			return err
+		}
+	}
+	s.reasoning.text.WriteString(delta)
+	return s.writer.Event("response.reasoning_text.delta", map[string]any{
+		"item_id": s.reasoning.id, "output_index": s.reasoning.index, "content_index": 0,
+		"delta": delta,
+	})
+}
+
+func (s *chatStreamState) addText(delta string) error {
+	if s.message == nil {
+		s.message = &messageStreamItem{
+			index: s.nextOutputIndex(), id: newResponseID("msg"),
+		}
+		s.items = append(s.items, s.message)
+		item := map[string]any{
+			"id": s.message.id, "type": "message", "role": "assistant",
+			"status": "in_progress", "content": []any{},
+		}
+		if err := s.writer.Event("response.output_item.added", map[string]any{
+			"output_index": s.message.index, "item": item,
+		}); err != nil {
+			return err
+		}
+		if err := s.writer.Event("response.content_part.added", map[string]any{
+			"item_id": s.message.id, "output_index": s.message.index, "content_index": 0,
+			"part": map[string]any{"type": "output_text", "text": "", "annotations": []any{}},
+		}); err != nil {
+			return err
+		}
+	}
+	s.message.text.WriteString(delta)
+	return s.writer.Event("response.output_text.delta", map[string]any{
+		"item_id": s.message.id, "output_index": s.message.index, "content_index": 0,
+		"delta": delta,
+	})
+}
+
+func (s *chatStreamState) addToolDelta(delta chatToolCall) error {
+	item := s.tools[delta.Index]
+	if item == nil {
+		callID := strings.TrimSpace(delta.ID)
+		if callID == "" {
+			callID = newResponseID("call")
+		}
+		item = &toolStreamItem{
+			index: s.nextOutputIndex(), chatIndex: delta.Index,
+			id: newResponseID("fc"), callID: callID, toolMap: s.toolMap,
+		}
+		s.tools[delta.Index] = item
+		s.items = append(s.items, item)
+		added := map[string]any{
+			"id": item.id, "type": "function_call", "status": "in_progress",
+			"call_id": item.callID, "name": item.name, "arguments": "",
+		}
+		if err := s.writer.Event("response.output_item.added", map[string]any{
+			"output_index": item.index, "item": added,
+		}); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(delta.ID) != "" {
+		item.callID = delta.ID
+	}
+	if delta.Function.Name != "" {
+		item.name = mergeStreamedName(item.name, delta.Function.Name)
+	}
+	arguments := rawJSONString(delta.Function.Arguments)
+	if arguments == "" {
+		return nil
+	}
+	item.arguments.WriteString(arguments)
+	return s.writer.Event("response.function_call_arguments.delta", map[string]any{
+		"item_id": item.id, "output_index": item.index, "delta": arguments,
+	})
+}
+
+func mergeStreamedName(current string, delta string) string {
+	if current == "" {
+		return delta
+	}
+	if current == delta {
+		return current
+	}
+	if strings.HasPrefix(delta, current) {
+		return delta
+	}
+	return current + delta
+}
+
+func (s *chatStreamState) complete() error {
+	sort.SliceStable(s.items, func(left int, right int) bool {
+		return s.items[left].outputIndex() < s.items[right].outputIndex()
+	})
+	output := make([]any, 0, len(s.items))
+	for _, item := range s.items {
+		completed, err := item.finish(s.writer)
+		if err != nil {
+			return err
+		}
+		output = append(output, completed)
+	}
+	status, incompleteDetails, responseError := responseStatus(s.finishReason)
+	response := responseObject(
+		s.request,
+		s.responseID,
+		s.createdAt,
+		s.model,
+		status,
+		output,
+		responseUsage(s.usage),
+		incompleteDetails,
+		responseError,
+	)
+	eventType := "response.completed"
+	if status == "incomplete" {
+		eventType = "response.incomplete"
+	}
+	if status == "failed" {
+		eventType = "response.failed"
+	}
+	return s.writer.Event(eventType, map[string]any{"response": response})
+}
+
+func (s *chatStreamState) fail(code string, message string) error {
+	response := responseObject(
+		s.request, s.responseID, s.createdAt, s.model, "failed", []any{},
+		responseUsage(s.usage), nil,
+		map[string]any{"code": code, "message": message},
+	)
+	return s.writer.Event("response.failed", map[string]any{"response": response})
+}
+
+func (g *Gateway) convertChatStream(
+	writer http.ResponseWriter,
+	clientRequest *http.Request,
+	request responsesRequest,
+	upstream *http.Response,
+	toolMap responseToolMap,
+) {
+	eventWriter, ok := newResponsesSSEWriter(writer)
+	if !ok {
+		writeResponsesError(writer, http.StatusInternalServerError, "server_error", "streaming_unsupported", "", "HTTP streaming is unavailable")
+		return
+	}
+	writer.Header().Set("Content-Type", "text/event-stream")
+	writer.Header().Set("Cache-Control", "no-cache, no-store")
+	writer.Header().Set("Connection", "keep-alive")
+	writer.Header().Set("X-Accel-Buffering", "no")
+	state := newChatStreamState(request, eventWriter, toolMap)
+	if err := state.start(); err != nil {
+		return
+	}
+	var firstTokenTimedOut atomic.Bool
+	var firstTokenSeen atomic.Bool
+	timer := time.AfterFunc(g.firstTokenLimit, func() {
+		if !firstTokenSeen.Load() {
+			firstTokenTimedOut.Store(true)
+			_ = upstream.Body.Close()
+		}
+	})
+	defer timer.Stop()
+	decoder := newSSEDecoder(upstream.Body)
+	done := false
+	for {
+		event, err := decoder.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if clientRequest.Context().Err() != nil {
+				return
+			}
+			if firstTokenTimedOut.Load() {
+				_ = state.fail("upstream_timeout", "Timed out waiting for the first upstream token")
+				return
+			}
+			_ = state.fail("upstream_stream_error", "Upstream Chat stream ended unexpectedly")
+			return
+		}
+		data := bytes.TrimSpace(event.Data)
+		if len(data) == 0 {
+			continue
+		}
+		if bytes.Equal(data, []byte("[DONE]")) {
+			done = true
+			break
+		}
+		if firstTokenSeen.CompareAndSwap(false, true) {
+			timer.Stop()
+		}
+		var chunk chatStreamChunk
+		if err := json.Unmarshal(data, &chunk); err != nil {
+			_ = state.fail("upstream_stream_error", "Upstream Chat stream emitted invalid JSON")
+			return
+		}
+		if err := state.process(chunk); err != nil {
+			_ = state.fail("upstream_error", "Upstream Chat stream could not be converted")
+			return
+		}
+	}
+	if !done && !state.sawFinish {
+		_ = state.fail("upstream_stream_error", "Upstream Chat stream closed before a finish reason")
+		return
+	}
+	_ = state.complete()
+}
+
+func writeSyntheticStream(
+	writer http.ResponseWriter,
+	request responsesRequest,
+	upstream chatCompletionResponse,
+	toolMap responseToolMap,
+) {
+	eventWriter, ok := newResponsesSSEWriter(writer)
+	if !ok {
+		writeResponsesError(writer, http.StatusInternalServerError, "server_error", "streaming_unsupported", "", "HTTP streaming is unavailable")
+		return
+	}
+	writer.Header().Set("Content-Type", "text/event-stream")
+	writer.Header().Set("Cache-Control", "no-cache, no-store")
+	writer.Header().Set("X-Accel-Buffering", "no")
+	state := newChatStreamState(request, eventWriter, toolMap)
+	if strings.TrimSpace(upstream.ID) != "" && strings.HasPrefix(upstream.ID, "resp_") {
+		state.responseID = upstream.ID
+	}
+	if upstream.Created > 0 {
+		state.createdAt = upstream.Created
+	}
+	if upstream.Model != "" {
+		state.model = upstream.Model
+	}
+	if err := state.start(); err != nil {
+		return
+	}
+	if len(upstream.Choices) == 0 {
+		_ = state.fail("upstream_error", "Upstream Chat response contained no choices")
+		return
+	}
+	choice := upstream.Choices[0]
+	delta := chatStreamDelta{
+		Role:             choice.Message.Role,
+		Content:          choice.Message.Content,
+		ReasoningContent: choice.Message.ReasoningContent,
+		Reasoning:        choice.Message.Reasoning,
+		ToolCalls:        choice.Message.ToolCalls,
+		FunctionCall:     choice.Message.FunctionCall,
+	}
+	if err := state.processDelta(delta); err != nil {
+		_ = state.fail("upstream_error", "Upstream Chat response could not be converted")
+		return
+	}
+	state.finishReason = choice.FinishReason
+	state.sawFinish = true
+	state.usage = upstream.Usage
+	_ = state.complete()
+}

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -22,6 +22,7 @@ import (
 	computersvc "github.com/tutti-os/tutti/services/tuttid/service/computer"
 	eventstreamservice "github.com/tutti-os/tutti/services/tuttid/service/eventstream"
 	mobileremoteservice "github.com/tutti-os/tutti/services/tuttid/service/mobileremote"
+	modelgatewayservice "github.com/tutti-os/tutti/services/tuttid/service/modelgateway"
 	preferencesservice "github.com/tutti-os/tutti/services/tuttid/service/preferences"
 	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
 	workspaceservice "github.com/tutti-os/tutti/services/tuttid/service/workspace"
@@ -40,6 +41,7 @@ type tuttiWiring struct {
 	providerAuthWatcher     *agentservice.ProviderAuthWatcher
 	agentCLIUpdateScheduler *agentstatusservice.ProviderUpdateScheduler
 	mobileRemoteService     *mobileremoteservice.Service
+	modelGateway            *modelgatewayservice.Gateway
 }
 
 type analyticsDebugEventPublisher struct {
@@ -141,8 +143,15 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 	if runtimeprep.ComputerUseDefaultEnabled() {
 		w.computerService = computersvc.NewService()
 	}
-	api, appCenterService, agentRuntime, providerAuthWatcher, err := buildDaemonAPI(ctx, workspaceStore, nil, w.browserService, w.computerService)
+	modelGateway, err := modelgatewayservice.New(modelgatewayservice.Config{})
 	if err != nil {
+		return fmt.Errorf("start model gateway: %w", err)
+	}
+	w.modelGateway = modelGateway
+	api, appCenterService, agentRuntime, providerAuthWatcher, err := buildDaemonAPI(ctx, workspaceStore, nil, w.browserService, w.computerService, modelGateway)
+	if err != nil {
+		_ = modelGateway.Close()
+		w.modelGateway = nil
 		return err
 	}
 	agentTargetSetup, ok := api.AgentTargetSetupService.(*agentextensionservice.SetupService)
@@ -282,6 +291,11 @@ func (w *tuttiWiring) Close() error {
 	}
 	if w.agentRuntime != nil {
 		w.agentRuntime.Close()
+	}
+	if w.modelGateway != nil {
+		if err := w.modelGateway.Close(); err != nil && closeErr == nil {
+			closeErr = err
+		}
 	}
 	if w.analyticsReporter != nil {
 		if err := w.analyticsReporter.Close(); err != nil && closeErr == nil {

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -47,6 +47,7 @@ import (
 	managedcredentialsservice "github.com/tutti-os/tutti/services/tuttid/service/managedcredentials"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 	modelbindingservice "github.com/tutti-os/tutti/services/tuttid/service/modelbinding"
+	modelgatewayservice "github.com/tutti-os/tutti/services/tuttid/service/modelgateway"
 	modelplanservice "github.com/tutti-os/tutti/services/tuttid/service/modelplan"
 	modelpolicyservice "github.com/tutti-os/tutti/services/tuttid/service/modelpolicy"
 	preferencesservice "github.com/tutti-os/tutti/services/tuttid/service/preferences"
@@ -76,7 +77,7 @@ func configureWorkspaceAgentResolution(
 	}
 }
 
-func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analyticsReporter reporterservice.Reporter, browserService *browsersvc.Service, computerService *computersvc.Service) (tuttiapi.DaemonAPI, *workspaceservice.AppCenterService, *agentdaemon.Runtime, *agentservice.ProviderAuthWatcher, error) {
+func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analyticsReporter reporterservice.Reporter, browserService *browsersvc.Service, computerService *computersvc.Service, modelGateway *modelgatewayservice.Gateway) (tuttiapi.DaemonAPI, *workspaceservice.AppCenterService, *agentdaemon.Runtime, *agentservice.ProviderAuthWatcher, error) {
 	workspaceStore, _ := store.(workspacedata.WorkbenchStore)
 	issueStore, _ := store.(workspaceissues.Store)
 	preferencesStore, _ := store.(workspacedata.PreferencesStore)
@@ -292,6 +293,7 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 	}
 	agentRuntimeController := newAgentRuntimeAdapter(agentRuntime.Controller())
 	agentSessionService := agentservice.NewService(agentRuntimeController)
+	agentSessionService.ModelGateway = modelGateway
 	if browserService != nil {
 		agentSessionService.AgentSessionResourceReleaser = browserService
 	}


### PR DESCRIPTION
## Summary

- add a tuttիդ-owned loopback Model Gateway that translates Codex `POST /v1/responses` traffic to OpenAI Chat Completions and converts JSON/SSE responses back into a complete Responses event sequence
- register isolated, session-scoped routes with temporary tokens while retaining upstream credentials only in daemon memory; clean up and rebuild routes across session lifecycle and resume
- make Codex model-plan runtime configuration explicitly use `wire_api = "responses"` against the local gateway while leaving OpenCode direct access and native provider paths unchanged
- filter hosted/future tool registrations that cannot be represented by Chat Completions, preserve function/namespace tools, and fail closed for unsupported hosted calls or explicit choices
- align message normalization with cc-switch for Chat-only upstreams: map `system`/`developer` to `system`, map unknown roles to `user`, join text parts, and collapse all system text to the leading message

## Root cause

Codex speaks the Responses API, but custom OpenAI-compatible model plans may expose only `/v1/chat/completions`. Pointing Codex directly at those upstreams leaves `/responses` unavailable and cannot satisfy Codex's Responses SSE state machine. Disabling only `web_search` is also version-specific: Codex can register other hosted tools later, and strict Chat-compatible upstreams may reject Codex-internal roles such as `developer` with tokenization errors.

## Impact and safety

- applies only to Codex sessions backed by OpenAI-protocol model plans
- binds the gateway to `127.0.0.1:0`; the public tuttիդ API and OpenAPI contract are unchanged
- generates at least 256-bit route tokens, prevents credential-bearing cross-origin redirects, redacts upstream secrets, and invalidates old routes during cleanup/replacement
- keeps upstream API keys out of Codex environment/configuration
- does not add Anthropic/Gemini translation or the unsupported Responses features documented in the architecture note

## Validation

- `go test ./service/modelgateway ./service/agent`
- `go test -race ./service/modelgateway`
- `corepack pnpm@10.11.0 check:changed`
- pre-push `corepack pnpm@10.11.0 check:changed -- --push-ready` (14 lanes)
- opt-in real Codex CLI smoke: two consecutive turns, one tool call/result round trip, upstream `/v1/chat/completions`, valid Responses SSE completion, hosted-tool filtering, and post-cleanup token revocation

## Documentation

Updated the model access plan architecture and Agent provider/runtime troubleshooting guidance with gateway ownership, data flow, hosted-tool handling, role normalization, and debugging evidence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches model routing, session credentials, and a large new protocol translation layer on the agent runtime path; mistakes could leak keys, break Codex turns, or mis-handle tool semantics.
> 
> **Overview**
> Adds a **tuttid-owned loopback Model Gateway** so Codex sessions on OpenAI-protocol Model Plans can keep `wire_api = "responses"` while upstreams only expose **Chat Completions**. The gateway listens on `127.0.0.1`, accepts authenticated `POST /v1/responses`, forwards as `/v1/chat/completions`, and rebuilds complete Responses JSON/SSE (tools, reasoning, usage, timeouts).
> 
> **Session wiring:** `agent.Service` registers per workspace/session routes with a **temporary bearer token**; upstream plan API keys stay in daemon memory. Codex runtime prep gets the loopback base URL, token, and `wire_api = "responses"`. OpenCode and other providers still use the plan endpoint directly. Routes are revoked on cleanup, failed prepare, and resume replacement.
> 
> **Provider registry** gains `ModelPlanEndpointAdapter` (`responses_to_chat_gateway` for Codex). **Gateway behavior** includes Codex role normalization and system-message collapse, filtering of non-translatable hosted/future tool registrations (fail-closed on explicit hosted choices/history), and credential redaction in upstream errors.
> 
> Docs and troubleshooting cover the new flow; tests include broad `modelgateway` coverage and an opt-in real Codex CLI smoke test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11e67874662ebe6ed33238ea76a0211f83f469cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->