### PR TITLE
fix(agent): recognize OpenCode config credentials

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -192,9 +192,13 @@ An ordinary read may reuse the full provider snapshot. A forced read bypasses
 that snapshot and rechecks current authentication/readiness, including the
 provider credential marker, but may reuse a successful CLI version or adapter
 launch result while the resolved executable fingerprint is unchanged. Failed
-version reads and failed adapter launches are never cached. OpenCode and
-Tutti Agent use their validated local credential files as the primary auth
-signal; malformed files may fall back to one CLI check. Cursor's single
+version reads and failed adapter launches are never cached. Tutti Agent uses
+its validated local credential file as the primary auth signal; malformed
+files may fall back to one CLI check. OpenCode additionally treats an effective
+`provider.*.options.apiKey` from its global or explicit JSON/JSONC config as
+authenticated, resolving environment/file references without exposing their
+values. Project-local OpenCode credentials are not projected into shared
+provider readiness because that snapshot has no workspace cwd. Cursor's single
 `about --format json` result supplies both auth and version when available.
 
 ## 3. Domain model

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -16,6 +16,8 @@ Use the focused runtime index or open one area directly:
 
 - [Agent Providers And Setup](./agent-provider-setup.md): Provider discovery, installation, authentication, models, configuration, and runtime reachability.
   Includes extension command/Skill palette hydration failures.
