### PR TITLE
feat(desktop): upgrade Electron to 43

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -328,6 +328,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Electron runtime
+        run: pnpm --filter @tutti-os/desktop exec install-electron
+
       - name: Align package version with release tag
         working-directory: apps/desktop
         run: node scripts/apply-ci-release-version.mjs "${TUTTI_DESKTOP_RELEASE_TAG}"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -52,6 +52,7 @@
         "dmg",
         "zip"
       ],
+      "minimumSystemVersion": "12.0.0",
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.inherit.plist",
       "hardenedRuntime": true,
@@ -132,7 +133,7 @@
     "@tutti-os/rrt-plugin-vite": "0.0.6",
     "babel-plugin-react-compiler": "^1.0.0",
     "dmg-builder": "^26.8.1",
-    "electron": "^35.7.5",
+    "electron": "^43.2.0",
     "electron-builder": "^26.8.1",
     "electron-builder-squirrel-windows": "^26.8.1",
     "electron-vite": "^3.1.0",

--- a/apps/desktop/src/main/bootstrap.ts
+++ b/apps/desktop/src/main/bootstrap.ts
@@ -41,6 +41,7 @@ import { registerTuttiAssetProtocol } from "./host/tuttiAssetProtocol.ts";
 import { desktopCustomProtocolSchemes } from "./host/desktopCustomProtocolSchemes.ts";
 import { createWorkspaceFileIconCacheStore } from "./host/workspaceFileIconCacheStore.ts";
 import { registerWorkspaceFileIconProtocol } from "./host/workspaceFileIconProtocol.ts";
