### PR TITLE
feat(agent-gui): add session input history

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -82,6 +82,7 @@ import { DESKTOP_AGENT_GUI_CURRENT_USER_ID } from "../services/desktopAgentGuiId
 import {
   AGENT_REFERENCE_PROVENANCE_FILTER_FLAG,
   isFeatureEnabled,
+  LAB_AGENT_INPUT_HISTORY_FLAG,
   LAB_TUTTI_MODE_FLAG
 } from "../../../../../shared/featureFlags/catalog.ts";
 
@@ -571,6 +572,10 @@ function DesktopAgentGUISurfaceImpl({
     desktopPreferencesState.featureFlags,
     AGENT_REFERENCE_PROVENANCE_FILTER_FLAG
   );
+  const sessionInputHistoryEnabled = isFeatureEnabled(
+    desktopPreferencesState.featureFlags,
+    LAB_AGENT_INPUT_HISTORY_FLAG
+  );
   const providerAuthAccountLabels = useMemo(() => {
     const labels: Partial<Record<WorkspaceAgentProvider, string>> = {};
     for (const status of providerStatusSnapshot.statuses) {
@@ -629,6 +634,7 @@ function DesktopAgentGUISurfaceImpl({
     },
     hostCapabilities: {
       referenceProvenanceFilterEnabled,
+      sessionInputHistoryEnabled,
       capabilityMenuState,
       visibleErrorPresentationOverrides,
       comingSoonProviders: comingSoonAgentProviders,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.ts
@@ -22,6 +22,7 @@ export type DesktopAgentGUIHostProps = {
   hostCapabilities: Pick<
     AgentGUIProps["hostCapabilities"],
     | "referenceProvenanceFilterEnabled"
+    | "sessionInputHistoryEnabled"
     | "capabilityMenuState"
     | "visibleErrorPresentationOverrides"
     | "comingSoonProviders"
@@ -95,6 +96,8 @@ export function useStableDesktopAgentGUIHostProps({
     hostCapabilities: {
       referenceProvenanceFilterEnabled:
         nextHostCapabilities.referenceProvenanceFilterEnabled,
+      sessionInputHistoryEnabled:
+        nextHostCapabilities.sessionInputHistoryEnabled,
       capabilityMenuState: nextHostCapabilities.capabilityMenuState,
       visibleErrorPresentationOverrides:
         nextHostCapabilities.visibleErrorPresentationOverrides,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceLabFeatureGateRows.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceLabFeatureGateRows.tsx
@@ -2,6 +2,7 @@ import { Switch } from "@tutti-os/ui-system";
 import { useTranslation } from "@renderer/i18n";
 import {
   EARLY_ACCESS_AGENT_INTEGRATIONS_FLAG,
+  LAB_AGENT_INPUT_HISTORY_FLAG,
   LAB_AUTOMATION_RULES_FLAG,
   LAB_MODEL_PLANS_FLAG,
   LAB_TUTTI_MODE_FLAG,
@@ -37,6 +38,12 @@ const featureGateRows = [
     labelKey: "workspace.settings.lab.workbenchShortcutsLabel" as const,
     descriptionKey:
       "workspace.settings.lab.workbenchShortcutsDescription" as const
+  },
+  {
+    key: LAB_AGENT_INPUT_HISTORY_FLAG,
+    labelKey: "workspace.settings.lab.agentInputHistoryLabel" as const,
+    descriptionKey:
+      "workspace.settings.lab.agentInputHistoryDescription" as const
   },
   {
     key: EARLY_ACCESS_AGENT_INTEGRATIONS_FLAG,

--- a/apps/desktop/src/shared/featureFlags/catalog.test.ts
+++ b/apps/desktop/src/shared/featureFlags/catalog.test.ts
@@ -15,6 +15,7 @@ import {
   isFeatureEnabled,
   labFeatureDefinitions,
   LAB_ENABLED_FLAG,
+  LAB_AGENT_INPUT_HISTORY_FLAG,
   LAB_AUTOMATION_RULES_FLAG,
   LAB_MODEL_PLANS_FLAG,
   LAB_TUTTI_MODE_FLAG,
@@ -87,6 +88,7 @@ test("labFeatureDefinitions excludes the master switch", () => {
 
 test("experimental Agent features require independent Lab opt-ins", () => {
   const flags = [
+    LAB_AGENT_INPUT_HISTORY_FLAG,
     LAB_TUTTI_MODE_FLAG,
     LAB_MODEL_PLANS_FLAG,
     LAB_WORKSPACE_AGENTS_FLAG,

--- a/apps/desktop/src/shared/featureFlags/catalog.ts
+++ b/apps/desktop/src/shared/featureFlags/catalog.ts
@@ -11,6 +11,7 @@ export const LAB_MODEL_PLANS_FLAG = "lab.modelPlans";
 export const LAB_WORKSPACE_AGENTS_FLAG = "lab.workspaceAgents";
 export const LAB_AUTOMATION_RULES_FLAG = "lab.automationRules";
 export const LAB_WORKBENCH_SHORTCUTS_FLAG = "lab.workbenchShortcuts";
+export const LAB_AGENT_INPUT_HISTORY_FLAG = "lab.agentInputHistory";
 // Keep the durable key for existing profiles while naming the product concept
 // after Tutti's integration maturity rather than the upstream Agent maturity.
 export const EARLY_ACCESS_AGENT_INTEGRATIONS_FLAG = "lab.previewAgents";
@@ -196,6 +197,13 @@ export const FEATURE_FLAG_DEFINITIONS: readonly FeatureFlagDefinition[] = [
     group: "lab",
     labelKey: "workspace.settings.lab.workbenchShortcutsLabel",
     descriptionKey: "workspace.settings.lab.workbenchShortcutsDescription"
+  },
+  {
+    key: LAB_AGENT_INPUT_HISTORY_FLAG,
+    default: false,
+    group: "lab",
+    labelKey: "workspace.settings.lab.agentInputHistoryLabel",
+    descriptionKey: "workspace.settings.lab.agentInputHistoryDescription"
   },
   {
     key: EARLY_ACCESS_AGENT_INTEGRATIONS_FLAG,

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -1208,6 +1208,9 @@ export const en = {
         visibilityLabel: "Show developer panel"
       },
       lab: {
+        agentInputHistoryDescription:
+          "Use Up and Down in Agent input to recall earlier prompts from the current session.",
+        agentInputHistoryLabel: "Agent input history",
         backLabel: "Back",
         automationRulesDescription:
           "Shows Automation Rule configuration and session overrides.",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -1133,6 +1133,9 @@ export const zhCN = {
         visibilityLabel: "显示开发者面板"
       },
       lab: {
+        agentInputHistoryDescription:
+          "在 Agent 输入框中使用上下键切换当前会话的历史输入",
+        agentInputHistoryLabel: "Agent 输入历史",
         backLabel: "返回",
         automationRulesDescription: "显示自动化规则配置与会话覆盖选项",
         automationRulesLabel: "自动化规则",

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -774,6 +774,21 @@ The editor recognizes stale controlled echoes from that transition so an older
 projection cannot overwrite newer local input; a value not emitted locally
 remains an authoritative external replacement.
 
+An existing-Session composer derives input history from that Session's
+canonical user-message projection; it does not persist a second history store.
+The host must opt in explicitly; Desktop maps the default-off
+`lab.agentInputHistory` Lab preference to that capability.
+Bare Up/Down recalls older/newer structured drafts only from an empty composer
+or an unchanged recalled entry, and only when the collapsed caret is at a
+whole-document boundary. Palette handling and IME composition take precedence,
+while editing a recalled draft exits history navigation. Moving past the newest
+entry clears the composer. Adjacent equivalent submissions collapse, persisted
+attachments are restored with exact workspace and Session identity, and
+reaching the oldest loaded entry requests the existing authoritative older-page
+read while preserving the timeline prepend scroll anchor. The history cursor
+is UI-local and resets when the draft Session scope changes; Home has no
+Session history.
+
 The dock observes geometry through one coalesced animation-frame measurement
 entry point. Editor document updates, attachment membership or intrinsic
 attachment size changes, and changes to the stable input-shell width may

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -51,6 +51,7 @@ import {
   groupAgentExternalPromptEntryInsertions,
   resolveAgentExternalPromptEntries
 } from "./model/agentExternalPromptEntries";
+import { useComposerInputHistory } from "./composer/useComposerInputHistory";
 
 export { formatSlashStatusTokenCount };
 
@@ -80,6 +81,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   "use memo";
   const {
     workspaceId,
+    agentSessionId = null,
     workspacePath,
     currentUserId,
     provider,
@@ -87,6 +89,10 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     draftContent,
     engagement,
     draftScopeKey = "current",
+    inputHistory = [],
+    inputHistoryHasOlderPage = false,
+    inputHistoryIsLoadingOlderPage = false,
+    onRequestOlderInputHistoryPage,
     availableCommands,
     hasCompactableContext = true,
     compactSupported = null,
@@ -245,6 +251,23 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     [draftScopeKey]: draftContent
   });
   draftByScopeKeyRef.current[draftScopeKey] = draftContent;
+  const {
+    disposeInputHistory,
+    onHistoryNavigation,
+    settlePendingInputHistory
+  } = useComposerInputHistory({
+    agentSessionId,
+    currentDraft: draftContent,
+    draftByScopeKeyRef,
+    draftScopeKey,
+    entries: inputHistory,
+    hasOlderPage: inputHistoryHasOlderPage,
+    isLoadingOlderPage: inputHistoryIsLoadingOlderPage,
+    onDraftContentChange,
+    onRequestOlderPage: onRequestOlderInputHistoryPage,
+    runtime: agentActivityRuntime,
+    workspaceId
+  });
   const promptTipRef = useRef<HTMLSpanElement | null>(null);
   const { mentionControllerRef, mentionSearchState } =
     useAgentMentionSearchController(referenceProvenanceFilters);
@@ -358,6 +381,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     const isExternalDraftReplacement = draftPromptRef.current !== draftPrompt;
     draftPromptRef.current = draftPrompt;
     setPaletteDraftPrompt(goalDraftObjective ?? draftPrompt);
+    settlePendingInputHistory();
     if (isExternalDraftReplacement && draftPrompt) {
       window.requestAnimationFrame(() => {
         window.requestAnimationFrame(() => {
@@ -367,17 +391,23 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
         });
       });
     }
-  }, [draftContent, draftPrompt, goalDraftObjective]);
+  }, [
+    draftContent,
+    draftPrompt,
+    goalDraftObjective,
+    settlePendingInputHistory
+  ]);
 
   useEffect(() => {
     if (
       previousSlashStatusAgentSessionIdRef.current === slashStatusAgentSessionId
     ) {
-      return;
+      return disposeInputHistory;
     }
     previousSlashStatusAgentSessionIdRef.current = slashStatusAgentSessionId;
     setIsSlashStatusPanelOpen(false);
-  }, [slashStatusAgentSessionId]);
+    return disposeInputHistory;
+  }, [disposeInputHistory, draftScopeKey, slashStatusAgentSessionId]);
 
   const slashActions = useComposerSlashActions({
     workspaceId,
@@ -676,6 +706,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
         onTuttiModeOrchestrationIntensityChange
       }
       isPromptTipOverflowing={isPromptTipOverflowing}
+      onHistoryNavigation={onHistoryNavigation}
     />
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.memo.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.memo.spec.tsx
@@ -129,6 +129,28 @@ describe("AgentGUINode memoization", () => {
     expect(agentGuiNodeViewSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("rerenders when Session input history is enabled", () => {
+    mockViewModel = createViewModel();
+    const props = createProps();
+    const { rerender } = render(<AgentGUINode {...props} />);
+
+    expect(agentGuiNodeViewSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sessionInputHistoryEnabled: false })
+    );
+    agentGuiNodeViewSpy.mockClear();
+
+    rerender(
+      <AgentGUINode
+        {...props}
+        hostCapabilities={{ sessionInputHistoryEnabled: true }}
+      />
+    );
+
+    expect(agentGuiNodeViewSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sessionInputHistoryEnabled: true })
+    );
+  });
+
   it("rerenders when per-target composer overrides change", () => {
     mockViewModel = createViewModel();
     const props = createProps({

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -113,7 +113,8 @@ export const AgentGUINode = memo(function AgentGUINode({
     workspaceAppIcons,
     disabledHomeSuggestions,
     referenceProvenanceFilterCatalog: injectedReferenceProvenanceFilterCatalog,
-    referenceProvenanceFilterEnabled = false
+    referenceProvenanceFilterEnabled = false,
+    sessionInputHistoryEnabled = false
   } = hostCapabilities;
   const referenceProvenanceFilters = useAgentMentionProvenanceFilters({
     agentTargets,
@@ -541,6 +542,7 @@ export const AgentGUINode = memo(function AgentGUINode({
               workspaceFileReferenceCopy={workspaceFileReferenceCopy}
               workspaceAppIcons={workspaceAppIcons}
               referenceProvenanceFilters={referenceProvenanceFilters}
+              sessionInputHistoryEnabled={sessionInputHistoryEnabled}
               renderProjectDirectoryPickerHeaderActions={
                 renderProjectDirectoryPickerHeaderActions
               }

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
@@ -124,6 +124,8 @@ export interface AgentGUINodeHostCapabilities {
   referenceProvenanceFilterCatalog?: ReferenceProvenanceCatalog | null;
   /** Legacy Tutti Agent-only opt-in. Prefer an explicit catalog in new hosts. */
   referenceProvenanceFilterEnabled?: boolean;
+  /** Host-owned experimental opt-in for current-Session composer history. */
+  sessionInputHistoryEnabled?: boolean;
   capabilityMenuState?: AgentComposerCapabilityMenuState;
   /**
    * Keeps owner-supported Browser/Computer capability entries visible while
@@ -376,6 +378,7 @@ export function areAgentGUINodePropsEqual(
       nc.referenceProvenanceFilterCatalog &&
     pc.referenceProvenanceFilterEnabled ===
       nc.referenceProvenanceFilterEnabled &&
+    pc.sessionInputHistoryEnabled === nc.sessionInputHistoryEnabled &&
     agentGuiStateEquals(previous.state, next.state) &&
     pf.position.x === nf.position.x &&
     pf.position.y === nf.position.y &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -80,6 +80,7 @@ import { useAgentGUIExternalRequests } from "./view/useAgentGUIExternalRequests"
 export function AgentGUINodeView({
   viewModel,
   referenceProvenanceFilters = null,
+  sessionInputHistoryEnabled = false,
   renderProjectDirectoryPickerHeaderActions,
   renderSidebarFooter,
   renderProviderRailEmpty,
@@ -685,6 +686,7 @@ export function AgentGUINodeView({
                 operations={viewModel.operations}
                 homeTargetProjection={homeTargetProjection}
                 referenceProvenanceFilters={referenceProvenanceFilters}
+                sessionInputHistoryEnabled={sessionInputHistoryEnabled}
                 composerEngagement={composerEngagement}
                 actions={actions}
                 labels={labels}

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
@@ -220,6 +220,59 @@ describe("AgentRichTextEditor prompt insertion", () => {
     );
   });
 
+  it("does not open mention suggestions for a restored controlled value", async () => {
+    const ref = createRef<AgentRichTextEditorHandle>();
+    const onFileMentionSuggestionChange = vi.fn();
+    const props = {
+      disabled: false,
+      onChange: vi.fn(),
+      onFileMentionSuggestionChange,
+      onSubmit: vi.fn(),
+      placeholder: "Prompt"
+    };
+    const rendered = render(
+      <AgentRichTextEditor ref={ref} value="" {...props} />
+    );
+    await waitFor(() => expect(ref.current).not.toBeNull());
+    onFileMentionSuggestionChange.mockClear();
+
+    rendered.rerender(
+      <AgentRichTextEditor
+        ref={ref}
+        value="@tutti-os/workbench-electron 得新增包是吗"
+        {...props}
+      />
+    );
+
+    await waitFor(() =>
+      expect(
+        rendered.container.querySelector('[contenteditable="true"]')
+      ).toHaveTextContent("@tutti-os/workbench-electron 得新增包是吗")
+    );
+    act(() => ref.current?.focusAtEnd());
+
+    expect(
+      onFileMentionSuggestionChange.mock.calls.some(
+        ([suggestion]) => suggestion !== null
+      )
+    ).toBe(false);
+    expect(rendered.container.querySelector(".suggestion")).toBeNull();
+
+    onFileMentionSuggestionChange.mockClear();
+    const editor = rendered.container.querySelector<HTMLElement>(
+      '[contenteditable="true"]'
+    );
+    expect(editor).not.toBeNull();
+    fireEvent.keyDown(editor!, { key: "x" });
+    act(() => ref.current?.insertPlainTextAtSelection("x"));
+
+    expect(onFileMentionSuggestionChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: "tutti-os/workbench-electron 得新增包是吗x"
+      })
+    );
+  });
+
   it("inserts multiline plain text at the current selection without submitting", async () => {
     const ref = createRef<AgentRichTextEditorHandle>();
     const onChange = vi.fn();

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
@@ -63,6 +63,7 @@ import {
   recordAgentRichTextLocalEdit,
   shouldApplyAgentRichTextControlledValue
 } from "./agentRichTextControlledValue";
+import { createAgentRichTextMentionSuggestionSuppression } from "./agentRichTextMentionSuggestionSuppression";
 
 export type {
   AgentRichTextEditorHandle,
@@ -91,6 +92,7 @@ export const AgentRichTextEditor = forwardRef<
     submitOnEnter = true,
     enableFileMentionSuggestions = true,
     onKeyDownForPalette,
+    onHistoryNavigation,
     onFileMentionSuggestionChange,
     onFileMentionSuggestionKeyDown,
     onLinkClick,
@@ -118,6 +120,7 @@ export const AgentRichTextEditor = forwardRef<
   const onSubmitRef = useRef(onSubmit);
   const onSubmitGuidanceRef = useRef(onSubmitGuidance);
   const onKeyDownForPaletteRef = useRef(onKeyDownForPalette);
+  const onHistoryNavigationRef = useRef(onHistoryNavigation);
   const onFileMentionSuggestionChangeRef = useRef(
     onFileMentionSuggestionChange
   );
@@ -135,7 +138,9 @@ export const AgentRichTextEditor = forwardRef<
   const removeMentionLabelRef = useRef(removeMentionLabel);
   const availableSkillsRef = useRef(availableSkills);
   const availableCapabilitiesRef = useRef(availableCapabilities);
-  const suppressPastedAtSuggestionRef = useRef(false);
+  const [mentionSuggestionSuppression] = useState(() =>
+    createAgentRichTextMentionSuggestionSuppression(value)
+  );
   const scrollFrameRef = useRef<number | null>(null);
   const [contextMenu, setContextMenu] =
     useState<AgentRichTextContextMenuState | null>(null);
@@ -153,11 +158,7 @@ export const AgentRichTextEditor = forwardRef<
       onPasteLargeTextRef.current(text);
       return;
     }
-    suppressPastedAtSuggestionRef.current =
-      text.includes("@") && !text.endsWith("@");
-    if (suppressPastedAtSuggestionRef.current) {
-      releasePastedAtSuggestionSuppression(suppressPastedAtSuggestionRef);
-    }
+    mentionSuggestionSuppression.suppressTextInsertion(text);
     currentEditor
       .chain()
       .focus()
@@ -262,7 +263,7 @@ export const AgentRichTextEditor = forwardRef<
           onSuggestionKeyDown: (event) =>
             onFileMentionSuggestionKeyDownRef.current?.(event) ?? false,
           removeActionAriaLabel: removeMentionLabelRef.current,
-          shouldSuppressSuggestion: () => suppressPastedAtSuggestionRef.current
+          shouldSuppressSuggestion: mentionSuggestionSuppression.isSuppressed
         },
         { skills: availableSkillsRef.current },
         { capabilities: availableCapabilitiesRef.current }
@@ -280,6 +281,7 @@ export const AgentRichTextEditor = forwardRef<
   onSubmitRef.current = onSubmit;
   onSubmitGuidanceRef.current = onSubmitGuidance;
   onKeyDownForPaletteRef.current = onKeyDownForPalette;
+  onHistoryNavigationRef.current = onHistoryNavigation;
   onFileMentionSuggestionChangeRef.current = onFileMentionSuggestionChange;
   onFileMentionSuggestionKeyDownRef.current = onFileMentionSuggestionKeyDown;
   onLinkClickRef.current = onLinkClick;
@@ -454,11 +456,7 @@ export const AgentRichTextEditor = forwardRef<
               currentEditor.state.doc.content.size
             );
           }
-          suppressPastedAtSuggestionRef.current =
-            text.includes("@") && !text.endsWith("@");
-          if (suppressPastedAtSuggestionRef.current) {
-            releasePastedAtSuggestionSuppression(suppressPastedAtSuggestionRef);
-          }
+          mentionSuggestionSuppression.suppressTextInsertion(text);
           currentEditor.commands.insertContent(
             plainTextToAgentRichTextInlineContent(text, {
               capabilities: availableCapabilitiesRef.current,
@@ -673,10 +671,12 @@ export const AgentRichTextEditor = forwardRef<
   const handleKeyDownCapture = (
     event: ReactKeyboardEvent<HTMLDivElement>
   ): void => {
+    mentionSuggestionSuppression.releaseForContentEditingKey(event);
     handleAgentRichTextKeyDownCapture(event, {
       disabled,
       editorRef,
       onKeyDownForPaletteRef,
+      onHistoryNavigationRef,
       onSubmitGuidanceRef,
       onSubmitRef,
       submitOnEnter
@@ -755,6 +755,7 @@ export const AgentRichTextEditor = forwardRef<
       capabilities: availableCapabilities,
       skills: availableSkills
     });
+    mentionSuggestionSuppression.setRestoredValue(value);
     if (JSON.stringify(editor.getJSON()) === JSON.stringify(nextDoc)) {
       lastEmittedPromptRef.current = value;
       return;
@@ -783,10 +784,3 @@ export const AgentRichTextEditor = forwardRef<
     />
   );
 });
-
-function releasePastedAtSuggestionSuppression(ref: { current: boolean }): void {
-  // timing: keep suppression through the synchronous editor insertion only.
-  window.setTimeout(() => {
-    ref.current = false;
-  }, 0);
-}

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.types.ts
@@ -28,6 +28,7 @@ export interface AgentRichTextEditorProps {
   submitOnEnter?: boolean;
   enableFileMentionSuggestions?: boolean;
   onKeyDownForPalette?: (event: KeyboardEvent) => boolean;
+  onHistoryNavigation?: (direction: "older" | "newer") => boolean;
   onFileMentionSuggestionChange?: (
     state: AgentFileMentionSuggestionState | null
   ) => void;

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextKeyboard.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextKeyboard.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Editor } from "@tiptap/core";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import { handleAgentRichTextKeyDownCapture } from "./agentRichTextKeyboard";
+
+describe("handleAgentRichTextKeyDownCapture input history", () => {
+  it("handles bare arrows at a whole-document boundary", () => {
+    const onHistoryNavigation = vi.fn(() => true);
+    const event = keyboardEvent("ArrowUp");
+
+    handleAgentRichTextKeyDownCapture(
+      event as unknown as ReactKeyboardEvent<HTMLDivElement>,
+      keyboardInput({
+        editor: editorAt({ from: 4, to: 4, documentSize: 5 }),
+        onHistoryNavigation
+      })
+    );
+
+    expect(onHistoryNavigation).toHaveBeenCalledWith("older");
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(event.stopPropagation).toHaveBeenCalledOnce();
+  });
+
+  it("leaves arrows in the middle of multiline input alone", () => {
+    const onHistoryNavigation = vi.fn(() => true);
+    const event = keyboardEvent("ArrowDown");
+
+    handleAgentRichTextKeyDownCapture(
+      event as unknown as ReactKeyboardEvent<HTMLDivElement>,
+      keyboardInput({
+        editor: editorAt({ from: 2, to: 2, documentSize: 5 }),
+        onHistoryNavigation
+      })
+    );
+
+    expect(onHistoryNavigation).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("gives an open palette priority over input history", () => {
+    const onHistoryNavigation = vi.fn(() => true);
+    const event = keyboardEvent("ArrowUp");
+    const input = keyboardInput({
+      editor: editorAt({ from: 1, to: 1, documentSize: 5 }),
+      onHistoryNavigation
+    });
+    input.onKeyDownForPaletteRef.current = () => true;
+
+    handleAgentRichTextKeyDownCapture(
+      event as unknown as ReactKeyboardEvent<HTMLDivElement>,
+      input
+    );
+
+    expect(onHistoryNavigation).not.toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+  });
+});
+
+function keyboardInput(input: {
+  editor: Editor;
+  onHistoryNavigation: (direction: "older" | "newer") => boolean;
+}) {
+  return {
+    disabled: false,
+    editorRef: { current: input.editor },
+    onKeyDownForPaletteRef: {
+      current: undefined as ((event: KeyboardEvent) => boolean) | undefined
+    },
+    onHistoryNavigationRef: { current: input.onHistoryNavigation },
+    onSubmitGuidanceRef: { current: undefined },
+    onSubmitRef: { current: vi.fn() },
+    submitOnEnter: true
+  };
+}
+
+function editorAt(input: {
+  documentSize: number;
+  from: number;
+  to: number;
+}): Editor {
+  return {
+    isDestroyed: false,
+    state: {
+      doc: { content: { size: input.documentSize } },
+      selection: {
+        empty: input.from === input.to,
+        from: input.from,
+        to: input.to
+      }
+    }
+  } as unknown as Editor;
+}
+
+function keyboardEvent(key: string) {
+  return {
+    altKey: false,
+    ctrlKey: false,
+    key,
+    metaKey: false,
+    nativeEvent: {
+      altKey: false,
+      ctrlKey: false,
+      isComposing: false,
+      key,
+      metaKey: false,
+      shiftKey: false
+    },
+    preventDefault: vi.fn(),
+    shiftKey: false,
+    stopPropagation: vi.fn()
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextKeyboard.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextKeyboard.ts
@@ -11,6 +11,9 @@ export function handleAgentRichTextKeyDownCapture(
     onKeyDownForPaletteRef: RefObject<
       ((event: KeyboardEvent) => boolean) | undefined
     >;
+    onHistoryNavigationRef: RefObject<
+      ((direction: "older" | "newer") => boolean) | undefined
+    >;
     onSubmitGuidanceRef: RefObject<(() => void) | undefined>;
     onSubmitRef: RefObject<() => void>;
     submitOnEnter: boolean;
@@ -26,6 +29,32 @@ export function handleAgentRichTextKeyDownCapture(
     event.preventDefault();
     event.stopPropagation();
     return;
+  }
+  if (
+    (event.key === "ArrowUp" || event.key === "ArrowDown") &&
+    !event.shiftKey &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey
+  ) {
+    const currentEditor = input.editorRef.current;
+    const selection = currentEditor?.state.selection;
+    const documentSize = currentEditor?.state.doc.content.size ?? 0;
+    const isAtDocumentBoundary =
+      Boolean(selection?.empty) &&
+      (selection?.from === 1 || selection?.to === documentSize - 1);
+    if (
+      currentEditor &&
+      !currentEditor.isDestroyed &&
+      isAtDocumentBoundary &&
+      input.onHistoryNavigationRef.current?.(
+        event.key === "ArrowUp" ? "older" : "newer"
+      )
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
   }
   if (
     (event.key === "ArrowLeft" || event.key === "ArrowRight") &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextMentionSuggestionSuppression.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextMentionSuggestionSuppression.ts
@@ -1,0 +1,47 @@
+export interface AgentRichTextContentEditingKey {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+}
+
+export function createAgentRichTextMentionSuggestionSuppression(
+  initialValue: string
+): {
+  isSuppressed: () => boolean;
+  releaseForContentEditingKey: (event: AgentRichTextContentEditingKey) => void;
+  setRestoredValue: (value: string) => void;
+  suppressTextInsertion: (text: string) => void;
+} {
+  let restoredValue = initialValue.includes("@");
+  let transientInsertion = false;
+
+  return {
+    isSuppressed: () => restoredValue || transientInsertion,
+    releaseForContentEditingKey: (event) => {
+      if (
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        (event.key.length === 1 ||
+          event.key === "Backspace" ||
+          event.key === "Delete")
+      ) {
+        restoredValue = false;
+      }
+    },
+    setRestoredValue: (value) => {
+      restoredValue = value.includes("@");
+    },
+    suppressTextInsertion: (text) => {
+      transientInsertion = text.includes("@") && !text.endsWith("@");
+      if (!transientInsertion) {
+        return;
+      }
+      // timing: keep suppression through the synchronous editor insertion only.
+      window.setTimeout(() => {
+        transientInsertion = false;
+      }, 0);
+    }
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -27,6 +27,7 @@ import type {
 } from "@tutti-os/workspace-file-reference/react";
 import type { AgentQuickPromptLabels } from "./quickPrompts/agentQuickPromptLabels";
 import type { AgentMentionFilterId } from "../AgentMentionSearchContracts";
+import type { AgentComposerInputHistoryEntry } from "../model/agentComposerInputHistory";
 
 export interface AgentComposerReferenceProvenanceFilter {
   snapshot: ReferenceProvenanceFilterSnapshot;
@@ -66,6 +67,7 @@ export interface AgentComposerCapabilityReference {
 
 export interface AgentComposerProps {
   workspaceId: string;
+  agentSessionId?: string | null;
   workspacePath?: string | null;
   currentUserId?: string | null;
   provider: string;
@@ -75,6 +77,10 @@ export interface AgentComposerProps {
   engagement?: AgentGUIComposerEngagement;
   /** Stable project/session owner for async draft attachment work. */
   draftScopeKey?: string;
+  inputHistory?: readonly AgentComposerInputHistoryEntry[];
+  inputHistoryHasOlderPage?: boolean;
+  inputHistoryIsLoadingOlderPage?: boolean;
+  onRequestOlderInputHistoryPage?: () => void;
   availableCommands: readonly AgentSessionCommand[];
   hasCompactableContext?: boolean;
   compactSupported?: boolean | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
@@ -108,6 +108,7 @@ interface Props {
   onClearTuttiMode: () => void;
   onTuttiModeOrchestrationIntensityChange: (value: number) => void;
   isPromptTipOverflowing: boolean;
+  onHistoryNavigation: (direction: "older" | "newer") => boolean;
 }
 
 export function AgentComposerView(input: Props): React.JSX.Element {
@@ -415,6 +416,7 @@ export function AgentComposerView(input: Props): React.JSX.Element {
                     availableCapabilities={availableCapabilities}
                     removeMentionLabel={labels.removeMention}
                     onKeyDownForPalette={handlePaletteKeyDown}
+                    onHistoryNavigation={input.onHistoryNavigation}
                     onFileMentionSuggestionChange={
                       handleFileMentionSuggestionChange
                     }

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerInputHistory.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerInputHistory.spec.tsx
@@ -1,0 +1,170 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildAgentComposerDraft,
+  emptyAgentComposerDraft
+} from "../model/agentComposerDraft";
+import type { AgentComposerInputHistoryEntry } from "../model/agentComposerInputHistory";
+import { useComposerInputHistory } from "./useComposerInputHistory";
+
+describe("useComposerInputHistory", () => {
+  it("supports repeated Up presses before the controlled draft rerenders", () => {
+    const onDraftContentChange = vi.fn();
+    const entries = historyEntries("one", "two");
+    const draftByScopeKeyRef = {
+      current: { "session:session-1": emptyAgentComposerDraft() }
+    };
+    const { result } = renderHook(() =>
+      useComposerInputHistory({
+        agentSessionId: "session-1",
+        currentDraft: emptyAgentComposerDraft(),
+        draftByScopeKeyRef,
+        draftScopeKey: "session:session-1",
+        entries,
+        hasOlderPage: false,
+        isLoadingOlderPage: false,
+        onDraftContentChange,
+        runtime: null,
+        workspaceId: "workspace-1"
+      })
+    );
+
+    act(() => {
+      expect(result.current.onHistoryNavigation("older")).toBe(true);
+      expect(result.current.onHistoryNavigation("older")).toBe(true);
+    });
+
+    expect(onDraftContentChange).toHaveBeenNthCalledWith(
+      1,
+      entries[1]!.draft,
+      "session:session-1"
+    );
+    expect(onDraftContentChange).toHaveBeenNthCalledWith(
+      2,
+      entries[0]!.draft,
+      "session:session-1"
+    );
+  });
+
+  it("recalls the next older entry after an older page is prepended", () => {
+    const onDraftContentChange = vi.fn();
+    const onRequestOlderPage = vi.fn();
+    const current = historyEntries("current")[0]!;
+    const older = historyEntries("older")[0]!;
+    const draftByScopeKeyRef = {
+      current: { "session:session-1": emptyAgentComposerDraft() }
+    };
+    const { result, rerender } = renderHook(
+      ({ currentDraft, entries }) => {
+        draftByScopeKeyRef.current["session:session-1"] = currentDraft;
+        return useComposerInputHistory({
+          agentSessionId: "session-1",
+          currentDraft,
+          draftByScopeKeyRef,
+          draftScopeKey: "session:session-1",
+          entries,
+          hasOlderPage: true,
+          isLoadingOlderPage: false,
+          onDraftContentChange,
+          onRequestOlderPage,
+          runtime: null,
+          workspaceId: "workspace-1"
+        });
+      },
+      {
+        initialProps: {
+          currentDraft: emptyAgentComposerDraft(),
+          entries: [current]
+        }
+      }
+    );
+
+    act(() => {
+      result.current.onHistoryNavigation("older");
+      result.current.onHistoryNavigation("older");
+    });
+    expect(onRequestOlderPage).toHaveBeenCalledOnce();
+
+    rerender({
+      currentDraft: current.draft,
+      entries: [older, current]
+    });
+    act(() => {
+      result.current.settlePendingInputHistory();
+    });
+
+    expect(onDraftContentChange).toHaveBeenLastCalledWith(
+      older.draft,
+      "session:session-1"
+    );
+  });
+
+  it("does not overwrite edits made while an older page is loading", () => {
+    const onDraftContentChange = vi.fn();
+    const onRequestOlderPage = vi.fn();
+    const current = historyEntries("current")[0]!;
+    const older = historyEntries("older")[0]!;
+    const editedDraft = buildAgentComposerDraft({ prompt: "edited" });
+    const draftByScopeKeyRef = {
+      current: { "session:session-1": emptyAgentComposerDraft() }
+    };
+    const { result, rerender } = renderHook(
+      ({ currentDraft, entries, isLoadingOlderPage }) => {
+        draftByScopeKeyRef.current["session:session-1"] = currentDraft;
+        return useComposerInputHistory({
+          agentSessionId: "session-1",
+          currentDraft,
+          draftByScopeKeyRef,
+          draftScopeKey: "session:session-1",
+          entries,
+          hasOlderPage: true,
+          isLoadingOlderPage,
+          onDraftContentChange,
+          onRequestOlderPage,
+          runtime: null,
+          workspaceId: "workspace-1"
+        });
+      },
+      {
+        initialProps: {
+          currentDraft: emptyAgentComposerDraft(),
+          entries: [current],
+          isLoadingOlderPage: false
+        }
+      }
+    );
+
+    act(() => {
+      result.current.onHistoryNavigation("older");
+      result.current.onHistoryNavigation("older");
+    });
+    rerender({
+      currentDraft: editedDraft,
+      entries: [current],
+      isLoadingOlderPage: true
+    });
+    rerender({
+      currentDraft: editedDraft,
+      entries: [older, current],
+      isLoadingOlderPage: false
+    });
+    act(() => {
+      result.current.settlePendingInputHistory();
+    });
+
+    expect(onDraftContentChange).toHaveBeenCalledOnce();
+    expect(onDraftContentChange).toHaveBeenLastCalledWith(
+      current.draft,
+      "session:session-1"
+    );
+  });
+});
+
+function historyEntries(
+  ...prompts: string[]
+): AgentComposerInputHistoryEntry[] {
+  return prompts.map((prompt) => ({
+    id: prompt,
+    draft: buildAgentComposerDraft({ prompt })
+  }));
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerInputHistory.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerInputHistory.ts
@@ -1,0 +1,221 @@
+import { useCallback, useRef, type RefObject } from "react";
+import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
+import type { AgentComposerDraft } from "../model/agentGuiNodeTypes";
+import {
+  agentComposerDraftHasContent,
+  agentComposerDraftImages,
+  snapshotAgentComposerDraft,
+  updateAgentComposerDraft
+} from "../model/agentComposerDraft";
+import {
+  areAgentComposerHistoryDraftsEqual,
+  EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE,
+  navigateAgentComposerInputHistory,
+  resolvePendingAgentComposerInputHistory,
+  type AgentComposerInputHistoryEntry,
+  type AgentComposerInputHistoryState
+} from "../model/agentComposerInputHistory";
+import { QueuedPromptImageLoadOwner } from "../queuedPromptImageLoadOwner";
+
+interface Input {
+  agentSessionId: string | null;
+  currentDraft: AgentComposerDraft;
+  draftByScopeKeyRef: RefObject<Record<string, AgentComposerDraft>>;
+  draftScopeKey: string;
+  entries: readonly AgentComposerInputHistoryEntry[];
+  hasOlderPage: boolean;
+  isLoadingOlderPage: boolean;
+  onDraftContentChange: (
+    draft: AgentComposerDraft,
+    sourceScopeKey?: string
+  ) => void;
+  onRequestOlderPage?: () => void;
+  runtime: AgentActivityRuntime | null;
+  workspaceId: string;
+}
+
+export function useComposerInputHistory(input: Input): {
+  disposeInputHistory: () => void;
+  onHistoryNavigation: (direction: "older" | "newer") => boolean;
+  settlePendingInputHistory: () => void;
+} {
+  const cursorRef = useRef<AgentComposerInputHistoryState>(
+    EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
+  );
+  const ownerScopeRef = useRef(input.draftScopeKey);
+  const imageOwnersRef = useRef<QueuedPromptImageLoadOwner[]>([]);
+
+  const disposeInputHistory = useCallback(() => {
+    for (const owner of imageOwnersRef.current) {
+      owner.dispose();
+    }
+    imageOwnersRef.current = [];
+  }, []);
+  if (ownerScopeRef.current !== input.draftScopeKey) {
+    ownerScopeRef.current = input.draftScopeKey;
+    cursorRef.current = EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE;
+    disposeInputHistory();
+  }
+
+  const restoreDraft = useCallback(
+    (draft: AgentComposerDraft, entryId: string | null) => {
+      disposeInputHistory();
+      const restoredDraft = snapshotAgentComposerDraft(draft);
+      input.draftByScopeKeyRef.current[input.draftScopeKey] = restoredDraft;
+      input.onDraftContentChange(restoredDraft, input.draftScopeKey);
+      if (!input.runtime || !input.agentSessionId || !entryId) {
+        return;
+      }
+      for (const restoredImage of agentComposerDraftImages(restoredDraft)) {
+        const attachmentId = restoredImage.attachmentId?.trim() ?? "";
+        const path = restoredImage.path?.trim() ?? "";
+        if (restoredImage.previewUrl || (!attachmentId && !path)) {
+          continue;
+        }
+        const owner = new QueuedPromptImageLoadOwner(
+          {
+            agentSessionId: input.agentSessionId,
+            attachmentId,
+            imageKey: restoredImage.id,
+            mimeType: restoredImage.mimeType,
+            name: restoredImage.name,
+            path,
+            remoteUrl: restoredImage.url?.trim() ?? "",
+            runtime: input.runtime,
+            workspaceId: input.workspaceId
+          },
+          (source) => {
+            if (
+              !source ||
+              cursorRef.current.entryId !== entryId ||
+              ownerScopeRef.current !== input.draftScopeKey
+            ) {
+              return;
+            }
+            const currentDraft =
+              input.draftByScopeKeyRef.current[input.draftScopeKey];
+            if (!currentDraft) {
+              return;
+            }
+            let updated = false;
+            const images = agentComposerDraftImages(currentDraft).map(
+              (currentImage) => {
+                if (
+                  currentImage.id !== restoredImage.id ||
+                  currentImage.previewUrl ||
+                  currentImage.attachmentId !== restoredImage.attachmentId ||
+                  currentImage.path !== restoredImage.path ||
+                  currentImage.url !== restoredImage.url
+                ) {
+                  return currentImage;
+                }
+                updated = true;
+                return { ...currentImage, previewUrl: source };
+              }
+            );
+            if (updated) {
+              const updatedDraft = updateAgentComposerDraft(currentDraft, {
+                images
+              });
+              input.draftByScopeKeyRef.current[input.draftScopeKey] =
+                updatedDraft;
+              input.onDraftContentChange(updatedDraft, input.draftScopeKey);
+            }
+          }
+        );
+        imageOwnersRef.current.push(owner);
+        owner.start();
+      }
+    },
+    [
+      disposeInputHistory,
+      input.agentSessionId,
+      input.draftByScopeKeyRef,
+      input.draftScopeKey,
+      input.onDraftContentChange,
+      input.runtime,
+      input.workspaceId
+    ]
+  );
+
+  const settlePendingInputHistory = useCallback(() => {
+    if (input.isLoadingOlderPage) {
+      return;
+    }
+    const pendingEntryId = cursorRef.current.pendingOlderPage
+      ? cursorRef.current.entryId
+      : null;
+    const pendingEntry = pendingEntryId
+      ? input.entries.find((entry) => entry.id === pendingEntryId)
+      : null;
+    const currentDraft =
+      input.draftByScopeKeyRef.current[input.draftScopeKey] ??
+      input.currentDraft;
+    if (
+      cursorRef.current.pendingOlderPage &&
+      (pendingEntry
+        ? !areAgentComposerHistoryDraftsEqual(currentDraft, pendingEntry.draft)
+        : agentComposerDraftHasContent(currentDraft))
+    ) {
+      cursorRef.current = EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE;
+      return;
+    }
+    const resolved = resolvePendingAgentComposerInputHistory({
+      entries: input.entries,
+      state: cursorRef.current
+    });
+    if (!resolved) {
+      return;
+    }
+    cursorRef.current = resolved.state;
+    if (resolved.draft) {
+      restoreDraft(resolved.draft, resolved.state.entryId);
+    }
+  }, [
+    input.currentDraft,
+    input.draftByScopeKeyRef,
+    input.draftScopeKey,
+    input.entries,
+    input.isLoadingOlderPage,
+    restoreDraft
+  ]);
+
+  const onHistoryNavigation = useCallback(
+    (direction: "older" | "newer"): boolean => {
+      settlePendingInputHistory();
+      const navigation = navigateAgentComposerInputHistory({
+        currentDraft:
+          input.draftByScopeKeyRef.current[input.draftScopeKey] ??
+          input.currentDraft,
+        direction,
+        entries: input.entries,
+        hasOlderPage: input.hasOlderPage,
+        state: cursorRef.current
+      });
+      cursorRef.current = navigation.state;
+      if (navigation.draft) {
+        restoreDraft(navigation.draft, navigation.state.entryId);
+      }
+      if (navigation.requestOlderPage) {
+        input.onRequestOlderPage?.();
+      }
+      return navigation.handled;
+    },
+    [
+      input.currentDraft,
+      input.draftByScopeKeyRef,
+      input.draftScopeKey,
+      input.entries,
+      input.hasOlderPage,
+      input.onRequestOlderPage,
+      restoreDraft,
+      settlePendingInputHistory
+    ]
+  );
+
+  return {
+    disposeInputHistory,
+    onHistoryNavigation,
+    settlePendingInputHistory
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts
@@ -481,6 +481,7 @@ describe("agentComposerDraft", () => {
     });
     expect(agentComposerDraftHasContent(draft)).toBe(true);
     expect(agentComposerDraftLargeTexts(draft)[0]).toMatchObject({
+      id: "restore-1:pasted-text:0",
       name: "pasted-text.txt",
       path: "/archive/aa/deadbeef.txt",
       sizeBytes: 22,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
@@ -410,7 +410,8 @@ export function agentPromptContentToComposerDraft(
 ): AgentComposerDraft {
   const normalizedContent = normalizeAgentPromptContentBlocks(content);
   const largeTexts = agentPromptPastedTextBlocks(normalizedContent).map(
-    (block) => agentPromptPastedTextBlockToDraftLargeText(block)
+    (block, index) =>
+      agentPromptPastedTextBlockToDraftLargeText(block, idPrefix, index)
   );
   const files = agentPromptFileBlocks(normalizedContent).map((file, index) =>
     agentPreparedPromptFileToDraftFile(file, idPrefix, index)
@@ -428,10 +429,12 @@ export function agentPromptContentToComposerDraft(
 }
 
 function agentPromptPastedTextBlockToDraftLargeText(
-  block: AgentPromptContentBlock & { type: "file" }
+  block: AgentPromptContentBlock & { type: "file" },
+  idPrefix: string,
+  index: number
 ): AgentComposerDraftLargeText {
   return {
-    id: crypto.randomUUID(),
+    id: `${idPrefix}:pasted-text:${index}`,
     name: block.name?.trim() || "pasted-text.txt",
     text: "",
     ...(block.path ? { path: block.path } : {}),

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
+import {
+  agentComposerDraftImages,
+  agentComposerDraftPrompt,
+  buildAgentComposerDraft,
+  emptyAgentComposerDraft
+} from "./agentComposerDraft";
+import {
+  EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE,
+  navigateAgentComposerInputHistory,
+  projectAgentComposerInputHistory,
+  resolvePendingAgentComposerInputHistory
+} from "./agentComposerInputHistory";
+
+describe("agent composer input history", () => {
+  it("projects structured user input and keeps the newest adjacent duplicate", () => {
+    const conversation = conversationWithUserMessages([
+      {
+        id: "message-1",
+        body: "expanded prompt",
+        sourceTimelineItems: [
+          {
+            payload: {
+              content: [
+                { type: "text", text: "expanded prompt" },
+                {
+                  type: "image",
+                  attachmentId: "attachment-1",
+                  mimeType: "image/png",
+                  name: "one.png"
+                }
+              ],
+              displayPrompt: "original prompt"
+            }
+          }
+        ]
+      },
+      {
+        id: "message-2",
+        body: "original prompt",
+        sourceTimelineItems: [
+          {
+            payload: {
+              content: [
+                { type: "text", text: "expanded prompt" },
+                {
+                  type: "image",
+                  attachmentId: "attachment-1",
+                  mimeType: "image/png",
+                  name: "one.png"
+                }
+              ],
+              displayPrompt: "original prompt"
+            }
+          }
+        ]
+      }
+    ]);
+
+    const history = projectAgentComposerInputHistory(conversation);
+
+    expect(history).toHaveLength(1);
+    expect(history[0]!.id).toBe("turn-1:message-2");
+    expect(agentComposerDraftPrompt(history[0]!.draft)).toBe("original prompt");
+    expect(agentComposerDraftImages(history[0]!.draft)).toEqual([
+      expect.objectContaining({
+        attachmentId: "attachment-1",
+        previewUrl: ""
+      })
+    ]);
+  });
+
+  it("does not restore a synthetic image-only display prompt as text", () => {
+    const history = projectAgentComposerInputHistory(
+      conversationWithUserMessages([
+        {
+          id: "image-message",
+          body: "[Image]",
+          sourceTimelineItems: [
+            {
+              payload: {
+                content: [
+                  {
+                    type: "image",
+                    path: "/tmp/image.png",
+                    mimeType: "image/png"
+                  }
+                ],
+                displayPrompt: "[Image]"
+              }
+            }
+          ]
+        }
+      ])
+    );
+
+    expect(agentComposerDraftPrompt(history[0]!.draft)).toBe("");
+    expect(agentComposerDraftImages(history[0]!.draft)).toHaveLength(1);
+  });
+
+  it("navigates from empty to older entries and clears past the newest", () => {
+    const entries = [
+      { id: "one", draft: buildAgentComposerDraft({ prompt: "one" }) },
+      { id: "two", draft: buildAgentComposerDraft({ prompt: "two" }) }
+    ];
+    const latest = navigateAgentComposerInputHistory({
+      currentDraft: emptyAgentComposerDraft(),
+      direction: "older",
+      entries,
+      hasOlderPage: false,
+      state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
+    });
+    const older = navigateAgentComposerInputHistory({
+      currentDraft: latest.draft!,
+      direction: "older",
+      entries,
+      hasOlderPage: false,
+      state: latest.state
+    });
+    const newer = navigateAgentComposerInputHistory({
+      currentDraft: older.draft!,
+      direction: "newer",
+      entries,
+      hasOlderPage: false,
+      state: older.state
+    });
+    const cleared = navigateAgentComposerInputHistory({
+      currentDraft: newer.draft!,
+      direction: "newer",
+      entries,
+      hasOlderPage: false,
+      state: newer.state
+    });
+
+    expect(agentComposerDraftPrompt(latest.draft!)).toBe("two");
+    expect(agentComposerDraftPrompt(older.draft!)).toBe("one");
+    expect(agentComposerDraftPrompt(newer.draft!)).toBe("two");
+    expect(cleared.state.entryId).toBeNull();
+    expect(agentComposerDraftPrompt(cleared.draft!)).toBe("");
+  });
+
+  it("leaves a typed or edited draft to normal arrow-key behavior", () => {
+    const entries = [
+      { id: "one", draft: buildAgentComposerDraft({ prompt: "one" }) }
+    ];
+
+    expect(
+      navigateAgentComposerInputHistory({
+        currentDraft: buildAgentComposerDraft({ prompt: "typed" }),
+        direction: "older",
+        entries,
+        hasOlderPage: false,
+        state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
+      }).handled
+    ).toBe(false);
+    expect(
+      navigateAgentComposerInputHistory({
+        currentDraft: buildAgentComposerDraft({ prompt: "edited" }),
+        direction: "older",
+        entries,
+        hasOlderPage: false,
+        state: { entryId: "one", pendingOlderPage: false }
+      })
+    ).toMatchObject({
+      handled: false,
+      state: { entryId: null }
+    });
+  });
+
+  it("starts again from the newest entry after a recalled draft is cleared", () => {
+    const entries = [
+      { id: "one", draft: buildAgentComposerDraft({ prompt: "one" }) },
+      { id: "two", draft: buildAgentComposerDraft({ prompt: "two" }) }
+    ];
+
+    const navigation = navigateAgentComposerInputHistory({
+      currentDraft: emptyAgentComposerDraft(),
+      direction: "older",
+      entries,
+      hasOlderPage: false,
+      state: { entryId: "one", pendingOlderPage: false }
+    });
+
+    expect(navigation.state.entryId).toBe("two");
+    expect(agentComposerDraftPrompt(navigation.draft!)).toBe("two");
+  });
+
+  it("requests an older page and resolves to the prepended entry", () => {
+    const current = {
+      id: "current",
+      draft: buildAgentComposerDraft({ prompt: "current" })
+    };
+    const pending = navigateAgentComposerInputHistory({
+      currentDraft: current.draft,
+      direction: "older",
+      entries: [current],
+      hasOlderPage: true,
+      state: { entryId: current.id, pendingOlderPage: false }
+    });
+    const older = {
+      id: "older",
+      draft: buildAgentComposerDraft({ prompt: "older" })
+    };
+    const resolved = resolvePendingAgentComposerInputHistory({
+      entries: [older, current],
+      state: pending.state
+    });
+
+    expect(pending).toMatchObject({
+      handled: true,
+      requestOlderPage: true,
+      state: { pendingOlderPage: true }
+    });
+    expect(resolved?.state.entryId).toBe("older");
+    expect(agentComposerDraftPrompt(resolved!.draft!)).toBe("older");
+  });
+});
+
+function conversationWithUserMessages(
+  messages: Array<{
+    id: string;
+    body: string;
+    sourceTimelineItems?: Array<{
+      payload: Record<string, unknown>;
+    }>;
+  }>
+): AgentConversationVM {
+  return {
+    sourceDetail: {
+      turns: [
+        {
+          id: "turn-1",
+          userMessages: messages
+        }
+      ]
+    }
+  } as unknown as AgentConversationVM;
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
 import {
+  agentComposerDraftFiles,
   agentComposerDraftImages,
+  agentComposerDraftLargeTexts,
   agentComposerDraftPrompt,
+  agentComposerDraftToPromptContent,
   buildAgentComposerDraft,
   emptyAgentComposerDraft
 } from "./agentComposerDraft";
+import { createAgentComposerFileMentionMarkdown } from "../agentRichText/agentMentionMarkdown";
 import {
   EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE,
   navigateAgentComposerInputHistory,
@@ -62,7 +66,7 @@ describe("agent composer input history", () => {
 
     expect(history).toHaveLength(1);
     expect(history[0]!.id).toBe("turn-1:message-2");
-    expect(agentComposerDraftPrompt(history[0]!.draft)).toBe("original prompt");
+    expect(agentComposerDraftPrompt(history[0]!.draft)).toBe("expanded prompt");
     expect(agentComposerDraftImages(history[0]!.draft)).toEqual([
       expect.objectContaining({
         attachmentId: "attachment-1",
@@ -97,6 +101,142 @@ describe("agent composer input history", () => {
 
     expect(agentComposerDraftPrompt(history[0]!.draft)).toBe("");
     expect(agentComposerDraftImages(history[0]!.draft)).toHaveLength(1);
+  });
+
+  it("restores a file-only structured input with a resendable mention", () => {
+    const displayPrompt = createAgentComposerFileMentionMarkdown({
+      id: "original-file",
+      name: "report.pdf",
+      status: "ready"
+    });
+    const history = projectAgentComposerInputHistory(
+      conversationWithUserMessages([
+        {
+          id: "file-message",
+          body: displayPrompt,
+          sourceTimelineItems: [
+            {
+              payload: {
+                content: [
+                  {
+                    type: "file",
+                    kind: "file",
+                    name: "report.pdf",
+                    path: "/runtime/report.pdf"
+                  }
+                ],
+                displayPrompt
+              }
+            }
+          ]
+        }
+      ])
+    );
+
+    expect(history).toHaveLength(1);
+    expect(agentComposerDraftFiles(history[0]!.draft)).toHaveLength(1);
+    expect(
+      agentComposerDraftToPromptContent({
+        draft: history[0]!.draft,
+        skills: []
+      })
+    ).toEqual([
+      {
+        type: "text",
+        text: "[@report.pdf](/runtime/report.pdf)"
+      }
+    ]);
+  });
+
+  it("restores mixed text and file input without dropping the file on resend", () => {
+    const fileMention = createAgentComposerFileMentionMarkdown({
+      id: "original-file",
+      name: "report.pdf",
+      status: "ready"
+    });
+    const history = projectAgentComposerInputHistory(
+      conversationWithUserMessages([
+        {
+          id: "mixed-message",
+          body: `Summarize${fileMention}`,
+          sourceTimelineItems: [
+            {
+              payload: {
+                content: [
+                  { type: "text", text: "Summarize" },
+                  {
+                    type: "file",
+                    kind: "file",
+                    name: "report.pdf",
+                    path: "/runtime/report.pdf"
+                  }
+                ],
+                displayPrompt: `Summarize${fileMention}`
+              }
+            }
+          ]
+        }
+      ])
+    );
+
+    expect(agentComposerDraftFiles(history[0]!.draft)).toHaveLength(1);
+    expect(
+      agentComposerDraftToPromptContent({
+        draft: history[0]!.draft,
+        skills: []
+      })
+    ).toEqual([
+      {
+        type: "text",
+        text: "Summarize[@report.pdf](/runtime/report.pdf)"
+      }
+    ]);
+  });
+
+  it("restores pasted text without resending its display mention as text", () => {
+    const history = projectAgentComposerInputHistory(
+      conversationWithUserMessages([
+        {
+          id: "pasted-text-message",
+          body: "Summarize this",
+          sourceTimelineItems: [
+            {
+              payload: {
+                content: [
+                  { type: "text", text: "Summarize this" },
+                  {
+                    type: "file",
+                    kind: "pasted-text",
+                    name: "first line…",
+                    path: "/archive/aa/deadbeef.txt",
+                    sizeBytes: 22
+                  }
+                ],
+                displayPrompt:
+                  "Summarize this\n[@first line…](mention://pasted-text/original-paste?path=%2Farchive%2Faa%2Fdeadbeef.txt&size=22)"
+              }
+            }
+          ]
+        }
+      ])
+    );
+
+    expect(agentComposerDraftLargeTexts(history[0]!.draft)).toHaveLength(1);
+    expect(
+      agentComposerDraftToPromptContent({
+        draft: history[0]!.draft,
+        skills: []
+      })
+    ).toEqual([
+      { type: "text", text: "Summarize this" },
+      {
+        type: "file",
+        kind: "pasted-text",
+        name: "first line…",
+        path: "/archive/aa/deadbeef.txt",
+        sizeBytes: 22
+      }
+    ]);
   });
 
   it("navigates from empty to older entries and clears past the newest", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.ts
@@ -1,0 +1,333 @@
+import type { AgentPromptContentBlock } from "../../../shared/contracts/dto";
+import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
+import type { AgentComposerDraft } from "./agentGuiNodeTypes";
+import {
+  agentComposerDraftHasContent,
+  agentPromptContentToComposerDraft,
+  buildAgentComposerDraft,
+  emptyAgentComposerDraft,
+  updateAgentComposerDraft
+} from "./agentComposerDraft";
+
+export interface AgentComposerInputHistoryEntry {
+  id: string;
+  draft: AgentComposerDraft;
+}
+
+export interface AgentComposerInputHistoryState {
+  entryId: string | null;
+  pendingOlderPage: boolean;
+}
+
+export interface AgentComposerInputHistoryNavigation {
+  draft?: AgentComposerDraft;
+  handled: boolean;
+  requestOlderPage: boolean;
+  state: AgentComposerInputHistoryState;
+}
+
+export const EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE: AgentComposerInputHistoryState =
+  {
+    entryId: null,
+    pendingOlderPage: false
+  };
+
+const inputHistoryByConversation = new WeakMap<
+  AgentConversationVM,
+  AgentComposerInputHistoryEntry[]
+>();
+
+export function projectAgentComposerInputHistory(
+  conversation: AgentConversationVM | null
+): AgentComposerInputHistoryEntry[] {
+  if (!conversation) {
+    return [];
+  }
+  const cached = inputHistoryByConversation.get(conversation);
+  if (cached) {
+    return cached;
+  }
+  const entries: AgentComposerInputHistoryEntry[] = [];
+  for (const turn of conversation.sourceDetail.turns) {
+    for (const message of turn.userMessages) {
+      const entry = projectHistoryEntry(message, turn.id);
+      if (!entry) {
+        continue;
+      }
+      const previous = entries.at(-1);
+      if (
+        previous &&
+        historyEntryDuplicateKey(previous) === historyEntryDuplicateKey(entry)
+      ) {
+        // Keep the newest duplicate id. Prepending an older page then cannot
+        // invalidate a cursor that already points at the loaded copy.
+        entries[entries.length - 1] = entry;
+      } else {
+        entries.push(entry);
+      }
+    }
+  }
+  inputHistoryByConversation.set(conversation, entries);
+  return entries;
+}
+
+export function navigateAgentComposerInputHistory(input: {
+  currentDraft: AgentComposerDraft;
+  direction: "older" | "newer";
+  entries: readonly AgentComposerInputHistoryEntry[];
+  hasOlderPage: boolean;
+  state: AgentComposerInputHistoryState;
+}): AgentComposerInputHistoryNavigation {
+  let currentIndex = input.state.entryId
+    ? input.entries.findIndex((entry) => entry.id === input.state.entryId)
+    : -1;
+  if (
+    input.state.entryId &&
+    (currentIndex < 0 ||
+      !areAgentComposerHistoryDraftsEqual(
+        input.currentDraft,
+        input.entries[currentIndex]!.draft
+      ))
+  ) {
+    if (agentComposerDraftHasContent(input.currentDraft)) {
+      return unhandledHistoryNavigation();
+    }
+    currentIndex = -1;
+  }
+
+  if (currentIndex < 0) {
+    if (
+      input.direction === "newer" ||
+      agentComposerDraftHasContent(input.currentDraft)
+    ) {
+      return unhandledHistoryNavigation();
+    }
+    const latest = input.entries.at(-1);
+    if (latest) {
+      return recalledHistoryNavigation(latest);
+    }
+    if (input.hasOlderPage) {
+      return olderPageHistoryNavigation(null);
+    }
+    return unhandledHistoryNavigation();
+  }
+
+  if (input.direction === "older") {
+    const older = input.entries[currentIndex - 1];
+    if (older) {
+      return recalledHistoryNavigation(older);
+    }
+    if (input.hasOlderPage) {
+      return olderPageHistoryNavigation(input.state.entryId);
+    }
+    return {
+      handled: false,
+      requestOlderPage: false,
+      state: { entryId: input.state.entryId, pendingOlderPage: false }
+    };
+  }
+
+  const newer = input.entries[currentIndex + 1];
+  if (newer) {
+    return recalledHistoryNavigation(newer);
+  }
+  return {
+    draft: emptyAgentComposerDraft(),
+    handled: true,
+    requestOlderPage: false,
+    state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
+  };
+}
+
+export function resolvePendingAgentComposerInputHistory(input: {
+  entries: readonly AgentComposerInputHistoryEntry[];
+  state: AgentComposerInputHistoryState;
+}): AgentComposerInputHistoryNavigation | null {
+  if (!input.state.pendingOlderPage) {
+    return null;
+  }
+  if (input.state.entryId === null) {
+    const latest = input.entries.at(-1);
+    return latest
+      ? recalledHistoryNavigation(latest)
+      : {
+          handled: false,
+          requestOlderPage: false,
+          state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
+        };
+  }
+  const currentIndex = input.entries.findIndex(
+    (entry) => entry.id === input.state.entryId
+  );
+  const older = currentIndex > 0 ? input.entries[currentIndex - 1] : null;
+  return older
+    ? recalledHistoryNavigation(older)
+    : {
+        handled: false,
+        requestOlderPage: false,
+        state: { entryId: input.state.entryId, pendingOlderPage: false }
+      };
+}
+
+export function areAgentComposerHistoryDraftsEqual(
+  left: AgentComposerDraft,
+  right: AgentComposerDraft
+): boolean {
+  return historyDraftValue(left) === historyDraftValue(right);
+}
+
+function projectHistoryEntry(
+  message: AgentConversationVM["sourceDetail"]["turns"][number]["userMessages"][number],
+  fallbackTurnId: string
+): AgentComposerInputHistoryEntry | null {
+  const sourceItem = message.sourceTimelineItems?.find((item) =>
+    Array.isArray(item.payload?.content)
+  );
+  const rawContent = Array.isArray(sourceItem?.payload?.content)
+    ? sourceItem.payload.content
+    : [];
+  const content = rawContent.filter((block): block is AgentPromptContentBlock =>
+    Boolean(block && typeof block === "object" && !Array.isArray(block))
+  );
+  const displayPrompt =
+    message.sourceTimelineItems
+      ?.map((item) =>
+        typeof item.payload?.displayPrompt === "string"
+          ? item.payload.displayPrompt.trim()
+          : ""
+      )
+      .find(Boolean) ?? "";
+  const visibleDisplayPrompt = isSyntheticImageOnlyDisplayPrompt(
+    displayPrompt,
+    rawContent
+  )
+    ? ""
+    : displayPrompt;
+  let draft =
+    content.length > 0
+      ? agentPromptContentToComposerDraft(
+          content,
+          `history-${message.turnId ?? fallbackTurnId}-${message.id}`
+        )
+      : buildAgentComposerDraft({ prompt: message.body });
+  if (visibleDisplayPrompt) {
+    draft = updateAgentComposerDraft(draft, {
+      prompt: visibleDisplayPrompt
+    });
+  }
+  if (!agentComposerDraftHasContent(draft)) {
+    return null;
+  }
+  const entry = {
+    id: `${message.turnId ?? fallbackTurnId}:${message.id}`,
+    draft
+  };
+  historyDuplicateKeyByEntry.set(
+    entry,
+    JSON.stringify({
+      content,
+      prompt: visibleDisplayPrompt || (content.length === 0 ? message.body : "")
+    })
+  );
+  return entry;
+}
+
+const historyDuplicateKeyByEntry = new WeakMap<
+  AgentComposerInputHistoryEntry,
+  string
+>();
+
+function historyEntryDuplicateKey(
+  entry: AgentComposerInputHistoryEntry
+): string {
+  const cached = historyDuplicateKeyByEntry.get(entry);
+  if (cached) {
+    return cached;
+  }
+  const key = historyDraftValueWithOptions(entry.draft, true);
+  historyDuplicateKeyByEntry.set(entry, key);
+  return key;
+}
+
+function isSyntheticImageOnlyDisplayPrompt(
+  displayPrompt: string,
+  content: readonly unknown[]
+): boolean {
+  if (displayPrompt !== "[Image]" && displayPrompt !== "[Images]") {
+    return false;
+  }
+  let imageCount = 0;
+  for (const raw of content) {
+    const block =
+      raw && typeof raw === "object" && !Array.isArray(raw)
+        ? (raw as Record<string, unknown>)
+        : null;
+    if (!block) {
+      continue;
+    }
+    if (
+      block.type === "text" &&
+      typeof block.text === "string" &&
+      block.text.trim()
+    ) {
+      return false;
+    }
+    if (block.type === "image") {
+      imageCount += 1;
+    }
+  }
+  return displayPrompt === "[Image]" ? imageCount === 1 : imageCount > 1;
+}
+
+function recalledHistoryNavigation(
+  entry: AgentComposerInputHistoryEntry
+): AgentComposerInputHistoryNavigation {
+  return {
+    draft: entry.draft,
+    handled: true,
+    requestOlderPage: false,
+    state: { entryId: entry.id, pendingOlderPage: false }
+  };
+}
+
+function olderPageHistoryNavigation(
+  entryId: string | null
+): AgentComposerInputHistoryNavigation {
+  return {
+    handled: true,
+    requestOlderPage: true,
+    state: { entryId, pendingOlderPage: true }
+  };
+}
+
+function unhandledHistoryNavigation(): AgentComposerInputHistoryNavigation {
+  return {
+    handled: false,
+    requestOlderPage: false,
+    state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
+  };
+}
+
+function historyDraftValue(draft: AgentComposerDraft): string {
+  return historyDraftValueWithOptions(draft, false);
+}
+
+function historyDraftValueWithOptions(
+  draft: AgentComposerDraft,
+  ignoreGeneratedIds: boolean
+): string {
+  return JSON.stringify(
+    draft.map((block) =>
+      block.type === "image"
+        ? {
+            ...block,
+            ...(ignoreGeneratedIds ? { id: "" } : {}),
+            // Preview data is presentation-only and may arrive asynchronously.
+            previewUrl: ""
+          }
+        : block.type === "file" && ignoreGeneratedIds
+          ? { ...block, id: "" }
+          : block
+    )
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.ts
@@ -5,8 +5,7 @@ import {
   agentComposerDraftHasContent,
   agentPromptContentToComposerDraft,
   buildAgentComposerDraft,
-  emptyAgentComposerDraft,
-  updateAgentComposerDraft
+  emptyAgentComposerDraft
 } from "./agentComposerDraft";
 
 export interface AgentComposerInputHistoryEntry {
@@ -203,18 +202,15 @@ function projectHistoryEntry(
   )
     ? ""
     : displayPrompt;
-  let draft =
+  const draft =
     content.length > 0
       ? agentPromptContentToComposerDraft(
           content,
           `history-${message.turnId ?? fallbackTurnId}-${message.id}`
         )
-      : buildAgentComposerDraft({ prompt: message.body });
-  if (visibleDisplayPrompt) {
-    draft = updateAgentComposerDraft(draft, {
-      prompt: visibleDisplayPrompt
-    });
-  }
+      : buildAgentComposerDraft({
+          prompt: visibleDisplayPrompt || message.body
+        });
   if (!agentComposerDraftHasContent(draft)) {
     return null;
   }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -1,36 +1,12 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { WorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-project/i18n";
-import type { WorkspaceLinkAction } from "../../../actions/workspaceLinkActions";
-import type { UiLanguage } from "../../../contexts/settings/domain/agentSettings";
 import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../../shared/AgentMessageMarkdown";
 import { latestAssistantMessageText } from "../../../shared/agentConversation/projection/agentConversationProjection";
 import { AGENT_GUI_WORKBENCH_OPEN_EXTERNAL_IMPORT_EVENT } from "../../../workbench/contribution";
 import { resolveAgentGuiWorkbenchProviderLabel } from "../../../workbench/providerCatalog";
-import type {
-  AgentComposerGitBranchLoader,
-  AgentComposerProps,
-  AgentComposerSlashStatusLimit,
-  WorkspaceReferencePickResult
-} from "../AgentComposer";
-import type { AgentContextMentionItem } from "../agentRichText/agentFileMentionExtension";
-import type {
-  AgentGUIComposerViewModel,
-  AgentGUIDetailViewModel,
-  AgentHomeSuggestionAction,
-  AgentGUIInteractionViewModel,
-  AgentGUIOperationsViewModel,
-  AgentGUIRailViewModel,
-  AgentGUIReadinessViewModel,
-  AgentGUIShellViewModel
-} from "../model/agentGuiNodeTypes";
+import type { AgentComposerProps } from "../AgentComposer";
+import type { AgentHomeSuggestionAction } from "../model/agentGuiNodeTypes";
 import { updateAgentComposerDraft } from "../model/agentComposerDraft";
 import { resolveAgentComposerDraftScopeKey } from "../model/agentComposerDraftScope";
-import type { AgentGUIManagedHomeTargetProjection } from "../model/agentGuiProviderRailOrder";
-import type {
-  AgentGUINodeViewProps,
-  AgentGUIProviderUnavailableStateRenderer,
-  AgentGUIViewLabels
-} from "../AgentGUINodeView";
 import {
   buildAgentConversationHandoffPrompt,
   handoffProjectPathForConversation
@@ -51,58 +27,11 @@ import styles from "../AgentGUINode.styles";
 import { useAgentGUIDetailScroll } from "./useAgentGUIDetailScroll";
 import { useAgentGUIDetailModel } from "./useAgentGUIDetailModel";
 import { useAgentGUIComposerInputHistoryProps } from "./useAgentGUIComposerInputHistoryProps";
-import type { AgentGUIComposerEngagement } from "../engagement/agentGUIEngagement.types";
 import { useAgentGUITuttiWorkflow } from "./useAgentGUITuttiWorkflow";
 import type { AgentTranscriptVirtualScrollController } from "../../../shared/agentConversation/components/AgentTranscriptView";
+import type { AgentGUIDetailPaneProps } from "./AgentGUINodeView.types";
 export const EMPTY_WORKSPACE_APP_ICONS: readonly AgentMessageMarkdownWorkspaceAppIcon[] =
   [];
-export interface AgentGUIDetailPaneProps {
-  shell: AgentGUIShellViewModel;
-  rail: AgentGUIRailViewModel;
-  detail: AgentGUIDetailViewModel;
-  composer: AgentGUIComposerViewModel;
-  interaction: AgentGUIInteractionViewModel;
-  readiness: AgentGUIReadinessViewModel;
-  operations: AgentGUIOperationsViewModel;
-  homeTargetProjection: AgentGUIManagedHomeTargetProjection;
-  referenceProvenanceFilters?: AgentComposerProps["referenceProvenanceFilters"];
-  sessionInputHistoryEnabled?: boolean;
-  composerEngagement?: AgentGUIComposerEngagement;
-  actions: AgentGUINodeViewProps["actions"];
-  labels: AgentGUIViewLabels;
-  workspaceUserProjectI18n: WorkspaceUserProjectI18nRuntime;
-  uiLanguage: UiLanguage;
-  isActive: boolean;
-  isVisible: boolean;
-  workspaceReferencePickerOpen: boolean;
-  composerFocusRequestSequence: number | null;
-  slashStatusLimits: readonly AgentComposerSlashStatusLimit[];
-  slashStatusLimitsLoading: boolean;
-  slashStatusLimitsUnavailable: boolean;
-  slashStatusOverride?: AgentComposerProps["slashStatus"];
-  onSlashStatusOpen?: AgentComposerProps["onSlashStatusOpen"];
-  onSlashStatusClose?: AgentComposerProps["onSlashStatusClose"];
-  onSlashStatusRefresh?: AgentComposerProps["onSlashStatusRefresh"];
-  onLinkAction?: (action: WorkspaceLinkAction) => void;
-  onHandoffConversation?: AgentGUINodeViewProps["onHandoffConversation"];
-  capabilityMenuState?: AgentComposerProps["capabilityMenuState"];
-  capabilityControlsReadOnly?: AgentComposerProps["capabilityControlsReadOnly"];
-  onCapabilitySettingsRequest?: AgentComposerProps["onCapabilitySettingsRequest"];
-  onAgentProviderLogin?: (provider?: string | null) => void;
-  onRequestWorkspaceReferences?:
-    | ((
-        entity?: AgentContextMentionItem | null
-      ) => Promise<WorkspaceReferencePickResult>)
-    | null;
-  resolveExternalPromptEntries?: AgentComposerProps["resolveExternalPromptEntries"];
-  prepareExternalPromptFiles?: AgentComposerProps["prepareExternalPromptFiles"];
-  promptAssetLimit?: number | null;
-  selectProjectDirectory?: () => Promise<{ path: string } | null>;
-  onRequestGitBranches?: AgentComposerGitBranchLoader | null;
-  onRequestComposerFocus: () => void;
-  workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
-  renderProviderUnavailableState?: AgentGUIProviderUnavailableStateRenderer;
-}
 export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
   shell,
   rail,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -50,10 +50,10 @@ import {
 import styles from "../AgentGUINode.styles";
 import { useAgentGUIDetailScroll } from "./useAgentGUIDetailScroll";
 import { useAgentGUIDetailModel } from "./useAgentGUIDetailModel";
+import { useAgentGUIComposerInputHistoryProps } from "./useAgentGUIComposerInputHistoryProps";
 import type { AgentGUIComposerEngagement } from "../engagement/agentGUIEngagement.types";
 import { useAgentGUITuttiWorkflow } from "./useAgentGUITuttiWorkflow";
 import type { AgentTranscriptVirtualScrollController } from "../../../shared/agentConversation/components/AgentTranscriptView";
-
 export const EMPTY_WORKSPACE_APP_ICONS: readonly AgentMessageMarkdownWorkspaceAppIcon[] =
   [];
 export interface AgentGUIDetailPaneProps {
@@ -66,6 +66,7 @@ export interface AgentGUIDetailPaneProps {
   operations: AgentGUIOperationsViewModel;
   homeTargetProjection: AgentGUIManagedHomeTargetProjection;
   referenceProvenanceFilters?: AgentComposerProps["referenceProvenanceFilters"];
+  sessionInputHistoryEnabled?: boolean;
   composerEngagement?: AgentGUIComposerEngagement;
   actions: AgentGUINodeViewProps["actions"];
   labels: AgentGUIViewLabels;
@@ -102,7 +103,6 @@ export interface AgentGUIDetailPaneProps {
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
   renderProviderUnavailableState?: AgentGUIProviderUnavailableStateRenderer;
 }
-
 export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
   shell,
   rail,
@@ -113,6 +113,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
   operations,
   homeTargetProjection,
   referenceProvenanceFilters = null,
+  sessionInputHistoryEnabled = false,
   composerEngagement,
   actions,
   labels,
@@ -401,6 +402,14 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
           })
       : undefined
   );
+  const composerInputHistoryProps = useAgentGUIComposerInputHistoryProps({
+    actions,
+    conversation,
+    enabled: sessionInputHistoryEnabled,
+    pendingPrependScrollAnchorRef,
+    timelineRef,
+    viewModel
+  });
   const bottomDockComposerProps = useMemo<AgentComposerProps>(
     () => ({
       workspaceId: viewModel.shell.workspaceId,
@@ -418,6 +427,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       draftScopeKey: resolveAgentComposerDraftScopeKey({
         agentSessionId: viewModel.rail.activeConversationId
       }),
+      ...composerInputHistoryProps,
       availableCommands: viewModel.composer.availableCommands,
       hasCompactableContext: viewModel.detail.hasSentUserMessage,
       compactSupported: viewModel.composer.compactSupported,
@@ -533,6 +543,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       composerDisabledReason,
       composerFocusRequestSequence,
       composerEngagement,
+      composerInputHistoryProps,
       composerHandoffProviderTargets,
       composerLabels,
       conversation,
@@ -721,7 +732,6 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       />
     )
   ) : null;
-
   return (
     <main
       className={styles.detail}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -27,7 +27,8 @@ import type {
   AgentComposerProps,
   AgentComposerReferenceProvenanceFilters,
   AgentComposerPromptTip,
-  AgentComposerSlashStatusLimit
+  AgentComposerSlashStatusLimit,
+  WorkspaceReferencePickResult
 } from "../AgentComposer";
 import type { AgentContextMentionItem } from "../agentRichText/agentFileMentionExtension";
 import type {
@@ -35,7 +36,11 @@ import type {
   AgentHomeSuggestionCategory,
   AgentGUINodeViewModel
 } from "../model/agentGuiNodeTypes";
-import type { AgentGUIEngagementEventSink } from "../engagement/agentGUIEngagement.types";
+import type {
+  AgentGUIComposerEngagement,
+  AgentGUIEngagementEventSink
+} from "../engagement/agentGUIEngagement.types";
+import type { AgentGUIManagedHomeTargetProjection } from "../model/agentGuiProviderRailOrder";
 import type { OpenAgentEnvPanelInput } from "../../../shared/agentEnv";
 import type {
   TuttiModePlanPanelLabels,
@@ -690,6 +695,54 @@ export interface AgentGUINodeViewProps {
   resolveMentionReferenceTarget?: AgentMentionReferenceTargetResolver | null;
   resolveWorkspaceReferenceInitialTarget?: AgentWorkspaceReferenceInitialTargetResolver | null;
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
+}
+
+export interface AgentGUIDetailPaneProps {
+  shell: AgentGUINodeViewModel["shell"];
+  rail: AgentGUINodeViewModel["rail"];
+  detail: AgentGUINodeViewModel["detail"];
+  composer: AgentGUINodeViewModel["composer"];
+  interaction: AgentGUINodeViewModel["interaction"];
+  readiness: AgentGUINodeViewModel["readiness"];
+  operations: AgentGUINodeViewModel["operations"];
+  homeTargetProjection: AgentGUIManagedHomeTargetProjection;
+  referenceProvenanceFilters?: AgentComposerProps["referenceProvenanceFilters"];
+  sessionInputHistoryEnabled?: boolean;
+  composerEngagement?: AgentGUIComposerEngagement;
+  actions: AgentGUINodeViewProps["actions"];
+  labels: AgentGUIViewLabels;
+  workspaceUserProjectI18n: WorkspaceUserProjectI18nRuntime;
+  uiLanguage: UiLanguage;
+  isActive: boolean;
+  isVisible: boolean;
+  workspaceReferencePickerOpen: boolean;
+  composerFocusRequestSequence: number | null;
+  slashStatusLimits: readonly AgentComposerSlashStatusLimit[];
+  slashStatusLimitsLoading: boolean;
+  slashStatusLimitsUnavailable: boolean;
+  slashStatusOverride?: AgentComposerProps["slashStatus"];
+  onSlashStatusOpen?: AgentComposerProps["onSlashStatusOpen"];
+  onSlashStatusClose?: AgentComposerProps["onSlashStatusClose"];
+  onSlashStatusRefresh?: AgentComposerProps["onSlashStatusRefresh"];
+  onLinkAction?: (action: WorkspaceLinkAction) => void;
+  onHandoffConversation?: AgentGUINodeViewProps["onHandoffConversation"];
+  capabilityMenuState?: AgentComposerProps["capabilityMenuState"];
+  capabilityControlsReadOnly?: AgentComposerProps["capabilityControlsReadOnly"];
+  onCapabilitySettingsRequest?: AgentComposerProps["onCapabilitySettingsRequest"];
+  onAgentProviderLogin?: (provider?: string | null) => void;
+  onRequestWorkspaceReferences?:
+    | ((
+        entity?: AgentContextMentionItem | null
+      ) => Promise<WorkspaceReferencePickResult>)
+    | null;
+  resolveExternalPromptEntries?: AgentComposerProps["resolveExternalPromptEntries"];
+  prepareExternalPromptFiles?: AgentComposerProps["prepareExternalPromptFiles"];
+  promptAssetLimit?: number | null;
+  selectProjectDirectory?: () => Promise<{ path: string } | null>;
+  onRequestGitBranches?: AgentComposerGitBranchLoader | null;
+  onRequestComposerFocus: () => void;
+  workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
+  renderProviderUnavailableState?: AgentGUIProviderUnavailableStateRenderer;
 }
 
 export interface AgentGUISidebarFooterContext {

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -516,6 +516,7 @@ export type AgentGUIConversationRailLabels = Pick<
 export interface AgentGUINodeViewProps {
   viewModel: AgentGUINodeViewModel;
   referenceProvenanceFilters?: AgentComposerReferenceProvenanceFilters | null;
+  sessionInputHistoryEnabled?: boolean;
   renderProjectDirectoryPickerHeaderActions?: ReferenceSourcePickerProps["renderHeaderActions"];
   renderSidebarFooter?: AgentGUISidebarFooterRenderer;
   /** Renders the provider rail empty state in "exact" mode. See the type doc. */

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIComposerInputHistoryProps.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIComposerInputHistoryProps.spec.tsx
@@ -1,0 +1,71 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
+import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
+import type { AgentGUINodeViewProps } from "./AgentGUINodeView.types";
+import { useAgentGUIComposerInputHistoryProps } from "./useAgentGUIComposerInputHistoryProps";
+
+describe("useAgentGUIComposerInputHistoryProps", () => {
+  it("keeps history disabled until the host opts in", () => {
+    const timeline = document.createElement("div");
+    Object.defineProperties(timeline, {
+      scrollHeight: { value: 900 },
+      scrollTop: { value: 120, writable: true }
+    });
+    const loadOlderConversationMessages = vi.fn();
+    const pendingPrependScrollAnchorRef = { current: null };
+    const input = {
+      actions: {
+        loadOlderConversationMessages
+      } as unknown as AgentGUINodeViewProps["actions"],
+      conversation: conversationWithPrompt(),
+      pendingPrependScrollAnchorRef,
+      timelineRef: { current: timeline },
+      viewModel: {
+        rail: { activeConversationId: "session-1" },
+        detail: {
+          hasOlderMessages: true,
+          isLoadingOlderMessages: false
+        }
+      } as AgentGUINodeViewModel
+    };
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        useAgentGUIComposerInputHistoryProps({ ...input, enabled }),
+      { initialProps: { enabled: false } }
+    );
+
+    expect(result.current).toEqual({
+      inputHistory: [],
+      inputHistoryHasOlderPage: false,
+      inputHistoryIsLoadingOlderPage: false,
+      onRequestOlderInputHistoryPage: undefined
+    });
+
+    rerender({ enabled: true });
+
+    expect(result.current.inputHistory).toHaveLength(1);
+    act(() => {
+      result.current.onRequestOlderInputHistoryPage?.();
+    });
+    expect(loadOlderConversationMessages).toHaveBeenCalledOnce();
+    expect(pendingPrependScrollAnchorRef.current).toEqual({
+      conversationId: "session-1",
+      scrollHeight: 900,
+      scrollTop: 120
+    });
+  });
+});
+
+function conversationWithPrompt(): AgentConversationVM {
+  return {
+    sourceDetail: {
+      turns: [
+        {
+          id: "turn-1",
+          userMessages: [{ id: "message-1", body: "hello" }]
+        }
+      ]
+    }
+  } as unknown as AgentConversationVM;
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIComposerInputHistoryProps.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIComposerInputHistoryProps.ts
@@ -1,0 +1,71 @@
+import { useMemo, type RefObject } from "react";
+import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
+import type { AgentComposerProps } from "../AgentComposer";
+import type { AgentGUINodeViewProps } from "../AgentGUINodeView";
+import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
+import { projectAgentComposerInputHistory } from "../model/agentComposerInputHistory";
+import { useStableEventCallback } from "./agentGUIViewUtils";
+
+type InputHistoryProps = Pick<
+  AgentComposerProps,
+  | "inputHistory"
+  | "inputHistoryHasOlderPage"
+  | "inputHistoryIsLoadingOlderPage"
+  | "onRequestOlderInputHistoryPage"
+>;
+const EMPTY_INPUT_HISTORY: NonNullable<InputHistoryProps["inputHistory"]> = [];
+
+export function useAgentGUIComposerInputHistoryProps(input: {
+  actions: AgentGUINodeViewProps["actions"];
+  conversation: AgentConversationVM | null;
+  enabled: boolean;
+  pendingPrependScrollAnchorRef: RefObject<{
+    conversationId: string;
+    scrollHeight: number;
+    scrollTop: number;
+  } | null>;
+  timelineRef: RefObject<HTMLDivElement | null>;
+  viewModel: AgentGUINodeViewModel;
+}): InputHistoryProps {
+  const onRequestOlderInputHistoryPage = useStableEventCallback(() => {
+    const activeConversationId = input.viewModel.rail.activeConversationId;
+    if (
+      !activeConversationId ||
+      !input.viewModel.detail.hasOlderMessages ||
+      input.viewModel.detail.isLoadingOlderMessages
+    ) {
+      return;
+    }
+    const timeline = input.timelineRef.current;
+    if (timeline) {
+      input.pendingPrependScrollAnchorRef.current = {
+        conversationId: activeConversationId,
+        scrollHeight: timeline.scrollHeight,
+        scrollTop: timeline.scrollTop
+      };
+    }
+    input.actions.loadOlderConversationMessages();
+  });
+  const inputHistory = input.enabled
+    ? projectAgentComposerInputHistory(input.conversation)
+    : EMPTY_INPUT_HISTORY;
+  return useMemo(
+    () => ({
+      inputHistory,
+      inputHistoryHasOlderPage:
+        input.enabled && input.viewModel.detail.hasOlderMessages,
+      inputHistoryIsLoadingOlderPage:
+        input.enabled && input.viewModel.detail.isLoadingOlderMessages,
+      onRequestOlderInputHistoryPage: input.enabled
+        ? onRequestOlderInputHistoryPage
+        : undefined
+    }),
+    [
+      input.viewModel.detail.hasOlderMessages,
+      input.viewModel.detail.isLoadingOlderMessages,
+      input.enabled,
+      inputHistory,
+      onRequestOlderInputHistoryPage
+    ]
+  );
+}


### PR DESCRIPTION
## Summary
- add current-session composer input history navigation with bare Up/Down
- restore structured drafts and reuse existing older-page loading
- add a default-off `lab.agentInputHistory` Lab switch
- keep restored raw `@` text from opening mention suggestions until the user edits

## Tests
- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm exec vitest run --environment jsdom agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts`

## Notes
- updated the AgentGUI architecture documentation
- live-session visual verification was not run

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->