### PR TITLE
fix(agent): bound live terminal fences

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -862,6 +862,14 @@ discontinuity carrying reconcile keys, and the caller falls back to canonical
 data. This avoids maintaining a second chunk assembly protocol while ensuring
 that the final oversized event is not silently lost.
 
+The publisher also keeps a bounded FIFO of the most recent settled Turn ids.
+Those fences convert late text or tool deltas into scoped discontinuities
+without allowing a long-lived stream to accumulate one permanent map entry per
+historical Turn. The retention bound is independent of canonical history:
+evicted Turns remain durable, and the activity-core overlay independently
+rejects a nonterminal delta against known terminal message truth so any later
+uncertainty still converges through authoritative reconciliation.
+
 A host materializes accepted deltas in the activity-core optimistic overlay and
 projects that overlay over its latest canonical message base. The Tutti desktop
 receives local deltas through the business-event WebSocket; shared-device hosts

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -65,8 +65,9 @@ Realtime events reduce latency but are not automatically complete truth:
   `/v1/events/ws` business-event WebSocket
 - continuous, version-complete `message_update` events may merge inline
 - terminal `message_update` is the durable confirmation; message version gaps,
-  invalid/unanchored deltas, reconnects, Turn, Interaction, and state changes
-  trigger authoritative reconciliation
+  invalid/unanchored deltas, nonterminal deltas after known terminal message
+  truth, reconnects, Turn, Interaction, and state changes trigger authoritative
+  reconciliation
 - event publication or observer failure cannot roll back a committed canonical transaction
 
 ### 1.6 Identity and correlation are explicit

--- a/packages/agent/activity-core/src/optimisticMessageOverlay.test.ts
+++ b/packages/agent/activity-core/src/optimisticMessageOverlay.test.ts
@@ -183,6 +183,50 @@ test("keeps an explicitly terminal optimistic projection until canonical becomes
   assert.equal(canonicalTerminal[0]?.payload.text, "canonical final");
 });
 
