### PR TITLE
fix(agent-gui): use React contentEditable property

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentCapabilityTokenExtension.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentCapabilityTokenExtension.ts
@@ -57,7 +57,7 @@ export function createAgentCapabilityTokenExtension(
         "span",
         mergeAttributes(HTMLAttributes, {
           "aria-label": attrs.label,
-          contenteditable: "false",
+          contentEditable: "false",
           "data-agent-capability-token": "true",
           "data-agent-capability-trigger": attrs.trigger,
           "data-agent-mention-kind": "capability",

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentSkillTokenExtension.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentSkillTokenExtension.ts
@@ -53,7 +53,7 @@ export function createAgentSkillTokenExtension(
         "span",
         mergeAttributes(HTMLAttributes, {
           "aria-label": attrs.label,
-          contenteditable: "false",
+          contentEditable: "false",
           "data-agent-skill-token": "true",
           "data-agent-skill-trigger": attrs.trigger,
           "data-agent-mention-kind": "skill",

--- a/packages/agent/gui/shared/AgentRichTextReadonly.spec.tsx
+++ b/packages/agent/gui/shared/AgentRichTextReadonly.spec.tsx
@@ -1,7 +1,11 @@
 import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, waitFor } from "@testing-library/react";
+import { renderToReactElement } from "@tiptap/static-renderer";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AgentRichTextReadonly } from "./AgentRichTextReadonly";
+import { createAgentCapabilityTokenExtension } from "../agent-gui/agentGuiNode/agentRichText/agentCapabilityTokenExtension";
+import { createAgentRichTextReadonlyExtensions } from "../agent-gui/agentGuiNode/agentRichText/agentRichTextExtensions";
+import { createAgentSkillTokenExtension } from "../agent-gui/agentGuiNode/agentRichText/agentSkillTokenExtension";
 import {
   registerAgentCustomMentionKind,
   resetAgentCustomMentionKindsForTests
@@ -364,5 +368,71 @@ describe("AgentRichTextReadonly", () => {
     expect(skillToken).toHaveTextContent("/caveman");
     expect(skillToken).toHaveAttribute("data-agent-skill-trigger", "/caveman");
     expect(container).toHaveTextContent("/compact");
+  });
+
+  it("renders readonly agent tokens without invalid React DOM properties", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const extensions = createAgentRichTextReadonlyExtensions();
+
+    for (const token of [
+      {
+        attrs: {
+          capability: "browser",
+          label: "Browser",
+          name: "browser",
+          trigger: "/browser"
+        },
+        dataAttribute: "data-agent-capability-token",
+        extension: createAgentCapabilityTokenExtension(),
+        type: "agentCapabilityToken"
+      },
+      {
+        attrs: {
+          label: "Caveman",
+          name: "caveman",
+          trigger: "/caveman"
+        },
+        dataAttribute: "data-agent-skill-token",
+        extension: createAgentSkillTokenExtension(),
+        type: "agentSkillToken"
+      }
+    ]) {
+      const renderHTML = token.extension.config.renderHTML as
+        | ((props: { HTMLAttributes: Record<string, unknown> }) => unknown)
+        | undefined;
+      const outputSpec = renderHTML?.({ HTMLAttributes: token.attrs });
+      const outputAttributes = Array.isArray(outputSpec)
+        ? (outputSpec[1] as Record<string, unknown>)
+        : {};
+
+      expect(outputAttributes.contentEditable).toBe("false");
+      expect(outputAttributes.contenteditable).toBeUndefined();
+
+      const content = renderToReactElement({
+        content: {
+          content: [
+            {
+              content: [{ attrs: token.attrs, type: token.type }],
+              type: "paragraph"
+            }
+          ],
+          type: "doc"
+        },
+        extensions
+      });
+
+      const rendered = render(content);
+
+      expect(
+        rendered.container.querySelector(`[${token.dataAttribute}="true"]`)
+      ).toHaveAttribute("contenteditable", "false");
+      rendered.unmount();
+    }
+
+    expect(consoleError.mock.calls.flat().join(" ")).not.toContain(
+      "Invalid DOM property `contenteditable`"
+    );
   });
 });


### PR DESCRIPTION
## Summary
- use React-compatible contentEditable attributes for capability and skill tokens
- add readonly rendering regression coverage for both token types

## Tests
- pnpm check:changed -- --push-ready

## Notes
- no documentation impact
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->