### PR TITLE
fix(agent): align Tutti Agent runtime contract

### DIFF
--- a/packages/agent/daemon/providerregistry/providers.go
+++ b/packages/agent/daemon/providerregistry/providers.go
@@ -9,8 +9,8 @@ const (
 	CursorTargetID               = "local:cursor"
 	TuttiAgentProviderID         = canonical.TuttiAgentProviderID
 	TuttiAgentTargetID           = "local:tutti-agent"
-	TuttiAgentMinVersion         = "0.0.5"
-	TuttiAgentRecommendedVersion = "0.0.5"
+	TuttiAgentMinVersion         = "0.0.6"
+	TuttiAgentRecommendedVersion = "0.0.6"
 	NexightProviderID            = canonical.NexightProviderID
 	NexightTargetID              = "local:nexight"
 	OpenClawProviderID           = canonical.OpenClawProviderID
@@ -73,7 +73,7 @@ func tuttiAgentDescriptor() ProviderDescriptor {
 		ComposerProfile: ComposerProfileDescriptor{
 			ModelSelection: true, ModelCatalog: ModelCatalogKindTuttiCLI, ReasoningEffort: true, ReasoningEffortOptions: ReasoningEffortOptionsModelCatalog, DefaultReasoningEffort: "high", Speed: true,
 			SpeedValues: []string{"standard", "fast"}, DefaultSpeed: "standard",
-			Capabilities: []string{CapabilityImageInput, CapabilitySkills, CapabilityCompact, CapabilityTokenUsage, CapabilityRateLimits, CapabilityPlanMode, CapabilityInterrupt, CapabilityActiveTurnGuidance, CapabilityModelSwitch, CapabilityModelPlanBinding}, PermissionConfigurable: true, DefaultPermissionModeID: "auto",
+			Capabilities: []string{CapabilityImageInput, CapabilitySkills, CapabilityCompact, CapabilityTokenUsage, CapabilityPlanMode, CapabilityInterrupt, CapabilityActiveTurnGuidance, CapabilityModelSwitch, CapabilityModelPlanBinding}, PermissionConfigurable: true, DefaultPermissionModeID: "auto",
 			PermissionModes: []PermissionModeDescriptor{{ID: "read-only", Semantic: "ask-before-write"}, {ID: "auto", Semantic: "auto"}, {ID: "full-access", Semantic: "full-access"}}, ConfigOptionIDs: ComposerConfigOptionIDs{Model: "model", Reasoning: "reasoning_effort", Speed: "service_tier", Permission: "mode"},
 		},
 		Target:  TargetDescriptor{ID: TuttiAgentTargetID, LaunchRefType: TargetLaunchRefTypeLocalCLI, Enabled: false, SortOrder: 40},

--- a/packages/agent/daemon/providerregistry/providers.go
+++ b/packages/agent/daemon/providerregistry/providers.go
@@ -9,8 +9,8 @@ const (
 	CursorTargetID               = "local:cursor"
 	TuttiAgentProviderID         = canonical.TuttiAgentProviderID
 	TuttiAgentTargetID           = "local:tutti-agent"
-	TuttiAgentMinVersion         = "0.0.6"
-	TuttiAgentRecommendedVersion = "0.0.6"
+	TuttiAgentMinVersion         = "0.0.7"
+	TuttiAgentRecommendedVersion = "0.0.7"
 	NexightProviderID            = canonical.NexightProviderID
 	NexightTargetID              = "local:nexight"
 	OpenClawProviderID           = canonical.OpenClawProviderID

--- a/packages/agent/daemon/providerregistry/registry_test.go
+++ b/packages/agent/daemon/providerregistry/registry_test.go
@@ -60,6 +60,9 @@ func TestMigratedTuttiAgentDescriptorRequiresRefreshCapableVersion(t *testing.T)
 		!descriptor.Status.Install.IncludeOptional {
 		t.Fatalf("Status.Install = %#v", descriptor.Status.Install)
 	}
+	if slices.Contains(descriptor.ComposerProfile.Capabilities, CapabilityRateLimits) {
+		t.Fatal("Tutti Agent must not advertise ChatGPT rate limits")
+	}
 }
 
 func TestValidateRejectsInvalidMinimumVersionFloor(t *testing.T) {

--- a/packages/agent/daemon/runtime/acp_client.go
+++ b/packages/agent/daemon/runtime/acp_client.go
@@ -87,6 +87,9 @@ func (e *acpCallError) AuthRequired() bool {
 		return false
 	}
 	haystack := strings.ToLower(e.Err.Message + " " + string(e.Err.Data))
+	if structuredProviderFailureCode(haystack) != "" {
+		return false
+	}
 	return strings.Contains(haystack, "auth")
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -94,6 +94,7 @@ type appServerAdapterConfig struct {
 	clientInfoName       string
 	authRequiredMessage  string
 	commandNetworkAccess bool
+	rateLimits           bool
 }
 
 // CodexAppServerAdapterOptions controls host-owned app-server execution policy

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -5815,6 +5815,33 @@ func TestCodexAppServerAdapterStartRestoresGoal(t *testing.T) {
 	}
 }
 
+func TestTuttiAgentAppServerAdapterStartRestoresGoalWithoutMetadataFetch(t *testing.T) {
+	t.Parallel()
+
+	transport := newScriptedAppServerTransport()
+	adapter := NewTuttiAgentAppServerAdapterWithHostMetadata(transport, LegacyHostMetadata())
+	adapter.SetSessionEventSink(func(string, []activityshared.Event) {})
+	transport.conn.mu.Lock()
+	transport.conn.goal = map[string]any{
+		"threadId":  "codex-thread-1",
+		"objective": "finish it",
+		"status":    "active",
+	}
+	transport.conn.mu.Unlock()
+	session := testAppServerSession()
+	session.Provider = ProviderTuttiAgent
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForCondition(t, func() bool {
+		return asString(adapter.sessionGoal(session.AgentSessionID)["status"]) == "active"
+	})
+	goalGet := appServerRequestParams(t, transport.conn, appServerMethodThreadGoalGet)
+	if asString(goalGet["threadId"]) != "codex-thread-1" {
+		t.Fatalf("goal/get params = %#v", goalGet)
+	}
+}
+
 func TestCodexAppServerAdapterSlashGoalReadsCurrentGoal(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -5842,6 +5842,34 @@ func TestTuttiAgentAppServerAdapterStartRestoresGoalWithoutMetadataFetch(t *test
 	}
 }
 
+func TestTuttiAgentAppServerAdapterResumeRestoresGoalWithoutMetadataFetch(t *testing.T) {
+	t.Parallel()
+
+	transport := newScriptedAppServerTransport()
+	adapter := NewTuttiAgentAppServerAdapterWithHostMetadata(transport, LegacyHostMetadata())
+	adapter.SetSessionEventSink(func(string, []activityshared.Event) {})
+	transport.conn.mu.Lock()
+	transport.conn.goal = map[string]any{
+		"threadId":  "codex-thread-1",
+		"objective": "finish it",
+		"status":    "active",
+	}
+	transport.conn.mu.Unlock()
+	session := testAppServerSession()
+	session.Provider = ProviderTuttiAgent
+	session.ProviderSessionID = "codex-thread-1"
+	if err := adapter.Resume(context.Background(), session); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	waitForCondition(t, func() bool {
+		return asString(adapter.sessionGoal(session.AgentSessionID)["status"]) == "active"
+	})
+	goalGet := appServerRequestParams(t, transport.conn, appServerMethodThreadGoalGet)
+	if asString(goalGet["threadId"]) != "codex-thread-1" {
+		t.Fatalf("goal/get params = %#v", goalGet)
+	}
+}
+
 func TestCodexAppServerAdapterSlashGoalReadsCurrentGoal(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/codex_appserver_metadata.go
+++ b/packages/agent/daemon/runtime/codex_appserver_metadata.go
@@ -286,7 +286,7 @@ func (a *CodexAppServerAdapter) refreshStartupMetadataAsync(
 	fetchRateLimits bool,
 	trace *codexAppServerStartupTrace,
 ) {
-	if a == nil || (!fetchModels && !fetchRateLimits) {
+	if a == nil {
 		return
 	}
 	a.mu.Lock()

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -149,7 +149,7 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 		acpLiveState:           liveState,
 		pendingRequests:        make(map[string]*pendingInteractiveRequest),
 	})
-	a.refreshStartupMetadataAsync(session, threadResult, len(models) == 0, true, trace)
+	a.refreshStartupMetadataAsync(session, threadResult, len(models) == 0, a.config.rateLimits, trace)
 	a.emitCommandSnapshot(AgentSessionCommandSnapshot{
 		AgentSessionID: strings.TrimSpace(session.AgentSessionID),
 		Commands:       codexAppServerCommands(),
@@ -291,7 +291,7 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) (er
 		acpLiveState:           liveState,
 		pendingRequests:        make(map[string]*pendingInteractiveRequest),
 	})
-	a.refreshStartupMetadataAsync(session, threadResult, len(models) == 0, true, trace)
+	a.refreshStartupMetadataAsync(session, threadResult, len(models) == 0, a.config.rateLimits, trace)
 	// Mirror Start: push the command snapshot so a resumed session advertises
 	// review/compact/undo to the GUI (otherwise the slash palette and the
 	// review picker only work on freshly created sessions).

--- a/packages/agent/daemon/runtime/codex_appserver_settings.go
+++ b/packages/agent/daemon/runtime/codex_appserver_settings.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -51,10 +52,13 @@ func (a *CodexAppServerAdapter) SessionState(session Session) SessionStateSnapsh
 	if len(state.rateLimits) > 0 {
 		snapshot.RuntimeContext["rateLimits"] = state.rateLimits
 	}
-	snapshot.RuntimeContext["appServerStartup"] = map[string]any{
-		"models":     codexAppServerStartupStatus(state.startupModelsReady),
-		"rateLimits": codexAppServerStartupStatus(state.startupRateLimitsReady),
+	startup := map[string]any{
+		"models": codexAppServerStartupStatus(state.startupModelsReady),
 	}
+	if a.config.rateLimits {
+		startup["rateLimits"] = codexAppServerStartupStatus(state.startupRateLimitsReady)
+	}
+	snapshot.RuntimeContext["appServerStartup"] = startup
 	if len(state.goal) > 0 {
 		snapshot.RuntimeContext["goal"] = state.goal
 	}
@@ -83,6 +87,11 @@ func (a *CodexAppServerAdapter) SessionState(session Session) SessionStateSnapsh
 		snapshot.RuntimeContext["usage"] = usage
 	}
 	codexCapabilities := codexAppServerCapabilities(state.planModeSupported)
+	if !a.config.rateLimits {
+		codexCapabilities = slices.DeleteFunc(codexCapabilities, func(capability string) bool {
+			return capability == CapabilityRateLimits
+		})
+	}
 	codexCapabilities = appendBrowserUseCapability(codexCapabilities, session.Env)
 	codexCapabilities = appendComputerUseCapability(codexCapabilities, session.Env)
 	snapshot.RuntimeContext["capabilities"] = codexCapabilities

--- a/packages/agent/daemon/runtime/provider_descriptors.go
+++ b/packages/agent/daemon/runtime/provider_descriptors.go
@@ -50,6 +50,7 @@ func newAdapterFromProviderDescriptor(
 				command:             append([]string(nil), descriptor.Runtime.Command...),
 				clientInfoName:      descriptor.Runtime.ClientInfoName,
 				authRequiredMessage: descriptor.Runtime.AuthRequiredMessage,
+				rateLimits:          providerDescriptorHasCapability(descriptor, CapabilityRateLimits),
 			},
 			commandResolver,
 		)
@@ -73,6 +74,15 @@ func newAdapterFromProviderDescriptor(
 	default:
 		return nil
 	}
+}
+
+func providerDescriptorHasCapability(descriptor providerregistry.ProviderDescriptor, capability string) bool {
+	for _, candidate := range descriptor.ComposerProfile.Capabilities {
+		if candidate == capability {
+			return true
+		}
+	}
+	return false
 }
 
 func newStandardACPAdapterFromProviderDescriptor(

--- a/packages/agent/daemon/runtime/provider_descriptors_test.go
+++ b/packages/agent/daemon/runtime/provider_descriptors_test.go
@@ -75,6 +75,12 @@ func TestSharedAppServerAdapterKeepsTuttiAgentIdentity(t *testing.T) {
 	if serverInfo["name"] != "tutti-agent-app-server" || serverInfo["title"] != "Tutti Agent" {
 		t.Fatalf("server info = %#v, want Tutti Agent identity", serverInfo)
 	}
+	if adapter.config.rateLimits {
+		t.Fatal("Tutti Agent adapter must not probe ChatGPT rate limits")
+	}
+	if capabilities := adapter.SessionState(Session{AgentSessionID: "missing"}).RuntimeContext["capabilities"]; capabilities != nil {
+		t.Fatalf("empty session capabilities = %#v, want nil", capabilities)
+	}
 }
 
 func TestMigratedCodexDescriptorOwnsPermissionModes(t *testing.T) {

--- a/packages/agent/daemon/runtime/visible_error.go
+++ b/packages/agent/daemon/runtime/visible_error.go
@@ -195,18 +195,34 @@ func limitVisibleErrorDetail(value string) string {
 	return strings.TrimSpace(value[:maxDetailLength]) + "\n..."
 }
 
+func structuredProviderFailureCode(detail string) string {
+	normalized := strings.ToLower(detail)
+	for _, code := range []string{"insufficient_credits", "model_not_allowed", "no_biscuit_no_service"} {
+		if strings.Contains(normalized, code) {
+			return code
+		}
+	}
+	return ""
+}
+
 func visibleFailureCode(detail string) string {
 	normalized := strings.ToLower(detail)
+	structuredCode := structuredProviderFailureCode(normalized)
 	switch {
 	// Tutti billing failures are actionable account state, not a generic provider
 	// crash. Prefer the structured code emitted by llm-token-usage, while also
 	// recognizing the legacy 402 text already present in persisted conversations.
-	case strings.Contains(normalized, "insufficient_credits") ||
+	case structuredCode == "insufficient_credits" ||
 		strings.Contains(normalized, "insufficient credits") ||
 		(strings.Contains(normalized, "402 payment required") &&
 			(strings.Contains(normalized, "pre-deduct credits failed") ||
 				strings.Contains(normalized, "pre_deduct_failed"))):
 		return "insufficient_credits"
+	case structuredCode == "model_not_allowed":
+		return "model_not_allowed"
+	case structuredCode == "no_biscuit_no_service" &&
+		(strings.Contains(normalized, "codex_apps") || strings.Contains(normalized, "mcp")):
+		return "plugin_unavailable"
 	// A tool MCP server's OAuth failure (Notion/Figma/...) crashes codex's MCP
 	// client and bubbles up here mentioning "access token"/"AuthRequired", which
 	// trips the auth pattern. That is the MCP SERVER needing re-auth, not codex's
@@ -408,6 +424,10 @@ func visibleFailureContent(provider string, phase string, code string) string {
 		switch code {
 		case "insufficient_credits":
 			return "Tutti Agent could not start because your Tutti credits are insufficient."
+		case "model_not_allowed":
+			return fmt.Sprintf("%s could not start because the selected model is unavailable for this account.", name)
+		case "plugin_unavailable":
+			return fmt.Sprintf("%s started without an optional integration that is currently unavailable.", name)
 		case "auth_required":
 			return fmt.Sprintf("%s needs authentication or configuration.", name)
 		case "cli_not_found":
@@ -435,6 +455,10 @@ func visibleFailureContent(provider string, phase string, code string) string {
 	switch code {
 	case "insufficient_credits":
 		return "Tutti Agent could not continue because your Tutti credits are insufficient."
+	case "model_not_allowed":
+		return fmt.Sprintf("%s could not use the selected model. Choose another model and try again.", name)
+	case "plugin_unavailable":
+		return fmt.Sprintf("%s could not use an optional integration that is currently unavailable.", name)
 	case "auth_required":
 		return fmt.Sprintf("%s needs authentication or configuration.", name)
 	case "cli_not_found":

--- a/packages/agent/daemon/runtime/visible_error_test.go
+++ b/packages/agent/daemon/runtime/visible_error_test.go
@@ -168,6 +168,19 @@ func TestVisibleFailureContentDescribesTuttiInsufficientCredits(t *testing.T) {
 	}
 }
 
+func TestVisibleFailureCodeDoesNotMisclassifyStructuredProviderFailuresAsAuth(t *testing.T) {
+	tests := map[string]string{
+		`HTTP 403: {"error":{"code":"model_not_allowed","message":"authorization denied for model"}}`:                     "model_not_allowed",
+		`MCP client for codex_apps failed: HTTP 451: {"message":"no_biscuit_no_service"} authentication transport failed`: "plugin_unavailable",
+		`HTTP 451: {"message":"no_biscuit_no_service"} authentication transport failed`:                                   "provider_error",
+	}
+	for detail, want := range tests {
+		if got := visibleFailureCode(detail); got != want {
+			t.Fatalf("visibleFailureCode(%q) = %q, want %q", detail, got, want)
+		}
+	}
+}
+
 func TestVisibleFailureContentDescribesInterruptedSession(t *testing.T) {
 	got := visibleFailureContent(ProviderCodex, "turn", "session_interrupted")
 	want := "Codex stopped unexpectedly before it finished responding. Try again."

--- a/packages/agent/runtimeprep/preparer_test.go
+++ b/packages/agent/runtimeprep/preparer_test.go
@@ -1522,30 +1522,54 @@ func TestDefaultPreparerClaudePlanModeDoesNotOverrideConfigDir(t *testing.T) {
 	}
 }
 
-func TestTuttiAgentConfigWithLLMProviderPinsExistingRootProvider(t *testing.T) {
+func TestTuttiAgentManagedConfigRemovesOnlyLegacyPinnedProvider(t *testing.T) {
 	input := strings.Join([]string{
-		`model_provider = "custom"`,
-		`model = "custom-model"`,
+		`model_provider = "tutti-llm"`,
+		`model = "gpt-5.4"`,
+		`custom_root = "preserved"`,
+		``,
+		`[model_providers.tutti-llm]`,
+		`name = "Tutti LLM"`,
+		`base_url = "https://llm-api.tutti.sh/v1"`,
+		`wire_api = "responses"`,
 		``,
 		`[model_providers.custom]`,
 		`name = "Custom"`,
-		`base_url = "https://example.invalid/v1"`,
 	}, "\n")
 
-	next, changed := tuttiAgentConfigWithLLMProvider(input)
+	next, changed := tuttiAgentConfigWithoutLegacyPinnedProvider(input)
 	if !changed {
 		t.Fatalf("changed = false, want true")
 	}
-	if strings.Contains(next, `model_provider = "custom"`) {
-		t.Fatalf("next retained custom provider: %s", next)
+	for _, removed := range []string{`model_provider = "tutti-llm"`, `model = "gpt-5.4"`, `[model_providers.tutti-llm]`} {
+		if strings.Contains(next, removed) {
+			t.Fatalf("next retained %q: %s", removed, next)
+		}
 	}
-	if !strings.Contains(next, `model_provider = "tutti-llm"`) ||
-		!strings.Contains(next, `model = "gpt-5.4"`) ||
-		!strings.Contains(next, `[model_providers.tutti-llm]`) {
-		t.Fatalf("next did not pin Tutti LLM provider: %s", next)
+	for _, want := range []string{`custom_root = "preserved"`, `[model_providers.custom]`} {
+		if !strings.Contains(next, want) {
+			t.Fatalf("next removed %q: %s", want, next)
+		}
 	}
-	if !strings.Contains(next, `[model_providers.custom]`) {
-		t.Fatalf("next removed user provider block: %s", next)
+}
+
+func TestTuttiAgentManagedConfigPreservesPartialLegacyLookalike(t *testing.T) {
+	input := strings.Join([]string{
+		`model_provider = "tutti-llm"`,
+		`model = "gpt-5.4"`,
+		``,
+		`[model_providers.tutti-llm]`,
+		`name = "Custom Tutti Gateway"`,
+		`base_url = "https://llm-api.tutti.sh/v1"`,
+		`wire_api = "responses"`,
+	}, "\n")
+
+	next, changed := tuttiAgentConfigWithoutLegacyPinnedProvider(input)
+	if changed {
+		t.Fatalf("changed = true, want false: %s", next)
+	}
+	if next != input {
+		t.Fatalf("next changed partial legacy lookalike:\n%s", next)
 	}
 }
 

--- a/packages/agent/runtimeprep/preparer_test.go
+++ b/packages/agent/runtimeprep/preparer_test.go
@@ -1535,18 +1535,31 @@ func TestTuttiAgentManagedConfigRemovesOnlyLegacyPinnedProvider(t *testing.T) {
 		``,
 		`[model_providers.custom]`,
 		`name = "Custom"`,
+		``,
+		`[profiles.custom]`,
+		`model_provider = "tutti-llm"`,
+		`model = "gpt-5.4"`,
 	}, "\n")
 
 	next, changed := tuttiAgentConfigWithoutLegacyPinnedProvider(input)
 	if !changed {
 		t.Fatalf("changed = false, want true")
 	}
-	for _, removed := range []string{`model_provider = "tutti-llm"`, `model = "gpt-5.4"`, `[model_providers.tutti-llm]`} {
+	for _, removed := range []string{`[model_providers.tutti-llm]`} {
 		if strings.Contains(next, removed) {
 			t.Fatalf("next retained %q: %s", removed, next)
 		}
 	}
-	for _, want := range []string{`custom_root = "preserved"`, `[model_providers.custom]`} {
+	if !strings.HasPrefix(next, `custom_root = "preserved"`) {
+		t.Fatalf("next retained legacy root assignments: %s", next)
+	}
+	for _, want := range []string{
+		`custom_root = "preserved"`,
+		`[model_providers.custom]`,
+		`[profiles.custom]`,
+		`model_provider = "tutti-llm"`,
+		`model = "gpt-5.4"`,
+	} {
 		if !strings.Contains(next, want) {
 			t.Fatalf("next removed %q: %s", want, next)
 		}
@@ -1570,6 +1583,47 @@ func TestTuttiAgentManagedConfigPreservesPartialLegacyLookalike(t *testing.T) {
 	}
 	if next != input {
 		t.Fatalf("next changed partial legacy lookalike:\n%s", next)
+	}
+}
+
+func TestTuttiAgentManagedConfigPreservesCommentedLegacySignature(t *testing.T) {
+	input := strings.Join([]string{
+		`# model_provider = "tutti-llm"`,
+		`# model = "gpt-5.4"`,
+		``,
+		`[model_providers.tutti-llm]`,
+		`name = "Tutti LLM"`,
+		`base_url = "https://llm-api.tutti.sh/v1"`,
+		`wire_api = "responses"`,
+	}, "\n")
+
+	next, changed := tuttiAgentConfigWithoutLegacyPinnedProvider(input)
+	if changed {
+		t.Fatalf("changed = true, want false: %s", next)
+	}
+	if next != input {
+		t.Fatalf("next changed commented legacy lookalike:\n%s", next)
+	}
+}
+
+func TestTuttiAgentManagedConfigPreservesLegacyProviderWithExtraKey(t *testing.T) {
+	input := strings.Join([]string{
+		`model_provider = "tutti-llm"`,
+		`model = "gpt-5.4"`,
+		``,
+		`[model_providers.tutti-llm]`,
+		`name = "Tutti LLM"`,
+		`base_url = "https://llm-api.tutti.sh/v1"`,
+		`wire_api = "responses"`,
+		`http_headers = { X-Custom = "preserve" }`,
+	}, "\n")
+
+	next, changed := tuttiAgentConfigWithoutLegacyPinnedProvider(input)
+	if changed {
+		t.Fatalf("changed = true, want false: %s", next)
+	}
+	if next != input {
+		t.Fatalf("next changed customized legacy provider:\n%s", next)
 	}
 }
 

--- a/packages/agent/runtimeprep/tutti_agent.go
+++ b/packages/agent/runtimeprep/tutti_agent.go
@@ -5,14 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
-)
-
-const (
-	tuttiAgentLLMProviderID     = "tutti-llm"
-	tuttiAgentDefaultLLMBaseURL = "https://llm-api.tutti.sh/v1"
-	tuttiAgentDefaultModel      = "gpt-5.4"
 )
 
 // TuttiAgentPreparer materializes the session-scoped TUTTI_AGENT_HOME for the
@@ -74,8 +67,9 @@ func (p TuttiAgentPreparer) Prepare(ctx context.Context, input ProviderPrepareIn
 }
 
 // PrepareTuttiAgentHome materializes a TUTTI_AGENT_HOME with the user's auth
-// exposed and a session-safe config pinned to the Tutti LLM gateway. Session
-// Skills are installed only by TuttiAgentPreparer after capabilities resolve.
+// exposed and session-safe host policy. Provider and model selection remain
+// owned by tutti-agent and the per-session launch request. Session Skills are
+// installed only by TuttiAgentPreparer after capabilities resolve.
 func PrepareTuttiAgentHome(home string, input PrepareInput) error {
 	return prepareTuttiAgentHome(home, input, "", false)
 }
@@ -87,7 +81,7 @@ func prepareTuttiAgentHome(home string, input PrepareInput, authSource string, a
 	if err := exposeUserTuttiAgentFiles(home, authSource, authSourceConfigured); err != nil {
 		return err
 	}
-	return ensureTuttiAgentSessionConfig(filepath.Join(home, "config.toml"), input)
+	return ensureTuttiAgentSessionConfig(filepath.Join(home, "config.toml"), input, authSourceConfigured)
 }
 
 func exposeUserTuttiAgentFiles(home string, explicitAuthSource string, explicitAuthSourceConfigured bool) error {
@@ -145,7 +139,7 @@ func exposeTuttiAgentAuth(home string, source string, allowMissingSource bool) e
 	return nil
 }
 
-func ensureTuttiAgentSessionConfig(configPath string, input PrepareInput) error {
+func ensureTuttiAgentSessionConfig(configPath string, input PrepareInput, managedHome bool) error {
 	contentBytes, err := os.ReadFile(configPath)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("read tutti-agent config: %w", err)
@@ -159,9 +153,11 @@ func ensureTuttiAgentSessionConfig(configPath string, input PrepareInput) error 
 		next = detailModeNext
 		changed = true
 	}
-	if providerNext, providerChanged := tuttiAgentConfigWithLLMProvider(next); providerChanged {
-		next = providerNext
-		changed = true
+	if managedHome {
+		if cleaned, cleanedChanged := tuttiAgentConfigWithoutLegacyPinnedProvider(next); cleanedChanged {
+			next = cleaned
+			changed = true
+		}
 	}
 	if planNext, planChanged := codexConfigWithModelPlanEndpoint(next, input.ModelEndpoint); planChanged {
 		next = planNext
@@ -176,56 +172,50 @@ func ensureTuttiAgentSessionConfig(configPath string, input PrepareInput) error 
 	return nil
 }
 
-func tuttiAgentConfigWithLLMProvider(content string) (string, bool) {
-	changed := false
-	content, changed = tuttiAgentConfigWithRootValue(content, "model_provider", tuttiAgentLLMProviderID, changed)
-	content, changed = tuttiAgentConfigWithRootValue(content, "model", tuttiAgentDefaultModel, changed)
-	sectionHeader := "[model_providers." + tuttiAgentLLMProviderID + "]"
-	if !strings.Contains(content, sectionHeader) {
-		block := sectionHeader + "\n" +
-			`name = "Tutti LLM"` + "\n" +
-			`base_url = ` + strconv.Quote(tuttiAgentLLMBaseURL()) + "\n" +
-			`wire_api = "responses"` + "\n"
-		if strings.TrimSpace(content) == "" {
-			content = block
-		} else {
-			content = strings.TrimRight(content, "\r\n") + "\n\n" + block
-		}
-		changed = true
-	}
-	return content, changed
-}
-
-func tuttiAgentConfigWithRootValue(content string, key string, value string, changed bool) (string, bool) {
-	line := key + " = " + strconv.Quote(value)
+// tuttiAgentConfigWithoutLegacyPinnedProvider removes only the exact
+// host-generated provider signature shipped by older runtimeprep releases.
+// User-owned provider/model settings are otherwise preserved.
+func tuttiAgentConfigWithoutLegacyPinnedProvider(content string) (string, bool) {
 	normalized := strings.ReplaceAll(content, "\r\n", "\n")
+	for _, signature := range []string{
+		`model_provider = "tutti-llm"`,
+		`model = "gpt-5.4"`,
+		`[model_providers.tutti-llm]`,
+		`name = "Tutti LLM"`,
+		`base_url = "https://llm-api.tutti.sh/v1"`,
+		`wire_api = "responses"`,
+	} {
+		if !strings.Contains(normalized, signature) {
+			return content, false
+		}
+	}
+	if strings.Count(normalized, `[model_providers.tutti-llm]`) != 1 {
+		return content, false
+	}
 	lines := strings.Split(normalized, "\n")
-	for index, current := range lines {
-		trimmed := strings.TrimSpace(current)
-		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+	result := make([]string, 0, len(lines))
+	inLegacyProvider := false
+	changed := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			inLegacyProvider = trimmed == `[model_providers.tutti-llm]`
+			if inLegacyProvider {
+				changed = true
+				continue
+			}
+		}
+		if inLegacyProvider {
 			continue
 		}
-		if strings.HasPrefix(trimmed, "[") {
-			lines = append(lines[:index], append([]string{line}, lines[index:]...)...)
-			return strings.Join(lines, "\n"), true
+		if trimmed == `model_provider = "tutti-llm"` || trimmed == `model = "gpt-5.4"` {
+			changed = true
+			continue
 		}
-		if codexConfigLineHasKey(trimmed, key) {
-			if strings.TrimSpace(current) == line {
-				return content, changed
-			}
-			lines[index] = line
-			return strings.Join(lines, "\n"), true
-		}
+		result = append(result, line)
 	}
-	if strings.TrimSpace(content) == "" {
-		return line + "\n", true
+	if !changed {
+		return content, false
 	}
-	return line + "\n" + strings.TrimLeft(normalized, "\n"), true
-}
-
-func tuttiAgentLLMBaseURL() string {
-	if value := strings.TrimSpace(os.Getenv("TUTTI_AGENT_LLM_BASE_URL")); value != "" {
-		return value
-	}
-	return tuttiAgentDefaultLLMBaseURL
+	return strings.TrimSpace(strings.Join(result, "\n")) + "\n", true
 }

--- a/packages/agent/runtimeprep/tutti_agent.go
+++ b/packages/agent/runtimeprep/tutti_agent.go
@@ -175,45 +175,82 @@ func ensureTuttiAgentSessionConfig(configPath string, input PrepareInput) error 
 // User-owned provider/model settings are otherwise preserved.
 func tuttiAgentConfigWithoutLegacyPinnedProvider(content string) (string, bool) {
 	normalized := strings.ReplaceAll(content, "\r\n", "\n")
-	for _, signature := range []string{
-		`model_provider = "tutti-llm"`,
-		`model = "gpt-5.4"`,
-		`[model_providers.tutti-llm]`,
-		`name = "Tutti LLM"`,
-		`base_url = "https://llm-api.tutti.sh/v1"`,
-		`wire_api = "responses"`,
-	} {
-		if !strings.Contains(normalized, signature) {
+	lines := strings.Split(normalized, "\n")
+	rootProviderLine := -1
+	rootModelLine := -1
+	legacySectionStart := -1
+	legacySectionEnd := len(lines)
+	firstSection := len(lines)
+	for index, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			if firstSection == len(lines) {
+				firstSection = index
+			}
+			if trimmed == `[model_providers.tutti-llm]` {
+				if legacySectionStart >= 0 {
+					return content, false
+				}
+				legacySectionStart = index
+				continue
+			}
+			if legacySectionStart >= 0 && legacySectionEnd == len(lines) {
+				legacySectionEnd = index
+			}
+			continue
+		}
+		if index >= firstSection {
+			continue
+		}
+		switch trimmed {
+		case `model_provider = "tutti-llm"`:
+			if rootProviderLine >= 0 {
+				return content, false
+			}
+			rootProviderLine = index
+		case `model = "gpt-5.4"`:
+			if rootModelLine >= 0 {
+				return content, false
+			}
+			rootModelLine = index
+		}
+	}
+	if rootProviderLine < 0 || rootModelLine < 0 || legacySectionStart < 0 {
+		return content, false
+	}
+	legacyKeys := map[string]bool{
+		`name = "Tutti LLM"`:                       false,
+		`base_url = "https://llm-api.tutti.sh/v1"`: false,
+		`wire_api = "responses"`:                   false,
+	}
+	for _, line := range lines[legacySectionStart+1 : legacySectionEnd] {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if _, ok := legacyKeys[trimmed]; !ok || legacyKeys[trimmed] {
+			return content, false
+		}
+		legacyKeys[trimmed] = true
+	}
+	for _, found := range legacyKeys {
+		if !found {
 			return content, false
 		}
 	}
-	if strings.Count(normalized, `[model_providers.tutti-llm]`) != 1 {
-		return content, false
-	}
-	lines := strings.Split(normalized, "\n")
 	result := make([]string, 0, len(lines))
-	inLegacyProvider := false
-	changed := false
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "[") {
-			inLegacyProvider = trimmed == `[model_providers.tutti-llm]`
-			if inLegacyProvider {
-				changed = true
-				continue
-			}
-		}
-		if inLegacyProvider {
+	for index, line := range lines {
+		if index == rootProviderLine || index == rootModelLine {
 			continue
 		}
-		if trimmed == `model_provider = "tutti-llm"` || trimmed == `model = "gpt-5.4"` {
-			changed = true
+		if index >= legacySectionStart && index < legacySectionEnd {
 			continue
 		}
 		result = append(result, line)
 	}
-	if !changed {
-		return content, false
+	next := strings.Join(result, "\n")
+	if strings.HasSuffix(normalized, "\n") && !strings.HasSuffix(next, "\n") {
+		next += "\n"
 	}
-	return strings.TrimSpace(strings.Join(result, "\n")) + "\n", true
+	return next, true
 }

--- a/packages/agent/runtimeprep/tutti_agent.go
+++ b/packages/agent/runtimeprep/tutti_agent.go
@@ -81,7 +81,7 @@ func prepareTuttiAgentHome(home string, input PrepareInput, authSource string, a
 	if err := exposeUserTuttiAgentFiles(home, authSource, authSourceConfigured); err != nil {
 		return err
 	}
-	return ensureTuttiAgentSessionConfig(filepath.Join(home, "config.toml"), input, authSourceConfigured)
+	return ensureTuttiAgentSessionConfig(filepath.Join(home, "config.toml"), input)
 }
 
 func exposeUserTuttiAgentFiles(home string, explicitAuthSource string, explicitAuthSourceConfigured bool) error {
@@ -139,7 +139,7 @@ func exposeTuttiAgentAuth(home string, source string, allowMissingSource bool) e
 	return nil
 }
 
-func ensureTuttiAgentSessionConfig(configPath string, input PrepareInput, managedHome bool) error {
+func ensureTuttiAgentSessionConfig(configPath string, input PrepareInput) error {
 	contentBytes, err := os.ReadFile(configPath)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("read tutti-agent config: %w", err)
@@ -153,11 +153,9 @@ func ensureTuttiAgentSessionConfig(configPath string, input PrepareInput, manage
 		next = detailModeNext
 		changed = true
 	}
-	if managedHome {
-		if cleaned, cleanedChanged := tuttiAgentConfigWithoutLegacyPinnedProvider(next); cleanedChanged {
-			next = cleaned
-			changed = true
-		}
+	if cleaned, cleanedChanged := tuttiAgentConfigWithoutLegacyPinnedProvider(next); cleanedChanged {
+		next = cleaned
+		changed = true
 	}
 	if planNext, planChanged := codexConfigWithModelPlanEndpoint(next, input.ModelEndpoint); planChanged {
 		next = planNext

--- a/packages/agent/runtimeprep/tutti_agent_test.go
+++ b/packages/agent/runtimeprep/tutti_agent_test.go
@@ -59,6 +59,11 @@ func TestTuttiAgentPreparerUsesExplicitAuthSourceAndInstallsSkills(t *testing.T)
 	if strings.Contains(string(config), "must-not-be-copied") {
 		t.Fatal("explicit auth source unexpectedly imported the VM user's config")
 	}
+	for _, unexpected := range []string{`model_provider =`, `model = "gpt-5.4"`, `[model_providers.tutti-llm]`} {
+		if strings.Contains(string(config), unexpected) {
+			t.Fatalf("managed config unexpectedly pinned %q: %s", unexpected, config)
+		}
+	}
 	if len(result.Env) == 0 || result.Env[0] != "TUTTI_AGENT_HOME="+home {
 		t.Fatalf("Prepare() env = %#v", result.Env)
 	}

--- a/packages/agent/runtimeprep/tutti_agent_test.go
+++ b/packages/agent/runtimeprep/tutti_agent_test.go
@@ -121,3 +121,39 @@ func TestTuttiAgentPreparerDoesNotFallbackWhenExplicitAuthSourceIsEmpty(t *testi
 		t.Fatal("explicit empty auth source imported the VM user's config")
 	}
 }
+
+func TestPrepareTuttiAgentHomeRemovesLegacyPinnedProvider(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.toml")
+	legacyConfig := strings.Join([]string{
+		`model_provider = "tutti-llm"`,
+		`model = "gpt-5.4"`,
+		``,
+		`[model_providers.tutti-llm]`,
+		`name = "Tutti LLM"`,
+		`base_url = "https://llm-api.tutti.sh/v1"`,
+		`wire_api = "responses"`,
+		``,
+	}, "\n")
+	if err := os.WriteFile(configPath, []byte(legacyConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := PrepareTuttiAgentHome(home, testResolvedInput(t, PrepareInput{Provider: "tutti-agent"})); err != nil {
+		t.Fatalf("PrepareTuttiAgentHome() error = %v", err)
+	}
+
+	config, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, removed := range []string{
+		`model_provider = "tutti-llm"`,
+		`model = "gpt-5.4"`,
+		`[model_providers.tutti-llm]`,
+	} {
+		if strings.Contains(string(config), removed) {
+			t.Fatalf("legacy pinned config still contains %q:\n%s", removed, config)
+		}
+	}
+}

--- a/services/tuttid/service/agent/model_catalog_test.go
+++ b/services/tuttid/service/agent/model_catalog_test.go
@@ -418,12 +418,24 @@ func TestDefaultTuttiAgentModelListerUsesTuttiHomeAndClearsCodexHome(t *testing.
 		t.Fatalf("catalog config missing: %v", err)
 	}
 	configText := string(config)
-	if !strings.Contains(configText, `model_provider = "tutti-llm"`) ||
-		!strings.Contains(configText, `model = "gpt-5.4"`) ||
-		!strings.Contains(configText, "[model_providers.tutti-llm]") ||
-		!strings.Contains(configText, "[model_providers.custom]") ||
-		strings.Contains(configText, `model_provider = "custom"`) {
-		t.Fatalf("catalog config = %q, want pinned tutti-llm root provider while preserving custom provider block", configText)
+	for _, expected := range []string{
+		`model_provider = "custom"`,
+		`model = "custom-model"`,
+		"[model_providers.custom]",
+		`base_url = "https://custom.example.test/v1"`,
+	} {
+		if !strings.Contains(configText, expected) {
+			t.Fatalf("catalog config = %q, want preserved user setting %q", configText, expected)
+		}
+	}
+	for _, unexpected := range []string{
+		`model_provider = "tutti-llm"`,
+		`model = "gpt-5.4"`,
+		"[model_providers.tutti-llm]",
+	} {
+		if strings.Contains(configText, unexpected) {
+			t.Fatalf("catalog config = %q, must not inject legacy setting %q", configText, unexpected)
+		}
 	}
 	userConfigAfterPrepare, err := os.ReadFile(filepath.Join(userAgentHome, "config.toml"))
 	if err != nil {

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -155,7 +155,7 @@ func TestDefaultRegistryUsesTuttiAgentManagedNPMInstaller(t *testing.T) {
 }
 
 func TestServiceListUsesDescriptorOwnedDaemonLoginAction(t *testing.T) {
-	service, _ := updateTestService(t, "0.0.5")
+	service, _ := updateTestService(t, "0.0.6")
 
 	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"tutti-agent"}})
 	if err != nil {

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -155,7 +155,7 @@ func TestDefaultRegistryUsesTuttiAgentManagedNPMInstaller(t *testing.T) {
 }
 
 func TestServiceListUsesDescriptorOwnedDaemonLoginAction(t *testing.T) {
-	service, _ := updateTestService(t, "0.0.6")
+	service, _ := updateTestService(t, "0.0.7")
 
 	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"tutti-agent"}})
 	if err != nil {

--- a/services/tuttid/service/agentstatus/service_update_test.go
+++ b/services/tuttid/service/agentstatus/service_update_test.go
@@ -69,8 +69,8 @@ func TestTuttiAgentBelowMinimumRequiresManagedInstall(t *testing.T) {
 	if status.Availability.Status != AvailabilityNotInstalled || status.Availability.ReasonCode != "cli_version_unsupported" {
 		t.Fatalf("Availability = %#v, want minimum-version repair", status.Availability)
 	}
-	if status.CLI.Version != "0.0.2" || status.CLI.MinVersion != "0.0.5" {
-		t.Fatalf("CLI = %#v, want current 0.0.2 and minimum 0.0.5", status.CLI)
+	if status.CLI.Version != "0.0.2" || status.CLI.MinVersion != "0.0.6" {
+		t.Fatalf("CLI = %#v, want current 0.0.2 and minimum 0.0.6", status.CLI)
 	}
 	if !hasProviderAction(status.Actions, ActionInstall) {
 		t.Fatalf("Actions = %#v, want install", status.Actions)
@@ -116,7 +116,7 @@ func TestTuttiAgentUnknownVersionFailsClosed(t *testing.T) {
 			if status.Availability.Status != AvailabilityNotInstalled || status.Availability.ReasonCode != "cli_version_unsupported" {
 				t.Fatalf("Availability = %#v, want unknown-version repair", status.Availability)
 			}
-			if status.CLI.Version != "" || status.CLI.MinVersion != "0.0.5" || !hasProviderAction(status.Actions, ActionInstall) {
+			if status.CLI.Version != "" || status.CLI.MinVersion != "0.0.6" || !hasProviderAction(status.Actions, ActionInstall) {
 				t.Fatalf("CLI/actions = %#v/%#v, want unknown current version and managed install", status.CLI, status.Actions)
 			}
 
@@ -165,13 +165,13 @@ func TestTuttiAgentVersionFloorPrecedesAdapterFailure(t *testing.T) {
 	if status.Availability.ReasonCode != "cli_version_unsupported" {
 		t.Fatalf("Availability = %#v, want CLI floor before adapter failure", status.Availability)
 	}
-	if status.CLI.Version != "0.0.2" || status.CLI.MinVersion != "0.0.5" {
+	if status.CLI.Version != "0.0.2" || status.CLI.MinVersion != "0.0.6" {
 		t.Fatalf("CLI = %#v, want version evidence retained", status.CLI)
 	}
 }
 
 func TestCompatibleTuttiAgentDoesNotRequireManagedInstall(t *testing.T) {
-	for _, version := range []string{"0.0.5", "0.0.6"} {
+	for _, version := range []string{"0.0.6", "0.0.7"} {
 		t.Run(version, func(t *testing.T) {
 			service, _ := updateTestService(t, version)
 			snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"tutti-agent"}})
@@ -217,10 +217,10 @@ func TestRunInstallActionUpgradesTuttiAgentBelowMinimumAndReprobes(t *testing.T)
 	var commands atomic.Int32
 	service.InstallCommand = func(_ context.Context, input InstallCommandInput) (InstallCommandResult, error) {
 		commands.Add(1)
-		if !strings.Contains(input.Command, "@tutti-os/tutti-agent@0.0.5") {
-			t.Fatalf("install command = %q, want exact managed Tutti Agent 0.0.5 package", input.Command)
+		if !strings.Contains(input.Command, "@tutti-os/tutti-agent@0.0.6") {
+			t.Fatalf("install command = %q, want exact managed Tutti Agent 0.0.6 package", input.Command)
 		}
-		writeUpdateTestCLI(t, binaryPath, "0.0.5")
+		writeUpdateTestCLI(t, binaryPath, "0.0.6")
 		return InstallCommandResult{ExitCode: 0, Stdout: "updated"}, nil
 	}
 
@@ -237,7 +237,7 @@ func TestRunInstallActionUpgradesTuttiAgentBelowMinimumAndReprobes(t *testing.T)
 		t.Fatalf("post-install List() error = %v", err)
 	}
 	status := onlyStatus(t, snapshot)
-	if status.Availability.Status != AvailabilityReady || status.CLI.Version != "0.0.5" {
+	if status.Availability.Status != AvailabilityReady || status.CLI.Version != "0.0.6" {
 		t.Fatalf("post-install status = %#v", status)
 	}
 }

--- a/services/tuttid/service/agentstatus/service_update_test.go
+++ b/services/tuttid/service/agentstatus/service_update_test.go
@@ -69,8 +69,8 @@ func TestTuttiAgentBelowMinimumRequiresManagedInstall(t *testing.T) {
 	if status.Availability.Status != AvailabilityNotInstalled || status.Availability.ReasonCode != "cli_version_unsupported" {
 		t.Fatalf("Availability = %#v, want minimum-version repair", status.Availability)
 	}
-	if status.CLI.Version != "0.0.2" || status.CLI.MinVersion != "0.0.6" {
-		t.Fatalf("CLI = %#v, want current 0.0.2 and minimum 0.0.6", status.CLI)
+	if status.CLI.Version != "0.0.2" || status.CLI.MinVersion != "0.0.7" {
+		t.Fatalf("CLI = %#v, want current 0.0.2 and minimum 0.0.7", status.CLI)
 	}
 	if !hasProviderAction(status.Actions, ActionInstall) {
 		t.Fatalf("Actions = %#v, want install", status.Actions)
@@ -116,7 +116,7 @@ func TestTuttiAgentUnknownVersionFailsClosed(t *testing.T) {
 			if status.Availability.Status != AvailabilityNotInstalled || status.Availability.ReasonCode != "cli_version_unsupported" {
 				t.Fatalf("Availability = %#v, want unknown-version repair", status.Availability)
 			}
-			if status.CLI.Version != "" || status.CLI.MinVersion != "0.0.6" || !hasProviderAction(status.Actions, ActionInstall) {
+			if status.CLI.Version != "" || status.CLI.MinVersion != "0.0.7" || !hasProviderAction(status.Actions, ActionInstall) {
 				t.Fatalf("CLI/actions = %#v/%#v, want unknown current version and managed install", status.CLI, status.Actions)
 			}
 
@@ -165,13 +165,13 @@ func TestTuttiAgentVersionFloorPrecedesAdapterFailure(t *testing.T) {
 	if status.Availability.ReasonCode != "cli_version_unsupported" {
 		t.Fatalf("Availability = %#v, want CLI floor before adapter failure", status.Availability)
 	}
-	if status.CLI.Version != "0.0.2" || status.CLI.MinVersion != "0.0.6" {
+	if status.CLI.Version != "0.0.2" || status.CLI.MinVersion != "0.0.7" {
 		t.Fatalf("CLI = %#v, want version evidence retained", status.CLI)
 	}
 }
 
 func TestCompatibleTuttiAgentDoesNotRequireManagedInstall(t *testing.T) {
-	for _, version := range []string{"0.0.6", "0.0.7"} {
+	for _, version := range []string{"0.0.7", "0.0.8"} {
 		t.Run(version, func(t *testing.T) {
 			service, _ := updateTestService(t, version)
 			snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"tutti-agent"}})
@@ -217,10 +217,10 @@ func TestRunInstallActionUpgradesTuttiAgentBelowMinimumAndReprobes(t *testing.T)
 	var commands atomic.Int32
 	service.InstallCommand = func(_ context.Context, input InstallCommandInput) (InstallCommandResult, error) {
 		commands.Add(1)
-		if !strings.Contains(input.Command, "@tutti-os/tutti-agent@0.0.6") {
-			t.Fatalf("install command = %q, want exact managed Tutti Agent 0.0.6 package", input.Command)
+		if !strings.Contains(input.Command, "@tutti-os/tutti-agent@0.0.7") {
+			t.Fatalf("install command = %q, want exact managed Tutti Agent 0.0.7 package", input.Command)
 		}
-		writeUpdateTestCLI(t, binaryPath, "0.0.6")
+		writeUpdateTestCLI(t, binaryPath, "0.0.7")
 		return InstallCommandResult{ExitCode: 0, Stdout: "updated"}, nil
 	}
 
@@ -237,7 +237,7 @@ func TestRunInstallActionUpgradesTuttiAgentBelowMinimumAndReprobes(t *testing.T)
 		t.Fatalf("post-install List() error = %v", err)
 	}
 	status := onlyStatus(t, snapshot)
-	if status.Availability.Status != AvailabilityReady || status.CLI.Version != "0.0.6" {
+	if status.Availability.Status != AvailabilityReady || status.CLI.Version != "0.0.7" {
 		t.Fatalf("post-install status = %#v", status)
 	}
 }


### PR DESCRIPTION
## Summary
- remove the legacy hard-coded Tutti LLM provider and `gpt-5.4` session pin while narrowly cleaning the exact old managed signature
- require managed Tutti Agent `0.0.6` and stop requesting ChatGPT rate-limit endpoints for this provider
- classify billing, unavailable-model, and MCP Apps failures without misreporting them as authentication failures
- keep Codex rate-limit behavior unchanged

## Validation
- `go test ./packages/agent/runtimeprep/...`
- `go test ./packages/agent/daemon/...`
- targeted providerregistry/runtime tests after rebase to latest main
- `git diff --check`

## Dependency
Blocked on merging tutti-os/tutti-agent#34 and publishing/verifying `@tutti-os/tutti-agent@0.0.6`. After that this MR can be marked ready and its unified package cohort published for TSH.