### PR TITLE
feat(workspace-files): expose shared image preview surface

### DIFF
--- a/packages/workspace/file-preview/CONTRACT.md
+++ b/packages/workspace/file-preview/CONTRACT.md
@@ -141,6 +141,12 @@ to:
 - `text` (including the text-degradation path for `markdown` / `json` / `csv` /
   `html` / `code` when no host hook is registered)
 
+The public `WorkspaceImagePreviewSurface` is the reusable image-only canvas.
+Callers provide the image source and own its loading, URL lifetime, and error
+policy. `WorkspaceFilePreviewSurface` delegates its built-in image branch to
+this component so hosts can reuse the same visual implementation without
+adopting the workspace file controller.
+
 `audio`, `pdf`, `markdown` (rich), Office kinds (`docx` / `xlsx` / `pptx`), and
 other rich viewers are **hook-only** unless a later contract revision promotes a
 kind into the built-in set.

--- a/packages/workspace/file-preview/README.md
+++ b/packages/workspace/file-preview/README.md
@@ -15,6 +15,8 @@ This package ships:
 - `createWorkspaceFilePreviewController` for shared frontend loading lifecycle
   (readiness, cancellation, stale-request fencing, decoding, object-URL cleanup)
 - Built-in React preview shells for `image` / `video` / `text`
+- `WorkspaceImagePreviewSurface` for reusing the built-in image canvas while
+  keeping source loading, URL lifetime, and error policy in the host
 - Host renderer registry (by `previewKind`) and a resolve chain:
   host hook → text degradation → unsupported state
 - `toSurfaceState(controllerState, copy)` to project controller state into the

--- a/packages/workspace/file-preview/src/react/index.ts
+++ b/packages/workspace/file-preview/src/react/index.ts
@@ -3,6 +3,8 @@ export {
   type WorkspaceFilePreviewSurfaceCopy
 } from "./toSurfaceState.ts";
 export {
+  WorkspaceImagePreviewSurface,
+  type WorkspaceImagePreviewSurfaceProps,
   WorkspaceFilePreviewSurface,
   type WorkspaceFilePreviewHostRenderer,
   type WorkspaceFilePreviewHostRendererProps,

--- a/packages/workspace/file-preview/src/react/workspaceFilePreviewSurface.tsx
+++ b/packages/workspace/file-preview/src/react/workspaceFilePreviewSurface.tsx
@@ -7,7 +7,7 @@
  * Ownership rules: packages/workspace/file-preview/CONTRACT.md
  */
 
-import type { ReactElement, ReactNode } from "react";
+import type { ImgHTMLAttributes, ReactElement, ReactNode } from "react";
 import type { WorkspaceFilePreviewKind } from "../core/workspaceFilePreviewKinds.ts";
 
 export type WorkspaceFilePreviewSurfaceState<TEntry> =
@@ -66,6 +66,41 @@ export type WorkspaceFilePreviewSurfaceVariant =
   | "canvas"
   | "compact"
   | "detail";
+
+/**
+ * Host-neutral image canvas shared by workspace previews and other file-backed
+ * surfaces. The caller owns the source URL lifecycle and error-state policy.
+ */
+export interface WorkspaceImagePreviewSurfaceProps {
+  alt: string;
+  draggable?: boolean;
+  onError?: ImgHTMLAttributes<HTMLImageElement>["onError"];
+  src: string;
+  variant: WorkspaceFilePreviewSurfaceVariant;
+}
+
+export function WorkspaceImagePreviewSurface({
+  alt,
+  draggable,
+  onError,
+  src,
+  variant
+}: WorkspaceImagePreviewSurfaceProps): ReactElement {
+  const styles = workspaceFilePreviewSurfaceStyles[variant];
+  return (
+    <WorkspaceFilePreviewFrame
+      className={joinClassNames(styles.frame, styles.imageFrame)}
+    >
+      <img
+        alt={alt}
+        className={styles.image}
+        draggable={draggable}
+        onError={onError}
+        src={src}
+      />
+    </WorkspaceFilePreviewFrame>
+  );
+}
 
 export interface WorkspaceFilePreviewHostRendererProps<TEntry> {
   entry: TEntry;
@@ -154,15 +189,11 @@ export function WorkspaceFilePreviewSurface<TEntry>({
       );
     case "image":
       return (
-        <WorkspaceFilePreviewFrame
-          className={joinClassNames(styles.frame, styles.imageFrame)}
-        >
-          <img
-            alt={imageAlt(state.entry)}
-            className={styles.image}
-            src={state.objectUrl}
-          />
-        </WorkspaceFilePreviewFrame>
+        <WorkspaceImagePreviewSurface
+          alt={imageAlt(state.entry)}
+          src={state.objectUrl}
+          variant={variant}
+        />
       );
     case "text":
       return (


### PR DESCRIPTION
## Summary

- export a host-neutral `WorkspaceImagePreviewSurface` from `@tutti-os/workspace-file-preview/react`
- make the existing workspace image branch delegate to the same component
- keep image source loading, URL lifetime, and error policy owned by each host
- document the new public boundary in the package README and contract

## Why

TSH Room Chat has its own artifact authority, direct media URL, retry, and release lifecycle, but should reuse the workspace image canvas UI. The existing public API only exposes the whole file preview surface, whose image state assumes a controller-owned object URL and does not expose image error handling. The new narrow component shares the visual implementation without coupling consumers to the workspace file controller.

## Impact

Existing workspace preview behavior and default DOM remain unchanged. Other hosts can now reuse the canonical image canvas with their own `src`, drag policy, and `onError` behavior.

## Validation

- `pnpm --filter @tutti-os/workspace-file-preview typecheck`
- `pnpm --filter @tutti-os/workspace-file-preview test` (18 passed)
- `pnpm --filter @tutti-os/workspace-file-preview build`
- `pnpm check:changed` (9 lanes passed after rebasing onto current `origin/main`)
- pre-push `pnpm check:changed -- --push-ready` (10 lanes passed)