### PR TITLE
fix(agent-gui): preserve new conversation placement

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -783,6 +783,14 @@ The pending activation carries the same resolved project section key as the
 create command. Exact rail projection therefore shows the conversation as soon
 as the intent is accepted; it does not wait for provider startup or invent a
 temporary catch-all section.
+The controller's new-conversation command must distinguish rail placement from
+the active Session's runtime working directory before entering the home
+composer. A Session in the Chats section may have a generated `cwd`, but that
+path is not a selected user project and must be cleared. A Session in a
+canonical project section keeps its working directory, while a command already
+on the home composer preserves the user's explicit project selection. Views
+only forward new-conversation intent; unresolved active rail membership fails
+closed rather than guessing from composer presentation fields.
 For delegated/shared execution, the initiating caller remains the placement
 authority: the adapter forwards that caller-selected `RailPlacement` through
 the binding to the owner Host. The owner persists the same section key and does

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -20,6 +20,8 @@ Use the focused runtime index or open one area directly:
   probes, and CPU spikes.
 - [Agent Sessions And Lifecycle](./agent-session-lifecycle.md): Turn state, activation, planning-mode classification, Tutti workflow response contracts, loading, cancel, goal controls, restore, file-change undo, rail projection, realtime completion provenance, event updates, imports, and performance.
   Includes shared-device recovery that looks terminal while the host is still retrying.
