### PR TITLE
fix(agent-gui): unify owner avatar fallback

### DIFF
--- a/.changeset/agent-owner-avatar-fallback.md
+++ b/.changeset/agent-owner-avatar-fallback.md
@@ -1,0 +1,8 @@
+---
+"@tutti-os/agent-gui": patch
+"@tutti-os/ui-system": patch
+---
+
+Render Agent owner badges through the shared Avatar primitive so failed images
+fall back to the owner initial, and apply a consistent no-referrer default to
+Avatar image requests.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -664,6 +664,9 @@ observe the portaled menu DOM, or infer target identity from provider or
 visible text. The current conversation's composer input availability is
 independent from this launch surface: a target connection may disable input
 while Handoff remains available when the host supplies the launch callback.
+AgentGUI DOM surfaces render the target's owner badge through the shared UI
+System Avatar primitive. A failed owner image falls back to the supplied owner
+label initial instead of exposing a browser broken-image glyph.
 
 For a signed Agent Extension, package `icon` is the primary identity and
 optional package `maskIcon` is the conversation-row glyph. All assets remain

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIOwnerAvatar.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIOwnerAvatar.tsx
@@ -1,0 +1,34 @@
+import { Avatar } from "@tutti-os/ui-system";
+
+interface AgentGUIOwnerAvatarProps {
+  className: string;
+  iconUrl: string;
+  imageClassName?: string;
+  label?: string | null;
+}
+
+export function AgentGUIOwnerAvatar({
+  className,
+  iconUrl,
+  imageClassName,
+  label
+}: AgentGUIOwnerAvatarProps): React.JSX.Element {
+  const ownerLabel = label?.trim() || "?";
+
+  return (
+    <span
+      aria-hidden="true"
+      className={className}
+      data-agent-owner-badge="true"
+    >
+      <Avatar
+        aria-hidden="true"
+        imageClassName={imageClassName}
+        label={ownerLabel}
+        size="md"
+        src={iconUrl}
+        style={{ height: "100%", width: "100%" }}
+      />
+    </span>
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIVinylPlayer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIVinylPlayer.spec.tsx
@@ -1,8 +1,23 @@
 import { render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentGUIVinylPlayer } from "./AgentGUIVinylPlayer";
 
 describe("AgentGUIVinylPlayer", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "Image").mockImplementation(function MockImage() {
+      const image = document.createElement("img");
+      Object.defineProperties(image, {
+        complete: { configurable: true, value: true },
+        naturalWidth: { configurable: true, value: 1 }
+      });
+      return image;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("renders the selected shared agent owner badge", () => {
     const { container } = render(
       <AgentGUIVinylPlayer

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIVinylPlayer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIVinylPlayer.tsx
@@ -4,6 +4,7 @@ import { isBetaAgentProvider } from "../../shared/managedAgentProviders";
 import chassisAssetUrl from "../../app/renderer/assets/icons/agent-vinyl-player-chassis.png";
 import tonearmAssetUrl from "../../app/renderer/assets/icons/agent-vinyl-tonearm.png";
 import betaTagAssetUrl from "../../app/renderer/assets/icons/agent-vinyl-beta-tag.svg";
+import { AgentGUIOwnerAvatar } from "./AgentGUIOwnerAvatar";
 
 interface AgentGUIVinylPlayerProps {
   selectedAgent: AgentGUIAgentAvatarPresentation | null;
@@ -86,12 +87,11 @@ export function AgentGUIVinylPlayer({
         <span>◦</span>
       </div>
       {selectedAgent?.badge?.iconUrl ? (
-        <span
+        <AgentGUIOwnerAvatar
           className="agent-gui-vinyl-player__owner-badge"
-          data-agent-owner-badge="true"
-        >
-          <img src={selectedAgent.badge.iconUrl} alt="" draggable={false} />
-        </span>
+          iconUrl={selectedAgent.badge.iconUrl}
+          label={selectedAgent.badge.label}
+        />
       ) : null}
     </div>
   );

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentHandoffMenu.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentHandoffMenu.tsx
@@ -18,6 +18,7 @@ import {
   resolveComposerProviderTargetIconUrl
 } from "./AgentComposerChrome";
 import { resolveHandoffTargetOwnershipLabel } from "./handoffTargetPresentation";
+import { AgentGUIOwnerAvatar } from "../AgentGUIOwnerAvatar";
 
 export interface AgentHandoffMenuLabels {
   action: string;
@@ -207,11 +208,10 @@ export function AgentHandoffMenu({
                       src={resolveComposerProviderTargetIconUrl(target)}
                     />
                     {target.badge?.iconUrl ? (
-                      <img
-                        alt=""
-                        aria-hidden="true"
-                        className="absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full border border-[var(--background-fronted)] bg-[var(--background-fronted)] object-cover"
-                        src={target.badge.iconUrl}
+                      <AgentGUIOwnerAvatar
+                        className="absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full border border-[var(--background-fronted)] bg-[var(--background-fronted)] text-[7px] leading-none object-cover"
+                        iconUrl={target.badge.iconUrl}
+                        label={target.badge.label}
                       />
                     ) : null}
                   </span>

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
@@ -50,6 +50,7 @@ import {
   projectAgentGUIAgentTargetName
 } from "./AgentGUIAgentTargetName";
 import styles from "../AgentGUINode.styles";
+import { AgentGUIOwnerAvatar } from "../AgentGUIOwnerAvatar";
 
 export interface AgentGUIProviderIconPresentation {
   iconUrl: string;
@@ -588,14 +589,12 @@ function AgentGUIAgentAvatarVisual({
         src={presentation.iconUrl}
       />
       {presentation.badge?.iconUrl ? (
-        <span className={styles.agentAvatarBadge}>
-          <img
-            alt=""
-            className={styles.agentAvatarBadgeImage}
-            draggable={false}
-            src={presentation.badge.iconUrl}
-          />
-        </span>
+        <AgentGUIOwnerAvatar
+          className={styles.agentAvatarBadge}
+          iconUrl={presentation.badge.iconUrl}
+          imageClassName={styles.agentAvatarBadgeImage}
+          label={presentation.badge.label}
+        />
       ) : null}
     </span>
   );

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIProviderRail.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIProviderRail.spec.tsx
@@ -221,6 +221,34 @@ describe("AgentGUIProviderRail selection", () => {
       screen.getAllByRole("tab").map((tab) => tab.getAttribute("aria-label"))
     ).toEqual(["All agents", "Cursor", "Codex", "Claude"]);
   });
+
+  it("renders a shared owner badge through the Avatar primitive", () => {
+    render(
+      providerRail(
+        providerRailProps({
+          agentTargets: [
+            target({
+              agentTargetId: "agent:shared",
+              badge: {
+                iconUrl: "https://cdn.example.test/jackson.png",
+                label: "Jackson"
+              },
+              label: "Shared Codex",
+              provider: "codex",
+              targetId: "shared:codex"
+            })
+          ]
+        })
+      )
+    );
+
+    const badge = screen
+      .getByRole("tab", { name: "Shared Codex, Jackson" })
+      .querySelector('[data-agent-owner-badge="true"]');
+
+    expect(badge).not.toBeNull();
+    expect(badge?.querySelector('[data-slot="avatar"]')).not.toBeNull();
+  });
 });
 
 function mockVerticalBounds(element: HTMLElement, top: number): void {

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIProviderRail.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIProviderRail.tsx
@@ -44,6 +44,7 @@ import betaTagAssetUrl from "../../../app/renderer/assets/icons/agent-vinyl-beta
 import styles from "../AgentGUINode.styles";
 import { AgentGUIProviderManagerDialog } from "./AgentGUIProviderManagerDialog";
 import { useAgentGUIProviderRailPreferences } from "./useAgentGUIProviderRailPreferences";
+import { AgentGUIOwnerAvatar } from "../AgentGUIOwnerAvatar";
 
 const agentGUIProviderRailCatalog = [
   ...migratedAgentGUIProviderIdentityCatalog
@@ -735,14 +736,12 @@ export const AgentGUIProviderRail = memo(function AgentGUIProviderRail({
                   )}
                 />
                 {target.badge?.iconUrl ? (
-                  <span aria-hidden="true" className={styles.agentAvatarBadge}>
-                    <img
-                      alt=""
-                      className={styles.agentAvatarBadgeImage}
-                      draggable={false}
-                      src={target.badge.iconUrl}
-                    />
-                  </span>
+                  <AgentGUIOwnerAvatar
+                    className={styles.agentAvatarBadge}
+                    iconUrl={target.badge.iconUrl}
+                    imageClassName={styles.agentAvatarBadgeImage}
+                    label={target.badge.label}
+                  />
                 ) : null}
                 {providerSelected && isBetaAgentProvider(target.provider) ? (
                   <img

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -9697,6 +9697,8 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   border-radius: 999px;
   background: var(--background-fronted);
   pointer-events: none;
+  font-size: 9px;
+  line-height: 1;
 }
 
 .agent-gui-node__agent-avatar-badge-image {
@@ -10247,12 +10249,8 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   border: 8px solid var(--background-fronted);
   border-radius: 999px;
   background: var(--background-fronted);
-}
-
-.agent-gui-vinyl-player__owner-badge > img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+  font-size: 18px;
+  line-height: 1;
 }
 
 .agent-gui-node__empty-hero-carousel:has(:focus-visible) {

--- a/packages/ui/system/src/components/avatar/AGENTS.md
+++ b/packages/ui/system/src/components/avatar/AGENTS.md
@@ -15,8 +15,10 @@ URL:
 <Avatar label={user.displayName} size={40} src={user.avatarUrl} />
 ```
 
-By default, `Avatar` requests `src` unchanged. Pass `transform` when the caller
-knows that the URL supports image-delivery query parameters:
+By default, `Avatar` requests `src` unchanged and uses
+`referrerPolicy="no-referrer"`. Callers may override the referrer policy through
+`imageProps` when the source contract requires it. Pass `transform` when the
+caller knows that the URL supports image-delivery query parameters:
 
 ```tsx
 <Avatar

--- a/packages/ui/system/src/components/avatar/avatar.spec.tsx
+++ b/packages/ui/system/src/components/avatar/avatar.spec.tsx
@@ -133,7 +133,28 @@ describe("Avatar", () => {
     );
     expect(image).toHaveAttribute("alt", "");
     expect(image).toHaveClass("object-contain");
+    expect(image).toHaveAttribute("referrerpolicy", "no-referrer");
     expect(onLoad).toHaveBeenCalledOnce();
+  });
+
+  it("allows callers to override the default referrer policy", () => {
+    render(
+      <Avatar
+        imageProps={{
+          "data-testid": "avatar-image",
+          referrerPolicy: "origin"
+        }}
+        label="Jun Sun"
+        src="https://example.test/avatar.png"
+      />
+    );
+
+    finishPreload("loaded");
+
+    expect(screen.getByTestId("avatar-image")).toHaveAttribute(
+      "referrerpolicy",
+      "origin"
+    );
   });
 
   it("falls back to the requested initial when an image fails", () => {

--- a/packages/ui/system/src/components/avatar/avatar.tsx
+++ b/packages/ui/system/src/components/avatar/avatar.tsx
@@ -292,6 +292,7 @@ function Avatar({
             "block size-full max-w-none object-cover",
             imageClassName
           )}
+          referrerPolicy={imageProps?.referrerPolicy ?? "no-referrer"}
           src={imageSrcForPrimitive}
           onError={(event) => {
             markImageError();

--- a/packages/ui/system/ui-system.md
+++ b/packages/ui/system/ui-system.md
@@ -55,7 +55,9 @@ disabled, keyboard-focus, and overlay states.
 image loading, rendered-box-aware image transformation, broken-image fallback,
 initial or empty fallback modes, loading presentation, named or numeric sizing,
 and a caller-owned overlay slot through `children`. Sources are requested
-unchanged by default. When the caller passes `transform`, HTTP(S) sources
+unchanged with a `no-referrer` request policy by default; callers may override
+that policy through `imageProps` for a source that requires it. When the caller
+passes `transform`, HTTP(S) sources
 request a bucketed two-times-size WebP variant with `fit=inside`, while
 preserving the original query string. A failed variant retries the original
 source once. Consumers own identity resolution, directly consumable image URLs,


### PR DESCRIPTION
## Summary

- render all DOM owner badges through the shared UI System Avatar primitive
- default Avatar requests to `no-referrer` while preserving caller overrides
- fall back to the room member initial instead of exposing a broken-image glyph
- document the behavior and add patch changesets for `@tutti-os/agent-gui` and `@tutti-os/ui-system`

## Verification

- `pnpm check:changed` — 14 lanes passed before commit
- pre-push `pnpm check:changed -- --push-ready` — 15 lanes passed on the final head
- `pnpm --dir packages/agent/gui test -- ...` — 281 files, 2384 tests passed
- `pnpm --dir packages/ui/system test -- ...` — 17 files, 60 tests passed
- `go test ./services/tuttid/service/agentstatus -run '^TestServiceListUsesDescriptorOwnedDaemonLoginAction$' -count=3`
- `go test ./packages/agent/daemon/runtime -run '^TestControllerGoalControl$' -count=3`

## Notes

- This is presentation behavior only; it does not change agent lifecycle semantics or Host APIs.
- `pnpm check:full` was attempted twice. The concurrent Go suite failed on two different unchanged timing-sensitive tests; each failing test passed three consecutive focused reruns. All changed-scope and push-ready lanes passed.
- TSH consumes the fix through the companion PR after the Tutti packages are released.

## Checklist

- [x] No agent lifecycle semantics changed; this is presentation only.
- [x] I kept the change focused on one concern.
- [x] I updated documentation for the changed behavior.
- [x] No README or CONTRIBUTING source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->