### PR TITLE
fix(desktop): expose Tutti Agent logs and mentions

### DIFF
--- a/apps/desktop/src/main/developerLogs.test.ts
+++ b/apps/desktop/src/main/developerLogs.test.ts
@@ -448,6 +448,32 @@ test("developer logs service exports provider session records from tuttid snapsh
         },
         updatedAtUnixMS: 10,
         workspaceID
+      },
+      {
+        agentSessionID: "agent-tutti",
+        hasMoreMessages: false,
+        latestMessageVersion: 9,
+        messages: [
+          {
+            agentSessionId: "agent-tutti",
+            id: 3,
+            kind: "text",
+            messageId: "tutti-message",
+            role: "assistant",
+            version: 9
+          }
+        ],
+        provider: "tutti-agent",
+        providerSessionID: "provider-tutti",
+        session: {
+          id: "agent-tutti",
+          provider: "tutti-agent",
+          providerSessionId: "provider-tutti",
+          createdAt: "2026-06-10T00:00:00Z",
+          updatedAt: "2026-06-10T00:00:25Z"
+        },
+        updatedAtUnixMS: 25,
+        workspaceID
       }
     ],
     defaults: {
@@ -469,7 +495,7 @@ test("developer logs service exports provider session records from tuttid snapsh
 
   const result = await service.exportLogs();
 
-  assert.equal(result.fileCount, 6);
+  assert.equal(result.fileCount, 9);
   assert.ok(result.filePath);
   const zipText = (await readFile(result.filePath)).toString("utf8");
   assert.equal(
@@ -493,6 +519,12 @@ test("developer logs service exports provider session records from tuttid snapsh
   assert.equal(
     zipText.includes(
       "agent-sessions/claude-code/workspace-1/agent-claude/manifest.json"
+    ),
+    true
+  );
+  assert.equal(
+    zipText.includes(
+      "agent-sessions/tutti-agent/workspace-1/agent-tutti/manifest.json"
     ),
     true
   );

--- a/apps/desktop/src/main/developerLogs.test.ts
+++ b/apps/desktop/src/main/developerLogs.test.ts
@@ -5,7 +5,10 @@ import { tmpdir } from "node:os";
 import test from "node:test";
 import { inflateRawSync } from "node:zlib";
 import { createDeveloperLogsService } from "./developerLogs.ts";
-import type { DeveloperLogsAgentSessionRecord } from "./developerLogsAgentSessions.ts";
+import {
+  loadDeveloperLogsAgentSessionAttachments,
+  type DeveloperLogsAgentSessionRecord
+} from "./developerLogsAgentSessions.ts";
 import { sanitizeDeveloperLogsTransportSnapshot } from "./developerLogsRuntimeContext.ts";
 import { workspaceAppScopeSegment } from "./host/workspaceAppFolderPaths.ts";
 
@@ -451,6 +454,14 @@ test("developer logs service exports provider session records from tuttid snapsh
       },
       {
         agentSessionID: "agent-tutti",
+        attachments: [
+          {
+            attachmentID: "attachment-screen",
+            dataBase64: Buffer.from("original-image-bytes").toString("base64"),
+            mimeType: "image/png",
+            name: "screen.png"
+          }
+        ],
         hasMoreMessages: false,
         latestMessageVersion: 9,
         messages: [
@@ -459,7 +470,17 @@ test("developer logs service exports provider session records from tuttid snapsh
             id: 3,
             kind: "text",
             messageId: "tutti-message",
-            role: "assistant",
+            payload: {
+              content: [
+                {
+                  attachmentId: "attachment-screen",
+                  mimeType: "image/png",
+                  name: "screen.png",
+                  type: "image"
+                }
+              ]
+            },
+            role: "user",
             version: 9
           }
         ],
@@ -495,9 +516,10 @@ test("developer logs service exports provider session records from tuttid snapsh
 
   const result = await service.exportLogs();
 
-  assert.equal(result.fileCount, 9);
+  assert.equal(result.fileCount, 10);
   assert.ok(result.filePath);
-  const zipText = (await readFile(result.filePath)).toString("utf8");
+  const zip = await readFile(result.filePath);
+  const zipText = zip.toString("utf8");
   assert.equal(
     zipText.includes(
       "agent-sessions/codex/workspace-1/agent-codex/manifest.json"
@@ -528,6 +550,98 @@ test("developer logs service exports provider session records from tuttid snapsh
     ),
     true
   );
+  const entries = readZipEntries(zip);
+  assert.equal(
+    entries
+      .get(
+        "agent-sessions/tutti-agent/workspace-1/agent-tutti/attachments/attachment-screen.png"
+      )
+      ?.toString("utf8"),
+    "original-image-bytes"
+  );
+  const manifest = JSON.parse(
+    entries
+      .get("agent-sessions/tutti-agent/workspace-1/agent-tutti/manifest.json")
+      ?.toString("utf8") ?? "{}"
+  ) as {
+    attachments?: unknown[];
+    files?: { attachments?: string[] };
+    unavailableAttachmentIds?: string[];
+  };
+  assert.deepEqual(manifest.attachments, [
+    {
+      attachmentId: "attachment-screen",
+      file: "attachments/attachment-screen.png",
+      mimeType: "image/png",
+      name: "screen.png",
+      sizeBytes: 20
+    }
+  ]);
+  assert.deepEqual(manifest.files?.attachments, [
+    "attachments/attachment-screen.png"
+  ]);
+  assert.deepEqual(manifest.unavailableAttachmentIds, []);
+});
+
+test("developer logs attachment loading deduplicates image references and records failures", async () => {
+  const requestedAttachmentIDs: string[] = [];
+  const result = await loadDeveloperLogsAgentSessionAttachments(
+    [
+      {
+        payload: {
+          content: [
+            {
+              attachmentId: "attachment-1",
+              mimeType: "image/png",
+              name: "screen.png",
+              type: "image"
+            },
+            {
+              attachmentId: "attachment-1",
+              mimeType: "image/png",
+              type: "image"
+            },
+            {
+              attachmentId: "attachment-file",
+              type: "file"
+            },
+            {
+              attachmentId: "attachment-missing",
+              mimeType: "image/webp",
+              type: "image"
+            }
+          ]
+        }
+      }
+    ],
+    async (attachmentID) => {
+      requestedAttachmentIDs.push(attachmentID);
+      if (attachmentID === "attachment-missing") {
+        throw new Error("attachment is unavailable");
+      }
+      return {
+        attachmentId: attachmentID,
+        data: Buffer.from("image").toString("base64"),
+        mimeType: "image/png"
+      };
+    }
+  );
+
+  assert.deepEqual(requestedAttachmentIDs, [
+    "attachment-1",
+    "attachment-missing"
+  ]);
+  assert.deepEqual(result, {
+    attachments: [
+      {
+        attachmentID: "attachment-1",
+        dataBase64: "aW1hZ2U=",
+        mimeType: "image/png",
+        name: "screen.png"
+      }
+    ],
+    unavailableAttachmentIDs: ["attachment-missing"]
+  });
 });
 
 test("developer logs service exports at most ten provider session records per provider", async () => {

--- a/apps/desktop/src/main/developerLogs.ts
+++ b/apps/desktop/src/main/developerLogs.ts
@@ -68,7 +68,7 @@ type DeveloperDiagnosticsArtifact =
       clearable: false;
       agentSessionID: string;
       path: string;
-      provider: "claude-code" | "codex" | "cursor";
+      provider: DeveloperLogsAgentSessionRecord["provider"];
       updatedAtUnixMS: number;
       workspaceID: string;
     }

--- a/apps/desktop/src/main/developerLogsAgentSessions.ts
+++ b/apps/desktop/src/main/developerLogsAgentSessions.ts
@@ -3,7 +3,7 @@ export interface DeveloperLogsAgentSessionRecord {
   hasMoreMessages: boolean;
   latestMessageVersion: number;
   messages: unknown[];
-  provider: "claude-code" | "codex" | "cursor";
+  provider: "claude-code" | "codex" | "cursor" | "tutti-agent";
   providerSessionID: string;
   session: unknown;
   updatedAtUnixMS: number;
@@ -15,7 +15,7 @@ export interface ExportedAgentSessionFile {
   archivePath: string;
   content: Buffer;
   path: string;
-  provider: "claude-code" | "codex" | "cursor";
+  provider: "claude-code" | "codex" | "cursor" | "tutti-agent";
   sizeBytes: number;
   workspaceID: string;
 }

--- a/apps/desktop/src/main/developerLogsAgentSessions.ts
+++ b/apps/desktop/src/main/developerLogsAgentSessions.ts
@@ -1,5 +1,13 @@
+export interface DeveloperLogsAgentSessionAttachment {
+  attachmentID: string;
+  dataBase64: string;
+  mimeType: "image/png" | "image/jpeg" | "image/webp";
+  name?: string;
+}
+
 export interface DeveloperLogsAgentSessionRecord {
   agentSessionID: string;
+  attachments?: DeveloperLogsAgentSessionAttachment[];
   hasMoreMessages: boolean;
   latestMessageVersion: number;
   messages: unknown[];
@@ -7,6 +15,7 @@ export interface DeveloperLogsAgentSessionRecord {
   providerSessionID: string;
   session: unknown;
   updatedAtUnixMS: number;
+  unavailableAttachmentIDs?: string[];
   workspaceID: string;
 }
 
@@ -34,6 +43,23 @@ export function buildProviderAgentSessionRecordFiles(
       safeZipPathSegment(record.workspaceID),
       safeZipPathSegment(record.agentSessionID)
     );
+    const attachmentFiles = (record.attachments ?? []).flatMap((attachment) => {
+      const extension = imageExtension(attachment.mimeType);
+      if (!extension) return [];
+      const fileName = `${safeZipPathSegment(attachment.attachmentID)}${extension}`;
+      const content = Buffer.from(attachment.dataBase64, "base64");
+      return [
+        {
+          attachmentID: attachment.attachmentID,
+          archivePath: joinZipPath(sessionDir, "attachments", fileName),
+          content,
+          fileName: joinZipPath("attachments", fileName),
+          mimeType: attachment.mimeType,
+          ...(attachment.name ? { name: attachment.name } : {}),
+          sizeBytes: content.byteLength
+        }
+      ];
+    });
     const manifest = jsonBuffer({
       schemaVersion: 1,
       exportedAt,
@@ -44,9 +70,18 @@ export function buildProviderAgentSessionRecordFiles(
       latestMessageVersion: record.latestMessageVersion,
       hasMoreMessages: record.hasMoreMessages,
       messageCount: record.messages.length,
+      attachments: attachmentFiles.map((attachment) => ({
+        attachmentId: attachment.attachmentID,
+        mimeType: attachment.mimeType,
+        ...(attachment.name ? { name: attachment.name } : {}),
+        file: attachment.fileName,
+        sizeBytes: attachment.sizeBytes
+      })),
+      unavailableAttachmentIds: record.unavailableAttachmentIDs ?? [],
       files: {
         session: "session.json",
-        messages: "messages.jsonl"
+        messages: "messages.jsonl",
+        attachments: attachmentFiles.map((attachment) => attachment.fileName)
       }
     });
     const session = jsonBuffer({
@@ -82,9 +117,69 @@ export function buildProviderAgentSessionRecordFiles(
         sessionDir,
         "messages.jsonl",
         messages
-      )
+      ),
+      ...attachmentFiles.map((attachment) => ({
+        agentSessionID: record.agentSessionID,
+        archivePath: attachment.archivePath,
+        content: attachment.content,
+        path: `tuttid-attachment://${record.workspaceID}/${record.agentSessionID}/${attachment.attachmentID}`,
+        provider: record.provider,
+        sizeBytes: attachment.sizeBytes,
+        workspaceID: record.workspaceID
+      }))
     ];
   });
+}
+
+export async function loadDeveloperLogsAgentSessionAttachments(
+  messages: readonly unknown[],
+  readAttachment: (attachmentID: string) => Promise<{
+    attachmentId: string;
+    data: string;
+    mimeType: "image/png" | "image/jpeg" | "image/webp";
+    name?: string;
+  }>
+): Promise<{
+  attachments: DeveloperLogsAgentSessionAttachment[];
+  unavailableAttachmentIDs: string[];
+}> {
+  const references = collectImageAttachmentReferences(messages);
+  const results = await Promise.all(
+    references.map(
+      async (
+        reference
+      ): Promise<
+        | { attachment: DeveloperLogsAgentSessionAttachment }
+        | { unavailableAttachmentID: string }
+      > => {
+        try {
+          const attachment = await readAttachment(reference.attachmentID);
+          return {
+            attachment: {
+              attachmentID: reference.attachmentID,
+              dataBase64: attachment.data,
+              mimeType: attachment.mimeType,
+              ...((attachment.name ?? reference.name)
+                ? { name: attachment.name ?? reference.name }
+                : {})
+            } satisfies DeveloperLogsAgentSessionAttachment
+          };
+        } catch {
+          return { unavailableAttachmentID: reference.attachmentID };
+        }
+      }
+    )
+  );
+  return {
+    attachments: results.flatMap((result) =>
+      "attachment" in result ? [result.attachment] : []
+    ),
+    unavailableAttachmentIDs: results.flatMap((result) =>
+      "unavailableAttachmentID" in result
+        ? [result.unavailableAttachmentID]
+        : []
+    )
+  };
 }
 
 function createExportedAgentSessionFile(
@@ -145,4 +240,48 @@ function safeZipPathSegment(value: string): string {
     return "_";
   }
   return safe;
+}
+
+function collectImageAttachmentReferences(
+  values: readonly unknown[]
+): Array<{ attachmentID: string; name?: string }> {
+  const references = new Map<string, { attachmentID: string; name?: string }>();
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+    if (!value || typeof value !== "object") return;
+    const candidate = value as Record<string, unknown>;
+    if (
+      candidate.type === "image" &&
+      typeof candidate.attachmentId === "string"
+    ) {
+      const attachmentID = candidate.attachmentId.trim();
+      if (attachmentID && !references.has(attachmentID)) {
+        const name =
+          typeof candidate.name === "string" ? candidate.name.trim() : "";
+        references.set(attachmentID, {
+          attachmentID,
+          ...(name ? { name } : {})
+        });
+      }
+    }
+    Object.values(candidate).forEach(visit);
+  };
+  values.forEach(visit);
+  return [...references.values()];
+}
+
+function imageExtension(
+  mimeType: DeveloperLogsAgentSessionAttachment["mimeType"]
+): ".jpg" | ".png" | ".webp" | null {
+  switch (mimeType) {
+    case "image/jpeg":
+      return ".jpg";
+    case "image/png":
+      return ".png";
+    case "image/webp":
+      return ".webp";
+  }
 }

--- a/apps/desktop/src/main/developerLogsDesktop.ts
+++ b/apps/desktop/src/main/developerLogsDesktop.ts
@@ -10,6 +10,7 @@ import {
   type DeveloperLogsAppCenterSnapshot
 } from "./developerLogs.ts";
 import type { DeveloperLogsAgentSessionRecord } from "./developerLogsAgentSessions.ts";
+import { loadDeveloperLogsAgentSessionAttachments } from "./developerLogsAgentSessions.ts";
 import { getSystemDesktopLocale } from "./desktopLocale.ts";
 import type { DesktopHostPreferencesState } from "./desktopHostPreferences.ts";
 import { resolveDesktopDefaultsFromEnv } from "./defaults.ts";
@@ -23,6 +24,7 @@ export function createDesktopDeveloperLogsService(
     TuttidClient,
     | "listWorkspaceAgentSessionMessages"
     | "listWorkspaceAgentSessions"
+    | "readWorkspaceAgentSessionAttachment"
     | "listWorkspaceAppFactoryJobs"
     | "listWorkspaceApps"
     | "listWorkspaces"
@@ -55,6 +57,7 @@ export async function exportDesktopDeveloperLogsAndNotify(
     TuttidClient,
     | "listWorkspaceAgentSessionMessages"
     | "listWorkspaceAgentSessions"
+    | "readWorkspaceAgentSessionAttachment"
     | "listWorkspaceAppFactoryJobs"
     | "listWorkspaceApps"
     | "listWorkspaces"
@@ -84,6 +87,7 @@ async function listDeveloperLogsAgentSessions(
     TuttidClient,
     | "listWorkspaceAgentSessionMessages"
     | "listWorkspaceAgentSessions"
+    | "readWorkspaceAgentSessionAttachment"
     | "listWorkspaceAppFactoryJobs"
     | "listWorkspaceApps"
     | "listWorkspaces"
@@ -140,8 +144,18 @@ async function listDeveloperLogsAgentSessions(
         if (!messages) {
           return null;
         }
+        const attachments = await loadDeveloperLogsAgentSessionAttachments(
+          messages.messages,
+          (attachmentID) =>
+            tuttidClient.readWorkspaceAgentSessionAttachment(
+              session.workspaceID,
+              session.agentSessionID,
+              attachmentID
+            )
+        );
         return {
           ...session,
+          ...attachments,
           hasMoreMessages: messages.hasMore,
           latestMessageVersion: messages.latestVersion,
           messages: messages.messages

--- a/apps/desktop/src/main/ipc/developer.ts
+++ b/apps/desktop/src/main/ipc/developer.ts
@@ -21,6 +21,7 @@ export function registerDeveloperIpc(
     TuttidClient,
     | "listWorkspaceAgentSessionMessages"
     | "listWorkspaceAgentSessions"
+    | "readWorkspaceAgentSessionAttachment"
     | "listWorkspaceAppFactoryJobs"
     | "listWorkspaceApps"
     | "listWorkspaces"

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -33,6 +33,7 @@ export interface IpcRegistrationDependencies {
     TuttidClient,
     | "listWorkspaceAgentSessionMessages"
     | "listWorkspaceAgentSessions"
+    | "readWorkspaceAgentSessionAttachment"
     | "listWorkspaceAppFactoryJobs"
     | "listWorkspaceApps"
     | "listWorkspaces"

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtAgentContributors.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtAgentContributors.ts
@@ -51,7 +51,6 @@ interface AgentTargetAtItem {
 export function createAgentTargetAtContributor(contributorInput: {
   agentsService?: Pick<IAgentsService, "load">;
   agentProviderStatuses?: () => readonly AgentProviderStatus[] | undefined;
-  isTuttiAgentSwitchEnabled?: () => boolean;
 }): DesktopRichTextAtContributor {
   return {
     capability: "agent-target",
@@ -68,8 +67,6 @@ export function createAgentTargetAtContributor(contributorInput: {
             if (searchInput.abortSignal?.aborted || !response) return [];
             return agentTargetAtItemsFromTargets({
               agentProviderStatuses: contributorInput.agentProviderStatuses?.(),
-              isTuttiAgentSwitchEnabled:
-                contributorInput.isTuttiAgentSwitchEnabled,
               keyword: searchInput.keyword,
               maxResults: searchInput.maxResults,
               targets: response.agentTargets,
@@ -99,8 +96,6 @@ export function createAgentTargetAtContributor(contributorInput: {
               const item = agentTargetAtItemsFromTargets({
                 agentProviderStatuses:
                   contributorInput.agentProviderStatuses?.(),
-                isTuttiAgentSwitchEnabled:
-                  contributorInput.isTuttiAgentSwitchEnabled,
                 keyword: "",
                 targets: response.agentTargets,
                 workspaceId
@@ -268,7 +263,6 @@ function resolveSessionAgentTarget(
 
 function agentTargetAtItemsFromTargets(input: {
   agentProviderStatuses?: readonly AgentProviderStatus[];
-  isTuttiAgentSwitchEnabled?: () => boolean;
   keyword: string;
   maxResults?: number;
   targets: readonly AgentTargetPresentation[];
@@ -281,12 +275,6 @@ function agentTargetAtItemsFromTargets(input: {
       const identity = resolveAgentGUIProviderCatalogIdentity(target.provider);
       const provider = target.provider.trim() as WorkspaceAgentProvider;
       if (!provider) return null;
-      if (
-        identity?.desktop.visibilityGate === "tutti_agent" &&
-        input.isTuttiAgentSwitchEnabled?.() !== true
-      ) {
-        return null;
-      }
       if (target.availability.status !== "ready") {
         return null;
       }

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
@@ -1026,6 +1026,37 @@ test("desktop rich text @ service assembles agent target mentions", async () => 
   });
 });
 
+test("desktop rich text @ service uses daemon enabled state for Tutti Agent mentions", async () => {
+  const targets = [
+    createAgentTarget({
+      id: "local:tutti-agent",
+      name: "Tutti Agent",
+      provider: "tutti-agent",
+      sortOrder: 5
+    }),
+    createAgentTarget({
+      enabled: false,
+      id: "disabled:tutti-agent",
+      name: "Disabled Tutti Agent",
+      provider: "tutti-agent",
+      sortOrder: 6
+    })
+  ];
+  const service = new DesktopRichTextAtService({
+    agentsService: createAgentsService(targets),
+    tuttidClient: createTuttidClient()
+  });
+
+  const provider = getProvider(service, "agent-target");
+  const items = await queryProvider(provider);
+
+  assert.deepEqual(
+    items.map((item) => provider.getItemKey(item)),
+    ["local:tutti-agent"]
+  );
+  assert.equal(provider.getItemLabel(items[0]), "Tutti Agent");
+});
+
 test("desktop rich text @ service includes ready open-provider extension targets", async () => {
   const targets = [
     createAgentTarget({

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.ts
@@ -59,8 +59,6 @@ export interface DesktopRichTextAtServiceDependencies {
   ) => DesktopAgentSessionStatusView | null;
   /** Live getter for agent availability, used to hide unbound agent apps. */
   agentProviderStatuses?: () => readonly AgentProviderStatus[] | undefined;
-  /** Live getter for the renderer-local Tutti Agent entry switch. */
-  isTuttiAgentSwitchEnabled?: () => boolean;
 }
 
 interface WorkspaceFileAtItem {
@@ -121,8 +119,7 @@ export class DesktopRichTextAtService implements IDesktopRichTextAtService {
       createWorkspaceIssueAtContributor(dependencies.tuttidClient),
       createAgentTargetAtContributor({
         agentsService: dependencies.agentsService,
-        agentProviderStatuses: dependencies.agentProviderStatuses,
-        isTuttiAgentSwitchEnabled: dependencies.isTuttiAgentSwitchEnabled
+        agentProviderStatuses: dependencies.agentProviderStatuses
       }),
       createAgentSessionAtContributor({
         agentsService: dependencies.agentsService,

--- a/packages/agent/daemon/providerregistry/providers.go
+++ b/packages/agent/daemon/providerregistry/providers.go
@@ -78,7 +78,7 @@ func tuttiAgentDescriptor() ProviderDescriptor {
 		Target:  TargetDescriptor{ID: TuttiAgentTargetID, LaunchRefType: TargetLaunchRefTypeLocalCLI, Enabled: false, SortOrder: 40},
 		Events:  EventsDescriptor{Enabled: true, Aliases: []string{"tutti_agent"}, TurnLifecycleProjection: TurnLifecycleProjectionExplicit},
 		Sidecar: SidecarDescriptor{ExecutionEnvironment: SidecarExecutionEnvironmentLocalIPC},
-		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 4, StatusProbePriority: 4, VisibilityGate: DesktopVisibilityGateTuttiAgent, InstallBootstrap: true, RefreshOnAccountChange: true},
+		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 4, StatusProbePriority: 4, VisibilityGate: DesktopVisibilityGateTuttiAgent, InstallBootstrap: true, RefreshOnAccountChange: true, DeveloperLogs: true},
 	}
 }
 

--- a/packages/agent/daemon/providerregistry/registry_test.go
+++ b/packages/agent/daemon/providerregistry/registry_test.go
@@ -278,7 +278,7 @@ func TestMigratedProviderDesktopIntegrationIsDescriptorOwned(t *testing.T) {
 		CodexProviderID:      {Managed: true, ManagedOrder: 2, StatusProbePriority: 1, UsageProbeKind: DesktopUsageProbeCodex, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 1},
 		ClaudeCodeProviderID: {Managed: true, ManagedOrder: 1, StatusProbePriority: 2, UsageProbeKind: DesktopUsageProbeClaudeCode, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 2},
 		CursorProviderID:     {Managed: true, ManagedOrder: 3, StatusProbePriority: 3, RuntimeProbeFallback: DesktopRuntimeProbeFallbackDirect, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 3},
-		TuttiAgentProviderID: {Managed: true, ManagedOrder: 4, StatusProbePriority: 4, VisibilityGate: DesktopVisibilityGateTuttiAgent, InstallBootstrap: true, RefreshOnAccountChange: true},
+		TuttiAgentProviderID: {Managed: true, ManagedOrder: 4, StatusProbePriority: 4, VisibilityGate: DesktopVisibilityGateTuttiAgent, InstallBootstrap: true, RefreshOnAccountChange: true, DeveloperLogs: true},
 		OpenCodeProviderID:   {Managed: true, ManagedOrder: 5, StatusProbePriority: 5, DefaultProviderEligible: true, DefaultProviderPriority: 4},
 		NexightProviderID:    {},
 		OpenClawProviderID:   {Managed: true, ManagedOrder: 7, StatusProbePriority: 7, UnavailableDockOrderOffset: 200},

--- a/packages/agent/gui/generated/providerIdentityCatalog.ts
+++ b/packages/agent/gui/generated/providerIdentityCatalog.ts
@@ -108,7 +108,7 @@ export const generatedProviderIdentityCatalog = [
       installBootstrap: true,
       refreshOnAccountChange: true,
       unavailableDockOrderOffset: 0,
-      developerLogs: false,
+      developerLogs: true,
       defaultProviderEligible: false,
       defaultProviderPriority: 0
     }

--- a/packages/agent/gui/providerIdentityCatalog.spec.ts
+++ b/packages/agent/gui/providerIdentityCatalog.spec.ts
@@ -35,6 +35,14 @@ describe("provider identity catalog", () => {
     });
   });
 
+  it("allows Tutti Agent sessions in developer log exports", () => {
+    expect(
+      resolveMigratedAgentGUIProviderIdentity("tutti-agent")?.desktop
+    ).toMatchObject({
+      developerLogs: true
+    });
+  });
+
   it("reads OpenCode aliases, identity, and target only from the generated catalog", () => {
     expect(resolveMigratedAgentGUIProviderIdentity("open-code")).toMatchObject({
       providerId: "opencode",


### PR DESCRIPTION
## Summary

- enable the provider-owned developer log capability for Tutti Agent
- include Tutti Agent session metadata and messages in diagnostic log archives
- export persisted session image attachments through the tuttid API under each session's `attachments/` directory
- record exported attachment metadata and unavailable attachment IDs in each session manifest
- show enabled, ready Tutti Agent targets in the rich-text `@` Agent panel
- remove the disconnected renderer-local Tutti Agent visibility gate and rely on the daemon-owned target enabled state
- add registry, generated catalog, desktop export, image attachment, and Agent mention regression coverage

## Verification

- targeted developer log export tests (15/15)
- targeted desktop rich-text `@` service tests (26/26)
- `pnpm check:changed -- --failed-only` (20/20 lanes)
- pre-push `pnpm check:changed -- --push-ready` (20/20 lanes)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
