### PR TITLE
fix(browser-node): trust committed Electron navigation events

### DIFF
--- a/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
@@ -1505,6 +1505,133 @@ test("uses registerGuest URL before loading a newly attached guest", async () =>
   );
 });
 
+test("publishes committed navigation events when Electron getters lag behind loadURL", async () => {
+  const events: BrowserNodeEvent[] = [];
+  const contents = new MockBrowserGuestWebContents(22);
+  contents.currentUrl = "https://example.com/previous";
+  contents.title = "Previous page";
+  const manager = createBrowserGuestManager({
+    emit: (event) => events.push(event),
+    openExternal: () => undefined,
+    resolveWebContents: (id) => (id === contents.id ? contents : null)
+  });
+
+  await manager.registerGuest({
+    nodeId: "browser-lagging-getters",
+    profileId: null,
+    sessionMode: "shared",
+    webContentsId: 22
+  });
+  events.length = 0;
+
+  contents.loadURL = async (url: string): Promise<void> => {
+    contents.loading = true;
+    contents.emit("did-start-loading");
+    contents.emit("did-navigate", {}, url, 200, "OK");
+    contents.emit("page-title-updated", {}, "Committed page", true);
+    contents.loading = false;
+    contents.emit("did-stop-loading");
+  };
+
+  await manager.navigate({
+    nodeId: "browser-lagging-getters",
+    url: "https://example.com/committed"
+  });
+
+  assert.deepEqual(
+    events
+      .filter((event) => event.type === "state")
+      .map((event) => ({
+        isLoading: event.isLoading,
+        title: event.title,
+        url: event.url
+      })),
+    [
+      {
+        isLoading: true,
+        title: "Previous page",
+        url: "https://example.com/previous"
+      },
+      {
+        isLoading: true,
+        title: "Previous page",
+        url: "https://example.com/committed"
+      },
+      {
+        isLoading: true,
+        title: "Committed page",
+        url: "https://example.com/committed"
+      },
+      {
+        isLoading: false,
+        title: "Committed page",
+        url: "https://example.com/committed"
+      }
+    ]
+  );
+  assert.deepEqual(manager.debugDump({ nodeId: "browser-lagging-getters" }), {
+    canGoBack: false,
+    canGoForward: false,
+    currentUrl: "https://example.com/committed",
+    desiredUrl: "https://example.com/committed",
+    isAttachedToWindow: true,
+    isLoading: false,
+    lifecycle: "active",
+    nodeId: "browser-lagging-getters",
+    profileId: null,
+    sessionMode: "shared",
+    sessionPartition: null,
+    title: "Committed page",
+    userAgent: "MockBrowser/1.0",
+    webContentsDestroyed: false,
+    webContentsId: 22
+  });
+  assert.equal(contents.getURL(), "https://example.com/previous");
+  assert.equal(contents.getTitle(), "Previous page");
+});
+
+test("updates committed URLs only for main-frame in-page navigations", async () => {
+  const events: BrowserNodeEvent[] = [];
+  const contents = new MockBrowserGuestWebContents(23);
+  contents.currentUrl = "https://example.com/page";
+  const manager = createBrowserGuestManager({
+    emit: (event) => events.push(event),
+    openExternal: () => undefined,
+    resolveWebContents: (id) => (id === contents.id ? contents : null)
+  });
+
+  await manager.registerGuest({
+    nodeId: "browser-in-page-navigation",
+    profileId: null,
+    sessionMode: "shared",
+    webContentsId: 23
+  });
+  events.length = 0;
+
+  contents.emit(
+    "did-navigate-in-page",
+    {},
+    "https://example.com/page#main",
+    true
+  );
+  contents.emit(
+    "did-navigate-in-page",
+    {},
+    "https://example.com/iframe#child",
+    false
+  );
+  contents.emit("did-stop-loading");
+
+  assert.deepEqual(
+    events.filter((event) => event.type === "state").map((event) => event.url),
+    [
+      "https://example.com/page#main",
+      "https://example.com/page#main",
+      "https://example.com/page#main"
+    ]
+  );
+});
+
 test("deduplicates Browser Node did-fail-load and loadURL rejection errors", async () => {
   const events: BrowserNodeEvent[] = [];
   const contents = new MockBrowserGuestWebContents(20);

--- a/packages/browser/workbench-node/src/electron-main/guestManager.ts
+++ b/packages/browser/workbench-node/src/electron-main/guestManager.ts
@@ -52,6 +52,8 @@ import {
 interface BrowserGuestSession {
   appliedColorScheme: BrowserPreferredColorScheme | null;
   automationTarget: BrowserNodeAutomationTargetMetadata | null;
+  committedTitle: string | null;
+  committedUrl: string | null;
   contents: BrowserGuestWebContents | null;
   desiredUrl: string;
   findQuery: string;
@@ -167,6 +169,8 @@ export function createBrowserGuestManager({
     const session: BrowserGuestSession = {
       appliedColorScheme: null,
       automationTarget: input?.automationTarget ?? null,
+      committedTitle: null,
+      committedUrl: null,
       contents: null,
       desiredUrl: input?.url ?? "about:blank",
       findQuery: "",
@@ -197,10 +201,10 @@ export function createBrowserGuestManager({
       isOccluded: session.lifecycle === "cold",
       lifecycle: session.lifecycle,
       nodeId: session.nodeId,
-      title: contents ? contents.getTitle() || null : null,
+      title: contents ? session.committedTitle : null,
       type: "state",
       url: contents
-        ? contents.getURL() || session.desiredUrl
+        ? session.committedUrl || session.desiredUrl
         : session.desiredUrl,
       zoomFactor: contents?.zoomFactor ?? 1
     });
@@ -218,6 +222,8 @@ export function createBrowserGuestManager({
     automationRegistry?.unregister(session.nodeId, contents);
     session.contents = null;
     session.appliedColorScheme = null;
+    session.committedTitle = null;
+    session.committedUrl = null;
     session.webContentsId = null;
     if (
       webContentsId !== null &&
@@ -261,6 +267,9 @@ export function createBrowserGuestManager({
       const url = typeof args[1] === "string" ? args[1] : undefined;
       const statusCode = typeof args[2] === "number" ? args[2] : undefined;
       const statusText = typeof args[3] === "string" ? args[3] : undefined;
+      if (url !== undefined) {
+        session.committedUrl = url || null;
+      }
       publishState(session);
       if (!isHttpErrorStatusCode(statusCode)) {
         return;
@@ -315,6 +324,21 @@ export function createBrowserGuestManager({
         nodeId: session.nodeId
       });
     };
+    const onDidNavigateInPage = (...args: unknown[]) => {
+      const url = typeof args[1] === "string" ? args[1] : undefined;
+      const isMainFrame = args[2] === true;
+      if (isMainFrame && url !== undefined) {
+        session.committedUrl = url || null;
+      }
+      publishState(session);
+    };
+    const onPageTitleUpdated = (...args: unknown[]) => {
+      const title = typeof args[1] === "string" ? args[1] : undefined;
+      if (title !== undefined) {
+        session.committedTitle = title || null;
+      }
+      publishState(session);
+    };
     const onDestroyed = () => detachGuest(session);
     const onFoundInPage = (...args: unknown[]) => {
       const result = readFoundInPageResult(args[1]);
@@ -354,8 +378,8 @@ export function createBrowserGuestManager({
       { event: "did-start-navigation", listener: onDidStartNavigation },
       { event: "did-stop-loading", listener: onStateChange },
       { event: "did-navigate", listener: onDidNavigate },
-      { event: "did-navigate-in-page", listener: onStateChange },
-      { event: "page-title-updated", listener: onStateChange },
+      { event: "did-navigate-in-page", listener: onDidNavigateInPage },
+      { event: "page-title-updated", listener: onPageTitleUpdated },
       { event: "will-navigate", listener: onWillNavigate },
       { event: "did-fail-load", listener: onFailLoad },
       { event: "destroyed", listener: onDestroyed },
@@ -410,7 +434,6 @@ export function createBrowserGuestManager({
     const failureSequenceBeforeLoad = session.navigationFailureSequence;
     try {
       await contents.loadURL(resolved.url);
-      publishState(session);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       logger?.warn?.("Browser Node guest loadURL failed", {
@@ -530,7 +553,7 @@ export function createBrowserGuestManager({
       return {
         canGoBack: contents ? canGuestGoBack(contents) : false,
         canGoForward: contents ? canGuestGoForward(contents) : false,
-        currentUrl: contents ? contents.getURL() : null,
+        currentUrl: contents ? session.committedUrl : null,
         desiredUrl: session.desiredUrl,
         isAttachedToWindow: Boolean(contents),
         isLoading: contents ? contents.isLoading() : false,
@@ -539,7 +562,7 @@ export function createBrowserGuestManager({
         profileId: session.profileId,
         sessionMode: session.sessionMode,
         sessionPartition: session.sessionPartition,
-        title: contents ? contents.getTitle() : null,
+        title: contents ? session.committedTitle : null,
         userAgent: contents?.getUserAgent?.() ?? null,
         webContentsDestroyed: session.contents
           ? session.contents.isDestroyed()
@@ -790,6 +813,8 @@ export function createBrowserGuestManager({
         detachGuest(session);
       }
       session.contents = contents;
+      session.committedTitle = contents.getTitle() || null;
+      session.committedUrl = contents.getURL() || null;
       session.webContentsId = input.webContentsId;
       nodeIdByWebContentsId.set(input.webContentsId, input.nodeId);
       if (contents.session) {


### PR DESCRIPTION
## Summary

Electron 43 can resolve `webContents.loadURL()` before `getURL()` and
`getTitle()` expose the newly committed document. Publishing state immediately
after that promise resolves can therefore regress a Browser Node to
`about:blank` or a stale title and cause a visible Home/title flash.

Make committed Electron navigation events the authoritative URL/title source:

- cache the URL from `did-navigate` and main-frame `did-navigate-in-page`
- cache the title from `page-title-updated`
- publish and debug-dump those committed values instead of timing-sensitive
  getters
- stop publishing state solely because `loadURL()` resolved
- initialize committed state from the attached guest once, preserving existing
  first-render behavior

This keeps the existing Browser Node event protocol unchanged and avoids
version checks, timers, retries, or polling.

## Verification

- Reproduced the getter lag under Electron 43: after `loadURL()` resolved, the
  guest document had navigated while `getURL()`/`getTitle()` briefly remained
  stale.
- Added a regression test that keeps both getters stale across
  `did-navigate`, `page-title-updated`, and `did-stop-loading`, and verifies
  emitted state never regresses.
- Added coverage ensuring subframe `did-navigate-in-page` events cannot replace
  the main-frame URL.
- `pnpm --filter @tutti-os/browser-node test` (151 passed)
- `pnpm --filter @tutti-os/browser-node typecheck`
- `pnpm --filter @tutti-os/browser-node build`
- `pnpm check:electron-runtime-boundaries`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop build`
- pre-push `pnpm check:changed -- --push-ready` (10 lanes passed)

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
