### PR TITLE
fix(agent-gui): align participant conversation flow

### DIFF
--- a/.changeset/agent-conversation-turn-scoped-avatars.md
+++ b/.changeset/agent-conversation-turn-scoped-avatars.md
@@ -3,4 +3,5 @@
 ---
 
 Render custom conversation participant avatars once per speaker and turn
-instead of repeating the Agent avatar for each tool-progress message.
+instead of repeating the Agent avatar for each tool-progress message, and keep
+subsequent assistant progress aligned with the participant name.

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -3797,6 +3797,17 @@ aside.workspace-agents-status-panel
   margin-right: -36px;
 }
 
+/*
+ * Participant headers render once per visible turn. Later assistant-owned
+ * transcript rows are siblings of that header row, so carry the same
+ * avatar-and-gap inset onto their content without changing host row padding.
+ */
+.agent-gui-transcript-row[data-agent-transcript-row-participant-content="assistant"]
+  > * {
+  box-sizing: border-box;
+  padding-left: 36px;
+}
+
 .agent-gui-conversation__participant-name {
   overflow: hidden;
   font-size: 13px;

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -248,6 +248,28 @@ describe("AgentTranscriptView", () => {
         )
         ?.closest("[data-agent-transcript-row]")
     ).toHaveAttribute("data-agent-transcript-row", "assistant-progress-1");
+    expect(
+      container.querySelector(
+        '[data-agent-transcript-row="assistant-progress-1"]'
+      )
+    ).not.toHaveAttribute("data-agent-transcript-row-participant-content");
+    expect(
+      container.querySelector(
+        '[data-agent-transcript-row="assistant-progress-2"]'
+      )
+    ).toHaveAttribute(
+      "data-agent-transcript-row-participant-content",
+      "assistant"
+    );
+    expect(
+      container.querySelector('[data-agent-transcript-row="assistant-final"]')
+    ).toHaveAttribute(
+      "data-agent-transcript-row-participant-content",
+      "assistant"
+    );
+    expect(
+      container.querySelector('[data-agent-transcript-row="user-row"]')
+    ).not.toHaveAttribute("data-agent-transcript-row-participant-content");
     expect(screen.getByText("Reading files")).toBeInTheDocument();
     expect(screen.getByText("Checking tests")).toBeInTheDocument();
     expect(screen.getByText("Done")).toBeInTheDocument();
@@ -301,6 +323,19 @@ describe("AgentTranscriptView", () => {
     ).toHaveAttribute(
       "data-agent-transcript-row",
       "assistant-final:turn-final"
+    );
+    expect(
+      container.querySelector(
+        '[data-agent-transcript-row="assistant-final:turn-final"]'
+      )
+    ).not.toHaveAttribute("data-agent-transcript-row-participant-content");
+    expect(
+      container.querySelector(
+        '[data-agent-transcript-row="assistant-progress-1"]'
+      )
+    ).toHaveAttribute(
+      "data-agent-transcript-row-participant-content",
+      "assistant"
     );
   });
 

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -117,7 +117,7 @@ describe("AgentTranscriptView", () => {
     ).toBe(false);
   });
 
-  it("renders each participant header once per turn across tool progress rows", () => {
+  it("renders each participant header once per turn across tool progress rows", async () => {
     const baseConversation = projectAgentConversationVM(
       detailViewModel({
         session: normalizeAgentActivitySession({
@@ -329,6 +329,10 @@ describe("AgentTranscriptView", () => {
         '[data-agent-transcript-row="assistant-final:turn-final"]'
       )
     ).not.toHaveAttribute("data-agent-transcript-row-participant-content");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Expand task details" })
+    );
+    await flushCollapsibleRevealFrames();
     expect(
       container.querySelector(
         '[data-agent-transcript-row="assistant-progress-1"]'

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
@@ -109,6 +109,22 @@ function participantPresentationEqual(
   );
 }
 
+function isAssistantParticipantContentRow(
+  row: AgentConversationVM["rows"][number]
+): boolean {
+  switch (row.kind) {
+    case "message":
+      return row.speaker === "assistant";
+    case "generated-image":
+    case "processing":
+    case "tool-group":
+    case "turn-summary":
+      return true;
+    case "goal-control":
+      return false;
+  }
+}
+
 function transcriptLabelsEqual(
   previous: AgentTranscriptViewProps["labels"],
   next: AgentTranscriptViewProps["labels"]
@@ -410,6 +426,14 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
         : transcriptRowKey(row));
     const shouldAnimateEnter =
       row.kind !== "processing" && enteringRowKeys.has(rowKey);
+    const showParticipantHeader =
+      participantHeaderRenderKeys?.has(rowKey) ?? false;
+    const participantContent =
+      participantHeadersEnabled &&
+      !showParticipantHeader &&
+      isAssistantParticipantContentRow(row)
+        ? "assistant"
+        : undefined;
 
     return (
       <div
@@ -436,6 +460,7 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
             : undefined
         }
         data-agent-transcript-row-index={rowIndex}
+        data-agent-transcript-row-participant-content={participantContent}
         data-agent-transcript-row-enter={
           shouldAnimateEnter ? "true" : undefined
         }
@@ -452,9 +477,7 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
           workspaceAppIcons={workspaceAppIcons}
           showRawTimelineJson={showRawTimelineJson}
           participantPresentation={participantPresentation}
-          showParticipantHeader={
-            participantHeaderRenderKeys?.has(rowKey) ?? false
-          }
+          showParticipantHeader={showParticipantHeader}
           toolGroupExpanded={
             row.kind === "tool-group"
               ? expandedToolRows[rowKey] === true


### PR DESCRIPTION
## What changed

- mark assistant-owned transcript rows that continue after the turn-scoped participant header
- apply the shared 36px avatar-and-gap inset to those row contents inside Agent GUI
- preserve host-owned transcript row padding and leave user and goal-control rows unchanged
- extend the existing participant-avatar regression coverage and changeset

## Root cause

Participant presentation intentionally renders each speaker header only once per visible turn. The 28px avatar plus 8px gap inset was attached only to the message flow that rendered that header, while later thinking, progress, tool, processing, image, and summary rows were sibling transcript rows. Those rows therefore jumped 36px left in consumers such as the TSH Agent board.

## Impact

All consumers of `@tutti-os/agent-gui` participant presentation receive one consistent assistant-content left edge without host-specific CSS overrides. Participant presentation disabled mode is unchanged.

## Validation

- targeted Oxfmt formatting completed for the changed TypeScript files
- Prettier confirmed the Agent GUI stylesheet was already formatted
- local test/typecheck gates were intentionally not run under the repository UI-only validation exception; PR CI owns the selected checks