### PR TITLE
feat(mobile): stream agent activity over DeviceLink

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -36,6 +36,8 @@ jobs:
           cache-dependency-path: |
             go.work
             go.work.sum
+            packages/agent/daemon/go.mod
+            packages/agent/daemon/go.sum
             packages/device-link/go.mod
             packages/device-link/go.sum
 

--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -1,6 +1,7 @@
 android/.gradle/
 android/app/.cxx/
 android/app/build/
+android/app/libs/
 android/build/
 android/local.properties
 .metro-health-check*

--- a/apps/mobile/android/Makefile
+++ b/apps/mobile/android/Makefile
@@ -1,0 +1,41 @@
+.PHONY: android-bindings-check android-aar android-aar-check
+
+ANDROID_API ?= 26
+ANDROID_NDK_VERSION ?= 27.3.13750724
+GOMOBILE_LDFLAGS ?= -checklinkname=0
+REPO_ROOT := $(abspath ../../..)
+DEVICE_LINK_DIR := $(REPO_ROOT)/packages/device-link
+AAR_OUTPUT ?= $(CURDIR)/app/libs/tutti-mobile-go.aar
+JAVA_PACKAGE := dev.tutti.mobile.bindings
+
+android-bindings-check:
+	@bind_tmp=$$(mktemp -d); \
+	trap 'rm -rf "$$bind_tmp"' EXIT; \
+	cd "$(DEVICE_LINK_DIR)" && go tool gobind -lang=java -javapkg=$(JAVA_PACKAGE) -outdir="$$bind_tmp" ./mobile ../agent/daemon/liveprotocol/mobile; \
+	test -f "$$bind_tmp/java/dev/tutti/mobile/bindings/mobile/Mobile.java"; \
+	test -f "$$bind_tmp/java/dev/tutti/mobile/bindings/liveprotocolmobile/Liveprotocolmobile.java"
+
+android-aar:
+	@test -n "$(ANDROID_HOME)" || (echo "ANDROID_HOME is required" >&2; exit 1)
+	@test -n "$(JAVA_HOME)" || (echo "JAVA_HOME is required" >&2; exit 1)
+	@test -x "$(JAVA_HOME)/bin/javac" || (echo "JAVA_HOME does not contain javac" >&2; exit 1)
+	@test -f "$(ANDROID_HOME)/ndk/$(ANDROID_NDK_VERSION)/source.properties" || (echo "Android NDK $(ANDROID_NDK_VERSION) is required" >&2; exit 1)
+	@mkdir -p "$(dir $(AAR_OUTPUT))"
+	@tool_tmp=$$(mktemp -d); \
+	trap 'rm -rf "$$tool_tmp"' EXIT; \
+	cd "$(DEVICE_LINK_DIR)" && GOBIN="$$tool_tmp" go install golang.org/x/mobile/cmd/gobind; \
+	cd "$(DEVICE_LINK_DIR)" && ANDROID_NDK_HOME="$(ANDROID_HOME)/ndk/$(ANDROID_NDK_VERSION)" PATH="$$tool_tmp:$$PATH" go tool gomobile bind -target=android -androidapi=$(ANDROID_API) -javapkg=$(JAVA_PACKAGE) -ldflags="$(GOMOBILE_LDFLAGS)" -o "$(AAR_OUTPUT)" ./mobile ../agent/daemon/liveprotocol/mobile
+	@$(MAKE) android-aar-check
+
+android-aar-check:
+	@test -n "$(JAVA_HOME)" || (echo "JAVA_HOME is required" >&2; exit 1)
+	@test -f "$(AAR_OUTPUT)" || (echo "AAR not found: $(AAR_OUTPUT)" >&2; exit 1)
+	@unzip -tq "$(AAR_OUTPUT)" >/dev/null
+	@for abi in armeabi-v7a arm64-v8a x86 x86_64; do \
+		unzip -Z1 "$(AAR_OUTPUT)" | grep -Fqx "jni/$$abi/libgojni.so" || exit 1; \
+	done
+	@aar_tmp=$$(mktemp -d); \
+	trap 'rm -rf "$$aar_tmp"' EXIT; \
+	unzip -p "$(AAR_OUTPUT)" classes.jar > "$$aar_tmp/classes.jar"; \
+	"$(JAVA_HOME)/bin/jar" tf "$$aar_tmp/classes.jar" | grep -Fqx 'dev/tutti/mobile/bindings/mobile/Mobile.class'; \
+	"$(JAVA_HOME)/bin/jar" tf "$$aar_tmp/classes.jar" | grep -Fqx 'dev/tutti/mobile/bindings/liveprotocolmobile/Liveprotocolmobile.class'

--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -6,13 +6,13 @@ react {
     autolinkLibrariesWithApp()
 }
 
-def deviceLinkAar = file("${rootDir}/../../../packages/device-link/dist/tutti-device-link.aar")
+def mobileGoAar = file("${rootDir}/app/libs/tutti-mobile-go.aar")
 
