### PR TITLE
fix(mobile): use aligned gomobile toolchain

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.5"
+          go-version: "1.26.0"
           cache-dependency-path: |
             go.work
             go.work.sum

--- a/apps/mobile/android/Makefile
+++ b/apps/mobile/android/Makefile
@@ -2,16 +2,18 @@
 
 ANDROID_API ?= 26
 ANDROID_NDK_VERSION ?= 27.3.13750724
+GOMOBILE_GO_TOOLCHAIN ?= go1.26.0
 GOMOBILE_LDFLAGS ?= -checklinkname=0
 REPO_ROOT := $(abspath ../../..)
 DEVICE_LINK_DIR := $(REPO_ROOT)/packages/device-link
 AAR_OUTPUT ?= $(CURDIR)/app/libs/tutti-mobile-go.aar
 JAVA_PACKAGE := dev.tutti.mobile.bindings
+GOMOBILE_GO := env GOTOOLCHAIN=$(GOMOBILE_GO_TOOLCHAIN) go
 
 android-bindings-check:
 	@bind_tmp=$$(mktemp -d); \
 	trap 'rm -rf "$$bind_tmp"' EXIT; \
-	cd "$(DEVICE_LINK_DIR)" && go tool gobind -lang=java -javapkg=$(JAVA_PACKAGE) -outdir="$$bind_tmp" ./mobile ../agent/daemon/liveprotocol/mobile; \
+	cd "$(DEVICE_LINK_DIR)" && $(GOMOBILE_GO) tool gobind -lang=java -javapkg=$(JAVA_PACKAGE) -outdir="$$bind_tmp" ./mobile ../agent/daemon/liveprotocol/mobile; \
 	test -f "$$bind_tmp/java/dev/tutti/mobile/bindings/mobile/Mobile.java"; \
 	test -f "$$bind_tmp/java/dev/tutti/mobile/bindings/liveprotocolmobile/Liveprotocolmobile.java"
 
@@ -23,8 +25,8 @@ android-aar:
 	@mkdir -p "$(dir $(AAR_OUTPUT))"
 	@tool_tmp=$$(mktemp -d); \
 	trap 'rm -rf "$$tool_tmp"' EXIT; \
-	cd "$(DEVICE_LINK_DIR)" && GOBIN="$$tool_tmp" go install golang.org/x/mobile/cmd/gobind; \
-	cd "$(DEVICE_LINK_DIR)" && ANDROID_NDK_HOME="$(ANDROID_HOME)/ndk/$(ANDROID_NDK_VERSION)" PATH="$$tool_tmp:$$PATH" go tool gomobile bind -target=android -androidapi=$(ANDROID_API) -javapkg=$(JAVA_PACKAGE) -ldflags="$(GOMOBILE_LDFLAGS)" -o "$(AAR_OUTPUT)" ./mobile ../agent/daemon/liveprotocol/mobile
+	cd "$(DEVICE_LINK_DIR)" && GOBIN="$$tool_tmp" $(GOMOBILE_GO) install golang.org/x/mobile/cmd/gobind; \
+	cd "$(DEVICE_LINK_DIR)" && ANDROID_NDK_HOME="$(ANDROID_HOME)/ndk/$(ANDROID_NDK_VERSION)" PATH="$$tool_tmp:$$PATH" $(GOMOBILE_GO) tool gomobile bind -target=android -androidapi=$(ANDROID_API) -javapkg=$(JAVA_PACKAGE) -ldflags="$(GOMOBILE_LDFLAGS)" -o "$(AAR_OUTPUT)" ./mobile ../agent/daemon/liveprotocol/mobile
 	@$(MAKE) android-aar-check
 
 android-aar-check:
@@ -38,4 +40,8 @@ android-aar-check:
 	trap 'rm -rf "$$aar_tmp"' EXIT; \
 	unzip -p "$(AAR_OUTPUT)" classes.jar > "$$aar_tmp/classes.jar"; \
 	"$(JAVA_HOME)/bin/jar" tf "$$aar_tmp/classes.jar" | grep -Fqx 'dev/tutti/mobile/bindings/mobile/Mobile.class'; \
-	"$(JAVA_HOME)/bin/jar" tf "$$aar_tmp/classes.jar" | grep -Fqx 'dev/tutti/mobile/bindings/liveprotocolmobile/Liveprotocolmobile.class'
+	"$(JAVA_HOME)/bin/jar" tf "$$aar_tmp/classes.jar" | grep -Fqx 'dev/tutti/mobile/bindings/liveprotocolmobile/Liveprotocolmobile.class'; \
+	for abi in armeabi-v7a arm64-v8a x86 x86_64; do \
+		unzip -p "$(AAR_OUTPUT)" "jni/$$abi/libgojni.so" > "$$aar_tmp/libgojni-$$abi.so"; \
+		$(GOMOBILE_GO) version -m "$$aar_tmp/libgojni-$$abi.so" | head -n 1 | grep -Fq ": $(GOMOBILE_GO_TOOLCHAIN)"; \
+	done

