### PR TITLE
fix(agent): show Codex ChatGPT model fallback while live list loads

### DIFF
--- a/packages/agent/daemon/modelcatalog/codex_chatgpt_fallback.go
+++ b/packages/agent/daemon/modelcatalog/codex_chatgpt_fallback.go
@@ -1,0 +1,104 @@
+package modelcatalog
+
+import (
+	_ "embed"
+	"encoding/json"
+	"sync"
+)
+
+// CodexChatGPTFallbackSource labels composer/runtime catalogs that are serving
+// the local ChatGPT-subscription fallback instead of a live model/list result.
+const CodexChatGPTFallbackSource = "codex-fallback"
+
+//go:embed codex_chatgpt_fallback_models.json
+var codexChatGPTFallbackModelsJSON []byte
+
+var (
+	codexChatGPTFallbackOnce    sync.Once
+	codexChatGPTFallbackOptions []ModelOption
+	codexChatGPTFallbackRaw     []map[string]any
+)
+
+func loadCodexChatGPTFallbackModels() {
+	codexChatGPTFallbackOnce.Do(func() {
+		var models []map[string]any
+		if err := json.Unmarshal(codexChatGPTFallbackModelsJSON, &models); err != nil {
+			return
+		}
+		options := make([]ModelOption, 0, len(models))
+		raw := make([]map[string]any, 0, len(models))
+		for _, model := range models {
+			encoded, err := json.Marshal(model)
+			if err != nil {
+				continue
+			}
+			normalized, ok := NormalizeCodexModel(encoded)
+			if !ok {
+				continue
+			}
+			options = append(options, normalized)
+			raw = append(raw, cloneStringAnyMap(model))
+		}
+		codexChatGPTFallbackOptions = options
+		codexChatGPTFallbackRaw = raw
+	})
+}
+
+// CodexChatGPTFallbackModelOptions returns the picker-ready ChatGPT
+// subscription fallback catalog used when live model/list is empty or slow.
+func CodexChatGPTFallbackModelOptions() []ModelOption {
+	loadCodexChatGPTFallbackModels()
+	if len(codexChatGPTFallbackOptions) == 0 {
+		return nil
+	}
+	cloned := make([]ModelOption, len(codexChatGPTFallbackOptions))
+	copy(cloned, codexChatGPTFallbackOptions)
+	return cloned
+}
+
+// CodexChatGPTFallbackAppServerModels returns the same fallback catalog in the
+// app-server model/list shape consumed by the Codex session adapter.
+func CodexChatGPTFallbackAppServerModels() []map[string]any {
+	loadCodexChatGPTFallbackModels()
+	if len(codexChatGPTFallbackRaw) == 0 {
+		return nil
+	}
+	cloned := make([]map[string]any, 0, len(codexChatGPTFallbackRaw))
+	for _, model := range codexChatGPTFallbackRaw {
+		cloned = append(cloned, cloneStringAnyMap(model))
+	}
+	return cloned
+}
+
+func cloneStringAnyMap(input map[string]any) map[string]any {
+	if input == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(input))
+	for key, value := range input {
+		switch typed := value.(type) {
+		case []any:
+			cloned[key] = cloneAnySlice(typed)
+		case map[string]any:
+			cloned[key] = cloneStringAnyMap(typed)
+		default:
+			cloned[key] = value
+		}
+	}
+	return cloned
+}
+
+func cloneAnySlice(input []any) []any {
+	cloned := make([]any, len(input))
+	for i, value := range input {
+		switch typed := value.(type) {
+		case []any:
+			cloned[i] = cloneAnySlice(typed)
+		case map[string]any:
+			cloned[i] = cloneStringAnyMap(typed)
+		default:
+			cloned[i] = value
+		}
+	}
+	return cloned
+}

