### PR TITLE
fix(agent): hide Tutti Agent reasoning and speed controls

### DIFF
--- a/packages/agent/daemon/providerregistry/providers.go
+++ b/packages/agent/daemon/providerregistry/providers.go
@@ -71,10 +71,9 @@ func tuttiAgentDescriptor() ProviderDescriptor {
 			Update:  UpdateDescriptor{Capability: UpdateCapabilitySupported, Source: UpdateSourceNPM, Strategy: UpdateStrategyManagedNPM, PackageName: "@tutti-os/tutti-agent", BinaryName: "tutti-agent", IncludeOptional: true},
 		},
 		ComposerProfile: ComposerProfileDescriptor{
-			ModelSelection: true, ModelCatalog: ModelCatalogKindTuttiCLI, ReasoningEffort: true, ReasoningEffortOptions: ReasoningEffortOptionsModelCatalog, DefaultReasoningEffort: "high", Speed: true,
-			SpeedValues: []string{"standard", "fast"}, DefaultSpeed: "standard",
+			ModelSelection: true, ModelCatalog: ModelCatalogKindTuttiCLI,
 			Capabilities: []string{CapabilityImageInput, CapabilitySkills, CapabilityCompact, CapabilityTokenUsage, CapabilityPlanMode, CapabilityInterrupt, CapabilityActiveTurnGuidance, CapabilityModelSwitch, CapabilityModelPlanBinding}, PermissionConfigurable: true, DefaultPermissionModeID: "auto",
-			PermissionModes: []PermissionModeDescriptor{{ID: "read-only", Semantic: "ask-before-write"}, {ID: "auto", Semantic: "auto"}, {ID: "full-access", Semantic: "full-access"}}, ConfigOptionIDs: ComposerConfigOptionIDs{Model: "model", Reasoning: "reasoning_effort", Speed: "service_tier", Permission: "mode"},
+			PermissionModes: []PermissionModeDescriptor{{ID: "read-only", Semantic: "ask-before-write"}, {ID: "auto", Semantic: "auto"}, {ID: "full-access", Semantic: "full-access"}}, ConfigOptionIDs: ComposerConfigOptionIDs{Model: "model", Permission: "mode"},
 		},
 		Target:  TargetDescriptor{ID: TuttiAgentTargetID, LaunchRefType: TargetLaunchRefTypeLocalCLI, Enabled: false, SortOrder: 40},
 		Events:  EventsDescriptor{Enabled: true, Aliases: []string{"tutti_agent"}, TurnLifecycleProjection: TurnLifecycleProjectionExplicit},

--- a/packages/agent/daemon/providerregistry/registry_test.go
+++ b/packages/agent/daemon/providerregistry/registry_test.go
@@ -63,6 +63,12 @@ func TestMigratedTuttiAgentDescriptorRequiresRefreshCapableVersion(t *testing.T)
 	if slices.Contains(descriptor.ComposerProfile.Capabilities, CapabilityRateLimits) {
 		t.Fatal("Tutti Agent must not advertise ChatGPT rate limits")
 	}
