### PR TITLE
perf(agent-gui): pause occluded presentation work

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -20,7 +20,7 @@ import { registerWorkspaceAgentGuiOpenSession } from "../../workspace-workbench/
 import {
   selectWorkbenchNodeIsVisuallyExposed,
   useWorkbenchSelector,
-  useWorkbenchNonOccludingNodeIDs,
+  useWorkbenchVisualOcclusionPresentation,
   workbenchFocusInputActivationType
 } from "@tutti-os/workbench-surface";
 import { useTranslation } from "@renderer/i18n";
@@ -706,12 +706,12 @@ function DesktopAgentGUIWorkbenchBodyAdapter({
   context,
   ...props
 }: DesktopAgentGUIWorkbenchBodyProps): JSX.Element {
-  const nonOccludingNodeIDs = useWorkbenchNonOccludingNodeIDs();
+  const visualOcclusionPresentation = useWorkbenchVisualOcclusionPresentation();
   const isVisuallyExposed = useWorkbenchSelector((state) =>
     selectWorkbenchNodeIsVisuallyExposed(
       state,
       context.node.id,
-      nonOccludingNodeIDs
+      visualOcclusionPresentation
     )
   );
   const isBodyVisible = context.isVisible && isVisuallyExposed;

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -20,6 +20,7 @@ import { registerWorkspaceAgentGuiOpenSession } from "../../workspace-workbench/
 import {
   selectWorkbenchNodeIsVisuallyExposed,
   useWorkbenchSelector,
+  useWorkbenchNonOccludingNodeIDs,
   workbenchFocusInputActivationType
 } from "@tutti-os/workbench-surface";
 import { useTranslation } from "@renderer/i18n";
@@ -705,8 +706,13 @@ function DesktopAgentGUIWorkbenchBodyAdapter({
   context,
   ...props
 }: DesktopAgentGUIWorkbenchBodyProps): JSX.Element {
+  const nonOccludingNodeIDs = useWorkbenchNonOccludingNodeIDs();
   const isVisuallyExposed = useWorkbenchSelector((state) =>
-    selectWorkbenchNodeIsVisuallyExposed(state, context.node.id)
+    selectWorkbenchNodeIsVisuallyExposed(
+      state,
+      context.node.id,
+      nonOccludingNodeIDs
+    )
   );
   const isBodyVisible = context.isVisible && isVisuallyExposed;
   const [bodyHydrated, setBodyHydrated] = useState(

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -950,6 +950,11 @@ While Genie replaces a real node with Canvas output, or scale minimize marks
 the node as pending, Workbench excludes that departing node from geometric
 occlusion. Covered windows therefore resume presentation during minimize; a
 restoring Genie node stays non-occluding until its real node is revealed.
+Scale restore, shell frame transitions, and onboarding entry keep the moving
+node's own presentation visible while temporarily excluding it as an occluder;
+DOM transition and animation completion release that state. Portal-backed
+`dialog-popover` nodes sort above default-layer nodes before Workbench applies
+normal stack order.
 Only fully occluded bodies pause descendant animations and use
 `content-visibility: hidden`. Visible Empty-Hero surfaces may own carousel
 images, alignment observers, wheel input, and a Three.js/WebGL scene.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -951,7 +951,14 @@ Only fully occluded bodies pause descendant animations and use
 images, alignment observers, wheel input, and a Three.js/WebGL scene.
 Occlusion releases those resources; exposure restores the DOM presentation
 immediately and defers WebGL reconstruction until after the reveal interaction
-settles.
+settles. Detail timelines follow the same geometric boundary: fully occluded
+surfaces disconnect dock/timeline resize observation and scroll listeners,
+while exposure reattaches them and resynchronizes the retained bottom lock.
+Elapsed Turn, compaction, subagent, and Goal labels subscribe to one shared
+renderer-realm second clock only while their containing presentation is
+visible; exposure catches the displayed value up from canonical timestamps.
+Focus alone must not stop either behavior because multiple exposed AgentGUI
+windows remain live at the same time.
 On workspace restore, Desktop mounts the focused AgentGUI body immediately and
 hydrates inactive bodies sequentially after browser idle, one animation frame
 at a time. Window shells and persisted geometry remain synchronous; this

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -946,6 +946,10 @@ its appearance transition. Background Workbench AgentGUI bodies remain mounted
 so drafts and local conversation presentation survive focus changes. Focus does
 not determine visibility. Workbench frame geometry and z-order classify bodies
 as fully occluded or visually exposed; partial exposure counts as visible.
+While Genie replaces a real node with Canvas output, or scale minimize marks
+the node as pending, Workbench excludes that departing node from geometric
+occlusion. Covered windows therefore resume presentation during minimize; a
+restoring Genie node stays non-occluding until its real node is revealed.
 Only fully occluded bodies pause descendant animations and use
 `content-visibility: hidden`. Visible Empty-Hero surfaces may own carousel
 images, alignment observers, wheel input, and a Three.js/WebGL scene.

--- a/docs/conventions/workbench.md
+++ b/docs/conventions/workbench.md
@@ -67,6 +67,13 @@ Rules:
 - project normal-window visibility through the mounted body context; it is
   false while minimized, Genie-hidden, or in Mission Control, so heavy child
   presentation can wait without importing Workbench animation state
+- separate a node's own exposure from whether it may occlude lower nodes.
+  Scale restore, shell frame transitions, and onboarding entry keep their own
+  body visible but do not cover lower bodies until the matching DOM animation
+  or transition settles; overlapping transitions release independently
+- order geometric occlusion by rendered surface layer before normal window
+  stack order. A `dialog-popover` node remains above default-layer nodes even
+  when the normal focus stack changes
 - keep window chrome hit zones unambiguous; floating-window resize handles
   should render outside the clipped window surface so corner handles remain
   reachable and take precedence over header drag regions; interactive controls

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -14,6 +14,7 @@ import {
   AgentTargetPresentationProvider,
   type AgentMessageMarkdownAgentTarget
 } from "../../shared/AgentTargetPresentationContext";
+import { AgentConversationClockProvider } from "../../shared/agentConversation/components/AgentConversationClock";
 import type { AgentGUINodeViewModel } from "./model/agentGuiNodeTypes";
 import {
   agentTargetPresentationKey,
@@ -673,48 +674,52 @@ export function AgentGUINodeView({
             onPointerUp={endConversationRailResize}
           />
           <section id="agent-gui-detail" className={styles.detailPanel}>
-            <AgentGUIDetailPane
-              shell={viewModel.shell}
-              rail={viewModel.rail}
-              detail={viewModel.detail}
-              composer={viewModel.composer}
-              interaction={viewModel.interaction}
-              readiness={viewModel.readiness}
-              operations={viewModel.operations}
-              homeTargetProjection={homeTargetProjection}
-              referenceProvenanceFilters={referenceProvenanceFilters}
-              composerEngagement={composerEngagement}
-              actions={actions}
-              labels={labels}
-              uiLanguage={uiLanguage}
-              isActive={isActive}
-              isVisible={isVisible}
-              workspaceReferencePickerOpen={workspaceReferencePickerOpen}
-              composerFocusRequestSequence={detailComposerFocusRequestSequence}
-              slashStatusLimits={slashStatusLimits}
-              slashStatusLimitsLoading={slashStatusLimitsLoading}
-              slashStatusLimitsUnavailable={slashStatusLimitsUnavailable}
-              slashStatusOverride={slashStatusOverride}
-              onSlashStatusOpen={onSlashStatusOpen}
-              onSlashStatusClose={onSlashStatusClose}
-              onSlashStatusRefresh={onSlashStatusRefresh}
-              onLinkAction={onLinkAction}
-              onHandoffConversation={onHandoffConversation}
-              capabilityMenuState={capabilityMenuState}
-              capabilityControlsReadOnly={capabilityControlsReadOnly}
-              onCapabilitySettingsRequest={onCapabilitySettingsRequest}
-              onAgentProviderLogin={onAgentProviderLogin}
-              onRequestWorkspaceReferences={requestWorkspaceReferences}
-              resolveExternalPromptEntries={resolveExternalPromptEntries}
-              prepareExternalPromptFiles={prepareExternalPromptFiles}
-              promptAssetLimit={promptAssetLimit}
-              selectProjectDirectory={effectiveSelectProjectDirectory}
-              onRequestGitBranches={onRequestGitBranches}
-              onRequestComposerFocus={requestComposerFocus}
-              workspaceAppIcons={effectiveWorkspaceAppIcons}
-              workspaceUserProjectI18n={workspaceUserProjectI18n}
-              renderProviderUnavailableState={renderProviderUnavailableState}
-            />
+            <AgentConversationClockProvider isVisible={isVisible}>
+              <AgentGUIDetailPane
+                shell={viewModel.shell}
+                rail={viewModel.rail}
+                detail={viewModel.detail}
+                composer={viewModel.composer}
+                interaction={viewModel.interaction}
+                readiness={viewModel.readiness}
+                operations={viewModel.operations}
+                homeTargetProjection={homeTargetProjection}
+                referenceProvenanceFilters={referenceProvenanceFilters}
+                composerEngagement={composerEngagement}
+                actions={actions}
+                labels={labels}
+                uiLanguage={uiLanguage}
+                isActive={isActive}
+                isVisible={isVisible}
+                workspaceReferencePickerOpen={workspaceReferencePickerOpen}
+                composerFocusRequestSequence={
+                  detailComposerFocusRequestSequence
+                }
+                slashStatusLimits={slashStatusLimits}
+                slashStatusLimitsLoading={slashStatusLimitsLoading}
+                slashStatusLimitsUnavailable={slashStatusLimitsUnavailable}
+                slashStatusOverride={slashStatusOverride}
+                onSlashStatusOpen={onSlashStatusOpen}
+                onSlashStatusClose={onSlashStatusClose}
+                onSlashStatusRefresh={onSlashStatusRefresh}
+                onLinkAction={onLinkAction}
+                onHandoffConversation={onHandoffConversation}
+                capabilityMenuState={capabilityMenuState}
+                capabilityControlsReadOnly={capabilityControlsReadOnly}
+                onCapabilitySettingsRequest={onCapabilitySettingsRequest}
+                onAgentProviderLogin={onAgentProviderLogin}
+                onRequestWorkspaceReferences={requestWorkspaceReferences}
+                resolveExternalPromptEntries={resolveExternalPromptEntries}
+                prepareExternalPromptFiles={prepareExternalPromptFiles}
+                promptAssetLimit={promptAssetLimit}
+                selectProjectDirectory={effectiveSelectProjectDirectory}
+                onRequestGitBranches={onRequestGitBranches}
+                onRequestComposerFocus={requestComposerFocus}
+                workspaceAppIcons={effectiveWorkspaceAppIcons}
+                workspaceUserProjectI18n={workspaceUserProjectI18n}
+                renderProviderUnavailableState={renderProviderUnavailableState}
+              />
+            </AgentConversationClockProvider>
           </section>
         </div>
         <AgentGUIReferencePickerSurface

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGoalBanner.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGoalBanner.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type JSX } from "react";
 import { CirclePause, CirclePlay, Pencil, Target, Trash2 } from "lucide-react";
 import { cn } from "../../app/renderer/lib/utils";
+import { useAgentConversationNowUnixMs } from "../../shared/agentConversation/components/AgentConversationClock";
 import styles from "./AgentGUIChrome.styles";
 
 export interface AgentGoalBannerLabels {
@@ -160,22 +161,38 @@ export function AgentGoalBanner({
       : isActive
         ? 0
         : null;
-  const [localElapsed, setLocalElapsed] = useState(0);
+  const [elapsedBaseline, setElapsedBaseline] = useState(() => ({
+    isActive,
+    serverSeconds,
+    startedAtUnixMs: Date.now()
+  }));
   useEffect(() => {
-    setLocalElapsed(0);
-    if (!isActive || serverSeconds === null) {
-      return;
-    }
-    const startedAtMs = Date.now();
-    const timer = window.setInterval(() => {
-      setLocalElapsed(Math.floor((Date.now() - startedAtMs) / 1000));
-    }, 1000);
-    return () => window.clearInterval(timer);
+    setElapsedBaseline((current) =>
+      current.isActive === isActive && current.serverSeconds === serverSeconds
+        ? current
+        : {
+            isActive,
+            serverSeconds,
+            startedAtUnixMs: Date.now()
+          }
+    );
   }, [isActive, serverSeconds]);
+  const nowUnixMs = useAgentConversationNowUnixMs(
+    isActive && serverSeconds !== null
+  );
+  const baselineMatches =
+    elapsedBaseline.isActive === isActive &&
+    elapsedBaseline.serverSeconds === serverSeconds;
   const elapsedSeconds =
     serverSeconds === null
       ? null
-      : serverSeconds + (isActive ? localElapsed : 0);
+      : isActive && nowUnixMs !== null && baselineMatches
+        ? serverSeconds +
+          Math.max(
+            0,
+            Math.floor((nowUnixMs - elapsedBaseline.startedAtUnixMs) / 1_000)
+          )
+        : serverSeconds;
 
   const title = goalStatusTitle(status, labels);
   const description = describeGoal({

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailClock.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailClock.tsx
@@ -1,50 +1,7 @@
 import type { ComponentProps } from "react";
-import { useExternalStoreSnapshot } from "@tutti-os/ui-react-hooks";
+import { useAgentConversationMinuteNowUnixMs } from "../../../shared/agentConversation/components/AgentConversationClock";
 import { ConversationMeta } from "../agentGuiNodeViewConversation";
 import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
-
-type ClockListener = () => void;
-
-class AgentGUIConversationRailClockStore {
-  private currentTimeMs = Date.now();
-  private readonly listeners = new Set<ClockListener>();
-  private timer: number | null = null;
-
-  readonly getSnapshot = (): number => this.currentTimeMs;
-
-  readonly subscribe = (listener: ClockListener): (() => void) => {
-    this.listeners.add(listener);
-    if (this.listeners.size === 1) {
-      this.start();
-    }
-    return () => {
-      this.listeners.delete(listener);
-      if (this.listeners.size === 0) {
-        this.stop();
-      }
-    };
-  };
-
-  private start(): void {
-    this.currentTimeMs = Date.now();
-    // timing: refresh relative timestamps in the rail once a minute
-    this.timer = window.setInterval(() => {
-      this.currentTimeMs = Date.now();
-      for (const listener of this.listeners) {
-        listener();
-      }
-    }, 60_000);
-  }
-
-  private stop(): void {
-    if (this.timer !== null) {
-      window.clearInterval(this.timer);
-      this.timer = null;
-    }
-  }
-}
-
-const agentGUIConversationRailClock = new AgentGUIConversationRailClockStore();
 
 export function AgentGUIConversationRailRelativeTime({
   item,
@@ -53,6 +10,6 @@ export function AgentGUIConversationRailRelativeTime({
   item: AgentGUINodeViewModel["rail"]["conversations"][number];
   labels: ComponentProps<typeof ConversationMeta>["labels"];
 }): React.JSX.Element {
-  const currentTimeMs = useExternalStoreSnapshot(agentGUIConversationRailClock);
+  const currentTimeMs = useAgentConversationMinuteNowUnixMs();
   return <ConversationMeta item={item} nowMs={currentTimeMs} labels={labels} />;
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -662,6 +662,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     bottomDockRef,
     bottomDockStoreRevision,
     conversation,
+    isVisible,
     pendingPrependScrollAnchorRef,
     showTimelineSkeleton,
     submittedPromptScrollConversationRef,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx
@@ -899,6 +899,70 @@ describe("useAgentGUIDetailScroll", () => {
     ).toBe(false);
   });
 
+  it("disconnects layout observation while fully occluded and catches up when exposed", () => {
+    const resizeObservers = installResizeObserverMock();
+    const harness = createHarness({ scrollHeight: 5_000 });
+    const { rerender } = renderHook(
+      ({ conversation, isVisible }) =>
+        useAgentGUIDetailScroll(
+          harness.input({
+            activeConversationId: "conversation-visibility",
+            conversation,
+            isVisible,
+            showTimelineSkeleton: false
+          })
+        ),
+      {
+        initialProps: {
+          conversation: conversationVM("initial"),
+          isVisible: true
+        }
+      }
+    );
+    const visibleDockObserver = resizeObservers.find((observer) =>
+      observer.observed.has(harness.bottomDock)
+    );
+    const visibleTimelineObserver = resizeObservers.find((observer) =>
+      observer.observed.has(harness.timelineContent)
+    );
+    expect(visibleDockObserver).toBeDefined();
+    expect(visibleTimelineObserver).toBeDefined();
+
+    rerender({ conversation: conversationVM("hidden"), isVisible: false });
+
+    expect(visibleDockObserver?.observed.size).toBe(0);
+    expect(visibleTimelineObserver?.observed.size).toBe(0);
+    harness.resetGeometryReadCounts();
+    harness.resetScrollTopWriteCount();
+    harness.setScrollHeight(8_000);
+    rerender({ conversation: conversationVM("streaming"), isVisible: false });
+    expect(harness.geometryReadCounts()).toEqual({
+      clientHeight: 0,
+      scrollHeight: 0,
+      scrollTop: 0
+    });
+    expect(harness.scrollTopWriteCount()).toBe(0);
+
+    rerender({ conversation: conversationVM("streaming"), isVisible: true });
+
+    const resumedTimelineObserver = resizeObservers.find(
+      (observer) =>
+        observer !== visibleTimelineObserver &&
+        observer.observed.has(harness.timelineContent)
+    );
+    expect(resumedTimelineObserver).toBeDefined();
+    act(() => {
+      resumedTimelineObserver?.callback([], resumedTimelineObserver);
+    });
+    expect(harness.timeline.scrollTop).toBe(7_900);
+    expect(harness.geometryReadCounts()).toEqual({
+      clientHeight: 1,
+      scrollHeight: 1,
+      scrollTop: 2
+    });
+    expect(harness.scrollTopWriteCount()).toBe(1);
+  });
+
   it("remeasures dock safe-area after store and ResizeObserver invalidation", () => {
     const resizeObservers = installResizeObserverMock();
     const harness = createHarness({ scrollHeight: 5_000 });
@@ -1077,6 +1141,7 @@ function createHarness(input: { scrollHeight: number }) {
       conversation?: AgentConversationVM;
       hasOlderMessages?: boolean;
       isLoadingOlderMessages?: boolean;
+      isVisible?: boolean;
       showTimelineSkeleton: boolean;
       timelineConversationId?: string | null;
     }) {
@@ -1085,6 +1150,7 @@ function createHarness(input: { scrollHeight: number }) {
         bottomDockRef: ref(bottomDock),
         bottomDockStoreRevision: options.bottomDockStoreRevision ?? "stable",
         conversation: options.conversation ?? null,
+        isVisible: options.isVisible ?? true,
         pendingPrependScrollAnchorRef,
         showTimelineSkeleton: options.showTimelineSkeleton,
         submittedPromptScrollConversationRef,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.ts
@@ -34,6 +34,7 @@ interface Input {
   bottomDockRef: RefObject<HTMLDivElement | null>;
   bottomDockStoreRevision: string;
   conversation: AgentConversationVM | null;
+  isVisible: boolean;
   pendingPrependScrollAnchorRef: MutableRefObject<{
     conversationId: string;
     scrollHeight: number;
@@ -60,6 +61,7 @@ export function useAgentGUIDetailScroll(input: Input) {
     bottomDockRef,
     bottomDockStoreRevision,
     conversation,
+    isVisible,
     pendingPrependScrollAnchorRef,
     showTimelineSkeleton,
     submittedPromptScrollConversationRef,
@@ -79,6 +81,9 @@ export function useAgentGUIDetailScroll(input: Input) {
   const lastShowTimelineSkeletonRef = useRef(showTimelineSkeleton);
   const bottomDockSafeAreaRef = useRef<BottomDockSafeArea | null>(null);
   useLayoutEffect(() => {
+    if (!isVisible) {
+      return;
+    }
     const timelineSkeletonChanged =
       lastShowTimelineSkeletonRef.current !== showTimelineSkeleton;
     lastShowTimelineSkeletonRef.current = showTimelineSkeleton;
@@ -252,6 +257,7 @@ export function useAgentGUIDetailScroll(input: Input) {
     );
   }, [
     conversation,
+    isVisible,
     showTimelineSkeleton,
     timelineConversationId,
     viewModel.rail.activeConversationId,
@@ -260,6 +266,9 @@ export function useAgentGUIDetailScroll(input: Input) {
 
   const hasTimelineConversation = timelineConversationId !== null;
   useLayoutEffect(() => {
+    if (!isVisible) {
+      return;
+    }
     const timeline = timelineRef.current;
     const bottomDock = bottomDockRef.current;
     if (!hasTimelineConversation || !timeline || !bottomDock) {
@@ -384,9 +393,12 @@ export function useAgentGUIDetailScroll(input: Input) {
       }
       observer.disconnect();
     };
-  }, [bottomDockStoreRevision, hasTimelineConversation]);
+  }, [bottomDockStoreRevision, hasTimelineConversation, isVisible]);
 
   useEffect(() => {
+    if (!isVisible) {
+      return;
+    }
     const timeline = timelineRef.current;
     const timelineContent = timelineContentRef.current;
     const activeConversationId = timelineConversationId;
@@ -647,6 +659,7 @@ export function useAgentGUIDetailScroll(input: Input) {
     };
   }, [
     actions,
+    isVisible,
     timelineConversationId,
     showTimelineSkeleton,
     viewModel.rail.activeConversationId,
@@ -657,7 +670,7 @@ export function useAgentGUIDetailScroll(input: Input) {
   const scrollTimelineToBottom = useCallback(() => {
     const timeline = timelineRef.current;
     const activeConversationId = timelineConversationId;
-    if (!timeline || !activeConversationId) {
+    if (!isVisible || !timeline || !activeConversationId) {
       return;
     }
     if (activeConversationId !== viewModel.rail.activeConversationId) {
@@ -701,6 +714,7 @@ export function useAgentGUIDetailScroll(input: Input) {
     );
     setIsTimelineScrolledToBottom(true);
   }, [
+    isVisible,
     timelineConversationId,
     viewModel.rail.activeConversationId,
     virtualScrollControllerRef

--- a/packages/agent/gui/shared/agentConversation/components/AgentConversationClock.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentConversationClock.spec.tsx
@@ -1,0 +1,59 @@
+import { act, render, screen } from "@testing-library/react";
+import type { JSX } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentConversationClockProvider } from "./AgentConversationClock";
+import { useElapsedSeconds } from "./useElapsedSeconds";
+
+describe("AgentConversationClock", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shares one interval and pauses it while the AgentGUI is hidden", () => {
+    const setInterval = vi.spyOn(window, "setInterval");
+    const clearInterval = vi.spyOn(window, "clearInterval");
+    const { rerender } = render(<ElapsedPair isVisible />);
+
+    expect(screen.getByTestId("elapsed-a")).toHaveTextContent("0");
+    expect(screen.getByTestId("elapsed-b")).toHaveTextContent("0");
+    expect(setInterval).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+    expect(screen.getByTestId("elapsed-a")).toHaveTextContent("2");
+    expect(screen.getByTestId("elapsed-b")).toHaveTextContent("2");
+
+    rerender(<ElapsedPair isVisible={false} />);
+    expect(clearInterval).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(vi.getTimerCount()).toBe(0);
+
+    rerender(<ElapsedPair isVisible />);
+    expect(screen.getByTestId("elapsed-a")).toHaveTextContent("7");
+    expect(screen.getByTestId("elapsed-b")).toHaveTextContent("7");
+    expect(setInterval).toHaveBeenCalledTimes(2);
+  });
+});
+
+function ElapsedPair({ isVisible }: { isVisible: boolean }): JSX.Element {
+  return (
+    <AgentConversationClockProvider isVisible={isVisible}>
+      <ElapsedValue testId="elapsed-a" />
+      <ElapsedValue testId="elapsed-b" />
+    </AgentConversationClockProvider>
+  );
+}
+
+function ElapsedValue({ testId }: { testId: string }): JSX.Element {
+  const elapsedSeconds = useElapsedSeconds(1_000);
+  return <span data-testid={testId}>{elapsedSeconds}</span>;
+}

--- a/packages/agent/gui/shared/agentConversation/components/AgentConversationClock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentConversationClock.tsx
@@ -1,0 +1,105 @@
+import { createContext, useContext, type JSX, type ReactNode } from "react";
+import {
+  useExternalStoreSnapshot,
+  type ExternalStoreSnapshotSource
+} from "@tutti-os/ui-react-hooks";
+
+const AgentConversationClockVisibilityContext = createContext(true);
+type ClockListener = () => void;
+
+class AgentConversationClockStore {
+  private readonly minuteListeners = new Set<ClockListener>();
+  private readonly secondListeners = new Set<ClockListener>();
+  private minuteTimeMs = Date.now();
+  private minuteTimer: number | null = null;
+  private secondTimeMs = Date.now();
+  private secondTimer: number | null = null;
+
+  readonly disabledSecond: ExternalStoreSnapshotSource<number> = {
+    getSnapshot: () => 0,
+    subscribe: () => () => undefined
+  };
+
+  readonly minute: ExternalStoreSnapshotSource<number> = {
+    getSnapshot: () => this.minuteTimeMs,
+    subscribe: (listener) =>
+      this.subscribe(
+        listener,
+        this.minuteListeners,
+        60_000,
+        "minuteTimeMs",
+        "minuteTimer"
+      )
+  };
+
+  readonly second: ExternalStoreSnapshotSource<number> = {
+    getSnapshot: () => this.secondTimeMs,
+    subscribe: (listener) =>
+      this.subscribe(
+        listener,
+        this.secondListeners,
+        1_000,
+        "secondTimeMs",
+        "secondTimer"
+      )
+  };
+
+  private subscribe(
+    listener: ClockListener,
+    listeners: Set<ClockListener>,
+    intervalMs: number,
+    timeKey: "minuteTimeMs" | "secondTimeMs",
+    timerKey: "minuteTimer" | "secondTimer"
+  ): () => void {
+    listeners.add(listener);
+    if (listeners.size === 1) {
+      this[timeKey] = Date.now();
+      // timing: share one cadence timer across all mounted consumers.
+      this[timerKey] = window.setInterval(() => {
+        this[timeKey] = Date.now();
+        listeners.forEach((candidate) => candidate());
+      }, intervalMs);
+    }
+    return () => {
+      listeners.delete(listener);
+      if (listeners.size === 0) {
+        const timer = this[timerKey];
+        if (timer !== null) {
+          window.clearInterval(timer);
+          this[timerKey] = null;
+        }
+      }
+    };
+  }
+}
+
+const agentConversationClock = new AgentConversationClockStore();
+
+export function AgentConversationClockProvider({
+  children,
+  isVisible
+}: {
+  children: ReactNode;
+  isVisible: boolean;
+}): JSX.Element {
+  return (
+    <AgentConversationClockVisibilityContext.Provider value={isVisible}>
+      {children}
+    </AgentConversationClockVisibilityContext.Provider>
+  );
+}
+
+export function useAgentConversationNowUnixMs(enabled: boolean): number | null {
+  const isVisible = useContext(AgentConversationClockVisibilityContext);
+  const shouldTick = enabled && isVisible;
+  const nowUnixMs = useExternalStoreSnapshot(
+    shouldTick
+      ? agentConversationClock.second
+      : agentConversationClock.disabledSecond
+  );
+  return shouldTick ? nowUnixMs : null;
+}
+
+export function useAgentConversationMinuteNowUnixMs(): number {
+  return useExternalStoreSnapshot(agentConversationClock.minute);
+}

--- a/packages/agent/gui/shared/agentConversation/components/AgentSubAgentCards.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentSubAgentCards.tsx
@@ -1,10 +1,11 @@
-import { memo, useEffect, useState, type JSX } from "react";
+import { memo, useState, type JSX } from "react";
 import { AlertCircle, ChevronDown, ChevronRight } from "lucide-react";
 import { AgentLinedIcon } from "../../../app/renderer/components/icons/AgentLinedIcon";
 import { translate } from "../../../i18n/index";
 import type { AgentTaskSubAgentVM } from "../contracts/agentTaskItemVM";
 import type { AgentToolCallVM } from "../contracts/agentToolCallVM";
 import { CollapsibleReveal } from "./CollapsibleReveal";
+import { useAgentConversationNowUnixMs } from "./AgentConversationClock";
 import { formatAgentToolDurationMs } from "./tool-renderers/render-data/agentToolRenderData";
 
 // A delegated sub-agent renders as a first-class row aligned with tool rows:
@@ -281,23 +282,7 @@ function useRunningSubAgentNowUnixMs(
   const shouldTick =
     isSubAgentActivelyRunning(subAgent) &&
     typeof subAgent.startedAtUnixMs === "number";
-  const [nowUnixMs, setNowUnixMs] = useState<number | null>(() =>
-    shouldTick ? Date.now() : null
-  );
-
-  useEffect(() => {
-    if (!shouldTick) {
-      setNowUnixMs(null);
-      return;
-    }
-
-    const updateNow = () => setNowUnixMs(Date.now());
-    updateNow();
-    const intervalId = window.setInterval(updateNow, 1000);
-    return () => window.clearInterval(intervalId);
-  }, [shouldTick, subAgent.startedAtUnixMs]);
-
-  return nowUnixMs;
+  return useAgentConversationNowUnixMs(shouldTick);
 }
 
 function subAgentElapsedText(

--- a/packages/agent/gui/shared/agentConversation/components/useElapsedSeconds.ts
+++ b/packages/agent/gui/shared/agentConversation/components/useElapsedSeconds.ts
@@ -1,17 +1,12 @@
-import { useEffect, useState } from "react";
+import { useAgentConversationNowUnixMs } from "./AgentConversationClock";
 
 export function useElapsedSeconds(startUnixMs: number | null): number | null {
-  const [nowUnixMs, setNowUnixMs] = useState(() => Date.now());
-  useEffect(() => {
-    if (startUnixMs === null) {
-      return;
-    }
-    // timing: drive second-level elapsed UI only while the canonical active turn is visible.
-    const timer = setInterval(() => setNowUnixMs(Date.now()), 1_000);
-    return () => clearInterval(timer);
-  }, [startUnixMs]);
+  const nowUnixMs = useAgentConversationNowUnixMs(startUnixMs !== null);
   if (startUnixMs === null) {
     return null;
   }
-  return Math.max(0, Math.floor((nowUnixMs - startUnixMs) / 1_000));
+  return Math.max(
+    0,
+    Math.floor(((nowUnixMs ?? startUnixMs) - startUnixMs) / 1_000)
+  );
 }

--- a/packages/workbench/surface/src/core/visualOcclusion.test.ts
+++ b/packages/workbench/surface/src/core/visualOcclusion.test.ts
@@ -63,6 +63,30 @@ test("clips visibility to the Workbench surface and ignores minimized covers", (
   );
 });
 
+test("ignores a transiently hidden Genie window as an occluder", () => {
+  const state = workbenchState([
+    node("covered", frame(0, 0)),
+    node("genie-minimizing", frame(0, 0))
+  ]);
+
+  assert.equal(
+    selectWorkbenchNodeIsVisuallyExposed(
+      state,
+      "covered",
+      new Set(["genie-minimizing"])
+    ),
+    true
+  );
+  assert.equal(
+    selectWorkbenchNodeIsVisuallyExposed(
+      state,
+      "genie-minimizing",
+      new Set(["genie-minimizing"])
+    ),
+    false
+  );
+});
+
 test("reuses exposure when only non-geometric Workbench state changes", () => {
   const state = workbenchState([
     node("covered", frame(0, 0)),

--- a/packages/workbench/surface/src/core/visualOcclusion.test.ts
+++ b/packages/workbench/surface/src/core/visualOcclusion.test.ts
@@ -68,22 +68,70 @@ test("ignores a transiently hidden Genie window as an occluder", () => {
     node("covered", frame(0, 0)),
     node("genie-minimizing", frame(0, 0))
   ]);
+  const hiddenNodeIDs = new Set(["genie-minimizing"]);
+  const presentation = {
+    hiddenNodeIDs,
+    nonOccludingNodeIDs: hiddenNodeIDs,
+    topLayerNodeIDs: []
+  };
 
   assert.equal(
-    selectWorkbenchNodeIsVisuallyExposed(
-      state,
-      "covered",
-      new Set(["genie-minimizing"])
-    ),
+    selectWorkbenchNodeIsVisuallyExposed(state, "covered", presentation),
     true
   );
   assert.equal(
     selectWorkbenchNodeIsVisuallyExposed(
       state,
       "genie-minimizing",
-      new Set(["genie-minimizing"])
+      presentation
     ),
     false
+  );
+});
+
+test("keeps a transitioning window visible without letting it cover others", () => {
+  const state = workbenchState([
+    node("covered", frame(0, 0)),
+    node("transitioning-cover", frame(0, 0))
+  ]);
+  const presentation = {
+    hiddenNodeIDs: new Set<string>(),
+    nonOccludingNodeIDs: new Set(["transitioning-cover"]),
+    topLayerNodeIDs: []
+  };
+
+  assert.equal(
+    selectWorkbenchNodeIsVisuallyExposed(state, "covered", presentation),
+    true
+  );
+  assert.equal(
+    selectWorkbenchNodeIsVisuallyExposed(
+      state,
+      "transitioning-cover",
+      presentation
+    ),
+    true
+  );
+});
+
+test("orders dialog popover windows above the default window layer", () => {
+  const state = workbenchState([
+    node("dialog-cover", frame(0, 0)),
+    node("covered", frame(0, 0))
+  ]);
+  const presentation = {
+    hiddenNodeIDs: new Set<string>(),
+    nonOccludingNodeIDs: new Set<string>(),
+    topLayerNodeIDs: ["dialog-cover"]
+  };
+
+  assert.equal(
+    selectWorkbenchNodeIsVisuallyExposed(state, "covered", presentation),
+    false
+  );
+  assert.equal(
+    selectWorkbenchNodeIsVisuallyExposed(state, "dialog-cover", presentation),
+    true
   );
 });
 

--- a/packages/workbench/surface/src/core/visualOcclusion.ts
+++ b/packages/workbench/surface/src/core/visualOcclusion.ts
@@ -1,11 +1,23 @@
 import type { WorkbenchFrame, WorkbenchState } from "./types.ts";
 
-const noNonOccludingNodeIDs: ReadonlySet<string> = new Set();
+export interface WorkbenchVisualOcclusionPresentation {
+  hiddenNodeIDs: ReadonlySet<string>;
+  nonOccludingNodeIDs: ReadonlySet<string>;
+  topLayerNodeIDs: readonly string[];
+}
+
+const noNodeIDs: ReadonlySet<string> = new Set();
+const defaultVisualOcclusionPresentation: WorkbenchVisualOcclusionPresentation =
+  {
+    hiddenNodeIDs: noNodeIDs,
+    nonOccludingNodeIDs: noNodeIDs,
+    topLayerNodeIDs: []
+  };
 const exposedNodeIDsByState = new WeakMap<
   object,
   {
     exposedNodeIDs: ReadonlySet<string>;
-    nonOccludingNodeIDs: ReadonlySet<string>;
+    presentation: WorkbenchVisualOcclusionPresentation;
   }
 >();
 const exposedNodeIDsByNodeStack = new WeakMap<
@@ -13,43 +25,51 @@ const exposedNodeIDsByNodeStack = new WeakMap<
   {
     exposedNodeIDs: ReadonlySet<string>;
     nodes: WorkbenchState<unknown>["nodes"];
-    nonOccludingNodeIDs: ReadonlySet<string>;
+    presentation: WorkbenchVisualOcclusionPresentation;
     surfaceSize: WorkbenchState<unknown>["surfaceSize"];
   }
 >();
 
 export function selectVisuallyExposedWorkbenchNodeIDs<TData>(
   state: WorkbenchState<TData>,
-  nonOccludingNodeIDs: ReadonlySet<string> = noNonOccludingNodeIDs
+  presentation: WorkbenchVisualOcclusionPresentation = defaultVisualOcclusionPresentation
 ): ReadonlySet<string> {
   const cachedByState = exposedNodeIDsByState.get(state);
-  if (cachedByState?.nonOccludingNodeIDs === nonOccludingNodeIDs) {
+  if (cachedByState?.presentation === presentation) {
     return cachedByState.exposedNodeIDs;
   }
   const cachedByGeometry = exposedNodeIDsByNodeStack.get(state.nodeStack);
   if (
     cachedByGeometry &&
-    cachedByGeometry.nonOccludingNodeIDs === nonOccludingNodeIDs &&
+    cachedByGeometry.presentation === presentation &&
     hasEquivalentVisualOcclusionGeometry(cachedByGeometry, state)
   ) {
     cachedByGeometry.nodes = state.nodes;
     cachedByGeometry.surfaceSize = state.surfaceSize;
     exposedNodeIDsByState.set(state, {
       exposedNodeIDs: cachedByGeometry.exposedNodeIDs,
-      nonOccludingNodeIDs
+      presentation
     });
     return cachedByGeometry.exposedNodeIDs;
   }
 
   const nodeByID = new Map(state.nodes.map((node) => [node.id, node]));
   const stackedIDs = new Set(state.nodeStack);
-  const orderedNodes = [
+  const stackOrderedNodes = [
     ...state.nodes.filter((node) => !stackedIDs.has(node.id)),
     ...state.nodeStack.flatMap((nodeID) => {
       const node = nodeByID.get(nodeID);
       return node ? [node] : [];
     })
   ];
+  const topLayerNodeIDs = new Set(presentation.topLayerNodeIDs);
+  const orderedNodes =
+    topLayerNodeIDs.size === 0
+      ? stackOrderedNodes
+      : [
+          ...stackOrderedNodes.filter((node) => !topLayerNodeIDs.has(node.id)),
+          ...stackOrderedNodes.filter((node) => topLayerNodeIDs.has(node.id))
+        ];
   const surfaceFrame: WorkbenchFrame = {
     x: 0,
     y: 0,
@@ -59,7 +79,7 @@ export function selectVisuallyExposedWorkbenchNodeIDs<TData>(
   const exposedNodeIDs = new Set<string>();
 
   orderedNodes.forEach((node, nodeIndex) => {
-    if (node.isMinimized || nonOccludingNodeIDs.has(node.id)) {
+    if (node.isMinimized || presentation.hiddenNodeIDs.has(node.id)) {
       return;
     }
     const visibleFrame = intersectFrames(node.frame, surfaceFrame);
@@ -77,7 +97,8 @@ export function selectVisuallyExposedWorkbenchNodeIDs<TData>(
       if (
         !occluder ||
         occluder.isMinimized ||
-        nonOccludingNodeIDs.has(occluder.id)
+        presentation.hiddenNodeIDs.has(occluder.id) ||
+        presentation.nonOccludingNodeIDs.has(occluder.id)
       ) {
         continue;
       }
@@ -92,12 +113,12 @@ export function selectVisuallyExposedWorkbenchNodeIDs<TData>(
 
   exposedNodeIDsByState.set(state, {
     exposedNodeIDs,
-    nonOccludingNodeIDs
+    presentation
   });
   exposedNodeIDsByNodeStack.set(state.nodeStack, {
     exposedNodeIDs,
     nodes: state.nodes,
-    nonOccludingNodeIDs,
+    presentation,
     surfaceSize: state.surfaceSize
   });
   return exposedNodeIDs;
@@ -106,11 +127,9 @@ export function selectVisuallyExposedWorkbenchNodeIDs<TData>(
 export function selectWorkbenchNodeIsVisuallyExposed<TData>(
   state: WorkbenchState<TData>,
   nodeID: string,
-  nonOccludingNodeIDs?: ReadonlySet<string>
+  presentation?: WorkbenchVisualOcclusionPresentation
 ): boolean {
-  return selectVisuallyExposedWorkbenchNodeIDs(state, nonOccludingNodeIDs).has(
-    nodeID
-  );
+  return selectVisuallyExposedWorkbenchNodeIDs(state, presentation).has(nodeID);
 }
 
 function intersectFrames(

--- a/packages/workbench/surface/src/core/visualOcclusion.ts
+++ b/packages/workbench/surface/src/core/visualOcclusion.ts
@@ -1,30 +1,43 @@
 import type { WorkbenchFrame, WorkbenchState } from "./types.ts";
 
-const exposedNodeIDsByState = new WeakMap<object, ReadonlySet<string>>();
+const noNonOccludingNodeIDs: ReadonlySet<string> = new Set();
+const exposedNodeIDsByState = new WeakMap<
+  object,
+  {
+    exposedNodeIDs: ReadonlySet<string>;
+    nonOccludingNodeIDs: ReadonlySet<string>;
+  }
+>();
 const exposedNodeIDsByNodeStack = new WeakMap<
   object,
   {
     exposedNodeIDs: ReadonlySet<string>;
     nodes: WorkbenchState<unknown>["nodes"];
+    nonOccludingNodeIDs: ReadonlySet<string>;
     surfaceSize: WorkbenchState<unknown>["surfaceSize"];
   }
 >();
 
 export function selectVisuallyExposedWorkbenchNodeIDs<TData>(
-  state: WorkbenchState<TData>
+  state: WorkbenchState<TData>,
+  nonOccludingNodeIDs: ReadonlySet<string> = noNonOccludingNodeIDs
 ): ReadonlySet<string> {
   const cachedByState = exposedNodeIDsByState.get(state);
-  if (cachedByState) {
-    return cachedByState;
+  if (cachedByState?.nonOccludingNodeIDs === nonOccludingNodeIDs) {
+    return cachedByState.exposedNodeIDs;
   }
   const cachedByGeometry = exposedNodeIDsByNodeStack.get(state.nodeStack);
   if (
     cachedByGeometry &&
+    cachedByGeometry.nonOccludingNodeIDs === nonOccludingNodeIDs &&
     hasEquivalentVisualOcclusionGeometry(cachedByGeometry, state)
   ) {
     cachedByGeometry.nodes = state.nodes;
     cachedByGeometry.surfaceSize = state.surfaceSize;
-    exposedNodeIDsByState.set(state, cachedByGeometry.exposedNodeIDs);
+    exposedNodeIDsByState.set(state, {
+      exposedNodeIDs: cachedByGeometry.exposedNodeIDs,
+      nonOccludingNodeIDs
+    });
     return cachedByGeometry.exposedNodeIDs;
   }
 
@@ -46,7 +59,7 @@ export function selectVisuallyExposedWorkbenchNodeIDs<TData>(
   const exposedNodeIDs = new Set<string>();
 
   orderedNodes.forEach((node, nodeIndex) => {
-    if (node.isMinimized) {
+    if (node.isMinimized || nonOccludingNodeIDs.has(node.id)) {
       return;
     }
     const visibleFrame = intersectFrames(node.frame, surfaceFrame);
@@ -61,7 +74,11 @@ export function selectVisuallyExposedWorkbenchNodeIDs<TData>(
       occluderIndex += 1
     ) {
       const occluder = orderedNodes[occluderIndex];
-      if (!occluder || occluder.isMinimized) {
+      if (
+        !occluder ||
+        occluder.isMinimized ||
+        nonOccludingNodeIDs.has(occluder.id)
+      ) {
         continue;
       }
       uncoveredFrames = uncoveredFrames.flatMap((frame) =>
@@ -73,10 +90,14 @@ export function selectVisuallyExposedWorkbenchNodeIDs<TData>(
     }
   });
 
-  exposedNodeIDsByState.set(state, exposedNodeIDs);
+  exposedNodeIDsByState.set(state, {
+    exposedNodeIDs,
+    nonOccludingNodeIDs
+  });
   exposedNodeIDsByNodeStack.set(state.nodeStack, {
     exposedNodeIDs,
     nodes: state.nodes,
+    nonOccludingNodeIDs,
     surfaceSize: state.surfaceSize
   });
   return exposedNodeIDs;
@@ -84,9 +105,12 @@ export function selectVisuallyExposedWorkbenchNodeIDs<TData>(
 
 export function selectWorkbenchNodeIsVisuallyExposed<TData>(
   state: WorkbenchState<TData>,
-  nodeID: string
+  nodeID: string,
+  nonOccludingNodeIDs?: ReadonlySet<string>
 ): boolean {
-  return selectVisuallyExposedWorkbenchNodeIDs(state).has(nodeID);
+  return selectVisuallyExposedWorkbenchNodeIDs(state, nonOccludingNodeIDs).has(
+    nodeID
+  );
 }
 
 function intersectFrames(

--- a/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
@@ -2,9 +2,13 @@ import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { describe, expect, it, vi } from "vitest";
 import type { WorkbenchSnapshot } from "@tutti-os/workbench-snapshot";
+import { selectWorkbenchNodeIsVisuallyExposed } from "../core/visualOcclusion.ts";
 import type { WorkbenchNode } from "../core/types.ts";
+import { useWorkbenchSelector } from "../react/hooks/useWorkbenchSelector.ts";
+import { WorkbenchNodeLayer } from "../react/WorkbenchNodeLayer.tsx";
 import { WorkbenchProvider } from "../react/WorkbenchProvider.tsx";
 import {
+  useWorkbenchNonOccludingNodeIDs,
   useWorkbenchWindowPresentationVisibility,
   WorkbenchWindowFrame
 } from "../react/WorkbenchWindowFrame.tsx";
@@ -48,6 +52,22 @@ function WorkbenchWindowVisibilityProbe({
   onRender: (isVisible: boolean) => void;
 }) {
   onRender(useWorkbenchWindowPresentationVisibility());
+  return null;
+}
+
+function WorkbenchVisualExposureProbe({
+  nodeID,
+  onRender
+}: {
+  nodeID: string;
+  onRender: (isVisible: boolean) => void;
+}) {
+  const nonOccludingNodeIDs = useWorkbenchNonOccludingNodeIDs();
+  onRender(
+    useWorkbenchSelector((state) =>
+      selectWorkbenchNodeIsVisuallyExposed(state, nodeID, nonOccludingNodeIDs)
+    )
+  );
   return null;
 }
 
@@ -820,6 +840,100 @@ describe("WorkbenchHost", () => {
       (
         globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
       ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+  });
+
+  it("exposes a covered window while its cover leaves through Genie", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const coveredNode: WorkbenchNode = {
+      data: null,
+      displayMode: "floating",
+      frame: { x: 0, y: 0, width: 320, height: 240 },
+      id: "covered",
+      isMinimized: false,
+      kind: "test",
+      restoreFrame: null,
+      title: "Covered"
+    };
+    const coverNode: WorkbenchNode = {
+      ...coveredNode,
+      id: "cover",
+      title: "Cover"
+    };
+    const controller = createWorkbenchController({
+      nodes: [coveredNode, coverNode],
+      nodeStack: [coveredNode.id, coverNode.id]
+    });
+    const nodeVisibility = createWorkbenchGenieNodeVisibilityStore();
+    const genie: WorkbenchGenieController = {
+      genieLayer: null,
+      isPendingMinimizedDockNode: () => false,
+      launchNodeFromAnchor: () => {},
+      minimizeNodeToAnchor: () => {},
+      nodeVisibility,
+      pendingMinimizedNode: null,
+      registerDockAnchor: () => {},
+      shouldAnimateMinimizedDockEnter: () => false
+    };
+    const coveredVisibility = vi.fn();
+    const coverVisibility = vi.fn();
+    const renderLayer = (genieController: WorkbenchGenieController) => (
+      <WorkbenchProvider controller={controller}>
+        <WorkbenchNodeLayer
+          genie={genieController}
+          renderNode={({ node }) => (
+            <WorkbenchVisualExposureProbe
+              nodeID={node.id}
+              onRender={
+                node.id === coveredNode.id ? coveredVisibility : coverVisibility
+              }
+            />
+          )}
+        />
+      </WorkbenchProvider>
+    );
+
+    try {
+      await act(async () => {
+        root.render(renderLayer(genie));
+      });
+
+      expect(coveredVisibility).toHaveBeenLastCalledWith(false);
+      expect(coverVisibility).toHaveBeenLastCalledWith(true);
+
+      await act(async () => {
+        nodeVisibility.setHidden(coverNode.id, true);
+      });
+
+      expect(coveredVisibility).toHaveBeenLastCalledWith(true);
+      expect(coverVisibility).toHaveBeenLastCalledWith(false);
+
+      await act(async () => {
+        nodeVisibility.setHidden(coverNode.id, false);
+      });
+      expect(coveredVisibility).toHaveBeenLastCalledWith(false);
+
+      await act(async () => {
+        root.render(
+          renderLayer({
+            ...genie,
+            pendingMinimizedNode: {
+              ...coverNode,
+              isMinimized: true
+            }
+          })
+        );
+      });
+      expect(coveredVisibility).toHaveBeenLastCalledWith(true);
+      expect(coverVisibility).toHaveBeenLastCalledWith(false);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      nodeVisibility.dispose();
+      container.remove();
     }
   });
 

--- a/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHost.render.test.tsx
@@ -8,11 +8,15 @@ import { useWorkbenchSelector } from "../react/hooks/useWorkbenchSelector.ts";
 import { WorkbenchNodeLayer } from "../react/WorkbenchNodeLayer.tsx";
 import { WorkbenchProvider } from "../react/WorkbenchProvider.tsx";
 import {
-  useWorkbenchNonOccludingNodeIDs,
+  useWorkbenchVisualOcclusionPresentation,
   useWorkbenchWindowPresentationVisibility,
   WorkbenchWindowFrame
 } from "../react/WorkbenchWindowFrame.tsx";
 import { createWorkbenchGenieNodeVisibilityStore } from "../react/genieNodeVisibility.ts";
+import {
+  createWorkbenchNodePresentationTransitionStore,
+  type WorkbenchNodePresentationTransitionStore
+} from "../react/nodePresentationTransitions.ts";
 import {
   useWorkbenchGenieAnimation,
   type WorkbenchGenieController
@@ -35,13 +39,22 @@ import type {
 function WorkbenchGenieIdentityProbe({
   controller,
   debugDiagnostics,
+  minimizeAnimation,
+  nodePresentationTransitions,
   onRender
 }: {
   controller: WorkbenchController;
   debugDiagnostics?: WorkbenchDebugDiagnostics;
+  minimizeAnimation?: "genie" | "off" | "scale";
+  nodePresentationTransitions: WorkbenchNodePresentationTransitionStore;
   onRender: (genie: WorkbenchGenieController) => void;
 }) {
-  const genie = useWorkbenchGenieAnimation({ controller, debugDiagnostics });
+  const genie = useWorkbenchGenieAnimation({
+    controller,
+    debugDiagnostics,
+    minimizeAnimation,
+    nodePresentationTransitions
+  });
   onRender(genie);
   return <>{genie.genieLayer}</>;
 }
@@ -62,13 +75,32 @@ function WorkbenchVisualExposureProbe({
   nodeID: string;
   onRender: (isVisible: boolean) => void;
 }) {
-  const nonOccludingNodeIDs = useWorkbenchNonOccludingNodeIDs();
+  const visualOcclusionPresentation = useWorkbenchVisualOcclusionPresentation();
   onRender(
     useWorkbenchSelector((state) =>
-      selectWorkbenchNodeIsVisuallyExposed(state, nodeID, nonOccludingNodeIDs)
+      selectWorkbenchNodeIsVisuallyExposed(
+        state,
+        nodeID,
+        visualOcclusionPresentation
+      )
     )
   );
   return null;
+}
+
+function createTestGenieController(
+  nodeVisibility: ReturnType<typeof createWorkbenchGenieNodeVisibilityStore>
+): WorkbenchGenieController {
+  return {
+    genieLayer: null,
+    isPendingMinimizedDockNode: () => false,
+    launchNodeFromAnchor: () => {},
+    minimizeNodeToAnchor: () => {},
+    nodeVisibility,
+    pendingMinimizedNode: null,
+    registerDockAnchor: () => {},
+    shouldAnimateMinimizedDockEnter: () => false
+  };
 }
 
 describe("WorkbenchHost", () => {
@@ -391,6 +423,8 @@ describe("WorkbenchHost", () => {
       nodeStack: [node.id]
     });
     const nodeVisibility = createWorkbenchGenieNodeVisibilityStore();
+    const nodePresentationTransitions =
+      createWorkbenchNodePresentationTransitionStore();
     const minimizeNodeToAnchor = vi.fn();
     const previousActEnvironment = (
       globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -407,6 +441,7 @@ describe("WorkbenchHost", () => {
               genieNodeVisibility={nodeVisibility}
               minimizeNodeToAnchor={minimizeNodeToAnchor}
               node={node}
+              nodePresentationTransitions={nodePresentationTransitions}
             >
               <div />
             </WorkbenchWindowFrame>
@@ -432,6 +467,7 @@ describe("WorkbenchHost", () => {
               genieNodeVisibility={nodeVisibility}
               minimizeNodeToAnchor={minimizeNodeToAnchor}
               node={node}
+              nodePresentationTransitions={nodePresentationTransitions}
               presentation={{
                 frameByNodeId: new Map([
                   [node.id, { x: 200, y: 160, width: 160, height: 120 }]
@@ -453,6 +489,7 @@ describe("WorkbenchHost", () => {
         root.unmount();
       });
       nodeVisibility.dispose();
+      nodePresentationTransitions.dispose();
       container.remove();
       (
         globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -685,6 +722,8 @@ describe("WorkbenchHost", () => {
       return <div data-window-header />;
     });
     const nodeVisibility = createWorkbenchGenieNodeVisibilityStore();
+    const nodePresentationTransitions =
+      createWorkbenchNodePresentationTransitionStore();
     const firstMinimize = vi.fn();
     const secondMinimize = vi.fn();
     const renderFrame = (
@@ -695,6 +734,7 @@ describe("WorkbenchHost", () => {
           genieNodeVisibility={nodeVisibility}
           minimizeNodeToAnchor={minimizeNodeToAnchor}
           node={node}
+          nodePresentationTransitions={nodePresentationTransitions}
           renderHeader={renderHeader}
           windowChromeMode="custom-header"
           windowHeaderPresentation={{
@@ -748,6 +788,7 @@ describe("WorkbenchHost", () => {
         root.unmount();
       });
       nodeVisibility.dispose();
+      nodePresentationTransitions.dispose();
       container.remove();
       (
         globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -780,6 +821,8 @@ describe("WorkbenchHost", () => {
       nodeStack: [nodeA.id, nodeB.id]
     });
     const nodeVisibility = createWorkbenchGenieNodeVisibilityStore();
+    const nodePresentationTransitions =
+      createWorkbenchNodePresentationTransitionStore();
     const renderActionsA = vi.fn(() => null);
     const renderActionsB = vi.fn(() => null);
     const visibilityA = vi.fn();
@@ -800,6 +843,7 @@ describe("WorkbenchHost", () => {
               genieNodeVisibility={nodeVisibility}
               minimizeNodeToAnchor={minimizeNodeToAnchor}
               node={nodeA}
+              nodePresentationTransitions={nodePresentationTransitions}
               renderActions={renderActionsA}
             >
               <WorkbenchWindowVisibilityProbe onRender={visibilityA} />
@@ -808,6 +852,7 @@ describe("WorkbenchHost", () => {
               genieNodeVisibility={nodeVisibility}
               minimizeNodeToAnchor={minimizeNodeToAnchor}
               node={nodeB}
+              nodePresentationTransitions={nodePresentationTransitions}
               renderActions={renderActionsB}
             >
               <WorkbenchWindowVisibilityProbe onRender={visibilityB} />
@@ -836,6 +881,7 @@ describe("WorkbenchHost", () => {
         root.unmount();
       });
       nodeVisibility.dispose();
+      nodePresentationTransitions.dispose();
       container.remove();
       (
         globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -867,6 +913,8 @@ describe("WorkbenchHost", () => {
       nodeStack: [coveredNode.id, coverNode.id]
     });
     const nodeVisibility = createWorkbenchGenieNodeVisibilityStore();
+    const nodePresentationTransitions =
+      createWorkbenchNodePresentationTransitionStore();
     const genie: WorkbenchGenieController = {
       genieLayer: null,
       isPendingMinimizedDockNode: () => false,
@@ -883,6 +931,7 @@ describe("WorkbenchHost", () => {
       <WorkbenchProvider controller={controller}>
         <WorkbenchNodeLayer
           genie={genieController}
+          nodePresentationTransitions={nodePresentationTransitions}
           renderNode={({ node }) => (
             <WorkbenchVisualExposureProbe
               nodeID={node.id}
@@ -933,7 +982,308 @@ describe("WorkbenchHost", () => {
         root.unmount();
       });
       nodeVisibility.dispose();
+      nodePresentationTransitions.dispose();
       container.remove();
+    }
+  });
+
+  it("keeps both windows exposed while the cover frame is transitioning", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const coveredNode: WorkbenchNode = {
+      data: null,
+      displayMode: "floating",
+      frame: { x: 8, y: 52, width: 320, height: 240 },
+      id: "covered",
+      isMinimized: false,
+      kind: "test",
+      restoreFrame: null,
+      title: "Covered"
+    };
+    const coverNode: WorkbenchNode = {
+      ...coveredNode,
+      frame: { x: 400, y: 0, width: 320, height: 240 },
+      id: "cover",
+      title: "Cover"
+    };
+    const controller = createWorkbenchController({
+      nodes: [coveredNode, coverNode],
+      nodeStack: [coveredNode.id, coverNode.id],
+      surfaceSize: { height: 600, width: 800 }
+    });
+    const nodeVisibility = createWorkbenchGenieNodeVisibilityStore();
+    const nodePresentationTransitions =
+      createWorkbenchNodePresentationTransitionStore();
+    const coveredVisibility = vi.fn();
+    const coverVisibility = vi.fn();
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchProvider controller={controller}>
+            <WorkbenchNodeLayer
+              genie={createTestGenieController(nodeVisibility)}
+              nodePresentationTransitions={nodePresentationTransitions}
+              renderNode={({ node }) => (
+                <WorkbenchVisualExposureProbe
+                  nodeID={node.id}
+                  onRender={
+                    node.id === coveredNode.id
+                      ? coveredVisibility
+                      : coverVisibility
+                  }
+                />
+              )}
+            />
+          </WorkbenchProvider>
+        );
+      });
+
+      expect(coveredVisibility).toHaveBeenLastCalledWith(true);
+      await act(async () => {
+        controller.commands.moveNode(coverNode.id, {
+          ...coverNode.frame,
+          x: 8
+        });
+      });
+      expect(
+        controller.getSnapshot().nodes.find((node) => node.id === coverNode.id)
+          ?.frame
+      ).toEqual(coveredNode.frame);
+      expect([...nodePresentationTransitions.getSnapshot()]).toEqual([
+        coverNode.id
+      ]);
+      expect(coveredVisibility).toHaveBeenLastCalledWith(true);
+      expect(coverVisibility).toHaveBeenLastCalledWith(true);
+
+      const coverShell = container.querySelector<HTMLElement>(
+        `[data-workbench-window-id="${coverNode.id}"]`
+      );
+      await act(async () => {
+        dispatchWorkbenchTransition(coverShell, "transitionrun", "translate");
+        dispatchWorkbenchTransition(coverShell, "transitionrun", "width");
+      });
+      await act(async () => {
+        dispatchWorkbenchTransition(coverShell, "transitionend", "translate");
+      });
+      expect([...nodePresentationTransitions.getSnapshot()]).toEqual([
+        coverNode.id
+      ]);
+      expect(coveredVisibility).toHaveBeenLastCalledWith(true);
+      await act(async () => {
+        dispatchWorkbenchTransition(coverShell, "transitionend", "width");
+      });
+      expect([...nodePresentationTransitions.getSnapshot()]).toEqual([]);
+      expect(coveredVisibility).toHaveBeenLastCalledWith(false);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      nodePresentationTransitions.dispose();
+      nodeVisibility.dispose();
+      container.remove();
+    }
+  });
+
+  it("keeps covered windows exposed through onboarding entry", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const coveredNode: WorkbenchNode = {
+      data: null,
+      displayMode: "floating",
+      frame: { x: 0, y: 0, width: 320, height: 240 },
+      id: "covered",
+      isMinimized: false,
+      kind: "test",
+      restoreFrame: null,
+      title: "Covered"
+    };
+    const coverNode: WorkbenchNode = {
+      ...coveredNode,
+      data: { launchSource: "onboarding-auto" },
+      id: "cover",
+      title: "Cover"
+    };
+    const controller = createWorkbenchController({
+      nodes: [coveredNode, coverNode],
+      nodeStack: [coveredNode.id, coverNode.id],
+      surfaceSize: { height: 600, width: 800 }
+    });
+    const nodeVisibility = createWorkbenchGenieNodeVisibilityStore();
+    const nodePresentationTransitions =
+      createWorkbenchNodePresentationTransitionStore();
+    const coveredVisibility = vi.fn();
+    const coverVisibility = vi.fn();
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchProvider controller={controller}>
+            <WorkbenchNodeLayer
+              genie={createTestGenieController(nodeVisibility)}
+              nodePresentationTransitions={nodePresentationTransitions}
+              renderNode={({ node }) => (
+                <WorkbenchVisualExposureProbe
+                  nodeID={node.id}
+                  onRender={
+                    node.id === coveredNode.id
+                      ? coveredVisibility
+                      : coverVisibility
+                  }
+                />
+              )}
+            />
+          </WorkbenchProvider>
+        );
+      });
+
+      expect(coveredVisibility).toHaveBeenLastCalledWith(true);
+      expect(coverVisibility).toHaveBeenLastCalledWith(true);
+
+      const entryContent = container.querySelector<HTMLElement>(
+        `[data-workbench-window-id="${coverNode.id}"] > .workbench-window-shell__content`
+      );
+      const animationEnd = new Event("animationend", { bubbles: true });
+      Object.defineProperty(animationEnd, "animationName", {
+        value: "workbench-shell-enter"
+      });
+      await act(async () => {
+        entryContent?.dispatchEvent(animationEnd);
+      });
+      expect(coveredVisibility).toHaveBeenLastCalledWith(false);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      nodePresentationTransitions.dispose();
+      nodeVisibility.dispose();
+      container.remove();
+    }
+  });
+
+  it("keeps a scale-restoring window non-occluding until its animation settles", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const nodeElement = document.createElement("section");
+    nodeElement.dataset.workbenchWindowId = "node-1";
+    document.body.append(nodeElement);
+    const dockElement = document.createElement("button");
+    document.body.append(dockElement);
+    const root = createRoot(container);
+    const node: WorkbenchNode = {
+      data: null,
+      displayMode: "floating",
+      frame: { x: 8, y: 52, width: 320, height: 240 },
+      id: "node-1",
+      isMinimized: true,
+      kind: "test",
+      restoreFrame: null,
+      title: "Node"
+    };
+    const controller = createWorkbenchController({
+      nodes: [node],
+      nodeStack: [node.id],
+      surfaceSize: { height: 600, width: 800 }
+    });
+    const nodePresentationTransitions =
+      createWorkbenchNodePresentationTransitionStore();
+    const renders: WorkbenchGenieController[] = [];
+    const animationFrameCallbacks: FrameRequestCallback[] = [];
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        animationFrameCallbacks.push(callback);
+        return animationFrameCallbacks.length;
+      });
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation(() => {});
+    const canvasContextSpy = vi
+      .spyOn(HTMLCanvasElement.prototype, "getContext")
+      .mockImplementation(() => null);
+    vi.spyOn(nodeElement, "getBoundingClientRect").mockReturnValue(
+      testDOMRect(80, 80, 320, 240)
+    );
+    vi.spyOn(dockElement, "getBoundingClientRect").mockReturnValue(
+      testDOMRect(20, 520, 44, 44)
+    );
+    let settleAnimation: (() => void) | null = null;
+    const finished = new Promise<void>((resolve) => {
+      settleAnimation = resolve;
+    });
+    const animation = {
+      cancel: vi.fn(),
+      finished
+    } as unknown as Animation;
+    const animate = vi.fn(() => animation);
+    Object.defineProperty(nodeElement, "animate", {
+      configurable: true,
+      value: animate
+    });
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    const flushAnimationFrame = async () => {
+      const callbacks = animationFrameCallbacks.splice(0);
+      for (const callback of callbacks) {
+        callback(performance.now());
+      }
+      await Promise.resolve();
+      await Promise.resolve();
+    };
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchGenieIdentityProbe
+            controller={controller}
+            minimizeAnimation="scale"
+            nodePresentationTransitions={nodePresentationTransitions}
+            onRender={(genie) => renders.push(genie)}
+          />
+        );
+      });
+      const genie = renders.at(-1);
+      genie?.registerDockAnchor("dock-node-1", dockElement);
+
+      await act(async () => {
+        genie?.launchNodeFromAnchor("dock-node-1", node.id, () => {
+          controller.commands.restoreNode(node.id);
+          return node.id;
+        });
+        await flushAnimationFrame();
+        await flushAnimationFrame();
+      });
+
+      expect(animate).toHaveBeenCalledOnce();
+      expect(genie?.nodeVisibility.getSnapshot(node.id)).toBe(false);
+      expect([...nodePresentationTransitions.getSnapshot()]).toEqual([node.id]);
+
+      await act(async () => {
+        settleAnimation?.();
+        await finished;
+        await Promise.resolve();
+      });
+      expect([...nodePresentationTransitions.getSnapshot()]).toEqual([]);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+      canvasContextSpy.mockRestore();
+      nodePresentationTransitions.dispose();
+      dockElement.remove();
+      nodeElement.remove();
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
     }
   });
 
@@ -942,6 +1292,8 @@ describe("WorkbenchHost", () => {
     document.body.append(container);
     const root = createRoot(container);
     const controller = createWorkbenchController();
+    const nodePresentationTransitions =
+      createWorkbenchNodePresentationTransitionStore();
     const firstLog = vi.fn();
     const secondLog = vi.fn();
     const firstDiagnostics: WorkbenchDebugDiagnostics = {
@@ -966,6 +1318,7 @@ describe("WorkbenchHost", () => {
           <WorkbenchGenieIdentityProbe
             controller={controller}
             debugDiagnostics={firstDiagnostics}
+            nodePresentationTransitions={nodePresentationTransitions}
             onRender={(genie) => renders.push(genie)}
           />
         );
@@ -975,6 +1328,7 @@ describe("WorkbenchHost", () => {
           <WorkbenchGenieIdentityProbe
             controller={controller}
             debugDiagnostics={secondDiagnostics}
+            nodePresentationTransitions={nodePresentationTransitions}
             onRender={(genie) => renders.push(genie)}
           />
         );
@@ -997,6 +1351,7 @@ describe("WorkbenchHost", () => {
       await act(async () => {
         root.unmount();
       });
+      nodePresentationTransitions.dispose();
       container.remove();
       (
         globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -1082,6 +1437,37 @@ describe("WorkbenchHost", () => {
     }
   });
 });
+
+function testDOMRect(
+  x: number,
+  y: number,
+  width: number,
+  height: number
+): DOMRect {
+  return {
+    bottom: y + height,
+    height,
+    left: x,
+    right: x + width,
+    top: y,
+    width,
+    x,
+    y,
+    toJSON() {
+      return {};
+    }
+  };
+}
+
+function dispatchWorkbenchTransition(
+  element: HTMLElement | null,
+  type: "transitionend" | "transitionrun",
+  propertyName: string
+): void {
+  const event = new Event(type, { bubbles: true });
+  Object.defineProperty(event, "propertyName", { value: propertyName });
+  element?.dispatchEvent(event);
+}
 
 function createSnapshotRepository(): WorkbenchHostSnapshotRepository {
   return {

--- a/packages/workbench/surface/src/index.ts
+++ b/packages/workbench/surface/src/index.ts
@@ -105,12 +105,13 @@ export {
   type WorkbenchDockComponentPreviewFrameProps
 } from "./react/WorkbenchDockComponentPreviewFrame.tsx";
 export { useWorkbenchSelector } from "./react/hooks/useWorkbenchSelector.ts";
-export { useWorkbenchNonOccludingNodeIDs } from "./react/WorkbenchWindowFrame.tsx";
+export { useWorkbenchVisualOcclusionPresentation } from "./react/WorkbenchWindowFrame.tsx";
 export { getWorkbenchLayoutFrame } from "./core/geometry.ts";
 export { selectFocusedWorkbenchNode } from "./core/selectors.ts";
 export {
   selectVisuallyExposedWorkbenchNodeIDs,
-  selectWorkbenchNodeIsVisuallyExposed
+  selectWorkbenchNodeIsVisuallyExposed,
+  type WorkbenchVisualOcclusionPresentation
 } from "./core/visualOcclusion.ts";
 export {
   canCreateNewWindow,

--- a/packages/workbench/surface/src/index.ts
+++ b/packages/workbench/surface/src/index.ts
@@ -105,6 +105,7 @@ export {
   type WorkbenchDockComponentPreviewFrameProps
 } from "./react/WorkbenchDockComponentPreviewFrame.tsx";
 export { useWorkbenchSelector } from "./react/hooks/useWorkbenchSelector.ts";
+export { useWorkbenchNonOccludingNodeIDs } from "./react/WorkbenchWindowFrame.tsx";
 export { getWorkbenchLayoutFrame } from "./core/geometry.ts";
 export { selectFocusedWorkbenchNode } from "./core/selectors.ts";
 export {

--- a/packages/workbench/surface/src/react/WorkbenchNodeLayer.tsx
+++ b/packages/workbench/surface/src/react/WorkbenchNodeLayer.tsx
@@ -1,4 +1,4 @@
-import { Fragment, memo, useMemo } from "react";
+import { memo, useMemo, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import {
   selectFocusedWorkbenchNode,
@@ -22,7 +22,10 @@ import type {
 import type { WorkbenchGenieController } from "./useWorkbenchGenieAnimation.tsx";
 import type { WorkbenchGenieNodeVisibility } from "./genieNodeVisibility.ts";
 import { useWorkbenchController } from "./WorkbenchProvider.tsx";
-import { WorkbenchWindowFrame } from "./WorkbenchWindowFrame.tsx";
+import {
+  WorkbenchNonOccludingNodeIDsProvider,
+  WorkbenchWindowFrame
+} from "./WorkbenchWindowFrame.tsx";
 import { useWorkbenchSelector } from "./hooks/useWorkbenchSelector.ts";
 import { createWorkbenchNodeLayerNodeIDsSelector } from "./renderedNodeIds.ts";
 import type { WorkbenchWindowChromeI18nRuntime } from "./workbenchWindowI18n.ts";
@@ -79,6 +82,21 @@ export function WorkbenchNodeLayer<TData>({
   const { defaultNodeIDs, dialogPopoverNodeIDs } = useWorkbenchSelector(
     selectNodeLayerNodeIDs
   );
+  const genieHiddenNodeIDs = useSyncExternalStore(
+    genie.nodeVisibility.subscribeAll,
+    genie.nodeVisibility.getHiddenNodeIDsSnapshot,
+    genie.nodeVisibility.getHiddenNodeIDsSnapshot
+  );
+  const pendingMinimizedNodeID = genie.pendingMinimizedNode?.id ?? null;
+  const nonOccludingNodeIDs = useMemo(() => {
+    if (
+      pendingMinimizedNodeID === null ||
+      genieHiddenNodeIDs.has(pendingMinimizedNodeID)
+    ) {
+      return genieHiddenNodeIDs;
+    }
+    return new Set([...genieHiddenNodeIDs, pendingMinimizedNodeID]);
+  }, [genieHiddenNodeIDs, pendingMinimizedNodeID]);
   const snapPreviewRect = useWorkbenchSelector(selectWorkbenchSnapPreviewRect);
   const presentationInteraction =
     interactive && presentation?.mode === "mission-control"
@@ -106,7 +124,7 @@ export function WorkbenchNodeLayer<TData>({
     ) : null;
 
   return (
-    <Fragment>
+    <WorkbenchNonOccludingNodeIDsProvider nodeIDs={nonOccludingNodeIDs}>
       <MemoizedWorkbenchNodeLayerGroup
         className="workbench-node-layer"
         edgeSnapEnabled={edgeSnapEnabled}
@@ -131,7 +149,7 @@ export function WorkbenchNodeLayer<TData>({
         : dialogPopoverLayer
           ? createPortal(dialogPopoverLayer, document.body)
           : null}
-    </Fragment>
+    </WorkbenchNonOccludingNodeIDsProvider>
   );
 }
 

--- a/packages/workbench/surface/src/react/WorkbenchNodeLayer.tsx
+++ b/packages/workbench/surface/src/react/WorkbenchNodeLayer.tsx
@@ -21,9 +21,10 @@ import type {
 } from "./types.ts";
 import type { WorkbenchGenieController } from "./useWorkbenchGenieAnimation.tsx";
 import type { WorkbenchGenieNodeVisibility } from "./genieNodeVisibility.ts";
+import type { WorkbenchNodePresentationTransitionStore } from "./nodePresentationTransitions.ts";
 import { useWorkbenchController } from "./WorkbenchProvider.tsx";
 import {
-  WorkbenchNonOccludingNodeIDsProvider,
+  WorkbenchVisualOcclusionPresentationProvider,
   WorkbenchWindowFrame
 } from "./WorkbenchWindowFrame.tsx";
 import { useWorkbenchSelector } from "./hooks/useWorkbenchSelector.ts";
@@ -35,6 +36,7 @@ export interface WorkbenchNodeLayerProps<TData = unknown> {
   genie: WorkbenchGenieController<TData>;
   edgeSnapEnabled?: boolean;
   interactive?: boolean;
+  nodePresentationTransitions: WorkbenchNodePresentationTransitionStore;
   presentation?: WorkbenchSurfacePresentation | null;
   renderNode: WorkbenchRenderNode<TData>;
   shouldKeepMinimizedNodeMounted?: WorkbenchKeepMinimizedNodeMounted<TData>;
@@ -54,6 +56,7 @@ export function WorkbenchNodeLayer<TData>({
   genie,
   edgeSnapEnabled = false,
   interactive = true,
+  nodePresentationTransitions,
   presentation,
   renderNode,
   shouldKeepMinimizedNodeMounted,
@@ -88,7 +91,7 @@ export function WorkbenchNodeLayer<TData>({
     genie.nodeVisibility.getHiddenNodeIDsSnapshot
   );
   const pendingMinimizedNodeID = genie.pendingMinimizedNode?.id ?? null;
-  const nonOccludingNodeIDs = useMemo(() => {
+  const visuallyHiddenNodeIDs = useMemo(() => {
     if (
       pendingMinimizedNodeID === null ||
       genieHiddenNodeIDs.has(pendingMinimizedNodeID)
@@ -97,6 +100,28 @@ export function WorkbenchNodeLayer<TData>({
     }
     return new Set([...genieHiddenNodeIDs, pendingMinimizedNodeID]);
   }, [genieHiddenNodeIDs, pendingMinimizedNodeID]);
+  const presentationTransitionNodeIDs = useSyncExternalStore(
+    nodePresentationTransitions.subscribe,
+    nodePresentationTransitions.getSnapshot,
+    nodePresentationTransitions.getSnapshot
+  );
+  const nonOccludingNodeIDs = useMemo(() => {
+    if (presentationTransitionNodeIDs.size === 0) {
+      return visuallyHiddenNodeIDs;
+    }
+    return new Set([
+      ...visuallyHiddenNodeIDs,
+      ...presentationTransitionNodeIDs
+    ]);
+  }, [presentationTransitionNodeIDs, visuallyHiddenNodeIDs]);
+  const visualOcclusionPresentation = useMemo(
+    () => ({
+      hiddenNodeIDs: visuallyHiddenNodeIDs,
+      nonOccludingNodeIDs,
+      topLayerNodeIDs: dialogPopoverNodeIDs
+    }),
+    [dialogPopoverNodeIDs, nonOccludingNodeIDs, visuallyHiddenNodeIDs]
+  );
   const snapPreviewRect = useWorkbenchSelector(selectWorkbenchSnapPreviewRect);
   const presentationInteraction =
     interactive && presentation?.mode === "mission-control"
@@ -111,6 +136,7 @@ export function WorkbenchNodeLayer<TData>({
         genieNodeVisibility={genie.nodeVisibility}
         interactive={interactive}
         minimizeNodeToAnchor={genie.minimizeNodeToAnchor}
+        nodePresentationTransitions={nodePresentationTransitions}
         nodeIDs={dialogPopoverNodeIDs}
         presentation={presentation}
         renderNode={renderNode}
@@ -124,7 +150,9 @@ export function WorkbenchNodeLayer<TData>({
     ) : null;
 
   return (
-    <WorkbenchNonOccludingNodeIDsProvider nodeIDs={nonOccludingNodeIDs}>
+    <WorkbenchVisualOcclusionPresentationProvider
+      presentation={visualOcclusionPresentation}
+    >
       <MemoizedWorkbenchNodeLayerGroup
         className="workbench-node-layer"
         edgeSnapEnabled={edgeSnapEnabled}
@@ -132,6 +160,7 @@ export function WorkbenchNodeLayer<TData>({
         genieNodeVisibility={genie.nodeVisibility}
         interactive={interactive}
         minimizeNodeToAnchor={genie.minimizeNodeToAnchor}
+        nodePresentationTransitions={nodePresentationTransitions}
         nodeIDs={defaultNodeIDs}
         onBackdropPress={presentationInteraction?.onBackdropPress}
         presentation={presentation}
@@ -149,7 +178,7 @@ export function WorkbenchNodeLayer<TData>({
         : dialogPopoverLayer
           ? createPortal(dialogPopoverLayer, document.body)
           : null}
-    </WorkbenchNonOccludingNodeIDsProvider>
+    </WorkbenchVisualOcclusionPresentationProvider>
   );
 }
 
@@ -160,6 +189,7 @@ interface WorkbenchNodeLayerGroupProps<TData = unknown> {
   genieNodeVisibility: WorkbenchGenieNodeVisibility;
   interactive: boolean;
   minimizeNodeToAnchor: WorkbenchGenieController<TData>["minimizeNodeToAnchor"];
+  nodePresentationTransitions: WorkbenchNodePresentationTransitionStore;
   nodeIDs: readonly string[];
   onBackdropPress?: () => void;
   presentation?: WorkbenchSurfacePresentation | null;
@@ -182,6 +212,7 @@ function WorkbenchNodeLayerGroup<TData>({
   genieNodeVisibility,
   interactive,
   minimizeNodeToAnchor,
+  nodePresentationTransitions,
   nodeIDs,
   onBackdropPress,
   presentation,
@@ -228,6 +259,7 @@ function WorkbenchNodeLayerGroup<TData>({
           edgeSnapEnabled={edgeSnapEnabled}
           interactive={interactive}
           minimizeNodeToAnchor={minimizeNodeToAnchor}
+          nodePresentationTransitions={nodePresentationTransitions}
           nodeID={nodeID}
           presentation={presentation}
           renderNode={renderNode}
@@ -253,6 +285,7 @@ interface WorkbenchNodeLayerItemProps<TData = unknown> {
   edgeSnapEnabled: boolean;
   interactive: boolean;
   minimizeNodeToAnchor: WorkbenchGenieController<TData>["minimizeNodeToAnchor"];
+  nodePresentationTransitions: WorkbenchNodePresentationTransitionStore;
   nodeID: string;
   presentation?: WorkbenchSurfacePresentation | null;
   renderNode: WorkbenchRenderNode<TData>;
@@ -272,6 +305,7 @@ function WorkbenchNodeLayerItem<TData>({
   edgeSnapEnabled,
   interactive,
   minimizeNodeToAnchor,
+  nodePresentationTransitions,
   nodeID,
   presentation,
   renderNode,
@@ -312,6 +346,7 @@ function WorkbenchNodeLayerItem<TData>({
       node={node}
       genieNodeVisibility={genieNodeVisibility}
       minimizeNodeToAnchor={minimizeNodeToAnchor}
+      nodePresentationTransitions={nodePresentationTransitions}
       resolveWindowZIndex={resolveWindowZIndex}
       fullscreenHeaderMode={fullscreenHeaderMode?.({
         controller,

--- a/packages/workbench/surface/src/react/WorkbenchSurface.tsx
+++ b/packages/workbench/surface/src/react/WorkbenchSurface.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   type CSSProperties,
   type ReactNode
 } from "react";
@@ -47,6 +48,7 @@ import type {
   WorkbenchNodePreviewImageCapture,
   WorkbenchNodePreviewImagesCapture
 } from "./nodePreviewCapture.ts";
+import { createWorkbenchNodePresentationTransitionStore } from "./nodePresentationTransitions.ts";
 
 export interface WorkbenchSurfaceProps<TData = unknown> {
   captureNodePreviewImage?: WorkbenchNodePreviewImageCapture<TData>;
@@ -225,6 +227,10 @@ function WorkbenchSurfaceInner<TData>({
     [controller]
   );
   const ref = useWorkbenchSurfaceSize<HTMLDivElement>(onSizeChange);
+  const nodePresentationTransitions = useMemo(
+    createWorkbenchNodePresentationTransitionStore,
+    []
+  );
   const genie = useWorkbenchGenieAnimation({
     captureNodePreviewImage,
     captureNodePreviewImages,
@@ -232,11 +238,16 @@ function WorkbenchSurfaceInner<TData>({
     debugDiagnostics,
     dockPreviewCache,
     minimizeAnimation,
+    nodePresentationTransitions,
     renderNodeGeniePreview,
     resolveDockAnchorKey,
     resolveDockPreviewCacheKey,
     shouldCaptureNodePreviewImage
   });
+  useEffect(
+    () => () => nodePresentationTransitions.dispose(),
+    [nodePresentationTransitions]
+  );
   useWorkbenchShortcuts<TData>({
     enabled: (shortcutsEnabled ?? true) && interactive,
     windowManagementShortcutPreset: windowManagement?.shortcutPreset ?? null
@@ -282,6 +293,7 @@ function WorkbenchSurfaceInner<TData>({
       <WorkbenchNodeLayer
         genie={genie}
         interactive={interactive}
+        nodePresentationTransitions={nodePresentationTransitions}
         presentation={presentation}
         renderNode={renderNode}
         edgeSnapEnabled={windowManagement?.edgeSnapEnabled === true}

--- a/packages/workbench/surface/src/react/WorkbenchWindowFrame.tsx
+++ b/packages/workbench/surface/src/react/WorkbenchWindowFrame.tsx
@@ -37,7 +37,9 @@ import type {
 } from "./types.ts";
 import type { WorkbenchGenieController } from "./useWorkbenchGenieAnimation.tsx";
 import type { WorkbenchGenieNodeVisibility } from "./genieNodeVisibility.ts";
+import type { WorkbenchNodePresentationTransitionStore } from "./nodePresentationTransitions.ts";
 import { resolveWorkbenchWindowHeader } from "./windowHeader.ts";
+import type { WorkbenchVisualOcclusionPresentation } from "../core/visualOcclusion.ts";
 
 export interface WorkbenchWindowFrameProps<TData = unknown> {
   children: ReactNode;
@@ -47,6 +49,7 @@ export interface WorkbenchWindowFrameProps<TData = unknown> {
   interactive?: boolean;
   minimizeNodeToAnchor: WorkbenchGenieController["minimizeNodeToAnchor"];
   node: WorkbenchNode<TData>;
+  nodePresentationTransitions: WorkbenchNodePresentationTransitionStore;
   presentation?: WorkbenchSurfacePresentation | null;
   renderActions?: WorkbenchRenderWindowActions<TData>;
   renderHeader?: WorkbenchRenderWindowHeader<TData>;
@@ -75,30 +78,36 @@ const defaultWindowChromeI18n = createWorkbenchWindowChromeI18nRuntime(
 );
 
 const WorkbenchWindowPresentationVisibilityContext = createContext(true);
-const noNonOccludingWorkbenchNodeIDs: ReadonlySet<string> = new Set();
-const WorkbenchNonOccludingNodeIDsContext = createContext(
-  noNonOccludingWorkbenchNodeIDs
+const noWorkbenchNodeIDs: ReadonlySet<string> = new Set();
+const defaultWorkbenchVisualOcclusionPresentation: WorkbenchVisualOcclusionPresentation =
+  {
+    hiddenNodeIDs: noWorkbenchNodeIDs,
+    nonOccludingNodeIDs: noWorkbenchNodeIDs,
+    topLayerNodeIDs: []
+  };
+const WorkbenchVisualOcclusionPresentationContext = createContext(
+  defaultWorkbenchVisualOcclusionPresentation
 );
 
 export function useWorkbenchWindowPresentationVisibility(): boolean {
   return useContext(WorkbenchWindowPresentationVisibilityContext);
 }
 
-export function useWorkbenchNonOccludingNodeIDs(): ReadonlySet<string> {
-  return useContext(WorkbenchNonOccludingNodeIDsContext);
+export function useWorkbenchVisualOcclusionPresentation(): WorkbenchVisualOcclusionPresentation {
+  return useContext(WorkbenchVisualOcclusionPresentationContext);
 }
 
-export function WorkbenchNonOccludingNodeIDsProvider({
+export function WorkbenchVisualOcclusionPresentationProvider({
   children,
-  nodeIDs
+  presentation
 }: {
   children: ReactNode;
-  nodeIDs: ReadonlySet<string>;
+  presentation: WorkbenchVisualOcclusionPresentation;
 }) {
   return (
-    <WorkbenchNonOccludingNodeIDsContext.Provider value={nodeIDs}>
+    <WorkbenchVisualOcclusionPresentationContext.Provider value={presentation}>
       {children}
-    </WorkbenchNonOccludingNodeIDsContext.Provider>
+    </WorkbenchVisualOcclusionPresentationContext.Provider>
   );
 }
 
@@ -128,6 +137,32 @@ function resolveWorkbenchNodeTypeId(data: unknown): string | undefined {
   return undefined;
 }
 
+function workbenchFramesEqual(
+  left: WorkbenchNode["frame"],
+  right: WorkbenchNode["frame"]
+): boolean {
+  return (
+    left.x === right.x &&
+    left.y === right.y &&
+    left.width === right.width &&
+    left.height === right.height
+  );
+}
+
+function isWorkbenchFrameTransitionProperty(propertyName: string): boolean {
+  return (
+    propertyName === "translate" ||
+    propertyName === "width" ||
+    propertyName === "height"
+  );
+}
+
+function shouldReduceWorkbenchMotion(): boolean {
+  return (
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true
+  );
+}
+
 export function WorkbenchWindowFrame<TData>({
   children,
   edgeSnapEnabled = false,
@@ -136,6 +171,7 @@ export function WorkbenchWindowFrame<TData>({
   interactive = true,
   minimizeNodeToAnchor: minimizeNodeToAnchorProp,
   node,
+  nodePresentationTransitions,
   presentation = null,
   renderActions,
   renderHeader,
@@ -144,6 +180,7 @@ export function WorkbenchWindowFrame<TData>({
   windowHeaderPresentation,
   windowChromeI18n
 }: WorkbenchWindowFrameProps<TData>) {
+  const shellRef = useRef<HTMLElement | null>(null);
   const controller = useWorkbenchController<TData>();
   const baseZIndex = useWorkbenchSelector((state) =>
     selectWorkbenchNodeZIndex(state, node.id)
@@ -183,6 +220,101 @@ export function WorkbenchWindowFrame<TData>({
     readGenieVisibility,
     readGenieVisibility
   );
+  const launchSource = resolveWorkbenchNodeLaunchSource(node.data);
+  const presentationMode = presentation?.mode ?? null;
+  const previousFrameRef = useRef(node.frame);
+  useLayoutEffect(() => {
+    const previousFrame = previousFrameRef.current;
+    previousFrameRef.current = node.frame;
+    if (workbenchFramesEqual(previousFrame, node.frame)) {
+      return;
+    }
+    nodePresentationTransitions.setActive(
+      node.id,
+      "frame",
+      !hiddenMounted &&
+        !isGenieHidden &&
+        !isDragging &&
+        !isResizing &&
+        presentationMode === null
+    );
+  }, [
+    hiddenMounted,
+    isDragging,
+    isGenieHidden,
+    isResizing,
+    node.frame.height,
+    node.frame.width,
+    node.frame.x,
+    node.frame.y,
+    node.id,
+    nodePresentationTransitions,
+    presentationMode
+  ]);
+  useLayoutEffect(() => {
+    const shell = shellRef.current;
+    if (!shell) {
+      return;
+    }
+    const activeFrameProperties = new Set<string>();
+    const handleTransitionEvent = (event: TransitionEvent) => {
+      if (
+        event.target !== shell ||
+        !isWorkbenchFrameTransitionProperty(event.propertyName)
+      ) {
+        return;
+      }
+      if (event.type === "transitionrun") {
+        if (
+          shell.dataset.windowDragState !== "dragging" &&
+          shell.dataset.windowResizeState !== "resizing" &&
+          shell.dataset.presentationMode === "default"
+        ) {
+          activeFrameProperties.add(event.propertyName);
+          nodePresentationTransitions.setActive(node.id, "frame", true);
+        }
+        return;
+      }
+      activeFrameProperties.delete(event.propertyName);
+      nodePresentationTransitions.setActive(
+        node.id,
+        "frame",
+        activeFrameProperties.size > 0
+      );
+    };
+    const handleAnimationEvent = (event: AnimationEvent) => {
+      if (
+        event.animationName !== "workbench-shell-enter" ||
+        !(event.target instanceof HTMLElement) ||
+        event.target.parentElement !== shell
+      ) {
+        return;
+      }
+      nodePresentationTransitions.setActive(
+        node.id,
+        "onboarding-entry",
+        event.type === "animationstart"
+      );
+    };
+    shell.addEventListener("transitionrun", handleTransitionEvent);
+    shell.addEventListener("transitionend", handleTransitionEvent);
+    shell.addEventListener("transitioncancel", handleTransitionEvent);
+    shell.addEventListener("animationstart", handleAnimationEvent);
+    shell.addEventListener("animationend", handleAnimationEvent);
+    shell.addEventListener("animationcancel", handleAnimationEvent);
+    if (launchSource === "onboarding-auto" && !shouldReduceWorkbenchMotion()) {
+      nodePresentationTransitions.setActive(node.id, "onboarding-entry", true);
+    }
+    return () => {
+      shell.removeEventListener("transitionrun", handleTransitionEvent);
+      shell.removeEventListener("transitionend", handleTransitionEvent);
+      shell.removeEventListener("transitioncancel", handleTransitionEvent);
+      shell.removeEventListener("animationstart", handleAnimationEvent);
+      shell.removeEventListener("animationend", handleAnimationEvent);
+      shell.removeEventListener("animationcancel", handleAnimationEvent);
+      nodePresentationTransitions.clearNode(node.id);
+    };
+  }, [launchSource, node.id, nodePresentationTransitions]);
   const minimizeNodeToAnchorRef = useRef(minimizeNodeToAnchorProp);
   useLayoutEffect(() => {
     minimizeNodeToAnchorRef.current = minimizeNodeToAnchorProp;
@@ -256,7 +388,6 @@ export function WorkbenchWindowFrame<TData>({
     resolvedHeader.windowChromeMode === "custom-header";
   const resolvedFullscreenHeaderMode: WorkbenchFullscreenHeaderMode =
     "persistent";
-  const presentationMode = presentation?.mode ?? null;
   const presentationFrame = presentation?.frameByNodeId.get(node.id) ?? null;
   const isPresentationHidden =
     presentationMode === "mission-control" &&
@@ -303,12 +434,13 @@ export function WorkbenchWindowFrame<TData>({
 
   return (
     <section
+      ref={shellRef}
       aria-hidden={hiddenMounted || isPresentationHidden ? true : undefined}
       className="workbench-window-shell"
       data-focused={isFocused ? "true" : "false"}
       data-display-mode={node.displayMode}
       data-genie-state={isGenieHidden ? "hidden" : "visible"}
-      data-launch-source={resolveWorkbenchNodeLaunchSource(node.data)}
+      data-launch-source={launchSource}
       data-minimized-mount={hiddenMounted ? "hidden" : "visible"}
       data-presentation-mode={presentationMode ?? "default"}
       data-presentation-visibility={isPresentationHidden ? "hidden" : "visible"}

--- a/packages/workbench/surface/src/react/WorkbenchWindowFrame.tsx
+++ b/packages/workbench/surface/src/react/WorkbenchWindowFrame.tsx
@@ -75,9 +75,31 @@ const defaultWindowChromeI18n = createWorkbenchWindowChromeI18nRuntime(
 );
 
 const WorkbenchWindowPresentationVisibilityContext = createContext(true);
+const noNonOccludingWorkbenchNodeIDs: ReadonlySet<string> = new Set();
+const WorkbenchNonOccludingNodeIDsContext = createContext(
+  noNonOccludingWorkbenchNodeIDs
+);
 
 export function useWorkbenchWindowPresentationVisibility(): boolean {
   return useContext(WorkbenchWindowPresentationVisibilityContext);
+}
+
+export function useWorkbenchNonOccludingNodeIDs(): ReadonlySet<string> {
+  return useContext(WorkbenchNonOccludingNodeIDsContext);
+}
+
+export function WorkbenchNonOccludingNodeIDsProvider({
+  children,
+  nodeIDs
+}: {
+  children: ReactNode;
+  nodeIDs: ReadonlySet<string>;
+}) {
+  return (
+    <WorkbenchNonOccludingNodeIDsContext.Provider value={nodeIDs}>
+      {children}
+    </WorkbenchNonOccludingNodeIDsContext.Provider>
+  );
 }
 
 function resolveWorkbenchNodeLaunchSource(data: unknown): string | undefined {

--- a/packages/workbench/surface/src/react/genieNodeVisibility.test.ts
+++ b/packages/workbench/surface/src/react/genieNodeVisibility.test.ts
@@ -26,6 +26,31 @@ test("notifies only the window whose genie visibility changed", () => {
   store.dispose();
 });
 
+test("publishes an immutable snapshot for transient occlusion", () => {
+  const store = createWorkbenchGenieNodeVisibilityStore();
+  const initialSnapshot = store.getHiddenNodeIDsSnapshot();
+  let allNotifications = 0;
+  const unsubscribe = store.subscribeAll(() => {
+    allNotifications += 1;
+  });
+
+  store.setHidden("node-a", true);
+  const hiddenSnapshot = store.getHiddenNodeIDsSnapshot();
+  store.setHidden("node-a", true);
+
+  assert.notStrictEqual(hiddenSnapshot, initialSnapshot);
+  assert.equal(initialSnapshot.has("node-a"), false);
+  assert.equal(hiddenSnapshot.has("node-a"), true);
+  assert.equal(allNotifications, 1);
+
+  store.setHidden("node-a", false);
+
+  assert.equal(store.getHiddenNodeIDsSnapshot().has("node-a"), false);
+  assert.equal(allNotifications, 2);
+  unsubscribe();
+  store.dispose();
+});
+
 test("lets another node animation reveal its own hidden node", () => {
   const store = createWorkbenchGenieNodeVisibilityStore();
   const tokenA = store.hide("node-a");

--- a/packages/workbench/surface/src/react/genieNodeVisibility.ts
+++ b/packages/workbench/surface/src/react/genieNodeVisibility.ts
@@ -1,5 +1,7 @@
 export interface WorkbenchGenieNodeVisibility {
+  getHiddenNodeIDsSnapshot(): ReadonlySet<string>;
   getSnapshot(nodeID: string): boolean;
+  subscribeAll(listener: () => void): () => void;
   subscribe(nodeID: string, listener: () => void): () => void;
 }
 
@@ -13,23 +15,29 @@ export interface WorkbenchGenieNodeVisibilityStore extends WorkbenchGenieNodeVis
 export type WorkbenchGenieNodeVisibilityToken = symbol;
 
 export function createWorkbenchGenieNodeVisibilityStore(): WorkbenchGenieNodeVisibilityStore {
-  const hiddenNodeIDs = new Set<string>();
+  let hiddenNodeIDs: ReadonlySet<string> = new Set();
   const hiddenTokenByNodeID = new Map<
     string,
     WorkbenchGenieNodeVisibilityToken
   >();
   const listenersByNodeID = new Map<string, Set<() => void>>();
+  const allListeners = new Set<() => void>();
 
   const setHidden = (nodeID: string, hidden: boolean): void => {
     if (hiddenNodeIDs.has(nodeID) === hidden) {
       return;
     }
+    const nextHiddenNodeIDs = new Set(hiddenNodeIDs);
     if (hidden) {
-      hiddenNodeIDs.add(nodeID);
+      nextHiddenNodeIDs.add(nodeID);
     } else {
-      hiddenNodeIDs.delete(nodeID);
+      nextHiddenNodeIDs.delete(nodeID);
     }
+    hiddenNodeIDs = nextHiddenNodeIDs;
     for (const listener of listenersByNodeID.get(nodeID) ?? []) {
+      listener();
+    }
+    for (const listener of allListeners) {
       listener();
     }
   };
@@ -53,9 +61,13 @@ export function createWorkbenchGenieNodeVisibilityStore(): WorkbenchGenieNodeVis
 
   return {
     dispose() {
-      hiddenNodeIDs.clear();
+      hiddenNodeIDs = new Set();
       hiddenTokenByNodeID.clear();
       listenersByNodeID.clear();
+      allListeners.clear();
+    },
+    getHiddenNodeIDsSnapshot() {
+      return hiddenNodeIDs;
     },
     getSnapshot(nodeID) {
       return hiddenNodeIDs.has(nodeID);
@@ -67,6 +79,12 @@ export function createWorkbenchGenieNodeVisibilityStore(): WorkbenchGenieNodeVis
       } else {
         show(nodeID);
       }
+    },
+    subscribeAll(listener) {
+      allListeners.add(listener);
+      return () => {
+        allListeners.delete(listener);
+      };
     },
     show,
     subscribe(nodeID, listener) {

--- a/packages/workbench/surface/src/react/nodePresentationTransitions.test.ts
+++ b/packages/workbench/surface/src/react/nodePresentationTransitions.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createWorkbenchNodePresentationTransitionStore } from "./nodePresentationTransitions.ts";
+
+test("keeps a node active until all presentation transitions settle", () => {
+  const store = createWorkbenchNodePresentationTransitionStore();
+
+  store.setActive("node-1", "frame", true);
+  store.setActive("node-1", "onboarding-entry", true);
+  assert.deepEqual([...store.getSnapshot()], ["node-1"]);
+
+  store.setActive("node-1", "frame", false);
+  assert.deepEqual([...store.getSnapshot()], ["node-1"]);
+
+  store.setActive("node-1", "onboarding-entry", false);
+  assert.deepEqual([...store.getSnapshot()], []);
+});

--- a/packages/workbench/surface/src/react/nodePresentationTransitions.ts
+++ b/packages/workbench/surface/src/react/nodePresentationTransitions.ts
@@ -1,0 +1,88 @@
+export type WorkbenchNodePresentationTransition =
+  | "frame"
+  | "onboarding-entry"
+  | "scale-restore";
+
+export interface WorkbenchNodePresentationTransitionStore {
+  clearNode(nodeID: string): void;
+  dispose(): void;
+  getSnapshot(): ReadonlySet<string>;
+  setActive(
+    nodeID: string,
+    transition: WorkbenchNodePresentationTransition,
+    active: boolean
+  ): void;
+  subscribe(listener: () => void): () => void;
+}
+
+export function createWorkbenchNodePresentationTransitionStore(): WorkbenchNodePresentationTransitionStore {
+  let activeNodeIDs: ReadonlySet<string> = new Set();
+  const activeTransitionsByNodeID = new Map<
+    string,
+    Set<WorkbenchNodePresentationTransition>
+  >();
+  const listeners = new Set<() => void>();
+
+  const publish = (nodeID: string, active: boolean): void => {
+    if (activeNodeIDs.has(nodeID) === active) {
+      return;
+    }
+    const nextActiveNodeIDs = new Set(activeNodeIDs);
+    if (active) {
+      nextActiveNodeIDs.add(nodeID);
+    } else {
+      nextActiveNodeIDs.delete(nodeID);
+    }
+    activeNodeIDs = nextActiveNodeIDs;
+    for (const listener of listeners) {
+      listener();
+    }
+  };
+
+  const clearNode = (nodeID: string): void => {
+    if (!activeTransitionsByNodeID.delete(nodeID)) {
+      return;
+    }
+    publish(nodeID, false);
+  };
+
+  return {
+    clearNode,
+    dispose() {
+      activeNodeIDs = new Set();
+      activeTransitionsByNodeID.clear();
+      listeners.clear();
+    },
+    getSnapshot() {
+      return activeNodeIDs;
+    },
+    setActive(nodeID, transition, active) {
+      const activeTransitions =
+        activeTransitionsByNodeID.get(nodeID) ??
+        new Set<WorkbenchNodePresentationTransition>();
+      if (active) {
+        if (activeTransitions.has(transition)) {
+          return;
+        }
+        activeTransitions.add(transition);
+        activeTransitionsByNodeID.set(nodeID, activeTransitions);
+        publish(nodeID, true);
+        return;
+      }
+      if (!activeTransitions.delete(transition)) {
+        return;
+      }
+      if (activeTransitions.size > 0) {
+        return;
+      }
+      activeTransitionsByNodeID.delete(nodeID);
+      publish(nodeID, false);
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    }
+  };
+}

--- a/packages/workbench/surface/src/react/useWorkbenchGenieAnimation.tsx
+++ b/packages/workbench/surface/src/react/useWorkbenchGenieAnimation.tsx
@@ -50,6 +50,7 @@ import type {
   WorkbenchNodePreviewImageCapture,
   WorkbenchNodePreviewImagesCapture
 } from "./nodePreviewCapture.ts";
+import type { WorkbenchNodePresentationTransitionStore } from "./nodePresentationTransitions.ts";
 import {
   resolveNativeFirstGenieTexture,
   scheduleWorkbenchGeniePostAnimationIdleTask,
@@ -728,6 +729,7 @@ export function useWorkbenchGenieAnimation<TData>({
   debugDiagnostics,
   dockPreviewCache,
   minimizeAnimation = "genie",
+  nodePresentationTransitions,
   renderNodeGeniePreview,
   resolveDockAnchorKey,
   resolveDockPreviewCacheKey,
@@ -739,6 +741,7 @@ export function useWorkbenchGenieAnimation<TData>({
   debugDiagnostics?: WorkbenchDebugDiagnostics;
   dockPreviewCache?: WorkbenchDockPreviewCache;
   minimizeAnimation?: WorkbenchMinimizeAnimation;
+  nodePresentationTransitions: WorkbenchNodePresentationTransitionStore;
   renderNodeGeniePreview?: WorkbenchNodeGeniePreviewRenderer<TData>;
   resolveDockAnchorKey?: (node: WorkbenchNode<TData>) => string;
   resolveDockPreviewCacheKey?: WorkbenchDockPreviewCacheKeyResolver<TData>;
@@ -1345,6 +1348,7 @@ export function useWorkbenchGenieAnimation<TData>({
           return;
         }
         flushSync(() => {
+          nodePresentationTransitions.setActive(nodeID, "scale-restore", true);
           showNodeForGenie(nodeID);
         });
         runScaleWindowAnimation({
@@ -1354,12 +1358,22 @@ export function useWorkbenchGenieAnimation<TData>({
           onCancel: () => {
             flushSync(() => {
               showNodeForGenie(nodeID);
+              nodePresentationTransitions.setActive(
+                nodeID,
+                "scale-restore",
+                false
+              );
             });
             clearMinimizedGenieTexture(nodeID);
           },
           onComplete: () => {
             flushSync(() => {
               showNodeForGenie(nodeID);
+              nodePresentationTransitions.setActive(
+                nodeID,
+                "scale-restore",
+                false
+              );
             });
             clearMinimizedGenieTexture(nodeID);
           }
@@ -1446,6 +1460,7 @@ export function useWorkbenchGenieAnimation<TData>({
       clearCanvas,
       clearMinimizedGenieTexture,
       minimizeAnimation,
+      nodePresentationTransitions,
       readMinimizedGenieTexture,
       requestRenderedGeniePreviewTexture,
       resolveDockAnchorRect,

--- a/tools/degradation-baseline/agent-gui.json
+++ b/tools/degradation-baseline/agent-gui.json
@@ -19,7 +19,7 @@
       "packages/agent/gui/shared/AgentMessageMarkdown.tsx": 7,
       "packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx": 9
     },
-    "effectCount": 137,
+    "effectCount": 135,
     "fileLines": {
       "packages/agent/gui/app/renderer/i18n/locales/en.ts": 1893,
       "packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts": 1773
@@ -30,7 +30,7 @@
     "overlayStores": 3,
     "providerBranches": 1,
     "renderMirrorRefs": 8,
-    "setTimeoutCount": 39,
+    "setTimeoutCount": 36,
     "swallowedCatch": 3,
     "useSyncExternalStoreCount": 4
   }


### PR DESCRIPTION
## Summary
- disconnect timeline/dock observers and scroll listeners while AgentGUI is fully occluded, then resynchronize bottom lock on exposure
- share renderer second/minute clocks across Turn, compaction, subagent, Goal, and Rail consumers; hidden AgentGUI elapsed consumers unsubscribe
- exclude hidden, minimizing, and transitioning Workbench nodes from covering lower AgentGUI bodies while keeping scale-restoring and moving windows themselves visible
- keep frame transitions, onboarding entry, and scale restore non-occluding until their DOM animation settles, and honor the portal-backed `dialog-popover` layer
- document the visibility resource boundary and Workbench occlusion rules

## Tests
- `pnpm --filter @tutti-os/workbench-surface test`
- `pnpm --filter @tutti-os/workbench-surface typecheck`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- `pnpm --filter @tutti-os/desktop build`

## Notes
- Regression tests cover Genie/scale minimize, scale restore, shell frame transitions, onboarding entry, overlapping transition completion, and `dialog-popover` ordering.
- No comparable post-change Electron trace was captured.
