### PR TITLE
fix(workbench): make dock previews reliable

### DIFF
--- a/apps/desktop/src/main/host/tuttiAssetProtocol.test.ts
+++ b/apps/desktop/src/main/host/tuttiAssetProtocol.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from "node:path";
 import test from "node:test";
 import { tuttiAssetProtocolAssets } from "./tuttiAssetProtocolAssets.ts";
 import { resolveTuttiAssetProtocolFilePath } from "./tuttiAssetProtocolResolver.ts";
+import { createTuttiAssetProtocolResponse } from "./tuttiAssetProtocolResponse.ts";
 
 test("tutti asset protocol resolves development source assets", () => {
   const appPath = mkdtempSync(join(tmpdir(), "tutti-asset-dev-"));
@@ -84,4 +85,20 @@ test("tutti asset protocol rejects unknown asset routes", () => {
     ),
     null
   );
+});
+
+test("tutti asset protocol responses allow anonymous canvas image loads", async () => {
+  const response = createTuttiAssetProtocolResponse(
+    new Response("image", {
+      headers: {
+        "Content-Type": "image/png",
+        "X-Asset-Header": "preserved"
+      }
+    })
+  );
+
+  assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+  assert.equal(response.headers.get("Content-Type"), "image/png");
+  assert.equal(response.headers.get("X-Asset-Header"), "preserved");
+  assert.equal(await response.text(), "image");
 });

--- a/apps/desktop/src/main/host/tuttiAssetProtocol.ts
+++ b/apps/desktop/src/main/host/tuttiAssetProtocol.ts
@@ -2,6 +2,7 @@ import { pathToFileURL } from "node:url";
 import { app, net, session, type Session } from "electron";
 import { tuttiAssetProtocolScheme } from "../../shared/tuttiAssetProtocol.ts";
 import { resolveTuttiAssetProtocolFilePath } from "./tuttiAssetProtocolResolver.ts";
+import { createTuttiAssetProtocolResponse } from "./tuttiAssetProtocolResponse.ts";
 
 const handledSessions = new WeakSet<Session>();
 
@@ -24,6 +25,8 @@ export function registerTuttiAssetProtocolForSession(
     if (!filePath) {
       return new Response(null, { status: 404 });
     }
-    return net.fetch(pathToFileURL(filePath).href);
+    return createTuttiAssetProtocolResponse(
+      await net.fetch(pathToFileURL(filePath).href)
+    );
   });
 }

--- a/apps/desktop/src/main/host/tuttiAssetProtocolResponse.ts
+++ b/apps/desktop/src/main/host/tuttiAssetProtocolResponse.ts
@@ -1,0 +1,14 @@
+/**
+ * Apply only after the request URL resolves through tuttiAssetProtocolAssets.
+ * These responses contain credentialless bundled images; wildcard CORS keeps
+ * anonymous image loads usable as WebGL textures in file and dev renderers.
+ */
+export function createTuttiAssetProtocolResponse(source: Response): Response {
+  const headers = new Headers(source.headers);
+  headers.set("Access-Control-Allow-Origin", "*");
+  return new Response(source.body, {
+    headers,
+    status: source.status,
+    statusText: source.statusText
+  });
+}

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -675,6 +675,11 @@ Harness target by exact target ID, then use the provider/icon catalog fallback.
 Host projections preserve these roles independently and do not create
 provider-specific renderer catalogs.
 
+Agent presentation images decoded for a canvas-backed texture must use
+anonymous CORS loading before assigning `src`. Any host-owned custom protocol
+that serves those images must return an `Access-Control-Allow-Origin` response
+header so the decoded image cannot taint the texture canvas.
+
 When the Desktop host projects built-in Agent mentions into a workspace app,
 it replaces host-local file URLs with bounded 64px WebP data URLs. The external
 bridge is the serialization owner: workspace apps must not read host paths,
@@ -946,10 +951,15 @@ only after native capture fails or exceeds its bounded wait. Electron hosts
 pass the sanitized node region directly to `webContents.capturePage`, retain
 the returned region for Genie, and resize a copy for the Dock. The Genie path
 must not reuse an undersized Dock image. Dock popup
-cards and minimized slots use the bounded image and its cache. If no captured
-image exists, those Dock surfaces show their placeholder; they do not mount
-AgentGUI as a fallback. AgentGUI therefore has no preview-mode rendering
-contract.
+cards and minimized slots use the bounded image and its cache. A background or
+minimized popup node must not request a fresh DOM snapshot: AgentGUI may be
+unhydrated, and `surface.isVisible=false` deactivates imperative resources such
+as the hero Canvas. Those nodes reuse only a previously successful image. If no
+captured image exists, the Dock shows a static terminal placeholder rather than
+an in-flight skeleton; it does not mount AgentGUI or render a conversation
+summary as a fallback. Capture failure is not cached across popup lifetimes, so
+a later foreground attempt may still populate the image. AgentGUI therefore
+has no preview-mode rendering contract.
 When a minimized node has a cached Genie texture, Workbench completes the
 restore animation before launching the host node, then replaces the final
 texture frame only after launch settles. The expensive AgentGUI reconstruction

--- a/docs/architecture/workbench-dock-model.md
+++ b/docs/architecture/workbench-dock-model.md
@@ -266,11 +266,25 @@ writes. Resetting the interaction or changing slot membership invalidates the
 snapshot.
 
 Native popup previews pass the clamped target rectangle to Electron capture;
-they must not capture the whole `webContents` and crop afterward. Popup capture
-effects are keyed by preview identity and revision, not transient item arrays or
-callback references. Cleanup may fence stale UI writes, but it must retain the
-pending marker for a native capture that has already started until that capture
-settles, because Electron capture cannot be canceled.
+they must not capture the whole `webContents` and crop afterward. A native
+region capture is valid only for the foreground node represented by those
+composited pixels. Background and minimized nodes must not use a fresh DOM
+snapshot because their bodies may be unhydrated or their imperative resources
+may be inactive. They reuse the last successful memory or persistent image
+instead. A failed capture is terminal only for the mounted popup; it must not
+be retained across popup lifetimes because the node may be foreground the next
+time. Popup capture effects are keyed by preview identity and revision, not
+transient item arrays or callback references. Cleanup may fence stale UI
+writes, but it must retain the pending marker for a native capture that has
+already started until that capture settles, because Electron capture cannot be
+canceled. Skeletons represent in-flight capture only; a terminally unavailable
+preview uses a non-loading static placeholder.
+
+Dock popup responsibilities stay split by lifecycle: `WorkbenchHostDockPopup`
+owns portal/layout and dismissal, `WorkbenchHostDockPopupPresentation` owns
+cards and context-menu rendering, and
+`useWorkbenchHostDockPopupPreviewCapture` owns capture, pending-operation
+fencing, and preview caches.
 
 ### Matching
 

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -517,6 +517,68 @@
 - References:
   [useAgentGUINodeController.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts)
 
+### Dock popup stays on skeletons after preview capture succeeds
+
+- Symptom:
+  Dock popup cards remain as skeletons even though renderer diagnostics report
+  `dock_preview_capture.succeeded`.
+- Quick checks:
+  Compare `dock.popup.preview_capture.started` and
+  `dock.popup.preview_capture.resolved`. If capture starts once but the popup
+  effect runs twice in development, inspect whether the first cleanup fences
+  the result while the replayed effect skips the same pending capture.
+- Root cause:
+  React StrictMode replays effect setup and cleanup. Electron capture cannot be
+  canceled, so a module-level pending marker can outlive the effect invocation
+  that started it. Treating that invocation as canceled drops its successful
+  result, while the replay cannot start a replacement.
+- Fix:
+  Keep the pending marker until the native capture settles. Commit the result
+  when the popup is still mounted and the item's semantic preview identity is
+  still current, regardless of which equivalent effect invocation issued the
+  capture.
+- Validation:
+  Render the popup under `StrictMode`, defer the capture promise until effect
+  replay completes, and assert one native capture plus a rendered image.
+- References:
+  [docs/architecture/workbench-dock-model.md](../../architecture/workbench-dock-model.md)
+  [WorkbenchHostDockPopup.tsx](../../../packages/workbench/surface/src/host/WorkbenchHostDockPopup.tsx)
+
+### Some background Dock previews remain as skeletons
+
+- Symptom:
+  A multi-window Dock popup renders foreground or previously cached previews,
+  but windows that have never been foreground remain visually identical to
+  loading skeletons.
+- Quick checks:
+  Correlate `dock.popup.preview_capture.started` with
+  `dock.popup.preview_capture.resolved`. An immediate `hasPreview: false`
+  without a native `dock_preview_capture.started` event means the host rejected
+  native capture before IPC. Check whether the node is background and whether
+  its revision has a persisted preview.
+- Root cause:
+  Electron's rectangular capture reads the currently composited foreground
+  pixels. The desktop host correctly rejects a background node because its
+  rectangle contains another window. AgentGUI may also be unhydrated or have
+  inactive imperative resources when `surface.isVisible=false`, so a fresh DOM
+  snapshot can produce a blank image. Treating an unavailable result as a
+  reusable cache entry also prevents a later foreground attempt for the same
+  revision.
+- Fix:
+  Keep native capture as the foreground high-fidelity path. Background and
+  minimized popup nodes reuse only a successful memory or persistent image;
+  they do not request a fresh DOM snapshot. Keep an unavailable result local to
+  the mounted popup so reopening can retry after the node becomes foreground.
+  Show a static terminal placeholder instead of a loading skeleton when no
+  successful image exists.
+- Validation:
+  Cover native-null plus persisted-cache success, assert that background DOM
+  capture is not called, and reopen the popup to prove that a prior unavailable
+  result does not block a later successful capture.
+- References:
+  [docs/architecture/workbench-dock-model.md](../../architecture/workbench-dock-model.md)
+  [WorkbenchHostDockPopup.tsx](../../../packages/workbench/surface/src/host/WorkbenchHostDockPopup.tsx)
+
 ### AgentGUI crashes while unmounting a Monaco diff
 
 - Symptom:

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselImageLoad.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselImageLoad.spec.ts
@@ -46,7 +46,7 @@ describe("AgentGuiHeroCarouselImageLoad", () => {
     FakeImage.autoLoad = true;
   });
 
