### PR TITLE
fix(mobile): restore composer option sheets

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -116,6 +116,7 @@ Android app login, native bridge, secure identity, and mobile transport diagnost
 
 - [Mobile quick prompts are missing from the plus menu](./mobile.md#mobile-quick-prompts-are-missing-from-the-plus-menu)
 - [Mobile composer model and permission controls are missing](./mobile.md#mobile-composer-model-and-permission-controls-are-missing)
+- [Mobile composer option chips do not open](./mobile.md#mobile-composer-option-chips-do-not-open)
 - [Browser login returns to the App but remains signed out](./mobile.md#browser-login-returns-to-the-app-but-remains-signed-out)
 - [Android DeviceLink opens a session and then repeatedly restarts](./mobile.md#android-devicelink-opens-a-session-and-then-repeatedly-restarts)
 - [React Native Pressable rows stack their children vertically](./mobile.md#react-native-pressable-rows-stack-their-children-vertically)

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -61,6 +61,31 @@
   `apps/mobile/src/services/workspaceActivityCommandAdapter.ts`,
   `apps/mobile/src/components/MobileComposerSettingsSheet.tsx`
 
+## Mobile composer option chips do not open
+
+- **Symptom:** Model, reasoning, speed, and permission chips are visible and
+  accessible above the composer, but tapping them does not show their option
+  sheet. The same model or permission options remain reachable through the `+`
+  menu.
+- **Quick checks:** Tap a chip on a real Android or iOS renderer and inspect the
+  JavaScript log. Repeated `BottomSheetModal::handlePortalRender` entries,
+  followed by a maximum-update-depth error, identify the overlay path; a
+  missing composer-options response is a different problem covered above.
+- **Root cause:** `@gorhom/bottom-sheet` delegates `BottomSheetModal` rendering
+  through `@gorhom/portal`. Its portal update path is incompatible with the
+  current React 19 Native renderer and recursively republishes the modal node
+  instead of presenting it.
+- **Fix:** Keep the shared compact `NativeSheet` on React Native's window-level
+  `Modal`, with UI System scrim and panel tokens. Reserve
+  `@gorhom/bottom-sheet` for app-owned complex sheets that genuinely need its
+  gesture, keyboard, or multi-snap-point behavior.
+- **Validation:** Open and dismiss the model, speed, and permission sheets more
+  than once, select the already active option without changing Session state,
+  and confirm there is no maximum-update-depth error. Also verify backdrop and
+  Android system-back dismissal.
+- **References:** `packages/ui/system/src/native/sheet.tsx`,
+  `apps/mobile/src/components/MobileComposerSettingsSheet.tsx`
+
 ## Browser login returns to the App but remains signed out
 
 - **Symptom:** Android opens the Tutti Web login page, completes the provider

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -259,7 +259,9 @@ screen composition and product-specific interaction.
   consumes it. Apps must not acquire direct third-party component imports.
 - Keep `@gorhom/bottom-sheet` as the dependency for complex gesture, keyboard,
   and dynamic-height sheets; wrap it behind a UI System Native component when
-  it becomes a reusable product pattern.
+  it becomes a reusable product pattern. The shared compact `NativeSheet` uses
+  React Native's window-level `Modal` instead, so its controlled open state does
+  not pass through `@gorhom/portal`.
 - Agent message Markdown is rendered natively with
   `react-native-enriched-markdown`; it consumes the existing AgentGUI
   conversation VM and maps every color, radius, and spacing decision back to

--- a/packages/ui/system/package.json
+++ b/packages/ui/system/package.json
@@ -68,7 +68,6 @@
     "ws": "^8.20.1"
   },
   "devDependencies": {
-    "@gorhom/bottom-sheet": "5.2.14",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@tutti-os/config-tsconfig": "workspace:*",
@@ -83,15 +82,11 @@
     "vitest": "^4.0.13"
   },
   "peerDependencies": {
-    "@gorhom/bottom-sheet": ">=5 <6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-native": ">=0.86 <0.87"
   },
   "peerDependenciesMeta": {
-    "@gorhom/bottom-sheet": {
-      "optional": true
-    },
     "react-dom": {
       "optional": true
     },

--- a/packages/ui/system/src/metadata/components.json
+++ b/packages/ui/system/src/metadata/components.json
@@ -3476,7 +3476,7 @@
       "status": "experimental",
       "source": "src/native/sheet.tsx",
       "propsType": "NativeSheetProps",
-      "description": "Controlled modal sheet backed by the shared Bottom Sheet dependency.",
+      "description": "Controlled compact sheet backed by React Native Modal with a token-backed scrim and panel.",
       "useCases": ["Row actions", "Confirmation flows", "Compact forms"],
       "migrationHints": [],
       "nativePreview": true

--- a/packages/ui/system/src/native/sheet.spec.tsx
+++ b/packages/ui/system/src/native/sheet.spec.tsx
@@ -21,15 +21,18 @@ vi.mock("react-native", () => ({
     return visible ? <div>{children}</div> : null;
   },
   Pressable: ({
+    accessible,
     children,
     onPress,
     testID
   }: {
+    accessible?: boolean;
     children: ReactNode;
     onPress(event: { stopPropagation(): void }): void;
     testID?: string;
   }) => (
     <div
+      data-accessible={String(accessible)}
       data-testid={testID}
       onClick={(event) =>
         onPress({ stopPropagation: () => event.stopPropagation() })
@@ -85,11 +88,15 @@ describe("NativeSheet", () => {
 
   it("reports backdrop and system dismissals to the controlled owner", () => {
     const onOpenChange = vi.fn();
-    render(
+    const { container } = render(
       <NativeSheet onOpenChange={onOpenChange} open>
         content
       </NativeSheet>
     );
+
+    expect(
+      container.querySelectorAll('[data-accessible="false"]')
+    ).toHaveLength(2);
 
     fireEvent.click(screen.getByText("content"));
     expect(onOpenChange).not.toHaveBeenCalled();

--- a/packages/ui/system/src/native/sheet.spec.tsx
+++ b/packages/ui/system/src/native/sheet.spec.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NativeSheet } from "./sheet";
+
+const nativeModal = vi.hoisted(() => ({
+  onRequestClose: null as (() => void) | null
+}));
+
+vi.mock("react-native", () => ({
+  Modal: ({
+    children,
+    onRequestClose,
+    visible
+  }: {
+    children: ReactNode;
+    onRequestClose(): void;
+    visible: boolean;
+  }) => {
+    nativeModal.onRequestClose = onRequestClose;
+    return visible ? <div>{children}</div> : null;
+  },
+  Pressable: ({
+    children,
+    onPress,
+    testID
+  }: {
+    children: ReactNode;
+    onPress(event: { stopPropagation(): void }): void;
+    testID?: string;
+  }) => (
+    <div
+      data-testid={testID}
+      onClick={(event) =>
+        onPress({ stopPropagation: () => event.stopPropagation() })
+      }
+    >
+      {children}
+    </div>
+  ),
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}));
+
+vi.mock("./theme-provider", () => ({
+  useNativeTheme: () => ({
+    color: {
+      muted: "#000",
+      panelRaised: "#fff",
+      scrim: "rgba(0, 0, 0, 0.6)"
+    },
+    radius: { large: 12 },
+    space: { small: 10 }
+  })
+}));
+
+describe("NativeSheet", () => {
+  beforeEach(() => {
+    nativeModal.onRequestClose = null;
+  });
+
+  it("renders its content only while open", () => {
+    const { rerender } = render(
+      <NativeSheet onOpenChange={() => undefined} open={false}>
+        content
+      </NativeSheet>
+    );
+
+    expect(screen.queryByText("content")).not.toBeInTheDocument();
+
+    rerender(
+      <NativeSheet onOpenChange={() => undefined} open>
+        content
+      </NativeSheet>
+    );
+    expect(screen.getByText("content")).toBeInTheDocument();
+
+    rerender(
+      <NativeSheet onOpenChange={() => undefined} open={false}>
+        content
+      </NativeSheet>
+    );
+    expect(screen.queryByText("content")).not.toBeInTheDocument();
+  });
+
+  it("reports backdrop and system dismissals to the controlled owner", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <NativeSheet onOpenChange={onOpenChange} open>
+        content
+      </NativeSheet>
+    );
+
+    fireEvent.click(screen.getByText("content"));
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("native-sheet-backdrop"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    onOpenChange.mockClear();
+    nativeModal.onRequestClose?.();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/ui/system/src/native/sheet.tsx
+++ b/packages/ui/system/src/native/sheet.tsx
@@ -1,22 +1,24 @@
+import type { ReactNode } from "react";
 import {
-  BottomSheetModal,
-  type BottomSheetModalProps
-} from "@gorhom/bottom-sheet";
-import { useEffect, useRef, type ReactNode } from "react";
+  type DimensionValue,
+  Modal,
+  Pressable,
+  StyleSheet
+} from "react-native";
 import { useNativeTheme } from "./theme-provider";
 
 export interface NativeSheetProps {
   children: ReactNode;
   onOpenChange(open: boolean): void;
   open: boolean;
-  snapPoints?: BottomSheetModalProps["snapPoints"];
+  snapPoints?: readonly (number | `${number}%`)[];
 }
 
 /**
- * Controlled modal sheet backed by @gorhom/bottom-sheet.
+ * Controlled sheet backed by React Native's window-level Modal.
  *
- * The app root owns BottomSheetModalProvider; callers own whether the sheet is
- * open and what product actions its content performs.
+ * Callers own whether the sheet is open and what product actions its content
+ * performs.
  */
 export function NativeSheet({
   children,
@@ -25,31 +27,58 @@ export function NativeSheet({
   snapPoints
 }: NativeSheetProps) {
   const theme = useNativeTheme();
-  const sheet = useRef<BottomSheetModal>(null);
-
-  useEffect(() => {
-    if (open) {
-      sheet.current?.present();
-      return;
-    }
-
-    sheet.current?.dismiss();
-  }, [open]);
+  const styles = createStyles(theme);
+  const height = resolveSheetHeight(snapPoints);
 
   return (
-    <BottomSheetModal
-      backgroundStyle={{
-        backgroundColor: theme.color.panelRaised,
-        borderTopLeftRadius: theme.radius.large,
-        borderTopRightRadius: theme.radius.large
-      }}
-      enableDynamicSizing={snapPoints === undefined}
-      handleIndicatorStyle={{ backgroundColor: theme.color.muted }}
-      onDismiss={() => onOpenChange(false)}
-      ref={sheet}
-      snapPoints={snapPoints}
+    <Modal
+      animationType="fade"
+      onRequestClose={() => onOpenChange(false)}
+      presentationStyle="overFullScreen"
+      statusBarTranslucent
+      transparent
+      visible={open}
     >
-      {children}
-    </BottomSheetModal>
+      <Pressable
+        accessible={false}
+        onPress={() => onOpenChange(false)}
+        style={styles.backdrop}
+        testID="native-sheet-backdrop"
+      >
+        <Pressable
+          onPress={(event) => event.stopPropagation()}
+          style={[styles.sheet, height === null ? null : { height }]}
+        >
+          {children}
+        </Pressable>
+      </Pressable>
+    </Modal>
   );
+}
+
+function resolveSheetHeight(
+  snapPoints: NativeSheetProps["snapPoints"]
+): DimensionValue | null {
+  if (!snapPoints) return null;
+  const first = snapPoints[0];
+  return typeof first === "number" || typeof first === "string"
+    ? (first as DimensionValue)
+    : null;
+}
+
+function createStyles(theme: ReturnType<typeof useNativeTheme>) {
+  return StyleSheet.create({
+    backdrop: {
+      backgroundColor: theme.color.scrim,
+      flex: 1,
+      justifyContent: "flex-end"
+    },
+    sheet: {
+      backgroundColor: theme.color.panelRaised,
+      borderTopLeftRadius: theme.radius.large,
+      borderTopRightRadius: theme.radius.large,
+      maxHeight: "80%",
+      overflow: "hidden"
+    }
+  });
 }

--- a/packages/ui/system/src/native/sheet.tsx
+++ b/packages/ui/system/src/native/sheet.tsx
@@ -46,6 +46,7 @@ export function NativeSheet({
         testID="native-sheet-backdrop"
       >
         <Pressable
+          accessible={false}
           onPress={(event) => event.stopPropagation()}
           style={[styles.sheet, height === null ? null : { height }]}
         >

--- a/packages/ui/system/src/packageManifest.spec.ts
+++ b/packages/ui/system/src/packageManifest.spec.ts
@@ -6,7 +6,6 @@ const manifest = JSON.parse(readFileSync("package.json", "utf8"));
 
 test("marks native-only peers optional for web consumers", () => {
   expect(manifest.peerDependenciesMeta).toMatchObject({
-    "@gorhom/bottom-sheet": { optional: true },
     "react-native": { optional: true }
   });
 });

--- a/packages/ui/system/ui-system.md
+++ b/packages/ui/system/ui-system.md
@@ -323,11 +323,12 @@ from experimental status. The gallery must import only the stable
 states; it is the Native counterpart of a DOM storyboard example, not a second
 component implementation.
 
-`NativeSheet` additionally requires the consuming app to install
-`@gorhom/bottom-sheet` and provide its `BottomSheetModalProvider` below a
-`GestureHandlerRootView`. Reanimated and Gesture Handler remain part of that
-Native renderer contract; application roots own provider placement, not the
-shared primitive.
+`NativeSheet` uses React Native's window-level `Modal` for its controlled
+overlay and does not require a portal provider. It owns the semantic scrim,
+bottom-aligned panel, system-back dismissal, backdrop dismissal, and
+optional initial height. Keep `@gorhom/bottom-sheet` app-owned for genuinely
+complex gesture, keyboard, or multi-snap-point sheets rather than routing the
+shared compact sheet through its React 19-incompatible portal.
 
 For cross-surface stacking, use shared semantic `z-index` tokens instead of
 local magic numbers. Current global layer tokens live in

--- a/packages/ui/system/ui-system.md
+++ b/packages/ui/system/ui-system.md
@@ -95,8 +95,8 @@ The visual language that this package should serve is defined in [Desktop Visual
 - `@tutti-os/ui-system/native`
   React Native primitive and semantic-token entry; this is separate from the
   DOM component entry and must not be imported by desktop renderers. Native
-  consumers provide React Native and the documented Bottom Sheet runtime;
-  `react-dom` is optional for this platform-specific entry.
+  consumers provide React Native; `react-dom` is optional for this
+  platform-specific entry.
 - `@tutti-os/ui-system/components`
   Stable component barrel for tooling and rare category-focused imports
 - `@tutti-os/ui-system/icons`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -861,9 +861,6 @@ importers:
         specifier: ^8.20.1
         version: 8.21.0
     devDependencies:
-      "@gorhom/bottom-sheet":
-        specifier: 5.2.14
-        version: 5.2.14(6f79d238c0d5e646a1f2d5fd6b392cdd)
       "@testing-library/jest-dom":
         specifier: ^6.9.1
         version: 6.9.1


### PR DESCRIPTION
## Summary

- replace the shared compact `NativeSheet` portal path with React Native's window-level `Modal`
- preserve controlled open state, token-backed scrim/panel styling, optional initial height, backdrop dismissal, and system-back dismissal
- remove the now-unused `@gorhom/bottom-sheet` peer from `@tutti-os/ui-system`
- add regression coverage and durable Mobile/UI System troubleshooting guidance

## Root cause

The composer settings were not read-only: the model, reasoning, speed, and permission options were still available. Tapping a chip presented `BottomSheetModal`, but its `@gorhom/portal` render path recursively republished the node under the current React 19 Native renderer and ended in a maximum-update-depth error before the sheet became visible.

## User impact

The model, reasoning, speed, and permission chips above the Mobile composer open their option sheets again. Compact shared sheets no longer depend on the incompatible portal path.

## Validation

- Android device (Vivo V2507A): opened model, speed, and permission sheets; selected the active permission; dismissed with the backdrop; reopened sheets; observed no maximum-update-depth or fatal React Native error
- `@tutti-os/ui-system`: 17 test files / 58 tests passed
- UI System and Mobile typechecks passed
- UI boundary checks passed
- changed-aware push-ready validation passed all 10 selected lanes against the latest `origin/main`, including full workspace typecheck, targeted tests, boundary checks, and npm package pack validation
- automated regression coverage verifies closed/open rendering, content taps, backdrop dismissal, and native system dismissal

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->