### PR TITLE
fix(agent): preserve tool output before start anchor

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -825,8 +825,14 @@ canonical tool-call anchor; provider-normalizer event ids are internal
 lifecycle identities and must not create a second optimistic row. The first
 output uses `set`; later `append_text` operations carry the prior UTF-8 byte
 length as `offsetBytes`. A missing anchor or offset mismatch triggers canonical
-reconciliation instead of guessed concatenation. Completed, failed, canceled,
-and rewritten tool results remain full canonical `message_update` snapshots.
+reconciliation instead of guessed concatenation. When an explicit provider
+output notification races immediately ahead of its `item/started`, the
+provider normalizer may retain that prefix in a bounded pre-anchor buffer, but
+it must emit nothing until the real anchor arrives; it then publishes the
+anchor first and the retained prefix as `set`. An unmatched or oversized
+prefix is dropped with diagnostics rather than inventing a tool row.
+Completed, failed, canceled, and rewritten tool results remain full canonical
+`message_update` snapshots.
 
 The Go live-protocol adapter owns the complete fast-lane envelope on both sides
 of a device link: schema validation, recipient identity projection,

--- a/packages/agent/daemon/runtime/acp_turn_normalizer.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer.go
@@ -27,6 +27,8 @@ type acpTurnNormalizer struct {
 	toolCallsSeen             map[string]bool
 	pendingToolCalls          map[string]pendingToolCallSnapshot
 	toolOutputText            map[string]string
+	earlyToolOutput           map[string]earlyToolOutputSnapshot
+	earlyToolOutputBytes      int
 	fileChanges               map[string]any
 	compactionMu              sync.Mutex
 	compactionMessageID       string
@@ -116,6 +118,7 @@ func newACPTurnNormalizer() *acpTurnNormalizer {
 		toolCallsSeen:    make(map[string]bool),
 		pendingToolCalls: make(map[string]pendingToolCallSnapshot),
 		toolOutputText:   make(map[string]string),
+		earlyToolOutput:  make(map[string]earlyToolOutputSnapshot),
 	}
 }
 
@@ -419,6 +422,7 @@ func (n *acpTurnNormalizer) ToolCallEvents(session Session, turnID string, updat
 		}
 		return appendTurnFileChangesEvent(nil, []activityshared.Event{event}, event), true
 	}
+	rawToolCallID := firstNonEmpty(asString(update["toolCallId"]), asString(update["id"]))
 	eventID := n.toolItemID(update)
 	if eventID == "" {
 		return nil, false
@@ -430,6 +434,7 @@ func (n *acpTurnNormalizer) ToolCallEvents(session Session, turnID string, updat
 	n.trackToolCallEvent(event)
 	events := n.Finish(session, turnID, messageStreamStateCompleted)
 	events = append(events, event)
+	events = append(events, n.consumeEarlyToolOutput(session, turnID, rawToolCallID)...)
 	events = appendTurnFileChangesEvent(n, events, event)
 	return events, true
 }
@@ -481,79 +486,16 @@ func (n *acpTurnNormalizer) StandardToolCallEvents(session Session, turnID strin
 		}
 		return appendTurnFileChangesEvent(nil, []activityshared.Event{event}, event), true
 	}
+	rawToolCallID := firstNonEmpty(asString(update["toolCallId"]), asString(update["callId"]), asString(update["id"]))
 	event, ok := n.StandardToolCallEvent(session, turnID, updateType, update)
 	if !ok {
 		return nil, false
 	}
 	events := n.Finish(session, turnID, messageStreamStateCompleted)
 	events = append(events, event)
+	events = append(events, n.consumeEarlyToolOutput(session, turnID, rawToolCallID)...)
 	events = appendTurnFileChangesEvent(n, events, event)
 	return events, true
