### PR TITLE
perf(workbench): reduce window move render work

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -69,6 +69,7 @@ import { useDesktopAgentGUIReadiness } from "./useDesktopAgentGUIReadiness.ts";
 import { useDesktopAgentGUIOpenConversationWindow } from "./useDesktopAgentGUIOpenConversationWindow.ts";
 import { useDesktopAgentGUIWorkbenchEvents } from "./useDesktopAgentGUIWorkbenchEvents.ts";
 import { useStableDesktopAgentGUIHostProps } from "./useStableDesktopAgentGUIHostProps.ts";
+import { resolveDesktopAgentGUIEmbeddedDesktopSize } from "./desktopAgentGUIEmbeddedFrame.ts";
 import { IAgentEnvService } from "../services/agentEnvService.interface.ts";
 import { preloadDesktopAgentGuiMentionBrowse } from "../services/preloadDesktopAgentGuiMentionBrowse.ts";
 import { DESKTOP_AGENT_GUI_CURRENT_USER_ID } from "../services/desktopAgentGuiIdentity.ts";
@@ -520,11 +521,8 @@ function DesktopAgentGUISurfaceImpl({
     [agentHostApi]
   );
   const desktopSize = useMemo(
-    () => ({
-      height: Math.max(frame.height, frame.y + frame.height),
-      width: Math.max(frame.width, frame.x + frame.width)
-    }),
-    [frame.height, frame.width, frame.x, frame.y]
+    () => resolveDesktopAgentGUIEmbeddedDesktopSize(frame),
+    [frame.height, frame.width]
   );
   const composerFocusRequestSequence =
     composerAppendRequest?.sequence ??

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIEmbeddedFrame.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIEmbeddedFrame.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { WorkbenchFrame } from "@tutti-os/workbench-surface";
+import { resolveDesktopAgentGUIEmbeddedDesktopSize } from "./desktopAgentGUIEmbeddedFrame.ts";
+
+test("embedded agent GUI desktop size ignores the outer window position", () => {
+  const frame: WorkbenchFrame = {
+    height: 640,
+    width: 960,
+    x: 320,
+    y: 180
+  };
+  assert.deepEqual(resolveDesktopAgentGUIEmbeddedDesktopSize(frame), {
+    height: 640,
+    width: 960
+  });
+});

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIEmbeddedFrame.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIEmbeddedFrame.ts
@@ -1,0 +1,10 @@
+import type { WorkbenchFrame } from "@tutti-os/workbench-surface";
+
+export function resolveDesktopAgentGUIEmbeddedDesktopSize(
+  frame: Pick<WorkbenchFrame, "height" | "width">
+): { height: number; width: number } {
+  return {
+    height: frame.height,
+    width: frame.width
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerChrome.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerChrome.tsx
@@ -329,18 +329,6 @@ export interface MentionPaletteFrame {
   zIndex: number | string;
 }
 
-export function resolveMentionPalettePortalTarget(
-  anchor: HTMLElement
-): Element {
-  return (
-    anchor.closest('[data-slot="viewport-menu-boundary"]') ??
-    anchor.closest(
-      "[data-workbench-window-id], [data-workspace-node-window-root='true']"
-    ) ??
-    document.body
-  );
-}
-
 export function resolveMentionPaletteZIndex(
   anchor: HTMLElement
 ): number | string {

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/composerPortalTarget.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/composerPortalTarget.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { resolveComposerPortalTarget } from "./composerPortalTarget";
+
+describe("resolveComposerPortalTarget", () => {
+  it("uses the body for viewport-positioned menus inside a translated boundary", () => {
+    const boundary = document.createElement("div");
+    boundary.setAttribute("data-slot", "viewport-menu-boundary");
+    boundary.setAttribute("data-viewport-menu-portal-target", "body");
+    const anchor = document.createElement("div");
+    boundary.appendChild(anchor);
+    document.body.appendChild(boundary);
+
+    expect(resolveComposerPortalTarget(anchor)).toBe(document.body);
+
+    boundary.remove();
+  });
+
+  it("keeps ordinary boundary-local menus inside their boundary", () => {
+    const boundary = document.createElement("div");
+    boundary.setAttribute("data-slot", "viewport-menu-boundary");
+    const anchor = document.createElement("div");
+    boundary.appendChild(anchor);
+    document.body.appendChild(boundary);
+
+    expect(resolveComposerPortalTarget(anchor)).toBe(boundary);
+
+    boundary.remove();
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/composerPortalTarget.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/composerPortalTarget.ts
@@ -1,0 +1,16 @@
+const VIEWPORT_MENU_BOUNDARY_SELECTOR = '[data-slot="viewport-menu-boundary"]';
+const COMPOSER_MENU_WINDOW_FRAME_SELECTOR =
+  "[data-workbench-window-id], [data-workspace-node-window-root='true']";
+
+export function resolveComposerPortalTarget(anchor: HTMLElement): Element {
+  const boundary = anchor.closest(VIEWPORT_MENU_BOUNDARY_SELECTOR);
+  if (boundary?.getAttribute("data-viewport-menu-portal-target") === "body") {
+    return document.body;
+  }
+
+  return (
+    boundary ??
+    anchor.closest(COMPOSER_MENU_WINDOW_FRAME_SELECTOR) ??
+    document.body
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useMentionPaletteFrame.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useMentionPaletteFrame.ts
@@ -12,10 +12,10 @@ import {
   MENTION_PALETTE_MIN_HEIGHT_PX,
   MENTION_PALETTE_VIEWPORT_PADDING_PX,
   composerPaletteZIndex,
-  resolveMentionPalettePortalTarget,
   resolveMentionPaletteZIndex,
   type MentionPaletteFrame
 } from "./AgentComposerChrome";
+import { resolveComposerPortalTarget } from "./composerPortalTarget";
 
 export function useMentionPaletteFrame(
   inputShellRef: RefObject<HTMLDivElement | null>,
@@ -57,7 +57,7 @@ export function useMentionPaletteFrame(
     setMentionPaletteFrame({
       height,
       left,
-      portalTarget: resolveMentionPalettePortalTarget(anchor),
+      portalTarget: resolveComposerPortalTarget(anchor),
       top: Math.max(
         MENTION_PALETTE_VIEWPORT_PADDING_PX,
         Math.min(

--- a/packages/agent/gui/agent-gui/agentGuiNode/composerFloatingMenu/ComposerFloatingMenuSurface.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composerFloatingMenu/ComposerFloatingMenuSurface.spec.tsx
@@ -17,6 +17,50 @@ function mockRect(rect: {
 }
 
 describe("ComposerFloatingMenuSurface", () => {
+  it("keeps viewport coordinates when a workbench boundary requests a body portal", () => {
+    const boundary = document.createElement("div");
+    boundary.setAttribute("data-slot", "viewport-menu-boundary");
+    boundary.setAttribute("data-viewport-menu-portal-target", "body");
+    boundary.setAttribute("data-workbench-window-id", "node-1");
+    boundary.style.zIndex = "4";
+
+    const anchorRef = createRef<HTMLDivElement>();
+    const anchor = document.createElement("div");
+    anchor.getBoundingClientRect = vi.fn(() =>
+      mockRect({
+        bottom: 560,
+        height: 30,
+        left: 312,
+        right: 588,
+        top: 530,
+        width: 276
+      })
+    );
+    boundary.appendChild(anchor);
+    document.body.appendChild(boundary);
+    anchorRef.current = anchor;
+
+    render(
+      <ComposerFloatingMenuSurface
+        anchorRef={anchorRef}
+        maxHeight={320}
+        open
+        placement="fixed-height"
+        testId="composer-floating-menu-surface-workbench"
+      >
+        <div>menu content</div>
+      </ComposerFloatingMenuSurface>
+    );
+
+    const surface = screen.getByTestId(
+      "composer-floating-menu-surface-workbench"
+    );
+    expect(surface.parentElement).toBe(document.body);
+    expect(surface.style.left).toBe("312px");
+
+    boundary.remove();
+  });
+
   it("keeps a fixed-height menu clear of the workspace window's traffic-light header even when the anchor sits near the top of the viewport", () => {
     const anchorRef = createRef<HTMLDivElement>();
     const anchor = document.createElement("div");

--- a/packages/agent/gui/agent-gui/agentGuiNode/composerFloatingMenu/ComposerFloatingMenuSurface.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composerFloatingMenu/ComposerFloatingMenuSurface.tsx
@@ -12,6 +12,7 @@ import {
 import { createPortal } from "react-dom";
 import { cn } from "../../../app/renderer/lib/utils";
 import { DESKTOP_WINDOW_TOP_MARGIN } from "../../workspaceDesktop/constants";
+import { resolveComposerPortalTarget } from "../composer/composerPortalTarget";
 
 const COMPOSER_MENU_GAP_PX = 8;
 const COMPOSER_MENU_VIEWPORT_PADDING_PX = 8;
@@ -63,14 +64,6 @@ const COMPOSER_MENU_WINDOW_FRAME_SELECTOR =
 
 function resolveComposerMenuWindowFrame(anchor: HTMLElement): Element | null {
   return anchor.closest(COMPOSER_MENU_WINDOW_FRAME_SELECTOR);
-}
-
-function resolveComposerMenuPortalTarget(anchor: HTMLElement): Element {
-  return (
-    anchor.closest('[data-slot="viewport-menu-boundary"]') ??
-    resolveComposerMenuWindowFrame(anchor) ??
-    document.body
-  );
 }
 
 function resolveComposerMenuZIndex(anchor: HTMLElement): number | string {
@@ -155,7 +148,7 @@ function computeComposerAnchoredMenuFrame(
     height,
     left,
     minHeight,
-    portalTarget: resolveComposerMenuPortalTarget(anchor),
+    portalTarget: resolveComposerPortalTarget(anchor),
     top: Math.max(
       topSafeArea,
       Math.min(
@@ -363,7 +356,7 @@ export const ComposerFloatingMenuSurface = forwardRef<
   const portalTarget =
     frame?.portalTarget ??
     (anchorRef.current
-      ? resolveComposerMenuPortalTarget(anchorRef.current)
+      ? resolveComposerPortalTarget(anchorRef.current)
       : document.body);
 
   return createPortal(

--- a/packages/ui/system/src/components/viewport-menu-surface/viewport-menu-surface.spec.tsx
+++ b/packages/ui/system/src/components/viewport-menu-surface/viewport-menu-surface.spec.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ViewportMenuSurface } from "./viewport-menu-surface";
+
+const originalElementsFromPoint = document.elementsFromPoint;
+
+afterEach(() => {
+  document.elementsFromPoint = originalElementsFromPoint;
+});
+
+describe("ViewportMenuSurface", () => {
+  it("keeps viewport coordinates when a boundary requests a body portal", () => {
+    const boundary = document.createElement("div");
+    boundary.dataset.slot = "viewport-menu-boundary";
+    boundary.dataset.viewportMenuPortalTarget = "body";
+    boundary.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: 380,
+          height: 300,
+          left: 100,
+          right: 500,
+          top: 80,
+          width: 400,
+          x: 100,
+          y: 80,
+          toJSON: () => ({})
+        }) as DOMRect
+    );
+    document.body.append(boundary);
+    document.elementsFromPoint = vi.fn(() => [boundary]);
+
+    render(
+      <ViewportMenuSurface
+        open
+        placement={{
+          type: "point",
+          point: { x: 150, y: 120 },
+          estimatedSize: { height: 80, width: 120 }
+        }}
+      >
+        menu
+      </ViewportMenuSurface>
+    );
+
+    const surface = screen.getByText("menu");
+    expect(surface.parentElement).toBe(document.body);
+    expect(surface).toHaveStyle({ left: "150px", top: "120px" });
+
+    boundary.remove();
+  });
+});

--- a/packages/ui/system/src/components/viewport-menu-surface/viewport-menu-surface.tsx
+++ b/packages/ui/system/src/components/viewport-menu-surface/viewport-menu-surface.tsx
@@ -63,7 +63,7 @@ interface MenuBoundaryRect {
 }
 
 interface MenuBoundary {
-  element: Element | null;
+  portalTarget: Element | null;
   rect: MenuBoundaryRect;
 }
 
@@ -160,7 +160,7 @@ function resolveMenuBoundaryFromPoint(point: {
 }): MenuBoundary {
   if (typeof document === "undefined" || !document.elementsFromPoint) {
     return {
-      element: null,
+      portalTarget: null,
       rect: viewportBoundary()
     };
   }
@@ -170,14 +170,18 @@ function resolveMenuBoundaryFromPoint(point: {
     const boundaryElement = element.closest(selector);
     if (boundaryElement) {
       return {
-        element: boundaryElement,
+        portalTarget:
+          boundaryElement.getAttribute("data-viewport-menu-portal-target") ===
+          "body"
+            ? null
+            : boundaryElement,
         rect: rectToBoundary(boundaryElement.getBoundingClientRect())
       };
     }
   }
 
   return {
-    element: null,
+    portalTarget: null,
     rect: viewportBoundary()
   };
 }
@@ -373,7 +377,7 @@ const ViewportMenuSurface = React.forwardRef<
       );
       const menuSize = measuredSize ?? { width: 0, height: 0 };
       return {
-        portalTarget: boundary.element,
+        portalTarget: boundary.portalTarget,
         position:
           placement.constrainToBoundary === false
             ? {
@@ -409,7 +413,7 @@ const ViewportMenuSurface = React.forwardRef<
     });
 
     return {
-      portalTarget: boundary.element,
+      portalTarget: boundary.portalTarget,
       position: {
         left: boundary.rect.left + relativePosition.left,
         top: boundary.rect.top + relativePosition.top

--- a/packages/workbench/surface/README.md
+++ b/packages/workbench/surface/README.md
@@ -44,10 +44,18 @@ When a node body or header needs host-owned business state, pass an
 `subscribe(...)`, the host re-renders when that subscription notifies.
 
 Node body and header contexts expose `isDragging` and `isResizing`. The Workbench
-shell continues applying live frame geometry during direct manipulation, while
-an expensive body adapter may use these flags to suppress frame-only renders
-until the interaction settles. The adapter must still observe both interaction
-transitions so the final committed frame reaches responsive body layout.
+shell continues applying live frame geometry during direct manipulation. Window
+position is shell-owned: changing only `frame.x` or `frame.y` does not render a
+body during drag or resize. Width and height changes remain live, as do changes
+to node data, external state, focus, visibility, or interaction state. The body
+always renders after the interaction settles so the final committed frame
+reaches responsive layout. Body actions that need execution-time window
+position should read the current node from `context.host.getSnapshot()` instead
+of closing over a rendered position.
+
+Translated window boundaries keep using their window rect for menu clamping,
+but viewport-positioned menus portal to `document.body` so fixed coordinates
+are not offset a second time by the window translation.
 
 Headers keep live frame renders by default. A definition may provide
 `getHeaderFrameRenderKey(context)` when several intermediate frames produce the

--- a/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
@@ -223,6 +223,223 @@ describe("WorkbenchHost", () => {
     }
   });
 
+  it("skips position-only body renders while keeping size renders live", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const renderBody = vi.fn((context) => (
+      <div
+        data-body-frame={`${context.node.frame.x}:${context.node.frame.width}`}
+      />
+    ));
+    const onHandleReady = vi.fn<(handle: WorkbenchHostHandle | null) => void>();
+    const bodyDefinition: WorkbenchHostNodeDefinition = {
+      frame: { x: 0, y: 0, width: 320, height: 240 },
+      renderBody,
+      title: "Body",
+      typeId: "body",
+      window: { defaultOpen: true }
+    };
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchHost
+            nodes={[bodyDefinition]}
+            onHandleReady={onHandleReady}
+            snapshotRepository={createSnapshotRepository()}
+            workspaceId="workspace-1"
+          />
+        );
+      });
+
+      const host = onHandleReady.mock
+        .calls[0]?.[0] as WorkbenchHostRuntimeHandle | null;
+      const nodeId = host
+        ?.getSnapshot()
+        .nodes.find((node) => node.data.typeId === "body")?.id;
+      expect(nodeId).toBeTruthy();
+
+      await act(async () => {
+        host?.controller.commands.setSurfaceSize({ width: 1200, height: 800 });
+        host?.controller.commands.focusNode(nodeId ?? "");
+        host?.controller.commands.setActiveDragNode(nodeId ?? null);
+      });
+      const rendersAtDragStart = renderBody.mock.calls.length;
+      const frameAtDragStart = host
+        ?.getSnapshot()
+        .nodes.find((node) => node.id === nodeId)?.frame;
+      if (!frameAtDragStart) {
+        throw new Error("Expected a body frame");
+      }
+
+      await act(async () => {
+        host?.controller.commands.dragNode(nodeId ?? "", {
+          ...frameAtDragStart,
+          x: 20,
+          y: 60
+        });
+      });
+      await act(async () => {
+        host?.controller.commands.dragNode(nodeId ?? "", {
+          ...frameAtDragStart,
+          x: 40,
+          y: 80
+        });
+      });
+
+      expect(renderBody).toHaveBeenCalledTimes(rendersAtDragStart);
+
+      await act(async () => {
+        host?.setNodeRuntimeState(nodeId ?? "", {
+          revision: 1
+        });
+      });
+      expect(renderBody).toHaveBeenCalledTimes(rendersAtDragStart + 1);
+
+      await act(async () => {
+        host?.controller.commands.setActiveDragNode(null);
+      });
+      expect(renderBody).toHaveBeenCalledTimes(rendersAtDragStart + 2);
+      expect(renderBody.mock.lastCall?.[0].node.frame.x).toBe(40);
+      expect(
+        container.querySelector(
+          `[data-body-frame='40:${frameAtDragStart.width}']`
+        )
+      ).not.toBeNull();
+
+      const rendersAtRest = renderBody.mock.calls.length;
+      await act(async () => {
+        host?.controller.commands.dragNode(nodeId ?? "", {
+          ...frameAtDragStart,
+          x: 60,
+          y: 100
+        });
+      });
+      expect(renderBody).toHaveBeenCalledTimes(rendersAtRest + 1);
+
+      await act(async () => {
+        host?.controller.commands.setActiveResizeNode(nodeId ?? null);
+      });
+      const rendersAtResizeStart = renderBody.mock.calls.length;
+      await act(async () => {
+        host?.controller.commands.resizeNode(nodeId ?? "", {
+          ...frameAtDragStart,
+          x: 40,
+          y: 80,
+          width: frameAtDragStart.width + 80,
+          height: frameAtDragStart.height + 20
+        });
+      });
+      expect(renderBody).toHaveBeenCalledTimes(rendersAtResizeStart + 1);
+      await act(async () => {
+        host?.controller.commands.setActiveResizeNode(null);
+      });
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+  });
+
+  it("positions windows with translate while preserving presentation transforms", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const node: WorkbenchNode = {
+      data: null,
+      displayMode: "floating",
+      frame: { x: 80, y: 60, width: 320, height: 240 },
+      id: "node-1",
+      isMinimized: false,
+      kind: "test",
+      restoreFrame: null,
+      title: "Test"
+    };
+    const controller = createWorkbenchController({
+      nodes: [node],
+      nodeStack: [node.id]
+    });
+    const nodeVisibility = createWorkbenchGenieNodeVisibilityStore();
+    const minimizeNodeToAnchor = vi.fn();
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchProvider controller={controller}>
+            <WorkbenchWindowFrame
+              genieNodeVisibility={nodeVisibility}
+              minimizeNodeToAnchor={minimizeNodeToAnchor}
+              node={node}
+            >
+              <div />
+            </WorkbenchWindowFrame>
+          </WorkbenchProvider>
+        );
+      });
+
+      const shell = container.querySelector(
+        ".workbench-window-shell"
+      ) as HTMLElement | null;
+      expect(shell?.style.left).toBe("0px");
+      expect(shell?.style.top).toBe("0px");
+      expect(shell?.style.translate).toBe("80px 60px");
+      expect(shell?.style.transform).toBe("");
+      expect(shell?.getAttribute("data-viewport-menu-portal-target")).toBe(
+        "body"
+      );
+
+      await act(async () => {
+        root.render(
+          <WorkbenchProvider controller={controller}>
+            <WorkbenchWindowFrame
+              genieNodeVisibility={nodeVisibility}
+              minimizeNodeToAnchor={minimizeNodeToAnchor}
+              node={node}
+              presentation={{
+                frameByNodeId: new Map([
+                  [node.id, { x: 200, y: 160, width: 160, height: 120 }]
+                ]),
+                mode: "mission-control",
+                visibleNodeIds: new Set([node.id])
+              }}
+            >
+              <div />
+            </WorkbenchWindowFrame>
+          </WorkbenchProvider>
+        );
+      });
+
+      expect(shell?.style.translate).toBe("80px 60px");
+      expect(shell?.style.transform).toBe("matrix(0.5, 0, 0, 0.5, 120, 100)");
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      nodeVisibility.dispose();
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+  });
+
   it("uses explicit frame keys while isolating inactive headers", async () => {
     const container = document.createElement("div");
     document.body.append(container);

--- a/packages/workbench/surface/src/host/WorkbenchHostNodeBodyRenderer.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostNodeBodyRenderer.tsx
@@ -1,0 +1,101 @@
+import { memo, type ReactNode } from "react";
+import type {
+  WorkbenchHostNodeBodyContext,
+  WorkbenchHostNodeDefinition
+} from "./types.ts";
+
+interface WorkbenchHostNodeBodyRendererProps {
+  context: WorkbenchHostNodeBodyContext;
+  definition: WorkbenchHostNodeDefinition;
+}
+
+function WorkbenchHostNodeBodyRenderer(
+  input: WorkbenchHostNodeBodyRendererProps
+): ReactNode {
+  return input.definition.renderBody(input.context);
+}
+
+function areWorkbenchHostNodeBodyRendererPropsEqual(
+  previous: WorkbenchHostNodeBodyRendererProps,
+  next: WorkbenchHostNodeBodyRendererProps
+): boolean {
+  const previousContext = previous.context;
+  const nextContext = next.context;
+  if (
+    previous.definition !== next.definition ||
+    previousContext.activation !== nextContext.activation ||
+    previousContext.displayMode !== nextContext.displayMode ||
+    previousContext.externalNodeState !== nextContext.externalNodeState ||
+    previousContext.externalWorkspaceState !==
+      nextContext.externalWorkspaceState ||
+    previousContext.host !== nextContext.host ||
+    previousContext.instanceId !== nextContext.instanceId ||
+    previousContext.instanceKey !== nextContext.instanceKey ||
+    previousContext.isDragging !== nextContext.isDragging ||
+    previousContext.isFocused !== nextContext.isFocused ||
+    previousContext.isResizing !== nextContext.isResizing ||
+    previousContext.isVisible !== nextContext.isVisible ||
+    previousContext.presentationMode !== nextContext.presentationMode ||
+    !areWorkbenchOptionalSizesEqual(
+      previousContext.previewViewport,
+      nextContext.previewViewport
+    )
+  ) {
+    return false;
+  }
+
+  const previousNode = previousContext.node;
+  const nextNode = nextContext.node;
+  if (
+    previousNode.id !== nextNode.id ||
+    previousNode.kind !== nextNode.kind ||
+    previousNode.title !== nextNode.title ||
+    previousNode.displayMode !== nextNode.displayMode ||
+    previousNode.restoreFrame !== nextNode.restoreFrame ||
+    previousNode.isMinimized !== nextNode.isMinimized ||
+    previousNode.minimizedAtUnixMs !== nextNode.minimizedAtUnixMs ||
+    previousNode.sizeConstraints !== nextNode.sizeConstraints ||
+    previousNode.data !== nextNode.data
+  ) {
+    return false;
+  }
+
+  if (nextContext.isDragging || nextContext.isResizing) {
+    return (
+      previousNode.frame.width === nextNode.frame.width &&
+      previousNode.frame.height === nextNode.frame.height
+    );
+  }
+
+  return areWorkbenchFramesEqual(previousNode.frame, nextNode.frame);
+}
+
+function areWorkbenchFramesEqual(
+  previous: WorkbenchHostNodeBodyContext["node"]["frame"],
+  next: WorkbenchHostNodeBodyContext["node"]["frame"]
+): boolean {
+  return (
+    previous.x === next.x &&
+    previous.y === next.y &&
+    previous.width === next.width &&
+    previous.height === next.height
+  );
+}
+
+function areWorkbenchOptionalSizesEqual(
+  previous: WorkbenchHostNodeBodyContext["previewViewport"],
+  next: WorkbenchHostNodeBodyContext["previewViewport"]
+): boolean {
+  return (
+    previous === next ||
+    (previous !== undefined &&
+      next !== undefined &&
+      previous.width === next.width &&
+      previous.height === next.height)
+  );
+}
+
+export const MemoizedWorkbenchHostNodeBodyRenderer = memo(
+  WorkbenchHostNodeBodyRenderer,
+  areWorkbenchHostNodeBodyRendererPropsEqual
+);

--- a/packages/workbench/surface/src/host/useWorkbenchHostSurfaceRenderers.tsx
+++ b/packages/workbench/surface/src/host/useWorkbenchHostSurfaceRenderers.tsx
@@ -18,6 +18,7 @@ import {
   renderMinimizedDockPreviewContent,
   WorkbenchHostDock
 } from "./WorkbenchHostDock.tsx";
+import { MemoizedWorkbenchHostNodeBodyRenderer } from "./WorkbenchHostNodeBodyRenderer.tsx";
 import {
   createWorkbenchHostNodeBodyContext,
   createWorkbenchHostNodeHeaderContext
@@ -36,7 +37,6 @@ import type {
   WorkbenchHostChromeRenderContext,
   WorkbenchHostDockEntry,
   WorkbenchHostExternalStateSource,
-  WorkbenchHostNodeBodyContext,
   WorkbenchHostNodeData,
   WorkbenchHostNodeDefinition,
   WorkbenchHostNodeHeaderContext,
@@ -548,7 +548,7 @@ function WorkbenchHostNodeRenderer(input: {
       resetKey={resetKey}
       workspaceId={input.workspaceId}
     >
-      <WorkbenchHostNodeBodyRenderer
+      <MemoizedWorkbenchHostNodeBodyRenderer
         context={bodyContext}
         definition={input.definition}
       />
@@ -889,16 +889,6 @@ class WorkbenchHostNodeRenderErrorBoundary extends Component<
 
     return this.props.children;
   }
-}
-
-function WorkbenchHostNodeBodyRenderer({
-  context,
-  definition
-}: {
-  context: WorkbenchHostNodeBodyContext;
-  definition: WorkbenchHostNodeDefinition;
-}): ReactNode {
-  return definition.renderBody(context);
 }
 
 function WorkbenchHostChromeRenderer({

--- a/packages/workbench/surface/src/react/WorkbenchWindowFrame.tsx
+++ b/packages/workbench/surface/src/react/WorkbenchWindowFrame.tsx
@@ -291,16 +291,18 @@ export function WorkbenchWindowFrame<TData>({
       data-presentation-mode={presentationMode ?? "default"}
       data-presentation-visibility={isPresentationHidden ? "hidden" : "visible"}
       data-slot="viewport-menu-boundary"
+      data-viewport-menu-portal-target="body"
       data-workbench-node-type-id={resolveWorkbenchNodeTypeId(node.data)}
       data-workbench-window-id={node.id}
       data-window-drag-state={isDragging ? "dragging" : "idle"}
       data-window-resize-state={isResizing ? "resizing" : "idle"}
       style={{
         height: node.frame.height,
-        left: node.frame.x,
-        top: node.frame.y,
+        left: 0,
+        top: 0,
         transform: shellTransform,
         transformOrigin: "top left",
+        translate: `${node.frame.x}px ${node.frame.y}px`,
         width: node.frame.width,
         zIndex
       }}

--- a/packages/workbench/surface/src/styles/workbench.css
+++ b/packages/workbench/surface/src/styles/workbench.css
@@ -111,8 +111,7 @@
   overflow: visible;
   transition:
     transform 0.18s ease,
-    left 0.22s cubic-bezier(0.4, 0, 0.2, 1),
-    top 0.22s cubic-bezier(0.4, 0, 0.2, 1),
+    translate 0.22s cubic-bezier(0.4, 0, 0.2, 1),
     width 0.22s cubic-bezier(0.4, 0, 0.2, 1),
     height 0.22s cubic-bezier(0.4, 0, 0.2, 1);
 }
@@ -132,12 +131,14 @@
     scale: 1;
   }
 }
-.workbench-window-shell[data-launch-source="onboarding-auto"][data-presentation-mode="default"][data-genie-state="visible"] {
+.workbench-window-shell[data-launch-source="onboarding-auto"][data-presentation-mode="default"][data-genie-state="visible"]
+  > .workbench-window-shell__content {
   transform-origin: bottom center;
   animation: workbench-shell-enter 0.46s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 @media (prefers-reduced-motion: reduce) {
-  .workbench-window-shell[data-launch-source="onboarding-auto"] {
+  .workbench-window-shell[data-launch-source="onboarding-auto"]
+    > .workbench-window-shell__content {
     animation: none;
   }
 }
@@ -163,10 +164,13 @@
 .workbench-window-shell[data-window-resize-state="resizing"] {
   transition:
     transform 0.18s ease,
-    left 0ms linear,
-    top 0ms linear,
+    translate 0ms linear,
     width 0ms linear,
     height 0ms linear;
+}
+
+.workbench-window-shell[data-window-drag-state="dragging"] {
+  will-change: translate;
 }
 
 .workbench-window-shell__content {


### PR DESCRIPTION
## Summary
- make position-only body render suppression the Workbench default during direct drag/resize; bodies still render live for size, state, focus, visibility, and interaction transitions
- move window positioning from `left`/`top` to compositor-friendly CSS `translate` while preserving Mission Control transforms
- keep viewport-positioned menus correctly aligned by retaining the Workbench boundary rect while portaling fixed surfaces outside the translated containing block
- remove the Issue Manager opt-in API/helper and fix AgentGUI's embedded desktop size so outer window `x`/`y` no longer affect inner layout
- document that body actions needing execution-time position should read `context.host.getSnapshot()`

## Why this is the default
- Workbench owns outer window position, so a body should not couple its inner layout to `frame.x`/`frame.y`
- audited all nine Tutti production body definitions; AgentGUI was the only body reading outer position, and that dependency was incorrect for its embedded coordinate space
- audited the TSH Workbench bodies used by the baseline capture; they do not depend on outer `x`/`y`
- programmatic/at-rest position changes still render, and drag/resize end always delivers the final frame

## Performance verification
- compared profiling captures with nearly identical pointer cadence: 102.7 moves/s before and 101.8 moves/s after
- during a 5.69s Issue Manager drag with 579 pointer moves, `WorkbenchHostNodeBodyRenderer` rendered twice instead of once per move
- pointermove handler average improved from 5.54ms to 0.65ms; P95 improved from 6.94ms to 0.79ms
- normalized layout events fell 98.6%, paint events 96.8%, and raster tasks 92.9%
- the Issue Manager drag recorded one dropped frame; its largest GPU task was 1.45ms
- the first post-change capture exposed AgentGUI as the remaining non-opted-in body; the final implementation removes opt-in and applies the same Workbench rule globally

## Tests
- red/green Workbench render test covering drag suppression, state updates, final-frame delivery, at-rest moves, and live resize
- red/green AgentGUI embedded-frame test proving outer `x`/`y` do not affect inner desktop size
- red/green portal tests covering UI System menus, Composer floating menus, and the `@` mention palette inside translated Workbench windows
- `pnpm --filter @tutti-os/workbench-surface test`
- `pnpm --filter @tutti-os/workbench-surface typecheck`
- `pnpm --filter @tutti-os/desktop typecheck`
- renderer CSS contract verification
- `pnpm check:changed -- --push-ready` (21 lanes)
- Chrome `getBoundingClientRect()` smoke check for normal and Mission Control positioning

## Notes
- pointermove rAF coalescing is intentionally out of scope
- a new Electron trace for the final global AgentGUI behavior has been captured; analysis is pending
- the post-change capture used the Tutti development desktop with React profiling; the baseline capture used TSH at the same input cadence

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
