### PR TITLE
fix(ui-system): make native sheets accessible

### DIFF
--- a/apps/mobile/src/components/MobileComposerSettingsSheet.tsx
+++ b/apps/mobile/src/components/MobileComposerSettingsSheet.tsx
@@ -103,6 +103,7 @@ export function MobileComposerSettingsSheet({
       </View>
 
       <NativeSheet
+        closeAccessibilityLabel={t("closeSheet")}
         onOpenChange={(open) => !open && setMenu(null)}
         open={menu !== null}
       >

--- a/apps/mobile/src/components/MobileConversationDrawer.tsx
+++ b/apps/mobile/src/components/MobileConversationDrawer.tsx
@@ -345,6 +345,7 @@ export function MobileConversationDrawer({
 
       {dialog && actionSession ? (
         <NativeSheet
+          closeAccessibilityLabel={t("closeSheet")}
           onOpenChange={(open) => {
             if (!open && !actionPending) setDialog(null);
           }}

--- a/apps/mobile/src/dev/NativeComponentGallery.tsx
+++ b/apps/mobile/src/dev/NativeComponentGallery.tsx
@@ -112,9 +112,10 @@ export function NativeComponentGallery({ onClose }: { onClose(): void }) {
       </ScrollView>
 
       <NativeSheet
+        closeAccessibilityLabel={t("closeSheet")}
+        height="50%"
         onOpenChange={setSheetOpen}
         open={sheetOpen}
-        snapPoints={["50%"]}
       >
         <View style={styles.sheetContent}>
           <Text style={styles.sheetTitle}>{t("nativeGallerySheet")}</Text>

--- a/apps/mobile/src/i18n.ts
+++ b/apps/mobile/src/i18n.ts
@@ -21,6 +21,7 @@ const messages = {
     copyAsMarkdown: "Copy as Markdown",
     copyImageUrl: "Copy image URL",
     changedFiles: "{count} changed files",
+    closeSheet: "Close sheet",
     collapseSection: "Collapse section",
     connecting: "Connecting securely…",
     connectionFailed:
@@ -161,6 +162,7 @@ const messages = {
     copyAsMarkdown: "复制为 Markdown",
     copyImageUrl: "复制图片链接",
     changedFiles: "已变更 {count} 个文件",
+    closeSheet: "关闭面板",
     collapseSection: "收起分组",
     connecting: "正在建立安全连接…",
     connectionFailed: "无法连接这台电脑，请确认 Tutti 正在运行后重试",

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -76,13 +76,17 @@
   current React 19 Native renderer and recursively republishes the modal node
   instead of presenting it.
 - **Fix:** Keep the shared compact `NativeSheet` on React Native's window-level
-  `Modal`, with UI System scrim and panel tokens. Reserve
+  `Modal`, with UI System scrim and panel tokens. Require a caller-localized
+  close label, expose backdrop dismissal as an accessibility button, handle the
+  iOS accessibility escape gesture, and represent an optional fixed height as
+  one value rather than silently accepting multiple snap points. Reserve
   `@gorhom/bottom-sheet` for app-owned complex sheets that genuinely need its
   gesture, keyboard, or multi-snap-point behavior.
 - **Validation:** Open and dismiss the model, speed, and permission sheets more
   than once, select the already active option without changing Session state,
-  and confirm there is no maximum-update-depth error. Also verify backdrop and
-  Android system-back dismissal.
+  and confirm there is no maximum-update-depth error. Also verify touch
+  backdrop, Android system-back, VoiceOver escape, and screen-reader close
+  button dismissal without hiding the sheet's interactive descendants.
 - **References:** `packages/ui/system/src/native/sheet.tsx`,
   `apps/mobile/src/components/MobileComposerSettingsSheet.tsx`
 

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -261,7 +261,9 @@ screen composition and product-specific interaction.
   and dynamic-height sheets; wrap it behind a UI System Native component when
   it becomes a reusable product pattern. The shared compact `NativeSheet` uses
   React Native's window-level `Modal` instead, so its controlled open state does
-  not pass through `@gorhom/portal`.
+  not pass through `@gorhom/portal`. Callers provide its localized accessible
+  close label and may set one fixed height; multi-snap behavior remains outside
+  the compact primitive.
 - Agent message Markdown is rendered natively with
   `react-native-enriched-markdown`; it consumes the existing AgentGUI
   conversation VM and maps every color, radius, and spacing decision back to

--- a/packages/ui/system/src/metadata/components.json
+++ b/packages/ui/system/src/metadata/components.json
@@ -3478,7 +3478,9 @@
       "propsType": "NativeSheetProps",
       "description": "Controlled compact sheet backed by React Native Modal with a token-backed scrim and panel.",
       "useCases": ["Row actions", "Confirmation flows", "Compact forms"],
-      "migrationHints": [],
+      "migrationHints": [
+        "Provide a localized closeAccessibilityLabel and replace a single snapPoints value with height; keep multi-snap sheets app-owned."
+      ],
       "nativePreview": true
     },
     {

--- a/packages/ui/system/src/native/sheet.spec.tsx
+++ b/packages/ui/system/src/native/sheet.spec.tsx
@@ -4,7 +4,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NativeSheet } from "./sheet";
 
 const nativeModal = vi.hoisted(() => ({
-  onRequestClose: null as (() => void) | null
+  onAccessibilityEscape: null as (() => void) | null,
+  onRequestClose: null as (() => void) | null,
+  panelStyle: null as unknown
 }));
 
 vi.mock("react-native", () => ({
@@ -21,28 +23,51 @@ vi.mock("react-native", () => ({
     return visible ? <div>{children}</div> : null;
   },
   Pressable: ({
+    accessibilityLabel,
+    accessibilityRole,
     accessible,
     children,
     onPress,
+    style,
     testID
+  }: {
+    accessibilityLabel?: string;
+    accessibilityRole?: "button";
+    accessible?: boolean;
+    children?: ReactNode;
+    onPress(): void;
+    style?: unknown;
+    testID?: string;
+  }) => {
+    if (testID === "native-sheet-panel") {
+      nativeModal.panelStyle = style;
+    }
+    return (
+      <div
+        aria-label={accessibilityLabel}
+        data-accessible={String(accessible)}
+        data-testid={testID}
+        onClick={onPress}
+        role={accessibilityRole}
+      >
+        {children}
+      </div>
+    );
+  },
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: ({
+    accessible,
+    children,
+    onAccessibilityEscape
   }: {
     accessible?: boolean;
     children: ReactNode;
-    onPress(event: { stopPropagation(): void }): void;
-    testID?: string;
-  }) => (
-    <div
-      data-accessible={String(accessible)}
-      data-testid={testID}
-      onClick={(event) =>
-        onPress({ stopPropagation: () => event.stopPropagation() })
-      }
-    >
-      {children}
-    </div>
-  ),
-  StyleSheet: { create: (styles: unknown) => styles },
-  View: ({ children }: { children: ReactNode }) => <div>{children}</div>
+    onAccessibilityEscape?(): void;
+  }) => {
+    nativeModal.onAccessibilityEscape =
+      onAccessibilityEscape ?? nativeModal.onAccessibilityEscape;
+    return <div data-accessible={String(accessible)}>{children}</div>;
+  }
 }));
 
 vi.mock("./theme-provider", () => ({
@@ -59,12 +84,18 @@ vi.mock("./theme-provider", () => ({
 
 describe("NativeSheet", () => {
   beforeEach(() => {
+    nativeModal.onAccessibilityEscape = null;
     nativeModal.onRequestClose = null;
+    nativeModal.panelStyle = null;
   });
 
   it("renders its content only while open", () => {
     const { rerender } = render(
-      <NativeSheet onOpenChange={() => undefined} open={false}>
+      <NativeSheet
+        closeAccessibilityLabel="Close sheet"
+        onOpenChange={() => undefined}
+        open={false}
+      >
         content
       </NativeSheet>
     );
@@ -72,14 +103,22 @@ describe("NativeSheet", () => {
     expect(screen.queryByText("content")).not.toBeInTheDocument();
 
     rerender(
-      <NativeSheet onOpenChange={() => undefined} open>
+      <NativeSheet
+        closeAccessibilityLabel="Close sheet"
+        onOpenChange={() => undefined}
+        open
+      >
         content
       </NativeSheet>
     );
     expect(screen.getByText("content")).toBeInTheDocument();
 
     rerender(
-      <NativeSheet onOpenChange={() => undefined} open={false}>
+      <NativeSheet
+        closeAccessibilityLabel="Close sheet"
+        onOpenChange={() => undefined}
+        open={false}
+      >
         content
       </NativeSheet>
     );
@@ -89,7 +128,11 @@ describe("NativeSheet", () => {
   it("reports backdrop and system dismissals to the controlled owner", () => {
     const onOpenChange = vi.fn();
     const { container } = render(
-      <NativeSheet onOpenChange={onOpenChange} open>
+      <NativeSheet
+        closeAccessibilityLabel="Close sheet"
+        onOpenChange={onOpenChange}
+        open
+      >
         content
       </NativeSheet>
     );
@@ -101,11 +144,36 @@ describe("NativeSheet", () => {
     fireEvent.click(screen.getByText("content"));
     expect(onOpenChange).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByTestId("native-sheet-backdrop"));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Close sheet"
+      })
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    onOpenChange.mockClear();
+    nativeModal.onAccessibilityEscape?.();
     expect(onOpenChange).toHaveBeenCalledWith(false);
 
     onOpenChange.mockClear();
     nativeModal.onRequestClose?.();
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("applies one explicit fixed height", () => {
+    render(
+      <NativeSheet
+        closeAccessibilityLabel="Close sheet"
+        height="50%"
+        onOpenChange={() => undefined}
+        open
+      >
+        content
+      </NativeSheet>
+    );
+
+    expect(nativeModal.panelStyle).toEqual(
+      expect.arrayContaining([{ height: "50%" }])
+    );
   });
 });

--- a/packages/ui/system/src/native/sheet.tsx
+++ b/packages/ui/system/src/native/sheet.tsx
@@ -1,17 +1,13 @@
 import type { ReactNode } from "react";
-import {
-  type DimensionValue,
-  Modal,
-  Pressable,
-  StyleSheet
-} from "react-native";
+import { Modal, Pressable, StyleSheet, View } from "react-native";
 import { useNativeTheme } from "./theme-provider";
 
 export interface NativeSheetProps {
   children: ReactNode;
+  closeAccessibilityLabel: string;
+  height?: number | `${number}%`;
   onOpenChange(open: boolean): void;
   open: boolean;
-  snapPoints?: readonly (number | `${number}%`)[];
 }
 
 /**
@@ -22,49 +18,48 @@ export interface NativeSheetProps {
  */
 export function NativeSheet({
   children,
+  closeAccessibilityLabel,
+  height,
   onOpenChange,
-  open,
-  snapPoints
+  open
 }: NativeSheetProps) {
   const theme = useNativeTheme();
   const styles = createStyles(theme);
-  const height = resolveSheetHeight(snapPoints);
+  const dismiss = () => onOpenChange(false);
 
   return (
     <Modal
       animationType="fade"
-      onRequestClose={() => onOpenChange(false)}
+      onRequestClose={dismiss}
       presentationStyle="overFullScreen"
       statusBarTranslucent
       transparent
       visible={open}
     >
-      <Pressable
+      <View
         accessible={false}
-        onPress={() => onOpenChange(false)}
+        onAccessibilityEscape={dismiss}
         style={styles.backdrop}
-        testID="native-sheet-backdrop"
       >
         <Pressable
+          accessibilityLabel={closeAccessibilityLabel}
+          accessibilityRole="button"
+          accessible
+          onPress={dismiss}
+          style={StyleSheet.absoluteFill}
+          testID="native-sheet-backdrop"
+        />
+        <Pressable
           accessible={false}
-          onPress={(event) => event.stopPropagation()}
-          style={[styles.sheet, height === null ? null : { height }]}
+          onPress={() => undefined}
+          style={[styles.sheet, height === undefined ? null : { height }]}
+          testID="native-sheet-panel"
         >
           {children}
         </Pressable>
-      </Pressable>
+      </View>
     </Modal>
   );
-}
-
-function resolveSheetHeight(
-  snapPoints: NativeSheetProps["snapPoints"]
-): DimensionValue | null {
-  if (!snapPoints) return null;
-  const first = snapPoints[0];
-  return typeof first === "number" || typeof first === "string"
-    ? (first as DimensionValue)
-    : null;
 }
 
 function createStyles(theme: ReturnType<typeof useNativeTheme>) {

--- a/packages/ui/system/ui-system.md
+++ b/packages/ui/system/ui-system.md
@@ -325,10 +325,12 @@ component implementation.
 
 `NativeSheet` uses React Native's window-level `Modal` for its controlled
 overlay and does not require a portal provider. It owns the semantic scrim,
-bottom-aligned panel, system-back dismissal, backdrop dismissal, and
-optional initial height. Keep `@gorhom/bottom-sheet` app-owned for genuinely
-complex gesture, keyboard, or multi-snap-point sheets rather than routing the
-shared compact sheet through its React 19-incompatible portal.
+bottom-aligned panel, system-back dismissal, screen-reader escape gesture,
+accessible backdrop dismissal, and optional fixed `height`. Callers must supply
+the localized `closeAccessibilityLabel`; one fixed height replaces the former
+single-value `snapPoints` usage. Keep `@gorhom/bottom-sheet` app-owned for
+genuinely complex gesture, keyboard, or multi-snap-point sheets rather than
+routing the shared compact sheet through its React 19-incompatible portal.
 
 For cross-surface stacking, use shared semantic `z-index` tokens instead of
 local magic numbers. Current global layer tokens live in


### PR DESCRIPTION
## Summary

- add a caller-localized accessible close button for compact `NativeSheet` backdrops
- handle the iOS VoiceOver accessibility escape gesture without grouping or hiding sheet controls
- replace the misleading multi-value `snapPoints` contract with one explicit optional `height`
- migrate every Mobile call site and synchronize i18n, Native Gallery, component metadata, and durable docs
- expand regression coverage for content taps, accessible close, escape, system dismissal, and fixed height

## Root cause

The React Native `Modal` migration restored the composer option sheets, but its event-only wrappers were both removed from the accessibility tree and it exposed no separate screen-reader close control. iOS VoiceOver users therefore lacked a reliable non-mutating dismissal path. The new implementation also retained an array-shaped `snapPoints` API while reading only its first value, silently promising unsupported multi-snap behavior.

## User impact

VoiceOver and TalkBack users can focus and activate a localized close button without losing access to the sheet's rows and controls. VoiceOver's two-finger escape gesture and Android system back both use the controlled dismissal path. Consumers now request one fixed height explicitly; complex multi-snap sheets remain app-owned.

## Validation

- independent pre-commit sub-agent review found no actionable code issues and confirmed all call sites and public contract surfaces were migrated
- changed-aware push-ready validation passed all 12 selected lanes twice, including Mobile tests, UI System tests, package typechecks, lint, i18n/UI boundaries, and npm package packing
- `@tutti-os/ui-system`: 17 test files / 59 tests passed
- UI System and Mobile typechecks passed
- i18n check passed for both locales
- UI metadata and boundary checks passed

## Remaining device coverage

No Android or iOS device was connected for this follow-up. The DOM-backed regression tests cannot prove native z-order or screen-reader gesture behavior, so touch backdrop/content handling, TalkBack close focus, Android system back, and VoiceOver escape remain explicit device checks.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->