### PR TITLE
ci(mobile): add iOS internal build

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,18 +1,29 @@
-name: Android Internal Build
+name: Mobile Internal Build
 
 on:
   workflow_dispatch:
+    inputs:
+      platform:
+        description: Mobile platform to build
+        required: true
+        type: choice
+        default: android
+        options:
+          - android
+          - ios
+          - all
 
 permissions:
   contents: read
 
 concurrency:
-  group: android-internal-build-${{ github.ref }}
+  group: mobile-internal-build-${{ inputs.platform }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build:
+  android:
     name: Build internal Android APK
+    if: inputs.platform == 'android' || inputs.platform == 'all'
     runs-on: ubuntu-latest
 
     steps:
@@ -108,5 +119,150 @@ jobs:
           path: |
             apps/mobile/android/app/build/outputs/apk/release/tutti-mobile-internal.apk
             apps/mobile/android/app/build/outputs/apk/release/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 14
+
+  ios:
+    name: Build internal iOS IPA
+    if: inputs.platform == 'ios' || inputs.platform == 'all'
+    runs-on: macos-26
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.0"
+          cache-dependency-path: |
+            go.work
+            go.work.sum
+            packages/agent/daemon/go.mod
+            packages/agent/daemon/go.sum
+            packages/device-link/go.mod
+            packages/device-link/go.sum
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Prepare App Store Connect authentication
+        shell: bash
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
+          IOS_DEVELOPMENT_TEAM: ${{ vars.IOS_DEVELOPMENT_TEAM }}
+        run: |
+          if [[ -z "${APPLE_API_ISSUER}" ||
+                -z "${APPLE_API_KEY_ID}" ||
+                -z "${APPLE_API_KEY_P8_BASE64}" ||
+                -z "${IOS_DEVELOPMENT_TEAM}" ]]; then
+            echo "Apple API key secrets and IOS_DEVELOPMENT_TEAM are required." >&2
+            exit 1
+          fi
+
+          private_key_dir="${RUNNER_TEMP}/tutti-ios-private-keys"
+          private_key_path="${private_key_dir}/AuthKey_${APPLE_API_KEY_ID}.p8"
+          mkdir -p "${private_key_dir}"
+          node -e \
+            "require('node:fs').writeFileSync(process.argv[1], Buffer.from(process.env.APPLE_API_KEY_P8_BASE64, 'base64'))" \
+            "${private_key_path}"
+          chmod 600 "${private_key_path}"
+
+          echo "APPLE_API_KEY_PATH=${private_key_path}" >> "${GITHUB_ENV}"
+          echo "IOS_DEVELOPMENT_TEAM=${IOS_DEVELOPMENT_TEAM}" >> "${GITHUB_ENV}"
+
+      - name: Build iOS framework and install pods
+        run: pnpm --filter @tutti-os/mobile ios:pods
+
+      - name: Archive iOS app
+        shell: bash
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        run: |
+          archive_path="${RUNNER_TEMP}/TuttiMobile.xcarchive"
+          xcodebuild \
+            -workspace apps/mobile/ios/TuttiMobile.xcworkspace \
+            -scheme TuttiMobile \
+            -configuration Release \
+            -destination "generic/platform=iOS" \
+            -archivePath "${archive_path}" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "${APPLE_API_KEY_PATH}" \
+            -authenticationKeyID "${APPLE_API_KEY_ID}" \
+            -authenticationKeyIssuerID "${APPLE_API_ISSUER}" \
+            DEVELOPMENT_TEAM="${IOS_DEVELOPMENT_TEAM}" \
+            CODE_SIGN_STYLE=Automatic \
+            clean archive
+
+          echo "IOS_ARCHIVE_PATH=${archive_path}" >> "${GITHUB_ENV}"
+
+      - name: Export internal IPA
+        shell: bash
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        run: |
+          export_dir="${RUNNER_TEMP}/tutti-ios-export"
+          export_options="${RUNNER_TEMP}/tutti-ios-export-options.plist"
+          artifact_dir="${RUNNER_TEMP}/tutti-ios-artifact"
+
+          plutil -create xml1 "${export_options}"
+          plutil -insert destination -string export "${export_options}"
+          plutil -insert method -string debugging "${export_options}"
+          plutil -insert signingStyle -string automatic "${export_options}"
+          plutil -insert teamID -string "${IOS_DEVELOPMENT_TEAM}" "${export_options}"
+
+          xcodebuild \
+            -exportArchive \
+            -archivePath "${IOS_ARCHIVE_PATH}" \
+            -exportPath "${export_dir}" \
+            -exportOptionsPlist "${export_options}" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "${APPLE_API_KEY_PATH}" \
+            -authenticationKeyID "${APPLE_API_KEY_ID}" \
+            -authenticationKeyIssuerID "${APPLE_API_ISSUER}"
+
+          ipa_path="$(find "${export_dir}" -maxdepth 1 -name '*.ipa' -print -quit)"
+          test -n "${ipa_path}"
+          mkdir -p "${artifact_dir}"
+          cp "${ipa_path}" "${artifact_dir}/tutti-mobile-internal.ipa"
+
+      - name: Verify internal IPA
+        shell: bash
+        run: |
+          artifact_dir="${RUNNER_TEMP}/tutti-ios-artifact"
+          verification_dir="${RUNNER_TEMP}/tutti-ios-verification"
+          mkdir -p "${verification_dir}"
+          unzip -q "${artifact_dir}/tutti-mobile-internal.ipa" -d "${verification_dir}"
+          app_path="$(find "${verification_dir}/Payload" -maxdepth 1 -name '*.app' -print -quit)"
+          test -n "${app_path}"
+          test -f "${app_path}/embedded.mobileprovision"
+          codesign --verify --deep --strict "${app_path}"
+          (
+            cd "${artifact_dir}"
+            shasum -a 256 tutti-mobile-internal.ipa > SHA256SUMS
+          )
+
+      - name: Upload internal iOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tutti-mobile-ios-internal-${{ github.sha }}
+          path: |
+            ${{ runner.temp }}/tutti-ios-artifact/tutti-mobile-internal.ipa
+            ${{ runner.temp }}/tutti-ios-artifact/SHA256SUMS
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -187,6 +187,139 @@ jobs:
       - name: Build iOS framework and install pods
         run: pnpm --filter @tutti-os/mobile ios:pods
 
+      - name: Register internal iOS device
+        shell: bash
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          IOS_TEST_DEVICE_UDID: ${{ secrets.IOS_TEST_DEVICE_UDID }}
+        run: |
+          if [[ -z "${IOS_TEST_DEVICE_UDID}" ]]; then
+            echo "IOS_TEST_DEVICE_UDID is required for development signing." >&2
+            exit 1
+          fi
+
+          node <<'NODE'
+          const crypto = require("node:crypto");
+          const fs = require("node:fs");
+
+          function encode(value) {
+            return Buffer.from(value).toString("base64url");
+          }
+
+          function createToken() {
+            const issuedAt = Math.floor(Date.now() / 1000);
+            const header = encode(
+              JSON.stringify({
+                alg: "ES256",
+                kid: process.env.APPLE_API_KEY_ID,
+                typ: "JWT",
+              }),
+            );
+            const payload = encode(
+              JSON.stringify({
+                aud: "appstoreconnect-v1",
+                exp: issuedAt + 600,
+                iat: issuedAt - 30,
+                iss: process.env.APPLE_API_ISSUER,
+              }),
+            );
+            const signingInput = `${header}.${payload}`;
+            const key = fs.readFileSync(process.env.APPLE_API_KEY_PATH, "utf8");
+            const signature = crypto.sign(
+              "sha256",
+              Buffer.from(signingInput),
+              {
+                dsaEncoding: "ieee-p1363",
+                key,
+              },
+            );
+            return `${signingInput}.${signature.toString("base64url")}`;
+          }
+
+          async function request(path, options = {}) {
+            const response = await fetch(
+              `https://api.appstoreconnect.apple.com${path}`,
+              {
+                ...options,
+                headers: {
+                  Authorization: `Bearer ${createToken()}`,
+                  "Content-Type": "application/json",
+                  ...options.headers,
+                },
+              },
+            );
+            if (!response.ok) {
+              const error = new Error(
+                `Apple Developer API request failed with HTTP ${response.status}`,
+              );
+              error.status = response.status;
+              throw error;
+            }
+            return response.json();
+          }
+
+          async function findDevice(udid) {
+            const query = new URLSearchParams({
+              "filter[udid]": udid,
+              limit: "1",
+            });
+            const existing = await request(`/v1/devices?${query}`);
+            return existing.data[0];
+          }
+
+          function assertEnabled(device) {
+            if (device.attributes.status !== "ENABLED") {
+              throw new Error(
+                "The configured internal iOS device is disabled in Apple Developer",
+              );
+            }
+          }
+
+          async function main() {
+            const udid = process.env.IOS_TEST_DEVICE_UDID;
+            const device = await findDevice(udid);
+            if (device) {
+              assertEnabled(device);
+              console.log("Internal iOS device is already registered");
+              return;
+            }
+
+            try {
+              await request("/v1/devices", {
+                body: JSON.stringify({
+                  data: {
+                    attributes: {
+                      name: "Tutti Internal iPhone",
+                      platform: "IOS",
+                      udid,
+                    },
+                    type: "devices",
+                  },
+                }),
+                method: "POST",
+              });
+            } catch (error) {
+              if (error.status !== 409) {
+                throw error;
+              }
+              const concurrentDevice = await findDevice(udid);
+              if (!concurrentDevice) {
+                throw error;
+              }
+              assertEnabled(concurrentDevice);
+              console.log("Internal iOS device was registered concurrently");
+              return;
+            }
+            console.log("Registered internal iOS device");
+          }
+
+          main().catch((error) => {
+            console.error(error.message);
+            process.exitCode = 1;
+          });
+          NODE
+
       - name: Archive iOS app
         shell: bash
         env:

--- a/apps/mobile/ios/Podfile
+++ b/apps/mobile/ios/Podfile
@@ -4,6 +4,7 @@ require Pod::Executable.execute_command('node', ['-p',
     "react-native/scripts/react_native_pods.rb",
     {paths: [process.argv[1]]},
   )', __dir__]).strip
+require_relative './cocoapods_pathname_workaround'
 
 platform :ios, min_ios_version_supported
 prepare_react_native_project!

--- a/apps/mobile/ios/cocoapods_pathname_workaround.rb
+++ b/apps/mobile/ios/cocoapods_pathname_workaround.rb
@@ -1,0 +1,46 @@
+# CocoaPods intermittently fails while resolving pnpm-backed local Pod paths
+# with `ArgumentError: pathname contains null byte`. Preserve CocoaPods'
+# filesystem-group behavior without resolving those symlinks through
+# Pathname#realdirpath.
+module CocoaPodsPathnameWorkaround
+  def group_for_path_in_group(
+    absolute_pathname,
+    group,
+    reflect_file_system_structure,
+    base_path = nil
+  )
+    unless absolute_pathname.absolute?
+      raise ArgumentError, "Paths must be absolute #{absolute_pathname}"
+    end
+    unless base_path.nil? || base_path.absolute?
+      raise ArgumentError, "Paths must be absolute #{base_path}"
+    end
+
+    relative_base = base_path.nil? ? group.real_path : base_path.cleanpath
+    relative_pathname = absolute_pathname.relative_path_from(relative_base)
+    relative_dir = relative_pathname.dirname
+
+    if reflect_file_system_structure
+      path = relative_base
+      relative_dir.each_filename do |name|
+        break if name.to_s.downcase.include? '.lproj'
+        next if name == '.'
+
+        path += name
+        group = group.children.find { |child| child.display_name == name } ||
+                group.new_group(name, path)
+      end
+    end
+
+    if relative_dir.basename.to_s.downcase.include? '.lproj'
+      group_name = variant_group_name(absolute_pathname)
+      lproj_parent_dir = absolute_pathname.dirname.dirname
+      group = @variant_groups_by_path_and_name[[lproj_parent_dir, group_name]] ||=
+                group.new_variant_group(group_name, lproj_parent_dir)
+    end
+
+    group
+  end
+end
+
+Pod::Project.prepend(CocoaPodsPathnameWorkaround)

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.29.0",
+    "@babel/plugin-transform-react-jsx": "7.29.7",
     "@babel/preset-env": "7.29.0",
     "@babel/runtime": "7.29.2",
     "@react-native-community/cli": "20.1.0",

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -456,7 +456,9 @@ DeviceLink module. Its iOS job runs on the pinned macOS 26 runner, assembles the
 same Mobile binding surface as an XCFramework, archives the React Native app,
 and uses the repository App Store Connect API key plus the
 `IOS_DEVELOPMENT_TEAM` repository variable for Xcode-managed cloud signing. It
-ensures the device configured by the `IOS_TEST_DEVICE_UDID` Actions secret is
+loads the Mobile Podfile's pnpm path compatibility shim before generating the
+Pods project, then ensures the device configured by the
+`IOS_TEST_DEVICE_UDID` Actions secret is
 registered before exporting a development IPA as a 14-day private validation
 artifact rather than creating a GitHub Release. Both jobs remain manual so pull
 request code does not receive mobile signing credentials automatically.

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -456,9 +456,10 @@ DeviceLink module. Its iOS job runs on the pinned macOS 26 runner, assembles the
 same Mobile binding surface as an XCFramework, archives the React Native app,
 and uses the repository App Store Connect API key plus the
 `IOS_DEVELOPMENT_TEAM` repository variable for Xcode-managed cloud signing. It
-exports a development IPA as a 14-day private validation artifact rather
-than creating a GitHub Release. Both jobs remain manual so pull request code
-does not receive mobile signing credentials automatically.
+ensures the device configured by the `IOS_TEST_DEVICE_UDID` Actions secret is
+registered before exporting a development IPA as a 14-day private validation
+artifact rather than creating a GitHub Release. Both jobs remain manual so pull
+request code does not receive mobile signing credentials automatically.
 
 Local runs resolve `golangci-lint` from `$(go env GOPATH)/bin` first and fall
 back to `PATH`. This matches the repository install command without requiring a

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -448,10 +448,17 @@ the DeviceLink and live Subscriber headers and expected exported symbols. This
 binding check needs the repository Go toolchain and macOS Command Line Tools,
 but not the full iOS SDK; building the XCFramework still requires full Xcode.
 AAR assembly remains an explicit Android-SDK validation locally.
-The manually dispatched Android Internal Build workflow installs the pinned
-SDK/NDK versions, assembles the Mobile composite AAR and internal mobile APK,
-and uploads a private validation artifact; it does not publish the currently
-provisional DeviceLink module.
+The manually dispatched Mobile Internal Build workflow accepts `android`,
+`ios`, or `all`. Its Android job installs the pinned SDK/NDK versions,
+assembles the Mobile composite AAR and internal mobile APK, and uploads a
+private validation artifact; it does not publish the currently provisional
+DeviceLink module. Its iOS job runs on the pinned macOS 26 runner, assembles the
+same Mobile binding surface as an XCFramework, archives the React Native app,
+and uses the repository App Store Connect API key plus the
+`IOS_DEVELOPMENT_TEAM` repository variable for Xcode-managed cloud signing. It
+exports a development IPA as a 14-day private validation artifact rather
+than creating a GitHub Release. Both jobs remain manual so pull request code
+does not receive mobile signing credentials automatically.
 
 Local runs resolve `golangci-lint` from `$(go env GOPATH)/bin` first and fall
 back to `PATH`. This matches the repository install command without requiring a

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -119,6 +119,7 @@ Android app login, native bridge, secure identity, and mobile transport diagnost
 - [Mobile composer option chips do not open](./mobile.md#mobile-composer-option-chips-do-not-open)
 - [Browser login returns to the App but remains signed out](./mobile.md#browser-login-returns-to-the-app-but-remains-signed-out)
 - [Android DeviceLink opens a session and then repeatedly restarts](./mobile.md#android-devicelink-opens-a-session-and-then-repeatedly-restarts)
+- [iOS pod install intermittently reports pathname contains null byte](./mobile.md#ios-pod-install-intermittently-reports-pathname-contains-null-byte)
 - [React Native Pressable rows stack their children vertically](./mobile.md#react-native-pressable-rows-stack-their-children-vertically)
 
 ## [Computer Use](./computer-use.md)

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -147,6 +147,30 @@ dev.tutti.mobile` and inspect a narrow logcat window for the Go fatal message.
 - **References:** `packages/device-link/mobile/link.go`,
   `apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt`
 
+## iOS pod install intermittently reports pathname contains null byte
+
+- **Symptom:** `pnpm --filter @tutti-os/mobile ios:pods` downloads and installs
+  every Pod, then fails during `Generating Pods project` with
+  `ArgumentError: pathname contains null byte` from
+  `Pod::Project#group_for_path_in_group`. Re-running may succeed.
+- **Quick checks:** Confirm the stack ends in `Pathname#realdirpath` and the
+  workspace uses pnpm-linked React Native packages. CocoaPods version changes or
+  deleting `Pods/` may change the frequency but do not identify a durable fix.
+- **Root cause:** CocoaPods preserves the filesystem layout for local Pods and
+  resolves their common base path through `realdirpath`. That resolution is
+  intermittently unsafe for pnpm-backed local Pod symlinks while the Pods
+  project is generated.
+- **Fix:** Keep `apps/mobile/ios/cocoapods_pathname_workaround.rb` loaded from
+  the Podfile. It retains CocoaPods' group-building behavior but normalizes the
+  local Pod base with `cleanpath` instead of resolving the pnpm symlink through
+  `realdirpath`. Do not depend on retries or a CocoaPods downgrade.
+- **Validation:** Run `ios:pods` from a clean checkout, confirm the Pods project
+  is generated, then archive the `TuttiMobile` workspace on the GitHub macOS 26
+  runner to exercise the same pnpm and CocoaPods path.
+- **References:** `apps/mobile/ios/Podfile`,
+  `apps/mobile/ios/cocoapods_pathname_workaround.rb`,
+  [CocoaPods #12798](https://github.com/CocoaPods/CocoaPods/issues/12798)
+
 ## React Native Pressable rows stack their children vertically
 
 - **Symptom:** A Native button, list row, or app-owned tappable row declares

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -280,10 +280,18 @@ screen composition and product-specific interaction.
   generic allow/deny commands.
 
 需要在没有本机开发环境的真机上测试时，可从 GitHub Actions 手动运行
-`Android Internal Build`。它只上传保留 14 天的内部 artifact
+`Mobile Internal Build` 并选择 `android`。它只上传保留 14 天的内部 artifact
 `tutti-mobile-internal-<commit>`，其中的 `tutti-mobile-internal.apk` 已嵌入
 JavaScript bundle，可直接侧载；不会创建 GitHub Release 或公开下载链接。每次
 运行使用新的临时签名 key，安装新构建前可能需要先卸载手机上的旧内部构建。
+
+在 iOS 真机上测试时，运行同一工作流并选择 `ios`。它使用仓库已有的 App Store
+Connect API Key 和 `IOS_DEVELOPMENT_TEAM` 仓库变量，让 Xcode 自动管理云签名并
+导出 development IPA。工作流上传保留 14 天的内部 artifact
+`tutti-mobile-ios-internal-<commit>`，其中包含 `tutti-mobile-internal.ipa` 和
+SHA-256 校验文件；不会创建 GitHub Release 或公开下载链接。IPA 只能安装到 Apple
+Developer 后台已登记且包含在自动生成描述文件中的设备。选择 `all` 可同时构建
+两个平台。
 
 ## 6. 调试时先判断问题属于哪一层
 

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -78,7 +78,8 @@ ICE/QUIC 问题进入 Go。
 - **Xcode project/workspace**：`TuttiMobile.xcodeproj` 是源码工程；执行 CocoaPods
   后生成的 `TuttiMobile.xcworkspace` 是日常构建入口。
 - **CocoaPods**：React Native iOS 原生依赖管理器。Pods 和 workspace 是本机构建
-  产物，不提交仓库。
+  产物，不提交仓库。Podfile 会加载仓库内的 pnpm 路径兼容处理，避免 CocoaPods
+  解析本地 Pod 符号链接时偶发 `pathname contains null byte`。
 - **XCFramework**：同时封装 iOS device arm64 与 iOS Simulator 架构的 Apple
   framework。本项目用 gomobile 生成 `TuttiMobileGo.xcframework`。
 - **Keychain / CryptoKit**：iOS 设备身份、Ed25519 私钥和账号 session 的安全存储
@@ -203,7 +204,9 @@ pnpm --filter @tutti-os/mobile ios:pods
 `apps/mobile/ios/Frameworks/TuttiMobileGo.xcframework`；`ios:pods` 随后生成
 忽略的 `Pods/` 和 `TuttiMobile.xcworkspace`。iOS build 仍保持 DeviceLink
 transport、Agent live Subscriber 和产品 adapter 的现有所有权，不把 framing 或
-账号策略移入共享 transport。
+账号策略移入共享 transport。不要移除 Podfile 加载的
+`cocoapods_pathname_workaround.rb`；GitHub macOS runner 和本机 pnpm workspace
+都可能在 CocoaPods 生成工程时触发该符号链接解析缺陷。
 
 ## 5. 正式 App 的日常开发循环
 

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -287,11 +287,12 @@ JavaScript bundle，可直接侧载；不会创建 GitHub Release 或公开下�
 
 在 iOS 真机上测试时，运行同一工作流并选择 `ios`。它使用仓库已有的 App Store
 Connect API Key 和 `IOS_DEVELOPMENT_TEAM` 仓库变量，让 Xcode 自动管理云签名并
-导出 development IPA。工作流上传保留 14 天的内部 artifact
+使用 `IOS_TEST_DEVICE_UDID` secret 幂等登记内部测试设备，再导出 development
+IPA。工作流上传保留 14 天的内部 artifact
 `tutti-mobile-ios-internal-<commit>`，其中包含 `tutti-mobile-internal.ipa` 和
 SHA-256 校验文件；不会创建 GitHub Release 或公开下载链接。IPA 只能安装到 Apple
-Developer 后台已登记且包含在自动生成描述文件中的设备。选择 `all` 可同时构建
-两个平台。
+Developer 后台由该 secret 配置并包含在自动生成描述文件中的设备。选择 `all` 可
+同时构建两个平台。
 
 ## 6. 调试时先判断问题属于哪一层
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,6 +265,9 @@ importers:
       "@babel/core":
         specifier: 7.29.0
         version: 7.29.0
+      "@babel/plugin-transform-react-jsx":
+        specifier: 7.29.7
+        version: 7.29.7(@babel/core@7.29.0)
       "@babel/preset-env":
         specifier: 7.29.0
         version: 7.29.0(@babel/core@7.29.0)


### PR DESCRIPTION
## Summary

- extend the existing manual mobile build workflow with `android`, `ios`, and `all` platform choices
- build the Go XCFramework, archive the React Native Release app, and export a development-signed IPA through Xcode-managed cloud signing
- upload the IPA and SHA-256 checksum as a private 14-day artifact
- declare the Babel JSX transform dependency required by clean Release bundling
- document the internal Android/iOS artifact workflow and signing boundary

## Why

Android already had a manual internal APK path, while iOS required a local Xcode environment. The shared workflow now provides an equivalent private iOS artifact without publishing a GitHub Release.

The signing job remains manual. Pull request code does not automatically receive the repository Apple credentials.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check:changed` (6 lanes)
- pre-commit hooks
- pre-push `pnpm check:changed -- --push-ready` (7 lanes)
- local Xcode 26.6: Go XCFramework generation and CocoaPods installation
- local Xcode 26.6: Release archive with embedded JavaScript/Hermes bundle
- local Xcode 26.6: development IPA export, embedded provisioning profile check, strict code-sign verification, and SHA-256 generation
- independent pre-commit sub-agent review; its credential-exposure finding was addressed by keeping both signing jobs manual

- GitHub Actions iOS build [#30217994598](https://github.com/tutti-os/tutti/actions/runs/30217994598) completed successfully on `macos-26`: XCFramework, Pods generation, device registration, cloud-signed archive, IPA export, embedded profile and code-sign verification, checksum, and artifact upload
- downloaded artifact `tutti-mobile-ios-internal-a5633477e34d816882d6ecef85eab072705e86a7` and re-verified `SHA256SUMS` locally
- independent follow-up sub-agent review confirmed the CocoaPods pnpm-path workaround preserves CocoaPods 1.17 semantics except for the targeted `realdirpath` to `cleanpath` substitution
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->