### PR TITLE
feat(device-link): finalize shared release boundary

### DIFF
--- a/docs/conventions/npm-package-release.md
+++ b/docs/conventions/npm-package-release.md
@@ -126,10 +126,11 @@ package release tag sequence. Do not add package Go modules that require an
 independent release cadence unless this convention and the release automation
 are updated together.
 
-`packages/device-link` is temporarily excluded while the Personal
-Android/Desktop path is still an unreleased transport spike. Remove the
-exclusion and add its stable Go tag only after that product path validates the
-authenticated connection lifecycle and AAR consumer build.
+`packages/device-link` participates in the same stable Go module tag sequence
+after the Personal Android/Desktop path validated its authenticated connection
+lifecycle and AAR consumer build. TSH and other consumers must install its
+released cohort version; do not consume a pseudo-version or add a workspace
+replacement.
 
 ## Local Beta Releases
 

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -451,17 +451,17 @@ AAR assembly remains an explicit Android-SDK validation locally.
 The manually dispatched Mobile Internal Build workflow accepts `android`,
 `ios`, or `all`. Its Android job installs the pinned SDK/NDK versions,
 assembles the Mobile composite AAR and internal mobile APK, and uploads a
-private validation artifact; it does not publish the currently provisional
-DeviceLink module. Its iOS job runs on the pinned macOS 26 runner, assembles the
-same Mobile binding surface as an XCFramework, archives the React Native app,
-and uses the repository App Store Connect API key plus the
-`IOS_DEVELOPMENT_TEAM` repository variable for Xcode-managed cloud signing. It
-loads the Mobile Podfile's pnpm path compatibility shim before generating the
-Pods project, then ensures the device configured by the
-`IOS_TEST_DEVICE_UDID` Actions secret is
-registered before exporting a development IPA as a 14-day private validation
-artifact rather than creating a GitHub Release. Both jobs remain manual so pull
-request code does not receive mobile signing credentials automatically.
+private validation artifact. It validates the DeviceLink consumer build but
+does not publish Go module tags; the stable package release workflow owns those
+tags. Its iOS job runs on the pinned macOS 26 runner, assembles the same Mobile
+binding surface as an XCFramework, archives the React Native app, and uses the
+repository App Store Connect API key plus the `IOS_DEVELOPMENT_TEAM` repository
+variable for Xcode-managed cloud signing. It loads the Mobile Podfile's pnpm
+path compatibility shim before generating the Pods project, then ensures the
+device configured by the `IOS_TEST_DEVICE_UDID` Actions secret is registered
+before exporting a development IPA as a 14-day private validation artifact
+rather than creating a GitHub Release. Both jobs remain manual so pull request
+code does not receive mobile signing credentials automatically.
 
 Local runs resolve `golangci-lint` from `$(go env GOPATH)/bin` first and fall
 back to `PATH`. This matches the repository install command without requiring a

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -114,6 +114,7 @@ CLI behavior, CI, package assets, skills, Browser Node, and terminal input.
 
 Android app login, native bridge, secure identity, and mobile transport diagnostics.
 