--- a/apps/mobile/ios/Makefile
+++ b/apps/mobile/ios/Makefile
@@ -1,15 +1,17 @@
 .PHONY: ios-bindings-check ios-framework ios-framework-check
 
+GOMOBILE_GO_TOOLCHAIN ?= go1.26.0
 GOMOBILE_LDFLAGS ?= -checklinkname=0
 REPO_ROOT := $(abspath ../../..)
 DEVICE_LINK_DIR := $(REPO_ROOT)/packages/device-link
 FRAMEWORK_OUTPUT ?= $(CURDIR)/Frameworks/TuttiMobileGo.xcframework
 OBJC_PREFIX := TUT
+GOMOBILE_GO := env GOTOOLCHAIN=$(GOMOBILE_GO_TOOLCHAIN) go
 
 ios-bindings-check:
 	@bind_tmp=$$(mktemp -d); \
 	trap 'rm -rf "$$bind_tmp"' EXIT; \
-	cd "$(DEVICE_LINK_DIR)" && DEVELOPER_DIR=/Library/Developer/CommandLineTools go tool gobind -lang=objc -prefix=$(OBJC_PREFIX) -outdir="$$bind_tmp" ./mobile ../agent/daemon/liveprotocol/mobile; \
+	cd "$(DEVICE_LINK_DIR)" && DEVELOPER_DIR=/Library/Developer/CommandLineTools $(GOMOBILE_GO) tool gobind -lang=objc -prefix=$(OBJC_PREFIX) -outdir="$$bind_tmp" ./mobile ../agent/daemon/liveprotocol/mobile; \
 	test -f "$$bind_tmp/src/gobind/$(OBJC_PREFIX)Mobile.objc.h"; \
 	test -f "$$bind_tmp/src/gobind/$(OBJC_PREFIX)Liveprotocolmobile.objc.h"; \
 	grep -Fq 'TUTMobileNewLink' "$$bind_tmp/src/gobind/$(OBJC_PREFIX)Mobile.objc.h"; \
@@ -21,8 +23,8 @@ ios-framework:
 	@mkdir -p "$(dir $(FRAMEWORK_OUTPUT))"
 	@tool_tmp=$$(mktemp -d); \
 	trap 'rm -rf "$$tool_tmp"' EXIT; \
