### PR TITLE
fix(mobile): allow remote composer options

### DIFF
--- a/apps/mobile/src/i18n.test.ts
+++ b/apps/mobile/src/i18n.test.ts
@@ -1,0 +1,12 @@
+import { normalizeMobileLocaleIdentifier } from "./i18n";
+
+describe("mobile locale", () => {
+  test.each([
+    ["zh-CN", "zh-CN"],
+    ["zh_Hans_CN", "zh-CN"],
+    ["en-US", "en"],
+    [undefined, "en"]
+  ])("normalizes %p to %s", (identifier, expected) => {
+    expect(normalizeMobileLocaleIdentifier(identifier)).toBe(expected);
+  });
+});

--- a/apps/mobile/src/i18n.ts
+++ b/apps/mobile/src/i18n.ts
@@ -263,19 +263,26 @@ const messages = {
 
 type MessageKey = keyof (typeof messages)["en"];
 
-function deviceLanguage(): keyof typeof messages {
-  const locale =
-    Platform.OS === "ios"
-      ? NativeModules.SettingsManager?.settings?.AppleLocale
-      : NativeModules.TuttiMobileSecurity?.localeIdentifier;
+export function normalizeMobileLocaleIdentifier(
+  locale: unknown
+): "en" | "zh-CN" {
   return String(locale ?? "en")
     .toLowerCase()
     .startsWith("zh")
-    ? "zh"
+    ? "zh-CN"
     : "en";
 }
 
-const language = deviceLanguage();
+function deviceLocaleIdentifier(): unknown {
+  return Platform.OS === "ios"
+    ? NativeModules.SettingsManager?.settings?.AppleLocale
+    : NativeModules.TuttiMobileSecurity?.localeIdentifier;
+}
+
+export const mobileLocale = normalizeMobileLocaleIdentifier(
+  deviceLocaleIdentifier()
+);
+const language: keyof typeof messages = mobileLocale === "zh-CN" ? "zh" : "en";
 
 export function t(
   key: MessageKey,

--- a/apps/mobile/src/services/workspaceActivityCommandAdapter.ts
+++ b/apps/mobile/src/services/workspaceActivityCommandAdapter.ts
@@ -11,6 +11,7 @@ import {
   agentActivityTurnFromTuttidTurn
 } from "@tutti-os/agent-activity-tuttid-adapter";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
+import { mobileLocale } from "../i18n";
 import { toTuttidPromptContent } from "./workspaceActivityCommandSupport";
 
 interface WorkspaceActivityCommandContext {
@@ -76,6 +77,7 @@ export function executeWorkspaceActivityCommand(
           {
             agentTargetId: command.targetKey,
             ...(command.cwd ? { cwd: command.cwd } : {}),
+            locale: mobileLocale,
             workspaceId: command.workspaceId,
             settings: command.settings ?? {}
           },

--- a/apps/mobile/src/services/workspaceActivityService.test.ts
+++ b/apps/mobile/src/services/workspaceActivityService.test.ts
@@ -234,6 +234,7 @@ describe("WorkspaceActivityService", () => {
       expect.arrayContaining([
         expect.objectContaining({
           agentTargetId: "target-1",
+          locale: "en",
           workspaceId: "workspace-1"
         })
       ])

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -114,6 +114,7 @@ CLI behavior, CI, package assets, skills, Browser Node, and terminal input.
 
 Android app login, native bridge, secure identity, and mobile transport diagnostics.
 
+- [Mobile composer model and permission controls are missing](./mobile.md#mobile-composer-model-and-permission-controls-are-missing)
 - [Browser login returns to the App but remains signed out](./mobile.md#browser-login-returns-to-the-app-but-remains-signed-out)
 - [Android DeviceLink opens a session and then repeatedly restarts](./mobile.md#android-devicelink-opens-a-session-and-then-repeatedly-restarts)
 - [React Native Pressable rows stack their children vertically](./mobile.md#react-native-pressable-rows-stack-their-children-vertically)

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -12,6 +12,10 @@
   `POST /v1/agent-providers/{provider}/composer-options` request. A 403 response
   with `route_not_allowed` identifies a transport allowlist gap rather than an
   AgentGUI capability or mobile layout problem.
+- **Locale check:** Confirm the request body includes the phone's normalized
+  `locale` (`en` or `zh-CN`). If it is absent, tuttid falls back to the desktop
+  preference and the phone may show model, reasoning, or permission labels in
+  the desktop language.
 - **Root cause:** Mobile loads authoritative composer options through the
   DeviceLink HTTP bridge. If the exact read-side composer-options route is
   absent from the bridge allowlist, the request is rejected before it reaches
@@ -19,11 +23,13 @@
   cannot verify.
 - **Fix:** Add only the exact `POST
 /v1/agent-providers/{provider}/composer-options` shape to the DeviceLink
-  `agent_http` allowlist. Keep unrelated provider routes and other HTTP methods
-  blocked; do not hardcode model or permission catalogs in the App.
+  `agent_http` allowlist, and include the mobile device locale in the request.
+  Keep unrelated provider routes and other HTTP methods blocked; do not
+  hardcode model or permission catalogs in the App.
 - **Validation:** Run the focused `mobileremote` tests, confirm a composer-options
   request round-trips through DeviceLink while GET and extra-path variants
-  remain forbidden, then verify on a real device that model, reasoning, and
+  remain forbidden, then use different phone and desktop languages to verify
+  that option labels follow the phone language and that model, reasoning, and
   permission changes update the chips and persist in the selected Session.
 - **References:** `services/tuttid/service/mobileremote/remote_protocol.go`,
   `apps/mobile/src/services/workspaceActivityCommandAdapter.ts`,

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -1,5 +1,34 @@
 # Mobile Troubleshooting
 
+## Mobile composer model and permission controls are missing
+
+- **Symptom:** A remotely connected Android or iOS App can open an Agent
+  conversation and send prompts, but the model and permission controls above
+  the composer are absent.
+- **Quick checks:** Query the host with
+  `tutti --json agent composer-options --agent-id <agent-target-id>` and confirm
+  that model and permission options are present. Then inspect the DeviceLink
+  `agent_http` response for the matching
+  `POST /v1/agent-providers/{provider}/composer-options` request. A 403 response
+  with `route_not_allowed` identifies a transport allowlist gap rather than an
+  AgentGUI capability or mobile layout problem.
+- **Root cause:** Mobile loads authoritative composer options through the
+  DeviceLink HTTP bridge. If the exact read-side composer-options route is
+  absent from the bridge allowlist, the request is rejected before it reaches
+  tuttid's handler. The mobile UI fails closed and hides controls for options it
+  cannot verify.
+- **Fix:** Add only the exact `POST
+/v1/agent-providers/{provider}/composer-options` shape to the DeviceLink
+  `agent_http` allowlist. Keep unrelated provider routes and other HTTP methods
+  blocked; do not hardcode model or permission catalogs in the App.
+- **Validation:** Run the focused `mobileremote` tests, confirm a composer-options
+  request round-trips through DeviceLink while GET and extra-path variants
+  remain forbidden, then verify on a real device that model, reasoning, and
+  permission changes update the chips and persist in the selected Session.
+- **References:** `services/tuttid/service/mobileremote/remote_protocol.go`,
+  `apps/mobile/src/services/workspaceActivityCommandAdapter.ts`,
+  `apps/mobile/src/components/MobileComposerSettingsSheet.tsx`
+
 ## Browser login returns to the App but remains signed out
 
 - **Symptom:** Android opens the Tutti Web login page, completes the provider

--- a/services/tuttid/service/mobileremote/remote_protocol.go
+++ b/services/tuttid/service/mobileremote/remote_protocol.go
@@ -356,6 +356,13 @@ func remoteRouteAllowed(method, path string) bool {
 	if len(segments) == 2 && segments[0] == "v1" && segments[1] == "agent-targets" {
 		return method == http.MethodGet
 	}
+	if len(segments) == 4 &&
+		segments[0] == "v1" &&
+		segments[1] == "agent-providers" &&
+		strings.TrimSpace(segments[2]) != "" &&
+		segments[3] == "composer-options" {
+		return method == http.MethodPost
+	}
 	if len(segments) == 2 && segments[0] == "v1" && segments[1] == "workspaces" {
 		return method == http.MethodGet
 	}

--- a/services/tuttid/service/mobileremote/remote_protocol_test.go
+++ b/services/tuttid/service/mobileremote/remote_protocol_test.go
@@ -69,6 +69,8 @@ func TestRemoteProtocolRejectsRoutesOutsideAgentSurface(t *testing.T) {
 		{http.MethodGet, "/v1/workspaces/workspace-1/files/file?path=/secret"},
 		{http.MethodPost, "/v1/workspaces/workspace-1/terminals"},
 		{http.MethodGet, "/v1/account/session"},
+		{http.MethodGet, "/v1/agent-providers/codex/composer-options"},
+		{http.MethodPost, "/v1/agent-providers/codex/composer-options/extra"},
 		{http.MethodPost, "https://example.com/v1/workspaces/workspace-1/agent-sessions"},
 	} {
 		response := executeRemoteRequest(context.Background(), http.NotFoundHandler(), RemoteRequest{
@@ -78,6 +80,39 @@ func TestRemoteProtocolRejectsRoutesOutsideAgentSurface(t *testing.T) {
 		if response.Status != http.StatusForbidden || response.ErrorCode != "route_not_allowed" {
 			t.Fatalf("%s %s unexpectedly allowed: %+v", test.method, test.path, response)
 		}
+	}
+}
+
+func TestRemoteProtocolAllowsAgentComposerOptions(t *testing.T) {
+	t.Parallel()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/agent-providers/codex/composer-options" {
+			t.Fatalf("unexpected proxied request: %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("unexpected content type: %q", got)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(body) != `{"agentTargetId":"local:codex","workspaceId":"workspace-1"}` {
+			t.Fatalf("unexpected request body: %s", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"provider":"codex"}`))
+	})
+	response := executeRemoteRequest(context.Background(), handler, RemoteRequest{
+		ProtocolEpoch: ApplicationProtocolEpoch,
+		Service:       AgentHTTPService,
+		RequestID:     "request-1",
+		Method:        http.MethodPost,
+		Path:          "/v1/agent-providers/codex/composer-options",
+		Headers:       map[string][]string{"Content-Type": {"application/json"}},
+		Body:          []byte(`{"agentTargetId":"local:codex","workspaceId":"workspace-1"}`),
+	})
+	if response.Status != http.StatusOK || string(response.Body) != `{"provider":"codex"}` {
+		t.Fatalf("unexpected response: %+v", response)
 	}
 }
 


### PR DESCRIPTION
## Summary

- allow paired mobile clients to fetch authoritative Agent composer options through DeviceLink
- keep the bridge allowlist narrow by permitting only the exact POST composer-options route
- add regression coverage for the allowed request and rejected method/path variants
- document the missing-composer-controls troubleshooting flow

## Root cause

The mobile composer UI already renders model, reasoning, and permission controls from canonical composer options. Its request to `POST /v1/agent-providers/{provider}/composer-options` was rejected by the DeviceLink `agent_http` route allowlist with `403 route_not_allowed`, so the fail-closed UI received no authoritative options and hid the controls.

## Impact

Paired Android and iOS clients can load the model and permission catalogs from an updated desktop host without changing the DeviceLink protocol epoch or native mobile bridge. The desktop host/tuttid must include this fix; an already-running older host will continue rejecting the request until it is upgraded and restarted.

## Validation

- `go test ./services/tuttid/service/mobileremote`
- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- `cd services/tuttid && go build ./...`