### PR TITLE
fix(ui-system): make native bottom sheet peer optional

### DIFF
--- a/docs/conventions/npm-package-release.md
+++ b/docs/conventions/npm-package-release.md
@@ -207,6 +207,12 @@ dependencies rather than resolved independently in the consumer. A
 package-private copy of the shared runtime can make structurally identical
 extensions type-incompatible in consumers.
 
+Platform-specific peers used only by an optional public subpath must remain
+peer dependencies and set `peerDependenciesMeta.<name>.optional` to `true`.
+The platform app that imports that subpath must declare the concrete runtime
+dependency itself. This keeps web and desktop consumers from installing
+unused native dependency chains.
+
 Runtime assets that are rendered or referenced by public entrypoints must also
 survive the packed package shape. When a public runtime entrypoint such as
 `./workbench` or `./ui` renders a package-local image, icon bitmap, schema, or

--- a/packages/ui/system/package.json
+++ b/packages/ui/system/package.json
@@ -89,6 +89,9 @@
     "react-native": ">=0.86 <0.87"
   },
   "peerDependenciesMeta": {
+    "@gorhom/bottom-sheet": {
+      "optional": true
+    },
     "react-dom": {
       "optional": true
     },

--- a/packages/ui/system/src/packageManifest.spec.ts
+++ b/packages/ui/system/src/packageManifest.spec.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+
+import { expect, test } from "vitest";
+
+const manifest = JSON.parse(readFileSync("package.json", "utf8"));
+
+test("marks native-only peers optional for web consumers", () => {
+  expect(manifest.peerDependenciesMeta).toMatchObject({
+    "@gorhom/bottom-sheet": { optional: true },
+    "react-native": { optional: true }
+  });
+});


### PR DESCRIPTION
## Summary
- mark @gorhom/bottom-sheet as an optional ui-system peer for web and desktop consumers
- add a manifest regression test for native-only optional peers
- document the package rule for platform-specific optional subpaths

## Tests
- pnpm --filter @tutti-os/ui-system exec vitest run src/packageManifest.spec.ts
- pnpm check:changed
- pnpm release:pack:check
- pnpm check:changed -- --push-ready

## Notes
- apps/mobile still declares its concrete bottom-sheet and React Native runtime dependencies directly
- no visual UI behavior changed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->