### PR TITLE
fix(agent-gui): keep handoff available when input is disabled

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -527,7 +527,10 @@ target, plus temporary disclosure/icon-motion state; a host supplies its
 authoritative ready target projection and retains launch orchestration in
 `onSelect`. Host surfaces must not reconstruct a second handoff row model,
 observe the portaled menu DOM, or infer target identity from provider or
-visible text.
+visible text. The current conversation's composer input availability is
+independent from this launch surface: a target connection may disable input
+while Handoff remains available when the host supplies a ready destination and
+the launch callback.
 
 For a signed Agent Extension, package `icon` is the primary identity and
 optional package `maskIcon` is the conversation-row glyph. All assets remain

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -529,8 +529,7 @@ authoritative ready target projection and retains launch orchestration in
 observe the portaled menu DOM, or infer target identity from provider or
 visible text. The current conversation's composer input availability is
 independent from this launch surface: a target connection may disable input
-while Handoff remains available when the host supplies a ready destination and
-the launch callback.
+while Handoff remains available when the host supplies the launch callback.
 
 For a signed Agent Extension, package `icon` is the primary identity and
 optional package `maskIcon` is the conversation-row glyph. All assets remain

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -520,6 +520,8 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   );
 
   const providerState = useComposerProviderTargets({
+    workspaceId,
+    agentActivityRuntime,
     layoutMode,
     provider,
     agentTargets,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -520,8 +520,6 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   );
 
   const providerState = useComposerProviderTargets({
-    workspaceId,
-    agentActivityRuntime,
     layoutMode,
     provider,
     agentTargets,

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.spec.ts
@@ -6,22 +6,19 @@ describe("resolveComposerHandoffDisabled", () => {
     expect(
       resolveComposerHandoffDisabled({
         composerControlsHardDisabled: false,
-        hasHandoffConversation: true,
-        handoffMenuTargetCount: 1
+        hasHandoffConversation: true
       })
     ).toBe(false);
   });
 
   it.each([
     ["hard-disabled composer", { composerControlsHardDisabled: true }],
-    ["missing handoff callback", { hasHandoffConversation: false }],
-    ["no ready handoff target", { handoffMenuTargetCount: 0 }]
+    ["missing handoff callback", { hasHandoffConversation: false }]
   ])("disables handoff when %s", (_reason, override) => {
     expect(
       resolveComposerHandoffDisabled({
         composerControlsHardDisabled: false,
         hasHandoffConversation: true,
-        handoffMenuTargetCount: 1,
         ...override
       })
     ).toBe(true);

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.spec.ts
@@ -2,24 +2,18 @@ import { describe, expect, it } from "vitest";
 import { resolveComposerHandoffDisabled } from "./useComposerProviderTargets";
 
 describe("resolveComposerHandoffDisabled", () => {
-  it("does not couple handoff availability to the current composer input", () => {
+  it("stays enabled when the current composer is disabled", () => {
     expect(
       resolveComposerHandoffDisabled({
-        composerControlsHardDisabled: false,
         hasHandoffConversation: true
       })
     ).toBe(false);
   });
 
-  it.each([
-    ["hard-disabled composer", { composerControlsHardDisabled: true }],
-    ["missing handoff callback", { hasHandoffConversation: false }]
-  ])("disables handoff when %s", (_reason, override) => {
+  it("disables handoff when the callback is missing", () => {
     expect(
       resolveComposerHandoffDisabled({
-        composerControlsHardDisabled: false,
-        hasHandoffConversation: true,
-        ...override
+        hasHandoffConversation: false
       })
     ).toBe(true);
   });

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { resolveComposerHandoffDisabled } from "./useComposerProviderTargets";
+
+describe("resolveComposerHandoffDisabled", () => {
+  it("does not couple handoff availability to the current composer input", () => {
+    expect(
+      resolveComposerHandoffDisabled({
+        composerControlsHardDisabled: false,
+        hasHandoffConversation: true,
+        handoffMenuTargetCount: 1
+      })
+    ).toBe(false);
+  });
+
+  it.each([
+    ["hard-disabled composer", { composerControlsHardDisabled: true }],
+    ["missing handoff callback", { hasHandoffConversation: false }],
+    ["no ready handoff target", { handoffMenuTargetCount: 0 }]
+  ])("disables handoff when %s", (_reason, override) => {
+    expect(
+      resolveComposerHandoffDisabled({
+        composerControlsHardDisabled: false,
+        hasHandoffConversation: true,
+        handoffMenuTargetCount: 1,
+        ...override
+      })
+    ).toBe(true);
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.ts
@@ -1,13 +1,9 @@
 import { useMemo } from "react";
 import { cn } from "../../../app/renderer/lib/utils";
-import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import styles from "../AgentGUINode.styles";
 import type { AgentGUIAgentTarget } from "../../../types";
-import { reportAgentComposerDiagnostic } from "./agentComposerDiagnostics";
 
 interface Input {
-  workspaceId: string;
-  agentActivityRuntime?: AgentActivityRuntime | null;
   layoutMode: "dock" | "hero";
   provider: string;
   agentTargets: readonly AgentGUIAgentTarget[];
@@ -27,8 +23,6 @@ interface Input {
 
 export function useComposerProviderTargets(input: Input) {
   const {
-    workspaceId,
-    agentActivityRuntime,
     layoutMode,
     provider,
     agentTargets,
@@ -112,39 +106,6 @@ export function useComposerProviderTargets(input: Input) {
     selectedProviderSwitchTarget !== null &&
     providerMenuTargets.length > 0;
   const showHandoffSelect = showProviderSelect && providerSelectReadonly;
-
-  useMemo(() => {
-    reportAgentComposerDiagnostic(agentActivityRuntime ?? null, {
-      event: "agent.gui.composer.handoff.state",
-      level: "debug",
-      workspaceId,
-      details: {
-        composerControlsHardDisabled,
-        hasHandoffConversation: onHandoffConversation !== undefined,
-        inputDisabled,
-        providerTargetCount: providerMenuTargets.length,
-        providerTargetIds: providerMenuTargets.map((target) => target.targetId),
-        handoffTargetCount: handoffMenuTargets.length,
-        handoffTargetIds: handoffMenuTargets.map((target) => target.targetId),
-        selectedTargetId: selectedProviderSwitchTarget?.targetId ?? null,
-        showProviderSelect,
-        showHandoffSelect,
-        handoffDisabled
-      }
-    });
-  }, [
-    agentActivityRuntime,
-    composerControlsHardDisabled,
-    handoffDisabled,
-    handoffMenuTargets,
-    inputDisabled,
-    onHandoffConversation,
-    providerMenuTargets,
-    selectedProviderSwitchTarget,
-    showHandoffSelect,
-    showProviderSelect,
-    workspaceId
-  ]);
 
   return {
     composerClassName,

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.ts
@@ -1,9 +1,13 @@
 import { useMemo } from "react";
 import { cn } from "../../../app/renderer/lib/utils";
+import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import styles from "../AgentGUINode.styles";
 import type { AgentGUIAgentTarget } from "../../../types";
+import { reportAgentComposerDiagnostic } from "./agentComposerDiagnostics";
 
 interface Input {
+  workspaceId: string;
+  agentActivityRuntime?: AgentActivityRuntime | null;
   layoutMode: "dock" | "hero";
   provider: string;
   agentTargets: readonly AgentGUIAgentTarget[];
@@ -23,6 +27,8 @@ interface Input {
 
 export function useComposerProviderTargets(input: Input) {
   const {
+    workspaceId,
+    agentActivityRuntime,
     layoutMode,
     provider,
     agentTargets,
@@ -107,6 +113,39 @@ export function useComposerProviderTargets(input: Input) {
     selectedProviderSwitchTarget !== null &&
     providerMenuTargets.length > 0;
   const showHandoffSelect = showProviderSelect && providerSelectReadonly;
+
+  useMemo(() => {
+    reportAgentComposerDiagnostic(agentActivityRuntime ?? null, {
+      event: "agent.gui.composer.handoff.state",
+      level: "debug",
+      workspaceId,
+      details: {
+        composerControlsHardDisabled,
+        hasHandoffConversation: onHandoffConversation !== undefined,
+        inputDisabled,
+        providerTargetCount: providerMenuTargets.length,
+        providerTargetIds: providerMenuTargets.map((target) => target.targetId),
+        handoffTargetCount: handoffMenuTargets.length,
+        handoffTargetIds: handoffMenuTargets.map((target) => target.targetId),
+        selectedTargetId: selectedProviderSwitchTarget?.targetId ?? null,
+        showProviderSelect,
+        showHandoffSelect,
+        handoffDisabled
+      }
+    });
+  }, [
+    agentActivityRuntime,
+    composerControlsHardDisabled,
+    handoffDisabled,
+    handoffMenuTargets,
+    inputDisabled,
+    onHandoffConversation,
+    providerMenuTargets,
+    selectedProviderSwitchTarget,
+    showHandoffSelect,
+    showProviderSelect,
+    workspaceId
+  ]);
 
   return {
     composerClassName,

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.ts
@@ -105,7 +105,6 @@ export function useComposerProviderTargets(input: Input) {
   const providerSelectDisabled =
     providerSelectReadonly || composerControlsHardDisabled || inputDisabled;
   const handoffDisabled = resolveComposerHandoffDisabled({
-    composerControlsHardDisabled,
     hasHandoffConversation: onHandoffConversation !== undefined
   });
   const showProviderSelect =
@@ -166,8 +165,7 @@ export function useComposerProviderTargets(input: Input) {
 }
 
 export function resolveComposerHandoffDisabled(input: {
-  composerControlsHardDisabled: boolean;
   hasHandoffConversation: boolean;
 }): boolean {
-  return input.composerControlsHardDisabled || !input.hasHandoffConversation;
+  return !input.hasHandoffConversation;
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.ts
@@ -98,11 +98,11 @@ export function useComposerProviderTargets(input: Input) {
     isSelectedProjectMissing || (disabled && !canQueueWhileBusy);
   const providerSelectDisabled =
     providerSelectReadonly || composerControlsHardDisabled || inputDisabled;
-  const handoffDisabled =
-    composerControlsHardDisabled ||
-    inputDisabled ||
-    !onHandoffConversation ||
-    handoffMenuTargets.length === 0;
+  const handoffDisabled = resolveComposerHandoffDisabled({
+    composerControlsHardDisabled,
+    hasHandoffConversation: onHandoffConversation !== undefined,
+    handoffMenuTargetCount: handoffMenuTargets.length
+  });
   const showProviderSelect =
     !isHeroLayout &&
     selectedProviderSwitchTarget !== null &&
@@ -125,4 +125,17 @@ export function useComposerProviderTargets(input: Input) {
     showHandoffSelect,
     showProviderSelect
   };
+}
+
+
+export function resolveComposerHandoffDisabled(input: {
+  composerControlsHardDisabled: boolean;
+  hasHandoffConversation: boolean;
+  handoffMenuTargetCount: number;
+}): boolean {
+  return (
+    input.composerControlsHardDisabled ||
+    !input.hasHandoffConversation ||
+    input.handoffMenuTargetCount === 0
+  );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.ts
@@ -100,8 +100,7 @@ export function useComposerProviderTargets(input: Input) {
     providerSelectReadonly || composerControlsHardDisabled || inputDisabled;
   const handoffDisabled = resolveComposerHandoffDisabled({
     composerControlsHardDisabled,
-    hasHandoffConversation: onHandoffConversation !== undefined,
-    handoffMenuTargetCount: handoffMenuTargets.length
+    hasHandoffConversation: onHandoffConversation !== undefined
   });
   const showProviderSelect =
     !isHeroLayout &&
@@ -127,15 +126,9 @@ export function useComposerProviderTargets(input: Input) {
   };
 }
 
-
 export function resolveComposerHandoffDisabled(input: {
   composerControlsHardDisabled: boolean;
   hasHandoffConversation: boolean;
-  handoffMenuTargetCount: number;
 }): boolean {
-  return (
-    input.composerControlsHardDisabled ||
-    !input.hasHandoffConversation ||
-    input.handoffMenuTargetCount === 0
-  );
+  return input.composerControlsHardDisabled || !input.hasHandoffConversation;
 }


### PR DESCRIPTION
## What changed

- Decouple Handoff availability from the current composer input disabled state.
- Keep Handoff enabled even when the current shared-agent connection disables input.
- Do not disable Handoff merely because the projected destination list is empty; the host callback owns launch handling and can resolve destinations independently.
- Add focused regression coverage and document the contract.

## Root cause

AgentGUI reused both `inputDisabled` and `handoffMenuTargets.length === 0` for `handoffDisabled`, although Handoff launches another agent target and is not an action on the current conversation.

## Validation

- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/composer/useComposerProviderTargets.spec.ts agent-gui/agentGuiNode/composer/ComposerFooter.composition.spec.ts`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- 11 focused tests passed