### PR TITLE
feat(agent-gui): support avatar delivery capability

### DIFF
--- a/.changeset/agent-conversation-avatar-delivery.md
+++ b/.changeset/agent-conversation-avatar-delivery.md
@@ -1,0 +1,7 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Forward the host-issued avatar client-transform capability through conversation
+participant presentation so shared avatars can request size-aware WebP delivery
+without inferring support from external image URLs.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -523,8 +523,11 @@ Standalone hosts may opt a transcript into participant avatars through the
 disabled presentation preserves the existing transcript DOM. Enabled
 presentation has distinct `loading` and `ready` states, so the renderer never
 infers identity readiness from a missing image URL. The host supplies user and
-Agent names and optional avatar URLs; AgentGUI owns the UI System Avatar,
-fixed-size loading slot, fallback initial, and user-right/Agent-left layout.
+Agent names, optional avatar URLs, and the avatar delivery capability projected
+by the owning identity service. AgentGUI forwards client-side transformation
+only when that explicit capability is true; it never infers support from the
+URL. AgentGUI owns the UI System Avatar, fixed-size loading slot, fallback
+initial, and user-right/Agent-left layout.
 Participant-header placement is projected from presentation turns rather than
 individual message, tool-progress, or canonical Turn rows. A presentation turn
 starts at a user message and continues until the next user message, so recovery

--- a/packages/agent/gui/agent-conversation/agentConversation.publicContract.spec.ts
+++ b/packages/agent/gui/agent-conversation/agentConversation.publicContract.spec.ts
@@ -11,7 +11,8 @@ const presentation: AgentConversationParticipantPresentation = {
   status: "ready",
   user: {
     name: "Alice",
-    avatarUrl: "https://example.test/alice.png"
+    avatarUrl: "https://example.test/alice.png",
+    avatarClientTransform: true
   },
   agent: {
     name: "Codex",

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -390,6 +390,7 @@ function AgentConversationParticipantAvatar({
       label={participant.name}
       size={28}
       src={participant.avatarUrl}
+      transform={participant.avatarClientTransform}
     />
   );
 }

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -115,6 +115,36 @@ describe("AgentTranscriptView", () => {
         }
       )
     ).toBe(false);
+    expect(
+      areAgentTranscriptViewPropsEqual(
+        {
+          ...baseProps,
+          participantPresentation: {
+            enabled: true,
+            status: "ready",
+            user: {
+              name: "Alice",
+              avatarUrl: "user.png",
+              avatarClientTransform: false
+            },
+            agent: { name: "Codex", avatarUrl: "agent.png" }
+          }
+        },
+        {
+          ...baseProps,
+          participantPresentation: {
+            enabled: true,
+            status: "ready",
+            user: {
+              name: "Alice",
+              avatarUrl: "user.png",
+              avatarClientTransform: true
+            },
+            agent: { name: "Codex", avatarUrl: "agent.png" }
+          }
+        }
+      )
+    ).toBe(false);
   });
 
   it("renders each participant header once per turn across tool progress rows", async () => {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
@@ -108,8 +108,10 @@ function participantPresentationEqual(
   return (
     previous.user.name === next.user.name &&
     previous.user.avatarUrl === next.user.avatarUrl &&
+    previous.user.avatarClientTransform === next.user.avatarClientTransform &&
     previous.agent.name === next.agent.name &&
-    previous.agent.avatarUrl === next.agent.avatarUrl
+    previous.agent.avatarUrl === next.agent.avatarUrl &&
+    previous.agent.avatarClientTransform === next.agent.avatarClientTransform
   );
 }
 

--- a/packages/agent/gui/shared/agentConversation/contracts/agentConversationParticipantPresentation.ts
+++ b/packages/agent/gui/shared/agentConversation/contracts/agentConversationParticipantPresentation.ts
@@ -1,6 +1,7 @@
 export interface AgentConversationParticipantIdentity {
   name: string;
   avatarUrl?: string | null;
+  avatarClientTransform?: boolean;
 }
 
 export type AgentConversationParticipantPresentation =


### PR DESCRIPTION
## Summary

Carry the server-issued `avatarClientTransform` capability through the agent conversation participant presentation contract and pass it to the shared UI System `Avatar`. This lets host applications opt CloudFront-backed avatars into adaptive image delivery without inferring capability from the URL, while existing participants continue to render unchanged when the field is absent.

The change also includes memoization coverage, public-contract and rendering tests, architecture documentation, and a patch changeset for `@tutti-os/agent-gui`.

## Verification

- `corepack pnpm@10.11.0 check:changed` — passed 11 lanes
- `pnpm check:changed -- --push-ready` — passed 12 lanes
- Commit hooks: formatting, lint, renderer boundaries, agent GUI degradation, and UI boundary checks passed

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.