### PR TITLE
feat(device-link): share managed connection lifecycle

### DIFF
--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -192,12 +192,18 @@ They should remain focused, named by responsibility, and free of hidden business
 DeviceLink is the shared Go peer-transport boundary for Tutti Desktop, TSH
 Desktop, and mobile clients. It owns ICE candidate negotiation, QUIC over the
 selected packet path, mutual ephemeral certificate pinning, categorical path
-classification, and the gomobile build surface.
+classification, the gomobile build surface, and product-neutral authenticated
+link lifecycle mechanics: generation-fenced admission, establishment
+serialization, pooled stream ownership, connection racing, and annealed path
+probing.
 
 It exposes authenticated bidirectional streams and must remain independent of
 Agent, Session, Workspace, account, pairing, rendezvous, and Relay product
-policy. Host services and apps own those adapters. Raw addresses, candidates,
-credentials, and payloads must not enter ordinary logs or metrics.
+policy. Peer keys and registration metadata stay opaque; host services and apps
+inject path dialers, credentials, fallback timing, and application stream
+protocols. The `tuttid` Mobile Remote owner is the first adapter for the shared
+manager; its pairing and Agent framing remain service-owned. Raw addresses,
+candidates, credentials, and payloads must not enter ordinary logs or metrics.
 
 ### `packages/events/*`
 

--- a/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
+++ b/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
@@ -2,17 +2,21 @@
 
 Status: accepted product direction; Personal direct-lane MVP in implementation
 
-## Implementation progress (2026-07-25)
+## Implementation progress (2026-07-27)
 
 The provisional `packages/device-link` core now preserves the production ICE,
 QUIC, certificate-pinning, candidate filtering and privacy behavior extracted
-from TSH. Personal Desktop and Android consume the same authenticated facade;
-the direct lane includes paired-device rendezvous, framed Agent HTTP, request
-deadlines and foreground/background close behavior. Android 15 ARM64 emulator
-build/install/start and authenticated loopback integration pass. Real-account
-physical-device network transitions, Relay fallback and event streaming remain
-acceptance work. The module is not yet a stable released cross-repository
-contract.
+from TSH. It also owns the shared generation fence, authenticated link pool,
+per-peer establishment serialization, connection race, annealed path-probe
+cache, trickle-ICE facade, and rolling ALPN compatibility seam. Product
+adapters still own room/device identity, rendezvous, Relay credentials and
+fallback policy. Personal Desktop and Android consume the same authenticated
+facade; the direct lane includes paired-device rendezvous, framed Agent HTTP,
+request deadlines, event streaming and foreground/background close behavior.
+Android 15 ARM64 emulator build/install/start and authenticated loopback
+integration pass. Real-account physical-device network transitions and Relay
+fallback remain acceptance work. TSH cutover to the shared manager is still
+pending, so the module is not yet a stable released cross-repository contract.
 
 The Mobile shell now uses mutually exclusive unauthenticated/authenticated DI
 children and one active workspace child. Login, pairing, DeviceLink lifecycle,
@@ -53,7 +57,8 @@ MVP 不包含：
 - 完整复制桌面右侧面板；
 - TSH/VM 用户入口；
 - Web 与 React Native 组件源码的全面统一；
-- 前期多版本协议兼容、迁移 shim 或灰度兼容窗口。
+- 长期多版本协议兼容矩阵；只保留 TSH 切换期间有界、可观测、可删除的临时 ALPN
+  seam。
 
 ## 4. 设计原则
 
@@ -62,7 +67,8 @@ MVP 不包含：
 - Session、Turn、Interaction、Goal 和 runtime operation 的生命周期仍由 `packages/agent/host` 唯一定义。
 - 移动端使用同一个 workspace `AgentSessionEngine` 语义，不创建 `MobileSession`、`RemoteSession` 或第二套会话状态机。
 - `tsh-server` 只拥有账号、设备、配对、在线发现和短期 rendezvous 状态。
-- DeviceLink 只拥有认证链路、P2P/Relay 选路和双向流，不解释 Agent DTO。
+- DeviceLink 只拥有认证链路、product-neutral 双路径竞速和双向流，不解释 Agent
+  DTO；direct/Relay 身份认证与选路策略由产品 adapter 注入。
 - React Native 只拥有导航、展示和设备本地的临时 UI 状态。
 
 ### 4.2 复用协议，不镜像页面
@@ -161,7 +167,8 @@ Mobile 使用稳定 Bootstrap container。未登录 child 与登录后 child 互
 
 新增一个先由 Personal 验证、随后再稳定为跨消费者边界的 `packages/device-link`：
 
-- 从 TSH 现有生产实现提炼 Go ICE、STUN candidate、QUIC、证书 pinning、连接竞速、负缓存和 Relay fallback；
+- 从 TSH 现有生产实现提炼 Go ICE、STUN candidate、QUIC、证书 pinning、连接竞速、
+  负缓存，以及供产品 adapter 注入 direct/Relay 的生命周期 seam；
 - 暴露认证后的双向流，不包含 Session、Turn、Composer 或 Workspace 业务实体；
 - 提供 gomobile/AAR 构建入口；
 - 在 Personal Desktop 和 Android 闭环验收后，成为 Tutti Desktop、TSH Desktop 和 Android 的共同源头。
@@ -181,7 +188,9 @@ TSH 当前代码作为 donor implementation。Personal 验收前不要求 TSH �
 - 投影 Android 网络变化与前后台生命周期；
 - 返回经过清洗的连接状态和错误分类。
 
-ICE、QUIC、证书校验、连接竞速和 Relay 选路不得在 Kotlin 中重写。
+ICE、QUIC、证书校验、连接竞速和探测退避不得在 Kotlin 中重写。direct/Relay
+身份认证、fallback 延迟和错误分类仍由产品 adapter 决定，并通过共享 manager
+提供的 dial、race 和 probe seam 接入。
 
 ### 7.3 业务传输
 
@@ -486,8 +495,12 @@ Wi-Fi/蜂窝切换和 VPN/TUN 失败分类仍待验证。
 完成条件：Personal Desktop 与 Android 真机通过同一 facade 建立链路，原始
 `QUICEndpoint` 不进入产品桥接；TSH 仍保持现状，不阻塞 Personal 验证。
 