-tasks.register("verifyDeviceLinkAar") {
+tasks.register("verifyMobileGoAar") {
     doLast {
-        if (!deviceLinkAar.isFile()) {
+        if (!mobileGoAar.isFile()) {
             throw new GradleException(
-                "DeviceLink AAR is missing. Run make -C packages/device-link android-aar first."
+                "Mobile Go AAR is missing. Run pnpm --filter @tutti-os/mobile android:aar first."
             )
         }
     }
@@ -45,12 +45,12 @@ android {
 }
 
 tasks.named("preBuild").configure {
-    dependsOn("verifyDeviceLinkAar")
+    dependsOn("verifyMobileGoAar")
 }
 
 dependencies {
     implementation("com.facebook.react:react-android")
     implementation("com.facebook.react:hermes-android")
     implementation("com.journeyapps:zxing-android-embedded:4.3.0")
-    implementation(files(deviceLinkAar))
+    implementation(files(mobileGoAar))
 }

--- a/apps/mobile/android/app/proguard-rules.pro
+++ b/apps/mobile/android/app/proguard-rules.pro
@@ -1,2 +1,2 @@
--keep class dev.tutti.devicelink.** { *; }
+-keep class dev.tutti.mobile.bindings.** { *; }
 -keep class go.** { *; }

--- a/apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt
+++ b/apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt
@@ -4,14 +4,18 @@ import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
 import android.util.Base64
+import android.util.Log
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
-import dev.tutti.devicelink.mobile.Link
-import dev.tutti.devicelink.mobile.Mobile
+import com.facebook.react.modules.core.DeviceEventManagerModule
+import dev.tutti.mobile.bindings.liveprotocolmobile.Liveprotocolmobile
+import dev.tutti.mobile.bindings.mobile.Link
+import dev.tutti.mobile.bindings.mobile.Mobile
+import dev.tutti.mobile.bindings.mobile.Stream
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -31,8 +35,12 @@ class DeviceLinkModule(
     LifecycleEventListener {
     @Volatile
     private var link: Link? = null
+    @Volatile
+    private var agentLiveStream: Stream? = null
     private var linkGeneration = 0L
+    private var agentLiveGeneration = 0L
     private val backgroundClose = Runnable { closeCurrentLink() }
+    private val agentLiveExecutor = Executors.newSingleThreadExecutor()
     private val closeExecutor = Executors.newSingleThreadExecutor()
     private val handler = Handler(Looper.getMainLooper())
     private val executor =
@@ -214,6 +222,142 @@ class DeviceLinkModule(
     }
 
     @ReactMethod
+    fun startAgentLive(
+        workspaceId: String,
+        promise: Promise,
+    ) {
+        val normalizedWorkspaceId = workspaceId.trim()
+        if (normalizedWorkspaceId.isEmpty()) {
+            promise.reject(
+                "AGENT_LIVE_SUBSCRIBE_FAILED",
+                "Agent live workspace id is required",
+            )
+            return
+        }
+        val selected = linkSnapshot()
+        if (selected == null) {
+            promise.reject(
+                "AGENT_LIVE_SUBSCRIBE_FAILED",
+                "DeviceLink is not prepared",
+            )
+            return
+        }
+        val generation = beginAgentLiveOperation()
+        try {
+            agentLiveExecutor.execute {
+                var stream: Stream? = null
+                var promiseSettled = false
+                try {
+                    stream = selected.openStream(AGENT_LIVE_OPEN_TIMEOUT_MILLIS)
+                    check(promoteAgentLiveStream(stream, generation)) {
+                        "Agent live subscription was cancelled"
+                    }
+                    val subscriber = Liveprotocolmobile.newSubscriber(0, 0)
+                    val requestID = UUID.randomUUID().toString()
+                    val subscription =
+                        JSONObject()
+                            .put(
+                                "protocolRevision",
+                                Liveprotocolmobile.protocolRevision(),
+                            ).put("workspaceId", normalizedWorkspaceId)
+                            .toString()
+                            .toByteArray(StandardCharsets.UTF_8)
+                    val request =
+                        JSONObject()
+                            .put("protocolEpoch", Mobile.protocolEpoch())
+                            .put("service", "agent_live")
+                            .put("requestId", requestID)
+                            .put("method", "SUBSCRIBE")
+                            .put(
+                                "path",
+                                "/v1/workspaces/$normalizedWorkspaceId/agent-live",
+                            ).put(
+                                "body",
+                                Base64.encodeToString(
+                                    subscription,
+                                    Base64.NO_WRAP,
+                                ),
+                            ).toString()
+                            .toByteArray(StandardCharsets.UTF_8)
+                    require(request.size <= MAX_REQUEST_FRAME_BYTES) {
+                        "Agent live subscription request is too large"
+                    }
+                    writeFully(
+                        stream,
+                        ByteBuffer
+                            .allocate(Int.SIZE_BYTES + request.size)
+                            .order(ByteOrder.BIG_ENDIAN)
+                            .putInt(request.size)
+                            .put(request)
+                            .array(),
+                    )
+                    promise.resolve(null)
+                    promiseSettled = true
+                    while (isAgentLiveCurrent(stream, generation)) {
+                        val header = readFully(stream, Int.SIZE_BYTES)
+                        val frameSize =
+                            ByteBuffer.wrap(header).order(ByteOrder.BIG_ENDIAN).int
+                        require(frameSize in 1..MAX_AGENT_LIVE_FRAME_BYTES) {
+                            "Agent live frame size is invalid"
+                        }
+                        val result =
+                            JSONObject(
+                                subscriber.apply(readFully(stream, frameSize)),
+                            )
+                        logAgentLiveControl(result)
+                        if (isAgentLiveCurrent(stream, generation)) {
+                            emitAgentLive(
+                                JSONObject()
+                                    .put("workspaceId", normalizedWorkspaceId)
+                                    .put("result", result)
+                                    .toString(),
+                            )
+                        }
+                    }
+                } catch (error: Throwable) {
+                    if (!promiseSettled) {
+                        promise.reject(
+                            "AGENT_LIVE_SUBSCRIBE_FAILED",
+                            "Unable to start Agent live subscription",
+                            error,
+                        )
+                    } else if (isAgentLiveGenerationCurrent(generation)) {
+                        Log.i(DEVICE_LINK_LOG_TAG, "Agent live stream disconnected")
+                        emitAgentLive(
+                            JSONObject()
+                                .put("workspaceId", normalizedWorkspaceId)
+                                .put("status", "disconnected")
+                                .put("reason", "stream_closed")
+                                .toString(),
+                        )
+                    }
+                } finally {
+                    clearAgentLiveStream(stream, generation)
+                    runCatching { stream?.close() }
+                }
+            }
+        } catch (error: RejectedExecutionException) {
+            promise.reject(
+                "AGENT_LIVE_SUBSCRIBE_FAILED",
+                "DeviceLink is busy; try again",
+                error,
+            )
+        }
+    }
+
+    @ReactMethod
+    fun stopAgentLive(promise: Promise) {
+        closeCurrentAgentLiveStream()
+        promise.resolve(null)
+    }
+
+    @ReactMethod
+    fun addListener(eventName: String) = Unit
+
+    @ReactMethod
+    fun removeListeners(count: Double) = Unit
+
+    @ReactMethod
     fun closeLink(promise: Promise) {
         closeCurrentLink()
         promise.resolve(null)
@@ -237,6 +381,7 @@ class DeviceLinkModule(
         handler.removeCallbacks(backgroundClose)
         reactApplicationContext.removeLifecycleEventListener(this)
         closeCurrentLink()
+        agentLiveExecutor.shutdownNow()
         executor.shutdownNow()
         closeExecutor.shutdown()
         super.invalidate()
@@ -272,6 +417,7 @@ class DeviceLinkModule(
         if (generation == linkGeneration) link else null
 
     private fun closeCurrentLink() {
+        closeCurrentAgentLiveStream()
         val previous =
             synchronized(this) {
                 linkGeneration += 1
@@ -295,8 +441,105 @@ class DeviceLinkModule(
         }
     }
 
+    private fun beginAgentLiveOperation(): Long {
+        var generation: Long
+        val previous =
+            synchronized(this) {
+                agentLiveGeneration += 1
+                generation = agentLiveGeneration
+                val detached = agentLiveStream
+                agentLiveStream = null
+                detached
+            }
+        closeDetachedAgentLiveStream(previous)
+        return generation
+    }
+
+    @Synchronized
+    private fun promoteAgentLiveStream(
+        next: Stream,
+        generation: Long,
+    ): Boolean {
+        if (generation != agentLiveGeneration) {
+            return false
+        }
+        agentLiveStream = next
+        return true
+    }
+
+    @Synchronized
+    private fun isAgentLiveCurrent(
+        stream: Stream,
+        generation: Long,
+    ): Boolean =
+        generation == agentLiveGeneration && agentLiveStream === stream
+
+    @Synchronized
+    private fun isAgentLiveGenerationCurrent(generation: Long): Boolean =
+        generation == agentLiveGeneration
+
+    @Synchronized
+    private fun clearAgentLiveStream(
+        stream: Stream?,
+        generation: Long,
+    ) {
+        if (generation == agentLiveGeneration && agentLiveStream === stream) {
+            agentLiveStream = null
+        }
+    }
+
+    private fun closeCurrentAgentLiveStream() {
+        val previous =
+            synchronized(this) {
+                agentLiveGeneration += 1
+                val detached = agentLiveStream
+                agentLiveStream = null
+                detached
+            }
+        closeDetachedAgentLiveStream(previous)
+    }
+
+    private fun closeDetachedAgentLiveStream(detached: Stream?) {
+        if (detached == null) {
+            return
+        }
+        try {
+            closeExecutor.execute {
+                runCatching(detached::close)
+            }
+        } catch (_: RejectedExecutionException) {
+            runCatching(detached::close)
+        }
+    }
+
+    private fun emitAgentLive(payload: String) {
+        if (!reactApplicationContext.hasActiveReactInstance()) {
+            return
+        }
+        reactApplicationContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit(AGENT_LIVE_EVENT_NAME, payload)
+    }
+
+    private fun logAgentLiveControl(result: JSONObject) {
+        val accepted = result.optJSONArray("accepted") ?: return
+        for (index in 0 until accepted.length()) {
+            when (accepted.optJSONObject(index)?.optString("kind")) {
+                "stream_ready" ->
+                    Log.i(DEVICE_LINK_LOG_TAG, "Agent live stream ready")
+                "discontinuity" ->
+                    Log.i(
+                        DEVICE_LINK_LOG_TAG,
+                        "Agent live stream requested canonical reconciliation",
+                    )
+                "rejected" ->
+                    Log.w(DEVICE_LINK_LOG_TAG, "Agent live stream rejected")
+            }
+        }
+    }
+
     private fun writeFully(
-        stream: dev.tutti.devicelink.mobile.Stream,
+        stream: Stream,
         payload: ByteArray,
     ) {
         var offset = 0
@@ -311,7 +554,7 @@ class DeviceLinkModule(
     }
 
     private fun readFully(
-        stream: dev.tutti.devicelink.mobile.Stream,
+        stream: Stream,
         size: Int,
     ): ByteArray {
         val output = ByteArrayOutputStream(size)
@@ -360,7 +603,11 @@ class DeviceLinkModule(
     }
 
     companion object {
+        private const val AGENT_LIVE_EVENT_NAME = "TuttiDeviceLinkAgentLive"
+        private const val AGENT_LIVE_OPEN_TIMEOUT_MILLIS = 10_000L
         private const val BACKGROUND_GRACE_MILLIS = 15_000L
+        private const val DEVICE_LINK_LOG_TAG = "TuttiDeviceLink"
+        private const val MAX_AGENT_LIVE_FRAME_BYTES = 2 shl 20
         private const val MAX_READ_CHUNK = 1 shl 20
         private const val MAX_REQUEST_BODY_BYTES = 8 shl 20
         private const val MAX_RESPONSE_BODY_BYTES = 16 shl 20

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -5,9 +5,10 @@
   "packageManager": "pnpm@10.11.0",
   "scripts": {
     "android": "pnpm android:aar && react-native run-android",
-    "android:aar": "make -C ../../packages/device-link android-aar",
+    "android:aar": "make -C android android-aar",
     "build:android": "pnpm android:aar && cd android && ./gradlew app:assembleDebug",
-    "check": "pnpm typecheck && pnpm test",
+    "check": "pnpm typecheck && pnpm test && pnpm check:android-bindings",
+    "check:android-bindings": "make -C android android-bindings-check",
     "start": "react-native start",
     "test": "jest --runInBand",
     "typecheck": "tsc --noEmit"

--- a/apps/mobile/src/native/agentLiveNativeBridge.test.ts
+++ b/apps/mobile/src/native/agentLiveNativeBridge.test.ts
@@ -1,0 +1,119 @@
+import { parseAgentLiveDeliveries } from "./agentLiveNativeBridge";
+
+describe("parseAgentLiveDeliveries", () => {
+  test("maps ready, event, and scoped discontinuity deliveries", () => {
+    expect(
+      parseAgentLiveDeliveries(
+        "workspace-1",
+        JSON.stringify({
+          result: {
+            accepted: [
+              { kind: "stream_ready" },
+              {
+                event: {
+                  agentSessionId: "session-1",
+                  data: {
+                    agentSessionId: "session-1",
+                    eventType: "session_audit",
+                    workspaceId: "workspace-1"
+                  },
+                  eventType: "session_audit",
+                  workspaceId: "workspace-1"
+                },
+                kind: "event"
+              },
+              {
+                discontinuity: {
+                  reason: "sequence_gap",
+                  reconcileKeys: [
+                    {
+                      agentSessionId: "session-1",
+                      kind: "session",
+                      workspaceId: "workspace-1"
+                    }
+                  ]
+                },
+                kind: "discontinuity"
+              }
+            ]
+          },
+          workspaceId: "workspace-1"
+        })
+      )
+    ).toEqual([
+      { kind: "connection", status: "connected" },
+      {
+        event: expect.objectContaining({
+          agentSessionId: "session-1",
+          eventType: "session_audit",
+          workspaceId: "workspace-1"
+        }),
+        kind: "event"
+      },
+      {
+        kind: "discontinuity",
+        reason: "sequence_gap",
+        reconcileKeys: [
+          {
+            agentSessionId: "session-1",
+            kind: "session",
+            workspaceId: "workspace-1"
+          }
+        ]
+      }
+    ]);
+  });
+
+  test("maps disconnect and rejects deliveries for another workspace", () => {
+    expect(
+      parseAgentLiveDeliveries(
+        "workspace-1",
+        JSON.stringify({
+          reason: "stream_closed",
+          status: "disconnected",
+          workspaceId: "workspace-1"
+        })
+      )
+    ).toEqual([
+      {
+        kind: "connection",
+        reason: "stream_closed",
+        status: "disconnected"
+      }
+    ]);
+    expect(
+      parseAgentLiveDeliveries(
+        "workspace-1",
+        JSON.stringify({
+          result: { accepted: [{ kind: "stream_ready" }] },
+          workspaceId: "workspace-2"
+        })
+      )
+    ).toEqual([]);
+  });
+
+  test("turns invalid or unknown native deliveries into reconciliation", () => {
+    expect(parseAgentLiveDeliveries("workspace-1", "{")).toEqual([
+      {
+        kind: "discontinuity",
+        reason: "invalid_native_delivery",
+        reconcileKeys: []
+      }
+    ]);
+    expect(
+      parseAgentLiveDeliveries(
+        "workspace-1",
+        JSON.stringify({
+          result: { accepted: [{ kind: "future_delivery" }] },
+          workspaceId: "workspace-1"
+        })
+      )
+    ).toEqual([
+      {
+        kind: "discontinuity",
+        reason: "unknown_delivery",
+        reconcileKeys: []
+      }
+    ]);
+  });
+});

--- a/apps/mobile/src/native/agentLiveNativeBridge.ts
+++ b/apps/mobile/src/native/agentLiveNativeBridge.ts
@@ -1,0 +1,142 @@
+import type {
+  AgentLiveDelivery,
+  AgentLiveReconcileKey
+} from "../services/servicePorts";
+
+export function parseAgentLiveDeliveries(
+  workspaceId: string,
+  payload: string
+): AgentLiveDelivery[] {
+  try {
+    const envelope = JSON.parse(payload) as {
+      reason?: unknown;
+      result?: {
+        accepted?: unknown;
+        reason?: unknown;
+        reconcileRequired?: unknown;
+      };
+      status?: unknown;
+      workspaceId?: unknown;
+    };
+    if (envelope.workspaceId !== workspaceId) return [];
+    if (envelope.status === "disconnected") {
+      return [
+        {
+          kind: "connection",
+          reason:
+            typeof envelope.reason === "string"
+              ? envelope.reason
+              : "stream_closed",
+          status: "disconnected"
+        }
+      ];
+    }
+    const result = envelope.result;
+    if (!result || !Array.isArray(result.accepted)) return [];
+    const deliveries: AgentLiveDelivery[] = [];
+    let hasDiscontinuity = false;
+    for (const accepted of result.accepted) {
+      if (!isRecord(accepted)) continue;
+      if (accepted.kind === "stream_ready") {
+        deliveries.push({ kind: "connection", status: "connected" });
+        continue;
+      }
+      if (accepted.kind === "event" && isRecord(accepted.event)) {
+        deliveries.push({
+          event: accepted.event as unknown as Extract<
+            AgentLiveDelivery,
+            { kind: "event" }
+          >["event"],
+          kind: "event"
+        });
+        continue;
+      }
+      if (accepted.kind === "discontinuity") {
+        const discontinuity = isRecord(accepted.discontinuity)
+          ? accepted.discontinuity
+          : {};
+        hasDiscontinuity = true;
+        deliveries.push({
+          kind: "discontinuity",
+          reason:
+            typeof discontinuity.reason === "string"
+              ? discontinuity.reason
+              : "stream_discontinuity",
+          reconcileKeys: parseReconcileKeys(discontinuity.reconcileKeys)
+        });
+        continue;
+      }
+      if (accepted.kind === "rejected") {
+        deliveries.push({
+          kind: "connection",
+          reason: "protocol_rejected",
+          status: "disconnected"
+        });
+        continue;
+      }
+      deliveries.push({
+        kind: "discontinuity",
+        reason:
+          accepted.kind === "goal_changed" ||
+          accepted.kind === "attachment_changed"
+            ? accepted.kind
+            : "unknown_delivery",
+        reconcileKeys: []
+      });
+    }
+    if (result.reconcileRequired === true && !hasDiscontinuity) {
+      deliveries.push({
+        kind: "discontinuity",
+        reason:
+          typeof result.reason === "string"
+            ? result.reason
+            : "stream_discontinuity",
+        reconcileKeys: []
+      });
+    }
+    return deliveries;
+  } catch {
+    return [
+      {
+        kind: "discontinuity",
+        reason: "invalid_native_delivery",
+        reconcileKeys: []
+      }
+    ];
+  }
+}
+
+function parseReconcileKeys(value: unknown): AgentLiveReconcileKey[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((candidate) => {
+    if (
+      !isRecord(candidate) ||
+      typeof candidate.kind !== "string" ||
+      typeof candidate.workspaceId !== "string"
+    ) {
+      return [];
+    }
+    return [
+      {
+        kind: candidate.kind,
+        workspaceId: candidate.workspaceId,
+        ...(typeof candidate.agentSessionId === "string"
+          ? { agentSessionId: candidate.agentSessionId }
+          : {}),
+        ...(typeof candidate.messageId === "string"
+          ? { messageId: candidate.messageId }
+          : {}),
+        ...(typeof candidate.turnId === "string"
+          ? { turnId: candidate.turnId }
+          : {}),
+        ...(typeof candidate.requestId === "string"
+          ? { requestId: candidate.requestId }
+          : {})
+      }
+    ];
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/mobile/src/native/createMobileServicePorts.ts
+++ b/apps/mobile/src/native/createMobileServicePorts.ts
@@ -1,4 +1,4 @@
-import { AppState } from "react-native";
+import { AppState, DeviceEventEmitter } from "react-native";
 import { deviceLink, mobileSecurity } from "./mobileNative";
 import {
   sendEmailCode,
@@ -16,6 +16,9 @@ import {
 } from "../services/pairingClient";
 import { createRemoteTuttidClient } from "../services/remoteTuttidClient";
 import type { MobileServicePorts } from "../services/servicePorts";
+import { parseAgentLiveDeliveries } from "./agentLiveNativeBridge";
+
+const AGENT_LIVE_EVENT_NAME = "TuttiDeviceLinkAgentLive";
 
 export function createMobileServicePorts(): MobileServicePorts {
   return {
@@ -31,7 +34,43 @@ export function createMobileServicePorts(): MobileServicePorts {
         return { cancel: () => clearTimeout(timer) };
       }
     },
-    deviceLink,
+    deviceLink: {
+      closeLink: () => deviceLink.closeLink(),
+      requestAgentHTTP: (method, path, body, timeoutMillis) =>
+        deviceLink.requestAgentHTTP(method, path, body, timeoutMillis),
+      subscribeAgentLive(workspaceId, listener) {
+        let active = true;
+        const subscription = DeviceEventEmitter.addListener(
+          AGENT_LIVE_EVENT_NAME,
+          (payload: string) => {
+            if (!active) return;
+            for (const delivery of parseAgentLiveDeliveries(
+              workspaceId,
+              payload
+            )) {
+              listener(delivery);
+            }
+          }
+        );
+        void deviceLink.startAgentLive(workspaceId).catch(() => {
+          if (active) {
+            listener({
+              kind: "connection",
+              reason: "subscribe_failed",
+              status: "disconnected"
+            });
+          }
+        });
+        return {
+          close() {
+            if (!active) return;
+            active = false;
+            subscription.remove();
+            void deviceLink.stopAgentLive().catch(() => undefined);
+          }
+        };
+      }
+    },
     deviceSecurity: mobileSecurity,
     lifecycle: {
       subscribe(listener) {

--- a/apps/mobile/src/native/mobileNative.ts
+++ b/apps/mobile/src/native/mobileNative.ts
@@ -34,6 +34,7 @@ interface MobileSecurityNative {
 }
 
 interface DeviceLinkNative {
+  addListener(eventName: string): void;
   closeLink(): Promise<void>;
   connectLink(
     peerDescriptionJSON: string,
@@ -62,7 +63,10 @@ interface DeviceLinkNative {
     protocolEpoch: number;
     status: number;
   }>;
+  removeListeners(count: number): void;
   runLoopbackProbe(timeoutMillis: number): Promise<string>;
+  startAgentLive(workspaceId: string): Promise<void>;
+  stopAgentLive(): Promise<void>;
 }
 
 function requireNativeModule<T>(name: string): T {

--- a/apps/mobile/src/services/mobileApplicationService.test.ts
+++ b/apps/mobile/src/services/mobileApplicationService.test.ts
@@ -93,7 +93,8 @@ function createHarness(storedSession: AccountSession | null): {
         headers: {},
         protocolEpoch: 1,
         status: 204
-      })
+      }),
+      subscribeAgentLive: () => ({ close() {} })
     },
     deviceSecurity: {
       getOrCreateIdentity: async () => ({

--- a/apps/mobile/src/services/mobileApplicationService.ts
+++ b/apps/mobile/src/services/mobileApplicationService.ts
@@ -184,7 +184,8 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
       drafts,
       rail,
       this.ports.clock,
-      authenticated.session.userId
+      authenticated.session.userId,
+      this.ports.deviceLink
     );
     const services = new ServiceCollection();
     services.set(IWorkspaceNavigationService, navigation);

--- a/apps/mobile/src/services/remoteTuttidClient.ts
+++ b/apps/mobile/src/services/remoteTuttidClient.ts
@@ -3,7 +3,9 @@ import type { DeviceLinkPort } from "./servicePorts";
 
 const applicationProtocolEpoch = 1;
 
-export function createRemoteTuttidClient(deviceLink: DeviceLinkPort) {
+export function createRemoteTuttidClient(
+  deviceLink: Pick<DeviceLinkPort, "requestAgentHTTP">
+) {
   const remoteFetch: typeof fetch = async (input, init) => {
     const request = input instanceof Request ? input : new Request(input, init);
     const url = new URL(request.url);

--- a/apps/mobile/src/services/servicePorts.ts
+++ b/apps/mobile/src/services/servicePorts.ts
@@ -1,4 +1,5 @@
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
+import type { AgentActivityLiveEvent } from "@tutti-os/agent-activity-core";
 import type {
   AccountSession,
   DeviceIdentity,
@@ -49,6 +50,35 @@ export interface DeviceLinkPort {
     protocolEpoch: number;
     status: number;
   }>;
+  subscribeAgentLive(
+    workspaceId: string,
+    listener: (delivery: AgentLiveDelivery) => void
+  ): { close(): void };
+}
+
+export type AgentLiveDelivery =
+  | {
+      kind: "connection";
+      reason?: string;
+      status: "connected" | "disconnected";
+    }
+  | {
+      event: AgentActivityLiveEvent;
+      kind: "event";
+    }
+  | {
+      kind: "discontinuity";
+      reason: string;
+      reconcileKeys: readonly AgentLiveReconcileKey[];
+    };
+
+export interface AgentLiveReconcileKey {
+  agentSessionId?: string;
+  kind: string;
+  messageId?: string;
+  requestId?: string;
+  turnId?: string;
+  workspaceId: string;
 }
 
 export interface PairingPort {

--- a/apps/mobile/src/services/workspaceActivityCommandAdapter.ts
+++ b/apps/mobile/src/services/workspaceActivityCommandAdapter.ts
@@ -1,0 +1,227 @@
+import type {
+  AgentActivitySession,
+  AgentSessionEngine,
+  EngineExternalCommand,
+  PromptQueueSendCommand,
+  SessionActivateCommand
+} from "@tutti-os/agent-activity-core";
+import {
+  agentActivityComposerOptionsFromTuttidResult,
+  agentActivitySessionFromTuttidSession,
+  agentActivityTurnFromTuttidTurn
+} from "@tutti-os/agent-activity-tuttid-adapter";
+import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
+import { toTuttidPromptContent } from "./workspaceActivityCommandSupport";
+
+interface WorkspaceActivityCommandContext {
+  client: TuttidClient;
+  engine: AgentSessionEngine;
+  loadComposerOptions(options?: { force?: boolean }): void;
+  mapSession(
+    session: Parameters<typeof agentActivitySessionFromTuttidSession>[1]
+  ): AgentActivitySession;
+  reconcileSession(agentSessionId: string): Promise<unknown>;
+  reconcileWorkspace(): Promise<unknown>;
+}
+
+export function executeWorkspaceActivityCommand(
+  context: WorkspaceActivityCommandContext,
+  command: EngineExternalCommand,
+  signal?: AbortSignal
+): Promise<unknown> {
+  switch (command.type) {
+    case "engine/probe":
+      return Promise.resolve({ ok: true });
+    case "engine/reconcileWorkspace":
+      return context.reconcileWorkspace();
+    case "session/activate":
+      return activateSession(context, command, signal);
+    case "queue/sendPrompt":
+      return sendPrompt(context, command);
+    case "turn/cancel":
+      return context.client
+        .cancelWorkspaceAgentTurn(
+          command.workspaceId,
+          command.agentSessionId,
+          command.turnId
+        )
+        .then((response) => ({
+          ...response,
+          ...(response.turn
+            ? { turn: agentActivityTurnFromTuttidTurn(response.turn) }
+            : {})
+        }));
+    case "interaction/respond":
+      return context.client
+        .submitWorkspaceAgentInteractive(
+          command.workspaceId,
+          command.agentSessionId,
+          command.requestId,
+          {
+            action: command.action ?? null,
+            optionId: command.optionId ?? null,
+            payload: command.payload ?? null,
+            turnId: command.turnId
+          }
+        )
+        .then((session) => ({ session: context.mapSession(session) }));
+    case "session/reconcile":
+      return context.reconcileSession(command.agentSessionId);
+    case "composerOptions/load":
+      return context.client
+        .getAgentProviderComposerOptions(
+          command.provider as Parameters<
+            TuttidClient["getAgentProviderComposerOptions"]
+          >[0],
+          {
+            agentTargetId: command.targetKey,
+            ...(command.cwd ? { cwd: command.cwd } : {}),
+            workspaceId: command.workspaceId,
+            settings: command.settings ?? {}
+          },
+          { signal }
+        )
+        .then((result) =>
+          agentActivityComposerOptionsFromTuttidResult(command.provider, result)
+        );
+    case "session/updateSettings":
+      return context.client
+        .updateWorkspaceAgentSessionSettings(
+          command.workspaceId,
+          command.agentSessionId,
+          command.settings
+        )
+        .then((session) => {
+          const activitySession = context.mapSession(session);
+          context.engine.dispatch({
+            session: activitySession,
+            type: "session/upserted"
+          });
+          const options = activitySession.agentTargetId
+            ? context.engine.getSnapshot().composerOptions.optionsByTargetKey[
+                activitySession.agentTargetId
+              ]
+            : null;
+          if (options?.behavior.refreshModelOptionsAfterSettings === true) {
+            context.loadComposerOptions({ force: true });
+          }
+          return { session: activitySession };
+        });
+    case "session/setPinned":
+      return context.client
+        .updateWorkspaceAgentSessionPin(
+          command.workspaceId,
+          command.agentSessionId,
+          { pinned: command.pinned }
+        )
+        .then((session) => ({ session: context.mapSession(session) }));
+    case "sessions/delete":
+      return context.client
+        .deleteWorkspaceAgentSessionsBatch(
+          command.workspaceId,
+          { sessionIds: [...command.agentSessionIds] },
+          { signal }
+        )
+        .then((response) => ({
+          cleanupFailedSessionIds: response.cleanupFailedSessionIds,
+          removedMessages: response.removedMessages,
+          removedSessionIds: response.removedSessionIds,
+          removedSessions: response.removedSessions
+        }));
+    default:
+      return Promise.reject(
+        new Error(`unsupported mobile agent command: ${command.type}`)
+      );
+  }
+}
+
+async function activateSession(
+  context: WorkspaceActivityCommandContext,
+  command: SessionActivateCommand,
+  signal?: AbortSignal
+): Promise<unknown> {
+  if (command.mode === "existing") {
+    if (signal?.aborted) throw signal.reason;
+    const detail = await context.client.getWorkspaceAgentSession(
+      command.workspaceId,
+      command.agentSessionId
+    );
+    const session = context.mapSession(detail.session);
+    context.engine.dispatch({ session, type: "session/upserted" });
+    return {
+      activation: { mode: "existing", status: "already_attached" },
+      session
+    };
+  }
+  const session = await context.client.createWorkspaceAgentSession(
+    command.workspaceId,
+    {
+      agentSessionId: command.agentSessionId,
+      agentTargetId: command.agentTargetId,
+      clientSubmitId: command.clientSubmitId,
+      cwd: command.cwd ?? null,
+      initialContent: toTuttidPromptContent(command.initialContent ?? []),
+      initialDisplayPrompt: command.initialDisplayPrompt ?? null,
+      ...(command.settings?.model ? { model: command.settings.model } : {}),
+      ...(command.settings?.reasoningEffort
+        ? { reasoningEffort: command.settings.reasoningEffort }
+        : {}),
+      ...(command.settings?.speed ? { speed: command.settings.speed } : {}),
+      ...(command.settings?.permissionModeId
+        ? { permissionModeId: command.settings.permissionModeId }
+        : {}),
+      ...(typeof command.settings?.planMode === "boolean"
+        ? { planMode: command.settings.planMode }
+        : {}),
+      ...(typeof command.settings?.browserUse === "boolean"
+        ? { browserUse: command.settings.browserUse }
+        : {}),
+      ...(typeof command.settings?.computerUse === "boolean"
+        ? { computerUse: command.settings.computerUse }
+        : {}),
+      submitDiagnostics: command.submitDiagnostics,
+      title: command.title ?? null,
+      visible: command.visible ?? true
+    },
+    { signal }
+  );
+  const activitySession = context.mapSession(session);
+  context.engine.dispatch({
+    session: activitySession,
+    type: "session/upserted"
+  });
+  return {
+    activation: { mode: "new", status: "attached" },
+    session: activitySession
+  };
+}
+
+async function sendPrompt(
+  context: WorkspaceActivityCommandContext,
+  command: PromptQueueSendCommand
+): Promise<unknown> {
+  const result = await context.client.sendWorkspaceAgentSessionInput(
+    command.workspaceId,
+    command.agentSessionId,
+    {
+      clientSubmitId: command.clientSubmitId,
+      content: toTuttidPromptContent(command.content),
+      displayPrompt: command.displayPrompt ?? null,
+      guidance: command.guidance ?? false,
+      submitDiagnostics: command.submitDiagnostics
+    }
+  );
+  if (result.kind === "goalControl") {
+    return {
+      kind: "goalControl",
+      goal: result.goal ?? result.session.goal ?? null,
+      session: context.mapSession(result.session)
+    };
+  }
+  return {
+    kind: "turn",
+    session: context.mapSession(result.session),
+    turn: agentActivityTurnFromTuttidTurn(result.turn),
+    turnId: result.turnId
+  };
+}

--- a/apps/mobile/src/services/workspaceActivityProjection.ts
+++ b/apps/mobile/src/services/workspaceActivityProjection.ts
@@ -25,6 +25,56 @@ import type { WorkspaceConversationRailSnapshot } from "./workspaceConversationR
 import type { WorkspaceActivitySnapshot } from "./workspaceActivityTypes";
 import type { WorkspaceNavigationSnapshot } from "./workspaceNavigationService";
 
+export interface WorkspaceComposerTarget {
+  agentSessionId: string | null;
+  agentTargetId: string;
+  cwd: string | null;
+  provider: string;
+  settings: AgentActivitySessionSettings;
+}
+
+export function resolveWorkspaceComposerTarget({
+  activity,
+  getDraftSettings,
+  navigation,
+  targets
+}: {
+  activity: AgentActivitySnapshot;
+  getDraftSettings(agentTargetId: string): AgentActivitySessionSettings;
+  navigation: WorkspaceNavigationSnapshot;
+  targets: readonly AgentTarget[];
+}): WorkspaceComposerTarget | null {
+  if (navigation.creating) {
+    const target =
+      targets.find(
+        (candidate) => candidate.id === navigation.selectedAgentTargetId
+      ) ?? null;
+    return target
+      ? {
+          agentSessionId: null,
+          agentTargetId: target.id,
+          cwd: null,
+          provider: target.provider,
+          settings: getDraftSettings(target.id)
+        }
+      : null;
+  }
+  const session =
+    activity.sessions.find(
+      (candidate) =>
+        candidate.agentSessionId === navigation.selectedAgentSessionId
+    ) ?? null;
+  return session?.agentTargetId
+    ? {
+        agentSessionId: session.agentSessionId,
+        agentTargetId: session.agentTargetId,
+        cwd: session.cwd,
+        provider: session.provider,
+        settings: session.settings
+      }
+    : null;
+}
+
 export function projectWorkspaceActivitySnapshot({
   activity,
   ambiguousSubmission,
@@ -69,7 +119,10 @@ export function projectWorkspaceActivitySnapshot({
       (record) =>
         (navigation.creating ||
           record.agentSessionId === navigation.selectedAgentSessionId) &&
-        (record.status === "requested" || record.status === "confirmed")
+        record.status === "requested" &&
+        !sessions.some(
+          (session) => session.agentSessionId === record.agentSessionId
+        )
     );
   const pinningSessionIds = selectSessionMutations(state).flatMap((mutation) =>
     mutation.kind === "pin" && mutation.status === "inFlight"

--- a/apps/mobile/src/services/workspaceActivityService.test.ts
+++ b/apps/mobile/src/services/workspaceActivityService.test.ts
@@ -7,6 +7,7 @@ import type {
 import { AgentDirectoryService } from "./agentDirectoryService";
 import { ComposerDraftService } from "./composerDraftService";
 import type { ClockPort } from "./servicePorts";
+import type { AgentLiveDelivery, DeviceLinkPort } from "./servicePorts";
 import { WorkspaceActivityService } from "./workspaceActivityService";
 import { WorkspaceConversationRailService } from "./workspaceConversationRailService";
 import { WorkspaceNavigationService } from "./workspaceNavigationService";
@@ -153,6 +154,48 @@ describe("WorkspaceActivityService", () => {
     });
     expect(service.getSnapshot().draft).toBe("");
     expect(service.getSnapshot().sending).toBe(true);
+
+    service.dispose();
+  });
+
+  test("stops presenting a new-session activation as sending after attach", async () => {
+    let createCalls = 0;
+    const client = createClient({
+      composerOptions: async () => ({
+        behavior: {
+          collapseModelOptionsToLatest: false,
+          modelOptionsAuthoritative: true,
+          planModeExclusiveWithPermissionMode: false,
+          prewarmDraftSession: false,
+          refreshModelOptionsAfterSettings: false
+        },
+        effectiveSettings: {},
+        provider: "codex"
+      }),
+      create: async (_workspaceId, input) => {
+        createCalls += 1;
+        return {
+          ...createSession(),
+          agentTargetId: "target-1",
+          id: input.agentSessionId
+        };
+      },
+      listMessages: emptyMessagePage,
+      session: () => null,
+      targets: [createTarget()]
+    });
+    const service = createService(client);
+
+    await service.start();
+    await flushAsyncWork();
+    service.startCreating();
+    service.setDraft("start");
+    await service.send();
+    await flushAsyncWork();
+
+    expect(createCalls).toBe(1);
+    expect(service.getSnapshot().selectedAgentSessionId).not.toBeNull();
+    expect(service.getSnapshot().sending).toBe(false);
 
     service.dispose();
   });
@@ -313,10 +356,78 @@ describe("WorkspaceActivityService", () => {
 
     service.dispose();
   });
+
+  test("projects live message deltas and disables fallback message polling", async () => {
+    const clock = new RecordingClock();
+    let liveListener: ((delivery: AgentLiveDelivery) => void) | null = null;
+    const client = createClient({
+      listMessages: async (_workspaceId, agentSessionId) => ({
+        agentSessionId,
+        hasMore: false,
+        latestVersion: 1,
+        messages: [createMessage("message-1", 1)]
+      })
+    });
+    const deviceLink = {
+      closeLink: async () => undefined,
+      requestAgentHTTP: async () => ({
+        body: "",
+        errorCode: "",
+        headers: {},
+        protocolEpoch: 1,
+        status: 204
+      }),
+      subscribeAgentLive: (
+        _workspaceId: string,
+        listener: (delivery: AgentLiveDelivery) => void
+      ) => {
+        liveListener = listener;
+        return { close() {} };
+      }
+    } satisfies DeviceLinkPort;
+    const service = createService(client, { clock, deviceLink });
+
+    await service.start();
+    await flushAsyncWork();
+    liveListener!({ kind: "connection", status: "connected" });
+    await flushAsyncWork();
+    liveListener!({
+      event: {
+        agentSessionId: "session-1",
+        data: {
+          agentSessionId: "session-1",
+          content: { operation: "append_text", text: "!" },
+          kind: "text",
+          messageId: "message-1",
+          occurredAtUnixMs: 2,
+          role: "assistant",
+          turnId: "turn-1",
+          workspaceId: workspace.id
+        },
+        eventType: "message_delta",
+        workspaceId: workspace.id
+      },
+      kind: "event"
+    });
+
+    expect(
+      service.getSnapshot().activity.sessionMessagesById["session-1"]?.[0]
+        ?.payload.text
+    ).toBe("message-1!");
+    expect(clock.activeDelays()).not.toContain(1_000);
+
+    service.dispose();
+  });
 });
 
-function createService(client: TuttidClient): WorkspaceActivityService {
-  const clock = new ManualClock();
+function createService(
+  client: TuttidClient,
+  options: {
+    clock?: ClockPort;
+    deviceLink?: DeviceLinkPort;
+  } = {}
+): WorkspaceActivityService {
+  const clock = options.clock ?? new ManualClock();
   return new WorkspaceActivityService(
     workspace,
     client,
@@ -325,7 +436,8 @@ function createService(client: TuttidClient): WorkspaceActivityService {
     new ComposerDraftService(),
     new WorkspaceConversationRailService(workspace, client, clock),
     clock,
-    "account-user-1"
+    "account-user-1",
+    options.deviceLink
   );
 }
 
@@ -334,6 +446,10 @@ function createClient(options: {
     provider: string,
     request?: Record<string, unknown>
   ): Promise<Record<string, unknown>>;
+  create?(
+    workspaceId: string,
+    input: { agentSessionId: string }
+  ): Promise<WorkspaceAgentSession>;
   deleteBatch?(
     workspaceId: string,
     input: { sessionIds: string[] }
@@ -381,6 +497,7 @@ function createClient(options: {
   }>;
 }): TuttidClient {
   return {
+    createWorkspaceAgentSession: options.create,
     deleteWorkspaceAgentSessionsBatch: options.deleteBatch,
     getAgentProviderComposerOptions: options.composerOptions,
     listAgentTargets: async () => ({ targets: options.targets ?? [] }),
@@ -519,5 +636,32 @@ class ManualClock implements ClockPort {
 
   schedule(): { cancel(): void } {
     return { cancel: () => undefined };
+  }
+}
+
+class RecordingClock implements ClockPort {
+  private readonly tasks: Array<{
+    canceled: boolean;
+    delayMs: number;
+  }> = [];
+
+  now(): number {
+    return 1_000;
+  }
+
+  schedule(delayMs: number): { cancel(): void } {
+    const task = { canceled: false, delayMs };
+    this.tasks.push(task);
+    return {
+      cancel: () => {
+        task.canceled = true;
+      }
+    };
+  }
+
+  activeDelays(): number[] {
+    return this.tasks
+      .filter((task) => !task.canceled)
+      .map((task) => task.delayMs);
   }
 }

--- a/apps/mobile/src/services/workspaceActivityService.ts
+++ b/apps/mobile/src/services/workspaceActivityService.ts
@@ -9,13 +9,10 @@ import {
   type AgentActivityInteraction,
   type AgentActivitySession,
   type AgentSessionEngine,
-  type EngineExternalCommand,
-  type PromptQueueSendCommand,
-  type SessionActivateCommand
+  type EngineExternalCommand
 } from "@tutti-os/agent-activity-core";
 import {
   agentActivityMessageFromTuttidMessage,
-  agentActivityComposerOptionsFromTuttidResult,
   agentActivitySessionFromTuttidSession,
   agentActivityTurnFromTuttidTurn
 } from "@tutti-os/agent-activity-tuttid-adapter";
@@ -30,17 +27,19 @@ import {
   resolvePendingSubmission,
   type PendingSubmission
 } from "./pendingSubmission";
-import type { ClockPort } from "./servicePorts";
-import { projectWorkspaceActivitySnapshot } from "./workspaceActivityProjection";
+import type { ClockPort, DeviceLinkPort } from "./servicePorts";
+import { executeWorkspaceActivityCommand } from "./workspaceActivityCommandAdapter";
+import {
+  projectWorkspaceActivitySnapshot,
+  resolveWorkspaceComposerTarget
+} from "./workspaceActivityProjection";
 import type {
   WorkspaceConversationRailService,
   WorkspaceConversationRailSnapshot
 } from "./workspaceConversationRailService";
-import {
-  createMobileActivityCommandId,
-  toTuttidPromptContent
-} from "./workspaceActivityCommandSupport";
+import { createMobileActivityCommandId } from "./workspaceActivityCommandSupport";
 import type { WorkspaceActivitySnapshot } from "./workspaceActivityTypes";
+import { WorkspaceAgentLiveLane } from "./workspaceAgentLiveLane";
 import type { WorkspaceNavigationService } from "./workspaceNavigationService";
 import { WorkspaceMediaService } from "./workspaceMediaService";
 
@@ -55,6 +54,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
   readonly _serviceBrand: undefined;
   readonly media: WorkspaceMediaService;
   private readonly engine: AgentSessionEngine;
+  private readonly liveLane: WorkspaceAgentLiveLane;
   private readonly projectActivity: (
     state: ReturnType<AgentSessionEngine["getSnapshot"]>
   ) => WorkspaceActivitySnapshot["activity"];
@@ -85,7 +85,8 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
     private readonly drafts: ComposerDraftService,
     private readonly rail: WorkspaceConversationRailService,
     private readonly clock: ClockPort,
-    private readonly currentUserId: string
+    private readonly currentUserId: string,
+    deviceLink?: DeviceLinkPort
   ) {
     super();
     this.media = new WorkspaceMediaService(workspace.id, client);
@@ -103,6 +104,29 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
       scheduler: {
         schedule: (delayMs, task) => this.clock.schedule(delayMs, task)
       }
+    });
+    this.liveLane = new WorkspaceAgentLiveLane({
+      clock: this.clock,
+      deviceLink,
+      engine: this.engine,
+      isAvailable: () => !this.disposed && !this.paused,
+      loadSelectedMessages: (authoritative) =>
+        this.loadSelectedMessages(authoritative),
+      navigation: this.navigation,
+      onActivityChanged: () => this.onDependencyChanged(),
+      onConnectionChanged: (connected) => {
+        if (connected) {
+          this.messagePollTask?.cancel();
+          this.messagePollTask = null;
+        } else {
+          this.scheduleMessagesPoll();
+        }
+      },
+      rail: this.rail,
+      readCanonicalActivity: () =>
+        this.projectActivity(this.engine.getSnapshot()),
+      reconcileWorkspace: () => this.reconcileWorkspace(),
+      workspaceId: this.workspace.id
     });
     this.disposables.push(
       this.engine.subscribe(() => this.onDependencyChanged()),
@@ -145,7 +169,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
   getSnapshot = (): WorkspaceActivitySnapshot => {
     if (this.snapshotCache) return this.snapshotCache;
     const state = this.engine.getSnapshot();
-    const activity = this.projectActivity(state);
+    const activity = this.liveLane.project(this.projectActivity(state));
     const railSnapshot = this.rail.getSnapshot();
     const navigation = this.navigation.getSnapshot();
     const draftKey = navigation.creating
@@ -196,6 +220,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
         if (this.disposed) return;
         this.loading = false;
         this.loadComposerOptions();
+        this.liveLane.start();
         this.onDependencyChanged();
       });
     return this.initializePromise;
@@ -436,6 +461,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
   pause(): void {
     if (this.paused || this.disposed) return;
     this.paused = true;
+    this.liveLane.stop();
     this.cancelPolls();
     this.rail.pause();
     this.engine.dispatch({
@@ -459,6 +485,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
     if (!this.paused || this.disposed) return;
     this.paused = false;
     this.rail.resume();
+    this.liveLane.start();
     this.engine.dispatch({
       status: "connected",
       type: "engine/connectionChanged",
@@ -469,11 +496,13 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
       workspaceId: this.workspace.id
     });
     void this.loadSelectedMessages(true);
+    this.scheduleMessagesPoll();
   }
 
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    this.liveLane.stop();
     this.cancelPolls();
     for (const dispose of this.disposables.splice(0)) dispose();
     this.pendingSubmissionsByDraftKey.clear();
@@ -551,6 +580,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
           type: "message/snapshotReceived",
           workspaceId: this.workspace.id
         });
+        this.liveLane.reconcileMessages(agentSessionId);
         this.errorCode = null;
       })
       .catch(() => {
@@ -568,202 +598,19 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
     command: EngineExternalCommand,
     signal?: AbortSignal
   ): Promise<unknown> {
-    switch (command.type) {
-      case "engine/probe":
-        return Promise.resolve({ ok: true });
-      case "engine/reconcileWorkspace":
-        return this.reconcileWorkspace();
-      case "session/activate":
-        return this.activateSession(command, signal);
-      case "queue/sendPrompt":
-        return this.sendPrompt(command);
-      case "turn/cancel":
-        return this.client
-          .cancelWorkspaceAgentTurn(
-            command.workspaceId,
-            command.agentSessionId,
-            command.turnId
-          )
-          .then((response) => ({
-            ...response,
-            ...(response.turn
-              ? { turn: agentActivityTurnFromTuttidTurn(response.turn) }
-              : {})
-          }));
-      case "interaction/respond":
-        return this.client
-          .submitWorkspaceAgentInteractive(
-            command.workspaceId,
-            command.agentSessionId,
-            command.requestId,
-            {
-              action: command.action ?? null,
-              optionId: command.optionId ?? null,
-              payload: command.payload ?? null,
-              turnId: command.turnId
-            }
-          )
-          .then((session) => ({
-            session: this.mapSession(session)
-          }));
-      case "session/reconcile":
-        return this.reconcileSession(command.agentSessionId);
-      case "composerOptions/load":
-        return this.client
-          .getAgentProviderComposerOptions(
-            command.provider as Parameters<
-              TuttidClient["getAgentProviderComposerOptions"]
-            >[0],
-            {
-              agentTargetId: command.targetKey,
-              ...(command.cwd ? { cwd: command.cwd } : {}),
-              workspaceId: command.workspaceId,
-              settings: command.settings ?? {}
-            },
-            { signal }
-          )
-          .then((result) =>
-            agentActivityComposerOptionsFromTuttidResult(
-              command.provider,
-              result
-            )
-          );
-      case "session/updateSettings":
-        return this.client
-          .updateWorkspaceAgentSessionSettings(
-            command.workspaceId,
-            command.agentSessionId,
-            command.settings
-          )
-          .then((session) => {
-            const activitySession = this.mapSession(session);
-            this.engine.dispatch({
-              session: activitySession,
-              type: "session/upserted"
-            });
-            const options = activitySession.agentTargetId
-              ? this.engine.getSnapshot().composerOptions.optionsByTargetKey[
-                  activitySession.agentTargetId
-                ]
-              : null;
-            if (options?.behavior.refreshModelOptionsAfterSettings === true) {
-              this.loadComposerOptions({ force: true });
-            }
-            return { session: activitySession };
-          });
-      case "session/setPinned":
-        return this.client
-          .updateWorkspaceAgentSessionPin(
-            command.workspaceId,
-            command.agentSessionId,
-            { pinned: command.pinned }
-          )
-          .then((session) => ({ session: this.mapSession(session) }));
-      case "sessions/delete":
-        return this.client
-          .deleteWorkspaceAgentSessionsBatch(
-            command.workspaceId,
-            { sessionIds: [...command.agentSessionIds] },
-            { signal }
-          )
-          .then((response) => ({
-            cleanupFailedSessionIds: response.cleanupFailedSessionIds,
-            removedMessages: response.removedMessages,
-            removedSessionIds: response.removedSessionIds,
-            removedSessions: response.removedSessions
-          }));
-      default:
-        return Promise.reject(
-          new Error(`unsupported mobile agent command: ${command.type}`)
-        );
-    }
-  }
-
-  private async activateSession(
-    command: SessionActivateCommand,
-    signal?: AbortSignal
-  ): Promise<unknown> {
-    if (command.mode === "existing") {
-      if (signal?.aborted) throw signal.reason;
-      const detail = await this.client.getWorkspaceAgentSession(
-        command.workspaceId,
-        command.agentSessionId
-      );
-      const session = this.mapSession(detail.session);
-      this.engine.dispatch({ session, type: "session/upserted" });
-      return {
-        activation: { mode: "existing", status: "already_attached" },
-        session
-      };
-    }
-    const session = await this.client.createWorkspaceAgentSession(
-      command.workspaceId,
+    return executeWorkspaceActivityCommand(
       {
-        agentSessionId: command.agentSessionId,
-        agentTargetId: command.agentTargetId,
-        clientSubmitId: command.clientSubmitId,
-        cwd: command.cwd ?? null,
-        initialContent: toTuttidPromptContent(command.initialContent ?? []),
-        initialDisplayPrompt: command.initialDisplayPrompt ?? null,
-        ...(command.settings?.model ? { model: command.settings.model } : {}),
-        ...(command.settings?.reasoningEffort
-          ? { reasoningEffort: command.settings.reasoningEffort }
-          : {}),
-        ...(command.settings?.speed ? { speed: command.settings.speed } : {}),
-        ...(command.settings?.permissionModeId
-          ? { permissionModeId: command.settings.permissionModeId }
-          : {}),
-        ...(typeof command.settings?.planMode === "boolean"
-          ? { planMode: command.settings.planMode }
-          : {}),
-        ...(typeof command.settings?.browserUse === "boolean"
-          ? { browserUse: command.settings.browserUse }
-          : {}),
-        ...(typeof command.settings?.computerUse === "boolean"
-          ? { computerUse: command.settings.computerUse }
-          : {}),
-        submitDiagnostics: command.submitDiagnostics,
-        title: command.title ?? null,
-        visible: command.visible ?? true
+        client: this.client,
+        engine: this.engine,
+        loadComposerOptions: (options) => this.loadComposerOptions(options),
+        mapSession: (session) => this.mapSession(session),
+        reconcileSession: (agentSessionId) =>
+          this.reconcileSession(agentSessionId),
+        reconcileWorkspace: () => this.reconcileWorkspace()
       },
-      { signal }
+      command,
+      signal
     );
-    const activitySession = this.mapSession(session);
-    this.engine.dispatch({
-      session: activitySession,
-      type: "session/upserted"
-    });
-    return {
-      activation: { mode: "new", status: "attached" },
-      session: activitySession
-    };
-  }
-
-  private async sendPrompt(command: PromptQueueSendCommand): Promise<unknown> {
-    const result = await this.client.sendWorkspaceAgentSessionInput(
-      command.workspaceId,
-      command.agentSessionId,
-      {
-        clientSubmitId: command.clientSubmitId,
-        content: toTuttidPromptContent(command.content),
-        displayPrompt: command.displayPrompt ?? null,
-        guidance: command.guidance ?? false,
-        submitDiagnostics: command.submitDiagnostics
-      }
-    );
-    if (result.kind === "goalControl") {
-      return {
-        kind: "goalControl",
-        goal: result.goal ?? result.session.goal ?? null,
-        session: this.mapSession(result.session)
-      };
-    }
-    return {
-      kind: "turn",
-      session: this.mapSession(result.session),
-      turn: agentActivityTurnFromTuttidTurn(result.turn),
-      turnId: result.turnId
-    };
   }
 
   private async reconcileWorkspace(): Promise<unknown> {
@@ -810,48 +657,19 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
     });
   }
 
-  private currentComposerTarget(): {
-    agentSessionId: string | null;
-    agentTargetId: string;
-    cwd: string | null;
-    provider: string;
-    settings: AgentActivitySessionSettings;
-  } | null {
-    const navigation = this.navigation.getSnapshot();
-    if (navigation.creating) {
-      const target = this.directory
-        .getSnapshot()
-        .targets.find(
-          (candidate) => candidate.id === navigation.selectedAgentTargetId
-        );
-      if (!target) return null;
-      return {
-        agentSessionId: null,
-        agentTargetId: target.id,
-        cwd: null,
-        provider: target.provider,
-        settings: this.drafts.getSettings(target.id)
-      };
-    }
-    const session = this.projectActivity(
-      this.engine.getSnapshot()
-    ).sessions.find(
-      (candidate) =>
-        candidate.agentSessionId === navigation.selectedAgentSessionId
-    );
-    if (!session?.agentTargetId) return null;
-    return {
-      agentSessionId: session.agentSessionId,
-      agentTargetId: session.agentTargetId,
-      cwd: session.cwd,
-      provider: session.provider,
-      settings: session.settings
-    };
+  private currentComposerTarget() {
+    return resolveWorkspaceComposerTarget({
+      activity: this.projectActivity(this.engine.getSnapshot()),
+      getDraftSettings: (agentTargetId) =>
+        this.drafts.getSettings(agentTargetId),
+      navigation: this.navigation.getSnapshot(),
+      targets: this.directory.getSnapshot().targets
+    });
   }
 
   private scheduleMessagesPoll(): void {
     this.messagePollTask?.cancel();
-    if (this.disposed || this.paused) return;
+    if (this.disposed || this.paused || this.liveLane.isConnected()) return;
     this.messagePollTask = this.clock.schedule(MESSAGE_POLL_MS, () => {
       this.messagePollTask = null;
       void this.loadSelectedMessages(false);

--- a/apps/mobile/src/services/workspaceAgentLiveLane.ts
+++ b/apps/mobile/src/services/workspaceAgentLiveLane.ts
@@ -1,0 +1,248 @@
+import {
+  createAgentActivityOptimisticMessageOverlay,
+  parseAgentActivityMessageDeltaEvent,
+  type AgentActivityLiveEvent,
+  type AgentActivitySnapshot,
+  type AgentActivityTurn,
+  type AgentSessionEngine
+} from "@tutti-os/agent-activity-core";
+import type {
+  AgentLiveDelivery,
+  ClockPort,
+  DeviceLinkPort
+} from "./servicePorts";
+import type { WorkspaceConversationRailService } from "./workspaceConversationRailService";
+import type { WorkspaceNavigationService } from "./workspaceNavigationService";
+
+const AGENT_LIVE_RETRY_MS = 1_000;
+const RAIL_RECONCILE_DELAY_MS = 250;
+
+interface WorkspaceAgentLiveLaneOptions {
+  clock: ClockPort;
+  deviceLink?: DeviceLinkPort;
+  engine: AgentSessionEngine;
+  isAvailable(): boolean;
+  loadSelectedMessages(authoritative: boolean): Promise<void>;
+  navigation: WorkspaceNavigationService;
+  onActivityChanged(): void;
+  onConnectionChanged(connected: boolean): void;
+  rail: WorkspaceConversationRailService;
+  readCanonicalActivity(): AgentActivitySnapshot;
+  reconcileWorkspace(): Promise<unknown>;
+  workspaceId: string;
+}
+
+export class WorkspaceAgentLiveLane {
+  private readonly optimisticMessages =
+    createAgentActivityOptimisticMessageOverlay();
+  private active = false;
+  private connected = false;
+  private retryTask: { cancel(): void } | null = null;
+  private railReconcileTask: { cancel(): void } | null = null;
+  private subscription: { close(): void } | null = null;
+
+  constructor(private readonly options: WorkspaceAgentLiveLaneOptions) {}
+
+  start(): void {
+    this.active = true;
+    if (!this.options.deviceLink || this.subscription) return;
+    this.retryTask?.cancel();
+    this.retryTask = null;
+    this.subscription = this.options.deviceLink.subscribeAgentLive(
+      this.options.workspaceId,
+      (delivery) => this.handleDelivery(delivery)
+    );
+  }
+
+  stop(): void {
+    this.active = false;
+    this.retryTask?.cancel();
+    this.retryTask = null;
+    this.railReconcileTask?.cancel();
+    this.railReconcileTask = null;
+    this.subscription?.close();
+    this.subscription = null;
+    this.setConnected(false);
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  project(canonical: AgentActivitySnapshot): AgentActivitySnapshot {
+    const selectedSessionId =
+      this.options.navigation.getSnapshot().selectedAgentSessionId;
+    const sessionIds = new Set([
+      ...Object.keys(canonical.sessionMessagesById),
+      ...(selectedSessionId ? [selectedSessionId] : [])
+    ]);
+    if (sessionIds.size === 0) return canonical;
+    const sessionMessagesById = { ...canonical.sessionMessagesById };
+    for (const agentSessionId of sessionIds) {
+      sessionMessagesById[agentSessionId] = this.optimisticMessages.project(
+        { workspaceId: this.options.workspaceId, agentSessionId },
+        canonical.sessionMessagesById[agentSessionId] ?? []
+      );
+    }
+    return { ...canonical, sessionMessagesById };
+  }
+
+  reconcileMessages(agentSessionId: string): void {
+    const canonical =
+      this.options.readCanonicalActivity().sessionMessagesById[
+        agentSessionId
+      ] ?? [];
+    this.optimisticMessages.reconcile(
+      { workspaceId: this.options.workspaceId, agentSessionId },
+      canonical
+    );
+  }
+
+  private handleDelivery(delivery: AgentLiveDelivery): void {
+    if (!this.active || !this.options.isAvailable()) return;
+    if (delivery.kind === "connection") {
+      if (delivery.status === "connected") {
+        this.setConnected(true);
+        void this.options.reconcileWorkspace().catch(() => undefined);
+        void this.options.loadSelectedMessages(true);
+        return;
+      }
+      this.subscription?.close();
+      this.subscription = null;
+      this.setConnected(false);
+      this.scheduleRetry();
+      return;
+    }
+    if (delivery.kind === "discontinuity") {
+      this.reconcileDiscontinuity(delivery);
+      return;
+    }
+    this.applyEvent(delivery.event);
+  }
+
+  private applyEvent(event: AgentActivityLiveEvent): void {
+    if (
+      event.workspaceId !== this.options.workspaceId ||
+      !event.agentSessionId.trim()
+    ) {
+      this.reconcileDiscontinuity({
+        kind: "discontinuity",
+        reason: "identity_mismatch",
+        reconcileKeys: []
+      });
+      return;
+    }
+    switch (event.eventType) {
+      case "message_delta": {
+        const parsed = parseAgentActivityMessageDeltaEvent(event);
+        if (!parsed) {
+          this.requestSessionReconcile(event.agentSessionId, true);
+          return;
+        }
+        const applied = this.optimisticMessages.apply(parsed);
+        if (applied.applied) this.options.onActivityChanged();
+        if (applied.needsReconcile) {
+          this.requestSessionReconcile(event.agentSessionId, true);
+        }
+        return;
+      }
+      case "turn_update":
+        this.options.engine.dispatch({
+          turn: agentActivityTurnFromLiveEvent(event),
+          type: "turn/upserted"
+        });
+        this.scheduleRailReconcile();
+        if (event.data.turn.phase === "settled") {
+          this.requestSessionReconcile(event.agentSessionId, true);
+        }
+        return;
+      case "interaction_update":
+        this.options.engine.dispatch({
+          interaction: event.data.interaction,
+          type: "interaction/upserted"
+        });
+        this.scheduleRailReconcile();
+        return;
+      case "session_audit":
+        this.requestSessionReconcile(event.agentSessionId, true);
+        this.scheduleRailReconcile();
+    }
+  }
+
+  private reconcileDiscontinuity(
+    delivery: Extract<AgentLiveDelivery, { kind: "discontinuity" }>
+  ): void {
+    const sessionIds = new Set(
+      delivery.reconcileKeys
+        .filter((key) => key.workspaceId === this.options.workspaceId)
+        .map((key) => key.agentSessionId?.trim())
+        .filter((value): value is string => Boolean(value))
+    );
+    if (sessionIds.size === 0) {
+      const selected = this.options.navigation
+        .getSnapshot()
+        .selectedAgentSessionId?.trim();
+      if (selected) sessionIds.add(selected);
+      void this.options.reconcileWorkspace().catch(() => undefined);
+    }
+    for (const agentSessionId of sessionIds) {
+      this.requestSessionReconcile(agentSessionId, true);
+    }
+    this.scheduleRailReconcile();
+  }
+
+  private requestSessionReconcile(
+    agentSessionId: string,
+    needsMessages: boolean
+  ): void {
+    this.options.engine.dispatch({
+      agentSessionId,
+      needsMessages,
+      needsState: true,
+      type: "session/reconcileRequested",
+      workspaceId: this.options.workspaceId
+    });
+  }
+
+  private scheduleRetry(): void {
+    this.retryTask?.cancel();
+    if (!this.active || this.subscription || !this.options.isAvailable())
+      return;
+    this.retryTask = this.options.clock.schedule(AGENT_LIVE_RETRY_MS, () => {
+      this.retryTask = null;
+      this.start();
+    });
+  }
+
+  private scheduleRailReconcile(): void {
+    if (this.railReconcileTask || !this.active || !this.options.isAvailable()) {
+      return;
+    }
+    this.railReconcileTask = this.options.clock.schedule(
+      RAIL_RECONCILE_DELAY_MS,
+      () => {
+        this.railReconcileTask = null;
+        void this.options.rail.reconcile().catch(() => undefined);
+      }
+    );
+  }
+
+  private setConnected(connected: boolean): void {
+    if (this.connected === connected) return;
+    this.connected = connected;
+    this.options.rail.setLiveConnected(connected);
+    this.options.onConnectionChanged(connected);
+  }
+}
+
+function agentActivityTurnFromLiveEvent(
+  event: Extract<AgentActivityLiveEvent, { eventType: "turn_update" }>
+): AgentActivityTurn {
+  return {
+    ...event.data.turn,
+    completedCommand: event.data.turn
+      .completedCommand as AgentActivityTurn["completedCommand"],
+    error: event.data.turn.error as AgentActivityTurn["error"],
+    fileChanges: event.data.turn.fileChanges as AgentActivityTurn["fileChanges"]
+  };
+}

--- a/apps/mobile/src/services/workspaceConversationRailService.test.ts
+++ b/apps/mobile/src/services/workspaceConversationRailService.test.ts
@@ -179,6 +179,32 @@ describe("WorkspaceConversationRailService", () => {
 
     service.dispose();
   });
+
+  test("uses polling only while the live event lane is disconnected", async () => {
+    const clock = new RecordingClock();
+    const client = {
+      listWorkspaceAgentSessionSections: async () => ({
+        pinned: { hasMore: false, sessions: [], totalCount: 0 },
+        sections: [],
+        workspaceId: workspace.id
+      })
+    } as unknown as TuttidClient;
+    const service = new WorkspaceConversationRailService(
+      workspace,
+      client,
+      clock
+    );
+
+    await service.start();
+    expect(clock.activeDelays()).toEqual([2_000]);
+
+    service.setLiveConnected(true);
+    expect(clock.activeDelays()).toEqual([]);
+
+    service.setLiveConnected(false);
+    expect(clock.activeDelays()).toEqual([2_000]);
+    service.dispose();
+  });
 });
 
 function createSession(
@@ -227,5 +253,29 @@ class ManualClock implements ClockPort {
 
   schedule(): { cancel(): void } {
     return { cancel: () => undefined };
+  }
+}
+
+class RecordingClock implements ClockPort {
+  private readonly tasks: Array<{ canceled: boolean; delayMs: number }> = [];
+
+  now(): number {
+    return 1_000;
+  }
+
+  schedule(delayMs: number): { cancel(): void } {
+    const task = { canceled: false, delayMs };
+    this.tasks.push(task);
+    return {
+      cancel: () => {
+        task.canceled = true;
+      }
+    };
+  }
+
+  activeDelays(): number[] {
+    return this.tasks
+      .filter((task) => !task.canceled)
+      .map((task) => task.delayMs);
   }
 }

--- a/apps/mobile/src/services/workspaceConversationRailService.ts
+++ b/apps/mobile/src/services/workspaceConversationRailService.ts
@@ -39,6 +39,7 @@ export interface WorkspaceConversationRailSnapshot {
 export class WorkspaceConversationRailService extends ObservableService<WorkspaceConversationRailSnapshot> {
   readonly _serviceBrand: undefined;
   private disposed = false;
+  private liveConnected = false;
   private paused = false;
   private loadPromise: Promise<void> | null = null;
   private pollTask: { cancel(): void } | null = null;
@@ -252,6 +253,14 @@ export class WorkspaceConversationRailService extends ObservableService<Workspac
     void this.refresh();
   }
 
+  setLiveConnected(connected: boolean): void {
+    if (this.liveConnected === connected || this.disposed) return;
+    this.liveConnected = connected;
+    this.pollTask?.cancel();
+    this.pollTask = null;
+    if (!connected) this.schedulePoll();
+  }
+
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
@@ -263,7 +272,7 @@ export class WorkspaceConversationRailService extends ObservableService<Workspac
 
   private schedulePoll(): void {
     this.pollTask?.cancel();
-    if (this.disposed || this.paused) return;
+    if (this.disposed || this.paused || this.liveConnected) return;
     this.pollTask = this.clock.schedule(SESSION_POLL_MS, () => {
       this.pollTask = null;
       void this.refresh();

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -878,6 +878,21 @@ gap, discontinuity, recovered connection, invalid payload, or unanchored append
 schedules authoritative reconciliation. UI consumers never retain transport
 epoch/sequence state or distinguish local from shared activity sources.
 
+For Personal paired devices, `services/tuttid/service/mobileremote` owns the
+`agent_live` application-stream adapter. It subscribes to
+`agent.activity.updated` with the requested workspace scope, projects only the
+closed live event variants into `liveprotocol.Publisher`, and converts
+canonical-only event variants into scoped discontinuities. It establishes the
+workspace subscription before publishing `stream_ready`, so events produced
+during ready-frame delivery are already buffered instead of falling through a
+subscribe gap. The Android bridge keeps one long-lived DeviceLink stream and
+delegates frame decoding and continuity checks to the Agent-owned Go mobile
+Subscriber before emitting accepted deliveries to React Native. The Mobile
+Android host co-links that Subscriber and DeviceLink into its own composite
+AAR; the transport package's AAR and Java namespace remain Agent-free. Mobile
+disables its message and Rail pollers after `stream_ready`; those pollers are
+disconnected-transport fallback only.
+
 Hosts may accept older provider/runtime reports with missing transcript
 ownership or ordering fields, but those gaps must be filled before events enter
 `agent-activity-core` or `@tutti-os/agent-gui`. Session-level notices and

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -439,11 +439,14 @@ files are touched.
 Every change under `packages/device-link/**`, including Makefiles, Java probe
 sources, and Android manifests, also selects
 `pnpm check:device-link-android`. That contract runs the Go suite, Android
-arm64 cross-compile, and Java gomobile binding generation. AAR assembly remains
-an explicit Android-SDK validation locally. The manually dispatched Android
-Internal Build workflow installs the pinned SDK/NDK versions, assembles the AAR
-and the internal mobile APK, and uploads a private validation artifact; it does
-not publish this currently provisional module.
+arm64 cross-compile, and the transport-only Java gomobile binding generation.
+`pnpm mobile:check` separately generates the Mobile-owned composite binding
+surface for DeviceLink plus the Agent live Subscriber without requiring an
+Android SDK. AAR assembly remains an explicit Android-SDK validation locally.
+The manually dispatched Android Internal Build workflow installs the pinned
+SDK/NDK versions, assembles the Mobile composite AAR and internal mobile APK,
+and uploads a private validation artifact; it does not publish the currently
+provisional DeviceLink module.
 
 Local runs resolve `golangci-lint` from `$(go env GOPATH)/bin` first and fall
 back to `PATH`. This matches the repository install command without requiring a

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -52,7 +52,9 @@ Desktop + tsh-server + relay
 - **APK**：可以直接安装到设备或模拟器的应用包，主要用于开发和测试。
 - **AAB**：Google Play 发布使用的 App Bundle，后期发布阶段才需要。
 - **Gradle**：Android 构建系统，负责 Kotlin/Java、资源、AAR 和 APK/AAB。
-- **AAR**：Android library。本项目用 gomobile 把 Go DeviceLink 编译为 AAR。
+- **AAR**：Android library。本项目用 gomobile 把 Go DeviceLink 和独立的 Agent
+  liveprotocol mobile subscriber 编译为同一个 AAR；后者仍由
+  `packages/agent/daemon/liveprotocol` 拥有，不属于 DeviceLink 语义。
 - **JNI**：Java/Kotlin 与 native 代码交互的底层机制。gomobile 帮我们生成
   JNI 和 Java binding。
 - **Metro**：React Native 的 JavaScript bundler。开发时负责把 TypeScript/
@@ -105,9 +107,11 @@ emulator -version
 
 ## 4. 当前可以运行的最小链路
 
-`apps/mobile` 已建立为 bare React Native 0.86 Android 工程，并直接消费
-DeviceLink AAR。独立 DeviceLink probe 仍用于在不经过 React Native 的情况下验证
-Go 和 Android native 边界；它会真实执行 ICE、pinned QUIC 和双向 stream。
+`apps/mobile` 已建立为 bare React Native 0.86 Android 工程。Mobile Android
+宿主生成并消费自己的组合 Go AAR，其中同时包含 transport-only DeviceLink
+绑定和 Agent-owned live Subscriber 绑定。独立 DeviceLink probe 仍使用
+DeviceLink 包自己的纯传输 AAR，在不经过 React Native 的情况下验证 Go 和
+Android native 边界；它会真实执行 ICE、pinned QUIC 和双向 stream。
 
 ```sh
 cd packages/device-link
@@ -144,6 +148,18 @@ probe 只验证 Android 内部的传输 vertical slice。正式 App 还会通过
 pairing 和 paired-device attempt 交换双方的 ephemeral fingerprint 与 ICE
 description，再使用同一个 authenticated facade 建立连接。
 
+正式 App 的组合绑定由 Mobile 宿主检查和构建：
+
+```sh
+pnpm --filter @tutti-os/mobile check:android-bindings
+pnpm --filter @tutti-os/mobile android:aar
+```
+
+输出位于忽略的
+`apps/mobile/android/app/libs/tutti-mobile-go.aar`。组合构建只是 Android
+宿主的 JNI 装配边界；它不会把 Agent 协议、Workspace DTO 或产品策略移入
+`packages/device-link`。
+
 ## 5. 正式 App 的日常开发循环
 
 典型开发循环是：
@@ -164,9 +180,9 @@ pnpm mobile:check
 pnpm mobile:test
 ```
 
-`pnpm mobile:android` 会先生成 DeviceLink AAR，再构建并安装 debug App；
-`pnpm mobile:start` 启动 Metro，`pnpm mobile:check` 运行移动端 TypeScript 和
-Jest 检查。
+`pnpm mobile:android` 会先生成 Mobile 组合 Go AAR，再构建并安装 debug App；
+`pnpm mobile:start` 启动 Metro，`pnpm mobile:check` 运行移动端 TypeScript、
+Jest 和组合 gomobile Java binding 检查。
 
 ### Native UI foundation
 
@@ -312,6 +328,13 @@ Google Play 账号。以下事项等正式分发前再处理：
   QUIC、stream 和关闭顺序；
 - `tuttid` owner host 已接入 paired-device rendezvous，并且只允许 workspace、
   Agent Target catalog 和 Agent Session HTTP surface；
+- `tuttid` owner host 已把 workspace-scoped `agent.activity.updated` 接入
+  `agent_live` DeviceLink 长流。Android 通过同一 AAR 中的 Go Subscriber 校验协议
+  revision、stream identity、epoch 和连续 sequence 后才交给 React Native；
+  Mobile 将 `message_delta` 投影到 activity-core optimistic overlay，直接应用
+  Turn/Interaction 更新，并在 discontinuity、序列断点和重连时读取 canonical 数据；
+- workspace 前台已有 live stream 时不再运行一秒消息轮询和两秒会话轮询；长流断开或
+  协议不可用时才恢复单飞轮询，并以一秒退避自动重建 live stream；
 - Android caller 已接入 create/get/update attempt、STUN 二次 gathering、真实
   DeviceLink request stream、端到端请求 deadline、prepare/connect generation
   fencing 和 Native 15 秒后台 grace period；
@@ -339,7 +362,8 @@ Google Play 账号。以下事项等正式分发前再处理：
 接下来按顺序推进：
 
 1. 用真实账号和 Android 真机跑通 QR claim/confirm、direct DeviceLink 与 Agent 操作；
-2. 增加 paired-device Relay fallback 和事件 stream，替换前台的一秒消息校准轮询；
+2. 增加 paired-device Relay fallback，并验证 direct/Relay 切换后的 live stream
+   重连与 canonical 对账；
 3. 补齐前台自动重连、撤销专用状态，以及 mention、workspace file 和媒体预览动作；
 4. Personal 闭环稳定后，再让 TSH 删除本地 transport 副本并消费共享 DeviceLink module。
 

--- a/docs/plans/2026-07-25-mobile-agent-di-data-layer.md
+++ b/docs/plans/2026-07-25-mobile-agent-di-data-layer.md
@@ -93,9 +93,18 @@ React bindings or decorator syntax in service modules.
   mapped command results to the Engine. Rename uses the generated client, then
   immediately upserts the returned canonical Session and reconciles Rail
   membership.
-- Session polling is single-flight at two seconds. Selected-session message
-  polling is single-flight at one second until the DeviceLink event lane is
-  available.
+- A workspace-scoped DeviceLink `agent_live` stream is the foreground update
+  lane. Its Go Subscriber validates revision, identity, epoch, and sequence
+  continuity before Mobile applies `message_delta` through the activity-core
+  optimistic overlay or schedules canonical reconciliation.
+- Mobile keeps that lane in a dedicated service and Android executor rather
+  than mixing its retry/overlay lifecycle into workspace orchestration or
+  consuming a general DeviceLink request worker. The Mobile Android host owns
+  the composite DeviceLink plus Agent Subscriber AAR assembly.
+- Session polling remains single-flight at two seconds and selected-session
+  message polling remains single-flight at one second only while the live lane
+  is disconnected. `stream_ready` disables both pollers; disconnect restores
+  them while Mobile retries the long stream.
 - Initial messages use the Desktop-aligned newest 100 descending page and the
   server `hasMore` boundary. Incremental reads use `afterVersion`; older history
   uses `beforeVersion`.
@@ -159,7 +168,7 @@ React bindings or decorator syntax in service modules.
 - Physical-device visual and accessibility review of the Native Rail.
 - Device/workspace/session navigation preference persistence after a generic
   Mobile preference port exists.
-- DeviceLink event stream and Relay fallback.
+- Relay fallback and direct/Relay live-stream handoff.
 - Richer ambiguous-delivery diagnostics beyond the current reconcile-first,
   exact-identity Retry state.
 - Remaining rich conversation parity after Markdown/code, canonical prompt

--- a/packages/agent/daemon/liveprotocol/mobile/subscriber.go
+++ b/packages/agent/daemon/liveprotocol/mobile/subscriber.go
@@ -1,0 +1,112 @@
+// Package liveprotocolmobile exposes the Agent live-protocol subscriber through
+// gomobile without moving Agent semantics into DeviceLink.
+package liveprotocolmobile
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/liveprotocol"
+)
+
+type Subscriber struct {
+	subscriber *liveprotocol.Subscriber
+}
+
+type applyEnvelope struct {
+	Accepted          []deliveryEnvelope `json:"accepted"`
+	AfterSeq          int64              `json:"afterSeq"`
+	DuplicateCount    int                `json:"duplicateCount"`
+	Epoch             int64              `json:"epoch"`
+	Reason            string             `json:"reason,omitempty"`
+	ReconcileRequired bool               `json:"reconcileRequired"`
+}
+
+type deliveryEnvelope struct {
+	Kind              string                          `json:"kind"`
+	Seq               int64                           `json:"seq"`
+	Event             json.RawMessage                 `json:"event,omitempty"`
+	Discontinuity     *liveprotocol.Discontinuity     `json:"discontinuity,omitempty"`
+	AttachmentChanged *liveprotocol.AttachmentChanged `json:"attachmentChanged,omitempty"`
+	GoalChanged       *liveprotocol.GoalChanged       `json:"goalChanged,omitempty"`
+	StreamReady       *liveprotocol.StreamReady       `json:"streamReady,omitempty"`
+	Rejected          *liveprotocol.Rejected          `json:"rejected,omitempty"`
+}
+
+func ProtocolRevision() string {
+	return liveprotocol.ProtocolRevision
+}
+
+func NewSubscriber(epoch int64, afterSeq int64) (*Subscriber, error) {
+	if epoch < 0 || afterSeq < 0 {
+		return nil, fmt.Errorf("agent live resume cursor must not be negative")
+	}
+	subscriber, err := liveprotocol.NewSubscriber(liveprotocol.SubscriberConfig{
+		Epoch:    uint64(epoch),
+		AfterSeq: uint64(afterSeq),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Subscriber{subscriber: subscriber}, nil
+}
+
+// Apply validates one protobuf-wire frame and returns only accepted,
+// contiguous deliveries as JSON for the React Native boundary.
+func (s *Subscriber) Apply(encoded []byte) (string, error) {
+	if s == nil || s.subscriber == nil {
+		return "", fmt.Errorf("agent live subscriber is unavailable")
+	}
+	result, err := liveprotocol.DecodeAndApply(s.subscriber, encoded)
+	if err != nil {
+		return "", err
+	}
+	cursor := s.subscriber.ResumeCursor()
+	if cursor.Epoch > uint64(^uint64(0)>>1) || cursor.AfterSeq > uint64(^uint64(0)>>1) {
+		return "", fmt.Errorf("agent live cursor exceeds mobile integer range")
+	}
+	envelope := applyEnvelope{
+		Accepted:          make([]deliveryEnvelope, 0, len(result.Accepted)),
+		AfterSeq:          int64(cursor.AfterSeq),
+		DuplicateCount:    result.DuplicateCount,
+		Epoch:             int64(cursor.Epoch),
+		Reason:            result.Reason,
+		ReconcileRequired: result.ReconcileRequired,
+	}
+	for _, delivery := range result.Accepted {
+		envelope.Accepted = append(envelope.Accepted, deliveryEnvelope{
+			Kind:              deliveryKindName(delivery.Kind),
+			Seq:               int64(delivery.Seq),
+			Event:             append(json.RawMessage(nil), delivery.Event...),
+			Discontinuity:     delivery.Discontinuity,
+			AttachmentChanged: delivery.AttachmentChanged,
+			GoalChanged:       delivery.GoalChanged,
+			StreamReady:       delivery.StreamReady,
+			Rejected:          delivery.Rejected,
+		})
+	}
+	raw, err := json.Marshal(envelope)
+	if err != nil {
+		return "", fmt.Errorf("encode agent live mobile delivery: %w", err)
+	}
+	return string(raw), nil
+}
+
+func deliveryKindName(kind liveprotocol.DeliveryKind) string {
+	switch kind {
+	case liveprotocol.DeliveryKindEvent:
+		return "event"
+	case liveprotocol.DeliveryKindDiscontinuity:
+		return "discontinuity"
+	case liveprotocol.DeliveryKindAttachmentChanged:
+		return "attachment_changed"
+	case liveprotocol.DeliveryKindGoalChanged:
+		return "goal_changed"
+	case liveprotocol.DeliveryKindStreamReady:
+		return "stream_ready"
+	case liveprotocol.DeliveryKindRejected:
+		return "rejected"
+	default:
+		return "unknown"
+	}
+}

--- a/packages/agent/daemon/liveprotocol/mobile/subscriber_test.go
+++ b/packages/agent/daemon/liveprotocol/mobile/subscriber_test.go
@@ -1,0 +1,98 @@
+package liveprotocolmobile
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/liveprotocol"
+)
+
+func TestSubscriberAppliesContiguousFrame(t *testing.T) {
+	t.Parallel()
+	subscriber, err := NewSubscriber(0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	event, err := liveprotocol.NewMessageDeltaEvent(liveprotocol.MessageDeltaData{
+		WorkspaceID:      "workspace-1",
+		AgentSessionID:   "session-1",
+		MessageID:        "message-1",
+		TurnID:           "turn-1",
+		Role:             "assistant",
+		Kind:             "text",
+		OccurredAtUnixMS: 10,
+		Content: &liveprotocol.MessageContentOperation{
+			Operation: "set",
+			Value:     json.RawMessage(`"hello"`),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawEvent, err := liveprotocol.MarshalEvent(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := liveprotocol.EncodeFrame(liveprotocol.Frame{
+		ProtocolRevision: liveprotocol.ProtocolRevision,
+		StreamID:         "stream-1",
+		BindingID:        "binding-1",
+		Epoch:            1,
+		Deliveries: []liveprotocol.Delivery{{
+			Seq:   1,
+			Kind:  liveprotocol.DeliveryKindEvent,
+			Event: rawEvent,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := subscriber.Apply(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded applyEnvelope
+	if err := json.Unmarshal([]byte(result), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Epoch != 1 || decoded.AfterSeq != 1 || len(decoded.Accepted) != 1 ||
+		decoded.Accepted[0].Kind != "event" {
+		t.Fatalf("unexpected mobile delivery: %+v", decoded)
+	}
+}
+
+func TestSubscriberReportsSequenceGap(t *testing.T) {
+	t.Parallel()
+	subscriber, err := NewSubscriber(0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := liveprotocol.EncodeFrame(liveprotocol.Frame{
+		ProtocolRevision: liveprotocol.ProtocolRevision,
+		StreamID:         "stream-1",
+		BindingID:        "binding-1",
+		Epoch:            1,
+		Deliveries: []liveprotocol.Delivery{{
+			Seq:  2,
+			Kind: liveprotocol.DeliveryKindDiscontinuity,
+			Discontinuity: &liveprotocol.Discontinuity{
+				Reason: "canonical_update",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := subscriber.Apply(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded applyEnvelope
+	if err := json.Unmarshal([]byte(result), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if !decoded.ReconcileRequired || decoded.Reason != "sequence_gap" ||
+		decoded.AfterSeq != 0 || len(decoded.Accepted) != 0 {
+		t.Fatalf("unexpected gap result: %+v", decoded)
+	}
+}

--- a/services/tuttid/service/mobileremote/remote_host.go
+++ b/services/tuttid/service/mobileremote/remote_host.go
@@ -30,6 +30,7 @@ type remoteHostState struct {
 
 	cancel            context.CancelFunc
 	handler           http.Handler
+	liveEvents        AgentLiveEventSource
 	attempts          map[string]activeRemoteAttempt
 	registeredSession string
 	registeredDevice  RegisteredDevice
@@ -44,12 +45,14 @@ func (s *Service) StartRemoteHost(handler http.Handler) {
 	s.remoteHost.mu.Lock()
 	if s.remoteHost.cancel != nil {
 		s.remoteHost.handler = handler
+		s.remoteHost.liveEvents = s.AgentLiveEvents
 		s.remoteHost.mu.Unlock()
 		return
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	s.remoteHost.cancel = cancel
 	s.remoteHost.handler = handler
+	s.remoteHost.liveEvents = s.AgentLiveEvents
 	s.remoteHost.attempts = make(map[string]activeRemoteAttempt)
 	s.remoteHost.mu.Unlock()
 
@@ -192,6 +195,7 @@ func (s *Service) startRemoteAttempt(
 		pairingID: pairingID, cancel: cancel, generation: generation,
 	}
 	handler := s.remoteHost.handler
+	liveEvents := s.remoteHost.liveEvents
 	s.remoteHost.mu.Unlock()
 
 	s.remoteWG.Add(1)
@@ -204,7 +208,7 @@ func (s *Service) startRemoteAttempt(
 		if !ok {
 			return
 		}
-		s.serveRemoteAttempt(ctx, handler, cookie, identity, pairingID, attempt)
+		s.serveRemoteAttempt(ctx, handler, liveEvents, cookie, identity, pairingID, attempt)
 	}()
 }
 
@@ -272,6 +276,7 @@ func (s *Service) settledRemoteAttempt(
 func (s *Service) serveRemoteAttempt(
 	ctx context.Context,
 	handler http.Handler,
+	liveEvents AgentLiveEventSource,
 	cookie string,
 	identity mobileremotebiz.DeviceIdentity,
 	pairingID string,
@@ -338,7 +343,7 @@ func (s *Service) serveRemoteAttempt(
 		s.remoteWG.Add(1)
 		go func() {
 			defer s.remoteWG.Done()
-			_ = serveRemoteStream(ctx, stream, handler)
+			_ = serveRemoteStreamWithAgentLive(ctx, stream, handler, pairingID, liveEvents)
 		}()
 	}
 }

--- a/services/tuttid/service/mobileremote/remote_protocol.go
+++ b/services/tuttid/service/mobileremote/remote_protocol.go
@@ -14,11 +14,16 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/liveprotocol"
+	eventsgenerated "github.com/tutti-os/tutti/services/tuttid/api/events/generated"
 )
 
 const (
 	ApplicationProtocolEpoch    = 1
 	AgentHTTPService            = "agent_http"
+	AgentLiveService            = "agent_live"
+	AgentLiveSubscribeMethod    = "SUBSCRIBE"
 	maxRemoteRequestBodyBytes   = 8 << 20
 	maxRemoteResponseBodyBytes  = 16 << 20
 	remoteFrameEnvelopeBytes    = 1 << 20
@@ -47,13 +52,247 @@ type RemoteResponse struct {
 }
 
 func serveRemoteStream(ctx context.Context, stream net.Conn, handler http.Handler) error {
+	return serveRemoteStreamWithAgentLive(ctx, stream, handler, "", nil)
+}
+
+func serveRemoteStreamWithAgentLive(
+	ctx context.Context,
+	stream net.Conn,
+	handler http.Handler,
+	bindingID string,
+	liveEvents AgentLiveEventSource,
+) error {
 	defer stream.Close()
 	var request RemoteRequest
 	if err := readRemoteFrame(stream, maxRemoteRequestFrameBytes, &request); err != nil {
 		return err
 	}
+	if strings.TrimSpace(request.Service) == AgentLiveService {
+		return serveAgentLiveStream(ctx, stream, request, bindingID, liveEvents)
+	}
 	response := executeRemoteRequest(ctx, handler, request)
 	return writeRemoteFrame(stream, response)
+}
+
+type agentLiveSubscribeRequest struct {
+	ProtocolRevision string `json:"protocolRevision"`
+	WorkspaceID      string `json:"workspaceId"`
+	Epoch            uint64 `json:"epoch,omitempty"`
+	AfterSeq         uint64 `json:"afterSeq,omitempty"`
+}
+
+func serveAgentLiveStream(
+	ctx context.Context,
+	stream net.Conn,
+	request RemoteRequest,
+	bindingID string,
+	liveEvents AgentLiveEventSource,
+) error {
+	subscription, err := validateAgentLiveSubscription(request, bindingID, liveEvents)
+	if err != nil {
+		return err
+	}
+	streamID := "device-link:" + strings.TrimSpace(request.RequestID)
+	publisher, err := liveprotocol.NewPublisher(liveprotocol.PublisherConfig{
+		StreamID:  streamID,
+		BindingID: strings.TrimSpace(bindingID),
+		Epoch:     1,
+	})
+	if err != nil {
+		return err
+	}
+	if subscription.ProtocolRevision != liveprotocol.ProtocolRevision {
+		return publishAgentLiveInput(stream, publisher, liveprotocol.PublishInput{
+			Rejected: &liveprotocol.Rejected{
+				Reason:           liveprotocol.RejectionProtocolRevisionMismatch,
+				ExpectedRevision: liveprotocol.ProtocolRevision,
+				ReceivedRevision: subscription.ProtocolRevision,
+			},
+			Immediate: true,
+		})
+	}
+	liveCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		var probe [1]byte
+		_, _ = stream.Read(probe[:])
+		cancel()
+	}()
+	return liveEvents.StreamAgentActivity(
+		liveCtx,
+		subscription.WorkspaceID,
+		func() error {
+			if err := publishAgentLiveInput(stream, publisher, liveprotocol.PublishInput{
+				StreamReady: &liveprotocol.StreamReady{
+					ProtocolRevision: liveprotocol.ProtocolRevision,
+					StreamID:         streamID,
+					BindingID:        strings.TrimSpace(bindingID),
+				},
+				Immediate: true,
+			}); err != nil {
+				return err
+			}
+			if subscription.Epoch == 0 && subscription.AfterSeq == 0 {
+				return nil
+			}
+			return publishAgentLiveInput(stream, publisher, liveprotocol.PublishInput{
+				Discontinuity: &liveprotocol.Discontinuity{
+					Reason: "resume_miss",
+					ReconcileKeys: []liveprotocol.ReconcileKey{{
+						Kind:        "workspace",
+						WorkspaceID: subscription.WorkspaceID,
+					}},
+				},
+				Immediate: true,
+			})
+		},
+		func(payload []byte) error {
+			return publishAgentActivityEnvelope(
+				stream,
+				publisher,
+				subscription.WorkspaceID,
+				payload,
+			)
+		},
+	)
+}
+
+func validateAgentLiveSubscription(
+	request RemoteRequest,
+	bindingID string,
+	liveEvents AgentLiveEventSource,
+) (agentLiveSubscribeRequest, error) {
+	if request.ProtocolEpoch != ApplicationProtocolEpoch {
+		return agentLiveSubscribeRequest{}, fmt.Errorf("agent live protocol epoch mismatch")
+	}
+	if strings.TrimSpace(request.RequestID) == "" ||
+		strings.ToUpper(strings.TrimSpace(request.Method)) != AgentLiveSubscribeMethod ||
+		strings.TrimSpace(bindingID) == "" {
+		return agentLiveSubscribeRequest{}, fmt.Errorf("invalid agent live subscription")
+	}
+	if liveEvents == nil {
+		return agentLiveSubscribeRequest{}, fmt.Errorf("agent live event source is unavailable")
+	}
+	var subscription agentLiveSubscribeRequest
+	decoder := json.NewDecoder(bytes.NewReader(request.Body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&subscription); err != nil {
+		return agentLiveSubscribeRequest{}, fmt.Errorf("decode agent live subscription: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return agentLiveSubscribeRequest{}, errors.New("agent live subscription contains trailing data")
+	}
+	subscription.ProtocolRevision = strings.TrimSpace(subscription.ProtocolRevision)
+	subscription.WorkspaceID = strings.TrimSpace(subscription.WorkspaceID)
+	if subscription.ProtocolRevision == "" || subscription.WorkspaceID == "" {
+		return agentLiveSubscribeRequest{}, fmt.Errorf("agent live subscription identity is required")
+	}
+	expectedPath := "/v1/workspaces/" + url.PathEscape(subscription.WorkspaceID) + "/agent-live"
+	if strings.TrimSpace(request.Path) != expectedPath {
+		return agentLiveSubscribeRequest{}, fmt.Errorf("agent live subscription path is invalid")
+	}
+	return subscription, nil
+}
+
+func publishAgentActivityEnvelope(
+	stream net.Conn,
+	publisher *liveprotocol.Publisher,
+	workspaceID string,
+	payload []byte,
+) error {
+	var envelope eventsgenerated.AgentActivityUpdatedPayload
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return publishAgentLiveInput(stream, publisher, liveprotocol.PublishInput{
+			Discontinuity: &liveprotocol.Discontinuity{Reason: "invalid_event"},
+			Immediate:     true,
+		})
+	}
+	var rawFields map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &rawFields); err != nil {
+		return publishAgentLiveInput(stream, publisher, liveprotocol.PublishInput{
+			Discontinuity: &liveprotocol.Discontinuity{Reason: "invalid_event"},
+			Immediate:     true,
+		})
+	}
+	envelope.WorkspaceId = strings.TrimSpace(envelope.WorkspaceId)
+	envelope.AgentSessionId = strings.TrimSpace(envelope.AgentSessionId)
+	envelope.EventType = strings.TrimSpace(envelope.EventType)
+	if envelope.WorkspaceId != strings.TrimSpace(workspaceID) {
+		return publishAgentLiveInput(stream, publisher, liveprotocol.PublishInput{
+			Discontinuity: &liveprotocol.Discontinuity{
+				Reason: "scope_mismatch",
+				ReconcileKeys: []liveprotocol.ReconcileKey{{
+					Kind:        "workspace",
+					WorkspaceID: strings.TrimSpace(workspaceID),
+				}},
+			},
+			Immediate: true,
+		})
+	}
+	event := liveprotocol.Event{
+		WorkspaceID:    envelope.WorkspaceId,
+		AgentSessionID: envelope.AgentSessionId,
+		EventType:      liveprotocol.EventType(envelope.EventType),
+		Data:           rawFields["data"],
+	}
+	if _, err := liveprotocol.MarshalEvent(event); err == nil {
+		return publishAgentLiveInput(stream, publisher, liveprotocol.PublishInput{
+			Event:     &event,
+			Immediate: true,
+		})
+	}
+	reconcileKeys := make([]liveprotocol.ReconcileKey, 0, 1)
+	if envelope.WorkspaceId != "" || envelope.AgentSessionId != "" {
+		reconcileKeys = append(reconcileKeys, liveprotocol.ReconcileKey{
+			Kind:           "session",
+			WorkspaceID:    envelope.WorkspaceId,
+			AgentSessionID: envelope.AgentSessionId,
+		})
+	}
+	return publishAgentLiveInput(stream, publisher, liveprotocol.PublishInput{
+		Discontinuity: &liveprotocol.Discontinuity{
+			Reason:        "canonical_update",
+			ReconcileKeys: reconcileKeys,
+		},
+		Immediate: true,
+	})
+}
+
+func publishAgentLiveInput(
+	stream net.Conn,
+	publisher *liveprotocol.Publisher,
+	input liveprotocol.PublishInput,
+) error {
+	frames, err := publisher.Publish(input)
+	if err != nil {
+		return err
+	}
+	for _, frame := range frames {
+		encoded, err := liveprotocol.EncodeFrame(frame)
+		if err != nil {
+			return err
+		}
+		if err := writeBinaryFrame(stream, encoded); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeBinaryFrame(writer io.Writer, payload []byte) error {
+	if len(payload) == 0 || len(payload) > liveprotocol.DefaultFrameMaxBytes {
+		return fmt.Errorf("agent live frame size %d is invalid", len(payload))
+	}
+	var size [4]byte
+	binary.BigEndian.PutUint32(size[:], uint32(len(payload)))
+	if _, err := writer.Write(size[:]); err != nil {
+		return fmt.Errorf("write agent live frame size: %w", err)
+	}
+	if _, err := writer.Write(payload); err != nil {
+		return fmt.Errorf("write agent live frame: %w", err)
+	}
+	return nil
 }
 
 func executeRemoteRequest(ctx context.Context, handler http.Handler, request RemoteRequest) RemoteResponse {

--- a/services/tuttid/service/mobileremote/remote_protocol_test.go
+++ b/services/tuttid/service/mobileremote/remote_protocol_test.go
@@ -5,10 +5,13 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"io"
 	"net"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/liveprotocol"
 )
 
 func TestRemoteProtocolRoundTripsAllowedAgentRequest(t *testing.T) {
@@ -167,4 +170,152 @@ func TestRemoteProtocolStreamHonorsCanceledContext(t *testing.T) {
 	if err := <-requestContextErr; err == nil {
 		t.Fatal("expected canceled request context")
 	}
+}
+
+type stubAgentLiveEventSource struct {
+	payloads [][]byte
+}
+
+func (s stubAgentLiveEventSource) StreamAgentActivity(
+	ctx context.Context,
+	_ string,
+	ready func() error,
+	emit func([]byte) error,
+) error {
+	if err := ready(); err != nil {
+		return err
+	}
+	for _, payload := range s.payloads {
+		if err := emit(payload); err != nil {
+			return err
+		}
+	}
+	<-ctx.Done()
+	return nil
+}
+
+func TestRemoteProtocolStreamsValidatedAgentLiveFrames(t *testing.T) {
+	t.Parallel()
+	server, client := net.Pipe()
+	done := make(chan error, 1)
+	go func() {
+		done <- serveRemoteStreamWithAgentLive(
+			context.Background(),
+			server,
+			http.NotFoundHandler(),
+			"pairing-1",
+			stubAgentLiveEventSource{payloads: [][]byte{[]byte(`{
+				"workspaceId":"workspace-1",
+				"agentSessionId":"session-1",
+				"eventType":"message_delta",
+				"data":{
+					"workspaceId":"workspace-1",
+					"agentSessionId":"session-1",
+					"messageId":"message-1",
+					"turnId":"turn-1",
+					"role":"assistant",
+					"kind":"text",
+					"occurredAtUnixMs":10,
+					"content":{"operation":"set","value":"hello"}
+				}
+			}`)}},
+		)
+	}()
+	body, err := json.Marshal(agentLiveSubscribeRequest{
+		ProtocolRevision: liveprotocol.ProtocolRevision,
+		WorkspaceID:      "workspace-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeRemoteFrame(client, RemoteRequest{
+		ProtocolEpoch: ApplicationProtocolEpoch,
+		Service:       AgentLiveService,
+		RequestID:     "request-live-1",
+		Method:        AgentLiveSubscribeMethod,
+		Path:          "/v1/workspaces/workspace-1/agent-live",
+		Body:          body,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ready := readAgentLiveTestFrame(t, client)
+	if len(ready.Deliveries) != 1 ||
+		ready.Deliveries[0].Kind != liveprotocol.DeliveryKindStreamReady ||
+		ready.BindingID != "pairing-1" {
+		t.Fatalf("unexpected ready frame: %+v", ready)
+	}
+	eventFrame := readAgentLiveTestFrame(t, client)
+	if len(eventFrame.Deliveries) != 1 ||
+		eventFrame.Deliveries[0].Kind != liveprotocol.DeliveryKindEvent {
+		t.Fatalf("unexpected event frame: %+v", eventFrame)
+	}
+	event, err := liveprotocol.DecodeEvent(eventFrame.Deliveries[0].Event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.EventType != liveprotocol.EventTypeMessageDelta ||
+		event.WorkspaceID != "workspace-1" ||
+		event.AgentSessionID != "session-1" {
+		t.Fatalf("unexpected live event: %+v", event)
+	}
+	_ = client.Close()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRemoteProtocolProjectsCanonicalOnlyEventAsDiscontinuity(t *testing.T) {
+	t.Parallel()
+	publisher, err := liveprotocol.NewPublisher(liveprotocol.PublisherConfig{
+		StreamID: "stream-1", BindingID: "binding-1", Epoch: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, client := net.Pipe()
+	done := make(chan error, 1)
+	go func() {
+		done <- publishAgentActivityEnvelope(
+			server,
+			publisher,
+			"workspace-1",
+			[]byte(`{
+				"workspaceId":"workspace-1",
+				"agentSessionId":"session-1",
+				"eventType":"message_update",
+				"data":{"workspaceId":"workspace-1","agentSessionId":"session-1"}
+			}`),
+		)
+	}()
+	frame := readAgentLiveTestFrame(t, client)
+	if len(frame.Deliveries) != 1 ||
+		frame.Deliveries[0].Kind != liveprotocol.DeliveryKindDiscontinuity ||
+		frame.Deliveries[0].Discontinuity.Reason != "canonical_update" {
+		t.Fatalf("unexpected discontinuity frame: %+v", frame)
+	}
+	_ = client.Close()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readAgentLiveTestFrame(t *testing.T, reader net.Conn) liveprotocol.Frame {
+	t.Helper()
+	var size [4]byte
+	if _, err := io.ReadFull(reader, size[:]); err != nil {
+		t.Fatal(err)
+	}
+	length := int(binary.BigEndian.Uint32(size[:]))
+	if length <= 0 || length > liveprotocol.DefaultFrameMaxBytes {
+		t.Fatalf("invalid agent live frame size: %d", length)
+	}
+	raw := make([]byte, length)
+	if _, err := io.ReadFull(reader, raw); err != nil {
+		t.Fatal(err)
+	}
+	frame, err := liveprotocol.DecodeFrame(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return frame
 }

--- a/services/tuttid/service/mobileremote/service.go
+++ b/services/tuttid/service/mobileremote/service.go
@@ -28,6 +28,19 @@ type IdentityStore interface {
 	LoadOrCreate(context.Context) (mobileremotebiz.DeviceIdentity, error)
 }
 
+// AgentLiveEventSource feeds already-validated agent.activity.updated
+// envelopes into one workspace-scoped DeviceLink stream. The source establishes
+// its subscription before calling ready, then emits every subsequent envelope.
+// DeviceLink itself remains unaware of Agent event vocabulary.
+type AgentLiveEventSource interface {
+	StreamAgentActivity(
+		context.Context,
+		string,
+		func() error,
+		func([]byte) error,
+	) error
+}
+
 type DeviceMetadata struct {
 	ReportedName  string
 	Platform      string
@@ -46,11 +59,12 @@ type pendingChallenge struct {
 }
 
 type Service struct {
-	Account      AccountSessionSource
-	Identities   IdentityStore
-	ControlPlane ControlPlane
-	Metadata     DeviceMetadata
-	Now          func() time.Time
+	Account         AccountSessionSource
+	Identities      IdentityStore
+	ControlPlane    ControlPlane
+	AgentLiveEvents AgentLiveEventSource
+	Metadata        DeviceMetadata
+	Now             func() time.Time
 	// RemotePollInterval is test-only tuning; zero uses the production default.
 	RemotePollInterval time.Duration
 

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -238,6 +238,7 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 	mobileRemoteService, err := buildMobileRemoteService(
 		agentExtensionStateDir,
 		accountService,
+		events,
 	)
 	if err != nil {
 		return tuttiapi.DaemonAPI{}, nil, nil, nil, err

--- a/services/tuttid/wiring_mobile_remote.go
+++ b/services/tuttid/wiring_mobile_remote.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -8,6 +9,7 @@ import (
 
 	deviceidentitydata "github.com/tutti-os/tutti/services/tuttid/data/deviceidentity"
 	accountservice "github.com/tutti-os/tutti/services/tuttid/service/account"
+	eventstreamservice "github.com/tutti-os/tutti/services/tuttid/service/eventstream"
 	mobileremoteservice "github.com/tutti-os/tutti/services/tuttid/service/mobileremote"
 	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
 )
@@ -15,6 +17,7 @@ import (
 func buildMobileRemoteService(
 	stateDir string,
 	account *accountservice.Service,
+	events *eventstreamservice.Service,
 ) (*mobileremoteservice.Service, error) {
 	deviceID, err := tuttitypes.LoadOrCreateDeviceID(stateDir)
 	if err != nil {
@@ -25,7 +28,8 @@ func buildMobileRemoteService(
 		reportedName = "Tutti Desktop"
 	}
 	return &mobileremoteservice.Service{
-		Account: account,
+		Account:         account,
+		AgentLiveEvents: mobileAgentLiveEventSource{events: events},
 		Identities: deviceidentitydata.NewFileStore(
 			filepath.Join(stateDir, "mobile-remote", "device-identity.json"),
 			deviceID,
@@ -40,4 +44,44 @@ func buildMobileRemoteService(
 			ClientVersion: tuttitypes.ResolveAppVersion(),
 		},
 	}, nil
+}
+
+type mobileAgentLiveEventSource struct {
+	events *eventstreamservice.Service
+}
+
+func (s mobileAgentLiveEventSource) StreamAgentActivity(
+	ctx context.Context,
+	workspaceID string,
+	ready func() error,
+	emit func([]byte) error,
+) error {
+	if s.events == nil {
+		return fmt.Errorf("agent live event stream is unavailable")
+	}
+	session := s.events.OpenSession()
+	defer s.events.CloseSession(session)
+	if err := s.events.Subscribe(
+		session,
+		[]string{eventstreamservice.TopicAgentActivityUpdated},
+		eventstreamservice.EventScope{WorkspaceID: workspaceID},
+	); err != nil {
+		return err
+	}
+	if err := ready(); err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case event, ok := <-s.events.Events(session):
+			if !ok {
+				return fmt.Errorf("agent live event session closed")
+			}
+			if err := emit(append([]byte(nil), event.Payload...)); err != nil {
+				return err
+			}
+		}
+	}
 }

--- a/services/tuttid/wiring_mobile_remote_test.go
+++ b/services/tuttid/wiring_mobile_remote_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	eventstreamservice "github.com/tutti-os/tutti/services/tuttid/service/eventstream"
+)
+
+func TestMobileAgentLiveEventSourceSubscribesBeforeReady(t *testing.T) {
+	t.Parallel()
+
+	events := eventstreamservice.NewService(eventstreamservice.DefaultCatalog(), nil)
+	source := mobileAgentLiveEventSource{events: events}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	readyEntered := make(chan struct{})
+	releaseReady := make(chan struct{})
+	emitted := make(chan []byte, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- source.StreamAgentActivity(
+			ctx,
+			"workspace-1",
+			func() error {
+				close(readyEntered)
+				<-releaseReady
+				return nil
+			},
+			func(payload []byte) error {
+				emitted <- payload
+				cancel()
+				return nil
+			},
+		)
+	}()
+
+	select {
+	case <-readyEntered:
+	case <-time.After(time.Second):
+		t.Fatal("event source did not report ready")
+	}
+
+	publisher := eventstreamservice.AgentActivityPublisher{Service: events}
+	if err := publisher.PublishAgentActivityUpdatedJSON(
+		context.Background(),
+		"workspace-1",
+		"session-1",
+		"message_delta",
+		json.RawMessage(`{
+			"workspaceId":"workspace-1",
+			"agentSessionId":"session-1",
+			"messageId":"message-1",
+			"turnId":"turn-1",
+			"role":"assistant",
+			"kind":"text",
+			"occurredAtUnixMs":10,
+			"content":{"operation":"set","value":"hello"}
+		}`),
+	); err != nil {
+		t.Fatal(err)
+	}
+	close(releaseReady)
+
+	select {
+	case payload := <-emitted:
+		if len(payload) == 0 {
+			t.Fatal("event source emitted an empty payload")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("event published after subscribe but before ready was lost")
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("event source did not stop after cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

- add a workspace-scoped `agent_live` DeviceLink stream backed by the repository Agent live protocol
- validate and sequence frames in an Agent-owned gomobile Subscriber before delivering events to React Native
- apply message deltas optimistically and fall back to canonical Session, message, and Rail reconciliation on gaps or disconnects
- move the composite DeviceLink + Agent gomobile AAR assembly into the Mobile Android host while keeping `packages/device-link` transport-only
- split Mobile activity orchestration, live-lane handling, native delivery parsing, and tuttid command adaptation into focused modules

## Why

Mobile previously depended on request polling while an existing live event protocol was available in the repository. The initial integration also exposed two structural risks: `stream_ready` could be sent before the daemon event subscription existed, creating a small loss window, and the transport-only DeviceLink package was assembling Agent bindings into its own AAR and Java namespace.

This change makes the live stream the foreground update lane, subscribes before publishing readiness, preserves opaque event payload bytes, and retains polling only as a disconnected-transport fallback.

## Impact

Foreground Agent messages, Turn state, and Interactions can reach a paired Android device without waiting for polling intervals. Discontinuities and reconnects continue to converge through canonical reads. Android runs the long-lived reader on a dedicated executor so ordinary DeviceLink requests remain available.

## Validation

- `pnpm check:changed`
- `pnpm check:changed -- --push-ready` (16 selected lanes passed after retrying an environment-sensitive Computer Use screenshot test)
- `pnpm --filter @tutti-os/mobile check:android-bindings`
- Mobile TypeScript typecheck and Jest suite
- focused tuttid Mobile remote protocol and subscribe-before-ready tests