### PR TITLE
feat(agent-runtime): wait for session availability

### DIFF
--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1596,6 +1596,42 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [service_session.go](../../../services/tuttid/service/agent/service_session.go)
   [agent-extensions.md](../../architecture/agent-extensions.md)
 
+### An authorized observer loops unavailable while a session is resuming
+
+- Symptom:
+  A remote or local observer has a durable Agent session ID and passes
+  authorization, but immediately receives `session not found` or
+  `Unavailable`. Its caller reconnects rapidly even though Agent Host restores
+  the provider session shortly afterward.
+- Quick checks:
+  Separate durable identity from the Controller registry. Confirm the session
+  exists in canonical persistence while `Controller.Session` is temporarily
+  absent, then correlate the observer attempt with the later Host
+  `EnsureRuntimeSession`, runtime `Start`, or runtime `Resume`. If observation
+  itself launches the provider, lifecycle authority is inverted.
+- Root cause:
+  A durable session record proves that work may be resumed; it does not prove a
+  live provider or runtime registry entry exists after daemon restart. A
+  one-shot `Controller.Subscribe` therefore turns a normal restore race into a
+  transport failure, and caller reconnect loops cannot know when the local
+  lifecycle owner has finished restoring ACP.
+- Fix:
+  Use `Controller.SubscribeWhenAvailable` when the consumer already has an
+  authorized durable session identity and must observe the next live runtime.
+  It waits on a per-session Controller notification and atomically subscribes
+  with the initial state snapshot once `Start` or `Resume` registers the
+  session. Keep provider launch and resume in Agent Host; the observation
+  method must never call those lifecycle operations.
+- Validation:
+  Start the observation against a missing runtime, assert that it neither
+  returns nor creates a session, then perform a real Controller `Resume` and
+  verify the observer receives the initial state snapshot. Also cancel a
+  missing-session wait and verify no waiter or runtime session remains, and
+  cover concurrent observers under the race detector.
+- References:
+  [controller_stream.go](../../../packages/agent/daemon/runtime/controller_stream.go)
+  [controller_stream_wait_test.go](../../../packages/agent/daemon/runtime/controller_stream_wait_test.go)
+
 ### Agent session restore breaks when durable snapshot ownership is split
 
 - Symptom:

