### PR TITLE
fix(agent): scope startup locks by session

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -22,7 +22,8 @@ Use the focused runtime index or open one area directly:
 - [Agent Sessions And Lifecycle](./agent-session-lifecycle.md): Turn state, activation, planning-mode classification, Tutti workflow response contracts, loading, cancel, goal controls, restore, file-change undo, rail projection, realtime completion provenance, event updates, imports, and performance.
   Includes shared-device recovery that looks terminal while the host is still retrying.
   Also covers new-conversation requests that silently fail after a Chats
-  Session working directory is mistaken for a selected project.
+  Session working directory is mistaken for a selected project, and one hung
+  provider startup blocking unrelated Agent sessions.
 - [Agent Approvals And Child Sessions](./agent-approvals-subagents.md): Approval gates, plan exits, root/parent/child event attribution, child sessions, and Message Center.
   Includes provider-native work that continues invisibly after root cancellation
   and late child creation racing the durable cancel boundary.

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -49,6 +49,7 @@ Provider discovery, installation, authentication, models, configuration, and run
 Turn state, loading, cancel, restore, rail projection, event updates, imports, and performance.
 
 - [AgentGUI turn actions return plain-text route 404s](./agent-session-lifecycle.md#agentgui-turn-actions-return-plain-text-route-404s)
+- [One hung provider startup blocks unrelated Agent sessions](./agent-session-lifecycle.md#one-hung-provider-startup-blocks-unrelated-agent-sessions)
 - [AgentGUI rail shows a failed Turn but the detail has no error](./agent-session-lifecycle.md#agentgui-rail-shows-a-failed-turn-but-the-detail-has-no-error)
 - [AgentGUI Stop reports no active turn after cancel succeeds](./agent-session-lifecycle.md#agentgui-stop-reports-no-active-turn-after-cancel-succeeds)
 - [AgentGUI send blocked by active_turn after settled snapshot](./agent-session-lifecycle.md#agentgui-send-blocked-by-activeturn-after-settled-snapshot)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -2,6 +2,32 @@
 
 [Agent runtime index](./agent-runtime.md) · [All troubleshooting](./README.md)
 
+### One hung provider startup blocks unrelated Agent sessions
+
+- **Symptom:** One provider process starts but never reaches runtime-ready, then
+  new or resumed Sessions for other providers also wait without starting their
+  own provider processes.
+- **Quick checks:** Order `agent_session.process.start.sent` with Host
+  `runtime_started` and `runtime_session_ready` lifecycle steps. If later,
+  unrelated Sessions accumulate wait time before their own process-start event,
+  inspect Controller startup-lock ownership separately from the provider that
+  first stopped making progress.
+- **Root cause:** The runtime Controller held one process-wide `startMu` across
+  `Adapter.Start` and `Adapter.Resume`. A slow or unbounded provider handshake
+  therefore formed a lock convoy across every room, Session, and provider.
+- **Fix:** Serialize explicit startup requests by `(roomID, agentSessionID)`.
+  Keep the legacy no-ID start path idempotent with a narrower room-and-provider
+  key, and let startup-lock waiters return when their context is canceled.
+  Provider credential coordination remains a separate Host gate.
+- **Validation:** Block each of `Start` and `Resume` for one provider and prove
+  both operations still complete for an independent provider. Also verify all
+  same-Session combinations remain serialized, anonymous start replay reuses
+  one Session, canceled waiters release their lock references, and repeated
+  shuffled race runs stay clean.
+- **References:**
+  [controller_session_lifecycle.go](../../../packages/agent/daemon/runtime/controller_session_lifecycle.go),
+  [controller_test.go](../../../packages/agent/daemon/runtime/controller_test.go)
+
 ### A shared-device connection banner looks terminal while the host is still retrying
 
 - **Symptom:** AgentGUI keeps showing a strong connection-lost notice for a

--- a/packages/agent/daemon/README.md
+++ b/packages/agent/daemon/README.md
@@ -27,6 +27,12 @@ if err != nil {
 controller := runtime.Controller()
 ```
 
+Controller startup coordination is scoped to one Session. The legacy `Start`
+form that omits `AgentSessionID` is scoped by room and provider while it
+allocates and deduplicates the Session ID. Provider-specific credential
+coordination belongs in the Host startup gate; provider I/O must not run under
+a process-wide Controller startup lock.
+
 `Controller.SubscribeWhenAvailable` is the observation-only stream attachment
 for consumers that already have durable session identity but may race runtime
 resume after a daemon restart. It waits for `Start`, `Resume`, or

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -24,7 +24,6 @@ const interactiveDenyFollowUpPollInterval = 25 * time.Millisecond
 type execMetadataContextKey struct{}
 
 type Controller struct {
-	startMu                     sync.Mutex
 	mu                          sync.Mutex
 	streamObserverMu            sync.RWMutex
 	sessions                    map[string]Session
@@ -37,7 +36,8 @@ type Controller struct {
 	configOptionsUpdates        map[string]AgentSessionConfigOptionsUpdate
 	pendingConfigOptionsUpdates map[string][]AgentSessionConfigOptionsUpdate
 	provisionalSessions         map[string]bool
-	lifecycleLocks              map[string]*sessionLifecycleLock
+	startupLocks                map[startupLockKey]*controllerLifecycleLock
+	lifecycleLocks              map[string]*controllerLifecycleLock
 	hub                         *EventHub
 	reporter                    DurableActivityReporter
 	reportQueue                 *reportRequestQueue
@@ -58,9 +58,17 @@ type RuntimeStreamEventObserver interface {
 	) error
 }
 
-type sessionLifecycleLock struct {
+type controllerLifecycleLock struct {
 	gate chan struct{}
 	refs int
+}
+
+// startupLockKey uses agentSessionID for normal Host calls. Provider is set
+// only for the legacy path that asks Controller.Start to allocate the ID.
+type startupLockKey struct {
+	roomID         string
+	agentSessionID string
+	provider       string
 }
 
 type sessionAvailabilityWaiter struct {
@@ -139,7 +147,8 @@ func NewControllerWithAdapterResolver(adapters []Adapter, reporter DurableActivi
 		configOptionsUpdates:        make(map[string]AgentSessionConfigOptionsUpdate),
 		pendingConfigOptionsUpdates: make(map[string][]AgentSessionConfigOptionsUpdate),
 		provisionalSessions:         make(map[string]bool),
-		lifecycleLocks:              make(map[string]*sessionLifecycleLock),
+		startupLocks:                make(map[startupLockKey]*controllerLifecycleLock),
+		lifecycleLocks:              make(map[string]*controllerLifecycleLock),
 		hub:                         NewEventHub(),
 		reporter:                    reporter,
 	}

--- a/packages/agent/daemon/runtime/controller_session_lifecycle.go
+++ b/packages/agent/daemon/runtime/controller_session_lifecycle.go
@@ -11,9 +11,6 @@ import (
 )
 
 func (c *Controller) Start(ctx context.Context, input StartInput) (StartResult, error) {
-	c.startMu.Lock()
-	defer c.startMu.Unlock()
-
 	roomID := strings.TrimSpace(input.RoomID)
 	provider := strings.TrimSpace(input.Provider)
 	if roomID == "" {
@@ -22,6 +19,13 @@ func (c *Controller) Start(ctx context.Context, input StartInput) (StartResult, 
 	if provider == "" {
 		return StartResult{}, fmt.Errorf("provider is required")
 	}
+	agentSessionID := strings.TrimSpace(input.AgentSessionID)
+	releaseStartupLock, err := c.acquireStartupLockContext(ctx, roomID, agentSessionID, provider)
+	if err != nil {
+		return StartResult{}, err
+	}
+	defer releaseStartupLock()
+
 	adapter, err := c.resolveAdapter(ctx, AdapterResolveInput{Provider: provider, AgentTargetID: input.AgentTargetID, CWD: input.CWD, ProviderTargetRef: clonePayload(input.ProviderTargetRef)})
 	if err != nil {
 		return StartResult{}, err
@@ -30,7 +34,6 @@ func (c *Controller) Start(ctx context.Context, input StartInput) (StartResult, 
 		return StartResult{}, fmt.Errorf("unsupported agent session provider %q", provider)
 	}
 	timestamp := unixMS(now())
-	agentSessionID := strings.TrimSpace(input.AgentSessionID)
 	settings := normalizeSessionSettings(
 		input.Settings,
 		provider,
@@ -111,9 +114,6 @@ func (c *Controller) Start(ctx context.Context, input StartInput) (StartResult, 
 }
 
 func (c *Controller) Resume(ctx context.Context, input ResumeInput) (Session, error) {
-	c.startMu.Lock()
-	defer c.startMu.Unlock()
-
 	roomID := strings.TrimSpace(input.RoomID)
 	agentSessionID := strings.TrimSpace(input.AgentSessionID)
 	provider := strings.TrimSpace(input.Provider)
@@ -130,6 +130,12 @@ func (c *Controller) Resume(ctx context.Context, input ResumeInput) (Session, er
 	if providerSessionID == "" {
 		return Session{}, fmt.Errorf("provider session id is required")
 	}
+	releaseStartupLock, err := c.acquireStartupLockContext(ctx, roomID, agentSessionID, provider)
+	if err != nil {
+		return Session{}, err
+	}
+	defer releaseStartupLock()
+
 	if existing, ok := c.get(roomID, agentSessionID); ok {
 		return existing, nil
 	}

--- a/packages/agent/daemon/runtime/controller_session_registry.go
+++ b/packages/agent/daemon/runtime/controller_session_registry.go
@@ -210,7 +210,7 @@ func (c *Controller) acquireLifecycleLockContext(ctx context.Context, roomID, ag
 	c.mu.Lock()
 	lock := c.lifecycleLocks[key]
 	if lock == nil {
-		lock = &sessionLifecycleLock{gate: make(chan struct{}, 1)}
+		lock = &controllerLifecycleLock{gate: make(chan struct{}, 1)}
 		lock.gate <- struct{}{}
 		c.lifecycleLocks[key] = lock
 	}
@@ -234,11 +234,63 @@ func (c *Controller) acquireLifecycleLockContext(ctx context.Context, roomID, ag
 	}, nil
 }
 
-func (c *Controller) releaseLifecycleLockReference(key string, lock *sessionLifecycleLock) {
+func (c *Controller) releaseLifecycleLockReference(key string, lock *controllerLifecycleLock) {
 	c.mu.Lock()
 	lock.refs--
 	if lock.refs <= 0 && c.lifecycleLocks[key] == lock {
 		delete(c.lifecycleLocks, key)
+	}
+	c.mu.Unlock()
+}
+
+func (c *Controller) acquireStartupLockContext(
+	ctx context.Context,
+	roomID string,
+	agentSessionID string,
+	provider string,
+) (func(), error) {
+	if c == nil {
+		return func() {}, nil
+	}
+	key := startupLockKey{
+		roomID:         strings.TrimSpace(roomID),
+		agentSessionID: strings.TrimSpace(agentSessionID),
+	}
+	if key.agentSessionID == "" {
+		key.provider = strings.TrimSpace(provider)
+	}
+	c.mu.Lock()
+	lock := c.startupLocks[key]
+	if lock == nil {
+		lock = &controllerLifecycleLock{gate: make(chan struct{}, 1)}
+		lock.gate <- struct{}{}
+		c.startupLocks[key] = lock
+	}
+	lock.refs++
+	c.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		c.releaseStartupLockReference(key, lock)
+		return func() {}, ctx.Err()
+	case <-lock.gate:
+	}
+	if err := ctx.Err(); err != nil {
+		lock.gate <- struct{}{}
+		c.releaseStartupLockReference(key, lock)
+		return func() {}, err
+	}
+	return func() {
+		lock.gate <- struct{}{}
+		c.releaseStartupLockReference(key, lock)
+	}, nil
+}
+
+func (c *Controller) releaseStartupLockReference(key startupLockKey, lock *controllerLifecycleLock) {
+	c.mu.Lock()
+	lock.refs--
+	if lock.refs <= 0 && c.startupLocks[key] == lock {
+		delete(c.startupLocks, key)
 	}
 	c.mu.Unlock()
 }

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -245,6 +245,267 @@ func TestControllerStartFailureDoesNotCreateCanonicalSessionOrTurnlessMessage(t 
 	}
 }
 
+func TestControllerStartupOperationsDoNotBlockIndependentSessions(t *testing.T) {
+	tests := []struct {
+		name              string
+		blocking          string
+		following         string
+		followingProvider string
+	}{
+		{name: "other provider start while start is blocked", blocking: "start", following: "start", followingProvider: ProviderCodex},
+		{name: "other provider resume while start is blocked", blocking: "start", following: "resume", followingProvider: ProviderCodex},
+		{name: "other provider start while resume is blocked", blocking: "resume", following: "start", followingProvider: ProviderCodex},
+		{name: "other provider resume while resume is blocked", blocking: "resume", following: "resume", followingProvider: ProviderCodex},
+		{name: "same provider start while start is blocked", blocking: "start", following: "start", followingProvider: ProviderClaudeCode},
+		{name: "same provider resume while start is blocked", blocking: "start", following: "resume", followingProvider: ProviderClaudeCode},
+		{name: "same provider start while resume is blocked", blocking: "resume", following: "start", followingProvider: ProviderClaudeCode},
+		{name: "same provider resume while resume is blocked", blocking: "resume", following: "resume", followingProvider: ProviderClaudeCode},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			blocker := &blockingStartupAdapter{
+				recordingStartAdapter: recordingStartAdapter{provider: ProviderClaudeCode},
+				operation:             test.blocking,
+				blockedSessionID:      "blocked-session",
+				entered:               make(chan struct{}),
+				release:               make(chan struct{}),
+			}
+			adapters := []Adapter{blocker}
+			if test.followingProvider != ProviderClaudeCode {
+				adapters = append(adapters, &recordingStartAdapter{provider: test.followingProvider})
+			}
+			controller := NewController(adapters, nil)
+
+			blocked := make(chan error, 1)
+			go func() {
+				blocked <- invokeControllerStartupOperation(
+					context.Background(),
+					controller,
+					test.blocking,
+					ProviderClaudeCode,
+					"blocked-session",
+				)
+			}()
+			select {
+			case <-blocker.entered:
+			case <-time.After(time.Second):
+				t.Fatal("blocking startup operation was not entered")
+			}
+
+			completed := make(chan error, 1)
+			go func() {
+				completed <- invokeControllerStartupOperation(
+					context.Background(),
+					controller,
+					test.following,
+					test.followingProvider,
+					"independent-session",
+				)
+			}()
+
+			select {
+			case err := <-completed:
+				if err != nil {
+					close(blocker.release)
+					<-blocked
+					t.Fatalf("independent startup operation: %v", err)
+				}
+			case <-time.After(time.Second):
+				close(blocker.release)
+				<-blocked
+				<-completed
+				t.Fatal("independent provider startup was blocked")
+			}
+
+			close(blocker.release)
+			if err := <-blocked; err != nil {
+				t.Fatalf("blocking startup operation: %v", err)
+			}
+		})
+	}
+}
+
+func TestControllerStartupLockPreservesSameSessionSerialization(t *testing.T) {
+	tests := []struct {
+		name      string
+		blocking  string
+		following string
+	}{
+		{name: "start then start", blocking: "start", following: "start"},
+		{name: "start then resume", blocking: "start", following: "resume"},
+		{name: "resume then start", blocking: "resume", following: "start"},
+		{name: "resume then resume", blocking: "resume", following: "resume"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			adapter := &blockingStartupAdapter{
+				recordingStartAdapter: recordingStartAdapter{provider: ProviderClaudeCode},
+				operation:             test.blocking,
+				blockedSessionID:      "same-session",
+				entered:               make(chan struct{}),
+				release:               make(chan struct{}),
+			}
+			controller := NewController([]Adapter{adapter}, nil)
+
+			blocked := make(chan error, 1)
+			go func() {
+				blocked <- invokeControllerStartupOperation(
+					context.Background(),
+					controller,
+					test.blocking,
+					ProviderClaudeCode,
+					"same-session",
+				)
+			}()
+			select {
+			case <-adapter.entered:
+			case <-time.After(time.Second):
+				t.Fatal("blocking startup operation was not entered")
+			}
+
+			waitCtx, cancelWait := context.WithCancel(context.Background())
+			waiting := make(chan error, 1)
+			go func() {
+				waiting <- invokeControllerStartupOperation(
+					waitCtx,
+					controller,
+					test.following,
+					ProviderClaudeCode,
+					"same-session",
+				)
+			}()
+			cancelWait()
+			select {
+			case err := <-waiting:
+				if !errors.Is(err, context.Canceled) {
+					close(adapter.release)
+					<-blocked
+					t.Fatalf("waiting startup error = %v, want context canceled", err)
+				}
+			case <-time.After(time.Second):
+				close(adapter.release)
+				<-blocked
+				<-waiting
+				t.Fatal("same-session startup lock did not honor context cancellation")
+			}
+
+			close(adapter.release)
+			if err := <-blocked; err != nil {
+				t.Fatalf("blocking startup operation: %v", err)
+			}
+			if err := invokeControllerStartupOperation(
+				context.Background(),
+				controller,
+				test.following,
+				ProviderClaudeCode,
+				"same-session",
+			); err != nil {
+				t.Fatalf("startup replay: %v", err)
+			}
+			if calls := adapter.startCalls.Load() + adapter.resumeCalls.Load(); calls != 1 {
+				t.Fatalf("adapter startup calls = %d, want 1", calls)
+			}
+			if locks := len(controller.startupLocks); locks != 0 {
+				t.Fatalf("startup locks = %d, want 0", locks)
+			}
+		})
+	}
+}
+
+func TestControllerAnonymousStartsRemainProviderScopedAndIdempotent(t *testing.T) {
+	adapter := &blockingStartupAdapter{
+		recordingStartAdapter: recordingStartAdapter{provider: ProviderClaudeCode},
+		operation:             "start",
+		entered:               make(chan struct{}),
+		release:               make(chan struct{}),
+	}
+	controller := NewController([]Adapter{adapter}, nil)
+	input := StartInput{RoomID: "room-1", Provider: ProviderClaudeCode}
+
+	firstResult := make(chan StartResult, 1)
+	firstErr := make(chan error, 1)
+	go func() {
+		result, err := controller.Start(context.Background(), input)
+		firstResult <- result
+		firstErr <- err
+	}()
+	select {
+	case <-adapter.entered:
+	case <-time.After(time.Second):
+		t.Fatal("blocking anonymous start was not entered")
+	}
+
+	waitCtx, cancelWait := context.WithCancel(context.Background())
+	waiting := make(chan error, 1)
+	go func() {
+		_, err := controller.Start(waitCtx, input)
+		waiting <- err
+	}()
+	cancelWait()
+	select {
+	case err := <-waiting:
+		if !errors.Is(err, context.Canceled) {
+			close(adapter.release)
+			<-firstResult
+			<-firstErr
+			t.Fatalf("waiting anonymous start error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		close(adapter.release)
+		<-firstResult
+		<-firstErr
+		<-waiting
+		t.Fatal("anonymous startup lock did not honor context cancellation")
+	}
+
+	close(adapter.release)
+	first := <-firstResult
+	if err := <-firstErr; err != nil {
+		t.Fatalf("first anonymous start: %v", err)
+	}
+	replayed, err := controller.Start(context.Background(), input)
+	if err != nil {
+		t.Fatalf("replayed anonymous start: %v", err)
+	}
+	if replayed.Session.AgentSessionID != first.Session.AgentSessionID {
+		t.Fatalf("replayed session = %q, want %q", replayed.Session.AgentSessionID, first.Session.AgentSessionID)
+	}
+	if calls := adapter.startCalls.Load(); calls != 1 {
+		t.Fatalf("adapter start calls = %d, want 1", calls)
+	}
+	if locks := len(controller.startupLocks); locks != 0 {
+		t.Fatalf("startup locks = %d, want 0", locks)
+	}
+}
+
+func invokeControllerStartupOperation(
+	ctx context.Context,
+	controller *Controller,
+	operation string,
+	provider string,
+	agentSessionID string,
+) error {
+	switch operation {
+	case "start":
+		_, err := controller.Start(ctx, StartInput{
+			RoomID:         "room-1",
+			AgentSessionID: agentSessionID,
+			Provider:       provider,
+		})
+		return err
+	case "resume":
+		_, err := controller.Resume(ctx, ResumeInput{
+			RoomID:            "room-1",
+			AgentSessionID:    agentSessionID,
+			Provider:          provider,
+			ProviderSessionID: "provider-" + agentSessionID,
+		})
+		return err
+	default:
+		return fmt.Errorf("unsupported startup operation %q", operation)
+	}
+}
+
 func TestControllerProvisionalStartRollsBackWithoutCanonicalReport(t *testing.T) {
 	t.Parallel()
 	reporter := &recordingReporter{}
@@ -2552,6 +2813,51 @@ type recordingStartAdapter struct {
 	cancelCalls    int
 	cancelEntered  chan<- struct{}
 	cancelReleased <-chan struct{}
+}
+
+type blockingStartupAdapter struct {
+	recordingStartAdapter
+	operation        string
+	blockedSessionID string
+	entered          chan struct{}
+	release          chan struct{}
+	enterOnce        sync.Once
+	startCalls       atomic.Int32
+	resumeCalls      atomic.Int32
+}
+
+func (a *blockingStartupAdapter) Start(ctx context.Context, session Session) ([]activityshared.Event, error) {
+	a.startCalls.Add(1)
+	if a.operation == "start" && a.blocks(session) {
+		if err := a.wait(ctx); err != nil {
+			return nil, err
+		}
+	}
+	return []activityshared.Event{
+		newSessionActivityEvent(session, EventSessionStarted, SessionStatusReady, nil),
+	}, nil
+}
+
+func (a *blockingStartupAdapter) Resume(ctx context.Context, session Session) error {
+	a.resumeCalls.Add(1)
+	if a.operation == "resume" && a.blocks(session) {
+		return a.wait(ctx)
+	}
+	return nil
+}
+
+func (a *blockingStartupAdapter) blocks(session Session) bool {
+	return a.blockedSessionID == "" || a.blockedSessionID == session.AgentSessionID
+}
+
+func (a *blockingStartupAdapter) wait(ctx context.Context) error {
+	a.enterOnce.Do(func() { close(a.entered) })
+	select {
+	case <-a.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 type recordingPromptAdapter struct {


### PR DESCRIPTION
## Summary
- replace the process-wide Controller startup mutex with keyed startup locks
- serialize explicit startup by room and Session while allowing independent Sessions to start concurrently
- keep legacy ID-less starts provider-scoped and make lock waiting context-cancelable
- add Start/Resume concurrency, idempotency, cancellation, cleanup, and troubleshooting coverage

## Tests
- `go test ./runtime -count=1`
- `pnpm check:changed -- --push-ready`

## Notes
- this changes daemon Controller coordination, not Host lifecycle semantics
- provider-specific startup hangs and timeout policy are intentionally out of scope

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->