### PR TITLE
fix(agent-gui): sync home target presentation

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -395,6 +395,12 @@ When runtime sections are enabled, projection unions IDs from the current sectio
 
 Scroll, section collapse, visible limits, and search query belong to mounted view scope. Non-search state is isolated by `workspaceId + agentTargetId/all`; search creates a temporary navigation scope. `activeConversationId` expresses selection only. Scrolling requires an explicit reveal intent.
 
+On the Home composer, a single-Agent Rail filter follows the effective composer
+Agent Target whether the change originates inside AgentGUI or from host-owned
+node data. The `all` filter remains broad, an open Session keeps its current
+Rail filter, and unresolved/loading targets neither rewrite presentation state
+nor expose placeholder target labels in Home chrome.
+
 Rail scroll memory is captured by scroll events and explicit navigation. Effect cleanup must not synchronously read `scrollTop`: React may already have dirtied the document, turning that read into a full layout inside the interaction task.
 
 An empty bounded Rail result must not unactivate an active or persisted Session.

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIProviderHome.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIProviderHome.spec.tsx
@@ -6,6 +6,110 @@ import type { AgentGUIConversationSummary } from "../model/agentGuiConversationM
 import { useAgentGUIProviderHome } from "./useAgentGUIProviderHome";
 
 describe("useAgentGUIProviderHome", () => {
+  it("syncs a scoped rail filter to an externally changed home composer target", () => {
+    const codexTarget = target("codex", "agent:codex", "provider-target:codex");
+    const claudeTarget = target(
+      "claude-code",
+      "agent:claude-code",
+      "provider-target:claude-code"
+    );
+    const fixture = renderProviderHome({
+      activeConversationId: null,
+      conversationFilter: {
+        kind: "agentTarget",
+        agentTargetId: "agent:codex"
+      },
+      conversations: [],
+      data: {
+        agentTargetId: "agent:claude-code",
+        lastActiveAgentSessionId: null,
+        provider: "claude-code"
+      },
+      selectedTarget: claudeTarget,
+      targets: [codexTarget, claudeTarget]
+    });
+
+    expect(fixture.setConversationFilter).toHaveBeenCalledWith({
+      kind: "agentTarget",
+      agentTargetId: "agent:claude-code"
+    });
+  });
+
+  it("does not narrow the all-agents rail filter when the home composer target changes", () => {
+    const claudeTarget = target(
+      "claude-code",
+      "agent:claude-code",
+      "provider-target:claude-code"
+    );
+    const fixture = renderProviderHome({
+      activeConversationId: null,
+      conversationFilter: { kind: "all" },
+      conversations: [],
+      data: {
+        agentTargetId: "agent:claude-code",
+        lastActiveAgentSessionId: null,
+        provider: "claude-code"
+      },
+      selectedTarget: claudeTarget,
+      targets: [claudeTarget]
+    });
+
+    expect(fixture.setConversationFilter).not.toHaveBeenCalled();
+  });
+
+  it("does not change the rail filter for an open conversation", () => {
+    const codexTarget = target("codex", "agent:codex", "provider-target:codex");
+    const claudeTarget = target(
+      "claude-code",
+      "agent:claude-code",
+      "provider-target:claude-code"
+    );
+    const fixture = renderProviderHome({
+      activeConversationId: "codex-session",
+      conversationFilter: {
+        kind: "agentTarget",
+        agentTargetId: "agent:codex"
+      },
+      conversations: [conversation("codex-session", "codex", "agent:codex")],
+      data: {
+        agentTargetId: "agent:claude-code",
+        lastActiveAgentSessionId: null,
+        provider: "claude-code"
+      },
+      selectedTarget: claudeTarget,
+      targets: [codexTarget, claudeTarget]
+    });
+
+    expect(fixture.setConversationFilter).not.toHaveBeenCalled();
+  });
+
+  it("does not change the rail filter while the home composer target is unresolved", () => {
+    const loadingTarget: AgentGUIAgentTarget = {
+      disabled: true,
+      label: "Loading",
+      provider: "claude-code",
+      ref: { kind: "loading", provider: "claude-code" },
+      targetId: "__loading__"
+    };
+    const fixture = renderProviderHome({
+      activeConversationId: null,
+      conversationFilter: {
+        kind: "agentTarget",
+        agentTargetId: "agent:codex"
+      },
+      conversations: [],
+      data: {
+        agentTargetId: "agent:claude-code",
+        lastActiveAgentSessionId: null,
+        provider: "claude-code"
+      },
+      selectedTarget: loadingTarget,
+      targets: []
+    });
+
+    expect(fixture.setConversationFilter).not.toHaveBeenCalled();
+  });
+
   it("restores the selected target's last session in the current node", () => {
     const codexTarget = target("codex", "agent:codex", "provider-target:codex");
     const claudeTarget = target(
@@ -98,6 +202,14 @@ describe("useAgentGUIProviderHome", () => {
 
 function renderProviderHome(input: {
   activeConversationId: string | null;
+  conversationFilter?:
+    | {
+        kind: "all";
+      }
+    | {
+        kind: "agentTarget";
+        agentTargetId: string;
+      };
   conversations: readonly AgentGUIConversationSummary[];
   data: AgentGUINodeData;
   selectedTarget: AgentGUIAgentTarget;
@@ -120,6 +232,10 @@ function renderProviderHome(input: {
     }
   );
   const agentTargetId = input.selectedTarget.agentTargetId!;
+  const conversationFilter = input.conversationFilter ?? {
+    kind: "agentTarget" as const,
+    agentTargetId
+  };
   const { result } = renderHook(() =>
     useAgentGUIProviderHome({
       activeConversationId: activeConversationIdRef.current,
@@ -127,10 +243,8 @@ function renderProviderHome(input: {
       activePendingActivation: null,
       agentActivityRuntime: {} as never,
       clearRailRevealRequest: vi.fn(),
-      conversationFilter: { kind: "agentTarget", agentTargetId },
-      conversationFilterRef: {
-        current: { kind: "agentTarget", agentTargetId }
-      },
+      conversationFilter,
+      conversationFilterRef: { current: conversationFilter },
       conversationsRef: { current: input.conversations },
       data,
       dataRef,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIProviderHome.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIProviderHome.ts
@@ -280,6 +280,19 @@ export function useAgentGUIProviderHome(input: UseAgentGUIProviderHomeInput) {
   );
 
   useEffect(() => {
+    const effectiveAgentTargetId =
+      input.effectiveSelectedProviderTarget.agentTargetId?.trim() ?? "";
+    if (
+      input.activeConversationId === null &&
+      input.conversationFilter.kind === "agentTarget" &&
+      effectiveAgentTargetId &&
+      effectiveAgentTargetId !== input.conversationFilter.agentTargetId.trim()
+    ) {
+      input.setConversationFilter({
+        kind: "agentTarget",
+        agentTargetId: effectiveAgentTargetId
+      });
+    }
     if (
       input.activeConversationId !== null ||
       input.conversationFilter.kind !== "all" ||
@@ -318,12 +331,13 @@ export function useAgentGUIProviderHome(input: UseAgentGUIProviderHomeInput) {
     });
   }, [
     input.activeConversationId,
-    input.conversationFilter.kind,
+    input.conversationFilter,
     input.data,
     input.effectiveSelectedProviderTarget,
     input.firstReadyHomeComposerProviderTarget,
     input.homeComposerTargetOverride,
     input.providerReadinessGates,
+    input.setConversationFilter,
     selectHomeComposerAgentTarget
   ]);
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.notice.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.notice.spec.tsx
@@ -2,13 +2,75 @@ import "@testing-library/jest-dom/vitest";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentComposerProps } from "../AgentComposer";
-import { AgentGUIEmptyHeroPane } from "./AgentGUIEmptyState";
+import type { AgentGUIViewLabels } from "../AgentGUINodeView";
+import {
+  AgentGUIEmptyHeroPane,
+  AgentGUIEmptyHomePane
+} from "./AgentGUIEmptyState";
 
 vi.mock("../AgentComposer", () => ({
   AgentComposer: () => <div data-testid="agent-composer" />
 }));
 
+vi.mock("./AgentGUIEmptyHeroCarouselStage", () => ({
+  AgentGUIEmptyHeroCarouselStage: ({
+    children
+  }: {
+    children: React.ReactNode;
+  }) => <>{children}</>
+}));
+
+vi.mock("./AgentTargetSetupGate.tsx", () => ({
+  AgentTargetSetupGate: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  )
+}));
+
 describe("AgentGUIEmptyHeroPane notices", () => {
+  it("does not render an unresolved target label in the Home title", () => {
+    render(
+      <AgentGUIEmptyHomePane
+        provider="unknown"
+        providerReadinessGate={null}
+        showAllProviders={false}
+        agentTargets={[]}
+        selectedAgentTarget={{
+          disabled: true,
+          label: "unknown",
+          provider: "unknown",
+          ref: { kind: "loading", provider: "unknown" },
+          targetId: "__loading__"
+        }}
+        labels={
+          {
+            empty: "需要 Agent 帮你做些什么？",
+            emptyForProvider: () => "需要 Agent 帮你做些什么？",
+            emptyProvider: "Agent",
+            emptyProviderForProvider: () => "Agent",
+            providerSwitchLabel: "选择 Agent",
+            sharedAgentOwnerSeparator: "的"
+          } as unknown as AgentGUIViewLabels
+        }
+        noticeChrome={null}
+        isRespondingApproval={false}
+        onSubmitApprovalOption={vi.fn()}
+        onRetryActivation={vi.fn()}
+        onContinueInNewConversation={vi.fn()}
+        chromeLabels={{} as never}
+        composerProps={{} as AgentComposerProps}
+        suggestions={[]}
+        onSelectSuggestion={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: "需要 Agent 帮你做些什么？"
+      })
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/unknown/i)).not.toBeInTheDocument();
+  });
+
   it("renders target connection chrome above the Home composer", () => {
     render(
       <AgentGUIEmptyHeroPane

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
@@ -123,12 +123,14 @@ export const AgentGUIEmptyHomePane = memo(function AgentGUIEmptyHomePane({
 }: AgentGUIEmptyHomePaneProps): React.JSX.Element {
   "use memo";
 
+  const presentedSelectedAgentTarget =
+    selectedAgentTarget?.ref.kind === "loading" ? null : selectedAgentTarget;
   const runtimeProviderLabel =
     labels.emptyProviderForProvider?.(provider) ?? labels.emptyProvider ?? "";
-  const providerLabel = selectedAgentTarget
+  const providerLabel = presentedSelectedAgentTarget
     ? projectAgentGUIAgentTargetName({
         ownerSeparator: labels.sharedAgentOwnerSeparator,
-        target: selectedAgentTarget
+        target: presentedSelectedAgentTarget
       }).fullLabel
     : runtimeProviderLabel;
   const baseLabel = labels.emptyForProvider?.(provider) ?? labels.empty;
@@ -139,22 +141,23 @@ export const AgentGUIEmptyHomePane = memo(function AgentGUIEmptyHomePane({
     () =>
       agentTargets.length
         ? agentTargets.map(projectAgentGUIAgentTargetAvatar)
-        : selectedAgentTarget
-          ? [projectAgentGUIAgentTargetAvatar(selectedAgentTarget)]
+        : presentedSelectedAgentTarget
+          ? [projectAgentGUIAgentTargetAvatar(presentedSelectedAgentTarget)]
           : [
               createFallbackAgentGUIAgentAvatar({
                 provider,
                 label: providerLabel
               })
             ],
-    [agentTargets, provider, providerLabel, selectedAgentTarget]
+    [agentTargets, presentedSelectedAgentTarget, provider, providerLabel]
   );
   const carouselMountedExternally = avatarPresentations.length > 1;
 
   return (
     <AgentGUIEmptyHeroCarouselStage
       activeAgentTargetId={
-        selectedAgentTarget?.agentTargetId ?? selectedAgentTarget?.targetId
+        presentedSelectedAgentTarget?.agentTargetId ??
+        presentedSelectedAgentTarget?.targetId
       }
       items={avatarPresentations}
       onProviderSelect={onProviderSelect}
@@ -175,7 +178,7 @@ export const AgentGUIEmptyHomePane = memo(function AgentGUIEmptyHomePane({
             onProviderSelect={onProviderSelect}
             providerLabel={providerLabel}
             providerSelectLabel={labels.providerSwitchLabel}
-            selectedAgentTarget={selectedAgentTarget}
+            selectedAgentTarget={presentedSelectedAgentTarget}
             labels={labels}
           />
         ) : (
@@ -188,7 +191,7 @@ export const AgentGUIEmptyHomePane = memo(function AgentGUIEmptyHomePane({
             carouselMountedExternally={carouselMountedExternally}
             onProviderSelect={onProviderSelect}
             agentTargets={agentTargets}
-            selectedAgentTarget={selectedAgentTarget}
+            selectedAgentTarget={presentedSelectedAgentTarget}
             providerSelectLabel={labels.providerSwitchLabel}
             sharedAgentOwnerSeparator={labels.sharedAgentOwnerSeparator}
           />


### PR DESCRIPTION
## Summary
- keep a scoped conversation Rail filter aligned with the effective Home composer Agent Target after host-owned node updates
- keep the all-Agents filter, open Sessions, and unresolved targets unchanged
- prevent loading targets from exposing `unknown` in Home chrome and document the presentation invariant

## Tests
- `pnpm check:changed -- --push-ready` (12 lanes passed)

## Notes
- real GUI pixel verification remains for the consuming TSH integration

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->