### PR TITLE
fix(agent): align live tool output message identity

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -820,11 +820,13 @@ provider-neutral `payload.output.text` display projection. A provider adapter
 may emit it only from an explicit ordered output-delta event, or from a
 cumulative textual output snapshot whose exact prefix relationship the adapter
 has verified. It must not classify by tool name or inspect arbitrary structured
-tool results. The first output uses `set`; later `append_text` operations carry
-the prior UTF-8 byte length as `offsetBytes`. A missing anchor or offset
-mismatch triggers canonical reconciliation instead of guessed concatenation.
-Completed, failed, canceled, and rewritten tool results remain full canonical
-`message_update` snapshots.
+tool results. Every output operation uses the exact `messageId` of the
+canonical tool-call anchor; provider-normalizer event ids are internal
+lifecycle identities and must not create a second optimistic row. The first
+output uses `set`; later `append_text` operations carry the prior UTF-8 byte
+length as `offsetBytes`. A missing anchor or offset mismatch triggers canonical
+reconciliation instead of guessed concatenation. Completed, failed, canceled,
+and rewritten tool results remain full canonical `message_update` snapshots.
 
 The Go live-protocol adapter owns the complete fast-lane envelope on both sides
 of a device link: schema validation, recipient identity projection,

--- a/packages/agent/daemon/runtime/activity_projection.go
+++ b/packages/agent/daemon/runtime/activity_projection.go
@@ -40,7 +40,7 @@ func ProjectActivityEventsToStreamEvents(session Session, events []activityshare
 				Data:      patch,
 			})
 		}