-  it("is the single network owner for icon, cover, and anonymous badge decoding", async () => {
+  it("loads every canvas-bound image anonymously before decoding", async () => {
     globalThis.Image = FakeImage as unknown as typeof Image;
     const load = new AgentGuiHeroCarouselImageLoad([
       {
@@ -63,7 +63,11 @@ describe("AgentGuiHeroCarouselImageLoad", () => {
     const result = await load.result;
 
     expect(FakeImage.instances).toHaveLength(3);
-    expect(FakeImage.instances[2]?.crossOrigin).toBe("anonymous");
+    expect(FakeImage.instances.map((image) => image.crossOrigin)).toEqual([
+      "anonymous",
+      "anonymous",
+      "anonymous"
+    ]);
     expect(FakeImage.instances[1]?.src).toBe("app://codex-hero.jpg");
     expect(result.icons[0]).toBe(FakeImage.instances[0]);
     expect(result.covers[0]).toBe(FakeImage.instances[1]);

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselImageLoad.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselImageLoad.ts
@@ -35,14 +35,13 @@ export class AgentGuiHeroCarouselImageLoad {
     this.result = Promise.all(
       items.map(async (item) => {
         const [icon, cover, badge] = await Promise.all([
-          this.loadImage(item.iconUrl, false),
+          this.loadImage(item.iconUrl),
           this.loadImage(
             item.heroImageUrl?.trim() ||
               AGENT_VINYL_COVER_BY_PROVIDER[item.provider] ||
-              null,
-            false
+              null
           ),
-          this.loadImage(item.badge?.iconUrl ?? null, true)
+          this.loadImage(item.badge?.iconUrl ?? null)
         ]);
         return { badge, cover, icon };
       })
@@ -64,17 +63,12 @@ export class AgentGuiHeroCarouselImageLoad {
     this.pendingLoads.clear();
   }
 
-  private loadImage(
-    url: string | null,
-    anonymous: boolean
-  ): Promise<HTMLImageElement | null> {
+  private loadImage(url: string | null): Promise<HTMLImageElement | null> {
     if (!url || this.canceled || typeof Image !== "function") {
       return Promise.resolve(null);
     }
     const image = new Image();
-    if (anonymous) {
-      image.crossOrigin = "anonymous";
-    }
+    image.crossOrigin = "anonymous";
     image.decoding = "async";
     image.loading = "eager";
     image.setAttribute("fetchpriority", "high");

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.render.test.tsx
@@ -1,8 +1,9 @@
-import { act, useRef } from "react";
+import { act, StrictMode, useRef } from "react";
 import { createRoot } from "react-dom/client";
 import { describe, expect, it, vi } from "vitest";
 import type { WorkbenchNode, WorkbenchState } from "../core/types.ts";
 import type { WorkbenchDockContext } from "../react/types.ts";
+import * as genieAnimation from "../react/useWorkbenchGenieAnimation.tsx";
 import type { WorkbenchController } from "../store/types.ts";
 import { WorkbenchHostDock } from "./WorkbenchHostDock.tsx";
 import { WorkbenchHostDockPopup } from "./WorkbenchHostDockPopup.tsx";
@@ -306,6 +307,215 @@ describe("WorkbenchHostDock", () => {
     }
   });
 
+  it("reuses a persisted preview without capturing background DOM", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        disconnect() {}
+        observe() {}
+        unobserve() {}
+      }
+    );
+    const node = {
+      ...createNode(),
+      id: "agent-gui:background-preview"
+    };
+    const unavailableNode = {
+      ...createNode(),
+      id: "agent-gui:unavailable-preview"
+    };
+    const { host } = createDockProps([node, unavailableNode]);
+    const capturePreview = vi.fn(async () => null);
+    const previewImageUrl = "data:image/png;base64,Q0FDSEU=";
+    const captureDomPreview = vi
+      .spyOn(genieAnimation, "captureWorkbenchNodePreviewImage")
+      .mockResolvedValue("data:image/png;base64,RE9N");
+    const readPersistedPreview = vi.fn(async (key: { nodeId: string }) =>
+      key.nodeId === node.id ? previewImageUrl : null
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchHostDockPopup
+            anchorRect={{ height: 40, left: 20, top: 100, width: 40 }}
+            capturePreview={capturePreview}
+            closeWindowLabel={() => "Close"}
+            dockPreviewCache={{
+              read: readPersistedPreview,
+              write: vi.fn()
+            }}
+            items={[
+              {
+                host,
+                isFocused: false,
+                isMinimized: false,
+                node,
+                preview: null,
+                previewRevision: "revision-1",
+                subtitle: null,
+                title: "Agent"
+              },
+              {
+                host,
+                isFocused: false,
+                isMinimized: false,
+                node: unavailableNode,
+                preview: null,
+                previewRevision: "revision-1",
+                subtitle: null,
+                title: "Background Agent"
+              }
+            ]}
+            label="Agent"
+            newWindowLabel="New"
+            onClose={() => undefined}
+            onCloseNode={() => undefined}
+            onCreateNew={() => undefined}
+            onSelectNode={() => undefined}
+            resolveDockPreviewCacheKey={(candidate) => ({
+              instanceId: candidate.data.instanceId,
+              instanceKey: candidate.data.instanceKey,
+              nodeId: candidate.id,
+              typeId: candidate.data.typeId,
+              workspaceId: "workspace-1"
+            })}
+          />
+        );
+      });
+
+      await vi.waitFor(() => {
+        expect(capturePreview).toHaveBeenCalledTimes(2);
+        expect(readPersistedPreview).toHaveBeenCalledTimes(2);
+        expect(captureDomPreview).not.toHaveBeenCalled();
+        expect(
+          document.body.querySelector<HTMLImageElement>(
+            `[data-preview-kind="image"] img`
+          )?.src
+        ).toBe(previewImageUrl);
+        expect(
+          document.body.querySelector<HTMLElement>(
+            `[data-preview-state="fallback"]`
+          )?.textContent
+        ).toBe("");
+        expect(
+          document.body.querySelector(`[data-preview-state="loading"]`)
+        ).toBeNull();
+      });
+    } finally {
+      captureDomPreview.mockRestore();
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("retries a previously unavailable preview when the popup reopens", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        disconnect() {}
+        observe() {}
+        unobserve() {}
+      }
+    );
+    const node = {
+      ...createNode(),
+      id: "agent-gui:retry-unavailable-preview"
+    };
+    const { host } = createDockProps([node]);
+    const previewImageUrl = "data:image/png;base64,UkVUUlk=";
+    const capturePreview = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(previewImageUrl);
+    const container = document.createElement("div");
+    document.body.append(container);
+    let root = createRoot(container);
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    const popup = (
+      <WorkbenchHostDockPopup
+        anchorRect={{ height: 40, left: 20, top: 100, width: 40 }}
+        capturePreview={capturePreview}
+        closeWindowLabel={() => "Close"}
+        items={[
+          {
+            host,
+            isFocused: false,
+            isMinimized: false,
+            node,
+            preview: null,
+            previewRevision: "revision-1",
+            subtitle: null,
+            title: "Agent"
+          }
+        ]}
+        label="Agent"
+        newWindowLabel="New"
+        onClose={() => undefined}
+        onCloseNode={() => undefined}
+        onCreateNew={() => undefined}
+        onSelectNode={() => undefined}
+      />
+    );
+
+    try {
+      await act(async () => {
+        root.render(popup);
+      });
+      await vi.waitFor(() => {
+        expect(
+          document.body.querySelector(`[data-preview-state="fallback"]`)
+        ).not.toBeNull();
+      });
+
+      await act(async () => {
+        root.unmount();
+      });
+      root = createRoot(container);
+      await act(async () => {
+        root.render(popup);
+      });
+
+      await vi.waitFor(() => {
+        expect(capturePreview).toHaveBeenCalledTimes(2);
+        expect(
+          document.body.querySelector<HTMLImageElement>(
+            `[data-preview-kind="image"] img`
+          )?.src
+        ).toBe(previewImageUrl);
+      });
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("does not restart an in-flight popup capture after a semantic no-op render", async () => {
     vi.stubGlobal(
       "ResizeObserver",
@@ -456,6 +666,127 @@ describe("WorkbenchHostDock", () => {
       pendingCapture.resolve("data:image/png;base64,AA==");
     } finally {
       pendingCapture.resolve("data:image/png;base64,AA==");
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("commits an issued preview after StrictMode replays the capture effect", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        disconnect() {}
+        observe() {}
+        unobserve() {}
+      }
+    );
+    const node = {
+      ...createNode(),
+      id: "agent-gui:strict-preview-effect"
+    };
+    const replayNode = {
+      ...createNode(),
+      id: "agent-gui:strict-preview-replay"
+    };
+    const { host } = createDockProps([node, replayNode]);
+    const pendingCapture = deferred<string>();
+    const replayPreviewImageUrl = "data:image/png;base64,UkVQTEFZ";
+    const capturePreview = vi.fn((item: { node: WorkbenchNode }) =>
+      item.node.id === node.id
+        ? pendingCapture.promise
+        : Promise.resolve(replayPreviewImageUrl)
+    );
+    const previewEvents: string[] = [];
+    const previewImageUrl = "data:image/png;base64,U1RSSUNU";
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(
+          <StrictMode>
+            <WorkbenchHostDockPopup
+              anchorRect={{ height: 40, left: 20, top: 100, width: 40 }}
+              capturePreview={capturePreview}
+              closeWindowLabel={() => "Close"}
+              debugDiagnostics={{
+                isEnabled: () => true,
+                log: ({ event }) => {
+                  previewEvents.push(event);
+                }
+              }}
+              items={[
+                {
+                  host,
+                  isFocused: true,
+                  isMinimized: false,
+                  node,
+                  preview: null,
+                  previewRevision: "revision-1",
+                  subtitle: null,
+                  title: "Agent"
+                },
+                {
+                  host,
+                  isFocused: false,
+                  isMinimized: false,
+                  node: replayNode,
+                  preview: null,
+                  previewRevision: "revision-1",
+                  subtitle: null,
+                  title: "Background Agent"
+                }
+              ]}
+              label="Agent"
+              newWindowLabel="New"
+              onClose={() => undefined}
+              onCloseNode={() => undefined}
+              onCreateNew={() => undefined}
+              onSelectNode={() => undefined}
+            />
+          </StrictMode>
+        );
+      });
+      await vi.waitFor(() => {
+        expect(capturePreview.mock.calls.map(([item]) => item.node.id)).toEqual(
+          [node.id, replayNode.id]
+        );
+      });
+
+      await act(async () => {
+        pendingCapture.resolve(previewImageUrl);
+        await Promise.resolve();
+      });
+
+      await vi.waitFor(() => {
+        expect(previewEvents).toContain("dock.popup.preview_capture.resolved");
+        expect(
+          Array.from(
+            document.body.querySelectorAll<HTMLImageElement>(
+              `[data-preview-kind="image"] img`
+            ),
+            (image) => image.src
+          )
+        ).toEqual([previewImageUrl, replayPreviewImageUrl]);
+        expect(capturePreview.mock.calls.map(([item]) => item.node.id)).toEqual(
+          [node.id, replayNode.id]
+        );
+      });
+    } finally {
+      pendingCapture.resolve(previewImageUrl);
       await act(async () => {
         root.unmount();
       });

--- a/packages/workbench/surface/src/host/WorkbenchHostDockPopup.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDockPopup.tsx
@@ -1,32 +1,14 @@
 import {
-  forwardRef,
   useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
   useState,
-  type CSSProperties,
-  type KeyboardEvent as ReactKeyboardEvent,
-  type ReactNode
+  type CSSProperties
 } from "react";
 import { createPortal } from "react-dom";
-import {
-  Button,
-  CheckIcon,
-  CloseIcon,
-  FileCreateIcon,
-  MaximizeIcon,
-  MinimizeIcon,
-  OverviewLayoutIcon,
-  PinFilledIcon,
-  PinIcon,
-  cn
-} from "@tutti-os/ui-system";
+import { FileCreateIcon, cn } from "@tutti-os/ui-system";
 import type { WorkbenchNode } from "../core/types.ts";
-import {
-  captureWorkbenchNodePreviewImage,
-  writeCachedWorkbenchNodePreviewImage
-} from "../react/useWorkbenchGenieAnimation.tsx";
 import type {
   WorkbenchDockPreviewContent,
   WorkbenchHostDockPopupCardLabelMode,
@@ -48,9 +30,18 @@ import {
 import { resolveDockPopupVerticalClampOffsetPx } from "./dockPopupViewportClamp.ts";
 import type {
   WorkbenchDockPreviewCache,
-  WorkbenchDockPreviewCacheKey,
   WorkbenchDockPreviewCacheKeyResolver
 } from "../react/dockPreviewCache.ts";
+import {
+  resolvePopupCardMagnificationStyle,
+  resolvePopupFanCardStyle,
+  WorkbenchHostDockContextMenu,
+  WorkbenchHostDockPopupCard
+} from "./WorkbenchHostDockPopupPresentation.tsx";
+import {
+  logWorkbenchDockPopupDebug,
+  useWorkbenchHostDockPopupPreviewCapture
+} from "./useWorkbenchHostDockPopupPreviewCapture.ts";
 
 const dockPopupCardWidthPx = 165;
 const dockPopupCardHeightPx = 103;
@@ -63,28 +54,7 @@ const dockPopupGridGapPx = 8;
 const dockPopupPanelPaddingInlinePx = 12;
 const dockPopupPanelBorderInlinePx = 2;
 const dockPopupPlacementGapPx = 14;
-const dockPopupMinimizedStackLaunchDisappearMs = 0;
 const dockPopupMinimizedStackPopupZIndex = 100300;
-const dockPopupPreviewCacheMaxEntries = 64;
-const dockPopupPreviewByMemoryKey = new Map<
-  string,
-  WorkbenchHostDockPopupCapturedPreview
->();
-const pendingDockPopupPreviewCaptureKeys = new Set<string>();
-
-type WorkbenchHostDockPopupCapturedPreview = {
-  preview: WorkbenchDockPreviewContent | null;
-  revision: string | null;
-};
-
-type WorkbenchHostDockPopupPreviewState =
-  | {
-      preview: WorkbenchDockPreviewContent;
-      status: "ready";
-    }
-  | {
-      status: "loading" | "fallback";
-    };
 
 export interface WorkbenchHostDockPopupAnchorRect {
   dockRight?: number;
@@ -125,94 +95,11 @@ export interface WorkbenchHostDockPopupRetentionAction {
   pendingLabel?: string;
 }
 
-interface WorkbenchHostDockPopupCardStyle extends CSSProperties {
-  "--desktop-dock-popup-card-lift"?: string;
-  "--desktop-dock-popup-card-scale"?: string;
-  "--desktop-dock-popup-card-z-index"?: string;
-  "--desktop-dock-popup-fan-delay"?: string;
-  "--desktop-dock-popup-fan-rotate"?: string;
-  "--desktop-dock-popup-fan-x"?: string;
-  "--desktop-dock-popup-fan-y"?: string;
-}
-
 interface WorkbenchHostDockPopupRootStyle extends CSSProperties {
   "--desktop-dock-minimized-stack-width"?: string;
   "--desktop-dock-popup-clamp-offset"?: string;
   "--desktop-dock-popup-columns": string;
   "--desktop-dock-popup-width": string;
-}
-
-const popupCardMagnificationRange = 160;
-const popupCardMaxScale = 1.16;
-const popupCardMaxLiftPx = 10;
-
-function resolvePopupCardMagnificationStyle(
-  pointer: { x: number; y: number } | null,
-  element: HTMLElement | null
-): WorkbenchHostDockPopupCardStyle | undefined {
-  if (!pointer || !element) {
-    return undefined;
-  }
-
-  const rect = element.getBoundingClientRect();
-  const centerX = rect.left + rect.width / 2;
-  const centerY = rect.top + rect.height / 2;
-  const distance = Math.hypot(pointer.x - centerX, pointer.y - centerY);
-  const influence = Math.max(0, 1 - distance / popupCardMagnificationRange);
-  if (influence <= 0) {
-    return undefined;
-  }
-
-  const eased = influence * influence * (3 - 2 * influence);
-  const scale = 1 + (popupCardMaxScale - 1) * eased;
-  const lift = -popupCardMaxLiftPx * eased;
-  return {
-    "--desktop-dock-popup-card-lift": `${Math.round(lift * 10) / 10}px`,
-    "--desktop-dock-popup-card-scale": `${Math.round(scale * 1000) / 1000}`,
-    "--desktop-dock-popup-card-z-index": `${Math.round(1 + influence * 20)}`
-  };
-}
-
-function resolvePopupFanCardStyle(
-  index: number,
-  count: number,
-  placement: WorkbenchDockPlacement
-): WorkbenchHostDockPopupCardStyle {
-  const safeCount = Math.max(1, count);
-  const cappedIndex = Math.min(index, safeCount - 1);
-  const arcDirection = placement === "left" ? -1 : 1;
-  const arcX = cappedIndex * 6 * arcDirection;
-  const arcY = -18 - cappedIndex * 78;
-  const rotateDeg = (-2 + cappedIndex * 0.8) * arcDirection;
-
-  return {
-    "--desktop-dock-popup-fan-delay": `${index * 22}ms`,
-    "--desktop-dock-popup-fan-rotate": `${Math.round(rotateDeg * 10) / 10}deg`,
-    "--desktop-dock-popup-fan-x": `${Math.round(arcX)}px`,
-    "--desktop-dock-popup-fan-y": `${Math.round(arcY)}px`
-  };
-}
-
-function readDockPopupPreviewImage(
-  memoryKey: string
-): WorkbenchHostDockPopupCapturedPreview | undefined {
-  return dockPopupPreviewByMemoryKey.get(memoryKey);
-}
-
-function writeDockPopupPreviewImage(
-  memoryKey: string,
-  preview: WorkbenchDockPreviewContent | null,
-  revision: string | null
-): void {
-  dockPopupPreviewByMemoryKey.delete(memoryKey);
-  dockPopupPreviewByMemoryKey.set(memoryKey, { preview, revision });
-  while (dockPopupPreviewByMemoryKey.size > dockPopupPreviewCacheMaxEntries) {
-    const oldestMemoryKey = dockPopupPreviewByMemoryKey.keys().next().value;
-    if (typeof oldestMemoryKey !== "string") {
-      break;
-    }
-    dockPopupPreviewByMemoryKey.delete(oldestMemoryKey);
-  }
 }
 
 export function WorkbenchHostDockPopup({
@@ -292,7 +179,6 @@ export function WorkbenchHostDockPopup({
   const resolvedVariant = variant ?? "default";
   const isMinimizedStack = resolvedVariant === "minimized-stack";
   const isContextMenu = resolvedVariant === "context-menu";
-  const hasCapturePreview = Boolean(capturePreview);
   const createCardCount = showCreateNew === false ? 0 : 1;
   const cardElementsRef = useRef(new Map<string, HTMLElement>());
   const cardRefCallbacksRef = useRef(
@@ -304,19 +190,14 @@ export function WorkbenchHostDockPopup({
   const [minimizedStackScrollOffset, setMinimizedStackScrollOffset] =
     useState(0);
   const [verticalClampOffsetPx, setVerticalClampOffsetPx] = useState(0);
-  const [capturedPreviewByMemoryKey, setCapturedPreviewByMemoryKey] = useState<
-    Record<string, WorkbenchHostDockPopupCapturedPreview | undefined>
-  >({});
-  const capturedPreviewByMemoryKeyRef = useRef(capturedPreviewByMemoryKey);
-  const capturePreviewRef = useRef(capturePreview);
-  const debugDiagnosticsRef = useRef(debugDiagnostics);
-  const dockPreviewCacheRef = useRef(dockPreviewCache);
-  const resolveDockPreviewCacheKeyRef = useRef(resolveDockPreviewCacheKey);
-  capturedPreviewByMemoryKeyRef.current = capturedPreviewByMemoryKey;
-  capturePreviewRef.current = capturePreview;
-  debugDiagnosticsRef.current = debugDiagnostics;
-  dockPreviewCacheRef.current = dockPreviewCache;
-  resolveDockPreviewCacheKeyRef.current = resolveDockPreviewCacheKey;
+  const { previewStateFor } = useWorkbenchHostDockPopupPreviewCapture({
+    capturePreview,
+    debugDiagnostics,
+    dockPreviewCache,
+    isContextMenu,
+    items,
+    resolveDockPreviewCacheKey
+  });
   const columnCount = isContextMenu
     ? 1
     : Math.min(Math.max(items.length + createCardCount, 1), 3);
@@ -565,21 +446,6 @@ export function WorkbenchHostDockPopup({
     };
   }, [onClose]);
 
-  const previewCaptureKey = items
-    .map((item) => {
-      const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
-        item.node,
-        resolveDockPreviewCacheKey?.(item.node) ?? null
-      );
-      return [
-        previewMemoryKey,
-        item.isMinimized ? "minimized" : "visible",
-        previewCacheToken(item.preview),
-        item.previewRevision ?? ""
-      ].join(":");
-    })
-    .join("|");
-
   useEffect(() => {
     if (!isMinimizedStack) {
       return;
@@ -608,269 +474,6 @@ export function WorkbenchHostDockPopup({
     viewport.addEventListener("wheel", handleWheel, { passive: false });
     return () => viewport.removeEventListener("wheel", handleWheel);
   }, [isMinimizedStack, minimizedStackMaxScrollOffset]);
-
-  useEffect(() => {
-    if (!capturePreviewRef.current || isContextMenu) {
-      return;
-    }
-    let cancelled = false;
-    const startedCaptureKeys = new Set<string>();
-    const missingItems = items.filter((item) => {
-      const revision = item.previewRevision;
-      const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
-        item.node,
-        resolveDockPreviewCacheKeyRef.current?.(item.node) ?? null
-      );
-      const pendingCaptureKey = resolveDockPopupPreviewCaptureKey(
-        previewMemoryKey,
-        revision
-      );
-      const capturedPreview =
-        capturedPreviewByMemoryKeyRef.current[previewMemoryKey] ??
-        readDockPopupPreviewImage(previewMemoryKey);
-      const hasCapturedPreview =
-        capturedPreview !== undefined && capturedPreview.revision === revision;
-      const shouldCaptureMissingPreview = !item.preview && !hasCapturedPreview;
-      return (
-        shouldCaptureMissingPreview &&
-        !pendingDockPopupPreviewCaptureKeys.has(pendingCaptureKey)
-      );
-    });
-    if (missingItems.length === 0) {
-      logWorkbenchDockPopupDebug(
-        "dock.popup.preview_capture.batch",
-        debugDiagnostics,
-        {
-          itemCount: items.length,
-          missingNodeIds: []
-        }
-      );
-      return () => {
-        cancelled = true;
-      };
-    }
-    logWorkbenchDockPopupDebug(
-      "dock.popup.preview_capture.batch",
-      debugDiagnostics,
-      {
-        itemCount: items.length,
-        missingNodeIds: missingItems.map((item) => item.node.id)
-      }
-    );
-
-    for (const item of missingItems) {
-      const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
-        item.node,
-        resolveDockPreviewCacheKeyRef.current?.(item.node) ?? null
-      );
-      pendingDockPopupPreviewCaptureKeys.add(
-        resolveDockPopupPreviewCaptureKey(
-          previewMemoryKey,
-          item.previewRevision
-        )
-      );
-    }
-
-    void (async () => {
-      for (const item of missingItems) {
-        if (cancelled) {
-          break;
-        }
-
-        const revision = item.previewRevision;
-        const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
-          item.node,
-          resolveDockPreviewCacheKeyRef.current?.(item.node) ?? null
-        );
-        const pendingCaptureKey = resolveDockPopupPreviewCaptureKey(
-          previewMemoryKey,
-          revision
-        );
-        startedCaptureKeys.add(pendingCaptureKey);
-        try {
-          logWorkbenchDockPopupDebug(
-            "dock.popup.preview_capture.started",
-            debugDiagnosticsRef.current,
-            {
-              isMinimized: item.isMinimized,
-              nodeId: item.node.id,
-              revision
-            }
-          );
-          const cacheKey = resolveDockPopupPreviewCacheKey(
-            resolveDockPreviewCacheKeyRef.current?.(item.node) ?? null,
-            revision
-          );
-          if (item.isMinimized && cacheKey) {
-            const minimizedPersistedPreview = await readPersistedDockPreview(
-              dockPreviewCacheRef.current,
-              cacheKey
-            );
-            if (cancelled) {
-              break;
-            }
-            if (minimizedPersistedPreview) {
-              const persistedPreview: WorkbenchDockPreviewContent = {
-                kind: "image",
-                src: minimizedPersistedPreview
-              };
-              writeCachedWorkbenchNodePreviewImage(
-                item.node.id,
-                minimizedPersistedPreview
-              );
-              writeDockPopupPreviewImage(
-                previewMemoryKey,
-                persistedPreview,
-                revision
-              );
-              setCapturedPreviewByMemoryKey((current) => ({
-                ...current,
-                [previewMemoryKey]: {
-                  preview: persistedPreview,
-                  revision
-                }
-              }));
-              continue;
-            }
-          }
-
-          const preview = normalizeDockPopupPreviewContentResult(
-            item.isMinimized
-              ? ((await capturePreviewRef.current?.(item)) ??
-                  (await captureWorkbenchNodePreviewImage(item.node.id, {
-                    bypassCache: false
-                  })))
-              : await Promise.resolve(
-                  capturePreviewRef.current?.(item) ?? null
-                ).catch(() => null),
-            revision
-          );
-          if (cancelled) {
-            break;
-          }
-          logWorkbenchDockPopupDebug(
-            "dock.popup.preview_capture.resolved",
-            debugDiagnosticsRef.current,
-            {
-              hasPreview: Boolean(preview),
-              nodeId: item.node.id,
-              providerRevision: preview?.revision ?? null,
-              revision
-            }
-          );
-          if (preview) {
-            if (preview.kind === "image") {
-              writeCachedWorkbenchNodePreviewImage(item.node.id, preview.src);
-            }
-            writeDockPopupPreviewImage(previewMemoryKey, preview, revision);
-            if (cacheKey && preview.kind === "image") {
-              dockPreviewCacheRef.current?.write({
-                key: cacheKey,
-                previewImageUrl: preview.src
-              });
-            }
-            setCapturedPreviewByMemoryKey((current) => ({
-              ...current,
-              [previewMemoryKey]: { preview, revision }
-            }));
-            continue;
-          }
-
-          const fallbackPersistedPreview =
-            !item.isMinimized && cacheKey
-              ? await readPersistedDockPreview(
-                  dockPreviewCacheRef.current,
-                  cacheKey
-                )
-              : null;
-          if (cancelled) {
-            break;
-          }
-          if (fallbackPersistedPreview) {
-            writeCachedWorkbenchNodePreviewImage(
-              item.node.id,
-              fallbackPersistedPreview
-            );
-          }
-          if (fallbackPersistedPreview || item.isMinimized) {
-            const fallbackPreview: WorkbenchDockPreviewContent | null =
-              fallbackPersistedPreview
-                ? { kind: "image", src: fallbackPersistedPreview }
-                : null;
-            writeDockPopupPreviewImage(
-              previewMemoryKey,
-              fallbackPreview,
-              revision
-            );
-          }
-          if (!cancelled) {
-            const fallbackPreview: WorkbenchDockPreviewContent | null =
-              fallbackPersistedPreview
-                ? { kind: "image", src: fallbackPersistedPreview }
-                : null;
-            setCapturedPreviewByMemoryKey((current) => ({
-              ...current,
-              [previewMemoryKey]: { preview: fallbackPreview, revision }
-            }));
-          }
-        } finally {
-          pendingDockPopupPreviewCaptureKeys.delete(pendingCaptureKey);
-        }
-      }
-    })().catch(() => {
-      for (const item of missingItems) {
-        const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
-          item.node,
-          resolveDockPreviewCacheKey?.(item.node) ?? null
-        );
-        writeDockPopupPreviewImage(
-          previewMemoryKey,
-          null,
-          item.previewRevision
-        );
-        pendingDockPopupPreviewCaptureKeys.delete(
-          resolveDockPopupPreviewCaptureKey(
-            previewMemoryKey,
-            item.previewRevision
-          )
-        );
-      }
-      if (!cancelled) {
-        setCapturedPreviewByMemoryKey((current) => ({
-          ...current,
-          ...Object.fromEntries(
-            missingItems.map((item) => {
-              const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
-                item.node,
-                resolveDockPreviewCacheKey?.(item.node) ?? null
-              );
-              return [
-                previewMemoryKey,
-                { preview: null, revision: item.previewRevision }
-              ];
-            })
-          )
-        }));
-      }
-    });
-
-    return () => {
-      cancelled = true;
-      for (const item of missingItems) {
-        const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
-          item.node,
-          resolveDockPreviewCacheKeyRef.current?.(item.node) ?? null
-        );
-        const pendingCaptureKey = resolveDockPopupPreviewCaptureKey(
-          previewMemoryKey,
-          item.previewRevision
-        );
-        if (!startedCaptureKeys.has(pendingCaptureKey)) {
-          pendingDockPopupPreviewCaptureKeys.delete(pendingCaptureKey);
-        }
-      }
-    };
-  }, [hasCapturePreview, isContextMenu, previewCaptureKey]);
 
   const content = (
     <div
@@ -949,19 +552,7 @@ export function WorkbenchHostDockPopup({
                   }}
                 >
                   {items.map((item, index) => {
-                    const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
-                      item.node,
-                      resolveDockPreviewCacheKey?.(item.node) ?? null
-                    );
-                    const capturedPreview =
-                      capturedPreviewByMemoryKey[previewMemoryKey] !== undefined
-                        ? capturedPreviewByMemoryKey[previewMemoryKey]
-                        : readDockPopupPreviewImage(previewMemoryKey);
-                    const previewState = resolveDockPopupItemPreviewState(
-                      item,
-                      capturedPreview,
-                      Boolean(capturePreview)
-                    );
+                    const previewState = previewStateFor(item);
                     return (
                       <WorkbenchHostDockPopupCard
                         key={item.node.id}
@@ -992,19 +583,7 @@ export function WorkbenchHostDockPopup({
             ) : (
               <div className="grid max-h-[min(52vh,420px)] grid-cols-[repeat(var(--desktop-dock-popup-columns,2),165px)] gap-2 overflow-auto overscroll-contain">
                 {items.map((item) => {
-                  const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
-                    item.node,
-                    resolveDockPreviewCacheKey?.(item.node) ?? null
-                  );
-                  const capturedPreview =
-                    capturedPreviewByMemoryKey[previewMemoryKey] !== undefined
-                      ? capturedPreviewByMemoryKey[previewMemoryKey]
-                      : readDockPopupPreviewImage(previewMemoryKey);
-                  const previewState = resolveDockPopupItemPreviewState(
-                    item,
-                    capturedPreview,
-                    Boolean(capturePreview)
-                  );
+                  const previewState = previewStateFor(item);
                   return (
                     <WorkbenchHostDockPopupCard
                       key={item.node.id}
@@ -1049,318 +628,6 @@ export function WorkbenchHostDockPopup({
   return createPortal(content, document.body);
 }
 
-function WorkbenchHostDockContextMenu({
-  canCreateNew,
-  canEnterFullscreen,
-  canShowAllWindows,
-  dockRetention,
-  fullscreenLabel,
-  hideLabel,
-  items,
-  newWindowLabel,
-  onCreateNew,
-  onEnterFullscreen,
-  onHide,
-  onQuit,
-  onRunDockRetentionAction,
-  onSelectNode,
-  onShowAllWindows,
-  quitLabel,
-  showAllWindowsLabel,
-  showOpen
-}: {
-  canCreateNew: boolean;
-  canEnterFullscreen: boolean;
-  canShowAllWindows: boolean;
-  dockRetention?: WorkbenchHostDockPopupRetentionAction | null;
-  fullscreenLabel?: string;
-  hideLabel?: string;
-  items: WorkbenchHostDockPopupItem[];
-  newWindowLabel: string;
-  onCreateNew: () => void;
-  onEnterFullscreen?: () => void;
-  onHide?: () => void;
-  onQuit?: () => void;
-  onRunDockRetentionAction?: () => void;
-  onSelectNode: (nodeId: string) => void;
-  onShowAllWindows?: () => void;
-  quitLabel?: string;
-  showAllWindowsLabel?: string;
-  showOpen: boolean;
-}) {
-  const hasOpenWindows = items.length > 0;
-  const hasNewWindowCommand = hasOpenWindows && canCreateNew;
-  const hasOpenCommand = !hasOpenWindows;
-  const hasDockActionGroup =
-    Boolean(dockRetention) || hasNewWindowCommand || hasOpenCommand;
-  const hasWindowActionGroup = hasOpenWindows;
-
-  return (
-    <div
-      className="flex min-w-0 flex-col gap-1"
-      data-desktop-dock-context-menu="true"
-      role="menu"
-    >
-      {hasOpenWindows ? (
-        <>
-          <div className="max-h-48 min-w-0 overflow-auto overscroll-contain">
-            {items.map((item) => (
-              <WorkbenchHostDockContextMenuItem
-                key={item.node.id}
-                checked={!item.isMinimized}
-                label={item.title?.trim() || item.node.title}
-                onSelect={() => onSelectNode(item.node.id)}
-              />
-            ))}
-          </div>
-        </>
-      ) : null}
-      {hasOpenWindows && (hasDockActionGroup || hasWindowActionGroup) ? (
-        <WorkbenchHostDockContextMenuSeparator />
-      ) : null}
-      {dockRetention ? (
-        <WorkbenchHostDockContextMenuItem
-          checked={dockRetention.checked}
-          checkedIcon={
-            <PinFilledIcon
-              aria-hidden="true"
-              className="size-4 text-[var(--tutti-purple)]"
-            />
-          }
-          disabled={dockRetention.disabled}
-          icon={<PinIcon aria-hidden="true" className="size-4" />}
-          label={dockRetention.pendingLabel ?? dockRetention.label}
-          onSelect={onRunDockRetentionAction}
-        />
-      ) : null}
-      {hasNewWindowCommand ? (
-        <WorkbenchHostDockContextMenuItem
-          icon={<FileCreateIcon aria-hidden="true" className="size-4" />}
-          label={newWindowLabel}
-          onSelect={onCreateNew}
-        />
-      ) : null}
-      {hasOpenCommand ? (
-        <WorkbenchHostDockContextMenuItem
-          disabled={!showOpen}
-          icon={<FileCreateIcon aria-hidden="true" className="size-4" />}
-          label={newWindowLabel}
-          onSelect={onCreateNew}
-        />
-      ) : null}
-      {hasOpenWindows ? (
-        <>
-          {hasDockActionGroup ? (
-            <WorkbenchHostDockContextMenuSeparator />
-          ) : null}
-          {canShowAllWindows && onShowAllWindows ? (
-            <WorkbenchHostDockContextMenuItem
-              icon={
-                <OverviewLayoutIcon aria-hidden="true" className="size-4" />
-              }
-              label={showAllWindowsLabel}
-              onSelect={onShowAllWindows}
-            />
-          ) : null}
-          <WorkbenchHostDockContextMenuItem
-            disabled={!canEnterFullscreen || !onEnterFullscreen}
-            icon={<MaximizeIcon aria-hidden="true" className="size-4" />}
-            label={fullscreenLabel}
-            onSelect={onEnterFullscreen}
-          />
-          <WorkbenchHostDockContextMenuItem
-            disabled={!onHide}
-            icon={<MinimizeIcon aria-hidden="true" className="size-4" />}
-            label={hideLabel}
-            onSelect={onHide}
-          />
-          <WorkbenchHostDockContextMenuItem
-            disabled={!onQuit}
-            icon={<CloseIcon aria-hidden="true" className="size-4" />}
-            label={quitLabel}
-            onSelect={onQuit}
-          />
-        </>
-      ) : null}
-    </div>
-  );
-}
-
-function WorkbenchHostDockContextMenuItem({
-  checked,
-  checkedIcon,
-  disabled,
-  icon,
-  label,
-  onSelect
-}: {
-  checked?: boolean;
-  checkedIcon?: ReactNode;
-  disabled?: boolean;
-  icon?: ReactNode;
-  label?: string;
-  onSelect?: () => void;
-}) {
-  return (
-    <button
-      className={cn(
-        "flex h-8 w-full min-w-0 items-center gap-2 rounded-md px-2 text-left text-sm text-[var(--text-primary)] transition-colors",
-        disabled
-          ? "cursor-default opacity-45"
-          : "hover:bg-transparency-hover focus-visible:bg-transparency-hover focus-visible:outline-none"
-      )}
-      disabled={disabled}
-      role="menuitem"
-      type="button"
-      onClick={() => {
-        if (disabled || !onSelect) {
-          return;
-        }
-        onSelect();
-      }}
-    >
-      <span className="flex size-4 shrink-0 items-center justify-center text-[var(--text-secondary)]">
-        {checked && checkedIcon ? (
-          checkedIcon
-        ) : checked ? (
-          <CheckIcon
-            aria-hidden="true"
-            className="size-4 text-[var(--tutti-purple)]"
-          />
-        ) : (
-          (icon ?? null)
-        )}
-      </span>
-      <span className="min-w-0 truncate">{label}</span>
-    </button>
-  );
-}
-
-function WorkbenchHostDockContextMenuSeparator() {
-  return (
-    <div
-      aria-hidden="true"
-      className="mx-2 my-1 h-px bg-[var(--border-1)]"
-      role="separator"
-    />
-  );
-}
-
-function readPersistedDockPreview(
-  dockPreviewCache: WorkbenchDockPreviewCache | undefined,
-  cacheKey: WorkbenchDockPreviewCacheKey | null
-): Promise<string | null> {
-  if (!cacheKey) {
-    return Promise.resolve(null);
-  }
-  return (
-    dockPreviewCache?.read(cacheKey).catch(() => null) ?? Promise.resolve(null)
-  );
-}
-
-function resolveDockPopupPreviewCacheKey(
-  cacheKey: WorkbenchDockPreviewCacheKey | null,
-  revision: string | null
-): WorkbenchDockPreviewCacheKey | null {
-  return cacheKey ? { ...cacheKey, revision } : null;
-}
-
-function resolveDockPopupPreviewMemoryKey(
-  node: WorkbenchNode<WorkbenchHostNodeData>,
-  cacheKey: WorkbenchDockPreviewCacheKey | null
-): string {
-  if (!cacheKey) {
-    return `node:${node.id}`;
-  }
-  return `cache:${JSON.stringify({
-    instanceId: cacheKey.instanceId,
-    instanceKey: cacheKey.instanceKey ?? null,
-    nodeId: cacheKey.nodeId,
-    typeId: cacheKey.typeId,
-    workspaceId: cacheKey.workspaceId
-  })}`;
-}
-
-function resolveDockPopupPreviewCaptureKey(
-  memoryKey: string,
-  revision: string | null
-): string {
-  return `${memoryKey}\u0000${revision ?? ""}`;
-}
-
-function normalizeDockPopupPreviewContentResult(
-  preview: WorkbenchDockPreviewContent | string | null | undefined,
-  revision: string | null
-): WorkbenchDockPreviewContent | null {
-  if (!preview) {
-    return null;
-  }
-  if (typeof preview === "string") {
-    return { kind: "image", revision: revision ?? undefined, src: preview };
-  }
-  return {
-    ...preview,
-    revision: preview.revision ?? revision ?? undefined
-  };
-}
-
-function resolveDockPopupItemPreviewState(
-  item: WorkbenchHostDockPopupItem,
-  capturedPreview: WorkbenchHostDockPopupCapturedPreview | undefined,
-  hasPreviewProvider: boolean
-): WorkbenchHostDockPopupPreviewState {
-  const revision = item.previewRevision;
-  if (item.preview) {
-    return { preview: item.preview, status: "ready" };
-  }
-  if (
-    capturedPreview &&
-    capturedPreview.revision === revision &&
-    capturedPreview.preview
-  ) {
-    return { preview: capturedPreview.preview, status: "ready" };
-  }
-  if (
-    (capturedPreview !== undefined && capturedPreview.revision === revision) ||
-    !hasPreviewProvider
-  ) {
-    return { status: "fallback" };
-  }
-  return { status: "loading" };
-}
-
-function previewCacheToken(
-  preview: WorkbenchDockPreviewContent | null | undefined
-): string {
-  if (!preview) {
-    return "";
-  }
-  switch (preview.kind) {
-    case "component":
-      return `component:${preview.revision ?? ""}`;
-    case "image":
-      return `image:${preview.revision ?? ""}:${preview.src}`;
-  }
-}
-
-function logWorkbenchDockPopupDebug(
-  event: string,
-  debugDiagnostics: WorkbenchHostProps["debugDiagnostics"],
-  details: Record<string, unknown>
-): void {
-  if (!debugDiagnostics?.log) {
-    return;
-  }
-  void Promise.resolve(
-    debugDiagnostics.log({
-      details,
-      event,
-      level: "info",
-      source: "workbench-dock"
-    })
-  ).catch(() => undefined);
-}
-
 function rectToDiagnostic(element: HTMLElement): Record<string, number> {
   const rect = element.getBoundingClientRect();
   return {
@@ -1384,202 +651,4 @@ function styleToDiagnostic(element: HTMLElement): Record<string, string> {
     visibility: style.visibility,
     zIndex: style.zIndex
   };
-}
-
-interface WorkbenchHostDockPopupCardProps {
-  closeWindowLabel: (title: string) => string;
-  item: WorkbenchHostDockPopupItem;
-  labelMode?: WorkbenchHostDockPopupCardLabelMode;
-  onCloseNode: (nodeId: string) => void;
-  onSelectNode: (nodeId: string) => void;
-  previewState: WorkbenchHostDockPopupPreviewState;
-  style?: CSSProperties;
-  variant?: WorkbenchHostDockPopupVariant;
-}
-
-const WorkbenchHostDockPopupCard = forwardRef<
-  HTMLDivElement,
-  WorkbenchHostDockPopupCardProps
->(function WorkbenchHostDockPopupCard(
-  {
-    closeWindowLabel,
-    item,
-    labelMode,
-    onCloseNode,
-    onSelectNode,
-    previewState,
-    style,
-    variant
-  },
-  ref
-) {
-  const title = item.title?.trim() || item.node.title;
-  const isMinimizedStack = variant === "minimized-stack";
-  const [isLaunching, setIsLaunching] = useState(false);
-  const launchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(
-    () => () => {
-      if (launchTimerRef.current !== null) {
-        clearTimeout(launchTimerRef.current);
-      }
-    },
-    []
-  );
-
-  const handleSelect = useCallback(() => {
-    if (!isMinimizedStack) {
-      onSelectNode(item.node.id);
-      return;
-    }
-    if (launchTimerRef.current !== null) {
-      return;
-    }
-    setIsLaunching(true);
-    launchTimerRef.current = setTimeout(() => {
-      launchTimerRef.current = null;
-      onSelectNode(item.node.id);
-    }, dockPopupMinimizedStackLaunchDisappearMs);
-  }, [isMinimizedStack, item.node.id, onSelectNode]);
-  const handleSelectKeyDown = useCallback(
-    (event: ReactKeyboardEvent<HTMLDivElement>) => {
-      if (event.key !== "Enter" && event.key !== " ") {
-        return;
-      }
-      event.preventDefault();
-      handleSelect();
-    },
-    [handleSelect]
-  );
-  const hasReadyPreview = previewState.status === "ready";
-
-  return (
-    <div
-      ref={ref}
-      className={cn(
-        "group/dock-popup-card relative flex h-[103px] w-[165px] min-w-0 flex-col overflow-hidden rounded-[8px] border border-[var(--border-1)] bg-background-fronted text-left text-[var(--text-primary)] transition-[border-color,color] duration-150",
-        item.isMinimized && "text-[var(--text-secondary)]"
-      )}
-      data-active={item.isFocused ? "true" : undefined}
-      data-desktop-dock-popup-card="true"
-      data-fan-card={isMinimizedStack ? "true" : undefined}
-      data-launching={isLaunching ? "true" : undefined}
-      data-minimized={item.isMinimized ? "true" : undefined}
-      style={style}
-    >
-      <div
-        aria-label={title}
-        data-active={item.isFocused ? "true" : undefined}
-        className={cn(
-          "relative flex min-h-0 min-w-0 flex-1 cursor-pointer flex-col overflow-hidden rounded-md bg-transparent text-inherit",
-          hasReadyPreview ? "p-0" : "p-1"
-        )}
-        role="button"
-        tabIndex={0}
-        onClick={handleSelect}
-        onKeyDown={handleSelectKeyDown}
-      >
-        <WorkbenchHostDockPopupCardPreview previewState={previewState} />
-        {labelMode === "hover-overlay" && item.title?.trim() ? (
-          <WorkbenchHostDockPopupCardLabel title={item.title} />
-        ) : null}
-      </div>
-      <Button
-        aria-label={closeWindowLabel(title)}
-        className="absolute top-1.5 right-1.5 z-[2] rounded-full bg-[var(--background-fronted)] opacity-0 transition-[background-color,opacity] duration-150 hover:bg-[var(--background-fronted)] focus-visible:bg-[var(--background-fronted)] group-hover/dock-popup-card:opacity-100 group-focus-within/dock-popup-card:opacity-100 focus-visible:opacity-100"
-        size="icon-sm"
-        title={closeWindowLabel(title)}
-        type="button"
-        variant="ghost"
-        onClick={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          onCloseNode(item.node.id);
-        }}
-      >
-        <CloseIcon className="size-3.5" />
-      </Button>
-      {item.isFocused ? (
-        <span
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-0 z-[3] rounded-md shadow-[inset_0_0_0_2px_var(--border-focus)]"
-          data-desktop-dock-popup-card-active-overlay="true"
-        />
-      ) : null}
-      {isMinimizedStack ? (
-        <span className="desktop-dock-popup__fan-title-tip" title={title}>
-          {title}
-        </span>
-      ) : null}
-    </div>
-  );
-});
-
-function WorkbenchHostDockPopupCardPreview({
-  previewState
-}: {
-  previewState: WorkbenchHostDockPopupPreviewState;
-}) {
-  if (previewState.status !== "ready") {
-    return (
-      <span
-        className="flex min-h-0 min-w-0 flex-1 flex-col justify-center gap-[7px] rounded-md border border-[var(--border-1)] bg-transparency-block px-3 py-[11px]"
-        aria-hidden="true"
-        data-preview-state={previewState.status}
-      >
-        <span className="block h-[7px] w-[72%] rounded-full bg-transparency-hover" />
-        <span className="block h-[7px] w-[58%] rounded-full bg-transparency-hover" />
-        <span className="block h-[7px] w-[34%] rounded-full bg-transparency-hover" />
-      </span>
-    );
-  }
-
-  const preview = previewState.preview;
-  if (preview.kind === "component") {
-    return (
-      <span
-        className="block min-h-0 min-w-0 flex-1 overflow-hidden rounded-md"
-        aria-hidden="true"
-        data-preview-kind={preview.kind}
-        data-preview-state={previewState.status}
-      >
-        {preview.element}
-      </span>
-    );
-  }
-
-  return (
-    <span
-      className="block min-h-0 min-w-0 flex-1 overflow-hidden rounded-md"
-      aria-hidden="true"
-      data-preview-kind={preview.kind}
-      data-preview-state={previewState.status}
-    >
-      <img
-        alt=""
-        className="block h-full max-h-full w-full max-w-full object-contain object-center"
-        draggable={false}
-        src={preview.src}
-      />
-    </span>
-  );
-}
-
-function WorkbenchHostDockPopupCardLabel({ title }: { title: string }) {
-  return (
-    <span
-      className="pointer-events-none absolute inset-x-0 bottom-0 z-[1] flex h-[30px] items-end px-[10px] pb-0.5 text-[var(--white-stationary)] opacity-0 transition-opacity duration-150 [text-shadow:0_1px_2px_rgb(0_0_0_/_20%)] group-hover/dock-popup-card:opacity-100 group-focus-within/dock-popup-card:opacity-100"
-      style={{
-        background:
-          "linear-gradient(180deg, transparent 0%, color-mix(in srgb, hsl(var(--card)) 28%, transparent) 18%, color-mix(in srgb, hsl(var(--card)) 82%, transparent) 56%, color-mix(in srgb, hsl(var(--card)) 98%, transparent) 100%)"
-      }}
-      title={title}
-    >
-      <span className="desktop-dock-popup__title-viewport block min-w-0 flex-1 overflow-hidden whitespace-nowrap">
-        <span className="desktop-dock-popup__title-marquee inline-block max-w-full overflow-hidden text-[12px] font-semibold leading-5 text-ellipsis whitespace-nowrap">
-          {title}
-        </span>
-      </span>
-    </span>
-  );
 }

--- a/packages/workbench/surface/src/host/WorkbenchHostDockPopupPresentation.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDockPopupPresentation.tsx
@@ -1,0 +1,494 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode
+} from "react";
+import {
+  Button,
+  CheckIcon,
+  CloseIcon,
+  FileCreateIcon,
+  MaximizeIcon,
+  MinimizeIcon,
+  OverviewLayoutIcon,
+  PinFilledIcon,
+  PinIcon,
+  cn
+} from "@tutti-os/ui-system";
+import type { WorkbenchDockPlacement } from "../react/types.ts";
+import type {
+  WorkbenchHostDockPopupItem,
+  WorkbenchHostDockPopupRetentionAction,
+  WorkbenchHostDockPopupVariant
+} from "./WorkbenchHostDockPopup.tsx";
+import type { WorkbenchHostDockPopupCardLabelMode } from "./types.ts";
+import type { WorkbenchHostDockPopupPreviewState } from "./useWorkbenchHostDockPopupPreviewCapture.ts";
+
+const dockPopupMinimizedStackLaunchDisappearMs = 0;
+const popupCardMagnificationRange = 160;
+const popupCardMaxScale = 1.16;
+const popupCardMaxLiftPx = 10;
+
+interface WorkbenchHostDockPopupCardStyle extends CSSProperties {
+  "--desktop-dock-popup-card-lift"?: string;
+  "--desktop-dock-popup-card-scale"?: string;
+  "--desktop-dock-popup-card-z-index"?: string;
+  "--desktop-dock-popup-fan-delay"?: string;
+  "--desktop-dock-popup-fan-rotate"?: string;
+  "--desktop-dock-popup-fan-x"?: string;
+  "--desktop-dock-popup-fan-y"?: string;
+}
+
+export function resolvePopupCardMagnificationStyle(
+  pointer: { x: number; y: number } | null,
+  element: HTMLElement | null
+): WorkbenchHostDockPopupCardStyle | undefined {
+  if (!pointer || !element) {
+    return undefined;
+  }
+
+  const rect = element.getBoundingClientRect();
+  const centerX = rect.left + rect.width / 2;
+  const centerY = rect.top + rect.height / 2;
+  const distance = Math.hypot(pointer.x - centerX, pointer.y - centerY);
+  const influence = Math.max(0, 1 - distance / popupCardMagnificationRange);
+  if (influence <= 0) {
+    return undefined;
+  }
+
+  const eased = influence * influence * (3 - 2 * influence);
+  const scale = 1 + (popupCardMaxScale - 1) * eased;
+  const lift = -popupCardMaxLiftPx * eased;
+  return {
+    "--desktop-dock-popup-card-lift": `${Math.round(lift * 10) / 10}px`,
+    "--desktop-dock-popup-card-scale": `${Math.round(scale * 1000) / 1000}`,
+    "--desktop-dock-popup-card-z-index": `${Math.round(1 + influence * 20)}`
+  };
+}
+
+export function resolvePopupFanCardStyle(
+  index: number,
+  count: number,
+  placement: WorkbenchDockPlacement
+): WorkbenchHostDockPopupCardStyle {
+  const safeCount = Math.max(1, count);
+  const cappedIndex = Math.min(index, safeCount - 1);
+  const arcDirection = placement === "left" ? -1 : 1;
+  const arcX = cappedIndex * 6 * arcDirection;
+  const arcY = -18 - cappedIndex * 78;
+  const rotateDeg = (-2 + cappedIndex * 0.8) * arcDirection;
+
+  return {
+    "--desktop-dock-popup-fan-delay": `${index * 22}ms`,
+    "--desktop-dock-popup-fan-rotate": `${Math.round(rotateDeg * 10) / 10}deg`,
+    "--desktop-dock-popup-fan-x": `${Math.round(arcX)}px`,
+    "--desktop-dock-popup-fan-y": `${Math.round(arcY)}px`
+  };
+}
+
+export function WorkbenchHostDockContextMenu({
+  canCreateNew,
+  canEnterFullscreen,
+  canShowAllWindows,
+  dockRetention,
+  fullscreenLabel,
+  hideLabel,
+  items,
+  newWindowLabel,
+  onCreateNew,
+  onEnterFullscreen,
+  onHide,
+  onQuit,
+  onRunDockRetentionAction,
+  onSelectNode,
+  onShowAllWindows,
+  quitLabel,
+  showAllWindowsLabel,
+  showOpen
+}: {
+  canCreateNew: boolean;
+  canEnterFullscreen: boolean;
+  canShowAllWindows: boolean;
+  dockRetention?: WorkbenchHostDockPopupRetentionAction | null;
+  fullscreenLabel?: string;
+  hideLabel?: string;
+  items: WorkbenchHostDockPopupItem[];
+  newWindowLabel: string;
+  onCreateNew: () => void;
+  onEnterFullscreen?: () => void;
+  onHide?: () => void;
+  onQuit?: () => void;
+  onRunDockRetentionAction?: () => void;
+  onSelectNode: (nodeId: string) => void;
+  onShowAllWindows?: () => void;
+  quitLabel?: string;
+  showAllWindowsLabel?: string;
+  showOpen: boolean;
+}) {
+  const hasOpenWindows = items.length > 0;
+  const hasNewWindowCommand = hasOpenWindows && canCreateNew;
+  const hasOpenCommand = !hasOpenWindows;
+  const hasDockActionGroup =
+    Boolean(dockRetention) || hasNewWindowCommand || hasOpenCommand;
+  const hasWindowActionGroup = hasOpenWindows;
+
+  return (
+    <div
+      className="flex min-w-0 flex-col gap-1"
+      data-desktop-dock-context-menu="true"
+      role="menu"
+    >
+      {hasOpenWindows ? (
+        <div className="max-h-48 min-w-0 overflow-auto overscroll-contain">
+          {items.map((item) => (
+            <WorkbenchHostDockContextMenuItem
+              key={item.node.id}
+              checked={!item.isMinimized}
+              label={item.title?.trim() || item.node.title}
+              onSelect={() => onSelectNode(item.node.id)}
+            />
+          ))}
+        </div>
+      ) : null}
+      {hasOpenWindows && (hasDockActionGroup || hasWindowActionGroup) ? (
+        <WorkbenchHostDockContextMenuSeparator />
+      ) : null}
+      {dockRetention ? (
+        <WorkbenchHostDockContextMenuItem
+          checked={dockRetention.checked}
+          checkedIcon={
+            <PinFilledIcon
+              aria-hidden="true"
+              className="size-4 text-[var(--tutti-purple)]"
+            />
+          }
+          disabled={dockRetention.disabled}
+          icon={<PinIcon aria-hidden="true" className="size-4" />}
+          label={dockRetention.pendingLabel ?? dockRetention.label}
+          onSelect={onRunDockRetentionAction}
+        />
+      ) : null}
+      {hasNewWindowCommand ? (
+        <WorkbenchHostDockContextMenuItem
+          icon={<FileCreateIcon aria-hidden="true" className="size-4" />}
+          label={newWindowLabel}
+          onSelect={onCreateNew}
+        />
+      ) : null}
+      {hasOpenCommand ? (
+        <WorkbenchHostDockContextMenuItem
+          disabled={!showOpen}
+          icon={<FileCreateIcon aria-hidden="true" className="size-4" />}
+          label={newWindowLabel}
+          onSelect={onCreateNew}
+        />
+      ) : null}
+      {hasOpenWindows ? (
+        <>
+          {hasDockActionGroup ? (
+            <WorkbenchHostDockContextMenuSeparator />
+          ) : null}
+          {canShowAllWindows && onShowAllWindows ? (
+            <WorkbenchHostDockContextMenuItem
+              icon={
+                <OverviewLayoutIcon aria-hidden="true" className="size-4" />
+              }
+              label={showAllWindowsLabel}
+              onSelect={onShowAllWindows}
+            />
+          ) : null}
+          <WorkbenchHostDockContextMenuItem
+            disabled={!canEnterFullscreen || !onEnterFullscreen}
+            icon={<MaximizeIcon aria-hidden="true" className="size-4" />}
+            label={fullscreenLabel}
+            onSelect={onEnterFullscreen}
+          />
+          <WorkbenchHostDockContextMenuItem
+            disabled={!onHide}
+            icon={<MinimizeIcon aria-hidden="true" className="size-4" />}
+            label={hideLabel}
+            onSelect={onHide}
+          />
+          <WorkbenchHostDockContextMenuItem
+            disabled={!onQuit}
+            icon={<CloseIcon aria-hidden="true" className="size-4" />}
+            label={quitLabel}
+            onSelect={onQuit}
+          />
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function WorkbenchHostDockContextMenuItem({
+  checked,
+  checkedIcon,
+  disabled,
+  icon,
+  label,
+  onSelect
+}: {
+  checked?: boolean;
+  checkedIcon?: ReactNode;
+  disabled?: boolean;
+  icon?: ReactNode;
+  label?: string;
+  onSelect?: () => void;
+}) {
+  return (
+    <button
+      className={cn(
+        "flex h-8 w-full min-w-0 items-center gap-2 rounded-md px-2 text-left text-sm text-[var(--text-primary)] transition-colors",
+        disabled
+          ? "cursor-default opacity-45"
+          : "hover:bg-transparency-hover focus-visible:bg-transparency-hover focus-visible:outline-none"
+      )}
+      disabled={disabled}
+      role="menuitem"
+      type="button"
+      onClick={() => {
+        if (disabled || !onSelect) {
+          return;
+        }
+        onSelect();
+      }}
+    >
+      <span className="flex size-4 shrink-0 items-center justify-center text-[var(--text-secondary)]">
+        {checked && checkedIcon ? (
+          checkedIcon
+        ) : checked ? (
+          <CheckIcon
+            aria-hidden="true"
+            className="size-4 text-[var(--tutti-purple)]"
+          />
+        ) : (
+          (icon ?? null)
+        )}
+      </span>
+      <span className="min-w-0 truncate">{label}</span>
+    </button>
+  );
+}
+
+function WorkbenchHostDockContextMenuSeparator() {
+  return (
+    <div
+      aria-hidden="true"
+      className="mx-2 my-1 h-px bg-[var(--border-1)]"
+      role="separator"
+    />
+  );
+}
+
+interface WorkbenchHostDockPopupCardProps {
+  closeWindowLabel: (title: string) => string;
+  item: WorkbenchHostDockPopupItem;
+  labelMode?: WorkbenchHostDockPopupCardLabelMode;
+  onCloseNode: (nodeId: string) => void;
+  onSelectNode: (nodeId: string) => void;
+  previewState: WorkbenchHostDockPopupPreviewState;
+  style?: CSSProperties;
+  variant?: WorkbenchHostDockPopupVariant;
+}
+
+export const WorkbenchHostDockPopupCard = forwardRef<
+  HTMLDivElement,
+  WorkbenchHostDockPopupCardProps
+>(function WorkbenchHostDockPopupCard(
+  {
+    closeWindowLabel,
+    item,
+    labelMode,
+    onCloseNode,
+    onSelectNode,
+    previewState,
+    style,
+    variant
+  },
+  ref
+) {
+  const title = item.title?.trim() || item.node.title;
+  const isMinimizedStack = variant === "minimized-stack";
+  const [isLaunching, setIsLaunching] = useState(false);
+  const launchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (launchTimerRef.current !== null) {
+        clearTimeout(launchTimerRef.current);
+      }
+    },
+    []
+  );
+
+  const handleSelect = useCallback(() => {
+    if (!isMinimizedStack) {
+      onSelectNode(item.node.id);
+      return;
+    }
+    if (launchTimerRef.current !== null) {
+      return;
+    }
+    setIsLaunching(true);
+    launchTimerRef.current = setTimeout(() => {
+      launchTimerRef.current = null;
+      onSelectNode(item.node.id);
+    }, dockPopupMinimizedStackLaunchDisappearMs);
+  }, [isMinimizedStack, item.node.id, onSelectNode]);
+  const handleSelectKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (event.key !== "Enter" && event.key !== " ") {
+        return;
+      }
+      event.preventDefault();
+      handleSelect();
+    },
+    [handleSelect]
+  );
+  const hasReadyPreview = previewState.status === "ready";
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "group/dock-popup-card relative flex h-[103px] w-[165px] min-w-0 flex-col overflow-hidden rounded-[8px] border border-[var(--border-1)] bg-background-fronted text-left text-[var(--text-primary)] transition-[border-color,color] duration-150",
+        item.isMinimized && "text-[var(--text-secondary)]"
+      )}
+      data-active={item.isFocused ? "true" : undefined}
+      data-desktop-dock-popup-card="true"
+      data-fan-card={isMinimizedStack ? "true" : undefined}
+      data-launching={isLaunching ? "true" : undefined}
+      data-minimized={item.isMinimized ? "true" : undefined}
+      style={style}
+    >
+      <div
+        aria-label={title}
+        data-active={item.isFocused ? "true" : undefined}
+        className={cn(
+          "relative flex min-h-0 min-w-0 flex-1 cursor-pointer flex-col overflow-hidden rounded-md bg-transparent text-inherit",
+          hasReadyPreview ? "p-0" : "p-1"
+        )}
+        role="button"
+        tabIndex={0}
+        onClick={handleSelect}
+        onKeyDown={handleSelectKeyDown}
+      >
+        <WorkbenchHostDockPopupCardPreview previewState={previewState} />
+        {labelMode === "hover-overlay" && item.title?.trim() ? (
+          <WorkbenchHostDockPopupCardLabel title={item.title} />
+        ) : null}
+      </div>
+      <Button
+        aria-label={closeWindowLabel(title)}
+        className="absolute top-1.5 right-1.5 z-[2] rounded-full bg-[var(--background-fronted)] opacity-0 transition-[background-color,opacity] duration-150 hover:bg-[var(--background-fronted)] focus-visible:bg-[var(--background-fronted)] group-hover/dock-popup-card:opacity-100 group-focus-within/dock-popup-card:opacity-100 focus-visible:opacity-100"
+        size="icon-sm"
+        title={closeWindowLabel(title)}
+        type="button"
+        variant="ghost"
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onCloseNode(item.node.id);
+        }}
+      >
+        <CloseIcon className="size-3.5" />
+      </Button>
+      {item.isFocused ? (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 z-[3] rounded-md shadow-[inset_0_0_0_2px_var(--border-focus)]"
+          data-desktop-dock-popup-card-active-overlay="true"
+        />
+      ) : null}
+      {isMinimizedStack ? (
+        <span className="desktop-dock-popup__fan-title-tip" title={title}>
+          {title}
+        </span>
+      ) : null}
+    </div>
+  );
+});
+
+function WorkbenchHostDockPopupCardPreview({
+  previewState
+}: {
+  previewState: WorkbenchHostDockPopupPreviewState;
+}) {
+  if (previewState.status === "loading") {
+    return (
+      <span
+        className="flex min-h-0 min-w-0 flex-1 flex-col justify-center gap-[7px] rounded-md border border-[var(--border-1)] bg-transparency-block px-3 py-[11px]"
+        aria-hidden="true"
+        data-preview-state={previewState.status}
+      >
+        <span className="block h-[7px] w-[72%] rounded-full bg-transparency-hover" />
+        <span className="block h-[7px] w-[58%] rounded-full bg-transparency-hover" />
+        <span className="block h-[7px] w-[34%] rounded-full bg-transparency-hover" />
+      </span>
+    );
+  }
+  if (previewState.status === "fallback") {
+    return (
+      <span
+        className="flex min-h-0 min-w-0 flex-1 rounded-md border border-[var(--border-1)] bg-transparency-block"
+        aria-hidden="true"
+        data-preview-state={previewState.status}
+      />
+    );
+  }
+
+  const preview = previewState.preview;
+  if (preview.kind === "component") {
+    return (
+      <span
+        className="block min-h-0 min-w-0 flex-1 overflow-hidden rounded-md"
+        aria-hidden="true"
+        data-preview-kind={preview.kind}
+        data-preview-state={previewState.status}
+      >
+        {preview.element}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className="block min-h-0 min-w-0 flex-1 overflow-hidden rounded-md"
+      aria-hidden="true"
+      data-preview-kind={preview.kind}
+      data-preview-state={previewState.status}
+    >
+      <img
+        alt=""
+        className="block h-full max-h-full w-full max-w-full object-contain object-center"
+        draggable={false}
+        src={preview.src}
+      />
+    </span>
+  );
+}
+
+function WorkbenchHostDockPopupCardLabel({ title }: { title: string }) {
+  return (
+    <span
+      className="pointer-events-none absolute inset-x-0 bottom-0 z-[1] flex h-[30px] items-end px-[10px] pb-0.5 text-[var(--white-stationary)] opacity-0 transition-opacity duration-150 [text-shadow:0_1px_2px_rgb(0_0_0_/_20%)] group-hover/dock-popup-card:opacity-100 group-focus-within/dock-popup-card:opacity-100"
+      style={{
+        background:
+          "linear-gradient(180deg, transparent 0%, color-mix(in srgb, hsl(var(--card)) 28%, transparent) 18%, color-mix(in srgb, hsl(var(--card)) 82%, transparent) 56%, color-mix(in srgb, hsl(var(--card)) 98%, transparent) 100%)"
+      }}
+      title={title}
+    >
+      <span className="desktop-dock-popup__title-viewport block min-w-0 flex-1 overflow-hidden whitespace-nowrap">
+        <span className="desktop-dock-popup__title-marquee inline-block max-w-full overflow-hidden text-[12px] font-semibold leading-5 text-ellipsis whitespace-nowrap">
+          {title}
+        </span>
+      </span>
+    </span>
+  );
+}

--- a/packages/workbench/surface/src/host/useWorkbenchHostDockPopupPreviewCapture.ts
+++ b/packages/workbench/surface/src/host/useWorkbenchHostDockPopupPreviewCapture.ts
@@ -1,0 +1,544 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { writeCachedWorkbenchNodePreviewImage } from "../react/useWorkbenchGenieAnimation.tsx";
+import type {
+  WorkbenchDockPreviewCache,
+  WorkbenchDockPreviewCacheKey,
+  WorkbenchDockPreviewCacheKeyResolver
+} from "../react/dockPreviewCache.ts";
+import type {
+  WorkbenchDockPreviewContent,
+  WorkbenchHostNodeData,
+  WorkbenchHostProps
+} from "./types.ts";
+import type { WorkbenchHostDockPopupItem } from "./WorkbenchHostDockPopup.tsx";
+
+const dockPopupPreviewCacheMaxEntries = 64;
+const dockPopupPreviewByMemoryKey = new Map<
+  string,
+  WorkbenchHostDockPopupCapturedPreview
+>();
+const pendingDockPopupPreviewCaptureKeys = new Set<string>();
+
+export type WorkbenchHostDockPopupCapturedPreview = {
+  preview: WorkbenchDockPreviewContent | null;
+  revision: string | null;
+};
+
+export type WorkbenchHostDockPopupPreviewState =
+  | {
+      preview: WorkbenchDockPreviewContent;
+      status: "ready";
+    }
+  | {
+      status: "loading";
+    }
+  | {
+      status: "fallback";
+    };
+
+export function useWorkbenchHostDockPopupPreviewCapture(input: {
+  capturePreview?: (
+    item: WorkbenchHostDockPopupItem
+  ) =>
+    | Promise<WorkbenchDockPreviewContent | string | null>
+    | WorkbenchDockPreviewContent
+    | string
+    | null;
+  debugDiagnostics?: WorkbenchHostProps["debugDiagnostics"];
+  dockPreviewCache?: WorkbenchDockPreviewCache;
+  isContextMenu: boolean;
+  items: WorkbenchHostDockPopupItem[];
+  resolveDockPreviewCacheKey?: WorkbenchDockPreviewCacheKeyResolver<WorkbenchHostNodeData>;
+}): {
+  previewStateFor: (
+    item: WorkbenchHostDockPopupItem
+  ) => WorkbenchHostDockPopupPreviewState;
+} {
+  const {
+    capturePreview,
+    debugDiagnostics,
+    dockPreviewCache,
+    isContextMenu,
+    items,
+    resolveDockPreviewCacheKey
+  } = input;
+  const hasCapturePreview = Boolean(capturePreview);
+  const [capturedPreviewByMemoryKey, setCapturedPreviewByMemoryKey] = useState<
+    Record<string, WorkbenchHostDockPopupCapturedPreview | undefined>
+  >({});
+  const capturedPreviewByMemoryKeyRef = useRef(capturedPreviewByMemoryKey);
+  const capturePreviewRef = useRef(capturePreview);
+  const debugDiagnosticsRef = useRef(debugDiagnostics);
+  const dockPreviewCacheRef = useRef(dockPreviewCache);
+  const resolveDockPreviewCacheKeyRef = useRef(resolveDockPreviewCacheKey);
+  const isMountedRef = useRef(false);
+  const isContextMenuRef = useRef(isContextMenu);
+  const activePreviewCaptureItemStateKeysRef = useRef<ReadonlySet<string>>(
+    new Set()
+  );
+  capturedPreviewByMemoryKeyRef.current = capturedPreviewByMemoryKey;
+  capturePreviewRef.current = capturePreview;
+  debugDiagnosticsRef.current = debugDiagnostics;
+  dockPreviewCacheRef.current = dockPreviewCache;
+  resolveDockPreviewCacheKeyRef.current = resolveDockPreviewCacheKey;
+
+  const previewCaptureItemStateKeys = items.map((item) =>
+    resolveDockPopupPreviewItemStateKey(
+      item,
+      resolveDockPreviewCacheKey?.(item.node) ?? null
+    )
+  );
+  const previewCaptureKey = previewCaptureItemStateKeys.join("|");
+
+  useLayoutEffect(() => {
+    isContextMenuRef.current = isContextMenu;
+    activePreviewCaptureItemStateKeysRef.current = new Set(
+      previewCaptureItemStateKeys
+    );
+  });
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!capturePreviewRef.current || isContextMenu) {
+      return;
+    }
+    const captureItemStateIsCurrent = (itemStateKey: string): boolean =>
+      isMountedRef.current &&
+      !isContextMenuRef.current &&
+      activePreviewCaptureItemStateKeysRef.current.has(itemStateKey);
+    let captureEffectActive = true;
+    const ownedCaptureKeys = new Set<string>();
+    const startedCaptureKeys = new Set<string>();
+    const missingItems = items.filter((item) => {
+      const revision = item.previewRevision;
+      const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
+        item,
+        resolveDockPreviewCacheKeyRef.current?.(item.node) ?? null
+      );
+      const pendingCaptureKey = resolveDockPopupPreviewCaptureKey(
+        previewMemoryKey,
+        revision
+      );
+      const capturedPreview =
+        capturedPreviewByMemoryKeyRef.current[previewMemoryKey] ??
+        readDockPopupPreviewImage(previewMemoryKey);
+      const hasCapturedPreview =
+        capturedPreview !== undefined && capturedPreview.revision === revision;
+      return (
+        !item.preview &&
+        !hasCapturedPreview &&
+        !pendingDockPopupPreviewCaptureKeys.has(pendingCaptureKey)
+      );
+    });
+    if (missingItems.length === 0) {
+      logWorkbenchDockPopupDebug(
+        "dock.popup.preview_capture.batch",
+        debugDiagnosticsRef.current,
+        {
+          itemCount: items.length,
+          missingNodeIds: []
+        }
+      );
+      return;
+    }
+    logWorkbenchDockPopupDebug(
+      "dock.popup.preview_capture.batch",
+      debugDiagnosticsRef.current,
+      {
+        itemCount: items.length,
+        missingNodeIds: missingItems.map((item) => item.node.id)
+      }
+    );
+
+    for (const item of missingItems) {
+      const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
+        item,
+        resolveDockPreviewCacheKeyRef.current?.(item.node) ?? null
+      );
+      const pendingCaptureKey = resolveDockPopupPreviewCaptureKey(
+        previewMemoryKey,
+        item.previewRevision
+      );
+      pendingDockPopupPreviewCaptureKeys.add(pendingCaptureKey);
+      ownedCaptureKeys.add(pendingCaptureKey);
+    }
+
+    void (async () => {
+      for (const item of missingItems) {
+        if (!captureEffectActive) {
+          break;
+        }
+        const revision = item.previewRevision;
+        const resolvedCacheKey =
+          resolveDockPreviewCacheKeyRef.current?.(item.node) ?? null;
+        const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
+          item,
+          resolvedCacheKey
+        );
+        const pendingCaptureKey = resolveDockPopupPreviewCaptureKey(
+          previewMemoryKey,
+          revision
+        );
+        const itemStateKey = resolveDockPopupPreviewItemStateKey(
+          item,
+          resolvedCacheKey
+        );
+        if (!captureItemStateIsCurrent(itemStateKey)) {
+          pendingDockPopupPreviewCaptureKeys.delete(pendingCaptureKey);
+          ownedCaptureKeys.delete(pendingCaptureKey);
+          continue;
+        }
+        startedCaptureKeys.add(pendingCaptureKey);
+        try {
+          logWorkbenchDockPopupDebug(
+            "dock.popup.preview_capture.started",
+            debugDiagnosticsRef.current,
+            {
+              isMinimized: item.isMinimized,
+              nodeId: item.node.id,
+              revision
+            }
+          );
+          const cacheKey = resolveDockPopupPreviewCacheKey(
+            resolvedCacheKey,
+            revision
+          );
+          if (item.isMinimized && cacheKey) {
+            const minimizedPersistedPreview = await readPersistedDockPreview(
+              dockPreviewCacheRef.current,
+              cacheKey
+            );
+            if (!captureItemStateIsCurrent(itemStateKey)) {
+              continue;
+            }
+            if (minimizedPersistedPreview) {
+              const persistedPreview: WorkbenchDockPreviewContent = {
+                kind: "image",
+                src: minimizedPersistedPreview
+              };
+              writeCachedWorkbenchNodePreviewImage(
+                item.node.id,
+                minimizedPersistedPreview
+              );
+              writeDockPopupPreviewImage(
+                previewMemoryKey,
+                persistedPreview,
+                revision
+              );
+              setCapturedPreviewByMemoryKey((current) => ({
+                ...current,
+                [previewMemoryKey]: {
+                  preview: persistedPreview,
+                  revision
+                }
+              }));
+              continue;
+            }
+          }
+
+          const providedPreview = await Promise.resolve(
+            capturePreviewRef.current?.(item) ?? null
+          ).catch(() => null);
+          if (!captureItemStateIsCurrent(itemStateKey)) {
+            continue;
+          }
+          const preview = normalizeDockPopupPreviewContentResult(
+            providedPreview,
+            revision
+          );
+          if (!captureItemStateIsCurrent(itemStateKey)) {
+            continue;
+          }
+          logWorkbenchDockPopupDebug(
+            "dock.popup.preview_capture.resolved",
+            debugDiagnosticsRef.current,
+            {
+              hasPreview: Boolean(preview),
+              nodeId: item.node.id,
+              providerRevision: preview?.revision ?? null,
+              revision
+            }
+          );
+          if (preview) {
+            if (preview.kind === "image") {
+              writeCachedWorkbenchNodePreviewImage(item.node.id, preview.src);
+            }
+            writeDockPopupPreviewImage(previewMemoryKey, preview, revision);
+            if (cacheKey && preview.kind === "image") {
+              dockPreviewCacheRef.current?.write({
+                key: cacheKey,
+                previewImageUrl: preview.src
+              });
+            }
+            setCapturedPreviewByMemoryKey((current) => ({
+              ...current,
+              [previewMemoryKey]: { preview, revision }
+            }));
+            continue;
+          }
+
+          const fallbackPersistedPreview =
+            !item.isMinimized && cacheKey
+              ? await readPersistedDockPreview(
+                  dockPreviewCacheRef.current,
+                  cacheKey
+                )
+              : null;
+          if (!captureItemStateIsCurrent(itemStateKey)) {
+            continue;
+          }
+          if (fallbackPersistedPreview) {
+            writeCachedWorkbenchNodePreviewImage(
+              item.node.id,
+              fallbackPersistedPreview
+            );
+            const fallbackPreview: WorkbenchDockPreviewContent = {
+              kind: "image",
+              src: fallbackPersistedPreview
+            };
+            writeDockPopupPreviewImage(
+              previewMemoryKey,
+              fallbackPreview,
+              revision
+            );
+          }
+          const fallbackPreview: WorkbenchDockPreviewContent | null =
+            fallbackPersistedPreview
+              ? { kind: "image", src: fallbackPersistedPreview }
+              : null;
+          setCapturedPreviewByMemoryKey((current) => ({
+            ...current,
+            [previewMemoryKey]: { preview: fallbackPreview, revision }
+          }));
+        } finally {
+          pendingDockPopupPreviewCaptureKeys.delete(pendingCaptureKey);
+          ownedCaptureKeys.delete(pendingCaptureKey);
+        }
+      }
+    })().catch(() => {
+      for (const captureKey of ownedCaptureKeys) {
+        pendingDockPopupPreviewCaptureKeys.delete(captureKey);
+      }
+      ownedCaptureKeys.clear();
+      const currentItems = missingItems.filter((item) =>
+        captureItemStateIsCurrent(
+          resolveDockPopupPreviewItemStateKey(
+            item,
+            resolveDockPreviewCacheKeyRef.current?.(item.node) ?? null
+          )
+        )
+      );
+      for (const item of currentItems) {
+        const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
+          item,
+          resolveDockPreviewCacheKey?.(item.node) ?? null
+        );
+        pendingDockPopupPreviewCaptureKeys.delete(
+          resolveDockPopupPreviewCaptureKey(
+            previewMemoryKey,
+            item.previewRevision
+          )
+        );
+      }
+      if (currentItems.length > 0) {
+        setCapturedPreviewByMemoryKey((current) => ({
+          ...current,
+          ...Object.fromEntries(
+            currentItems.map((item) => {
+              const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
+                item,
+                resolveDockPreviewCacheKey?.(item.node) ?? null
+              );
+              return [
+                previewMemoryKey,
+                { preview: null, revision: item.previewRevision }
+              ];
+            })
+          )
+        }));
+      }
+    });
+
+    return () => {
+      captureEffectActive = false;
+      for (const captureKey of ownedCaptureKeys) {
+        if (!startedCaptureKeys.has(captureKey)) {
+          pendingDockPopupPreviewCaptureKeys.delete(captureKey);
+          ownedCaptureKeys.delete(captureKey);
+        }
+      }
+    };
+  }, [hasCapturePreview, isContextMenu, previewCaptureKey]);
+
+  return {
+    previewStateFor(item) {
+      const previewMemoryKey = resolveDockPopupPreviewMemoryKey(
+        item,
+        resolveDockPreviewCacheKey?.(item.node) ?? null
+      );
+      const capturedPreview =
+        capturedPreviewByMemoryKey[previewMemoryKey] ??
+        readDockPopupPreviewImage(previewMemoryKey);
+      return resolveDockPopupItemPreviewState(
+        item,
+        capturedPreview,
+        hasCapturePreview
+      );
+    }
+  };
+}
+
+export function logWorkbenchDockPopupDebug(
+  event: string,
+  debugDiagnostics: WorkbenchHostProps["debugDiagnostics"],
+  details: Record<string, unknown>
+): void {
+  if (!debugDiagnostics?.log) {
+    return;
+  }
+  void Promise.resolve(
+    debugDiagnostics.log({
+      details,
+      event,
+      level: "info",
+      source: "workbench-dock"
+    })
+  ).catch(() => undefined);
+}
+
+function readDockPopupPreviewImage(
+  memoryKey: string
+): WorkbenchHostDockPopupCapturedPreview | undefined {
+  return dockPopupPreviewByMemoryKey.get(memoryKey);
+}
+
+function writeDockPopupPreviewImage(
+  memoryKey: string,
+  preview: WorkbenchDockPreviewContent,
+  revision: string | null
+): void {
+  dockPopupPreviewByMemoryKey.delete(memoryKey);
+  dockPopupPreviewByMemoryKey.set(memoryKey, { preview, revision });
+  while (dockPopupPreviewByMemoryKey.size > dockPopupPreviewCacheMaxEntries) {
+    const oldestMemoryKey = dockPopupPreviewByMemoryKey.keys().next().value;
+    if (typeof oldestMemoryKey !== "string") {
+      break;
+    }
+    dockPopupPreviewByMemoryKey.delete(oldestMemoryKey);
+  }
+}
+
+function readPersistedDockPreview(
+  dockPreviewCache: WorkbenchDockPreviewCache | undefined,
+  cacheKey: WorkbenchDockPreviewCacheKey | null
+): Promise<string | null> {
+  if (!cacheKey) {
+    return Promise.resolve(null);
+  }
+  return (
+    dockPreviewCache?.read(cacheKey).catch(() => null) ?? Promise.resolve(null)
+  );
+}
+
+function resolveDockPopupPreviewCacheKey(
+  cacheKey: WorkbenchDockPreviewCacheKey | null,
+  revision: string | null
+): WorkbenchDockPreviewCacheKey | null {
+  return cacheKey ? { ...cacheKey, revision } : null;
+}
+
+function resolveDockPopupPreviewMemoryKey(
+  item: WorkbenchHostDockPopupItem,
+  cacheKey: WorkbenchDockPreviewCacheKey | null
+): string {
+  if (!cacheKey) {
+    return `node:${item.node.id}`;
+  }
+  return `cache:${JSON.stringify({
+    instanceId: cacheKey.instanceId,
+    instanceKey: cacheKey.instanceKey ?? null,
+    nodeId: cacheKey.nodeId,
+    typeId: cacheKey.typeId,
+    workspaceId: cacheKey.workspaceId
+  })}`;
+}
+
+function resolveDockPopupPreviewCaptureKey(
+  memoryKey: string,
+  revision: string | null
+): string {
+  return `${memoryKey}\u0000${revision ?? ""}`;
+}
+
+function resolveDockPopupPreviewItemStateKey(
+  item: WorkbenchHostDockPopupItem,
+  cacheKey: WorkbenchDockPreviewCacheKey | null
+): string {
+  return [
+    resolveDockPopupPreviewMemoryKey(item, cacheKey),
+    item.isMinimized ? "minimized" : "visible",
+    previewCacheToken(item.preview),
+    item.previewRevision ?? ""
+  ].join(":");
+}
+
+function normalizeDockPopupPreviewContentResult(
+  preview: WorkbenchDockPreviewContent | string | null | undefined,
+  revision: string | null
+): WorkbenchDockPreviewContent | null {
+  if (!preview) {
+    return null;
+  }
+  if (typeof preview === "string") {
+    return { kind: "image", revision: revision ?? undefined, src: preview };
+  }
+  return {
+    ...preview,
+    revision: preview.revision ?? revision ?? undefined
+  };
+}
+
+function resolveDockPopupItemPreviewState(
+  item: WorkbenchHostDockPopupItem,
+  capturedPreview: WorkbenchHostDockPopupCapturedPreview | undefined,
+  hasPreviewProvider: boolean
+): WorkbenchHostDockPopupPreviewState {
+  const revision = item.previewRevision;
+  if (item.preview) {
+    return { preview: item.preview, status: "ready" };
+  }
+  if (
+    capturedPreview &&
+    capturedPreview.revision === revision &&
+    capturedPreview.preview
+  ) {
+    return { preview: capturedPreview.preview, status: "ready" };
+  }
+  if (
+    (capturedPreview !== undefined && capturedPreview.revision === revision) ||
+    !hasPreviewProvider
+  ) {
+    return { status: "fallback" };
+  }
+  return { status: "loading" };
+}
+
+function previewCacheToken(
+  preview: WorkbenchDockPreviewContent | null | undefined
+): string {
+  if (!preview) {
+    return "";
+  }
+  switch (preview.kind) {
+    case "component":
+      return `component:${preview.revision ?? ""}`;
+    case "image":
+      return `image:${preview.revision ?? ""}:${preview.src}`;
+  }
+}


### PR DESCRIPTION
## Summary
- preserve Dock preview captures across React StrictMode effect replay and retry unavailable previews on a later popup
- use only native or previously cached images for background AGUI windows; remove blank DOM capture fallback
- make AgentGUI carousel images CORS-safe for WebGL textures through anonymous loads and allowlisted `tutti-asset` responses
- split Dock popup layout, presentation, and preview-capture responsibilities into files below the 800-line limit

## Tests
- `pnpm --filter @tutti-os/workbench-surface test`
- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`

## Notes
- no proactive/background capture and no conversation summary card
- a window without any successful prior capture shows a static terminal placeholder
- desktop pixel verification was not completed locally