### PR TITLE
fix(agent): make session deletion idempotent

### DIFF
--- a/packages/agent/activity-core/src/engine/sessionMutations.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionMutations.reducer.test.ts
@@ -149,6 +149,44 @@ test("delete result emits removals for requested and cascaded sessions", () => {
   ]);
 });
 
+test("delete result accepts an idempotent no-op", () => {
+  const requested = sessionMutationsReducer(
+    createInitialSessionMutationsState(),
+    {
+      agentSessionIds: ["session-1"],
+      mutationId: "delete-replay-1",
+      type: "sessions/deleteRequested",
+      workspaceId: "workspace-1"
+    },
+    { deletedSessionIds: {}, sessionsById: { "session-1": session } }
+  );
+  const succeeded = sessionMutationsReducer(
+    requested.state,
+    {
+      commandId: "delete-replay-1",
+      commandType: "sessions/delete",
+      correlationId: "delete-replay-1",
+      outcome: "succeeded",
+      type: "engine/commandResult",
+      value: {
+        cleanupFailedSessionIds: [],
+        removedMessages: 0,
+        removedSessionIds: [],
+        removedSessions: 0
+      }
+    },
+    { deletedSessionIds: {}, sessionsById: { "session-1": session } }
+  );
+
+  assert.equal(
+    succeeded.state.byMutationId["delete-replay-1"]?.status,
+    "succeeded"
+  );
+  assert.deepEqual(succeeded.followUpIntents, [
+    { agentSessionId: "session-1", type: "session/removed" }
+  ]);
+});
+
 test("settled mutation history stays bounded across unique sessions", () => {
   let state = createInitialSessionMutationsState();
   for (let index = 0; index < 200; index += 1) {

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -89,8 +89,10 @@ every live runtime in that closure, and commits only if the store resolves the
 same closure inside the write transaction. A changed child tree is replanned
 before any tombstone is written. A requested runtime that is live before its
 first canonical report is still closed and cleaned up by the same coordinator;
-the empty canonical plan simply skips the tombstone transaction. Goal provider
-mutations use the same outer session-mutation actor, so clear/set/reconcile work
+the empty canonical plan simply skips the tombstone transaction, so deleting an
+already absent session is a successful no-op and batch responses retain empty
+arrays for their ID fields. Goal provider mutations use the same outer
+session-mutation actor, so clear/set/reconcile work
 cannot race session deletion. Post-commit runtime cleanup failures are reported
 separately from the committed delete result. Authorization, shared bindings,
 transport DTOs,

--- a/packages/agent/host/conformance/session_management_scenarios.go
+++ b/packages/agent/host/conformance/session_management_scenarios.go
@@ -213,6 +213,13 @@ func runDeleteSession(ctx context.Context, driver Driver) error {
 	if _, err := driver.GetSession(ctx, agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-delete"}); !errors.Is(err, agenthost.ErrSessionNotFound) {
 		return fmt.Errorf("get deleted session error=%v", err)
 	}
+	replay, err := driver.DeleteSession(ctx, agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-delete"})
+	if err != nil {
+		return fmt.Errorf("replay delete session: %w", err)
+	}
+	if replay.Deleted || replay.RuntimeClosed || replay.CanonicalRemoved || replay.CleanupFailed {
+		return fmt.Errorf("replay delete result=%#v, want a successful no-op", replay)
+	}
 	return nil
 }
 

--- a/packages/agent/host/session_batch_management_test.go
+++ b/packages/agent/host/session_batch_management_test.go
@@ -26,12 +26,13 @@ func (r *batchRuntime) Close(_ context.Context, input RuntimeCloseInput) error {
 }
 
 type batchManagementStore struct {
-	runtime      *batchRuntime
-	plan         []string
-	input        storesqlite.DeleteSessionsBatchInput
-	changes      int
-	calls        int
-	useExactPlan bool
+	runtime              *batchRuntime
+	plan                 []string
+	input                storesqlite.DeleteSessionsBatchInput
+	changes              int
+	calls                int
+	useExactPlan         bool
+	clearPlanAfterDelete bool
 }
 
 type batchCleanup struct {
@@ -95,11 +96,55 @@ func (s *batchManagementStore) DeleteSessionsBatch(_ context.Context, input stor
 		panic("canonical batch delete ran before all live runtimes closed")
 	}
 	s.input = input
+	if s.clearPlanAfterDelete {
+		s.plan = nil
+	}
 	return storesqlite.DeleteSessionsBatchResult{
 		RemovedSessionIDs: append([]string(nil), input.SessionIDs...),
 		RemovedSessions:   len(input.SessionIDs),
 		RemovedMessages:   3,
 	}, nil
+}
+
+func TestDeleteSessionIsIdempotentWhenCanonicalSessionIsAlreadyGone(t *testing.T) {
+	runtime := &batchRuntime{live: map[string]bool{}}
+	store := &batchManagementStore{
+		runtime:              runtime,
+		plan:                 []string{"session-replay"},
+		useExactPlan:         true,
+		clearPlanAfterDelete: true,
+	}
+	host := New(Config{Runtime: runtime, SessionBatchManagement: store})
+	ref := SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-replay"}
+
+	first, err := host.DeleteSession(t.Context(), ref)
+	if err != nil {
+		t.Fatalf("first DeleteSession() error = %v", err)
+	}
+	if !first.Deleted || !first.CanonicalRemoved {
+		t.Fatalf("first DeleteSession() result = %#v", first)
+	}
+
+	second, err := host.DeleteSession(t.Context(), ref)
+	if err != nil {
+		t.Fatalf("replayed DeleteSession() error = %v", err)
+	}
+	if second.Deleted || second.RuntimeClosed || second.CanonicalRemoved || second.CleanupFailed {
+		t.Fatalf("replayed DeleteSession() result = %#v, want a successful no-op", second)
+	}
+	if store.calls != 1 {
+		t.Fatalf("canonical delete calls = %d, want one committed delete", store.calls)
+	}
+
+	batch, err := host.DeleteSessions(t.Context(), DeleteSessionsInput{
+		WorkspaceID: "workspace-1", SessionIDs: []string{"session-replay"},
+	})
+	if err != nil {
+		t.Fatalf("replayed DeleteSessions() error = %v", err)
+	}
+	if batch.RemovedSessionIDs == nil || batch.RuntimeClosedIDs == nil || batch.CleanupFailedIDs == nil {
+		t.Fatalf("replayed DeleteSessions() result = %#v, want non-nil empty arrays", batch)
+	}
 }
 
 func TestDeleteSessionsUsesOneCanonicalBatchAfterClosingRuntimes(t *testing.T) {

--- a/packages/agent/host/session_management.go
+++ b/packages/agent/host/session_management.go
@@ -152,9 +152,6 @@ func (h *Host) DeleteSession(ctx context.Context, ref SessionRef) (DeleteSession
 		CanonicalRemoved: containsSessionID(batch.RemovedSessionIDs, ref.AgentSessionID),
 		CleanupFailed:    len(batch.CleanupFailedIDs) > 0,
 	}
-	if !result.Deleted {
-		return DeleteSessionResult{}, ErrSessionNotFound
-	}
 	return result, nil
 }
 
@@ -246,11 +243,11 @@ func (h *Host) DeleteSessions(ctx context.Context, input DeleteSessionsInput) (D
 		}
 	}
 	return DeleteSessionsResult{
-		RemovedSessionIDs: append([]string(nil), deleted.RemovedSessionIDs...),
+		RemovedSessionIDs: copySessionIDs(deleted.RemovedSessionIDs),
 		RemovedSessions:   deleted.RemovedSessions,
 		RemovedMessages:   deleted.RemovedMessages,
-		RuntimeClosedIDs:  runtimeClosedIDs,
-		CleanupFailedIDs:  cleanupFailedIDs,
+		RuntimeClosedIDs:  copySessionIDs(runtimeClosedIDs),
+		CleanupFailedIDs:  copySessionIDs(cleanupFailedIDs),
 	}, nil
 }
 
@@ -283,6 +280,13 @@ func containsSessionID(values []string, expected string) bool {
 		}
 	}
 	return false
+}
+
+func copySessionIDs(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	return append([]string(nil), values...)
 }
 
 func normalizedUniqueSessionIDs(values []string) []string {

--- a/services/tuttid/api/daemon_agent_session_list.go
+++ b/services/tuttid/api/daemon_agent_session_list.go
@@ -190,9 +190,9 @@ func (api DaemonAPI) DeleteWorkspaceAgentSessionsBatch(ctx context.Context, requ
 	}
 	return tuttigenerated.DeleteWorkspaceAgentSessionsBatch200JSONResponse{
 		RemovedMessages:         result.RemovedMessages,
-		RemovedSessionIds:       result.RemovedSessionIDs,
+		RemovedSessionIds:       append([]string{}, result.RemovedSessionIDs...),
 		RemovedSessions:         result.RemovedSessions,
-		CleanupFailedSessionIds: result.CleanupFailedSessionIDs,
+		CleanupFailedSessionIds: append([]string{}, result.CleanupFailedSessionIDs...),
 	}, nil
 }
 

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -65,7 +65,7 @@ func (api DaemonAPI) ClearWorkspaceAgentSessions(ctx context.Context, request tu
 	return tuttigenerated.ClearWorkspaceAgentSessions200JSONResponse{
 		RemovedMessages:         result.RemovedMessages,
 		RemovedSessions:         result.RemovedSessions,
-		CleanupFailedSessionIds: append([]string(nil), result.CleanupFailedSessionIDs...),
+		CleanupFailedSessionIds: append([]string{}, result.CleanupFailedSessionIDs...),
 	}, nil
 }
 