-	cd "$(DEVICE_LINK_DIR)" && GOBIN="$$tool_tmp" go install golang.org/x/mobile/cmd/gobind; \
-	cd "$(DEVICE_LINK_DIR)" && PATH="$$tool_tmp:$$PATH" go tool gomobile bind -target=ios,iossimulator -prefix=$(OBJC_PREFIX) -ldflags="$(GOMOBILE_LDFLAGS)" -o "$(FRAMEWORK_OUTPUT)" ./mobile ../agent/daemon/liveprotocol/mobile
+	cd "$(DEVICE_LINK_DIR)" && GOBIN="$$tool_tmp" $(GOMOBILE_GO) install golang.org/x/mobile/cmd/gobind; \
+	cd "$(DEVICE_LINK_DIR)" && PATH="$$tool_tmp:$$PATH" $(GOMOBILE_GO) tool gomobile bind -target=ios,iossimulator -prefix=$(OBJC_PREFIX) -ldflags="$(GOMOBILE_LDFLAGS)" -o "$(FRAMEWORK_OUTPUT)" ./mobile ../agent/daemon/liveprotocol/mobile
 	@$(MAKE) ios-framework-check
 
 ios-framework-check:

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -68,24 +68,27 @@
 dev.tutti.mobile` and inspect a narrow logcat window for the Go fatal message.
   This distinguishes a Go runtime abort from an Android lifecycle transition or
   a React Native development reload.
-- **Root cause:** A gomobile-exported Go method returned `([]byte, error)`.
-  Generated cgo code moves the pointer-bearing return values through a packed
-  result structure; its address is not guaranteed to satisfy the Go runtime
-  write barrier's pointer alignment. The first successful response-body read
-  therefore exposed the upstream cgo alignment defect. Returning final data
-  together with `io.EOF` also cannot be represented by the generated Java API,
-  which chooses either a byte array or an exception.
-- **Fix:** Keep bulk stream data in a Java-owned byte array passed into Go and
-  return only a scalar byte count from the gomobile method. A positive count
-  takes precedence when the underlying Go reader returns data together with
-  `io.EOF`; zero or a negative count is a failed incomplete frame. Do not change
-  this boundary back to a Go slice-plus-error return while the repository uses a
-  Go toolchain affected by
-  [golang/go#46893](https://github.com/golang/go/issues/46893).
+- **Root cause:** A gomobile-exported Go method returned a pointer-bearing value,
+  first `([]byte, error)` and later `(string, error)` from Agent Live's
+  `Subscriber.Apply`. Generated cgo code moves pointer-bearing parameters and
+  return values through a packed structure whose address is not guaranteed to
+  satisfy the Go runtime write barrier's pointer alignment before Go 1.26. The
+  first successful response-body or Agent Live frame therefore exposes the
+  upstream cgo alignment defect. Returning final stream data together with
+  `io.EOF` also cannot be represented by the generated Java API, which chooses
+  either a byte array or an exception.
+- **Fix:** Build every Android AAR and iOS XCFramework gomobile artifact with
+  Go 1.26.0 or newer, which includes the
+  [cmd/cgo alignment fix](https://github.com/golang/go/commit/d5b950399de01a0e28eeb48d2c8474db4aad0e8a).
+  Keep bulk stream data in a Java-owned byte array passed into Go and return only
+  a scalar byte count so final bytes plus `io.EOF` remain representable. The
+  Mobile and DeviceLink Makefiles pin the fixed toolchain; do not bypass that pin
+  when rebuilding native artifacts.
 - **Validation:** Generate the Java binding and confirm the stream method is
-  `readInto(byte[])` with a scalar return, run the mobile DeviceLink tests, build
-  and install the AAR consumer, load a real session on an ARM64 Android device,
-  and observe beyond the previous crash window with no new Go fatal message.
+  `readInto(byte[])` with a scalar return, build the AAR and confirm every
+  `libgojni.so` reports the pinned Go toolchain, then install the AAR consumer,
+  connect on an ARM64 Android device, receive Agent Live frames, and observe
+  beyond the previous crash window with no new Go fatal message.
 - **References:** `packages/device-link/mobile/link.go`,
   `apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt`
 

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -180,6 +180,12 @@ pnpm --filter @tutti-os/mobile check:android-bindings
 pnpm --filter @tutti-os/mobile android:aar
 ```
 
+Android AAR 与 iOS XCFramework 的 gomobile 构建固定使用 Go 1.26.0。该版本包含
+cgo 导出参数与返回值结构的对齐修复；不要用 Go 1.25 或更早版本重建移动端
+native 产物，否则 ARM64 真机可能在返回 `string`、`[]byte` 等含指针值时直接
+触发 `bulkBarrierPreWrite: unaligned arguments`。Makefile 会通过 Go 的
+`GOTOOLCHAIN` 自动选择所需版本。
+
 输出位于忽略的
 `apps/mobile/android/app/libs/tutti-mobile-go.aar`。组合构建只是 Android
 宿主的 JNI 装配边界；它不会把 Agent 协议、Workspace DTO 或产品策略移入

--- a/packages/device-link/Makefile
+++ b/packages/device-link/Makefile
@@ -3,10 +3,12 @@
 ANDROID_API ?= 26
 ANDROID_NDK_VERSION ?= 27.3.13750724
 ANDROID_BUILD_TOOLS_VERSION ?= 36.0.0
+GOMOBILE_GO_TOOLCHAIN ?= go1.26.0
 AAR_OUTPUT ?= dist/tutti-device-link.aar
 PROBE_APK_OUTPUT ?= dist/tutti-device-link-probe.apk
 PROBE_KEYSTORE ?= dist/tutti-device-link-probe-debug.keystore
 GOMOBILE_LDFLAGS ?= -checklinkname=0
+GOMOBILE_GO := env GOTOOLCHAIN=$(GOMOBILE_GO_TOOLCHAIN) go
 
 test:
 	go test ./...
@@ -17,7 +19,7 @@ android-crosscompile:
 android-bindings-check:
 	@bind_tmp=$$(mktemp -d); \
 	trap 'rm -rf "$$bind_tmp"' EXIT; \
-	go tool gobind -lang=java -javapkg=dev.tutti.devicelink -outdir="$$bind_tmp" ./mobile; \
+	$(GOMOBILE_GO) tool gobind -lang=java -javapkg=dev.tutti.devicelink -outdir="$$bind_tmp" ./mobile; \
 	test -f "$$bind_tmp/java/dev/tutti/devicelink/mobile/Mobile.java"
 
 android-aar:
