### PR TITLE
fix(agent-gui): render participant avatars per conversation turn

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -454,9 +454,12 @@ infers identity readiness from a missing image URL. The host supplies user and
 Agent names and optional avatar URLs; AgentGUI owns the UI System Avatar,
 fixed-size loading slot, fallback initial, and user-right/Agent-left layout.
 Participant-header placement is projected from presentation turns rather than
-individual message or tool-progress rows: each speaker renders at most one
-header per turn, and a collapsed completed turn keeps the Agent header on
-visible reply content.
+individual message, tool-progress, or canonical Turn rows. A presentation turn
+starts at a user message and continues until the next user message, so recovery
+or provider continuation may span canonical Turns without duplicating the
+participant header. Each speaker renders at most one header per presentation
+turn, and a collapsed completed canonical Turn keeps the Agent header on visible
+reply content.
 This presentation input is view data only and must not enter canonical Session,
 Turn, Message, activity-runtime, or workspace-engine state.
 

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -304,6 +304,130 @@ describe("AgentTranscriptView", () => {
     );
   });
 
+  it("keeps one Agent header when a visible reply spans canonical Turns", () => {
+    const baseConversation = projectAgentConversationVM(detailViewModel());
+    const message = (id: string, turnId: string, body: string) => ({
+      kind: "message-content" as const,
+      id,
+      turnId,
+      body,
+      presentationKind: "content" as const,
+      occurredAtUnixMs: 1
+    });
+    const conversation = {
+      ...baseConversation,
+      rows: [
+        {
+          kind: "message" as const,
+          id: "user-first",
+          turnId: "turn-1",
+          speaker: "user" as const,
+          messages: [message("user-first-message", "turn-1", "Check prices")],
+          thinking: [],
+          occurredAtUnixMs: 1
+        },
+        {
+          kind: "message" as const,
+          id: "assistant-progress",
+          turnId: "turn-1",
+          speaker: "assistant" as const,
+          messages: [
+            message(
+              "assistant-progress-message",
+              "turn-1",
+              "Loading tools and fetching the latest data"
+            )
+          ],
+          thinking: [],
+          occurredAtUnixMs: 2
+        },
+        {
+          kind: "tool-group" as const,
+          id: "recovery-tool-group",
+          turnId: "turn-recovery",
+          grouped: true,
+          calls: [],
+          entries: [],
+          occurredAtUnixMs: 3
+        },
+        {
+          kind: "message" as const,
+          id: "assistant-restart-warning",
+          turnId: "turn-recovery",
+          speaker: "assistant" as const,
+          messages: [
+            message(
+              "assistant-restart-warning-message",
+              "turn-recovery",
+              "Agent run was interrupted by an application restart."
+            )
+          ],
+          thinking: [],
+          occurredAtUnixMs: 4
+        },
+        {
+          kind: "message" as const,
+          id: "user-second",
+          turnId: "turn-2",
+          speaker: "user" as const,
+          messages: [message("user-second-message", "turn-2", "Try again")],
+          thinking: [],
+          occurredAtUnixMs: 5
+        },
+        {
+          kind: "message" as const,
+          id: "assistant-second",
+          turnId: "turn-2",
+          speaker: "assistant" as const,
+          messages: [
+            message("assistant-second-message", "turn-2", "Trying again")
+          ],
+          thinking: [],
+          occurredAtUnixMs: 6
+        }
+      ]
+    };
+
+    const { container } = render(
+      <AgentTranscriptView
+        conversation={conversation}
+        participantPresentation={{
+          enabled: true,
+          status: "ready",
+          user: { name: "Alice", avatarUrl: "user.png" },
+          agent: { name: "Claude Code", avatarUrl: "agent.png" }
+        }}
+        labels={{
+          thinkingLabel: "Thought process",
+          toolCallsLabel: (count) => `Tool calls (${count})`,
+          processing: "Planning next moves",
+          turnSummary: "Changed files"
+        }}
+      />
+    );
+
+    const agentHeaders = container.querySelectorAll(
+      '[data-agent-conversation-participant-header="assistant"]'
+    );
+    expect(agentHeaders).toHaveLength(2);
+    expect(
+      agentHeaders[0]?.closest("[data-agent-transcript-row]")
+    ).toHaveAttribute("data-agent-transcript-row", "assistant-progress");
+    expect(
+      screen
+        .getByText("Agent run was interrupted by an application restart.")
+        .closest("[data-agent-transcript-row]")
+    ).not.toContainElement(agentHeaders[0] as HTMLElement);
+    expect(
+      agentHeaders[1]?.closest("[data-agent-transcript-row]")
+    ).toHaveAttribute("data-agent-transcript-row", "assistant-second");
+    expect(
+      container.querySelectorAll(
+        '[data-agent-conversation-participant-header="user"]'
+      )
+    ).toHaveLength(2);
+  });
+
   it("rerenders when canonical turn timing changes", () => {
     const labels = {
       thinkingLabel: "Thought process",

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
@@ -34,7 +34,6 @@ import {
   buildTurnGroupIndexByRowIndex,
   buildUserMessageLocatorItems,
   escapeCssString,
-  findParticipantTurnDividerRowIndexes,
   findTurnDividerRowIndexes,
   transcriptRowKey,
   useAgentTranscriptDisplayRows,
@@ -235,7 +234,8 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
   const participantHeadersEnabled = participantPresentation?.enabled === true;
   // Participant-header presentation (Agent board session detail): tool-group
   // rows attach to the assistant message that follows them instead of sitting
-  // after the previous message, and turn dividers key off user messages. The
+  // after the previous message, and presentation turns key off user messages.
+  // Canonical Turn groups remain responsible for disclosure and timing. The
   // row projection lives in the transcript model read hook so this component
   // stays within the degradation-check memo budget.
   const transcriptRowSet = useAgentTranscriptDisplayRows(
@@ -244,6 +244,7 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
   );
   const displayRows = transcriptRowSet.rows;
   const rowKeys = transcriptRowSet.rowKeys;
+  const participantTurnProjection = transcriptRowSet.participantTurnProjection;
   const turnGroups = useMemo(
     () => buildAgentTranscriptTurnGroups(displayRows, rowKeys),
     [displayRows, rowKeys]
@@ -285,10 +286,10 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
   );
   const dividerRowIndexes = useMemo(
     () =>
-      participantHeadersEnabled
-        ? findParticipantTurnDividerRowIndexes(displayRows)
+      participantTurnProjection
+        ? participantTurnProjection.dividerRowIndexes
         : findTurnDividerRowIndexes(turnIndexById, displayRows),
-    [displayRows, turnIndexById, participantHeadersEnabled]
+    [displayRows, turnIndexById, participantTurnProjection]
   );
   const canonicalTurnById = new Map(
     (conversation.sourceDetail.sessionTurns ?? []).map((turn) => [
@@ -315,11 +316,12 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
       ] as const;
     })
   );
-  const participantHeaderRenderKeys = participantHeadersEnabled
+  const participantHeaderRenderKeys = participantTurnProjection
     ? findParticipantHeaderRenderKeys(
         turnGroups,
         rowKeys,
-        turnWorkSectionModelByKey
+        turnWorkSectionModelByKey,
+        participantTurnProjection.turnIndexByRowIndex
       )
     : null;
   const basePath = conversation.sourceDetail.cwd;

--- a/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.spec.ts
@@ -3,8 +3,8 @@ import type { AgentTranscriptPresentationKind } from "../contracts/agentTranscri
 import type { AgentTranscriptRowVM } from "../contracts/agentTranscriptRowVM";
 import {
   attachLeadingToolRowsToFollowingMessages,
+  buildAgentParticipantTurnProjection,
   buildAgentTranscriptTurnGroups,
-  findParticipantTurnDividerRowIndexes,
   findTurnDividerRowIndexes,
   transcriptRowKey
 } from "./agentTranscriptModel";
@@ -150,31 +150,38 @@ function toolGroupRow(id: string, turnId: string): AgentTranscriptRowVM {
   };
 }
 
-describe("findParticipantTurnDividerRowIndexes", () => {
-  it("marks every user message after the first row as a turn divider", () => {
-    expect([
-      ...findParticipantTurnDividerRowIndexes([
-        userRow("turn-1"),
-        row("turn-1"),
-        userRow("turn-2"),
-        row("turn-2")
-      ])
-    ]).toEqual([2]);
+describe("buildAgentParticipantTurnProjection", () => {
+  it("starts a presentation turn at each user message", () => {
+    const projection = buildAgentParticipantTurnProjection([
+      userRow("turn-1"),
+      row("turn-1"),
+      userRow("turn-2"),
+      row("turn-2")
+    ]);
+
+    expect([...projection.dividerRowIndexes]).toEqual([2]);
+    expect([...projection.turnIndexByRowIndex.values()]).toEqual([0, 0, 1, 1]);
   });
 
-  it("marks a user message that follows another user message", () => {
-    expect([
-      ...findParticipantTurnDividerRowIndexes([
-        userRow("turn-1"),
-        userRow("turn-2")
-      ])
-    ]).toEqual([1]);
+  it("does not split a reply when its canonical turn id changes", () => {
+    const projection = buildAgentParticipantTurnProjection([
+      userRow("turn-1"),
+      row("turn-1"),
+      row("turn-recovery")
+    ]);
+
+    expect([...projection.dividerRowIndexes]).toEqual([]);
+    expect([...projection.turnIndexByRowIndex.values()]).toEqual([0, 0, 0]);
   });
 
-  it("never marks the first row", () => {
-    expect([
-      ...findParticipantTurnDividerRowIndexes([userRow("turn-1")])
-    ]).toEqual([]);
+  it("starts a new turn when user messages are adjacent", () => {
+    const projection = buildAgentParticipantTurnProjection([
+      userRow("turn-1"),
+      userRow("turn-2")
+    ]);
+
+    expect([...projection.dividerRowIndexes]).toEqual([1]);
+    expect([...projection.turnIndexByRowIndex.values()]).toEqual([0, 1]);
   });
 });
 

--- a/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.ts
@@ -21,6 +21,11 @@ export interface AgentMessageLocatorItem {
   summary: string;
 }
 
+export interface AgentParticipantTurnProjection {
+  dividerRowIndexes: ReadonlySet<number>;
+  turnIndexByRowIndex: ReadonlyMap<number, number>;
+}
+
 export function useEnteringTranscriptRows(
   rowKeys: string[]
 ): ReadonlySet<string> {
@@ -219,21 +224,30 @@ export function findTurnDividerRowIndexes(
 }
 
 /**
- * Participant-header presentation (Agent board session detail): a new user
- * message always starts the next turn, so the divider goes between the
- * previous turn's last row and every user message row — regardless of whether
- * the rebuilt session carries canonical turn ids.
+ * Participant-header presentation (Agent board session detail): a presentation
+ * turn starts at each user message and continues until the next user message.
+ * Canonical Turn ids deliberately do not participate because recovery or
+ * provider continuation may split one visible reply across multiple Turns.
  */
-export function findParticipantTurnDividerRowIndexes(
+export function buildAgentParticipantTurnProjection(
   rows: ReadonlyArray<AgentConversationVM["rows"][number]>
-): ReadonlySet<number> {
+): AgentParticipantTurnProjection {
   const dividerRowIndexes = new Set<number>();
+  const turnIndexByRowIndex = new Map<number, number>();
+  let turnIndex = 0;
+
   rows.forEach((row, rowIndex) => {
     if (rowIndex > 0 && row.kind === "message" && row.speaker === "user") {
+      turnIndex += 1;
       dividerRowIndexes.add(rowIndex);
     }
+    turnIndexByRowIndex.set(rowIndex, turnIndex);
   });
-  return dividerRowIndexes;
+
+  return {
+    dividerRowIndexes,
+    turnIndexByRowIndex
+  };
 }
 
 /**
@@ -259,10 +273,7 @@ export function attachLeadingToolRowsToFollowingMessages(
       if (pendingToolRows.length > 0) {
         result.push({
           ...row,
-          leadingToolRows: [
-            ...(row.leadingToolRows ?? []),
-            ...pendingToolRows
-          ]
+          leadingToolRows: [...(row.leadingToolRows ?? []), ...pendingToolRows]
         });
         pendingToolRows = [];
         continue;
@@ -283,9 +294,10 @@ export function attachLeadingToolRowsToFollowingMessages(
 /**
  * Read hook owning the display-row projection for the transcript view: in
  * participant-header mode tool-group rows attach to the following assistant
- * message, and row keys derive from the same pass. Keeping the memoization in
- * this model module (next to `useEnteringTranscriptRows`) keeps the view
- * component within the degradation-check memoization budget.
+ * message, presentation turns start at user messages, and row keys derive from
+ * the same pass. Keeping the memoization in this model module (next to
+ * `useEnteringTranscriptRows`) keeps the view component within the
+ * degradation-check memoization budget.
  */
 export function useAgentTranscriptDisplayRows(
   rows: ReadonlyArray<AgentConversationVM["rows"][number]>,
@@ -293,11 +305,18 @@ export function useAgentTranscriptDisplayRows(
 ): {
   rows: ReadonlyArray<AgentConversationVM["rows"][number]>;
   rowKeys: string[];
+  participantTurnProjection: AgentParticipantTurnProjection | null;
 } {
   return useMemo(() => {
     const displayRows = participantHeadersEnabled
       ? attachLeadingToolRowsToFollowingMessages(rows)
       : rows;
-    return { rows: displayRows, rowKeys: displayRows.map(transcriptRowKey) };
+    return {
+      rows: displayRows,
+      rowKeys: displayRows.map(transcriptRowKey),
+      participantTurnProjection: participantHeadersEnabled
+        ? buildAgentParticipantTurnProjection(displayRows)
+        : null
+    };
   }, [rows, participantHeadersEnabled]);
 }

--- a/packages/agent/gui/shared/agentConversation/components/agentTurnWorkSectionModel.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTurnWorkSectionModel.ts
@@ -39,45 +39,69 @@ export interface AgentTurnWorkSectionModel {
 export function findParticipantHeaderRenderKeys(
   groups: readonly AgentTranscriptTurnGroup[],
   rowKeys: readonly string[],
-  modelByGroupKey: ReadonlyMap<string, AgentTurnWorkSectionModel | null>
+  modelByGroupKey: ReadonlyMap<string, AgentTurnWorkSectionModel | null>,
+  participantTurnIndexByRowIndex: ReadonlyMap<number, number>
 ): ReadonlySet<string> {
-  const headerKeys = new Set<string>();
+  const headerCandidateByTurn = new Map<
+    number,
+    Map<
+      AgentMessageRowVM["speaker"],
+      { renderKey: string; visibilityPriority: number }
+    >
+  >();
 
   for (const group of groups) {
     const model = modelByGroupKey.get(group.key);
-    const renderedRows: readonly AgentTurnWorkSectionRow[] = model
-      ? model.collapseEligible
-        ? [
-            ...model.leadingRows,
-            ...model.sections.flatMap((section) =>
-              section.kind === "visible" ? section.rows : []
-            ),
-            ...model.sections.flatMap((section) =>
-              section.kind === "work" ? section.rows : []
-            )
-          ]
-        : [
-            ...model.leadingRows,
-            ...model.sections.flatMap((section) => section.rows)
-          ]
-      : group.rows;
-    const seenSpeakers = new Set<AgentMessageRowVM["speaker"]>();
+    const renderedRows: ReadonlyArray<{
+      entry: AgentTurnWorkSectionRow;
+      visibilityPriority: number;
+    }> = model
+      ? [
+          ...model.leadingRows.map((entry) => ({
+            entry,
+            visibilityPriority: 0
+          })),
+          ...model.sections.flatMap((section) =>
+            section.rows.map((entry) => ({
+              entry,
+              visibilityPriority:
+                model.collapseEligible && section.kind === "work" ? 1 : 0
+            }))
+          )
+        ]
+      : group.rows.map((entry) => ({ entry, visibilityPriority: 0 }));
 
-    for (const entry of renderedRows) {
+    for (const { entry, visibilityPriority } of renderedRows) {
       const row = entry.row;
+      if (row.kind !== "message" || row.messages.length === 0) {
+        continue;
+      }
+      const participantTurnIndex =
+        participantTurnIndexByRowIndex.get(entry.rowIndex) ?? entry.rowIndex;
+      let candidateBySpeaker = headerCandidateByTurn.get(participantTurnIndex);
+      if (!candidateBySpeaker) {
+        candidateBySpeaker = new Map();
+        headerCandidateByTurn.set(participantTurnIndex, candidateBySpeaker);
+      }
+      const currentCandidate = candidateBySpeaker.get(row.speaker);
       if (
-        row.kind !== "message" ||
-        row.messages.length === 0 ||
-        seenSpeakers.has(row.speaker)
+        currentCandidate &&
+        currentCandidate.visibilityPriority <= visibilityPriority
       ) {
         continue;
       }
-      seenSpeakers.add(row.speaker);
-      headerKeys.add(entry.renderKey ?? rowKeys[entry.rowIndex] ?? row.id);
+      candidateBySpeaker.set(row.speaker, {
+        renderKey: entry.renderKey ?? rowKeys[entry.rowIndex] ?? row.id,
+        visibilityPriority
+      });
     }
   }
 
-  return headerKeys;
+  return new Set(
+    [...headerCandidateByTurn.values()].flatMap((candidateBySpeaker) =>
+      [...candidateBySpeaker.values()].map((candidate) => candidate.renderKey)
+    )
+  );
 }
 
 interface AgentTurnWorkSectionOptions {


### PR DESCRIPTION
## Summary

Participant avatars were allocated once per canonical `turnId`, while participant-mode dividers already used user-message boundaries. Recovery or provider continuation can split one visible Agent reply across multiple canonical Turns, which caused the Agent avatar and name to repeat within one user-facing conversation turn.

This change introduces one presentation-only turn projection from each user message to the next user message. Participant headers and dividers share that projection, while canonical Turns continue to own timing, disclosure, tool state, and lifecycle. Header selection spans canonical Turn groups and still prefers the visible final reply for collapsed completed work.

## Verification

- Added a regression scenario matching an Agent reply split by restart recovery: progress message, tool group, and restart warning span two canonical Turns but render one Agent header.
- Verified the next user message starts a new presentation turn and restores both participant headers.
- `pnpm check:changed`
- Push-ready validation: 12 lanes passed.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (N/A: presentation-only; canonical lifecycle is unchanged.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (N/A: no README or CONTRIBUTING changes.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
