### PR TITLE
feat(agent): add bounded Codex tool timing diagnostics

### DIFF
--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -311,6 +311,7 @@ type codexAppServerActiveTurn struct {
 	session        Session
 	ctx            context.Context
 	normalizer     *acpTurnNormalizer
+	diagnostics    *codexAppServerTurnDiagnostics
 	emit           func([]activityshared.Event)
 	emitCommands   CommandSnapshotSink
 	kind           codexAppServerTurnKind

--- a/packages/agent/daemon/runtime/codex_appserver_goal.go
+++ b/packages/agent/daemon/runtime/codex_appserver_goal.go
@@ -572,6 +572,7 @@ func (a *CodexAppServerAdapter) adoptServerInitiatedTurn(session Session, provid
 		session:     session,
 		ctx:         context.Background(),
 		normalizer:  normalizer,
+		diagnostics: newCodexAppServerTurnDiagnostics(nil, turnID),
 		emit:        emitEvents,
 		kind:        codexAppServerTurnKindGoalAdopted,
 		phase:       codexAppServerTurnPhaseRunning,
@@ -584,6 +585,8 @@ func (a *CodexAppServerAdapter) adoptServerInitiatedTurn(session Session, provid
 		// A registered turn won the race; leave tracking to it.
 		return false
 	}
+	trace := newCodexAppServerTurnTrace(session, turnID, nil)
+	appTurn.diagnostics.Start(trace)
 	slog.Info("agent session app-server goal turn adopted",
 		"event", "agent_session.app_server.goal.turn_adopted",
 		"agent_session_id", session.AgentSessionID,

--- a/packages/agent/daemon/runtime/codex_appserver_goal.go
+++ b/packages/agent/daemon/runtime/codex_appserver_goal.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync"
 	"time"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
@@ -529,87 +528,6 @@ func (a *CodexAppServerAdapter) sessionGoal(agentSessionID string) map[string]an
 		return nil
 	}
 	return clonePayload(appSession.goal)
-}
-
-// adoptServerInitiatedTurn registers a turn that codex started on its own
-// (goal auto-continuation) as a first-class tracked turn: it gets a fresh
-// turn id, a normalizer, and a session-sink emitter, so its output persists
-// and renders exactly like an Exec-driven turn. Settlement is owned by the
-// notification path (settleEmits); no goroutine blocks on it. Runs on the
-// client read loop, so registration completes before the turn's first item
-// notification is processed.
-func (a *CodexAppServerAdapter) adoptServerInitiatedTurn(session Session, providerTurnID string, identity goalOperationIdentity) bool {
-	appSession := a.getSession(session.AgentSessionID)
-	if appSession == nil || appSession.client == nil {
-		return false
-	}
-	turnID := newID()
-	normalizer := newACPTurnNormalizer()
-	var eventsMu sync.Mutex
-	turnClosed := false
-	emitEvents := func(next []activityshared.Event) {
-		if len(next) == 0 {
-			return
-		}
-		eventsMu.Lock()
-		defer eventsMu.Unlock()
-		if turnClosed {
-			return
-		}
-		a.emitSessionEvents(session.AgentSessionID, a.stampTurnLifecycleSnapshots(session.AgentSessionID, next))
-	}
-	emitTerminal := func(next []activityshared.Event) {
-		eventsMu.Lock()
-		defer eventsMu.Unlock()
-		if turnClosed {
-			return
-		}
-		turnClosed = true
-		a.emitSessionEvents(session.AgentSessionID, a.stampTurnLifecycleSnapshots(session.AgentSessionID, next))
-	}
-	appTurn := &codexAppServerActiveTurn{
-		turnID:      turnID,
-		session:     session,
-		ctx:         context.Background(),
-		normalizer:  normalizer,
-		diagnostics: newCodexAppServerTurnDiagnostics(nil, turnID),
-		emit:        emitEvents,
-		kind:        codexAppServerTurnKindGoalAdopted,
-		phase:       codexAppServerTurnPhaseRunning,
-		terminal:    make(chan codexAppServerTurnTerminal, 1),
-		terminated:  make(chan struct{}),
-		settleEmits: true,
-	}
-	appTurn.emitTerminal = emitTerminal
-	if !a.beginGoalTurnHandoff(session.AgentSessionID, providerTurnID, appTurn, identity) {
-		// A registered turn won the race; leave tracking to it.
-		return false
-	}
-	trace := newCodexAppServerTurnTrace(session, turnID, nil)
-	appTurn.diagnostics.Start(trace)
-	slog.Info("agent session app-server goal turn adopted",
-		"event", "agent_session.app_server.goal.turn_adopted",
-		"agent_session_id", session.AgentSessionID,
-		"provider_turn_id", providerTurnID,
-		"turn_id", turnID,
-		"provenance_mode", appTurn.goalProvenance,
-	)
-	emitEvents([]activityshared.Event{
-		newTurnActivityEvent(session, EventTurnStarted, turnID, SessionStatusWorking, "", "", map[string]any{
-			"goalContinuation":      true,
-			"turnOrigin":            "goal_continuation",
-			"sourceGoalOperationId": identity.operationID,
-			"sourceGoalRevision":    identity.revision,
-			"sourceGoalRepairEpoch": identity.repairEpoch,
-			"goalProvenanceMode":    appTurn.goalProvenance,
-		}),
-	})
-	if a.goalHandoffCommittedHook != nil {
-		a.goalHandoffCommittedHook()
-	}
-	a.drainGoalTurnHandoff(session.AgentSessionID, providerTurnID, appTurn)
-	go a.watchTurnExternalTermination(appSession, appTurn)
-	return true
 }
 
 // beginGoalTurnHandoff atomically commits pending ownership, active

--- a/packages/agent/daemon/runtime/codex_appserver_goal_turn.go
+++ b/packages/agent/daemon/runtime/codex_appserver_goal_turn.go
@@ -1,0 +1,90 @@
+package agentruntime
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+// adoptServerInitiatedTurn registers a turn that codex started on its own
+// (goal auto-continuation) as a first-class tracked turn: it gets a fresh
+// turn id, a normalizer, and a session-sink emitter, so its output persists
+// and renders exactly like an Exec-driven turn. Settlement is owned by the
+// notification path (settleEmits); no goroutine blocks on it. Runs on the
+// client read loop, so registration completes before the turn's first item
+// notification is processed.
+func (a *CodexAppServerAdapter) adoptServerInitiatedTurn(session Session, providerTurnID string, identity goalOperationIdentity) bool {
+	appSession := a.getSession(session.AgentSessionID)
+	if appSession == nil || appSession.client == nil {
+		return false
+	}
+	turnID := newID()
+	normalizer := newACPTurnNormalizer()
+	var eventsMu sync.Mutex
+	turnClosed := false
+	emitEvents := func(next []activityshared.Event) {
+		if len(next) == 0 {
+			return
+		}
+		eventsMu.Lock()
+		defer eventsMu.Unlock()
+		if turnClosed {
+			return
+		}
+		a.emitSessionEvents(session.AgentSessionID, a.stampTurnLifecycleSnapshots(session.AgentSessionID, next))
+	}
+	emitTerminal := func(next []activityshared.Event) {
+		eventsMu.Lock()
+		defer eventsMu.Unlock()
+		if turnClosed {
+			return
+		}
+		turnClosed = true
+		a.emitSessionEvents(session.AgentSessionID, a.stampTurnLifecycleSnapshots(session.AgentSessionID, next))
+	}
+	appTurn := &codexAppServerActiveTurn{
+		turnID:      turnID,
+		session:     session,
+		ctx:         context.Background(),
+		normalizer:  normalizer,
+		diagnostics: newCodexAppServerTurnDiagnostics(nil, turnID),
+		emit:        emitEvents,
+		kind:        codexAppServerTurnKindGoalAdopted,
+		phase:       codexAppServerTurnPhaseRunning,
+		terminal:    make(chan codexAppServerTurnTerminal, 1),
+		terminated:  make(chan struct{}),
+		settleEmits: true,
+	}
+	appTurn.emitTerminal = emitTerminal
+	if !a.beginGoalTurnHandoff(session.AgentSessionID, providerTurnID, appTurn, identity) {
+		// A registered turn won the race; leave tracking to it.
+		return false
+	}
+	trace := newCodexAppServerTurnTrace(session, turnID, nil)
+	appTurn.diagnostics.Start(trace)
+	slog.Info("agent session app-server goal turn adopted",
+		"event", "agent_session.app_server.goal.turn_adopted",
+		"agent_session_id", session.AgentSessionID,
+		"provider_turn_id", providerTurnID,
+		"turn_id", turnID,
+		"provenance_mode", appTurn.goalProvenance,
+	)
+	emitEvents([]activityshared.Event{
+		newTurnActivityEvent(session, EventTurnStarted, turnID, SessionStatusWorking, "", "", map[string]any{
+			"goalContinuation":      true,
+			"turnOrigin":            "goal_continuation",
+			"sourceGoalOperationId": identity.operationID,
+			"sourceGoalRevision":    identity.revision,
+			"sourceGoalRepairEpoch": identity.repairEpoch,
+			"goalProvenanceMode":    appTurn.goalProvenance,
+		}),
+	})
+	if a.goalHandoffCommittedHook != nil {
+		a.goalHandoffCommittedHook()
+	}
+	a.drainGoalTurnHandoff(session.AgentSessionID, providerTurnID, appTurn)
+	go a.watchTurnExternalTermination(appSession, appTurn)
+	return true
+}

--- a/packages/agent/daemon/runtime/codex_appserver_reducer.go
+++ b/packages/agent/daemon/runtime/codex_appserver_reducer.go
@@ -51,6 +51,7 @@ func (r codexAppServerReducer) reduceNotification(
 		a.bufferPendingGoalTurnNotification(session.AgentSessionID, providerTurnID, message) {
 		return codexAppServerReduction{}
 	}
+	diagnosticTurn := a.activeTurnForNormalizer(rootAgentSessionID, normalizer)
 	route := a.appServerNotificationRoute(session, turnID, message.Method, params)
 	if route.drop {
 		return codexAppServerReduction{Events: route.events}
@@ -69,6 +70,9 @@ func (r codexAppServerReducer) reduceNotification(
 		// child threads. No transcript/progress from the canceled execution is
 		// projected after the durable cancel boundary.
 		return codexAppServerReduction{}
+	}
+	if diagnosticTurn != nil {
+		diagnosticTurn.diagnostics.ObserveNotification(message.Method, params)
 	}
 	emit := func(events []activityshared.Event) codexAppServerReduction {
 		events = appServerEventsForChild(events, route.child)

--- a/packages/agent/daemon/runtime/codex_appserver_turn.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn.go
@@ -131,6 +131,8 @@ func (a *CodexAppServerAdapter) finalizeSettledTurn(agentSessionID string, appTu
 	if a == nil || appTurn == nil || appTurn.emitTerminal == nil {
 		return
 	}
+	providerTurnID := firstNonEmpty(asString(terminal.turn["id"]), appTurn.providerTurnID)
+	appTurn.diagnostics.Finish(string(terminal.phase), providerTurnID)
 	appTurn.processMu.Lock()
 	appTurn.settleFinalized.Store(true)
 	session := appTurn.session
@@ -330,6 +332,7 @@ func (a *CodexAppServerAdapter) execBlocking(
 		session:      session,
 		ctx:          ctx,
 		normalizer:   normalizer,
+		diagnostics:  newCodexAppServerTurnDiagnostics(nil, turnID),
 		emit:         emitEvents,
 		emitCommands: emitCommands,
 		kind:         codexAppServerTurnKindNormal,
@@ -357,6 +360,7 @@ func (a *CodexAppServerAdapter) execBlocking(
 
 	execMetadata := execMetadataFromContext(ctx)
 	trace := newCodexAppServerTurnTrace(session, turnID, execMetadata)
+	appTurn.diagnostics.Start(trace)
 	turnParams := appServerTurnStartParams(
 		session,
 		appSession.threadID,
@@ -379,6 +383,7 @@ func (a *CodexAppServerAdapter) execBlocking(
 	result, err := appSession.client.TurnStart(ctx, turnStartAckTimeout, turnParams)
 	if err != nil {
 		durationMS := time.Since(turnStartedAt).Milliseconds()
+		appTurn.diagnostics.Finish("failed", "")
 		trace.Log("turn.start.failed", map[string]any{
 			"duration_ms": durationMS,
 			"error":       err.Error(),
@@ -452,6 +457,15 @@ func (a *CodexAppServerAdapter) execBlocking(
 		"agent_session_id", session.AgentSessionID,
 		"turn_id", turnID,
 	)
+	if finishErr != nil {
+		outcome := "failed"
+		if errors.Is(finishErr, context.Canceled) || errors.Is(finishErr, errPermissionRequestCanceled) || a.turnForceCanceled(appTurn) {
+			outcome = "canceled"
+		}
+		appTurn.diagnostics.Finish(outcome, appTurn.providerTurnID)
+	} else {
+		appTurn.diagnostics.Finish("completed", appTurn.providerTurnID)
+	}
 	if finishErr != nil {
 		if errors.Is(finishErr, context.Canceled) || errors.Is(finishErr, errPermissionRequestCanceled) || a.turnForceCanceled(appTurn) {
 			terminalEvents := a.pendingRequestFailureEvents(session, turnID, errPermissionRequestCanceled)

--- a/packages/agent/daemon/runtime/codex_appserver_turn_diagnostics.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn_diagnostics.go
@@ -1,0 +1,288 @@
+package agentruntime
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+type codexAppServerTurnTraceSink interface {
+	Log(event string, fields map[string]any)
+}
+
+type codexAppServerToolTiming struct {
+	startedAt time.Time
+	itemType  string
+}
+
+// codexAppServerTurnDiagnostics writes bounded lifecycle records to the
+// exported app-server diagnostics trace. It intentionally excludes tool
+// arguments, commands, paths, output, queries, URLs, and error text.
+type codexAppServerTurnDiagnostics struct {
+	mu             sync.Mutex
+	trace          codexAppServerTurnTraceSink
+	now            func() time.Time
+	startedAt      time.Time
+	turnID         string
+	providerTurnID string
+	finished       bool
+	tools          map[string]codexAppServerToolTiming
+	completedTools map[string]struct{}
+	startedCount   int
+	completedCount int
+	failedCount    int
+	maxDuration    time.Duration
+	maxItemType    string
+}
+
+func newCodexAppServerTurnDiagnostics(
+	trace codexAppServerTurnTraceSink,
+	turnID string,
+) *codexAppServerTurnDiagnostics {
+	now := time.Now
+	diagnostics := &codexAppServerTurnDiagnostics{
+		now:            now,
+		turnID:         strings.TrimSpace(turnID),
+		tools:          make(map[string]codexAppServerToolTiming),
+		completedTools: make(map[string]struct{}),
+	}
+	diagnostics.Start(trace)
+	return diagnostics
+}
+
+func (d *codexAppServerTurnDiagnostics) Start(trace codexAppServerTurnTraceSink) {
+	if d == nil || trace == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.trace != nil {
+		return
+	}
+	d.trace = trace
+	d.startedAt = d.now()
+}
+
+func (d *codexAppServerTurnDiagnostics) ObserveNotification(method string, params map[string]any) {
+	if d == nil {
+		return
+	}
+	switch method {
+	case appServerNotifyItemStarted:
+		d.toolStarted(payloadObject(params["item"]), asString(params["threadId"]), asString(params["turnId"]))
+	case appServerNotifyItemCompleted:
+		d.toolCompleted(payloadObject(params["item"]), asString(params["threadId"]), asString(params["turnId"]))
+	}
+}
+
+func (d *codexAppServerTurnDiagnostics) toolStarted(item map[string]any, providerThreadID, providerTurnID string) {
+	itemID, itemType, safeFields, ok := codexAppServerToolDiagnosticFields(item)
+	if !ok {
+		return
+	}
+	toolKey := codexAppServerToolDiagnosticKey(providerThreadID, itemID)
+	now := d.now()
+	d.mu.Lock()
+	if d.trace == nil || d.finished {
+		d.mu.Unlock()
+		return
+	}
+	if _, exists := d.tools[toolKey]; exists {
+		d.mu.Unlock()
+		return
+	}
+	if _, completed := d.completedTools[toolKey]; completed {
+		d.mu.Unlock()
+		return
+	}
+	d.tools[toolKey] = codexAppServerToolTiming{startedAt: now, itemType: itemType}
+	d.startedCount++
+	fields := d.toolFieldsLocked(itemID, itemType, providerThreadID, providerTurnID, safeFields)
+	trace := d.trace
+	d.mu.Unlock()
+	trace.Log("turn.tool.started", fields)
+}
+
+func (d *codexAppServerTurnDiagnostics) toolCompleted(item map[string]any, providerThreadID, providerTurnID string) {
+	itemID, itemType, safeFields, ok := codexAppServerToolDiagnosticFields(item)
+	if !ok {
+		return
+	}
+	toolKey := codexAppServerToolDiagnosticKey(providerThreadID, itemID)
+	now := d.now()
+	d.mu.Lock()
+	if d.trace == nil || d.finished {
+		d.mu.Unlock()
+		return
+	}
+	if _, completed := d.completedTools[toolKey]; completed {
+		d.mu.Unlock()
+		return
+	}
+	d.completedTools[toolKey] = struct{}{}
+	d.completedCount++
+	fields := d.toolFieldsLocked(itemID, itemType, providerThreadID, providerTurnID, safeFields)
+	if timing, started := d.tools[toolKey]; started {
+		duration := now.Sub(timing.startedAt)
+		if duration < 0 {
+			duration = 0
+		}
+		fields["duration_ms"] = duration.Milliseconds()
+		fields["start_observed"] = true
+		delete(d.tools, toolKey)
+		if duration > d.maxDuration {
+			d.maxDuration = duration
+			d.maxItemType = timing.itemType
+		}
+	} else {
+		fields["start_observed"] = false
+	}
+	outcome, failed := codexAppServerToolDiagnosticOutcome(item)
+	fields["outcome"] = outcome
+	if failed {
+		d.failedCount++
+	}
+	trace := d.trace
+	d.mu.Unlock()
+	trace.Log("turn.tool.completed", fields)
+}
+
+func (d *codexAppServerTurnDiagnostics) Finish(outcome, providerTurnID string) {
+	if d == nil {
+		return
+	}
+	now := d.now()
+	d.mu.Lock()
+	if d.trace == nil || d.finished {
+		d.mu.Unlock()
+		return
+	}
+	d.finished = true
+	if providerTurnID = strings.TrimSpace(providerTurnID); providerTurnID != "" {
+		d.providerTurnID = providerTurnID
+	}
+	fields := d.baseFieldsLocked()
+	duration := now.Sub(d.startedAt)
+	if duration < 0 {
+		duration = 0
+	}
+	fields["duration_ms"] = duration.Milliseconds()
+	fields["outcome"] = firstNonEmpty(strings.TrimSpace(outcome), "unknown")
+	fields["tool_started_count"] = d.startedCount
+	fields["tool_completed_count"] = d.completedCount
+	fields["tool_failed_count"] = d.failedCount
+	fields["open_tool_count"] = len(d.tools)
+	if d.maxDuration > 0 {
+		fields["max_tool_duration_ms"] = d.maxDuration.Milliseconds()
+		fields["max_tool_item_type"] = d.maxItemType
+	}
+	var longestOpen time.Duration
+	var longestOpenType string
+	for _, timing := range d.tools {
+		openFor := now.Sub(timing.startedAt)
+		if openFor > longestOpen {
+			longestOpen = openFor
+			longestOpenType = timing.itemType
+		}
+	}
+	if longestOpen > 0 {
+		fields["longest_open_tool_ms"] = longestOpen.Milliseconds()
+		fields["longest_open_item_type"] = longestOpenType
+	}
+	trace := d.trace
+	d.mu.Unlock()
+	trace.Log("turn.completed", fields)
+}
+
+func (d *codexAppServerTurnDiagnostics) baseFieldsLocked() map[string]any {
+	return map[string]any{
+		"turn_id":          d.turnID,
+		"provider_turn_id": d.providerTurnID,
+	}
+}
+
+func (d *codexAppServerTurnDiagnostics) toolFieldsLocked(
+	itemID string,
+	itemType string,
+	providerThreadID string,
+	providerTurnID string,
+	safeFields map[string]any,
+) map[string]any {
+	fields := d.baseFieldsLocked()
+	fields["item_id"] = itemID
+	fields["item_type"] = itemType
+	if providerThreadID = strings.TrimSpace(providerThreadID); providerThreadID != "" {
+		fields["item_provider_thread_id"] = providerThreadID
+	}
+	if providerTurnID = strings.TrimSpace(providerTurnID); providerTurnID != "" {
+		fields["item_provider_turn_id"] = providerTurnID
+	}
+	for key, value := range safeFields {
+		fields[key] = value
+	}
+	return fields
+}
+
+func codexAppServerToolDiagnosticKey(providerThreadID, itemID string) string {
+	return strings.TrimSpace(providerThreadID) + "\x00" + strings.TrimSpace(itemID)
+}
+
+func codexAppServerToolDiagnosticFields(item map[string]any) (string, string, map[string]any, bool) {
+	itemID := strings.TrimSpace(asString(item["id"]))
+	itemType := strings.TrimSpace(asString(item["type"]))
+	if itemID == "" {
+		return "", "", nil, false
+	}
+	fields := map[string]any{}
+	switch itemType {
+	case "commandExecution":
+		if output := asStringRaw(item["aggregatedOutput"]); output != "" {
+			fields["output_bytes"] = len(output)
+		}
+		if exitCode, ok := acpIntFromValue(item["exitCode"]); ok {
+			fields["exit_code"] = exitCode
+		}
+	case "fileChange":
+		if changes, ok := item["changes"].([]any); ok {
+			fields["change_count"] = len(changes)
+		}
+	case "mcpToolCall":
+		fields["tool_server"] = asString(item["server"])
+		fields["tool_name"] = asString(item["tool"])
+		fields["has_error"] = strings.TrimSpace(asStringRaw(item["error"])) != ""
+	case "webSearch":
+		action := payloadObject(item["action"])
+		fields["action_type"] = firstNonEmpty(asString(action["type"]), "search")
+		fields["query_count"] = len(appServerSearchQueries(action["queries"]))
+		fields["has_url"] = strings.TrimSpace(asString(action["url"])) != ""
+	case "dynamicToolCall", "collabAgentToolCall":
+		fields["tool_name"] = asString(item["tool"])
+	case "imageGeneration":
+		fields["has_saved_path"] = strings.TrimSpace(asString(item["savedPath"])) != ""
+	case "imageView":
+	default:
+		return "", "", nil, false
+	}
+	return itemID, itemType, fields, true
+}
+
+func codexAppServerToolDiagnosticOutcome(item map[string]any) (string, bool) {
+	status := firstNonEmpty(strings.TrimSpace(asString(item["status"])), "completed")
+	failed := status == "failed" || status == "declined" || status == "canceled" || status == "cancelled"
+	switch asString(item["type"]) {
+	case "commandExecution":
+		if exitCode, ok := acpIntFromValue(item["exitCode"]); ok && exitCode != 0 {
+			failed = true
+		}
+	case "mcpToolCall":
+		failed = failed || strings.TrimSpace(asStringRaw(item["error"])) != ""
+	case "dynamicToolCall":
+		if success, ok := item["success"].(bool); ok && !success {
+			failed = true
+		}
+	}
+	if failed {
+		return "failed", true
+	}
+	return status, false
+}

--- a/packages/agent/daemon/runtime/codex_appserver_turn_diagnostics_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn_diagnostics_test.go
@@ -1,0 +1,248 @@
+package agentruntime
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+type codexAppServerDiagnosticRecord struct {
+	event  string
+	fields map[string]any
+}
+
+type codexAppServerDiagnosticSink struct {
+	records []codexAppServerDiagnosticRecord
+}
+
+func (s *codexAppServerDiagnosticSink) Log(event string, fields map[string]any) {
+	s.records = append(s.records, codexAppServerDiagnosticRecord{event: event, fields: fields})
+}
+
+func TestCodexAppServerTurnDiagnosticsRecordsBoundedToolLifecycle(t *testing.T) {
+	startedAt := time.Date(2026, 7, 24, 7, 0, 0, 0, time.UTC)
+	now := startedAt
+	sink := &codexAppServerDiagnosticSink{}
+	diagnostics := newCodexAppServerTurnDiagnostics(sink, "turn-1")
+	diagnostics.startedAt = startedAt
+	diagnostics.now = func() time.Time { return now }
+
+	now = startedAt.Add(time.Second)
+	command := map[string]any{
+		"id":      "command-1",
+		"type":    "commandExecution",
+		"command": "curl https://secret.example/?token=do-not-log",
+		"cwd":     "/secret/workspace",
+		"status":  "inProgress",
+	}
+	diagnostics.ObserveNotification(appServerNotifyItemStarted, map[string]any{"item": command})
+	diagnostics.ObserveNotification(appServerNotifyItemStarted, map[string]any{"item": command})
+
+	now = startedAt.Add(3250 * time.Millisecond)
+	command["status"] = "completed"
+	command["exitCode"] = 7
+	command["aggregatedOutput"] = "secret command output"
+	diagnostics.ObserveNotification(appServerNotifyItemCompleted, map[string]any{"item": command})
+	diagnostics.ObserveNotification(appServerNotifyItemCompleted, map[string]any{"item": command})
+
+	now = startedAt.Add(4 * time.Second)
+	diagnostics.ObserveNotification(appServerNotifyItemStarted, map[string]any{
+		"item": map[string]any{
+			"id":        "mcp-1",
+			"type":      "mcpToolCall",
+			"server":    "documents",
+			"tool":      "search",
+			"arguments": map[string]any{"query": "secret query"},
+		},
+	})
+	diagnostics.ObserveNotification(appServerNotifyAgentMessageDelta, map[string]any{
+		"delta": "secret assistant content",
+	})
+
+	now = startedAt.Add(10 * time.Second)
+	diagnostics.Finish("completed", "provider-turn-1")
+	diagnostics.Finish("failed", "provider-turn-1")
+
+	if got, want := len(sink.records), 4; got != want {
+		t.Fatalf("record count = %d, want %d: %#v", got, want, sink.records)
+	}
+	wantEvents := []string{
+		"turn.tool.started",
+		"turn.tool.completed",
+		"turn.tool.started",
+		"turn.completed",
+	}
+	for index, want := range wantEvents {
+		if got := sink.records[index].event; got != want {
+			t.Fatalf("record[%d].event = %q, want %q", index, got, want)
+		}
+	}
+
+	completed := sink.records[1].fields
+	if got := completed["duration_ms"]; got != int64(2250) {
+		t.Fatalf("command duration_ms = %#v, want 2250", got)
+	}
+	if got := completed["outcome"]; got != "failed" {
+		t.Fatalf("command outcome = %#v, want failed", got)
+	}
+	if got := completed["exit_code"]; got != 7 {
+		t.Fatalf("command exit_code = %#v, want 7", got)
+	}
+
+	summary := sink.records[3].fields
+	for key, want := range map[string]any{
+		"duration_ms":            int64(10000),
+		"tool_started_count":     2,
+		"tool_completed_count":   1,
+		"tool_failed_count":      1,
+		"open_tool_count":        1,
+		"max_tool_duration_ms":   int64(2250),
+		"max_tool_item_type":     "commandExecution",
+		"longest_open_tool_ms":   int64(6000),
+		"longest_open_item_type": "mcpToolCall",
+		"provider_turn_id":       "provider-turn-1",
+		"turn_id":                "turn-1",
+		"outcome":                "completed",
+	} {
+		if got := summary[key]; got != want {
+			t.Fatalf("summary[%q] = %#v, want %#v", key, got, want)
+		}
+	}
+
+	serializedRecords := make([]map[string]any, 0, len(sink.records))
+	for _, record := range sink.records {
+		serializedRecords = append(serializedRecords, map[string]any{
+			"event":  record.event,
+			"fields": record.fields,
+		})
+	}
+	encoded, err := json.Marshal(serializedRecords)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, secret := range []string{
+		"do-not-log",
+		"/secret/workspace",
+		"secret command output",
+		"secret query",
+		"secret assistant content",
+	} {
+		if strings.Contains(string(encoded), secret) {
+			t.Fatalf("diagnostic records leaked %q: %s", secret, encoded)
+		}
+	}
+}
+
+func TestCodexAppServerTurnDiagnosticsCompletesToolWithoutStart(t *testing.T) {
+	sink := &codexAppServerDiagnosticSink{}
+	diagnostics := newCodexAppServerTurnDiagnostics(sink, "turn-2")
+	diagnostics.ObserveNotification(appServerNotifyItemCompleted, map[string]any{
+		"item": map[string]any{
+			"id":      "tool-1",
+			"type":    "dynamicToolCall",
+			"tool":    "render",
+			"status":  "completed",
+			"success": true,
+		},
+	})
+
+	if got, want := len(sink.records), 1; got != want {
+		t.Fatalf("record count = %d, want %d", got, want)
+	}
+	fields := sink.records[0].fields
+	if got := fields["start_observed"]; got != false {
+		t.Fatalf("start_observed = %#v, want false", got)
+	}
+	if _, ok := fields["duration_ms"]; ok {
+		t.Fatalf("duration_ms should be absent when item/started was not observed: %#v", fields)
+	}
+}
+
+func TestCodexAppServerReducerRecordsOnlyAcceptedToolNotifications(t *testing.T) {
+	adapter := NewCodexAppServerAdapter(nil)
+	session := Session{
+		AgentSessionID:    "agent-1",
+		Provider:          ProviderCodex,
+		ProviderSessionID: "thread-1",
+	}
+	normalizer := newACPTurnNormalizer()
+	sink := &codexAppServerDiagnosticSink{}
+	activeTurn := &codexAppServerActiveTurn{
+		turnID:      "turn-1",
+		normalizer:  normalizer,
+		diagnostics: newCodexAppServerTurnDiagnostics(sink, "turn-1"),
+		phase:       codexAppServerTurnPhaseRunning,
+	}
+	adapter.storeSession(session.AgentSessionID, &codexAppServerSession{
+		threadID:   session.ProviderSessionID,
+		activeTurn: activeTurn,
+	})
+	reducer := newCodexAppServerReducer(adapter)
+
+	reducer.ReduceNotification(nil, session, activeTurn.turnID, acpMessage{
+		Method: appServerNotifyItemStarted,
+		Params: mustJSONRawMessage(t, map[string]any{
+			"threadId": session.ProviderSessionID,
+			"turnId":   "provider-turn-1",
+			"item": map[string]any{
+				"id":      "command-1",
+				"type":    "commandExecution",
+				"command": "do-not-log this command",
+			},
+		}),
+	}, normalizer, nil)
+	reducer.ReduceNotification(nil, session, activeTurn.turnID, acpMessage{
+		Method: appServerNotifyItemStarted,
+		Params: mustJSONRawMessage(t, map[string]any{
+			"threadId": "foreign-thread",
+			"turnId":   "foreign-turn",
+			"item": map[string]any{
+				"id":      "foreign-command",
+				"type":    "commandExecution",
+				"command": "foreign command",
+			},
+		}),
+	}, normalizer, nil)
+
+	if got, want := len(sink.records), 1; got != want {
+		t.Fatalf("record count = %d, want %d: %#v", got, want, sink.records)
+	}
+	if got := sink.records[0].fields["item_id"]; got != "command-1" {
+		t.Fatalf("item_id = %#v, want command-1", got)
+	}
+}
+
+func TestCodexAppServerToolDiagnosticFieldsRecognizeOnlyTools(t *testing.T) {
+	toolTypes := []string{
+		"commandExecution",
+		"fileChange",
+		"mcpToolCall",
+		"webSearch",
+		"dynamicToolCall",
+		"collabAgentToolCall",
+		"imageGeneration",
+		"imageView",
+	}
+	for _, itemType := range toolTypes {
+		t.Run(itemType, func(t *testing.T) {
+			_, gotType, _, ok := codexAppServerToolDiagnosticFields(map[string]any{
+				"id":   "item-1",
+				"type": itemType,
+			})
+			if !ok || gotType != itemType {
+				t.Fatalf("recognized = %v, type = %q", ok, gotType)
+			}
+		})
+	}
+	for _, itemType := range []string{"agentMessage", "reasoning", "plan", "userMessage"} {
+		t.Run(itemType, func(t *testing.T) {
+			if _, _, _, ok := codexAppServerToolDiagnosticFields(map[string]any{
+				"id":   "item-1",
+				"type": itemType,
+			}); ok {
+				t.Fatalf("non-tool item %q was recognized as a tool", itemType)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- record bounded Codex tool start/completion timing in the existing exported app-server trace
- add Turn terminal summaries with tool counts, longest completed tool, and longest still-open tool
- deduplicate lifecycle notifications and exclude commands, arguments, paths, queries, output, and error text

## Tests
- `go test ./packages/agent/daemon/runtime -run 'TestCodexAppServerTurnDiagnostics|TestCodexAppServerReducerRecordsOnlyAcceptedToolNotifications|TestCodexAppServerToolDiagnosticFields|TestControllerGoalControl' -count=30`
- `pnpm check:full` (passed 26 tasks)
- pre-push `pnpm check:changed -- --push-ready` (passed 8 lanes)

## Notes
- This is provider diagnostics only; it does not change Agent Host Turn or Goal lifecycle semantics.
- No documentation impact: the existing exported JSONL trace remains the diagnostics surface.