--- a/services/tuttid/api/daemon_test.go
+++ b/services/tuttid/api/daemon_test.go
@@ -1232,6 +1232,36 @@ func TestDaemonAPIGeneratedRoutesDeleteAgentSessionsBatchForwardsExactIDs(t *tes
 	}
 }
 
+func TestDaemonAPIGeneratedRoutesDeleteAgentSessionsBatchKeepsEmptyIDArrays(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		AgentSessionService: stubAgentSessionService{
+			deleteSessionsBatchFn: func(context.Context, string, agentservice.DeleteSessionsBatchInput) (agentservice.DeleteSessionsBatchResult, error) {
+				return agentservice.DeleteSessionsBatchResult{}, nil
+			},
+		},
+	}))
+
+	recorder := performGeneratedRouteRequest(
+		t,
+		mux,
+		http.MethodDelete,
+		"/v1/workspaces/ws-1/agent-sessions/batch",
+		tuttigenerated.DeleteWorkspaceAgentSessionsBatchRequest{SessionIds: []string{"already-absent"}},
+	)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var response tuttigenerated.DeleteWorkspaceAgentSessionsBatchResponse
+	decodeGeneratedRouteResponse(t, recorder, &response)
+	if response.RemovedSessionIds == nil || response.CleanupFailedSessionIds == nil {
+		t.Fatalf("response = %#v, want empty arrays", response)
+	}
+	if len(response.RemovedSessionIds) != 0 || len(response.CleanupFailedSessionIds) != 0 {
+		t.Fatalf("response = %#v, want empty arrays", response)
+	}
+}
+
 func TestDaemonAPIGeneratedRoutesDeleteAgentSessionsBatchRejectsInvalidIDs(t *testing.T) {
 	deleteCalls := 0
 	mux := http.NewServeMux()

--- a/services/tuttid/service/agent/service_session_sections.go
+++ b/services/tuttid/service/agent/service_session_sections.go
@@ -394,8 +394,8 @@ func (s *Service) DeleteSessionsBatch(
 	return DeleteSessionsBatchResult{
 		RemovedMessages:         hostResult.RemovedMessages,
 		RemovedSessions:         hostResult.RemovedSessions,
-		RemovedSessionIDs:       hostResult.RemovedSessionIDs,
-		CleanupFailedSessionIDs: hostResult.CleanupFailedIDs,
+		RemovedSessionIDs:       append([]string{}, hostResult.RemovedSessionIDs...),
+		CleanupFailedSessionIDs: append([]string{}, hostResult.CleanupFailedIDs...),
 	}, nil
 }
 

--- a/services/tuttid/service/agent/service_tutti_mode_deletion_test.go
+++ b/services/tuttid/service/agent/service_tutti_mode_deletion_test.go
@@ -9,24 +9,25 @@ import (
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 )
 
-func TestDeleteRetryConvergesTuttiModeCleanupForOrphanState(t *testing.T) {
+func TestDeleteRetryIsIdempotentForMissingSession(t *testing.T) {
 	t.Parallel()
-	wantErr := errors.New("temporary activation cleanup failure")
 	reader := &fakeSessionReader{sessions: map[string]PersistedSession{}}
-	coordinator := &fakeTuttiModeActivationCoordinator{deleteErrors: []error{wantErr, nil}}
+	coordinator := &fakeTuttiModeActivationCoordinator{}
 	service := NewService(&fakeRuntime{sessions: map[string]ProviderRuntimeSession{}})
 	service.SessionReader = reader
 	service.TuttiModeActivations = coordinator
 	configureTestApplicationHost(service)
 
-	if _, err := service.Delete(context.Background(), "workspace-1", "session-1"); !errors.Is(err, wantErr) {
-		t.Fatalf("first Delete() error = %v", err)
+	first, err := service.Delete(context.Background(), "workspace-1", "session-1")
+	if err != nil || first.Removed {
+		t.Fatalf("first Delete() result=%#v error=%v, want successful no-op", first, err)
 	}
-	if _, err := service.Delete(context.Background(), "workspace-1", "session-1"); !errors.Is(err, ErrSessionNotFound) {
-		t.Fatalf("retry Delete() error = %v, want ErrSessionNotFound after cleanup", err)
+	second, err := service.Delete(context.Background(), "workspace-1", "session-1")
+	if err != nil || second.Removed {
+		t.Fatalf("retry Delete() result=%#v error=%v, want successful no-op", second, err)
 	}
-	if !slices.Equal(coordinator.deleteSessionIDs, []string{"session-1", "session-1"}) {
-		t.Fatalf("cleanup calls = %#v", coordinator.deleteSessionIDs)
+	if len(coordinator.deleteSessionIDs) != 0 {
+		t.Fatalf("cleanup calls = %#v, want none for a missing session", coordinator.deleteSessionIDs)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Treat deleting an already absent agent session as a successful no-op.
- Preserve empty batch deletion ID fields as JSON arrays (`[]`) across Host, service, and API boundaries.
- Add Host/conformance, service, API, and frontend reducer regression coverage.
- Document the idempotent deletion contract.

## Why

A delete can be replayed after the first request has already committed the tombstone. The previous Host response converted that expected state into `ErrSessionNotFound`; in addition, nil slices could serialize as `null`, causing the frontend result validator to report `session mutation unknown`.

## Validation

- `go test ./packages/agent/host/... ./services/tuttid/api ./services/tuttid/service/agent`
- Frontend session mutation reducer tests
- `pnpm check:changed -- --push-ready` (19 lanes)