--- a/packages/agent/daemon/README.md
+++ b/packages/agent/daemon/README.md
@@ -27,6 +27,13 @@ if err != nil {
 controller := runtime.Controller()
 ```
 
+`Controller.SubscribeWhenAvailable` is the observation-only stream attachment
+for consumers that already have durable session identity but may race runtime
+resume after a daemon restart. It waits for `Start`, `Resume`, or
+`Host.EnsureRuntimeSession` to repopulate the runtime registry and then
+subscribes with the current state snapshot. It never starts or resumes a
+provider itself; lifecycle authority stays with Agent Host.
+
 Hosts that need to prepare a provider launch immediately before process spawn
 can set `ProviderLaunchPreparer`. The hook receives the provider, session,
 command, environment, cwd, and direct-start mode; it returns the command,

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -27,6 +27,7 @@ type Controller struct {
 	startMu                     sync.Mutex
 	mu                          sync.Mutex
 	sessions                    map[string]Session
+	sessionAvailabilityWaiters  map[string]*sessionAvailabilityWaiter
 	adapters                    map[string]Adapter
 	adapterResolver             AdapterResolver
 	turns                       map[string]activeTurn
@@ -45,6 +46,11 @@ type Controller struct {
 type sessionLifecycleLock struct {
 	gate chan struct{}
 	refs int
+}
+
+type sessionAvailabilityWaiter struct {
+	changed chan struct{}
+	refs    int
 }
 
 type activeTurn struct {
@@ -109,6 +115,7 @@ func NewControllerWithAdapterResolver(adapters []Adapter, reporter DurableActivi
 	}
 	controller := &Controller{
 		sessions:                    make(map[string]Session),
+		sessionAvailabilityWaiters:  make(map[string]*sessionAvailabilityWaiter),
 		adapters:                    byProvider,
 		adapterResolver:             resolver,
 		turns:                       make(map[string]activeTurn),

--- a/packages/agent/daemon/runtime/controller_session_lifecycle.go
+++ b/packages/agent/daemon/runtime/controller_session_lifecycle.go
@@ -91,9 +91,11 @@ func (c *Controller) Start(ctx context.Context, input StartInput) (StartResult, 
 	}
 	session = applySessionEvents(session, events)
 	c.mu.Lock()
-	c.sessions[sessionKey(roomID, agentSessionID)] = session
+	key := sessionKey(roomID, agentSessionID)
+	c.sessions[key] = session
+	c.notifySessionAvailableLocked(key)
 	if input.Provisional {
-		c.provisionalSessions[sessionKey(roomID, agentSessionID)] = true
+		c.provisionalSessions[key] = true
 	}
 	c.mu.Unlock()
 	if input.Provisional {

--- a/packages/agent/daemon/runtime/controller_session_registry.go
+++ b/packages/agent/daemon/runtime/controller_session_registry.go
@@ -319,8 +319,19 @@ func (c *Controller) store(session Session) {
 		return
 	}
 	c.mu.Lock()
-	c.sessions[sessionKey(session.RoomID, session.AgentSessionID)] = session
+	key := sessionKey(session.RoomID, session.AgentSessionID)
+	c.sessions[key] = session
+	c.notifySessionAvailableLocked(key)
 	c.mu.Unlock()
+}
+
+func (c *Controller) notifySessionAvailableLocked(key string) {
+	waiter := c.sessionAvailabilityWaiters[key]
+	if waiter == nil {
+		return
+	}
+	delete(c.sessionAvailabilityWaiters, key)
+	close(waiter.changed)
 }
 
 func (c *Controller) publishPendingConfigOptionsUpdates(session Session) {

--- a/packages/agent/daemon/runtime/controller_stream.go
+++ b/packages/agent/daemon/runtime/controller_stream.go
@@ -1,6 +1,7 @@
 package agentruntime
 
 import (
+	"context"
 	"strings"
 
 	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
@@ -11,13 +12,68 @@ import (
 func (c *Controller) Subscribe(roomID, agentSessionID string) (<-chan StreamEvent, func(), bool) {
 	roomID = strings.TrimSpace(roomID)
 	agentSessionID = strings.TrimSpace(agentSessionID)
-	if roomID == "" || agentSessionID == "" {
-		ch := make(chan StreamEvent)
-		close(ch)
-		return ch, func() {}, false
+	if c == nil || roomID == "" || agentSessionID == "" {
+		return closedStreamSubscription()
+	}
+	c.mu.Lock()
+	events, unsubscribe, ok := c.subscribeLocked(roomID, agentSessionID)
+	c.mu.Unlock()
+	return events, unsubscribe, ok
+}
+
+// SubscribeWhenAvailable waits for a runtime session to enter the Controller
+// registry and then subscribes atomically with its initial state snapshot.
+// It is observation-only: it never starts or resumes a provider. The lifecycle
+// owner must call Start, Resume, or Host.EnsureRuntimeSession.
+func (c *Controller) SubscribeWhenAvailable(
+	ctx context.Context,
+	roomID string,
+	agentSessionID string,
+) (<-chan StreamEvent, func(), error) {
+	roomID = strings.TrimSpace(roomID)
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	if c == nil || roomID == "" || agentSessionID == "" {
+		events, unsubscribe, _ := closedStreamSubscription()
+		return events, unsubscribe, ErrSessionNotFound
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	key := sessionKey(roomID, agentSessionID)
-	c.mu.Lock()
+	for {
+		if err := ctx.Err(); err != nil {
+			events, unsubscribe, _ := closedStreamSubscription()
+			return events, unsubscribe, err
+		}
+		c.mu.Lock()
+		if events, unsubscribe, ok := c.subscribeLocked(roomID, agentSessionID); ok {
+			c.mu.Unlock()
+			return events, unsubscribe, nil
+		}
+		if c.sessionAvailabilityWaiters == nil {
+			c.sessionAvailabilityWaiters = make(map[string]*sessionAvailabilityWaiter)
+		}
+		waiter := c.sessionAvailabilityWaiters[key]
+		if waiter == nil {
+			waiter = &sessionAvailabilityWaiter{changed: make(chan struct{})}
+			c.sessionAvailabilityWaiters[key] = waiter
+		}
+		waiter.refs++
+		c.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			c.releaseSessionAvailabilityWaiter(key, waiter)
+			events, unsubscribe, _ := closedStreamSubscription()
+			return events, unsubscribe, ctx.Err()
+		case <-waiter.changed:
+			c.releaseSessionAvailabilityWaiter(key, waiter)
+		}
+	}
+}
+
+func (c *Controller) subscribeLocked(roomID, agentSessionID string) (<-chan StreamEvent, func(), bool) {
+	key := sessionKey(roomID, agentSessionID)
 	session, ok := c.sessions[key]
 	var initial []StreamEvent
 	if ok {
@@ -31,14 +87,29 @@ func (c *Controller) Subscribe(roomID, agentSessionID string) (<-chan StreamEven
 		initial = append(initial, configOptionsUpdateStreamEvent(update))
 	}
 	if !ok {
-		c.mu.Unlock()
-		ch := make(chan StreamEvent)
-		close(ch)
-		return ch, func() {}, false
+		return closedStreamSubscription()
 	}
 	events, unsubscribe := c.hub.SubscribeWithInitial(roomID, agentSessionID, initial)
-	c.mu.Unlock()
 	return events, unsubscribe, true
+}
+
+func (c *Controller) releaseSessionAvailabilityWaiter(key string, waiter *sessionAvailabilityWaiter) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	current := c.sessionAvailabilityWaiters[key]
+	if current != waiter {
+		return
+	}
+	waiter.refs--
+	if waiter.refs == 0 {
+		delete(c.sessionAvailabilityWaiters, key)
+	}
+}
+
+func closedStreamSubscription() (<-chan StreamEvent, func(), bool) {
+	ch := make(chan StreamEvent)
+	close(ch)
+	return ch, func() {}, false
 }
 
 func sessionStateSnapshotStreamEvent(session Session) StreamEvent {

--- a/packages/agent/daemon/runtime/controller_stream_wait_test.go
+++ b/packages/agent/daemon/runtime/controller_stream_wait_test.go
@@ -1,0 +1,147 @@
+package agentruntime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+)
+
+func TestSubscribeWhenAvailableWaitsForResumeAndReplaysState(t *testing.T) {
+	t.Parallel()
+
+	controller := NewController([]Adapter{&statefulInteractiveAdapter{}}, nil)
+	type result struct {
+		events      <-chan StreamEvent
+		unsubscribe func()
+		err         error
+	}
+	resultCh := make(chan result, 1)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	go func() {
+		events, unsubscribe, err := controller.SubscribeWhenAvailable(ctx, "room-1", "session-1")
+		resultCh <- result{events: events, unsubscribe: unsubscribe, err: err}
+	}()
+
+	select {
+	case got := <-resultCh:
+		got.unsubscribe()
+		t.Fatalf("SubscribeWhenAvailable returned before resume: %v", got.err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	resumed, err := controller.Resume(t.Context(), ResumeInput{
+		RoomID:            "room-1",
+		AgentSessionID:    "session-1",
+		Provider:          ProviderCodex,
+		ProviderSessionID: "provider-session-1",
+		CWD:               "/workspace",
+		Title:             "Recovered",
+	})
+	if err != nil {
+		t.Fatalf("Resume() error = %v", err)
+	}
+	if resumed.AgentSessionID != "session-1" {
+		t.Fatalf("Resume() session = %#v", resumed)
+	}
+
+	got := <-resultCh
+	if got.err != nil {
+		t.Fatalf("SubscribeWhenAvailable() error = %v", got.err)
+	}
+	defer got.unsubscribe()
+	event := waitForStreamEventType(t, got.events, StreamEventStatePatch)
+	patch, ok := event.Data.(agentsessionstore.WorkspaceAgentStatePatch)
+	if !ok {
+		t.Fatalf("state patch = %#v, want WorkspaceAgentStatePatch", event.Data)
+	}
+	if patch.AgentSessionID != "session-1" || patch.ProviderSessionID != "provider-session-1" {
+		t.Fatalf("resumed state = %#v", patch)
+	}
+}
+
+func TestSubscribeWhenAvailableCancellationDoesNotLeakWaiterOrCreateSession(t *testing.T) {
+	t.Parallel()
+
+	controller := NewController([]Adapter{&statefulInteractiveAdapter{}}, nil)
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, unsubscribe, err := controller.SubscribeWhenAvailable(ctx, "room-1", "missing")
+		unsubscribe()
+		done <- err
+	}()
+	waitForCondition(t, func() bool {
+		controller.mu.Lock()
+		defer controller.mu.Unlock()
+		return controller.sessionAvailabilityWaiters[sessionKey("room-1", "missing")] != nil
+	})
+
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("SubscribeWhenAvailable() error = %v, want context canceled", err)
+	}
+	controller.mu.Lock()
+	defer controller.mu.Unlock()
+	if len(controller.sessionAvailabilityWaiters) != 0 {
+		t.Fatalf("availability waiters = %#v, want empty", controller.sessionAvailabilityWaiters)
+	}
+	if len(controller.sessions) != 0 {
+		t.Fatalf("sessions = %#v, observation unexpectedly created runtime authority", controller.sessions)
+	}
+}
+
+func TestSubscribeWhenAvailableWakesConcurrentSubscribersOnce(t *testing.T) {
+	t.Parallel()
+
+	const subscriberCount = 32
+	controller := NewController([]Adapter{&statefulInteractiveAdapter{}}, nil)
+	type result struct {
+		events      <-chan StreamEvent
+		unsubscribe func()
+		err         error
+	}
+	results := make(chan result, subscriberCount)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	for range subscriberCount {
+		go func() {
+			events, unsubscribe, err := controller.SubscribeWhenAvailable(ctx, "room-1", "session-1")
+			results <- result{events: events, unsubscribe: unsubscribe, err: err}
+		}()
+	}
+	waitForCondition(t, func() bool {
+		controller.mu.Lock()
+		defer controller.mu.Unlock()
+		waiter := controller.sessionAvailabilityWaiters[sessionKey("room-1", "session-1")]
+		return waiter != nil && waiter.refs == subscriberCount
+	})
+
+	if _, err := controller.Resume(t.Context(), ResumeInput{
+		RoomID:            "room-1",
+		AgentSessionID:    "session-1",
+		Provider:          ProviderCodex,
+		ProviderSessionID: "provider-session-1",
+		CWD:               "/workspace",
+	}); err != nil {
+		t.Fatalf("Resume() error = %v", err)
+	}
+
+	for index := range subscriberCount {
+		got := <-results
+		if got.err != nil {
+			t.Fatalf("subscriber %d error = %v", index, got.err)
+		}
+		waitForStreamEventType(t, got.events, StreamEventStatePatch)
+		got.unsubscribe()
+	}
+	controller.mu.Lock()
+	defer controller.mu.Unlock()
+	if len(controller.sessionAvailabilityWaiters) != 0 {
+		t.Fatalf("availability waiters after resume = %s", fmt.Sprint(controller.sessionAvailabilityWaiters))
+	}
+}


### PR DESCRIPTION
## Summary

- add `Controller.SubscribeWhenAvailable` for observers that already hold durable session identity but race runtime restoration after daemon restart
- wake all waiters from the Controller session-registration boundary and atomically replay the current state snapshot
- keep the API observation-only: Agent Host remains the sole authority for provider Start, Resume, and `EnsureRuntimeSession`
- document the ownership boundary and add a troubleshooting playbook

## Why

A durable Agent session record can exist while the process-local Controller registry and ACP connection are still being restored. A one-shot subscription treated that normal restart window as `session not found`, causing remote callers to reconnect repeatedly with no useful progress.

The new API waits for the lifecycle owner to register the runtime session instead of starting provider work from an observation path.

## Impact and risks

- no provider lifecycle authority moves into the Controller subscription path
- waiting is event-driven and keyed per session; it does not poll
- canceled waits release their waiter entry
- concurrent observers share one availability notification

## Verification

- `cd packages/agent/daemon && go test ./runtime -count=1`
- `cd packages/agent/daemon && go test ./...`
- `cd packages/agent/daemon && go test -race ./runtime -run 'TestSubscribeWhenAvailable|TestControllerReplaysCurrentSessionStateOnSubscribe' -count=1`
- `pnpm check:changed`

## Checklist

- [x] This does not create, resume, or terminalize Agent lifecycle state; lifecycle authority remains in Agent Host
- [x] I kept the change focused on one concern
- [x] I updated documentation when behavior or troubleshooting guidance changed
- [x] No README/CONTRIBUTING language variants are affected
- [x] I ran the lowest meaningful local checks for the changed surface
- [x] The commit includes the required DCO sign-off