+  Also covers OpenCode API-key configuration being misreported as requiring
+  interactive login.
   Also covers focus-driven provider CLI scans, repeated Extension Target version
   probes, and CPU spikes.
 - [Agent Sessions And Lifecycle](./agent-session-lifecycle.md): Turn state, activation, planning-mode classification, Tutti workflow response contracts, loading, cancel, goal controls, restore, file-change undo, rail projection, realtime completion provenance, event updates, imports, and performance.

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -645,6 +645,40 @@ file or directory`. If the CLI path exists but `codex app-server` cannot
   API-key-without-login readiness, then run
   `cd services/tuttid && go test ./service/agentstatus`.
 
+### OpenCode shows login required when `provider.options.apiKey` is configured
+
+- Symptom:
+  OpenCode sessions work from the CLI, but Tutti marks OpenCode as
+  `auth_required`. Clicking Login from a standalone Agent window can then show
+  a generic internal-service error even though no interactive login is needed.
+- Quick checks:
+  Run `opencode auth list`. If it has no stored login, inspect the effective
+  global or explicit OpenCode config for a non-empty
+  `provider.<id>.options.apiKey` declaration. Check all supported global names
+  in merge order: `config.json`, `opencode.json`, and `opencode.jsonc`. When the
+  declaration uses `{env:NAME}` or `{file:path}`, verify that the reference
+  resolves without printing the credential.
+- Root cause:
+  `opencode auth list` and `~/.local/share/opencode/auth.json` describe
+  OpenCode's stored auth records. OpenCode can also authenticate directly from
+  provider config, including JSONC and environment/file substitutions. A
+  detector that checks only the auth store reports a false login requirement;
+  omitting `opencode.jsonc` from the auth/config watcher can also leave the
+  false result cached after the config changes.
+- Fix:
+  Provider status must merge the global, `OPENCODE_CONFIG`,
+  `OPENCODE_CONFIG_DIR`, and `OPENCODE_CONFIG_CONTENT` sources in OpenCode
+  precedence order. Resolve only the winning `apiKey` declarations and report
+  `apiKey` / `API Usage Billing` when at least one resolves non-empty. Watch all
+  three global file names, including JSONC. Do not log or return credential
+  values. Project-local config remains outside shared provider readiness
+  because the status snapshot has no workspace cwd.
+- Validation:
+  Cover literal, `{env:...}`, `{file:...}`, JSONC, empty higher-precedence
+  overrides, and the final `ready` status in `agentstatus` tests. Also assert
+  that the provider auth watcher includes `opencode.jsonc`, then run
+  `cd services/tuttid && go test ./service/agentstatus ./service/agent`.
+
 ### Codex session fails with not connected when model_catalog_json is relative
 
 - Symptom:

--- a/packages/agent/daemon/providerregistry/opencode.go
+++ b/packages/agent/daemon/providerregistry/opencode.go
@@ -63,11 +63,16 @@ func openCodeDescriptor() ProviderDescriptor {
 					{PathEnvVars: []string{"OPENCODE_CONFIG"}},
 					{
 						RootCandidates: []AuthWatchRootCandidateDescriptor{
-							{EnvVar: "OPENCODE_CONFIG_DIR"},
 							{EnvVar: "XDG_CONFIG_HOME", Suffix: "opencode"},
 						},
 						DefaultRoot: "~/.config/opencode",
-						Paths:       []string{"opencode.json", "config.json"},
+						Paths:       []string{"config.json", "opencode.json", "opencode.jsonc"},
+					},
+					{
+						RootCandidates: []AuthWatchRootCandidateDescriptor{
+							{EnvVar: "OPENCODE_CONFIG_DIR"},
+						},
+						Paths: []string{"opencode.json", "opencode.jsonc"},
 					},
 					{
 						RootCandidates: []AuthWatchRootCandidateDescriptor{

--- a/packages/agent/daemon/providerregistry/registry_test.go
+++ b/packages/agent/daemon/providerregistry/registry_test.go
@@ -385,7 +385,8 @@ func TestMigratedReturnsOpenCodeNestedClones(t *testing.T) {
 	first.Runtime.StandardACP.SettingsEnvironment.JSONFields[0].JSONKey = "mutated"
 	first.Status.AuthWatch.Sources[0].PathEnvVars[0] = "MUTATED"
 	first.Status.AuthWatch.Sources[1].RootCandidates[0].EnvVar = "MUTATED"
-	first.Status.AuthWatch.Sources[1].Paths[0] = "mutated"
+	first.Status.AuthWatch.Sources[2].RootCandidates[0].EnvVar = "MUTATED"
+	first.Status.AuthWatch.Sources[2].Paths[0] = "mutated"
 
 	second, ok := Find(OpenCodeProviderID)
 	if !ok {
@@ -396,8 +397,10 @@ func TestMigratedReturnsOpenCodeNestedClones(t *testing.T) {
 		t.Fatalf("Runtime.StandardACP leaked mutation: %#v", second.Runtime.StandardACP)
 	}
 	if second.Status.AuthWatch.Sources[0].PathEnvVars[0] != "OPENCODE_CONFIG" ||
-		second.Status.AuthWatch.Sources[1].RootCandidates[0].EnvVar != "OPENCODE_CONFIG_DIR" ||
-		second.Status.AuthWatch.Sources[1].Paths[0] != "opencode.json" {
+		second.Status.AuthWatch.Sources[1].RootCandidates[0].EnvVar != "XDG_CONFIG_HOME" ||
+		second.Status.AuthWatch.Sources[1].Paths[0] != "config.json" ||
+		second.Status.AuthWatch.Sources[2].RootCandidates[0].EnvVar != "OPENCODE_CONFIG_DIR" ||
+		second.Status.AuthWatch.Sources[2].Paths[0] != "opencode.json" {
 		t.Fatalf("Status.AuthWatch leaked mutation: %#v", second.Status.AuthWatch)
 	}
 }

--- a/services/tuttid/service/agent/provider_auth_watcher_test.go
+++ b/services/tuttid/service/agent/provider_auth_watcher_test.go
@@ -141,8 +141,11 @@ func TestDefaultProviderAuthWatchEntriesCoverCodexClaudeAndOpenCode(t *testing.T
 	}
 	for _, want := range []string{
 		configPath,
+		filepath.Join(home, ".config", "opencode", "config.json"),
+		filepath.Join(home, ".config", "opencode", "opencode.json"),
+		filepath.Join(home, ".config", "opencode", "opencode.jsonc"),
 		filepath.Join(configDir, "opencode.json"),
-		filepath.Join(configDir, "config.json"),
+		filepath.Join(configDir, "opencode.jsonc"),
 		filepath.Join(dataDir, "opencode", "auth.json"),
 	} {
 		if !containsString(opencodePaths, want) {

--- a/services/tuttid/service/agentstatus/auth_marker_strategy_test.go
+++ b/services/tuttid/service/agentstatus/auth_marker_strategy_test.go
@@ -2,9 +2,11 @@ package agentstatus
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 )
@@ -46,6 +48,67 @@ func TestOpenCodeAuthMarkerEmptyObjectRequiresLogin(t *testing.T) {
 	auth, ok := parseOpenCodeAuthMarkerFile(path)
 	if !ok || auth.Status != AuthRequired {
 		t.Fatalf("parseOpenCodeAuthMarkerFile() = %#v, %v", auth, ok)
+	}
+}
+
+func TestOpenCodeConfigAPIKeyOverridesMissingAuthMarker(t *testing.T) {
+	home := t.TempDir()
+	binaryPath := filepath.Join(home, "bin", "opencode")
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o755); err != nil {
+		t.Fatalf("mkdir binary dir: %v", err)
+	}
+	if err := os.WriteFile(binaryPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write OpenCode binary: %v", err)
+	}
+	configPath := filepath.Join(home, ".config", "opencode", "opencode.jsonc")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{
+		"provider": {
+			"openai": {
+				"options": { "apiKey": "sk-test", },
+			},
+		},
+	}`), 0o600); err != nil {
+		t.Fatalf("write OpenCode config: %v", err)
+	}
+
+	service := Service{
+		Environ: func() []string { return []string{"PATH=" + filepath.Dir(binaryPath)} },
+		HomeDir: func() (string, error) { return home, nil },
+		LookPath: func(name string) (string, error) {
+			if name == "opencode" {
+				return binaryPath, nil
+			}
+			return "", errors.New("not found")
+		},
+		IsExecutableFile: func(path string) bool { return path == binaryPath },
+		RunAuthStatusCommand: func(context.Context, ProviderSpec, string) (AuthInfo, bool) {
+			return AuthInfo{Status: AuthRequired}, true
+		},
+	}
+	status := service.statusForSpec(
+		context.Background(),
+		ProviderSpec{
+			Kind:               providerregistry.StatusKindOpenCodeCLI,
+			Provider:           providerregistry.OpenCodeProviderID,
+			BinaryNames:        []string{"opencode"},
+			AdapterBinaryNames: []string{"opencode"},
+			AdapterCommand:     []string{"opencode", "acp"},
+			LoginArgs:          []string{"auth", "login"},
+		},
+		time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC),
+		statusDetectionOptions{skipAdapterProbe: true},
+	)
+
+	if status.Availability.Status != AvailabilityReady {
+		t.Fatalf("Availability.Status = %q, want %q", status.Availability.Status, AvailabilityReady)
+	}
+	if status.Auth.Status != AuthAuthenticated ||
+		status.Auth.AuthMethod != "apiKey" ||
+		status.Auth.AccountLabel != "API Usage Billing" {
+		t.Fatalf("Auth = %#v, want configured API billing", status.Auth)
 	}
 }
 

