### PR TITLE
fix(workspace-account): restore Tutti Agent gate

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAccountMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAccountMenu.tsx
@@ -49,12 +49,16 @@ export function WorkspaceAccountMenu({
   workspaceId
 }: WorkspaceAccountMenuProps) {
   const { state: workspaceSettingsState } = useWorkspaceSettingsService();
-  const commerceEnabled =
+  const tuttiAgentEnabled =
     workspaceSettingsState.tuttiAgentSwitchEnabled === true;
+
+  if (!tuttiAgentEnabled) {
+    return null;
+  }
 
   return (
     <WorkspaceAccountMenuEnabled
-      commerceEnabled={commerceEnabled}
+      commerceEnabled={tuttiAgentEnabled}
       showLeadingDivider={showLeadingDivider}
       signedOutPresentation={signedOutPresentation}
       workspaceId={workspaceId}


### PR DESCRIPTION
## Summary
- hide the workspace account shell, including the signed-out login action, when the Tutti Agent switch is disabled
- keep Commerce/account rendering unchanged while the switch is enabled

## Validation
- `pnpm --filter @tutti-os/desktop typecheck`
- Oxfmt check
- `git diff --check`
- pre-push `check:changed`: 29/34 lanes passed; four Go lint lanes were blocked by local golangci-lint v1 versus the repository v2 config, and unrelated agentstatus Go tests failed

## Documentation
- No documentation impact; this restores the established account-menu gate behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->