+import { applyDesktopElectronPlatformCompatibility } from "./electronPlatformCompatibility.ts";
 
 function envFlagEnabled(value: string | undefined): boolean {
   return /^(1|true|yes|on)$/iu.test(value?.trim() ?? "");
@@ -74,6 +75,7 @@ function focusPrimaryDesktopWindow(): void {
 }
 
 export async function bootstrapDesktopApp(): Promise<void> {
+  applyDesktopElectronPlatformCompatibility(app.commandLine);
   applyElectronDiagnosticSwitches();
   initializeDesktopEnvironment({
     appVersion: app.getVersion(),

--- a/apps/desktop/src/main/desktopHostServices.ts
+++ b/apps/desktop/src/main/desktopHostServices.ts
@@ -1,4 +1,5 @@
 import type { DesktopLocale } from "../shared/i18n";
+import { app } from "electron";
 import {
   createDesktopHostPreferencesState,
   type DesktopHostPreferencesState
@@ -50,6 +51,7 @@ export async function createDesktopHostServices(
     tuttidClient: options.tuttidClient
   });
   const fileDialogs = createDesktopFileDialogAccess({
+    getDefaultPath: (name) => app.getPath(name),
     getLocale: () => preferences.getLocale()
   });
   const workspaceLaunch = createWorkspaceLaunch({

--- a/apps/desktop/src/main/electronPlatformCompatibility.test.ts
+++ b/apps/desktop/src/main/electronPlatformCompatibility.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { applyDesktopElectronPlatformCompatibility } from "./electronPlatformCompatibility.ts";
+
+test("desktop Electron compatibility keeps Linux on X11", () => {
+  const switches: Array<[string, string | undefined]> = [];
+
+  applyDesktopElectronPlatformCompatibility(
+    {
+      appendSwitch(name, value) {
+        switches.push([name, value]);
+      }
+    },
+    "linux"
+  );
+
+  assert.deepEqual(switches, [["ozone-platform", "x11"]]);
+});
+
+test("desktop Electron compatibility leaves non-Linux platforms unchanged", () => {
+  const switches: Array<[string, string | undefined]> = [];
+
+  applyDesktopElectronPlatformCompatibility(
+    {
+      appendSwitch(name, value) {
+        switches.push([name, value]);
+      }
+    },
+    "darwin"
+  );
+
+  assert.deepEqual(switches, []);
+});

--- a/apps/desktop/src/main/electronPlatformCompatibility.ts
+++ b/apps/desktop/src/main/electronPlatformCompatibility.ts
@@ -1,0 +1,17 @@
+export interface DesktopElectronCommandLine {
+  appendSwitch(name: string, value?: string): void;
+}
+
+/**
+ * Keep the current desktop window contract while Electron's native Wayland
+ * path cannot provide global bounds, deterministic positioning, or
+ * programmatic content resizing.
+ */
+export function applyDesktopElectronPlatformCompatibility(
+  commandLine: DesktopElectronCommandLine,
+  platform: NodeJS.Platform = process.platform
+): void {
+  if (platform === "linux") {
+    commandLine.appendSwitch("ozone-platform", "x11");
+  }
+}

--- a/apps/desktop/src/main/host/desktopFileDialogAccess.test.ts
+++ b/apps/desktop/src/main/host/desktopFileDialogAccess.test.ts
@@ -155,3 +155,65 @@ test("desktop file dialog access can disable directory upload selection", async 
     properties: ["openFile", "multiSelections"]
   });
 });
+
+test("desktop file dialog access uses product-aligned initial directories", async () => {
+  const calls: Parameters<
+    NonNullable<DesktopFileDialogAccessDependencies["showOpenDialog"]>
+  >[] = [];
+  const dialogAccess = createDesktopFileDialogAccess({
+    getDefaultPath: (name) =>
+      name === "documents" ? "/Users/demo/Documents" : "/Users/demo/Downloads",
+    getLocale: () => "en",
+    showOpenDialog: async (...args) => {
+      calls.push(args);
+      return {
+        canceled: true,
+        filePaths: []
+      };
+    }
+  });
+
+  await dialogAccess.selectDirectory();
+  await dialogAccess.selectAppArchive();
+  await dialogAccess.selectAppIconImage();
+  await dialogAccess.selectUploadFiles();
+
+  assert.equal(calls[0]?.[1].defaultPath, "/Users/demo/Documents");
+  assert.equal(calls[1]?.[1].defaultPath, "/Users/demo/Downloads");
+  assert.equal(calls[2]?.[1].defaultPath, "/Users/demo/Downloads");
+  assert.equal(calls[3]?.[1].defaultPath, "/Users/demo/Downloads");
+});
+
+test("desktop file dialog access remembers successful selections for the process lifetime", async () => {
+  const calls: Parameters<
+    NonNullable<DesktopFileDialogAccessDependencies["showOpenDialog"]>
+  >[] = [];
+  const selections = [
+    ["/Users/demo/Projects/tutti"],
+    ["/Users/demo/Projects/next"],
+    ["/Users/demo/Imports/app.zip"],
+    ["/Users/demo/Imports/icon.png"]
+  ];
+  const dialogAccess = createDesktopFileDialogAccess({
+    getDefaultPath: (name) =>
+      name === "documents" ? "/Users/demo/Documents" : "/Users/demo/Downloads",
+    getLocale: () => "en",
+    showOpenDialog: async (...args) => {
+      calls.push(args);
+      return {
+        canceled: false,
+        filePaths: selections.shift() ?? []
+      };
+    }
+  });
+
+  await dialogAccess.selectDirectory();
+  await dialogAccess.selectDirectory();
+  await dialogAccess.selectAppArchive();
+  await dialogAccess.selectAppIconImage();
+
+  assert.equal(calls[0]?.[1].defaultPath, "/Users/demo/Documents");
+  assert.equal(calls[1]?.[1].defaultPath, "/Users/demo/Projects/tutti");
+  assert.equal(calls[2]?.[1].defaultPath, "/Users/demo/Downloads");
+  assert.equal(calls[3]?.[1].defaultPath, "/Users/demo/Imports");
+});

--- a/apps/desktop/src/main/host/desktopFileDialogAccess.ts
+++ b/apps/desktop/src/main/host/desktopFileDialogAccess.ts
@@ -5,6 +5,7 @@ import type {
   SaveDialogOptions,
   SaveDialogReturnValue
 } from "electron";
+import { dirname } from "node:path";
 import {
   createTranslator,
   type DesktopLocale
@@ -31,6 +32,7 @@ export interface DesktopSelectUploadFilesInput {
 }
 
 export interface DesktopFileDialogAccessDependencies {
+  getDefaultPath?: (name: "documents" | "downloads") => string;
   getLocale: () => DesktopLocale;
   showOpenDialog?: ShowOpenDialog;
   showSaveDialog?: ShowSaveDialog;
@@ -51,11 +53,14 @@ export function createDesktopFileDialogAccess(
 ): DesktopFileDialogAccess {
   const showOpenDialog = deps.showOpenDialog ?? defaultShowOpenDialog;
   const showSaveDialog = deps.showSaveDialog ?? defaultShowSaveDialog;
+  let lastImportDirectory = deps.getDefaultPath?.("downloads");
+  let lastProjectDirectory = deps.getDefaultPath?.("documents");
 
   return {
     async selectAppArchive(ownerWindow) {
       const translator = createTranslator(deps.getLocale());
       const selection = await showOpenDialog(ownerWindow, {
+        ...defaultPathOption(lastImportDirectory),
         filters: [
           {
             extensions: ["zip"],
@@ -69,7 +74,11 @@ export function createDesktopFileDialogAccess(
         return null;
       }
 
-      return selection.filePaths[0] ?? null;
+      const selectedPath = selection.filePaths[0] ?? null;
+      lastImportDirectory = selectedPath
+        ? dirname(selectedPath)
+        : lastImportDirectory;
+      return selectedPath;
     },
 
     async selectAppArchiveExportPath(defaultPath, ownerWindow) {
@@ -88,11 +97,13 @@ export function createDesktopFileDialogAccess(
         return null;
       }
 
+      lastImportDirectory = dirname(selection.filePath);
       return selection.filePath;
     },
 
     async selectAppIconImage(ownerWindow) {
       const selection = await showOpenDialog(ownerWindow, {
+        ...defaultPathOption(lastImportDirectory),
         filters: [
           { extensions: ["png", "jpg", "jpeg", "webp"], name: "Image" }
         ],
@@ -103,7 +114,11 @@ export function createDesktopFileDialogAccess(
         return null;
       }
 
-      return selection.filePaths[0] ?? null;
+      const selectedPath = selection.filePaths[0] ?? null;
+      lastImportDirectory = selectedPath
+        ? dirname(selectedPath)
+        : lastImportDirectory;
+      return selectedPath;
     },
 
     async selectDirectory(ownerWindow) {
@@ -111,6 +126,7 @@ export function createDesktopFileDialogAccess(
       const selectDirectoryLabel = translator.t("common.selectFolder");
       const selection = await showOpenDialog(ownerWindow, {
         buttonLabel: selectDirectoryLabel,
+        ...defaultPathOption(lastProjectDirectory),
         properties: ["openDirectory"],
         title: selectDirectoryLabel
       });
@@ -119,7 +135,9 @@ export function createDesktopFileDialogAccess(
         return null;
       }
 
-      return selection.filePaths[0] ?? null;
+      const selectedPath = selection.filePaths[0] ?? null;
+      lastProjectDirectory = selectedPath ?? lastProjectDirectory;
+      return selectedPath;
     },
 
     async selectUploadFiles(ownerWindow, input) {
@@ -131,6 +149,7 @@ export function createDesktopFileDialogAccess(
         properties.splice(1, 0, "openDirectory");
       }
       const selection = await showOpenDialog(ownerWindow, {
+        ...defaultPathOption(lastImportDirectory),
         properties
       });
 
@@ -138,9 +157,16 @@ export function createDesktopFileDialogAccess(
         return [];
       }
 
+      lastImportDirectory = dirname(selection.filePaths[0]!);
       return selection.filePaths;
     }
   };
+}
+
+function defaultPathOption(
+  defaultPath: string | undefined
+): Pick<OpenDialogOptions, "defaultPath"> | Record<never, never> {
+  return defaultPath ? { defaultPath } : {};
 }
 
 async function defaultShowOpenDialog(

--- a/apps/desktop/src/main/ipc/browser.ts
+++ b/apps/desktop/src/main/ipc/browser.ts
@@ -11,7 +11,7 @@ import {
 } from "electron";
 import { randomUUID } from "node:crypto";
 import { readFile, stat, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveBrowserSessionPartition } from "@tutti-os/browser-node";
 import { createMacosChromeCookieImportAdapter } from "@tutti-os/browser-node/chrome-cookie-import/macos";
@@ -118,6 +118,8 @@ export async function registerBrowserIpc(
     selectTarget: automationCoordinator.selectTarget
   });
   const preparedDownloadSessions = new WeakSet<Electron.Session>();
+  let lastBrowserDownloadDirectory = app.getPath("downloads");
+  let lastCookieImportDirectory = app.getPath("downloads");
   const chromeCookieImport = createMacosChromeCookieImportAdapter({
     isEnabled: () =>
       isFeatureEnabled(
@@ -141,9 +143,15 @@ export async function registerBrowserIpc(
     },
     async chooseDownloadDirectory(ownerWindow) {
       const result = await dialog.showOpenDialog(ownerWindow, {
+        defaultPath: lastBrowserDownloadDirectory,
         properties: ["openDirectory", "createDirectory"]
       });
-      return result.canceled ? null : (result.filePaths[0] ?? null);
+      const selectedPath = result.canceled
+        ? null
+        : (result.filePaths[0] ?? null);
+      lastBrowserDownloadDirectory =
+        selectedPath ?? lastBrowserDownloadDirectory;
+      return selectedPath;
     },
     getOwnerWindow(event) {
       return resolveOwnerWindowFromEvent(event as Electron.IpcMainInvokeEvent);
@@ -170,10 +178,14 @@ export async function registerBrowserIpc(
             : translator.t("browser.chromeImportNotification.completed", {
                 imported: result.imported
               });
-      new Notification({
+      const notification = new Notification({
         body,
         title: translator.t("browser.chromeImportNotification.title")
-      }).show();
+      });
+      notification.on("failed", (_event, error) => {
+        logger.warn("browser Chrome import notification failed", { error });
+      });
+      notification.show();
     },
     openDownloadedFile: async (path) => {
       const error = await shell.openPath(path);
@@ -242,12 +254,14 @@ export async function registerBrowserIpc(
     },
     async selectCookieImport(ownerWindow) {
       const result = await dialog.showOpenDialog(ownerWindow, {
+        defaultPath: lastCookieImportDirectory,
         properties: ["openFile"]
       });
       const filePath = result.canceled ? null : (result.filePaths[0] ?? null);
       if (!filePath) {
         return null;
       }
+      lastCookieImportDirectory = dirname(filePath);
       const metadata = await stat(filePath);
       if (!metadata.isFile() || metadata.size > maximumCookieImportBytes) {
         throw new Error("Browser Cookie import file is invalid or too large");

--- a/apps/desktop/src/main/windows/workspaceWindow.ts
+++ b/apps/desktop/src/main/windows/workspaceWindow.ts
@@ -127,6 +127,9 @@ export function createWorkspaceWindow(
   const workspaceWindow = new BrowserWindow({
     backgroundColor: resolveDesktopWindowBackgroundColor(),
     frame: windowKind === "agent" ? false : undefined,
+    ...(process.platform === "linux" && windowKind === "agent"
+      ? { roundedCorners: false }
+      : {}),
     // The agent window's green control is a native fullscreen toggle, and its
     // frameless chrome draws custom traffic lights. Disabling native zoom stops
     // macOS double-click-title-bar from zooming into an ambiguous "maximized"

--- a/docs/architecture/desktop-windows.md
+++ b/docs/architecture/desktop-windows.md
@@ -18,6 +18,20 @@ The window model is intentionally simple:
 - keep Agent-only windows tied to the same workspace, preload, renderer
   bundle, daemon session, and persisted account state as the workspace window
 
+On Linux, the desktop currently requests X11/Xwayland explicitly. The
+Agent-only window contract depends on global source-window bounds,
+deterministic duplicate-window positioning, and programmatic content-width
+resizing, which native Wayland does not expose. Native Wayland must not be
+enabled until those interactions have a Wayland-specific product contract and
+fallback behavior. Agent-only windows also keep square native corners on Linux
+so Electron upgrades do not silently change the established frameless shell.
+
+Native file dialogs use product-semantic starting locations. Project
+directories start in Documents, while archive import/export, icon upload,
+browser downloads, and cookie import start in Downloads. A successful choice
+updates the matching starting directory for the remainder of the current app
+process; these locations are not persisted as user preferences.
+
 ## Current Window Types
 
 ### Dashboard Window

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -90,6 +90,11 @@ Use beta for earlier development-branch packaging that should not affect RC vali
 
 Do not introduce nightly-only desktop version suffixes. Use `beta` or `rc` prereleases instead when a build should be published ahead of the next stable release.
 
+The Electron 43 desktop runtime supports macOS 12 and later. Release CI must
+run `pnpm --filter @tutti-os/desktop exec install-electron` after the frozen
+workspace install so packaging never relies on Electron's lazy runtime
+download.
+
 ## Artifacts
 
 Packaging is driven by:

--- a/packages/browser/workbench-node/package.json
+++ b/packages/browser/workbench-node/package.json
@@ -47,13 +47,13 @@
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",
     "@types/ws": "^8.18.1",
-    "electron": "^35.7.5",
+    "electron": "^43.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "typescript": "^5.8.3"
   },
   "peerDependencies": {
-    "electron": "^35.7.5",
+    "electron": ">=35.7.5 <44",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,8 +169,8 @@ importers:
         specifier: ^26.8.1
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
       electron:
-        specifier: ^35.7.5
-        version: 35.7.5
+        specifier: ^43.2.0
+        version: 43.2.0
       electron-builder:
         specifier: ^26.8.1
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
@@ -586,8 +586,8 @@ importers:
         specifier: ^8.18.1
         version: 8.18.1
       electron:
-        specifier: ^35.7.5
-        version: 35.7.5
+        specifier: ^43.2.0
+        version: 43.2.0
       react:
         specifier: ^19.1.0
         version: 19.2.6
@@ -2820,6 +2820,13 @@ packages:
         integrity: sha512-VYJy0uhFm9zTJ1TxBaW/pA8bjbOM/OttaNMwZ1RHG4JKyRG7DhSdiqD1ipQoAyoD22olUtxbP78W9xY3Wd11bg==
       }
 
+  "@electron-internal/extract-zip@1.0.4":
+    resolution:
+      {
+        integrity: sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==
+      }
+    engines: { node: ">=22.12.0" }
+
   "@electron/asar@3.4.1":
     resolution:
       {
@@ -2835,19 +2842,19 @@ packages:
       }
     hasBin: true
 
-  "@electron/get@2.0.3":
-    resolution:
-      {
-        integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==
-      }
-    engines: { node: ">=12" }
-
   "@electron/get@3.1.0":
     resolution:
       {
         integrity: sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==
       }
     engines: { node: ">=14" }
+
+  "@electron/get@5.0.0":
+    resolution:
+      {
+        integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==
+      }
+    engines: { node: ">=22.12.0" }
 
   "@electron/notarize@2.5.0":
     resolution:
@@ -6456,12 +6463,6 @@ packages:
         integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
       }
 
-  "@types/node@22.19.19":
-    resolution:
-      {
-        integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==
-      }
-
   "@types/node@24.12.4":
     resolution:
       {
@@ -6576,12 +6577,6 @@ packages:
     resolution:
       {
         integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==
-      }
-
-  "@types/yauzl@2.10.3":
-    resolution:
-      {
-        integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==
       }
 
   "@types/yazl@3.3.1":
@@ -8634,12 +8629,12 @@ packages:
       }
     engines: { node: ">=8.0.0" }
 
-  electron@35.7.5:
+  electron@43.2.0:
     resolution:
       {
-        integrity: sha512-dnL+JvLraKZl7iusXTVTGYs10TKfzUi30uEDTqsmTm0guN9V2tbOjTzyIZbh9n3ygUjgEYyo+igAwMRXIi3IPw==
+        integrity: sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA==
       }
-    engines: { node: ">= 12.20.55" }
+    engines: { node: ">= 22.12.0" }
     hasBin: true
 
   emittery@0.13.1:
@@ -8708,6 +8703,13 @@ packages:
         integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
       }
     engines: { node: ">=6" }
+
+  env-paths@3.0.0:
+    resolution:
+      {
+        integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
   envinfo@7.21.0:
     resolution:
@@ -9195,14 +9197,6 @@ packages:
       {
         integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==
       }
-
-  extract-zip@2.0.1:
-    resolution:
-      {
-        integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
-      }
-    engines: { node: ">= 10.17.0" }
-    hasBin: true
 
   extsprintf@1.4.1:
     resolution:
@@ -12523,12 +12517,6 @@ packages:
       }
     engines: { node: ">=12", npm: ">=6" }
 
-  pend@1.2.0:
-    resolution:
-      {
-        integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
-      }
-
   perfect-debounce@2.1.0:
     resolution:
       {
@@ -14556,12 +14544,6 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  undici-types@6.21.0:
-    resolution:
-      {
-        integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
-      }
-
   undici-types@7.16.0:
     resolution:
       {
@@ -15269,13 +15251,6 @@ packages:
     resolution:
       {
         integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
-      }
-    engines: { node: ">=12" }
-
-  yauzl@3.4.0:
-    resolution:
-      {
-        integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==
       }
     engines: { node: ">=12" }
 
@@ -16515,6 +16490,8 @@ snapshots:
 
   "@dotenvx/primitives@0.8.0": {}
 
+  "@electron-internal/extract-zip@1.0.4": {}
+
   "@electron/asar@3.4.1":
     dependencies:
       commander: 5.1.0
@@ -16527,7 +16504,7 @@ snapshots:
       fs-extra: 9.1.0
       minimist: 1.2.8
 
-  "@electron/get@2.0.3":
+  "@electron/get@3.1.0":
     dependencies:
       debug: 4.4.3
       env-paths: 2.2.1
@@ -16541,17 +16518,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@electron/get@3.1.0":
+  "@electron/get@5.0.0":
     dependencies:
       debug: 4.4.3
-      env-paths: 2.2.1
-      fs-extra: 8.1.0
-      got: 11.8.6
+      env-paths: 3.0.0
+      graceful-fs: 4.2.11
       progress: 2.0.3
-      semver: 6.3.1
+      semver: 7.8.0
       sumchecker: 3.0.1
     optionalDependencies:
-      global-agent: 3.0.0
+      undici: 7.28.0
     transitivePeerDependencies:
       - supports-color
 
@@ -18990,10 +18966,6 @@ snapshots:
 
   "@types/node@12.20.55": {}
 
-  "@types/node@22.19.19":
-    dependencies:
-      undici-types: 6.21.0
-
   "@types/node@24.12.4":
     dependencies:
       undici-types: 7.16.0
@@ -19058,11 +19030,6 @@ snapshots:
   "@types/yargs@17.0.35":
     dependencies:
       "@types/yargs-parser": 21.0.3
-
-  "@types/yauzl@2.10.3":
-    dependencies:
-      "@types/node": 24.12.4
-    optional: true
 
   "@types/yazl@3.3.1":
     dependencies:
@@ -20409,11 +20376,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@35.7.5:
+  electron@43.2.0:
     dependencies:
-      "@electron/get": 2.0.3
-      "@types/node": 22.19.19
-      extract-zip: 2.0.1
+      "@electron-internal/extract-zip": 1.0.4
+      "@electron/get": 5.0.0
+      "@types/node": 24.12.4
     transitivePeerDependencies:
       - supports-color
 
@@ -20444,6 +20411,8 @@ snapshots:
   entities@8.0.0: {}
 
   env-paths@2.2.1: {}
+
+  env-paths@3.0.0: {}
 
   envinfo@7.21.0: {}
 
@@ -20936,16 +20905,6 @@ snapshots:
   extend@3.0.2: {}
 
   extendable-error@0.1.7: {}
-
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3
-      get-stream: 5.2.0
-      yauzl: 3.4.0
-    optionalDependencies:
-      "@types/yauzl": 2.10.3
-    transitivePeerDependencies:
-      - supports-color
 
   extsprintf@1.4.1:
     optional: true
@@ -23328,8 +23287,6 @@ snapshots:
 
   pe-library@0.4.1: {}
 
-  pend@1.2.0: {}
-
   perfect-debounce@2.1.0: {}
 
   picocolors@1.1.1: {}
@@ -24755,8 +24712,6 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@6.21.0: {}
-
   undici-types@7.16.0: {}
 
   undici@6.25.0: {}
@@ -25193,10 +25148,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yauzl@3.4.0:
-    dependencies:
-      pend: 1.2.0
 
   yazl@3.3.1:
     dependencies:

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -702,6 +702,19 @@ test("desktop package declares the workspace package manager for electron-builde
   assert.equal(packageJson.packageManager, "pnpm@10.11.0");
 });
 
+test("desktop release pins the supported Electron platform contract", async () => {
+  const packageJson = JSON.parse(await readFile(desktopPackagePath, "utf8"));
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.equal(packageJson.devDependencies.electron, "^43.2.0");
+  assert.equal(packageJson.build.mac.minimumSystemVersion, "12.0.0");
+  assert.match(workflow, /name:\s+Install Electron runtime/);
+  assert.match(
+    workflow,
+    /run:\s+pnpm --filter @tutti-os\/desktop exec install-electron/
+  );
+});
+
 test("desktop package verifies channel-specific prerelease updater metadata", async () => {
   const packageJson = JSON.parse(await readFile(desktopPackagePath, "utf8"));
   const workflow = await readFile(workflowPath, "utf8");


### PR DESCRIPTION
## Summary

- upgrade the Tutti desktop runtime and browser-node development types from Electron 35.7.5 to 43.2.0
- preserve the current Linux Agent window product contract by explicitly using X11/Xwayland and disabling new native rounded corners
- make native file-dialog starting locations product-semantic and remember successful selections for the current process
- declare macOS 12 as the minimum supported version and explicitly install the lazy Electron runtime in release CI
- keep the shared browser-node package compatible with Electron 35 through 43 so TSH consumers are not forced to upgrade

## Why

Electron 38+ changes Linux defaults to native Wayland, where Tutti's Agent window cannot rely on global bounds, deterministic duplicate-window positioning, or programmatic resizing. Electron 43 also changes native frameless-window and file-dialog behavior, while Electron 42+ no longer guarantees an eagerly installed runtime binary. Without explicit compatibility policy, a dependency-only upgrade would silently change product behavior and could break release packaging.

## Product impact

- Linux keeps the existing X11/Xwayland window behavior and square Agent-window shell.
- Project selection starts in Documents; archive import/export, icon upload, browser downloads, and cookie import start in Downloads.
- Successful dialog selections are remembered only for the current app process.
- macOS 11 is no longer supported; packaged builds declare macOS 12+.
- Renderer UI and public IPC protocols are unchanged.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/browser-node typecheck`
- desktop test suite with Node test runner
- `pnpm --filter @tutti-os/browser-node test` — 149 passed
- `node --test tools/scripts/desktop-release-config.test.mjs` — 37 passed
- `pnpm check:electron-runtime-boundaries`
- `pnpm lint:ts`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm --filter @tutti-os/desktop build:unpack`
- pre-push `pnpm check:changed -- --push-ready` — 13 lanes passed

The unpacked macOS artifact contains Electron 43.2.0, declares `LSMinimumSystemVersion=12.0.0`, and includes executable `tuttid` and `tutti` binaries.