### PR TITLE
fix(desktop): reduce idle rendering and dock capture overhead

### DIFF
--- a/apps/desktop/src/main/ipc/hostWindow.ts
+++ b/apps/desktop/src/main/ipc/hostWindow.ts
@@ -264,22 +264,10 @@ function logCapturePreviewDiagnostic(input: {
             : String(input.diagnostic.error)
       });
       return;
-    case "full_capture_empty":
+    case "capture_empty":
       input.logger.warn("host window preview capture returned empty image", {
         ...fields
       });
-      return;
-    case "crop_empty":
-      input.logger.warn(
-        "host window preview capture crop returned empty image",
-        {
-          ...fields,
-          cropRect: input.diagnostic.cropRect,
-          imageHeight: input.diagnostic.imageSize?.height,
-          imageWidth: input.diagnostic.imageSize?.width,
-          requestedRect: input.input.rect
-        }
-      );
       return;
     case "resize_empty":
       input.logger.warn(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentStatusSource.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentStatusSource.test.ts
@@ -5,7 +5,10 @@ import type {
   AgentStatusSourceError,
   AgentStatusStreamObserver
 } from "@tutti-os/agent-gui";
-import { createDesktopAgentStatusSource } from "./createDesktopAgentStatusSource.ts";
+import {
+  createDesktopAgentStatusSource,
+  createDesktopWorkspaceAgentStatusSource
+} from "./createDesktopAgentStatusSource.ts";
 
 const agent = {
   agentTargetId: "local:codex",
@@ -124,6 +127,122 @@ test("desktop status fails closed before probing a cross-target session", () => 
   assert.equal(listCalled, false);
 });
 
+test("workspace status shares Provider refreshes while keeping per-session controller state", async () => {
+  let currentTime = 1_000;
+  const firstProbe = deferred<ReturnType<typeof probeSnapshot>>();
+  const secondProbe = deferred<ReturnType<typeof probeSnapshot>>();
+  const thirdProbe = deferred<ReturnType<typeof probeSnapshot>>();
+  const listCalls: unknown[] = [];
+  const responses = [
+    firstProbe.promise,
+    secondProbe.promise,
+    thirdProbe.promise
+  ];
+  const source = createDesktopWorkspaceAgentStatusSource(
+    {
+      agentActivityRuntime: runtimeWithSessions([
+        {
+          workspaceId: "workspace-1",
+          agentSessionId: "session-1",
+          agentTargetId: "local:codex",
+          provider: "codex",
+          usage: {
+            contextWindow: { usedTokens: 100, totalTokens: 1_000 },
+            quotas: []
+          }
+        },
+        {
+          workspaceId: "workspace-1",
+          agentSessionId: "session-2",
+          agentTargetId: "local:codex",
+          provider: "codex",
+          usage: {
+            contextWindow: { usedTokens: 200, totalTokens: 2_000 },
+            quotas: []
+          }
+        }
+      ]),
+      agents: () => [agent] as never,
+      workspaceAgentProbes: {
+        list: (input: unknown) => {
+          listCalls.push(input);
+          const response = responses.shift();
+          if (!response) throw new Error("unexpected probe");
+          return response;
+        }
+      } as never,
+      workspaceId: "workspace-1"
+    },
+    { now: () => currentTime }
+  );
+  const firstObserved = createObserver();
+  const secondObserved = createObserver();
+  const closeFirst = source.open(
+    statusQuery("session-1"),
+    firstObserved.observer
+  );
+  source.open(statusQuery("session-2"), secondObserved.observer);
+  await Promise.resolve();
+  assert.equal(listCalls.length, 1);
+
+  closeFirst();
+  firstProbe.resolve(probeSnapshot(500));
+  await secondObserved.completed;
+  assert.deepEqual(firstObserved.frames, []);
+  assert.deepEqual(secondObserved.frames[0]?.value.contextWindow, {
+    usedTokens: 200,
+    totalTokens: 2_000
+  });
+
+  const debouncedObserved = createObserver();
+  source.open(statusQuery("session-1"), debouncedObserved.observer);
+  await debouncedObserved.completed;
+  assert.deepEqual(
+    debouncedObserved.frames.map((frame) => frame.kind),
+    ["snapshot"]
+  );
+  assert.deepEqual(debouncedObserved.frames[0]?.value.contextWindow, {
+    usedTokens: 100,
+    totalTokens: 1_000
+  });
+  assert.equal(listCalls.length, 1);
+
+  currentTime += 5_000;
+  const revalidatingObserved = createObserver();
+  source.open(statusQuery("session-1"), revalidatingObserved.observer);
+  assert.deepEqual(
+    revalidatingObserved.frames.map((frame) => frame.kind),
+    ["snapshot"]
+  );
+  await Promise.resolve();
+  assert.equal(listCalls.length, 2);
+
+  secondProbe.resolve(probeSnapshot(600));
+  await revalidatingObserved.completed;
+  assert.deepEqual(
+    revalidatingObserved.frames.map((frame) => frame.kind),
+    ["snapshot", "refreshed"]
+  );
+  assert.equal(
+    revalidatingObserved.frames[1]?.value.limitsCapturedAtUnixMs,
+    600
+  );
+
+  currentTime += 60 * 60_000 + 1;
+  const expiredObserved = createObserver();
+  source.open(statusQuery("session-1"), expiredObserved.observer);
+  assert.equal(expiredObserved.frames.length, 0);
+  await Promise.resolve();
+  assert.equal(listCalls.length, 3);
+
+  thirdProbe.resolve(probeSnapshot(700));
+  await expiredObserved.completed;
+  assert.deepEqual(
+    expiredObserved.frames.map((frame) => frame.kind),
+    ["refreshed"]
+  );
+});
+
 function createObserver(): {
   completed: Promise<void>;
   errors: AgentStatusSourceError[];
@@ -152,4 +271,41 @@ function runtimeWithSessions(sessions: readonly unknown[]) {
   return {
     getSnapshot: () => ({ sessions })
   } as never;
+}
+
+function statusQuery(agentSessionId: string) {
+  return {
+    agentSessionId,
+    forceRefresh: true,
+    reason: "agent-info" as const,
+    scopeKey: "local:codex"
+  };
+}
+
+function probeSnapshot(capturedAtUnixMs: number) {
+  return {
+    capturedAtUnixMs,
+    providers: [
+      {
+        availability: { detailsVisible: false, status: "available" as const },
+        provider: "codex",
+        usage: {
+          capturedAtUnixMs,
+          quotas: [{ percentRemaining: 70, quotaType: "weekly" }]
+        }
+      }
+    ],
+    workspaceId: "workspace-1"
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolvePromise = (_value: T): void => undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: resolvePromise };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentStatusSource.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentStatusSource.ts
@@ -8,10 +8,23 @@ import type {
 
 interface DesktopAgentStatusSourceInput {
   agentActivityRuntime: AgentGUIProps["agentActivityRuntime"];
-  agents: readonly AgentGUIAgent[];
+  agents: readonly AgentGUIAgent[] | (() => readonly AgentGUIAgent[]);
   workspaceAgentProbes: AgentHostInputApi["workspaceAgentProbes"];
   workspaceId: string;
 }
+
+interface DesktopWorkspaceAgentStatusSourceOptions {
+  forcedRefreshDebounceMs?: number;
+  now?: () => number;
+  retainedSnapshotMs?: number;
+}
+
+type WorkspaceAgentProbeSnapshot = Awaited<
+  ReturnType<NonNullable<AgentHostInputApi["workspaceAgentProbes"]>["list"]>
+>;
+
+const desktopStatusRetainedSnapshotMs = 60 * 60_000;
+const desktopStatusForcedRefreshDebounceMs = 5_000;
 
 /**
  * Adapts Desktop's canonical activity/probe ports to AgentGUI's bounded status
@@ -21,57 +34,29 @@ interface DesktopAgentStatusSourceInput {
 export function createDesktopAgentStatusSource(
   input: DesktopAgentStatusSourceInput
 ): AgentStatusSource {
-  const workspaceId = input.workspaceId.trim();
-  const agentsByTargetId = new Map(
-    input.agents.map((agent) => [agent.agentTargetId.trim(), agent] as const)
-  );
-
   return {
     open(query, observer) {
       let closed = false;
-      const agent = agentsByTargetId.get(query.scopeKey.trim());
-      if (!workspaceId || !agent || !input.workspaceAgentProbes) {
-        observer.onError({
-          code: agent && workspaceId ? "unavailable" : "invalid_target"
-        });
+      const request = resolveDesktopAgentStatusRequest(input, query);
+      if ("errorCode" in request) {
+        observer.onError({ code: request.errorCode });
         return () => {
           closed = true;
         };
       }
 
-      const context = resolveDesktopAgentStatusContext({
-        agentActivityRuntime: input.agentActivityRuntime,
-        agentSessionId: query.agentSessionId,
-        agentTargetId: agent.agentTargetId,
-        provider: agent.provider,
-        workspaceId
-      });
-      if (context === null) {
-        observer.onError({ code: "invalid_target" });
-        return () => {
-          closed = true;
-        };
-      }
-
-      void input.workspaceAgentProbes
+      void request.workspaceAgentProbes
         .list({
           includeUsage: true,
-          providers: [agent.provider],
+          providers: [request.agent.provider],
           refresh: true,
-          workspaceId
+          workspaceId: request.workspaceId
         })
         .then((snapshot) => {
           if (closed) return;
-          const probe = snapshot.providers.find(
-            (candidate) => candidate.provider === agent.provider
-          );
           observer.onFrame({
             kind: "refreshed",
-            value: statusValueFromDesktopProbe(
-              context,
-              probe,
-              snapshot.capturedAtUnixMs
-            )
+            value: statusValueFromDesktopProbeSnapshot(request, snapshot)
           });
           observer.onComplete();
         })
@@ -86,6 +71,213 @@ export function createDesktopAgentStatusSource(
       };
     }
   };
+}
+
+/**
+ * Shares Provider probe work across AgentGUI surfaces without sharing their
+ * query, loading, or close state.
+ */
+export function createDesktopWorkspaceAgentStatusSource(
+  input: DesktopAgentStatusSourceInput,
+  options: DesktopWorkspaceAgentStatusSourceOptions = {}
+): AgentStatusSource {
+  const now = options.now ?? Date.now;
+  const retainedSnapshotMs =
+    options.retainedSnapshotMs ?? desktopStatusRetainedSnapshotMs;
+  const forcedRefreshDebounceMs =
+    options.forcedRefreshDebounceMs ?? desktopStatusForcedRefreshDebounceMs;
+  const retainedByProvider = new Map<
+    string,
+    { receivedAtUnixMs: number; snapshot: WorkspaceAgentProbeSnapshot }
+  >();
+  const refreshByProvider = new Map<
+    string,
+    Promise<WorkspaceAgentProbeSnapshot>
+  >();
+  const lastRefreshAtByProvider = new Map<string, number>();
+
+  return {
+    open(query, observer) {
+      let closed = false;
+      const request = resolveDesktopAgentStatusRequest(input, query);
+      if ("errorCode" in request) {
+        observer.onError({ code: request.errorCode });
+        return () => {
+          closed = true;
+        };
+      }
+
+      const requestedAt = now();
+      pruneDesktopAgentStatusCache({
+        lastRefreshAtByProvider,
+        retainedByProvider,
+        retainedSnapshotMs,
+        requestedAt
+      });
+      const provider = request.agent.provider;
+      const retained = retainedByProvider.get(provider);
+      if (retained) {
+        observer.onFrame({
+          kind: "snapshot",
+          value: statusValueFromDesktopProbeSnapshot(request, retained.snapshot)
+        });
+      }
+
+      let refresh = refreshByProvider.get(provider);
+      const lastRefreshAt = lastRefreshAtByProvider.get(provider);
+      if (
+        !refresh &&
+        lastRefreshAt !== undefined &&
+        requestedAt - lastRefreshAt < forcedRefreshDebounceMs
+      ) {
+        if (retained) {
+          observer.onComplete();
+        } else {
+          observer.onError({ code: "unavailable" });
+        }
+        return () => {
+          closed = true;
+        };
+      }
+
+      if (!refresh) {
+        lastRefreshAtByProvider.set(provider, requestedAt);
+        refresh = Promise.resolve().then(() =>
+          request.workspaceAgentProbes.list({
+            includeUsage: true,
+            providers: [provider],
+            refresh: true,
+            workspaceId: request.workspaceId
+          })
+        );
+        refreshByProvider.set(provider, refresh);
+        void refresh.then(
+          (snapshot) => {
+            retainedByProvider.set(provider, {
+              receivedAtUnixMs: now(),
+              snapshot
+            });
+            if (refreshByProvider.get(provider) === refresh) {
+              refreshByProvider.delete(provider);
+            }
+          },
+          () => {
+            if (refreshByProvider.get(provider) === refresh) {
+              refreshByProvider.delete(provider);
+            }
+          }
+        );
+      }
+
+      void refresh.then(
+        (snapshot) => {
+          if (closed) return;
+          observer.onFrame({
+            kind: "refreshed",
+            value: statusValueFromDesktopProbeSnapshot(request, snapshot)
+          });
+          observer.onComplete();
+        },
+        () => {
+          if (!closed) {
+            observer.onError({ code: "unavailable" });
+          }
+        }
+      );
+      return () => {
+        closed = true;
+      };
+    }
+  };
+}
+
+function resolveDesktopAgentStatusRequest(
+  input: DesktopAgentStatusSourceInput,
+  query: { agentSessionId?: string | null; scopeKey: string }
+):
+  | {
+      agent: AgentGUIAgent;
+      context: Pick<
+        AgentStatusValue,
+        "agentSessionId" | "contextState" | "contextWindow"
+      >;
+      workspaceAgentProbes: NonNullable<
+        AgentHostInputApi["workspaceAgentProbes"]
+      >;
+      workspaceId: string;
+    }
+  | { errorCode: "invalid_target" | "unavailable" } {
+  const workspaceId = input.workspaceId.trim();
+  const agents =
+    typeof input.agents === "function" ? input.agents() : input.agents;
+  const agent = agents.find(
+    (candidate) => candidate.agentTargetId.trim() === query.scopeKey.trim()
+  );
+  if (!workspaceId || !agent) {
+    return { errorCode: "invalid_target" };
+  }
+  if (!input.workspaceAgentProbes) {
+    return { errorCode: "unavailable" };
+  }
+  const context = resolveDesktopAgentStatusContext({
+    agentActivityRuntime: input.agentActivityRuntime,
+    agentSessionId: query.agentSessionId,
+    agentTargetId: agent.agentTargetId,
+    provider: agent.provider,
+    workspaceId
+  });
+  if (context === null) {
+    return { errorCode: "invalid_target" };
+  }
+  return {
+    agent,
+    context,
+    workspaceAgentProbes: input.workspaceAgentProbes,
+    workspaceId
+  };
+}
+
+function statusValueFromDesktopProbeSnapshot(
+  request: {
+    agent: AgentGUIAgent;
+    context: Pick<
+      AgentStatusValue,
+      "agentSessionId" | "contextState" | "contextWindow"
+    >;
+  },
+  snapshot: WorkspaceAgentProbeSnapshot
+): AgentStatusValue {
+  return statusValueFromDesktopProbe(
+    request.context,
+    snapshot.providers.find(
+      (candidate) => candidate.provider === request.agent.provider
+    ),
+    snapshot.capturedAtUnixMs
+  );
+}
+
+function pruneDesktopAgentStatusCache(input: {
+  lastRefreshAtByProvider: Map<string, number>;
+  retainedByProvider: Map<
+    string,
+    { receivedAtUnixMs: number; snapshot: WorkspaceAgentProbeSnapshot }
+  >;
+  retainedSnapshotMs: number;
+  requestedAt: number;
+}): void {
+  for (const [provider, retained] of input.retainedByProvider) {
+    if (
+      input.requestedAt - retained.receivedAtUnixMs >
+      input.retainedSnapshotMs
+    ) {
+      input.retainedByProvider.delete(provider);
+    }
+  }
+  for (const [provider, refreshedAt] of input.lastRefreshAtByProvider) {
+    if (input.requestedAt - refreshedAt > input.retainedSnapshotMs) {
+      input.lastRefreshAtByProvider.delete(provider);
+    }
+  }
 }
 
 function resolveDesktopAgentStatusContext(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -82,6 +82,7 @@ import {
 function DesktopAgentGUISurfaceImpl({
   agentActivityRuntime,
   agentHostApi,
+  agentStatusSource,
   tuttiModePlanReviewRuntime,
   appCenterService,
   agentProviderStatusService,
@@ -332,12 +333,15 @@ function DesktopAgentGUISurfaceImpl({
     },
     [desktopPreferencesService, nodeProvider, runtimeApi, workspaceId]
   );
-  const agentStatusController = useDesktopAgentStatusController({
-    agentActivityRuntime,
-    agents,
-    workspaceAgentProbes: agentHostApi.workspaceAgentProbes,
-    workspaceId
-  });
+  const agentStatusController = useDesktopAgentStatusController(
+    {
+      agentActivityRuntime,
+      agents,
+      workspaceAgentProbes: agentHostApi.workspaceAgentProbes,
+      workspaceId
+    },
+    agentStatusSource
+  );
   const handleOpenSessionActivationError = useCallback(
     (input: { agentSessionId: string; error: unknown }) => {
       Toast.Error(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchModel.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchModel.ts
@@ -6,7 +6,8 @@ import type {
   AgentGUIComposerAppendRequest,
   AgentGUIAgentsEmptyRenderer,
   AgentGUIProps,
-  AgentHostInputApi
+  AgentHostInputApi,
+  AgentStatusSource
 } from "@tutti-os/agent-gui";
 import type { AgentContextMentionProvider } from "@tutti-os/agent-gui/context-mention-provider";
 import {
@@ -59,6 +60,7 @@ export interface DesktopAgentGUISurfaceContext {
 export interface DesktopAgentGUIWorkbenchBodyProps {
   agentActivityRuntime: AgentActivityRuntime;
   agentHostApi: AgentHostInputApi;
+  agentStatusSource?: AgentStatusSource;
   tuttiModePlanReviewRuntime: NonNullable<
     AgentGUIProps["tuttiModePlanReviewRuntime"]
   >;
@@ -158,6 +160,7 @@ export function areDesktopAgentGUIWorkbenchBodyPropsEqual(
   return (
     previous.agentActivityRuntime === next.agentActivityRuntime &&
     previous.agentHostApi === next.agentHostApi &&
+    previous.agentStatusSource === next.agentStatusSource &&
     previous.tuttiModePlanReviewRuntime === next.tuttiModePlanReviewRuntime &&
     previous.appCenterService === next.appCenterService &&
     previous.agentProviderStatusService === next.agentProviderStatusService &&

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentStatusController.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentStatusController.ts
@@ -1,7 +1,8 @@
 import { useEffect, useMemo } from "react";
 import {
   createAgentStatusController,
-  type AgentStatusController
+  type AgentStatusController,
+  type AgentStatusSource
 } from "@tutti-os/agent-gui";
 import { createDesktopAgentStatusSource } from "../services/createDesktopAgentStatusSource.ts";
 
@@ -11,19 +12,22 @@ type DesktopAgentStatusControllerInput = Parameters<
 
 /** Owns the Desktop host adapter/controller lifetime for one workspace scope. */
 export function useDesktopAgentStatusController(
-  input: DesktopAgentStatusControllerInput
+  input: DesktopAgentStatusControllerInput,
+  workspaceSource?: AgentStatusSource
 ): AgentStatusController {
-  const controller = useMemo(
-    () =>
-      createAgentStatusController({
-        source: createDesktopAgentStatusSource(input)
-      }),
+  const source = useMemo(
+    () => workspaceSource ?? createDesktopAgentStatusSource(input),
     [
       input.agentActivityRuntime,
       input.agents,
       input.workspaceAgentProbes,
-      input.workspaceId
+      input.workspaceId,
+      workspaceSource
     ]
+  );
+  const controller = useMemo(
+    () => createAgentStatusController({ source }),
+    [source]
   );
   useEffect(() => () => controller.close(), [controller]);
   return controller;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -44,6 +44,7 @@ import type { IWorkspaceFileManagerService } from "@renderer/features/workspace-
 import type { IWorkspaceFilePreviewSurfaceHost } from "@renderer/features/workspace-file-preview";
 import type { IReporterService } from "@renderer/features/analytics";
 import { createDesktopAgentGUIWorkbenchHostInput } from "@renderer/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts";
+import { createDesktopWorkspaceAgentStatusSource } from "@renderer/features/workspace-agent/services/createDesktopAgentStatusSource.ts";
 import { requestWorkspaceAgentGuiLaunch } from "@renderer/features/workspace-agent/services/workspaceAgentGuiLaunchCoordinator.ts";
 import type { IAgentProviderStatusService as AgentProviderStatusService } from "@renderer/features/workspace-agent/services/agentProviderStatusService.interface.ts";
 import type { IAgentQuickPromptService as AgentQuickPromptService } from "@renderer/features/workspace-agent/services/agentQuickPromptService.interface.ts";
@@ -120,6 +121,13 @@ export function createWorkspaceAgentGuiContribution(input: {
     workspaceUserProjectService: input.workspaceUserProjectService,
     workspaceId: input.workspaceId
   });
+  const workspaceAgentStatusSource = createDesktopWorkspaceAgentStatusSource({
+    agentActivityRuntime: agentGUIWorkbenchHostInput.agentActivityRuntime,
+    agents: () => input.agentsService.getSnapshot().agents,
+    workspaceAgentProbes:
+      agentGUIWorkbenchHostInput.agentHostApi.workspaceAgentProbes,
+    workspaceId: input.workspaceId
+  });
   const trackWorkspaceAgentGUIEngagement =
     agentGUIWorkbenchHostInput.createAgentGUIEngagementEventSink("workspace");
   const sessionEngine = input.workspaceAgentActivityService.getSessionEngine(
@@ -158,6 +166,7 @@ export function createWorkspaceAgentGuiContribution(input: {
     return createElement(DesktopWorkspaceAgentGUIWorkbenchBody, {
       agentActivityRuntime: agentGUIWorkbenchHostInput.agentActivityRuntime,
       agentHostApi: agentGUIWorkbenchHostInput.agentHostApi,
+      agentStatusSource: workspaceAgentStatusSource,
       tuttiModePlanReviewRuntime:
         agentGUIWorkbenchHostInput.tuttiModePlanReviewRuntime,
       appCenterService: input.appCenterService,

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -849,11 +849,12 @@ is currently visible; the carousel waits for that visibility and then browser
 idle time before creating its WebGL renderer. This keeps Genie restore work out
 of the WebGL creation task without exposing Genie state to AgentGUI. An existing
 scene remains allocated while the normal presentation is hidden, but cancels
-all render, spring, and record-spin animation frames until visibility returns.
-While visible, only the focused AgentGUI runs the decorative record spin, and
-that spin renders at no more than 30 frames per second. Unfocused surfaces keep
-their current frame and WebGL resources so focus does not rebuild the scene;
-explicit carousel interaction continues to use the full-rate spring path.
+all render and spring animation frames until visibility returns. Once
+initialized, WebGL renders only for texture or size changes and carousel
+selection changes; the spring stops requesting frames after it settles. The
+DOM turntable record uses a compositor animation only in the active visible
+AgentGUI. Inactive surfaces preserve their current visual state without a
+JavaScript animation loop.
 WebGL scene readiness remains local presentation state; it must not enter
 `AgentActivityRuntime`, the workspace engine, or Workbench node state.
 

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -162,6 +162,15 @@ provider-derived fallback. The active conversation id is the request Session
 identity because it exists before detail hydration; raw Session chrome remains
 presentation data.
 
+Tutti Desktop creates one status source per workspace renderer and injects it
+into every AgentGUI surface in that workspace. The source shares the one-hour
+Provider snapshot, five-second refresh debounce, and in-flight Provider probe
+by provider, while each surface keeps its own controller and therefore its own
+query, loading, close, and stale-response state. Sharing the controller itself
+is invalid because one surface could replace or close another surface's active
+request. Standalone renderer processes have their own source; the Electron main
+process remains the cross-window short-lived Provider cache.
+
 A source emits at most one cached `snapshot` followed by at most one
 `refreshed` value, then completes. Backend probing may continue independently
 to fill a host-owned cache after the presentation request is canceled; late
@@ -804,8 +813,9 @@ Opening a panel/window creates presentation state only. It does not clone a Sess
 Workbench previews must not mount a second AgentGUI tree. Genie capture prefers
 the host-provided native image and clones the visible node DOM into a texture
 only after native capture fails or exceeds its bounded wait. Electron hosts
-capture the node region once, retain the full crop for Genie, and resize a copy
-for the Dock. The Genie path must not reuse an undersized Dock image. Dock popup
+pass the sanitized node region directly to `webContents.capturePage`, retain
+the returned region for Genie, and resize a copy for the Dock. The Genie path
+must not reuse an undersized Dock image. Dock popup
 cards and minimized slots use the bounded image and its cache. If no captured
 image exists, those Dock surfaces show their placeholder; they do not mount
 AgentGUI as a fallback. AgentGUI therefore has no preview-mode rendering
@@ -837,8 +847,10 @@ The empty AgentGUI Hero renders its existing DOM player before initializing the
 optional WebGL carousel. A host projects whether the normal window presentation
 is currently visible; the carousel waits for that visibility and then browser
 idle time before creating its WebGL renderer. This keeps Genie restore work out
-of the WebGL creation task without exposing Genie state to AgentGUI. WebGL scene
-readiness remains local presentation state; it must not enter
+of the WebGL creation task without exposing Genie state to AgentGUI. An existing
+scene remains allocated while the normal presentation is hidden, but cancels
+all render, spring, and record-spin animation frames until visibility returns.
+WebGL scene readiness remains local presentation state; it must not enter
 `AgentActivityRuntime`, the workspace engine, or Workbench node state.
 
 The shared Workbench Header owns conversation-identity visibility. When no

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -850,6 +850,10 @@ idle time before creating its WebGL renderer. This keeps Genie restore work out
 of the WebGL creation task without exposing Genie state to AgentGUI. An existing
 scene remains allocated while the normal presentation is hidden, but cancels
 all render, spring, and record-spin animation frames until visibility returns.
+While visible, only the focused AgentGUI runs the decorative record spin, and
+that spin renders at no more than 30 frames per second. Unfocused surfaces keep
+their current frame and WebGL resources so focus does not rebuild the scene;
+explicit carousel interaction continues to use the full-rate spring path.
 WebGL scene readiness remains local presentation state; it must not enter
 `AgentActivityRuntime`, the workspace engine, or Workbench node state.
 

--- a/docs/architecture/workbench-dock-model.md
+++ b/docs/architecture/workbench-dock-model.md
@@ -258,6 +258,20 @@ better matches product-owned dock organization.
 
 Dock interaction should follow stable, entry-level rules.
 
+Dock magnification snapshots viewport and slot geometry once when a pointer
+session starts. Later animation frames derive centered or overflow-aligned slot
+positions from that snapshot and the sizes already written by the spring. They
+must not interleave per-frame `getBoundingClientRect()` reads with slot size
+writes. Resetting the interaction or changing slot membership invalidates the
+snapshot.
+
+Native popup previews pass the clamped target rectangle to Electron capture;
+they must not capture the whole `webContents` and crop afterward. Popup capture
+effects are keyed by preview identity and revision, not transient item arrays or
+callback references. Cleanup may fence stale UI writes, but it must retain the
+pending marker for a native capture that has already started until that capture
+settles, because Electron capture cannot be canceled.
+
 ### Matching
 
 For each dock entry, the host resolves matching nodes using:

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.spec.tsx
@@ -218,7 +218,6 @@ describe("AgentGUIHeroAgentCarousel", () => {
     const scene = {
       dispose: vi.fn(),
       moveTo: vi.fn(),
-      setRecordSpinActive: vi.fn(),
       setSize: vi.fn(),
       setVisible: vi.fn()
     };
@@ -259,14 +258,13 @@ describe("AgentGUIHeroAgentCarousel", () => {
     }
   });
 
-  it("keeps the scene mounted while focus controls record spin", async () => {
+  it("keeps only the active visible DOM record playing", async () => {
     const frames = installAnimationFrameQueue();
     const idle = installIdleCallbackQueue();
     vi.stubGlobal("Image", undefined);
     const scene = {
       dispose: vi.fn(),
       moveTo: vi.fn(),
-      setRecordSpinActive: vi.fn(),
       setSize: vi.fn(),
       setVisible: vi.fn()
     };
@@ -290,16 +288,31 @@ describe("AgentGUIHeroAgentCarousel", () => {
         frames.flushNext();
         idle.flushNext();
       });
-      expect(sceneCreate).toHaveBeenCalledWith(
-        expect.objectContaining({ recordSpinActive: false })
-      );
+      expect(
+        container.querySelector(".agent-gui-vinyl-player__record--playing")
+      ).toBeNull();
 
       await act(async () => {
         root.render(
           <AgentGUIHeroAgentCarousel isActive isVisible items={[item]} />
         );
       });
-      expect(scene.setRecordSpinActive).toHaveBeenLastCalledWith(true);
+      expect(
+        container.querySelector(".agent-gui-vinyl-player__record--playing")
+      ).not.toBeNull();
+
+      await act(async () => {
+        root.render(
+          <AgentGUIHeroAgentCarousel
+            isActive
+            isVisible={false}
+            items={[item]}
+          />
+        );
+      });
+      expect(
+        container.querySelector(".agent-gui-vinyl-player__record--playing")
+      ).toBeNull();
       expect(sceneCreate).toHaveBeenCalledOnce();
       expect(scene.dispose).not.toHaveBeenCalled();
     } finally {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.spec.tsx
@@ -210,4 +210,51 @@ describe("AgentGUIHeroAgentCarousel", () => {
       container.remove();
     }
   });
+
+  it("pauses and resumes an existing WebGL scene with host visibility", async () => {
+    const frames = installAnimationFrameQueue();
+    const idle = installIdleCallbackQueue();
+    vi.stubGlobal("Image", undefined);
+    const scene = {
+      dispose: vi.fn(),
+      moveTo: vi.fn(),
+      setSize: vi.fn(),
+      setVisible: vi.fn()
+    };
+    sceneCreate.mockReturnValue(scene);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(<AgentGUIHeroAgentCarousel isVisible items={[item]} />);
+      });
+      await act(async () => {
+        frames.flushNext();
+        frames.flushNext();
+        idle.flushNext();
+      });
+      expect(sceneCreate).toHaveBeenCalledOnce();
+
+      await act(async () => {
+        root.render(
+          <AgentGUIHeroAgentCarousel isVisible={false} items={[item]} />
+        );
+      });
+      expect(scene.setVisible).toHaveBeenLastCalledWith(false);
+
+      await act(async () => {
+        root.render(<AgentGUIHeroAgentCarousel isVisible items={[item]} />);
+      });
+      expect(scene.setVisible).toHaveBeenLastCalledWith(true);
+      expect(sceneCreate).toHaveBeenCalledOnce();
+      expect(scene.dispose).not.toHaveBeenCalled();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.spec.tsx
@@ -218,6 +218,7 @@ describe("AgentGUIHeroAgentCarousel", () => {
     const scene = {
       dispose: vi.fn(),
       moveTo: vi.fn(),
+      setRecordSpinActive: vi.fn(),
       setSize: vi.fn(),
       setVisible: vi.fn()
     };
@@ -248,6 +249,57 @@ describe("AgentGUIHeroAgentCarousel", () => {
         root.render(<AgentGUIHeroAgentCarousel isVisible items={[item]} />);
       });
       expect(scene.setVisible).toHaveBeenLastCalledWith(true);
+      expect(sceneCreate).toHaveBeenCalledOnce();
+      expect(scene.dispose).not.toHaveBeenCalled();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  });
+
+  it("keeps the scene mounted while focus controls record spin", async () => {
+    const frames = installAnimationFrameQueue();
+    const idle = installIdleCallbackQueue();
+    vi.stubGlobal("Image", undefined);
+    const scene = {
+      dispose: vi.fn(),
+      moveTo: vi.fn(),
+      setRecordSpinActive: vi.fn(),
+      setSize: vi.fn(),
+      setVisible: vi.fn()
+    };
+    sceneCreate.mockReturnValue(scene);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <AgentGUIHeroAgentCarousel
+            isActive={false}
+            isVisible
+            items={[item]}
+          />
+        );
+      });
+      await act(async () => {
+        frames.flushNext();
+        frames.flushNext();
+        idle.flushNext();
+      });
+      expect(sceneCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ recordSpinActive: false })
+      );
+
+      await act(async () => {
+        root.render(
+          <AgentGUIHeroAgentCarousel isActive isVisible items={[item]} />
+        );
+      });
+      expect(scene.setRecordSpinActive).toHaveBeenLastCalledWith(true);
       expect(sceneCreate).toHaveBeenCalledOnce();
       expect(scene.dispose).not.toHaveBeenCalled();
     } finally {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.tsx
@@ -124,7 +124,9 @@ export class AgentGUIHeroAgentCarousel extends Component<
     if (previousProps.isVisible !== this.props.isVisible) {
       if (this.props.isVisible === false) {
         this.cancelScheduledSceneMount();
+        this.scene?.setVisible(false);
       } else {
+        this.scene?.setVisible(true);
         this.scheduleSceneMount();
       }
     }
@@ -308,7 +310,9 @@ export class AgentGUIHeroAgentCarousel extends Component<
 
   private syncWheelListener(): void {
     const stage = this.stageRef.current;
-    const shouldAttach = Boolean(stage && this.interactive());
+    const shouldAttach = Boolean(
+      stage && this.props.isVisible !== false && this.interactive()
+    );
     if (shouldAttach && !this.wheelListenerAttached) {
       stage!.addEventListener("wheel", this.handleWheel, { passive: false });
       this.wheelListenerAttached = true;

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.tsx
@@ -131,10 +131,6 @@ export class AgentGUIHeroAgentCarousel extends Component<
         this.scheduleSceneMount();
       }
     }
-    if (previousProps.isActive !== this.props.isActive) {
-      this.scene?.setRecordSpinActive(this.props.isActive !== false);
-    }
-
     if (
       previousProps.activeAgentTargetId !== this.props.activeAgentTargetId ||
       previousProps.items !== this.props.items
@@ -284,7 +280,6 @@ export class AgentGUIHeroAgentCarousel extends Component<
       loadedCoverImages: this.state.coverImages,
       loadedBadgeImages: this.state.badgeImages,
       loadedImages: this.state.images,
-      recordSpinActive: this.props.isActive !== false,
       onSettle: this.handleSceneSettle
     });
     this.scene = scene;
@@ -520,7 +515,6 @@ export class AgentGUIHeroAgentCarousel extends Component<
   };
 
   private readonly handleCanvasLeave = (): void => {
-    this.scene?.clearHover();
     if (this.canvasRef.current) {
       this.canvasRef.current.style.cursor = "";
     }
@@ -549,7 +543,9 @@ export class AgentGUIHeroAgentCarousel extends Component<
             this.props.items[0] ??
             null
           }
-          isPlaying
+          isPlaying={
+            this.props.isActive !== false && this.props.isVisible !== false
+          }
         />
         <canvas
           ref={this.canvasRef}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.tsx
@@ -19,6 +19,7 @@ export interface AgentGUIHeroCarouselSelectInput {
 
 interface AgentGUIHeroAgentCarouselProps {
   activeAgentTargetId?: string | null;
+  isActive?: boolean;
   isVisible?: boolean;
   items: readonly AgentGUIAgentAvatarPresentation[];
   onProviderSelect?: (input: AgentGUIHeroCarouselSelectInput) => void;
@@ -129,6 +130,9 @@ export class AgentGUIHeroAgentCarousel extends Component<
         this.scene?.setVisible(true);
         this.scheduleSceneMount();
       }
+    }
+    if (previousProps.isActive !== this.props.isActive) {
+      this.scene?.setRecordSpinActive(this.props.isActive !== false);
     }
 
     if (
@@ -280,6 +284,7 @@ export class AgentGUIHeroAgentCarousel extends Component<
       loadedCoverImages: this.state.coverImages,
       loadedBadgeImages: this.state.badgeImages,
       loadedImages: this.state.images,
+      recordSpinActive: this.props.isActive !== false,
       onSettle: this.handleSceneSettle
     });
     this.scene = scene;

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIVinylPlayer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIVinylPlayer.tsx
@@ -48,10 +48,10 @@ export function AgentGUIVinylPlayer({
       </div>
       <div className="agent-gui-vinyl-player__platter">
         <div className="agent-gui-vinyl-player__platter-inner">
-          <motion.div
-            className="agent-gui-vinyl-player__record"
-            animate={{ rotate: isPlaying ? 360 : 0 }}
-            transition={{ duration: 4, repeat: Infinity, ease: "linear" }}
+          <div
+            className={`agent-gui-vinyl-player__record${
+              isPlaying ? " agent-gui-vinyl-player__record--playing" : ""
+            }`}
           >
             {Array.from({ length: 18 }, (_, index) => (
               <span
@@ -66,7 +66,7 @@ export function AgentGUIVinylPlayer({
                 <img src={selectedAgentCover} alt="" />
               ) : null}
             </span>
-          </motion.div>
+          </div>
         </div>
       </div>
       <img

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.spec.ts
@@ -415,6 +415,69 @@ describe("AgentGuiHeroCarouselScene", () => {
     scene?.dispose();
   });
 
+  it("pauses only the decorative spin while inactive", () => {
+    let nextFrameID = 1;
+    const pendingFrames = new Map<number, FrameRequestCallback>();
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      const frameID = nextFrameID;
+      nextFrameID += 1;
+      pendingFrames.set(frameID, callback);
+      return frameID;
+    });
+    globalThis.cancelAnimationFrame = vi.fn((frameID) => {
+      pendingFrames.delete(frameID);
+    });
+    const scene = createSceneWithBadge(null, { recordSpinActive: false });
+
+    scene?.setVisible(false);
+    scene?.setVisible(true);
+    expect(pendingFrames.size).toBe(0);
+
+    scene?.setRecordSpinActive(true);
+    expect(pendingFrames.size).toBe(1);
+
+    scene?.setRecordSpinActive(false);
+    expect(pendingFrames.size).toBe(0);
+    scene?.dispose();
+  });
+
+  it("bounds decorative spin rendering to 30 frames per second", () => {
+    let nextFrameID = 1;
+    const pendingFrames = new Map<number, FrameRequestCallback>();
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      const frameID = nextFrameID;
+      nextFrameID += 1;
+      pendingFrames.set(frameID, callback);
+      return frameID;
+    });
+    globalThis.cancelAnimationFrame = vi.fn((frameID) => {
+      pendingFrames.delete(frameID);
+    });
+    const scene = createSceneWithBadge(null);
+    scene?.setVisible(false);
+    scene?.setVisible(true);
+    threeState.renderCount = 0;
+
+    const runNextFrame = (now: number): void => {
+      const next = pendingFrames.entries().next().value as
+        | [number, FrameRequestCallback]
+        | undefined;
+      expect(next).toBeDefined();
+      pendingFrames.delete(next![0]);
+      next![1](now);
+    };
+
+    runNextFrame(0);
+    runNextFrame(8);
+    runNextFrame(16);
+    runNextFrame(25);
+    expect(threeState.renderCount).toBe(1);
+
+    runNextFrame(34);
+    expect(threeState.renderCount).toBe(2);
+    scene?.dispose();
+  });
+
   it("disposes a rejected texture and keeps the fallback when WebGL upload fails", () => {
     threeState.failTextureUpload = true;
     const scene = createSceneWithBadge(createLoadedImage());
@@ -440,7 +503,8 @@ function createLoadedImage(): HTMLImageElement {
 }
 
 function createSceneWithBadge(
-  badgeImage: HTMLImageElement | null
+  badgeImage: HTMLImageElement | null,
+  options: { recordSpinActive?: boolean } = {}
 ): AgentGuiHeroCarouselScene | null {
   const loadedImage = createLoadedImage();
   return AgentGuiHeroCarouselScene.create({
@@ -461,6 +525,7 @@ function createSceneWithBadge(
     loadedBadgeImages: [badgeImage],
     loadedCoverImages: [null],
     loadedImages: [loadedImage],
+    recordSpinActive: options.recordSpinActive,
     onSettle: vi.fn()
   });
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.spec.ts
@@ -385,6 +385,66 @@ describe("AgentGuiHeroCarouselScene", () => {
     scene?.dispose();
   });
 
+  it("settles to zero scheduled frames after its static render", () => {
+    let nextFrameID = 1;
+    const pendingFrames = new Map<number, FrameRequestCallback>();
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      const frameID = nextFrameID;
+      nextFrameID += 1;
+      pendingFrames.set(frameID, callback);
+      return frameID;
+    });
+    globalThis.cancelAnimationFrame = vi.fn((frameID) => {
+      pendingFrames.delete(frameID);
+    });
+    const scene = createSceneWithBadge(null);
+
+    expect(scene).not.toBeNull();
+    expect(pendingFrames.size).toBeGreaterThan(0);
+    for (const [frameID, callback] of [...pendingFrames]) {
+      pendingFrames.delete(frameID);
+      callback(0);
+    }
+    expect(pendingFrames.size).toBe(0);
+    scene?.dispose();
+  });
+
+  it("stops scheduling frames after an interactive spring settles", () => {
+    let nextFrameID = 1;
+    const pendingFrames = new Map<number, FrameRequestCallback>();
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      const frameID = nextFrameID;
+      nextFrameID += 1;
+      pendingFrames.set(frameID, callback);
+      return frameID;
+    });
+    globalThis.cancelAnimationFrame = vi.fn((frameID) => {
+      pendingFrames.delete(frameID);
+    });
+    const scene = createSceneWithBadge(null);
+
+    for (const [frameID, callback] of [...pendingFrames]) {
+      pendingFrames.delete(frameID);
+      callback(0);
+    }
+    scene?.stepBy(1);
+
+    let now = 16;
+    while (pendingFrames.size > 0 && now < 5_000) {
+      const next = pendingFrames.entries().next().value as [
+        number,
+        FrameRequestCallback
+      ];
+      pendingFrames.delete(next[0]);
+      next[1](now);
+      now += 16;
+    }
+
+    expect(pendingFrames.size).toBe(0);
+    expect(now).toBeLessThan(5_000);
+    scene?.dispose();
+  });
+
   it("cancels every frame while hidden and resumes without rebuilding", () => {
     let nextFrameID = 1;
     const pendingFrames = new Map<number, FrameRequestCallback>();
@@ -411,70 +471,7 @@ describe("AgentGuiHeroCarouselScene", () => {
     expect(pendingFrames.size).toBe(0);
 
     scene?.setVisible(true);
-    expect(pendingFrames.size).toBeGreaterThan(0);
-    scene?.dispose();
-  });
-
-  it("pauses only the decorative spin while inactive", () => {
-    let nextFrameID = 1;
-    const pendingFrames = new Map<number, FrameRequestCallback>();
-    globalThis.requestAnimationFrame = vi.fn((callback) => {
-      const frameID = nextFrameID;
-      nextFrameID += 1;
-      pendingFrames.set(frameID, callback);
-      return frameID;
-    });
-    globalThis.cancelAnimationFrame = vi.fn((frameID) => {
-      pendingFrames.delete(frameID);
-    });
-    const scene = createSceneWithBadge(null, { recordSpinActive: false });
-
-    scene?.setVisible(false);
-    scene?.setVisible(true);
-    expect(pendingFrames.size).toBe(0);
-
-    scene?.setRecordSpinActive(true);
     expect(pendingFrames.size).toBe(1);
-
-    scene?.setRecordSpinActive(false);
-    expect(pendingFrames.size).toBe(0);
-    scene?.dispose();
-  });
-
-  it("bounds decorative spin rendering to 30 frames per second", () => {
-    let nextFrameID = 1;
-    const pendingFrames = new Map<number, FrameRequestCallback>();
-    globalThis.requestAnimationFrame = vi.fn((callback) => {
-      const frameID = nextFrameID;
-      nextFrameID += 1;
-      pendingFrames.set(frameID, callback);
-      return frameID;
-    });
-    globalThis.cancelAnimationFrame = vi.fn((frameID) => {
-      pendingFrames.delete(frameID);
-    });
-    const scene = createSceneWithBadge(null);
-    scene?.setVisible(false);
-    scene?.setVisible(true);
-    threeState.renderCount = 0;
-
-    const runNextFrame = (now: number): void => {
-      const next = pendingFrames.entries().next().value as
-        | [number, FrameRequestCallback]
-        | undefined;
-      expect(next).toBeDefined();
-      pendingFrames.delete(next![0]);
-      next![1](now);
-    };
-
-    runNextFrame(0);
-    runNextFrame(8);
-    runNextFrame(16);
-    runNextFrame(25);
-    expect(threeState.renderCount).toBe(1);
-
-    runNextFrame(34);
-    expect(threeState.renderCount).toBe(2);
     scene?.dispose();
   });
 
@@ -503,8 +500,7 @@ function createLoadedImage(): HTMLImageElement {
 }
 
 function createSceneWithBadge(
-  badgeImage: HTMLImageElement | null,
-  options: { recordSpinActive?: boolean } = {}
+  badgeImage: HTMLImageElement | null
 ): AgentGuiHeroCarouselScene | null {
   const loadedImage = createLoadedImage();
   return AgentGuiHeroCarouselScene.create({
@@ -525,7 +521,6 @@ function createSceneWithBadge(
     loadedBadgeImages: [badgeImage],
     loadedCoverImages: [null],
     loadedImages: [loadedImage],
-    recordSpinActive: options.recordSpinActive,
     onSettle: vi.fn()
   });
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.spec.ts
@@ -385,6 +385,36 @@ describe("AgentGuiHeroCarouselScene", () => {
     scene?.dispose();
   });
 
+  it("cancels every frame while hidden and resumes without rebuilding", () => {
+    let nextFrameID = 1;
+    const pendingFrames = new Map<number, FrameRequestCallback>();
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      const frameID = nextFrameID;
+      nextFrameID += 1;
+      pendingFrames.set(frameID, callback);
+      return frameID;
+    });
+    globalThis.cancelAnimationFrame = vi.fn((frameID) => {
+      pendingFrames.delete(frameID);
+    });
+    const scene = createSceneWithBadge(null);
+
+    expect(scene).not.toBeNull();
+    expect(pendingFrames.size).toBeGreaterThan(0);
+
+    scene?.setVisible(false);
+    expect(pendingFrames.size).toBe(0);
+
+    const hiddenRenderCount = threeState.renderCount;
+    scene?.setSize(320, 112);
+    expect(threeState.renderCount).toBe(hiddenRenderCount);
+    expect(pendingFrames.size).toBe(0);
+
+    scene?.setVisible(true);
+    expect(pendingFrames.size).toBeGreaterThan(0);
+    scene?.dispose();
+  });
+
   it("disposes a rejected texture and keeps the fallback when WebGL upload fails", () => {
     threeState.failTextureUpload = true;
     const scene = createSceneWithBadge(createLoadedImage());

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.ts
@@ -144,6 +144,7 @@ export class AgentGuiHeroCarouselScene {
   private lastFrameAt: number | null = null;
   private lastRecordSpinFrameAt: number | null = null;
   private hoveredTile: AgentGuiHeroCarouselTile | null = null;
+  private visible = true;
   private disposed = false;
 
   private constructor(options: AgentGuiHeroCarouselSceneOptions) {
@@ -286,7 +287,39 @@ export class AgentGuiHeroCarouselScene {
     // setSize clears the drawing buffer. Render synchronously so a window
     // resize never exposes that cleared frame while the next animation frame
     // is pending during interactive window dragging.
-    this.renderer.render(this.scene, this.camera);
+    if (this.visible) {
+      this.renderer.render(this.scene, this.camera);
+    }
+  }
+
+  setVisible(visible: boolean): void {
+    if (this.disposed || this.visible === visible) {
+      return;
+    }
+    this.visible = visible;
+    this.cancelScheduledFrames();
+    if (!visible) {
+      return;
+    }
+
+    const hasPendingMotion =
+      Math.abs(this.target - this.scroll) > SPRING_SETTLE_EPSILON ||
+      Math.abs(this.velocity) > SPRING_SETTLE_VELOCITY;
+    if (this.prefersReducedMotion()) {
+      this.scroll = this.target;
+      this.velocity = 0;
+      this.applyPoses();
+      this.requestRender();
+      if (hasPendingMotion) {
+        this.onSettle(this.targetIndex());
+      }
+      return;
+    }
+
+    if (hasPendingMotion) {
+      this.animate();
+    }
+    this.startRecordSpin();
   }
 
   // Agent index of the tile slot the wheel is heading to.
@@ -406,18 +439,7 @@ export class AgentGuiHeroCarouselScene {
 
   dispose(): void {
     this.disposed = true;
-    if (this.renderFrameHandle !== null) {
-      cancelAnimationFrame(this.renderFrameHandle);
-      this.renderFrameHandle = null;
-    }
-    if (this.springFrameHandle !== null) {
-      cancelAnimationFrame(this.springFrameHandle);
-      this.springFrameHandle = null;
-    }
-    if (this.recordSpinFrameHandle !== null) {
-      cancelAnimationFrame(this.recordSpinFrameHandle);
-      this.recordSpinFrameHandle = null;
-    }
+    this.cancelScheduledFrames();
     for (const tile of this.tiles) {
       tile.badgeMesh.geometry.dispose();
       tile.badgeMesh.material.dispose();
@@ -438,6 +460,23 @@ export class AgentGuiHeroCarouselScene {
     this.renderer.dispose();
   }
 
+  private cancelScheduledFrames(): void {
+    if (this.renderFrameHandle !== null) {
+      cancelAnimationFrame(this.renderFrameHandle);
+      this.renderFrameHandle = null;
+    }
+    if (this.springFrameHandle !== null) {
+      cancelAnimationFrame(this.springFrameHandle);
+      this.springFrameHandle = null;
+    }
+    if (this.recordSpinFrameHandle !== null) {
+      cancelAnimationFrame(this.recordSpinFrameHandle);
+      this.recordSpinFrameHandle = null;
+    }
+    this.lastFrameAt = null;
+    this.lastRecordSpinFrameAt = null;
+  }
+
   private prefersReducedMotion(): boolean {
     return (
       typeof window.matchMedia === "function" &&
@@ -446,7 +485,7 @@ export class AgentGuiHeroCarouselScene {
   }
 
   private animate(): void {
-    if (this.disposed) {
+    if (this.disposed || !this.visible) {
       return;
     }
     if (this.prefersReducedMotion()) {
@@ -485,7 +524,7 @@ export class AgentGuiHeroCarouselScene {
 
   private readonly frame = (now: number): void => {
     this.springFrameHandle = null;
-    if (this.disposed) {
+    if (this.disposed || !this.visible) {
       return;
     }
     const dt =
@@ -517,6 +556,7 @@ export class AgentGuiHeroCarouselScene {
   private startRecordSpin(): void {
     if (
       this.disposed ||
+      !this.visible ||
       this.prefersReducedMotion() ||
       this.recordSpinFrameHandle !== null
     ) {
@@ -529,7 +569,12 @@ export class AgentGuiHeroCarouselScene {
   private readonly recordSpinFrame = (now: number): void => {
     this.recordSpinFrameHandle = null;
     const spinningTile = this.centerTile();
-    if (this.disposed || !spinningTile || this.prefersReducedMotion()) {
+    if (
+      this.disposed ||
+      !this.visible ||
+      !spinningTile ||
+      this.prefersReducedMotion()
+    ) {
       return;
     }
     const dt =
@@ -571,6 +616,7 @@ export class AgentGuiHeroCarouselScene {
   private requestRender(): void {
     if (
       this.disposed ||
+      !this.visible ||
       this.renderFrameHandle !== null ||
       this.springFrameHandle !== null
     ) {
@@ -578,7 +624,7 @@ export class AgentGuiHeroCarouselScene {
     }
     this.renderFrameHandle = requestAnimationFrame(() => {
       this.renderFrameHandle = null;
-      if (!this.disposed) {
+      if (!this.disposed && this.visible) {
         this.renderer.render(this.scene, this.camera);
       }
     });

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.ts
@@ -59,6 +59,8 @@ const BADGE_DIAMETER = 0.36;
 const BADGE_OFFSET = 0.48;
 const MAX_PIXEL_RATIO = 2;
 const RECORD_SPIN_SECONDS = 10;
+const RECORD_SPIN_MIN_FRAME_INTERVAL_MS = 30;
+const RECORD_SPIN_MAX_FRAME_DELTA_SECONDS = 0.1;
 const RECORD_MODEL_SCALE = 1.3;
 const RECORD_MODEL_RADIUS = 0.45;
 const RECORD_MODEL_THICKNESS = 0.03;
@@ -104,6 +106,7 @@ export interface AgentGuiHeroCarouselSceneOptions {
   loadedBadgeImages: readonly (HTMLImageElement | null)[];
   loadedImages: readonly (HTMLImageElement | null)[];
   loadedCoverImages: readonly (HTMLImageElement | null)[];
+  recordSpinActive?: boolean;
   // Fired once the wheel settles on an integer slot after an animated move.
   onSettle: (index: number) => void;
 }
@@ -144,6 +147,7 @@ export class AgentGuiHeroCarouselScene {
   private lastFrameAt: number | null = null;
   private lastRecordSpinFrameAt: number | null = null;
   private hoveredTile: AgentGuiHeroCarouselTile | null = null;
+  private recordSpinActive: boolean;
   private visible = true;
   private disposed = false;
 
@@ -157,6 +161,7 @@ export class AgentGuiHeroCarouselScene {
     // Rim spacing fixes the wheel size: radius = arc spacing / slot angle.
     this.wheelRadius = (TILE_SPACING * this.tileCount) / (Math.PI * 2);
     this.onSettle = options.onSettle;
+    this.recordSpinActive = options.recordSpinActive !== false;
     this.renderer = new THREE.WebGLRenderer({
       canvas: options.canvas,
       alpha: true,
@@ -322,6 +327,18 @@ export class AgentGuiHeroCarouselScene {
     this.startRecordSpin();
   }
 
+  setRecordSpinActive(active: boolean): void {
+    if (this.disposed || this.recordSpinActive === active) {
+      return;
+    }
+    this.recordSpinActive = active;
+    if (!active) {
+      this.cancelRecordSpinFrame();
+      return;
+    }
+    this.startRecordSpin();
+  }
+
   // Agent index of the tile slot the wheel is heading to.
   targetIndex(): number {
     const slot =
@@ -469,11 +486,15 @@ export class AgentGuiHeroCarouselScene {
       cancelAnimationFrame(this.springFrameHandle);
       this.springFrameHandle = null;
     }
+    this.cancelRecordSpinFrame();
+    this.lastFrameAt = null;
+  }
+
+  private cancelRecordSpinFrame(): void {
     if (this.recordSpinFrameHandle !== null) {
       cancelAnimationFrame(this.recordSpinFrameHandle);
       this.recordSpinFrameHandle = null;
     }
-    this.lastFrameAt = null;
     this.lastRecordSpinFrameAt = null;
   }
 
@@ -557,6 +578,7 @@ export class AgentGuiHeroCarouselScene {
     if (
       this.disposed ||
       !this.visible ||
+      !this.recordSpinActive ||
       this.prefersReducedMotion() ||
       this.recordSpinFrameHandle !== null
     ) {
@@ -568,13 +590,23 @@ export class AgentGuiHeroCarouselScene {
 
   private readonly recordSpinFrame = (now: number): void => {
     this.recordSpinFrameHandle = null;
-    const spinningTile = this.centerTile();
     if (
       this.disposed ||
       !this.visible ||
-      !spinningTile ||
+      !this.recordSpinActive ||
       this.prefersReducedMotion()
     ) {
+      return;
+    }
+    if (
+      this.lastRecordSpinFrameAt !== null &&
+      now - this.lastRecordSpinFrameAt < RECORD_SPIN_MIN_FRAME_INTERVAL_MS
+    ) {
+      this.recordSpinFrameHandle = requestAnimationFrame(this.recordSpinFrame);
+      return;
+    }
+    const spinningTile = this.centerTile();
+    if (!spinningTile) {
       return;
     }
     const dt =
@@ -582,7 +614,7 @@ export class AgentGuiHeroCarouselScene {
         ? 1 / 60
         : Math.min(
             (now - this.lastRecordSpinFrameAt) / 1000,
-            MAX_FRAME_DELTA_SECONDS
+            RECORD_SPIN_MAX_FRAME_DELTA_SECONDS
           );
     this.lastRecordSpinFrameAt = now;
     spinningTile.rotation =

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.ts
@@ -58,9 +58,6 @@ const BADGE_DIAMETER = 0.36;
 // layer scale => ~48.6px per world unit).
 const BADGE_OFFSET = 0.48;
 const MAX_PIXEL_RATIO = 2;
-const RECORD_SPIN_SECONDS = 10;
-const RECORD_SPIN_MIN_FRAME_INTERVAL_MS = 30;
-const RECORD_SPIN_MAX_FRAME_DELTA_SECONDS = 0.1;
 const RECORD_MODEL_SCALE = 1.3;
 const RECORD_MODEL_RADIUS = 0.45;
 const RECORD_MODEL_THICKNESS = 0.03;
@@ -95,8 +92,6 @@ interface AgentGuiHeroCarouselTile {
   faceMesh: THREE.Mesh<THREE.PlaneGeometry, THREE.MeshBasicMaterial>;
   poseGroup: THREE.Group;
   ready: boolean;
-  recordGroup: THREE.Group;
-  rotation: number;
   vinylTexture: THREE.Texture | null;
 }
 
@@ -106,7 +101,6 @@ export interface AgentGuiHeroCarouselSceneOptions {
   loadedBadgeImages: readonly (HTMLImageElement | null)[];
   loadedImages: readonly (HTMLImageElement | null)[];
   loadedCoverImages: readonly (HTMLImageElement | null)[];
-  recordSpinActive?: boolean;
   // Fired once the wheel settles on an integer slot after an animated move.
   onSettle: (index: number) => void;
 }
@@ -143,11 +137,7 @@ export class AgentGuiHeroCarouselScene {
   private velocity = 0;
   private renderFrameHandle: number | null = null;
   private springFrameHandle: number | null = null;
-  private recordSpinFrameHandle: number | null = null;
   private lastFrameAt: number | null = null;
-  private lastRecordSpinFrameAt: number | null = null;
-  private hoveredTile: AgentGuiHeroCarouselTile | null = null;
-  private recordSpinActive: boolean;
   private visible = true;
   private disposed = false;
 
@@ -161,7 +151,6 @@ export class AgentGuiHeroCarouselScene {
     // Rim spacing fixes the wheel size: radius = arc spacing / slot angle.
     this.wheelRadius = (TILE_SPACING * this.tileCount) / (Math.PI * 2);
     this.onSettle = options.onSettle;
-    this.recordSpinActive = options.recordSpinActive !== false;
     this.renderer = new THREE.WebGLRenderer({
       canvas: options.canvas,
       alpha: true,
@@ -255,8 +244,6 @@ export class AgentGuiHeroCarouselScene {
         faceMesh,
         poseGroup,
         ready: false,
-        recordGroup,
-        rotation: 0,
         vinylTexture: null
       });
     }
@@ -276,7 +263,6 @@ export class AgentGuiHeroCarouselScene {
     });
 
     this.applyPoses();
-    this.startRecordSpin();
   }
 
   setSize(width: number, height: number): void {
@@ -323,20 +309,9 @@ export class AgentGuiHeroCarouselScene {
 
     if (hasPendingMotion) {
       this.animate();
-    }
-    this.startRecordSpin();
-  }
-
-  setRecordSpinActive(active: boolean): void {
-    if (this.disposed || this.recordSpinActive === active) {
       return;
     }
-    this.recordSpinActive = active;
-    if (!active) {
-      this.cancelRecordSpinFrame();
-      return;
-    }
-    this.startRecordSpin();
+    this.requestRender();
   }
 
   // Agent index of the tile slot the wheel is heading to.
@@ -400,21 +375,10 @@ export class AgentGuiHeroCarouselScene {
     return typeof index === "number" ? index : null;
   }
 
-  // Gives playback to the record beneath the pointer. When no record is
-  // hovered, playback returns to the record nearest the center.
   hover(x: number, y: number, width: number, height: number): number | null {
     const tile = this.pickTile(x, y, width, height);
-    if (tile !== this.hoveredTile) {
-      this.hoveredTile = tile;
-      this.startRecordSpin();
-    }
     const index = tile?.poseGroup.userData.agentIndex;
     return typeof index === "number" ? index : null;
-  }
-
-  clearHover(): void {
-    this.hoveredTile = null;
-    this.startRecordSpin();
   }
 
   private pickTile(
@@ -486,16 +450,7 @@ export class AgentGuiHeroCarouselScene {
       cancelAnimationFrame(this.springFrameHandle);
       this.springFrameHandle = null;
     }
-    this.cancelRecordSpinFrame();
     this.lastFrameAt = null;
-  }
-
-  private cancelRecordSpinFrame(): void {
-    if (this.recordSpinFrameHandle !== null) {
-      cancelAnimationFrame(this.recordSpinFrameHandle);
-      this.recordSpinFrameHandle = null;
-    }
-    this.lastRecordSpinFrameAt = null;
   }
 
   private prefersReducedMotion(): boolean {
@@ -574,77 +529,6 @@ export class AgentGuiHeroCarouselScene {
     this.springFrameHandle = requestAnimationFrame(this.frame);
   };
 
-  private startRecordSpin(): void {
-    if (
-      this.disposed ||
-      !this.visible ||
-      !this.recordSpinActive ||
-      this.prefersReducedMotion() ||
-      this.recordSpinFrameHandle !== null
-    ) {
-      return;
-    }
-    this.lastRecordSpinFrameAt = null;
-    this.recordSpinFrameHandle = requestAnimationFrame(this.recordSpinFrame);
-  }
-
-  private readonly recordSpinFrame = (now: number): void => {
-    this.recordSpinFrameHandle = null;
-    if (
-      this.disposed ||
-      !this.visible ||
-      !this.recordSpinActive ||
-      this.prefersReducedMotion()
-    ) {
-      return;
-    }
-    if (
-      this.lastRecordSpinFrameAt !== null &&
-      now - this.lastRecordSpinFrameAt < RECORD_SPIN_MIN_FRAME_INTERVAL_MS
-    ) {
-      this.recordSpinFrameHandle = requestAnimationFrame(this.recordSpinFrame);
-      return;
-    }
-    const spinningTile = this.centerTile();
-    if (!spinningTile) {
-      return;
-    }
-    const dt =
-      this.lastRecordSpinFrameAt === null
-        ? 1 / 60
-        : Math.min(
-            (now - this.lastRecordSpinFrameAt) / 1000,
-            RECORD_SPIN_MAX_FRAME_DELTA_SECONDS
-          );
-    this.lastRecordSpinFrameAt = now;
-    spinningTile.rotation =
-      (spinningTile.rotation + (Math.PI * 2 * dt) / RECORD_SPIN_SECONDS) %
-      (Math.PI * 2);
-    // While the spring is moving it owns the single pose/render pass. The spin
-    // loop only advances its scalar angle, avoiding duplicate transforms.
-    if (this.springFrameHandle === null) {
-      this.applyPoses();
-      this.renderer.render(this.scene, this.camera);
-    }
-    this.recordSpinFrameHandle = requestAnimationFrame(this.recordSpinFrame);
-  };
-
-  private centerTile(): AgentGuiHeroCarouselTile | null {
-    let centeredTile: AgentGuiHeroCarouselTile | null = null;
-    let centeredOffset = Number.POSITIVE_INFINITY;
-    this.tiles.forEach((tile, index) => {
-      if (!tile.ready) {
-        return;
-      }
-      const offset = Math.abs(ringOffset(index, this.scroll, this.tileCount));
-      if (offset < centeredOffset) {
-        centeredTile = tile;
-        centeredOffset = offset;
-      }
-    });
-    return centeredTile;
-  }
-
   private requestRender(): void {
     if (
       this.disposed ||
@@ -678,7 +562,6 @@ export class AgentGuiHeroCarouselScene {
       }
     }
     this.applyPoses();
-    this.startRecordSpin();
   }
 
   private applyCoverImageTexture(
@@ -768,9 +651,6 @@ export class AgentGuiHeroCarouselScene {
         THREE.MathUtils.smoothstep(fadeProgress, 0, 1),
         RECORD_FADE_CURVE
       );
-      // The tile tangent still follows the wheel. Record playback rotation is
-      // independent, so only the currently hovered record advances while all
-      // others retain the angle where their previous hover ended.
       tile.poseGroup.rotation.set(
         RECORD_MODEL_TILT_X,
         THREE.MathUtils.clamp(
@@ -780,7 +660,6 @@ export class AgentGuiHeroCarouselScene {
         ),
         -angle * VISIBLE_ARC_CURVATURE
       );
-      tile.recordGroup.rotation.z = isCenterTile ? -tile.rotation : 0;
       const edgeKill =
         1 -
         THREE.MathUtils.smoothstep(

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -687,6 +687,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       </>
     ) : (
       <AgentGUIEmptyHomePane
+        isActive={isActive}
         isVisible={isVisible}
         provider={emptyHeroProvider}
         providerReadinessGate={emptyProviderReadinessGate}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyHeroCarouselStage.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyHeroCarouselStage.spec.tsx
@@ -35,6 +35,7 @@ describe("AgentGUIEmptyHeroCarouselStage", () => {
   it("measures live carousel alignment", () => {
     const { container } = render(
       <AgentGUIEmptyHeroCarouselStage
+        isActive
         isVisible
         items={items}
         providerSelectLabel="Select provider"
@@ -64,6 +65,7 @@ describe("AgentGUIEmptyHeroCarouselStage", () => {
     const view = render(
       <AgentGUIEmptyHeroCarouselStage
         activeAgentTargetId="codex"
+        isActive
         isVisible
         items={items}
         providerSelectLabel="Select provider"
@@ -76,6 +78,7 @@ describe("AgentGUIEmptyHeroCarouselStage", () => {
     view.rerender(
       <AgentGUIEmptyHeroCarouselStage
         activeAgentTargetId="claude"
+        isActive
         isVisible
         items={items}
         providerSelectLabel="Select provider"

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyHeroCarouselStage.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyHeroCarouselStage.tsx
@@ -7,6 +7,7 @@ import styles from "../AgentGUINode.styles";
 interface AgentGUIEmptyHeroCarouselStageProps {
   activeAgentTargetId?: string | null;
   children: ReactNode;
+  isActive: boolean;
   isVisible: boolean;
   items: readonly AgentGUIAgentAvatarPresentation[];
   onProviderSelect?: AgentGUINodeViewProps["actions"]["selectHomeComposerAgentTarget"];
@@ -47,6 +48,7 @@ export class AgentGUIEmptyHeroCarouselStage extends Component<AgentGUIEmptyHeroC
     const {
       activeAgentTargetId,
       children,
+      isActive,
       isVisible,
       items,
       onProviderSelect,
@@ -60,6 +62,7 @@ export class AgentGUIEmptyHeroCarouselStage extends Component<AgentGUIEmptyHeroC
           <div ref={this.setLayer} className={styles.emptyHeroCarouselLayer}>
             <AgentGUIHeroAgentCarousel
               activeAgentTargetId={activeAgentTargetId}
+              isActive={isActive}
               isVisible={isVisible}
               items={items}
               onProviderSelect={onProviderSelect}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.notice.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.notice.spec.tsx
@@ -30,6 +30,7 @@ describe("AgentGUIEmptyHeroPane notices", () => {
   it("does not render an unresolved target label in the Home title", () => {
     render(
       <AgentGUIEmptyHomePane
+        isActive
         isVisible
         provider="unknown"
         providerReadinessGate={null}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
@@ -90,6 +90,7 @@ export const EMPTY_HOME_SUGGESTIONS: readonly AgentHomeSuggestionCategory[] =
   Object.freeze([]);
 
 interface AgentGUIEmptyHomePaneProps {
+  isActive: boolean;
   isVisible: boolean;
   provider: AgentGUINodeViewModel["shell"]["data"]["provider"];
   providerReadinessGate: AgentGUIProviderReadinessGate | null;
@@ -113,6 +114,7 @@ interface AgentGUIEmptyHomePaneProps {
 }
 
 export const AgentGUIEmptyHomePane = memo(function AgentGUIEmptyHomePane({
+  isActive,
   isVisible,
   provider,
   providerReadinessGate,
@@ -161,6 +163,7 @@ export const AgentGUIEmptyHomePane = memo(function AgentGUIEmptyHomePane({
         presentedSelectedAgentTarget?.agentTargetId ??
         presentedSelectedAgentTarget?.targetId
       }
+      isActive={isActive}
       isVisible={isVisible}
       items={avatarPresentations}
       onProviderSelect={onProviderSelect}
@@ -171,6 +174,7 @@ export const AgentGUIEmptyHomePane = memo(function AgentGUIEmptyHomePane({
       >
         {providerReadinessGate ? (
           <AgentGUIProviderReadinessGatePane
+            isActive={isActive}
             isVisible={isVisible}
             provider={provider}
             gate={providerReadinessGate}
@@ -188,6 +192,7 @@ export const AgentGUIEmptyHomePane = memo(function AgentGUIEmptyHomePane({
         ) : (
           <AgentGUIEmptyHeroPane
             {...heroProps}
+            isActive={isActive}
             isVisible={isVisible}
             provider={provider}
             emptyLabel={emptyLabel}
@@ -207,6 +212,7 @@ export const AgentGUIEmptyHomePane = memo(function AgentGUIEmptyHomePane({
 });
 
 interface AgentGUIEmptyHeroPaneProps {
+  isActive?: boolean;
   isVisible?: boolean;
   provider: AgentGUINodeViewModel["shell"]["data"]["provider"];
   emptyLabel: string;
@@ -233,6 +239,7 @@ interface AgentGUIEmptyHeroPaneProps {
 }
 
 export const AgentGUIEmptyHeroPane = memo(function AgentGUIEmptyHeroPane({
+  isActive = true,
   isVisible = true,
   provider,
   emptyLabel,
@@ -289,6 +296,7 @@ export const AgentGUIEmptyHeroPane = memo(function AgentGUIEmptyHeroPane({
                 selectedAgentTarget?.agentTargetId ??
                 selectedAgentTarget?.targetId
               }
+              isActive={isActive}
               items={heroAvatarPresentations}
               isVisible={isVisible}
               onProviderSelect={onProviderSelect}
@@ -337,6 +345,7 @@ export const AgentGUIEmptyHeroPane = memo(function AgentGUIEmptyHeroPane({
 });
 
 interface AgentGUIProviderReadinessGatePaneProps {
+  isActive?: boolean;
   isVisible?: boolean;
   provider: AgentGUINodeViewModel["shell"]["data"]["provider"];
   gate: AgentGUIProviderReadinessGate;
@@ -375,6 +384,7 @@ interface AgentGUIProviderReadinessGatePaneProps {
 
 export const AgentGUIProviderReadinessGatePane = memo(
   function AgentGUIProviderReadinessGatePane({
+    isActive = true,
     isVisible = true,
     provider,
     gate,
@@ -445,6 +455,7 @@ export const AgentGUIProviderReadinessGatePane = memo(
                 selectedAgentTarget?.agentTargetId ??
                 selectedAgentTarget?.targetId
               }
+              isActive={isActive}
               items={heroAvatarPresentations}
               isVisible={isVisible}
               onProviderSelect={onProviderSelect}

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -10093,6 +10093,23 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
     ),
     #111;
   box-shadow: 0 4px 15px rgb(0 0 0 / 60%);
+  animation: agent-gui-vinyl-player-record-spin 4s linear infinite paused;
+}
+
+.agent-gui-vinyl-player__record--playing {
+  animation-play-state: running;
+}
+
+@keyframes agent-gui-vinyl-player-record-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-gui-vinyl-player__record {
+    animation: none;
+  }
 }
 
 .agent-gui-vinyl-player__groove,

--- a/packages/workbench/electron/src/captureWorkbenchDockPreview.test.ts
+++ b/packages/workbench/electron/src/captureWorkbenchDockPreview.test.ts
@@ -11,17 +11,19 @@ import {
 
 test("creates full-size Genie and bounded Dock images from one capture", async () => {
   const source = new FakeNativeImage(
-    { height: 800, width: 1_000 },
+    { height: 700, width: 900 },
     { resizedDataUrl: "data:image/png;base64,ZG9jaw==" }
   );
   let captureCount = 0;
+  let captureRect: WorkbenchDockPreviewRect | undefined;
   const images = await captureWorkbenchPreviewImages({
     contentSize: { height: 800, width: 1_000 },
     maxHeight: 170,
     maxWidth: 260,
     rect: { height: 700, width: 900, x: 20, y: 30 },
-    webContents: fakeWebContents(async () => {
+    webContents: fakeWebContents(async (rect) => {
       captureCount += 1;
+      captureRect = rect;
       return source.asNativeImage();
     })
   });
@@ -31,16 +33,27 @@ test("creates full-size Genie and bounded Dock images from one capture", async (
     dockPreviewImageUrl: "data:image/png;base64,ZG9jaw==",
     genieImageUrl: "data:image/png;base64,cHJldmlldw=="
   });
-  assert.deepEqual(source.cropRects, [
-    { height: 700, width: 900, x: 20, y: 30 }
-  ]);
-  assert.deepEqual(source.croppedImages[0]?.resizeSizes, [
-    { height: 170, width: 219 }
-  ]);
+  assert.deepEqual(captureRect, { height: 700, width: 900, x: 20, y: 30 });
+  assert.deepEqual(source.resizeSizes, [{ height: 170, width: 219 }]);
 });
 
-test("captures, scales, crops, and bounds the preview image", async () => {
-  const source = new FakeNativeImage({ height: 800, width: 1_000 });
+test("passes the sanitized target region to capturePage", async () => {
+  const captureRects: (WorkbenchDockPreviewRect | undefined)[] = [];
+
+  await captureWorkbenchDockPreview({
+    contentSize: { height: 400, width: 500 },
+    rect: { height: 100.2, width: 200.2, x: 10.2, y: 20.2 },
+    webContents: fakeWebContents(async (rect) => {
+      captureRects.push(rect);
+      return new FakeNativeImage({ height: 101, width: 201 }).asNativeImage();
+    })
+  });
+
+  assert.deepEqual(captureRects, [{ height: 101, width: 201, x: 10, y: 20 }]);
+});
+
+test("captures the region and bounds the returned preview image", async () => {
+  const source = new FakeNativeImage({ height: 202, width: 402 });
   const webContents = fakeWebContents(async () => source.asNativeImage());
 
   const dataUrl = await captureWorkbenchDockPreview({
@@ -52,26 +65,23 @@ test("captures, scales, crops, and bounds the preview image", async () => {
   });
 
   assert.equal(dataUrl, "data:image/png;base64,cHJldmlldw==");
-  assert.deepEqual(source.cropRects, [
-    { height: 202, width: 402, x: 20, y: 40 }
-  ]);
-  assert.deepEqual(source.croppedImages[0]?.resizeSizes, [
-    { height: 75, width: 150 }
-  ]);
+  assert.deepEqual(source.resizeSizes, [{ height: 75, width: 150 }]);
 });
 
 test("clamps renderer rectangles to the content bounds", async () => {
-  const source = new FakeNativeImage({ height: 200, width: 300 });
+  const source = new FakeNativeImage({ height: 20, width: 50 });
+  const captureRects: (WorkbenchDockPreviewRect | undefined)[] = [];
 
   await captureWorkbenchDockPreview({
     contentSize: { height: 100, width: 150 },
     rect: { height: 50, width: 80, x: 100, y: 80 },
-    webContents: fakeWebContents(async () => source.asNativeImage())
+    webContents: fakeWebContents(async (rect) => {
+      captureRects.push(rect);
+      return source.asNativeImage();
+    })
   });
 
-  assert.deepEqual(source.cropRects, [
-    { height: 40, width: 100, x: 200, y: 160 }
-  ]);
+  assert.deepEqual(captureRects, [{ height: 20, width: 50, x: 100, y: 80 }]);
 });
 
 test("rejects invalid renderer rectangles before capture", async () => {
@@ -123,15 +133,8 @@ test("reports destroyed, failed, and empty captures", async (context) => {
     },
     { expectedReason: "capture_page_failed", reject: true },
     {
-      expectedReason: "full_capture_empty",
+      expectedReason: "capture_empty",
       image: new FakeNativeImage({ height: 100, width: 100 }, { empty: true })
-    },
-    {
-      expectedReason: "crop_empty",
-      image: new FakeNativeImage(
-        { height: 100, width: 100 },
-        { cropEmpty: true }
-      )
     },
     {
       expectedReason: "resize_empty",
@@ -208,12 +211,9 @@ test("serializes capturePage calls", async () => {
 });
 
 class FakeNativeImage {
-  readonly cropRects: WorkbenchDockPreviewRect[] = [];
-  readonly croppedImages: FakeNativeImage[] = [];
   readonly resizeSizes: WorkbenchDockPreviewSize[] = [];
   private readonly dataUrl: string;
   private readonly empty: boolean;
-  private readonly cropEmpty: boolean;
   private readonly resizedDataUrl: string;
   private readonly resizeEmpty: boolean;
   private readonly size: WorkbenchDockPreviewSize;
@@ -221,14 +221,12 @@ class FakeNativeImage {
   constructor(
     size: WorkbenchDockPreviewSize,
     options: {
-      cropEmpty?: boolean;
       dataUrl?: string;
       empty?: boolean;
       resizedDataUrl?: string;
       resizeEmpty?: boolean;
     } = {}
   ) {
-    this.cropEmpty = options.cropEmpty ?? false;
     this.dataUrl = options.dataUrl ?? "data:image/png;base64,cHJldmlldw==";
     this.empty = options.empty ?? false;
     this.resizeEmpty = options.resizeEmpty ?? false;
@@ -238,21 +236,6 @@ class FakeNativeImage {
 
   asNativeImage(): NativeImage {
     return this as unknown as NativeImage;
-  }
-
-  crop(rect: WorkbenchDockPreviewRect): NativeImage {
-    this.cropRects.push(rect);
-    const cropped = new FakeNativeImage(
-      { height: rect.height, width: rect.width },
-      {
-        dataUrl: this.dataUrl,
-        empty: this.cropEmpty,
-        resizedDataUrl: this.resizedDataUrl,
-        resizeEmpty: this.resizeEmpty
-      }
-    );
-    this.croppedImages.push(cropped);
-    return cropped.asNativeImage();
   }
 
   getSize(): WorkbenchDockPreviewSize {
@@ -277,7 +260,7 @@ class FakeNativeImage {
 }
 
 function fakeWebContents(
-  capturePage: () => Promise<NativeImage>,
+  capturePage: (rect?: WorkbenchDockPreviewRect) => Promise<NativeImage>,
   destroyed = false
 ): Pick<WebContents, "capturePage" | "isDestroyed"> {
   return {

--- a/packages/workbench/electron/src/captureWorkbenchDockPreview.ts
+++ b/packages/workbench/electron/src/captureWorkbenchDockPreview.ts
@@ -13,19 +13,16 @@ export interface WorkbenchDockPreviewSize {
 }
 
 export type WorkbenchDockPreviewCaptureDiagnosticReason =
+  | "capture_empty"
   | "capture_page_failed"
   | "capture_page_timeout"
-  | "crop_empty"
   | "data_url_empty"
-  | "full_capture_empty"
   | "invalid_rect"
   | "resize_empty"
   | "web_contents_destroyed_before_capture";
 
 export interface WorkbenchDockPreviewCaptureDiagnostic {
-  cropRect?: WorkbenchDockPreviewRect;
   error?: unknown;
-  imageSize?: WorkbenchDockPreviewSize;
   reason: WorkbenchDockPreviewCaptureDiagnosticReason;
 }
 
@@ -85,6 +82,7 @@ function captureWorkbenchPreviewImagesInternal(
       try {
         const capturedImage = await capturePageWithTimeout(
           input.webContents,
+          rect,
           sanitizeTimeout(input.timeoutMs)
         );
         if (!capturedImage) {
@@ -98,33 +96,17 @@ function captureWorkbenchPreviewImagesInternal(
       }
 
       if (image.isEmpty()) {
-        emitDiagnostic(input, { reason: "full_capture_empty" });
+        emitDiagnostic(input, { reason: "capture_empty" });
         return null;
       }
 
-      const imageSize = image.getSize();
-      const cropRect = scaleCaptureRectForImage(
-        rect,
-        imageSize,
-        input.contentSize
-      );
-      const cropped = image.crop(cropRect);
-      if (cropped.isEmpty()) {
-        emitDiagnostic(input, {
-          cropRect,
-          imageSize,
-          reason: "crop_empty"
-        });
-        return null;
-      }
-
-      const genieImageUrl = includeGenieImage ? cropped.toDataURL() : "";
+      const genieImageUrl = includeGenieImage ? image.toDataURL() : "";
       if (includeGenieImage && !genieImageUrl) {
         emitDiagnostic(input, { reason: "data_url_empty" });
         return null;
       }
 
-      const resized = resizeCapturePreviewImage(cropped, input);
+      const resized = resizeCapturePreviewImage(image, input);
       if (resized.isEmpty()) {
         emitDiagnostic(input, { reason: "resize_empty" });
         return null;
@@ -145,9 +127,10 @@ function captureWorkbenchPreviewImagesInternal(
 
 function capturePageWithTimeout(
   webContents: Pick<WebContents, "capturePage">,
+  rect: WorkbenchDockPreviewRect,
   timeoutMs: number
 ): Promise<NativeImage | null> {
-  const capturePromise = webContents.capturePage();
+  const capturePromise = webContents.capturePage(rect);
   capturePromise.catch(() => undefined);
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<null>((resolve) => {
@@ -196,31 +179,6 @@ function enqueueCapturePreview<TResult>(
     () => undefined
   );
   return result;
-}
-
-function scaleCaptureRectForImage(
-  rect: WorkbenchDockPreviewRect,
-  imageSize: WorkbenchDockPreviewSize,
-  contentSize: WorkbenchDockPreviewSize
-): WorkbenchDockPreviewRect {
-  const scaleX = imageSize.width / contentSize.width;
-  const scaleY = imageSize.height / contentSize.height;
-  const x = Math.max(0, Math.floor(rect.x * scaleX));
-  const y = Math.max(0, Math.floor(rect.y * scaleY));
-  const right = Math.min(
-    imageSize.width,
-    Math.ceil((rect.x + rect.width) * scaleX)
-  );
-  const bottom = Math.min(
-    imageSize.height,
-    Math.ceil((rect.y + rect.height) * scaleY)
-  );
-  return {
-    height: Math.max(1, bottom - y),
-    width: Math.max(1, right - x),
-    x,
-    y
-  };
 }
 
 function resizeCapturePreviewImage(

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.render.test.tsx
@@ -1,10 +1,12 @@
-import { act } from "react";
+import { act, useRef } from "react";
 import { createRoot } from "react-dom/client";
 import { describe, expect, it, vi } from "vitest";
 import type { WorkbenchNode, WorkbenchState } from "../core/types.ts";
 import type { WorkbenchDockContext } from "../react/types.ts";
 import type { WorkbenchController } from "../store/types.ts";
 import { WorkbenchHostDock } from "./WorkbenchHostDock.tsx";
+import { WorkbenchHostDockPopup } from "./WorkbenchHostDockPopup.tsx";
+import { useDockMagnification } from "./dockMagnification.ts";
 import type {
   WorkbenchHostDockPopupPreviewProvider,
   WorkbenchHostHandle,
@@ -13,6 +15,118 @@ import type {
 import { createWorkbenchHostI18nRuntime } from "./workbenchHostI18n.ts";
 
 describe("WorkbenchHostDock", () => {
+  it("reads slot geometry once during a dock magnification session", async () => {
+    const frames = installAnimationFrameQueue();
+    let magnification: ReturnType<typeof useDockMagnification> | null = null;
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    function Harness(): React.JSX.Element {
+      const dockPlateRef = useRef<HTMLDivElement>(null);
+      const dockRootRef = useRef<HTMLDivElement>(null);
+      const dockViewportRef = useRef<HTMLDivElement>(null);
+      const slotRefs = useRef(new Map<string, HTMLElement>());
+      magnification = useDockMagnification({
+        dockPlateRef,
+        dockPlacement: "bottom",
+        dockRootRef,
+        dockViewportRef,
+        slotRefs
+      });
+      const registerSlot =
+        (anchorKey: string) => (element: HTMLDivElement | null) => {
+          if (element) {
+            slotRefs.current.set(anchorKey, element);
+          } else {
+            slotRefs.current.delete(anchorKey);
+          }
+        };
+
+      return (
+        <div ref={dockPlateRef}>
+          <div ref={dockRootRef}>
+            <div ref={dockViewportRef} data-testid="viewport">
+              <div
+                ref={registerSlot("a")}
+                data-desktop-dock-anchor-key="a"
+                data-testid="slot-a"
+              >
+                <span data-desktop-dock-icon-shell />
+              </div>
+              <div
+                ref={registerSlot("b")}
+                data-desktop-dock-anchor-key="b"
+                data-testid="slot-b"
+              >
+                <span data-desktop-dock-icon-shell />
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    try {
+      await act(async () => {
+        root.render(<Harness />);
+      });
+      const viewport = container.querySelector<HTMLElement>(
+        '[data-testid="viewport"]'
+      );
+      const slotA = container.querySelector<HTMLElement>(
+        '[data-testid="slot-a"]'
+      );
+      const slotB = container.querySelector<HTMLElement>(
+        '[data-testid="slot-b"]'
+      );
+      if (!viewport || !slotA || !slotB || !magnification) {
+        throw new Error("Expected dock magnification harness");
+      }
+      const viewportRect = vi
+        .spyOn(viewport, "getBoundingClientRect")
+        .mockReturnValue(domRect(0, 0, 400, 100));
+      const slotARect = vi
+        .spyOn(slotA, "getBoundingClientRect")
+        .mockReturnValue(domRect(100, 36.8, 43.2, 43.2));
+      const slotBRect = vi
+        .spyOn(slotB, "getBoundingClientRect")
+        .mockReturnValue(domRect(160, 36.8, 43.2, 43.2));
+
+      act(() => {
+        magnification?.handlePointerMove(120, 60);
+      });
+      expect(viewportRect).toHaveBeenCalledOnce();
+      expect(slotARect).toHaveBeenCalledOnce();
+      expect(slotBRect).toHaveBeenCalledOnce();
+
+      await act(async () => {
+        frames.flushNext(0);
+        frames.flushNext(16);
+        frames.flushNext(32);
+      });
+
+      expect(viewportRect).toHaveBeenCalledOnce();
+      expect(slotARect).toHaveBeenCalledOnce();
+      expect(slotBRect).toHaveBeenCalledOnce();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+      vi.restoreAllMocks();
+    }
+  });
+
   it("preserves hook order while dock entries appear and disappear", async () => {
     const props = createDockProps();
     const dockEntry = {
@@ -191,7 +305,215 @@ describe("WorkbenchHostDock", () => {
       vi.unstubAllGlobals();
     }
   });
+
+  it("does not restart an in-flight popup capture after a semantic no-op render", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        disconnect() {}
+        observe() {}
+        unobserve() {}
+      }
+    );
+    const node = {
+      ...createNode(),
+      id: "agent-gui:pending-preview"
+    };
+    const props = createDockProps([node]);
+    const pendingCapture = deferred<string>();
+    const captureNodePreviewImage = vi.fn(() => pendingCapture.promise);
+    const dockEntry = {
+      icon: null,
+      id: "agent-gui",
+      instanceMode: "multi" as const,
+      label: "Agent",
+      typeId: "agent-gui",
+      visibility: "always" as const
+    };
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchHostDock
+            {...props}
+            captureNodePreviewImage={captureNodePreviewImage}
+            dockEntries={[dockEntry]}
+          />
+        );
+      });
+      const button = container.querySelector<HTMLButtonElement>(
+        'button[aria-haspopup="dialog"]'
+      );
+      await act(async () => {
+        button?.click();
+      });
+      await vi.waitFor(() => {
+        expect(captureNodePreviewImage).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        root.render(
+          <WorkbenchHostDock
+            {...props}
+            captureNodePreviewImage={captureNodePreviewImage}
+            dockEntries={[dockEntry]}
+          />
+        );
+      });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      expect(captureNodePreviewImage).toHaveBeenCalledTimes(1);
+      pendingCapture.resolve("data:image/png;base64,AA==");
+    } finally {
+      pendingCapture.resolve("data:image/png;base64,AA==");
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("keeps an issued capture pending while the popup effect is replaced", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        disconnect() {}
+        observe() {}
+        unobserve() {}
+      }
+    );
+    const node = {
+      ...createNode(),
+      id: "agent-gui:replaced-preview-effect"
+    };
+    const { host } = createDockProps([node]);
+    const pendingCapture = deferred<string>();
+    const capturePreview = vi.fn(() => pendingCapture.promise);
+    const item = {
+      host,
+      isFocused: false,
+      isMinimized: false,
+      node,
+      preview: null,
+      previewRevision: null,
+      subtitle: null,
+      title: "Agent"
+    };
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    const renderPopup = (variant: "context-menu" | "default") => (
+      <WorkbenchHostDockPopup
+        anchorRect={{ height: 40, left: 20, top: 100, width: 40 }}
+        capturePreview={capturePreview}
+        closeWindowLabel={() => "Close"}
+        items={[item]}
+        label="Agent"
+        newWindowLabel="New"
+        onClose={() => undefined}
+        onCloseNode={() => undefined}
+        onCreateNew={() => undefined}
+        onSelectNode={() => undefined}
+        variant={variant}
+      />
+    );
+
+    try {
+      await act(async () => {
+        root.render(renderPopup("default"));
+      });
+      await vi.waitFor(() => {
+        expect(capturePreview).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        root.render(renderPopup("context-menu"));
+      });
+      await act(async () => {
+        root.render(renderPopup("default"));
+      });
+
+      expect(capturePreview).toHaveBeenCalledTimes(1);
+      pendingCapture.resolve("data:image/png;base64,AA==");
+    } finally {
+      pendingCapture.resolve("data:image/png;base64,AA==");
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+      vi.unstubAllGlobals();
+    }
+  });
 });
+
+function installAnimationFrameQueue(): {
+  flushNext(frameTime: number): void;
+} {
+  let nextID = 1;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    const id = nextID;
+    nextID += 1;
+    callbacks.set(id, callback);
+    return id;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id) => {
+    callbacks.delete(id);
+  });
+  return {
+    flushNext(frameTime) {
+      const first = callbacks.entries().next().value as
+        | [number, FrameRequestCallback]
+        | undefined;
+      if (!first) {
+        throw new Error("Expected a pending animation frame");
+      }
+      callbacks.delete(first[0]);
+      first[1](frameTime);
+    }
+  };
+}
+
+function domRect(
+  left: number,
+  top: number,
+  width: number,
+  height: number
+): DOMRect {
+  return {
+    bottom: top + height,
+    height,
+    left,
+    right: left + width,
+    top,
+    width,
+    x: left,
+    y: top,
+    toJSON: () => ({})
+  };
+}
 
 function createNode(): WorkbenchNode<WorkbenchHostNodeData> {
   return {
@@ -275,4 +597,15 @@ function createDockProps(
     nodeDefinitions: new Map(),
     workspaceId: "workspace-hook-order"
   };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolvePromise = (_value: T): void => undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: resolvePromise };
 }

--- a/packages/workbench/surface/src/host/WorkbenchHostDockPopup.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDockPopup.tsx
@@ -70,7 +70,7 @@ const dockPopupPreviewByMemoryKey = new Map<
   string,
   WorkbenchHostDockPopupCapturedPreview
 >();
-const pendingDockPopupPreviewMemoryKeys = new Set<string>();
+const pendingDockPopupPreviewCaptureKeys = new Set<string>();
 
 type WorkbenchHostDockPopupCapturedPreview = {
   preview: WorkbenchDockPreviewContent | null;
@@ -292,6 +292,7 @@ export function WorkbenchHostDockPopup({
   const resolvedVariant = variant ?? "default";
   const isMinimizedStack = resolvedVariant === "minimized-stack";
   const isContextMenu = resolvedVariant === "context-menu";
+  const hasCapturePreview = Boolean(capturePreview);
   const createCardCount = showCreateNew === false ? 0 : 1;
   const cardElementsRef = useRef(new Map<string, HTMLElement>());
   const cardRefCallbacksRef = useRef(
@@ -306,6 +307,16 @@ export function WorkbenchHostDockPopup({
   const [capturedPreviewByMemoryKey, setCapturedPreviewByMemoryKey] = useState<
     Record<string, WorkbenchHostDockPopupCapturedPreview | undefined>
   >({});
+  const capturedPreviewByMemoryKeyRef = useRef(capturedPreviewByMemoryKey);
+  const capturePreviewRef = useRef(capturePreview);
+  const debugDiagnosticsRef = useRef(debugDiagnostics);
+  const dockPreviewCacheRef = useRef(dockPreviewCache);
+  const resolveDockPreviewCacheKeyRef = useRef(resolveDockPreviewCacheKey);
+  capturedPreviewByMemoryKeyRef.current = capturedPreviewByMemoryKey;
+  capturePreviewRef.current = capturePreview;
+  debugDiagnosticsRef.current = debugDiagnostics;
+  dockPreviewCacheRef.current = dockPreviewCache;
+  resolveDockPreviewCacheKeyRef.current = resolveDockPreviewCacheKey;
   const columnCount = isContextMenu
     ? 1
     : Math.min(Math.max(items.length + createCardCount, 1), 3);
@@ -555,10 +566,18 @@ export function WorkbenchHostDockPopup({
   }, [onClose]);
 
   const previewCaptureKey = items
-    .map(
-      (item) =>
-        `${item.node.id}:${previewCacheToken(item.preview)}:${item.previewRevision ?? ""}`
-    )
+    .map((item) => {
+      const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
+        item.node,
+        resolveDockPreviewCacheKey?.(item.node) ?? null
+      );
+      return [
+        previewMemoryKey,
+        item.isMinimized ? "minimized" : "visible",
+        previewCacheToken(item.preview),
+        item.previewRevision ?? ""
+      ].join(":");
+    })
     .join("|");
 
   useEffect(() => {
@@ -591,25 +610,30 @@ export function WorkbenchHostDockPopup({
   }, [isMinimizedStack, minimizedStackMaxScrollOffset]);
 
   useEffect(() => {
-    if (!capturePreview || isContextMenu) {
+    if (!capturePreviewRef.current || isContextMenu) {
       return;
     }
     let cancelled = false;
+    const startedCaptureKeys = new Set<string>();
     const missingItems = items.filter((item) => {
       const revision = item.previewRevision;
       const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
         item.node,
-        resolveDockPreviewCacheKey?.(item.node) ?? null
+        resolveDockPreviewCacheKeyRef.current?.(item.node) ?? null
+      );
+      const pendingCaptureKey = resolveDockPopupPreviewCaptureKey(
+        previewMemoryKey,
+        revision
       );
       const capturedPreview =
-        capturedPreviewByMemoryKey[previewMemoryKey] ??
+        capturedPreviewByMemoryKeyRef.current[previewMemoryKey] ??
         readDockPopupPreviewImage(previewMemoryKey);
       const hasCapturedPreview =
         capturedPreview !== undefined && capturedPreview.revision === revision;
       const shouldCaptureMissingPreview = !item.preview && !hasCapturedPreview;
       return (
         shouldCaptureMissingPreview &&
-        !pendingDockPopupPreviewMemoryKeys.has(previewMemoryKey)
+        !pendingDockPopupPreviewCaptureKeys.has(pendingCaptureKey)
       );
     });
     if (missingItems.length === 0) {
@@ -635,10 +659,14 @@ export function WorkbenchHostDockPopup({
     );
 
     for (const item of missingItems) {
-      pendingDockPopupPreviewMemoryKeys.add(
-        resolveDockPopupPreviewMemoryKey(
-          item.node,
-          resolveDockPreviewCacheKey?.(item.node) ?? null
+      const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
+        item.node,
+        resolveDockPreviewCacheKeyRef.current?.(item.node) ?? null
+      );
+      pendingDockPopupPreviewCaptureKeys.add(
+        resolveDockPopupPreviewCaptureKey(
+          previewMemoryKey,
+          item.previewRevision
         )
       );
     }
@@ -650,135 +678,144 @@ export function WorkbenchHostDockPopup({
         }
 
         const revision = item.previewRevision;
-        logWorkbenchDockPopupDebug(
-          "dock.popup.preview_capture.started",
-          debugDiagnostics,
-          {
-            isMinimized: item.isMinimized,
-            nodeId: item.node.id,
-            revision
-          }
-        );
         const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
           item.node,
-          resolveDockPreviewCacheKey?.(item.node) ?? null
+          resolveDockPreviewCacheKeyRef.current?.(item.node) ?? null
         );
-        const cacheKey = resolveDockPopupPreviewCacheKey(
-          resolveDockPreviewCacheKey?.(item.node) ?? null,
+        const pendingCaptureKey = resolveDockPopupPreviewCaptureKey(
+          previewMemoryKey,
           revision
         );
-        if (item.isMinimized && cacheKey) {
-          const minimizedPersistedPreview = await readPersistedDockPreview(
-            dockPreviewCache,
-            cacheKey
+        startedCaptureKeys.add(pendingCaptureKey);
+        try {
+          logWorkbenchDockPopupDebug(
+            "dock.popup.preview_capture.started",
+            debugDiagnosticsRef.current,
+            {
+              isMinimized: item.isMinimized,
+              nodeId: item.node.id,
+              revision
+            }
+          );
+          const cacheKey = resolveDockPopupPreviewCacheKey(
+            resolveDockPreviewCacheKeyRef.current?.(item.node) ?? null,
+            revision
+          );
+          if (item.isMinimized && cacheKey) {
+            const minimizedPersistedPreview = await readPersistedDockPreview(
+              dockPreviewCacheRef.current,
+              cacheKey
+            );
+            if (cancelled) {
+              break;
+            }
+            if (minimizedPersistedPreview) {
+              const persistedPreview: WorkbenchDockPreviewContent = {
+                kind: "image",
+                src: minimizedPersistedPreview
+              };
+              writeCachedWorkbenchNodePreviewImage(
+                item.node.id,
+                minimizedPersistedPreview
+              );
+              writeDockPopupPreviewImage(
+                previewMemoryKey,
+                persistedPreview,
+                revision
+              );
+              setCapturedPreviewByMemoryKey((current) => ({
+                ...current,
+                [previewMemoryKey]: {
+                  preview: persistedPreview,
+                  revision
+                }
+              }));
+              continue;
+            }
+          }
+
+          const preview = normalizeDockPopupPreviewContentResult(
+            item.isMinimized
+              ? ((await capturePreviewRef.current?.(item)) ??
+                  (await captureWorkbenchNodePreviewImage(item.node.id, {
+                    bypassCache: false
+                  })))
+              : await Promise.resolve(
+                  capturePreviewRef.current?.(item) ?? null
+                ).catch(() => null),
+            revision
           );
           if (cancelled) {
             break;
           }
-          if (minimizedPersistedPreview) {
-            const persistedPreview: WorkbenchDockPreviewContent = {
-              kind: "image",
-              src: minimizedPersistedPreview
-            };
-            writeCachedWorkbenchNodePreviewImage(
-              item.node.id,
-              minimizedPersistedPreview
-            );
-            writeDockPopupPreviewImage(
-              previewMemoryKey,
-              persistedPreview,
+          logWorkbenchDockPopupDebug(
+            "dock.popup.preview_capture.resolved",
+            debugDiagnosticsRef.current,
+            {
+              hasPreview: Boolean(preview),
+              nodeId: item.node.id,
+              providerRevision: preview?.revision ?? null,
               revision
-            );
+            }
+          );
+          if (preview) {
+            if (preview.kind === "image") {
+              writeCachedWorkbenchNodePreviewImage(item.node.id, preview.src);
+            }
+            writeDockPopupPreviewImage(previewMemoryKey, preview, revision);
+            if (cacheKey && preview.kind === "image") {
+              dockPreviewCacheRef.current?.write({
+                key: cacheKey,
+                previewImageUrl: preview.src
+              });
+            }
             setCapturedPreviewByMemoryKey((current) => ({
               ...current,
-              [previewMemoryKey]: {
-                preview: persistedPreview,
-                revision
-              }
+              [previewMemoryKey]: { preview, revision }
             }));
-            pendingDockPopupPreviewMemoryKeys.delete(previewMemoryKey);
             continue;
           }
-        }
 
-        const preview = normalizeDockPopupPreviewContentResult(
-          item.isMinimized
-            ? ((await capturePreview?.(item)) ??
-                (await captureWorkbenchNodePreviewImage(item.node.id, {
-                  bypassCache: false
-                })))
-            : await Promise.resolve(capturePreview?.(item) ?? null).catch(
-                () => null
-              ),
-          revision
-        );
-        if (cancelled) {
-          break;
-        }
-        logWorkbenchDockPopupDebug(
-          "dock.popup.preview_capture.resolved",
-          debugDiagnostics,
-          {
-            hasPreview: Boolean(preview),
-            nodeId: item.node.id,
-            providerRevision: preview?.revision ?? null,
-            revision
-          }
-        );
-        if (preview) {
-          if (preview.kind === "image") {
-            writeCachedWorkbenchNodePreviewImage(item.node.id, preview.src);
-          }
-          writeDockPopupPreviewImage(previewMemoryKey, preview, revision);
-          if (cacheKey && preview.kind === "image") {
-            dockPreviewCache?.write({
-              key: cacheKey,
-              previewImageUrl: preview.src
-            });
-          }
-          setCapturedPreviewByMemoryKey((current) => ({
-            ...current,
-            [previewMemoryKey]: { preview, revision }
-          }));
-          pendingDockPopupPreviewMemoryKeys.delete(previewMemoryKey);
-          continue;
-        }
-
-        const fallbackPersistedPreview =
-          !item.isMinimized && cacheKey
-            ? await readPersistedDockPreview(dockPreviewCache, cacheKey)
-            : null;
-        if (cancelled) {
-          break;
-        }
-        if (fallbackPersistedPreview) {
-          writeCachedWorkbenchNodePreviewImage(
-            item.node.id,
-            fallbackPersistedPreview
-          );
-        }
-        if (fallbackPersistedPreview || item.isMinimized) {
-          const fallbackPreview: WorkbenchDockPreviewContent | null =
-            fallbackPersistedPreview
-              ? { kind: "image", src: fallbackPersistedPreview }
+          const fallbackPersistedPreview =
+            !item.isMinimized && cacheKey
+              ? await readPersistedDockPreview(
+                  dockPreviewCacheRef.current,
+                  cacheKey
+                )
               : null;
-          writeDockPopupPreviewImage(
-            previewMemoryKey,
-            fallbackPreview,
-            revision
-          );
+          if (cancelled) {
+            break;
+          }
+          if (fallbackPersistedPreview) {
+            writeCachedWorkbenchNodePreviewImage(
+              item.node.id,
+              fallbackPersistedPreview
+            );
+          }
+          if (fallbackPersistedPreview || item.isMinimized) {
+            const fallbackPreview: WorkbenchDockPreviewContent | null =
+              fallbackPersistedPreview
+                ? { kind: "image", src: fallbackPersistedPreview }
+                : null;
+            writeDockPopupPreviewImage(
+              previewMemoryKey,
+              fallbackPreview,
+              revision
+            );
+          }
+          if (!cancelled) {
+            const fallbackPreview: WorkbenchDockPreviewContent | null =
+              fallbackPersistedPreview
+                ? { kind: "image", src: fallbackPersistedPreview }
+                : null;
+            setCapturedPreviewByMemoryKey((current) => ({
+              ...current,
+              [previewMemoryKey]: { preview: fallbackPreview, revision }
+            }));
+          }
+        } finally {
+          pendingDockPopupPreviewCaptureKeys.delete(pendingCaptureKey);
         }
-        if (!cancelled) {
-          const fallbackPreview: WorkbenchDockPreviewContent | null =
-            fallbackPersistedPreview
-              ? { kind: "image", src: fallbackPersistedPreview }
-              : null;
-          setCapturedPreviewByMemoryKey((current) => ({
-            ...current,
-            [previewMemoryKey]: { preview: fallbackPreview, revision }
-          }));
-        }
-        pendingDockPopupPreviewMemoryKeys.delete(previewMemoryKey);
       }
     })().catch(() => {
       for (const item of missingItems) {
@@ -791,7 +828,12 @@ export function WorkbenchHostDockPopup({
           null,
           item.previewRevision
         );
-        pendingDockPopupPreviewMemoryKeys.delete(previewMemoryKey);
+        pendingDockPopupPreviewCaptureKeys.delete(
+          resolveDockPopupPreviewCaptureKey(
+            previewMemoryKey,
+            item.previewRevision
+          )
+        );
       }
       if (!cancelled) {
         setCapturedPreviewByMemoryKey((current) => ({
@@ -815,22 +857,20 @@ export function WorkbenchHostDockPopup({
     return () => {
       cancelled = true;
       for (const item of missingItems) {
-        pendingDockPopupPreviewMemoryKeys.delete(
-          resolveDockPopupPreviewMemoryKey(
-            item.node,
-            resolveDockPreviewCacheKey?.(item.node) ?? null
-          )
+        const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
+          item.node,
+          resolveDockPreviewCacheKeyRef.current?.(item.node) ?? null
         );
+        const pendingCaptureKey = resolveDockPopupPreviewCaptureKey(
+          previewMemoryKey,
+          item.previewRevision
+        );
+        if (!startedCaptureKeys.has(pendingCaptureKey)) {
+          pendingDockPopupPreviewCaptureKeys.delete(pendingCaptureKey);
+        }
       }
     };
-  }, [
-    capturePreview,
-    dockPreviewCache,
-    isContextMenu,
-    items,
-    previewCaptureKey,
-    resolveDockPreviewCacheKey
-  ]);
+  }, [hasCapturePreview, isContextMenu, previewCaptureKey]);
 
   const content = (
     <div
@@ -1239,6 +1279,13 @@ function resolveDockPopupPreviewMemoryKey(
     typeId: cacheKey.typeId,
     workspaceId: cacheKey.workspaceId
   })}`;
+}
+
+function resolveDockPopupPreviewCaptureKey(
+  memoryKey: string,
+  revision: string | null
+): string {
+  return `${memoryKey}\u0000${revision ?? ""}`;
 }
 
 function normalizeDockPopupPreviewContentResult(

--- a/packages/workbench/surface/src/host/dockMagnification.test.ts
+++ b/packages/workbench/surface/src/host/dockMagnification.test.ts
@@ -12,6 +12,7 @@ import {
   isDockMagnificationSlotLayoutLocked,
   isDockMagnificationSpringSettled,
   mapDistanceToTargetSize,
+  projectDockMagnificationGeometry,
   resolveDockMagnificationHitBounds,
   resolveDockMagnificationSlotLayoutSize,
   resolveDockMagnificationSlotCenter,
@@ -30,6 +31,26 @@ function assertBoundsEqual(
   assert.ok(Math.abs(actual.crossStart - expected.crossStart) < 0.001);
   assert.ok(Math.abs(actual.mainEnd - expected.mainEnd) < 0.001);
   assert.ok(Math.abs(actual.mainStart - expected.mainStart) < 0.001);
+}
+
+function assertRectEqual(
+  actual: {
+    bottom: number;
+    left: number;
+    right: number;
+    top: number;
+  },
+  expected: {
+    bottom: number;
+    left: number;
+    right: number;
+    top: number;
+  }
+) {
+  assert.ok(Math.abs(actual.bottom - expected.bottom) < 0.001);
+  assert.ok(Math.abs(actual.left - expected.left) < 0.001);
+  assert.ok(Math.abs(actual.right - expected.right) < 0.001);
+  assert.ok(Math.abs(actual.top - expected.top) < 0.001);
 }
 
 class FakePointerTrackingTarget {
@@ -369,6 +390,64 @@ test("left dock magnification center ignores the slot's current magnified size",
   );
 
   assert.equal(restCenter, magnifiedCenter);
+});
+
+test("dock magnification projects centered flex reflow without DOM reads", () => {
+  const geometry = projectDockMagnificationGeometry({
+    appliedSizes: new Map([["a", 70]]),
+    dockPlacement: "bottom",
+    mainAxisStartAligned: false,
+    order: ["a", "b"],
+    restRects: new Map([
+      ["a", { bottom: 80, left: 100, right: 143.2, top: 36.8 }],
+      ["b", { bottom: 80, left: 160, right: 203.2, top: 36.8 }]
+    ])
+  });
+
+  assert.equal(geometry.slotRects.length, 2);
+  assertRectEqual(geometry.slotRects[0]!, {
+    bottom: 80,
+    left: 86.6,
+    right: 156.6,
+    top: 10
+  });
+  assertRectEqual(geometry.slotRects[1]!, {
+    bottom: 80,
+    left: 173.4,
+    right: 216.6,
+    top: 36.8
+  });
+  assert.ok(Math.abs(geometry.centers.get("a")! - 108.2) < 0.001);
+  assert.ok(Math.abs(geometry.centers.get("b")! - 195) < 0.001);
+});
+
+test("dock magnification projects start-aligned vertical flex reflow", () => {
+  const geometry = projectDockMagnificationGeometry({
+    appliedSizes: new Map([["a", 70]]),
+    dockPlacement: "left",
+    mainAxisStartAligned: true,
+    order: ["a", "b"],
+    restRects: new Map([
+      ["a", { bottom: 143.2, left: 20, right: 63.2, top: 100 }],
+      ["b", { bottom: 203.2, left: 20, right: 63.2, top: 160 }]
+    ])
+  });
+
+  assert.equal(geometry.slotRects.length, 2);
+  assertRectEqual(geometry.slotRects[0]!, {
+    bottom: 170,
+    left: 6.6,
+    right: 76.6,
+    top: 100
+  });
+  assertRectEqual(geometry.slotRects[1]!, {
+    bottom: 230,
+    left: 20,
+    right: 63.2,
+    top: 186.8
+  });
+  assert.ok(Math.abs(geometry.centers.get("a")! - 121.6) < 0.001);
+  assert.ok(Math.abs(geometry.centers.get("b")! - 208.4) < 0.001);
 });
 
 test("dock magnification spring settles on the target size", () => {

--- a/packages/workbench/surface/src/host/dockMagnification.ts
+++ b/packages/workbench/surface/src/host/dockMagnification.ts
@@ -2,240 +2,82 @@ import { useCallback, useEffect, useRef, type RefObject } from "react";
 import {
   isDockMagnificationPointInsideHitBounds,
   isDockMagnificationPointInsideSlotRect,
+  resolveDockMagnificationHitBounds,
   resolveDockMagnificationVisibleHitBounds,
   resolveDockMagnificationVisibleSlotRects,
   type DockMagnificationHitBounds
 } from "./dockMagnificationBounds.ts";
+import {
+  applyDockMagnificationEntryRamp,
+  DOCK_ICON_BASE_SIZE,
+  DOCK_MAGNIFICATION_HALF_RANGE,
+  mapDistanceToTargetSize,
+  projectDockMagnificationGeometry,
+  type DockMagnificationSlotRect
+} from "./dockMagnificationGeometry.ts";
+import {
+  createDockMagnificationGlobalPointerTracker,
+  dockMagnificationPointerListenerOptions,
+  type DockMagnificationGlobalPointerTracker
+} from "./dockMagnificationPointerTracker.ts";
+import {
+  advanceDockMagnificationSpring,
+  isDockMagnificationSpringSettled,
+  type DockMagnificationSpring
+} from "./dockMagnificationSpring.ts";
 
 export {
   isDockMagnificationPointInsideHitBounds,
   isDockMagnificationPointInsideSlotRect,
+  resolveDockMagnificationHitBounds,
   resolveDockMagnificationVisibleHitBounds,
   resolveDockMagnificationVisibleSlotRects,
   type DockMagnificationHitBounds
 } from "./dockMagnificationBounds.ts";
+export {
+  applyDockMagnificationEntryRamp,
+  DOCK_ICON_BASE_SIZE,
+  DOCK_ICON_PEAK_SIZE,
+  DOCK_MAGNIFICATION_HALF_RANGE,
+  mapDistanceToTargetSize,
+  projectDockMagnificationGeometry,
+  resolveDockMagnificationSlotCenter,
+  type DockMagnificationProjectedGeometry,
+  type DockMagnificationSlotRect
+} from "./dockMagnificationGeometry.ts";
+export {
+  createDockMagnificationGlobalPointerTracker,
+  type DockMagnificationGlobalPointerTracker,
+  type DockMagnificationPointerTrackingTarget
+} from "./dockMagnificationPointerTracker.ts";
+export {
+  advanceDockMagnificationSpring,
+  isDockMagnificationSpringSettled,
+  type DockMagnificationSpring
+} from "./dockMagnificationSpring.ts";
 
-export const DOCK_ICON_BASE_SIZE = 43.2;
-export const DOCK_ICON_PEAK_SIZE = DOCK_ICON_BASE_SIZE * 1.7;
-export const DOCK_MAGNIFICATION_HALF_RANGE = DOCK_ICON_BASE_SIZE * 2.4;
-
-const DOCK_MAGNIFICATION_SPRING_MASS = 0.1;
-const DOCK_MAGNIFICATION_SPRING_STIFFNESS = 200;
-const DOCK_MAGNIFICATION_SPRING_DAMPING = 14;
-const MAGNIFICATION_SETTLE_EPSILON = 0.2;
 const MAGNIFICATION_SIZE_EPSILON = 0.2;
 const MAX_MAGNIFICATION_STEP_SECONDS = 1 / 30;
 const MAGNIFICATION_INFLUENCE_PADDING = 8;
 const DOCK_MAGNIFICATION_ENTRY_RAMP_MS = 90;
-const DOCK_MAGNIFICATION_CROSS_AXIS_PADDING = 8;
 const DOCK_MAGNIFICATION_MAIN_AXIS_EDGE_PADDING = DOCK_ICON_BASE_SIZE / 2;
 const DOCK_MAGNIFICATION_AMBIENT_EDGE_RANGE = 180;
 const DOCK_MAGNIFICATION_AMBIENT_VIEWPORT_PADDING = 8;
-
-interface DockMagnificationSpring {
-  value: number;
-  velocity: number;
-}
 
 interface DockMagnificationAppliedStyle {
   size: number;
 }
 
-export interface DockMagnificationSlotRect {
-  bottom: number;
-  left: number;
-  right: number;
-  top: number;
-}
-
-interface DockMagnificationPointerTrackingTarget {
-  addEventListener: EventTarget["addEventListener"];
-  removeEventListener: EventTarget["removeEventListener"];
-}
-
-interface DockMagnificationGlobalPointerTracker {
-  isActive: () => boolean;
-  start: () => void;
-  stop: () => void;
+interface DockMagnificationGeometryBasis {
+  mainAxisStartAligned: boolean;
+  slotRects: Map<string, DockMagnificationSlotRect>;
+  viewportRect: DockMagnificationSlotRect | null;
 }
 
 const dockMagnificationShellBySlot = new WeakMap<
   HTMLElement,
   HTMLElement | null
 >();
-
-const globalPointerListenerOptions = {
-  capture: true,
-  passive: true
-} as const;
-
-export function mapDistanceToTargetSize(
-  distance: number,
-  baseSize = DOCK_ICON_BASE_SIZE,
-  peakSize = DOCK_ICON_PEAK_SIZE,
-  halfRange = DOCK_MAGNIFICATION_HALF_RANGE
-): number {
-  const absoluteDistance = Math.abs(distance);
-  if (absoluteDistance >= halfRange) {
-    return baseSize;
-  }
-
-  const influence = 1 - absoluteDistance / halfRange;
-  return baseSize + (peakSize - baseSize) * influence;
-}
-
-export function applyDockMagnificationEntryRamp(
-  targetSize: number,
-  baseSize: number,
-  progress: number
-): number {
-  const clampedProgress = Math.min(1, Math.max(0, progress));
-  return baseSize + (targetSize - baseSize) * clampedProgress;
-}
-
-export function resolveDockMagnificationHitBounds(
-  slotRects: readonly DockMagnificationSlotRect[],
-  dockPlacement: "bottom" | "left",
-  crossAxisPadding = DOCK_MAGNIFICATION_CROSS_AXIS_PADDING
-): DockMagnificationHitBounds | null {
-  if (slotRects.length === 0) {
-    return null;
-  }
-
-  let mainStart = Number.POSITIVE_INFINITY;
-  let mainEnd = Number.NEGATIVE_INFINITY;
-  let crossStart = Number.POSITIVE_INFINITY;
-  let crossEnd = Number.NEGATIVE_INFINITY;
-
-  for (const rect of slotRects) {
-    if (dockPlacement === "left") {
-      mainStart = Math.min(mainStart, rect.top);
-      mainEnd = Math.max(mainEnd, rect.bottom);
-      crossStart = Math.min(crossStart, rect.left);
-      crossEnd = Math.max(crossEnd, rect.right);
-    } else {
-      mainStart = Math.min(mainStart, rect.left);
-      mainEnd = Math.max(mainEnd, rect.right);
-      crossStart = Math.min(crossStart, rect.top);
-      crossEnd = Math.max(crossEnd, rect.bottom);
-    }
-  }
-
-  return {
-    crossEnd: crossEnd + crossAxisPadding,
-    crossStart: crossStart - crossAxisPadding,
-    mainEnd,
-    mainStart
-  };
-}
-
-export function createDockMagnificationGlobalPointerTracker({
-  blurTarget,
-  onPointerCancel,
-  onPointerMove,
-  pointerTarget
-}: {
-  blurTarget: DockMagnificationPointerTrackingTarget | null;
-  onPointerCancel: () => void;
-  onPointerMove: (clientX: number, clientY: number) => void;
-  pointerTarget: DockMagnificationPointerTrackingTarget;
-}): DockMagnificationGlobalPointerTracker {
-  let active = false;
-
-  const handlePointerMove = (event: Event) => {
-    const pointerEvent = event as PointerEvent;
-    onPointerMove(pointerEvent.clientX, pointerEvent.clientY);
-  };
-
-  const handlePointerCancel = () => {
-    stop();
-    onPointerCancel();
-  };
-
-  const start = () => {
-    if (active) {
-      return;
-    }
-    active = true;
-    pointerTarget.addEventListener(
-      "pointermove",
-      handlePointerMove,
-      globalPointerListenerOptions
-    );
-    pointerTarget.addEventListener(
-      "pointercancel",
-      handlePointerCancel,
-      globalPointerListenerOptions
-    );
-    blurTarget?.addEventListener("blur", handlePointerCancel);
-  };
-
-  const stop = () => {
-    if (!active) {
-      return;
-    }
-    active = false;
-    pointerTarget.removeEventListener(
-      "pointermove",
-      handlePointerMove,
-      globalPointerListenerOptions
-    );
-    pointerTarget.removeEventListener(
-      "pointercancel",
-      handlePointerCancel,
-      globalPointerListenerOptions
-    );
-    blurTarget?.removeEventListener("blur", handlePointerCancel);
-  };
-
-  return {
-    isActive: () => active,
-    start,
-    stop
-  };
-}
-
-export function resolveDockMagnificationSlotCenter(
-  rect: DockMagnificationSlotRect,
-  dockPlacement: "bottom" | "left",
-  baseSize = DOCK_ICON_BASE_SIZE
-): number {
-  return dockPlacement === "left"
-    ? rect.top + baseSize / 2
-    : rect.left + baseSize / 2;
-}
-
-const DOCK_MAGNIFICATION_SPRING_SUBSTEPS = 8;
-
-export function advanceDockMagnificationSpring(
-  current: DockMagnificationSpring,
-  target: number,
-  deltaSeconds: number
-): DockMagnificationSpring {
-  const subDeltaSeconds = deltaSeconds / DOCK_MAGNIFICATION_SPRING_SUBSTEPS;
-  let { value, velocity } = current;
-
-  for (let step = 0; step < DOCK_MAGNIFICATION_SPRING_SUBSTEPS; step += 1) {
-    const force =
-      -DOCK_MAGNIFICATION_SPRING_STIFFNESS * (value - target) -
-      DOCK_MAGNIFICATION_SPRING_DAMPING * velocity;
-    const acceleration = force / DOCK_MAGNIFICATION_SPRING_MASS;
-    velocity += acceleration * subDeltaSeconds;
-    value += velocity * subDeltaSeconds;
-  }
-
-  return { value, velocity };
-}
-
-export function isDockMagnificationSpringSettled(
-  spring: DockMagnificationSpring,
-  target: number
-): boolean {
-  return (
-    Math.abs(spring.value - target) <= MAGNIFICATION_SETTLE_EPSILON &&
-    Math.abs(spring.velocity) <= MAGNIFICATION_SETTLE_EPSILON
-  );
-}
 
 function roundDockMagnificationSize(size: number): number {
   return Math.round(size * 10) / 10;
@@ -417,10 +259,11 @@ export function useDockMagnification({
   const animationFrameRef = useRef<number | null>(null);
   const lastFrameTimeRef = useRef<number | null>(null);
   const entryRampStartedAtRef = useRef<number | null>(null);
-  const restCentersRef = useRef<Map<string, number> | null>(null);
+  const centersRef = useRef<Map<string, number> | null>(null);
   const hitBoundsRef = useRef<DockMagnificationHitBounds | null>(null);
   const visibleSlotRectsRef = useRef<DockMagnificationSlotRect[] | null>(null);
   const slotOrderRef = useRef<string[]>([]);
+  const geometryBasisRef = useRef<DockMagnificationGeometryBasis | null>(null);
   const magnifyActiveRef = useRef(false);
   const globalPointerTrackerRef =
     useRef<DockMagnificationGlobalPointerTracker | null>(null);
@@ -458,23 +301,52 @@ export function useDockMagnification({
     lastFrameTimeRef.current = null;
   }, []);
 
-  const captureRestCenters = useCallback(() => {
+  const updateProjectedGeometry = useCallback(() => {
+    const basis = geometryBasisRef.current;
+    if (!basis) {
+      return;
+    }
+    const appliedSizes = new Map<string, number>();
+    for (const [anchorKey, style] of appliedStylesRef.current) {
+      appliedSizes.set(anchorKey, style.size);
+    }
+    const geometry = projectDockMagnificationGeometry({
+      appliedSizes,
+      dockPlacement,
+      mainAxisStartAligned: basis.mainAxisStartAligned,
+      order: slotOrderRef.current,
+      restRects: basis.slotRects
+    });
+    hitBoundsRef.current = resolveDockMagnificationVisibleHitBounds({
+      dockPlacement,
+      hitBounds: resolveDockMagnificationHitBounds(
+        geometry.slotRects,
+        dockPlacement
+      ),
+      mainAxisEdgePadding: DOCK_MAGNIFICATION_MAIN_AXIS_EDGE_PADDING,
+      viewportRect: basis.viewportRect
+    });
+    visibleSlotRectsRef.current = resolveDockMagnificationVisibleSlotRects({
+      slotRects: geometry.slotRects,
+      viewportRect: basis.viewportRect
+    });
+    centersRef.current = geometry.centers;
+  }, [dockPlacement]);
+
+  const captureBaseGeometry = useCallback(() => {
     const slots = slotRefs.current;
-    const centers = new Map<string, number>();
-    const slotRects: DockMagnificationSlotRect[] = [];
+    const slotRects = new Map<string, DockMagnificationSlotRect>();
     const order: string[] = [];
     const viewportRect = dockViewportRef.current?.getBoundingClientRect();
     for (const [anchorKey, slotElement] of slots) {
       order.push(anchorKey);
       const rect = slotElement.getBoundingClientRect();
-      slotRects.push({
+      slotRects.set(anchorKey, {
         bottom: rect.bottom,
         left: rect.left,
         right: rect.right,
         top: rect.top
       });
-      const center = resolveDockMagnificationSlotCenter(rect, dockPlacement);
-      centers.set(anchorKey, center);
     }
     slotOrderRef.current = order;
     const visibleViewportRect = viewportRect
@@ -485,18 +357,14 @@ export function useDockMagnification({
           top: viewportRect.top
         }
       : null;
-    hitBoundsRef.current = resolveDockMagnificationVisibleHitBounds({
-      dockPlacement,
-      hitBounds: resolveDockMagnificationHitBounds(slotRects, dockPlacement),
-      mainAxisEdgePadding: DOCK_MAGNIFICATION_MAIN_AXIS_EDGE_PADDING,
-      viewportRect: visibleViewportRect
-    });
-    visibleSlotRectsRef.current = resolveDockMagnificationVisibleSlotRects({
+    geometryBasisRef.current = {
+      mainAxisStartAligned:
+        dockRootRef.current?.hasAttribute("data-scroll-overflow") ?? false,
       slotRects,
       viewportRect: visibleViewportRect
-    });
-    restCentersRef.current = centers;
-  }, [dockPlacement, dockViewportRef, slotRefs]);
+    };
+    updateProjectedGeometry();
+  }, [dockRootRef, dockViewportRef, slotRefs, updateProjectedGeometry]);
 
   const isPointerInsideAnyVisibleDockSlot = useCallback(
     (clientX: number, clientY: number): boolean => {
@@ -518,13 +386,13 @@ export function useDockMagnification({
 
   const ensureDockMagnificationGeometry = useCallback(() => {
     if (
-      restCentersRef.current === null ||
+      centersRef.current === null ||
       hitBoundsRef.current === null ||
       visibleSlotRectsRef.current === null
     ) {
-      captureRestCenters();
+      captureBaseGeometry();
     }
-  }, [captureRestCenters]);
+  }, [captureBaseGeometry]);
 
   const isPointerInsideDockMagnificationTarget = useCallback(
     (clientX: number, clientY: number): boolean =>
@@ -545,7 +413,6 @@ export function useDockMagnification({
 
       const pointerAxis = pointerAxisRef.current;
       if (pointerAxis !== null) {
-        captureRestCenters();
         entryRampStartedAtRef.current ??= frameTime;
       }
       const slots = slotRefs.current;
@@ -576,7 +443,7 @@ export function useDockMagnification({
           continue;
         }
 
-        const center = restCentersRef.current?.get(anchorKey);
+        const center = centersRef.current?.get(anchorKey);
         if (center === undefined) {
           continue;
         }
@@ -663,6 +530,7 @@ export function useDockMagnification({
           appliedStylesRef.current
         );
       }
+      updateProjectedGeometry();
 
       if (pointerAxis !== null) {
         shouldContinue = true;
@@ -672,10 +540,11 @@ export function useDockMagnification({
 
       if (pointerAxis === null && allSettled) {
         entryRampStartedAtRef.current = null;
-        restCentersRef.current = null;
+        centersRef.current = null;
         hitBoundsRef.current = null;
         visibleSlotRectsRef.current = null;
         slotOrderRef.current = [];
+        geometryBasisRef.current = null;
         setMagnifyActive(false);
       }
 
@@ -687,7 +556,7 @@ export function useDockMagnification({
       animationFrameRef.current = null;
       lastFrameTimeRef.current = null;
     },
-    [captureRestCenters, setMagnifyActive, slotRefs]
+    [setMagnifyActive, slotRefs, updateProjectedGeometry]
   );
 
   const scheduleAnimation = useCallback(() => {
@@ -841,13 +710,13 @@ export function useDockMagnification({
     document.addEventListener(
       "pointermove",
       handleAmbientPointerMove,
-      globalPointerListenerOptions
+      dockMagnificationPointerListenerOptions
     );
     return () => {
       document.removeEventListener(
         "pointermove",
         handleAmbientPointerMove,
-        globalPointerListenerOptions
+        dockMagnificationPointerListenerOptions
       );
       clearAmbientPointerSample();
     };
@@ -868,10 +737,11 @@ export function useDockMagnification({
   const clearSlotMagnification = useCallback(
     (anchorKey: string) => {
       springsRef.current.delete(anchorKey);
-      restCentersRef.current?.delete(anchorKey);
+      centersRef.current = null;
       appliedStylesRef.current.delete(anchorKey);
       hitBoundsRef.current = null;
       visibleSlotRectsRef.current = null;
+      geometryBasisRef.current = null;
       slotOrderRef.current = slotOrderRef.current.filter(
         (key) => key !== anchorKey
       );
@@ -900,10 +770,11 @@ export function useDockMagnification({
     }
     springsRef.current.clear();
     appliedStylesRef.current.clear();
-    restCentersRef.current = null;
+    centersRef.current = null;
     hitBoundsRef.current = null;
     visibleSlotRectsRef.current = null;
     slotOrderRef.current = [];
+    geometryBasisRef.current = null;
     pointerAxisRef.current = null;
     pendingPointerAxisRef.current = null;
     entryRampStartedAtRef.current = null;

--- a/packages/workbench/surface/src/host/dockMagnificationBounds.ts
+++ b/packages/workbench/surface/src/host/dockMagnificationBounds.ts
@@ -1,10 +1,48 @@
-import type { DockMagnificationSlotRect } from "./dockMagnification.ts";
+import type { DockMagnificationSlotRect } from "./dockMagnificationGeometry.ts";
+
+const DOCK_MAGNIFICATION_CROSS_AXIS_PADDING = 8;
 
 export interface DockMagnificationHitBounds {
   crossEnd: number;
   crossStart: number;
   mainEnd: number;
   mainStart: number;
+}
+
+export function resolveDockMagnificationHitBounds(
+  slotRects: readonly DockMagnificationSlotRect[],
+  dockPlacement: "bottom" | "left",
+  crossAxisPadding = DOCK_MAGNIFICATION_CROSS_AXIS_PADDING
+): DockMagnificationHitBounds | null {
+  if (slotRects.length === 0) {
+    return null;
+  }
+
+  let mainStart = Number.POSITIVE_INFINITY;
+  let mainEnd = Number.NEGATIVE_INFINITY;
+  let crossStart = Number.POSITIVE_INFINITY;
+  let crossEnd = Number.NEGATIVE_INFINITY;
+
+  for (const rect of slotRects) {
+    if (dockPlacement === "left") {
+      mainStart = Math.min(mainStart, rect.top);
+      mainEnd = Math.max(mainEnd, rect.bottom);
+      crossStart = Math.min(crossStart, rect.left);
+      crossEnd = Math.max(crossEnd, rect.right);
+    } else {
+      mainStart = Math.min(mainStart, rect.left);
+      mainEnd = Math.max(mainEnd, rect.right);
+      crossStart = Math.min(crossStart, rect.top);
+      crossEnd = Math.max(crossEnd, rect.bottom);
+    }
+  }
+
+  return {
+    crossEnd: crossEnd + crossAxisPadding,
+    crossStart: crossStart - crossAxisPadding,
+    mainEnd,
+    mainStart
+  };
 }
 
 function resolveDockMagnificationViewportBounds(

--- a/packages/workbench/surface/src/host/dockMagnificationGeometry.ts
+++ b/packages/workbench/surface/src/host/dockMagnificationGeometry.ts
@@ -1,0 +1,117 @@
+export const DOCK_ICON_BASE_SIZE = 43.2;
+export const DOCK_ICON_PEAK_SIZE = DOCK_ICON_BASE_SIZE * 1.7;
+export const DOCK_MAGNIFICATION_HALF_RANGE = DOCK_ICON_BASE_SIZE * 2.4;
+
+export interface DockMagnificationSlotRect {
+  bottom: number;
+  left: number;
+  right: number;
+  top: number;
+}
+
+export interface DockMagnificationProjectedGeometry {
+  centers: Map<string, number>;
+  slotRects: DockMagnificationSlotRect[];
+}
+
+export function mapDistanceToTargetSize(
+  distance: number,
+  baseSize = DOCK_ICON_BASE_SIZE,
+  peakSize = DOCK_ICON_PEAK_SIZE,
+  halfRange = DOCK_MAGNIFICATION_HALF_RANGE
+): number {
+  const absoluteDistance = Math.abs(distance);
+  if (absoluteDistance >= halfRange) {
+    return baseSize;
+  }
+
+  const influence = 1 - absoluteDistance / halfRange;
+  return baseSize + (peakSize - baseSize) * influence;
+}
+
+export function applyDockMagnificationEntryRamp(
+  targetSize: number,
+  baseSize: number,
+  progress: number
+): number {
+  const clampedProgress = Math.min(1, Math.max(0, progress));
+  return baseSize + (targetSize - baseSize) * clampedProgress;
+}
+
+export function resolveDockMagnificationSlotCenter(
+  rect: DockMagnificationSlotRect,
+  dockPlacement: "bottom" | "left",
+  baseSize = DOCK_ICON_BASE_SIZE
+): number {
+  return dockPlacement === "left"
+    ? rect.top + baseSize / 2
+    : rect.left + baseSize / 2;
+}
+
+export function projectDockMagnificationGeometry({
+  appliedSizes,
+  dockPlacement,
+  mainAxisStartAligned,
+  order,
+  restRects
+}: {
+  appliedSizes: ReadonlyMap<string, number>;
+  dockPlacement: "bottom" | "left";
+  mainAxisStartAligned: boolean;
+  order: readonly string[];
+  restRects: ReadonlyMap<string, DockMagnificationSlotRect>;
+}): DockMagnificationProjectedGeometry {
+  const growthByAnchorKey = new Map<string, number>();
+  let totalGrowth = 0;
+  for (const anchorKey of order) {
+    const restRect = restRects.get(anchorKey);
+    if (!restRect) {
+      continue;
+    }
+    const restMainSize =
+      dockPlacement === "left"
+        ? restRect.bottom - restRect.top
+        : restRect.right - restRect.left;
+    const growth = (appliedSizes.get(anchorKey) ?? restMainSize) - restMainSize;
+    growthByAnchorKey.set(anchorKey, growth);
+    totalGrowth += growth;
+  }
+
+  let mainAxisOffset = mainAxisStartAligned ? 0 : -totalGrowth / 2;
+  const centers = new Map<string, number>();
+  const slotRects: DockMagnificationSlotRect[] = [];
+  for (const anchorKey of order) {
+    const restRect = restRects.get(anchorKey);
+    if (!restRect) {
+      continue;
+    }
+    const growth = growthByAnchorKey.get(anchorKey) ?? 0;
+    const restMainSize =
+      dockPlacement === "left"
+        ? restRect.bottom - restRect.top
+        : restRect.right - restRect.left;
+    const size = restMainSize + growth;
+    const rect =
+      dockPlacement === "left"
+        ? {
+            bottom: restRect.top + mainAxisOffset + size,
+            left: (restRect.left + restRect.right - size) / 2,
+            right: (restRect.left + restRect.right + size) / 2,
+            top: restRect.top + mainAxisOffset
+          }
+        : {
+            bottom: restRect.bottom,
+            left: restRect.left + mainAxisOffset,
+            right: restRect.left + mainAxisOffset + size,
+            top: restRect.bottom - size
+          };
+    slotRects.push(rect);
+    centers.set(
+      anchorKey,
+      resolveDockMagnificationSlotCenter(rect, dockPlacement)
+    );
+    mainAxisOffset += growth;
+  }
+
+  return { centers, slotRects };
+}

--- a/packages/workbench/surface/src/host/dockMagnificationPointerTracker.ts
+++ b/packages/workbench/surface/src/host/dockMagnificationPointerTracker.ts
@@ -1,0 +1,81 @@
+export interface DockMagnificationPointerTrackingTarget {
+  addEventListener: EventTarget["addEventListener"];
+  removeEventListener: EventTarget["removeEventListener"];
+}
+
+export interface DockMagnificationGlobalPointerTracker {
+  isActive: () => boolean;
+  start: () => void;
+  stop: () => void;
+}
+
+export const dockMagnificationPointerListenerOptions = {
+  capture: true,
+  passive: true
+} as const;
+
+export function createDockMagnificationGlobalPointerTracker({
+  blurTarget,
+  onPointerCancel,
+  onPointerMove,
+  pointerTarget
+}: {
+  blurTarget: DockMagnificationPointerTrackingTarget | null;
+  onPointerCancel: () => void;
+  onPointerMove: (clientX: number, clientY: number) => void;
+  pointerTarget: DockMagnificationPointerTrackingTarget;
+}): DockMagnificationGlobalPointerTracker {
+  let active = false;
+
+  const handlePointerMove = (event: Event) => {
+    const pointerEvent = event as PointerEvent;
+    onPointerMove(pointerEvent.clientX, pointerEvent.clientY);
+  };
+
+  const handlePointerCancel = () => {
+    stop();
+    onPointerCancel();
+  };
+
+  const start = () => {
+    if (active) {
+      return;
+    }
+    active = true;
+    pointerTarget.addEventListener(
+      "pointermove",
+      handlePointerMove,
+      dockMagnificationPointerListenerOptions
+    );
+    pointerTarget.addEventListener(
+      "pointercancel",
+      handlePointerCancel,
+      dockMagnificationPointerListenerOptions
+    );
+    blurTarget?.addEventListener("blur", handlePointerCancel);
+  };
+
+  const stop = () => {
+    if (!active) {
+      return;
+    }
+    active = false;
+    pointerTarget.removeEventListener(
+      "pointermove",
+      handlePointerMove,
+      dockMagnificationPointerListenerOptions
+    );
+    pointerTarget.removeEventListener(
+      "pointercancel",
+      handlePointerCancel,
+      dockMagnificationPointerListenerOptions
+    );
+    blurTarget?.removeEventListener("blur", handlePointerCancel);
+  };
+
+  return {
+    isActive: () => active,
+    start,
+    stop
+  };
+}

--- a/packages/workbench/surface/src/host/dockMagnificationSpring.ts
+++ b/packages/workbench/surface/src/host/dockMagnificationSpring.ts
@@ -1,0 +1,40 @@
+const DOCK_MAGNIFICATION_SPRING_MASS = 0.1;
+const DOCK_MAGNIFICATION_SPRING_STIFFNESS = 200;
+const DOCK_MAGNIFICATION_SPRING_DAMPING = 14;
+const DOCK_MAGNIFICATION_SPRING_SUBSTEPS = 8;
+const MAGNIFICATION_SETTLE_EPSILON = 0.2;
+
+export interface DockMagnificationSpring {
+  value: number;
+  velocity: number;
+}
+
+export function advanceDockMagnificationSpring(
+  current: DockMagnificationSpring,
+  target: number,
+  deltaSeconds: number
+): DockMagnificationSpring {
+  const subDeltaSeconds = deltaSeconds / DOCK_MAGNIFICATION_SPRING_SUBSTEPS;
+  let { value, velocity } = current;
+
+  for (let step = 0; step < DOCK_MAGNIFICATION_SPRING_SUBSTEPS; step += 1) {
+    const force =
+      -DOCK_MAGNIFICATION_SPRING_STIFFNESS * (value - target) -
+      DOCK_MAGNIFICATION_SPRING_DAMPING * velocity;
+    const acceleration = force / DOCK_MAGNIFICATION_SPRING_MASS;
+    velocity += acceleration * subDeltaSeconds;
+    value += velocity * subDeltaSeconds;
+  }
+
+  return { value, velocity };
+}
+
+export function isDockMagnificationSpringSettled(
+  spring: DockMagnificationSpring,
+  target: number
+): boolean {
+  return (
+    Math.abs(spring.value - target) <= MAGNIFICATION_SETTLE_EPSILON &&
+    Math.abs(spring.velocity) <= MAGNIFICATION_SETTLE_EPSILON
+  );
+}


### PR DESCRIPTION
## Summary
- render AgentGUI WebGL only for initialization, texture or size changes, and carousel selection motion; stop frames after settling; run only the active visible DOM record through a compositor animation
- cache Dock magnification geometry for the pointer session
- capture only the requested Dock preview region and keep issued captures deduplicated across effect replacement
- share Provider snapshots, refresh debounce, and in-flight probes across AgentGUI surfaces in one workspace renderer

## Tests
- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- `pnpm --filter @tutti-os/workbench-surface test`
- `pnpm --filter @tutti-os/agent-gui test`
- `pnpm --filter @tutti-os/workbench-electron test`
- targeted Desktop Agent status source tests

## Notes
- the latest 15-second trace removed all AgentGUI WebGL animation callbacks, reduced JavaScript animation-frame callbacks from 3,845 to 515, RasterTask events from 14,796 to 1,010, and GPUTask events from 7,238 to 795; the active DOM record still produces compositor draw frames by design
- the Provider sharing change is source-backed; the supplied trace did not contain that request chain
- standalone renderer processes retain separate one-hour snapshots; Electron main remains the cross-window short-lived Provider cache

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

