### PR TITLE
fix(agent): reconstruct imported transcript turns

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -629,10 +629,18 @@ authoritative read is explicitly named `session_reconcile_required` and must
 never be applied as a partial Session entity. The old public `state_patch` and
 storage message row id are removed.
 
-Message `turnId` is explicitly nullable. Runtime execution messages should use
-the exact durable Turn id, while historical imports without trustworthy
-provider turn boundaries stay session-scoped (`turnId = null`); import must not
-manufacture one live synthetic Turn per transcript message.
+Message `turnId` is explicitly nullable. Runtime execution messages use the
+exact durable Turn id. An external transcript importer may reconstruct stable
+historical Turn ids only from trustworthy provider evidence: each retained real
+user message starts one Turn and the following assistant/tool messages keep
+that identity until the next retained user message. Persistence creates those
+Turns as settled backfills in the same transaction as their messages. A
+forward-only store migration repairs legacy imported turnless rows from the
+same retained-user boundary; re-import applies the same stable identity.
+Content before the first trustworthy boundary stays session-scoped
+(`turnId = null`). AgentGUI never reconstructs canonical Turn ownership from
+the currently loaded page, and import must not manufacture one Turn per
+transcript message.
 
 It should not know how a host connects to `tuttid`, subscribes to the
 business-event WebSocket, resolves workspace paths, or talks to Electron.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -279,6 +279,14 @@ authoritative window. It must not infer older history from a non-one minimum
 version, a version gap, `sequence`, timestamps, or transcript shape; streaming
 updates can raise a message version without creating any older row.
 
+The same rule applies to imported transcripts. When the provider transcript
+contains trustworthy user-message boundaries, the import adapter persists
+stable settled Turn identities before the data reaches AgentGUI. A page that
+starts midway through a long imported Turn must therefore retain that Turn id;
+AgentGUI must not depend on the leading user message being present in the
+currently loaded window. Imported content before the first trustworthy
+boundary remains explicitly session-scoped.
+
 ## 4. Workspace frontend engine
 
 One `(workspaceId, runtime origin)` maps to one `AgentSessionEngine`. Panel unmount, Workbench node reconstruction, and standalone window switching must not change its lifecycle.

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -2037,6 +2037,39 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [ExternalAgentSessionImportWizard.tsx](../../../apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportWizard.tsx)
   [service_session.go](../../../services/tuttid/service/agent/service_session.go)
 
+### Imported long Turns show one disclosure per tool call
+
+- Symptom:
+  A long imported Codex or Claude Code execution shows many adjacent
+  `1 tool call` disclosures instead of one grouped Turn, especially after
+  opening or paging into the middle of the conversation.
+- Quick checks:
+  Inspect the affected `workspace_agent_messages` rows without printing
+  payload text. If the user/tool/assistant rows all have `turn_id = NULL`, then
+  compare the loaded page with the source transcript. A page that starts after
+  the initiating user message cannot recover the Turn boundary locally.
+- Root cause:
+  The external importer historically used the turnless compatibility path for
+  every message. AgentGUI can make a temporary presentation group when the
+  leading user row is loaded, but that grouping cannot survive a page boundary;
+  assigning each orphan row from its current page position would manufacture
+  lifecycle identity in the renderer.
+- Fix:
+  At the provider transcript boundary, start a stable historical Turn from each
+  retained real user message and carry it through following assistant and tool
+  messages. Persist the messages with settled backfilled Turns atomically.
+  The forward-only store migration repairs existing imported rows, while a
+  later re-import applies the same identity to any still-turnless rows. Content
+  before the first trustworthy user boundary remains turnless.
+- Validation:
+  Run `go test ./packages/agent/store-sqlite -run HistoricalImport`, then
+  `cd services/tuttid && go test ./service/agent -run
+'ServiceImportsExternalAgentSessionsByProject|ServiceReimportRepairsLegacyTurnlessExternalMessages'`.
+- References:
+  [external_import.go](../../../services/tuttid/service/agent/external_import.go)
+  [activity_historical_import_turns.go](../../../packages/agent/store-sqlite/activity_historical_import_turns.go)
+  [agent-gui-node.md](../../architecture/agent-gui-node.md)
+
 ### Imported sessions trigger fresh-completion indicators
 
 - Symptom:

