### PR TITLE
perf(agent-gui): reduce background window rendering work

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.spec.tsx
@@ -8,7 +8,7 @@ afterEach(() => {
 });
 
 describe("useComposerLayout", () => {
-  it("rotates prompt tips only while the AgentGUI window is active", () => {
+  it("runs hero composer animations only while the AgentGUI window is active", () => {
     const promptTips = [
       { id: "tip-1", label: "First", prompt: "Prompt one" },
       { id: "tip-2", label: "Second", prompt: "Prompt two" }
@@ -27,6 +27,7 @@ describe("useComposerLayout", () => {
 
     expect(result.current.rotatingPromptTips).toEqual([promptTips[0]]);
     expect(result.current.promptTipStyle).toBeUndefined();
+    expect(result.current.showEdgeGlow).toBe(false);
 
     rerender({ isActive: true });
 
@@ -38,6 +39,7 @@ describe("useComposerLayout", () => {
       "--agent-gui-prompt-tip-count": 2,
       "--agent-gui-prompt-tip-cycle-duration": "10400ms"
     });
+    expect(result.current.showEdgeGlow).toBe(true);
   });
 
   it("does not probe a locked project while its session is still being created", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerLayout.ts
@@ -92,7 +92,7 @@ export function useComposerLayout({
 }: UseComposerLayoutInput) {
   const composerMeasurementFrameRef = useRef<number | null>(null);
   const labels = { promptTipsPrefix };
-  const showEdgeGlow = isHeroLayout && !inputDisabled;
+  const showEdgeGlow = isActive && isHeroLayout && !inputDisabled;
   const showPromptTips = isHeroLayout && promptTips.length > 0;
   const activePromptTip = showPromptTips ? (promptTips[0] ?? null) : null;
   const showHeroProjectSelector = isHeroLayout;

--- a/packages/workbench/surface/src/core/visualOcclusion.test.ts
+++ b/packages/workbench/surface/src/core/visualOcclusion.test.ts
@@ -63,6 +63,60 @@ test("clips visibility to the Workbench surface and ignores minimized covers", (
   );
 });
 
+test("reuses exposure when only non-geometric Workbench state changes", () => {
+  const state = workbenchState([
+    node("covered", frame(0, 0)),
+    node("cover", frame(0, 0))
+  ]);
+  const exposed = selectVisuallyExposedWorkbenchNodeIDs(state);
+
+  const nextState = {
+    ...state,
+    activeDragNodeId: "cover",
+    activeSnapTarget: "left" as const
+  };
+
+  assert.strictEqual(selectVisuallyExposedWorkbenchNodeIDs(nextState), exposed);
+});
+
+test("reuses exposure across data-only node replacements", () => {
+  const state = workbenchState([
+    node("covered", frame(0, 0)),
+    node("cover", frame(0, 0))
+  ]);
+  const exposed = selectVisuallyExposedWorkbenchNodeIDs(state);
+
+  const nextState = {
+    ...state,
+    nodes: state.nodes.map((candidate) => ({
+      ...candidate,
+      data: { revision: 1 }
+    }))
+  };
+
+  assert.strictEqual(selectVisuallyExposedWorkbenchNodeIDs(nextState), exposed);
+});
+
+test("invalidates exposure when node geometry changes", () => {
+  const state = workbenchState([
+    node("covered", frame(0, 0)),
+    node("cover", frame(0, 0))
+  ]);
+  const exposed = selectVisuallyExposedWorkbenchNodeIDs(state);
+  const nextState = {
+    ...state,
+    nodes: state.nodes.map((candidate) =>
+      candidate.id === "cover"
+        ? { ...candidate, frame: frame(300, 0) }
+        : candidate
+    )
+  };
+  const nextExposed = selectVisuallyExposedWorkbenchNodeIDs(nextState);
+
+  assert.notStrictEqual(nextExposed, exposed);
+  assert.equal(nextExposed.has("covered"), true);
+});
+
 function workbenchState(nodes: WorkbenchNode[]): WorkbenchState {
   return {
     activeDragNodeId: null,

--- a/packages/workbench/surface/src/core/visualOcclusion.ts
+++ b/packages/workbench/surface/src/core/visualOcclusion.ts
@@ -1,13 +1,31 @@
 import type { WorkbenchFrame, WorkbenchState } from "./types.ts";
 
 const exposedNodeIDsByState = new WeakMap<object, ReadonlySet<string>>();
+const exposedNodeIDsByNodeStack = new WeakMap<
+  object,
+  {
+    exposedNodeIDs: ReadonlySet<string>;
+    nodes: WorkbenchState<unknown>["nodes"];
+    surfaceSize: WorkbenchState<unknown>["surfaceSize"];
+  }
+>();
 
 export function selectVisuallyExposedWorkbenchNodeIDs<TData>(
   state: WorkbenchState<TData>
 ): ReadonlySet<string> {
-  const cached = exposedNodeIDsByState.get(state);
-  if (cached) {
-    return cached;
+  const cachedByState = exposedNodeIDsByState.get(state);
+  if (cachedByState) {
+    return cachedByState;
+  }
+  const cachedByGeometry = exposedNodeIDsByNodeStack.get(state.nodeStack);
+  if (
+    cachedByGeometry &&
+    hasEquivalentVisualOcclusionGeometry(cachedByGeometry, state)
+  ) {
+    cachedByGeometry.nodes = state.nodes;
+    cachedByGeometry.surfaceSize = state.surfaceSize;
+    exposedNodeIDsByState.set(state, cachedByGeometry.exposedNodeIDs);
+    return cachedByGeometry.exposedNodeIDs;
   }
 
   const nodeByID = new Map(state.nodes.map((node) => [node.id, node]));
@@ -56,6 +74,11 @@ export function selectVisuallyExposedWorkbenchNodeIDs<TData>(
   });
 
   exposedNodeIDsByState.set(state, exposedNodeIDs);
+  exposedNodeIDsByNodeStack.set(state.nodeStack, {
+    exposedNodeIDs,
+    nodes: state.nodes,
+    surfaceSize: state.surfaceSize
+  });
   return exposedNodeIDs;
 }
 
@@ -137,4 +160,35 @@ function pushFrame(frames: WorkbenchFrame[], frame: WorkbenchFrame): void {
   if (frame.width > 0 && frame.height > 0) {
     frames.push(frame);
   }
+}
+
+function hasEquivalentVisualOcclusionGeometry<TData>(
+  cached: {
+    nodes: WorkbenchState<unknown>["nodes"];
+    surfaceSize: WorkbenchState<unknown>["surfaceSize"];
+  },
+  state: WorkbenchState<TData>
+): boolean {
+  if (
+    cached.surfaceSize.width !== state.surfaceSize.width ||
+    cached.surfaceSize.height !== state.surfaceSize.height ||
+    cached.nodes.length !== state.nodes.length
+  ) {
+    return false;
+  }
+  if (cached.nodes === state.nodes) {
+    return true;
+  }
+  return cached.nodes.every((cachedNode, index) => {
+    const node = state.nodes[index];
+    return (
+      node !== undefined &&
+      cachedNode.id === node.id &&
+      cachedNode.isMinimized === node.isMinimized &&
+      cachedNode.frame.x === node.frame.x &&
+      cachedNode.frame.y === node.frame.y &&
+      cachedNode.frame.width === node.frame.width &&
+      cachedNode.frame.height === node.frame.height
+    );
+  });
 }


### PR DESCRIPTION
## Summary
- stop inactive hero-composer glow and reuse Workbench occlusion results across non-geometric state updates
- disconnect timeline/dock observers and scroll listeners while an AgentGUI is fully occluded, then resynchronize bottom lock on exposure
- share renderer second/minute clocks across Turn, compaction, subagent, Goal, and Rail consumers; hidden AgentGUI elapsed consumers unsubscribe
- document the geometric visibility boundary and lock lower AgentGUI effect/timer ratchet values

## Tests
- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 shared/agentConversation/components/AgentConversationClock.spec.tsx shared/agentConversation/components/AgentTurnWorkSection.spec.tsx shared/agentConversation/components/AgentSubAgentCards.spec.tsx agent-gui/agentGuiNode/AgentGoalBanner.spec.tsx agent-gui/agentGuiNode/view/AgentGUIConversationRailClock.spec.tsx agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:agent-gui-degradation`
- `pnpm check:changed -- --push-ready`

## Notes
- Direct regression tests prove hidden streaming rerenders perform zero timeline geometry reads/writes and that elapsed consumers share one 1 Hz interval which stops when no visible consumer remains.
- The earlier 50-window capture passed 10/11 assertions; its unrelated CSS animation-iteration budget reported 24 iterations against a limit of 20. No comparable post-change Electron trace was captured.