### PR TITLE
fix(agent-gui): keep locator aligned with transcript scrolling

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationTimelinePane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationTimelinePane.tsx
@@ -25,6 +25,7 @@ interface AgentGUIConversationTimelinePaneProps {
   ) => void;
   isLoading: boolean;
   isLoadingOlderMessages: boolean;
+  isVisible: boolean;
   followEndMode: AgentConversationFollowEndMode;
   virtualScrollControllerRef: Ref<AgentTranscriptVirtualScrollController>;
   loadingLabel: string;
@@ -50,6 +51,7 @@ export const AgentGUIConversationTimelinePane = memo(
     onTurnAttachmentVisibilityChange,
     isLoading,
     isLoadingOlderMessages,
+    isVisible,
     followEndMode,
     virtualScrollControllerRef,
     loadingLabel,
@@ -80,6 +82,7 @@ export const AgentGUIConversationTimelinePane = memo(
           turnAttachmentLocatorRef={turnAttachmentLocatorRef}
           onTurnAttachmentVisibilityChange={onTurnAttachmentVisibilityChange}
           isLoading={isLoading}
+          isVisible={isVisible}
           loadingLabel={loadingLabel}
           empty={empty}
           onLinkAction={onLinkAction}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -684,6 +684,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
         hasActiveConversation={hasActiveConversation}
         homeContent={homeContent}
         isLoadingOlderMessages={viewModel.detail.isLoadingOlderMessages}
+        isVisible={isVisible}
         isTimelineScrolledToTop={isTimelineScrolledToTop}
         labels={labels}
         onAuthLogin={authLogin}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailTimeline.renderBudget.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailTimeline.renderBudget.spec.tsx
@@ -32,6 +32,7 @@ describe("AgentGUIDetailTimeline render budget", () => {
       followEndMode: "following" as const,
       homeContent: null,
       isLoadingOlderMessages: false,
+      isVisible: true,
       isTimelineScrolledToTop: true,
       labels: { loadingConversation: "Loading" },
       showTimelineSkeleton: false,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailTimeline.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailTimeline.tsx
@@ -37,6 +37,7 @@ interface AgentGUIDetailTimelineProps {
   followEndMode: AgentConversationFollowEndMode;
   homeContent: ReactNode;
   isLoadingOlderMessages: boolean;
+  isVisible: boolean;
   isTimelineScrolledToTop: boolean;
   labels: {
     loadingConversation: string;
@@ -60,6 +61,7 @@ export const AgentGUIDetailTimeline = memo(function AgentGUIDetailTimeline({
   followEndMode,
   homeContent,
   isLoadingOlderMessages,
+  isVisible,
   isTimelineScrolledToTop,
   labels,
   onAuthLogin,
@@ -94,6 +96,7 @@ export const AgentGUIDetailTimeline = memo(function AgentGUIDetailTimeline({
           followEndMode={followEndMode}
           isLoading={showTimelineSkeleton}
           isLoadingOlderMessages={isLoadingOlderMessages}
+          isVisible={isVisible}
           loadingLabel={labels.loadingConversation}
           empty={conversationFlowEmpty}
           onLinkAction={onLinkAction}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx
@@ -1050,6 +1050,40 @@ describe("useAgentGUIDetailScroll", () => {
     expect(harness.scrollTopWriteCount()).toBe(1);
   });
 
+  it("restores a following virtualized conversation after exposure", () => {
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
+    const harness = createHarness({ scrollHeight: 5_000 });
+    const controller = virtualScrollController("conversation-exposure");
+    harness.virtualScrollControllerRef.current = controller;
+    const hiddenConversation = conversationVM("hidden-update");
+    const { rerender } = renderHook(
+      ({ conversation, isVisible }) =>
+        useAgentGUIDetailScroll(
+          harness.input({
+            activeConversationId: "conversation-exposure",
+            conversation,
+            isVisible,
+            showTimelineSkeleton: false
+          })
+        ),
+      {
+        initialProps: {
+          conversation: conversationVM("initial"),
+          isVisible: true
+        }
+      }
+    );
+    controller.scrollToEnd.mockClear();
+
+    rerender({ conversation: hiddenConversation, isVisible: false });
+    rerender({ conversation: hiddenConversation, isVisible: true });
+
+    expect(controller.scrollToEnd).toHaveBeenCalledWith({ behavior: "auto" });
+  });
+
   it("remeasures dock safe-area after store and ResizeObserver invalidation", () => {
     const resizeObservers = installResizeObserverMock();
     const harness = createHarness({ scrollHeight: 5_000 });

--- a/packages/agent/gui/shared/agentConversation/components/AgentConversationFlow.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentConversationFlow.tsx
@@ -23,6 +23,7 @@ export interface AgentConversationFlowProps {
     visible: boolean
   ) => void;
   isLoading: boolean;
+  isVisible?: boolean;
   loadingLabel: string;
   loadingTestId?: string;
   empty: ReactNode;
@@ -51,6 +52,7 @@ export const AgentConversationFlow = memo(function AgentConversationFlow({
   turnAttachmentLocatorRef,
   onTurnAttachmentVisibilityChange,
   isLoading,
+  isVisible = true,
   loadingLabel,
   loadingTestId,
   empty,
@@ -81,6 +83,7 @@ export const AgentConversationFlow = memo(function AgentConversationFlow({
     content = (
       <AgentTranscriptView
         conversation={conversation}
+        isVisible={isVisible}
         turnAttachments={turnAttachments}
         turnAttachmentLocatorRef={turnAttachmentLocatorRef}
         onTurnAttachmentVisibilityChange={onTurnAttachmentVisibilityChange}

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageLocatorRail.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageLocatorRail.tsx
@@ -10,6 +10,7 @@ import {
   type WheelEvent
 } from "react";
 import type { AgentMessageLocatorItem } from "./agentTranscriptModel";
+import type { AgentConversationFollowEndMode } from "../agentConversationFollowEndController";
 import {
   findMessageLocatorScrollParent,
   useAgentMessageLocatorSelection,
@@ -31,12 +32,16 @@ interface AgentMessageLocatorVisibleFrame {
 }
 
 export function AgentMessageLocatorRail({
+  followEndMode,
   items,
+  isVisible = true,
   label,
   onLocate,
   virtualSelectionSource
 }: {
+  followEndMode?: AgentConversationFollowEndMode;
   items: readonly AgentMessageLocatorItem[];
+  isVisible?: boolean;
   label?: string;
   onLocate: (item: AgentMessageLocatorItem) => void;
   virtualSelectionSource?: AgentMessageLocatorVirtualSelectionSource;
@@ -48,7 +53,9 @@ export function AgentMessageLocatorRail({
   const [shouldRenderPanel, setShouldRenderPanel] = useState(false);
   const [activeKey, setActiveKey] = useState<string | null>(null);
   const { selectItem, selectedKey } = useAgentMessageLocatorSelection({
+    followEndMode,
     items,
+    isVisible,
     locatorRef,
     virtualSelectionSource
   });
@@ -136,6 +143,9 @@ export function AgentMessageLocatorRail({
     });
   }, [selectedKey]);
   useLayoutEffect(() => {
+    if (!isVisible) {
+      return;
+    }
     const locator = locatorRef.current;
     const scrollParent = locator
       ? findMessageLocatorScrollParent(locator)
@@ -176,8 +186,11 @@ export function AgentMessageLocatorRail({
         window.cancelAnimationFrame(animationFrame);
       }
     };
-  }, [items.length]);
+  }, [isVisible, items.length]);
   useLayoutEffect(() => {
+    if (!isVisible) {
+      return;
+    }
     const selectedIndex = selectedKey
       ? items.findIndex((item) => item.key === selectedKey)
       : -1;
@@ -198,7 +211,7 @@ export function AgentMessageLocatorRail({
       selectedIndex,
       viewportHeight
     );
-  }, [items, selectedKey, visibleFrame]);
+  }, [isVisible, items, selectedKey, visibleFrame]);
 
   if (items.length < 2) {
     return null;

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -1210,6 +1210,80 @@ describe("AgentTranscriptView", () => {
     expect(within(panel).queryByText(mentionPrompt)).toBeNull();
   });
 
+  it("remeasures the message locator when an occluded transcript becomes visible", async () => {
+    const base = detailViewModel();
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        turns: [
+          base.turns[0]!,
+          {
+            id: "turn-2",
+            userMessage: { id: "user-2", body: "Follow-up request" },
+            userMessages: [{ id: "user-2", body: "Follow-up request" }],
+            agentMessages: [{ id: "assistant-2", body: "Follow-up answer" }],
+            toolCalls: [],
+            toolCallCount: 0,
+            hasFailedToolCall: false,
+            agentItems: [
+              {
+                kind: "message",
+                message: {
+                  id: "assistant-2",
+                  body: "Follow-up answer"
+                }
+              }
+            ]
+          }
+        ]
+      })
+    );
+    const transcriptLabels = {
+      thinkingLabel: "Thought process",
+      toolCallsLabel: (count: number) => `Tool calls (${count})`,
+      processing: "Planning next moves",
+      turnSummary: "Changed files",
+      userMessageLocator: "User messages"
+    };
+    const { rerender } = render(
+      <div data-testid="agent-gui-timeline">
+        <AgentTranscriptView
+          conversation={conversation}
+          isVisible={false}
+          labels={transcriptLabels}
+        />
+      </div>
+    );
+    const timeline = screen.getByTestId("agent-gui-timeline");
+    let timelineClientHeight = 0;
+    Object.defineProperty(timeline, "clientHeight", {
+      configurable: true,
+      get: () => timelineClientHeight
+    });
+    await flushAnimationFrame();
+
+    expect(
+      screen
+        .getByTestId("agent-message-locator")
+        .style.getPropertyValue("--agent-message-locator-visible-height")
+    ).toBe("");
+
+    timelineClientHeight = 240;
+    rerender(
+      <div data-testid="agent-gui-timeline">
+        <AgentTranscriptView
+          conversation={conversation}
+          isVisible
+          labels={transcriptLabels}
+        />
+      </div>
+    );
+    await flushAnimationFrame();
+
+    expect(screen.getByTestId("agent-message-locator")).toHaveStyle({
+      "--agent-message-locator-visible-height": "240px"
+    });
+  });
+
   it("locates the nearest user message when clicking the locator rail around a dot", () => {
     const scrollIntoView = vi.fn();
     const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
@@ -63,6 +63,7 @@ export type { AgentTranscriptVirtualScrollController } from "./useAgentTranscrip
 
 export interface AgentTranscriptViewProps {
   conversation: AgentConversationVM;
+  isVisible?: boolean;
   turnAttachments?: readonly AgentTranscriptTurnAttachment[];
   turnAttachmentLocatorRef?: Ref<AgentTranscriptAttachmentLocator>;
   onTurnAttachmentVisibilityChange?: (
@@ -213,6 +214,7 @@ export function areAgentTranscriptViewPropsEqual(
       previous.conversation,
       next.conversation
     ) &&
+    (previous.isVisible ?? true) === (next.isVisible ?? true) &&
     previous.onLinkAction === next.onLinkAction &&
     previous.onAuthLogin === next.onAuthLogin &&
     previous.availableSkills === next.availableSkills &&
@@ -235,6 +237,7 @@ export function areAgentTranscriptViewPropsEqual(
 
 export const AgentTranscriptView = memo(function AgentTranscriptView({
   conversation,
+  isVisible = true,
   turnAttachments = [],
   turnAttachmentLocatorRef,
   onTurnAttachmentVisibilityChange,
@@ -418,7 +421,7 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
   );
 
   useLayoutEffect(() => {
-    if (!shouldVirtualize) {
+    if (!isVisible || !shouldVirtualize) {
       return;
     }
     const virtualizerHost = virtualizerHostRef.current;
@@ -439,7 +442,7 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
     setVirtualListOffsetFromScrollOrigin((previousOffset) =>
       previousOffset === nextOffset ? previousOffset : nextOffset
     );
-  }, [shouldVirtualize, virtualListLayoutRevision]);
+  }, [isVisible, shouldVirtualize, virtualListLayoutRevision]);
 
   const renderRow = (
     row: AgentConversationVM["rows"][number],
@@ -591,7 +594,9 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
     return (
       <>
         <AgentMessageLocatorRail
+          followEndMode={followEndMode}
           items={userMessageLocatorItems}
+          isVisible={isVisible}
           label={labels.userMessageLocator}
           onLocate={handleLocateUserMessage}
           virtualSelectionSource={rowVirtualizer}
@@ -642,7 +647,9 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
   return (
     <>
       <AgentMessageLocatorRail
+        followEndMode={followEndMode}
         items={userMessageLocatorItems}
+        isVisible={isVisible}
         label={labels.userMessageLocator}
         onLocate={handleLocateUserMessage}
       />

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.virtual.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.virtual.spec.tsx
@@ -645,6 +645,86 @@ describe("AgentTranscriptView virtual rendering", () => {
     timeline.remove();
   });
 
+  it("follows an explicit downward wheel reversal immediately", async () => {
+    virtualizerMockState.centerIndex = 10;
+    virtualizerMockState.virtualIndexes = [10];
+    const timeline = document.createElement("div");
+    timeline.dataset.testid = "agent-gui-timeline";
+    timeline.style.overflow = "auto";
+    timeline.scrollTop = 1_000;
+    document.body.appendChild(timeline);
+    render(
+      <AgentTranscriptView
+        conversation={conversationWithMultiRowTurns(40)}
+        followEndMode="detached"
+        labels={TRANSCRIPT_LABELS_WITH_LOCATOR}
+      />,
+      { container: timeline }
+    );
+    const selectedIndex = () =>
+      [
+        ...timeline.querySelectorAll(".agent-gui-message-locator__tick")
+      ].findIndex((tick) => tick.getAttribute("data-selected") === "true");
+    await waitFor(() => expect(selectedIndex()).toBe(10));
+
+    fireEvent.wheel(timeline, { deltaY: -100 });
+    virtualizerMockState.centerIndex = 5;
+    timeline.scrollTop = 500;
+    fireEvent.scroll(timeline);
+    await waitFor(() => expect(selectedIndex()).toBe(5));
+
+    fireEvent.wheel(timeline, { deltaY: 100 });
+    virtualizerMockState.centerIndex = 6;
+    timeline.scrollTop = 600;
+    fireEvent.scroll(timeline);
+
+    await waitFor(() => expect(selectedIndex()).toBe(6));
+    timeline.remove();
+  });
+
+  it("follows a semantic return to the transcript end from measured positions", async () => {
+    virtualizerMockState.centerIndex = 10;
+    virtualizerMockState.virtualIndexes = [10];
+    const timeline = document.createElement("div");
+    timeline.dataset.testid = "agent-gui-timeline";
+    timeline.style.overflow = "auto";
+    timeline.scrollTop = 1_000;
+    document.body.appendChild(timeline);
+    const rendered = render(
+      <AgentTranscriptView
+        conversation={conversationWithMultiRowTurns(40)}
+        followEndMode="detached"
+        labels={TRANSCRIPT_LABELS_WITH_LOCATOR}
+      />,
+      { container: timeline }
+    );
+    const selectedIndex = () =>
+      [
+        ...timeline.querySelectorAll(".agent-gui-message-locator__tick")
+      ].findIndex((tick) => tick.getAttribute("data-selected") === "true");
+    await waitFor(() => expect(selectedIndex()).toBe(10));
+
+    fireEvent.wheel(timeline, { deltaY: -100 });
+    virtualizerMockState.centerIndex = 5;
+    timeline.scrollTop = 500;
+    fireEvent.scroll(timeline);
+    await waitFor(() => expect(selectedIndex()).toBe(5));
+
+    rendered.rerender(
+      <AgentTranscriptView
+        conversation={conversationWithMultiRowTurns(40)}
+        followEndMode="following"
+        labels={TRANSCRIPT_LABELS_WITH_LOCATOR}
+      />
+    );
+    virtualizerMockState.centerIndex = 39;
+    timeline.scrollTop = 3_900;
+    fireEvent.scroll(timeline);
+
+    await waitFor(() => expect(selectedIndex()).toBe(39));
+    timeline.remove();
+  });
+
   it("selects the preceding user message when the centered turn has no user row", async () => {
     virtualizerMockState.centerIndex = 18;
     virtualizerMockState.virtualIndexes = [18];

--- a/packages/agent/gui/shared/agentConversation/components/useAgentMessageLocatorSelection.ts
+++ b/packages/agent/gui/shared/agentConversation/components/useAgentMessageLocatorSelection.ts
@@ -7,6 +7,7 @@ import {
 } from "react";
 import type { AgentMessageLocatorItem } from "./agentTranscriptModel";
 import { escapeCssString } from "./agentTranscriptModel";
+import type { AgentConversationFollowEndMode } from "../agentConversationFollowEndController";
 
 const REVERSE_CONFIRMATION_FRAMES = 3;
 const SCROLL_INTENT_WINDOW_MS = 1_000;
@@ -25,11 +26,15 @@ interface AgentMessageLocatorSelection {
 }
 
 export function useAgentMessageLocatorSelection({
+  followEndMode,
   items,
+  isVisible,
   locatorRef,
   virtualSelectionSource
 }: {
+  followEndMode?: AgentConversationFollowEndMode;
   items: readonly AgentMessageLocatorItem[];
+  isVisible: boolean;
   locatorRef: RefObject<HTMLElement | null>;
   virtualSelectionSource?: AgentMessageLocatorVirtualSelectionSource;
 }): AgentMessageLocatorSelection {
@@ -50,6 +55,9 @@ export function useAgentMessageLocatorSelection({
       virtualSelectionSource.scrollRect !== null);
 
   useLayoutEffect(() => {
+    if (!isVisible) {
+      return;
+    }
     if (!selectedKey) {
       return;
     }
@@ -107,9 +115,12 @@ export function useAgentMessageLocatorSelection({
         : candidateIndex;
     selectedIndexRef.current = replacementIndex;
     setSelectedKey(items[replacementIndex]?.key ?? null);
-  }, [items, locatorRef, selectedKey, virtualSelectionSource]);
+  }, [isVisible, items, locatorRef, selectedKey, virtualSelectionSource]);
 
   useEffect(() => {
+    if (!isVisible) {
+      return;
+    }
     const locator = locatorRef.current;
     const scrollParent = locator
       ? findMessageLocatorScrollParent(locator)
@@ -156,7 +167,10 @@ export function useAgentMessageLocatorSelection({
           scrollIntent && scrollIntent.expiresAt >= performance.now()
             ? scrollIntent.direction
             : 0;
+        const followsSemanticEnd =
+          followEndMode === "following" && nextDirection === 1;
         if (
+          !followsSemanticEnd &&
           intendedDirection !== 0 &&
           nextDirection !== 0 &&
           nextDirection !== intendedDirection
@@ -166,6 +180,8 @@ export function useAgentMessageLocatorSelection({
         }
         const selectionDirection = selectionDirectionRef.current;
         if (
+          !followsSemanticEnd &&
+          intendedDirection === 0 &&
           currentIndex >= 0 &&
           nextIndex >= 0 &&
           selectionDirection !== 0 &&
@@ -244,7 +260,14 @@ export function useAgentMessageLocatorSelection({
         window.cancelAnimationFrame(animationFrame);
       }
     };
-  }, [items, locatorRef, virtualSelectionReady, virtualSelectionSource]);
+  }, [
+    followEndMode,
+    isVisible,
+    items,
+    locatorRef,
+    virtualSelectionReady,
+    virtualSelectionSource
+  ]);
 
   const selectItem = (itemKey: string): void => {
     selectionDirectionRef.current = 0;


### PR DESCRIPTION
## Summary

- pause locator DOM measurement and listeners while AgentGUI is fully occluded, then remeasure on exposure without disabling TanStack Virtual
- let explicit downward input and the shared `followEndMode` end-following state update locator selection from measured virtual positions
- cover exposure recovery, direct wheel reversal, semantic scroll-to-end, and retained bottom-lock recovery

This replaces and supersedes #1695, using the latest centralized transcript follow-state architecture.

## Tests

- `pnpm check:changed -- --push-ready`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 agent-gui/agentGuiNode/view/AgentGUIDetailTimeline.renderBudget.spec.tsx agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx shared/agentConversation/components/AgentTranscriptView.spec.tsx shared/agentConversation/components/AgentTranscriptView.virtual.spec.tsx`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->