--- a/packages/agent/store-sqlite/activity.go
+++ b/packages/agent/store-sqlite/activity.go
@@ -323,6 +323,15 @@ func (s *Store) ReportSessionMessages(
 
 	result := MessageReportResult{}
 	allowLegacyTurnless := input.HistoricalImport
+	historicalTurnIDs := []string(nil)
+	if input.HistoricalImport {
+		historicalTurnIDs, err = ensureHistoricalImportTurnsTx(
+			ctx, tx, workspaceID, agentSessionID, input.Messages, now,
+		)
+		if err != nil {
+			return MessageReportResult{}, err
+		}
+	}
 	for _, message := range input.Messages {
 		message.MessageID = strings.TrimSpace(message.MessageID)
 		if message.MessageID == "" {
@@ -333,6 +342,12 @@ func (s *Store) ReportSessionMessages(
 			return MessageReportResult{}, err
 		}
 		if !accepted {
+			if input.HistoricalImport && strings.TrimSpace(message.TurnID) != "" {
+				return MessageReportResult{}, fmt.Errorf(
+					"historical import message %q was rejected",
+					message.MessageID,
+				)
+			}
 			continue
 		}
 		result.AcceptedCount++
@@ -340,7 +355,21 @@ func (s *Store) ReportSessionMessages(
 		result.Messages = append(result.Messages, acceptedMessage)
 	}
 
-	mutations := make([]TransactionMutation, 0, len(result.Messages))
+	historicalTurns := []Turn(nil)
+	if len(historicalTurnIDs) > 0 {
+		historicalTurns, err = refreshHistoricalImportTurnsTx(
+			ctx, tx, workspaceID, agentSessionID, historicalTurnIDs,
+		)
+		if err != nil {
+			return MessageReportResult{}, err
+		}
+	}
+	mutations := make([]TransactionMutation, 0, len(historicalTurns)+len(result.Messages))
+	for _, turn := range historicalTurns {
+		mutations = append(mutations, transactionMutation(
+			workspaceID, agentSessionID, MutationEntityTurn, turn.TurnID, "upsert", turn.UpdatedAtUnixMS,
+		))
+	}
 	for _, message := range result.Messages {
 		mutations = append(mutations, transactionMutation(workspaceID, agentSessionID, MutationEntityMessage, message.MessageID, "upsert", int64(message.Version)))
 	}

--- a/packages/agent/store-sqlite/activity_historical_import_turns.go
+++ b/packages/agent/store-sqlite/activity_historical_import_turns.go
@@ -1,0 +1,153 @@
+package storesqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type historicalImportTurnRange struct {
+	startedAtUnixMS int64
+	settledAtUnixMS int64
+}
+
+func ensureHistoricalImportTurnsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	workspaceID string,
+	agentSessionID string,
+	messages []MessageUpdate,
+	now int64,
+) ([]string, error) {
+	ranges := map[string]historicalImportTurnRange{}
+	for _, message := range messages {
+		turnID := strings.TrimSpace(message.TurnID)
+		if turnID == "" {
+			continue
+		}
+		startedAt := historicalImportFirstNonZeroInt64(message.StartedAtUnixMS, message.OccurredAtUnixMS, message.CompletedAtUnixMS, now)
+		settledAt := historicalImportFirstNonZeroInt64(message.CompletedAtUnixMS, message.OccurredAtUnixMS, message.StartedAtUnixMS, now)
+		current, ok := ranges[turnID]
+		if !ok || startedAt < current.startedAtUnixMS {
+			current.startedAtUnixMS = startedAt
+		}
+		if settledAt > current.settledAtUnixMS {
+			current.settledAtUnixMS = settledAt
+		}
+		ranges[turnID] = current
+	}
+
+	turnIDs := make([]string, 0, len(ranges))
+	for turnID := range ranges {
+		turnIDs = append(turnIDs, turnID)
+	}
+	sort.Strings(turnIDs)
+	for _, turnID := range turnIDs {
+		timeRange := ranges[turnID]
+		if _, err := tx.ExecContext(ctx, `
+INSERT OR IGNORE INTO workspace_agent_turns (
+  workspace_id, agent_session_id, turn_id, phase, outcome, backfilled,
+  turn_origin, started_at_unix_ms, settled_at_unix_ms,
+  created_at_unix_ms, updated_at_unix_ms
+) VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?)
+`, workspaceID, agentSessionID, turnID, TurnPhaseSettled, TurnOutcomeCompleted,
+			TurnOriginUserPrompt, timeRange.startedAtUnixMS, timeRange.settledAtUnixMS,
+			timeRange.startedAtUnixMS, timeRange.settledAtUnixMS); err != nil {
+			return nil, fmt.Errorf("create historical import turn %q: %w", turnID, err)
+		}
+		stored, ok, err := getAgentTurnTx(ctx, tx, workspaceID, agentSessionID, turnID)
+		if err != nil {
+			return nil, err
+		}
+		if !ok || !stored.Backfilled {
+			return nil, fmt.Errorf("historical import turn %q conflicts with a canonical live turn", turnID)
+		}
+	}
+	return turnIDs, nil
+}
+
+func refreshHistoricalImportTurnsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	workspaceID string,
+	agentSessionID string,
+	turnIDs []string,
+) ([]Turn, error) {
+	turns := make([]Turn, 0, len(turnIDs))
+	for _, turnID := range turnIDs {
+		var startedAtUnixMS int64
+		var settledAtUnixMS int64
+		if err := tx.QueryRowContext(ctx, `
+SELECT
+  COALESCE(
+    MIN(CASE WHEN LOWER(TRIM(role)) = 'user' THEN
+      CASE
+        WHEN started_at_unix_ms > 0 THEN started_at_unix_ms
+        WHEN occurred_at_unix_ms > 0 THEN occurred_at_unix_ms
+        WHEN completed_at_unix_ms > 0 THEN completed_at_unix_ms
+        ELSE created_at_unix_ms
+      END
+    END),
+    MIN(CASE
+      WHEN started_at_unix_ms > 0 THEN started_at_unix_ms
+      WHEN occurred_at_unix_ms > 0 THEN occurred_at_unix_ms
+      WHEN completed_at_unix_ms > 0 THEN completed_at_unix_ms
+      ELSE created_at_unix_ms
+    END)
+  ),
+  MAX(CASE
+    WHEN completed_at_unix_ms > 0 THEN completed_at_unix_ms
+    WHEN occurred_at_unix_ms > 0 THEN occurred_at_unix_ms
+    WHEN started_at_unix_ms > 0 THEN started_at_unix_ms
+    ELSE updated_at_unix_ms
+  END)
+FROM workspace_agent_messages
+WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ?
+  AND deleted_at_unix_ms = 0
+`, workspaceID, agentSessionID, turnID).Scan(&startedAtUnixMS, &settledAtUnixMS); err != nil {
+			return nil, fmt.Errorf("derive historical import turn %q timestamps: %w", turnID, err)
+		}
+		finalAssistantMessageID, err := finalAssistantMessageIDAtSettlementTx(
+			ctx, tx, workspaceID, agentSessionID, turnID, "",
+		)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := tx.ExecContext(ctx, `
+UPDATE workspace_agent_turns
+SET phase = ?, outcome = ?, backfilled = 1, turn_origin = ?,
+    started_at_unix_ms = ?, settled_at_unix_ms = ?,
+    created_at_unix_ms = ?, updated_at_unix_ms = ?,
+    completed_command_json = ?
+WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ? AND backfilled = 1
+`, TurnPhaseSettled, TurnOutcomeCompleted, TurnOriginUserPrompt,
+			startedAtUnixMS, settledAtUnixMS, startedAtUnixMS, settledAtUnixMS,
+			encodeCompletedCommandJSON("", "", finalAssistantWatermark{
+				MessageID: finalAssistantMessageID,
+				Resolved:  true,
+			}),
+			workspaceID, agentSessionID, turnID); err != nil {
+			return nil, fmt.Errorf("refresh historical import turn %q: %w", turnID, err)
+		}
+		stored, ok, err := getAgentTurnTx(ctx, tx, workspaceID, agentSessionID, turnID)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, fmt.Errorf("read refreshed historical import turn %q: %w", turnID, sql.ErrNoRows)
+		}
+		turns = append(turns, stored)
+	}
+	return turns, nil
+}
+
+func historicalImportFirstNonZeroInt64(values ...int64) int64 {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -69,6 +69,7 @@ const schemaMigrationWorkspaceAgentMessageSemanticsV1 = "workspace_agent_message
 const schemaMigrationWorkspaceAgentDeletedPurgeIndexV1 = "workspace_agent_deleted_purge_index_v1"
 const schemaMigrationWorkspaceAgentSessionTurnPageIndexV1 = "workspace_agent_session_turn_page_index_v1"
 const schemaMigrationWorkspaceAgentTurnCapabilityRefsV1 = "workspace_agent_turn_capability_refs_v1"
+const schemaMigrationWorkspaceAgentImportedTurnsV1 = "workspace_agent_imported_turns_v1"
 
 // claimableMigrationIDs are the migration IDs that may already be recorded
 // in the legacy tuttid ledger; the claim copies exactly these.
@@ -248,7 +249,10 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 	if err := s.applyWorkspaceAgentSessionTurnPageIndexV1(ctx); err != nil {
 		return err
 	}
-	return s.applyWorkspaceAgentTurnCapabilityRefsV1(ctx)
+	if err := s.applyWorkspaceAgentTurnCapabilityRefsV1(ctx); err != nil {
+		return err
+	}
+	return s.applyWorkspaceAgentImportedTurnsV1(ctx)
 }
 
 // claimLegacyMigrations copies agent-store migration records that were

