### PR TITLE
Fix/agent gui 0725

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -295,6 +295,12 @@ The engine owns:
 
 The engine does not own daemon persistence, provider transport, DOM, or permanent UI layout.
 
+When a model change invalidates canonical context-window usage, AgentGUI keeps
+the last rendered usage for that exact Session visible until a fresh canonical
+usage value arrives. This retained value is presentation-only: it is keyed by
+Session, never crosses into another conversation, and is never written back to
+the workspace engine.
+
 Runtime command availability is session-scoped whenever one workspace engine
 can contain Sessions backed by different transports. The host projects
 `available`, `transport_reconnecting`, or `transport_unavailable`; the engine

--- a/docs/architecture/claude-code-sdk-runtime.md
+++ b/docs/architecture/claude-code-sdk-runtime.md
@@ -66,6 +66,12 @@ New normalized session updates use `sessionUpdateKind`; the former ACP-named
 metadata key is accepted only while reading imported or durable historical
 events.
 
+Context usage is published only when the provider reports a context-window
+limit or the live Session already has a provider-reported limit for the same
+model. Token deltas from a new Session do not synthesize a 200k or 1M
+denominator from the model name; AgentGUI keeps usage hidden until the first
+authoritative window arrives.
+
 Claude credential-sensitive operations share the process-wide gate owned by
 `services/tuttid/service/claudecode`. Real session startup, hidden model
 discovery, and `claude auth status` acquire this same gate. The AgentGUI's

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -16,8 +16,6 @@ const (
 	claudeSDKAppRuntimeCacheEnv    = "TUTTI_APP_RUNTIME_CACHE_ROOT"
 	claudeSDKSidecarAdapterName    = "claude-agent-sdk"
 	claudeSDKSidecarDefaultNodeArg = "--experimental-strip-types"
-	claudeSDKDefaultContextWindow  = int64(200000)
-	claudeSDK1MContextWindow       = int64(1000000)
 	claudeSDKAuthRefreshLogPrefix  = "CLAUDE_CODE_AUTH_REFRESH_DEBUG"
 )
 