--- a/services/tuttid/service/agentstatus/opencode_config.go
+++ b/services/tuttid/service/agentstatus/opencode_config.go
@@ -1,0 +1,270 @@
+package agentstatus
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var (
+	openCodeEnvReference  = regexp.MustCompile(`\{env:([^}]+)\}`)
+	openCodeFileReference = regexp.MustCompile(`\{file:([^}]+)\}`)
+)
+
+type openCodeProviderOption struct {
+	sourceDir string
+	value     string
+}
+
+// openCodeConfigHasAPICredential checks the same global and explicit config
+// sources OpenCode can use without a workspace cwd. Project-local config is
+// intentionally excluded because provider readiness is shared across
+// workspaces and cannot safely resolve one project's precedence here.
+func (s Service) openCodeConfigHasAPICredential() bool {
+	options := s.openCodeProviderOptions()
+	for _, option := range options["apiKey"] {
+		if value, valid := s.resolveOpenCodeConfigValue(option); valid &&
+			strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func (s Service) openCodeConfigDeclaresProviderOption(keys ...string) bool {
+	options := s.openCodeProviderOptions()
+	for _, key := range keys {
+		for _, option := range options[key] {
+			if value, valid := s.resolveOpenCodeConfigValue(option); valid &&
+				strings.TrimSpace(value) != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// openCodeProviderOptions applies OpenCode's merge order for provider options:
+// legacy global JSON, global JSON, global JSONC, an explicit config path, an
+// explicit config directory, then inline config. A later declaration for the
+// same provider and option replaces the earlier one.
+func (s Service) openCodeProviderOptions() map[string]map[string]openCodeProviderOption {
+	byOption := make(map[string]map[string]openCodeProviderOption)
+	applyFile := func(path string) {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return
+		}
+		applyOpenCodeProviderOptions(byOption, content, filepath.Dir(path))
+	}
+
+	if configDir := s.openCodeGlobalConfigDir(); configDir != "" {
+		for _, name := range []string{"config.json", "opencode.json", "opencode.jsonc"} {
+			applyFile(filepath.Join(configDir, name))
+		}
+	}
+	if path := strings.TrimSpace(s.lookupEnv("OPENCODE_CONFIG")); path != "" {
+		applyFile(expandOpenCodeHomePath(path, s.openCodeHomeDir()))
+	}
+	if configDir := strings.TrimSpace(s.lookupEnv("OPENCODE_CONFIG_DIR")); configDir != "" {
+		configDir = expandOpenCodeHomePath(configDir, s.openCodeHomeDir())
+		for _, name := range []string{"opencode.json", "opencode.jsonc"} {
+			applyFile(filepath.Join(configDir, name))
+		}
+	}
+	if content := strings.TrimSpace(s.lookupEnv("OPENCODE_CONFIG_CONTENT")); content != "" {
+		applyOpenCodeProviderOptions(byOption, []byte(content), "")
+	}
+	return byOption
+}
+
+func applyOpenCodeProviderOptions(
+	byOption map[string]map[string]openCodeProviderOption,
+	content []byte,
+	sourceDir string,
+) {
+	var parsed struct {
+		Provider map[string]struct {
+			Options map[string]json.RawMessage `json:"options"`
+		} `json:"provider"`
+	}
+	if err := json.Unmarshal(normalizeOpenCodeJSONC(content), &parsed); err != nil {
+		return
+	}
+	for providerID, provider := range parsed.Provider {
+		for optionName, raw := range provider.Options {
+			var value string
+			if err := json.Unmarshal(raw, &value); err != nil {
+				value = ""
+			}
+			providers := byOption[optionName]
+			if providers == nil {
+				providers = make(map[string]openCodeProviderOption)
+				byOption[optionName] = providers
+			}
+			providers[providerID] = openCodeProviderOption{
+				sourceDir: sourceDir,
+				value:     value,
+			}
+		}
+	}
+}
+
+func (s Service) resolveOpenCodeConfigValue(option openCodeProviderOption) (string, bool) {
+	value := openCodeEnvReference.ReplaceAllStringFunc(option.value, func(match string) string {
+		parts := openCodeEnvReference.FindStringSubmatch(match)
+		if len(parts) != 2 {
+			return ""
+		}
+		return s.lookupEnv(parts[1])
+	})
+	valid := true
+	value = openCodeFileReference.ReplaceAllStringFunc(value, func(match string) string {
+		parts := openCodeFileReference.FindStringSubmatch(match)
+		if len(parts) != 2 {
+			valid = false
+			return ""
+		}
+		path := expandOpenCodeHomePath(strings.TrimSpace(parts[1]), s.openCodeHomeDir())
+		if path == "" {
+			valid = false
+			return ""
+		}
+		if !filepath.IsAbs(path) {
+			if option.sourceDir == "" {
+				valid = false
+				return ""
+			}
+			path = filepath.Join(option.sourceDir, path)
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			valid = false
+			return ""
+		}
+		return strings.TrimSpace(string(content))
+	})
+	return value, valid
+}
+
+func (s Service) openCodeGlobalConfigDir() string {
+	if root := strings.TrimSpace(s.lookupEnv("XDG_CONFIG_HOME")); root != "" {
+		return filepath.Join(root, "opencode")
+	}
+	if home := s.openCodeHomeDir(); home != "" {
+		return filepath.Join(home, ".config", "opencode")
+	}
+	return ""
+}
+
+func (s Service) openCodeHomeDir() string {
+	home, err := s.homeDir()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(home)
+}
+
+func expandOpenCodeHomePath(path string, home string) string {
+	path = strings.TrimSpace(path)
+	if path == "~" {
+		return home
+	}
+	if strings.HasPrefix(path, "~/") && home != "" {
+		return filepath.Join(home, strings.TrimPrefix(path, "~/"))
+	}
+	return path
+}
+
+// normalizeOpenCodeJSONC removes comments and trailing commas while preserving
+// quoted strings. OpenCode accepts both JSON and JSONC for all config sources.
+func normalizeOpenCodeJSONC(content []byte) []byte {
+	withoutComments := make([]byte, 0, len(content))
+	inString := false
+	escaped := false
+	for index := 0; index < len(content); index++ {
+		current := content[index]
+		if inString {
+			withoutComments = append(withoutComments, current)
+			if escaped {
+				escaped = false
+			} else if current == '\\' {
+				escaped = true
+			} else if current == '"' {
+				inString = false
+			}
+			continue
+		}
+		if current == '"' {
+			inString = true
+			withoutComments = append(withoutComments, current)
+			continue
+		}
+		if current == '/' && index+1 < len(content) {
+			next := content[index+1]
+			if next == '/' {
+				index += 2
+				for index < len(content) && content[index] != '\n' && content[index] != '\r' {
+					index++
+				}
+				if index < len(content) {
+					withoutComments = append(withoutComments, content[index])
+				}
+				continue
+			}
+			if next == '*' {
+				index += 2
+				for index+1 < len(content) && (content[index] != '*' || content[index+1] != '/') {
+					if content[index] == '\n' || content[index] == '\r' {
+						withoutComments = append(withoutComments, content[index])
+					}
+					index++
+				}
+				if index+1 < len(content) {
+					index++
+				}
+				continue
+			}
+		}
+		withoutComments = append(withoutComments, current)
+	}
+
+	normalized := make([]byte, 0, len(withoutComments))
+	inString = false
+	escaped = false
+	for index := 0; index < len(withoutComments); index++ {
+		current := withoutComments[index]
+		if inString {
+			normalized = append(normalized, current)
+			if escaped {
+				escaped = false
+			} else if current == '\\' {
+				escaped = true
+			} else if current == '"' {
+				inString = false
+			}
+			continue
+		}
+		if current == '"' {
+			inString = true
+			normalized = append(normalized, current)
+			continue
+		}
+		if current == ',' {
+			next := index + 1
+			for next < len(withoutComments) &&
+				(withoutComments[next] == ' ' || withoutComments[next] == '\t' ||
+					withoutComments[next] == '\n' || withoutComments[next] == '\r') {
+				next++
+			}
+			if next < len(withoutComments) &&
+				(withoutComments[next] == '}' || withoutComments[next] == ']') {
+				continue
+			}
+		}
+		normalized = append(normalized, current)
+	}
+	return normalized
+}

--- a/services/tuttid/service/agentstatus/provider_custom_config.go
+++ b/services/tuttid/service/agentstatus/provider_custom_config.go
@@ -48,6 +48,8 @@ func (s Service) providerUsesCustomConfig(provider string) bool {
 			return s.codexConfigDeclares("base_url", "chatgpt_base_url", "api_key") || s.codexAuthJSONHasAPIKey()
 		case providerregistry.StatusKindClaudeCLI:
 			return s.claudeSettingsDeclares(claudeCustomConfigKeys, true)
+		case providerregistry.StatusKindOpenCodeCLI:
+			return s.openCodeConfigDeclaresProviderOption("apiKey", "baseURL")
 		}
 	}
 	return false
@@ -71,6 +73,8 @@ func (s Service) providerHasAPICredential(provider string) bool {
 			return s.codexConfigDeclares("api_key") || s.codexAuthJSONHasAPIKey()
 		case providerregistry.StatusKindClaudeCLI:
 			return s.claudeSettingsDeclares(claudeAPICredentialKeys, true)
+		case providerregistry.StatusKindOpenCodeCLI:
+			return s.openCodeConfigHasAPICredential()
 		}
 	}
 	return false

--- a/services/tuttid/service/agentstatus/provider_custom_config_test.go
+++ b/services/tuttid/service/agentstatus/provider_custom_config_test.go
@@ -253,6 +253,98 @@ base_url = "https://gateway.mycorp.com/v1"
 	}
 }
 