--- a/packages/agent/store-sqlite/migrations_imported_turns.go
+++ b/packages/agent/store-sqlite/migrations_imported_turns.go
@@ -1,0 +1,181 @@
+package storesqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+type importedTranscriptMessage struct {
+	id                int64
+	workspaceID       string
+	agentSessionID    string
+	messageID         string
+	turnID            string
+	role              string
+	kind              string
+	occurredAtUnixMS  int64
+	startedAtUnixMS   int64
+	completedAtUnixMS int64
+}
+
+type importedTranscriptTurnAssignment struct {
+	message importedTranscriptMessage
+	turnID  string
+}
+
+func (s *Store) applyWorkspaceAgentImportedTurnsV1(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentImportedTurnsV1)
+	if err != nil || applied {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin workspace agent imported turns v1: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	messages, err := readImportedTranscriptMessagesTx(ctx, tx)
+	if err != nil {
+		return err
+	}
+	assignments := importedTranscriptTurnAssignments(messages)
+	for _, sessionAssignments := range assignments {
+		if len(sessionAssignments) == 0 {
+			continue
+		}
+		first := sessionAssignments[0]
+		updates := make([]MessageUpdate, 0, len(sessionAssignments))
+		for _, assignment := range sessionAssignments {
+			updates = append(updates, MessageUpdate{
+				MessageID:         assignment.message.messageID,
+				TurnID:            assignment.turnID,
+				Role:              assignment.message.role,
+				Kind:              assignment.message.kind,
+				OccurredAtUnixMS:  assignment.message.occurredAtUnixMS,
+				StartedAtUnixMS:   assignment.message.startedAtUnixMS,
+				CompletedAtUnixMS: assignment.message.completedAtUnixMS,
+			})
+		}
+		turnIDs, err := ensureHistoricalImportTurnsTx(
+			ctx, tx, first.message.workspaceID, first.message.agentSessionID, updates, first.message.occurredAtUnixMS,
+		)
+		if err != nil {
+			return err
+		}
+		for _, assignment := range sessionAssignments {
+			if _, err := tx.ExecContext(ctx, `
+UPDATE workspace_agent_messages
+SET turn_id = ?
+WHERE id = ? AND workspace_id = ? AND agent_session_id = ? AND turn_id IS NULL
+`, assignment.turnID, assignment.message.id,
+				assignment.message.workspaceID, assignment.message.agentSessionID); err != nil {
+				return fmt.Errorf("assign imported message %q turn: %w", assignment.message.messageID, err)
+			}
+		}
+		if _, err := refreshHistoricalImportTurnsTx(
+			ctx, tx, first.message.workspaceID, first.message.agentSessionID, turnIDs,
+		); err != nil {
+			return err
+		}
+	}
+	if err := recordMigrationTx(ctx, tx, schemaMigrationWorkspaceAgentImportedTurnsV1); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit workspace agent imported turns v1: %w", err)
+	}
+	return nil
+}
+
+func readImportedTranscriptMessagesTx(ctx context.Context, tx *sql.Tx) ([]importedTranscriptMessage, error) {
+	rows, err := tx.QueryContext(ctx, `
+SELECT
+  m.id, m.workspace_id, m.agent_session_id, m.message_id, m.turn_id,
+  m.role, m.kind, m.occurred_at_unix_ms, m.started_at_unix_ms, m.completed_at_unix_ms
+FROM workspace_agent_messages m
+INNER JOIN workspace_agent_sessions s
+  ON s.workspace_id = m.workspace_id
+ AND s.agent_session_id = m.agent_session_id
+WHERE s.deleted_at_unix_ms = 0
+  AND m.deleted_at_unix_ms = 0
+  AND json_extract(s.session_metadata_json, '$.imported') = 1
+  AND m.message_id LIKE 'imported-%'
+ORDER BY m.workspace_id, m.agent_session_id, m.id
+`)
+	if err != nil {
+		return nil, fmt.Errorf("list imported transcript messages: %w", err)
+	}
+	defer rows.Close()
+
+	messages := make([]importedTranscriptMessage, 0)
+	for rows.Next() {
+		var message importedTranscriptMessage
+		var turnID sql.NullString
+		if err := rows.Scan(
+			&message.id,
+			&message.workspaceID,
+			&message.agentSessionID,
+			&message.messageID,
+			&turnID,
+			&message.role,
+			&message.kind,
+			&message.occurredAtUnixMS,
+			&message.startedAtUnixMS,
+			&message.completedAtUnixMS,
+		); err != nil {
+			return nil, fmt.Errorf("scan imported transcript message: %w", err)
+		}
+		message.turnID = strings.TrimSpace(turnID.String)
+		messages = append(messages, message)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate imported transcript messages: %w", err)
+	}
+	return messages, nil
+}
+
+func importedTranscriptTurnAssignments(
+	messages []importedTranscriptMessage,
+) map[string][]importedTranscriptTurnAssignment {
+	assignments := map[string][]importedTranscriptTurnAssignment{}
+	currentSession := ""
+	currentTurnID := ""
+	for _, message := range messages {
+		sessionKey := message.workspaceID + "\x00" + message.agentSessionID
+		if sessionKey != currentSession {
+			currentSession = sessionKey
+			currentTurnID = ""
+		}
+		if !strings.HasPrefix(strings.TrimSpace(message.messageID), "imported-") {
+			currentTurnID = ""
+			continue
+		}
+		if message.turnID != "" {
+			currentTurnID = message.turnID
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(message.role), "user") &&
+			strings.EqualFold(strings.TrimSpace(message.kind), "text") {
+			currentTurnID = importedTranscriptTurnID(message.messageID)
+		}
+		if currentTurnID == "" {
+			continue
+		}
+		assignments[sessionKey] = append(assignments[sessionKey], importedTranscriptTurnAssignment{
+			message: message,
+			turnID:  currentTurnID,
+		})
+	}
+	return assignments
+}
+
+func importedTranscriptTurnID(userMessageID string) string {
+	const messagePrefix = "imported-"
+	userMessageID = strings.TrimSpace(userMessageID)
+	if !strings.HasPrefix(userMessageID, messagePrefix) || len(userMessageID) == len(messagePrefix) {
+		return ""
+	}
+	return "imported-turn-" + strings.TrimPrefix(userMessageID, messagePrefix)
+}

