### PR TITLE
fix(mobile): preserve pairing across scanner lifecycle

### DIFF
--- a/apps/mobile/android/app/src/main/java/dev/tutti/mobile/MobileSecurityModule.kt
+++ b/apps/mobile/android/app/src/main/java/dev/tutti/mobile/MobileSecurityModule.kt
@@ -13,12 +13,13 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.modules.network.ForwardingCookieHandler
 import com.google.zxing.client.android.Intents
 import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
-import java.nio.charset.StandardCharsets
 import java.net.URI
+import java.nio.charset.StandardCharsets
 import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.KeyStore
@@ -39,6 +40,10 @@ class MobileSecurityModule(
     private val browserAuthBridge = MobileBrowserAuthBridge(reactContext)
     private val store = SecureStore(reactContext)
     private var scanPromise: Promise? = null
+    private var scanCancellationPromise: Promise? = null
+    private var scanActivity: Activity? = null
+    private var scanRequestCode: Int? = null
+    private var nextScanRequestCode = QR_SCAN_REQUEST_CODE_MIN
     private val scanContract = ScanContract()
     private val activityEventListener =
         object : BaseActivityEventListener() {
@@ -48,12 +53,27 @@ class MobileSecurityModule(
                 resultCode: Int,
                 intent: Intent?,
             ) {
-                if (requestCode != QR_SCAN_REQUEST_CODE) {
+                if (requestCode != scanRequestCode) {
+                    return
+                }
+                val promise = scanPromise
+                val cancellation = scanCancellationPromise
+                if (promise == null && cancellation == null) {
+                    return
+                }
+                scanPromise = null
+                scanCancellationPromise = null
+                scanActivity = null
+                scanRequestCode = null
+                if (cancellation != null) {
+                    promise?.reject("SCAN_CANCELLED", "QR scan cancelled")
+                    cancellation.resolve(null)
                     return
                 }
                 val result = scanContract.parseResult(resultCode, intent)
-                val promise = scanPromise ?: return
-                scanPromise = null
+                if (promise == null) {
+                    return
+                }
                 val value = result.contents?.trim().orEmpty()
                 when {
                     result.originalIntent?.getBooleanExtra(
@@ -162,39 +182,7 @@ class MobileSecurityModule(
     }
 
     @ReactMethod
-    fun installSessionCookie(
-        accountBaseURL: String,
-        sessionId: String,
-        promise: Promise,
-    ) {
-        runCatching {
-            val cookieURL = validatedCookieURL(accountBaseURL)
-            val normalizedSessionID = sessionId.trim()
-            require(
-                normalizedSessionID.isNotEmpty() &&
-                    normalizedSessionID.none {
-                        it == ';' || it == '\r' || it == '\n'
-                    },
-            ) {
-                "Account session is invalid"
-            }
-            ForwardingCookieHandler().addCookies(
-                cookieURL,
-                listOf(
-                    "session_id=$normalizedSessionID; Path=/; Secure; HttpOnly; SameSite=Lax",
-                ),
-            )
-        }.fold({ promise.resolve(null) }) {
-            promise.reject(
-                "SESSION_COOKIE_WRITE_FAILED",
-                "Unable to install account session cookie",
-                it,
-            )
-        }
-    }
-
-    @ReactMethod
-    fun clearSessionCookie(
+    fun clearLegacySessionCookie(
         accountBaseURL: String,
         promise: Promise,
     ) {
@@ -208,7 +196,7 @@ class MobileSecurityModule(
         }.fold({ promise.resolve(null) }) {
             promise.reject(
                 "SESSION_COOKIE_CLEAR_FAILED",
-                "Unable to clear account session cookie",
+                "Unable to clear legacy account session cookie",
                 it,
             )
         }
@@ -248,12 +236,21 @@ class MobileSecurityModule(
             promise.reject("SCANNER_UNAVAILABLE", "No active Android activity")
             return
         }
-        if (scanPromise != null) {
-            promise.reject("SCANNER_BUSY", "A QR scan is already active")
-            return
-        }
-        scanPromise = promise
-        activity.runOnUiThread {
+        UiThreadUtil.runOnUiThread {
+            if (scanPromise != null || scanCancellationPromise != null) {
+                promise.reject("SCANNER_BUSY", "A QR scan is already active")
+                return@runOnUiThread
+            }
+            val requestCode = nextScanRequestCode
+            nextScanRequestCode =
+                if (requestCode >= QR_SCAN_REQUEST_CODE_MAX) {
+                    QR_SCAN_REQUEST_CODE_MIN
+                } else {
+                    requestCode + 1
+                }
+            scanPromise = promise
+            scanActivity = activity
+            scanRequestCode = requestCode
             try {
                 val options =
                     ScanOptions()
@@ -265,11 +262,13 @@ class MobileSecurityModule(
                     .setOrientationLocked(false)
                 activity.startActivityForResult(
                     scanContract.createIntent(activity, options),
-                    QR_SCAN_REQUEST_CODE,
+                    requestCode,
                 )
             } catch (cause: Exception) {
                 if (scanPromise === promise) {
                     scanPromise = null
+                    scanActivity = null
+                    scanRequestCode = null
                     promise.reject(
                         "SCAN_FAILED",
                         "Unable to scan QR code",
@@ -280,19 +279,66 @@ class MobileSecurityModule(
         }
     }
 
+    @ReactMethod
+    fun cancelQRCodeScan(promise: Promise) {
+        UiThreadUtil.runOnUiThread {
+            val pending = scanPromise
+            when {
+                pending == null -> promise.resolve(null)
+                scanCancellationPromise != null ->
+                    promise.reject(
+                        "SCANNER_BUSY",
+                        "QR scanner cancellation is already in progress",
+                    )
+                else -> {
+                    val activity = scanActivity
+                    val requestCode = scanRequestCode
+                    if (
+                        activity == null ||
+                        requestCode == null ||
+                        activity.isFinishing ||
+                        (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 &&
+                            activity.isDestroyed)
+                    ) {
+                        scanPromise = null
+                        scanActivity = null
+                        scanRequestCode = null
+                        pending.reject("SCAN_CANCELLED", "QR scan cancelled")
+                        promise.resolve(null)
+                    } else {
+                        scanCancellationPromise = promise
+                        activity.finishActivity(requestCode)
+                    }
+                }
+            }
+        }
+    }
+
     override fun invalidate() {
         reactContext.removeActivityEventListener(activityEventListener)
         browserAuthBridge.close()
-        scanPromise?.reject(
-            "SCANNER_UNAVAILABLE",
-            "QR scanner was closed",
-        )
-        scanPromise = null
+        UiThreadUtil.runOnUiThread {
+            val activity = scanActivity
+            val requestCode = scanRequestCode
+            if (activity != null && requestCode != null) {
+                activity.finishActivity(requestCode)
+            }
+            scanPromise?.reject(
+                "SCANNER_UNAVAILABLE",
+                "QR scanner was closed",
+            )
+            scanPromise = null
+            scanActivity = null
+            scanRequestCode = null
+            scanCancellationPromise?.resolve(null)
+            scanCancellationPromise = null
+        }
         super.invalidate()
     }
 
     companion object {
-        private const val QR_SCAN_REQUEST_CODE = 51731
+        private const val QR_SCAN_REQUEST_CODE_MIN = 51731
+        private const val QR_SCAN_REQUEST_CODE_MAX = 60000
 
         private fun validatedCookieURL(rawURL: String): String {
             val uri = URI(rawURL.trim())

--- a/apps/mobile/ios/TuttiMobile/MobileNativeModules.m
+++ b/apps/mobile/ios/TuttiMobile/MobileNativeModules.m
@@ -27,13 +27,7 @@ RCT_EXTERN_METHOD(clearSession
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(installSessionCookie
-                  : (NSString *)accountBaseURL sessionId
-                  : (NSString *)sessionId resolver
-                  : (RCTPromiseResolveBlock)resolve rejecter
-                  : (RCTPromiseRejectBlock)reject)
-
-RCT_EXTERN_METHOD(clearSessionCookie
+RCT_EXTERN_METHOD(clearLegacySessionCookie
                   : (NSString *)accountBaseURL resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject)
@@ -46,6 +40,10 @@ RCT_EXTERN_METHOD(startBrowserLogin
                   : (RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(scanQRCode
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(cancelQRCodeScan
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject)
 

--- a/apps/mobile/ios/TuttiMobile/MobileSecurityModule.swift
+++ b/apps/mobile/ios/TuttiMobile/MobileSecurityModule.swift
@@ -9,6 +9,8 @@ final class MobileSecurityModule: NSObject {
   private let browserAuthBridge = MobileBrowserAuthBridge()
   private let store = MobileSecureStore()
   private var scannerActive = false
+  private var scannerCancellationResolvers: [RCTPromiseResolveBlock] = []
+  private weak var scannerViewController: QRCodeScannerViewController?
 
   @objc
   static func requiresMainQueueSetup() -> Bool {
@@ -103,48 +105,8 @@ final class MobileSecurityModule: NSObject {
     }
   }
 
-  @objc(installSessionCookie:sessionId:resolver:rejecter:)
-  func installSessionCookie(
-    _ accountBaseURL: String,
-    sessionId: String,
-    resolver resolve: RCTPromiseResolveBlock,
-    rejecter reject: RCTPromiseRejectBlock
-  ) {
-    do {
-      let url = try validatedCookieURL(accountBaseURL)
-      let normalizedSessionID = sessionId.trimmingCharacters(
-        in: .whitespacesAndNewlines
-      )
-      guard
-        !normalizedSessionID.isEmpty,
-        !normalizedSessionID.contains(";"),
-        !normalizedSessionID.contains("\r"),
-        !normalizedSessionID.contains("\n"),
-        let host = url.host,
-        let cookie = HTTPCookie(properties: [
-          .domain: host,
-          .path: "/",
-          .name: "session_id",
-          .value: normalizedSessionID,
-          .secure: "TRUE",
-          .expires: Date(timeIntervalSinceNow: 60 * 60 * 24 * 365),
-        ])
-      else {
-        throw MobileSecurityError.invalidSession
-      }
-      HTTPCookieStorage.shared.setCookie(cookie)
-      resolve(nil)
-    } catch {
-      reject(
-        "SESSION_COOKIE_WRITE_FAILED",
-        "Unable to install account session cookie",
-        error
-      )
-    }
-  }
-
-  @objc(clearSessionCookie:resolver:rejecter:)
-  func clearSessionCookie(
+  @objc(clearLegacySessionCookie:resolver:rejecter:)
+  func clearLegacySessionCookie(
     _ accountBaseURL: String,
     resolver resolve: RCTPromiseResolveBlock,
     rejecter reject: RCTPromiseRejectBlock
@@ -159,7 +121,7 @@ final class MobileSecurityModule: NSObject {
     } catch {
       reject(
         "SESSION_COOKIE_CLEAR_FAILED",
-        "Unable to clear account session cookie",
+        "Unable to clear legacy account session cookie",
         error
       )
     }
@@ -207,8 +169,21 @@ final class MobileSecurityModule: NSObject {
   ) {
     #if targetEnvironment(simulator)
       reject("SCANNER_UNAVAILABLE", "QR scanner is unavailable in Simulator", nil)
-      return
+    #else
+      DispatchQueue.main.async { [weak self] in
+        guard let self else {
+          reject("SCANNER_UNAVAILABLE", "QR scanner is unavailable", nil)
+          return
+        }
+        self.presentQRCodeScanner(resolve, rejecter: reject)
+      }
     #endif
+  }
+
+  private func presentQRCodeScanner(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    rejecter reject: @escaping RCTPromiseRejectBlock
+  ) {
     guard !scannerActive else {
       reject("SCANNER_BUSY", "A QR scan is already active", nil)
       return
@@ -220,9 +195,11 @@ final class MobileSecurityModule: NSObject {
 
     scannerActive = true
     let scanner = QRCodeScannerViewController()
+    scannerViewController = scanner
     scanner.modalPresentationStyle = .fullScreen
-    scanner.onCompletion = { [weak self] result in
-      self?.scannerActive = false
+    scanner.onCompletion = { result in
+      self.scannerActive = false
+      self.scannerViewController = nil
       switch result {
       case .success(let value):
         resolve(value)
@@ -238,24 +215,36 @@ final class MobileSecurityModule: NSObject {
           reject("SCANNER_UNAVAILABLE", "QR scanner is unavailable", error)
         }
       }
+      let cancellationResolvers = self.scannerCancellationResolvers
+      self.scannerCancellationResolvers.removeAll()
+      for resolveCancellation in cancellationResolvers {
+        resolveCancellation(nil)
+      }
     }
     presenter.present(scanner, animated: true)
+  }
+
+  @objc(cancelQRCodeScan:rejecter:)
+  func cancelQRCodeScan(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    rejecter _: @escaping RCTPromiseRejectBlock
+  ) {
+    DispatchQueue.main.async { [weak self] in
+      guard let self, let scanner = self.scannerViewController else {
+        resolve(nil)
+        return
+      }
+      self.scannerCancellationResolvers.append(resolve)
+      scanner.cancelScanning()
+    }
   }
 
   @objc
   func invalidate() {
     browserAuthBridge.close()
-  }
-
-  private func validatedCookieURL(_ rawURL: String) throws -> URL {
-    guard
-      let url = URL(string: rawURL.trimmingCharacters(in: .whitespacesAndNewlines)),
-      url.scheme == "https",
-      url.host != nil
-    else {
-      throw MobileSecurityError.invalidAccountURL
+    DispatchQueue.main.async { [weak self] in
+      self?.scannerViewController?.cancelScanning()
     }
-    return url
   }
 
   private func topViewController() -> UIViewController? {
@@ -272,6 +261,17 @@ final class MobileSecurityModule: NSObject {
       current = presented
     }
     return current
+  }
+
+  private func validatedCookieURL(_ rawURL: String) throws -> URL {
+    guard
+      let url = URL(string: rawURL.trimmingCharacters(in: .whitespacesAndNewlines)),
+      url.scheme == "https",
+      url.host != nil
+    else {
+      throw MobileSecurityError.invalidAccountURL
+    }
+    return url
   }
 }
 

--- a/apps/mobile/ios/TuttiMobile/QRCodeScannerViewController.swift
+++ b/apps/mobile/ios/TuttiMobile/QRCodeScannerViewController.swift
@@ -14,6 +14,10 @@ final class QRCodeScannerViewController: UIViewController,
   var onCompletion: ((Result<String, Error>) -> Void)?
 
   private let captureSession = AVCaptureSession()
+  private let captureQueue = DispatchQueue(
+    label: "dev.tutti.mobile.qr-capture",
+    qos: .userInitiated
+  )
   private let previewLayer = AVCaptureVideoPreviewLayer()
   private var completed = false
 
@@ -68,7 +72,7 @@ final class QRCodeScannerViewController: UIViewController,
 
   override func viewWillDisappear(_ animated: Bool) {
     super.viewWillDisappear(animated)
-    captureSession.stopRunning()
+    stopCapture()
   }
 
   func metadataOutput(
@@ -118,6 +122,7 @@ final class QRCodeScannerViewController: UIViewController,
   }
 
   private func startCapture() {
+    guard !completed else { return }
     guard
       let camera = AVCaptureDevice.default(for: .video),
       let input = try? AVCaptureDeviceInput(device: camera),
@@ -136,13 +141,16 @@ final class QRCodeScannerViewController: UIViewController,
     captureSession.addOutput(output)
     output.setMetadataObjectsDelegate(self, queue: .main)
     output.metadataObjectTypes = [.qr]
-    let session = captureSession
-    DispatchQueue.global(qos: .userInitiated).async {
+    captureQueue.async { [session = captureSession] in
       session.startRunning()
     }
   }
 
   @objc private func cancel() {
+    complete(.failure(QRCodeScannerError.cancelled))
+  }
+
+  func cancelScanning() {
     complete(.failure(QRCodeScannerError.cancelled))
   }
 
@@ -152,14 +160,30 @@ final class QRCodeScannerViewController: UIViewController,
   ) {
     guard !completed else { return }
     completed = true
-    captureSession.stopRunning()
     let completion = onCompletion
-    if shouldDismiss {
-      dismiss(animated: true) {
+    stopCapture { [weak self] in
+      guard let self else {
+        completion?(result)
+        return
+      }
+      if shouldDismiss {
+        self.dismiss(animated: true) {
+          completion?(result)
+        }
+      } else {
         completion?(result)
       }
-    } else {
-      completion?(result)
+    }
+  }
+
+  private func stopCapture(completion: (() -> Void)? = nil) {
+    captureQueue.async { [session = captureSession] in
+      if session.isRunning {
+        session.stopRunning()
+      }
+      if let completion {
+        DispatchQueue.main.async(execute: completion)
+      }
     }
   }
 }

--- a/apps/mobile/src/native/createMobileServicePorts.ts
+++ b/apps/mobile/src/native/createMobileServicePorts.ts
@@ -1,4 +1,8 @@
-import { AppState, DeviceEventEmitter } from "react-native";
+import {
+  AppState,
+  DeviceEventEmitter,
+  type AppStateStatus
+} from "react-native";
 import { deviceLink, mobileSecurity } from "./mobileNative";
 import {
   sendEmailCode,
@@ -11,12 +15,12 @@ import {
   getPairingChallenge,
   listDevices,
   listPairings,
-  parsePairingQR,
   registerCurrentDevice
 } from "../services/pairingClient";
 import { createRemoteTuttidClient } from "../services/remoteTuttidClient";
 import type { MobileServicePorts } from "../services/servicePorts";
 import { parseAgentLiveDeliveries } from "./agentLiveNativeBridge";
+import { accountBaseURL } from "../config";
 
 const AGENT_LIVE_EVENT_NAME = "TuttiDeviceLinkAgentLive";
 
@@ -71,12 +75,20 @@ export function createMobileServicePorts(): MobileServicePorts {
         };
       }
     },
-    deviceSecurity: mobileSecurity,
+    diagnostics: {
+      record(event) {
+        console.info("[TuttiMobile]", JSON.stringify(event));
+      }
+    },
+    legacySessionCookie: {
+      clear: () => mobileSecurity.clearLegacySessionCookie(accountBaseURL)
+    },
     lifecycle: {
       subscribe(listener) {
-        const subscription = AppState.addEventListener("change", (state) =>
-          listener(state === "active")
-        );
+        listener(applicationVisibility(AppState.currentState));
+        const subscription = AppState.addEventListener("change", (state) => {
+          listener(applicationVisibility(state));
+        });
         return () => subscription.remove();
       }
     },
@@ -86,10 +98,27 @@ export function createMobileServicePorts(): MobileServicePorts {
       getPairingChallenge,
       listDevices,
       listPairings,
-      parsePairingQR,
       registerCurrentDevice
+    },
+    qrCodeScanner: {
+      start() {
+        return {
+          cancel: () => mobileSecurity.cancelQRCodeScan(),
+          result: mobileSecurity.scanQRCode()
+        };
+      }
     },
     sessionStorage: mobileSecurity,
     createRemoteClient: () => createRemoteTuttidClient(deviceLink)
   };
+}
+
+function applicationVisibility(
+  state: AppStateStatus
+): "active" | "background" | "inactive" {
+  return state === "active"
+    ? "active"
+    : state === "background"
+      ? "background"
+      : "inactive";
 }

--- a/apps/mobile/src/native/mobileNative.ts
+++ b/apps/mobile/src/native/mobileNative.ts
@@ -10,14 +10,11 @@ export interface BrowserLoginCompletion {
 }
 
 interface MobileSecurityNative {
+  cancelQRCodeScan(): Promise<void>;
+  clearLegacySessionCookie(accountBaseURL: string): Promise<void>;
   clearSession(): Promise<void>;
-  clearSessionCookie(accountBaseURL: string): Promise<void>;
   getOrCreateIdentity(): Promise<DeviceIdentity>;
   loadSession(): Promise<AccountSession | null>;
-  installSessionCookie(
-    accountBaseURL: string,
-    sessionId: string
-  ): Promise<void>;
   saveSession(
     sessionId: string,
     userId: string,

--- a/apps/mobile/src/screens/DeviceScreen.tsx
+++ b/apps/mobile/src/screens/DeviceScreen.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useServiceSnapshot } from "../bindings/useServiceSnapshot";
 import type { DeviceService } from "../services/deviceService";
 import type { AccountSession } from "../services/mobileDomain";
@@ -13,14 +14,27 @@ export function DeviceScreen({
   session: AccountSession;
 }) {
   const model = useServiceSnapshot(service);
+  const [manualPairingCode, setManualPairingCode] = useState("");
+  const [manualPairingOpen, setManualPairingOpen] = useState(false);
+
+  const submitManualPairingCode = async () => {
+    if (await service.pairWithCode(manualPairingCode)) {
+      setManualPairingCode("");
+      setManualPairingOpen(false);
+    }
+  };
+
   return (
     <DeviceScreenView
+      manualPairingCode={manualPairingCode}
+      manualPairingOpen={manualPairingOpen}
       model={model}
       onConnect={(pairing, device) => void service.connect(pairing, device)}
-      onManualPairingCodeChange={(value) => service.setManualPairingCode(value)}
-      onManualPairingOpen={() => service.setManualPairingOpen(true)}
-      onPair={(payload) => void service.pair(payload)}
+      onManualPairingCodeChange={setManualPairingCode}
+      onManualPairingOpen={() => setManualPairingOpen(true)}
+      onManualPairingSubmit={() => void submitManualPairingCode()}
       onRefresh={() => void service.refresh()}
+      onScanPairingCode={() => void service.scanAndPair()}
       onSignOut={() => void onSignOut()}
       accountName={session.name}
     />

--- a/apps/mobile/src/screens/DeviceScreenView.tsx
+++ b/apps/mobile/src/screens/DeviceScreenView.tsx
@@ -17,23 +17,29 @@ import type { DevicePairing, UserDevice } from "../services/mobileDomain";
 
 export interface DeviceScreenViewProps {
   accountName: string;
+  manualPairingCode: string;
+  manualPairingOpen: boolean;
   model: DeviceSnapshot;
   onConnect(pairing: DevicePairing, device?: UserDevice): void;
   onManualPairingCodeChange(value: string): void;
   onManualPairingOpen(): void;
-  onPair(manualPayload?: string): void;
+  onManualPairingSubmit(): void;
   onRefresh(): void;
+  onScanPairingCode(): void;
   onSignOut(): void;
 }
 
 export function DeviceScreenView({
   accountName,
+  manualPairingCode,
+  manualPairingOpen,
   model,
   onConnect,
   onManualPairingCodeChange,
   onManualPairingOpen,
-  onPair,
+  onManualPairingSubmit,
   onRefresh,
+  onScanPairingCode,
   onSignOut
 }: DeviceScreenViewProps) {
   const theme = useNativeTheme();
@@ -140,14 +146,18 @@ export function DeviceScreenView({
           }
           label={
             model.pairingState === "claiming" ||
-            model.pairingState === "waiting"
+            model.pairingState === "waiting" ||
+            model.pairingState === "scanning"
               ? t("pairing")
               : t("pairAction")
           }
-          loading={model.pairingState === "claiming"}
-          onPress={() => onPair()}
+          loading={
+            model.pairingState === "claiming" ||
+            model.pairingState === "scanning"
+          }
+          onPress={onScanPairingCode}
         />
-        {model.manualPairingOpen ? (
+        {manualPairingOpen ? (
           <>
             <TextInput
               autoCapitalize="none"
@@ -157,14 +167,16 @@ export function DeviceScreenView({
               placeholder={t("pairingCodeHint")}
               placeholderTextColor={theme.color.muted}
               style={styles.manualInput}
-              value={model.manualPairingCode}
+              value={manualPairingCode}
             />
             <PrimaryButton
               disabled={
-                !model.manualPairingCode.trim() || model.pairingState !== "idle"
+                !manualPairingCode.trim() ||
+                (model.pairingState !== "idle" &&
+                  model.pairingState !== "confirmed")
               }
               label={t("pairingCodeSubmit")}
-              onPress={() => onPair(model.manualPairingCode)}
+              onPress={onManualPairingSubmit}
               secondary
             />
           </>

--- a/apps/mobile/src/services/accountClient.test.ts
+++ b/apps/mobile/src/services/accountClient.test.ts
@@ -1,7 +1,6 @@
 jest.mock("../native/mobileNative", () => ({
   __esModule: true,
   mobileSecurity: {
-    installSessionCookie: jest.fn(),
     startBrowserLogin: jest.fn()
   }
 }));
@@ -56,10 +55,6 @@ describe("signInWithGitHub", () => {
       "https://tutti.sh/auth/login",
       "tutti://auth/login"
     );
-    expect(mobileSecurity.installSessionCookie).toHaveBeenCalledWith(
-      "https://tutti.sh/api/account",
-      "session-1"
-    );
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
       "https://tutti.sh/api/account/auth/v1/redeem_desktop_transfer_code",
@@ -71,6 +66,7 @@ describe("signInWithGitHub", () => {
           device_id: "mobile-device-1",
           transfer_code: "transfer-code-1"
         }),
+        credentials: "omit",
         method: "POST"
       })
     );
@@ -78,6 +74,7 @@ describe("signInWithGitHub", () => {
       2,
       "https://tutti.sh/api/account/user/v1/user_info",
       expect.objectContaining({
+        credentials: "omit",
         headers: expect.objectContaining({
           Cookie: "session_id=session-1"
         }),

--- a/apps/mobile/src/services/accountClient.ts
+++ b/apps/mobile/src/services/accountClient.ts
@@ -87,7 +87,6 @@ async function accountSession(
   sessionId: string,
   fallbackEmail = ""
 ): Promise<AccountSession> {
-  await mobileSecurity.installSessionCookie(accountBaseURL, sessionId);
   const user = await accountRequest<UserInfo>(
     "user/v1/user_info",
     {},
@@ -114,6 +113,7 @@ async function accountRequest<T>(
 ): Promise<T> {
   const response = await fetch(`${accountBaseURL}/${path}`, {
     body: JSON.stringify(body),
+    credentials: "omit",
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json",

--- a/apps/mobile/src/services/deviceService.test.ts
+++ b/apps/mobile/src/services/deviceService.test.ts
@@ -1,0 +1,427 @@
+import { DeviceService } from "./deviceService";
+import type { AccountSession, DevicePairingChallenge } from "./mobileDomain";
+import type {
+  ClockPort,
+  MobileDiagnosticEvent,
+  PairingPort,
+  QRCodeScannerPort
+} from "./servicePorts";
+
+const session: AccountSession = {
+  email: "person@example.com",
+  name: "Person",
+  sessionId: "session-cookie",
+  userId: "user-1"
+};
+const pairingCode = JSON.stringify({
+  challengeId: "challenge-1",
+  secret: "a".repeat(43),
+  version: 1
+});
+
+describe("DeviceService pairing lifecycle", () => {
+  test("keeps an Android scanner interaction alive across background and active transitions", async () => {
+    const scannerResult = deferred<string>();
+    const harness = createHarness({
+      scanner: scannerFrom(scannerResult)
+    });
+
+    const pairing = harness.service.scanAndPair();
+    expect(harness.service.getSnapshot().pairingState).toBe("scanning");
+
+    harness.service.suspendRemoteOperations();
+    expect(harness.service.getSnapshot().pairingState).toBe("scanning");
+    scannerResult.resolve(pairingCode);
+    await flushPromises();
+
+    expect(harness.claimCalls).toBe(0);
+    expect(harness.service.getSnapshot().pairingState).toBe("scanning");
+
+    harness.service.resumeRemoteOperations();
+    await flushPromises();
+
+    expect(harness.claimCalls).toBe(1);
+    expect(harness.service.getSnapshot().pairingState).toBe("waiting");
+
+    harness.clock.advanceBy(1_000);
+    await pairing;
+
+    expect(harness.challengeCalls).toBe(1);
+    expect(harness.service.getSnapshot().pairingState).toBe("confirmed");
+    expect(
+      harness.diagnosticEvents
+        .filter((event) => event.name === "device_pairing.phase_changed")
+        .map((event) => event.phase)
+    ).toEqual(["scanning", "claiming", "waiting", "confirmed"]);
+    expect(JSON.stringify(harness.diagnosticEvents)).not.toContain(
+      "a".repeat(43)
+    );
+  });
+
+  test("starts only one scanner interaction while scanning", async () => {
+    const scannerResult = deferred<string>();
+    let scanCalls = 0;
+    const harness = createHarness({
+      scanner: {
+        start: () => {
+          scanCalls += 1;
+          return {
+            cancel: async () => undefined,
+            result: scannerResult.promise
+          };
+        }
+      }
+    });
+
+    const first = harness.service.scanAndPair();
+    const duplicate = harness.service.scanAndPair();
+    expect(scanCalls).toBe(1);
+
+    harness.service.dispose();
+    scannerResult.resolve(pairingCode);
+    await Promise.all([first, duplicate]);
+
+    expect(harness.claimCalls).toBe(0);
+  });
+
+  test.each([
+    ["SCAN_CANCELLED", null],
+    ["SCANNER_PERMISSION_DENIED", "camera_permission_required"],
+    ["SCAN_FAILED", "scanner_unavailable"]
+  ] as const)(
+    "maps scanner failure %s without attempting a claim",
+    async (code, errorCode) => {
+      const harness = createHarness({
+        scanner: {
+          start: () => ({
+            cancel: async () => undefined,
+            result: Promise.reject({ code })
+          })
+        }
+      });
+
+      await harness.service.scanAndPair();
+      harness.service.resumeRemoteOperations();
+      await flushPromises();
+
+      expect(harness.claimCalls).toBe(0);
+      expect(harness.service.getSnapshot()).toMatchObject({
+        errorCode,
+        pairingState: "idle"
+      });
+    }
+  );
+
+  test("cancels the native scanner when the service is disposed", async () => {
+    const scannerResult = deferred<string>();
+    let cancelCalls = 0;
+    const harness = createHarness({
+      scanner: {
+        start: () => ({
+          cancel: async () => {
+            cancelCalls += 1;
+            scannerResult.reject({ code: "SCAN_CANCELLED" });
+          },
+          result: scannerResult.promise
+        })
+      }
+    });
+
+    const pairing = harness.service.scanAndPair();
+    harness.service.dispose();
+    await pairing;
+
+    expect(cancelCalls).toBe(1);
+    expect(harness.claimCalls).toBe(0);
+  });
+
+  test("settles an in-flight claim and resumes polling after returning active", async () => {
+    const claimResult = deferred<DevicePairingChallenge>();
+    const harness = createHarness({ claimResult });
+
+    const pairing = harness.service.pairWithCode(pairingCode);
+    await flushPromises();
+    expect(harness.claimCalls).toBe(1);
+
+    harness.service.suspendRemoteOperations();
+    claimResult.resolve({
+      challengeId: "challenge-1",
+      expiresAt: new Date(10_000).toISOString(),
+      state: "awaiting_confirmation"
+    });
+
+    await flushPromises();
+    expect(harness.challengeCalls).toBe(0);
+    expect(harness.service.getSnapshot().pairingState).toBe("claiming");
+
+    harness.service.resumeRemoteOperations();
+    await flushPromises();
+    expect(harness.service.getSnapshot().pairingState).toBe("waiting");
+
+    harness.clock.advanceBy(1_000);
+    await expect(pairing).resolves.toBe(true);
+    expect(harness.challengeCalls).toBe(1);
+    expect(harness.service.getSnapshot().pairingState).toBe("confirmed");
+  });
+
+  test("reconciles an ambiguous in-flight claim without submitting it twice", async () => {
+    const claimResult = deferred<DevicePairingChallenge>();
+    const harness = createHarness({
+      challengeResults: [
+        {
+          challengeId: "challenge-1",
+          expiresAt: new Date(10_000).toISOString(),
+          state: "awaiting_confirmation"
+        }
+      ],
+      claimResult
+    });
+
+    const pairing = harness.service.pairWithCode(pairingCode);
+    await flushPromises();
+    expect(harness.claimCalls).toBe(1);
+
+    harness.service.suspendRemoteOperations();
+    claimResult.reject(new Error("claim response was lost"));
+    harness.service.resumeRemoteOperations();
+    await flushPromises();
+
+    expect(harness.claimCalls).toBe(1);
+    expect(harness.challengeCalls).toBe(1);
+    expect(harness.service.getSnapshot().pairingState).toBe("waiting");
+
+    harness.clock.advanceBy(1_000);
+    await expect(pairing).resolves.toBe(true);
+    expect(harness.claimCalls).toBe(1);
+    expect(harness.challengeCalls).toBe(2);
+  });
+
+  test("retries claim reconciliation when a second background transition interrupts its read", async () => {
+    const claimResult = deferred<DevicePairingChallenge>();
+    const reconciliationResult = deferred<DevicePairingChallenge>();
+    const harness = createHarness({
+      challengeResults: [reconciliationResult.promise],
+      claimResult
+    });
+
+    const pairing = harness.service.pairWithCode(pairingCode);
+    await flushPromises();
+    harness.service.suspendRemoteOperations();
+    claimResult.reject(new Error("claim response was lost"));
+    harness.service.resumeRemoteOperations();
+    await flushPromises();
+    expect(harness.challengeCalls).toBe(1);
+
+    harness.service.suspendRemoteOperations();
+    reconciliationResult.reject(new Error("reconciliation response was lost"));
+    await flushPromises();
+    expect(harness.service.getSnapshot().pairingState).toBe("claiming");
+
+    harness.service.resumeRemoteOperations();
+    await expect(pairing).resolves.toBe(true);
+
+    expect(harness.claimCalls).toBe(1);
+    expect(harness.challengeCalls).toBe(2);
+    expect(harness.service.getSnapshot().pairingState).toBe("confirmed");
+  });
+
+  test("holds a successful in-flight poll result until the app is active", async () => {
+    const pollResult = deferred<DevicePairingChallenge>();
+    const harness = createHarness({
+      challengeResults: [pollResult.promise]
+    });
+
+    const pairing = harness.service.pairWithCode(pairingCode);
+    await flushPromises();
+    harness.clock.advanceBy(1_000);
+    await flushPromises();
+    expect(harness.challengeCalls).toBe(1);
+
+    harness.service.suspendRemoteOperations();
+    pollResult.resolve({
+      challengeId: "challenge-1",
+      expiresAt: new Date(10_000).toISOString(),
+      state: "confirmed"
+    });
+    await flushPromises();
+
+    expect(harness.service.getSnapshot().pairingState).toBe("waiting");
+
+    harness.service.resumeRemoteOperations();
+    await expect(pairing).resolves.toBe(true);
+    expect(harness.challengeCalls).toBe(1);
+    expect(harness.service.getSnapshot().pairingState).toBe("confirmed");
+  });
+
+  test("retries a read-only poll interrupted by a background transition", async () => {
+    const pollResult = deferred<DevicePairingChallenge>();
+    const harness = createHarness({
+      challengeResults: [pollResult.promise]
+    });
+
+    const pairing = harness.service.pairWithCode(pairingCode);
+    await flushPromises();
+    harness.clock.advanceBy(1_000);
+    await flushPromises();
+    expect(harness.challengeCalls).toBe(1);
+
+    harness.service.suspendRemoteOperations();
+    pollResult.reject(new Error("poll response was lost"));
+    await flushPromises();
+    expect(harness.service.getSnapshot().pairingState).toBe("waiting");
+
+    harness.service.resumeRemoteOperations();
+    await expect(pairing).resolves.toBe(true);
+    expect(harness.challengeCalls).toBe(2);
+    expect(harness.service.getSnapshot().pairingState).toBe("confirmed");
+  });
+
+  test("rejects invalid manual pairing codes before calling the gateway", async () => {
+    const harness = createHarness();
+
+    await expect(harness.service.pairWithCode("not-json")).resolves.toBe(false);
+
+    expect(harness.claimCalls).toBe(0);
+    expect(harness.service.getSnapshot()).toMatchObject({
+      errorCode: "pairing_failed",
+      pairingState: "idle"
+    });
+  });
+});
+
+function createHarness({
+  challengeResults = [],
+  claimResult,
+  scanner = {
+    start: () => ({
+      cancel: async () => undefined,
+      result: Promise.resolve(pairingCode)
+    })
+  }
+}: {
+  challengeResults?: Array<
+    DevicePairingChallenge | Promise<DevicePairingChallenge>
+  >;
+  claimResult?: Deferred<DevicePairingChallenge>;
+  scanner?: QRCodeScannerPort;
+} = {}) {
+  const clock = new ManualClock();
+  const diagnosticEvents: MobileDiagnosticEvent[] = [];
+  let challengeCalls = 0;
+  let claimCalls = 0;
+  const pairing: PairingPort = {
+    claimPairing: async () => {
+      claimCalls += 1;
+      return claimResult
+        ? claimResult.promise
+        : {
+            challengeId: "challenge-1",
+            expiresAt: new Date(10_000).toISOString(),
+            state: "awaiting_confirmation"
+          };
+    },
+    connectPairedDevice: async () => undefined,
+    getPairingChallenge: async () => {
+      challengeCalls += 1;
+      return (
+        (await challengeResults.shift()) ?? {
+          challengeId: "challenge-1",
+          expiresAt: new Date(10_000).toISOString(),
+          state: "confirmed"
+        }
+      );
+    },
+    listDevices: async () => [],
+    listPairings: async () => [],
+    registerCurrentDevice: async () => ({ userDeviceId: "mobile-1" })
+  };
+  const service = new DeviceService(
+    session,
+    pairing,
+    scanner,
+    { record: (event) => diagnosticEvents.push(event) },
+    clock,
+    async () => undefined
+  );
+  return {
+    get challengeCalls() {
+      return challengeCalls;
+    },
+    get claimCalls() {
+      return claimCalls;
+    },
+    clock,
+    diagnosticEvents,
+    service
+  };
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  reject(cause: unknown): void;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let reject!: (cause: unknown) => void;
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolver, rejecter) => {
+    reject = rejecter;
+    resolve = resolver;
+  });
+  return { promise, reject, resolve };
+}
+
+function scannerFrom(result: Deferred<string>): QRCodeScannerPort {
+  return {
+    start: () => ({
+      cancel: async () => {
+        result.reject({ code: "SCAN_CANCELLED" });
+      },
+      result: result.promise
+    })
+  };
+}
+
+async function flushPromises(): Promise<void> {
+  for (let index = 0; index < 16; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+class ManualClock implements ClockPort {
+  private nowValue = 0;
+  private readonly tasks: Array<{
+    at: number;
+    canceled: boolean;
+    callback(): void;
+  }> = [];
+
+  now(): number {
+    return this.nowValue;
+  }
+
+  schedule(delayMs: number, callback: () => void): { cancel(): void } {
+    const task = {
+      at: this.nowValue + delayMs,
+      callback,
+      canceled: false
+    };
+    this.tasks.push(task);
+    return {
+      cancel: () => {
+        task.canceled = true;
+      }
+    };
+  }
+
+  advanceBy(delayMs: number): void {
+    this.nowValue += delayMs;
+    for (const task of this.tasks) {
+      if (!task.canceled && task.at <= this.nowValue) {
+        task.canceled = true;
+        task.callback();
+      }
+    }
+  }
+}

--- a/apps/mobile/src/services/deviceService.ts
+++ b/apps/mobile/src/services/deviceService.ts
@@ -1,9 +1,18 @@
-import type { AccountSession, DevicePairing, UserDevice } from "./mobileDomain";
-import { ObservableService } from "./observableService";
 import type {
-  ClockPort,
-  DeviceSecurityPort,
-  PairingPort
+  AccountSession,
+  DevicePairing,
+  DevicePairingPhase,
+  UserDevice
+} from "./mobileDomain";
+import { ObservableService } from "./observableService";
+import { parsePairingQR } from "./pairingProtocol";
+import {
+  PAIRING_OPERATION_SUSPENDED,
+  type ClockPort,
+  type MobileDiagnosticsPort,
+  type PairingPort,
+  type QRCodeScanOperation,
+  type QRCodeScannerPort
 } from "./servicePorts";
 
 export type DeviceErrorCode =
@@ -23,9 +32,7 @@ export interface DeviceSnapshot {
   connectingPairingId: string | null;
   devices: readonly UserDevice[];
   errorCode: DeviceErrorCode;
-  manualPairingCode: string;
-  manualPairingOpen: boolean;
-  pairingState: "idle" | "claiming" | "waiting" | "confirmed";
+  pairingState: DevicePairingPhase;
   pairings: readonly DevicePairing[];
   refreshing: boolean;
 }
@@ -34,14 +41,16 @@ export class DeviceService extends ObservableService<DeviceSnapshot> {
   readonly _serviceBrand: undefined;
   private connectionGeneration = 0;
   private pairingGeneration = 0;
+  private remoteOperationsEnabled = true;
+  private remoteOperationsRevision = 0;
+  private readonly remoteResumeWaiters = new Set<() => void>();
+  private scanOperation: QRCodeScanOperation | null = null;
   private started = false;
   private disposed = false;
   private snapshot: DeviceSnapshot = {
     connectingPairingId: null,
     devices: [],
     errorCode: null,
-    manualPairingCode: "",
-    manualPairingOpen: false,
     pairingState: "idle",
     pairings: [],
     refreshing: false
@@ -50,7 +59,8 @@ export class DeviceService extends ObservableService<DeviceSnapshot> {
   constructor(
     private readonly session: AccountSession,
     private readonly pairing: PairingPort,
-    private readonly security: DeviceSecurityPort,
+    private readonly qrCodeScanner: QRCodeScannerPort,
+    private readonly diagnostics: MobileDiagnosticsPort,
     private readonly clock: ClockPort,
     private readonly onConnected: (device: ConnectedDevice) => Promise<void>
   ) {
@@ -62,20 +72,20 @@ export class DeviceService extends ObservableService<DeviceSnapshot> {
   start(): void {
     if (this.started || this.disposed) return;
     this.started = true;
-    void this.refresh();
-  }
-
-  setManualPairingCode(value: string): void {
-    this.patch({ manualPairingCode: value });
-  }
-
-  setManualPairingOpen(open: boolean): void {
-    this.patch({ manualPairingOpen: open });
+    if (this.remoteOperationsEnabled) {
+      void this.refresh();
+    }
   }
 
   async refresh(): Promise<void> {
     if (this.disposed || this.snapshot.refreshing) return;
-    this.patch({ errorCode: null, refreshing: true });
+    this.patch({
+      errorCode:
+        this.snapshot.errorCode === "request_failed"
+          ? null
+          : this.snapshot.errorCode,
+      refreshing: true
+    });
     try {
       const [registered, pairings, devices] = await Promise.all([
         this.pairing.registerCurrentDevice(this.session.sessionId),
@@ -94,62 +104,95 @@ export class DeviceService extends ObservableService<DeviceSnapshot> {
       });
     } catch {
       if (!this.disposed) {
-        this.patch({ errorCode: "request_failed", refreshing: false });
+        this.patch({
+          errorCode: this.snapshot.errorCode ?? "request_failed",
+          refreshing: false
+        });
       }
     }
   }
 
-  async pair(manualPayload?: string): Promise<void> {
-    const generation = ++this.pairingGeneration;
-    this.patch({ errorCode: null, pairingState: "claiming" });
+  async scanAndPair(): Promise<void> {
+    if (!this.canStartPairing()) return;
+    this.transitionPairing("scanning", { errorCode: null }, "scanner");
+    const operation = this.qrCodeScanner.start();
+    this.scanOperation = operation;
+    let rawPayload: string;
     try {
-      const rawPayload =
-        manualPayload?.trim() || (await this.security.scanQRCode());
-      const payload = this.pairing.parsePairingQR(rawPayload);
-      if (!this.isPairingCurrent(generation)) return;
-      const challenge = await this.pairing.claimPairing(
-        this.session.sessionId,
-        payload
-      );
-      if (!this.isPairingCurrent(generation)) return;
-      this.patch({ pairingState: "waiting" });
+      rawPayload = await operation.result;
+    } catch (cause) {
+      if (!this.disposed && this.snapshot.pairingState === "scanning") {
+        const errorCode = this.scannerErrorCode(cause);
+        this.transitionPairing("idle", { errorCode });
+        this.diagnostics.record({
+          errorCode,
+          name: "device_pairing.failed",
+          stage: "scanner"
+        });
+      }
+      return;
+    } finally {
+      if (this.scanOperation === operation) {
+        this.scanOperation = null;
+      }
+    }
+    if (this.disposed || this.snapshot.pairingState !== "scanning") return;
+    await this.pairWithRawPayload(rawPayload, "scanner");
+  }
+
+  async pairWithCode(rawPayload: string): Promise<boolean> {
+    if (!this.canStartPairing()) return false;
+    return this.pairWithRawPayload(rawPayload.trim(), "manual");
+  }
+
+  private async pairWithRawPayload(
+    rawPayload: string,
+    source: "manual" | "scanner"
+  ): Promise<boolean> {
+    const generation = ++this.pairingGeneration;
+    if (source === "manual") {
+      this.transitionPairing("claiming", { errorCode: null }, source);
+    }
+    try {
+      const payload = parsePairingQR(rawPayload);
+      if (!(await this.waitForRemoteOperations(generation))) return false;
+      if (source === "scanner") {
+        this.transitionPairing("claiming", { errorCode: null }, source);
+      }
+      const challenge = await this.claimWhenRemoteEnabled(generation, payload);
+      if (!this.isPairingCurrent(generation)) return false;
+      if (!(await this.waitForRemoteOperations(generation))) return false;
+      if (challenge.state === "confirmed") {
+        this.transitionPairing("confirmed");
+        await this.refresh();
+        return true;
+      }
+      this.transitionPairing("waiting");
       const deadline = Date.parse(challenge.expiresAt);
       while (this.clock.now() < deadline) {
         await this.wait(1_000);
-        if (!this.isPairingCurrent(generation)) return;
-        const latest = await this.pairing.getPairingChallenge(
-          this.session.sessionId,
-          payload.challengeId
+        if (!this.isPairingCurrent(generation)) return false;
+        const latest = await this.pollPairingChallengeWhenEnabled(
+          generation,
+          challenge.challengeId
         );
         if (latest.state === "confirmed") {
-          if (!this.isPairingCurrent(generation)) return;
-          this.patch({
-            manualPairingCode: "",
-            manualPairingOpen: false,
-            pairingState: "confirmed"
-          });
+          if (!this.isPairingCurrent(generation)) return false;
+          this.transitionPairing("confirmed");
           await this.refresh();
-          return;
+          return true;
         }
       }
       throw new Error("pairing challenge expired");
-    } catch (cause) {
-      if (!this.isPairingCurrent(generation)) return;
-      const code =
-        typeof cause === "object" && cause !== null && "code" in cause
-          ? String(cause.code)
-          : "";
-      this.patch({
-        errorCode:
-          code === "SCAN_CANCELLED"
-            ? null
-            : code === "SCANNER_PERMISSION_DENIED"
-              ? "camera_permission_required"
-              : code === "SCANNER_UNAVAILABLE" || code === "SCAN_FAILED"
-                ? "scanner_unavailable"
-                : "pairing_failed",
-        pairingState: "idle"
+    } catch {
+      if (!this.isPairingCurrent(generation)) return false;
+      this.transitionPairing("idle", { errorCode: "pairing_failed" });
+      this.diagnostics.record({
+        errorCode: "pairing_failed",
+        name: "device_pairing.failed",
+        stage: "pairing"
       });
+      return false;
     }
   }
 
@@ -182,28 +225,166 @@ export class DeviceService extends ObservableService<DeviceSnapshot> {
     }
   }
 
-  pause(): void {
-    this.pairingGeneration += 1;
+  suspendRemoteOperations(): void {
+    if (this.disposed || !this.remoteOperationsEnabled) return;
+    this.remoteOperationsEnabled = false;
+    this.remoteOperationsRevision += 1;
     this.connectionGeneration += 1;
-    this.patch({
-      connectingPairingId: null,
-      pairingState:
-        this.snapshot.pairingState === "claiming" ||
-        this.snapshot.pairingState === "waiting"
-          ? "idle"
-          : this.snapshot.pairingState
-    });
+    const suspendedPairingState =
+      this.snapshot.pairingState === "claiming" ||
+      this.snapshot.pairingState === "waiting"
+        ? this.snapshot.pairingState
+        : null;
+    if (suspendedPairingState) {
+      this.diagnostics.record({
+        name: "device_pairing.remote_suspended",
+        phase: suspendedPairingState
+      });
+    }
+    this.patch({ connectingPairingId: null });
   }
 
-  resume(): void {
-    if (!this.disposed) void this.refresh();
+  resumeRemoteOperations(): void {
+    if (this.disposed) return;
+    this.remoteOperationsEnabled = true;
+    this.releaseRemoteResumeWaiters();
+    void this.refresh();
   }
 
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    this.pause();
+    this.pairingGeneration += 1;
+    this.connectionGeneration += 1;
+    this.releaseRemoteResumeWaiters();
+    const scanOperation = this.scanOperation;
+    this.scanOperation = null;
+    void scanOperation?.cancel().catch(() => undefined);
     this.clearListeners();
+  }
+
+  private canStartPairing(): boolean {
+    return (
+      !this.disposed &&
+      (this.snapshot.pairingState === "idle" ||
+        this.snapshot.pairingState === "confirmed")
+    );
+  }
+
+  private scannerErrorCode(
+    cause: unknown
+  ): "camera_permission_required" | "scanner_unavailable" | null {
+    const code =
+      typeof cause === "object" && cause !== null && "code" in cause
+        ? String(cause.code)
+        : "";
+    if (code === "SCAN_CANCELLED") return null;
+    if (code === "SCANNER_PERMISSION_DENIED") {
+      return "camera_permission_required";
+    }
+    return "scanner_unavailable";
+  }
+
+  private transitionPairing(
+    pairingState: DeviceSnapshot["pairingState"],
+    patch: Partial<DeviceSnapshot> = {},
+    source?: "manual" | "scanner"
+  ): void {
+    this.patch({ ...patch, pairingState });
+    this.diagnostics.record({
+      name: "device_pairing.phase_changed",
+      phase: pairingState,
+      ...(source ? { source } : {})
+    });
+  }
+
+  private async claimWhenRemoteEnabled(
+    generation: number,
+    payload: ReturnType<typeof parsePairingQR>
+  ) {
+    while (this.isPairingCurrent(generation)) {
+      if (!(await this.waitForRemoteOperations(generation))) {
+        throw new Error("pairing was cancelled");
+      }
+      const remoteOperationsRevision = this.remoteOperationsRevision;
+      try {
+        return await this.pairing.claimPairing(
+          this.session.sessionId,
+          payload,
+          () =>
+            this.isPairingCurrent(generation) && this.remoteOperationsEnabled
+        );
+      } catch (cause) {
+        if (!this.isPairingCurrent(generation)) throw cause;
+        if (this.isPairingOperationSuspended(cause)) continue;
+        if (remoteOperationsRevision !== this.remoteOperationsRevision) {
+          if (!(await this.waitForRemoteOperations(generation))) throw cause;
+          const latest = await this.pollPairingChallengeWhenEnabled(
+            generation,
+            payload.challengeId
+          );
+          if (
+            latest.state === "awaiting_confirmation" ||
+            latest.state === "confirmed"
+          ) {
+            return latest;
+          }
+        }
+        throw cause;
+      }
+    }
+    throw new Error("pairing was cancelled");
+  }
+
+  private async pollPairingChallengeWhenEnabled(
+    generation: number,
+    challengeId: string
+  ) {
+    while (this.isPairingCurrent(generation)) {
+      if (!(await this.waitForRemoteOperations(generation))) {
+        throw new Error("pairing was cancelled");
+      }
+      const remoteOperationsRevision = this.remoteOperationsRevision;
+      try {
+        const challenge = await this.pairing.getPairingChallenge(
+          this.session.sessionId,
+          challengeId
+        );
+        if (!(await this.waitForRemoteOperations(generation))) {
+          throw new Error("pairing was cancelled");
+        }
+        return challenge;
+      } catch (cause) {
+        if (!this.isPairingCurrent(generation)) throw cause;
+        if (remoteOperationsRevision === this.remoteOperationsRevision) {
+          throw cause;
+        }
+      }
+    }
+    throw new Error("pairing was cancelled");
+  }
+
+  private isPairingOperationSuspended(cause: unknown): boolean {
+    return (
+      typeof cause === "object" &&
+      cause !== null &&
+      "code" in cause &&
+      cause.code === PAIRING_OPERATION_SUSPENDED
+    );
+  }
+
+  private async waitForRemoteOperations(generation: number): Promise<boolean> {
+    while (!this.remoteOperationsEnabled && this.isPairingCurrent(generation)) {
+      await new Promise<void>((resolve) => {
+        this.remoteResumeWaiters.add(resolve);
+      });
+    }
+    return this.remoteOperationsEnabled && this.isPairingCurrent(generation);
+  }
+
+  private releaseRemoteResumeWaiters(): void {
+    for (const resolve of this.remoteResumeWaiters) resolve();
+    this.remoteResumeWaiters.clear();
   }
 
   private isPairingCurrent(generation: number): boolean {

--- a/apps/mobile/src/services/http.test.ts
+++ b/apps/mobile/src/services/http.test.ts
@@ -1,0 +1,16 @@
+import { accountCookie } from "./http";
+
+describe("accountCookie", () => {
+  test("normalizes a valid account session", () => {
+    expect(accountCookie(" session-1 ")).toBe("session_id=session-1");
+  });
+
+  test.each(["", "session;admin=true", "session\rvalue", "session\nvalue"])(
+    "rejects an unsafe account session value",
+    (sessionId) => {
+      expect(() => accountCookie(sessionId)).toThrow(
+        "account session is missing"
+      );
+    }
+  );
+});

--- a/apps/mobile/src/services/http.ts
+++ b/apps/mobile/src/services/http.ts
@@ -21,7 +21,7 @@ export async function readJSON<T>(response: Response): Promise<T> {
 
 export function accountCookie(sessionID: string): string {
   const value = sessionID.trim();
-  if (!value) {
+  if (!value || /[;\r\n]/.test(value)) {
     throw new Error("account session is missing");
   }
   return `session_id=${value}`;

--- a/apps/mobile/src/services/mobileApplicationService.test.ts
+++ b/apps/mobile/src/services/mobileApplicationService.test.ts
@@ -2,7 +2,11 @@ import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
 import { InstantiationService } from "@tutti-os/infra/di";
 import type { AccountSession } from "./mobileDomain";
 import { MobileApplicationService } from "./mobileApplicationService";
-import type { ClockPort, MobileServicePorts } from "./servicePorts";
+import type {
+  ApplicationVisibility,
+  ClockPort,
+  MobileServicePorts
+} from "./servicePorts";
 
 const session: AccountSession = {
   email: "person@example.com",
@@ -21,6 +25,7 @@ describe("MobileApplicationService scopes", () => {
     await service.start();
 
     expect(service.getSnapshot().route).toBe("login");
+    expect(harness.legacyCookieClearCalls).toBe(1);
     const login = service.loginService!;
     login.setEmail(session.email);
     await login.submitEmail();
@@ -34,6 +39,7 @@ describe("MobileApplicationService scopes", () => {
     await service.signOut();
     expect(service.getSnapshot().route).toBe("login");
     expect(service.deviceService).toBeNull();
+    expect(harness.legacyCookieClearCalls).toBe(2);
   });
 
   test("background grace closes DeviceLink only after the deadline", async () => {
@@ -44,7 +50,7 @@ describe("MobileApplicationService scopes", () => {
     );
     await service.start();
 
-    harness.emitLifecycle(false);
+    harness.emitLifecycle("background");
     expect(harness.closeCalls).toBe(0);
     harness.clock.advanceBy(14_999);
     expect(harness.closeCalls).toBe(0);
@@ -53,21 +59,64 @@ describe("MobileApplicationService scopes", () => {
     expect(harness.closeCalls).toBe(1);
     expect(service.getSnapshot().route).toBe("devices");
   });
+
+  test("inactive transitions do not start the background disconnect grace", async () => {
+    const harness = createHarness(session);
+    const service = new MobileApplicationService(
+      new InstantiationService(),
+      harness.ports
+    );
+    await service.start();
+
+    harness.emitLifecycle("inactive");
+    harness.clock.advanceBy(15_000);
+    await Promise.resolve();
+
+    expect(harness.closeCalls).toBe(0);
+  });
+
+  test("creates an authenticated device scope with the current background level", async () => {
+    const storedSession = deferred<AccountSession | null>();
+    const harness = createHarness(storedSession.promise);
+    const service = new MobileApplicationService(
+      new InstantiationService(),
+      harness.ports
+    );
+
+    const start = service.start();
+    harness.emitLifecycle("background");
+    storedSession.resolve(session);
+    await start;
+
+    expect(service.getSnapshot().route).toBe("devices");
+    expect(harness.registerCalls).toBe(0);
+
+    harness.emitLifecycle("active");
+    await flushPromises();
+    expect(harness.registerCalls).toBe(1);
+  });
 });
 
-function createHarness(storedSession: AccountSession | null): {
+function createHarness(
+  storedSession: AccountSession | null | Promise<AccountSession | null>
+): {
   clock: ManualClock;
   closeCalls: number;
-  emitLifecycle(active: boolean): void;
+  emitLifecycle(visibility: ApplicationVisibility): void;
   ports: MobileServicePorts;
+  legacyCookieClearCalls: number;
+  registerCalls: number;
 } {
   const clock = new ManualClock();
-  let lifecycleListener: ((active: boolean) => void) | null = null;
+  let lifecycleListener: ((visibility: ApplicationVisibility) => void) | null =
+    null;
   const harness = {
     clock,
     closeCalls: 0,
-    emitLifecycle(active: boolean) {
-      lifecycleListener?.(active);
+    legacyCookieClearCalls: 0,
+    registerCalls: 0,
+    emitLifecycle(visibility: ApplicationVisibility) {
+      lifecycleListener?.(visibility);
     },
     ports: null as unknown as MobileServicePorts
   };
@@ -96,15 +145,13 @@ function createHarness(storedSession: AccountSession | null): {
       }),
       subscribeAgentLive: () => ({ close() {} })
     },
-    deviceSecurity: {
-      getOrCreateIdentity: async () => ({
-        arch: "arm64",
-        deviceId: "mobile-1",
-        deviceName: "Phone",
-        publicKey: "public-key"
-      }),
-      scanQRCode: async () => "",
-      sign: async () => ""
+    diagnostics: {
+      record: () => undefined
+    },
+    legacySessionCookie: {
+      clear: async () => {
+        harness.legacyCookieClearCalls += 1;
+      }
     },
     lifecycle: {
       subscribe(listener) {
@@ -118,7 +165,7 @@ function createHarness(storedSession: AccountSession | null): {
       claimPairing: async () => ({
         challengeId: "challenge-1",
         expiresAt: new Date(Date.now() + 1_000).toISOString(),
-        state: "claimed"
+        state: "awaiting_confirmation"
       }),
       connectPairedDevice: async () => undefined,
       getPairingChallenge: async () => ({
@@ -128,22 +175,43 @@ function createHarness(storedSession: AccountSession | null): {
       }),
       listDevices: async () => [],
       listPairings: async () => [],
-      parsePairingQR: () => ({
-        challengeId: "challenge-1",
-        secret: "secret",
-        version: 1
-      }),
-      registerCurrentDevice: async () => ({ userDeviceId: "mobile-1" })
+      registerCurrentDevice: async () => {
+        harness.registerCalls += 1;
+        return { userDeviceId: "mobile-1" };
+      }
+    },
+    qrCodeScanner: {
+      start: () => ({
+        cancel: async () => undefined,
+        result: Promise.resolve("")
+      })
     },
     sessionStorage: {
       clearSession: async () => undefined,
-      clearSessionCookie: async () => undefined,
-      installSessionCookie: async () => undefined,
       loadSession: async () => storedSession,
       saveSession: async () => undefined
     }
   };
   return harness;
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolver) => {
+    resolve = resolver;
+  });
+  return { promise, resolve };
+}
+
+async function flushPromises(): Promise<void> {
+  for (let index = 0; index < 8; index += 1) {
+    await Promise.resolve();
+  }
 }
 
 class ManualClock implements ClockPort {

--- a/apps/mobile/src/services/mobileApplicationService.ts
+++ b/apps/mobile/src/services/mobileApplicationService.ts
@@ -6,7 +6,6 @@ import {
   ServiceCollection,
   type IInstantiationService
 } from "@tutti-os/infra/di";
-import { accountBaseURL } from "../config";
 import type { AccountSession } from "./mobileDomain";
 import { AgentDirectoryService } from "./agentDirectoryService";
 import { ComposerDraftService } from "./composerDraftService";
@@ -26,7 +25,7 @@ import {
 } from "./mobileServiceIdentifiers";
 import { ObservableService } from "./observableService";
 import { MobileQuickPromptLibraryService } from "./mobileQuickPromptLibraryService";
-import type { MobileServicePorts } from "./servicePorts";
+import type { ApplicationVisibility, MobileServicePorts } from "./servicePorts";
 import { WorkspaceActivityService } from "./workspaceActivityService";
 import { WorkspaceCatalogService } from "./workspaceCatalogService";
 import { WorkspaceConversationRailService } from "./workspaceConversationRailService";
@@ -82,6 +81,7 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
   private workspaceCandidate: WorkspaceScope | null = null;
   private lifecycleDispose: (() => void) | null = null;
   private backgroundTask: { cancel(): void } | null = null;
+  private visibility: ApplicationVisibility = "active";
   private startPromise: Promise<void> | null = null;
   private workspaceGeneration = 0;
   private disposed = false;
@@ -117,18 +117,16 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
 
   start(): Promise<void> {
     if (this.startPromise) return this.startPromise;
-    this.lifecycleDispose = this.ports.lifecycle.subscribe((active) =>
-      this.handleLifecycle(active)
+    this.lifecycleDispose = this.ports.lifecycle.subscribe((visibility) =>
+      this.handleLifecycle(visibility)
     );
-    this.startPromise = this.ports.sessionStorage
-      .loadSession()
+    this.startPromise = this.ports.legacySessionCookie
+      .clear()
+      .catch(() => undefined)
+      .then(() => this.ports.sessionStorage.loadSession())
       .then(async (session) => {
         if (this.disposed) return;
         if (session) {
-          await this.ports.sessionStorage.installSessionCookie(
-            accountBaseURL,
-            session.sessionId
-          );
           this.enterAuthenticated(session);
         } else {
           this.enterUnauthenticated();
@@ -142,10 +140,10 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
 
   async signOut(): Promise<void> {
     await this.ports.deviceLink.closeLink().catch(() => undefined);
-    await this.ports.sessionStorage.clearSession();
-    await this.ports.sessionStorage
-      .clearSessionCookie(accountBaseURL)
-      .catch(() => undefined);
+    await Promise.all([
+      this.ports.sessionStorage.clearSession(),
+      this.ports.legacySessionCookie.clear().catch(() => undefined)
+    ]);
     this.disposeAuthenticatedScope();
     this.enterUnauthenticated();
   }
@@ -158,7 +156,9 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
     scope.device = null;
     scope.quickPrompts.reset();
     this.publish({ route: "devices", session: scope.session });
-    scope.deviceService.resume();
+    if (this.visibility === "active") {
+      scope.deviceService.resumeRemoteOperations();
+    }
   }
 
   showWorkspacePicker(): void {
@@ -295,10 +295,14 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
     const deviceService = new DeviceService(
       session,
       this.ports.pairing,
-      this.ports.deviceSecurity,
+      this.ports.qrCodeScanner,
+      this.ports.diagnostics,
       this.ports.clock,
       (device) => this.onDeviceConnected(device)
     );
+    if (this.visibility !== "active") {
+      deviceService.suspendRemoteOperations();
+    }
     const services = new ServiceCollection();
     services.set(IDeviceService, deviceService);
     services.set(IAgentDirectoryService, directory);
@@ -323,7 +327,7 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
     const scope = this.authenticatedScope;
     if (!scope) return;
     scope.device = device;
-    scope.deviceService.pause();
+    scope.deviceService.suspendRemoteOperations();
     void scope.directory.load();
     void scope.quickPrompts.refresh();
     this.publish({
@@ -339,24 +343,27 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
     }
   }
 
-  private handleLifecycle(active: boolean): void {
-    if (active) {
-      const hadPendingGrace = this.backgroundTask !== null;
+  private handleLifecycle(visibility: ApplicationVisibility): void {
+    this.visibility = visibility;
+    this.ports.diagnostics.record({
+      name: "application.visibility_changed",
+      visibility
+    });
+    if (visibility === "active") {
       this.backgroundTask?.cancel();
       this.backgroundTask = null;
-      if (hadPendingGrace) {
-        this.workspaceScope?.activity.resume();
-        this.workspaceCandidate?.activity.resume();
-        if (this.snapshot.route === "devices") {
-          this.authenticatedScope?.deviceService.resume();
-        }
+      this.workspaceScope?.activity.resume();
+      this.workspaceCandidate?.activity.resume();
+      if (this.snapshot.route === "devices") {
+        this.authenticatedScope?.deviceService.resumeRemoteOperations();
       }
       return;
     }
+    if (visibility === "inactive") return;
     if (this.backgroundTask) return;
     this.workspaceScope?.activity.pause();
     this.workspaceCandidate?.activity.pause();
-    this.authenticatedScope?.deviceService.pause();
+    this.authenticatedScope?.deviceService.suspendRemoteOperations();
     this.backgroundTask = this.ports.clock.schedule(BACKGROUND_GRACE_MS, () => {
       this.backgroundTask = null;
       void this.disconnectDevice();

--- a/apps/mobile/src/services/mobileDomain.ts
+++ b/apps/mobile/src/services/mobileDomain.ts
@@ -21,6 +21,24 @@ export interface DevicePairing {
   targetUserDeviceId: string;
 }
 
+export type DevicePairingPhase =
+  | "idle"
+  | "scanning"
+  | "claiming"
+  | "waiting"
+  | "confirmed";
+
+export type DevicePairingChallengeState =
+  | "awaiting_claim"
+  | "awaiting_confirmation"
+  | "confirmed";
+
+export interface DevicePairingChallenge {
+  challengeId: string;
+  expiresAt: string;
+  state: DevicePairingChallengeState;
+}
+
 export interface UserDevice {
   displayName: string;
   platform: string;

--- a/apps/mobile/src/services/pairingClient.test.ts
+++ b/apps/mobile/src/services/pairingClient.test.ts
@@ -1,3 +1,14 @@
+jest.mock("../native/mobileNative", () => ({
+  __esModule: true,
+  deviceLink: {},
+  mobileSecurity: {
+    getOrCreateIdentity: jest.fn(),
+    sign: jest.fn()
+  }
+}));
+
+import { mobileSecurity } from "../native/mobileNative";
+import { claimPairing, registerCurrentDevice } from "./pairingClient";
 import {
   deviceLinkProof,
   identityProof,
@@ -5,6 +16,80 @@ import {
   parsePairingQR,
   standardBase64ToURL
 } from "./pairingProtocol";
+import { PAIRING_OPERATION_SUSPENDED } from "./servicePorts";
+
+const mockGetOrCreateIdentity = jest.mocked(mobileSecurity.getOrCreateIdentity);
+const mockSign = jest.mocked(mobileSecurity.sign);
+
+function controlPlaneResponse(data: unknown): Response {
+  return {
+    json: async () => data,
+    ok: true,
+    status: 200
+  } as Response;
+}
+
+describe("control-plane authentication", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("uses only the explicit session cookie", async () => {
+    mockGetOrCreateIdentity.mockResolvedValue({
+      arch: "arm64",
+      deviceId: "device-1",
+      deviceName: "Alice's iPhone",
+      publicKey: "cHVibGljLWtleQ"
+    });
+    mockSign.mockResolvedValue("proof-1");
+    const fetchMock = jest.fn().mockResolvedValue(
+      controlPlaneResponse({
+        device: { userDeviceId: "user-device-1" }
+      })
+    );
+    globalThis.fetch = fetchMock;
+
+    await expect(registerCurrentDevice("session-1")).resolves.toEqual({
+      userDeviceId: "user-device-1"
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://tutti.sh/api/desktop/v1/devices/current",
+      expect.objectContaining({
+        credentials: "omit",
+        headers: expect.objectContaining({
+          Cookie: "session_id=session-1"
+        }),
+        method: "PUT"
+      })
+    );
+  });
+
+  it("does not send a claim after the operation is suspended", async () => {
+    mockGetOrCreateIdentity.mockResolvedValue({
+      arch: "arm64",
+      deviceId: "device-1",
+      deviceName: "Alice's iPhone",
+      publicKey: "cHVibGljLWtleQ"
+    });
+    const fetchMock = jest.fn();
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      claimPairing(
+        "session-1",
+        {
+          challengeId: "challenge-1",
+          secret: "a".repeat(43),
+          version: 1
+        },
+        () => false
+      )
+    ).rejects.toMatchObject({ code: PAIRING_OPERATION_SUSPENDED });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
 
 describe("parsePairingQR", () => {
   it("accepts the canonical version one payload", () => {

--- a/apps/mobile/src/services/pairingClient.ts
+++ b/apps/mobile/src/services/pairingClient.ts
@@ -1,7 +1,12 @@
 import { Platform } from "react-native";
 import { controlPlaneBaseURL, mobileClientVersion } from "../config";
 import { deviceLink, mobileSecurity } from "../native/mobileNative";
-import type { DeviceIdentity, DevicePairing, UserDevice } from "./mobileDomain";
+import type {
+  DeviceIdentity,
+  DevicePairing,
+  DevicePairingChallenge,
+  UserDevice
+} from "./mobileDomain";
 export type { DevicePairing, UserDevice } from "./mobileDomain";
 import { accountCookie, readJSON } from "./http";
 import {
@@ -12,18 +17,14 @@ import {
   standardBase64ToURL,
   type PairingQRPayload
 } from "./pairingProtocol";
-
-export { parsePairingQR } from "./pairingProtocol";
+import { PAIRING_OPERATION_SUSPENDED } from "./servicePorts";
 
 interface RegisteredDevice {
   userDeviceId: string;
 }
 
-interface PairingChallenge {
-  challengeId: string;
-  expiresAt: string;
+interface PairingChallenge extends DevicePairingChallenge {
   pairingId?: string;
-  state: string;
 }
 
 interface DeviceLinkICE {
@@ -49,13 +50,17 @@ interface DeviceLinkAttempt {
 
 export async function claimPairing(
   sessionId: string,
-  payload: PairingQRPayload
+  payload: PairingQRPayload,
+  isCurrent: () => boolean = () => true
 ): Promise<PairingChallenge> {
   const identity = await mobileSecurity.getOrCreateIdentity();
+  requireCurrentPairing(isCurrent);
   await registerIdentity(sessionId, identity);
+  requireCurrentPairing(isCurrent);
   const signature = await mobileSecurity.sign(
     pairingClaimProof(payload.challengeId, payload.secret)
   );
+  requireCurrentPairing(isCurrent);
   const response = await controlPlaneRequest<{ challenge: PairingChallenge }>(
     sessionId,
     `/device-pairing-challenges/${encodeURIComponent(payload.challengeId)}/claim`,
@@ -69,6 +74,13 @@ export async function claimPairing(
     }
   );
   return response.challenge;
+}
+
+function requireCurrentPairing(isCurrent: () => boolean): void {
+  if (isCurrent()) return;
+  throw Object.assign(new Error("pairing operation was suspended"), {
+    code: PAIRING_OPERATION_SUSPENDED
+  });
 }
 
 export async function getPairingChallenge(
@@ -342,6 +354,7 @@ async function controlPlaneRequest<T>(
   try {
     const response = await fetch(`${controlPlaneBaseURL}${path}`, {
       ...init,
+      credentials: "omit",
       headers: {
         Accept: "application/json",
         Cookie: accountCookie(sessionId),

--- a/apps/mobile/src/services/servicePorts.ts
+++ b/apps/mobile/src/services/servicePorts.ts
@@ -2,8 +2,9 @@ import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
 import type { AgentActivityLiveEvent } from "@tutti-os/agent-activity-core";
 import type {
   AccountSession,
-  DeviceIdentity,
+  DevicePairingChallenge,
   DevicePairing,
+  DevicePairingPhase,
   UserDevice
 } from "./mobileDomain";
 import type { PairingQRPayload } from "./pairingProtocol";
@@ -16,11 +17,6 @@ export interface AccountPort {
 
 export interface SessionStoragePort {
   clearSession(): Promise<void>;
-  clearSessionCookie(accountBaseURL: string): Promise<void>;
-  installSessionCookie(
-    accountBaseURL: string,
-    sessionId: string
-  ): Promise<void>;
   loadSession(): Promise<AccountSession | null>;
   saveSession(
     sessionId: string,
@@ -30,11 +26,20 @@ export interface SessionStoragePort {
   ): Promise<void>;
 }
 
-export interface DeviceSecurityPort {
-  getOrCreateIdentity(): Promise<DeviceIdentity>;
-  scanQRCode(): Promise<string>;
-  sign(message: string): Promise<string>;
+export interface LegacySessionCookiePort {
+  clear(): Promise<void>;
 }
+
+export interface QRCodeScanOperation {
+  cancel(): Promise<void>;
+  result: Promise<string>;
+}
+
+export interface QRCodeScannerPort {
+  start(): QRCodeScanOperation;
+}
+
+export const PAIRING_OPERATION_SUSPENDED = "PAIRING_OPERATION_SUSPENDED";
 
 export interface DeviceLinkPort {
   closeLink(): Promise<void>;
@@ -101,8 +106,9 @@ export interface AgentLiveReconcileKey {
 export interface PairingPort {
   claimPairing(
     sessionId: string,
-    payload: PairingQRPayload
-  ): Promise<{ challengeId: string; expiresAt: string; state: string }>;
+    payload: PairingQRPayload,
+    isCurrent: () => boolean
+  ): Promise<DevicePairingChallenge>;
   connectPairedDevice(
     sessionId: string,
     pairingId: string,
@@ -111,15 +117,44 @@ export interface PairingPort {
   getPairingChallenge(
     sessionId: string,
     challengeId: string
-  ): Promise<{ challengeId: string; expiresAt: string; state: string }>;
+  ): Promise<DevicePairingChallenge>;
   listDevices(sessionId: string): Promise<UserDevice[]>;
   listPairings(sessionId: string): Promise<DevicePairing[]>;
-  parsePairingQR(raw: string): PairingQRPayload;
   registerCurrentDevice(sessionId: string): Promise<{ userDeviceId: string }>;
 }
 
+export type ApplicationVisibility = "active" | "background" | "inactive";
+
 export interface LifecyclePort {
-  subscribe(listener: (active: boolean) => void): () => void;
+  subscribe(listener: (visibility: ApplicationVisibility) => void): () => void;
+}
+
+export type MobileDiagnosticEvent =
+  | {
+      name: "application.visibility_changed";
+      visibility: ApplicationVisibility;
+    }
+  | {
+      name: "device_pairing.phase_changed";
+      phase: DevicePairingPhase;
+      source?: "manual" | "scanner";
+    }
+  | {
+      errorCode:
+        | "camera_permission_required"
+        | "pairing_failed"
+        | "scanner_unavailable"
+        | null;
+      name: "device_pairing.failed";
+      stage: "pairing" | "scanner";
+    }
+  | {
+      name: "device_pairing.remote_suspended";
+      phase: "claiming" | "waiting";
+    };
+
+export interface MobileDiagnosticsPort {
+  record(event: MobileDiagnosticEvent): void;
 }
 
 export interface ClockPort {
@@ -131,9 +166,11 @@ export interface MobileServicePorts {
   account: AccountPort;
   clock: ClockPort;
   deviceLink: DeviceLinkPort;
-  deviceSecurity: DeviceSecurityPort;
+  diagnostics: MobileDiagnosticsPort;
+  legacySessionCookie: LegacySessionCookiePort;
   lifecycle: LifecyclePort;
   pairing: PairingPort;
+  qrCodeScanner: QRCodeScannerPort;
   sessionStorage: SessionStoragePort;
   createRemoteClient(): TuttidClient;
 }

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -120,6 +120,7 @@ Android app login, native bridge, secure identity, and mobile transport diagnost
 - [Mobile composer model and permission controls are missing](./mobile.md#mobile-composer-model-and-permission-controls-are-missing)
 - [Mobile composer option chips do not open](./mobile.md#mobile-composer-option-chips-do-not-open)
 - [Browser login returns to the App but remains signed out](./mobile.md#browser-login-returns-to-the-app-but-remains-signed-out)
+- [Android scanner returns but pairing never starts](./mobile.md#android-scanner-returns-but-pairing-never-starts)
 - [Android DeviceLink opens a session and then repeatedly restarts](./mobile.md#android-devicelink-opens-a-session-and-then-repeatedly-restarts)
 - [iOS pod install intermittently reports pathname contains null byte](./mobile.md#ios-pod-install-intermittently-reports-pathname-contains-null-byte)
 - [React Native Pressable rows stack their children vertically](./mobile.md#react-native-pressable-rows-stack-their-children-vertically)

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -120,19 +120,62 @@
   the callback. In read-only account-service access logs, compare the transfer
   code redemption with the immediately following `user/v1/user_info` request. A
   successful redemption followed by `SESSION_ID_MISSING` identifies this case.
-- **Root cause:** React Native Android networking uses its native
-  `ForwardingCookieHandler` and WebView `CookieManager`. A JavaScript `Cookie`
-  request header is not sufficient to seed that cookie jar after the desktop
-  transfer-code endpoint returns a session id in JSON.
-- **Fix:** Install the redeemed `session_id` into the native cookie store before
-  requesting account information. Reinstall it from encrypted session storage
-  during App startup, and expire it on sign-out. Do not move provider credentials
-  or browser cookies through JavaScript.
+- **Root cause:** Mobile API requests already authenticate from the encrypted
+  session using one explicit `Cookie` header. Leaving React Native's native
+  cookie jar enabled creates a second credential source; a stale native
+  `session_id` can be appended to or override the explicit session after browser
+  login.
+- **Fix:** Keep the account session in encrypted native storage, set
+  `credentials: "omit"` on account and control-plane fetches, and attach exactly
+  one validated `session_id` header per API request. The system browser login
+  bridge returns only a short-lived transfer code; do not copy provider or
+  browser cookies into the App, and do not make API login depend on a WebView
+  cookie store. During migration, clear the legacy native `session_id` cookie
+  at startup and sign-out, but keep cookie installation outside the application
+  port contract.
 - **Validation:** Complete a real system-browser login, verify the App reaches the
   device page, restart the App, and verify the same account session still
   authorizes device-list requests.
 - **References:** `apps/mobile/src/services/accountClient.ts`,
   `apps/mobile/android/app/src/main/java/dev/tutti/mobile/MobileSecurityModule.kt`
+
+## Android scanner returns but pairing never starts
+
+- **Symptom:** Tapping “Scan pairing code” opens the camera and recognizes the
+  Desktop QR code, but the Mobile device page shows no result and the account
+  control-plane API never receives the pairing challenge claim.
+- **Quick checks:** Filter `ReactNativeJS` in logcat. A healthy sequence contains
+  `device_pairing.phase_changed` with `scanning`, an
+  `application.visibility_changed` event with `background`, then
+  `device_pairing.phase_changed` with `claiming` after the scanner returns.
+  These events contain no QR payload or secret. If the sequence ends after
+  `scanning`, inspect the application lifecycle boundary before the camera,
+  parser, or control-plane request.
+- **Root cause:** ZXing presents a separate Android `CaptureActivity`, so the
+  React Native host enters the background while the system scanner is visible.
+  A boolean lifecycle adapter previously treated that transition as a request
+  to cancel every device-page operation. It invalidated the pairing generation
+  while the scanner promise was pending, then silently discarded the valid
+  result before sending the claim.
+- **Fix:** Model `active`, `inactive`, and `background` explicitly. Keep QR
+  acquisition in a `scanning` phase that survives host background transitions,
+  and start the cancellable remote pairing generation only after parsing the
+  scanner result. If a claim POST is already in flight, settle it and resume
+  confirmation polling after returning active; its server-side effect cannot be
+  canceled safely. If the response is lost across that transition, read the
+  challenge state to reconcile the result instead of repeating the claim POST.
+  Keep manual form state in the screen rather than adding scanner-specific flags
+  to the global application lifecycle.
+- **Validation:** In a service regression test, start scanning, emit background
+  and active transitions, resolve the scanner once, and assert exactly one
+  claim followed by confirmation. Also cover duplicate taps, scanner
+  cancellation, permission denial, disposal while scanning, invalid manual
+  codes, and background suspension during a remote claim. Repeat the sequence
+  on a physical Android device and confirm the structured log contains no
+  pairing payload.
+- **References:** `apps/mobile/src/services/deviceService.ts`,
+  `apps/mobile/src/services/mobileApplicationService.ts`,
+  `apps/mobile/src/native/createMobileServicePorts.ts`
 
 ## Android DeviceLink opens a session and then repeatedly restarts
 

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -331,6 +331,20 @@ adb install -r path/to/app-debug.apk
 首次使用由 Android 请求相机权限。设备签名私钥由 Android Keystore 生成并持有，
 Native bridge 只导出原始 Ed25519 公钥和签名结果。
 
+扫码属于页面发起、Native 完成的本地系统交互，不属于远端配对操作。Android 打开
+ZXing `CaptureActivity` 时 React Native 宿主会进入 `background`，iOS 的系统过渡
+也可能先进入 `inactive`；生命周期 adapter 必须保留这两个状态，不能压缩成一个
+`active: boolean`。设备服务使用显式 `scanning` 阶段承接扫码结果，只有解析出配对码
+后才启动可被后台策略暂停的 claim/poll。应用进入后台可以中止正在进行的远端
+连接尝试并暂停配对的后续远端步骤，但不能仅因系统扫码界面覆盖宿主 Activity 就作废
+扫码结果。已经发出的 claim 必须在回到前台后按 challenge 状态对账，不能盲目重试
+可能已经成功的 POST；只读 poll 才可以在生命周期中断后安全重试。扫码 adapter 返回
+可取消 operation；设备服务销毁时必须关闭原生扫描界面，并在旧 scanner callback
+排空后才完成取消。手动输入框的展开和值属于 screen 临时状态，不进入设备服务快照。
+
+移动端为生命周期与配对阶段输出结构化 JavaScript 日志，只记录事件名、可枚举阶段、
+来源和脱敏错误码。禁止记录二维码、手动配对码、challenge id、secret 或 session。
+
 ## 7. 真机开发需要做什么
 
 Android 手机启用“开发者选项”和“USB 调试”，连接电脑后执行：
@@ -426,9 +440,10 @@ Google Play 账号。以下事项等正式分发前再处理：
   TypeScript/Jest、Metro bundle、Kotlin/Java/CMake、四 ABI APK 均已有自动验证。
 - `apps/mobile/ios` 已建立 React Native 0.86/Fabric Simulator shell，并提供与
   Android 相同的两个 Native Module contract；iOS adapter 已接入 Keychain
-  Ed25519 identity/session、共享 Cookie、localhost browser login bridge、AVFoundation
-  QR scanner、Go DeviceLink request framing、Agent live Subscriber、事件派发和
-  15 秒后台 grace。模拟器扫码明确降级到现有手动粘贴入口，不伪造相机成功。
+  Ed25519 identity/session、显式 API session cookie、localhost browser login
+  bridge、AVFoundation QR scanner、Go DeviceLink request framing、Agent live
+  Subscriber、事件派发和 15 秒后台 grace。模拟器扫码明确降级到现有手动粘贴入口，
+  不伪造相机成功。
 - iOS Metro production bundle、device + Simulator XCFramework、Pods、generic
   Simulator build 均已通过；App 已安装并启动于 iPhone 17 Pro / iOS 26.5
   Simulator，Hermes 成功执行共享 JavaScript bundle。


### PR DESCRIPTION
## Summary

- keep QR acquisition alive while Android's ZXing `CaptureActivity` backgrounds the React Native host
- model application visibility and pairing phases explicitly, with lifecycle-safe claim reconciliation and read-only polling retries
- make Android and iOS scanner cancellation drain the native operation before releasing the scanner slot
- keep account authentication on one explicit validated session cookie while cleaning up legacy native cookies
- add focused lifecycle, race, scanner error, authentication, and scope-creation regression coverage
- document the architecture boundary and durable troubleshooting path

## Root cause

The scanner is presented as a separate Android Activity. Opening it backgrounds the React Native host, and the previous lifecycle adapter treated that transition as a request to invalidate every device-page operation. The pending scanner result was therefore discarded before the pairing claim was sent.

The fix also closes adjacent race windows discovered during review: an ambiguous claim response is reconciled through the authoritative challenge state instead of repeating a potentially successful POST, read-only polling waits for the active lifecycle level, and newly created authenticated scopes inherit the already-observed application visibility.

## Design

- local QR acquisition is represented by a cancellable scanner operation and an explicit `scanning` phase
- remote pairing owns `awaiting_claim -> awaiting_confirmation -> confirmed` as typed domain states
- mutating claims are never blindly retried after an ambiguous response; challenge reads perform reconciliation
- Android uses a main-thread scanner state machine and per-operation request codes so late callbacks cannot settle a newer scan
- iOS serializes capture start/stop and resolves cancellation only after the old capture session has stopped and dismissed
- manual form state remains screen-local; application lifecycle and product state are not coupled through UI flags

## Validation

- `pnpm check:changed -- --push-ready`
- focused Mobile Jest suites: 29 tests passed
- `pnpm --filter @tutti-os/mobile typecheck`
- Android and iOS native binding checks
- Android `app:assembleDebug`
- iOS Simulator Debug build
- three independent final reviews covering architecture, lifecycle races/tests, and native adapters: no findings

## Remaining device validation

A physical Android device is not currently connected. The PR remains draft until the scan -> claim -> confirm flow is exercised once on device.