-}
-
-// AppendToolOutputDelta projects an explicit provider-ordered tool output
-// chunk onto the stable tool_call message created by the corresponding start
-// event. It keeps the cumulative snapshot on the activity event for local
-// persistence while attaching only the semantic operation used by the live
-// fast lane. Callers must not feed inferred or arbitrary structured payloads
-// into this method.
-func (n *acpTurnNormalizer) AppendToolOutputDelta(
-	session Session,
-	turnID string,
-	rawToolCallID string,
-	delta string,
-) []activityshared.Event {
-	if n == nil || delta == "" {
-		return nil
-	}
-	eventID := n.knownToolItemID(rawToolCallID)
-	pending, ok := n.pendingToolCalls[eventID]
-	if !ok || strings.TrimSpace(eventID) == "" {
-		// An output delta without its start anchor is unsafe to invent: the
-		// transport sequence/reconcile path will recover from an actual gap.
-		return nil
-	}
-	current := n.toolOutputText[eventID]
-	next := current + delta
-	payload := clonePayload(pending.payload)
-	if payload == nil {
-		payload = map[string]any{}
-	}
-	output := payloadMap(payload, "output")
-	output = clonePayload(output)
-	if output == nil {
-		output = map[string]any{}
-	}
-	output["text"] = next
-	payload["output"] = output
-	payload["status"] = string(activityshared.ActivityStatusRunning)
-
-	operation := &liveprotocol.MessageToolOutputOperation{
-		Operation: "set",
-		Text:      next,
-	}
-	if current != "" {
-		offset := int64(len(current))
-		operation = &liveprotocol.MessageToolOutputOperation{
-			Operation:   "append_text",
-			Text:        delta,
-			OffsetBytes: &offset,
-		}
-	}
-	event := newTurnActivityEventWithID(
-		session,
-		eventID,
-		EventCallStarted,
-		turnID,
-		messageStreamStateStreaming,
-		"",
-		stringFromPayload(payload, "name"),
-		payload,
-	)
-	attachToolOutputLiveOperation(&event, operation)
-	n.toolOutputText[eventID] = next
-	n.trackToolCallEvent(event)
-	return []activityshared.Event{event}
 }
 
 func appendTurnFileChangesEvent(

--- a/packages/agent/daemon/runtime/acp_turn_normalizer_tool_output.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer_tool_output.go
@@ -1,0 +1,149 @@
+package agentruntime
+
+import (
+	"log/slog"
+	"strings"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+	"github.com/tutti-os/tutti/packages/agent/daemon/liveprotocol"
+)
+
+type earlyToolOutputSnapshot struct {
+	turnID  string
+	text    string
+	dropped bool
+}
+
+const maxEarlyToolOutputCalls = 64
+
+// AppendToolOutputDelta projects an explicit provider-ordered tool output
+// chunk onto the stable tool_call message created by the corresponding start
+// event. Some providers can deliver the first output notification immediately
+// before item/started. That prefix is buffered, within one live-delivery frame,
+// and emitted only after the real anchor arrives; an anchor is never invented.
+// The cumulative snapshot remains on the activity event for local persistence
+// while only the semantic operation is attached to the live fast lane. Callers
+// must not feed inferred or arbitrary structured payloads into this method.
+func (n *acpTurnNormalizer) AppendToolOutputDelta(
+	session Session,
+	turnID string,
+	rawToolCallID string,
+	delta string,
+) []activityshared.Event {
+	if n == nil || delta == "" {
+		return nil
+	}
+	eventID := n.knownToolItemID(rawToolCallID)
+	pending, ok := n.pendingToolCalls[eventID]
+	if !ok || strings.TrimSpace(eventID) == "" {
+		n.bufferEarlyToolOutput(turnID, rawToolCallID, delta)
+		return nil
+	}
+	current := n.toolOutputText[eventID]
+	next := current + delta
+	payload := clonePayload(pending.payload)
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	output := payloadMap(payload, "output")
+	output = clonePayload(output)
+	if output == nil {
+		output = map[string]any{}
+	}
+	output["text"] = next
+	payload["output"] = output
+	payload["status"] = string(activityshared.ActivityStatusRunning)
+
+	operation := &liveprotocol.MessageToolOutputOperation{
+		Operation: "set",
+		Text:      next,
+	}
+	if current != "" {
+		offset := int64(len(current))
+		operation = &liveprotocol.MessageToolOutputOperation{
+			Operation:   "append_text",
+			Text:        delta,
+			OffsetBytes: &offset,
+		}
+	}
+	event := newTurnActivityEventWithID(
+		session,
+		eventID,
+		EventCallStarted,
+		turnID,
+		messageStreamStateStreaming,
+		"",
+		stringFromPayload(payload, "name"),
+		payload,
+	)
+	attachToolOutputLiveOperation(&event, operation)
+	n.toolOutputText[eventID] = next
+	n.trackToolCallEvent(event)
+	return []activityshared.Event{event}
+}
+
+func (n *acpTurnNormalizer) bufferEarlyToolOutput(turnID string, rawToolCallID string, delta string) {
+	if n == nil || delta == "" {
+		return
+	}
+	turnID = strings.TrimSpace(turnID)
+	rawToolCallID = strings.TrimSpace(rawToolCallID)
+	if turnID == "" || rawToolCallID == "" {
+		return
+	}
+	current, exists := n.earlyToolOutput[rawToolCallID]
+	if !exists && len(n.earlyToolOutput) >= maxEarlyToolOutputCalls {
+		slog.Warn(
+			"agent tool output arrived before too many unresolved anchors",
+			"event", "agent_session.tool_output.pre_anchor_dropped",
+			"reason", "call_limit",
+			"limit", maxEarlyToolOutputCalls,
+		)
+		return
+	}
+	if exists && current.turnID != turnID {
+		n.earlyToolOutputBytes -= len(current.text)
+		current = earlyToolOutputSnapshot{turnID: turnID}
+	}
+	if current.dropped {
+		return
+	}
+	if n.earlyToolOutputBytes+len(delta) > liveprotocol.DefaultDeliveryMaxBytes {
+		n.earlyToolOutputBytes -= len(current.text)
+		current.text = ""
+		current.dropped = true
+		n.earlyToolOutput[rawToolCallID] = current
+		slog.Warn(
+			"agent tool output before its anchor exceeded the live delivery limit",
+			"event", "agent_session.tool_output.pre_anchor_dropped",
+			"reason", "byte_limit",
+			"limit_bytes", liveprotocol.DefaultDeliveryMaxBytes,
+		)
+		return
+	}
+	current.turnID = turnID
+	current.text += delta
+	n.earlyToolOutputBytes += len(delta)
+	n.earlyToolOutput[rawToolCallID] = current
+}
+
+func (n *acpTurnNormalizer) consumeEarlyToolOutput(
+	session Session,
+	turnID string,
+	rawToolCallID string,
+) []activityshared.Event {
+	if n == nil {
+		return nil
+	}
+	rawToolCallID = strings.TrimSpace(rawToolCallID)
+	pending, ok := n.earlyToolOutput[rawToolCallID]
+	if !ok {
+		return nil
+	}
+	delete(n.earlyToolOutput, rawToolCallID)
+	n.earlyToolOutputBytes -= len(pending.text)
+	if pending.dropped || pending.turnID != strings.TrimSpace(turnID) || pending.text == "" {
+		return nil
+	}
+	return n.AppendToolOutputDelta(session, turnID, rawToolCallID, pending.text)
+}

--- a/packages/agent/daemon/runtime/activity_projection_test.go
+++ b/packages/agent/daemon/runtime/activity_projection_test.go
@@ -243,16 +243,46 @@ func TestExplicitToolOutputDeltaPersistsSnapshotAndProjectsOffsetAppend(t *testi
 	}
 }
 