--- a/packages/agent/daemon/modelcatalog/codex_chatgpt_fallback_models.json
+++ b/packages/agent/daemon/modelcatalog/codex_chatgpt_fallback_models.json
@@ -1,0 +1,164 @@
+[
+  {
+    "id": "gpt-5.5",
+    "model": "gpt-5.5",
+    "displayName": "GPT-5.5",
+    "description": "Frontier model for complex coding, research, and real-world work.",
+    "hidden": false,
+    "isDefault": true,
+    "defaultReasoningEffort": "medium",
+    "supportedReasoningEfforts": [
+      {
+        "reasoningEffort": "low",
+        "description": "Fast responses with lighter reasoning"
+      },
+      {
+        "reasoningEffort": "medium",
+        "description": "Balances speed and reasoning depth for everyday tasks"
+      },
+      {
+        "reasoningEffort": "high",
+        "description": "Greater reasoning depth for complex problems"
+      },
+      {
+        "reasoningEffort": "xhigh",
+        "description": "Extra high reasoning depth for complex problems"
+      }
+    ],
+    "inputModalities": ["text", "image"],
+    "serviceTiers": [
+      {
+        "id": "priority",
+        "name": "Fast",
+        "description": "1.5x speed, increased usage"
+      }
+    ],
+    "additionalSpeedTiers": ["fast"]
+  },
+  {
+    "id": "gpt-5.4",
+    "model": "gpt-5.4",
+    "displayName": "gpt-5.4",
+    "description": "Strong model for everyday coding.",
+    "hidden": false,
+    "isDefault": false,
+    "defaultReasoningEffort": "medium",
+    "supportedReasoningEfforts": [
+      {
+        "reasoningEffort": "low",
+        "description": "Fast responses with lighter reasoning"
+      },
+      {
+        "reasoningEffort": "medium",
+        "description": "Balances speed and reasoning depth for everyday tasks"
+      },
+      {
+        "reasoningEffort": "high",
+        "description": "Greater reasoning depth for complex problems"
+      },
+      {
+        "reasoningEffort": "xhigh",
+        "description": "Extra high reasoning depth for complex problems"
+      }
+    ],
+    "inputModalities": ["text", "image"],
+    "serviceTiers": [
+      {
+        "id": "priority",
+        "name": "Fast",
+        "description": "1.5x speed, increased usage"
+      }
+    ],
+    "additionalSpeedTiers": ["fast"]
+  },
+  {
+    "id": "gpt-5.4-mini",
+    "model": "gpt-5.4-mini",
+    "displayName": "GPT-5.4-Mini",
+    "description": "Small, fast, and cost-efficient model for simpler coding tasks.",
+    "hidden": false,
+    "isDefault": false,
+    "defaultReasoningEffort": "medium",
+    "supportedReasoningEfforts": [
+      {
+        "reasoningEffort": "low",
+        "description": "Fast responses with lighter reasoning"
+      },
+      {
+        "reasoningEffort": "medium",
+        "description": "Balances speed and reasoning depth for everyday tasks"
+      },
+      {
+        "reasoningEffort": "high",
+        "description": "Greater reasoning depth for complex problems"
+      },
+      {
+        "reasoningEffort": "xhigh",
+        "description": "Extra high reasoning depth for complex problems"
+      }
+    ],
+    "inputModalities": ["text", "image"],
+    "serviceTiers": [],
+    "additionalSpeedTiers": []
+  },
+  {
+    "id": "gpt-5.3-codex",
+    "model": "gpt-5.3-codex",
+    "displayName": "gpt-5.3-codex",
+    "description": "Coding-optimized model.",
+    "hidden": false,
+    "isDefault": false,
+    "defaultReasoningEffort": "medium",
+    "supportedReasoningEfforts": [
+      {
+        "reasoningEffort": "low",
+        "description": "Fast responses with lighter reasoning"
+      },
+      {
+        "reasoningEffort": "medium",
+        "description": "Balances speed and reasoning depth for everyday tasks"
+      },
+      {
+        "reasoningEffort": "high",
+        "description": "Greater reasoning depth for complex problems"
+      },
+      {
+        "reasoningEffort": "xhigh",
+        "description": "Extra high reasoning depth for complex problems"
+      }
+    ],
+    "inputModalities": ["text", "image"],
+    "serviceTiers": [],
+    "additionalSpeedTiers": []
+  },
+  {
+    "id": "gpt-5.2",
+    "model": "gpt-5.2",
+    "displayName": "gpt-5.2",
+    "description": "Optimized for professional work and long-running agents.",
+    "hidden": false,
+    "isDefault": false,
+    "defaultReasoningEffort": "medium",
+    "supportedReasoningEfforts": [
+      {
+        "reasoningEffort": "low",
+        "description": "Balances speed with some reasoning; useful for straightforward queries and short explanations"
+      },
+      {
+        "reasoningEffort": "medium",
+        "description": "Provides a solid balance of reasoning depth and latency for general-purpose tasks"
+      },
+      {
+        "reasoningEffort": "high",
+        "description": "Maximizes reasoning depth for complex or ambiguous problems"
+      },
+      {
+        "reasoningEffort": "xhigh",
+        "description": "Extra high reasoning for complex problems"
+      }
+    ],
+    "inputModalities": ["text", "image"],
+    "serviceTiers": [],
+    "additionalSpeedTiers": []
+  }
+]