--- a/packages/agent/store-sqlite/migrations_imported_turns_test.go
+++ b/packages/agent/store-sqlite/migrations_imported_turns_test.go
@@ -1,0 +1,127 @@
+package storesqlite
+
+import (
+	"context"
+	"testing"
+)
+
+func TestImportedTurnsMigrationRepairsOnlyImportedTranscriptRows(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID: "ws-import-migration", AgentSessionID: "imported-session",
+		Origin: "WORKSPACE_AGENT_SESSION_ORIGIN_IMPORTED", Provider: "codex",
+		RuntimeContext: map[string]any{"imported": true}, OccurredAtUnixMS: 10,
+	}); err != nil {
+		t.Fatalf("ReportSessionState(imported) error = %v", err)
+	}
+	if _, err := store.ReportSessionMessages(ctx, SessionMessageReport{
+		WorkspaceID: "ws-import-migration", AgentSessionID: "imported-session",
+		Origin: "WORKSPACE_AGENT_SESSION_ORIGIN_IMPORTED", Provider: "codex",
+		HistoricalImport: true,
+		Messages: []MessageUpdate{
+			{MessageID: "imported-orphan", Role: "assistant", Kind: "text", Status: "completed", OccurredAtUnixMS: 11},
+			{MessageID: "imported-user-1", Role: "user", Kind: "text", Status: "completed", OccurredAtUnixMS: 20},
+			{MessageID: "imported-tool-1", Role: "assistant", Kind: "tool_call", Status: "completed", OccurredAtUnixMS: 30},
+			{MessageID: "imported-assistant-1", Role: "assistant", Kind: "text", Status: "completed", OccurredAtUnixMS: 40},
+			{MessageID: "imported-user-2", Role: "user", Kind: "text", Status: "completed", OccurredAtUnixMS: 50},
+			{MessageID: "imported-assistant-2", Role: "assistant", Kind: "text", Status: "completed", OccurredAtUnixMS: 60},
+		},
+	}); err != nil {
+		t.Fatalf("ReportSessionMessages(imported) error = %v", err)
+	}
+	if _, accepted, err := store.RecordTurnTransition(ctx, TurnTransition{
+		WorkspaceID: "ws-import-migration", AgentSessionID: "imported-session",
+		TurnID: "live-turn", Phase: TurnPhaseSettled, Outcome: TurnOutcomeCompleted, OccurredAtUnixMS: 70,
+	}); err != nil || !accepted {
+		t.Fatalf("RecordTurnTransition(live continuation) accepted=%v error=%v", accepted, err)
+	}
+	if _, err := store.ReportSessionMessages(ctx, SessionMessageReport{
+		WorkspaceID: "ws-import-migration", AgentSessionID: "imported-session",
+		Origin: "runtime", Provider: "codex",
+		Messages: []MessageUpdate{
+			{MessageID: "live-assistant", TurnID: "live-turn", Role: "assistant", Kind: "text", Status: "completed", OccurredAtUnixMS: 71},
+			{MessageID: "goal-control:audit", Role: "user", Kind: "session_audit", Status: "completed", OccurredAtUnixMS: 72},
+		},
+	}); err != nil {
+		t.Fatalf("ReportSessionMessages(live continuation) error = %v", err)
+	}
+
+	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID: "ws-import-migration", AgentSessionID: "ordinary-session",
+		Origin: "runtime", Provider: "codex", OccurredAtUnixMS: 10,
+	}); err != nil {
+		t.Fatalf("ReportSessionState(ordinary) error = %v", err)
+	}
+	if _, err := store.ReportSessionMessages(ctx, SessionMessageReport{
+		WorkspaceID: "ws-import-migration", AgentSessionID: "ordinary-session",
+		Origin: "runtime", Provider: "codex", HistoricalImport: true,
+		Messages: []MessageUpdate{
+			{MessageID: "imported-ordinary-user", Role: "user", Kind: "text", Status: "completed", OccurredAtUnixMS: 20},
+			{MessageID: "imported-ordinary-assistant", Role: "assistant", Kind: "text", Status: "completed", OccurredAtUnixMS: 30},
+		},
+	}); err != nil {
+		t.Fatalf("ReportSessionMessages(ordinary fixture) error = %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx,
+		`DELETE FROM `+schemaMigrationsTable+` WHERE id = ?`,
+		schemaMigrationWorkspaceAgentImportedTurnsV1,
+	); err != nil {
+		t.Fatalf("delete imported-turn migration ledger error = %v", err)
+	}
+	if err := store.applyWorkspaceAgentImportedTurnsV1(ctx); err != nil {
+		t.Fatalf("applyWorkspaceAgentImportedTurnsV1() error = %v", err)
+	}
+
+	importedPage, ok, err := store.ListSessionMessages(ctx, ListSessionMessagesInput{
+		WorkspaceID: "ws-import-migration", AgentSessionID: "imported-session", Limit: 20,
+	})
+	if err != nil || !ok {
+		t.Fatalf("ListSessionMessages(imported) ok=%v error=%v", ok, err)
+	}
+	wantTurnIDs := map[string]string{
+		"imported-orphan":      "",
+		"imported-user-1":      "imported-turn-user-1",
+		"imported-tool-1":      "imported-turn-user-1",
+		"imported-assistant-1": "imported-turn-user-1",
+		"imported-user-2":      "imported-turn-user-2",
+		"imported-assistant-2": "imported-turn-user-2",
+		"live-assistant":       "live-turn",
+		"goal-control:audit":   "",
+	}
+	for _, message := range importedPage.Messages {
+		if message.TurnID != wantTurnIDs[message.MessageID] {
+			t.Fatalf("message %q turn = %q, want %q", message.MessageID, message.TurnID, wantTurnIDs[message.MessageID])
+		}
+	}
+	for turnID, finalMessageID := range map[string]string{
+		"imported-turn-user-1": "imported-assistant-1",
+		"imported-turn-user-2": "imported-assistant-2",
+	} {
+		turn, ok, err := store.GetTurn(ctx, "ws-import-migration", "imported-session", turnID)
+		if err != nil || !ok {
+			t.Fatalf("GetTurn(%s) ok=%v error=%v", turnID, ok, err)
+		}
+		if !turn.Backfilled || turn.Origin != TurnOriginUserPrompt ||
+			turn.FinalAssistantMessageID != finalMessageID {
+			t.Fatalf("migrated turn %s = %#v", turnID, turn)
+		}
+	}
+
+	ordinaryPage, ok, err := store.ListSessionMessages(ctx, ListSessionMessagesInput{
+		WorkspaceID: "ws-import-migration", AgentSessionID: "ordinary-session", Limit: 10,
+	})
+	if err != nil || !ok {
+		t.Fatalf("ListSessionMessages(ordinary) ok=%v error=%v", ok, err)
+	}
+	for _, message := range ordinaryPage.Messages {
+		if message.TurnID != "" {
+			t.Fatalf("ordinary message %q gained turn %q", message.MessageID, message.TurnID)
+		}
+	}
+	if err := store.applyWorkspaceAgentImportedTurnsV1(ctx); err != nil {
+		t.Fatalf("idempotent applyWorkspaceAgentImportedTurnsV1() error = %v", err)
+	}
+}

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -609,9 +609,10 @@ type SessionMessageReport struct {
 	AgentSessionID string
 	Origin         string
 	Provider       string
-	// HistoricalImport is an internal-only compatibility boundary for
-	// read-only external transcript imports that predate Turn identities. It
-	// must never be populated from runtime/API report payloads.
+	// HistoricalImport is the internal-only write boundary for read-only
+	// external transcripts. Messages with a trustworthy reconstructed TurnID
+	// create settled backfilled Turns; messages without one remain session
+	// scoped. It must never be populated from runtime/API report payloads.
 	HistoricalImport bool
 	Messages         []MessageUpdate
 }

