### PR TITLE
fix(agent-gui): scope participant avatars to turns

### DIFF
--- a/.changeset/agent-conversation-turn-scoped-avatars.md
+++ b/.changeset/agent-conversation-turn-scoped-avatars.md
@@ -1,0 +1,6 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Render custom conversation participant avatars once per speaker and turn
+instead of repeating the Agent avatar for each tool-progress message.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -453,6 +453,10 @@ presentation has distinct `loading` and `ready` states, so the renderer never
 infers identity readiness from a missing image URL. The host supplies user and
 Agent names and optional avatar URLs; AgentGUI owns the UI System Avatar,
 fixed-size loading slot, fallback initial, and user-right/Agent-left layout.
+Participant-header placement is projected from presentation turns rather than
+individual message or tool-progress rows: each speaker renders at most one
+header per turn, and a collapsed completed turn keeps the Agent header on
+visible reply content.
 This presentation input is view data only and must not enter canonical Session,
 Turn, Message, activity-runtime, or workspace-engine state.
 

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -144,6 +144,12 @@ package renders fixed-size circular loading slots. In the `ready` state, each
 participant requires a non-empty `name`; `avatarUrl` is optional and the shared
 UI System `Avatar` falls back to the name's initial.
 
+Participant headers are turn-scoped. Agent GUI renders at most one header for
+each speaker in a presentation turn, even when thinking, tool progress, or
+turn-work disclosure splits that turn into multiple message rows. A completed
+collapsed turn anchors the Agent header to visible reply content instead of the
+hidden work section.
+
 The host owns identity lookup and lifecycle. Agent GUI owns placement, sizing,
 loading treatment, image fallback, and left/right message alignment. The
 contract is presentation-only and must not be copied into canonical Session,

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -69,6 +69,7 @@ interface AgentMessageBlockProps {
   showRawTimelineJson?: boolean;
   rawTimelineJsonLabel?: string;
   participantPresentation?: AgentConversationParticipantPresentation;
+  showParticipantHeader?: boolean;
 }
 
 export function AgentMessageBlock({
@@ -84,7 +85,8 @@ export function AgentMessageBlock({
   workspaceAppIcons,
   showRawTimelineJson = false,
   rawTimelineJsonLabel = "",
-  participantPresentation
+  participantPresentation,
+  showParticipantHeader = true
 }: AgentMessageBlockProps): JSX.Element {
   "use memo";
   const agentHostApi = useOptionalAgentHostApi();
@@ -269,7 +271,9 @@ export function AgentMessageBlock({
   const enabledParticipantPresentation =
     participantPresentation?.enabled === true ? participantPresentation : null;
   const showParticipant =
-    enabledParticipantPresentation !== null && row.messages.length > 0;
+    enabledParticipantPresentation !== null &&
+    showParticipantHeader &&
+    row.messages.length > 0;
 
   return (
     <div

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.tsx
@@ -30,6 +30,7 @@ interface AgentTranscriptItemViewProps {
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
   showRawTimelineJson?: boolean;
   participantPresentation?: AgentConversationParticipantPresentation;
+  showParticipantHeader?: boolean;
   toolGroupExpanded?: boolean;
   toolGroupExpansionKey?: string;
   onToolGroupExpandedChange?: (key: string, expanded: boolean) => void;
@@ -47,6 +48,7 @@ export const AgentTranscriptItemView = memo(function AgentTranscriptItemView({
   workspaceAppIcons,
   showRawTimelineJson = false,
   participantPresentation,
+  showParticipantHeader,
   toolGroupExpanded,
   toolGroupExpansionKey,
   onToolGroupExpandedChange
@@ -94,6 +96,7 @@ export const AgentTranscriptItemView = memo(function AgentTranscriptItemView({
           showRawTimelineJson={showRawTimelineJson}
           rawTimelineJsonLabel={labels.rawTimelineJson}
           participantPresentation={participantPresentation}
+          showParticipantHeader={showParticipantHeader}
         />
       );
     case "tool-group":

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -117,6 +117,193 @@ describe("AgentTranscriptView", () => {
     ).toBe(false);
   });
 
+  it("renders each participant header once per turn across tool progress rows", () => {
+    const baseConversation = projectAgentConversationVM(
+      detailViewModel({
+        session: normalizeAgentActivitySession({
+          ...detailViewModel().session,
+          activeTurnId: "turn-1"
+        }),
+        sessionTurns: [canonicalTurn()]
+      })
+    );
+    const message = (
+      id: string,
+      body: string,
+      presentationKind: "content" | "specific-progress" = "content"
+    ) => ({
+      kind: "message-content" as const,
+      id,
+      turnId: "turn-1",
+      body,
+      presentationKind,
+      occurredAtUnixMs: 1
+    });
+    const conversation = {
+      ...baseConversation,
+      rows: [
+        {
+          kind: "message" as const,
+          id: "user-row",
+          turnId: "turn-1",
+          speaker: "user" as const,
+          messages: [message("user-message", "Please inspect the files")],
+          thinking: [],
+          occurredAtUnixMs: 1
+        },
+        {
+          kind: "tool-group" as const,
+          id: "tool-group-1",
+          turnId: "turn-1",
+          grouped: true,
+          calls: [],
+          entries: [],
+          occurredAtUnixMs: 2
+        },
+        {
+          kind: "message" as const,
+          id: "assistant-progress-1",
+          turnId: "turn-1",
+          speaker: "assistant" as const,
+          messages: [
+            message(
+              "assistant-progress-message-1",
+              "Reading files",
+              "specific-progress"
+            )
+          ],
+          thinking: [],
+          occurredAtUnixMs: 3
+        },
+        {
+          kind: "tool-group" as const,
+          id: "tool-group-2",
+          turnId: "turn-1",
+          grouped: true,
+          calls: [],
+          entries: [],
+          occurredAtUnixMs: 4
+        },
+        {
+          kind: "message" as const,
+          id: "assistant-progress-2",
+          turnId: "turn-1",
+          speaker: "assistant" as const,
+          messages: [
+            message(
+              "assistant-progress-message-2",
+              "Checking tests",
+              "specific-progress"
+            )
+          ],
+          thinking: [],
+          occurredAtUnixMs: 5
+        },
+        {
+          kind: "message" as const,
+          id: "assistant-final",
+          turnId: "turn-1",
+          speaker: "assistant" as const,
+          messages: [message("assistant-final-message", "Done")],
+          thinking: [],
+          occurredAtUnixMs: 6
+        }
+      ]
+    };
+    const participantPresentation = {
+      enabled: true,
+      status: "ready",
+      user: { name: "Alice", avatarUrl: "user.png" },
+      agent: { name: "Codex", avatarUrl: "agent.png" }
+    } as const;
+    const labels = {
+      thinkingLabel: "Thought process",
+      toolCallsLabel: (count: number) => `Tool calls (${count})`,
+      processing: "Planning next moves",
+      turnSummary: "Changed files"
+    };
+
+    const { container, rerender } = render(
+      <AgentTranscriptView
+        conversation={conversation}
+        participantPresentation={participantPresentation}
+        labels={labels}
+      />
+    );
+
+    expect(
+      container.querySelectorAll(
+        '[data-agent-conversation-participant-header="user"]'
+      )
+    ).toHaveLength(1);
+    expect(
+      container.querySelectorAll(
+        '[data-agent-conversation-participant-header="assistant"]'
+      )
+    ).toHaveLength(1);
+    expect(
+      container
+        .querySelector(
+          '[data-agent-conversation-participant-header="assistant"]'
+        )
+        ?.closest("[data-agent-transcript-row]")
+    ).toHaveAttribute("data-agent-transcript-row", "assistant-progress-1");
+    expect(screen.getByText("Reading files")).toBeInTheDocument();
+    expect(screen.getByText("Checking tests")).toBeInTheDocument();
+    expect(screen.getByText("Done")).toBeInTheDocument();
+
+    rerender(
+      <AgentTranscriptView
+        conversation={{
+          ...conversation,
+          rows: conversation.rows.map((row) =>
+            row.kind === "message" && row.id === "assistant-final"
+              ? {
+                  ...row,
+                  messages: row.messages.map((finalMessage) => ({
+                    ...finalMessage,
+                    isTurnFinalText: true as const
+                  }))
+                }
+              : row
+          ),
+          sourceDetail: {
+            ...conversation.sourceDetail,
+            session: normalizeAgentActivitySession({
+              ...conversation.sourceDetail.session,
+              activeTurnId: null
+            }),
+            sessionTurns: [
+              canonicalTurn({
+                phase: "settled",
+                outcome: "completed",
+                settledAtUnixMs: 12_000
+              })
+            ]
+          }
+        }}
+        participantPresentation={participantPresentation}
+        labels={labels}
+      />
+    );
+
+    expect(
+      container.querySelectorAll(
+        '[data-agent-conversation-participant-header="assistant"]'
+      )
+    ).toHaveLength(1);
+    expect(
+      container
+        .querySelector(
+          '[data-agent-conversation-participant-header="assistant"]'
+        )
+        ?.closest("[data-agent-transcript-row]")
+    ).toHaveAttribute(
+      "data-agent-transcript-row",
+      "assistant-final:turn-final"
+    );
+  });
+
   it("rerenders when canonical turn timing changes", () => {
     const labels = {
       thinkingLabel: "Thought process",

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
@@ -18,7 +18,10 @@ import type { AgentConversationParticipantPresentation } from "../contracts/agen
 import { AgentTranscriptItemView } from "./AgentTranscriptItemView";
 import { useAgentTurnDisclosureStore } from "./AgentTurnDisclosureContext";
 import { AgentTurnWorkSection } from "./AgentTurnWorkSection";
-import { buildAgentTurnWorkSectionModel } from "./agentTurnWorkSectionModel";
+import {
+  buildAgentTurnWorkSectionModel,
+  findParticipantHeaderRenderKeys
+} from "./agentTurnWorkSectionModel";
 import { assessAgentTranscriptComplexity } from "./agentTranscriptComplexity";
 import { useTurnDisclosureMotion } from "./useTurnDisclosureMotion";
 import {
@@ -312,6 +315,13 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
       ] as const;
     })
   );
+  const participantHeaderRenderKeys = participantHeadersEnabled
+    ? findParticipantHeaderRenderKeys(
+        turnGroups,
+        rowKeys,
+        turnWorkSectionModelByKey
+      )
+    : null;
   const basePath = conversation.sourceDetail.cwd;
   const workspaceRoot = conversation.workspaceRoot;
   const provider = conversation.activity.agentProvider;
@@ -440,6 +450,9 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
           workspaceAppIcons={workspaceAppIcons}
           showRawTimelineJson={showRawTimelineJson}
           participantPresentation={participantPresentation}
+          showParticipantHeader={
+            participantHeaderRenderKeys?.has(rowKey) ?? false
+          }
           toolGroupExpanded={
             row.kind === "tool-group"
               ? expandedToolRows[rowKey] === true

--- a/packages/agent/gui/shared/agentConversation/components/agentTurnWorkSectionModel.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTurnWorkSectionModel.ts
@@ -31,6 +31,55 @@ export interface AgentTurnWorkSectionModel {
   collapseEligible: boolean;
 }
 
+/**
+ * Selects at most one participant header per speaker in each presentation
+ * turn. Completed collapsed turns prefer a visible message so the Agent header
+ * does not disappear into the hidden work section.
+ */
+export function findParticipantHeaderRenderKeys(
+  groups: readonly AgentTranscriptTurnGroup[],
+  rowKeys: readonly string[],
+  modelByGroupKey: ReadonlyMap<string, AgentTurnWorkSectionModel | null>
+): ReadonlySet<string> {
+  const headerKeys = new Set<string>();
+
+  for (const group of groups) {
+    const model = modelByGroupKey.get(group.key);
+    const renderedRows: readonly AgentTurnWorkSectionRow[] = model
+      ? model.collapseEligible
+        ? [
+            ...model.leadingRows,
+            ...model.sections.flatMap((section) =>
+              section.kind === "visible" ? section.rows : []
+            ),
+            ...model.sections.flatMap((section) =>
+              section.kind === "work" ? section.rows : []
+            )
+          ]
+        : [
+            ...model.leadingRows,
+            ...model.sections.flatMap((section) => section.rows)
+          ]
+      : group.rows;
+    const seenSpeakers = new Set<AgentMessageRowVM["speaker"]>();
+
+    for (const entry of renderedRows) {
+      const row = entry.row;
+      if (
+        row.kind !== "message" ||
+        row.messages.length === 0 ||
+        seenSpeakers.has(row.speaker)
+      ) {
+        continue;
+      }
+      seenSpeakers.add(row.speaker);
+      headerKeys.add(entry.renderKey ?? rowKeys[entry.rowIndex] ?? row.id);
+    }
+  }
+
+  return headerKeys;
+}
+
 interface AgentTurnWorkSectionOptions {
   collapseIntermediateAssistantReplies?: boolean;
 }


### PR DESCRIPTION
## Summary

- project participant headers from transcript turn groups instead of individual message rows
- render at most one header per speaker and turn across thinking and tool-progress rows
- keep the Agent header on visible final content when completed turn work is collapsed
- document the public participant-presentation behavior and add a patch changeset

## Root cause

`participantPresentation` reached every `AgentMessageBlock`, and each block decided independently whether to render a header. A canonical turn can be split into multiple assistant message rows for thinking, tool progress, and final output, so the same Agent avatar was repeated for each row even though the transcript already had turn grouping.

## Validation

- `pnpm check:changed -- --failed-only` (11 lanes passed)
- pre-push `pnpm check:changed -- --push-ready` (12 lanes passed)
- Agent GUI full test suite during iteration: 275 files / 2331 tests passed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->