### PR TITLE
fix(agent-gui): align composer input history with Codex

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -788,20 +788,21 @@ The editor recognizes stale controlled echoes from that transition so an older
 projection cannot overwrite newer local input; a value not emitted locally
 remains an authoritative external replacement.
 
-An existing-Session composer derives input history from that Session's
-canonical user-message projection; it does not persist a second history store.
-The host must opt in explicitly; Desktop maps the default-off
-`lab.agentInputHistory` Lab preference to that capability.
-Bare Up/Down recalls older/newer structured drafts only from an empty composer
-or an unchanged recalled entry, and only when the collapsed caret is at a
-whole-document boundary. Palette handling and IME composition take precedence,
-while editing a recalled draft exits history navigation. Moving past the newest
-entry clears the composer. Adjacent equivalent submissions collapse, persisted
-attachments are restored with exact workspace and Session identity, and
-reaching the oldest loaded entry requests the existing authoritative older-page
-read while preserving the timeline prepend scroll anchor. The history cursor
-is UI-local and resets when the draft Session scope changes; Home has no
-Session history.
+The mounted Agent GUI owns one in-memory composer input history store. The host
+must opt in explicitly; Desktop maps the default-off `lab.agentInputHistory`
+Lab preference to that capability. Every non-empty structured draft submitted
+while the GUI is open is appended, including equivalent consecutive inputs.
+The store is shared by the Home and Session composer presentations and is
+discarded when the Agent GUI closes.
+
+Bare Up/Down recalls older/newer structured drafts regardless of whether the
+composer currently has content, but only when the collapsed caret is at a
+whole-document boundary. Palette handling and IME composition take precedence.
+On first recall, the current structured draft is captured as the newest
+navigation entry, so moving past the newest submitted input restores the text
+and attachments that were being edited. Editing a recalled draft makes that
+edit the new current entry on the next recall. The history cursor is UI-local
+and resets when the draft Session scope changes.
 
 The dock observes geometry through one coalesced animation-frame measurement
 entry point. Editor document updates, attachment membership or intrinsic

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -81,7 +81,6 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   "use memo";
   const {
     workspaceId,
-    agentSessionId = null,
     workspacePath,
     currentUserId,
     provider,
@@ -89,10 +88,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     draftContent,
     engagement,
     draftScopeKey = "current",
-    inputHistory = [],
-    inputHistoryHasOlderPage = false,
-    inputHistoryIsLoadingOlderPage = false,
-    onRequestOlderInputHistoryPage,
+    inputHistoryStore,
     availableCommands,
     hasCompactableContext = true,
     compactSupported = null,
@@ -183,34 +179,6 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   };
   const [isPaletteOpen, setIsPaletteOpen] = useState(true);
   const [isReviewPickerOpen, setIsReviewPickerOpen] = useState(false);
-  const submitWithComposerModifiers: AgentComposerProps["onSubmit"] = (
-    content,
-    displayPrompt,
-    options
-  ) => {
-    onSubmit(
-      content,
-      displayPrompt,
-      withAgentComposerTuttiModeSnapshot({
-        options,
-        active: tuttiModeActive,
-        orchestrationIntensity: tuttiModeOrchestrationIntensity
-      })
-    );
-  };
-  const submitGuidanceWithComposerModifiers: NonNullable<
-    AgentComposerProps["onSubmitGuidance"]
-  > = (content, displayPrompt) => {
-    onSubmitGuidance?.(
-      content,
-      displayPrompt,
-      tuttiModeActive
-        ? {
-            capabilityRefs: [{ capability: "tutti", source: "slash_command" }]
-          }
-        : undefined
-    );
-  };
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [mentionHighlightedKey, setMentionHighlightedKey] = useState<
     string | null
@@ -251,23 +219,52 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     [draftScopeKey]: draftContent
   });
   draftByScopeKeyRef.current[draftScopeKey] = draftContent;
-  const {
-    disposeInputHistory,
-    onHistoryNavigation,
-    settlePendingInputHistory
-  } = useComposerInputHistory({
-    agentSessionId,
-    currentDraft: draftContent,
-    draftByScopeKeyRef,
-    draftScopeKey,
-    entries: inputHistory,
-    hasOlderPage: inputHistoryHasOlderPage,
-    isLoadingOlderPage: inputHistoryIsLoadingOlderPage,
-    onDraftContentChange,
-    onRequestOlderPage: onRequestOlderInputHistoryPage,
-    runtime: agentActivityRuntime,
-    workspaceId
-  });
+  const { onHistoryNavigation, recordSubmittedDraft } = useComposerInputHistory(
+    {
+      currentDraft: draftContent,
+      draftByScopeKeyRef,
+      draftScopeKey,
+      inputHistoryStore,
+      onDraftContentChange
+    }
+  );
+  const submitWithComposerModifiers: AgentComposerProps["onSubmit"] = (
+    content,
+    displayPrompt,
+    options
+  ) => {
+    recordSubmittedDraft(
+      draftByScopeKeyRef.current[draftScopeKey] ?? draftContent
+    );
+    onSubmit(
+      content,
+      displayPrompt,
+      withAgentComposerTuttiModeSnapshot({
+        options,
+        active: tuttiModeActive,
+        orchestrationIntensity: tuttiModeOrchestrationIntensity
+      })
+    );
+  };
+  const submitGuidanceWithComposerModifiers: NonNullable<
+    AgentComposerProps["onSubmitGuidance"]
+  > = (content, displayPrompt) => {
+    if (!onSubmitGuidance) {
+      return;
+    }
+    recordSubmittedDraft(
+      draftByScopeKeyRef.current[draftScopeKey] ?? draftContent
+    );
+    onSubmitGuidance(
+      content,
+      displayPrompt,
+      tuttiModeActive
+        ? {
+            capabilityRefs: [{ capability: "tutti", source: "slash_command" }]
+          }
+        : undefined
+    );
+  };
   const promptTipRef = useRef<HTMLSpanElement | null>(null);
   const { mentionControllerRef, mentionSearchState } =
     useAgentMentionSearchController(referenceProvenanceFilters);
@@ -381,7 +378,6 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     const isExternalDraftReplacement = draftPromptRef.current !== draftPrompt;
     draftPromptRef.current = draftPrompt;
     setPaletteDraftPrompt(goalDraftObjective ?? draftPrompt);
-    settlePendingInputHistory();
     if (isExternalDraftReplacement && draftPrompt) {
       window.requestAnimationFrame(() => {
         window.requestAnimationFrame(() => {
@@ -391,23 +387,17 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
         });
       });
     }