+  Also covers new-conversation requests that silently fail after a Chats
+  Session working directory is mistaken for a selected project.
 - [Agent Approvals And Child Sessions](./agent-approvals-subagents.md): Approval gates, plan exits, root/parent/child event attribution, child sessions, and Message Center.
   Includes provider-native work that continues invisibly after root cancellation
   and late child creation racing the durable cancel boundary.

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -62,6 +62,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [AgentGUI Batch delete sessions does nothing](./agent-session-lifecycle.md#agentgui-batch-delete-sessions-does-nothing)
 - [Agent GUI provider tab shows fused or stale conversations](./agent-session-lifecycle.md#agent-gui-provider-tab-shows-fused-or-stale-conversations)
 - [Agent GUI sessions appear under the wrong user project](./agent-session-lifecycle.md#agent-gui-sessions-appear-under-the-wrong-user-project)
+- [AgentGUI new conversation does nothing after leaving a Chats session](./agent-session-lifecycle.md#agentgui-new-conversation-does-nothing-after-leaving-a-chats-session)
 - [Agent GUI context usage is absent or has the wrong total](./agent-session-lifecycle.md#agent-gui-context-usage-is-absent-or-has-the-wrong-total)
 - [Extension history becomes non-resumable after daemon restart](./agent-session-lifecycle.md#extension-history-becomes-non-resumable-after-daemon-restart)
 - [Agent session restore breaks when durable snapshot ownership is split](./agent-session-lifecycle.md#agent-session-restore-breaks-when-durable-snapshot-ownership-is-split)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1515,6 +1515,44 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [agentGuiConversationProjectResolver.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationProjectResolver.ts)
   [useAgentGuiConversationList.ts](../../../packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.ts)
 
+### AgentGUI new conversation does nothing after leaving a Chats session
+
+- Symptom:
+  After using an ordinary Chats Session, the toolbar new-conversation action
+  opens the home composer but submitting by Enter or the send button creates no
+  visible Session and produces no `session/activate` command. Enabling Tutti
+  Mode before submitting can make the problem look mode-specific even though
+  activation is blocked before provider or Tutti Mode execution starts.
+- Quick checks:
+  Inspect the active conversation projection before the new-conversation
+  request. If `railSectionKey` is `conversations` while `cwd` is a generated
+  runtime directory, confirm that directory is not copied into the home
+  composer's selected project. A subsequent activation that resolves the path
+  against user projects and returns no placement explains the missing
+  `session/activate`.
+- Root cause:
+  Composer presentation intentionally exposes the active Session `cwd` for
+  file mentions, Git operations, and missing-directory checks. Treating that
+  presentation field as the user's home project selection conflates runtime
+  working directory with rail placement. The generated Chats directory then
+  enters project resolution and fails closed because it has no canonical
+  project section.
+- Fix:
+  Normalize default project selection at the AgentGUI controller's
+  new-conversation command. Explicit section actions remain authoritative; an
+  active Chats Session replaces the home selection with no project, an active
+  project Session keeps its working directory, and an action already on Home
+  preserves the user's explicit selection. Views forward the intent without
+  interpreting composer presentation fields.
+- Validation:
+  Cover the command through final `session/activate` for three P0 scenarios:
+  active Chats clears a generated cwd, active Project preserves its cwd and
+  canonical placement, and Home preserves an explicit project selection.
+- References:
+  [agentGuiNewConversationRequest.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.ts)
+  [useAgentGUIOperationActions.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIOperationActions.ts)
+  [agentGuiNewConversationRequest.spec.tsx](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.spec.tsx)
+
 ### Extension history becomes non-resumable after daemon restart
 
 - Symptom:

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -231,17 +231,7 @@ export function AgentGUINodeView({
   }, []);
   const requestCreateConversation = useStableEventCallback(
     (options?: { projectPath?: string | null; source?: string }) => {
-      const source = options?.source;
-      if (options && "projectPath" in options) {
-        createConversationAction(options);
-      } else if (viewModel.composer.composerSettings.selectedProjectPath) {
-        createConversationAction({
-          projectPath: viewModel.composer.composerSettings.selectedProjectPath,
-          source: source ?? "selected_project"
-        });
-      } else {
-        createConversationAction({ source: source ?? "rail_toolbar" });
-      }
+      createConversationAction(options);
       requestComposerFocus();
     }
   );

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.spec.tsx
@@ -1,0 +1,350 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+  createAgentSessionEngine,
+  type AgentActivityRailPlacement,
+  type EngineExternalCommand
+} from "@tutti-os/agent-activity-core";
+import { describe, expect, it, vi } from "vitest";
+import { createLocalAgentGUIAgentTarget } from "../../../agentTargets";
+import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
+import type { AgentHostUserProject } from "../../../host/agentHostApi";
+import type { AgentGUINodeData } from "../../../types";
+import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
+import type { AgentComposerDraft } from "../model/agentGuiNodeTypes";
+import type { AgentGUIComposerTargetData } from "./agentGuiController.composerPresentation";
+import { requestAgentGUINewConversation } from "./agentGuiNewConversationRequest";
+import { useAgentGUIActivation } from "./useAgentGUIActivation";
+import { useAgentGUIConversationHome } from "./useAgentGUIConversationHome";
+import { useAgentGUINewConversationActivation } from "./useAgentGUINewConversationActivation";
+import { useAgentGUISubmitInteractionActions } from "./useAgentGUISubmitInteractionActions";
+
+describe("P0 new-conversation placement scenarios", () => {
+  it("creates a conversations-scoped activation from an active Chats session", async () => {
+    const previousSessionCwd = "/Users/example/Documents/tutti/session-current";
+    const scenario = renderNewConversationScenario({
+      activeConversation: conversationSummary({
+        cwd: previousSessionCwd,
+        railSectionKey: "conversations"
+      }),
+      initialHomeProjectPath: previousSessionCwd,
+      userProjects: []
+    });
+
+    act(() => scenario.requestNewConversation());
+    act(() =>
+      scenario.submitPrompt([{ type: "text", text: "start a new chat" }])
+    );
+
+    const activation = await scenario.waitForActivation();
+    expect(activation).toMatchObject({
+      cwd: "",
+      initialContent: [{ type: "text", text: "start a new chat" }],
+      railPlacement: {
+        version: 1,
+        kind: "conversations",
+        sectionKey: "conversations"
+      }
+    });
+    expect(activation.cwd).not.toBe(previousSessionCwd);
+  });
+
+  it("keeps canonical project placement when starting from a project session", async () => {
+    const projectPath = "/workspace/project-a";
+    const sectionKey = "project:workspace-1:/workspace/project-a";
+    const scenario = renderNewConversationScenario({
+      activeConversation: conversationSummary({
+        cwd: projectPath,
+        railSectionKey: sectionKey
+      }),
+      initialHomeProjectPath: null,
+      userProjects: [
+        {
+          id: "project-a",
+          label: "Project A",
+          path: projectPath,
+          pinnedAtUnixMs: 0,
+          sectionKey
+        }
+      ]
+    });
+
+    act(() => scenario.requestNewConversation());
+    act(() =>
+      scenario.submitPrompt([{ type: "text", text: "continue in project" }])
+    );
+
+    expect(await scenario.waitForActivation()).toMatchObject({
+      cwd: projectPath,
+      initialContent: [{ type: "text", text: "continue in project" }],
+      railPlacement: {
+        version: 1,
+        kind: "project",
+        projectPath,
+        sectionKey
+      }
+    });
+  });
+
+  it("preserves an explicit project selection already made on Home", async () => {
+    const projectPath = "/workspace/project-a";
+    const sectionKey = "project:workspace-1:/workspace/project-a";
+    const scenario = renderNewConversationScenario({
+      activeConversation: null,
+      initialHomeProjectPath: projectPath,
+      userProjects: [
+        {
+          id: "project-a",
+          label: "Project A",
+          path: projectPath,
+          pinnedAtUnixMs: 0,
+          sectionKey
+        }
+      ]
+    });
+
+    act(() => scenario.requestNewConversation());
+    act(() =>
+      scenario.submitPrompt([{ type: "text", text: "start in my project" }])
+    );
+
+    expect(await scenario.waitForActivation()).toMatchObject({
+      cwd: projectPath,
+      initialContent: [{ type: "text", text: "start in my project" }],
+      railPlacement: {
+        version: 1,
+        kind: "project",
+        projectPath,
+        sectionKey
+      }
+    });
+  });
+});
+
+function renderNewConversationScenario(input: {
+  activeConversation: AgentGUIConversationSummary | null;
+  initialHomeProjectPath: string | null;
+  userProjects: AgentHostUserProject[];
+}) {
+  const commands: EngineExternalCommand[] = [];
+  const sessionEngine = createAgentSessionEngine({
+    clock: { nowUnixMs: () => 1 },
+    commandPort: {
+      execute: (command) => {
+        commands.push(command);
+        return new Promise<never>(() => {});
+      }
+    },
+    identity: { origin: "test", workspaceId: "workspace-1" },
+    scheduler: { schedule: () => ({ cancel() {} }) }
+  });
+  const target = createLocalAgentGUIAgentTarget("codex");
+  const dataRef: { current: AgentGUINodeData } = {
+    current: {
+      agentTargetId: target.agentTargetId,
+      lastActiveAgentSessionId: input.activeConversation?.id ?? null,
+      provider: "codex" as const
+    }
+  };
+  const targetData: AgentGUIComposerTargetData = {
+    agentTargetId: target.agentTargetId ?? null,
+    data: dataRef.current,
+    provider: "codex",
+    targetId: target.targetId
+  };
+  const activeConversationIdRef = {
+    current: input.activeConversation?.id ?? null
+  };
+  const isComposerHomeRef = { current: input.activeConversation === null };
+  const selectedProjectPathRef = {
+    current: input.initialHomeProjectPath
+  };
+  const draftByScopeKeyRef = {
+    current: {} as Record<string, AgentComposerDraft>
+  };
+  const submittedDraftSnapshotsRef = { current: {} };
+  const agentActivityRuntime = {} as AgentActivityRuntime;
+  const setDraftByScopeKey = vi.fn();
+  const conversationsRef = {
+    current: input.activeConversation ? [input.activeConversation] : []
+  };
+  const conversationListQuery = {
+    provider: "codex" as const,
+    sessionOrigin: "local",
+    userId: "user-1",
+    workspaceId: "workspace-1"
+  };
+
+  const { result } = renderHook(() => {
+    const activation = useAgentGUIActivation({
+      engine: sessionEngine,
+      getErrorMessage: (error) => String(error),
+      workspaceId: "workspace-1"
+    });
+    const { createConversation } = useAgentGUIConversationHome({
+      activeConversationIdRef,
+      activePendingActivation: null,
+      agentActivityRuntime,
+      composerAppendRequest: null,
+      composerTargetDataFromProviderTarget: () => targetData,
+      conversationFilterRef: { current: { kind: "all" } },
+      currentProvider: "codex",
+      dataRef,
+      defaultAgentTargetId: target.agentTargetId ?? null,
+      draftByScopeKeyRef,
+      handledComposerAppendSequenceRef: { current: null },
+      handledPrefillPromptSequenceRef: { current: null },
+      isComposerHomeRef,
+      isExplicitAgentGUIAgentTarget: () => true,
+      loadDraftComposerOptions: vi.fn(),
+      normalizedExplicitProviderTargets: [target],
+      normalizedProviderTargets: [target],
+      onDataChangeRef: {
+        current: (updater) => {
+          dataRef.current = updater(dataRef.current);
+        }
+      },
+      persistActiveConversation: vi.fn(),
+      prefillPromptRequest: null,
+      reportActiveConversationCleared: vi.fn(),
+      selectedComposerTargetDataRef: { current: targetData },
+      selectedProjectPathRef,
+      setActiveConversationId: vi.fn(),
+      setConversationFilter: vi.fn(),
+      setDetailError: vi.fn(),
+      setDraftByScopeKey,
+      setHomeComposerTargetOverride: vi.fn(),
+      setIntent: vi.fn(),
+      setIsComposerHome: vi.fn(),
+      setIsLoadingMessages: vi.fn(),
+      setSelectedProjectPath: vi.fn(),
+      shouldUseStaticProviderTargets: true,
+      submitPrefillPrompt: vi.fn(),
+      unactivate: async () => undefined,
+      workspaceId: "workspace-1"
+    });
+    const startConversation = useAgentGUINewConversationActivation({
+      activation,
+      activeConversationIdRef,
+      activeSessionState: null,
+      agentActivityRuntime,
+      agentTargetsProvidedRef: { current: true },
+      conversationListQuery,
+      conversationsRef,
+      currentUserId: "user-1",
+      data: dataRef.current,
+      defaultReasoningEffort: "high",
+      draftByScopeKeyRef,
+      draftSettingsBySessionIdRef: { current: {} },
+      getCachedComposerOptions: () => null,
+      isComposerHomeRef,
+      isConversationStale: () => false,
+      isCreatingConversationRef: { current: false },
+      isCurrentConversation: () => false,
+      loadSelectedConversationMessages: async () => undefined,
+      loadSessionState: vi.fn(),
+      onDataChangeRef: {
+        current: (updater) => {
+          dataRef.current = updater(dataRef.current);
+        }
+      },
+      persistActiveConversation: vi.fn(),
+      refreshMessagesFromSnapshot: vi.fn(),
+      requestRailReveal: vi.fn(),
+      selectedAgentTargetIsExplicitRef: { current: true },
+      selectedAgentTargetRef: { current: target },
+      selectedComposerTargetDataRef: { current: targetData },
+      selectedProjectPathRef,
+      sessionEngine,
+      setActiveConversationId: vi.fn(),
+      setDetailError: vi.fn(),
+      setIntent: vi.fn(),
+      setIsComposerHome: vi.fn(),
+      setIsLoadingMessages: vi.fn(),
+      submittedDraftSnapshotsRef,
+      syncConversationListProjection: async () => undefined,
+      tuttiModeDraftKey: "node-default:codex:local:codex",
+      userProjectsRef: { current: input.userProjects },
+      workspaceId: "workspace-1"
+    });
+    const { submitPrompt } = useAgentGUISubmitInteractionActions({
+      activation,
+      activeConversationIdRef,
+      activeEngineActiveTurn: null,
+      activeEnginePendingInteractions: [],
+      agentActivityRuntime,
+      conversationListQuery,
+      conversationsRef,
+      dataRef,
+      draftByScopeKeyRef,
+      executePromptRef: { current: vi.fn() },
+      isComposerHomeRef,
+      isCurrentConversation: () => false,
+      isRespondingToInteraction: false,
+      isSessionMarkedNonResumable: () => false,
+      optimisticGoalControl: null,
+      persistActiveConversation: vi.fn(),
+      planActionsRef: {
+        current: {
+          feedback: vi.fn(),
+          implement: vi.fn(),
+          skip: vi.fn()
+        }
+      },
+      promptImagesSupported: true,
+      sessionEngine,
+      setActiveConversationId: vi.fn(),
+      setDetailError: vi.fn(),
+      setDraftByScopeKey,
+      setGoalClearNoticeSequence: vi.fn(),
+      setIntent: vi.fn(),
+      setOptimisticGoalControl: vi.fn(),
+      startConversation,
+      submitPromptRef: { current: vi.fn() },
+      submittedDraftSnapshotsRef,
+      transientConversation: null,
+      workspaceId: "workspace-1"
+    });
+    return { createConversation, submitPrompt };
+  });
+
+  return {
+    requestNewConversation() {
+      requestAgentGUINewConversation({
+        activeConversationId: activeConversationIdRef.current,
+        conversations: conversationsRef.current,
+        createConversation: result.current.createConversation,
+        transientConversation: null
+      });
+    },
+    submitPrompt: result.current.submitPrompt,
+    async waitForActivation() {
+      let activation: EngineExternalCommand | undefined;
+      await waitFor(() => {
+        const matches = commands.filter(
+          (command) => command.type === "session/activate"
+        );
+        expect(matches).toHaveLength(1);
+        activation = matches[0];
+      });
+      return activation as EngineExternalCommand & {
+        cwd: string;
+        railPlacement: AgentActivityRailPlacement;
+      };
+    }
+  };
+}
+
+function conversationSummary(input: {
+  cwd: string;
+  railSectionKey: string;
+}): AgentGUIConversationSummary {
+  return {
+    id: "session-current",
+    provider: "codex",
+    title: "Current conversation",
+    status: "ready",
+    cwd: input.cwd,
+    railSectionKey: input.railSectionKey,
+    updatedAtUnixMs: 1
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.ts
@@ -1,0 +1,69 @@
+import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
+import { resolveConversationSummaryById } from "./useAgentConversationSelection";
+
+export interface AgentGUINewConversationRequestOptions {
+  projectPath?: string | null;
+  source?: string;
+}
+
+export type AgentGUINewConversationProjectSelection =
+  | { kind: "preserve_home" }
+  | { kind: "replace"; projectPath: string | null }
+  | { kind: "unresolved" };
+
+export function requestAgentGUINewConversation(input: {
+  createConversation(options: AgentGUINewConversationRequestOptions): void;
+  activeConversationId: string | null;
+  conversations: readonly AgentGUIConversationSummary[];
+  transientConversation: AgentGUIConversationSummary | null;
+  options?: AgentGUINewConversationRequestOptions;
+}): boolean {
+  if (input.options && "projectPath" in input.options) {
+    input.createConversation(input.options);
+    return true;
+  }
+  const selection = resolveAgentGUINewConversationProjectSelection({
+    activeConversationId: input.activeConversationId,
+    conversations: input.conversations,
+    transientConversation: input.transientConversation
+  });
+  if (selection.kind === "unresolved") {
+    return false;
+  }
+  if (selection.kind === "preserve_home") {
+    input.createConversation(input.options ?? {});
+    return true;
+  }
+  input.createConversation({
+    ...input.options,
+    projectPath: selection.projectPath
+  });
+  return true;
+}
+
+export function resolveAgentGUINewConversationProjectSelection(input: {
+  activeConversationId: string | null;
+  conversations: readonly AgentGUIConversationSummary[];
+  transientConversation: AgentGUIConversationSummary | null;
+}): AgentGUINewConversationProjectSelection {
+  if (input.activeConversationId === null) {
+    return { kind: "preserve_home" };
+  }
+  const activeConversation = resolveConversationSummaryById(
+    input.conversations,
+    input.activeConversationId,
+    input.transientConversation
+  );
+  if (!activeConversation) {
+    return { kind: "unresolved" };
+  }
+  const sectionKey = activeConversation.railSectionKey?.trim() ?? "";
+  if (sectionKey === "conversations") {
+    return { kind: "replace", projectPath: null };
+  }
+  const projectPath = activeConversation.cwd.trim();
+  if (!sectionKey || !projectPath) {
+    return { kind: "unresolved" };
+  }
+  return { kind: "replace", projectPath };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIOperationActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIOperationActions.ts
@@ -1,6 +1,11 @@
 import { selectEngineSession } from "@tutti-os/agent-activity-core";
 import { useCallback } from "react";
+import { translate } from "../../../i18n/index";
 import { textPromptContent } from "../model/agentComposerDraft";
+import {
+  requestAgentGUINewConversation,
+  type AgentGUINewConversationRequestOptions
+} from "./agentGuiNewConversationRequest";
 import { resolveConversationSummaryById } from "./useAgentConversationSelection";
 import { useAgentGUIComposerSettingsActions } from "./useAgentGUIComposerSettingsActions";
 import { useAgentGUIContinueConversation } from "./useAgentGUIContinueConversation";
@@ -52,18 +57,44 @@ export function useAgentGUIOperationActions(
     getCachedComposerOptions: () => input.providerComposerOptions
   });
 
-  const { createConversation } = useAgentGUIConversationHome({
-    ...input,
-    submitPrefillPrompt: (prompt) => {
-      queueMicrotask(() => {
-        input.submitPromptRef.current(textPromptContent(prompt));
-      });
-    }
-  });
+  const { createConversation: enterConversationHome } =
+    useAgentGUIConversationHome({
+      ...input,
+      submitPrefillPrompt: (prompt) => {
+        queueMicrotask(() => {
+          input.submitPromptRef.current(textPromptContent(prompt));
+        });
+      }
+    });
+  const createConversation = useCallback(
+    (options?: AgentGUINewConversationRequestOptions) => {
+      if (
+        requestAgentGUINewConversation({
+          activeConversationId: input.activeConversationIdRef.current,
+          conversations: input.conversationsRef.current,
+          createConversation: enterConversationHome,
+          options,
+          transientConversation: input.transientConversation
+        })
+      ) {
+        return;
+      }
+      input.setDetailError(
+        translate("agentHost.agentGui.sessionActivationFailed")
+      );
+    },
+    [
+      enterConversationHome,
+      input.activeConversationIdRef,
+      input.conversationsRef,
+      input.setDetailError,
+      input.transientConversation
+    ]
+  );
 
   const continueInNewConversation = useAgentGUIContinueConversation({
     ...input,
-    createConversation
+    createConversation: enterConversationHome
   });
 
   const isSessionMarkedNonResumable = useCallback(


### PR DESCRIPTION
## Summary

- move default new-conversation project selection from the React view into the AgentGUI controller command
- clear generated working directories when leaving a Chats session, preserve the working directory for project-scoped sessions, and keep an explicit project selection already made on Home
- add three P0 behavioral scenarios through the final `session/activate` command
- document the placement contract and the recurring troubleshooting pattern

## Root cause

For an active conversation, `composerSettings.selectedProjectPath` intentionally projects the Session `cwd` for file mentions, Git operations, and directory checks. The toolbar treated that presentation field as the user's selected project and copied it into the Home composer. A generated Chats working directory was therefore sent through project placement resolution, which failed closed and produced no `session/activate` command.

## Impact

Creating a conversation after leaving an ordinary Chats session now works from both Enter and the send action. Project-scoped sessions continue to inherit their working directory, and an explicit Home project selection is preserved.

The change remains inside the AgentGUI controller/presentation boundary; it does not alter Host lifecycle semantics, Activity Core contracts, daemon APIs, or persistence.

## Validation

- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=1 agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.spec.tsx`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready` (12 lanes)
- counterfactual check: restoring the old “inherit every active cwd” behavior makes the Chats P0 scenario fail with zero `session/activate` commands

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to AgentGUI controller/presentation; host lifecycle and persistence are untouched, with focused P0 tests on activation placement.
> 
> **Overview**
> Fixes **new conversation** silently doing nothing after leaving a **Chats** session, when the toolbar copied the active Session’s runtime `cwd` into the home composer as if it were a user-selected project and placement resolution failed closed (no `session/activate`).
> 
> **Controller-owned placement:** Default project selection for “new conversation” moves from `AgentGUINodeView` into `requestAgentGUINewConversation` / `resolveAgentGUINewConversationProjectSelection`. The view only forwards intent; explicit `projectPath` in options stays authoritative. From an active **Chats** rail (`railSectionKey === "conversations"`), the home composer clears project (`null`); from a **project** session, it keeps that session’s `cwd`; when already on Home, it preserves the user’s explicit selection. Unresolved active membership fails closed and surfaces `sessionActivationFailed` instead of guessing from composer presentation fields.
> 
> **Tests & docs:** Three P0 hook scenarios assert the final `session/activate` command (Chats → conversations placement with empty `cwd`, project session → project placement, Home → preserved project). Architecture and troubleshooting docs describe the rail-vs-`cwd` contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56e0a5b886247e189e2288edc32aa1f2349855e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->