### PR TITLE
refactor(workspace-settings): trim account tab & polish agents table header

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentsSettingsTab.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentsSettingsTab.tsx
@@ -433,7 +433,7 @@ export function WorkspaceAgentsSettingsTab({
         <div
           className={cn(
             agentsTableColumnsClass,
-            "items-center border-b border-[var(--border-1)] px-2 pb-2 text-[12px] font-medium text-[var(--text-tertiary)]"
+            "items-center border-b border-[var(--border-1)] px-2 pb-2 pt-2 text-[12px] font-medium text-[var(--text-tertiary)]"
           )}
           role="row"
         >

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -93,7 +93,6 @@ import {
   LAB_WORKBENCH_SHORTCUTS_FLAG,
   LAB_AUTOMATION_RULES_FLAG,
   LAB_WORKSPACE_AGENTS_FLAG,
-  MOBILE_REMOTE_ACCESS_SETTINGS_FLAG,
   resolveDesktopWorkspaceUiMode
 } from "../../../../../shared/featureFlags/catalog.ts";
 import { resolveWorkspaceAgentGuiLabel } from "../services/workspaceAgentProviderCatalog";
@@ -108,7 +107,6 @@ import {
 } from "../../../../../shared/theme/index.ts";
 import { useWorkspaceSettingsService } from "./useWorkspaceSettingsService";
 import { useWorkspaceWorkbenchHostService } from "./useWorkspaceWorkbenchHostService";
-import { useAccountService } from "./useAccountService";
 import { WorkspaceDeveloperSettingsSection } from "./WorkspaceDeveloperSettingsSection";
 import { WorkspaceLabFeatureGateRows } from "./WorkspaceLabFeatureGateRows";
 import { WorkspaceAgentsSection } from "./WorkspaceAgentsSection";
@@ -133,7 +131,6 @@ import {
   workspaceWallpaperOptions
 } from "../services/workspaceWallpaper";
 import { WorkspaceModelPlansSection } from "./WorkspaceModelPlansSection";
-import { WorkspaceMobileRemoteSettingsSection } from "./WorkspaceMobileRemoteSettingsSection";
 import {
   workspaceSettingsInputClass,
   workspaceSettingsSelectContentClass,
@@ -320,14 +317,6 @@ export function WorkspaceSettingsPanel({
               id: "appearance" as const,
               label: t("workspace.settings.nav.appearance")
             },
-            ...(settingsState.tuttiAgentSwitchEnabled
-              ? [
-                  {
-                    id: "account" as const,
-                    label: t("workspace.settings.nav.account")
-                  }
-                ]
-              : []),
             {
               id: "about" as const,
               label: t("workspace.settings.nav.about")
@@ -600,13 +589,6 @@ export function WorkspaceSettingsPanel({
                 onWorkbenchShortcutsChange={(shortcuts) => {
                   void settingsService.changeWorkbenchShortcuts(shortcuts);
                 }}
-              />
-            ) : settingsState.activeSection === "account" ? (
-              <WorkspaceAccountSettingsSection
-                featureFlags={
-                  desktopPreferencesState.changingFeatureFlags ??
-                  desktopPreferencesState.featureFlags
-                }
               />
             ) : settingsState.activeSection === "about" ? (
               <WorkspaceAboutSettingsSection
@@ -2774,124 +2756,6 @@ function WorkspaceGeneralSettingsSection({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
-  );
-}
-
-function WorkspaceAccountSettingsSection({
-  featureFlags
-}: {
-  featureFlags: DesktopFeatureFlags;
-}) {
-  const { t } = useTranslation();
-  const { service: accountService, state: accountState } = useAccountService();
-  const mobileRemoteAccessSettingsEnabled = isFeatureEnabled(
-    featureFlags,
-    MOBILE_REMOTE_ACCESS_SETTINGS_FLAG
-  );
-
-  useEffect(() => {
-    void accountService.refreshUserInfo();
-  }, [accountService]);
-
-  const handleLogin = async () => {
-    if (accountState.signingOut) {
-      return;
-    }
-    await accountService.startLogin();
-  };
-
-  const handleLogout = async () => {
-    if (accountState.signingIn || accountState.signingOut) {
-      return;
-    }
-    await accountService.logout();
-  };
-
-  const user = accountState.user;
-  const displayName = user?.name || user?.email || user?.user_id || "Tutti";
-
-  return (
-    <div className="flex flex-col gap-6 pb-[22px] pt-5">
-      <div className="flex min-w-0 items-center justify-between gap-4 max-[560px]:flex-col max-[560px]:items-stretch">
-        <div className="flex min-w-0 flex-1 items-center gap-3">
-          {user?.avatar ? (
-            <img
-              alt=""
-              className="size-12 shrink-0 rounded-full object-cover"
-              draggable={false}
-              src={user.avatar}
-            />
-          ) : (
-            <div className="grid size-12 shrink-0 place-items-center rounded-full bg-[var(--transparency-block)] text-[18px] font-semibold text-[var(--text-primary)]">
-              {displayName.slice(0, 1).toUpperCase()}
-            </div>
-          )}
-          <div className="min-w-0">
-            <strong className="block truncate text-[16px] font-semibold leading-6 text-[var(--text-primary)]">
-              {accountState.loading
-                ? t("common.loading")
-                : user
-                  ? displayName
-                  : t("workspace.settings.account.signedOutTitle")}
-            </strong>
-            <p className="m-0 truncate text-[13px] text-[var(--text-secondary)]">
-              {user?.email || t("workspace.settings.account.description")}
-            </p>
-          </div>
-        </div>
-
-        <div className="flex shrink-0 flex-wrap justify-end gap-2 max-[560px]:w-full max-[560px]:justify-start">
-          {user ? (
-            <>
-              <WorkspaceSettingsActionButton
-                className="w-auto min-w-[96px]"
-                disabled={accountState.signingIn || accountState.signingOut}
-                label={
-                  accountState.signingOut
-                    ? t("workspace.settings.account.signingOut")
-                    : t("workspace.settings.account.logout")
-                }
-                onClick={handleLogout}
-              />
-              <WorkspaceSettingsActionButton
-                className="w-auto min-w-[96px]"
-                disabled={accountState.signingIn || accountState.signingOut}
-                label={t("workspace.settings.account.refresh")}
-                onClick={() => void accountService.refreshUserInfo()}
-              />
-            </>
-          ) : (
-            <WorkspaceSettingsActionButton
-              className="w-auto min-w-[104px] max-[560px]:w-full"
-              disabled={accountState.loading || accountState.signingOut}
-              icon={
-                accountState.signingIn ? (
-                  <LoadingIcon className="size-3.5" />
-                ) : null
-              }
-              label={
-                accountState.signingIn
-                  ? t("workspace.settings.account.signingIn")
-                  : accountState.loginStatus === "pending"
-                    ? t("workspace.settings.account.reopenLogin")
-                    : t("workspace.settings.account.login")
-              }
-              onClick={handleLogin}
-              variant="default"
-            />
-          )}
-        </div>
-      </div>
-
-      {accountState.error ? (
-        <p className="m-0 rounded-[6px] bg-[color-mix(in_srgb,var(--state-warning)_16%,transparent)] px-3 py-2 text-[13px] text-[var(--text-primary)]">
-          {accountState.error}
-        </p>
-      ) : null}
-      {user && mobileRemoteAccessSettingsEnabled ? (
-        <WorkspaceMobileRemoteSettingsSection />
-      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Two focused UI improvements to the desktop Settings panel.

### 1. Add 8px top padding to agents table header
`WorkspaceAgentsSettingsTab.tsx` — the agents table header row had no top padding, causing it to sit flush against the auto-update banner above it. Added `pt-2` (8px) so the header breathes.

### 2. Remove the Account tab from the settings sidebar
`WorkspaceSettingsPanel.tsx` — removed the `account` nav entry, its render branch, and the now-unused local `WorkspaceAccountSettingsSection` component (login / logout / refresh account UI), plus the three imports it was the sole consumer of (`useAccountService`, `WorkspaceMobileRemoteSettingsSection`, `MOBILE_REMOTE_ACCESS_SETTINGS_FLAG`).

**Note:** the account service (`accountService`) itself is untouched; only the settings-panel entry point is removed. Account management UI now needs a new home (e.g. top bar / About panel) — tracked separately.

## Changes
- `apps/desktop/.../WorkspaceAgentsSettingsTab.tsx`: +1/-1 (header `pt-2`)
- `apps/desktop/.../WorkspaceSettingsPanel.tsx`: -136 (account tab + component + imports)

## Validation
- `pnpm check:changed` — passed (15 lanes)
- pre-push `pnpm check:changed -- --push-ready` — passed (12 lanes)

## Documentation impact
No durable documentation impact: module ownership, data flow, public API/CLI behavior, runtime/config overrides, validation commands, and troubleshooting paths are unchanged. The `accountService` remains; only a settings-panel entry point was removed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->