### PR TITLE
fix(workspace-settings): restore mobile connection section

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
@@ -326,6 +326,21 @@ test("WorkspaceSettingsService opens the model plans pane for managed-models req
   assert.equal(service.store.activeSection, "model");
 });
 
+test("WorkspaceSettingsService maps the legacy Account section to Connection", () => {
+  const service = new WorkspaceSettingsService({
+    client: createWorkspaceSettingsClient({})
+  });
+
+  service.openPanel(
+    { id: "workspace-1" },
+    {
+      section: "account"
+    }
+  );
+
+  assert.equal(service.store.activeSection, "connection");
+});
+
 test("WorkspaceSettingsService opens agent settings with a focused anchor", () => {
   const service = new WorkspaceSettingsService({
     client: createWorkspaceSettingsClient({})

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.ts
@@ -172,7 +172,8 @@ export class WorkspaceSettingsService implements IWorkspaceSettingsService {
     if (options?.pane === "managed-models" || requestedSection === "apps") {
       this.store.activeSection = "model";
     } else if (options?.section) {
-      this.store.activeSection = options.section;
+      this.store.activeSection =
+        options.section === "account" ? "connection" : options.section;
     }
     if (options?.anchor) {
       this.store.activeSection = "agent";
@@ -432,9 +433,6 @@ export class WorkspaceSettingsService implements IWorkspaceSettingsService {
 
   private applyTuttiAgentTargetEnabled(enabled: boolean): void {
     this.store.tuttiAgentSwitchEnabled = enabled;
-    if (!enabled && this.store.activeSection === "account") {
-      this.store.activeSection = "general";
-    }
   }
 
   private async refreshAgentTargetConsumers(): Promise<void> {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceSettingsService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceSettingsService.interface.ts
@@ -102,7 +102,7 @@ export interface WorkspaceSettingsOpenOptions {
   anchor?: WorkspaceSettingsGeneralFocusAnchor;
   pane?: string;
   provider?: string;
-  section?: WorkspaceSettingsSectionID;
+  section?: WorkspaceSettingsSectionID | "account";
 }
 
 export interface IWorkspaceSettingsService {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceSettingsTypes.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceSettingsTypes.ts
@@ -17,9 +17,9 @@ type WorkspaceSettingsReadonly<T> = T extends readonly (infer Item)[]
 
 export type WorkspaceSettingsSectionID =
   | "about"
-  | "account"
   | "agent"
   | "appearance"
+  | "connection"
   | "developer"
   | "general"
   | "lab"

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceConnectionSettingsSection.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceConnectionSettingsSection.tsx
@@ -1,0 +1,130 @@
+import { useEffect } from "react";
+import type { DesktopFeatureFlags } from "@shared/preferences";
+import { LoadingIcon } from "@tutti-os/ui-system";
+import {
+  isFeatureEnabled,
+  MOBILE_REMOTE_ACCESS_SETTINGS_FLAG
+} from "../../../../../shared/featureFlags/catalog.ts";
+import { useTranslation } from "@renderer/i18n";
+import { WorkspaceMobileRemoteSettingsSection } from "./WorkspaceMobileRemoteSettingsSection";
+import { WorkspaceSettingsActionButton } from "./WorkspaceSettingsActionButton";
+import { useAccountService } from "./useAccountService";
+
+export function WorkspaceConnectionSettingsSection({
+  featureFlags
+}: {
+  featureFlags: DesktopFeatureFlags;
+}) {
+  const { t } = useTranslation();
+  const { service: accountService, state: accountState } = useAccountService();
+  const mobileRemoteAccessSettingsEnabled = isFeatureEnabled(
+    featureFlags,
+    MOBILE_REMOTE_ACCESS_SETTINGS_FLAG
+  );
+
+  useEffect(() => {
+    void accountService.refreshUserInfo();
+  }, [accountService]);
+
+  const handleLogin = async () => {
+    if (accountState.signingOut) {
+      return;
+    }
+    await accountService.startLogin();
+  };
+
+  const handleLogout = async () => {
+    if (accountState.signingIn || accountState.signingOut) {
+      return;
+    }
+    await accountService.logout();
+  };
+
+  const user = accountState.user;
+  const displayName = user?.name || user?.email || user?.user_id || "Tutti";
+
+  return (
+    <div className="flex flex-col gap-6 pb-[22px] pt-5">
+      <div className="flex min-w-0 items-center justify-between gap-4 max-[560px]:flex-col max-[560px]:items-stretch">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          {user?.avatar ? (
+            <img
+              alt=""
+              className="size-12 shrink-0 rounded-full object-cover"
+              draggable={false}
+              src={user.avatar}
+            />
+          ) : (
+            <div className="grid size-12 shrink-0 place-items-center rounded-full bg-[var(--transparency-block)] text-[18px] font-semibold text-[var(--text-primary)]">
+              {displayName.slice(0, 1).toUpperCase()}
+            </div>
+          )}
+          <div className="min-w-0">
+            <strong className="block truncate text-[16px] font-semibold leading-6 text-[var(--text-primary)]">
+              {accountState.loading
+                ? t("common.loading")
+                : user
+                  ? displayName
+                  : t("workspace.settings.account.signedOutTitle")}
+            </strong>
+            <p className="m-0 truncate text-[13px] text-[var(--text-secondary)]">
+              {user?.email || t("workspace.settings.account.description")}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 flex-wrap justify-end gap-2 max-[560px]:w-full max-[560px]:justify-start">
+          {user ? (
+            <>
+              <WorkspaceSettingsActionButton
+                className="w-auto min-w-[96px]"
+                disabled={accountState.signingIn || accountState.signingOut}
+                label={
+                  accountState.signingOut
+                    ? t("workspace.settings.account.signingOut")
+                    : t("workspace.settings.account.logout")
+                }
+                onClick={handleLogout}
+              />
+              <WorkspaceSettingsActionButton
+                className="w-auto min-w-[96px]"
+                disabled={accountState.signingIn || accountState.signingOut}
+                label={t("workspace.settings.account.refresh")}
+                onClick={() => void accountService.refreshUserInfo()}
+              />
+            </>
+          ) : (
+            <WorkspaceSettingsActionButton
+              className="w-auto min-w-[104px] max-[560px]:w-full"
+              disabled={accountState.loading || accountState.signingOut}
+              icon={
+                accountState.signingIn ? (
+                  <LoadingIcon className="size-3.5" />
+                ) : null
+              }
+              label={
+                accountState.signingIn
+                  ? t("workspace.settings.account.signingIn")
+                  : accountState.loginStatus === "pending"
+                    ? t("workspace.settings.account.reopenLogin")
+                    : t("workspace.settings.account.login")
+              }
+              onClick={handleLogin}
+              variant="default"
+            />
+          )}
+        </div>
+      </div>
+
+      {accountState.error ? (
+        <p className="m-0 rounded-[6px] bg-[color-mix(in_srgb,var(--state-warning)_16%,transparent)] px-3 py-2 text-[13px] text-[var(--text-primary)]">
+          {accountState.error}
+        </p>
+      ) : null}
+
+      {user && mobileRemoteAccessSettingsEnabled ? (
+        <WorkspaceMobileRemoteSettingsSection />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
@@ -13,6 +13,10 @@ const runtimeTabSource = readFileSync(
   resolve(directory, "WorkspaceAgentsSettingsTab.tsx"),
   "utf8"
 );
+const connectionSectionSource = readFileSync(
+  resolve(directory, "WorkspaceConnectionSettingsSection.tsx"),
+  "utf8"
+);
 
 test("workspace settings gives Model an independent Plan-only section", () => {
   assert.match(panelSource, /id: "model" as const/);
@@ -39,4 +43,24 @@ test("workspace settings makes Custom Agents the third Agent tab", () => {
     /agentTab === "customAgents"[\s\S]{0,220}<WorkspaceAgentsSection \/>/
   );
   assert.doesNotMatch(runtimeTabSource, /WorkspaceAgentsSection/);
+});
+
+test("workspace settings shows Connection with mobile remote access settings", () => {
+  assert.match(
+    panelSource,
+    /\.\.\.\(mobileRemoteAccessSettingsEnabled[\s\S]{0,220}id: "connection" as const/
+  );
+  assert.match(
+    panelSource,
+    /activeSection === "connection"[\s\S]{0,220}<WorkspaceConnectionSettingsSection/
+  );
+  assert.match(
+    panelSource,
+    /!mobileRemoteAccessSettingsEnabled[\s\S]{0,120}activeSection === "connection"[\s\S]{0,120}selectSection\("general"\)/
+  );
+  assert.match(connectionSectionSource, /accountService\.refreshUserInfo\(\)/);
+  assert.match(
+    connectionSectionSource,
+    /user && mobileRemoteAccessSettingsEnabled[\s\S]{0,120}<WorkspaceMobileRemoteSettingsSection/
+  );
 });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -93,6 +93,7 @@ import {
   LAB_WORKBENCH_SHORTCUTS_FLAG,
   LAB_AUTOMATION_RULES_FLAG,
   LAB_WORKSPACE_AGENTS_FLAG,
+  MOBILE_REMOTE_ACCESS_SETTINGS_FLAG,
   resolveDesktopWorkspaceUiMode
 } from "../../../../../shared/featureFlags/catalog.ts";
 import { resolveWorkspaceAgentGuiLabel } from "../services/workspaceAgentProviderCatalog";
@@ -131,6 +132,7 @@ import {
   workspaceWallpaperOptions
 } from "../services/workspaceWallpaper";
 import { WorkspaceModelPlansSection } from "./WorkspaceModelPlansSection";
+import { WorkspaceConnectionSettingsSection } from "./WorkspaceConnectionSettingsSection";
 import {
   workspaceSettingsInputClass,
   workspaceSettingsSelectContentClass,
@@ -204,6 +206,10 @@ export function WorkspaceSettingsPanel({
     pendingFeatureFlags,
     LAB_AUTOMATION_RULES_FLAG
   );
+  const mobileRemoteAccessSettingsEnabled = isFeatureEnabled(
+    pendingFeatureFlags,
+    MOBILE_REMOTE_ACCESS_SETTINGS_FLAG
+  );
 
   useEffect(() => {
     if (settingsState.open) {
@@ -222,6 +228,19 @@ export function WorkspaceSettingsPanel({
       settingsService.selectSection("general");
     }
   }, [modelPlansEnabled, settingsService, settingsState.activeSection]);
+
+  useEffect(() => {
+    if (
+      !mobileRemoteAccessSettingsEnabled &&
+      settingsState.activeSection === "connection"
+    ) {
+      settingsService.selectSection("general");
+    }
+  }, [
+    mobileRemoteAccessSettingsEnabled,
+    settingsService,
+    settingsState.activeSection
+  ]);
 
   useEffect(() => {
     if (
@@ -317,6 +336,14 @@ export function WorkspaceSettingsPanel({
               id: "appearance" as const,
               label: t("workspace.settings.nav.appearance")
             },
+            ...(mobileRemoteAccessSettingsEnabled
+              ? [
+                  {
+                    id: "connection" as const,
+                    label: t("workspace.settings.nav.connection")
+                  }
+                ]
+              : []),
             {
               id: "about" as const,
               label: t("workspace.settings.nav.about")
@@ -589,6 +616,13 @@ export function WorkspaceSettingsPanel({
                 onWorkbenchShortcutsChange={(shortcuts) => {
                   void settingsService.changeWorkbenchShortcuts(shortcuts);
                 }}
+              />
+            ) : settingsState.activeSection === "connection" ? (
+              <WorkspaceConnectionSettingsSection
+                featureFlags={
+                  desktopPreferencesState.changingFeatureFlags ??
+                  desktopPreferencesState.featureFlags
+                }
               />
             ) : settingsState.activeSection === "about" ? (
               <WorkspaceAboutSettingsSection

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -808,11 +808,11 @@ export const en = {
       },
       nav: {
         about: "About",
-        account: "Account",
         apps: "Apps",
         sectionsLabel: "Settings sections",
         appearance: "Appearance",
         agent: "Agent",
+        connection: "Connection",
         developer: "Developer",
         general: "General",
         lab: "Lab",
@@ -1169,7 +1169,7 @@ export const en = {
         logsSummary: "{{count}} files, {{size}} total",
         logsTitle: "Logs",
         mobileRemoteAccessSettingsDescription:
-          "Show phone pairing and remote access controls in Account settings.",
+          "Show Connection settings with phone pairing and remote access controls.",
         mobileRemoteAccessSettingsLabel: "Show mobile remote access settings",
         mobileRemoteAccessSettingsSaveFailed:
           "We couldn't update mobile remote access visibility.",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -760,11 +760,11 @@ export const zhCN = {
       },
       nav: {
         about: "关于",
-        account: "账号",
         apps: "应用",
         sectionsLabel: "设置分区",
         appearance: "外观",
         agent: "Agent",
+        connection: "连接",
         developer: "开发者",
         general: "通用",
         lab: "实验室",
@@ -1099,7 +1099,7 @@ export const zhCN = {
         logsSummary: "{{count}} 个文件，共 {{size}}",
         logsTitle: "日志",
         mobileRemoteAccessSettingsDescription:
-          "在账号设置中显示手机配对与远程访问控制项",
+          "显示连接设置以及手机配对与远程访问控制项",
         mobileRemoteAccessSettingsLabel: "显示手机远程访问设置",
         mobileRemoteAccessSettingsSaveFailed:
           "暂时无法更新手机远程访问显示设置",

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -472,9 +472,11 @@ pnpm mobile:android
 
 App 启动后，使用与 Desktop 相同的账号登录方式。如果 Desktop 使用 GitHub 登录，
 Mobile 也点击“使用 GitHub 登录”并在系统浏览器中完成登录；仅输入 GitHub 展示的
-相同邮箱不保证得到同一个账号 identity。登录成功后点击配对，优先扫描 Desktop
-二维码。首次扫码时允许 App 使用相机；如果当前环境无法使用相机，就在 Desktop
-点击“复制配对码”，再在 Mobile 展开手动配对入口并粘贴。
+相同邮箱不保证得到同一个账号 identity。Desktop 先在设置的开发者页打开
+“显示手机远程访问设置”，再进入「连接」并点击“配对手机”生成二维码。Mobile
+登录成功后点击配对，优先扫描 Desktop 二维码。首次扫码时允许 App 使用相机；如果
+当前环境无法使用相机，就在 Desktop 点击“复制配对码”，再在 Mobile 展开手动配对
+入口并粘贴。
 
 配对二维码是 5 分钟有效的一次性 challenge。Desktop 会在 challenge 到期或状态查询
 失败后撤下旧二维码；此时重新点击“配对手机”生成新码，不要继续使用之前复制或拍摄的

--- a/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
+++ b/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
@@ -224,10 +224,11 @@ Cookie，也不新增移动端账号实体。
 5. tsh-server 校验同账号和 challenge 状态；
 6. Desktop 显式确认配对。
 
-Desktop 的账号登录入口与手机远程访问入口独立发布。登录能力可以面向用户开放，
-而账号设置中的手机配对和远程访问区块默认隐藏；开发者设置通过持久化
-`mobile.remoteAccessSettings` feature flag 控制该区块是否显示。此开关只控制
-Desktop 设置入口可见性，不创建第二套登录态、设备实体或协议能力。
+Desktop 的账号登录入口与手机远程访问入口独立发布。开发者设置中的
+`Tutti Agent Switch` 控制工作区账号菜单和 Agent 开发控制项是否显示。独立持久化的
+`mobile.remoteAccessSettings` feature flag 控制「连接」设置入口是否显示；「连接」
+页承载账号登录、退出、刷新、手机配对和远程访问能力。两个开关都只控制 Desktop
+入口可见性，不创建第二套登录态、设备实体或协议能力。
 
 QR 不包含 bearer token、私钥、原始候选或可长期使用的连接凭据。
 


### PR DESCRIPTION
## Summary

- add a new **Connection** section to workspace settings
- show the section only when **Show mobile remote access settings** is enabled
- restore account sign-in, sign-out, refresh, QR pairing, pairing-code copy, and paired-device removal
- map legacy `account` settings deep links to `connection`
- update localized copy and mobile pairing documentation

## Why

The workspace settings refactor removed the Account section while leaving the mobile pairing services, feature flag, and developer toggle in place. This made the QR pairing flow unreachable even when the remote-access setting was enabled.

The restored Connection section gives those existing capabilities a dedicated entry and keeps its visibility owned by `mobile.remoteAccessSettings`, independently of the Tutti Agent switch.

## User impact

After enabling **Show mobile remote access settings** under Developer settings, users can open **Connection**, sign in, generate a phone-pairing QR code, copy the pairing code, and manage paired phones. Disabling the setting hides Connection and returns an open Connection page to General.

## Validation

- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- `pnpm --filter @tutti-os/desktop build`
