### PR TITLE
feat(agent-gui): add target account menu extension

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -845,6 +845,12 @@ login/logout, external navigation, reward receipt persistence, clipboard
 writes, notifications, localization, feature gating, and menu lifecycle.
 Neither AgentGUI nor the frontend Commerce package may receive a Cookie or
 start a Commerce request.
+The optional `renderSlots.agentConfigAccount` is a presentation-only Host
+chrome seam for the exact selected Agent Target. Its paired
+`hostActions.onAgentConfigMenuOpen` notification lets the Host refresh account
+state without hiding workflow in the render slot. Returning no content keeps
+the provider account and quota block unchanged. AgentGUI never derives billing
+ownership from provider identity.
 Host chrome that aligns to AgentGUI's internal layout must consume explicit
 package signals such as `hostActions.onConversationRailLayoutChange`; it must
 not observe package DOM, CSS variables, or class names with

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -422,3 +422,10 @@ The old public `providerTargets`, `providerRailMode`, provider-target renderers,
 and `defaultProviderTargetId` contract is intentionally unsupported. Workbench
 state hydration performs a one-time read of legacy `providerTargetId` into
 `agentTargetId`; new state writes contain only `agentTargetId`.
+
+Account and Commerce remain Host chrome. A Host may use
+`renderSlots.agentConfigAccount` to replace the selected target's default
+account/quota block and `hostActions.onAgentConfigMenuOpen` to refresh its
+Host-owned account state. Both receive the same exact target context. Returning
+`null` preserves the default provider account and quota presentation; the slot
+must not start requests or own menu lifecycle.

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.status.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.status.spec.tsx
@@ -160,6 +160,56 @@ describe("AgentGUINode status controller integration", () => {
     ).toBe(true);
   });
 