--- a/packages/agent/store-sqlite/store_test.go
+++ b/packages/agent/store-sqlite/store_test.go
@@ -487,6 +487,54 @@ func TestHistoricalImportCompatibilityCannotBeForgedByOrigin(t *testing.T) {
 	}
 }
 
+func TestHistoricalImportPersistsTrustworthyTurnBoundaries(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	result, err := store.ReportSessionMessages(ctx, SessionMessageReport{
+		WorkspaceID:      "ws-import-turns",
+		AgentSessionID:   "session-import",
+		Origin:           "WORKSPACE_AGENT_SESSION_ORIGIN_IMPORTED",
+		HistoricalImport: true,
+		Messages: []MessageUpdate{
+			{MessageID: "user-1", TurnID: "imported-turn-1", Role: "user", Kind: "text", Status: "completed", OccurredAtUnixMS: 10, StartedAtUnixMS: 10, CompletedAtUnixMS: 10},
+			{MessageID: "tool-1", TurnID: "imported-turn-1", Role: "assistant", Kind: "tool_call", Status: "completed", OccurredAtUnixMS: 20, StartedAtUnixMS: 20, CompletedAtUnixMS: 30},
+			{MessageID: "assistant-1", TurnID: "imported-turn-1", Role: "assistant", Kind: "text", Status: "completed", OccurredAtUnixMS: 40, StartedAtUnixMS: 40, CompletedAtUnixMS: 40},
+			{MessageID: "user-2", TurnID: "imported-turn-2", Role: "user", Kind: "text", Status: "completed", OccurredAtUnixMS: 50, StartedAtUnixMS: 50, CompletedAtUnixMS: 50},
+			{MessageID: "assistant-2", TurnID: "imported-turn-2", Role: "assistant", Kind: "text", Status: "completed", OccurredAtUnixMS: 60, StartedAtUnixMS: 60, CompletedAtUnixMS: 60},
+		},
+	})
+	if err != nil || result.AcceptedCount != 5 {
+		t.Fatalf("historical import result=%#v error=%v", result, err)
+	}
+	for _, expected := range []struct {
+		turnID                string
+		startedAtUnixMS       int64
+		settledAtUnixMS       int64
+		finalAssistantMessage string
+	}{
+		{turnID: "imported-turn-1", startedAtUnixMS: 10, settledAtUnixMS: 40, finalAssistantMessage: "assistant-1"},
+		{turnID: "imported-turn-2", startedAtUnixMS: 50, settledAtUnixMS: 60, finalAssistantMessage: "assistant-2"},
+	} {
+		turn, ok, err := store.GetTurn(ctx, "ws-import-turns", "session-import", expected.turnID)
+		if err != nil || !ok {
+			t.Fatalf("GetTurn(%s) ok=%v error=%v", expected.turnID, ok, err)
+		}
+		if turn.Phase != TurnPhaseSettled || turn.Outcome != TurnOutcomeCompleted ||
+			!turn.Backfilled || turn.Origin != TurnOriginUserPrompt {
+			t.Fatalf("turn %s = %#v, want settled completed user-prompt backfill", expected.turnID, turn)
+		}
+		if turn.StartedAtUnixMS != expected.startedAtUnixMS || turn.SettledAtUnixMS != expected.settledAtUnixMS {
+			t.Fatalf("turn %s timestamps = %d..%d, want %d..%d", expected.turnID,
+				turn.StartedAtUnixMS, turn.SettledAtUnixMS, expected.startedAtUnixMS, expected.settledAtUnixMS)
+		}
+		if !turn.FinalAssistantMessageResolved || turn.FinalAssistantMessageID != expected.finalAssistantMessage {
+			t.Fatalf("turn %s final assistant = resolved:%v id:%q, want %q",
+				expected.turnID, turn.FinalAssistantMessageResolved, turn.FinalAssistantMessageID, expected.finalAssistantMessage)
+		}
+	}
+}
+
 func TestStoreMessageSemanticsRoundTrip(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t, testOptions(&staticProjectPaths{}))