+- [Android release bundling cannot resolve the JSX transform](./mobile.md#android-release-bundling-cannot-resolve-the-jsx-transform)
 - [Mobile quick prompts are missing from the plus menu](./mobile.md#mobile-quick-prompts-are-missing-from-the-plus-menu)
 - [Mobile composer model and permission controls are missing](./mobile.md#mobile-composer-model-and-permission-controls-are-missing)
 - [Mobile composer option chips do not open](./mobile.md#mobile-composer-option-chips-do-not-open)

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -1,5 +1,27 @@
 # Mobile Troubleshooting
 
+## Android release bundling cannot resolve the JSX transform
+
+- **Symptom:** `app:assembleRelease` reaches Metro bundling and fails
+  `app:createBundleReleaseJsAndAssets` with `Cannot find module
+'@babel/plugin-transform-react-jsx'`, while TypeScript, Jest, and debug
+  development may still pass.
+- **Quick checks:** Resolve `@babel/plugin-transform-react-jsx` from the
+  `apps/mobile` package, then run a production Android Metro bundle. If
+  resolution fails from the app but the plugin exists only below the React
+  Native preset in pnpm's store, the app has been relying on transitive layout.
+- **Root cause:** `react-native-css-interop` asks Babel to load the JSX
+  transform by package name but does not declare that package. pnpm's strict
+  dependency isolation therefore does not expose the preset's private copy to
+  the app-level Babel configuration.
+- **Fix:** Keep `@babel/plugin-transform-react-jsx` as an explicit
+  `apps/mobile` development dependency aligned with the locked Babel cohort.
+  Do not solve this by changing pnpm hoisting.
+- **Validation:** Resolve the plugin from `apps/mobile`, produce a
+  `--dev false` Android Metro bundle, and run the `Android Internal Build`
+  workflow through APK assembly.
+- **References:** `apps/mobile/package.json`, `apps/mobile/babel.config.js`
+
 ## Mobile quick prompts are missing from the plus menu
 
 - **Symptom:** The Desktop quick-prompt library is enabled and contains

--- a/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
+++ b/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
@@ -4,7 +4,7 @@ Status: accepted product direction; Personal direct-lane MVP in implementation
 
 ## Implementation progress (2026-07-27)
 
-The provisional `packages/device-link` core now preserves the production ICE,
+The release-enabled `packages/device-link` core now preserves the production ICE,
 QUIC, certificate-pinning, candidate filtering and privacy behavior extracted
 from TSH. It also owns the shared generation fence, authenticated link pool,
 per-peer establishment serialization, connection race, annealed path-probe
@@ -15,8 +15,10 @@ facade; the direct lane includes paired-device rendezvous, framed Agent HTTP,
 request deadlines, event streaming and foreground/background close behavior.
 Android 15 ARM64 emulator build/install/start and authenticated loopback
 integration pass. Real-account physical-device network transitions and Relay
-fallback remain acceptance work. TSH cutover to the shared manager is still
-pending, so the module is not yet a stable released cross-repository contract.
+fallback remain hardening work that does not expand the transport API. A stable
+tag still requires the authenticated lifecycle checks and reproducible Mobile
+AAR consumer build to pass at the release head. TSH cutover to the shared
+manager remains a consumer-side rollout step.
 
 The Mobile shell now uses mutually exclusive unauthenticated/authenticated DI
 children and one active workspace child. Login, pairing, DeviceLink lifecycle,
@@ -608,7 +610,8 @@ identity 进入显式 Retry。事件流 reconcile、Markdown/code、unsupported 
 - 完成前后台、睡眠唤醒、网络切换、daemon 重启和事件缺口测试。
 - 清洗指标与诊断，确认无 IP、candidate、token 和 Agent payload 泄露。
 - 根据验证结果决定 UI token 提炼和共享组件的下一批范围。
-- Personal 验收后冻结最小公开 API、启用稳定 Go tag 和可复现 AAR consumer gate。
+- 已冻结最小 transport API；每次启用稳定 Go tag 前，在 release head 重跑可复现
+  AAR consumer gate。真实网络切换和 Relay 验收作为后续 hardening，不改变该公开边界。
 - 再安排 TSH 切换上游依赖、删除复制实现并启用 VM/room workspace lane。
 
 ### M7 — iOS Simulator 功能对齐

--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -87,7 +87,10 @@ share semantics.
 
 `authenticated.ErrorPhase` distinguishes connectivity failures from
 authenticated transport failures so consumers can keep network probe caches
-free of certificate, ALPN, and QUIC-handshake failures.
+free of certificate, ALPN, QUIC-handshake, and caller-cancellation failures.
+`authenticated.FailurePhase` additionally reports the layer interrupted by a
+caller cancellation. It is reserved for callers that own a dedicated probe
+deadline and verify that exact context cause before recording a verdict.
 
 ## Mobile vertical slice
 

--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -1,16 +1,16 @@
 # DeviceLink
 
-`packages/device-link` is the provisional, transport-only DeviceLink core being
-validated first by Tutti Personal Desktop and Mobile. It owns ICE candidate
+`packages/device-link` is the release-enabled, transport-only DeviceLink core
+for Tutti Desktop, Android, and the pending TSH cutover. It owns ICE candidate
 negotiation, QUIC over the selected packet path, and mutual ephemeral
 certificate pinning. It does not own Agent, Session, Turn,
 Workspace, pairing, account, rendezvous, or Relay product policy.
 
 The initial implementation was upstreamed from TSH's production
-`core/devicelink` package. This module is intentionally excluded from stable Go
-package tags until the Personal product path proves the authenticated
-Android/Desktop lifecycle. TSH cutover is a later consumer migration, not a
-condition of this spike.
+`core/devicelink` package. It is eligible for Tutti's stable package cohort
+after the authenticated Android/Desktop lifecycle and reproducible Mobile AAR
+consumer build pass. Consumer adapters keep their product policy outside this
+module.
 
 The low-level candidate, ICE, TLS, and QUIC types remain provisional primitives.
 Product consumers use `authenticated.Participant`, which composes ICE,
@@ -84,6 +84,10 @@ is always offered first. After connection, `Link.NegotiatedProtocol` lets the
 product adapter select only the matching application framing. Compatibility
 entries are a temporary cutover tool, not a promise that old wire protocols
 share semantics.
+
+`authenticated.ErrorPhase` distinguishes connectivity failures from
+authenticated transport failures so consumers can keep network probe caches
+free of certificate, ALPN, and QUIC-handshake failures.
 
 ## Mobile vertical slice
 

--- a/packages/device-link/authenticated/connection_error_test.go
+++ b/packages/device-link/authenticated/connection_error_test.go
@@ -38,4 +38,30 @@ func TestClassifyConnectFailurePreservesCallerCancellation(t *testing.T) {
 	if _, ok := ErrorPhase(err); ok {
 		t.Fatal("caller cancellation was classified as a path or transport failure")
 	}
+	phase, ok := FailurePhase(err)
+	if !ok || phase != ConnectErrorPhaseAuthenticatedTransport {
+		t.Fatalf("FailurePhase() = %q, %v; want %q, true", phase, ok, ConnectErrorPhaseAuthenticatedTransport)
+	}
+}
+
+func TestClassifyConnectFailurePreservesCallerDeadlinePhase(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	defer cancel()
+	<-ctx.Done()
+
+	err := classifyConnectFailure(
+		ctx,
+		ConnectErrorPhaseConnectivity,
+		errors.New("late connectivity failure"),
+	)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("classifyConnectFailure() = %v; want deadline exceeded", err)
+	}
+	if _, ok := ErrorPhase(err); ok {
+		t.Fatal("caller deadline was classified as an ordinary connectivity failure")
+	}
+	phase, ok := FailurePhase(err)
+	if !ok || phase != ConnectErrorPhaseConnectivity {
+		t.Fatalf("FailurePhase() = %q, %v; want %q, true", phase, ok, ConnectErrorPhaseConnectivity)
+	}
 }

--- a/packages/device-link/authenticated/connection_error_test.go
+++ b/packages/device-link/authenticated/connection_error_test.go
@@ -1,0 +1,41 @@
+package authenticated
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestErrorPhaseFindsWrappedConnectError(t *testing.T) {
+	root := errors.New("connectivity check failed")
+	err := fmt.Errorf("establish peer: %w", &ConnectError{
+		Phase: ConnectErrorPhaseConnectivity,
+		Err:   root,
+	})
+
+	phase, ok := ErrorPhase(err)
+	if !ok || phase != ConnectErrorPhaseConnectivity {
+		t.Fatalf("ErrorPhase() = %q, %v; want %q, true", phase, ok, ConnectErrorPhaseConnectivity)
+	}
+	if !errors.Is(err, root) {
+		t.Fatal("ConnectError does not unwrap its cause")
+	}
+}
+
+func TestClassifyConnectFailurePreservesCallerCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := classifyConnectFailure(
+		ctx,
+		ConnectErrorPhaseAuthenticatedTransport,
+		errors.New("late transport failure"),
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("classifyConnectFailure() = %v; want context cancellation", err)
+	}
+	if _, ok := ErrorPhase(err); ok {
+		t.Fatal("caller cancellation was classified as a path or transport failure")
+	}
+}

--- a/packages/device-link/authenticated/link.go
+++ b/packages/device-link/authenticated/link.go
@@ -21,6 +21,48 @@ const (
 	RoleOwner  Role = "owner"
 )
 
+// ConnectErrorPhase identifies the product-neutral connection layer that
+// failed. Consumers may use it to distinguish path reachability from
+// authenticated transport failures without parsing error text.
+type ConnectErrorPhase string
+
+const (
+	ConnectErrorPhaseConnectivity           ConnectErrorPhase = "connectivity"
+	ConnectErrorPhaseAuthenticatedTransport ConnectErrorPhase = "authenticated_transport"
+)
+
+type ConnectError struct {
+	Phase ConnectErrorPhase
+	Err   error
+}
+
+func (e *ConnectError) Error() string {
+	if e == nil {
+		return "device-link connection failed"
+	}
+	if e.Err == nil {
+		return fmt.Sprintf("device-link %s connection failed", e.Phase)
+	}
+	return fmt.Sprintf("device-link %s connection failed: %v", e.Phase, e.Err)
+}
+
+func (e *ConnectError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// ErrorPhase returns the connection layer reported by Connect. Validation and
+// caller cancellation errors are intentionally unclassified.
+func ErrorPhase(err error) (ConnectErrorPhase, bool) {
+	var connectErr *ConnectError
+	if !errors.As(err, &connectErr) || connectErr == nil {
+		return "", false
+	}
+	return connectErr.Phase, true
+}
+
 type ParticipantConfig struct {
 	STUNEndpoints         []string
 	NetworkPolicy         string
@@ -296,12 +338,12 @@ func connectLink(
 		role == RoleCaller,
 	)
 	if err != nil {
-		return nil, err
+		return nil, classifyConnectFailure(ctx, ConnectErrorPhaseConnectivity, err)
 	}
 	endpoint, err := devicelink.NewQUICEndpointFromPacketConn(path)
 	if err != nil {
 		_ = path.Close()
-		return nil, err
+		return nil, classifyConnectFailure(ctx, ConnectErrorPhaseAuthenticatedTransport, err)
 	}
 
 	var session *devicelink.QUICSession
@@ -309,30 +351,39 @@ func connectLink(
 		tlsConfig, configErr := identity.ClientTLSConfigForProtocols(peer.Fingerprint, protocols)
 		if configErr != nil {
 			_ = endpoint.Close()
-			return nil, configErr
+			return nil, classifyConnectFailure(ctx, ConnectErrorPhaseAuthenticatedTransport, configErr)
 		}
 		session, err = endpoint.Dial(ctx, path.RemoteAddr(), tlsConfig)
 	} else {
 		tlsConfig, configErr := identity.ServerTLSConfigForProtocols(peer.Fingerprint, protocols)
 		if configErr != nil {
 			_ = endpoint.Close()
-			return nil, configErr
+			return nil, classifyConnectFailure(ctx, ConnectErrorPhaseAuthenticatedTransport, configErr)
 		}
 		listener, listenErr := endpoint.Listen(tlsConfig)
 		if listenErr != nil {
 			_ = endpoint.Close()
-			return nil, listenErr
+			return nil, classifyConnectFailure(ctx, ConnectErrorPhaseAuthenticatedTransport, listenErr)
 		}
 		session, err = listener.Accept(ctx)
 		_ = listener.Close()
 	}
 	if err != nil {
 		_ = endpoint.Close()
-		return nil, err
+		return nil, classifyConnectFailure(ctx, ConnectErrorPhaseAuthenticatedTransport, err)
 	}
 	return &Link{
 		agent: agent, endpoint: endpoint, session: session, scope: agent.SelectedScope(),
 	}, nil
+}
+
+func classifyConnectFailure(ctx context.Context, phase ConnectErrorPhase, err error) error {
+	if ctx != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return contextErr
+		}
+	}
+	return &ConnectError{Phase: phase, Err: err}
 }
 
 func validateDescription(description Description) error {

--- a/packages/device-link/authenticated/link.go
+++ b/packages/device-link/authenticated/link.go
@@ -34,6 +34,8 @@ const (
 type ConnectError struct {
 	Phase ConnectErrorPhase
 	Err   error
+
+	callerCanceled bool
 }
 
 func (e *ConnectError) Error() string {
@@ -56,6 +58,20 @@ func (e *ConnectError) Unwrap() error {
 // ErrorPhase returns the connection layer reported by Connect. Validation and
 // caller cancellation errors are intentionally unclassified.
 func ErrorPhase(err error) (ConnectErrorPhase, bool) {
+	var connectErr *ConnectError
+	if !errors.As(err, &connectErr) || connectErr == nil || connectErr.callerCanceled {
+		return "", false
+	}
+	return connectErr.Phase, true
+}
+
+// FailurePhase returns the connection layer in which Connect stopped,
+// including caller cancellation. Most product policy should use ErrorPhase so
+// cancellation does not become a reachability verdict. A caller that owns a
+// dedicated probe deadline may combine FailurePhase with its exact context
+// cause to classify only that deadline without classifying unrelated
+// cancellation or control-plane timeouts.
+func FailurePhase(err error) (ConnectErrorPhase, bool) {
 	var connectErr *ConnectError
 	if !errors.As(err, &connectErr) || connectErr == nil {
 		return "", false
@@ -380,7 +396,11 @@ func connectLink(
 func classifyConnectFailure(ctx context.Context, phase ConnectErrorPhase, err error) error {
 	if ctx != nil {
 		if contextErr := ctx.Err(); contextErr != nil {
-			return contextErr
+			return &ConnectError{
+				Phase:          phase,
+				Err:            contextErr,
+				callerCanceled: true,
+			}
 		}
 	}
 	return &ConnectError{Phase: phase, Err: err}

--- a/tools/scripts/publish-packages.mjs
+++ b/tools/scripts/publish-packages.mjs
@@ -13,10 +13,6 @@ import {
 } from "./package-release-version.mjs";
 import { preparePackageGoModuleReleaseTree } from "./go-module-release.mjs";
 
-// DeviceLink remains an unreleased Personal-first transport spike until the
-// Android/Desktop product path proves its authenticated lifecycle.
-const provisionalGoModuleDirectories = new Set(["packages/device-link"]);
-
 if (isExecutedAsEntryPoint()) {
   await main();
 }
@@ -268,9 +264,7 @@ async function discoverPackageGoModuleDirectories() {
 
   await collectPackageGoModuleDirectories(packagesRoot, directories);
 
-  return directories
-    .filter((directory) => !provisionalGoModuleDirectories.has(directory))
-    .sort();
+  return directories.sort();
 }
 
 async function collectPackageGoModuleDirectories(directory, directories) {

--- a/tools/scripts/publish-packages.test.mjs
+++ b/tools/scripts/publish-packages.test.mjs
@@ -60,6 +60,7 @@ test("resolveReleaseTagNames includes package Go module tags", async () => {
       "packages/agent/activity-replication/v0.0.25",
       "packages/agent/store-sqlite/canonical/v0.0.25",
       "packages/appcli/core/v0.0.25",
+      "packages/device-link/v0.0.25",
       "packages/workbench/service/v0.0.25",
       "packages/workspace/files/v0.0.25",
       "packages/workspace/issues/v0.0.25"


### PR DESCRIPTION
## Summary

- include `packages/device-link` in the stable Tutti Go module release cohort
- add release-tool coverage for the Device Link module tag
- classify connectivity versus authenticated-transport failures without error-string parsing, while preserving the interrupted phase for a caller-owned probe deadline
- document and validate the explicit Android JSX transform required by the mobile release bundle
- update the Device Link and mobile architecture documentation to record the validated release boundary

## Why

The authenticated Android/Desktop lifecycle and AAR consumer build are now validated, and TSH needs to consume the shared Device Link implementation through a released cohort version. Keeping the module excluded would force an unsupported pseudo-version, replacement, or copied implementation. TSH also owns a bounded direct-connect probe: it needs the shared facade to preserve which connection phase its exact deadline interrupted without turning ordinary cancellation into a reachability verdict. The latest main branch now carries the explicit JSX transform dependency; this PR records the durable troubleshooting path and validates that exact combined source.

## Risk

The release workflow will create one additional Go submodule tag, `packages/device-link/v<cohort>`. The module remains transport-only; account, rendezvous, Relay policy, probe policy, and product adapters are unchanged. `ErrorPhase` still excludes caller cancellation; the new `FailurePhase` is only safe when a consumer verifies the exact context cause it owns. The base branch's Babel dependency is an exact mobile dev dependency and does not add a new lockfile package artifact.

## Verification

- `node --test tools/scripts/publish-packages.test.mjs`
- `pnpm --silent release:packages:next-version` (`0.0.237`)
- PR `Go Tests` and `Go Lint` on exact head `017d24c59`
- `make -C packages/device-link android-aar`
- Android release bundle with `react-native bundle`
- [Mobile Internal Build (Android) on exact head `017d24c59`](https://github.com/tutti-os/tutti/actions/runs/30218555149)
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`
