### PR TITLE
fix(desktop): allow renderer fetches for image protocols

### DIFF
--- a/apps/desktop/src/main/bootstrap.ts
+++ b/apps/desktop/src/main/bootstrap.ts
@@ -1,6 +1,6 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, protocol } from "electron";
 import {
   initializeDesktopEnvironment,
   resolveDesktopDevelopmentAppName,
@@ -37,15 +37,10 @@ import { getSystemDesktopLocale } from "./desktopLocale";
 import { openDesktopWorkspaceAppFolder } from "./host/workspaceAppFolderAccess";
 import { openPerfMonitorDevToolsWindow } from "./windows/perfMonitorDevToolsWindow.ts";
 import { createTranslator } from "../shared/i18n/index.ts";
-import {
-  registerTuttiAssetProtocol,
-  registerTuttiAssetProtocolScheme
-} from "./host/tuttiAssetProtocol.ts";
+import { registerTuttiAssetProtocol } from "./host/tuttiAssetProtocol.ts";
+import { desktopCustomProtocolSchemes } from "./host/desktopCustomProtocolSchemes.ts";
 import { createWorkspaceFileIconCacheStore } from "./host/workspaceFileIconCacheStore.ts";
-import {
-  registerWorkspaceFileIconProtocol,
-  registerWorkspaceFileIconProtocolScheme
-} from "./host/workspaceFileIconProtocol.ts";
+import { registerWorkspaceFileIconProtocol } from "./host/workspaceFileIconProtocol.ts";
 
 function envFlagEnabled(value: string | undefined): boolean {
   return /^(1|true|yes|on)$/iu.test(value?.trim() ?? "");
@@ -84,8 +79,7 @@ export async function bootstrapDesktopApp(): Promise<void> {
     appVersion: app.getVersion(),
     isPackaged: app.isPackaged
   });
-  registerTuttiAssetProtocolScheme();
-  registerWorkspaceFileIconProtocolScheme();
+  protocol.registerSchemesAsPrivileged(desktopCustomProtocolSchemes);
   const loginCallbackUrl = resolveDesktopLoginCallbackUrl();
   const protocolClientRegistration =
     resolveDesktopLoginProtocolClientRegistration({

--- a/apps/desktop/src/main/host/desktopCustomProtocolSchemes.test.ts
+++ b/apps/desktop/src/main/host/desktopCustomProtocolSchemes.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { tuttiAssetProtocolScheme } from "../../shared/tuttiAssetProtocol.ts";
+import { desktopCustomProtocolSchemes } from "./desktopCustomProtocolSchemes.ts";
+import { workspaceFileIconProtocolScheme } from "./workspaceFileIconCacheStore.ts";
+
+test("desktop image protocols support cross-origin renderer fetch", () => {
+  for (const scheme of [
+    tuttiAssetProtocolScheme,
+    workspaceFileIconProtocolScheme
+  ]) {
+    const definition = desktopCustomProtocolSchemes.find(
+      (candidate) => candidate.scheme === scheme
+    );
+
+    assert.equal(definition?.privileges?.supportFetchAPI, true);
+    assert.equal(definition?.privileges?.corsEnabled, true);
+  }
+});

--- a/apps/desktop/src/main/host/desktopCustomProtocolSchemes.ts
+++ b/apps/desktop/src/main/host/desktopCustomProtocolSchemes.ts
@@ -1,0 +1,24 @@
+import type { CustomScheme } from "electron";
+import { tuttiAssetProtocolScheme } from "../../shared/tuttiAssetProtocol.ts";
+import { workspaceFileIconProtocolScheme } from "./workspaceFileIconCacheStore.ts";
+
+export const desktopCustomProtocolSchemes = [
+  {
+    privileges: {
+      corsEnabled: true,
+      secure: true,
+      standard: true,
+      supportFetchAPI: true
+    },
+    scheme: tuttiAssetProtocolScheme
+  },
+  {
+    privileges: {
+      corsEnabled: true,
+      secure: true,
+      standard: true,
+      supportFetchAPI: true
+    },
+    scheme: workspaceFileIconProtocolScheme
+  }
+] satisfies CustomScheme[];

--- a/apps/desktop/src/main/host/tuttiAssetProtocol.ts
+++ b/apps/desktop/src/main/host/tuttiAssetProtocol.ts
@@ -1,27 +1,9 @@
 import { pathToFileURL } from "node:url";
-import { app, net, protocol, session, type Session } from "electron";
+import { app, net, session, type Session } from "electron";
 import { tuttiAssetProtocolScheme } from "../../shared/tuttiAssetProtocol.ts";
 import { resolveTuttiAssetProtocolFilePath } from "./tuttiAssetProtocolResolver.ts";
 
-let schemeRegistered = false;
 const handledSessions = new WeakSet<Session>();
-
-export function registerTuttiAssetProtocolScheme(): void {
-  if (schemeRegistered) {
-    return;
-  }
-  schemeRegistered = true;
-  protocol.registerSchemesAsPrivileged([
-    {
-      privileges: {
-        secure: true,
-        standard: true,
-        supportFetchAPI: true
-      },
-      scheme: tuttiAssetProtocolScheme
-    }
-  ]);
-}
 
 export function registerTuttiAssetProtocol(): void {
   registerTuttiAssetProtocolForSession(session.defaultSession);

--- a/apps/desktop/src/main/host/workspaceFileIconProtocol.ts
+++ b/apps/desktop/src/main/host/workspaceFileIconProtocol.ts
@@ -5,25 +5,7 @@ import {
   type WorkspaceFileIconCacheStore
 } from "./workspaceFileIconCacheStore.ts";
 
-let schemeRegistered = false;
 let protocolHandled = false;
-
-export function registerWorkspaceFileIconProtocolScheme(): void {
-  if (schemeRegistered) {
-    return;
-  }
-  schemeRegistered = true;
-  protocol.registerSchemesAsPrivileged([
-    {
-      privileges: {
-        secure: true,
-        standard: true,
-        supportFetchAPI: true
-      },
-      scheme: workspaceFileIconProtocolScheme
-    }
-  ]);
-}
 
 export function registerWorkspaceFileIconProtocol(
   store: WorkspaceFileIconCacheStore

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -50,6 +50,7 @@ Electron startup, daemon supervision, macOS packaging, updates, and performance 
 React rendering, Workbench state, external stores, input composition, and UI performance.
 
 - [Renderer body requests fail with `ERR_H2_OR_QUIC_REQUIRED`](./workbench-renderer.md#renderer-body-requests-fail-with-err_h2_or_quic_required)
+- [Renderer `fetch()` rejects an Electron image protocol that `<img>` can load](./workbench-renderer.md#renderer-fetch-rejects-an-electron-image-protocol-that-img-can-load)
 - [Renderer tile memory warnings from hidden autoplay animation](./workbench-renderer.md#renderer-tile-memory-warnings-from-hidden-autoplay-animation)
 - [Standalone Agent dev window stays black during cold startup](./workbench-renderer.md#standalone-agent-dev-window-stays-black-during-cold-startup)
 - [IME composition breaks fuzzy search or controlled search inputs](./workbench-renderer.md#ime-composition-breaks-fuzzy-search-or-controlled-search-inputs)

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -205,6 +205,39 @@
   [createRestartAwareFetch.ts](../../../apps/desktop/src/renderer/src/platform/tuttid/createRestartAwareFetch.ts)
   [desktop-transport.md](../../architecture/desktop-transport.md)
 
+### Renderer `fetch()` rejects an Electron image protocol that `<img>` can load
+
+- Symptom:
+  An image rendered from a Desktop custom protocol remains visible, but
+  renderer code that inlines or resizes the same image logs
+  `Fetch API cannot load` and `URL scheme ... is not supported`. Catching the
+  rejected promise does not suppress Chromium's console message.
+- Quick checks:
+  Find the scheme passed to `fetch()`. Confirm its privileged registration
+  enables both `supportFetchAPI` and `corsEnabled`, runs before Electron
+  `ready`, and its handler is installed on the renderer's exact `Session`.
+  A working `<img>` only proves the no-CORS subresource path and protocol
+  handler; it does not prove that renderer JavaScript may read the response.
+- Root cause:
+  The renderer page and custom protocol have different origins. Electron
+  permits `<img>` to load a no-CORS custom-protocol response, but blocks a
+  cross-origin `fetch()` from reading it when the scheme is not CORS-enabled.
+- Fix:
+  For fixed, non-sensitive image routes that renderer code must inline, register
+  the scheme with `supportFetchAPI: true` and `corsEnabled: true`. Register all
+  privileged Desktop schemes together in the single pre-`ready` call, then
+  install handlers on every intended Session. Do not enable cross-origin reads
+  for protocols that expose arbitrary or sensitive local files.
+- Validation:
+  Keep a contract test over every fetchable image scheme, run the Desktop
+  Electron boundary checks and typecheck, and build the production Desktop
+  bundle. Verify the renderer can read the response body, not only display the
+  URL in an image element.
+- References:
+  [desktopCustomProtocolSchemes.ts](../../../apps/desktop/src/main/host/desktopCustomProtocolSchemes.ts)
+  [tuttiAssetProtocol.ts](../../../apps/desktop/src/main/host/tuttiAssetProtocol.ts)
+  [workspaceFileIconProtocol.ts](../../../apps/desktop/src/main/host/workspaceFileIconProtocol.ts)
+
 ### Renderer tile memory warnings from hidden autoplay animation
 
 - Symptom:


### PR DESCRIPTION
## Summary
- allow renderer `fetch()` to read fixed Desktop image protocols by enabling CORS
- register privileged Desktop schemes together before Electron `ready`
- cover both asset and file-icon protocols and document the troubleshooting pattern

## Tests
- `pnpm check:changed -- --push-ready`
- `pnpm --filter @tutti-os/desktop build`

## Notes
- a hidden Electron renderer smoke test fetched a custom-protocol response body with status 200

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->