+func TestProviderHasAPICredentialOpenCodeJSONCAPIKey(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "opencode", "opencode.jsonc"), `{
+		// OpenCode accepts comments and trailing commas.
+		"provider": {
+			"openai": {
+				"options": {
+					"apiKey": "sk-test",
+				},
+			},
+		},
+	}`)
+	svc := customConfigService(home)
+	if !svc.providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("expected OpenCode JSONC provider apiKey to count as an API credential")
+	}
+}
+
+func TestProviderHasAPICredentialOpenCodeResolvesEnvReference(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "opencode", "opencode.json"),
+		`{"provider":{"openai":{"options":{"apiKey":"{env:OPENAI_API_KEY}"}}}}`)
+	svc := customConfigService(home)
+	if svc.providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("unset OpenCode env reference must not count as an API credential")
+	}
+	svc.Environ = func() []string { return []string{"OPENAI_API_KEY=sk-test"} }
+	if !svc.providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("resolved OpenCode env reference should count as an API credential")
+	}
+}
+
+func TestProviderHasAPICredentialOpenCodeResolvesRelativeFileReference(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".config", "opencode")
+	writeFile(t, filepath.Join(configDir, "secrets", "openai-key"), "sk-test\n")
+	writeFile(t, filepath.Join(configDir, "opencode.json"),
+		`{"provider":{"openai":{"options":{"apiKey":"{file:secrets/openai-key}"}}}}`)
+	svc := customConfigService(home)
+	if !svc.providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("resolved OpenCode file reference should count as an API credential")
+	}
+}
+
+func TestProviderHasAPICredentialOpenCodeRejectsMissingFileReference(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "opencode", "opencode.json"),
+		`{"provider":{"openai":{"options":{"apiKey":"prefix-{file:missing-key}"}}}}`)
+	svc := customConfigService(home)
+	if svc.providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("missing OpenCode file reference must invalidate the apiKey declaration")
+	}
+}
+
+func TestProviderHasAPICredentialOpenCodeHonorsConfigPrecedence(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".config", "opencode")
+	writeFile(t, filepath.Join(configDir, "opencode.json"),
+		`{"provider":{"openai":{"options":{"apiKey":"sk-lower"}}}}`)
+	writeFile(t, filepath.Join(configDir, "opencode.jsonc"),
+		`{"provider":{"openai":{"options":{"apiKey":""}}}}`)
+	svc := customConfigService(home)
+	if svc.providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("later empty OpenCode JSONC apiKey must override an earlier credential")
+	}
+}
+
+func TestProviderHasAPICredentialOpenCodeCustomConfig(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, "custom", "opencode.jsonc")
+	writeFile(t, configPath,
+		`{"provider":{"anthropic":{"options":{"apiKey":"sk-test"}}}}`)
+	svc := customConfigService(home)
+	svc.Environ = func() []string { return []string{"OPENCODE_CONFIG=" + configPath} }
+	if !svc.providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("expected OPENCODE_CONFIG provider apiKey to count as an API credential")
+	}
+}
+
+func TestProviderHasAPICredentialOpenCodeBaseURLOnlyIsNotCredential(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "opencode", "opencode.json"),
+		`{"provider":{"openai":{"options":{"baseURL":"https://gw.local/v1"}}}}`)
+	svc := customConfigService(home)
+	if svc.providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("OpenCode baseURL without apiKey must not count as an API credential")
+	}
+	if !svc.providerUsesCustomConfig(agentprovider.OpenCode) {
+		t.Fatal("OpenCode baseURL should still count as custom config")
+	}
+}
+
 func TestProviderHasAPICredentialNone(t *testing.T) {
 	svc := customConfigService(t.TempDir())
 	if svc.providerHasAPICredential(agentprovider.ClaudeCode) {
@@ -260,5 +352,8 @@ func TestProviderHasAPICredentialNone(t *testing.T) {
 	}
 	if svc.providerHasAPICredential(agentprovider.Codex) {
 		t.Fatal("no env and no config should not have an API credential")
+	}
+	if svc.providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("no env and no config should not have an OpenCode API credential")
 	}
 }

