### PR TITLE
revert(agent-gui): restore session input history

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -813,21 +813,20 @@ The editor recognizes stale controlled echoes from that transition so an older
 projection cannot overwrite newer local input; a value not emitted locally
 remains an authoritative external replacement.
 
-The mounted Agent GUI owns one in-memory composer input history store. The host
-must opt in explicitly; Desktop maps the default-off `lab.agentInputHistory`
-Lab preference to that capability. Every non-empty structured draft submitted
-while the GUI is open is appended, including equivalent consecutive inputs.
-The store is shared by the Home and Session composer presentations and is
-discarded when the Agent GUI closes.
-
-Bare Up/Down recalls older/newer structured drafts regardless of whether the
-composer currently has content, but only when the collapsed caret is at a
-whole-document boundary. Palette handling and IME composition take precedence.
-On first recall, the current structured draft is captured as the newest
-navigation entry, so moving past the newest submitted input restores the text
-and attachments that were being edited. Editing a recalled draft makes that
-edit the new current entry on the next recall. The history cursor is UI-local
-and resets when the draft Session scope changes.
+An existing-Session composer derives input history from that Session's
+canonical user-message projection; it does not persist a second history store.
+The host must opt in explicitly; Desktop maps the default-off
+`lab.agentInputHistory` Lab preference to that capability.
+Bare Up/Down recalls older/newer structured drafts only from an empty composer
+or an unchanged recalled entry, and only when the collapsed caret is at a
+whole-document boundary. Palette handling and IME composition take precedence,
+while editing a recalled draft exits history navigation. Moving past the newest
+entry clears the composer. Adjacent equivalent submissions collapse, persisted
+attachments are restored with exact workspace and Session identity, and
+reaching the oldest loaded entry requests the existing authoritative older-page
+read while preserving the timeline prepend scroll anchor. The history cursor
+is UI-local and resets when the draft Session scope changes; Home has no
+Session history.
 
 The dock observes geometry through one coalesced animation-frame measurement
 entry point. Editor document updates, attachment membership or intrinsic

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -81,6 +81,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   "use memo";
   const {
     workspaceId,
+    agentSessionId = null,
     workspacePath,
     currentUserId,
     provider,
@@ -88,7 +89,10 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     draftContent,
     engagement,
     draftScopeKey = "current",
-    inputHistoryStore,
+    inputHistory = [],
+    inputHistoryHasOlderPage = false,
+    inputHistoryIsLoadingOlderPage = false,
+    onRequestOlderInputHistoryPage,
     availableCommands,
     hasCompactableContext = true,
     compactSupported = null,
@@ -179,6 +183,34 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   };
   const [isPaletteOpen, setIsPaletteOpen] = useState(true);
   const [isReviewPickerOpen, setIsReviewPickerOpen] = useState(false);
+  const submitWithComposerModifiers: AgentComposerProps["onSubmit"] = (
+    content,
+    displayPrompt,
+    options
+  ) => {
+    onSubmit(
+      content,
+      displayPrompt,
+      withAgentComposerTuttiModeSnapshot({
+        options,
+        active: tuttiModeActive,
+        orchestrationIntensity: tuttiModeOrchestrationIntensity
+      })
+    );
+  };
+  const submitGuidanceWithComposerModifiers: NonNullable<
+    AgentComposerProps["onSubmitGuidance"]
+  > = (content, displayPrompt) => {
+    onSubmitGuidance?.(
+      content,
+      displayPrompt,
+      tuttiModeActive
+        ? {
+            capabilityRefs: [{ capability: "tutti", source: "slash_command" }]
+          }
+        : undefined
+    );
+  };
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [mentionHighlightedKey, setMentionHighlightedKey] = useState<
     string | null
@@ -219,52 +251,23 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     [draftScopeKey]: draftContent
   });
   draftByScopeKeyRef.current[draftScopeKey] = draftContent;
-  const { onHistoryNavigation, recordSubmittedDraft } = useComposerInputHistory(
-    {
-      currentDraft: draftContent,
-      draftByScopeKeyRef,
-      draftScopeKey,
-      inputHistoryStore,
-      onDraftContentChange
-    }
-  );
-  const submitWithComposerModifiers: AgentComposerProps["onSubmit"] = (
-    content,
-    displayPrompt,
-    options
-  ) => {
-    recordSubmittedDraft(
-      draftByScopeKeyRef.current[draftScopeKey] ?? draftContent
-    );
-    onSubmit(
-      content,
-      displayPrompt,
-      withAgentComposerTuttiModeSnapshot({
-        options,
-        active: tuttiModeActive,
-        orchestrationIntensity: tuttiModeOrchestrationIntensity
-      })
-    );
-  };
-  const submitGuidanceWithComposerModifiers: NonNullable<
-    AgentComposerProps["onSubmitGuidance"]
-  > = (content, displayPrompt) => {
-    if (!onSubmitGuidance) {
-      return;
-    }
-    recordSubmittedDraft(
-      draftByScopeKeyRef.current[draftScopeKey] ?? draftContent
-    );
-    onSubmitGuidance(
-      content,
-      displayPrompt,
-      tuttiModeActive
-        ? {
-            capabilityRefs: [{ capability: "tutti", source: "slash_command" }]
-          }
-        : undefined
-    );
-  };
+  const {
+    disposeInputHistory,
+    onHistoryNavigation,
+    settlePendingInputHistory
+  } = useComposerInputHistory({
+    agentSessionId,
+    currentDraft: draftContent,
+    draftByScopeKeyRef,
+    draftScopeKey,
+    entries: inputHistory,
+    hasOlderPage: inputHistoryHasOlderPage,
+    isLoadingOlderPage: inputHistoryIsLoadingOlderPage,
+    onDraftContentChange,
+    onRequestOlderPage: onRequestOlderInputHistoryPage,
+    runtime: agentActivityRuntime,
+    workspaceId
+  });
   const promptTipRef = useRef<HTMLSpanElement | null>(null);
   const { mentionControllerRef, mentionSearchState } =
     useAgentMentionSearchController(referenceProvenanceFilters);
@@ -378,6 +381,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     const isExternalDraftReplacement = draftPromptRef.current !== draftPrompt;
     draftPromptRef.current = draftPrompt;
     setPaletteDraftPrompt(goalDraftObjective ?? draftPrompt);
+    settlePendingInputHistory();
     if (isExternalDraftReplacement && draftPrompt) {
       window.requestAnimationFrame(() => {
         window.requestAnimationFrame(() => {
@@ -387,17 +391,23 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
         });
       });
     }
