### PR TITLE
fix(release): raise desktop build heap limit

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -405,6 +405,7 @@ jobs:
         env:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          NODE_OPTIONS: --max-old-space-size=4096
         run: |
           if [[ "${TUTTI_DESKTOP_DRY_RUN}" == "true" ]]; then
             unset CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY APPLE_API_KEY_ID APPLE_API_ISSUER

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -652,6 +652,15 @@ test("desktop release workflow materializes macOS signing certificate before pac
   );
 });
 
+test("desktop release macOS builds reserve enough Node heap for the renderer bundle", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(
+    workflow,
+    /Build release artifacts[\s\S]*?NODE_OPTIONS:\s+--max-old-space-size=4096[\s\S]*?pnpm --filter @tutti-os\/desktop build:mac:signed/
+  );
+});
+
 test("desktop macOS packaging builds architecture-specific and universal artifacts", async () => {
   const buildScript = await readFile(buildScriptPath, "utf8");
   const claudeSidecarVendorScript = await readFile(


### PR DESCRIPTION
## Summary

- reserve a 4 GiB Node.js old-space heap for the macOS desktop release build step
- add a release workflow regression test that protects the heap setting

## Root cause

Desktop release run https://github.com/tutti-os/tutti/actions/runs/30246757970 failed for x64, arm64, and universal builds while Vite transformed the renderer bundle. The Mermaid renderer dependency graph increased the renderer build from roughly 5,700 to 7,776 modules, pushing Node 24 past the runner's approximately 2 GiB default V8 heap limit and terminating with exit code 134.

## Impact

Both signed and unsigned macOS release builds now run the existing packaging flow with a deterministic 4 GiB Node heap budget. Runtime behavior and packaging architecture are unchanged.

## Validation

- `node --test tools/scripts/desktop-release-config.test.mjs` — 39/39 passed
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @tutti-os/desktop build` — passed, 7,776 modules transformed
- `pnpm exec oxfmt --check tools/scripts/desktop-release-config.test.mjs` — passed
- workflow YAML parse — passed
- `git diff --check` — passed
- pre-push `check:changed -- --push-ready` — passed (5 lanes)