--- a/services/tuttid/service/agentstatus/registry.go
+++ b/services/tuttid/service/agentstatus/registry.go
@@ -196,6 +196,16 @@ func isClaudeStatusSpec(spec ProviderSpec) bool {
 	return kind == providerregistry.StatusKindClaudeCLI
 }
 
+func isOpenCodeStatusSpec(spec ProviderSpec) bool {
+	kind := spec.Kind
+	if kind == "" {
+		if status, ok := migratedProviderStatus(spec.Provider); ok {
+			kind = status.Kind
+		}
+	}
+	return kind == providerregistry.StatusKindOpenCodeCLI
+}
+
 func migratedProviderStatus(provider string) (providerregistry.StatusDescriptor, bool) {
 	descriptor, ok := providerregistry.Find(provider)
 	if !ok {

--- a/services/tuttid/service/agentstatus/service_status.go
+++ b/services/tuttid/service/agentstatus/service_status.go
@@ -170,16 +170,13 @@ func (s Service) statusForSpec(
 			actions = append(actions, terminalAction(ActionLogin, loginCommandForRuntime(spec, runtimeResolution)))
 		}
 
-		// Claude Code can run in API Usage Billing mode — an API key, an auth
-		// token, or an apiKeyHelper — which bills usage to an API account and
-		// overrides any stored OAuth/subscription session. `claude auth status`
-		// only reflects the stored session, so it is blind to these env/settings
-		// credentials; detect them directly and prefer that signal over whatever
-		// the CLI reports, so the wizard shows "已配置 API 计费" instead of a
-		// stale OAuth label or "未登录". A bare custom endpoint without a
-		// credential is NOT API billing (the user may still be on an OAuth
-		// session), so it does not trigger this override.
-		if isClaudeStatusSpec(spec) && s.providerHasAPICredential(spec.Provider) {
+		// Some provider auth commands only report their stored login database
+		// and are blind to API credentials supplied through env/settings.
+		// Prefer a configured credential for Claude Code and OpenCode so the
+		// wizard does not require an irrelevant interactive login. A bare custom
+		// endpoint is not a credential and does not trigger this override.
+		if (isClaudeStatusSpec(spec) || isOpenCodeStatusSpec(spec)) &&
+			s.providerHasAPICredential(spec.Provider) {
 			auth.Status = AuthAuthenticated
 			auth.AccountLabel = "API Usage Billing"
 			auth.AuthMethod = "apiKey"


### PR DESCRIPTION
## Summary

- recognize OpenCode `provider.*.options.apiKey` credentials from global and explicit config sources
- support OpenCode's JSON/JSONC merge order plus `{env:...}` and `{file:...}` references without logging credential values
- watch `opencode.jsonc` and keep global and `OPENCODE_CONFIG_DIR` watch roots independent so readiness/model caches invalidate after config changes
- document the provider-readiness contract and troubleshooting path

## Root cause

The affected logs repeatedly report OpenCode as `auth_required`, then show the standalone Login action failing because its terminal launch returned no Workbench node. The status probe only consulted `opencode auth list` / `auth.json`; those describe OpenCode's stored auth records but do not include API keys configured under `provider.<id>.options.apiKey`. That false negative exposed an irrelevant Login action to a user whose runtime was already configured.

This change fixes the configured-API-key path at the source: the provider is reported as ready with `apiKey` / `API Usage Billing`, so the erroneous Login action is not offered.

## Validation

- `go test ./service/agentstatus ./service/agent`
- `go test ./providerregistry`
- `pnpm check:changed` — 11 lanes passed
- pre-push `pnpm check:changed -- --push-ready` — 12 lanes passed