### PR TITLE
feat(agent-gui): disambiguate file mention paths

### DIFF
--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
@@ -107,6 +107,12 @@ test("desktop rich text @ service assembles workspace file providers by capabili
             name: "README.md",
             path: "/Users/test/project/tutti/README.md",
             score: 1
+          },
+          {
+            kind: "file",
+            name: "README.md",
+            path: "/Users/test/project/tutti/docs/README.md",
+            score: 1
           }
         ].filter((entry) => {
           const query = input.query.toLowerCase();
@@ -140,10 +146,19 @@ test("desktop rich text @ service assembles workspace file providers by capabili
   assert.deepEqual(items, [
     {
       displayName: "README.md",
+      displayPath: "README.md",
       kind: "file",
       path: "/Users/test/project/tutti/README.md"
+    },
+    {
+      displayName: "README.md",
+      displayPath: "docs/README.md",
+      kind: "file",
+      path: "/Users/test/project/tutti/docs/README.md"
     }
   ]);
+  assert.equal(provider.getItemSubtitle?.(items[0]), "README.md");
+  assert.equal(provider.getItemSubtitle?.(items[1]), "docs/README.md");
   assert.equal(provider.getItemIconUrl?.(items[0]), tuttiFileAssetUrls.default);
   assert.deepEqual(provider.toInsertResult(items[0]), {
     href: "/Users/test/project/tutti/README.md",
@@ -155,10 +170,18 @@ test("desktop rich text @ service assembles workspace file providers by capabili
   assert.deepEqual(folderItems, [
     {
       displayName: "docs",
+      displayPath: "docs",
       kind: "directory",
       path: "/Users/test/project/tutti/docs"
+    },
+    {
+      displayName: "README.md",
+      displayPath: "docs/README.md",
+      kind: "file",
+      path: "/Users/test/project/tutti/docs/README.md"
     }
   ]);
+  assert.equal(provider.getItemSubtitle?.(folderItems[0]), "docs");
   assert.equal(
     provider.getItemIconUrl?.(folderItems[0]),
     tuttiFolderAssetUrls.default

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.ts
@@ -65,6 +65,7 @@ export interface DesktopRichTextAtServiceDependencies {
 
 interface WorkspaceFileAtItem {
   displayName?: string | null;
+  displayPath: string;
   kind?: "directory" | "file" | (string & {});
   name?: string | null;
   path: string;
@@ -573,13 +574,18 @@ function createWorkspaceFileAtContributor(
               )
               .map((entry) => ({
                 displayName: entry.name,
+                displayPath: workspaceRelativeDisplayPath(
+                  entry.path,
+                  response.root,
+                  entry.name
+                ),
                 kind: entry.kind,
                 path: entry.path
               }));
           },
           getItemKey: (item) => item.path,
           getItemLabel: resolveWorkspaceFileLabel,
-          getItemSubtitle: (item) => item.path.trim(),
+          getItemSubtitle: (item) => item.displayPath,
           getItemIconUrl: workspaceFileIconUrl,
           toInsertResult(item) {
             return createRichTextMarkdownLinkInsertResult(
@@ -591,6 +597,26 @@ function createWorkspaceFileAtContributor(
       ];
     }
   };
+}
+
+function workspaceRelativeDisplayPath(
+  path: string,
+  root: string,
+  fallbackName: string
+): string {
+  const normalizedPath = path.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+  const normalizedRoot = root.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+  if (
+    normalizedRoot &&
+    (normalizedPath === normalizedRoot ||
+      normalizedPath.startsWith(`${normalizedRoot}/`))
+  ) {
+    return (
+      normalizedPath.slice(normalizedRoot.length).replace(/^\/+/, "") ||
+      fallbackName
+    );
+  }
+  return fallbackName;
 }
 
 function workspaceFileReferenceHref(item: WorkspaceFileAtItem): string {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/createDesktopAgentGeneratedFileMentionProvider.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/createDesktopAgentGeneratedFileMentionProvider.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AgentActivityRuntime } from "@tutti-os/agent-gui";
+import { createDesktopAgentGeneratedFileMentionProvider } from "./createDesktopAgentGeneratedFileMentionProvider.ts";
+
+test("generated file mentions expose project-relative subtitles", async () => {
+  const provider = createProvider([
+    {
+      label: "README.md",
+      path: "/Users/local/project/packages/a/README.md"
+    },
+    {
+      label: "README.md",
+      path: "/Users/local/project/packages/b/README.md"
+    }
+  ]);
+
+  const items = await queryProvider(provider, {
+    sectionKey: "project:/Users/local/project",
+    sessionCwd: "/Users/local/project"
+  });
+
+  assert.deepEqual(
+    items.map((item) => provider.getItemSubtitle?.(item)),
+    ["packages/a/README.md", "packages/b/README.md"]
+  );
+});
+
+test("generated file mentions hide host paths without a trusted project root", async () => {
+  const provider = createProvider([
+    { label: "README.md", path: "/Users/private/project/docs/README.md" }
+  ]);
+
+  const items = await queryProvider(provider, {
+    sectionKey: "conversations"
+  });
+
+  assert.deepEqual(
+    items.map((item) => provider.getItemSubtitle?.(item)),
+    ["README.md"]
+  );
+  assert.equal(
+    items.some((item) =>
+      (provider.getItemSubtitle?.(item) ?? "").startsWith("/Users/")
+    ),
+    false
+  );
+});
+
+function createProvider(entries: readonly { label: string; path: string }[]) {
+  return createDesktopAgentGeneratedFileMentionProvider({
+    agentActivityRuntime: {
+      async listAgentGeneratedFiles() {
+        return {
+          entries: [...entries],
+          workspaceId: "workspace-1"
+        };
+      }
+    } satisfies Pick<AgentActivityRuntime, "listAgentGeneratedFiles">,
+    workspaceId: "workspace-1"
+  });
+}
+
+async function queryProvider(
+  provider: ReturnType<typeof createProvider>,
+  metadata: { sectionKey: string; sessionCwd?: string }
+) {
+  return provider.query({
+    context: { metadata },
+    keyword: "readme",
+    maxResults: 20,
+    trigger: "@"
+  });
+}

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/createDesktopAgentGeneratedFileMentionProvider.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/createDesktopAgentGeneratedFileMentionProvider.ts
@@ -16,6 +16,7 @@ const { agentGeneratedFile: AGENT_GENERATED_FILE_PROVIDER_ID } =
 interface AgentGeneratedFileMentionItem {
   displayName: string;
   path: string;
+  relativePath: string;
 }
 
 export function createDesktopAgentGeneratedFileMentionProvider(input: {
@@ -59,14 +60,20 @@ export function createDesktopAgentGeneratedFileMentionProvider(input: {
       if (searchInput.abortSignal?.aborted) {
         return [];
       }
-      return result.entries.map((file) => ({
+      const relativePaths = generatedFileRelativePaths(
+        result.entries,
+        metadataString(searchInput.context.metadata, "sessionCwd", "") ||
+          projectRootFromSectionKey(sectionKey)
+      );
+      return result.entries.map((file, index) => ({
         displayName: file.label,
-        path: file.path
+        path: file.path,
+        relativePath: relativePaths[index] ?? file.label
       }));
     },
     getItemKey: (item) => item.path,
     getItemLabel: (item) => item.displayName,
-    getItemSubtitle: (item) => item.path,
+    getItemSubtitle: (item) => item.relativePath,
     getItemIconUrl: (item) =>
       item.path.endsWith("/")
         ? tuttiFolderAssetUrls.default
@@ -78,6 +85,56 @@ export function createDesktopAgentGeneratedFileMentionProvider(input: {
       );
     }
   };
+}
+
+function projectRootFromSectionKey(sectionKey: string): string {
+  return sectionKey.startsWith("project:")
+    ? sectionKey.slice("project:".length).trim()
+    : "";
+}
+
+function generatedFileRelativePaths(
+  files: readonly { label: string; path: string }[],
+  root: string
+): string[] {
+  const normalizedRoot = normalizeHostPath(root);
+  return files.map(
+    (file) =>
+      relativePathInsideRoot(
+        normalizeHostPath(file.path),
+        normalizedRoot,
+        file.label
+      ) ?? file.label
+  );
+}
+
+function relativePathInsideRoot(
+  path: string,
+  root: string,
+  fileName: string
+): string | undefined {
+  if (!isAbsoluteHostPath(path) || !isAbsoluteHostPath(root)) {
+    return undefined;
+  }
+  const comparablePath = comparableHostPath(path);
+  const comparableRoot = comparableHostPath(root);
+  if (!comparablePath.startsWith(`${comparableRoot}/`)) {
+    return undefined;
+  }
+  const relativePath = path.slice(root.length + 1);
+  return relativePath.split("/").at(-1) === fileName ? relativePath : undefined;
+}
+
+function normalizeHostPath(value: string): string {
+  return value.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function comparableHostPath(value: string): string {
+  return /^[A-Za-z]:\//.test(value) ? value.toLowerCase() : value;
+}
+
+function isAbsoluteHostPath(value: string): boolean {
+  return value.startsWith("/") || /^[A-Za-z]:\//.test(value);
 }
 
 function metadataReferenceProvenanceFilter(

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
@@ -85,12 +85,21 @@ describe("AgentFileMentionPalette", () => {
       },
       {
         kind: "file" as const,
-        href: "/workspace/packages/agent/gui/agentGuiNode/README.md",
-        path: "/workspace/packages/agent/gui/agentGuiNode/README.md",
-        relativePath: "packages/agent/gui/agentGuiNode/README.md",
+        href: "/workspace/packages/group/feature-a/src/components/README.md",
+        path: "/workspace/packages/group/feature-a/src/components/README.md",
+        relativePath: "packages/group/feature-a/src/components/README.md",
         name: "README.md",
         entryKind: "file" as const,
-        directoryPath: "/workspace/packages/agent/gui/agentGuiNode"
+        directoryPath: "/workspace/packages/group/feature-a/src/components"
+      },
+      {
+        kind: "file" as const,
+        href: "/workspace/packages/group/feature-b/src/components/README.md",
+        path: "/workspace/packages/group/feature-b/src/components/README.md",
+        relativePath: "packages/group/feature-b/src/components/README.md",
+        name: "README.md",
+        entryKind: "file" as const,
+        directoryPath: "/workspace/packages/group/feature-b/src/components"
       }
     ] satisfies AgentContextMentionItem[];
     const state: AgentMentionSearchState = {
@@ -133,28 +142,111 @@ describe("AgentFileMentionPalette", () => {
     );
 
     const options = screen.getAllByRole("option");
-    expect(options).toHaveLength(3);
-    const [shortPathOption, mediumPathOption, longPathOption] = options;
-    if (!shortPathOption || !mediumPathOption || !longPathOption) {
-      throw new Error("Expected three file mention options");
+    expect(options).toHaveLength(4);
+    const [shortPathOption, mediumPathOption, featureAOption, featureBOption] =
+      options;
+    if (
+      !shortPathOption ||
+      !mediumPathOption ||
+      !featureAOption ||
+      !featureBOption
+    ) {
+      throw new Error("Expected four file mention options");
     }
     expect(shortPathOption).toHaveTextContent("docs/README.md");
     expect(shortPathOption).not.toHaveTextContent("…");
     expect(mediumPathOption).toHaveTextContent("apps/desktop/README.md");
-    expect(longPathOption).toHaveTextContent(
-      "packages/…/gui/agentGuiNode/README.md"
+    expect(featureAOption).toHaveTextContent(
+      "packages/group/feature-a/…/components/README.md"
+    );
+    expect(featureBOption).toHaveTextContent(
+      "packages/group/feature-b/…/components/README.md"
     );
     expect(
-      within(longPathOption).getByTitle(
-        "packages/agent/gui/agentGuiNode/README.md"
+      within(featureAOption).getByTitle(
+        "packages/group/feature-a/src/components/README.md"
       )
     ).toBeVisible();
-    expect(within(longPathOption).getByText("README.md")).toHaveClass(
-      "rich-text-at-mention-row__file-name"
-    );
+    const featureAFileName = within(featureAOption).getByText("README.md");
+    expect(featureAFileName).toHaveClass("rich-text-at-mention-row__file-name");
 
     fireEvent.click(mediumPathOption);
     expect(onSelectItem).toHaveBeenCalledWith(files[1]);
+  });
+
+  it("disambiguates same-named files across hidden file subgroups", () => {
+    const openedFile = {
+      kind: "file" as const,
+      href: "/workspace/packages/group/feature-a/src/components/README.md",
+      path: "/workspace/packages/group/feature-a/src/components/README.md",
+      relativePath: "packages/group/feature-a/src/components/README.md",
+      name: "README.md",
+      entryKind: "file" as const,
+      directoryPath: "/workspace/packages/group/feature-a/src/components"
+    };
+    const generatedFile = {
+      kind: "file" as const,
+      href: "/workspace/packages/group/feature-b/src/components/README.md",
+      path: "/workspace/packages/group/feature-b/src/components/README.md",
+      relativePath: "packages/group/feature-b/src/components/README.md",
+      name: "README.md",
+      entryKind: "file" as const,
+      directoryPath: "/workspace/packages/group/feature-b/src/components"
+    };
+    const state: AgentMentionSearchState = {
+      status: "ready",
+      query: "read",
+      mode: "results",
+      filter: "file",
+      categories: [],
+      groups: [
+        {
+          id: "opened_files",
+          items: [openedFile],
+          totalCount: 1,
+          visibleCount: 1,
+          hasMore: false
+        },
+        {
+          id: "agent_generated_files",
+          items: [generatedFile],
+          totalCount: 1,
+          visibleCount: 1,
+          hasMore: false
+        }
+      ],
+      error: null
+    };
+
+    render(
+      <div style={{ width: 180 }}>
+        <AgentFileMentionPalette
+          state={state}
+          highlightedKey={null}
+          label="mention palette"
+          loadingLabel="loading"
+          emptyLabel="empty"
+          errorLabel="error"
+          tabHintLabel="hint"
+          maxHeightPx={320}
+          onHighlightChange={vi.fn()}
+          onSelectItem={vi.fn()}
+          onSelectCategory={vi.fn()}
+          onSelectFilter={vi.fn()}
+          onExpandGroup={vi.fn()}
+        />
+      </div>
+    );
+
+    const [openedOption, generatedOption] = screen.getAllByRole("option");
+    expect(openedOption).toHaveTextContent(
+      "packages/group/feature-a/…/components/README.md"
+    );
+    expect(generatedOption).toHaveTextContent(
+      "packages/group/feature-b/…/components/README.md"
+    );
+    expect(screen.queryByText("我打开的文件")).toBeNull();
+    expect(screen.queryByText("近期 Agent 生成的文件")).toBeNull();
   });
 
   it("shows unavailable agent targets but prevents selecting them", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
@@ -63,6 +63,100 @@ vi.mock("../../i18n/index", async () => {
 });
 
 describe("AgentFileMentionPalette", () => {
+  it("disambiguates same-named files with safe relative paths without changing selection identity", () => {
+    const files = [
+      {
+        kind: "file" as const,
+        href: "/workspace/docs/README.md",
+        path: "/workspace/docs/README.md",
+        relativePath: "docs/README.md",
+        name: "README.md",
+        entryKind: "file" as const,
+        directoryPath: "/workspace/docs"
+      },
+      {
+        kind: "file" as const,
+        href: "/workspace/apps/desktop/README.md",
+        path: "/workspace/apps/desktop/README.md",
+        relativePath: "apps/desktop/README.md",
+        name: "README.md",
+        entryKind: "file" as const,
+        directoryPath: "/workspace/apps/desktop"
+      },
+      {
+        kind: "file" as const,
+        href: "/workspace/packages/agent/gui/agentGuiNode/README.md",
+        path: "/workspace/packages/agent/gui/agentGuiNode/README.md",
+        relativePath: "packages/agent/gui/agentGuiNode/README.md",
+        name: "README.md",
+        entryKind: "file" as const,
+        directoryPath: "/workspace/packages/agent/gui/agentGuiNode"
+      }
+    ] satisfies AgentContextMentionItem[];
+    const state: AgentMentionSearchState = {
+      status: "ready",
+      query: "read",
+      mode: "results",
+      filter: "file",
+      categories: [],
+      groups: [
+        {
+          id: "files",
+          items: files,
+          totalCount: files.length,
+          visibleCount: files.length,
+          hasMore: false
+        }
+      ],
+      error: null
+    };
+    const onSelectItem = vi.fn();
+
+    render(
+      <div style={{ width: 180 }}>
+        <AgentFileMentionPalette
+          state={state}
+          highlightedKey="files:file:/workspace/apps/desktop/README.md"
+          label="mention palette"
+          loadingLabel="loading"
+          emptyLabel="empty"
+          errorLabel="error"
+          tabHintLabel="hint"
+          maxHeightPx={320}
+          onHighlightChange={vi.fn()}
+          onSelectItem={onSelectItem}
+          onSelectCategory={vi.fn()}
+          onSelectFilter={vi.fn()}
+          onExpandGroup={vi.fn()}
+        />
+      </div>
+    );
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(3);
+    const [shortPathOption, mediumPathOption, longPathOption] = options;
+    if (!shortPathOption || !mediumPathOption || !longPathOption) {
+      throw new Error("Expected three file mention options");
+    }
+    expect(shortPathOption).toHaveTextContent("docs/README.md");
+    expect(shortPathOption).not.toHaveTextContent("…");
+    expect(mediumPathOption).toHaveTextContent("apps/desktop/README.md");
+    expect(longPathOption).toHaveTextContent(
+      "packages/…/gui/agentGuiNode/README.md"
+    );
+    expect(
+      within(longPathOption).getByTitle(
+        "packages/agent/gui/agentGuiNode/README.md"
+      )
+    ).toBeVisible();
+    expect(within(longPathOption).getByText("README.md")).toHaveClass(
+      "rich-text-at-mention-row__file-name"
+    );
+
+    fireEvent.click(mediumPathOption);
+    expect(onSelectItem).toHaveBeenCalledWith(files[1]);
+  });
+
   it("shows unavailable agent targets but prevents selecting them", () => {
     const unavailableAgent = {
       kind: "agent-target" as const,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
@@ -33,6 +33,7 @@ import {
   AGENT_MENTION_FILTER_TAB_ORDER,
   mentionGroupExpandCount
 } from "./agentMentionSearchHelpers";
+import { mentionFileDisambiguationPrefixSegments } from "./agentMentionFileProjection";
 import {
   type AgentMentionGroup,
   type AgentMentionBrowseCategory,
@@ -272,6 +273,9 @@ export function AgentFileMentionPalette({
         mode: state.mode,
         query: state.query
       });
+  const visibleFileCandidates = shellState.groups.flatMap(
+    (group) => group.items
+  );
 
   return (
     <MentionPaletteFromState<AgentContextMentionItem>
@@ -280,22 +284,25 @@ export function AgentFileMentionPalette({
       getItemKey={agentMentionItemKey}
       isItemDisabled={isAgentMentionItemDisabled}
       renderItem={(item) =>
-        renderMentionRow(agentMentionItemToRowItem(item), {
-          classNames: AGENT_MENTION_ROW_CLASS_NAMES,
-          dataAttributeMode: "agent",
-          ...(onNavigateIntoItem && canNavigateIntoMentionItem(item)
-            ? {
-                onNavigateInto: () => onNavigateIntoItem(item),
-                navigateIntoLabel
-              }
-            : {}),
-          ...(onOpenReferences && isReferenceableMentionItem(item)
-            ? {
-                onOpenReferences: () => onOpenReferences(item),
-                openReferencesLabel
-              }
-            : {})
-        })
+        renderMentionRow(
+          agentMentionItemToRowItem(item, visibleFileCandidates),
+          {
+            classNames: AGENT_MENTION_ROW_CLASS_NAMES,
+            dataAttributeMode: "agent",
+            ...(onNavigateIntoItem && canNavigateIntoMentionItem(item)
+              ? {
+                  onNavigateInto: () => onNavigateIntoItem(item),
+                  navigateIntoLabel
+                }
+              : {}),
+            ...(onOpenReferences && isReferenceableMentionItem(item)
+              ? {
+                  onOpenReferences: () => onOpenReferences(item),
+                  openReferencesLabel
+                }
+              : {})
+          }
+        )
       }
       labels={{
         loading: loadingLabel,
@@ -452,7 +459,8 @@ function shouldRenderMentionGroupLabel(input: {
  * issue status labels — are resolved here so the shared renderer stays pure.
  */
 function agentMentionItemToRowItem(
-  item: AgentContextMentionItem
+  item: AgentContextMentionItem,
+  candidates: readonly AgentContextMentionItem[]
 ): MentionRowItem {
   if (item.kind === "file") {
     const visualKind = resolveAgentMentionFileVisualKind({
@@ -475,6 +483,10 @@ function agentMentionItemToRowItem(
       kind: "file",
       name: item.name,
       relativePath: item.relativePath,
+      disambiguationPrefixSegments: mentionFileDisambiguationPrefixSegments(
+        item,
+        candidates
+      ),
       visualKind,
       thumbnailUrl: resolveAgentMentionFileThumbnailUrl(item) ?? null,
       childCountLabel,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
@@ -474,6 +474,7 @@ function agentMentionItemToRowItem(
     return {
       kind: "file",
       name: item.name,
+      relativePath: item.relativePath,
       visualKind,
       thumbnailUrl: resolveAgentMentionFileThumbnailUrl(item) ?? null,
       childCountLabel,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.spec.ts
@@ -33,6 +33,15 @@ describe("providerItemToAgentMentionItem", () => {
     expect(createFile("../outside/README.md")).not.toHaveProperty(
       "relativePath"
     );
+    for (const unsafePath of [
+      "file:C:/Users/alice/README.md",
+      "C:private/README.md",
+      "C:/Users/alice/README.md",
+      String.raw`\\server\share\README.md`,
+      "https://example.com/README.md"
+    ]) {
+      expect(createFile(unsafePath)).not.toHaveProperty("relativePath");
+    }
   });
 
   it("preserves Agent Target identity in session mention metadata", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.spec.ts
@@ -6,6 +6,35 @@ import {
 } from "./AgentMentionSearchModel";
 
 describe("providerItemToAgentMentionItem", () => {
+  it("preserves only safe source-relative paths for file presentation", () => {
+    const createFile = (subtitle: string) =>
+      providerItemToAgentMentionItem({
+        currentUserId: "user-1",
+        providerId: "file",
+        insertResult: {
+          kind: "markdown-link",
+          href: "/Users/test/project/tutti/docs/README.md",
+          label: "README.md"
+        },
+        label: "README.md",
+        subtitle,
+        workspaceId: "workspace-1"
+      });
+
+    expect(createFile("docs/README.md")).toMatchObject({
+      href: "/Users/test/project/tutti/docs/README.md",
+      kind: "file",
+      name: "README.md",
+      relativePath: "docs/README.md"
+    });
+    expect(
+      createFile("/Users/test/project/tutti/docs/README.md")
+    ).not.toHaveProperty("relativePath");
+    expect(createFile("../outside/README.md")).not.toHaveProperty(
+      "relativePath"
+    );
+  });
+
   it("preserves Agent Target identity in session mention metadata", () => {
     expect(
       providerItemToAgentMentionItem({

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
@@ -40,6 +40,11 @@ import {
   shouldShowEmptyGroup
 } from "./agentMentionSearchHelpers";
 import { resolveReferenceProvenanceAgentLabelParts } from "@tutti-os/workspace-file-reference/core";
+import {
+  dirnameFromProviderWorkspaceFileHref,
+  normalizeMentionDirectoryChildCount,
+  normalizeMentionFileRelativePath
+} from "./agentMentionFileProjection";
 
 type AgentProvenanceMentionItem = Extract<
   AgentContextMentionItem,
@@ -568,11 +573,16 @@ export function providerItemToAgentMentionItem(input: {
   if (input.insertResult.kind === "markdown-link") {
     const href = input.insertResult.href.trim();
     const directoryPath = input.directory?.path.trim() ?? "";
+    const relativePath = normalizeMentionFileRelativePath(
+      input.subtitle,
+      label
+    );
     return {
       kind: "file",
       href,
       path: directoryPath || href,
       name: label,
+      ...(relativePath ? { relativePath } : {}),
       entryKind: directoryPath || href.endsWith("/") ? "directory" : "unknown",
       directoryPath: dirnameFromProviderWorkspaceFileHref(
         directoryPath || href
@@ -604,6 +614,10 @@ export function providerItemToAgentMentionItem(input: {
     input.providerId === AGENT_GENERATED_FILE_PROVIDER_ID
   ) {
     const directoryPath = input.directory?.path.trim() ?? "";
+    const relativePath = normalizeMentionFileRelativePath(
+      input.subtitle,
+      label
+    );
     return {
       kind: "file",
       href: createRichTextMentionHref({
@@ -614,6 +628,7 @@ export function providerItemToAgentMentionItem(input: {
       }),
       path: directoryPath || targetId,
       name: label,
+      ...(relativePath ? { relativePath } : {}),
       entryKind:
         directoryPath || targetId.endsWith("/") ? "directory" : "unknown",
       directoryPath: dirnameFromProviderWorkspaceFileHref(
@@ -746,15 +761,6 @@ export function providerItemToAgentMentionItem(input: {
   return null;
 }
 
-function normalizeMentionDirectoryChildCount(
-  value: number | null | undefined
-): number | undefined {
-  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
-    return undefined;
-  }
-  return Math.floor(value);
-}
-
 export function normalizeMentionScope(
   scope?: Readonly<Record<string, string>>
 ): Record<string, string> {
@@ -785,13 +791,4 @@ export function mentionSessionScope(input: {
     return "my_sessions";
   }
   return userId === currentUserId ? "my_sessions" : "collab_sessions";
-}
-
-export function dirnameFromProviderWorkspaceFileHref(href: string): string {
-  const normalized = href.replace(/\/+$/, "");
-  const index = normalized.lastIndexOf("/");
-  if (index <= 0) {
-    return "/";
-  }
-  return normalized.slice(0, index);
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentMentionFileProjection.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentMentionFileProjection.ts
@@ -1,0 +1,40 @@
+import { compactText } from "./agentMentionSearchHelpers";
+
+export function normalizeMentionFileRelativePath(
+  value: string,
+  fileName: string
+): string | undefined {
+  const normalized = compactText(value)
+    .replace(/\\/g, "/")
+    .replace(/^\.\/+/, "")
+    .replace(/\/{2,}/g, "/")
+    .replace(/\/+$/, "");
+  if (
+    !normalized ||
+    normalized.startsWith("/") ||
+    /^[a-zA-Z]:\//.test(normalized) ||
+    /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(normalized) ||
+    normalized.split("/").includes("..")
+  ) {
+    return undefined;
+  }
+  return normalized.split("/").at(-1) === fileName ? normalized : undefined;
+}
+
+export function normalizeMentionDirectoryChildCount(
+  value: number | null | undefined
+): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+export function dirnameFromProviderWorkspaceFileHref(href: string): string {
+  const normalized = href.replace(/\/+$/, "");
+  const index = normalized.lastIndexOf("/");
+  if (index <= 0) {
+    return "/";
+  }
+  return normalized.slice(0, index);
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentMentionFileProjection.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentMentionFileProjection.ts
@@ -1,5 +1,11 @@
 import { compactText } from "./agentMentionSearchHelpers";
 
+interface MentionFilePathCandidate {
+  kind: string;
+  name?: string;
+  relativePath?: string | null;
+}
+
 export function normalizeMentionFileRelativePath(
   value: string,
   fileName: string
@@ -12,13 +18,54 @@ export function normalizeMentionFileRelativePath(
   if (
     !normalized ||
     normalized.startsWith("/") ||
-    /^[a-zA-Z]:\//.test(normalized) ||
-    /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(normalized) ||
+    /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(normalized) ||
     normalized.split("/").includes("..")
   ) {
     return undefined;
   }
   return normalized.split("/").at(-1) === fileName ? normalized : undefined;
+}
+
+export function mentionFileDisambiguationPrefixSegments(
+  item: MentionFilePathCandidate & { kind: "file"; name: string },
+  candidates: readonly MentionFilePathCandidate[]
+): number | undefined {
+  const relativePath = normalizeMentionFileRelativePath(
+    item.relativePath ?? "",
+    item.name
+  );
+  if (!relativePath) {
+    return undefined;
+  }
+  const directories = relativePath.split("/").slice(0, -1);
+  const sameNameDirectories = candidates.flatMap((candidate) => {
+    if (candidate === item || candidate.kind !== "file") {
+      return [];
+    }
+    const candidateName = candidate.name ?? "";
+    if (candidateName !== item.name) {
+      return [];
+    }
+    const candidatePath = normalizeMentionFileRelativePath(
+      candidate.relativePath ?? "",
+      candidateName
+    );
+    return candidatePath ? [candidatePath.split("/").slice(0, -1)] : [];
+  });
+  if (sameNameDirectories.length === 0) {
+    return undefined;
+  }
+  for (let count = 1; count <= directories.length; count += 1) {
+    const prefix = directories.slice(0, count).join("/");
+    if (
+      sameNameDirectories.every(
+        (candidate) => candidate.slice(0, count).join("/") !== prefix
+      )
+    ) {
+      return count;
+    }
+  }
+  return directories.length;
 }
 
 export function normalizeMentionDirectoryChildCount(

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionContracts.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionContracts.ts
@@ -24,6 +24,8 @@ export interface AgentMentionFileItem {
   path: string;
   href: string;
   name: string;
+  /** Safe source-relative path used only by mention candidate presentation. */
+  relativePath?: string;
   entryKind: AgentFileMentionKind;
   directoryPath: string;
   /** Present only for a regular file attached from the local composer. */

--- a/packages/ui/rich-text/README.md
+++ b/packages/ui/rich-text/README.md
@@ -387,6 +387,15 @@ Minimum integration checklist:
    />;
    ```
 
+   `MentionRowFileItem.relativePath` is optional, source-relative presentation
+   metadata for disambiguating same-named file candidates. Callers must not
+   provide absolute paths, URI values, traversal segments, or other
+   host-sensitive paths. When sibling rows need more than the default leading
+   context, `disambiguationPrefixSegments` may specify how many leading
+   directory segments must remain visible before middle omission. Both values
+   only affect the visible row label and its title; selection identity and
+   mention serialization continue to use the existing item fields.
+
 6. Wire keyboard handling to the state adapter or to `makeAtPanelKeyDown`.
    External apps should keep the exact shortcut policy local; the shared shell
    supports moving selection, cycling categories, expanding groups, and

--- a/packages/ui/rich-text/src/at-panel/MentionFileRow.tsx
+++ b/packages/ui/rich-text/src/at-panel/MentionFileRow.tsx
@@ -1,0 +1,309 @@
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  FileCodeIcon,
+  FileTextIcon,
+  FolderIcon,
+  ImageFileIcon,
+  ProductIcon,
+  VideoFileIcon,
+  cn,
+  type IconProps
+} from "@tutti-os/ui-system";
+import type { MentionFileVisualKind } from "./mentionFileVisualKind.ts";
+import {
+  mentionRowDataAttribute,
+  mentionRowRootDataAttributes,
+  type MentionRowDataAttributeMode
+} from "./mentionRowDataAttributes.ts";
+import type { MentionRowFileItem } from "./mentionRowTypes.ts";
+
+const MENTION_FILE_VISUAL_KIND_ICON: Record<
+  MentionFileVisualKind,
+  (props: IconProps) => React.JSX.Element
+> = {
+  back: ArrowLeftIcon,
+  folder: FolderIcon,
+  document: FileTextIcon,
+  markdown: ProductIcon,
+  code: FileCodeIcon,
+  image: ImageFileIcon,
+  video: VideoFileIcon
+};
+
+interface MentionFileRowClassNames {
+  fileIcon: string;
+  fileThumb: string;
+}
+
+export function MentionFileRow({
+  item,
+  classNames,
+  dataAttributeMode,
+  navigateIntoLabel,
+  onNavigateInto,
+  usesDefaultFileIcon
+}: {
+  item: MentionRowFileItem;
+  classNames: MentionFileRowClassNames;
+  dataAttributeMode: MentionRowDataAttributeMode;
+  navigateIntoLabel?: string;
+  onNavigateInto?: () => void;
+  usesDefaultFileIcon: boolean;
+}): React.JSX.Element {
+  const pathPresentation = mentionFilePathPresentation(
+    item.relativePath,
+    item.name,
+    item.disambiguationPrefixSegments
+  );
+  return (
+    <span
+      className="rich-text-at-mention-row rich-text-at-mention-row--file"
+      {...mentionRowRootDataAttributes(dataAttributeMode, "file")}
+      {...(item.entryKind
+        ? mentionRowDataAttribute(
+            dataAttributeMode,
+            "fileEntryKind",
+            item.entryKind
+          )
+        : {})}
+      {...mentionRowDataAttribute(
+        dataAttributeMode,
+        "fileVisualKind",
+        item.visualKind
+      )}
+      {...(item.mentionNavigation
+        ? mentionRowDataAttribute(
+            dataAttributeMode,
+            "navigation",
+            item.mentionNavigation
+          )
+        : {})}
+    >
+      <MentionFileIcon
+        item={item}
+        classNames={classNames}
+        dataAttributeMode={dataAttributeMode}
+        usesDefaultFileIcon={usesDefaultFileIcon}
+      />
+      <span
+        className="rich-text-at-mention-row__file-text"
+        title={pathPresentation?.fullPath}
+      >
+        {pathPresentation?.directory ? (
+          <MentionFileDirectory presentation={pathPresentation.directory} />
+        ) : null}
+        <span className="rich-text-at-mention-row__file-name">{item.name}</span>
+      </span>
+      {item.childCountLabel ? (
+        <span className="rich-text-at-mention-row__file-count">
+          {item.childCountLabel}
+        </span>
+      ) : null}
+      {onNavigateInto ? (
+        <MentionNavigateIntoButton
+          label={navigateIntoLabel}
+          onNavigateInto={onNavigateInto}
+          dataAttributeMode={dataAttributeMode}
+        />
+      ) : null}
+    </span>
+  );
+}
+
+function MentionNavigateIntoButton({
+  label,
+  onNavigateInto,
+  dataAttributeMode
+}: {
+  label?: string;
+  onNavigateInto: () => void;
+  dataAttributeMode: MentionRowDataAttributeMode;
+}): React.JSX.Element {
+  return (
+    <span
+      role="button"
+      tabIndex={-1}
+      aria-label={label}
+      title={label}
+      className="rich-text-at-mention-row__navigate-into"
+      {...mentionRowDataAttribute(dataAttributeMode, "navigateInto", "true")}
+      onMouseDown={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        onNavigateInto();
+      }}
+    >
+      <ArrowRightIcon size={16} />
+    </span>
+  );
+}
+
+interface MentionFileDirectoryPresentation {
+  head: string;
+  tail: string | null;
+}
+
+function MentionFileDirectory({
+  presentation
+}: {
+  presentation: MentionFileDirectoryPresentation;
+}): React.JSX.Element {
+  if (!presentation.tail) {
+    return (
+      <span className="rich-text-at-mention-row__file-directory">
+        {presentation.head}
+      </span>
+    );
+  }
+  return (
+    <span className="rich-text-at-mention-row__file-directory rich-text-at-mention-row__file-directory--condensed">
+      <span className="rich-text-at-mention-row__file-directory-head">
+        {presentation.head}
+      </span>
+      <span className="rich-text-at-mention-row__file-directory-middle">
+        /…/
+      </span>
+      <span className="rich-text-at-mention-row__file-directory-tail">
+        {presentation.tail}
+      </span>
+    </span>
+  );
+}
+
+function mentionFilePathPresentation(
+  relativePath: string | null | undefined,
+  fileName: string,
+  disambiguationPrefixSegments: number | null | undefined
+): {
+  directory: MentionFileDirectoryPresentation | null;
+  fullPath: string;
+} | null {
+  const normalized = relativePath
+    ?.trim()
+    .replace(/\\/g, "/")
+    .replace(/^\.\/+/, "")
+    .replace(/\/{2,}/g, "/")
+    .replace(/\/+$/, "");
+  if (!normalized) {
+    return null;
+  }
+  const segments = normalized.split("/").filter(Boolean);
+  if (segments.at(-1) !== fileName) {
+    return null;
+  }
+  const directories = segments.slice(0, -1);
+  if (directories.length === 0) {
+    return { directory: null, fullPath: normalized };
+  }
+  const prefixSegmentCount = Math.max(
+    1,
+    Math.min(
+      directories.length,
+      Number.isFinite(disambiguationPrefixSegments)
+        ? Math.floor(disambiguationPrefixSegments ?? 0)
+        : 2
+    )
+  );
+  if (directories.length <= 3 || directories.length <= prefixSegmentCount + 1) {
+    return {
+      directory: { head: `${directories.join("/")}/`, tail: null },
+      fullPath: normalized
+    };
+  }
+  return {
+    directory: {
+      head: directories.slice(0, prefixSegmentCount).join("/"),
+      tail: `${directories.at(-1)}/`
+    },
+    fullPath: normalized
+  };
+}
+
+function MentionFileIcon({
+  item,
+  classNames,
+  dataAttributeMode,
+  usesDefaultFileIcon
+}: {
+  item: MentionRowFileItem;
+  classNames: MentionFileRowClassNames;
+  dataAttributeMode: MentionRowDataAttributeMode;
+  usesDefaultFileIcon: boolean;
+}): React.JSX.Element {
+  const thumbnailUrl =
+    item.visualKind === "image" ? item.thumbnailUrl?.trim() || "" : "";
+  if (thumbnailUrl) {
+    return (
+      <span
+        className={classNames.fileThumb}
+        {...mentionRowDataAttribute(dataAttributeMode, "fileThumb", "true")}
+        aria-hidden="true"
+      >
+        <img
+          src={thumbnailUrl}
+          alt=""
+          className="rich-text-at-mention-row__media"
+          decoding="async"
+          loading="lazy"
+          draggable={false}
+        />
+      </span>
+    );
+  }
+
+  if (item.visualKind === "back") {
+    return (
+      <span
+        className={cn(
+          classNames.fileIcon,
+          "rich-text-at-mention-file-icon--glyph"
+        )}
+        {...mentionRowDataAttribute(
+          dataAttributeMode,
+          "fileVisualKind",
+          item.visualKind
+        )}
+        aria-hidden="true"
+      >
+        <ArrowLeftIcon size={16} />
+      </span>
+    );
+  }
+
+  if (usesDefaultFileIcon) {
+    const Icon = MENTION_FILE_VISUAL_KIND_ICON[item.visualKind];
+    return (
+      <span
+        className={cn(
+          classNames.fileIcon,
+          "rich-text-at-mention-file-icon--glyph"
+        )}
+        {...mentionRowDataAttribute(
+          dataAttributeMode,
+          "fileVisualKind",
+          item.visualKind
+        )}
+        aria-hidden="true"
+      >
+        <Icon size={16} />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={classNames.fileIcon}
+      {...mentionRowDataAttribute(
+        dataAttributeMode,
+        "fileVisualKind",
+        item.visualKind
+      )}
+      aria-hidden="true"
+    />
+  );
+}

--- a/packages/ui/rich-text/src/at-panel/MentionRow.tsx
+++ b/packages/ui/rich-text/src/at-panel/MentionRow.tsx
@@ -372,6 +372,10 @@ function MentionFileRow({
   navigateIntoLabel?: string;
   onNavigateInto?: () => void;
 }): React.JSX.Element {
+  const pathPresentation = mentionFilePathPresentation(
+    item.relativePath,
+    item.name
+  );
   return (
     <span
       className="rich-text-at-mention-row rich-text-at-mention-row--file"
@@ -401,8 +405,14 @@ function MentionFileRow({
         classNames={classNames}
         dataAttributeMode={dataAttributeMode}
       />
-      <span className="rich-text-at-mention-row__file-text">
-        <span className="rich-text-at-mention-row__title">{item.name}</span>
+      <span
+        className="rich-text-at-mention-row__file-text"
+        title={pathPresentation?.fullPath}
+      >
+        {pathPresentation?.directory ? (
+          <MentionFileDirectory presentation={pathPresentation.directory} />
+        ) : null}
+        <span className="rich-text-at-mention-row__file-name">{item.name}</span>
       </span>
       {item.childCountLabel ? (
         <span className="rich-text-at-mention-row__file-count">
@@ -418,6 +428,77 @@ function MentionFileRow({
       ) : null}
     </span>
   );
+}
+
+interface MentionFileDirectoryPresentation {
+  head: string;
+  tail: string | null;
+}
+
+function MentionFileDirectory({
+  presentation
+}: {
+  presentation: MentionFileDirectoryPresentation;
+}): React.JSX.Element {
+  if (!presentation.tail) {
+    return (
+      <span className="rich-text-at-mention-row__file-directory">
+        {presentation.head}
+      </span>
+    );
+  }
+  return (
+    <span className="rich-text-at-mention-row__file-directory rich-text-at-mention-row__file-directory--condensed">
+      <span className="rich-text-at-mention-row__file-directory-head">
+        {presentation.head}
+      </span>
+      <span className="rich-text-at-mention-row__file-directory-middle">
+        /…/
+      </span>
+      <span className="rich-text-at-mention-row__file-directory-tail">
+        {presentation.tail}
+      </span>
+    </span>
+  );
+}
+
+function mentionFilePathPresentation(
+  relativePath: string | null | undefined,
+  fileName: string
+): {
+  directory: MentionFileDirectoryPresentation | null;
+  fullPath: string;
+} | null {
+  const normalized = relativePath
+    ?.trim()
+    .replace(/\\/g, "/")
+    .replace(/^\.\/+/, "")
+    .replace(/\/{2,}/g, "/")
+    .replace(/\/+$/, "");
+  if (!normalized) {
+    return null;
+  }
+  const segments = normalized.split("/").filter(Boolean);
+  if (segments.at(-1) !== fileName) {
+    return null;
+  }
+  const directories = segments.slice(0, -1);
+  if (directories.length === 0) {
+    return { directory: null, fullPath: normalized };
+  }
+  if (directories.length <= 3) {
+    return {
+      directory: { head: `${directories.join("/")}/`, tail: null },
+      fullPath: normalized
+    };
+  }
+  return {
+    directory: {
+      head: directories[0] ?? "",
+      tail: `${directories.slice(-2).join("/")}/`
+    },
+    fullPath: normalized
+  };
 }
 
 function MentionFileIcon({

--- a/packages/ui/rich-text/src/at-panel/MentionRow.tsx
+++ b/packages/ui/rich-text/src/at-panel/MentionRow.tsx
@@ -1,55 +1,16 @@
-import {
-  ArrowLeftIcon,
-  ArrowRightIcon,
-  Badge,
-  FileCodeIcon,
-  FileTextIcon,
-  FolderIcon,
-  ImageFileIcon,
-  ProductIcon,
-  StatusDot,
-  VideoFileIcon,
-  cn,
-  type IconProps
-} from "@tutti-os/ui-system";
+import { Badge, StatusDot, cn } from "@tutti-os/ui-system";
 import { Fragment } from "react";
-import type { MentionFileVisualKind } from "./mentionFileVisualKind.ts";
+import { MentionFileRow } from "./MentionFileRow.tsx";
 import {
   mentionRowDataAttribute,
-  mentionRowRootDataAttributes,
   type MentionRowDataAttributeMode
 } from "./mentionRowDataAttributes.ts";
 import type {
-  MentionRowFileItem,
   MentionRowItem,
   MentionRowSessionItem,
   MentionRowStatusTag
 } from "./mentionRowTypes.ts";
 import { mentionStatusBadgeClassName } from "./mentionStatusTone.ts";
-
-/**
- * Default file kind-icon shapes for surfaces that do NOT ship the agent's
- * CSS-masked glyph stylesheet. These mirror the agent's mask glyph shapes
- * (`agentactivity.css`: folder-filled / doc-filled / code-filled / image-filled
- * / video-filled / arrow-left-filled) using ui-system icon components, so a
- * file row renders a real glyph without `agentactivity.css`. The agent composer
- * passes its own `fileIcon` class and keeps rendering masked `<span>` glyphs,
- * except `back` rows which always use {@link ArrowLeftIcon}.
- */
-const MENTION_FILE_VISUAL_KIND_ICON: Record<
-  MentionFileVisualKind,
-  (props: IconProps) => React.JSX.Element
-> = {
-  back: ArrowLeftIcon,
-  folder: FolderIcon,
-  document: FileTextIcon,
-  // The agent maps markdown to `product-filled.svg`; ProductIcon is the
-  // matching boundary-safe ui-system glyph.
-  markdown: ProductIcon,
-  code: FileCodeIcon,
-  image: ImageFileIcon,
-  video: VideoFileIcon
-};
 
 /**
  * Structural class-name hooks for the elements a {@link MentionRow} renders that
@@ -189,6 +150,9 @@ export function renderMentionRow(
         dataAttributeMode={dataAttributeMode}
         navigateIntoLabel={navigateIntoLabel}
         onNavigateInto={onNavigateInto}
+        usesDefaultFileIcon={
+          resolved.fileIcon === DEFAULT_MENTION_ROW_CLASS_NAMES.fileIcon
+        }
       />
     );
   }
@@ -324,270 +288,6 @@ function MentionOpenReferencesButton({
     >
       {resolvedLabel}
     </span>
-  );
-}
-
-function MentionNavigateIntoButton({
-  label,
-  onNavigateInto,
-  dataAttributeMode
-}: {
-  label?: string;
-  onNavigateInto: () => void;
-  dataAttributeMode: MentionRowDataAttributeMode;
-}): React.JSX.Element {
-  return (
-    <span
-      role="button"
-      tabIndex={-1}
-      aria-label={label}
-      title={label}
-      className="rich-text-at-mention-row__navigate-into"
-      {...mentionRowDataAttribute(dataAttributeMode, "navigateInto", "true")}
-      onMouseDown={(event) => {
-        event.preventDefault();
-        event.stopPropagation();
-      }}
-      onClick={(event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        onNavigateInto();
-      }}
-    >
-      <ArrowRightIcon size={16} />
-    </span>
-  );
-}
-
-function MentionFileRow({
-  item,
-  classNames,
-  dataAttributeMode,
-  navigateIntoLabel,
-  onNavigateInto
-}: {
-  item: MentionRowFileItem;
-  classNames: Required<MentionRowClassNames>;
-  dataAttributeMode: MentionRowDataAttributeMode;
-  navigateIntoLabel?: string;
-  onNavigateInto?: () => void;
-}): React.JSX.Element {
-  const pathPresentation = mentionFilePathPresentation(
-    item.relativePath,
-    item.name
-  );
-  return (
-    <span
-      className="rich-text-at-mention-row rich-text-at-mention-row--file"
-      {...mentionRowRootDataAttributes(dataAttributeMode, "file")}
-      {...(item.entryKind
-        ? mentionRowDataAttribute(
-            dataAttributeMode,
-            "fileEntryKind",
-            item.entryKind
-          )
-        : {})}
-      {...mentionRowDataAttribute(
-        dataAttributeMode,
-        "fileVisualKind",
-        item.visualKind
-      )}
-      {...(item.mentionNavigation
-        ? mentionRowDataAttribute(
-            dataAttributeMode,
-            "navigation",
-            item.mentionNavigation
-          )
-        : {})}
-    >
-      <MentionFileIcon
-        item={item}
-        classNames={classNames}
-        dataAttributeMode={dataAttributeMode}
-      />
-      <span
-        className="rich-text-at-mention-row__file-text"
-        title={pathPresentation?.fullPath}
-      >
-        {pathPresentation?.directory ? (
-          <MentionFileDirectory presentation={pathPresentation.directory} />
-        ) : null}
-        <span className="rich-text-at-mention-row__file-name">{item.name}</span>
-      </span>
-      {item.childCountLabel ? (
-        <span className="rich-text-at-mention-row__file-count">
-          {item.childCountLabel}
-        </span>
-      ) : null}
-      {onNavigateInto ? (
-        <MentionNavigateIntoButton
-          label={navigateIntoLabel}
-          onNavigateInto={onNavigateInto}
-          dataAttributeMode={dataAttributeMode}
-        />
-      ) : null}
-    </span>
-  );
-}
-
-interface MentionFileDirectoryPresentation {
-  head: string;
-  tail: string | null;
-}
-
-function MentionFileDirectory({
-  presentation
-}: {
-  presentation: MentionFileDirectoryPresentation;
-}): React.JSX.Element {
-  if (!presentation.tail) {
-    return (
-      <span className="rich-text-at-mention-row__file-directory">
-        {presentation.head}
-      </span>
-    );
-  }
-  return (
-    <span className="rich-text-at-mention-row__file-directory rich-text-at-mention-row__file-directory--condensed">
-      <span className="rich-text-at-mention-row__file-directory-head">
-        {presentation.head}
-      </span>
-      <span className="rich-text-at-mention-row__file-directory-middle">
-        /…/
-      </span>
-      <span className="rich-text-at-mention-row__file-directory-tail">
-        {presentation.tail}
-      </span>
-    </span>
-  );
-}
-
-function mentionFilePathPresentation(
-  relativePath: string | null | undefined,
-  fileName: string
-): {
-  directory: MentionFileDirectoryPresentation | null;
-  fullPath: string;
-} | null {
-  const normalized = relativePath
-    ?.trim()
-    .replace(/\\/g, "/")
-    .replace(/^\.\/+/, "")
-    .replace(/\/{2,}/g, "/")
-    .replace(/\/+$/, "");
-  if (!normalized) {
-    return null;
-  }
-  const segments = normalized.split("/").filter(Boolean);
-  if (segments.at(-1) !== fileName) {
-    return null;
-  }
-  const directories = segments.slice(0, -1);
-  if (directories.length === 0) {
-    return { directory: null, fullPath: normalized };
-  }
-  if (directories.length <= 3) {
-    return {
-      directory: { head: `${directories.join("/")}/`, tail: null },
-      fullPath: normalized
-    };
-  }
-  return {
-    directory: {
-      head: directories[0] ?? "",
-      tail: `${directories.slice(-2).join("/")}/`
-    },
-    fullPath: normalized
-  };
-}
-
-function MentionFileIcon({
-  item,
-  classNames,
-  dataAttributeMode
-}: {
-  item: MentionRowFileItem;
-  classNames: Required<MentionRowClassNames>;
-  dataAttributeMode: MentionRowDataAttributeMode;
-}): React.JSX.Element {
-  const thumbnailUrl =
-    item.visualKind === "image" ? item.thumbnailUrl?.trim() || "" : "";
-  if (thumbnailUrl) {
-    return (
-      <span
-        className={classNames.fileThumb}
-        {...mentionRowDataAttribute(dataAttributeMode, "fileThumb", "true")}
-        aria-hidden="true"
-      >
-        <img
-          src={thumbnailUrl}
-          alt=""
-          className="rich-text-at-mention-row__media"
-          decoding="async"
-          loading="lazy"
-          draggable={false}
-        />
-      </span>
-    );
-  }
-
-  // Back navigation always renders the ui-system back glyph so every surface
-  // (including the agent composer's CSS-masked file icons) shares one source.
-  if (item.visualKind === "back") {
-    return (
-      <span
-        className={cn(
-          classNames.fileIcon,
-          "rich-text-at-mention-file-icon--glyph"
-        )}
-        {...mentionRowDataAttribute(
-          dataAttributeMode,
-          "fileVisualKind",
-          item.visualKind
-        )}
-        aria-hidden="true"
-      >
-        <ArrowLeftIcon size={16} />
-      </span>
-    );
-  }
-
-  // Surfaces that ship a custom file-icon stylesheet (e.g. the agent composer
-  // via `agentactivity.css`) render the empty CSS-masked `<span>` so their DOM
-  // stays byte-identical. Surfaces using the package default class have no such
-  // stylesheet, so render a real ui-system kind glyph instead of an empty box.
-  const usesDefaultFileIcon =
-    classNames.fileIcon === DEFAULT_MENTION_ROW_CLASS_NAMES.fileIcon;
-  if (usesDefaultFileIcon) {
-    const Icon = MENTION_FILE_VISUAL_KIND_ICON[item.visualKind];
-    return (
-      <span
-        className={cn(
-          classNames.fileIcon,
-          "rich-text-at-mention-file-icon--glyph"
-        )}
-        {...mentionRowDataAttribute(
-          dataAttributeMode,
-          "fileVisualKind",
-          item.visualKind
-        )}
-        aria-hidden="true"
-      >
-        <Icon size={16} />
-      </span>
-    );
-  }
-
-  return (
-    <span
-      className={classNames.fileIcon}
-      {...mentionRowDataAttribute(
-        dataAttributeMode,
-        "fileVisualKind",
-        item.visualKind
-      )}
-      aria-hidden="true"
-    />
   );
 }
 

--- a/packages/ui/rich-text/src/at-panel/mentionPalette.css
+++ b/packages/ui/rich-text/src/at-panel/mentionPalette.css
@@ -661,6 +661,47 @@
 
 .rich-text-at-mention-row__file-text {
   flex: 1 1 0;
+  gap: 0;
+}
+
+.rich-text-at-mention-row__file-directory,
+.rich-text-at-mention-row__file-directory-head,
+.rich-text-at-mention-row__file-directory-tail,
+.rich-text-at-mention-row__file-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rich-text-at-mention-row__file-directory {
+  flex: 0 1 auto;
+  color: var(--rich-text-at-mention-text-secondary);
+  font-size: 13px;
+  font-weight: 400;
+}
+
+.rich-text-at-mention-row__file-directory--condensed {
+  display: flex;
+}
+
+.rich-text-at-mention-row__file-directory-head {
+  flex: 1 1 auto;
+}
+
+.rich-text-at-mention-row__file-directory-middle {
+  flex: 0 0 auto;
+}
+
+.rich-text-at-mention-row__file-directory-tail {
+  flex: 0 1 auto;
+}
+
+.rich-text-at-mention-row__file-name {
+  flex: 0 0 auto;
+  color: var(--rich-text-at-mention-text-primary);
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .rich-text-at-mention-row__app-text,

--- a/packages/ui/rich-text/src/at-panel/mentionPalette.css
+++ b/packages/ui/rich-text/src/at-panel/mentionPalette.css
@@ -699,6 +699,7 @@
 
 .rich-text-at-mention-row__file-name {
   flex: 0 0 auto;
+  max-width: 100%;
   color: var(--rich-text-at-mention-text-primary);
   font-size: 13px;
   font-weight: 600;

--- a/packages/ui/rich-text/src/at-panel/mentionRowTypes.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionRowTypes.ts
@@ -28,6 +28,8 @@ export interface MentionRowFileItem {
   name: string;
   /** Safe source-relative path used for candidate disambiguation and its title. */
   relativePath?: string | null;
+  /** Number of leading directory segments needed to distinguish sibling rows. */
+  disambiguationPrefixSegments?: number | null;
   visualKind: MentionFileVisualKind;
   thumbnailUrl?: string | null;
   childCountLabel?: string | null;

--- a/packages/ui/rich-text/src/at-panel/mentionRowTypes.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionRowTypes.ts
@@ -26,6 +26,8 @@ export interface MentionRowStatusTag {
 export interface MentionRowFileItem {
   kind: "file";
   name: string;
+  /** Safe source-relative path used for candidate disambiguation and its title. */
+  relativePath?: string | null;
   visualKind: MentionFileVisualKind;
   thumbnailUrl?: string | null;
   childCountLabel?: string | null;


### PR DESCRIPTION
## Summary

- 为文件 mention 增加安全的来源相对路径展示，用于区分同名候选项，不改变选择 identity、href、插入路径或 Markdown 序列化
- 同名文件的路径前缀会基于所有当前可见文件组统一计算；即使搜索时隐藏“已打开文件”和“Agent 生成文件”标题，候选项仍可辨识
- Desktop Agent 生成文件仅在可信 `sessionCwd` 或 `project:<root>` 内展示相对路径；缺少可信根目录或文件位于根目录外时严格退回 basename，避免泄露绝对主机路径
- 短路径直接显示，长路径从中间省略并保留完整文件名；将文件行拆分为独立组件，相关业务文件均保持在 800 行以内
- 补充跨组同名、隐藏中段碰撞、不安全 URI/Windows 路径、Agent 生成文件隐私边界及选择行为不变的测试

Closes #1271

## Root Cause

Desktop provider 已经通过 subtitle 提供文件路径上下文，但 AgentGUI 在将 provider 结果投影为 mention row 时丢弃了这部分信息。因此，即使同名候选项对应不同路径，界面上仍只显示相同的 basename。路径展示还需要同时满足两项约束：跨文件分组统一辨识，以及任何情况下都不能把绝对主机路径当成相对展示数据。

## Verification

- `pnpm check:changed`：18 个 lane 全部通过
- pre-push `pnpm check:changed -- --push-ready`：19 个 lane 全部通过
- AgentGUI 聚焦测试：2 个文件、32 项全部通过
- Desktop generated-file provider：2 项测试全部通过
- `@tutti-os/ui-rich-text`、`@tutti-os/agent-gui`、`@tutti-os/desktop` typecheck 全部通过
- correctness subagent 最终复审：no actionable findings
- 使用 Computer Use 在 `make dev-gui` 启动的真实 Electron 应用中验证：
  - 多个 `README.md` 结果显示不同的安全相对路径前缀
  - 搜索态不依赖文件分组标题，长路径中间省略且文件名保持完整
  - 使用 ArrowDown + Enter 可以插入当前高亮的文件候选项

## Screenshots

### 同名文件显示不同的相对路径前缀

![多个同名 README 文件显示不同的相对路径前缀](https://github.com/user-attachments/assets/bfd82064-fa91-4dfe-a055-328e6efcab8e)

### 长路径中间省略并保留完整文件名

![长路径中间省略并保留完整文件名](https://github.com/user-attachments/assets/8a374146-ca43-401d-b540-ab11dfeaf8bb)

## Documentation Impact

已更新 `packages/ui/rich-text/README.md`，记录 `MentionRowFileItem.relativePath` 与 `disambiguationPrefixSegments` 的公共展示契约、安全约束，以及它们不影响选择和序列化语义的边界。此次修改不改变模块职责、公共 API/CLI、运行时配置或排障流程，无需更新其他持久文档。

## Checklist

- [x] 本次修改不定义或改变 Agent lifecycle 语义
- [x] 修改范围只聚焦于文件 mention 路径辨识与安全展示
- [x] 已完成文档影响检查并更新对应 package README
- [x] 已运行适用于本次改动的本地检查与真实 Electron 验证
- [x] commit 已包含 DCO sign-off