+test("rejects a nonterminal delta after canonical terminal truth", () => {
+  const overlay = createAgentActivityOptimisticMessageOverlay();
+  const terminal = canonical({
+    status: "completed",
+    completedAtUnixMs: 30,
+    payload: { text: "final", content: "final" }
+  });
+  overlay.reconcile(scope, [terminal]);
+
+  assert.deepEqual(
+    overlay.apply(delta({ operation: "append_text", text: " late" })),
+    {
+      applied: false,
+      needsReconcile: true,
+      reason: "late_after_terminal"
+    }
+  );
+  assert.equal(overlay.project(scope, [terminal])[0]?.payload.text, "final");
+});
+
+test("allows a terminal set to correct an earlier terminal projection", () => {
+  const overlay = createAgentActivityOptimisticMessageOverlay();
+  const terminal = canonical({
+    status: "completed",
+    completedAtUnixMs: 30,
+    payload: { text: "first final", content: "first final" }
+  });
+  overlay.reconcile(scope, [terminal]);
+
+  assert.deepEqual(
+    overlay.apply(
+      delta({ operation: "set", value: "corrected final" }, "completed")
+    ),
+    {
+      applied: true,
+      needsReconcile: false
+    }
+  );
+  assert.equal(
+    overlay.project(scope, [terminal])[0]?.payload.text,
+    "corrected final"
+  );
+});
+
 test("normalizes missing canonical workspace identity without duplicate messages or a false missing anchor", () => {
   const overlay = createAgentActivityOptimisticMessageOverlay();
   const withoutWorkspace = canonical({

--- a/packages/agent/activity-core/src/optimisticMessageOverlay.ts
+++ b/packages/agent/activity-core/src/optimisticMessageOverlay.ts
@@ -18,6 +18,7 @@ export interface AgentActivityOptimisticApplyResult {
   reason?:
     | "append_without_anchor"
     | "identity_mismatch"
+    | "late_after_terminal"
     | "tool_output_offset_mismatch";
 }
 
@@ -140,6 +141,17 @@ export function createAgentActivityOptimisticMessageOverlay(): AgentActivityOpti
     const key = liveMessageKey(event);
     const existing =
       optimistic.get(key)?.message ?? canonical.get(key) ?? undefined;
+    if (
+      existing &&
+      isTerminalMessage(existing) &&
+      !deltaIsExplicitlyTerminal(data)
+    ) {
+      return {
+        applied: false,
+        needsReconcile: true,
+        reason: "late_after_terminal"
+      };
+    }
     if (data.content?.operation === "append_text" && !existing) {
       return {
         applied: false,

--- a/packages/agent/daemon/liveprotocol/publisher.go
+++ b/packages/agent/daemon/liveprotocol/publisher.go
@@ -15,6 +15,8 @@ type replayEntry struct {
 	at       time.Time
 }
 
+const settledTurnRetention = 256
+
 type Publisher struct {
 	mu sync.Mutex
 
@@ -27,6 +29,7 @@ type Publisher struct {
 	replay              []replayEntry
 	replayBytes         int
 	settledTurns        map[string]struct{}
+	settledTurnOrder    []string
 }
 
 func NewPublisher(config PublisherConfig) (*Publisher, error) {
@@ -112,9 +115,23 @@ func (p *Publisher) Publish(input PublishInput) ([]Frame, error) {
 	}
 	frames, err := p.flushLocked()
 	if err == nil && terminal && turnID != "" {
-		p.settledTurns[turnID] = struct{}{}
+		p.recordSettledTurnLocked(turnID)
 	}
 	return frames, err
+}
+
+func (p *Publisher) recordSettledTurnLocked(turnID string) {
+	if _, exists := p.settledTurns[turnID]; exists {
+		return
+	}
+	if len(p.settledTurnOrder) == settledTurnRetention {
+		delete(p.settledTurns, p.settledTurnOrder[0])
+		copy(p.settledTurnOrder, p.settledTurnOrder[1:])
+		p.settledTurnOrder[len(p.settledTurnOrder)-1] = turnID
+	} else {
+		p.settledTurnOrder = append(p.settledTurnOrder, turnID)
+	}
+	p.settledTurns[turnID] = struct{}{}
 }
 
 func liveEventTurnFence(event *Event) (turnID string, terminal, rejectAfterTerminal bool) {

--- a/packages/agent/daemon/liveprotocol/publisher_regression_test.go
+++ b/packages/agent/daemon/liveprotocol/publisher_regression_test.go
@@ -3,6 +3,7 @@ package liveprotocol
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -353,5 +354,59 @@ func TestPublisherAllowsCommittedInteractionAndDuplicateTerminalAfterFence(t *te
 		lateFrames[0].Deliveries[0].Kind != DeliveryKindDiscontinuity ||
 		lateFrames[0].Deliveries[0].Discontinuity.Reason != "late_after_terminal" {
 		t.Fatalf("late message was not fenced: %#v", lateFrames)
+	}
+}
+
+func TestPublisherBoundsSettledTurnFences(t *testing.T) {
+	t.Parallel()
+
+	publisher, err := NewPublisher(PublisherConfig{
+		StreamID: "stream-1", BindingID: "binding-1", Epoch: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index < settledTurnRetention+1; index++ {
+		turnID := fmt.Sprintf("turn-%d", index)
+		outcome := "completed"
+		settledAt := int64(index + 1)
+		event, eventErr := NewTurnUpdateEvent(TurnUpdateData{
+			WorkspaceID:      "owner-workspace",
+			AgentSessionID:   "owner-session",
+			EventType:        EventTypeTurnUpdate,
+			OccurredAtUnixMS: int64(index + 1),
+			Turn: EventTurn{
+				TurnID:          turnID,
+				AgentSessionID:  "owner-session",
+				Phase:           "settled",
+				Origin:          "user_prompt",
+				Outcome:         &outcome,
+				StartedAtUnixMS: 1,
+				UpdatedAtUnixMS: int64(index + 1),
+				SettledAtUnixMS: &settledAt,
+				FileChanges:     json.RawMessage(`null`),
+			},
+		})
+		if eventErr != nil {
+			t.Fatal(eventErr)
+		}
+		if _, eventErr = publisher.Publish(PublishInput{Event: &event}); eventErr != nil {
+			t.Fatal(eventErr)
+		}
+	}
+	if len(publisher.settledTurns) != settledTurnRetention ||
+		len(publisher.settledTurnOrder) != settledTurnRetention {
+		t.Fatalf(
+			"settled fences = map:%d order:%d, want %d",
+			len(publisher.settledTurns),
+			len(publisher.settledTurnOrder),
+			settledTurnRetention,
+		)
+	}
+	if _, retained := publisher.settledTurns["turn-0"]; retained {
+		t.Fatal("oldest settled turn fence was not evicted")
+	}
+	if _, retained := publisher.settledTurns[fmt.Sprintf("turn-%d", settledTurnRetention)]; !retained {
+		t.Fatal("newest settled turn fence was not retained")
 	}
 }


### PR DESCRIPTION
## What changed

- bound each liveprotocol publisher to the 256 most recent exact settled-Turn fences
- keep the terminal fence FIFO and lookup map synchronized without growing backing storage
- reject nonterminal optimistic deltas against already-known terminal message truth and request canonical reconciliation
- retain terminal correction sets after a terminal projection
- update the Agent activity and AgentGUI architecture documentation

## Why

The liveprotocol publisher retained every settled Turn id for its full process lifetime. A long-lived owner stream could therefore grow memory indefinitely. Simply evicting old ids would weaken correctness because an extremely late delta could pass the transport fence; the activity-core guard closes that gap by failing closed and reconciling whenever canonical or optimistic message truth is already terminal.

## Risk / impact

No wire schema, protocol revision, persistence, or canonical history format changes. The bounded transport fence optimizes memory; authoritative reconciliation remains the correctness path for late or uncertain events.

After merge, this change needs a normal Tutti release cohort and a coordinated TSH dependency upgrade.

## Verification

- `pnpm check:changed` (14 selected lanes)
- pre-push `pnpm check:changed -- --push-ready` (16 selected lanes)
- `go test ./packages/agent/daemon/liveprotocol`
- activity-core optimistic overlay tests and typecheck selected by changed-aware validation