+  it("gives Host account chrome the same exact target on config open", () => {
+    const target = {
+      ...createLocalAgentGUIAgentTarget("tutti-agent"),
+      ownership: "self" as const
+    };
+    mockViewModel = createViewModel({
+      selectedAgentTarget: target,
+      agentTargets: [target],
+      conversationFilter: {
+        kind: "agentTarget",
+        agentTargetId: target.agentTargetId ?? target.targetId
+      }
+    });
+    const onAgentConfigMenuOpen = vi.fn();
+    const renderAgentConfigAccount = vi.fn(() => (
+      <div data-testid="host-account">Host account</div>
+    ));
+    const props = createProps();
+    render(
+      <AgentGUINode
+        {...props}
+        hostActions={{
+          ...props.hostActions,
+          onAgentConfigMenuOpen
+        }}
+        renderSlots={{
+          agentConfigAccount: renderAgentConfigAccount
+        }}
+      />
+    );
+
+    expect(renderAgentConfigAccount).toHaveBeenCalledWith({
+      agentTargetId: "local:tutti-agent",
+      provider: "tutti-agent",
+      label: target.label,
+      ownership: "self"
+    });
+    expect(latestViewProps().agentConfigAccountContent).toBeTruthy();
+
+    act(() => latestViewProps().onAgentConfigMenuOpen?.());
+
+    expect(onAgentConfigMenuOpen).toHaveBeenCalledOnce();
+    expect(onAgentConfigMenuOpen).toHaveBeenCalledWith({
+      agentTargetId: "local:tutti-agent",
+      provider: "tutti-agent",
+      label: target.label,
+      ownership: "self"
+    });
+  });
+
   it("does not project status from the previous target after a target switch", () => {
     mockViewModel = createViewModel();
     let observer: AgentStatusStreamObserver | null = null;
@@ -321,6 +371,7 @@ describe("AgentGUINode status controller integration", () => {
 });
 
 interface CapturedViewProps {
+  agentConfigAccountContent?: React.ReactNode;
   onAgentConfigMenuOpen?: () => void;
   onAgentConfigMenuClose?: () => void;
   onSlashStatusOpen?: () => void;

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -4,7 +4,7 @@ import { createWorkspaceFileManagerI18nRuntime } from "@tutti-os/workspace-file-
 import type { WorkspaceFileReference } from "@tutti-os/workspace-file-reference/contracts";
 import { useTranslation } from "../../i18n/index";
 import type { WorkspaceLinkAction } from "../../actions/workspaceLinkActions";
-import type { AgentGUINodeData } from "../../types";
+import type { AgentGUIAgentTarget, AgentGUINodeData } from "../../types";
 import { resolveCanonicalNodeMinSize } from "../../utils/workspaceNodeSizing";
 import { WorkspaceNodeWindow } from "../shared/WorkspaceNodeWindow";
 import { CanvasNodeGhostIconButton } from "../shared/CanvasNodeGhostIconButton";
@@ -28,7 +28,10 @@ import {
   resolveNextAgentGUIConversationRailWidthPx,
   resolveAgentGUIConversationRailMaxWidthPx
 } from "./model/agentGuiRailLayout";
-import type { AgentGUINodeProps } from "./AgentGUINode.types";
+import type {
+  AgentGUIAgentConfigMenuContext,
+  AgentGUINodeProps
+} from "./AgentGUINode.types";
 import { areAgentGUINodePropsEqual } from "./AgentGUINode.types";
 import { AgentGUIMentionServiceBoundary } from "./AgentGUIMentionServiceBoundary";
 import {
@@ -123,6 +126,7 @@ export const AgentGUINode = memo(function AgentGUINode({
     onCapabilitySettingsRequest,
     onAgentProviderLogin,
     onAgentEnvPanelOpen,
+    onAgentConfigMenuOpen: onHostAgentConfigMenuOpen,
     onOpenConversationWindow,
     onClose,
     onResize,
@@ -136,6 +140,7 @@ export const AgentGUINode = memo(function AgentGUINode({
     onConversationRailLayoutChange
   } = hostActions;
   const {
+    agentConfigAccount: renderAgentConfigAccount,
     projectDirectoryPickerHeaderActions:
       renderProjectDirectoryPickerHeaderActions,
     providerRailEmpty: renderProviderRailEmpty,
@@ -333,7 +338,7 @@ export const AgentGUINode = memo(function AgentGUINode({
     agentProbeLines,
     controllerRailStatus,
     handleAgentConfigMenuClose,
-    handleAgentConfigMenuOpen,
+    handleAgentConfigMenuOpen: handleStatusAgentConfigMenuOpen,
     handleAgentProbeInfoClose,
     handleAgentProbeInfoOpen,
     handleAgentUsageRefresh,
@@ -350,6 +355,19 @@ export const AgentGUINode = memo(function AgentGUINode({
     t,
     viewModel
   });
+  const agentConfigMenuContext =
+    viewModel.rail.conversationFilter.kind === "all"
+      ? null
+      : resolveAgentConfigMenuContext(viewModel.rail.selectedAgentTarget);
+  const handleAgentConfigMenuOpen = () => {
+    handleStatusAgentConfigMenuOpen();
+    if (agentConfigMenuContext) {
+      onHostAgentConfigMenuOpen?.(agentConfigMenuContext);
+    }
+  };
+  const agentConfigAccountContent = agentConfigMenuContext
+    ? (renderAgentConfigAccount?.(agentConfigMenuContext) ?? null)
+    : null;
 
   return (
     <AgentGUIMentionServiceBoundary service={mentionService}>
@@ -456,6 +474,7 @@ export const AgentGUINode = memo(function AgentGUINode({
               slashStatusLimitsResolvedEmpty={
                 controllerRailStatus?.resolvedEmpty ?? false
               }
+              agentConfigAccountContent={agentConfigAccountContent}
               providerAuthAccountLabels={providerAuthAccountLabels}
               onAgentConfigMenuClose={handleAgentConfigMenuClose}
               onAgentConfigMenuOpen={handleAgentConfigMenuOpen}
@@ -532,3 +551,19 @@ export const AgentGUINode = memo(function AgentGUINode({
     </AgentGUIMentionServiceBoundary>
   );
 }, areAgentGUINodePropsEqual);
+
+function resolveAgentConfigMenuContext(
+  target: AgentGUIAgentTarget
+): AgentGUIAgentConfigMenuContext | null {
+  const agentTargetId = target.agentTargetId?.trim() || target.targetId.trim();
+  const provider = target.provider.trim();
+  if (!agentTargetId || !provider) {
+    return null;
+  }
+  return {
+    agentTargetId,
+    provider,
+    label: target.label,
+    ...(target.ownership ? { ownership: target.ownership } : {})
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
@@ -19,6 +19,7 @@ import type {
   AgentGUITargetConnectionSource,
   AgentGUIHomeSuggestionId,
   AgentGUIAgentTarget,
+  AgentGUIAgentOwnership,
   NodeFrame,
   Point
 } from "../../types";
@@ -167,6 +168,11 @@ export interface AgentGUINodeHostActions {
   ) => void;
   onAgentProviderLogin?: (provider: AgentGUIProvider) => void;
   onAgentEnvPanelOpen?: (input?: OpenAgentEnvPanelInput) => void;
+  /**
+   * Notifies the Host when the exact target's config menu opens. Account and
+   * Commerce refreshes remain Host-owned and must not enter Agent status.
+   */
+  onAgentConfigMenuOpen?: (context: AgentGUIAgentConfigMenuContext) => void;
   onOpenConversationWindow?: (agentSessionId: string) => void;
   onClose: () => void;
   onResize: (frame: NodeFrame) => void;
@@ -194,7 +200,19 @@ export interface AgentGUINodeHostActions {
   ) => void;
 }
 
+export interface AgentGUIAgentConfigMenuContext {
+  agentTargetId: string;
+  provider: AgentGUIProvider;
+  label: string;
+  ownership?: AgentGUIAgentOwnership;
+}
+
 export interface AgentGUINodeRenderSlots {
+  /**
+   * Optional Host chrome for the exact target's account/Commerce presentation.
+   * Returning null preserves AgentGUI's provider account and quota content.
+   */
+  agentConfigAccount?: (context: AgentGUIAgentConfigMenuContext) => ReactNode;
   projectDirectoryPickerHeaderActions?: ReferenceSourcePickerProps["renderHeaderActions"];
   providerRailEmpty?: AgentGUIAgentsEmptyRenderer;
   providerUnavailableState?: AgentGUIProviderUnavailableStateRenderer;
@@ -400,6 +418,7 @@ export function areAgentGUINodePropsEqual(
     pa.onCapabilitySettingsRequest === na.onCapabilitySettingsRequest &&
     pa.onAgentProviderLogin === na.onAgentProviderLogin &&
     pa.onAgentEnvPanelOpen === na.onAgentEnvPanelOpen &&
+    pa.onAgentConfigMenuOpen === na.onAgentConfigMenuOpen &&
     pa.onOpenConversationWindow === na.onOpenConversationWindow &&
     pa.onClose === na.onClose &&
     pa.onResize === na.onResize &&
@@ -411,6 +430,7 @@ export function areAgentGUINodePropsEqual(
     pa.onShowMessage === na.onShowMessage &&
     pa.onEngagementEvent === na.onEngagementEvent &&
     pa.onConversationRailLayoutChange === na.onConversationRailLayoutChange &&
+    ps.agentConfigAccount === ns.agentConfigAccount &&
     ps.providerRailEmpty === ns.providerRailEmpty &&
     ps.providerUnavailableState === ns.providerUnavailableState &&
     ps.projectDirectoryPickerHeaderActions ===

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -106,6 +106,7 @@ export function AgentGUINodeView({
   slashStatusUsageCapturedAtUnixMs = null,
   slashStatusUsageDidFail = false,
   slashStatusUsageAttempted = false,
+  agentConfigAccountContent,
   onAgentConfigMenuClose,
   onAgentConfigMenuOpen,
   onAgentUsageRefresh,
@@ -613,6 +614,7 @@ export function AgentGUINodeView({
                   slashStatusUsageAttempted={slashStatusUsageAttempted}
                   provider={effectiveRailConfigProvider}
                   providerAuthAccountLabel={effectiveProviderAuthAccountLabel}
+                  accountContent={agentConfigAccountContent}
                   onAgentConfigMenuClose={onAgentConfigMenuClose}
                   onAgentConfigMenuOpen={onAgentConfigMenuOpen}
                   onAgentUsageRefresh={onAgentUsageRefresh}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.spec.tsx
@@ -1,0 +1,92 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentGUIViewLabels } from "../AgentGUINodeView";
+import { AgentGUIConfigMenu } from "./AgentGUIAccountConfig";
+
+afterEach(cleanup);
+
+const labels = {
+  agentConfig: "More",
+  slashStatusProviderAccount: (provider: string) => `${provider} account`,
+  slashStatusAccount: "Account",
+  slashStatusLimits: "Limits",
+  slashStatusEmptyValue: "--",
+  slashStatusLimitsUnavailable: "Unavailable",
+  slashStatusUsageJustUpdated: "Updated",
+  slashStatusUsageMinutesAgo: () => "Minutes ago",
+  slashStatusUsageHoursAgo: () => "Hours ago",
+  slashStatusUsageUpdating: "Updating",
+  slashStatusUsageRefreshFailed: "Refresh failed",
+  slashStatusUsageRefreshAria: "Refresh usage",
+  agentEnvSetup: "Environment",
+  agentSettingsMenu: "Settings"
+} as unknown as AgentGUIViewLabels;
+
+describe("AgentGUIConfigMenu", () => {
+  it("replaces provider quota chrome only when the Host supplies account content", () => {
+    const onOpen = vi.fn();
+    render(
+      <AgentGUIConfigMenu
+        accountContent={<div>Host Commerce account</div>}
+        environmentSetupVisible={false}
+        labels={labels}
+        providerScopedActionsVisible
+        provider="tutti-agent"
+        providerAuthAccountLabel="provider@example.test"
+        slashStatusLimits={[]}
+        slashStatusLimitsLoading={false}
+        slashStatusLimitsResolvedEmpty={false}
+        slashStatusUsageCapturedAtUnixMs={null}
+        slashStatusUsageDidFail={false}
+        slashStatusUsageAttempted
+        onAgentConfigMenuOpen={onOpen}
+        onOpenAgentEnvSetup={vi.fn()}
+        onOpenAgentSettings={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+    expect(onOpen).toHaveBeenCalledOnce();
+    expect(screen.getByText("Host Commerce account")).toBeInTheDocument();
+    expect(screen.queryByText("provider@example.test")).not.toBeInTheDocument();
+    expect(screen.queryByText("Limits")).not.toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
+  it("preserves the provider account and quota fallback without Host content", () => {
+    render(
+      <AgentGUIConfigMenu
+        environmentSetupVisible={false}
+        labels={labels}
+        providerScopedActionsVisible
+        provider="codex"
+        providerAuthAccountLabel="provider@example.test"
+        slashStatusLimits={[
+          {
+            id: "weekly",
+            label: "Weekly",
+            percentRemaining: 50,
+            value: "50%",
+            reset: null
+          }
+        ]}
+        slashStatusLimitsLoading={false}
+        slashStatusLimitsResolvedEmpty={false}
+        slashStatusUsageCapturedAtUnixMs={null}
+        slashStatusUsageDidFail={false}
+        slashStatusUsageAttempted
+        onAgentConfigMenuOpen={vi.fn()}
+        onOpenAgentEnvSetup={vi.fn()}
+        onOpenAgentSettings={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+    expect(screen.getByText("provider@example.test")).toBeInTheDocument();
+    expect(screen.getByText("Limits")).toBeInTheDocument();
+    expect(screen.getByText("Weekly")).toBeInTheDocument();
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.spec.tsx
@@ -89,4 +89,43 @@ describe("AgentGUIConfigMenu", () => {
     expect(screen.getByText("Limits")).toBeInTheDocument();
     expect(screen.getByText("Weekly")).toBeInTheDocument();
   });
+
+  it.each([false, true, 0, ""])(
+    "preserves the provider fallback for non-rendering Host content %#",
+    (accountContent) => {
+      render(
+        <AgentGUIConfigMenu
+          accountContent={accountContent}
+          environmentSetupVisible={false}
+          labels={labels}
+          providerScopedActionsVisible
+          provider="codex"
+          providerAuthAccountLabel="provider@example.test"
+          slashStatusLimits={[
+            {
+              id: "weekly",
+              label: "Weekly",
+              percentRemaining: 50,
+              value: "50%",
+              reset: null
+            }
+          ]}
+          slashStatusLimitsLoading={false}
+          slashStatusLimitsResolvedEmpty={false}
+          slashStatusUsageCapturedAtUnixMs={null}
+          slashStatusUsageDidFail={false}
+          slashStatusUsageAttempted
+          onAgentConfigMenuOpen={vi.fn()}
+          onOpenAgentEnvSetup={vi.fn()}
+          onOpenAgentSettings={vi.fn()}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+      expect(screen.getByText("provider@example.test")).toBeInTheDocument();
+      expect(screen.getByText("Limits")).toBeInTheDocument();
+      expect(screen.getByText("Weekly")).toBeInTheDocument();
+    }
+  );
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { Gauge, Wrench } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@tutti-os/ui-system";
 import { MoreHorizontalIcon } from "@tutti-os/ui-system/icons";
@@ -11,6 +11,7 @@ import type { AgentComposerSlashStatusLimit } from "../AgentComposer";
 import type { AgentGUIViewLabels } from "../AgentGUINodeView";
 
 interface AgentGUIConfigMenuProps {
+  accountContent?: ReactNode;
   environmentSetupVisible: boolean;
   labels: AgentGUIViewLabels;
   providerScopedActionsVisible: boolean;
@@ -30,6 +31,7 @@ interface AgentGUIConfigMenuProps {
 }
 
 export function AgentGUIConfigMenu({
+  accountContent,
   environmentSetupVisible,
   labels,
   providerScopedActionsVisible,
@@ -55,6 +57,8 @@ export function AgentGUIConfigMenu({
     ? labels.slashStatusProviderAccount(provider.trim())
     : null;
   const accountTitle = providerDisplayTitle ?? labels.slashStatusAccount;
+  const hasAccountContent =
+    accountContent !== null && accountContent !== undefined;
   return (
     <Popover
       open={open}
@@ -87,7 +91,17 @@ export function AgentGUIConfigMenu({
         data-testid="agent-gui-config-menu"
       >
         <div className="flex min-w-0 flex-col gap-1">
-          {providerScopedActionsVisible && providerAuthAccountLabel ? (
+          {hasAccountContent ? (
+            <>
+              {accountContent}
+              <div className="px-2">
+                <span className="block h-px bg-[var(--border-1)]" />
+              </div>
+            </>
+          ) : null}
+          {!hasAccountContent &&
+          providerScopedActionsVisible &&
+          providerAuthAccountLabel ? (
             <>
               <div className="flex min-w-0 flex-col gap-2 p-2">
                 <div className="flex min-w-0 items-center gap-2">
@@ -118,7 +132,8 @@ export function AgentGUIConfigMenu({
               ) : null}
             </>
           ) : null}
-          {providerScopedActionsVisible &&
+          {!hasAccountContent &&
+          providerScopedActionsVisible &&
           (slashStatusLimits.length > 0 ||
             slashStatusUsageAttempted ||
             slashStatusLimitsLoading) ? (

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.tsx
@@ -58,7 +58,7 @@ export function AgentGUIConfigMenu({
     : null;
   const accountTitle = providerDisplayTitle ?? labels.slashStatusAccount;
   const hasAccountContent =
-    accountContent !== null && accountContent !== undefined;
+    Boolean(accountContent) && typeof accountContent !== "boolean";
   return (
     <Popover
       open={open}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -560,6 +560,8 @@ export interface AgentGUINodeViewProps {
    * the config menu shows a "no limits / retry" row rather than hiding the
    * whole section when there are no meters to display. */
   slashStatusUsageAttempted?: boolean;
+  /** Host-rendered account/Commerce chrome for the exact selected target. */
+  agentConfigAccountContent?: ReactNode;
   onAgentConfigMenuClose?: () => void;
   onAgentConfigMenuOpen?: () => void;
   /** Forces a fresh usage probe from the config menu's refresh control. */

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -16,6 +16,7 @@ export type {
   AgentGUIProps,
   AgentGUIReferenceProvenanceFilterCatalog
 } from "./AgentGUI";
+export type { AgentGUIAgentConfigMenuContext } from "./agent-gui/agentGuiNode/AgentGUINode.types";
 export type {
   TuttiModePlanAssignmentAgentDetail,
   TuttiModePlanAssignmentAgentOption,

--- a/packages/commerce/web/README.md
+++ b/packages/commerce/web/README.md
@@ -9,7 +9,10 @@ provide normalized data, labels, links, and callbacks.
 
 The Account shell (avatar, popover, sign-in/out, settings, and UID copy)
 belongs to each Host. `CommerceMenuContent` renders only membership, credits,
-and account-center rows.
+and account-center rows. `AgentConfigCommerceContent` is the compact account,
+credits-refresh, membership, usage-history, and account-center presentation for
+an Agent config menu. The Host still supplies the account name, state, labels,
+refresh command, and navigation.
 
 Host actions may be asynchronous. `CommerceMenuContent` catches rejected
 external-link actions and forwards them to the optional `onActionError`
@@ -21,6 +24,7 @@ import {
   resolveMembershipAction
 } from "@tutti-os/commerce";
 import {
+  AgentConfigCommerceContent,
   CommerceMenuContent,
   MembershipTierIcon
 } from "@tutti-os/commerce/react";

--- a/packages/commerce/web/README.md
+++ b/packages/commerce/web/README.md
@@ -10,9 +10,10 @@ provide normalized data, labels, links, and callbacks.
 The Account shell (avatar, popover, sign-in/out, settings, and UID copy)
 belongs to each Host. `CommerceMenuContent` renders only membership, credits,
 and account-center rows. `AgentConfigCommerceContent` is the compact account,
-credits-refresh, membership, usage-history, and account-center presentation for
-an Agent config menu. The Host still supplies the account name, state, labels,
-refresh command, and navigation.
+clickable credits balance with inline refresh, membership, and account-center
+presentation for an Agent config menu. Clicking Credits opens the Host-provided
+`usageUrl`. The Host still supplies the account name, state, labels, refresh
+command, and navigation.
 
 Host actions may be asynchronous. `CommerceMenuContent` catches rejected
 external-link actions and forwards them to the optional `onActionError`

--- a/packages/commerce/web/src/react/AgentConfigCommerceContent.spec.tsx
+++ b/packages/commerce/web/src/react/AgentConfigCommerceContent.spec.tsx
@@ -1,0 +1,142 @@
+import "@testing-library/jest-dom/vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CommerceMenuState } from "../index";
+import {
+  AgentConfigCommerceContent,
+  type AgentConfigCommerceLabels
+} from "./AgentConfigCommerceContent";
+
+const labels: AgentConfigCommerceLabels = {
+  account: "Tutti Agent account",
+  membership: "Membership",
+  upgradeMembership: "Upgrade",
+  rechargeCredits: "Recharge",
+  viewCreditPlans: "View plans",
+  creditsBalance: "Credits",
+  refresh: "Refresh",
+  refreshing: "Refreshing",
+  freeMembership: "Free",
+  creditHistory: "Credit history",
+  accountCenter: "Account center",
+  loading: "Loading",
+  unavailable: "Unavailable",
+  dataUnavailable: "Some account data is unavailable"
+};
+
+afterEach(cleanup);
+
+function state(overrides: Partial<CommerceMenuState> = {}): CommerceMenuState {
+  return {
+    membershipLabel: "Pro",
+    membershipAccess: "active",
+    creditsLabel: "42.50",
+    loading: false,
+    dataUnavailable: false,
+    links: {
+      planUrl: "https://example.test/plan",
+      usageUrl: "https://example.test/usage",
+      settingsUrl: "https://example.test/settings"
+    },
+    onOpenExternal: vi.fn(),
+    ...overrides
+  };
+}
+
+describe("AgentConfigCommerceContent", () => {
+  it("renders account, credits, membership, and Host-owned destinations", () => {
+    const menuState = state();
+    const onRefresh = vi.fn();
+    render(
+      <AgentConfigCommerceContent
+        accountName="Mia"
+        state={menuState}
+        labels={labels}
+        onRefresh={onRefresh}
+      />
+    );
+
+    expect(screen.getByText("Mia")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("agent-config-commerce-credits")
+    ).toHaveTextContent("42.50");
+    expect(screen.getByText("Pro")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    fireEvent.click(screen.getByText("Recharge"));
+    fireEvent.click(screen.getByText("Credit history"));
+    fireEvent.click(screen.getByText("Account center"));
+
+    expect(onRefresh).toHaveBeenCalledOnce();
+    expect(menuState.onOpenExternal).toHaveBeenNthCalledWith(
+      1,
+      "https://example.test/plan"
+    );
+    expect(menuState.onOpenExternal).toHaveBeenNthCalledWith(
+      2,
+      "https://example.test/usage"
+    );
+    expect(menuState.onOpenExternal).toHaveBeenNthCalledWith(
+      3,
+      "https://example.test/settings"
+    );
+  });
+
+  it("reports rejected Host external actions", async () => {
+    const onActionError = vi.fn();
+    const menuState = state({
+      onOpenExternal: vi.fn().mockRejectedValue(new Error("open failed")),
+      onActionError
+    });
+    render(
+      <AgentConfigCommerceContent
+        accountName="Mia"
+        state={menuState}
+        labels={labels}
+        onRefresh={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Recharge"));
+
+    await waitFor(() => expect(onActionError).toHaveBeenCalledOnce());
+  });
+
+  it("shows initial loading and disables duplicate refreshes", () => {
+    render(
+      <AgentConfigCommerceContent
+        accountName={null}
+        state={state({
+          membershipLabel: "",
+          creditsLabel: null,
+          loading: true
+        })}
+        labels={labels}
+        onRefresh={vi.fn()}
+      />
+    );
+
+    expect(screen.getAllByText("Loading")).toHaveLength(3);
+    expect(screen.getByRole("button", { name: "Refreshing" })).toBeDisabled();
+  });
+
+  it("uses the free membership fallback without inventing a paid tier", () => {
+    render(
+      <AgentConfigCommerceContent
+        accountName="Mia"
+        state={state({ membershipAccess: "free", membershipLabel: "" })}
+        labels={labels}
+        onRefresh={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Free")).toBeInTheDocument();
+    expect(screen.getByText("Upgrade")).toBeInTheDocument();
+  });
+});

--- a/packages/commerce/web/src/react/AgentConfigCommerceContent.spec.tsx
+++ b/packages/commerce/web/src/react/AgentConfigCommerceContent.spec.tsx
@@ -16,9 +16,6 @@ import {
 const labels: AgentConfigCommerceLabels = {
   account: "Tutti Agent account",
   membership: "Membership",
-  upgradeMembership: "Upgrade",
-  rechargeCredits: "Recharge",
-  viewCreditPlans: "View plans",
   creditsBalance: "Credits",
   refresh: "Refresh",
   refreshing: "Refreshing",
@@ -69,7 +66,7 @@ describe("AgentConfigCommerceContent", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
     fireEvent.click(screen.getByRole("button", { name: "Credits 42.50" }));
-    fireEvent.click(screen.getByText("Recharge"));
+    fireEvent.click(screen.getByRole("button", { name: "Membership Pro" }));
     fireEvent.click(screen.getByText("Account center"));
 
     expect(onRefresh).toHaveBeenCalledOnce();
@@ -102,7 +99,7 @@ describe("AgentConfigCommerceContent", () => {
       />
     );
 
-    fireEvent.click(screen.getByText("Recharge"));
+    fireEvent.click(screen.getByRole("button", { name: "Membership Pro" }));
 
     await waitFor(() => expect(onActionError).toHaveBeenCalledOnce());
   });
@@ -167,6 +164,8 @@ describe("AgentConfigCommerceContent", () => {
     );
 
     expect(screen.getByText("Free")).toBeInTheDocument();
-    expect(screen.getByText("Upgrade")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Membership Free" })
+    ).toBeInTheDocument();
   });
 });

--- a/packages/commerce/web/src/react/AgentConfigCommerceContent.spec.tsx
+++ b/packages/commerce/web/src/react/AgentConfigCommerceContent.spec.tsx
@@ -23,7 +23,6 @@ const labels: AgentConfigCommerceLabels = {
   refresh: "Refresh",
   refreshing: "Refreshing",
   freeMembership: "Free",
-  creditHistory: "Credit history",
   accountCenter: "Account center",
   loading: "Loading",
   unavailable: "Unavailable",
@@ -50,7 +49,7 @@ function state(overrides: Partial<CommerceMenuState> = {}): CommerceMenuState {
 }
 
 describe("AgentConfigCommerceContent", () => {
-  it("renders account, credits, membership, and Host-owned destinations", () => {
+  it("renders account, clickable credits, membership, and account center", () => {
     const menuState = state();
     const onRefresh = vi.fn();
     render(
@@ -69,18 +68,18 @@ describe("AgentConfigCommerceContent", () => {
     expect(screen.getByText("Pro")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    fireEvent.click(screen.getByRole("button", { name: "Credits 42.50" }));
     fireEvent.click(screen.getByText("Recharge"));
-    fireEvent.click(screen.getByText("Credit history"));
     fireEvent.click(screen.getByText("Account center"));
 
     expect(onRefresh).toHaveBeenCalledOnce();
     expect(menuState.onOpenExternal).toHaveBeenNthCalledWith(
       1,
-      "https://example.test/plan"
+      "https://example.test/usage"
     );
     expect(menuState.onOpenExternal).toHaveBeenNthCalledWith(
       2,
-      "https://example.test/usage"
+      "https://example.test/plan"
     );
     expect(menuState.onOpenExternal).toHaveBeenNthCalledWith(
       3,
@@ -124,6 +123,37 @@ describe("AgentConfigCommerceContent", () => {
 
     expect(screen.getAllByText("Loading")).toHaveLength(3);
     expect(screen.getByRole("button", { name: "Refreshing" })).toBeDisabled();
+  });
+
+  it("keeps refresh available when the credits destination is missing", () => {
+    const menuState = state({
+      links: {
+        planUrl: "https://example.test/plan",
+        usageUrl: "",
+        settingsUrl: "https://example.test/settings"
+      }
+    });
+    const onRefresh = vi.fn();
+    render(
+      <AgentConfigCommerceContent
+        accountName="Mia"
+        state={menuState}
+        labels={labels}
+        onRefresh={onRefresh}
+      />
+    );
+
+    const creditsButton = screen.getByRole("button", {
+      name: "Credits 42.50"
+    });
+    expect(creditsButton).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeEnabled();
+
+    fireEvent.click(creditsButton);
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    expect(menuState.onOpenExternal).not.toHaveBeenCalled();
+    expect(onRefresh).toHaveBeenCalledOnce();
   });
 
   it("uses the free membership fallback without inventing a paid tier", () => {

--- a/packages/commerce/web/src/react/AgentConfigCommerceContent.tsx
+++ b/packages/commerce/web/src/react/AgentConfigCommerceContent.tsx
@@ -6,17 +6,11 @@ import {
   UserLinedIcon
 } from "@tutti-os/ui-system";
 import type { CommerceMenuState } from "../index";
-import {
-  resolveCommerceMembershipActionLabel,
-  useCommerceOpenExternal
-} from "./commerceMenuPresentation";
+import { useCommerceOpenExternal } from "./commerceMenuPresentation";
 
 export interface AgentConfigCommerceLabels {
   account: string;
   membership: string;
-  upgradeMembership: string;
-  rechargeCredits: string;
-  viewCreditPlans: string;
   creditsBalance: string;
   refresh: string;
   refreshing: string;
@@ -59,11 +53,6 @@ export function AgentConfigCommerceContent({
       : state.loading
         ? labels.loading
         : labels.unavailable);
-  const membershipActionLabel = resolveCommerceMembershipActionLabel(
-    state,
-    labels
-  );
-
   return (
     <div
       className="flex min-w-0 flex-col gap-1"
@@ -123,6 +112,7 @@ export function AgentConfigCommerceContent({
         type="button"
         className={menuItemClassName}
         disabled={!state.links.planUrl.trim()}
+        aria-label={`${labels.membership} ${membershipLabel}`}
         onClick={() => openExternal(state.links.planUrl)}
       >
         <BillingIcon aria-hidden="true" size={16} />
@@ -132,9 +122,11 @@ export function AgentConfigCommerceContent({
         <span className="max-w-[72px] truncate text-[var(--text-secondary)]">
           {membershipLabel}
         </span>
-        <span className="shrink-0 text-[12px] text-[var(--accent)]">
-          {membershipActionLabel}
-        </span>
+        <LaunchIcon
+          aria-hidden="true"
+          className="text-[var(--text-secondary)]"
+          size={14}
+        />
       </button>
       <button
         type="button"

--- a/packages/commerce/web/src/react/AgentConfigCommerceContent.tsx
+++ b/packages/commerce/web/src/react/AgentConfigCommerceContent.tsx
@@ -1,0 +1,174 @@
+import {
+  BillingIcon,
+  CreditsIcon,
+  LaunchIcon,
+  RefreshIcon,
+  UserLinedIcon,
+  ViewListLinedIcon
+} from "@tutti-os/ui-system";
+import type { CommerceMenuState } from "../index";
+import {
+  resolveCommerceMembershipActionLabel,
+  useCommerceOpenExternal
+} from "./commerceMenuPresentation";
+
+export interface AgentConfigCommerceLabels {
+  account: string;
+  membership: string;
+  upgradeMembership: string;
+  rechargeCredits: string;
+  viewCreditPlans: string;
+  creditsBalance: string;
+  refresh: string;
+  refreshing: string;
+  freeMembership: string;
+  creditHistory: string;
+  accountCenter: string;
+  loading: string;
+  unavailable: string;
+  dataUnavailable: string;
+}
+
+export interface AgentConfigCommerceContentProps {
+  accountName: string | null;
+  state: CommerceMenuState;
+  labels: AgentConfigCommerceLabels;
+  onRefresh(): void;
+}
+
+const menuItemClassName =
+  "nodrag flex h-7 w-full items-center gap-2 rounded-[6px] px-2 text-[13px] text-[var(--text-primary)] transition-colors hover:bg-[var(--transparency-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-focus)] disabled:cursor-not-allowed disabled:text-[var(--text-disabled)] disabled:hover:bg-transparent [-webkit-app-region:no-drag]";
+
+export function AgentConfigCommerceContent({
+  accountName,
+  state,
+  labels,
+  onRefresh
+}: AgentConfigCommerceContentProps): React.JSX.Element {
+  const openExternal = useCommerceOpenExternal(state);
+  const accountNameLabel =
+    accountName?.trim() ||
+    (state.loading ? labels.loading : labels.unavailable);
+  const creditsLabel =
+    state.loading && !state.creditsLabel
+      ? labels.loading
+      : (state.creditsLabel ?? labels.unavailable);
+  const membershipLabel =
+    state.membershipLabel.trim() ||
+    (state.membershipAccess === "free"
+      ? labels.freeMembership
+      : state.loading
+        ? labels.loading
+        : labels.unavailable);
+  const membershipActionLabel = resolveCommerceMembershipActionLabel(
+    state,
+    labels
+  );
+
+  return (
+    <div
+      className="flex min-w-0 flex-col gap-1"
+      data-testid="agent-config-commerce-content"
+    >
+      <div className="flex min-w-0 flex-col gap-1 p-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <UserLinedIcon aria-hidden="true" size={16} />
+          <span className="truncate text-[13px] font-semibold leading-4">
+            {labels.account}
+          </span>
+        </div>
+        <span className="truncate pl-6 text-[13px] leading-5 text-[var(--text-secondary)]">
+          {accountNameLabel}
+        </span>
+      </div>
+      <div className="px-2">
+        <span className="block h-px bg-[var(--border-1)]" />
+      </div>
+      <div
+        className="flex h-7 min-w-0 items-center gap-2 px-2 text-[13px] text-[var(--text-primary)]"
+        aria-live="polite"
+      >
+        <CreditsIcon aria-hidden="true" size={16} />
+        <span className="min-w-0 flex-1 truncate">{labels.creditsBalance}</span>
+        <span
+          className="max-w-[120px] truncate text-[var(--text-secondary)] tabular-nums"
+          data-testid="agent-config-commerce-credits"
+        >
+          {creditsLabel}
+        </span>
+      </div>
+      <button
+        type="button"
+        className={`${menuItemClassName} justify-end`}
+        data-testid="agent-config-commerce-refresh"
+        disabled={state.loading}
+        aria-label={state.loading ? labels.refreshing : labels.refresh}
+        onClick={onRefresh}
+      >
+        <RefreshIcon
+          aria-hidden="true"
+          className={state.loading ? "motion-safe:animate-spin" : undefined}
+          size={14}
+        />
+        <span>{state.loading ? labels.refreshing : labels.refresh}</span>
+      </button>
+      <button
+        type="button"
+        className={menuItemClassName}
+        disabled={!state.links.planUrl.trim()}
+        onClick={() => openExternal(state.links.planUrl)}
+      >
+        <BillingIcon aria-hidden="true" size={16} />
+        <span className="min-w-0 flex-1 truncate text-left">
+          {labels.membership}
+        </span>
+        <span className="max-w-[72px] truncate text-[var(--text-secondary)]">
+          {membershipLabel}
+        </span>
+        <span className="shrink-0 text-[12px] text-[var(--accent)]">
+          {membershipActionLabel}
+        </span>
+      </button>
+      <button
+        type="button"
+        className={menuItemClassName}
+        disabled={!state.links.usageUrl.trim()}
+        onClick={() => openExternal(state.links.usageUrl)}
+      >
+        <ViewListLinedIcon aria-hidden="true" size={16} />
+        <span className="min-w-0 flex-1 truncate text-left">
+          {labels.creditHistory}
+        </span>
+        <LaunchIcon
+          aria-hidden="true"
+          className="text-[var(--text-secondary)]"
+          size={14}
+        />
+      </button>
+      <button
+        type="button"
+        className={menuItemClassName}
+        disabled={!state.links.settingsUrl.trim()}
+        onClick={() => openExternal(state.links.settingsUrl)}
+      >
+        <UserLinedIcon aria-hidden="true" size={16} />
+        <span className="min-w-0 flex-1 truncate text-left">
+          {labels.accountCenter}
+        </span>
+        <LaunchIcon
+          aria-hidden="true"
+          className="text-[var(--text-secondary)]"
+          size={14}
+        />
+      </button>
+      {state.dataUnavailable ? (
+        <span
+          className="px-2 py-1 text-[11px] leading-4 text-[var(--state-danger)]"
+          role="status"
+        >
+          {labels.dataUnavailable}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/commerce/web/src/react/AgentConfigCommerceContent.tsx
+++ b/packages/commerce/web/src/react/AgentConfigCommerceContent.tsx
@@ -3,8 +3,7 @@ import {
   CreditsIcon,
   LaunchIcon,
   RefreshIcon,
-  UserLinedIcon,
-  ViewListLinedIcon
+  UserLinedIcon
 } from "@tutti-os/ui-system";
 import type { CommerceMenuState } from "../index";
 import {
@@ -22,7 +21,6 @@ export interface AgentConfigCommerceLabels {
   refresh: string;
   refreshing: string;
   freeMembership: string;
-  creditHistory: string;
   accountCenter: string;
   loading: string;
   unavailable: string;
@@ -36,8 +34,9 @@ export interface AgentConfigCommerceContentProps {
   onRefresh(): void;
 }
 
-const menuItemClassName =
-  "nodrag flex h-7 w-full items-center gap-2 rounded-[6px] px-2 text-[13px] text-[var(--text-primary)] transition-colors hover:bg-[var(--transparency-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-focus)] disabled:cursor-not-allowed disabled:text-[var(--text-disabled)] disabled:hover:bg-transparent [-webkit-app-region:no-drag]";
+const menuItemBaseClassName =
+  "nodrag flex h-7 items-center gap-2 rounded-[6px] text-[13px] text-[var(--text-primary)] transition-colors hover:bg-[var(--transparency-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-focus)] disabled:cursor-not-allowed disabled:text-[var(--text-disabled)] disabled:hover:bg-transparent [-webkit-app-region:no-drag]";
+const menuItemClassName = `${menuItemBaseClassName} w-full px-2`;
 
 export function AgentConfigCommerceContent({
   accountName,
@@ -84,34 +83,42 @@ export function AgentConfigCommerceContent({
       <div className="px-2">
         <span className="block h-px bg-[var(--border-1)]" />
       </div>
-      <div
-        className="flex h-7 min-w-0 items-center gap-2 px-2 text-[13px] text-[var(--text-primary)]"
-        aria-live="polite"
-      >
-        <CreditsIcon aria-hidden="true" size={16} />
-        <span className="min-w-0 flex-1 truncate">{labels.creditsBalance}</span>
-        <span
-          className="max-w-[120px] truncate text-[var(--text-secondary)] tabular-nums"
-          data-testid="agent-config-commerce-credits"
+      <div className="flex min-w-0 items-center">
+        <button
+          type="button"
+          className={`${menuItemBaseClassName} min-w-0 flex-1 px-2`}
+          disabled={!state.links.usageUrl.trim()}
+          aria-label={`${labels.creditsBalance} ${creditsLabel}`}
+          onClick={() => openExternal(state.links.usageUrl)}
         >
-          {creditsLabel}
-        </span>
+          <CreditsIcon aria-hidden="true" size={16} />
+          <span className="min-w-0 flex-1 truncate text-left">
+            {labels.creditsBalance}
+          </span>
+          <span
+            className="max-w-[120px] truncate text-[var(--text-secondary)] tabular-nums"
+            data-testid="agent-config-commerce-credits"
+            aria-live="polite"
+          >
+            {creditsLabel}
+          </span>
+        </button>
+        <button
+          type="button"
+          className={`${menuItemBaseClassName} shrink-0 px-2`}
+          data-testid="agent-config-commerce-refresh"
+          disabled={state.loading}
+          aria-label={state.loading ? labels.refreshing : labels.refresh}
+          onClick={onRefresh}
+        >
+          <RefreshIcon
+            aria-hidden="true"
+            className={state.loading ? "motion-safe:animate-spin" : undefined}
+            size={14}
+          />
+          <span>{state.loading ? labels.refreshing : labels.refresh}</span>
+        </button>
       </div>
-      <button
-        type="button"
-        className={`${menuItemClassName} justify-end`}
-        data-testid="agent-config-commerce-refresh"
-        disabled={state.loading}
-        aria-label={state.loading ? labels.refreshing : labels.refresh}
-        onClick={onRefresh}
-      >
-        <RefreshIcon
-          aria-hidden="true"
-          className={state.loading ? "motion-safe:animate-spin" : undefined}
-          size={14}
-        />
-        <span>{state.loading ? labels.refreshing : labels.refresh}</span>
-      </button>
       <button
         type="button"
         className={menuItemClassName}
@@ -128,22 +135,6 @@ export function AgentConfigCommerceContent({
         <span className="shrink-0 text-[12px] text-[var(--accent)]">
           {membershipActionLabel}
         </span>
-      </button>
-      <button
-        type="button"
-        className={menuItemClassName}
-        disabled={!state.links.usageUrl.trim()}
-        onClick={() => openExternal(state.links.usageUrl)}
-      >
-        <ViewListLinedIcon aria-hidden="true" size={16} />
-        <span className="min-w-0 flex-1 truncate text-left">
-          {labels.creditHistory}
-        </span>
-        <LaunchIcon
-          aria-hidden="true"
-          className="text-[var(--text-secondary)]"
-          size={14}
-        />
       </button>
       <button
         type="button"

--- a/packages/commerce/web/src/react/CommerceMenuContent.tsx
+++ b/packages/commerce/web/src/react/CommerceMenuContent.tsx
@@ -1,11 +1,14 @@
-import { useCallback } from "react";
 import {
   BillingIcon,
   CreditsIcon,
   LaunchIcon,
   UserLinedIcon
 } from "@tutti-os/ui-system";
-import { resolveMembershipAction, type CommerceMenuState } from "../index";
+import type { CommerceMenuState } from "../index";
+import {
+  resolveCommerceMembershipActionLabel,
+  useCommerceOpenExternal
+} from "./commerceMenuPresentation";
 
 export interface CommerceMenuLabels {
   member: string;
@@ -32,25 +35,11 @@ export function CommerceMenuContent({
     state.loading && !state.creditsLabel
       ? labels.loading
       : (state.creditsLabel ?? labels.unavailable);
-  const openExternal = useCallback(
-    (url: string) => {
-      if (!url.trim()) {
-        return;
-      }
-      try {
-        const result = state.onOpenExternal(url);
-        if (result) {
-          void result.catch((error: unknown) => {
-            state.onActionError?.(error);
-          });
-        }
-      } catch (error) {
-        state.onActionError?.(error);
-      }
-    },
-    [state]
+  const openExternal = useCommerceOpenExternal(state);
+  const membershipActionLabel = resolveCommerceMembershipActionLabel(
+    state,
+    labels
   );
-  const membershipActionLabel = resolveMembershipActionLabel(state, labels);
 
   return (
     <div className="flex min-w-0 flex-col" data-testid="commerce-menu-content">
@@ -105,21 +94,4 @@ export function CommerceMenuContent({
       ) : null}
     </div>
   );
-}
-
-function resolveMembershipActionLabel(
-  state: CommerceMenuState,
-  labels: Pick<
-    CommerceMenuLabels,
-    "upgradeMembership" | "rechargeCredits" | "viewCreditPlans"
-  >
-): string {
-  switch (resolveMembershipAction(state.membershipAccess)) {
-    case "upgrade-membership":
-      return labels.upgradeMembership;
-    case "recharge-credits":
-      return labels.rechargeCredits;
-    case "view-credit-plans":
-      return labels.viewCreditPlans;
-  }
 }

--- a/packages/commerce/web/src/react/commerceMenuPresentation.ts
+++ b/packages/commerce/web/src/react/commerceMenuPresentation.ts
@@ -1,0 +1,45 @@
+import { useCallback } from "react";
+import { resolveMembershipAction, type CommerceMenuState } from "../index";
+
+export interface CommerceMembershipActionLabels {
+  upgradeMembership: string;
+  rechargeCredits: string;
+  viewCreditPlans: string;
+}
+
+export function resolveCommerceMembershipActionLabel(
+  state: CommerceMenuState,
+  labels: CommerceMembershipActionLabels
+): string {
+  switch (resolveMembershipAction(state.membershipAccess)) {
+    case "upgrade-membership":
+      return labels.upgradeMembership;
+    case "recharge-credits":
+      return labels.rechargeCredits;
+    case "view-credit-plans":
+      return labels.viewCreditPlans;
+  }
+}
+
+export function useCommerceOpenExternal(
+  state: CommerceMenuState
+): (url: string) => void {
+  return useCallback(
+    (url: string) => {
+      if (!url.trim()) {
+        return;
+      }
+      try {
+        const result = state.onOpenExternal(url);
+        if (result) {
+          void result.catch((error: unknown) => {
+            state.onActionError?.(error);
+          });
+        }
+      } catch (error) {
+        state.onActionError?.(error);
+      }
+    },
+    [state]
+  );
+}

--- a/packages/commerce/web/src/react/index.ts
+++ b/packages/commerce/web/src/react/index.ts
@@ -1,4 +1,9 @@
 export {
+  AgentConfigCommerceContent,
+  type AgentConfigCommerceContentProps,
+  type AgentConfigCommerceLabels
+} from "./AgentConfigCommerceContent";
+export {
   CommerceMenuContent,
   type CommerceMenuContentProps,
   type CommerceMenuLabels


### PR DESCRIPTION
## Summary

- add an exact-target AgentGUI config-menu contract for Host-owned account content and menu-open refresh events
- add a reusable Commerce account presentation for account name, clickable credits balance with inline refresh, membership, and account center
- route Credits through the Host-provided usage URL without a redundant history row
- preserve the existing provider account/quota UI when the Host does not supply content; environment and settings remain unchanged
- document the Host/Adapter boundary and exported APIs

## Verification

- `pnpm check:changed` (13 lanes)
- pre-push `pnpm check:changed -- --push-ready` (14 lanes)
- `pnpm --filter @tutti-os/commerce exec vitest run --environment jsdom src/react/AgentConfigCommerceContent.spec.tsx` (5 tests)
- `pnpm lint:ts`
- `pnpm typecheck`
- `pnpm check:ui-boundaries`
- `pnpm release:pack:check`
- package builds for `@tutti-os/agent-gui` and `@tutti-os/commerce`
- downstream production build and Electron E2E with Credits/Refresh same-row assertion

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (Not applicable: no lifecycle change.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (No translated counterpart exists for the changed package docs.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.