### PR TITLE
feat(mobile): restore remote conversation design

### DIFF
--- a/apps/mobile/src/components/MobileComposerDock.tsx
+++ b/apps/mobile/src/components/MobileComposerDock.tsx
@@ -10,6 +10,7 @@ import {
   ActivityIndicator,
   Modal,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -167,55 +168,65 @@ export function MobileComposerDock({
                 ) : null}
               </>
             ) : (
-              <View style={styles.menuHeader}>
-                <NativeIconButton
-                  accessibilityLabel={t("cancel")}
-                  icon={<Text style={styles.menuBackIcon}>←</Text>}
-                  onPress={() => setMenu("tools")}
-                  style={styles.menuBackButton}
-                />
-                <Text style={styles.menuTitle}>
-                  {menu === "model" ? t("model") : t("permissions")}
-                </Text>
-              </View>
+              <>
+                <View style={styles.menuHeader}>
+                  <NativeIconButton
+                    accessibilityLabel={t("cancel")}
+                    icon={<Text style={styles.menuBackIcon}>←</Text>}
+                    onPress={() => setMenu("tools")}
+                    style={styles.menuBackButton}
+                  />
+                  <Text style={styles.menuTitle}>
+                    {menu === "model" ? t("model") : t("permissions")}
+                  </Text>
+                </View>
+                <ScrollView
+                  nestedScrollEnabled
+                  showsVerticalScrollIndicator
+                  style={styles.menuOptions}
+                >
+                  {menu === "model"
+                    ? modelOptions.map((option) => (
+                        <NativeListRow
+                          key={option.value}
+                          onPress={() => {
+                            onUpdate({ model: option.value });
+                            setMenu(null);
+                          }}
+                          selected={
+                            option.value === model.composerSettings.model
+                          }
+                          title={option.label}
+                        />
+                      ))
+                    : null}
+                  {menu === "permission"
+                    ? permissionOptions.map((option) => (
+                        <NativeListRow
+                          description={option.description}
+                          key={option.id}
+                          onPress={() => {
+                            onUpdate({ permissionModeId: option.id });
+                            setMenu(null);
+                          }}
+                          selected={
+                            option.id ===
+                            model.composerSettings.permissionModeId
+                          }
+                          title={option.label ?? option.id}
+                        />
+                      ))
+                    : null}
+                  {model.composerOptionsLoadStatus === "loading" ? (
+                    <ActivityIndicator
+                      color={theme.color.accent}
+                      size="small"
+                      style={styles.loading}
+                    />
+                  ) : null}
+                </ScrollView>
+              </>
             )}
-            {menu === "model"
-              ? modelOptions.map((option) => (
-                  <NativeListRow
-                    key={option.value}
-                    onPress={() => {
-                      onUpdate({ model: option.value });
-                      setMenu(null);
-                    }}
-                    selected={option.value === model.composerSettings.model}
-                    title={option.label}
-                  />
-                ))
-              : null}
-            {menu === "permission"
-              ? permissionOptions.map((option) => (
-                  <NativeListRow
-                    description={option.description}
-                    key={option.id}
-                    onPress={() => {
-                      onUpdate({ permissionModeId: option.id });
-                      setMenu(null);
-                    }}
-                    selected={
-                      option.id === model.composerSettings.permissionModeId
-                    }
-                    title={option.label ?? option.id}
-                  />
-                ))
-              : null}
-            {menu !== "tools" &&
-            model.composerOptionsLoadStatus === "loading" ? (
-              <ActivityIndicator
-                color={theme.color.accent}
-                size="small"
-                style={styles.loading}
-              />
-            ) : null}
           </Pressable>
         </Pressable>
       </Modal>
@@ -377,6 +388,7 @@ function createStyles(theme: NativeTheme) {
       gap: theme.space.small,
       minHeight: 50
     },