-func TestToolOutputDeltaRequiresKnownStartAnchor(t *testing.T) {
+func TestToolOutputDeltaWaitsForKnownStartAnchor(t *testing.T) {
 	t.Parallel()
+	session := reportTestSession()
 	normalizer := newACPTurnNormalizer()
 	if events := normalizer.AppendToolOutputDelta(
-		reportTestSession(),
+		session,
 		"turn-1",
 		"missing-command",
-		"unsafe",
+		"first",
 	); len(events) != 0 {
-		t.Fatalf("orphan output events = %#v", events)
+		t.Fatalf("pre-anchor output events = %#v, want no invented anchor", events)
+	}
+	started, ok := normalizer.ToolCallEvents(session, "turn-1", map[string]any{
+		"sessionUpdate": "tool_call",
+		"toolCallId":    "missing-command",
+		"title":         "printf",
+		"kind":          "execute",
+		"status":        "in_progress",
+	})
+	if !ok || len(started) != 2 {
+		t.Fatalf("started = %#v, ok = %v, want anchor followed by buffered output", started, ok)
+	}
+	if started[0].Type != activityshared.EventCallStarted ||
+		started[1].Type != activityshared.EventCallStarted {
+		t.Fatalf("started events = %#v", started)
+	}
+	stream := ProjectActivityEventsToStreamEvents(session, started)
+	if len(stream) != 2 ||
+		stream[0].EventType != StreamEventMessageUpdate ||
+		stream[1].EventType != StreamEventMessageDelta {
+		t.Fatalf("stream = %#v, want canonical anchor then live output", stream)
+	}
+	var delta liveprotocol.MessageDeltaData
+	if err := json.Unmarshal(stream[1].Data.(liveprotocol.Event).Data, &delta); err != nil {
+		t.Fatal(err)
+	}
+	if delta.ToolOutput == nil ||
+		delta.ToolOutput.Operation != "set" ||
+		delta.ToolOutput.Text != "first" {
+		t.Fatalf("buffered tool output = %#v", delta.ToolOutput)
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_events_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events_test.go
@@ -178,6 +178,76 @@ func TestCodexAppServerCommandOutputDeltaUsesToolOutputFastLane(t *testing.T) {
 	}
 }
 
+func TestCodexAppServerCommandOutputDeltaBeforeItemStartPreservesPrefix(t *testing.T) {
+	t.Parallel()
+	session := reportTestSession()
+	session.ProviderSessionID = "thread-1"
+	normalizer := newACPTurnNormalizer()
+	reducer := newCodexAppServerReducer(&CodexAppServerAdapter{})
+
+	for _, chunk := range []string{"first\n", "second\n"} {
+		early := reducer.ReduceNotification(
+			nil,
+			session,
+			"turn-1",
+			acpMessage{
+				Method: appServerNotifyCommandOutputDelta,
+				Params: mustJSONRawMessage(t, map[string]any{
+					"threadId": "thread-1",
+					"turnId":   "provider-turn-1",
+					"itemId":   "command-1",
+					"delta":    chunk,
+				}),
+			},
+			normalizer,
+			nil,
+		)
+		if len(early.Events) != 0 {
+			t.Fatalf("early events for %q = %#v, want no output before its anchor", chunk, early.Events)
+		}
+	}
+
+	started := reducer.ReduceNotification(
+		nil,
+		session,
+		"turn-1",
+		acpMessage{
+			Method: appServerNotifyItemStarted,
+			Params: mustJSONRawMessage(t, map[string]any{
+				"threadId": "thread-1",
+				"turnId":   "provider-turn-1",
+				"item": map[string]any{
+					"type": "commandExecution", "id": "command-1",
+					"command": "printf first", "status": "inProgress",
+				},
+			}),
+		},
+		normalizer,
+		nil,
+	)
+	if len(started.Events) != 2 ||
+		started.Events[0].Type != activityshared.EventCallStarted ||
+		started.Events[1].Type != activityshared.EventCallStarted {
+		t.Fatalf("started events = %#v, want anchor followed by buffered prefix", started.Events)
+	}
+	report := reportActivityInput(session, started.Events)
+	if len(report.MessageUpdates) != 2 {
+		t.Fatalf("report = %#v, want anchor and cumulative prefix", report)
+	}
+	startMessageID := report.MessageUpdates[0].MessageID
+	if report.MessageUpdates[1].MessageID != startMessageID {
+		t.Fatalf(
+			"message ids = %q / %q, want one canonical tool row",
+			startMessageID,
+			report.MessageUpdates[1].MessageID,
+		)
+	}
+	output, _ := report.MessageUpdates[1].Payload["output"].(map[string]any)
+	if output["text"] != "first\nsecond\n" {
+		t.Fatalf("persisted buffered prefix = %#v", output)
+	}
+}
+
 // appServerUserInputAnswers is the codex-specific translation of the GUI's
 // interactive answer payload into codex's requestUserInput response. The GUI
 // contract (packages/agent/gui shared/agentConversation/interactiveAnswerPayload.ts)


### PR DESCRIPTION
## Summary

- retain explicit tool output deltas that race immediately ahead of their real tool-call start anchor
- release the retained prefix only after the anchor, preserving `anchor -> set -> append_text -> terminal` ordering and canonical `toolcall:<callId>` identity
- bound pre-anchor retention to 64 unresolved calls and the existing 1 MiB live-delivery limit, with structured diagnostics on rejection
- document the provider-normalizer ordering contract

## Root cause

Codex app-server can emit the first `item/commandExecution/outputDelta` before `item/started` when a command writes stdout immediately. `AppendToolOutputDelta` previously discarded any delta whose normalizer anchor was not registered yet. The loss affected both the optimistic live stream and the durable terminal snapshot, so cloud reconciliation could not restore the prefix.

A real command that printed `01..04` immediately consistently persisted `02..04`; adding a one-second delay before the first write persisted `01..04`.

## Design

The normalizer does not invent an anchor. It buffers only explicit provider output keyed by the provider call id. When the matching real start event arrives, it publishes the anchor first and then emits the accumulated prefix as one `set` operation. Unmatched or oversized prefixes remain rejected and emit diagnostics.

## Validation

- `go test ./packages/agent/daemon/...`
- focused early-anchor and stable-identity tests repeated 20 times
- `pnpm check:changed -- --push-ready` (8 lanes passed)