-  }, [draftContent, draftPrompt, goalDraftObjective]);
+  }, [
+    draftContent,
+    draftPrompt,
+    goalDraftObjective,
+    settlePendingInputHistory
+  ]);
 
   useEffect(() => {
     if (
       previousSlashStatusAgentSessionIdRef.current === slashStatusAgentSessionId
     ) {
-      return;
+      return disposeInputHistory;
     }
     previousSlashStatusAgentSessionIdRef.current = slashStatusAgentSessionId;
     setIsSlashStatusPanelOpen(false);
-  }, [draftScopeKey, slashStatusAgentSessionId]);
+    return disposeInputHistory;
+  }, [disposeInputHistory, draftScopeKey, slashStatusAgentSessionId]);
 
   const slashActions = useComposerSlashActions({
     workspaceId,

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -27,7 +27,7 @@ import type {
 } from "@tutti-os/workspace-file-reference/react";
 import type { AgentQuickPromptLabels } from "./quickPrompts/agentQuickPromptLabels";
 import type { AgentMentionFilterId } from "../AgentMentionSearchContracts";
-import type { AgentComposerInputHistoryStore } from "../model/agentComposerInputHistory";
+import type { AgentComposerInputHistoryEntry } from "../model/agentComposerInputHistory";
 
 export interface AgentComposerReferenceProvenanceFilter {
   snapshot: ReferenceProvenanceFilterSnapshot;
@@ -77,7 +77,10 @@ export interface AgentComposerProps {
   engagement?: AgentGUIComposerEngagement;
   /** Stable project/session owner for async draft attachment work. */
   draftScopeKey?: string;
-  inputHistoryStore?: AgentComposerInputHistoryStore;
+  inputHistory?: readonly AgentComposerInputHistoryEntry[];
+  inputHistoryHasOlderPage?: boolean;
+  inputHistoryIsLoadingOlderPage?: boolean;
+  onRequestOlderInputHistoryPage?: () => void;
   availableCommands: readonly AgentSessionCommand[];
   hasCompactableContext?: boolean;
   compactSupported?: boolean | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerInputHistory.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerInputHistory.spec.tsx
@@ -1,75 +1,170 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
-  agentComposerDraftPrompt,
   buildAgentComposerDraft,
   emptyAgentComposerDraft
 } from "../model/agentComposerDraft";
-import { createAgentComposerInputHistoryStore } from "../model/agentComposerInputHistory";
+import type { AgentComposerInputHistoryEntry } from "../model/agentComposerInputHistory";
 import { useComposerInputHistory } from "./useComposerInputHistory";
 
 describe("useComposerInputHistory", () => {
-  it("records submissions and supports repeated navigation before rerender", () => {
+  it("supports repeated Up presses before the controlled draft rerenders", () => {
     const onDraftContentChange = vi.fn();
-    const inputHistoryStore = createAgentComposerInputHistoryStore();
+    const entries = historyEntries("one", "two");
     const draftByScopeKeyRef = {
-      current: {
-        "session:session-1": buildAgentComposerDraft({
-          prompt: "current draft"
-        })
-      }
+      current: { "session:session-1": emptyAgentComposerDraft() }
     };
     const { result } = renderHook(() =>
       useComposerInputHistory({
-        currentDraft: draftByScopeKeyRef.current["session:session-1"],
-        draftByScopeKeyRef,
-        draftScopeKey: "session:session-1",
-        inputHistoryStore,
-        onDraftContentChange
-      })
-    );
-
-    act(() => {
-      result.current.recordSubmittedDraft(
-        buildAgentComposerDraft({ prompt: "one" })
-      );
-      result.current.recordSubmittedDraft(
-        buildAgentComposerDraft({ prompt: "two" })
-      );
-      expect(result.current.onHistoryNavigation("older")).toBe(true);
-      expect(result.current.onHistoryNavigation("older")).toBe(true);
-      expect(result.current.onHistoryNavigation("newer")).toBe(true);
-      expect(result.current.onHistoryNavigation("newer")).toBe(true);
-    });
-
-    expect(
-      onDraftContentChange.mock.calls.map(([draft]) =>
-        agentComposerDraftPrompt(draft)
-      )
-    ).toEqual(["two", "one", "two", "current draft"]);
-  });
-
-  it("is inert when the host has not enabled input history", () => {
-    const onDraftContentChange = vi.fn();
-    const draftByScopeKeyRef = {
-      current: { current: emptyAgentComposerDraft() }
-    };
-    const { result } = renderHook(() =>
-      useComposerInputHistory({
+        agentSessionId: "session-1",
         currentDraft: emptyAgentComposerDraft(),
         draftByScopeKeyRef,
-        draftScopeKey: "current",
-        onDraftContentChange
+        draftScopeKey: "session:session-1",
+        entries,
+        hasOlderPage: false,
+        isLoadingOlderPage: false,
+        onDraftContentChange,
+        runtime: null,
+        workspaceId: "workspace-1"
       })
     );
 
     act(() => {
-      result.current.recordSubmittedDraft(
-        buildAgentComposerDraft({ prompt: "one" })
-      );
-      expect(result.current.onHistoryNavigation("older")).toBe(false);
+      expect(result.current.onHistoryNavigation("older")).toBe(true);
+      expect(result.current.onHistoryNavigation("older")).toBe(true);
     });
 
-    expect(onDraftContentChange).not.toHaveBeenCalled();
+    expect(onDraftContentChange).toHaveBeenNthCalledWith(
+      1,
+      entries[1]!.draft,
+      "session:session-1"
+    );
+    expect(onDraftContentChange).toHaveBeenNthCalledWith(
+      2,
+      entries[0]!.draft,
+      "session:session-1"
+    );
+  });
+
+  it("recalls the next older entry after an older page is prepended", () => {
+    const onDraftContentChange = vi.fn();
+    const onRequestOlderPage = vi.fn();
+    const current = historyEntries("current")[0]!;
+    const older = historyEntries("older")[0]!;
+    const draftByScopeKeyRef = {
+      current: { "session:session-1": emptyAgentComposerDraft() }
+    };
+    const { result, rerender } = renderHook(
+      ({ currentDraft, entries }) => {
+        draftByScopeKeyRef.current["session:session-1"] = currentDraft;
+        return useComposerInputHistory({
+          agentSessionId: "session-1",
+          currentDraft,
+          draftByScopeKeyRef,
+          draftScopeKey: "session:session-1",
+          entries,
+          hasOlderPage: true,
+          isLoadingOlderPage: false,
+          onDraftContentChange,
+          onRequestOlderPage,
+          runtime: null,
+          workspaceId: "workspace-1"
+        });
+      },
+      {
+        initialProps: {
+          currentDraft: emptyAgentComposerDraft(),
+          entries: [current]
+        }
+      }
+    );
+
+    act(() => {
+      result.current.onHistoryNavigation("older");
+      result.current.onHistoryNavigation("older");
+    });
+    expect(onRequestOlderPage).toHaveBeenCalledOnce();
+
+    rerender({
+      currentDraft: current.draft,
+      entries: [older, current]
+    });
+    act(() => {
+      result.current.settlePendingInputHistory();
+    });
+
+    expect(onDraftContentChange).toHaveBeenLastCalledWith(
+      older.draft,
+      "session:session-1"
+    );
+  });
+
+  it("does not overwrite edits made while an older page is loading", () => {
+    const onDraftContentChange = vi.fn();
+    const onRequestOlderPage = vi.fn();
+    const current = historyEntries("current")[0]!;
+    const older = historyEntries("older")[0]!;
+    const editedDraft = buildAgentComposerDraft({ prompt: "edited" });
+    const draftByScopeKeyRef = {
+      current: { "session:session-1": emptyAgentComposerDraft() }
+    };
+    const { result, rerender } = renderHook(
+      ({ currentDraft, entries, isLoadingOlderPage }) => {
+        draftByScopeKeyRef.current["session:session-1"] = currentDraft;
+        return useComposerInputHistory({
+          agentSessionId: "session-1",
+          currentDraft,
+          draftByScopeKeyRef,
+          draftScopeKey: "session:session-1",
+          entries,
+          hasOlderPage: true,
+          isLoadingOlderPage,
+          onDraftContentChange,
+          onRequestOlderPage,
+          runtime: null,
+          workspaceId: "workspace-1"
+        });
+      },
+      {
+        initialProps: {
+          currentDraft: emptyAgentComposerDraft(),
+          entries: [current],
+          isLoadingOlderPage: false
+        }
+      }
+    );
+
+    act(() => {
+      result.current.onHistoryNavigation("older");
+      result.current.onHistoryNavigation("older");
+    });
+    rerender({
+      currentDraft: editedDraft,
+      entries: [current],
+      isLoadingOlderPage: true
+    });
+    rerender({
+      currentDraft: editedDraft,
+      entries: [older, current],
+      isLoadingOlderPage: false
+    });
+    act(() => {
+      result.current.settlePendingInputHistory();
+    });
+
+    expect(onDraftContentChange).toHaveBeenCalledOnce();
+    expect(onDraftContentChange).toHaveBeenLastCalledWith(
+      current.draft,
+      "session:session-1"
+    );
   });
 });
+
+function historyEntries(
+  ...prompts: string[]
+): AgentComposerInputHistoryEntry[] {
+  return prompts.map((prompt) => ({
+    id: prompt,
+    draft: buildAgentComposerDraft({ prompt })
+  }));
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerInputHistory.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerInputHistory.ts
@@ -1,79 +1,203 @@
 import { useCallback, useRef, type RefObject } from "react";
+import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import type { AgentComposerDraft } from "../model/agentGuiNodeTypes";
-import { snapshotAgentComposerDraft } from "../model/agentComposerDraft";
 import {
+  agentComposerDraftHasContent,
+  agentComposerDraftImages,
+  snapshotAgentComposerDraft,
+  updateAgentComposerDraft
+} from "../model/agentComposerDraft";
+import {
+  areAgentComposerHistoryDraftsEqual,
   EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE,
   navigateAgentComposerInputHistory,
-  recordAgentComposerInputHistory,
-  type AgentComposerInputHistoryState,
-  type AgentComposerInputHistoryStore
+  resolvePendingAgentComposerInputHistory,
+  type AgentComposerInputHistoryEntry,
+  type AgentComposerInputHistoryState
 } from "../model/agentComposerInputHistory";
+import { QueuedPromptImageLoadOwner } from "../queuedPromptImageLoadOwner";
 
 interface Input {
+  agentSessionId: string | null;
   currentDraft: AgentComposerDraft;
   draftByScopeKeyRef: RefObject<Record<string, AgentComposerDraft>>;
   draftScopeKey: string;
-  inputHistoryStore?: AgentComposerInputHistoryStore;
+  entries: readonly AgentComposerInputHistoryEntry[];
+  hasOlderPage: boolean;
+  isLoadingOlderPage: boolean;
   onDraftContentChange: (
     draft: AgentComposerDraft,
     sourceScopeKey?: string
   ) => void;
+  onRequestOlderPage?: () => void;
+  runtime: AgentActivityRuntime | null;
+  workspaceId: string;
 }
 
 export function useComposerInputHistory(input: Input): {
+  disposeInputHistory: () => void;
   onHistoryNavigation: (direction: "older" | "newer") => boolean;
-  recordSubmittedDraft: (draft: AgentComposerDraft) => void;
+  settlePendingInputHistory: () => void;
 } {
   const cursorRef = useRef<AgentComposerInputHistoryState>(
     EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
   );
   const ownerScopeRef = useRef(input.draftScopeKey);
-  const ownerStoreRef = useRef(input.inputHistoryStore);
-  if (
-    ownerScopeRef.current !== input.draftScopeKey ||
-    ownerStoreRef.current !== input.inputHistoryStore
-  ) {
+  const imageOwnersRef = useRef<QueuedPromptImageLoadOwner[]>([]);
+
+  const disposeInputHistory = useCallback(() => {
+    for (const owner of imageOwnersRef.current) {
+      owner.dispose();
+    }
+    imageOwnersRef.current = [];
+  }, []);
+  if (ownerScopeRef.current !== input.draftScopeKey) {
     ownerScopeRef.current = input.draftScopeKey;
-    ownerStoreRef.current = input.inputHistoryStore;
     cursorRef.current = EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE;
+    disposeInputHistory();
   }
 
   const restoreDraft = useCallback(
-    (draft: AgentComposerDraft) => {
+    (draft: AgentComposerDraft, entryId: string | null) => {
+      disposeInputHistory();
       const restoredDraft = snapshotAgentComposerDraft(draft);
       input.draftByScopeKeyRef.current[input.draftScopeKey] = restoredDraft;
       input.onDraftContentChange(restoredDraft, input.draftScopeKey);
-    },
-    [input.draftByScopeKeyRef, input.draftScopeKey, input.onDraftContentChange]
-  );
-
-  const recordSubmittedDraft = useCallback(
-    (draft: AgentComposerDraft): void => {
-      if (!input.inputHistoryStore) {
+      if (!input.runtime || !input.agentSessionId || !entryId) {
         return;
       }
-      recordAgentComposerInputHistory(input.inputHistoryStore, draft);
-      cursorRef.current = EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE;
+      for (const restoredImage of agentComposerDraftImages(restoredDraft)) {
+        const attachmentId = restoredImage.attachmentId?.trim() ?? "";
+        const path = restoredImage.path?.trim() ?? "";
+        if (restoredImage.previewUrl || (!attachmentId && !path)) {
+          continue;
+        }
+        const owner = new QueuedPromptImageLoadOwner(
+          {
+            agentSessionId: input.agentSessionId,
+            attachmentId,
+            imageKey: restoredImage.id,
+            mimeType: restoredImage.mimeType,
+            name: restoredImage.name,
+            path,
+            remoteUrl: restoredImage.url?.trim() ?? "",
+            runtime: input.runtime,
+            workspaceId: input.workspaceId
+          },
+          (source) => {
+            if (
+              !source ||
+              cursorRef.current.entryId !== entryId ||
+              ownerScopeRef.current !== input.draftScopeKey
+            ) {
+              return;
+            }
+            const currentDraft =
+              input.draftByScopeKeyRef.current[input.draftScopeKey];
+            if (!currentDraft) {
+              return;
+            }
+            let updated = false;
+            const images = agentComposerDraftImages(currentDraft).map(
+              (currentImage) => {
+                if (
+                  currentImage.id !== restoredImage.id ||
+                  currentImage.previewUrl ||
+                  currentImage.attachmentId !== restoredImage.attachmentId ||
+                  currentImage.path !== restoredImage.path ||
+                  currentImage.url !== restoredImage.url
+                ) {
+                  return currentImage;
+                }
+                updated = true;
+                return { ...currentImage, previewUrl: source };
+              }
+            );
+            if (updated) {
+              const updatedDraft = updateAgentComposerDraft(currentDraft, {
+                images
+              });
+              input.draftByScopeKeyRef.current[input.draftScopeKey] =
+                updatedDraft;
+              input.onDraftContentChange(updatedDraft, input.draftScopeKey);
+            }
+          }
+        );
+        imageOwnersRef.current.push(owner);
+        owner.start();
+      }
     },
-    [input.inputHistoryStore]
+    [
+      disposeInputHistory,
+      input.agentSessionId,
+      input.draftByScopeKeyRef,
+      input.draftScopeKey,
+      input.onDraftContentChange,
+      input.runtime,
+      input.workspaceId
+    ]
   );
+
+  const settlePendingInputHistory = useCallback(() => {
+    if (input.isLoadingOlderPage) {
+      return;
+    }
+    const pendingEntryId = cursorRef.current.pendingOlderPage
+      ? cursorRef.current.entryId
+      : null;
+    const pendingEntry = pendingEntryId
+      ? input.entries.find((entry) => entry.id === pendingEntryId)
+      : null;
+    const currentDraft =
+      input.draftByScopeKeyRef.current[input.draftScopeKey] ??
+      input.currentDraft;
+    if (
+      cursorRef.current.pendingOlderPage &&
+      (pendingEntry
+        ? !areAgentComposerHistoryDraftsEqual(currentDraft, pendingEntry.draft)
+        : agentComposerDraftHasContent(currentDraft))
+    ) {
+      cursorRef.current = EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE;
+      return;
+    }
+    const resolved = resolvePendingAgentComposerInputHistory({
+      entries: input.entries,
+      state: cursorRef.current
+    });
+    if (!resolved) {
+      return;
+    }
+    cursorRef.current = resolved.state;
+    if (resolved.draft) {
+      restoreDraft(resolved.draft, resolved.state.entryId);
+    }
+  }, [
+    input.currentDraft,
+    input.draftByScopeKeyRef,
+    input.draftScopeKey,
+    input.entries,
+    input.isLoadingOlderPage,
+    restoreDraft
+  ]);
 
   const onHistoryNavigation = useCallback(
     (direction: "older" | "newer"): boolean => {
-      if (!input.inputHistoryStore) {
-        return false;
-      }
+      settlePendingInputHistory();
       const navigation = navigateAgentComposerInputHistory({
         currentDraft:
           input.draftByScopeKeyRef.current[input.draftScopeKey] ??
           input.currentDraft,
         direction,
-        entries: input.inputHistoryStore.entries,
+        entries: input.entries,
+        hasOlderPage: input.hasOlderPage,
         state: cursorRef.current
       });
       cursorRef.current = navigation.state;
       if (navigation.draft) {
-        restoreDraft(navigation.draft);
+        restoreDraft(navigation.draft, navigation.state.entryId);
+      }
+      if (navigation.requestOlderPage) {
+        input.onRequestOlderPage?.();
       }
       return navigation.handled;
     },
@@ -81,13 +205,17 @@ export function useComposerInputHistory(input: Input): {
       input.currentDraft,
       input.draftByScopeKeyRef,
       input.draftScopeKey,
-      input.inputHistoryStore,
-      restoreDraft
+      input.entries,
+      input.hasOlderPage,
+      input.onRequestOlderPage,
+      restoreDraft,
+      settlePendingInputHistory
     ]
   );
 
   return {
+    disposeInputHistory,
     onHistoryNavigation,
-    recordSubmittedDraft
+    settlePendingInputHistory
   };
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts
@@ -1,121 +1,379 @@
 import { describe, expect, it } from "vitest";
+import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
 import {
+  agentComposerDraftFiles,
+  agentComposerDraftImages,
+  agentComposerDraftLargeTexts,
   agentComposerDraftPrompt,
+  agentComposerDraftToPromptContent,
   buildAgentComposerDraft,
   emptyAgentComposerDraft
 } from "./agentComposerDraft";
+import { createAgentComposerFileMentionMarkdown } from "../agentRichText/agentMentionMarkdown";
 import {
-  createAgentComposerInputHistoryStore,
   EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE,
   navigateAgentComposerInputHistory,
-  recordAgentComposerInputHistory
+  projectAgentComposerInputHistory,
+  resolvePendingAgentComposerInputHistory
 } from "./agentComposerInputHistory";
 
 describe("agent composer input history", () => {
-  it("records every non-empty submission made while the store is alive", () => {
-    const store = createAgentComposerInputHistoryStore();
-    const firstDraft = buildAgentComposerDraft({ prompt: "repeat" });
-
-    expect(recordAgentComposerInputHistory(store, firstDraft)).toBe(true);
-    expect(recordAgentComposerInputHistory(store, firstDraft)).toBe(true);
-    expect(
-      recordAgentComposerInputHistory(store, emptyAgentComposerDraft())
-    ).toBe(false);
-
-    firstDraft[0].text = "changed later";
-    expect(store.entries.map((entry) => entry.id)).toEqual([
-      "open:1",
-      "open:2"
+  it("projects structured user input and keeps the newest adjacent duplicate", () => {
+    const conversation = conversationWithUserMessages([
+      {
+        id: "message-1",
+        body: "expanded prompt",
+        sourceTimelineItems: [
+          {
+            payload: {
+              content: [
+                { type: "text", text: "expanded prompt" },
+                {
+                  type: "image",
+                  attachmentId: "attachment-1",
+                  mimeType: "image/png",
+                  name: "one.png"
+                }
+              ],
+              displayPrompt: "original prompt"
+            }
+          }
+        ]
+      },
+      {
+        id: "message-2",
+        body: "original prompt",
+        sourceTimelineItems: [
+          {
+            payload: {
+              content: [
+                { type: "text", text: "expanded prompt" },
+                {
+                  type: "image",
+                  attachmentId: "attachment-1",
+                  mimeType: "image/png",
+                  name: "one.png"
+                }
+              ],
+              displayPrompt: "original prompt"
+            }
+          }
+        ]
+      }
     ]);
-    expect(
-      store.entries.map((entry) => agentComposerDraftPrompt(entry.draft))
-    ).toEqual(["repeat", "repeat"]);
+
+    const history = projectAgentComposerInputHistory(conversation);
+
+    expect(history).toHaveLength(1);
+    expect(history[0]!.id).toBe("turn-1:message-2");
+    expect(agentComposerDraftPrompt(history[0]!.draft)).toBe("expanded prompt");
+    expect(agentComposerDraftImages(history[0]!.draft)).toEqual([
+      expect.objectContaining({
+        attachmentId: "attachment-1",
+        previewUrl: ""
+      })
+    ]);
   });
 
-  it("navigates history from a non-empty draft and restores it after newest", () => {
+  it("does not restore a synthetic image-only display prompt as text", () => {
+    const history = projectAgentComposerInputHistory(
+      conversationWithUserMessages([
+        {
+          id: "image-message",
+          body: "[Image]",
+          sourceTimelineItems: [
+            {
+              payload: {
+                content: [
+                  {
+                    type: "image",
+                    path: "/tmp/image.png",
+                    mimeType: "image/png"
+                  }
+                ],
+                displayPrompt: "[Image]"
+              }
+            }
+          ]
+        }
+      ])
+    );
+
+    expect(agentComposerDraftPrompt(history[0]!.draft)).toBe("");
+    expect(agentComposerDraftImages(history[0]!.draft)).toHaveLength(1);
+  });
+
+  it("restores a file-only structured input with a resendable mention", () => {
+    const displayPrompt = createAgentComposerFileMentionMarkdown({
+      id: "original-file",
+      name: "report.pdf",
+      status: "ready"
+    });
+    const history = projectAgentComposerInputHistory(
+      conversationWithUserMessages([
+        {
+          id: "file-message",
+          body: displayPrompt,
+          sourceTimelineItems: [
+            {
+              payload: {
+                content: [
+                  {
+                    type: "file",
+                    kind: "file",
+                    name: "report.pdf",
+                    path: "/runtime/report.pdf"
+                  }
+                ],
+                displayPrompt
+              }
+            }
+          ]
+        }
+      ])
+    );
+
+    expect(history).toHaveLength(1);
+    expect(agentComposerDraftFiles(history[0]!.draft)).toHaveLength(1);
+    expect(
+      agentComposerDraftToPromptContent({
+        draft: history[0]!.draft,
+        skills: []
+      })
+    ).toEqual([
+      {
+        type: "text",
+        text: "[@report.pdf](/runtime/report.pdf)"
+      }
+    ]);
+  });
+
+  it("restores mixed text and file input without dropping the file on resend", () => {
+    const fileMention = createAgentComposerFileMentionMarkdown({
+      id: "original-file",
+      name: "report.pdf",
+      status: "ready"
+    });
+    const history = projectAgentComposerInputHistory(
+      conversationWithUserMessages([
+        {
+          id: "mixed-message",
+          body: `Summarize${fileMention}`,
+          sourceTimelineItems: [
+            {
+              payload: {
+                content: [
+                  { type: "text", text: "Summarize" },
+                  {
+                    type: "file",
+                    kind: "file",
+                    name: "report.pdf",
+                    path: "/runtime/report.pdf"
+                  }
+                ],
+                displayPrompt: `Summarize${fileMention}`
+              }
+            }
+          ]
+        }
+      ])
+    );
+
+    expect(agentComposerDraftFiles(history[0]!.draft)).toHaveLength(1);
+    expect(
+      agentComposerDraftToPromptContent({
+        draft: history[0]!.draft,
+        skills: []
+      })
+    ).toEqual([
+      {
+        type: "text",
+        text: "Summarize[@report.pdf](/runtime/report.pdf)"
+      }
+    ]);
+  });
+
+  it("restores pasted text without resending its display mention as text", () => {
+    const history = projectAgentComposerInputHistory(
+      conversationWithUserMessages([
+        {
+          id: "pasted-text-message",
+          body: "Summarize this",
+          sourceTimelineItems: [
+            {
+              payload: {
+                content: [
+                  { type: "text", text: "Summarize this" },
+                  {
+                    type: "file",
+                    kind: "pasted-text",
+                    name: "first line…",
+                    path: "/archive/aa/deadbeef.txt",
+                    sizeBytes: 22
+                  }
+                ],
+                displayPrompt:
+                  "Summarize this\n[@first line…](mention://pasted-text/original-paste?path=%2Farchive%2Faa%2Fdeadbeef.txt&size=22)"
+              }
+            }
+          ]
+        }
+      ])
+    );
+
+    expect(agentComposerDraftLargeTexts(history[0]!.draft)).toHaveLength(1);
+    expect(
+      agentComposerDraftToPromptContent({
+        draft: history[0]!.draft,
+        skills: []
+      })
+    ).toEqual([
+      { type: "text", text: "Summarize this" },
+      {
+        type: "file",
+        kind: "pasted-text",
+        name: "first line…",
+        path: "/archive/aa/deadbeef.txt",
+        sizeBytes: 22
+      }
+    ]);
+  });
+
+  it("navigates from empty to older entries and clears past the newest", () => {
     const entries = [
       { id: "one", draft: buildAgentComposerDraft({ prompt: "one" }) },
       { id: "two", draft: buildAgentComposerDraft({ prompt: "two" }) }
     ];
-    const typedDraft = buildAgentComposerDraft({ prompt: "typing now" });
     const latest = navigateAgentComposerInputHistory({
-      currentDraft: typedDraft,
+      currentDraft: emptyAgentComposerDraft(),
       direction: "older",
       entries,
+      hasOlderPage: false,
       state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
     });
     const older = navigateAgentComposerInputHistory({
       currentDraft: latest.draft!,
       direction: "older",
       entries,
+      hasOlderPage: false,
       state: latest.state
     });
     const newer = navigateAgentComposerInputHistory({
       currentDraft: older.draft!,
       direction: "newer",
       entries,
+      hasOlderPage: false,
       state: older.state
     });
-    const current = navigateAgentComposerInputHistory({
+    const cleared = navigateAgentComposerInputHistory({
       currentDraft: newer.draft!,
       direction: "newer",
       entries,
+      hasOlderPage: false,
       state: newer.state
     });
 
     expect(agentComposerDraftPrompt(latest.draft!)).toBe("two");
     expect(agentComposerDraftPrompt(older.draft!)).toBe("one");
     expect(agentComposerDraftPrompt(newer.draft!)).toBe("two");
-    expect(agentComposerDraftPrompt(current.draft!)).toBe("typing now");
-    expect(current.state).toBe(EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE);
+    expect(cleared.state.entryId).toBeNull();
+    expect(agentComposerDraftPrompt(cleared.draft!)).toBe("");
   });
 
-  it("restores an empty current draft after moving past the newest entry", () => {
-    const entry = {
-      id: "one",
-      draft: buildAgentComposerDraft({ prompt: "one" })
-    };
-    const recalled = navigateAgentComposerInputHistory({
-      currentDraft: emptyAgentComposerDraft(),
-      direction: "older",
-      entries: [entry],
-      state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
-    });
-    const current = navigateAgentComposerInputHistory({
-      currentDraft: recalled.draft!,
-      direction: "newer",
-      entries: [entry],
-      state: recalled.state
-    });
+  it("leaves a typed or edited draft to normal arrow-key behavior", () => {
+    const entries = [
+      { id: "one", draft: buildAgentComposerDraft({ prompt: "one" }) }
+    ];
 
-    expect(agentComposerDraftPrompt(current.draft!)).toBe("");
+    expect(
+      navigateAgentComposerInputHistory({
+        currentDraft: buildAgentComposerDraft({ prompt: "typed" }),
+        direction: "older",
+        entries,
+        hasOlderPage: false,
+        state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
+      }).handled
+    ).toBe(false);
+    expect(
+      navigateAgentComposerInputHistory({
+        currentDraft: buildAgentComposerDraft({ prompt: "edited" }),
+        direction: "older",
+        entries,
+        hasOlderPage: false,
+        state: { entryId: "one", pendingOlderPage: false }
+      })
+    ).toMatchObject({
+      handled: false,
+      state: { entryId: null }
+    });
   });
 
-  it("treats an edited recalled entry as the new current draft", () => {
+  it("starts again from the newest entry after a recalled draft is cleared", () => {
     const entries = [
       { id: "one", draft: buildAgentComposerDraft({ prompt: "one" }) },
       { id: "two", draft: buildAgentComposerDraft({ prompt: "two" }) }
     ];
-    const recalled = navigateAgentComposerInputHistory({
-      currentDraft: buildAgentComposerDraft({ prompt: "initial current" }),
+
+    const navigation = navigateAgentComposerInputHistory({
+      currentDraft: emptyAgentComposerDraft(),
       direction: "older",
       entries,
-      state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
-    });
-    const restarted = navigateAgentComposerInputHistory({
-      currentDraft: buildAgentComposerDraft({ prompt: "edited recall" }),
-      direction: "older",
-      entries,
-      state: recalled.state
-    });
-    const current = navigateAgentComposerInputHistory({
-      currentDraft: restarted.draft!,
-      direction: "newer",
-      entries,
-      state: restarted.state
+      hasOlderPage: false,
+      state: { entryId: "one", pendingOlderPage: false }
     });
 
-    expect(agentComposerDraftPrompt(restarted.draft!)).toBe("two");
-    expect(agentComposerDraftPrompt(current.draft!)).toBe("edited recall");
+    expect(navigation.state.entryId).toBe("two");
+    expect(agentComposerDraftPrompt(navigation.draft!)).toBe("two");
+  });
+
+  it("requests an older page and resolves to the prepended entry", () => {
+    const current = {
+      id: "current",
+      draft: buildAgentComposerDraft({ prompt: "current" })
+    };
+    const pending = navigateAgentComposerInputHistory({
+      currentDraft: current.draft,
+      direction: "older",
+      entries: [current],
+      hasOlderPage: true,
+      state: { entryId: current.id, pendingOlderPage: false }
+    });
+    const older = {
+      id: "older",
+      draft: buildAgentComposerDraft({ prompt: "older" })
+    };
+    const resolved = resolvePendingAgentComposerInputHistory({
+      entries: [older, current],
+      state: pending.state
+    });
+
+    expect(pending).toMatchObject({
+      handled: true,
+      requestOlderPage: true,
+      state: { pendingOlderPage: true }
+    });
+    expect(resolved?.state.entryId).toBe("older");
+    expect(agentComposerDraftPrompt(resolved!.draft!)).toBe("older");
   });
 });
+
+function conversationWithUserMessages(
+  messages: Array<{
+    id: string;
+    body: string;
+    sourceTimelineItems?: Array<{
+      payload: Record<string, unknown>;
+    }>;
+  }>
+): AgentConversationVM {
+  return {
+    sourceDetail: {
+      turns: [
+        {
+          id: "turn-1",
+          userMessages: messages
+        }
+      ]
+    }
+  } as unknown as AgentConversationVM;
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.ts
@@ -1,7 +1,11 @@
+import type { AgentPromptContentBlock } from "../../../shared/contracts/dto";
+import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
 import type { AgentComposerDraft } from "./agentGuiNodeTypes";
 import {
   agentComposerDraftHasContent,
-  snapshotAgentComposerDraft
+  agentPromptContentToComposerDraft,
+  buildAgentComposerDraft,
+  emptyAgentComposerDraft
 } from "./agentComposerDraft";
 
 export interface AgentComposerInputHistoryEntry {
@@ -9,60 +13,73 @@ export interface AgentComposerInputHistoryEntry {
   draft: AgentComposerDraft;
 }
 
-export interface AgentComposerInputHistoryStore {
-  entries: AgentComposerInputHistoryEntry[];
-  nextEntryId: number;
-}
-
 export interface AgentComposerInputHistoryState {
   entryId: string | null;
-  currentDraft: AgentComposerDraft | null;
+  pendingOlderPage: boolean;
 }
 
 export interface AgentComposerInputHistoryNavigation {
   draft?: AgentComposerDraft;
   handled: boolean;
+  requestOlderPage: boolean;
   state: AgentComposerInputHistoryState;
 }
 
 export const EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE: AgentComposerInputHistoryState =
   {
     entryId: null,
-    currentDraft: null
+    pendingOlderPage: false
   };
 
-export function createAgentComposerInputHistoryStore(): AgentComposerInputHistoryStore {
-  return {
-    entries: [],
-    nextEntryId: 1
-  };
-}
+const inputHistoryByConversation = new WeakMap<
+  AgentConversationVM,
+  AgentComposerInputHistoryEntry[]
+>();
 
-export function recordAgentComposerInputHistory(
-  store: AgentComposerInputHistoryStore,
-  draft: AgentComposerDraft
-): boolean {
-  if (!agentComposerDraftHasContent(draft)) {
-    return false;
+export function projectAgentComposerInputHistory(
+  conversation: AgentConversationVM | null
+): AgentComposerInputHistoryEntry[] {
+  if (!conversation) {
+    return [];
   }
-  store.entries.push({
-    id: `open:${store.nextEntryId}`,
-    draft: snapshotAgentComposerDraft(draft)
-  });
-  store.nextEntryId += 1;
-  return true;
+  const cached = inputHistoryByConversation.get(conversation);
+  if (cached) {
+    return cached;
+  }
+  const entries: AgentComposerInputHistoryEntry[] = [];
+  for (const turn of conversation.sourceDetail.turns) {
+    for (const message of turn.userMessages) {
+      const entry = projectHistoryEntry(message, turn.id);
+      if (!entry) {
+        continue;
+      }
+      const previous = entries.at(-1);
+      if (
+        previous &&
+        historyEntryDuplicateKey(previous) === historyEntryDuplicateKey(entry)
+      ) {
+        // Keep the newest duplicate id. Prepending an older page then cannot
+        // invalidate a cursor that already points at the loaded copy.
+        entries[entries.length - 1] = entry;
+      } else {
+        entries.push(entry);
+      }
+    }
+  }
+  inputHistoryByConversation.set(conversation, entries);
+  return entries;
 }
 
 export function navigateAgentComposerInputHistory(input: {
   currentDraft: AgentComposerDraft;
   direction: "older" | "newer";
   entries: readonly AgentComposerInputHistoryEntry[];
+  hasOlderPage: boolean;
   state: AgentComposerInputHistoryState;
 }): AgentComposerInputHistoryNavigation {
   let currentIndex = input.state.entryId
     ? input.entries.findIndex((entry) => entry.id === input.state.entryId)
     : -1;
-  let currentDraft = input.state.currentDraft;
   if (
     input.state.entryId &&
     (currentIndex < 0 ||
@@ -71,44 +88,84 @@ export function navigateAgentComposerInputHistory(input: {
         input.entries[currentIndex]!.draft
       ))
   ) {
+    if (agentComposerDraftHasContent(input.currentDraft)) {
+      return unhandledHistoryNavigation();
+    }
     currentIndex = -1;
-    currentDraft = null;
   }
 
   if (currentIndex < 0) {
-    if (input.direction === "newer") {
+    if (
+      input.direction === "newer" ||
+      agentComposerDraftHasContent(input.currentDraft)
+    ) {
       return unhandledHistoryNavigation();
     }
     const latest = input.entries.at(-1);
-    return latest
-      ? recalledHistoryNavigation(latest, input.currentDraft)
-      : unhandledHistoryNavigation();
+    if (latest) {
+      return recalledHistoryNavigation(latest);
+    }
+    if (input.hasOlderPage) {
+      return olderPageHistoryNavigation(null);
+    }
+    return unhandledHistoryNavigation();
   }
 
   if (input.direction === "older") {
     const older = input.entries[currentIndex - 1];
-    return older
-      ? recalledHistoryNavigation(older, currentDraft)
-      : {
-          handled: false,
-          state: {
-            entryId: input.state.entryId,
-            currentDraft
-          }
-        };
+    if (older) {
+      return recalledHistoryNavigation(older);
+    }
+    if (input.hasOlderPage) {
+      return olderPageHistoryNavigation(input.state.entryId);
+    }
+    return {
+      handled: false,
+      requestOlderPage: false,
+      state: { entryId: input.state.entryId, pendingOlderPage: false }
+    };
   }
 
   const newer = input.entries[currentIndex + 1];
   if (newer) {
-    return recalledHistoryNavigation(newer, currentDraft);
+    return recalledHistoryNavigation(newer);
   }
   return {
-    draft: currentDraft
-      ? snapshotAgentComposerDraft(currentDraft)
-      : snapshotAgentComposerDraft(input.currentDraft),
+    draft: emptyAgentComposerDraft(),
     handled: true,
+    requestOlderPage: false,
     state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
   };
+}
+
+export function resolvePendingAgentComposerInputHistory(input: {
+  entries: readonly AgentComposerInputHistoryEntry[];
+  state: AgentComposerInputHistoryState;
+}): AgentComposerInputHistoryNavigation | null {
+  if (!input.state.pendingOlderPage) {
+    return null;
+  }
+  if (input.state.entryId === null) {
+    const latest = input.entries.at(-1);
+    return latest
+      ? recalledHistoryNavigation(latest)
+      : {
+          handled: false,
+          requestOlderPage: false,
+          state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
+        };
+  }
+  const currentIndex = input.entries.findIndex(
+    (entry) => entry.id === input.state.entryId
+  );
+  const older = currentIndex > 0 ? input.entries[currentIndex - 1] : null;
+  return older
+    ? recalledHistoryNavigation(older)
+    : {
+        handled: false,
+        requestOlderPage: false,
+        state: { entryId: input.state.entryId, pendingOlderPage: false }
+      };
 }
 
 export function areAgentComposerHistoryDraftsEqual(
@@ -118,38 +175,155 @@ export function areAgentComposerHistoryDraftsEqual(
   return historyDraftValue(left) === historyDraftValue(right);
 }
 
+function projectHistoryEntry(
+  message: AgentConversationVM["sourceDetail"]["turns"][number]["userMessages"][number],
+  fallbackTurnId: string
+): AgentComposerInputHistoryEntry | null {
+  const sourceItem = message.sourceTimelineItems?.find((item) =>
+    Array.isArray(item.payload?.content)
+  );
+  const rawContent = Array.isArray(sourceItem?.payload?.content)
+    ? sourceItem.payload.content
+    : [];
+  const content = rawContent.filter((block): block is AgentPromptContentBlock =>
+    Boolean(block && typeof block === "object" && !Array.isArray(block))
+  );
+  const displayPrompt =
+    message.sourceTimelineItems
+      ?.map((item) =>
+        typeof item.payload?.displayPrompt === "string"
+          ? item.payload.displayPrompt.trim()
+          : ""
+      )
+      .find(Boolean) ?? "";
+  const visibleDisplayPrompt = isSyntheticImageOnlyDisplayPrompt(
+    displayPrompt,
+    rawContent
+  )
+    ? ""
+    : displayPrompt;
+  const draft =
+    content.length > 0
+      ? agentPromptContentToComposerDraft(
+          content,
+          `history-${message.turnId ?? fallbackTurnId}-${message.id}`
+        )
+      : buildAgentComposerDraft({
+          prompt: visibleDisplayPrompt || message.body
+        });
+  if (!agentComposerDraftHasContent(draft)) {
+    return null;
+  }
+  const entry = {
+    id: `${message.turnId ?? fallbackTurnId}:${message.id}`,
+    draft
+  };
+  historyDuplicateKeyByEntry.set(
+    entry,
+    JSON.stringify({
+      content,
+      prompt: visibleDisplayPrompt || (content.length === 0 ? message.body : "")
+    })
+  );
+  return entry;
+}
+
+const historyDuplicateKeyByEntry = new WeakMap<
+  AgentComposerInputHistoryEntry,
+  string
+>();
+
+function historyEntryDuplicateKey(
+  entry: AgentComposerInputHistoryEntry
+): string {
+  const cached = historyDuplicateKeyByEntry.get(entry);
+  if (cached) {
+    return cached;
+  }
+  const key = historyDraftValueWithOptions(entry.draft, true);
+  historyDuplicateKeyByEntry.set(entry, key);
+  return key;
+}
+
+function isSyntheticImageOnlyDisplayPrompt(
+  displayPrompt: string,
+  content: readonly unknown[]
+): boolean {
+  if (displayPrompt !== "[Image]" && displayPrompt !== "[Images]") {
+    return false;
+  }
+  let imageCount = 0;
+  for (const raw of content) {
+    const block =
+      raw && typeof raw === "object" && !Array.isArray(raw)
+        ? (raw as Record<string, unknown>)
+        : null;
+    if (!block) {
+      continue;
+    }
+    if (
+      block.type === "text" &&
+      typeof block.text === "string" &&
+      block.text.trim()
+    ) {
+      return false;
+    }
+    if (block.type === "image") {
+      imageCount += 1;
+    }
+  }
+  return displayPrompt === "[Image]" ? imageCount === 1 : imageCount > 1;
+}
+
 function recalledHistoryNavigation(
-  entry: AgentComposerInputHistoryEntry,
-  currentDraft: AgentComposerDraft | null
+  entry: AgentComposerInputHistoryEntry
 ): AgentComposerInputHistoryNavigation {
   return {
-    draft: snapshotAgentComposerDraft(entry.draft),
+    draft: entry.draft,
     handled: true,
-    state: {
-      entryId: entry.id,
-      currentDraft:
-        currentDraft === null ? null : snapshotAgentComposerDraft(currentDraft)
-    }
+    requestOlderPage: false,
+    state: { entryId: entry.id, pendingOlderPage: false }
+  };
+}
+
+function olderPageHistoryNavigation(
+  entryId: string | null
+): AgentComposerInputHistoryNavigation {
+  return {
+    handled: true,
+    requestOlderPage: true,
+    state: { entryId, pendingOlderPage: true }
   };
 }
 
 function unhandledHistoryNavigation(): AgentComposerInputHistoryNavigation {
   return {
     handled: false,
+    requestOlderPage: false,
     state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
   };
 }
 
 function historyDraftValue(draft: AgentComposerDraft): string {
+  return historyDraftValueWithOptions(draft, false);
+}
+
+function historyDraftValueWithOptions(
+  draft: AgentComposerDraft,
+  ignoreGeneratedIds: boolean
+): string {
   return JSON.stringify(
     draft.map((block) =>
       block.type === "image"
         ? {
             ...block,
+            ...(ignoreGeneratedIds ? { id: "" } : {}),
             // Preview data is presentation-only and may arrive asynchronously.
             previewUrl: ""
           }
-        : block
+        : block.type === "file" && ignoreGeneratedIds
+          ? { ...block, id: "" }
+          : block
     )
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -332,7 +332,12 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       : undefined
   );
   const composerInputHistoryProps = useAgentGUIComposerInputHistoryProps({
-    enabled: sessionInputHistoryEnabled
+    actions,
+    conversation,
+    enabled: sessionInputHistoryEnabled,
+    pendingPrependScrollAnchorRef,
+    timelineRef,
+    viewModel
   });
   const bottomDockComposerProps = useMemo<AgentComposerProps>(
     () => ({

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIComposerInputHistoryProps.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIComposerInputHistoryProps.spec.tsx
@@ -1,24 +1,71 @@
-import { renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
+import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
+import type { AgentGUINodeViewProps } from "./AgentGUINodeView.types";
 import { useAgentGUIComposerInputHistoryProps } from "./useAgentGUIComposerInputHistoryProps";
 
 describe("useAgentGUIComposerInputHistoryProps", () => {
-  it("keeps one open-period store and exposes it only when enabled", () => {
+  it("keeps history disabled until the host opts in", () => {
+    const timeline = document.createElement("div");
+    Object.defineProperties(timeline, {
+      scrollHeight: { value: 900 },
+      scrollTop: { value: 120, writable: true }
+    });
+    const loadOlderConversationMessages = vi.fn();
+    const pendingPrependScrollAnchorRef = { current: null };
+    const input = {
+      actions: {
+        loadOlderConversationMessages
+      } as unknown as AgentGUINodeViewProps["actions"],
+      conversation: conversationWithPrompt(),
+      pendingPrependScrollAnchorRef,
+      timelineRef: { current: timeline },
+      viewModel: {
+        rail: { activeConversationId: "session-1" },
+        detail: {
+          hasOlderMessages: true,
+          isLoadingOlderMessages: false
+        }
+      } as AgentGUINodeViewModel
+    };
     const { result, rerender } = renderHook(
-      ({ enabled }) => useAgentGUIComposerInputHistoryProps({ enabled }),
+      ({ enabled }) =>
+        useAgentGUIComposerInputHistoryProps({ ...input, enabled }),
       { initialProps: { enabled: false } }
     );
 
-    expect(result.current.inputHistoryStore).toBeUndefined();
+    expect(result.current).toEqual({
+      inputHistory: [],
+      inputHistoryHasOlderPage: false,
+      inputHistoryIsLoadingOlderPage: false,
+      onRequestOlderInputHistoryPage: undefined
+    });
 
     rerender({ enabled: true });
-    const openPeriodStore = result.current.inputHistoryStore;
-    expect(openPeriodStore).toBeDefined();
 
-    rerender({ enabled: false });
-    expect(result.current.inputHistoryStore).toBeUndefined();
-
-    rerender({ enabled: true });
-    expect(result.current.inputHistoryStore).toBe(openPeriodStore);
+    expect(result.current.inputHistory).toHaveLength(1);
+    act(() => {
+      result.current.onRequestOlderInputHistoryPage?.();
+    });
+    expect(loadOlderConversationMessages).toHaveBeenCalledOnce();
+    expect(pendingPrependScrollAnchorRef.current).toEqual({
+      conversationId: "session-1",
+      scrollHeight: 900,
+      scrollTop: 120
+    });
   });
 });
+
+function conversationWithPrompt(): AgentConversationVM {
+  return {
+    sourceDetail: {
+      turns: [
+        {
+          id: "turn-1",
+          userMessages: [{ id: "message-1", body: "hello" }]
+        }
+      ]
+    }
+  } as unknown as AgentConversationVM;
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIComposerInputHistoryProps.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIComposerInputHistoryProps.ts
@@ -1,17 +1,71 @@
-import { useMemo, useState } from "react";
+import { useMemo, type RefObject } from "react";
+import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
 import type { AgentComposerProps } from "../AgentComposer";
-import { createAgentComposerInputHistoryStore } from "../model/agentComposerInputHistory";
+import type { AgentGUINodeViewProps } from "../AgentGUINodeView";
+import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
+import { projectAgentComposerInputHistory } from "../model/agentComposerInputHistory";
+import { useStableEventCallback } from "./agentGUIViewUtils";
 
-type InputHistoryProps = Pick<AgentComposerProps, "inputHistoryStore">;
+type InputHistoryProps = Pick<
+  AgentComposerProps,
+  | "inputHistory"
+  | "inputHistoryHasOlderPage"
+  | "inputHistoryIsLoadingOlderPage"
+  | "onRequestOlderInputHistoryPage"
+>;
+const EMPTY_INPUT_HISTORY: NonNullable<InputHistoryProps["inputHistory"]> = [];
 
 export function useAgentGUIComposerInputHistoryProps(input: {
+  actions: AgentGUINodeViewProps["actions"];
+  conversation: AgentConversationVM | null;
   enabled: boolean;
+  pendingPrependScrollAnchorRef: RefObject<{
+    conversationId: string;
+    scrollHeight: number;
+    scrollTop: number;
+  } | null>;
+  timelineRef: RefObject<HTMLDivElement | null>;
+  viewModel: AgentGUINodeViewModel;
 }): InputHistoryProps {
-  const [inputHistoryStore] = useState(createAgentComposerInputHistoryStore);
+  const onRequestOlderInputHistoryPage = useStableEventCallback(() => {
+    const activeConversationId = input.viewModel.rail.activeConversationId;
+    if (
+      !activeConversationId ||
+      !input.viewModel.detail.hasOlderMessages ||
+      input.viewModel.detail.isLoadingOlderMessages
+    ) {
+      return;
+    }
+    const timeline = input.timelineRef.current;
+    if (timeline) {
+      input.pendingPrependScrollAnchorRef.current = {
+        conversationId: activeConversationId,
+        scrollHeight: timeline.scrollHeight,
+        scrollTop: timeline.scrollTop
+      };
+    }
+    input.actions.loadOlderConversationMessages();
+  });
+  const inputHistory = input.enabled
+    ? projectAgentComposerInputHistory(input.conversation)
+    : EMPTY_INPUT_HISTORY;
   return useMemo(
     () => ({
-      inputHistoryStore: input.enabled ? inputHistoryStore : undefined
+      inputHistory,
+      inputHistoryHasOlderPage:
+        input.enabled && input.viewModel.detail.hasOlderMessages,
+      inputHistoryIsLoadingOlderPage:
+        input.enabled && input.viewModel.detail.isLoadingOlderMessages,
+      onRequestOlderInputHistoryPage: input.enabled
+        ? onRequestOlderInputHistoryPage
+        : undefined
     }),
-    [input.enabled, inputHistoryStore]
+    [
+      input.viewModel.detail.hasOlderMessages,
+      input.viewModel.detail.isLoadingOlderMessages,
+      input.enabled,
+      inputHistory,
+      onRequestOlderInputHistoryPage
+    ]
   );
 }


### PR DESCRIPTION
## Summary
- revert #1702 and restore Session-backed Agent composer input history
- restore older-message pagination and structured attachment recall
- restore the architecture documentation for Session-scoped history

## Tests
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`

## Notes
- this restores #1696 behavior; device-global cross-session history remains out of scope
- live Desktop visual verification was not run
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->