--- a/services/tuttid/service/agent/external_import.go
+++ b/services/tuttid/service/agent/external_import.go
@@ -416,18 +416,24 @@ func (s *Service) importExternalSession(
 	projectPath string,
 ) (int, bool, error) {
 	agentSessionID := externalImportedSessionID(session.Provider, session.ProviderSessionID)
-	existingIDs, sessionExists, err := s.existingExternalImportMessageIDs(ctx, workspaceID, agentSessionID)
+	existingTurnIDs, sessionExists, err := s.existingExternalImportMessageTurnIDs(ctx, workspaceID, agentSessionID)
 	if err != nil {
 		return 0, false, err
 	}
 	updates := make([]agentactivitybiz.MessageUpdate, 0, len(session.Messages))
+	currentTurnID := ""
 	for i, message := range session.Messages {
 		messageID := externalImportedMessageIDForMessage(session.Provider, session.ProviderSessionID, message, i)
-		if _, ok := existingIDs[messageID]; ok {
+		if message.Role == "user" && message.Kind == "text" {
+			currentTurnID = externalImportedTurnID(messageID)
+		}
+		existingTurnID, exists := existingTurnIDs[messageID]
+		if exists && (currentTurnID == "" || existingTurnID == currentTurnID) {
 			continue
 		}
 		updates = append(updates, agentactivitybiz.MessageUpdate{
 			MessageID:         messageID,
+			TurnID:            currentTurnID,
 			Role:              message.Role,
 			Kind:              message.Kind,
 			Status:            message.Status,
@@ -492,13 +498,13 @@ func (s *Service) importExternalSession(
 	return importedMessages, true, nil
 }
 
-func (s *Service) existingExternalImportMessageIDs(ctx context.Context, workspaceID string, agentSessionID string) (map[string]struct{}, bool, error) {
-	ids := map[string]struct{}{}
+func (s *Service) existingExternalImportMessageTurnIDs(ctx context.Context, workspaceID string, agentSessionID string) (map[string]string, bool, error) {
+	turnIDs := map[string]string{}
 	if s == nil || s.ExternalImportStore == nil {
-		return ids, false, nil
+		return turnIDs, false, nil
 	}
 	if _, ok, err := s.ExternalImportStore.GetSession(ctx, workspaceID, agentSessionID); err != nil || !ok {
-		return ids, ok, err
+		return turnIDs, ok, err
 	}
 	var after uint64
 	for {
@@ -510,19 +516,19 @@ func (s *Service) existingExternalImportMessageIDs(ctx context.Context, workspac
 			Order:          agentactivitybiz.MessageOrderAsc,
 		})
 		if err != nil || !ok {
-			return ids, true, err
+			return turnIDs, true, err
 		}
 		if len(page.Messages) == 0 {
-			return ids, true, nil
+			return turnIDs, true, nil
 		}
 		for _, message := range page.Messages {
-			ids[strings.TrimSpace(message.MessageID)] = struct{}{}
+			turnIDs[strings.TrimSpace(message.MessageID)] = strings.TrimSpace(message.TurnID)
 			if message.Version > after {
 				after = message.Version
 			}
 		}
 		if !page.HasMore {
-			return ids, true, nil
+			return turnIDs, true, nil
 		}
 	}
 }
@@ -540,6 +546,15 @@ func externalImportedMessageIDForMessage(provider string, providerSessionID stri
 		return "imported-" + externalStableHash(provider + "\x00" + providerSessionID + "\x00" + seed)[:32]
 	}
 	return externalImportedMessageID(provider, providerSessionID, message.RawID, index)
+}
+
+func externalImportedTurnID(userMessageID string) string {
+	const messagePrefix = "imported-"
+	userMessageID = strings.TrimSpace(userMessageID)
+	if !strings.HasPrefix(userMessageID, messagePrefix) || len(userMessageID) == len(messagePrefix) {
+		return ""
+	}
+	return "imported-turn-" + strings.TrimPrefix(userMessageID, messagePrefix)
 }
 
 func externalImportedMessagePayload(message externalImportedMessage) map[string]any {

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -1640,6 +1640,25 @@ func TestServiceImportsExternalAgentSessionsByProject(t *testing.T) {
 	}) {
 		t.Fatalf("imported messages = %#v, want structured Codex tool call", importedMessages.Messages)
 	}
+	codexTurnID := ""
+	for _, message := range importedMessages.Messages {
+		if message.TurnID == "" {
+			t.Fatalf("imported Codex message %q has no reconstructed turn", message.MessageID)
+		}
+		if codexTurnID == "" {
+			codexTurnID = message.TurnID
+		} else if message.TurnID != codexTurnID {
+			t.Fatalf("imported Codex message %q turn = %q, want %q", message.MessageID, message.TurnID, codexTurnID)
+		}
+	}
+	codexTurn, ok, err := store.GetTurn(ctx, "ws-1", codexAID, codexTurnID)
+	if err != nil || !ok {
+		t.Fatalf("GetTurn(imported Codex) ok=%v error=%v", ok, err)
+	}
+	if !codexTurn.Backfilled || codexTurn.Phase != agentactivitybiz.TurnPhaseSettled ||
+		codexTurn.Origin != agentactivitybiz.TurnOriginUserPrompt {
+		t.Fatalf("imported Codex turn = %#v, want settled user-prompt backfill", codexTurn)
+	}
 	sessions, err := service.List(ctx, "ws-1")
 	if err != nil {
 		t.Fatalf("List error = %v", err)
@@ -1675,6 +1694,15 @@ func TestServiceImportsExternalAgentSessionsByProject(t *testing.T) {
 	}
 	if claudeSession.AgentTargetID != agenttargetbiz.IDLocalClaudeCode {
 		t.Fatalf("imported Claude Code agent target id = %q, want %s", claudeSession.AgentTargetID, agenttargetbiz.IDLocalClaudeCode)
+	}
+	claudeMessages, err := service.ListMessages(ctx, "ws-1", claudeSession.ID, ListMessagesInput{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMessages imported Claude Code session error = %v", err)
+	}
+	if len(claudeMessages.Messages) != 2 ||
+		claudeMessages.Messages[0].TurnID == "" ||
+		claudeMessages.Messages[0].TurnID != claudeMessages.Messages[1].TurnID {
+		t.Fatalf("imported Claude Code messages = %#v, want one reconstructed turn", claudeMessages.Messages)
 	}
 	finalRerun, err := service.ImportExternalSessions(ctx, "ws-1", ExternalImportInput{
 		Projects: []ExternalImportProjectSelection{{Path: projectA}},
@@ -1727,6 +1755,107 @@ func TestServiceImportsExternalAgentSessionsByProject(t *testing.T) {
 	}
 	if value(refreshedSession.Title) != "Updated first prompt" {
 		t.Fatalf("refreshed title = %q, want updated first user message", value(refreshedSession.Title))
+	}
+}
+
+func TestServiceReimportRepairsLegacyTurnlessExternalMessages(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-1", Name: "Workspace One"}); err != nil {
+		t.Fatalf("Create workspace error = %v", err)
+	}
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatalf("create project error = %v", err)
+	}
+	if canonical, ok := canonicalExistingDir(project); ok {
+		project = canonical
+	}
+	codexHome := filepath.Join(root, "codex-home")
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(root, "claude-home"))
+	sourcePath := filepath.Join(codexHome, "sessions", "legacy-turnless.jsonl")
+	writeAgentServiceJSONL(t, sourcePath,
+		map[string]any{
+			"timestamp": "2026-07-24T00:00:00Z",
+			"type":      "session_meta",
+			"payload":   map[string]any{"id": "legacy-turnless", "cwd": project},
+		},
+		map[string]any{"timestamp": "2026-07-24T00:00:01Z", "type": "response_item", "payload": map[string]any{
+			"type": "message", "id": "user-1", "role": "user",
+			"content": []any{map[string]any{"type": "input_text", "text": "Inspect the project"}},
+		}},
+		map[string]any{"timestamp": "2026-07-24T00:00:02Z", "type": "response_item", "payload": map[string]any{
+			"type": "function_call", "id": "tool-1", "name": "exec_command",
+			"call_id": "call-status", "arguments": `{"cmd":"git status --short"}`,
+		}},
+		map[string]any{"timestamp": "2026-07-24T00:00:03Z", "type": "response_item", "payload": map[string]any{
+			"type": "function_call_output", "call_id": "call-status", "output": "clean",
+		}},
+		map[string]any{"timestamp": "2026-07-24T00:00:04Z", "type": "response_item", "payload": map[string]any{
+			"type": "message", "id": "assistant-1", "role": "assistant",
+			"content": []any{map[string]any{"type": "output_text", "text": "The project is clean"}},
+		}},
+	)
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatalf("open source transcript error = %v", err)
+	}
+	defer source.Close()
+	parsed, ok, err := parseCodexJSONL(sourcePath, source)
+	if err != nil || !ok {
+		t.Fatalf("parseCodexJSONL ok=%v error=%v", ok, err)
+	}
+	agentSessionID := externalImportedSessionID(parsed.Provider, parsed.ProviderSessionID)
+	legacyUpdates := make([]agentactivitybiz.MessageUpdate, 0, len(parsed.Messages))
+	for index, message := range parsed.Messages {
+		legacyUpdates = append(legacyUpdates, agentactivitybiz.MessageUpdate{
+			MessageID:         externalImportedMessageIDForMessage(parsed.Provider, parsed.ProviderSessionID, message, index),
+			Role:              message.Role,
+			Kind:              message.Kind,
+			Status:            message.Status,
+			Payload:           externalImportedMessagePayload(message),
+			OccurredAtUnixMS:  message.OccurredAtUnixMS,
+			StartedAtUnixMS:   message.StartedAtUnixMS,
+			CompletedAtUnixMS: message.CompletedAtUnixMS,
+		})
+	}
+	if _, err := store.ReportSessionMessages(ctx, agentactivitybiz.SessionMessageReport{
+		WorkspaceID: "ws-1", AgentSessionID: agentSessionID,
+		Origin: WorkspaceAgentSessionOriginImported, Provider: parsed.Provider,
+		HistoricalImport: true, Messages: legacyUpdates,
+	}); err != nil {
+		t.Fatalf("seed legacy turnless messages error = %v", err)
+	}
+
+	service := newIsolatedAgentService(newFakeRuntime())
+	service.ExternalImportStore = store
+	result, err := service.ImportExternalSessions(ctx, "ws-1", ExternalImportInput{
+		Projects: []ExternalImportProjectSelection{{Path: project}},
+	})
+	if err != nil {
+		t.Fatalf("ImportExternalSessions repair error = %v", err)
+	}
+	if result.ImportedMessages != len(parsed.Messages) {
+		t.Fatalf("repair result = %#v, want %d repaired updates", result, len(parsed.Messages))
+	}
+	page, found, err := store.ListSessionMessages(ctx, agentactivitybiz.ListSessionMessagesInput{
+		WorkspaceID: "ws-1", AgentSessionID: agentSessionID, Limit: 10,
+	})
+	if err != nil || !found {
+		t.Fatalf("ListSessionMessages repaired found=%v error=%v", found, err)
+	}
+	repairedTurnID := ""
+	for _, message := range page.Messages {
+		if message.TurnID == "" {
+			t.Fatalf("repaired message %q remains turnless", message.MessageID)
+		}
+		if repairedTurnID == "" {
+			repairedTurnID = message.TurnID
+		} else if message.TurnID != repairedTurnID {
+			t.Fatalf("repaired message %q turn = %q, want %q", message.MessageID, message.TurnID, repairedTurnID)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- reconstruct stable historical turns from retained user-message boundaries during Codex and Claude Code imports
- atomically persist settled backfilled turns and repair legacy imported turnless rows with a forward-only migration
- keep pre-boundary content session-scoped and document the canonical ownership/troubleshooting flow

## Tests
- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`

## Notes
- no OpenAPI or user-visible copy changes
- migration only targets non-deleted sessions marked as imported and `imported-*` message rows
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->