### PR TITLE
fix(desktop): trim package without dropping protocol assets

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
@@ -5,6 +6,7 @@ import { PerfMonitorVitePlugin } from "@tutti-os/rrt-plugin-vite";
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 import type { PluginOption } from "vite";
 import { waitForRendererWarmupPlugin } from "../../tools/scripts/renderer-dev-warmup.mjs";
+import { tuttiAssetProtocolAssets } from "./src/main/host/tuttiAssetProtocolAssets.ts";
 
 const aliases = {
   "@app/renderer": resolve("../../packages/agent/gui/app/renderer"),
@@ -89,6 +91,25 @@ const rendererWarmupEntryUrls = [
   "/src/app/windows/workspace/StandaloneAgentWorkspaceWindow.tsx"
 ];
 
+function emitTuttiAssetProtocolAssetsPlugin(): PluginOption {
+  return {
+    name: "emit-tutti-asset-protocol-assets",
+    apply: "build",
+    async buildStart(): Promise<void> {
+      for (const [route, sourceRelativePath] of Object.entries(
+        tuttiAssetProtocolAssets
+      )) {
+        const source = await readFile(resolve(sourceRelativePath));
+        this.emitFile({
+          type: "asset",
+          fileName: `assets/tutti-asset/${route}`,
+          source
+        });
+      }
+    }
+  };
+}
+
 function envFlagEnabled(value: string | undefined): boolean {
   return /^(1|true|yes|on)$/iu.test(value?.trim() ?? "");
 }
@@ -172,6 +193,7 @@ export default defineConfig({
   renderer: {
     server: devServer,
     plugins: [
+      emitTuttiAssetProtocolAssetsPlugin(),
       waitForRendererWarmupPlugin({
         entryUrls: rendererWarmupEntryUrls
       }),

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,6 +14,10 @@
     "executableName": "Tutti",
     "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
     "generateUpdatesFilesForAllChannels": true,
+    "files": [
+      "out/**",
+      "package.json"
+    ],
     "afterPack": "scripts/copy-vendored-node-resources-after-pack.mjs",
     "afterAllArtifactBuild": "scripts/notarize-mac-dmg-artifacts.mjs",
     "extraResources": [

--- a/apps/desktop/src/main/host/tuttiAssetProtocol.test.ts
+++ b/apps/desktop/src/main/host/tuttiAssetProtocol.test.ts
@@ -3,30 +3,19 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
+import { tuttiAssetProtocolAssets } from "./tuttiAssetProtocolAssets.ts";
 import { resolveTuttiAssetProtocolFilePath } from "./tuttiAssetProtocolResolver.ts";
 
 test("tutti asset protocol resolves development source assets", () => {
   const appPath = mkdtempSync(join(tmpdir(), "tutti-asset-dev-"));
-  const sourcePath = join(
-    appPath,
-    "src",
-    "renderer",
-    "src",
-    "assets",
-    "workspace-canvas",
-    "dock",
-    "default",
-    "codex.png"
-  );
+  const route = "agent/codex.png";
+  const sourcePath = join(appPath, tuttiAssetProtocolAssets[route]);
   mkdirSync(dirname(sourcePath), { recursive: true });
   writeFileSync(sourcePath, "");
 
   try {
     assert.equal(
-      resolveTuttiAssetProtocolFilePath(
-        "tutti-asset://agent/codex.png",
-        appPath
-      ),
+      resolveTuttiAssetProtocolFilePath(`tutti-asset://${route}`, appPath),
       sourcePath
     );
   } finally {
@@ -34,244 +23,46 @@ test("tutti asset protocol resolves development source assets", () => {
   }
 });
 
-test("tutti asset protocol resolves packaged renderer assets", () => {
+test("tutti asset protocol resolves every packaged asset by exact route", () => {
   const appPath = mkdtempSync(join(tmpdir(), "tutti-asset-packaged-"));
-  const builtAssetPath = join(
-    appPath,
-    "out",
-    "renderer",
-    "assets",
-    "claude-rounded-abc123.png"
-  );
-  mkdirSync(dirname(builtAssetPath), { recursive: true });
-  writeFileSync(builtAssetPath, "");
 
   try {
-    assert.equal(
-      resolveTuttiAssetProtocolFilePath(
-        "tutti-asset://agent/claudecode.png",
-        appPath
-      ),
-      builtAssetPath
-    );
-  } finally {
-    rmSync(appPath, { force: true, recursive: true });
-  }
-});
+    for (const route of Object.keys(tuttiAssetProtocolAssets)) {
+      const builtAssetPath = join(
+        appPath,
+        "out",
+        "renderer",
+        "assets",
+        "tutti-asset",
+        route
+      );
+      mkdirSync(dirname(builtAssetPath), { recursive: true });
+      writeFileSync(builtAssetPath, "");
 
-test("tutti asset protocol resolves packaged codex rounded asset", () => {
-  const appPath = mkdtempSync(join(tmpdir(), "tutti-asset-codex-"));
-  const builtAssetPath = join(
-    appPath,
-    "out",
-    "renderer",
-    "assets",
-    "codex-rounded-abc123.png"
-  );
-  mkdirSync(dirname(builtAssetPath), { recursive: true });
-  writeFileSync(builtAssetPath, "");
-
-  try {
-    assert.equal(
-      resolveTuttiAssetProtocolFilePath(
-        "tutti-asset://agent/codex.png",
-        appPath
-      ),
-      builtAssetPath
-    );
-  } finally {
-    rmSync(appPath, { force: true, recursive: true });
-  }
-});
-
-test("tutti asset protocol resolves packaged codex mask asset", () => {
-  const appPath = mkdtempSync(join(tmpdir(), "tutti-asset-codex-mask-"));
-  const builtAssetPath = join(
-    appPath,
-    "out",
-    "renderer",
-    "assets",
-    "codex-flat-filled-abc123.svg"
-  );
-  mkdirSync(dirname(builtAssetPath), { recursive: true });
-  writeFileSync(builtAssetPath, "");
-
-  try {
-    assert.equal(
-      resolveTuttiAssetProtocolFilePath(
-        "tutti-asset://agent/codex-mask.svg",
-        appPath
-      ),
-      builtAssetPath
-    );
-  } finally {
-    rmSync(appPath, { force: true, recursive: true });
-  }
-});
-
-for (const [agent, builtFileName] of [
-  ["cursor", "cursor-colorful-abc123.png"],
-  ["openclaw", "openclaw-rounded-abc123.png"],
-  ["opencode", "opencode-rounded-abc123.png"]
-] as const) {
-  test(`tutti asset protocol resolves packaged ${agent} asset`, () => {
-    const appPath = mkdtempSync(join(tmpdir(), `tutti-asset-${agent}-`));
-    const builtAssetPath = join(
-      appPath,
-      "out",
-      "renderer",
-      "assets",
-      builtFileName
-    );
-    mkdirSync(dirname(builtAssetPath), { recursive: true });
-    writeFileSync(builtAssetPath, "");
-
-    try {
       assert.equal(
-        resolveTuttiAssetProtocolFilePath(
-          `tutti-asset://agent/${agent}.png`,
-          appPath
-        ),
+        resolveTuttiAssetProtocolFilePath(`tutti-asset://${route}`, appPath),
         builtAssetPath
       );
-    } finally {
-      rmSync(appPath, { force: true, recursive: true });
     }
-  });
-}
-
-test("tutti asset protocol resolves issue default asset route", () => {
-  const appPath = mkdtempSync(join(tmpdir(), "tutti-asset-issue-"));
-  const sourcePath = join(
-    appPath,
-    "src",
-    "renderer",
-    "src",
-    "assets",
-    "workspace-canvas",
-    "dock",
-    "default",
-    "issue.png"
-  );
-  mkdirSync(dirname(sourcePath), { recursive: true });
-  writeFileSync(sourcePath, "");
-
-  try {
-    assert.equal(
-      resolveTuttiAssetProtocolFilePath(
-        "tutti-asset://issue/default.png",
-        appPath
-      ),
-      sourcePath
-    );
   } finally {
     rmSync(appPath, { force: true, recursive: true });
   }
 });
 
-test("tutti asset protocol resolves file default asset route", () => {
-  const appPath = mkdtempSync(join(tmpdir(), "tutti-asset-file-"));
-  const sourcePath = join(
-    appPath,
-    "src",
-    "renderer",
-    "src",
-    "assets",
-    "workspace-canvas",
-    "dock",
-    "default",
-    "apps",
-    "document.png"
-  );
-  mkdirSync(dirname(sourcePath), { recursive: true });
-  writeFileSync(sourcePath, "");
+test("tutti asset protocol ignores similarly prefixed renderer assets", () => {
+  const appPath = mkdtempSync(join(tmpdir(), "tutti-asset-collision-"));
+  const builtAssetsDirectory = join(appPath, "out", "renderer", "assets");
+  mkdirSync(builtAssetsDirectory, { recursive: true });
+  writeFileSync(join(builtAssetsDirectory, "tutti-00000000.png"), "");
+  writeFileSync(join(builtAssetsDirectory, "tutti-vinyl-00000000.png"), "");
 
   try {
     assert.equal(
       resolveTuttiAssetProtocolFilePath(
-        "tutti-asset://file/default.png",
+        "tutti-asset://agent/tutti.png",
         appPath
       ),
-      sourcePath
-    );
-  } finally {
-    rmSync(appPath, { force: true, recursive: true });
-  }
-});
-
-test("tutti asset protocol resolves packaged file default asset", () => {
-  const appPath = mkdtempSync(join(tmpdir(), "tutti-asset-file-packaged-"));
-  const builtAssetPath = join(
-    appPath,
-    "out",
-    "renderer",
-    "assets",
-    "document-abc123.png"
-  );
-  mkdirSync(dirname(builtAssetPath), { recursive: true });
-  writeFileSync(builtAssetPath, "");
-
-  try {
-    assert.equal(
-      resolveTuttiAssetProtocolFilePath(
-        "tutti-asset://file/default.png",
-        appPath
-      ),
-      builtAssetPath
-    );
-  } finally {
-    rmSync(appPath, { force: true, recursive: true });
-  }
-});
-
-test("tutti asset protocol resolves folder default asset route", () => {
-  const appPath = mkdtempSync(join(tmpdir(), "tutti-asset-folder-"));
-  const sourcePath = join(
-    appPath,
-    "src",
-    "renderer",
-    "src",
-    "assets",
-    "workspace-canvas",
-    "dock",
-    "default",
-    "files.png"
-  );
-  mkdirSync(dirname(sourcePath), { recursive: true });
-  writeFileSync(sourcePath, "");
-
-  try {
-    assert.equal(
-      resolveTuttiAssetProtocolFilePath(
-        "tutti-asset://folder/default.png",
-        appPath
-      ),
-      sourcePath
-    );
-  } finally {
-    rmSync(appPath, { force: true, recursive: true });
-  }
-});
-
-test("tutti asset protocol resolves packaged folder default asset", () => {
-  const appPath = mkdtempSync(join(tmpdir(), "tutti-asset-folder-packaged-"));
-  const builtAssetPath = join(
-    appPath,
-    "out",
-    "renderer",
-    "assets",
-    "files-abc123.png"
-  );
-  mkdirSync(dirname(builtAssetPath), { recursive: true });
-  writeFileSync(builtAssetPath, "");
-
-  try {
-    assert.equal(
-      resolveTuttiAssetProtocolFilePath(
-        "tutti-asset://folder/default.png",
-        appPath
-      ),
-      builtAssetPath
+      null
     );
   } finally {
     rmSync(appPath, { force: true, recursive: true });

--- a/apps/desktop/src/main/host/tuttiAssetProtocolAssets.ts
+++ b/apps/desktop/src/main/host/tuttiAssetProtocolAssets.ts
@@ -1,0 +1,32 @@
+export const tuttiAssetProtocolAssets = {
+  "agent/claudecode-mask.svg":
+    "../../packages/agent/gui/app/renderer/assets/icons/agents/claudecode-flat-filled.svg",
+  "agent/claudecode.png":
+    "src/renderer/src/assets/workspace-canvas/dock/default/claudecode.png",
+  "agent/codex-mask.svg":
+    "../../packages/agent/gui/app/renderer/assets/icons/agents/codex-flat-filled.svg",
+  "agent/codex.png":
+    "src/renderer/src/assets/workspace-canvas/dock/default/codex.png",
+  "agent/cursor-mask.svg":
+    "../../packages/agent/gui/app/renderer/assets/icons/agents/cursor-flat-filled.svg",
+  "agent/cursor.png":
+    "src/renderer/src/assets/workspace-canvas/dock/default/cursor.png",
+  "agent/openclaw.png":
+    "src/renderer/src/assets/workspace-canvas/dock/default/openclaw.png",
+  "agent/opencode-mask.svg":
+    "../../packages/agent/gui/app/renderer/assets/icons/agents/opencode-flat-filled.svg",
+  "agent/opencode.png":
+    "src/renderer/src/assets/workspace-canvas/dock/default/opencode.png",
+  "agent/tutti-mask.svg":
+    "../../packages/agent/gui/app/renderer/assets/icons/agents/tutti-flat-filled.svg",
+  "agent/tutti.png":
+    "src/renderer/src/assets/workspace-canvas/dock/default/tutti.png",
+  "file/default.png":
+    "src/renderer/src/assets/workspace-canvas/dock/default/apps/document.png",
+  "folder/default.png":
+    "src/renderer/src/assets/workspace-canvas/dock/default/files.png",
+  "issue/default.png":
+    "src/renderer/src/assets/workspace-canvas/dock/default/issue.png"
+} as const;
+
+export type TuttiAssetProtocolRoute = keyof typeof tuttiAssetProtocolAssets;

--- a/apps/desktop/src/main/host/tuttiAssetProtocolResolver.ts
+++ b/apps/desktop/src/main/host/tuttiAssetProtocolResolver.ts
@@ -1,93 +1,10 @@
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { tuttiAssetProtocolScheme } from "../../shared/tuttiAssetProtocol.ts";
-
-const tuttiAssetRoutes = {
-  "agent/claudecode-mask.svg": {
-    builtFileExtensions: [".svg"],
-    builtFilePrefixes: ["claudecode-flat-filled-"],
-    sourceRelativePath:
-      "../../packages/agent/gui/app/renderer/assets/icons/agents/claudecode-flat-filled.svg"
-  },
-  "agent/claudecode.png": {
-    builtFileExtensions: [".png"],
-    builtFilePrefixes: ["claude-rounded-", "claudecode-"],
-    sourceRelativePath:
-      "src/renderer/src/assets/workspace-canvas/dock/default/claudecode.png"
-  },
-  "agent/codex-mask.svg": {
-    builtFileExtensions: [".svg"],
-    builtFilePrefixes: ["codex-flat-filled-"],
-    sourceRelativePath:
-      "../../packages/agent/gui/app/renderer/assets/icons/agents/codex-flat-filled.svg"
-  },
-  "agent/codex.png": {
-    builtFileExtensions: [".png"],
-    builtFilePrefixes: ["codex-rounded-", "codex-"],
-    sourceRelativePath:
-      "src/renderer/src/assets/workspace-canvas/dock/default/codex.png"
-  },
-  "agent/cursor-mask.svg": {
-    builtFileExtensions: [".svg"],
-    builtFilePrefixes: ["cursor-flat-filled-"],
-    sourceRelativePath:
-      "../../packages/agent/gui/app/renderer/assets/icons/agents/cursor-flat-filled.svg"
-  },
-  "agent/cursor.png": {
-    builtFileExtensions: [".png"],
-    builtFilePrefixes: ["cursor-colorful-", "cursor-rounded-", "cursor-"],
-    sourceRelativePath:
-      "src/renderer/src/assets/workspace-canvas/dock/default/cursor.png"
-  },
-  "agent/openclaw.png": {
-    builtFileExtensions: [".png"],
-    builtFilePrefixes: ["openclaw-rounded-", "openclaw-"],
-    sourceRelativePath:
-      "src/renderer/src/assets/workspace-canvas/dock/default/openclaw.png"
-  },
-  "agent/opencode-mask.svg": {
-    builtFileExtensions: [".svg"],
-    builtFilePrefixes: ["opencode-flat-filled-"],
-    sourceRelativePath:
-      "../../packages/agent/gui/app/renderer/assets/icons/agents/opencode-flat-filled.svg"
-  },
-  "agent/opencode.png": {
-    builtFileExtensions: [".png"],
-    builtFilePrefixes: ["opencode-rounded-", "opencode-"],
-    sourceRelativePath:
-      "src/renderer/src/assets/workspace-canvas/dock/default/opencode.png"
-  },
-  "agent/tutti-mask.svg": {
-    builtFileExtensions: [".svg"],
-    builtFilePrefixes: ["tutti-flat-filled-"],
-    sourceRelativePath:
-      "../../packages/agent/gui/app/renderer/assets/icons/agents/tutti-flat-filled.svg"
-  },
-  "agent/tutti.png": {
-    builtFileExtensions: [".png"],
-    builtFilePrefixes: ["tutti-"],
-    sourceRelativePath:
-      "src/renderer/src/assets/workspace-canvas/dock/default/tutti.png"
-  },
-  "file/default.png": {
-    builtFileExtensions: [".png"],
-    builtFilePrefixes: ["document-"],
-    sourceRelativePath:
-      "src/renderer/src/assets/workspace-canvas/dock/default/apps/document.png"
-  },
-  "folder/default.png": {
-    builtFileExtensions: [".png"],
-    builtFilePrefixes: ["files-"],
-    sourceRelativePath:
-      "src/renderer/src/assets/workspace-canvas/dock/default/files.png"
-  },
-  "issue/default.png": {
-    builtFileExtensions: [".png"],
-    builtFilePrefixes: ["issue-"],
-    sourceRelativePath:
-      "src/renderer/src/assets/workspace-canvas/dock/default/issue.png"
-  }
-} as const;
+import {
+  tuttiAssetProtocolAssets,
+  type TuttiAssetProtocolRoute
+} from "./tuttiAssetProtocolAssets.ts";
 
 export function resolveTuttiAssetProtocolFilePath(
   url: string,
@@ -98,29 +15,23 @@ export function resolveTuttiAssetProtocolFilePath(
     return null;
   }
 
-  const sourcePath = join(appPath, route.sourceRelativePath);
+  const sourcePath = join(appPath, tuttiAssetProtocolAssets[route]);
   if (existsSync(sourcePath)) {
     return sourcePath;
   }
 
-  const builtAssetsDirectory = join(appPath, "out", "renderer", "assets");
-  if (!existsSync(builtAssetsDirectory)) {
-    return null;
-  }
-
-  const builtFileName = readdirSync(builtAssetsDirectory).find(
-    (fileName) =>
-      route.builtFilePrefixes.some((prefix) => fileName.startsWith(prefix)) &&
-      route.builtFileExtensions.some((extension) =>
-        fileName.toLowerCase().endsWith(extension)
-      )
+  const builtAssetPath = join(
+    appPath,
+    "out",
+    "renderer",
+    "assets",
+    "tutti-asset",
+    route
   );
-  return builtFileName ? join(builtAssetsDirectory, builtFileName) : null;
+  return existsSync(builtAssetPath) ? builtAssetPath : null;
 }
 
-function tuttiAssetRouteFromUrl(
-  value: string
-): (typeof tuttiAssetRoutes)[keyof typeof tuttiAssetRoutes] | null {
+function tuttiAssetRouteFromUrl(value: string): TuttiAssetProtocolRoute | null {
   let url: URL;
   try {
     url = new URL(value);
@@ -131,5 +42,7 @@ function tuttiAssetRouteFromUrl(
     return null;
   }
   const key = `${url.hostname}${url.pathname}`.replace(/^\/+/, "");
-  return tuttiAssetRoutes[key as keyof typeof tuttiAssetRoutes] ?? null;
+  return key in tuttiAssetProtocolAssets
+    ? (key as TuttiAssetProtocolRoute)
+    : null;
 }

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -114,6 +114,15 @@ Vendored Node bundles (`claude-sdk-sidecar`, `browser-mcp`) must stay free of pl
 Contents/Resources/bin/tuttid
 ```
 
+The Electron `app.asar` file list is allowlisted to built `out/**` runtime
+outputs plus the package manifest. Do not package repository `src/**`, tests,
+scripts, or documentation into the application archive. Production
+`node_modules` dependencies remain managed by `electron-builder`.
+Assets served through `tutti-asset://` must be emitted explicitly into
+`out/renderer/assets/tutti-asset/<route>` and resolved by that exact route.
+Packaged builds must not depend on repository source paths or hashed filename
+prefix scans as a runtime fallback.
+
 On Windows the bundled daemon filename is `tuttid.exe`.
 
 Expected release artifacts include:

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -40,6 +40,12 @@ const desktopBuildIconPath = new URL(
   import.meta.url
 );
 
+test("desktop package includes runtime outputs without repository source", async () => {
+  const packageJson = JSON.parse(await readFile(desktopPackagePath, "utf8"));
+
+  assert.deepEqual(packageJson.build.files, ["out/**", "package.json"]);
+});
+
 test("desktop release workflow uses the published desktop package name", async () => {
   const packageJson = JSON.parse(await readFile(desktopPackagePath, "utf8"));
   const workflow = await readFile(workflowPath, "utf8");


### PR DESCRIPTION
## Summary
- allowlist Desktop app.asar to built runtime output and package metadata
- emit every tutti-asset route to a stable packaged path instead of scanning hashed filename prefixes
- cover development, packaged, prefix-collision, and unknown-route resolution

## Tests
- `pnpm check:changed`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm --filter @tutti-os/desktop build:unpack`
- `pnpm check:changed -- --push-ready`
- `codesign --verify --deep --strict apps/desktop/dist/mac-arm64/Tutti.app`

## Notes
- verified all 14 protocol assets exist in app.asar under `out/renderer/assets/tutti-asset/`
- CI workflow changes are intentionally out of scope
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->