### PR TITLE
fix(agent-gui): restore task mention icons

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -681,6 +681,14 @@ onto the owning message flow or transcript row. Small, self-contained controls
 may still use local relational selectors when their subject and mutation scope
 are bounded.
 
+Composer mention providers own entity presentation metadata, including an
+optional `iconUrl`, through their insertion result. AgentGUI mention
+projections must preserve that metadata for every supported entity kind, and
+the shared mention row renders the icon only when supplied. A provider-level
+icon assertion is not sufficient coverage: presentation changes require both a
+projection assertion and a consuming-row DOM assertion so an intermediate
+view-model cannot silently discard the icon.
+
 External OS file paste and drop enter one host-injected classification boundary before draft attachment creation. The synchronous `resolveExternalPromptEntries` port classifies each source index as a live `WorkspaceFileReference` or a snapshot requiring preparation. AgentGUI owns ordered mention insertion and draft reconciliation: references become ordinary file/folder mentions and never consume prompt-asset slots, while only `prepare` entries create pending attachment state and enter `prepareExternalPromptFiles`. A host without the resolver prepares every external entry. The preparer owns native-path or byte lookup, size enforcement, persistence, and remote transport; each prepared input has one `sourceIndex` result, one failure must not fail siblings, successful results include a provider-readable `path` or `url`, and failures carry typed error codes. Hosts that classify path-backed entries as references must reject any such entry that unexpectedly reaches preparation, so classification failure cannot silently create a duplicate snapshot.
 
 Workspace picker results and internal workspace-reference drags remain live references. They enter the rich-text document as mentions and never pass through external-file preparation. A picker source whose selected locator is not yet consumer-readable may perform source-owned confirmation preparation before the mention is inserted; the picker waits in a loading state, publishes no partial result on failure, and remains open for retry. This confirmation transaction belongs to the reference source contract and is distinct from the external OS file preparation pipeline. Removing an inline external-file mention removes its draft intent; a later async result must not revive it or lose its error reason when the draft is in another scope.

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
@@ -137,6 +137,7 @@ describe("AgentFileMentionPalette", () => {
               name: "写一个文件",
               title: "写一个文件",
               creatorName: "Alice",
+              iconUrl: "tutti-asset://issue/default.png",
               status: "not_started"
             },
             {
@@ -227,6 +228,11 @@ describe("AgentFileMentionPalette", () => {
     );
 
     expect(screen.getByText("待开始")).toBeVisible();
+    expect(
+      screen
+        .getByRole("option", { name: /写一个文件/ })
+        .querySelector('[data-agent-mention-issue-icon="true"] img')
+    ).toHaveAttribute("src", "tutti-asset://issue/default.png");
     expect(screen.getAllByText("执行中")).toHaveLength(2);
     expect(screen.getByText("待验收")).toBeVisible();
     expect(screen.getByText("已完成")).toBeVisible();

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
@@ -558,6 +558,7 @@ function agentMentionItemToRowItem(
     kind: "issue",
     title: item.title,
     creatorName: item.creatorName ?? null,
+    iconUrl: item.iconUrl ?? null,
     statusTag: agentIssueStatusTag(item.status)
   };
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.spec.ts
@@ -6,6 +6,34 @@ import {
 } from "./AgentMentionSearchModel";
 
 describe("providerItemToAgentMentionItem", () => {
+  it("preserves workspace issue icon presentation", () => {
+    expect(
+      providerItemToAgentMentionItem({
+        currentUserId: "user-1",
+        providerId: "workspace-issue",
+        insertResult: {
+          kind: "mention",
+          mention: {
+            entityId: "issue-1",
+            label: "Fix task icon",
+            scope: {
+              workspaceId: "workspace-1"
+            },
+            presentation: {
+              iconUrl: "tutti-asset://issue/default.png"
+            }
+          }
+        },
+        label: "Fix task icon",
+        subtitle: "",
+        workspaceId: "workspace-1"
+      })
+    ).toMatchObject({
+      iconUrl: "tutti-asset://issue/default.png",
+      kind: "workspace-issue"
+    });
+  });
+
   it("preserves Agent Target identity in session mention metadata", () => {
     expect(
       providerItemToAgentMentionItem({

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
@@ -647,6 +647,7 @@ export function providerItemToAgentMentionItem(input: {
       topicId: scope.topicId,
       name: label,
       title: label,
+      iconUrl: presentation.iconUrl?.trim() || undefined,
       status: presentation.status?.trim() || undefined,
       contentPreview:
         compactText(presentation.description) ||

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionContracts.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionContracts.ts
@@ -71,6 +71,7 @@ export interface AgentMentionWorkspaceIssueItem {
   name: string;
   title: string;
   creatorName?: string;
+  iconUrl?: string;
   status?: string;
   contentPreview?: string;
   updatedAtUnixMs?: number;

--- a/packages/ui/rich-text/src/at-panel/MentionRow.tsx
+++ b/packages/ui/rich-text/src/at-panel/MentionRow.tsx
@@ -233,10 +233,11 @@ export function renderMentionRow(
   if (item.kind === "app") {
     return (
       <span className="rich-text-at-mention-row rich-text-at-mention-row--app">
-        <MentionWorkspaceAppIcon
+        <MentionEntityIcon
           iconUrl={item.iconUrl}
           kindIconClassName={resolved.kindIcon}
           dataAttributeMode={dataAttributeMode}
+          dataAttributeKey="appIcon"
         />
         <span className="rich-text-at-mention-row__entity-text rich-text-at-mention-row__app-text">
           <span className="rich-text-at-mention-row__entity-name rich-text-at-mention-row__app-name">
@@ -269,6 +270,14 @@ export function renderMentionRow(
 
   return (
     <span className="rich-text-at-mention-row rich-text-at-mention-row--issue">
+      {item.iconUrl ? (
+        <MentionEntityIcon
+          iconUrl={item.iconUrl}
+          kindIconClassName={resolved.kindIcon}
+          dataAttributeMode={dataAttributeMode}
+          dataAttributeKey="issueIcon"
+        />
+      ) : null}
       <span className="rich-text-at-mention-row__text-stack rich-text-at-mention-row__text-stack--fill">
         <span className="rich-text-at-mention-row__inline">
           <span className="rich-text-at-mention-row__title">{item.title}</span>
@@ -510,20 +519,22 @@ function MentionFileIcon({
   );
 }
 
-function MentionWorkspaceAppIcon({
+function MentionEntityIcon({
   iconUrl,
   kindIconClassName,
-  dataAttributeMode
+  dataAttributeMode,
+  dataAttributeKey
 }: {
   iconUrl?: string | null;
   kindIconClassName: string;
   dataAttributeMode: MentionRowDataAttributeMode;
+  dataAttributeKey: "appIcon" | "issueIcon";
 }): React.JSX.Element {
   const normalizedIconUrl = iconUrl?.trim() ?? "";
   return (
     <span
       className="rich-text-at-mention-app-icon"
-      {...mentionRowDataAttribute(dataAttributeMode, "appIcon", "true")}
+      {...mentionRowDataAttribute(dataAttributeMode, dataAttributeKey, "true")}
       data-workspace-app-icon="true"
       aria-hidden="true"
     >

--- a/packages/ui/rich-text/src/at-panel/mentionRowDataAttributes.test.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionRowDataAttributes.test.ts
@@ -16,6 +16,9 @@ test("shared mention row data hooks are the default package vocabulary", () => {
       "data-rich-text-at-mention-file-visual-kind": "document"
     }
   );
+  assert.deepEqual(mentionRowDataAttribute("shared", "issueIcon", "true"), {
+    "data-rich-text-at-mention-issue-icon": "true"
+  });
 });
 
 test("agent mode keeps the legacy agent data hooks for compatibility", () => {
@@ -29,4 +32,7 @@ test("agent mode keeps the legacy agent data hooks for compatibility", () => {
       "data-agent-file-visual-kind": "document"
     }
   );
+  assert.deepEqual(mentionRowDataAttribute("agent", "issueIcon", "true"), {
+    "data-agent-mention-issue-icon": "true"
+  });
 });

--- a/packages/ui/rich-text/src/at-panel/mentionRowDataAttributes.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionRowDataAttributes.ts
@@ -8,6 +8,7 @@ export type MentionRowDataAttributeKey =
   | "fileEntryKind"
   | "fileThumb"
   | "fileVisualKind"
+  | "issueIcon"
   | "navigation"
   | "navigateInto"
   | "openReferences"
@@ -24,6 +25,7 @@ const MENTION_ROW_DATA_ATTRIBUTES: Record<
     fileEntryKind: "data-rich-text-at-mention-file-entry-kind",
     fileThumb: "data-rich-text-at-mention-file-thumb",
     fileVisualKind: "data-rich-text-at-mention-file-visual-kind",
+    issueIcon: "data-rich-text-at-mention-issue-icon",
     navigation: "data-rich-text-at-mention-navigation",
     navigateInto: "data-rich-text-at-mention-navigate-into",
     openReferences: "data-rich-text-at-mention-open-references",
@@ -36,6 +38,7 @@ const MENTION_ROW_DATA_ATTRIBUTES: Record<
     fileEntryKind: "data-agent-file-entry-kind",
     fileThumb: "data-agent-mention-file-thumb",
     fileVisualKind: "data-agent-file-visual-kind",
+    issueIcon: "data-agent-mention-issue-icon",
     navigation: "data-agent-mention-navigation",
     navigateInto: "data-agent-mention-navigate-into",
     openReferences: "data-agent-mention-open-references",

--- a/packages/ui/rich-text/src/at-panel/mentionRowTypes.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionRowTypes.ts
@@ -72,6 +72,7 @@ export interface MentionRowIssueItem {
   kind: "issue";
   title: string;
   creatorName?: string | null;
+  iconUrl?: string | null;
   statusTag?: MentionRowStatusTag | null;
 }
 

--- a/packages/ui/rich-text/src/at-panel/mentionTriggerRowItem.test.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionTriggerRowItem.test.ts
@@ -74,6 +74,41 @@ test("maps workspace-app matches to app rows with optional tutti icon fallback",
   assert.equal(isMentionTriggerRowProviderId("unknown-provider"), false);
 });
 
+test("maps workspace-issue matches to issue rows with their provider icon", () => {
+  const row = richTextTriggerQueryMatchToMentionRowItem(
+    match({
+      insertResult: {
+        kind: "mention",
+        mention: {
+          entityId: "issue-1",
+          label: "Fix task icon",
+          presentation: {
+            iconUrl: "tutti-asset://issue/default.png",
+            statusLabel: "In progress"
+          }
+        }
+      },
+      key: "issue-1",
+      label: "Fix task icon",
+      providerId: "workspace-issue"
+    })
+  );
+
+  assert.deepEqual(row, {
+    kind: "issue",
+    creatorName: null,
+    iconUrl: "tutti-asset://issue/default.png",
+    statusTag: {
+      dataStatus: undefined,
+      label: "In progress",
+      pulse: false,
+      tone: "neutral",
+      variant: "issue"
+    },
+    title: "Fix task icon"
+  });
+});
+
 test("maps file matches with inferred image visual kind and icon thumbnail source", () => {
   const row = richTextTriggerQueryMatchToMentionRowItem(
     match({

--- a/packages/ui/rich-text/src/at-panel/mentionTriggerRowItem.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionTriggerRowItem.ts
@@ -123,6 +123,7 @@ export function richTextTriggerQueryMatchToMentionRowItem<
     return {
       kind: "issue",
       creatorName: description,
+      iconUrl,
       statusTag: resolveMentionRowStatusTag(match, "issue", options),
       title: label
     };


### PR DESCRIPTION
## What

- preserve provider `presentation.iconUrl` for workspace-issue search results
- carry the issue icon through AgentGUI and shared rich-text row projections
- render the task icon in the `@` panel while keeping hosts without an icon blank
- add model, mapping, DOM-hook, and palette regression coverage
- document the provider presentation metadata invariant

## Why

The workspace-issue provider already returned `tutti-asset://issue/default.png`, but the workspace-issue result type and the intermediate AgentGUI/shared rich-text projections dropped `presentation.iconUrl`. The task row therefore reached `MentionRow` without any leading visual.

## Impact

Restores task icons in the AgentGUI `@` panel. No protocol, persistence, or task-state behavior changes.

## Checks

- `pnpm --filter @tutti-os/ui-rich-text test` (108 passed)
- `pnpm --filter @tutti-os/agent-gui exec vitest run agentGuiNode/AgentMentionSearchModel.spec.ts agentGuiNode/AgentFileMentionPalette.spec.tsx` (30 passed)
- `pnpm check:changed -- --failed-only` (13 lanes passed)
- pre-push `pnpm check:changed -- --push-ready` (14 lanes passed)
- `pnpm lint:ts`
- `pnpm typecheck` (30 packages passed)
- `pnpm check:ui-boundaries`
- `pnpm release:pack:check` (fixed release cohort passed)
- `git diff --check`