+	if descriptor.ComposerProfile.ReasoningEffort ||
+		descriptor.ComposerProfile.Speed ||
+		descriptor.ComposerProfile.ConfigOptionIDs.Reasoning != "" ||
+		descriptor.ComposerProfile.ConfigOptionIDs.Speed != "" {
+		t.Fatalf("Tutti Agent must hide provider-wide reasoning and speed controls: %#v", descriptor.ComposerProfile)
+	}
 }
 
 func TestValidateRejectsInvalidMinimumVersionFloor(t *testing.T) {

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -358,7 +358,7 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 	if catalogProjectionOK {
 		modelOptions = s.enrichModelCapabilityOptions(ctx, provider, catalogProjection.ModelOptions)
 		runtimeContext["modelCatalogSource"] = catalogProjection.Source
-		if len(catalogProjection.ReasoningProfiles) > 0 {
+		if composerProfileFor(provider).ReasoningEffort && len(catalogProjection.ReasoningProfiles) > 0 {
 			reasoningOptionsByModel = composerModelReasoningOptionsByModel(
 				provider,
 				locale,
@@ -366,7 +366,7 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 			)
 		}
 		selection := catalogProjection.Selection
-		if selection.ReasoningEffortsAdvertised {
+		if composerProfileFor(provider).ReasoningEffort && selection.ReasoningEffortsAdvertised {
 			effectiveSettings.ReasoningEffort = resolveAdvertisedReasoningEffort(
 				provider,
 				settings.ReasoningEffort,
@@ -381,7 +381,7 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 			)
 			runtimeContext["reasoningEffort"] = nullableString(effectiveSettings.ReasoningEffort)
 		}
-		if selection.SpeedsAdvertised {
+		if composerProfileFor(provider).Speed && selection.SpeedsAdvertised {
 			effectiveSettings.Speed = resolveAdvertisedSpeed(
 				settings.Speed,
 				selection.DefaultSpeed,

--- a/services/tuttid/service/agent/composer_options_test.go
+++ b/services/tuttid/service/agent/composer_options_test.go
@@ -180,9 +180,10 @@ func TestNormalizeComposerSettingsClampsByProviderSupport(t *testing.T) {
 	tuttiAgent := normalizeComposerSettingsForProvider("tutti-agent", ComposerSettings{
 		Model:           "gpt-5.4",
 		ReasoningEffort: "high",
+		Speed:           "fast",
 	})
-	if tuttiAgent.Model != "gpt-5.4" || tuttiAgent.ReasoningEffort != "high" {
-		t.Fatalf("tutti-agent settings clamped unexpectedly: %+v", tuttiAgent)
+	if tuttiAgent.Model != "gpt-5.4" || tuttiAgent.ReasoningEffort != "" || tuttiAgent.Speed != "" {
+		t.Fatalf("tutti-agent provider-wide hidden settings were not clamped: %+v", tuttiAgent)
 	}
 	opencode := normalizeComposerSettingsForProvider("opencode", ComposerSettings{
 		Model:           "openai/gpt-5.3-codex-spark",
@@ -302,7 +303,7 @@ func TestComposerConfigConfigurableTruthTable(t *testing.T) {
 	}{
 		{"claude-code", false, true, true},
 		{"codex", true, true, true},
-		{"tutti-agent", true, true, true},
+		{"tutti-agent", true, false, true},
 		{"cursor", true, false, true},
 		{"opencode", true, false, true},
 		{"hermes", false, false, false},
@@ -365,7 +366,7 @@ func TestNormalizeObservedComposerSettingsUsesProviderReasoningPolicy(t *testing
 		want     string
 	}{
 		{provider: "codex", selected: "none", want: "none"},
-		{provider: "tutti-agent", selected: "minimal", want: "minimal"},
+		{provider: "tutti-agent", selected: "minimal", want: ""},
 		{provider: "opencode", selected: "none", want: "none"},
 	} {
 		t.Run(tc.provider, func(t *testing.T) {

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -3351,24 +3351,23 @@ func TestServiceGetsComposerOptionsFromTuttiAgentModelCatalog(t *testing.T) {
 	if options.EffectiveSettings.Model != "gpt-5.4" {
 		t.Fatalf("effectiveSettings.model = %q, want gpt-5.4", options.EffectiveSettings.Model)
 	}
-	if options.EffectiveSettings.ReasoningEffort != "high" {
-		t.Fatalf("effectiveSettings.reasoningEffort = %q, want high", options.EffectiveSettings.ReasoningEffort)
+	if options.EffectiveSettings.ReasoningEffort != "" || options.EffectiveSettings.Speed != "" {
+		t.Fatalf("provider-wide hidden controls leaked into effectiveSettings: %#v", options.EffectiveSettings)
 	}
 	if options.ModelConfig.CurrentValue != "gpt-5.4" || len(options.ModelConfig.Options) != 2 {
 		t.Fatalf("modelConfig = %#v, want catalog-backed tutti-agent models", options.ModelConfig)
 	}
 	configOptions, ok := options.RuntimeContext["configOptions"].([]map[string]any)
-	if !ok || len(configOptions) < 3 {
+	if !ok || len(configOptions) != 1 {
 		t.Fatalf("configOptions = %#v", options.RuntimeContext["configOptions"])
 	}
 	if configOptions[0]["id"] != "model" || configOptions[0]["currentValue"] != "gpt-5.4" {
 		t.Fatalf("model option = %#v", configOptions[0])
 	}
-	if configOptions[1]["id"] != "reasoning_effort" {
-		t.Fatalf("reasoning option = %#v, want reasoning_effort id", configOptions[1])
-	}
-	if configOptions[2]["id"] != "service_tier" {
-		t.Fatalf("speed option = %#v, want service_tier id", configOptions[2])
+	if len(options.ReasoningOptionsByModel) != 0 ||
+		options.ReasoningConfig.Configurable ||
+		options.SpeedConfig.Configurable {
+		t.Fatalf("provider-wide hidden controls leaked into composer options: %#v", options)
 	}
 	if options.RuntimeContext["modelCatalogSource"] != "tutti-agent-cli" {
 		t.Fatalf("modelCatalogSource = %#v, want tutti-agent-cli", options.RuntimeContext["modelCatalogSource"])


### PR DESCRIPTION
## Summary
- make Tutti Agent provider policy expose model selection but no reasoning or speed composer controls
- remove reasoning/speed option ids and defaults for the provider
- gate model-derived reasoning and speed projections by provider policy so catalog data cannot reopen hidden controls
- preserve model controls for providers that explicitly support them

## Validation
- pnpm check:changed -- --dry-run
- pnpm check:changed
- pre-push pnpm check:changed -- --push-ready
- all 12 selected push-ready lanes passed

## Coordinated rollout
This change must be published as part of the complete Tutti Go module cohort before TSH upgrades its pinned dependencies. No package was published and no deployment was performed by this PR.