--- a/packages/agent/daemon/modelcatalog/codex_chatgpt_fallback_models.json
+++ b/packages/agent/daemon/modelcatalog/codex_chatgpt_fallback_models.json
@@ -1,11 +1,139 @@
 [
   {
+    "id": "gpt-5.6-sol",
+    "model": "gpt-5.6-sol",
+    "displayName": "GPT-5.6-Sol",
+    "description": "Latest frontier agentic coding model.",
+    "hidden": false,
+    "isDefault": true,
+    "defaultReasoningEffort": "low",
+    "supportedReasoningEfforts": [
+      {
+        "reasoningEffort": "low",
+        "description": "Fast responses with lighter reasoning"
+      },
+      {
+        "reasoningEffort": "medium",
+        "description": "Balances speed and reasoning depth for everyday tasks"
+      },
+      {
+        "reasoningEffort": "high",
+        "description": "Greater reasoning depth for complex problems"
+      },
+      {
+        "reasoningEffort": "xhigh",
+        "description": "Extra high reasoning depth for complex problems"
+      },
+      {
+        "reasoningEffort": "max",
+        "description": "Maximum reasoning depth for the hardest problems"
+      },
+      {
+        "reasoningEffort": "ultra",
+        "description": "Maximum reasoning with automatic task delegation"
+      }
+    ],
+    "inputModalities": ["text", "image"],
+    "serviceTiers": [
+      {
+        "id": "priority",
+        "name": "Fast",
+        "description": "1.5x speed, increased usage"
+      }
+    ],
+    "additionalSpeedTiers": ["fast"]
+  },
+  {
+    "id": "gpt-5.6-terra",
+    "model": "gpt-5.6-terra",
+    "displayName": "GPT-5.6-Terra",
+    "description": "Balanced agentic coding model for everyday work.",
+    "hidden": false,
+    "isDefault": false,
+    "defaultReasoningEffort": "medium",
+    "supportedReasoningEfforts": [
+      {
+        "reasoningEffort": "low",
+        "description": "Fast responses with lighter reasoning"
+      },
+      {
+        "reasoningEffort": "medium",
+        "description": "Balances speed and reasoning depth for everyday tasks"
+      },
+      {
+        "reasoningEffort": "high",
+        "description": "Greater reasoning depth for complex problems"
+      },
+      {
+        "reasoningEffort": "xhigh",
+        "description": "Extra high reasoning depth for complex problems"
+      },
+      {
+        "reasoningEffort": "max",
+        "description": "Maximum reasoning depth for the hardest problems"
+      },
+      {
+        "reasoningEffort": "ultra",
+        "description": "Maximum reasoning with automatic task delegation"
+      }
+    ],
+    "inputModalities": ["text", "image"],
+    "serviceTiers": [
+      {
+        "id": "priority",
+        "name": "Fast",
+        "description": "1.5x speed, increased usage"
+      }
+    ],
+    "additionalSpeedTiers": ["fast"]
+  },
+  {
+    "id": "gpt-5.6-luna",
+    "model": "gpt-5.6-luna",
+    "displayName": "GPT-5.6-Luna",
+    "description": "Fast and affordable agentic coding model.",
+    "hidden": false,
+    "isDefault": false,
+    "defaultReasoningEffort": "medium",
+    "supportedReasoningEfforts": [
+      {
+        "reasoningEffort": "low",
+        "description": "Fast responses with lighter reasoning"
+      },
+      {
+        "reasoningEffort": "medium",
+        "description": "Balances speed and reasoning depth for everyday tasks"
+      },
+      {
+        "reasoningEffort": "high",
+        "description": "Greater reasoning depth for complex problems"
+      },
+      {
+        "reasoningEffort": "xhigh",
+        "description": "Extra high reasoning depth for complex problems"
+      },
+      {
+        "reasoningEffort": "max",
+        "description": "Maximum reasoning depth for the hardest problems"
+      }
+    ],
+    "inputModalities": ["text", "image"],
+    "serviceTiers": [
+      {
+        "id": "priority",
+        "name": "Fast",
+        "description": "1.5x speed, increased usage"
+      }
+    ],
+    "additionalSpeedTiers": ["fast"]
+  },
+  {
     "id": "gpt-5.5",
     "model": "gpt-5.5",
     "displayName": "GPT-5.5",
     "description": "Frontier model for complex coding, research, and real-world work.",
     "hidden": false,
-    "isDefault": true,
+    "isDefault": false,
     "defaultReasoningEffort": "medium",
     "supportedReasoningEfforts": [
       {
@@ -38,7 +166,7 @@
   {
     "id": "gpt-5.4",
     "model": "gpt-5.4",
-    "displayName": "gpt-5.4",
+    "displayName": "GPT-5.4",
     "description": "Strong model for everyday coding.",
     "hidden": false,
     "isDefault": false,
@@ -102,13 +230,13 @@
     "additionalSpeedTiers": []
   },
   {
-    "id": "gpt-5.3-codex",
-    "model": "gpt-5.3-codex",
-    "displayName": "gpt-5.3-codex",
-    "description": "Coding-optimized model.",
+    "id": "gpt-5.3-codex-spark",
+    "model": "gpt-5.3-codex-spark",
+    "displayName": "GPT-5.3-Codex-Spark",
+    "description": "Ultra-fast coding model.",
     "hidden": false,
     "isDefault": false,
-    "defaultReasoningEffort": "medium",
+    "defaultReasoningEffort": "high",
     "supportedReasoningEfforts": [
       {
         "reasoningEffort": "low",
@@ -127,37 +255,7 @@
         "description": "Extra high reasoning depth for complex problems"
       }
     ],
-    "inputModalities": ["text", "image"],
-    "serviceTiers": [],
-    "additionalSpeedTiers": []
-  },
-  {
-    "id": "gpt-5.2",
-    "model": "gpt-5.2",
-    "displayName": "gpt-5.2",
-    "description": "Optimized for professional work and long-running agents.",
-    "hidden": false,
-    "isDefault": false,
-    "defaultReasoningEffort": "medium",
-    "supportedReasoningEfforts": [
-      {
-        "reasoningEffort": "low",
-        "description": "Balances speed with some reasoning; useful for straightforward queries and short explanations"
-      },
-      {
-        "reasoningEffort": "medium",
-        "description": "Provides a solid balance of reasoning depth and latency for general-purpose tasks"
-      },
-      {
-        "reasoningEffort": "high",
-        "description": "Maximizes reasoning depth for complex or ambiguous problems"
-      },
-      {
-        "reasoningEffort": "xhigh",
-        "description": "Extra high reasoning for complex problems"
-      }
-    ],
-    "inputModalities": ["text", "image"],
+    "inputModalities": ["text"],
     "serviceTiers": [],
     "additionalSpeedTiers": []
   }

--- a/packages/agent/daemon/modelcatalog/codex_chatgpt_fallback_test.go
+++ b/packages/agent/daemon/modelcatalog/codex_chatgpt_fallback_test.go
@@ -1,0 +1,37 @@
+package modelcatalog
+
+import (
+	"testing"
+)
+
+func TestCodexChatGPTFallbackModelOptionsArePickerReady(t *testing.T) {
+	t.Parallel()
+
+	options := CodexChatGPTFallbackModelOptions()
+	if len(options) == 0 {
+		t.Fatal("CodexChatGPTFallbackModelOptions() returned no models")
+	}
+	defaults := 0
+	for _, option := range options {
+		if option.ID == "" {
+			t.Fatalf("fallback model missing id: %#v", option)
+		}
+		if !option.ReasoningEffortsAdvertised || len(option.SupportedReasoningEfforts) == 0 {
+			t.Fatalf("fallback model %q missing reasoning efforts", option.ID)
+		}
+		if option.IsDefault {
+			defaults++
+		}
+	}
+	if defaults != 1 {
+		t.Fatalf("default models = %d, want 1", defaults)
+	}
+
+	raw := CodexChatGPTFallbackAppServerModels()
+	if len(raw) != len(options) {
+		t.Fatalf("app-server fallback count = %d, want %d", len(raw), len(options))
+	}
+	if CodexChatGPTFallbackSource != "codex-fallback" {
+		t.Fatalf("CodexChatGPTFallbackSource = %q", CodexChatGPTFallbackSource)
+	}
+}

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -233,9 +233,13 @@ type codexAppServerSession struct {
 	provenanceDegraded bool
 	// goalMutationMu is the provider-side half of the Host goal mutation lane. It serializes
 	// direct control, reconcile and delayed continuation nudges for this thread.
-	goalMutationMu         sync.Mutex
-	models                 []map[string]any
-	startupModelsReady     bool
+	goalMutationMu     sync.Mutex
+	models             []map[string]any
+	startupModelsReady bool
+	// startupModelsFallback is true while the session is advertising the local
+	// ChatGPT-subscription catalog because live model/list has not resolved yet.
+	// Background refresh keeps running until a live catalog replaces it.
+	startupModelsFallback  bool
 	startupRateLimitsReady bool
 	// lifecycleSeq numbers the adapter's TurnLifecycle snapshots (ADR 0008):
 	// monotonically increasing per session so consumers receiving snapshots

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -6260,9 +6260,18 @@ func TestCodexAppServerAdapterStartSkipsSlowStartupProbesWhenReasoningNeedsNoVal
 	if !containsString(values, "gpt-5.3-codex-spark") {
 		t.Fatalf("model option values = %#v, want explicit model", values)
 	}
+	// ChatGPT subscription sessions advertise the local fallback catalog
+	// immediately so the picker is usable; rate limits still load async and
+	// live model/list still refreshes in the background.
 	startup, _ := state.RuntimeContext["appServerStartup"].(map[string]any)
-	if asString(startup["models"]) != "loading" || asString(startup["rateLimits"]) != "loading" {
-		t.Fatalf("appServerStartup = %#v, want startup probes loading", startup)
+	if asString(startup["models"]) != "ready" || asString(startup["rateLimits"]) != "loading" {
+		t.Fatalf("appServerStartup = %#v, want models ready via fallback and rateLimits loading", startup)
+	}
+	adapter.mu.Lock()
+	fallback := adapter.sessions[session.AgentSessionID].startupModelsFallback
+	adapter.mu.Unlock()
+	if !fallback {
+		t.Fatal("startupModelsFallback = false, want true before live model/list")
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+	"github.com/tutti-os/tutti/packages/agent/daemon/modelcatalog"
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 )
 
@@ -6272,6 +6273,65 @@ func TestCodexAppServerAdapterStartSkipsSlowStartupProbesWhenReasoningNeedsNoVal
 	adapter.mu.Unlock()
 	if !fallback {
 		t.Fatal("startupModelsFallback = false, want true before live model/list")
+	}
+}
+
+func TestCodexAppServerAdapterStartOmitsChatGPTFallbackDefaultFromThreadStart(t *testing.T) {
+	t.Parallel()
+
+	transport := newScriptedAppServerTransport()
+	transport.conn.modelList = []any{}
+	adapter := NewCodexAppServerAdapter(transport)
+	session := testAppServerSession()
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if requests := appServerRequestParamsList(t, transport.conn, appServerMethodModelList); len(requests) != 1 {
+		t.Fatalf("model/list requests = %d, want 1 when no explicit model", len(requests))
+	}
+	threadStart := appServerRequestParams(t, transport.conn, appServerMethodThreadStart)
+	if _, ok := threadStart["model"]; ok {
+		t.Fatalf("thread/start params = %#v, want no model override on ChatGPT fallback without explicit model", threadStart)
+	}
+	fallbackDefault := ""
+	for _, model := range modelcatalog.CodexChatGPTFallbackAppServerModels() {
+		if model["isDefault"] == true {
+			fallbackDefault = asString(model["id"])
+			break
+		}
+	}
+	if fallbackDefault == "" {
+		t.Fatal("fallback catalog missing default model")
+	}
+	if got := asString(threadStart["model"]); got == fallbackDefault {
+		t.Fatalf("thread/start model = %q, want omitted instead of fallback default", got)
+	}
+
+	adapter.mu.Lock()
+	appSession := adapter.sessions[session.AgentSessionID]
+	fallback := appSession.startupModelsFallback
+	defaultModel := appSession.defaultModel
+	adapter.mu.Unlock()
+	if !fallback {
+		t.Fatal("startupModelsFallback = false, want true before live model/list")
+	}
+	if defaultModel != "" {
+		t.Fatalf("defaultModel = %q, want empty when fallback without explicit model", defaultModel)
+	}
+
+	state := adapter.SessionState(session)
+	options, _ := state.RuntimeContext["configOptions"].([]map[string]any)
+	modelOption := configOptionByID(options, "model")
+	if modelOption == nil {
+		t.Fatalf("missing model config option: %#v", options)
+	}
+	values := configOptionValues(modelOption)
+	if !containsString(values, fallbackDefault) {
+		t.Fatalf("model option values = %#v, want fallback catalog models in picker", values)
+	}
+	startup, _ := state.RuntimeContext["appServerStartup"].(map[string]any)
+	if asString(startup["models"]) != "ready" {
+		t.Fatalf("appServerStartup = %#v, want models ready via fallback", startup)
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_metadata.go
+++ b/packages/agent/daemon/runtime/codex_appserver_metadata.go
@@ -346,12 +346,11 @@ func (a *CodexAppServerAdapter) refreshStartupMetadataAsync(
 	}()
 }
 
-// retryStartupModels re-fetches the codex model/list until it returns a
-// non-empty list (and the startup state resolves to "ready"), the session is
+// retryStartupModels re-fetches the codex model/list until a live non-empty
+// catalog arrives (clearing any ChatGPT subscription fallback), the session is
 // torn down, the context is canceled, or the bounded backoff budget is
-// exhausted. A single transient empty/slow response therefore no longer pins
-// the composer's model options at "loading" forever — the previous code fetched
-// exactly once and silently left the state stuck on failure.
+// exhausted. Fallback catalogs keep the picker usable immediately, but this
+// loop continues until a live model/list replaces them.
 func (a *CodexAppServerAdapter) retryStartupModels(
 	ctx context.Context,
 	agentSessionID string,
@@ -372,11 +371,22 @@ func (a *CodexAppServerAdapter) retryStartupModels(
 			return false
 		}
 		models := fetch(ctx)
+		if len(models) == 0 {
+			if attempt == len(backoffs) {
+				break
+			}
+			if sleep != nil && !sleep(ctx, backoffs[attempt]) {
+				return false
+			}
+			continue
+		}
+		wasFallback := a.startupModelsNeedLiveRefresh(agentSessionID)
 		if a.applyStartupModels(agentSessionID, session, threadResult, models) {
-			if attempt > 0 {
+			if attempt > 0 || wasFallback {
 				slog.Info("agent session app-server model list resolved after retry",
 					"agent_session_id", agentSessionID,
 					"attempts", attempt+1,
+					"replaced_fallback", wasFallback,
 				)
 			}
 			return true

--- a/packages/agent/daemon/runtime/codex_appserver_model_settings.go
+++ b/packages/agent/daemon/runtime/codex_appserver_model_settings.go
@@ -58,6 +58,28 @@ func codexAppServerNeedsSynchronousModels(session Session) bool {
 		strings.TrimSpace(settings.ReasoningEffort) != ""
 }
 
+func isCodexChatGPTAccount(account map[string]any) bool {
+	return strings.EqualFold(strings.TrimSpace(asString(account["type"])), "chatgpt")
+}
+
+// resolveCodexStartupModels prefers a live model/list catalog. For ChatGPT
+// subscription accounts, an empty/slow live result falls back to the local
+// bundled subscription catalog so the picker is usable immediately while
+// background refresh continues.
+func resolveCodexStartupModels(account map[string]any, models []map[string]any) (resolved []map[string]any, usedFallback bool) {
+	if len(models) > 0 {
+		return models, false
+	}
+	if !isCodexChatGPTAccount(account) {
+		return nil, false
+	}
+	fallback := modelcatalog.CodexChatGPTFallbackAppServerModels()
+	if len(fallback) == 0 {
+		return nil, false
+	}
+	return fallback, true
+}
+
 func codexAppServerSessionDefaultModel(session Session, models []map[string]any) string {
 	return firstNonEmpty(strings.TrimSpace(session.SettingsValue().Model), codexAppServerDefaultModel(models))
 }
@@ -119,6 +141,16 @@ func (a *CodexAppServerAdapter) applyStartupModels(
 	threadResult json.RawMessage,
 	models []map[string]any,
 ) bool {
+	return a.applyStartupModelsWithFallback(agentSessionID, session, threadResult, models, false)
+}
+
+func (a *CodexAppServerAdapter) applyStartupModelsWithFallback(
+	agentSessionID string,
+	session Session,
+	threadResult json.RawMessage,
+	models []map[string]any,
+	fallback bool,
+) bool {
 	if len(models) == 0 {
 		return false
 	}
@@ -138,7 +170,21 @@ func (a *CodexAppServerAdapter) applyStartupModels(
 	appSession.models = cloneCodexAppServerModels(models)
 	appSession.defaultModel = codexAppServerSessionDefaultModel(effectiveSession, models)
 	appSession.startupModelsReady = true
+	appSession.startupModelsFallback = fallback
 	return true
+}
+
+func (a *CodexAppServerAdapter) startupModelsNeedLiveRefresh(agentSessionID string) bool {
+	if a == nil {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	appSession := a.sessions[strings.TrimSpace(agentSessionID)]
+	if appSession == nil {
+		return false
+	}
+	return !appSession.startupModelsReady || appSession.startupModelsFallback
 }
 
 func codexAppServerConfigOptionDescriptors(

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -72,8 +72,15 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 		models = a.fetchModels(ctx, client, session, trace)
 	}
 	models, usedFallback := resolveCodexStartupModels(account, models)
+	hasExplicitModel := strings.TrimSpace(session.SettingsValue().Model) != ""
 	if len(models) > 0 {
 		effectiveSettings := codexAppServerEffectiveSettings(models, session, nil)
+		if usedFallback && !hasExplicitModel {
+			// Fallback catalog defaults must not become the thread/start model
+			// override. Keep Model empty so the provider picks its live default
+			// until model/list resolves.
+			effectiveSettings.Model = ""
+		}
 		session.Settings = &effectiveSettings
 	}
 	planModeMask, defaultModeMask := a.fetchCollaborationModeMasks(ctx, client, session, trace)
@@ -143,6 +150,10 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 
 	started = true
 	keepSession = true
+	storedDefaultModel := codexAppServerSessionDefaultModel(session, models)
+	if usedFallback && !hasExplicitModel {
+		storedDefaultModel = ""
+	}
 	a.storeSession(session.AgentSessionID, &codexAppServerSession{
 		client:                 client,
 		threadID:               threadID,
@@ -154,7 +165,7 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 		startupRateLimitsReady: false,
 		planModeMask:           planModeMask,
 		defaultModeMask:        defaultModeMask,
-		defaultModel:           codexAppServerSessionDefaultModel(session, models),
+		defaultModel:           storedDefaultModel,
 		authState:              "authenticated",
 		acpLiveState:           liveState,
 		pendingRequests:        make(map[string]*pendingInteractiveRequest),

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -71,6 +71,7 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 	if codexAppServerNeedsSynchronousModels(session) {
 		models = a.fetchModels(ctx, client, session, trace)
 	}
+	models, usedFallback := resolveCodexStartupModels(account, models)
 	if len(models) > 0 {
 		effectiveSettings := codexAppServerEffectiveSettings(models, session, nil)
 		session.Settings = &effectiveSettings
@@ -125,6 +126,14 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 		"agent_session_id", session.AgentSessionID,
 		"provider_session_id", threadID,
 	)
+	if usedFallback {
+		slog.Info("agent session app-server using chatgpt model list fallback",
+			"event", "agent_session.app_server.models.fallback",
+			"provider", a.config.provider,
+			"agent_session_id", session.AgentSessionID,
+			"model_count", len(models),
+		)
+	}
 
 	liveState := newACPLiveState()
 	liveState.currentMode = codexACPEffectiveModeID(session)
@@ -141,6 +150,7 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 		account:                account,
 		models:                 cloneCodexAppServerModels(models),
 		startupModelsReady:     len(models) > 0,
+		startupModelsFallback:  usedFallback,
 		startupRateLimitsReady: false,
 		planModeMask:           planModeMask,
 		defaultModeMask:        defaultModeMask,
@@ -149,7 +159,7 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 		acpLiveState:           liveState,
 		pendingRequests:        make(map[string]*pendingInteractiveRequest),
 	})
-	a.refreshStartupMetadataAsync(session, threadResult, len(models) == 0, a.config.rateLimits, trace)
+	a.refreshStartupMetadataAsync(session, threadResult, len(models) == 0 || usedFallback, a.config.rateLimits, trace)
 	a.emitCommandSnapshot(AgentSessionCommandSnapshot{
 		AgentSessionID: strings.TrimSpace(session.AgentSessionID),
 		Commands:       codexAppServerCommands(),
@@ -218,6 +228,7 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) (er
 	if codexAppServerNeedsSynchronousModels(session) {
 		models = a.fetchModels(ctx, client, session, trace)
 	}
+	models, usedFallback := resolveCodexStartupModels(account, models)
 	if len(models) > 0 && strings.TrimSpace(session.SettingsValue().ReasoningEffort) != "" {
 		hasExplicitModel := strings.TrimSpace(session.SettingsValue().Model) != ""
 		effectiveSettings := codexAppServerEffectiveSettings(models, session, nil)
@@ -283,6 +294,7 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) (er
 		account:                account,
 		models:                 cloneCodexAppServerModels(models),
 		startupModelsReady:     len(models) > 0,
+		startupModelsFallback:  usedFallback,
 		startupRateLimitsReady: false,
 		planModeMask:           planModeMask,
 		defaultModeMask:        defaultModeMask,
@@ -291,7 +303,7 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) (er
 		acpLiveState:           liveState,
 		pendingRequests:        make(map[string]*pendingInteractiveRequest),
 	})
-	a.refreshStartupMetadataAsync(session, threadResult, len(models) == 0, a.config.rateLimits, trace)
+	a.refreshStartupMetadataAsync(session, threadResult, len(models) == 0 || usedFallback, a.config.rateLimits, trace)
 	// Mirror Start: push the command snapshot so a resumed session advertises
 	// review/compact/undo to the GUI (otherwise the slash palette and the
 	// review picker only work on freshly created sessions).

--- a/packages/agent/daemon/runtime/codex_appserver_settings.go
+++ b/packages/agent/daemon/runtime/codex_appserver_settings.go
@@ -125,6 +125,7 @@ type codexAppServerSessionStateSnapshot struct {
 	account                map[string]any
 	rateLimits             map[string]any
 	startupModelsReady     bool
+	startupModelsFallback  bool
 	startupRateLimitsReady bool
 	goal                   map[string]any
 	authState              string
@@ -156,6 +157,7 @@ func (a *CodexAppServerAdapter) snapshotSessionState(agentSessionID string) (cod
 		account:                clonePayload(appSession.account),
 		rateLimits:             clonePayload(appSession.rateLimits),
 		startupModelsReady:     appSession.startupModelsReady,
+		startupModelsFallback:  appSession.startupModelsFallback,
 		startupRateLimitsReady: appSession.startupRateLimitsReady,
 		goal:                   clonePayload(appSession.goal),
 		authState:              strings.TrimSpace(appSession.authState),

--- a/packages/agent/daemon/runtime/codex_appserver_startup_models_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_startup_models_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/modelcatalog"
 )
 
 func startupModelsTestSession(adapter *CodexAppServerAdapter) Session {
@@ -22,6 +24,89 @@ func startupModelsReadyFlag(adapter *CodexAppServerAdapter, agentSessionID strin
 		return appSession.startupModelsReady
 	}
 	return false
+}
+
+func startupModelsFallbackFlag(adapter *CodexAppServerAdapter, agentSessionID string) bool {
+	adapter.mu.Lock()
+	defer adapter.mu.Unlock()
+	if appSession := adapter.sessions[agentSessionID]; appSession != nil {
+		return appSession.startupModelsFallback
+	}
+	return false
+}
+
+func TestResolveCodexStartupModelsUsesChatGPTFallback(t *testing.T) {
+	t.Parallel()
+
+	live := []map[string]any{{"id": "live-model", "model": "live-model"}}
+	resolved, fallback := resolveCodexStartupModels(map[string]any{"type": "chatgpt"}, live)
+	if fallback {
+		t.Fatal("expected live models to skip fallback")
+	}
+	if len(resolved) != 1 || asString(resolved[0]["id"]) != "live-model" {
+		t.Fatalf("resolved = %#v", resolved)
+	}
+
+	resolved, fallback = resolveCodexStartupModels(map[string]any{"type": "apiKey"}, nil)
+	if fallback || len(resolved) != 0 {
+		t.Fatalf("apiKey empty list = %#v fallback=%v", resolved, fallback)
+	}
+
+	resolved, fallback = resolveCodexStartupModels(map[string]any{"type": "chatgpt"}, nil)
+	if !fallback {
+		t.Fatal("expected chatgpt empty list to use fallback")
+	}
+	want := modelcatalog.CodexChatGPTFallbackAppServerModels()
+	if len(resolved) != len(want) || len(resolved) == 0 {
+		t.Fatalf("fallback count = %d, want %d", len(resolved), len(want))
+	}
+}
+
+func TestRetryStartupModelsReplacesChatGPTFallback(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewCodexAppServerAdapter(newScriptedAppServerTransport())
+	adapter.startupModelRetryBackoffs = []time.Duration{0, 0, 0}
+	session := startupModelsTestSession(adapter)
+	fallback := modelcatalog.CodexChatGPTFallbackAppServerModels()
+	if !adapter.applyStartupModelsWithFallback(session.AgentSessionID, session, nil, fallback, true) {
+		t.Fatal("apply fallback = false, want true")
+	}
+	if !startupModelsFallbackFlag(adapter, session.AgentSessionID) {
+		t.Fatal("startupModelsFallback = false after seeding fallback")
+	}
+
+	calls := 0
+	fetch := func(context.Context) []map[string]any {
+		calls++
+		if calls < 2 {
+			return nil
+		}
+		return []map[string]any{{"id": "gpt-5.6-terra", "model": "gpt-5.6-terra", "displayName": "GPT-5.6 Terra"}}
+	}
+	resolved := adapter.retryStartupModels(
+		context.Background(),
+		session.AgentSessionID,
+		session,
+		nil,
+		fetch,
+		func(context.Context, time.Duration) bool { return true },
+	)
+	if !resolved {
+		t.Fatal("retryStartupModels = false, want true after live models arrive")
+	}
+	if calls != 2 {
+		t.Fatalf("fetch calls = %d, want 2", calls)
+	}
+	if startupModelsFallbackFlag(adapter, session.AgentSessionID) {
+		t.Fatal("startupModelsFallback still true after live refresh")
+	}
+	adapter.mu.Lock()
+	models := adapter.sessions[session.AgentSessionID].models
+	adapter.mu.Unlock()
+	if len(models) != 1 || asString(models[0]["id"]) != "gpt-5.6-terra" {
+		t.Fatalf("models after refresh = %#v", models)
+	}
 }
 
 // A single transient empty/slow model/list response must not pin the session at

--- a/services/tuttid/service/agent/codex_model_catalog.go
+++ b/services/tuttid/service/agent/codex_model_catalog.go
@@ -34,6 +34,9 @@ type CodexCLIModelLister struct {
 	HomeDir          func() (string, error)
 	IsExecutableFile func(string) bool
 	LookPath         func(string) (string, error)
+	// UseChatGPTFallback serves the bundled ChatGPT-subscription catalog when
+	// live model/list is empty or fails. Enable only for the Codex provider.
+	UseChatGPTFallback bool
 }
 
 type truncatingBuffer struct {
@@ -124,8 +127,20 @@ func (l CodexCLIModelLister) ListModels(ctx context.Context) (AgentModelListResu
 	}()
 
 	models, err := requestCodexModelList(stdin, stdout, l.clientName())
-	if err == nil {
+	if err == nil && len(models) > 0 {
 		return AgentModelListResult{Models: models}, nil
+	}
+	if l.UseChatGPTFallback {
+		if fallback := modelcatalog.CodexChatGPTFallbackModelOptions(); len(fallback) > 0 {
+			// ChatGPT subscription model/list often times out (~5s in Codex).
+			// Serve the bundled subscription catalog immediately so the
+			// composer stays usable; CachedAgentModelCatalog refreshes after
+			// fallbackTTL.
+			return AgentModelListResult{Models: fallback, IsFallback: true}, nil
+		}
+	}
+	if err == nil {
+		return AgentModelListResult{}, errors.New("codex app-server model/list returned no models")
 	}
 	if processCtx.Err() != nil {
 		return AgentModelListResult{}, fmt.Errorf("codex app-server model/list timed out: %w", processCtx.Err())

--- a/services/tuttid/service/agent/codex_model_catalog_test.go
+++ b/services/tuttid/service/agent/codex_model_catalog_test.go
@@ -12,6 +12,76 @@ import (
 	"time"
 )
 
+func TestCodexCLIModelListerFallsBackWhenModelListEmpty(t *testing.T) {
+	scriptPath := filepath.Join(t.TempDir(), "codex")
+	script := `#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      echo '{"id":"1","result":{}}'
+      ;;
+    *model/list*)
+      echo '{"id":"2","result":{"data":[]}}'
+      exit 0
+      ;;
+  esac
+done
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake codex script: %v", err)
+	}
+
+	result, err := (CodexCLIModelLister{
+		Command:            scriptPath,
+		Timeout:            5 * time.Second,
+		UseChatGPTFallback: true,
+	}).ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels returned error: %v", err)
+	}
+	if !result.IsFallback {
+		t.Fatal("IsFallback = false, want true")
+	}
+	if len(result.Models) == 0 {
+		t.Fatal("fallback models empty")
+	}
+}
+
+func TestCodexCLIModelListerFallsBackWhenModelListTimesOut(t *testing.T) {
+	scriptPath := filepath.Join(t.TempDir(), "codex")
+	script := `#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      echo '{"id":"1","result":{}}'
+      ;;
+    *model/list*)
+      sleep 10
+      exit 0
+      ;;
+  esac
+done
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake codex script: %v", err)
+	}
+
+	result, err := (CodexCLIModelLister{
+		Command:            scriptPath,
+		Timeout:            200 * time.Millisecond,
+		UseChatGPTFallback: true,
+	}).ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels returned error: %v", err)
+	}
+	if !result.IsFallback {
+		t.Fatal("IsFallback = false, want true")
+	}
+	if len(result.Models) == 0 {
+		t.Fatal("fallback models empty")
+	}
+}
+
 func TestCodexCLIModelListerCompletesInitializeHandshakeBeforeModelList(t *testing.T) {
 	scriptPath := filepath.Join(t.TempDir(), "codex")
 	script := `#!/bin/sh

--- a/services/tuttid/service/agent/model_catalog.go
+++ b/services/tuttid/service/agent/model_catalog.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	codexModelCacheTTL      = 30 * time.Second
-	codexModelErrorCacheTTL = 5 * time.Second
+	codexModelCacheTTL         = 30 * time.Second
+	codexModelErrorCacheTTL    = 5 * time.Second
+	codexModelFallbackCacheTTL = 5 * time.Second
 )
 
 type AgentModelOption = modelcatalog.ModelOption
@@ -112,16 +113,18 @@ func agentModelCatalogSpecFromDescriptor(descriptor providerregistry.ProviderDes
 			return agentModelCatalogSpec{}, false, err
 		}
 		return agentModelCatalogSpec{
-			source: string(descriptor.ComposerProfile.ModelCatalog),
-			ttl:    codexModelCacheTTL,
-			errTTL: codexModelErrorCacheTTL,
+			source:      string(descriptor.ComposerProfile.ModelCatalog),
+			ttl:         codexModelCacheTTL,
+			errTTL:      codexModelErrorCacheTTL,
+			fallbackTTL: codexModelFallbackCacheTTL,
 			lister: func(c *CachedAgentModelCatalog, _ AgentModelCatalogInput) AgentModelLister {
 				if c.Codex != nil {
 					return c.Codex
 				}
 				return CodexCLIModelLister{
-					Command: command[0],
-					Args:    append([]string(nil), command[1:]...),
+					Command:            command[0],
+					Args:               append([]string(nil), command[1:]...),
+					UseChatGPTFallback: true,
 				}
 			},
 			configuredDefaultModel:    readCodexConfiguredDefaultModel,
@@ -222,6 +225,10 @@ func (c *CachedAgentModelCatalog) ListModels(ctx context.Context, input AgentMod
 	configuredDefaultModel := spec.configuredDefaultModel()
 	models := applyConfiguredDefaultModel(listResult.Models, configuredDefaultModel, spec.missingDefaultDescription)
 	source := spec.source
+	if listResult.IsFallback {
+		source = modelcatalog.CodexChatGPTFallbackSource
+		err = nil
+	}
 	if configuredDefaultModel != "" && spec.configuredModelOnly != nil && spec.configuredModelOnly(listResult.Models, configuredDefaultModel) {
 		models = []AgentModelOption{{
 			ID:          configuredDefaultModel,


### PR DESCRIPTION
## Summary
- Bundle a ChatGPT-subscription Codex model catalog and show it immediately when live `model/list` is empty/slow for ChatGPT accounts (session start/resume).
- Keep background retry until a live catalog arrives, then replace the fallback.
- Composer Codex model listing uses the same fallback (short `fallbackTTL`) so the picker is not stuck on loading after subscription backend timeouts.

## Test plan
- [x] `go test ./packages/agent/daemon/modelcatalog/ ./packages/agent/daemon/runtime/ -run 'CodexChatGPTFallback|ResolveCodexStartup|RetryStartupModels|StartSkipsSlowStartupProbes'`
- [x] `go test ./services/tuttid/service/agent/ -run 'CodexCLIModelListerFallsBack|CodexCLIModelListerCompletes'`
- [x] `pnpm check:changed -- --push-ready` (pre-push)
- [ ] Manual: ChatGPT-subscription Codex user with slow/unreachable `chatgpt.com` models endpoint — picker shows fallback models immediately, then updates when live list succeeds
- [ ] Manual: API-key Codex user still gets live/bundled Codex list without ChatGPT fallback on empty account type


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->