### PR TITLE
fix(agent): prevent terminal report starvation

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -23,7 +23,8 @@ Use the focused runtime index or open one area directly:
   Includes shared-device recovery that looks terminal while the host is still retrying.
   Also covers new-conversation requests that silently fail after a Chats
   Session working directory is mistaken for a selected project, and one hung
-  provider startup blocking unrelated Agent sessions.
+  provider startup blocking unrelated Agent sessions. Includes canonical
+  completion delayed behind a streaming activity-report backlog.
 - [Agent Approvals And Child Sessions](./agent-approvals-subagents.md): Approval gates, plan exits, root/parent/child event attribution, child sessions, and Message Center.
   Includes provider-native work that continues invisibly after root cancellation
   and late child creation racing the durable cancel boundary.

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -233,6 +233,36 @@
   order without deadlocking. Unsupported capability/source values must fail at
   HTTP ingress and event publication without changing activation.
 
+### Codex finishes but AgentGUI keeps showing the Session as working
+
+- **Symptom:** Codex has emitted its final assistant message, but AgentGUI keeps
+  showing a busy spinner and the Session still has an active Turn. The UI may
+  settle several minutes later without a restart.
+- **Quick checks:** Search `tuttid.log` for
+  `agent_session.activity_report.queue_backlog` and compare its `queue_depth`
+  with the final message's `occurredAtUnixMs` and canonical
+  `updatedAtUnixMs`. A large gap means provider completion reached the runtime
+  before canonical persistence. When prod and dev are both running, identify
+  them by listener, PID, state, and workspace paths; a shared log file alone
+  does not prove they share a database.
+- **Root cause:** Streaming text, reasoning, and tool-output snapshots entered
+  the unbounded report FIFO before coalescing. When the single reporter was
+  slower than producers, thousands of superseded snapshots accumulated ahead
+  of the same Session's terminal report. Tool-call output snapshots were not
+  eligible for coalescing at all.
+- **Fix:** Coalesce pending streaming snapshots by Session and message while
+  they are enqueued. Preserve the latest cumulative tool output, original tool
+  input, and earliest start time. Keep terminal and submit-provenance reports
+  as same-Session FIFO barriers.
+- **Validation:** Enqueue at least 2048 text and tool-output snapshots and prove
+  each pending Session occupies one queue slot. Verify the latest snapshot is
+  retained, terminal and submit-provenance barriers stay ordered, reporter
+  re-entry remains non-blocking, and focused race tests pass.
+- **References:**
+  [controller_report_queue.go](../../../packages/agent/daemon/runtime/controller_report_queue.go),
+  [report_coalescer.go](../../../packages/agent/daemon/runtime/report_coalescer.go),
+  [controller_report_queue_test.go](../../../packages/agent/daemon/runtime/controller_report_queue_test.go)
+
 ### Tutti mode is active in the composer but disappears after the first submit
 
 - **Symptom:** The home composer shows Tutti enabled and the submit trace records

--- a/packages/agent/daemon/runtime/controller_report_queue.go
+++ b/packages/agent/daemon/runtime/controller_report_queue.go
@@ -1,19 +1,28 @@
 package agentruntime
 
-import "sync"
+import (
+	"sync"
+
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+)
 
 // reportRequestQueue is an unbounded FIFO with a single non-blocking wake-up