--- a/packages/agent/daemon/runtime/claude_sdk_live_state.go
+++ b/packages/agent/daemon/runtime/claude_sdk_live_state.go
@@ -430,15 +430,11 @@ func claudeSDKUsageUpdate(payload map[string]any, previous claudeSDKUsageState, 
 	}
 	if contextWindow := payloadMap(payload, "contextWindow"); len(contextWindow) > 0 {
 		if _, ok := firstInt64Value(contextWindow, "totalTokens", "total_tokens", "size", "limit", "max"); !ok {
-			total := int64(0)
-			if claudeSDKCanReusePreviousContextWindow(previous, contextModel) {
-				total = previous.contextWindowTokens
-			}
-			if total <= 0 {
-				total = claudeSDKAssumedContextWindow(contextModel)
+			if !claudeSDKCanReusePreviousContextWindow(previous, contextModel) {
+				return nil
 			}
 			contextWindow = clonePayload(contextWindow)
-			contextWindow["totalTokens"] = total
+			contextWindow["totalTokens"] = previous.contextWindowTokens
 		}
 		return map[string]any{
 			"sessionUpdate": "usage_update",
@@ -464,7 +460,7 @@ func claudeSDKUsageUpdate(payload map[string]any, previous claudeSDKUsageState, 
 		total = previous.contextWindowTokens
 	}
 	if total <= 0 {
-		total = claudeSDKAssumedContextWindow(contextModel)
+		return nil
 	}
 	return map[string]any{
 		"sessionUpdate": "usage_update",
@@ -473,25 +469,6 @@ func claudeSDKUsageUpdate(payload map[string]any, previous claudeSDKUsageState, 
 			"totalTokens": total,
 		},
 	}
-}
-
-// claudeSDKAssumedContextWindow picks the context-window size to assume when
-// the Claude Agent SDK hasn't yet reported an authoritative per-model window
-// for this turn (claudeSDKContextWindowTokens returns 0, e.g. every streamed
-// usage delta before the turn's final "result" message carries modelUsage)
-// and there's no matching previously-known window to carry forward
-// (claudeSDKCanReusePreviousContextWindow). Model IDs/aliases across the
-// Claude Code model aliases mark 1M-context variants with a "[1m]" suffix,
-// including the built-in "sonnet[1m]" alias and user-configured aliases such
-// as "claude-fable-5[1m]". Honor that
-// convention here too, so a brand-new session/turn on a 1M-context model
-// doesn't render the usage popover against the base 200k denominator for the
-// entire duration of the turn.
-func claudeSDKAssumedContextWindow(contextModel string) int64 {
-	if strings.Contains(strings.ToLower(claudeSDKCanonicalModel(contextModel)), "[1m]") {
-		return claudeSDK1MContextWindow
-	}
-	return claudeSDKDefaultContextWindow
 }
 
 func claudeSDKCanReusePreviousContextWindow(previous claudeSDKUsageState, contextModel string) bool {

--- a/packages/agent/daemon/runtime/claude_sdk_usage_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_usage_test.go
@@ -6,10 +6,11 @@ import (
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
-func TestClaudeCodeSDKAdapterMapsUsageUpdatedIntoRuntimeContext(t *testing.T) {
+func TestClaudeCodeSDKAdapterWaitsForContextWindowBeforePublishingUsage(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)
 	adapterSession := &claudeSDKAdapterSession{liveState: newClaudeSDKLiveState()}
+	adapterSession.applyConfigOption("model", "opus")
 	adapter.storeSession(session.AgentSessionID, adapterSession)
 
 	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-1", claudeSDKSidecarEvent{
@@ -27,17 +28,12 @@ func TestClaudeCodeSDKAdapterMapsUsageUpdatedIntoRuntimeContext(t *testing.T) {
 	if err != nil || terminal {
 		t.Fatalf("usage_updated terminal=%v err=%v", terminal, err)
 	}
-	if len(events) != 1 || events[0].Type != activityshared.EventSessionUpdated {
-		t.Fatalf("usage events = %#v, want session.updated", events)
+	if len(events) != 0 {
+		t.Fatalf("usage events = %#v, want none before context window is known", events)
 	}
 	state := adapter.SessionState(session)
-	usage, _ := state.RuntimeContext["usage"].(map[string]any)
-	contextWindow, _ := usage["contextWindow"].(map[string]any)
-	if got, ok := int64Value(contextWindow["usedTokens"]); !ok || got != 130 {
-		t.Fatalf("usedTokens = %#v, want 130", contextWindow["usedTokens"])
-	}
-	if got, ok := int64Value(contextWindow["totalTokens"]); !ok || got != claudeSDKDefaultContextWindow {
-		t.Fatalf("totalTokens = %#v, want default context window", contextWindow["totalTokens"])
+	if usage := state.RuntimeContext["usage"]; usage != nil {
+		t.Fatalf("runtime usage = %#v, want unavailable before context window is known", usage)
 	}
 }
 
@@ -97,31 +93,13 @@ func TestClaudeCodeSDKContextWindowDoesNotBorrowAnotherModel(t *testing.T) {
 	}
 }
 
-// TestClaudeCodeSDKAdapterAssumes1MWindowForOneMillionModelAliasBeforeResult
-// reproduces the context-usage popover bug reported after PR #749: on a
-// "[1m]" (1M-context) model alias, every usage_updated delta streamed before
-// the turn's final result message (the only one carrying an authoritative
-// modelUsage.contextWindow) used to fall back to the flat 200k default,
-// so the popover showed e.g. "38,551 / 200,000 (19%)" for a model whose real
-// window is 1,000,000 — for the entire duration of the turn. Once the final
-// message with modelUsage landed, the total would jump to 1,000,000, only to
-// reset back to the wrong 200k default on the next turn/session. This test
-// pins the fix: even the very first, modelUsage-less delta on a "[1m]" alias
-// must assume the 1,000,000 window, not the flat 200k default.
-func TestClaudeCodeSDKAdapterAssumes1MWindowForOneMillionModelAliasBeforeResult(t *testing.T) {
+func TestClaudeCodeSDKAdapterPublishesFirstTurnUsageAfterModelWindowArrives(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)
 	adapterSession := &claudeSDKAdapterSession{liveState: newClaudeSDKLiveState()}
 	adapter.storeSession(session.AgentSessionID, adapterSession)
-	// Mirrors a user-configured custom model alias such as the reported
-	// "claude-fable-5[1m]", following the same "[1m]" suffix convention as
-	// the built-in "opus[1m]"/"sonnet[1m]" aliases.
-	adapterSession.applyConfigOption("model", "claude-fable-5[1m]")
+	adapterSession.applyConfigOption("model", "opus")
 
-	// First streamed usage delta of a brand-new turn/session: no
-	// modelUsage yet (previous.contextKnown is false), matching the
-	// "agent session Claude SDK usage update" log lines observed at
-	// current_context_known=false in the field report.
 	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-1", claudeSDKSidecarEvent{
 		Type: "usage_updated",
 		Payload: map[string]any{
@@ -135,19 +113,14 @@ func TestClaudeCodeSDKAdapterAssumes1MWindowForOneMillionModelAliasBeforeResult(
 	if err != nil || terminal {
 		t.Fatalf("usage_updated terminal=%v err=%v", terminal, err)
 	}
-	if len(events) != 1 || events[0].Type != activityshared.EventSessionUpdated {
-		t.Fatalf("usage events = %#v, want session.updated", events)
+	if len(events) != 0 {
+		t.Fatalf("usage events = %#v, want none before modelUsage arrives", events)
 	}
 	state := adapter.SessionState(session)
-	usage, _ := state.RuntimeContext["usage"].(map[string]any)
-	contextWindow, _ := usage["contextWindow"].(map[string]any)
-	if got, ok := int64Value(contextWindow["totalTokens"]); !ok || got != 1_000_000 {
-		t.Fatalf("totalTokens = %#v, want assumed 1,000,000 window for a [1m] model alias before modelUsage is known", contextWindow["totalTokens"])
+	if usage := state.RuntimeContext["usage"]; usage != nil {
+		t.Fatalf("runtime usage = %#v, want unavailable before modelUsage arrives", usage)
 	}
 
-	// The turn's final result message now reports the authoritative
-	// modelUsage window: it must agree with the assumed value, not flip
-	// the denominator mid-turn.
 	events, terminal, err = adapter.sidecarTurnEvents(adapterSession, session, "turn-1", claudeSDKSidecarEvent{
 		Type: "usage_updated",
 		Payload: map[string]any{
@@ -157,7 +130,7 @@ func TestClaudeCodeSDKAdapterAssumes1MWindowForOneMillionModelAliasBeforeResult(
 				"output_tokens": 8_859,
 			},
 			"modelUsage": map[string]any{
-				"claude-fable-5[1m]": map[string]any{
+				"claude-opus-4-6": map[string]any{
 					"contextWindow": 1_000_000,
 				},
 			},
@@ -170,8 +143,11 @@ func TestClaudeCodeSDKAdapterAssumes1MWindowForOneMillionModelAliasBeforeResult(
 		t.Fatalf("usage events (final) = %#v", events)
 	}
 	state = adapter.SessionState(session)
-	usage, _ = state.RuntimeContext["usage"].(map[string]any)
-	contextWindow, _ = usage["contextWindow"].(map[string]any)
+	usage, _ := state.RuntimeContext["usage"].(map[string]any)
+	contextWindow, _ := usage["contextWindow"].(map[string]any)
+	if got, ok := int64Value(contextWindow["usedTokens"]); !ok || got != 40_859 {
+		t.Fatalf("usedTokens (final) = %#v, want 40,859", contextWindow["usedTokens"])
+	}
 	if got, ok := int64Value(contextWindow["totalTokens"]); !ok || got != 1_000_000 {
 		t.Fatalf("totalTokens (final) = %#v, want 1,000,000 from modelUsage", contextWindow["totalTokens"])
 	}
@@ -230,17 +206,57 @@ func TestClaudeCodeSDKAdapterDoesNotCarryContextWindowAcrossModelChange(t *testi
 			},
 		},
 	})
-	if err != nil || terminal || len(events) != 1 {
-		t.Fatalf("haiku context usage events=%#v terminal=%v err=%v, want session.updated", events, terminal, err)
+	if err != nil || terminal {
+		t.Fatalf("haiku context usage terminal=%v err=%v", terminal, err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("haiku context usage events=%#v, want none before the new model window is known", events)
 	}
 	state := adapter.SessionState(session)
 	usage, _ := state.RuntimeContext["usage"].(map[string]any)
 	contextWindow, _ := usage["contextWindow"].(map[string]any)
-	if got, ok := int64Value(contextWindow["usedTokens"]); !ok || got != 29_538 {
-		t.Fatalf("usedTokens = %#v, want latest haiku context usage", contextWindow["usedTokens"])
+	if got, ok := int64Value(contextWindow["usedTokens"]); !ok || got != 36_103 {
+		t.Fatalf("usedTokens = %#v, want previous published usage until the new model window is known", contextWindow["usedTokens"])
 	}
-	if got, ok := int64Value(contextWindow["totalTokens"]); !ok || got != 200_000 {
-		t.Fatalf("totalTokens = %#v, want default context window after model switch", contextWindow["totalTokens"])
+	if got, ok := int64Value(contextWindow["totalTokens"]); !ok || got != 1_000_000 {
+		t.Fatalf("totalTokens = %#v, want previous published context window until the new model window is known", contextWindow["totalTokens"])
+	}
+}
+
+func TestClaudeCodeSDKAdapterReusesKnownContextWindowForSameModel(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{liveState: newClaudeSDKLiveState()}
+	adapterSession.applyConfigOption("model", "opus")
+	adapterSession.liveState.usage = claudeSDKUsageState{
+		contextUsedTokens:   20_000,
+		contextWindowTokens: 1_000_000,
+		contextKnown:        true,
+		contextModel:        "opus",
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+
+	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-2", claudeSDKSidecarEvent{
+		Type: "usage_updated",
+		Payload: map[string]any{
+			"turnId": "turn-2",
+			"usage": map[string]any{
+				"input_tokens":  30_000,
+				"output_tokens": 8_551,
+			},
+		},
+	})
+	if err != nil || terminal || len(events) != 1 {
+		t.Fatalf("usage events=%#v terminal=%v err=%v, want same-model session.updated", events, terminal, err)
+	}
+	state := adapter.SessionState(session)
+	usage, _ := state.RuntimeContext["usage"].(map[string]any)
+	contextWindow, _ := usage["contextWindow"].(map[string]any)
+	if got, ok := int64Value(contextWindow["usedTokens"]); !ok || got != 38_551 {
+		t.Fatalf("usedTokens = %#v, want 38,551", contextWindow["usedTokens"])
+	}
+	if got, ok := int64Value(contextWindow["totalTokens"]); !ok || got != 1_000_000 {
+		t.Fatalf("totalTokens = %#v, want retained same-model context window", contextWindow["totalTokens"])
 	}
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIConversation.styles.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIConversation.styles.ts
@@ -13,6 +13,8 @@ const styles = {
   interactiveOptionDisplay:
     "agent-gui-conversation__interactive-option-display",
   interactiveOptionButton: "agent-gui-conversation__interactive-option-button",
+  interactiveOptionContent:
+    "agent-gui-conversation__interactive-option-content",
   interactiveOptionTitle: "agent-gui-conversation__interactive-option-title",
   interactiveOptionDescription:
     "agent-gui-conversation__interactive-option-description",

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.spec.tsx
@@ -8,7 +8,10 @@ import { describe, expect, it } from "vitest";
 import { useAgentGUIComposerCapabilities } from "./useAgentGUIComposerCapabilities";
 
 describe("useAgentGUIComposerCapabilities", () => {
-  it("projects typed canonical session usage into the composer footer", () => {
+  function engineSession(input: {
+    agentSessionId?: string;
+    usage: CanonicalAgentSession["usage"];
+  }): CanonicalAgentSession {
     const normalized = normalizeAgentActivitySession({
       ...{
         activeTurnId: null,
@@ -16,15 +19,12 @@ describe("useAgentGUIComposerCapabilities", () => {
         pendingInteractions: []
       },
       workspaceId: "workspace-1",
-      agentSessionId: "session-1",
+      agentSessionId: input.agentSessionId ?? "session-1",
       provider: "opencode",
       providerSessionId: "provider-session-1",
       cwd: "/workspace/project",
       title: "OpenCode",
-      usage: {
-        contextWindow: { usedTokens: 33_168, totalTokens: 400_000 },
-        quotas: []
-      }
+      usage: input.usage
     });
     const {
       activeTurn: _activeTurn,
@@ -33,6 +33,16 @@ describe("useAgentGUIComposerCapabilities", () => {
       pendingInteractions: _pendingInteractions,
       ...activeEngineSession
     } = normalized;
+    return activeEngineSession as CanonicalAgentSession;
+  }
+
+  it("projects typed canonical session usage into the composer footer", () => {
+    const activeEngineSession = engineSession({
+      usage: {
+        contextWindow: { usedTokens: 33_168, totalTokens: 400_000 },
+        quotas: []
+      }
+    });
     const data = {
       provider: "opencode" as const,
       agentTargetId: "local:opencode",
@@ -42,7 +52,7 @@ describe("useAgentGUIComposerCapabilities", () => {
     const { result, rerender } = renderHook(() =>
       useAgentGUIComposerCapabilities({
         activeConversationId: "session-1",
-        activeEngineSession: activeEngineSession as CanonicalAgentSession,
+        activeEngineSession,
         activeSessionState: null,
         agentActivitySnapshot: createEmptyAgentActivitySnapshot("workspace-1"),
         data,
@@ -67,5 +77,96 @@ describe("useAgentGUIComposerCapabilities", () => {
     rerender();
 
     expect(result.current.usage).toBe(previousUsage);
+  });
+
+  it("retains the last session usage while a model change awaits fresh usage", () => {
+    let activeEngineSession = engineSession({
+      usage: {
+        contextWindow: { usedTokens: 20_000, totalTokens: 200_000 },
+        quotas: []
+      }
+    });
+    const data = {
+      provider: "opencode" as const,
+      agentTargetId: "local:opencode",
+      lastActiveAgentSessionId: "session-1"
+    };
+    const { result, rerender } = renderHook(() =>
+      useAgentGUIComposerCapabilities({
+        activeConversationId: activeEngineSession.agentSessionId,
+        activeEngineSession,
+        activeSessionState: null,
+        agentActivitySnapshot: createEmptyAgentActivitySnapshot("workspace-1"),
+        data,
+        draftSettingsBySessionId: {},
+        selectedComposerTargetData: {
+          agentTargetId: "local:opencode",
+          data,
+          provider: "opencode",
+          targetId: "local:opencode"
+        }
+      })
+    );
+
+    const previousUsage = result.current.usage;
+    activeEngineSession = engineSession({ usage: null });
+    rerender();
+
+    expect(result.current.usage).toBe(previousUsage);
+
+    activeEngineSession = engineSession({
+      usage: {
+        contextWindow: { usedTokens: 36_103, totalTokens: 1_000_000 },
+        quotas: []
+      }
+    });
+    rerender();
+
+    expect(result.current.usage).toEqual({
+      usedTokens: 36_103,
+      totalTokens: 1_000_000,
+      percentUsed: 4,
+      quotas: []
+    });
+  });
+
+  it("does not carry retained usage into another session", () => {
+    let activeEngineSession = engineSession({
+      usage: {
+        contextWindow: { usedTokens: 20_000, totalTokens: 200_000 },
+        quotas: []
+      }
+    });
+    const data = {
+      provider: "opencode" as const,
+      agentTargetId: "local:opencode",
+      lastActiveAgentSessionId: "session-1"
+    };
+    const { result, rerender } = renderHook(() =>
+      useAgentGUIComposerCapabilities({
+        activeConversationId: activeEngineSession.agentSessionId,
+        activeEngineSession,
+        activeSessionState: null,
+        agentActivitySnapshot: createEmptyAgentActivitySnapshot("workspace-1"),
+        data,
+        draftSettingsBySessionId: {},
+        selectedComposerTargetData: {
+          agentTargetId: "local:opencode",
+          data,
+          provider: "opencode",
+          targetId: "local:opencode"
+        }
+      })
+    );
+
+    expect(result.current.usage?.totalTokens).toBe(200_000);
+
+    activeEngineSession = engineSession({
+      agentSessionId: "session-2",
+      usage: null
+    });
+    rerender();
+
+    expect(result.current.usage).toBeNull();
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.ts
@@ -1,10 +1,11 @@
 import {
   resolveAgentActivityCapability,
   resolveAgentActivityUsage,
+  type AgentActivityUsage,
   type AgentActivitySnapshot,
   type CanonicalAgentSession
 } from "@tutti-os/agent-activity-core";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import type {
   AgentSessionComposerSettings,
   AgentSessionReasoningEffort,
@@ -36,6 +37,9 @@ interface UseAgentGUIComposerCapabilitiesInput {
 export function useAgentGUIComposerCapabilities(
   input: UseAgentGUIComposerCapabilitiesInput
 ) {
+  const retainedUsageBySessionIdRef = useRef(
+    new Map<string, AgentActivityUsage>()
+  );
   const composerTargetData = composerTargetDataForConversation({
     activeConversationId: input.activeConversationId,
     data: input.data,
@@ -106,10 +110,21 @@ export function useAgentGUIComposerCapabilities(
   }, [providerComposerOptions, sessionCapabilities]);
 
   const usageSource = input.activeEngineSession?.usage ?? null;
-  const usage = useMemo(
-    () => resolveAgentActivityUsage({ sessionUsage: usageSource }),
-    [usageSource]
-  );
+  const usage = useMemo(() => {
+    const agentSessionId =
+      input.activeEngineSession?.agentSessionId.trim() ?? "";
+    if (!agentSessionId) {
+      return null;
+    }
+    const resolved = resolveAgentActivityUsage({
+      sessionUsage: usageSource
+    });
+    if (resolved) {
+      retainedUsageBySessionIdRef.current.set(agentSessionId, resolved);
+      return resolved;
+    }
+    return retainedUsageBySessionIdRef.current.get(agentSessionId) ?? null;
+  }, [input.activeEngineSession?.agentSessionId, usageSource]);
 
   return {
     compactSupported:

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -3580,19 +3580,10 @@ aside.workspace-agents-status-panel
 
 .agent-gui-conversation__interactive-option-shortcut {
   position: absolute;
-  top: 50%;
+  inset-block: 0;
   right: 8px;
-  display: inline-flex;
-  align-items: center;
-  height: 20px;
-  border-radius: 4px;
-  background: color-mix(in srgb, var(--transparency-block) 72%, transparent);
-  color: var(--text-tertiary);
-  font-size: 11px;
+  margin-block: auto;
   font-weight: 500;
-  line-height: 1;
-  padding: 4px 6px;
-  transform: translateY(-50%);
 }
 
 .agent-gui-conversation__interactive-option-spinner {

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -149,12 +149,6 @@
   cursor: zoom-out;
 }
 
-.tsh-zoom-dialog__image-actions {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
 .tsh-zoom-dialog__zoom-controls {
   position: fixed;
   top: max(20px, calc(var(--cove-titlebar-reserve, 0px) + 10px));
@@ -174,7 +168,7 @@
   -webkit-app-region: no-drag;
 }
 
-.tsh-zoom-dialog:not(:has(.tsh-zoom-dialog__image-actions))
+.tsh-zoom-dialog:not([data-tsh-image-actions="true"])
   .tsh-zoom-dialog__zoom-controls {
   right: 72px;
 }
@@ -193,7 +187,6 @@
   -webkit-app-region: no-drag;
 }
 
-.tsh-zoom-dialog__image-actions button,
 .tsh-zoom-dialog__zoom-controls button,
 .tsh-image-context-menu button {
   display: flex;
@@ -232,8 +225,7 @@
   font-variant-numeric: tabular-nums;
 }
 
-.tsh-zoom-dialog__icon-button,
-.tsh-zoom-dialog__image-actions button {
+.tsh-zoom-dialog__icon-button {
   justify-content: center;
   width: 32px;
   height: 32px;
@@ -250,8 +242,7 @@
   padding: 7px 10px;
 }
 
-.tsh-zoom-dialog__icon-button:hover,
-.tsh-zoom-dialog__image-actions button:hover {
+.tsh-zoom-dialog__icon-button:hover {
   background: color-mix(in srgb, var(--background-panel) 82%, white 12%);
 }
 

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -128,12 +128,16 @@
   }
 }
 
-.tsh-zoom-dialog [data-rmiz-btn-unzoom] {
+.tsh-zoom-dialog__toolbar-actions {
   position: fixed;
   top: max(20px, calc(var(--cove-titlebar-reserve, 0px) + 10px));
   right: 20px;
   inset-inline-end: 20px;
   z-index: 100301;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  -webkit-app-region: no-drag;
 }
 
 .tsh-zoom-dialog__image {
@@ -146,11 +150,8 @@
 }
 
 .tsh-zoom-dialog__image-actions {
-  position: fixed;
-  top: max(20px, calc(var(--cove-titlebar-reserve, 0px) + 10px));
-  right: 58px;
-  z-index: 100301;
   display: flex;
+  align-items: center;
   gap: 6px;
 }
 

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -3448,11 +3448,12 @@ aside.workspace-agents-status-panel
 }
 
 .agent-gui-conversation__interactive-option-button {
-  position: relative;
-  display: grid;
-  gap: 3px;
-  justify-items: start;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  gap: 12px;
   width: 100%;
+  min-width: 0;
   border: 0;
   border-radius: 8px;
   background: var(--transparency-block);
@@ -3461,6 +3462,7 @@ aside.workspace-agents-status-panel
   font-size: 13px;
   font-weight: 500;
   line-height: 1.3;
+  outline: none;
   padding: 8px 8px 8px 12px;
   text-align: left;
   transition:
@@ -3479,8 +3481,12 @@ aside.workspace-agents-status-panel
     color-mix(in srgb, var(--text-primary) 24%, transparent);
 }
 
+.agent-gui-conversation__interactive-option-button:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+}
+
 .agent-gui-conversation__interactive-option-display {
-  position: relative;
   display: grid;
   gap: 3px;
   justify-items: start;
@@ -3533,31 +3539,22 @@ aside.workspace-agents-status-panel
   -webkit-line-clamp: 2;
 }
 
-.agent-gui-conversation__interactive-option-button:has(
-  .agent-gui-conversation__interactive-option-shortcut,
-  .agent-gui-conversation__interactive-option-spinner
-) {
-  padding-right: 8px;
-}
-
-.agent-gui-conversation__interactive-option-button:has(
-    .agent-gui-conversation__interactive-option-shortcut,
-    .agent-gui-conversation__interactive-option-spinner
-  )
-  .agent-gui-conversation__interactive-option-title,
-.agent-gui-conversation__interactive-option-button:has(
-    .agent-gui-conversation__interactive-option-shortcut,
-    .agent-gui-conversation__interactive-option-spinner
-  )
-  .agent-gui-conversation__interactive-option-description {
-  max-width: calc(100% - 112px);
+.agent-gui-conversation__interactive-option-content {
+  display: grid;
+  flex: 1 1 auto;
+  gap: 3px;
+  justify-items: start;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .agent-gui-conversation__interactive-option-description {
+  max-width: 100%;
   color: var(--text-tertiary);
   font-size: 11px;
   font-weight: 400;
   line-height: 1.3;
+  overflow-wrap: anywhere;
 }
 
 .agent-gui-conversation__interactive-option-command-description {
@@ -3579,19 +3576,14 @@ aside.workspace-agents-status-panel
 }
 
 .agent-gui-conversation__interactive-option-shortcut {
-  position: absolute;
-  inset-block: 0;
-  right: 8px;
-  margin-block: auto;
+  flex: none;
+  margin-inline-start: auto;
   font-weight: 500;
 }
 
 .agent-gui-conversation__interactive-option-spinner {
-  position: absolute;
-  top: 50%;
-  right: 8px;
+  flex: none;
   color: currentColor;
-  transform: translateY(-50%);
 }
 
 .agent-gui-conversation__interactive-feedback-composer {
@@ -3682,14 +3674,6 @@ aside.workspace-agents-status-panel
   height: 22px;
 }
 
-.agent-gui-conversation__interactive-feedback-send-button
-  .agent-gui-conversation__interactive-option-spinner {
-  position: static;
-  top: auto;
-  right: auto;
-  transform: none;
-}
-
 .agent-gui-conversation__interactive-prompt-footer {
   display: grid;
   gap: 10px;
@@ -3700,27 +3684,6 @@ aside.workspace-agents-status-panel
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 8px;
-}
-
-.agent-gui-conversation__interactive-prompt-actions
-  button:not([data-slot="button"]) {
-  min-height: 30px;
-  border: 1px solid var(--line-2);
-  border-radius: 999px;
-  background: var(--background-fronted);
-  color: var(--text-primary);
-  font-family: inherit;
-  font-size: 11px;
-  font-weight: 560;
-  padding: 6px 12px;
-}
-
-.agent-gui-conversation__interactive-prompt-actions
-  button:not([data-slot="button"]):disabled {
-  cursor: not-allowed;
-  background: var(--transparency-block);
-  color: var(--text-disabled);
-  opacity: 0.58;
 }
 
 .agent-gui-conversation__user-message-flow,

--- a/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
+++ b/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
@@ -334,6 +334,7 @@ export function ZoomableImage({
               autoFocus
               className="tsh-zoom-dialog nodrag tsh-desktop-no-drag"
               data-closing={isImagePreviewClosing ? "true" : undefined}
+              data-tsh-image-actions={hasImageActions ? "true" : undefined}
               data-rmiz-modal=""
               role="dialog"
               tabIndex={-1}
@@ -368,25 +369,21 @@ export function ZoomableImage({
                 onWheel={handlePreviewImageWheel}
               />
               <div className="tsh-zoom-dialog__toolbar-actions nodrag tsh-desktop-no-drag">
-                {actionButtons ? (
-                  <div className="tsh-zoom-dialog__image-actions">
-                    {actionButtons}
-                  </div>
-                ) : null}
+                {actionButtons}
                 <Button
-                  asChild
+                  aria-label={t("common.minimizeImage")}
                   className="tsh-zoom-dialog__icon-button nodrag tsh-desktop-no-drag"
                   size="icon"
+                  title={t("common.minimizeImage")}
+                  onPointerDown={(event) => event.stopPropagation()}
                   variant="chrome"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    closePreviewImage();
+                  }}
                 >
-                  <button
-                    type="button"
-                    aria-label={t("common.minimizeImage")}
-                    data-rmiz-btn-unzoom=""
-                    onClick={closePreviewImage}
-                  >
-                    <RestoreIcon aria-hidden="true" className="size-4" />
-                  </button>
+                  <RestoreIcon aria-hidden="true" className="size-4" />
                 </Button>
               </div>
               {contextMenuPosition?.inZoomDialog && actionButtons ? (

--- a/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
+++ b/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
@@ -367,11 +367,28 @@ export function ZoomableImage({
                 onZoomOut={zoomOutPreviewImage}
                 onWheel={handlePreviewImageWheel}
               />
-              {actionButtons ? (
-                <div className="tsh-zoom-dialog__image-actions nodrag tsh-desktop-no-drag">
-                  {actionButtons}
-                </div>
-              ) : null}
+              <div className="tsh-zoom-dialog__toolbar-actions nodrag tsh-desktop-no-drag">
+                {actionButtons ? (
+                  <div className="tsh-zoom-dialog__image-actions">
+                    {actionButtons}
+                  </div>
+                ) : null}
+                <Button
+                  asChild
+                  className="tsh-zoom-dialog__icon-button nodrag tsh-desktop-no-drag"
+                  size="icon"
+                  variant="chrome"
+                >
+                  <button
+                    type="button"
+                    aria-label={t("common.minimizeImage")}
+                    data-rmiz-btn-unzoom=""
+                    onClick={closePreviewImage}
+                  >
+                    <RestoreIcon aria-hidden="true" className="size-4" />
+                  </button>
+                </Button>
+              </div>
               {contextMenuPosition?.inZoomDialog && actionButtons ? (
                 <div
                   className="tsh-image-context-menu nodrag tsh-desktop-no-drag"
@@ -403,21 +420,6 @@ export function ZoomableImage({
                   }}
                 />
               ) : null}
-              <Button
-                asChild
-                className="tsh-zoom-dialog__icon-button nodrag tsh-desktop-no-drag"
-                size="icon"
-                variant="chrome"
-              >
-                <button
-                  type="button"
-                  aria-label={t("common.minimizeImage")}
-                  data-rmiz-btn-unzoom=""
-                  onClick={closePreviewImage}
-                >
-                  <RestoreIcon aria-hidden="true" className="size-4" />
-                </button>
-              </Button>
             </div>,
             document.body
           )

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -1058,21 +1058,19 @@ describe("AgentMessageMarkdown", () => {
       ".tsh-zoom-dialog__toolbar-actions"
     );
     expect(toolbarActions).toBeInstanceOf(HTMLElement);
-    expect(
-      screen
-        .getByRole("button", { name: "Copy image" })
-        .closest(".tsh-zoom-dialog__toolbar-actions")
-    ).toBe(toolbarActions);
-    expect(
-      screen
-        .getByRole("button", { name: "Download image" })
-        .closest(".tsh-zoom-dialog__toolbar-actions")
-    ).toBe(toolbarActions);
-    expect(
-      screen
-        .getByRole("button", { name: /Minimize image/ })
-        .closest(".tsh-zoom-dialog__toolbar-actions")
-    ).toBe(toolbarActions);
+    const previewActionButtons = [
+      screen.getByRole("button", { name: "Copy image" }),
+      screen.getByRole("button", { name: "Download image" }),
+      screen.getByRole("button", { name: /Minimize image/ })
+    ];
+    expect(Array.from(toolbarActions?.children ?? [])).toEqual(
+      previewActionButtons
+    );
+    for (const button of previewActionButtons) {
+      expect(button).toHaveAttribute("data-size", "icon");
+      expect(button).toHaveAttribute("data-variant", "chrome");
+    }
+    expect(previewActionButtons[2]).not.toHaveAttribute("data-rmiz-btn-unzoom");
     fireEvent.click(screen.getByRole("button", { name: "Copy image" }));
     await waitFor(() => {
       expect(screen.getByRole("status")).toHaveTextContent("Copied");

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -1054,6 +1054,25 @@ describe("AgentMessageMarkdown", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Zoom image/ }));
     const dialog = await screen.findByRole("dialog");
+    const toolbarActions = dialog.querySelector(
+      ".tsh-zoom-dialog__toolbar-actions"
+    );
+    expect(toolbarActions).toBeInstanceOf(HTMLElement);
+    expect(
+      screen
+        .getByRole("button", { name: "Copy image" })
+        .closest(".tsh-zoom-dialog__toolbar-actions")
+    ).toBe(toolbarActions);
+    expect(
+      screen
+        .getByRole("button", { name: "Download image" })
+        .closest(".tsh-zoom-dialog__toolbar-actions")
+    ).toBe(toolbarActions);
+    expect(
+      screen
+        .getByRole("button", { name: /Minimize image/ })
+        .closest(".tsh-zoom-dialog__toolbar-actions")
+    ).toBe(toolbarActions);
     fireEvent.click(screen.getByRole("button", { name: "Copy image" }));
     await waitFor(() => {
       expect(screen.getByRole("status")).toHaveTextContent("Copied");

--- a/packages/agent/gui/shared/agentConversation/components/AgentAskUserPromptSurface.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentAskUserPromptSurface.tsx
@@ -105,14 +105,16 @@ function CompactQuickAnswerSurface({
                 })
               }
             >
-              <span className={styles.interactiveOptionTitle}>
-                {option.label}
-              </span>
-              {option.description ? (
-                <span className={styles.interactiveOptionDescription}>
-                  {option.description}
+              <span className={styles.interactiveOptionContent}>
+                <span className={styles.interactiveOptionTitle}>
+                  {option.label}
                 </span>
-              ) : null}
+                {option.description ? (
+                  <span className={styles.interactiveOptionDescription}>
+                    {option.description}
+                  </span>
+                ) : null}
+              </span>
             </button>
           ))}
         </div>
@@ -188,14 +190,16 @@ function AskUserAnswerFlowSurface({
                   disabled={isSubmitting}
                   onClick={() => flow.toggleOption(option.label)}
                 >
-                  <span className={styles.interactiveOptionTitle}>
-                    {option.label}
-                  </span>
-                  {option.description ? (
-                    <span className={styles.interactiveOptionDescription}>
-                      {option.description}
+                  <span className={styles.interactiveOptionContent}>
+                    <span className={styles.interactiveOptionTitle}>
+                      {option.label}
                     </span>
-                  ) : null}
+                    {option.description ? (
+                      <span className={styles.interactiveOptionDescription}>
+                        {option.description}
+                      </span>
+                    ) : null}
+                  </span>
                 </button>
               );
             })}

--- a/packages/agent/gui/shared/agentConversation/components/AgentInteractiveDecisionPromptSurfaces.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentInteractiveDecisionPromptSurfaces.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ShortcutBadge } from "@tutti-os/ui-system";
+import { Button, ShortcutBadge } from "@tutti-os/ui-system";
 import {
   getOptionalAgentHostApi,
   useOptionalAgentHostApi
@@ -277,21 +277,23 @@ export function ApprovalPromptSurface({
                 disabled={isSubmitting || submittingOptionId !== null}
                 onClick={() => submitOption(option.id)}
               >
-                <span className={styles.interactiveOptionTitle}>
-                  {optionPresentation.label}
-                </span>
-                {optionPresentation.commandPrefix ? (
-                  <CommandTextWithTooltip
-                    value={optionPresentation.commandPrefix}
-                    testId="agent-interactive-command-prefix-option"
-                    tooltipsEnabled
-                  />
-                ) : null}
-                {option.description ? (
-                  <span className={styles.interactiveOptionDescription}>
-                    {option.description}
+                <span className={styles.interactiveOptionContent}>
+                  <span className={styles.interactiveOptionTitle}>
+                    {optionPresentation.label}
                   </span>
-                ) : null}
+                  {optionPresentation.commandPrefix ? (
+                    <CommandTextWithTooltip
+                      value={optionPresentation.commandPrefix}
+                      testId="agent-interactive-command-prefix-option"
+                      tooltipsEnabled
+                    />
+                  ) : null}
+                  {option.description ? (
+                    <span className={styles.interactiveOptionDescription}>
+                      {option.description}
+                    </span>
+                  ) : null}
+                </span>
                 {keyboardShortcuts && shortcutLabel && !showSpinner ? (
                   <ShortcutBadge
                     className={styles.interactiveOptionShortcut}
@@ -388,11 +390,13 @@ export function ExitPlanPromptSurface({
                   });
                 }}
               >
-                <span className={styles.interactiveOptionTitle}>
-                  {mode.label}
-                </span>
-                <span className={styles.interactiveOptionDescription}>
-                  {mode.description}
+                <span className={styles.interactiveOptionContent}>
+                  <span className={styles.interactiveOptionTitle}>
+                    {mode.label}
+                  </span>
+                  <span className={styles.interactiveOptionDescription}>
+                    {mode.description}
+                  </span>
                 </span>
                 {showSpinner ? <InteractiveOptionSpinner /> : null}
               </button>
@@ -409,8 +413,10 @@ export function ExitPlanPromptSurface({
               onChange={(event) => setFeedback(event.currentTarget.value)}
             />
             <div className={styles.interactivePromptActions}>
-              <button
+              <Button
                 type="button"
+                variant="secondary"
+                size="sm"
                 disabled={isSubmitting}
                 onClick={() =>
                   onSubmit({
@@ -428,7 +434,7 @@ export function ExitPlanPromptSurface({
                 }
               >
                 {continueLabel}
-              </button>
+              </Button>
             </div>
           </div>
         ) : (
@@ -436,8 +442,10 @@ export function ExitPlanPromptSurface({
           // must still let the user keep planning (refining/feedback is deferred
           // to the conversation via the card's "open conversation" jump).
           <div className={styles.interactivePromptActions}>
-            <button
+            <Button
               type="button"
+              variant="secondary"
+              size="sm"
               disabled={isSubmitting}
               onClick={() =>
                 onSubmit({
@@ -450,7 +458,7 @@ export function ExitPlanPromptSurface({
               }
             >
               {labels.stayInPlan}
-            </button>
+            </Button>
           </div>
         )}
       </div>
@@ -504,8 +512,10 @@ export function PlanImplementationSurface({
               })
             }
           >
-            <span className={styles.interactiveOptionTitle}>
-              {labels.planImplementationConfirm}
+            <span className={styles.interactiveOptionContent}>
+              <span className={styles.interactiveOptionTitle}>
+                {labels.planImplementationConfirm}
+              </span>
             </span>
           </button>
         </div>
@@ -520,8 +530,10 @@ export function PlanImplementationSurface({
               onChange={(event) => setFeedback(event.currentTarget.value)}
             />
             <div className={styles.interactivePromptActions}>
-              <button
+              <Button
                 type="button"
+                variant="secondary"
+                size="sm"
                 data-testid="agent-plan-implementation-continue"
                 disabled={isSubmitting}
                 onClick={() =>
@@ -536,7 +548,7 @@ export function PlanImplementationSurface({
                 }
               >
                 {continueLabel}
-              </button>
+              </Button>
             </div>
           </div>
         ) : null}


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Verification

<!-- Commands run, manual checks, or why verification is not applicable. -->

## Fallback Three Questions

<!--
Required when this change adds a timer, retry, cache, or defensive branch;
delete otherwise.

- Source: which event or state does this fallback compensate for?
- Why can it not be fixed at that source?
- Removal condition: when can this fallback be deleted?
-->

## Checklist

- [ ] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [ ] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [ ] I ran the lowest meaningful local checks for the changed surface.
- [ ] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->