### PR TITLE
fix(agent-gui): render only visually exposed windows

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -17,7 +17,11 @@ import { resolveInsufficientCreditsSemantic } from "@tutti-os/commerce";
 import { useService } from "@tutti-os/infra/di";
 import { requestWorkspaceAgentGuiLaunch } from "../services/workspaceAgentGuiLaunchCoordinator.ts";
 import { registerWorkspaceAgentGuiOpenSession } from "../../workspace-workbench/services/workspaceAgentGuiOpenSessionCoordinator.ts";
-import { workbenchFocusInputActivationType } from "@tutti-os/workbench-surface";
+import {
+  selectWorkbenchNodeIsVisuallyExposed,
+  useWorkbenchSelector,
+  workbenchFocusInputActivationType
+} from "@tutti-os/workbench-surface";
 import { useTranslation } from "@renderer/i18n";
 import type { WorkspaceAgentProvider } from "@tutti-os/client-tuttid-ts";
 import { useDesktopPreferencesService } from "@renderer/features/desktop-preferences/ui/useDesktopPreferencesService";
@@ -70,6 +74,7 @@ import { useDesktopAgentGUIOpenConversationWindow } from "./useDesktopAgentGUIOp
 import { useDesktopAgentGUIWorkbenchEvents } from "./useDesktopAgentGUIWorkbenchEvents.ts";
 import { useStableDesktopAgentGUIHostProps } from "./useStableDesktopAgentGUIHostProps.ts";
 import { resolveDesktopAgentGUIEmbeddedDesktopSize } from "./desktopAgentGUIEmbeddedFrame.ts";
+import { scheduleDesktopAgentGUIWorkbenchHydration } from "./desktopAgentGUIWorkbenchHydration.ts";
 import { IAgentEnvService } from "../services/agentEnvService.interface.ts";
 import { preloadDesktopAgentGuiMentionBrowse } from "../services/preloadDesktopAgentGuiMentionBrowse.ts";
 import { DESKTOP_AGENT_GUI_CURRENT_USER_ID } from "../services/desktopAgentGuiIdentity.ts";