-当前进度：共享 facade、Desktop owner host、Android caller bridge 和真实
-authenticated stream 集成测试已完成；真机跨网络验证仍待完成。
+当前进度：共享 facade、Desktop owner host、Android caller bridge、真实
+authenticated stream 集成测试，以及代际隔离、连接池、建连去重、连接竞速和探测
+退避的 product-neutral manager 均已完成；Tutti Desktop `mobileremote` owner
+已经作为首个 adapter 接管共享 manager，TSH adapter 切换和真机跨网络验证仍待
+完成。Relay 身份认证、控制面、fallback 产品策略和 TSH 产品诊断继续由消费端
+拥有。
 
 ### M2 — 设备、配对和控制面
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -40,7 +40,7 @@ If you are editing `packages/ui/*`, also read [packages/ui/AGENTS.md](ui/AGENTS.
 - name packages by responsibility, not by audience
 - avoid vague names such as `shared`, `common`, `utils`, or `client-sdk`
 - keep `clients/*` focused on domain-specific access patterns
-- keep `device-link` transport-only: it may own candidate selection, authenticated peer streams, and platform build boundaries, but not account, pairing, rendezvous, Relay product policy, or Agent/Workspace DTOs
+- keep `device-link` transport-only: it may own candidate selection, authenticated peer streams, generation-fenced admission, product-neutral pooling/racing/probe mechanics, and platform build boundaries, but not account, pairing, rendezvous, path-specific authentication, Relay product policy, or Agent/Workspace DTOs
 - keep `events/*` focused on repository-owned business event protocol contracts, topic catalogs, generated validators, and transport metadata rather than socket lifecycle or daemon business workflows
 - keep `browser/*` focused on browser mechanics, workbench node integration, bridge shape, Electron webview guest management, and package-local i18n defaults; host product globals, backend-token access, preview proxy behavior, and business bridge methods stay in host adapters
 - keep `ui/*` focused on shared frontend-foundation concerns such as tokens, icons, styles, primitives, and host-agnostic i18n runtime support

--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -20,6 +20,71 @@ required by Go's dependency direction; it does not own account, pairing,
 rendezvous, or Agent behavior. Product bridges must not expose raw
 `QUICEndpoint.Listen` or `Dial`.
 
+## Managed connection lifecycle
+
+The `linkmanager` package owns the reusable lifecycle mechanics that sit above
+an authenticated link:
+
+- generation-fenced admission, so a connection completed after invalidation
+  cannot re-enter the pool;
+- one in-flight establishment per opaque peer key;
+- authenticated link reuse, stream reference counting, idle retirement, and
+  deterministic collision resolution;
+- a delayed two-path race that closes every losing late connection;
+- an annealed direct-probe cache with bounded peer state and explicit
+  environment invalidation.
+
+The manager does not name or authenticate direct, Relay, room, account, or
+rendezvous paths. Product adapters inject opaque keys and metadata, dial
+functions, path timing, and policy. In particular, a consumer may let a
+preferred-path probe continue after a fallback path wins so it can learn direct
+reachability; that detached probe must have its own deadline and close every
+connection it does not register. Cache only path reachability failures, never
+authorization, control-plane, or product-policy failures. `ClaimProbe` returns
+a generation-bound lease; complete it with `RecordFailure`, `RecordSuccess`, or
+`Close` so invalidation can fence every late probe result.
+
+The intended integration is:
+
+```text
+product attempt + credentials
+  -> linkmanager admission snapshot
+  -> product-supplied direct/fallback dial policy
+  -> authenticated.Participant.Connect
+  -> linkmanager.Register
+  -> shared OpenStream / incoming stream handler
+```
+
+One admission snapshot may register at most one link. Network, credential, or
+ownership changes invalidate the relevant peer generation before the old
+attempt is cancelled. A product-wide availability gate uses `SetEnabled(false)`
+to fence current and future admissions until explicitly re-enabled. Shutdown
+first begins manager quiescence, which rejects new admissions and streams, then
+waits for accepted stream handlers to finish. Link observations carry a
+per-connection sequence; projections must ignore older deliveries and treat
+`disconnected` as terminal for that globally comparable connection ID.
+
+Tutti's `mobileremote` Desktop owner is the first production adapter: it keeps
+pairing, identity proof, rendezvous, and Agent framing in `tuttid`, while the
+shared manager owns the authenticated link and incoming stream lifecycle.
+
+## Trickle ICE and protocol migration
+
+Consumers that exchange candidates incrementally call
+`StartLocalDescription`, publish candidate additions from
+`LocalCandidateChanges`, and publish a final
+`LocalDescriptionSnapshot` when `LocalGatheringComplete` closes. Remote
+candidates may arrive before or after `Connect` through
+`AddRemoteCandidates`. A `Participant` represents one connection attempt and
+must not be reused after completion or cancellation.
+
+`ALPN` remains the canonical protocol name. During a rolling migration, a
+consumer may add a bounded list of `CompatibleProtocols`; the canonical value
+is always offered first. After connection, `Link.NegotiatedProtocol` lets the
+product adapter select only the matching application framing. Compatibility
+entries are a temporary cutover tool, not a promise that old wire protocols
+share semantics.
+
 ## Mobile vertical slice
 
 The `mobile` package deliberately exposes only a gomobile-safe authenticated

--- a/packages/device-link/authenticated/link.go
+++ b/packages/device-link/authenticated/link.go
@@ -27,6 +27,10 @@ type ParticipantConfig struct {
 	STUNGatherTimeout     time.Duration
 	ExcludeHostCandidates bool
 	IncludeLoopback       bool
+	// CompatibleProtocols appends temporary legacy ALPN values after the
+	// canonical DeviceLink protocol. It exists for rolling consumer migrations;
+	// new integrations leave it empty.
+	CompatibleProtocols []string
 }
 
 type Description struct {
@@ -37,8 +41,9 @@ type Description struct {
 }
 
 type Participant struct {
-	identity devicelink.Identity
-	agent    *icequic.Agent
+	identity  devicelink.Identity
+	agent     *icequic.Agent
+	protocols []string
 
 	mu             sync.Mutex
 	connectStarted bool
@@ -52,6 +57,10 @@ func NewParticipant(cfg ParticipantConfig) (*Participant, error) {
 	if err != nil {
 		return nil, err
 	}
+	protocols := append([]string{devicelink.ALPN}, cfg.CompatibleProtocols...)
+	if _, err := identity.ClientTLSConfigForProtocols(identity.Fingerprint, protocols); err != nil {
+		return nil, fmt.Errorf("configure device-link protocols: %w", err)
+	}
 	agent, err := icequic.NewAgent(icequic.AgentConfig{
 		STUNEndpoints:         append([]string(nil), cfg.STUNEndpoints...),
 		NetworkPolicy:         icequic.NetworkPolicy(strings.TrimSpace(cfg.NetworkPolicy)),
@@ -62,32 +71,86 @@ func NewParticipant(cfg ParticipantConfig) (*Participant, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Participant{identity: identity, agent: agent}, nil
+	return &Participant{identity: identity, agent: agent, protocols: protocols}, nil
+}
+
+// StartLocalDescription starts asynchronous candidate gathering and returns
+// the current authenticated description immediately. Candidates may be empty;
+// callers publish later snapshots when LocalCandidateChanges fires.
+func (p *Participant) StartLocalDescription() (Description, error) {
+	agent, fingerprint, err := p.transport()
+	if err != nil {
+		return Description{}, err
+	}
+	params, err := agent.StartGathering()
+	if err != nil {
+		return Description{}, err
+	}
+	return descriptionFromParams(fingerprint, params), nil
+}
+
+// LocalDescriptionSnapshot returns the credentials and candidates gathered so
+// far without waiting for gathering completion.
+func (p *Participant) LocalDescriptionSnapshot() (Description, error) {
+	agent, fingerprint, err := p.transport()
+	if err != nil {
+		return Description{}, err
+	}
+	params, err := agent.LocalParamsSnapshot()
+	if err != nil {
+		return Description{}, err
+	}
+	return descriptionFromParams(fingerprint, params), nil
+}
+
+// LocalCandidateChanges coalesces local candidate arrivals. Candidate values
+// remain available only through LocalDescriptionSnapshot.
+func (p *Participant) LocalCandidateChanges() <-chan struct{} {
+	agent := p.channelAgent()
+	if agent == nil {
+		return nil
+	}
+	return agent.CandidateChanges()
+}
+
+// LocalGatheringComplete is closed when local ICE gathering finishes.
+func (p *Participant) LocalGatheringComplete() <-chan struct{} {
+	agent := p.channelAgent()
+	if agent == nil {
+		return nil
+	}
+	return agent.GatheringComplete()
+}
+
+// Done is closed when the participant transport is closed.
+func (p *Participant) Done() <-chan struct{} {
+	agent := p.channelAgent()
+	if agent == nil {
+		return nil
+	}
+	return agent.Done()
+}
+
+// AddRemoteCandidates trickles newly published peer candidates into an
+// in-progress Connect. Duplicate and malformed candidates are ignored.
+func (p *Participant) AddRemoteCandidates(candidates []string) int {
+	agent, _, err := p.transport()
+	if err != nil {
+		return 0
+	}
+	return agent.AddRemoteCandidates(candidates)
 }
 
 func (p *Participant) LocalDescription(ctx context.Context) (Description, error) {
-	if p == nil {
-		return Description{}, errors.New("device-link participant is unavailable")
+	agent, fingerprint, err := p.transport()
+	if err != nil {
+		return Description{}, err
 	}
-	p.mu.Lock()
-	if p.closed || p.agent == nil {
-		p.mu.Unlock()
-		return Description{}, errors.New("device-link participant is closed")
-	}
-	agent := p.agent
-	fingerprint := p.identity.Fingerprint
-	p.mu.Unlock()
-
 	params, err := agent.LocalParams(ctx)
 	if err != nil {
 		return Description{}, err
 	}
-	return Description{
-		Fingerprint: fingerprint,
-		Ufrag:       params.Ufrag,
-		Pwd:         params.Pwd,
-		Candidates:  append([]string(nil), params.Candidates...),
-	}, nil
+	return descriptionFromParams(fingerprint, params), nil
 }
 
 func (p *Participant) Connect(
@@ -104,6 +167,9 @@ func (p *Participant) Connect(
 	if role != RoleCaller && role != RoleOwner {
 		return nil, fmt.Errorf("unsupported device-link role %q", role)
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	p.mu.Lock()
 	if p.closed || p.agent == nil {
@@ -119,9 +185,10 @@ func (p *Participant) Connect(
 	p.connectCancel = cancel
 	agent := p.agent
 	identity := p.identity
+	protocols := append([]string(nil), p.protocols...)
 	p.mu.Unlock()
 
-	link, err := connectLink(connectCtx, agent, identity, peer, role)
+	link, err := connectLink(connectCtx, agent, identity, protocols, peer, role)
 	cancel()
 	if err != nil {
 		_ = agent.Close()
@@ -195,6 +262,13 @@ func (l *Link) SelectedScope() string {
 	return l.scope
 }
 
+func (l *Link) NegotiatedProtocol() string {
+	if l == nil || l.session == nil {
+		return ""
+	}
+	return l.session.NegotiatedProtocol()
+}
+
 func (l *Link) Close() error {
 	if l == nil {
 		return nil
@@ -210,6 +284,7 @@ func connectLink(
 	ctx context.Context,
 	agent *icequic.Agent,
 	identity devicelink.Identity,
+	protocols []string,
 	peer Description,
 	role Role,
 ) (*Link, error) {
@@ -231,14 +306,14 @@ func connectLink(
 
 	var session *devicelink.QUICSession
 	if role == RoleCaller {
-		tlsConfig, configErr := identity.ClientTLSConfig(peer.Fingerprint)
+		tlsConfig, configErr := identity.ClientTLSConfigForProtocols(peer.Fingerprint, protocols)
 		if configErr != nil {
 			_ = endpoint.Close()
 			return nil, configErr
 		}
 		session, err = endpoint.Dial(ctx, path.RemoteAddr(), tlsConfig)
 	} else {
-		tlsConfig, configErr := identity.ServerTLSConfig(peer.Fingerprint)
+		tlsConfig, configErr := identity.ServerTLSConfigForProtocols(peer.Fingerprint, protocols)
 		if configErr != nil {
 			_ = endpoint.Close()
 			return nil, configErr
@@ -268,8 +343,35 @@ func validateDescription(description Description) error {
 	if strings.TrimSpace(description.Ufrag) == "" || strings.TrimSpace(description.Pwd) == "" {
 		return errors.New("peer device-link ICE credentials are required")
 	}
-	if len(description.Candidates) == 0 {
-		return errors.New("peer device-link candidates are required")
-	}
 	return nil
+}
+
+func (p *Participant) transport() (*icequic.Agent, string, error) {
+	if p == nil {
+		return nil, "", errors.New("device-link participant is unavailable")
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed || p.agent == nil {
+		return nil, "", errors.New("device-link participant is closed")
+	}
+	return p.agent, p.identity.Fingerprint, nil
+}
+
+func (p *Participant) channelAgent() *icequic.Agent {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.agent
+}
+
+func descriptionFromParams(fingerprint string, params icequic.LocalParams) Description {
+	return Description{
+		Fingerprint: fingerprint,
+		Ufrag:       params.Ufrag,
+		Pwd:         params.Pwd,
+		Candidates:  append([]string(nil), params.Candidates...),
+	}
 }

--- a/packages/device-link/authenticated/link_test.go
+++ b/packages/device-link/authenticated/link_test.go
@@ -100,6 +100,107 @@ func TestAuthenticatedParticipantRejectsInvalidPeerBeforeConnecting(t *testing.T
 	}
 }
 
+func TestAuthenticatedParticipantsAcceptCredentialsBeforeCandidateTrickle(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	caller, err := authenticated.NewParticipant(authenticated.ParticipantConfig{IncludeLoopback: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer caller.Close()
+	owner, err := authenticated.NewParticipant(authenticated.ParticipantConfig{IncludeLoopback: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer owner.Close()
+
+	callerInitial, err := caller.StartLocalDescription()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerInitial, err := owner.StartLocalDescription()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if caller.LocalCandidateChanges() == nil || owner.LocalGatheringComplete() == nil {
+		t.Fatal("authenticated trickle signals are unavailable")
+	}
+	callerFull, err := caller.LocalDescription(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerFull, err := owner.LocalDescription(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	callerInitial.Candidates = nil
+	ownerInitial.Candidates = nil
+
+	callerResult := make(chan linkResult, 1)
+	ownerResult := make(chan linkResult, 1)
+	go func() {
+		link, connectErr := caller.Connect(ctx, ownerInitial, authenticated.RoleCaller)
+		callerResult <- linkResult{link: link, err: connectErr}
+	}()
+	go func() {
+		link, connectErr := owner.Connect(ctx, callerInitial, authenticated.RoleOwner)
+		ownerResult <- linkResult{link: link, err: connectErr}
+	}()
+	time.Sleep(50 * time.Millisecond)
+	if added := caller.AddRemoteCandidates(ownerFull.Candidates); added == 0 {
+		t.Fatal("caller accepted no trickled owner candidates")
+	}
+	if added := owner.AddRemoteCandidates(callerFull.Candidates); added == 0 {
+		t.Fatal("owner accepted no trickled caller candidates")
+	}
+
+	callerConnected, ownerConnected := <-callerResult, <-ownerResult
+	if callerConnected.err != nil {
+		t.Fatalf("caller Connect after trickle: %v", callerConnected.err)
+	}
+	if ownerConnected.err != nil {
+		t.Fatalf("owner Connect after trickle: %v", ownerConnected.err)
+	}
+	defer callerConnected.link.Close()
+	defer ownerConnected.link.Close()
+}
+
+func TestAuthenticatedParticipantRejectsInvalidCompatibleProtocol(t *testing.T) {
+	t.Parallel()
+	_, err := authenticated.NewParticipant(authenticated.ParticipantConfig{
+		IncludeLoopback:     true,
+		CompatibleProtocols: []string{" "},
+	})
+	if err == nil {
+		t.Fatal("NewParticipant accepted an empty compatible protocol")
+	}
+}
+
+func TestAuthenticatedParticipantDoneRemainsObservableAfterClose(t *testing.T) {
+	t.Parallel()
+	participant, err := authenticated.NewParticipant(authenticated.ParticipantConfig{IncludeLoopback: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := participant.Done()
+	if done == nil {
+		t.Fatal("Done returned a nil channel")
+	}
+	if err := participant.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if participant.Done() != done {
+		t.Fatal("Done channel changed after Close")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Done did not close")
+	}
+}
+
 type linkResult struct {
 	link *authenticated.Link
 	err  error

--- a/packages/device-link/devicelink_test.go
+++ b/packages/device-link/devicelink_test.go
@@ -3,6 +3,7 @@ package devicelink
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -72,10 +73,41 @@ func TestListenGlobalIPv6CurrentHost(t *testing.T) {
 func TestQUICMutualPinningAndStreamRoundTrip(t *testing.T) {
 	callerUDP := listenLoopbackUDP6(t)
 	ownerUDP := listenLoopbackUDP6(t)
-	runQUICRoundTrip(t, context.Background(), callerUDP, ownerUDP)
+	runQUICRoundTrip(t, context.Background(), callerUDP, ownerUDP, nil, nil, ALPN)
 }
 
-func runQUICRoundTrip(t *testing.T, parent context.Context, callerUDP, ownerUDP *net.UDPConn) {
+func TestQUICRollingALPNCompatibility(t *testing.T) {
+	legacy := "tsh-device-link-p2p/2"
+	tests := []struct {
+		name            string
+		callerProtocols []string
+		ownerProtocols  []string
+	}{
+		{name: "new caller old owner", callerProtocols: []string{ALPN, legacy}, ownerProtocols: []string{legacy}},
+		{name: "old caller new owner", callerProtocols: []string{legacy}, ownerProtocols: []string{ALPN, legacy}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runQUICRoundTrip(
+				t,
+				context.Background(),
+				listenLoopbackUDP6(t),
+				listenLoopbackUDP6(t),
+				tt.callerProtocols,
+				tt.ownerProtocols,
+				legacy,
+			)
+		})
+	}
+}
+
+func runQUICRoundTrip(
+	t *testing.T,
+	parent context.Context,
+	callerUDP, ownerUDP *net.UDPConn,
+	callerProtocols, ownerProtocols []string,
+	expectedProtocol string,
+) {
 	t.Helper()
 	callerEndpoint, err := NewQUICEndpoint(callerUDP)
 	if err != nil {
@@ -96,11 +128,11 @@ func runQUICRoundTrip(t *testing.T, parent context.Context, callerUDP, ownerUDP 
 	if err != nil {
 		t.Fatal(err)
 	}
-	serverTLS, err := ownerIdentity.ServerTLSConfig(callerIdentity.Fingerprint)
+	serverTLS, err := ownerIdentity.ServerTLSConfigForProtocols(callerIdentity.Fingerprint, ownerProtocols)
 	if err != nil {
 		t.Fatal(err)
 	}
-	clientTLS, err := callerIdentity.ClientTLSConfig(ownerIdentity.Fingerprint)
+	clientTLS, err := callerIdentity.ClientTLSConfigForProtocols(ownerIdentity.Fingerprint, callerProtocols)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,6 +152,10 @@ func runQUICRoundTrip(t *testing.T, parent context.Context, callerUDP, ownerUDP 
 			return
 		}
 		defer session.Close()
+		if got := session.NegotiatedProtocol(); got != expectedProtocol {
+			serverDone <- fmt.Errorf("server negotiated protocol = %q, want %q", got, expectedProtocol)
+			return
+		}
 		stream, err := session.AcceptStream(ctx)
 		if err != nil {
 			serverDone <- err
@@ -133,6 +169,9 @@ func runQUICRoundTrip(t *testing.T, parent context.Context, callerUDP, ownerUDP 
 	clientSession, err := callerEndpoint.Dial(ctx, ownerUDP.LocalAddr().(*net.UDPAddr), clientTLS)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if got := clientSession.NegotiatedProtocol(); got != expectedProtocol {
+		t.Fatalf("negotiated protocol = %q, want %q", got, expectedProtocol)
 	}
 	stream, err := clientSession.OpenStream(ctx)
 	if err != nil {

--- a/packages/device-link/icequic/agent.go
+++ b/packages/device-link/icequic/agent.go
@@ -271,11 +271,16 @@ func (a *Agent) LocalParams(ctx context.Context) (LocalParams, error) {
 	if a == nil || a.agent == nil {
 		return LocalParams{}, errors.New("device-link ICE agent is not initialized")
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if _, err := a.StartGathering(); err != nil {
 		return LocalParams{}, err
 	}
 	select {
 	case <-a.gathered:
+	case <-a.done:
+		return LocalParams{}, errors.New("device-link ICE agent is closed")
 	case <-ctx.Done():
 		return LocalParams{}, ctx.Err()
 	}
@@ -329,6 +334,9 @@ func (a *Agent) Connect(ctx context.Context, remoteUfrag, remotePwd string, remo
 	if a == nil || a.agent == nil {
 		return nil, errors.New("device-link ICE agent is not initialized")
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	remoteUfrag = strings.TrimSpace(remoteUfrag)
 	remotePwd = strings.TrimSpace(remotePwd)
 	if remoteUfrag == "" || remotePwd == "" {
@@ -374,11 +382,16 @@ func (a *Agent) SelectedScope() string {
 	if pair.Local.Type() == ice.CandidateTypeServerReflexive || pair.Remote.Type() == ice.CandidateTypeServerReflexive {
 		return ScopePublicInternet
 	}
-	if ip, err := netip.ParseAddr(pair.Remote.Address()); err == nil {
-		if ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLoopback() {
-			return ScopePrivateNetwork
-		}
-		if ip.IsGlobalUnicast() {
+	if selectedHostPairScope(pair.Local.Address(), pair.Remote.Address()) == ScopePublicInternet {
+		return ScopePublicInternet
+	}
+	return ScopePrivateNetwork
+}
+
+func selectedHostPairScope(addresses ...string) string {
+	for _, address := range addresses {
+		ip, err := netip.ParseAddr(address)
+		if err == nil && ip.IsGlobalUnicast() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast() && !ip.IsLoopback() {
 			return ScopePublicInternet
 		}
 	}

--- a/packages/device-link/icequic/agent_test.go
+++ b/packages/device-link/icequic/agent_test.go
@@ -330,7 +330,7 @@ func TestConnectRejectsMissingCredentials(t *testing.T) {
 }
 
 func TestConnectAcceptsLateDuplicateOutOfOrderCandidates(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	caller, err := NewAgent(AgentConfig{IncludeLoopback: true})
 	if err != nil {
@@ -383,5 +383,27 @@ func TestConnectAcceptsLateDuplicateOutOfOrderCandidates(t *testing.T) {
 	defer ownerRes.conn.Close()
 	if got := caller.AddRemoteCandidates(ownerParams.Candidates); got != 0 {
 		t.Fatalf("duplicate candidate feed added %d candidates, want 0", got)
+	}
+}
+
+func TestSelectedHostPairScopeUsesBothPerspectives(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		addresses []string
+		wantScope string
+	}{
+		{name: "remote global", addresses: []string{"10.0.0.2", "2001:4860:4860::8888"}, wantScope: ScopePublicInternet},
+		{name: "local global", addresses: []string{"2001:4860:4860::8888", "10.0.0.2"}, wantScope: ScopePublicInternet},
+		{name: "private pair", addresses: []string{"10.0.0.1", "fd00::2"}, wantScope: ScopePrivateNetwork},
+		{name: "invalid pair", addresses: []string{"invalid", ""}, wantScope: ScopePrivateNetwork},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := selectedHostPairScope(tt.addresses...); got != tt.wantScope {
+				t.Fatalf("selectedHostPairScope(%q) = %q, want %q", tt.addresses, got, tt.wantScope)
+			}
+		})
 	}
 }

--- a/packages/device-link/identity.go
+++ b/packages/device-link/identity.go
@@ -12,10 +12,14 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 )
 
-const identityLifetime = 5 * time.Minute
+const (
+	identityLifetime = 5 * time.Minute
+	maxALPNProtocols = 4
+)
 
 type Identity struct {
 	Certificate tls.Certificate
@@ -64,16 +68,34 @@ func NewEphemeralIdentity(now time.Time) (Identity, error) {
 }
 
 func (i Identity) ClientTLSConfig(expectedPeerFingerprint string) (*tls.Config, error) {
-	return i.tlsConfig(expectedPeerFingerprint, false)
+	return i.ClientTLSConfigForProtocols(expectedPeerFingerprint, nil)
 }
 
 func (i Identity) ServerTLSConfig(expectedPeerFingerprint string) (*tls.Config, error) {
-	return i.tlsConfig(expectedPeerFingerprint, true)
+	return i.ServerTLSConfigForProtocols(expectedPeerFingerprint, nil)
 }
 
-func (i Identity) tlsConfig(expectedPeerFingerprint string, server bool) (*tls.Config, error) {
+// ClientTLSConfigForProtocols builds the pinned client TLS configuration with
+// an explicit ordered ALPN compatibility set. An empty set uses the canonical
+// DeviceLink ALPN. Product adapters may temporarily include an older protocol
+// during a rolling migration without forking certificate or pinning behavior.
+func (i Identity) ClientTLSConfigForProtocols(expectedPeerFingerprint string, protocols []string) (*tls.Config, error) {
+	return i.tlsConfig(expectedPeerFingerprint, protocols, false)
+}
+
+// ServerTLSConfigForProtocols is the server-side counterpart of
+// ClientTLSConfigForProtocols.
+func (i Identity) ServerTLSConfigForProtocols(expectedPeerFingerprint string, protocols []string) (*tls.Config, error) {
+	return i.tlsConfig(expectedPeerFingerprint, protocols, true)
+}
+
+func (i Identity) tlsConfig(expectedPeerFingerprint string, protocols []string, server bool) (*tls.Config, error) {
 	if len(i.Certificate.Certificate) == 0 || i.Certificate.PrivateKey == nil {
 		return nil, errors.New("device-link identity certificate is required")
+	}
+	protocols, err := normalizeALPNProtocols(protocols)
+	if err != nil {
+		return nil, err
 	}
 	expected, err := base64.RawURLEncoding.DecodeString(expectedPeerFingerprint)
 	if err != nil || len(expected) != sha256.Size {
@@ -99,7 +121,7 @@ func (i Identity) tlsConfig(expectedPeerFingerprint string, server bool) (*tls.C
 	config := &tls.Config{
 		Certificates:          []tls.Certificate{i.Certificate},
 		MinVersion:            tls.VersionTLS13,
-		NextProtos:            []string{ALPN},
+		NextProtos:            protocols,
 		InsecureSkipVerify:    true, // Verification is the strict SPKI pin above.
 		VerifyPeerCertificate: verify,
 	}
@@ -107,6 +129,32 @@ func (i Identity) tlsConfig(expectedPeerFingerprint string, server bool) (*tls.C
 		config.ClientAuth = tls.RequireAnyClientCert
 	}
 	return config, nil
+}
+
+func normalizeALPNProtocols(protocols []string) ([]string, error) {
+	if len(protocols) == 0 {
+		return []string{ALPN}, nil
+	}
+	if len(protocols) > maxALPNProtocols {
+		return nil, fmt.Errorf("device-link ALPN compatibility set exceeds %d entries", maxALPNProtocols)
+	}
+	normalized := make([]string, 0, len(protocols))
+	seen := make(map[string]struct{}, len(protocols))
+	for _, protocol := range protocols {
+		protocol = strings.TrimSpace(protocol)
+		if protocol == "" || len(protocol) > 255 {
+			return nil, errors.New("device-link ALPN protocol must contain 1 to 255 bytes")
+		}
+		if _, ok := seen[protocol]; ok {
+			continue
+		}
+		seen[protocol] = struct{}{}
+		normalized = append(normalized, protocol)
+	}
+	if len(normalized) == 0 {
+		return nil, errors.New("device-link ALPN compatibility set is empty")
+	}
+	return normalized, nil
 }
 
 func fingerprintSPKI(spki []byte) string {

--- a/packages/device-link/linkmanager/doc.go
+++ b/packages/device-link/linkmanager/doc.go
@@ -1,0 +1,10 @@
+// Package linkmanager owns product-neutral DeviceLink connection lifecycle
+// mechanics above an authenticated stream link.
+//
+// It provides generation-fenced admission, per-peer establishment
+// serialization, authenticated link reuse with idle retirement, deterministic
+// collision handling, two-path connection racing, and an annealed probe cache.
+// Consumers inject opaque peer keys, metadata, dial functions, and path policy;
+// this package does not know about accounts, rooms, rendezvous, Relay
+// credentials, or application stream protocols.
+package linkmanager

--- a/packages/device-link/linkmanager/flight.go
+++ b/packages/device-link/linkmanager/flight.go
@@ -1,0 +1,56 @@
+package linkmanager
+
+import "sync"
+
+type establishFlight struct {
+	done             chan struct{}
+	globalGeneration uint64
+	keyGeneration    uint64
+	once             sync.Once
+}
+
+func (m *Manager[K, M]) joinFlight(key K) (*establishFlight, bool, error) {
+	m.mu.Lock()
+	if m.closing {
+		m.mu.Unlock()
+		return nil, false, ErrManagerClosed
+	}
+	if !m.enabled {
+		m.mu.Unlock()
+		return nil, false, ErrManagerDisabled
+	}
+	if flight := m.flights[key]; flight != nil &&
+		flight.globalGeneration == m.globalGeneration &&
+		flight.keyGeneration == m.keyGenerations[key] {
+		m.mu.Unlock()
+		return flight, false, nil
+	}
+	stale := m.flights[key]
+	flight := &establishFlight{
+		done:             make(chan struct{}),
+		globalGeneration: m.globalGeneration,
+		keyGeneration:    m.keyGenerations[key],
+	}
+	m.flights[key] = flight
+	m.mu.Unlock()
+	stale.finish()
+	return flight, true, nil
+}
+
+func (m *Manager[K, M]) finishFlight(key K, flight *establishFlight) {
+	m.mu.Lock()
+	if m.flights[key] == flight {
+		delete(m.flights, key)
+	}
+	m.mu.Unlock()
+	flight.finish()
+}
+
+func (flight *establishFlight) finish() {
+	if flight == nil {
+		return
+	}
+	flight.once.Do(func() {
+		close(flight.done)
+	})
+}

--- a/packages/device-link/linkmanager/integration_test.go
+++ b/packages/device-link/linkmanager/integration_test.go
@@ -1,0 +1,8 @@
+package linkmanager_test
+
+import (
+	"github.com/tutti-os/tutti/packages/device-link/authenticated"
+	"github.com/tutti-os/tutti/packages/device-link/linkmanager"
+)
+
+var _ linkmanager.Link = (*authenticated.Link)(nil)

--- a/packages/device-link/linkmanager/manager.go
+++ b/packages/device-link/linkmanager/manager.go
@@ -1,0 +1,756 @@
+package linkmanager
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultIdleGrace       = 60 * time.Second
+	defaultCollisionWindow = 5 * time.Second
+)
+
+var (
+	ErrLinkUnavailable      = errors.New("device-link peer link is unavailable")
+	ErrManagerClosed        = errors.New("device-link manager is closed")
+	ErrManagerDisabled      = errors.New("device-link manager is disabled")
+	ErrAdmissionInvalidated = errors.New("device-link admission was invalidated")
+)
+
+type Link interface {
+	OpenStream(context.Context) (net.Conn, error)
+	AcceptStream(context.Context) (net.Conn, error)
+	Close() error
+}
+
+type IncomingStream[K comparable, M any] struct {
+	Key          K
+	ConnectionID string
+	Metadata     M
+	Stream       net.Conn
+}
+
+type IncomingHandler[K comparable, M any] func(context.Context, IncomingStream[K, M]) error
+
+type LinkState string
+
+const (
+	LinkReady        LinkState = "ready"
+	LinkDisconnected LinkState = "disconnected"
+)
+
+type LinkEvent[K comparable, M any] struct {
+	Key          K
+	ConnectionID string
+	// Sequence increases for one ConnectionID. Observe callbacks may run
+	// concurrently, so projections must discard a sequence older than the last
+	// one they applied. Disconnected is terminal for that ConnectionID.
+	Sequence      uint64
+	Metadata      M
+	State         LinkState
+	ActiveStreams int
+	ChangedAt     time.Time
+}
+
+type ManagerConfig[K comparable, M any] struct {
+	IdleGrace       time.Duration
+	CollisionWindow time.Duration
+	Now             func() time.Time
+	// Observe must return promptly. Calls for different state transitions may
+	// overlap; LinkEvent.Sequence provides deterministic projection ordering.
+	Observe func(LinkEvent[K, M])
+}
+
+type Registration[K comparable, M any] struct {
+	Key K
+	// ConnectionID must be the same globally comparable attempt identifier at
+	// both peers. Locally generated IDs can make collision decisions diverge.
+	ConnectionID   string
+	Link           Link
+	Metadata       M
+	HandleIncoming IncomingHandler[K, M]
+}
+
+type RegisterDisposition string
+
+const (
+	RegisterInstalled    RegisterDisposition = "installed"
+	RegisterReplaced     RegisterDisposition = "replaced"
+	RegisterKeptExisting RegisterDisposition = "kept_existing"
+)
+
+type Manager[K comparable, M any] struct {
+	cfg ManagerConfig[K, M]
+
+	mu               sync.Mutex
+	links            map[K]*managedLink[K, M]
+	flights          map[K]*establishFlight
+	keyGenerations   map[K]uint64
+	admissions       map[*Admission[K, M]]struct{}
+	globalGeneration uint64
+	enabled          bool
+	closing          bool
+	ctx              context.Context
+	cancel           context.CancelFunc
+	wg               sync.WaitGroup
+	waitOnce         sync.Once
+	quiesced         chan struct{}
+}
+
+type Admission[K comparable, M any] struct {
+	manager          *Manager[K, M]
+	key              K
+	globalGeneration uint64
+	keyGeneration    uint64
+	ctx              context.Context
+	cancel           context.CancelCauseFunc
+	used             bool
+	once             sync.Once
+}
+
+type managedLink[K comparable, M any] struct {
+	manager        *Manager[K, M]
+	key            K
+	connectionID   string
+	metadata       M
+	establishedAt  time.Time
+	link           Link
+	handleIncoming IncomingHandler[K, M]
+	handlerCtx     context.Context
+	cancelHandlers context.CancelFunc
+	activeStreams  int
+	idleTimer      *time.Timer
+	idleGeneration uint64
+	eventSequence  uint64
+	disconnected   bool
+	closed         bool
+	closeOnce      sync.Once
+}
+
+type EstablishFunc[K comparable, M any] func(context.Context, *Admission[K, M]) (Registration[K, M], error)
+
+func NewManager[K comparable, M any](cfg ManagerConfig[K, M]) *Manager[K, M] {
+	if cfg.IdleGrace <= 0 {
+		cfg.IdleGrace = defaultIdleGrace
+	}
+	if cfg.CollisionWindow <= 0 {
+		cfg.CollisionWindow = defaultCollisionWindow
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Manager[K, M]{
+		cfg:            cfg,
+		links:          make(map[K]*managedLink[K, M]),
+		flights:        make(map[K]*establishFlight),
+		keyGenerations: make(map[K]uint64),
+		admissions:     make(map[*Admission[K, M]]struct{}),
+		enabled:        true,
+		ctx:            ctx,
+		cancel:         cancel,
+		quiesced:       make(chan struct{}),
+	}
+}
+
+// Admit binds an in-flight authenticated connection attempt to the current
+// global and peer generations. Register rejects and closes a link produced by
+// an admission invalidated before the handshake completes. The caller must
+// Close every successful admission, normally with defer.
+func (m *Manager[K, M]) Admit(ctx context.Context, key K) (*Admission[K, M], error) {
+	if m == nil {
+		return nil, ErrManagerClosed
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closing {
+		return nil, ErrManagerClosed
+	}
+	if !m.enabled {
+		return nil, ErrManagerDisabled
+	}
+	admissionCtx, cancel := context.WithCancelCause(ctx)
+	admission := &Admission[K, M]{
+		manager:          m,
+		key:              key,
+		globalGeneration: m.globalGeneration,
+		keyGeneration:    m.keyGenerations[key],
+		ctx:              admissionCtx,
+		cancel:           cancel,
+	}
+	m.admissions[admission] = struct{}{}
+	m.wg.Add(1)
+	return admission, nil
+}
+
+func (a *Admission[K, M]) Context() context.Context {
+	if a == nil || a.ctx == nil {
+		return context.Background()
+	}
+	return a.ctx
+}
+
+func (a *Admission[K, M]) Close() {
+	if a == nil {
+		return
+	}
+	a.once.Do(func() {
+		a.cancel(context.Canceled)
+		if a.manager != nil {
+			a.manager.releaseAdmission(a)
+		}
+	})
+}
+
+// Register transfers ownership of registration.Link to the manager regardless
+// of disposition. Callers must not close the Link after calling Register.
+func (m *Manager[K, M]) Register(
+	admission *Admission[K, M],
+	registration Registration[K, M],
+) (RegisterDisposition, error) {
+	if registration.Link == nil {
+		return "", errors.New("device-link registration requires an authenticated link")
+	}
+	registration.ConnectionID = strings.TrimSpace(registration.ConnectionID)
+	if registration.ConnectionID == "" {
+		_ = registration.Link.Close()
+		return "", errors.New("device-link registration requires a connection id")
+	}
+	if admission == nil || admission.manager != m || registration.Key != admission.key {
+		_ = registration.Link.Close()
+		return "", ErrAdmissionInvalidated
+	}
+	if m == nil {
+		_ = registration.Link.Close()
+		return "", ErrManagerClosed
+	}
+	establishedAt := m.cfg.Now()
+
+	handlerCtx, cancelHandlers := context.WithCancel(m.ctx)
+	incoming := &managedLink[K, M]{
+		manager:        m,
+		key:            registration.Key,
+		connectionID:   registration.ConnectionID,
+		metadata:       registration.Metadata,
+		establishedAt:  establishedAt,
+		link:           registration.Link,
+		handleIncoming: registration.HandleIncoming,
+		handlerCtx:     handlerCtx,
+		cancelHandlers: cancelHandlers,
+	}
+
+	var replaced *managedLink[K, M]
+	disposition := RegisterInstalled
+	m.mu.Lock()
+	_, admissionActive := m.admissions[admission]
+	if m.closing ||
+		!m.enabled ||
+		!admissionActive ||
+		admission.used ||
+		admission.ctx.Err() != nil ||
+		admission.globalGeneration != m.globalGeneration ||
+		admission.keyGeneration != m.keyGenerations[admission.key] {
+		m.mu.Unlock()
+		incoming.closeTransport()
+		return "", ErrAdmissionInvalidated
+	}
+	admission.used = true
+	existing := m.links[registration.Key]
+	if existing != nil && !existing.closed {
+		age := m.cfg.Now().Sub(existing.establishedAt)
+		withinCollisionWindow := age >= 0 && age <= m.cfg.CollisionWindow
+		if !withinCollisionWindow || existing.connectionID <= incoming.connectionID {
+			m.mu.Unlock()
+			incoming.closeTransport()
+			return RegisterKeptExisting, nil
+		}
+		replaced = existing
+		replaced.closed = true
+		replaced.stopIdleLocked()
+		disposition = RegisterReplaced
+	}
+	m.links[registration.Key] = incoming
+	incoming.scheduleIdleLocked()
+	m.wg.Add(1)
+	m.mu.Unlock()
+
+	if replaced != nil {
+		m.notify(replaced, LinkDisconnected)
+		replaced.closeTransport()
+	}
+	m.notify(incoming, LinkReady)
+	go m.acceptStreams(incoming)
+	return disposition, nil
+}
+
+func (m *Manager[K, M]) Ready(key K) bool {
+	if m == nil {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	link := m.links[key]
+	return !m.closing && m.enabled && link != nil && !link.closed
+}
+
+func (m *Manager[K, M]) OpenStream(ctx context.Context, key K) (net.Conn, error) {
+	if m == nil {
+		return nil, ErrLinkUnavailable
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	m.mu.Lock()
+	link := m.links[key]
+	if m.closing || !m.enabled || link == nil || link.closed {
+		m.mu.Unlock()
+		return nil, ErrLinkUnavailable
+	}
+	link.acquireStreamLocked()
+	m.mu.Unlock()
+
+	stream, err := link.link.OpenStream(ctx)
+	if err != nil {
+		link.releaseStream()
+		if ctx.Err() == nil {
+			m.remove(link)
+		}
+		return nil, err
+	}
+	m.mu.Lock()
+	current := !m.closing && m.enabled && !link.closed && m.links[key] == link
+	m.mu.Unlock()
+	if !current {
+		_ = stream.Close()
+		link.releaseStream()
+		return nil, ErrLinkUnavailable
+	}
+	m.notify(link, LinkReady)
+	return &managedStream{Conn: stream, release: link.releaseStream}, nil
+}
+
+// OpenOrConnect reuses a pooled link or serializes establishment for one key.
+// Followers may cancel independently; after a failed leader, a follower may
+// become the next leader and retry instead of inheriting the first error.
+func (m *Manager[K, M]) OpenOrConnect(
+	ctx context.Context,
+	key K,
+	establish EstablishFunc[K, M],
+) (net.Conn, error) {
+	if m == nil {
+		return nil, ErrManagerClosed
+	}
+	if establish == nil {
+		return nil, errors.New("device-link establish function is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for {
+		if stream, err := m.OpenStream(ctx, key); err == nil {
+			return stream, nil
+		}
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		flight, leader, err := m.joinFlight(key)
+		if err != nil {
+			return nil, err
+		}
+		if leader {
+			establishErr := func() error {
+				defer m.finishFlight(key, flight)
+				admission, err := m.Admit(ctx, key)
+				if err != nil {
+					return err
+				}
+				defer admission.Close()
+				registration, err := establish(admission.Context(), admission)
+				if err != nil {
+					return err
+				}
+				_, err = m.Register(admission, registration)
+				return err
+			}()
+			if establishErr != nil {
+				return nil, establishErr
+			}
+			return m.OpenStream(ctx, key)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-flight.done:
+		}
+	}
+}
+
+func (m *Manager[K, M]) Invalidate(key K) {
+	if m == nil {
+		return
+	}
+	var closing *managedLink[K, M]
+	var cancelAdmissions []context.CancelCauseFunc
+	var flight *establishFlight
+	m.mu.Lock()
+	m.keyGenerations[key]++
+	for admission := range m.admissions {
+		if admission.key == key {
+			cancelAdmissions = append(cancelAdmissions, admission.cancel)
+		}
+	}
+	if link := m.links[key]; link != nil {
+		delete(m.links, key)
+		link.closed = true
+		link.stopIdleLocked()
+		closing = link
+	}
+	if flight = m.flights[key]; flight != nil {
+		delete(m.flights, key)
+	}
+	m.mu.Unlock()
+	flight.finish()
+	for _, cancel := range cancelAdmissions {
+		cancel(ErrAdmissionInvalidated)
+	}
+	if closing != nil {
+		m.notify(closing, LinkDisconnected)
+		closing.closeTransport()
+	}
+}
+
+// InvalidateAll advances the manager generation, cancels every in-flight
+// admission, and closes all pooled links. The manager remains reusable.
+func (m *Manager[K, M]) InvalidateAll() {
+	m.invalidateAll(false)
+}
+
+// SetEnabled atomically pauses or resumes admission. Disabling advances the
+// global generation, rejects future Admit calls, cancels in-flight admissions,
+// and closes pooled links. Enabling starts another fresh generation.
+func (m *Manager[K, M]) SetEnabled(enabled bool) error {
+	if m == nil {
+		return ErrManagerClosed
+	}
+	if enabled {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if m.closing {
+			return ErrManagerClosed
+		}
+		if m.enabled {
+			return nil
+		}
+		m.globalGeneration++
+		m.enabled = true
+		return nil
+	}
+
+	var closing []*managedLink[K, M]
+	var cancelAdmissions []context.CancelCauseFunc
+	var flights []*establishFlight
+	m.mu.Lock()
+	if m.closing {
+		m.mu.Unlock()
+		return ErrManagerClosed
+	}
+	if !m.enabled {
+		m.mu.Unlock()
+		return nil
+	}
+	m.enabled = false
+	m.globalGeneration++
+	for admission := range m.admissions {
+		cancelAdmissions = append(cancelAdmissions, admission.cancel)
+	}
+	for key, link := range m.links {
+		delete(m.links, key)
+		link.closed = true
+		link.stopIdleLocked()
+		closing = append(closing, link)
+	}
+	for key, flight := range m.flights {
+		delete(m.flights, key)
+		flights = append(flights, flight)
+	}
+	m.mu.Unlock()
+	for _, flight := range flights {
+		flight.finish()
+	}
+	for _, cancel := range cancelAdmissions {
+		cancel(ErrAdmissionInvalidated)
+	}
+	for _, link := range closing {
+		m.notify(link, LinkDisconnected)
+		link.closeTransport()
+	}
+	return nil
+}
+
+// BeginQuiescence permanently closes admission and cancels all stream handlers.
+func (m *Manager[K, M]) BeginQuiescence() {
+	m.invalidateAll(true)
+}
+
+func (m *Manager[K, M]) WaitForQuiescence(ctx context.Context) error {
+	if m == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	m.BeginQuiescence()
+	m.waitOnce.Do(func() {
+		go func() {
+			m.wg.Wait()
+			close(m.quiesced)
+		}()
+	})
+	select {
+	case <-m.quiesced:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (m *Manager[K, M]) invalidateAll(permanent bool) {
+	if m == nil {
+		return
+	}
+	var closing []*managedLink[K, M]
+	var cancelAdmissions []context.CancelCauseFunc
+	var flights []*establishFlight
+	m.mu.Lock()
+	m.globalGeneration++
+	if permanent && !m.closing {
+		m.closing = true
+		m.enabled = false
+		m.cancel()
+	}
+	for admission := range m.admissions {
+		cancelAdmissions = append(cancelAdmissions, admission.cancel)
+	}
+	for key, link := range m.links {
+		delete(m.links, key)
+		link.closed = true
+		link.stopIdleLocked()
+		closing = append(closing, link)
+	}
+	for key, flight := range m.flights {
+		delete(m.flights, key)
+		flights = append(flights, flight)
+	}
+	m.mu.Unlock()
+	for _, flight := range flights {
+		flight.finish()
+	}
+	for _, cancel := range cancelAdmissions {
+		cancel(ErrAdmissionInvalidated)
+	}
+	for _, link := range closing {
+		m.notify(link, LinkDisconnected)
+		link.closeTransport()
+	}
+}
+
+func (m *Manager[K, M]) acceptStreams(link *managedLink[K, M]) {
+	defer m.wg.Done()
+	for {
+		stream, err := link.link.AcceptStream(link.handlerCtx)
+		if err != nil {
+			m.remove(link)
+			return
+		}
+		m.mu.Lock()
+		if m.closing || link.closed || m.links[link.key] != link {
+			m.mu.Unlock()
+			_ = stream.Close()
+			m.remove(link)
+			return
+		}
+		link.acquireStreamLocked()
+		m.wg.Add(1)
+		m.mu.Unlock()
+		m.notify(link, LinkReady)
+		managed := &managedStream{Conn: stream, release: link.releaseStream}
+		incoming := IncomingStream[K, M]{
+			Key:          link.key,
+			ConnectionID: link.connectionID,
+			Metadata:     link.metadata,
+			Stream:       managed,
+		}
+		go func() {
+			defer m.wg.Done()
+			defer managed.Close()
+			if link.handleIncoming != nil {
+				_ = link.handleIncoming(link.handlerCtx, incoming)
+			}
+		}()
+	}
+}
+
+func (m *Manager[K, M]) remove(link *managedLink[K, M]) {
+	if m == nil || link == nil {
+		return
+	}
+	m.mu.Lock()
+	removedCurrent := false
+	if m.links[link.key] == link {
+		delete(m.links, link.key)
+		removedCurrent = true
+	}
+	link.closed = true
+	link.stopIdleLocked()
+	m.mu.Unlock()
+	if removedCurrent {
+		m.notify(link, LinkDisconnected)
+	}
+	link.closeTransport()
+}
+
+func (m *Manager[K, M]) notify(link *managedLink[K, M], state LinkState) {
+	if m == nil || link == nil || m.cfg.Observe == nil {
+		return
+	}
+	m.mu.Lock()
+	if state == LinkReady && (link.closed || m.links[link.key] != link) {
+		m.mu.Unlock()
+		return
+	}
+	if state == LinkDisconnected && link.disconnected {
+		m.mu.Unlock()
+		return
+	}
+	link.eventSequence++
+	if state == LinkDisconnected {
+		link.disconnected = true
+	}
+	event := LinkEvent[K, M]{
+		Key:           link.key,
+		ConnectionID:  link.connectionID,
+		Sequence:      link.eventSequence,
+		Metadata:      link.metadata,
+		State:         state,
+		ActiveStreams: link.activeStreams,
+		ChangedAt:     m.cfg.Now().UTC(),
+	}
+	m.mu.Unlock()
+	m.cfg.Observe(event)
+}
+
+func (m *Manager[K, M]) releaseAdmission(admission *Admission[K, M]) {
+	m.mu.Lock()
+	if _, ok := m.admissions[admission]; ok {
+		delete(m.admissions, admission)
+		m.mu.Unlock()
+		m.wg.Done()
+		return
+	}
+	m.mu.Unlock()
+}
+
+func (link *managedLink[K, M]) acquireStreamLocked() {
+	link.idleGeneration++
+	if link.idleTimer != nil {
+		link.idleTimer.Stop()
+		link.idleTimer = nil
+	}
+	link.activeStreams++
+}
+
+func (link *managedLink[K, M]) releaseStream() {
+	if link == nil || link.manager == nil {
+		return
+	}
+	manager := link.manager
+	manager.mu.Lock()
+	if link.activeStreams > 0 {
+		link.activeStreams--
+	}
+	current := !link.closed && manager.links[link.key] == link
+	if current && link.activeStreams == 0 {
+		link.scheduleIdleLocked()
+	}
+	manager.mu.Unlock()
+	if current {
+		manager.notify(link, LinkReady)
+	}
+}
+
+func (link *managedLink[K, M]) scheduleIdleLocked() {
+	link.idleGeneration++
+	generation := link.idleGeneration
+	if link.idleTimer != nil {
+		link.idleTimer.Stop()
+	}
+	link.idleTimer = time.AfterFunc(link.manager.cfg.IdleGrace, func() {
+		link.manager.expireIdle(link, generation)
+	})
+}
+
+func (link *managedLink[K, M]) stopIdleLocked() {
+	link.idleGeneration++
+	if link.idleTimer != nil {
+		link.idleTimer.Stop()
+		link.idleTimer = nil
+	}
+}
+
+func (m *Manager[K, M]) expireIdle(link *managedLink[K, M], generation uint64) {
+	if m == nil || link == nil {
+		return
+	}
+	m.mu.Lock()
+	if link.closed ||
+		m.links[link.key] != link ||
+		link.activeStreams != 0 ||
+		link.idleGeneration != generation {
+		m.mu.Unlock()
+		return
+	}
+	delete(m.links, link.key)
+	link.closed = true
+	link.idleTimer = nil
+	m.mu.Unlock()
+	m.notify(link, LinkDisconnected)
+	link.closeTransport()
+}
+
+func (link *managedLink[K, M]) closeTransport() {
+	link.closeOnce.Do(func() {
+		if link.cancelHandlers != nil {
+			link.cancelHandlers()
+		}
+		if link.link != nil {
+			_ = link.link.Close()
+		}
+	})
+}
+
+type managedStream struct {
+	net.Conn
+	once    sync.Once
+	release func()
+}
+
+func (stream *managedStream) Close() error {
+	if stream == nil || stream.Conn == nil {
+		return nil
+	}
+	var err error
+	stream.once.Do(func() {
+		err = stream.Conn.Close()
+		if stream.release != nil {
+			stream.release()
+		}
+	})
+	return err
+}

--- a/packages/device-link/linkmanager/manager_test.go
+++ b/packages/device-link/linkmanager/manager_test.go
@@ -1,0 +1,473 @@
+package linkmanager
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type testMetadata struct {
+	Peer string
+}
+
+func TestManagerReusesLinkAndExpiresOnlyAfterLastStreamCloses(t *testing.T) {
+	t.Parallel()
+	manager := NewManager[string, testMetadata](ManagerConfig[string, testMetadata]{
+		IdleGrace: 30 * time.Millisecond,
+	})
+	link := newFakeLink()
+	registerTestLink(t, manager, "peer", "connection", link, nil)
+
+	stream, err := manager.OpenStream(context.Background(), "peer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(60 * time.Millisecond)
+	if !manager.Ready("peer") {
+		t.Fatal("active stream did not keep the pooled link ready")
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, time.Second, func() bool {
+		return !manager.Ready("peer") && link.closeCount.Load() == 1
+	})
+}
+
+func TestManagerRejectsLateLinkAfterGenerationInvalidation(t *testing.T) {
+	t.Parallel()
+	manager := NewManager[string, testMetadata](ManagerConfig[string, testMetadata]{})
+	admission, err := manager.Admit(context.Background(), "peer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.Invalidate("peer")
+	if !errors.Is(context.Cause(admission.Context()), ErrAdmissionInvalidated) {
+		t.Fatalf("admission cause = %v, want invalidated", context.Cause(admission.Context()))
+	}
+	link := newFakeLink()
+	_, err = manager.Register(admission, Registration[string, testMetadata]{
+		Key: "peer", ConnectionID: "late", Link: link,
+	})
+	if !errors.Is(err, ErrAdmissionInvalidated) {
+		t.Fatalf("Register error = %v, want invalidated", err)
+	}
+	if link.closeCount.Load() != 1 || manager.Ready("peer") {
+		t.Fatalf("late link close=%d ready=%v", link.closeCount.Load(), manager.Ready("peer"))
+	}
+	admission.Close()
+}
+
+func TestManagerRejectsLinkAfterAdmissionContextCancellation(t *testing.T) {
+	t.Parallel()
+	manager := NewManager[string, testMetadata](ManagerConfig[string, testMetadata]{})
+	ctx, cancel := context.WithCancel(context.Background())
+	admission, err := manager.Admit(ctx, "peer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer admission.Close()
+	cancel()
+	link := newFakeLink()
+	_, err = manager.Register(admission, Registration[string, testMetadata]{
+		Key: "peer", ConnectionID: "late", Link: link,
+	})
+	if !errors.Is(err, ErrAdmissionInvalidated) {
+		t.Fatalf("Register error = %v, want invalidated", err)
+	}
+	if link.closeCount.Load() != 1 || manager.Ready("peer") {
+		t.Fatalf("canceled link close=%d ready=%v", link.closeCount.Load(), manager.Ready("peer"))
+	}
+}
+
+func TestManagerDisableFencesAttemptsUntilReenabled(t *testing.T) {
+	t.Parallel()
+	manager := NewManager[string, testMetadata](ManagerConfig[string, testMetadata]{})
+	admission, err := manager.Admit(context.Background(), "peer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer admission.Close()
+	if err := manager.SetEnabled(false); err != nil {
+		t.Fatal(err)
+	}
+	if !errors.Is(context.Cause(admission.Context()), ErrAdmissionInvalidated) {
+		t.Fatalf("disabled admission cause = %v, want invalidated", context.Cause(admission.Context()))
+	}
+	if _, err := manager.Admit(context.Background(), "peer"); !errors.Is(err, ErrManagerDisabled) {
+		t.Fatalf("Admit while disabled error = %v, want disabled", err)
+	}
+	late := newFakeLink()
+	if _, err := manager.Register(admission, Registration[string, testMetadata]{
+		Key: "peer", ConnectionID: "late", Link: late,
+	}); !errors.Is(err, ErrAdmissionInvalidated) {
+		t.Fatalf("late Register error = %v, want invalidated", err)
+	}
+	if late.closeCount.Load() != 1 {
+		t.Fatalf("late link close count = %d, want 1", late.closeCount.Load())
+	}
+	if err := manager.SetEnabled(true); err != nil {
+		t.Fatal(err)
+	}
+	replacement := newFakeLink()
+	registerTestLink(t, manager, "peer", "replacement", replacement, nil)
+	if !manager.Ready("peer") {
+		t.Fatal("manager did not admit a link after re-enable")
+	}
+	manager.InvalidateAll()
+}
+
+func TestManagerReenableDoesNotWaitForStaleEstablishmentFlight(t *testing.T) {
+	t.Parallel()
+	manager := NewManager[string, testMetadata](ManagerConfig[string, testMetadata]{
+		IdleGrace: time.Minute,
+	})
+	oldStarted := make(chan struct{})
+	releaseOld := make(chan struct{})
+	oldResult := make(chan error, 1)
+	go func() {
+		stream, err := manager.OpenOrConnect(
+			context.Background(),
+			"peer",
+			func(context.Context, *Admission[string, testMetadata]) (Registration[string, testMetadata], error) {
+				close(oldStarted)
+				<-releaseOld
+				return Registration[string, testMetadata]{
+					Key: "peer", ConnectionID: "old", Link: newFakeLink(),
+				}, nil
+			},
+		)
+		if stream != nil {
+			_ = stream.Close()
+		}
+		oldResult <- err
+	}()
+	<-oldStarted
+	if err := manager.SetEnabled(false); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.SetEnabled(true); err != nil {
+		t.Fatal(err)
+	}
+	freshResult := make(chan error, 1)
+	go func() {
+		stream, err := manager.OpenOrConnect(
+			context.Background(),
+			"peer",
+			func(context.Context, *Admission[string, testMetadata]) (Registration[string, testMetadata], error) {
+				return Registration[string, testMetadata]{
+					Key: "peer", ConnectionID: "fresh", Link: newFakeLink(),
+				}, nil
+			},
+		)
+		if stream != nil {
+			_ = stream.Close()
+		}
+		freshResult <- err
+	}()
+	select {
+	case err := <-freshResult:
+		if err != nil {
+			t.Fatalf("fresh establishment: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("fresh establishment waited for stale flight")
+	}
+	close(releaseOld)
+	if err := <-oldResult; !errors.Is(err, ErrAdmissionInvalidated) {
+		t.Fatalf("stale establishment error = %v, want invalidated", err)
+	}
+	manager.InvalidateAll()
+}
+
+func TestManagerResolvesCollisionDeterministically(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(100, 0)
+	manager := NewManager[string, testMetadata](ManagerConfig[string, testMetadata]{
+		Now:             func() time.Time { return now },
+		CollisionWindow: 5 * time.Second,
+	})
+	incumbent := newFakeLink()
+	registerTestLink(t, manager, "peer", "b", incumbent, nil)
+	winner := newFakeLink()
+	if disposition := registerTestLink(t, manager, "peer", "a", winner, nil); disposition != RegisterReplaced {
+		t.Fatalf("lower connection id disposition = %q, want replaced", disposition)
+	}
+	if incumbent.closeCount.Load() != 1 || winner.closeCount.Load() != 0 {
+		t.Fatalf("collision close counts incumbent=%d winner=%d", incumbent.closeCount.Load(), winner.closeCount.Load())
+	}
+	rejected := newFakeLink()
+	if disposition := registerTestLink(t, manager, "peer", "z", rejected, nil); disposition != RegisterKeptExisting {
+		t.Fatalf("higher connection id disposition = %q, want kept_existing", disposition)
+	}
+	if rejected.closeCount.Load() != 1 {
+		t.Fatalf("rejected link close count = %d, want 1", rejected.closeCount.Load())
+	}
+	now = now.Add(6 * time.Second)
+	outsideWindow := newFakeLink()
+	if disposition := registerTestLink(t, manager, "peer", "0", outsideWindow, nil); disposition != RegisterKeptExisting {
+		t.Fatalf("outside-window disposition = %q, want kept_existing", disposition)
+	}
+	manager.Invalidate("peer")
+	if winner.closeCount.Load() != 1 {
+		t.Fatalf("winning link close count = %d, want 1", winner.closeCount.Load())
+	}
+}
+
+func TestManagerOpenOrConnectSerializesEstablishmentPerKey(t *testing.T) {
+	t.Parallel()
+	manager := NewManager[string, testMetadata](ManagerConfig[string, testMetadata]{
+		IdleGrace: time.Minute,
+	})
+	var establishCalls atomic.Int32
+	release := make(chan struct{})
+	establish := func(
+		ctx context.Context,
+		_ *Admission[string, testMetadata],
+	) (Registration[string, testMetadata], error) {
+		establishCalls.Add(1)
+		select {
+		case <-ctx.Done():
+			return Registration[string, testMetadata]{}, ctx.Err()
+		case <-release:
+		}
+		return Registration[string, testMetadata]{
+			Key: "peer", ConnectionID: "connection", Link: newFakeLink(),
+		}, nil
+	}
+
+	const callers = 8
+	start := make(chan struct{})
+	results := make(chan error, callers)
+	var ready sync.WaitGroup
+	ready.Add(callers)
+	for range callers {
+		go func() {
+			ready.Done()
+			<-start
+			stream, err := manager.OpenOrConnect(context.Background(), "peer", establish)
+			if stream != nil {
+				_ = stream.Close()
+			}
+			results <- err
+		}()
+	}
+	ready.Wait()
+	close(start)
+	waitFor(t, time.Second, func() bool { return establishCalls.Load() == 1 })
+	close(release)
+	for range callers {
+		if err := <-results; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if establishCalls.Load() != 1 {
+		t.Fatalf("establish calls = %d, want 1", establishCalls.Load())
+	}
+	manager.InvalidateAll()
+}
+
+func TestManagerCanceledOpenDoesNotCloseHealthySharedLink(t *testing.T) {
+	t.Parallel()
+	manager := NewManager[string, testMetadata](ManagerConfig[string, testMetadata]{
+		IdleGrace: time.Minute,
+	})
+	link := &cancelableOpenLink{fakeLink: newFakeLink()}
+	registerTestLink(t, manager, "peer", "connection", link, nil)
+	active, err := manager.OpenStream(context.Background(), "peer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	link.cancelNext.Store(true)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := manager.OpenStream(ctx, "peer"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled OpenStream error = %v, want context canceled", err)
+	}
+	if !manager.Ready("peer") || link.closeCount.Load() != 0 {
+		t.Fatalf("canceled open removed healthy link: ready=%v close=%d", manager.Ready("peer"), link.closeCount.Load())
+	}
+	link.cancelNext.Store(true)
+	var establishCalls atomic.Int32
+	if _, err := manager.OpenOrConnect(ctx, "peer", func(
+		context.Context,
+		*Admission[string, testMetadata],
+	) (Registration[string, testMetadata], error) {
+		establishCalls.Add(1)
+		return Registration[string, testMetadata]{}, errors.New("unexpected establish")
+	}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled OpenOrConnect error = %v, want context canceled", err)
+	}
+	if establishCalls.Load() != 0 {
+		t.Fatalf("canceled OpenOrConnect establish calls = %d, want 0", establishCalls.Load())
+	}
+	if err := active.Close(); err != nil {
+		t.Fatal(err)
+	}
+	manager.Invalidate("peer")
+}
+
+func TestManagerEventsProvideTerminalSequenceAcrossConcurrentCallbacks(t *testing.T) {
+	t.Parallel()
+	var (
+		mu        sync.Mutex
+		events    []LinkEvent[string, testMetadata]
+		readySeen = make(chan struct{})
+		release   = make(chan struct{})
+	)
+	manager := NewManager[string, testMetadata](ManagerConfig[string, testMetadata]{
+		IdleGrace: time.Minute,
+		Observe: func(event LinkEvent[string, testMetadata]) {
+			if event.State == LinkReady && event.Sequence == 2 {
+				close(readySeen)
+				<-release
+			}
+			mu.Lock()
+			events = append(events, event)
+			mu.Unlock()
+		},
+	})
+	link := newFakeLink()
+	registerTestLink(t, manager, "peer", "connection", link, nil)
+	opened := make(chan net.Conn, 1)
+	go func() {
+		stream, _ := manager.OpenStream(context.Background(), "peer")
+		opened <- stream
+	}()
+	select {
+	case <-readySeen:
+	case <-time.After(time.Second):
+		t.Fatal("second ready callback did not start")
+	}
+	manager.Invalidate("peer")
+	close(release)
+	if stream := <-opened; stream != nil {
+		_ = stream.Close()
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(events) != 3 {
+		t.Fatalf("events = %#v, want initial ready, disconnected, delayed ready", events)
+	}
+	if events[1].State != LinkDisconnected || events[1].Sequence != 3 ||
+		events[2].State != LinkReady || events[2].Sequence != 2 {
+		t.Fatalf("callback completion order = %#v, want terminal sequence to dominate delayed ready", events)
+	}
+}
+
+func TestManagerRoutesIncomingStreamWithTypedMetadata(t *testing.T) {
+	t.Parallel()
+	manager := NewManager[string, testMetadata](ManagerConfig[string, testMetadata]{})
+	link := newFakeLink()
+	handled := make(chan IncomingStream[string, testMetadata], 1)
+	registerTestLink(t, manager, "peer", "connection", link, func(
+		_ context.Context,
+		stream IncomingStream[string, testMetadata],
+	) error {
+		handled <- stream
+		return nil
+	})
+	link.queueIncoming(newTrackingConn())
+	select {
+	case incoming := <-handled:
+		if incoming.Key != "peer" || incoming.ConnectionID != "connection" || incoming.Metadata.Peer != "peer-label" {
+			t.Fatalf("incoming stream = %#v", incoming)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("incoming stream was not handled")
+	}
+	manager.Invalidate("peer")
+}
+
+func TestManagerQuiescenceCancelsAdmissionsAndRejectsNewWork(t *testing.T) {
+	t.Parallel()
+	manager := NewManager[string, testMetadata](ManagerConfig[string, testMetadata]{})
+	admission, err := manager.Admit(context.Background(), "peer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.BeginQuiescence()
+	if !errors.Is(context.Cause(admission.Context()), ErrAdmissionInvalidated) {
+		t.Fatalf("admission cause = %v, want invalidated", context.Cause(admission.Context()))
+	}
+	if _, err := manager.Admit(context.Background(), "peer"); !errors.Is(err, ErrManagerClosed) {
+		t.Fatalf("Admit after quiescence error = %v, want manager closed", err)
+	}
+	admission.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := manager.WaitForQuiescence(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestManagerWaitForQuiescenceBeginsShutdown(t *testing.T) {
+	t.Parallel()
+	manager := NewManager[string, testMetadata](ManagerConfig[string, testMetadata]{})
+	admission, err := manager.Admit(context.Background(), "peer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waited := make(chan error, 1)
+	go func() {
+		waited <- manager.WaitForQuiescence(context.Background())
+	}()
+	waitFor(t, time.Second, func() bool {
+		return errors.Is(context.Cause(admission.Context()), ErrAdmissionInvalidated)
+	})
+	if _, err := manager.Admit(context.Background(), "peer"); !errors.Is(err, ErrManagerClosed) {
+		t.Fatalf("Admit while waiting error = %v, want manager closed", err)
+	}
+	admission.Close()
+	select {
+	case err := <-waited:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WaitForQuiescence did not finish")
+	}
+}
+
+func registerTestLink(
+	t *testing.T,
+	manager *Manager[string, testMetadata],
+	key, connectionID string,
+	link Link,
+	handler IncomingHandler[string, testMetadata],
+) RegisterDisposition {
+	t.Helper()
+	admission, err := manager.Admit(context.Background(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer admission.Close()
+	disposition, err := manager.Register(admission, Registration[string, testMetadata]{
+		Key:            key,
+		ConnectionID:   connectionID,
+		Link:           link,
+		Metadata:       testMetadata{Peer: "peer-label"},
+		HandleIncoming: handler,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return disposition
+}
+
+func waitFor(t *testing.T, timeout time.Duration, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for !condition() {
+		if time.Now().After(deadline) {
+			t.Fatal("condition was not satisfied before timeout")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+var _ net.Conn = (*trackingConn)(nil)

--- a/packages/device-link/linkmanager/probe_cache.go
+++ b/packages/device-link/linkmanager/probe_cache.go
@@ -1,0 +1,306 @@
+package linkmanager
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultProbeTTL      = 10 * time.Minute
+	defaultProbeCapacity = 64
+)
+
+var defaultProbeBackoff = []time.Duration{
+	0,
+	0,
+	time.Minute,
+	5 * time.Minute,
+	15 * time.Minute,
+	30 * time.Minute,
+}
+
+type ProbeCacheConfig struct {
+	TTL      time.Duration
+	Capacity int
+	Backoff  []time.Duration
+}
+
+type ProbeDecision struct {
+	RecentFailure bool
+	ProbeDue      bool
+}
+
+type probeOutcome struct {
+	consecutiveFailures int
+	lastFailureAt       time.Time
+	nextProbeAt         time.Time
+	environment         string
+}
+
+func (o *probeOutcome) horizon(ttl time.Duration) time.Duration {
+	backoff := o.nextProbeAt.Sub(o.lastFailureAt)
+	if backoff < 0 {
+		backoff = 0
+	}
+	return backoff + ttl
+}
+
+// ProbeCache remembers categorical direct-path failures without knowing what
+// the preferred or fallback paths mean. Callers provide an opaque peer key and
+// a sanitized environment fingerprint.
+type ProbeCache struct {
+	cfg ProbeCacheConfig
+
+	mu               sync.Mutex
+	entries          map[string]*probeOutcome
+	probing          map[string]uint64
+	probeGenerations map[string]uint64
+	globalGeneration uint64
+	nextProbeLeaseID uint64
+}
+
+// ProbeLease owns one peer's failure accounting in the generations that were
+// current when ClaimProbe succeeded. A lease completed after invalidation is
+// ignored and cannot recreate stale negative state.
+type ProbeLease struct {
+	cache            *ProbeCache
+	peerKey          string
+	id               uint64
+	globalGeneration uint64
+	peerGeneration   uint64
+	once             sync.Once
+}
+
+func NewProbeCache(cfg ProbeCacheConfig) *ProbeCache {
+	if cfg.TTL == 0 {
+		cfg.TTL = defaultProbeTTL
+	}
+	if cfg.Capacity <= 0 {
+		cfg.Capacity = defaultProbeCapacity
+	}
+	if len(cfg.Backoff) == 0 {
+		cfg.Backoff = append([]time.Duration(nil), defaultProbeBackoff...)
+	} else {
+		cfg.Backoff = append([]time.Duration(nil), cfg.Backoff...)
+		for index, delay := range cfg.Backoff {
+			if delay < 0 {
+				cfg.Backoff[index] = 0
+			}
+		}
+	}
+	return &ProbeCache{cfg: cfg}
+}
+
+// Decision reports whether the preference window should be skipped because of
+// a recent failure and whether an annealed probe is due on this attempt.
+func (c *ProbeCache) Decision(peerKey, environment string, now time.Time) ProbeDecision {
+	if c == nil {
+		return ProbeDecision{ProbeDue: true}
+	}
+	peerKey = strings.TrimSpace(peerKey)
+	if peerKey == "" || c.cfg.TTL <= 0 {
+		return ProbeDecision{ProbeDue: true}
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry := c.entries[peerKey]
+	if entry == nil {
+		return ProbeDecision{ProbeDue: true}
+	}
+	if entry.environment != environment {
+		if c.probeGenerations == nil {
+			c.probeGenerations = make(map[string]uint64)
+		}
+		c.probeGenerations[peerKey]++
+		delete(c.probing, peerKey)
+		delete(c.entries, peerKey)
+		return ProbeDecision{ProbeDue: true}
+	}
+	if now.Sub(entry.lastFailureAt) >= entry.horizon(c.cfg.TTL) {
+		delete(c.entries, peerKey)
+		return ProbeDecision{ProbeDue: true}
+	}
+	return ProbeDecision{
+		RecentFailure: true,
+		ProbeDue:      !now.Before(entry.nextProbeAt),
+	}
+}
+
+// ClaimProbe ensures one concurrent attempt owns failure accounting for a
+// peer. The caller must complete the lease with RecordFailure, RecordSuccess,
+// or Close.
+func (c *ProbeCache) ClaimProbe(peerKey string) *ProbeLease {
+	if c == nil {
+		return nil
+	}
+	peerKey = strings.TrimSpace(peerKey)
+	if peerKey == "" {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.probing == nil {
+		c.probing = make(map[string]uint64)
+	}
+	if c.probing[peerKey] != 0 {
+		return nil
+	}
+	c.nextProbeLeaseID++
+	if c.nextProbeLeaseID == 0 {
+		c.nextProbeLeaseID++
+	}
+	id := c.nextProbeLeaseID
+	c.probing[peerKey] = id
+	return &ProbeLease{
+		cache:            c,
+		peerKey:          peerKey,
+		id:               id,
+		globalGeneration: c.globalGeneration,
+		peerGeneration:   c.probeGenerations[peerKey],
+	}
+}
+
+// Close releases a probe claim without changing reachability state.
+func (l *ProbeLease) Close() {
+	l.complete(nil)
+}
+
+// RecordFailure atomically records one current probe failure and releases the
+// claim. It returns false when the lease was already completed or invalidated.
+func (l *ProbeLease) RecordFailure(environment string, now time.Time) bool {
+	return l.complete(func(c *ProbeCache) {
+		c.recordFailureLocked(l.peerKey, environment, now)
+	})
+}
+
+// RecordSuccess clears negative state and releases the current probe claim.
+func (l *ProbeLease) RecordSuccess() bool {
+	return l.complete(func(c *ProbeCache) {
+		delete(c.entries, l.peerKey)
+	})
+}
+
+func (l *ProbeLease) complete(apply func(*ProbeCache)) bool {
+	if l == nil || l.cache == nil {
+		return false
+	}
+	applied := false
+	l.once.Do(func() {
+		c := l.cache
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if c.probing[l.peerKey] != l.id ||
+			c.globalGeneration != l.globalGeneration ||
+			c.probeGenerations[l.peerKey] != l.peerGeneration {
+			return
+		}
+		delete(c.probing, l.peerKey)
+		if apply != nil {
+			apply(c)
+		}
+		applied = true
+	})
+	return applied
+}
+
+func (c *ProbeCache) recordFailureLocked(peerKey, environment string, now time.Time) {
+	if c.cfg.TTL <= 0 {
+		return
+	}
+	if c.entries == nil {
+		c.entries = make(map[string]*probeOutcome)
+	}
+	entry := c.entries[peerKey]
+	if entry == nil {
+		if len(c.entries) >= c.cfg.Capacity {
+			c.evictOldestLocked()
+		}
+		entry = &probeOutcome{}
+		c.entries[peerKey] = entry
+	} else if entry.environment != environment {
+		entry.consecutiveFailures = 0
+	}
+	entry.consecutiveFailures++
+	entry.lastFailureAt = now
+	entry.nextProbeAt = now.Add(c.backoffFor(entry.consecutiveFailures))
+	entry.environment = environment
+}
+
+// RecordSuccess clears a peer verdict and fences any older in-flight probe.
+func (c *ProbeCache) RecordSuccess(peerKey string) {
+	c.Invalidate(peerKey)
+}
+
+func (c *ProbeCache) Invalidate(peerKey string) {
+	if c == nil {
+		return
+	}
+	peerKey = strings.TrimSpace(peerKey)
+	if peerKey == "" {
+		return
+	}
+	c.mu.Lock()
+	if c.probeGenerations == nil {
+		c.probeGenerations = make(map[string]uint64)
+	}
+	c.probeGenerations[peerKey]++
+	delete(c.entries, peerKey)
+	delete(c.probing, peerKey)
+	c.mu.Unlock()
+}
+
+func (c *ProbeCache) InvalidateAll() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.globalGeneration++
+	c.entries = nil
+	c.probing = nil
+	c.probeGenerations = nil
+	c.mu.Unlock()
+}
+
+func (c *ProbeCache) backoffFor(consecutiveFailures int) time.Duration {
+	if consecutiveFailures < 1 {
+		consecutiveFailures = 1
+	}
+	index := consecutiveFailures - 1
+	if index >= len(c.cfg.Backoff) {
+		index = len(c.cfg.Backoff) - 1
+	}
+	return c.cfg.Backoff[index]
+}
+
+func (c *ProbeCache) evictOldestLocked() {
+	oldestKey := ""
+	var oldestAt time.Time
+	for key, entry := range c.entries {
+		if oldestKey == "" || entry.lastFailureAt.Before(oldestAt) {
+			oldestKey = key
+			oldestAt = entry.lastFailureAt
+		}
+	}
+	if oldestKey != "" {
+		delete(c.entries, oldestKey)
+	}
+}
+
+// EnvironmentFingerprint creates a bounded opaque token from product-owned
+// lane, policy, STUN snapshot, and local-network generation inputs.
+func EnvironmentFingerprint(parts ...string) string {
+	digest := sha256.New()
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		_, _ = digest.Write([]byte(strconv.Itoa(len(part))))
+		_, _ = digest.Write([]byte{0})
+		_, _ = digest.Write([]byte(part))
+		_, _ = digest.Write([]byte{0})
+	}
+	sum := digest.Sum(nil)
+	return hex.EncodeToString(sum[:8])
+}

--- a/packages/device-link/linkmanager/probe_cache_test.go
+++ b/packages/device-link/linkmanager/probe_cache_test.go
@@ -1,0 +1,155 @@
+package linkmanager
+
+import (
+	"testing"
+	"time"
+)
+
+func TestProbeCacheAnnealsFailuresAndPreservesDueWindow(t *testing.T) {
+	t.Parallel()
+	cache := NewProbeCache(ProbeCacheConfig{
+		TTL:     10 * time.Minute,
+		Backoff: []time.Duration{0, 0, time.Minute, 5 * time.Minute},
+	})
+	now := time.Unix(100, 0)
+	const peer = "peer"
+	const environment = "environment"
+
+	for failure := 1; failure <= 3; failure++ {
+		recordProbeFailure(t, cache, peer, environment, now)
+		decision := cache.Decision(peer, environment, now)
+		if !decision.RecentFailure {
+			t.Fatalf("failure %d did not produce a recent verdict", failure)
+		}
+		wantDue := failure <= 2
+		if decision.ProbeDue != wantDue {
+			t.Fatalf("failure %d ProbeDue = %v, want %v", failure, decision.ProbeDue, wantDue)
+		}
+	}
+	dueAt := now.Add(time.Minute)
+	if decision := cache.Decision(peer, environment, dueAt); !decision.RecentFailure || !decision.ProbeDue {
+		t.Fatalf("decision at due time = %#v, want recent due probe", decision)
+	}
+}
+
+func TestProbeCacheEnvironmentChangeAndSuccessClearVerdict(t *testing.T) {
+	t.Parallel()
+	cache := NewProbeCache(ProbeCacheConfig{})
+	now := time.Now()
+	recordProbeFailure(t, cache, "peer", "old", now)
+	if decision := cache.Decision("peer", "new", now); decision.RecentFailure || !decision.ProbeDue {
+		t.Fatalf("environment change decision = %#v, want fresh probe", decision)
+	}
+	recordProbeFailure(t, cache, "peer", "new", now)
+	cache.RecordSuccess("peer")
+	if decision := cache.Decision("peer", "new", now); decision.RecentFailure || !decision.ProbeDue {
+		t.Fatalf("success decision = %#v, want fresh probe", decision)
+	}
+}
+
+func TestProbeCacheRecordFailureResetsBackoffForNewEnvironment(t *testing.T) {
+	t.Parallel()
+	cache := NewProbeCache(ProbeCacheConfig{
+		Backoff: []time.Duration{0, time.Minute},
+	})
+	now := time.Now()
+	recordProbeFailure(t, cache, "peer", "old", now)
+	recordProbeFailure(t, cache, "peer", "old", now)
+	if decision := cache.Decision("peer", "old", now); decision.ProbeDue {
+		t.Fatalf("second old-environment failure decision = %#v, want annealed probe", decision)
+	}
+	recordProbeFailure(t, cache, "peer", "new", now)
+	if decision := cache.Decision("peer", "new", now); !decision.RecentFailure || !decision.ProbeDue {
+		t.Fatalf("new-environment failure decision = %#v, want reset backoff", decision)
+	}
+}
+
+func TestProbeCacheClaimsOneConcurrentProbe(t *testing.T) {
+	t.Parallel()
+	cache := NewProbeCache(ProbeCacheConfig{})
+	first := cache.ClaimProbe("peer")
+	if first == nil {
+		t.Fatal("first probe was not claimed")
+	}
+	if cache.ClaimProbe("peer") != nil {
+		t.Fatal("second concurrent probe was claimed")
+	}
+	first.Close()
+	if cache.ClaimProbe("peer") == nil {
+		t.Fatal("probe was not claimable after finish")
+	}
+}
+
+func TestProbeCacheInvalidationFencesStaleLeaseResults(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		invalidate func(*ProbeCache)
+	}{
+		{name: "peer", invalidate: func(cache *ProbeCache) { cache.Invalidate("peer") }},
+		{name: "all", invalidate: func(cache *ProbeCache) { cache.InvalidateAll() }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := NewProbeCache(ProbeCacheConfig{})
+			now := time.Now()
+			stale := cache.ClaimProbe("peer")
+			if stale == nil {
+				t.Fatal("stale probe was not claimed")
+			}
+			tt.invalidate(cache)
+			current := cache.ClaimProbe("peer")
+			if current == nil {
+				t.Fatal("new generation probe was not claimed")
+			}
+			if !current.RecordSuccess() {
+				t.Fatal("current success was not applied")
+			}
+			if stale.RecordFailure("old-environment", now) {
+				t.Fatal("stale failure was applied after invalidation")
+			}
+			if decision := cache.Decision("peer", "old-environment", now); decision.RecentFailure {
+				t.Fatalf("stale failure recreated verdict: %#v", decision)
+			}
+		})
+	}
+}
+
+func TestProbeCachePreservesLongBackoffDueWindow(t *testing.T) {
+	t.Parallel()
+	cache := NewProbeCache(ProbeCacheConfig{})
+	now := time.Unix(100, 0)
+	for range 6 {
+		recordProbeFailure(t, cache, "peer", "environment", now)
+	}
+	dueAt := now.Add(30 * time.Minute)
+	if decision := cache.Decision("peer", "environment", dueAt); !decision.RecentFailure || !decision.ProbeDue {
+		t.Fatalf("30-minute due decision = %#v, want retained due probe", decision)
+	}
+}
+
+func TestEnvironmentFingerprintIsBoundedAndOrderSensitive(t *testing.T) {
+	t.Parallel()
+	first := EnvironmentFingerprint("direct", "stun-a", "network-a")
+	second := EnvironmentFingerprint("direct", "stun-a", "network-a")
+	reordered := EnvironmentFingerprint("network-a", "stun-a", "direct")
+	if len(first) != 16 || first != second || first == reordered {
+		t.Fatalf("fingerprints first=%q second=%q reordered=%q", first, second, reordered)
+	}
+}
+
+func recordProbeFailure(
+	t *testing.T,
+	cache *ProbeCache,
+	peerKey, environment string,
+	now time.Time,
+) {
+	t.Helper()
+	lease := cache.ClaimProbe(peerKey)
+	if lease == nil {
+		t.Fatalf("probe %q was not claimable", peerKey)
+	}
+	if !lease.RecordFailure(environment, now) {
+		t.Fatalf("probe %q failure was not applied", peerKey)
+	}
+}

--- a/packages/device-link/linkmanager/race.go
+++ b/packages/device-link/linkmanager/race.go
@@ -1,0 +1,184 @@
+package linkmanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+)
+
+type DialFunc func(context.Context) (net.Conn, error)
+
+type DialPath struct {
+	Name string
+	Dial DialFunc
+}
+
+type RaceOutcome string
+
+const (
+	RaceStarted  RaceOutcome = "started"
+	RaceSelected RaceOutcome = "selected"
+	RaceFailed   RaceOutcome = "failed"
+	RaceCanceled RaceOutcome = "canceled"
+)
+
+type RaceEvent struct {
+	Outcome RaceOutcome
+	Path    string
+	Elapsed time.Duration
+}
+
+type RaceObserver func(RaceEvent)
+
+type RaceConfig struct {
+	Primary       DialPath
+	Fallback      DialPath
+	FallbackDelay time.Duration
+	Observe       RaceObserver
+}
+
+type RaceResult struct {
+	Conn net.Conn
+	Path string
+}
+
+type dialResult struct {
+	path string
+	conn net.Conn
+	err  error
+}
+
+// Race starts the primary authenticated-stream dial immediately and starts the
+// fallback after FallbackDelay or as soon as the primary fails. The first
+// successful stream wins; every late successful stream is closed.
+//
+// Both dialers receive a child context canceled when the race settles. A
+// product that intentionally wants a losing probe to continue for reachability
+// learning may detach that dial inside its DialFunc and apply its own deadline.
+func Race(ctx context.Context, cfg RaceConfig) (RaceResult, error) {
+	primary, fallback, err := validateRacePaths(cfg.Primary, cfg.Fallback)
+	if err != nil {
+		return RaceResult{}, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if cfg.FallbackDelay < 0 {
+		cfg.FallbackDelay = 0
+	}
+	startedAt := time.Now()
+	observe := func(outcome RaceOutcome, path string) {
+		if cfg.Observe != nil {
+			cfg.Observe(RaceEvent{Outcome: outcome, Path: path, Elapsed: time.Since(startedAt)})
+		}
+	}
+	observe(RaceStarted, primary.Name)
+
+	dialCtx, cancel := context.WithCancel(ctx)
+	settled := make(chan struct{})
+	results := make(chan dialResult)
+	start := func(path DialPath) {
+		go func() {
+			conn, dialErr := path.Dial(dialCtx)
+			result := dialResult{path: path.Name, conn: conn, err: dialErr}
+			select {
+			case results <- result:
+			case <-settled:
+				if conn != nil {
+					_ = conn.Close()
+				}
+			}
+		}()
+	}
+	var settleOnce sync.Once
+	settle := func() {
+		settleOnce.Do(func() {
+			cancel()
+			close(settled)
+		})
+	}
+	start(primary)
+	started, completed := 1, 0
+	fallbackStarted := false
+	errs := make(map[string]error, 2)
+	timer := time.NewTimer(cfg.FallbackDelay)
+	defer timer.Stop()
+	startFallback := func() {
+		if fallbackStarted {
+			return
+		}
+		fallbackStarted = true
+		started++
+		observe(RaceStarted, fallback.Name)
+		start(fallback)
+	}
+	if cfg.FallbackDelay == 0 {
+		if !timer.Stop() {
+			<-timer.C
+		}
+		startFallback()
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			settle()
+			observe(RaceCanceled, "")
+			return RaceResult{}, ctx.Err()
+		case <-timer.C:
+			startFallback()
+		case result := <-results:
+			completed++
+			if result.err == nil && result.conn != nil {
+				settle()
+				observe(RaceSelected, result.path)
+				return RaceResult{Conn: result.conn, Path: result.path}, nil
+			}
+			if result.conn != nil {
+				_ = result.conn.Close()
+			}
+			if result.err == nil {
+				result.err = errors.New("dialer returned no stream")
+			}
+			errs[result.path] = result.err
+			if result.path == primary.Name && !fallbackStarted {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				startFallback()
+			}
+			if fallbackStarted && completed == started {
+				settle()
+				observe(RaceFailed, "")
+				return RaceResult{}, fmt.Errorf(
+					"device-link paths %q and %q failed: %w",
+					primary.Name,
+					fallback.Name,
+					errors.Join(errs[primary.Name], errs[fallback.Name]),
+				)
+			}
+		}
+	}
+}
+
+func validateRacePaths(primary, fallback DialPath) (DialPath, DialPath, error) {
+	primary.Name = strings.TrimSpace(primary.Name)
+	fallback.Name = strings.TrimSpace(fallback.Name)
+	if primary.Name == "" || fallback.Name == "" {
+		return DialPath{}, DialPath{}, errors.New("device-link race paths require names")
+	}
+	if primary.Name == fallback.Name {
+		return DialPath{}, DialPath{}, errors.New("device-link race paths require distinct names")
+	}
+	if primary.Dial == nil || fallback.Dial == nil {
+		return DialPath{}, DialPath{}, errors.New("device-link race paths require dialers")
+	}
+	return primary, fallback, nil
+}

--- a/packages/device-link/linkmanager/race_test.go
+++ b/packages/device-link/linkmanager/race_test.go
@@ -1,0 +1,109 @@
+package linkmanager
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRaceSelectsPrimaryBeforeFallbackDelay(t *testing.T) {
+	t.Parallel()
+	primary, primaryPeer := net.Pipe()
+	defer primaryPeer.Close()
+	var fallbackCalls atomic.Int32
+	result, err := Race(context.Background(), RaceConfig{
+		Primary: DialPath{Name: "preferred", Dial: func(context.Context) (net.Conn, error) {
+			return primary, nil
+		}},
+		Fallback: DialPath{Name: "fallback", Dial: func(context.Context) (net.Conn, error) {
+			fallbackCalls.Add(1)
+			return nil, errors.New("unexpected fallback")
+		}},
+		FallbackDelay: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer result.Conn.Close()
+	if result.Path != "preferred" {
+		t.Fatalf("selected path = %q, want preferred", result.Path)
+	}
+	if fallbackCalls.Load() != 0 {
+		t.Fatalf("fallback calls = %d, want 0", fallbackCalls.Load())
+	}
+}
+
+func TestRaceStartsFallbackImmediatelyAfterPrimaryFailure(t *testing.T) {
+	t.Parallel()
+	fallback, fallbackPeer := net.Pipe()
+	defer fallbackPeer.Close()
+	started := time.Now()
+	result, err := Race(context.Background(), RaceConfig{
+		Primary: DialPath{Name: "preferred", Dial: func(context.Context) (net.Conn, error) {
+			return nil, errors.New("preferred unavailable")
+		}},
+		Fallback: DialPath{Name: "fallback", Dial: func(context.Context) (net.Conn, error) {
+			return fallback, nil
+		}},
+		FallbackDelay: time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer result.Conn.Close()
+	if result.Path != "fallback" {
+		t.Fatalf("selected path = %q, want fallback", result.Path)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("fast failure waited %s for fallback", elapsed)
+	}
+}
+
+func TestRaceClosesLateSuccessfulConnection(t *testing.T) {
+	t.Parallel()
+	releasePrimary := make(chan struct{})
+	late := newTrackingConn()
+	fallback := newTrackingConn()
+	result, err := Race(context.Background(), RaceConfig{
+		Primary: DialPath{Name: "preferred", Dial: func(context.Context) (net.Conn, error) {
+			<-releasePrimary
+			return late, nil
+		}},
+		Fallback: DialPath{Name: "fallback", Dial: func(context.Context) (net.Conn, error) {
+			return fallback, nil
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Path != "fallback" {
+		t.Fatalf("selected path = %q, want fallback", result.Path)
+	}
+	close(releasePrimary)
+	deadline := time.Now().Add(time.Second)
+	for late.closeCount.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("late successful connection was not closed")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	_ = result.Conn.Close()
+}
+
+func TestRaceJoinsBothFailures(t *testing.T) {
+	t.Parallel()
+	_, err := Race(context.Background(), RaceConfig{
+		Primary: DialPath{Name: "preferred", Dial: func(context.Context) (net.Conn, error) {
+			return nil, errors.New("preferred failure")
+		}},
+		Fallback: DialPath{Name: "fallback", Dial: func(context.Context) (net.Conn, error) {
+			return nil, nil
+		}},
+	})
+	if err == nil {
+		t.Fatal("Race succeeded when both paths failed")
+	}
+}

--- a/packages/device-link/linkmanager/test_helpers_test.go
+++ b/packages/device-link/linkmanager/test_helpers_test.go
@@ -1,0 +1,96 @@
+package linkmanager
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type trackingConn struct {
+	closeCount atomic.Int32
+}
+
+func newTrackingConn() *trackingConn {
+	return &trackingConn{}
+}
+
+func (*trackingConn) Read([]byte) (int, error)         { return 0, io.EOF }
+func (*trackingConn) Write(p []byte) (int, error)      { return len(p), nil }
+func (*trackingConn) LocalAddr() net.Addr              { return testAddr("local") }
+func (*trackingConn) RemoteAddr() net.Addr             { return testAddr("remote") }
+func (*trackingConn) SetDeadline(time.Time) error      { return nil }
+func (*trackingConn) SetReadDeadline(time.Time) error  { return nil }
+func (*trackingConn) SetWriteDeadline(time.Time) error { return nil }
+func (c *trackingConn) Close() error {
+	c.closeCount.Add(1)
+	return nil
+}
+
+type testAddr string
+
+func (testAddr) Network() string        { return "test" }
+func (address testAddr) String() string { return string(address) }
+
+type fakeLink struct {
+	openCount  atomic.Int32
+	closeCount atomic.Int32
+
+	incoming chan net.Conn
+	closed   chan struct{}
+	once     sync.Once
+}
+
+type cancelableOpenLink struct {
+	*fakeLink
+	cancelNext atomic.Bool
+}
+
+func (link *cancelableOpenLink) OpenStream(ctx context.Context) (net.Conn, error) {
+	if link.cancelNext.CompareAndSwap(true, false) {
+		return nil, ctx.Err()
+	}
+	return link.fakeLink.OpenStream(ctx)
+}
+
+func newFakeLink() *fakeLink {
+	return &fakeLink{
+		incoming: make(chan net.Conn, 8),
+		closed:   make(chan struct{}),
+	}
+}
+
+func (link *fakeLink) OpenStream(context.Context) (net.Conn, error) {
+	select {
+	case <-link.closed:
+		return nil, net.ErrClosed
+	default:
+	}
+	link.openCount.Add(1)
+	return newTrackingConn(), nil
+}
+
+func (link *fakeLink) AcceptStream(ctx context.Context) (net.Conn, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-link.closed:
+		return nil, net.ErrClosed
+	case stream := <-link.incoming:
+		return stream, nil
+	}
+}
+
+func (link *fakeLink) Close() error {
+	link.once.Do(func() {
+		link.closeCount.Add(1)
+		close(link.closed)
+	})
+	return nil
+}
+
+func (link *fakeLink) queueIncoming(stream net.Conn) {
+	link.incoming <- stream
+}

--- a/packages/device-link/quic.go
+++ b/packages/device-link/quic.go
@@ -109,6 +109,16 @@ type QUICSession struct {
 	conn *quic.Conn
 }
 
+// NegotiatedProtocol reports the ALPN selected by the authenticated QUIC
+// handshake. Consumers use it to measure and retire temporary compatibility
+// protocols after a rolling migration.
+func (s *QUICSession) NegotiatedProtocol() string {
+	if s == nil || s.conn == nil {
+		return ""
+	}
+	return s.conn.ConnectionState().TLS.NegotiatedProtocol
+}
+
 func (s *QUICSession) OpenStream(ctx context.Context) (net.Conn, error) {
 	if s == nil || s.conn == nil {
 		return nil, errors.New("device-link QUIC session is closed")

--- a/services/tuttid/service/mobileremote/remote_host.go
+++ b/services/tuttid/service/mobileremote/remote_host.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	authenticatedlink "github.com/tutti-os/tutti/packages/device-link/authenticated"
+	"github.com/tutti-os/tutti/packages/device-link/linkmanager"
 	mobileremotebiz "github.com/tutti-os/tutti/services/tuttid/biz/mobileremote"
 )
 
@@ -25,42 +26,69 @@ type activeRemoteAttempt struct {
 	generation uint64
 }
 
+type remoteLinkMetadata struct {
+	pairingID  string
+	handler    http.Handler
+	liveEvents AgentLiveEventSource
+}
+
+type remoteManagedLink struct {
+	connectionID string
+}
+
 type remoteHostState struct {
 	mu sync.Mutex
 
-	cancel            context.CancelFunc
-	handler           http.Handler
-	liveEvents        AgentLiveEventSource
-	attempts          map[string]activeRemoteAttempt
-	registeredSession string
-	registeredDevice  RegisteredDevice
-	registerAfter     time.Time
-	nextGeneration    uint64
+	cancel             context.CancelFunc
+	stopping           bool
+	stopDone           chan struct{}
+	handler            http.Handler
+	liveEvents         AgentLiveEventSource
+	attempts           map[string]activeRemoteAttempt
+	registeredSession  string
+	registeredDevice   RegisteredDevice
+	registerAfter      time.Time
+	nextGeneration     uint64
+	linkManager        *linkmanager.Manager[string, remoteLinkMetadata]
+	managedLinks       map[string]remoteManagedLink
+	observedLinkEvents map[string]uint64
 }
 
 func (s *Service) StartRemoteHost(handler http.Handler) {
 	if s == nil || handler == nil {
 		return
 	}
-	s.remoteHost.mu.Lock()
-	if s.remoteHost.cancel != nil {
+	for {
+		s.remoteHost.mu.Lock()
+		if s.remoteHost.stopping {
+			done := s.remoteHost.stopDone
+			s.remoteHost.mu.Unlock()
+			<-done
+			continue
+		}
+		if s.remoteHost.cancel != nil {
+			s.remoteHost.handler = handler
+			s.remoteHost.liveEvents = s.AgentLiveEvents
+			s.remoteHost.mu.Unlock()
+			return
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		s.remoteWG.Add(1)
+		s.remoteHost.cancel = cancel
 		s.remoteHost.handler = handler
 		s.remoteHost.liveEvents = s.AgentLiveEvents
+		s.remoteHost.attempts = make(map[string]activeRemoteAttempt)
+		s.remoteHost.managedLinks = make(map[string]remoteManagedLink)
+		s.remoteHost.observedLinkEvents = make(map[string]uint64)
+		s.remoteHost.linkManager = s.newRemoteLinkManager()
 		s.remoteHost.mu.Unlock()
+
+		go func() {
+			defer s.remoteWG.Done()
+			s.runRemoteHost(ctx)
+		}()
 		return
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	s.remoteHost.cancel = cancel
-	s.remoteHost.handler = handler
-	s.remoteHost.liveEvents = s.AgentLiveEvents
-	s.remoteHost.attempts = make(map[string]activeRemoteAttempt)
-	s.remoteHost.mu.Unlock()
-
-	s.remoteWG.Add(1)
-	go func() {
-		defer s.remoteWG.Done()
-		s.runRemoteHost(ctx)
-	}()
 }
 
 func (s *Service) Close() {
@@ -68,16 +96,45 @@ func (s *Service) Close() {
 		return
 	}
 	s.remoteHost.mu.Lock()
+	if s.remoteHost.stopping {
+		done := s.remoteHost.stopDone
+		s.remoteHost.mu.Unlock()
+		<-done
+		return
+	}
 	cancel := s.remoteHost.cancel
-	s.remoteHost.cancel = nil
+	manager := s.remoteHost.linkManager
+	if cancel == nil && manager == nil {
+		s.remoteHost.mu.Unlock()
+		return
+	}
+	done := make(chan struct{})
+	s.remoteHost.stopping = true
+	s.remoteHost.stopDone = done
 	for _, attempt := range s.remoteHost.attempts {
 		attempt.cancel()
 	}
 	s.remoteHost.mu.Unlock()
+	if manager != nil {
+		manager.BeginQuiescence()
+	}
 	if cancel != nil {
 		cancel()
 	}
 	s.remoteWG.Wait()
+	if manager != nil {
+		_ = manager.WaitForQuiescence(context.Background())
+	}
+	s.remoteHost.mu.Lock()
+	s.remoteHost.cancel = nil
+	s.remoteHost.linkManager = nil
+	s.remoteHost.attempts = nil
+	s.remoteHost.managedLinks = nil
+	s.remoteHost.observedLinkEvents = nil
+	s.remoteHost.stopping = false
+	s.remoteHost.stopDone = nil
+	close(done)
+	s.remoteHost.mu.Unlock()
 }
 
 func (s *Service) runRemoteHost(ctx context.Context) {
@@ -104,6 +161,7 @@ func (s *Service) pollRemoteHost(ctx context.Context) {
 		s.stopRemoteAttempts(nil)
 		return
 	}
+	s.setRemoteLinkEnabled(true)
 	registered, err := s.ensureRegisteredDevice(ctx, session.SessionID, session.Cookie, identity)
 	if err != nil {
 		if isControlPlaneUnauthorized(err) {
@@ -184,6 +242,10 @@ func (s *Service) startRemoteAttempt(
 	attempt DeviceLinkAttempt,
 ) {
 	s.remoteHost.mu.Lock()
+	if s.remoteHost.stopping || s.remoteHost.cancel == nil || parent.Err() != nil {
+		s.remoteHost.mu.Unlock()
+		return
+	}
 	if _, exists := s.remoteHost.attempts[attempt.AttemptID]; exists {
 		s.remoteHost.mu.Unlock()
 		return
@@ -196,9 +258,9 @@ func (s *Service) startRemoteAttempt(
 	}
 	handler := s.remoteHost.handler
 	liveEvents := s.remoteHost.liveEvents
+	s.remoteWG.Add(1)
 	s.remoteHost.mu.Unlock()
 
-	s.remoteWG.Add(1)
 	go func() {
 		defer s.remoteWG.Done()
 		defer cancel()
@@ -222,14 +284,19 @@ func (s *Service) finishRemoteAttempt(attemptID string, generation uint64) {
 }
 
 func (s *Service) stopRemotePairing(pairingID string) {
+	pairingID = strings.TrimSpace(pairingID)
 	s.remoteHost.mu.Lock()
-	defer s.remoteHost.mu.Unlock()
 	for attemptID, attempt := range s.remoteHost.attempts {
-		if attempt.pairingID != strings.TrimSpace(pairingID) {
+		if attempt.pairingID != pairingID {
 			continue
 		}
 		attempt.cancel()
 		delete(s.remoteHost.attempts, attemptID)
+	}
+	manager := s.remoteHost.linkManager
+	s.remoteHost.mu.Unlock()
+	if manager != nil {
+		manager.Invalidate(pairingID)
 	}
 }
 
@@ -288,6 +355,17 @@ func (s *Service) serveRemoteAttempt(
 		handshakeCtx, cancelHandshake = context.WithDeadline(ctx, deadline)
 	}
 	defer cancelHandshake()
+	s.remoteHost.mu.Lock()
+	manager := s.remoteHost.linkManager
+	s.remoteHost.mu.Unlock()
+	if manager == nil {
+		return
+	}
+	admission, err := manager.Admit(handshakeCtx, pairingID)
+	if err != nil {
+		return
+	}
+	defer admission.Close()
 	participant, err := authenticatedlink.NewParticipant(authenticatedlink.ParticipantConfig{
 		STUNEndpoints:   append([]string(nil), attempt.STUNEndpoints...),
 		IncludeLoopback: s.includeLoopback,
@@ -295,7 +373,12 @@ func (s *Service) serveRemoteAttempt(
 	if err != nil {
 		return
 	}
-	defer participant.Close()
+	transferred := false
+	defer func() {
+		if !transferred {
+			_ = participant.Close()
+		}
+	}()
 	description, err := participant.LocalDescription(handshakeCtx)
 	if err != nil {
 		return
@@ -332,25 +415,25 @@ func (s *Service) serveRemoteAttempt(
 	if err != nil {
 		return
 	}
-	cancelHandshake()
-	defer link.Close()
-
-	for {
-		stream, err := link.AcceptStream(ctx)
-		if err != nil {
-			return
-		}
-		s.remoteWG.Add(1)
-		go func() {
-			defer s.remoteWG.Done()
-			_ = serveRemoteStreamWithAgentLive(ctx, stream, handler, pairingID, liveEvents)
-		}()
+	_, err = manager.Register(admission, linkmanager.Registration[string, remoteLinkMetadata]{
+		Key:          pairingID,
+		ConnectionID: attempt.AttemptID,
+		Link:         link,
+		Metadata: remoteLinkMetadata{
+			pairingID: pairingID, handler: handler, liveEvents: liveEvents,
+		},
+		HandleIncoming: serveManagedRemoteStream,
+	})
+	transferred = true
+	if err != nil {
+		return
 	}
+	cancelHandshake()
 }
 
 func (s *Service) stopRemoteAttempts(validPairings map[string]struct{}) {
 	s.remoteHost.mu.Lock()
-	defer s.remoteHost.mu.Unlock()
+	invalidPairingSet := make(map[string]struct{})
 	for attemptID, attempt := range s.remoteHost.attempts {
 		if validPairings != nil {
 			if _, valid := validPairings[attempt.pairingID]; valid {
@@ -359,12 +442,84 @@ func (s *Service) stopRemoteAttempts(validPairings map[string]struct{}) {
 		}
 		attempt.cancel()
 		delete(s.remoteHost.attempts, attemptID)
+		invalidPairingSet[attempt.pairingID] = struct{}{}
+	}
+	manager := s.remoteHost.linkManager
+	for pairingID := range s.remoteHost.managedLinks {
+		if validPairings != nil {
+			if _, valid := validPairings[pairingID]; valid {
+				continue
+			}
+		}
+		invalidPairingSet[pairingID] = struct{}{}
 	}
 	if validPairings == nil {
 		s.remoteHost.registeredSession = ""
 		s.remoteHost.registeredDevice = RegisteredDevice{}
 		s.remoteHost.registerAfter = time.Time{}
 	}
+	s.remoteHost.mu.Unlock()
+	if manager == nil {
+		return
+	}
+	if validPairings == nil {
+		_ = manager.SetEnabled(false)
+		return
+	}
+	for pairingID := range invalidPairingSet {
+		manager.Invalidate(pairingID)
+	}
+}
+
+func (s *Service) setRemoteLinkEnabled(enabled bool) {
+	s.remoteHost.mu.Lock()
+	manager := s.remoteHost.linkManager
+	s.remoteHost.mu.Unlock()
+	if manager != nil {
+		_ = manager.SetEnabled(enabled)
+	}
+}
+
+func (s *Service) newRemoteLinkManager() *linkmanager.Manager[string, remoteLinkMetadata] {
+	return linkmanager.NewManager(linkmanager.ManagerConfig[string, remoteLinkMetadata]{
+		Observe: func(event linkmanager.LinkEvent[string, remoteLinkMetadata]) {
+			s.remoteHost.mu.Lock()
+			defer s.remoteHost.mu.Unlock()
+			if s.remoteHost.observedLinkEvents == nil {
+				s.remoteHost.observedLinkEvents = make(map[string]uint64)
+			}
+			if event.Sequence <= s.remoteHost.observedLinkEvents[event.ConnectionID] {
+				return
+			}
+			s.remoteHost.observedLinkEvents[event.ConnectionID] = event.Sequence
+			switch event.State {
+			case linkmanager.LinkReady:
+				if s.remoteHost.managedLinks != nil {
+					s.remoteHost.managedLinks[event.Key] = remoteManagedLink{
+						connectionID: event.ConnectionID,
+					}
+				}
+			case linkmanager.LinkDisconnected:
+				if s.remoteHost.managedLinks[event.Key].connectionID == event.ConnectionID {
+					delete(s.remoteHost.managedLinks, event.Key)
+				}
+			}
+		},
+	})
+}
+
+func serveManagedRemoteStream(
+	ctx context.Context,
+	incoming linkmanager.IncomingStream[string, remoteLinkMetadata],
+) error {
+	metadata := incoming.Metadata
+	return serveRemoteStreamWithAgentLive(
+		ctx,
+		incoming.Stream,
+		metadata.handler,
+		metadata.pairingID,
+		metadata.liveEvents,
+	)
 }
 
 func deviceLinkProof(action, pairingID, attemptID, fingerprint string) []byte {

--- a/services/tuttid/service/mobileremote/remote_host_test.go
+++ b/services/tuttid/service/mobileremote/remote_host_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"errors"
 	"net/http"
 	"strings"
 	"sync"
@@ -12,6 +13,7 @@ import (
 
 	authbridge "github.com/tutti-os/tutti/packages/auth/bridge-go"
 	authenticatedlink "github.com/tutti-os/tutti/packages/device-link/authenticated"
+	"github.com/tutti-os/tutti/packages/device-link/linkmanager"
 	mobileremotebiz "github.com/tutti-os/tutti/services/tuttid/biz/mobileremote"
 )
 
@@ -228,6 +230,77 @@ func TestRemoteHostAttemptCleanupDoesNotDeleteNewGeneration(t *testing.T) {
 	}
 }
 
+func TestRemoteHostDisablesSharedAdmissionUntilIdentityRecovers(t *testing.T) {
+	t.Parallel()
+	service := &Service{}
+	service.remoteHost.managedLinks = make(map[string]remoteManagedLink)
+	service.remoteHost.observedLinkEvents = make(map[string]uint64)
+	service.remoteHost.linkManager = service.newRemoteLinkManager()
+	manager := service.remoteHost.linkManager
+
+	service.stopRemoteAttempts(nil)
+	if _, err := manager.Admit(context.Background(), "pairing-1"); !errors.Is(err, linkmanager.ErrManagerDisabled) {
+		t.Fatalf("Admit while identity unavailable error = %v, want disabled", err)
+	}
+	service.setRemoteLinkEnabled(true)
+	admission, err := manager.Admit(context.Background(), "pairing-1")
+	if err != nil {
+		t.Fatalf("Admit after identity recovery: %v", err)
+	}
+	admission.Close()
+	if err := manager.WaitForQuiescence(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRemoteHostStartWaitsForInProgressClose(t *testing.T) {
+	t.Parallel()
+	service := &Service{}
+	service.remoteHost.cancel = func() {}
+	service.remoteHost.managedLinks = make(map[string]remoteManagedLink)
+	service.remoteHost.observedLinkEvents = make(map[string]uint64)
+	service.remoteHost.linkManager = service.newRemoteLinkManager()
+	admission, err := service.remoteHost.linkManager.Admit(context.Background(), "pairing-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		service.Close()
+		close(closed)
+	}()
+	waitForRemoteHostCondition(t, func() bool {
+		service.remoteHost.mu.Lock()
+		defer service.remoteHost.mu.Unlock()
+		return service.remoteHost.stopping
+	})
+
+	started := make(chan struct{})
+	go func() {
+		service.StartRemoteHost(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		close(started)
+	}()
+	select {
+	case <-started:
+		t.Fatal("StartRemoteHost returned before the previous run closed")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	admission.Close()
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not finish after admission release")
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("StartRemoteHost did not resume after Close")
+	}
+	service.Close()
+}
+
 func TestControlPlaneUnauthorizedClassification(t *testing.T) {
 	t.Parallel()
 	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
@@ -237,5 +310,16 @@ func TestControlPlaneUnauthorizedClassification(t *testing.T) {
 	}
 	if isControlPlaneUnauthorized(&ControlPlaneError{StatusCode: http.StatusInternalServerError}) {
 		t.Fatal("server error was classified as unauthorized")
+	}
+}
+
+func waitForRemoteHostCondition(t *testing.T, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for !condition() {
+		if time.Now().After(deadline) {
+			t.Fatal("remote host condition was not satisfied")
+		}
+		time.Sleep(time.Millisecond)
 	}
 }


### PR DESCRIPTION
## Summary

- extract the reusable DeviceLink connection lifecycle into `linkmanager`: generation-bound admission, pause/resume fencing, per-peer singleflight, authenticated link pooling, stream refcounts, idle retirement, deterministic collision handling, two-path racing, and generation-safe annealed probe caching
- add trickle-ICE facade methods, rolling ALPN compatibility/negotiation reporting, and the latest selected-scope fix from TSH
- cut Tutti `mobileremote` over as the first real adapter while keeping pairing, identity proof, rendezvous, Relay policy, and Agent framing product-owned
- document the shared seam and the remaining TSH adapter-only cutover work

## Validation

- `pnpm check:changed` (9 lanes)
- pre-push `pnpm check:changed -- --push-ready` (10 lanes)
- `go test -race ./...` in `packages/device-link`
- `go test -race ./service/mobileremote`
- independent package-boundary, concurrency/lifecycle, and TSH migration reviews; final passes reported no remaining P0-P3 findings
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->