### PR TITLE
fix(agent): harden cross-host activity contracts

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
@@ -4,6 +4,7 @@ import {
   type AgentActivityAdapter,
   type AgentActivitySendInput,
   type AgentSessionEngine,
+  type PlanSubmitDecisionResult,
   type PromptQueueSendCommand,
   type SessionActivateCommand,
   type SessionReconcileCommand,
@@ -44,7 +45,7 @@ interface CreateWorkspaceAgentSessionEngineHostInput {
     requestId: string;
     turnId: string;
     workspaceId: string;
-  }): Promise<unknown>;
+  }): Promise<PlanSubmitDecisionResult>;
   subscribeSessionEvents(
     workspaceId: string,
     listener: (event: unknown) => void
@@ -121,6 +122,16 @@ export function createWorkspaceAgentSessionEngineHost(
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => Date.now() },
     commandPort: {
+      executePlanDecision: (command) =>
+        input.submitPlanDecision({
+          action: command.action,
+          agentSessionId: command.agentSessionId,
+          idempotencyKey: command.idempotencyKey,
+          promptKind: command.promptKind,
+          requestId: command.requestId,
+          turnId: command.turnId,
+          workspaceId: command.workspaceId
+        }),
       execute: async (command, options) => {
         switch (command.type) {
           case "attention/readState/read":
@@ -170,16 +181,6 @@ export function createWorkspaceAgentSessionEngineHost(
               agentSessionId: command.agentSessionId,
               ...(command.optionId ? { optionId: command.optionId } : {}),
               ...(command.payload ? { payload: { ...command.payload } } : {}),
-              requestId: command.requestId,
-              turnId: command.turnId,
-              workspaceId: command.workspaceId
-            });
-          case "plan/submitDecision":
-            return input.submitPlanDecision({
-              action: command.action,
-              agentSessionId: command.agentSessionId,
-              idempotencyKey: command.idempotencyKey,
-              promptKind: command.promptKind,
               requestId: command.requestId,
               turnId: command.turnId,
               workspaceId: command.workspaceId

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentOutcomeNotification.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentOutcomeNotification.test.ts
@@ -172,7 +172,11 @@ test("controller does not notify a historical settled turn hydrated after baseli
 function createTestEngine(): AgentSessionEngine {
   return createAgentSessionEngine({
     clock: { nowUnixMs: () => 1 },
-    commandPort: { execute: () => Promise.resolve(undefined) },
+    commandPort: {
+      execute: () => Promise.resolve(undefined),
+      executePlanDecision: () =>
+        Promise.reject(new Error("unexpected plan decision command"))
+    },
     identity: {
       origin: AGENT_SESSION_ENGINE_LOCAL_ORIGIN,
       workspaceId: "ws-1"

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -681,6 +681,17 @@ createAgentSessionEngine({
 });
 ```
 
+`plan/submitDecision` uses the dedicated
+`EngineCommandPort.executePlanDecision` method. Its public
+`PlanSubmitDecisionResult` contains the durable operation identity returned by
+the Host. It must not pass through the generic `execute(): Promise<unknown>`
+path or manufacture an operation id from a command id.
+
+Durable daemon message pages and `message_update` payloads use
+`AgentActivityDurableMessage`, whose immutable `sequence` is required. Local
+optimistic and session-audit projections may use the separate transient
+message shape; this must not weaken the durable page or realtime contract.
+
 The adapter exposes the HTTP operations used by that command port and by the
 desktop reconcile bridge:
 

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -857,6 +857,12 @@ icon assertion is not sufficient coverage: presentation changes require both a
 projection assertion and a consuming-row DOM assertion so an intermediate
 view-model cannot silently discard the icon.
 
+Composer copy and cut write both the canonical prompt Markdown as
+`text/plain` and schema-serialized mention markup as `text/html`. Pasting that
+markup reparses it through the AgentGUI editor schema, so built-in and
+currently registered custom mentions retain their canonical href and chip
+identity without a host DOM event interceptor.
+
 External OS file paste and drop enter one host-injected classification boundary before draft attachment creation. The synchronous `resolveExternalPromptEntries` port classifies each source index as a live `WorkspaceFileReference` or a snapshot requiring preparation. AgentGUI owns ordered mention insertion and draft reconciliation: references become ordinary file/folder mentions and never consume prompt-asset slots, while only `prepare` entries create pending attachment state and enter `prepareExternalPromptFiles`. A host without the resolver prepares every external entry. The preparer owns native-path or byte lookup, size enforcement, persistence, and remote transport; each prepared input has one `sourceIndex` result, one failure must not fail siblings, successful results include a provider-readable `path` or `url`, and failures carry typed error codes. Hosts that classify path-backed entries as references must reject any such entry that unexpectedly reaches preparation, so classification failure cannot silently create a duplicate snapshot.
 
 Workspace picker results and internal workspace-reference drags remain live references. They enter the rich-text document as mentions and never pass through external-file preparation. A picker source whose selected locator is not yet consumer-readable may perform source-owned confirmation preparation before the mention is inserted; the picker waits in a loading state, publishes no partial result on failure, and remains open for retry. This confirmation transaction belongs to the reference source contract and is distinct from the external OS file preparation pipeline. Removing an inline external-file mention removes its draft intent; a later async result must not revive it or lose its error reason when the draft is in another scope.

--- a/packages/agent/activity-core/src/durableMessageContracts.typecheck.ts
+++ b/packages/agent/activity-core/src/durableMessageContracts.typecheck.ts
@@ -1,0 +1,40 @@
+import type {
+  AgentActivityMessagePage,
+  AgentActivityMessageUpdatedEvent
+} from "./types.ts";
+
+const messageWithoutSequence = {
+  agentSessionId: "session-1",
+  kind: "text",
+  messageId: "message-1",
+  occurredAtUnixMs: 1,
+  payload: {},
+  role: "assistant",
+  turnId: "turn-1",
+  version: 1
+};
+
+const invalidPage: AgentActivityMessagePage = {
+  hasMore: false,
+  latestVersion: 1,
+  // @ts-expect-error daemon pages contain durable messages with an immutable sequence
+  messages: [messageWithoutSequence]
+};
+
+const invalidUpdate: AgentActivityMessageUpdatedEvent = {
+  agentSessionId: "session-1",
+  data: {
+    acceptedCount: 1,
+    agentSessionId: "session-1",
+    eventType: "message_update",
+    latestVersion: 1,
+    // @ts-expect-error message_update contains durable messages with an immutable sequence
+    messages: [messageWithoutSequence],
+    workspaceId: "workspace-1"
+  },
+  eventType: "message_update",
+  workspaceId: "workspace-1"
+};
+
+void invalidPage;
+void invalidUpdate;

--- a/packages/agent/activity-core/src/engine/createAgentSessionEngine.test.ts
+++ b/packages/agent/activity-core/src/engine/createAgentSessionEngine.test.ts
@@ -92,6 +92,21 @@ function createManualCommandPort(): ManualCommandPort {
   const executedCommands: EngineExternalCommand[] = [];
   const abortSignalsByCommandId = new Map<string, AbortSignal>();
   return {
+    executePlanDecision(command, options) {
+      executedCommands.push(command);
+      if (options?.signal) {
+        abortSignalsByCommandId.set(command.commandId, options.signal);
+      }
+      return new Promise((resolve, reject) => {
+        settlersByCommandId.set(command.commandId, {
+          reject,
+          resolve: (value) =>
+            resolve(
+              value as import("./planDecision.types.ts").PlanSubmitDecisionResult
+            )
+        });
+      });
+    },
     execute(command, options) {
       executedCommands.push(command);
       if (options?.signal) {
@@ -653,6 +668,7 @@ test("an authoritative Session detail snapshot notifies subscribers once", () =>
         occurredAtUnixMs: 3,
         payload: { text: "hello" },
         role: "assistant",
+        sequence: 1,
         turnId: "turn-1",
         version: 1,
         workspaceId: "workspace-1"

--- a/packages/agent/activity-core/src/engine/effectExecutor.ts
+++ b/packages/agent/activity-core/src/engine/effectExecutor.ts
@@ -104,7 +104,19 @@ export function createEngineEffectExecutor({
         timeoutTasks.add(timeoutTask);
       }
 
-      commandPort.execute(command, { signal: abortController.signal }).then(
+      const execution =
+        command.type === "plan/submitDecision"
+          ? commandPort.executePlanDecision
+            ? commandPort.executePlanDecision(command, {
+                signal: abortController.signal
+              })
+            : Promise.reject(
+                new Error(
+                  "EngineCommandPort.executePlanDecision is not configured"
+                )
+              )
+          : commandPort.execute(command, { signal: abortController.signal });
+      execution.then(
         (value) => {
           if (settled) {
             diagnosticSink?.({

--- a/packages/agent/activity-core/src/engine/engineRuntime.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/engineRuntime.reducer.test.ts
@@ -1235,6 +1235,7 @@ test("timeout message confirmation waits for exact-turn lifecycle reconcile", ()
         occurredAtUnixMs: 4,
         payload: { clientSubmitId: "submit-1", text: "submit-1" },
         role: "user",
+        sequence: 1,
         turnId: "turn-1",
         version: 1
       }

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
@@ -709,6 +709,7 @@ function message(clientSubmitId: string) {
     occurredAtUnixMs: 2,
     payload: { clientSubmitId },
     role: "user",
+    sequence: 1,
     turnId: "turn-1",
     version: 1
   };

--- a/packages/agent/activity-core/src/engine/planDecision.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/planDecision.reducer.test.ts
@@ -63,6 +63,7 @@ test("pending plan decision is confirmed by its durable completed notice", () =>
             planTurnId: "plan-turn-1"
           },
           role: "system",
+          sequence: 1,
           status: "running",
           turnId: null,
           version: 1,
@@ -92,6 +93,7 @@ test("pending plan decision is confirmed by its durable completed notice", () =>
             planTurnId: "plan-turn-1"
           },
           role: "system",
+          sequence: 1,
           status: "completed",
           turnId: null,
           version: 2,
@@ -165,6 +167,7 @@ test("unrelated completed plan notice cannot confirm an unknown decision", () =>
             planTurnId: "plan-turn-1"
           },
           role: "system",
+          sequence: 1,
           turnId: null,
           version: 2,
           workspaceId: "workspace-1"

--- a/packages/agent/activity-core/src/engine/planDecision.reducer.ts
+++ b/packages/agent/activity-core/src/engine/planDecision.reducer.ts
@@ -1,5 +1,6 @@
 import { canonicalInteractionKey } from "./sessionEntityKeys.ts";
 import type {
+  PlanDecisionOperation,
   PlanDecisionRecord,
   PlanDecisionState
 } from "./planDecision.types.ts";
@@ -227,8 +228,9 @@ function validateOperation(
 } {
   if (!value || typeof value !== "object")
     return { operationId: null, status: "invalid" };
-  const operation = (value as { operation?: Record<string, unknown> })
-    .operation;
+  const operation = planDecisionOperation(
+    (value as { operation?: unknown }).operation
+  );
   if (
     !operation ||
     operation.workspaceId !== record.workspaceId ||
@@ -249,6 +251,29 @@ function validateOperation(
           ? "pending"
           : "invalid";
   return { operationId, status };
+}
+
+function planDecisionOperation(value: unknown): PlanDecisionOperation | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const operation = value as Record<string, unknown>;
+  const status = operation.status;
+  if (
+    typeof operation.agentSessionId !== "string" ||
+    typeof operation.idempotencyKey !== "string" ||
+    typeof operation.operationId !== "string" ||
+    typeof operation.requestId !== "string" ||
+    typeof operation.turnId !== "string" ||
+    typeof operation.workspaceId !== "string" ||
+    (status !== "prepared" &&
+      status !== "leased" &&
+      status !== "completed" &&
+      status !== "failed")
+  ) {
+    return null;
+  }
+  return operation as unknown as PlanDecisionOperation;
 }
 
 function text(value: unknown): string | null {

--- a/packages/agent/activity-core/src/engine/planDecision.types.ts
+++ b/packages/agent/activity-core/src/engine/planDecision.types.ts
@@ -80,3 +80,19 @@ export interface PlanSubmitDecisionCommand {
   turnId: string;
   workspaceId: string;
 }
+
+export interface PlanDecisionOperation {
+  agentSessionId: string;
+  error?: string | null;
+  idempotencyKey: string;
+  operationId: string;
+  requestId: string;
+  result?: string | null;
+  status: "prepared" | "leased" | "completed" | "failed";
+  turnId: string;
+  workspaceId: string;
+}
+
+export interface PlanSubmitDecisionResult {
+  operation: PlanDecisionOperation;
+}

--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts
@@ -939,6 +939,7 @@ function messagesReceived(clientSubmitId: string, turnId: string | null) {
         occurredAtUnixMs: 4,
         payload: { clientSubmitId, text: clientSubmitId },
         role: "user",
+        sequence: 1,
         turnId,
         version: 1
       }

--- a/packages/agent/activity-core/src/engine/sessionMessages.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionMessages.reducer.test.ts
@@ -16,6 +16,7 @@ function message(
   return {
     workspaceId: "workspace-1",
     role: "assistant",
+    sequence: overrides.sequence ?? overrides.version ?? 1,
     kind: "text",
     turnId: "turn-1",
     version: 1,

--- a/packages/agent/activity-core/src/engine/sessionMutations.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionMutations.reducer.test.ts
@@ -26,6 +26,9 @@ const session = normalizeAgentActivitySession({
 test("pin result commits mutation and canonical session in one engine notification", async () => {
   let resolveCommand: (value: unknown) => void = () => {};
   const commandPort: EngineCommandPort = {
+    executePlanDecision: async () => {
+      throw new Error("unexpected plan decision command");
+    },
     execute: async () =>
       new Promise((resolve) => {
         resolveCommand = resolve;

--- a/packages/agent/activity-core/src/engine/sessionReconcile.types.ts
+++ b/packages/agent/activity-core/src/engine/sessionReconcile.types.ts
@@ -1,4 +1,7 @@
-import type { AgentActivityMessage, AgentActivityTurn } from "../types.ts";
+import type {
+  AgentActivityDurableMessage,
+  AgentActivityTurn
+} from "../types.ts";
 import type { AgentActivitySessionMessageWindow } from "../messageWindow.types.ts";
 import type { AgentActivitySessionInput } from "../sessionNormalization.ts";
 
@@ -43,7 +46,7 @@ export interface SessionDetailSnapshotReceivedIntent {
   type: "session/detailSnapshotReceived";
   childSessions: readonly AgentActivitySessionInput[];
   live?: boolean;
-  messages?: readonly AgentActivityMessage[];
+  messages?: readonly AgentActivityDurableMessage[];
   session: AgentActivitySessionInput;
   sessionMessageWindows?: readonly (AgentActivitySessionMessageWindow & {
     agentSessionId: string;

--- a/packages/agent/activity-core/src/engine/types.ts
+++ b/packages/agent/activity-core/src/engine/types.ts
@@ -173,6 +173,11 @@ export type EngineExternalCommand =
   | ComposerOptionsCommand
   | TuttiModeActivationCommand;
 
+export type EngineExternalCommandExceptPlanDecision = Exclude<
+  EngineExternalCommand,
+  PlanSubmitDecisionCommand
+>;
+
 export type EngineCommand = EngineExternalCommand | EngineInternalCommand;
 
 export function isEngineInternalCommand(
@@ -259,9 +264,13 @@ export interface EngineClock {
 /** Transport adapter surface: executes external command descriptions. */
 export interface EngineCommandPort {
   execute(
-    command: EngineExternalCommand,
+    command: EngineExternalCommandExceptPlanDecision,
     options?: { signal?: AbortSignal }
   ): Promise<unknown>;
+  executePlanDecision?(
+    command: PlanSubmitDecisionCommand,
+    options?: { signal?: AbortSignal }
+  ): Promise<PlanSubmitDecisionResult>;
 }
 
 // ---------------------------------------------------------------------------
@@ -319,7 +328,8 @@ import type {
 import type {
   PlanDecisionIntent,
   PlanDecisionState,
-  PlanSubmitDecisionCommand
+  PlanSubmitDecisionCommand,
+  PlanSubmitDecisionResult
 } from "./planDecision.types.ts";
 import type {
   SessionCommandsIntent,

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -77,6 +77,7 @@ export type {
   EngineDispatchOptions,
   EngineDomainReducer,
   EngineExternalCommand,
+  EngineExternalCommandExceptPlanDecision,
   EngineIntent,
   EngineInternalCommand,
   EngineReducerResult,
@@ -196,11 +197,13 @@ export type {
   TurnCancelCommand
 } from "./engine/sessionLifecycle.types.ts";
 export type {
+  PlanDecisionOperation,
   PlanDecisionIntent,
   PlanDecisionRecord,
   PlanDecisionState,
   PlanDecisionStatus,
-  PlanSubmitDecisionCommand
+  PlanSubmitDecisionCommand,
+  PlanSubmitDecisionResult
 } from "./engine/planDecision.types.ts";
 export {
   selectPlanDecisionForTurn,
@@ -304,6 +307,7 @@ export type {
   AgentActivityDeleteSessionResult,
   AgentActivityDeleteSessionsInput,
   AgentActivityDeleteSessionsResult,
+  AgentActivityDurableMessage,
   AgentActivityModelPlanModel,
   AgentActivityModelPlanSummary,
   AgentActivitySetCollaborationAdoptionInput,
@@ -347,6 +351,7 @@ export type {
   AgentActivityTurn,
   AgentActivityTurnOrigin,
   AgentActivityTurnCancelResponse,
+  AgentActivityTransientMessage,
   AgentActivityInteraction,
   AgentActivityUpdatedApplyResult,
   AgentActivityUpdatedEvent

--- a/packages/agent/activity-core/src/message.types.ts
+++ b/packages/agent/activity-core/src/message.types.ts
@@ -5,7 +5,7 @@ export interface AgentActivityMessageSemantics {
   noticeCommandStatus?: "running" | "completed" | "failed" | "canceled";
 }
 
-export interface AgentActivityMessage {
+export interface AgentActivityMessageBase {
   workspaceId?: string;
   agentSessionId: string;
   messageId: string;
@@ -16,12 +16,23 @@ export interface AgentActivityMessage {
   status?: string | null;
   semantics?: AgentActivityMessageSemantics;
   payload: Record<string, unknown>;
-  sequence?: number;
   occurredAtUnixMs: number;
   createdAtUnixMs?: number;
   startedAtUnixMs?: number;
   completedAtUnixMs?: number;
 }
+
+export interface AgentActivityDurableMessage extends AgentActivityMessageBase {
+  sequence: number;
+}
+
+export interface AgentActivityTransientMessage extends AgentActivityMessageBase {
+  sequence?: undefined;
+}
+
+export type AgentActivityMessage =
+  | AgentActivityDurableMessage
+  | AgentActivityTransientMessage;
 
 export interface AgentActivityMessageDeltaEvent {
   workspaceId: string;

--- a/packages/agent/activity-core/src/selectors.test.ts
+++ b/packages/agent/activity-core/src/selectors.test.ts
@@ -201,6 +201,7 @@ function message(
     version: 1,
     turnId: "turn-1",
     role: "assistant",
+    sequence: overrides.version ?? 1,
     kind: "tool_call",
     status: "waiting_input",
     payload: {},

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -1,5 +1,6 @@
 import type { AgentActivityComposerModelConfiguration } from "./composerModelConfiguration.types.ts";
 import type {
+  AgentActivityDurableMessage,
   AgentActivityMessage,
   AgentActivityMessageDeltaEvent
 } from "./message.types.ts";
@@ -12,9 +13,11 @@ import type {
 } from "./tuttiMode.types.ts";
 
 export type {
+  AgentActivityDurableMessage,
   AgentActivityMessage,
   AgentActivityMessageDeltaEvent,
-  AgentActivityMessageSemantics
+  AgentActivityMessageSemantics,
+  AgentActivityTransientMessage
 } from "./message.types.ts";
 
 export type {
@@ -127,7 +130,7 @@ export interface AgentActivityPresence {
 }
 
 export interface AgentActivityMessagePage {
-  messages: AgentActivityMessage[];
+  messages: AgentActivityDurableMessage[];
   hasMore: boolean;
   latestVersion: number;
 }
@@ -392,7 +395,7 @@ export interface AgentActivityEventMessage {
   version: number;
   turnId: string | null;
   status?: string;
-  sequence?: number;
+  sequence: number;
   occurredAtUnixMs: number;
   startedAtUnixMs?: number;
   completedAtUnixMs?: number;

--- a/packages/agent/activity-tuttid-adapter/src/mappers.ts
+++ b/packages/agent/activity-tuttid-adapter/src/mappers.ts
@@ -1,5 +1,5 @@
 import type {
-  AgentActivityMessage,
+  AgentActivityDurableMessage,
   AgentActivitySession,
   AgentActivityTurn
 } from "@tutti-os/agent-activity-core";
@@ -139,7 +139,7 @@ export function agentActivityTuttiModeActivationFromTuttid(
 export function agentActivityMessageFromTuttidMessage(
   workspaceId: string,
   message: WorkspaceAgentSessionMessage
-): AgentActivityMessage {
+): AgentActivityDurableMessage {
   return {
     workspaceId,
     agentSessionId: message.agentSessionId,

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
@@ -1,6 +1,10 @@
 import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import { createRef } from "react";
 import { describe, expect, it, vi } from "vitest";
+import {
+  registerAgentCustomMentionKind,
+  resetAgentCustomMentionKindsForTests
+} from "../../../shared/agentCustomMentionKinds";
 import { AgentRichTextEditor } from "./AgentRichTextEditor";
 import type { AgentRichTextEditorHandle } from "./AgentRichTextEditor.types";
 
@@ -345,3 +349,113 @@ describe("AgentRichTextEditor prompt insertion", () => {
     expect(onChange).toHaveBeenLastCalledWith("hello Tutti");
   });
 });
+
+describe("AgentRichTextEditor mention clipboard", () => {
+  it("round-trips a built-in mention through text/plain and text/html", async () => {
+    const prompt = "Read [@report.md](/workspace/report.md) next";
+    const copied = await copyEditorPrompt(prompt);
+
+    expect(copied["text/plain"]).toBe(prompt);
+    expect(copied["text/html"]).toContain("data-agent-file-mention");
+    expect(copied["text/html"]).toContain("/workspace/report.md");
+    expect(await pasteEditorPrompt(copied)).toBe(prompt);
+  });
+
+  it("round-trips a registered custom mention without losing its href", async () => {
+    registerAgentCustomMentionKind({
+      kind: "external-note",
+      present: (mention) => ({
+        name: mention.label,
+        summary: mention.scope?.preview
+      })
+    });
+    try {
+      const prompt =
+        "Use [@Note A](mention://external-note/note-a?preview=hello&spaceId=space-1)";
+      const copied = await copyEditorPrompt(prompt);
+
+      expect(copied["text/plain"]).toBe(prompt);
+      expect(copied["text/html"]).toContain("data-agent-mention-kind");
+      expect(copied["text/html"]).toContain("external-note");
+      expect(await pasteEditorPrompt(copied)).toBe(prompt);
+    } finally {
+      resetAgentCustomMentionKindsForTests();
+    }
+  });
+});
+
+async function copyEditorPrompt(
+  prompt: string
+): Promise<Record<string, string>> {
+  const rendered = render(
+    <AgentRichTextEditor
+      value={prompt}
+      disabled={false}
+      placeholder="Prompt"
+      onChange={vi.fn()}
+      onSubmit={vi.fn()}
+    />
+  );
+  const editor = await waitFor(() => {
+    const element = rendered.container.querySelector<HTMLElement>(
+      '[contenteditable="true"]'
+    );
+    expect(element).not.toBeNull();
+    return element!;
+  });
+  selectEditorContents(editor);
+  const copied: Record<string, string> = {};
+  fireEvent.copy(editor, {
+    clipboardData: {
+      files: [],
+      getData: (type: string) => copied[type] ?? "",
+      setData: (type: string, value: string) => {
+        copied[type] = value;
+      }
+    }
+  });
+  rendered.unmount();
+  return copied;
+}
+
+async function pasteEditorPrompt(
+  clipboard: Record<string, string>
+): Promise<string> {
+  const onChange = vi.fn<(value: string) => void>();
+  const rendered = render(
+    <AgentRichTextEditor
+      value=""
+      disabled={false}
+      placeholder="Prompt"
+      onChange={onChange}
+      onSubmit={vi.fn()}
+    />
+  );
+  const editor = await waitFor(() => {
+    const element = rendered.container.querySelector<HTMLElement>(
+      '[contenteditable="true"]'
+    );
+    expect(element).not.toBeNull();
+    return element!;
+  });
+  fireEvent.paste(editor, {
+    clipboardData: {
+      files: [],
+      getData: (type: string) => clipboard[type] ?? ""
+    }
+  });
+  await waitFor(() => expect(onChange).toHaveBeenCalled());
+  const result = onChange.mock.calls.at(-1)?.[0] ?? "";
+  rendered.unmount();
+  return result;
+}
+
+function selectEditorContents(editor: HTMLElement): void {
+  editor.focus();
+  const selection = window.getSelection();
+  const range = document.createRange();
+  range.selectNodeContents(editor);
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+  document.dispatchEvent(new Event("selectionchange", { bubbles: true }));
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
@@ -40,6 +40,7 @@ import {
   classifyAgentRichTextTextPaste,
   createAgentRichTextCaretAnchorExtension,
   createAgentRichTextPlaceholderExtension,
+  insertAgentRichTextClipboardHtml,
   isAgentRichTextLargeTextPaste,
   isPromptVisualLineStart,
   readEditorDomSelectionRange,
@@ -47,6 +48,7 @@ import {
   readPromptSelection,
   readPromptTextRange,
   readSelectedPlainText,
+  serializeAgentRichTextSelection,
   scrollEditorSelectionIntoView,
   writePlainTextToClipboard
 } from "./agentRichTextEditorSupport";
@@ -372,11 +374,12 @@ export const AgentRichTextEditor = forwardRef<
           ) {
             return false;
           }
-          const selection = readPromptSelection(currentEditor);
-          if (!selection.text) {
+          const clipboard = serializeAgentRichTextSelection(currentEditor);
+          if (!clipboard) {
             return false;
           }
-          event.clipboardData.setData("text/plain", selection.text);
+          event.clipboardData.setData("text/plain", clipboard.text);
+          event.clipboardData.setData("text/html", clipboard.html);
           event.preventDefault();
           return true;
         },
@@ -391,10 +394,12 @@ export const AgentRichTextEditor = forwardRef<
             return false;
           }
           const selection = readPromptSelection(currentEditor);
-          if (!selection.text) {
+          const clipboard = serializeAgentRichTextSelection(currentEditor);
+          if (!clipboard) {
             return false;
           }
-          event.clipboardData.setData("text/plain", selection.text);
+          event.clipboardData.setData("text/plain", clipboard.text);
+          event.clipboardData.setData("text/html", clipboard.html);
           event.preventDefault();
           currentEditor.commands.deleteRange({
             from: selection.from,
@@ -444,7 +449,15 @@ export const AgentRichTextEditor = forwardRef<
             return true;
           }
           if (textPasteKind === "structured-mention") {
-            return false;
+            event.preventDefault();
+            const currentEditor = editorRef.current;
+            if (!currentEditor) {
+              return true;
+            }
+            if (insertAgentRichTextClipboardHtml(currentEditor, html)) {
+              mentionSuggestionSuppression.suppressTextInsertion(text);
+            }
+            return true;
           }
           event.preventDefault();
           const currentEditor = editorRef.current;

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionAttrs.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionAttrs.ts
@@ -401,6 +401,12 @@ export function parseAgentMentionHTMLElementAttrs(
     node.getAttribute("name") ||
     (node.textContent ?? "").replace(/^@+/, "").trim();
   const parsedItem = href ? parseMentionItemFromHref({ name, href }) : null;
+  if (
+    node.getAttribute("data-agent-mention-kind") === "custom" &&
+    parsedItem?.kind !== "custom"
+  ) {
+    return false;
+  }
   const parsedAttrs = parsedItem ? mentionItemToAttrs(parsedItem) : {};
   const iconUrl = node.getAttribute("data-agent-mention-icon-url") || "";
   const fileCount = node.getAttribute("data-agent-mention-file-count") || "";

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextEditorSupport.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextEditorSupport.ts
@@ -1,5 +1,9 @@
 import { Extension, type Editor, type JSONContent } from "@tiptap/core";
-import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import {
+  DOMParser as ProseMirrorDOMParser,
+  DOMSerializer,
+  type Node as ProseMirrorNode
+} from "@tiptap/pm/model";
 import {
   Plugin,
   PluginKey,
@@ -23,6 +27,57 @@ export type AgentRichTextTextPasteKind =
   | "large-text"
   | "plain-text"
   | "structured-mention";
+
+export interface AgentRichTextClipboardPayload {
+  html: string;
+  text: string;
+}
+
+export function serializeAgentRichTextSelection(
+  editor: Editor
+): AgentRichTextClipboardPayload | null {
+  const selection = readPromptSelection(editor);
+  if (!selection.text) {
+    return null;
+  }
+  const slice = editor.state.doc.slice(selection.from, selection.to);
+  const wrapper = document.createElement("div");
+  wrapper.appendChild(
+    DOMSerializer.fromSchema(editor.schema).serializeFragment(slice.content)
+  );
+  return { html: wrapper.innerHTML, text: selection.text };
+}
+
+export function parseAgentRichTextClipboardHtml(
+  editor: Editor,
+  html: string
+): JSONContent[] | null {
+  if (!html.includes("data-agent-file-mention")) {
+    return null;
+  }
+  const wrapper = document.createElement("div");
+  wrapper.innerHTML = html;
+  const slice = ProseMirrorDOMParser.fromSchema(editor.schema).parseSlice(
+    wrapper,
+    { preserveWhitespace: true }
+  );
+  return slice.content.toJSON();
+}
+
+export function insertAgentRichTextClipboardHtml(
+  editor: Editor,
+  html: string
+): boolean {
+  if (!editor.isFocused) {
+    editor.commands.setTextSelection(editor.state.doc.content.size);
+  }
+  const content = parseAgentRichTextClipboardHtml(editor, html);
+  if (!content) {
+    return false;
+  }
+  editor.commands.insertContent(content);
+  return true;
+}
 
 export function classifyAgentRichTextTextPaste(
   text: string,

--- a/packages/agent/gui/shared/agentConversation/agentPlanPromptDispatch.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/agentPlanPromptDispatch.spec.ts
@@ -17,6 +17,20 @@ describe("dispatchAgentPlanPromptAction", () => {
       const engine = createAgentSessionEngine({
         clock: { nowUnixMs: () => 10 },
         commandPort: {
+          async executePlanDecision(command) {
+            executedTypes.push(command.type);
+            return {
+              operation: {
+                agentSessionId: command.agentSessionId,
+                idempotencyKey: command.idempotencyKey,
+                operationId: `operation:${command.commandId}`,
+                requestId: command.requestId,
+                status: "prepared",
+                turnId: command.turnId,
+                workspaceId: command.workspaceId
+              }
+            };
+          },
           async execute(command) {
             executedTypes.push(command.type);
           }


### PR DESCRIPTION
## Summary

- add a dedicated plan-decision command port that returns the Host's durable runtime operation
- require immutable sequence values on durable activity messages while keeping transient projections separate
- preserve built-in and registered custom AgentGUI mentions across copy, cut, and paste

## Tests

- `pnpm check:changed`
- `pnpm check:changed -- --push-ready` (20 lanes)

## Architecture

TSH and other Host consumers need these contracts. Lifecycle ownership stays in Tutti's Host/activity boundary; product repositories only implement transport adapters.

## Notes

- No E2E tests were run.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->