@@ -700,6 +705,33 @@ function DesktopAgentGUIWorkbenchBodyAdapter({
   context,
   ...props
 }: DesktopAgentGUIWorkbenchBodyProps): JSX.Element {
+  const isVisuallyExposed = useWorkbenchSelector((state) =>
+    selectWorkbenchNodeIsVisuallyExposed(state, context.node.id)
+  );
+  const isBodyVisible = context.isVisible && isVisuallyExposed;
+  const [bodyHydrated, setBodyHydrated] = useState(
+    context.isFocused || isBodyVisible
+  );
+  useEffect(() => {
+    if (bodyHydrated || context.isFocused || isBodyVisible) {
+      if (!bodyHydrated) {
+        setBodyHydrated(true);
+      }
+      return;
+    }
+    return scheduleDesktopAgentGUIWorkbenchHydration(() => {
+      setBodyHydrated(true);
+    });
+  }, [bodyHydrated, context.isFocused, isBodyVisible]);
+  if (!bodyHydrated && !context.isFocused && !isBodyVisible) {
+    return (
+      <div
+        aria-hidden="true"
+        className="size-full bg-[var(--background-panel)]"
+        data-agent-gui-workbench-hydration="pending"
+      />
+    );
+  }
   const surface: DesktopAgentGUISurfaceContext = {
     activation: context.activation,
     displayMode: context.displayMode,
@@ -710,7 +742,7 @@ function DesktopAgentGUIWorkbenchBodyAdapter({
     isFocused: context.isFocused,
     isMinimized: context.node.isMinimized === true,
     isResizing: context.isResizing,
-    isVisible: context.isVisible,
+    isVisible: isBodyVisible,
     nodeId: context.node.id,
     nodeTitle: context.node.title,
     presentationMode: context.presentationMode,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchHydration.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchHydration.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createSequentialAgentGUIHydrationScheduler } from "./desktopAgentGUIWorkbenchHydration.ts";
+
+test("hydrates restored AgentGUI bodies one idle frame at a time", async () => {
+  const idleCallbacks: IdleRequestCallback[] = [];
+  const frameCallbacks: FrameRequestCallback[] = [];
+  const hydrated: string[] = [];
+  const schedule = createSequentialAgentGUIHydrationScheduler({
+    requestAnimationFrame(callback) {
+      frameCallbacks.push(callback);
+      return frameCallbacks.length;
+    },
+    requestIdleCallback(callback) {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    },
+    setTimeout() {
+      throw new Error("idle callback fallback should not run");
+    }
+  });
+
+  schedule(() => hydrated.push("first"));
+  schedule(() => hydrated.push("second"));
+  await Promise.resolve();
+
+  assert.equal(idleCallbacks.length, 1);
+  idleCallbacks.shift()?.({ didTimeout: false, timeRemaining: () => 10 });
+  frameCallbacks.shift()?.(0);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(hydrated, ["first"]);
+  assert.equal(idleCallbacks.length, 1);
+
+  idleCallbacks.shift()?.({ didTimeout: false, timeRemaining: () => 10 });
+  frameCallbacks.shift()?.(16);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(hydrated, ["first", "second"]);
+});
+
+test("skips canceled AgentGUI body hydration", async () => {
+  const frameCallbacks: FrameRequestCallback[] = [];
+  const schedule = createSequentialAgentGUIHydrationScheduler({
+    requestAnimationFrame(callback) {
+      frameCallbacks.push(callback);
+      return frameCallbacks.length;
+    },
+    setTimeout(callback) {
+      callback();
+      return 1;
+    }
+  });
+  let hydrated = false;
+  const cancel = schedule(() => {
+    hydrated = true;
+  });
+  cancel();
+  await Promise.resolve();
+  frameCallbacks.shift()?.(0);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal(hydrated, false);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchHydration.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchHydration.ts
@@ -1,0 +1,56 @@
+interface DesktopAgentGUIHydrationSchedulerScope {
+  requestAnimationFrame(callback: FrameRequestCallback): number;
+  requestIdleCallback?: (
+    callback: IdleRequestCallback,
+    options?: IdleRequestOptions
+  ) => number;
+  setTimeout(callback: () => void, timeout: number): number;
+}
+
+type CancelHydration = () => void;
+type ScheduleHydration = (hydrate: () => void) => CancelHydration;
+
+export function createSequentialAgentGUIHydrationScheduler(
+  scope: DesktopAgentGUIHydrationSchedulerScope
+): ScheduleHydration {
+  let tail = Promise.resolve();
+
+  return (hydrate) => {
+    let canceled = false;
+    const scheduled = tail
+      .then(() => waitForIdleFrame(scope))
+      .then(() => {
+        if (!canceled) {
+          hydrate();
+        }
+      });
+    tail = scheduled.catch(() => {});
+    return () => {
+      canceled = true;
+    };
+  };
+}
+
+let scheduleHydration: ScheduleHydration | null = null;
+
+export function scheduleDesktopAgentGUIWorkbenchHydration(
+  hydrate: () => void
+): CancelHydration {
+  scheduleHydration ??= createSequentialAgentGUIHydrationScheduler(window);
+  return scheduleHydration(hydrate);
+}
+
+function waitForIdleFrame(
+  scope: DesktopAgentGUIHydrationSchedulerScope
+): Promise<void> {
+  return new Promise((resolve) => {
+    const afterIdle = () => {
+      scope.requestAnimationFrame(() => resolve());
+    };
+    if (scope.requestIdleCallback) {
+      scope.requestIdleCallback(afterIdle, { timeout: 2_000 });
+      return;
+    }
+    scope.setTimeout(afterIdle, 0);
+  });
+}

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -919,14 +919,32 @@ The empty AgentGUI Hero renders its existing DOM player before initializing the
 optional WebGL carousel. A host projects whether the normal window presentation
 is currently visible; the carousel waits for that visibility and then browser
 idle time before creating its WebGL renderer. This keeps Genie restore work out
-of the WebGL creation task without exposing Genie state to AgentGUI. An existing
-scene remains allocated while the normal presentation is hidden, but cancels
-all render and spring animation frames until visibility returns. Once
+of the WebGL creation task without exposing Genie state to AgentGUI. A fully
+occluded presentation releases its scene, decoded images, observer, and wheel
+listener; exposure restores them after the reveal interaction settles. Once
 initialized, WebGL renders only for texture or size changes and carousel
-selection changes; the spring stops requesting frames after it settles. The
-DOM turntable record uses a compositor animation only in the active visible
-AgentGUI. Inactive surfaces preserve their current visual state without a
-JavaScript animation loop.
+selection changes; the spring stops requesting frames after it settles. The DOM
+turntable record uses a compositor animation only in the active visible
+AgentGUI, and composer prompt tips follow the same active-surface rule.
+Empty-Hero entry animations may fill backwards across their delay, but must
+release their final identity transform after completion so every mounted
+AgentGUI does not retain decorative compositor layers. An embedded AgentGUI
+skips those internal entry animations because the Workbench shell already owns
+its appearance transition. Background Workbench AgentGUI bodies remain mounted
+so drafts and local conversation presentation survive focus changes. Focus does
+not determine visibility. Workbench frame geometry and z-order classify bodies
+as fully occluded or visually exposed; partial exposure counts as visible.
+Only fully occluded bodies pause descendant animations and use
+`content-visibility: hidden`. Visible Empty-Hero surfaces may own carousel
+images, alignment observers, wheel input, and a Three.js/WebGL scene.
+Occlusion releases those resources; exposure restores the DOM presentation
+immediately and defers WebGL reconstruction until after the reveal interaction
+settles.
+On workspace restore, Desktop mounts the focused AgentGUI body immediately and
+hydrates inactive bodies sequentially after browser idle, one animation frame
+at a time. Window shells and persisted geometry remain synchronous; this
+staging is Desktop presentation work and does not enter engine or Session
+lifecycle state.
 WebGL scene readiness remains local presentation state; it must not enter
 `AgentActivityRuntime`, the workspace engine, or Workbench node state.
 

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -115,7 +115,9 @@ The capture runner ships `provider-switch`, `session-switch`,
 `virtualized-scroll-locator`, `virtualized-session-cycle`,
 `virtualized-oversized-active-turn`, `browser-behind-agent-gui-pixels`,
 `rail-scope-reveal`, `composer-input`, `composer-overflow-resize`, `workbench-window-lifecycle`,
-`desktop-window-state`, and `provider-status-focus-refresh`. List them with
+`workbench-window-drag`, `workbench-fifty-window-stress`,
+`desktop-window-state`, and
+`provider-status-focus-refresh`. List them with
 `--list-scenarios`; select one with
 `--scenario <id>`. Scenario modules own preparation, completion conditions,
 semantic assertions, milestones, and metadata; runtime startup, trace capture,
@@ -176,6 +178,20 @@ the draft.
 
 `workbench-window-lifecycle` measures the internal AgentGUI Workbench node's
 minimize, restore, maximize, unmaximize, close, and reopen mechanics.
+`workbench-window-drag` requires at least three mounted AgentGUI Workbench
+windows. It drives 120 trusted pointer moves through Chromium and fails when the
+startup or drag emits a Chromium tile-memory warning, or when the drag records
+more than 20 CSS animation iterations. This catches background AgentGUI
+animations that retain too many compositor tiles while windows restore or move.
+Before the drag marker starts, the scenario waits for staged background-body
+hydration to finish and for the resulting DOM mutations and images to settle,
+so startup work is checked separately instead of leaking into the drag window.
+`workbench-fifty-window-stress` rewrites only the isolated performance snapshot
+to contain exactly 50 mounted AgentGUI nodes. It verifies startup, focuses an
+exposed background window without remounting its body, then drags that window.
+The scenario rejects tile-memory warnings, any geometrically exposed body that
+becomes hidden, more than 20 animation iterations, or a renderer task above
+50 ms.
 `desktop-window-state` measures the owning Electron window's minimize, restore,
 maximize, and unmaximize states through typed host-window APIs and is currently
 macOS-only because only that host emits typed minimize-state events. Native

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -257,20 +257,45 @@
   In the trace, group `FunctionCall` or `v8.callFunction` events by `url` and
   `functionName`. Hidden animation players often still appear as repeated
   `requestAnimationFrame` callbacks even when their DOM node has
-  `opacity: 0`.
+  `opacity: 0`. Also inspect `animationiteration` volume and completed CSS
+  entry animations whose `fill-mode: both` leaves an identity `transform` on
+  every mounted window.
 - Root cause:
   CSS-hidden animation elements are still live renderers. An autoplay/looping
   Lottie, canvas, or WebGL player can keep scheduling frames and force layer
-  updates across every mounted instance.
+  updates across every mounted instance. CSS can produce the same pressure:
+  inactive windows may keep infinite transform/opacity animations running, and
+  a completed entry animation with forwards fill can retain a compositor layer
+  long after its visual work ends.
 - Fix:
   Mount animation players only while the animation is actually visible, and
   defer loading third-party animation runtimes until an active state needs
-  them. Do not rely on `opacity`, `visibility`, or off-screen placement to stop
-  playback.
+  them. When a workspace restores many heavy bodies, render the active body
+  immediately but hydrate inactive bodies sequentially after idle, one
+  animation frame at a time; keep their shells and saved geometry visible
+  throughout. Once mounted, derive visual exposure from Workbench geometry and
+  z-order, not keyboard focus. Pause descendant CSS animations only while a
+  window is fully occluded. A partially exposed window remains fully painted;
+  only a window whose frame is completely covered may use
+  `content-visibility: hidden`. Release imperative resources such as WebGL
+  scenes, decoded carousel images, observers, and non-passive listeners while
+  fully occluded. Avoid running a body's entry animation when its host shell
+  already owns the appearance transition. For delayed entry animations whose
+  normal styles already match the final keyframe, use backwards fill so the
+  initial keyframe covers the delay and the final identity transform is
+  released. Do not rely on `opacity`, `visibility`, or off-screen placement to
+  stop playback.
 - Validation:
   Re-record a short DevTools trace after the fix. Idle UI should no longer show
   the hidden player's function as a high-frequency `requestAnimationFrame`
-  source, and Chromium tile memory warnings should stop during idle.
+  source, and Chromium tile memory warnings should stop during idle. For
+  multi-window AgentGUI changes, run
+  `pnpm perf:agent-gui -- --scenario workbench-window-drag`; it moves one
+  window while at least three are mounted and rejects tile-memory warnings or
+  excessive background animation iterations. Use
+  `--scenario workbench-fifty-window-stress` for the 50-window startup,
+  background-focus, retained-DOM, geometric exposure, drag, and 50 ms
+  renderer-task budgets.
 
 ### IME composition breaks fuzzy search or controlled search inputs
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -575,6 +575,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   });
   const { fileDropOverlayActive, fileDropOverlayHost } = focusAndDrop;
   const layout = useComposerLayout({
+    isActive,
     isHeroLayout,
     inputDisabled,
     projectMissingProbeEnabled,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.spec.tsx
@@ -91,10 +91,52 @@ function installIdleCallbackQueue(): {
   };
 }
 
+function installBackgroundTaskQueue(): {
+  flushNext(): Promise<void>;
+  pendingDelays(): number[];
+} {
+  const tasks: Array<{
+    callback: () => void;
+    delay: number;
+    signal: AbortSignal;
+  }> = [];
+  const scheduler = {
+    postTask(
+      callback: () => void,
+      options: { delay: number; signal: AbortSignal }
+    ): Promise<void> {
+      tasks.push({ callback, delay: options.delay, signal: options.signal });
+      return Promise.resolve();
+    }
+  };
+  vi.stubGlobal("scheduler", scheduler);
+  Object.defineProperty(window, "scheduler", {
+    configurable: true,
+    value: scheduler
+  });
+  return {
+    async flushNext() {
+      const task = tasks.shift();
+      if (!task) {
+        throw new Error("Expected a pending background task");
+      }
+      if (!task.signal.aborted) {
+        task.callback();
+      }
+      await Promise.resolve();
+    },
+    pendingDelays() {
+      return tasks.map((task) => task.delay);
+    }
+  };
+}
+
 afterEach(() => {
   sceneCreate.mockReset();
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  Reflect.deleteProperty(window, "scheduler");
 });
 
 describe("AgentGUIHeroAgentCarousel", () => {
@@ -169,6 +211,7 @@ describe("AgentGUIHeroAgentCarousel", () => {
   it("waits for host presentation visibility before scheduling WebGL", async () => {
     const frames = installAnimationFrameQueue();
     const idle = installIdleCallbackQueue();
+    const backgroundTasks = installBackgroundTaskQueue();
     vi.stubGlobal("Image", undefined);
     sceneCreate.mockReturnValue({
       dispose: vi.fn(),
@@ -185,16 +228,22 @@ describe("AgentGUIHeroAgentCarousel", () => {
           <AgentGUIHeroAgentCarousel isVisible={false} items={[item]} />
         );
       });
-      await act(async () => {
-        frames.flushNext();
-        frames.flushNext();
-      });
 
+      expect(frames.pendingIDs()).toHaveLength(0);
       expect(idle.pendingIDs()).toHaveLength(0);
       expect(sceneCreate).not.toHaveBeenCalled();
 
       await act(async () => {
         root.render(<AgentGUIHeroAgentCarousel isVisible items={[item]} />);
+      });
+      await act(async () => {
+        frames.flushNext();
+        frames.flushNext();
+      });
+      expect(idle.pendingIDs()).toHaveLength(0);
+      expect(backgroundTasks.pendingDelays()[0]).toBeGreaterThanOrEqual(2_900);
+      await act(async () => {
+        await backgroundTasks.flushNext();
       });
       expect(idle.pendingIDs()).toHaveLength(1);
       expect(sceneCreate).not.toHaveBeenCalled();
@@ -211,15 +260,15 @@ describe("AgentGUIHeroAgentCarousel", () => {
     }
   });
 
-  it("pauses and resumes an existing WebGL scene with host visibility", async () => {
+  it("releases hidden WebGL and recreates it when visible", async () => {
     const frames = installAnimationFrameQueue();
     const idle = installIdleCallbackQueue();
+    const backgroundTasks = installBackgroundTaskQueue();
     vi.stubGlobal("Image", undefined);
     const scene = {
       dispose: vi.fn(),
       moveTo: vi.fn(),
-      setSize: vi.fn(),
-      setVisible: vi.fn()
+      setSize: vi.fn()
     };
     sceneCreate.mockReturnValue(scene);
     const container = document.createElement("div");
@@ -242,14 +291,18 @@ describe("AgentGUIHeroAgentCarousel", () => {
           <AgentGUIHeroAgentCarousel isVisible={false} items={[item]} />
         );
       });
-      expect(scene.setVisible).toHaveBeenLastCalledWith(false);
+      expect(scene.dispose).toHaveBeenCalledOnce();
 
       await act(async () => {
         root.render(<AgentGUIHeroAgentCarousel isVisible items={[item]} />);
       });
-      expect(scene.setVisible).toHaveBeenLastCalledWith(true);
-      expect(sceneCreate).toHaveBeenCalledOnce();
-      expect(scene.dispose).not.toHaveBeenCalled();
+      await act(async () => {
+        await backgroundTasks.flushNext();
+      });
+      await act(async () => {
+        idle.flushNext();
+      });
+      expect(sceneCreate).toHaveBeenCalledTimes(2);
     } finally {
       await act(async () => {
         root.unmount();
@@ -265,8 +318,7 @@ describe("AgentGUIHeroAgentCarousel", () => {
     const scene = {
       dispose: vi.fn(),
       moveTo: vi.fn(),
-      setSize: vi.fn(),
-      setVisible: vi.fn()
+      setSize: vi.fn()
     };
     sceneCreate.mockReturnValue(scene);
     const container = document.createElement("div");
@@ -288,6 +340,7 @@ describe("AgentGUIHeroAgentCarousel", () => {
         frames.flushNext();
         idle.flushNext();
       });
+      expect(sceneCreate).toHaveBeenCalledOnce();
       expect(
         container.querySelector(".agent-gui-vinyl-player__record--playing")
       ).toBeNull();
@@ -300,6 +353,7 @@ describe("AgentGUIHeroAgentCarousel", () => {
       expect(
         container.querySelector(".agent-gui-vinyl-player__record--playing")
       ).not.toBeNull();
+      expect(sceneCreate).toHaveBeenCalledOnce();
 
       await act(async () => {
         root.render(
@@ -314,7 +368,7 @@ describe("AgentGUIHeroAgentCarousel", () => {
         container.querySelector(".agent-gui-vinyl-player__record--playing")
       ).toBeNull();
       expect(sceneCreate).toHaveBeenCalledOnce();
-      expect(scene.dispose).not.toHaveBeenCalled();
+      expect(scene.dispose).toHaveBeenCalledOnce();
     } finally {
       await act(async () => {
         root.unmount();

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.tsx
@@ -35,10 +35,22 @@ interface AgentGUIHeroAgentCarouselState {
   imagesReady: boolean;
 }
 
+interface AgentGUIHeroCarouselTaskScheduler {
+  postTask(
+    callback: () => void,
+    options: {
+      delay: number;
+      priority: "background";
+      signal: AbortSignal;
+    }
+  ): Promise<unknown>;
+}
+
 const CAROUSEL_WHEEL_STEP_THRESHOLD = 42;
 const CAROUSEL_WHEEL_STEP_COOLDOWN_MS = 110;
 const CAROUSEL_DRAG_STEP_PX = 52;
 const CAROUSEL_SCENE_IDLE_TIMEOUT_MS = 1_000;
+const CAROUSEL_REACTIVATION_SCENE_DELAY_MS = 3_000;
 
 function activeAgentIndex(props: AgentGUIHeroAgentCarouselProps): number {
   if (!props.activeAgentTargetId) {
@@ -79,6 +91,8 @@ export class AgentGUIHeroAgentCarousel extends Component<
   private resizeObserver: ResizeObserver | null = null;
   private firstPaintFrameId: number | null = null;
   private firstPaintReady = false;
+  private sceneMountDelayController: AbortController | null = null;
+  private sceneMountEligibleAt = 0;
   private sceneMountIdleId: number | null = null;
   private imagePreloadGeneration = 0;
   private imageLoad: AgentGuiHeroCarouselImageLoad | null = null;
@@ -99,14 +113,29 @@ export class AgentGUIHeroAgentCarousel extends Component<
   };
 
   componentDidMount(): void {
-    this.waitForFirstPaint();
-    this.preloadImages();
+    if (this.ownsImperativeResources()) {
+      this.activateImperativeResources();
+    }
     this.syncWheelListener();
   }
 
   componentDidUpdate(previousProps: AgentGUIHeroAgentCarouselProps): void {
     const iconKey = carouselIconKey(this.props.items);
+    const ownedResources = this.props.isVisible !== false;
+    const previouslyOwnedResources = previousProps.isVisible !== false;
+
+    if (!ownedResources) {
+      if (previouslyOwnedResources) {
+        this.deactivateImperativeResources(iconKey);
+      } else if (iconKey !== this.state.iconKey) {
+        this.resetPreloadedImages(iconKey);
+      }
+      this.syncWheelListener();
+      return;
+    }
+
     if (iconKey !== this.state.iconKey) {
+      this.cancelImagePreload();
       this.disposeScene();
       this.setState(
         {
@@ -117,19 +146,13 @@ export class AgentGUIHeroAgentCarousel extends Component<
           images: [],
           imagesReady: this.props.items.length === 0
         },
-        () => this.preloadImages()
+        () => this.activateImperativeResources()
       );
       return;
     }
 
-    if (previousProps.isVisible !== this.props.isVisible) {
-      if (this.props.isVisible === false) {
-        this.cancelScheduledSceneMount();
-        this.scene?.setVisible(false);
-      } else {
-        this.scene?.setVisible(true);
-        this.scheduleSceneMount();
-      }
+    if (!previouslyOwnedResources) {
+      this.activateImperativeResources(true);
     }
     if (
       previousProps.activeAgentTargetId !== this.props.activeAgentTargetId ||
@@ -145,23 +168,69 @@ export class AgentGUIHeroAgentCarousel extends Component<
   }
 
   componentWillUnmount(): void {
-    this.imagePreloadGeneration += 1;
+    this.cancelImagePreload();
     if (this.firstPaintFrameId !== null) {
       window.cancelAnimationFrame(this.firstPaintFrameId);
       this.firstPaintFrameId = null;
     }
-    this.cancelScheduledSceneMount();
     this.removeWheelListener();
     this.disposeScene();
-    this.imageLoad?.cancel();
-    this.imageLoad = null;
   }
 
   private interactive(): boolean {
     return this.props.onProviderSelect != null && this.props.items.length > 0;
   }
 
+  private ownsImperativeResources(): boolean {
+    return this.props.isVisible !== false;
+  }
+
+  private activateImperativeResources(deferScene = false): void {
+    if (!this.ownsImperativeResources()) {
+      return;
+    }
+    this.sceneMountEligibleAt = deferScene
+      ? performance.now() + CAROUSEL_REACTIVATION_SCENE_DELAY_MS
+      : 0;
+    this.waitForFirstPaint();
+    if (!this.state.imagesReady) {
+      this.preloadImages();
+    } else {
+      this.scheduleSceneMount();
+    }
+  }
+
+  private deactivateImperativeResources(iconKey: string): void {
+    this.cancelImagePreload();
+    if (this.firstPaintFrameId !== null) {
+      window.cancelAnimationFrame(this.firstPaintFrameId);
+      this.firstPaintFrameId = null;
+    }
+    this.removeWheelListener();
+    this.disposeScene();
+    this.resetPreloadedImages(iconKey);
+  }
+
+  private resetPreloadedImages(iconKey: string): void {
+    this.setState({
+      badgeImages: [],
+      coverImages: [],
+      iconKey,
+      images: [],
+      imagesReady: this.props.items.length === 0
+    });
+  }
+
+  private cancelImagePreload(): void {
+    this.imagePreloadGeneration += 1;
+    this.imageLoad?.cancel();
+    this.imageLoad = null;
+  }
+
   private waitForFirstPaint(): void {
+    if (this.firstPaintReady || this.firstPaintFrameId !== null) {
+      return;
+    }
     this.firstPaintFrameId = window.requestAnimationFrame(() => {
       this.firstPaintFrameId = window.requestAnimationFrame(() => {
         this.firstPaintFrameId = null;
@@ -209,7 +278,8 @@ export class AgentGUIHeroAgentCarousel extends Component<
     void imageLoad.result.then((preloaded) => {
       if (
         generation !== this.imagePreloadGeneration ||
-        carouselIconKey(this.props.items) !== this.state.iconKey
+        carouselIconKey(this.props.items) !== this.state.iconKey ||
+        !this.ownsImperativeResources()
       ) {
         return;
       }
@@ -226,10 +296,50 @@ export class AgentGUIHeroAgentCarousel extends Component<
   }
 
   private scheduleSceneMount(): void {
+    const sceneMountDelay = this.sceneMountEligibleAt - performance.now();
+    if (sceneMountDelay > 0) {
+      if (this.sceneMountDelayController !== null) {
+        return;
+      }
+      const scheduler = (
+        window as Window & {
+          scheduler?: AgentGUIHeroCarouselTaskScheduler;
+        }
+      ).scheduler;
+      if (scheduler) {
+        const controller = new AbortController();
+        this.sceneMountDelayController = controller;
+        void scheduler
+          .postTask(
+            () => {
+              this.sceneMountDelayController = null;
+              this.sceneMountEligibleAt = 0;
+              this.scheduleSceneMount();
+            },
+            {
+              delay: sceneMountDelay,
+              priority: "background",
+              signal: controller.signal
+            }
+          )
+          .catch((error: unknown) => {
+            if (error instanceof DOMException && error.name === "AbortError") {
+              return;
+            }
+            if (this.sceneMountDelayController === controller) {
+              this.sceneMountDelayController = null;
+              this.sceneMountEligibleAt = 0;
+              this.scheduleSceneMount();
+            }
+          });
+        return;
+      }
+      this.sceneMountEligibleAt = 0;
+    }
     if (
       this.scene ||
       this.sceneMountIdleId !== null ||
-      this.props.isVisible === false ||
+      !this.ownsImperativeResources() ||
       !this.canvasRef.current ||
       !this.stageRef.current ||
       !this.firstPaintReady ||
@@ -254,6 +364,9 @@ export class AgentGUIHeroAgentCarousel extends Component<
   }
 
   private cancelScheduledSceneMount(): void {
+    this.sceneMountDelayController?.abort();
+    this.sceneMountDelayController = null;
+    this.sceneMountEligibleAt = 0;
     if (this.sceneMountIdleId !== null) {
       window.cancelIdleCallback(this.sceneMountIdleId);
       this.sceneMountIdleId = null;
@@ -267,7 +380,7 @@ export class AgentGUIHeroAgentCarousel extends Component<
       this.scene ||
       !canvas ||
       !stage ||
-      this.props.isVisible === false ||
+      !this.ownsImperativeResources() ||
       !this.firstPaintReady ||
       !this.state.imagesReady ||
       this.props.items.length === 0
@@ -311,7 +424,7 @@ export class AgentGUIHeroAgentCarousel extends Component<
   private syncWheelListener(): void {
     const stage = this.stageRef.current;
     const shouldAttach = Boolean(
-      stage && this.props.isVisible !== false && this.interactive()
+      stage && this.ownsImperativeResources() && this.interactive()
     );
     if (shouldAttach && !this.wheelListenerAttached) {
       stage!.addEventListener("wheel", this.handleWheel, { passive: false });

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -547,6 +547,8 @@ export function AgentGUINodeView({
         <div
           ref={layoutElementRef}
           className={styles.layout}
+          data-agent-gui-active={isActive ? "true" : "false"}
+          data-agent-gui-visible={isVisible ? "true" : "false"}
           data-rail-resizing={isRailResizing ? "true" : undefined}
           style={layoutStyle}
         >

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.spec.ts
@@ -445,36 +445,6 @@ describe("AgentGuiHeroCarouselScene", () => {
     scene?.dispose();
   });
 
-  it("cancels every frame while hidden and resumes without rebuilding", () => {
-    let nextFrameID = 1;
-    const pendingFrames = new Map<number, FrameRequestCallback>();
-    globalThis.requestAnimationFrame = vi.fn((callback) => {
-      const frameID = nextFrameID;
-      nextFrameID += 1;
-      pendingFrames.set(frameID, callback);
-      return frameID;
-    });
-    globalThis.cancelAnimationFrame = vi.fn((frameID) => {
-      pendingFrames.delete(frameID);
-    });
-    const scene = createSceneWithBadge(null);
-
-    expect(scene).not.toBeNull();
-    expect(pendingFrames.size).toBeGreaterThan(0);
-
-    scene?.setVisible(false);
-    expect(pendingFrames.size).toBe(0);
-
-    const hiddenRenderCount = threeState.renderCount;
-    scene?.setSize(320, 112);
-    expect(threeState.renderCount).toBe(hiddenRenderCount);
-    expect(pendingFrames.size).toBe(0);
-
-    scene?.setVisible(true);
-    expect(pendingFrames.size).toBe(1);
-    scene?.dispose();
-  });
-
   it("disposes a rejected texture and keeps the fallback when WebGL upload fails", () => {
     threeState.failTextureUpload = true;
     const scene = createSceneWithBadge(createLoadedImage());

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.ts
@@ -138,7 +138,6 @@ export class AgentGuiHeroCarouselScene {
   private renderFrameHandle: number | null = null;
   private springFrameHandle: number | null = null;
   private lastFrameAt: number | null = null;
-  private visible = true;
   private disposed = false;
 
   private constructor(options: AgentGuiHeroCarouselSceneOptions) {
@@ -278,40 +277,7 @@ export class AgentGuiHeroCarouselScene {
     // setSize clears the drawing buffer. Render synchronously so a window
     // resize never exposes that cleared frame while the next animation frame
     // is pending during interactive window dragging.
-    if (this.visible) {
-      this.renderer.render(this.scene, this.camera);
-    }
-  }
-
-  setVisible(visible: boolean): void {
-    if (this.disposed || this.visible === visible) {
-      return;
-    }
-    this.visible = visible;
-    this.cancelScheduledFrames();
-    if (!visible) {
-      return;
-    }
-
-    const hasPendingMotion =
-      Math.abs(this.target - this.scroll) > SPRING_SETTLE_EPSILON ||
-      Math.abs(this.velocity) > SPRING_SETTLE_VELOCITY;
-    if (this.prefersReducedMotion()) {
-      this.scroll = this.target;
-      this.velocity = 0;
-      this.applyPoses();
-      this.requestRender();
-      if (hasPendingMotion) {
-        this.onSettle(this.targetIndex());
-      }
-      return;
-    }
-
-    if (hasPendingMotion) {
-      this.animate();
-      return;
-    }
-    this.requestRender();
+    this.renderer.render(this.scene, this.camera);
   }
 
   // Agent index of the tile slot the wheel is heading to.
@@ -461,7 +427,7 @@ export class AgentGuiHeroCarouselScene {
   }
 
   private animate(): void {
-    if (this.disposed || !this.visible) {
+    if (this.disposed) {
       return;
     }
     if (this.prefersReducedMotion()) {
@@ -500,7 +466,7 @@ export class AgentGuiHeroCarouselScene {
 
   private readonly frame = (now: number): void => {
     this.springFrameHandle = null;
-    if (this.disposed || !this.visible) {
+    if (this.disposed) {
       return;
     }
     const dt =
@@ -532,7 +498,6 @@ export class AgentGuiHeroCarouselScene {
   private requestRender(): void {
     if (
       this.disposed ||
-      !this.visible ||
       this.renderFrameHandle !== null ||
       this.springFrameHandle !== null
     ) {
@@ -540,7 +505,7 @@ export class AgentGuiHeroCarouselScene {
     }
     this.renderFrameHandle = requestAnimationFrame(() => {
       this.renderFrameHandle = null;
-      if (!this.disposed && this.visible) {
+      if (!this.disposed) {
         this.renderer.render(this.scene, this.camera);
       }
     });

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.spec.tsx
@@ -8,6 +8,38 @@ afterEach(() => {
 });
 
 describe("useComposerLayout", () => {
+  it("rotates prompt tips only while the AgentGUI window is active", () => {
+    const promptTips = [
+      { id: "tip-1", label: "First", prompt: "Prompt one" },
+      { id: "tip-2", label: "Second", prompt: "Prompt two" }
+    ];
+    const { result, rerender } = renderHook(
+      ({ isActive }) =>
+        useComposerLayout(
+          createComposerLayoutInput({
+            isActive,
+            isHeroLayout: true,
+            promptTips
+          })
+        ),
+      { initialProps: { isActive: false } }
+    );
+
+    expect(result.current.rotatingPromptTips).toEqual([promptTips[0]]);
+    expect(result.current.promptTipStyle).toBeUndefined();
+
+    rerender({ isActive: true });
+
+    expect(result.current.rotatingPromptTips).toEqual([
+      ...promptTips,
+      promptTips[0]
+    ]);
+    expect(result.current.promptTipStyle).toMatchObject({
+      "--agent-gui-prompt-tip-count": 2,
+      "--agent-gui-prompt-tip-cycle-duration": "10400ms"
+    });
+  });
+
   it("does not probe a locked project while its session is still being created", () => {
     const { result } = renderHook(() =>
       useComposerLayout(
@@ -307,6 +339,7 @@ function createComposerLayoutInput(
   overrides: Partial<ComposerLayoutInput>
 ): ComposerLayoutInput {
   return {
+    isActive: true,
     isHeroLayout: false,
     inputDisabled: false,
     projectMissingProbeEnabled: true,

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.ts
@@ -52,6 +52,7 @@ function hasInlineOverflow(element: HTMLElement | null): boolean {
 }
 
 interface UseComposerLayoutInput {
+  isActive: boolean;
   isHeroLayout: boolean;
   inputDisabled: boolean;
   projectMissingProbeEnabled: boolean;
@@ -71,6 +72,7 @@ interface UseComposerLayoutInput {
 }
 
 export function useComposerLayout({
+  isActive,
   isHeroLayout,
   inputDisabled,
   projectMissingProbeEnabled,
@@ -107,21 +109,21 @@ export function useComposerLayout({
   const activePromptTipText = activePromptTip
     ? `${labels.promptTipsPrefix}${activePromptTip.label} · ${activePromptTip.prompt}`
     : "";
+  const shouldRotatePromptTips = isActive && promptTips.length > 1;
   const rotatingPromptTips =
-    activePromptTip && promptTips.length > 1
+    activePromptTip && shouldRotatePromptTips
       ? [...promptTips, activePromptTip]
       : activePromptTip
         ? [activePromptTip]
         : [];
-  const promptTipStyle =
-    promptTips.length > 1
-      ? ({
-          "--agent-gui-prompt-tip-count": promptTips.length,
-          "--agent-gui-prompt-tip-cycle-duration": `${
-            promptTips.length * PROMPT_TIP_CYCLE_STEP_MS
-          }ms`
-        } as CSSProperties)
-      : undefined;
+  const promptTipStyle = shouldRotatePromptTips
+    ? ({
+        "--agent-gui-prompt-tip-count": promptTips.length,
+        "--agent-gui-prompt-tip-cycle-duration": `${
+          promptTips.length * PROMPT_TIP_CYCLE_STEP_MS
+        }ms`
+      } as CSSProperties)
+    : undefined;
   useLayoutEffect(() => {
     if (!activePromptTipId) {
       setIsPromptTipOverflowing(false);

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPresentation.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPresentation.tsx
@@ -324,7 +324,7 @@ export function useComposerPresentation(input: Input) {
       key={activePromptTip.id}
       ref={promptTipRef}
       className={styles.composerPromptTip}
-      data-rotating={promptTips.length > 1 ? "true" : undefined}
+      data-rotating={rotatingPromptTips.length > 1 ? "true" : undefined}
       data-testid="agent-gui-prompt-tip"
       style={promptTipStyle}
     >

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyHeroCarouselStage.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyHeroCarouselStage.spec.tsx
@@ -32,10 +32,30 @@ afterEach(() => {
 });
 
 describe("AgentGUIEmptyHeroCarouselStage", () => {
+  it("does not measure a fully occluded carousel", () => {
+    const getBoundingClientRect = vi.spyOn(
+      HTMLElement.prototype,
+      "getBoundingClientRect"
+    );
+
+    render(
+      <AgentGUIEmptyHeroCarouselStage
+        isActive={false}
+        isVisible={false}
+        items={items}
+        providerSelectLabel="Select provider"
+      >
+        <div data-carousel-placeholder />
+      </AgentGUIEmptyHeroCarouselStage>
+    );
+
+    expect(getBoundingClientRect).not.toHaveBeenCalled();
+  });
+
   it("measures live carousel alignment", () => {
     const { container } = render(
       <AgentGUIEmptyHeroCarouselStage
-        isActive
+        isActive={false}
         isVisible
         items={items}
         providerSelectLabel="Select provider"

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyHeroCarouselStage.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyHeroCarouselStage.tsx
@@ -105,7 +105,12 @@ export class AgentGUIEmptyHeroCarouselStage extends Component<AgentGUIEmptyHeroC
   }
 
   private canAlign(): boolean {
-    return Boolean(this.props.items.length > 1 && this.stage && this.layer);
+    return Boolean(
+      this.props.isVisible &&
+      this.props.items.length > 1 &&
+      this.stage &&
+      this.layer
+    );
   }
 
   private stopAlignment(): void {

--- a/packages/agent/gui/agent-gui/shared/WorkspaceNodeWindow.tsx
+++ b/packages/agent/gui/agent-gui/shared/WorkspaceNodeWindow.tsx
@@ -186,6 +186,7 @@ export function WorkspaceNodeWindow({
       )}
       style={rootStyle}
       data-workspace-node-window-root="true"
+      data-workspace-node-window-appearance={appearance}
       data-workspace-node-window-kind={kind}
       data-workspace-node-window-maximized={isMaximized ? "true" : "false"}
       data-workspace-node-window-muted={isMuted ? "true" : "false"}

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -874,7 +874,6 @@ aside.workspace-agents-status-panel
   background: var(--transparency-block);
   cursor: grab;
   transition: background-color 160ms ease-in-out;
-  will-change: transform;
 }
 
 .workspace-agents-status-panel__scrollbar-thumb {
@@ -884,7 +883,6 @@ aside.workspace-agents-status-panel
   background: var(--transparency-block);
   cursor: grab;
   transition: background-color 160ms ease-in-out;
-  will-change: transform;
 }
 
 .tsh-custom-scrollbar:hover .tsh-custom-scrollbar__thumb,
@@ -903,6 +901,7 @@ aside.workspace-agents-status-panel
   .workspace-agents-status-panel__scrollbar-thumb {
   background: var(--transparency-hover);
   cursor: grabbing;
+  will-change: transform;
 }
 
 .agent-tool-scroll-area__scrollbar {
@@ -1962,7 +1961,6 @@ aside.workspace-agents-status-panel
     height 220ms ease,
     opacity 160ms ease,
     transform 180ms ease;
-  will-change: height, opacity, transform;
 }
 
 .agent-collapsible-reveal[data-expanded="true"] {
@@ -2812,7 +2810,6 @@ aside.workspace-agents-status-panel
   transition:
     border-radius 220ms cubic-bezier(0.16, 1, 0.3, 1),
     transform 280ms var(--agent-gui-chrome-card-spring);
-  will-change: transform;
 }
 
 @keyframes agent-gui-chrome-card-enter {
@@ -8842,16 +8839,17 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   position: absolute;
   inset: 0;
   /* Match the APNG's padded 44px canvas to the static icon's visual size. */
-  transform: translateZ(0) scale(1.3);
+  transform: scale(1.3);
   filter: var(--agent-gui-handoff-animation-filter, none);
   opacity: 0;
   pointer-events: none;
-  backface-visibility: hidden;
-  will-change: opacity, transform;
 }
 
 .agent-gui-node__composer-handoff-icon-animated[data-active="true"] {
+  transform: translateZ(0) scale(1.3);
   opacity: 1;
+  backface-visibility: hidden;
+  will-change: opacity, transform;
 }
 
 .agent-gui-node__composer-tutti-mode-icon {
@@ -8891,15 +8889,15 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   inset: 0;
   /* Match the 16px static mark exactly; the APNG canvas already pads the
     snapping hand and bursting stars, so no enlargement is applied. */
-  transform: translateZ(0);
   opacity: 0;
   pointer-events: none;
-  backface-visibility: hidden;
-  will-change: opacity, transform;
 }
 
 .agent-gui-node__composer-tutti-mode-icon-animated[data-active="true"] {
+  transform: translateZ(0);
   opacity: 1;
+  backface-visibility: hidden;
+  will-change: opacity, transform;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -8976,8 +8974,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 .agent-gui-node__composer-prompt-tip-track {
   display: block;
   min-width: 0;
-  animation: agent-gui-node-prompt-tip-in 180ms ease both;
-  will-change: transform;
+  animation: agent-gui-node-prompt-tip-in 180ms ease backwards;
 }
 
 .agent-gui-node__composer-prompt-tip[data-rotating="true"]
@@ -8985,6 +8982,15 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   animation: agent-gui-node-prompt-tip-track
     var(--agent-gui-prompt-tip-cycle-duration)
     steps(var(--agent-gui-prompt-tip-count)) infinite;
+  will-change: transform;
+}
+
+.agent-gui-node__layout[data-agent-gui-active="false"]
+  .agent-gui-node__composer-prompt-tip-track,
+.agent-gui-node__layout[data-agent-gui-active="false"]
+  .agent-gui-node__composer-prompt-tip-item {
+  animation: none;
+  will-change: auto;
 }
 
 .agent-gui-node__composer-prompt-tip-item {
@@ -9927,7 +9933,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   height: 48px;
   object-fit: contain;
   animation: agent-gui-empty-hero-enter 260ms cubic-bezier(0.16, 1, 0.3, 1) 40ms
-    both;
+    backwards;
 }
 
 /* Empty-hero agent carousel ("All" tab): a three.js ring of same-sized agent
@@ -9942,7 +9948,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   outline: none;
   touch-action: pan-y;
   animation: agent-gui-empty-hero-enter 260ms cubic-bezier(0.16, 1, 0.3, 1) 40ms
-    both;
+    backwards;
 }
 
 /* Reference VinylPlayer structure, scaled from 440px to the 112px hero slot. */
@@ -10303,7 +10309,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   line-height: 1.3;
   font-weight: 500;
   animation: agent-gui-empty-hero-enter 280ms cubic-bezier(0.16, 1, 0.3, 1)
-    110ms both;
+    110ms backwards;
 }
 
 .agent-gui-node__empty-hero-provider {
@@ -10339,7 +10345,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   font-size: 14px;
   line-height: 1.55;
   animation: agent-gui-empty-hero-enter 280ms cubic-bezier(0.16, 1, 0.3, 1)
-    150ms both;
+    150ms backwards;
 }
 
 .agent-gui-node__empty-provider-gate-status {
@@ -10348,14 +10354,14 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   font-size: 13px;
   line-height: 20px;
   animation: agent-gui-empty-hero-enter 280ms cubic-bezier(0.16, 1, 0.3, 1)
-    170ms both;
+    170ms backwards;
 }
 
 .agent-gui-node__empty-provider-gate-action {
   /* Container gap is 8px; add 16px so the description-to-button spacing is 24px. */
   margin-top: 16px;
   animation: agent-gui-empty-hero-enter 300ms cubic-bezier(0.16, 1, 0.3, 1)
-    190ms both;
+    190ms backwards;
 }
 
 .agent-gui-node__empty-hero-provider-select {
@@ -10407,7 +10413,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 
 .agent-gui-node__empty-hero-body > .agent-gui-node__composer-hero {
   animation: agent-gui-empty-hero-enter 300ms cubic-bezier(0.16, 1, 0.3, 1)
-    180ms both;
+    180ms backwards;
 }
 
 .agent-gui-node__empty-hero-suggestions {
@@ -10418,7 +10424,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   gap: 12px;
   justify-items: stretch;
   animation: agent-gui-empty-hero-enter 300ms cubic-bezier(0.16, 1, 0.3, 1)
-    240ms both;
+    240ms backwards;
 }
 
 .agent-gui-node__empty-hero-suggestions-chips {
@@ -10479,7 +10485,8 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   background: var(--background-fronted);
   padding: 8px;
   box-shadow: 0 12px 32px -12px rgba(0, 0, 0, 0.28);
-  animation: agent-gui-empty-hero-enter 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation: agent-gui-empty-hero-enter 220ms cubic-bezier(0.16, 1, 0.3, 1)
+    backwards;
 }
 
 .agent-gui-node__empty-hero-suggestions-card-header {
@@ -10563,6 +10570,28 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   .agent-gui-node__empty-hero-body > .agent-gui-node__empty-hero-suggestions {
     width: 100%;
   }
+}
+
+[data-workspace-node-window-kind="agentGui"][data-workspace-node-window-appearance="embedded"]
+  .agent-gui-node__empty-hero-icon-effect,
+[data-workspace-node-window-kind="agentGui"][data-workspace-node-window-appearance="embedded"]
+  .agent-gui-node__empty-hero-carousel,
+[data-workspace-node-window-kind="agentGui"][data-workspace-node-window-appearance="embedded"]
+  .agent-gui-node__empty-hero-title,
+[data-workspace-node-window-kind="agentGui"][data-workspace-node-window-appearance="embedded"]
+  .agent-gui-node__empty-provider-gate-description,
+[data-workspace-node-window-kind="agentGui"][data-workspace-node-window-appearance="embedded"]
+  .agent-gui-node__empty-provider-gate-status,
+[data-workspace-node-window-kind="agentGui"][data-workspace-node-window-appearance="embedded"]
+  .agent-gui-node__empty-provider-gate-action,
+[data-workspace-node-window-kind="agentGui"][data-workspace-node-window-appearance="embedded"]
+  .agent-gui-node__empty-hero-body
+  > .agent-gui-node__composer-hero,
+[data-workspace-node-window-kind="agentGui"][data-workspace-node-window-appearance="embedded"]
+  .agent-gui-node__empty-hero-suggestions,
+[data-workspace-node-window-kind="agentGui"][data-workspace-node-window-appearance="embedded"]
+  .agent-gui-node__empty-hero-suggestions-card {
+  animation: none;
 }
 
 @keyframes agent-gui-empty-hero-enter {
@@ -10964,4 +10993,19 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
     animation: none;
     opacity: 0;
   }
+}
+
+/* Fully occluded Workbench nodes stay mounted for instant switching, but their
+   animations must not keep repainting pixels that cannot reach the screen.
+   Partial exposure removes this rule, even when another window owns focus. */
+.agent-gui-node__layout[data-agent-gui-visible="false"]
+  :where(*, *::before, *::after) {
+  animation-play-state: paused !important;
+}
+
+/* Occlusion is geometric, not focus-based. Fully covered Workbench bodies keep
+   their DOM state but stop producing tiles; partially exposed bodies remain
+   painted in full so moving the covering window never reveals a black region. */
+.agent-gui-node__layout[data-agent-gui-visible="false"] {
+  content-visibility: hidden;
 }

--- a/packages/workbench/surface/src/core/visualOcclusion.test.ts
+++ b/packages/workbench/surface/src/core/visualOcclusion.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  selectVisuallyExposedWorkbenchNodeIDs,
+  selectWorkbenchNodeIsVisuallyExposed
+} from "./visualOcclusion.ts";
+import {
+  defaultWorkbenchLayoutConstraints,
+  type WorkbenchFrame,
+  type WorkbenchNode,
+  type WorkbenchState
+} from "./types.ts";
+
+test("keeps fully and partially exposed windows visible", () => {
+  const state = workbenchState([
+    node("hidden-1", frame(0, 0)),
+    node("hidden-2", frame(0, 0)),
+    node("hidden-3", frame(0, 0)),
+    node("hidden-4", frame(0, 0)),
+    node("partial-right", frame(80, 0)),
+    node("partial-bottom", frame(0, 80)),
+    node("visible-a", frame(0, 0)),
+    node("visible-b", frame(300, 0)),
+    node("visible-c", frame(0, 300)),
+    node("visible-d", frame(300, 300))
+  ]);
+
+  assert.deepEqual([...selectVisuallyExposedWorkbenchNodeIDs(state)].sort(), [
+    "partial-bottom",
+    "partial-right",
+    "visible-a",
+    "visible-b",
+    "visible-c",
+    "visible-d"
+  ]);
+});
+
+test("treats the union of higher windows as full occlusion", () => {
+  const state = workbenchState([
+    node("covered", frame(0, 0, 200, 100)),
+    node("left-cover", frame(0, 0)),
+    node("right-cover", frame(100, 0))
+  ]);
+
+  assert.equal(selectWorkbenchNodeIsVisuallyExposed(state, "covered"), false);
+  assert.equal(selectWorkbenchNodeIsVisuallyExposed(state, "left-cover"), true);
+});
+
+test("clips visibility to the Workbench surface and ignores minimized covers", () => {
+  const minimizedCover = node("minimized-cover", frame(0, 0));
+  minimizedCover.isMinimized = true;
+  const state = workbenchState([
+    node("offscreen", frame(700, 0)),
+    node("onscreen", frame(550, 0)),
+    minimizedCover
+  ]);
+
+  assert.equal(selectWorkbenchNodeIsVisuallyExposed(state, "offscreen"), false);
+  assert.equal(selectWorkbenchNodeIsVisuallyExposed(state, "onscreen"), true);
+  assert.equal(
+    selectWorkbenchNodeIsVisuallyExposed(state, "minimized-cover"),
+    false
+  );
+});
+
+function workbenchState(nodes: WorkbenchNode[]): WorkbenchState {
+  return {
+    activeDragNodeId: null,
+    activeResizeNodeId: null,
+    activeSnapTarget: null,
+    layoutConstraints: defaultWorkbenchLayoutConstraints,
+    lockedLayout: null,
+    nodes,
+    nodeStack: nodes.map((candidate) => candidate.id),
+    surfaceSize: { width: 600, height: 600 }
+  };
+}
+
+function node(id: string, nodeFrame: WorkbenchFrame): WorkbenchNode {
+  return {
+    data: null,
+    displayMode: "floating",
+    frame: nodeFrame,
+    id,
+    isMinimized: false,
+    kind: "test",
+    restoreFrame: null,
+    title: id
+  };
+}
+
+function frame(
+  x: number,
+  y: number,
+  width = 100,
+  height = 100
+): WorkbenchFrame {
+  return { height, width, x, y };
+}

--- a/packages/workbench/surface/src/core/visualOcclusion.ts
+++ b/packages/workbench/surface/src/core/visualOcclusion.ts
@@ -1,0 +1,140 @@
+import type { WorkbenchFrame, WorkbenchState } from "./types.ts";
+
+const exposedNodeIDsByState = new WeakMap<object, ReadonlySet<string>>();
+
+export function selectVisuallyExposedWorkbenchNodeIDs<TData>(
+  state: WorkbenchState<TData>
+): ReadonlySet<string> {
+  const cached = exposedNodeIDsByState.get(state);
+  if (cached) {
+    return cached;
+  }
+
+  const nodeByID = new Map(state.nodes.map((node) => [node.id, node]));
+  const stackedIDs = new Set(state.nodeStack);
+  const orderedNodes = [
+    ...state.nodes.filter((node) => !stackedIDs.has(node.id)),
+    ...state.nodeStack.flatMap((nodeID) => {
+      const node = nodeByID.get(nodeID);
+      return node ? [node] : [];
+    })
+  ];
+  const surfaceFrame: WorkbenchFrame = {
+    x: 0,
+    y: 0,
+    width: state.surfaceSize.width,
+    height: state.surfaceSize.height
+  };
+  const exposedNodeIDs = new Set<string>();
+
+  orderedNodes.forEach((node, nodeIndex) => {
+    if (node.isMinimized) {
+      return;
+    }
+    const visibleFrame = intersectFrames(node.frame, surfaceFrame);
+    if (!visibleFrame) {
+      return;
+    }
+
+    let uncoveredFrames = [visibleFrame];
+    for (
+      let occluderIndex = nodeIndex + 1;
+      occluderIndex < orderedNodes.length && uncoveredFrames.length > 0;
+      occluderIndex += 1
+    ) {
+      const occluder = orderedNodes[occluderIndex];
+      if (!occluder || occluder.isMinimized) {
+        continue;
+      }
+      uncoveredFrames = uncoveredFrames.flatMap((frame) =>
+        subtractFrame(frame, occluder.frame)
+      );
+    }
+    if (uncoveredFrames.length > 0) {
+      exposedNodeIDs.add(node.id);
+    }
+  });
+
+  exposedNodeIDsByState.set(state, exposedNodeIDs);
+  return exposedNodeIDs;
+}
+
+export function selectWorkbenchNodeIsVisuallyExposed<TData>(
+  state: WorkbenchState<TData>,
+  nodeID: string
+): boolean {
+  return selectVisuallyExposedWorkbenchNodeIDs(state).has(nodeID);
+}
+
+function intersectFrames(
+  left: WorkbenchFrame,
+  right: WorkbenchFrame
+): WorkbenchFrame | null {
+  const x = Math.max(left.x, right.x);
+  const y = Math.max(left.y, right.y);
+  const rightEdge = Math.min(
+    left.x + Math.max(0, left.width),
+    right.x + Math.max(0, right.width)
+  );
+  const bottomEdge = Math.min(
+    left.y + Math.max(0, left.height),
+    right.y + Math.max(0, right.height)
+  );
+  if (rightEdge <= x || bottomEdge <= y) {
+    return null;
+  }
+  return {
+    x,
+    y,
+    width: rightEdge - x,
+    height: bottomEdge - y
+  };
+}
+
+function subtractFrame(
+  source: WorkbenchFrame,
+  occluder: WorkbenchFrame
+): WorkbenchFrame[] {
+  const covered = intersectFrames(source, occluder);
+  if (!covered) {
+    return [source];
+  }
+
+  const sourceRight = source.x + source.width;
+  const sourceBottom = source.y + source.height;
+  const coveredRight = covered.x + covered.width;
+  const coveredBottom = covered.y + covered.height;
+  const remaining: WorkbenchFrame[] = [];
+
+  pushFrame(remaining, {
+    x: source.x,
+    y: source.y,
+    width: source.width,
+    height: covered.y - source.y
+  });
+  pushFrame(remaining, {
+    x: source.x,
+    y: coveredBottom,
+    width: source.width,
+    height: sourceBottom - coveredBottom
+  });
+  pushFrame(remaining, {
+    x: source.x,
+    y: covered.y,
+    width: covered.x - source.x,
+    height: covered.height
+  });
+  pushFrame(remaining, {
+    x: coveredRight,
+    y: covered.y,
+    width: sourceRight - coveredRight,
+    height: covered.height
+  });
+  return remaining;
+}
+
+function pushFrame(frames: WorkbenchFrame[], frame: WorkbenchFrame): void {
+  if (frame.width > 0 && frame.height > 0) {
+    frames.push(frame);
+  }
+}

--- a/packages/workbench/surface/src/index.ts
+++ b/packages/workbench/surface/src/index.ts
@@ -108,6 +108,10 @@ export { useWorkbenchSelector } from "./react/hooks/useWorkbenchSelector.ts";
 export { getWorkbenchLayoutFrame } from "./core/geometry.ts";
 export { selectFocusedWorkbenchNode } from "./core/selectors.ts";
 export {
+  selectVisuallyExposedWorkbenchNodeIDs,
+  selectWorkbenchNodeIsVisuallyExposed
+} from "./core/visualOcclusion.ts";
+export {
   canCreateNewWindow,
   canCreateNewWindowInDockPopup,
   createDockNewWindowLaunchPayload,

--- a/tools/scripts/agent-gui-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-performance-scenarios.mjs
@@ -5,6 +5,8 @@ import {
 } from "./agent-gui-session-performance-scenarios.mjs";
 import {
   desktopWindowStateScenario,
+  workbenchFiftyWindowStressScenario,
+  workbenchWindowDragScenario,
   workbenchWindowLifecycleScenario
 } from "./agent-gui-window-performance-scenarios.mjs";
 import {
@@ -33,6 +35,8 @@ export const agentGuiPerformanceScenarios = [
   railScopeRevealScenario,
   composerInputScenario,
   composerOverflowResizeScenario,
+  workbenchFiftyWindowStressScenario,
+  workbenchWindowDragScenario,
   workbenchWindowLifecycleScenario,
   desktopWindowStateScenario,
   providerStatusFocusRefreshScenario

--- a/tools/scripts/agent-gui-window-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-window-performance-scenarios.mjs
@@ -1,3 +1,6 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import {
   clickAgentWindowControl,
   evaluate,
@@ -11,6 +14,731 @@ import {
   waitForStableViewport,
   waitForEvaluation
 } from "./agent-gui-performance-helpers.mjs";
+import {
+  requiredScenarioData,
+  sqlString,
+  startupWorkspaceID
+} from "./agent-gui-performance-snapshot-helpers.mjs";
+
+const workbenchDragPointerMoveCount = 120;
+const workbenchStressAgentGUIWindowCount = 50;
+const workbenchStressExposedWindowCount = 6;
+const tileMemoryWarning =
+  "WARNING: tile memory limits exceeded, some content may not draw";
+const workbenchWindowDragMarkers = buildMarkers("workbench-window-drag", []);
+const workbenchFiftyWindowStressMarkers = buildMarkers(
+  "workbench-fifty-window-stress",
+  []
+);
+
+export const workbenchWindowDragScenario = {
+  id: "workbench-window-drag",
+  markers: workbenchWindowDragMarkers,
+  milestones: [],
+  prepare: prepareWorkbenchWindowDrag,
+  execute: executeWorkbenchWindowDrag,
+  describe(prepared) {
+    return `${prepared.windowCount} mounted AgentGUI windows; ${workbenchDragPointerMoveCount} pointer moves`;
+  },
+  summarize(prepared, result) {
+    return summary(
+      [
+        { name: "window entered drag state", passed: result.dragStarted },
+        { name: "window left drag state", passed: result.dragEnded },
+        {
+          name: "window followed the pointer",
+          passed:
+            Math.abs(result.deltaX - result.requestedDeltaX) <= 3 &&
+            Math.abs(result.deltaY - result.requestedDeltaY) <= 1
+        },
+        {
+          name: "drag emitted no tile-memory warnings",
+          passed: result.tileMemoryWarnings === 0
+        },
+        {
+          name: "startup emitted no tile-memory warnings",
+          passed: result.startupTileMemoryWarnings === 0
+        }
+      ],
+      [
+        { label: "Mounted AgentGUI windows", value: prepared.windowCount },
+        { label: "Pointer moves", value: workbenchDragPointerMoveCount },
+        {
+          label: "Observed movement",
+          value: `${result.deltaX.toFixed(1)} × ${result.deltaY.toFixed(1)} px`
+        },
+        {
+          label: "Drag tile-memory warnings",
+          value: result.tileMemoryWarnings
+        },
+        {
+          label: "Startup tile-memory warnings",
+          value: result.startupTileMemoryWarnings
+        }
+      ],
+      "trusted CDP pointer input moves one visible Workbench window while at least three AgentGUI windows remain mounted"
+    );
+  },
+  assessTrace: assessWorkbenchWindowDragTrace
+};
+
+export const workbenchFiftyWindowStressScenario = {
+  id: "workbench-fifty-window-stress",
+  markers: workbenchFiftyWindowStressMarkers,
+  milestones: [],
+  prepareSnapshot: prepareFiftyWindowStressSnapshot,
+  prepare: prepareWorkbenchFiftyWindowStress,
+  execute: executeWorkbenchFiftyWindowStress,
+  describe(prepared) {
+    return `${prepared.windowCount} mounted AgentGUI windows; ${workbenchDragPointerMoveCount} pointer moves`;
+  },
+  summarize(prepared, result) {
+    return summary(
+      [
+        {
+          name: `${workbenchStressAgentGUIWindowCount} AgentGUI windows mounted`,
+          passed: prepared.windowCount === workbenchStressAgentGUIWindowCount
+        },
+        {
+          name: "background window became active",
+          passed: result.focusSwitched
+        },
+        {
+          name: "background body stayed mounted across focus",
+          passed: result.bodyPreserved
+        },
+        {
+          name: "geometric visibility keeps exposed bodies painted",
+          passed:
+            result.exposedBodyCountBeforeFocus ===
+              workbenchStressExposedWindowCount &&
+            result.hiddenBodyCountBeforeFocus ===
+              workbenchStressAgentGUIWindowCount -
+                workbenchStressExposedWindowCount &&
+            result.switchBodyVisibleBeforeFocus
+        },
+        { name: "window entered drag state", passed: result.dragStarted },
+        { name: "window left drag state", passed: result.dragEnded },
+        {
+          name: "window followed the pointer",
+          passed:
+            Math.abs(result.deltaX - result.requestedDeltaX) <= 3 &&
+            Math.abs(result.deltaY - result.requestedDeltaY) <= 1
+        },
+        {
+          name: "drag emitted no tile-memory warnings",
+          passed: result.tileMemoryWarnings === 0
+        },
+        {
+          name: "startup emitted no tile-memory warnings",
+          passed: result.startupTileMemoryWarnings === 0
+        }
+      ],
+      [
+        { label: "Mounted AgentGUI windows", value: prepared.windowCount },
+        { label: "Pointer moves", value: workbenchDragPointerMoveCount },
+        {
+          label: "Observed movement",
+          value: `${result.deltaX.toFixed(1)} × ${result.deltaY.toFixed(1)} px`
+        },
+        {
+          label: "Drag tile-memory warnings",
+          value: result.tileMemoryWarnings
+        },
+        {
+          label: "Startup tile-memory warnings",
+          value: result.startupTileMemoryWarnings
+        },
+        {
+          label: "Exposed bodies before focus",
+          value: result.exposedBodyCountBeforeFocus
+        },
+        {
+          label: "Fully occluded bodies before focus",
+          value: result.hiddenBodyCountBeforeFocus
+        }
+      ],
+      `trusted CDP pointer input moves one visible Workbench window while exactly ${workbenchStressAgentGUIWindowCount} AgentGUI windows remain mounted`
+    );
+  },
+  assessTrace: assessWorkbenchWindowDragTrace
+};
+
+export function assessWorkbenchWindowDragTrace(traceSummary) {
+  const animationIterationCount =
+    traceSummary.inputEvents.animationiteration ?? 0;
+  const maximumAnimationIterationCount = 20;
+  const maximumRendererTaskMs = 50;
+  const maximumObservedRendererTaskMs = traceSummary.timing.maxLongTaskMs;
+  return {
+    assertions: [
+      {
+        name: `drag animation iterations <= ${maximumAnimationIterationCount}`,
+        passed: animationIterationCount <= maximumAnimationIterationCount
+      },
+      {
+        name: `renderer task <= ${maximumRendererTaskMs} ms`,
+        passed: maximumObservedRendererTaskMs <= maximumRendererTaskMs
+      }
+    ],
+    details: [
+      { label: "Drag animation iterations", value: animationIterationCount },
+      {
+        label: "Drag animation-iteration budget",
+        value: maximumAnimationIterationCount
+      },
+      {
+        label: "Maximum renderer task",
+        value: `${maximumObservedRendererTaskMs} ms`
+      },
+      {
+        label: "Renderer task budget",
+        value: `${maximumRendererTaskMs} ms`
+      }
+    ]
+  };
+}
+
+async function prepareFiftyWindowStressSnapshot(context) {
+  const workspaceID = await startupWorkspaceID(context);
+  const rows = await context.sqliteJSON(
+    context.databasePath,
+    `
+SELECT snapshot_json AS snapshotJSON
+FROM workspace_workbench_snapshots
+WHERE workspace_id = '${sqlString(workspaceID)}'
+LIMIT 1;
+`
+  );
+  const snapshot = JSON.parse(rows[0]?.snapshotJSON ?? "null");
+  const stressedSnapshot = prepareAgentGUIWindowStressSnapshot(
+    snapshot,
+    workbenchStressAgentGUIWindowCount
+  );
+  await context.sqliteExec(
+    context.databasePath,
+    `
+UPDATE workspace_workbench_snapshots
+SET snapshot_json = '${sqlString(JSON.stringify(stressedSnapshot))}'
+WHERE workspace_id = '${sqlString(workspaceID)}';
+`
+  );
+  return {
+    data: {
+      expectedWindowCount: workbenchStressAgentGUIWindowCount
+    }
+  };
+}
+
+export function prepareAgentGUIWindowStressSnapshot(snapshot, windowCount) {
+  if (
+    !snapshot ||
+    typeof snapshot !== "object" ||
+    !Array.isArray(snapshot.nodes) ||
+    !Number.isInteger(windowCount) ||
+    windowCount < 1
+  ) {
+    throw new Error("invalid AgentGUI window stress snapshot input");
+  }
+  const template =
+    snapshot.nodes.find(
+      (node) =>
+        node?.id === snapshot.activeNodeId && node?.data?.typeId === "agent-gui"
+    ) ?? snapshot.nodes.find((node) => node?.data?.typeId === "agent-gui");
+  if (!template) {
+    throw new Error("AgentGUI window stress snapshot has no template node");
+  }
+  const retainedNodes = snapshot.nodes.filter(
+    (node) => node?.data?.typeId !== "agent-gui"
+  );
+  const agentGuiNodes = Array.from({ length: windowCount }, (_, index) => {
+    const instanceID = `agent-gui:instance:perf-stress-${index + 1}`;
+    const node = structuredClone(template);
+    node.id = `agent-gui:${instanceID}`;
+    node.data = {
+      ...node.data,
+      instanceId: instanceID,
+      instanceKey: null
+    };
+    node.frame = stressAgentGUIWindowFrame(template.frame, index, windowCount);
+    node.isMinimized = false;
+    return node;
+  });
+  const activeNodeID = agentGuiNodes.at(-1).id;
+  return {
+    ...snapshot,
+    activeNodeId: activeNodeID,
+    nodeStack: [
+      ...retainedNodes.map((node) => node.id),
+      ...agentGuiNodes.map((node) => node.id)
+    ],
+    nodes: [...retainedNodes, ...agentGuiNodes]
+  };
+}
+
+function stressAgentGUIWindowFrame(template, index, windowCount) {
+  if (windowCount < workbenchStressExposedWindowCount) {
+    return { ...template };
+  }
+  const hiddenWindowCount = windowCount - workbenchStressExposedWindowCount;
+  const gap = Math.min(160, template.width * 0.2, template.height * 0.2);
+  const width = (template.width - gap) / 2;
+  const height = (template.height - gap) / 2;
+  const left = template.x;
+  const top = template.y;
+  const right = left + width + gap;
+  const bottom = top + height + gap;
+  const frames = [
+    {
+      ...template,
+      x: left + width - 120,
+      y: top + 80,
+      width: 400,
+      height: Math.max(240, height - 160)
+    },
+    {
+      ...template,
+      x: left + 80,
+      y: top + height - 120,
+      width: Math.max(400, width - 160),
+      height: 400
+    },
+    { ...template, x: left, y: top, width, height },
+    { ...template, x: right, y: top, width, height },
+    { ...template, x: left, y: bottom, width, height },
+    { ...template, x: right, y: bottom, width, height }
+  ];
+  return index < hiddenWindowCount
+    ? { ...frames[2] }
+    : frames[index - hiddenWindowCount];
+}
+
+async function prepareWorkbenchFiftyWindowStress(context, options) {
+  const scenarioData = requiredScenarioData(
+    context,
+    "workbench-fifty-window-stress"
+  );
+  const prepared = await prepareWorkbenchWindowDrag(
+    context,
+    options,
+    scenarioData.expectedWindowCount
+  );
+  const switchTarget = await waitForEvaluation(
+    context.pageClient,
+    `(() => {
+      const shells = [...document.querySelectorAll('[data-workbench-window-id][data-workbench-node-type-id="agent-gui"]')]
+        .filter((shell) =>
+          shell instanceof HTMLElement &&
+          shell.dataset.workbenchWindowId !== ${JSON.stringify(prepared.nodeID)} &&
+          shell.querySelector('[data-agent-gui-visible="true"]') != null
+        )
+        .sort((left, right) =>
+          Number.parseInt(getComputedStyle(right).zIndex || '0', 10) -
+          Number.parseInt(getComputedStyle(left).zIndex || '0', 10)
+        );
+      for (const shell of shells) {
+        const header = shell.querySelector('.workbench-window__header');
+        if (!(header instanceof HTMLElement)) continue;
+        const rect = header.getBoundingClientRect();
+        for (let offsetX = 8; offsetX < rect.width - 8; offsetX += 4) {
+          const x = rect.left + offsetX;
+          const y = rect.top + rect.height / 2;
+          const hit = document.elementFromPoint(x, y);
+          if (!hit || !header.contains(hit) || hit.closest('button')) continue;
+          return {
+            ready: true,
+            switchNodeID: shell.dataset.workbenchWindowId ?? '',
+            switchX: x,
+            switchY: y
+          };
+        }
+      }
+      return { ready: false };
+    })()`,
+    options.timeoutMs,
+    "exposed background AgentGUI window header"
+  );
+  return { ...prepared, ...switchTarget };
+}
+
+async function executeWorkbenchFiftyWindowStress(context, prepared, options) {
+  const { pageClient } = context;
+  const mountSentinel = `perf-${Date.now()}`;
+  const visibilityBeforeFocus = await evaluate(
+    pageClient,
+    `(() => {
+      const shell = document.querySelector(${JSON.stringify(`[data-workbench-window-id="${prepared.switchNodeID}"]`)});
+      const body = shell?.querySelector('[data-agent-gui-active="false"]');
+      if (!(body instanceof HTMLElement)) {
+        throw new Error('background AgentGUI body is unavailable before focus switch');
+      }
+      body.dataset.perfMountSentinel = ${JSON.stringify(mountSentinel)};
+      const bodies = [
+        ...document.querySelectorAll('.agent-gui-node__layout[data-agent-gui-visible]')
+      ];
+      return {
+        exposedBodyCountBeforeFocus: bodies.filter(
+          (candidate) => candidate.getAttribute('data-agent-gui-visible') === 'true'
+        ).length,
+        hiddenBodyCountBeforeFocus: bodies.filter(
+          (candidate) => candidate.getAttribute('data-agent-gui-visible') === 'false'
+        ).length,
+        switchBodyVisibleBeforeFocus:
+          body.getAttribute('data-agent-gui-visible') === 'true' &&
+          getComputedStyle(body).contentVisibility !== 'hidden'
+      };
+    })()`
+  );
+  const tileWarningsAtStart = await countTileMemoryWarnings(
+    context.outputDirectory
+  );
+  await startRendererScenario(
+    pageClient,
+    workbenchFiftyWindowStressMarkers.start
+  );
+  await pageClient.send("Input.dispatchMouseEvent", {
+    button: "left",
+    buttons: 1,
+    clickCount: 1,
+    type: "mousePressed",
+    x: prepared.switchX,
+    y: prepared.switchY
+  });
+  await pageClient.send("Input.dispatchMouseEvent", {
+    button: "left",
+    buttons: 0,
+    clickCount: 1,
+    type: "mouseReleased",
+    x: prepared.switchX,
+    y: prepared.switchY
+  });
+  const focused = await waitForEvaluation(
+    pageClient,
+    `(() => {
+      const shell = document.querySelector(${JSON.stringify(`[data-workbench-window-id="${prepared.switchNodeID}"]`)});
+      const previousShell = document.querySelector(${JSON.stringify(`[data-workbench-window-id="${prepared.nodeID}"]`)});
+      const body = shell?.querySelector('[data-agent-gui-active="true"]');
+      const previousBody = previousShell?.querySelector('[data-agent-gui-active="false"]');
+      return {
+        ready:
+          body instanceof HTMLElement &&
+          previousBody instanceof HTMLElement &&
+          body.getAttribute('data-agent-gui-visible') === 'true' &&
+          getComputedStyle(body).contentVisibility !== 'hidden',
+        bodyPreserved:
+          body instanceof HTMLElement &&
+          body.dataset.perfMountSentinel === ${JSON.stringify(mountSentinel)}
+      };
+    })()`,
+    options.timeoutMs,
+    "background AgentGUI focus switch"
+  );
+  const dragTarget = await waitForEvaluation(
+    pageClient,
+    `(() => {
+      const shell = document.querySelector(${JSON.stringify(`[data-workbench-window-id="${prepared.switchNodeID}"]`)});
+      const header = shell?.querySelector('.workbench-window__header');
+      if (!(shell instanceof HTMLElement) || !(header instanceof HTMLElement)) {
+        return { ready: false };
+      }
+      const headerRect = header.getBoundingClientRect();
+      const shellRect = shell.getBoundingClientRect();
+      for (const fraction of [0.5, 0.4, 0.6, 0.3]) {
+        const x = headerRect.left + headerRect.width * fraction;
+        const y = headerRect.top + headerRect.height / 2;
+        const hit = document.elementFromPoint(x, y);
+        if (!hit || !header.contains(hit) || hit.closest('button')) continue;
+        const availableRight = window.innerWidth - shellRect.right;
+        const availableLeft = shellRect.left;
+        return {
+          ready: true,
+          nodeID: shell.dataset.workbenchWindowId ?? '',
+          startX: x,
+          startY: y,
+          startLeft: shellRect.left,
+          startTop: shellRect.top,
+          deltaX: availableRight >= 120
+            ? 120
+            : availableLeft >= 120
+              ? -120
+              : Math.max(40, Math.min(120, availableRight)) * 0.75,
+          deltaY: 0
+        };
+      }
+      return { ready: false };
+    })()`,
+    options.timeoutMs,
+    "focused AgentGUI drag target"
+  );
+  const dragResult = await executeWorkbenchWindowDrag(
+    context,
+    { ...prepared, ...dragTarget },
+    options,
+    workbenchFiftyWindowStressMarkers,
+    { scenarioStarted: true, tileWarningsAtStart }
+  );
+  return {
+    ...dragResult,
+    bodyPreserved: focused.bodyPreserved,
+    focusSwitched: focused.ready,
+    ...visibilityBeforeFocus
+  };
+}
+
+async function prepareWorkbenchWindowDrag(
+  context,
+  options,
+  minimumWindowCount = 3
+) {
+  await waitForEvaluation(
+    context.pageClient,
+    "({ ready: document.documentElement !== null })",
+    options.timeoutMs,
+    "renderer document root"
+  );
+  await waitForWorkbenchRendererQuiet(context.pageClient);
+  await waitForWorkbenchRendererIdle(context.pageClient);
+  await waitForEvaluation(
+    context.pageClient,
+    `(() => {
+      const shells = [...document.querySelectorAll('[data-workbench-window-id][data-workbench-node-type-id="agent-gui"]')]
+        .filter((shell) =>
+          shell instanceof HTMLElement &&
+          shell.dataset.minimizedMount === 'visible' &&
+          shell.dataset.presentationVisibility === 'visible' &&
+          getComputedStyle(shell).visibility !== 'hidden'
+        )
+      const pendingHydrationCount = document.querySelectorAll(
+        '[data-agent-gui-workbench-hydration="pending"]'
+      ).length;
+      return {
+        ready: shells.length >= ${minimumWindowCount} && pendingHydrationCount === 0,
+        windowCount: shells.length,
+        pendingHydrationCount
+      };
+    })()`,
+    options.timeoutMs,
+    "all staged AgentGUI Workbench bodies"
+  );
+  await waitForWorkbenchRendererQuiet(context.pageClient);
+  await waitForWorkbenchRendererIdle(context.pageClient);
+  return waitForEvaluation(
+    context.pageClient,
+    `(() => {
+      const shells = [...document.querySelectorAll('[data-workbench-window-id][data-workbench-node-type-id="agent-gui"]')]
+        .filter((shell) =>
+          shell instanceof HTMLElement &&
+          shell.dataset.minimizedMount === 'visible' &&
+          shell.dataset.presentationVisibility === 'visible' &&
+          getComputedStyle(shell).visibility !== 'hidden'
+        )
+        .sort((left, right) =>
+          Number.parseInt(getComputedStyle(right).zIndex || '0', 10) -
+          Number.parseInt(getComputedStyle(left).zIndex || '0', 10)
+        );
+      for (const shell of shells) {
+        const header = shell.querySelector('.workbench-window__header');
+        if (!(header instanceof HTMLElement)) continue;
+        const headerRect = header.getBoundingClientRect();
+        const shellRect = shell.getBoundingClientRect();
+        for (const fraction of [0.5, 0.4, 0.6, 0.3]) {
+          const x = headerRect.left + headerRect.width * fraction;
+          const y = headerRect.top + headerRect.height / 2;
+          const hit = document.elementFromPoint(x, y);
+          if (!hit || !header.contains(hit) || hit.closest('button')) continue;
+          const availableRight = window.innerWidth - shellRect.right;
+          const availableLeft = shellRect.left;
+          const deltaX = availableRight >= 120
+            ? 120
+            : availableLeft >= 120
+              ? -120
+              : Math.max(40, Math.min(120, availableRight)) * 0.75;
+          const deltaY = 0;
+          return {
+            ready: shells.length >= ${minimumWindowCount},
+            windowCount: shells.length,
+            nodeID: shell.dataset.workbenchWindowId ?? '',
+            startX: x,
+            startY: y,
+            startLeft: shellRect.left,
+            startTop: shellRect.top,
+            deltaX,
+            deltaY
+          };
+        }
+      }
+      return {
+        ready: false,
+        windowCount: shells.length
+      };
+    })()`,
+    options.timeoutMs,
+    `${minimumWindowCount} mounted AgentGUI windows with a draggable top window`
+  );
+}
+
+async function waitForWorkbenchRendererQuiet(pageClient) {
+  await evaluate(
+    pageClient,
+    `new Promise((resolve) => {
+      let quietTimer = 0;
+      const timeout = setTimeout(finish, 15000);
+      const observer = new MutationObserver(schedule);
+      function finish() {
+        clearTimeout(timeout);
+        clearTimeout(quietTimer);
+        observer.disconnect();
+        resolve(true);
+      }
+      function schedule() {
+        clearTimeout(quietTimer);
+        quietTimer = setTimeout(() => {
+          if ([...document.images].every((image) => image.complete)) finish();
+          else schedule();
+        }, 1000);
+      }
+      observer.observe(document.documentElement, {
+        attributes: true,
+        childList: true,
+        subtree: true
+      });
+      schedule();
+    })`,
+    true
+  );
+}
+
+async function waitForWorkbenchRendererIdle(pageClient) {
+  await evaluate(
+    pageClient,
+    `new Promise((resolve) => {
+      const afterIdle = () =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve));
+      if (typeof requestIdleCallback !== 'function') {
+        setTimeout(afterIdle, 1000);
+        return;
+      }
+      requestIdleCallback(
+        () => requestIdleCallback(afterIdle, { timeout: 5000 }),
+        { timeout: 5000 }
+      );
+    })`,
+    true
+  );
+}
+
+async function executeWorkbenchWindowDrag(
+  context,
+  prepared,
+  options,
+  markers = workbenchWindowDragMarkers,
+  measurement = {}
+) {
+  const { pageClient } = context;
+  await pageClient.send("Input.dispatchMouseEvent", {
+    button: "left",
+    buttons: 1,
+    clickCount: 1,
+    type: "mousePressed",
+    x: prepared.startX,
+    y: prepared.startY
+  });
+  const dragging = await waitForEvaluation(
+    pageClient,
+    `(() => {
+      const shell = document.querySelector(${JSON.stringify(`[data-workbench-window-id="${prepared.nodeID}"]`)});
+      return { ready: shell?.dataset.windowDragState === 'dragging' };
+    })()`,
+    options.timeoutMs,
+    "Workbench window drag state"
+  );
+  await evaluate(
+    pageClient,
+    "new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))",
+    true
+  );
+  await delay(100);
+  const tileWarningsAtStart =
+    measurement.tileWarningsAtStart ??
+    (await countTileMemoryWarnings(context.outputDirectory));
+  if (!measurement.scenarioStarted) {
+    await startRendererScenario(pageClient, markers.start);
+  }
+
+  for (let index = 1; index <= workbenchDragPointerMoveCount; index += 1) {
+    const progress = index / workbenchDragPointerMoveCount;
+    await pageClient.send("Input.dispatchMouseEvent", {
+      button: "left",
+      buttons: 1,
+      type: "mouseMoved",
+      x: prepared.startX + prepared.deltaX * progress,
+      y: prepared.startY + prepared.deltaY * progress
+    });
+    await delay(8);
+  }
+  await evaluate(
+    pageClient,
+    `new Promise((resolve) =>
+      requestAnimationFrame(() =>
+        requestAnimationFrame(() => {
+          console.timeStamp(${JSON.stringify(markers.end)});
+          resolve(true);
+        })
+      )
+    )`,
+    true
+  );
+  await delay(100);
+  const tileWarningsAtEnd = await countTileMemoryWarnings(
+    context.outputDirectory
+  );
+  await pageClient.send("Input.dispatchMouseEvent", {
+    button: "left",
+    buttons: 0,
+    clickCount: 1,
+    type: "mouseReleased",
+    x: prepared.startX + prepared.deltaX,
+    y: prepared.startY + prepared.deltaY
+  });
+
+  const settled = await waitForEvaluation(
+    pageClient,
+    `(() => {
+      const shell = document.querySelector(${JSON.stringify(`[data-workbench-window-id="${prepared.nodeID}"]`)});
+      if (!(shell instanceof HTMLElement)) return { ready: false };
+      const rect = shell.getBoundingClientRect();
+      return {
+        ready: shell.dataset.windowDragState === 'idle',
+        deltaX: rect.left - ${prepared.startLeft},
+        deltaY: rect.top - ${prepared.startTop}
+      };
+    })()`,
+    options.timeoutMs,
+    "settled Workbench window drag"
+  );
+  return {
+    deltaX: settled.deltaX,
+    deltaY: settled.deltaY,
+    dragEnded: settled.ready,
+    dragStarted: dragging.ready,
+    requestedDeltaX: prepared.deltaX,
+    requestedDeltaY: prepared.deltaY,
+    startupTileMemoryWarnings: tileWarningsAtStart,
+    tileMemoryWarnings: Math.max(0, tileWarningsAtEnd - tileWarningsAtStart)
+  };
+}
+
+async function countTileMemoryWarnings(outputDirectory) {
+  try {
+    const log = await readFile(join(outputDirectory, "desktop.log"), "utf8");
+    return log.split(tileMemoryWarning).length - 1;
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return 0;
+    }
+    throw error;
+  }
+}
 
 const workbenchSteps = [
   ["minimized", "internal window minimized"],

--- a/tools/scripts/analyze-electron-trace.mjs
+++ b/tools/scripts/analyze-electron-trace.mjs
@@ -290,6 +290,7 @@ export async function analyzeElectronTrace(input) {
       prePaintInclusiveMs: inclusiveDurationForNames(renderer.eventStats, [
         "PrePaint"
       ]),
+      paintEventCount: countEventsForNames(renderer.eventStats, ["Paint"]),
       paintInclusiveMs: inclusiveDurationForNames(renderer.eventStats, [
         "Paint"
       ]),
@@ -351,6 +352,7 @@ export function renderElectronTraceMarkdown(summary, options = {}) {
     `- UpdateLayoutTree inclusive: ${summary.timing.updateLayoutTreeInclusiveMs} ms`,
     `- Layout inclusive: ${summary.timing.layoutInclusiveMs} ms`,
     `- PrePaint inclusive: ${summary.timing.prePaintInclusiveMs} ms`,
+    `- Paint events: ${summary.timing.paintEventCount.toLocaleString("en-US")}`,
     `- Paint inclusive: ${summary.timing.paintInclusiveMs} ms`,
     "",
     "## Input event timing",
@@ -699,6 +701,13 @@ function inclusiveDurationForNames(values, names) {
     0
   );
   return round(totalUs / 1_000);
+}
+
+function countEventsForNames(values, names) {
+  return names.reduce(
+    (total, name) => total + (values.get(name)?.count ?? 0),
+    0
+  );
 }
 
 function finiteNumber(value) {

--- a/tools/scripts/run-agent-gui-performance.test.mjs
+++ b/tools/scripts/run-agent-gui-performance.test.mjs
@@ -11,6 +11,10 @@ import {
 } from "./agent-gui-performance-scenarios.mjs";
 import { sessionSwitchScenario } from "./agent-gui-session-performance-scenarios.mjs";
 import { composerInputScenario } from "./agent-gui-composer-performance-scenarios.mjs";
+import {
+  assessWorkbenchWindowDragTrace,
+  prepareAgentGUIWindowStressSnapshot
+} from "./agent-gui-window-performance-scenarios.mjs";
 import { summarizeProviderStatusFocusRefresh } from "./agent-provider-status-performance-scenario.mjs";
 import { buildAllProcessTimeProfileArgs } from "./all-process-time-profile.mjs";
 import {
@@ -197,6 +201,8 @@ test("performance scenario registry exposes renderer and window scenarios", () =
       "rail-scope-reveal",
       "composer-input",
       "composer-overflow-resize",
+      "workbench-fifty-window-stress",
+      "workbench-window-drag",
       "workbench-window-lifecycle",
       "desktop-window-state",
       "provider-status-focus-refresh"
@@ -209,6 +215,76 @@ test("performance scenario registry exposes renderer and window scenarios", () =
   assert.throws(
     () => resolveAgentGuiPerformanceScenario("missing"),
     /unknown scenario: missing/
+  );
+});
+
+test("AgentGUI window stress snapshot creates exact unique mounted windows", () => {
+  const snapshot = prepareAgentGUIWindowStressSnapshot(
+    {
+      activeNodeId: "agent-gui:instance:source",
+      nodeStack: ["terminal:1", "agent-gui:instance:source"],
+      nodes: [
+        {
+          id: "terminal:1",
+          data: { typeId: "terminal" },
+          frame: { x: 0, y: 0, width: 800, height: 600 }
+        },
+        {
+          id: "agent-gui:instance:source",
+          data: {
+            instanceId: "instance:source",
+            instanceKey: null,
+            typeId: "agent-gui"
+          },
+          frame: { x: 100, y: 50, width: 1200, height: 800 },
+          isMinimized: true
+        }
+      ]
+    },
+    50
+  );
+  const agentGuiNodes = snapshot.nodes.filter(
+    (node) => node.data.typeId === "agent-gui"
+  );
+
+  assert.equal(agentGuiNodes.length, 50);
+  assert.equal(new Set(agentGuiNodes.map((node) => node.id)).size, 50);
+  assert.equal(new Set(snapshot.nodeStack).size, 51);
+  assert.equal(
+    agentGuiNodes.every((node) => !node.isMinimized),
+    true
+  );
+  assert.equal(snapshot.activeNodeId, agentGuiNodes.at(-1).id);
+  assert.equal(
+    snapshot.nodes.some((node) => node.id === "terminal:1"),
+    true
+  );
+});
+
+test("workbench drag trace bounds background animation work", () => {
+  assert.deepEqual(
+    assessWorkbenchWindowDragTrace({
+      inputEvents: { animationiteration: 20 },
+      timing: { maxLongTaskMs: 50 }
+    }).assertions,
+    [
+      { name: "drag animation iterations <= 20", passed: true },
+      { name: "renderer task <= 50 ms", passed: true }
+    ]
+  );
+  assert.equal(
+    assessWorkbenchWindowDragTrace({
+      inputEvents: { animationiteration: 21 },
+      timing: { maxLongTaskMs: 51 }
+    }).assertions[0].passed,
+    false
+  );
+  assert.equal(
+    assessWorkbenchWindowDragTrace({
+      inputEvents: { animationiteration: 20 },
+      timing: { maxLongTaskMs: 51 }
+    }).assertions[1].passed,
+    false
   );
 });
 


### PR DESCRIPTION
## Summary

- classify AgentGUI windows from Workbench geometry and z-order, keeping fully and partially exposed windows painted
- stage restored body hydration and release animations, observers, decoded carousel images, and WebGL only while a body is fully occluded
- remove the obsolete WebGL scene visibility API and add focused occlusion plus 50-window performance coverage

## Validation

- `pnpm check:changed -- --push-ready` (20 lanes passed)
- focused AgentGUI carousel/scene tests: 11 passed
- Workbench visual occlusion tests: 3 passed
- Desktop hydration tests: 2 passed
- 50-window runtime scenario: 50 mounted, 6 exposed, 44 fully occluded, 0 startup/drag tile-memory warnings, max renderer task 33.19 ms

## Performance evidence

The original trace reproduced 10,160 startup and 488 drag `tile memory limits exceeded` warnings. The final 50-window trace reported 0 for both and passed all 11 scenario assertions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->