### PR TITLE
feat(desktop): refine settings & browser chrome UI styling

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentEditor.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentEditor.tsx
@@ -19,17 +19,10 @@ import type {
   WorkspaceAgentHarnessTargetOption,
   WorkspaceModelPlan
 } from "../services/workspaceSettingsTypes";
-import {
-  workspaceSettingsInputClass,
-  workspaceSettingsSelectContentClass,
-  workspaceSettingsSelectTriggerClass
-} from "./workspaceSettingsFieldStyles";
 
 const NO_HARNESS_VALUE = "__no_harness__";
 const NO_PLAN_VALUE = "__no_plan__";
 const PLAN_DEFAULT_MODEL_VALUE = "__plan_default__";
-const textareaClass =
-  "min-h-[88px] resize-y border-[var(--border-1)] bg-[var(--transparency-block)] text-[13px] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] hover:bg-[var(--transparency-hover)] focus-visible:border-[var(--border-focus)] focus-visible:ring-0";
 
 /**
  * Simplified Agent editor: name, Agent Runtime, model plan + default model,
@@ -92,7 +85,7 @@ export function WorkspaceAgentEditor({
   const editing = draft.agentId !== null;
 
   return (
-    <section className="flex w-full flex-col gap-4 rounded-[10px] border border-[var(--border-1)] bg-[var(--transparency-block)] p-4">
+    <section className="flex w-full flex-col gap-4 rounded-[6px] border border-[var(--border-1)] bg-[var(--transparency-block)] p-4">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <strong className="text-[13px] font-semibold text-[var(--text-primary)]">
@@ -123,7 +116,6 @@ export function WorkspaceAgentEditor({
             {t("workspace.settings.apps.agents.nameLabel")}
           </span>
           <Input
-            className={workspaceSettingsInputClass}
             placeholder={t("workspace.settings.apps.agents.namePlaceholder")}
             type="text"
             value={draft.name}
@@ -150,14 +142,11 @@ export function WorkspaceAgentEditor({
           >
             <SelectTrigger
               aria-label={t("workspace.settings.apps.agents.harnessLabel")}
-              className={workspaceSettingsSelectTriggerClass}
+              className="w-full rounded-[6px]"
             >
               <SelectValue />
             </SelectTrigger>
-            <SelectContent
-              className={workspaceSettingsSelectContentClass}
-              style={{ zIndex: "var(--z-panel-popover)" }}
-            >
+            <SelectContent style={{ zIndex: "var(--z-panel-popover)" }}>
               {harnessOptions.length === 0 ? (
                 <SelectItem disabled value={NO_HARNESS_VALUE}>
                   {t("workspace.settings.apps.agents.noHarnesses")}
@@ -190,14 +179,11 @@ export function WorkspaceAgentEditor({
           >
             <SelectTrigger
               aria-label={t("workspace.settings.apps.agents.modelPlanLabel")}
-              className={workspaceSettingsSelectTriggerClass}
+              className="w-full rounded-[6px]"
             >
               <SelectValue />
             </SelectTrigger>
-            <SelectContent
-              className={workspaceSettingsSelectContentClass}
-              style={{ zIndex: "var(--z-panel-popover)" }}
-            >
+            <SelectContent style={{ zIndex: "var(--z-panel-popover)" }}>
               <SelectItem value={NO_PLAN_VALUE}>
                 {t("workspace.settings.apps.agents.noModelPlan")}
               </SelectItem>
@@ -231,14 +217,11 @@ export function WorkspaceAgentEditor({
           >
             <SelectTrigger
               aria-label={t("workspace.settings.apps.agents.defaultModelLabel")}
-              className={workspaceSettingsSelectTriggerClass}
+              className="w-full rounded-[6px]"
             >
               <SelectValue />
             </SelectTrigger>
-            <SelectContent
-              className={workspaceSettingsSelectContentClass}
-              style={{ zIndex: "var(--z-panel-popover)" }}
-            >
+            <SelectContent style={{ zIndex: "var(--z-panel-popover)" }}>
               <SelectItem value={PLAN_DEFAULT_MODEL_VALUE}>
                 {t("workspace.settings.apps.agents.planDefaultModel")}
               </SelectItem>
@@ -257,7 +240,6 @@ export function WorkspaceAgentEditor({
           {t("workspace.settings.apps.agents.descriptionLabel")}
         </span>
         <Input
-          className={workspaceSettingsInputClass}
           placeholder={t(
             "workspace.settings.apps.agents.descriptionPlaceholder"
           )}
@@ -269,50 +251,40 @@ export function WorkspaceAgentEditor({
         />
       </label>
 
-      <details
-        className="group rounded-[8px] border border-[var(--border-1)] p-3"
-        open
-      >
-        <summary className="cursor-pointer text-[11px] font-medium text-[var(--text-secondary)]">
-          {t("workspace.settings.apps.agents.behaviorDetailsTitle")}
-        </summary>
-        <div className="mt-3 grid gap-3">
-          <label className="flex flex-col gap-1.5">
-            <span className="text-[11px] font-medium text-[var(--text-secondary)]">
-              {t("workspace.settings.apps.agents.instructionsLabel")}
-            </span>
-            <Textarea
-              className={textareaClass}
-              placeholder={t(
-                "workspace.settings.apps.agents.instructionsPlaceholder"
-              )}
-              value={draft.instructions}
-              onChange={(event) =>
-                onUpdate({ instructions: event.currentTarget.value })
-              }
-            />
-          </label>
+      <div className="grid gap-3">
+        <label className="flex flex-col gap-1.5">
+          <span className="text-[11px] font-medium text-[var(--text-secondary)]">
+            {t("workspace.settings.apps.agents.instructionsLabel")}
+          </span>
+          <Textarea
+            placeholder={t(
+              "workspace.settings.apps.agents.instructionsPlaceholder"
+            )}
+            value={draft.instructions}
+            onChange={(event) =>
+              onUpdate({ instructions: event.currentTarget.value })
+            }
+          />
+        </label>
 
-          <label className="flex flex-col gap-1.5">
-            <span className="text-[11px] font-medium text-[var(--text-secondary)]">
-              {t("workspace.settings.apps.agents.callConditionsLabel")}
-            </span>
-            <Textarea
-              className={textareaClass}
-              placeholder={t(
-                "workspace.settings.apps.agents.callConditionsPlaceholder"
-              )}
-              value={draft.callConditions}
-              onChange={(event) =>
-                onUpdate({ callConditions: event.currentTarget.value })
-              }
-            />
-            <span className="text-[10px] leading-[1.3] text-[var(--text-tertiary)]">
-              {t("workspace.settings.apps.agents.onePerLine")}
-            </span>
-          </label>
-        </div>
-      </details>
+        <label className="flex flex-col gap-1.5">
+          <span className="text-[11px] font-medium text-[var(--text-secondary)]">
+            {t("workspace.settings.apps.agents.callConditionsLabel")}
+          </span>
+          <Textarea
+            placeholder={t(
+              "workspace.settings.apps.agents.callConditionsPlaceholder"
+            )}
+            value={draft.callConditions}
+            onChange={(event) =>
+              onUpdate({ callConditions: event.currentTarget.value })
+            }
+          />
+          <span className="text-[10px] leading-[1.3] text-[var(--text-tertiary)]">
+            {t("workspace.settings.apps.agents.onePerLine")}
+          </span>
+        </label>
+      </div>
 
       <div className="flex items-center justify-end gap-2">
         <Button type="button" variant="ghost" onClick={onCancel}>

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentsSettingsTab.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentsSettingsTab.tsx
@@ -392,11 +392,7 @@ export function WorkspaceAgentsSettingsTab({
   }
 
   return (
-    <div
-      className="pb-[22px]"
-      data-testid="workspace-settings-agents-list"
-      role="table"
-    >
+    <div className="pb-[22px]" data-testid="workspace-settings-agents-list">
       <div className="mb-3 flex flex-wrap items-center justify-between gap-3 rounded-lg bg-[var(--transparency-block)] px-3 py-2.5">
         <div className="flex min-w-0 items-center gap-2.5">
           <Switch
@@ -431,227 +427,249 @@ export function WorkspaceAgentsSettingsTab({
         </Button>
       </div>
       <div
-        className={cn(
-          agentsTableColumnsClass,
-          "items-center border-b border-[var(--border-1)] px-2 pb-2 text-[12px] font-medium text-[var(--text-tertiary)]"
-        )}
-        role="row"
+        className="overflow-hidden rounded-[12px] border border-[var(--line-1)]"
+        role="table"
       >
-        <div role="columnheader">
-          {t("workspace.workbenchDesktop.agentProviders.manageColumnAgent")}
+        <div
+          className={cn(
+            agentsTableColumnsClass,
+            "items-center border-b border-[var(--border-1)] px-2 pb-2 text-[12px] font-medium text-[var(--text-tertiary)]"
+          )}
+          role="row"
+        >
+          <div role="columnheader">
+            {t("workspace.workbenchDesktop.agentProviders.manageColumnAgent")}
+          </div>
+          <div className="max-[560px]:hidden" role="columnheader">
+            {t("workspace.settings.agent.agents.environmentColumn")}
+          </div>
+          <div className="text-right" role="columnheader">
+            {t("workspace.settings.agent.agents.enabledColumn")}
+          </div>
         </div>
-        <div className="max-[560px]:hidden" role="columnheader">
-          {t("workspace.settings.agent.agents.environmentColumn")}
-        </div>
-        <div className="text-right" role="columnheader">
-          {t("workspace.settings.agent.agents.enabledColumn")}
-        </div>
-      </div>
-      <div role="rowgroup">
-        {visibleProviders.map((provider) => {
-          const row = rowByProvider.get(provider);
-          const status = row?.status ?? "unknown";
-          const label = resolveWorkspaceAgentGuiLabel(provider);
-          const targetID = agentTargetId(provider);
-          const agentTarget = targetID ? agentTargetByID.get(targetID) : null;
-          const iconUrl = resolveAgentSettingsIconUrl(provider, agentTarget);
-          const agentEnabled = agentTarget?.enabled ?? false;
-          const agentEnabledPending = targetID
-            ? pendingAgentTargetIDs.has(targetID)
-            : false;
-          const isEarlyAccess =
-            isWorkspaceAgentGuiEarlyAccessProvider(provider);
-          const environmentLabel = t("workspace.agentEnv.configTitle", {
-            provider: label
-          });
-          const providerStatus = snapshot.statuses.find(
-            (item) => item.provider === provider
-          );
-          const updatePresentation =
-            resolveAgentProviderUpdateRowPresentation(providerStatus);
-          const updateSummary = formatAgentProviderUpdateSummary({
-            checkFailed: updatePresentation.checkFailed,
-            currentVersion: updatePresentation.currentVersion,
-            latestVersion: updatePresentation.latestVersion,
-            t,
-            updateAvailable: updatePresentation.updateAvailable
-          });
-          return (
-            <div
-              key={provider}
-              ref={(element) => {
-                if (element) {
-                  rowRefs.current.set(provider, element);
-                } else {
-                  rowRefs.current.delete(provider);
-                }
-              }}
-              className={cn(
-                agentsTableColumnsClass,
-                "items-center border-b border-[var(--border-1)] px-2 py-2.5 text-[13px] transition-colors duration-150 last:border-b-0",
-                highlightedProvider === provider
-                  ? "bg-[var(--transparency-block)]"
-                  : "bg-transparent"
-              )}
-              data-agent-provider={provider}
-              role="row"
-            >
-              <div className="flex min-w-0 items-center gap-2.5" role="cell">
-                {iconUrl ? (
-                  <img
-                    alt=""
-                    aria-hidden="true"
-                    className="size-7 shrink-0 rounded-[6px]"
-                    src={iconUrl}
-                  />
-                ) : (
-                  <span className="size-7 shrink-0 rounded-[6px] bg-[var(--transparency-block)]" />
+        <div role="rowgroup">
+          {visibleProviders.map((provider) => {
+            const row = rowByProvider.get(provider);
+            const status = row?.status ?? "unknown";
+            const label = resolveWorkspaceAgentGuiLabel(provider);
+            const targetID = agentTargetId(provider);
+            const agentTarget = targetID ? agentTargetByID.get(targetID) : null;
+            const iconUrl = resolveAgentSettingsIconUrl(provider, agentTarget);
+            const agentEnabled = agentTarget?.enabled ?? false;
+            const agentEnabledPending = targetID
+              ? pendingAgentTargetIDs.has(targetID)
+              : false;
+            const isEarlyAccess =
+              isWorkspaceAgentGuiEarlyAccessProvider(provider);
+            const environmentLabel = t("workspace.agentEnv.configTitle", {
+              provider: label
+            });
+            const providerStatus = snapshot.statuses.find(
+              (item) => item.provider === provider
+            );
+            const updatePresentation =
+              resolveAgentProviderUpdateRowPresentation(providerStatus);
+            const updateSummary = formatAgentProviderUpdateSummary({
+              checkFailed: updatePresentation.checkFailed,
+              currentVersion: updatePresentation.currentVersion,
+              latestVersion: updatePresentation.latestVersion,
+              t,
+              updateAvailable: updatePresentation.updateAvailable
+            });
+            return (
+              <div
+                key={provider}
+                ref={(element) => {
+                  if (element) {
+                    rowRefs.current.set(provider, element);
+                  } else {
+                    rowRefs.current.delete(provider);
+                  }
+                }}
+                className={cn(
+                  agentsTableColumnsClass,
+                  "items-center border-b border-[var(--border-1)] px-2 py-2.5 text-[13px] transition-colors duration-150 last:border-b-0",
+                  highlightedProvider === provider
+                    ? "bg-[var(--transparency-block)]"
+                    : "bg-transparent"
                 )}
-                <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                  <span className="flex min-w-0 items-center gap-2">
-                    <span className="truncate font-semibold text-[var(--text-primary)]">
-                      {label}
+                data-agent-provider={provider}
+                role="row"
+              >
+                <div className="flex min-w-0 items-center gap-2.5" role="cell">
+                  {iconUrl ? (
+                    <img
+                      alt=""
+                      aria-hidden="true"
+                      className="size-7 shrink-0 rounded-[6px]"
+                      src={iconUrl}
+                    />
+                  ) : (
+                    <span className="size-7 shrink-0 rounded-[6px] bg-[var(--transparency-block)]" />
+                  )}
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="flex min-w-0 items-center gap-2">
+                      <span className="truncate font-semibold text-[var(--text-primary)]">
+                        {label}
+                      </span>
+                      {isEarlyAccess ? (
+                        <span className="shrink-0 rounded-full border border-[var(--border-1)] px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none text-[var(--text-secondary)]">
+                          {t(
+                            "workspace.settings.agent.agents.earlyAccessBadge"
+                          )}
+                        </span>
+                      ) : null}
                     </span>
-                    {isEarlyAccess ? (
-                      <span className="shrink-0 rounded-full border border-[var(--border-1)] px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none text-[var(--text-secondary)]">
-                        {t("workspace.settings.agent.agents.earlyAccessBadge")}
+                    {updateSummary ? (
+                      <span
+                        className="truncate text-[11px] text-[var(--text-tertiary)]"
+                        data-testid={`workspace-settings-agents-update-summary-${provider}`}
+                      >
+                        {updateSummary}
                       </span>
                     ) : null}
+                    <AgentConnectionStatus
+                      className="hidden w-fit text-[11px] text-[var(--text-secondary)] max-[560px]:flex"
+                      environmentLabel={environmentLabel}
+                      label={t(statusLabelKeys[status])}
+                      status={status}
+                      onOpenEnvironment={() => onOpenEnvironment(provider)}
+                    />
                   </span>
-                  {updateSummary ? (
-                    <span
-                      className="truncate text-[11px] text-[var(--text-tertiary)]"
-                      data-testid={`workspace-settings-agents-update-summary-${provider}`}
-                    >
-                      {updateSummary}
-                    </span>
-                  ) : null}
+                </div>
+                <div
+                  className="flex min-w-0 items-center gap-1.5 max-[560px]:hidden"
+                  role="cell"
+                >
                   <AgentConnectionStatus
-                    className="hidden w-fit text-[11px] text-[var(--text-secondary)] max-[560px]:flex"
+                    className="flex"
                     environmentLabel={environmentLabel}
                     label={t(statusLabelKeys[status])}
                     status={status}
                     onOpenEnvironment={() => onOpenEnvironment(provider)}
                   />
-                </span>
-              </div>
-              <div
-                className="flex min-w-0 items-center gap-1.5 max-[560px]:hidden"
-                role="cell"
-              >
-                <AgentConnectionStatus
-                  className="flex"
-                  environmentLabel={environmentLabel}
-                  label={t(statusLabelKeys[status])}
-                  status={status}
-                  onOpenEnvironment={() => onOpenEnvironment(provider)}
-                />
-              </div>
-              <div className="flex items-center justify-end gap-2" role="cell">
-                <span className="text-[11px] text-[var(--text-secondary)]">
-                  {agentEnabled
-                    ? t("workspace.settings.agent.agents.enabled")
-                    : t("workspace.settings.agent.agents.disabled")}
-                </span>
-                <Switch
-                  aria-label={t("workspace.settings.agent.agents.enableAgent", {
-                    agent: label
-                  })}
-                  checked={agentEnabled}
-                  disabled={
-                    agentsSnapshot.status === "loading" ||
-                    !agentTarget ||
-                    agentEnabledPending
-                  }
-                  size="sm"
-                  onCheckedChange={(next) => {
-                    void toggleAgentEnabled(provider, next);
-                  }}
-                />
-              </div>
-            </div>
-          );
-        })}
-        {extensionRows.map((row) => {
-          const label = t(row.labelKey);
-          const environmentLabel = t("workspace.agentEnv.configTitle", {
-            provider: label
-          });
-          const statusLabel = row.enabled
-            ? row.status === "unknown"
-              ? t("workspace.settings.agent.agents.extensionPreparing")
-              : t(statusLabelKeys[row.status])
-            : t("workspace.settings.agent.agents.extensionEnableToSetUp");
-          return (
-            <div
-              key={row.key}
-              className={cn(
-                agentsTableColumnsClass,
-                "items-center border-b border-[var(--border-1)] px-2 py-2.5 text-[13px] last:border-b-0"
-              )}
-              data-agent-target={row.agentTargetId}
-              role="row"
-            >
-              <div className="flex min-w-0 items-center gap-2.5" role="cell">
-                {row.iconUrl ? (
-                  <img
-                    alt=""
-                    aria-hidden="true"
-                    className="size-7 shrink-0 rounded-[6px]"
-                    src={row.iconUrl}
-                  />
-                ) : (
-                  <span className="size-7 shrink-0 rounded-[6px] bg-[var(--transparency-block)]" />
-                )}
-                <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                  <span className="flex min-w-0 items-center gap-2">
-                    <span className="truncate font-semibold text-[var(--text-primary)]">
-                      {label}
-                    </span>
-                    <span className="shrink-0 rounded-full border border-[var(--border-1)] px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none text-[var(--text-secondary)]">
-                      {t("workspace.settings.agent.agents.earlyAccessBadge")}
-                    </span>
+                </div>
+                <div
+                  className="flex items-center justify-end gap-2"
+                  role="cell"
+                >
+                  <span className="text-[11px] text-[var(--text-secondary)]">
+                    {agentEnabled
+                      ? t("workspace.settings.agent.agents.enabled")
+                      : t("workspace.settings.agent.agents.disabled")}
                   </span>
+                  <Switch
+                    aria-label={t(
+                      "workspace.settings.agent.agents.enableAgent",
+                      {
+                        agent: label
+                      }
+                    )}
+                    checked={agentEnabled}
+                    disabled={
+                      agentsSnapshot.status === "loading" ||
+                      !agentTarget ||
+                      agentEnabledPending
+                    }
+                    size="sm"
+                    onCheckedChange={(next) => {
+                      void toggleAgentEnabled(provider, next);
+                    }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+          {extensionRows.map((row) => {
+            const label = t(row.labelKey);
+            const environmentLabel = t("workspace.agentEnv.configTitle", {
+              provider: label
+            });
+            const statusLabel = row.enabled
+              ? row.status === "unknown"
+                ? t("workspace.settings.agent.agents.extensionPreparing")
+                : t(statusLabelKeys[row.status])
+              : t("workspace.settings.agent.agents.extensionEnableToSetUp");
+            return (
+              <div
+                key={row.key}
+                className={cn(
+                  agentsTableColumnsClass,
+                  "items-center border-b border-[var(--border-1)] px-2 py-2.5 text-[13px] last:border-b-0"
+                )}
+                data-agent-target={row.agentTargetId}
+                role="row"
+              >
+                <div className="flex min-w-0 items-center gap-2.5" role="cell">
+                  {row.iconUrl ? (
+                    <img
+                      alt=""
+                      aria-hidden="true"
+                      className="size-7 shrink-0 rounded-[6px]"
+                      src={row.iconUrl}
+                    />
+                  ) : (
+                    <span className="size-7 shrink-0 rounded-[6px] bg-[var(--transparency-block)]" />
+                  )}
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="flex min-w-0 items-center gap-2">
+                      <span className="truncate font-semibold text-[var(--text-primary)]">
+                        {label}
+                      </span>
+                      <span className="shrink-0 rounded-full border border-[var(--border-1)] px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none text-[var(--text-secondary)]">
+                        {t("workspace.settings.agent.agents.earlyAccessBadge")}
+                      </span>
+                    </span>
+                    <AgentConnectionStatus
+                      className="hidden w-fit text-[11px] text-[var(--text-secondary)] max-[560px]:flex"
+                      environmentLabel={environmentLabel}
+                      label={statusLabel}
+                      status={row.status}
+                    />
+                  </span>
+                </div>
+                <div
+                  className="flex min-w-0 items-center gap-1.5 max-[560px]:hidden"
+                  role="cell"
+                >
                   <AgentConnectionStatus
-                    className="hidden w-fit text-[11px] text-[var(--text-secondary)] max-[560px]:flex"
+                    className="flex"
                     environmentLabel={environmentLabel}
                     label={statusLabel}
                     status={row.status}
                   />
-                </span>
+                </div>
+                <div
+                  className="flex items-center justify-end gap-2"
+                  role="cell"
+                >
+                  <span className="text-[11px] text-[var(--text-secondary)]">
+                    {row.enabled
+                      ? t("workspace.settings.agent.agents.enabled")
+                      : t("workspace.settings.agent.agents.disabled")}
+                  </span>
+                  <Switch
+                    aria-label={t(
+                      "workspace.settings.agent.agents.enableAgent",
+                      {
+                        agent: label
+                      }
+                    )}
+                    checked={row.enabled}
+                    disabled={featureFlagsPending}
+                    size="sm"
+                    onCheckedChange={(enabled) => {
+                      void onExtensionEnabledChange(
+                        row.activationFlag,
+                        enabled
+                      );
+                    }}
+                  />
+                </div>
               </div>
-              <div
-                className="flex min-w-0 items-center gap-1.5 max-[560px]:hidden"
-                role="cell"
-              >
-                <AgentConnectionStatus
-                  className="flex"
-                  environmentLabel={environmentLabel}
-                  label={statusLabel}
-                  status={row.status}
-                />
-              </div>
-              <div className="flex items-center justify-end gap-2" role="cell">
-                <span className="text-[11px] text-[var(--text-secondary)]">
-                  {row.enabled
-                    ? t("workspace.settings.agent.agents.enabled")
-                    : t("workspace.settings.agent.agents.disabled")}
-                </span>
-                <Switch
-                  aria-label={t("workspace.settings.agent.agents.enableAgent", {
-                    agent: label
-                  })}
-                  checked={row.enabled}
-                  disabled={featureFlagsPending}
-                  size="sm"
-                  onCheckedChange={(enabled) => {
-                    void onExtensionEnabledChange(row.activationFlag, enabled);
-                  }}
-                />
-              </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceDeveloperSettingsSection.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceDeveloperSettingsSection.tsx
@@ -594,15 +594,20 @@ export function WorkspaceDeveloperSettingsSection() {
               <Button
                 variant="secondary"
                 type="button"
+                className="group"
                 disabled={developerLogs.exporting}
               >
                 {developerLogs.exporting
                   ? t("workspace.settings.developer.exportingLogs")
                   : t("workspace.settings.developer.exportLogs")}
-                <ChevronDownIcon className="size-3.5" />
+                <ChevronDownIcon className="size-3.5 transition-transform duration-200 group-data-[state=open]:rotate-180" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-64">
+            <DropdownMenuContent
+              align="end"
+              className="w-64"
+              style={{ zIndex: "var(--z-panel-popover)" }}
+            >
               <DropdownMenuItem
                 onSelect={() =>
                   onExportLogs({
@@ -717,7 +722,7 @@ function AppCatalogChannelControl({
               className={cn(
                 "min-w-[92px] rounded-[5px] border-0 px-3 text-[13px] font-semibold leading-none outline-none transition-colors duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--border-focus)]",
                 selected
-                  ? "bg-[var(--background-fronted)] text-[var(--text-primary)] shadow-none"
+                  ? "bg-[var(--background-board-card)] text-[var(--text-primary)] shadow-none"
                   : "bg-transparent text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
               )}
               disabled={changingAppCatalogChannel !== null}
@@ -780,7 +785,7 @@ function ReleaseChannelControl({
               className={cn(
                 "min-w-[92px] rounded-[5px] border-0 px-3 text-[13px] font-semibold leading-none outline-none transition-colors duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--border-focus)]",
                 selected
-                  ? "bg-[var(--background-fronted)] text-[var(--text-primary)] shadow-none"
+                  ? "bg-[var(--background-board-card)] text-[var(--text-primary)] shadow-none"
                   : "bg-transparent text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
               )}
               disabled={changingUpdateChannel !== null}

--- a/packages/browser/workbench-node/src/react/BrowserNodeChrome.tsx
+++ b/packages/browser/workbench-node/src/react/BrowserNodeChrome.tsx
@@ -126,7 +126,7 @@ export function BrowserNodeChrome({
   return (
     <div
       className={cn(
-        "relative z-[1] flex h-[76px] min-h-[76px] flex-col overflow-visible bg-[var(--background-panel)]",
+        "relative z-[1] flex h-[76px] min-h-[76px] flex-col overflow-visible bg-[var(--background-fronted)]",
         withBorder ? "border-b border-border" : null,
         className
       )}
@@ -137,6 +137,7 @@ export function BrowserNodeChrome({
         {...restDragHandleProps}
         className={cn(
           "flex h-[38px] min-h-[38px] items-center gap-1.5 px-2 cursor-grab active:cursor-grabbing",
+          "bg-[var(--background-1)]",
           dragClassName
         )}
         data-browser-node-tab-strip="true"

--- a/packages/ui/system/src/styles/theme.css
+++ b/packages/ui/system/src/styles/theme.css
@@ -19,6 +19,7 @@
 
   --background: oklch(0.986 0.004 84);
   --background-panel: rgb(248 250 252);
+  --background-1: rgb(244 245 247);
   --background-session-flow: rgb(252 253 255);
   --background-session-sidepanel: rgb(244 245 247);
   --background-fronted: rgb(255 255 255 / 1);
@@ -208,6 +209,7 @@
 :root[data-theme="dark"] {
   --background: oklch(0.192 0.008 255);
   --background-panel: rgb(42 42 43);
+  --background-1: rgb(24 24 24);
   --background-session-flow: rgb(24 24 24);
   --background-session-sidepanel: rgb(42 42 43);
   --background-fronted: rgb(51 51 51 / 1);
@@ -387,6 +389,7 @@
   :root:not([data-theme="light"]) {
     --background: oklch(0.192 0.008 255);
     --background-panel: rgb(42 42 43);
+    --background-1: rgb(24 24 24);
     --background-session-flow: rgb(24 24 24);
     --background-session-sidepanel: rgb(42 42 43);
     --background-fronted: rgb(51 51 51 / 1);


### PR DESCRIPTION
## Summary

A set of UI styling refinements across settings panels, the browser node chrome, and the shared theme tokens.

### Changes

- **Agent runtime list** (`WorkspaceAgentsSettingsTab`): wrap the agent table (header + rows) in a `--line-1` bordered, 12px-radius card. The "Automatically check for updates" row stays outside the card.
- **WorkspaceAgentEditor**: flatten the behavior `<details>` block into a plain grid, switch selects to `rounded-[6px]`, and remove unused `workspaceSettings*` field-style helpers / `textareaClass`.
- **Developer settings** (`WorkspaceDeveloperSettingsSection`): add chevron rotate-on-open animation + z-index for the export-logs dropdown; use `--background-board-card` for app-catalog/release channel controls.
- **BrowserNodeChrome**: use `--background-fronted` for the chrome and `--background-1` for the tab strip.
- **theme.css**: introduce a `--background-1` token for light/dark/auto themes.

### Notes

- UI-only presentation changes; per the repo UI-only exception no test/build runs are required.
- DCO sign-off included.

🤖 Generated with [Tutti Agent](https://github.com/tutti-os)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->