-// signal. Producers may be re-entered from reporter observers, so they must
+// signal. Pending streaming snapshots are coalesced before they can become a
+// backlog. Producers may be re-entered from reporter observers, so they must
 // never call the reporter inline or wait for the sole consumer.
 type reportRequestQueue struct {
-	mu      sync.Mutex
-	items   []reportRequest
-	head    int
-	readyCh chan struct{}
+	mu               sync.Mutex
+	items            []*reportRequest
+	head             int
+	pendingStreaming map[string]*reportRequest
+	readyCh          chan struct{}
 }
 
 func newReportRequestQueue() *reportRequestQueue {
-	return &reportRequestQueue{readyCh: make(chan struct{}, 1)}
+	return &reportRequestQueue{
+		pendingStreaming: make(map[string]*reportRequest),
+		readyCh:          make(chan struct{}, 1),
+	}
 }
 
 func (q *reportRequestQueue) enqueue(request reportRequest) int {
@@ -21,7 +30,22 @@ func (q *reportRequestQueue) enqueue(request reportRequest) int {
 		return 0
 	}
 	q.mu.Lock()
-	q.items = append(q.items, request)
+	streamingKey := queuedStreamingReportKey(request)
+	if streamingKey != "" {
+		if pending := q.pendingStreaming[streamingKey]; pending != nil {
+			mergeQueuedStreamingReport(pending, request)
+			depth := len(q.items) - q.head
+			q.mu.Unlock()
+			return depth
+		}
+	} else {
+		delete(q.pendingStreaming, queuedReportSessionKey(request.report))
+	}
+	queued := request
+	q.items = append(q.items, &queued)
+	if streamingKey != "" {
+		q.pendingStreaming[streamingKey] = &queued
+	}
 	depth := len(q.items) - q.head
 	q.mu.Unlock()
 	select {
@@ -40,18 +64,60 @@ func (q *reportRequestQueue) dequeue() (reportRequest, bool) {
 	if q.head >= len(q.items) {
 		return reportRequest{}, false
 	}
-	request := q.items[q.head]
-	q.items[q.head] = reportRequest{}
+	queued := q.items[q.head]
+	request := *queued
+	if streamingKey := queuedStreamingReportKey(request); streamingKey != "" &&
+		q.pendingStreaming[streamingKey] == queued {
+		delete(q.pendingStreaming, streamingKey)
+	}
+	q.items[q.head] = nil
 	q.head++
 	if q.head == len(q.items) {
 		q.items = nil
 		q.head = 0
 	} else if q.head >= 1024 && q.head*2 >= len(q.items) {
-		remaining := append([]reportRequest(nil), q.items[q.head:]...)
+		remaining := append([]*reportRequest(nil), q.items[q.head:]...)
 		q.items = remaining
 		q.head = 0
 	}
 	return request, true
+}
+
+func queuedStreamingReportKey(request reportRequest) string {
+	if request.submitProvenance || request.done != nil || !isCoalescibleStreamingReport(request.report) {
+		return ""
+	}
+	return queuedReportSessionKey(request.report)
+}
+
+func queuedReportSessionKey(report agentsessionstore.ReportActivityInput) string {
+	if key := reportCoalesceSessionKey(report); key != "" {
+		return key
+	}
+	return reportCoalesceFallbackSessionKey(report)
+}
+
+func mergeQueuedStreamingReport(current *reportRequest, incoming reportRequest) {
+	if current == nil {
+		return
+	}
+	current.ctx = incoming.ctx
+	indexByMessageKey := make(map[string]int, len(current.report.MessageUpdates))
+	for index, update := range current.report.MessageUpdates {
+		indexByMessageKey[reportMessageUpdateCoalesceKey(current.report, update)] = index
+	}
+	for _, update := range incoming.report.MessageUpdates {
+		messageKey := reportMessageUpdateCoalesceKey(incoming.report, update)
+		if index, ok := indexByMessageKey[messageKey]; ok {
+			current.report.MessageUpdates[index] = latestMessageUpdate(
+				current.report.MessageUpdates[index],
+				update,
+			)
+			continue
+		}
+		indexByMessageKey[messageKey] = len(current.report.MessageUpdates)
+		current.report.MessageUpdates = append(current.report.MessageUpdates, update)
+	}
 }
 
 func (q *reportRequestQueue) ready() <-chan struct{} {

--- a/packages/agent/daemon/runtime/controller_report_queue_test.go
+++ b/packages/agent/daemon/runtime/controller_report_queue_test.go
@@ -1,0 +1,155 @@
+package agentruntime
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestReportRequestQueueCoalescesStreamingSnapshotsBeforeTheyBecomeBacklog(t *testing.T) {
+	t.Parallel()
+
+	queue := newReportRequestQueue()
+	const updateCount = 2048
+	for seq := 1; seq <= updateCount; seq++ {
+		depth := queue.enqueue(streamingRequestForSession("session-1", uint64(seq)))
+		if depth != 1 {
+			t.Fatalf("queue depth after streaming update %d = %d, want 1", seq, depth)
+		}
+	}
+
+	depth := queue.enqueue(terminalRequestForSession("session-1", updateCount+1))
+	if depth != 2 {
+		t.Fatalf("queue depth after terminal = %d, want 2", depth)
+	}
+
+	streaming, ok := queue.dequeue()
+	if !ok {
+		t.Fatal("streaming report was not queued")
+	}
+	update := streaming.report.MessageUpdates[0]
+	if update.Seq != updateCount || update.Payload["content"] != fmt.Sprintf("content-%d", updateCount) {
+		t.Fatalf("streaming update = %#v, want latest snapshot", update)
+	}
+
+	terminal, ok := queue.dequeue()
+	if !ok {
+		t.Fatal("terminal report was not queued")
+	}
+	if status := terminal.report.MessageUpdates[0].Status; status != messageStreamStateCompleted {
+		t.Fatalf("second report status = %q, want completed", status)
+	}
+}
+
+func TestReportRequestQueueKeepsStreamingAfterSameSessionTerminalBehindTerminal(t *testing.T) {
+	t.Parallel()
+
+	queue := newReportRequestQueue()
+	queue.enqueue(streamingRequestForSession("session-1", 1))
+	queue.enqueue(terminalRequestForSession("session-1", 2))
+	depth := queue.enqueue(streamingRequestForSession("session-1", 3))
+	if depth != 3 {
+		t.Fatalf("queue depth = %d, want 3 reports separated by the terminal barrier", depth)
+	}
+
+	wantStatuses := []string{
+		messageStreamStateStreaming,
+		messageStreamStateCompleted,
+		messageStreamStateStreaming,
+	}
+	for index, wantStatus := range wantStatuses {
+		request, ok := queue.dequeue()
+		if !ok {
+			t.Fatalf("report %d was not queued", index)
+		}
+		if status := request.report.MessageUpdates[0].Status; status != wantStatus {
+			t.Fatalf("report %d status = %q, want %q", index, status, wantStatus)
+		}
+	}
+}
+
+func TestReportRequestQueueKeepsSubmitProvenanceAsSameSessionBarrier(t *testing.T) {
+	t.Parallel()
+
+	queue := newReportRequestQueue()
+	queue.enqueue(streamingRequestForSession("session-1", 1))
+	provenance := streamingRequestForSession("session-1", 2)
+	provenance.submitProvenance = true
+	provenance.done = make(chan error, 1)
+	queue.enqueue(provenance)
+	depth := queue.enqueue(streamingRequestForSession("session-1", 3))
+	if depth != 3 {
+		t.Fatalf("queue depth = %d, want streaming, provenance barrier, streaming", depth)
+	}
+
+	queue.dequeue()
+	barrier, ok := queue.dequeue()
+	if !ok || !barrier.submitProvenance || barrier.done == nil {
+		t.Fatalf("second report = %#v, want submit provenance barrier", barrier)
+	}
+}
+
+func TestReportRequestQueueCoalescesToolOutputSnapshotsBeforeTheyBecomeBacklog(t *testing.T) {
+	t.Parallel()
+
+	queue := newReportRequestQueue()
+	first := toolCallStreamingReport(1, map[string]any{
+		"input": map[string]any{"command": "pnpm test"},
+	})
+	queue.enqueue(reportRequest{ctx: context.Background(), report: first})
+
+	const updateCount = 2048
+	for seq := 2; seq <= updateCount; seq++ {
+		latest := toolCallStreamingReport(uint64(seq), map[string]any{
+			"output": map[string]any{"text": fmt.Sprintf("chunk-%d", seq)},
+		})
+		depth := queue.enqueue(reportRequest{ctx: context.Background(), report: latest})
+		if depth != 1 {
+			t.Fatalf("queue depth after tool output %d = %d, want 1", seq, depth)
+		}
+	}
+
+	request, ok := queue.dequeue()
+	if !ok {
+		t.Fatal("tool report was not queued")
+	}
+	update := request.report.MessageUpdates[0]
+	input, _ := update.Payload["input"].(map[string]any)
+	output, _ := update.Payload["output"].(map[string]any)
+	if update.Seq != updateCount || input["command"] != "pnpm test" || output["text"] != "chunk-2048" {
+		t.Fatalf("tool update = %#v, want latest output with original input", update)
+	}
+}
+
+func TestReportRequestQueueCoalescesInterleavedSessionsIndependently(t *testing.T) {
+	t.Parallel()
+
+	queue := newReportRequestQueue()
+	const updateCount = 1024
+	for seq := 1; seq <= updateCount; seq++ {
+		sessionID := "session-1"
+		if seq%2 == 0 {
+			sessionID = "session-2"
+		}
+		queue.enqueue(streamingRequestForSession(sessionID, uint64(seq)))
+	}
+
+	depth := queue.enqueue(terminalRequestForSession("session-1", updateCount+1))
+	if depth != 3 {
+		t.Fatalf("queue depth = %d, want two coalesced sessions plus terminal", depth)
+	}
+}
+
+func streamingRequestForSession(sessionID string, seq uint64) reportRequest {
+	report := streamingReport("assistant-"+sessionID, seq, fmt.Sprintf("content-%d", seq))
+	report.Source.AgentID = sessionID
+	report.MessageUpdates[0].AgentSessionID = sessionID
+	return reportRequest{ctx: context.Background(), report: report}
+}
+
+func terminalRequestForSession(sessionID string, seq int) reportRequest {
+	report := terminalReport("assistant-"+sessionID, uint64(seq), fmt.Sprintf("content-%d", seq))
+	report.Source.AgentID = sessionID
+	report.MessageUpdates[0].AgentSessionID = sessionID
+	return reportRequest{ctx: context.Background(), report: report}
+}

--- a/packages/agent/daemon/runtime/report_coalescer.go
+++ b/packages/agent/daemon/runtime/report_coalescer.go
@@ -165,7 +165,7 @@ func isCoalescibleStreamingReport(report agentsessionstore.ReportActivityInput) 
 
 func isCoalescibleStreamingMessageUpdate(update agentsessionstore.WorkspaceAgentMessageUpdate) bool {
 	switch strings.ToLower(strings.TrimSpace(update.Kind)) {
-	case "text", "reasoning":
+	case "text", "reasoning", "tool_call":
 	default:
 		return false
 	}
@@ -208,11 +208,65 @@ func latestMessageUpdate(
 	current agentsessionstore.WorkspaceAgentMessageUpdate,
 	incoming agentsessionstore.WorkspaceAgentMessageUpdate,
 ) agentsessionstore.WorkspaceAgentMessageUpdate {
+	earlier := incoming
+	latest := current
 	if incoming.Seq > current.Seq {
-		return incoming
+		earlier = current
+		latest = incoming
+	} else if incoming.Seq == current.Seq && incoming.OccurredAtUnixMS >= current.OccurredAtUnixMS {
+		earlier = current
+		latest = incoming
 	}
-	if incoming.Seq == current.Seq && incoming.OccurredAtUnixMS >= current.OccurredAtUnixMS {
-		return incoming
+	if strings.EqualFold(strings.TrimSpace(latest.Kind), "tool_call") {
+		latest = mergeCoalescedToolCallUpdate(earlier, latest)
 	}
-	return current
+	return latest
+}
+
+func mergeCoalescedToolCallUpdate(
+	earlier agentsessionstore.WorkspaceAgentMessageUpdate,
+	latest agentsessionstore.WorkspaceAgentMessageUpdate,
+) agentsessionstore.WorkspaceAgentMessageUpdate {
+	if latest.AgentSessionID == "" {
+		latest.AgentSessionID = earlier.AgentSessionID
+	}
+	if latest.MessageID == "" {
+		latest.MessageID = earlier.MessageID
+	}
+	if latest.TurnID == "" {
+		latest.TurnID = earlier.TurnID
+	}
+	if latest.Role == "" {
+		latest.Role = earlier.Role
+	}
+	if latest.Kind == "" {
+		latest.Kind = earlier.Kind
+	}
+	if latest.Status == "" {
+		latest.Status = earlier.Status
+	}
+	if latest.Semantics == nil {
+		latest.Semantics = earlier.Semantics
+	}
+	if latest.CallID == "" {
+		latest.CallID = earlier.CallID
+	}
+	if latest.ParentCallID == "" {
+		latest.ParentCallID = earlier.ParentCallID
+	}
+	if latest.RootCallID == "" {
+		latest.RootCallID = earlier.RootCallID
+	}
+	if latest.Title == "" {
+		latest.Title = earlier.Title
+	}
+	latest.Payload = mergePendingToolCallPayload(earlier.Payload, latest.Payload)
+	if earlier.StartedAtUnixMS > 0 &&
+		(latest.StartedAtUnixMS <= 0 || earlier.StartedAtUnixMS < latest.StartedAtUnixMS) {
+		latest.StartedAtUnixMS = earlier.StartedAtUnixMS
+	}
+	if earlier.CompletedAtUnixMS > latest.CompletedAtUnixMS {
+		latest.CompletedAtUnixMS = earlier.CompletedAtUnixMS
+	}
+	return latest
 }

--- a/packages/agent/daemon/runtime/report_coalescer_test.go
+++ b/packages/agent/daemon/runtime/report_coalescer_test.go
@@ -72,6 +72,43 @@ func TestStreamingReportCoalescerFlushesBeforeTerminalReport(t *testing.T) {
 	}
 }
 
+func TestStreamingReportCoalescerKeepsLatestToolOutputWithoutDroppingStartMetadata(t *testing.T) {
+	t.Parallel()
+
+	coalescer := newStreamingReportCoalescer(time.Hour)
+	defer coalescer.stop()
+
+	first := toolCallStreamingReport(1, map[string]any{
+		"input": map[string]any{"command": "pnpm test"},
+	})
+	first.MessageUpdates[0].StartedAtUnixMS = 10
+	if flushed := coalescer.add(reportRequest{ctx: context.Background(), report: first}); len(flushed) != 0 {
+		t.Fatalf("first tool snapshot flushed %#v, want pending", flushed)
+	}
+
+	latest := toolCallStreamingReport(2, map[string]any{
+		"output": map[string]any{"text": "tests passed"},
+	})
+	latest.MessageUpdates[0].StartedAtUnixMS = 20
+	if flushed := coalescer.add(reportRequest{ctx: context.Background(), report: latest}); len(flushed) != 0 {
+		t.Fatalf("latest tool snapshot flushed %#v, want pending", flushed)
+	}
+
+	flushed := coalescer.flushAll()
+	if len(flushed) != 1 || len(flushed[0].report.MessageUpdates) != 1 {
+		t.Fatalf("flushed reports = %#v, want one coalesced tool update", flushed)
+	}
+	update := flushed[0].report.MessageUpdates[0]
+	input, _ := update.Payload["input"].(map[string]any)
+	output, _ := update.Payload["output"].(map[string]any)
+	if update.Seq != 2 || input["command"] != "pnpm test" || output["text"] != "tests passed" {
+		t.Fatalf("tool update = %#v, want latest output with original input", update)
+	}
+	if update.StartedAtUnixMS != 10 {
+		t.Fatalf("tool startedAtUnixMs = %d, want earliest 10", update.StartedAtUnixMS)
+	}
+}
+
 func TestStreamingReportCoalescerNeverCoalescesSessionAudit(t *testing.T) {
 	t.Parallel()
 	coalescer := newStreamingReportCoalescer(time.Second)
@@ -92,6 +129,29 @@ func streamingReport(messageID string, seq uint64, content string) agentsessions
 
 func terminalReport(messageID string, seq uint64, content string) agentsessionstore.ReportActivityInput {
 	return messageReport(messageID, seq, messageStreamStateCompleted, content)
+}
+
+func toolCallStreamingReport(seq uint64, payload map[string]any) agentsessionstore.ReportActivityInput {
+	return agentsessionstore.ReportActivityInput{
+		WorkspaceID: "workspace-1",
+		Source: canonical.EventSource{
+			AgentID:       "agent-session-1",
+			SessionOrigin: agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		},
+		MessageUpdates: []agentsessionstore.WorkspaceAgentMessageUpdate{{
+			AgentSessionID:   "agent-session-1",
+			MessageID:        "tool-call-1",
+			Seq:              seq,
+			TurnID:           "turn-1",
+			Role:             "assistant",
+			Kind:             "tool_call",
+			Status:           "running",
+			CallID:           "call-1",
+			Title:            "Bash",
+			Payload:          payload,
+			OccurredAtUnixMS: int64(seq),
+		}},
+	}
 }
 
 func messageReport(messageID string, seq uint64, status string, content string) agentsessionstore.ReportActivityInput {


### PR DESCRIPTION
## Summary
- coalesce pending text, reasoning, and tool-output snapshots before they build an activity-report backlog
- preserve tool input, latest output, and start metadata while keeping terminal and submit-provenance reports ordered
- document how to distinguish canonical persistence delay from UI state and mixed prod/dev logs

## Tests
- `go test ./runtime -count=1`
- `go test -race ./runtime -run 'Test(ReportRequestQueue|StreamingReportCoalescer|ReportWorkerPreservesFIFO)' -count=1`
- `pnpm check:changed -- --push-ready`

## Notes
- intentionally does not change the separate dev/prod log-directory isolation behavior

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->