-		if delta, ok := liveMessageDeltaFromSessionEvent(session, event, timestamp); ok {
+		if delta, ok := liveMessageDeltaFromSessionEvent(session, event, sessionID, timestamp); ok {
 			out = append(out, StreamEvent{
 				EventType: StreamEventMessageDelta,
 				Data:      delta,
@@ -71,13 +71,26 @@ func ProjectActivityEventsToStreamEvents(session Session, events []activityshare
 	return out
 }
 
-func liveMessageDeltaFromSessionEvent(session Session, event activityshared.Event, timestamp int64) (liveprotocol.Event, bool) {
+func liveMessageDeltaFromSessionEvent(
+	session Session,
+	event activityshared.Event,
+	sessionID string,
+	timestamp int64,
+) (liveprotocol.Event, bool) {
 	contentOperation, _ := event.Payload.Metadata[liveContentOperationMetadataKey].(*liveprotocol.MessageContentOperation)
 	toolOutputOperation, _ := event.Payload.Metadata[liveToolOutputOperationMetadataKey].(*liveprotocol.MessageToolOutputOperation)
 	if contentOperation == nil && toolOutputOperation == nil {
 		return liveprotocol.Event{}, false
 	}
 	messageID := firstNonEmptyString(stringFromPayload(event.Payload.Metadata, "messageId"), event.EventID)
+	if toolOutputOperation != nil {
+		// Tool-call persistence deliberately keys the canonical message by call
+		// identity (`toolcall:<callId>`), while EventID is the normalizer's
+		// internal lifecycle identity. The live output must target that same
+		// canonical anchor or the optimistic overlay would create a second,
+		// output-only tool row.
+		messageID = toolCallMessageUpdateID(event, sessionID, timestamp)
+	}
 	if messageID == "" || strings.TrimSpace(event.Payload.TurnID) == "" || timestamp <= 0 {
 		return liveprotocol.Event{}, false
 	}

--- a/packages/agent/daemon/runtime/activity_projection_test.go
+++ b/packages/agent/daemon/runtime/activity_projection_test.go
@@ -222,6 +222,21 @@ func TestExplicitToolOutputDeltaPersistsSnapshotAndProjectsOffsetAppend(t *testi
 	if len(report.MessageUpdates) != 1 {
 		t.Fatalf("report = %#v, want one cumulative tool snapshot", report)
 	}
+	startReport := reportActivityInput(session, started)
+	if len(startReport.MessageUpdates) != 1 {
+		t.Fatalf("start report = %#v, want one canonical tool anchor", startReport)
+	}
+	if firstDelta.MessageID != startReport.MessageUpdates[0].MessageID ||
+		secondDelta.MessageID != startReport.MessageUpdates[0].MessageID ||
+		report.MessageUpdates[0].MessageID != startReport.MessageUpdates[0].MessageID {
+		t.Fatalf(
+			"tool message identity = start:%q first:%q second:%q snapshot:%q, want one canonical anchor",
+			startReport.MessageUpdates[0].MessageID,
+			firstDelta.MessageID,
+			secondDelta.MessageID,
+			report.MessageUpdates[0].MessageID,
+		)
+	}
 	output, _ := report.MessageUpdates[0].Payload["output"].(map[string]any)
 	if output["text"] != "你好\n" {
 		t.Fatalf("persisted output = %#v", output)

--- a/packages/agent/daemon/runtime/codex_appserver_events_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events_test.go
@@ -97,6 +97,10 @@ func TestCodexAppServerCommandOutputDeltaUsesToolOutputFastLane(t *testing.T) {
 	if len(started.Events) != 1 || started.Events[0].Type != activityshared.EventCallStarted {
 		t.Fatalf("started events = %#v", started.Events)
 	}
+	startReport := reportActivityInput(session, started.Events)
+	if len(startReport.MessageUpdates) != 1 {
+		t.Fatalf("started report = %#v, want one canonical tool anchor", startReport)
+	}
 
 	output := reducer.ReduceNotification(
 		nil,
@@ -130,6 +134,47 @@ func TestCodexAppServerCommandOutputDeltaUsesToolOutputFastLane(t *testing.T) {
 		data.ToolOutput.Operation != "set" ||
 		data.ToolOutput.Text != "hello" {
 		t.Fatalf("tool output delta = %#v", data.ToolOutput)
+	}
+	if data.MessageID != startReport.MessageUpdates[0].MessageID {
+		t.Fatalf(
+			"live output message id = %q, want canonical start anchor %q",
+			data.MessageID,
+			startReport.MessageUpdates[0].MessageID,
+		)
+	}
+
+	completed := reducer.ReduceNotification(
+		nil,
+		session,
+		"turn-1",
+		acpMessage{
+			Method: appServerNotifyItemCompleted,
+			Params: mustJSONRawMessage(t, map[string]any{
+				"threadId": "thread-1",
+				"turnId":   "provider-turn-1",
+				"item": map[string]any{
+					"type": "commandExecution", "id": "command-1",
+					"command": "printf hello", "status": "completed",
+					"aggregatedOutput": "hello", "exitCode": 0,
+				},
+			}),
+		},
+		normalizer,
+		nil,
+	)
+	if len(completed.Events) != 1 || completed.Events[0].Type != activityshared.EventCallCompleted {
+		t.Fatalf("completed events = %#v", completed.Events)
+	}
+	completedReport := reportActivityInput(session, completed.Events)
+	if len(completedReport.MessageUpdates) != 1 {
+		t.Fatalf("completed report = %#v, want one canonical terminal tool update", completedReport)
+	}
+	if completedReport.MessageUpdates[0].MessageID != startReport.MessageUpdates[0].MessageID {
+		t.Fatalf(
+			"completed message id = %q, want canonical start anchor %q",
+			completedReport.MessageUpdates[0].MessageID,
+			startReport.MessageUpdates[0].MessageID,
+		)
 	}
 }
 


### PR DESCRIPTION
## What changed

- derive live `toolOutput` message IDs from the same canonical `toolcall:<callId>` identity used by persisted tool-call messages
- keep normalizer event IDs internal instead of exposing them as optimistic message anchors
- add projection and Codex app-server regressions covering stable tool output identity
- document the canonical/live identity contract

## Why

Tool output deltas previously used the normalizer event ID while the durable tool message used `toolcall:<callId>`. A caller could therefore materialize a second output-only tool row and fail to reconcile the optimistic overlay with the canonical snapshot.

## Impact and risk

The change is limited to the daemon live projection. Canonical storage, local-agent message identity, schemas, and lifecycle behavior are unchanged. Text deltas retain their existing identity rules.

## Verification

- `go test ./packages/agent/daemon/...`
- `pnpm check:changed -- --push-ready` (8 lanes passed)
- real Codex shared-agent run through TSH `make dev-web`: tool anchor, `toolOutput.set`, every `append_text`, and the terminal canonical message all used one `toolcall:<callId>`