### PR TITLE
fix(desktop): warm renderer before dev launch

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -4,6 +4,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { PerfMonitorVitePlugin } from "@tutti-os/rrt-plugin-vite";
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 import type { PluginOption } from "vite";
+import { waitForRendererWarmupPlugin } from "../../tools/scripts/renderer-dev-warmup.mjs";
 
 const aliases = {
   "@app/renderer": resolve("../../packages/agent/gui/app/renderer"),
@@ -79,6 +80,14 @@ const devServer = {
     host: "127.0.0.1"
   }
 };
+
+const rendererWarmupEntryUrls = [
+  "/src/main.tsx",
+  "/src/app/windows/workspace/createWorkspaceWindowContainer.ts",
+  "/src/app/windows/workspace/DefaultWorkspaceWindow.tsx",
+  "/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx",
+  "/src/app/windows/workspace/StandaloneAgentWorkspaceWindow.tsx"
+];
 
 function envFlagEnabled(value: string | undefined): boolean {
   return /^(1|true|yes|on)$/iu.test(value?.trim() ?? "");
@@ -163,6 +172,9 @@ export default defineConfig({
   renderer: {
     server: devServer,
     plugins: [
+      waitForRendererWarmupPlugin({
+        entryUrls: rendererWarmupEntryUrls
+      }),
       react({
         babel: {
           plugins: [

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -133,7 +133,12 @@
   settings aligned between development and production; do not hide a cold
   transform bottleneck by changing compiler semantics only in development.
   Reduce the initial module graph, precompile a stable package boundary, or
-  schedule non-blocking preload work instead. Keep the
+  schedule non-blocking preload work instead. For desktop development, wait for
+  Vite to transform the statically reachable startup graphs before
+  `electron-vite` launches Electron. Treat the top-level workspace and
+  standalone Agent lazy route modules as explicit warmup entries; do not follow
+  every dynamic import, because that compiles unopened tools and diagnostics.
+  Keep the
   right side shaped like the empty-home/new-conversation hero, not a selected
   conversation timeline with a bottom dock. Keep the fallback hero composer
   non-interactive until the real controller owns its draft.
@@ -158,7 +163,8 @@
   Finally cold-start local dev and compare the same timestamp landmarks; this
   manual renderer verification requires explicit user approval. If the dynamic
   import still dominates, compare cold and warm module-graph timings before
-  investigating daemon hydration or provider discovery.
+  investigating daemon hydration or provider discovery. The dev server must log
+  `renderer warmup completed` before `start electron app`.
   When a provider-status request is slow, compare Renderer `durationMs` with the
   daemon batch `durationMs`. A large daemon total points to provider detection;
   a large Renderer-only gap points to transport, timeout handling, or Renderer
@@ -169,6 +175,8 @@
 - References:
   [agent-gui-node.md](../../architecture/agent-gui-node.md)
   [WorkspaceWindow.tsx](../../../apps/desktop/src/renderer/src/app/windows/workspace/WorkspaceWindow.tsx)
+  [electron.vite.config.ts](../../../apps/desktop/electron.vite.config.ts)
+  [renderer-dev-warmup.mjs](../../../tools/scripts/renderer-dev-warmup.mjs)
   [StandaloneAgentToolSidebar.tsx](../../../apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx)
   [desktopAgentProviderStatusService.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts)
   [desktopAgentProviderStatusDiagnostics.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusDiagnostics.ts)

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "@hey-api/openapi-ts": "0.97.2",
     "@tutti-os/ui-system": "workspace:*",
     "@typescript/native-preview": "7.0.0-dev.20260617.2",
+    "es-module-lexer": "2.1.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.5",
     "oxfmt": "0.55.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       "@typescript/native-preview":
         specifier: 7.0.0-dev.20260617.2
         version: 7.0.0-dev.20260617.2
+      es-module-lexer:
+        specifier: 2.1.0
+        version: 2.1.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -11,7 +11,10 @@ Current examples include:
 
 - `dev-gui.sh` for checking local prerequisites, preparing workspace
   dependencies, downloading and building the development `tuttid` binary, and
-  launching the desktop GUI with `TUTTID_BIN`
+  launching the desktop GUI with `TUTTID_BIN`; the renderer dev server warms
+  its reachable module graph before Electron opens
+- `renderer-dev-warmup.mjs` for moving cold Vite and React Compiler transforms
+  ahead of the Electron launch during desktop development
 - `setup-dev.mjs` for checking local developer prerequisites such as pinned lint tooling
 - `setup-dev.mjs --install=golangci-lint` for installing the pinned Go lint tool
 - `generate-defaults.mjs` for generating shared Go and desktop TypeScript defaults from `config/tutti.defaults.json`

--- a/tools/scripts/renderer-dev-warmup.d.mts
+++ b/tools/scripts/renderer-dev-warmup.d.mts
@@ -1,0 +1,15 @@
+import type { Plugin, ViteDevServer } from "vite";
+
+export interface RendererDevWarmupOptions {
+  concurrency?: number;
+  entryUrls?: string[];
+}
+
+export function warmRendererModuleGraph(
+  server: ViteDevServer,
+  options?: RendererDevWarmupOptions
+): Promise<number>;
+
+export function waitForRendererWarmupPlugin(
+  options?: RendererDevWarmupOptions
+): Plugin;

--- a/tools/scripts/renderer-dev-warmup.mjs
+++ b/tools/scripts/renderer-dev-warmup.mjs
@@ -1,0 +1,86 @@
+import { init, parse } from "es-module-lexer";
+
+const defaultConcurrency = 8;
+const defaultEntryUrls = ["/src/main.tsx"];
+
+export async function warmRendererModuleGraph(
+  server,
+  { concurrency = defaultConcurrency, entryUrls = defaultEntryUrls } = {}
+) {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error("Renderer warmup concurrency must be a positive integer.");
+  }
+  if (
+    !Array.isArray(entryUrls) ||
+    entryUrls.length === 0 ||
+    entryUrls.some((entryUrl) => typeof entryUrl !== "string")
+  ) {
+    throw new Error("Renderer warmup entry URLs must be a non-empty array.");
+  }
+
+  await init;
+
+  const queuedUrls = new Set(entryUrls);
+  const pendingUrls = [...entryUrls];
+  let transformedModuleCount = 0;
+
+  while (pendingUrls.length > 0) {
+    const batch = pendingUrls.splice(0, concurrency);
+    const importedUrlGroups = await Promise.all(
+      batch.map(async (url) => {
+        const result = await server.transformRequest(url);
+        transformedModuleCount += 1;
+
+        if (!result?.code) {
+          return [];
+        }
+
+        const [imports] = parse(result.code);
+        return imports
+          .filter((importedModule) => importedModule.d === -1)
+          .map((importedModule) => importedModule.n)
+          .filter((importedUrl) => typeof importedUrl === "string");
+      })
+    );
+
+    for (const importedUrl of importedUrlGroups.flat()) {
+      if (queuedUrls.has(importedUrl)) {
+        continue;
+      }
+      queuedUrls.add(importedUrl);
+      pendingUrls.push(importedUrl);
+    }
+  }
+
+  return transformedModuleCount;
+}
+
+export function waitForRendererWarmupPlugin({
+  concurrency = defaultConcurrency,
+  entryUrls = defaultEntryUrls
+} = {}) {
+  return {
+    name: "wait-for-renderer-warmup",
+    apply: "serve",
+    configureServer(server) {
+      const listen = server.listen.bind(server);
+
+      server.listen = async (...args) => {
+        const result = await listen(...args);
+        const startedAt = performance.now();
+        server.config.logger.info(
+          "warming renderer modules before Electron launch..."
+        );
+        const transformedModuleCount = await warmRendererModuleGraph(server, {
+          concurrency,
+          entryUrls
+        });
+        const durationMs = Math.round(performance.now() - startedAt);
+        server.config.logger.info(
+          `renderer warmup completed in ${durationMs}ms (${transformedModuleCount} modules)`
+        );
+        return result;
+      };
+    }
+  };
+}

--- a/tools/scripts/renderer-dev-warmup.test.mjs
+++ b/tools/scripts/renderer-dev-warmup.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  waitForRendererWarmupPlugin,
+  warmRendererModuleGraph
+} from "./renderer-dev-warmup.mjs";
+
+test("renderer warmup transforms each statically reachable module once", async () => {
+  const modules = createTransformedModules({
+    "/src/lazy.tsx": "",
+    "/src/main.tsx": `
+      import "/src/shared.ts";
+      import { view } from "/src/view.tsx";
+    `,
+    "/src/shared.ts": "",
+    "/src/view.tsx": `
+      import("/src/lazy.tsx");
+      export { shared } from "/src/shared.ts";
+    `
+  });
+  const transformedUrls = [];
+
+  const transformedModuleCount = await warmRendererModuleGraph(
+    {
+      async transformRequest(url) {
+        transformedUrls.push(url);
+        return { code: modules.get(url) ?? "" };
+      }
+    },
+    { concurrency: 2 }
+  );
+
+  assert.equal(transformedModuleCount, 3);
+  assert.deepEqual(
+    new Set(transformedUrls),
+    new Set(["/src/main.tsx", "/src/shared.ts", "/src/view.tsx"])
+  );
+});
+
+test("renderer warmup plugin waits for transforms after the server listens", async () => {
+  const events = [];
+  const server = {
+    config: {
+      logger: {
+        info(message) {
+          events.push(message);
+        }
+      }
+    },
+    async listen() {
+      events.push("listen");
+      return server;
+    },
+    async transformRequest(url) {
+      events.push(`transform:${url}`);
+      return { code: "" };
+    }
+  };
+
+  const plugin = waitForRendererWarmupPlugin();
+  plugin.configureServer(server);
+  const result = await server.listen();
+
+  assert.equal(result, server);
+  assert.equal(events[0], "listen");
+  assert.equal(events[2], "transform:/src/main.tsx");
+  assert.match(
+    events.at(-1),
+    /^renderer warmup completed in \d+ms \(1 modules\)$/
+  );
+});
+
+test("renderer warmup rejects invalid concurrency", async () => {
+  await assert.rejects(
+    warmRendererModuleGraph(
+      {
+        async transformRequest() {
+          return { code: "" };
+        }
+      },
+      { concurrency: 0 }
+    ),
+    /positive integer/
+  );
+});
+
+function createTransformedModules(codeByUrl) {
+  return new Map(Object.entries(codeByUrl));
+}


### PR DESCRIPTION
## Summary
- wait for Vite to transform the desktop renderer startup graphs before Electron launches in development
- warm the explicit workspace and standalone Agent route entries without traversing unopened dynamic tools
- cover the warmup traversal and launch ordering, and document the cold-start diagnostic

## Tests
- `pnpm check:full`
- `pnpm --filter @tutti-os/desktop build`
- `node --test tools/scripts/renderer-dev-warmup.test.mjs`

## Notes
- the warmup plugin applies only to the Vite serve path; production bundles are unchanged
- transform failures now stop the dev launch in the CLI instead of surfacing behind an empty Electron window

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->