@@ -28,8 +30,8 @@ android-aar:
 	@mkdir -p "$(dir $(AAR_OUTPUT))"
 	@tool_tmp=$$(mktemp -d); \
 	trap 'rm -rf "$$tool_tmp"' EXIT; \
-	GOBIN="$$tool_tmp" go install golang.org/x/mobile/cmd/gobind; \
-	ANDROID_NDK_HOME="$(ANDROID_HOME)/ndk/$(ANDROID_NDK_VERSION)" PATH="$$tool_tmp:$$PATH" go tool gomobile bind -target=android -androidapi=$(ANDROID_API) -javapkg=dev.tutti.devicelink -ldflags="$(GOMOBILE_LDFLAGS)" -o "$(AAR_OUTPUT)" ./mobile
+	GOBIN="$$tool_tmp" $(GOMOBILE_GO) install golang.org/x/mobile/cmd/gobind; \
+	ANDROID_NDK_HOME="$(ANDROID_HOME)/ndk/$(ANDROID_NDK_VERSION)" PATH="$$tool_tmp:$$PATH" $(GOMOBILE_GO) tool gomobile bind -target=android -androidapi=$(ANDROID_API) -javapkg=dev.tutti.devicelink -ldflags="$(GOMOBILE_LDFLAGS)" -o "$(AAR_OUTPUT)" ./mobile
 	@$(MAKE) android-aar-check
 
 android-aar-check:
@@ -42,7 +44,11 @@ android-aar-check:
 	@aar_tmp=$$(mktemp -d); \
 	trap 'rm -rf "$$aar_tmp"' EXIT; \
 	unzip -p "$(AAR_OUTPUT)" classes.jar > "$$aar_tmp/classes.jar"; \
-	"$(JAVA_HOME)/bin/jar" tf "$$aar_tmp/classes.jar" | grep -Fqx 'dev/tutti/devicelink/mobile/Mobile.class'
+	"$(JAVA_HOME)/bin/jar" tf "$$aar_tmp/classes.jar" | grep -Fqx 'dev/tutti/devicelink/mobile/Mobile.class'; \
+	for abi in armeabi-v7a arm64-v8a x86 x86_64; do \
+		unzip -p "$(AAR_OUTPUT)" "jni/$$abi/libgojni.so" > "$$aar_tmp/libgojni-$$abi.so"; \
+		$(GOMOBILE_GO) version -m "$$aar_tmp/libgojni-$$abi.so" | head -n 1 | grep -Fq ": $(GOMOBILE_GO_TOOLCHAIN)"; \
+	done
 
 android-probe-apk: android-aar-check
 	@test -n "$(ANDROID_HOME)" || (echo "ANDROID_HOME is required" >&2; exit 1)


### PR DESCRIPTION
## Summary

- pin Android AAR and iOS XCFramework gomobile builds to Go 1.26.0
- verify every Android ABI embeds the pinned Go toolchain
- update Android CI and mobile troubleshooting/build documentation

## Root cause

After DeviceLink connected successfully, the first Agent Live frame called `Subscriber.Apply([]byte) (string, error)`. gomobile artifacts built with the previous Go toolchain used a packed cgo argument/result structure without sufficient pointer alignment. The Go write barrier aborted in `bulkBarrierPreWrite` while moving the pointer-bearing `string` result, producing a native `SIGABRT` on both Android and iOS.

Go 1.26 includes the upstream cmd/cgo alignment fix, so mobile native artifacts are now built with that toolchain explicitly rather than inheriting the repository-wide Go version.

## Impact

Android and iOS clients can receive Agent Live frames after a successful DeviceLink connection without crashing in `libgojni` or the generated gomobile bridge. Build-time checks prevent an Android AAR produced by the affected toolchain from being accepted silently.

## Validation

- built the Android gomobile AAR and confirmed the ARM64 `libgojni.so` reports `go1.26.0`; the Makefile check covers `armeabi-v7a`, `arm64-v8a`, `x86`, and `x86_64`
- assembled and covered-installed the debug APK on a Vivo V2507A ARM64 device
- connected successfully, entered the Agent session, retained the same process PID beyond the previous crash window, and observed no `SIGABRT`, `bulkBarrierPreWrite`, or crash-buffer entry
- regenerated the iOS XCFramework with the same Go 1.26 Makefile and confirmed its binary reports `go1.26.0`
- rebuilt and covered-installed on an iPhone 11; DeviceLink continued receiving substantial Agent Live data beyond the previous first-frame crash window with no `SIGABRT` or `bulkBarrierPreWrite`
- `pnpm check:changed` passed all 5 selected lanes
- pre-commit and pre-push hooks passed

## Documentation

Updated the mobile build guide and durable mobile troubleshooting entry with the affected boundary, required toolchain, artifact verification, and true-device validation path.