-  }, [
-    draftContent,
-    draftPrompt,
-    goalDraftObjective,
-    settlePendingInputHistory
-  ]);
+  }, [draftContent, draftPrompt, goalDraftObjective]);
 
   useEffect(() => {
     if (
       previousSlashStatusAgentSessionIdRef.current === slashStatusAgentSessionId
     ) {
-      return disposeInputHistory;
+      return;
     }
     previousSlashStatusAgentSessionIdRef.current = slashStatusAgentSessionId;
     setIsSlashStatusPanelOpen(false);
-    return disposeInputHistory;
-  }, [disposeInputHistory, draftScopeKey, slashStatusAgentSessionId]);
+  }, [draftScopeKey, slashStatusAgentSessionId]);
 
   const slashActions = useComposerSlashActions({
     workspaceId,

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -27,7 +27,7 @@ import type {
 } from "@tutti-os/workspace-file-reference/react";
 import type { AgentQuickPromptLabels } from "./quickPrompts/agentQuickPromptLabels";
 import type { AgentMentionFilterId } from "../AgentMentionSearchContracts";
-import type { AgentComposerInputHistoryEntry } from "../model/agentComposerInputHistory";
+import type { AgentComposerInputHistoryStore } from "../model/agentComposerInputHistory";
 
 export interface AgentComposerReferenceProvenanceFilter {
   snapshot: ReferenceProvenanceFilterSnapshot;
@@ -77,10 +77,7 @@ export interface AgentComposerProps {
   engagement?: AgentGUIComposerEngagement;
   /** Stable project/session owner for async draft attachment work. */
   draftScopeKey?: string;
-  inputHistory?: readonly AgentComposerInputHistoryEntry[];
-  inputHistoryHasOlderPage?: boolean;
-  inputHistoryIsLoadingOlderPage?: boolean;
-  onRequestOlderInputHistoryPage?: () => void;
+  inputHistoryStore?: AgentComposerInputHistoryStore;
   availableCommands: readonly AgentSessionCommand[];
   hasCompactableContext?: boolean;
   compactSupported?: boolean | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerInputHistory.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerInputHistory.spec.tsx
@@ -1,170 +1,75 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
+  agentComposerDraftPrompt,
   buildAgentComposerDraft,
   emptyAgentComposerDraft
 } from "../model/agentComposerDraft";
-import type { AgentComposerInputHistoryEntry } from "../model/agentComposerInputHistory";
+import { createAgentComposerInputHistoryStore } from "../model/agentComposerInputHistory";
 import { useComposerInputHistory } from "./useComposerInputHistory";
 
 describe("useComposerInputHistory", () => {
-  it("supports repeated Up presses before the controlled draft rerenders", () => {
+  it("records submissions and supports repeated navigation before rerender", () => {
     const onDraftContentChange = vi.fn();
-    const entries = historyEntries("one", "two");
+    const inputHistoryStore = createAgentComposerInputHistoryStore();
     const draftByScopeKeyRef = {
-      current: { "session:session-1": emptyAgentComposerDraft() }
+      current: {
+        "session:session-1": buildAgentComposerDraft({
+          prompt: "current draft"
+        })
+      }
     };
     const { result } = renderHook(() =>
       useComposerInputHistory({
-        agentSessionId: "session-1",
-        currentDraft: emptyAgentComposerDraft(),
+        currentDraft: draftByScopeKeyRef.current["session:session-1"],
         draftByScopeKeyRef,
         draftScopeKey: "session:session-1",
-        entries,
-        hasOlderPage: false,
-        isLoadingOlderPage: false,
-        onDraftContentChange,
-        runtime: null,
-        workspaceId: "workspace-1"
+        inputHistoryStore,
+        onDraftContentChange
       })
     );
 
     act(() => {
+      result.current.recordSubmittedDraft(
+        buildAgentComposerDraft({ prompt: "one" })
+      );
+      result.current.recordSubmittedDraft(
+        buildAgentComposerDraft({ prompt: "two" })
+      );
       expect(result.current.onHistoryNavigation("older")).toBe(true);
       expect(result.current.onHistoryNavigation("older")).toBe(true);
+      expect(result.current.onHistoryNavigation("newer")).toBe(true);
+      expect(result.current.onHistoryNavigation("newer")).toBe(true);
     });
 
-    expect(onDraftContentChange).toHaveBeenNthCalledWith(
-      1,
-      entries[1]!.draft,
-      "session:session-1"
-    );
-    expect(onDraftContentChange).toHaveBeenNthCalledWith(
-      2,
-      entries[0]!.draft,
-      "session:session-1"
-    );
+    expect(
+      onDraftContentChange.mock.calls.map(([draft]) =>
+        agentComposerDraftPrompt(draft)
+      )
+    ).toEqual(["two", "one", "two", "current draft"]);
   });
 
-  it("recalls the next older entry after an older page is prepended", () => {
+  it("is inert when the host has not enabled input history", () => {
     const onDraftContentChange = vi.fn();
-    const onRequestOlderPage = vi.fn();
-    const current = historyEntries("current")[0]!;
-    const older = historyEntries("older")[0]!;
     const draftByScopeKeyRef = {
-      current: { "session:session-1": emptyAgentComposerDraft() }
+      current: { current: emptyAgentComposerDraft() }
     };
-    const { result, rerender } = renderHook(
-      ({ currentDraft, entries }) => {
-        draftByScopeKeyRef.current["session:session-1"] = currentDraft;
-        return useComposerInputHistory({
-          agentSessionId: "session-1",
-          currentDraft,
-          draftByScopeKeyRef,
-          draftScopeKey: "session:session-1",
-          entries,
-          hasOlderPage: true,
-          isLoadingOlderPage: false,
-          onDraftContentChange,
-          onRequestOlderPage,
-          runtime: null,
-          workspaceId: "workspace-1"
-        });
-      },
-      {
-        initialProps: {
-          currentDraft: emptyAgentComposerDraft(),
-          entries: [current]
-        }
-      }
+    const { result } = renderHook(() =>
+      useComposerInputHistory({
+        currentDraft: emptyAgentComposerDraft(),
+        draftByScopeKeyRef,
+        draftScopeKey: "current",
+        onDraftContentChange
+      })
     );
 
     act(() => {
-      result.current.onHistoryNavigation("older");
-      result.current.onHistoryNavigation("older");
-    });
-    expect(onRequestOlderPage).toHaveBeenCalledOnce();
-
-    rerender({
-      currentDraft: current.draft,
-      entries: [older, current]
-    });
-    act(() => {
-      result.current.settlePendingInputHistory();
+      result.current.recordSubmittedDraft(
+        buildAgentComposerDraft({ prompt: "one" })
+      );
+      expect(result.current.onHistoryNavigation("older")).toBe(false);
     });
 
-    expect(onDraftContentChange).toHaveBeenLastCalledWith(
-      older.draft,
-      "session:session-1"
-    );
-  });
-
-  it("does not overwrite edits made while an older page is loading", () => {
-    const onDraftContentChange = vi.fn();
-    const onRequestOlderPage = vi.fn();
-    const current = historyEntries("current")[0]!;
-    const older = historyEntries("older")[0]!;
-    const editedDraft = buildAgentComposerDraft({ prompt: "edited" });
-    const draftByScopeKeyRef = {
-      current: { "session:session-1": emptyAgentComposerDraft() }
-    };
-    const { result, rerender } = renderHook(
-      ({ currentDraft, entries, isLoadingOlderPage }) => {
-        draftByScopeKeyRef.current["session:session-1"] = currentDraft;
-        return useComposerInputHistory({
-          agentSessionId: "session-1",
-          currentDraft,
-          draftByScopeKeyRef,
-          draftScopeKey: "session:session-1",
-          entries,
-          hasOlderPage: true,
-          isLoadingOlderPage,
-          onDraftContentChange,
-          onRequestOlderPage,
-          runtime: null,
-          workspaceId: "workspace-1"
-        });
-      },
-      {
-        initialProps: {
-          currentDraft: emptyAgentComposerDraft(),
-          entries: [current],
-          isLoadingOlderPage: false
-        }
-      }
-    );
-
-    act(() => {
-      result.current.onHistoryNavigation("older");
-      result.current.onHistoryNavigation("older");
-    });
-    rerender({
-      currentDraft: editedDraft,
-      entries: [current],
-      isLoadingOlderPage: true
-    });
-    rerender({
-      currentDraft: editedDraft,
-      entries: [older, current],
-      isLoadingOlderPage: false
-    });
-    act(() => {
-      result.current.settlePendingInputHistory();
-    });
-
-    expect(onDraftContentChange).toHaveBeenCalledOnce();
-    expect(onDraftContentChange).toHaveBeenLastCalledWith(
-      current.draft,
-      "session:session-1"
-    );
+    expect(onDraftContentChange).not.toHaveBeenCalled();
   });
 });
-
-function historyEntries(
-  ...prompts: string[]
-): AgentComposerInputHistoryEntry[] {
-  return prompts.map((prompt) => ({
-    id: prompt,
-    draft: buildAgentComposerDraft({ prompt })
-  }));
-}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerInputHistory.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerInputHistory.ts
@@ -1,203 +1,79 @@
 import { useCallback, useRef, type RefObject } from "react";
-import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import type { AgentComposerDraft } from "../model/agentGuiNodeTypes";
+import { snapshotAgentComposerDraft } from "../model/agentComposerDraft";
 import {
-  agentComposerDraftHasContent,
-  agentComposerDraftImages,
-  snapshotAgentComposerDraft,
-  updateAgentComposerDraft
-} from "../model/agentComposerDraft";
-import {
-  areAgentComposerHistoryDraftsEqual,
   EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE,
   navigateAgentComposerInputHistory,
-  resolvePendingAgentComposerInputHistory,
-  type AgentComposerInputHistoryEntry,
-  type AgentComposerInputHistoryState
+  recordAgentComposerInputHistory,
+  type AgentComposerInputHistoryState,
+  type AgentComposerInputHistoryStore
 } from "../model/agentComposerInputHistory";
-import { QueuedPromptImageLoadOwner } from "../queuedPromptImageLoadOwner";
 
 interface Input {
-  agentSessionId: string | null;
   currentDraft: AgentComposerDraft;
   draftByScopeKeyRef: RefObject<Record<string, AgentComposerDraft>>;
   draftScopeKey: string;
-  entries: readonly AgentComposerInputHistoryEntry[];
-  hasOlderPage: boolean;
-  isLoadingOlderPage: boolean;
+  inputHistoryStore?: AgentComposerInputHistoryStore;
   onDraftContentChange: (
     draft: AgentComposerDraft,
     sourceScopeKey?: string
   ) => void;
-  onRequestOlderPage?: () => void;
-  runtime: AgentActivityRuntime | null;
-  workspaceId: string;
 }
 
 export function useComposerInputHistory(input: Input): {
-  disposeInputHistory: () => void;
   onHistoryNavigation: (direction: "older" | "newer") => boolean;
-  settlePendingInputHistory: () => void;
+  recordSubmittedDraft: (draft: AgentComposerDraft) => void;
 } {
   const cursorRef = useRef<AgentComposerInputHistoryState>(
     EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
   );
   const ownerScopeRef = useRef(input.draftScopeKey);
-  const imageOwnersRef = useRef<QueuedPromptImageLoadOwner[]>([]);
-
-  const disposeInputHistory = useCallback(() => {
-    for (const owner of imageOwnersRef.current) {
-      owner.dispose();
-    }
-    imageOwnersRef.current = [];
-  }, []);
-  if (ownerScopeRef.current !== input.draftScopeKey) {
+  const ownerStoreRef = useRef(input.inputHistoryStore);
+  if (
+    ownerScopeRef.current !== input.draftScopeKey ||
+    ownerStoreRef.current !== input.inputHistoryStore
+  ) {
     ownerScopeRef.current = input.draftScopeKey;
+    ownerStoreRef.current = input.inputHistoryStore;
     cursorRef.current = EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE;
-    disposeInputHistory();
   }
 
   const restoreDraft = useCallback(
-    (draft: AgentComposerDraft, entryId: string | null) => {
-      disposeInputHistory();
+    (draft: AgentComposerDraft) => {
       const restoredDraft = snapshotAgentComposerDraft(draft);
       input.draftByScopeKeyRef.current[input.draftScopeKey] = restoredDraft;
       input.onDraftContentChange(restoredDraft, input.draftScopeKey);
-      if (!input.runtime || !input.agentSessionId || !entryId) {
-        return;
-      }
-      for (const restoredImage of agentComposerDraftImages(restoredDraft)) {
-        const attachmentId = restoredImage.attachmentId?.trim() ?? "";
-        const path = restoredImage.path?.trim() ?? "";
-        if (restoredImage.previewUrl || (!attachmentId && !path)) {
-          continue;
-        }
-        const owner = new QueuedPromptImageLoadOwner(
-          {
-            agentSessionId: input.agentSessionId,
-            attachmentId,
-            imageKey: restoredImage.id,
-            mimeType: restoredImage.mimeType,
-            name: restoredImage.name,
-            path,
-            remoteUrl: restoredImage.url?.trim() ?? "",
-            runtime: input.runtime,
-            workspaceId: input.workspaceId
-          },
-          (source) => {
-            if (
-              !source ||
-              cursorRef.current.entryId !== entryId ||
-              ownerScopeRef.current !== input.draftScopeKey
-            ) {
-              return;
-            }
-            const currentDraft =
-              input.draftByScopeKeyRef.current[input.draftScopeKey];
-            if (!currentDraft) {
-              return;
-            }
-            let updated = false;
-            const images = agentComposerDraftImages(currentDraft).map(
-              (currentImage) => {
-                if (
-                  currentImage.id !== restoredImage.id ||
-                  currentImage.previewUrl ||
-                  currentImage.attachmentId !== restoredImage.attachmentId ||
-                  currentImage.path !== restoredImage.path ||
-                  currentImage.url !== restoredImage.url
-                ) {
-                  return currentImage;
-                }
-                updated = true;
-                return { ...currentImage, previewUrl: source };
-              }
-            );
-            if (updated) {
-              const updatedDraft = updateAgentComposerDraft(currentDraft, {
-                images
-              });
-              input.draftByScopeKeyRef.current[input.draftScopeKey] =
-                updatedDraft;
-              input.onDraftContentChange(updatedDraft, input.draftScopeKey);
-            }
-          }
-        );
-        imageOwnersRef.current.push(owner);
-        owner.start();
-      }
     },
-    [
-      disposeInputHistory,
-      input.agentSessionId,
-      input.draftByScopeKeyRef,
-      input.draftScopeKey,
-      input.onDraftContentChange,
-      input.runtime,
-      input.workspaceId
-    ]
+    [input.draftByScopeKeyRef, input.draftScopeKey, input.onDraftContentChange]
   );
 
-  const settlePendingInputHistory = useCallback(() => {
-    if (input.isLoadingOlderPage) {
-      return;
-    }
-    const pendingEntryId = cursorRef.current.pendingOlderPage
-      ? cursorRef.current.entryId
-      : null;
-    const pendingEntry = pendingEntryId
-      ? input.entries.find((entry) => entry.id === pendingEntryId)
-      : null;
-    const currentDraft =
-      input.draftByScopeKeyRef.current[input.draftScopeKey] ??
-      input.currentDraft;
-    if (
-      cursorRef.current.pendingOlderPage &&
-      (pendingEntry
-        ? !areAgentComposerHistoryDraftsEqual(currentDraft, pendingEntry.draft)
-        : agentComposerDraftHasContent(currentDraft))
-    ) {
+  const recordSubmittedDraft = useCallback(
+    (draft: AgentComposerDraft): void => {
+      if (!input.inputHistoryStore) {
+        return;
+      }
+      recordAgentComposerInputHistory(input.inputHistoryStore, draft);
       cursorRef.current = EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE;
-      return;
-    }
-    const resolved = resolvePendingAgentComposerInputHistory({
-      entries: input.entries,
-      state: cursorRef.current
-    });
-    if (!resolved) {
-      return;
-    }
-    cursorRef.current = resolved.state;
-    if (resolved.draft) {
-      restoreDraft(resolved.draft, resolved.state.entryId);
-    }
-  }, [
-    input.currentDraft,
-    input.draftByScopeKeyRef,
-    input.draftScopeKey,
-    input.entries,
-    input.isLoadingOlderPage,
-    restoreDraft
-  ]);
+    },
+    [input.inputHistoryStore]
+  );
 
   const onHistoryNavigation = useCallback(
     (direction: "older" | "newer"): boolean => {
-      settlePendingInputHistory();
+      if (!input.inputHistoryStore) {
+        return false;
+      }
       const navigation = navigateAgentComposerInputHistory({
         currentDraft:
           input.draftByScopeKeyRef.current[input.draftScopeKey] ??
           input.currentDraft,
         direction,
-        entries: input.entries,
-        hasOlderPage: input.hasOlderPage,
+        entries: input.inputHistoryStore.entries,
         state: cursorRef.current
       });
       cursorRef.current = navigation.state;
       if (navigation.draft) {
-        restoreDraft(navigation.draft, navigation.state.entryId);
-      }
-      if (navigation.requestOlderPage) {
-        input.onRequestOlderPage?.();
+        restoreDraft(navigation.draft);
       }
       return navigation.handled;
     },
@@ -205,17 +81,13 @@ export function useComposerInputHistory(input: Input): {
       input.currentDraft,
       input.draftByScopeKeyRef,
       input.draftScopeKey,
-      input.entries,
-      input.hasOlderPage,
-      input.onRequestOlderPage,
-      restoreDraft,
-      settlePendingInputHistory
+      input.inputHistoryStore,
+      restoreDraft
     ]
   );
 
   return {
-    disposeInputHistory,
     onHistoryNavigation,
-    settlePendingInputHistory
+    recordSubmittedDraft
   };
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts
@@ -1,379 +1,121 @@
 import { describe, expect, it } from "vitest";
-import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
 import {
-  agentComposerDraftFiles,
-  agentComposerDraftImages,
-  agentComposerDraftLargeTexts,
   agentComposerDraftPrompt,
-  agentComposerDraftToPromptContent,
   buildAgentComposerDraft,
   emptyAgentComposerDraft
 } from "./agentComposerDraft";
-import { createAgentComposerFileMentionMarkdown } from "../agentRichText/agentMentionMarkdown";
 import {
+  createAgentComposerInputHistoryStore,
   EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE,
   navigateAgentComposerInputHistory,
-  projectAgentComposerInputHistory,
-  resolvePendingAgentComposerInputHistory
+  recordAgentComposerInputHistory
 } from "./agentComposerInputHistory";
 
 describe("agent composer input history", () => {
-  it("projects structured user input and keeps the newest adjacent duplicate", () => {
-    const conversation = conversationWithUserMessages([
-      {
-        id: "message-1",
-        body: "expanded prompt",
-        sourceTimelineItems: [
-          {
-            payload: {
-              content: [
-                { type: "text", text: "expanded prompt" },
-                {
-                  type: "image",
-                  attachmentId: "attachment-1",
-                  mimeType: "image/png",
-                  name: "one.png"
-                }
-              ],
-              displayPrompt: "original prompt"
-            }
-          }
-        ]
-      },
-      {
-        id: "message-2",
-        body: "original prompt",
-        sourceTimelineItems: [
-          {
-            payload: {
-              content: [
-                { type: "text", text: "expanded prompt" },
-                {
-                  type: "image",
-                  attachmentId: "attachment-1",
-                  mimeType: "image/png",
-                  name: "one.png"
-                }
-              ],
-              displayPrompt: "original prompt"
-            }
-          }
-        ]
-      }
-    ]);
+  it("records every non-empty submission made while the store is alive", () => {
+    const store = createAgentComposerInputHistoryStore();
+    const firstDraft = buildAgentComposerDraft({ prompt: "repeat" });
 
-    const history = projectAgentComposerInputHistory(conversation);
-
-    expect(history).toHaveLength(1);
-    expect(history[0]!.id).toBe("turn-1:message-2");
-    expect(agentComposerDraftPrompt(history[0]!.draft)).toBe("expanded prompt");
-    expect(agentComposerDraftImages(history[0]!.draft)).toEqual([
-      expect.objectContaining({
-        attachmentId: "attachment-1",
-        previewUrl: ""
-      })
-    ]);
-  });
-
-  it("does not restore a synthetic image-only display prompt as text", () => {
-    const history = projectAgentComposerInputHistory(
-      conversationWithUserMessages([
-        {
-          id: "image-message",
-          body: "[Image]",
-          sourceTimelineItems: [
-            {
-              payload: {
-                content: [
-                  {
-                    type: "image",
-                    path: "/tmp/image.png",
-                    mimeType: "image/png"
-                  }
-                ],
-                displayPrompt: "[Image]"
-              }
-            }
-          ]
-        }
-      ])
-    );
-
-    expect(agentComposerDraftPrompt(history[0]!.draft)).toBe("");
-    expect(agentComposerDraftImages(history[0]!.draft)).toHaveLength(1);
-  });
-
-  it("restores a file-only structured input with a resendable mention", () => {
-    const displayPrompt = createAgentComposerFileMentionMarkdown({
-      id: "original-file",
-      name: "report.pdf",
-      status: "ready"
-    });
-    const history = projectAgentComposerInputHistory(
-      conversationWithUserMessages([
-        {
-          id: "file-message",
-          body: displayPrompt,
-          sourceTimelineItems: [
-            {
-              payload: {
-                content: [
-                  {
-                    type: "file",
-                    kind: "file",
-                    name: "report.pdf",
-                    path: "/runtime/report.pdf"
-                  }
-                ],
-                displayPrompt
-              }
-            }
-          ]
-        }
-      ])
-    );
-
-    expect(history).toHaveLength(1);
-    expect(agentComposerDraftFiles(history[0]!.draft)).toHaveLength(1);
+    expect(recordAgentComposerInputHistory(store, firstDraft)).toBe(true);
+    expect(recordAgentComposerInputHistory(store, firstDraft)).toBe(true);
     expect(
-      agentComposerDraftToPromptContent({
-        draft: history[0]!.draft,
-        skills: []
-      })
-    ).toEqual([
-      {
-        type: "text",
-        text: "[@report.pdf](/runtime/report.pdf)"
-      }
+      recordAgentComposerInputHistory(store, emptyAgentComposerDraft())
+    ).toBe(false);
+
+    firstDraft[0].text = "changed later";
+    expect(store.entries.map((entry) => entry.id)).toEqual([
+      "open:1",
+      "open:2"
     ]);
-  });
-
-  it("restores mixed text and file input without dropping the file on resend", () => {
-    const fileMention = createAgentComposerFileMentionMarkdown({
-      id: "original-file",
-      name: "report.pdf",
-      status: "ready"
-    });
-    const history = projectAgentComposerInputHistory(
-      conversationWithUserMessages([
-        {
-          id: "mixed-message",
-          body: `Summarize${fileMention}`,
-          sourceTimelineItems: [
-            {
-              payload: {
-                content: [
-                  { type: "text", text: "Summarize" },
-                  {
-                    type: "file",
-                    kind: "file",
-                    name: "report.pdf",
-                    path: "/runtime/report.pdf"
-                  }
-                ],
-                displayPrompt: `Summarize${fileMention}`
-              }
-            }
-          ]
-        }
-      ])
-    );
-
-    expect(agentComposerDraftFiles(history[0]!.draft)).toHaveLength(1);
     expect(
-      agentComposerDraftToPromptContent({
-        draft: history[0]!.draft,
-        skills: []
-      })
-    ).toEqual([
-      {
-        type: "text",
-        text: "Summarize[@report.pdf](/runtime/report.pdf)"
-      }
-    ]);
+      store.entries.map((entry) => agentComposerDraftPrompt(entry.draft))
+    ).toEqual(["repeat", "repeat"]);
   });
 
-  it("restores pasted text without resending its display mention as text", () => {
-    const history = projectAgentComposerInputHistory(
-      conversationWithUserMessages([
-        {
-          id: "pasted-text-message",
-          body: "Summarize this",
-          sourceTimelineItems: [
-            {
-              payload: {
-                content: [
-                  { type: "text", text: "Summarize this" },
-                  {
-                    type: "file",
-                    kind: "pasted-text",
-                    name: "first line…",
-                    path: "/archive/aa/deadbeef.txt",
-                    sizeBytes: 22
-                  }
-                ],
-                displayPrompt:
-                  "Summarize this\n[@first line…](mention://pasted-text/original-paste?path=%2Farchive%2Faa%2Fdeadbeef.txt&size=22)"
-              }
-            }
-          ]
-        }
-      ])
-    );
-
-    expect(agentComposerDraftLargeTexts(history[0]!.draft)).toHaveLength(1);
-    expect(
-      agentComposerDraftToPromptContent({
-        draft: history[0]!.draft,
-        skills: []
-      })
-    ).toEqual([
-      { type: "text", text: "Summarize this" },
-      {
-        type: "file",
-        kind: "pasted-text",
-        name: "first line…",
-        path: "/archive/aa/deadbeef.txt",
-        sizeBytes: 22
-      }
-    ]);
-  });
-
-  it("navigates from empty to older entries and clears past the newest", () => {
+  it("navigates history from a non-empty draft and restores it after newest", () => {
     const entries = [
       { id: "one", draft: buildAgentComposerDraft({ prompt: "one" }) },
       { id: "two", draft: buildAgentComposerDraft({ prompt: "two" }) }
     ];
+    const typedDraft = buildAgentComposerDraft({ prompt: "typing now" });
     const latest = navigateAgentComposerInputHistory({
-      currentDraft: emptyAgentComposerDraft(),
+      currentDraft: typedDraft,
       direction: "older",
       entries,
-      hasOlderPage: false,
       state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
     });
     const older = navigateAgentComposerInputHistory({
       currentDraft: latest.draft!,
       direction: "older",
       entries,
-      hasOlderPage: false,
       state: latest.state
     });
     const newer = navigateAgentComposerInputHistory({
       currentDraft: older.draft!,
       direction: "newer",
       entries,
-      hasOlderPage: false,
       state: older.state
     });
-    const cleared = navigateAgentComposerInputHistory({
+    const current = navigateAgentComposerInputHistory({
       currentDraft: newer.draft!,
       direction: "newer",
       entries,
-      hasOlderPage: false,
       state: newer.state
     });
 
     expect(agentComposerDraftPrompt(latest.draft!)).toBe("two");
     expect(agentComposerDraftPrompt(older.draft!)).toBe("one");
     expect(agentComposerDraftPrompt(newer.draft!)).toBe("two");
-    expect(cleared.state.entryId).toBeNull();
-    expect(agentComposerDraftPrompt(cleared.draft!)).toBe("");
+    expect(agentComposerDraftPrompt(current.draft!)).toBe("typing now");
+    expect(current.state).toBe(EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE);
   });
 
-  it("leaves a typed or edited draft to normal arrow-key behavior", () => {
-    const entries = [
-      { id: "one", draft: buildAgentComposerDraft({ prompt: "one" }) }
-    ];
-
-    expect(
-      navigateAgentComposerInputHistory({
-        currentDraft: buildAgentComposerDraft({ prompt: "typed" }),
-        direction: "older",
-        entries,
-        hasOlderPage: false,
-        state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
-      }).handled
-    ).toBe(false);
-    expect(
-      navigateAgentComposerInputHistory({
-        currentDraft: buildAgentComposerDraft({ prompt: "edited" }),
-        direction: "older",
-        entries,
-        hasOlderPage: false,
-        state: { entryId: "one", pendingOlderPage: false }
-      })
-    ).toMatchObject({
-      handled: false,
-      state: { entryId: null }
+  it("restores an empty current draft after moving past the newest entry", () => {
+    const entry = {
+      id: "one",
+      draft: buildAgentComposerDraft({ prompt: "one" })
+    };
+    const recalled = navigateAgentComposerInputHistory({
+      currentDraft: emptyAgentComposerDraft(),
+      direction: "older",
+      entries: [entry],
+      state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
     });
+    const current = navigateAgentComposerInputHistory({
+      currentDraft: recalled.draft!,
+      direction: "newer",
+      entries: [entry],
+      state: recalled.state
+    });
+
+    expect(agentComposerDraftPrompt(current.draft!)).toBe("");
   });
 
-  it("starts again from the newest entry after a recalled draft is cleared", () => {
+  it("treats an edited recalled entry as the new current draft", () => {
     const entries = [
       { id: "one", draft: buildAgentComposerDraft({ prompt: "one" }) },
       { id: "two", draft: buildAgentComposerDraft({ prompt: "two" }) }
     ];
-
-    const navigation = navigateAgentComposerInputHistory({
-      currentDraft: emptyAgentComposerDraft(),
+    const recalled = navigateAgentComposerInputHistory({
+      currentDraft: buildAgentComposerDraft({ prompt: "initial current" }),
       direction: "older",
       entries,
-      hasOlderPage: false,
-      state: { entryId: "one", pendingOlderPage: false }
+      state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
     });
-
-    expect(navigation.state.entryId).toBe("two");
-    expect(agentComposerDraftPrompt(navigation.draft!)).toBe("two");
-  });
-
-  it("requests an older page and resolves to the prepended entry", () => {
-    const current = {
-      id: "current",
-      draft: buildAgentComposerDraft({ prompt: "current" })
-    };
-    const pending = navigateAgentComposerInputHistory({
-      currentDraft: current.draft,
+    const restarted = navigateAgentComposerInputHistory({
+      currentDraft: buildAgentComposerDraft({ prompt: "edited recall" }),
       direction: "older",
-      entries: [current],
-      hasOlderPage: true,
-      state: { entryId: current.id, pendingOlderPage: false }
+      entries,
+      state: recalled.state
     });
-    const older = {
-      id: "older",
-      draft: buildAgentComposerDraft({ prompt: "older" })
-    };
-    const resolved = resolvePendingAgentComposerInputHistory({
-      entries: [older, current],
-      state: pending.state
+    const current = navigateAgentComposerInputHistory({
+      currentDraft: restarted.draft!,
+      direction: "newer",
+      entries,
+      state: restarted.state
     });
 
-    expect(pending).toMatchObject({
-      handled: true,
-      requestOlderPage: true,
-      state: { pendingOlderPage: true }
-    });
-    expect(resolved?.state.entryId).toBe("older");
-    expect(agentComposerDraftPrompt(resolved!.draft!)).toBe("older");
+    expect(agentComposerDraftPrompt(restarted.draft!)).toBe("two");
+    expect(agentComposerDraftPrompt(current.draft!)).toBe("edited recall");
   });
 });
-
-function conversationWithUserMessages(
-  messages: Array<{
-    id: string;
-    body: string;
-    sourceTimelineItems?: Array<{
-      payload: Record<string, unknown>;
-    }>;
-  }>
-): AgentConversationVM {
-  return {
-    sourceDetail: {
-      turns: [
-        {
-          id: "turn-1",
-          userMessages: messages
-        }
-      ]
-    }
-  } as unknown as AgentConversationVM;
-}

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.ts
@@ -1,11 +1,7 @@
-import type { AgentPromptContentBlock } from "../../../shared/contracts/dto";
-import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
 import type { AgentComposerDraft } from "./agentGuiNodeTypes";
 import {
   agentComposerDraftHasContent,
-  agentPromptContentToComposerDraft,
-  buildAgentComposerDraft,
-  emptyAgentComposerDraft
+  snapshotAgentComposerDraft
 } from "./agentComposerDraft";
 
 export interface AgentComposerInputHistoryEntry {
@@ -13,73 +9,60 @@ export interface AgentComposerInputHistoryEntry {
   draft: AgentComposerDraft;
 }
 
+export interface AgentComposerInputHistoryStore {
+  entries: AgentComposerInputHistoryEntry[];
+  nextEntryId: number;
+}
+
 export interface AgentComposerInputHistoryState {
   entryId: string | null;
-  pendingOlderPage: boolean;
+  currentDraft: AgentComposerDraft | null;
 }
 
 export interface AgentComposerInputHistoryNavigation {
   draft?: AgentComposerDraft;
   handled: boolean;
-  requestOlderPage: boolean;
   state: AgentComposerInputHistoryState;
 }
 
 export const EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE: AgentComposerInputHistoryState =
   {
     entryId: null,
-    pendingOlderPage: false
+    currentDraft: null
   };
 
-const inputHistoryByConversation = new WeakMap<
-  AgentConversationVM,
-  AgentComposerInputHistoryEntry[]
->();
+export function createAgentComposerInputHistoryStore(): AgentComposerInputHistoryStore {
+  return {
+    entries: [],
+    nextEntryId: 1
+  };
+}
 
-export function projectAgentComposerInputHistory(
-  conversation: AgentConversationVM | null
-): AgentComposerInputHistoryEntry[] {
-  if (!conversation) {
-    return [];
+export function recordAgentComposerInputHistory(
+  store: AgentComposerInputHistoryStore,
+  draft: AgentComposerDraft
+): boolean {
+  if (!agentComposerDraftHasContent(draft)) {
+    return false;
   }
-  const cached = inputHistoryByConversation.get(conversation);
-  if (cached) {
-    return cached;
-  }
-  const entries: AgentComposerInputHistoryEntry[] = [];
-  for (const turn of conversation.sourceDetail.turns) {
-    for (const message of turn.userMessages) {
-      const entry = projectHistoryEntry(message, turn.id);
-      if (!entry) {
-        continue;
-      }
-      const previous = entries.at(-1);
-      if (
-        previous &&
-        historyEntryDuplicateKey(previous) === historyEntryDuplicateKey(entry)
-      ) {
-        // Keep the newest duplicate id. Prepending an older page then cannot
-        // invalidate a cursor that already points at the loaded copy.
-        entries[entries.length - 1] = entry;
-      } else {
-        entries.push(entry);
-      }
-    }
-  }
-  inputHistoryByConversation.set(conversation, entries);
-  return entries;
+  store.entries.push({
+    id: `open:${store.nextEntryId}`,
+    draft: snapshotAgentComposerDraft(draft)
+  });
+  store.nextEntryId += 1;
+  return true;
 }
 
 export function navigateAgentComposerInputHistory(input: {
   currentDraft: AgentComposerDraft;
   direction: "older" | "newer";
   entries: readonly AgentComposerInputHistoryEntry[];
-  hasOlderPage: boolean;
   state: AgentComposerInputHistoryState;
 }): AgentComposerInputHistoryNavigation {
   let currentIndex = input.state.entryId
     ? input.entries.findIndex((entry) => entry.id === input.state.entryId)
     : -1;
+  let currentDraft = input.state.currentDraft;
   if (
     input.state.entryId &&
     (currentIndex < 0 ||
@@ -88,84 +71,44 @@ export function navigateAgentComposerInputHistory(input: {
         input.entries[currentIndex]!.draft
       ))
   ) {
-    if (agentComposerDraftHasContent(input.currentDraft)) {
-      return unhandledHistoryNavigation();
-    }
     currentIndex = -1;
+    currentDraft = null;
   }
 
   if (currentIndex < 0) {
-    if (
-      input.direction === "newer" ||
-      agentComposerDraftHasContent(input.currentDraft)
-    ) {
+    if (input.direction === "newer") {
       return unhandledHistoryNavigation();
     }
     const latest = input.entries.at(-1);
-    if (latest) {
-      return recalledHistoryNavigation(latest);
-    }
-    if (input.hasOlderPage) {
-      return olderPageHistoryNavigation(null);
-    }
-    return unhandledHistoryNavigation();
+    return latest
+      ? recalledHistoryNavigation(latest, input.currentDraft)
+      : unhandledHistoryNavigation();
   }
 
   if (input.direction === "older") {
     const older = input.entries[currentIndex - 1];
-    if (older) {
-      return recalledHistoryNavigation(older);
-    }
-    if (input.hasOlderPage) {
-      return olderPageHistoryNavigation(input.state.entryId);
-    }
-    return {
-      handled: false,
-      requestOlderPage: false,
-      state: { entryId: input.state.entryId, pendingOlderPage: false }
-    };
+    return older
+      ? recalledHistoryNavigation(older, currentDraft)
+      : {
+          handled: false,
+          state: {
+            entryId: input.state.entryId,
+            currentDraft
+          }
+        };
   }
 
   const newer = input.entries[currentIndex + 1];
   if (newer) {
-    return recalledHistoryNavigation(newer);
+    return recalledHistoryNavigation(newer, currentDraft);
   }
   return {
-    draft: emptyAgentComposerDraft(),
+    draft: currentDraft
+      ? snapshotAgentComposerDraft(currentDraft)
+      : snapshotAgentComposerDraft(input.currentDraft),
     handled: true,
-    requestOlderPage: false,
     state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
   };
-}
-
-export function resolvePendingAgentComposerInputHistory(input: {
-  entries: readonly AgentComposerInputHistoryEntry[];
-  state: AgentComposerInputHistoryState;
-}): AgentComposerInputHistoryNavigation | null {
-  if (!input.state.pendingOlderPage) {
-    return null;
-  }
-  if (input.state.entryId === null) {
-    const latest = input.entries.at(-1);
-    return latest
-      ? recalledHistoryNavigation(latest)
-      : {
-          handled: false,
-          requestOlderPage: false,
-          state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
-        };
-  }
-  const currentIndex = input.entries.findIndex(
-    (entry) => entry.id === input.state.entryId
-  );
-  const older = currentIndex > 0 ? input.entries[currentIndex - 1] : null;
-  return older
-    ? recalledHistoryNavigation(older)
-    : {
-        handled: false,
-        requestOlderPage: false,
-        state: { entryId: input.state.entryId, pendingOlderPage: false }
-      };
 }
 
 export function areAgentComposerHistoryDraftsEqual(
@@ -175,155 +118,38 @@ export function areAgentComposerHistoryDraftsEqual(
   return historyDraftValue(left) === historyDraftValue(right);
 }
 
-function projectHistoryEntry(
-  message: AgentConversationVM["sourceDetail"]["turns"][number]["userMessages"][number],
-  fallbackTurnId: string
-): AgentComposerInputHistoryEntry | null {
-  const sourceItem = message.sourceTimelineItems?.find((item) =>
-    Array.isArray(item.payload?.content)
-  );
-  const rawContent = Array.isArray(sourceItem?.payload?.content)
-    ? sourceItem.payload.content
-    : [];
-  const content = rawContent.filter((block): block is AgentPromptContentBlock =>
-    Boolean(block && typeof block === "object" && !Array.isArray(block))
-  );
-  const displayPrompt =
-    message.sourceTimelineItems
-      ?.map((item) =>
-        typeof item.payload?.displayPrompt === "string"
-          ? item.payload.displayPrompt.trim()
-          : ""
-      )
-      .find(Boolean) ?? "";
-  const visibleDisplayPrompt = isSyntheticImageOnlyDisplayPrompt(
-    displayPrompt,
-    rawContent
-  )
-    ? ""
-    : displayPrompt;
-  const draft =
-    content.length > 0
-      ? agentPromptContentToComposerDraft(
-          content,
-          `history-${message.turnId ?? fallbackTurnId}-${message.id}`
-        )
-      : buildAgentComposerDraft({
-          prompt: visibleDisplayPrompt || message.body
-        });
-  if (!agentComposerDraftHasContent(draft)) {
-    return null;
-  }
-  const entry = {
-    id: `${message.turnId ?? fallbackTurnId}:${message.id}`,
-    draft
-  };
-  historyDuplicateKeyByEntry.set(
-    entry,
-    JSON.stringify({
-      content,
-      prompt: visibleDisplayPrompt || (content.length === 0 ? message.body : "")
-    })
-  );
-  return entry;
-}
-
-const historyDuplicateKeyByEntry = new WeakMap<
-  AgentComposerInputHistoryEntry,
-  string
->();
-
-function historyEntryDuplicateKey(
-  entry: AgentComposerInputHistoryEntry
-): string {
-  const cached = historyDuplicateKeyByEntry.get(entry);
-  if (cached) {
-    return cached;
-  }
-  const key = historyDraftValueWithOptions(entry.draft, true);
-  historyDuplicateKeyByEntry.set(entry, key);
-  return key;
-}
-
-function isSyntheticImageOnlyDisplayPrompt(
-  displayPrompt: string,
-  content: readonly unknown[]
-): boolean {
-  if (displayPrompt !== "[Image]" && displayPrompt !== "[Images]") {
-    return false;
-  }
-  let imageCount = 0;
-  for (const raw of content) {
-    const block =
-      raw && typeof raw === "object" && !Array.isArray(raw)
-        ? (raw as Record<string, unknown>)
-        : null;
-    if (!block) {
-      continue;
-    }
-    if (
-      block.type === "text" &&
-      typeof block.text === "string" &&
-      block.text.trim()
-    ) {
-      return false;
-    }
-    if (block.type === "image") {
-      imageCount += 1;
-    }
-  }
-  return displayPrompt === "[Image]" ? imageCount === 1 : imageCount > 1;
-}
-
 function recalledHistoryNavigation(
-  entry: AgentComposerInputHistoryEntry
+  entry: AgentComposerInputHistoryEntry,
+  currentDraft: AgentComposerDraft | null
 ): AgentComposerInputHistoryNavigation {
   return {
-    draft: entry.draft,
+    draft: snapshotAgentComposerDraft(entry.draft),
     handled: true,
-    requestOlderPage: false,
-    state: { entryId: entry.id, pendingOlderPage: false }
-  };
-}
-
-function olderPageHistoryNavigation(
-  entryId: string | null
-): AgentComposerInputHistoryNavigation {
-  return {
-    handled: true,
-    requestOlderPage: true,
-    state: { entryId, pendingOlderPage: true }
+    state: {
+      entryId: entry.id,
+      currentDraft:
+        currentDraft === null ? null : snapshotAgentComposerDraft(currentDraft)
+    }
   };
 }
 
 function unhandledHistoryNavigation(): AgentComposerInputHistoryNavigation {
   return {
     handled: false,
-    requestOlderPage: false,
     state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
   };
 }
 
 function historyDraftValue(draft: AgentComposerDraft): string {
-  return historyDraftValueWithOptions(draft, false);
-}
-
-function historyDraftValueWithOptions(
-  draft: AgentComposerDraft,
-  ignoreGeneratedIds: boolean
-): string {
   return JSON.stringify(
     draft.map((block) =>
       block.type === "image"
         ? {
             ...block,
-            ...(ignoreGeneratedIds ? { id: "" } : {}),
             // Preview data is presentation-only and may arrive asynchronously.
             previewUrl: ""
           }
-        : block.type === "file" && ignoreGeneratedIds
-          ? { ...block, id: "" }
-          : block
+        : block
     )
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -332,12 +332,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       : undefined
   );
   const composerInputHistoryProps = useAgentGUIComposerInputHistoryProps({
-    actions,
-    conversation,
-    enabled: sessionInputHistoryEnabled,
-    pendingPrependScrollAnchorRef,
-    timelineRef,
-    viewModel
+    enabled: sessionInputHistoryEnabled
   });
   const bottomDockComposerProps = useMemo<AgentComposerProps>(
     () => ({

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIComposerInputHistoryProps.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIComposerInputHistoryProps.spec.tsx
@@ -1,71 +1,24 @@
-import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
-import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
-import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
-import type { AgentGUINodeViewProps } from "./AgentGUINodeView.types";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
 import { useAgentGUIComposerInputHistoryProps } from "./useAgentGUIComposerInputHistoryProps";
 
 describe("useAgentGUIComposerInputHistoryProps", () => {
-  it("keeps history disabled until the host opts in", () => {
-    const timeline = document.createElement("div");
-    Object.defineProperties(timeline, {
-      scrollHeight: { value: 900 },
-      scrollTop: { value: 120, writable: true }
-    });
-    const loadOlderConversationMessages = vi.fn();
-    const pendingPrependScrollAnchorRef = { current: null };
-    const input = {
-      actions: {
-        loadOlderConversationMessages
-      } as unknown as AgentGUINodeViewProps["actions"],
-      conversation: conversationWithPrompt(),
-      pendingPrependScrollAnchorRef,
-      timelineRef: { current: timeline },
-      viewModel: {
-        rail: { activeConversationId: "session-1" },
-        detail: {
-          hasOlderMessages: true,
-          isLoadingOlderMessages: false
-        }
-      } as AgentGUINodeViewModel
-    };
+  it("keeps one open-period store and exposes it only when enabled", () => {
     const { result, rerender } = renderHook(
-      ({ enabled }) =>
-        useAgentGUIComposerInputHistoryProps({ ...input, enabled }),
+      ({ enabled }) => useAgentGUIComposerInputHistoryProps({ enabled }),
       { initialProps: { enabled: false } }
     );
 
-    expect(result.current).toEqual({
-      inputHistory: [],
-      inputHistoryHasOlderPage: false,
-      inputHistoryIsLoadingOlderPage: false,
-      onRequestOlderInputHistoryPage: undefined
-    });
+    expect(result.current.inputHistoryStore).toBeUndefined();
 
     rerender({ enabled: true });
+    const openPeriodStore = result.current.inputHistoryStore;
+    expect(openPeriodStore).toBeDefined();
 
-    expect(result.current.inputHistory).toHaveLength(1);
-    act(() => {
-      result.current.onRequestOlderInputHistoryPage?.();
-    });
-    expect(loadOlderConversationMessages).toHaveBeenCalledOnce();
-    expect(pendingPrependScrollAnchorRef.current).toEqual({
-      conversationId: "session-1",
-      scrollHeight: 900,
-      scrollTop: 120
-    });
+    rerender({ enabled: false });
+    expect(result.current.inputHistoryStore).toBeUndefined();
+
+    rerender({ enabled: true });
+    expect(result.current.inputHistoryStore).toBe(openPeriodStore);
   });
 });
-
-function conversationWithPrompt(): AgentConversationVM {
-  return {
-    sourceDetail: {
-      turns: [
-        {
-          id: "turn-1",
-          userMessages: [{ id: "message-1", body: "hello" }]
-        }
-      ]
-    }
-  } as unknown as AgentConversationVM;
-}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIComposerInputHistoryProps.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIComposerInputHistoryProps.ts
@@ -1,71 +1,17 @@
-import { useMemo, type RefObject } from "react";
-import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
+import { useMemo, useState } from "react";
 import type { AgentComposerProps } from "../AgentComposer";
-import type { AgentGUINodeViewProps } from "../AgentGUINodeView";
-import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
-import { projectAgentComposerInputHistory } from "../model/agentComposerInputHistory";
-import { useStableEventCallback } from "./agentGUIViewUtils";
+import { createAgentComposerInputHistoryStore } from "../model/agentComposerInputHistory";
 
-type InputHistoryProps = Pick<
-  AgentComposerProps,
-  | "inputHistory"
-  | "inputHistoryHasOlderPage"
-  | "inputHistoryIsLoadingOlderPage"
-  | "onRequestOlderInputHistoryPage"
->;
-const EMPTY_INPUT_HISTORY: NonNullable<InputHistoryProps["inputHistory"]> = [];
+type InputHistoryProps = Pick<AgentComposerProps, "inputHistoryStore">;
 
 export function useAgentGUIComposerInputHistoryProps(input: {
-  actions: AgentGUINodeViewProps["actions"];
-  conversation: AgentConversationVM | null;
   enabled: boolean;
-  pendingPrependScrollAnchorRef: RefObject<{
-    conversationId: string;
-    scrollHeight: number;
-    scrollTop: number;
-  } | null>;
-  timelineRef: RefObject<HTMLDivElement | null>;
-  viewModel: AgentGUINodeViewModel;
 }): InputHistoryProps {
-  const onRequestOlderInputHistoryPage = useStableEventCallback(() => {
-    const activeConversationId = input.viewModel.rail.activeConversationId;
-    if (
-      !activeConversationId ||
-      !input.viewModel.detail.hasOlderMessages ||
-      input.viewModel.detail.isLoadingOlderMessages
-    ) {
-      return;
-    }
-    const timeline = input.timelineRef.current;
-    if (timeline) {
-      input.pendingPrependScrollAnchorRef.current = {
-        conversationId: activeConversationId,
-        scrollHeight: timeline.scrollHeight,
-        scrollTop: timeline.scrollTop
-      };
-    }
-    input.actions.loadOlderConversationMessages();
-  });
-  const inputHistory = input.enabled
-    ? projectAgentComposerInputHistory(input.conversation)
-    : EMPTY_INPUT_HISTORY;
+  const [inputHistoryStore] = useState(createAgentComposerInputHistoryStore);
   return useMemo(
     () => ({
-      inputHistory,
-      inputHistoryHasOlderPage:
-        input.enabled && input.viewModel.detail.hasOlderMessages,
-      inputHistoryIsLoadingOlderPage:
-        input.enabled && input.viewModel.detail.isLoadingOlderMessages,
-      onRequestOlderInputHistoryPage: input.enabled
-        ? onRequestOlderInputHistoryPage
-        : undefined
+      inputHistoryStore: input.enabled ? inputHistoryStore : undefined
     }),
-    [
-      input.viewModel.detail.hasOlderMessages,
-      input.viewModel.detail.isLoadingOlderMessages,
-      input.enabled,
-      inputHistory,
-      onRequestOlderInputHistoryPage
-    ]
+    [input.enabled, inputHistoryStore]
   );
 }


### PR DESCRIPTION
## What changed

- keep one in-memory structured composer history for the lifetime of the mounted Agent GUI
- record every non-empty submitted input, including consecutive duplicates
- capture the current composer draft as the newest navigation entry so Down restores it exactly
- allow Up/Down history navigation when the composer already contains text
- share the open-period history between the Home and Session composer presentations

## Why

The initial implementation derived history from persisted Session transcript messages and only entered history navigation from an empty composer. Codex behavior is scoped to inputs submitted while the UI is open, with the live draft treated as the final entry, so the transcript-backed and empty-only behavior did not match the intended interaction.

## Impact

With the existing `lab.agentInputHistory` capability enabled, users can navigate all inputs submitted during the current Agent GUI open period without first clearing their draft. Moving forward past the latest submitted input restores the draft that was present before navigation. Palette/IME precedence and whole-document caret boundary behavior remain unchanged.

## Validation

- `pnpm --filter @tutti-os/agent-gui test` (287 files, 2407 tests)
- `pnpm check:changed` (11 lanes)
- push-ready pre-push checks (12 lanes)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->