+    menuOptions: { flexShrink: 1 },
     menuTitle: {
       color: theme.color.text,
       fontSize: 17,

--- a/apps/mobile/src/components/MobileComposerDock.tsx
+++ b/apps/mobile/src/components/MobileComposerDock.tsx
@@ -1,0 +1,387 @@
+import type { AgentActivitySessionSettings } from "@tutti-os/agent-activity-core";
+import {
+  NativeIconButton,
+  NativeListRow,
+  type NativeTheme,
+  useNativeTheme
+} from "@tutti-os/ui-system/native";
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View
+} from "react-native";
+import { t } from "../i18n";
+import type { WorkspaceActivitySnapshot } from "../services/workspaceActivityService";
+import { MobileComposerSettingsSheet } from "./MobileComposerSettingsSheet";
+
+type ComposerToolsMenu = "tools" | "model" | "permission" | null;
+
+export function MobileComposerDock({
+  model,
+  onDraftChange,
+  onSend,
+  onStop,
+  onUpdate
+}: {
+  model: WorkspaceActivitySnapshot;
+  onDraftChange(value: string): void;
+  onSend(): void;
+  onStop(): void;
+  onUpdate(settings: AgentActivitySessionSettings): void;
+}) {
+  const theme = useNativeTheme();
+  const styles = createStyles(theme);
+  const [menu, setMenu] = useState<ComposerToolsMenu>(null);
+  const hasActiveTurn = Boolean(
+    model.selectedSession?.activeTurnId && !model.creating
+  );
+  const canSend = Boolean(
+    model.draft.trim() &&
+    (!model.creating || model.selectedAgentTargetId) &&
+    !model.sending
+  );
+  const modelOptions = model.composerOptions?.models ?? [];
+  const permissionOptions =
+    model.composerOptions?.permissionConfig?.modes ?? [];
+  const hasComposerTools =
+    (model.composerSettingsSupport.model && modelOptions.length > 0) ||
+    (model.composerSettingsSupport.permission &&
+      permissionOptions.length > 0) ||
+    model.composerSettingsSupport.plan ||
+    model.composerOptionsLoadStatus === "loading";
+  const selectedModelLabel =
+    modelOptions.find((option) => option.value === model.composerSettings.model)
+      ?.label ?? t("model");
+  const selectedPermissionLabel =
+    permissionOptions.find(
+      (option) => option.id === model.composerSettings.permissionModeId
+    )?.label ?? t("defaultPermissions");
+
+  return (
+    <View style={styles.dock}>
+      <MobileComposerSettingsSheet model={model} onUpdate={onUpdate} />
+      <View style={styles.inputRow}>
+        <NativeIconButton
+          accessibilityLabel={t("moreActions")}
+          disabled={!hasComposerTools}
+          icon={<Text style={styles.plus}>＋</Text>}
+          onPress={() => setMenu((current) => (current ? null : "tools"))}
+          style={styles.addButton}
+          variant="secondary"
+        />
+        <View style={styles.inputPill}>
+          <TextInput
+            editable={!model.sending}
+            multiline
+            onChangeText={onDraftChange}
+            placeholder={t("messageHint")}
+            placeholderTextColor={theme.color.muted}
+            style={styles.input}
+            value={model.draft}
+          />
+          {hasActiveTurn ? (
+            <NativeIconButton
+              accessibilityLabel={t("stop")}
+              icon={<Text style={styles.actionIcon}>■</Text>}
+              onPress={onStop}
+              style={styles.actionButton}
+            />
+          ) : canSend ? (
+            <NativeIconButton
+              accessibilityLabel={
+                model.ambiguousSubmission ? t("retry") : t("send")
+              }
+              icon={<Text style={styles.sendIcon}>↑</Text>}
+              onPress={onSend}
+              style={styles.actionButton}
+            />
+          ) : model.sending ? (
+            <ActivityIndicator color={theme.color.text} size="small" />
+          ) : (
+            <MicrophoneGlyph theme={theme} />
+          )}
+        </View>
+      </View>
+
+      <Modal
+        animationType="fade"
+        onRequestClose={() => setMenu(null)}
+        presentationStyle="overFullScreen"
+        statusBarTranslucent
+        transparent
+        visible={menu !== null}
+      >
+        <Pressable onPress={() => setMenu(null)} style={styles.backdrop}>
+          <Pressable
+            onPress={(event) => event.stopPropagation()}
+            style={styles.menu}
+          >
+            {menu === "tools" ? (
+              <>
+                {model.composerSettingsSupport.model &&
+                modelOptions.length > 0 ? (
+                  <NativeListRow
+                    description={selectedModelLabel}
+                    onPress={() => setMenu("model")}
+                    title={t("model")}
+                    trailing={<Text style={styles.chevron}>›</Text>}
+                  />
+                ) : null}
+                {model.composerSettingsSupport.permission &&
+                permissionOptions.length > 0 ? (
+                  <NativeListRow
+                    description={selectedPermissionLabel}
+                    onPress={() => setMenu("permission")}
+                    title={t("permissions")}
+                    trailing={<Text style={styles.chevron}>›</Text>}
+                  />
+                ) : null}
+                {model.composerSettingsSupport.plan ? (
+                  <NativeListRow
+                    description={
+                      model.composerSettings.planMode
+                        ? t("planModeOn")
+                        : t("planModeOff")
+                    }
+                    onPress={() => {
+                      onUpdate({
+                        planMode: !model.composerSettings.planMode
+                      });
+                      setMenu(null);
+                    }}
+                    selected={model.composerSettings.planMode === true}
+                    title={t("planMode")}
+                  />
+                ) : null}
+                {model.composerOptionsLoadStatus === "loading" ? (
+                  <ActivityIndicator
+                    color={theme.color.accent}
+                    size="small"
+                    style={styles.loading}
+                  />
+                ) : null}
+              </>
+            ) : (
+              <View style={styles.menuHeader}>
+                <NativeIconButton
+                  accessibilityLabel={t("cancel")}
+                  icon={<Text style={styles.menuBackIcon}>←</Text>}
+                  onPress={() => setMenu("tools")}
+                  style={styles.menuBackButton}
+                />
+                <Text style={styles.menuTitle}>
+                  {menu === "model" ? t("model") : t("permissions")}
+                </Text>
+              </View>
+            )}
+            {menu === "model"
+              ? modelOptions.map((option) => (
+                  <NativeListRow
+                    key={option.value}
+                    onPress={() => {
+                      onUpdate({ model: option.value });
+                      setMenu(null);
+                    }}
+                    selected={option.value === model.composerSettings.model}
+                    title={option.label}
+                  />
+                ))
+              : null}
+            {menu === "permission"
+              ? permissionOptions.map((option) => (
+                  <NativeListRow
+                    description={option.description}
+                    key={option.id}
+                    onPress={() => {
+                      onUpdate({ permissionModeId: option.id });
+                      setMenu(null);
+                    }}
+                    selected={
+                      option.id === model.composerSettings.permissionModeId
+                    }
+                    title={option.label ?? option.id}
+                  />
+                ))
+              : null}
+            {menu !== "tools" &&
+            model.composerOptionsLoadStatus === "loading" ? (
+              <ActivityIndicator
+                color={theme.color.accent}
+                size="small"
+                style={styles.loading}
+              />
+            ) : null}
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </View>
+  );
+}
+
+function MicrophoneGlyph({ theme }: { theme: NativeTheme }) {
+  const styles = createStyles(theme);
+  return (
+    <View
+      accessibilityElementsHidden
+      importantForAccessibility="no"
+      style={styles.mic}
+    >
+      <View style={styles.micCapsule} />
+      <View style={styles.micStem} />
+      <View style={styles.micBase} />
+    </View>
+  );
+}
+
+function createStyles(theme: NativeTheme) {
+  return StyleSheet.create({
+    actionButton: {
+      alignItems: "center",
+      backgroundColor: theme.color.text,
+      borderRadius: 22,
+      height: 44,
+      justifyContent: "center",
+      width: 44
+    },
+    actionIcon: {
+      color: theme.color.background,
+      fontSize: 11
+    },
+    backdrop: {
+      bottom: 0,
+      left: 0,
+      position: "absolute",
+      right: 0,
+      top: 0
+    },
+    chevron: {
+      color: theme.color.muted,
+      fontSize: 25,
+      lineHeight: 27
+    },
+    addButton: {
+      alignItems: "center",
+      backgroundColor: theme.color.panelRaised,
+      borderColor: theme.color.border,
+      borderRadius: 28,
+      borderWidth: StyleSheet.hairlineWidth,
+      height: 56,
+      justifyContent: "center",
+      width: 56
+    },
+    dock: {
+      gap: theme.space.small,
+      paddingBottom: theme.space.small,
+      paddingHorizontal: theme.space.medium,
+      paddingTop: theme.space.small
+    },
+    input: {
+      color: theme.color.text,
+      flex: 1,
+      fontSize: 17,
+      lineHeight: 22,
+      maxHeight: 132,
+      minHeight: 54,
+      paddingLeft: theme.space.medium,
+      paddingVertical: 15
+    },
+    inputPill: {
+      alignItems: "center",
+      backgroundColor: theme.color.panelRaised,
+      borderColor: theme.color.border,
+      borderRadius: 28,
+      borderWidth: StyleSheet.hairlineWidth,
+      flex: 1,
+      flexDirection: "row",
+      gap: theme.space.small,
+      minHeight: 56,
+      paddingRight: 6
+    },
+    inputRow: {
+      alignItems: "flex-end",
+      flexDirection: "row",
+      gap: theme.space.small
+    },
+    loading: { marginVertical: theme.space.medium },
+    mic: {
+      alignItems: "center",
+      height: 36,
+      justifyContent: "center",
+      marginRight: theme.space.small,
+      width: 28
+    },
+    micBase: {
+      backgroundColor: theme.color.textSecondary,
+      borderRadius: 2,
+      height: 2,
+      marginTop: 3,
+      width: 14
+    },
+    micCapsule: {
+      borderColor: theme.color.textSecondary,
+      borderRadius: 7,
+      borderWidth: 2,
+      height: 18,
+      width: 12
+    },
+    micStem: {
+      backgroundColor: theme.color.textSecondary,
+      height: 5,
+      width: 2
+    },
+    plus: {
+      color: theme.color.text,
+      fontSize: 31,
+      fontWeight: "300",
+      lineHeight: 34
+    },
+    sendIcon: {
+      color: theme.color.background,
+      fontSize: 25,
+      fontWeight: "700",
+      lineHeight: 27
+    },
+    menu: {
+      backgroundColor: theme.color.panelRaised,
+      borderColor: theme.color.border,
+      borderRadius: 24,
+      borderWidth: StyleSheet.hairlineWidth,
+      bottom: 96,
+      left: theme.space.medium,
+      maxHeight: 560,
+      padding: theme.space.small,
+      position: "absolute",
+      right: theme.space.medium,
+      shadowColor: theme.color.text,
+      shadowOffset: { height: 10, width: 0 },
+      shadowOpacity: 0.16,
+      shadowRadius: 24,
+      elevation: 12
+    },
+    menuBackButton: {
+      height: 40,
+      width: 40
+    },
+    menuBackIcon: {
+      color: theme.color.text,
+      fontSize: 24
+    },
+    menuHeader: {
+      alignItems: "center",
+      flexDirection: "row",
+      gap: theme.space.small,
+      minHeight: 50
+    },
+    menuTitle: {
+      color: theme.color.text,
+      fontSize: 17,
+      fontWeight: "700",
+      paddingRight: theme.space.medium
+    }
+  });
+}

