### PR TITLE
fix(agent-gui): avoid restoring provisional sessions

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -912,6 +912,15 @@ The pending activation carries the same resolved project section key as the
 create command. Exact rail projection therefore shows the conversation as soon
 as the intent is accepted; it does not wait for provider startup or invent a
 temporary catch-all section.
+AgentGUI may select that optimistic conversation in mounted UI immediately,
+but it must not persist the provisional Session ID into Workbench navigation
+state. The selection becomes durable only after the workspace engine confirms
+the activation from an authoritative Session snapshot. On restart, absence
+from a bounded Rail page is not deletion evidence. A host that proves the
+selected Session is absent returns typed `session.not_found`; the activity
+engine retains that code, and AgentGUI clears only the matching global and
+per-target navigation memories before returning Home. Timeout, transport, and
+other reconcile failures preserve the remembered selection.
 The controller's new-conversation command must distinguish rail placement from
 the active Session's runtime working directory before entering the home
 composer. A Session in the Chats section may have a generated `cwd`, but that

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -64,6 +64,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [Agent GUI provider tab shows fused or stale conversations](./agent-session-lifecycle.md#agent-gui-provider-tab-shows-fused-or-stale-conversations)
 - [Agent GUI sessions appear under the wrong user project](./agent-session-lifecycle.md#agent-gui-sessions-appear-under-the-wrong-user-project)
 - [AgentGUI new conversation does nothing after leaving a Chats session](./agent-session-lifecycle.md#agentgui-new-conversation-does-nothing-after-leaving-a-chats-session)
+- [AgentGUI restores a provisional conversation after creation fails](./agent-session-lifecycle.md#agentgui-restores-a-provisional-conversation-after-creation-fails)
 - [Agent GUI context usage is absent or has the wrong total](./agent-session-lifecycle.md#agent-gui-context-usage-is-absent-or-has-the-wrong-total)
 - [Extension history becomes non-resumable after daemon restart](./agent-session-lifecycle.md#extension-history-becomes-non-resumable-after-daemon-restart)
 - [Agent session restore breaks when durable snapshot ownership is split](./agent-session-lifecycle.md#agent-session-restore-breaks-when-durable-snapshot-ownership-is-split)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -326,6 +326,41 @@
 
 Turn state, loading, cancel, restore, file-change undo, rail projection, event updates, imports, and performance.
 
+### AgentGUI restores a provisional conversation after creation fails
+
+- Symptom:
+  A new conversation fails to start, but a renderer reload selects the same
+  Session ID again. The Rail may show an optimistic row while the canonical
+  store has no matching Session.
+- Quick checks:
+  Correlate the activation request, Workbench
+  `lastActiveAgentSessionId`, renderer reload, and canonical Session lookup by
+  exact ID. If navigation persistence precedes canonical activation
+  confirmation and the lookup returns typed `session.not_found`, this is a
+  provisional-selection leak. A bounded Rail page that omits the Session is
+  not enough evidence.
+- Root cause:
+  The new-conversation controller persisted its generated Session ID when it
+  selected the optimistic row. A crash or reload could therefore restore that
+  ID before Host committed a canonical Session. Reconcile errors also lost
+  their typed code in the frontend engine, so AgentGUI could not distinguish a
+  proven missing Session from a transient read failure.
+- Fix:
+  Keep provisional selection in mounted UI only. Persist it after the engine
+  confirms activation from canonical Session state. Preserve reconcile
+  `errorCode`; clear only the exact global and per-target navigation memories
+  when the active reconcile settles with `session.not_found`. Preserve them
+  for timeout, transport failure, and bounded-list absence.
+- Validation:
+  Verify a requested activation performs no persistence, canonical
+  confirmation writes once, create failure plus reload cannot restore the
+  provisional ID, typed `session.not_found` clears only the matching memories,
+  and a transient reconcile error keeps the selection.
+- References:
+  [agent-gui-node.md](../../architecture/agent-gui-node.md)
+  [sessionReconcile.reducer.ts](../../../packages/agent/activity-core/src/engine/sessionReconcile.reducer.ts)
+  [useAgentGUIConversationSelectionController.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts)
+
 ### AgentGUI rail shows a failed Turn but the detail has no error
 
 - Symptom:

--- a/packages/agent/activity-core/src/engine/sessionReconcile.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionReconcile.reducer.test.ts
@@ -120,6 +120,97 @@ test("a timed-out reconcile releases merged demand into the next command", () =>
   );
 });
 
+test("failed reconcile preserves typed error details for exact recovery", () => {
+  let state = reduce(createInitialSessionReconcileState(), {
+    type: "session/reconcileRequested",
+    agentSessionId: "session-1",
+    needsMessages: true,
+    needsState: true,
+    workspaceId: "workspace-1"
+  }).state;
+  state = reduce(state, {
+    type: "engine/commandResult",
+    commandId: "session:reconcile:session-1:1",
+    commandType: "session/reconcile",
+    errorCode: "session.not_found",
+    errorMessage: "Session not found.",
+    outcome: "failed"
+  }).state;
+
+  assert.deepEqual(state.recordsBySessionId["session-1"], {
+    agentSessionId: "session-1",
+    errorCode: "session.not_found",
+    errorMessage: "Session not found.",
+    inFlightCommandId: null,
+    inFlightScope: null,
+    messagesHydrated: false,
+    pendingMessages: false,
+    pendingState: false,
+    workspaceId: "workspace-1"
+  });
+});
+
+test("a later reconcile request clears stale typed error details", () => {
+  let state = reduce(createInitialSessionReconcileState(), {
+    type: "session/reconcileRequested",
+    agentSessionId: "session-1",
+    needsMessages: false,
+    needsState: true,
+    workspaceId: "workspace-1"
+  }).state;
+  state = reduce(state, {
+    type: "engine/commandResult",
+    commandId: "session:reconcile:session-1:1",
+    commandType: "session/reconcile",
+    errorCode: "session.not_found",
+    errorMessage: "Session not found.",
+    outcome: "failed"
+  }).state;
+
+  const retried = reduce(state, {
+    type: "session/reconcileRequested",
+    agentSessionId: "session-1",
+    needsMessages: false,
+    needsState: true,
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(retried.state.recordsBySessionId["session-1"]?.errorCode, null);
+});
+
+test("a merged retry does not expose the previous attempt's typed error", () => {
+  let state = reduce(createInitialSessionReconcileState(), {
+    type: "session/reconcileRequested",
+    agentSessionId: "session-1",
+    needsMessages: true,
+    needsState: false,
+    workspaceId: "workspace-1"
+  }).state;
+  state = reduce(state, {
+    type: "session/reconcileRequested",
+    agentSessionId: "session-1",
+    needsMessages: false,
+    needsState: true,
+    workspaceId: "workspace-1"
+  }).state;
+
+  const retrying = reduce(state, {
+    type: "engine/commandResult",
+    commandId: "session:reconcile:session-1:1",
+    commandType: "session/reconcile",
+    errorCode: "session.not_found",
+    errorMessage: "Session not found.",
+    outcome: "failed"
+  });
+
+  assert.equal(retrying.commands[0]?.type, "session/reconcile");
+  assert.equal(retrying.state.recordsBySessionId["session-1"]?.errorCode, null);
+  assert.equal(
+    retrying.state.recordsBySessionId["session-1"]?.errorMessage,
+    null
+  );
+});
+
 function reduce(
   state: ReturnType<typeof createInitialSessionReconcileState>,
   intent: Parameters<typeof sessionReconcileReducer>[1]

--- a/packages/agent/activity-core/src/engine/sessionReconcile.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionReconcile.reducer.ts
@@ -121,6 +121,7 @@ function requestReconcile(
   }
   const current = state.recordsBySessionId[agentSessionId] ?? {
     agentSessionId,
+    errorCode: null,
     errorMessage: null,
     inFlightCommandId: null,
     inFlightScope: null,
@@ -131,6 +132,7 @@ function requestReconcile(
   };
   const record = {
     ...current,
+    errorCode: null,
     errorMessage: null,
     pendingMessages: current.pendingMessages || input.needsMessages,
     pendingState: current.pendingState || input.needsState
@@ -153,6 +155,8 @@ function settleReconcile(
   }
   const settled = {
     ...record,
+    errorCode:
+      intent.outcome === "succeeded" ? null : intent.errorCode?.trim() || null,
     errorMessage:
       intent.outcome === "succeeded"
         ? null
@@ -196,6 +200,8 @@ function startReconcile(
       { ...state, nextCommandSequence: state.nextCommandSequence + 1 },
       {
         ...record,
+        errorCode: null,
+        errorMessage: null,
         inFlightCommandId: commandId,
         inFlightScope: scope,
         pendingMessages: false,

--- a/packages/agent/activity-core/src/engine/sessionReconcile.types.ts
+++ b/packages/agent/activity-core/src/engine/sessionReconcile.types.ts
@@ -2,6 +2,7 @@ export type SessionReconcileScope = "messages" | "state" | "state_and_messages";
 
 export interface SessionReconcileRecord {
   agentSessionId: string;
+  errorCode: string | null;
   errorMessage: string | null;
   inFlightCommandId: string | null;
   inFlightScope: SessionReconcileScope | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationActivation.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationActivation.types.ts
@@ -49,10 +49,6 @@ export interface UseAgentGUINewConversationActivationInput {
   tuttiModeDraftKey: string;
   conversationListQuery: AgentGUIConversationListQuery | null;
   currentUserId: string | null | undefined;
-  persistActiveConversation: (
-    agentSessionId: string | null,
-    agentTargetId?: string | null
-  ) => void;
   requestRailReveal(
     agentSessionId: string,
     reason: AgentGUIConversationRailRevealReason

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.spec.tsx
@@ -19,6 +19,23 @@ import { useAgentGUINewConversationActivation } from "./useAgentGUINewConversati
 import { useAgentGUISubmitInteractionActions } from "./useAgentGUISubmitInteractionActions";
 
 describe("P0 new-conversation placement scenarios", () => {
+  it("does not persist a provisional session before canonical confirmation", async () => {
+    const scenario = renderNewConversationScenario({
+      activeConversation: null,
+      initialHomeProjectPath: null,
+      userProjects: []
+    });
+
+    act(() => scenario.requestNewConversation());
+    scenario.persistActiveConversation.mockClear();
+    act(() =>
+      scenario.submitPrompt([{ type: "text", text: "start a new chat" }])
+    );
+
+    await scenario.waitForActivation();
+    expect(scenario.persistActiveConversation).not.toHaveBeenCalled();
+  });
+
   it("creates a conversations-scoped activation from an active Chats session", async () => {
     const previousSessionCwd = "/Users/example/Documents/tutti/session-current";
     const scenario = renderNewConversationScenario({
@@ -164,6 +181,7 @@ function renderNewConversationScenario(input: {
   const submittedDraftSnapshotsRef = { current: {} };
   const agentActivityRuntime = {} as AgentActivityRuntime;
   const setDraftByScopeKey = vi.fn();
+  const persistActiveConversation = vi.fn();
   const conversationsRef = {
     current: input.activeConversation ? [input.activeConversation] : []
   };
@@ -203,7 +221,7 @@ function renderNewConversationScenario(input: {
           dataRef.current = updater(dataRef.current);
         }
       },
-      persistActiveConversation: vi.fn(),
+      persistActiveConversation,
       prefillPromptRequest: null,
       reportActiveConversationCleared: vi.fn(),
       selectedComposerTargetDataRef: { current: targetData },
@@ -247,7 +265,6 @@ function renderNewConversationScenario(input: {
           dataRef.current = updater(dataRef.current);
         }
       },
-      persistActiveConversation: vi.fn(),
       refreshMessagesFromSnapshot: vi.fn(),
       requestRailReveal: vi.fn(),
       selectedAgentTargetIsExplicitRef: { current: true },
@@ -316,6 +333,7 @@ function renderNewConversationScenario(input: {
         transientConversation: null
       });
     },
+    persistActiveConversation,
     submitPrompt: result.current.submitPrompt,
     async waitForActivation() {
       let activation: EngineExternalCommand | undefined;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { AgentSessionEngine } from "@tutti-os/agent-activity-core";
 import { useRef, useState } from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -6,7 +6,8 @@ import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import type { AgentGUINodeData } from "../../../types";
 import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
 import {
-  clearFailedAgentGUIActivationSelection,
+  clearRolledBackAgentGUISelection,
+  shouldClearMissingAgentGUISelection,
   shouldMarkActiveConversationRead
 } from "./useAgentGUIConversationSelectionController";
 import { useAgentGUIConversationSelectionController } from "./useAgentGUIConversationSelectionController";
@@ -14,20 +15,238 @@ import { useAgentGUIConversationRouting } from "./useAgentGUIConversationRouting
 import type { ConversationIntent } from "./useAgentConversationSelection";
 import type { useAgentGUIActivation } from "./useAgentGUIActivation";
 
-describe("clearFailedAgentGUIActivationSelection", () => {
+describe("clearRolledBackAgentGUISelection", () => {
   it("does not clear a newer external selection", () => {
     const current = {
       lastActiveAgentSessionId: "session-newer",
       provider: "codex" as const
     };
 
+    expect(clearRolledBackAgentGUISelection(current, "session-failed")).toBe(
+      current
+    );
     expect(
-      clearFailedAgentGUIActivationSelection(current, "session-failed")
-    ).toBe(current);
-    expect(
-      clearFailedAgentGUIActivationSelection(current, "session-newer")
+      clearRolledBackAgentGUISelection(current, "session-newer")
         .lastActiveAgentSessionId
     ).toBeNull();
+  });
+
+  it("persists a new selection only after canonical activation confirmation", async () => {
+    const agentSessionId = "session-new";
+    const data: AgentGUINodeData = {
+      provider: "codex",
+      lastActiveAgentSessionId: null
+    };
+    let persistedData = data;
+    const onDataChange = vi.fn(
+      (updater: (current: AgentGUINodeData) => AgentGUINodeData) => {
+        persistedData = updater(persistedData);
+      }
+    );
+
+    const { result } = renderHook(() => {
+      const [activeConversationId, setActiveConversationId] = useState<
+        string | null
+      >(null);
+      const [activePendingActivation, setActivePendingActivation] = useState<{
+        agentSessionId: string;
+        agentTargetId: string;
+        errorMessage: null;
+        mode: "new";
+        requestId: string;
+        status: "requested" | "confirmed";
+      } | null>(null);
+      const [intent, setIntent] = useState<ConversationIntent>({ tag: "home" });
+      const [isComposerHome, setIsComposerHome] = useState(true);
+      const activeConversationIdRef = useRef<string | null>(null);
+      const isComposerHomeRef = useRef(true);
+
+      useAgentGUIConversationSelectionController({
+        activation: {
+          clearFailure: vi.fn(),
+          unactivate: vi.fn(() => Promise.resolve())
+        } as unknown as ReturnType<typeof useAgentGUIActivation>,
+        activeConversationId,
+        activeConversationIdRef,
+        activePendingActivation,
+        activeSessionReconcileErrorCode: null,
+        agentActivityRuntime: {} as AgentActivityRuntime,
+        attentionReadRecordsBySessionId: {},
+        conversationIdsRef: { current: new Set() },
+        conversationsRef: { current: [] },
+        conversationListQuery: {},
+        currentUserId: null,
+        data,
+        dataRef: { current: data },
+        intent,
+        isComposerHomeRef,
+        isMountedRef: { current: true },
+        loadDraftComposerOptions: vi.fn(),
+        markSelectedConversationDetailPending: vi.fn(() => null),
+        onDataChangeRef: { current: onDataChange },
+        reloadSelectedConversationRef: { current: vi.fn() },
+        sessionEngine: {
+          dispatch: vi.fn(),
+          getSnapshot: vi.fn(() => ({
+            pendingIntents: { activationsByRequestId: {} }
+          }))
+        } as unknown as AgentSessionEngine,
+        setActiveConversationId,
+        setDetailError: vi.fn(),
+        setIntent,
+        setIsComposerHome,
+        setIsLoadingMessages: vi.fn(),
+        clearRailRevealRequest: vi.fn(),
+        requestRailReveal: vi.fn(),
+        transientConversation: null,
+        workspaceId: "workspace-1"
+      });
+
+      return {
+        activate(status: "requested" | "confirmed") {
+          activeConversationIdRef.current = agentSessionId;
+          setActiveConversationId(agentSessionId);
+          setActivePendingActivation({
+            agentSessionId,
+            agentTargetId: "target-1",
+            errorMessage: null,
+            mode: "new",
+            requestId: "activation-1",
+            status
+          });
+          isComposerHomeRef.current = false;
+          setIsComposerHome(false);
+          setIntent({ tag: "active", id: agentSessionId });
+        },
+        activeConversationId,
+        isComposerHome
+      };
+    });
+
+    act(() => result.current.activate("requested"));
+    expect(onDataChange).not.toHaveBeenCalled();
+
+    act(() => result.current.activate("confirmed"));
+    await waitFor(() => {
+      expect(persistedData).toMatchObject({
+        lastActiveAgentSessionId: agentSessionId,
+        lastActiveAgentSessionIdByAgentTargetId: {
+          "target-1": agentSessionId
+        }
+      });
+    });
+    expect(onDataChange).toHaveBeenCalledOnce();
+  });
+
+  it("clears only an active persisted selection rejected as session.not_found", async () => {
+    const missingAgentSessionId = "session-missing";
+    const data: AgentGUINodeData = {
+      provider: "codex",
+      lastActiveAgentSessionId: missingAgentSessionId,
+      lastActiveAgentSessionIdByAgentTargetId: {
+        "target-1": missingAgentSessionId,
+        "target-2": "session-preserved"
+      }
+    };
+    let persistedData = data;
+    const onDataChange = vi.fn(
+      (updater: (current: AgentGUINodeData) => AgentGUINodeData) => {
+        persistedData = updater(persistedData);
+      }
+    );
+    const setDetailError = vi.fn();
+
+    const { result } = renderHook(() => {
+      const [activeConversationId, setActiveConversationId] = useState<
+        string | null
+      >(missingAgentSessionId);
+      const [intent, setIntent] = useState<ConversationIntent>({
+        tag: "active",
+        id: missingAgentSessionId
+      });
+      const [isComposerHome, setIsComposerHome] = useState(false);
+      const activeConversationIdRef = useRef<string | null>(
+        missingAgentSessionId
+      );
+      const isComposerHomeRef = useRef(false);
+
+      useAgentGUIConversationSelectionController({
+        activation: {
+          clearFailure: vi.fn(),
+          unactivate: vi.fn(() => Promise.resolve())
+        } as unknown as ReturnType<typeof useAgentGUIActivation>,
+        activeConversationId,
+        activeConversationIdRef,
+        activePendingActivation: null,
+        activeSessionReconcileErrorCode: "session.not_found",
+        agentActivityRuntime: {} as AgentActivityRuntime,
+        attentionReadRecordsBySessionId: {},
+        conversationIdsRef: { current: new Set() },
+        conversationsRef: { current: [] },
+        conversationListQuery: {},
+        currentUserId: null,
+        data,
+        dataRef: { current: data },
+        intent,
+        isComposerHomeRef,
+        isMountedRef: { current: true },
+        loadDraftComposerOptions: vi.fn(),
+        markSelectedConversationDetailPending: vi.fn(() => null),
+        onDataChangeRef: { current: onDataChange },
+        reloadSelectedConversationRef: { current: vi.fn() },
+        sessionEngine: {
+          dispatch: vi.fn(),
+          getSnapshot: vi.fn(() => ({
+            pendingIntents: { activationsByRequestId: {} }
+          }))
+        } as unknown as AgentSessionEngine,
+        setActiveConversationId,
+        setDetailError,
+        setIntent,
+        setIsComposerHome,
+        setIsLoadingMessages: vi.fn(),
+        clearRailRevealRequest: vi.fn(),
+        requestRailReveal: vi.fn(),
+        transientConversation: null,
+        workspaceId: "workspace-1"
+      });
+
+      return { activeConversationId, intent, isComposerHome };
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        activeConversationId: null,
+        intent: { tag: "home" },
+        isComposerHome: true
+      });
+    });
+    expect(persistedData).toMatchObject({
+      lastActiveAgentSessionId: null,
+      lastActiveAgentSessionIdByAgentTargetId: {
+        "target-2": "session-preserved"
+      }
+    });
+    expect(setDetailError).toHaveBeenCalledWith(
+      "The previous agent session is no longer available."
+    );
+  });
+
+  it("keeps an active selection after a transient reconcile failure", () => {
+    expect(
+      shouldClearMissingAgentGUISelection({
+        activeConversationId: "session-1",
+        currentActiveConversationId: "session-1",
+        reconcileErrorCode: "request_timed_out"
+      })
+    ).toBe(false);
+    expect(
+      shouldClearMissingAgentGUISelection({
+        activeConversationId: "session-1",
+        currentActiveConversationId: "session-newer",
+        reconcileErrorCode: "session.not_found"
+      })
+    ).toBe(false);
   });
 
   it("does not reinterpret the failed selection persistence echo as a new request", async () => {
@@ -68,11 +287,14 @@ describe("clearFailedAgentGUIActivationSelection", () => {
           activeConversationId === failedAgentSessionId
             ? {
                 agentSessionId: failedAgentSessionId,
+                agentTargetId: "target-1",
                 errorMessage: "create failed",
                 mode: "new",
+                requestId: "activation-1",
                 status: "failed"
               }
             : null,
+        activeSessionReconcileErrorCode: null,
         agentActivityRuntime: {} as AgentActivityRuntime,
         attentionReadRecordsBySessionId: {},
         conversationIdsRef: { current: new Set() },

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts
@@ -14,7 +14,11 @@ import { translate } from "../../../i18n/index";
 import type { AgentGUINodeData } from "../../../types";
 import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
 import type { AgentGUIConversationRailRevealReason } from "../model/agentGuiConversationRailViewState";
-import { forgetAgentGUISessionMemories } from "../model/agentGuiSessionNavigationMemory";
+import {
+  forgetAgentGUISessionMemories,
+  rememberAgentGUIActiveConversation
+} from "../model/agentGuiSessionNavigationMemory";
+import { AGENT_SESSION_NOT_FOUND_ERROR } from "./agentGuiController.errors";
 import {
   reportAgentGUIActiveConversationCleared,
   reportAgentGUIConversationListProjectionSkipped
@@ -32,7 +36,12 @@ import {
 
 type ActivationRecord = Pick<
   PendingActivationIntentRecord,
-  "agentSessionId" | "errorMessage" | "mode" | "status"
+  | "agentSessionId"
+  | "agentTargetId"
+  | "errorMessage"
+  | "mode"
+  | "requestId"
+  | "status"
 >;
 
 interface UseAgentGUIConversationSelectionControllerInput {
@@ -40,6 +49,7 @@ interface UseAgentGUIConversationSelectionControllerInput {
   activeConversationId: string | null;
   activeConversationIdRef: RefObject<string | null>;
   activePendingActivation: ActivationRecord | null;
+  activeSessionReconcileErrorCode: string | null;
   agentActivityRuntime: AgentActivityRuntime;
   attentionReadRecordsBySessionId: Record<
     string,
@@ -80,11 +90,11 @@ interface UseAgentGUIConversationSelectionControllerInput {
   workspaceId: string;
 }
 
-export function clearFailedAgentGUIActivationSelection(
+export function clearRolledBackAgentGUISelection(
   current: AgentGUINodeData,
-  failedAgentSessionId: string
+  rolledBackAgentSessionId: string
 ): AgentGUINodeData {
-  const normalized = failedAgentSessionId.trim();
+  const normalized = rolledBackAgentSessionId.trim();
   return normalized
     ? forgetAgentGUISessionMemories(current, new Set([normalized]))
     : current;
@@ -103,6 +113,20 @@ export function shouldMarkActiveConversationRead(input: {
   );
 }
 
+export function shouldClearMissingAgentGUISelection(input: {
+  activeConversationId: string | null;
+  currentActiveConversationId: string | null;
+  reconcileErrorCode: string | null;
+}): boolean {
+  const activeConversationId = input.activeConversationId?.trim() ?? "";
+  return (
+    activeConversationId !== "" &&
+    activeConversationId ===
+      (input.currentActiveConversationId?.trim() ?? "") &&
+    input.reconcileErrorCode?.trim() === AGENT_SESSION_NOT_FOUND_ERROR
+  );
+}
+
 export function useAgentGUIConversationSelectionController(
   input: UseAgentGUIConversationSelectionControllerInput
 ) {
@@ -111,6 +135,7 @@ export function useAgentGUIConversationSelectionController(
     activeConversationId,
     activeConversationIdRef,
     activePendingActivation,
+    activeSessionReconcileErrorCode,
     agentActivityRuntime,
     attentionReadRecordsBySessionId,
     conversationIdsRef,
@@ -138,7 +163,8 @@ export function useAgentGUIConversationSelectionController(
     workspaceId
   } = input;
   const previousAttentionActiveConversationIdRef = useRef<string | null>(null);
-  const failedActivationRollbackSessionIdRef = useRef<string | null>(null);
+  const rolledBackSelectionSessionIdRef = useRef<string | null>(null);
+  const persistedConfirmedActivationRequestIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     const userId = currentUserId?.trim() ?? "";
@@ -153,13 +179,11 @@ export function useAgentGUIConversationSelectionController(
   }, [currentUserId, sessionEngine, workspaceId]);
 
   useEffect(() => {
-    if (
-      activePendingActivation?.mode === "new" &&
-      !isPendingActivationViable(activePendingActivation) &&
-      activeConversationIdRef.current === activePendingActivation.agentSessionId
-    ) {
-      failedActivationRollbackSessionIdRef.current =
-        activePendingActivation.agentSessionId;
+    const rollbackSelection = (
+      agentSessionId: string,
+      errorMessage: string | null
+    ) => {
+      rolledBackSelectionSessionIdRef.current = agentSessionId;
       activeConversationIdRef.current = null;
       setActiveConversationId(null);
       isComposerHomeRef.current = true;
@@ -167,21 +191,63 @@ export function useAgentGUIConversationSelectionController(
       setIntent({ tag: "home" });
       clearRailRevealRequest();
       onDataChangeRef.current((current) =>
-        clearFailedAgentGUIActivationSelection(
+        clearRolledBackAgentGUISelection(current, agentSessionId)
+      );
+      if (errorMessage) setDetailError(errorMessage);
+      previousAttentionActiveConversationIdRef.current = null;
+    };
+
+    if (
+      activePendingActivation?.mode === "new" &&
+      !isPendingActivationViable(activePendingActivation) &&
+      activeConversationIdRef.current === activePendingActivation.agentSessionId
+    ) {
+      rollbackSelection(
+        activePendingActivation.agentSessionId,
+        activePendingActivation.status === "failed"
+          ? activePendingActivation.errorMessage ||
+              translate("agentHost.agentGui.sessionActivationFailed")
+          : null
+      );
+      return;
+    }
+    if (
+      shouldClearMissingAgentGUISelection({
+        activeConversationId,
+        currentActiveConversationId: activeConversationIdRef.current,
+        reconcileErrorCode: activeSessionReconcileErrorCode
+      })
+    ) {
+      rollbackSelection(
+        activeConversationId!.trim(),
+        translate("agentHost.agentGui.sessionNoLongerAvailable")
+      );
+      setIsLoadingMessages(false);
+      return;
+    }
+    if (
+      activePendingActivation?.mode === "new" &&
+      activePendingActivation.status === "confirmed" &&
+      activeConversationIdRef.current ===
+        activePendingActivation.agentSessionId &&
+      persistedConfirmedActivationRequestIdRef.current !==
+        activePendingActivation.requestId
+    ) {
+      persistedConfirmedActivationRequestIdRef.current =
+        activePendingActivation.requestId;
+      onDataChangeRef.current((current) =>
+        rememberAgentGUIActiveConversation(
           current,
-          activePendingActivation.agentSessionId
+          activePendingActivation.agentSessionId,
+          activePendingActivation.agentTargetId
         )
       );
-      if (activePendingActivation.status === "failed") {
-        setDetailError(
-          activePendingActivation.errorMessage ||
-            translate("agentHost.agentGui.sessionActivationFailed")
-        );
-      }
+    }
+    if (!activeConversationId) {
       previousAttentionActiveConversationIdRef.current = null;
       return;
     }
-    if (!activeConversationId) {
+    if (activeConversationIdRef.current !== activeConversationId) {
       previousAttentionActiveConversationIdRef.current = null;
       return;
     }
@@ -204,6 +270,7 @@ export function useAgentGUIConversationSelectionController(
   }, [
     activeConversationId,
     activePendingActivation,
+    activeSessionReconcileErrorCode,
     attentionReadRecordsBySessionId,
     clearRailRevealRequest,
     currentUserId,
@@ -212,16 +279,16 @@ export function useAgentGUIConversationSelectionController(
 
   useEffect(() => {
     const externalId = data.lastActiveAgentSessionId?.trim() ?? "";
-    const failedActivationRollbackSessionId =
-      failedActivationRollbackSessionIdRef.current;
-    if (failedActivationRollbackSessionId) {
-      if (externalId === failedActivationRollbackSessionId) {
-        // The workbench state update that clears a failed optimistic session
+    const rolledBackSelectionSessionId =
+      rolledBackSelectionSessionIdRef.current;
+    if (rolledBackSelectionSessionId) {
+      if (externalId === rolledBackSelectionSessionId) {
+        // The Workbench state update that clears a failed or missing session
         // can reach this component after the local rollback. Until that echo
         // arrives, the old persisted id is not a new external selection.
         return;
       }
-      failedActivationRollbackSessionIdRef.current = null;
+      rolledBackSelectionSessionIdRef.current = null;
     }
     if (externalId === (activeConversationIdRef.current ?? "")) return;
     if (!externalId) {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
@@ -135,7 +135,6 @@ export function useAgentGUINewConversationActivation(
     loadSelectedConversationMessages,
     loadSessionState,
     refreshMessagesFromSnapshot,
-    persistActiveConversation,
     requestRailReveal,
     setActiveConversationId,
     setIntent,
@@ -301,7 +300,6 @@ export function useAgentGUINewConversationActivation(
       setIsComposerHome(false);
       setIntent({ tag: "active", id: agentSessionId });
       setIsLoadingMessages(false);
-      persistActiveConversation(agentSessionId, agentTargetId);
       return { agentSessionId, requestId };
     },
     [
@@ -313,7 +311,6 @@ export function useAgentGUINewConversationActivation(
       loadSelectedConversationMessages,
       loadSessionState,
       refreshMessagesFromSnapshot,
-      persistActiveConversation,
       requestRailReveal,
       activation,
       conversationListQuery,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -484,6 +484,8 @@ export function useAgentGUINodeController({
     activeConversationId,
     activeConversationIdRef,
     activePendingActivation,
+    activeSessionReconcileErrorCode:
+      sessionEngineState.activeSessionReconcileErrorCode,
     agentActivityRuntime,
     attentionReadRecordsBySessionId: attentionReadState.recordsBySessionId,
     conversationIdsRef,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionEngineState.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionEngineState.ts
@@ -221,6 +221,7 @@ export function useAgentGUISessionEngineState(input: {
     ),
     activeSessionState,
     activeSessionDetailLoading,
+    activeSessionReconcileErrorCode: activeSessionReconcile?.errorCode ?? null,
     activeSessionReconcileError: activeSessionDetailHydrated
       ? null
       : (activeSessionReconcile?.errorMessage ?? null),

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -505,6 +505,8 @@ export const enAgentGui = {
   agentTargetRequired:
     "Select an available agent target before starting a session.",
   sessionActivationFailed: "The agent session could not be started.",
+  sessionNoLongerAvailable:
+    "The previous agent session is no longer available.",
   promptImagesUnsupported:
     "This agent does not support image input with the current model.",
   ...enAgentGuiRuntimeNotices,

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -522,6 +522,7 @@ export const zhCNAgentGui = {
   collapseTurnWork: "收起任务详情",
   agentTargetRequired: "请先选择可用的 Agent 目标。",
   sessionActivationFailed: "Agent 会话启动失败。",
+  sessionNoLongerAvailable: "之前的 Agent 会话已不可用",
   promptImagesUnsupported: "当前模型不支持图片输入。",
   ...zhCNAgentGuiRuntimeNotices,
   contextCompactionInProgress: "正在压缩上下文",


### PR DESCRIPTION
## Summary
- keep provisional new-conversation selection in mounted AgentGUI state until canonical activation confirmation
- retain typed session reconcile error codes and clear only the exact persisted selection on `session.not_found`
- preserve remembered selections for transient reconcile failures and bounded rail absence
- document the navigation persistence and recovery contract

## Tests
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`

## Notes
- downstream hosts must surface typed `session.not_found` for canonical absence; the TSH adapter update and package bump are intentionally separate

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->