--- a/apps/mobile/src/components/MobileComposerSettingsSheet.tsx
+++ b/apps/mobile/src/components/MobileComposerSettingsSheet.tsx
@@ -35,6 +35,9 @@ export function MobileComposerSettingsSheet({
       options?.reasoningEfforts ??
       [])
     : (options?.reasoningEfforts ?? []);
+  const showsModelChip = Boolean(
+    model.composerSettingsSupport.model && options?.models.length
+  );
 
   const closeWith = (settings: AgentActivitySessionSettings): void => {
     onUpdate(settings);
@@ -44,7 +47,7 @@ export function MobileComposerSettingsSheet({
   return (
     <>
       <View style={styles.chips}>
-        {model.composerSettingsSupport.model && options?.models.length ? (
+        {showsModelChip ? (
           <ComposerChip
             label={[
               selectedOptionLabel(options?.models ?? [], selectedModel) ??
@@ -59,6 +62,19 @@ export function MobileComposerSettingsSheet({
               .filter(Boolean)
               .join(" ")}
             onPress={() => setMenu("model")}
+          />
+        ) : null}
+        {!showsModelChip &&
+        model.composerSettingsSupport.reasoning &&
+        reasoningOptions.length ? (
+          <ComposerChip
+            label={
+              selectedOptionLabel(
+                reasoningOptions,
+                model.composerSettings.reasoningEffort ?? null
+              ) ?? t("reasoning")
+            }
+            onPress={() => setMenu("reasoning")}
           />
         ) : null}
         {model.composerSettingsSupport.speed && options?.speeds.length ? (

--- a/apps/mobile/src/components/MobileComposerSettingsSheet.tsx
+++ b/apps/mobile/src/components/MobileComposerSettingsSheet.tsx
@@ -1,5 +1,6 @@
 import type { AgentActivitySessionSettings } from "@tutti-os/agent-activity-core";
 import {
+  NativeButton,
   NativeListRow,
   NativeSheet,
   type NativeTheme,
@@ -15,7 +16,6 @@ type ComposerSettingMenu =
   | "reasoning"
   | "speed"
   | "permission"
-  | "plan"
   | null;
 
 export function MobileComposerSettingsSheet({
@@ -46,22 +46,19 @@ export function MobileComposerSettingsSheet({
       <View style={styles.chips}>
         {model.composerSettingsSupport.model && options?.models.length ? (
           <ComposerChip
-            label={
+            label={[
               selectedOptionLabel(options?.models ?? [], selectedModel) ??
-              t("model")
-            }
+                t("model"),
+              model.composerSettingsSupport.reasoning
+                ? selectedOptionLabel(
+                    reasoningOptions,
+                    model.composerSettings.reasoningEffort ?? null
+                  )
+                : null
+            ]
+              .filter(Boolean)
+              .join(" ")}
             onPress={() => setMenu("model")}
-          />
-        ) : null}
-        {model.composerSettingsSupport.reasoning && reasoningOptions.length ? (
-          <ComposerChip
-            label={
-              selectedOptionLabel(
-                reasoningOptions,
-                model.composerSettings.reasoningEffort ?? null
-              ) ?? t("reasoning")
-            }
-            onPress={() => setMenu("reasoning")}
           />
         ) : null}
         {model.composerSettingsSupport.speed && options?.speeds.length ? (
@@ -82,17 +79,9 @@ export function MobileComposerSettingsSheet({
               selectedOptionLabel(
                 options?.permissionConfig?.modes ?? [],
                 model.composerSettings.permissionModeId ?? null
-              ) ?? t("permissions")
+              ) ?? t("defaultPermissions")
             }
             onPress={() => setMenu("permission")}
-          />
-        ) : null}
-        {model.composerSettingsSupport.plan ? (
-          <ComposerChip
-            label={
-              model.composerSettings.planMode ? t("planModeOn") : t("planMode")
-            }
-            onPress={() => setMenu("plan")}
           />
         ) : null}
       </View>
@@ -105,14 +94,37 @@ export function MobileComposerSettingsSheet({
           <Text style={styles.sheetTitle}>{titleForMenu(menu)}</Text>
           <ScrollView contentContainerStyle={styles.options}>
             {menu === "model"
-              ? options?.models.map((option) => (
-                  <NativeListRow
-                    key={option.value}
-                    onPress={() => closeWith({ model: option.value })}
-                    selected={option.value === selectedModel}
-                    title={option.label}
-                  />
-                ))
+              ? [
+                  ...(options?.models.map((option) => (
+                    <NativeListRow
+                      key={`model:${option.value}`}
+                      onPress={() => closeWith({ model: option.value })}
+                      selected={option.value === selectedModel}
+                      title={option.label}
+                    />
+                  )) ?? []),
+                  ...(model.composerSettingsSupport.reasoning &&
+                  reasoningOptions.length
+                    ? [
+                        <Text key="reasoning-title" style={styles.sectionTitle}>
+                          {t("reasoning")}
+                        </Text>,
+                        ...reasoningOptions.map((option) => (
+                          <NativeListRow
+                            key={`reasoning:${option.value}`}
+                            onPress={() =>
+                              closeWith({ reasoningEffort: option.value })
+                            }
+                            selected={
+                              option.value ===
+                              model.composerSettings.reasoningEffort
+                            }
+                            title={option.label}
+                          />
+                        ))
+                      ]
+                    : [])
+                ]
               : null}
             {menu === "reasoning"
               ? reasoningOptions.map((option) => (
@@ -149,22 +161,7 @@ export function MobileComposerSettingsSheet({
                   />
                 ))
               : null}
-            {menu === "plan" ? (
-              <>
-                <NativeListRow
-                  onPress={() => closeWith({ planMode: false })}
-                  selected={!model.composerSettings.planMode}
-                  title={t("planModeOff")}
-                />
-                <NativeListRow
-                  onPress={() => closeWith({ planMode: true })}
-                  selected={model.composerSettings.planMode === true}
-                  title={t("planModeOn")}
-                />
-              </>
-            ) : null}
-            {menu !== "plan" &&
-            model.composerOptionsLoadStatus === "loading" ? (
+            {model.composerOptionsLoadStatus === "loading" ? (
               <Text style={styles.loading}>{t("loading")}</Text>
             ) : null}
           </ScrollView>
@@ -177,7 +174,15 @@ export function MobileComposerSettingsSheet({
 function ComposerChip({ label, onPress }: { label: string; onPress(): void }) {
   const theme = useNativeTheme();
   const styles = createStyles(theme);
-  return <NativeListRow onPress={onPress} style={styles.chip} title={label} />;
+  return (
+    <NativeButton
+      label={label}
+      onPress={onPress}
+      size="compact"
+      style={styles.chip}
+      variant="secondary"
+    />
+  );
 }
 
 function selectedOptionLabel(
@@ -201,8 +206,6 @@ function titleForMenu(menu: ComposerSettingMenu): string {
       return t("speed");
     case "permission":
       return t("permissions");
-    case "plan":
-      return t("planMode");
     default:
       return "";
   }
@@ -212,15 +215,21 @@ function createStyles(theme: NativeTheme) {
   return StyleSheet.create({
     chip: {
       backgroundColor: theme.color.panel,
-      borderColor: theme.color.border,
-      borderRadius: theme.radius.large,
-      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: theme.color.panel,
+      borderRadius: 20,
       minHeight: theme.control.compact,
-      paddingHorizontal: theme.space.small
+      paddingHorizontal: theme.space.medium
     },
     chips: { flexDirection: "row", flexWrap: "wrap", gap: theme.space.small },
     loading: { color: theme.color.muted, padding: theme.space.medium },
     options: { padding: theme.space.small },
+    sectionTitle: {
+      color: theme.color.muted,
+      fontSize: 13,
+      fontWeight: "600",
+      paddingHorizontal: theme.space.small,
+      paddingTop: theme.space.medium
+    },
     sheet: { minHeight: 180, padding: theme.space.medium },
     sheetTitle: {
       color: theme.color.text,

--- a/apps/mobile/src/components/MobileConversationDrawer.tsx
+++ b/apps/mobile/src/components/MobileConversationDrawer.tsx
@@ -9,7 +9,6 @@ import {
 } from "@tutti-os/ui-system/native";
 import {
   ActivityIndicator,
-  Image,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -19,6 +18,7 @@ import {
 } from "react-native";
 import { t } from "../i18n";
 import type { WorkspaceActivitySnapshot } from "../services/workspaceActivityService";
+import { MobileComputerGlyph, MobileFolderGlyph } from "./MobileLocationGlyphs";
 
 type DrawerDialog =
   | { kind: "actions"; sessionId: string }
@@ -27,6 +27,7 @@ type DrawerDialog =
   | null;
 
 export function MobileConversationDrawer({
+  deviceName,
   model,
   onBack,
   onClose,
@@ -39,6 +40,7 @@ export function MobileConversationDrawer({
   onTogglePinned,
   workspaceName
 }: {
+  deviceName: string;
   model: WorkspaceActivitySnapshot;
   onBack(): void;
   onClose(): void;
@@ -60,6 +62,7 @@ export function MobileConversationDrawer({
     () => new Set()
   );
   const [refreshing, setRefreshing] = useState(false);
+  const [searchDraft, setSearchDraft] = useState("");
   const actionSession = dialog
     ? model.railSections
         .flatMap((section) => section.items)
@@ -104,45 +107,70 @@ export function MobileConversationDrawer({
       <Pressable onPress={onClose} style={styles.scrim} />
       <View style={styles.drawer}>
         <View style={styles.header}>
-          <View style={styles.heading}>
-            <Text numberOfLines={1} style={styles.workspace}>
-              {workspaceName}
-            </Text>
-            <Text style={styles.title}>{t("sessions")}</Text>
-          </View>
-          <View style={styles.headerActions}>
-            {refreshing ? (
-              <ActivityIndicator color={theme.color.accent} size="small" />
-            ) : (
-              <NativeIconButton
-                accessibilityLabel={t("refreshSessions")}
-                icon={<Text style={styles.refresh}>↻</Text>}
-                onPress={() => void refreshRail()}
-                style={styles.closeButton}
-              />
-            )}
+          <View style={styles.headerButtonSlot}>
             <NativeIconButton
               accessibilityLabel={t("cancel")}
-              icon={<Text style={styles.close}>×</Text>}
+              icon={<Text style={styles.backIcon}>←</Text>}
               onPress={onClose}
-              style={styles.closeButton}
+              style={styles.headerButton}
+              variant="secondary"
             />
           </View>
+          <Text style={styles.title}>{t("remote")}</Text>
+          {refreshing ? (
+            <View style={styles.headerButtonSlot}>
+              <View style={styles.headerButton}>
+                <ActivityIndicator color={theme.color.accent} size="small" />
+              </View>
+            </View>
+          ) : (
+            <View style={styles.headerButtonSlot}>
+              <NativeIconButton
+                accessibilityLabel={t("refreshSessions")}
+                icon={<Text style={styles.moreIconLarge}>⋮</Text>}
+                onPress={() => void refreshRail()}
+                style={styles.headerButton}
+                variant="secondary"
+              />
+            </View>
+          )}
         </View>
 
-        <NativeButton
-          disabled={model.targets.length === 0}
-          label={t("newSession")}
-          leading={<Text style={styles.newSessionIcon}>＋</Text>}
-          onPress={() => {
-            onNewSession();
-            onClose();
-          }}
-          style={styles.newSessionButton}
-          variant="secondary"
-        />
+        <ScrollView
+          contentContainerStyle={styles.deviceRail}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.deviceScroller}
+        >
+          <View style={styles.devicePill}>
+            <View style={styles.deviceDot} />
+            <MobileComputerGlyph color={theme.color.background} size={18} />
+            <Text numberOfLines={1} style={styles.deviceName}>
+              {deviceName || t("desktopFallback")}
+            </Text>
+          </View>
+        </ScrollView>
 
-        <ScrollView contentContainerStyle={styles.list}>
+        <View style={styles.projectSection}>
+          <Text style={styles.groupTitle}>{t("projects")}</Text>
+          <Pressable
+            accessibilityLabel={t("backToWorkspaces")}
+            onPress={onBack}
+            style={({ pressed }) => pressed && styles.pressed}
+          >
+            <View style={styles.projectRow}>
+              <MobileFolderGlyph color={theme.color.text} size={26} />
+              <Text numberOfLines={1} style={styles.projectName}>
+                {workspaceName}
+              </Text>
+            </View>
+          </Pressable>
+        </View>
+
+        <ScrollView
+          contentContainerStyle={styles.list}
+          style={styles.sessionScroller}
+        >
           {model.railStatus === "loading" && model.railSections.length === 0 ? (
             <View style={styles.feedback}>
               <ActivityIndicator color={theme.color.accent} size="small" />
@@ -176,6 +204,15 @@ export function MobileConversationDrawer({
               ) : null}
               {model.railSections.map((section) => {
                 const collapsed = collapsedSectionIds.has(section.id);
+                const query = searchDraft.trim().toLocaleLowerCase();
+                const visibleItems = query
+                  ? section.items.filter((session) =>
+                      (session.title || t("untitledSession"))
+                        .toLocaleLowerCase()
+                        .includes(query)
+                    )
+                  : section.items;
+                if (query && visibleItems.length === 0) return null;
                 return (
                   <View key={section.id} style={styles.section}>
                     <Pressable
@@ -185,99 +222,59 @@ export function MobileConversationDrawer({
                       accessibilityRole="button"
                       accessibilityState={{ expanded: !collapsed }}
                       onPress={() => toggleSection(section.id)}
-                      style={({ pressed }) => [
-                        styles.sectionHeader,
-                        pressed && styles.pressed
-                      ]}
+                      style={({ pressed }) => pressed && styles.pressed}
                     >
-                      <Text numberOfLines={1} style={styles.sectionTitle}>
-                        {sectionTitle(section)}
-                      </Text>
-                      <Text style={styles.sectionCount}>
-                        {section.totalCount}
-                      </Text>
-                      <Text style={styles.sectionChevron}>
-                        {collapsed ? "›" : "⌄"}
-                      </Text>
+                      <View style={styles.sectionHeader}>
+                        <Text numberOfLines={1} style={styles.sectionTitle}>
+                          {sectionTitle(section)}
+                        </Text>
+                        <Text style={styles.sectionCount}>
+                          {section.totalCount}
+                        </Text>
+                        <Text style={styles.sectionChevron}>
+                          {collapsed ? "›" : "⌄"}
+                        </Text>
+                      </View>
                     </Pressable>
                     {!collapsed
-                      ? section.items.map((session) => {
+                      ? visibleItems.map((session) => {
                           const selected =
                             session.id === model.selectedAgentSessionId;
-                          const target =
-                            model.targets.find(
-                              (candidate) =>
-                                candidate.id === session.agentTargetId
-                            ) ??
-                            model.targets.find(
-                              (candidate) =>
-                                candidate.provider === session.provider
-                            );
                           return (
                             <NativeListRow
                               accessibilityLabel={
                                 session.title || t("untitledSession")
                               }
                               key={session.id}
-                              leading={
-                                <View style={styles.agentIconFrame}>
-                                  {target?.iconUrl ? (
-                                    <Image
-                                      source={{ uri: target.iconUrl }}
-                                      style={styles.agentIcon}
-                                    />
-                                  ) : (
-                                    <Text style={styles.agentIconFallback}>
-                                      {session.provider
-                                        .slice(0, 1)
-                                        .toUpperCase()}
-                                    </Text>
-                                  )}
-                                  <View
-                                    style={[
-                                      styles.statusDot,
-                                      statusDotStyle(theme, session.status)
-                                    ]}
-                                  />
-                                </View>
-                              }
                               onPress={() => {
                                 onSelectSession(session.id);
                                 onClose();
                               }}
                               selected={selected}
-                              description={
-                                <View style={styles.sessionMeta}>
+                              title={session.title || t("untitledSession")}
+                              trailing={
+                                <View style={styles.sessionTrailing}>
                                   <Text style={styles.sessionTime}>
                                     {formatSessionTime(
                                       session.sortTimeUnixMs ??
                                         session.updatedAtUnixMs
                                     )}
                                   </Text>
-                                  <Text style={styles.sessionStatus}>
-                                    {sessionStatusLabel(session.status)}
-                                  </Text>
-                                  {session.needsUserAction ? (
-                                    <Text style={styles.attention}>
-                                      {t("needsAttention")}
-                                    </Text>
-                                  ) : null}
+                                  <NativeIconButton
+                                    accessibilityLabel={t("moreActions")}
+                                    icon={
+                                      <Text style={styles.moreIcon}>⋯</Text>
+                                    }
+                                    onPress={(event) => {
+                                      event.stopPropagation();
+                                      setDialog({
+                                        kind: "actions",
+                                        sessionId: session.id
+                                      });
+                                    }}
+                                    style={styles.moreButton}
+                                  />
                                 </View>
-                              }
-                              title={session.title || t("untitledSession")}
-                              trailing={
-                                <NativeIconButton
-                                  accessibilityLabel={t("moreActions")}
-                                  icon={<Text style={styles.moreIcon}>⋯</Text>}
-                                  onPress={(event) => {
-                                    event.stopPropagation();
-                                    setDialog({
-                                      kind: "actions",
-                                      sessionId: session.id
-                                    });
-                                  }}
-                                  style={styles.moreButton}
-                                />
                               }
                             />
                           );
@@ -311,11 +308,31 @@ export function MobileConversationDrawer({
           )}
         </ScrollView>
 
-        <Pressable onPress={onBack} style={styles.workspaceBackButton}>
-          <Text style={styles.workspaceBackLabel}>
-            ‹ {t("backToWorkspaces")}
-          </Text>
-        </Pressable>
+        <View style={styles.bottomDock}>
+          <View style={styles.searchPill}>
+            <Text style={styles.searchIcon}>⌕</Text>
+            <TextInput
+              onChangeText={setSearchDraft}
+              placeholder={t("searchChats")}
+              placeholderTextColor={theme.color.muted}
+              style={styles.searchInput}
+              value={searchDraft}
+            />
+          </View>
+          <View style={styles.chatButtonSlot}>
+            <NativeButton
+              disabled={model.targets.length === 0}
+              label={t("chat")}
+              leading={<Text style={styles.chatIcon}>＋</Text>}
+              onPress={() => {
+                onNewSession();
+                onClose();
+              }}
+              size="large"
+              style={styles.chatButton}
+            />
+          </View>
+        </View>
       </View>
 
       {dialog && actionSession ? (
@@ -472,42 +489,6 @@ function sectionTitle(
   return t("recentSessions");
 }
 
-function sessionStatusLabel(
-  status: WorkspaceActivitySnapshot["railSections"][number]["items"][number]["status"]
-): string {
-  switch (status) {
-    case "working":
-      return t("running");
-    case "waiting":
-      return t("waiting");
-    case "completed":
-      return t("completed");
-    case "failed":
-      return t("failed");
-    case "canceled":
-      return t("canceled");
-    default:
-      return t("ready");
-  }
-}
-
-function statusDotStyle(
-  theme: NativeTheme,
-  status: WorkspaceActivitySnapshot["railSections"][number]["items"][number]["status"]
-): { backgroundColor: string } {
-  switch (status) {
-    case "working":
-      return { backgroundColor: theme.color.accent };
-    case "waiting":
-    case "failed":
-      return { backgroundColor: theme.color.danger };
-    case "completed":
-      return { backgroundColor: theme.color.success };
-    default:
-      return { backgroundColor: theme.color.muted };
-  }
-}
-
 function formatSessionTime(unixMs: number): string {
   if (!unixMs) return "";
   const date = new Date(unixMs);
@@ -538,52 +519,79 @@ function createStyles(theme: NativeTheme) {
       lineHeight: 18,
       marginBottom: theme.space.small
     },
-    agentIcon: { borderRadius: 8, height: 28, width: 28 },
-    agentIconFallback: {
+    backIcon: {
       color: theme.color.text,
-      fontSize: 12,
-      fontWeight: "800"
+      fontSize: 32,
+      fontWeight: "300",
+      lineHeight: 34
     },
-    agentIconFrame: {
+    bottomDock: {
       alignItems: "center",
-      backgroundColor: theme.color.panel,
-      borderColor: theme.color.border,
-      borderRadius: 9,
-      borderWidth: StyleSheet.hairlineWidth,
-      height: 30,
-      justifyContent: "center",
-      marginRight: theme.space.small,
-      overflow: "visible",
-      width: 30
+      backgroundColor: theme.color.background,
+      flexDirection: "row",
+      gap: theme.space.small,
+      paddingBottom: theme.space.small,
+      paddingTop: theme.space.small,
+      zIndex: 2
     },
-    attention: {
-      color: theme.color.danger,
-      fontSize: 10,
-      fontWeight: "700"
+    chatButton: {
+      backgroundColor: theme.color.text,
+      borderRadius: 28,
+      height: 56,
+      width: "100%"
     },
-    close: { color: theme.color.textSecondary, fontSize: 32, lineHeight: 34 },
-    closeButton: {
-      alignItems: "center",
-      height: 44,
-      justifyContent: "center",
-      width: 44
+    chatButtonSlot: {
+      flexShrink: 0,
+      height: 56,
+      width: 112
     },
+    chatIcon: { color: theme.color.background, fontSize: 22 },
     deleteDescription: {
       color: theme.color.textSecondary,
       fontSize: 14,
       lineHeight: 20
     },
-    disabled: { opacity: 0.45 },
+    deviceDot: {
+      backgroundColor: theme.color.success,
+      borderRadius: 5,
+      height: 10,
+      width: 10
+    },
+    deviceName: {
+      color: theme.color.background,
+      flexShrink: 1,
+      fontSize: 15,
+      fontWeight: "700"
+    },
+    devicePill: {
+      alignItems: "center",
+      backgroundColor: theme.color.text,
+      borderRadius: 24,
+      flexDirection: "row",
+      gap: theme.space.small,
+      height: 48,
+      maxWidth: 340,
+      paddingHorizontal: theme.space.medium
+    },
+    deviceRail: {
+      alignItems: "center",
+      paddingBottom: theme.space.medium,
+      paddingTop: theme.space.large
+    },
+    deviceScroller: {
+      flexGrow: 0,
+      maxHeight: 88
+    },
     drawer: {
       backgroundColor: theme.color.background,
       bottom: 0,
       left: 0,
-      maxWidth: 420,
       paddingHorizontal: theme.space.medium,
-      paddingTop: theme.space.large,
+      paddingTop: theme.space.medium,
       position: "absolute",
+      right: 0,
       top: 0,
-      width: "92%"
+      width: "100%"
     },
     empty: {
       color: theme.color.muted,
@@ -597,12 +605,21 @@ function createStyles(theme: NativeTheme) {
       flexDirection: "row",
       justifyContent: "space-between"
     },
-    headerActions: {
+    headerButton: {
       alignItems: "center",
-      flexDirection: "row",
-      gap: theme.space.small
+      backgroundColor: theme.color.panelRaised,
+      borderColor: theme.color.border,
+      borderRadius: 28,
+      borderWidth: StyleSheet.hairlineWidth,
+      height: 56,
+      justifyContent: "center",
+      width: 56
     },
-    heading: { flex: 1 },
+    headerButtonSlot: {
+      flexShrink: 0,
+      height: 56,
+      width: 56
+    },
     feedback: {
       alignItems: "center",
       gap: theme.space.small,
@@ -629,7 +646,7 @@ function createStyles(theme: NativeTheme) {
     },
     list: {
       gap: theme.space.large,
-      paddingBottom: theme.space.large,
+      paddingBottom: theme.space.medium,
       paddingTop: theme.space.medium
     },
     loadMoreButton: {
@@ -654,12 +671,37 @@ function createStyles(theme: NativeTheme) {
       fontWeight: "900",
       letterSpacing: 1
     },
-    newSessionButton: {
-      marginTop: theme.space.medium
+    moreIconLarge: {
+      color: theme.color.text,
+      fontSize: 30,
+      fontWeight: "800",
+      lineHeight: 31
     },
-    newSessionIcon: { color: theme.color.accent, fontSize: 22 },
     pressed: { opacity: 0.7 },
-    refresh: { color: theme.color.accent, fontSize: 24, lineHeight: 28 },
+    groupTitle: {
+      color: theme.color.text,
+      fontSize: 18,
+      fontWeight: "700",
+      marginBottom: theme.space.medium
+    },
+    projectName: {
+      color: theme.color.text,
+      flexShrink: 1,
+      fontSize: 18,
+      fontWeight: "500",
+      minWidth: 0
+    },
+    projectRow: {
+      alignItems: "center",
+      alignSelf: "stretch",
+      flexDirection: "row",
+      gap: theme.space.medium,
+      minHeight: 48,
+      width: "100%"
+    },
+    projectSection: {
+      paddingBottom: theme.space.medium
+    },
     renameInput: {
       backgroundColor: theme.color.panel,
       borderColor: theme.color.border,
@@ -677,6 +719,32 @@ function createStyles(theme: NativeTheme) {
       position: "absolute",
       right: 0,
       top: 0
+    },
+    searchIcon: {
+      color: theme.color.textSecondary,
+      fontSize: 30,
+      lineHeight: 32
+    },
+    searchInput: {
+      color: theme.color.text,
+      flex: 1,
+      fontSize: 16,
+      minWidth: 0,
+      minHeight: 54,
+      paddingVertical: 12
+    },
+    searchPill: {
+      alignItems: "center",
+      backgroundColor: theme.color.panelRaised,
+      borderColor: theme.color.border,
+      borderRadius: 28,
+      borderWidth: StyleSheet.hairlineWidth,
+      flex: 1,
+      flexDirection: "row",
+      gap: theme.space.small,
+      minWidth: 0,
+      minHeight: 56,
+      paddingHorizontal: theme.space.medium
     },
     section: { gap: 2 },
     sectionCount: {
@@ -697,49 +765,26 @@ function createStyles(theme: NativeTheme) {
       paddingHorizontal: theme.space.small
     },
     sectionTitle: {
-      color: theme.color.textSecondary,
+      color: theme.color.text,
       flex: 1,
-      fontSize: 12,
+      fontSize: 17,
       fontWeight: "700",
       letterSpacing: 0.2
     },
-    sessionMeta: {
+    sessionScroller: { flex: 1 },
+    sessionTime: { color: theme.color.muted, fontSize: 12 },
+    sessionTrailing: {
       alignItems: "center",
+      flexShrink: 0,
       flexDirection: "row",
-      gap: theme.space.small,
-      marginTop: 4
+      gap: 2
     },
-    sessionTime: { color: theme.color.muted, fontSize: 10 },
-    sessionStatus: { color: theme.color.textSecondary, fontSize: 10 },
-    statusDot: {
-      borderColor: theme.color.background,
-      borderRadius: 4,
-      borderWidth: 2,
-      bottom: -2,
-      height: 9,
-      position: "absolute",
-      right: -2,
-      width: 9
-    },
-    title: { color: theme.color.text, fontSize: 24, fontWeight: "700" },
-    workspace: {
-      color: theme.color.muted,
-      fontSize: 12,
-      fontWeight: "600",
-      marginBottom: 3
-    },
-    workspaceBackButton: {
-      alignItems: "flex-start",
-      borderTopColor: theme.color.border,
-      borderTopWidth: StyleSheet.hairlineWidth,
-      minHeight: 54,
-      paddingHorizontal: theme.space.small,
-      paddingVertical: theme.space.medium
-    },
-    workspaceBackLabel: {
-      color: theme.color.textSecondary,
-      fontSize: 14,
-      fontWeight: "600"
+    title: {
+      color: theme.color.text,
+      flex: 1,
+      fontSize: 24,
+      fontWeight: "700",
+      textAlign: "center"
     }
   });
 }

--- a/apps/mobile/src/components/MobileConversationDrawer.tsx
+++ b/apps/mobile/src/components/MobileConversationDrawer.tsx
@@ -63,6 +63,7 @@ export function MobileConversationDrawer({
   );
   const [refreshing, setRefreshing] = useState(false);
   const [searchDraft, setSearchDraft] = useState("");
+  const searchQuery = searchDraft.trim().toLocaleLowerCase();
   const actionSession = dialog
     ? model.railSections
         .flatMap((section) => section.items)
@@ -204,23 +205,30 @@ export function MobileConversationDrawer({
               ) : null}
               {model.railSections.map((section) => {
                 const collapsed = collapsedSectionIds.has(section.id);
-                const query = searchDraft.trim().toLocaleLowerCase();
-                const visibleItems = query
+                const effectiveCollapsed = collapsed && !searchQuery;
+                const visibleItems = searchQuery
                   ? section.items.filter((session) =>
                       (session.title || t("untitledSession"))
                         .toLocaleLowerCase()
-                        .includes(query)
+                        .includes(searchQuery)
                     )
                   : section.items;
-                if (query && visibleItems.length === 0) return null;
+                if (searchQuery && !visibleItems.length && !section.hasMore)
+                  return null;
                 return (
                   <View key={section.id} style={styles.section}>
                     <Pressable
                       accessibilityLabel={
-                        collapsed ? t("expandSection") : t("collapseSection")
+                        effectiveCollapsed
+                          ? t("expandSection")
+                          : t("collapseSection")
                       }
                       accessibilityRole="button"
-                      accessibilityState={{ expanded: !collapsed }}
+                      accessibilityState={{
+                        disabled: Boolean(searchQuery),
+                        expanded: !effectiveCollapsed
+                      }}
+                      disabled={Boolean(searchQuery)}
                       onPress={() => toggleSection(section.id)}
                       style={({ pressed }) => pressed && styles.pressed}
                     >
@@ -232,11 +240,11 @@ export function MobileConversationDrawer({
                           {section.totalCount}
                         </Text>
                         <Text style={styles.sectionChevron}>
-                          {collapsed ? "›" : "⌄"}
+                          {effectiveCollapsed ? "›" : "⌄"}
                         </Text>
                       </View>
                     </Pressable>
-                    {!collapsed
+                    {!effectiveCollapsed
                       ? visibleItems.map((session) => {
                           const selected =
                             session.id === model.selectedAgentSessionId;
@@ -280,7 +288,7 @@ export function MobileConversationDrawer({
                           );
                         })
                       : null}
-                    {!collapsed && section.hasMore ? (
+                    {!effectiveCollapsed && section.hasMore ? (
                       <Pressable
                         disabled={section.loadingMore}
                         onPress={() => onLoadMoreSessions(section.id)}

--- a/apps/mobile/src/components/MobileConversationTimeline.tsx
+++ b/apps/mobile/src/components/MobileConversationTimeline.tsx
@@ -93,10 +93,12 @@ function MobileMessageRow({
   );
 
   return (
-    <View style={[styles.message, user && styles.userMessage]}>
-      <Text style={[styles.role, user && styles.userRole]}>
-        {user ? t("you") : t("agent")}
-      </Text>
+    <View
+      style={[
+        styles.message,
+        user ? styles.userMessage : styles.assistantMessage
+      ]}
+    >
       {row.thinking.map((thinking) => (
         <View key={thinking.id} style={styles.thinkingBlock}>
           <Text style={styles.thinkingLabel}>{t("reasoning")}</Text>
@@ -338,13 +340,13 @@ function createStyles(theme: NativeTheme) {
     },
     message: {
       alignSelf: "flex-start",
-      backgroundColor: theme.color.panel,
-      borderColor: theme.color.border,
       borderRadius: theme.radius.large,
-      borderWidth: StyleSheet.hairlineWidth,
       gap: theme.space.small,
-      maxWidth: "92%",
-      padding: theme.space.medium
+      maxWidth: "88%"
+    },
+    assistantMessage: {
+      alignSelf: "stretch",
+      maxWidth: "100%"
     },
     messageContent: { gap: theme.space.small },
     noticeDetail: {
@@ -368,13 +370,6 @@ function createStyles(theme: NativeTheme) {
       width: 8
     },
     processingText: { color: theme.color.muted, fontSize: 13 },
-    role: {
-      color: theme.color.accent,
-      fontSize: 11,
-      fontWeight: "700",
-      letterSpacing: 0.5,
-      textTransform: "uppercase"
-    },
     summaryTitle: {
       color: theme.color.text,
       flex: 1,
@@ -442,8 +437,8 @@ function createStyles(theme: NativeTheme) {
     },
     userMessage: {
       alignSelf: "flex-end",
-      backgroundColor: theme.color.panelRaised
-    },
-    userRole: { color: theme.color.textSecondary }
+      backgroundColor: theme.color.panel,
+      padding: theme.space.medium
+    }
   });
 }

--- a/apps/mobile/src/components/MobileConversationTimeline.tsx
+++ b/apps/mobile/src/components/MobileConversationTimeline.tsx
@@ -99,6 +99,12 @@ function MobileMessageRow({
         user ? styles.userMessage : styles.assistantMessage
       ]}
     >
+      <View
+        accessible
+        accessibilityLabel={user ? t("you") : t("agent")}
+        accessibilityRole="text"
+        style={styles.speakerAccessibilityLabel}
+      />
       {row.thinking.map((thinking) => (
         <View key={thinking.id} style={styles.thinkingBlock}>
           <Text style={styles.thinkingLabel}>{t("reasoning")}</Text>
@@ -370,6 +376,11 @@ function createStyles(theme: NativeTheme) {
       width: 8
     },
     processingText: { color: theme.color.muted, fontSize: 13 },
+    speakerAccessibilityLabel: {
+      height: 1,
+      position: "absolute",
+      width: 1
+    },
     summaryTitle: {
       color: theme.color.text,
       flex: 1,

--- a/apps/mobile/src/components/MobileLocationGlyphs.tsx
+++ b/apps/mobile/src/components/MobileLocationGlyphs.tsx
@@ -1,0 +1,107 @@
+import { StyleSheet, View } from "react-native";
+
+export function MobileComputerGlyph({
+  color,
+  size = 18
+}: {
+  color: string;
+  size?: number;
+}) {
+  return (
+    <View
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={{ height: size, width: size + 4 }}
+    >
+      <View
+        style={[
+          styles.computerScreen,
+          {
+            borderColor: color,
+            height: size - 5,
+            width: size
+          }
+        ]}
+      />
+      <View
+        style={[
+          styles.computerBase,
+          {
+            backgroundColor: color,
+            top: size - 3,
+            width: size + 4
+          }
+        ]}
+      />
+    </View>
+  );
+}
+
+export function MobileFolderGlyph({
+  color,
+  size = 20
+}: {
+  color: string;
+  size?: number;
+}) {
+  return (
+    <View
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={{ height: size - 3, width: size }}
+    >
+      <View
+        style={[
+          styles.folderTab,
+          {
+            borderColor: color,
+            height: Math.max(5, size * 0.32),
+            width: size * 0.48
+          }
+        ]}
+      />
+      <View
+        style={[
+          styles.folderBody,
+          {
+            borderColor: color,
+            height: size * 0.7,
+            top: size * 0.22,
+            width: size
+          }
+        ]}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  computerBase: {
+    borderRadius: 2,
+    height: 2,
+    left: 0,
+    position: "absolute"
+  },
+  computerScreen: {
+    borderRadius: 3,
+    borderWidth: 1.5,
+    left: 2,
+    position: "absolute",
+    top: 0
+  },
+  folderBody: {
+    borderRadius: 3,
+    borderWidth: 1.5,
+    left: 0,
+    position: "absolute"
+  },
+  folderTab: {
+    borderBottomWidth: 0,
+    borderTopLeftRadius: 3,
+    borderTopRightRadius: 3,
+    borderWidth: 1.5,
+    left: 2,
+    position: "absolute",
+    top: 0
+  }
+});

--- a/apps/mobile/src/i18n.ts
+++ b/apps/mobile/src/i18n.ts
@@ -29,6 +29,7 @@ const messages = {
       "Pair your computer to start using Agent sessions on your phone.",
     deviceEmptyTitle: "No computer paired",
     devices: "Your computers",
+    defaultPermissions: "Default permissions",
     deny: "Deny",
     deleteSession: "Delete session",
     deleteSessionConfirm: "Delete",
@@ -127,6 +128,9 @@ const messages = {
     closeImagePreview: "Close image preview",
     failed: "Failed",
     projects: "Projects",
+    remote: "Remote",
+    searchChats: "Search chats",
+    chat: "Chat",
     welcome: "Remote Agent",
     you: "You"
   },
@@ -155,6 +159,7 @@ const messages = {
     deviceEmpty: "先配对你的电脑，即可在手机上使用 Agent 会话",
     deviceEmptyTitle: "还没有配对电脑",
     devices: "你的电脑",
+    defaultPermissions: "默认权限",
     deny: "拒绝",
     deleteSession: "删除会话",
     deleteSessionConfirm: "删除",
@@ -248,6 +253,9 @@ const messages = {
     closeImagePreview: "关闭图片预览",
     failed: "失败",
     projects: "项目",
+    remote: "Remote",
+    searchChats: "搜索聊天",
+    chat: "聊天",
     welcome: "远程 Agent",
     you: "你"
   }

--- a/apps/mobile/src/screens/WorkspaceScreenView.tsx
+++ b/apps/mobile/src/screens/WorkspaceScreenView.tsx
@@ -20,13 +20,16 @@ import {
   ScrollView,
   StyleSheet,
   Text,
-  TextInput,
   View
 } from "react-native";
 import { MobileInteractionCard } from "../components/MobileConversationRows";
+import { MobileComposerDock } from "../components/MobileComposerDock";
 import { MobileConversationDrawer } from "../components/MobileConversationDrawer";
 import { MobileConversationTimeline } from "../components/MobileConversationTimeline";
-import { MobileComposerSettingsSheet } from "../components/MobileComposerSettingsSheet";
+import {
+  MobileComputerGlyph,
+  MobileFolderGlyph
+} from "../components/MobileLocationGlyphs";
 import { PrimaryButton } from "../components/PrimaryButton";
 import { t } from "../i18n";
 import type { WorkspaceActivitySnapshot } from "../services/workspaceActivityService";
@@ -195,26 +198,56 @@ export function ConversationWorkspaceView({
       style={styles.root}
     >
       <View style={styles.conversationHeader}>
-        <NativeIconButton
-          accessibilityLabel={t("sessions")}
-          onPress={() => setDrawerOpen(true)}
-          icon={<Text style={styles.iconText}>☰</Text>}
-          style={styles.iconButton}
-        />
+        <View style={styles.headerButtonSlot}>
+          <NativeIconButton
+            accessibilityLabel={t("sessions")}
+            onPress={() => setDrawerOpen(true)}
+            icon={<Text style={styles.backIcon}>←</Text>}
+            style={styles.headerCircleButton}
+            variant="secondary"
+          />
+        </View>
         <View style={styles.conversationTitle}>
           <Text numberOfLines={1} style={styles.sessionTitle}>
             {model.selectedSession?.title || workspace.name}
           </Text>
-          <Text numberOfLines={1} style={styles.deviceCaption}>
-            {deviceName || t("desktopFallback")} · {workspace.name}
-          </Text>
+          <View style={styles.locationRow}>
+            <View style={styles.locationItem}>
+              <MobileFolderGlyph color={theme.color.textSecondary} size={14} />
+              <Text numberOfLines={1} style={styles.locationLabel}>
+                {workspace.name}
+              </Text>
+            </View>
+            <View style={styles.locationItem}>
+              <MobileComputerGlyph
+                color={theme.color.textSecondary}
+                size={14}
+              />
+              <Text numberOfLines={1} style={styles.locationLabel}>
+                {deviceName || t("desktopFallback")}
+              </Text>
+            </View>
+          </View>
         </View>
-        <View style={styles.onlineDot} />
+        <View style={styles.headerButtonSlot}>
+          <NativeIconButton
+            accessibilityLabel={t("moreActions")}
+            icon={<Text style={styles.moreIcon}>⋮</Text>}
+            onPress={() => setDrawerOpen(true)}
+            style={styles.headerCircleButton}
+            variant="secondary"
+          />
+        </View>
       </View>
 
       {model.loading ? (
-        <View style={styles.center}>
-          <ActivityIndicator color={theme.color.accent} size="large" />
+        <View
+          accessibilityLabel={t("loading")}
+          accessibilityLiveRegion="polite"
+          style={styles.loadingSkeleton}
+        >
+          <View style={[styles.skeletonBlock, styles.skeletonShort]} />
+          <View style={[styles.skeletonBlock, styles.skeletonLong]} />
         </View>
       ) : model.selectedSession && !model.creating ? (
         <View style={styles.conversationBody}>
@@ -318,40 +351,13 @@ export function ConversationWorkspaceView({
         <Text style={styles.inlineError}>{t("genericError")}</Text>
       ) : null}
       {model.selectedSession || model.creating ? (
-        <View style={styles.composer}>
-          <MobileComposerSettingsSheet
-            model={model}
-            onUpdate={onUpdateComposerSettings}
-          />
-          <TextInput
-            editable={!model.sending}
-            multiline
-            onChangeText={onDraftChange}
-            placeholder={t("messageHint")}
-            placeholderTextColor={theme.color.muted}
-            style={styles.input}
-            value={model.draft}
-          />
-          {model.selectedSession?.activeTurnId && !model.creating ? (
-            <PrimaryButton
-              label={t("stop")}
-              onPress={onStop}
-              secondary
-              style={styles.sendButton}
-            />
-          ) : (
-            <PrimaryButton
-              disabled={
-                !model.draft.trim() ||
-                (model.creating && !model.selectedAgentTargetId)
-              }
-              label={model.ambiguousSubmission ? t("retry") : t("send")}
-              loading={model.sending}
-              onPress={onSend}
-              style={styles.sendButton}
-            />
-          )}
-        </View>
+        <MobileComposerDock
+          model={model}
+          onDraftChange={onDraftChange}
+          onSend={onSend}
+          onStop={onStop}
+          onUpdate={onUpdateComposerSettings}
+        />
       ) : null}
 
       {drawerOpen ? (
@@ -366,6 +372,7 @@ export function ConversationWorkspaceView({
           onRefreshSessions={onRefreshSessions}
           onSelectSession={onSelectSession}
           onTogglePinned={onTogglePinned}
+          deviceName={deviceName}
           workspaceName={workspace.name}
         />
       ) : null}
@@ -383,26 +390,26 @@ function createStyles(theme: NativeTheme) {
       padding: theme.space.large
     },
     chevron: { color: theme.color.muted, fontSize: 30 },
-    composer: {
-      alignItems: "flex-end",
-      borderTopColor: theme.color.border,
-      borderTopWidth: StyleSheet.hairlineWidth,
-      flexDirection: "row",
-      flexWrap: "wrap",
-      gap: theme.space.small,
-      padding: theme.space.medium
-    },
     conversationHeader: {
       alignItems: "center",
-      borderBottomColor: theme.color.border,
-      borderBottomWidth: StyleSheet.hairlineWidth,
       flexDirection: "row",
-      minHeight: 64,
-      paddingHorizontal: theme.space.medium
+      gap: theme.space.small,
+      minHeight: 82,
+      paddingHorizontal: theme.space.medium,
+      paddingVertical: theme.space.small
     },
     conversationBody: { flex: 1, position: "relative" },
-    conversationTitle: { flex: 1, marginHorizontal: theme.space.small },
-    deviceCaption: { color: theme.color.muted, fontSize: 12, marginTop: 3 },
+    conversationTitle: {
+      backgroundColor: theme.color.panelRaised,
+      borderColor: theme.color.border,
+      borderRadius: 28,
+      borderWidth: StyleSheet.hairlineWidth,
+      flex: 1,
+      justifyContent: "center",
+      minWidth: 0,
+      minHeight: 56,
+      paddingHorizontal: theme.space.medium
+    },
     emptyText: {
       color: theme.color.textSecondary,
       fontSize: 15,
@@ -411,13 +418,28 @@ function createStyles(theme: NativeTheme) {
     },
     error: { color: theme.color.danger, fontSize: 14 },
     eyebrow: { color: theme.color.accent, fontSize: 12, fontWeight: "700" },
-    iconButton: {
-      alignItems: "center",
-      height: 44,
-      justifyContent: "center",
-      width: 44
+    backIcon: {
+      color: theme.color.text,
+      fontSize: 32,
+      fontWeight: "300",
+      lineHeight: 34
     },
-    iconText: { color: theme.color.text, fontSize: 22 },
+    headerCircleButton: {
+      alignItems: "center",
+      backgroundColor: theme.color.panelRaised,
+      borderColor: theme.color.border,
+      borderRadius: 28,
+      borderWidth: StyleSheet.hairlineWidth,
+      flexShrink: 0,
+      height: 56,
+      justifyContent: "center",
+      width: 56
+    },
+    headerButtonSlot: {
+      flexShrink: 0,
+      height: 56,
+      width: 56
+    },
     inlineError: {
       backgroundColor: theme.color.panel,
       color: theme.color.danger,
@@ -425,27 +447,44 @@ function createStyles(theme: NativeTheme) {
       padding: theme.space.small,
       textAlign: "center"
     },
-    input: {
-      backgroundColor: theme.color.panel,
-      borderColor: theme.color.border,
-      borderRadius: theme.radius.large,
-      borderWidth: StyleSheet.hairlineWidth,
-      color: theme.color.text,
-      flex: 1,
-      fontSize: 16,
-      maxHeight: 132,
-      minHeight: 48,
-      paddingHorizontal: theme.space.medium,
-      paddingVertical: 12
-    },
     loadOlder: { color: theme.color.muted, fontSize: 12, textAlign: "center" },
-    messageList: { gap: theme.space.medium, padding: theme.space.large },
+    loadingSkeleton: {
+      flex: 1,
+      gap: theme.space.medium,
+      paddingHorizontal: theme.space.large,
+      paddingTop: theme.space.xlarge
+    },
+    locationLabel: {
+      color: theme.color.textSecondary,
+      flex: 1,
+      flexShrink: 1,
+      fontSize: 12
+    },
+    locationItem: {
+      alignItems: "center",
+      flex: 1,
+      flexDirection: "row",
+      gap: 4,
+      minWidth: 0
+    },
+    locationRow: {
+      flexDirection: "row",
+      gap: theme.space.small,
+      marginTop: 3,
+      overflow: "hidden"
+    },
+    messageList: {
+      gap: theme.space.large,
+      paddingBottom: theme.space.xlarge,
+      paddingHorizontal: theme.space.large,
+      paddingTop: theme.space.medium
+    },
     messageScroller: { flex: 1 },
-    onlineDot: {
-      backgroundColor: theme.color.success,
-      borderRadius: 5,
-      height: 10,
-      width: 10
+    moreIcon: {
+      color: theme.color.text,
+      fontSize: 30,
+      fontWeight: "800",
+      lineHeight: 31
     },
     pageHeader: {
       alignItems: "center",
@@ -468,7 +507,16 @@ function createStyles(theme: NativeTheme) {
       position: "absolute",
       right: theme.space.medium
     },
-    sendButton: { minWidth: 76 },
+    skeletonBlock: {
+      backgroundColor: theme.color.panel,
+      borderRadius: theme.radius.large
+    },
+    skeletonLong: { height: 96 },
+    skeletonShort: {
+      alignSelf: "flex-end",
+      height: 64,
+      width: "78%"
+    },
     sessionTitle: { color: theme.color.text, fontSize: 16, fontWeight: "700" },
     targetChip: {
       borderColor: theme.color.border,

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -116,6 +116,7 @@ Android app login, native bridge, secure identity, and mobile transport diagnost
 
 - [Browser login returns to the App but remains signed out](./mobile.md#browser-login-returns-to-the-app-but-remains-signed-out)
 - [Android DeviceLink opens a session and then repeatedly restarts](./mobile.md#android-devicelink-opens-a-session-and-then-repeatedly-restarts)
+- [React Native Pressable rows stack their children vertically](./mobile.md#react-native-pressable-rows-stack-their-children-vertically)
 
 ## [Computer Use](./computer-use.md)
 

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -53,3 +53,29 @@ dev.tutti.mobile` and inspect a narrow logcat window for the Go fatal message.
   and observe beyond the previous crash window with no new Go fatal message.
 - **References:** `packages/device-link/mobile/link.go`,
   `apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt`
+
+## React Native Pressable rows stack their children vertically
+
+- **Symptom:** A Native button, list row, or app-owned tappable row declares
+  `flexDirection: "row"` but its icon, label, count, or trailing action appears
+  vertically stacked on a Fabric Android device. Plain `View` rows on the same
+  screen remain horizontal.
+- **Quick checks:** Inspect the real device rather than relying only on
+  TypeScript or snapshots. Compare the bounds from `uiautomator dump` for the
+  direct children of the `Pressable`; consecutive vertical bounds identify the
+  failure even when the parent style contains the expected row declaration.
+- **Root cause:** In the current React Native NativeWind/CSS interop renderer,
+  layout declarations on the `Pressable` host are not reliable for arranging
+  its direct children. Interaction, surface, size, and pressed-state styles
+  still apply, which makes this easy to mistake for stale Fast Refresh state.
+- **Fix:** Keep interaction and surface styling on `Pressable`, but wrap its
+  visual children in a plain token-backed `View` that owns
+  `flexDirection: "row"` and alignment. Shared buttons and list rows should fix
+  this once in `@tutti-os/ui-system/native`; app-specific tappable rows should
+  follow the same inner-layout pattern.
+- **Validation:** Perform a full JavaScript reload, then verify on Android that
+  button icon/label, list title/trailing action, and section label/count remain
+  horizontal. Confirm touch and accessibility actions still reach the outer
+  `Pressable`.
+- **References:** `packages/ui/system/src/native/button.tsx`,
+  `packages/ui/system/src/native/list-row.tsx`

--- a/packages/ui/system/src/native/button.tsx
+++ b/packages/ui/system/src/native/button.tsx
@@ -75,25 +75,27 @@ export function NativeButton({
       ]}
       testID={testID}
     >
-      {loading ? (
-        <ActivityIndicator color={foreground} size="small" />
-      ) : (
-        <>
-          {leading ? (
-            <View style={[styles.leading, !hasLabel && styles.leadingOnly]}>
-              {leading}
-            </View>
-          ) : null}
-          {hasLabel ? (
-            <Text
-              numberOfLines={1}
-              style={[styles.label, { color: foreground }]}
-            >
-              {label}
-            </Text>
-          ) : null}
-        </>
-      )}
+      <View style={styles.content}>
+        {loading ? (
+          <ActivityIndicator color={foreground} size="small" />
+        ) : (
+          <>
+            {leading ? (
+              <View style={[styles.leading, !hasLabel && styles.leadingOnly]}>
+                {leading}
+              </View>
+            ) : null}
+            {hasLabel ? (
+              <Text
+                numberOfLines={1}
+                style={[styles.label, { color: foreground }]}
+              >
+                {label}
+              </Text>
+            ) : null}
+          </>
+        )}
+      </View>
     </Pressable>
   );
 }
@@ -127,12 +129,16 @@ function createStyles(theme: NativeTheme) {
     button: {
       alignItems: "center",
       borderRadius: theme.radius.medium,
-      flexDirection: "row",
       justifyContent: "center"
     },
     compact: {
       minHeight: theme.control.compact,
       paddingHorizontal: theme.space.small
+    },
+    content: {
+      alignItems: "center",
+      flexDirection: "row",
+      justifyContent: "center"
     },
     disabled: { opacity: 0.45 },
     icon: {

--- a/packages/ui/system/src/native/list-row.tsx
+++ b/packages/ui/system/src/native/list-row.tsx
@@ -52,30 +52,41 @@ export function NativeListRow({
         style
       ]}
     >
-      {selected ? <View style={styles.selectedIndicator} /> : null}
-      {leading ? <View style={styles.leading}>{leading}</View> : null}
-      <View style={styles.copy}>
-        <Text
-          numberOfLines={2}
-          style={[styles.title, selected ? styles.titleSelected : undefined]}
-        >
-          {title}
-        </Text>
-        {typeof description === "string" ? (
-          <Text numberOfLines={1} style={styles.description}>
-            {description}
+      <View style={styles.content}>
+        {selected ? <View style={styles.selectedIndicator} /> : null}
+        {leading ? <View style={styles.leading}>{leading}</View> : null}
+        <View style={styles.copy}>
+          <Text
+            numberOfLines={2}
+            style={[styles.title, selected ? styles.titleSelected : undefined]}
+          >
+            {title}
           </Text>
-        ) : description ? (
-          <View style={styles.descriptionSlot}>{description}</View>
-        ) : null}
+          {typeof description === "string" ? (
+            <Text numberOfLines={1} style={styles.description}>
+              {description}
+            </Text>
+          ) : description ? (
+            <View style={styles.descriptionSlot}>{description}</View>
+          ) : null}
+        </View>
+        {trailing ? <View style={styles.trailing}>{trailing}</View> : null}
       </View>
-      {trailing ? <View style={styles.trailing}>{trailing}</View> : null}
     </Pressable>
   );
 }
 
 function createStyles(theme: NativeTheme) {
   return StyleSheet.create({
+    content: {
+      alignItems: "center",
+      flex: 1,
+      flexDirection: "row",
+      minHeight: theme.control.row,
+      paddingHorizontal: theme.space.small,
+      position: "relative",
+      width: "100%"
+    },
     copy: { flex: 1, paddingVertical: theme.space.small },
     description: {
       color: theme.color.muted,
@@ -87,12 +98,9 @@ function createStyles(theme: NativeTheme) {
     leading: { marginRight: theme.space.small },
     pressed: { opacity: 0.7 },
     row: {
-      alignItems: "center",
       borderRadius: theme.radius.small,
-      flexDirection: "row",
       minHeight: theme.control.row,
-      overflow: "hidden",
-      paddingHorizontal: theme.space.small
+      overflow: "hidden"
     },
     selected: { backgroundColor: theme.color.panelRaised },
     selectedIndicator: {


### PR DESCRIPTION
## Summary

- restore the Android Remote/session list, conversation header, timeline, loading state, and composer dock to match the provided mobile design direction
- make the composer `+` affordance open real model, permission, and plan controls backed by the existing agent settings flow
- keep user-visible copy in the mobile i18n layer and reuse semantic UI System tokens and primitives
- fix horizontal child layout for shared native buttons and list rows under the current Fabric/NativeWind interop renderer

## Why

The first Android functional integration established the live Agent GUI event stream and core session flow. This follow-up brings the primary Remote and conversation surfaces closer to the intended mobile interaction and visual hierarchy while keeping the controls connected to existing product capabilities.

The shared row fix is needed because `Pressable` host layout styles are not reliably arranging direct children horizontally on the tested Fabric Android runtime. The visual children now use an inner token-backed `View` for row layout while the outer `Pressable` retains interaction and surface styling.

## User impact

- clearer Remote device, project, and recent-session hierarchy
- searchable session list and a dedicated new-chat action
- compact conversation location header and redesigned message/composer presentation
- `+` menu exposes only capabilities actually reported by the connected agent target; no placeholder upload or plugin actions are introduced

## Validation

- `pnpm check:changed -- --push-ready` — passed all 12 selected lanes
- Android real device (V2507A): secure connection, conversation loading, session drawer, session search, `+` popover, outside dismissal, and plan-mode action verified
- confirmed no current crash or fatal Android logs during the validation window

## Current test limitation

The connected desktop runtime did not report an available Agent target/model/permission option set during this test session, so the model and permission nested option lists could not be exercised on-device. Their visibility remains capability-gated and the composer correctly stays disabled when no target is available.

## Documentation

- added a mobile troubleshooting entry for React Native `Pressable` children stacking vertically on Fabric Android, including the shared UI System remediation and real-device verification steps
